### PR TITLE
fix(cost_governor): scale cap by N for parallel-stream fan-out

### DIFF
--- a/backend/core/ouroboros/governance/cost_governor.py
+++ b/backend/core/ouroboros/governance/cost_governor.py
@@ -79,6 +79,38 @@ logger = logging.getLogger(__name__)
 # Env-var helpers
 # -----------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Default-singleton accessor (rooted-problem fix 2026-04-25)
+# ---------------------------------------------------------------------------
+# Process-wide reference to the active CostGovernor instance. Set by
+# the orchestrator at boot via :func:`set_default_cost_governor` after
+# it constructs `self._cost_governor`. Lookups via :func:`get_default_cost_governor`
+# return None when no governor is active (test isolation, partial boot).
+#
+# This indirection avoids forcing PLAN-EXPLOIT (or any other "pure"
+# helper module) to take a CostGovernor parameter through every call
+# site. The pure-module discipline is preserved — PLAN-EXPLOIT still
+# never imports orchestrator; it imports this accessor and tolerates
+# None.
+_default_cost_governor: Optional["CostGovernor"] = None
+
+
+def set_default_cost_governor(governor: "CostGovernor") -> None:
+    """Register the process-wide CostGovernor for default-singleton lookup.
+
+    Idempotent — calling twice with the same instance is a no-op; calling
+    with a different instance replaces the reference. Tests should call
+    with ``governor=None`` between cases for isolation.
+    """
+    global _default_cost_governor
+    _default_cost_governor = governor
+
+
+def get_default_cost_governor() -> Optional["CostGovernor"]:
+    """Return the process-wide CostGovernor, or None if not registered."""
+    return _default_cost_governor
+
+
 def _env_float(name: str, default: float) -> float:
     """Read a float env var with a safe default. Negative values fall back."""
     raw = os.environ.get(name)
@@ -177,6 +209,23 @@ class CostGovernorConfig:
     readonly_factor: float = field(
         default_factory=lambda: _env_float("JARVIS_OP_COST_READONLY_FACTOR", 5.0)
     )
+    # Parallel-stream multiplier for fan-out paths (rooted-problem fix
+    # 2026-04-25). PLAN-EXPLOIT spawns N concurrent Claude streams for
+    # a single op; the cap must scale with stream count or the governor
+    # will cancel mid-flight (observed F1 Slice 4 S2: 3-stream fan-out
+    # spent $0.49 against $0.45 single-stream cap → enforce_cancelled
+    # 53.3s into wait, fan-out units exhausted).
+    #
+    # Default 1.10× safety margin per stream — the parallel cost isn't
+    # exactly N× single-stream because each stream may have variable
+    # output size, but the multiplier needs SOME headroom over linear
+    # scaling. PLAN-EXPLOIT passes n_streams; the governor uses
+    # max(1.0, n_streams) × parallel_stream_factor as the multiplier.
+    parallel_stream_factor: float = field(
+        default_factory=lambda: _env_float(
+            "JARVIS_OP_COST_PARALLEL_STREAM_FACTOR", 1.1,
+        )
+    )
     # Default multiplier if route/complexity key is unknown (unknown token
     # taxonomy shouldn't starve the op — default to standard/light).
     default_route_factor: float = 1.5
@@ -215,6 +264,13 @@ class _OpCostEntry:
     route_factor: float = 1.0
     complexity_factor: float = 1.0
     retry_headroom: float = 1.0
+    # Parallel-stream multiplier (rooted-problem fix 2026-04-25).
+    # Defaults to 1.0 (single-stream / serial). PLAN-EXPLOIT calls
+    # `bump_for_parallel_streams(op_id, n_streams)` BEFORE its `gather()`
+    # so the cap is sized for N concurrent provider calls — preventing
+    # the F1 Slice 4 S2 post-fix bottleneck where a 3-stream fan-out
+    # ($0.49 total) tripped a single-stream-sized cap ($0.45).
+    parallel_factor: float = 1.0
     # Per-phase cost instrumentation — drill-down arc Slice 2.
     # phase_totals: {phase_name: cumulative_usd} rolling per-phase.
     # phase_by_provider: {phase_name: {provider: cumulative_usd}}.
@@ -319,7 +375,11 @@ class CostGovernor:
     # --------------------------------------------------------------
 
     def _derive_cap(
-        self, route: str, complexity: str, is_read_only: bool = False,
+        self,
+        route: str,
+        complexity: str,
+        is_read_only: bool = False,
+        parallel_factor: float = 1.0,
     ) -> Tuple[float, float, float]:
         """Compute ``(cap_usd, route_factor, complexity_factor)`` dynamically.
 
@@ -329,7 +389,15 @@ class CostGovernor:
         When ``is_read_only=True`` the cap is multiplied by
         ``cfg.readonly_factor`` (default 5.0) BEFORE the min/max clamp
         to account for subagent fan-out + Claude synthesis payload sizes.
-        Still bounded by max_cap_usd so runaway costs remain capped.
+
+        ``parallel_factor`` (default 1.0) scales the cap for fan-out
+        paths. PLAN-EXPLOIT passes ``max(1.0, n_streams) × cfg.parallel_stream_factor``
+        via :meth:`bump_for_parallel_streams` so a 3-stream concurrent
+        gather doesn't trip a single-stream-sized cap.
+
+        Still bounded by max_cap_usd so runaway costs remain capped
+        (the operator's financial circuit-breaker mandate per Manifesto
+        §6 — Iron Gate at the wallet layer).
         """
         cfg = self._config
         route_key = (route or "").strip().lower() or "standard"
@@ -348,6 +416,12 @@ class CostGovernor:
         )
         if is_read_only:
             raw_cap *= cfg.readonly_factor
+        # Parallel-stream multiplier (rooted-problem fix 2026-04-25).
+        # Defaults to 1.0 for serial / single-stream ops — byte-for-byte
+        # identical to pre-fix behavior. PLAN-EXPLOIT sets it via
+        # `bump_for_parallel_streams` to scale for fan-out.
+        if parallel_factor > 1.0:
+            raw_cap *= parallel_factor
 
         # Clamp into [min_cap_usd, max_cap_usd]; protects against env typos.
         cap = max(cfg.min_cap_usd, min(cfg.max_cap_usd, raw_cap))
@@ -418,6 +492,114 @@ class CostGovernor:
             self._config.retry_headroom,
         )
         return cap
+
+    def bump_for_parallel_streams(
+        self,
+        op_id: str,
+        n_streams: int,
+    ) -> Optional[float]:
+        """Recompute the cap for an op about to launch ``n_streams`` parallel
+        provider calls. Idempotent.
+
+        Called by PLAN-EXPLOIT before its ``asyncio.gather()`` of N
+        concurrent fan-out streams. Without this bump, the cap derived
+        at :meth:`start` (sized for ONE stream) would trip mid-flight
+        when the gather's cumulative spend crosses the cap, cancelling
+        the in-progress fan-out and exhausting the units (observed
+        F1 Slice 4 S2 post-fix: 3-stream gather = $0.49 vs $0.45 cap).
+
+        Multiplier semantics:
+          * ``n_streams <= 1`` → no-op (returns None, cap unchanged)
+          * ``n_streams >= 2`` → cap *= max(1.0, n_streams) × cfg.parallel_stream_factor
+
+        The bump is idempotent within an op's lifecycle: subsequent
+        calls with the same ``n_streams`` produce the same cap. Calls
+        with a HIGHER ``n_streams`` raise the cap further (rare —
+        most fan-outs decide n_streams once and stick with it).
+        Calls with a LOWER ``n_streams`` are NO-OP (caps never shrink
+        — the orchestrator must not retroactively starve an op that
+        already committed to a higher concurrency budget).
+
+        Returns the new cap_usd on success, None when:
+          * Governor disabled (master flag off)
+          * No entry for op_id (op not yet started — shouldn't happen
+            in production but defensive)
+          * n_streams <= 1 (no-op case)
+
+        Authority: this method ONLY raises the cap; it never lowers
+        below the existing cap_usd. The financial circuit-breaker
+        invariant (cumulative_usd < cap_usd) remains the sole
+        authoritative gate.
+        """
+        if not self._config.enabled:
+            return None
+        if n_streams <= 1:
+            return None
+
+        entry = self._entries.get(op_id)
+        if entry is None:
+            logger.debug(
+                "[CostGovernor] bump_for_parallel_streams: op=%s not yet "
+                "started — skipping bump (will use single-stream cap on charge)",
+                op_id[:12],
+            )
+            return None
+
+        # Compute the new parallel_factor. max(1.0, ...) guards against
+        # n_streams=0 misuse upstream (shouldn't happen per the n_streams<=1
+        # short-circuit above, but defensive).
+        new_parallel_factor = max(1.0, float(n_streams)) * self._config.parallel_stream_factor
+
+        # Idempotent: same factor → no change.
+        if abs(entry.parallel_factor - new_parallel_factor) < 1e-6:
+            return entry.cap_usd
+
+        # Caps NEVER shrink — only grow.
+        if new_parallel_factor < entry.parallel_factor:
+            return entry.cap_usd
+
+        # Recompute cap with the new factor. Preserves all other factors
+        # frozen at start() (route, complexity, headroom, readonly).
+        old_cap = entry.cap_usd
+        new_cap, _, _ = self._derive_cap(
+            route=entry.route,
+            complexity=entry.complexity,
+            is_read_only=False,  # readonly already absorbed into raw_cap at start()
+            parallel_factor=new_parallel_factor,
+        )
+        # If readonly was applied at start, _derive_cap above WITHOUT
+        # is_read_only=True would shrink the cap. Detect this by
+        # comparing baseline derivation to the saved entry's existing
+        # cap with parallel_factor=1.0; only apply the bump as a
+        # *delta* on top of the existing cap.
+        baseline_no_parallel, _, _ = self._derive_cap(
+            route=entry.route,
+            complexity=entry.complexity,
+            is_read_only=False,
+            parallel_factor=1.0,
+        )
+        # Multiplicative bump in linear space, then re-clamp to max_cap.
+        if baseline_no_parallel > 0:
+            ratio = new_parallel_factor / 1.0
+            new_cap = min(self._config.max_cap_usd, old_cap * ratio)
+        # Cap can never shrink below current
+        new_cap = max(new_cap, old_cap)
+
+        entry.cap_usd = new_cap
+        entry.parallel_factor = new_parallel_factor
+        # Reset exceeded flag if the new cap accommodates current spend
+        # (e.g. governor saw 1-stream cap exceed before PLAN-EXPLOIT
+        # called this — the bump retroactively rescues the op).
+        if entry.exceeded and entry.cumulative_usd < new_cap:
+            entry.exceeded = False
+        logger.info(
+            "[CostGovernor] op=%s cap bumped for parallel fan-out: "
+            "$%.4f → $%.4f (n_streams=%d, parallel_factor=%.2fx — "
+            "rooted-problem fix; per-stream cost stays charged against the "
+            "single per-op ledger but cap scales with concurrency)",
+            op_id[:12], old_cap, new_cap, n_streams, new_parallel_factor,
+        )
+        return new_cap
 
     def charge(
         self,

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -698,6 +698,17 @@ class GovernedOrchestrator:
         # pattern below, which is required for *rebindable* fields.
         self._oracle_update_lock: asyncio.Lock = self._state.oracle_update_lock
         self._cost_governor: CostGovernor = self._state.cost_governor
+        # Register the cost_governor as the process-wide default so
+        # pure helper modules (PLAN-EXPLOIT, etc.) can look it up
+        # without taking it as a parameter through every call site.
+        # Best-effort — never fails orchestrator construction.
+        try:
+            from backend.core.ouroboros.governance.cost_governor import (
+                set_default_cost_governor as _set_default_cg,
+            )
+            _set_default_cg(self._cost_governor)
+        except Exception:  # noqa: BLE001
+            pass
         self._forward_progress: ForwardProgressDetector = self._state.forward_progress
         self._productivity_detector: ProductivityDetector = (
             self._state.productivity_detector

--- a/backend/core/ouroboros/governance/plan_exploit.py
+++ b/backend/core/ouroboros/governance/plan_exploit.py
@@ -405,6 +405,29 @@ async def try_parallel_generate(
     # in the same task chain don't inherit the override. The reset is
     # done after every `return None` early-exit too.
     _plan_exploit_token = plan_exploit_active_var.set(True)
+    # Rooted-problem fix 2026-04-25 — bump the cost-governor cap to
+    # accommodate N concurrent provider calls. The cap derived at
+    # CLASSIFY/start() was sized for ONE stream; fanning out to
+    # len(units) streams without bumping causes the governor to
+    # cancel mid-gather (observed F1 Slice 4 S2: 3-stream fan-out
+    # spent $0.49 against $0.45 single-stream cap → enforce_cancelled
+    # 53.3s into wait, units exhausted on the false signal). Best-effort:
+    # any failure here MUST NOT block the gather (cap bump is purely
+    # additive observability + budget headroom — if the governor isn't
+    # available, fall through to the existing single-stream cap and
+    # let the gather either succeed or trip the cap as before).
+    try:
+        from backend.core.ouroboros.governance.cost_governor import (
+            get_default_cost_governor as _get_default_cg,
+        )
+        _cg = _get_default_cg()
+        if _cg is not None and hasattr(_cg, "bump_for_parallel_streams"):
+            _cg.bump_for_parallel_streams(_op_id, n_streams=len(units))
+    except Exception:  # noqa: BLE001 — additive, never blocks gather
+        logger.debug(
+            "[PLAN-EXPLOIT] op=%s cost-cap bump skipped (best-effort)",
+            _op_id, exc_info=True,
+        )
     try:
         per_unit_results = await _race_or_wait_for(
             asyncio.gather(*(_generate_unit(u) for u in units)),

--- a/tests/governance/test_cost_governor_parallel_streams.py
+++ b/tests/governance/test_cost_governor_parallel_streams.py
@@ -1,0 +1,257 @@
+"""Cost-governor parallel-stream cap fix (rooted-problem follow-up 2026-04-25).
+
+Pin the `bump_for_parallel_streams` behavior added to fix the F1 Slice 4
+S2 post-fix bottleneck:
+
+  Cost summary op=op-019dc369-982e phase=CLASSIFY spent=$0.4914 / cap=$0.4500
+  [ParallelDispatch enforce_cancelled] phase=wait elapsed_s=53.3
+
+3-stream PLAN-EXPLOIT cost ($0.49) vs single-stream cap ($0.45) caused
+the cost-governor to (correctly) cancel the in-flight fan-out. The
+financial circuit breaker fired EXACTLY as designed — the bug was in
+the cap derivation, not the enforcement.
+
+Operator binding 2026-04-25: "A 3-stream parallel fan-out (PLAN-EXPLOIT)
+should not be bottlenecked by a static, single-stream CLASSIFY cap...
+dynamicize the cost cap based on the n_allowed parallel streams."
+
+Pin coverage:
+
+A. Default-singleton accessor — set/get round-trip.
+B. `bump_for_parallel_streams` is no-op on n_streams<=1 (single-stream
+   = pre-fix behavior, byte-for-byte).
+C. `bump_for_parallel_streams` raises cap by `n_streams * parallel_stream_factor`.
+D. Cap NEVER shrinks — calls with lower n_streams return current cap.
+E. Idempotent — same n_streams produces same cap (no compounding).
+F. Cap never exceeds `max_cap_usd` (financial circuit-breaker invariant).
+G. Master-off (governor disabled) → bump returns None.
+H. No entry (op not started) → bump returns None gracefully.
+I. Reset of `exceeded` flag when bump retroactively rescues cap.
+J. Source-grep pin — PLAN-EXPLOIT calls bump before its gather.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.cost_governor import (
+    CostGovernor,
+    CostGovernorConfig,
+    get_default_cost_governor,
+    set_default_cost_governor,
+)
+
+
+# ---------------------------------------------------------------------------
+# (A) Default-singleton accessor
+# ---------------------------------------------------------------------------
+
+
+def test_default_singleton_round_trip() -> None:
+    """set_default_cost_governor + get_default_cost_governor round-trip."""
+    governor = CostGovernor(CostGovernorConfig())
+    set_default_cost_governor(governor)
+    try:
+        assert get_default_cost_governor() is governor
+    finally:
+        set_default_cost_governor(None)  # type: ignore[arg-type]
+
+
+def test_default_singleton_default_none() -> None:
+    """Before set, get returns None — pure helpers tolerate it."""
+    set_default_cost_governor(None)  # type: ignore[arg-type]
+    assert get_default_cost_governor() is None
+
+
+# ---------------------------------------------------------------------------
+# (B) Single-stream is no-op
+# ---------------------------------------------------------------------------
+
+
+def test_bump_n_streams_1_is_noop() -> None:
+    """n_streams=1 → bump returns None, cap unchanged (pre-fix parity)."""
+    g = CostGovernor(CostGovernorConfig())
+    g.start("op-test", route="standard", complexity="moderate")
+    pre_cap = g._entries["op-test"].cap_usd
+    result = g.bump_for_parallel_streams("op-test", n_streams=1)
+    assert result is None
+    assert g._entries["op-test"].cap_usd == pre_cap
+
+
+def test_bump_n_streams_0_is_noop() -> None:
+    """Defensive: n_streams=0 → no-op (shouldn't happen but guard)."""
+    g = CostGovernor(CostGovernorConfig())
+    g.start("op-test", route="standard", complexity="moderate")
+    pre_cap = g._entries["op-test"].cap_usd
+    assert g.bump_for_parallel_streams("op-test", n_streams=0) is None
+    assert g._entries["op-test"].cap_usd == pre_cap
+
+
+# ---------------------------------------------------------------------------
+# (C) Multi-stream raises cap proportionally
+# ---------------------------------------------------------------------------
+
+
+def test_bump_3_streams_raises_cap_by_3x_with_safety_margin() -> None:
+    """The F1 Slice 4 S2 scenario: 3-stream fan-out gets 3x baseline cap
+    × safety margin (default 1.1)."""
+    g = CostGovernor(CostGovernorConfig())
+    # standard + moderate (= "light" default) → cap=$0.10*1.5*1.0*3.0 = $0.45
+    g.start("op-test", route="standard", complexity="moderate")
+    pre_cap = g._entries["op-test"].cap_usd
+    new_cap = g.bump_for_parallel_streams("op-test", n_streams=3)
+    assert new_cap is not None
+    # 3 streams × 1.1 factor = 3.3x multiplier
+    assert new_cap == pytest.approx(pre_cap * 3 * 1.1, rel=0.01)
+    assert g._entries["op-test"].parallel_factor == pytest.approx(3.3, rel=0.01)
+
+
+def test_bump_5_streams_higher_cap() -> None:
+    g = CostGovernor(CostGovernorConfig())
+    g.start("op-test", route="standard", complexity="moderate")
+    pre_cap = g._entries["op-test"].cap_usd
+    new_cap = g.bump_for_parallel_streams("op-test", n_streams=5)
+    assert new_cap is not None
+    # 5 streams × 1.1 = 5.5x — but max_cap is $5.00 so will clamp
+    expected_unclamped = pre_cap * 5 * 1.1
+    cfg = g._config
+    expected_clamped = min(cfg.max_cap_usd, expected_unclamped)
+    assert new_cap == pytest.approx(expected_clamped, rel=0.01)
+
+
+# ---------------------------------------------------------------------------
+# (D) Caps never shrink — only grow
+# ---------------------------------------------------------------------------
+
+
+def test_bump_lower_n_streams_does_not_shrink_cap() -> None:
+    """After 5-stream bump, calling with 2-stream must NOT reduce cap.
+    The op already committed to a higher concurrency; retroactively
+    starving it would be incorrect."""
+    g = CostGovernor(CostGovernorConfig())
+    g.start("op-test", route="standard", complexity="moderate")
+    high_cap = g.bump_for_parallel_streams("op-test", n_streams=5)
+    lower_cap = g.bump_for_parallel_streams("op-test", n_streams=2)
+    assert lower_cap == high_cap  # No-op — caps never shrink
+
+
+# ---------------------------------------------------------------------------
+# (E) Idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_bump_idempotent_same_n_streams() -> None:
+    """Calling bump twice with same n_streams produces same cap."""
+    g = CostGovernor(CostGovernorConfig())
+    g.start("op-test", route="standard", complexity="moderate")
+    cap_a = g.bump_for_parallel_streams("op-test", n_streams=3)
+    cap_b = g.bump_for_parallel_streams("op-test", n_streams=3)
+    assert cap_a == cap_b
+
+
+# ---------------------------------------------------------------------------
+# (F) Financial circuit-breaker invariant — never exceeds max_cap
+# ---------------------------------------------------------------------------
+
+
+def test_bump_clamps_to_max_cap() -> None:
+    """Even with absurd n_streams, cap never exceeds max_cap_usd."""
+    g = CostGovernor(CostGovernorConfig())
+    g.start("op-test", route="complex", complexity="complex")  # high baseline
+    new_cap = g.bump_for_parallel_streams("op-test", n_streams=100)
+    cfg = g._config
+    assert new_cap <= cfg.max_cap_usd
+
+
+# ---------------------------------------------------------------------------
+# (G) Master-off — governor disabled → bump no-op
+# ---------------------------------------------------------------------------
+
+
+def test_bump_governor_disabled_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When master flag off, bump returns None without side effects."""
+    monkeypatch.setenv("JARVIS_OP_COST_GOVERNOR_ENABLED", "false")
+    g = CostGovernor(CostGovernorConfig())
+    assert g.bump_for_parallel_streams("op-test", n_streams=3) is None
+
+
+# ---------------------------------------------------------------------------
+# (H) Defensive — bump on unstarted op returns None gracefully
+# ---------------------------------------------------------------------------
+
+
+def test_bump_unstarted_op_returns_none() -> None:
+    """If start() wasn't called for op_id, bump is a graceful no-op."""
+    g = CostGovernor(CostGovernorConfig())
+    assert g.bump_for_parallel_streams("op-not-started", n_streams=3) is None
+
+
+# ---------------------------------------------------------------------------
+# (I) Bump retroactively rescues op that just exceeded
+# ---------------------------------------------------------------------------
+
+
+def test_bump_resets_exceeded_when_new_cap_accommodates() -> None:
+    """If charge() set exceeded=True at the old cap, but the bump raises
+    the cap above cumulative_usd, exceeded must reset (retroactive
+    rescue — the F1 Slice 4 S2 fix scenario)."""
+    g = CostGovernor(CostGovernorConfig())
+    g.start("op-test", route="standard", complexity="moderate")
+    # Charge $0.49 against $0.45 cap — sets exceeded=True
+    g.charge("op-test", 0.49, provider="claude-api", phase="GENERATE")
+    assert g.is_exceeded("op-test") is True
+    # Now PLAN-EXPLOIT calls bump for the 3-stream gather
+    new_cap = g.bump_for_parallel_streams("op-test", n_streams=3)
+    assert new_cap > 0.49
+    # Critical: exceeded flag MUST reset (cumulative now < new cap)
+    assert g.is_exceeded("op-test") is False
+
+
+# ---------------------------------------------------------------------------
+# (J) Source-grep pin — PLAN-EXPLOIT calls bump before gather
+# ---------------------------------------------------------------------------
+
+
+def _read(p: str) -> str:
+    return Path(p).read_text(encoding="utf-8")
+
+
+def test_pin_plan_exploit_calls_bump_before_gather() -> None:
+    """plan_exploit.py imports get_default_cost_governor + calls
+    bump_for_parallel_streams BEFORE the asyncio.gather()."""
+    src = _read("backend/core/ouroboros/governance/plan_exploit.py")
+    assert "get_default_cost_governor" in src
+    assert "bump_for_parallel_streams" in src
+    # Must appear BEFORE the gather (sequence pin)
+    bump_idx = src.find("bump_for_parallel_streams(_op_id")
+    gather_idx = src.find("asyncio.gather(*(_generate_unit")
+    assert bump_idx > 0, "bump call site missing"
+    assert gather_idx > 0, "gather call site missing"
+    assert bump_idx < gather_idx, (
+        "bump_for_parallel_streams must be called BEFORE asyncio.gather "
+        "(rooted-problem fix: cap must be sized for fan-out before the "
+        "concurrent provider calls fire)"
+    )
+
+
+def test_pin_orchestrator_registers_default_cost_governor() -> None:
+    """Orchestrator wires set_default_cost_governor at __init__ so pure
+    helpers can look it up."""
+    src = _read("backend/core/ouroboros/governance/orchestrator.py")
+    assert "set_default_cost_governor" in src
+
+
+def test_pin_cost_governor_has_bump_method() -> None:
+    """CostGovernor exposes bump_for_parallel_streams with correct signature."""
+    g = CostGovernor(CostGovernorConfig())
+    assert hasattr(g, "bump_for_parallel_streams")
+    assert callable(g.bump_for_parallel_streams)
+
+
+def test_pin_parallel_stream_factor_default_1_1() -> None:
+    """Default safety margin 1.1× per stream — env-overridable."""
+    cfg = CostGovernorConfig()
+    assert cfg.parallel_stream_factor == 1.1


### PR DESCRIPTION
## Cost-cap accounting fix — completes the Wave 3 unblock chain

Per operator binding 2026-04-25: *"A 3-stream parallel fan-out
(PLAN-EXPLOIT) should not be bottlenecked by a static, single-stream
CLASSIFY cap... dynamicize the cost cap based on the n_allowed parallel
streams."*

## The diagnosis

F1 Slice 4 S2 post-fix (\`bt-2026-04-25-065229\`) — the breakthrough
session — proved the entire integration chain works end-to-end when
budget allows:

1. ✅ F1 priority queue (8 markers, seed dequeued first in 0.10s)
2. ✅ F2 routing override (3 markers, STANDARD route via priority-0.5)
3. ✅ Outer-retry fix (#19706) firing (4 retry attempts)
4. ✅ GENERATE → PLAN-EXPLOIT 3 streams → 8 merged files in 176s
5. ✅ \`[ParallelDispatch] allowed=true n_requested=4 n_allowed=3\` — **first ever live**
6. ✅ \`[ParallelDispatch enforce_submit_start]\` — **first ever live**
7. ❌ \`[ParallelDispatch enforce_cancelled]\` at \`phase=wait elapsed_s=53.3\`
   → \`Cost summary spent=\$0.4914 / cap=\$0.4500\`

The cost-governor (correctly) cancelled the in-flight fan-out. The
financial circuit breaker fired EXACTLY as designed — the bug was in
the cap derivation, not the enforcement.

## Why the cap was wrong

The seed's per-op cap derivation:
\`\`\`
cap = baseline (\$0.10) × route[standard] (1.5) × complexity[moderate→light] (1.0) × headroom (3.0)
    = \$0.45
\`\`\`

That \$0.45 was sized for ONE Claude stream. PLAN-EXPLOIT spawned 3
concurrent Claude streams (\$0.49 total). The cap derivation didn't
know about the fan-out width.

## The fix (Option 1 — dynamicize the cap)

\`cost_governor.py\`:
- \`CostGovernorConfig.parallel_stream_factor\` (default 1.10× safety
  margin per stream, env-overridable)
- \`_OpCostEntry.parallel_factor\` (frozen multiplier for postmortem)
- \`_derive_cap\` accepts \`parallel_factor\` (defaults 1.0 → byte-for-byte
  pre-fix)
- \`CostGovernor.bump_for_parallel_streams(op_id, n_streams)\`:
  - No-op when \`n_streams ≤ 1\` (pre-fix parity)
  - No-op when governor disabled / op not yet started
  - Idempotent — same n_streams → same cap
  - **Caps NEVER shrink** (lower n_streams → no-op)
  - **Always clamped to \`max_cap_usd\`** (financial circuit-breaker
    invariant preserved)
  - Resets \`entry.exceeded\` if new cap accommodates current spend
    (retroactive rescue)
- New default-singleton accessors \`set/get_default_cost_governor\` —
  process-wide reference so PLAN-EXPLOIT (a "pure" helper) can look
  up the active governor without taking it as a parameter through every
  call site.

\`orchestrator.py\`:
- After \`self._cost_governor\` binding, registers the process-wide
  default via \`set_default_cost_governor\` (best-effort, never fails
  construction).

\`plan_exploit.py\`:
- BEFORE \`asyncio.gather(*(_generate_unit(u) for u in units))\`, calls
  \`bump_for_parallel_streams(_op_id, n_streams=len(units))\`.
- Best-effort — never blocks the gather. If the governor isn't
  available, falls through to existing single-stream cap behavior.

## Authority preservation

- **§1 additive only** — no rule softened, no new mutation surface
- **§6 Iron Gate (financial circuit-breaker layer) ENHANCED** — cap
  derivation correct for fan-out; enforcement remains authoritative
- **\`max_cap_usd\` clamp NEVER BREACHED** — runaway costs still capped
- **Caps NEVER shrink** — operator commitment to higher concurrency
  budget honored
- **Master-off** (\`JARVIS_OP_COST_GOVERNOR_ENABLED=false\`) → all bumps
  silently skip

## Hot-revert

- \`JARVIS_OP_COST_PARALLEL_STREAM_FACTOR=0.0\` → multiplier disabled
  (effectively pre-fix behavior)
- OR \`JARVIS_OP_COST_GOVERNOR_ENABLED=false\` → full hot-revert (whole
  governor off)

## Tests (16 new — \`test_cost_governor_parallel_streams.py\`)

| # | Pin |
|---|---|
| A | Default-singleton round-trip + None-default |
| B | n_streams ∈ {0, 1} are no-ops (pre-fix parity) |
| C | n_streams=3 → cap × 3 × 1.1 (default safety margin) |
| D | Lower n_streams call NEVER shrinks cap |
| E | Idempotent — same n_streams → same cap |
| F | \`max_cap_usd\` clamp holds under absurd n_streams |
| G | Master-off → bump returns None |
| H | Unstarted op → graceful None |
| I | **Retroactive rescue**: bump resets \`exceeded\` if new cap accommodates |
| J | Source-grep pins (PLAN-EXPLOIT bump-before-gather sequence, orchestrator registration, bump method exists, parallel_stream_factor default 1.1) |

## Test plan
- [x] **16/16** cost-governor parallel-stream tests green
- [x] **88/88** combined regression green (cost-governor + outer-retry
      + plan-exploit + W3(7) graduation + W3(6) Slice 5a structural pins)

## What this unblocks for Wave 3

S2 post-fix proved the whole chain works when budget allows. The single
remaining gap was the cost-cap vs fan-out spend mismatch this commit
fixes. Next live battle-test session under post-merge conditions should
produce the first complete W3(6) Slice 5b graduation evidence:
\`enforce_submit_start\` → fan-out units complete → 3 target files
written → APPLY → COMPLETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cost-cap accounting by scaling each op’s cap to the number of parallel PLAN-EXPLOIT streams. Prevents false cancellations during fan-out while keeping the max-cap safety invariant.

- **Bug Fixes**
  - Cap now multiplies by `n_streams * parallel_stream_factor` (default 1.1) and remains clamped to `max_cap_usd`.
  - Added `CostGovernor.bump_for_parallel_streams(op_id, n_streams)`; idempotent, no-op for `<=1`, caps never shrink, and it clears `exceeded` if spend fits the new cap.
  - `plan_exploit` calls the bump before `asyncio.gather`; best-effort and falls back to single-stream behavior if the governor isn’t available.
  - Orchestrator registers a process-wide default via `set_default_cost_governor`; helpers read it with `get_default_cost_governor` (no new params threaded).
  - Env controls: `JARVIS_OP_COST_PARALLEL_STREAM_FACTOR` (tune/disable) and `JARVIS_OP_COST_GOVERNOR_ENABLED` (master off) retained.

<sup>Written for commit 8ab48aae42676494bb0645404163240151711053. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

