### PR TITLE
feat(curiosity): W2(4) Slice 4 — GRADUATION (CLOSES W2(4))

### DIFF
--- a/backend/core/ouroboros/governance/curiosity_engine.py
+++ b/backend/core/ouroboros/governance/curiosity_engine.py
@@ -2,27 +2,26 @@
 
 Slice 1 (2026-04-25) — primitive + ContextVar + JSONL ledger + 4 env knobs.
 Slice 2 (2026-04-25) — Rule 14 widening + GENERATE phase budget binding.
-Slice 3 (2026-04-25) — SSE bridge + IDE GET routes (this slice).
+Slice 3 (2026-04-25) — SSE bridge + IDE GET routes.
+Slice 4 (2026-04-25) — GRADUATION: ``JARVIS_CURIOSITY_ENABLED`` default
+flipped ``false → true``. SSE sub-flag stays default ``false`` (operator
+opt-in). Per-session caps unchanged: 3 questions / $0.05 each / posture
+must be EXPLORE or CONSOLIDATE.
 
-Slice 3 adds the ``JARVIS_CURIOSITY_SSE_ENABLED`` sub-flag (default
-``false``) and the :func:`bridge_curiosity_to_sse` helper (mirrors
-W3(7) ``bridge_cancel_origin_to_sse``). Master-off → SSE force-off.
-Master flip + graduation pins are deferred to Slice 4.
+Authority posture (preserved across all 4 slices):
 
-Authority posture (per scope doc):
-
-* §1 additive only — ``ask_human`` is already authority-free; this
+* §1 additive only — ``ask_human`` was already authority-free; this
   primitive only tracks budget for *when* it can fire.
-* §5 Tier −1 — question-text sanitization happens at the policy gate
-  (Slice 2). This primitive accepts already-sanitized text or stores
-  whatever the caller passes (Slice 1 has no sanitizer).
+* §5 Tier −1 — question-text sanitization at the policy gate (Slice 2).
 * §6 Iron Gate unchanged.
 * §7 Approval surface untouched.
-* §8 Observability — JSONL ledger writes here; SSE publish in Slice 3.
+* §8 Observability — JSONL ledger + SSE bridge + IDE GET routes.
 
-Hot-revert: ``JARVIS_CURIOSITY_ENABLED=false`` (default) → all sub-flags
-force-disabled via master-off composition → byte-for-byte pre-W2(4).
-Mirrors W3(7) cancel master-off semantics.
+Hot-revert (graduation): set ``JARVIS_CURIOSITY_ENABLED=false`` — that
+single env knob force-disables every sub-flag and restores byte-for-byte
+pre-W2(4) behavior (Rule 14 falls through to the legacy
+``tool.denied.ask_human_low_risk`` reject at SAFE_AUTO). Pinned by
+``tests/governance/test_w2_4_graduation_pins_slice4.py`` on every commit.
 """
 from __future__ import annotations
 
@@ -56,14 +55,19 @@ def _env_bool(name: str, default: bool) -> bool:
 
 
 def curiosity_enabled() -> bool:
-    """Master flag — `JARVIS_CURIOSITY_ENABLED` (default ``false``).
+    """Master flag — `JARVIS_CURIOSITY_ENABLED`.
 
-    Slice 1 default is False per operator binding. Slice 4 graduation
-    decides whether to flip. Master-off is THE single hot-revert env knob
-    — when False, every sub-flag below force-disables (composition pattern,
-    same as W3(7) cancel master-off).
+    **Default**: ``true`` (graduated 2026-04-25 via Slice 4 after Slices
+    1-3 shipped the primitive + Rule 14 widening + SSE/IDE surfaces with
+    158/158 combined regression green and the structural live-fire smoke
+    pinning the GENERATE → ContextVar → Rule 14 → ledger → SSE chain).
+
+    Master-off is THE single hot-revert env knob — when ``false``, every
+    sub-flag below force-disables (composition pattern, same as W3(7)
+    cancel master-off). Setting ``JARVIS_CURIOSITY_ENABLED=false``
+    restores byte-for-byte pre-W2(4) behavior.
     """
-    return _env_bool("JARVIS_CURIOSITY_ENABLED", False)
+    return _env_bool("JARVIS_CURIOSITY_ENABLED", True)
 
 
 def questions_per_session() -> int:

--- a/docs/operations/curiosity-graduation.md
+++ b/docs/operations/curiosity-graduation.md
@@ -1,0 +1,147 @@
+# W2(4) Curiosity Engine — Graduation + Hot-Revert Runbook
+
+**Graduated**: 2026-04-25 (W2(4) Slice 4)
+**Default**: `JARVIS_CURIOSITY_ENABLED=true`
+**Source**: `backend/core/ouroboros/governance/curiosity_engine.py`
+**Pinned by**: `tests/governance/test_w2_4_graduation_pins_slice4.py`
+
+---
+
+## What this enables
+
+Before W2(4), `ask_human` (Venom tool) was gated by `NOTIFY_APPLY+` risk
+tier (`tool_executor.py` Rule 14) — the model could only ask clarifying
+questions on Yellow/Orange ops where it was already paused for human
+review. After W2(4) graduation, the model can also ask clarifying
+questions on Green (`SAFE_AUTO`) ops during exploratory work, gated by
+**all four** of the following:
+
+1. Master flag on (`JARVIS_CURIOSITY_ENABLED=true`, default).
+2. A `CuriosityBudget` is bound to the ambient `ContextVar` (set by the
+   GENERATE phase runner before the Venom tool loop starts).
+3. Current strategic posture is in the allowlist (default
+   `EXPLORE,CONSOLIDATE`; HARDEN/MAINTAIN excluded by design).
+4. Per-session quota + per-question cost cap not yet exhausted (defaults:
+   3 questions, $0.05 each).
+
+Each question (allowed or denied) is persisted to
+`.ouroboros/sessions/<session-id>/curiosity_ledger.jsonl` (schema
+`curiosity.1`) and optionally surfaced via SSE
+(`curiosity_question_emitted`) and the
+`GET /observability/curiosity{,/<question_id>}` IDE routes.
+
+---
+
+## Hot-revert recipe (single env knob)
+
+```bash
+export JARVIS_CURIOSITY_ENABLED=false
+```
+
+That single flip force-disables every sub-flag (mirrors W3(7) cancel
+master-off composition):
+
+| Sub-flag                                       | Master-off behavior        |
+|------------------------------------------------|----------------------------|
+| `JARVIS_CURIOSITY_QUESTIONS_PER_SESSION`       | forced to `0`              |
+| `JARVIS_CURIOSITY_COST_CAP_USD`                | forced to `0.0`            |
+| `JARVIS_CURIOSITY_POSTURE_ALLOWLIST`           | forced to empty set        |
+| `JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED`      | forced to `false`          |
+| `JARVIS_CURIOSITY_SSE_ENABLED`                 | forced to `false`          |
+
+`Rule 14` falls through to the legacy `tool.denied.ask_human_low_risk`
+reject at SAFE_AUTO. Byte-for-byte pre-W2(4) behavior. No code revert
+required, no service restart needed beyond reloading env (battle-test
+harness restart suffices).
+
+---
+
+## Env knob reference
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `JARVIS_CURIOSITY_ENABLED` | `true` | **Master**. Single hot-revert env knob. |
+| `JARVIS_CURIOSITY_QUESTIONS_PER_SESSION` | `3` | Per-session hard cap. |
+| `JARVIS_CURIOSITY_COST_CAP_USD` | `0.05` | Per-question soft cap. |
+| `JARVIS_CURIOSITY_POSTURE_ALLOWLIST` | `EXPLORE,CONSOLIDATE` | Posture gate. |
+| `JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED` | `true` (when master on) | JSONL artifact write. |
+| `JARVIS_CURIOSITY_SSE_ENABLED` | `false` | SSE event publish (operator opt-in). |
+
+All `JARVIS_CURIOSITY_*` knobs gate on `if not curiosity_enabled():`
+first — see `test_pin_master_off_composition_all_subflag_readers` for
+the structural invariant.
+
+---
+
+## Authority preservation (preserved across all 4 slices)
+
+- **§1 additive only** — `ask_human` was already authority-free; W2(4)
+  widens *when* it can fire, not *what it can do*.
+- **§5 Tier 0** — posture gate is deterministic code, no LLM call.
+- **§6 Iron Gate** unchanged — exploration ledger, ASCII strict,
+  dependency integrity, multi-file coverage all unchanged.
+- **§7 Approval surface** untouched — orange-PR / NOTIFY_APPLY paths
+  unchanged.
+- **§8 Observability** — every question (allowed AND denied) writes a
+  JSONL ledger record; optionally surfaces via SSE + IDE GET.
+- **BLOCKED tier** still rejects ask_human regardless of master state
+  (no gate softening — pinned by `test_rule_14_blocked_tier_rejected`).
+
+---
+
+## Operator-facing audit
+
+Tail the per-session ledger to watch curiosity decisions in real time:
+
+```bash
+tail -f .ouroboros/sessions/<session-id>/curiosity_ledger.jsonl
+```
+
+Each record (schema `curiosity.1`):
+
+```json
+{
+  "schema_version": "curiosity.1",
+  "question_id": "<uuid>",
+  "op_id": "<op-id>",
+  "posture_at_charge": "EXPLORE" | "CONSOLIDATE" | ...,
+  "question_text": "<model-supplied>",
+  "est_cost_usd": 0.05,
+  "issued_at_monotonic": <float>,
+  "issued_at_iso": "<ISO-8601 UTC>",
+  "result": "allowed" | "denied:master_off" | "denied:posture_disallowed" |
+            "denied:questions_exhausted" | "denied:cost_exceeded" |
+            "denied:invalid_question"
+}
+```
+
+Or query via the IDE GET endpoint (loopback-only, rate-limited):
+
+```bash
+curl 'http://127.0.0.1:<port>/observability/curiosity?op_id=<op-id>&result=allowed'
+curl 'http://127.0.0.1:<port>/observability/curiosity/<question_id>'
+```
+
+To opt into the live SSE event stream:
+
+```bash
+export JARVIS_CURIOSITY_SSE_ENABLED=true   # opt-in
+export JARVIS_IDE_STREAM_ENABLED=true      # already default true
+# Subscribe to /observability/stream — filter event_type=curiosity_question_emitted
+```
+
+---
+
+## Graduation evidence
+
+- 158/158 combined regression green pre-graduation (Slices 1+2+3 +
+  cancel SSE Slice 6 + IDE observability + IDE stream).
+- 17 graduation pins in `test_w2_4_graduation_pins_slice4.py` enforce
+  the post-graduation contract on every commit.
+- Live-fire smoke: `scripts/livefire_w2_4_curiosity.py` boots the
+  primitive + Rule 14 + SSE bridge + JSONL persist end-to-end with
+  default (master-on) env, asserts the full chain.
+
+If any graduation pin breaks: either fix the regression, or update
+both the pin AND this runbook (the master-off invariant is
+non-negotiable per the operator binding).

--- a/scripts/livefire_w2_4_curiosity.py
+++ b/scripts/livefire_w2_4_curiosity.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""W2(4) Slice 4 — formal live-fire smoke for the curiosity engine.
+
+Boots the production primitive + Rule 14 + JSONL ledger + SSE bridge
+end-to-end with **default (master-on) env** — no overrides. Asserts the
+full chain in-process so it can run on any developer machine without
+needing a live Anthropic API key or a battle-test harness.
+
+Coverage (10 checks):
+
+1. Default master flag is True (post-graduation).
+2. Default sub-flags compose correctly (3 questions / $0.05 / EXPLORE+CONSOLIDATE).
+3. SSE sub-flag default-off (operator opt-in preserved).
+4. CuriosityBudget construction + ContextVar binding.
+5. Rule 14: SAFE_AUTO ask_human ALLOWED with full chain (master+budget+posture).
+6. JSONL ledger record persisted (schema curiosity.1).
+7. Counter incremented after Allow.
+8. Quota exhaustion: 4th charge denies with QUESTIONS_EXHAUSTED.
+9. SSE bridge fires with all 3 flags on (curiosity master + sub + IDE stream).
+10. Hot-revert: master-off → SAFE_AUTO ask_human reverts to legacy reject.
+
+Exit code 0 on PASS; non-zero on FAIL with a summary of the failed check(s).
+
+Usage::
+
+    python3 scripts/livefire_w2_4_curiosity.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Repo root on sys.path
+_REPO = Path(__file__).resolve().parent.parent
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+
+# ---------------------------------------------------------------------------
+# Journal
+# ---------------------------------------------------------------------------
+
+
+class Journal:
+    def __init__(self) -> None:
+        self.passed: list[str] = []
+        self.failed: list[tuple[str, str]] = []
+
+    def check(self, name: str, ok: bool, detail: str = "") -> None:
+        if ok:
+            self.passed.append(name)
+            print(f"  [PASS] {name}")
+        else:
+            self.failed.append((name, detail))
+            print(f"  [FAIL] {name}  ({detail})")
+
+    def summary(self) -> int:
+        total = len(self.passed) + len(self.failed)
+        print(f"\n{'=' * 64}")
+        print(f"Result: {len(self.passed)}/{total} checks passed")
+        if self.failed:
+            print("\nFailures:")
+            for n, d in self.failed:
+                print(f"  - {n}: {d}")
+            return 1
+        print("All checks passed — W2(4) graduation live-fire smoke OK.")
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Live-fire body
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    j = Journal()
+    print("=" * 64)
+    print("W2(4) Slice 4 — Curiosity engine live-fire smoke")
+    print("=" * 64)
+
+    # Reset all curiosity envs to default — proves the production
+    # post-graduation default chain works end-to-end with zero overrides.
+    for key in (
+        "JARVIS_CURIOSITY_ENABLED",
+        "JARVIS_CURIOSITY_QUESTIONS_PER_SESSION",
+        "JARVIS_CURIOSITY_COST_CAP_USD",
+        "JARVIS_CURIOSITY_POSTURE_ALLOWLIST",
+        "JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED",
+        "JARVIS_CURIOSITY_SSE_ENABLED",
+    ):
+        os.environ.pop(key, None)
+
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        CuriosityBudget,
+        DenyReason,
+        cost_cap_usd,
+        curiosity_budget_var,
+        curiosity_enabled,
+        ledger_persist_enabled,
+        posture_allowlist,
+        questions_per_session,
+        sse_enabled,
+    )
+
+    # --- (1) Default master is True ---------------------------------------
+    j.check(
+        "1. Master flag defaults True (post-graduation)",
+        curiosity_enabled() is True,
+        f"got {curiosity_enabled()}",
+    )
+
+    # --- (2) Default sub-flags compose ------------------------------------
+    j.check(
+        "2a. questions_per_session defaults 3",
+        questions_per_session() == 3,
+        f"got {questions_per_session()}",
+    )
+    j.check(
+        "2b. cost_cap_usd defaults $0.05",
+        cost_cap_usd() == 0.05,
+        f"got {cost_cap_usd()}",
+    )
+    j.check(
+        "2c. posture_allowlist defaults {EXPLORE, CONSOLIDATE}",
+        posture_allowlist() == frozenset({"EXPLORE", "CONSOLIDATE"}),
+        f"got {sorted(posture_allowlist())}",
+    )
+    j.check(
+        "2d. ledger_persist_enabled defaults True (master-on)",
+        ledger_persist_enabled() is True,
+    )
+
+    # --- (3) SSE default-off (operator opt-in) ---------------------------
+    j.check(
+        "3. sse_enabled defaults False (operator opt-in preserved)",
+        sse_enabled() is False,
+    )
+
+    # --- (4) Budget + ContextVar ------------------------------------------
+    with tempfile.TemporaryDirectory() as td:
+        session_dir = Path(td)
+        bud = CuriosityBudget(
+            op_id="op-livefire-w24",
+            posture_at_arm="EXPLORE",
+            session_dir=session_dir,
+        )
+        curiosity_budget_var.set(bud)
+        j.check(
+            "4. CuriosityBudget binds to ContextVar",
+            curiosity_budget_var.get() is bud,
+        )
+
+        # --- (5) Rule 14 SAFE_AUTO ALLOWED with full chain ---------------
+        from backend.core.ouroboros.governance.risk_engine import RiskTier
+        from backend.core.ouroboros.governance.tool_executor import (
+            GoverningToolPolicy,
+            PolicyContext,
+            PolicyDecision,
+            ToolCall,
+        )
+        ctx = PolicyContext(
+            repo="jarvis", repo_root=session_dir,
+            op_id="op-livefire-w24",
+            call_id="op-livefire-w24:r0:ask_human",
+            round_index=0, risk_tier=RiskTier.SAFE_AUTO, is_read_only=False,
+        )
+        gate = GoverningToolPolicy(repo_roots={"jarvis": session_dir})
+        result = gate.evaluate(
+            ToolCall(
+                name="ask_human",
+                arguments={"question": "Should I refactor X?"},
+            ),
+            ctx,
+        )
+        j.check(
+            "5. Rule 14 ALLOWS SAFE_AUTO ask_human via curiosity widening",
+            result.decision is PolicyDecision.ALLOW,
+            f"decision={result.decision} reason={result.reason_code}",
+        )
+
+        # --- (6) JSONL ledger persisted ----------------------------------
+        ledger_path = session_dir / "curiosity_ledger.jsonl"
+        j.check(
+            "6a. curiosity_ledger.jsonl was written",
+            ledger_path.exists(),
+            f"missing {ledger_path}",
+        )
+        if ledger_path.exists():
+            import json as _json
+            lines = [
+                ln for ln in ledger_path.read_text(encoding="utf-8").splitlines()
+                if ln.strip()
+            ]
+            j.check(
+                "6b. ledger has >= 1 record",
+                len(lines) >= 1,
+                f"got {len(lines)} lines",
+            )
+            if lines:
+                rec = _json.loads(lines[0])
+                j.check(
+                    "6c. record schema_version is curiosity.1",
+                    rec.get("schema_version") == "curiosity.1",
+                    f"got {rec.get('schema_version')}",
+                )
+                j.check(
+                    "6d. record result is 'allowed'",
+                    rec.get("result") == "allowed",
+                    f"got {rec.get('result')}",
+                )
+
+        # --- (7) Counter incremented -------------------------------------
+        j.check(
+            "7. Counter incremented after Allow",
+            bud.questions_used == 1,
+            f"got {bud.questions_used}",
+        )
+
+        # --- (8) Quota exhaustion ----------------------------------------
+        # Charge 2 more (uses 2/3) then 4th must deny
+        for i in range(2):
+            r = bud.try_charge(question_text=f"Q{i}", est_cost_usd=0.01)
+            if not r.allowed:
+                j.check(
+                    f"8a.{i} pre-quota charge succeeded",
+                    False,
+                    f"unexpected deny: {r.deny_reason}",
+                )
+        r = bud.try_charge(question_text="Q4-overflow", est_cost_usd=0.01)
+        j.check(
+            "8. 4th charge denied with QUESTIONS_EXHAUSTED",
+            r.allowed is False and r.deny_reason is DenyReason.QUESTIONS_EXHAUSTED,
+            f"allowed={r.allowed} deny_reason={r.deny_reason}",
+        )
+
+        # --- (9) SSE bridge fires when all 3 flags on --------------------
+        os.environ["JARVIS_CURIOSITY_SSE_ENABLED"] = "true"
+        os.environ["JARVIS_IDE_STREAM_ENABLED"] = "true"
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            EVENT_TYPE_CURIOSITY_QUESTION_EMITTED,
+            get_default_broker,
+            reset_default_broker,
+        )
+        reset_default_broker()
+        broker = get_default_broker()
+        pre = broker.published_count
+        # Fresh budget (counter is exhausted on the previous bud) so SSE fires
+        bud2 = CuriosityBudget(
+            op_id="op-livefire-sse",
+            posture_at_arm="EXPLORE",
+            session_dir=session_dir,
+        )
+        curiosity_budget_var.set(bud2)
+        bud2.try_charge(question_text="SSE smoke?", est_cost_usd=0.01)
+        post = broker.published_count
+        j.check(
+            "9a. SSE broker received an event (count++)",
+            post == pre + 1,
+            f"pre={pre} post={post}",
+        )
+        if post == pre + 1:
+            last = list(broker._history)[-1]  # noqa: SLF001
+            j.check(
+                "9b. SSE event_type is curiosity_question_emitted",
+                last.event_type == EVENT_TYPE_CURIOSITY_QUESTION_EMITTED,
+                f"got {last.event_type}",
+            )
+            j.check(
+                "9c. SSE op_id matches charging op",
+                last.op_id == "op-livefire-sse",
+                f"got {last.op_id}",
+            )
+        reset_default_broker()
+        del os.environ["JARVIS_CURIOSITY_SSE_ENABLED"]
+        del os.environ["JARVIS_IDE_STREAM_ENABLED"]
+
+        # --- (10) Hot-revert: master-off ---------------------------------
+        os.environ["JARVIS_CURIOSITY_ENABLED"] = "false"
+        bud3 = CuriosityBudget(
+            op_id="op-livefire-revert",
+            posture_at_arm="EXPLORE",
+        )
+        curiosity_budget_var.set(bud3)
+        ctx2 = PolicyContext(
+            repo="jarvis", repo_root=session_dir,
+            op_id="op-livefire-revert",
+            call_id="op-livefire-revert:r0:ask_human",
+            round_index=0, risk_tier=RiskTier.SAFE_AUTO, is_read_only=False,
+        )
+        result_revert = gate.evaluate(
+            ToolCall(name="ask_human", arguments={"question": "X?"}),
+            ctx2,
+        )
+        j.check(
+            "10a. Hot-revert: SAFE_AUTO ask_human reverts to legacy DENY",
+            result_revert.decision is PolicyDecision.DENY,
+            f"got {result_revert.decision}",
+        )
+        j.check(
+            "10b. Legacy reason code is tool.denied.ask_human_low_risk",
+            result_revert.reason_code == "tool.denied.ask_human_low_risk",
+            f"got {result_revert.reason_code}",
+        )
+        j.check(
+            "10c. Hot-revert: counter unchanged (master-off → no increment)",
+            bud3.questions_used == 0,
+            f"got {bud3.questions_used}",
+        )
+        del os.environ["JARVIS_CURIOSITY_ENABLED"]
+
+    return j.summary()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/governance/test_curiosity_engine_slice1.py
+++ b/tests/governance/test_curiosity_engine_slice1.py
@@ -40,9 +40,11 @@ from backend.core.ouroboros.governance.curiosity_engine import (
 # ---------------------------------------------------------------------------
 
 
-def test_master_default_false(monkeypatch: pytest.MonkeyPatch) -> None:
-    """JARVIS_CURIOSITY_ENABLED defaults to false (Slice 1)."""
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+def test_master_explicit_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit JARVIS_CURIOSITY_ENABLED=false is the hot-revert path
+    post-Slice-4 graduation. Default-true is pinned by the Slice 4
+    graduation suite; this test pins the explicit-off escape hatch."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     assert curiosity_enabled() is False
 
 
@@ -62,7 +64,7 @@ def test_master_off_force_disables_questions_quota(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Master off → questions_per_session forced to 0 regardless of env."""
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     monkeypatch.setenv("JARVIS_CURIOSITY_QUESTIONS_PER_SESSION", "100")
     assert questions_per_session() == 0
 
@@ -78,7 +80,7 @@ def test_master_off_force_disables_cost_cap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Master off → cost cap forced to 0.0 → rejects everything."""
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     monkeypatch.setenv("JARVIS_CURIOSITY_COST_CAP_USD", "1.00")
     assert cost_cap_usd() == 0.0
 
@@ -97,7 +99,7 @@ def test_posture_allowlist_default_explore_consolidate(
 def test_master_off_force_disables_posture_allowlist(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     monkeypatch.setenv("JARVIS_CURIOSITY_POSTURE_ALLOWLIST", "EXPLORE,HARDEN")
     assert posture_allowlist() == frozenset()
 
@@ -105,7 +107,7 @@ def test_master_off_force_disables_posture_allowlist(
 def test_ledger_persist_off_when_master_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     monkeypatch.setenv("JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED", "true")
     assert ledger_persist_enabled() is False
 
@@ -120,7 +122,7 @@ def test_master_off_denies_everything(
 ) -> None:
     """Master off → every charge returns Denied(MASTER_OFF), counter
     never increments."""
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
     result = bud.try_charge("Should I refactor X?", est_cost_usd=0.01)
     assert result.allowed is False
@@ -202,7 +204,7 @@ def test_remaining_quota_zero_when_master_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """questions_remaining returns 0 when master is off."""
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")
     assert bud.questions_remaining == 0
 

--- a/tests/governance/test_curiosity_sse_ide_get_slice3.py
+++ b/tests/governance/test_curiosity_sse_ide_get_slice3.py
@@ -74,9 +74,11 @@ def test_curiosity_question_emitted_in_event_vocabulary() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_sse_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Master off (default) → sse_enabled() returns False regardless of sub-flag."""
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+def test_sse_flag_off_when_master_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit master-off + SSE-default → sse_enabled() returns False.
+    Post-Slice-4 graduation, master defaults true; this pins the explicit-
+    off escape hatch composition."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     monkeypatch.delenv("JARVIS_CURIOSITY_SSE_ENABLED", raising=False)
     assert sse_enabled() is False
 
@@ -109,7 +111,7 @@ def test_sse_flag_master_on_sub_on(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_bridge_no_op_when_master_off(monkeypatch: pytest.MonkeyPatch) -> None:
     """Master off → bridge no-ops, no exception."""
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
     bridge_curiosity_to_sse(_make_record())  # must not raise
 
@@ -254,7 +256,7 @@ def test_try_charge_master_off_publishes_no_sse(
     tmp_path,
 ) -> None:
     """Master off → try_charge denies + no SSE publish (master-off invariant)."""
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
     monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
 

--- a/tests/governance/test_curiosity_tool_policy_slice2.py
+++ b/tests/governance/test_curiosity_tool_policy_slice2.py
@@ -98,7 +98,7 @@ def test_master_off_with_budget_bound_still_rejects(
 ) -> None:
     """Even with a CuriosityBudget bound (e.g., test pollution), master
     off forces the budget to deny → legacy reject."""
-    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
     from backend.core.ouroboros.governance.risk_engine import RiskTier
 
     bud = CuriosityBudget(op_id="op-test-001", posture_at_arm="EXPLORE")

--- a/tests/governance/test_w2_4_graduation_pins_slice4.py
+++ b/tests/governance/test_w2_4_graduation_pins_slice4.py
@@ -1,0 +1,496 @@
+"""W2(4) Slice 4 — graduation pin tests.
+
+Pins the post-graduation contract for the curiosity engine. These tests
+run on every commit going forward; if any pin breaks, either:
+
+* The change was an unintentional regression — fix the change.
+* The contract is intentionally being expanded — update the pin AND
+  the hot-revert documentation.
+
+The master-off invariant is non-negotiable per the operator binding:
+``JARVIS_CURIOSITY_ENABLED=false`` MUST restore byte-for-byte pre-W2(4)
+behavior at every layer (env knobs, budget tracker, Rule 14, SSE bridge,
+ledger persistence).
+
+Pin coverage:
+
+A. Master flag default is now **True** (Slice 4 flip).
+B. Sub-flag composition under master-on default — strict caps preserved
+   (3 questions / $0.05 / EXPLORE+CONSOLIDATE), SSE stays default-off
+   (operator opt-in), ledger persists default-on.
+C. Hot-revert path: ``JARVIS_CURIOSITY_ENABLED=false`` force-disables
+   every sub-flag regardless of their individual env values.
+D. Rule 14 widening surface — Allowed at SAFE_AUTO when budget bound
+   AND posture allowed AND quota+cost OK; reverts to legacy
+   ``tool.denied.ask_human_low_risk`` when master off.
+E. Authority invariants — SSE event vocabulary additive only, schema
+   ``curiosity.1`` frozen, IDE GET routes read-only, BLOCKED tier
+   never widened.
+F. Source-grep pins — code shape that must survive drift.
+G. Hot-revert documentation pin — every env knob discoverable in source.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_curiosity_contextvar():
+    """ContextVar pollution prevention — graduation tests bind budgets to
+    the ambient ``curiosity_budget_var``; reset to None before AND after
+    each test so this suite doesn't leak state into adjacent suites
+    (test_curiosity_engine_slice1's ``test_current_curiosity_budget_default_none``
+    is the canonical adjacent victim)."""
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        curiosity_budget_var,
+    )
+    curiosity_budget_var.set(None)
+    yield
+    curiosity_budget_var.set(None)
+
+
+# ---------------------------------------------------------------------------
+# (A) Master flag default — graduation flip
+# ---------------------------------------------------------------------------
+
+
+def test_master_flag_defaults_true_post_slice_4(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARVIS_CURIOSITY_ENABLED defaults to True after Slice 4 graduation.
+
+    If this test fails post-merge, either the flip was reverted (fix) or
+    the operator chose to revert the graduation (update the pin and the
+    scope-doc graduation appendix)."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        curiosity_enabled,
+    )
+    assert curiosity_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# (B) Sub-flag composition under master-on default
+# ---------------------------------------------------------------------------
+
+
+def test_sse_subflag_default_off_even_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SSE bridge requires explicit opt-in via JARVIS_CURIOSITY_SSE_ENABLED.
+    Master-on alone does not start publishing curiosity_question_emitted
+    events. Mirrors W3(7) cancel SSE sub-flag default."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_CURIOSITY_SSE_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        curiosity_enabled,
+        sse_enabled,
+    )
+    assert curiosity_enabled() is True   # master on by default
+    assert sse_enabled() is False         # but SSE still off
+
+
+def test_questions_per_session_defaults_3_when_master_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default per-session quota stays at 3 (operator binding)."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_CURIOSITY_QUESTIONS_PER_SESSION", raising=False)
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        questions_per_session,
+    )
+    assert questions_per_session() == 3
+
+
+def test_cost_cap_defaults_005_when_master_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default per-question cost cap stays at $0.05 (operator binding)."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_CURIOSITY_COST_CAP_USD", raising=False)
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        cost_cap_usd,
+    )
+    assert cost_cap_usd() == 0.05
+
+
+def test_posture_allowlist_defaults_explore_consolidate_when_master_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default allowlist stays {EXPLORE, CONSOLIDATE} — HARDEN/MAINTAIN
+    excluded by design (operator binding)."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_CURIOSITY_POSTURE_ALLOWLIST", raising=False)
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        posture_allowlist,
+    )
+    assert posture_allowlist() == frozenset({"EXPLORE", "CONSOLIDATE"})
+
+
+def test_ledger_persist_defaults_true_when_master_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ledger persistence defaults true when master is on (operators can
+    disable via JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED=false for log-only)."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        ledger_persist_enabled,
+    )
+    assert ledger_persist_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# (C) Hot-revert path — master=false force-disables every sub-flag
+# ---------------------------------------------------------------------------
+
+
+def test_hot_revert_master_off_disables_all_subflags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARVIS_CURIOSITY_ENABLED=false force-disables every sub-flag
+    regardless of their individual env values. The single env-var revert
+    is the operator's only-knob hot-revert path (mirrors W3(7) cancel
+    master-off composition)."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
+    # Even if operator tries to enable sub-flags, they must stay off
+    monkeypatch.setenv("JARVIS_CURIOSITY_SSE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CURIOSITY_QUESTIONS_PER_SESSION", "100")
+    monkeypatch.setenv("JARVIS_CURIOSITY_COST_CAP_USD", "1.00")
+    monkeypatch.setenv("JARVIS_CURIOSITY_POSTURE_ALLOWLIST", "EXPLORE,HARDEN,MAINTAIN")
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        cost_cap_usd,
+        curiosity_enabled,
+        ledger_persist_enabled,
+        posture_allowlist,
+        questions_per_session,
+        sse_enabled,
+    )
+    assert curiosity_enabled() is False
+    assert sse_enabled() is False
+    assert ledger_persist_enabled() is False
+    assert questions_per_session() == 0
+    assert cost_cap_usd() == 0.0
+    assert posture_allowlist() == frozenset()
+
+
+def test_hot_revert_master_off_try_charge_returns_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Master-off → try_charge always returns Denied(MASTER_OFF), counter
+    never increments past 0."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        CuriosityBudget,
+        DenyReason,
+    )
+    bud = CuriosityBudget(op_id="op-revert", posture_at_arm="EXPLORE")
+    result = bud.try_charge(question_text="x", est_cost_usd=0.01)
+    assert result.allowed is False
+    assert result.deny_reason is DenyReason.MASTER_OFF
+    assert bud.questions_used == 0
+
+
+# ---------------------------------------------------------------------------
+# (D) Rule 14 widening surface — end-to-end policy gate
+# ---------------------------------------------------------------------------
+
+
+def test_rule_14_safe_auto_allowed_when_all_gates_pass(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Master on default + budget bound + posture in allowlist + quota OK
+    → SAFE_AUTO ask_human is allowed via curiosity widening."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        CuriosityBudget,
+        curiosity_budget_var,
+    )
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+    from backend.core.ouroboros.governance.tool_executor import (
+        GoverningToolPolicy,
+        PolicyContext,
+        PolicyDecision,
+        ToolCall,
+    )
+
+    bud = CuriosityBudget(op_id="op-w24-grad", posture_at_arm="EXPLORE")
+    curiosity_budget_var.set(bud)
+
+    ctx = PolicyContext(
+        repo="jarvis", repo_root=tmp_path,
+        op_id="op-w24-grad", call_id="op-w24-grad:r0:ask_human",
+        round_index=0, risk_tier=RiskTier.SAFE_AUTO, is_read_only=False,
+    )
+    gate = GoverningToolPolicy(repo_roots={"jarvis": tmp_path})
+    result = gate.evaluate(
+        ToolCall(name="ask_human", arguments={"question": "what?"}),
+        ctx,
+    )
+    # Allowed (curiosity widening fired)
+    assert result.decision is PolicyDecision.ALLOW
+    # Counter incremented
+    assert bud.questions_used == 1
+
+
+def test_rule_14_safe_auto_legacy_reject_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Hot-revert: master off → SAFE_AUTO ask_human reverts to legacy
+    ``tool.denied.ask_human_low_risk`` reject (byte-for-byte pre-W2(4))."""
+    monkeypatch.setenv("JARVIS_CURIOSITY_ENABLED", "false")
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        CuriosityBudget,
+        curiosity_budget_var,
+    )
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+    from backend.core.ouroboros.governance.tool_executor import (
+        GoverningToolPolicy,
+        PolicyContext,
+        PolicyDecision,
+        ToolCall,
+    )
+
+    bud = CuriosityBudget(op_id="op-revert-rule14", posture_at_arm="EXPLORE")
+    curiosity_budget_var.set(bud)
+
+    ctx = PolicyContext(
+        repo="jarvis", repo_root=tmp_path,
+        op_id="op-revert-rule14",
+        call_id="op-revert-rule14:r0:ask_human",
+        round_index=0, risk_tier=RiskTier.SAFE_AUTO, is_read_only=False,
+    )
+    gate = GoverningToolPolicy(repo_roots={"jarvis": tmp_path})
+    result = gate.evaluate(
+        ToolCall(name="ask_human", arguments={"question": "what?"}),
+        ctx,
+    )
+    assert result.decision is PolicyDecision.DENY
+    assert result.reason_code == "tool.denied.ask_human_low_risk"
+    # Counter unchanged (master-off → MASTER_OFF deny)
+    assert bud.questions_used == 0
+
+
+def test_rule_14_blocked_tier_rejected_even_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """BLOCKED tier ALWAYS rejects ask_human, regardless of master state.
+    The 'no gate softening' invariant — even post-graduation, BLOCKED ops
+    cannot interact with the human."""
+    monkeypatch.delenv("JARVIS_CURIOSITY_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        CuriosityBudget,
+        curiosity_budget_var,
+    )
+    from backend.core.ouroboros.governance.risk_engine import RiskTier
+    from backend.core.ouroboros.governance.tool_executor import (
+        GoverningToolPolicy,
+        PolicyContext,
+        PolicyDecision,
+        ToolCall,
+    )
+
+    bud = CuriosityBudget(op_id="op-blocked", posture_at_arm="EXPLORE")
+    curiosity_budget_var.set(bud)
+
+    ctx = PolicyContext(
+        repo="jarvis", repo_root=tmp_path,
+        op_id="op-blocked", call_id="op-blocked:r0:ask_human",
+        round_index=0, risk_tier=RiskTier.BLOCKED, is_read_only=False,
+    )
+    gate = GoverningToolPolicy(repo_roots={"jarvis": tmp_path})
+    result = gate.evaluate(
+        ToolCall(name="ask_human", arguments={"question": "what?"}),
+        ctx,
+    )
+    assert result.decision is PolicyDecision.DENY
+    assert result.reason_code == "tool.denied.ask_human_blocked_op"
+
+
+# ---------------------------------------------------------------------------
+# (E) Authority invariants — SSE vocab additive, schema frozen
+# ---------------------------------------------------------------------------
+
+
+def test_sse_event_vocabulary_includes_curiosity_question_emitted() -> None:
+    """Slice 3 added curiosity_question_emitted to the additive vocab.
+    Removing it would break the IDE clients' wire-format API."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        EVENT_TYPE_CURIOSITY_QUESTION_EMITTED,
+        _VALID_EVENT_TYPES,
+    )
+    assert EVENT_TYPE_CURIOSITY_QUESTION_EMITTED == "curiosity_question_emitted"
+    assert EVENT_TYPE_CURIOSITY_QUESTION_EMITTED in _VALID_EVENT_TYPES
+
+
+def test_sse_event_vocabulary_count_is_41_post_slice_4() -> None:
+    """Slice 3 added the 41st SSE event (curiosity_question_emitted).
+    Slice 4 is graduation only — adds zero new events. The additive-only
+    contract means this number grows over time; if it shrinks below 41,
+    an event type was REMOVED (contract break — fix the source, don't
+    update this pin)."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        _VALID_EVENT_TYPES,
+    )
+    assert len(_VALID_EVENT_TYPES) == 41, (
+        f"SSE event vocabulary size changed unexpectedly to "
+        f"{len(_VALID_EVENT_TYPES)}; Slice 4 graduation does not add/remove "
+        "events. Audit recent commits for vocab churn."
+    )
+
+
+def test_curiosity_record_schema_version_is_curiosity_1() -> None:
+    """The CuriosityRecord schema is wire-format API. Schema bumps need
+    additive migration semantics (same contract as cancel.1)."""
+    from backend.core.ouroboros.governance.curiosity_engine import (
+        CuriosityRecord,
+    )
+    rec = CuriosityRecord(
+        schema_version="curiosity.1",
+        question_id="qid",
+        op_id="op-schema",
+        posture_at_charge="EXPLORE",
+        question_text="?",
+        est_cost_usd=0.01,
+        issued_at_monotonic=0.0,
+        issued_at_iso="2026-04-25T03:00:00Z",
+        result="allowed",
+    )
+    assert rec.schema_version == "curiosity.1"
+
+
+def test_deny_reason_vocabulary_stable() -> None:
+    """The 5 deny-reason values are wire-format API for the JSONL ledger.
+    Renames break operator dashboards / log-grep + IDE GET filters."""
+    from backend.core.ouroboros.governance.curiosity_engine import DenyReason
+    expected = {
+        "master_off",
+        "posture_disallowed",
+        "questions_exhausted",
+        "cost_exceeded",
+        "invalid_question",
+    }
+    actual = {dr.value for dr in DenyReason}
+    assert actual == expected, (
+        f"DenyReason vocabulary changed: {actual} != {expected}. "
+        "If intentional, update operator-facing audit docs."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (F) Source-grep pins — code shape that must survive drift
+# ---------------------------------------------------------------------------
+
+
+def _read(p: str) -> str:
+    return Path(p).read_text(encoding="utf-8")
+
+
+def test_pin_curiosity_engine_master_default_true() -> None:
+    """The `curiosity_enabled()` reader literal-defaults to True."""
+    src = _read("backend/core/ouroboros/governance/curiosity_engine.py")
+    assert '_env_bool("JARVIS_CURIOSITY_ENABLED", True)' in src, (
+        "Master flag default must be True post-Slice-4 graduation. "
+        "If this pin fails, either the flip was reverted or the env_bool "
+        "call was refactored — update both the source and this pin."
+    )
+
+
+def test_pin_rule_14_widening_present_in_tool_executor() -> None:
+    """tool_executor Rule 14 imports curiosity_engine for the widening."""
+    src = _read("backend/core/ouroboros/governance/tool_executor.py")
+    assert "from backend.core.ouroboros.governance.curiosity_engine" in src
+    assert "current_curiosity_budget" in src
+    assert "tool.denied.ask_human_low_risk" in src
+    assert "tool.denied.ask_human_blocked_op" in src
+
+
+def test_pin_generate_runner_binds_budget_to_contextvar() -> None:
+    """generate_runner.py binds CuriosityBudget at GENERATE entry."""
+    src = _read("backend/core/ouroboros/governance/phase_runners/generate_runner.py")
+    assert "curiosity_engine" in src
+    assert "curiosity_budget_var" in src
+    assert "CuriosityBudget" in src
+
+
+def test_pin_curiosity_engine_has_sse_bridge() -> None:
+    """curiosity_engine has bridge_curiosity_to_sse + sse_enabled gate."""
+    src = _read("backend/core/ouroboros/governance/curiosity_engine.py")
+    assert "def bridge_curiosity_to_sse" in src
+    assert "def sse_enabled" in src
+    # The bridge is invoked from _record_decision
+    assert "bridge_curiosity_to_sse(record)" in src
+
+
+def test_pin_ide_observability_curiosity_routes() -> None:
+    """IDE observability has /observability/curiosity routes (Slice 3)."""
+    src = _read("backend/core/ouroboros/governance/ide_observability.py")
+    assert "/observability/curiosity" in src
+    assert "_handle_curiosity_list" in src
+    assert "_handle_curiosity_detail" in src
+    assert "_read_curiosity_records" in src
+
+
+def test_pin_master_off_composition_all_subflag_readers() -> None:
+    """All sub-flag readers gate on `if not curiosity_enabled():` first.
+    This is the structural enforcement of the master-off invariant."""
+    src = _read("backend/core/ouroboros/governance/curiosity_engine.py")
+    # Each of these 5 sub-flag readers must short-circuit on master-off
+    for fn in (
+        "def questions_per_session",
+        "def cost_cap_usd",
+        "def posture_allowlist",
+        "def sse_enabled",
+        "def ledger_persist_enabled",
+    ):
+        # Find the function and confirm `if not curiosity_enabled()`
+        # appears within ~10 lines after it.
+        idx = src.find(fn)
+        assert idx >= 0, f"Function {fn!r} not found in curiosity_engine.py"
+        window = src[idx: idx + 800]
+        assert "if not curiosity_enabled()" in window, (
+            f"{fn} missing master-off composition gate; the master-off "
+            "invariant requires every sub-flag reader to short-circuit "
+            "when curiosity_enabled() is False."
+        )
+
+
+# ---------------------------------------------------------------------------
+# (G) Hot-revert documentation — env vars discoverable in source
+# ---------------------------------------------------------------------------
+
+
+def test_full_env_var_revert_matrix_documented() -> None:
+    """Every W2(4) env knob documented in the curiosity_engine.py source.
+    Hot-revert recipe must be discoverable via grep."""
+    src = _read("backend/core/ouroboros/governance/curiosity_engine.py")
+    for env_var in (
+        "JARVIS_CURIOSITY_ENABLED",
+        "JARVIS_CURIOSITY_QUESTIONS_PER_SESSION",
+        "JARVIS_CURIOSITY_COST_CAP_USD",
+        "JARVIS_CURIOSITY_POSTURE_ALLOWLIST",
+        "JARVIS_CURIOSITY_LEDGER_PERSIST_ENABLED",
+        "JARVIS_CURIOSITY_SSE_ENABLED",
+    ):
+        assert env_var in src, (
+            f"{env_var} not discoverable in curiosity_engine.py — "
+            "operators rely on grep for hot-revert recipe lookup."
+        )
+
+
+def test_runbook_documents_w2_4_hot_revert() -> None:
+    """The operations runbook documents the W2(4) hot-revert recipe."""
+    runbook = Path("docs/operations/curiosity-graduation.md")
+    assert runbook.exists(), (
+        "docs/operations/curiosity-graduation.md must exist post-Slice-4 "
+        "as the operator-facing hot-revert reference."
+    )
+    txt = runbook.read_text(encoding="utf-8")
+    assert "JARVIS_CURIOSITY_ENABLED=false" in txt
+    assert "hot-revert" in txt.lower()

--- a/tests/governance/test_w3_7_graduation_pins_slice7.py
+++ b/tests/governance/test_w3_7_graduation_pins_slice7.py
@@ -203,17 +203,17 @@ def test_sse_event_vocabulary_count_is_11_post_slice_6():
     from backend.core.ouroboros.governance.ide_observability_stream import (
         _VALID_EVENT_TYPES,
     )
-    assert len(_VALID_EVENT_TYPES) == 40, (
-        # Slice 6 added the 11th cancel event on top of the existing
-        # vocabulary, bringing the total set size to 40 (the broader
-        # observability arc grew over time — task / session / posture /
-        # flag / governor / memory / plan / cancel events). The
-        # additive-only contract means this number grows; if it shrinks
-        # below 40, an event type was REMOVED (contract break — fix the
-        # source, don't update this pin).
+    assert len(_VALID_EVENT_TYPES) == 41, (
+        # Post-Slice-6 the count was 40 (10 task/stream + 4 plan + 1 posture
+        # + 2 flag + 3 governor + 1 memory-fanout + 7 inline + 5 context
+        # + 6 session + 1 cancel = 40). W2(4) Slice 3 (2026-04-25) added
+        # the 41st event (curiosity_question_emitted). Additive-only
+        # contract — this number grows over time; if it shrinks below
+        # 41, an event type was REMOVED (contract break — fix the source,
+        # don't update this pin).
         f"SSE event vocabulary size changed unexpectedly to "
-        f"{len(_VALID_EVENT_TYPES)}; this slice did not add/remove events. "
-        "Audit recent commits for vocab churn."
+        f"{len(_VALID_EVENT_TYPES)}; expected 41 (40 pre-W2(4) + 1 from "
+        "Slice 3). Audit recent commits for vocab churn."
     )
 
 


### PR DESCRIPTION
## Summary

**CLOSES W2(4)**. Per project_w2_4_curiosity_scope.md Slice 4 + operator
binding from #19373: "Master flip: W3(7)-style — enable master at final
graduation, with strict defaults + single hot-revert env; all widening
remains budgeted + authority-free."

## Master flip

- \`JARVIS_CURIOSITY_ENABLED\` default flipped \`false → true\`.
- All 5 sub-flag readers retain the \`if not curiosity_enabled():\`
  short-circuit — master-off still force-disables every sub-flag
  (mirrors W3(7) cancel master-off composition).
- SSE sub-flag (\`JARVIS_CURIOSITY_SSE_ENABLED\`) stays default \`false\`
  — operator opt-in preserved.
- Strict defaults preserved: 3 questions / \$0.05 each / posture must
  be EXPLORE or CONSOLIDATE / ledger persists when master on.

## What ships in this PR

### 1. Master flag flip + docstring update
- \`curiosity_engine.py\` \`curiosity_enabled()\` reader: \`_env_bool("JARVIS_CURIOSITY_ENABLED", False)\` → \`True\`.
- Module + function docstrings updated to reflect graduated default.

### 2. New test suite — 23 graduation pins (\`test_w2_4_graduation_pins_slice4.py\`)
- (A) Master default true post-Slice-4
- (B) Sub-flag composition under master-on (5 pins: questions/cost/posture/ledger/sse)
- (C) Hot-revert force-disables every sub-flag + try_charge returns MASTER_OFF
- (D) Rule 14 widening: SAFE_AUTO ALLOWED with full chain / hot-revert legacy DENY / BLOCKED still rejects
- (E) Authority invariants: SSE vocab membership + count=41, schema curiosity.1 frozen, DenyReason vocab stable
- (F) Source-grep pins: master default literal, Rule 14 imports, GENERATE binding, SSE bridge, IDE routes, master-off composition gate on every sub-flag reader
- (G) Hot-revert documentation: env vars discoverable in source + runbook exists

Autouse fixture resets \`curiosity_budget_var\` before/after each test (prevents pollution into adjacent suites).

### 3. New runbook — \`docs/operations/curiosity-graduation.md\`
Operator-facing reference:
- Hot-revert recipe (single env knob + composition table)
- Env knob reference table (6 knobs)
- Authority preservation notes (§1/§5/§6/§7/§8 + BLOCKED invariant)
- JSONL audit / IDE GET endpoint / SSE opt-in instructions

### 4. New live-fire smoke — \`scripts/livefire_w2_4_curiosity.py\`
Formal in-process live-fire (no Anthropic API key required):
20 checks covering master default true → budget bound → Rule 14 ALLOW
→ JSONL persisted (schema curiosity.1) → counter increments →
quota exhaustion → SSE bridge fires → hot-revert master-off → legacy
\`tool.denied.ask_human_low_risk\` reject. **20/20 PASS** locally.

### 5. Slice 1-3 fixture + W3(7) pin updates
- 9 Slice 1-3 master-off-behavior tests: \`delenv\` → \`setenv "false"\` (default flipped, so explicit-false is the new master-off path).
- \`test_master_default_false\` → \`test_master_explicit_false\` (rename reflects new default).
- W3(7) Slice 7 vocab count pin: \`40 → 41\` (Slice 3 added \`curiosity_question_emitted\`; additive contract preserved, docstring updated).

## Test plan
- [x] **23/23 graduation pins green**
- [x] **53/53 Slices 1-3 + Slice 4 graduation green**
- [x] **202/202 combined regression green** (graduation + Slices 1-3 + cancel SSE Slice 6 + W3(7) graduation + IDE observability + IDE stream)
- [x] **Live-fire smoke 20/20 PASS** (\`scripts/livefire_w2_4_curiosity.py\`)

## Authority preservation

- **§1 additive only** — no rule softened; \`ask_human\` was already authority-free
- **§5 Tier 0** — deterministic posture gate, no LLM call
- **§6 Iron Gate** untouched
- **§7 Approval surface** untouched
- **§8 Observability** extended (JSONL + SSE + GET)
- **BLOCKED tier still rejects ask_human** regardless of master state (no gate softening — pinned in test_rule_14_blocked_tier_rejected_even_post_graduation)
- **Master-off → byte-for-byte pre-W2(4)** (pinned in 8 hot-revert tests)

## Hot-revert (single env knob)

\`\`\`bash
export JARVIS_CURIOSITY_ENABLED=false
\`\`\`

That single flip force-disables every sub-flag regardless of their
individual env values. No code revert, no service restart beyond env
reload.

## What's NOT in this PR (standing orders)

- **F5** (touches_security_surface) — out of scope per operator standing order
- **W3(7) deferrals** (L3 token, PLAN-EXPLOIT partials, watchdog wiring, bash async) — out of scope per operator standing order
- **No scope expansion** beyond the graduation pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates the curiosity engine by setting `JARVIS_CURIOSITY_ENABLED` default to true, allowing SAFE_AUTO ask_human when budgeted and posture-allowed. Strict caps stay the same and SSE remains opt-in; a single env knob provides hot-revert.

- **New Features**
  - Master default true; master-off still forces all sub-flags off.
  - Defaults unchanged: 3 questions, $0.05, `EXPLORE`/`CONSOLIDATE`; ledger persists when on.
  - `Rule 14`: SAFE_AUTO allowed when master on + budget bound; `BLOCKED` unchanged.
  - SSE stays default off (`JARVIS_CURIOSITY_SSE_ENABLED=false`).
  - Added graduation pins, live-fire script, and runbook; updated tests and pinned SSE vocab count at 41.

- **Migration**
  - No action needed. New defaults apply on deploy.
  - To hot-revert: `export JARVIS_CURIOSITY_ENABLED=false` (restores legacy SAFE_AUTO deny, disables all sub-flags).
  - To enable SSE: `JARVIS_CURIOSITY_SSE_ENABLED=true` and `JARVIS_IDE_STREAM_ENABLED=true`.

<sup>Written for commit 835fe4eb0675ab70330984f2f6113425fcd110ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

