### PR TITLE
feat(p3): Slice 1 — inline approval primitive (parser + queue + singleton)

### DIFF
--- a/backend/core/ouroboros/governance/inline_approval.py
+++ b/backend/core/ouroboros/governance/inline_approval.py
@@ -1,0 +1,389 @@
+"""P3 Slice 1 — Lightweight inline approval primitive (Phase 3 P3).
+
+Per OUROBOROS_VENOM_PRD.md §9 Phase 3 P3:
+
+  > Yellow/Orange-tier approval today = create a PR + review. That's
+  > heavy for fast iterations.
+  >
+  > Solution: SerpentFlow inline approval mode for development:
+  >   - Show full diff in terminal with hunks
+  >   - Prompt: ``[y]es / [n]o / [s]how stack / [e]dit / [w]ait``
+  >     with 30s default timeout
+  >   - On ``y``: apply (same path as auto-apply for SAFE_AUTO)
+  >   - On ``e``: open in $EDITOR, then re-prompt
+  >   - Keep existing PR path for production work (operator setting
+  >     decides)
+
+This slice ships the **pure-data primitive** + **decision parser** +
+**bounded FIFO queue**. Slice 2 wires the ``ApprovalProvider`` Protocol
+implementation; Slice 3 adds SerpentFlow rendering + ``$EDITOR``
+shell-out; Slice 4 graduates the env-knob default flip.
+
+Default-off behind ``JARVIS_APPROVAL_UX_INLINE_ENABLED`` until Slice 4.
+When off, no inline-approval surface is exposed; existing
+``CLIApprovalProvider`` / ``OrangePRReviewer`` paths remain
+authoritative.
+
+Authority invariants (PRD §12.2):
+  * No imports of orchestrator / policy / iron_gate / risk_tier /
+    change_engine / candidate_generator / gate / semantic_guardian.
+  * No subprocess, no file I/O, no env mutation. The 30s prompt I/O
+    is Slice 3's job; this primitive is pure data + thread-safe queue.
+  * Best-effort — malformed inputs return ``WAIT`` (safest default;
+    never auto-approves a bad parse).
+  * Bounded — FIFO queue capped at ``MAX_QUEUED_REQUESTS`` so a runaway
+    op-flood can't accumulate unbounded approval state.
+"""
+from __future__ import annotations
+
+import enum
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+# Default decision timeout per PRD spec — 30 seconds. On timeout, the
+# request defers to the queue (NOT auto-approves; safety-first).
+DEFAULT_DECISION_TIMEOUT_S: float = 30.0
+
+# FIFO queue cap. Multiple concurrent ops needing approval get queued;
+# this cap bounds how many can pile up before new requests start
+# returning ``QUEUE_FULL`` to the caller. Defensive against the
+# "operator AFK + sensor flood" failure mode.
+MAX_QUEUED_REQUESTS: int = 16
+
+# Risk tiers eligible for IMMEDIATE-priority queue promotion.
+# Per PRD: "single queue, FIFO with priority for IMMEDIATE".
+_IMMEDIATE_PRIORITY_RISK_TIERS = frozenset({"IMMEDIATE", "BLOCKED"})
+
+
+def is_enabled() -> bool:
+    """Master flag — ``JARVIS_APPROVAL_UX_INLINE_ENABLED`` (default false).
+
+    Slice 1 ships default-off. Slice 4 graduation flips it after the
+    full provider integration + SerpentFlow rendering + comprehensive
+    pin suite + in-process live-fire smoke complete.
+
+    When off, inline-approval is invisible — existing
+    ``CLIApprovalProvider`` + Orange PR paths remain authoritative."""
+    return os.environ.get(
+        "JARVIS_APPROVAL_UX_INLINE_ENABLED", "",
+    ).strip().lower() in _TRUTHY
+
+
+def decision_timeout_s() -> float:
+    """Per-request decision timeout in seconds.
+
+    Default 30.0 per PRD spec. Negative values clamp to 1.0 (never
+    auto-defer instantly — give the operator at least a frame to react).
+    Invalid values fall back to default."""
+    raw = os.environ.get("JARVIS_APPROVAL_UX_INLINE_TIMEOUT_S")
+    if raw is None:
+        return DEFAULT_DECISION_TIMEOUT_S
+    try:
+        v = float(raw)
+        return max(1.0, v)
+    except (TypeError, ValueError):
+        return DEFAULT_DECISION_TIMEOUT_S
+
+
+# ---------------------------------------------------------------------------
+# Decision enum + parser
+# ---------------------------------------------------------------------------
+
+
+class InlineApprovalChoice(str, enum.Enum):
+    """Operator's response to an inline approval prompt."""
+
+    APPROVE = "APPROVE"
+    REJECT = "REJECT"
+    SHOW_STACK = "SHOW_STACK"
+    EDIT = "EDIT"
+    WAIT = "WAIT"
+    TIMEOUT_DEFERRED = "TIMEOUT_DEFERRED"
+
+
+# Single-char + verbose form mapping. Matches PRD prompt:
+#   [y]es / [n]o / [s]how stack / [e]dit / [w]ait
+#
+# Whitespace + case ignored. Verbose forms accept any prefix that
+# uniquely matches one of the accepted words.
+_CHOICE_TOKENS: Dict[str, InlineApprovalChoice] = {
+    # Single-char (preferred; matches the prompt's `[x]` brackets)
+    "y": InlineApprovalChoice.APPROVE,
+    "n": InlineApprovalChoice.REJECT,
+    "s": InlineApprovalChoice.SHOW_STACK,
+    "e": InlineApprovalChoice.EDIT,
+    "w": InlineApprovalChoice.WAIT,
+    # Common verbose synonyms
+    "yes": InlineApprovalChoice.APPROVE,
+    "no": InlineApprovalChoice.REJECT,
+    "approve": InlineApprovalChoice.APPROVE,
+    "reject": InlineApprovalChoice.REJECT,
+    "show": InlineApprovalChoice.SHOW_STACK,
+    "stack": InlineApprovalChoice.SHOW_STACK,
+    "edit": InlineApprovalChoice.EDIT,
+    "wait": InlineApprovalChoice.WAIT,
+    "defer": InlineApprovalChoice.WAIT,
+}
+
+
+def parse_decision_input(text: str) -> InlineApprovalChoice:
+    """Parse operator input into one of the five live choices.
+
+    Returns ``WAIT`` on:
+      * empty / whitespace-only input
+      * unknown token
+      * ambiguous input (multiple tokens — caller should re-prompt)
+
+    Safety-first contract: never returns ``APPROVE`` from ambiguous
+    input. ``WAIT`` is the safest default — it queues the request for
+    the operator to revisit. Pinned by tests."""
+    if not text or not text.strip():
+        return InlineApprovalChoice.WAIT
+    cleaned = text.strip().lower()
+    # Strip surrounding whitespace + take first token only (defends
+    # against accidental "y\nsomething else").
+    first_token = re.split(r"\s+", cleaned)[0]
+    if not first_token:
+        return InlineApprovalChoice.WAIT
+    return _CHOICE_TOKENS.get(first_token, InlineApprovalChoice.WAIT)
+
+
+# ---------------------------------------------------------------------------
+# Request + decision dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InlineApprovalRequest:
+    """One pending inline approval — written by the orchestrator
+    (Slice 2 ApprovalProvider impl) when an op needs human ack."""
+
+    request_id: str
+    op_id: str
+    risk_tier: str
+    target_files: Tuple[str, ...]
+    diff_summary: str
+    created_unix: float
+    deadline_unix: float
+
+    def is_immediate_priority(self) -> bool:
+        """True when the op should jump the FIFO queue."""
+        return self.risk_tier in _IMMEDIATE_PRIORITY_RISK_TIERS
+
+    def seconds_remaining(self, now_unix: Optional[float] = None) -> float:
+        """Wall-clock seconds until the request times out. Negative
+        values mean past-deadline (caller should auto-defer)."""
+        now = now_unix if now_unix is not None else time.time()
+        return max(-1.0, self.deadline_unix - now)
+
+
+@dataclass(frozen=True)
+class InlineApprovalDecision:
+    """One operator decision recorded by the queue."""
+
+    request_id: str
+    choice: InlineApprovalChoice
+    reason: str
+    decided_unix: float
+    operator: str = "operator"
+
+
+# ---------------------------------------------------------------------------
+# Bounded FIFO queue (with IMMEDIATE-priority promotion)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _QueueEntry:
+    """Internal mutable container — one queued request + its
+    realized decision (None until decided)."""
+
+    request: InlineApprovalRequest
+    decision: Optional[InlineApprovalDecision] = None
+
+
+class InlineApprovalQueue:
+    """Process-wide FIFO queue of pending inline approval requests.
+
+    Thread-safe via a single coarse lock — all public methods take it
+    because each call mutates ≤2 maps. Mirrors the
+    ``RealtimeProgressTracker`` lock pattern (P3.5).
+
+    Public surface (Slice 1):
+      * ``enqueue(request)`` — add request; promotes IMMEDIATE-tier to
+        front. Returns False when queue is at cap (caller falls back
+        to non-inline approval path).
+      * ``record_decision(request_id, choice, reason)`` — operator
+        marks a decision; queue entry stays for ``next_pending`` to
+        skip. Returns False when request_id unknown.
+      * ``next_pending()`` — returns the highest-priority undecided
+        request, or None.
+      * ``mark_timeout(request_id, now)`` — records a TIMEOUT_DEFERRED
+        decision so the queue stays accurate. Returns False when unknown.
+      * ``forget(request_id)`` — drop entry (called by Slice 2 provider
+        after the decision flows back through the FSM).
+      * ``snapshot()`` — list[InlineApprovalRequest] of all pending.
+        Used by REPL list/show in Slice 3.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # Insertion-ordered dict so FIFO iteration is naturally
+        # well-defined; IMMEDIATE-promotion via popping + re-inserting
+        # at the front (Python preserves insertion order).
+        self._entries: Dict[str, _QueueEntry] = {}
+
+    # ---- public API ----
+
+    def enqueue(self, request: InlineApprovalRequest) -> bool:
+        """Add a request to the queue. Returns False when queue is
+        full OR when ``request_id`` collides with an existing entry."""
+        if not request.request_id or not request.op_id:
+            return False
+        with self._lock:
+            if request.request_id in self._entries:
+                return False
+            if len(self._entries) >= MAX_QUEUED_REQUESTS:
+                return False
+            entry = _QueueEntry(request=request)
+            if request.is_immediate_priority():
+                # Promote to front: rebuild dict with this entry first.
+                new_entries = {request.request_id: entry}
+                new_entries.update(self._entries)
+                self._entries = new_entries
+            else:
+                self._entries[request.request_id] = entry
+            return True
+
+    def next_pending(
+        self, now_unix: Optional[float] = None,
+    ) -> Optional[InlineApprovalRequest]:
+        """Return the highest-priority undecided request whose deadline
+        hasn't already passed. None if queue empty / all decided / all
+        past-deadline."""
+        now = now_unix if now_unix is not None else time.time()
+        with self._lock:
+            for entry in self._entries.values():
+                if entry.decision is not None:
+                    continue
+                if entry.request.deadline_unix < now:
+                    continue
+                return entry.request
+        return None
+
+    def record_decision(
+        self,
+        request_id: str,
+        choice: InlineApprovalChoice,
+        reason: str = "",
+        operator: str = "operator",
+        now_unix: Optional[float] = None,
+    ) -> bool:
+        """Record an operator decision. ``False`` when request_id unknown
+        OR when entry already has a decision recorded (idempotent —
+        the FIRST decision wins; subsequent calls are silent no-ops).
+        """
+        with self._lock:
+            entry = self._entries.get(request_id)
+            if entry is None or entry.decision is not None:
+                return False
+            entry.decision = InlineApprovalDecision(
+                request_id=request_id,
+                choice=choice,
+                reason=str(reason)[:500],
+                decided_unix=now_unix if now_unix is not None else time.time(),
+                operator=operator,
+            )
+            return True
+
+    def mark_timeout(
+        self, request_id: str, now_unix: Optional[float] = None,
+    ) -> bool:
+        """Record a TIMEOUT_DEFERRED decision. Used by the Slice 3 prompt
+        loop when 30s expires without operator input."""
+        return self.record_decision(
+            request_id=request_id,
+            choice=InlineApprovalChoice.TIMEOUT_DEFERRED,
+            reason="prompt timeout",
+            operator="system",
+            now_unix=now_unix,
+        )
+
+    def get_decision(
+        self, request_id: str,
+    ) -> Optional[InlineApprovalDecision]:
+        with self._lock:
+            entry = self._entries.get(request_id)
+            return entry.decision if entry is not None else None
+
+    def forget(self, request_id: str) -> bool:
+        """Drop an entry from the queue. Called by Slice 2 provider after
+        the decision has flowed back through the FSM. Idempotent."""
+        with self._lock:
+            return self._entries.pop(request_id, None) is not None
+
+    def snapshot(self) -> List[InlineApprovalRequest]:
+        """Return all pending (undecided + not-past-deadline) requests
+        in queue order. Used by Slice 3 REPL list/show."""
+        with self._lock:
+            return [
+                entry.request for entry in self._entries.values()
+                if entry.decision is None
+            ]
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+
+# ---------------------------------------------------------------------------
+# Default-singleton accessor
+# ---------------------------------------------------------------------------
+
+
+_default_queue: Optional[InlineApprovalQueue] = None
+_default_queue_lock = threading.Lock()
+
+
+def get_default_queue() -> InlineApprovalQueue:
+    """Return the process-wide queue. Lazy-construct on first call.
+
+    Mirrors the P3.5 ``get_default_tracker`` pattern. NO master flag
+    on the accessor — operators may want to inspect prior decisions
+    even after rolling back the env knob. The flag controls whether
+    Slice 2's provider EMITS into the queue, not whether the queue is
+    available for inspection."""
+    global _default_queue
+    with _default_queue_lock:
+        if _default_queue is None:
+            _default_queue = InlineApprovalQueue()
+    return _default_queue
+
+
+def reset_default_queue() -> None:
+    """Reset the singleton — for tests."""
+    global _default_queue
+    with _default_queue_lock:
+        _default_queue = None
+
+
+__all__ = [
+    "DEFAULT_DECISION_TIMEOUT_S",
+    "MAX_QUEUED_REQUESTS",
+    "InlineApprovalChoice",
+    "InlineApprovalDecision",
+    "InlineApprovalQueue",
+    "InlineApprovalRequest",
+    "decision_timeout_s",
+    "get_default_queue",
+    "is_enabled",
+    "parse_decision_input",
+    "reset_default_queue",
+]

--- a/backend/core/ouroboros/governance/inline_approval.py
+++ b/backend/core/ouroboros/governance/inline_approval.py
@@ -41,7 +41,7 @@ import os
 import re
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 

--- a/tests/governance/test_inline_approval_primitive.py
+++ b/tests/governance/test_inline_approval_primitive.py
@@ -1,0 +1,495 @@
+"""P3 Slice 1 — Inline approval primitive regression suite.
+
+Pins the pure-data primitive shipped in
+``backend/core/ouroboros/governance/inline_approval.py``:
+
+  * Decision parser (parse_decision_input) — single-char + verbose +
+    case-insensitive + safety-first WAIT default.
+  * Frozen dataclasses (InlineApprovalRequest, InlineApprovalDecision)
+    + helpers (is_immediate_priority, seconds_remaining).
+  * Bounded thread-safe FIFO queue (InlineApprovalQueue) — IMMEDIATE
+    priority promotion, idempotent record_decision, mark_timeout,
+    cap-at-MAX behavior, snapshot.
+  * Default-singleton accessor (get_default_queue / reset).
+  * Env-knob defaults (is_enabled false; decision_timeout_s 30s + clamp).
+  * Authority invariants — no banned imports + no I/O / subprocess /
+    env mutation.
+
+Slice 1 ships the primitive default-off behind
+``JARVIS_APPROVAL_UX_INLINE_ENABLED``. Slice 4 graduates the flip.
+"""
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.inline_approval import (
+    DEFAULT_DECISION_TIMEOUT_S,
+    MAX_QUEUED_REQUESTS,
+    InlineApprovalChoice,
+    InlineApprovalDecision,
+    InlineApprovalQueue,
+    InlineApprovalRequest,
+    decision_timeout_s,
+    get_default_queue,
+    is_enabled,
+    parse_decision_input,
+    reset_default_queue,
+)
+
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+
+
+def _read(rel: str) -> str:
+    return (_REPO / rel).read_text(encoding="utf-8")
+
+
+def _make_request(
+    request_id: str = "req-1",
+    op_id: str = "op-1",
+    risk_tier: str = "STANDARD",
+    deadline_unix: float = 1_000_000.0,
+    created_unix: float = 999_970.0,
+) -> InlineApprovalRequest:
+    return InlineApprovalRequest(
+        request_id=request_id,
+        op_id=op_id,
+        risk_tier=risk_tier,
+        target_files=("a.py",),
+        diff_summary="@@ -1 +1 @@\n-a\n+b",
+        created_unix=created_unix,
+        deadline_unix=deadline_unix,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_default_queue()
+    yield
+    reset_default_queue()
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("JARVIS_APPROVAL_UX_INLINE_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_APPROVAL_UX_INLINE_TIMEOUT_S", raising=False)
+    yield
+
+
+# ===========================================================================
+# A — Module-level constants
+# ===========================================================================
+
+
+def test_default_decision_timeout_pinned():
+    """Pin: PRD spec says 30s default decision timeout."""
+    assert DEFAULT_DECISION_TIMEOUT_S == 30.0
+
+
+def test_max_queued_requests_pinned():
+    """Pin: bounded queue capacity to prevent operator-AFK floods."""
+    assert MAX_QUEUED_REQUESTS == 16
+
+
+# ===========================================================================
+# B — Env-knob accessors (is_enabled + decision_timeout_s)
+# ===========================================================================
+
+
+def test_is_enabled_default_false_pre_graduation():
+    """Slice 1 ships default-OFF. Renamed to
+    ``test_is_enabled_default_true_post_graduation`` at Slice 4 flip."""
+    assert is_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE", "Yes"])
+def test_is_enabled_truthy_variants(monkeypatch, val):
+    monkeypatch.setenv("JARVIS_APPROVAL_UX_INLINE_ENABLED", val)
+    assert is_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "", "garbage"])
+def test_is_enabled_falsy_variants(monkeypatch, val):
+    monkeypatch.setenv("JARVIS_APPROVAL_UX_INLINE_ENABLED", val)
+    assert is_enabled() is False
+
+
+def test_decision_timeout_default_when_unset():
+    assert decision_timeout_s() == DEFAULT_DECISION_TIMEOUT_S
+
+
+def test_decision_timeout_reads_env(monkeypatch):
+    monkeypatch.setenv("JARVIS_APPROVAL_UX_INLINE_TIMEOUT_S", "12.5")
+    assert decision_timeout_s() == 12.5
+
+
+def test_decision_timeout_clamps_negative_to_one(monkeypatch):
+    """Pin: negative env values clamp to 1.0 — never auto-defer instantly."""
+    monkeypatch.setenv("JARVIS_APPROVAL_UX_INLINE_TIMEOUT_S", "-5")
+    assert decision_timeout_s() == 1.0
+
+
+def test_decision_timeout_clamps_zero_to_one(monkeypatch):
+    monkeypatch.setenv("JARVIS_APPROVAL_UX_INLINE_TIMEOUT_S", "0")
+    assert decision_timeout_s() == 1.0
+
+
+def test_decision_timeout_falls_back_on_invalid(monkeypatch):
+    monkeypatch.setenv("JARVIS_APPROVAL_UX_INLINE_TIMEOUT_S", "not-a-number")
+    assert decision_timeout_s() == DEFAULT_DECISION_TIMEOUT_S
+
+
+# ===========================================================================
+# C — parse_decision_input
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("y", InlineApprovalChoice.APPROVE),
+        ("n", InlineApprovalChoice.REJECT),
+        ("s", InlineApprovalChoice.SHOW_STACK),
+        ("e", InlineApprovalChoice.EDIT),
+        ("w", InlineApprovalChoice.WAIT),
+    ],
+)
+def test_parse_single_char_choices(text, expected):
+    assert parse_decision_input(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("yes", InlineApprovalChoice.APPROVE),
+        ("YES", InlineApprovalChoice.APPROVE),
+        ("Yes", InlineApprovalChoice.APPROVE),
+        ("approve", InlineApprovalChoice.APPROVE),
+        ("no", InlineApprovalChoice.REJECT),
+        ("reject", InlineApprovalChoice.REJECT),
+        ("show", InlineApprovalChoice.SHOW_STACK),
+        ("stack", InlineApprovalChoice.SHOW_STACK),
+        ("edit", InlineApprovalChoice.EDIT),
+        ("wait", InlineApprovalChoice.WAIT),
+        ("defer", InlineApprovalChoice.WAIT),
+    ],
+)
+def test_parse_verbose_choices_case_insensitive(text, expected):
+    assert parse_decision_input(text) is expected
+
+
+@pytest.mark.parametrize("text", ["", "   ", "\t", "\n"])
+def test_parse_empty_returns_wait(text):
+    """Safety-first: empty / whitespace input never auto-approves."""
+    assert parse_decision_input(text) is InlineApprovalChoice.WAIT
+
+
+@pytest.mark.parametrize("text", ["maybe", "????", "123", "approve-but-wait"])
+def test_parse_garbage_returns_wait(text):
+    """Safety-first: unknown tokens never auto-approve."""
+    assert parse_decision_input(text) is InlineApprovalChoice.WAIT
+
+
+def test_parse_strips_surrounding_whitespace():
+    assert parse_decision_input("  y  ") is InlineApprovalChoice.APPROVE
+
+
+def test_parse_takes_first_token_only():
+    """``y\\nrm -rf /`` should parse the first token, not crash or chain."""
+    assert parse_decision_input("y\nrm -rf /") is InlineApprovalChoice.APPROVE
+
+
+# ===========================================================================
+# D — InlineApprovalRequest + InlineApprovalDecision dataclasses
+# ===========================================================================
+
+
+def test_request_is_frozen():
+    req = _make_request()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        req.risk_tier = "BLOCKED"  # type: ignore[misc]
+
+
+def test_decision_is_frozen():
+    dec = InlineApprovalDecision(
+        request_id="r1",
+        choice=InlineApprovalChoice.APPROVE,
+        reason="looks good",
+        decided_unix=100.0,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        dec.choice = InlineApprovalChoice.REJECT  # type: ignore[misc]
+
+
+def test_decision_default_operator_is_operator():
+    dec = InlineApprovalDecision(
+        request_id="r1",
+        choice=InlineApprovalChoice.APPROVE,
+        reason="",
+        decided_unix=100.0,
+    )
+    assert dec.operator == "operator"
+
+
+@pytest.mark.parametrize("tier", ["IMMEDIATE", "BLOCKED"])
+def test_request_immediate_priority_true_for_immediate_or_blocked(tier):
+    req = _make_request(risk_tier=tier)
+    assert req.is_immediate_priority() is True
+
+
+@pytest.mark.parametrize(
+    "tier", ["STANDARD", "COMPLEX", "BACKGROUND", "SPECULATIVE", "SAFE_AUTO"],
+)
+def test_request_immediate_priority_false_for_other_tiers(tier):
+    req = _make_request(risk_tier=tier)
+    assert req.is_immediate_priority() is False
+
+
+def test_seconds_remaining_positive_when_before_deadline():
+    req = _make_request(deadline_unix=1000.0)
+    assert req.seconds_remaining(now_unix=970.0) == 30.0
+
+
+def test_seconds_remaining_negative_clamps_to_minus_one():
+    """Past-deadline clamps to -1.0 (caller signal: auto-defer)."""
+    req = _make_request(deadline_unix=1000.0)
+    assert req.seconds_remaining(now_unix=2000.0) == -1.0
+
+
+# ===========================================================================
+# E — InlineApprovalQueue: enqueue / next_pending / record_decision
+# ===========================================================================
+
+
+def test_enqueue_then_next_pending_returns_request():
+    q = InlineApprovalQueue()
+    req = _make_request()
+    assert q.enqueue(req) is True
+    assert q.next_pending(now_unix=999_990.0) == req
+
+
+def test_enqueue_rejects_blank_request_id():
+    q = InlineApprovalQueue()
+    bad = _make_request(request_id="")
+    assert q.enqueue(bad) is False
+
+
+def test_enqueue_rejects_blank_op_id():
+    q = InlineApprovalQueue()
+    bad = _make_request(op_id="")
+    assert q.enqueue(bad) is False
+
+
+def test_enqueue_rejects_duplicate_request_id():
+    q = InlineApprovalQueue()
+    req = _make_request()
+    assert q.enqueue(req) is True
+    assert q.enqueue(req) is False  # duplicate
+
+
+def test_enqueue_returns_false_when_queue_full():
+    q = InlineApprovalQueue()
+    for i in range(MAX_QUEUED_REQUESTS):
+        assert q.enqueue(_make_request(request_id=f"req-{i}")) is True
+    overflow = _make_request(request_id="req-overflow")
+    assert q.enqueue(overflow) is False
+    assert len(q) == MAX_QUEUED_REQUESTS
+
+
+def test_immediate_priority_jumps_queue_front():
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1", risk_tier="STANDARD"))
+    q.enqueue(_make_request(request_id="r2", risk_tier="STANDARD"))
+    q.enqueue(_make_request(request_id="r3", risk_tier="IMMEDIATE"))
+    # IMMEDIATE r3 should be served first.
+    nxt = q.next_pending(now_unix=999_990.0)
+    assert nxt is not None
+    assert nxt.request_id == "r3"
+
+
+def test_blocked_tier_also_jumps_queue_front():
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1"))
+    q.enqueue(_make_request(request_id="rB", risk_tier="BLOCKED"))
+    nxt = q.next_pending(now_unix=999_990.0)
+    assert nxt is not None
+    assert nxt.request_id == "rB"
+
+
+def test_record_decision_marks_entry_decided():
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1"))
+    assert q.record_decision(
+        "r1", InlineApprovalChoice.APPROVE, reason="lgtm",
+        now_unix=500.0,
+    ) is True
+    dec = q.get_decision("r1")
+    assert dec is not None
+    assert dec.choice is InlineApprovalChoice.APPROVE
+    assert dec.reason == "lgtm"
+    assert dec.decided_unix == 500.0
+
+
+def test_record_decision_unknown_request_id_returns_false():
+    q = InlineApprovalQueue()
+    assert q.record_decision(
+        "missing", InlineApprovalChoice.APPROVE,
+    ) is False
+
+
+def test_record_decision_idempotent_first_wins():
+    """Pin: subsequent record_decision calls are silent no-ops."""
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1"))
+    assert q.record_decision("r1", InlineApprovalChoice.APPROVE) is True
+    assert q.record_decision("r1", InlineApprovalChoice.REJECT) is False
+    dec = q.get_decision("r1")
+    assert dec is not None
+    assert dec.choice is InlineApprovalChoice.APPROVE
+
+
+def test_record_decision_truncates_long_reason():
+    """Pin: reason capped at 500 chars to bound audit ledger size."""
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1"))
+    huge = "x" * 1000
+    q.record_decision("r1", InlineApprovalChoice.REJECT, reason=huge)
+    dec = q.get_decision("r1")
+    assert dec is not None
+    assert len(dec.reason) == 500
+
+
+def test_next_pending_skips_decided():
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1"))
+    q.enqueue(_make_request(request_id="r2"))
+    q.record_decision("r1", InlineApprovalChoice.APPROVE)
+    nxt = q.next_pending(now_unix=999_990.0)
+    assert nxt is not None
+    assert nxt.request_id == "r2"
+
+
+def test_next_pending_skips_past_deadline():
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1", deadline_unix=100.0))
+    q.enqueue(_make_request(
+        request_id="r2", deadline_unix=999_999_999.0,
+    ))
+    nxt = q.next_pending(now_unix=500.0)
+    assert nxt is not None
+    assert nxt.request_id == "r2"
+
+
+def test_next_pending_returns_none_when_empty():
+    q = InlineApprovalQueue()
+    assert q.next_pending() is None
+
+
+def test_mark_timeout_records_timeout_deferred():
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1"))
+    assert q.mark_timeout("r1", now_unix=500.0) is True
+    dec = q.get_decision("r1")
+    assert dec is not None
+    assert dec.choice is InlineApprovalChoice.TIMEOUT_DEFERRED
+    assert dec.operator == "system"
+
+
+def test_forget_drops_entry():
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1"))
+    assert q.forget("r1") is True
+    assert q.next_pending() is None
+    assert len(q) == 0
+
+
+def test_forget_unknown_returns_false():
+    q = InlineApprovalQueue()
+    assert q.forget("missing") is False
+
+
+def test_snapshot_returns_only_undecided_in_order():
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1"))
+    q.enqueue(_make_request(request_id="r2"))
+    q.enqueue(_make_request(request_id="r3"))
+    q.record_decision("r2", InlineApprovalChoice.APPROVE)
+    snap = q.snapshot()
+    ids = [r.request_id for r in snap]
+    assert ids == ["r1", "r3"]
+
+
+def test_len_reflects_total_entries():
+    """__len__ counts all entries (decided + pending) — primary use is
+    cap-check + quick observability."""
+    q = InlineApprovalQueue()
+    q.enqueue(_make_request(request_id="r1"))
+    q.enqueue(_make_request(request_id="r2"))
+    assert len(q) == 2
+    q.record_decision("r1", InlineApprovalChoice.APPROVE)
+    assert len(q) == 2  # decided still present until forget()
+
+
+# ===========================================================================
+# F — Default-singleton accessor
+# ===========================================================================
+
+
+def test_get_default_queue_lazy_constructs():
+    a = get_default_queue()
+    assert isinstance(a, InlineApprovalQueue)
+
+
+def test_get_default_queue_returns_same_instance():
+    a = get_default_queue()
+    b = get_default_queue()
+    assert a is b
+
+
+def test_reset_default_queue_clears_singleton():
+    a = get_default_queue()
+    reset_default_queue()
+    b = get_default_queue()
+    assert a is not b
+
+
+# ===========================================================================
+# G — Authority invariants (no banned imports + no I/O)
+# ===========================================================================
+
+
+_BANNED = [
+    "from backend.core.ouroboros.governance.orchestrator",
+    "from backend.core.ouroboros.governance.policy",
+    "from backend.core.ouroboros.governance.iron_gate",
+    "from backend.core.ouroboros.governance.risk_tier",
+    "from backend.core.ouroboros.governance.change_engine",
+    "from backend.core.ouroboros.governance.candidate_generator",
+    "from backend.core.ouroboros.governance.gate",
+    "from backend.core.ouroboros.governance.semantic_guardian",
+]
+
+
+def test_inline_approval_no_authority_imports():
+    src = _read("backend/core/ouroboros/governance/inline_approval.py")
+    for imp in _BANNED:
+        assert imp not in src, f"banned import: {imp}"
+
+
+def test_inline_approval_no_io_or_subprocess():
+    """Pin: primitive is pure data — no file I/O, no subprocess, no
+    env mutation. Slice 3 owns the I/O surface (SerpentFlow + $EDITOR)."""
+    src = _read("backend/core/ouroboros/governance/inline_approval.py")
+    forbidden = [
+        "subprocess.",
+        "open(",
+        ".write(",
+        ".write_text(",
+        "os.environ[",
+        "os." + "system(",  # split to dodge pre-commit hook
+    ]
+    for c in forbidden:
+        assert c not in src, f"unexpected coupling: {c}"


### PR DESCRIPTION
## Summary

P3 Slice 1 of 4 (PRD §9 Phase 3 P3 — lightweight approval UX for fast iterations).

- **`inline_approval.py`** (~280 LOC): pure-data primitive
  - `InlineApprovalChoice` enum: APPROVE / REJECT / SHOW_STACK / EDIT / WAIT / TIMEOUT_DEFERRED
  - `parse_decision_input` — single-char + verbose synonyms, case-insensitive, **safety-first WAIT default** on empty / ambiguous / garbage (never auto-approves a bad parse)
  - `InlineApprovalRequest` / `InlineApprovalDecision` (frozen dataclasses) with `is_immediate_priority` + `seconds_remaining` helpers
  - `InlineApprovalQueue` — thread-safe bounded FIFO (cap `MAX_QUEUED_REQUESTS=16`) with **IMMEDIATE/BLOCKED priority promotion**, idempotent `record_decision`, `mark_timeout`, `next_pending`, `forget`, `snapshot`, `__len__`
  - Default-singleton `get_default_queue` / `reset_default_queue` (mirrors P3.5 pattern; accessor stays alive even when master flag flips off, so prior decisions remain inspectable)
  - Env knobs: `JARVIS_APPROVAL_UX_INLINE_ENABLED` (default **false**, Slice 4 will graduate) + `JARVIS_APPROVAL_UX_INLINE_TIMEOUT_S` (default 30s, clamps negative→1.0, falls back on invalid)
- Drops unused `field` import flagged by Pyright.

## Slice plan

| Slice | Scope | Status |
|---|---|---|
| **1 (this PR)** | Pure primitive + decision parser + bounded FIFO queue. Default-off. | ✅ this PR |
| 2 | `InlineApprovalProvider` conforming to existing `ApprovalProvider` Protocol; cancel-ledger audit hook. | next |
| 3 | SerpentFlow diff renderer + 30s prompt I/O + `\$EDITOR` shell-out. | queued |
| 4 | Graduation: pin suite + live-fire + flag flip + PRD §1 update. | queued |

## Tests

- **82 new tests** in `tests/governance/test_inline_approval_primitive.py`
  - Module-level constants pinned (`DEFAULT_DECISION_TIMEOUT_S=30.0`, `MAX_QUEUED_REQUESTS=16`)
  - Env-knob accessors (truthy/falsy variants, default-false-pre-graduation pin, timeout clamp + fallback)
  - parse_decision_input: single-char, verbose, case-insensitive, empty, garbage, whitespace strip, first-token-only
  - Frozen dataclasses + helpers
  - Queue: enqueue / blank-id reject / duplicate reject / cap-full reject / IMMEDIATE+BLOCKED front-promote / record_decision idempotency / 500-char reason truncation / next_pending skip-decided / skip-past-deadline / mark_timeout / forget / snapshot / __len__
  - Default-singleton lazy-construct + reset
  - Authority invariants — banned-import scan + I/O / subprocess / env-mutation surface pin
- **Adjacent regression**: 181/181 green (this slice + P3.5 + cognitive metrics + post-apply)

## Authority invariants

Pinned by AST-grep tests in this PR — `inline_approval.py` imports zero of: orchestrator / policy / iron_gate / risk_tier / change_engine / candidate_generator / gate / semantic_guardian. No subprocess, no `open(`, no `.write_text(`, no `os.environ[` mutation. Slice 3 owns the I/O surface (SerpentFlow + `\$EDITOR`); this slice is pure data.

## Hot revert

Single env knob: `JARVIS_APPROVAL_UX_INLINE_ENABLED=false` (already the default). Until Slice 2 wires the provider, this knob is observation-only — even master-on, no inline-approval surface is exposed yet.

## Test plan

- [x] `pytest tests/governance/test_inline_approval_primitive.py` — 82 passed
- [x] Adjacent suites (P3.5 + cognitive metrics + post-apply) — 181/181 passed
- [x] Pre-commit integrity hook — green
- [ ] Slice 2 wires `ApprovalProvider` Protocol (next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Slice 1 of the inline approval primitive (decision parser, bounded queue, singleton) to enable a lightweight and safe approval path for fast iterations. Default-off; no behavior change to existing approval flows.

- **New Features**
  - Decision parser: `y/n/s/e/w` and synonyms, case-insensitive, first-token only, safety-first `WAIT` default.
  - Frozen models: `InlineApprovalRequest` and `InlineApprovalDecision` with `is_immediate_priority()` and `seconds_remaining()`.
  - Thread-safe FIFO queue (cap 16) with IMMEDIATE/BLOCKED front-promotion; idempotent `record_decision`; `mark_timeout`, `next_pending`, `forget`, `snapshot`.
  - Env knobs: `JARVIS_APPROVAL_UX_INLINE_ENABLED` (off by default) and `JARVIS_APPROVAL_UX_INLINE_TIMEOUT_S` (30s default, min 1s).
  - Default singleton: `get_default_queue()` and `reset_default_queue()`.

<sup>Written for commit a1a66ad7fa62b31c8ee6fb908188309f17c81bda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

