### PR TITLE
feat(curiosity): W2(4) Slice 1 — CuriosityBudget primitive + per-op tracker

### DIFF
--- a/backend/core/ouroboros/governance/curiosity_engine.py
+++ b/backend/core/ouroboros/governance/curiosity_engine.py
@@ -1,0 +1,438 @@
+"""Wave 2 (4) Slice 1 — Curiosity engine primitive + per-op budget tracker.
+
+Per ``project_w2_4_curiosity_scope.md`` Slice 1 (operator-authorized
+2026-04-25). Ships the in-memory primitive + ContextVar transport + JSONL
+ledger + 4 env knobs. Does NOT widen tool policy (Slice 2), publish SSE
+events (Slice 3), or flip the master flag (Slice 4).
+
+Authority posture (per scope doc):
+
+* §1 additive only — ``ask_human`` is already authority-free; this
+  primitive only tracks budget for *when* it can fire.
+* §5 Tier −1 — question-text sanitization happens at the policy gate
+  (Slice 2). This primitive accepts already-sanitized text or stores
+  whatever the caller passes (Slice 1 has no sanitizer).
+* §6 Iron Gate unchanged.
+* §7 Approval surface untouched.
+* §8 Observability — JSONL ledger writes here; SSE publish in Slice 3.
+
+Hot-revert: ``JARVIS_CURIOSITY_ENABLED=false`` (default) → all sub-flags
+force-disabled via master-off composition → byte-for-byte pre-W2(4).
+Mirrors W3(7) cancel master-off semantics.
+"""
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+
+logger = logging.getLogger("Ouroboros.CuriosityEngine")
+
+
+# ---------------------------------------------------------------------------
+# Env knobs
+# ---------------------------------------------------------------------------
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Standard JARVIS env-bool parse — true/1/yes/on (case-insensitive)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("true", "1", "yes", "on")
+
+
+def curiosity_enabled() -> bool:
+    """Master flag — `JARVIS_CURIOSITY_ENABLED` (default ``false``).
+
+    Slice 1 default is False per operator binding. Slice 4 graduation
+    decides whether to flip. Master-off is THE single hot-revert env knob
+    — when False, every sub-flag below force-disables (composition pattern,
+    same as W3(7) cancel master-off).
+    """
+    return _env_bool("JARVIS_CURIOSITY_ENABLED", False)
+
+
+def questions_per_session() -> int:
+    """`JARVIS_CURIOSITY_QUESTIONS_PER_SESSION` — default ``3``.
+
+    Hard ceiling on the number of curiosity questions the model can ask
+    in a single session. Each ``try_charge`` Allowed result decrements the
+    remaining quota; once it hits 0, every subsequent ``try_charge``
+    returns Denied(questions_exhausted). Master-off → effective cap is 0.
+    """
+    if not curiosity_enabled():
+        return 0
+    raw = os.environ.get("JARVIS_CURIOSITY_QUESTIONS_PER_SESSION", "3")
+    try:
+        n = int(raw)
+        return max(0, n)
+    except (TypeError, ValueError):
+        return 3
+
+
+def cost_cap_usd() -> float:
+    """`JARVIS_CURIOSITY_COST_CAP_USD` — default ``0.05`` per question.
+
+    Per-question soft cap on the estimated LLM cost of generating the
+    question text. Each ``try_charge`` rejects if ``est_cost_usd`` exceeds
+    this cap. Operator-binding default 0.05. Master-off → cap is 0.0
+    (rejects everything).
+    """
+    if not curiosity_enabled():
+        return 0.0
+    raw = os.environ.get("JARVIS_CURIOSITY_COST_CAP_USD", "0.05")
+    try:
+        v = float(raw)
+        return max(0.0, v)
+    except (TypeError, ValueError):
+        return 0.05
+
+
+# Posture allowlist v1 per operator binding 2026-04-25 — EXPLORE +
+# CONSOLIDATE only. HARDEN excluded by design (focus stabilization, not
+# new questions). MAINTAIN excluded for Slice 1 — operator can revisit.
+_DEFAULT_POSTURE_ALLOWLIST = "EXPLORE,CONSOLIDATE"
+
+
+def posture_allowlist() -> frozenset:
+    """`JARVIS_CURIOSITY_POSTURE_ALLOWLIST` — default ``"EXPLORE,CONSOLIDATE"``.
+
+    Comma-separated list of posture values that allow curiosity to fire.
+    Master-off → empty set. Whitespace + case tolerated.
+    """
+    if not curiosity_enabled():
+        return frozenset()
+    raw = os.environ.get(
+        "JARVIS_CURIOSITY_POSTURE_ALLOWLIST", _DEFAULT_POSTURE_ALLOWLIST,
+    )
+    return frozenset(
+        part.strip().upper()
+        for part in raw.split(",")
+        if part.strip()
+    )
+
+
+def ledger_persist_enabled() -> bool:
+    """`JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED` — default ``true``
+    when master is on. Master-off → always False."""
+    if not curiosity_enabled():
+        return False
+    return _env_bool("JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED", True)
+
+
+# ---------------------------------------------------------------------------
+# Decision result types
+# ---------------------------------------------------------------------------
+
+
+class DenyReason(str, Enum):
+    """Stable, grep-friendly deny-reason vocabulary for telemetry."""
+
+    MASTER_OFF = "master_off"
+    POSTURE_DISALLOWED = "posture_disallowed"
+    QUESTIONS_EXHAUSTED = "questions_exhausted"
+    COST_EXCEEDED = "cost_exceeded"
+    INVALID_QUESTION = "invalid_question"  # empty / non-string text
+
+
+@dataclass(frozen=True)
+class ChargeResult:
+    """Immutable result of :meth:`CuriosityBudget.try_charge`.
+
+    ``allowed=True`` → ``question_id`` is populated with the assigned UUID.
+    ``allowed=False`` → ``deny_reason`` carries the structured reason; the
+    caller should NOT proceed with the question.
+    """
+
+    allowed: bool
+    question_id: Optional[str] = None
+    deny_reason: Optional[DenyReason] = None
+    detail: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Ledger record (schema curiosity.1)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CuriosityRecord:
+    """Immutable record of one curiosity decision (schema ``curiosity.1``).
+
+    Frozen because once persisted it's the system of record for the
+    operator-facing audit. Mutating it would break the deterministic
+    ledger contract.
+    """
+
+    schema_version: str
+    question_id: str
+    op_id: str
+    posture_at_charge: str
+    question_text: str
+    est_cost_usd: float
+    issued_at_monotonic: float
+    issued_at_iso: str
+    result: str  # "allowed" | "denied:<reason>"
+
+    def to_jsonl(self) -> str:
+        return json.dumps(asdict(self), separators=(",", ":")) + "\n"
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _new_question_id() -> str:
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# CuriosityBudget — per-op tracker
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CuriosityBudget:
+    """Per-op budget tracker.
+
+    Construct one per op (typically inside the GENERATE runner before the
+    Venom tool loop starts). Slice 2 will look this up via the
+    :data:`current_curiosity_budget_var` ContextVar from
+    ``tool_executor.py`` Rule 14.
+
+    Lifecycle:
+      1. ``CuriosityBudget(op_id, posture)`` — captures posture_at_arm.
+      2. ``try_charge(question_text, est_cost_usd)`` — call once per
+         model-issued question. Returns Allowed (and increments the
+         counter) or Denied(reason).
+      3. ``snapshot()`` — read-only view (questions_used, cost_burn,
+         remaining quota) for postmortem + summary.json.
+
+    Thread-safety: Slice 1 is single-threaded inside one op (Venom tool
+    loop is async-serial per op). If a future slice needs concurrent
+    access, add a lock. Don't add prematurely.
+
+    Master-off contract: when ``curiosity_enabled()`` is False, every
+    ``try_charge`` returns ``Denied(MASTER_OFF)`` without touching the
+    counter. The counter never increments past 0 in that mode.
+    """
+
+    op_id: str
+    posture_at_arm: str
+    session_dir: Optional[Path] = None
+    # Internal mutable state (not constructor args)
+    _questions_used: int = field(default=0, init=False)
+    _cost_burn_usd: float = field(default=0.0, init=False)
+
+    @property
+    def questions_used(self) -> int:
+        return self._questions_used
+
+    @property
+    def cost_burn_usd(self) -> float:
+        return self._cost_burn_usd
+
+    @property
+    def questions_remaining(self) -> int:
+        """Quota left for this session. Returns 0 when master-off or used up."""
+        cap = questions_per_session()
+        return max(0, cap - self._questions_used)
+
+    def try_charge(
+        self,
+        question_text: str,
+        est_cost_usd: float,
+    ) -> ChargeResult:
+        """Atomic decision + commit.
+
+        Composition order (first deny wins):
+          1. master flag — gates everything
+          2. invalid question (empty / non-string)
+          3. posture allowlist
+          4. questions-per-session quota
+          5. per-question cost cap
+
+        On Allowed: increments counter, accumulates cost, persists ledger
+        record (if persist sub-flag on + session_dir set), returns the
+        ``question_id``. On Denied: persists a denied record (so operators
+        can see WHY curiosity didn't fire), returns the reason.
+        """
+        # 1. Master flag
+        if not curiosity_enabled():
+            return self._record_decision(
+                question_text=question_text,
+                est_cost_usd=est_cost_usd,
+                allowed=False,
+                deny_reason=DenyReason.MASTER_OFF,
+            )
+        # 2. Invalid question
+        if not isinstance(question_text, str) or not question_text.strip():
+            return self._record_decision(
+                question_text=str(question_text)[:200],
+                est_cost_usd=est_cost_usd,
+                allowed=False,
+                deny_reason=DenyReason.INVALID_QUESTION,
+                detail="empty or non-string question_text",
+            )
+        # 3. Posture allowlist
+        allowlist = posture_allowlist()
+        normalized_posture = (self.posture_at_arm or "").strip().upper()
+        if normalized_posture not in allowlist:
+            return self._record_decision(
+                question_text=question_text,
+                est_cost_usd=est_cost_usd,
+                allowed=False,
+                deny_reason=DenyReason.POSTURE_DISALLOWED,
+                detail=(
+                    f"posture={normalized_posture!r} not in "
+                    f"allowlist={sorted(allowlist)}"
+                ),
+            )
+        # 4. Questions quota
+        cap = questions_per_session()
+        if self._questions_used >= cap:
+            return self._record_decision(
+                question_text=question_text,
+                est_cost_usd=est_cost_usd,
+                allowed=False,
+                deny_reason=DenyReason.QUESTIONS_EXHAUSTED,
+                detail=f"used={self._questions_used}/cap={cap}",
+            )
+        # 5. Per-question cost cap
+        per_q_cap = cost_cap_usd()
+        if est_cost_usd > per_q_cap:
+            return self._record_decision(
+                question_text=question_text,
+                est_cost_usd=est_cost_usd,
+                allowed=False,
+                deny_reason=DenyReason.COST_EXCEEDED,
+                detail=f"est_cost=${est_cost_usd:.4f} > cap=${per_q_cap:.4f}",
+            )
+        # All gates passed — commit
+        self._questions_used += 1
+        self._cost_burn_usd += float(est_cost_usd)
+        return self._record_decision(
+            question_text=question_text,
+            est_cost_usd=est_cost_usd,
+            allowed=True,
+        )
+
+    def _record_decision(
+        self,
+        *,
+        question_text: str,
+        est_cost_usd: float,
+        allowed: bool,
+        deny_reason: Optional[DenyReason] = None,
+        detail: str = "",
+    ) -> ChargeResult:
+        """Build the ChargeResult, log, and persist."""
+        question_id = _new_question_id()
+        record = CuriosityRecord(
+            schema_version="curiosity.1",
+            question_id=question_id,
+            op_id=self.op_id,
+            posture_at_charge=(self.posture_at_arm or "").strip().upper(),
+            question_text=question_text,
+            est_cost_usd=float(est_cost_usd),
+            issued_at_monotonic=time.monotonic(),
+            issued_at_iso=_now_iso(),
+            result=("allowed" if allowed else f"denied:{deny_reason.value}"
+                    if deny_reason else "denied:unknown"),
+        )
+        # Single-line INFO log line (operator-facing audit).
+        if allowed:
+            logger.info(
+                "[Curiosity] op=%s ALLOWED question_id=%s "
+                "posture=%s est_cost=$%.4f used=%d/%d",
+                self.op_id[:16], question_id,
+                record.posture_at_charge, record.est_cost_usd,
+                self._questions_used, questions_per_session(),
+            )
+        else:
+            logger.info(
+                "[Curiosity] op=%s DENIED reason=%s detail=%r question_text=%r",
+                self.op_id[:16],
+                deny_reason.value if deny_reason else "unknown",
+                detail,
+                question_text[:80],
+            )
+        # Persist to ledger (best-effort).
+        if ledger_persist_enabled() and self.session_dir is not None:
+            self._persist(record)
+        return ChargeResult(
+            allowed=allowed,
+            question_id=question_id if allowed else None,
+            deny_reason=deny_reason,
+            detail=detail,
+        )
+
+    def _persist(self, record: CuriosityRecord) -> None:
+        """Append the record to ``curiosity_ledger.jsonl``. Best-effort."""
+        try:
+            artifact = self.session_dir / "curiosity_ledger.jsonl"  # type: ignore[union-attr]
+            artifact.parent.mkdir(parents=True, exist_ok=True)
+            with artifact.open("a", encoding="utf-8") as f:
+                f.write(record.to_jsonl())
+        except Exception as exc:  # noqa: BLE001 — persistence is best-effort
+            logger.warning(
+                "[Curiosity] persist failed op=%s question_id=%s err=%s",
+                self.op_id[:16], record.question_id,
+                f"{type(exc).__name__}: {exc}",
+            )
+
+    def snapshot(self) -> dict:
+        """Read-only view for postmortem + summary.json composition."""
+        return {
+            "op_id": self.op_id,
+            "posture_at_arm": (self.posture_at_arm or "").strip().upper(),
+            "questions_used": self._questions_used,
+            "questions_remaining": self.questions_remaining,
+            "cost_burn_usd": round(self._cost_burn_usd, 4),
+        }
+
+
+# ---------------------------------------------------------------------------
+# ContextVar — Slice 2 transport
+# ---------------------------------------------------------------------------
+
+
+curiosity_budget_var: contextvars.ContextVar[Optional[CuriosityBudget]] = (
+    contextvars.ContextVar("ouroboros.curiosity_budget", default=None)
+)
+
+
+def current_curiosity_budget() -> Optional[CuriosityBudget]:
+    """Read the ambient :class:`CuriosityBudget` for this asyncio task chain.
+
+    Returns ``None`` when no budget has been bound (default — Slice 1
+    callers, unit tests, pre-W2(4) call paths). Slice 2's tool_executor
+    Rule 14 reads this to decide whether to allow ``ask_human`` at
+    SAFE_AUTO risk tier.
+    """
+    return curiosity_budget_var.get()
+
+
+__all__ = [
+    "CuriosityBudget",
+    "CuriosityRecord",
+    "ChargeResult",
+    "DenyReason",
+    "curiosity_budget_var",
+    "current_curiosity_budget",
+    "curiosity_enabled",
+    "questions_per_session",
+    "cost_cap_usd",
+    "posture_allowlist",
+    "ledger_persist_enabled",
+]

--- a/tests/governance/test_curiosity_engine_slice1.py
+++ b/tests/governance/test_curiosity_engine_slice1.py
@@ -1,0 +1,342 @@
+"""Wave 2 (4) Slice 1 — CuriosityBudget primitive tests.
+
+Pins the contract per ``project_w2_4_curiosity_scope.md`` Slice 1:
+
+A. Env knob defaults — master default `false`; sub-flags force-disabled
+   under master-off composition (single hot-revert env per operator binding).
+B. Charge composition — master / invalid / posture / quota / cost cap, in order.
+C. Counter increments only on Allowed.
+D. ContextVar default-None + propagates through asyncio.create_task.
+E. Ledger schema curiosity.1 round-trip + persistence.
+F. snapshot() shape for postmortem.
+
+All tests offline. NO Rule 14 widening, NO SSE, NO graduation pins —
+those are Slices 2/3/4.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from backend.core.ouroboros.governance.curiosity_engine import (
+    ChargeResult,
+    CuriosityBudget,
+    CuriosityRecord,
+    DenyReason,
+    cost_cap_usd,
+    curiosity_budget_var,
+    curiosity_enabled,
+    current_curiosity_budget,
+    ledger_persist_enabled,
+    posture_allowlist,
+    questions_per_session,
+)
+
+
+# ---------------------------------------------------------------------------
+# (A) Env knob defaults + master-off composition
+# ---------------------------------------------------------------------------
+
+
+def test_master_default_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JARVIS_CURIOSITY_ENABLED defaults to false (Slice 1)."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    assert curiosity_enabled() is False
+
+
+def test_master_explicit_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    assert curiosity_enabled() is True
+
+
+def test_questions_per_session_default_3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default 3 questions per session when master is on."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CURIOSITY_QUESTIONS_PER_SESSION", raising=False)
+    assert questions_per_session() == 3
+
+
+def test_master_off_force_disables_questions_quota(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Master off → questions_per_session forced to 0 regardless of env."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_QUESTIONS_PER_SESSION", "100")
+    assert questions_per_session() == 0
+
+
+def test_cost_cap_default_005(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default per-question cost cap $0.05 (operator-binding)."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CURIOSITY_COST_CAP_USD", raising=False)
+    assert cost_cap_usd() == 0.05
+
+
+def test_master_off_force_disables_cost_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Master off → cost cap forced to 0.0 → rejects everything."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_COST_CAP_USD", "1.00")
+    assert cost_cap_usd() == 0.0
+
+
+def test_posture_allowlist_default_explore_consolidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default allowlist EXPLORE+CONSOLIDATE per operator binding (HARDEN
+    excluded by design; MAINTAIN excluded for Slice 1)."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CURIOSITY_POSTURE_ALLOWLIST", raising=False)
+    al = posture_allowlist()
+    assert al == frozenset({"EXPLORE", "CONSOLIDATE"})
+
+
+def test_master_off_force_disables_posture_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_POSTURE_ALLOWLIST", "EXPLORE,HARDEN")
+    assert posture_allowlist() == frozenset()
+
+
+def test_ledger_persist_off_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED", "true")
+    assert ledger_persist_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# (B) Charge composition — first deny wins, in documented order
+# ---------------------------------------------------------------------------
+
+
+def test_master_off_denies_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Master off → every charge returns Denied(MASTER_OFF), counter
+    never increments."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
+    result = bud.try_charge("Should I refactor X?", est_cost_usd=0.01)
+    assert result.allowed is False
+    assert result.deny_reason is DenyReason.MASTER_OFF
+    assert bud.questions_used == 0
+    assert bud.cost_burn_usd == 0.0
+
+
+def test_invalid_question_denies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty / non-string question text → INVALID_QUESTION before posture check."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
+    for bad in ("", "   ", None):
+        result = bud.try_charge(bad, est_cost_usd=0.01)  # type: ignore[arg-type]
+        assert result.allowed is False
+        assert result.deny_reason is DenyReason.INVALID_QUESTION
+    assert bud.questions_used == 0
+
+
+def test_posture_disallowed_denies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Posture HARDEN (excluded from default allowlist) → POSTURE_DISALLOWED."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="HARDEN")
+    result = bud.try_charge("Q?", est_cost_usd=0.01)
+    assert result.allowed is False
+    assert result.deny_reason is DenyReason.POSTURE_DISALLOWED
+    assert "HARDEN" in result.detail
+    assert bud.questions_used == 0
+
+
+def test_questions_quota_exhausted_denies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After 3 successful charges, the 4th returns QUESTIONS_EXHAUSTED."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CURIOSITY_QUESTIONS_PER_SESSION", "3")
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
+    for i in range(3):
+        result = bud.try_charge(f"Q{i}?", est_cost_usd=0.01)
+        assert result.allowed is True, f"charge {i} must be allowed"
+    # 4th — denied
+    result = bud.try_charge("Q3?", est_cost_usd=0.01)
+    assert result.allowed is False
+    assert result.deny_reason is DenyReason.QUESTIONS_EXHAUSTED
+    assert "used=3/cap=3" in result.detail
+    assert bud.questions_used == 3  # not incremented past cap
+
+
+def test_cost_cap_exceeded_denies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """est_cost_usd > $0.05 default → COST_EXCEEDED."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
+    result = bud.try_charge("expensive question?", est_cost_usd=0.10)
+    assert result.allowed is False
+    assert result.deny_reason is DenyReason.COST_EXCEEDED
+    assert "$0.1000" in result.detail
+    assert bud.questions_used == 0
+
+
+# ---------------------------------------------------------------------------
+# (C) Counter increments only on Allowed
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_charge_increments_counter_and_cost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
+    result = bud.try_charge("Q?", est_cost_usd=0.02)
+    assert result.allowed is True
+    assert result.question_id is not None
+    assert bud.questions_used == 1
+    assert bud.cost_burn_usd == pytest.approx(0.02)
+    assert bud.questions_remaining == 2  # 3 cap - 1 used
+
+
+def test_remaining_quota_zero_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """questions_remaining returns 0 when master is off."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
+    assert bud.questions_remaining == 0
+
+
+# ---------------------------------------------------------------------------
+# (D) ContextVar default-None + propagation
+# ---------------------------------------------------------------------------
+
+
+def test_current_curiosity_budget_default_none():
+    """Outside any binding, current_curiosity_budget() returns None."""
+    assert current_curiosity_budget() is None
+
+
+@pytest.mark.asyncio
+async def test_contextvar_propagates_through_create_task() -> None:
+    """ContextVars survive `asyncio.create_task` boundaries — same pattern
+    as W3(7) cancel_token + W2(4) Path 3 plan_exploit override. Critical
+    for Slice 2's tool_executor Rule 14 to see the budget from any
+    Venom tool task spawned during GENERATE."""
+    bud = CuriosityBudget(op_id="op-ctx-test", posture_at_arm="EXPLORE")
+    curiosity_budget_var.set(bud)
+
+    async def _child_reads():
+        return current_curiosity_budget()
+
+    got = await asyncio.create_task(_child_reads())
+    assert got is bud
+
+
+# ---------------------------------------------------------------------------
+# (E) Ledger schema + persistence
+# ---------------------------------------------------------------------------
+
+
+def test_record_schema_curiosity_1():
+    """Schema version is curiosity.1 and the JSONL line round-trips."""
+    rec = CuriosityRecord(
+        schema_version="curiosity.1",
+        question_id="qid-x",
+        op_id="op-x",
+        posture_at_charge="EXPLORE",
+        question_text="Q?",
+        est_cost_usd=0.02,
+        issued_at_monotonic=0.0,
+        issued_at_iso="2026-04-25T03:00:00Z",
+        result="allowed",
+    )
+    line = rec.to_jsonl()
+    parsed = json.loads(line)
+    assert parsed["schema_version"] == "curiosity.1"
+    assert parsed["question_id"] == "qid-x"
+    assert parsed["result"] == "allowed"
+
+
+def test_persist_writes_jsonl_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Ledger writes to <session_dir>/curiosity_ledger.jsonl when persist
+    sub-flag is on AND session_dir is set."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED", "true")
+    bud = CuriosityBudget(
+        op_id="op-persist-001",
+        posture_at_arm="EXPLORE",
+        session_dir=tmp_path,
+    )
+    bud.try_charge("Q1?", est_cost_usd=0.01)
+    bud.try_charge("Q2?", est_cost_usd=0.02)
+
+    artifact = tmp_path / "curiosity_ledger.jsonl"
+    assert artifact.exists()
+    lines = [
+        json.loads(line)
+        for line in artifact.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(lines) == 2
+    assert all(line["op_id"] == "op-persist-001" for line in lines)
+    assert all(line["result"] == "allowed" for line in lines)
+
+
+def test_persist_writes_denied_records_too(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Denied charges also persist (operators want to see WHY curiosity
+    didn't fire). Pinned so future drift doesn't silently drop denials."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    bud = CuriosityBudget(
+        op_id="op-deny-001",
+        posture_at_arm="HARDEN",  # excluded — every charge denied
+        session_dir=tmp_path,
+    )
+    bud.try_charge("Q?", est_cost_usd=0.01)
+
+    artifact = tmp_path / "curiosity_ledger.jsonl"
+    assert artifact.exists()
+    parsed = json.loads(artifact.read_text(encoding="utf-8").strip())
+    assert parsed["result"] == "denied:posture_disallowed"
+
+
+def test_persist_skipped_when_no_session_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """No session_dir → log-only mode (helper falls through cleanly)."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    bud = CuriosityBudget(
+        op_id="op-nosd-001",
+        posture_at_arm="EXPLORE",
+        session_dir=None,
+    )
+    result = bud.try_charge("Q?", est_cost_usd=0.01)
+    assert result.allowed is True
+    # No artifact written — and no crash
+    assert not (tmp_path / "curiosity_ledger.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# (F) snapshot() shape for postmortem
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    bud = CuriosityBudget(op_id="op-snap-001", posture_at_arm="explore")
+    bud.try_charge("Q?", est_cost_usd=0.03)
+    snap = bud.snapshot()
+    assert snap == {
+        "op_id": "op-snap-001",
+        "posture_at_arm": "EXPLORE",  # normalized uppercase
+        "questions_used": 1,
+        "questions_remaining": 2,
+        "cost_burn_usd": 0.03,
+    }


### PR DESCRIPTION
## Summary

**W2(4) Curiosity Engine Slice 1.** Operator-authorized 2026-04-25 with binding decisions:
- 4 slices as scoped (no consolidation)
- Master flip at Slice 4 only (W3(7) pattern)
- Posture allowlist `EXPLORE,CONSOLIDATE` (HARDEN excluded by design)
- Per-question cap $0.05 (env-overridable)
- Live-fire optional dev smoke after Slice 2; formal at Slice 4 only

Slice 1 ships ONLY the in-memory primitive. Does NOT widen `ask_human`'s Rule 14 risk-tier gate (Slice 2), publish SSE events (Slice 3), or flip the master flag (Slice 4).

## What ships

**`backend/core/ouroboros/governance/curiosity_engine.py`** (new):

- `CuriosityBudget` per-op tracker with composition:
  1. master flag → `DenyReason.MASTER_OFF`
  2. invalid question → `INVALID_QUESTION`
  3. posture allowlist → `POSTURE_DISALLOWED`
  4. quota → `QUESTIONS_EXHAUSTED`
  5. cost cap → `COST_EXCEEDED`
- First-deny-wins. Counter increments only on Allowed.
- `CuriosityRecord` schema `curiosity.1` (frozen, JSONL-serializable).
- `curiosity_budget_var: ContextVar` for Slice 2 transport (default None).
- `snapshot()` for postmortem + summary.json.
- Best-effort `_persist()` to `<session_dir>/curiosity_ledger.jsonl` — writes BOTH allowed AND denied records.

## Env knobs (single hot-revert)

| Flag | Default | Behavior |
|---|---|---|
| `JARVIS_CURIOSITY_ENABLED` | `false` | Master |
| `JARVIS_CURIOSITY_QUESTIONS_PER_SESSION` | `3` (when master on) | Hard ceiling |
| `JARVIS_CURIOSITY_COST_CAP_USD` | `0.05` (when master on) | Per-question soft cap |
| `JARVIS_CURIOSITY_POSTURE_ALLOWLIST` | `"EXPLORE,CONSOLIDATE"` | HARDEN excluded by design |
| `JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED` | `true` (when master on) | JSONL artifact |

**Hot-revert**: `JARVIS_CURIOSITY_ENABLED=false` → all sub-flags force-disabled via composition → byte-for-byte pre-W2(4). Single env knob.

## Authority posture preserved

- §1 additive only — primitive only tracks budget; no new authority surface
- §5 Tier −1 — question-text sanitization deferred to Slice 2 policy gate
- §6 Iron Gate unchanged
- §7 Approval surface untouched
- §8 Observability — JSONL writes here; SSE deferred to Slice 3

## Test plan

- [x] **23/23 green** in `test_curiosity_engine_slice1.py`
  - (A) Env defaults + master-off composition (9)
  - (B) Charge composition — first-deny-wins (5)
  - (C) Counter increments only on Allowed (2)
  - (D) ContextVar default-None + `asyncio.create_task` propagation (2)
  - (E) Ledger schema `curiosity.1` + persistence (4)
  - (F) `snapshot()` shape (1)
- [ ] Live-fire deferred per operator binding (formal at Slice 4 only)

## Rollback

`JARVIS_CURIOSITY_ENABLED=false` (default). No code revert needed. Pinned by master-off composition tests.

## Commit → Slice mapping

| Commit | Description | Files |
|---|---|---|
| `c6af78f845` | W2(4) Slice 1 | `curiosity_engine.py` primitive + 23 tests |

## NOT in this PR (per operator binding — strict slice boundary)

- Slice 2: `ask_human` Rule 14 widening at SAFE_AUTO when curiosity enabled + posture allowed + budget remaining
- Slice 3: SSE event `curiosity_question_emitted` + `/observability/curiosity` GET routes
- Slice 4: graduation pins + master flip decision

## NOT in this PR (other deferred items, separate operator-authorized arcs)

F5 (touches_security_surface) + W3(7) deferrals — explicitly out of scope per operator standing order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)