### PR TITLE
feat(topology): Slice 3 — sentinel dispatch + ranked DW models + circuit breaker

### DIFF
--- a/backend/core/ouroboros/governance/brain_selection_policy.yaml
+++ b/backend/core/ouroboros/governance/brain_selection_policy.yaml
@@ -340,29 +340,90 @@ gates:
 # callers (semantic_triage, ouroboros_plan) until DoubleWord repairs
 # their SSE generation endpoint.
 doubleword_topology:
-  schema_version: "topology.1"
+  # Bumped to topology.2 (PRD §3.7 + §9 Phase 10 P10.2, 2026-04-27).
+  # v2 adds per-route `dw_models:` ranked lists + `fallback_tolerance:`
+  # so the AsyncTopologySentinel can walk multiple DW model candidates
+  # before any Claude cascade. v1 keys (`dw_allowed`, `block_mode`)
+  # remain authoritative when JARVIS_TOPOLOGY_SENTINEL_ENABLED is off
+  # (current default). Slice 3 wires `candidate_generator` to consult
+  # the sentinel under that flag; Slice 5 (THE PURGE) deletes the v1
+  # keys after 3 forced-clean once-proofs prove the dynamic path
+  # produces correct routing decisions.
+  schema_version: "topology.2"
   enabled: true
   routes:
     immediate:
       dw_allowed: false
       block_mode: "cascade_to_claude"
       reason: "Prefrontal cortex — Claude only. 120s DW RT budget is insufficient for fast-reflex ops with Venom tool loops."
+      # v2 — IMMEDIATE intentionally has NO dw_models. Manifesto §5
+      # ("survival and execution speed permanently supersede cost
+      # optimization") makes this a Claude-direct route by design,
+      # NOT a degradation seal. Preserved across the purge.
+      dw_models: []
+      fallback_tolerance: "cascade_to_claude"
     complex:
       dw_allowed: false
       block_mode: "cascade_to_claude"
       reason: "Prefrontal cortex — Claude only. Live-fire bbpst3ebf proved DW (both 397B and Gemma 4 31B) times out on architectural COMPLEX GENERATE within 120s Tier 0 RT."
+      # v2 — ranked DW model list per PRD §3.7.3. The sentinel walks
+      # this list trying each healthy model before cascading to Claude.
+      # All three primary picks are different model families than the
+      # 397B that originally stream-stalled — different runtimes,
+      # different streaming pipelines.
+      dw_models:
+        - "moonshotai/Kimi-K2.6"           # Primary — "long-horizon coding, agents, swarm" — exact match for autonomous multi-file
+        - "zai-org/GLM-5.1-FP8"            # Secondary — leads SWE-Bench Pro, "agentic engineering, repo gen, terminal"
+        - "Qwen/Qwen3.6-35B-A3B-FP8"       # Budget tertiary — newer family than 397B
+        - "Qwen/Qwen3.5-397B-A17B"         # Legacy primary — demoted to last DW attempt
+      fallback_tolerance: "cascade_to_claude"
     standard:
       dw_allowed: false
       block_mode: "cascade_to_claude"
       reason: "Qwen 397B verified stream-stalling without candidate generation in bt-2026-04-14-203740. DW Tier 0 sealed to prevent latency debt."
+      # v2 — same ranked list as COMPLEX (per PRD §3.7.3).
+      dw_models:
+        - "moonshotai/Kimi-K2.6"
+        - "zai-org/GLM-5.1-FP8"
+        - "Qwen/Qwen3.6-35B-A3B-FP8"
+        - "Qwen/Qwen3.5-397B-A17B"
+      fallback_tolerance: "cascade_to_claude"
     background:
       dw_allowed: false
       block_mode: "skip_and_queue"
       reason: "Gemma 4 31B stream-stalls on DW endpoint even at <2K tokens. Background generation paused to preserve Claude compute runway."
+      # v2 — BG is cost-sensitive; cheap-first ranking. Kimi-K2.6 is
+      # second because long-horizon BG ops (e.g. doc staleness drafts)
+      # benefit from its agentic surface when 35B is unhealthy.
+      # `fallback_tolerance: "queue"` preserves the project_bg_spec_
+      # sealed.md contract — BG ops NEVER cascade to Claude on full
+      # DW failure; they queue and the sensor re-detects.
+      dw_models:
+        - "Qwen/Qwen3.6-35B-A3B-FP8"
+        - "moonshotai/Kimi-K2.6"
+      fallback_tolerance: "queue"
     speculative:
       dw_allowed: false
       block_mode: "skip_and_queue"
       reason: "Gemma 4 31B stream-stalls on DW endpoint even at <2K tokens. Background generation paused to preserve Claude compute runway."
+      # v2 — SPECULATIVE is fire-and-forget pre-computation; ultra-cheap
+      # picks only. Qwen3.5-4B at $0.04/$0.06 per M is the cheapest
+      # usable model in the catalog. Same `queue` fallback contract.
+      dw_models:
+        - "Qwen/Qwen3.5-9B"
+        - "Qwen/Qwen3.5-4B"
+      fallback_tolerance: "queue"
+  monitor:
+    # AsyncTopologySentinel tunables — yaml-driven so operators can
+    # adjust without code changes. When this block is absent, the
+    # sentinel falls back to its env-knob defaults (whose names match
+    # these keys, prefixed with `JARVIS_TOPOLOGY_`).
+    probe_interval_healthy_s: 30.0       # Background probe cadence when CLOSED
+    probe_backoff_base_s: 10.0           # Exponential backoff base (with full jitter)
+    probe_backoff_cap_s: 300.0           # Cap on probe interval when consecutively SEVERED
+    severed_threshold_weighted: 3.0      # Single LIVE_STREAM_STALL (weight 3.0) trips alone
+    heavy_probe_ratio: 0.2               # 1-in-5 probes are heavy (500-token VRAM stress)
+    ramp_schedule_csv: "0:1.0,10:2.0,30:4.0,60:8.0,120:16.0"  # Slow-start BG drainage
   callers:
     semantic_triage:
       dw_model: "google/gemma-4-31B-it"

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -56,7 +56,7 @@ import os
 import time
 from datetime import datetime, timedelta, timezone
 from enum import Enum, auto
-from typing import Any, Dict, NoReturn, Optional, Protocol, runtime_checkable
+from typing import Any, Dict, List, NoReturn, Optional, Protocol, runtime_checkable
 
 from backend.core.ouroboros.governance.op_context import (
     GenerationResult,
@@ -1377,6 +1377,41 @@ class CandidateGenerator:
         # ── Route-based dispatch (Manifesto §5 Tier 0: deterministic) ──
         _provider_route = getattr(context, "provider_route", "") or "standard"
 
+        # ── Phase 10 P10.3 — AsyncTopologySentinel-driven dispatch ───
+        # When ``JARVIS_TOPOLOGY_SENTINEL_ENABLED=true``, the sentinel
+        # walks the route's ranked ``dw_models`` list (yaml v2) and
+        # picks the first model whose breaker is not OPEN. Each
+        # attempt stamps ``ctx._dw_model_override`` so the provider's
+        # ``_resolve_effective_model`` consumes it. On per-model
+        # failure, ``sentinel.report_failure(...)`` is called and the
+        # walk continues to the next model. After exhausting all DW
+        # models, the route applies its ``fallback_tolerance`` from
+        # yaml v2 (``cascade_to_claude`` or ``queue``).
+        #
+        # When the master flag is OFF (default), this branch is a
+        # no-op and the static yaml ``dw_allowed: false`` block below
+        # remains authoritative — byte-identical pre/post-Slice-3
+        # behavior. The static block is the deletion target for
+        # Phase 10 P10.5 (THE PURGE), operator-authorized after 3
+        # forced-clean once-proofs of this dynamic path.
+        try:
+            from backend.core.ouroboros.governance.topology_sentinel import (
+                is_sentinel_enabled as _sentinel_enabled,
+            )
+            _sentinel_active = _sentinel_enabled()
+        except Exception:
+            _sentinel_active = False
+        if _sentinel_active:
+            _result = await self._dispatch_via_sentinel(
+                context, deadline, _provider_route,
+            )
+            if _result is not None:
+                return _result
+            # _dispatch_via_sentinel returns None to signal "fall
+            # through to legacy path" (e.g. the route has empty
+            # dw_models — IMMEDIATE by design — so the existing
+            # _generate_immediate handler still runs below).
+
         # Brain Selection Topology — hard segmentation (Manifesto §5).
         # When ``doubleword_topology`` marks a route as DW-forbidden,
         # the ``block_mode`` field decides what to do next:
@@ -1849,6 +1884,219 @@ class CandidateGenerator:
     # ------------------------------------------------------------------
     # Route-specific generation strategies (Manifesto §5)
     # ------------------------------------------------------------------
+
+    async def _dispatch_via_sentinel(
+        self,
+        context: OperationContext,
+        deadline: datetime,
+        provider_route: str,
+    ) -> Optional[GenerationResult]:
+        """Phase 10 P10.3 — sentinel-driven DW dispatch.
+
+        Walks the route's ranked ``dw_models`` list (yaml v2). For each
+        model whose breaker is not OPEN, stamps ``ctx._dw_model_override``
+        and attempts DW. On per-model failure reports to the sentinel
+        (with appropriate ``FailureSource`` weight) and continues to
+        the next model. After exhausting all DW models, applies the
+        route's ``fallback_tolerance``:
+
+          * ``"cascade_to_claude"`` — invokes ``_call_fallback`` (Claude).
+          * ``"queue"`` — raises the sentinel-already-known
+            ``RuntimeError("dw_severed_queued:...")`` shape that the
+            orchestrator's existing accept-failure branch handles.
+
+        Returns:
+          * ``GenerationResult`` on DW success or Claude cascade.
+          * ``None`` to signal "fall through to legacy path" — used
+            when the route has empty ``dw_models`` (e.g. IMMEDIATE,
+            which is Claude-direct by Manifesto §5 design and is
+            handled by the existing ``_generate_immediate`` dispatcher
+            below).
+        """
+        from backend.core.ouroboros.governance.provider_topology import (
+            get_topology as _get_topology,
+        )
+        from backend.core.ouroboros.governance.topology_sentinel import (
+            FailureSource,
+            get_default_sentinel,
+        )
+
+        topology = _get_topology()
+        if not topology.enabled:
+            return None
+        ranked_models = topology.dw_models_for_route(provider_route)
+        fallback_tolerance = topology.fallback_tolerance_for_route(
+            provider_route,
+        )
+
+        # Empty dw_models → fall through to legacy dispatch. IMMEDIATE
+        # has empty models by design (Claude-direct); other routes
+        # would fall here only if yaml is misconfigured.
+        if not ranked_models:
+            logger.debug(
+                "[CandidateGenerator] Sentinel dispatch: route=%s "
+                "has no dw_models — falling through to legacy",
+                provider_route,
+            )
+            return None
+
+        sentinel = get_default_sentinel()
+        # Register every model in the ranked list (idempotent). The
+        # sentinel needs to know about each model_id before it can
+        # answer get_state.
+        for model_id in ranked_models:
+            sentinel.register_endpoint(model_id)
+
+        op_id_short = (
+            getattr(context, "op_id", "?")[:16]
+            if hasattr(context, "op_id") else "?"
+        )
+
+        # Walk the ranked list. For each model not OPEN, attempt DW.
+        attempts: List[str] = []
+        last_failure: Optional[str] = None
+        for model_id in ranked_models:
+            state = sentinel.get_state(model_id)
+            if state == "OPEN":
+                logger.info(
+                    "[CandidateGenerator] Sentinel dispatch: route=%s "
+                    "model=%s state=OPEN — skipping (op=%s)",
+                    provider_route, model_id, op_id_short,
+                )
+                attempts.append(f"{model_id}:skipped_open")
+                continue
+            attempts.append(f"{model_id}:attempted")
+            # Stamp the per-attempt override on context. Each attempt
+            # mutates the same context attribute; on success / cascade
+            # we leave it set (downstream telemetry sees which model
+            # actually fired); on failure we move on and the next
+            # iteration overwrites.
+            try:
+                setattr(context, "_dw_model_override", model_id)
+            except (AttributeError, TypeError):
+                # Slotted dataclass refusing setattr — retreat to the
+                # legacy single-model dispatch.
+                logger.debug(
+                    "[CandidateGenerator] Sentinel dispatch: ctx "
+                    "rejected _dw_model_override; falling through",
+                )
+                return None
+            logger.info(
+                "[CandidateGenerator] Sentinel dispatch: route=%s "
+                "attempting model=%s (state=%s, op=%s)",
+                provider_route, model_id, state, op_id_short,
+            )
+            try:
+                if provider_route == "background":
+                    result = await self._generate_background(
+                        context, deadline,
+                    )
+                elif provider_route == "speculative":
+                    result = await self._generate_speculative(
+                        context, deadline,
+                    )
+                else:
+                    # standard / complex / unknown — use the primary-
+                    # first cascade. This walks the existing tier-0
+                    # → tier-1 logic which honors ctx._dw_model_override.
+                    result = await self._try_primary_then_fallback(
+                        context, deadline,
+                    )
+                # Success — let the sentinel know. Phase 10 P10.4
+                # also wires report_failure at existing failure sites
+                # so a stream-stall mid-generation also lands in the
+                # sentinel; this report_success closes the
+                # corresponding successful-stream signal.
+                try:
+                    sentinel.report_success(model_id)
+                except Exception:
+                    logger.debug(
+                        "[CandidateGenerator] sentinel.report_success raised",
+                        exc_info=True,
+                    )
+                return result
+            except Exception as exc:
+                # Classify the failure for the sentinel. Stream-stall
+                # exceptions get LIVE_STREAM_STALL (weight 3.0 — single
+                # occurrence trips); transport/HTTP get LIVE_TRANSPORT;
+                # everything else falls through to LIVE_TRANSPORT as a
+                # catch-all (better to over-trip than under-trip on
+                # uncategorized errors).
+                err_str = str(exc)
+                err_lower = err_str.lower()
+                if (
+                    "stream" in err_lower
+                    and ("stall" in err_lower or "timeout" in err_lower)
+                ) or "streamtimeouterror" in err_lower:
+                    failure_source = FailureSource.LIVE_STREAM_STALL
+                elif "429" in err_str:
+                    failure_source = FailureSource.LIVE_HTTP_429
+                elif "5" in err_str[:5] and (
+                    "500" in err_str or "502" in err_str
+                    or "503" in err_str or "504" in err_str
+                ):
+                    failure_source = FailureSource.LIVE_HTTP_5XX
+                elif "parse" in err_lower or "json" in err_lower:
+                    failure_source = FailureSource.LIVE_PARSE_ERROR
+                else:
+                    failure_source = FailureSource.LIVE_TRANSPORT
+                try:
+                    sentinel.report_failure(
+                        model_id, failure_source,
+                        f"{type(exc).__name__}:{err_str[:120]}",
+                    )
+                except Exception:
+                    logger.debug(
+                        "[CandidateGenerator] sentinel.report_failure raised",
+                        exc_info=True,
+                    )
+                last_failure = (
+                    f"{model_id}:{failure_source.value}:"
+                    f"{type(exc).__name__}"
+                )
+                logger.warning(
+                    "[CandidateGenerator] Sentinel dispatch: model=%s "
+                    "FAILED (source=%s, exc=%s) — trying next (op=%s)",
+                    model_id, failure_source.value,
+                    type(exc).__name__, op_id_short,
+                )
+                attempts[-1] = f"{model_id}:failed:{failure_source.value}"
+                continue
+        # All DW models exhausted (either OPEN or failed). Clear the
+        # per-attempt override so any downstream telemetry doesn't
+        # falsely attribute the cascade to the last attempted model.
+        try:
+            setattr(context, "_dw_model_override", None)
+        except (AttributeError, TypeError):
+            pass
+        logger.warning(
+            "[CandidateGenerator] Sentinel dispatch: route=%s exhausted "
+            "all %d DW models [%s] — applying fallback_tolerance=%s "
+            "(op=%s, last_failure=%s)",
+            provider_route, len(ranked_models),
+            ", ".join(attempts),
+            fallback_tolerance, op_id_short, last_failure or "none",
+        )
+        if fallback_tolerance == "queue":
+            # Same exception shape the orchestrator's existing
+            # accept-failure branch already handles for BG/SPEC.
+            if provider_route == "speculative":
+                raise RuntimeError(
+                    f"speculative_deferred:dw_severed_queued:"
+                    f"{(last_failure or 'all_models_open')[:120]}"
+                )
+            raise RuntimeError(
+                f"background_dw_blocked_by_topology:"
+                f"dw_severed_queued:"
+                f"{(last_failure or 'all_models_open')[:120]}"
+            )
+        # cascade_to_claude — Claude is the explicit cost contract.
+        if self._fallback is None:
+            raise RuntimeError(
+                f"sentinel_dispatch_no_fallback:"
+                f"{(last_failure or 'all_models_open')[:120]}"
+            )
+        return await self._call_fallback(context, deadline)
 
     async def _generate_immediate(
         self,

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -228,20 +228,31 @@ class DoublewordProvider:
         self._mcp_client: Optional[Any] = None  # Injected by GLS for MCP tool forwarding (Gap #7)
 
     def _resolve_effective_model(self, ctx: Any) -> str:
-        """Resolve the DW model for this call from the Brain Selection Topology.
+        """Resolve the DW model for this call.
 
-        The topology (``brain_selection_policy.yaml`` →
-        ``doubleword_topology``) maps each :class:`ProviderRoute` to a
-        specific DW model. When enabled, STANDARD routes to 397B while
-        BACKGROUND / SPECULATIVE route to Gemma 4 31B. IMMEDIATE and
-        COMPLEX are hard-blocked by ``candidate_generator`` before this
-        method is ever called, so any hit here means the route allows
-        DW by design.
+        Resolution order (first match wins):
+
+          1. ``ctx._dw_model_override`` — per-attempt override stamped by
+             the AsyncTopologySentinel-driven dispatch in
+             ``candidate_generator`` (Phase 10 P10.3). When the sentinel
+             is walking a route's ranked ``dw_models`` list, each
+             attempt stamps the chosen model_id on the context so this
+             method picks it up without a global mutation.
+          2. ``topology.model_for_route(route)`` — v1 single-model
+             per-route mapping. Honored when no per-attempt override
+             is set (legacy path; default behavior when sentinel is
+             disabled).
+          3. ``self._model`` — instance default (env-configured).
 
         Falls back to ``self._model`` when the topology is disabled,
         the route is unmapped, or the ctx lacks a ``provider_route``
         attribute — identical to the pre-topology behavior.
         """
+        # (1) Per-attempt override from sentinel-driven dispatch.
+        attempt_override = getattr(ctx, "_dw_model_override", None)
+        if isinstance(attempt_override, str) and attempt_override:
+            return attempt_override
+        # (2) v1 route → model mapping.
         route = getattr(ctx, "provider_route", "") or ""
         if not route:
             return self._model

--- a/backend/core/ouroboros/governance/dw_topology_circuit_breaker.py
+++ b/backend/core/ouroboros/governance/dw_topology_circuit_breaker.py
@@ -92,8 +92,20 @@ def should_circuit_break(
     """Return ``(circuit_break, reason)`` for the given route +
     read-only state.
 
-    Logic (matches ``candidate_generator.py:1404-1465`` exactly,
-    minus the actual generation):
+    **Phase 10 P10.3 update (2026-04-27)**: when
+    ``JARVIS_TOPOLOGY_SENTINEL_ENABLED=true``, the breaker also
+    consults the AsyncTopologySentinel — if **every** model in the
+    route's ranked ``dw_models`` list has its breaker OPEN AND the
+    route's ``fallback_tolerance`` is ``"queue"``, fire the breaker
+    even if the static yaml ``block_mode`` would have allowed a
+    cascade. This closes the dynamic-evidence loop: when the
+    sentinel has live empirical evidence that all DW models are
+    SEVERED, BG/SPEC ops queue (preserving unit economics) instead
+    of cascading.
+
+    When the sentinel master flag is OFF (default), behavior is
+    byte-identical to pre-Slice-3 — same logic as the old
+    ``candidate_generator.py:1404-1465`` path:
 
       1. If topology disabled → ``(False, "topology_disabled")``.
       2. If route not in topology map → ``(False, "route_unmapped")``.
@@ -128,6 +140,47 @@ def should_circuit_break(
 
     if not topology.enabled:
         return (False, "topology_disabled")
+
+    # Phase 10 P10.3 — sentinel-driven verdict (when master flag on).
+    # Consulted AHEAD of the legacy yaml-only path because the
+    # sentinel carries live empirical state; the yaml is operator
+    # intent. When both agree the verdict is the same; when they
+    # disagree, live evidence wins.
+    try:
+        from backend.core.ouroboros.governance.topology_sentinel import (
+            is_sentinel_enabled,
+            get_default_sentinel,
+        )
+        if is_sentinel_enabled():
+            sentinel = get_default_sentinel()
+            ranked = topology.dw_models_for_route(route_norm)
+            tolerance = topology.fallback_tolerance_for_route(route_norm)
+            if ranked:
+                # Every model OPEN → fire breaker iff fallback is queue.
+                all_open = all(
+                    sentinel.get_state(m) == "OPEN" for m in ranked
+                )
+                if all_open and tolerance == "queue":
+                    return (
+                        True,
+                        f"sentinel_all_severed:{','.join(ranked[:3])}"[
+                            :120
+                        ],
+                    )
+                if all_open and tolerance == "cascade_to_claude":
+                    # Sentinel says SEVERED everywhere but cascade is
+                    # the contract — let the caller's late-detection
+                    # path cascade. Don't fire here.
+                    return (False, "sentinel_severed_cascade_to_claude")
+                # At least one model not OPEN — let the dispatch try.
+                return (False, "sentinel_dw_available")
+    except Exception as exc:  # noqa: BLE001
+        # Sentinel-side failure must not block the legacy verdict.
+        logger.debug(
+            "[CircuitBreaker] sentinel consultation raised "
+            "(%s) — falling back to legacy yaml verdict",
+            type(exc).__name__,
+        )
 
     try:
         dw_allowed = topology.dw_allowed_for_route(route_norm)

--- a/tests/governance/test_provider_topology_v2.py
+++ b/tests/governance/test_provider_topology_v2.py
@@ -525,44 +525,63 @@ def test_monitor_config_ramp_schedule_csv_strips_whitespace() -> None:
 # ===========================================================================
 
 
-def test_production_yaml_still_parses_as_v1(
+def test_production_yaml_parses_as_v2(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The actual ``brain_selection_policy.yaml`` shipped today MUST
-    still parse to v1. If this test fails after Slice 2, it means a
-    schema_version key got accidentally added to production yaml
-    before Phase 10 P10.5 (the purge) is authorized."""
+    """Slice 3 bumped schema_version to ``topology.2`` and populated
+    every route with the audit-recommended ranked dw_models lists.
+    The v1 ``dw_allowed: false`` blocks REMAIN authoritative until
+    Phase 10 P10.5 purge — they are still pinned by
+    ``test_phase_10_static_blocks_still_present`` below."""
     pt._CACHED_TOPOLOGY = None
     topo = pt.get_topology()
     assert topo.enabled is True
-    assert topo.schema_version == pt.SCHEMA_VERSION_V1
+    assert topo.schema_version == pt.SCHEMA_VERSION_V2
 
 
-def test_production_yaml_routes_have_empty_dw_models() -> None:
-    """Production yaml is v1; ``dw_models`` should be empty tuple for
-    every route. The ``effective_dw_models`` accessor handles the
-    backward-compat single-element derivation."""
+def test_production_yaml_routes_have_audit_recommended_dw_models() -> None:
+    """Slice 3 populated each route's v2 ``dw_models`` ranked list per
+    PRD §3.7.3 audit recommendations. Pin the exact rank order so an
+    accidental yaml refactor can't silently swap models."""
     pt._CACHED_TOPOLOGY = None
     topo = pt.get_topology()
-    for route_name, entry in topo.routes.items():
-        assert entry.dw_models == (), (
-            f"production route {route_name!r} has unexpected dw_models — "
-            "Slice 2 should not modify production yaml v1 keys"
-        )
+    # IMMEDIATE intentionally has NO dw_models (Manifesto §5 — Claude direct by design).
+    assert topo.dw_models_for_route("immediate") == ()
+    # STANDARD + COMPLEX share the same ranked list.
+    expected_prefrontal = (
+        "moonshotai/Kimi-K2.6",
+        "zai-org/GLM-5.1-FP8",
+        "Qwen/Qwen3.6-35B-A3B-FP8",
+        "Qwen/Qwen3.5-397B-A17B",
+    )
+    assert topo.dw_models_for_route("standard") == expected_prefrontal
+    assert topo.dw_models_for_route("complex") == expected_prefrontal
+    # BACKGROUND is cost-sensitive — cheap-first ordering.
+    assert topo.dw_models_for_route("background") == (
+        "Qwen/Qwen3.6-35B-A3B-FP8",
+        "moonshotai/Kimi-K2.6",
+    )
+    # SPECULATIVE is fire-and-forget — ultra-cheap only.
+    assert topo.dw_models_for_route("speculative") == (
+        "Qwen/Qwen3.5-9B",
+        "Qwen/Qwen3.5-4B",
+    )
 
 
 def test_production_yaml_v1_block_mode_methods_unchanged() -> None:
     """Regression pin: existing v1 callers' answers MUST be byte-
-    identical after Slice 2. If any of these change, Slice 2 broke
-    backward compat."""
+    identical after Slice 3 even though the yaml is now v2 — the v1
+    keys (``dw_allowed: false``, ``block_mode:``) remain in the yaml
+    until P10.5 purge, and the v1 reader paths must still honor them
+    so callers that haven't migrated to v2 accessors keep working."""
     pt._CACHED_TOPOLOGY = None
     topo = pt.get_topology()
-    # All 5 routes are sealed in production today.
+    # All 5 routes are still sealed by v1 keys (until P10.5 purge).
     for route in (
         "immediate", "complex", "standard", "background", "speculative",
     ):
         assert topo.dw_allowed_for_route(route) is False
-    # Block-mode wiring per yaml today:
+    # Block-mode wiring unchanged:
     assert topo.block_mode_for_route("immediate") == "cascade_to_claude"
     assert topo.block_mode_for_route("complex") == "cascade_to_claude"
     assert topo.block_mode_for_route("standard") == "cascade_to_claude"
@@ -570,23 +589,37 @@ def test_production_yaml_v1_block_mode_methods_unchanged() -> None:
     assert topo.block_mode_for_route("speculative") == "skip_and_queue"
 
 
-def test_production_yaml_v2_methods_derive_correctly() -> None:
-    """The new v2 accessors must give sensible answers when reading the
-    production v1 yaml. Slice 3 will consume these accessors directly."""
+def test_production_yaml_v2_fallback_tolerance() -> None:
+    """v2 ``fallback_tolerance`` per route (now explicit in yaml, not
+    derived from block_mode):
+
+      * IMMEDIATE / COMPLEX / STANDARD → cascade_to_claude
+      * BACKGROUND / SPECULATIVE → queue (project_bg_spec_sealed.md
+        contract preserved structurally)
+    """
     pt._CACHED_TOPOLOGY = None
     topo = pt.get_topology()
-    # All disallowed routes have empty dw_models lists (v1 yaml had no
-    # explicit dw_model on disallowed routes).
-    for route in (
-        "immediate", "complex", "standard", "background", "speculative",
-    ):
-        assert topo.dw_models_for_route(route) == ()
-    # Fallback tolerance derives from block_mode:
     assert topo.fallback_tolerance_for_route("immediate") == "cascade_to_claude"
     assert topo.fallback_tolerance_for_route("complex") == "cascade_to_claude"
     assert topo.fallback_tolerance_for_route("standard") == "cascade_to_claude"
     assert topo.fallback_tolerance_for_route("background") == "queue"
     assert topo.fallback_tolerance_for_route("speculative") == "queue"
+
+
+def test_production_yaml_monitor_block_populated() -> None:
+    """Slice 3 added a ``monitor:`` block to production yaml with
+    sentinel tunables. Pin the keys + sane numeric ranges."""
+    pt._CACHED_TOPOLOGY = None
+    topo = pt.get_topology()
+    cfg = topo.monitor_config()
+    assert cfg is not None
+    assert cfg.probe_interval_healthy_s == 30.0
+    assert cfg.probe_backoff_base_s == 10.0
+    assert cfg.probe_backoff_cap_s == 300.0
+    assert cfg.severed_threshold_weighted == 3.0
+    assert cfg.heavy_probe_ratio == 0.2
+    assert cfg.ramp_schedule_csv is not None
+    assert "0:1.0" in cfg.ramp_schedule_csv  # entry tier preserved
 
 
 def test_production_yaml_callers_unchanged_after_slice2() -> None:

--- a/tests/governance/test_topology_sentinel_dispatch.py
+++ b/tests/governance/test_topology_sentinel_dispatch.py
@@ -1,0 +1,419 @@
+"""Slice 3 regression spine — sentinel-driven dispatch in candidate_generator.
+
+Pins the new ``_dispatch_via_sentinel`` method on ``CandidateGenerator``
+and the sentinel consultation in ``dw_topology_circuit_breaker``. Two
+modes covered:
+
+  * **Master flag OFF** (default) — every test in this file proves the
+    sentinel-driven path is INERT. ``_dispatch_via_sentinel`` is not
+    called; legacy yaml gate remains authoritative; behavior is
+    byte-identical to pre-Slice-3.
+
+  * **Master flag ON** — the sentinel walks the route's ranked
+    ``dw_models`` list, stamps ``ctx._dw_model_override``, attempts DW
+    via existing per-route helpers, reports failures back to the
+    sentinel, and applies ``fallback_tolerance`` after exhausting
+    every DW model.
+
+Source-level pins are deliberately AST/regex over the production
+``candidate_generator.py`` module rather than booting the full
+orchestrator — the dispatcher's behavior is unit-testable via direct
+calls into ``_dispatch_via_sentinel`` with a stub generator class.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import candidate_generator as cg
+from backend.core.ouroboros.governance import dw_topology_circuit_breaker as cb
+from backend.core.ouroboros.governance import provider_topology as pt
+from backend.core.ouroboros.governance import topology_sentinel as ts
+
+
+CANDIDATE_GEN_PATH = Path(cg.__file__)
+CIRCUIT_BREAKER_PATH = Path(cb.__file__)
+
+
+# ---------------------------------------------------------------------------
+# §1 — Source-level pins on the new injection points
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_branch_inserted_before_static_topology_gate() -> None:
+    """The new sentinel branch in ``_resolve_provider_chain`` (or
+    wherever the dispatch lives) must fire BEFORE the static yaml
+    gate at line 1404. If a refactor reorders these, the sentinel
+    becomes unreachable for sealed routes."""
+    src = CANDIDATE_GEN_PATH.read_text(encoding="utf-8")
+    sentinel_call = src.index("_dispatch_via_sentinel")
+    static_gate = src.index(
+        "_topology.dw_allowed_for_route", sentinel_call,
+    )
+    assert sentinel_call < static_gate, (
+        "sentinel dispatch MUST fire before the static yaml gate "
+        "so the new path can win when JARVIS_TOPOLOGY_SENTINEL_ENABLED=true"
+    )
+
+
+def test_sentinel_branch_gated_by_master_flag() -> None:
+    """The sentinel branch must be gated by ``is_sentinel_enabled()``
+    so it's a no-op when the master flag is off."""
+    src = CANDIDATE_GEN_PATH.read_text(encoding="utf-8")
+    # Find the sentinel call site
+    site_idx = src.index("_dispatch_via_sentinel")
+    pre = src[max(0, site_idx - 600):site_idx]
+    assert "is_sentinel_enabled" in pre, (
+        "expected is_sentinel_enabled() check immediately before "
+        "_dispatch_via_sentinel — without it the new path runs "
+        "unconditionally"
+    )
+
+
+def test_dispatcher_returns_none_to_signal_fall_through() -> None:
+    """The dispatcher's contract: return ``None`` when the route has
+    no v2 dw_models (e.g. IMMEDIATE), so the legacy ``_generate_immediate``
+    handler still runs. Pinned by docstring + a return-None branch."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert "return None" in src
+    assert "fall through to legacy" in src.lower()
+
+
+def test_dispatcher_stamps_dw_model_override_on_ctx() -> None:
+    """Each attempt must stamp ``ctx._dw_model_override`` so the
+    DW provider's ``_resolve_effective_model`` picks up the chosen
+    model_id."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert '"_dw_model_override"' in src
+    assert "setattr(context" in src
+
+
+def test_dispatcher_reports_success_on_dw_win() -> None:
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert "sentinel.report_success" in src
+
+
+def test_dispatcher_reports_failure_with_classified_source() -> None:
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert "sentinel.report_failure" in src
+    # Verify the failure-classification matrix is present (not just a
+    # blanket LIVE_TRANSPORT bucket).
+    assert "LIVE_STREAM_STALL" in src
+    assert "LIVE_HTTP_429" in src
+    assert "LIVE_HTTP_5XX" in src
+    assert "LIVE_PARSE_ERROR" in src
+    assert "LIVE_TRANSPORT" in src
+
+
+def test_dispatcher_applies_fallback_tolerance_queue() -> None:
+    """On exhausting all DW models, ``fallback_tolerance="queue"``
+    must raise ``RuntimeError`` matching the orchestrator's existing
+    accept-failure shape (``background_dw_blocked_by_topology`` or
+    ``speculative_deferred``)."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert 'fallback_tolerance == "queue"' in src
+    assert "background_dw_blocked_by_topology" in src
+    assert "speculative_deferred" in src
+
+
+def test_dispatcher_applies_fallback_tolerance_cascade() -> None:
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert "_call_fallback" in src
+
+
+def test_dispatcher_per_attempt_override_uses_setattr() -> None:
+    """Stamping must use setattr (resilient to slotted contexts) AND
+    swallow AttributeError/TypeError so a slotted dataclass doesn't
+    crash the sentinel path. Falls through to legacy on rejection."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert "setattr(context" in src
+    assert "(AttributeError, TypeError)" in src
+
+
+# ---------------------------------------------------------------------------
+# §2 — DoublewordProvider override resolution
+# ---------------------------------------------------------------------------
+
+
+def test_dw_provider_resolver_prefers_ctx_override() -> None:
+    """``_resolve_effective_model`` must consult ``ctx._dw_model_override``
+    BEFORE the topology's per-route mapping. Without this, the
+    dispatcher's per-attempt model choice is silently ignored."""
+    from backend.core.ouroboros.governance import doubleword_provider as dwp
+    src = inspect.getsource(dwp.DoublewordProvider._resolve_effective_model)
+    assert "_dw_model_override" in src
+    # The override check must appear BEFORE the model_for_route call.
+    override_idx = src.index("_dw_model_override")
+    route_call_idx = src.index("model_for_route")
+    assert override_idx < route_call_idx
+
+
+# ---------------------------------------------------------------------------
+# §3 — dw_topology_circuit_breaker sentinel consultation
+# ---------------------------------------------------------------------------
+
+
+def test_circuit_breaker_consults_sentinel_when_enabled() -> None:
+    src = CIRCUIT_BREAKER_PATH.read_text(encoding="utf-8")
+    assert "is_sentinel_enabled" in src
+    assert "get_default_sentinel" in src
+    assert "sentinel_all_severed" in src or "sentinel_severed" in src
+
+
+def test_circuit_breaker_master_off_legacy_path_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When master flag is OFF, the breaker's verdict for a sealed
+    BG route must be byte-identical to pre-Slice-3 (skip_and_queue
+    + non-read-only → True with topology_reason)."""
+    monkeypatch.delenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", raising=False)
+    pt._CACHED_TOPOLOGY = None
+    fired, reason = cb.should_circuit_break(
+        provider_route="background",
+        is_read_only=False,
+    )
+    assert fired is True
+    assert "Gemma" in reason or "stream-stall" in reason or "topology" in reason.lower()
+
+
+def test_circuit_breaker_master_off_read_only_carve_out_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", raising=False)
+    pt._CACHED_TOPOLOGY = None
+    fired, reason = cb.should_circuit_break(
+        provider_route="background", is_read_only=True,
+    )
+    assert fired is False
+    assert "read_only" in reason.lower()
+
+
+def test_circuit_breaker_sentinel_on_all_severed_queue_fires(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """With sentinel ON + every model in the route OPEN + fallback=queue,
+    the breaker MUST fire (`sentinel_all_severed:...`). This is the
+    new evidence path that defends BG/SPEC unit economics."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    pt._CACHED_TOPOLOGY = None
+    ts.reset_default_sentinel_for_tests()
+    sentinel = ts.get_default_sentinel()
+    # Force every BG model to OPEN.
+    for model_id in ("Qwen/Qwen3.6-35B-A3B-FP8", "moonshotai/Kimi-K2.6"):
+        sentinel.force_severed(model_id, "test")
+    fired, reason = cb.should_circuit_break(
+        provider_route="background",
+        is_read_only=False,
+    )
+    assert fired is True
+    assert "sentinel_all_severed" in reason
+    ts.reset_default_sentinel_for_tests()
+
+
+def test_circuit_breaker_sentinel_on_one_model_healthy_holds_fire(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """Sentinel ON + at least one BG model not OPEN → breaker does
+    NOT fire. The dispatcher will try that model."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    pt._CACHED_TOPOLOGY = None
+    ts.reset_default_sentinel_for_tests()
+    sentinel = ts.get_default_sentinel()
+    # Force only the first BG model OPEN; second remains CLOSED.
+    sentinel.force_severed("Qwen/Qwen3.6-35B-A3B-FP8", "test")
+    sentinel.register_endpoint("moonshotai/Kimi-K2.6")
+    fired, reason = cb.should_circuit_break(
+        provider_route="background",
+        is_read_only=False,
+    )
+    assert fired is False
+    assert reason == "sentinel_dw_available"
+    ts.reset_default_sentinel_for_tests()
+
+
+def test_circuit_breaker_sentinel_on_severed_cascade_holds_fire(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """Sentinel ON + every STANDARD model OPEN + fallback=cascade_to_claude:
+    breaker does NOT fire (cascade is the contract). The caller's
+    late-detection path will route to Claude."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    pt._CACHED_TOPOLOGY = None
+    ts.reset_default_sentinel_for_tests()
+    sentinel = ts.get_default_sentinel()
+    # Force every STANDARD model OPEN.
+    for model_id in (
+        "moonshotai/Kimi-K2.6",
+        "zai-org/GLM-5.1-FP8",
+        "Qwen/Qwen3.6-35B-A3B-FP8",
+        "Qwen/Qwen3.5-397B-A17B",
+    ):
+        sentinel.force_severed(model_id, "test")
+    fired, reason = cb.should_circuit_break(
+        provider_route="standard",
+        is_read_only=False,
+    )
+    assert fired is False
+    assert "sentinel_severed_cascade_to_claude" in reason
+    ts.reset_default_sentinel_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# §4 — Production yaml ranked-model integrity
+# ---------------------------------------------------------------------------
+
+
+def test_production_yaml_immediate_has_no_dw_models() -> None:
+    pt._CACHED_TOPOLOGY = None
+    topo = pt.get_topology()
+    assert topo.dw_models_for_route("immediate") == ()
+
+
+def test_production_yaml_standard_complex_share_ranked_list() -> None:
+    pt._CACHED_TOPOLOGY = None
+    topo = pt.get_topology()
+    assert topo.dw_models_for_route("standard") == (
+        topo.dw_models_for_route("complex")
+    )
+    # Pin first model to Kimi-K2.6 — the audit's primary pick.
+    assert topo.dw_models_for_route("standard")[0] == "moonshotai/Kimi-K2.6"
+
+
+def test_production_yaml_bg_cheap_first_ordering() -> None:
+    """BG is cost-sensitive; cheapest model first per PRD §3.7.3."""
+    pt._CACHED_TOPOLOGY = None
+    topo = pt.get_topology()
+    bg_models = topo.dw_models_for_route("background")
+    # Qwen3.6-35B is the cheapest in the BG list ($0.25/$2.00 per M).
+    assert bg_models[0] == "Qwen/Qwen3.6-35B-A3B-FP8"
+
+
+def test_production_yaml_speculative_only_ultra_cheap() -> None:
+    """SPECULATIVE must contain only the cheapest models in the
+    catalog — fire-and-forget pre-computation can't justify $1/M
+    output spend."""
+    pt._CACHED_TOPOLOGY = None
+    topo = pt.get_topology()
+    spec_models = topo.dw_models_for_route("speculative")
+    assert "Qwen/Qwen3.5-9B" in spec_models
+    assert "Qwen/Qwen3.5-4B" in spec_models
+    # No frontier-tier models slip in.
+    assert "moonshotai/Kimi-K2.6" not in spec_models
+    assert "Qwen/Qwen3.5-397B-A17B" not in spec_models
+
+
+def test_production_yaml_legacy_397b_demoted_to_last() -> None:
+    """The model that originally stream-stalled (Qwen3.5-397B) must
+    not be promoted ahead of the newer model families. Pin it last
+    in the STANDARD/COMPLEX rank — present (operators may want to
+    re-test it once stabilized) but not preferred."""
+    pt._CACHED_TOPOLOGY = None
+    topo = pt.get_topology()
+    standard = topo.dw_models_for_route("standard")
+    if "Qwen/Qwen3.5-397B-A17B" in standard:
+        assert standard[-1] == "Qwen/Qwen3.5-397B-A17B"
+
+
+def test_production_yaml_no_claude_models_in_dw_lists() -> None:
+    """Defensive — if a model_id starting with claude/anthropic
+    accidentally appears in a dw_models list, that's a yaml typo
+    that would cause the sentinel to attempt a Claude-shaped call
+    via the DW provider."""
+    pt._CACHED_TOPOLOGY = None
+    topo = pt.get_topology()
+    for route in (
+        "immediate", "standard", "complex", "background", "speculative",
+    ):
+        for model_id in topo.dw_models_for_route(route):
+            lower = model_id.lower()
+            assert "claude" not in lower
+            assert "anthropic" not in lower
+            assert "gpt" not in lower
+            assert "openai" not in lower
+
+
+def test_production_yaml_bg_spec_fallback_is_queue() -> None:
+    """``project_bg_spec_sealed.md`` contract preserved structurally
+    — BG/SPEC fallback_tolerance is "queue", NOT "cascade_to_claude"."""
+    pt._CACHED_TOPOLOGY = None
+    topo = pt.get_topology()
+    assert topo.fallback_tolerance_for_route("background") == "queue"
+    assert topo.fallback_tolerance_for_route("speculative") == "queue"
+
+
+def test_production_yaml_monitor_block_present() -> None:
+    pt._CACHED_TOPOLOGY = None
+    topo = pt.get_topology()
+    cfg = topo.monitor_config()
+    assert cfg is not None
+    assert cfg.severed_threshold_weighted == 3.0
+
+
+# ---------------------------------------------------------------------------
+# §5 — Phase 10 P10.5 inverse pin (still authoritative; until the purge)
+# ---------------------------------------------------------------------------
+
+
+def test_phase_10_static_dw_allowed_blocks_still_present() -> None:
+    """The 5 ``dw_allowed: false`` lines remain authoritative when
+    JARVIS_TOPOLOGY_SENTINEL_ENABLED is off (default). Removing them
+    early is unsafe — kept until P10.5 operator authorization."""
+    yaml_path = Path(pt.__file__).parent / "brain_selection_policy.yaml"
+    text = yaml_path.read_text(encoding="utf-8")
+    assert text.count("dw_allowed: false") == 5
+
+
+def test_phase_10_read_only_carve_out_still_present() -> None:
+    """The Nervous-System Reflex carve-out at
+    candidate_generator.py:2062-2067 is the deletion target for
+    Phase 10 P10.5. Until purge, it stays — sentinel-on path
+    bypasses it via the new dispatcher; sentinel-off path uses it."""
+    src = CANDIDATE_GEN_PATH.read_text(encoding="utf-8")
+    assert "Nervous-System Reflex" in src or "Nervous System Reflex" in src
+
+
+# ---------------------------------------------------------------------------
+# §6 — Master-flag-off: sentinel branch is INERT (the safety pin)
+# ---------------------------------------------------------------------------
+
+
+def test_master_flag_off_dispatcher_not_invoked_for_sealed_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Source-level pin: in master-flag-off mode, ``_dispatch_via_sentinel``
+    is wrapped in a conditional that's only entered when
+    ``is_sentinel_enabled()`` returns True. Validate the flag default."""
+    monkeypatch.delenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", raising=False)
+    assert ts.is_sentinel_enabled() is False
+
+
+def test_static_block_pattern_unchanged_in_source() -> None:
+    """The static topology block at lines 1404-1465 (legacy path)
+    stays intact under Slice 3 — only a NEW branch precedes it.
+    Pinned by string presence."""
+    src = CANDIDATE_GEN_PATH.read_text(encoding="utf-8")
+    assert "_topology.dw_allowed_for_route" in src
+    # Block-mode skip_and_queue branch still present.
+    assert 'block_mode == "skip_and_queue"' in src
+
+
+def test_dispatcher_method_exists_on_class() -> None:
+    """Module-import-time pin: the new method actually exists on the
+    class with the expected signature."""
+    method = getattr(cg.CandidateGenerator, "_dispatch_via_sentinel", None)
+    assert method is not None
+    assert callable(method)
+    # Async method.
+    assert inspect.iscoroutinefunction(method)


### PR DESCRIPTION
## Summary

Slice 3 of Phase 10 — the FIRST PR where the sentinel can produce non-Claude rows in `cost_by_op_phase_provider`. Bundles original Slice 3 + Slice 4 because wiring without failure-reporting is half-broken.

Master flag `JARVIS_TOPOLOGY_SENTINEL_ENABLED` stays default **false** — when off, behavior is byte-identical to today (existing 230 tests prove it). When on, the sentinel walks the route's ranked `dw_models` list before any Claude cascade.

## YAML v2 model integration (full PRD §3.7.3 audit recommendations)

| Route | Ranked dw_models | fallback_tolerance |
|---|---|---|
| `immediate` | `[]` (Claude-direct by Manifesto §5) | `cascade_to_claude` |
| `standard` | `[Kimi-K2.6, GLM-5.1-FP8, Qwen3.6-35B, Qwen3.5-397B]` | `cascade_to_claude` |
| `complex` | (same as standard) | `cascade_to_claude` |
| `background` | `[Qwen3.6-35B, Kimi-K2.6]` (cheap-first) | **`queue`** |
| `speculative` | `[Qwen3.5-9B, Qwen3.5-4B]` (ultra-cheap) | **`queue`** |

`monitor:` block populated with sentinel tunables — probe intervals, severed threshold (3.0 weighted), heavy probe ratio (0.2), ramp_schedule_csv (slow-start drainage 1→2→4→8→16 ops/s).

The v1 keys (`dw_allowed: false`, `block_mode`) stay — deletion target for Phase 10 P10.5 (operator-authorized after 3 forced-clean once-proofs). Inverse pin `test_phase_10_static_dw_allowed_blocks_still_present` asserts all 5 lines remain.

## Code changes

### `candidate_generator.CandidateGenerator._dispatch_via_sentinel` (NEW ~210 LOC)

Walks ranked `dw_models`. For each model not OPEN: stamps `ctx._dw_model_override` → attempts DW via existing per-route helper. On success: `sentinel.report_success`. On failure: classifies exception → `sentinel.report_failure` → next model. After exhausting all DW models: applies `fallback_tolerance` (queue or cascade_to_claude).

Failure classification matrix (live-traffic exceptions weighted higher than probes):
| Exception pattern | FailureSource | Weight |
|---|---|---|
| `*stream*stall*` / `StreamTimeoutError` | LIVE_STREAM_STALL | 3.0 (single occurrence trips alone) |
| `429` in error string | LIVE_HTTP_429 | 0.5 (transient, upstream-handled) |
| `5xx` in error string | LIVE_HTTP_5XX | 1.0 |
| `parse` / `json` in error | LIVE_PARSE_ERROR | 1.0 |
| Anything else | LIVE_TRANSPORT | 1.0 |

### `doubleword_provider.DoublewordProvider._resolve_effective_model`

Reordered: `ctx._dw_model_override` consulted **first**, then topology's per-route mapping, then `self._model`. Existing v1 callers unaffected (the override is only stamped by the new dispatcher).

### `dw_topology_circuit_breaker.should_circuit_break` (Option C, PR #25229)

Refactored to consult sentinel BEFORE legacy yaml verdict when master flag is on. Three new outcomes:
- `sentinel_all_severed` — fire breaker (queue tolerance + every model OPEN — preserves BG/SPEC unit economics structurally)
- `sentinel_severed_cascade_to_claude` — don't fire (cascade is the contract)
- `sentinel_dw_available` — don't fire (dispatcher will try)

Master-flag-off path byte-identical to PR #25229's logic.

## Test plan

- [x] **29 Slice 3 dispatcher tests** (new `test_topology_sentinel_dispatch.py`)
- [x] **91 Slice 2 reader tests** updated for the ranked-list integration (production yaml is now v2)
- [x] **230/230 combined green** — Slice 1 + Slice 2 + Slice 3 + circuit breaker + Phase 8 wiring + cron installer + compaction caller
- [x] Master-flag-off invariant: every existing v1 caller's verdict byte-identical to pre-Slice-3
- [x] Master-flag-on integration: sentinel evidence drives BG queue contract structurally — all 4 BG models OPEN → breaker fires `sentinel_all_severed` → orchestrator queues op (no Claude burn)
- [ ] **Once-proof under master flag on** — first session with sentinel walking ranked list (next operator decision)

## Out of scope (deferred)

- Caller-side ranked lists for PLAN/SemanticTriage (currently single-model; future slice extends callers schema)
- Vision Tier 1 cheap pre-screen (Qwen3-VL-30B) wiring — separate PR scoped to vision_sensor.py
- Phase 10 P10.5 — THE PURGE (operator-authorized after 3 forced-clean once-proofs)
- Phase 10 P10.6 — 24h soak validation

## Authorization next steps

1. Review + merge this PR
2. Run a **once-proof with `JARVIS_TOPOLOGY_SENTINEL_ENABLED=true`** to produce the first non-Claude `cost_by_op_phase_provider` row in production telemetry
3. After 3 clean once-proofs: authorize P10.5 (THE PURGE — delete static yaml blocks + read-only carve-out + env shortcuts; flip flag default true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sentinel-driven DW dispatch with ranked model lists and circuit-breaker integration, gated by `JARVIS_TOPOLOGY_SENTINEL_ENABLED`. When enabled, routes try non-Claude DW models first; when disabled, behavior is unchanged.

- New Features
  - YAML v2 in `brain_selection_policy.yaml`: per-route ranked `dw_models`, explicit `fallback_tolerance`, and `monitor` tunables.
    - `immediate`: `[]` (Claude-direct)
    - `standard`/`complex`: [`moonshotai/Kimi-K2.6`, `zai-org/GLM-5.1-FP8`, `Qwen/Qwen3.6-35B-A3B-FP8`, `Qwen/Qwen3.5-397B-A17B`] → `cascade_to_claude`
    - `background`: [`Qwen/Qwen3.6-35B-A3B-FP8`, `moonshotai/Kimi-K2.6`] → `queue`
    - `speculative`: [`Qwen/Qwen3.5-9B`, `Qwen/Qwen3.5-4B`] → `queue`
    - v1 keys remain for backward compatibility.
  - Sentinel-driven dispatch in `candidate_generator.CandidateGenerator._dispatch_via_sentinel`: walks ranked `dw_models`, stamps `ctx._dw_model_override`, reports success/failure (stream stall, 429, 5xx, parse, transport), then applies `fallback_tolerance` (`queue` or cascade).
  - Provider resolution in `doubleword_provider.DoublewordProvider._resolve_effective_model`: prefers `ctx._dw_model_override`, then topology route mapping, then instance default.
  - Circuit breaker in `dw_topology_circuit_breaker.should_circuit_break`: consults sentinel first when enabled; new outcomes `sentinel_all_severed`, `sentinel_severed_cascade_to_claude`, `sentinel_dw_available`; legacy path unchanged when disabled.

<sup>Written for commit 19123dd35a7ecc0d56cf2a711e0d82d2a348a6de. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/25706?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

