### PR TITLE
feat(curiosity): W2(4) Slice 3 — SSE bridge + IDE GET routes

### DIFF
--- a/backend/core/ouroboros/governance/curiosity_engine.py
+++ b/backend/core/ouroboros/governance/curiosity_engine.py
@@ -1,9 +1,13 @@
-"""Wave 2 (4) Slice 1 — Curiosity engine primitive + per-op budget tracker.
+"""Wave 2 (4) Curiosity engine primitive + per-op budget tracker.
 
-Per ``project_w2_4_curiosity_scope.md`` Slice 1 (operator-authorized
-2026-04-25). Ships the in-memory primitive + ContextVar transport + JSONL
-ledger + 4 env knobs. Does NOT widen tool policy (Slice 2), publish SSE
-events (Slice 3), or flip the master flag (Slice 4).
+Slice 1 (2026-04-25) — primitive + ContextVar + JSONL ledger + 4 env knobs.
+Slice 2 (2026-04-25) — Rule 14 widening + GENERATE phase budget binding.
+Slice 3 (2026-04-25) — SSE bridge + IDE GET routes (this slice).
+
+Slice 3 adds the ``JARVIS_CURIOSITY_SSE_ENABLED`` sub-flag (default
+``false``) and the :func:`bridge_curiosity_to_sse` helper (mirrors
+W3(7) ``bridge_cancel_origin_to_sse``). Master-off → SSE force-off.
+Master flip + graduation pins are deferred to Slice 4.
 
 Authority posture (per scope doc):
 
@@ -120,6 +124,21 @@ def posture_allowlist() -> frozenset:
         for part in raw.split(",")
         if part.strip()
     )
+
+
+def sse_enabled() -> bool:
+    """`JARVIS_CURIOSITY_SSE_ENABLED` — default ``false`` (operator opt-in).
+
+    Slice 3 sub-flag. Mirrors W3(7) ``cancel_token.sse_enabled()``: even
+    when curiosity master is on + persistence on, the SSE publish stays
+    off until the operator explicitly opts in. Composition: master-off
+    forces SSE-off (no event ever leaks past the gate). The IDE stream's
+    own master flag (`JARVIS_IDE_STREAM_ENABLED`) is consulted at publish
+    time too — both gates must be on for an event to land on the broker.
+    """
+    if not curiosity_enabled():
+        return False
+    return _env_bool("JARVIS_CURIOSITY_SSE_ENABLED", False)
 
 
 def ledger_persist_enabled() -> bool:
@@ -370,6 +389,11 @@ class CuriosityBudget:
         # Persist to ledger (best-effort).
         if ledger_persist_enabled() and self.session_dir is not None:
             self._persist(record)
+        # Slice 3 — bridge to SSE (best-effort, gated by master + sub-flag
+        # + IDE stream master). Both allowed and denied records are
+        # surfaced so operators can see the full curiosity audit trail
+        # in the live stream — same shape as cancel_origin_emitted.
+        bridge_curiosity_to_sse(record)
         return ChargeResult(
             allowed=allowed,
             question_id=question_id if allowed else None,
@@ -423,6 +447,57 @@ def current_curiosity_budget() -> Optional[CuriosityBudget]:
     return curiosity_budget_var.get()
 
 
+# ---------------------------------------------------------------------------
+# Slice 3 — SSE bridge
+# ---------------------------------------------------------------------------
+
+
+def bridge_curiosity_to_sse(record: "CuriosityRecord") -> None:
+    """Publish a ``curiosity_question_emitted`` SSE event for ``record``.
+
+    Slice 3 (W2(4)). Best-effort, never raises. Gated by:
+
+    1. :func:`sse_enabled` — curiosity master + curiosity SSE sub-flag.
+    2. :func:`ide_observability_stream.stream_enabled` — IDE stream master.
+
+    Both must be on for the event to land on the broker. The payload is
+    a summary form (question_id, op_id, posture, result, question text
+    truncated to 80 chars). Full record stays in
+    ``curiosity_ledger.jsonl`` and at the
+    ``/observability/curiosity/<question_id>`` GET endpoint.
+
+    Mirrors ``cancel_token.bridge_cancel_origin_to_sse`` byte-for-byte
+    in error handling: never raises, swallows ImportError /
+    AttributeError / broker-publish exceptions silently.
+    """
+    if not sse_enabled():
+        return
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            EVENT_TYPE_CURIOSITY_QUESTION_EMITTED as _EV_TYPE,
+            get_default_broker as _get_default_broker,
+            stream_enabled as _stream_enabled,
+        )
+        if not _stream_enabled():
+            return
+        _broker = _get_default_broker()
+        if _broker is None:
+            return
+        _broker.publish(
+            event_type=_EV_TYPE,
+            op_id=record.op_id,
+            payload={
+                "question_id": record.question_id,
+                "posture": record.posture_at_charge,
+                "result": record.result,
+                # Truncate model-supplied text — full text in ledger.
+                "question_text": record.question_text[:80],
+            },
+        )
+    except Exception:  # noqa: BLE001 — SSE publish is best-effort
+        pass
+
+
 __all__ = [
     "CuriosityBudget",
     "CuriosityRecord",
@@ -435,4 +510,6 @@ __all__ = [
     "cost_cap_usd",
     "posture_allowlist",
     "ledger_persist_enabled",
+    "sse_enabled",
+    "bridge_curiosity_to_sse",
 ]

--- a/backend/core/ouroboros/governance/ide_observability.py
+++ b/backend/core/ouroboros/governance/ide_observability.py
@@ -248,6 +248,14 @@ class IDEObservabilityRouter:
             "/observability/cancels/{cancel_id}",
             self._handle_cancel_detail,
         )
+        # W2(4) Slice 3 — curiosity question record surface.
+        app.router.add_get(
+            "/observability/curiosity", self._handle_curiosity_list,
+        )
+        app.router.add_get(
+            "/observability/curiosity/{question_id}",
+            self._handle_curiosity_detail,
+        )
 
     # --- request-path helpers ---------------------------------------------
 
@@ -1299,5 +1307,130 @@ class IDEObservabilityRouter:
                 return self._json_response(request, 200, r)
         return self._error_response(
             request, 404, "ide_observability.cancel_not_found",
+        )
+
+    # --- W2(4) Slice 3 — curiosity record surface ------------------------
+
+    def _read_curiosity_records(self) -> Tuple[List[Dict[str, Any]], int]:
+        """Read all records from curiosity_ledger.jsonl in session_dir.
+
+        Returns ``(records, parse_error_count)``. Never raises. Mirrors
+        :meth:`_read_cancel_records` byte-for-byte (same JSONL contract).
+        """
+        if self._session_dir is None:
+            return [], 0
+        artifact = self._session_dir / "curiosity_ledger.jsonl"
+        if not artifact.exists():
+            return [], 0
+        records: List[Dict[str, Any]] = []
+        parse_errors = 0
+        try:
+            text = artifact.read_text(encoding="utf-8")
+        except Exception:  # noqa: BLE001
+            return [], 0
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+                if isinstance(rec, dict):
+                    records.append(rec)
+            except (ValueError, TypeError):
+                parse_errors += 1
+        return records, parse_errors
+
+    async def _handle_curiosity_list(self, request: "web.Request") -> Any:
+        """GET /observability/curiosity — list of CuriosityRecord projections.
+
+        Query params (optional):
+          * ``op_id``   — filter to a specific op (exact match).
+          * ``result``  — filter by result substring (e.g. ``allowed`` for
+                          successful charges, ``denied:`` for any deny).
+          * ``limit``   — 1..1000 (default 100).
+
+        Shape::
+
+            {"schema_version": "1.0", "records": [...], "count": N,
+             "parse_errors": K}
+
+        503 when no session_dir is bound (IDE-only mount, no harness).
+        """
+        if not ide_observability_enabled():
+            return self._error_response(
+                request, 403, "ide_observability.disabled",
+            )
+        if not self._check_rate_limit(self._client_key(request)):
+            return self._error_response(
+                request, 429, "ide_observability.rate_limited",
+            )
+        if self._session_dir is None:
+            return self._error_response(
+                request, 503, "ide_observability.curiosity_unavailable",
+            )
+        try:
+            limit = int(request.query.get("limit", "100"))
+        except ValueError:
+            return self._error_response(
+                request, 400, "ide_observability.malformed_limit",
+            )
+        if limit < 1 or limit > 1000:
+            return self._error_response(
+                request, 400, "ide_observability.malformed_limit",
+            )
+        records, parse_errors = self._read_curiosity_records()
+        # Filters
+        op_id_filter = request.query.get("op_id", "").strip()
+        result_filter = request.query.get("result", "").strip()
+        filtered = []
+        for r in records:
+            if op_id_filter and r.get("op_id") != op_id_filter:
+                continue
+            if result_filter and not str(r.get("result", "")).startswith(
+                result_filter
+            ):
+                continue
+            filtered.append(r)
+        # Newest-last is the natural JSONL order; UI usually wants
+        # newest-first, so reverse for the response.
+        filtered.reverse()
+        truncated = filtered[:limit]
+        return self._json_response(
+            request, 200,
+            {
+                "schema_version": "1.0",
+                "records": truncated,
+                "count": len(truncated),
+                "parse_errors": parse_errors,
+            },
+        )
+
+    async def _handle_curiosity_detail(self, request: "web.Request") -> Any:
+        """GET /observability/curiosity/{question_id} — full CuriosityRecord."""
+        if not ide_observability_enabled():
+            return self._error_response(
+                request, 403, "ide_observability.disabled",
+            )
+        if not self._check_rate_limit(self._client_key(request)):
+            return self._error_response(
+                request, 429, "ide_observability.rate_limited",
+            )
+        if self._session_dir is None:
+            return self._error_response(
+                request, 503, "ide_observability.curiosity_unavailable",
+            )
+        question_id = request.match_info.get("question_id", "").strip()
+        if not question_id or not re.match(
+            r"^[A-Za-z0-9_\-:.]{1,128}$", question_id,
+        ):
+            return self._error_response(
+                request, 400, "ide_observability.malformed_question_id",
+            )
+        records, _ = self._read_curiosity_records()
+        for r in records:
+            if r.get("question_id") == question_id:
+                return self._json_response(request, 200, r)
+        return self._error_response(
+            request, 404, "ide_observability.curiosity_not_found",
         )
 

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -172,6 +172,14 @@ EVENT_TYPE_SESSION_UNPINNED = "session_unpinned"
 # ``/observability/cancels/<cancel_id>`` GET endpoint.
 EVENT_TYPE_CANCEL_ORIGIN_EMITTED = "cancel_origin_emitted"
 
+# W2(4) Slice 3 — curiosity question SSE event (additive). Payload schema
+# per scope doc §6: ``{"event": "curiosity_question_emitted", "data":
+# {"question_id": str, "op_id": str, "posture": str, "result": str,
+# "question_text": str (<=80 chars)}}``. Full record (with cost burn,
+# monotonic timestamp, full question text) lives at the
+# ``/observability/curiosity/<question_id>`` GET endpoint.
+EVENT_TYPE_CURIOSITY_QUESTION_EMITTED = "curiosity_question_emitted"
+
 _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_TASK_CREATED,
     EVENT_TYPE_TASK_STARTED,
@@ -213,6 +221,7 @@ _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_MEMORY_PRESSURE_CHANGED,
     EVENT_TYPE_MEMORY_FANOUT_DECISION,
     EVENT_TYPE_CANCEL_ORIGIN_EMITTED,  # W3(7) Slice 6
+    EVENT_TYPE_CURIOSITY_QUESTION_EMITTED,  # W2(4) Slice 3
 })
 
 

--- a/tests/governance/test_curiosity_sse_ide_get_slice3.py
+++ b/tests/governance/test_curiosity_sse_ide_get_slice3.py
@@ -1,0 +1,370 @@
+"""Wave 2 (4) Slice 3 — SSE event + IDE GET endpoint curiosity observability.
+
+Per ``project_w2_4_curiosity_scope.md`` Slice 3:
+
+* Additive ``curiosity_question_emitted`` SSE event (12th in the IDE
+  stream vocab — additive-only contract preserved).
+* ``JARVIS_CURIOSITY_SSE_ENABLED`` sub-flag (default ``false``,
+  operator opt-in). Master-off → SSE force-off (composition).
+* New ``GET /observability/curiosity`` and
+  ``/observability/curiosity/{question_id}`` endpoints reading from
+  the ``curiosity_ledger.jsonl`` artifact (Slice 1).
+
+Coverage:
+
+A. SSE event vocabulary — ``EVENT_TYPE_CURIOSITY_QUESTION_EMITTED``
+   in ``_VALID_EVENT_TYPES``.
+B. ``sse_enabled()`` flag composition — master gates sub-flag.
+C. ``bridge_curiosity_to_sse`` — gating, payload shape, never raises.
+D. End-to-end ``try_charge`` → SSE publish when all flags on.
+E. Master-off invariant — no SSE event emitted when master off.
+F. IDE GET endpoint — list, filter, detail, malformed id, 503 paths.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.curiosity_engine import (
+    CuriosityBudget,
+    CuriosityRecord,
+    bridge_curiosity_to_sse,
+    sse_enabled,
+)
+
+
+def _make_record(
+    *,
+    op_id: str = "op-test-001",
+    question_id: str = "qid-1",
+    posture: str = "EXPLORE",
+    result: str = "allowed",
+    question_text: str = "what should I do?",
+) -> CuriosityRecord:
+    return CuriosityRecord(
+        schema_version="curiosity.1",
+        question_id=question_id,
+        op_id=op_id,
+        posture_at_charge=posture,
+        question_text=question_text,
+        est_cost_usd=0.05,
+        issued_at_monotonic=0.0,
+        issued_at_iso="2026-04-25T01:23:45Z",
+        result=result,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (A) SSE event type vocabulary pin
+# ---------------------------------------------------------------------------
+
+
+def test_curiosity_question_emitted_in_event_vocabulary() -> None:
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        EVENT_TYPE_CURIOSITY_QUESTION_EMITTED,
+        _VALID_EVENT_TYPES,
+    )
+    assert EVENT_TYPE_CURIOSITY_QUESTION_EMITTED == "curiosity_question_emitted"
+    assert EVENT_TYPE_CURIOSITY_QUESTION_EMITTED in _VALID_EVENT_TYPES
+
+
+# ---------------------------------------------------------------------------
+# (B) sse_enabled flag composition (master gates sub-flag)
+# ---------------------------------------------------------------------------
+
+
+def test_sse_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Master off (default) → sse_enabled() returns False regardless of sub-flag."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_CURIOSITY_SSE_ENABLED", raising=False)
+    assert sse_enabled() is False
+
+
+def test_sse_flag_master_off_forces_sub_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Master off + sub on → still off (master-off composition)."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
+    assert sse_enabled() is False
+
+
+def test_sse_flag_master_on_sub_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Master on + sub off (default) → sse_enabled() False (operator opt-in)."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CURIOSITY_SSE_ENABLED", raising=False)
+    assert sse_enabled() is False
+
+
+def test_sse_flag_master_on_sub_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Master on + sub on → sse_enabled() True."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
+    assert sse_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# (C) bridge_curiosity_to_sse — gating + payload shape + never-raise
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_no_op_when_master_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Master off → bridge no-ops, no exception."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
+    bridge_curiosity_to_sse(_make_record())  # must not raise
+
+
+def test_bridge_no_op_when_sse_sub_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Master on but sub off → no publish, no exception."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CURIOSITY_SSE_ENABLED", raising=False)
+
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        get_default_broker,
+        reset_default_broker,
+    )
+    reset_default_broker()
+    broker = get_default_broker()
+    pre = broker.published_count
+
+    bridge_curiosity_to_sse(_make_record())
+    assert broker.published_count == pre
+    reset_default_broker()
+
+
+def test_bridge_publishes_when_all_flags_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All flags on → broker.publish called with correct payload shape."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
+
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        EVENT_TYPE_CURIOSITY_QUESTION_EMITTED,
+        get_default_broker,
+        reset_default_broker,
+    )
+    reset_default_broker()
+    broker = get_default_broker()
+    pre = broker.published_count
+
+    rec = _make_record(
+        op_id="op-bridge-001",
+        question_id="qid-bridge-1",
+        posture="EXPLORE",
+        result="allowed",
+        question_text="what should I do here?",
+    )
+    bridge_curiosity_to_sse(rec)
+
+    assert broker.published_count == pre + 1
+    history = list(broker._history)  # noqa: SLF001 — test-only inspection
+    last = history[-1]
+    assert last.event_type == EVENT_TYPE_CURIOSITY_QUESTION_EMITTED
+    assert last.op_id == "op-bridge-001"
+    assert last.payload["question_id"] == "qid-bridge-1"
+    assert last.payload["posture"] == "EXPLORE"
+    assert last.payload["result"] == "allowed"
+    assert last.payload["question_text"] == "what should I do here?"
+    reset_default_broker()
+
+
+def test_bridge_truncates_question_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Question text >80 chars is truncated in the SSE payload."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
+
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        get_default_broker,
+        reset_default_broker,
+    )
+    reset_default_broker()
+    broker = get_default_broker()
+
+    long_text = "x" * 200
+    bridge_curiosity_to_sse(_make_record(question_text=long_text))
+
+    last = list(broker._history)[-1]  # noqa: SLF001
+    assert len(last.payload["question_text"]) == 80
+    reset_default_broker()
+
+
+def test_bridge_never_raises_on_broker_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Broker construction failure → bridge swallows, no raise."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
+
+    import backend.core.ouroboros.governance.ide_observability_stream as stream_mod
+
+    def _broken():
+        raise RuntimeError("broker construction failed")
+
+    monkeypatch.setattr(stream_mod, "get_default_broker", _broken)
+    bridge_curiosity_to_sse(_make_record())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# (D + E) End-to-end try_charge → SSE publish + master-off no-publish
+# ---------------------------------------------------------------------------
+
+
+def test_try_charge_allowed_publishes_sse_when_all_flags_on(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Allowed try_charge fires the bridge → broker has the event."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
+
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        EVENT_TYPE_CURIOSITY_QUESTION_EMITTED,
+        get_default_broker,
+        reset_default_broker,
+    )
+    reset_default_broker()
+    broker = get_default_broker()
+    pre = broker.published_count
+
+    bud = CuriosityBudget(
+        op_id="op-e2e-001",
+        posture_at_arm="EXPLORE",
+        session_dir=tmp_path,
+    )
+    result = bud.try_charge(question_text="what next?", est_cost_usd=0.01)
+    assert result.allowed is True
+
+    assert broker.published_count == pre + 1
+    last = list(broker._history)[-1]  # noqa: SLF001
+    assert last.event_type == EVENT_TYPE_CURIOSITY_QUESTION_EMITTED
+    assert last.op_id == "op-e2e-001"
+    assert last.payload["result"] == "allowed"
+    reset_default_broker()
+
+
+def test_try_charge_master_off_publishes_no_sse(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Master off → try_charge denies + no SSE publish (master-off invariant)."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
+
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        get_default_broker,
+        reset_default_broker,
+    )
+    reset_default_broker()
+    broker = get_default_broker()
+    pre = broker.published_count
+
+    bud = CuriosityBudget(
+        op_id="op-master-off",
+        posture_at_arm="EXPLORE",
+        session_dir=tmp_path,
+    )
+    result = bud.try_charge(question_text="x", est_cost_usd=0.01)
+    assert result.allowed is False
+    # Master-off → SSE gate denies even though sub + stream are on
+    assert broker.published_count == pre
+    reset_default_broker()
+
+
+# ---------------------------------------------------------------------------
+# (F) IDE GET endpoint — JSONL read + helpers
+# ---------------------------------------------------------------------------
+
+
+def test_router_reads_curiosity_records_from_artifact(tmp_path: Path) -> None:
+    from backend.core.ouroboros.governance.ide_observability import (
+        IDEObservabilityRouter,
+    )
+
+    artifact = tmp_path / "curiosity_ledger.jsonl"
+    rec_a = _make_record(op_id="op-a", question_id="qid-a")
+    rec_b = _make_record(
+        op_id="op-b", question_id="qid-b", result="denied:posture_disallowed",
+    )
+    artifact.write_text(
+        rec_a.to_jsonl() + rec_b.to_jsonl(), encoding="utf-8",
+    )
+
+    router = IDEObservabilityRouter(session_dir=tmp_path)
+    records, parse_errors = router._read_curiosity_records()
+    assert parse_errors == 0
+    assert len(records) == 2
+    assert records[0]["question_id"] == "qid-a"
+    assert records[1]["question_id"] == "qid-b"
+
+
+def test_router_curiosity_no_artifact(tmp_path: Path) -> None:
+    """No file → empty list, zero parse errors."""
+    from backend.core.ouroboros.governance.ide_observability import (
+        IDEObservabilityRouter,
+    )
+    router = IDEObservabilityRouter(session_dir=tmp_path)
+    records, parse_errors = router._read_curiosity_records()
+    assert records == []
+    assert parse_errors == 0
+
+
+def test_router_curiosity_no_session_dir() -> None:
+    """No session_dir bound → empty list (handler returns 503 — verified
+    via gate check in production path; this tests the helper contract)."""
+    from backend.core.ouroboros.governance.ide_observability import (
+        IDEObservabilityRouter,
+    )
+    router = IDEObservabilityRouter(session_dir=None)
+    records, parse_errors = router._read_curiosity_records()
+    assert records == []
+    assert parse_errors == 0
+
+
+def test_router_curiosity_counts_parse_errors(tmp_path: Path) -> None:
+    """Malformed JSONL lines counted, valid lines still parsed."""
+    from backend.core.ouroboros.governance.ide_observability import (
+        IDEObservabilityRouter,
+    )
+    artifact = tmp_path / "curiosity_ledger.jsonl"
+    rec = _make_record(question_id="qid-good")
+    artifact.write_text(
+        rec.to_jsonl() + "{not valid json\n" + "[]\n",
+        encoding="utf-8",
+    )
+    router = IDEObservabilityRouter(session_dir=tmp_path)
+    records, parse_errors = router._read_curiosity_records()
+    assert len(records) == 1
+    assert records[0]["question_id"] == "qid-good"
+    assert parse_errors == 1
+
+
+# ---------------------------------------------------------------------------
+# (G) Route registration pin — ensures the GETs are wired
+# ---------------------------------------------------------------------------
+
+
+def test_curiosity_routes_registered() -> None:
+    """The list + detail GET routes are registered on the app router."""
+    from aiohttp import web
+
+    from backend.core.ouroboros.governance.ide_observability import (
+        IDEObservabilityRouter,
+    )
+
+    app = web.Application()
+    router = IDEObservabilityRouter(session_dir=None)
+    router.register_routes(app)
+
+    paths = sorted(
+        getattr(r, "resource", r).canonical for r in app.router.routes()
+    )
+    assert "/observability/curiosity" in paths
+    assert "/observability/curiosity/{question_id}" in paths


### PR DESCRIPTION
## Summary

W2(4) Slice 3 — SSE event surface + IDE GET routes for the curiosity
ledger artifact. Per operator binding (carried forward from #19373 / #19410):

- 4 slices as written
- **NO master flip** in this PR (Slice 4 owns)
- **NO graduation pins** in this PR (Slice 4 owns)
- **NO live-fire** (Slice 4 owns formal live-fire; per operator: optional dev smoke after Slice 2 only)

> **Stack note**: this PR is stacked on #19410 (Slice 2). When Slice 2
> merges, this diff against main will collapse to 2 commits.

## What this PR does (Slice 3 scope)

### 1. \`curiosity_engine.py\` — SSE flag + bridge helper
- Add \`JARVIS_CURIOSITY_SSE_ENABLED\` env knob (default \`false\` —
  operator opt-in even when curiosity master is on).
- \`sse_enabled()\` composition: master-off forces sub-off, mirroring
  W3(7) cancel master-off semantics.
- New \`bridge_curiosity_to_sse(record)\` helper — best-effort, never
  raises, gated by both \`sse_enabled()\` AND \`stream_enabled()\`.
- Hook bridge from \`_record_decision\` after \`_persist\`.

### 2. \`ide_observability_stream.py\` — additive event vocab
- \`EVENT_TYPE_CURIOSITY_QUESTION_EMITTED = \"curiosity_question_emitted\"\`
- Added to \`_VALID_EVENT_TYPES\` (12th event in vocabulary, additive only).

### 3. \`ide_observability.py\` — read-only GET routes
- \`GET /observability/curiosity\` — list with filters (\`op_id\`,
  \`result\` substring, \`limit\` 1..1000, default 100, newest-first).
- \`GET /observability/curiosity/{question_id}\` — detail (200 / 404 /
  400 malformed / 503 no session_dir).
- \`_read_curiosity_records\` helper mirrors \`_read_cancel_records\`
  byte-for-byte (same JSONL contract).

### 4. 17 new unit tests (\`test_curiosity_sse_ide_get_slice3.py\`)
- (A) Event vocabulary pin
- (B) sse_enabled flag composition (4 tests)
- (C) Bridge gating + payload shape + truncation + never-raise (5 tests)
- (D+E) End-to-end \`try_charge\` → SSE publish + master-off no-publish (2 tests)
- (F) IDE GET helpers — read, missing artifact, no session_dir, parse errors (4 tests)
- (G) Route registration pin (1 test)

## Authority preservation

- **Master-off → SSE force-off** — \`sse_enabled()\` returns False
  whenever \`curiosity_enabled()\` is False, regardless of sub-flag.
  Test pins this composition.
- **Two-flag composition** — both \`JARVIS_CURIOSITY_SSE_ENABLED\` AND
  \`JARVIS_IDE_STREAM_ENABLED\` required for publish to land on broker.
- **Question text truncated** to 80 chars in SSE payload (full text
  stays in ledger + at the GET detail endpoint).
- **§1 additive only** — no rule softened, no new mutation surface.
  Adds *additional* observability surfaces only.
- **§5 Tier 0 preserved** — posture allowlist unchanged.
- **§6 Iron Gate preserved** — \`ask_human\` not gated by Iron Gate.
- **§7 Approval surface untouched.**
- **§8 Audit preserved + extended** — same JSONL ledger from Slice 1
  is now also queryable via GET endpoint and stream.

## What's NOT in this PR (binding deferrals)

- **Slice 4** — Graduation pins + master flag default flip + live-fire
- **F5** (touches_security_surface) — out of scope per operator standing order
- **W3(7) deferrals** — out of scope per operator standing order

## Test plan
- [x] 17/17 Slice 3 tests pass in isolation
- [x] 158/158 combined regression green (Slice 1 + Slice 2 + Slice 3
      + cancel SSE Slice 6 + ide_observability + ide_observability_stream)

## Wiring invariant pins
- Cross-component hook test: \`try_charge\` ALLOWED → bridge fires →
  broker captures event with correct \`event_type\` + \`op_id\` + payload
- Master-off invariant pin: \`try_charge\` denies + zero broker
  publishes when master off, even with sub + stream both on
- Source-grep wiring pin: GET routes registered on \`web.Application\`
  router (\`/observability/curiosity\` + \`/observability/curiosity/{question_id}\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an SSE event bridge for curiosity questions and read-only IDE GET endpoints to inspect the curiosity ledger. Improves live observability; the curiosity master flag remains off by default.

- **New Features**
  - Added `JARVIS_CURIOSITY_SSE_ENABLED` (default false). SSE publish requires curiosity master, `JARVIS_CURIOSITY_SSE_ENABLED`, and `JARVIS_IDE_STREAM_ENABLED`.
  - New `curiosity_question_emitted` event added to the IDE stream vocabulary.
  - `bridge_curiosity_to_sse(record)` is best-effort, never raises, and truncates `question_text` to 80 chars; called after ledger persist in `_record_decision`.
  - IDE GET routes: `GET /observability/curiosity` (filters: `op_id`, `result` prefix, `limit` 1..1000, newest-first) and `GET /observability/curiosity/{question_id}` (200/404/400/503).
  - `_read_curiosity_records` reads `curiosity_ledger.jsonl`; additive observability only; no mutation.

- **Migration**
  - Optional to enable streaming: set `JARVIS_CURIOSITY_ENABLED=true`, `JARVIS_CURIOSITY_SSE_ENABLED=true`, and `JARVIS_IDE_STREAM_ENABLED=true`. IDE routes are read-only and require no changes.

<sup>Written for commit abc52ca49f45cff3b0c0ec4ef087f76d99e3d18f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

