### PR TITLE
feat(cancel_token): W3(7) Slice 1 — CancelToken primitive + Class D REPL trigger

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -3200,8 +3200,23 @@ class SerpentREPL:
                         self._print_help()
                         continue
                     if line.startswith("cancel "):
-                        _cancel_target = line.split(None, 1)[1].strip()
-                        await self._handle_cancel(_cancel_target)
+                        _cancel_args = line.split(None, 1)[1].strip()
+                        # W3(7) Slice 1 — `cancel <op-id> --immediate` extension.
+                        # Existing `cancel <op-id>` keeps phase-boundary
+                        # semantics (CLAUDE.md current behavior). The `--immediate`
+                        # flag fires the new Class D trigger; structurally
+                        # complete in Slice 1 (record + log + artifact). The
+                        # mid-phase propagation that actually cancels in-flight
+                        # work lands in Slice 2. Master flag default off ⇒
+                        # `--immediate` parses but is a no-op (byte-for-byte
+                        # pre-W3(7)) until operator flips JARVIS_MID_OP_CANCEL_ENABLED.
+                        _immediate = False
+                        for _flag in ("--immediate", "-i"):
+                            if _cancel_args.endswith(" " + _flag) or _cancel_args == _flag:
+                                _immediate = True
+                                _cancel_args = _cancel_args[: -len(_flag)].strip()
+                                break
+                        await self._handle_cancel(_cancel_args, immediate=_immediate)
                         continue
 
                     # Runtime configuration commands
@@ -3457,8 +3472,21 @@ class SerpentREPL:
         f.console.print(panel)
         f.console.print()
 
-    async def _handle_cancel(self, op_id: str) -> None:
-        """Request cancellation of an in-flight operation."""
+    async def _handle_cancel(self, op_id: str, immediate: bool = False) -> None:
+        """Request cancellation of an in-flight operation.
+
+        Backward-compat: ``immediate=False`` (the existing ``cancel <op-id>``
+        UX) keeps phase-boundary semantics — adds the op_id to GovernedLoop's
+        cooperative cancel set; orchestrator catches at the next transition.
+
+        New (W3(7) Slice 1): ``immediate=True`` (``cancel <op-id> --immediate``)
+        also emits a Class D `[CancelOrigin]` log + cancel_records.jsonl entry
+        via :class:`CancelOriginEmitter`, gated by
+        ``JARVIS_MID_OP_CANCEL_ENABLED`` + ``JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE``.
+        Master-off → no-op (record never created, byte-for-byte pre-W3(7)).
+        Slice 2 will propagate the cancel mid-phase; Slice 1 is observability
+        only — the op continues until the existing phase-boundary check fires.
+        """
         if self._gls is None:
             self._flow.console.print(
                 f"  [{_C['death']}]Cancel not available (no GLS reference)[/{_C['death']}]",
@@ -3468,8 +3496,19 @@ class SerpentREPL:
         if hasattr(self._gls, "request_cancel"):
             found = self._gls.request_cancel(op_id)
             if found:
+                # W3(7) Slice 1 — Class D emission (gated; default no-op)
+                if immediate:
+                    self._emit_class_d_cancel(op_id)
+                msg = (
+                    f"Cancel requested for {op_id}"
+                    + (
+                        " — Class D recorded; will take effect at next phase boundary (Slice 1 observability only)"
+                        if immediate
+                        else " — will take effect at next phase boundary"
+                    )
+                )
                 self._flow.console.print(
-                    f"  [{_C['evolved']}]Cancel requested for {op_id} — will take effect at next phase boundary[/{_C['evolved']}]",
+                    f"  [{_C['evolved']}]{msg}[/{_C['evolved']}]",
                     highlight=False,
                 )
             else:
@@ -3482,6 +3521,60 @@ class SerpentREPL:
                 f"  [{_C['death']}]GLS does not support cancel (upgrade needed)[/{_C['death']}]",
                 highlight=False,
             )
+
+    def _emit_class_d_cancel(self, op_id_prefix: str) -> None:
+        """W3(7) Slice 1 — Class D Cancel record emission via REPL.
+
+        Gated by ``JARVIS_MID_OP_CANCEL_ENABLED`` (master, default false)
+        and ``JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE`` (sub-flag, default true
+        when master on). Master off → silent no-op.
+
+        Looks up the CancelToken via the GLS-attached registry (Slice 2 will
+        wire the registry; Slice 1 falls back to a per-call temporary token
+        when the registry isn't available, so the artifact + log surface is
+        still exercised). Phase tag is "unknown" until Slice 2 threads it
+        through the orchestrator.
+        """
+        try:
+            from backend.core.ouroboros.governance.cancel_token import (
+                CancelOriginEmitter,
+                CancelToken,
+                mid_op_cancel_enabled,
+            )
+        except Exception:
+            return
+        if not mid_op_cancel_enabled():
+            return
+
+        # Slice 2 attaches a CancelTokenRegistry on GLS; Slice 1 falls back
+        # to a fresh token so the trigger surface is exercisable today.
+        registry = getattr(self._gls, "_cancel_token_registry", None)
+        token: Optional[CancelToken] = None
+        resolved_op_id = op_id_prefix
+        if registry is not None:
+            token = registry.find_by_prefix(op_id_prefix)
+            if token is not None:
+                resolved_op_id = token.op_id
+        if token is None:
+            token = CancelToken(resolved_op_id)
+
+        # Resolve session dir for the durable artifact (best-effort).
+        session_dir = None
+        for attr in ("_session_dir", "session_dir"):
+            sd = getattr(self._gls, attr, None)
+            if sd is not None:
+                from pathlib import Path as _Path
+                session_dir = _Path(sd) if not isinstance(sd, _Path) else sd
+                break
+
+        emitter = CancelOriginEmitter(session_dir=session_dir)
+        emitter.emit_class_d(
+            op_id=resolved_op_id,
+            token=token,
+            phase_at_trigger="unknown",  # Slice 2 will thread the live phase
+            reason="operator-initiated immediate cancel (REPL)",
+            initiator_task="repl_operator",
+        )
 
     # ── /attach — human-initiated multi-modal ingest (CC-parity) ────
 

--- a/backend/core/ouroboros/governance/cancel_token.py
+++ b/backend/core/ouroboros/governance/cancel_token.py
@@ -1,0 +1,441 @@
+"""W3(7) Slice 1 — CancelToken primitive + Class D (REPL operator) cancel record.
+
+Slice 1 scope per `project_wave3_item7_mid_op_cancel_scope.md` §9:
+    "CancelToken primitive + Class D wiring (JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE)."
+
+This module ships the observability layer: the primitive, the record schema,
+the `[CancelOrigin]` log emission, and the optional `cancel_records.jsonl`
+durable artifact. Propagation through PhaseDispatcher / ToolLoop (i.e., the
+mechanism that *actually* cancels mid-phase) is Slice 2 and is NOT included
+here; in Slice 1 the operator-facing surface is structurally complete but
+the cancel still settles at the next phase boundary (existing behavior).
+
+Master flag invariant: when ``JARVIS_MID_OP_CANCEL_ENABLED`` is false
+(default), nothing in this module is invoked from production code paths.
+The byte-for-byte pre-W3(7) contract holds.
+
+Cancel classes (full taxonomy per scope doc §3):
+    A — per-call timeout (TimeoutError, own deadline)        [pre-existing]
+    B — outer wait_for / ToolLoop round budget               [pre-existing]
+    C — sibling-task cancel inside asyncio.gather            [pre-existing]
+    D — operator REPL /cancel <op-id> --immediate            [SLICE 1]
+    E — watchdog (cost / wall / productivity / idle)         [Slice 3]
+    F — system signal (SIGTERM / SIGINT / SIGHUP)            [Slice 4]
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Awaitable, Optional, Set
+
+
+logger = logging.getLogger("Ouroboros.CancelToken")
+
+
+# ---------------------------------------------------------------------------
+# Flags (defaults align with scope doc §8 — all default OFF when master is off)
+# ---------------------------------------------------------------------------
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Standard JARVIS env-bool parse — true/1/yes/on (case-insensitive)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("true", "1", "yes", "on")
+
+
+def mid_op_cancel_enabled() -> bool:
+    """Master flag — `JARVIS_MID_OP_CANCEL_ENABLED` (default false).
+
+    When false: no `[CancelOrigin]` emissions, no record artifacts, no
+    behavior change vs pre-W3(7). Existing REPL /cancel keeps phase-
+    boundary semantics (see GovernedLoopService.request_cancel).
+    """
+    return _env_bool("JARVIS_MID_OP_CANCEL_ENABLED", False)
+
+
+def repl_immediate_enabled() -> bool:
+    """REPL `/cancel ... --immediate` sub-flag (default true when master on).
+
+    Always returns False when master is off, regardless of this sub-flag.
+    """
+    if not mid_op_cancel_enabled():
+        return False
+    return _env_bool("JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE", True)
+
+
+def record_persist_enabled() -> bool:
+    """`cancel_records.jsonl` write sub-flag (default true when master on).
+
+    When false: log-only mode. When true: durable artifact under
+    `<session_dir>/cancel_records.jsonl`.
+    """
+    if not mid_op_cancel_enabled():
+        return False
+    return _env_bool("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", True)
+
+
+def bounded_deadline_s() -> float:
+    """`JARVIS_CANCEL_BOUNDED_DEADLINE_S` — settle budget (default 30s).
+
+    Slice 1 records this on the CancelRecord for downstream slices to
+    consult; the deadline itself is enforced in Slice 2 (propagation).
+    """
+    raw = os.environ.get("JARVIS_CANCEL_BOUNDED_DEADLINE_S", "30.0")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 30.0
+
+
+# ---------------------------------------------------------------------------
+# CancelRecord — schema cancel.1 per scope doc §6.2
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CancelRecord:
+    """Immutable record of one cancel decision (schema `cancel.1`).
+
+    Frozen because once committed the record is the system of record for
+    attribution. Mutating it would break the deterministic-origin contract.
+
+    Slice 1 fields cover the trigger side. Slice 2 will populate
+    ``tasks_cancelled``, ``settle_monotonic``, and ``settle_within_deadline``
+    once propagation lands.
+    """
+
+    schema_version: str
+    cancel_id: str
+    op_id: str
+    origin: str
+    phase_at_trigger: str
+    trigger_monotonic: float
+    trigger_wall_iso: str
+    bounded_deadline_s: float
+    reason: str
+    tasks_cancelled: list = field(default_factory=list)
+    settle_monotonic: Optional[float] = None
+    settle_within_deadline: Optional[bool] = None
+
+    def to_jsonl(self) -> str:
+        return json.dumps(asdict(self), separators=(",", ":")) + "\n"
+
+
+def _new_cancel_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# CancelToken — async primitive for awaitable cancel + race
+# ---------------------------------------------------------------------------
+
+
+class CancelToken:
+    """Per-op cancel signal with idempotent set + awaitable wait.
+
+    Contract (scope doc §4 deterministic guarantees):
+        * ``set(record)`` is idempotent — only the first call commits a
+          record; subsequent calls return False without overwriting.
+        * ``is_cancelled`` is a sync boolean readable any time.
+        * ``wait()`` blocks until set; returns the committed CancelRecord.
+        * ``race(coro)`` runs ``coro`` concurrent with ``wait()``; whichever
+          finishes first wins. The loser is cancelled cooperatively.
+        * ``get_record()`` returns the committed CancelRecord or None.
+
+    The token is lazily-bound to an event loop on first ``wait()`` /
+    ``race()`` call. Safe to construct in sync code (e.g., test fixtures)
+    and consume from async.
+    """
+
+    def __init__(self, op_id: str) -> None:
+        self._op_id = op_id
+        self._record: Optional[CancelRecord] = None
+        self._event: Optional[asyncio.Event] = None
+        # Track which event loop owns the lazy ``_event`` so we can detect
+        # cross-loop misuse early instead of getting silent no-fire bugs.
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    @property
+    def op_id(self) -> str:
+        return self._op_id
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._record is not None
+
+    def get_record(self) -> Optional[CancelRecord]:
+        return self._record
+
+    def set(self, record: CancelRecord) -> bool:
+        """Commit a CancelRecord. Idempotent — only first call wins.
+
+        Returns True on first commit, False if already cancelled.
+        Mismatched op_id raises ValueError (defensive — token is per-op).
+        """
+        if record.op_id != self._op_id:
+            raise ValueError(
+                f"CancelRecord op_id={record.op_id!r} does not match "
+                f"token op_id={self._op_id!r}"
+            )
+        if self._record is not None:
+            # Idempotent — already cancelled. Caller can inspect
+            # `get_record()` to see who won the race.
+            return False
+        self._record = record
+        # Wake any waiters lazily; if no event was created, nobody is
+        # waiting and we don't need one.
+        if self._event is not None:
+            self._event.set()
+        return True
+
+    def _ensure_event(self) -> asyncio.Event:
+        """Lazy event allocation; pinned to the current running loop."""
+        loop = asyncio.get_event_loop()
+        if self._event is None:
+            self._event = asyncio.Event()
+            self._loop = loop
+            if self._record is not None:
+                # Already-cancelled tokens fire immediately.
+                self._event.set()
+        return self._event
+
+    async def wait(self) -> CancelRecord:
+        """Block until set; return the CancelRecord."""
+        evt = self._ensure_event()
+        await evt.wait()
+        # Invariant: when event fires, _record must be populated (set()
+        # writes _record before signalling).
+        assert self._record is not None
+        return self._record
+
+    async def race(self, coro: Awaitable[Any]) -> Any:
+        """Race ``coro`` against cancellation.
+
+        If ``coro`` finishes first → returns its result; cancel-wait task
+        is cancelled. If cancellation fires first → returns the
+        CancelRecord; ``coro`` is cancelled cooperatively.
+
+        Caller is responsible for handling the CancelRecord vs result-of-coro
+        disambiguation (e.g. via isinstance check).
+        """
+        evt = self._ensure_event()
+        coro_task = asyncio.ensure_future(coro)
+        wait_task = asyncio.ensure_future(evt.wait())
+        try:
+            done, pending = await asyncio.wait(
+                {coro_task, wait_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for p in pending:
+                p.cancel()
+            # Drain pending so we don't leave warning-spewing tasks
+            for p in pending:
+                try:
+                    await p
+                except (asyncio.CancelledError, Exception):
+                    pass
+            if coro_task in done:
+                return coro_task.result()
+            # cancel-wait fired first — return the record
+            return self._record
+        finally:
+            # Final defensive guard against stray pending tasks.
+            for t in (coro_task, wait_task):
+                if not t.done():
+                    t.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Class D — REPL operator immediate cancel trigger
+# ---------------------------------------------------------------------------
+
+
+class CancelOriginEmitter:
+    """Trigger-side helper that creates a CancelRecord and emits telemetry.
+
+    Slice 1 covers Class D (REPL operator). Slices 3/4 add E/F via the
+    same emit path with different ``origin`` strings.
+
+    The emitter is intentionally NOT a singleton — callers (REPL handler,
+    watchdogs) construct their own and pass in the session_dir for the
+    durable artifact. This keeps the dependency graph simple and makes
+    multi-session test setups trivial.
+    """
+
+    def __init__(
+        self,
+        session_dir: Optional[Path] = None,
+    ) -> None:
+        self._session_dir = session_dir
+
+    def emit_class_d(
+        self,
+        *,
+        op_id: str,
+        token: CancelToken,
+        phase_at_trigger: str,
+        reason: str = "operator-initiated immediate cancel",
+        initiator_task: str = "repl_operator",
+    ) -> Optional[CancelRecord]:
+        """Class D — REPL operator `/cancel <op-id> --immediate`.
+
+        Returns the committed CancelRecord, or None if:
+        * master flag is off (no-op, byte-for-byte pre-W3(7) behavior),
+        * REPL-immediate sub-flag is off,
+        * the token was already cancelled by another origin (idempotent loss).
+
+        Side effects:
+        * ``[CancelOrigin] op=... origin=D:repl_operator ...`` INFO log.
+        * ``cancel_records.jsonl`` append (when persist sub-flag is on AND
+          session_dir is set).
+
+        No PhaseDispatcher / ToolLoop propagation in Slice 1 — that's
+        Slice 2. The op continues until the existing phase-boundary
+        cancellation check fires (current behavior).
+        """
+        if not mid_op_cancel_enabled():
+            return None
+        if not repl_immediate_enabled():
+            return None
+
+        record = CancelRecord(
+            schema_version="cancel.1",
+            cancel_id=_new_cancel_id(),
+            op_id=op_id,
+            origin="D:repl_operator",
+            phase_at_trigger=phase_at_trigger,
+            trigger_monotonic=time.monotonic(),
+            trigger_wall_iso=_now_iso(),
+            bounded_deadline_s=bounded_deadline_s(),
+            reason=reason,
+        )
+
+        committed = token.set(record)
+        if not committed:
+            # Race with another origin (in Slice 1 this is rare — REPL is
+            # the only trigger path. In later slices Class E/F can race.)
+            existing = token.get_record()
+            logger.info(
+                "[CancelOrigin] superseded — op=%s requested_origin=D:repl_operator "
+                "winner_origin=%s winner_cancel_id=%s",
+                op_id[:16],
+                existing.origin if existing else "unknown",
+                existing.cancel_id if existing else "unknown",
+            )
+            return None
+
+        logger.info(
+            "[CancelOrigin] op=%s origin=%s phase=%s cancel_id=%s "
+            "at_monotonic=%.3f reason=%r initiator_task=%s "
+            "bounded_deadline_s=%.1f",
+            op_id[:16],
+            record.origin,
+            phase_at_trigger,
+            record.cancel_id,
+            record.trigger_monotonic,
+            reason,
+            initiator_task,
+            record.bounded_deadline_s,
+        )
+
+        if record_persist_enabled() and self._session_dir is not None:
+            self._persist(record)
+
+        return record
+
+    def _persist(self, record: CancelRecord) -> None:
+        """Append the record to ``cancel_records.jsonl``. Best-effort."""
+        try:
+            artifact = self._session_dir / "cancel_records.jsonl"  # type: ignore[union-attr]
+            artifact.parent.mkdir(parents=True, exist_ok=True)
+            with artifact.open("a", encoding="utf-8") as f:
+                f.write(record.to_jsonl())
+        except Exception as exc:  # noqa: BLE001 — persistence is best-effort
+            logger.warning(
+                "[CancelOrigin] persist failed op=%s cancel_id=%s err=%s",
+                record.op_id[:16],
+                record.cancel_id,
+                f"{type(exc).__name__}: {exc}",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Per-session token registry — opt-in, used by Slice 2 for token lookup
+# ---------------------------------------------------------------------------
+
+
+class CancelTokenRegistry:
+    """Per-session registry mapping op_id → CancelToken.
+
+    Slice 1 ships this as an empty primitive consumed only by the test
+    suite + the REPL trigger. Slice 2 will wire it into PhaseDispatcher /
+    ToolLoop so runner code can look up the token for the in-flight op.
+
+    The registry is intentionally NOT a singleton; ownership lives with
+    GovernedLoopService (Slice 2 will attach one). Tests construct their
+    own per-test instance.
+    """
+
+    def __init__(self) -> None:
+        self._tokens: dict = {}
+        # Track op_ids ever registered (incl. settled) so attribution
+        # logs can resolve historical lookups during postmortem.
+        self._known_ops: Set[str] = set()
+
+    def get_or_create(self, op_id: str) -> CancelToken:
+        if op_id not in self._tokens:
+            self._tokens[op_id] = CancelToken(op_id)
+            self._known_ops.add(op_id)
+        return self._tokens[op_id]
+
+    def get(self, op_id: str) -> Optional[CancelToken]:
+        return self._tokens.get(op_id)
+
+    def find_by_prefix(self, prefix: str) -> Optional[CancelToken]:
+        """Match by op-id prefix (REPL UX — operators type abbreviations).
+
+        Returns the unique match, or None if 0 or >1 active tokens match.
+        Ambiguous matches are a no-op (caller should report to operator).
+        """
+        matches = [
+            tok for op_id, tok in self._tokens.items()
+            if op_id.startswith(prefix)
+        ]
+        if len(matches) != 1:
+            return None
+        return matches[0]
+
+    def discard(self, op_id: str) -> None:
+        """Remove a token from the active set (post-terminal cleanup).
+
+        op_id remains in ``_known_ops`` for postmortem attribution.
+        """
+        self._tokens.pop(op_id, None)
+
+    def active_op_ids(self) -> Set[str]:
+        return set(self._tokens.keys())
+
+
+__all__ = [
+    "CancelRecord",
+    "CancelToken",
+    "CancelTokenRegistry",
+    "CancelOriginEmitter",
+    "mid_op_cancel_enabled",
+    "repl_immediate_enabled",
+    "record_persist_enabled",
+    "bounded_deadline_s",
+]

--- a/notebooks/report.ipynb
+++ b/notebooks/report.ipynb
@@ -2,22 +2,22 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "592909be",
+   "id": "88823e2a",
    "metadata": {},
    "source": [
     "# Ouroboros Battle Test Report\n",
     "\n",
     "| Field | Value |\n",
     "|-------|-------|\n",
-    "| Session ID | `bt-2026-04-24-044547` |\n",
+    "| Session ID | `bt-2026-04-25-003533` |\n",
     "| Stop Reason | `idle_timeout` |\n",
-    "| Duration | 876.9 s |\n"
+    "| Duration | 1774.1 s |\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf6d3ca9",
+   "id": "0c0703e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,9 +28,9 @@
     "_SUMMARY_JSON = '''\n",
     "{\n",
     "  \"schema_version\": 2,\n",
-    "  \"session_id\": \"bt-2026-04-24-044547\",\n",
+    "  \"session_id\": \"bt-2026-04-25-003533\",\n",
     "  \"stop_reason\": \"idle_timeout\",\n",
-    "  \"duration_s\": 876.8567180633545,\n",
+    "  \"duration_s\": 1774.0870277881622,\n",
     "  \"stats\": {\n",
     "    \"attempted\": 0,\n",
     "    \"completed\": 0,\n",
@@ -38,9 +38,9 @@
     "    \"cancelled\": 0,\n",
     "    \"queued\": 0\n",
     "  },\n",
-    "  \"cost_total\": 0.12075,\n",
+    "  \"cost_total\": 1.068039,\n",
     "  \"cost_breakdown\": {\n",
-    "    \"claude\": 0.12075\n",
+    "    \"claude\": 1.068039\n",
     "  },\n",
     "  \"branch_stats\": {\n",
     "    \"commits\": 0,\n",
@@ -55,32 +55,40 @@
     "  \"top_techniques\": [],\n",
     "  \"operations\": [],\n",
     "  \"strategic_drift\": {\n",
-    "    \"total_ops\": 15,\n",
+    "    \"total_ops\": 4,\n",
     "    \"drifted_ops\": 1,\n",
-    "    \"ratio\": 0.0667,\n",
-    "    \"threshold_met\": true,\n",
+    "    \"ratio\": null,\n",
+    "    \"threshold_met\": false,\n",
     "    \"warning\": false,\n",
-    "    \"status\": \"ok\"\n",
+    "    \"status\": \"insufficient_data\"\n",
     "  },\n",
     "  \"session_outcome\": \"complete\",\n",
-    "  \"last_activity_ts\": 1777006824.656673,\n",
-    "  \"ops_digest\": {\n",
-    "    \"last_apply_mode\": \"single\",\n",
-    "    \"last_apply_files\": 1,\n",
-    "    \"last_apply_op_id\": \"op-019dbdd1-06a0-7520-b660-e3a052483f4b-cau\"\n",
-    "  },\n",
+    "  \"last_activity_ts\": 1777079107.6952949,\n",
     "  \"cost_by_phase\": {\n",
-    "    \"GENERATE\": 0.12075\n",
+    "    \"GENERATE\": 0.650319,\n",
+    "    \"GENERATE_RETRY\": 0.399972\n",
     "  },\n",
     "  \"cost_by_op_phase\": {\n",
-    "    \"op-019dbdd1-06a0-7520-b660-e3a052483f4b-cau\": {\n",
-    "      \"GENERATE\": 0.12075\n",
+    "    \"op-019dc212-0f02-71ce-acb4-671715bd9554-cau\": {\n",
+    "      \"GENERATE\": 0.031059\n",
+    "    },\n",
+    "    \"op-019dc210-5fe3-78f8-8ba4-28697430af15-cau\": {\n",
+    "      \"GENERATE\": 0.61926,\n",
+    "      \"GENERATE_RETRY\": 0.399972\n",
     "    }\n",
     "  },\n",
     "  \"cost_by_op_phase_provider\": {\n",
-    "    \"op-019dbdd1-06a0-7520-b660-e3a052483f4b-cau\": {\n",
+    "    \"op-019dc212-0f02-71ce-acb4-671715bd9554-cau\": {\n",
     "      \"GENERATE\": {\n",
-    "        \"claude-api\": 0.12075\n",
+    "        \"claude-api\": 0.031059\n",
+    "      }\n",
+    "    },\n",
+    "    \"op-019dc210-5fe3-78f8-8ba4-28697430af15-cau\": {\n",
+    "      \"GENERATE\": {\n",
+    "        \"claude-api\": 0.61926\n",
+    "      },\n",
+    "      \"GENERATE_RETRY\": {\n",
+    "        \"claude-api\": 0.399972\n",
     "      }\n",
     "    }\n",
     "  }\n",
@@ -102,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a20abb8f",
+   "id": "d2a9cc49",
    "metadata": {},
    "source": [
     "## Composite Score Trend\n",
@@ -113,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aab16356",
+   "id": "d5da6bfe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36e60857",
+   "id": "b6d98f15",
    "metadata": {},
    "source": [
     "## Convergence State\n",
@@ -161,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "482863fe",
+   "id": "ffb1f098",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +198,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8407c721",
+   "id": "04f1defa",
    "metadata": {},
    "source": [
     "## Operations Breakdown\n",
@@ -201,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7b882ec",
+   "id": "65e96560",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e642f15",
+   "id": "68d9aef4",
    "metadata": {},
    "source": [
     "## Sensor Activation\n",
@@ -241,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70e99f6c",
+   "id": "06628823",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5de06ab4",
+   "id": "cfb205bc",
    "metadata": {},
    "source": [
     "## Cost & Branch Summary\n",
@@ -276,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6081e2c4",
+   "id": "b5db62db",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tests/governance/test_cancel_token_protocol.py
+++ b/tests/governance/test_cancel_token_protocol.py
@@ -1,0 +1,366 @@
+"""W3(7) Slice 1 — CancelToken primitive protocol tests.
+
+Pins the contracts in `cancel_token.py` per scope doc §4 deterministic
+guarantees:
+    * idempotent ``set`` (only first commit wins),
+    * sync ``is_cancelled`` readability,
+    * async ``wait()`` blocks until set,
+    * ``race(coro)`` semantics — coro vs cancel,
+    * ``get_record()`` returns committed record or None.
+
+Plus the registry's per-op uniqueness + prefix-match contract.
+
+Slice 1 only — these tests do NOT require the orchestrator/PhaseDispatcher
+integration (Slice 2). They exercise the primitive standalone.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from backend.core.ouroboros.governance.cancel_token import (
+    CancelOriginEmitter,
+    CancelRecord,
+    CancelToken,
+    CancelTokenRegistry,
+    bounded_deadline_s,
+    mid_op_cancel_enabled,
+    record_persist_enabled,
+    repl_immediate_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# (1) Flag defaults — master-off invariant (scope doc §8)
+# ---------------------------------------------------------------------------
+
+
+def test_master_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JARVIS_MID_OP_CANCEL_ENABLED defaults to false."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    assert mid_op_cancel_enabled() is False
+
+
+def test_repl_immediate_off_when_master_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sub-flag is force-False when master is off, regardless of its own value."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE", "true")
+    assert repl_immediate_enabled() is False
+
+
+def test_repl_immediate_on_when_master_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sub-flag default true when master is on."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE", raising=False)
+    assert repl_immediate_enabled() is True
+
+
+def test_record_persist_off_when_master_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Persist sub-flag is force-False when master is off."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", "true")
+    assert record_persist_enabled() is False
+
+
+def test_bounded_deadline_default_30s(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JARVIS_CANCEL_BOUNDED_DEADLINE_S defaults to 30.0."""
+    monkeypatch.delenv("JARVIS_CANCEL_BOUNDED_DEADLINE_S", raising=False)
+    assert bounded_deadline_s() == 30.0
+
+
+def test_bounded_deadline_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_CANCEL_BOUNDED_DEADLINE_S", "5.5")
+    assert bounded_deadline_s() == 5.5
+
+
+def test_bounded_deadline_garbage_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed env value falls back to 30.0 — never raises."""
+    monkeypatch.setenv("JARVIS_CANCEL_BOUNDED_DEADLINE_S", "not-a-number")
+    assert bounded_deadline_s() == 30.0
+
+
+# ---------------------------------------------------------------------------
+# (2) CancelToken primitive — idempotent set + sync is_cancelled
+# ---------------------------------------------------------------------------
+
+
+def _make_record(op_id: str = "op-test-001", origin: str = "D:repl_operator") -> CancelRecord:
+    return CancelRecord(
+        schema_version="cancel.1",
+        cancel_id="test-cancel-id",
+        op_id=op_id,
+        origin=origin,
+        phase_at_trigger="GENERATE",
+        trigger_monotonic=time.monotonic(),
+        trigger_wall_iso="2026-04-25T01:23:45Z",
+        bounded_deadline_s=30.0,
+        reason="test",
+    )
+
+
+def test_token_starts_uncancelled():
+    token = CancelToken("op-test-001")
+    assert token.is_cancelled is False
+    assert token.get_record() is None
+    assert token.op_id == "op-test-001"
+
+
+def test_token_set_commits_record():
+    token = CancelToken("op-test-001")
+    record = _make_record()
+    assert token.set(record) is True
+    assert token.is_cancelled is True
+    assert token.get_record() is record
+
+
+def test_token_set_idempotent_first_wins():
+    """Second set() returns False and does NOT overwrite the first record."""
+    token = CancelToken("op-test-001")
+    first = _make_record(origin="D:repl_operator")
+    second = CancelRecord(
+        schema_version="cancel.1",
+        cancel_id="second-cancel-id",
+        op_id="op-test-001",
+        origin="E:cost_watchdog",  # would-be racer
+        phase_at_trigger="GENERATE",
+        trigger_monotonic=time.monotonic(),
+        trigger_wall_iso="2026-04-25T01:23:46Z",
+        bounded_deadline_s=30.0,
+        reason="cost burn",
+    )
+    assert token.set(first) is True
+    assert token.set(second) is False
+    # First wins — record identity unchanged
+    assert token.get_record() is first
+    assert token.get_record().origin == "D:repl_operator"
+
+
+def test_token_set_rejects_mismatched_op_id():
+    """Defensive: token is per-op; foreign records raise."""
+    token = CancelToken("op-test-001")
+    foreign = _make_record(op_id="op-OTHER-999")
+    with pytest.raises(ValueError, match="does not match"):
+        token.set(foreign)
+
+
+# ---------------------------------------------------------------------------
+# (3) CancelToken async — wait() + race()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_token_wait_blocks_until_set() -> None:
+    token = CancelToken("op-test-001")
+    record = _make_record()
+
+    async def _setter():
+        await asyncio.sleep(0.05)
+        token.set(record)
+
+    asyncio.create_task(_setter())
+    got = await token.wait()
+    assert got is record
+
+
+@pytest.mark.asyncio
+async def test_token_wait_returns_immediately_if_already_cancelled() -> None:
+    token = CancelToken("op-test-001")
+    record = _make_record()
+    token.set(record)
+    got = await asyncio.wait_for(token.wait(), timeout=0.5)
+    assert got is record
+
+
+@pytest.mark.asyncio
+async def test_token_race_coro_wins() -> None:
+    """When the racing coroutine completes first, race() returns its result."""
+    token = CancelToken("op-test-001")
+
+    async def _work():
+        await asyncio.sleep(0.05)
+        return "work_result"
+
+    result = await token.race(_work())
+    assert result == "work_result"
+    assert token.is_cancelled is False
+
+
+@pytest.mark.asyncio
+async def test_token_race_cancel_wins() -> None:
+    """When the cancel fires first, race() returns the CancelRecord."""
+    token = CancelToken("op-test-001")
+    record = _make_record()
+
+    async def _slow_work():
+        await asyncio.sleep(2.0)
+        return "should_not_complete"
+
+    async def _cancel_after_short_delay():
+        await asyncio.sleep(0.05)
+        token.set(record)
+
+    asyncio.create_task(_cancel_after_short_delay())
+    result = await token.race(_slow_work())
+    assert result is record
+    assert token.is_cancelled is True
+
+
+# ---------------------------------------------------------------------------
+# (4) CancelTokenRegistry — per-op uniqueness + prefix match
+# ---------------------------------------------------------------------------
+
+
+def test_registry_get_or_create_returns_same_token():
+    reg = CancelTokenRegistry()
+    a = reg.get_or_create("op-abc-123")
+    b = reg.get_or_create("op-abc-123")
+    assert a is b
+
+
+def test_registry_get_returns_none_for_unknown():
+    reg = CancelTokenRegistry()
+    assert reg.get("op-never-registered") is None
+
+
+def test_registry_find_by_prefix_unique_match():
+    reg = CancelTokenRegistry()
+    target = reg.get_or_create("op-019dc1b1-4baa")
+    reg.get_or_create("op-019dc1c5-725b")  # distinct op
+    assert reg.find_by_prefix("op-019dc1b1") is target
+
+
+def test_registry_find_by_prefix_no_match_returns_none():
+    reg = CancelTokenRegistry()
+    reg.get_or_create("op-aaa-111")
+    assert reg.find_by_prefix("op-zzz") is None
+
+
+def test_registry_find_by_prefix_ambiguous_returns_none():
+    """Multi-match → caller's UX problem; primitive returns None."""
+    reg = CancelTokenRegistry()
+    reg.get_or_create("op-abc-111")
+    reg.get_or_create("op-abc-222")
+    assert reg.find_by_prefix("op-abc") is None
+
+
+def test_registry_discard_removes_active_keeps_known():
+    reg = CancelTokenRegistry()
+    reg.get_or_create("op-discard-test")
+    assert "op-discard-test" in reg.active_op_ids()
+    reg.discard("op-discard-test")
+    assert "op-discard-test" not in reg.active_op_ids()
+    # Re-create returns a fresh token (not the discarded one)
+    fresh = reg.get_or_create("op-discard-test")
+    assert fresh.is_cancelled is False
+
+
+# ---------------------------------------------------------------------------
+# (5) CancelOriginEmitter — Class D path (master flag gating + log + persist)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_class_d_returns_none_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Master flag off → emit is silent no-op (byte-for-byte pre-W3(7))."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()
+    record = emitter.emit_class_d(
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert record is None
+    assert token.is_cancelled is False  # CRITICAL — no record committed
+
+
+def test_emit_class_d_writes_record_when_master_on(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Master on + sub-flag on → record committed, [CancelOrigin] log emitted."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE", "true")
+    monkeypatch.delenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", raising=False)
+
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()  # no session_dir → log-only
+    caplog.set_level("INFO", logger="Ouroboros.CancelToken")
+
+    record = emitter.emit_class_d(
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+        reason="test reason",
+    )
+
+    assert record is not None
+    assert token.is_cancelled is True
+    assert token.get_record() is record
+    assert record.origin == "D:repl_operator"
+    assert record.phase_at_trigger == "GENERATE"
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("[CancelOrigin]" in m and "origin=D:repl_operator" in m for m in msgs)
+
+
+def test_emit_class_d_persists_to_session_dir_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Persist sub-flag on + session_dir set → cancel_records.jsonl appended."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", "true")
+
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter(session_dir=tmp_path)
+    record = emitter.emit_class_d(
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert record is not None
+
+    artifact = tmp_path / "cancel_records.jsonl"
+    assert artifact.exists()
+    line = artifact.read_text(encoding="utf-8").strip()
+    import json as _json
+    parsed = _json.loads(line)
+    assert parsed["schema_version"] == "cancel.1"
+    assert parsed["op_id"] == "op-test-001"
+    assert parsed["origin"] == "D:repl_operator"
+
+
+def test_emit_class_d_idempotent_on_double_trigger(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Second trigger on already-cancelled token returns None + emits supersede log."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", raising=False)
+
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()
+
+    first = emitter.emit_class_d(
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert first is not None
+
+    caplog.clear()
+    caplog.set_level("INFO", logger="Ouroboros.CancelToken")
+    second = emitter.emit_class_d(
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert second is None  # idempotent loss
+    assert token.get_record() is first  # original record preserved
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("superseded" in m.lower() for m in msgs)


### PR DESCRIPTION
## Summary

Slice 1 of the Wave 3 (7) Mid-Op Cancellation arc per `project_wave3_item7_mid_op_cancel_scope.md` §9. Operator-authorized 2026-04-25 with binding resolutions (1)–(5) on §12.

Ships the **observability layer** of mid-op cancellation:
- `CancelToken` primitive (idempotent set / sync `is_cancelled` / async `wait()` / `race(coro)` with FIRST_COMPLETED).
- `CancelRecord` dataclass (schema `cancel.1`, frozen, JSONL-serializable).
- `CancelTokenRegistry` (per-op uniqueness, prefix-match for REPL UX).
- `CancelOriginEmitter` Class D path (REPL operator origin, `[CancelOrigin]` log, optional `cancel_records.jsonl` artifact).
- SerpentREPL `cancel <op-id> --immediate` (or `-i`) flag extension.

## Master-off invariant (non-negotiable)

When `JARVIS_MID_OP_CANCEL_ENABLED=false` (default) the new code path is structurally bypassed: `emit_class_d` returns `None` without writing a record, log line, or artifact. Existing `cancel <op-id>` (without `--immediate`) keeps phase-boundary semantics on both branches. Pre-W3(7) behavior is byte-for-byte preserved.

## Commit → Slice mapping

| Commit | Slice | What it ships |
|---|---|---|
| `87007f88f0` (cherry-picked here) | W3(7) Slice 1 | `cancel_token.py` (primitive, registry, Class D emitter) + `serpent_flow.py` REPL `--immediate` extension + 25 protocol tests |

Single-commit PR; no rebase needed.

## NOT in this PR (per operator resolution-1 thin-slice)

- Slice 2: PhaseDispatcher / ToolLoop / parallel-path cancel propagation (the *mechanism* that actually cancels mid-phase)
- Slice 3: Class E watchdog hooks
- Slice 4: Class F signal hooks
- Slice 5: PLAN-EXPLOIT + parallel_dispatch propagation
- Slice 6: SSE event + IDE GET endpoint
- Slice 7: graduation / master flag flip
- Per operator-binding standing orders: no Test A audit, no harness code, no F5, no W2(4), no new battle sessions in this PR.

## Test plan

- [x] `tests/governance/test_cancel_token_protocol.py` — 25/25 passing locally
  - Flag defaults + env override + malformed-env fallback (7)
  - Sync surface — uncancelled init / commit / idempotent / op_id mismatch (4)
  - Async surface — `wait()` blocks / pre-cancelled / `race()` coro-wins / `race()` cancel-wins (4)
  - Registry — unique / prefix unique / prefix none / prefix ambiguous / discard (5)
  - Class D emit — master-off no-op / master-on log+record / persist artifact / idempotent supersede (5)
- [x] Master-off invariant pinned by `test_emit_class_d_returns_none_when_master_off`
- [ ] Live-fire (deferred per operator resolution-5 — no battle session in this PR)

## Rollback

Single env flip: `JARVIS_MID_OP_CANCEL_ENABLED=false` (default). No code revert needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the mid-op cancellation observability layer: a `CancelToken` primitive and a Class D REPL trigger (`cancel <op-id> --immediate`) that records and logs operator-initiated cancels. Updates the battle test report notebook with the latest session metrics; defaults are gated behind `JARVIS_MID_OP_CANCEL_ENABLED=false`, so current behavior is unchanged.

- **New Features**
  - `CancelToken`: idempotent `set`, `is_cancelled`, `wait()`, and `race(coro)`.
  - `CancelRecord` (schema `cancel.1`), frozen, JSONL-serializable.
  - `CancelTokenRegistry`: per-op uniqueness, prefix lookup, discard.
  - `CancelOriginEmitter` (Class D): `[CancelOrigin]` log and optional `cancel_records.jsonl`.
  - SerpentREPL: `cancel <op-id> --immediate` (or `-i`) to emit Class D when enabled; Slice 1 is observability only (phase-boundary cancel remains).

- **Migration**
  - Default off: no changes when `JARVIS_MID_OP_CANCEL_ENABLED=false`.
  - To enable REPL immediate recording: set `JARVIS_MID_OP_CANCEL_ENABLED=true` (and optionally `JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE=true` and `JARVIS_CANCEL_RECORD_PERSIST_ENABLED=true`).
  - Note: mid-phase cancel propagation arrives in Slice 2.

<sup>Written for commit 59337e52f5ba36d31acc8325efdd9194fe9b46f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

