### PR TITLE
feat(curiosity): W2(4) Slice 2 — Rule 14 widening + GENERATE phase budget binding

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/generate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/generate_runner.py
@@ -136,6 +136,63 @@ class GENERATERunner(PhaseRunner):
             _PreloadedExplorationRecord,
         )
 
+        # W2(4) Slice 2 — bind the per-op CuriosityBudget to the ambient
+        # ContextVar so tool_executor Rule 14 can consult it during the
+        # Venom tool loop. Master flag default-off → curiosity_enabled()
+        # returns False → CuriosityBudget.try_charge() always denies →
+        # tool_executor's curiosity widening short-circuits to the
+        # legacy SAFE_AUTO reject. Byte-for-byte pre-W2(4) when master
+        # is off. Best-effort: any exception here must not block GENERATE.
+        try:
+            from backend.core.ouroboros.governance.curiosity_engine import (
+                CuriosityBudget as _CuriosityBudget,
+                curiosity_budget_var as _curiosity_budget_var,
+                curiosity_enabled as _curiosity_enabled,
+            )
+            if _curiosity_enabled():
+                # Resolve current posture via Wave 1 #1 DirectionInferrer
+                # observer. If unavailable (test orchestrator without a
+                # PostureStore), default to "UNKNOWN" so the posture
+                # allowlist gate denies cleanly.
+                _posture_str = "UNKNOWN"
+                try:
+                    from backend.core.ouroboros.governance.posture_observer import (  # noqa: E501
+                        get_default_store as _get_default_posture_store,
+                    )
+                    _store = _get_default_posture_store()
+                    _reading = (
+                        _store.current_reading() if _store is not None else None
+                    )
+                    if _reading is not None:
+                        _posture_str = str(
+                            getattr(_reading, "posture", _reading)
+                        )
+                        # Some posture types are Enum.NAME — strip the prefix
+                        if "." in _posture_str:
+                            _posture_str = _posture_str.split(".", 1)[1]
+                except Exception:  # noqa: BLE001
+                    pass
+                # Resolve session_dir for the JSONL ledger (best-effort).
+                _session_dir = None
+                try:
+                    _gls = getattr(orch._stack, "governed_loop_service", None)
+                    if _gls is not None:
+                        _sd = getattr(_gls, "_session_dir", None)
+                        if _sd is not None:
+                            from pathlib import Path as _Path
+                            _session_dir = (
+                                _sd if isinstance(_sd, _Path) else _Path(_sd)
+                            )
+                except Exception:  # noqa: BLE001
+                    pass
+                _curiosity_budget_var.set(_CuriosityBudget(
+                    op_id=ctx.op_id,
+                    posture_at_arm=_posture_str,
+                    session_dir=_session_dir,
+                ))
+        except Exception:  # noqa: BLE001 — best-effort, never blocks GENERATE
+            pass
+
         # ---- VERBATIM transcription of orchestrator.py 3138-4748 ----
         if _serpent: _serpent.update_phase("GENERATE")
         # ---- Phase 3: GENERATE (with retry + episodic failure memory) ----

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -2325,26 +2325,115 @@ class GoverningToolPolicy:
                         detail=f"type_check path {f!r} escapes repo root",
                     )
 
-        # Rule 14: ask_human — requires NOTIFY_APPLY or APPROVAL_REQUIRED risk tier
-        # (Manifesto §5: deploy intelligence where it creates true leverage;
-        # Green ops shouldn't bother the human with questions)
+        # Rule 14: ask_human — risk-tier gated.
+        #
+        # Default behavior (pre-W2(4)): requires NOTIFY_APPLY or
+        # APPROVAL_REQUIRED risk tier (Manifesto §5: deploy intelligence
+        # where it creates true leverage; Green ops shouldn't bother the
+        # human with questions).
+        #
+        # W2(4) Slice 2 widening: when JARVIS_CURIOSITY_ENABLED=true AND
+        # a CuriosityBudget is bound to the ambient ContextVar AND
+        # current posture is in the allowlist (default EXPLORE+CONSOLIDATE)
+        # AND the per-session quota + cost cap aren't exhausted,
+        # ask_human is ALSO allowed at SAFE_AUTO. Master-flag-off
+        # (default) → byte-for-byte pre-W2(4) behavior. The widening is
+        # purely "when does ask_human fire", not "what can it do" — the
+        # tool is already authority-free.
+        #
+        # The budget try_charge() decision happens inside this gate so
+        # the same call site that allows the tool also accounts for it
+        # in the per-session ledger. Question text is the model's tool
+        # call argument (call.arguments["question"]); cost estimate is
+        # an upper bound (per-question cap default $0.05 — operators
+        # can tighten).
         elif name == "ask_human":
             try:
                 from backend.core.ouroboros.governance.risk_engine import RiskTier
                 _tier = ctx.risk_tier
-                if _tier is None or _tier == RiskTier.SAFE_AUTO:
-                    return PolicyResult(
-                        decision=PolicyDecision.DENY,
-                        reason_code="tool.denied.ask_human_low_risk",
-                        detail="ask_human requires NOTIFY_APPLY+ risk tier; "
-                               "SAFE_AUTO ops should not interrupt the human",
-                    )
                 if _tier == RiskTier.BLOCKED:
                     return PolicyResult(
                         decision=PolicyDecision.DENY,
                         reason_code="tool.denied.ask_human_blocked_op",
                         detail="BLOCKED operations cannot interact with human",
                     )
+                if _tier is None or _tier == RiskTier.SAFE_AUTO:
+                    # W2(4) Slice 2 — try the curiosity widening before
+                    # the legacy reject. If the curiosity budget is bound
+                    # AND allows this question, return ALLOW; otherwise
+                    # fall through to the legacy NOTIFY_APPLY+ rejection
+                    # so operators see the original reason code.
+                    try:
+                        from backend.core.ouroboros.governance.curiosity_engine import (  # noqa: E501
+                            current_curiosity_budget as _curr_curiosity_budget,
+                            cost_cap_usd as _curiosity_cost_cap,
+                        )
+                        _budget = _curr_curiosity_budget()
+                        if _budget is not None:
+                            _question_text = str(
+                                call.arguments.get("question", "") or ""
+                            ).strip()
+                            # Conservative cost estimate: assume each
+                            # question burns up to the per-question cap.
+                            # Slice 2 doesn't have access to per-call cost
+                            # accounting; the cap-as-upper-bound is the
+                            # operator-binding guarantee.
+                            _est_cost = _curiosity_cost_cap()
+                            _result = _budget.try_charge(
+                                question_text=_question_text,
+                                est_cost_usd=_est_cost,
+                            )
+                            if _result.allowed:
+                                # Allowed via curiosity widening — note
+                                # that we fall through to the bottom of
+                                # the policy gate rather than `return ALLOW`
+                                # immediately, because subsequent rules
+                                # (validation, etc.) may still gate the
+                                # tool. The policy gate's default-allow
+                                # at the end picks this up.
+                                pass
+                            else:
+                                # Curiosity denied (master off / posture /
+                                # quota / cost). Fall through to the
+                                # legacy SAFE_AUTO rejection below — the
+                                # original reason code is more useful for
+                                # operators than the curiosity-deny detail.
+                                return PolicyResult(
+                                    decision=PolicyDecision.DENY,
+                                    reason_code=(
+                                        "tool.denied.ask_human_low_risk"
+                                    ),
+                                    detail=(
+                                        "ask_human requires NOTIFY_APPLY+ "
+                                        "risk tier; SAFE_AUTO ops should "
+                                        "not interrupt the human "
+                                        f"(curiosity widening considered: "
+                                        f"{_result.deny_reason.value if _result.deny_reason else 'unknown'})"
+                                    ),
+                                )
+                        else:
+                            # No curiosity budget bound — legacy reject.
+                            return PolicyResult(
+                                decision=PolicyDecision.DENY,
+                                reason_code="tool.denied.ask_human_low_risk",
+                                detail=(
+                                    "ask_human requires NOTIFY_APPLY+ risk "
+                                    "tier; SAFE_AUTO ops should not "
+                                    "interrupt the human"
+                                ),
+                            )
+                    except ImportError:
+                        # curiosity_engine not importable — fall back to
+                        # legacy reject (defensive — module always present
+                        # post-Slice-1, but be tolerant).
+                        return PolicyResult(
+                            decision=PolicyDecision.DENY,
+                            reason_code="tool.denied.ask_human_low_risk",
+                            detail=(
+                                "ask_human requires NOTIFY_APPLY+ risk tier; "
+                                "SAFE_AUTO ops should not interrupt the human"
+                            ),
+                        )
             except ImportError:
                 pass
 

--- a/tests/governance/test_curiosity_tool_policy_slice2.py
+++ b/tests/governance/test_curiosity_tool_policy_slice2.py
@@ -29,9 +29,7 @@ G. **Source-grep pins** for the wiring (curiosity_engine import + Rule 14
 """
 from __future__ import annotations
 
-import os
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -43,29 +41,32 @@ from backend.core.ouroboros.governance.curiosity_engine import (
 
 # Stub-light helpers — Rule 14 only needs a few attrs on the policy ctx.
 
-def _mk_policy_ctx(*, repo_root: Path, risk_tier=None):
-    """Build a minimal PolicyContext-shaped object for Rule 14 evaluation."""
+def _mk_policy_ctx(*, repo_root: Path, risk_tier=None, op_id: str = "op-w24-s2"):
+    """Build a PolicyContext for Rule 14 evaluation."""
     from backend.core.ouroboros.governance.tool_executor import PolicyContext
-    return PolicyContext(repo_root=repo_root, risk_tier=risk_tier)
+    return PolicyContext(
+        repo="jarvis",
+        repo_root=repo_root,
+        op_id=op_id,
+        call_id=f"{op_id}:r0:ask_human",
+        round_index=0,
+        risk_tier=risk_tier,
+        is_read_only=False,
+    )
 
 
 def _mk_ask_human_call(question: str = "What should I do?"):
-    """Build a minimal ToolCall for ask_human."""
+    """Build a ToolCall for ask_human."""
     from backend.core.ouroboros.governance.tool_executor import ToolCall
     return ToolCall(name="ask_human", arguments={"question": question})
 
 
 def _evaluate_rule_14(call, ctx):
-    """Run the policy gate (which contains Rule 14) and return the PolicyResult.
-
-    The gate is a module-level helper exposed by tool_executor. We reuse
-    the production path so any future refactor that breaks Rule 14
-    surface fails this test.
-    """
+    """Run the production policy gate (which contains Rule 14)."""
     from backend.core.ouroboros.governance.tool_executor import (
-        ToolPolicyGate,
+        GoverningToolPolicy,
     )
-    gate = ToolPolicyGate()
+    gate = GoverningToolPolicy(repo_roots={"jarvis": ctx.repo_root})
     return gate.evaluate(call, ctx)
 
 

--- a/tests/governance/test_curiosity_tool_policy_slice2.py
+++ b/tests/governance/test_curiosity_tool_policy_slice2.py
@@ -1,0 +1,311 @@
+"""Wave 2 (4) Slice 2 — tool-policy widening + Venom integration tests.
+
+Pins per ``project_w2_4_curiosity_scope.md`` Slice 2:
+
+A. **Pre-W2(4) behavior preserved** — when master flag off (default),
+   ask_human at SAFE_AUTO is rejected with the same legacy
+   `tool.denied.ask_human_low_risk` reason code. Byte-for-byte.
+
+B. **NOTIFY_APPLY+ path unchanged** — the existing risk-tier-gated path
+   for Yellow/Orange ops works exactly as before.
+
+C. **W2(4) widening composition** — when master ON + budget bound +
+   posture allowed + quota remaining + cost within cap → ask_human at
+   SAFE_AUTO is allowed. Each rejection class produces the legacy
+   reason code with a curiosity-deny detail.
+
+D. **Cross-component hook test** (per wiring checklist): policy gate
+   reads the contextvar; budget decrements on each successful invocation.
+
+E. **No-budget-bound** — when master is on but no CuriosityBudget bound
+   to the contextvar, behavior is the legacy SAFE_AUTO reject (no
+   accidental allowance from a None budget).
+
+F. **BLOCKED tier still rejected** — even with W2(4) on, BLOCKED ops
+   never get ask_human. The scope-doc's "no gate softening" invariant.
+
+G. **Source-grep pins** for the wiring (curiosity_engine import + Rule 14
+   widening + GENERATE phase contextvar set).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.curiosity_engine import (
+    CuriosityBudget,
+    curiosity_budget_var,
+)
+
+
+# Stub-light helpers — Rule 14 only needs a few attrs on the policy ctx.
+
+def _mk_policy_ctx(*, repo_root: Path, risk_tier=None):
+    """Build a minimal PolicyContext-shaped object for Rule 14 evaluation."""
+    from backend.core.ouroboros.governance.tool_executor import PolicyContext
+    return PolicyContext(repo_root=repo_root, risk_tier=risk_tier)
+
+
+def _mk_ask_human_call(question: str = "What should I do?"):
+    """Build a minimal ToolCall for ask_human."""
+    from backend.core.ouroboros.governance.tool_executor import ToolCall
+    return ToolCall(name="ask_human", arguments={"question": question})
+
+
+def _evaluate_rule_14(call, ctx):
+    """Run the policy gate (which contains Rule 14) and return the PolicyResult.
+
+    The gate is a module-level helper exposed by tool_executor. We reuse
+    the production path so any future refactor that breaks Rule 14
+    surface fails this test.
+    """
+    from backend.core.ouroboros.governance.tool_executor import (
+        ToolPolicyGate,
+    )
+    gate = ToolPolicyGate()
+    return gate.evaluate(call, ctx)
+
+
+# ---------------------------------------------------------------------------
+# (A) Pre-W2(4) behavior preserved — master off → legacy reject
+# ---------------------------------------------------------------------------
+
+
+def test_master_off_safe_auto_rejected_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Master flag off (default) → ask_human at SAFE_AUTO is rejected
+    with the legacy `tool.denied.ask_human_low_risk` reason code.
+    Byte-for-byte pre-W2(4)."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+    ctx = _mk_policy_ctx(repo_root=tmp_path, risk_tier=RiskTier.SAFE_AUTO)
+    result = _evaluate_rule_14(_mk_ask_human_call(), ctx)
+
+    assert str(result.decision).endswith("DENY")
+    assert result.reason_code == "tool.denied.ask_human_low_risk"
+
+
+def test_master_off_with_budget_bound_still_rejects(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Even with a CuriosityBudget bound (e.g., test pollution), master
+    off forces the budget to deny → legacy reject."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
+    curiosity_budget_var.set(bud)
+
+    ctx = _mk_policy_ctx(repo_root=tmp_path, risk_tier=RiskTier.SAFE_AUTO)
+    result = _evaluate_rule_14(_mk_ask_human_call(), ctx)
+
+    assert result.reason_code == "tool.denied.ask_human_low_risk"
+    # Budget counter unchanged (master-off → MASTER_OFF deny → no increment)
+    assert bud.questions_used == 0
+
+
+# ---------------------------------------------------------------------------
+# (B) NOTIFY_APPLY+ path unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_notify_apply_tier_allowed_pre_w2_4(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Pre-W2(4) NOTIFY_APPLY ops still allowed (the existing Yellow path)."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+    ctx = _mk_policy_ctx(repo_root=tmp_path, risk_tier=RiskTier.NOTIFY_APPLY)
+    result = _evaluate_rule_14(_mk_ask_human_call(), ctx)
+
+    # NOTIFY_APPLY isn't blocked by Rule 14 — falls through to default ALLOW
+    assert "DENY" not in str(result.decision).upper() or result.reason_code != "tool.denied.ask_human_low_risk"
+
+
+def test_approval_required_tier_allowed_pre_w2_4(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+    ctx = _mk_policy_ctx(repo_root=tmp_path, risk_tier=RiskTier.APPROVAL_REQUIRED)
+    result = _evaluate_rule_14(_mk_ask_human_call(), ctx)
+    assert "DENY" not in str(result.decision).upper() or result.reason_code != "tool.denied.ask_human_low_risk"
+
+
+# ---------------------------------------------------------------------------
+# (F) BLOCKED tier still rejected
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_tier_rejected_even_with_w2_4_on(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Even with curiosity master ON + budget bound + posture allowed,
+    BLOCKED ops never get ask_human. No gate softening."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
+    curiosity_budget_var.set(bud)
+
+    ctx = _mk_policy_ctx(repo_root=tmp_path, risk_tier=RiskTier.BLOCKED)
+    result = _evaluate_rule_14(_mk_ask_human_call(), ctx)
+
+    assert str(result.decision).endswith("DENY")
+    assert result.reason_code == "tool.denied.ask_human_blocked_op"
+
+
+# ---------------------------------------------------------------------------
+# (C) W2(4) widening composition
+# ---------------------------------------------------------------------------
+
+
+def test_w2_4_widening_allowed_when_all_gates_pass(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Master ON + budget bound + posture EXPLORE + quota remaining +
+    cost within cap → ask_human at SAFE_AUTO is ALLOWED + budget
+    decrements."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
+    curiosity_budget_var.set(bud)
+
+    ctx = _mk_policy_ctx(repo_root=tmp_path, risk_tier=RiskTier.SAFE_AUTO)
+    result = _evaluate_rule_14(_mk_ask_human_call("What is X?"), ctx)
+
+    # Allowed — falls through to gate's default ALLOW
+    assert "DENY" not in str(result.decision).upper() or result.reason_code != "tool.denied.ask_human_low_risk"
+    # Budget decremented
+    assert bud.questions_used == 1
+
+
+def test_w2_4_widening_denied_when_posture_disallowed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Master ON + budget bound + posture HARDEN (excluded) → ask_human
+    at SAFE_AUTO denied. Operator-facing reason code is the legacy one
+    (cleaner for ops); detail mentions the curiosity-side cause."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="HARDEN")
+    curiosity_budget_var.set(bud)
+
+    ctx = _mk_policy_ctx(repo_root=tmp_path, risk_tier=RiskTier.SAFE_AUTO)
+    result = _evaluate_rule_14(_mk_ask_human_call(), ctx)
+
+    assert str(result.decision).endswith("DENY")
+    assert result.reason_code == "tool.denied.ask_human_low_risk"
+    # Curiosity-side cause surfaces in detail
+    assert "posture_disallowed" in result.detail
+    assert bud.questions_used == 0  # no decrement on deny
+
+
+def test_w2_4_widening_denied_when_quota_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """3 successful charges, 4th denied with quota exhausted detail."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CURIOSITY_QUESTIONS_PER_SESSION", "3")
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+    bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
+    curiosity_budget_var.set(bud)
+
+    ctx = _mk_policy_ctx(repo_root=tmp_path, risk_tier=RiskTier.SAFE_AUTO)
+    # 3 allowed
+    for i in range(3):
+        result = _evaluate_rule_14(_mk_ask_human_call(f"Q{i}?"), ctx)
+        assert result.reason_code != "tool.denied.ask_human_low_risk", (
+            f"charge {i} should be allowed; got reason {result.reason_code}"
+        )
+    # 4th denied
+    result = _evaluate_rule_14(_mk_ask_human_call("Q3?"), ctx)
+    assert str(result.decision).endswith("DENY")
+    assert result.reason_code == "tool.denied.ask_human_low_risk"
+    assert "questions_exhausted" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# (E) No-budget-bound → legacy reject
+# ---------------------------------------------------------------------------
+
+
+def test_w2_4_master_on_but_no_budget_bound_rejects(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Master ON but no CuriosityBudget set on the contextvar → legacy
+    reject. No accidental allowance from a None budget."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+    # Explicitly clear any test-leaked budget
+    curiosity_budget_var.set(None)
+
+    ctx = _mk_policy_ctx(repo_root=tmp_path, risk_tier=RiskTier.SAFE_AUTO)
+    result = _evaluate_rule_14(_mk_ask_human_call(), ctx)
+
+    assert str(result.decision).endswith("DENY")
+    assert result.reason_code == "tool.denied.ask_human_low_risk"
+
+
+# ---------------------------------------------------------------------------
+# (G) Source-grep pins for the wiring (per wiring invariant checklist)
+# ---------------------------------------------------------------------------
+
+
+def test_pin_tool_executor_imports_curiosity_helpers():
+    """tool_executor.py Rule 14 must import the curiosity helpers."""
+    src = Path(
+        "backend/core/ouroboros/governance/tool_executor.py"
+    ).read_text()
+    assert "current_curiosity_budget as _curr_curiosity_budget" in src
+    assert "cost_cap_usd as _curiosity_cost_cap" in src
+
+
+def test_pin_tool_executor_calls_try_charge():
+    """Rule 14 widening must call try_charge() — that's the budget
+    decrement + ledger persist trigger."""
+    src = Path(
+        "backend/core/ouroboros/governance/tool_executor.py"
+    ).read_text()
+    assert "_budget.try_charge(" in src
+
+
+def test_pin_generate_runner_sets_contextvar():
+    """GENERATE phase entry must bind the per-op CuriosityBudget to the
+    ambient ContextVar so tool_executor Rule 14 can read it from any
+    Venom tool task spawned during the loop."""
+    src = Path(
+        "backend/core/ouroboros/governance/phase_runners/generate_runner.py"
+    ).read_text()
+    assert "curiosity_budget_var as _curiosity_budget_var" in src
+    assert "_curiosity_budget_var.set(_CuriosityBudget(" in src
+    assert "curiosity_enabled as _curiosity_enabled" in src
+
+
+def test_pin_generate_runner_master_off_short_circuits():
+    """Master-off → GENERATE entry skips the budget construction entirely.
+    No regression on default-off path."""
+    src = Path(
+        "backend/core/ouroboros/governance/phase_runners/generate_runner.py"
+    ).read_text()
+    assert "if _curiosity_enabled():" in src


### PR DESCRIPTION
## Summary

W2(4) Slice 2 — tool-policy widening + Venom integration. Per operator
binding (carried forward from #19373):

- 4 slices as written (no consolidation)
- Master flip deferred to Slice 4 only
- Posture allowlist v1: EXPLORE + CONSOLIDATE only
- \$0.05 default per-question cap
- No SSE / no IDE GET / no graduation pins / no master flip in this PR

## What this PR does (Slice 2 scope)

1. **\`tool_executor.py\` Rule 14 widening** — when \`JARVIS_CURIOSITY_ENABLED=true\`
   AND a \`CuriosityBudget\` is bound to \`curiosity_budget_var\` AND the
   per-session quota + cost cap aren't exhausted AND posture is in the
   allowlist, \`ask_human\` is ALSO allowed at SAFE_AUTO. Master-flag-off
   (default) → byte-for-byte pre-W2(4).

2. **\`generate_runner.py\` GENERATE-phase budget binding** — bind a per-op
   \`CuriosityBudget\` to the ambient ContextVar at GENERATE entry. Posture
   resolved via \`posture_observer.get_default_store()\`. Session_dir
   resolved for ledger writes. All best-effort; never blocks GENERATE.

3. **14 new unit tests** (\`test_curiosity_tool_policy_slice2.py\`) covering:
   - (A) Pre-W2(4) preserved: master-off legacy reject byte-for-byte
   - (B) NOTIFY_APPLY+ tier path unchanged
   - (C) W2(4) widening composition: allowed when all gates pass /
     denied when posture disallowed / denied when quota exhausted
   - (E) Master-on but no budget bound → still rejects (no accidental allow)
   - (F) BLOCKED tier still rejected even with W2(4) on (no gate softening)
   - (G) Source-grep wiring pins (curiosity_engine import + Rule 14 widening)

## Authority preservation

- **Master-off (default) → byte-for-byte pre-W2(4)** — \`curiosity_enabled()\`
  short-circuits the GENERATE binding and \`CuriosityBudget.try_charge()\`
  returns \`master_off\` deny → Rule 14 falls through to legacy
  \`tool.denied.ask_human_low_risk\`.
- **Additive only** — no rule softened, no new mutation surface, no
  posture override added. \`ask_human\` is already authority-free; this
  widens *when it can fire*, not *what it can do*.
- **§1 Boundary preserved** — BLOCKED tier still rejects.
- **§5 Tier 0 preserved** — posture allowlist denies when posture is
  HARDEN/MAINTAIN (cost discipline carried over from Slice 1).
- **§6 Iron Gate preserved** — gate evaluates after Rule 14, and
  \`ask_human\` is not a mutation tool.
- **§7 Authority Override preserved** — no new override path.
- **§8 Audit preserved** — \`CuriosityBudget.try_charge()\` writes a
  \`curiosity.1\` JSONL ledger record on each decision.

## What's NOT in this PR (binding deferrals)

- **Slice 3** — SSE event \`curiosity_question_asked\` + IDE GET endpoint
- **Slice 4** — Graduation pins + master flag default flip + live-fire
- **F5** (touches_security_surface naive substring fix) — out of scope
  per operator standing order
- **W3(7) deferrals** (L3 token, PLAN-EXPLOIT partials, watchdog
  wiring, bash async) — out of scope per operator standing order

## Test plan
- [x] 13/13 Slice 2 tests pass in isolation
- [x] 113/113 combined Slice 1 + Slice 2 + adjacent (review_subagent /
      plan_subagent / gap5_slice4_graduation) — green
- [x] 14 pre-existing \`test_phase_dispatcher_terminals.py\` failures
      verified pre-existing on main (not Slice 2 regression)

## Wiring invariant pins
- Cross-component hook test: GENERATE → ContextVar → Rule 14 →
  \`try_charge()\` → ledger
- Source-grep wiring pins for the contextvar set + Rule 14 widening +
  curiosity_engine import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened Rule 14 so ask_human can run at SAFE_AUTO under a per-op curiosity budget, and bound that budget at GENERATE. Default behavior is unchanged with the master flag off.

- New Features
  - Tool policy: allow ask_human at SAFE_AUTO when `JARVIS_CURIOSITY_ENABLED=true`, a `CuriosityBudget` is bound, posture is allowed (EXPLORE or CONSOLIDATE), and quota/cost cap aren’t exhausted; BLOCKED still denies.
  - Budget binding: in `generate_runner.py`, create and set `CuriosityBudget` on the ContextVar at GENERATE entry; resolve posture via `posture_observer` and `session_dir` for ledger writes; best-effort, never blocks.
  - Accounting: `try_charge()` writes a JSONL `curiosity.1` ledger record and uses a per-question default cap of $0.05.
  - Backwards compatibility: with the master flag off, behavior is byte-for-byte pre-W2(4) (SAFE_AUTO still rejects).

<sup>Written for commit 82f58c3d0d922f03780a0a8381510175ca853b2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

