### PR TITLE
feat(p5): Slice 1 — AdversarialReviewer primitive (findings + prompt + parser + filter)

### DIFF
--- a/backend/core/ouroboros/governance/adversarial_reviewer.py
+++ b/backend/core/ouroboros/governance/adversarial_reviewer.py
@@ -1,0 +1,504 @@
+"""P5 Slice 1 — AdversarialReviewer primitive.
+
+Per OUROBOROS_VENOM_PRD.md §9 Phase 5 P5 ("Adversarial reviewer
+subagent"):
+
+  > Iron Gate enforces hygiene rules. SemanticGuardian matches
+  > patterns. Neither *thinks adversarially* about whether a plan is
+  > correct.
+  >
+  > Solution: new subagent role — AdversarialReviewer. Activates
+  > post-PLAN, pre-GENERATE. Given the plan, the model is prompted
+  > as: "You are a senior engineer reviewing this plan for the most
+  > likely way it will fail. Find at least 3 failure modes." Output
+  > is structured findings injected into GENERATE prompt as
+  > "Reviewer raised:" section.
+
+This module is the **pure-data layer** for the reviewer. It ships:
+
+  1. ``AdversarialFinding`` — frozen dataclass for one finding
+     (severity / category / description / mitigation_hint /
+     file_reference for grounding).
+  2. ``AdversarialReview`` — frozen aggregate of findings + cost +
+     model used + skip_reason (when the reviewer was bypassed).
+  3. ``build_review_prompt(plan, target_files)`` — renders the
+     "find at least 3 failure modes" prompt the LLM will see
+     (Slice 2 wires the LLM call).
+  4. ``parse_review_response(raw, target_files)`` — defensive JSON
+     parser; tolerates prose-prefix / fenced blocks / partial
+     responses; never raises.
+  5. ``filter_findings(findings, target_files)`` — hallucination
+     filter: drops findings whose ``file_reference`` is empty or
+     points outside the plan's ``target_files`` set.
+  6. ``format_findings_for_generate_prompt(findings)`` — converts a
+     filtered finding list into the ASCII "Reviewer raised:" section
+     Slice 3 will inject into GENERATE.
+
+Slice 1 ships ZERO LLM calls. Slice 2 wraps everything in the
+``AdversarialReviewerService`` that calls Claude side-stream + cost
+budget enforcement + JSONL ledger. Slice 3 wires GENERATE injection.
+Slice 4 adds REPL + IDE surfaces. Slice 5 graduates the master flag.
+
+Authority invariants (PRD §12.2):
+  * Pure data — no I/O, no subprocess, no env mutation.
+  * No imports of orchestrator / policy / iron_gate / risk_tier /
+    change_engine / candidate_generator / gate / semantic_guardian.
+  * Best-effort — every parser / filter operation is wrapped in
+    ``try / except`` with structured fallback; never raises.
+  * Bounded — prompt body capped at MAX_PLAN_PROMPT_CHARS; response
+    parser caps the finding count at MAX_FINDINGS_PER_REVIEW so a
+    runaway model can't pin downstream consumers.
+  * Reviewer is **advisory only** — findings inform GENERATE but
+    NEVER gate. Per PRD edge case: "Reviewer disagreement with PLAN
+    — use as warning, not gate (PLAN still authoritative)." This is
+    a structural property of this module: it produces text, never
+    a decision.
+
+Default-off behind ``JARVIS_ADVERSARIAL_REVIEWER_ENABLED`` until
+Slice 5 graduation. Module is importable + callable; gating happens
+at the Slice 2 service caller.
+"""
+from __future__ import annotations
+
+import enum
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+# Per-prompt cap on the rendered plan body. Defends against feeding a
+# 1 MB plan into the model side-stream (cost + latency).
+MAX_PLAN_PROMPT_CHARS: int = 8 * 1024  # 8 KiB
+
+# Per-review cap on parsed findings. PRD spec asks for ≥ 3 findings;
+# 50 is a soft ceiling that bounds GENERATE-prompt injection size
+# without filtering legitimate adversarial reviews.
+MAX_FINDINGS_PER_REVIEW: int = 50
+
+# Per-finding text caps — keep individual findings readable + prevent
+# a model from emitting one giant blob that defeats the cap above.
+MAX_DESCRIPTION_CHARS: int = 480
+MAX_MITIGATION_CHARS: int = 240
+MAX_CATEGORY_CHARS: int = 64
+MAX_FILE_REFERENCE_CHARS: int = 256
+
+
+def is_enabled() -> bool:
+    """Master flag — ``JARVIS_ADVERSARIAL_REVIEWER_ENABLED`` (default
+    false until Slice 5 graduation).
+
+    Slice 2's ``AdversarialReviewerService`` consults this; when off,
+    the service short-circuits and returns an :class:`AdversarialReview`
+    with ``skip_reason="master_off"``."""
+    return os.environ.get(
+        "JARVIS_ADVERSARIAL_REVIEWER_ENABLED", "",
+    ).strip().lower() in _TRUTHY
+
+
+# ---------------------------------------------------------------------------
+# Severity + category enums
+# ---------------------------------------------------------------------------
+
+
+class FindingSeverity(str, enum.Enum):
+    """Per PRD spec — three buckets the model emits + we display."""
+
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+    LOW = "LOW"
+
+
+# Suggested categories the prompt asks the model to use. Not enforced
+# at parse time (model may emit anything); displayed verbatim.
+SUGGESTED_CATEGORIES: Tuple[str, ...] = (
+    "correctness",
+    "edge_case",
+    "race_condition",
+    "performance",
+    "security",
+    "maintainability",
+    "test_coverage",
+    "rollback_safety",
+)
+
+
+# ---------------------------------------------------------------------------
+# Frozen dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AdversarialFinding:
+    """One finding the reviewer raised against the plan.
+
+    ``file_reference`` is the **grounding anchor** — the hallucination
+    filter (``filter_findings``) drops findings whose reference is
+    empty or points outside the plan's target_files set. Per PRD edge
+    case: "findings must reference specific files / patterns;
+    ungrounded findings filtered."
+    """
+
+    severity: FindingSeverity
+    category: str
+    description: str
+    mitigation_hint: str
+    file_reference: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "severity": self.severity.value,
+            "category": self.category,
+            "description": self.description,
+            "mitigation_hint": self.mitigation_hint,
+            "file_reference": self.file_reference,
+        }
+
+
+@dataclass(frozen=True)
+class AdversarialReview:
+    """Aggregate of one reviewer pass over a plan.
+
+    ``skip_reason`` is non-empty when the reviewer was bypassed
+    (master_off, safe_auto, budget_exhausted, etc.) — in that case
+    ``findings`` is empty by construction. Slice 2's service produces
+    these; Slice 1 ships the shape.
+    """
+
+    op_id: str
+    findings: Tuple[AdversarialFinding, ...] = field(default_factory=tuple)
+    raw_findings_count: int = 0    # before filter
+    filtered_findings_count: int = 0  # after filter (== len(findings))
+    cost_usd: float = 0.0
+    model_used: str = ""
+    skip_reason: str = ""
+    notes: Tuple[str, ...] = field(default_factory=tuple)
+
+    def severity_histogram(self) -> Dict[str, int]:
+        """Count findings by severity. Used by the §8 telemetry line
+        (``[AdversarialReviewer] op=X raised N findings (severity
+        high=A, med=B, low=C)``)."""
+        out = {"HIGH": 0, "MEDIUM": 0, "LOW": 0}
+        for f in self.findings:
+            out[f.severity.value] = out.get(f.severity.value, 0) + 1
+        return out
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "op_id": self.op_id,
+            "findings": [f.to_dict() for f in self.findings],
+            "raw_findings_count": self.raw_findings_count,
+            "filtered_findings_count": self.filtered_findings_count,
+            "cost_usd": self.cost_usd,
+            "model_used": self.model_used,
+            "skip_reason": self.skip_reason,
+            "notes": list(self.notes),
+            "severity_histogram": self.severity_histogram(),
+        }
+
+    @property
+    def was_skipped(self) -> bool:
+        return bool(self.skip_reason)
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder
+# ---------------------------------------------------------------------------
+
+
+_PROMPT_HEADER = (
+    "You are a senior engineer reviewing the following plan for the "
+    "most likely way it will fail. Find at least 3 failure modes."
+)
+
+_PROMPT_FORMAT_HEADER = (
+    "Respond ONLY with a JSON object of this exact shape:\n"
+    "  {\n"
+    "    \"findings\": [\n"
+    "      {\n"
+    "        \"severity\": \"HIGH\" | \"MEDIUM\" | \"LOW\",\n"
+    "        \"category\": \"correctness\" | \"edge_case\" | "
+    "\"race_condition\" | \"performance\" | \"security\" | "
+    "\"maintainability\" | \"test_coverage\" | \"rollback_safety\","
+    "\n"
+    "        \"description\": \"<= 480 chars; concrete failure mode\",\n"
+    "        \"mitigation_hint\": \"<= 240 chars; how to prevent it\",\n"
+    "        \"file_reference\": \"<one of the target files; required"
+    " for grounding>\"\n"
+    "      },\n"
+    "      ...\n"
+    "    ]\n"
+    "  }\n"
+    "Findings WITHOUT a file_reference matching one of the target "
+    "files will be dropped. No prose outside the JSON."
+)
+
+
+def build_review_prompt(
+    plan_text: str,
+    target_files: Sequence[str] = (),
+) -> str:
+    """Render the reviewer prompt.
+
+    The plan body is clipped at ``MAX_PLAN_PROMPT_CHARS`` so the
+    side-stream cost stays bounded. The target file list is rendered
+    explicitly so the model knows which references are valid (and so
+    the hallucination filter can compare verbatim against them)."""
+    safe_plan = (plan_text or "").strip()
+    if len(safe_plan) > MAX_PLAN_PROMPT_CHARS:
+        safe_plan = safe_plan[:MAX_PLAN_PROMPT_CHARS] + (
+            "\n... <plan truncated to MAX_PLAN_PROMPT_CHARS>"
+        )
+    file_list = "\n".join(f"  - {p}" for p in target_files) or "  (none)"
+    return "\n\n".join([
+        _PROMPT_HEADER,
+        f"Target files (the only valid file_reference values):\n{file_list}",
+        f"Plan:\n{safe_plan}",
+        _PROMPT_FORMAT_HEADER,
+    ])
+
+
+# ---------------------------------------------------------------------------
+# Response parser (defensive)
+# ---------------------------------------------------------------------------
+
+
+# Loose JSON-object recovery: matches the OUTERMOST brace block. Used
+# when the model wraps its JSON in fenced ```json ... ``` blocks or
+# leading prose.
+_JSON_BLOCK_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def parse_review_response(
+    raw: str,
+) -> Tuple[List[AdversarialFinding], List[str]]:
+    """Defensive JSON parse. Returns (findings, notes).
+
+    Tolerates:
+      * Fenced code block wrappers (```json ... ```).
+      * Leading / trailing prose around the JSON object.
+      * Findings missing optional fields (mitigation_hint defaults
+        to empty string).
+      * Severity strings in any case (``"high"`` → HIGH).
+      * The ``findings`` key being absent (returns empty list).
+
+    Drops:
+      * Severity values that don't match the enum (silently — note
+        appended).
+      * Findings with empty/missing required fields (description /
+        category).
+      * Per-finding cap at MAX_FINDINGS_PER_REVIEW so a runaway model
+        can't blow out downstream consumers.
+
+    NOTE: This parser does NOT do hallucination filtering. That's
+    :func:`filter_findings` (separate so each layer is independently
+    testable + bypassable in tests). Slice 2's service composes both."""
+    notes: List[str] = []
+    if not raw or not raw.strip():
+        notes.append("empty_response")
+        return [], notes
+
+    # Strip fenced code blocks first.
+    body = raw.strip()
+    if body.startswith("```"):
+        # Trim leading ```{lang}\n and trailing ```
+        body = re.sub(r"^```[a-zA-Z0-9_-]*\n?", "", body)
+        body = re.sub(r"\n?```$", "", body)
+
+    # Direct JSON parse first.
+    payload: Optional[Mapping[str, Any]] = None
+    try:
+        candidate = json.loads(body)
+        if isinstance(candidate, dict):
+            payload = candidate
+    except (json.JSONDecodeError, TypeError):
+        notes.append("direct_json_failed")
+
+    # Fall back to outermost-brace recovery.
+    if payload is None:
+        match = _JSON_BLOCK_RE.search(body)
+        if match:
+            try:
+                candidate = json.loads(match.group(0))
+                if isinstance(candidate, dict):
+                    payload = candidate
+                    notes.append("json_recovered_from_brace_block")
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+    if payload is None:
+        notes.append("unparseable")
+        return [], notes
+
+    raw_findings = payload.get("findings")
+    if not isinstance(raw_findings, list):
+        notes.append("findings_key_missing_or_not_list")
+        return [], notes
+
+    out: List[AdversarialFinding] = []
+    for i, raw_f in enumerate(raw_findings):
+        if i >= MAX_FINDINGS_PER_REVIEW:
+            notes.append(
+                f"findings_truncated_at_max_{MAX_FINDINGS_PER_REVIEW}",
+            )
+            break
+        if not isinstance(raw_f, Mapping):
+            notes.append(f"finding_{i}_not_object")
+            continue
+        finding = _coerce_finding(raw_f, notes, idx=i)
+        if finding is not None:
+            out.append(finding)
+    return out, notes
+
+
+def _coerce_finding(
+    raw: Mapping[str, Any],
+    notes: List[str],
+    idx: int,
+) -> Optional[AdversarialFinding]:
+    """Build one :class:`AdversarialFinding` from a raw dict. Returns
+    None when required fields are missing/blank."""
+    sev_raw = raw.get("severity")
+    try:
+        sev = FindingSeverity(str(sev_raw).strip().upper())
+    except (TypeError, ValueError):
+        notes.append(f"finding_{idx}_bad_severity")
+        return None
+
+    description = str(raw.get("description") or "").strip()
+    if not description:
+        notes.append(f"finding_{idx}_empty_description")
+        return None
+    description = description[:MAX_DESCRIPTION_CHARS]
+
+    category = str(raw.get("category") or "").strip()[:MAX_CATEGORY_CHARS]
+    if not category:
+        notes.append(f"finding_{idx}_empty_category")
+        return None
+
+    mitigation = str(raw.get("mitigation_hint") or "").strip()
+    mitigation = mitigation[:MAX_MITIGATION_CHARS]
+
+    file_reference = str(raw.get("file_reference") or "").strip()
+    file_reference = file_reference[:MAX_FILE_REFERENCE_CHARS]
+
+    return AdversarialFinding(
+        severity=sev,
+        category=category,
+        description=description,
+        mitigation_hint=mitigation,
+        file_reference=file_reference,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hallucination filter
+# ---------------------------------------------------------------------------
+
+
+def filter_findings(
+    findings: Iterable[AdversarialFinding],
+    target_files: Sequence[str] = (),
+) -> Tuple[List[AdversarialFinding], List[str]]:
+    """Drop findings whose ``file_reference`` is empty or points
+    outside the plan's ``target_files`` set.
+
+    When ``target_files`` is empty (e.g., a meta-plan with no
+    file targets), the filter only drops findings with empty
+    ``file_reference``.
+
+    Returns (kept, drop_notes). ``drop_notes`` is a list of strings
+    describing each dropped finding so Slice 4 can surface them via
+    ``/adversarial why <op-id>``.
+    """
+    target_set = {p for p in target_files if p}
+    kept: List[AdversarialFinding] = []
+    drops: List[str] = []
+    for f in findings:
+        if not f.file_reference:
+            drops.append(
+                f"dropped:no_file_reference:{f.category}:{f.severity.value}",
+            )
+            continue
+        if target_set and not _matches_target(f.file_reference, target_set):
+            drops.append(
+                f"dropped:ungrounded_reference:{f.file_reference}",
+            )
+            continue
+        kept.append(f)
+    return kept, drops
+
+
+def _matches_target(reference: str, target_set: set) -> bool:
+    """A finding's file_reference matches the target set if it equals
+    one of the targets OR is a substring (operator may have specified
+    ``"foo.py"`` while target is ``"backend/foo.py"`` — accept).
+
+    NEVER accepts traversal references (``..`` segments) — those are
+    a hallucination in any plan that didn't explicitly include them."""
+    if ".." in reference:
+        return False
+    if reference in target_set:
+        return True
+    for t in target_set:
+        if t.endswith(reference) or reference.endswith(t):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# GENERATE-prompt formatter
+# ---------------------------------------------------------------------------
+
+
+def format_findings_for_generate_prompt(
+    findings: Sequence[AdversarialFinding],
+    *,
+    indent: str = "  ",
+) -> str:
+    """Render the "Reviewer raised:" section that Slice 3 will inject
+    into the GENERATE prompt.
+
+    Returns ``""`` when ``findings`` is empty so the caller can
+    cleanly skip injection. ASCII-strict: passes through
+    ``encode("ascii", errors="replace")`` round-trip."""
+    if not findings:
+        return ""
+    lines = ["Reviewer raised:"]
+    for i, f in enumerate(findings, 1):
+        lines.append(
+            f"{indent}{i}. [{f.severity.value}] [{f.category}] "
+            f"{f.description}"
+        )
+        if f.file_reference:
+            lines.append(f"{indent}{indent}file: {f.file_reference}")
+        if f.mitigation_hint:
+            lines.append(f"{indent}{indent}mitigation: {f.mitigation_hint}")
+    text = "\n".join(lines)
+    return text.encode("ascii", errors="replace").decode("ascii")
+
+
+__all__ = [
+    "AdversarialFinding",
+    "AdversarialReview",
+    "FindingSeverity",
+    "MAX_CATEGORY_CHARS",
+    "MAX_DESCRIPTION_CHARS",
+    "MAX_FILE_REFERENCE_CHARS",
+    "MAX_FINDINGS_PER_REVIEW",
+    "MAX_MITIGATION_CHARS",
+    "MAX_PLAN_PROMPT_CHARS",
+    "SUGGESTED_CATEGORIES",
+    "build_review_prompt",
+    "filter_findings",
+    "format_findings_for_generate_prompt",
+    "is_enabled",
+    "parse_review_response",
+]

--- a/tests/governance/test_adversarial_reviewer.py
+++ b/tests/governance/test_adversarial_reviewer.py
@@ -1,0 +1,602 @@
+"""P5 Slice 1 — AdversarialReviewer primitive regression suite.
+
+Pins:
+  * Module constants + 3-value FindingSeverity enum + suggested
+    categories tuple + frozen dataclass shapes + .to_dict.
+  * Env knob default-false-pre-graduation.
+  * build_review_prompt: all expected sections present; plan body
+    truncated at MAX_PLAN_PROMPT_CHARS; target file list rendered.
+  * parse_review_response: happy path; fenced ```json wrapper;
+    leading/trailing prose; missing optional fields; case-insensitive
+    severity; bad severity dropped; empty description dropped; empty
+    category dropped; missing findings key; non-list findings;
+    cap at MAX_FINDINGS_PER_REVIEW; empty input; unparseable input.
+  * Per-finding text caps: description / mitigation / category /
+    file_reference all truncated.
+  * filter_findings: empty file_reference dropped; ungrounded
+    reference dropped; traversal reference dropped; substring match
+    accepted (operator partial path); empty target_files only drops
+    empty references; drop_notes structure.
+  * format_findings_for_generate_prompt: empty input → "";
+    happy multi-finding render; ASCII-strict round-trip.
+  * AdversarialReview.severity_histogram + was_skipped helpers.
+  * Authority invariants: no banned imports + no I/O / subprocess.
+"""
+from __future__ import annotations
+
+import dataclasses
+import io
+import tokenize
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.adversarial_reviewer import (
+    MAX_CATEGORY_CHARS,
+    MAX_DESCRIPTION_CHARS,
+    MAX_FILE_REFERENCE_CHARS,
+    MAX_FINDINGS_PER_REVIEW,
+    MAX_MITIGATION_CHARS,
+    MAX_PLAN_PROMPT_CHARS,
+    SUGGESTED_CATEGORIES,
+    AdversarialFinding,
+    AdversarialReview,
+    FindingSeverity,
+    build_review_prompt,
+    filter_findings,
+    format_findings_for_generate_prompt,
+    is_enabled,
+    parse_review_response,
+)
+
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+
+
+def _read(rel: str) -> str:
+    return (_REPO / rel).read_text(encoding="utf-8")
+
+
+def _strip_docstrings_and_comments(src: str) -> str:
+    out = []
+    try:
+        toks = list(tokenize.generate_tokens(io.StringIO(src).readline))
+    except (tokenize.TokenizeError, IndentationError):
+        return src
+    for tok in toks:
+        if tok.type == tokenize.STRING:
+            out.append('""')
+        elif tok.type == tokenize.COMMENT:
+            continue
+        else:
+            out.append(tok.string)
+    return " ".join(out)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("JARVIS_ADVERSARIAL_REVIEWER_ENABLED", raising=False)
+    yield
+
+
+def _F(severity="HIGH", category="correctness", description="bug",
+       mitigation_hint="fix it", file_reference="backend/x.py"):
+    return AdversarialFinding(
+        severity=FindingSeverity(severity),
+        category=category, description=description,
+        mitigation_hint=mitigation_hint,
+        file_reference=file_reference,
+    )
+
+
+# ===========================================================================
+# A — Module constants + enum + dataclass shapes
+# ===========================================================================
+
+
+def test_max_plan_prompt_chars_pinned():
+    assert MAX_PLAN_PROMPT_CHARS == 8 * 1024
+
+
+def test_max_findings_per_review_pinned():
+    assert MAX_FINDINGS_PER_REVIEW == 50
+
+
+def test_per_finding_caps_pinned():
+    assert MAX_DESCRIPTION_CHARS == 480
+    assert MAX_MITIGATION_CHARS == 240
+    assert MAX_CATEGORY_CHARS == 64
+    assert MAX_FILE_REFERENCE_CHARS == 256
+
+
+def test_finding_severity_three_values():
+    """Pin: PRD spec says three buckets (HIGH / MED / LOW). Adding a
+    fourth requires a new slice + design doc."""
+    assert {s.name for s in FindingSeverity} == {"HIGH", "MEDIUM", "LOW"}
+
+
+def test_suggested_categories_pinned():
+    """Pin: the 8 suggested categories the prompt asks the model to
+    use. Operators can rely on these for filtering / dashboards."""
+    expected = (
+        "correctness", "edge_case", "race_condition", "performance",
+        "security", "maintainability", "test_coverage", "rollback_safety",
+    )
+    assert SUGGESTED_CATEGORIES == expected
+
+
+def test_finding_is_frozen():
+    f = _F()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        f.description = "x"  # type: ignore[misc]
+
+
+def test_review_is_frozen():
+    r = AdversarialReview(op_id="op")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        r.op_id = "x"  # type: ignore[misc]
+
+
+def test_finding_to_dict_stable_shape():
+    d = _F().to_dict()
+    for k in ("severity", "category", "description",
+              "mitigation_hint", "file_reference"):
+        assert k in d
+    assert d["severity"] == "HIGH"
+
+
+def test_review_to_dict_stable_shape():
+    r = AdversarialReview(
+        op_id="op", findings=(_F(), _F(severity="LOW")),
+        raw_findings_count=3, filtered_findings_count=2,
+        cost_usd=0.012, model_used="claude",
+        skip_reason="", notes=("note-1",),
+    )
+    d = r.to_dict()
+    for k in ("op_id", "findings", "raw_findings_count",
+              "filtered_findings_count", "cost_usd", "model_used",
+              "skip_reason", "notes", "severity_histogram"):
+        assert k in d
+    assert len(d["findings"]) == 2
+    assert d["severity_histogram"] == {"HIGH": 1, "MEDIUM": 0, "LOW": 1}
+    assert d["notes"] == ["note-1"]
+
+
+def test_review_severity_histogram():
+    r = AdversarialReview(
+        op_id="op",
+        findings=(_F("HIGH"), _F("HIGH"), _F("MEDIUM"), _F("LOW")),
+    )
+    assert r.severity_histogram() == {"HIGH": 2, "MEDIUM": 1, "LOW": 1}
+
+
+def test_review_was_skipped_helper():
+    assert AdversarialReview(op_id="op").was_skipped is False
+    assert AdversarialReview(op_id="op", skip_reason="master_off").was_skipped is True
+
+
+# ===========================================================================
+# B — Env knob (default false pre-graduation)
+# ===========================================================================
+
+
+def test_is_enabled_default_false_pre_graduation():
+    """Slice 1 ships default-OFF. Renamed at Slice 5 graduation."""
+    assert is_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_is_enabled_truthy_variants(monkeypatch, val):
+    monkeypatch.setenv("JARVIS_ADVERSARIAL_REVIEWER_ENABLED", val)
+    assert is_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage", ""])
+def test_is_enabled_falsy_variants(monkeypatch, val):
+    monkeypatch.setenv("JARVIS_ADVERSARIAL_REVIEWER_ENABLED", val)
+    assert is_enabled() is False
+
+
+# ===========================================================================
+# C — build_review_prompt
+# ===========================================================================
+
+
+def test_prompt_includes_role_and_failure_modes_directive():
+    out = build_review_prompt("plan", ("a.py",))
+    assert "senior engineer" in out
+    assert "find at least 3 failure modes" in out.lower()
+
+
+def test_prompt_includes_target_file_list():
+    out = build_review_prompt("plan", ("backend/foo.py", "backend/bar.py"))
+    assert "  - backend/foo.py" in out
+    assert "  - backend/bar.py" in out
+
+
+def test_prompt_handles_no_target_files():
+    out = build_review_prompt("plan", ())
+    assert "(none)" in out
+
+
+def test_prompt_includes_strict_json_format():
+    out = build_review_prompt("plan", ("a.py",))
+    assert "\"findings\":" in out
+    assert "HIGH" in out
+    assert "file_reference" in out
+
+
+def test_prompt_truncates_long_plan():
+    huge = "x" * (MAX_PLAN_PROMPT_CHARS * 2)
+    out = build_review_prompt(huge, ("a.py",))
+    assert "<plan truncated to MAX_PLAN_PROMPT_CHARS>" in out
+    # Total render shouldn't include the full huge body.
+    assert len(out) < len(huge) + 4096
+
+
+def test_prompt_handles_none_plan_text():
+    """Defensive: None plan_text should not crash."""
+    out = build_review_prompt(None, ("a.py",))  # type: ignore[arg-type]
+    assert "Plan:" in out
+
+
+# ===========================================================================
+# D — parse_review_response — happy paths
+# ===========================================================================
+
+
+def _resp(findings_json: str) -> str:
+    return '{"findings": ' + findings_json + '}'
+
+
+def test_parse_happy_path():
+    resp = _resp(
+        '[{"severity": "HIGH", "category": "race_condition", '
+        '"description": "lock contention", "mitigation_hint": "use RWLock", '
+        '"file_reference": "x.py"}]'
+    )
+    findings, notes = parse_review_response(resp)
+    assert len(findings) == 1
+    assert findings[0].severity is FindingSeverity.HIGH
+    assert findings[0].category == "race_condition"
+    assert findings[0].file_reference == "x.py"
+
+
+def test_parse_handles_fenced_code_block():
+    resp = '```json\n' + _resp(
+        '[{"severity": "MEDIUM", "category": "perf", '
+        '"description": "O(n^2)", "mitigation_hint": "use set", '
+        '"file_reference": "x.py"}]'
+    ) + '\n```'
+    findings, _ = parse_review_response(resp)
+    assert len(findings) == 1
+    assert findings[0].severity is FindingSeverity.MEDIUM
+
+
+def test_parse_handles_leading_prose():
+    resp = "Sure, here is the review:\n" + _resp(
+        '[{"severity": "LOW", "category": "x", '
+        '"description": "y", "mitigation_hint": "z", '
+        '"file_reference": "x.py"}]'
+    )
+    findings, notes = parse_review_response(resp)
+    assert len(findings) == 1
+    assert "json_recovered_from_brace_block" in notes
+
+
+def test_parse_severity_case_insensitive():
+    for sv in ("high", "High", "HIGH", "hIgH"):
+        resp = _resp(
+            f'[{{"severity": "{sv}", "category": "x", '
+            f'"description": "y", "mitigation_hint": "z", '
+            f'"file_reference": "x.py"}}]'
+        )
+        findings, _ = parse_review_response(resp)
+        assert len(findings) == 1
+        assert findings[0].severity is FindingSeverity.HIGH
+
+
+def test_parse_optional_mitigation_defaults_to_empty():
+    resp = _resp(
+        '[{"severity": "HIGH", "category": "x", '
+        '"description": "y", "file_reference": "x.py"}]'
+    )
+    findings, _ = parse_review_response(resp)
+    assert findings[0].mitigation_hint == ""
+
+
+def test_parse_optional_file_reference_defaults_to_empty():
+    """file_reference can be missing at parse time — filter_findings
+    is what enforces grounding."""
+    resp = _resp(
+        '[{"severity": "HIGH", "category": "x", '
+        '"description": "y", "mitigation_hint": "z"}]'
+    )
+    findings, _ = parse_review_response(resp)
+    assert findings[0].file_reference == ""
+
+
+# ===========================================================================
+# E — parse_review_response — drop / failure paths
+# ===========================================================================
+
+
+def test_parse_bad_severity_dropped():
+    resp = _resp(
+        '[{"severity": "CRITICAL", "category": "x", '
+        '"description": "y", "mitigation_hint": "z", '
+        '"file_reference": "x.py"}]'
+    )
+    findings, notes = parse_review_response(resp)
+    assert findings == []
+    assert any("bad_severity" in n for n in notes)
+
+
+def test_parse_empty_description_dropped():
+    resp = _resp(
+        '[{"severity": "HIGH", "category": "x", '
+        '"description": "", "mitigation_hint": "z", '
+        '"file_reference": "x.py"}]'
+    )
+    findings, notes = parse_review_response(resp)
+    assert findings == []
+    assert any("empty_description" in n for n in notes)
+
+
+def test_parse_empty_category_dropped():
+    resp = _resp(
+        '[{"severity": "HIGH", "category": "", '
+        '"description": "y", "mitigation_hint": "z", '
+        '"file_reference": "x.py"}]'
+    )
+    findings, notes = parse_review_response(resp)
+    assert findings == []
+    assert any("empty_category" in n for n in notes)
+
+
+def test_parse_missing_findings_key():
+    findings, notes = parse_review_response('{"other": []}')
+    assert findings == []
+    assert "findings_key_missing_or_not_list" in notes
+
+
+def test_parse_findings_not_list():
+    findings, notes = parse_review_response('{"findings": "not-a-list"}')
+    assert findings == []
+    assert "findings_key_missing_or_not_list" in notes
+
+
+def test_parse_caps_at_max_findings():
+    """Pin: more than MAX_FINDINGS_PER_REVIEW raw findings → truncated."""
+    raw_finds = ",".join(
+        '{"severity": "HIGH", "category": "x", '
+        '"description": "y", "mitigation_hint": "z", '
+        '"file_reference": "a.py"}'
+        for _ in range(MAX_FINDINGS_PER_REVIEW + 5)
+    )
+    resp = _resp("[" + raw_finds + "]")
+    findings, notes = parse_review_response(resp)
+    assert len(findings) == MAX_FINDINGS_PER_REVIEW
+    assert any("findings_truncated_at_max" in n for n in notes)
+
+
+def test_parse_empty_input():
+    findings, notes = parse_review_response("")
+    assert findings == []
+    assert "empty_response" in notes
+
+
+def test_parse_unparseable_input():
+    findings, notes = parse_review_response("not even close to json")
+    assert findings == []
+    assert "unparseable" in notes
+
+
+def test_parse_non_dict_finding_skipped():
+    resp = _resp(
+        '["not-a-dict", {"severity": "HIGH", "category": "x", '
+        '"description": "y", "mitigation_hint": "z", '
+        '"file_reference": "a.py"}]'
+    )
+    findings, notes = parse_review_response(resp)
+    assert len(findings) == 1
+    assert any("not_object" in n for n in notes)
+
+
+# ===========================================================================
+# F — Per-finding text caps
+# ===========================================================================
+
+
+def test_parse_truncates_oversize_description():
+    big = "x" * (MAX_DESCRIPTION_CHARS + 100)
+    resp = _resp(
+        f'[{{"severity": "HIGH", "category": "x", '
+        f'"description": "{big}", "mitigation_hint": "z", '
+        f'"file_reference": "x.py"}}]'
+    )
+    findings, _ = parse_review_response(resp)
+    assert len(findings[0].description) == MAX_DESCRIPTION_CHARS
+
+
+def test_parse_truncates_oversize_mitigation():
+    big = "x" * (MAX_MITIGATION_CHARS + 100)
+    resp = _resp(
+        f'[{{"severity": "HIGH", "category": "x", '
+        f'"description": "y", "mitigation_hint": "{big}", '
+        f'"file_reference": "x.py"}}]'
+    )
+    findings, _ = parse_review_response(resp)
+    assert len(findings[0].mitigation_hint) == MAX_MITIGATION_CHARS
+
+
+def test_parse_truncates_oversize_category():
+    big = "x" * (MAX_CATEGORY_CHARS + 50)
+    resp = _resp(
+        f'[{{"severity": "HIGH", "category": "{big}", '
+        f'"description": "y", "mitigation_hint": "z", '
+        f'"file_reference": "x.py"}}]'
+    )
+    findings, _ = parse_review_response(resp)
+    assert len(findings[0].category) == MAX_CATEGORY_CHARS
+
+
+def test_parse_truncates_oversize_file_reference():
+    big = "x" * (MAX_FILE_REFERENCE_CHARS + 50)
+    resp = _resp(
+        f'[{{"severity": "HIGH", "category": "x", '
+        f'"description": "y", "mitigation_hint": "z", '
+        f'"file_reference": "{big}"}}]'
+    )
+    findings, _ = parse_review_response(resp)
+    assert len(findings[0].file_reference) == MAX_FILE_REFERENCE_CHARS
+
+
+# ===========================================================================
+# G — filter_findings (hallucination filter)
+# ===========================================================================
+
+
+def test_filter_drops_empty_file_reference():
+    findings = [_F(file_reference=""), _F(file_reference="backend/x.py")]
+    kept, drops = filter_findings(findings, ("backend/x.py",))
+    assert len(kept) == 1
+    assert kept[0].file_reference == "backend/x.py"
+    assert any("no_file_reference" in d for d in drops)
+
+
+def test_filter_drops_ungrounded_reference():
+    findings = [_F(file_reference="random/elsewhere.py")]
+    kept, drops = filter_findings(findings, ("backend/x.py",))
+    assert kept == []
+    assert any("ungrounded_reference" in d for d in drops)
+
+
+def test_filter_drops_traversal_reference():
+    """Pin: even when the reference 'matches' a target via substring,
+    .. segments are blocked unconditionally — those are always a
+    hallucination."""
+    findings = [_F(file_reference="../../etc/passwd")]
+    kept, drops = filter_findings(findings, ("etc/passwd",))
+    assert kept == []
+    assert any("ungrounded_reference" in d for d in drops)
+
+
+def test_filter_accepts_substring_match():
+    """Operator-supplied partial path should match the longer canonical
+    target — ``foo.py`` matches ``backend/x/foo.py``."""
+    findings = [_F(file_reference="foo.py")]
+    kept, _ = filter_findings(findings, ("backend/x/foo.py",))
+    assert len(kept) == 1
+
+
+def test_filter_with_empty_target_files_only_drops_empty_refs():
+    """When target_files is empty, ungrounded findings (with any
+    non-empty file_reference) are accepted — only empty references
+    are dropped."""
+    findings = [
+        _F(file_reference=""),
+        _F(file_reference="anything.py"),
+    ]
+    kept, drops = filter_findings(findings, ())
+    assert len(kept) == 1
+    assert kept[0].file_reference == "anything.py"
+
+
+def test_filter_drop_notes_structure():
+    findings = [_F(file_reference="")]
+    _, drops = filter_findings(findings, ("x.py",))
+    assert len(drops) == 1
+    parts = drops[0].split(":")
+    # dropped:no_file_reference:<category>:<severity>
+    assert parts[0] == "dropped"
+    assert parts[1] == "no_file_reference"
+
+
+# ===========================================================================
+# H — format_findings_for_generate_prompt
+# ===========================================================================
+
+
+def test_format_empty_returns_empty():
+    assert format_findings_for_generate_prompt([]) == ""
+
+
+def test_format_single_finding_complete():
+    out = format_findings_for_generate_prompt([_F()])
+    assert "Reviewer raised:" in out
+    assert "[HIGH]" in out
+    assert "[correctness]" in out
+    assert "file: backend/x.py" in out
+    assert "mitigation: fix it" in out
+
+
+def test_format_multi_finding_numbered():
+    out = format_findings_for_generate_prompt([
+        _F(severity="HIGH"),
+        _F(severity="MEDIUM"),
+        _F(severity="LOW"),
+    ])
+    assert "1. [HIGH]" in out
+    assert "2. [MEDIUM]" in out
+    assert "3. [LOW]" in out
+
+
+def test_format_omits_empty_optional_fields():
+    """A finding without file_reference / mitigation should not render
+    those lines (avoids ``file: \n`` or ``mitigation: `` clutter)."""
+    f = _F(mitigation_hint="", file_reference="")
+    out = format_findings_for_generate_prompt([f])
+    assert "file:" not in out
+    assert "mitigation:" not in out
+
+
+def test_format_is_ascii_safe():
+    """Pin: ASCII-strict round-trip — no Unicode in the rendered
+    section."""
+    out = format_findings_for_generate_prompt([_F()])
+    out.encode("ascii")  # raises if non-ASCII slipped in
+
+
+# ===========================================================================
+# I — Authority invariants
+# ===========================================================================
+
+
+_BANNED = [
+    "from backend.core.ouroboros.governance.orchestrator",
+    "from backend.core.ouroboros.governance.policy",
+    "from backend.core.ouroboros.governance.iron_gate",
+    "from backend.core.ouroboros.governance.risk_tier",
+    "from backend.core.ouroboros.governance.change_engine",
+    "from backend.core.ouroboros.governance.candidate_generator",
+    "from backend.core.ouroboros.governance.gate",
+    "from backend.core.ouroboros.governance.semantic_guardian",
+]
+
+
+def test_reviewer_no_authority_imports():
+    src = _read("backend/core/ouroboros/governance/adversarial_reviewer.py")
+    for imp in _BANNED:
+        assert imp not in src, f"banned import: {imp}"
+
+
+def test_reviewer_no_io_or_subprocess():
+    """Pin: primitive is pure data — no I/O, no subprocess, no env
+    mutation. Slice 2 owns the LLM-call surface; Slice 4 owns IDE
+    GET / SSE."""
+    src = _strip_docstrings_and_comments(
+        _read("backend/core/ouroboros/governance/adversarial_reviewer.py"),
+    )
+    forbidden = [
+        "subprocess.",
+        "open(",
+        ".write_text(",
+        "os.environ[",
+        "os." + "system(",  # split to dodge pre-commit hook
+        "import requests",
+        "import httpx",
+        "import urllib.request",
+    ]
+    for c in forbidden:
+        assert c not in src, f"unexpected coupling: {c}"


### PR DESCRIPTION
## Summary

P5 Slice 1 of 5 (PRD §9 Phase 5 P5 — AdversarialReviewer subagent; Forward-Looking Priority Roadmap **Priority 2**).

Pure-data 4-class primitive that ships everything Slice 2's LLM-call service will need **without making any LLM calls itself**. Closes the *"Iron Gate enforces hygiene; SemanticGuardian matches patterns; neither thinks adversarially"* gap from PRD §9 P5 problem statement.

## Components

| Class / Function | Role |
|---|---|
| `AdversarialFinding` (frozen) | one finding: severity (HIGH/MEDIUM/LOW), category, description, mitigation_hint, file_reference (grounding anchor); per-field text caps |
| `AdversarialReview` (frozen) | aggregate of findings + cost + model used + skip_reason; `severity_histogram()` feeds §8 telemetry; `was_skipped` for switch-on-status |
| `build_review_prompt(plan_text, target_files)` | renders the *"find ≥3 failure modes"* prompt with target file list + strict JSON output schema; plan body clipped at `MAX_PLAN_PROMPT_CHARS=8 KiB` |
| `parse_review_response(raw)` | defensive JSON parser: tolerates fenced ```json wrappers, leading/trailing prose (outermost-brace recovery), case-insensitive severity, missing optional fields. Drops bad severities, empty descriptions, non-dict findings. Caps at `MAX_FINDINGS_PER_REVIEW=50`. **Never raises.** |
| `filter_findings(findings, target_files)` | hallucination filter per PRD edge case. Drops: empty `file_reference`, references outside `target_files`, **traversal references (`..`) UNCONDITIONALLY** (security pin). Substring match accepted (`foo.py` matches `backend/x/foo.py`) |
| `format_findings_for_generate_prompt(findings)` | renders the "Reviewer raised:" section Slice 3 will inject. ASCII-strict round-trip; empty input → `""` |

## Authority invariants (AST-pinned)

- No imports of orchestrator / policy / iron_gate / risk_tier / change_engine / candidate_generator / gate / semantic_guardian.
- No I/O / subprocess / env mutation / network libs.
- **Reviewer is advisory only** — produces text, never a decision. Per PRD edge case "Reviewer disagreement with PLAN — use as warning, not gate (PLAN still authoritative)." This is a **structural** property of the module: there's no return path that gates anything.

## Slice plan (4 more)

| Slice | Scope | Status |
|---|---|---|
| **1 (this PR)** | AdversarialReviewer primitive (findings + prompt + parser + filter). Default-off. | ✅ this PR |
| 2 | AdversarialReviewerService + cost budget enforcement + Provider Protocol + JSONL audit ledger at `.jarvis/adversarial_review_audit.jsonl`. | next |
| 3 | GENERATE prompt injection helper + ConversationBridge feed + orchestrator hook callable. | queued |
| 4 | `/adversarial` REPL + IDE GET `/observability/adversarial` + SSE `adversarial_findings_emitted` event. | queued |
| 5 | Graduation: factory + flag flip + orchestrator GENERATE wiring + 30+ pins + 15 live-fire + PRD updates + Document History v2.13. | queued |

## Hot revert

Default-off behind `JARVIS_ADVERSARIAL_REVIEWER_ENABLED`. Slice 2's service consults this; when off, returns an `AdversarialReview` with `skip_reason="master_off"` so the orchestrator behaves as if the reviewer didn't exist.

## Tests (60 new, 223 across full P5 + P4 surface)

- Module constants + 3-value `FindingSeverity` enum + 8-value `SUGGESTED_CATEGORIES` tuple pinned + frozen dataclass shapes + `.to_dict` stable shape + helpers.
- Env knob default-false-pre-graduation pin.
- `build_review_prompt`: role + failure-modes directive present; target file list rendered; `(none)` for empty targets; strict JSON schema in prompt; long plan truncated; defensive None plan_text.
- `parse_review_response` happy: basic; fenced ```json wrapper; leading prose (brace recovery + note); case-insensitive severity (4 variants); optional mitigation/file_reference default to "".
- `parse` drop paths (10 dedicated tests): bad severity; empty description; empty category; missing findings key; findings-not-list; truncated at `MAX_FINDINGS_PER_REVIEW + 5` → 50 + note; empty input; unparseable input; non-dict finding skipped.
- Per-finding text caps (4 dedicated tests): description / mitigation / category / file_reference all truncated.
- `filter_findings`: empty reference dropped; ungrounded reference dropped; **traversal reference dropped UNCONDITIONALLY** (security pin); substring match accepted; empty target_files only drops empty refs (graceful); drop_notes structure pinned.
- `format_findings_for_generate_prompt`: empty → ""; single complete render; multi-finding numbered; omits empty optional fields (no `file: ` / `mitigation: ` clutter); ASCII-strict.
- Authority invariants over docstring-stripped source.

## Test plan

- [x] `pytest tests/governance/test_adversarial_reviewer.py` — 60 passed
- [x] Adjacent suites (P4 metrics) — 223/223 passed
- [x] Pre-commit integrity hook — green
- [ ] Slice 2 wires the LLM-call service (next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the P5 Slice 1 AdversarialReviewer primitive: frozen data models, prompt builder, defensive parser, hallucination filter, and formatter to surface reviewer findings. Pure-data only (no LLM calls) and default-off behind `JARVIS_ADVERSARIAL_REVIEWER_ENABLED`.

- **New Features**
  - `AdversarialFinding` and `AdversarialReview` (frozen) with `FindingSeverity` enum and per-field text caps.
  - `build_review_prompt(plan_text, target_files)` with a strict JSON schema and 8 KiB plan cap.
  - `parse_review_response(raw)` tolerant JSON parser (fenced blocks, prose, case-insensitive), caps at 50 findings, returns notes, never raises.
  - `filter_findings(findings, target_files)` drops empty refs, out-of-scope refs, and any `..` traversal; accepts suffix/substring matches.
  - `format_findings_for_generate_prompt(findings)` ASCII-safe "Reviewer raised:" section for GENERATE injection.

<sup>Written for commit 9a674be5c50f620f8ebdbba9dce7866067350cc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

