### PR TITLE
feat(topology-sentinel): Slice 1 — foundation module + 62-test spine

### DIFF
--- a/backend/core/ouroboros/governance/topology_sentinel.py
+++ b/backend/core/ouroboros/governance/topology_sentinel.py
@@ -940,7 +940,10 @@ class TopologySentinel:
         self._breakers: Dict[str, Any] = {}     # model_id -> CircuitBreaker
         self._snapshots: Dict[str, EndpointSnapshot] = {}
         self._ramps: Dict[str, SlowStartRamp] = {}
-        self._lock = threading.Lock()
+        # RLock — force_severed/force_healthy hold the lock then call
+        # register_endpoint which also acquires it. Same re-entrancy
+        # pattern that bit posture_observer (slice5_arc_a fix).
+        self._lock = threading.RLock()
         self._probe_task: Optional[asyncio.Task] = None
         self._stopping = asyncio.Event()
         self._daily_probe_cost_usd = 0.0

--- a/backend/core/ouroboros/governance/topology_sentinel.py
+++ b/backend/core/ouroboros/governance/topology_sentinel.py
@@ -1,0 +1,1526 @@
+"""AsyncTopologySentinel — Slice 1 (foundation, no consumers).
+
+The Sentinel replaces the static ``dw_allowed: false`` blocks in
+``brain_selection_policy.yaml`` with a live, asynchronous, per-model
+health observer driven by:
+
+  1. **Active probing** — context-weighted (light + heavy) probes on a
+     jittered exponential backoff schedule (existing
+     ``preemption_fsm._compute_backoff_ms`` with ``full_jitter=True``).
+  2. **Passive failure ingest** — live-traffic exceptions reported by
+     ``candidate_generator`` carry heavier weight than probe failures,
+     because they're load-realistic.
+  3. **Slow-start ramp** — on OPEN→HALF_OPEN→CLOSED recovery, BG/SPEC
+     ops drain through a leaky-bucket capacity schedule rather than
+     stampeding the freshly-recovered endpoint.
+  4. **Persistent state** — current snapshot + transition history land
+     on disk every transition; on boot the Sentinel hydrates from
+     ``.jarvis/topology_sentinel_current.json``, refusing to attempt
+     DW for the remainder of an in-flight SEVERED window.
+
+This module is the **foundation** layer: state machine, prober, ramp,
+persistence. **Slice 1 ships it isolated** — no orchestrator wiring,
+no candidate_generator consultation, no provider topology refactor.
+The behavior of the running system is byte-identical pre- and post-
+merge of Slice 1.
+
+## Authority posture (AST-pinned in tests)
+
+  * **Top-level imports**: stdlib + asyncio + typing only. Every
+    governance/provider symbol is imported lazily inside method
+    bodies so this module can be loaded without booting the
+    orchestrator. Test ``test_top_level_imports_stdlib_only``
+    enforces this.
+  * **No primitive duplication**: 3-state FSM is
+    ``rate_limiter.CircuitBreaker``; backoff is
+    ``preemption_fsm._compute_backoff_ms``; rate-limit primitive is
+    ``rate_limiter.TokenBucket``. Test ``test_no_local_fsm_or_bucket``
+    asserts no class definitions named ``*Breaker`` / ``*Bucket`` /
+    ``*Backoff`` exist in this file.
+  * **No orchestrator/policy/iron_gate imports**: AST-pinned. The
+    Sentinel is a pure observer; cascade-decision authority lives in
+    ``candidate_generator`` (Slice 3).
+  * **NEVER raises**: every public method swallows exceptions and
+    returns a fail-safe value. ``get_state`` defaults to
+    ``BreakerState.CLOSED`` when the sentinel is uninitialized so
+    Slice 3's cascade matrix can interpret "unknown" as "let it try"
+    rather than "force cascade" (which would be a cascade storm on
+    boot before the first probe completes).
+
+## Boot-loop protection (the directive's primary correctness goal)
+
+A process killed mid-SEVERED would, in a memory-only design, init
+its replacement to CLOSED on next boot — first BG op would attempt
+DW, stream-stall, cascade to Claude. Repeat per-op until the in-
+memory streak rebuilds. That is the boot-loop Claude-burn the
+directive forbids.
+
+Mitigation: the persisted snapshot carries ``state``, ``opened_at``,
+and ``backoff_idx``. On hydrate, if ``state == OPEN`` and
+``opened_at + recovery_timeout_s > now``, the new sentinel rebuilds
+its ``CircuitBreaker`` already in OPEN with the original
+``opened_at``. The next ``check()`` therefore reproduces exactly the
+same rejection that would have fired pre-restart. No probe burn,
+no Claude burn, no thrash.
+
+## Master flag
+
+``JARVIS_TOPOLOGY_SENTINEL_ENABLED`` (default ``false``). When off,
+the module is fully importable and tests pass; the singleton
+``get_default_sentinel()`` returns a sentinel with ``start()`` not
+called and every ``get_state(...)`` returning ``CLOSED`` (fail-open
+to legacy yaml authority — no behavior change).
+
+When on, callers (Slice 3+) consult ``get_state`` for routing
+decisions. The Sentinel itself doesn't change cascade behavior;
+that's the cascade-matrix in candidate_generator's job.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import json
+import logging
+import os
+import random
+import tempfile
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_VERSION = "topology_sentinel.1"
+
+
+# ---------------------------------------------------------------------------
+# Env helpers — same idiom as posture_observer / posture_store
+# ---------------------------------------------------------------------------
+
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in _TRUTHY
+
+
+def _env_int(name: str, default: int, minimum: int = 0) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_path(name: str, default: str) -> Path:
+    raw = os.environ.get(name)
+    return Path(raw) if raw else Path(default)
+
+
+# ---------------------------------------------------------------------------
+# Master flag + tunables
+# ---------------------------------------------------------------------------
+
+
+def is_sentinel_enabled() -> bool:
+    """Master flag — ``JARVIS_TOPOLOGY_SENTINEL_ENABLED`` (default
+    ``false``). When off, ``get_state`` returns ``CLOSED`` for every
+    ``model_id`` and consumers MUST treat the verdict as advisory
+    (legacy static yaml stays authoritative)."""
+    return _env_bool("JARVIS_TOPOLOGY_SENTINEL_ENABLED", default=False)
+
+
+def severed_threshold_weighted() -> float:
+    """Weighted-sum threshold to trip CLOSED→OPEN. Default 3.0 means a
+    single live-traffic stream-stall (weight 3.0) trips alone, OR three
+    light probe failures (weight 1.0 each) trip together."""
+    return _env_float(
+        "JARVIS_TOPOLOGY_SEVERED_THRESHOLD_WEIGHTED", default=3.0,
+        minimum=0.5,
+    )
+
+
+def heavy_probe_ratio() -> float:
+    """Fraction of probes that are heavy (mid-weight payload). Default
+    0.2 = 1-in-5 probes test full-stream throughput."""
+    raw = _env_float(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_RATIO", default=0.2, minimum=0.0,
+    )
+    return min(1.0, raw)
+
+
+def light_probe_first_token_timeout_s() -> float:
+    return _env_float(
+        "JARVIS_TOPOLOGY_LIGHT_PROBE_FIRST_TOKEN_TIMEOUT_S",
+        default=2.0, minimum=0.5,
+    )
+
+
+def heavy_probe_total_timeout_s() -> float:
+    return _env_float(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_TOTAL_TIMEOUT_S",
+        default=15.0, minimum=2.0,
+    )
+
+
+def heavy_probe_max_tokens() -> int:
+    return _env_int(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_MAX_TOKENS",
+        default=500, minimum=10,
+    )
+
+
+def probe_backoff_base_s() -> float:
+    """Base interval for the jittered probe schedule. Equivalent to
+    ``backoff_base_seconds`` in ``RetryBudget``."""
+    return _env_float(
+        "JARVIS_TOPOLOGY_PROBE_BACKOFF_BASE_S",
+        default=10.0, minimum=1.0,
+    )
+
+
+def probe_backoff_cap_s() -> float:
+    """Cap on probe interval. Equivalent to ``backoff_cap_seconds``."""
+    return _env_float(
+        "JARVIS_TOPOLOGY_PROBE_BACKOFF_CAP_S",
+        default=300.0, minimum=10.0,
+    )
+
+
+def healthy_probe_interval_s() -> float:
+    """Interval between probes when the endpoint is CLOSED (HEALTHY).
+    Single fixed value; backoff applies only to OPEN-state recovery."""
+    return _env_float(
+        "JARVIS_TOPOLOGY_HEALTHY_PROBE_INTERVAL_S",
+        default=30.0, minimum=5.0,
+    )
+
+
+def state_max_age_s() -> float:
+    """Maximum age of a hydrated current.json snapshot. Older
+    snapshots are discarded (cold-start). Default 1h — long enough to
+    survive routine restarts, short enough that an old SEVERED state
+    doesn't pin a now-recovered endpoint."""
+    return _env_float(
+        "JARVIS_TOPOLOGY_STATE_MAX_AGE_S", default=3600.0, minimum=60.0,
+    )
+
+
+def probe_daily_usd_cap() -> float:
+    """Soft cap on daily probe spend. When breached, the active
+    prober short-circuits to no-op (returns CLOSED for state queries —
+    fail-open to availability rather than fail-closed to cascade
+    storm). Default $1.00."""
+    return _env_float(
+        "JARVIS_TOPOLOGY_PROBE_DAILY_USD_CAP",
+        default=1.0, minimum=0.0,
+    )
+
+
+def history_size() -> int:
+    return max(
+        16,
+        _env_int(
+            "JARVIS_TOPOLOGY_SENTINEL_HISTORY_SIZE",
+            default=512, minimum=16,
+        ),
+    )
+
+
+def force_severed() -> bool:
+    """Operator panic switch — pin every endpoint OPEN. Used during
+    incidents when the operator wants every cascade-eligible op to
+    skip DW even if the sentinel thinks it's healthy."""
+    return _env_bool("JARVIS_TOPOLOGY_FORCE_SEVERED", default=False)
+
+
+def state_dir() -> Path:
+    """Directory holding ``topology_sentinel_*.{json,jsonl}``. Default
+    ``.jarvis/`` matches every other governance disk artifact."""
+    return _env_path(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR",
+        default=str(Path(".jarvis").resolve()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Failure classification — live > heavy > light
+# ---------------------------------------------------------------------------
+
+
+class FailureSource(str, enum.Enum):
+    """Source of a failure signal. Drives the weight toward the
+    weighted-streak threshold."""
+
+    LIVE_STREAM_STALL = "live_stream_stall"        # 3.0 — single-occurrence trip
+    LIVE_TRANSPORT = "live_transport"              # 1.0
+    LIVE_HTTP_5XX = "live_http_5xx"                # 1.0
+    LIVE_HTTP_429 = "live_http_429"                # 0.5 (transient, upstream-handled)
+    LIVE_PARSE_ERROR = "live_parse_error"          # 1.0
+    HEAVY_PROBE_FAIL = "heavy_probe_fail"          # 1.5
+    LIGHT_PROBE_FAIL = "light_probe_fail"          # 1.0
+    LIGHT_PROBE_TIMEOUT = "light_probe_timeout"    # 1.0
+
+
+_DEFAULT_FAILURE_WEIGHTS: Dict[FailureSource, float] = {
+    FailureSource.LIVE_STREAM_STALL: 3.0,
+    FailureSource.LIVE_TRANSPORT: 1.0,
+    FailureSource.LIVE_HTTP_5XX: 1.0,
+    FailureSource.LIVE_HTTP_429: 0.5,
+    FailureSource.LIVE_PARSE_ERROR: 1.0,
+    FailureSource.HEAVY_PROBE_FAIL: 1.5,
+    FailureSource.LIGHT_PROBE_FAIL: 1.0,
+    FailureSource.LIGHT_PROBE_TIMEOUT: 1.0,
+}
+
+
+def failure_weight(source: FailureSource) -> float:
+    """Per-source weight, with optional env overrides
+    ``JARVIS_TOPOLOGY_WEIGHT_<SOURCE_UPPER>``. Bounded to
+    ``[0.0, 10.0]`` to prevent absurd configs from disabling the
+    streak entirely or instantly tripping on noise."""
+    env_name = f"JARVIS_TOPOLOGY_WEIGHT_{source.name}"
+    default = _DEFAULT_FAILURE_WEIGHTS[source]
+    raw = _env_float(env_name, default=default, minimum=0.0)
+    return min(10.0, raw)
+
+
+def success_decay() -> float:
+    """Weighted-streak decay applied on each ``report_success``.
+    Slow forgetting (default 0.5) prevents flapping — a single
+    success doesn't immediately erase a real failure history."""
+    return _env_float(
+        "JARVIS_TOPOLOGY_SUCCESS_DECAY", default=0.5, minimum=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Probe domain types
+# ---------------------------------------------------------------------------
+
+
+class ProbeWeight(str, enum.Enum):
+    LIGHT = "light"
+    HEAVY = "heavy"
+
+
+class ProbeOutcome(str, enum.Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    model_id: str
+    weight: ProbeWeight
+    outcome: ProbeOutcome
+    latency_s: float
+    failure_source: Optional[FailureSource] = None
+    failure_detail: str = ""
+    cost_usd: float = 0.0
+    ts_epoch: float = field(default_factory=time.time)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot + transition record
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EndpointSnapshot:
+    """Per-``model_id`` state, captured durably to
+    ``topology_sentinel_current.json``. Fields are denormalized from
+    the ``CircuitBreaker`` instance so a fresh process can rebuild
+    the breaker faithfully on hydrate."""
+
+    model_id: str
+    state: str                          # "CLOSED" / "OPEN" / "HALF_OPEN" (BreakerState.value)
+    weighted_failure_streak: float = 0.0
+    consecutive_passes: int = 0
+    backoff_idx: int = 0                # retry_index for _compute_backoff_ms
+    opened_at_epoch: float = 0.0        # wall-clock; survives restart
+    last_transition_at_epoch: float = field(default_factory=time.time)
+    last_failure_source: Optional[str] = None
+    last_failure_detail: str = ""
+    last_probe_at_epoch: float = 0.0
+    last_probe_outcome: Optional[str] = None
+    ramp_phase: int = 0                 # 0=full, 1+=ramp tier (slow-start)
+    schema_version: str = SCHEMA_VERSION
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "state": self.state,
+            "weighted_failure_streak": self.weighted_failure_streak,
+            "consecutive_passes": self.consecutive_passes,
+            "backoff_idx": self.backoff_idx,
+            "opened_at_epoch": self.opened_at_epoch,
+            "last_transition_at_epoch": self.last_transition_at_epoch,
+            "last_failure_source": self.last_failure_source,
+            "last_failure_detail": self.last_failure_detail[:200],
+            "last_probe_at_epoch": self.last_probe_at_epoch,
+            "last_probe_outcome": self.last_probe_outcome,
+            "ramp_phase": self.ramp_phase,
+            "schema_version": self.schema_version,
+        }
+
+    @classmethod
+    def from_json(cls, payload: Dict[str, Any]) -> Optional["EndpointSnapshot"]:
+        if payload.get("schema_version") != SCHEMA_VERSION:
+            return None
+        try:
+            return cls(
+                model_id=str(payload["model_id"]),
+                state=str(payload.get("state", "CLOSED")),
+                weighted_failure_streak=float(
+                    payload.get("weighted_failure_streak", 0.0),
+                ),
+                consecutive_passes=int(
+                    payload.get("consecutive_passes", 0),
+                ),
+                backoff_idx=int(payload.get("backoff_idx", 0)),
+                opened_at_epoch=float(
+                    payload.get("opened_at_epoch", 0.0),
+                ),
+                last_transition_at_epoch=float(
+                    payload.get(
+                        "last_transition_at_epoch", time.time(),
+                    ),
+                ),
+                last_failure_source=payload.get("last_failure_source"),
+                last_failure_detail=str(
+                    payload.get("last_failure_detail", ""),
+                ),
+                last_probe_at_epoch=float(
+                    payload.get("last_probe_at_epoch", 0.0),
+                ),
+                last_probe_outcome=payload.get("last_probe_outcome"),
+                ramp_phase=int(payload.get("ramp_phase", 0)),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning(
+                "[TopologySentinel] EndpointSnapshot.from_json failed: %s",
+                exc,
+            )
+            return None
+
+
+@dataclass(frozen=True)
+class TransitionRecord:
+    """One row of ``topology_sentinel_history.jsonl``. Captured on
+    every state change AND on every probe (transition_kind="probe")
+    so the audit log is complete."""
+
+    ts_epoch: float
+    model_id: str
+    transition_kind: str                # "state_change" | "probe" | "failure_report"
+    from_state: str = ""
+    to_state: str = ""
+    weighted_failure_streak: float = 0.0
+    failure_source: Optional[str] = None
+    failure_detail: str = ""
+    probe_weight: Optional[str] = None
+    probe_outcome: Optional[str] = None
+    probe_latency_s: float = 0.0
+    probe_cost_usd: float = 0.0
+    schema_version: str = SCHEMA_VERSION
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "ts_epoch": self.ts_epoch,
+            "model_id": self.model_id,
+            "transition_kind": self.transition_kind,
+            "from_state": self.from_state,
+            "to_state": self.to_state,
+            "weighted_failure_streak": self.weighted_failure_streak,
+            "failure_source": self.failure_source,
+            "failure_detail": self.failure_detail[:200],
+            "probe_weight": self.probe_weight,
+            "probe_outcome": self.probe_outcome,
+            "probe_latency_s": self.probe_latency_s,
+            "probe_cost_usd": self.probe_cost_usd,
+            "schema_version": self.schema_version,
+        }
+
+
+# ---------------------------------------------------------------------------
+# SentinelStateStore — disk persistence (mirrors PostureStore idiom)
+# ---------------------------------------------------------------------------
+
+
+class SentinelStateStore:
+    """Durable triplet under ``state_dir()``:
+
+      * ``topology_sentinel_current.json``  — Dict[model_id, snapshot],
+        atomic temp+rename.
+      * ``topology_sentinel_history.jsonl`` — append-only ring trimmed
+        to ``history_size()``.
+      * ``topology_sentinel.lock``           — single-writer flock-style
+        guard via ``threading.Lock`` (the orchestrator process is
+        single — multi-process locking is out of scope; the lock
+        prevents in-process races between probe loop and
+        report_failure callers).
+    """
+
+    def __init__(
+        self,
+        directory: Optional[Path] = None,
+        history_capacity: Optional[int] = None,
+    ) -> None:
+        self._dir = Path(directory) if directory else state_dir()
+        self._capacity = (
+            history_capacity if history_capacity is not None
+            else history_size()
+        )
+        self._lock = threading.Lock()
+
+    @property
+    def current_path(self) -> Path:
+        return self._dir / "topology_sentinel_current.json"
+
+    @property
+    def history_path(self) -> Path:
+        return self._dir / "topology_sentinel_history.jsonl"
+
+    def _ensure_dir(self) -> bool:
+        try:
+            self._dir.mkdir(parents=True, exist_ok=True)
+            return True
+        except OSError as exc:
+            logger.warning(
+                "[TopologySentinel] cannot create state dir %s: %s",
+                self._dir, exc,
+            )
+            return False
+
+    def hydrate(self) -> Dict[str, EndpointSnapshot]:
+        """Read the current snapshot map. Returns an empty dict on any
+        failure — caller treats as cold-start."""
+        if not self.current_path.exists():
+            return {}
+        try:
+            payload = json.loads(self.current_path.read_text("utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "[TopologySentinel] hydrate read failed: %s", exc,
+            )
+            return {}
+        if not isinstance(payload, dict):
+            return {}
+        if payload.get("schema_version") != SCHEMA_VERSION:
+            logger.info(
+                "[TopologySentinel] schema mismatch (got %r), cold-starting",
+                payload.get("schema_version"),
+            )
+            return {}
+        # Age check — discard if too old (safety net for systems left
+        # offline for days: an OPEN state from 3 days ago is meaningless).
+        snapshot_ts = float(payload.get("written_at_epoch", 0.0))
+        if snapshot_ts <= 0.0:
+            return {}
+        if (time.time() - snapshot_ts) > state_max_age_s():
+            logger.info(
+                "[TopologySentinel] snapshot age %.1fs exceeds max %s; "
+                "cold-starting",
+                time.time() - snapshot_ts, state_max_age_s(),
+            )
+            return {}
+        snapshots: Dict[str, EndpointSnapshot] = {}
+        for model_id, raw in (payload.get("endpoints") or {}).items():
+            snap = EndpointSnapshot.from_json(raw)
+            if snap is not None:
+                snapshots[model_id] = snap
+        return snapshots
+
+    def write_current(
+        self, snapshots: Dict[str, EndpointSnapshot],
+    ) -> bool:
+        """Atomic temp+rename so readers never see a torn write."""
+        if not self._ensure_dir():
+            return False
+        payload: Dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "written_at_epoch": time.time(),
+            "endpoints": {
+                mid: snap.to_json() for mid, snap in snapshots.items()
+            },
+        }
+        with self._lock:
+            try:
+                fd, tmp = tempfile.mkstemp(
+                    prefix="topology_sentinel_current_",
+                    suffix=".json.tmp",
+                    dir=str(self._dir),
+                )
+                try:
+                    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                        json.dump(payload, fh, indent=2, sort_keys=True)
+                    os.replace(tmp, self.current_path)
+                    return True
+                except Exception:
+                    try:
+                        os.unlink(tmp)
+                    except OSError:
+                        pass
+                    raise
+            except OSError as exc:
+                logger.warning(
+                    "[TopologySentinel] write_current failed: %s", exc,
+                )
+                return False
+
+    def append_history(self, record: TransitionRecord) -> bool:
+        if not self._ensure_dir():
+            return False
+        line = json.dumps(record.to_json(), sort_keys=True) + "\n"
+        with self._lock:
+            try:
+                with open(self.history_path, "a", encoding="utf-8") as fh:
+                    fh.write(line)
+            except OSError as exc:
+                logger.warning(
+                    "[TopologySentinel] append_history failed: %s", exc,
+                )
+                return False
+            self._maybe_trim_history()
+        return True
+
+    def _maybe_trim_history(self) -> None:
+        """Bounded trim: keep only the last ``capacity`` lines."""
+        try:
+            with open(self.history_path, "r", encoding="utf-8") as fh:
+                lines = fh.readlines()
+        except OSError:
+            return
+        if len(lines) <= self._capacity:
+            return
+        kept = lines[-self._capacity:]
+        try:
+            fd, tmp = tempfile.mkstemp(
+                prefix="topology_sentinel_history_",
+                suffix=".jsonl.tmp",
+                dir=str(self._dir),
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.writelines(kept)
+            os.replace(tmp, self.history_path)
+        except OSError as exc:
+            logger.debug(
+                "[TopologySentinel] history trim failed: %s", exc,
+            )
+
+
+# ---------------------------------------------------------------------------
+# SlowStartRamp — wraps rate_limiter.TokenBucket; BG/SPEC concurrency cap
+# ---------------------------------------------------------------------------
+
+
+# Default ramp schedule: (seconds_since_close, capacity). Operators can
+# override the entire schedule via JARVIS_TOPOLOGY_RAMP_SCHEDULE. Each
+# tuple says "by elapsed t, allow up to N concurrent ops/sec for BG/SPEC."
+_DEFAULT_RAMP_SCHEDULE: Tuple[Tuple[float, float], ...] = (
+    (0.0, 1.0),
+    (10.0, 2.0),
+    (30.0, 4.0),
+    (60.0, 8.0),
+    (120.0, 16.0),    # baseline cap; downstream BG_POOL_SIZE clamps further
+)
+
+
+def parse_ramp_schedule_env() -> Tuple[Tuple[float, float], ...]:
+    """Parse ``JARVIS_TOPOLOGY_RAMP_SCHEDULE`` of the form
+    ``"0:1.0,10:2.0,30:4.0,..."``. Returns the default if unset or
+    malformed."""
+    raw = os.environ.get("JARVIS_TOPOLOGY_RAMP_SCHEDULE", "").strip()
+    if not raw:
+        return _DEFAULT_RAMP_SCHEDULE
+    try:
+        steps: List[Tuple[float, float]] = []
+        for part in raw.split(","):
+            t_str, c_str = part.split(":", 1)
+            t = max(0.0, float(t_str.strip()))
+            c = max(0.0, float(c_str.strip()))
+            steps.append((t, c))
+        steps.sort(key=lambda x: x[0])
+        return tuple(steps) if steps else _DEFAULT_RAMP_SCHEDULE
+    except (ValueError, IndexError):
+        logger.warning(
+            "[TopologySentinel] malformed ramp schedule %r; "
+            "using default", raw,
+        )
+        return _DEFAULT_RAMP_SCHEDULE
+
+
+def ramp_max_wait_s() -> float:
+    """Per-acquire wait cap when the ramp is throttling. If the
+    bucket would block longer than this, ``try_acquire`` returns
+    ``(False, ...)`` so the BG worker re-queues rather than holds a
+    pool slot indefinitely. Default 10s."""
+    return _env_float(
+        "JARVIS_TOPOLOGY_RAMP_MAX_WAIT_S",
+        default=10.0, minimum=0.5,
+    )
+
+
+class SlowStartRamp:
+    """BG/SPEC concurrency ramp on OPEN→CLOSED recovery.
+
+    Composes ``rate_limiter.TokenBucket`` whose ``set_throttle(m)`` is
+    the public primitive for "scale my effective refill rate by m"
+    (m ∈ (0, 1]). Ramp = wall-clock schedule that calls
+    ``set_throttle`` with progressively higher m until full baseline
+    rate is restored. No bucket-internals reach-in.
+
+    Failure during ramp (``register_failure()``) calls ``deactivate``
+    + ``activate`` to restart the schedule from t=0; the breaker
+    re-trip is the caller's responsibility (sentinel does it inside
+    ``report_failure``).
+
+    BG/SPEC-only — IMMEDIATE/STANDARD/COMPLEX cascade decisions are
+    urgency-gated by the Slice 3 cascade matrix and bypass the ramp
+    entirely because user-driven traffic is itself the recovery test.
+    """
+
+    def __init__(
+        self,
+        schedule: Optional[Tuple[Tuple[float, float], ...]] = None,
+        max_wait_s: Optional[float] = None,
+    ) -> None:
+        self._schedule = schedule or parse_ramp_schedule_env()
+        self._max_wait_s = (
+            max_wait_s if max_wait_s is not None else ramp_max_wait_s()
+        )
+        self._closed_at: float = 0.0   # 0 = ramp inactive
+        self._bucket: Any = None        # rate_limiter.TokenBucket; lazy
+        self._failure_resets: int = 0   # observability
+        self._lock = threading.Lock()
+
+    @property
+    def baseline_capacity_per_s(self) -> float:
+        """Capacity at the final schedule tier — corresponds to
+        ``set_throttle(1.0)`` on the underlying TokenBucket."""
+        return self._schedule[-1][1]
+
+    def _capacity_for(self, elapsed: float) -> float:
+        capacity = self._schedule[0][1]
+        for t, c in self._schedule:
+            if elapsed >= t:
+                capacity = c
+            else:
+                break
+        return capacity
+
+    def _throttle_for(self, elapsed: float) -> float:
+        baseline = self.baseline_capacity_per_s
+        if baseline <= 0:
+            return 1.0
+        return min(1.0, max(0.01, self._capacity_for(elapsed) / baseline))
+
+    def _ensure_bucket(self) -> Any:
+        if self._bucket is None:
+            from backend.core.ouroboros.governance.rate_limiter import (
+                MemoryRateLimitStore, TokenBucket,
+            )
+            # rpm = ops_per_sec × 60. Burst = at most one second of
+            # baseline so a queue surge can't stampede past the ramp.
+            baseline = self.baseline_capacity_per_s
+            rpm = max(1, int(round(baseline * 60.0)))
+            burst = max(1, int(round(baseline)))
+            self._bucket = TokenBucket(
+                key="topology_sentinel_ramp",
+                store=MemoryRateLimitStore(),
+                rpm=rpm,
+                burst=burst,
+            )
+        return self._bucket
+
+    def activate(self) -> None:
+        """Start the ramp clock. Called when the breaker transitions
+        HALF_OPEN→CLOSED."""
+        with self._lock:
+            self._closed_at = time.monotonic()
+            self._ensure_bucket()
+            # Throttle to entry tier — first token issued at t=0 only,
+            # subsequent tokens accrue at the (low) ramp rate.
+            self._bucket.set_throttle(self._throttle_for(0.0))
+
+    def deactivate(self) -> None:
+        """Cancel the ramp (e.g. breaker re-tripped to OPEN, or ramp
+        finished and we want full throughput restored)."""
+        with self._lock:
+            self._closed_at = 0.0
+            if self._bucket is not None:
+                self._bucket.set_throttle(1.0)
+
+    def is_active(self) -> bool:
+        return self._closed_at > 0.0
+
+    def current_capacity(self) -> float:
+        if not self.is_active():
+            return self.baseline_capacity_per_s
+        elapsed = time.monotonic() - self._closed_at
+        if elapsed >= self._schedule[-1][0]:
+            # Schedule complete — auto-deactivate to baseline.
+            self.deactivate()
+            return self.baseline_capacity_per_s
+        return self._capacity_for(elapsed)
+
+    async def try_acquire(self) -> Tuple[bool, float]:
+        """Returns ``(allowed, wait_s)``. NEVER raises.
+
+          * ``allowed=True``  — a token was acquired (bucket may have
+            slept up to ``max_wait_s`` for refill); BG worker proceeds.
+          * ``allowed=False`` — bucket would have slept longer than
+            ``max_wait_s``; BG worker should re-queue the op rather
+            than tie up a pool slot.
+
+        When the ramp is inactive returns ``(True, 0.0)`` — full
+        throughput, no throttle applied."""
+        if not self.is_active():
+            return (True, 0.0)
+        # Sync the bucket's throttle to the current ramp tier.
+        elapsed = time.monotonic() - self._closed_at
+        bucket = self._ensure_bucket()
+        bucket.set_throttle(self._throttle_for(elapsed))
+        try:
+            wait_s = await asyncio.wait_for(
+                bucket.acquire(1), timeout=self._max_wait_s,
+            )
+            return (True, wait_s)
+        except asyncio.TimeoutError:
+            return (False, self._max_wait_s)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "[TopologySentinel] ramp.try_acquire failed: %s", exc,
+            )
+            return (True, 0.0)   # fail-open — don't starve BG on ramp bug
+
+    def register_failure(self) -> None:
+        """Snap ramp back to entry tier on a failure during ramp. The
+        sentinel calls this BEFORE re-tripping the breaker; when the
+        breaker re-trips, ``deactivate()`` follows from the
+        report_failure path."""
+        with self._lock:
+            self._failure_resets += 1
+            if self._bucket is None or self._closed_at == 0.0:
+                return
+            # Restart the schedule clock at t=0 (entry tier).
+            self._closed_at = time.monotonic()
+            self._bucket.set_throttle(self._throttle_for(0.0))
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {
+            "active": self.is_active(),
+            "elapsed_s": (
+                time.monotonic() - self._closed_at
+                if self.is_active() else 0.0
+            ),
+            "current_capacity": self.current_capacity(),
+            "baseline_capacity": self.baseline_capacity_per_s,
+            "failure_resets": self._failure_resets,
+            "schedule": list(self._schedule),
+            "max_wait_s": self._max_wait_s,
+        }
+
+
+# ---------------------------------------------------------------------------
+# ContextWeightedProber — light + heavy probe orchestration
+# ---------------------------------------------------------------------------
+
+
+# Probe payload = callable returning (outcome, latency_s, cost_usd, detail).
+# The default factory wires it to DoublewordProvider.complete_sync; tests
+# inject a deterministic mock.
+ProbeFn = Callable[[str, ProbeWeight], Awaitable[ProbeResult]]
+
+
+class ContextWeightedProber:
+    """Generates probes. State-free; the sentinel owns scheduling and
+    state. Defers to the provided ``probe_fn`` for the actual call —
+    any DW provider must satisfy the ``ProbeFn`` shape. The probe_fn
+    NEVER raises; failures are reported via ``ProbeResult.outcome``."""
+
+    def __init__(
+        self,
+        probe_fn: ProbeFn,
+        heavy_ratio: Optional[float] = None,
+        rng: Optional[random.Random] = None,
+    ) -> None:
+        self._probe_fn = probe_fn
+        self._heavy_ratio = (
+            heavy_ratio if heavy_ratio is not None else heavy_probe_ratio()
+        )
+        self._rng = rng or random.Random()
+        self._counter = 0
+
+    def pick_weight(self) -> ProbeWeight:
+        """Deterministic-ish 1-in-N heavy schedule. Uses an internal
+        counter so every Nth probe is heavy; jitters ±1 via RNG so
+        probe schedules across processes desync."""
+        self._counter += 1
+        if self._heavy_ratio <= 0.0:
+            return ProbeWeight.LIGHT
+        if self._heavy_ratio >= 1.0:
+            return ProbeWeight.HEAVY
+        # Expected-period heavy probe: 1/heavy_ratio. Small RNG nudge.
+        period = max(2, int(round(1.0 / self._heavy_ratio)))
+        nudge = self._rng.randint(0, max(0, period - 1))
+        if (self._counter + nudge) % period == 0:
+            return ProbeWeight.HEAVY
+        return ProbeWeight.LIGHT
+
+    async def probe(self, model_id: str) -> ProbeResult:
+        weight = self.pick_weight()
+        try:
+            return await self._probe_fn(model_id, weight)
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[TopologySentinel] probe_fn raised: %s", exc,
+            )
+            return ProbeResult(
+                model_id=model_id, weight=weight,
+                outcome=ProbeOutcome.FAIL, latency_s=0.0,
+                failure_source=(
+                    FailureSource.HEAVY_PROBE_FAIL
+                    if weight == ProbeWeight.HEAVY
+                    else FailureSource.LIGHT_PROBE_FAIL
+                ),
+                failure_detail=(
+                    f"probe_fn_raised:{type(exc).__name__}"
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# TopologySentinel — coordinator
+# ---------------------------------------------------------------------------
+
+
+class TopologySentinel:
+    """Per-``model_id`` health observer. Composes existing primitives.
+
+    Threading: state mutations are guarded by ``self._lock`` so the
+    probe loop (asyncio task) and synchronous failure-report calls
+    from candidate_generator (Slice 4) interleave safely. ``get_state``
+    reads through the breaker which has its own atomic semantics.
+    """
+
+    def __init__(
+        self,
+        prober: Optional[ContextWeightedProber] = None,
+        store: Optional[SentinelStateStore] = None,
+        weighted_threshold: Optional[float] = None,
+    ) -> None:
+        self._prober = prober
+        self._store = store or SentinelStateStore()
+        self._threshold = (
+            weighted_threshold if weighted_threshold is not None
+            else severed_threshold_weighted()
+        )
+        self._breakers: Dict[str, Any] = {}     # model_id -> CircuitBreaker
+        self._snapshots: Dict[str, EndpointSnapshot] = {}
+        self._ramps: Dict[str, SlowStartRamp] = {}
+        self._lock = threading.Lock()
+        self._probe_task: Optional[asyncio.Task] = None
+        self._stopping = asyncio.Event()
+        self._daily_probe_cost_usd = 0.0
+        self._daily_probe_window_start = time.time()
+        self._listeners: List[Callable[[TransitionRecord], None]] = []
+
+    # -- imports (lazy) -----------------------------------------------------
+
+    @staticmethod
+    def _BreakerCls() -> Any:
+        from backend.core.ouroboros.governance.rate_limiter import (
+            CircuitBreaker,
+        )
+        return CircuitBreaker
+
+    @staticmethod
+    def _BreakerStateCls() -> Any:
+        from backend.core.ouroboros.governance.rate_limiter import (
+            BreakerState,
+        )
+        return BreakerState
+
+    @staticmethod
+    def _compute_backoff(retry_index: int) -> float:
+        """Wraps ``preemption_fsm._compute_backoff_ms`` with a
+        ``RetryBudget`` constructed from the sentinel's env knobs.
+        Returns seconds (not ms) for ``asyncio.sleep`` ergonomics."""
+        from backend.core.ouroboros.governance.contracts.fsm_contract import (
+            RetryBudget,
+        )
+        from backend.core.ouroboros.governance.preemption_fsm import (
+            _compute_backoff_ms,
+        )
+        budget = RetryBudget(
+            backoff_base_seconds=probe_backoff_base_s(),
+            backoff_cap_seconds=probe_backoff_cap_s(),
+            full_jitter=True,
+        )
+        return _compute_backoff_ms(retry_index, budget) / 1000.0
+
+    # -- public API ---------------------------------------------------------
+
+    def register_endpoint(
+        self,
+        model_id: str,
+        failure_threshold: int = 3,
+        recovery_timeout_s: float = 30.0,
+    ) -> None:
+        """Idempotent — register a new endpoint, hydrating from disk
+        if a snapshot exists. Safe to call repeatedly."""
+        with self._lock:
+            if model_id in self._breakers:
+                return
+            BreakerCls = self._BreakerCls()
+            breaker = BreakerCls(
+                failure_threshold=failure_threshold,
+                recovery_timeout_s=recovery_timeout_s,
+            )
+            self._breakers[model_id] = breaker
+            self._ramps[model_id] = SlowStartRamp()
+            # Hydrate if we have a persisted snapshot.
+            snap = self._snapshots.get(model_id)
+            if snap is not None:
+                self._restore_breaker_state(breaker, snap)
+            else:
+                self._snapshots[model_id] = EndpointSnapshot(
+                    model_id=model_id, state="CLOSED",
+                )
+
+    def _restore_breaker_state(
+        self, breaker: Any, snap: EndpointSnapshot,
+    ) -> None:
+        """Rebuild a CircuitBreaker into the persisted state. The
+        ``CircuitBreaker`` API is small; we reach into private slots
+        only here, in one isolated location, to avoid a parallel
+        FSM."""
+        BreakerState = self._BreakerStateCls()
+        if snap.state == "OPEN":
+            breaker._state = BreakerState.OPEN  # noqa: SLF001
+            breaker._failure_count = breaker._failure_threshold  # noqa: SLF001
+            # Reconstruct opened_at in monotonic frame: offset by
+            # how long ago the wall-clock event happened.
+            wall_ago = max(0.0, time.time() - snap.opened_at_epoch)
+            breaker._opened_at = (  # noqa: SLF001
+                time.monotonic() - wall_ago
+            )
+        elif snap.state == "HALF_OPEN":
+            # Half-open is transient; re-open conservatively so a
+            # crash mid-half-open doesn't unblock cascade storm.
+            breaker._state = BreakerState.OPEN  # noqa: SLF001
+            breaker._failure_count = breaker._failure_threshold  # noqa: SLF001
+            breaker._opened_at = time.monotonic()  # noqa: SLF001
+        # CLOSED: default state, no reach-in needed.
+
+    def hydrate(self) -> int:
+        """Read persisted snapshots into memory. Endpoints become
+        active when the caller subsequently invokes
+        ``register_endpoint``. Returns the number of snapshots
+        loaded."""
+        loaded = self._store.hydrate()
+        with self._lock:
+            self._snapshots = dict(loaded)
+        logger.info(
+            "[TopologySentinel] hydrated %d endpoint snapshot(s)",
+            len(loaded),
+        )
+        return len(loaded)
+
+    def get_state(self, model_id: str) -> str:
+        """Synchronous, lock-free read. Returns the BreakerState value
+        as a string ("CLOSED" / "OPEN" / "HALF_OPEN").
+
+        Uninitialized endpoint → "CLOSED" (fail-open to availability).
+        Sentinel master flag off → "CLOSED" (legacy yaml authoritative).
+        Force-severed env → "OPEN" (operator panic switch)."""
+        if force_severed():
+            return "OPEN"
+        if not is_sentinel_enabled():
+            return "CLOSED"
+        breaker = self._breakers.get(model_id)
+        if breaker is None:
+            return "CLOSED"
+        try:
+            breaker.check()
+            return breaker.state.value
+        except Exception:  # noqa: BLE001 — CircuitBreakerOpen + others
+            return "OPEN"
+
+    def is_dw_allowed(self, model_id: str) -> bool:
+        return self.get_state(model_id) != "OPEN"
+
+    def report_failure(
+        self,
+        model_id: str,
+        source: FailureSource,
+        detail: str = "",
+    ) -> None:
+        """Ingest a live-traffic OR probe failure. Adds the source's
+        weight to the model's weighted streak; trips CLOSED→OPEN
+        when the streak reaches ``severed_threshold_weighted``.
+        NEVER raises."""
+        try:
+            with self._lock:
+                if model_id not in self._breakers:
+                    return
+                breaker = self._breakers[model_id]
+                snap = self._snapshots.get(model_id)
+                if snap is None:
+                    snap = EndpointSnapshot(
+                        model_id=model_id, state="CLOSED",
+                    )
+                    self._snapshots[model_id] = snap
+                weight = failure_weight(source)
+                snap.weighted_failure_streak += weight
+                snap.consecutive_passes = 0
+                snap.last_failure_source = source.value
+                snap.last_failure_detail = detail
+                # Snap ramp back to entry tier — even if we don't trip
+                # the breaker, we don't want a partial-failure window
+                # to keep ramping concurrency upward.
+                ramp = self._ramps.get(model_id)
+                if ramp is not None:
+                    ramp.register_failure()
+                # Should we trip?
+                pre_state = breaker.state.value
+                if (
+                    pre_state == "CLOSED"
+                    and snap.weighted_failure_streak >= self._threshold
+                ):
+                    # Translate weighted streak into CircuitBreaker's
+                    # integer failure_count by bumping enough times.
+                    while breaker.state.value == "CLOSED":
+                        breaker.record_failure()
+                elif pre_state == "HALF_OPEN":
+                    # Single failure during half-open re-opens.
+                    breaker.record_failure()
+                post_state = breaker.state.value
+                if post_state != pre_state:
+                    snap.state = post_state
+                    if post_state == "OPEN":
+                        snap.opened_at_epoch = time.time()
+                        snap.backoff_idx += 1
+                        if ramp is not None:
+                            ramp.deactivate()
+                    snap.last_transition_at_epoch = time.time()
+                    self._store.write_current(self._snapshots)
+                    self._emit_transition(
+                        model_id, "state_change",
+                        from_state=pre_state, to_state=post_state,
+                        weighted_failure_streak=snap.weighted_failure_streak,
+                        failure_source=source.value,
+                        failure_detail=detail,
+                    )
+                else:
+                    # Persist updated streak even without transition;
+                    # log a failure_report record for observability.
+                    self._store.write_current(self._snapshots)
+                    self._emit_transition(
+                        model_id, "failure_report",
+                        from_state=pre_state, to_state=post_state,
+                        weighted_failure_streak=snap.weighted_failure_streak,
+                        failure_source=source.value,
+                        failure_detail=detail,
+                    )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[TopologySentinel] report_failure failed", exc_info=True,
+            )
+
+    def report_success(self, model_id: str) -> None:
+        """Record a successful live-traffic call. Decays the weighted
+        streak (slow forgetting) and steps the breaker through
+        HALF_OPEN→CLOSED if applicable. NEVER raises."""
+        try:
+            with self._lock:
+                if model_id not in self._breakers:
+                    return
+                breaker = self._breakers[model_id]
+                snap = self._snapshots.get(model_id)
+                if snap is None:
+                    return
+                pre_state = breaker.state.value
+                breaker.record_success()
+                post_state = breaker.state.value
+                snap.consecutive_passes += 1
+                snap.weighted_failure_streak = max(
+                    0.0,
+                    snap.weighted_failure_streak - success_decay(),
+                )
+                if post_state != pre_state:
+                    snap.state = post_state
+                    snap.last_transition_at_epoch = time.time()
+                    if post_state == "CLOSED":
+                        # Activate slow-start ramp for BG/SPEC drainage.
+                        ramp = self._ramps.get(model_id)
+                        if ramp is not None:
+                            ramp.activate()
+                        snap.backoff_idx = 0
+                    self._store.write_current(self._snapshots)
+                    self._emit_transition(
+                        model_id, "state_change",
+                        from_state=pre_state, to_state=post_state,
+                        weighted_failure_streak=snap.weighted_failure_streak,
+                    )
+                else:
+                    self._store.write_current(self._snapshots)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[TopologySentinel] report_success failed", exc_info=True,
+            )
+
+    def get_ramp(self, model_id: str) -> Optional[SlowStartRamp]:
+        return self._ramps.get(model_id)
+
+    def force_severed(self, model_id: str, reason: str) -> None:
+        """Operator override — pin the endpoint OPEN immediately."""
+        with self._lock:
+            self.register_endpoint(model_id)
+            breaker = self._breakers[model_id]
+            BreakerState = self._BreakerStateCls()
+            breaker._state = BreakerState.OPEN  # noqa: SLF001
+            breaker._opened_at = time.monotonic()  # noqa: SLF001
+            breaker._failure_count = breaker._failure_threshold  # noqa: SLF001
+            snap = self._snapshots[model_id]
+            pre_state = snap.state
+            snap.state = "OPEN"
+            snap.opened_at_epoch = time.time()
+            snap.last_failure_source = "operator_force_severed"
+            snap.last_failure_detail = reason[:200]
+            snap.last_transition_at_epoch = time.time()
+            ramp = self._ramps.get(model_id)
+            if ramp is not None:
+                ramp.deactivate()
+            self._store.write_current(self._snapshots)
+            self._emit_transition(
+                model_id, "state_change",
+                from_state=pre_state, to_state="OPEN",
+                failure_source="operator_force_severed",
+                failure_detail=reason,
+            )
+
+    def force_healthy(self, model_id: str) -> None:
+        """Operator override — pin the endpoint CLOSED immediately
+        (use after confirming DW is back up)."""
+        with self._lock:
+            self.register_endpoint(model_id)
+            breaker = self._breakers[model_id]
+            BreakerState = self._BreakerStateCls()
+            breaker._state = BreakerState.CLOSED  # noqa: SLF001
+            breaker._failure_count = 0  # noqa: SLF001
+            breaker._opened_at = 0.0  # noqa: SLF001
+            snap = self._snapshots[model_id]
+            pre_state = snap.state
+            snap.state = "CLOSED"
+            snap.weighted_failure_streak = 0.0
+            snap.last_transition_at_epoch = time.time()
+            ramp = self._ramps.get(model_id)
+            if ramp is not None:
+                ramp.activate()
+            self._store.write_current(self._snapshots)
+            self._emit_transition(
+                model_id, "state_change",
+                from_state=pre_state, to_state="CLOSED",
+                failure_source="operator_force_healthy",
+            )
+
+    def add_listener(
+        self, listener: Callable[[TransitionRecord], None],
+    ) -> None:
+        """Subscribe to TransitionRecord emissions (Slice 4 SSE bridge
+        will add the broker listener here)."""
+        self._listeners.append(listener)
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Read-only observability surface."""
+        with self._lock:
+            return {
+                "schema_version": SCHEMA_VERSION,
+                "enabled": is_sentinel_enabled(),
+                "force_severed_env": force_severed(),
+                "weighted_threshold": self._threshold,
+                "endpoints": {
+                    mid: snap.to_json()
+                    for mid, snap in self._snapshots.items()
+                },
+                "ramps": {
+                    mid: ramp.snapshot()
+                    for mid, ramp in self._ramps.items()
+                },
+                "daily_probe_cost_usd": round(
+                    self._daily_probe_cost_usd, 6,
+                ),
+            }
+
+    # -- probe loop ---------------------------------------------------------
+
+    async def start(self) -> None:
+        """Spawn the probe loop. Idempotent. Master-flag-aware: when
+        off, returns immediately (no probe burn)."""
+        if not is_sentinel_enabled():
+            return
+        if self._prober is None:
+            logger.info(
+                "[TopologySentinel] no prober wired; start is a no-op",
+            )
+            return
+        if self._probe_task is not None and not self._probe_task.done():
+            return
+        self._stopping.clear()
+        self._probe_task = asyncio.create_task(
+            self._probe_loop(), name="topology_sentinel_probe_loop",
+        )
+
+    async def stop(self) -> None:
+        """Graceful shutdown."""
+        self._stopping.set()
+        task = self._probe_task
+        if task is not None:
+            try:
+                await asyncio.wait_for(task, timeout=5.0)
+            except asyncio.TimeoutError:
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+        self._probe_task = None
+
+    async def _probe_loop(self) -> None:
+        """Per-model probe schedule. Single loop drains all registered
+        endpoints; each endpoint gets a wall-clock-aware "next probe
+        at" computed from its breaker state."""
+        try:
+            while not self._stopping.is_set():
+                await self._refresh_daily_window()
+                model_ids = list(self._breakers.keys())
+                if not model_ids:
+                    await self._sleep_or_stop(
+                        healthy_probe_interval_s(),
+                    )
+                    continue
+                # Pick the model whose next-probe-time is earliest;
+                # probe it; loop. This avoids starving slow-recovering
+                # endpoints when many endpoints are registered.
+                next_at: Dict[str, float] = {}
+                now = time.monotonic()
+                for mid in model_ids:
+                    next_at[mid] = self._next_probe_at(mid, now)
+                target = min(next_at.items(), key=lambda kv: kv[1])
+                mid, when = target
+                wait_s = max(0.0, when - now)
+                if wait_s > 0:
+                    if await self._sleep_or_stop(wait_s):
+                        return
+                if self._daily_probe_cost_usd >= probe_daily_usd_cap():
+                    # Cost-cap breached — halt active probing for the
+                    # day. Fail-open: existing breakers continue to
+                    # serve get_state from their last-known states.
+                    if await self._sleep_or_stop(60.0):
+                        return
+                    continue
+                await self._do_probe_and_apply(mid)
+        except asyncio.CancelledError:
+            return
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "[TopologySentinel] probe loop crashed; exiting",
+            )
+
+    async def _sleep_or_stop(self, seconds: float) -> bool:
+        try:
+            await asyncio.wait_for(
+                self._stopping.wait(), timeout=seconds,
+            )
+            return True
+        except asyncio.TimeoutError:
+            return False
+
+    def _next_probe_at(self, model_id: str, now_mono: float) -> float:
+        snap = self._snapshots.get(model_id)
+        breaker = self._breakers.get(model_id)
+        if snap is None or breaker is None:
+            return now_mono + healthy_probe_interval_s()
+        if breaker.state.value == "OPEN":
+            backoff_s = self._compute_backoff(snap.backoff_idx)
+            # Reference point is monotonic-translated from wall clock.
+            wall_now = time.time()
+            since_open = max(0.0, wall_now - snap.opened_at_epoch)
+            wait_s = max(0.0, backoff_s - since_open)
+            return now_mono + wait_s
+        # CLOSED / HALF_OPEN — fixed cadence
+        return now_mono + healthy_probe_interval_s()
+
+    async def _do_probe_and_apply(self, model_id: str) -> None:
+        if self._prober is None:
+            return
+        result = await self._prober.probe(model_id)
+        with self._lock:
+            snap = self._snapshots.get(model_id)
+            if snap is not None:
+                snap.last_probe_at_epoch = result.ts_epoch
+                snap.last_probe_outcome = result.outcome.value
+            self._daily_probe_cost_usd += result.cost_usd
+        # Translate probe outcome → breaker call.
+        if result.outcome == ProbeOutcome.PASS:
+            self.report_success(model_id)
+        elif result.outcome == ProbeOutcome.FAIL:
+            src = result.failure_source or (
+                FailureSource.HEAVY_PROBE_FAIL
+                if result.weight == ProbeWeight.HEAVY
+                else FailureSource.LIGHT_PROBE_FAIL
+            )
+            self.report_failure(model_id, src, result.failure_detail)
+        # Record probe in history regardless of outcome.
+        self._emit_transition(
+            model_id, "probe",
+            probe_weight=result.weight.value,
+            probe_outcome=result.outcome.value,
+            probe_latency_s=result.latency_s,
+            probe_cost_usd=result.cost_usd,
+            failure_source=(
+                result.failure_source.value
+                if result.failure_source else None
+            ),
+            failure_detail=result.failure_detail,
+        )
+
+    async def _refresh_daily_window(self) -> None:
+        # Reset the daily probe cost window every 24h.
+        now = time.time()
+        if (now - self._daily_probe_window_start) >= 86400.0:
+            self._daily_probe_window_start = now
+            self._daily_probe_cost_usd = 0.0
+
+    # -- internals ----------------------------------------------------------
+
+    def _emit_transition(
+        self,
+        model_id: str,
+        kind: str,
+        from_state: str = "",
+        to_state: str = "",
+        weighted_failure_streak: float = 0.0,
+        failure_source: Optional[str] = None,
+        failure_detail: str = "",
+        probe_weight: Optional[str] = None,
+        probe_outcome: Optional[str] = None,
+        probe_latency_s: float = 0.0,
+        probe_cost_usd: float = 0.0,
+    ) -> None:
+        record = TransitionRecord(
+            ts_epoch=time.time(),
+            model_id=model_id,
+            transition_kind=kind,
+            from_state=from_state,
+            to_state=to_state,
+            weighted_failure_streak=weighted_failure_streak,
+            failure_source=failure_source,
+            failure_detail=failure_detail,
+            probe_weight=probe_weight,
+            probe_outcome=probe_outcome,
+            probe_latency_s=probe_latency_s,
+            probe_cost_usd=probe_cost_usd,
+        )
+        self._store.append_history(record)
+        for listener in list(self._listeners):
+            try:
+                listener(record)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[TopologySentinel] listener raised; ignored",
+                    exc_info=True,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (Slice 5 wires GovernedLoopService to call .start)
+# ---------------------------------------------------------------------------
+
+
+_default_sentinel: Optional[TopologySentinel] = None
+_default_sentinel_lock = threading.Lock()
+
+
+def get_default_sentinel(
+    prober: Optional[ContextWeightedProber] = None,
+) -> TopologySentinel:
+    """Module singleton. Slice 5 boot wiring will call this from
+    ``GovernedLoopService.start`` to spawn the probe loop. Tests may
+    inject a custom prober the first time this is called.
+
+    NEVER raises. When the master flag is off, the returned sentinel
+    is fully functional but ``start()`` is a no-op (no probe burn)."""
+    global _default_sentinel
+    with _default_sentinel_lock:
+        if _default_sentinel is None:
+            _default_sentinel = TopologySentinel(prober=prober)
+            _default_sentinel.hydrate()
+    return _default_sentinel
+
+
+def reset_default_sentinel_for_tests() -> None:
+    """Tests-only escape hatch — clears the module singleton so each
+    test can construct its own."""
+    global _default_sentinel
+    with _default_sentinel_lock:
+        _default_sentinel = None
+
+
+__all__ = [
+    "ContextWeightedProber",
+    "EndpointSnapshot",
+    "FailureSource",
+    "ProbeFn",
+    "ProbeOutcome",
+    "ProbeResult",
+    "ProbeWeight",
+    "SCHEMA_VERSION",
+    "SentinelStateStore",
+    "SlowStartRamp",
+    "TopologySentinel",
+    "TransitionRecord",
+    "failure_weight",
+    "force_severed",
+    "get_default_sentinel",
+    "healthy_probe_interval_s",
+    "heavy_probe_max_tokens",
+    "heavy_probe_ratio",
+    "heavy_probe_total_timeout_s",
+    "history_size",
+    "is_sentinel_enabled",
+    "light_probe_first_token_timeout_s",
+    "parse_ramp_schedule_env",
+    "probe_backoff_base_s",
+    "probe_backoff_cap_s",
+    "probe_daily_usd_cap",
+    "ramp_max_wait_s",
+    "reset_default_sentinel_for_tests",
+    "severed_threshold_weighted",
+    "state_dir",
+    "state_max_age_s",
+    "success_decay",
+]

--- a/notebooks/report.ipynb
+++ b/notebooks/report.ipynb
@@ -2,22 +2,22 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0b5d72ad",
+   "id": "4b7cc03f",
    "metadata": {},
    "source": [
     "# Ouroboros Battle Test Report\n",
     "\n",
     "| Field | Value |\n",
     "|-------|-------|\n",
-    "| Session ID | `bt-2026-04-25-033803` |\n",
+    "| Session ID | `bt-2026-04-27-181437` |\n",
     "| Stop Reason | `idle_timeout` |\n",
-    "| Duration | 662.8 s |\n"
+    "| Duration | 708.8 s |\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee6bad3e",
+   "id": "ddb09a11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,9 +28,9 @@
     "_SUMMARY_JSON = '''\n",
     "{\n",
     "  \"schema_version\": 2,\n",
-    "  \"session_id\": \"bt-2026-04-25-033803\",\n",
+    "  \"session_id\": \"bt-2026-04-27-181437\",\n",
     "  \"stop_reason\": \"idle_timeout\",\n",
-    "  \"duration_s\": 662.7653529644012,\n",
+    "  \"duration_s\": 708.7511169910431,\n",
     "  \"stats\": {\n",
     "    \"attempted\": 0,\n",
     "    \"completed\": 0,\n",
@@ -38,9 +38,9 @@
     "    \"cancelled\": 0,\n",
     "    \"queued\": 0\n",
     "  },\n",
-    "  \"cost_total\": 0.461457,\n",
+    "  \"cost_total\": 0.048093,\n",
     "  \"cost_breakdown\": {\n",
-    "    \"claude\": 0.461457\n",
+    "    \"claude\": 0.048093\n",
     "  },\n",
     "  \"branch_stats\": {\n",
     "    \"commits\": 0,\n",
@@ -55,17 +55,53 @@
     "  \"top_techniques\": [],\n",
     "  \"operations\": [],\n",
     "  \"strategic_drift\": {\n",
-    "    \"total_ops\": 8,\n",
+    "    \"total_ops\": 6,\n",
     "    \"drifted_ops\": 1,\n",
-    "    \"ratio\": 0.125,\n",
+    "    \"ratio\": 0.1667,\n",
     "    \"threshold_met\": true,\n",
     "    \"warning\": false,\n",
     "    \"status\": \"ok\"\n",
     "  },\n",
     "  \"session_outcome\": \"complete\",\n",
-    "  \"last_activity_ts\": 1777088946.3660412,\n",
-    "  \"cost_by_op_phase\": {},\n",
-    "  \"cost_by_op_phase_provider\": {}\n",
+    "  \"last_activity_ts\": 1777314386.403096,\n",
+    "  \"cost_by_phase\": {\n",
+    "    \"GENERATE\": 0.030342\n",
+    "  },\n",
+    "  \"cost_by_op_phase\": {\n",
+    "    \"op-019dd028-c38b-718c-9160-ab20f65dc3fb-cau\": {\n",
+    "      \"GENERATE\": 0.030342\n",
+    "    }\n",
+    "  },\n",
+    "  \"cost_by_op_phase_provider\": {\n",
+    "    \"op-019dd028-c38b-718c-9160-ab20f65dc3fb-cau\": {\n",
+    "      \"GENERATE\": {\n",
+    "        \"claude-api\": 0.030342\n",
+    "      }\n",
+    "    }\n",
+    "  },\n",
+    "  \"metrics\": {\n",
+    "    \"schema_version\": 1,\n",
+    "    \"session_id\": \"bt-2026-04-27-181437\",\n",
+    "    \"computed_at_unix\": 1777314386.405372,\n",
+    "    \"composite_score_session_mean\": null,\n",
+    "    \"composite_score_session_min\": null,\n",
+    "    \"composite_score_session_max\": null,\n",
+    "    \"per_op_composite_scores\": [],\n",
+    "    \"trend\": \"INSUFFICIENT_DATA\",\n",
+    "    \"convergence_slope\": null,\n",
+    "    \"convergence_oscillation_ratio\": null,\n",
+    "    \"convergence_scores_analyzed\": 0,\n",
+    "    \"convergence_recommendation\": \"\",\n",
+    "    \"session_completion_rate\": null,\n",
+    "    \"self_formation_ratio\": null,\n",
+    "    \"postmortem_recall_rate\": null,\n",
+    "    \"cost_per_successful_apply\": null,\n",
+    "    \"posture_stability_seconds\": null,\n",
+    "    \"ops_inspected\": 0,\n",
+    "    \"ops_truncated\": false,\n",
+    "    \"notes\": []\n",
+    "  },\n",
+    "  \"metrics_observability_schema\": \"1.0\"\n",
     "}\n",
     "'''\n",
     "\n",
@@ -84,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0638c65",
+   "id": "59d5cade",
    "metadata": {},
    "source": [
     "## Composite Score Trend\n",
@@ -95,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c7935bc3",
+   "id": "ef1ddfab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f56dfba",
+   "id": "ead550d0",
    "metadata": {},
    "source": [
     "## Convergence State\n",
@@ -143,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83e4bccc",
+   "id": "5a48bbad",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3cad51b0",
+   "id": "230324ce",
    "metadata": {},
    "source": [
     "## Operations Breakdown\n",
@@ -183,7 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3379ccd",
+   "id": "0b8971f0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4bc30c4",
+   "id": "8831a723",
    "metadata": {},
    "source": [
     "## Sensor Activation\n",
@@ -223,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7937c187",
+   "id": "5b0faa11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10d414c1",
+   "id": "e931d393",
    "metadata": {},
    "source": [
     "## Cost & Branch Summary\n",
@@ -258,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3676be55",
+   "id": "f2b928ec",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tests/governance/test_topology_sentinel.py
+++ b/tests/governance/test_topology_sentinel.py
@@ -1,0 +1,916 @@
+"""Slice 1 regression spine for AsyncTopologySentinel.
+
+Pins the foundation primitives: state machine composition over
+``rate_limiter.CircuitBreaker``, slow-start ramp over ``TokenBucket``,
+context-weighted prober, disk-backed persistence with boot-loop
+protection. **No orchestrator wiring is exercised here** — Slice 1
+ships the module isolated; Slice 3 wires consumers.
+
+Test categories:
+  * §1 Module authority invariants (AST scans + import-shape pins)
+  * §2 Env knobs + master flag
+  * §3 FailureSource weight matrix
+  * §4 EndpointSnapshot + TransitionRecord serialization
+  * §5 SentinelStateStore disk round-trips
+  * §6 SlowStartRamp
+  * §7 ContextWeightedProber
+  * §8 TopologySentinel coordinator
+  * §9 Boot-loop protection (the marquee correctness goal)
+  * §10 Default singleton accessor
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.governance import topology_sentinel as ts
+
+
+SENTINEL_PATH = Path(ts.__file__)
+
+
+# ===========================================================================
+# §1 — Module authority invariants
+# ===========================================================================
+
+
+def _module_ast() -> ast.Module:
+    return ast.parse(SENTINEL_PATH.read_text(encoding="utf-8"))
+
+
+def test_top_level_imports_stdlib_only() -> None:
+    """Top-level imports must be stdlib only — providers /
+    governance modules are imported lazily inside method bodies so
+    importing the sentinel doesn't boot the orchestrator."""
+    module = _module_ast()
+    allowed = {
+        "asyncio", "enum", "json", "logging", "os", "random",
+        "tempfile", "threading", "time", "dataclasses", "pathlib",
+        "typing", "__future__",
+    }
+    for node in module.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                assert root in allowed, (
+                    f"top-level import {alias.name} is not stdlib"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            root = (node.module or "").split(".")[0]
+            assert root in allowed, (
+                f"top-level from-import {node.module} not stdlib"
+            )
+
+
+def test_no_local_fsm_or_bucket_or_backoff_class() -> None:
+    """No reimplementation of primitives owned by rate_limiter or
+    preemption_fsm. The sentinel composes; it does not duplicate."""
+    module = _module_ast()
+    forbidden_suffixes = ("Breaker", "Bucket", "Backoff")
+    for node in ast.walk(module):
+        if isinstance(node, ast.ClassDef):
+            for suffix in forbidden_suffixes:
+                assert not node.name.endswith(suffix), (
+                    f"class {node.name} duplicates a primitive that "
+                    "already exists in rate_limiter / preemption_fsm — "
+                    "compose, do not duplicate"
+                )
+
+
+def test_no_orchestrator_or_gate_imports() -> None:
+    """Sentinel is a pure observer; cascade-decision authority lives
+    in candidate_generator (Slice 3). The sentinel module must not
+    import any module that grants it cascade authority by accident."""
+    src = SENTINEL_PATH.read_text(encoding="utf-8")
+    forbidden = (
+        "from backend.core.ouroboros.governance.orchestrator",
+        "from backend.core.ouroboros.governance.iron_gate",
+        "from backend.core.ouroboros.governance.policy",
+        "from backend.core.ouroboros.governance.gate",
+        "from backend.core.ouroboros.governance.change_engine",
+        "from backend.core.ouroboros.governance.candidate_generator",
+    )
+    for needle in forbidden:
+        assert needle not in src, (
+            f"forbidden import {needle!r} appeared in sentinel module"
+        )
+
+
+def test_imports_existing_primitives_lazily() -> None:
+    """Reverse pin — confirm the sentinel actually USES the existing
+    primitives. If somebody refactors away the lazy imports we want
+    a regression here."""
+    src = SENTINEL_PATH.read_text(encoding="utf-8")
+    assert (
+        "from backend.core.ouroboros.governance.rate_limiter import"
+    ) in src, "sentinel must import CircuitBreaker / TokenBucket"
+    assert (
+        "from backend.core.ouroboros.governance.preemption_fsm import"
+    ) in src, "sentinel must import _compute_backoff_ms"
+    assert (
+        "from backend.core.ouroboros.governance.contracts.fsm_contract"
+    ) in src, "sentinel must import RetryBudget"
+
+
+def test_schema_version_constant() -> None:
+    assert ts.SCHEMA_VERSION == "topology_sentinel.1"
+
+
+# ===========================================================================
+# §2 — Env knobs + master flag
+# ===========================================================================
+
+
+def test_master_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", raising=False)
+    assert ts.is_sentinel_enabled() is False
+
+
+def test_master_flag_truthy_values_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for val in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", val)
+        assert ts.is_sentinel_enabled() is True
+
+
+def test_force_severed_default_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_TOPOLOGY_FORCE_SEVERED", raising=False)
+    assert ts.force_severed() is False
+
+
+def test_severed_threshold_default_3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(
+        "JARVIS_TOPOLOGY_SEVERED_THRESHOLD_WEIGHTED", raising=False,
+    )
+    assert ts.severed_threshold_weighted() == pytest.approx(3.0)
+
+
+def test_heavy_probe_ratio_clamped_to_unit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_RATIO", "5.0")
+    assert ts.heavy_probe_ratio() == 1.0
+
+
+def test_state_dir_env_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    assert ts.state_dir() == tmp_path
+
+
+# ===========================================================================
+# §3 — FailureSource weight matrix
+# ===========================================================================
+
+
+def test_failure_source_enum_values() -> None:
+    assert ts.FailureSource.LIVE_STREAM_STALL.value == "live_stream_stall"
+    assert ts.FailureSource.HEAVY_PROBE_FAIL.value == "heavy_probe_fail"
+
+
+def test_live_stream_stall_weight_dominates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single live-traffic stream-stall must trip alone at default
+    threshold (3.0). This is the critical empirical signal."""
+    for env in (
+        "JARVIS_TOPOLOGY_WEIGHT_LIVE_STREAM_STALL",
+        "JARVIS_TOPOLOGY_WEIGHT_LIGHT_PROBE_FAIL",
+    ):
+        monkeypatch.delenv(env, raising=False)
+    assert ts.failure_weight(ts.FailureSource.LIVE_STREAM_STALL) == 3.0
+
+
+def test_failure_weight_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_WEIGHT_LIGHT_PROBE_FAIL", "2.5",
+    )
+    assert ts.failure_weight(
+        ts.FailureSource.LIGHT_PROBE_FAIL,
+    ) == 2.5
+
+
+def test_failure_weight_bounded_at_10(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_WEIGHT_LIVE_STREAM_STALL", "9999",
+    )
+    assert ts.failure_weight(ts.FailureSource.LIVE_STREAM_STALL) == 10.0
+
+
+# ===========================================================================
+# §4 — Snapshot + transition record serialization
+# ===========================================================================
+
+
+def test_snapshot_to_json_round_trip() -> None:
+    snap = ts.EndpointSnapshot(
+        model_id="qwen-397b", state="OPEN",
+        weighted_failure_streak=3.5,
+        opened_at_epoch=1234567890.0,
+        last_failure_source="live_stream_stall",
+        backoff_idx=2,
+    )
+    payload = snap.to_json()
+    rehydrated = ts.EndpointSnapshot.from_json(payload)
+    assert rehydrated is not None
+    assert rehydrated.model_id == "qwen-397b"
+    assert rehydrated.state == "OPEN"
+    assert rehydrated.weighted_failure_streak == pytest.approx(3.5)
+    assert rehydrated.backoff_idx == 2
+
+
+def test_snapshot_from_json_rejects_wrong_schema() -> None:
+    payload = {
+        "model_id": "x", "state": "CLOSED",
+        "schema_version": "wrong",
+    }
+    assert ts.EndpointSnapshot.from_json(payload) is None
+
+
+def test_snapshot_truncates_long_failure_detail() -> None:
+    long_detail = "x" * 5000
+    snap = ts.EndpointSnapshot(
+        model_id="x", state="OPEN", last_failure_detail=long_detail,
+    )
+    payload = snap.to_json()
+    assert len(payload["last_failure_detail"]) <= 200
+
+
+def test_transition_record_to_json_pins_schema() -> None:
+    rec = ts.TransitionRecord(
+        ts_epoch=time.time(), model_id="x",
+        transition_kind="state_change",
+        from_state="CLOSED", to_state="OPEN",
+        weighted_failure_streak=3.0,
+    )
+    out = rec.to_json()
+    assert out["schema_version"] == ts.SCHEMA_VERSION
+    assert out["transition_kind"] == "state_change"
+
+
+# ===========================================================================
+# §5 — SentinelStateStore disk round-trips
+# ===========================================================================
+
+
+def test_store_hydrate_empty_returns_empty(tmp_path: Path) -> None:
+    store = ts.SentinelStateStore(directory=tmp_path)
+    assert store.hydrate() == {}
+
+
+def test_store_round_trip_current_then_hydrate(tmp_path: Path) -> None:
+    store = ts.SentinelStateStore(directory=tmp_path)
+    snap = ts.EndpointSnapshot(
+        model_id="qwen-397b", state="OPEN",
+        opened_at_epoch=time.time(),
+        weighted_failure_streak=4.5,
+    )
+    store.write_current({"qwen-397b": snap})
+    out = store.hydrate()
+    assert "qwen-397b" in out
+    assert out["qwen-397b"].state == "OPEN"
+    assert out["qwen-397b"].weighted_failure_streak == pytest.approx(4.5)
+
+
+def test_store_hydrate_rejects_old_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Snapshots older than state_max_age_s must cold-start. The
+    safety net: an OPEN state from days ago is not authoritative."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_STATE_MAX_AGE_S", "60")
+    store = ts.SentinelStateStore(directory=tmp_path)
+    payload = {
+        "schema_version": ts.SCHEMA_VERSION,
+        "written_at_epoch": time.time() - 3600,  # 1h ago, exceeds 60s
+        "endpoints": {"x": {"model_id": "x", "state": "OPEN",
+                            "schema_version": ts.SCHEMA_VERSION}},
+    }
+    store.current_path.parent.mkdir(parents=True, exist_ok=True)
+    store.current_path.write_text(json.dumps(payload), encoding="utf-8")
+    assert store.hydrate() == {}
+
+
+def test_store_hydrate_rejects_bad_schema(tmp_path: Path) -> None:
+    store = ts.SentinelStateStore(directory=tmp_path)
+    store.current_path.parent.mkdir(parents=True, exist_ok=True)
+    store.current_path.write_text(
+        json.dumps({"schema_version": "wrong"}), encoding="utf-8",
+    )
+    assert store.hydrate() == {}
+
+
+def test_store_history_append_and_trim(
+    tmp_path: Path,
+) -> None:
+    store = ts.SentinelStateStore(
+        directory=tmp_path, history_capacity=5,
+    )
+    for i in range(20):
+        rec = ts.TransitionRecord(
+            ts_epoch=time.time(), model_id=f"m{i}",
+            transition_kind="probe",
+        )
+        store.append_history(rec)
+    lines = store.history_path.read_text(
+        encoding="utf-8",
+    ).splitlines()
+    assert len(lines) == 5  # trimmed to capacity
+
+
+def test_store_atomic_write_no_torn_state(tmp_path: Path) -> None:
+    """Multiple writes must always leave a valid JSON file — temp+
+    rename guarantees readers never see torn state."""
+    store = ts.SentinelStateStore(directory=tmp_path)
+    for i in range(10):
+        snap = ts.EndpointSnapshot(model_id=f"m{i}", state="CLOSED")
+        store.write_current({f"m{i}": snap})
+    # File must be valid JSON throughout — at the end, parseable.
+    payload = json.loads(store.current_path.read_text("utf-8"))
+    assert payload["schema_version"] == ts.SCHEMA_VERSION
+
+
+# ===========================================================================
+# §6 — SlowStartRamp
+# ===========================================================================
+
+
+def test_ramp_inactive_allows_immediately() -> None:
+    ramp = ts.SlowStartRamp()
+    assert ramp.is_active() is False
+    assert ramp.current_capacity() == ramp.baseline_capacity_per_s
+
+
+def test_ramp_activate_starts_at_entry_tier() -> None:
+    schedule = ((0.0, 1.0), (10.0, 4.0), (60.0, 16.0))
+    ramp = ts.SlowStartRamp(schedule=schedule)
+    ramp.activate()
+    assert ramp.is_active() is True
+    assert ramp.current_capacity() == 1.0
+
+
+def test_ramp_capacity_walks_schedule_over_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use a controllable monotonic clock — process-relative
+    ``time.monotonic`` can return values < 12.0 in fresh test
+    processes, which would make the subtraction trick unsound."""
+    schedule = ((0.0, 1.0), (10.0, 4.0), (60.0, 16.0))
+    ramp = ts.SlowStartRamp(schedule=schedule)
+    fake_now = [1000.0]
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.topology_sentinel."
+        "time.monotonic",
+        lambda: fake_now[0],
+    )
+    ramp.activate()  # closed_at = 1000.0
+    fake_now[0] = 1012.0  # 12s elapsed → 4-tier
+    assert ramp.current_capacity() == 4.0
+
+
+def test_ramp_finishes_after_last_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schedule = ((0.0, 1.0), (10.0, 4.0))
+    ramp = ts.SlowStartRamp(schedule=schedule)
+    fake_now = [1000.0]
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.topology_sentinel."
+        "time.monotonic",
+        lambda: fake_now[0],
+    )
+    ramp.activate()
+    fake_now[0] = 1100.0  # 100s elapsed → past last tier (10s)
+    cap = ramp.current_capacity()
+    assert cap == 4.0
+    assert ramp.is_active() is False
+
+
+def test_ramp_register_failure_resets_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    schedule = ((0.0, 1.0), (10.0, 4.0), (60.0, 16.0))
+    ramp = ts.SlowStartRamp(schedule=schedule)
+    fake_now = [1000.0]
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.topology_sentinel."
+        "time.monotonic",
+        lambda: fake_now[0],
+    )
+    ramp.activate()
+    fake_now[0] = 1030.0  # 30s elapsed → 4-tier territory
+    ramp.register_failure()
+    # Reset puts closed_at at current monotonic (1030.0) → t=0 again.
+    assert ramp.current_capacity() == 1.0
+    assert ramp.snapshot()["failure_resets"] == 1
+
+
+def test_ramp_deactivate_restores_baseline() -> None:
+    ramp = ts.SlowStartRamp(
+        schedule=((0.0, 1.0), (10.0, 16.0)),
+    )
+    ramp.activate()
+    ramp.deactivate()
+    assert ramp.is_active() is False
+    assert ramp.current_capacity() == 16.0
+
+
+def test_ramp_parses_env_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_RAMP_SCHEDULE", "0:0.5,5:2.0,30:8.0",
+    )
+    schedule = ts.parse_ramp_schedule_env()
+    assert schedule[0] == (0.0, 0.5)
+    assert schedule[-1] == (30.0, 8.0)
+
+
+def test_ramp_malformed_env_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_RAMP_SCHEDULE", "garbage,not-numbers",
+    )
+    schedule = ts.parse_ramp_schedule_env()
+    # Default has at least 4 tiers
+    assert len(schedule) >= 4
+
+
+@pytest.mark.asyncio
+async def test_ramp_try_acquire_inactive_returns_true_immediately() -> None:
+    ramp = ts.SlowStartRamp()
+    allowed, wait_s = await ramp.try_acquire()
+    assert allowed is True
+    assert wait_s == 0.0
+
+
+@pytest.mark.asyncio
+async def test_ramp_try_acquire_within_max_wait_returns_true() -> None:
+    schedule = ((0.0, 1.0), (10.0, 16.0))
+    ramp = ts.SlowStartRamp(schedule=schedule, max_wait_s=2.0)
+    ramp.activate()
+    # First acquire must succeed (full burst on activate).
+    allowed, _ = await ramp.try_acquire()
+    assert allowed is True
+
+
+# ===========================================================================
+# §7 — ContextWeightedProber
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_prober_calls_probe_fn() -> None:
+    calls: list = []
+
+    async def fake_probe(model_id: str, weight: ts.ProbeWeight):
+        calls.append((model_id, weight))
+        return ts.ProbeResult(
+            model_id=model_id, weight=weight,
+            outcome=ts.ProbeOutcome.PASS, latency_s=0.05,
+        )
+
+    prober = ts.ContextWeightedProber(probe_fn=fake_probe)
+    result = await prober.probe("qwen-397b")
+    assert result.outcome == ts.ProbeOutcome.PASS
+    assert calls and calls[0][0] == "qwen-397b"
+
+
+@pytest.mark.asyncio
+async def test_prober_probe_fn_raise_returns_FAIL() -> None:
+    async def raising_probe(model_id: str, weight: ts.ProbeWeight):
+        raise RuntimeError("simulated transport failure")
+
+    prober = ts.ContextWeightedProber(probe_fn=raising_probe)
+    result = await prober.probe("qwen-397b")
+    assert result.outcome == ts.ProbeOutcome.FAIL
+    assert result.failure_source is not None
+    assert "probe_fn_raised" in result.failure_detail
+
+
+def test_prober_pick_weight_zero_ratio_always_light() -> None:
+    async def noop(model_id: str, weight: ts.ProbeWeight):
+        return ts.ProbeResult(
+            model_id=model_id, weight=weight,
+            outcome=ts.ProbeOutcome.PASS, latency_s=0.0,
+        )
+
+    prober = ts.ContextWeightedProber(probe_fn=noop, heavy_ratio=0.0)
+    for _ in range(20):
+        assert prober.pick_weight() == ts.ProbeWeight.LIGHT
+
+
+def test_prober_pick_weight_full_ratio_always_heavy() -> None:
+    async def noop(model_id: str, weight: ts.ProbeWeight):
+        return ts.ProbeResult(
+            model_id=model_id, weight=weight,
+            outcome=ts.ProbeOutcome.PASS, latency_s=0.0,
+        )
+
+    prober = ts.ContextWeightedProber(probe_fn=noop, heavy_ratio=1.0)
+    for _ in range(20):
+        assert prober.pick_weight() == ts.ProbeWeight.HEAVY
+
+
+def test_prober_pick_weight_default_ratio_mixes() -> None:
+    """Default ratio 0.2 → ~1 in 5 heavy. Over 100 picks we expect
+    a non-zero count of each (RNG-seeded so test is deterministic)."""
+    import random as _r
+
+    async def noop(model_id: str, weight: ts.ProbeWeight):
+        return ts.ProbeResult(
+            model_id=model_id, weight=weight,
+            outcome=ts.ProbeOutcome.PASS, latency_s=0.0,
+        )
+
+    rng = _r.Random(42)
+    prober = ts.ContextWeightedProber(
+        probe_fn=noop, heavy_ratio=0.2, rng=rng,
+    )
+    counts = {ts.ProbeWeight.LIGHT: 0, ts.ProbeWeight.HEAVY: 0}
+    for _ in range(100):
+        counts[prober.pick_weight()] += 1
+    assert counts[ts.ProbeWeight.LIGHT] > 0
+    assert counts[ts.ProbeWeight.HEAVY] > 0
+
+
+# ===========================================================================
+# §8 — TopologySentinel coordinator
+# ===========================================================================
+
+
+@pytest.fixture
+def sentinel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    monkeypatch.delenv("JARVIS_TOPOLOGY_FORCE_SEVERED", raising=False)
+    store = ts.SentinelStateStore(directory=tmp_path)
+    return ts.TopologySentinel(store=store)
+
+
+def test_sentinel_get_state_master_off_returns_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", raising=False)
+    s = ts.TopologySentinel(
+        store=ts.SentinelStateStore(directory=tmp_path),
+    )
+    s.register_endpoint("x")
+    s.report_failure(
+        "x", ts.FailureSource.LIVE_STREAM_STALL, "stall",
+    )
+    # Master flag off — get_state always CLOSED regardless of state.
+    assert s.get_state("x") == "CLOSED"
+
+
+def test_sentinel_force_severed_env_pins_open(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TOPOLOGY_FORCE_SEVERED", "true")
+    s = ts.TopologySentinel(
+        store=ts.SentinelStateStore(directory=tmp_path),
+    )
+    # No need to register — operator panic switch wins.
+    assert s.get_state("any-model") == "OPEN"
+    assert s.is_dw_allowed("any-model") is False
+
+
+def test_sentinel_unknown_model_returns_closed(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    assert sentinel.get_state("never-registered") == "CLOSED"
+
+
+def test_sentinel_register_endpoint_idempotent(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    sentinel.register_endpoint("qwen-397b")
+    sentinel.register_endpoint("qwen-397b")
+    assert sentinel.get_state("qwen-397b") == "CLOSED"
+
+
+def test_sentinel_live_stream_stall_trips_alone(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    """The marquee correctness pin — a SINGLE live-traffic stream-
+    stall must trip CLOSED→OPEN immediately at the default
+    threshold (3.0). This is the empirical signal we trust most."""
+    sentinel.register_endpoint("qwen-397b")
+    assert sentinel.get_state("qwen-397b") == "CLOSED"
+    sentinel.report_failure(
+        "qwen-397b", ts.FailureSource.LIVE_STREAM_STALL,
+        "first-token timeout",
+    )
+    assert sentinel.get_state("qwen-397b") == "OPEN"
+
+
+def test_sentinel_three_light_probes_trip(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    """Three light-probe failures (weight 1.0 each) accumulate to
+    threshold and trip."""
+    sentinel.register_endpoint("qwen-397b")
+    for _ in range(3):
+        sentinel.report_failure(
+            "qwen-397b", ts.FailureSource.LIGHT_PROBE_FAIL, "no token",
+        )
+    assert sentinel.get_state("qwen-397b") == "OPEN"
+
+
+def test_sentinel_two_light_probes_dont_trip(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    sentinel.register_endpoint("qwen-397b")
+    for _ in range(2):
+        sentinel.report_failure(
+            "qwen-397b", ts.FailureSource.LIGHT_PROBE_FAIL, "no token",
+        )
+    assert sentinel.get_state("qwen-397b") == "CLOSED"
+
+
+def test_sentinel_429_weight_subdued(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    """429 is rate-limit (transient, upstream-handled) — five 429s
+    don't trip alone (weight 0.5 × 5 = 2.5 < 3.0)."""
+    sentinel.register_endpoint("qwen-397b")
+    for _ in range(5):
+        sentinel.report_failure(
+            "qwen-397b", ts.FailureSource.LIVE_HTTP_429, "429",
+        )
+    assert sentinel.get_state("qwen-397b") == "CLOSED"
+
+
+def test_sentinel_report_success_decays_streak(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    sentinel.register_endpoint("qwen-397b")
+    # Two light probe failures — under threshold but streak built up.
+    sentinel.report_failure(
+        "qwen-397b", ts.FailureSource.LIGHT_PROBE_FAIL, "x",
+    )
+    sentinel.report_failure(
+        "qwen-397b", ts.FailureSource.LIGHT_PROBE_FAIL, "x",
+    )
+    snap_before = sentinel.snapshot()["endpoints"]["qwen-397b"]
+    streak_before = snap_before["weighted_failure_streak"]
+    sentinel.report_success("qwen-397b")
+    snap_after = sentinel.snapshot()["endpoints"]["qwen-397b"]
+    assert snap_after["weighted_failure_streak"] < streak_before
+
+
+def test_sentinel_force_severed_call_pins_open(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    sentinel.force_severed("qwen-397b", "operator incident")
+    assert sentinel.get_state("qwen-397b") == "OPEN"
+
+
+def test_sentinel_force_healthy_call_pins_closed(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    sentinel.register_endpoint("qwen-397b")
+    sentinel.report_failure(
+        "qwen-397b", ts.FailureSource.LIVE_STREAM_STALL, "stall",
+    )
+    assert sentinel.get_state("qwen-397b") == "OPEN"
+    sentinel.force_healthy("qwen-397b")
+    assert sentinel.get_state("qwen-397b") == "CLOSED"
+
+
+def test_sentinel_persists_state_change_to_disk(
+    sentinel: ts.TopologySentinel, tmp_path: Path,
+) -> None:
+    sentinel.register_endpoint("qwen-397b")
+    sentinel.report_failure(
+        "qwen-397b", ts.FailureSource.LIVE_STREAM_STALL, "x",
+    )
+    current = json.loads(
+        (tmp_path / "topology_sentinel_current.json").read_text("utf-8"),
+    )
+    assert current["endpoints"]["qwen-397b"]["state"] == "OPEN"
+
+
+def test_sentinel_listener_receives_transition(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    received: list = []
+    sentinel.add_listener(lambda rec: received.append(rec))
+    sentinel.register_endpoint("qwen-397b")
+    sentinel.report_failure(
+        "qwen-397b", ts.FailureSource.LIVE_STREAM_STALL, "x",
+    )
+    assert any(r.transition_kind == "state_change" for r in received)
+
+
+def test_sentinel_listener_exception_swallowed(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    """A misbehaving listener must not break the sentinel."""
+    def bad(rec):
+        raise RuntimeError("listener bug")
+
+    sentinel.add_listener(bad)
+    sentinel.register_endpoint("qwen-397b")
+    # Must not raise.
+    sentinel.report_failure(
+        "qwen-397b", ts.FailureSource.LIVE_STREAM_STALL, "x",
+    )
+    assert sentinel.get_state("qwen-397b") == "OPEN"
+
+
+def test_sentinel_report_failure_unknown_model_no_raise(
+    sentinel: ts.TopologySentinel,
+) -> None:
+    """report_failure on an unregistered endpoint is a no-op (defense
+    against caller bugs); must NEVER raise."""
+    sentinel.report_failure(
+        "never-registered", ts.FailureSource.LIVE_STREAM_STALL, "x",
+    )
+
+
+# ===========================================================================
+# §9 — Boot-loop protection (the marquee correctness goal)
+# ===========================================================================
+
+
+def test_sentinel_hydrates_open_state_from_disk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """**The boot-loop-prevention pin.**
+
+    Process A: trips OPEN, persists current.json, dies (SIGKILL).
+    Process B: starts fresh, hydrates current.json, registers the
+    same endpoint. The breaker MUST come up OPEN — not CLOSED
+    (which would let the first BG op stampede DW and re-trip)."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+
+    # --- Process A simulation
+    store_a = ts.SentinelStateStore(directory=tmp_path)
+    s_a = ts.TopologySentinel(store=store_a)
+    s_a.register_endpoint("qwen-397b")
+    s_a.report_failure(
+        "qwen-397b", ts.FailureSource.LIVE_STREAM_STALL, "stall",
+    )
+    assert s_a.get_state("qwen-397b") == "OPEN"
+
+    # --- Process B simulation: fresh sentinel reads same state dir
+    store_b = ts.SentinelStateStore(directory=tmp_path)
+    s_b = ts.TopologySentinel(store=store_b)
+    loaded = s_b.hydrate()
+    assert loaded == 1
+    s_b.register_endpoint("qwen-397b")
+    # Must come up OPEN, not CLOSED — the boot-loop guarantee.
+    assert s_b.get_state("qwen-397b") == "OPEN"
+
+
+def test_sentinel_hydrate_old_snapshot_cold_starts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """A snapshot older than max-age must NOT pin OPEN — that would
+    keep a now-recovered endpoint sealed forever."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TOPOLOGY_STATE_MAX_AGE_S", "60")
+    payload = {
+        "schema_version": ts.SCHEMA_VERSION,
+        "written_at_epoch": time.time() - 86400,  # 24h ago
+        "endpoints": {
+            "x": {
+                "model_id": "x", "state": "OPEN",
+                "schema_version": ts.SCHEMA_VERSION,
+                "opened_at_epoch": time.time() - 86400,
+            },
+        },
+    }
+    state_path = tmp_path / "topology_sentinel_current.json"
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+    store = ts.SentinelStateStore(directory=tmp_path)
+    s = ts.TopologySentinel(store=store)
+    assert s.hydrate() == 0
+    s.register_endpoint("x")
+    assert s.get_state("x") == "CLOSED"
+
+
+def test_sentinel_half_open_at_kill_re_opens_on_boot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Process killed mid-HALF_OPEN must boot back into OPEN, not
+    CLOSED — half-open is an unsafe transient and we err toward
+    cascade prevention."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    payload = {
+        "schema_version": ts.SCHEMA_VERSION,
+        "written_at_epoch": time.time(),
+        "endpoints": {
+            "x": {
+                "model_id": "x", "state": "HALF_OPEN",
+                "schema_version": ts.SCHEMA_VERSION,
+                "opened_at_epoch": time.time() - 5,
+            },
+        },
+    }
+    state_path = tmp_path / "topology_sentinel_current.json"
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+    store = ts.SentinelStateStore(directory=tmp_path)
+    s = ts.TopologySentinel(store=store)
+    s.hydrate()
+    s.register_endpoint("x")
+    assert s.get_state("x") == "OPEN"
+
+
+# ===========================================================================
+# §10 — Default singleton + lifecycle no-op when off
+# ===========================================================================
+
+
+def test_default_sentinel_is_singleton() -> None:
+    ts.reset_default_sentinel_for_tests()
+    a = ts.get_default_sentinel()
+    b = ts.get_default_sentinel()
+    assert a is b
+    ts.reset_default_sentinel_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_start_no_op_when_master_off(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", raising=False)
+    s = ts.TopologySentinel(
+        store=ts.SentinelStateStore(directory=tmp_path),
+    )
+    await s.start()  # must not spawn a task
+    assert s._probe_task is None  # noqa: SLF001
+    await s.stop()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_start_no_op_when_no_prober(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    s = ts.TopologySentinel(
+        store=ts.SentinelStateStore(directory=tmp_path),
+        # no prober wired
+    )
+    await s.start()
+    assert s._probe_task is None  # noqa: SLF001
+    await s.stop()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_probe_loop_stops_on_event(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """End-to-end: spawn the probe loop with a fake prober, register
+    one endpoint, observe at least one probe land, then stop."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEALTHY_PROBE_INTERVAL_S", "5")
+    probes_seen: list = []
+
+    async def fake_probe(model_id: str, weight: ts.ProbeWeight):
+        probes_seen.append((model_id, weight))
+        return ts.ProbeResult(
+            model_id=model_id, weight=weight,
+            outcome=ts.ProbeOutcome.PASS, latency_s=0.01,
+            cost_usd=1e-6,
+        )
+
+    prober = ts.ContextWeightedProber(probe_fn=fake_probe)
+    s = ts.TopologySentinel(
+        prober=prober,
+        store=ts.SentinelStateStore(directory=tmp_path),
+    )
+    s.register_endpoint("qwen-397b")
+    await s.start()
+    # Give the loop a moment to run one tick.
+    await asyncio.sleep(0.1)
+    await s.stop()
+    # Exact count is loop-dependent; the contract is "stop terminates
+    # cleanly within budget" rather than "exactly N probes ran."
+    assert s._probe_task is None  # noqa: SLF001


### PR DESCRIPTION
## Summary

First slice of the **AsyncTopologySentinel** arc replacing the static `dw_allowed: false` blocks in `brain_selection_policy.yaml` with a live, asynchronous, per-model health observer. **No consumers wired** — Slice 1 ships the foundation isolated. Behavior of the running system is byte-identical pre- and post-merge.

## Architecture

Per the [architectural directive] — composes existing primitives, **does not duplicate**:

| Sub-component | Existing primitive reused | New code |
|---|---|---|
| 3-state FSM (CLOSED/HALF_OPEN/OPEN) | `rate_limiter.CircuitBreaker` per `model_id` | — |
| Exponential backoff with full jitter | `preemption_fsm._compute_backoff_ms` + `RetryBudget` | — |
| Leaky-bucket primitive | `rate_limiter.TokenBucket` + `MemoryRateLimitStore` | `SlowStartRamp` wrapper (BG concurrency ramp on recovery) |
| Disk-backed `_current.json` + `_history.jsonl` triplet | `posture_store.py` pattern (atomic temp+rename, bounded ring trim) | `SentinelStateStore` |
| Probe orchestration | n/a | `ContextWeightedProber` (light + heavy mix; failure-weight matrix) |

The 4 distributed-systems mechanisms from the directive:

1. **Slow-start ramp** — `SlowStartRamp` wraps `TokenBucket.set_throttle(m)` on a wall-clock schedule. Default `(0:1/s, 10:2/s, 30:4/s, 60:8/s, 120:16/s)`. BG/SPEC-only — IMMEDIATE/STANDARD/COMPLEX cascade decisions are urgency-gated by Slice 3 cascade matrix and bypass the ramp because user-driven traffic is itself the recovery test.
2. **Context-weighted probing** — `ContextWeightedProber` mixes light (1-token, network connectivity) and heavy (500-token, GPU/VRAM stress) probes at 4:1. Live-traffic exceptions weighted **3.0** (single occurrence trips); heavy probe failure **1.5**; light probe failure **1.0**; HTTP 429 subdued to **0.5** (transient, upstream-handled).
3. **Randomized jitter** — `preemption_fsm._compute_backoff_ms(retry_idx, RetryBudget(full_jitter=True))` is Amazon-style full-jitter; mathematically stronger than ±20% (desyncs 100% per call rather than ±20%).
4. **Persistent state with boot-loop protection** — `EndpointSnapshot` writes on every transition; on hydrate, `state=OPEN` snapshots reconstruct the breaker into OPEN with the original `opened_at` — process killed mid-SEVERED comes back into SEVERED, no boot-loop Claude burn. Snapshots older than `JARVIS_TOPOLOGY_STATE_MAX_AGE_S` (default 1h) cold-start to avoid pinning a now-recovered endpoint.

## Authority posture (AST-pinned)

- Top-level imports stdlib only — providers/governance modules imported lazily inside method bodies
- No class definitions ending in `*Breaker` / `*Bucket` / `*Backoff` (no primitive duplication)
- No imports from `orchestrator` / `iron_gate` / `policy` / `gate` / `change_engine` / `candidate_generator` (observer-not-decider)
- Reverse pin: rate_limiter + preemption_fsm + fsm_contract MUST be imported (regression catches accidental refactor away from composition)
- NEVER raises: every public method swallows exceptions; uninitialized endpoint or sentinel error returns `state="CLOSED"` (fail-open to availability) — except operator panic switch which forces `"OPEN"`
- RLock instead of Lock: `force_severed` / `force_healthy` hold the lock then call `register_endpoint` (same re-entrancy pattern as posture_observer slice5_arc_a fix)

## Master flag

`JARVIS_TOPOLOGY_SENTINEL_ENABLED` (default **false**). When off, `get_state` returns `"CLOSED"` for every model_id — legacy yaml stays authoritative. Slice 3 wires consumers; Slice 5 flips default and purges the static yaml blocks.

## Test plan

- [x] 62 Slice 1 tests green
- [x] 134/134 combined regression (Slice 1 + Phase 8 wiring #25394 + circuit breaker #25229 + cron installer #25256)
- [x] Boot-loop protection pin: simulated SIGKILL during SEVERED — fresh sentinel boots back into OPEN, not CLOSED
- [x] AST authority pins: no FSM/bucket/backoff duplication
- [ ] Slice 2: yaml v2 schema with dual-reader (next PR)

## Out of scope (deferred to Slice 2+)

- yaml v2 schema (`dw_priority` + `fallback_tolerance`)
- candidate_generator wiring
- Live-exception `report_failure` ingest at existing failure sites
- Probe loop boot from GovernedLoopService
- The purge: deleting `dw_allowed: false` lines + read-only Nervous System Reflex carve-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the foundation for an async topology sentinel that observes per‑model health with active probes, weighted failure ingest, slow‑start recovery, and durable state. No consumers are wired and the master flag defaults off, so runtime behavior is unchanged.

- **New Features**
  - Introduces `topology_sentinel.py` composing `rate_limiter.CircuitBreaker`, `rate_limiter.TokenBucket`, and `preemption_fsm._compute_backoff_ms`/`RetryBudget` (no primitive duplication).
  - Durable snapshots with boot‑loop protection; stale state ignored via `JARVIS_TOPOLOGY_STATE_MAX_AGE_S`.
  - Context‑weighted probing (light/heavy mix) with env‑tunable timeouts and a daily cost cap `JARVIS_TOPOLOGY_PROBE_DAILY_USD_CAP`.
  - Slow‑start BG/SPEC ramp (`SlowStartRamp`) on recovery; master flag `JARVIS_TOPOLOGY_SENTINEL_ENABLED` (default false) and operator override `JARVIS_TOPOLOGY_FORCE_SEVERED`.

- **Bug Fixes**
  - Switches to `threading.RLock` to avoid deadlock in `force_severed` and `force_healthy`.

<sup>Written for commit 1d5040bb40988ff1c7c94ac920f05a075162c696. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/25504?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

