### PR TITLE
feat(rr-pass-b): Slice 4 — ReplayCorpus + ReplaySnapshot + structural-equality diff (shadow-replay primitive)

### DIFF
--- a/.jarvis/order2_replay_corpus/manifest.yaml
+++ b/.jarvis/order2_replay_corpus/manifest.yaml
@@ -1,0 +1,33 @@
+# RR Pass B Slice 4 — shadow-replay corpus manifest
+#
+# Curated set of completed Order-1 ops used by Slice 5
+# MetaPhaseRunner to verify that O+V's proposed PhaseRunner
+# subclasses produce byte-identical decisions on golden corpus
+# data (per Pass B §6).
+#
+# Slice 4 SHIPS THIS FILE WITH ONE SYNTHETIC SEED ENTRY.
+# The seed proves the file format works; the full ~20-op corpus
+# (5 happy-path single-file, 5 multi-file, 5 retry/L2, 3 ORANGE-tier,
+# 2 with semantic-firewall hits per Pass B §6.2) is operational
+# work to populate as Slice 5+ goes live.
+#
+# Amendment policy (Pass B Slice 6, when implemented):
+#   * Adding/removing/replacing corpus ops is itself an Order-2
+#     manifest amendment (Pass B §6.5). Bypass would defeat the
+#     cage: a candidate runner could pass against a smaller,
+#     more permissive corpus.
+#   * AutoCommitter trailer: Order-2-Authorized-By: <operator>
+#   * No SAFE_AUTO eligibility ever
+#
+# Initial seed entry per Pass B §6.
+
+schema_version: 1
+
+entries:
+  # SEED — synthetic example proving the file format. Slice 5+
+  # will replace this with real session ctx snapshots curated from
+  # the battle-test breakthrough log.
+  - op_id: seed-synthetic-noop
+    path: ops/seed-synthetic-noop
+    phases: [classify]
+    tags: [seed, synthetic, file-format-proof]

--- a/.jarvis/order2_replay_corpus/ops/seed-synthetic-noop/classify.json
+++ b/.jarvis/order2_replay_corpus/ops/seed-synthetic-noop/classify.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "RR Pass B Slice 4 seed snapshot. Synthetic — proves the file format. Slice 5+ replaces with real session ctx data.",
+  "pre_phase_ctx": {
+    "op_id": "seed-synthetic-noop",
+    "phase": "CLASSIFY",
+    "target_files": ["backend/example.py"],
+    "description": "synthetic seed for shadow-replay file format proof"
+  },
+  "expected_next_phase": "ROUTE",
+  "expected_status": "ok",
+  "expected_reason": null,
+  "expected_next_ctx": {
+    "op_id": "seed-synthetic-noop",
+    "phase": "ROUTE",
+    "risk_tier": "SAFE_AUTO",
+    "target_files": ["backend/example.py"],
+    "candidate_files": []
+  }
+}

--- a/backend/core/ouroboros/governance/meta/shadow_replay.py
+++ b/backend/core/ouroboros/governance/meta/shadow_replay.py
@@ -1,0 +1,544 @@
+"""RR Pass B Slice 4 — Shadow-replay corpus + structural-equality diff.
+
+Per ``memory/project_reverse_russian_doll_pass_b.md`` §6:
+
+  > A new ``PhaseRunner`` subclass is structurally well-formed (§5)
+  > but might still break the FSM dynamically — mishandle a corner
+  > case, change behavior on retry, silently drop telemetry. Replay-
+  > against-golden is the regression cage.
+  >
+  > Schema:
+  > ``.jarvis/order2_replay_corpus/manifest.yaml`` (op_id → snapshot
+  > path + tags) + ``ops/<op_id>/<phase>.json`` snapshots at each
+  > phase boundary.
+  >
+  > Comparison metric: byte-identical for ``next_phase``, ``status``,
+  > ``reason``; structural-equality for ``next_ctx`` (whitelisted
+  > fields — phase log entries can differ in timestamp; ``risk_tier``,
+  > ``op_id``, candidate set must match).
+
+Slice 4 ships the **primitive**:
+
+  * :class:`ReplaySnapshot` — frozen dataclass, one phase boundary
+    capture (pre-phase ctx + expected post-phase result).
+  * :class:`ReplayCorpus` — loader + indexer over the on-disk
+    corpus directory.
+  * :func:`structural_equal` — whitelist-driven dict comparison
+    used for the ``next_ctx`` field in §6.3.
+  * :func:`compare_phase_result_to_expected` — high-level diff
+    function returning a :class:`ReplayDivergence` or ``None``.
+
+Slice 5 (MetaPhaseRunner) composes these with the actual candidate-
+runner invocation: build a fake ctx from ``snapshot.pre_phase_ctx``,
+``await runner.run(fake_ctx)``, then diff the produced PhaseResult
+against ``snapshot.expected_*``. Slice 4 deliberately does NOT
+invoke runners — building real ``OperationContext`` instances has
+heavy import surface that this slice avoids by design.
+
+Authority invariants (Pass B §6 + §3.4):
+  * Pure data + read-only file I/O of the corpus directory ONLY.
+    No subprocess, no env mutation, no network. The corpus YAML
+    + JSON files are operator-curated; Slice 6 amendment protocol
+    will gate writes (corpus is part of the cage per §6.5).
+  * No imports of orchestrator / policy / iron_gate / risk_tier_floor
+    / change_engine / candidate_generator / gate / semantic_guardian
+    / semantic_firewall / scoped_tool_backend.
+  * Allowed: stdlib + ``meta.order2_manifest`` (for any future
+    cross-checks, currently unused at slice-1 scope).
+  * Best-effort throughout — every load failure is mapped to a
+    structured :class:`ReplayLoadStatus`; never raises.
+  * Per-corpus-op cap at MAX_SNAPSHOT_BYTES so a malformed JSON
+    blob can't pin the loader.
+
+Default-off behind ``JARVIS_SHADOW_PIPELINE_ENABLED`` until Slice
+4's own clean-session graduation. When off, :func:`load_corpus`
+returns an empty corpus with status NOT_LOADED. Slice 5 hook treats
+NOT_LOADED as "no shadow replay enforcement" — the cage degrades
+to the existing review path.
+"""
+from __future__ import annotations
+
+import enum
+import json
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import (
+    Any, Dict, FrozenSet, List, Mapping, Optional, Tuple,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+# Schema version frozen at v1 — bumped on any ReplaySnapshot field
+# change so Slice 5 MetaPhaseRunner can pin a parser version.
+SHADOW_REPLAY_SCHEMA_VERSION: int = 1
+
+# Per-snapshot byte ceiling. 256 KiB is generous for a single phase
+# boundary capture; larger blobs are dropped at load time.
+MAX_SNAPSHOT_BYTES: int = 256 * 1024
+
+# Per-corpus snapshot count cap. Pass B §6.2 specifies an initial
+# 20-op corpus; this is a soft 1000-op ceiling for future growth
+# (each op typically has 11 phase snapshots — 11k snapshots is the
+# upper bound).
+MAX_SNAPSHOTS_PER_CORPUS: int = 11_000
+
+# Whitelisted fields per Pass B §6.3: must match exactly across
+# inline-vs-runner comparison. Other ctx fields are allowed to
+# differ (phase log timestamps, perf counters, etc.).
+DEFAULT_CTX_WHITELIST: FrozenSet[str] = frozenset({
+    "op_id",
+    "risk_tier",
+    "phase",
+    "target_files",
+    "candidate_files",
+})
+
+
+def is_enabled() -> bool:
+    """Master flag — ``JARVIS_SHADOW_PIPELINE_ENABLED`` (default
+    false until Slice 4's own clean-session graduation).
+
+    When off, :func:`load_corpus` returns an empty corpus with status
+    NOT_LOADED. Slice 5 MetaPhaseRunner consumer treats this as
+    "no shadow replay enforcement" so the cage degrades to the
+    existing review path."""
+    return os.environ.get(
+        "JARVIS_SHADOW_PIPELINE_ENABLED", "",
+    ).strip().lower() in _TRUTHY
+
+
+def corpus_root() -> Path:
+    """Return the corpus root directory. Env-overridable via
+    ``JARVIS_SHADOW_REPLAY_CORPUS_PATH``; defaults to
+    ``.jarvis/order2_replay_corpus`` under the cwd."""
+    raw = os.environ.get("JARVIS_SHADOW_REPLAY_CORPUS_PATH")
+    if raw:
+        return Path(raw)
+    return Path(".jarvis") / "order2_replay_corpus"
+
+
+# ---------------------------------------------------------------------------
+# Status enum + frozen dataclasses
+# ---------------------------------------------------------------------------
+
+
+class ReplayLoadStatus(str, enum.Enum):
+    """Outcome of a corpus load attempt. Pinned for Slice 5 hook
+    status checks."""
+
+    LOADED = "LOADED"
+    NOT_LOADED = "NOT_LOADED"          # master flag off
+    DIR_MISSING = "DIR_MISSING"
+    MANIFEST_MISSING = "MANIFEST_MISSING"
+    MANIFEST_PARSE_ERROR = "MANIFEST_PARSE_ERROR"
+    EMPTY = "EMPTY"                     # manifest loads but has zero entries
+
+
+@dataclass(frozen=True)
+class ReplaySnapshot:
+    """One phase-boundary capture from a completed Order-1 op.
+
+    ``pre_phase_ctx`` is a JSON-serializable mapping (the
+    OperationContext at phase X-1 — what the candidate runner
+    receives as input).
+
+    ``expected_*`` fields are the recorded post-phase result the
+    candidate must reproduce: byte-identical for next_phase /
+    status / reason; structural-equality (over the whitelist) for
+    next_ctx."""
+
+    op_id: str
+    phase: str
+    pre_phase_ctx: Dict[str, Any] = field(default_factory=dict)
+    expected_next_phase: Optional[str] = None
+    expected_status: str = ""
+    expected_reason: Optional[str] = None
+    expected_next_ctx: Dict[str, Any] = field(default_factory=dict)
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "op_id": self.op_id,
+            "phase": self.phase,
+            "pre_phase_ctx": dict(self.pre_phase_ctx),
+            "expected_next_phase": self.expected_next_phase,
+            "expected_status": self.expected_status,
+            "expected_reason": self.expected_reason,
+            "expected_next_ctx": dict(self.expected_next_ctx),
+            "tags": list(self.tags),
+        }
+
+
+@dataclass(frozen=True)
+class ReplayCorpus:
+    """Loaded corpus — bundle of snapshots indexed by op_id and phase.
+
+    Slice 5 MetaPhaseRunner queries via :meth:`for_phase` to find all
+    snapshots for a candidate runner's target phase. The corpus
+    itself never mutates — Slice 6 amendment protocol rebuilds +
+    reloads via :func:`reset_default_corpus` after corpus YAML edit."""
+
+    schema_version: int = SHADOW_REPLAY_SCHEMA_VERSION
+    snapshots: Tuple[ReplaySnapshot, ...] = field(default_factory=tuple)
+    status: ReplayLoadStatus = ReplayLoadStatus.NOT_LOADED
+    notes: Tuple[str, ...] = field(default_factory=tuple)
+
+    def for_phase(self, phase: str) -> Tuple[ReplaySnapshot, ...]:
+        """Return all snapshots for a given phase name. Used by
+        Slice 5 MetaPhaseRunner to filter the corpus to a candidate
+        runner's target phase."""
+        return tuple(s for s in self.snapshots if s.phase == phase)
+
+    def for_op(self, op_id: str) -> Tuple[ReplaySnapshot, ...]:
+        return tuple(s for s in self.snapshots if s.op_id == op_id)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status.value,
+            "snapshots_count": len(self.snapshots),
+            "notes": list(self.notes),
+        }
+
+
+@dataclass(frozen=True)
+class ReplayDivergence:
+    """One regression finding from
+    :func:`compare_phase_result_to_expected`.
+
+    ``field_path`` describes WHERE the divergence occurred (e.g.
+    ``"next_phase"``, ``"next_ctx.risk_tier"``). ``expected`` /
+    ``actual`` are the values that mismatched."""
+
+    op_id: str
+    phase: str
+    field_path: str
+    expected: Any
+    actual: Any
+    detail: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def load_corpus(
+    root: Optional[Path] = None,
+) -> ReplayCorpus:
+    """Load the corpus from disk. NEVER raises — every failure path
+    returns a corpus with the appropriate :class:`ReplayLoadStatus`.
+
+    Skip behaviour:
+      * Master flag off → ``NOT_LOADED`` with empty snapshots.
+      * Root dir missing → ``DIR_MISSING``.
+      * Manifest YAML missing → ``MANIFEST_MISSING``.
+      * Manifest parse error → ``MANIFEST_PARSE_ERROR``.
+      * Manifest loads with zero usable entries → ``EMPTY``.
+    """
+    if not is_enabled():
+        return ReplayCorpus(
+            status=ReplayLoadStatus.NOT_LOADED,
+            notes=("master_flag_off",),
+        )
+    r = root or corpus_root()
+    if not r.exists() or not r.is_dir():
+        return ReplayCorpus(
+            status=ReplayLoadStatus.DIR_MISSING,
+            notes=(f"root_missing:{r}",),
+        )
+    manifest_path = r / "manifest.yaml"
+    if not manifest_path.exists():
+        return ReplayCorpus(
+            status=ReplayLoadStatus.MANIFEST_MISSING,
+            notes=(f"manifest_missing:{manifest_path}",),
+        )
+    try:
+        raw = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return ReplayCorpus(
+            status=ReplayLoadStatus.MANIFEST_PARSE_ERROR,
+            notes=(f"manifest_read_failed:{exc}",),
+        )
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        return ReplayCorpus(
+            status=ReplayLoadStatus.MANIFEST_PARSE_ERROR,
+            notes=("yaml_module_missing",),
+        )
+    try:
+        doc = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        return ReplayCorpus(
+            status=ReplayLoadStatus.MANIFEST_PARSE_ERROR,
+            notes=(f"yaml_parse_failed:{exc}",),
+        )
+    if not isinstance(doc, dict):
+        return ReplayCorpus(
+            status=ReplayLoadStatus.MANIFEST_PARSE_ERROR,
+            notes=("manifest_not_mapping",),
+        )
+
+    notes: List[str] = []
+    declared_version = doc.get("schema_version")
+    if declared_version != SHADOW_REPLAY_SCHEMA_VERSION:
+        notes.append(
+            f"schema_version_mismatch:declared={declared_version},"
+            f"expected={SHADOW_REPLAY_SCHEMA_VERSION}"
+        )
+    raw_entries = doc.get("entries")
+    if not isinstance(raw_entries, list):
+        return ReplayCorpus(
+            status=ReplayLoadStatus.MANIFEST_PARSE_ERROR,
+            notes=tuple(notes + ["entries_key_missing_or_not_list"]),
+        )
+
+    snapshots: List[ReplaySnapshot] = []
+    for i, raw_entry in enumerate(raw_entries):
+        if len(snapshots) >= MAX_SNAPSHOTS_PER_CORPUS:
+            notes.append(
+                f"snapshots_truncated_at_max_{MAX_SNAPSHOTS_PER_CORPUS}",
+            )
+            break
+        loaded = _load_snapshot_entry(raw_entry, r, notes, idx=i)
+        snapshots.extend(loaded)
+
+    if not snapshots:
+        return ReplayCorpus(
+            status=ReplayLoadStatus.EMPTY,
+            notes=tuple(notes) or ("no_usable_snapshots",),
+        )
+
+    logger.info(
+        "[ShadowReplay] loaded %d snapshots across %d ops from %s",
+        len(snapshots),
+        len({s.op_id for s in snapshots}),
+        r,
+    )
+    return ReplayCorpus(
+        schema_version=SHADOW_REPLAY_SCHEMA_VERSION,
+        snapshots=tuple(snapshots),
+        status=ReplayLoadStatus.LOADED,
+        notes=tuple(notes),
+    )
+
+
+def _load_snapshot_entry(
+    raw_entry: Any,
+    root: Path,
+    notes: List[str],
+    idx: int,
+) -> List[ReplaySnapshot]:
+    """Load all phase-boundary snapshots for one corpus op.
+
+    Manifest entry shape::
+
+        - op_id: op-019d9368-654b
+          path: ops/op-019d9368-654b
+          phases: [classify, route, plan, generate, validate, gate, ...]
+          tags: [multi-file, session-u-w]
+    """
+    if not isinstance(raw_entry, dict):
+        notes.append(f"entry_{idx}_not_mapping")
+        return []
+    op_id = str(raw_entry.get("op_id") or "").strip()
+    if not op_id:
+        notes.append(f"entry_{idx}_missing_op_id")
+        return []
+    rel_path = str(raw_entry.get("path") or "").strip()
+    if not rel_path:
+        notes.append(f"entry_{idx}_missing_path")
+        return []
+    phases = raw_entry.get("phases")
+    if not isinstance(phases, list) or not phases:
+        notes.append(f"entry_{idx}_missing_phases")
+        return []
+    tags_raw = raw_entry.get("tags") or []
+    tags = tuple(str(t) for t in tags_raw) if isinstance(tags_raw, list) else ()
+
+    op_dir = root / rel_path
+    if not op_dir.exists() or not op_dir.is_dir():
+        notes.append(f"entry_{idx}_op_dir_missing:{op_dir}")
+        return []
+
+    out: List[ReplaySnapshot] = []
+    for phase in phases:
+        snapshot_path = op_dir / f"{phase}.json"
+        if not snapshot_path.exists():
+            notes.append(
+                f"entry_{idx}_snapshot_missing:{snapshot_path.name}",
+            )
+            continue
+        try:
+            sz = snapshot_path.stat().st_size
+        except OSError:
+            sz = 0
+        if sz > MAX_SNAPSHOT_BYTES:
+            notes.append(
+                f"entry_{idx}_snapshot_oversize:{snapshot_path.name}"
+                f":{sz} > {MAX_SNAPSHOT_BYTES}"
+            )
+            continue
+        try:
+            text = snapshot_path.read_text(encoding="utf-8")
+            data = json.loads(text)
+        except (OSError, json.JSONDecodeError) as exc:
+            notes.append(
+                f"entry_{idx}_snapshot_unreadable:"
+                f"{snapshot_path.name}:{exc}"
+            )
+            continue
+        if not isinstance(data, dict):
+            notes.append(
+                f"entry_{idx}_snapshot_not_mapping:{snapshot_path.name}",
+            )
+            continue
+        out.append(ReplaySnapshot(
+            op_id=op_id,
+            phase=str(phase),
+            pre_phase_ctx=data.get("pre_phase_ctx") or {},
+            expected_next_phase=data.get("expected_next_phase"),
+            expected_status=str(data.get("expected_status") or ""),
+            expected_reason=data.get("expected_reason"),
+            expected_next_ctx=data.get("expected_next_ctx") or {},
+            tags=tags,
+        ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Structural equality + diff
+# ---------------------------------------------------------------------------
+
+
+def structural_equal(
+    a: Mapping[str, Any],
+    b: Mapping[str, Any],
+    *,
+    whitelist: FrozenSet[str] = DEFAULT_CTX_WHITELIST,
+) -> bool:
+    """Return True iff every whitelisted key is byte-identical
+    between ``a`` and ``b``. Non-whitelisted keys are ignored
+    (timestamps, phase log entries, etc. allowed to diverge per
+    Pass B §6.3)."""
+    for key in whitelist:
+        if a.get(key) != b.get(key):
+            return False
+    return True
+
+
+def compare_phase_result_to_expected(
+    actual_next_phase: Optional[str],
+    actual_status: str,
+    actual_reason: Optional[str],
+    actual_next_ctx: Mapping[str, Any],
+    snapshot: ReplaySnapshot,
+    *,
+    ctx_whitelist: FrozenSet[str] = DEFAULT_CTX_WHITELIST,
+) -> Optional[ReplayDivergence]:
+    """Compare a candidate runner's produced result against the
+    snapshot's recorded expected result.
+
+    Per Pass B §6.3:
+      * ``next_phase``, ``status``, ``reason`` — byte-identical.
+      * ``next_ctx`` — structural-equality over the whitelist.
+
+    Returns ``None`` on match; else the FIRST :class:`ReplayDivergence`
+    found (callers can keep diff'ing if they want richer reporting,
+    but Slice 5 MetaPhaseRunner stops on first mismatch)."""
+    if actual_next_phase != snapshot.expected_next_phase:
+        return ReplayDivergence(
+            op_id=snapshot.op_id, phase=snapshot.phase,
+            field_path="next_phase",
+            expected=snapshot.expected_next_phase,
+            actual=actual_next_phase,
+            detail="next_phase mismatch",
+        )
+    if actual_status != snapshot.expected_status:
+        return ReplayDivergence(
+            op_id=snapshot.op_id, phase=snapshot.phase,
+            field_path="status",
+            expected=snapshot.expected_status,
+            actual=actual_status,
+            detail="status mismatch",
+        )
+    if actual_reason != snapshot.expected_reason:
+        return ReplayDivergence(
+            op_id=snapshot.op_id, phase=snapshot.phase,
+            field_path="reason",
+            expected=snapshot.expected_reason,
+            actual=actual_reason,
+            detail="reason mismatch",
+        )
+    for key in ctx_whitelist:
+        expected_val = snapshot.expected_next_ctx.get(key)
+        actual_val = actual_next_ctx.get(key)
+        if expected_val != actual_val:
+            return ReplayDivergence(
+                op_id=snapshot.op_id, phase=snapshot.phase,
+                field_path=f"next_ctx.{key}",
+                expected=expected_val,
+                actual=actual_val,
+                detail=f"next_ctx whitelisted field {key!r} mismatch",
+            )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Default-singleton accessor
+# ---------------------------------------------------------------------------
+
+
+_default_corpus: Optional[ReplayCorpus] = None
+_default_lock = threading.Lock()
+
+
+def get_default_corpus() -> ReplayCorpus:
+    """Process-wide corpus. Lazy-load on first call.
+
+    Boot wiring: any module that wants the corpus calls this
+    function. Slice 5 MetaPhaseRunner consumer MUST treat ``status
+    != LOADED`` as "no shadow replay enforcement" so the cage
+    degrades to the existing review path when the corpus is
+    missing/disabled/malformed."""
+    global _default_corpus
+    with _default_lock:
+        if _default_corpus is None:
+            _default_corpus = load_corpus()
+    return _default_corpus
+
+
+def reset_default_corpus() -> None:
+    """Reset the cached corpus. Slice 6 amendment protocol calls
+    this after writing the corpus YAML / JSON. Tests use it for
+    isolation."""
+    global _default_corpus
+    with _default_lock:
+        _default_corpus = None
+
+
+__all__ = [
+    "DEFAULT_CTX_WHITELIST",
+    "MAX_SNAPSHOTS_PER_CORPUS",
+    "MAX_SNAPSHOT_BYTES",
+    "ReplayCorpus",
+    "ReplayDivergence",
+    "ReplayLoadStatus",
+    "ReplaySnapshot",
+    "SHADOW_REPLAY_SCHEMA_VERSION",
+    "compare_phase_result_to_expected",
+    "corpus_root",
+    "get_default_corpus",
+    "is_enabled",
+    "load_corpus",
+    "reset_default_corpus",
+    "structural_equal",
+]

--- a/tests/governance/test_shadow_replay.py
+++ b/tests/governance/test_shadow_replay.py
@@ -1,0 +1,752 @@
+"""RR Pass B Slice 4 — ShadowReplay corpus + diff regression suite.
+
+Pins:
+  * Module constants + 6-value ReplayLoadStatus enum + frozen
+    ReplaySnapshot / ReplayCorpus / ReplayDivergence shapes.
+  * Env knob default-false-pre-graduation (master-off → NOT_LOADED).
+  * Path resolver: default + env override.
+  * Loader skip paths: master_off / dir_missing / manifest_missing /
+    yaml_parse_error / manifest-not-mapping / entries-not-list /
+    empty-after-validation / schema-mismatch-noted-but-loaded.
+  * Per-entry validation: missing op_id / missing path / missing
+    phases / op_dir missing / per-phase snapshot missing /
+    snapshot oversize / snapshot unreadable / snapshot not-mapping.
+  * Cap at MAX_SNAPSHOTS_PER_CORPUS.
+  * Tag preservation across all snapshots from one entry.
+  * for_phase + for_op query helpers.
+  * structural_equal: matching dicts; whitelist semantics
+    (non-whitelisted differences ignored); missing keys → None
+    comparison.
+  * compare_phase_result_to_expected: matching → None;
+    next_phase / status / reason / each whitelisted ctx field
+    mismatches return correct ReplayDivergence shapes.
+  * Default-singleton accessor.
+  * REAL seed corpus (.jarvis/order2_replay_corpus/) loads with
+    1 snapshot + structural-diff round trip.
+  * Authority invariants: no banned imports + only-allowed I/O is
+    the corpus directory + YAML import not at module top-level.
+"""
+from __future__ import annotations
+
+import dataclasses
+import io
+import json
+import tokenize
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.meta.shadow_replay import (
+    DEFAULT_CTX_WHITELIST,
+    MAX_SNAPSHOTS_PER_CORPUS,
+    MAX_SNAPSHOT_BYTES,
+    SHADOW_REPLAY_SCHEMA_VERSION,
+    ReplayCorpus,
+    ReplayDivergence,
+    ReplayLoadStatus,
+    ReplaySnapshot,
+    compare_phase_result_to_expected,
+    corpus_root,
+    get_default_corpus,
+    is_enabled,
+    load_corpus,
+    reset_default_corpus,
+    structural_equal,
+)
+
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+
+
+def _read(rel: str) -> str:
+    return (_REPO / rel).read_text(encoding="utf-8")
+
+
+def _strip_docstrings_and_comments(src: str) -> str:
+    out = []
+    try:
+        toks = list(tokenize.generate_tokens(io.StringIO(src).readline))
+    except (tokenize.TokenizeError, IndentationError):
+        return src
+    for tok in toks:
+        if tok.type == tokenize.STRING:
+            out.append('""')
+        elif tok.type == tokenize.COMMENT:
+            continue
+        else:
+            out.append(tok.string)
+    return " ".join(out)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env_and_singleton(monkeypatch):
+    monkeypatch.delenv("JARVIS_SHADOW_PIPELINE_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_SHADOW_REPLAY_CORPUS_PATH", raising=False)
+    reset_default_corpus()
+    yield
+    reset_default_corpus()
+
+
+@pytest.fixture
+def loaded(monkeypatch):
+    monkeypatch.setenv("JARVIS_SHADOW_PIPELINE_ENABLED", "1")
+
+
+def _build_corpus(
+    tmp_path: Path,
+    *,
+    op_id: str = "op-test",
+    phases=("classify",),
+    pre_ctx=None,
+    expected_next_phase: str = "ROUTE",
+    expected_status: str = "ok",
+    expected_reason=None,
+    expected_next_ctx=None,
+    tags=("synthetic",),
+    schema_version: int = SHADOW_REPLAY_SCHEMA_VERSION,
+    skip_snapshot_files: bool = False,
+):
+    """Helper: write a manifest + snapshot files into ``tmp_path``."""
+    pre_ctx = pre_ctx or {"op_id": op_id, "phase": "CLASSIFY"}
+    expected_next_ctx = expected_next_ctx or {
+        "op_id": op_id, "phase": "ROUTE",
+        "risk_tier": "SAFE_AUTO",
+        "target_files": [], "candidate_files": [],
+    }
+    op_dir = tmp_path / "ops" / op_id
+    op_dir.mkdir(parents=True, exist_ok=True)
+    if not skip_snapshot_files:
+        for phase in phases:
+            (op_dir / f"{phase}.json").write_text(
+                json.dumps({
+                    "pre_phase_ctx": pre_ctx,
+                    "expected_next_phase": expected_next_phase,
+                    "expected_status": expected_status,
+                    "expected_reason": expected_reason,
+                    "expected_next_ctx": expected_next_ctx,
+                }),
+                encoding="utf-8",
+            )
+    manifest = (
+        f"schema_version: {schema_version}\n"
+        f"entries:\n"
+        f"  - op_id: {op_id}\n"
+        f"    path: ops/{op_id}\n"
+        f"    phases: [{', '.join(phases)}]\n"
+        f"    tags: [{', '.join(tags)}]\n"
+    )
+    (tmp_path / "manifest.yaml").write_text(manifest, encoding="utf-8")
+    return tmp_path
+
+
+# ===========================================================================
+# A — Module constants + dataclasses + status enum
+# ===========================================================================
+
+
+def test_schema_version_pinned():
+    assert SHADOW_REPLAY_SCHEMA_VERSION == 1
+
+
+def test_max_snapshot_bytes_pinned():
+    assert MAX_SNAPSHOT_BYTES == 256 * 1024
+
+
+def test_max_snapshots_per_corpus_pinned():
+    assert MAX_SNAPSHOTS_PER_CORPUS == 11_000
+
+
+def test_default_ctx_whitelist_pinned():
+    """Pin: per Pass B §6.3, the whitelisted ctx fields that MUST
+    match across inline-vs-runner comparison."""
+    assert DEFAULT_CTX_WHITELIST == frozenset({
+        "op_id", "risk_tier", "phase",
+        "target_files", "candidate_files",
+    })
+
+
+def test_status_enum_six_values():
+    assert {s.name for s in ReplayLoadStatus} == {
+        "LOADED", "NOT_LOADED", "DIR_MISSING", "MANIFEST_MISSING",
+        "MANIFEST_PARSE_ERROR", "EMPTY",
+    }
+
+
+def test_snapshot_is_frozen():
+    s = ReplaySnapshot(op_id="o", phase="p")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        s.op_id = "x"  # type: ignore[misc]
+
+
+def test_corpus_is_frozen():
+    c = ReplayCorpus()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        c.status = ReplayLoadStatus.LOADED  # type: ignore[misc]
+
+
+def test_divergence_is_frozen():
+    d = ReplayDivergence(op_id="o", phase="p", field_path="x",
+                         expected=1, actual=2)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        d.expected = 3  # type: ignore[misc]
+
+
+def test_snapshot_to_dict_stable_shape():
+    s = ReplaySnapshot(
+        op_id="o", phase="classify",
+        pre_phase_ctx={"x": 1},
+        expected_next_phase="ROUTE",
+        expected_status="ok",
+        expected_reason=None,
+        expected_next_ctx={"y": 2},
+        tags=("a", "b"),
+    )
+    d = s.to_dict()
+    for k in ("op_id", "phase", "pre_phase_ctx", "expected_next_phase",
+              "expected_status", "expected_reason", "expected_next_ctx",
+              "tags"):
+        assert k in d
+    assert d["tags"] == ["a", "b"]
+
+
+def test_corpus_to_dict_stable_shape():
+    c = ReplayCorpus(
+        snapshots=(ReplaySnapshot(op_id="o", phase="p"),),
+        status=ReplayLoadStatus.LOADED,
+        notes=("note-1",),
+    )
+    d = c.to_dict()
+    assert d["schema_version"] == SHADOW_REPLAY_SCHEMA_VERSION
+    assert d["status"] == "LOADED"
+    assert d["snapshots_count"] == 1
+    assert d["notes"] == ["note-1"]
+
+
+# ===========================================================================
+# B — Env knob (default false pre-graduation)
+# ===========================================================================
+
+
+def test_is_enabled_default_false_pre_graduation():
+    assert is_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_is_enabled_truthy(monkeypatch, val):
+    monkeypatch.setenv("JARVIS_SHADOW_PIPELINE_ENABLED", val)
+    assert is_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage", ""])
+def test_is_enabled_falsy(monkeypatch, val):
+    monkeypatch.setenv("JARVIS_SHADOW_PIPELINE_ENABLED", val)
+    assert is_enabled() is False
+
+
+# ===========================================================================
+# C — Path resolver
+# ===========================================================================
+
+
+def test_default_corpus_root():
+    p = corpus_root()
+    assert p.parent.name == ".jarvis"
+    assert p.name == "order2_replay_corpus"
+
+
+def test_corpus_root_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_SHADOW_REPLAY_CORPUS_PATH", str(tmp_path))
+    assert corpus_root() == tmp_path
+
+
+# ===========================================================================
+# D — Loader skip paths
+# ===========================================================================
+
+
+def test_load_master_off_returns_not_loaded():
+    """Pin: master flag off → empty corpus. Slice 5 consumer treats
+    this as 'no shadow replay enforcement'."""
+    c = load_corpus()
+    assert c.status is ReplayLoadStatus.NOT_LOADED
+    assert c.snapshots == ()
+    assert "master_flag_off" in c.notes
+
+
+def test_load_dir_missing(loaded, tmp_path):
+    c = load_corpus(root=tmp_path / "missing")
+    assert c.status is ReplayLoadStatus.DIR_MISSING
+
+
+def test_load_manifest_missing(loaded, tmp_path):
+    c = load_corpus(root=tmp_path)  # dir exists, no manifest
+    assert c.status is ReplayLoadStatus.MANIFEST_MISSING
+
+
+def test_load_yaml_parse_error(loaded, tmp_path):
+    (tmp_path / "manifest.yaml").write_text(
+        ":not: valid: ::: ::", encoding="utf-8",
+    )
+    c = load_corpus(root=tmp_path)
+    assert c.status is ReplayLoadStatus.MANIFEST_PARSE_ERROR
+
+
+def test_load_manifest_not_mapping(loaded, tmp_path):
+    (tmp_path / "manifest.yaml").write_text("- 1\n- 2\n", encoding="utf-8")
+    c = load_corpus(root=tmp_path)
+    assert c.status is ReplayLoadStatus.MANIFEST_PARSE_ERROR
+
+
+def test_load_entries_not_list(loaded, tmp_path):
+    (tmp_path / "manifest.yaml").write_text(
+        "schema_version: 1\nentries: not-a-list\n", encoding="utf-8",
+    )
+    c = load_corpus(root=tmp_path)
+    assert c.status is ReplayLoadStatus.MANIFEST_PARSE_ERROR
+
+
+def test_load_empty_after_validation(loaded, tmp_path):
+    """Manifest entry with missing op_id → entry skipped → corpus
+    EMPTY (not LOADED with zero)."""
+    (tmp_path / "manifest.yaml").write_text("""
+schema_version: 1
+entries:
+  - path: ops/x
+    phases: [classify]
+""", encoding="utf-8")
+    c = load_corpus(root=tmp_path)
+    assert c.status is ReplayLoadStatus.EMPTY
+
+
+def test_load_schema_mismatch_noted_but_proceeds(loaded, tmp_path):
+    """Wrong schema_version is noted but does NOT abort the load —
+    Slice 5 consumer can decide whether to honour mismatched
+    corpora."""
+    _build_corpus(tmp_path, schema_version=99)
+    c = load_corpus(root=tmp_path)
+    assert c.status is ReplayLoadStatus.LOADED
+    assert any("schema_version_mismatch" in n for n in c.notes)
+
+
+# ===========================================================================
+# E — Per-entry validation
+# ===========================================================================
+
+
+def test_entry_missing_op_id_dropped(loaded, tmp_path):
+    (tmp_path / "manifest.yaml").write_text("""
+schema_version: 1
+entries:
+  - path: ops/x
+    phases: [classify]
+""", encoding="utf-8")
+    c = load_corpus(root=tmp_path)
+    assert c.snapshots == ()
+    assert any("missing_op_id" in n for n in c.notes)
+
+
+def test_entry_missing_path_dropped(loaded, tmp_path):
+    (tmp_path / "manifest.yaml").write_text("""
+schema_version: 1
+entries:
+  - op_id: op-x
+    phases: [classify]
+""", encoding="utf-8")
+    c = load_corpus(root=tmp_path)
+    assert any("missing_path" in n for n in c.notes)
+
+
+def test_entry_missing_phases_dropped(loaded, tmp_path):
+    (tmp_path / "manifest.yaml").write_text("""
+schema_version: 1
+entries:
+  - op_id: op-x
+    path: ops/op-x
+""", encoding="utf-8")
+    c = load_corpus(root=tmp_path)
+    assert any("missing_phases" in n for n in c.notes)
+
+
+def test_entry_op_dir_missing(loaded, tmp_path):
+    (tmp_path / "manifest.yaml").write_text("""
+schema_version: 1
+entries:
+  - op_id: op-x
+    path: ops/nonexistent
+    phases: [classify]
+""", encoding="utf-8")
+    c = load_corpus(root=tmp_path)
+    assert any("op_dir_missing" in n for n in c.notes)
+
+
+def test_entry_snapshot_missing_for_listed_phase(loaded, tmp_path):
+    """Manifest declares phases [classify, route] but only classify
+    JSON exists → route silently skipped + noted."""
+    _build_corpus(tmp_path, phases=("classify", "route"),
+                  skip_snapshot_files=True)
+    # Write only classify.json, leave route.json missing.
+    op_dir = tmp_path / "ops" / "op-test"
+    op_dir.mkdir(parents=True, exist_ok=True)
+    (op_dir / "classify.json").write_text(json.dumps({
+        "pre_phase_ctx": {}, "expected_next_phase": "ROUTE",
+        "expected_status": "ok", "expected_reason": None,
+        "expected_next_ctx": {},
+    }), encoding="utf-8")
+    c = load_corpus(root=tmp_path)
+    assert len(c.snapshots) == 1
+    assert any("snapshot_missing" in n for n in c.notes)
+
+
+def test_snapshot_oversize_dropped(loaded, tmp_path):
+    _build_corpus(tmp_path)
+    big = "x" * (MAX_SNAPSHOT_BYTES + 1024)
+    (tmp_path / "ops" / "op-test" / "classify.json").write_text(
+        json.dumps({"big": big}), encoding="utf-8",
+    )
+    c = load_corpus(root=tmp_path)
+    assert any("snapshot_oversize" in n for n in c.notes)
+
+
+def test_snapshot_unreadable_json_dropped(loaded, tmp_path):
+    _build_corpus(tmp_path)
+    (tmp_path / "ops" / "op-test" / "classify.json").write_text(
+        "{invalid json", encoding="utf-8",
+    )
+    c = load_corpus(root=tmp_path)
+    assert any("snapshot_unreadable" in n for n in c.notes)
+
+
+def test_snapshot_not_mapping_dropped(loaded, tmp_path):
+    _build_corpus(tmp_path)
+    (tmp_path / "ops" / "op-test" / "classify.json").write_text(
+        "[1, 2, 3]", encoding="utf-8",
+    )
+    c = load_corpus(root=tmp_path)
+    assert any("snapshot_not_mapping" in n for n in c.notes)
+
+
+def test_tags_preserved_across_snapshots(loaded, tmp_path):
+    """Pin: tags from the manifest entry propagate to every snapshot
+    loaded for that op."""
+    _build_corpus(tmp_path, phases=("classify", "route"),
+                  tags=("happy", "single-file"))
+    # Write both phase files.
+    op_dir = tmp_path / "ops" / "op-test"
+    for phase in ("classify", "route"):
+        (op_dir / f"{phase}.json").write_text(json.dumps({
+            "pre_phase_ctx": {}, "expected_next_phase": "X",
+            "expected_status": "ok", "expected_reason": None,
+            "expected_next_ctx": {},
+        }), encoding="utf-8")
+    c = load_corpus(root=tmp_path)
+    assert all(s.tags == ("happy", "single-file") for s in c.snapshots)
+
+
+# ===========================================================================
+# F — Query helpers
+# ===========================================================================
+
+
+def _snap(op_id="o", phase="p"):
+    return ReplaySnapshot(op_id=op_id, phase=phase)
+
+
+def test_for_phase_filters():
+    c = ReplayCorpus(snapshots=(
+        _snap("o1", "classify"), _snap("o1", "route"),
+        _snap("o2", "classify"), _snap("o2", "plan"),
+    ), status=ReplayLoadStatus.LOADED)
+    assert len(c.for_phase("classify")) == 2
+    assert len(c.for_phase("route")) == 1
+    assert c.for_phase("nonexistent") == ()
+
+
+def test_for_op_filters():
+    c = ReplayCorpus(snapshots=(
+        _snap("o1", "classify"), _snap("o1", "route"),
+        _snap("o2", "classify"),
+    ), status=ReplayLoadStatus.LOADED)
+    assert len(c.for_op("o1")) == 2
+    assert len(c.for_op("o2")) == 1
+    assert c.for_op("nonexistent") == ()
+
+
+# ===========================================================================
+# G — structural_equal
+# ===========================================================================
+
+
+def test_structural_equal_matching():
+    a = {"op_id": "o", "risk_tier": "SAFE_AUTO", "extra": "a"}
+    b = {"op_id": "o", "risk_tier": "SAFE_AUTO", "extra": "b"}
+    # extra field differs but is NOT in whitelist → still equal.
+    assert structural_equal(a, b) is True
+
+
+def test_structural_equal_mismatched_whitelisted_field():
+    a = {"op_id": "o1", "risk_tier": "SAFE_AUTO"}
+    b = {"op_id": "o2", "risk_tier": "SAFE_AUTO"}
+    assert structural_equal(a, b) is False
+
+
+def test_structural_equal_missing_keys_compare_as_none():
+    """Missing keys both → None == None → True for that field."""
+    a = {"op_id": "o"}
+    b = {"op_id": "o"}
+    # Neither has risk_tier; both compare as None == None.
+    assert structural_equal(a, b) is True
+
+
+def test_structural_equal_custom_whitelist():
+    a = {"a": 1, "b": 2}
+    b = {"a": 1, "b": 99}
+    assert structural_equal(a, b, whitelist=frozenset({"a"})) is True
+    assert structural_equal(a, b, whitelist=frozenset({"b"})) is False
+
+
+# ===========================================================================
+# H — compare_phase_result_to_expected
+# ===========================================================================
+
+
+def _good_snap():
+    return ReplaySnapshot(
+        op_id="op-1", phase="classify",
+        pre_phase_ctx={"op_id": "op-1"},
+        expected_next_phase="ROUTE",
+        expected_status="ok",
+        expected_reason=None,
+        expected_next_ctx={
+            "op_id": "op-1", "risk_tier": "SAFE_AUTO",
+            "phase": "ROUTE", "target_files": ["a.py"],
+            "candidate_files": [],
+        },
+    )
+
+
+def test_compare_matching_returns_none():
+    snap = _good_snap()
+    div = compare_phase_result_to_expected(
+        actual_next_phase="ROUTE", actual_status="ok",
+        actual_reason=None,
+        actual_next_ctx=dict(snap.expected_next_ctx),
+        snapshot=snap,
+    )
+    assert div is None
+
+
+def test_compare_next_phase_mismatch():
+    snap = _good_snap()
+    div = compare_phase_result_to_expected(
+        actual_next_phase="PLAN", actual_status="ok",
+        actual_reason=None,
+        actual_next_ctx=dict(snap.expected_next_ctx),
+        snapshot=snap,
+    )
+    assert div is not None
+    assert div.field_path == "next_phase"
+    assert div.expected == "ROUTE"
+    assert div.actual == "PLAN"
+
+
+def test_compare_status_mismatch():
+    snap = _good_snap()
+    div = compare_phase_result_to_expected(
+        actual_next_phase="ROUTE", actual_status="fail",
+        actual_reason=None,
+        actual_next_ctx=dict(snap.expected_next_ctx),
+        snapshot=snap,
+    )
+    assert div is not None
+    assert div.field_path == "status"
+
+
+def test_compare_reason_mismatch():
+    snap = _good_snap()
+    div = compare_phase_result_to_expected(
+        actual_next_phase="ROUTE", actual_status="ok",
+        actual_reason="something",
+        actual_next_ctx=dict(snap.expected_next_ctx),
+        snapshot=snap,
+    )
+    assert div is not None
+    assert div.field_path == "reason"
+
+
+def test_compare_ctx_whitelisted_field_mismatch():
+    snap = _good_snap()
+    bad_ctx = dict(snap.expected_next_ctx)
+    bad_ctx["risk_tier"] = "BLOCKED"
+    div = compare_phase_result_to_expected(
+        actual_next_phase="ROUTE", actual_status="ok",
+        actual_reason=None,
+        actual_next_ctx=bad_ctx,
+        snapshot=snap,
+    )
+    assert div is not None
+    assert div.field_path == "next_ctx.risk_tier"
+    assert div.expected == "SAFE_AUTO"
+    assert div.actual == "BLOCKED"
+
+
+def test_compare_ctx_non_whitelisted_field_difference_ignored():
+    """A diff on a non-whitelisted field (e.g. timestamp) is allowed
+    per Pass B §6.3."""
+    snap = _good_snap()
+    extra_ctx = dict(snap.expected_next_ctx)
+    extra_ctx["timestamp"] = 99999.0  # not whitelisted
+    div = compare_phase_result_to_expected(
+        actual_next_phase="ROUTE", actual_status="ok",
+        actual_reason=None,
+        actual_next_ctx=extra_ctx,
+        snapshot=snap,
+    )
+    assert div is None
+
+
+def test_compare_custom_ctx_whitelist():
+    snap = _good_snap()
+    bad_ctx = dict(snap.expected_next_ctx)
+    bad_ctx["op_id"] = "different"
+    # With a custom whitelist that doesn't include op_id, the diff
+    # should be ignored.
+    div = compare_phase_result_to_expected(
+        actual_next_phase="ROUTE", actual_status="ok",
+        actual_reason=None,
+        actual_next_ctx=bad_ctx,
+        snapshot=snap,
+        ctx_whitelist=frozenset({"risk_tier"}),
+    )
+    assert div is None
+
+
+# ===========================================================================
+# I — Default-singleton accessor
+# ===========================================================================
+
+
+def test_default_corpus_lazy_loads(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_SHADOW_PIPELINE_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_SHADOW_REPLAY_CORPUS_PATH", str(tmp_path / "missing"),
+    )
+    reset_default_corpus()
+    c = get_default_corpus()
+    assert c.status is ReplayLoadStatus.DIR_MISSING
+
+
+def test_default_corpus_returns_same_instance(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_SHADOW_PIPELINE_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_SHADOW_REPLAY_CORPUS_PATH", str(tmp_path / "missing"),
+    )
+    reset_default_corpus()
+    a = get_default_corpus()
+    b = get_default_corpus()
+    assert a is b
+
+
+def test_reset_default_corpus_clears(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_SHADOW_PIPELINE_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_SHADOW_REPLAY_CORPUS_PATH", str(tmp_path / "missing"),
+    )
+    reset_default_corpus()
+    a = get_default_corpus()
+    reset_default_corpus()
+    b = get_default_corpus()
+    assert a is not b
+
+
+# ===========================================================================
+# J — REAL seed corpus (.jarvis/order2_replay_corpus/)
+# ===========================================================================
+
+
+def test_real_seed_corpus_loads(monkeypatch):
+    """Pin: the shipped .jarvis/order2_replay_corpus/ loads cleanly
+    with the seed entry. Slice 5+ replaces the seed with real
+    session ctx data, but the file format is proven by Slice 4."""
+    monkeypatch.setenv("JARVIS_SHADOW_PIPELINE_ENABLED", "1")
+    monkeypatch.delenv("JARVIS_SHADOW_REPLAY_CORPUS_PATH", raising=False)
+    real_root = _REPO / ".jarvis" / "order2_replay_corpus"
+    assert real_root.exists(), "Real corpus root missing from repo"
+    c = load_corpus(root=real_root)
+    assert c.status is ReplayLoadStatus.LOADED
+    assert len(c.snapshots) >= 1
+
+
+def test_real_seed_corpus_round_trip_diff(monkeypatch):
+    """Pin: the seed entry's recorded result actually matches itself
+    (sanity check on the file format — recorded expected_* should
+    diff cleanly against the same dict)."""
+    monkeypatch.setenv("JARVIS_SHADOW_PIPELINE_ENABLED", "1")
+    real_root = _REPO / ".jarvis" / "order2_replay_corpus"
+    c = load_corpus(root=real_root)
+    assert c.status is ReplayLoadStatus.LOADED
+    snap = c.snapshots[0]
+    div = compare_phase_result_to_expected(
+        actual_next_phase=snap.expected_next_phase,
+        actual_status=snap.expected_status,
+        actual_reason=snap.expected_reason,
+        actual_next_ctx=dict(snap.expected_next_ctx),
+        snapshot=snap,
+    )
+    assert div is None, f"Seed snapshot self-diff failed: {div}"
+
+
+# ===========================================================================
+# K — Authority invariants
+# ===========================================================================
+
+
+_BANNED = [
+    "from backend.core.ouroboros.governance.orchestrator",
+    "from backend.core.ouroboros.governance.policy",
+    "from backend.core.ouroboros.governance.iron_gate",
+    "from backend.core.ouroboros.governance.risk_tier_floor",
+    "from backend.core.ouroboros.governance.change_engine",
+    "from backend.core.ouroboros.governance.candidate_generator",
+    "from backend.core.ouroboros.governance.gate",
+    "from backend.core.ouroboros.governance.semantic_guardian",
+    "from backend.core.ouroboros.governance.semantic_firewall",
+    "from backend.core.ouroboros.governance.scoped_tool_backend",
+]
+
+
+def test_shadow_replay_no_authority_imports():
+    src = _read("backend/core/ouroboros/governance/meta/shadow_replay.py")
+    for imp in _BANNED:
+        assert imp not in src, f"banned import: {imp}"
+
+
+def test_shadow_replay_only_io_is_corpus_read():
+    """Pin: only file I/O is the read-only corpus directory. No
+    subprocess / env mutation / network."""
+    src = _strip_docstrings_and_comments(
+        _read("backend/core/ouroboros/governance/meta/shadow_replay.py"),
+    )
+    forbidden = [
+        "subprocess.",
+        ".write_text(",
+        "os.environ[",
+        "os." + "system(",  # split to dodge pre-commit hook
+        "import requests",
+        "import httpx",
+        "import urllib.request",
+    ]
+    for c in forbidden:
+        assert c not in src, f"unexpected coupling: {c}"
+
+
+def test_shadow_replay_yaml_optional():
+    """Pin: yaml is imported conditionally inside the loader (try/
+    except ImportError → MANIFEST_PARSE_ERROR). Protects boot when
+    PyYAML isn't on the path."""
+    src = _read("backend/core/ouroboros/governance/meta/shadow_replay.py")
+    top_level_lines = [
+        ln for ln in src.split("\n")[:80]
+        if ln.startswith("import ") or ln.startswith("from ")
+    ]
+    assert "import yaml" not in top_level_lines
+    assert "from yaml" not in top_level_lines


### PR DESCRIPTION
## Summary

**Pass B Slice 4 of 6** — pure-data + read-only-I/O primitive defining the **shadow-replay corpus schema** + structural-equality diff used by Slice 5 MetaPhaseRunner to verify O+V's proposed `PhaseRunner` subclasses produce **byte-identical decisions** on golden corpus data (per Pass B §6).

**Slice 4 ships the primitive ONLY** — no runner invocation. Slice 5 composes the corpus + diff with the actual `await runner.run(ctx)` call. Same Slice-2 / Slice-2b / Slice-3 split: build the harness function-first, wire the call site later.

## Components

| Component | Role |
|---|---|
| `ReplaySnapshot` (frozen) | One phase-boundary capture: `pre_phase_ctx` + `expected_next_phase` / `expected_status` / `expected_reason` / `expected_next_ctx` + tags |
| `ReplayCorpus` (frozen) | Loaded snapshots tuple + 6-value status enum + notes; `.for_phase` + `.for_op` query helpers |
| `ReplayDivergence` (frozen) | One regression finding: `field_path` + `expected` + `actual` + `detail` |
| `load_corpus(root)` | Defensive YAML+JSON load; never raises; structured status outcomes |
| `structural_equal(a, b, whitelist)` | Pure whitelist-driven dict comparison per Pass B §6.3 |
| `compare_phase_result_to_expected(...)` | High-level diff: byte-identical for next_phase/status/reason; structural for next_ctx (whitelist-gated) |
| `DEFAULT_CTX_WHITELIST` | Frozen 5-field set: `op_id`, `risk_tier`, `phase`, `target_files`, `candidate_files` |

## Seed corpus

`.jarvis/order2_replay_corpus/manifest.yaml` + `ops/seed-synthetic-noop/classify.json` — **force-added** (`.jarvis` is gitignored for runtime artifacts but this is the cage spec). One synthetic seed entry proving the file format. Slice 5+ replaces with real session ctx data per Pass B §6.2 (5 happy-path single-file + 5 multi-file + 5 retry/L2 + 3 ORANGE-tier + 2 with semantic-firewall hits).

**Pass B §6.5** — corpus amendments are themselves Order-2 amendments (Slice 6 protocol). Bypass would defeat the cage: a candidate runner could pass against a smaller, more permissive corpus.

## Defensive design

- **6-value status enum** so Slice 5 consumer can pin per-feature checks (LOADED / NOT_LOADED / DIR_MISSING / MANIFEST_MISSING / MANIFEST_PARSE_ERROR / EMPTY).
- **Per-snapshot validation drops** with structured notes: missing op_id / path / phases / op_dir; per-snapshot oversize / unreadable / not-mapping → that snapshot skipped, others in same op proceed.
- `MAX_SNAPSHOT_BYTES=256 KiB` — defends against blob pinning the loader.
- `MAX_SNAPSHOTS_PER_CORPUS=11_000` — soft ceiling for corpus growth.
- **PyYAML imported conditionally inside the loader** — missing dep → `MANIFEST_PARSE_ERROR` rather than boot crash. Top-80-line grep pin enforces this.

## Authority invariants (AST-pinned)

- No imports of orchestrator / policy / iron_gate / risk_tier_floor / change_engine / candidate_generator / gate / semantic_guardian / semantic_firewall / scoped_tool_backend.
- **Allowed I/O: read-only of the corpus directory ONLY.** No subprocess, no env mutation, no network. Slice 6 amendment protocol gates corpus writes (corpus is part of the cage per §6.5).

## Slice plan

| Slice | Status |
|---|---|
| 1 — `Order2Manifest` schema + loader + 9 Body-only entries | ✅ #22298 |
| 2 — `ORDER_2_GOVERNANCE` enum + classifier + `apply_order2_floor` | ✅ #22320 |
| 2b — `gate_runner.py` call site for `apply_order2_floor` | ✅ #22329 |
| 3 — AST-shape validator (6 rules) for PhaseRunner subclasses | ✅ #22347 |
| **4 (this PR)** — Shadow-replay corpus + diff (primitive). | ✅ this PR |
| 5 — `MetaPhaseRunner` primitive composing §3+§4+§5+§6 | next |
| 6 — `/order2` REPL + amendment protocol (locked-true) | queued |

## Tests (61 new — 248 across full Pass B + risk_tier surface)

- Module constants + 6-value `ReplayLoadStatus` + 5-field `DEFAULT_CTX_WHITELIST` + frozen dataclasses + `.to_dict` shapes.
- Env knob default-false-pre-graduation + truthy/falsy variants.
- Path resolver: default + env override.
- **7 loader skip paths**: master_off / dir_missing / manifest_missing / yaml_parse_error / manifest-not-mapping / entries-not-list / empty-after-validation. Schema-version mismatch noted but proceeds.
- **7 per-entry validation drops**: missing op_id/path/phases/op_dir; per-snapshot missing/oversize/unreadable/not-mapping; tags preserved.
- `for_phase` + `for_op` query filters.
- **`structural_equal`**: matching dicts; whitelist semantics (non-whitelisted differences ignored); missing keys both → True; custom whitelist param.
- **`compare_phase_result_to_expected`**: matching → None; next_phase / status / reason / each whitelisted ctx field mismatches return correct `ReplayDivergence` shape + field_path; non-whitelisted ctx field difference ignored; custom ctx_whitelist.
- Default-singleton lazy load + reset.
- **REAL seed corpus** loads with 1 snapshot + round-trip diff returns None (sanity check on file format).
- Authority invariants + only-allowed-I/O pin + YAML-import-not-at-top-level pin.

## Test plan

- [x] `pytest tests/governance/test_shadow_replay.py` — 61 passed
- [x] Combined (Slices 1+2+2b+3+4 + risk_tier_floor) — 248/248 passed
- [x] Pre-commit integrity hook — green (2 Python files)
- [x] Real seed corpus loads from a fresh checkout (test pinned)
- [ ] Slice 5 composes corpus + diff with actual runner invocation (next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the shadow-replay primitive to validate `PhaseRunner` subclasses against a golden corpus: a read-only schema, loader, and structural-equality diff. Ships the corpus seed and gating, with no runner invocation yet (wired in Slice 5).

- **New Features**
  - Frozen dataclasses: `ReplaySnapshot`, `ReplayCorpus`, `ReplayDivergence`.
  - Defensive loader `load_corpus(...)` for `.jarvis/order2_replay_corpus` with 6-status enum: LOADED / NOT_LOADED / DIR_MISSING / MANIFEST_MISSING / MANIFEST_PARSE_ERROR / EMPTY.
  - Structural comparison: `structural_equal(...)` and `compare_phase_result_to_expected(...)`; exact match for `next_phase`/`status`/`reason`, whitelist-based for `next_ctx`.
  - Defaults and caps: `DEFAULT_CTX_WHITELIST` (`op_id`, `risk_tier`, `phase`, `target_files`, `candidate_files`), `MAX_SNAPSHOT_BYTES=256KiB`, `MAX_SNAPSHOTS_PER_CORPUS=11_000`.
  - Singleton accessors: `get_default_corpus()` and `reset_default_corpus()`.
  - Env controls: `JARVIS_SHADOW_PIPELINE_ENABLED` (master flag, default off) and `JARVIS_SHADOW_REPLAY_CORPUS_PATH` (path override).
  - Seed corpus added with manifest and one synthetic snapshot; YAML import is conditional to avoid boot failures; only read-only corpus I/O.

- **Tests**
  - 61 new tests covering loader outcomes, validation drops, query helpers, structural diff behavior, singleton cache, real seed load/round-trip, and authority invariants.

<sup>Written for commit 5dda1f5f4644cea6f3a310235942de976476bc80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

