### PR TITLE
feat(rsi): Phase 0 audit + P0 PostmortemRecallService (PRD Phase 1 — first cognitive feedback loop)

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -1818,6 +1818,64 @@ class GovernedOrchestrator:
                     exc_info=True,
                 )
 
+            # ---- P0 PostmortemRecall (PRD Phase 1): prior-op lessons ----
+            # Closes the rooted "system has perfect memory and zero recall"
+            # gap from PRD §4.2 Shallow #2. Looks up POSTMORTEMs from prior
+            # sessions whose op_signature is similar to the current op's
+            # signature (file paths + descriptive intent) and injects up to
+            # top_k lessons into the prompt as "## Lessons from prior similar
+            # ops" section.
+            #
+            # Authority invariant per PRD §12.2: read-only, best-effort, never
+            # blocks the FSM. Master flag default-off
+            # (`JARVIS_POSTMORTEM_RECALL_ENABLED=true` to enable). When off
+            # this is byte-for-byte pre-P0 behavior. PostmortemRecallService
+            # itself returns [] cleanly on any failure path.
+            try:
+                from backend.core.ouroboros.governance.postmortem_recall import (
+                    get_default_service as _get_pm_recall,
+                    render_recall_section as _render_pm_recall,
+                )
+                _pm_svc = _get_pm_recall()
+                if _pm_svc is not None:
+                    # Build the op signature: target_files + description.
+                    _pm_target_files = ", ".join(
+                        sorted((ctx.target_files or ()))[:5]
+                    )
+                    _pm_op_signature = (
+                        f"description={(ctx.description or '')[:200]} | "
+                        f"files={_pm_target_files}"
+                    )
+                    _pm_matches = _pm_svc.recall_for_op(_pm_op_signature)
+                    _pm_section = _render_pm_recall(_pm_matches)
+                    if _pm_section:
+                        _existing = getattr(ctx, "strategic_memory_prompt", "") or ""
+                        ctx = ctx.with_strategic_memory_context(
+                            strategic_intent_id=ctx.strategic_intent_id or "pm-recall-p0",
+                            strategic_memory_fact_ids=ctx.strategic_memory_fact_ids,
+                            strategic_memory_prompt=(
+                                _existing + "\n\n" + _pm_section
+                                if _existing else _pm_section
+                            ),
+                            strategic_memory_digest=ctx.strategic_memory_digest,
+                        )
+                        logger.info(
+                            "[PostmortemRecall] op=%s enabled=true matched=%d "
+                            "inject_site=context_expansion (P0 — PRD Phase 1)",
+                            ctx.op_id, len(_pm_matches),
+                        )
+                    else:
+                        logger.debug(
+                            "[PostmortemRecall] op=%s no matches "
+                            "inject_site=context_expansion",
+                            ctx.op_id,
+                        )
+            except Exception:
+                logger.debug(
+                    "[Orchestrator] PostmortemRecall injection skipped",
+                    exc_info=True,
+                )
+
             # ---- SemanticIndex v0.1: recency-weighted focus + closures ----
             # Soft semantic prior drawn from the recency-weighted centroid
             # over recent commits + active goals + recent conversation.

--- a/backend/core/ouroboros/governance/postmortem_recall.py
+++ b/backend/core/ouroboros/governance/postmortem_recall.py
@@ -1,0 +1,585 @@
+"""Postmortem Recall Service — P0 of OUROBOROS_VENOM_PRD.md Phase 1.
+
+Closes the rooted "system has perfect memory and zero recall" gap from
+the PRD §4.2 Shallow #2.
+
+Today, POSTMORTEM messages get written to session debug.log + summary.json
++ ConversationBridge buffer — and then nothing reads them at the next op's
+decision time. The system makes the same mistake, writes the same
+postmortem, learns nothing.
+
+This service provides a thin recall layer:
+
+    recall = PostmortemRecallService(...)
+    lessons = recall.recall_for_op(op_signature, top_k=3)
+    if lessons:
+        prompt += render_recall_section(lessons)
+
+Architecture:
+- Reads POSTMORTEM events from `.ouroboros/sessions/<id>/debug.log`
+  files (matches existing comm_protocol output format).
+- Computes similarity between current op signature and each prior
+  postmortem using the SemanticIndex `_Embedder` (cosine similarity).
+- Time-decays by halflife (default 30 days) so old postmortems matter
+  less than recent ones.
+- Returns top-k matches above a similarity threshold.
+
+Authority preservation (per PRD §12.2):
+- Read-only — never mutates code, never writes to git/, never opens
+  approval surfaces, never invokes Iron Gate / risk-tier-floor / etc.
+- Best-effort — any failure (no semantic index, no embedder, parse
+  errors) returns an empty list. Caller renders nothing.
+- Master flag default OFF (`JARVIS_POSTMORTEM_RECALL_ENABLED=true`
+  to enable). Per PRD discipline.
+
+Authority invariants (grep-pinned per PRD §11 Layer 1):
+- Does NOT import: orchestrator, policy, iron_gate, risk_tier,
+  change_engine, candidate_generator, gate, semantic_guardian.
+- Read-only data access — only reads files; never writes (except its
+  own JSONL ledger).
+- Uses narrow regex parsing for postmortem payload — does NOT call
+  ``ast.literal_eval`` or any code-evaluation function (per security
+  invariant).
+
+PRD reference: §9 Phase 1 P0.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+
+logger = logging.getLogger("Ouroboros.PostmortemRecall")
+
+
+# ---------------------------------------------------------------------------
+# Env knobs
+# ---------------------------------------------------------------------------
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("true", "1", "yes", "on")
+
+
+def _env_int(name: str, default: int, minimum: int = 0) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        v = float(raw)
+        return max(minimum, v)
+    except (TypeError, ValueError):
+        return default
+
+
+def is_enabled() -> bool:
+    """Master flag — `JARVIS_POSTMORTEM_RECALL_ENABLED` (default ``false``).
+
+    Default-off until graduation cadence (3 clean live sessions per PRD §11
+    Layer 4). Master-off → service is a no-op; never queries postmortems,
+    never logs.
+    """
+    return _env_bool("JARVIS_POSTMORTEM_RECALL_ENABLED", False)
+
+
+def top_k() -> int:
+    """`JARVIS_POSTMORTEM_RECALL_TOP_K` — default ``3``.
+
+    Maximum number of past postmortems to inject into a single prompt.
+    PRD §9 P0 specifies "up to 3 relevant lessons". Tunable for ops
+    where deeper recall might help (or shallower for cost/context
+    discipline)."""
+    return _env_int("JARVIS_POSTMORTEM_RECALL_TOP_K", 3, minimum=0)
+
+
+def decay_days() -> float:
+    """`JARVIS_POSTMORTEM_RECALL_DECAY_DAYS` — default ``30.0``.
+
+    Half-life for postmortem relevance. Older postmortems get weighted
+    less in the similarity score (multiplied by 2^(-age_days/halflife)).
+    Operator binding 2026-04-25 (PRD §16): default 30d, env-tunable.
+    """
+    return _env_float("JARVIS_POSTMORTEM_RECALL_DECAY_DAYS", 30.0, minimum=0.1)
+
+
+def similarity_threshold() -> float:
+    """`JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD` — default ``0.5``.
+
+    Below this cosine similarity, postmortems are filtered out. Prevents
+    spurious injection when there's no meaningful match. 0.5 is
+    conservative; tighten to 0.7 in HARDEN posture for noise reduction.
+    """
+    return _env_float("JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD", 0.5, minimum=0.0)
+
+
+def max_postmortems_to_scan() -> int:
+    """`JARVIS_POSTMORTEM_RECALL_MAX_SCAN` — default ``500``.
+
+    Hard ceiling on how many recent postmortems get embedded + scored.
+    Prevents unbounded scan-time on long-running deployments.
+    """
+    return _env_int("JARVIS_POSTMORTEM_RECALL_MAX_SCAN", 500, minimum=1)
+
+
+# ---------------------------------------------------------------------------
+# Records
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PostmortemRecord:
+    """One postmortem extracted from a session debug.log."""
+
+    op_id: str
+    session_id: str
+    root_cause: str
+    failed_phase: str
+    next_safe_action: str
+    target_files: tuple
+    timestamp_iso: str
+    timestamp_unix: float
+
+    def signature_text(self) -> str:
+        """Build the embeddable text representation for similarity scoring."""
+        files_text = ", ".join(sorted(self.target_files))[:300]
+        return (
+            f"phase={self.failed_phase} | root_cause={self.root_cause[:200]} | "
+            f"files={files_text}"
+        )
+
+    def lesson_text(self) -> str:
+        """Render a one-line lesson suitable for prompt injection."""
+        files_summary = ", ".join(sorted(self.target_files)[:3])
+        if len(self.target_files) > 3:
+            files_summary += f" (+{len(self.target_files) - 3} more)"
+        next_action = (
+            f" — next-safe-action: {self.next_safe_action}"
+            if self.next_safe_action and self.next_safe_action != "none"
+            else ""
+        )
+        return (
+            f"op={self.op_id[:16]} failed at {self.failed_phase} "
+            f"because: {self.root_cause[:150]} (files: {files_summary}){next_action}"
+        )
+
+
+@dataclass(frozen=True)
+class RecallMatch:
+    """A scored postmortem match for the current op."""
+
+    record: PostmortemRecord
+    raw_similarity: float
+    decayed_similarity: float
+    age_days: float
+
+    def to_ledger_dict(self) -> Dict[str, Any]:
+        """JSONL-serializable representation for postmortem_recall_history.jsonl."""
+        return {
+            "schema_version": "postmortem_recall.1",
+            "op_id": self.record.op_id,
+            "session_id": self.record.session_id,
+            "failed_phase": self.record.failed_phase,
+            "root_cause": self.record.root_cause[:300],
+            "raw_similarity": round(self.raw_similarity, 4),
+            "decayed_similarity": round(self.decayed_similarity, 4),
+            "age_days": round(self.age_days, 2),
+            "matched_at_iso": datetime.now(tz=timezone.utc).isoformat(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Postmortem extraction (narrow regex parser — never calls ast/eval)
+# ---------------------------------------------------------------------------
+
+
+# Matches: 2026-04-25T01:08:13 [...comm_protocol] INFO [CommProtocol] POSTMORTEM op=op-019dc... seq=N payload={...}
+_POSTMORTEM_LINE_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\s+"
+    r"\[.*comm_protocol.*\]\s+\w+\s+\[CommProtocol\]\s+POSTMORTEM\s+"
+    r"op=(?P<op_id>[a-zA-Z0-9_\-]+)\s+seq=\d+\s+payload=(?P<payload>.+)$"
+)
+
+# Narrow extractors for each payload field. Avoid ast.literal_eval (security
+# hook flags it; also overkill for our 4 known string/list fields).
+# Format is Python repr() — single quotes, with True/False/None literals.
+_PAYLOAD_FIELD_STR_RE = re.compile(
+    r"['\"]({field})['\"]\s*:\s*['\"]([^'\"]*?)['\"](?=\s*[,}}])"
+)
+_PAYLOAD_FIELD_LIST_RE = re.compile(
+    r"['\"]({field})['\"]\s*:\s*\[([^\]]*)\]"
+)
+
+
+def _extract_payload_str(payload: str, field: str) -> str:
+    """Extract a single string-typed field value from a Python-repr dict.
+    Returns empty string if not found."""
+    pattern = re.compile(
+        r"['\"]" + re.escape(field) + r"['\"]\s*:\s*['\"]([^'\"]*?)['\"]"
+    )
+    m = pattern.search(payload)
+    return m.group(1).strip() if m else ""
+
+
+def _extract_payload_list(payload: str, field: str) -> List[str]:
+    """Extract a string-list-typed field value from a Python-repr dict.
+    Returns empty list if not found."""
+    pattern = re.compile(
+        r"['\"]" + re.escape(field) + r"['\"]\s*:\s*\[([^\]]*)\]"
+    )
+    m = pattern.search(payload)
+    if not m:
+        return []
+    inner = m.group(1)
+    # Split on commas; strip whitespace + surrounding quotes.
+    items = []
+    for part in inner.split(","):
+        cleaned = part.strip().strip("'\"")
+        if cleaned:
+            items.append(cleaned)
+    return items
+
+
+def _parse_postmortem_line(
+    line: str, session_id: str,
+) -> Optional[PostmortemRecord]:
+    """Parse one debug.log line into a PostmortemRecord, or None on miss.
+
+    Defensive parsing — comm_protocol uses Python repr() for payload
+    serialization (NOT JSON). We use narrow regex extractors for each
+    field rather than ast.literal_eval (security hook + overkill).
+    Skips any line that doesn't parse cleanly.
+    """
+    m = _POSTMORTEM_LINE_RE.match(line.strip())
+    if m is None:
+        return None
+    payload = m.group("payload").strip()
+    if not payload.startswith("{"):
+        return None
+
+    root_cause = _extract_payload_str(payload, "root_cause")
+    failed_phase = _extract_payload_str(payload, "failed_phase")
+    next_safe_action = _extract_payload_str(payload, "next_safe_action")
+    target_files = _extract_payload_list(payload, "target_files")
+
+    ts_raw = m.group("ts")
+    try:
+        ts_dt = datetime.strptime(ts_raw, "%Y-%m-%dT%H:%M:%S").replace(
+            tzinfo=timezone.utc
+        )
+        ts_unix = ts_dt.timestamp()
+    except (ValueError, TypeError):
+        return None
+
+    return PostmortemRecord(
+        op_id=str(m.group("op_id")),
+        session_id=session_id,
+        root_cause=root_cause,
+        failed_phase=failed_phase,
+        next_safe_action=next_safe_action,
+        target_files=tuple(target_files),
+        timestamp_iso=ts_dt.isoformat(),
+        timestamp_unix=ts_unix,
+    )
+
+
+def _scan_session_debug_log(
+    debug_log: Path, session_id: str, limit: int,
+) -> List[PostmortemRecord]:
+    """Extract POSTMORTEM records from a single session debug.log."""
+    records: List[PostmortemRecord] = []
+    if not debug_log.exists():
+        return records
+    try:
+        with debug_log.open("r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if "POSTMORTEM" not in line:
+                    continue
+                rec = _parse_postmortem_line(line, session_id=session_id)
+                if rec is None:
+                    continue
+                # Skip "root_cause=none" — those are clean COMPLETE ops,
+                # not failures with lessons. (Per ConversationBridge
+                # filter at format_postmortem_payload.)
+                if rec.root_cause.lower() in ("", "none"):
+                    continue
+                records.append(rec)
+                if len(records) >= limit:
+                    break
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "[PostmortemRecall] scan failed for %s — best-effort skip",
+            debug_log, exc_info=True,
+        )
+    return records
+
+
+def _gather_recent_postmortems(
+    sessions_dir: Path, max_total: int,
+) -> List[PostmortemRecord]:
+    """Walk sessions newest-first, accumulate postmortems up to max_total."""
+    all_records: List[PostmortemRecord] = []
+    if not sessions_dir.exists() or not sessions_dir.is_dir():
+        return all_records
+    # Newest sessions first (lexicographic on bt-YYYY-MM-DD-HHMMSS).
+    session_dirs = sorted(
+        [p for p in sessions_dir.iterdir() if p.is_dir() and p.name.startswith("bt-")],
+        reverse=True,
+    )
+    per_session_cap = max(1, max_total // max(1, min(20, len(session_dirs))))
+    for session_dir in session_dirs:
+        debug_log = session_dir / "debug.log"
+        recs = _scan_session_debug_log(
+            debug_log, session_id=session_dir.name, limit=per_session_cap,
+        )
+        all_records.extend(recs)
+        if len(all_records) >= max_total:
+            break
+    return all_records[:max_total]
+
+
+# ---------------------------------------------------------------------------
+# Similarity + recall
+# ---------------------------------------------------------------------------
+
+
+def _decay_factor(age_seconds: float, halflife_days: float) -> float:
+    """Standard half-life decay: 2^(-age_days/halflife)."""
+    age_days = age_seconds / 86400.0
+    if halflife_days <= 0:
+        return 1.0
+    return float(2.0 ** (-age_days / halflife_days))
+
+
+class PostmortemRecallService:
+    """Recall prior postmortems similar to the current op for prompt injection.
+
+    Construction is cheap; embedding happens lazily on first recall_for_op().
+
+    Parameters
+    ----------
+    sessions_dir:
+        Path to ``.ouroboros/sessions/`` (where battle-test sessions
+        write their debug.log + summary.json).
+    semantic_index:
+        Optional pre-constructed ``SemanticIndex`` instance. Reserved
+        for future use; currently lazy-loads the embedder directly.
+    ledger_path:
+        Optional path to write the recall history JSONL. Defaults to
+        ``.jarvis/postmortem_recall_history.jsonl``.
+    """
+
+    def __init__(
+        self,
+        sessions_dir: Path,
+        semantic_index: Any = None,
+        ledger_path: Optional[Path] = None,
+    ) -> None:
+        self._sessions_dir = Path(sessions_dir)
+        self._semantic_index = semantic_index
+        self._ledger_path = ledger_path or Path(".jarvis/postmortem_recall_history.jsonl")
+        self._embedder: Optional[Any] = None  # lazy
+
+    def _ensure_embedder(self) -> Optional[Any]:
+        """Lazy-init the embedder. Returns None if unavailable (best-effort)."""
+        if self._embedder is not None:
+            return self._embedder
+        try:
+            from backend.core.ouroboros.governance.semantic_index import (
+                _Embedder as _SemanticEmbedder,
+                _embedder_name as _emb_name,
+            )
+            emb = _SemanticEmbedder(model_name=_emb_name())
+            if emb.disabled:
+                return None
+            self._embedder = emb
+            return emb
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[PostmortemRecall] embedder lazy-init failed", exc_info=True,
+            )
+            return None
+
+    def recall_for_op(
+        self,
+        op_signature: str,
+        top_k_override: Optional[int] = None,
+    ) -> List[RecallMatch]:
+        """Find prior postmortems similar to ``op_signature``."""
+        if not is_enabled():
+            return []
+        if not op_signature or not op_signature.strip():
+            return []
+        try:
+            return self._recall_inner(op_signature, top_k_override)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[PostmortemRecall] recall_for_op failed — returning []",
+                exc_info=True,
+            )
+            return []
+
+    def _recall_inner(
+        self,
+        op_signature: str,
+        top_k_override: Optional[int],
+    ) -> List[RecallMatch]:
+        embedder = self._ensure_embedder()
+        if embedder is None:
+            logger.debug("[PostmortemRecall] no embedder available — returning []")
+            return []
+
+        records = _gather_recent_postmortems(
+            self._sessions_dir, max_total=max_postmortems_to_scan(),
+        )
+        if not records:
+            return []
+
+        # Embed query + corpus in one batch for efficiency.
+        texts = [op_signature] + [r.signature_text() for r in records]
+        vectors = embedder.embed(texts)
+        if vectors is None or len(vectors) != len(texts):
+            logger.debug(
+                "[PostmortemRecall] embedding returned %s vectors for %d texts — skip",
+                "None" if vectors is None else len(vectors), len(texts),
+            )
+            return []
+
+        from backend.core.ouroboros.governance.semantic_index import _cosine
+
+        query_vec = vectors[0]
+        corpus_vecs = vectors[1:]
+        now_unix = time.time()
+        threshold = similarity_threshold()
+        halflife = decay_days()
+
+        scored: List[RecallMatch] = []
+        for rec, vec in zip(records, corpus_vecs):
+            raw_sim = float(_cosine(query_vec, vec))
+            age_seconds = max(0.0, now_unix - rec.timestamp_unix)
+            decay = _decay_factor(age_seconds, halflife)
+            decayed = raw_sim * decay
+            if decayed < threshold:
+                continue
+            scored.append(RecallMatch(
+                record=rec,
+                raw_similarity=raw_sim,
+                decayed_similarity=decayed,
+                age_days=age_seconds / 86400.0,
+            ))
+
+        scored.sort(key=lambda m: m.decayed_similarity, reverse=True)
+        k = top_k_override if top_k_override is not None else top_k()
+        result = scored[:max(0, k)]
+        if result:
+            self._persist_to_ledger(op_signature, result)
+            logger.info(
+                "[PostmortemRecall] op_signature=%r matched %d postmortems "
+                "(threshold=%.2f, top_k=%d, decayed_top=%.3f)",
+                op_signature[:60], len(result), threshold, k,
+                result[0].decayed_similarity,
+            )
+        return result
+
+    def _persist_to_ledger(
+        self,
+        op_signature: str,
+        matches: List[RecallMatch],
+    ) -> None:
+        """Append a recall event to the JSONL ledger. Best-effort."""
+        try:
+            self._ledger_path.parent.mkdir(parents=True, exist_ok=True)
+            entry = {
+                "schema_version": "postmortem_recall.1",
+                "ts_iso": datetime.now(tz=timezone.utc).isoformat(),
+                "op_signature": op_signature[:300],
+                "match_count": len(matches),
+                "matches": [m.to_ledger_dict() for m in matches],
+            }
+            with self._ledger_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[PostmortemRecall] ledger write failed", exc_info=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering
+# ---------------------------------------------------------------------------
+
+
+def render_recall_section(matches: Sequence[RecallMatch]) -> Optional[str]:
+    """Render recalled postmortems as a prompt section, or None if empty."""
+    if not matches:
+        return None
+    lines = ["## Lessons from prior similar ops"]
+    lines.append("")
+    for m in matches:
+        lines.append(f"- {m.record.lesson_text()}")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Default-singleton accessor
+# ---------------------------------------------------------------------------
+
+
+_default_service: Optional[PostmortemRecallService] = None
+
+
+def get_default_service(
+    sessions_dir: Optional[Path] = None,
+) -> Optional[PostmortemRecallService]:
+    """Return the process-wide PostmortemRecallService.
+
+    Lazily constructs on first call. Returns None if disabled (master
+    flag off) so callers can short-circuit cleanly.
+    """
+    if not is_enabled():
+        return None
+    global _default_service
+    if _default_service is None:
+        sd = sessions_dir or Path(".ouroboros/sessions")
+        _default_service = PostmortemRecallService(sessions_dir=sd)
+    return _default_service
+
+
+def reset_default_service() -> None:
+    """Reset the singleton — for tests and config reload."""
+    global _default_service
+    _default_service = None
+
+
+__all__ = [
+    "PostmortemRecord",
+    "RecallMatch",
+    "PostmortemRecallService",
+    "is_enabled",
+    "top_k",
+    "decay_days",
+    "similarity_threshold",
+    "max_postmortems_to_scan",
+    "render_recall_section",
+    "get_default_service",
+    "reset_default_service",
+]

--- a/tests/governance/test_postmortem_recall_p0.py
+++ b/tests/governance/test_postmortem_recall_p0.py
@@ -575,3 +575,29 @@ def test_pin_jsonl_schema_version() -> None:
     """Schema version pinned for ledger compatibility."""
     src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
     assert '"postmortem_recall.1"' in src
+
+
+def test_pin_orchestrator_invokes_recall_at_context_expansion() -> None:
+    """Wiring invariant: orchestrator must invoke get_default_service +
+    render_recall_section at the CONTEXT_EXPANSION injection site."""
+    src = _read("backend/core/ouroboros/governance/orchestrator.py")
+    assert "from backend.core.ouroboros.governance.postmortem_recall" in src
+    assert "get_default_service as _get_pm_recall" in src
+    assert "render_recall_section as _render_pm_recall" in src
+    assert "PRD Phase 1" in src
+    # Best-effort discipline: wrapped in try/except (never blocks FSM)
+    assert "[Orchestrator] PostmortemRecall injection skipped" in src
+
+
+def test_pin_orchestrator_recall_after_conversation_bridge() -> None:
+    """Sequence pin: PostmortemRecall block appears AFTER ConversationBridge
+    block (matches the ordering established in CONTEXT_EXPANSION)."""
+    src = _read("backend/core/ouroboros/governance/orchestrator.py")
+    bridge_idx = src.find("ConversationBridge injection skipped")
+    recall_idx = src.find("PostmortemRecall injection skipped")
+    assert bridge_idx > 0, "ConversationBridge marker missing"
+    assert recall_idx > 0, "PostmortemRecall marker missing"
+    assert bridge_idx < recall_idx, (
+        "PostmortemRecall must inject AFTER ConversationBridge "
+        "(per CONTEXT_EXPANSION ordering)"
+    )

--- a/tests/governance/test_postmortem_recall_p0.py
+++ b/tests/governance/test_postmortem_recall_p0.py
@@ -1,0 +1,577 @@
+"""P0 — POSTMORTEM Recall Service tests (PRD Phase 1).
+
+Per OUROBOROS_VENOM_PRD.md §11 4-layer test discipline:
+- Layer 1 (Unit): ~25 unit tests covering parsing, scoring, env knobs
+- Layer 2 (Integration): cross-component (recall hook surface)
+- Layer 4 (Graduation pins): source-grep + master-off + authority
+  invariants
+
+Coverage map per PRD §11 P0 row.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# (A) Env knobs
+# ---------------------------------------------------------------------------
+
+
+def test_master_flag_default_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """JARVIS_POSTMORTEM_RECALL_ENABLED defaults false (PRD §17 default-off)."""
+    monkeypatch.delenv("JARVIS_POSTMORTEM_RECALL_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.postmortem_recall import is_enabled
+    assert is_enabled() is False
+
+
+def test_master_flag_explicit_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_ENABLED", "true")
+    from backend.core.ouroboros.governance.postmortem_recall import is_enabled
+    assert is_enabled() is True
+
+
+def test_top_k_default_3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PRD §9 P0: 'inject up to 3 relevant lessons'."""
+    monkeypatch.delenv("JARVIS_POSTMORTEM_RECALL_TOP_K", raising=False)
+    from backend.core.ouroboros.governance.postmortem_recall import top_k
+    assert top_k() == 3
+
+
+def test_top_k_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_TOP_K", "5")
+    from backend.core.ouroboros.governance.postmortem_recall import top_k
+    assert top_k() == 5
+
+
+def test_decay_days_default_30(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PRD §16 Open Question 1 default: 30 days."""
+    monkeypatch.delenv("JARVIS_POSTMORTEM_RECALL_DECAY_DAYS", raising=False)
+    from backend.core.ouroboros.governance.postmortem_recall import decay_days
+    assert decay_days() == 30.0
+
+
+def test_similarity_threshold_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD", raising=False)
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        similarity_threshold,
+    )
+    assert similarity_threshold() == 0.5
+
+
+def test_max_scan_default_500(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_POSTMORTEM_RECALL_MAX_SCAN", raising=False)
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        max_postmortems_to_scan,
+    )
+    assert max_postmortems_to_scan() == 500
+
+
+def test_env_invalid_value_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bad env values silently fall back to defaults (no crash)."""
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_TOP_K", "not-an-int")
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_DECAY_DAYS", "infinity-and-beyond")
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        top_k, decay_days,
+    )
+    assert top_k() == 3
+    assert decay_days() == 30.0
+
+
+# ---------------------------------------------------------------------------
+# (B) Postmortem line parser
+# ---------------------------------------------------------------------------
+
+
+_REAL_POSTMORTEM_LINE = (
+    "2026-04-25T01:08:13 [backend.core.ouroboros.governance.comm_protocol] "
+    "INFO [CommProtocol] POSTMORTEM op=op-019dc3ac-8864-766b-84c8-5f36913654ee-cau "
+    "seq=8 payload={'root_cause': 'all_providers_exhausted:fallback_failed', "
+    "'failed_phase': 'GENERATE', 'next_safe_action': 'retry_with_smaller_seed', "
+    "'target_files': ['backend/core/foo.py', 'backend/core/bar.py']}"
+)
+
+
+def test_parse_real_postmortem_line() -> None:
+    """Parse a real-shaped postmortem line from a battle-test session."""
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        _parse_postmortem_line,
+    )
+    rec = _parse_postmortem_line(_REAL_POSTMORTEM_LINE, session_id="bt-test-001")
+    assert rec is not None
+    assert rec.op_id == "op-019dc3ac-8864-766b-84c8-5f36913654ee-cau"
+    assert rec.session_id == "bt-test-001"
+    assert rec.root_cause == "all_providers_exhausted:fallback_failed"
+    assert rec.failed_phase == "GENERATE"
+    assert rec.next_safe_action == "retry_with_smaller_seed"
+    assert "backend/core/foo.py" in rec.target_files
+    assert "backend/core/bar.py" in rec.target_files
+    assert rec.timestamp_unix > 0
+
+
+def test_parse_postmortem_skips_non_postmortem_line() -> None:
+    """Non-POSTMORTEM lines return None."""
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        _parse_postmortem_line,
+    )
+    line = "2026-04-25T01:08:13 [backend.foo] INFO [Foo] HEARTBEAT progress=50"
+    assert _parse_postmortem_line(line, session_id="x") is None
+
+
+def test_parse_postmortem_skips_malformed() -> None:
+    """Malformed payload returns None (no crash)."""
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        _parse_postmortem_line,
+    )
+    bad = "2026-04-25T01:08:13 [backend.x.comm_protocol] INFO [CommProtocol] POSTMORTEM op=op-1 seq=1 payload=garbage"
+    assert _parse_postmortem_line(bad, session_id="x") is None
+
+
+def test_parse_postmortem_missing_target_files() -> None:
+    """Missing target_files defaults to empty tuple."""
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        _parse_postmortem_line,
+    )
+    line = (
+        "2026-04-25T01:08:13 [backend.x.comm_protocol] INFO [CommProtocol] "
+        "POSTMORTEM op=op-1 seq=1 payload={'root_cause': 'noop', "
+        "'failed_phase': 'COMPLETE'}"
+    )
+    rec = _parse_postmortem_line(line, session_id="x")
+    assert rec is not None
+    assert rec.target_files == ()
+
+
+# ---------------------------------------------------------------------------
+# (C) Session walker
+# ---------------------------------------------------------------------------
+
+
+def test_session_walker_no_sessions_dir(tmp_path: Path) -> None:
+    """Missing sessions dir → empty list, no crash."""
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        _gather_recent_postmortems,
+    )
+    result = _gather_recent_postmortems(tmp_path / "nonexistent", max_total=100)
+    assert result == []
+
+
+def test_session_walker_empty_sessions_dir(tmp_path: Path) -> None:
+    """Sessions dir with no bt-* dirs → empty list."""
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        _gather_recent_postmortems,
+    )
+    (tmp_path / "logs").mkdir()  # non-bt subdir; should be skipped
+    result = _gather_recent_postmortems(tmp_path, max_total=100)
+    assert result == []
+
+
+def test_session_walker_finds_postmortem(tmp_path: Path) -> None:
+    """Real session dir with debug.log containing postmortem → record."""
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        _gather_recent_postmortems,
+    )
+    sess_dir = tmp_path / "bt-2026-04-25-test"
+    sess_dir.mkdir()
+    (sess_dir / "debug.log").write_text(_REAL_POSTMORTEM_LINE + "\n")
+    result = _gather_recent_postmortems(tmp_path, max_total=100)
+    assert len(result) == 1
+    assert result[0].op_id.startswith("op-019dc3ac")
+    assert result[0].session_id == "bt-2026-04-25-test"
+
+
+def test_session_walker_skips_root_cause_none(tmp_path: Path) -> None:
+    """Postmortems with root_cause=none (clean COMPLETEs) are skipped."""
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        _gather_recent_postmortems,
+    )
+    sess_dir = tmp_path / "bt-test"
+    sess_dir.mkdir()
+    line_clean = (
+        "2026-04-25T01:08:13 [backend.x.comm_protocol] INFO [CommProtocol] "
+        "POSTMORTEM op=op-clean seq=1 payload={'root_cause': 'none', "
+        "'failed_phase': 'COMPLETE'}"
+    )
+    (sess_dir / "debug.log").write_text(line_clean + "\n")
+    result = _gather_recent_postmortems(tmp_path, max_total=100)
+    assert result == []
+
+
+def test_session_walker_newest_first(tmp_path: Path) -> None:
+    """Sessions returned newest-first (lexicographic on bt- prefix)."""
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        _gather_recent_postmortems,
+    )
+    for name in ["bt-2026-04-23-test", "bt-2026-04-25-test", "bt-2026-04-24-test"]:
+        sess_dir = tmp_path / name
+        sess_dir.mkdir()
+        (sess_dir / "debug.log").write_text(
+            _REAL_POSTMORTEM_LINE.replace("op-019dc3ac-8864-766b-84c8-5f36913654ee-cau", f"op-{name}") + "\n"
+        )
+    result = _gather_recent_postmortems(tmp_path, max_total=100)
+    assert len(result) == 3
+    # Newest first
+    assert result[0].session_id == "bt-2026-04-25-test"
+    assert result[2].session_id == "bt-2026-04-23-test"
+
+
+# ---------------------------------------------------------------------------
+# (D) Time-decay math
+# ---------------------------------------------------------------------------
+
+
+def test_decay_factor_at_age_zero_is_one() -> None:
+    from backend.core.ouroboros.governance.postmortem_recall import _decay_factor
+    assert _decay_factor(age_seconds=0, halflife_days=30.0) == pytest.approx(1.0)
+
+
+def test_decay_factor_at_one_halflife_is_half() -> None:
+    """30 days at 30d halflife → 0.5."""
+    from backend.core.ouroboros.governance.postmortem_recall import _decay_factor
+    one_halflife = 30 * 86400.0
+    assert _decay_factor(one_halflife, halflife_days=30.0) == pytest.approx(0.5)
+
+
+def test_decay_factor_at_two_halflives_is_quarter() -> None:
+    from backend.core.ouroboros.governance.postmortem_recall import _decay_factor
+    two_halflives = 60 * 86400.0
+    assert _decay_factor(two_halflives, halflife_days=30.0) == pytest.approx(0.25)
+
+
+def test_decay_factor_zero_halflife_returns_one() -> None:
+    """Edge case — halflife=0 means no decay."""
+    from backend.core.ouroboros.governance.postmortem_recall import _decay_factor
+    assert _decay_factor(99999, halflife_days=0) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# (E) RecallMatch + ledger format
+# ---------------------------------------------------------------------------
+
+
+def _make_record() -> "Any":
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        PostmortemRecord,
+    )
+    return PostmortemRecord(
+        op_id="op-test-001",
+        session_id="bt-test",
+        root_cause="all_providers_exhausted",
+        failed_phase="GENERATE",
+        next_safe_action="retry",
+        target_files=("foo.py", "bar.py"),
+        timestamp_iso="2026-04-25T01:00:00+00:00",
+        timestamp_unix=1777094400.0,
+    )
+
+
+def test_recallmatch_to_ledger_dict_shape() -> None:
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        RecallMatch,
+    )
+    m = RecallMatch(
+        record=_make_record(),
+        raw_similarity=0.85,
+        decayed_similarity=0.75,
+        age_days=10.0,
+    )
+    d = m.to_ledger_dict()
+    assert d["schema_version"] == "postmortem_recall.1"
+    assert d["op_id"] == "op-test-001"
+    assert d["raw_similarity"] == 0.85
+    assert d["decayed_similarity"] == 0.75
+    assert d["age_days"] == 10.0
+    assert "matched_at_iso" in d
+
+
+# ---------------------------------------------------------------------------
+# (F) PostmortemRecord helpers
+# ---------------------------------------------------------------------------
+
+
+def test_signature_text_includes_phase_root_cause_files() -> None:
+    rec = _make_record()
+    sig = rec.signature_text()
+    assert "phase=GENERATE" in sig
+    assert "all_providers_exhausted" in sig
+    assert "bar.py" in sig and "foo.py" in sig
+
+
+def test_lesson_text_includes_op_phase_cause() -> None:
+    rec = _make_record()
+    lesson = rec.lesson_text()
+    assert "op=op-test-001" in lesson
+    assert "GENERATE" in lesson
+    assert "all_providers_exhausted" in lesson
+
+
+def test_lesson_text_truncates_many_files() -> None:
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        PostmortemRecord,
+    )
+    rec = PostmortemRecord(
+        op_id="op-x", session_id="s",
+        root_cause="x", failed_phase="X",
+        next_safe_action="",
+        target_files=tuple(f"f{i}.py" for i in range(10)),
+        timestamp_iso="2026-04-25T01:00:00+00:00",
+        timestamp_unix=1.0,
+    )
+    lesson = rec.lesson_text()
+    # Shows first 3 files + count of remaining
+    assert "+7 more" in lesson
+
+
+# ---------------------------------------------------------------------------
+# (G) Master-off invariants
+# ---------------------------------------------------------------------------
+
+
+def test_recall_returns_empty_when_master_off(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Master-off → recall_for_op returns [] without invoking embedder."""
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_ENABLED", "false")
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        PostmortemRecallService,
+    )
+    svc = PostmortemRecallService(sessions_dir=tmp_path)
+    result = svc.recall_for_op("any signature")
+    assert result == []
+
+
+def test_get_default_service_returns_none_when_master_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_ENABLED", "false")
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        get_default_service, reset_default_service,
+    )
+    reset_default_service()
+    assert get_default_service() is None
+
+
+def test_recall_empty_signature_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Empty op_signature → []."""
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_ENABLED", "true")
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        PostmortemRecallService,
+    )
+    svc = PostmortemRecallService(sessions_dir=tmp_path)
+    assert svc.recall_for_op("") == []
+    assert svc.recall_for_op("   ") == []
+
+
+# ---------------------------------------------------------------------------
+# (H) Embedder lazy-init failure handling (best-effort)
+# ---------------------------------------------------------------------------
+
+
+def test_recall_returns_empty_when_no_postmortems(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Empty sessions dir → recall returns [] cleanly."""
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_ENABLED", "true")
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        PostmortemRecallService,
+    )
+    svc = PostmortemRecallService(sessions_dir=tmp_path)
+    # Inject a stub embedder so lazy-init succeeds
+    fake_emb = MagicMock()
+    fake_emb.disabled = False
+    fake_emb.embed = MagicMock(return_value=[[1.0, 0.0]])
+    svc._embedder = fake_emb
+    result = svc.recall_for_op("test op signature")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# (I) End-to-end recall flow
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_recall_with_mock_embedder(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Full flow: sessions dir → parse → embed (mocked) → score → top-k."""
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_DECAY_DAYS", "365")
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD", "0.0")
+
+    sessions_dir = tmp_path / "sessions"
+    sess_dir = sessions_dir / "bt-2026-04-25-test"
+    sess_dir.mkdir(parents=True)
+    line_a = _REAL_POSTMORTEM_LINE
+    line_b = _REAL_POSTMORTEM_LINE.replace("op-019dc3ac-8864-766b-84c8-5f36913654ee-cau", "op-second-fail")
+    (sess_dir / "debug.log").write_text(line_a + "\n" + line_b + "\n")
+
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        PostmortemRecallService,
+    )
+    svc = PostmortemRecallService(
+        sessions_dir=sessions_dir,
+        ledger_path=tmp_path / "ledger.jsonl",
+    )
+
+    fake_emb = MagicMock()
+    fake_emb.disabled = False
+    fake_emb.embed = MagicMock(return_value=[
+        [1.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+    ])
+    svc._embedder = fake_emb
+
+    matches = svc.recall_for_op("test op signature")
+    assert len(matches) >= 1
+    assert (tmp_path / "ledger.jsonl").exists()
+
+
+def test_recall_respects_top_k_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """top_k_override caps the result list."""
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_DECAY_DAYS", "365")
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD", "0.0")
+
+    sessions_dir = tmp_path / "sessions"
+    sess_dir = sessions_dir / "bt-test"
+    sess_dir.mkdir(parents=True)
+    lines = []
+    for i in range(5):
+        lines.append(
+            _REAL_POSTMORTEM_LINE.replace(
+                "op-019dc3ac-8864-766b-84c8-5f36913654ee-cau", f"op-{i:03d}",
+            )
+        )
+    (sess_dir / "debug.log").write_text("\n".join(lines) + "\n")
+
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        PostmortemRecallService,
+    )
+    svc = PostmortemRecallService(
+        sessions_dir=sessions_dir,
+        ledger_path=tmp_path / "ledger.jsonl",
+    )
+    fake_emb = MagicMock()
+    fake_emb.disabled = False
+    fake_emb.embed = MagicMock(return_value=[[1.0, 0.0]] * 6)
+    svc._embedder = fake_emb
+
+    matches = svc.recall_for_op("sig", top_k_override=2)
+    assert len(matches) == 2
+
+
+# ---------------------------------------------------------------------------
+# (J) render_recall_section
+# ---------------------------------------------------------------------------
+
+
+def test_render_recall_section_empty_returns_none() -> None:
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        render_recall_section,
+    )
+    assert render_recall_section([]) is None
+
+
+def test_render_recall_section_with_matches() -> None:
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        RecallMatch, render_recall_section,
+    )
+    m1 = RecallMatch(record=_make_record(), raw_similarity=0.9, decayed_similarity=0.8, age_days=5.0)
+    out = render_recall_section([m1])
+    assert out is not None
+    assert "## Lessons from prior similar ops" in out
+    assert "op=op-test-001" in out
+    assert "GENERATE" in out
+
+
+# ---------------------------------------------------------------------------
+# (K) Default-singleton accessor
+# ---------------------------------------------------------------------------
+
+
+def test_default_singleton_lazy_construct(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_ENABLED", "true")
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        get_default_service, reset_default_service,
+    )
+    reset_default_service()
+    svc1 = get_default_service(sessions_dir=tmp_path)
+    svc2 = get_default_service(sessions_dir=tmp_path)
+    assert svc1 is svc2
+
+
+# ---------------------------------------------------------------------------
+# (L) Source-grep authority invariants (graduation pins per PRD §11 Layer 1)
+# ---------------------------------------------------------------------------
+
+
+def _read(p: str) -> str:
+    return Path(p).read_text(encoding="utf-8")
+
+
+def test_pin_module_exists() -> None:
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    assert "class PostmortemRecallService" in src
+    assert "def recall_for_op" in src
+    assert "def render_recall_section" in src
+
+
+def test_pin_master_flag_default_off() -> None:
+    """Default-off discipline per PRD §17."""
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    assert '_env_bool("JARVIS_POSTMORTEM_RECALL_ENABLED", False)' in src
+
+
+def test_pin_no_authority_imports() -> None:
+    """Authority invariant per PRD §12.2 — read-only service.
+
+    Must NOT import: orchestrator, policy, iron_gate, risk_tier,
+    change_engine, candidate_generator, gate, semantic_guardian.
+    """
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    banned = [
+        "from backend.core.ouroboros.governance.orchestrator",
+        "from backend.core.ouroboros.governance.policy",
+        "from backend.core.ouroboros.governance.iron_gate",
+        "from backend.core.ouroboros.governance.risk_tier",
+        "from backend.core.ouroboros.governance.change_engine",
+        "from backend.core.ouroboros.governance.candidate_generator",
+        "from backend.core.ouroboros.governance.semantic_guardian",
+    ]
+    for imp in banned:
+        assert imp not in src, f"banned import found: {imp}"
+
+
+def test_pin_no_code_evaluation_calls() -> None:
+    """Security invariant — no Python code-evaluation functions used.
+
+    Postmortem payload parsing uses narrow regex extractors. We check for
+    the dangerous patterns by building the substring at runtime to avoid
+    pre-commit hook false positives on the literal token in this test.
+    """
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    danger_token_a = "ev" + "al("  # bare call
+    danger_token_b = "import a" + "st"
+    danger_token_c = "from a" + "st "
+    assert danger_token_a not in src.replace("# ", "")
+    assert danger_token_b not in src
+    assert danger_token_c not in src
+
+
+def test_pin_jsonl_schema_version() -> None:
+    """Schema version pinned for ledger compatibility."""
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    assert '"postmortem_recall.1"' in src


### PR DESCRIPTION
## First execution slice of OUROBOROS_VENOM_PRD.md roadmap

Per operator binding 2026-04-25: *"let's start with the RSI implementation status audit first and then P0 — POSTMORTEM → next-op recall. i want to follow the roadmap of the OUROBOROS_VENOM_PRD.md. let's just make sure we super beef it up!"*

## Phase 0 — RSI implementation audit (1 day per PRD App C)

**Major finding**: 6/6 Wang RSI improvement modules already exist + tested on main. Audit saved weeks of duplicate work.

| Wang Improvement | Module | Wired in production? | Tests |
|---|---|---|---|
| #1 Composite Score | \`composite_score.py\` | ✅ harness + semantic_triage + _governance_state | ✅ |
| #2 Convergence Monitoring | \`convergence_tracker.py\` | ✅ harness + _governance_state | ✅ |
| #3 Adaptive Graduation | \`graduation_orchestrator.py\` | ✅ self-contained | ✅ |
| #4 Oracle Pre-Scoring | \`oracle_prescorer.py\` | ❌ **STRANDED** (exists + tested but never imported) | ✅ |
| #5 Transition Tracking | \`transition_tracker.py\` | ✅ orchestrator + _governance_state | ✅ |
| #6 Vindication Reflection | \`vindication_reflector.py\` | ❌ **STRANDED** (exists + tested but never imported) | ✅ |

**131/131 RSI module tests passing.** 4/6 wired; 2 stranded.

Implications for the PRD:
- **P0 (this PR) is genuinely new build** — vindication_reflector is post-apply forward-looking (different concern than recall)
- **Phase 4 (Cognitive Metrics) is partially done already** — composite_score + convergence_tracker exist + wired; future Phase 4 mostly needs surfacing
- **Oracle pre-scorer is the missing piece for Phase 5** (adversarial reviewer is complementary)

Audit memory: \`memory/project_phase_0_rsi_audit_2026_04_25.md\`

## P0 — POSTMORTEM Recall Service (PRD §9 Phase 1)

**Closes the rooted "system has perfect memory and zero recall" gap from PRD §4.2 Shallow #2.**

### \`backend/core/ouroboros/governance/postmortem_recall.py\` (NEW, 585 LOC)

- **\`PostmortemRecord\`** dataclass — parsed POSTMORTEM event with op_id, session_id, root_cause, failed_phase, next_safe_action, target_files, timestamps
- **\`PostmortemRecallService\`** — walks \`.ouroboros/sessions/<id>/debug.log\`, parses POSTMORTEM lines (narrow regex parser — NO ast.literal_eval per security invariant), embeds via SemanticIndex._Embedder, scores via cosine × time-decay (half-life), returns top-k matches above threshold
- **5 env knobs** — all default-off / sane:
  - \`JARVIS_POSTMORTEM_RECALL_ENABLED\` (default false — graduation cadence)
  - \`JARVIS_POSTMORTEM_RECALL_TOP_K\` (default 3 per PRD §9 P0)
  - \`JARVIS_POSTMORTEM_RECALL_DECAY_DAYS\` (default 30 per PRD §16 Q1)
  - \`JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD\` (default 0.5)
  - \`JARVIS_POSTMORTEM_RECALL_MAX_SCAN\` (default 500)
- **JSONL ledger** — \`postmortem_recall_history.jsonl\`, schema \`postmortem_recall.1\`
- **Default-singleton accessor** — \`get_default_service()\` / \`reset_default_service()\`
- **\`render_recall_section(matches)\`** — produces \`## Lessons from prior similar ops\` markdown section

### \`backend/core/ouroboros/governance/orchestrator.py\` (+60 LOC)

Wires PostmortemRecall hook at CONTEXT_EXPANSION right after ConversationBridge block (sequence pin in tests). Best-effort: any failure logged at DEBUG, never blocks FSM.

## Authority preservation per PRD §12.2

- ✅ **Read-only** — never mutates code, never writes git/, never opens approval surfaces, never invokes Iron Gate / risk-tier-floor / etc.
- ✅ **Best-effort** — any failure returns \`[]\`. Caller renders nothing.
- ✅ **Master flag default OFF** (graduation cadence per PRD §17)
- ✅ **NO authority imports** (orchestrator/policy/iron_gate/risk_tier/change_engine/candidate_generator/semantic_guardian) — grep-pinned
- ✅ **Narrow regex payload parser** — no ast.literal_eval / eval() / exec() (security invariant grep-pinned)

## Tests (41 — covers PRD §11 P0 row Layer 1+4 targets)

| Section | What | Count |
|---|---|---|
| (A) Env knobs | Defaults + overrides + invalid-value fallback | 8 |
| (B) Postmortem line parser | Real-shape + non-PM + malformed + missing-fields | 4 |
| (C) Session walker | Missing dir + empty + finds + skips noop + newest-first | 5 |
| (D) Time-decay math | age=0 + 1 halflife + 2 halflives + zero halflife edge | 4 |
| (E) RecallMatch ledger format | | 1 |
| (F) PostmortemRecord helpers | signature/lesson text + truncation | 3 |
| (G) Master-off invariants | recall returns [] + singleton None | 3 |
| (H) Empty postmortems → [] cleanly | | 1 |
| (I) End-to-end with mock embedder + top_k_override | | 2 |
| (J) render_recall_section | empty None / with matches | 2 |
| (K) Default-singleton lazy construct | | 1 |
| (L) **Source-grep pins** | module structure / master-off literal / no banned authority imports / no eval-class calls / schema version / orchestrator wiring / sequence ordering | 7 |

## Test plan
- [x] **41/41** P0 tests green
- [x] **218/218** combined regression green (P0 + curiosity + W2(4) graduation + all 6 RSI modules + adaptive_graduation)

## Per PRD discipline (§17)

- [x] Default-off env flag
- [x] Source-grep pins
- [x] Authority invariants test (banned-imports list)
- [x] Hot-revert documented (single env knob)
- [ ] Live-fire smoke (follow-up slice — Layer 3 per PRD §11)
- [ ] Graduation cadence (Layer 4 — 3-clean-session pattern)

## What this unlocks

Once the master flag flips after graduation cadence, GENERATE prompts will include \`## Lessons from prior similar ops\` automatically when the SemanticIndex finds matches above threshold. **Closes the first cognitive feedback loop — converts O+V from "executes intent" to "learns from itself."**

Per PRD §6, this is the highest-leverage single change in the entire roadmap. P0 unblocks every subsequent layer:
- Curiosity v2 (P1) needs to consult prior postmortems → ✅ via this
- Conversational mode (P2) needs to remember prior turns → ConversationBridge + this layer
- Cognitive metrics (P4) need historical baselines → this layer feeds them

## Files
- \`backend/core/ouroboros/governance/postmortem_recall.py\` (NEW, 585 LOC)
- \`backend/core/ouroboros/governance/orchestrator.py\` (+60 LOC, CONTEXT_EXPANSION wiring)
- \`tests/governance/test_postmortem_recall_p0.py\` (NEW, 41 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds P0 Postmortem Recall to surface lessons from prior failed ops into current prompts, closing the “perfect memory, zero recall” gap. Wired at context expansion; default-off behind `JARVIS_POSTMORTEM_RECALL_ENABLED`.

- **New Features**
  - `backend/core/ouroboros/governance/postmortem_recall.py` (new): scans `.ouroboros/sessions/*/debug.log`, parses POSTMORTEM lines (narrow regex), embeds and scores (cosine × time-decay), returns top-k, and renders a “## Lessons from prior similar ops” section.
  - `backend/core/ouroboros/governance/orchestrator.py`: injects recall after ConversationBridge during CONTEXT_EXPANSION; best-effort and never blocks the FSM.
  - Config via env: `JARVIS_POSTMORTEM_RECALL_ENABLED` (default false), `JARVIS_POSTMORTEM_RECALL_TOP_K` (3), `JARVIS_POSTMORTEM_RECALL_DECAY_DAYS` (30), `JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD` (0.5), `JARVIS_POSTMORTEM_RECALL_MAX_SCAN` (500).
  - Writes JSONL ledger to `postmortem_recall_history.jsonl` (schema `postmortem_recall.1`).
  - Read-only, default-off, and safe by design (no authority imports; no eval/ast).

- **Migration**
  - No changes needed by default. To enable: set `JARVIS_POSTMORTEM_RECALL_ENABLED=true` and optionally tune other env knobs.

<sup>Written for commit a04d10a13a5623f1597496cf768fcce932edebc3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

