### PR TITLE
feat(topology): Slice 3.5 — boundary isolation + pre-flight handshake

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1377,31 +1377,56 @@ class CandidateGenerator:
         # ── Route-based dispatch (Manifesto §5 Tier 0: deterministic) ──
         _provider_route = getattr(context, "provider_route", "") or "standard"
 
-        # ── Phase 10 P10.3 — AsyncTopologySentinel-driven dispatch ───
+        # ── Phase 10 P10.3+P10.3.5 — AsyncTopologySentinel gate ────
         # When ``JARVIS_TOPOLOGY_SENTINEL_ENABLED=true``, the sentinel
         # walks the route's ranked ``dw_models`` list (yaml v2) and
-        # picks the first model whose breaker is not OPEN. Each
-        # attempt stamps ``ctx._dw_model_override`` so the provider's
-        # ``_resolve_effective_model`` consumes it. On per-model
-        # failure, ``sentinel.report_failure(...)`` is called and the
-        # walk continues to the next model. After exhausting all DW
-        # models, the route applies its ``fallback_tolerance`` from
-        # yaml v2 (``cascade_to_claude`` or ``queue``).
+        # picks the first model whose breaker is not OPEN.
         #
-        # When the master flag is OFF (default), this branch is a
-        # no-op and the static yaml ``dw_allowed: false`` block below
-        # remains authoritative — byte-identical pre/post-Slice-3
-        # behavior. The static block is the deletion target for
-        # Phase 10 P10.5 (THE PURGE), operator-authorized after 3
-        # forced-clean once-proofs of this dynamic path.
-        try:
-            from backend.core.ouroboros.governance.topology_sentinel import (
-                is_sentinel_enabled as _sentinel_enabled,
+        # Pre-flight handshake (directive 2026-04-27): instead of a
+        # silent try/except that swallows boundary-isolation defects
+        # (which is what bit session bt-2026-04-27-194550), we run
+        # ``preflight_check()`` at the gate. If the sentinel fails to
+        # initialize inside this subprocess for ANY reason — module
+        # import, topology load, missing dw_models — we raise
+        # ``SentinelInitializationError`` so the operator sees the
+        # defect at the point of decision, not minutes later in the
+        # postmortem. Master-flag-off remains byte-identical legacy
+        # behavior: this entire block is bypassed.
+        _flag_raw = os.environ.get(
+            "JARVIS_TOPOLOGY_SENTINEL_ENABLED", "",
+        ).strip().lower()
+        if _flag_raw in ("1", "true", "yes", "on"):
+            try:
+                from backend.core.ouroboros.governance.topology_sentinel import (
+                    preflight_check as _sentinel_preflight,
+                    SentinelInitializationError as _SentinelInitError,
+                )
+            except ImportError as _imp_exc:
+                # Master flag explicitly true but the module is
+                # unimportable — this is a deployment defect, NOT a
+                # silent fall-through. Raise so the orchestrator's
+                # existing accept-failure branch records it visibly.
+                raise RuntimeError(
+                    f"sentinel_module_import_failed:"
+                    f"{type(_imp_exc).__name__}:"
+                    f"{str(_imp_exc)[:120]}"
+                ) from _imp_exc
+            _preflight = _sentinel_preflight()
+            if not _preflight.healthy:
+                raise _SentinelInitError(
+                    _preflight.failed_assertions,
+                    _preflight.diagnostics,
+                )
+            logger.info(
+                "[CandidateGenerator] Phase 10 sentinel preflight: "
+                "healthy=True schema=%s routes_with_dw_models=%s "
+                "monitor_config=%s event_loop_bound=%s diagnostics=%s",
+                _preflight.schema_version,
+                list(_preflight.routes_with_dw_models),
+                _preflight.monitor_config_present,
+                _preflight.event_loop_bound,
+                list(_preflight.diagnostics),
             )
-            _sentinel_active = _sentinel_enabled()
-        except Exception:
-            _sentinel_active = False
-        if _sentinel_active:
             _result = await self._dispatch_via_sentinel(
                 context, deadline, _provider_route,
             )

--- a/backend/core/ouroboros/governance/graduation/live_fire_soak.py
+++ b/backend/core/ouroboros/governance/graduation/live_fire_soak.py
@@ -767,12 +767,32 @@ class LiveFireSoakHarness:
 
     def _build_env_for_flag(self, flag_name: str) -> Dict[str, str]:
         """Build the env dict for the subprocess: inherit current
-        env + set ONLY (flag_name + dependencies) to ``true``.
+        env + set ONLY (flag_name + dependencies) to ``true`` + EXPLICITLY
+        forward AsyncTopologySentinel-related env vars.
 
         Other JARVIS_* substrate flags are NOT touched — the subprocess
         sees the inherited env exactly. This matches the contract that
         substrate flags are individually graduated; flipping multiple
         in one soak would muddle the evidence.
+
+        **Slice 3.5 — explicit sentinel env propagation** (directive
+        2026-04-27): Sentinel-related env vars are forwarded VIA AN
+        EXPLICIT ALLOWLIST (``topology_sentinel.sentinel_propagated_vars``)
+        rather than relying on ``dict(os.environ)`` inheritance alone.
+        This makes the propagation contract:
+
+          (a) Discoverable — operators grep ``_SENTINEL_PROPAGATED_VARS``
+              in topology_sentinel.py to see the full list.
+          (b) Defensible — if ``os.environ`` ever gets stripped or a
+              future refactor breaks the inherit-everything assumption,
+              the explicit forwarding still holds.
+          (c) Testable — ``test_sentinel_env_propagation_contract``
+              asserts the harness forwards every sentinel env var the
+              dispatcher reads.
+
+        Closes the boundary-isolation gap that bit session
+        bt-2026-04-27-194550 (sentinel module loaded inside the
+        subprocess but the dispatcher never entered its branch).
         """
         env = dict(os.environ)
         env[flag_name] = "true"
@@ -787,6 +807,30 @@ class LiveFireSoakHarness:
         # the canonical record_session call inside the harness's
         # post-subprocess phase succeeds.
         env["JARVIS_GRADUATION_LEDGER_ENABLED"] = "true"
+        # Explicit sentinel env propagation (Slice 3.5). Re-asserts
+        # the parent's value (or absence) for every sentinel-related
+        # env var. If the parent set JARVIS_TOPOLOGY_SENTINEL_ENABLED=true,
+        # the subprocess will see it; if unset in parent, it stays
+        # unset (default behavior). Same effect as inheritance, but
+        # explicit + AST-grep-able.
+        try:
+            from backend.core.ouroboros.governance.topology_sentinel import (
+                sentinel_propagated_vars,
+            )
+            for name in sentinel_propagated_vars():
+                value = os.environ.get(name)
+                if value is not None:
+                    env[name] = value
+                # If unset in parent, do NOT inject a default — the
+                # sentinel module's own defaults handle that.
+        except ImportError:
+            # Sentinel module not available (e.g. on a branch that
+            # hasn't merged Slice 1). Inheritance still applies via
+            # dict(os.environ) above; degrade gracefully.
+            logger.debug(
+                "[LiveFireSoak] sentinel_propagated_vars unavailable — "
+                "falling back to inheritance-only env propagation"
+            )
         return env
 
     def _maybe_apply_contract(

--- a/backend/core/ouroboros/governance/topology_sentinel.py
+++ b/backend/core/ouroboros/governance/topology_sentinel.py
@@ -97,6 +97,66 @@ SCHEMA_VERSION = "topology_sentinel.1"
 
 
 # ---------------------------------------------------------------------------
+# Boundary isolation — explicit env propagation contract (Slice 3.5)
+# ---------------------------------------------------------------------------
+#
+# Per the 2026-04-27 directive ("Process Boundary Isolation & Pre-Flight
+# Handshake"): the harness MUST NOT rely on implicit env inheritance to
+# reach the orchestrator subprocess. Every env var the sentinel layer
+# consumes is enumerated here so ``live_fire_soak._build_env_for_flag``
+# can forward them explicitly + so a future operator can grep this
+# constant to discover the full sentinel-related env surface.
+#
+# Adding a new sentinel env var? Add it here AND update
+# ``test_sentinel_env_propagation_contract`` (which asserts every
+# JARVIS_TOPOLOGY_* var the module reads is in this list).
+
+_SENTINEL_PROPAGATED_VARS: Tuple[str, ...] = (
+    # Master flag
+    "JARVIS_TOPOLOGY_SENTINEL_ENABLED",
+    "JARVIS_TOPOLOGY_FORCE_SEVERED",
+    # Threshold + decay
+    "JARVIS_TOPOLOGY_SEVERED_THRESHOLD_WEIGHTED",
+    "JARVIS_TOPOLOGY_SUCCESS_DECAY",
+    # Probe schedule
+    "JARVIS_TOPOLOGY_HEALTHY_PROBE_INTERVAL_S",
+    "JARVIS_TOPOLOGY_PROBE_BACKOFF_BASE_S",
+    "JARVIS_TOPOLOGY_PROBE_BACKOFF_CAP_S",
+    "JARVIS_TOPOLOGY_HEAVY_PROBE_RATIO",
+    "JARVIS_TOPOLOGY_LIGHT_PROBE_FIRST_TOKEN_TIMEOUT_S",
+    "JARVIS_TOPOLOGY_HEAVY_PROBE_TOTAL_TIMEOUT_S",
+    "JARVIS_TOPOLOGY_HEAVY_PROBE_MAX_TOKENS",
+    "JARVIS_TOPOLOGY_PROBE_DAILY_USD_CAP",
+    # Slow-start ramp
+    "JARVIS_TOPOLOGY_RAMP_SCHEDULE",
+    "JARVIS_TOPOLOGY_RAMP_MAX_WAIT_S",
+    # State persistence
+    "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR",
+    "JARVIS_TOPOLOGY_SENTINEL_HISTORY_SIZE",
+    "JARVIS_TOPOLOGY_STATE_MAX_AGE_S",
+    # Per-source weight overrides
+    "JARVIS_TOPOLOGY_WEIGHT_LIVE_STREAM_STALL",
+    "JARVIS_TOPOLOGY_WEIGHT_LIVE_TRANSPORT",
+    "JARVIS_TOPOLOGY_WEIGHT_LIVE_HTTP_5XX",
+    "JARVIS_TOPOLOGY_WEIGHT_LIVE_HTTP_429",
+    "JARVIS_TOPOLOGY_WEIGHT_LIVE_PARSE_ERROR",
+    "JARVIS_TOPOLOGY_WEIGHT_HEAVY_PROBE_FAIL",
+    "JARVIS_TOPOLOGY_WEIGHT_LIGHT_PROBE_FAIL",
+    "JARVIS_TOPOLOGY_WEIGHT_LIGHT_PROBE_TIMEOUT",
+)
+
+
+def sentinel_propagated_vars() -> Tuple[str, ...]:
+    """Tuple of env var names the harness MUST forward into the
+    orchestrator subprocess. Read by
+    ``live_fire_soak._build_env_for_flag`` for explicit propagation.
+
+    Never raises. Stable ordering — operators can diff this surface
+    over time without churning the harness."""
+    return _SENTINEL_PROPAGATED_VARS
+
+
+# ---------------------------------------------------------------------------
 # Env helpers — same idiom as posture_observer / posture_store
 # ---------------------------------------------------------------------------
 
@@ -1460,6 +1520,233 @@ class TopologySentinel:
 
 
 # ---------------------------------------------------------------------------
+# Slice 3.5 — Pre-flight handshake (boundary isolation diagnostic)
+# ---------------------------------------------------------------------------
+#
+# Per the 2026-04-27 directive: when the master flag is on, the
+# orchestrator MUST natively verify its sentinel state before accepting
+# traffic. Silent failure inside the dispatcher's lazy import was the
+# bug that caused the once-proof on session bt-2026-04-27-194550 to
+# never enter the sentinel branch despite env being set.
+#
+# ``preflight_check()`` runs at the moment the dispatcher gate fires.
+# If any assertion fails, the dispatcher raises
+# ``SentinelInitializationError`` so the operator sees the boundary
+# isolation defect at the point of decision, not minutes later in
+# the postmortem.
+
+
+class SentinelInitializationError(RuntimeError):
+    """Raised when ``preflight_check()`` detects a boundary-isolation
+    failure that prevents the AsyncTopologySentinel from making
+    correct routing decisions for the current operation.
+
+    Carries a structured failure list so the orchestrator's existing
+    accept-failure branch (and future SSE telemetry) can record
+    exactly what went wrong without parsing free-form strings.
+
+    Raised path: ``candidate_generator._generate_dispatch`` →
+    ``preflight_check()`` → if not healthy → raise. Caller may catch
+    + cascade-to-Claude OR re-raise depending on operator policy.
+    """
+
+    def __init__(
+        self, failed_assertions: Tuple[str, ...], diagnostics: Tuple[str, ...] = (),
+    ) -> None:
+        self.failed_assertions = tuple(failed_assertions)
+        self.diagnostics = tuple(diagnostics)
+        msg = (
+            "AsyncTopologySentinel boundary-isolation failure: "
+            + "; ".join(failed_assertions)
+        )
+        super().__init__(msg)
+
+
+@dataclass(frozen=True)
+class SentinelPreflightResult:
+    """Structured snapshot of the sentinel's readiness at one
+    decision point. Returned by ``preflight_check()``; consumed by
+    the dispatcher gate AND by tests + observability surfaces.
+
+    A "healthy" result means the dispatcher can proceed with full
+    confidence that:
+      * the master flag is on
+      * the topology yaml is loaded with v2 schema + ranked dw_models
+      * the singleton is hydrated (or hydration was attempted cleanly)
+      * the running asyncio event loop is the loop the sentinel will
+        attach its probe task to (no orphan-loop bug)
+
+    Any of the above missing → ``failed_assertions`` populated → the
+    dispatcher raises ``SentinelInitializationError``.
+    """
+
+    flag_enabled: bool
+    module_imported: bool
+    singleton_initialized: bool
+    topology_loaded: bool
+    schema_version: str
+    routes_with_dw_models: Tuple[str, ...]
+    monitor_config_present: bool
+    event_loop_bound: bool
+    state_dir_writable: bool
+    diagnostics: Tuple[str, ...] = ()
+    failed_assertions: Tuple[str, ...] = ()
+
+    @property
+    def healthy(self) -> bool:
+        return not self.failed_assertions
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Stable JSON shape for telemetry + audit."""
+        return {
+            "schema_version": "preflight.1",
+            "flag_enabled": self.flag_enabled,
+            "module_imported": self.module_imported,
+            "singleton_initialized": self.singleton_initialized,
+            "topology_loaded": self.topology_loaded,
+            "topology_schema_version": self.schema_version,
+            "routes_with_dw_models": list(self.routes_with_dw_models),
+            "monitor_config_present": self.monitor_config_present,
+            "event_loop_bound": self.event_loop_bound,
+            "state_dir_writable": self.state_dir_writable,
+            "diagnostics": list(self.diagnostics),
+            "failed_assertions": list(self.failed_assertions),
+            "healthy": self.healthy,
+        }
+
+
+def preflight_check(
+    *,
+    require_routes: bool = True,
+) -> SentinelPreflightResult:
+    """Native, structured initialization check.
+
+    Runs at the dispatcher gate; designed for the orchestrator
+    subprocess context (NOT pure-test ergonomics — tests mock the
+    pieces). NEVER raises directly — every check is bounded by
+    try/except + assertion accumulator. The CALLER decides whether
+    ``not healthy`` is fatal (dispatcher raises
+    ``SentinelInitializationError``; observability surfaces just
+    report).
+
+    Parameters:
+      ``require_routes`` — when True (default), at least one route
+      MUST have a non-empty ``dw_models`` list. The IMMEDIATE-only
+      degenerate case is caught by the dispatcher's per-route
+      empty-list fall-through and isn't a healthy sentinel system.
+      Tests pass False for the no-routes case.
+
+    Returns ``SentinelPreflightResult`` with explicit booleans +
+    diagnostics + failed_assertions list. ``healthy`` is True iff
+    failed_assertions is empty.
+    """
+    diagnostics: List[str] = []
+    failed: List[str] = []
+
+    flag_enabled = is_sentinel_enabled()
+    if not flag_enabled:
+        # Not an error — just informational. Dispatcher won't enter
+        # this code path in this case, but the helper still returns
+        # a complete shape for telemetry.
+        diagnostics.append("master_flag_off")
+
+    module_imported = True   # if this function is running, the module imported
+    singleton_initialized = False
+    topology_loaded = False
+    schema_version = ""
+    monitor_config_present = False
+    routes_with_dw_models: List[str] = []
+
+    try:
+        sentinel = get_default_sentinel()
+        singleton_initialized = sentinel is not None
+    except Exception as exc:  # noqa: BLE001
+        failed.append(
+            f"singleton_init_failed:{type(exc).__name__}:{str(exc)[:80]}"
+        )
+        sentinel = None
+
+    try:
+        from backend.core.ouroboros.governance.provider_topology import (
+            get_topology,
+        )
+        topo = get_topology()
+        topology_loaded = bool(getattr(topo, "enabled", False))
+        schema_version = str(getattr(topo, "schema_version", ""))
+        monitor_config_present = topo.monitor_config() is not None
+        for route in (
+            "immediate", "standard", "complex", "background", "speculative",
+        ):
+            try:
+                models = topo.dw_models_for_route(route)
+                if models:
+                    routes_with_dw_models.append(route)
+            except Exception as exc:  # noqa: BLE001
+                diagnostics.append(
+                    f"dw_models_query_failed:{route}:{type(exc).__name__}"
+                )
+    except Exception as exc:  # noqa: BLE001
+        failed.append(
+            f"topology_load_failed:{type(exc).__name__}:{str(exc)[:80]}"
+        )
+
+    if not topology_loaded:
+        failed.append("topology_not_loaded")
+    if require_routes and not routes_with_dw_models:
+        failed.append("no_routes_have_dw_models")
+
+    # Event-loop binding probe — the directive's "async event loop
+    # binding" check. ``asyncio.get_running_loop()`` raises
+    # RuntimeError when called outside an active loop; if the
+    # dispatcher is calling this, an active loop exists. Any failure
+    # here = the sentinel's probe task would be orphaned.
+    event_loop_bound = False
+    try:
+        loop = asyncio.get_running_loop()
+        event_loop_bound = loop is not None and not loop.is_closed()
+    except RuntimeError:
+        # Called from a non-async context — preflight_check still
+        # works for synchronous callers (tests, /sentinel REPL); the
+        # dispatcher's call site is async so it'll always have a loop.
+        diagnostics.append("preflight_called_outside_async_loop")
+    except Exception as exc:  # noqa: BLE001
+        failed.append(
+            f"event_loop_probe_failed:{type(exc).__name__}"
+        )
+
+    # State dir writability — the persistence path. If the harness
+    # picked a state dir we can't write to, sentinel state wouldn't
+    # survive process restart (boot-loop protection broken).
+    state_dir_writable = False
+    try:
+        d = state_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        # Probe a lock file (cheap, doesn't pollute the real ledger).
+        probe = d / ".preflight_probe.tmp"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink(missing_ok=True)
+        state_dir_writable = True
+    except Exception as exc:  # noqa: BLE001
+        diagnostics.append(
+            f"state_dir_unwritable:{type(exc).__name__}"
+        )
+
+    return SentinelPreflightResult(
+        flag_enabled=flag_enabled,
+        module_imported=module_imported,
+        singleton_initialized=singleton_initialized,
+        topology_loaded=topology_loaded,
+        schema_version=schema_version,
+        routes_with_dw_models=tuple(routes_with_dw_models),
+        monitor_config_present=monitor_config_present,
+        event_loop_bound=event_loop_bound,
+        state_dir_writable=state_dir_writable,
+        diagnostics=tuple(diagnostics),
+        failed_assertions=tuple(failed),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Module-level singleton (Slice 5 wires GovernedLoopService to call .start)
 # ---------------------------------------------------------------------------
 
@@ -1498,6 +1785,10 @@ __all__ = [
     "EndpointSnapshot",
     "FailureSource",
     "ProbeFn",
+    "SentinelInitializationError",
+    "SentinelPreflightResult",
+    "preflight_check",
+    "sentinel_propagated_vars",
     "ProbeOutcome",
     "ProbeResult",
     "ProbeWeight",

--- a/tests/governance/test_topology_sentinel_dispatch.py
+++ b/tests/governance/test_topology_sentinel_dispatch.py
@@ -60,16 +60,24 @@ def test_sentinel_branch_inserted_before_static_topology_gate() -> None:
 
 
 def test_sentinel_branch_gated_by_master_flag() -> None:
-    """The sentinel branch must be gated by ``is_sentinel_enabled()``
-    so it's a no-op when the master flag is off."""
+    """The sentinel branch must be gated by an explicit master-flag
+    check (post-Slice-3.5: an explicit ``os.environ.get`` read +
+    truthy-value comparison). Master-flag-off must short-circuit
+    BEFORE importing the sentinel module so legacy is byte-identical."""
     src = CANDIDATE_GEN_PATH.read_text(encoding="utf-8")
-    # Find the sentinel call site
-    site_idx = src.index("_dispatch_via_sentinel")
-    pre = src[max(0, site_idx - 600):site_idx]
-    assert "is_sentinel_enabled" in pre, (
-        "expected is_sentinel_enabled() check immediately before "
-        "_dispatch_via_sentinel — without it the new path runs "
-        "unconditionally"
+    # Anchor on the gate's own comment, not _dispatch_via_sentinel
+    # (which also appears in the method's own definition far below).
+    anchor_idx = src.index("Phase 10 P10.3+P10.3.5")
+    window = src[anchor_idx:anchor_idx + 2500]
+    assert "JARVIS_TOPOLOGY_SENTINEL_ENABLED" in window, (
+        "expected master-flag env-name in dispatcher gate block"
+    )
+    assert (
+        'in ("1", "true", "yes", "on")' in window
+        or 'is_sentinel_enabled' in window
+    ), (
+        "expected truthy-value parse OR is_sentinel_enabled() helper "
+        "call in the gate"
     )
 
 

--- a/tests/governance/test_topology_sentinel_preflight.py
+++ b/tests/governance/test_topology_sentinel_preflight.py
@@ -1,0 +1,462 @@
+"""Slice 3.5 regression spine — Pre-Flight Handshake + boundary isolation.
+
+Pins the architectural fix from the 2026-04-27 directive:
+
+  * ``SentinelInitializationError`` raised when the sentinel can't
+    initialize inside the subprocess context — instead of the prior
+    silent try/except that swallowed boundary-isolation defects.
+  * ``preflight_check()`` returns a structured result with explicit
+    booleans for every gate: flag enabled, module imported, singleton
+    initialized, topology loaded, schema_version, routes with
+    dw_models, monitor config, event-loop binding, state-dir writable.
+  * ``sentinel_propagated_vars()`` enumerates every JARVIS_TOPOLOGY_*
+    env var the sentinel layer reads. Test asserts every var the
+    module reads is in the list (no silent additions).
+  * ``live_fire_soak._build_env_for_flag`` explicitly forwards every
+    var from ``sentinel_propagated_vars()``. Test asserts the
+    forwarding holds end-to-end through the harness's env build.
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import topology_sentinel as ts
+from backend.core.ouroboros.governance import candidate_generator as cg
+from backend.core.ouroboros.governance.graduation import live_fire_soak as lfs
+
+
+# ===========================================================================
+# §1 — SentinelInitializationError shape
+# ===========================================================================
+
+
+def test_sentinel_init_error_is_runtime_error_subclass() -> None:
+    assert issubclass(ts.SentinelInitializationError, RuntimeError)
+
+
+def test_sentinel_init_error_carries_failed_assertions() -> None:
+    err = ts.SentinelInitializationError(
+        ("topology_not_loaded", "no_routes_have_dw_models"),
+        ("master_flag_off",),
+    )
+    assert err.failed_assertions == (
+        "topology_not_loaded", "no_routes_have_dw_models",
+    )
+    assert err.diagnostics == ("master_flag_off",)
+    # Stringification must surface the assertions.
+    msg = str(err)
+    assert "topology_not_loaded" in msg
+    assert "no_routes_have_dw_models" in msg
+
+
+def test_sentinel_init_error_empty_assertions() -> None:
+    err = ts.SentinelInitializationError((), ())
+    assert err.failed_assertions == ()
+    assert err.diagnostics == ()
+
+
+# ===========================================================================
+# §2 — preflight_check() — structured initialization result
+# ===========================================================================
+
+
+def test_preflight_returns_healthy_with_master_flag_on(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    ts.reset_default_sentinel_for_tests()
+    # Force topology cache reload to read v2 yaml.
+    from backend.core.ouroboros.governance import provider_topology as pt
+    pt._CACHED_TOPOLOGY = None
+    result = ts.preflight_check()
+    assert result.healthy is True
+    assert result.flag_enabled is True
+    assert result.topology_loaded is True
+    assert result.schema_version == "topology.2"
+    assert "background" in result.routes_with_dw_models
+    assert result.monitor_config_present is True
+    assert result.state_dir_writable is True
+    ts.reset_default_sentinel_for_tests()
+
+
+def test_preflight_with_master_flag_off_still_returns_result(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Master-flag-off is a valid state — preflight returns a result
+    with diagnostics, NOT failed_assertions. Caller decides what to
+    do (the dispatcher won't enter the gate at all in this case)."""
+    monkeypatch.delenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", raising=False)
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    result = ts.preflight_check()
+    assert result.flag_enabled is False
+    assert "master_flag_off" in result.diagnostics
+
+
+def test_preflight_routes_with_dw_models_drops_immediate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """IMMEDIATE has empty dw_models by design (Manifesto §5 — Claude
+    direct). It must NOT appear in routes_with_dw_models."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    from backend.core.ouroboros.governance import provider_topology as pt
+    pt._CACHED_TOPOLOGY = None
+    ts.reset_default_sentinel_for_tests()
+    result = ts.preflight_check()
+    assert "immediate" not in result.routes_with_dw_models
+    assert "standard" in result.routes_with_dw_models
+    assert "background" in result.routes_with_dw_models
+    ts.reset_default_sentinel_for_tests()
+
+
+def test_preflight_to_dict_pinned_schema(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    from backend.core.ouroboros.governance import provider_topology as pt
+    pt._CACHED_TOPOLOGY = None
+    ts.reset_default_sentinel_for_tests()
+    result = ts.preflight_check()
+    payload = result.to_dict()
+    assert payload["schema_version"] == "preflight.1"
+    assert "flag_enabled" in payload
+    assert "failed_assertions" in payload
+    assert "healthy" in payload
+    ts.reset_default_sentinel_for_tests()
+
+
+def test_preflight_state_dir_unwritable_marked_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the state dir can't be created (permission, etc.), preflight
+    reports it via diagnostic. This isn't a fatal assertion — the
+    dispatcher can still function; only persistence is affected."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    # Point at a path that contains a file (so mkdir fails with NotADirectory).
+    bad = "/etc/passwd/subdir"
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", bad)
+    from backend.core.ouroboros.governance import provider_topology as pt
+    pt._CACHED_TOPOLOGY = None
+    ts.reset_default_sentinel_for_tests()
+    result = ts.preflight_check()
+    assert result.state_dir_writable is False
+    assert any(
+        "state_dir_unwritable" in d for d in result.diagnostics
+    )
+    ts.reset_default_sentinel_for_tests()
+
+
+def test_preflight_require_routes_false_no_routes_still_healthy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tests can disable the routes-required check via the kwarg —
+    useful for unit tests that want to verify other branches in
+    isolation."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    from backend.core.ouroboros.governance import provider_topology as pt
+    pt._CACHED_TOPOLOGY = None
+    ts.reset_default_sentinel_for_tests()
+    result = ts.preflight_check(require_routes=False)
+    # Result is still produced even with require_routes=False; production
+    # yaml has routes, so this returns healthy.
+    assert isinstance(result, ts.SentinelPreflightResult)
+    ts.reset_default_sentinel_for_tests()
+
+
+# ===========================================================================
+# §3 — sentinel_propagated_vars() contract
+# ===========================================================================
+
+
+def test_sentinel_propagated_vars_includes_master_flag() -> None:
+    vars_list = ts.sentinel_propagated_vars()
+    assert "JARVIS_TOPOLOGY_SENTINEL_ENABLED" in vars_list
+
+
+def test_sentinel_propagated_vars_includes_force_severed() -> None:
+    assert "JARVIS_TOPOLOGY_FORCE_SEVERED" in ts.sentinel_propagated_vars()
+
+
+def test_sentinel_propagated_vars_includes_state_dir() -> None:
+    assert "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR" in ts.sentinel_propagated_vars()
+
+
+def test_sentinel_propagated_vars_returns_tuple() -> None:
+    vars_list = ts.sentinel_propagated_vars()
+    assert isinstance(vars_list, tuple)
+    # Stable shape — every element must be a string starting with the
+    # canonical prefix.
+    for name in vars_list:
+        assert isinstance(name, str)
+        assert name.startswith("JARVIS_TOPOLOGY_") or name.startswith(
+            "JARVIS_TOPOLOGY_WEIGHT_"
+        )
+
+
+def test_sentinel_propagated_vars_no_duplicates() -> None:
+    vars_list = ts.sentinel_propagated_vars()
+    assert len(vars_list) == len(set(vars_list))
+
+
+def test_sentinel_env_propagation_contract() -> None:
+    """**The boundary isolation contract** — every JARVIS_TOPOLOGY_*
+    env var that ``topology_sentinel.py`` reads MUST appear in
+    ``_SENTINEL_PROPAGATED_VARS``. Otherwise the harness's explicit
+    forwarding will miss it and the silent boundary failure recurs.
+
+    This test parses the module source, finds every ``os.environ.get``
+    / ``os.environ[..]`` access with a JARVIS_TOPOLOGY_ prefix, and
+    asserts each is in the propagated list."""
+    src = Path(ts.__file__).read_text(encoding="utf-8")
+    pattern = re.compile(
+        r'os\.environ(?:\.get)?\(\s*["\'](JARVIS_TOPOLOGY_\w+)["\']'
+    )
+    found = set(pattern.findall(src))
+    # _env_bool / _env_int / _env_float / _env_path receive the name as
+    # an arg — also scan for those.
+    helper_pattern = re.compile(
+        r'_env_\w+\(\s*["\'](JARVIS_TOPOLOGY_\w+)["\']'
+    )
+    found |= set(helper_pattern.findall(src))
+    # f-string access for the per-source weight overrides.
+    fstring_pattern = re.compile(
+        r'f["\']JARVIS_TOPOLOGY_WEIGHT_'
+    )
+    if fstring_pattern.search(src):
+        # The weight env knobs are constructed dynamically — they're
+        # already pinned by name in _SENTINEL_PROPAGATED_VARS via the
+        # FailureSource enum mapping. Verify the mapping is complete.
+        for source in ts.FailureSource:
+            expected = f"JARVIS_TOPOLOGY_WEIGHT_{source.name}"
+            assert expected in ts.sentinel_propagated_vars(), (
+                f"FailureSource {source.name} weight knob {expected} "
+                "must appear in _SENTINEL_PROPAGATED_VARS"
+            )
+    propagated = set(ts.sentinel_propagated_vars())
+    missing = found - propagated
+    assert not missing, (
+        f"env vars read by sentinel module but not in propagation "
+        f"list: {missing}"
+    )
+
+
+# ===========================================================================
+# §4 — Harness env forwarding (live_fire_soak)
+# ===========================================================================
+
+
+def test_harness_env_forwards_sentinel_master_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """End-to-end: parent sets JARVIS_TOPOLOGY_SENTINEL_ENABLED=true,
+    harness builds env, subprocess sees it."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    h = lfs.LiveFireSoakHarness(
+        project_root=Path("/Users/djrussell23/Documents/repos/JARVIS-AI-Agent"),
+    )
+    env = h._build_env_for_flag("JARVIS_DECISION_TRACE_LEDGER_ENABLED")
+    assert env.get("JARVIS_TOPOLOGY_SENTINEL_ENABLED") == "true"
+
+
+def test_harness_env_does_not_inject_sentinel_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When parent has NOT set the master flag, harness must not
+    inject a default value — the sentinel module's own default-false
+    handles it. Forwarding ≠ defaulting."""
+    monkeypatch.delenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", raising=False)
+    h = lfs.LiveFireSoakHarness(
+        project_root=Path("/Users/djrussell23/Documents/repos/JARVIS-AI-Agent"),
+    )
+    env = h._build_env_for_flag("JARVIS_DECISION_TRACE_LEDGER_ENABLED")
+    assert "JARVIS_TOPOLOGY_SENTINEL_ENABLED" not in env or (
+        env["JARVIS_TOPOLOGY_SENTINEL_ENABLED"] == ""
+    )
+
+
+def test_harness_env_forwards_force_severed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_FORCE_SEVERED", "true")
+    h = lfs.LiveFireSoakHarness(
+        project_root=Path("/Users/djrussell23/Documents/repos/JARVIS-AI-Agent"),
+    )
+    env = h._build_env_for_flag("JARVIS_DECISION_TRACE_LEDGER_ENABLED")
+    assert env.get("JARVIS_TOPOLOGY_FORCE_SEVERED") == "true"
+
+
+def test_harness_env_forwards_state_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    h = lfs.LiveFireSoakHarness(
+        project_root=Path("/Users/djrussell23/Documents/repos/JARVIS-AI-Agent"),
+    )
+    env = h._build_env_for_flag("JARVIS_DECISION_TRACE_LEDGER_ENABLED")
+    assert env.get("JARVIS_TOPOLOGY_SENTINEL_STATE_DIR") == str(tmp_path)
+
+
+def test_harness_env_forwards_every_propagated_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Stress test: set every var in _SENTINEL_PROPAGATED_VARS, build
+    env, assert all forwarded."""
+    sentinel_value = "test-fwd"
+    for name in ts.sentinel_propagated_vars():
+        monkeypatch.setenv(name, f"{sentinel_value}-{name}")
+    h = lfs.LiveFireSoakHarness(
+        project_root=Path("/Users/djrussell23/Documents/repos/JARVIS-AI-Agent"),
+    )
+    env = h._build_env_for_flag("JARVIS_DECISION_TRACE_LEDGER_ENABLED")
+    for name in ts.sentinel_propagated_vars():
+        assert env.get(name) == f"{sentinel_value}-{name}", (
+            f"{name} not forwarded by harness env build"
+        )
+
+
+# ===========================================================================
+# §5 — Dispatcher gate uses preflight + raises on failure
+# ===========================================================================
+
+
+def test_dispatcher_gate_imports_preflight_check() -> None:
+    """Source-level pin: the dispatcher's gate at line 1404+ must
+    import ``preflight_check`` and ``SentinelInitializationError``
+    (not just ``is_sentinel_enabled``)."""
+    src = Path(cg.__file__).read_text(encoding="utf-8")
+    # Find the Phase 10 gate block.
+    gate_idx = src.index("Phase 10 sentinel preflight")
+    pre_window = src[max(0, gate_idx - 1000):gate_idx]
+    assert "preflight_check" in pre_window
+    assert "SentinelInitializationError" in pre_window
+
+
+def test_dispatcher_gate_raises_on_unhealthy_preflight() -> None:
+    """Source-level pin: dispatcher MUST raise (not silently fall
+    through) when preflight is unhealthy. Verify the raise statement
+    is present in the gate block."""
+    src = Path(cg.__file__).read_text(encoding="utf-8")
+    gate_idx = src.index("Phase 10 sentinel preflight")
+    window = src[max(0, gate_idx - 1500):gate_idx + 500]
+    assert "raise _SentinelInitError" in window or (
+        "raise SentinelInitializationError" in window
+    )
+
+
+def test_dispatcher_gate_raises_on_import_failure() -> None:
+    """Source-level pin: master-flag-on + module import failure must
+    raise (not silently set _sentinel_active=False). The directive's
+    'no silent fallback' contract."""
+    src = Path(cg.__file__).read_text(encoding="utf-8")
+    gate_idx = src.index("Phase 10 sentinel preflight")
+    window = src[max(0, gate_idx - 1500):gate_idx + 500]
+    assert "sentinel_module_import_failed" in window
+    assert "raise RuntimeError" in window
+
+
+def test_dispatcher_gate_logs_preflight_result() -> None:
+    """Source-level pin: on successful preflight, the dispatcher logs
+    a single structured INFO line so operators can confirm the gate
+    fired correctly. This is NOT the silent-failure log line we
+    rejected — it's an affirmative success record."""
+    src = Path(cg.__file__).read_text(encoding="utf-8")
+    gate_idx = src.index("Phase 10 sentinel preflight")
+    window = src[max(0, gate_idx - 1500):gate_idx + 500]
+    assert "Phase 10 sentinel preflight:" in window
+
+
+def test_dispatcher_gate_master_flag_off_path_unchanged() -> None:
+    """Master-flag-off path MUST remain byte-identical legacy behavior.
+    The gate block is wrapped in ``if _flag_raw in (...)``; below it
+    the static yaml gate at line 1439+ is the legacy path."""
+    src = Path(cg.__file__).read_text(encoding="utf-8")
+    # The legacy gate's signature stays present (regression guard).
+    assert "_topology.dw_allowed_for_route" in src
+    # The flag-on conditional surrounds the preflight block.
+    gate_idx = src.index("Phase 10 sentinel preflight")
+    # Widen the search window to include the gate's own block + a few
+    # lines after, where the conditional's text resides.
+    pre = src[max(0, gate_idx - 2000):gate_idx + 1500]
+    assert "JARVIS_TOPOLOGY_SENTINEL_ENABLED" in pre, (
+        "expected master-flag check string in dispatcher gate block"
+    )
+    assert 'in ("1", "true", "yes", "on")' in pre, (
+        "expected truthy-value parsing in the gate's flag check"
+    )
+
+
+# ===========================================================================
+# §6 — Boundary isolation invariants
+# ===========================================================================
+
+
+def test_preflight_function_is_synchronous() -> None:
+    """preflight_check() must be synchronous so it can be called from
+    both async (the dispatcher) AND sync (tests, /sentinel REPL)
+    contexts."""
+    assert not inspect.iscoroutinefunction(ts.preflight_check)
+
+
+def test_preflight_never_raises_on_caller_facing_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The CALLER raises SentinelInitializationError when
+    .healthy is False. preflight_check() itself must never raise —
+    it must always return a structured result."""
+    # Force a topology-load failure by pointing yaml resolution at a
+    # bogus path. This isn't a real env knob — we monkey-patch the
+    # resolver so the test is deterministic.
+    from backend.core.ouroboros.governance import provider_topology as pt
+    monkeypatch.setattr(
+        pt, "_locate_policy_yaml", lambda: None,
+    )
+    pt._CACHED_TOPOLOGY = None
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
+    )
+    ts.reset_default_sentinel_for_tests()
+    # Must not raise. Must return a result with healthy=False.
+    result = ts.preflight_check()
+    assert isinstance(result, ts.SentinelPreflightResult)
+    assert result.healthy is False
+    ts.reset_default_sentinel_for_tests()
+
+
+def test_sentinel_init_error_carries_unhealthy_preflight_data() -> None:
+    """When the dispatcher raises SentinelInitializationError, the
+    error MUST carry the failed_assertions + diagnostics from the
+    preflight result so operators see exactly what failed."""
+    err = ts.SentinelInitializationError(
+        ("topology_not_loaded",),
+        ("master_flag_off", "state_dir_unwritable:OSError"),
+    )
+    assert "topology_not_loaded" in err.failed_assertions
+    assert "master_flag_off" in err.diagnostics
+
+
+def test_preflight_export_in_module_all() -> None:
+    assert "preflight_check" in ts.__all__
+    assert "SentinelInitializationError" in ts.__all__
+    assert "SentinelPreflightResult" in ts.__all__
+    assert "sentinel_propagated_vars" in ts.__all__


### PR DESCRIPTION
## Summary

Architectural fix per directive 2026-04-27 ("Process Boundary Isolation & Pre-Flight Handshake"). Replaces the silent try/except in `candidate_generator`'s sentinel gate (which swallowed the boundary-isolation defect that caused session `bt-2026-04-27-194550` to never enter the dispatcher branch) with a permanent, structured pre-flight handshake + hard failure mode + explicit env propagation contract.

## Three permanent components

1. **`SentinelInitializationError` + `SentinelPreflightResult` + `preflight_check()`** in `topology_sentinel.py`. Structured native initialization check. Returns explicit booleans for:
   - `flag_enabled`, `module_imported`, `singleton_initialized`
   - `topology_loaded`, `schema_version`, `routes_with_dw_models`, `monitor_config_present`
   - `event_loop_bound`, `state_dir_writable`
   - Plus `diagnostics` + `failed_assertions` lists
   - NEVER raises directly — caller decides what to do with `.healthy`.

2. **Dispatcher gate refactor** in `candidate_generator._generate_dispatch`. Master flag now read via explicit `os.environ.get` (not via the sentinel module's import — so import-failure is detectable):
   - Module import failure → `RuntimeError("sentinel_module_import_failed:...")` (visible in postmortem)
   - `preflight_check()` unhealthy → `SentinelInitializationError(failed_assertions, diagnostics)` raised — **NO silent fallback**
   - `preflight_check()` healthy → logs structured result at INFO + proceeds to `_dispatch_via_sentinel`
   - Master-flag-off path remains byte-identical legacy behavior

3. **`_SENTINEL_PROPAGATED_VARS` + `sentinel_propagated_vars()`** — explicit allowlist of 25 JARVIS_TOPOLOGY_* env vars the sentinel reads. `live_fire_soak._build_env_for_flag` iterates this list and explicitly forwards each value into the subprocess env payload. `dict(os.environ)` inheritance still applies as defense-in-depth.

## Boundary contract test

`test_sentinel_env_propagation_contract` parses `topology_sentinel.py` source, finds every `os.environ.get` / `_env_*("JARVIS_TOPOLOGY_*")` access, and asserts each is in `_SENTINEL_PROPAGATED_VARS`. A future operator who adds a new env knob without updating the propagation list gets a hard test failure.

## What this proves vs what it can't

- **Proves**: the dispatcher gate's behavior is now fully observable and any boundary-isolation defect surfaces as a deterministic exception with structured diagnostics. Silent failure mode eliminated.
- **Can't prove yet**: whether DW models actually stream reliably. That requires a once-proof under master-flag-on with the new gate — running immediately after merge.

## Test plan

- [x] 29 Slice 3.5 preflight + env contract tests
- [x] 259/259 combined green: Slice 1 + 2 + 3 + 3.5 + dispatcher + circuit breaker + cron installer + Phase 8 wiring + compaction caller
- [x] One existing Slice 3 test updated to anchor on new gate comment
- [ ] Once-proof under `JARVIS_TOPOLOGY_SENTINEL_ENABLED=true` (next step)

## Failure-mode envelope

If preflight raises `SentinelInitializationError` on the first op, the orchestrator's existing accept-failure branch catches it + advances the op to POSTMORTEM with the full `failed_assertions` tuple. Operator sees the defect immediately. Subsequent ops in the same session also raise — there's no "first one fails, rest degrade silently" pattern.

If preflight is HEALTHY, the dispatcher proceeds to walk the ranked DW models. The next once-proof's `cost_by_op_phase_provider` will show either:
- Non-Claude provider rows (DW success — first measured cost win)
- All-Claude rows for STANDARD/COMPLEX (cascade), zero cost for BG/SPEC (queue contract preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pre-flight handshake and explicit env propagation for the topology sentinel to remove silent boundary failures and make the dispatcher gate deterministic when the feature flag is on.

- **New Features**
  - `preflight_check()` in `topology_sentinel.py` returns a structured `SentinelPreflightResult` with readiness booleans and diagnostics; failures surface via `SentinelInitializationError`.
  - `_SENTINEL_PROPAGATED_VARS` and `sentinel_propagated_vars()` define all `JARVIS_TOPOLOGY_*` knobs the sentinel reads; `live_fire_soak._build_env_for_flag` now forwards them explicitly to the subprocess.

- **Refactors**
  - Dispatcher gate in `candidate_generator._generate_dispatch` now:
    - Reads `JARVIS_TOPOLOGY_SENTINEL_ENABLED` via `os.environ.get` (import failure raises `RuntimeError("sentinel_module_import_failed:...")`).
    - Runs `preflight_check()`; unhealthy results raise `SentinelInitializationError`, healthy results log once at INFO and proceed to `_dispatch_via_sentinel`.
    - Keeps master-flag-off path byte-identical to legacy behavior.

<sup>Written for commit 29d7c44e9b098e1036fe46d3be02cd4fa56ba028. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/26065?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

