### PR TITLE
feat(cancel_token): W3(7) Slice 4 — Class F system signal cancel hooks

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -3254,6 +3254,33 @@ class BattleTestHarness:
                 self._atexit_fallback_write()
         except Exception:  # noqa: BLE001
             logger.debug("signal-driven partial write failed", exc_info=True)
+        # W3(7) Slice 4 — Class F cancel emission for in-flight ops.
+        # ADDITIVE to the existing partial-summary write above (operator
+        # resolution-4: no harness dependency for correctness; the
+        # partial-summary path keeps working regardless of this hook).
+        # Master flag off OR signal sub-flag off (both default false) →
+        # emit_signal_cancel returns 0 — silent no-op, byte-for-byte
+        # pre-W3(7). Never raises into the signal handler — interrupt-safe.
+        if signal_name is not None:
+            try:
+                from backend.core.ouroboros.governance.cancel_token import (
+                    emit_signal_cancel as _emit_signal_cancel,
+                )
+                _gls = getattr(self, "_governed_loop_service", None)
+                _registry = getattr(_gls, "_cancel_token_registry", None) if _gls else None
+                if _registry is not None:
+                    _emit_signal_cancel(
+                        signal_name=signal_name,
+                        registry=_registry,
+                        session_dir=getattr(self, "_session_dir", None),
+                        phase_at_trigger="unknown",
+                        reason=f"signal {signal_name} received during session",
+                    )
+            except Exception:  # noqa: BLE001 — interrupt-safe
+                logger.debug(
+                    "signal-driven Class F emission skipped",
+                    exc_info=True,
+                )
         if self._shutdown_event is not None:
             self._shutdown_event.set()
 

--- a/backend/core/ouroboros/governance/cancel_token.py
+++ b/backend/core/ouroboros/governance/cancel_token.py
@@ -133,6 +133,25 @@ def watchdog_enabled() -> bool:
     return _env_bool("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", False)
 
 
+def signal_enabled() -> bool:
+    """Class F signal sub-flag — `JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED`.
+
+    Default false (even when master is on) per operator resolution-2 — Class F
+    (system signal cancels: SIGTERM / SIGINT / SIGHUP) is a separate trust
+    step beyond Class D operator and Class E watchdog. Always returns False
+    when master is off.
+
+    Slice 4 (W3(7)) gates the signal-handler-emitted Class F records on this
+    flag. The existing harness signal-handler partial-summary write path is
+    unchanged regardless of this flag — Class F is *additive* observability
+    on top of the existing handler (operator resolution-4: no harness
+    dependency for correctness).
+    """
+    if not mid_op_cancel_enabled():
+        return False
+    return _env_bool("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", False)
+
+
 def bounded_deadline_s() -> float:
     """`JARVIS_CANCEL_BOUNDED_DEADLINE_S` — settle budget (default 30s).
 
@@ -505,6 +524,107 @@ class CancelOriginEmitter:
 
         return record
 
+    # Class F signals (W3(7) Slice 4) — SIGTERM / SIGINT / SIGHUP.
+    # Names mirror the lowercase form already used by harness ticket B
+    # (`signal_name` arg of `_handle_shutdown_signal`).
+    _ALLOWED_SIGNALS: frozenset = frozenset({
+        "sigterm",  # container kill / external orchestrator stop
+        "sigint",   # operator Ctrl-C / interactive interrupt
+        "sighup",   # parent-process death (per S5/S6 incidents — terminal pipeline)
+    })
+
+    def emit_class_f(
+        self,
+        *,
+        signal_name: str,
+        op_id: str,
+        token: CancelToken,
+        phase_at_trigger: str,
+        reason: str = "",
+        initiator_task: str = "",
+    ) -> Optional[CancelRecord]:
+        """Class F — system-signal-initiated immediate cancel.
+
+        Slice 4 (W3(7)). Same mechanics as :meth:`emit_class_d` /
+        :meth:`emit_class_e` but:
+
+        * Gated by :func:`signal_enabled` (sub-flag default false even
+          when master is on — operator resolution-2).
+        * ``signal_name`` MUST be in :attr:`_ALLOWED_SIGNALS` — surfaces
+          typos loudly. Use the same lowercase form as harness ticket B
+          (``"sigterm"``, ``"sigint"``, ``"sighup"``).
+        * Origin string is ``F:<signal_name>`` for machine-grep stability.
+
+        Coordination with harness ticket B (operator resolution-4 — Class F
+        works correctly even if harness epic items still have bugs):
+        the existing harness ``_handle_shutdown_signal`` path that writes
+        the partial ``summary.json`` is unchanged. Class F is *additive*
+        observability on top — emitted ONCE per in-flight op when the
+        signal handler chooses to. The `cancel_records.jsonl` artifact
+        and `[CancelOrigin]` log line live alongside the existing
+        partial-summary write; they do not replace or block it.
+
+        Returns the committed CancelRecord, or None if:
+        * master flag is off (no-op),
+        * signal sub-flag is off (no-op),
+        * the signal name is unknown (raises ValueError — typo guard),
+        * the token was already cancelled by another origin (idempotent loss).
+        """
+        if signal_name not in self._ALLOWED_SIGNALS:
+            raise ValueError(
+                f"unknown signal_name={signal_name!r}; "
+                f"allowed={sorted(self._ALLOWED_SIGNALS)}"
+            )
+        if not mid_op_cancel_enabled():
+            return None
+        if not signal_enabled():
+            return None
+
+        origin = f"F:{signal_name}"
+        record = CancelRecord(
+            schema_version="cancel.1",
+            cancel_id=_new_cancel_id(),
+            op_id=op_id,
+            origin=origin,
+            phase_at_trigger=phase_at_trigger,
+            trigger_monotonic=time.monotonic(),
+            trigger_wall_iso=_now_iso(),
+            bounded_deadline_s=bounded_deadline_s(),
+            reason=reason or f"system signal received ({signal_name})",
+        )
+
+        committed = token.set(record)
+        if not committed:
+            existing = token.get_record()
+            logger.info(
+                "[CancelOrigin] superseded — op=%s requested_origin=%s "
+                "winner_origin=%s winner_cancel_id=%s",
+                op_id[:16],
+                origin,
+                existing.origin if existing else "unknown",
+                existing.cancel_id if existing else "unknown",
+            )
+            return None
+
+        logger.info(
+            "[CancelOrigin] op=%s origin=%s phase=%s cancel_id=%s "
+            "at_monotonic=%.3f reason=%r initiator_task=%s "
+            "bounded_deadline_s=%.1f",
+            op_id[:16],
+            origin,
+            phase_at_trigger,
+            record.cancel_id,
+            record.trigger_monotonic,
+            record.reason,
+            initiator_task or signal_name,
+            record.bounded_deadline_s,
+        )
+
+        if record_persist_enabled() and self._session_dir is not None:
+            self._persist(record)
+
+        return record
+
     def _persist(self, record: CancelRecord) -> None:
         """Append the record to ``cancel_records.jsonl``. Best-effort."""
         try:
@@ -721,6 +841,59 @@ def emit_watchdog_cancel(
     )
 
 
+def emit_signal_cancel(
+    *,
+    signal_name: str,
+    registry: "CancelTokenRegistry",
+    session_dir: Optional[Path] = None,
+    phase_at_trigger: str = "unknown",
+    reason: str = "",
+) -> int:
+    """Convenience — emit Class F:<signal> for **every active op** in the registry.
+
+    Slice 4 (W3(7)). The harness signal handler calls this from within
+    ``_handle_shutdown_signal`` so that one signal arrival fans out into
+    one cancel record per in-flight op (typical case: 1-3 active ops at
+    signal time).
+
+    Returns the number of records emitted (0 when master/sub-flag off, or
+    when no active ops exist). Never raises — the harness signal handler
+    must remain interrupt-safe.
+
+    The existing harness partial-summary write path is NOT touched by this
+    helper (per operator resolution-4 — Class F is additive observability,
+    not a replacement). Callers invoke both: the partial-summary write
+    AND ``emit_signal_cancel`` from the same handler.
+    """
+    if not signal_enabled():
+        return 0
+    try:
+        active = registry.active_op_ids()
+    except Exception:  # noqa: BLE001 — registry must not crash signal handler
+        return 0
+
+    emitter = CancelOriginEmitter(session_dir=session_dir)
+    emitted = 0
+    for op_id in list(active):
+        try:
+            token = registry.get(op_id)
+            if token is None:
+                continue
+            rec = emitter.emit_class_f(
+                signal_name=signal_name,
+                op_id=op_id,
+                token=token,
+                phase_at_trigger=phase_at_trigger,
+                reason=reason,
+                initiator_task=f"harness:{signal_name}",
+            )
+            if rec is not None:
+                emitted += 1
+        except Exception:  # noqa: BLE001 — per-op emit must not block others
+            continue
+    return emitted
+
+
 def subprocess_grace_s() -> float:
     """`JARVIS_CANCEL_SUBPROCESS_GRACE_S` — terminate→kill grace (default 5s).
 
@@ -750,4 +923,6 @@ __all__ = [
     "bounded_deadline_s",
     "watchdog_enabled",
     "emit_watchdog_cancel",
+    "signal_enabled",
+    "emit_signal_cancel",
 ]

--- a/tests/governance/test_cancel_class_f_signal_slice4.py
+++ b/tests/governance/test_cancel_class_f_signal_slice4.py
@@ -1,0 +1,364 @@
+"""W3(7) Slice 4 — Class F system signal cancel hooks.
+
+Operator resolutions binding (project_wave3_item7_mid_op_cancel_scope.md):
+
+* Resolution-2: Default OFF for ALL new flags. ``JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED``
+  defaults False even when master is on.
+* Resolution-4: Class F coordinated with documented harness interactions
+  but NO dependency on harness epic fixes for correctness — the existing
+  harness signal-handler partial-summary write path is *unchanged*; Class F
+  is additive observability only.
+
+Coverage:
+
+A. ``signal_enabled()`` flag composition.
+B. ``CancelOriginEmitter.emit_class_f`` — gating, allowed-signal set,
+   record shape (origin=F:<signal>), supersede semantics.
+C. ``emit_signal_cancel`` convenience helper — fans out to all active ops,
+   returns count, never raises.
+D. Master-off invariant.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.cancel_token import (
+    CancelOriginEmitter,
+    CancelRecord,
+    CancelToken,
+    CancelTokenRegistry,
+    emit_signal_cancel,
+    mid_op_cancel_enabled,
+    signal_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# (A) signal_enabled flag composition
+# ---------------------------------------------------------------------------
+
+
+def test_signal_flag_default_off_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+    assert signal_enabled() is False
+
+
+def test_signal_flag_default_off_even_when_master_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator resolution-2: default OFF even with master on."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", raising=False)
+    assert mid_op_cancel_enabled() is True
+    assert signal_enabled() is False
+
+
+def test_signal_flag_on_when_both_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+    assert signal_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# (B) emit_class_f — gating + allowed-signal set + record shape
+# ---------------------------------------------------------------------------
+
+
+def test_emit_class_f_returns_none_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()
+    result = emitter.emit_class_f(
+        signal_name="sigterm",
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert result is None
+    assert token.is_cancelled is False
+
+
+def test_emit_class_f_returns_none_when_subflag_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", raising=False)
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()
+    result = emitter.emit_class_f(
+        signal_name="sigterm",
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert result is None
+    assert token.is_cancelled is False
+
+
+def test_emit_class_f_writes_record_when_both_flags_on(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", raising=False)
+
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()
+    caplog.set_level("INFO", logger="Ouroboros.CancelToken")
+
+    record = emitter.emit_class_f(
+        signal_name="sigterm",
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+        reason="container kill",
+    )
+
+    assert record is not None
+    assert record.origin == "F:sigterm"
+    assert record.phase_at_trigger == "GENERATE"
+    assert "container kill" in record.reason
+    assert token.is_cancelled is True
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("[CancelOrigin]" in m and "origin=F:sigterm" in m for m in msgs)
+
+
+@pytest.mark.parametrize("signal_name", ["sigterm", "sigint", "sighup"])
+def test_emit_class_f_accepts_canonical_signal_names(
+    monkeypatch: pytest.MonkeyPatch,
+    signal_name: str,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+    token = CancelToken(f"op-{signal_name}-001")
+    emitter = CancelOriginEmitter()
+    record = emitter.emit_class_f(
+        signal_name=signal_name,
+        op_id=f"op-{signal_name}-001",
+        token=token,
+        phase_at_trigger="VALIDATE",
+    )
+    assert record is not None
+    assert record.origin == f"F:{signal_name}"
+
+
+def test_emit_class_f_rejects_unknown_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Typo guard — unknown signal raises ValueError loudly."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+    token = CancelToken("op-test-001")
+    emitter = CancelOriginEmitter()
+    with pytest.raises(ValueError, match="unknown signal_name"):
+        emitter.emit_class_f(
+            signal_name="SIGTERM",  # uppercase typo (canonical is lowercase)
+            op_id="op-test-001",
+            token=token,
+            phase_at_trigger="GENERATE",
+        )
+
+
+def test_emit_class_f_supersede_log_when_token_already_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Class F losing to an earlier Class D operator cancel — supersede log fires."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+
+    token = CancelToken("op-test-001")
+    d_record = CancelRecord(
+        schema_version="cancel.1",
+        cancel_id="d-cid",
+        op_id="op-test-001",
+        origin="D:repl_operator",
+        phase_at_trigger="GENERATE",
+        trigger_monotonic=0.0,
+        trigger_wall_iso="2026-04-25T01:23:45Z",
+        bounded_deadline_s=30.0,
+        reason="operator first",
+    )
+    token.set(d_record)
+
+    emitter = CancelOriginEmitter()
+    caplog.set_level("INFO", logger="Ouroboros.CancelToken")
+
+    second = emitter.emit_class_f(
+        signal_name="sigterm",
+        op_id="op-test-001",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert second is None
+    assert token.get_record() is d_record  # original preserved
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any(
+        "superseded" in m.lower()
+        and "requested_origin=F:sigterm" in m
+        and "winner_origin=D:repl_operator" in m
+        for m in msgs
+    )
+
+
+# ---------------------------------------------------------------------------
+# (C) emit_signal_cancel convenience helper — fan-out across active ops
+# ---------------------------------------------------------------------------
+
+
+def test_emit_signal_cancel_fans_out_to_all_active_ops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+
+    reg = CancelTokenRegistry()
+    op_ids = ["op-fanout-1", "op-fanout-2", "op-fanout-3"]
+    for op_id in op_ids:
+        reg.get_or_create(op_id)
+
+    emitted = emit_signal_cancel(
+        signal_name="sigterm",
+        registry=reg,
+    )
+
+    assert emitted == 3
+    for op_id in op_ids:
+        tok = reg.get(op_id)
+        assert tok is not None
+        assert tok.is_cancelled is True
+        rec = tok.get_record()
+        assert rec is not None
+        assert rec.origin == "F:sigterm"
+
+
+def test_emit_signal_cancel_returns_zero_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+    reg = CancelTokenRegistry()
+    reg.get_or_create("op-master-off")
+
+    emitted = emit_signal_cancel(signal_name="sigterm", registry=reg)
+    assert emitted == 0
+    tok = reg.get("op-master-off")
+    assert tok is not None and tok.is_cancelled is False
+
+
+def test_emit_signal_cancel_returns_zero_when_subflag_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", raising=False)
+    reg = CancelTokenRegistry()
+    reg.get_or_create("op-subflag-off")
+
+    emitted = emit_signal_cancel(signal_name="sigterm", registry=reg)
+    assert emitted == 0
+
+
+def test_emit_signal_cancel_returns_zero_when_no_active_ops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+    reg = CancelTokenRegistry()
+    emitted = emit_signal_cancel(signal_name="sigterm", registry=reg)
+    assert emitted == 0
+
+
+def test_emit_signal_cancel_persists_to_session_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", "true")
+
+    reg = CancelTokenRegistry()
+    reg.get_or_create("op-persist-1")
+    reg.get_or_create("op-persist-2")
+
+    emitted = emit_signal_cancel(
+        signal_name="sighup",
+        registry=reg,
+        session_dir=tmp_path,
+    )
+    assert emitted == 2
+
+    artifact = tmp_path / "cancel_records.jsonl"
+    assert artifact.exists()
+    lines = artifact.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 2
+    import json as _json
+    for line in lines:
+        rec = _json.loads(line)
+        assert rec["origin"] == "F:sighup"
+
+
+def test_emit_signal_cancel_skips_already_cancelled_ops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When some ops are already cancelled (e.g. by Class D before signal),
+    emit_signal_cancel still tries them — they return None (supersede),
+    not counted in the emitted total."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+
+    reg = CancelTokenRegistry()
+    tok_d = reg.get_or_create("op-pre-cancelled")
+    tok_d.set(CancelRecord(
+        schema_version="cancel.1",
+        cancel_id="d",
+        op_id="op-pre-cancelled",
+        origin="D:repl_operator",
+        phase_at_trigger="GENERATE",
+        trigger_monotonic=0.0,
+        trigger_wall_iso="2026-04-25T01:23:45Z",
+        bounded_deadline_s=30.0,
+        reason="op",
+    ))
+    reg.get_or_create("op-fresh-1")
+    reg.get_or_create("op-fresh-2")
+
+    emitted = emit_signal_cancel(signal_name="sigterm", registry=reg)
+    # Only the 2 fresh ops counted; pre-cancelled supersede returned None
+    assert emitted == 2
+
+    # Pre-cancelled record preserved (Class D, not Class F)
+    assert reg.get("op-pre-cancelled").get_record().origin == "D:repl_operator"
+
+
+def test_emit_signal_cancel_never_raises_on_registry_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interrupt-safe: signal handler must never get a Python exception
+    from emit_signal_cancel even when the registry is broken."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+
+    class _BrokenRegistry:
+        def active_op_ids(self):
+            raise RuntimeError("registry broken")
+
+        def get(self, op_id):
+            return None
+
+    # Must not raise
+    emitted = emit_signal_cancel(
+        signal_name="sigterm",
+        registry=_BrokenRegistry(),
+    )
+    assert emitted == 0


### PR DESCRIPTION
## Summary

Slice 4 of the Wave 3 (7) Mid-Op Cancellation arc per `project_wave3_item7_mid_op_cancel_scope.md` §9. Operator-authorized 2026-04-25 with binding resolutions (1)–(5).

Builds on Slice 1 (`165639c6cb`) + Slice 2 (`29a28e2065`) + Slice 3 (`1c87b10289`). Adds the **Class F (system signal) cancel surface** + additive harness integration in the existing `_handle_shutdown_signal` path.

## What ships

- `CancelOriginEmitter.emit_class_f(signal_name, ...)` — parallel to Slice 1 D / Slice 3 E. Origin `F:<signal_name>`.
- `_ALLOWED_SIGNALS = {"sigterm", "sigint", "sighup"}` typo-guard frozenset (rejects uppercase; canonical lowercase mirrors harness ticket B).
- `signal_enabled()` env reader for `JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED` (default **false** even when master on, per resolution-2).
- `emit_signal_cancel(signal_name, registry, ...)` fan-out helper — emits one Class F record per active op in the registry. Returns count emitted. **Never raises** (interrupt-safe).
- Additive Class F emission in `harness.py:_handle_shutdown_signal` — the existing partial-summary write path is unchanged; Class F is emitted *after* the summary write, gated by master + signal sub-flag.

## Resolution-4 honored — no harness dependency for correctness

The existing 4-step `_handle_shutdown_signal` path:

1. `self._stop_reason = signal_name` — unchanged
2. `self._atexit_fallback_write(session_outcome="incomplete_kill")` — unchanged
3. **NEW** `emit_signal_cancel(...)` — gated, returns 0 on master-off / sub-flag-off, never raises
4. `self._shutdown_event.set()` — unchanged

If harness epic items #3 (bounded shutdown) / #6 (SIGTERM insurance) still have bugs, Class F path **does not depend** on them.

## Master-off invariants

- `JARVIS_MID_OP_CANCEL_ENABLED=false` (default) → `emit_class_f` returns None, `emit_signal_cancel` returns 0. Existing partial-summary write path fully preserved. Byte-for-byte pre-W3(7).
- Master on + sub-flag off (default) → still no-op.
- Empty registry → `emit_signal_cancel` returns 0.

## Resolution-3 (precedence) extended for F

- Idempotent `token.set()` — Class F losing to prior Class D logs `[CancelOrigin] superseded` with both origins.
- `emit_signal_cancel` over a registry with pre-cancelled ops handles supersede gracefully (pre-cancelled ops not counted in emitted total).

## Interrupt-safety

`emit_signal_cancel` never raises. Pinned by `test_emit_signal_cancel_never_raises_on_registry_failure` (broken registry that raises on `active_op_ids()` → helper returns 0 cleanly).

## Test plan

- [x] `tests/governance/test_cancel_class_f_signal_slice4.py` — 18/18 passing
  - `signal_enabled` flag composition (3)
  - `emit_class_f` gating + allowed-signal set + record shape + supersede (7)
  - `emit_signal_cancel` fan-out, master/sub-flag no-op, empty registry, persist, pre-cancelled supersede, interrupt-safe (8)
  - Parametrized over all 3 signal names
- [x] Combined regression: 80/80 across Slices 1+2+3+4 + W3(6) wiring
- [ ] Live-fire (deferred per operator standing order)

## Rollback

`JARVIS_MID_OP_CANCEL_ENABLED=false` (default). No code revert needed.

## Commit → Slice mapping

| Commit | Slice | Files |
|---|---|---|
| `ea51448ac4` | W3(7) Slice 4 | `cancel_token.py` Class F emitter + flag + helper, `harness.py` additive emission, 18 tests |

## NOT in this PR (Slice 5+ remain queued)

- Slice 5: PLAN-EXPLOIT + parallel_dispatch propagation
- Slice 6: SSE event + IDE GET endpoint
- Slice 7: graduation / master flag flip
- wall / productivity / idle watchdog hook wiring (Slice 3 deferral)
- `_bash` async conversion (Slice 2 deferral)
- Per operator standing orders: no Test A audit, no harness code beyond this Slice 4 additive emission, no F5, no W2(4), no new battle sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Class F mid-op cancellation via system signals (SIGTERM, SIGINT, SIGHUP) and wires it into the harness shutdown handler as an additive, interrupt-safe hook. Default-off; no behavior change unless flags are enabled.

- **New Features**
  - `CancelOriginEmitter.emit_class_f(signal_name, op_id, token, ...)` with origin `F:<signal>`.
  - Allowed signals: `sigterm`, `sigint`, `sighup` (lowercase only; typos raise).
  - `signal_enabled()` reads `JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED` (gated by `JARVIS_MID_OP_CANCEL_ENABLED`).
  - `emit_signal_cancel(signal_name, registry, session_dir, ...)` fans out to active ops, returns count, never raises.
  - Harness: `_handle_shutdown_signal` now calls `emit_signal_cancel` after the existing partial-summary write; gated and no-op when flags are off.

- **Migration**
  - To enable: set `JARVIS_MID_OP_CANCEL_ENABLED=true` and `JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED=true`.
  - Optional persistence: `JARVIS_CANCEL_RECORD_PERSIST_ENABLED=true` to write `cancel_records.jsonl`.
  - No changes needed to keep current behavior (both flags default off).

<sup>Written for commit ea51448ac408bdfb3f08eac4d7644698010d6f12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

