### PR TITLE
feat(cron-installer): arm contract + circuit-breaker flags in cron entry

### DIFF
--- a/scripts/install_live_fire_soak_cron.sh
+++ b/scripts/install_live_fire_soak_cron.sh
@@ -85,12 +85,40 @@ EOF
 }
 
 build_cron_block() {
+    # Three master flags armed in the cron entry:
+    #
+    # 1. JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED=true — original P9.1
+    #    master switch. Cron-only authority; no production-runtime side
+    #    effect when off.
+    #
+    # 2. JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true — P9.2 contract
+    #    consultation. Without this, the default classifier silently
+    #    graduates 0-op sessions as CLEAN (the once-proof on session
+    #    bt-2026-04-27-162115 demonstrated this: outcome=clean,
+    #    ops_count=0, $0.0299 cost — would have ticked the flag's
+    #    clean-count by 1 toward graduation despite the substrate
+    #    never actually firing). Contract consultation forces the
+    #    P9.2 predicate_requires_decision_trace_rows guard to
+    #    DOWNGRADE 0-op CLEAN to RUNNER, blocking false graduation.
+    #
+    # 3. JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED=true — Option C
+    #    circuit breaker. When DW topology blocks BG generation
+    #    (e.g. Gemma 4 31B stream-stalls), op skips GENERATE phase
+    #    entirely + emits ONE clean [CircuitBreaker] log line vs
+    #    today's multi-line cascade. Late-detection path remains
+    #    the fallback if circuit-breaker raises (try/except wrap
+    #    in orchestrator).
+    #
+    # All three default OFF in the codebase. Cron sets them locally
+    # for the subprocess invocation only — no global state mutation.
     cat <<EOF
 $BEGIN_MARKER
 # Phase 9.1 — Live-Fire Graduation Soak Harness (auto-installed)
 # Master flag JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED gates execution.
 # Operator pause: export JARVIS_LIVE_FIRE_GRADUATION_SOAK_PAUSED=true
-$CRON_SCHEDULE cd $REPO_ROOT && JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED=true /usr/bin/env python3 $HARNESS_SCRIPT run --cost-cap $COST_CAP --max-wall-seconds $WALL_CAP --timeout $TIMEOUT >> $LOG_DIR/$LOG_FILE_TEMPLATE 2>&1
+# Contract consultation (P9.2) blocks 0-op false-graduation.
+# Circuit breaker (Option C) keeps logs mathematically pure on DW topology block.
+$CRON_SCHEDULE cd $REPO_ROOT && JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED=true JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED=true /usr/bin/env python3 $HARNESS_SCRIPT run --cost-cap $COST_CAP --max-wall-seconds $WALL_CAP --timeout $TIMEOUT >> $LOG_DIR/$LOG_FILE_TEMPLATE 2>&1
 $END_MARKER
 EOF
 }
@@ -172,7 +200,11 @@ run_once() {
         echo -e "${DIM}  setting=true for this single invocation${RESET}"
     fi
     cd "$REPO_ROOT"
+    # --once mirrors the cron entry's three master flags so a
+    # first-proof run reproduces production cadence behavior.
     JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED=true \
+        JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true \
+        JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED=true \
         python3 "$HARNESS_SCRIPT" run \
         --cost-cap "$COST_CAP" \
         --max-wall-seconds "$WALL_CAP" \

--- a/tests/governance/test_install_live_fire_soak_cron.py
+++ b/tests/governance/test_install_live_fire_soak_cron.py
@@ -105,3 +105,78 @@ def test_dry_run_includes_log_redirect():
 def test_dry_run_carries_pause_documentation():
     r = _run(["--dry-run"])
     assert "JARVIS_LIVE_FIRE_GRADUATION_SOAK_PAUSED" in r.stdout
+
+
+# ---------------------------------------------------------------------------
+# 2026-04-27 update — three-master-flag cron entry
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_arms_graduation_contract():
+    """JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true is set in the
+    cron entry. Without this flag, the default classifier silently
+    graduates 0-op sessions as CLEAN — once-proof on session
+    bt-2026-04-27-162115 demonstrated this explicitly."""
+    r = _run(["--dry-run"])
+    assert (
+        "JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true" in r.stdout
+    )
+
+
+def test_dry_run_arms_circuit_breaker():
+    """JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED=true is set in the
+    cron entry so Option C circuit breaker fires pre-GENERATE on
+    DW topology block (vs late-detection messy-log path)."""
+    r = _run(["--dry-run"])
+    assert (
+        "JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED=true" in r.stdout
+    )
+
+
+def test_dry_run_three_master_flags_in_correct_order():
+    """The cron entry must arm all three master flags BEFORE
+    invoking python — env-on-prefix syntax. Order: soak, contract,
+    circuit-breaker. Not strictly required, but pinned for review-
+    friendly diffs."""
+    r = _run(["--dry-run"])
+    soak_idx = r.stdout.index(
+        "JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED=true",
+    )
+    contract_idx = r.stdout.index(
+        "JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true",
+    )
+    cb_idx = r.stdout.index(
+        "JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED=true",
+    )
+    py_idx = r.stdout.index("/usr/bin/env python3")
+    assert soak_idx < contract_idx < cb_idx < py_idx
+
+
+def test_dry_run_documents_contract_in_comment_block():
+    """Operators reading the crontab should see why each flag is
+    set. Pin the comment block."""
+    r = _run(["--dry-run"])
+    assert "Contract consultation (P9.2) blocks 0-op" in r.stdout
+    assert "Circuit breaker (Option C)" in r.stdout
+
+
+def test_dry_run_only_one_set_of_three_flags():
+    """Bit-rot guard: re-running --dry-run after a refactor must
+    NOT accidentally double the flag block (e.g. a buggy edit that
+    appends a second cron line). Each master flag literal appears
+    EXACTLY ONCE in the rendered cron entry."""
+    r = _run(["--dry-run"])
+    for flag in [
+        "JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED=true",
+        "JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true",
+        "JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED=true",
+    ]:
+        # The `=true` literal appears EXACTLY ONCE — on the cron
+        # line itself. The comment block names the flags by name
+        # only (without `=true` suffix). A buggy refactor that
+        # appends a second cron line would surface as count > 1.
+        count = r.stdout.count(flag)
+        assert count == 1, (
+            f"flag {flag!r} appeared {count}× in dry-run; expected 1 "
+            "(cron line only)"
+        )


### PR DESCRIPTION
## Summary

Per the once-proof on session `bt-2026-04-27-162115` (PR #25229 + Phase 9.1c diagnostics): the cron-installed entry was missing two master flags that are essential for cadence correctness:

| Missing flag | Why it matters |
| --- | --- |
| `JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true` | **Without this, the default classifier silently graduates 0-op sessions as CLEAN.** The once-proof produced `ops_count=0`, `cost=$0.0299`, `complete/idle_timeout` and was classified `clean` — would have ticked the flag's clean-count by 1 toward graduation despite the substrate never actually firing. Three such sessions = false graduation. |
| `JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED=true` | Without this, the Option C circuit breaker (PR #25229) never fires. BG ops blocked by DW topology (Gemma 4 31B stream-stalls observed in the once-proof) enter GENERATE → raise → graceful-accept, producing multi-line messy log cascade vs ONE clean `[CircuitBreaker]` line. |

## What this PR ships

Arms **all three** master flags in both:

1. **Cron entry** (`build_cron_block`):
   ```
   0 */8 * * * cd /repo && \
     JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED=true \
     JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true \
     JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED=true \
     /usr/bin/env python3 .../live_fire_graduation_soak.py run \
     --cost-cap 0.50 --max-wall-seconds 2400 --timeout 3600 \
     >> .jarvis/live_fire_soak_logs/<ts>.log 2>&1
   ```

2. **`--once` first-proof mode** (`run_once`): mirrors the same three flags so a first-proof reproduces production cadence behavior.

**Defense-in-depth**: defaults remain `false` in the codebase. Cron sets them **locally for the subprocess invocation only** — no global state mutation. Operators can disable any one by editing the crontab block (`--remove` + reinstall).

## Layered evidence

**5 new regression pins** (`tests/governance/test_install_live_fire_soak_cron.py`):

| Pin | What |
| --- | --- |
| `test_dry_run_arms_graduation_contract` | `JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true` literal present |
| `test_dry_run_arms_circuit_breaker` | `JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED=true` literal present |
| `test_dry_run_three_master_flags_in_correct_order` | `soak < contract < circuit-breaker < python` ordering for review-friendly diffs |
| `test_dry_run_documents_contract_in_comment_block` | Operator-readable comments explain why each flag is set |
| `test_dry_run_only_one_set_of_three_flags` | **Bit-rot guard** — each flag literal appears EXACTLY once on the cron line (catches accidental duplication on refactor) |

**Combined regression: 608/608 green** across cron installer + circuit breaker + Phase 9 + watchdog stack.

## Cron-readiness impact — the cadence is now CORRECTNESS-SAFE

With these three flags wired in, the cron cadence:

- **Correctly classifies 0-op sessions as RUNNER** (blocks graduation) instead of CLEAN (false graduation) — protects all 24 substrate flags from premature graduation
- Produces **one clean log line** per DW-topology-blocked BG op instead of multi-line cascade
- Maintains **identical downstream ledger row shape** (downstream consumers grep `circuit_breaker_dw_topology_blocked` same as today's `background_dw_failure`)

## Operator next-steps after merge

```bash
# Re-run the once-proof — should now produce a RUNNER-classified
# 0-op session (vs prior CLEAN false-graduation):
bash scripts/install_live_fire_soak_cron.sh --once

# Inspect the new evidence row — outcome should be RUNNER, NOT CLEAN:
tail -1 .jarvis/live_fire_graduation_history.jsonl | python3 -m json.tool

# If RUNNER as expected → install the cron (cadence is now safe):
bash scripts/install_live_fire_soak_cron.sh --install
```

## Test plan

- [x] `pytest tests/governance/test_install_live_fire_soak_cron.py` (16 pass)
- [x] Combined regression: 608/608 green across all adjacent test suites
- [x] Manual smoke verified — `bash scripts/install_live_fire_soak_cron.sh --dry-run` renders all three flags in correct order with documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Arms three master flags in the live-fire soak cron and --once mode to enforce the graduation contract and enable the DW topology circuit breaker. Prevents false graduation of 0-op sessions and reduces noisy logs.

- **Bug Fixes**
  - Cron entry now sets JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED, JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT, and JARVIS_DW_TOPOLOGY_EARLY_REJECT_ENABLED before the Python invocation (with brief inline docs).
  - --once mirrors the same three flags for reproducible first-proof behavior.
  - Flags are scoped to the subprocess; codebase defaults remain false.
  - Tests: added 5 dry-run pins to verify presence, order, documentation, and single-instance of the flags.

<sup>Written for commit 385d27f07d395fb8ea6b4359b4fd0fcbf8e87db0. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/25256?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

