### PR TITLE
chore(ci): Fix CI infra failures (orphan submodule, setuptools, diagram-output)

### DIFF
--- a/.github/workflows/auto-diagram-generator.yml
+++ b/.github/workflows/auto-diagram-generator.yml
@@ -222,9 +222,13 @@ jobs:
           fi
           echo "has_changes=$has_changes" >> "$GITHUB_OUTPUT"
 
-          # Safely convert changed_files array to JSON, handling empty arrays
+          # Safely convert changed_files array to JSON, handling empty arrays.
+          # NOTE: -c flag (compact) is required — $GITHUB_OUTPUT only accepts
+          # single-line `name=value` writes; jq's default pretty-print emits
+          # multi-line JSON which the actions runner rejects with
+          # "Invalid format" and fails the job.
           if [[ "${#changed_files[@]}" -gt 0 ]]; then
-            changed_files_json=$(printf '%s\n' "${changed_files[@]}" | jq -Rs 'split("\n") | map(select(length > 0))')
+            changed_files_json=$(printf '%s\n' "${changed_files[@]}" | jq -Rsc 'split("\n") | map(select(length > 0))')
           else
             changed_files_json='[]'
           fi

--- a/.github/workflows/screen-lock-e2e-test.yml
+++ b/.github/workflows/screen-lock-e2e-test.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip
+          pip install --upgrade pip setuptools wheel
           pip install pytest pytest-asyncio pytest-mock pytest-timeout aiohttp
 
           # Install project dependencies
@@ -931,7 +931,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip
+          pip install --upgrade pip setuptools wheel
           pip install pytest pytest-asyncio aiohttp
 
           if [ -f "backend/requirements.txt" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -387,3 +387,6 @@ terraform/terraform.tfvars
 .jarvis/vision_frames/
 .jarvis/vision_cost_ledger.json
 .jarvis/vision_sensor_fp_ledger.json
+
+# Local wiki working tree (deploy-wiki.sh clones https://github.com/drussell23/JARVIS-AI.wiki.git here)
+JARVIS-AI.wiki/


### PR DESCRIPTION
## Summary

Resolves three of the four CI infra issues filed during the §23 Reverse Russian Doll PRD admin-merge (#21749 → `b4706e455d`). All three were verified as infra-only failures unrelated to any code change. Each is a small, surgical fix with its own commit for clean revert.

The fourth issue (#21797 Vercel) is external — the Vercel GitHub App posts the status check directly, not from a workflow file, and the `jarvis-cloud/.vercel/vercel.json` is real production cron config that must not be touched. It will be addressed by a comment on the issue with operator-action context (resolve account block, remove integration, or mark not-required in branch protection).

## Commits (one per issue, squash on merge)

### 1. `chore(ci): Remove orphan JARVIS-AI.wiki submodule gitlink` — Closes #21795

The repo tree carried a gitlink (mode 160000, commit `99cd9e07d36b840`) at `JARVIS-AI.wiki/` with no corresponding entry in `.gitmodules`. Likely an accidental `git add` from a sibling local clone. The orphan caused every workflow that runs `git submodule foreach --recursive` to emit `fatal: No url found for submodule path 'JARVIS-AI.wiki' in .gitmodules`.

Fix: `git rm --cached JARVIS-AI.wiki` removes the gitlink from the index without deleting any local working-tree contents. `deploy-wiki.sh` continues to clone the wiki as a sibling working dir — its workflow is unaffected. Added `JARVIS-AI.wiki/` to `.gitignore` so the orphan cannot be re-added accidentally.

### 2. `chore(ci): Install setuptools+wheel on Mock + Integration testing runners` — Closes #21796

`Mock Testing (Safe)` and `Integration Testing` jobs in `screen-lock-e2e-test.yml` failed with `ModuleNotFoundError: No module named 'pkg_resources'`. Root cause: `pkg_resources` was removed from Python 3.12+ stdlib (it now lives only in setuptools), and `actions/setup-python@v5` does not pre-install setuptools by default on newer Python versions.

Fix: change `pip install --upgrade pip` → `pip install --upgrade pip setuptools wheel` in both jobs. The `Real E2E Testing (Self-Hosted)` job uses a different setup pattern and is unaffected.

### 3. `chore(ci): Use jq -Rsc for compact GITHUB_OUTPUT in auto-diagram discover` — Closes #21798

The `🔍 Discover & Analyze Diagrams` step in `auto-diagram-generator.yml` failed with `##[error]Unable to process file command 'output' successfully. ##[error]Invalid format '  "docs/architecture/OUROBOROS_VENOM_PRD.md"'`. Root cause: the step writes a JSON array to `$GITHUB_OUTPUT` via `echo "name=$json" >> $GITHUB_OUTPUT`, but `jq -Rs` emits pretty-printed multi-line JSON by default. `$GITHUB_OUTPUT`'s `name=value` syntax only accepts single-line values; multi-line writes need heredoc syntax.

Fix: add `-c` (compact) flag → `jq -Rsc`. Single-line JSON, same array shape, no behavior change beyond the format fix. Same potential issue exists with the `diagram_matrix` output but it's already constructed via bash concatenation that produces single-line output, so no change needed there.

## What's NOT in this PR

- **#21797 (Vercel)**: external, not code-resolvable. Will receive an operator-action comment on the issue. No `vercel.json` edits — that's real prod cron config (`/api/ouroboros/submit` daily, `/api/devices/health` daily) and must stay untouched without explicit ops approval.
- No code in `backend/` modified
- No tests added or modified
- No env flags introduced

## Diff stats

- 3 files changed
- +9 insertions, −5 deletions
- One per-issue commit; squash on merge to keep main history linear

## Test plan

- [x] `git rm --cached` preserves local `JARVIS-AI.wiki/` working dir (deploy-wiki.sh untouched)
- [x] Both `pip install` lines updated to include `setuptools wheel`
- [x] `jq -Rsc` produces single-line JSON (verified spec — `-c` flag standard)
- [x] No workflow YAML structural change beyond the targeted lines

## Revert path

Three independent commits — each can be reverted in isolation if any single fix proves wrong. After squash-merge, single revert restores all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three CI workflow failures to restore reliable runs. Removes an orphan wiki submodule, installs missing Python build tools, and outputs compact JSON in the diagram discovery step.

- **Bug Fixes**
  - Removed orphan `JARVIS-AI.wiki` submodule gitlink and added to `.gitignore`; `deploy-wiki.sh` behavior unchanged.
  - Updated test jobs to `pip install --upgrade pip setuptools wheel` to restore `pkg_resources` on Python 3.12+ (`actions/setup-python@v5`).
  - Switched to `jq -Rsc` so JSON written to `$GITHUB_OUTPUT` is single-line and accepted by the runner.

<sup>Written for commit 7ab0c760a83dfb791e4b746bb13a9c928cd668ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

