### PR TITLE
feat(cancel_token): W3(7) Slice 7 — graduation (master flag flip + 21 pins)

### DIFF
--- a/backend/core/ouroboros/governance/cancel_token.py
+++ b/backend/core/ouroboros/governance/cancel_token.py
@@ -88,13 +88,32 @@ def _env_bool(name: str, default: bool) -> bool:
 
 
 def mid_op_cancel_enabled() -> bool:
-    """Master flag — `JARVIS_MID_OP_CANCEL_ENABLED` (default false).
+    """Master flag — `JARVIS_MID_OP_CANCEL_ENABLED` (default **true** post-Slice-7).
 
-    When false: no `[CancelOrigin]` emissions, no record artifacts, no
-    behavior change vs pre-W3(7). Existing REPL /cancel keeps phase-
-    boundary semantics (see GovernedLoopService.request_cancel).
+    Pre-graduation (Slices 1–6) default was ``False``. Slice 7 flipped the
+    default to ``True`` after the full propagation surface (D/E/F + SSE +
+    IDE GET) landed and was unit-test green. The flip is safe because the
+    *actuating* sub-flags stay default off:
+
+    * ``JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED`` — Class E (cost / wall /
+      productivity / idle) — default ``False``.
+    * ``JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED`` — Class F signals — default ``False``.
+    * ``JARVIS_CANCEL_SSE_ENABLED`` — additive SSE event — default ``False``.
+
+    Class D REPL ``cancel <op-id> --immediate`` defaults active when master
+    is on (sub-flag default ``True``) but only fires on explicit operator
+    action — no auto-cancellation surface.
+
+    The ContextVar token plumbing runs on every dispatched op once master
+    is on, but is observably-no-op when no Class D/E/F trigger ever calls
+    ``token.set(...)`` — ``race_or_wait_for`` falls through to plain
+    ``asyncio.wait_for``. This is the standard graduation pattern from
+    Wave 1 / Wave 2 / W3(6) Slice 5b.
+
+    Hot-revert: ``JARVIS_MID_OP_CANCEL_ENABLED=false`` restores byte-for-byte
+    pre-W3(7) behavior. No code revert needed. Pinned by graduation tests.
     """
-    return _env_bool("JARVIS_MID_OP_CANCEL_ENABLED", False)
+    return _env_bool("JARVIS_MID_OP_CANCEL_ENABLED", True)
 
 
 def repl_immediate_enabled() -> bool:

--- a/tests/governance/test_cancel_class_5_parallel_paths_slice5.py
+++ b/tests/governance/test_cancel_class_5_parallel_paths_slice5.py
@@ -279,7 +279,7 @@ async def test_master_off_plan_exploit_passes_through_to_wait_for(
 ) -> None:
     """With token=None (master off), the helper falls through to plain
     asyncio.wait_for — no Slice 5 behavior change."""
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
 
     cancel_token_var.set(None)
 

--- a/tests/governance/test_cancel_class_e_watchdog_slice3.py
+++ b/tests/governance/test_cancel_class_e_watchdog_slice3.py
@@ -43,7 +43,7 @@ from backend.core.ouroboros.governance.cancel_token import (
 def test_watchdog_flag_default_off_when_master_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
     monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
     # Master off forces sub-flag off regardless
     assert watchdog_enabled() is False
@@ -75,7 +75,7 @@ def test_watchdog_flag_on_when_both_set(
 def test_emit_class_e_returns_none_when_master_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
     monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
     token = CancelToken("op-test-001")
     emitter = CancelOriginEmitter()
@@ -226,7 +226,7 @@ def test_emit_class_e_supersede_log_when_token_already_cancelled(
 def test_emit_watchdog_cancel_master_off_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
     monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
     reg = CancelTokenRegistry()
     result = emit_watchdog_cancel(
@@ -354,7 +354,7 @@ def test_cost_governor_cap_exceeded_no_op_when_master_off(
     """Master flag off → cap exceeded doesn't emit a cancel record (byte-for-byte
     pre-W3(7) — cost_governor still flips entry.exceeded=True for the
     orchestrator's existing cap-check at line ~3402)."""
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
 
     from backend.core.ouroboros.governance.cost_governor import (
         CostGovernor,

--- a/tests/governance/test_cancel_class_f_signal_slice4.py
+++ b/tests/governance/test_cancel_class_f_signal_slice4.py
@@ -41,7 +41,7 @@ from backend.core.ouroboros.governance.cancel_token import (
 def test_signal_flag_default_off_when_master_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
     monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
     assert signal_enabled() is False
 
@@ -72,7 +72,7 @@ def test_signal_flag_on_when_both_set(
 def test_emit_class_f_returns_none_when_master_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
     monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
     token = CancelToken("op-test-001")
     emitter = CancelOriginEmitter()
@@ -246,7 +246,7 @@ def test_emit_signal_cancel_fans_out_to_all_active_ops(
 def test_emit_signal_cancel_returns_zero_when_master_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
     monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
     reg = CancelTokenRegistry()
     reg.get_or_create("op-master-off")

--- a/tests/governance/test_cancel_propagation_slice2.py
+++ b/tests/governance/test_cancel_propagation_slice2.py
@@ -387,7 +387,7 @@ async def test_master_off_emit_no_op_does_not_set_token(
 ) -> None:
     """End-to-end: master flag off → REPL Class D emit returns None,
     token never gets set, race_or_wait_for falls through."""
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
 
     token = CancelToken("op-master-off-001")
     emitter = CancelOriginEmitter()

--- a/tests/governance/test_cancel_token_protocol.py
+++ b/tests/governance/test_cancel_token_protocol.py
@@ -37,15 +37,21 @@ from backend.core.ouroboros.governance.cancel_token import (
 # ---------------------------------------------------------------------------
 
 
-def test_master_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
-    """JARVIS_MID_OP_CANCEL_ENABLED defaults to false."""
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+def test_master_flag_explicit_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JARVIS_MID_OP_CANCEL_ENABLED=false reverts to pre-W3(7) (hot-revert path).
+
+    Note: post-Slice-7 the *default* is True. This test pins the
+    explicit-false behavior — the byte-for-byte pre-W3(7) hot-revert path.
+    The default-True invariant lives in
+    ``test_w3_7_graduation_pins_slice7.py``.
+    """
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
     assert mid_op_cancel_enabled() is False
 
 
 def test_repl_immediate_off_when_master_off(monkeypatch: pytest.MonkeyPatch) -> None:
     """Sub-flag is force-False when master is off, regardless of its own value."""
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
     monkeypatch.setenv("JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE", "true")
     assert repl_immediate_enabled() is False
 
@@ -59,7 +65,7 @@ def test_repl_immediate_on_when_master_on(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_record_persist_off_when_master_off(monkeypatch: pytest.MonkeyPatch) -> None:
     """Persist sub-flag is force-False when master is off."""
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
     monkeypatch.setenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", "true")
     assert record_persist_enabled() is False
 
@@ -265,7 +271,7 @@ def test_emit_class_d_returns_none_when_master_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Master flag off → emit is silent no-op (byte-for-byte pre-W3(7))."""
-    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
     token = CancelToken("op-test-001")
     emitter = CancelOriginEmitter()
     record = emitter.emit_class_d(

--- a/tests/governance/test_w3_7_graduation_pins_slice7.py
+++ b/tests/governance/test_w3_7_graduation_pins_slice7.py
@@ -1,0 +1,350 @@
+"""W3(7) Slice 7 — graduation pin tests.
+
+Pins the post-graduation contract:
+
+A. Master flag default is now **True** (Slice 7 flip).
+B. All *actuating* sub-flags (WATCHDOG, SIGNAL, SSE) stay default **False** —
+   master-on alone causes ZERO observable behavior change vs pre-W3(7) at
+   the cancel-actuation layer. Operators must explicitly opt into D/E/F/SSE.
+C. REPL_IMMEDIATE defaults True when master is on (per Slice 1 design) —
+   but only fires on explicit operator action (`cancel <op-id> --immediate`).
+D. RECORD_PERSIST defaults True when master is on — but only writes when an
+   emit() actually fires, which requires sub-flags above to fire first.
+E. Hot-revert path: ``JARVIS_MID_OP_CANCEL_ENABLED=false`` restores byte-for-byte
+   pre-W3(7) behavior — verified by re-running master-off invariant pins.
+F. Authority invariants: SSE event vocabulary is additive only (11 events
+   post-Slice-6); IDE GET routes are read-only; cancel record schema is
+   ``cancel.1`` (frozen); 4 cancel classes (D/E/F + the existing A/B/C
+   classification taxonomy).
+G. Source-grep pins: bridge call sites in all 3 emit methods, dispatcher
+   pre-iteration cancel-check, candidate_generator race wraps,
+   tool_executor terminate-grace-kill, plan_exploit/parallel_dispatch
+   cancel propagation, IDE routes registered.
+
+These tests run on EVERY commit going forward. If any pin breaks, either:
+* The change was an unintentional regression — fix the change.
+* The contract is intentionally being expanded — update the pin AND the
+  hot-revert documentation. (Per Slice 1 contract, the master-off invariant
+  is non-negotiable; contract widening must preserve it.)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# (A) Master flag default — graduation flip
+# ---------------------------------------------------------------------------
+
+
+def test_master_flag_defaults_true_post_slice_7(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARVIS_MID_OP_CANCEL_ENABLED defaults to True after Slice 7 graduation."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.cancel_token import (
+        mid_op_cancel_enabled,
+    )
+    assert mid_op_cancel_enabled() is True, (
+        "Slice 7 graduation flips JARVIS_MID_OP_CANCEL_ENABLED default to True. "
+        "If this test fails post-merge, either the flip was reverted (fix) or "
+        "the operator chose to revert the graduation (update the pin and the "
+        "scope-doc graduation appendix)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (B) Actuating sub-flags stay default-off — operator opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_watchdog_subflag_default_off_even_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Class E (cost / wall / productivity / idle) requires explicit opt-in
+    via JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED. Master-on alone is not enough."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.cancel_token import (
+        mid_op_cancel_enabled,
+        watchdog_enabled,
+    )
+    assert mid_op_cancel_enabled() is True   # master on by default
+    assert watchdog_enabled() is False        # but watchdog still off
+
+
+def test_signal_subflag_default_off_even_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Class F (system signals) requires explicit opt-in via
+    JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED. Master-on alone is not enough."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.cancel_token import (
+        mid_op_cancel_enabled,
+        signal_enabled,
+    )
+    assert mid_op_cancel_enabled() is True
+    assert signal_enabled() is False
+
+
+def test_sse_subflag_default_off_even_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SSE bridge requires explicit opt-in via JARVIS_CANCEL_SSE_ENABLED.
+    Master-on alone does not start publishing cancel_origin_emitted events."""
+    monkeypatch.delenv("JARVIS_CANCEL_SSE_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.cancel_token import sse_enabled
+    assert sse_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# (C) REPL_IMMEDIATE default-true-when-master-on (per Slice 1 design)
+# ---------------------------------------------------------------------------
+
+
+def test_repl_immediate_defaults_true_when_master_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REPL_IMMEDIATE inherits master-on by default. The Class D operator
+    cancel surface is enabled at graduation, but the only trigger is an
+    explicit ``cancel <op-id> --immediate`` REPL invocation — no
+    auto-cancellation."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE", raising=False)
+    from backend.core.ouroboros.governance.cancel_token import (
+        repl_immediate_enabled,
+    )
+    assert repl_immediate_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# (D) RECORD_PERSIST default-true-when-master-on
+# ---------------------------------------------------------------------------
+
+
+def test_record_persist_defaults_true_when_master_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When an emit fires, the record IS persisted to cancel_records.jsonl
+    by default. Operators can disable via JARVIS_CANCEL_RECORD_PERSIST_ENABLED=false
+    for log-only mode."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.cancel_token import (
+        record_persist_enabled,
+    )
+    assert record_persist_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# (E) Hot-revert path — master=false restores pre-W3(7) byte-for-byte
+# ---------------------------------------------------------------------------
+
+
+def test_hot_revert_master_off_disables_all_subflags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARVIS_MID_OP_CANCEL_ENABLED=false force-disables every sub-flag
+    regardless of their individual env values. The single env-var revert
+    is the operator's only-knob hot-revert path."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
+    # Even if operator tries to enable sub-flags, they must stay off
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CANCEL_RECORD_PERSIST_ENABLED", "true")
+    from backend.core.ouroboros.governance.cancel_token import (
+        mid_op_cancel_enabled,
+        record_persist_enabled,
+        repl_immediate_enabled,
+        signal_enabled,
+        watchdog_enabled,
+    )
+    assert mid_op_cancel_enabled() is False
+    assert repl_immediate_enabled() is False
+    assert watchdog_enabled() is False
+    assert signal_enabled() is False
+    assert record_persist_enabled() is False
+
+
+def test_hot_revert_master_off_emit_class_d_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Class D emit returns None when master is off, even if REPL_IMMEDIATE on."""
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE", "true")
+    from backend.core.ouroboros.governance.cancel_token import (
+        CancelOriginEmitter,
+        CancelToken,
+    )
+    token = CancelToken("op-revert-test")
+    emitter = CancelOriginEmitter()
+    result = emitter.emit_class_d(
+        op_id="op-revert-test",
+        token=token,
+        phase_at_trigger="GENERATE",
+    )
+    assert result is None
+    assert token.is_cancelled is False
+
+
+# ---------------------------------------------------------------------------
+# (F) Authority invariants — SSE vocabulary additive, schema frozen
+# ---------------------------------------------------------------------------
+
+
+def test_sse_event_vocabulary_count_is_11_post_slice_6():
+    """Slice 6 added the 11th SSE event (cancel_origin_emitted). The
+    additive-only contract means this count grows over time, never shrinks
+    (no event type removal). Post-Slice-7 the count remains 11."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        _VALID_EVENT_TYPES,
+    )
+    assert len(_VALID_EVENT_TYPES) == 40, (
+        # Slice 6 added the 11th cancel event on top of the existing
+        # vocabulary, bringing the total set size to 40 (the broader
+        # observability arc grew over time — task / session / posture /
+        # flag / governor / memory / plan / cancel events). The
+        # additive-only contract means this number grows; if it shrinks
+        # below 40, an event type was REMOVED (contract break — fix the
+        # source, don't update this pin).
+        f"SSE event vocabulary size changed unexpectedly to "
+        f"{len(_VALID_EVENT_TYPES)}; this slice did not add/remove events. "
+        "Audit recent commits for vocab churn."
+    )
+
+
+def test_cancel_origin_emitted_event_type_string_stable():
+    """The event type string is the wire-format API. Don't rename."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        EVENT_TYPE_CANCEL_ORIGIN_EMITTED,
+    )
+    assert EVENT_TYPE_CANCEL_ORIGIN_EMITTED == "cancel_origin_emitted"
+
+
+def test_cancel_record_schema_version_is_cancel_1():
+    """The CancelRecord schema is wire-format API. Schema bumps need
+    additive migration semantics."""
+    from backend.core.ouroboros.governance.cancel_token import (
+        CancelRecord,
+    )
+    rec = CancelRecord(
+        schema_version="cancel.1",
+        cancel_id="x",
+        op_id="op-x",
+        origin="D:repl_operator",
+        phase_at_trigger="GENERATE",
+        trigger_monotonic=0.0,
+        trigger_wall_iso="2026-04-25T01:23:45Z",
+        bounded_deadline_s=30.0,
+        reason="t",
+    )
+    assert rec.schema_version == "cancel.1"
+
+
+# ---------------------------------------------------------------------------
+# (G) Source-grep pins — code shape that must survive drift
+# ---------------------------------------------------------------------------
+
+
+def _read(p: str) -> str:
+    return Path(p).read_text(encoding="utf-8")
+
+
+def test_pin_dispatcher_has_pre_iteration_cancel_check():
+    """phase_dispatcher.py routes to POSTMORTEM on cancel before each
+    iteration. Pinned by Slice 2."""
+    src = _read("backend/core/ouroboros/governance/phase_dispatcher.py")
+    assert "is_cancelled" in src
+    assert "POSTMORTEM" in src
+    assert "cancel_record" in src
+
+
+def test_pin_candidate_generator_race_wraps():
+    """candidate_generator._call_primary and _call_fallback use
+    race_or_wait_for. Pinned by Slice 2."""
+    src = _read("backend/core/ouroboros/governance/candidate_generator.py")
+    # At least 2 race_or_wait_for sites (one per call path)
+    assert src.count("race_or_wait_for") >= 2
+    assert "current_cancel_token" in src
+
+
+def test_pin_tool_executor_terminate_grace_kill():
+    """tool_executor._run_tests_async has terminate→grace→kill on
+    OperationCancelledError. Pinned by Slice 2."""
+    src = _read("backend/core/ouroboros/governance/tool_executor.py")
+    assert "OperationCancelledError" in src
+    assert "_term_then_force" in src
+    assert "subprocess_grace_s" in src
+
+
+def test_pin_cost_governor_has_class_e_hook():
+    """cost_governor.charge() emits Class E:cost on cap-exceeded. Pinned by Slice 3."""
+    src = _read("backend/core/ouroboros/governance/cost_governor.py")
+    assert "_emit_class_e_cancel" in src
+    assert "attach_cancel_surface" in src
+    assert 'watchdog="cost"' in src
+
+
+def test_pin_harness_has_class_f_emission():
+    """harness._handle_shutdown_signal emits Class F additive. Pinned by Slice 4."""
+    src = _read("backend/core/ouroboros/battle_test/harness.py")
+    assert "emit_signal_cancel" in src
+    assert "Class F" in src or "class_f" in src.lower()
+
+
+def test_pin_plan_exploit_cancel_handler():
+    """plan_exploit gather has cancel handling. Pinned by Slice 5."""
+    src = _read("backend/core/ouroboros/governance/plan_exploit.py")
+    assert "race_or_wait_for as _race_or_wait_for" in src
+    assert "[PLAN-EXPLOIT] op=%s status=cancelled" in src
+
+
+def test_pin_parallel_dispatch_cancel_handler():
+    """parallel_dispatch.enforce_evaluate_fanout returns CANCELLED on cancel.
+    Pinned by Slice 5."""
+    src = _read("backend/core/ouroboros/governance/parallel_dispatch.py")
+    assert "FanoutOutcome.CANCELLED" in src
+    assert 'getattr(scheduler, "cancel_graph"' in src
+
+
+def test_pin_ide_observability_cancel_routes():
+    """IDE observability has /observability/cancels routes. Pinned by Slice 6."""
+    src = _read("backend/core/ouroboros/governance/ide_observability.py")
+    assert "/observability/cancels" in src
+    assert "_handle_cancel_list" in src
+    assert "_handle_cancel_detail" in src
+
+
+def test_pin_emit_methods_call_sse_bridge():
+    """All 3 emit methods (D/E/F) call bridge_cancel_origin_to_sse(record).
+    Pinned by Slice 6."""
+    src = _read("backend/core/ouroboros/governance/cancel_token.py")
+    assert src.count("bridge_cancel_origin_to_sse(record)") >= 3
+
+
+# ---------------------------------------------------------------------------
+# (H) Hot-revert documentation — env vars enumerated
+# ---------------------------------------------------------------------------
+
+
+def test_full_env_var_revert_matrix_documented():
+    """Every W3(7) env knob documented in the cancel_token.py module
+    docstring or function docstrings. Hot-revert recipe must be discoverable."""
+    src = _read("backend/core/ouroboros/governance/cancel_token.py")
+    # Every gating env var must be referenced in the source (and thus
+    # discoverable via grep + module docs)
+    for env_var in (
+        "JARVIS_MID_OP_CANCEL_ENABLED",
+        "JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE",
+        "JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED",
+        "JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED",
+        "JARVIS_CANCEL_SSE_ENABLED",
+        "JARVIS_CANCEL_RECORD_PERSIST_ENABLED",
+        "JARVIS_CANCEL_BOUNDED_DEADLINE_S",
+        "JARVIS_CANCEL_SUBPROCESS_GRACE_S",
+    ):
+        assert env_var in src, f"env var {env_var!r} missing from cancel_token.py"


### PR DESCRIPTION
## Summary

**Final slice of the Wave 3 (7) Mid-Op Cancellation arc.** Operator-authorized 2026-04-25.

Builds on Slices 1–6 (all merged). Flips `JARVIS_MID_OP_CANCEL_ENABLED` default from `False` → `True` and pins the post-graduation contract via 21 new tests + a 13-occurrence bulk-update of master-off invariant tests to use explicit `setenv`.

## Why the master-flip is safe (zero observable behavior change)

Standard graduation pattern from Wave 1 / Wave 2 / W3(6) Slice 5b. Sub-flags that gate ACTUATION stay default-off:

| Sub-flag | Default | What it gates | Effect |
|---|---|---|---|
| `JARVIS_MID_OP_CANCEL_REPL_IMMEDIATE` | True | Class D `cancel <op-id> --immediate` | Available, only fires on operator action |
| `JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED` | **False** | Class E (cost / wall / productivity / idle) | OFF — operator opts in |
| `JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED` | **False** | Class F (system signals) | OFF — operator opts in |
| `JARVIS_CANCEL_SSE_ENABLED` | **False** | SSE `cancel_origin_emitted` | OFF — operator opts in |
| `JARVIS_CANCEL_RECORD_PERSIST_ENABLED` | True | `cancel_records.jsonl` writes | True — but writes only when emit fires |

ContextVar plumbing runs on every dispatched op but is observably-no-op when no `set()` ever happens. `race_or_wait_for` falls through. Master-flip alone causes ZERO observable behavior change at the cancel-actuation layer.

## Hot-revert

Single env var: `JARVIS_MID_OP_CANCEL_ENABLED=false` → all sub-flags force-disabled regardless of their individual env values → byte-for-byte pre-W3(7). Pinned by 2 hot-revert tests.

## What ships

| Module | Change |
|---|---|
| `cancel_token.py` | `mid_op_cancel_enabled()` default `False` → `True`; docstring rewritten |
| `tests/governance/test_w3_7_graduation_pins_slice7.py` | NEW — 21 pin tests (master default, sub-flag defaults, hot-revert, authority invariants, source-grep) |
| 5 existing test files | Bulk-update: 13 `monkeypatch.delenv(...)` → `monkeypatch.setenv(..., "false")` so master-off invariant tests still pass post-flip; one rename `test_master_flag_default_off` → `test_master_flag_explicit_false` |

## Live-fire status

Per operator resolution-5 ("No live-fire/battle until unit slice is green and I explicitly authorize live-fire"), the actual 3-clean-session live-fire arc is gated on operator authorization. This PR ships:
- ✅ Code flip (master default true)
- ✅ 21 graduation pin tests
- ✅ Bulk test update for master-off invariant
- ✅ Hot-revert documentation
- ⏳ Live-fire validation (operator-authorized separately)

The graduation-via-flag-flip pattern matches Wave 1 / Wave 2 / W3(6) Slice 5b — those graduations also flipped + pinned via tests; live-fire was operator-decided afterward and the master-off hot-revert was always the safety net.

## Test plan

- [x] `tests/governance/test_w3_7_graduation_pins_slice7.py` — 21/21 passing
- [x] Existing cancel suite — 101/101 still passing post-flip (master-off invariant tests use explicit `setenv("false")` now)
- [x] Combined: 160/160 across all 7 slice test files + W3(6) parallel_dispatch + adjacent suites
- [ ] Live-fire 3-clean-session arc (deferred per operator standing order)

## Combined arc totals (Slices 1–7)

- 6 env knobs total, fully documented + grep-pinned
- 4 cancel origin classes (D / E / F + existing A / B / C taxonomy)
- 1 SSE event added (40 total in vocabulary, additive-only)
- 2 IDE GET routes added
- 160/160 tests
- Hot-revert: single env var

## Wave 3 completion

Slice 7 closes Wave 3 (7), which closes Wave 3 entirely (W3(6) was already CLOSED at the structural bar 2026-04-24).

## Rollback

`JARVIS_MID_OP_CANCEL_ENABLED=false` (set explicitly). No code revert needed.

## Commit → Slice mapping

| Commit | Slice | Files |
|---|---|---|
| `62b62d44bc` | W3(7) Slice 7 (auto-commit) | `cancel_token.py` master flip + 5 test file bulk-updates (13 occurrences) |
| `d175ca4e02` | W3(7) Slice 7 follow-on | `test_w3_7_graduation_pins_slice7.py` (21 graduation pins) |

## NOT in this PR (operator-authorized follow-ups)

- Live-fire / battle session validation of the graduated default
- L3 subagent token injection / per-stream partial records (Slice 5 deferral)
- Wall / productivity / idle watchdog wiring (Slice 3 deferral — helper available)
- `_bash` async conversion (Slice 2 deferral)
- Per operator standing orders: no Test A audit, no harness code beyond Slice 4, no F5, no W2(4), no new battle sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates mid-op cancellation by flipping `JARVIS_MID_OP_CANCEL_ENABLED` default to true and pinning the contract with 21 new tests. No behavior change by default; actuating sub-flags remain off, and hot-revert is a single env var.

- New Features
  - `mid_op_cancel_enabled()` now defaults true; docstring updated.
  - Actuating sub-flags stay default-off: `JARVIS_MID_OP_CANCEL_WATCHDOG_ENABLED`, `JARVIS_MID_OP_CANCEL_SIGNAL_ENABLED`, `JARVIS_CANCEL_SSE_ENABLED`.
  - REPL immediate remains operator-triggered; record persist defaults true but writes only when an emit occurs.

- Migration
  - No action needed; defaults keep behavior unchanged.
  - Hot-revert: set `JARVIS_MID_OP_CANCEL_ENABLED=false` to force-disable all sub-flags and restore pre-W3(7) behavior.

<sup>Written for commit d175ca4e028e8a3aff715c8c06e7ecd59e0463d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

