### PR TITLE
fix(plan_exploit): aggregate exploration credit from child streams to parent (Seed Arc Path 2)

### DIFF
--- a/backend/core/ouroboros/governance/plan_exploit.py
+++ b/backend/core/ouroboros/governance/plan_exploit.py
@@ -165,10 +165,31 @@ def _merge_results(
     support — caller plugs the merged result into the existing VALIDATE
     path without further translation.
 
-    Cost, tokens, duration, and provider name are aggregated across
-    units. ``is_noop=False`` because by this point every unit returned
-    at least one candidate (the caller guarantees that invariant before
-    invoking the merger).
+    Cost, tokens, duration, provider name AND exploration evidence
+    (tool_execution_records + prompt_preloaded_files) are aggregated
+    across units. ``is_noop=False`` because by this point every unit
+    returned at least one candidate (the caller guarantees that
+    invariant before invoking the merger).
+
+    Exploration-evidence merge contract (Seed Arc Path 2 fix, 2026-04-25):
+      * **Additive** — parent ``tool_execution_records`` is the
+        concatenation of every child stream's records. Same for
+        ``prompt_preloaded_files``.
+      * **Dedupe deferred** — this step does NOT pre-deduplicate by
+        ``(tool_name, arguments_hash)``. Downstream consumers (notably
+        :meth:`ExplorationLedger.diversity_score`) own the dedup policy
+        because pre-deduping at merge would lose call-count signals.
+      * **Single-writer** — only this function writes the merged
+        ``tool_execution_records`` field. Child streams write their
+        own per-stream records during their tool loop; the merge
+        collects, never re-writes.
+      * **No gate softening** — the Iron Gate floor + diversity scoring
+        are unchanged. This fix only makes evidence reach the ledger.
+
+    Closes the false ``exploration_insufficient`` rejection class
+    (S6/S7/S8 Test A: 11–21 actual exploration tool calls per session,
+    but Iron Gate read ``cumulative=0 preloaded=0`` because the merged
+    generation was carrying ``tool_execution_records=()``).
     """
     # Lazy import — avoid circular during module load. GenerationResult
     # lives in op_context.py.
@@ -180,6 +201,9 @@ def _merge_results(
     total_out = 0
     max_duration = 0.0
     providers: List[str] = []
+    # Exploration-evidence aggregation (Seed Arc Path 2)
+    merged_tool_records: List[Any] = []
+    merged_preloaded_files: List[str] = []
 
     for r in per_unit_results:
         for cand in (getattr(r, "candidates", ()) or ()):
@@ -205,6 +229,13 @@ def _merge_results(
         pname = str(getattr(r, "provider_name", "") or "")
         if pname and pname not in providers:
             providers.append(pname)
+        # Aggregate exploration evidence (Seed Arc Path 2 fix). Treat
+        # missing attrs as empty tuples — defensive for synthetic test
+        # results that may not set every field.
+        _unit_records = getattr(r, "tool_execution_records", ()) or ()
+        merged_tool_records.extend(_unit_records)
+        _unit_preloaded = getattr(r, "prompt_preloaded_files", ()) or ()
+        merged_preloaded_files.extend(str(p) for p in _unit_preloaded)
 
     composite_candidate: Dict[str, Any] = {
         "files": files,
@@ -223,6 +254,9 @@ def _merge_results(
         cost_usd=total_cost,
         total_input_tokens=total_in,
         total_output_tokens=total_out,
+        # Seed Arc Path 2 — close the Iron Gate exploration-credit gap.
+        tool_execution_records=tuple(merged_tool_records),
+        prompt_preloaded_files=tuple(merged_preloaded_files),
     )
 
 

--- a/tests/governance/test_plan_exploit_ledger_merge.py
+++ b/tests/governance/test_plan_exploit_ledger_merge.py
@@ -1,0 +1,338 @@
+"""Seed exploration arc — PLAN-EXPLOIT exploration-ledger merge.
+
+Path 2 fix per `project_followup_seed_exploration_arc.md` Test A finding:
+PLAN-EXPLOIT child streams accumulate exploration credit (tool_execution_records
++ prompt_preloaded_files) per-unit, but `_merge_results` was dropping them
+when composing the parent ``GenerationResult``. The orchestrator's Iron Gate
+exploration-ledger consumer then read `cumulative=0 preloaded=0` for the
+parent op despite 11–21 actual tool calls per session — false
+``exploration_insufficient`` rejection.
+
+This test file pins the merge contract:
+
+A. **Pre-fix regression** — without aggregation, the parent generation
+   carries `tool_execution_records=()` even when children had records.
+   This test was written to FAIL on the current code, then PASS once
+   the fix lands. (Per operator: Path 1 = failing regression folded
+   into the same PR as Path 2.)
+
+B. **Merge semantics** (additive, dedupe, single-writer):
+   - Additive: parent's `tool_execution_records` is the concatenation
+     of all child streams' records.
+   - Dedupe: handled downstream by `ExplorationLedger.diversity_score()`'s
+     dedup-by-(tool, arguments_hash). The merge step does NOT pre-dedupe
+     because dedup at merge would lose call-count signals downstream
+     consumers may want.
+   - Single-writer: only `_merge_results` writes the merged
+     `tool_execution_records` field. Child streams write their own
+     records during their tool loop; the merge collects, never re-writes.
+
+C. **Cross-component hook test** (per
+   `feedback_orchestrator_wiring_invariant_checklist.md`):
+   verify that the orchestrator's Iron Gate ledger consumer (which reads
+   `generation.tool_execution_records`) sees a non-empty bag when given
+   a merged result built from N child streams that each had records.
+
+D. **No gate softening** — the merge fix does NOT lower the Iron Gate
+   floor or change scoring. It only ensures the credit reaches the
+   ledger. The 2-tool minimum + diversity-weighted scoring stay
+   exactly as-is.
+"""
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic GenerationResult for unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_unit_result(
+    *,
+    file_path: str,
+    tool_records: Tuple[Any, ...] = (),
+    preloaded: Tuple[str, ...] = (),
+    cost: float = 0.10,
+):
+    """Build a minimal GenerationResult representing one PLAN-EXPLOIT child stream."""
+    from backend.core.ouroboros.governance.op_context import GenerationResult
+    return GenerationResult(
+        candidates=({
+            "file_path": file_path,
+            "full_content": f"# stub for {file_path}\n",
+            "rationale": f"unit stub {file_path}",
+        },),
+        provider_name="claude-stub",
+        generation_duration_s=1.0,
+        model_id="claude-stub-model",
+        is_noop=False,
+        cost_usd=cost,
+        total_input_tokens=100,
+        total_output_tokens=50,
+        tool_execution_records=tool_records,
+        prompt_preloaded_files=preloaded,
+    )
+
+
+class _StubToolRecord:
+    """Duck-typed stand-in for ``ToolExecutionRecord`` that
+    ``ExplorationLedger.from_records`` can ingest. Only needs ``tool_name``,
+    ``arguments_hash``, ``output_bytes``, and ``status``."""
+
+    def __init__(
+        self,
+        tool_name: str,
+        *,
+        args_hash: str = "h",
+        output_bytes: int = 100,
+        succeeded: bool = True,
+    ):
+        self.tool_name = tool_name
+        self.arguments_hash = args_hash
+        self.output_bytes = output_bytes
+        self.status = "success" if succeeded else "exec_error"
+
+
+# ---------------------------------------------------------------------------
+# (A) Pre-fix regression — confirms the bug + verifies the fix once landed
+# ---------------------------------------------------------------------------
+
+
+def test_merge_aggregates_tool_execution_records_from_all_units():
+    """Failing pre-fix; passing post-fix.
+
+    Three child streams each made 2 exploration tool calls. The merged
+    parent generation MUST expose all 6 records via
+    ``tool_execution_records``. Without the fix, the merged generation
+    has `()` and Iron Gate sees `cumulative=0`.
+    """
+    from backend.core.ouroboros.governance.plan_exploit import _merge_results
+
+    unit_a = _make_unit_result(
+        file_path="a.py",
+        tool_records=(
+            _StubToolRecord("read_file", args_hash="ha1"),
+            _StubToolRecord("read_file", args_hash="ha2"),
+        ),
+    )
+    unit_b = _make_unit_result(
+        file_path="b.py",
+        tool_records=(
+            _StubToolRecord("read_file", args_hash="hb1"),
+            _StubToolRecord("glob_files", args_hash="hb2"),
+        ),
+    )
+    unit_c = _make_unit_result(
+        file_path="c.py",
+        tool_records=(
+            _StubToolRecord("search_code", args_hash="hc1"),
+            _StubToolRecord("read_file", args_hash="hc2"),
+        ),
+    )
+
+    merged = _merge_results([unit_a, unit_b, unit_c], parent_ctx=None)
+
+    # Aggregated count = 6 (2 per unit × 3 units)
+    assert len(merged.tool_execution_records) == 6, (
+        f"merged generation should aggregate all child stream records; "
+        f"got {len(merged.tool_execution_records)} "
+        f"(expected 6 = 2 per unit × 3 units). "
+        f"Iron Gate exploration ledger reads this attribute — empty here "
+        f"causes false `exploration_insufficient` rejection per "
+        f"Test A audit (S6/S7/S8)."
+    )
+    # Spot-check that the records survived intact
+    names = sorted(r.tool_name for r in merged.tool_execution_records)
+    assert names == [
+        "glob_files", "read_file", "read_file", "read_file", "read_file",
+        "search_code",
+    ]
+
+
+def test_merge_aggregates_prompt_preloaded_files_from_all_units():
+    """Same contract for prompt_preloaded_files. Without aggregation,
+    Iron Gate's preload credit also drops to 0."""
+    from backend.core.ouroboros.governance.plan_exploit import _merge_results
+
+    unit_a = _make_unit_result(
+        file_path="a.py", preloaded=("preload_1.py",),
+    )
+    unit_b = _make_unit_result(
+        file_path="b.py", preloaded=("preload_2.py", "preload_3.py"),
+    )
+    unit_c = _make_unit_result(file_path="c.py", preloaded=())
+
+    merged = _merge_results([unit_a, unit_b, unit_c], parent_ctx=None)
+
+    assert len(merged.prompt_preloaded_files) == 3
+    assert sorted(merged.prompt_preloaded_files) == [
+        "preload_1.py", "preload_2.py", "preload_3.py",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# (B) Merge semantics — additive, dedupe-deferred, single-writer
+# ---------------------------------------------------------------------------
+
+
+def test_merge_additive_no_prededuplication_at_merge_step():
+    """Two streams call read_file with the same arguments_hash. The merge
+    step does NOT pre-dedupe — it preserves both records so downstream
+    consumers (ExplorationLedger.diversity_score) can apply their own
+    dedup policy. Pre-deduping at merge would lose call-count signals."""
+    from backend.core.ouroboros.governance.plan_exploit import _merge_results
+
+    unit_a = _make_unit_result(
+        file_path="a.py",
+        tool_records=(_StubToolRecord("read_file", args_hash="DUPLICATE"),),
+    )
+    unit_b = _make_unit_result(
+        file_path="b.py",
+        tool_records=(_StubToolRecord("read_file", args_hash="DUPLICATE"),),
+    )
+    merged = _merge_results([unit_a, unit_b], parent_ctx=None)
+    # Both records present — no pre-dedupe at merge
+    assert len(merged.tool_execution_records) == 2
+    assert all(
+        r.arguments_hash == "DUPLICATE"
+        for r in merged.tool_execution_records
+    )
+
+
+def test_merge_handles_units_with_no_records():
+    """Mixed-bag: some streams have records, others don't. Merge tolerates."""
+    from backend.core.ouroboros.governance.plan_exploit import _merge_results
+
+    unit_a = _make_unit_result(file_path="a.py")  # no records
+    unit_b = _make_unit_result(
+        file_path="b.py",
+        tool_records=(_StubToolRecord("read_file"),),
+    )
+    unit_c = _make_unit_result(file_path="c.py")  # no records
+    merged = _merge_results([unit_a, unit_b, unit_c], parent_ctx=None)
+    assert len(merged.tool_execution_records) == 1
+    assert merged.tool_execution_records[0].tool_name == "read_file"
+
+
+def test_merge_handles_all_empty_records():
+    """Edge case: every stream returned with no records (legacy callers).
+    Merge produces empty tuple, not a crash."""
+    from backend.core.ouroboros.governance.plan_exploit import _merge_results
+
+    units = [_make_unit_result(file_path=f"{n}.py") for n in "abc"]
+    merged = _merge_results(units, parent_ctx=None)
+    assert merged.tool_execution_records == ()
+    assert merged.prompt_preloaded_files == ()
+
+
+def test_merge_preserves_existing_aggregations_cost_tokens():
+    """Sanity — the existing aggregations (cost, tokens, duration, providers)
+    are unchanged by the new fields. Test ensures the fix is purely
+    additive to the merge step's behavior."""
+    from backend.core.ouroboros.governance.plan_exploit import _merge_results
+
+    unit_a = _make_unit_result(file_path="a.py", cost=0.10)
+    unit_b = _make_unit_result(file_path="b.py", cost=0.20)
+    merged = _merge_results([unit_a, unit_b], parent_ctx=None)
+    assert merged.cost_usd == pytest.approx(0.30)
+    assert merged.total_input_tokens == 200
+    assert merged.total_output_tokens == 100
+
+
+# ---------------------------------------------------------------------------
+# (C) Cross-component hook test — Iron Gate ledger consumer sees the credit
+# ---------------------------------------------------------------------------
+
+
+def test_iron_gate_ledger_consumes_merged_records():
+    """End-to-end pin: a merged generation built from N child streams
+    that each had ≥2 exploration tool calls produces an ExplorationLedger
+    with the aggregated record set. This is the critical wiring fix —
+    if the merge drops records, the ledger sees `cumulative=0` and
+    Iron Gate rejects with `exploration_insufficient`.
+
+    Per `feedback_orchestrator_wiring_invariant_checklist.md`: "Cross-component
+    hook test — at least one regression test that constructs <feature> and
+    asserts the consumer-side getattr resolves to the sentinel."
+    """
+    from backend.core.ouroboros.governance.exploration_engine import (
+        ExplorationLedger,
+    )
+    from backend.core.ouroboros.governance.plan_exploit import _merge_results
+
+    # Build 3 streams each with 2 unique tool calls (6 total)
+    units = [
+        _make_unit_result(
+            file_path=f"{name}.py",
+            tool_records=(
+                _StubToolRecord("read_file", args_hash=f"{name}_h1"),
+                _StubToolRecord("read_file", args_hash=f"{name}_h2"),
+            ),
+        )
+        for name in ("a", "b", "c")
+    ]
+    merged = _merge_results(units, parent_ctx=None)
+
+    # The orchestrator's Iron Gate consumer does this exact call:
+    ledger = ExplorationLedger.from_records(merged.tool_execution_records)
+
+    # 6 ExplorationCalls present — well above the 2-floor minimum
+    assert len(ledger.calls) == 6, (
+        f"Iron Gate ledger sees {len(ledger.calls)} calls; expected 6. "
+        "If 0, the merge step is dropping records (the rooted bug). "
+        "If 2-5, partial loss — investigate."
+    )
+    # Diversity score > 0 — the gate's pass condition
+    assert ledger.diversity_score() > 0
+
+
+# ---------------------------------------------------------------------------
+# (D) No gate softening — Iron Gate scoring rules unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_no_gate_softening_iron_gate_scoring_unchanged():
+    """Slice contract: the merge fix MUST NOT change Iron Gate's scoring
+    floor or rules. Test by verifying that an empty ledger still scores
+    0 (no shortcut), and a single-call ledger still scores low (no
+    free credit)."""
+    from backend.core.ouroboros.governance.exploration_engine import (
+        ExplorationLedger,
+    )
+    empty = ExplorationLedger(calls=())
+    assert empty.diversity_score() == 0.0
+    # A single ledger entry shouldn't shortcut the floor
+    from backend.core.ouroboros.governance.exploration_engine import (
+        ExplorationCall,
+    )
+    single = ExplorationLedger(
+        calls=(ExplorationCall(
+            tool_name="read_file",
+            arguments_hash="x",
+            output_bytes=100,
+            succeeded=True,
+        ),),
+    )
+    # Score is positive but bounded (depends on weights — this just
+    # asserts the floor isn't somehow lower post-fix)
+    assert single.diversity_score() > 0.0
+
+
+# ---------------------------------------------------------------------------
+# (E) Source-grep pin — merge step references the new aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_pin_merge_aggregates_records_in_source():
+    """Source-grep: future drift in `_merge_results` that drops the
+    aggregation step will fail this pin BEFORE shipping."""
+    from pathlib import Path
+    src = Path(
+        "backend/core/ouroboros/governance/plan_exploit.py"
+    ).read_text()
+    # The fix must reference both new aggregation fields
+    assert "tool_execution_records" in src
+    assert "prompt_preloaded_files" in src


### PR DESCRIPTION
## Summary

**Seed exploration arc — Path 2 fix.** Operator-authorized 2026-04-25 (Path 1 failing regression tests folded in per operator request).

Closes the rooted bug identified in Test A audit: PLAN-EXPLOIT child streams accumulate exploration credit (`tool_execution_records` + `prompt_preloaded_files`) per-unit, but `_merge_results` was dropping them when composing the parent `GenerationResult`. The orchestrator's Iron Gate exploration-ledger consumer read `cumulative=0 preloaded=0` for the parent op despite **11–21 actual exploration tool calls per session** (S6: 20, S7: 11, S8: 21) — false `exploration_insufficient` rejection on S3/S6/S7/S8.

This is structurally the same class of integration bug as W3(6) Slice 4 (`_subagent_scheduler` attribute mismatch fixed in `d378dea968`). Both are integration gaps between a feature module and the surrounding governance machinery.

## What ships

**`backend/core/ouroboros/governance/plan_exploit.py`** — `_merge_results`:
- Aggregate per-unit `tool_execution_records` (list extend → tuple).
- Aggregate per-unit `prompt_preloaded_files` (list extend → tuple).
- Pass both into the merged `GenerationResult(...)` constructor.
- Defensive: missing attrs treated as empty tuples.

**`tests/governance/test_plan_exploit_ledger_merge.py`** (NEW) — 9 tests, **6 of them failed pre-fix** (Path 1 folded in per operator request).

## Merge semantics (operator requirement)

- **Additive** — parent records = concatenation of all child records.
- **Dedupe deferred** — merge does NOT pre-dedupe by `(tool_name, args_hash)`; downstream `ExplorationLedger.diversity_score()` owns dedup policy. Pre-deduping at merge would lose call-count signals.
- **Single-writer** — only `_merge_results` writes the merged field on the parent generation. Child streams write their own per-stream records during their tool loop; merge collects, never re-writes.
- **No gate softening** — Iron Gate floor + diversity scoring are unchanged. Pinned by `test_no_gate_softening_iron_gate_scoring_unchanged`.

## Cross-component hook test (per wiring checklist)

`test_iron_gate_ledger_consumes_merged_records` constructs a merged generation from 3 child streams that each had 2 exploration tool calls, calls `ExplorationLedger.from_records(merged.tool_execution_records)` (the orchestrator's exact consumer pattern), and asserts the ledger sees 6 calls + diversity_score > 0. Closes the same class of integration gap as W3(6) Slice 4 wiring miss.

## Test plan

- [x] Pre-fix simulation: **6 of 9 fail** as expected (the regression assertions).
- [x] Post-fix: **9/9 green**.
- [x] Combined regression: **18/18** across new tests + Slice 5 cancel propagation suite (also touches plan_exploit).
- [ ] **Path 3 live-fire** — pending operator's explicit "seed live verify go" after this PR merges + CI is clean.

## Slice 5b ledger row update

```
seed_slice5b_traversal: FAIL (deferred)
  → BLOCKED-BY-INTEGRATION-BUG (identified 2026-04-25, fix in this PR)
```

After Path 3 live-fire confirms the fix end-to-end, this row flips to PASS.

## Rollback

This is a structural bug fix — no env knob. To revert, `git revert d223401797`. The fix is small (one helper function, ~10 LOC) so revert risk is low.

## Commit → Slice mapping

| Commit | Path | Files |
|---|---|---|
| `d223401797` | Seed Arc Path 2 | `plan_exploit.py` `_merge_results` aggregation, 9 tests (Path 1 + Path 2) |

## Cross-links

- `memory/project_followup_seed_exploration_arc.md` — full arc + Test A audit + Path 2 implementation notes.
- `memory/project_f1_w3_slice5b_s1_s6_checkpoint.md` — ledger row updated.
- `memory/feedback_orchestrator_wiring_invariant_checklist.md` — same integration-gap class as W3(6) Slice 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes exploration credit aggregation in plan-exploit by merging child exploration evidence into the parent `GenerationResult`, so the Iron Gate ledger sees the correct tool-call and preload counts. This prevents false `exploration_insufficient` rejections.

- **Bug Fixes**
  - Aggregate `tool_execution_records` and `prompt_preloaded_files` from all child streams in `_merge_results` and pass them to the parent `GenerationResult` (missing attrs treated as empty).
  - Merge semantics: additive concatenation, no pre-dedupe (handled downstream by `ExplorationLedger`), single-writer; Iron Gate scoring rules unchanged.
  - Added `tests/governance/test_plan_exploit_ledger_merge.py` covering aggregation, empty/mixed cases, no pre-dedupe, and a cross-component check that `ExplorationLedger.from_records(...)` sees the full set.

<sup>Written for commit d223401797012b3cf16c94554960ff73d3a246cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

