### PR TITLE
soak(p0): session #1 of 3 — BLOCKED (api_key_missing)

### DIFF
--- a/memory/project_p0_postmortem_recall_soak_ledger.md
+++ b/memory/project_p0_postmortem_recall_soak_ledger.md
@@ -1,0 +1,16 @@
+# P0 PostmortemRecall Graduation Soak Ledger
+
+Tracks the 3-session graduation soak for `PostmortemRecall` (PRD §11 Layer 4).
+Merged commit: `d708c5d425` — PR #20976.
+Required: 3 consecutive CLEAN sessions before graduation PR may be opened.
+
+## Columns
+
+| session_id | start_utc | duration_s | stop_reason | session_outcome | postmortem_recall_markers | clean_verdict | notes |
+|---|---|---|---|---|---|---|---|
+| N/A | 2026-04-26T02:04:00Z | ~15 | api_key_missing | not_started | 0 | BLOCKED | ANTHROPIC_API_KEY + DOUBLEWORD_API_KEY both unset in sandbox env. Sanity gate passed: 16/16 livefire + 57/57 pytest. Harness preflight exits before session creation. Must set ≥1 API key to run soak. |
+
+---
+
+> **Soak conductor:** agent.
+> **HUMAN_REVIEW_WAIVED:** TTY-only affordances (Rich diff, REPL) not exercised in headless soak — accepted residual risk per feedback_agent_conducted_soak_delegation.md.


### PR DESCRIPTION
## Soak Session #1 of 3 — P0 PostmortemRecall Graduation

### Session Metrics

| Field | Value |
|---|---|
| Soak target | PostmortemRecall (PRD §11 Layer 4) |
| Merged commit | `d708c5d425` (PR #20976) |
| Start UTC | 2026-04-26T02:04:00Z |
| Duration | ~15s (preflight exit) |
| Stop reason | `api_key_missing` |
| Session outcome | `not_started` |
| PostmortemRecall markers | 0 (harness never reached session init) |
| Clean verdict | **BLOCKED** |

### What Passed

- **16/16** livefire smoke checks (`scripts/livefire_p0_postmortem_recall.py`) ✓
- **57/57** pytest graduation pins (`test_postmortem_recall_p0.py` + `test_postmortem_recall_graduation_pins.py`) ✓
- All required files confirmed on `d708c5d425`: `postmortem_recall.py`, `livefire_p0_postmortem_recall.py`, `test_postmortem_recall_graduation_pins.py` ✓

### Blocker

The battle-test harness hard-exits at preflight if neither `ANTHROPIC_API_KEY` nor `DOUBLEWORD_API_KEY` is set. Both are unset (empty) in the sandbox environment used for this soak run. The harness has no dry-run or mock mode — it requires a live provider to generate and apply code changes.

**Operator action required before re-scheduling session #1:**
```bash
export ANTHROPIC_API_KEY=<real-key>   # or DOUBLEWORD_API_KEY
```

Then re-schedule via `/schedule` and the conductor will re-attempt with `JARVIS_POSTMORTEM_RECALL_ENABLED=true`.

### Soak Ledger

Creates `memory/project_p0_postmortem_recall_soak_ledger.md` with the blocker row and the required footer block.

---

> Soak conductor: agent.
> HUMAN_REVIEW_WAIVED: TTY-only affordances (Rich diff, REPL) not exercised in headless soak — accepted residual risk per feedback_agent_conducted_soak_delegation.md.

https://claude.ai/code/session_01Ut18i9u5gwWzTMuUs9zHVy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ut18i9u5gwWzTMuUs9zHVy)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `memory/project_p0_postmortem_recall_soak_ledger.md` and logs P0 PostmortemRecall soak session #1 as BLOCKED (`api_key_missing`). The soak run didn’t start because neither `ANTHROPIC_API_KEY` nor `DOUBLEWORD_API_KEY` was set.

- **Migration**
  - Set at least one key: export `ANTHROPIC_API_KEY` or `DOUBLEWORD_API_KEY` in the sandbox.
  - Re-schedule session #1 via `/schedule`.

<sup>Written for commit 18bf137a69df7001aef4b0be6b336e7c197e7040. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

