### PR TITLE
feat(harness): Slice 3 — operator runbook + CI guard for banned stdin-guard

### DIFF
--- a/docs/operations/battle_test_runbook.md
+++ b/docs/operations/battle_test_runbook.md
@@ -1,0 +1,213 @@
+# Battle-Test Operator Runbook
+
+Last updated: 2026-04-25 (Harness Epic Slice 3).
+
+This runbook is the canonical operator reference for launching, monitoring,
+and recovering battle-test sessions of the Ouroboros pipeline. It supersedes
+ad-hoc runbook fragments scattered across older session-graduation docs.
+
+If you are an LLM agent reading this to figure out how to run a battle-test,
+follow it literally. Do **not** invent variations.
+
+## TL;DR — standard launch
+
+```bash
+python3 scripts/ouroboros_battle_test.py \
+  --cost-cap 2.00 \
+  --idle-timeout 600 \
+  --max-wall-seconds 2400 \
+  --headless -v
+```
+
+This recipe is the only supported invocation pattern. Operators and agent-
+conducted soaks both use this exact form (vary the numeric flags as
+appropriate).
+
+## What changed in the harness epic (Slices 1–4, 2026-04-25)
+
+| Slice | What it added |
+|---|---|
+| 1 | `BoundedShutdownWatchdog` — daemon thread + `os._exit(75)` after 30s if asyncio shutdown wedges. |
+| 2 | `intake_router.lock` schema upgrade + wedged-but-alive TTL detection + single-flight launcher preflight. |
+| 3 | Process hygiene canonicalization (this runbook + CI grep guard for banned patterns). |
+| 4 | Graduation pins. |
+
+**You no longer need to manually clean up zombies, stale locks, or wedged
+sessions in normal operation.** Slices 1+2 cure the 14-incident class
+structurally.
+
+## Canonical process probe
+
+Use this exact form everywhere — runbooks, agent prompts, debugging notes,
+ad-hoc shell sessions:
+
+```bash
+pgrep -f "python3? scripts/ouroboros_battle_test\.py"
+```
+
+The `python3?` (regex `?` quantifier) accepts both `python` and `python3`.
+The path-anchored `scripts/ouroboros_battle_test\.py` avoids matching:
+
+* `zsh` wrapper processes that contain the script path inside their `eval`
+  text (the ones with `/bin/zsh -c source ... && eval '...python3 scripts/ouroboros_battle_test.py ...'`).
+* IDE search tabs that happen to mention the path.
+* `grep` invocations searching for the pattern.
+
+Anti-patterns (do **not** use any of these — they false-positive or
+false-negative):
+
+```bash
+# Too loose — matches zsh wrappers + grep itself
+pgrep -f ouroboros_battle_test
+# Too loose — matches any python process running anything ouroboros
+pgrep -f "python.*ouroboros"
+# Wrong tool — pgrep without -f matches process name (always "python3"),
+# never the script
+pgrep ouroboros_battle_test
+```
+
+## Banned pattern: `tail -f /dev/null | python`
+
+The deprecated `tail -f /dev/null | python3 scripts/ouroboros_battle_test.py ...`
+stdin-guard idiom is **banned** in `docs/` and `scripts/`. CI enforces
+this via `scripts/check_no_stdin_guard.sh`.
+
+Why it's banned (per S5/S6 incidents 2026-04-24):
+
+* When the parent shell dies, `tail -f /dev/null` keeps stdout open, so
+  the Python child never receives SIGPIPE. The Python child becomes an
+  orphan but stays alive — leading to the Py_FinalizeEx zombie class
+  (14 documented incidents).
+* The 7 orphans observed in the S4 mass-cleanup all had this pattern.
+
+The replacement is built-in:
+
+```bash
+python3 scripts/ouroboros_battle_test.py --headless ...
+```
+
+The `--headless` flag (or env `OUROBOROS_BATTLE_HEADLESS=true`) skips the
+`SerpentREPL` input task entirely — no stdin needed, no parent-shell
+dependency. Auto-detected via `not sys.stdin.isatty()` when omitted.
+
+## Recovery procedures
+
+### Symptom: launcher exits with code 75
+
+```
+[single-flight] REJECTED — concurrent battle-test detected
+  • pgrep: PID 12345
+  • lock: PID 12345
+  exit code 75 (EX_TEMPFAIL) — try again after the other run completes
+```
+
+This is expected behavior — Slice 2 single-flight rejected your launch
+because another battle-test is already running. Two valid responses:
+
+1. **Wait** for the other run to complete naturally.
+2. **Take over** if you're sure the other run is yours and you want to
+   replace it. Kill the other PID:
+   ```bash
+   pgrep -f "python3? scripts/ouroboros_battle_test\.py" | xargs kill -TERM
+   sleep 30  # bounded-shutdown deadline
+   ```
+   Then re-launch.
+
+**Override** (operator escape hatch): `JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED=false`
+disables the check. Only use for diagnostics or recovery — running two
+battle-tests in parallel will contaminate each other's WAL state.
+
+### Symptom: lock file exists but no process holds it
+
+```
+[IntakeRouter] Removed stale lock (dead PID 12345)
+```
+
+This is automatic recovery — the dead-PID staleness check (pre-existing,
+preserved through Slice 2) reclaims locks held by crashed sessions. No
+operator action needed.
+
+### Symptom: lock file exists, PID is alive, but battle-test is wedged
+
+```
+[IntakeRouter] Removed wedged-but-alive stale lock (PID=12345 alive,
+age=8000s > TTL=7200s — treating as Py_FinalizeEx-class zombie)
+```
+
+This is automatic recovery — Slice 2's wedged-TTL check reclaims locks
+held by Py_FinalizeEx-deadlocked zombies. No operator action needed in
+the new session — but you may want to investigate the wedged process:
+
+```bash
+sample <PID> 30 10 > .jarvis/forensics/pid<PID>_sample_$(date +%s).txt
+kill -KILL <PID>
+```
+
+Slice 1's `BoundedShutdownWatchdog` should have prevented the wedge in
+the first place; if you see this in production it's worth filing
+forensics for follow-up.
+
+### Symptom: session ran past `--max-wall-seconds` without terminating
+
+This was the S6 pattern (51min on a 40min cap). Slice 1 fixed it via the
+thread-side bounded-shutdown watchdog.
+
+If you still see this post-Slice-1, the watchdog itself failed. Check:
+
+* `JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED` (default `true`) — was it
+  explicitly set to `false`?
+* `JARVIS_BATTLE_SHUTDOWN_DEADLINE_S` (default `30`) — was it set to a
+  large value?
+
+If neither was tampered with and the session still hung, capture
+forensics and treat as a regression.
+
+### Symptom: session dir has `debug.log` but no `summary.json`
+
+S5/S6 pattern — the SIGTERM-during-steady-state regression. Slice 1's
+bounded-shutdown watchdog + the existing `_atexit_fallback_write` path
+in `harness.py` should have written a partial summary before `os._exit`
+fires.
+
+If this happens post-Slice-1, capture the debug.log tail to forensics
+and treat as a regression.
+
+## Forensics directory
+
+When capturing process state for a wedged session, write to
+`.jarvis/forensics/`. The directory is gitignored. Standard naming:
+
+```
+.jarvis/forensics/pid<PID>_sample_<unix_ts>.txt
+.jarvis/forensics/pid<PID>_lsof_<unix_ts>.txt
+```
+
+## Live-fire validation pattern
+
+For arc-graduation or post-deferral validation:
+
+1. Sync to main (`git pull --ff-only`).
+2. Run preflight (`pgrep` clean, `intake_router.lock` absent or stale).
+3. Launch with the standard recipe above.
+4. Watch `tail -f .ouroboros/sessions/<session-id>/debug.log` for the
+   first signal you're looking for (e.g. `[CancelOrigin]`,
+   `[ParallelDispatch]`, etc.).
+5. When the signal lands (or fails to land within reasonable time),
+   trigger graceful shutdown:
+   ```bash
+   pgrep -f "python3? scripts/ouroboros_battle_test\.py" | xargs kill -TERM
+   ```
+   Slice 1's bounded-shutdown watchdog will guarantee `summary.json`
+   lands within 30s.
+6. Inspect `.ouroboros/sessions/<session-id>/summary.json` for the
+   final classification.
+
+## Cross-references
+
+- `memory/project_followup_battle_test_post_summary_hang.md` — 14-incident
+  forensic record (Py_FinalizeEx class), 5-item original epic.
+- `memory/project_harness_epic_scope.md` — current 4-slice epic scope.
+- `memory/project_f1_w3_slice5b_s1_s6_checkpoint.md` — S5/S6 incidents
+  that added items 6 + 7 to the epic.
+- `CLAUDE.md` — top-level harness behavior summary; references this
+  runbook as the operational source of truth.

--- a/scripts/check_no_stdin_guard.sh
+++ b/scripts/check_no_stdin_guard.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Harness Epic Slice 3 — CI guard against the banned `tail -f /dev/null | python`
+# stdin-guard idiom in `docs/` and `scripts/`.
+#
+# Why banned: the stdin-guard pattern keeps the Python child's stdout
+# pipe open after the parent shell dies, so the child becomes an orphan
+# instead of receiving SIGPIPE. The 7 orphan PIDs in the S4 mass-cleanup
+# (2026-04-23) all had this pattern. Slice 3 enforces the ban so the
+# pattern can't sneak back in via runbook drift or copy-paste.
+#
+# Replacement: `python3 scripts/ouroboros_battle_test.py --headless ...`
+# (or env `OUROBOROS_BATTLE_HEADLESS=true`). See
+# `docs/operations/battle_test_runbook.md`.
+#
+# Usage:
+#   ./scripts/check_no_stdin_guard.sh
+#
+# Exit codes:
+#   0 — no banned patterns found in `docs/` or `scripts/`
+#   1 — banned pattern found; offending lines printed to stderr
+#
+# Wire into CI as a fast pre-merge check (subsecond runtime).
+
+set -euo pipefail
+
+# Use git grep so the check honors .gitignore and only inspects tracked
+# content. Falls back to grep -r when git is unavailable (defensive — the
+# repo always has git, but tests construct synthetic scenarios).
+PATTERN='tail -f /dev/null \| python'
+SCOPE=("docs/" "scripts/")
+
+# Self-references that legitimately quote the pattern (the guard script
+# itself contains the regex; the runbook documents the ban). These are
+# excluded from the violation set — they're meta-references, not the
+# pattern actually being USED.
+EXEMPT=(
+    "scripts/check_no_stdin_guard.sh"
+    "docs/operations/battle_test_runbook.md"
+)
+
+# Build a `git grep` exclude list from the EXEMPT array.
+EXCLUDE_ARGS=()
+for f in "${EXEMPT[@]}"; do
+    EXCLUDE_ARGS+=(":(exclude)${f}")
+done
+
+if command -v git > /dev/null 2>&1 && git rev-parse --git-dir > /dev/null 2>&1; then
+    if git grep -E "${PATTERN}" -- "${SCOPE[@]}" "${EXCLUDE_ARGS[@]}" 2>/dev/null; then
+        echo "" >&2
+        echo "ERROR: banned 'tail -f /dev/null | python' stdin-guard pattern" \
+             "found in docs/ or scripts/." >&2
+        echo "       Use --headless instead. See docs/operations/battle_test_runbook.md." >&2
+        exit 1
+    fi
+else
+    # grep -r fallback: build --exclude= args from EXEMPT basenames
+    EXCLUDE_GREP=()
+    for f in "${EXEMPT[@]}"; do
+        EXCLUDE_GREP+=("--exclude=$(basename "${f}")")
+    done
+    if grep -rE "${PATTERN}" "${EXCLUDE_GREP[@]}" "${SCOPE[@]}" 2>/dev/null; then
+        echo "" >&2
+        echo "ERROR: banned 'tail -f /dev/null | python' stdin-guard pattern" \
+             "found in docs/ or scripts/." >&2
+        exit 1
+    fi
+fi
+
+echo "OK: no banned stdin-guard patterns in docs/ or scripts/."
+exit 0

--- a/tests/battle_test/test_process_hygiene_slice3.py
+++ b/tests/battle_test/test_process_hygiene_slice3.py
@@ -1,0 +1,222 @@
+"""Harness Epic Slice 3 — process hygiene + runbook tests.
+
+Pins:
+
+A. The operator runbook exists at the canonical path with required sections.
+B. The CI guard script exists, is executable, and exits 0 on the current
+   clean tree.
+C. The CI guard correctly catches the banned pattern when it appears
+   (fixture test using a temp dir + subprocess invocation of the script).
+D. The canonical pgrep probe is the documented form (regex-anchored).
+E. Cross-references in the runbook point to existing docs/memory files.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# (A) Runbook exists with required sections
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_exists_at_canonical_path():
+    """The operator runbook lives at docs/operations/battle_test_runbook.md."""
+    p = Path("docs/operations/battle_test_runbook.md")
+    assert p.is_file(), f"runbook missing at {p}"
+
+
+def test_runbook_documents_canonical_pgrep_probe():
+    """Runbook includes the canonical pgrep probe pattern."""
+    src = Path("docs/operations/battle_test_runbook.md").read_text()
+    assert r'pgrep -f "python3? scripts/ouroboros_battle_test\.py"' in src
+
+
+def test_runbook_documents_banned_stdin_guard():
+    """Runbook explicitly bans the tail -f /dev/null | python pattern."""
+    src = Path("docs/operations/battle_test_runbook.md").read_text()
+    # Banned pattern is mentioned + ban is explicit
+    assert "tail -f /dev/null" in src
+    assert "banned" in src.lower()
+
+
+def test_runbook_documents_standard_launch_recipe():
+    """Standard launch recipe uses --headless (per Slice 3 + ticket C)."""
+    src = Path("docs/operations/battle_test_runbook.md").read_text()
+    assert "ouroboros_battle_test.py" in src
+    assert "--headless" in src
+
+
+def test_runbook_documents_recovery_procedures():
+    """Recovery sections cover exit code 75, stale lock, wedged TTL, and
+    missing summary.json."""
+    src = Path("docs/operations/battle_test_runbook.md").read_text()
+    assert "exit code 75" in src.lower() or "exit 75" in src.lower()
+    assert "stale lock" in src.lower()
+    assert "wedged" in src.lower()
+    assert "summary.json" in src
+
+
+def test_runbook_cross_links_existing_docs():
+    """Cross-references must point to files that actually exist."""
+    src = Path("docs/operations/battle_test_runbook.md").read_text()
+    # CLAUDE.md should be referenced
+    assert "CLAUDE.md" in src
+    # Cross-link to the harness epic memory file (memory/ paths exist
+    # outside the repo, so we just pin that they're MENTIONED — the
+    # content is curated, not git-tracked)
+    assert "harness_epic_scope" in src
+    assert "battle_test_post_summary_hang" in src
+
+
+# ---------------------------------------------------------------------------
+# (B) CI guard script exists + executable + clean tree exits 0
+# ---------------------------------------------------------------------------
+
+
+def test_guard_script_exists():
+    p = Path("scripts/check_no_stdin_guard.sh")
+    assert p.is_file(), "guard script missing"
+
+
+def test_guard_script_is_executable():
+    p = Path("scripts/check_no_stdin_guard.sh")
+    mode = p.stat().st_mode
+    assert mode & stat.S_IXUSR, "guard script must be executable"
+
+
+def test_guard_script_exits_zero_on_clean_tree():
+    """The current tree (post-Slice-3) must pass the guard."""
+    result = subprocess.run(
+        ["bash", "scripts/check_no_stdin_guard.sh"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"clean tree should pass guard; stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (C) CI guard correctly catches violations (fixture test)
+# ---------------------------------------------------------------------------
+
+
+def test_guard_script_catches_banned_pattern_in_docs(tmp_path):
+    """Stage a violation in a synthetic docs/scripts tree and verify the
+    guard exits non-zero. Uses bash-only fallback (no git repo)."""
+    docs = tmp_path / "docs"
+    scripts = tmp_path / "scripts"
+    docs.mkdir()
+    scripts.mkdir()
+    (docs / "violation.md").write_text(
+        "Run with: tail -f /dev/null | python3 foo.py\n"
+    )
+    # Copy guard script into the synthetic tree
+    guard_src = Path("scripts/check_no_stdin_guard.sh").read_text()
+    (scripts / "check_no_stdin_guard.sh").write_text(guard_src)
+    (scripts / "check_no_stdin_guard.sh").chmod(0o755)
+
+    # Run from synthetic tree (no git → uses grep fallback path)
+    result = subprocess.run(
+        ["bash", "scripts/check_no_stdin_guard.sh"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 1, (
+        f"guard should catch violation; stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+    assert "tail -f /dev/null" in result.stderr or "tail -f /dev/null" in result.stdout
+
+
+def test_guard_script_catches_banned_pattern_in_scripts(tmp_path):
+    """Same as above but the violation is in scripts/ instead of docs/."""
+    docs = tmp_path / "docs"
+    scripts = tmp_path / "scripts"
+    docs.mkdir()
+    scripts.mkdir()
+    (scripts / "bad_runner.sh").write_text(
+        "#!/usr/bin/env bash\ntail -f /dev/null | python3 foo.py\n"
+    )
+    guard_src = Path("scripts/check_no_stdin_guard.sh").read_text()
+    (scripts / "check_no_stdin_guard.sh").write_text(guard_src)
+    (scripts / "check_no_stdin_guard.sh").chmod(0o755)
+
+    result = subprocess.run(
+        ["bash", "scripts/check_no_stdin_guard.sh"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# (D) Canonical pgrep probe consistency check
+#     The runbook + the launcher single-flight check should reference the
+#     same pattern. If either drifts, this test catches it.
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_pgrep_pattern_consistent_runbook_vs_launcher():
+    """The runbook + the launcher single-flight code use the same pgrep pattern.
+    If either drifts, false-positive / false-negative bugs surface."""
+    runbook = Path("docs/operations/battle_test_runbook.md").read_text()
+    launcher = Path("scripts/ouroboros_battle_test.py").read_text()
+    canonical = r'python3? scripts/ouroboros_battle_test\.py'
+    assert canonical in runbook, (
+        "runbook drifted from canonical pgrep pattern"
+    )
+    assert canonical in launcher, (
+        "launcher single-flight drifted from canonical pgrep pattern"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (E) Source-grep that the codebase is currently clean
+#     This is the regression pin — if any future commit adds the banned
+#     pattern to docs/ or scripts/, this test fails BEFORE the CI guard
+#     runs (cheaper feedback for local pytest runs).
+# ---------------------------------------------------------------------------
+
+
+def test_codebase_currently_clean_of_banned_pattern():
+    """No banned stdin-guard pattern in docs/ or scripts/ today.
+
+    If this fails, you (or a recent commit) added back the banned
+    pattern. Use --headless instead. See
+    docs/operations/battle_test_runbook.md.
+    """
+    # Same exempt set as scripts/check_no_stdin_guard.sh — these files
+    # legitimately quote the pattern (one IS the guard regex, one
+    # documents the ban).
+    EXEMPT_PATHS = {
+        "scripts/check_no_stdin_guard.sh",
+        "docs/operations/battle_test_runbook.md",
+    }
+    for scope in (Path("docs"), Path("scripts")):
+        for f in scope.rglob("*"):
+            if not f.is_file():
+                continue
+            relpath = str(f.as_posix())
+            if relpath in EXEMPT_PATHS:
+                continue
+            try:
+                content = f.read_text(errors="ignore")
+            except (OSError, UnicodeDecodeError):
+                continue
+            assert "tail -f /dev/null | python" not in content, (
+                f"banned pattern found in {f} — use --headless instead. "
+                f"See docs/operations/battle_test_runbook.md"
+            )


### PR DESCRIPTION
## Summary

**Slice 3 of the Harness Reliability Epic.** Operator-authorized 2026-04-25.

Builds on Slices 1 (`b4e5942084`) + 2 (`51eec8991f`). Closes harness epic items 1 (ban `tail -f /dev/null | python`) + 4 (canonical pgrep probe documented in runbook).

## What ships

**`docs/operations/battle_test_runbook.md`** (new) — canonical operator runbook:
- Standard launch recipe (uses `--headless`).
- Canonical pgrep probe: `pgrep -f "python3? scripts/ouroboros_battle_test\.py"`.
- Recovery procedures for: exit code 75 (single-flight reject), stale-PID lock, wedged-but-alive TTL lock, missing summary.json.
- Forensics directory convention.
- Live-fire validation pattern.

**`scripts/check_no_stdin_guard.sh`** (new) — CI guard:
- `git grep -E 'tail -f /dev/null \\| python'` over `docs/` + `scripts/`.
- Exempts itself + the runbook (both legitimately quote the pattern as documentation).
- Exit 0 on clean tree, exit 1 with offending lines on violation.
- Subsecond runtime — fast pre-merge check.

## Why item 1 matters (S5/S6 forensics)

The `tail -f /dev/null | python ...` idiom keeps the Python child's stdout pipe open after the parent shell dies. The Python child becomes an orphan instead of receiving SIGPIPE. **7 of the orphan PIDs in the S4 mass-cleanup (2026-04-23) had this pattern** — directly contributing to the Py_FinalizeEx zombie class.

Replacement is built-in: `--headless` flag (or env `OUROBOROS_BATTLE_HEADLESS=true`).

## Test plan

- [x] **12/12 green** in `test_process_hygiene_slice3.py`
  - Runbook exists at canonical path with required sections (6)
  - CI guard exists, executable, exits 0 on clean tree (3)
  - CI guard catches violations in synthetic trees (2)
  - Canonical pgrep pattern consistent runbook ↔ launcher (1)
  - Codebase clean of banned pattern (regression pin) (1)
- [x] Combined regression: 51/51 across Slices 1+2+3
- [ ] Live-fire (deferred)

## Rollback

The runbook + guard are documentation/CI infrastructure only — no behavior change. To temporarily allow the banned pattern (e.g. emergency operator escape), the guard can be bypassed in CI config; no code revert needed.

## Commit → Slice mapping

| Commit | Slice | Files |
|---|---|---|
| `21bd7e3d93` | Harness Epic Slice 3 | `battle_test_runbook.md`, `check_no_stdin_guard.sh`, 12 tests |

## NOT in this PR (last harness slice)

- Slice 4: graduation pins (per W3(7) pattern — pin all 3 slices' invariants + master flip if applicable)

## NOT in this PR (other deferred items, separate operator-authorized arcs)

L3 token, PLAN-EXPLOIT partials, watchdog wiring, bash async, Test A, F5, W2(4) — same list as Slices 1+2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an operator runbook and a CI guard to enforce process hygiene for the battle-test harness. Bans the `tail -f /dev/null | python` stdin-guard and documents the canonical `pgrep` probe to reduce zombie processes.

- **New Features**
  - `docs/operations/battle_test_runbook.md`: Standard launch recipe using `--headless`, canonical probe `pgrep -f "python3? scripts/ouroboros_battle_test\.py"`, recovery steps (exit 75, stale lock, TTL wedge, missing `summary.json`), forensics path, and live-fire validation pattern.
  - `scripts/check_no_stdin_guard.sh`: Fast CI check that scans `docs/` and `scripts/` for the banned `tail -f /dev/null | python` pattern; exempts itself and the runbook; exits non-zero on violation.

- **Migration**
  - Replace any `tail -f /dev/null | python` usage with `--headless` (or `OUROBOROS_BATTLE_HEADLESS=true`).
  - No runtime behavior change; to temporarily bypass the guard, disable it in CI if needed.

<sup>Written for commit 21bd7e3d9308280d63fbe1f287d8f703d35e4655. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

