### PR TITLE
feat(cancel_token): W3(7) Slice 3 — Class E watchdog hooks + cost reference integration

### DIFF
--- a/backend/core/ouroboros/governance/cancel_token.py
+++ b/backend/core/ouroboros/governance/cancel_token.py
@@ -118,6 +118,21 @@ def record_persist_enabled() -> bool:
     return _env_bool("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", True)
 
 
+def watchdog_enabled() -> bool:
+    """Class E watchdog sub-flag — `JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED`.
+
+    Default false (even when master is on) per operator resolution-2 — the
+    first rollout is operator-only (Class D); watchdog-initiated cancels
+    are a separate trust step. Always returns False when master is off.
+
+    Slice 3 (W3(7)) gates Class E (cost / wall / productivity / idle
+    watchdog cancels) on this flag.
+    """
+    if not mid_op_cancel_enabled():
+        return False
+    return _env_bool("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", False)
+
+
 def bounded_deadline_s() -> float:
     """`JARVIS_CANCEL_BOUNDED_DEADLINE_S` — settle budget (default 30s).
 
@@ -391,6 +406,105 @@ class CancelOriginEmitter:
 
         return record
 
+    # Class E watchdogs (W3(7) Slice 3) — cost / wall / productivity / idle.
+    # Each watchdog identifies itself via the ``watchdog`` keyword; the
+    # origin string follows the canonical ``E:<watchdog>`` shape.
+    _ALLOWED_WATCHDOGS: frozenset = frozenset({
+        "cost",          # cost_governor cap exceeded
+        "wall",          # WallClockWatchdog wall-clock cap
+        "productivity",  # productivity / forward-progress trip
+        "idle",          # idle-timeout (lowest precedence per operator resolution-3)
+    })
+
+    def emit_class_e(
+        self,
+        *,
+        watchdog: str,
+        op_id: str,
+        token: CancelToken,
+        phase_at_trigger: str,
+        reason: str = "",
+        initiator_task: str = "",
+    ) -> Optional[CancelRecord]:
+        """Class E — watchdog-initiated immediate cancel.
+
+        Slice 3 (W3(7)). Same mechanics as :meth:`emit_class_d` but:
+
+        * Gated by :func:`watchdog_enabled` (sub-flag default false even
+          when master is on — operator resolution-2).
+        * ``watchdog`` MUST be in :attr:`_ALLOWED_WATCHDOGS` — surfaces
+          typos loudly rather than silently emitting an unparseable origin.
+        * Origin string is ``E:<watchdog>`` for machine-grep stability.
+
+        Precedence (operator resolution-3) — operator/safety > idle/productivity:
+        the actual *trigger* logic in each watchdog module owns the timing
+        decision; if multiple watchdogs fire near-simultaneously, asyncio
+        scheduling determines which wins ``token.set()``. The supersede
+        log includes both origins so postmortem can audit. Watchdog
+        modules SHOULD self-throttle (e.g., idle-timeout backs off when a
+        Class D / safety-class E is in flight) per the resolution.
+
+        Returns the committed CancelRecord, or None if:
+        * master flag is off (no-op),
+        * watchdog sub-flag is off (no-op),
+        * the watchdog name is unknown (raises ValueError — typo guard),
+        * the token was already cancelled by another origin (idempotent loss).
+        """
+        if watchdog not in self._ALLOWED_WATCHDOGS:
+            raise ValueError(
+                f"unknown watchdog={watchdog!r}; "
+                f"allowed={sorted(self._ALLOWED_WATCHDOGS)}"
+            )
+        if not mid_op_cancel_enabled():
+            return None
+        if not watchdog_enabled():
+            return None
+
+        origin = f"E:{watchdog}"
+        record = CancelRecord(
+            schema_version="cancel.1",
+            cancel_id=_new_cancel_id(),
+            op_id=op_id,
+            origin=origin,
+            phase_at_trigger=phase_at_trigger,
+            trigger_monotonic=time.monotonic(),
+            trigger_wall_iso=_now_iso(),
+            bounded_deadline_s=bounded_deadline_s(),
+            reason=reason or f"watchdog-initiated cancel ({watchdog})",
+        )
+
+        committed = token.set(record)
+        if not committed:
+            existing = token.get_record()
+            logger.info(
+                "[CancelOrigin] superseded — op=%s requested_origin=%s "
+                "winner_origin=%s winner_cancel_id=%s",
+                op_id[:16],
+                origin,
+                existing.origin if existing else "unknown",
+                existing.cancel_id if existing else "unknown",
+            )
+            return None
+
+        logger.info(
+            "[CancelOrigin] op=%s origin=%s phase=%s cancel_id=%s "
+            "at_monotonic=%.3f reason=%r initiator_task=%s "
+            "bounded_deadline_s=%.1f",
+            op_id[:16],
+            origin,
+            phase_at_trigger,
+            record.cancel_id,
+            record.trigger_monotonic,
+            record.reason,
+            initiator_task or watchdog,
+            record.bounded_deadline_s,
+        )
+
+        if record_persist_enabled() and self._session_dir is not None:
+            self._persist(record)
+
+        return record
+
     def _persist(self, record: CancelRecord) -> None:
         """Append the record to ``cancel_records.jsonl``. Best-effort."""
         try:
@@ -565,6 +679,48 @@ async def race_or_wait_for(
                 t.cancel()
 
 
+def emit_watchdog_cancel(
+    *,
+    watchdog: str,
+    op_id: str,
+    registry: "CancelTokenRegistry",
+    session_dir: Optional[Path] = None,
+    phase_at_trigger: str = "unknown",
+    reason: str = "",
+    initiator_task: str = "",
+) -> Optional[CancelRecord]:
+    """Convenience helper for watchdog modules — look up token + emit Class E.
+
+    Slice 3 (W3(7)). Watchdogs (cost_governor, WallClockWatchdog,
+    productivity-trip detector, idle-timeout) call this from their
+    termination path instead of importing/instantiating
+    :class:`CancelOriginEmitter` themselves.
+
+    Returns None when:
+    * master flag off (no-op, byte-for-byte pre-W3(7)),
+    * Class E sub-flag off (no-op — operator hasn't enabled watchdog cancels),
+    * the token was already cancelled by another origin (race lost,
+      logged as supersede).
+
+    The watchdog module's existing termination logic (raising
+    OpCostCapExceeded, writing stop_reason=wall_clock_cap, etc.) is NOT
+    replaced by this hook — it's *added alongside* so the cancel record
+    + dispatcher's POSTMORTEM routing engages cleanly.
+    """
+    if not watchdog_enabled():
+        return None
+    token = registry.get_or_create(op_id)
+    emitter = CancelOriginEmitter(session_dir=session_dir)
+    return emitter.emit_class_e(
+        watchdog=watchdog,
+        op_id=op_id,
+        token=token,
+        phase_at_trigger=phase_at_trigger,
+        reason=reason,
+        initiator_task=initiator_task,
+    )
+
+
 def subprocess_grace_s() -> float:
     """`JARVIS_CANCEL_SUBPROCESS_GRACE_S` — terminate→kill grace (default 5s).
 
@@ -592,4 +748,6 @@ __all__ = [
     "repl_immediate_enabled",
     "record_persist_enabled",
     "bounded_deadline_s",
+    "watchdog_enabled",
+    "emit_watchdog_cancel",
 ]

--- a/backend/core/ouroboros/governance/cost_governor.py
+++ b/backend/core/ouroboros/governance/cost_governor.py
@@ -257,6 +257,62 @@ class CostGovernor:
     def __init__(self, config: Optional[CostGovernorConfig] = None) -> None:
         self._config = config or CostGovernorConfig()
         self._entries: Dict[str, _OpCostEntry] = {}
+        # W3(7) Slice 3 — Class E cancel hook surfaces. The registry +
+        # session_dir are attached lazily by GovernedLoopService when
+        # available; both default None so unit tests / standalone callers
+        # don't need to provide them. When None, ``_emit_class_e_cancel``
+        # is a silent no-op (matches the master-off invariant).
+        self._cancel_token_registry = None  # type: ignore[assignment]
+        self._cancel_session_dir = None  # type: ignore[assignment]
+
+    def attach_cancel_surface(
+        self,
+        *,
+        registry: Any,
+        session_dir: Optional[Any] = None,
+    ) -> None:
+        """Wire the Class E cancel surface (registry + optional session dir).
+
+        Called by GovernedLoopService after construction. Slice 3 (W3(7)).
+        Idempotent — re-attaching just overwrites the previous handles.
+        """
+        self._cancel_token_registry = registry
+        self._cancel_session_dir = session_dir
+
+    def _emit_class_e_cancel(
+        self,
+        op_id: str,
+        *,
+        cumulative_usd: float,
+        cap_usd: float,
+    ) -> None:
+        """Emit a Class E:cost cancel record on cap exceeded.
+
+        Best-effort. No registry attached → silent no-op. Master flag off
+        OR Class E sub-flag off → ``emit_watchdog_cancel`` returns None.
+        Never raises into the charge() path (cost accounting must not be
+        blocked by cancel-side failures).
+        """
+        if self._cancel_token_registry is None:
+            return
+        try:
+            from backend.core.ouroboros.governance.cancel_token import (
+                emit_watchdog_cancel as _emit_watchdog_cancel,
+            )
+            _emit_watchdog_cancel(
+                watchdog="cost",
+                op_id=op_id,
+                registry=self._cancel_token_registry,
+                session_dir=self._cancel_session_dir,
+                phase_at_trigger="unknown",  # cost charge can fire from any phase
+                reason=(
+                    f"per-op cost cap exceeded: "
+                    f"cumulative=${cumulative_usd:.4f} >= cap=${cap_usd:.4f}"
+                ),
+                initiator_task="cost_governor",
+            )
+        except Exception:  # noqa: BLE001 — emit is best-effort, never blocks
+            pass
 
     # --------------------------------------------------------------
     # Cap derivation
@@ -439,6 +495,14 @@ class CostGovernor:
                 entry.call_count,
                 {k: round(v, 4) for k, v in entry.provider_totals.items()},
             )
+            # W3(7) Slice 3 — Class E watchdog cancel hook (best-effort).
+            # When master + watchdog sub-flag are both on, emit a Class E
+            # cancel record so the dispatcher's pre-iteration cancel-check
+            # routes the op to POSTMORTEM cleanly. Master-off OR
+            # sub-flag-off → no-op (byte-for-byte pre-W3(7) — existing
+            # `entry.exceeded=True` flag remains the authoritative signal
+            # the orchestrator already consults at line ~3402).
+            self._emit_class_e_cancel(op_id, cumulative_usd=entry.cumulative_usd, cap_usd=entry.cap_usd)
         else:
             logger.debug(
                 "[CostGovernor] op=%s charge +$%.4f (%s) cumulative=$%.4f / $%.4f",

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -3300,6 +3300,22 @@ class GovernedLoopService:
             validation_runner=validation_runner,
         )
 
+        # W3(7) Slice 3 — attach Class E cancel surface to CostGovernor.
+        # CostGovernor needs the registry to emit a Class E:cost record on
+        # cap-exceeded. Master + watchdog sub-flag both off (default) →
+        # the emit path inside cost_governor returns None (byte-for-byte
+        # pre-W3(7)). Attach is best-effort; if cost_governor lacks the
+        # method (older test fixture), silently skip.
+        try:
+            _cost_gov = getattr(self._orchestrator, "_cost_governor", None)
+            if _cost_gov is not None and hasattr(_cost_gov, "attach_cancel_surface"):
+                _cost_gov.attach_cancel_surface(
+                    registry=self._cancel_token_registry,
+                    session_dir=getattr(self, "_session_dir", None),
+                )
+        except Exception as _attach_exc:  # noqa: BLE001 — best-effort
+            logger.debug("[GLS] Class E cancel surface attach skipped: %s", _attach_exc)
+
         # ---- Wire ReasoningChainBridge (P1) ----
         try:
             from backend.core.ouroboros.governance.reasoning_chain_bridge import ReasoningChainBridge

--- a/tests/governance/test_cancel_class_e_watchdog_slice3.py
+++ b/tests/governance/test_cancel_class_e_watchdog_slice3.py
@@ -1,0 +1,397 @@
+"""W3(7) Slice 3 — Class E watchdog cancel hooks.
+
+Operator-binding resolutions in scope (project_wave3_item7_mid_op_cancel_scope.md):
+
+* Resolution-2: Default OFF for ALL new flags. ``JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED``
+  defaults False even when master is on.
+* Resolution-3: Class E must respect single-terminal + precedence
+  (operator/safety > idle watchdog). The Slice 1 idempotent-set semantics
+  enforce single-terminal; Slice 3 adds the named watchdog set + supersede log.
+
+Coverage:
+
+A. ``watchdog_enabled()`` flag composition.
+B. ``CancelOriginEmitter.emit_class_e`` — gating, allowed-watchdog set,
+   record shape (origin=E:<watchdog>), supersede semantics.
+C. ``emit_watchdog_cancel`` convenience helper — registry lookup, master-off
+   no-op, sub-flag-off no-op.
+D. ``CostGovernor`` reference integration — cap-exceeded path emits Class E:cost
+   when surface attached + flags on; silent no-op when surface missing.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from backend.core.ouroboros.governance.cancel_token import (
+    CancelOriginEmitter,
+    CancelRecord,
+    CancelToken,
+    CancelTokenRegistry,
+    emit_watchdog_cancel,
+    mid_op_cancel_enabled,
+    watchdog_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# (A) watchdog_enabled flag composition
+# ---------------------------------------------------------------------------
+
+
+def test_watchdog_flag_default_off_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+    # Master off forces sub-flag off regardless
+    assert watchdog_enabled() is False
+
+
+def test_watchdog_flag_default_off_even_when_master_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator resolution-2: default OFF even with master on."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", raising=False)
+    assert mid_op_cancel_enabled() is True
+    assert watchdog_enabled() is False
+
+
+def test_watchdog_flag_on_when_both_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+    assert watchdog_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# (B) emit_class_e — gating + allowed-watchdog set + record shape
+# ---------------------------------------------------------------------------
+
+
+def test_emit_class_e_returns_none_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()
+    result = emitter.emit_class_e(
+        watchdog="cost",
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert result is None
+    assert token.is_cancelled is False
+
+
+def test_emit_class_e_returns_none_when_subflag_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Master on but watchdog sub-flag off → no-op."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", raising=False)
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()
+    result = emitter.emit_class_e(
+        watchdog="cost",
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert result is None
+    assert token.is_cancelled is False
+
+
+def test_emit_class_e_writes_record_when_both_flags_on(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", raising=False)
+
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()
+    caplog.set_level("INFO", logger="Ouroboros.CancelToken")
+
+    record = emitter.emit_class_e(
+        watchdog="cost",
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+        reason="cap exceeded",
+    )
+
+    assert record is not None
+    assert record.origin == "E:cost"
+    assert record.phase_at_trigger == "GENERATE"
+    assert "cap exceeded" in record.reason
+    assert token.is_cancelled is True
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("[CancelOrigin]" in m and "origin=E:cost" in m for m in msgs)
+
+
+@pytest.mark.parametrize("watchdog", ["cost", "wall", "productivity", "idle"])
+def test_emit_class_e_accepts_canonical_watchdog_names(
+    monkeypatch: pytest.MonkeyPatch,
+    watchdog: str,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+    token = CancelToken(f"op-{watchdog}-001")
+    emitter = CancelOriginEmitter()
+    record = emitter.emit_class_e(
+        watchdog=watchdog,
+        op_id=f"op-{watchdog}-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert record is not None
+    assert record.origin == f"E:{watchdog}"
+
+
+def test_emit_class_e_rejects_unknown_watchdog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Typo guard — unknown watchdog raises ValueError loudly."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()
+    with pytest.raises(ValueError, match="unknown watchdog"):
+        emitter.emit_class_e(
+            watchdog="cosst",  # typo
+            op_id="op-test-001",
+            token=token,
+            phase_at_trigger="GENERATE",
+        )
+
+
+def test_emit_class_e_supersede_log_when_token_already_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Class E loses to a previous Class D — supersede log emits, no overwrite."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+
+    token = CancelToken("op-test-001")
+    # Pre-set a Class D record (operator was first)
+    d_record = CancelRecord(
+        schema_version="cancel.1",
+        cancel_id="d-cancel-id",
+        op_id="op-test-001",
+        origin="D:repl_operator",
+        phase_at_trigger="GENERATE",
+        trigger_monotonic=0.0,
+        trigger_wall_iso="2026-04-25T01:23:45Z",
+        bounded_deadline_s=30.0,
+        reason="operator first",
+    )
+    token.set(d_record)
+
+    emitter = CancelOriginEmitter()
+    caplog.set_level("INFO", logger="Ouroboros.CancelToken")
+
+    second = emitter.emit_class_e(
+        watchdog="idle",
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert second is None
+    # First-arrival record preserved
+    assert token.get_record() is d_record
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any(
+        "superseded" in m.lower()
+        and "requested_origin=E:idle" in m
+        and "winner_origin=D:repl_operator" in m
+        for m in msgs
+    )
+
+
+# ---------------------------------------------------------------------------
+# (C) emit_watchdog_cancel convenience helper
+# ---------------------------------------------------------------------------
+
+
+def test_emit_watchdog_cancel_master_off_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+    reg = CancelTokenRegistry()
+    result = emit_watchdog_cancel(
+        watchdog="cost",
+        op_id="op-test-001",
+        registry=reg,
+    )
+    assert result is None
+    # Token may have been created by registry but never set
+    tok = reg.get("op-test-001")
+    if tok is not None:
+        assert tok.is_cancelled is False
+
+
+def test_emit_watchdog_cancel_subflag_off_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", raising=False)
+    reg = CancelTokenRegistry()
+    result = emit_watchdog_cancel(
+        watchdog="cost",
+        op_id="op-test-001",
+        registry=reg,
+    )
+    assert result is None
+
+
+def test_emit_watchdog_cancel_returns_record_with_both_flags_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+    reg = CancelTokenRegistry()
+    record = emit_watchdog_cancel(
+        watchdog="cost",
+        op_id="op-helper-001",
+        registry=reg,
+        phase_at_trigger="VALIDATE",
+        reason="test reason",
+    )
+    assert record is not None
+    assert record.origin == "E:cost"
+    tok = reg.get("op-helper-001")
+    assert tok is not None and tok.is_cancelled
+
+
+def test_emit_watchdog_cancel_persists_to_session_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", "true")
+
+    reg = CancelTokenRegistry()
+    record = emit_watchdog_cancel(
+        watchdog="wall",
+        op_id="op-persist-001",
+        registry=reg,
+        session_dir=tmp_path,
+    )
+    assert record is not None
+
+    artifact = tmp_path / "cancel_records.jsonl"
+    assert artifact.exists()
+    import json as _json
+    parsed = _json.loads(artifact.read_text(encoding="utf-8").strip())
+    assert parsed["origin"] == "E:wall"
+
+
+# ---------------------------------------------------------------------------
+# (D) CostGovernor — Class E reference integration
+# ---------------------------------------------------------------------------
+
+
+def test_cost_governor_attach_cancel_surface_idempotent():
+    """CostGovernor.attach_cancel_surface is idempotent — re-attach overwrites."""
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor,
+        CostGovernorConfig,
+    )
+
+    cg = CostGovernor(CostGovernorConfig())
+    reg1 = CancelTokenRegistry()
+    reg2 = CancelTokenRegistry()
+    cg.attach_cancel_surface(registry=reg1)
+    assert cg._cancel_token_registry is reg1
+    cg.attach_cancel_surface(registry=reg2)
+    assert cg._cancel_token_registry is reg2
+
+
+def test_cost_governor_cap_exceeded_emits_class_e_when_attached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: charge() trips cap → CostGovernor emits Class E:cost record
+    when the cancel surface is attached AND both flags are on."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor,
+        CostGovernorConfig,
+    )
+
+    cg = CostGovernor(CostGovernorConfig())
+    reg = CancelTokenRegistry()
+    cg.attach_cancel_surface(registry=reg)
+
+    cg.start("op-cap-test-001", route="standard", complexity="moderate")
+    # Force a charge that exceeds cap (cap defaults to ~$0.45 for STANDARD/moderate)
+    cg.charge("op-cap-test-001", cost_usd=10.0, provider="claude")
+
+    tok = reg.get("op-cap-test-001")
+    assert tok is not None and tok.is_cancelled
+    record = tok.get_record()
+    assert record is not None
+    assert record.origin == "E:cost"
+    assert "cost cap exceeded" in record.reason
+
+
+def test_cost_governor_cap_exceeded_no_op_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Master flag off → cap exceeded doesn't emit a cancel record (byte-for-byte
+    pre-W3(7) — cost_governor still flips entry.exceeded=True for the
+    orchestrator's existing cap-check at line ~3402)."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor,
+        CostGovernorConfig,
+    )
+
+    cg = CostGovernor(CostGovernorConfig())
+    reg = CancelTokenRegistry()
+    cg.attach_cancel_surface(registry=reg)
+
+    cg.start("op-master-off-001", route="standard", complexity="moderate")
+    cg.charge("op-master-off-001", cost_usd=10.0, provider="claude")
+
+    # Existing exceeded flag still flips
+    assert cg.is_exceeded("op-master-off-001") is True
+    # But NO Class E cancel record was emitted
+    tok = reg.get("op-master-off-001")
+    if tok is not None:
+        assert tok.is_cancelled is False
+
+
+def test_cost_governor_cap_exceeded_no_op_when_no_registry_attached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even with both flags on, missing registry → no-op (silent, never raises)."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor,
+        CostGovernorConfig,
+    )
+
+    cg = CostGovernor(CostGovernorConfig())
+    # No attach_cancel_surface — registry stays None
+
+    cg.start("op-noreg-001", route="standard", complexity="moderate")
+    # Must NOT raise even with flags on
+    cg.charge("op-noreg-001", cost_usd=10.0, provider="claude")
+    assert cg.is_exceeded("op-noreg-001") is True


### PR DESCRIPTION
## Summary

Slice 3 of the Wave 3 (7) Mid-Op Cancellation arc per `project_wave3_item7_mid_op_cancel_scope.md` §9. Operator-authorized 2026-04-25 with binding resolutions (1)–(5).

Builds on Slice 1 (`165639c6cb`) + Slice 2 (`29a28e2065`). This PR adds the **Class E (watchdog-initiated) cancel surface** with one reference integration in CostGovernor; the other three watchdogs (wall / productivity / idle) get the helper function in place but their hook wiring is deferred per resolution-1 (thin slice).

## What ships

- `CancelOriginEmitter.emit_class_e(watchdog, op_id, token, ...)` — parallel to Slice 1's `emit_class_d`. Origin string `E:<watchdog>`.
- `_ALLOWED_WATCHDOGS = {"cost", "wall", "productivity", "idle"}` — typo-guard frozenset.
- `watchdog_enabled()` env reader for `JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED` (default **false** even when master on, per resolution-2).
- `emit_watchdog_cancel(...)` convenience helper.
- `CostGovernor.attach_cancel_surface(registry, session_dir)` + `_emit_class_e_cancel(...)` + hook in `charge()` cap-exceeded branch.
- `GovernedLoopService` attaches the cost surface after orchestrator construction.

## Master-off + sub-flag-off invariants

- `JARVIS_MID_OP_CANCEL_ENABLED=false` (default) → `emit_class_e` returns None. CostGovernor's existing `entry.exceeded=True` flag still flips → orchestrator's existing cap-check at line ~3402 keeps working unchanged. Pinned by `test_cost_governor_cap_exceeded_no_op_when_master_off`.
- Master on + sub-flag off (default) → `emit_class_e` returns None. Pinned by `test_emit_class_e_returns_none_when_subflag_off`.
- Missing registry attach → silent no-op even with both flags on. Pinned by `test_cost_governor_cap_exceeded_no_op_when_no_registry_attached`.

## Resolution-3 (precedence) honored

Slice 1's idempotent `token.set()` enforces single-terminal. Class E loser logs `[CancelOrigin] superseded` carrying both `requested_origin` + `winner_origin` for postmortem audit. Pinned by `test_emit_class_e_supersede_log_when_token_already_cancelled`.

Per-watchdog trigger timing stays in each watchdog module (operator's "trigger logic belongs to the watchdog modules" doctrine).

## Hooks: shipped vs deferred

| Watchdog | Wired? | Notes |
|---|---|---|
| `cost` | ✅ at `cost_governor.charge()` cap-exceeded | Reference integration |
| `wall` | ❌ deferred | Helper available; harness epic item 7 (wall_clock_cap not firing) is a separate ticket |
| `productivity` | ❌ deferred | Helper available |
| `idle` | ❌ deferred | Helper available |

## Test plan

- [x] `tests/governance/test_cancel_class_e_watchdog_slice3.py` — 20/20 passing
  - `watchdog_enabled` flag composition (3)
  - `emit_class_e` gating + allowed-watchdog set + record shape + supersede (7)
  - `emit_watchdog_cancel` helper (4)
  - CostGovernor reference integration — attach idempotent, end-to-end cap-exceeded emits Class E:cost, master-off no-op, no-registry no-op (4)
  - Parametrized over all 4 watchdog names
- [x] Combined regression: 97/97 across Slices 1+2+3 + W3(6) wiring + adjacent parallel_dispatch suites
- [ ] Live-fire (deferred per operator standing order)

## Rollback

`JARVIS_MID_OP_CANCEL_ENABLED=false` (default). No code revert needed.

## Commit → Slice mapping

| Commit | Slice | Files |
|---|---|---|
| `4053ae1589` | W3(7) Slice 3 | `cancel_token.py` Class E emitter + flag + helper, `cost_governor.py` attach + hook, `governed_loop_service.py` surface attach, 20 tests |

## NOT in this PR (Slice 4+ remain queued)

- Slice 4: Class F signal hooks (SIGTERM / SIGINT / SIGHUP)
- Slice 5: PLAN-EXPLOIT + parallel_dispatch propagation
- Slice 6: SSE event + IDE GET endpoint
- Slice 7: graduation / master flag flip
- wall / productivity / idle watchdog hook wiring (deferred — helper in place)
- `_bash` async conversion
- Per operator standing orders: no Test A audit, no harness code, no F5, no W2(4), no new battle sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Class E (watchdog-initiated) mid-op cancellation with a reference integration in the CostGovernor. Default-off flags keep existing behavior unchanged until explicitly enabled.

- **New Features**
  - Added `CancelOriginEmitter.emit_class_e(watchdog, op_id, token, ...)` with origin `E:<watchdog>` and a guarded set: `{"cost","wall","productivity","idle"}`. Unknown names raise `ValueError`. Supersede logs include both origins.
  - Added `watchdog_enabled()` for `JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED` (defaults false; also requires `JARVIS_MID_OP_CANCEL_ENABLED=true`).
  - Added `emit_watchdog_cancel(...)` helper for watchdog modules to look up the token and emit Class E.
  - CostGovernor: `attach_cancel_surface(registry, session_dir)` and `_emit_class_e_cancel(...)` wired into the cap-exceeded branch; best-effort and never raises.
  - GovernedLoopService attaches the cancel surface to the CostGovernor on startup. Flags off or missing registry → no-op.

- **Migration**
  - No changes needed by default. To enable Class E cancels, set `JARVIS_MID_OP_CANCEL_ENABLED=true` and `JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED=true`.

<sup>Written for commit 4053ae158993d3ac4aeeb07b284b06f0b72f1570. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

