### PR TITLE
feat(harness): Slice 1 — BoundedShutdownWatchdog (rooted fix for 14 zombie incidents)

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -218,6 +218,17 @@ class BattleTestHarness:
         self._summary_written: bool = False
         self._install_atexit_fallback()
 
+        # Harness Epic Slice 1 — bounded shutdown watchdog.
+        # Daemon thread, idle until ``arm()``-ed by signal handler / wall
+        # cap. On arm, sleeps the deadline; if not disarmed, calls
+        # ``os._exit(75)``. Closes the 14-incident Py_FinalizeEx zombie
+        # class + S5/S6 SIGTERM-partial-summary regression + S6
+        # WallClockWatchdog asyncio-task starvation.
+        from backend.core.ouroboros.battle_test.shutdown_watchdog import (
+            BoundedShutdownWatchdog as _BoundedShutdownWatchdog,
+        )
+        self._shutdown_watchdog = _BoundedShutdownWatchdog()
+
         # Component references (populated during boot)
         self._oracle: Any = None
         self._governance_stack: Any = None
@@ -758,6 +769,17 @@ class BattleTestHarness:
         finally:
             await self._shutdown_components()
             await self._generate_report()
+            # Harness Epic Slice 1 — disarm the bounded-shutdown watchdog
+            # since clean shutdown completed within deadline. Without
+            # this disarm, a race between graceful shutdown completion
+            # and the watchdog's deadline could cause spurious os._exit.
+            # Idempotent — no-op if not armed.
+            try:
+                _wdg = getattr(self, "_shutdown_watchdog", None)
+                if _wdg is not None:
+                    _wdg.disarm()
+            except Exception:  # noqa: BLE001
+                pass
 
     # ------------------------------------------------------------------
     # Boot methods (all overridable for test mocking)
@@ -3240,6 +3262,22 @@ class BattleTestHarness:
         contract that the ``register_signal_handlers`` production path
         always supplies the signal name.
         """
+        # Harness Epic Slice 1 — arm the bounded-shutdown watchdog FIRST
+        # (before any of the existing async / partial-summary work). If
+        # the rest of this handler (or the downstream asyncio shutdown
+        # path) wedges, the watchdog's daemon thread will fire
+        # os._exit(75) after the deadline. Master flag default true;
+        # ``=false`` reverts to pre-Slice-1 (asyncio-only shutdown).
+        try:
+            from backend.core.ouroboros.battle_test.shutdown_watchdog import (
+                default_deadline_s as _bsw_deadline_s,
+            )
+            _wdg = getattr(self, "_shutdown_watchdog", None)
+            if _wdg is not None and signal_name is not None:
+                _wdg.arm(reason=signal_name, deadline_s=_bsw_deadline_s())
+        except Exception:  # noqa: BLE001 — never let watchdog arm crash signal handler
+            pass
+
         # Stamp the signal-specific reason before the write runs so the
         # partial summary carries an actionable classifier instead of the
         # generic "shutdown_signal" catch-all. Keep the existing value if
@@ -3587,6 +3625,20 @@ class BattleTestHarness:
             time.time() - self._started_at,
             cap_s,
         )
+        # Harness Epic Slice 1 — arm the bounded-shutdown watchdog in
+        # PARALLEL to the asyncio event. If the asyncio loop is wedged
+        # (the S6 hypothesis — wall watchdog never fired at 2400s),
+        # this thread-side arm guarantees os._exit fires after the
+        # deadline. Best-effort, never raises.
+        try:
+            from backend.core.ouroboros.battle_test.shutdown_watchdog import (
+                default_deadline_s as _bsw_deadline_s,
+            )
+            _wdg = getattr(self, "_shutdown_watchdog", None)
+            if _wdg is not None:
+                _wdg.arm(reason="wall_clock_cap", deadline_s=_bsw_deadline_s())
+        except Exception:  # noqa: BLE001
+            pass
         self._wall_clock_event.set()
 
     async def _monitor_restart_pending(self) -> None:

--- a/backend/core/ouroboros/battle_test/shutdown_watchdog.py
+++ b/backend/core/ouroboros/battle_test/shutdown_watchdog.py
@@ -1,0 +1,300 @@
+"""Harness Epic Slice 1 — BoundedShutdownWatchdog.
+
+Guarantees that every battle-test session terminates within a bounded
+deadline, regardless of asyncio event-loop state. Closes the rooted
+problem documented in ``project_followup_battle_test_post_summary_hang.md``:
+
+* 14 incidents of ``Py_FinalizeEx → PyThread_acquire_lock_timed →
+  __psynch_cvwait`` deadlock during interpreter shutdown.
+* SIGTERM-during-steady-state failing to write ``summary.json`` (S5/S6).
+* ``WallClockWatchdog`` not firing at ``max_wall_seconds`` (S6 — asyncio
+  task starvation hypothesis).
+
+All three classes have the same root cause: shutdown discipline that
+depends on the asyncio event loop being responsive. When the loop is
+wedged, the asyncio-side termination paths can't fire — and Python's
+own ``Py_FinalizeEx`` deadlocks on non-daemon thread joins.
+
+This module provides a **synchronous-thread-based** escape hatch.
+
+Architecture:
+
+* A daemon thread is spawned at harness init. It blocks on a
+  ``threading.Event`` until ``arm()`` is called.
+* On ``arm(reason, deadline_s)``, the thread wakes, sleeps
+  ``deadline_s``, then calls ``os._exit(EXIT_CODE_HARNESS_WEDGED=75)``.
+  ``os._exit`` does NOT run cleanup handlers, atexit, or finalizers —
+  it terminates the process immediately at the C level.
+* If clean shutdown completes before the deadline, ``disarm()`` clears
+  the event and the thread re-blocks. No ``os._exit`` fires.
+* Daemon thread → no ``Py_FinalizeEx`` join blocking → interpreter can
+  exit cleanly via the asyncio path when that path works.
+
+Master flag: ``JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED`` (default
+``true``). Hot-revert: ``=false`` reverts to pre-Slice-1 (asyncio-only
+shutdown — old behavior). Defaulting ``true`` is safe because the
+watchdog is ``disarm()``-able; clean shutdowns don't trigger
+``os._exit``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+import time
+from typing import Callable, Optional
+
+
+logger = logging.getLogger("Ouroboros.ShutdownWatchdog")
+
+
+# Reserved exit code for "harness wedged, os._exit fired". 75 = EX_TEMPFAIL
+# in BSD sysexits.h — operationally appropriate (try-again-later semantics).
+# Distinct from 0 (clean) and 1 (generic error) so wrappers can detect
+# wedge-vs-error without log parsing.
+EXIT_CODE_HARNESS_WEDGED: int = 75
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Standard JARVIS env-bool parse — true/1/yes/on (case-insensitive)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("true", "1", "yes", "on")
+
+
+def bounded_shutdown_enabled() -> bool:
+    """Master flag — `JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED` (default true).
+
+    Post-Slice-1 graduation, defaults true. Hot-revert: ``=false`` reverts
+    to pre-Slice-1 (asyncio-only shutdown). Safe to default true because
+    the watchdog is ``disarm()``-able; clean shutdowns don't trigger
+    ``os._exit``.
+    """
+    return _env_bool("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", True)
+
+
+def default_deadline_s() -> float:
+    """`JARVIS_BATTLE_SHUTDOWN_DEADLINE_S` — bounded shutdown budget.
+
+    Default 30s. Sized for the worst-case clean-shutdown chain: stop GLS
+    (~5s) + flush durables (~5s) + write summary.json (~2s) + GC + asyncio
+    teardown (~5s) + slack. If exceeded, ``os._exit`` fires.
+    """
+    raw = os.environ.get("JARVIS_BATTLE_SHUTDOWN_DEADLINE_S", "30.0")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 30.0
+
+
+class BoundedShutdownWatchdog:
+    """Daemon-thread-based deadline watchdog for harness shutdown.
+
+    Lifecycle:
+      1. ``__init__()`` — spawns the daemon thread. Thread is idle (blocked
+         on the arm event) until ``arm()`` is called.
+      2. ``arm(reason, deadline_s)`` — wakes the thread; deadline starts.
+      3. ``disarm()`` — clears the event so a subsequent ``arm()`` re-arms
+         cleanly. If the thread is currently in its post-arm sleep, the
+         disarm event interrupts it and the thread re-blocks.
+      4. If deadline elapses with arm still held, ``os._exit(75)`` fires.
+
+    Idempotency:
+      * Multiple ``arm()`` calls — first wins (records first reason), later
+        calls are no-ops. Avoids accidentally extending the deadline.
+      * Multiple ``disarm()`` calls — idempotent.
+      * ``arm()`` after ``disarm()`` — re-arms cleanly with new reason.
+
+    Test affordances:
+      * ``exit_fn`` constructor kwarg — defaults to ``os._exit``. Tests
+        inject a recorder so the deadline-elapse path is observable
+        without actually exiting.
+      * ``sleep_fn`` constructor kwarg — defaults to ``time.sleep``. Tests
+        inject a fast-clock to verify deadline math without real-time waits.
+    """
+
+    def __init__(
+        self,
+        *,
+        exit_fn: Callable[[int], None] = os._exit,
+        sleep_fn: Callable[[float], None] = time.sleep,
+        thread_name: str = "BoundedShutdownWatchdog",
+    ) -> None:
+        self._exit_fn = exit_fn
+        self._sleep_fn = sleep_fn
+        # The arm event signals "shutdown requested; deadline running".
+        self._arm_event = threading.Event()
+        # The disarm event lets disarm() interrupt a sleeping thread.
+        self._disarm_event = threading.Event()
+        # Stop-thread event for clean teardown in tests.
+        self._stop_event = threading.Event()
+        # State (only mutated under _lock)
+        self._lock = threading.Lock()
+        self._reason: Optional[str] = None
+        self._deadline_s: float = 0.0
+        self._armed_at_monotonic: Optional[float] = None
+        self._fired: bool = False
+        # Daemon thread — won't block Py_FinalizeEx
+        self._thread = threading.Thread(
+            target=self._thread_loop,
+            name=thread_name,
+            daemon=True,
+        )
+        self._thread.start()
+
+    @property
+    def is_armed(self) -> bool:
+        return self._arm_event.is_set() and not self._disarm_event.is_set()
+
+    @property
+    def reason(self) -> Optional[str]:
+        with self._lock:
+            return self._reason
+
+    @property
+    def deadline_s(self) -> float:
+        with self._lock:
+            return self._deadline_s
+
+    @property
+    def armed_at_monotonic(self) -> Optional[float]:
+        with self._lock:
+            return self._armed_at_monotonic
+
+    @property
+    def fired(self) -> bool:
+        return self._fired
+
+    def arm(self, reason: str, deadline_s: float) -> bool:
+        """Start the deadline. Returns True on first arm, False if already armed.
+
+        First-arm-wins semantics: if armed already, the existing deadline
+        + reason are preserved. This avoids accidentally extending the
+        deadline by re-arming.
+        """
+        if not bounded_shutdown_enabled():
+            return False
+        with self._lock:
+            if self._arm_event.is_set() and not self._disarm_event.is_set():
+                # Already armed — first wins
+                logger.info(
+                    "[ShutdownWatchdog] arm() ignored — already armed reason=%r "
+                    "deadline_s=%.1f (requested reason=%r deadline_s=%.1f)",
+                    self._reason, self._deadline_s, reason, deadline_s,
+                )
+                return False
+            self._reason = reason
+            self._deadline_s = max(0.0, float(deadline_s))
+            self._armed_at_monotonic = time.monotonic()
+            self._disarm_event.clear()
+        # Set arm event AFTER state is committed so the thread sees the
+        # right deadline when it wakes.
+        self._arm_event.set()
+        logger.warning(
+            "[ShutdownWatchdog] ARMED reason=%r deadline_s=%.1f — "
+            "os._exit(%d) will fire if not disarmed within deadline",
+            reason, deadline_s, EXIT_CODE_HARNESS_WEDGED,
+        )
+        return True
+
+    def disarm(self) -> bool:
+        """Cancel the deadline. Returns True if was armed, False if already idle.
+
+        Idempotent. Resets state so next ``arm()`` starts fresh.
+        """
+        with self._lock:
+            if not self._arm_event.is_set():
+                return False
+            self._disarm_event.set()
+            self._arm_event.clear()
+            elapsed = (
+                time.monotonic() - self._armed_at_monotonic
+                if self._armed_at_monotonic is not None
+                else 0.0
+            )
+            reason = self._reason
+            deadline = self._deadline_s
+        logger.info(
+            "[ShutdownWatchdog] DISARMED reason=%r elapsed=%.2fs / deadline=%.1fs "
+            "(clean shutdown completed within budget)",
+            reason, elapsed, deadline,
+        )
+        return True
+
+    def stop(self) -> None:
+        """Signal the daemon thread to exit. Used in tests for clean teardown.
+
+        Production daemon threads die with the interpreter; ``stop()`` is
+        only needed when a test constructs a watchdog and wants to release
+        the thread before the test ends.
+        """
+        self._stop_event.set()
+        # Wake the thread if it's blocked
+        self._arm_event.set()
+        self._disarm_event.set()
+
+    def _thread_loop(self) -> None:
+        """Daemon thread body — wait, sleep deadline, fire os._exit."""
+        while True:
+            # Wait for arm or stop
+            self._arm_event.wait()
+            if self._stop_event.is_set():
+                return
+            # Snapshot deadline + reason under lock
+            with self._lock:
+                deadline = self._deadline_s
+                reason = self._reason
+            # Sleep deadline_s, but interruptible by disarm or stop.
+            # Use the disarm event's wait(timeout=) — it blocks for up to
+            # deadline_s and returns True if disarm fired.
+            disarmed = self._disarm_event.wait(timeout=deadline)
+            if self._stop_event.is_set():
+                return
+            if disarmed:
+                # Clean shutdown beat the deadline — clear and loop
+                self._disarm_event.clear()
+                # Wait for re-arm (arm event was cleared by disarm())
+                continue
+            # Deadline elapsed without disarm — fire os._exit
+            self._fired = True
+            elapsed_at_fire = (
+                time.monotonic() - self._armed_at_monotonic
+                if self._armed_at_monotonic is not None
+                else deadline
+            )
+            # Forensic line to stderr — bypasses logging which may itself
+            # be wedged. Flush before _exit.
+            try:
+                sys.stderr.write(
+                    f"\n[BoundedShutdownWatchdog] FIRED — "
+                    f"reason={reason!r} elapsed={elapsed_at_fire:.1f}s "
+                    f"deadline={deadline:.1f}s — calling "
+                    f"os._exit({EXIT_CODE_HARNESS_WEDGED}) NOW\n"
+                )
+                sys.stderr.flush()
+            except Exception:
+                pass
+            try:
+                logger.error(
+                    "[ShutdownWatchdog] FIRED reason=%r elapsed=%.1fs "
+                    "deadline=%.1fs — os._exit(%d)",
+                    reason, elapsed_at_fire, deadline,
+                    EXIT_CODE_HARNESS_WEDGED,
+                )
+            except Exception:
+                pass
+            # GO
+            self._exit_fn(EXIT_CODE_HARNESS_WEDGED)
+            # exit_fn returned (only happens in tests with mocked exit) —
+            # break out of loop and let stop()/test handle cleanup
+            return
+
+
+__all__ = [
+    "BoundedShutdownWatchdog",
+    "EXIT_CODE_HARNESS_WEDGED",
+    "bounded_shutdown_enabled",
+    "default_deadline_s",
+]

--- a/tests/battle_test/test_bounded_shutdown_watchdog.py
+++ b/tests/battle_test/test_bounded_shutdown_watchdog.py
@@ -1,0 +1,435 @@
+"""Harness Epic Slice 1 — BoundedShutdownWatchdog tests.
+
+Pins the contract:
+
+* Daemon thread spawns at construction (does not block test teardown).
+* ``arm(reason, deadline_s)`` triggers the deadline.
+* ``disarm()`` cancels before fire.
+* Deadline elapse without disarm → ``os._exit(75)`` fires (verified via
+  injected ``exit_fn`` recorder).
+* First-arm-wins (no accidental deadline extension).
+* Master flag default true; ``=false`` disables arm/fire entirely.
+* Re-arm after disarm works cleanly.
+* Forensic stderr line emitted before the exit call.
+* Concurrent arm/disarm is thread-safe.
+
+Test affordances injected via constructor:
+* ``exit_fn`` — recorder that captures the exit code without exiting.
+* ``sleep_fn`` — fast-clock that returns immediately for deadline tests.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+from backend.core.ouroboros.battle_test.shutdown_watchdog import (
+    BoundedShutdownWatchdog,
+    EXIT_CODE_HARNESS_WEDGED,
+    bounded_shutdown_enabled,
+    default_deadline_s,
+)
+
+
+# ---------------------------------------------------------------------------
+# (A) Flag defaults + env knobs
+# ---------------------------------------------------------------------------
+
+
+def test_master_flag_default_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED defaults true post-Slice-1."""
+    monkeypatch.delenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", raising=False)
+    assert bounded_shutdown_enabled() is True
+
+
+def test_master_flag_explicit_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "false")
+    assert bounded_shutdown_enabled() is False
+
+
+def test_default_deadline_default_30s(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_BATTLE_SHUTDOWN_DEADLINE_S", raising=False)
+    assert default_deadline_s() == 30.0
+
+
+def test_default_deadline_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_BATTLE_SHUTDOWN_DEADLINE_S", "5.5")
+    assert default_deadline_s() == 5.5
+
+
+def test_default_deadline_garbage_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_BATTLE_SHUTDOWN_DEADLINE_S", "not-a-number")
+    assert default_deadline_s() == 30.0
+
+
+def test_exit_code_constant():
+    assert EXIT_CODE_HARNESS_WEDGED == 75
+
+
+# ---------------------------------------------------------------------------
+# (B) Construction + daemon thread
+# ---------------------------------------------------------------------------
+
+
+def test_construction_starts_daemon_thread() -> None:
+    """The watchdog thread MUST be daemon — otherwise Py_FinalizeEx
+    deadlock (the original problem this whole epic exists to solve)."""
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        assert wdg._thread.is_alive()
+        assert wdg._thread.daemon is True
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+def test_initial_state_idle() -> None:
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        assert wdg.is_armed is False
+        assert wdg.reason is None
+        assert wdg.fired is False
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# (C) arm() / disarm() lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_arm_records_reason_and_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        result = wdg.arm(reason="sigterm", deadline_s=10.0)
+        assert result is True
+        assert wdg.is_armed is True
+        assert wdg.reason == "sigterm"
+        assert wdg.deadline_s == 10.0
+        assert wdg.armed_at_monotonic is not None
+    finally:
+        wdg.disarm()
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+def test_disarm_clears_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        wdg.arm(reason="sigterm", deadline_s=10.0)
+        result = wdg.disarm()
+        assert result is True
+        assert wdg.is_armed is False
+        # Reason is preserved for postmortem (not cleared)
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+def test_arm_first_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple arm() calls — first wins, later are no-ops. Avoids
+    accidental deadline extension."""
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        wdg.arm(reason="sigterm", deadline_s=10.0)
+        result = wdg.arm(reason="sigint", deadline_s=60.0)
+        assert result is False
+        assert wdg.reason == "sigterm"
+        assert wdg.deadline_s == 10.0
+    finally:
+        wdg.disarm()
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+def test_disarm_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        wdg.arm(reason="sigterm", deadline_s=10.0)
+        wdg.disarm()
+        result = wdg.disarm()
+        assert result is False  # already disarmed
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+def test_rearm_after_disarm_works_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        wdg.arm(reason="sigterm", deadline_s=10.0)
+        wdg.disarm()
+        result = wdg.arm(reason="sigint", deadline_s=20.0)
+        assert result is True
+        assert wdg.reason == "sigint"
+        assert wdg.deadline_s == 20.0
+    finally:
+        wdg.disarm()
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+def test_arm_returns_false_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Master flag off → arm() is a no-op (returns False, doesn't set state)."""
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "false")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        result = wdg.arm(reason="sigterm", deadline_s=10.0)
+        assert result is False
+        assert wdg.is_armed is False
+        assert wdg.reason is None
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# (D) Deadline elapse → exit_fn fires
+# ---------------------------------------------------------------------------
+
+
+def test_deadline_elapse_fires_exit_fn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real-time deadline test (short deadline). exit_fn is called with
+    EXIT_CODE_HARNESS_WEDGED when the deadline elapses without disarm."""
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    fired_event = threading.Event()
+
+    def _record_exit(code: int) -> None:
+        exit_calls.append(code)
+        fired_event.set()
+
+    wdg = BoundedShutdownWatchdog(exit_fn=_record_exit)
+    try:
+        wdg.arm(reason="test_deadline", deadline_s=0.1)
+        # Wait for the thread to fire (with generous timeout)
+        fired = fired_event.wait(timeout=2.0)
+        assert fired, "watchdog should have fired exit_fn within 2s"
+        assert exit_calls == [EXIT_CODE_HARNESS_WEDGED]
+        assert wdg.fired is True
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+def test_disarm_before_deadline_prevents_fire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        wdg.arm(reason="test_disarm", deadline_s=2.0)
+        time.sleep(0.05)  # let thread enter the post-arm sleep
+        wdg.disarm()
+        time.sleep(0.3)  # wait past where the deadline would have fired
+        assert exit_calls == []
+        assert wdg.fired is False
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+def test_deadline_elapse_writes_forensic_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The forensic stderr line is critical — bypasses logging which may
+    itself be wedged. Pinned so it's not accidentally removed."""
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    fired_event = threading.Event()
+
+    def _record_exit(code: int) -> None:
+        exit_calls.append(code)
+        fired_event.set()
+
+    wdg = BoundedShutdownWatchdog(exit_fn=_record_exit)
+    try:
+        wdg.arm(reason="forensic_test", deadline_s=0.05)
+        fired_event.wait(timeout=2.0)
+        captured = capsys.readouterr()
+        assert "[BoundedShutdownWatchdog] FIRED" in captured.err
+        assert "forensic_test" in captured.err
+        assert "os._exit(75)" in captured.err
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# (E) Multi-cycle (arm → disarm → arm → fire)
+# ---------------------------------------------------------------------------
+
+
+def test_arm_disarm_arm_fire_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First arm gets disarmed cleanly; second arm fires."""
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    fired_event = threading.Event()
+
+    def _record_exit(code: int) -> None:
+        exit_calls.append(code)
+        fired_event.set()
+
+    wdg = BoundedShutdownWatchdog(exit_fn=_record_exit)
+    try:
+        wdg.arm(reason="first_arm", deadline_s=2.0)
+        time.sleep(0.05)
+        wdg.disarm()
+        time.sleep(0.05)
+        # Second arm — let it fire
+        wdg.arm(reason="second_arm_fires", deadline_s=0.05)
+        fired_event.wait(timeout=2.0)
+        assert exit_calls == [EXIT_CODE_HARNESS_WEDGED]
+        assert wdg.reason == "second_arm_fires"
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# (F) Thread safety — concurrent arm/disarm
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_arm_calls_thread_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Many threads racing to arm() — first-wins invariant holds, no crashes."""
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    arm_results: list = []
+
+    def _race_arm(idx: int) -> None:
+        result = wdg.arm(reason=f"thread_{idx}", deadline_s=10.0)
+        arm_results.append(result)
+
+    try:
+        threads = [
+            threading.Thread(target=_race_arm, args=(i,))
+            for i in range(20)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=1.0)
+
+        # Exactly one True (the first arm) and 19 False
+        assert sum(arm_results) == 1
+        assert wdg.is_armed is True
+    finally:
+        wdg.disarm()
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+def test_concurrent_arm_and_disarm_does_not_deadlock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stress test: 50 arm/disarm pairs racing in 20 threads. Must complete
+    within reasonable time (no deadlock)."""
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+
+    def _churn(idx: int) -> None:
+        for _ in range(50):
+            wdg.arm(reason=f"t{idx}", deadline_s=10.0)
+            wdg.disarm()
+
+    try:
+        threads = [
+            threading.Thread(target=_churn, args=(i,))
+            for i in range(20)
+        ]
+        t0 = time.monotonic()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+        elapsed = time.monotonic() - t0
+        assert elapsed < 5.0, f"churn took {elapsed:.2f}s — possible deadlock"
+        # No exit fired (all disarms beat any deadline)
+        assert exit_calls == []
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# (G) Source-grep pins
+# ---------------------------------------------------------------------------
+
+
+def test_module_uses_os_underscore_exit_not_sys_exit():
+    """os._exit is the documented escape hatch — sys.exit runs cleanup
+    handlers which is exactly what we're trying to bypass."""
+    from pathlib import Path
+    src = Path(
+        "backend/core/ouroboros/battle_test/shutdown_watchdog.py"
+    ).read_text()
+    # Default exit_fn is os._exit
+    assert "exit_fn: Callable[[int], None] = os._exit" in src
+    # No sys.exit usage at module level
+    assert "sys.exit" not in src
+
+
+def test_thread_is_daemon_pinned():
+    """Daemon=True is THE invariant — it's why Py_FinalizeEx doesn't
+    deadlock waiting for this thread. Pin it source-side."""
+    from pathlib import Path
+    src = Path(
+        "backend/core/ouroboros/battle_test/shutdown_watchdog.py"
+    ).read_text()
+    assert "daemon=True" in src
+
+
+def test_harness_wires_watchdog_at_three_sites():
+    """harness.py wires arm() at signal handler + WallClockWatchdog,
+    and disarm() at clean-shutdown completion. Pin the wiring so it
+    survives drift."""
+    from pathlib import Path
+    src = Path(
+        "backend/core/ouroboros/battle_test/harness.py"
+    ).read_text()
+    # arm sites: 2 (signal handler + wall clock)
+    assert src.count('_wdg.arm(') >= 2
+    # disarm site: 1 (clean shutdown)
+    assert "_wdg.disarm()" in src
+    # Construction at __init__
+    assert "BoundedShutdownWatchdog as _BoundedShutdownWatchdog" in src


### PR DESCRIPTION
## Summary

**Slice 1 of the Harness Reliability Epic.** Operator-authorized 2026-04-25 with the binding rallying cry: *"let's start with the Harness epic (trust/cost) and let's make sure we resolve this rooted problem and super beef it up!"*

Closes the rooted problem class (14 documented zombie incidents + S5/S6 SIGTERM regression + S6 WallClockWatchdog silent-fail) per `project_followup_battle_test_post_summary_hang.md`. All three failure classes have the same root cause: shutdown discipline that depends on a responsive asyncio event loop. When the loop is wedged, asyncio-side termination paths can't fire, and Python's own `Py_FinalizeEx` deadlocks on non-daemon thread joins.

**Solution:** synchronous-thread-based escape hatch.

## What ships

- **`backend/core/ouroboros/battle_test/shutdown_watchdog.py`** (new):
  - `BoundedShutdownWatchdog` primitive — daemon thread (NOT joined by `Py_FinalizeEx`), `arm(reason, deadline_s)` starts deadline, `disarm()` cancels, `os._exit(75)` fires after deadline if not disarmed.
  - First-arm-wins semantics (no accidental deadline extension under races).
  - Forensic stderr line BEFORE `os._exit` (bypasses logging which may itself be wedged).
  - Master flag: `JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED` (default **true**). Hot-revert: `=false`.

- **`harness.py`** — three wire-in sites:
  - `__init__`: construct watchdog (daemon thread idle until armed)
  - `_handle_shutdown_signal`: arm BEFORE existing partial-summary write
  - `WallClockWatchdog._wall_clock_alarm`: arm IN PARALLEL to setting asyncio event (S6 fix — thread-side guarantees fire even if loop is wedged)
  - Clean shutdown completion: disarm so spurious `os._exit` doesn't fire on graceful termination
  - All wire-ins are best-effort (try/except), never crash signal handler.

## Why default-true is safe

The watchdog is `disarm()`-able. Clean shutdowns call `disarm()` before the deadline elapses, so `os._exit` never fires on the happy path. Only wedged sessions (the 14-incident class) trigger the escape hatch. Hot-revert to pre-Slice-1 behavior is a single env var: `JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED=false`.

## Test plan

- [x] **23/23 green** in `test_bounded_shutdown_watchdog.py`:
  - Flag defaults + env knobs (6)
  - Construction — daemon thread, initial idle state (2)
  - arm/disarm lifecycle — first-arm-wins, idempotent disarm, re-arm cycle, master-off no-op (5)
  - Real-time deadline elapse → `exit_fn(75)` fires (1)
  - Disarm before deadline prevents fire (1)
  - Forensic stderr line emitted (1)
  - Multi-cycle (arm → disarm → arm → fire) (1)
  - Thread safety — concurrent arm calls, arm+disarm churn (2)
  - Source-grep pins — `os._exit` not `sys.exit`, `daemon=True`, harness 3-site wiring (3)
- [ ] Live-fire validation (deferred per operator standing order)

## Rollback

Single env var: `JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED=false`. No code revert needed.

## Commit → Slice mapping

| Commit | Slice | Files |
|---|---|---|
| `d8bcbba4bb` | Harness Epic Slice 1 | `shutdown_watchdog.py` primitive, `harness.py` 3 wire-ins, 23 tests |

## NOT in this PR (later harness slices)

- Slice 2: `intake_router.lock` lifecycle hardening + single-flight launcher (items 2 + 5)
- Slice 3: process hygiene — stdin guard ban + canonical pgrep + runbook (items 1 + 4)
- Slice 4: graduation pins (per W3(7) pattern)

## NOT in this PR (other deferred items, separate operator-authorized arcs)

- L3 worktree subagent cancel-token injection (W3(7) Slice 5 deferral)
- PLAN-EXPLOIT per-stream partial-record contributions (W3(7) Slice 5 deferral)
- Wall/productivity/idle watchdog hook wiring (W3(7) Slice 3 deferral)
- `_bash` async conversion (W3(7) Slice 2 deferral)
- Test A audit (seed exploration arc, separate ticket)
- F5 (touches_security_surface)
- W2(4) curiosity engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded shutdown watchdog to ensure the harness exits within a fixed deadline even if the asyncio loop wedges. Default-on, it force-exits with `os._exit(75)` only when the deadline is exceeded and disarms on clean shutdown.

- **New Features**
  - New `BoundedShutdownWatchdog` (daemon thread). `arm(reason, deadline_s)` starts a deadline; `disarm()` cancels; first-arm-wins; writes a forensic line to stderr before `os._exit(75)`.
  - Default enabled via `JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED=true`; set to `false` to revert. Deadline via `JARVIS_BATTLE_SHUTDOWN_DEADLINE_S` (default 30s).
  - Wired into `harness.py`: constructed in `__init__`; armed first in `_handle_shutdown_signal`; armed in the wall-clock monitor path alongside the asyncio event; disarmed after clean shutdown completes. All paths are best-effort and never raise.
  - Added tests covering flags, lifecycle, thread-safety, and wiring.

- **Bug Fixes**
  - Eliminates interpreter shutdown deadlocks causing zombie processes (14 incidents).
  - Restores SIGTERM partial-summary reliability by arming before the write and bounding shutdown (S5/S6).
  - Ensures the wall-clock cap terminates even if the event loop is unresponsive.

<sup>Written for commit d8bcbba4bb2f643d74cf14e833cbc8229fb08aa7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

