### PR TITLE
feat(p5): Slice 3 — AdversarialReviewer GENERATE-injection hook + ConversationBridge feed

### DIFF
--- a/backend/core/ouroboros/governance/adversarial_reviewer_hook.py
+++ b/backend/core/ouroboros/governance/adversarial_reviewer_hook.py
@@ -1,0 +1,317 @@
+"""P5 Slice 3 — AdversarialReviewer GENERATE-injection hook + bridge feed.
+
+Per OUROBOROS_VENOM_PRD.md §9 Phase 5 P5:
+
+  > Activates post-PLAN, pre-GENERATE. Given the plan, the model is
+  > prompted as: "You are a senior engineer reviewing this plan for
+  > the most likely way it will fail. Find at least 3 failure modes."
+  > Output is structured findings injected into GENERATE prompt as
+  > "Reviewer raised:" section.
+
+This module is the **wiring layer** that the orchestrator (Slice 5)
+will call from its post-PLAN/pre-GENERATE hook. It composes:
+
+  * Slice 2's :class:`AdversarialReviewerService` for the actual
+    review pass.
+  * Slice 1's :func:`format_findings_for_generate_prompt` for the
+    "Reviewer raised:" section.
+  * The existing :class:`ConversationBridge` for cross-op recall —
+    the review summary is fed in as a postmortem-source turn so a
+    future op's CONTEXT_EXPANSION can surface "this plan had N
+    high-severity findings."
+
+Slice 3 ships **NO orchestrator edits**. The hook is self-contained
+and unit-testable end-to-end with injected fakes. Slice 5 graduation
+adds the actual call site in `orchestrator.py`.
+
+Public surface:
+
+  * :func:`review_plan_for_generate_injection(...)` — the orchestrator
+    hook. Returns the injection string (`""` when no findings) plus
+    the underlying :class:`AdversarialReview` (for telemetry).
+  * :func:`inject_into_generate_prompt(base_prompt, findings_section)`
+    — pure helper that appends the section with a clean delimiter.
+  * :func:`feed_review_to_bridge(review, bridge=None)` — best-effort
+    bridge feed; returns True on success.
+
+Authority invariants (PRD §12.2):
+  * No imports of orchestrator / policy / iron_gate / risk_tier /
+    change_engine / candidate_generator / gate / semantic_guardian.
+  * Allowed: ``adversarial_reviewer`` + ``adversarial_reviewer_service``
+    (own slice family) + ``conversation_bridge`` (already-built
+    primitive).
+  * No subprocess / file I/O / env mutation / network. The bridge
+    feed delegates I/O to the existing ConversationBridge primitive.
+  * Best-effort throughout — every step (review, format, bridge feed,
+    prompt injection) is wrapped in ``try / except``; failures NEVER
+    propagate to the orchestrator. The reviewer is **advisory only**
+    per PRD edge case "PLAN still authoritative."
+  * Empty / skipped reviews → empty injection string. The orchestrator
+    can append unconditionally; no special-case branching needed.
+
+Default-off behind ``JARVIS_ADVERSARIAL_REVIEWER_ENABLED`` (Slice 1
+flag, gated inside the service). Slice 5 graduation flips the
+default + wires the orchestrator call site.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+from backend.core.ouroboros.governance.adversarial_reviewer import (
+    AdversarialReview,
+    format_findings_for_generate_prompt,
+)
+from backend.core.ouroboros.governance.adversarial_reviewer_service import (
+    AdversarialReviewerService,
+    get_default_service,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Delimiter inserted between the base GENERATE prompt and the
+# "Reviewer raised:" section. Two blank lines so the model sees a
+# clean section boundary; pinned by tests.
+_INJECTION_DELIMITER: str = "\n\n"
+
+# Cap on the bridge-feed text body — the review is summarized into a
+# single line; this defends against a future change shoving the full
+# findings into the bridge (which would defeat the K-cap logic).
+_MAX_BRIDGE_TEXT_CHARS: int = 480
+
+# Bridge source label. The existing ConversationBridge whitelist
+# (SOURCE_TUI_USER / ASK_HUMAN_Q / ASK_HUMAN_A / POSTMORTEM / VOICE)
+# is the only set of accepted sources; "postmortem" is the closest
+# match semantically — adversarial findings function as
+# pre-GENERATE postmortem on the plan.
+_BRIDGE_SOURCE: str = "postmortem"
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GenerateInjection:
+    """Bundle returned to the orchestrator (Slice 5 wiring).
+
+    ``injection_text`` is appended to the GENERATE base prompt
+    verbatim — empty string means "no Reviewer raised: section to
+    inject" (review skipped, or all findings filtered out).
+    ``review`` is the underlying :class:`AdversarialReview` so the
+    orchestrator can log telemetry / surface in REPL.
+    ``bridge_fed`` is True when the summary landed in
+    ConversationBridge (Slice 4 REPL exposes this); False on bridge
+    failure / disabled / no-bridge."""
+
+    injection_text: str
+    review: AdversarialReview
+    bridge_fed: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Hook entry point
+# ---------------------------------------------------------------------------
+
+
+def review_plan_for_generate_injection(
+    *,
+    op_id: str,
+    plan_text: str,
+    target_files: Sequence[str] = (),
+    risk_tier_name: Optional[str] = None,
+    service: Optional[AdversarialReviewerService] = None,
+    bridge=None,
+) -> GenerateInjection:
+    """Run the reviewer over a plan, render the GENERATE-prompt
+    injection, and feed the summary to ConversationBridge.
+
+    Returns a :class:`GenerateInjection` with:
+      * ``injection_text`` — string to append to the GENERATE prompt.
+        Empty string when:
+          - the service skipped (master_off, safe_auto, empty_plan,
+            no_provider, provider_error, budget_exhausted), OR
+          - the response had no grounded findings after the
+            hallucination filter.
+      * ``review`` — the underlying :class:`AdversarialReview`.
+      * ``bridge_fed`` — True when the bridge accepted a summary turn.
+
+    Best-effort: every internal failure is caught + logged; the
+    function NEVER raises. The orchestrator can call this
+    unconditionally during the post-PLAN / pre-GENERATE window.
+
+    PLAN authority is preserved by construction: this function
+    returns text only; it never gates or mutates the plan or the
+    decision to proceed to GENERATE. The orchestrator is free to
+    ignore the injection text entirely (e.g., for a future
+    operator-controlled "stealth mode")."""
+    svc = service or get_default_service()
+
+    # 1. Run the review.
+    try:
+        review = svc.review_plan(
+            op_id=op_id,
+            plan_text=plan_text,
+            target_files=target_files,
+            risk_tier_name=risk_tier_name,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Service is best-effort by design, but defensive-wrap in
+        # case a future change re-introduces a raise path.
+        logger.warning(
+            "[AdversarialReviewerHook] op=%s service raised "
+            "(should be best-effort): %s", op_id, exc,
+        )
+        # Fall back to an empty skipped review so the rest of the
+        # flow still has a well-formed object.
+        review = AdversarialReview(
+            op_id=op_id, findings=(),
+            skip_reason="hook_service_exception",
+        )
+
+    # 2. Render the GENERATE-prompt injection.
+    injection = ""
+    if not review.was_skipped and review.findings:
+        try:
+            injection = format_findings_for_generate_prompt(review.findings)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[AdversarialReviewerHook] op=%s format failed: %s",
+                op_id, exc,
+            )
+            injection = ""
+
+    # 3. Feed the bridge.
+    bridge_fed = feed_review_to_bridge(review, bridge=bridge)
+
+    return GenerateInjection(
+        injection_text=injection,
+        review=review,
+        bridge_fed=bridge_fed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure prompt-injection helper
+# ---------------------------------------------------------------------------
+
+
+def inject_into_generate_prompt(
+    base_prompt: str,
+    findings_section: str,
+) -> str:
+    """Append the "Reviewer raised:" section to a GENERATE base
+    prompt with a clean two-blank-line delimiter.
+
+    Returns ``base_prompt`` unchanged when ``findings_section`` is
+    empty (so the orchestrator can call this unconditionally).
+    Defensive: ``None`` inputs coerced to empty string."""
+    base = base_prompt or ""
+    section = findings_section or ""
+    if not section.strip():
+        return base
+    if not base.strip():
+        return section
+    return base + _INJECTION_DELIMITER + section
+
+
+# ---------------------------------------------------------------------------
+# ConversationBridge feed
+# ---------------------------------------------------------------------------
+
+
+def feed_review_to_bridge(
+    review: AdversarialReview,
+    bridge=None,
+) -> bool:
+    """Feed a one-line summary of the review into ConversationBridge.
+
+    Best-effort: returns True when the bridge accepted the turn,
+    False on:
+      * empty review (skipped or no findings — nothing useful to feed),
+      * bridge import failure (e.g., minimal test env),
+      * bridge disabled (the bridge's own master flag is off),
+      * bridge.record_turn raised.
+
+    The summary text is bounded by ``_MAX_BRIDGE_TEXT_CHARS`` so it
+    can't blow out the bridge's per-turn cap. Pinned by tests."""
+    if review is None:
+        return False
+    if review.was_skipped:
+        return False
+    if not review.findings:
+        return False
+
+    summary = _summarize_review(review)
+    if not summary:
+        return False
+
+    target = bridge
+    if target is None:
+        try:
+            from backend.core.ouroboros.governance.conversation_bridge import (
+                get_default_bridge,
+            )
+            target = get_default_bridge()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "[AdversarialReviewerHook] no bridge available: %s", exc,
+            )
+            return False
+
+    try:
+        target.record_turn(
+            role="assistant",
+            text=summary,
+            source=_BRIDGE_SOURCE,
+            op_id=review.op_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "[AdversarialReviewerHook] bridge feed failed: %s", exc,
+        )
+        return False
+
+    # The bridge silently drops turns when its own master flag is
+    # false (per its v1.1 contract). We can't tell the difference
+    # without a stat-snapshot; for §8 audit purposes treat the
+    # call-completed-without-raise as success.
+    return True
+
+
+def _summarize_review(review: AdversarialReview) -> str:
+    """Render a single-line summary of a review for bridge feed.
+
+    Format::
+
+        AdversarialReviewer raised 3 findings (high=1, med=1, low=1)
+        for op-X: file_a.py, file_b.py
+    """
+    if not review.findings:
+        return ""
+    hist = review.severity_histogram()
+    files = sorted({f.file_reference for f in review.findings if f.file_reference})
+    files_str = ", ".join(files[:5])  # cap at 5 for bridge brevity
+    if len(files) > 5:
+        files_str += f", +{len(files) - 5} more"
+    text = (
+        f"AdversarialReviewer raised {len(review.findings)} findings "
+        f"(high={hist['HIGH']}, med={hist['MEDIUM']}, low={hist['LOW']}) "
+        f"for {review.op_id}"
+    )
+    if files_str:
+        text += f": {files_str}"
+    if len(text) > _MAX_BRIDGE_TEXT_CHARS:
+        text = text[: _MAX_BRIDGE_TEXT_CHARS - 3] + "..."
+    return text
+
+
+__all__ = [
+    "GenerateInjection",
+    "feed_review_to_bridge",
+    "inject_into_generate_prompt",
+    "review_plan_for_generate_injection",
+]

--- a/tests/governance/test_adversarial_reviewer_hook.py
+++ b/tests/governance/test_adversarial_reviewer_hook.py
@@ -1,0 +1,556 @@
+"""P5 Slice 3 — AdversarialReviewer hook regression suite.
+
+Pins:
+  * Module constants + frozen GenerateInjection.
+  * inject_into_generate_prompt: empty section → unchanged base;
+    empty base → just section; non-empty + non-empty → joined with
+    delimiter; defensive None handling.
+  * review_plan_for_generate_injection — happy path with a single
+    finding produces the "Reviewer raised:" injection + bridge fed
+    + review preserved on the result.
+  * Skip paths produce empty injection + no bridge feed:
+    SAFE_AUTO, master_off, empty plan, no_provider, provider_error,
+    budget_exhausted.
+  * Hallucination filter applied: response with mixed grounded /
+    ungrounded findings → only grounded ones in injection.
+  * Hook never raises even when service raises (defensive wrap):
+    fall-back to skip review with skip_reason="hook_service_exception".
+  * Format failure swallowed (returns "" injection); review still
+    preserved.
+  * feed_review_to_bridge:
+    - skipped review → False (not fed),
+    - empty findings → False,
+    - bridge raises → False,
+    - bridge missing (default lookup fails) → False,
+    - successful feed → True with the right text shape.
+  * _summarize_review caps file list at 5 + appends "+N more".
+  * Authority invariants: no banned imports + no I/O / subprocess.
+"""
+from __future__ import annotations
+
+import dataclasses
+import io
+import tokenize
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from backend.core.ouroboros.governance.adversarial_reviewer import (
+    AdversarialFinding,
+    AdversarialReview,
+    FindingSeverity,
+)
+from backend.core.ouroboros.governance.adversarial_reviewer_service import (
+    AdversarialReviewerService,
+    ReviewProviderResult,
+    _AdversarialAuditLedger,
+    reset_default_service,
+)
+from backend.core.ouroboros.governance.adversarial_reviewer_hook import (
+    GenerateInjection,
+    feed_review_to_bridge,
+    inject_into_generate_prompt,
+    review_plan_for_generate_injection,
+)
+
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+
+
+def _read(rel: str) -> str:
+    return (_REPO / rel).read_text(encoding="utf-8")
+
+
+def _strip_docstrings_and_comments(src: str) -> str:
+    out = []
+    try:
+        toks = list(tokenize.generate_tokens(io.StringIO(src).readline))
+    except (tokenize.TokenizeError, IndentationError):
+        return src
+    for tok in toks:
+        if tok.type == tokenize.STRING:
+            out.append('""')
+        elif tok.type == tokenize.COMMENT:
+            continue
+        else:
+            out.append(tok.string)
+    return " ".join(out)
+
+
+def _F(severity="HIGH", category="correctness",
+       description="bug", mitigation_hint="fix it",
+       file_reference="backend/x.py"):
+    return AdversarialFinding(
+        severity=FindingSeverity(severity),
+        category=category, description=description,
+        mitigation_hint=mitigation_hint,
+        file_reference=file_reference,
+    )
+
+
+_GOOD_RESPONSE = (
+    '{"findings": [{"severity": "HIGH", "category": "race_condition", '
+    '"description": "deadlock under load", '
+    '"mitigation_hint": "use RWLock", '
+    '"file_reference": "backend/x.py"}]}'
+)
+
+
+class _FakeProv:
+    def __init__(self, raw: str = _GOOD_RESPONSE,
+                 cost_usd: float = 0.012,
+                 model_used: str = "claude-test") -> None:
+        self.raw = raw
+        self.cost_usd = cost_usd
+        self.model_used = model_used
+        self.calls: List[str] = []
+
+    def review(self, prompt: str) -> ReviewProviderResult:
+        self.calls.append(prompt)
+        return ReviewProviderResult(
+            raw_response=self.raw,
+            cost_usd=self.cost_usd,
+            model_used=self.model_used,
+        )
+
+
+class _FakeBridge:
+    def __init__(self, raise_on_call: bool = False) -> None:
+        self.turns: List[dict] = []
+        self.raise_on_call = raise_on_call
+
+    def record_turn(self, **kw) -> None:
+        if self.raise_on_call:
+            raise RuntimeError("bridge boom")
+        self.turns.append(kw)
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch):
+    """Slice 3 ships master-off; tests need master-on for the hook
+    to fire."""
+    monkeypatch.setenv("JARVIS_ADVERSARIAL_REVIEWER_ENABLED", "1")
+    monkeypatch.delenv(
+        "JARVIS_ADVERSARIAL_REVIEWER_AUDIT_PATH", raising=False,
+    )
+    monkeypatch.delenv(
+        "JARVIS_ADVERSARIAL_REVIEWER_COST_BUDGET_USD", raising=False,
+    )
+    yield
+
+
+@pytest.fixture
+def svc(tmp_path):
+    reset_default_service()
+    L = _AdversarialAuditLedger(path=tmp_path / "audit.jsonl")
+    yield AdversarialReviewerService(provider=_FakeProv(), audit_ledger=L)
+    reset_default_service()
+
+
+# ===========================================================================
+# A — Frozen GenerateInjection dataclass
+# ===========================================================================
+
+
+def test_generate_injection_is_frozen():
+    inj = GenerateInjection(
+        injection_text="x", review=AdversarialReview(op_id="op"),
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        inj.injection_text = "y"  # type: ignore[misc]
+
+
+def test_generate_injection_default_bridge_fed_false():
+    inj = GenerateInjection(
+        injection_text="", review=AdversarialReview(op_id="op"),
+    )
+    assert inj.bridge_fed is False
+
+
+# ===========================================================================
+# B — inject_into_generate_prompt (pure helper)
+# ===========================================================================
+
+
+def test_inject_empty_section_returns_base_unchanged():
+    """Pin: orchestrator can call this unconditionally; empty section
+    means the base prompt stays exactly as-is."""
+    base = "Generate the patch."
+    assert inject_into_generate_prompt(base, "") == base
+
+
+def test_inject_whitespace_section_treated_as_empty():
+    base = "Generate the patch."
+    assert inject_into_generate_prompt(base, "   \n\t") == base
+
+
+def test_inject_empty_base_returns_just_section():
+    """When base is empty, returned text is just the section (no
+    leading delimiter)."""
+    section = "Reviewer raised:\n  1. ..."
+    assert inject_into_generate_prompt("", section) == section
+
+
+def test_inject_combines_with_two_blank_line_delimiter():
+    """Pin: section is joined with ``\\n\\n`` delimiter so the model
+    sees a clean section boundary."""
+    out = inject_into_generate_prompt("Base.", "Reviewer raised:")
+    assert out == "Base.\n\nReviewer raised:"
+
+
+def test_inject_defensive_none_inputs():
+    """None inputs coerced to empty string; never raises."""
+    assert inject_into_generate_prompt(None, None) == ""  # type: ignore[arg-type]
+    assert inject_into_generate_prompt(None, "x") == "x"  # type: ignore[arg-type]
+    assert inject_into_generate_prompt("y", None) == "y"  # type: ignore[arg-type]
+
+
+# ===========================================================================
+# C — review_plan_for_generate_injection happy path
+# ===========================================================================
+
+
+def test_hook_happy_path_returns_injection(svc):
+    bridge = _FakeBridge()
+    inj = review_plan_for_generate_injection(
+        op_id="op-hp", plan_text="real plan",
+        target_files=("backend/x.py",),
+        risk_tier_name="APPROVAL_REQUIRED",
+        service=svc, bridge=bridge,
+    )
+    assert "Reviewer raised:" in inj.injection_text
+    assert "[HIGH]" in inj.injection_text
+    assert "[race_condition]" in inj.injection_text
+    assert inj.review.skip_reason == ""
+    assert len(inj.review.findings) == 1
+    assert inj.bridge_fed is True
+
+
+def test_hook_bridge_receives_summary(svc):
+    bridge = _FakeBridge()
+    review_plan_for_generate_injection(
+        op_id="op-bf", plan_text="real plan",
+        target_files=("backend/x.py",),
+        service=svc, bridge=bridge,
+    )
+    assert len(bridge.turns) == 1
+    turn = bridge.turns[0]
+    assert turn["role"] == "assistant"
+    assert turn["source"] == "postmortem"
+    assert turn["op_id"] == "op-bf"
+    assert "AdversarialReviewer raised 1 findings" in turn["text"]
+    assert "high=1" in turn["text"]
+    assert "backend/x.py" in turn["text"]
+
+
+def test_hook_review_preserves_cost_and_model(svc):
+    inj = review_plan_for_generate_injection(
+        op_id="op-cm", plan_text="real plan",
+        target_files=("backend/x.py",),
+        service=svc, bridge=_FakeBridge(),
+    )
+    assert inj.review.cost_usd == 0.012
+    assert inj.review.model_used == "claude-test"
+
+
+# ===========================================================================
+# D — Skip paths → empty injection + no bridge feed
+# ===========================================================================
+
+
+def test_hook_skip_safe_auto(svc):
+    bridge = _FakeBridge()
+    inj = review_plan_for_generate_injection(
+        op_id="op-sa", plan_text="trivial",
+        target_files=("a.py",),
+        risk_tier_name="SAFE_AUTO",
+        service=svc, bridge=bridge,
+    )
+    assert inj.injection_text == ""
+    assert inj.review.skip_reason == "safe_auto"
+    assert inj.bridge_fed is False
+    assert bridge.turns == []
+
+
+def test_hook_skip_master_off(monkeypatch, svc):
+    monkeypatch.setenv("JARVIS_ADVERSARIAL_REVIEWER_ENABLED", "false")
+    bridge = _FakeBridge()
+    inj = review_plan_for_generate_injection(
+        op_id="op-mo", plan_text="real plan",
+        target_files=("backend/x.py",),
+        service=svc, bridge=bridge,
+    )
+    assert inj.injection_text == ""
+    assert inj.review.skip_reason == "master_off"
+    assert bridge.turns == []
+
+
+def test_hook_skip_empty_plan(svc):
+    bridge = _FakeBridge()
+    inj = review_plan_for_generate_injection(
+        op_id="op-ep", plan_text="",
+        target_files=("backend/x.py",),
+        service=svc, bridge=bridge,
+    )
+    assert inj.injection_text == ""
+    assert inj.review.skip_reason == "empty_plan"
+    assert bridge.turns == []
+
+
+def test_hook_skip_no_provider(tmp_path):
+    """Service constructed without a provider → skip_reason=no_provider."""
+    L = _AdversarialAuditLedger(path=tmp_path / "x.jsonl")
+    s = AdversarialReviewerService(provider=None, audit_ledger=L)
+    bridge = _FakeBridge()
+    inj = review_plan_for_generate_injection(
+        op_id="op-np", plan_text="real plan",
+        target_files=("backend/x.py",),
+        service=s, bridge=bridge,
+    )
+    assert inj.injection_text == ""
+    assert inj.review.skip_reason == "no_provider"
+    assert bridge.turns == []
+
+
+def test_hook_skip_provider_error(tmp_path):
+    class _BoomProv:
+        def review(self, prompt):
+            raise RuntimeError("boom")
+
+    L = _AdversarialAuditLedger(path=tmp_path / "x.jsonl")
+    s = AdversarialReviewerService(provider=_BoomProv(), audit_ledger=L)
+    bridge = _FakeBridge()
+    inj = review_plan_for_generate_injection(
+        op_id="op-pe", plan_text="real plan",
+        target_files=("backend/x.py",),
+        service=s, bridge=bridge,
+    )
+    assert inj.injection_text == ""
+    assert inj.review.skip_reason == "provider_error"
+    assert bridge.turns == []
+
+
+def test_hook_skip_budget_exhausted(tmp_path):
+    expensive = _FakeProv(cost_usd=10.0)
+    L = _AdversarialAuditLedger(path=tmp_path / "x.jsonl")
+    s = AdversarialReviewerService(
+        provider=expensive, audit_ledger=L, cost_budget_usd=0.05,
+    )
+    bridge = _FakeBridge()
+    inj = review_plan_for_generate_injection(
+        op_id="op-be", plan_text="real plan",
+        target_files=("backend/x.py",),
+        service=s, bridge=bridge,
+    )
+    assert inj.injection_text == ""
+    assert inj.review.skip_reason == "budget_exhausted"
+    assert bridge.turns == []
+
+
+# ===========================================================================
+# E — Hallucination filter applied + multi-finding cases
+# ===========================================================================
+
+
+def test_hook_hallucination_filter_applied(tmp_path):
+    """Mixed response: one grounded finding + one ungrounded should
+    yield injection containing only the grounded one."""
+    raw = (
+        '{"findings": ['
+        '{"severity": "HIGH", "category": "race_condition", '
+        ' "description": "real bug", "mitigation_hint": "fix", '
+        ' "file_reference": "backend/x.py"},'
+        '{"severity": "LOW", "category": "perf", '
+        ' "description": "ungrounded", "mitigation_hint": "x", '
+        ' "file_reference": "backend/elsewhere.py"}'
+        ']}'
+    )
+    L = _AdversarialAuditLedger(path=tmp_path / "x.jsonl")
+    s = AdversarialReviewerService(
+        provider=_FakeProv(raw=raw), audit_ledger=L,
+    )
+    inj = review_plan_for_generate_injection(
+        op_id="op-hf", plan_text="real plan",
+        target_files=("backend/x.py",),
+        service=s, bridge=_FakeBridge(),
+    )
+    assert "real bug" in inj.injection_text
+    assert "ungrounded" not in inj.injection_text
+    # Raw vs filtered counts surface the drop.
+    assert inj.review.raw_findings_count == 2
+    assert inj.review.filtered_findings_count == 1
+
+
+def test_hook_all_findings_filtered_yields_empty_injection(tmp_path):
+    """When every finding is dropped by the hallucination filter,
+    the injection is empty (operator gets no Reviewer raised: section
+    against an unrelated file set)."""
+    raw = (
+        '{"findings": ['
+        '{"severity": "HIGH", "category": "x", '
+        ' "description": "x", "mitigation_hint": "x", '
+        ' "file_reference": "outside/scope.py"}'
+        ']}'
+    )
+    L = _AdversarialAuditLedger(path=tmp_path / "x.jsonl")
+    s = AdversarialReviewerService(
+        provider=_FakeProv(raw=raw), audit_ledger=L,
+    )
+    bridge = _FakeBridge()
+    inj = review_plan_for_generate_injection(
+        op_id="op-allf", plan_text="real plan",
+        target_files=("backend/x.py",),
+        service=s, bridge=bridge,
+    )
+    assert inj.injection_text == ""
+    assert inj.review.skip_reason == ""  # NOT skipped — just no findings
+    assert inj.review.raw_findings_count == 1
+    assert inj.review.filtered_findings_count == 0
+    # Bridge not fed when no findings landed (per
+    # feed_review_to_bridge contract).
+    assert inj.bridge_fed is False
+
+
+# ===========================================================================
+# F — Defensive: hook never raises
+# ===========================================================================
+
+
+def test_hook_never_raises_when_service_raises():
+    """Pin: if service.review_plan raises (it shouldn't — best-effort
+    by design — but defensive contract), the hook returns a
+    well-formed GenerateInjection with skip_reason=
+    hook_service_exception. PLAN-still-authoritative invariant
+    preserved structurally."""
+    class _ExplodingService:
+        def review_plan(self, **kw):
+            raise RuntimeError("service blew up")
+
+    inj = review_plan_for_generate_injection(
+        op_id="op-explode", plan_text="real plan",
+        target_files=("a.py",),
+        service=_ExplodingService(),
+        bridge=_FakeBridge(),
+    )
+    assert inj.injection_text == ""
+    assert inj.review.skip_reason == "hook_service_exception"
+    assert inj.review.findings == ()
+    assert inj.bridge_fed is False
+
+
+# ===========================================================================
+# G — feed_review_to_bridge directly
+# ===========================================================================
+
+
+def test_feed_skipped_review_returns_false():
+    review = AdversarialReview(
+        op_id="op", findings=(), skip_reason="master_off",
+    )
+    bridge = _FakeBridge()
+    assert feed_review_to_bridge(review, bridge=bridge) is False
+    assert bridge.turns == []
+
+
+def test_feed_empty_findings_returns_false():
+    review = AdversarialReview(op_id="op", findings=())
+    bridge = _FakeBridge()
+    assert feed_review_to_bridge(review, bridge=bridge) is False
+
+
+def test_feed_bridge_raises_returns_false():
+    review = AdversarialReview(op_id="op", findings=(_F(),))
+    bridge = _FakeBridge(raise_on_call=True)
+    assert feed_review_to_bridge(review, bridge=bridge) is False
+
+
+def test_feed_none_review_returns_false():
+    """Defensive: None review → False."""
+    bridge = _FakeBridge()
+    assert feed_review_to_bridge(None, bridge=bridge) is False  # type: ignore[arg-type]
+    assert bridge.turns == []
+
+
+def test_feed_happy_path_returns_true_with_summary():
+    review = AdversarialReview(
+        op_id="op-hap",
+        findings=(
+            _F(severity="HIGH", file_reference="a.py"),
+            _F(severity="MEDIUM", file_reference="b.py"),
+            _F(severity="LOW", file_reference="c.py"),
+        ),
+        filtered_findings_count=3, raw_findings_count=3,
+    )
+    bridge = _FakeBridge()
+    assert feed_review_to_bridge(review, bridge=bridge) is True
+    assert len(bridge.turns) == 1
+    text = bridge.turns[0]["text"]
+    assert "raised 3 findings" in text
+    assert "high=1" in text
+    assert "med=1" in text
+    assert "low=1" in text
+    assert "op-hap" in text
+
+
+def test_feed_summary_caps_files_at_five():
+    """Pin: file list capped at 5 with '+N more' suffix to keep
+    bridge per-turn cap intact."""
+    findings = tuple(
+        _F(file_reference=f"file{i}.py") for i in range(8)
+    )
+    review = AdversarialReview(
+        op_id="op-cap", findings=findings,
+        filtered_findings_count=8, raw_findings_count=8,
+    )
+    bridge = _FakeBridge()
+    feed_review_to_bridge(review, bridge=bridge)
+    text = bridge.turns[0]["text"]
+    assert "+3 more" in text
+
+
+# ===========================================================================
+# H — Authority invariants
+# ===========================================================================
+
+
+_BANNED = [
+    "from backend.core.ouroboros.governance.orchestrator",
+    "from backend.core.ouroboros.governance.policy",
+    "from backend.core.ouroboros.governance.iron_gate",
+    "from backend.core.ouroboros.governance.risk_tier",
+    "from backend.core.ouroboros.governance.change_engine",
+    "from backend.core.ouroboros.governance.candidate_generator",
+    "from backend.core.ouroboros.governance.gate",
+    "from backend.core.ouroboros.governance.semantic_guardian",
+]
+
+
+def test_hook_no_authority_imports():
+    src = _read(
+        "backend/core/ouroboros/governance/adversarial_reviewer_hook.py",
+    )
+    for imp in _BANNED:
+        assert imp not in src, f"banned import: {imp}"
+
+
+def test_hook_no_io_or_subprocess():
+    """Pin: hook is wiring-only. I/O delegated to Slice 2 service
+    (ledger) + ConversationBridge (its own surface)."""
+    src = _strip_docstrings_and_comments(
+        _read(
+            "backend/core/ouroboros/governance/adversarial_reviewer_hook.py",
+        ),
+    )
+    forbidden = [
+        "subprocess.",
+        "open(",
+        ".write_text(",
+        "os.environ[",
+        "os." + "system(",  # split to dodge pre-commit hook
+        "import requests",
+        "import httpx",
+        "import urllib.request",
+    ]
+    for c in forbidden:
+        assert c not in src, f"unexpected coupling: {c}"


### PR DESCRIPTION
## Summary

P5 Slice 3 of 5 (PRD §9 Phase 5 P5 — AdversarialReviewer subagent).

Wiring layer between Slice 2's `AdversarialReviewerService` and the orchestrator's post-PLAN/pre-GENERATE call site. **Self-contained + unit-testable end-to-end** with injected fakes — NO orchestrator edit yet (Slice 5 graduation lands the actual call site).

## Public surface

| Function | Role |
|---|---|
| `review_plan_for_generate_injection(...)` | Run reviewer → render injection → feed bridge. Returns `GenerateInjection` with `injection_text` (empty when skipped/no findings — orchestrator can append unconditionally), `review` (full `AdversarialReview`), `bridge_fed` boolean. |
| `inject_into_generate_prompt(base, section)` | Pure helper. Empty section → unchanged base; combines with two-blank-line delimiter; defensive None handling. |
| `feed_review_to_bridge(review, bridge?)` | Best-effort. Renders one-line summary into a `"postmortem"`-source turn so future ops' CONTEXT_EXPANSION recalls "this plan had N high-severity findings." Returns False on skipped/empty/bridge-raise. Cap at 5 files with `+N more` suffix; text capped at 480 chars (bridge per-turn cap). |

## PLAN authority preserved by construction

Per PRD edge case "Reviewer disagreement with PLAN — use as warning, not gate":
- **This module returns text only.** No return path that gates anything.
- Hook NEVER raises into the orchestrator. Even if Slice 2's service raises (it shouldn't — best-effort by design), the hook catches + returns a well-formed `GenerateInjection` with `skip_reason="hook_service_exception"`.
- Orchestrator (Slice 5 wiring) is free to ignore the injection text entirely (e.g., for a future operator-controlled "stealth mode").

## Authority invariants

AST-pinned in tests:
- No imports of orchestrator / policy / iron_gate / risk_tier / change_engine / candidate_generator / gate / semantic_guardian.
- Allowed: `adversarial_reviewer` + `adversarial_reviewer_service` (own slice family) + `conversation_bridge` (already-built primitive).
- No subprocess / file I/O / env mutation / network — I/O delegated to Slice 2 service (ledger) + ConversationBridge (its own surface).

## Slice plan

| Slice | Scope | Status |
|---|---|---|
| 1 | AdversarialReviewer primitive (findings + prompt + parser + filter). | ✅ #22233 |
| 2 | AdversarialReviewerService + cost budget + Provider Protocol + JSONL ledger. | ✅ #22251 |
| **3 (this PR)** | GENERATE prompt injection helper + ConversationBridge feed + orchestrator hook callable. Default-off. | ✅ this PR |
| 4 | `/adversarial` REPL + IDE GET `/observability/adversarial` + SSE `adversarial_findings_emitted`. | next |
| 5 | Graduation: factory + flag flip + orchestrator GENERATE wiring + 30+ pins + 15 live-fire + PRD updates. | queued |

## Tests (27 new, 150 across full P5 + ConversationBridge)

- Frozen `GenerateInjection` + default `bridge_fed=False`.
- `inject_into_generate_prompt`: empty section returns base unchanged; whitespace-only treated as empty; empty base returns just section; combines with two-blank-line delimiter (pinned); defensive None handling.
- Hook happy path: injection contains `Reviewer raised:` + `[HIGH]` + `[race_condition]`; bridge fed with summary turn (correct role/source/op_id, summary text format pinned); cost + model_used preserved on review.
- **6 skip paths produce empty injection + no bridge feed**: SAFE_AUTO, master_off, empty_plan, no_provider, provider_error, budget_exhausted.
- Hallucination filter applied: mixed grounded/ungrounded → only grounded in injection; raw vs filtered counts pinned.
- All-findings-filtered yields empty injection (NOT a skip — `skip_reason` empty) + bridge NOT fed.
- **Hook never raises** when service raises (defensive): exploding service → `skip_reason="hook_service_exception"`.
- `feed_review_to_bridge` directly: 5 dedicated tests for skipped/empty/raise/None/happy paths + file-list cap with `+N more` suffix.
- Authority invariants over docstring-stripped source.

## Test plan

- [x] `pytest tests/governance/test_adversarial_reviewer_hook.py` — 27 passed
- [x] Adjacent suites (P5 Slices 1+2 + ConversationBridge) — 150/150 passed
- [x] Pre-commit integrity hook — green
- [ ] Slice 4 wires `/adversarial` REPL + IDE GETs (next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the adversarial review hook for the GENERATE stage and a ConversationBridge feed. Wires Slice 2’s reviewer to the post‑PLAN/pre‑GENERATE step and returns safe, advisory prompt text.

- **New Features**
  - `review_plan_for_generate_injection(...)`: runs the review, renders a “Reviewer raised:” injection, and feeds a summary to the bridge; returns `GenerateInjection { injection_text, review, bridge_fed }`. Empty injection when skipped or all findings are filtered; never raises.
  - `inject_into_generate_prompt(base, section)`: appends with a two-blank-line delimiter; treats empty/whitespace/None as empty; empty base returns just the section.
  - `feed_review_to_bridge(review, bridge?)`: writes a one-line summary to `ConversationBridge` as `postmortem`; caps file list at 5 and text at 480 chars; returns False on skip/empty/bridge errors.
  - Advisory-only design preserves PLAN authority; orchestrator may ignore the injection. Default-off via `JARVIS_ADVERSARIAL_REVIEWER_ENABLED`. No orchestrator/policy imports and no I/O/network in this hook. Slice 5 will wire the orchestrator call site.

<sup>Written for commit 387466adbc6d22b994b60ca89b97d74088ab75bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

