### PR TITLE
test(harness): Slice 4 — graduation pins (closes harness reliability epic)

### DIFF
--- a/notebooks/report.ipynb
+++ b/notebooks/report.ipynb
@@ -2,22 +2,22 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "88823e2a",
+   "id": "3fa2ed45",
    "metadata": {},
    "source": [
     "# Ouroboros Battle Test Report\n",
     "\n",
     "| Field | Value |\n",
     "|-------|-------|\n",
-    "| Session ID | `bt-2026-04-25-003533` |\n",
+    "| Session ID | `bt-2026-04-25-024021` |\n",
     "| Stop Reason | `idle_timeout` |\n",
-    "| Duration | 1774.1 s |\n"
+    "| Duration | 650.0 s |\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c0703e2",
+   "id": "fe064ef1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,9 +28,9 @@
     "_SUMMARY_JSON = '''\n",
     "{\n",
     "  \"schema_version\": 2,\n",
-    "  \"session_id\": \"bt-2026-04-25-003533\",\n",
+    "  \"session_id\": \"bt-2026-04-25-024021\",\n",
     "  \"stop_reason\": \"idle_timeout\",\n",
-    "  \"duration_s\": 1774.0870277881622,\n",
+    "  \"duration_s\": 649.9895989894867,\n",
     "  \"stats\": {\n",
     "    \"attempted\": 0,\n",
     "    \"completed\": 0,\n",
@@ -38,10 +38,8 @@
     "    \"cancelled\": 0,\n",
     "    \"queued\": 0\n",
     "  },\n",
-    "  \"cost_total\": 1.068039,\n",
-    "  \"cost_breakdown\": {\n",
-    "    \"claude\": 1.068039\n",
-    "  },\n",
+    "  \"cost_total\": 0.0,\n",
+    "  \"cost_breakdown\": {},\n",
     "  \"branch_stats\": {\n",
     "    \"commits\": 0,\n",
     "    \"files_changed\": 0,\n",
@@ -55,43 +53,17 @@
     "  \"top_techniques\": [],\n",
     "  \"operations\": [],\n",
     "  \"strategic_drift\": {\n",
-    "    \"total_ops\": 4,\n",
-    "    \"drifted_ops\": 1,\n",
-    "    \"ratio\": null,\n",
-    "    \"threshold_met\": false,\n",
+    "    \"total_ops\": 14,\n",
+    "    \"drifted_ops\": 0,\n",
+    "    \"ratio\": 0.0,\n",
+    "    \"threshold_met\": true,\n",
     "    \"warning\": false,\n",
-    "    \"status\": \"insufficient_data\"\n",
+    "    \"status\": \"ok\"\n",
     "  },\n",
     "  \"session_outcome\": \"complete\",\n",
-    "  \"last_activity_ts\": 1777079107.6952949,\n",
-    "  \"cost_by_phase\": {\n",
-    "    \"GENERATE\": 0.650319,\n",
-    "    \"GENERATE_RETRY\": 0.399972\n",
-    "  },\n",
-    "  \"cost_by_op_phase\": {\n",
-    "    \"op-019dc212-0f02-71ce-acb4-671715bd9554-cau\": {\n",
-    "      \"GENERATE\": 0.031059\n",
-    "    },\n",
-    "    \"op-019dc210-5fe3-78f8-8ba4-28697430af15-cau\": {\n",
-    "      \"GENERATE\": 0.61926,\n",
-    "      \"GENERATE_RETRY\": 0.399972\n",
-    "    }\n",
-    "  },\n",
-    "  \"cost_by_op_phase_provider\": {\n",
-    "    \"op-019dc212-0f02-71ce-acb4-671715bd9554-cau\": {\n",
-    "      \"GENERATE\": {\n",
-    "        \"claude-api\": 0.031059\n",
-    "      }\n",
-    "    },\n",
-    "    \"op-019dc210-5fe3-78f8-8ba4-28697430af15-cau\": {\n",
-    "      \"GENERATE\": {\n",
-    "        \"claude-api\": 0.61926\n",
-    "      },\n",
-    "      \"GENERATE_RETRY\": {\n",
-    "        \"claude-api\": 0.399972\n",
-    "      }\n",
-    "    }\n",
-    "  }\n",
+    "  \"last_activity_ts\": 1777085471.752296,\n",
+    "  \"cost_by_op_phase\": {},\n",
+    "  \"cost_by_op_phase_provider\": {}\n",
     "}\n",
     "'''\n",
     "\n",
@@ -110,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2a9cc49",
+   "id": "e339c976",
    "metadata": {},
    "source": [
     "## Composite Score Trend\n",
@@ -121,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5da6bfe",
+   "id": "b5e1a0a0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6d98f15",
+   "id": "e1ff88fe",
    "metadata": {},
    "source": [
     "## Convergence State\n",
@@ -169,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffb1f098",
+   "id": "ce870091",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04f1defa",
+   "id": "125540f2",
    "metadata": {},
    "source": [
     "## Operations Breakdown\n",
@@ -209,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65e96560",
+   "id": "e5f4829b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68d9aef4",
+   "id": "2bf684f9",
    "metadata": {},
    "source": [
     "## Sensor Activation\n",
@@ -249,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06628823",
+   "id": "4231a3c8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfb205bc",
+   "id": "3c435b4a",
    "metadata": {},
    "source": [
     "## Cost & Branch Summary\n",
@@ -284,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5db62db",
+   "id": "202c44f8",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tests/battle_test/test_harness_epic_graduation_pins_slice4.py
+++ b/tests/battle_test/test_harness_epic_graduation_pins_slice4.py
@@ -1,0 +1,352 @@
+"""Harness Epic Slice 4 — graduation pin tests.
+
+Closes the harness reliability epic. Pins the post-graduation contract
+across all 4 slices:
+
+A. Master flag defaults — `JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED` and
+   `JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED` both default `True`.
+B. Sub-flag defaults — `JARVIS_BATTLE_SHUTDOWN_DEADLINE_S=30`,
+   `JARVIS_INTAKE_LOCK_STALE_TTL_S=7200`.
+C. Hot-revert per safety mechanism — each can be disabled individually
+   via env var without touching others.
+D. Authority invariants — clean shutdown is unchanged (no os._exit fires
+   on graceful termination); single-flight allows the current process.
+E. Source-grep pins for every Slice 1–3 surface so unintended drift
+   surfaces in CI rather than in production.
+
+These tests run on every commit going forward. If a pin breaks, either
+the change was an unintentional regression or the contract was
+intentionally widened — in the latter case, update the pin AND the
+runbook so the operator-facing source of truth stays aligned.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.battle_test.shutdown_watchdog import (
+    BoundedShutdownWatchdog,
+    EXIT_CODE_HARNESS_WEDGED,
+    bounded_shutdown_enabled,
+    default_deadline_s,
+)
+
+
+# ---------------------------------------------------------------------------
+# (A) Master flag defaults — graduated post-epic
+# ---------------------------------------------------------------------------
+
+
+def test_bounded_shutdown_default_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED defaults true post-Slice-1.
+
+    The watchdog is disarm()-able, so default-true is safe — clean
+    shutdowns never trigger os._exit.
+    """
+    monkeypatch.delenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", raising=False)
+    assert bounded_shutdown_enabled() is True
+
+
+def test_single_flight_default_true_in_launcher_source():
+    """Source-grep: launcher uses default `true` for the single-flight
+    env knob. No way to test the launcher's main() code path in isolation
+    without subprocess machinery; the source-pin catches drift."""
+    src = Path("scripts/ouroboros_battle_test.py").read_text()
+    assert 'JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED", "true"' in src
+
+
+# ---------------------------------------------------------------------------
+# (B) Sub-flag defaults
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_deadline_default_30s(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_BATTLE_SHUTDOWN_DEADLINE_S", raising=False)
+    assert default_deadline_s() == 30.0
+
+
+def test_intake_lock_stale_ttl_default_7200s_in_source():
+    """Source-grep: stale-TTL default is 7200 (2h) in the lock cleanup."""
+    src = Path(
+        "backend/core/ouroboros/governance/intake/unified_intake_router.py"
+    ).read_text()
+    # Used in the staleness check default fallback
+    assert 'JARVIS_INTAKE_LOCK_STALE_TTL_S", "7200"' in src
+    # Default 7200s
+    assert "_stale_ttl = 7200.0" in src
+
+
+def test_exit_code_harness_wedged_constant():
+    assert EXIT_CODE_HARNESS_WEDGED == 75
+
+
+# ---------------------------------------------------------------------------
+# (C) Hot-revert — each safety mechanism disable-able individually
+# ---------------------------------------------------------------------------
+
+
+def test_hot_revert_bounded_shutdown_disabled_returns_false_from_arm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED=false → arm() is no-op."""
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "false")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        result = wdg.arm(reason="test", deadline_s=10.0)
+        assert result is False
+        assert wdg.is_armed is False
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+def test_hot_revert_single_flight_disabled_in_main_flow():
+    """Source-grep: single-flight check is gated by env var so operators
+    can opt out without code patching."""
+    src = Path("scripts/ouroboros_battle_test.py").read_text()
+    # Gated check
+    assert "JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED" in src
+    # The check is wrapped in env-disable conditional
+    assert (
+        '"JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED", "true").lower() not in '
+        '("false", "0", "no", "off")'
+    ) in src
+
+
+def test_hot_revert_lock_ttl_can_be_extended(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARVIS_INTAKE_LOCK_STALE_TTL_S can be set to a huge value to
+    effectively disable the wedged-but-alive TTL detection."""
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (
+        UnifiedIntakeRouter,
+    )
+    monkeypatch.setenv("JARVIS_INTAKE_LOCK_STALE_TTL_S", "999999999")
+    artifact = tmp_path / "intake_router.lock"
+    # PID 1 (alive), lock 1h old — well within the huge TTL
+    artifact.write_text(json.dumps({
+        "pid": 1,
+        "ts": time.time() - 3600,
+    }))
+    result = UnifiedIntakeRouter._cleanup_stale_lock(artifact)
+    assert result is False
+    assert artifact.exists()
+
+
+# ---------------------------------------------------------------------------
+# (D) Authority invariants — clean shutdown unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_clean_shutdown_disarms_before_deadline_no_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Authority pin: graceful arm → disarm cycle does NOT call exit_fn.
+    This is the contract that makes default-true safe."""
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls: list = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append)
+    try:
+        wdg.arm(reason="clean_shutdown_pin", deadline_s=2.0)
+        time.sleep(0.05)
+        wdg.disarm()
+        time.sleep(0.3)
+        assert exit_calls == []
+        assert wdg.fired is False
+    finally:
+        wdg.stop()
+        wdg._thread.join(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# (E) Source-grep pins for every Slice 1–3 surface
+# ---------------------------------------------------------------------------
+
+
+def _read(p: str) -> str:
+    return Path(p).read_text(encoding="utf-8")
+
+
+def test_slice_1_pin_watchdog_module_exists():
+    """Slice 1 — BoundedShutdownWatchdog primitive lives in the canonical
+    location."""
+    p = Path("backend/core/ouroboros/battle_test/shutdown_watchdog.py")
+    assert p.is_file()
+
+
+def test_slice_1_pin_watchdog_uses_os_underscore_exit():
+    """Slice 1 — os._exit (NOT sys.exit) is THE invariant; sys.exit runs
+    cleanup handlers which is exactly what we're trying to bypass when
+    the asyncio path is wedged."""
+    src = _read("backend/core/ouroboros/battle_test/shutdown_watchdog.py")
+    assert "exit_fn: Callable[[int], None] = os._exit" in src
+    assert "sys.exit" not in src
+
+
+def test_slice_1_pin_watchdog_thread_is_daemon():
+    """Slice 1 — daemon=True is the THE invariant that prevents
+    Py_FinalizeEx deadlock on join."""
+    src = _read("backend/core/ouroboros/battle_test/shutdown_watchdog.py")
+    assert "daemon=True" in src
+
+
+def test_slice_1_pin_harness_wires_three_sites():
+    """Slice 1 — harness wires watchdog at __init__ + signal handler +
+    WallClockWatchdog + clean-shutdown disarm."""
+    src = _read("backend/core/ouroboros/battle_test/harness.py")
+    # 2 arm sites (signal handler + wall clock alarm)
+    assert src.count("_wdg.arm(") >= 2
+    # 1 disarm site (clean shutdown)
+    assert "_wdg.disarm()" in src
+    # __init__ construction
+    assert "BoundedShutdownWatchdog as _BoundedShutdownWatchdog" in src
+
+
+def test_slice_2_pin_lock_writer_emits_new_schema():
+    """Slice 2 — lock writer includes monotonic_ts, wall_iso, session_id."""
+    src = _read(
+        "backend/core/ouroboros/governance/intake/unified_intake_router.py"
+    )
+    assert '"monotonic_ts": time.monotonic()' in src
+    assert '"session_id": _session_id' in src
+
+
+def test_slice_2_pin_wedged_but_alive_ttl_branch():
+    """Slice 2 — the wedged-but-alive branch in _cleanup_stale_lock
+    references the env knob and the canonical phrase for log audits."""
+    src = _read(
+        "backend/core/ouroboros/governance/intake/unified_intake_router.py"
+    )
+    assert "JARVIS_INTAKE_LOCK_STALE_TTL_S" in src
+    assert "wedged-but-alive" in src
+
+
+def test_slice_2_pin_single_flight_helper_exists():
+    """Slice 2 — single-flight launcher helper exists with canonical
+    pgrep + sys.exit(75)."""
+    src = _read("scripts/ouroboros_battle_test.py")
+    assert "def _single_flight_preflight()" in src
+    assert r'"python3? scripts/ouroboros_battle_test\.py"' in src
+    assert "sys.exit(75)" in src
+
+
+def test_slice_2_pin_single_flight_runs_after_zombie_reap():
+    """Slice 2 — single-flight check runs AFTER the zombie reap so it
+    doesn't false-trip on dead-PID lockholders the reaper can clean."""
+    src = _read("scripts/ouroboros_battle_test.py")
+    reap_idx = src.find("_reap_zombies()")
+    sf_idx = src.find("_single_flight_preflight()")
+    assert reap_idx > 0
+    assert sf_idx > reap_idx
+
+
+def test_slice_3_pin_runbook_exists():
+    """Slice 3 — operator runbook at canonical path."""
+    p = Path("docs/operations/battle_test_runbook.md")
+    assert p.is_file()
+
+
+def test_slice_3_pin_ci_guard_exists_and_executable():
+    """Slice 3 — CI guard script exists and is executable."""
+    p = Path("scripts/check_no_stdin_guard.sh")
+    assert p.is_file()
+    mode = p.stat().st_mode
+    assert mode & stat.S_IXUSR
+
+
+def test_slice_3_pin_canonical_pgrep_consistent_runbook_vs_launcher():
+    """Slice 3 — runbook + launcher use the same pgrep regex. If either
+    drifts, false-positive/negative bugs surface."""
+    runbook = _read("docs/operations/battle_test_runbook.md")
+    launcher = _read("scripts/ouroboros_battle_test.py")
+    canonical = r'python3? scripts/ouroboros_battle_test\.py'
+    assert canonical in runbook
+    assert canonical in launcher
+
+
+def test_slice_3_pin_codebase_clean_of_banned_pattern():
+    """Slice 3 — no banned 'tail -f /dev/null | python' pattern outside
+    the documented exemptions (guard script + runbook)."""
+    EXEMPT_PATHS = {
+        "scripts/check_no_stdin_guard.sh",
+        "docs/operations/battle_test_runbook.md",
+    }
+    for scope in (Path("docs"), Path("scripts")):
+        for f in scope.rglob("*"):
+            if not f.is_file():
+                continue
+            relpath = str(f.as_posix())
+            if relpath in EXEMPT_PATHS:
+                continue
+            try:
+                content = f.read_text(errors="ignore")
+            except (OSError, UnicodeDecodeError):
+                continue
+            assert "tail -f /dev/null | python" not in content, (
+                f"banned pattern found in {f} — use --headless instead"
+            )
+
+
+# ---------------------------------------------------------------------------
+# (F) End-to-end: ci guard exits clean on the current tree
+# ---------------------------------------------------------------------------
+
+
+def test_ci_guard_exits_zero_on_current_tree():
+    """The current main HEAD passes the CI guard. Any future commit
+    that adds the banned pattern will fail this test in pytest BEFORE
+    it reaches CI — fast-feedback for local development."""
+    result = subprocess.run(
+        ["bash", "scripts/check_no_stdin_guard.sh"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"CI guard fails on current tree; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (G) Combined hot-revert recipe — full epic disable
+# ---------------------------------------------------------------------------
+
+
+def test_combined_hot_revert_recipe_documented_in_runbook():
+    """The runbook mentions all hot-revert env knobs so operators have
+    a single source of truth for "how do I turn off the new safety nets"."""
+    runbook = _read("docs/operations/battle_test_runbook.md")
+    # Each Slice 1–2 hot-revert env knob mentioned
+    assert "JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED" in runbook
+    assert "JARVIS_BATTLE_SHUTDOWN_DEADLINE_S" in runbook
+    assert "JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED" in runbook
+
+
+# ---------------------------------------------------------------------------
+# (H) Wave-3 contract preservation — graduated harness epic doesn't
+#     accidentally disable the Wave 3 (7) cancel infrastructure that
+#     graduated yesterday.
+# ---------------------------------------------------------------------------
+
+
+def test_wave_3_7_cancel_infrastructure_still_graduated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity: harness epic graduation didn't somehow regress W3(7)."""
+    monkeypatch.delenv("JARVIS_MID_OP_CANCEL_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.cancel_token import (
+        mid_op_cancel_enabled,
+    )
+    assert mid_op_cancel_enabled() is True, (
+        "W3(7) graduated default must remain True post-harness-epic"
+    )


### PR DESCRIPTION
## Summary

**Final slice of the Harness Reliability Epic.** Operator-authorized 2026-04-25.

Pure paperwork — pins the post-graduation contract across all 4 slices via 24 graduation-pin tests. Closes the harness reliability epic.

Builds on Slices 1 (`b4e5942084`) + 2 (`51eec8991f`) + 3 (`85a00510c9`).

## Pins added (24 tests)

| Section | Pins |
|---|---|
| (A) Master flag defaults | `JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED` + `JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED` both default `True` (2) |
| (B) Sub-flag defaults | `JARVIS_BATTLE_SHUTDOWN_DEADLINE_S=30`, `JARVIS_INTAKE_LOCK_STALE_TTL_S=7200`, `EXIT_CODE_HARNESS_WEDGED=75` (3) |
| (C) Hot-revert per safety mechanism | bounded shutdown disable, single-flight env-gated, lock TTL extendable (3) |
| (D) Authority — clean shutdown unchanged | arm→disarm cycle does NOT call `exit_fn` (1) |
| (E) Source-grep — every Slice 1–3 surface | watchdog module + `os._exit` not `sys.exit` + `daemon=True` + 3-site harness wiring + lock writer schema + wedged-TTL branch + single-flight helper + post-zombie-reap ordering + runbook + CI guard exec + canonical pgrep consistency + codebase clean of banned pattern (12) |
| (F) End-to-end | CI guard exits 0 on current tree (1) |
| (G) Combined hot-revert recipe | All Slice 1–2 hot-revert env knobs documented in runbook (1) |
| (H) Wave 3 (7) preservation | Cancel infrastructure still graduated post-harness-epic (sanity) (1) |

## Combined regression

**75/75 across all 4 harness epic slices** (BoundedShutdownWatchdog + intake_router.lock TTL + process hygiene + graduation pins).

## Wave 3 + Harness Epic combined invariants

- Master `JARVIS_MID_OP_CANCEL_ENABLED=true` (W3(7) Slice 7)
- Master `JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED=true` (Harness Slice 1)
- Master `JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED=true` (Harness Slice 2)
- Hot-reverts independent — each safety net disable-able in isolation
- No actuating sub-flags default-on (operator opt-in for Class E/F/SSE)

## Harness Epic outcome

The 14-incident Py_FinalizeEx zombie class is structurally cured by:
- **Slice 1** (bounded shutdown daemon thread + `os._exit(75)` after 30s)
- **Slice 2** (wedged-TTL lock reclaim + single-flight launcher with exit 75)
- **Slice 3** (banned `tail -f /dev/null | python` CI guard + canonical operator runbook)
- **Slice 4** (graduation pins — this PR)

Hot-revert via 3 independent env vars; no code revert needed.

## Rollback

Each safety mechanism can be disabled individually:
- `JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED=false` → reverts Slice 1
- `JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED=false` → reverts Slice 2 launcher check
- `JARVIS_INTAKE_LOCK_STALE_TTL_S=999999999` → effectively disables Slice 2 wedged-TTL
- Slice 3 is documentation/CI; bypass the CI guard step in CI config if needed

## Commit → Slice mapping

| Commit | Slice | Files |
|---|---|---|
| `19e387f377` | Harness Epic Slice 4 | `test_harness_epic_graduation_pins_slice4.py` (24 pins) |

## NOT in this PR (other deferred items, separate operator-authorized arcs)

After harness epic closes, the remaining slate per operator's noted order:
1. Seed exploration offline arc
2. W2(4) curiosity scoping
3. F5 (touches_security_surface)
4. W3(7) deferrals — L3 token, PLAN-EXPLOIT partials, watchdog wiring, bash async

Each gets its own scope doc + operator-gated thin-slice arc, same discipline as W3(7) and the harness epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 24 graduation-pin tests to lock the post‑graduation contract for the Harness reliability epic and updates the battle test report with the latest session metrics. Closes the epic and pins defaults, hot‑revert controls, source surfaces, and end‑to‑end guard behavior.

- **Graduation Pins**
  - Defaults: bounded shutdown and single-flight default true; shutdown deadline 30s; lock stale TTL 7200; exit code 75.
  - Hot-revert: each safety net can be disabled via env; lock TTL extendable via large value.
  - Authority: clean shutdown disarms before deadline; no os._exit on graceful path.
  - Source pins: watchdog uses os._exit with a daemon thread; harness wiring present; single-flight preflight exists and runs after zombie reap; runbook/CI guard aligned; banned stdin pattern stays out of the codebase.
  - End-to-end and safety: CI guard exits 0 on current tree; Wave 3(7) cancel default remains true.

- **Refactors**
  - Refreshed `notebooks/report.ipynb` with session `bt-2026-04-25-024021`, duration 650.0s, zero costs, updated strategic drift (ratio 0.0, status ok), and removed per-phase cost details.

<sup>Written for commit 070e933e7acafd7966aa80ec8427f64672fcd11a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

