### PR TITLE
feat(p0): PostmortemRecall live-fire smoke + graduation pins + PRD status tracking

### DIFF
--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -67,6 +67,34 @@ A-level reliable execution from A-level vision — measurable by:
 
 This PRD lays out a phased roadmap to close the gap. **The gap is internal to JARVIS, not external.** External provider quality is sufficient; what's missing is the orchestration layer that converts that intelligence into self-directing, self-improving behavior.
 
+### Roadmap Execution Status (live)
+
+Per-slice status. `[x]` = landed on main; `[~]` = in-flight on a branch / open PR; `[ ]` = not started. Master-flag flips after a graduation cadence are tracked separately (see §17 Implementation Discipline).
+
+**Phase 0 — RSI implementation status audit** (gate for Phase 1)
+- [x] 6/6 Wang RSI modules verified to exist (composite_score, convergence_tracker, oracle_prescorer, transition_tracker, vindication_reflector, adaptive graduation threshold)
+- [x] 4/6 wired into the live FSM; 2 stranded (oracle_prescorer, vindication_reflector — tracked for Phase 4)
+- [x] 131/131 RSI module tests green
+- [x] Audit memo committed (`memory/project_phase_0_rsi_audit_2026_04_25.md`)
+
+**Phase 1 — Self-Reading**
+- P0 — POSTMORTEM → next-op recall (`PostmortemRecallService`, PRD §9.P0)
+  - [x] Module + orchestrator wiring + 41 unit tests landed (PR #20968 merged → main `ef32006663`)
+  - [x] Live-fire smoke (`scripts/livefire_p0_postmortem_recall.py`, 16/16 PASS)
+  - [x] Graduation pin tests (`tests/governance/test_postmortem_recall_graduation_pins.py`, 16/16 PASS)
+  - [ ] Master flag `JARVIS_POSTMORTEM_RECALL_ENABLED` flip false→true (gate: 3 clean live sessions per §11 Layer 4)
+- P0.5 — POSTMORTEM root-cause taxonomy expansion: [ ] not started
+- P1 — Cross-session pattern detector: [ ] not started
+- P1.5 — Self-RAG over own commit history: [ ] not started
+
+**Phase 2 — Self-Direction**: [ ] not started
+**Phase 3 — Operator Symbiosis**: [ ] not started (CC-parity items P2/P3 in §3.2 deferred here)
+**Phase 4 — Cognitive Metrics**: [ ] not started (oracle_prescorer + vindication_reflector wiring lives here)
+**Phase 5 — Adversarial Depth**: [ ] not started
+**Phase 6 — Self-Modeling**: [ ] not started
+
+Update discipline: each closing slice updates this section in the same PR. Status is the source of truth for "what's next" — when in doubt, the lowest-numbered `[ ]` row in the lowest-numbered active phase is the next slice.
+
 ---
 
 ## 2. Vision Statement
@@ -1162,3 +1190,4 @@ When §5.4 MVP RSI conditions all met → claim Wang-grounded RSI.
 |---|---|---|---|
 | 2026-04-25 | 1.0 | Initial draft | Claude Opus 4.7 (synthesis from 7-day operator collaboration) |
 | 2026-04-25 | 2.0 | Added: TOC, §4 Cognitive Scaffolding deep dive, §5 RSI Convergence Framework, §8 Manifesto alignment, §10 Per-phase telemetry, §11 Per-phase testing, §18 Stakeholder map, §19 Migration & versioning. Expanded: §22 Trinity context, App A glossary, App B reference docs map, App C phase gate criteria. | Claude Opus 4.7 (per operator request: "more depth, RSI section, more references") |
+| 2026-04-25 | 2.1 | Added §1 "Roadmap Execution Status (live)" subsection — per-slice [x]/[~]/[ ] tracking. Records: Phase 0 audit complete; Phase 1 P0 build (PR #20968) + live-fire smoke + graduation pins landed; P0 master-flag flip pending 3-clean-session cadence. Update discipline noted: each closing slice updates this section in same PR. | Claude Opus 4.7 (P0 follow-on PR) |

--- a/scripts/livefire_p0_postmortem_recall.py
+++ b/scripts/livefire_p0_postmortem_recall.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""P0 — PostmortemRecall live-fire smoke (PRD §11 Layer 3).
+
+Formal in-process smoke that exercises the full P0 chain end-to-end
+WITHOUT requiring an Anthropic API key, a running battle-test harness,
+or any network call. Mirrors the W2(4) curiosity / W3(6) parallel-dispatch
+live-fire pattern.
+
+15 checks per PRD §11 P0 row Layer 3 target:
+
+1. Master flag default OFF (graduation discipline pin)
+2. Master flag explicit ON enables service
+3. PostmortemRecallService construction (no crash)
+4. Empty sessions dir → recall returns [] cleanly
+5. Real-shape postmortem line parsed from synthesized debug.log
+6. Session walker finds the postmortem
+7. Embedder lazy-init via SemanticIndex._Embedder
+8. End-to-end recall with embedder present + similarity above threshold
+9. JSONL ledger written on match
+10. Ledger schema_version is "postmortem_recall.1"
+11. Time-decay halves match score at one halflife
+12. Top-k cap respected
+13. render_recall_section produces "## Lessons from prior similar ops"
+14. Master-OFF makes recall return [] even with embedder + postmortems
+15. Default-singleton accessor respects master-flag composition
+
+Exit 0 on PASS; non-zero with failed-check summary on FAIL.
+
+Usage::
+
+    python3 scripts/livefire_p0_postmortem_recall.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Repo root on sys.path
+_REPO = Path(__file__).resolve().parent.parent
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+
+# ---------------------------------------------------------------------------
+# Journal
+# ---------------------------------------------------------------------------
+
+
+class Journal:
+    def __init__(self) -> None:
+        self.passed: list[str] = []
+        self.failed: list[tuple[str, str]] = []
+
+    def check(self, name: str, ok: bool, detail: str = "") -> None:
+        if ok:
+            self.passed.append(name)
+            print(f"  [PASS] {name}")
+        else:
+            self.failed.append((name, detail))
+            print(f"  [FAIL] {name}  ({detail})")
+
+    def summary(self) -> int:
+        total = len(self.passed) + len(self.failed)
+        print(f"\n{'=' * 64}")
+        print(f"Result: {len(self.passed)}/{total} checks passed")
+        if self.failed:
+            print("\nFailures:")
+            for n, d in self.failed:
+                print(f"  - {n}: {d}")
+            return 1
+        print("All checks passed — P0 PostmortemRecall live-fire smoke OK.")
+        return 0
+
+
+_REAL_POSTMORTEM_LINE = (
+    "2026-04-25T01:08:13 [backend.core.ouroboros.governance.comm_protocol] "
+    "INFO [CommProtocol] POSTMORTEM op=op-019dc3ac-8864-766b-84c8-5f36913654ee-cau "
+    "seq=8 payload={'root_cause': 'all_providers_exhausted:fallback_failed', "
+    "'failed_phase': 'GENERATE', 'next_safe_action': 'retry_with_smaller_seed', "
+    "'target_files': ['backend/core/foo.py', 'backend/core/bar.py']}"
+)
+
+
+def main() -> int:
+    j = Journal()
+    print("=" * 64)
+    print("P0 — PostmortemRecall live-fire smoke (PRD Phase 1)")
+    print("=" * 64)
+
+    # Reset all P0 envs to default
+    for key in (
+        "JARVIS_POSTMORTEM_RECALL_ENABLED",
+        "JARVIS_POSTMORTEM_RECALL_TOP_K",
+        "JARVIS_POSTMORTEM_RECALL_DECAY_DAYS",
+        "JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD",
+        "JARVIS_POSTMORTEM_RECALL_MAX_SCAN",
+    ):
+        os.environ.pop(key, None)
+
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        PostmortemRecallService,
+        PostmortemRecord,
+        RecallMatch,
+        _decay_factor,
+        _gather_recent_postmortems,
+        _parse_postmortem_line,
+        decay_days,
+        get_default_service,
+        is_enabled,
+        max_postmortems_to_scan,
+        render_recall_section,
+        reset_default_service,
+        similarity_threshold,
+        top_k,
+    )
+
+    # --- (1) Master flag default OFF (graduation discipline)
+    j.check(
+        "1. Master flag defaults False (PRD §17 default-off)",
+        is_enabled() is False,
+        f"got {is_enabled()}",
+    )
+
+    # --- (2) Master flag explicit ON
+    os.environ["JARVIS_POSTMORTEM_RECALL_ENABLED"] = "true"
+    j.check(
+        "2. Master flag explicit True enables service",
+        is_enabled() is True,
+    )
+
+    # --- (3) Construction smoke
+    with tempfile.TemporaryDirectory() as td:
+        sessions_dir = Path(td) / "sessions"
+        sessions_dir.mkdir()
+        ledger_path = Path(td) / "ledger.jsonl"
+
+        try:
+            svc = PostmortemRecallService(
+                sessions_dir=sessions_dir, ledger_path=ledger_path,
+            )
+            j.check("3. PostmortemRecallService constructs without crash", True)
+        except Exception as e:  # noqa: BLE001
+            j.check("3. PostmortemRecallService constructs", False, repr(e))
+            return j.summary()
+
+        # --- (4) Empty sessions dir
+        # Inject a stub embedder so the lazy-init path doesn't try to
+        # download fastembed weights during smoke.
+        fake_emb = MagicMock()
+        fake_emb.disabled = False
+        fake_emb.embed = MagicMock(return_value=[[1.0, 0.0]])
+        svc._embedder = fake_emb
+
+        result = svc.recall_for_op("any signature")
+        j.check(
+            "4. Empty sessions dir → recall returns [] cleanly",
+            result == [],
+            f"got {len(result)} matches",
+        )
+
+        # --- (5) Real-shape postmortem line parses
+        rec = _parse_postmortem_line(_REAL_POSTMORTEM_LINE, session_id="bt-test")
+        j.check(
+            "5. Real postmortem line parses → PostmortemRecord",
+            rec is not None and rec.failed_phase == "GENERATE",
+            f"got {rec}",
+        )
+
+        # --- (6) Session walker finds postmortems on disk
+        sess_dir = sessions_dir / "bt-2026-04-25-test"
+        sess_dir.mkdir()
+        (sess_dir / "debug.log").write_text(_REAL_POSTMORTEM_LINE + "\n")
+        records = _gather_recent_postmortems(sessions_dir, max_total=10)
+        j.check(
+            "6. Session walker finds postmortem in synthesized debug.log",
+            len(records) == 1 and records[0].failed_phase == "GENERATE",
+            f"got {len(records)} records",
+        )
+
+        # --- (7) Embedder lazy-init (SemanticIndex._Embedder is the real thing,
+        #         but smoke doesn't need to actually load weights — we just
+        #         confirm the import path exists)
+        try:
+            from backend.core.ouroboros.governance.semantic_index import (
+                _Embedder as _SE,
+                _embedder_name,
+            )
+            j.check(
+                "7. SemanticIndex._Embedder import path resolves (lazy-init substrate)",
+                callable(_SE) and isinstance(_embedder_name(), str),
+            )
+        except Exception as e:  # noqa: BLE001
+            j.check("7. SemanticIndex._Embedder import", False, repr(e))
+
+        # --- (8) End-to-end recall with stub embedder
+        os.environ["JARVIS_POSTMORTEM_RECALL_DECAY_DAYS"] = "365"
+        os.environ["JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD"] = "0.0"
+        # Stub embedder returns identity vectors so cosine = 1.0
+        fake_emb.embed = MagicMock(
+            return_value=[[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+        )
+        matches = svc.recall_for_op("test op signature")
+        j.check(
+            "8. End-to-end recall with stub embedder produces ≥1 match",
+            len(matches) >= 1,
+            f"got {len(matches)} matches",
+        )
+
+        # --- (9) Ledger written on match
+        j.check(
+            "9. JSONL ledger written on match",
+            ledger_path.exists() and ledger_path.stat().st_size > 0,
+        )
+
+        # --- (10) Ledger schema version pinned
+        if ledger_path.exists():
+            import json as _json
+            line = ledger_path.read_text(encoding="utf-8").splitlines()[0]
+            try:
+                rec_d = _json.loads(line)
+                j.check(
+                    "10. Ledger entry schema_version=postmortem_recall.1",
+                    rec_d.get("schema_version") == "postmortem_recall.1",
+                    f"got {rec_d.get('schema_version')}",
+                )
+            except Exception as e:  # noqa: BLE001
+                j.check("10. Ledger entry parse", False, repr(e))
+
+        # --- (11) Time-decay halves at one halflife
+        decay_at_zero = _decay_factor(age_seconds=0, halflife_days=30.0)
+        decay_at_one = _decay_factor(age_seconds=30 * 86400.0, halflife_days=30.0)
+        j.check(
+            "11. Time-decay: factor(age=0)=1.0, factor(age=halflife)≈0.5",
+            abs(decay_at_zero - 1.0) < 0.001 and abs(decay_at_one - 0.5) < 0.001,
+            f"got zero={decay_at_zero}, halflife={decay_at_one}",
+        )
+
+        # --- (12) Top-k cap respected
+        # Create 5 postmortems then cap at 2
+        sess2 = sessions_dir / "bt-test-many"
+        sess2.mkdir()
+        many_lines = []
+        for i in range(5):
+            many_lines.append(_REAL_POSTMORTEM_LINE.replace(
+                "op-019dc3ac-8864-766b-84c8-5f36913654ee-cau", f"op-many-{i}",
+            ))
+        (sess2 / "debug.log").write_text("\n".join(many_lines) + "\n")
+        # Reset singleton + use new svc
+        svc2 = PostmortemRecallService(
+            sessions_dir=sessions_dir,
+            ledger_path=Path(td) / "ledger2.jsonl",
+        )
+        fake2 = MagicMock()
+        fake2.disabled = False
+        # query + 5 (from sess2) + 1 (from earlier sess1 still on disk)
+        fake2.embed = MagicMock(return_value=[[1.0, 0.0]] * 7)
+        svc2._embedder = fake2
+        matches2 = svc2.recall_for_op("test", top_k_override=2)
+        j.check(
+            "12. Top-k override caps result list (override=2)",
+            len(matches2) == 2,
+            f"got {len(matches2)} matches",
+        )
+
+        # --- (13) render_recall_section
+        if matches2:
+            rendered = render_recall_section(matches2)
+            j.check(
+                "13. render_recall_section produces '## Lessons from prior similar ops'",
+                rendered is not None and "## Lessons from prior similar ops" in rendered,
+                f"got {rendered[:100] if rendered else 'None'}",
+            )
+            j.check(
+                "13a. Each match rendered as a bullet line with op_id + phase",
+                rendered is not None and rendered.count("- op=") == len(matches2),
+                f"got {rendered.count('- op=') if rendered else 0} bullets",
+            )
+
+        # --- (14) Master-OFF returns [] even with embedder + postmortems
+        os.environ["JARVIS_POSTMORTEM_RECALL_ENABLED"] = "false"
+        result_off = svc2.recall_for_op("any signature")
+        j.check(
+            "14. Master-OFF returns [] even with embedder + postmortems",
+            result_off == [],
+            f"got {len(result_off)} matches with master off",
+        )
+
+        # --- (15) Default-singleton respects master-flag composition
+        os.environ["JARVIS_POSTMORTEM_RECALL_ENABLED"] = "false"
+        reset_default_service()
+        j.check(
+            "15. get_default_service() returns None when master OFF",
+            get_default_service() is None,
+        )
+
+    return j.summary()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/governance/test_postmortem_recall_graduation_pins.py
+++ b/tests/governance/test_postmortem_recall_graduation_pins.py
@@ -1,0 +1,265 @@
+"""P0 — PostmortemRecall graduation pins (PRD §11 Layer 4 prep).
+
+Pins the post-graduation contract for PostmortemRecallService. These tests
+run on every commit going forward; if any pin breaks:
+
+* The change was an unintentional regression — fix the change.
+* The contract is intentionally being expanded — update the pin AND the
+  hot-revert documentation.
+
+Pin coverage (matches W2(4) Slice 4 + W3(7) Slice 7 graduation pin pattern):
+
+A. Master flag default — pre-graduation == False; post-graduation == True
+   (currently False; flip happens after 3 clean live sessions per
+   PRD §11 Layer 4)
+B. All 5 sub-flag defaults composition (top_k=3 / decay=30d /
+   threshold=0.5 / max_scan=500)
+C. Hot-revert: master=false force-disables the service even with
+   stranded postmortems on disk
+D. Authority invariants — read-only, no banned imports, no eval-class
+E. JSONL schema version is "postmortem_recall.1" (frozen wire format)
+F. Source-grep pins for the orchestrator wiring + ordering
+G. Per-PRD §10 telemetry vocabulary additivity (no event types yet
+   for P0; future SSE events documented inline as they're added)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# (A) Master flag default — pre-graduation pin
+# ---------------------------------------------------------------------------
+
+
+def test_master_flag_default_false_pre_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JARVIS_POSTMORTEM_RECALL_ENABLED defaults False until P0 graduation
+    cadence completes (3 clean live sessions per PRD §11 Layer 4).
+
+    If this test fails AND P0 has been graduated: rename to
+    test_master_flag_default_true_post_graduation, update assertion,
+    update the env-reader source-grep pin in (F)."""
+    monkeypatch.delenv("JARVIS_POSTMORTEM_RECALL_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.postmortem_recall import is_enabled
+    assert is_enabled() is False, (
+        "Pre-graduation default is False. If P0 has been graduated, update "
+        "this pin to assert True."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (B) Sub-flag defaults composition
+# ---------------------------------------------------------------------------
+
+
+def test_top_k_default_3(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PRD §9 P0: 'inject up to 3 relevant lessons'."""
+    monkeypatch.delenv("JARVIS_POSTMORTEM_RECALL_TOP_K", raising=False)
+    from backend.core.ouroboros.governance.postmortem_recall import top_k
+    assert top_k() == 3
+
+
+def test_decay_days_default_30(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PRD §16 Open Question 1 default: 30 days."""
+    monkeypatch.delenv("JARVIS_POSTMORTEM_RECALL_DECAY_DAYS", raising=False)
+    from backend.core.ouroboros.governance.postmortem_recall import decay_days
+    assert decay_days() == 30.0
+
+
+def test_similarity_threshold_default_05(monkeypatch: pytest.MonkeyPatch) -> None:
+    """0.5 conservative default (per inline docstring)."""
+    monkeypatch.delenv("JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD", raising=False)
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        similarity_threshold,
+    )
+    assert similarity_threshold() == 0.5
+
+
+def test_max_scan_default_500(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_POSTMORTEM_RECALL_MAX_SCAN", raising=False)
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        max_postmortems_to_scan,
+    )
+    assert max_postmortems_to_scan() == 500
+
+
+# ---------------------------------------------------------------------------
+# (C) Hot-revert: master=false force-disables service
+# ---------------------------------------------------------------------------
+
+
+def test_hot_revert_master_off_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """JARVIS_POSTMORTEM_RECALL_ENABLED=false → recall returns [] even
+    with postmortems on disk. The single env knob hot-revert path."""
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_ENABLED", "false")
+    # Even with overrides on sub-flags, master-off wins
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_TOP_K", "10")
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_SIM_THRESHOLD", "0.0")
+
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        PostmortemRecallService,
+    )
+    svc = PostmortemRecallService(sessions_dir=tmp_path)
+    result = svc.recall_for_op("any signature")
+    assert result == [], "master-off must return [] regardless of sub-flags"
+
+
+def test_hot_revert_master_off_singleton_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_default_service() returns None when master off."""
+    monkeypatch.setenv("JARVIS_POSTMORTEM_RECALL_ENABLED", "false")
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        get_default_service, reset_default_service,
+    )
+    reset_default_service()
+    assert get_default_service() is None
+
+
+# ---------------------------------------------------------------------------
+# (D) Authority invariants — read-only, no banned imports
+# ---------------------------------------------------------------------------
+
+
+def _read(p: str) -> str:
+    return Path(p).read_text(encoding="utf-8")
+
+
+def test_authority_no_banned_module_imports() -> None:
+    """Read-only invariant per PRD §12.2 — must NOT import authority modules."""
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    banned = [
+        "from backend.core.ouroboros.governance.orchestrator",
+        "from backend.core.ouroboros.governance.policy",
+        "from backend.core.ouroboros.governance.iron_gate",
+        "from backend.core.ouroboros.governance.risk_tier",
+        "from backend.core.ouroboros.governance.change_engine",
+        "from backend.core.ouroboros.governance.candidate_generator",
+        "from backend.core.ouroboros.governance.semantic_guardian",
+    ]
+    for imp in banned:
+        assert imp not in src, f"banned authority import found: {imp}"
+
+
+def test_security_no_code_evaluation_calls() -> None:
+    """Security invariant — narrow regex parser only.
+
+    Builds danger tokens at runtime to avoid pre-commit hook false
+    positives on literal substrings in the test file itself.
+    """
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    # Standalone bare call — must not appear
+    danger_a = "ev" + "al("
+    danger_b = "import a" + "st"
+    danger_c = "from a" + "st "
+    assert danger_a not in src.replace("# ", "")
+    assert danger_b not in src
+    assert danger_c not in src
+
+
+# ---------------------------------------------------------------------------
+# (E) Schema version frozen
+# ---------------------------------------------------------------------------
+
+
+def test_jsonl_schema_version_frozen_at_postmortem_recall_1() -> None:
+    """Wire-format API: ledger schema_version is "postmortem_recall.1".
+
+    Future schema bumps need additive migration semantics + this pin
+    updated."""
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    assert '"postmortem_recall.1"' in src
+    # Also verify no other version string snuck in
+    assert '"postmortem_recall.2"' not in src
+
+
+# ---------------------------------------------------------------------------
+# (F) Source-grep pins for module structure + orchestrator wiring
+# ---------------------------------------------------------------------------
+
+
+def test_pin_master_env_reader_default_false_literal() -> None:
+    """The is_enabled() reader literal-defaults to False (pre-graduation).
+
+    Slice flip will change this to True in a single commit."""
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    assert '_env_bool("JARVIS_POSTMORTEM_RECALL_ENABLED", False)' in src, (
+        "Master flag default literal moved or changed. If P0 has been "
+        "graduated, update both the source and this pin (rename to "
+        "test_pin_master_env_reader_default_true_literal)."
+    )
+
+
+def test_pin_module_exports_public_api() -> None:
+    """Module exports the public API surface used by orchestrator."""
+    from backend.core.ouroboros.governance.postmortem_recall import (
+        PostmortemRecallService,
+        PostmortemRecord,
+        RecallMatch,
+        get_default_service,
+        is_enabled,
+        render_recall_section,
+        reset_default_service,
+    )
+    assert callable(get_default_service)
+    assert callable(render_recall_section)
+    assert callable(is_enabled)
+    assert callable(reset_default_service)
+    assert hasattr(PostmortemRecallService, "recall_for_op")
+    assert hasattr(PostmortemRecord, "signature_text")
+    assert hasattr(PostmortemRecord, "lesson_text")
+    assert hasattr(RecallMatch, "to_ledger_dict")
+
+
+def test_pin_orchestrator_wiring_at_context_expansion() -> None:
+    """Orchestrator imports + invokes the recall service at CONTEXT_EXPANSION."""
+    src = _read("backend/core/ouroboros/governance/orchestrator.py")
+    assert "from backend.core.ouroboros.governance.postmortem_recall" in src
+    assert "get_default_service as _get_pm_recall" in src
+    assert "render_recall_section as _render_pm_recall" in src
+    # Best-effort discipline: wrapped in try/except (never blocks FSM)
+    assert "[Orchestrator] PostmortemRecall injection skipped" in src
+    # PRD reference present
+    assert "PRD Phase 1" in src
+
+
+def test_pin_orchestrator_recall_after_conversation_bridge() -> None:
+    """Sequence pin: PostmortemRecall block AFTER ConversationBridge block."""
+    src = _read("backend/core/ouroboros/governance/orchestrator.py")
+    bridge_idx = src.find("ConversationBridge injection skipped")
+    recall_idx = src.find("PostmortemRecall injection skipped")
+    assert bridge_idx > 0, "ConversationBridge marker missing"
+    assert recall_idx > 0, "PostmortemRecall marker missing"
+    assert bridge_idx < recall_idx, (
+        "PostmortemRecall must inject AFTER ConversationBridge "
+        "(per CONTEXT_EXPANSION ordering)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (G) Cross-cutting integration pins
+# ---------------------------------------------------------------------------
+
+
+def test_pin_uses_semantic_index_embedder() -> None:
+    """Composes with existing SemanticIndex._Embedder (per PRD §9 P0
+    'builds on existing SemanticIndex + ConversationBridge primitives')."""
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    assert "from backend.core.ouroboros.governance.semantic_index import" in src
+    assert "_Embedder as _SemanticEmbedder" in src
+    assert "_cosine" in src
+
+
+def test_pin_lazy_singleton_pattern() -> None:
+    """Default-singleton pattern matches W3(7) cancel_token + W2(4)
+    curiosity_engine convention."""
+    src = _read("backend/core/ouroboros/governance/postmortem_recall.py")
+    assert "_default_service: Optional[PostmortemRecallService]" in src
+    assert "def get_default_service" in src
+    assert "def reset_default_service" in src


### PR DESCRIPTION
## Summary

Follow-on to PR #20968 (PostmortemRecallService landed on main). Closes the PRD §11 Layer 3 (live-fire smoke) and Layer 4 prep (graduation pins) for **P0 — POSTMORTEM → next-op recall** (Phase 1 first cognitive feedback loop).

- **`scripts/livefire_p0_postmortem_recall.py`** — 16 in-process checks (no API key, no network). Mirrors the W2(4) curiosity / W3(6) parallel-dispatch live-fire pattern. Exits 0 on PASS. Verified **16/16 PASS** locally.
- **`tests/governance/test_postmortem_recall_graduation_pins.py`** — 16 graduation pins matching the W2(4) Slice 4 / W3(7) Slice 7 pattern. Sections A-G:
  - (A) master-flag default `False` pre-graduation (with explicit rename + assertion-flip instructions baked into the docstring for the post-graduation slice)
  - (B) sub-flag composition (top_k=3 / decay=30d / threshold=0.5 / max_scan=500)
  - (C) hot-revert: master-off force-disables the service even with sub-flag overrides
  - (D) authority invariants — no banned imports, no eval-class
  - (E) JSONL schema frozen at `"postmortem_recall.1"`
  - (F) source-grep pins for module structure + orchestrator wiring + sequence ordering (PostmortemRecall block must come **after** ConversationBridge block at CONTEXT_EXPANSION)
  - (G) cross-cutting: uses `SemanticIndex._Embedder`, lazy-singleton pattern matches existing W3(7) cancel_token / W2(4) curiosity_engine convention
- **`docs/architecture/OUROBOROS_VENOM_PRD.md`** — new §1 "Roadmap Execution Status (live)" subsection with per-slice `[x]/[~]/[ ]` tracking. Records Phase 0 audit complete, Phase 1 P0 build (#20968) + smoke + pins landed, P0 master-flag flip pending the 3-clean-session cadence per §11 Layer 4. Update discipline noted: each closing slice updates this section in the same PR.

## Risk surface

**Zero production code changes.** Master flag `JARVIS_POSTMORTEM_RECALL_ENABLED` stays default-`false` until operator-authorized graduation flip. No new authority paths, no new env knobs, no orchestrator FSM changes.

## What's next per the roadmap

After merge, the next slice is the 3-clean-session graduation cadence soak with `JARVIS_POSTMORTEM_RECALL_ENABLED=true` set per-session. After 3 clean sessions, operator-authorized graduation slice flips the master-flag default `false` → `true` and renames `test_master_flag_default_false_pre_graduation` per its embedded instructions.

## Test plan

- [x] `python3 -m pytest tests/governance/test_postmortem_recall_p0.py tests/governance/test_postmortem_recall_graduation_pins.py --no-header -q --timeout=60` — 57/57 PASS
- [x] `python3 scripts/livefire_p0_postmortem_recall.py` — 16/16 PASS
- [x] No production source files changed (verify via `git diff --stat main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds P0 PostmortemRecall live-fire smoke and graduation pin tests, plus PRD roadmap status tracking, to validate end-to-end behavior and lock the graduation contract. No production code changes; `JARVIS_POSTMORTEM_RECALL_ENABLED` stays default `false`.

- **New Features**
  - `scripts/livefire_p0_postmortem_recall.py`: 16 in-process checks (no network/API key), exit 0 on pass.
  - `tests/governance/test_postmortem_recall_graduation_pins.py`: 16 pins for default-off master flag, sub-flag defaults, hot-revert, schema, and orchestrator wiring order.
  - `docs/architecture/OUROBOROS_VENOM_PRD.md`: Adds live per-slice roadmap status; records P0 build + smoke + pins landed; master-flag flip pending 3 clean sessions.

<sup>Written for commit 9900fb0efc18a1f8958434f8ec8011176670591d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

