### PR TITLE
feat(codegen): Slice 11.3 — AST-aware GENERATE prompt slicing

### DIFF
--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -374,6 +374,205 @@ def _read_with_truncation(
     return head + marker + tail
 
 
+# ---------------------------------------------------------------------------
+# Slice 11.3 — AST-aware codegen-prompt slicing.
+# ---------------------------------------------------------------------------
+#
+# When ``JARVIS_GEN_AST_SLICE_ENABLED=true`` AND a target file is Python AND
+# the file is larger than ``JARVIS_GEN_AST_SLICE_MIN_CHARS`` (default 8000),
+# replace the raw fenced file content with a structured AST outline:
+# module header (full), then per function/method either the full body (if
+# under ``JARVIS_GEN_AST_SLICE_FN_MAX_CHARS``, default 1500) or a
+# signature-only skeleton.
+#
+# This composes ``ast_slicer.ASTChunker`` (Slice 11.1's shared module) — no
+# duplicate parsing logic. Token-savings come from large files where
+# helper functions get skeleton treatment while the operationally
+# relevant ones stay full-body.
+#
+# Master-flag-off path is byte-identical legacy: ``_build_codegen_prompt``
+# never enters the slicing branch.
+
+
+def _gen_ast_slice_enabled() -> bool:
+    """``JARVIS_GEN_AST_SLICE_ENABLED`` (default ``false``)."""
+    raw = os.environ.get(
+        "JARVIS_GEN_AST_SLICE_ENABLED", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _gen_ast_slice_min_chars() -> int:
+    """File size below which we DON'T bother slicing — small files are
+    cheap to inject in full and the model gets useful surrounding
+    context. Default 8000 chars (~200 lines)."""
+    raw = os.environ.get("JARVIS_GEN_AST_SLICE_MIN_CHARS")
+    if raw is None:
+        return 8000
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 8000
+
+
+def _gen_ast_slice_fn_max_chars() -> int:
+    """Per-function/method threshold for full-body inclusion.
+    Functions ABOVE this size get signature-only skeleton treatment.
+    Default 1500 chars (~40 lines)."""
+    raw = os.environ.get("JARVIS_GEN_AST_SLICE_FN_MAX_CHARS")
+    if raw is None:
+        return 1500
+    try:
+        return max(100, int(raw))
+    except (TypeError, ValueError):
+        return 1500
+
+
+def _ast_outline_python_file(
+    content: str,
+    file_path: Path,
+    fn_max_chars: Optional[int] = None,
+) -> Optional[str]:
+    """Produce an AST-aware outline of a Python file.
+
+    Module header (always full), then per function/method/class either
+    full body or signature-only skeleton based on ``fn_max_chars``.
+    Returns ``None`` on parse failure so caller falls back to legacy
+    ``_read_with_truncation``.
+
+    NEVER raises.
+    """
+    if fn_max_chars is None:
+        fn_max_chars = _gen_ast_slice_fn_max_chars()
+
+    try:
+        from backend.core.ouroboros.governance.ast_slicer import (
+            ASTChunker, ChunkType,
+        )
+    except ImportError:
+        return None
+
+    class _NoOpCounter:
+        def count(self, text: str) -> int:
+            return 0
+
+    try:
+        chunker = ASTChunker(_NoOpCounter())
+        chunks = chunker.extract_chunks_from_source(
+            content, file_path, target_names=None, include_all=True,
+        )
+    except Exception:  # noqa: BLE001 — defensive, fallback to legacy
+        return None
+
+    if not chunks:
+        return None
+
+    # Emit module header (always full), then walk function/method
+    # chunks. CLASS / CLASS_SKELETON chunks are emitted in-place; for
+    # method chunks under the parent class we collapse to a "..."
+    # skeleton if the method's source exceeds fn_max_chars.
+    parts: List[str] = []
+    skeletons_count = 0
+    fullbody_count = 0
+
+    for chunk in chunks:
+        if chunk.chunk_type == ChunkType.MODULE_HEADER:
+            parts.append(chunk.source_code)
+            continue
+        if chunk.chunk_type in (
+            ChunkType.CLASS_SKELETON, ChunkType.CLASS,
+        ):
+            # Class skeleton — already a signature outline.
+            parts.append(chunk.source_code)
+            continue
+        # FUNCTION or METHOD
+        body_chars = len(chunk.source_code)
+        if body_chars <= fn_max_chars:
+            parts.append(chunk.source_code)
+            fullbody_count += 1
+        else:
+            # Skeleton: signature + docstring + ellipsis
+            sig = chunk.signature or f"def {chunk.name}(...)"
+            ds_line = (
+                f'    """{(chunk.docstring or "...")[:80]}"""'
+                if chunk.docstring else ""
+            )
+            indent = (
+                "    " if chunk.chunk_type == ChunkType.METHOD else ""
+            )
+            skeleton_lines = [f"{indent}{sig}"]
+            if ds_line:
+                skeleton_lines.append(ds_line)
+            skeleton_lines.append(
+                f"{indent}    ...  # [AST-SKELETON: {body_chars} chars omitted]"
+            )
+            parts.append("\n".join(skeleton_lines))
+            skeletons_count += 1
+
+    outline = "\n\n".join(parts)
+    summary_marker = (
+        f"\n# [AST-OUTLINE: {fullbody_count} fn/method full bodies, "
+        f"{skeletons_count} skeletons]"
+    )
+    return outline + summary_marker
+
+
+def _maybe_ast_outline(
+    abs_path: Path,
+    raw_path: str,
+    full_content: str,
+    op_id: str = "",
+) -> Optional[str]:
+    """Slice 11.3 dispatcher — returns AST outline string or None to
+    fall through to legacy truncation. Records metrics on every
+    dispatch (success or fallback) so operators can quantify the
+    token reduction empirically before flipping the master flag's
+    default in P11.7. NEVER raises."""
+    if not _gen_ast_slice_enabled():
+        return None
+    if abs_path.suffix.lower() != ".py":
+        return None
+    full_chars = len(full_content)
+    if full_chars < _gen_ast_slice_min_chars():
+        # Small file — cheaper to inject in full. Skip slicing without
+        # logging (avoids ledger pollution from sub-threshold cases).
+        return None
+
+    try:
+        from backend.core.ouroboros.governance.slicing_metrics import (
+            SliceMetric, record_slice,
+        )
+    except ImportError:
+        return None
+
+    outlined = _ast_outline_python_file(full_content, abs_path)
+    if outlined is None:
+        # Parse failure or empty chunk list — fall back.
+        record_slice(SliceMetric(
+            file_path=raw_path,
+            target_symbol="__codegen_outline__",
+            full_chars=full_chars,
+            sliced_chars=full_chars,
+            include_imports=True,
+            outcome="fallback",
+            fallback_reason="parse_failed_or_empty",
+            op_id=op_id,
+        ))
+        return None
+    sliced_chars = len(outlined)
+    record_slice(SliceMetric(
+        file_path=raw_path,
+        target_symbol="__codegen_outline__",
+        full_chars=full_chars,
+        sliced_chars=sliced_chars,
+        include_imports=True,
+        outcome="ok",
+        fallback_reason=None,
+        op_id=op_id,
+    ))
+    return outlined
+
+
 def _build_function_index(content: str, file_path: str) -> str:
     """Build a structural index of functions/classes in a Python file.
 
@@ -1610,26 +1809,42 @@ def _build_codegen_prompt(
         source_hash = _file_source_hash(content)
         size_bytes = len(content.encode())
         line_count = content.count("\n")
-        if _is_bg_route:
+
+        # Slice 11.3 — try AST-aware outline first when master flag is on
+        # AND content is Python AND large enough. Returns None for the
+        # fallback path (which preserves byte-identical legacy behavior).
+        _op_id_short = (
+            getattr(ctx, "op_id", "")[:24]
+            if hasattr(ctx, "op_id") else ""
+        )
+        ast_outlined = _maybe_ast_outline(
+            abs_path, str(raw_path), content, op_id=_op_id_short,
+        )
+        if ast_outlined is not None:
+            truncated = ast_outlined
+            slice_marker = " [AST-SLICED]"
+        elif _is_bg_route:
             truncated = _read_with_truncation(
                 abs_path,
                 max_chars=_BG_MAX_TARGET_FILE_CHARS,
                 head_chars=_BG_TARGET_FILE_HEAD_CHARS,
                 tail_chars=_BG_TARGET_FILE_TAIL_CHARS,
             )
+            slice_marker = ""
         else:
             truncated = _read_with_truncation(abs_path)
+            slice_marker = ""
 
         # Build the section header — include [repo_name] label for cross-repo ops
         if repo_label is not None:
             header = (
                 f"## File: {raw_path} [{repo_label}] [SHA-256: {source_hash[:12]}]"
-                f" [{size_bytes} bytes, {line_count} lines]"
+                f" [{size_bytes} bytes, {line_count} lines]{slice_marker}"
             )
         else:
             header = (
                 f"## File: {raw_path} [SHA-256: {source_hash[:12]}]"
-                f" [{size_bytes} bytes, {line_count} lines]"
+                f" [{size_bytes} bytes, {line_count} lines]{slice_marker}"
             )
 
         file_sections.append(f"{header}\n```\n{truncated}\n```")

--- a/tests/governance/test_codegen_prompt_ast_slicing.py
+++ b/tests/governance/test_codegen_prompt_ast_slicing.py
@@ -1,0 +1,459 @@
+"""Slice 11.3 regression spine — AST-aware codegen prompt slicing.
+
+Pins:
+  §1 Master flag — JARVIS_GEN_AST_SLICE_ENABLED default false +
+                   truthy/falsy parsing
+  §2 Threshold knobs — JARVIS_GEN_AST_SLICE_MIN_CHARS,
+                       JARVIS_GEN_AST_SLICE_FN_MAX_CHARS
+  §3 _ast_outline_python_file behavior — outline shape, skeleton
+                                          markers, summary footer
+  §4 _maybe_ast_outline dispatcher — flag-off short-circuit, small-
+                                     file short-circuit, non-Python
+                                     short-circuit, parse-failure
+                                     fallback
+  §5 Slicing-metrics integration — every dispatch records exactly
+                                   one row (success or fallback)
+  §6 _build_codegen_prompt integration — flag off byte-identical;
+                                          flag on injects [AST-SLICED]
+                                          marker for large Python
+                                          files; small files get
+                                          legacy treatment
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.governance import providers as pv
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic Python source large enough to trigger slicing
+# ---------------------------------------------------------------------------
+
+
+SMALL_PY = textwrap.dedent('''
+    """Small module."""
+    def tiny() -> int:
+        return 1
+''').lstrip()
+
+
+def _make_large_py(n_methods: int = 30) -> str:
+    """Build a Python source ~30 KB with one big class containing many
+    methods of variable size."""
+    parts: list[str] = []
+    parts.append('"""Large module for slicing tests."""')
+    parts.append("import os")
+    parts.append("import sys")
+    parts.append("from typing import List, Dict, Optional")
+    parts.append("")
+    parts.append("")
+    parts.append("def small_top_level(x: int) -> int:")
+    parts.append('    """Add one to x."""')
+    parts.append("    return x + 1")
+    parts.append("")
+    parts.append("")
+    parts.append("class BigService:")
+    parts.append('    """A big class with many methods."""')
+    parts.append("")
+    for i in range(n_methods):
+        parts.append(f"    def method_{i}(self, value: int) -> int:")
+        parts.append(f'        """Method number {i}."""')
+        # Bloat — intentional padding to push past fn_max_chars
+        for j in range(50):
+            parts.append(f"        # padding line {j} for method {i}")
+            parts.append(f"        intermediate_{j} = value + {j}")
+        parts.append(f"        return value + {i}")
+        parts.append("")
+    return "\n".join(parts)
+
+
+@pytest.fixture
+def small_py_file(tmp_path: Path) -> Path:
+    p = tmp_path / "small.py"
+    p.write_text(SMALL_PY, encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def large_py_file(tmp_path: Path) -> Path:
+    p = tmp_path / "large.py"
+    p.write_text(_make_large_py(), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def non_py_file(tmp_path: Path) -> Path:
+    p = tmp_path / "doc.md"
+    p.write_text("# Docs\n\nNot Python.\n" * 500, encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def broken_py_file(tmp_path: Path) -> Path:
+    p = tmp_path / "broken.py"
+    p.write_text("def broken(:\n" * 1000, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# §1 — Master flag
+# ---------------------------------------------------------------------------
+
+
+def test_master_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_GEN_AST_SLICE_ENABLED", raising=False)
+    assert pv._gen_ast_slice_enabled() is False
+
+
+def test_master_flag_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    for val in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("JARVIS_GEN_AST_SLICE_ENABLED", val)
+        assert pv._gen_ast_slice_enabled() is True
+
+
+def test_master_flag_falsy_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    for val in ("0", "false", "no", "off", "", "garbage"):
+        monkeypatch.setenv("JARVIS_GEN_AST_SLICE_ENABLED", val)
+        assert pv._gen_ast_slice_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# §2 — Threshold knobs
+# ---------------------------------------------------------------------------
+
+
+def test_min_chars_default_8000(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_GEN_AST_SLICE_MIN_CHARS", raising=False)
+    assert pv._gen_ast_slice_min_chars() == 8000
+
+
+def test_min_chars_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_GEN_AST_SLICE_MIN_CHARS", "1000")
+    assert pv._gen_ast_slice_min_chars() == 1000
+
+
+def test_min_chars_invalid_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_GEN_AST_SLICE_MIN_CHARS", "garbage")
+    assert pv._gen_ast_slice_min_chars() == 8000
+
+
+def test_fn_max_chars_default_1500(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(
+        "JARVIS_GEN_AST_SLICE_FN_MAX_CHARS", raising=False,
+    )
+    assert pv._gen_ast_slice_fn_max_chars() == 1500
+
+
+def test_fn_max_chars_floor_100(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Per-function threshold must have a sane minimum so a misconfig
+    can't reduce it to ~0 (which would skeleton-everything)."""
+    monkeypatch.setenv("JARVIS_GEN_AST_SLICE_FN_MAX_CHARS", "1")
+    assert pv._gen_ast_slice_fn_max_chars() == 100
+
+
+# ---------------------------------------------------------------------------
+# §3 — _ast_outline_python_file behavior
+# ---------------------------------------------------------------------------
+
+
+def test_outline_emits_summary_marker(large_py_file: Path) -> None:
+    content = large_py_file.read_text(encoding="utf-8")
+    outline = pv._ast_outline_python_file(content, large_py_file)
+    assert outline is not None
+    assert "[AST-OUTLINE:" in outline
+    assert "skeletons" in outline
+
+
+def test_outline_module_header_preserved(large_py_file: Path) -> None:
+    content = large_py_file.read_text(encoding="utf-8")
+    outline = pv._ast_outline_python_file(content, large_py_file)
+    assert outline is not None
+    # Imports retained verbatim (module header chunk is full).
+    assert "import os" in outline
+    assert "from typing import List" in outline
+
+
+def test_outline_small_function_full_body(large_py_file: Path) -> None:
+    content = large_py_file.read_text(encoding="utf-8")
+    outline = pv._ast_outline_python_file(content, large_py_file)
+    assert outline is not None
+    # small_top_level is small — should be full body.
+    assert "def small_top_level" in outline
+    assert "return x + 1" in outline
+
+
+def test_outline_large_method_skeletonized(large_py_file: Path) -> None:
+    content = large_py_file.read_text(encoding="utf-8")
+    outline = pv._ast_outline_python_file(content, large_py_file)
+    assert outline is not None
+    # Each method has 50+ padding lines → exceeds fn_max_chars.
+    # Skeleton marker present.
+    assert "[AST-SKELETON:" in outline
+    # The padding strings (real bodies) should be ABSENT for at least
+    # some methods.
+    skeleton_count = outline.count("[AST-SKELETON:")
+    assert skeleton_count >= 5
+
+
+def test_outline_returns_none_on_parse_error(broken_py_file: Path) -> None:
+    content = broken_py_file.read_text(encoding="utf-8")
+    outline = pv._ast_outline_python_file(content, broken_py_file)
+    assert outline is None
+
+
+def test_outline_returns_none_on_empty(tmp_path: Path) -> None:
+    p = tmp_path / "empty.py"
+    p.write_text("", encoding="utf-8")
+    outline = pv._ast_outline_python_file("", p)
+    # Empty file produces no chunks → fallback
+    assert outline is None
+
+
+def test_outline_smaller_than_full_for_large_file(
+    large_py_file: Path,
+) -> None:
+    """The whole point — outline must reduce char count for large files."""
+    content = large_py_file.read_text(encoding="utf-8")
+    outline = pv._ast_outline_python_file(content, large_py_file)
+    assert outline is not None
+    assert len(outline) < len(content), (
+        f"outline ({len(outline)}) must be smaller than full "
+        f"({len(content)}) for a file with >5 large methods"
+    )
+
+
+# ---------------------------------------------------------------------------
+# §4 — _maybe_ast_outline dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_master_flag_off_returns_none(
+    large_py_file: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_GEN_AST_SLICE_ENABLED", raising=False)
+    content = large_py_file.read_text(encoding="utf-8")
+    result = pv._maybe_ast_outline(
+        large_py_file, "large.py", content,
+    )
+    assert result is None
+
+
+def test_dispatcher_non_python_returns_none(
+    non_py_file: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_GEN_AST_SLICE_ENABLED", "true")
+    content = non_py_file.read_text(encoding="utf-8")
+    result = pv._maybe_ast_outline(
+        non_py_file, "doc.md", content,
+    )
+    assert result is None
+
+
+def test_dispatcher_small_file_returns_none(
+    small_py_file: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Small files (under min_chars threshold) skip slicing — full
+    file is cheap enough to inject."""
+    monkeypatch.setenv("JARVIS_GEN_AST_SLICE_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_SLICING_METRICS_PATH", str(tmp_path / "m.jsonl"),
+    )
+    content = small_py_file.read_text(encoding="utf-8")
+    result = pv._maybe_ast_outline(
+        small_py_file, "small.py", content,
+    )
+    assert result is None
+
+
+def test_dispatcher_large_python_returns_outline(
+    large_py_file: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("JARVIS_GEN_AST_SLICE_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_SLICING_METRICS_PATH", str(tmp_path / "m.jsonl"),
+    )
+    content = large_py_file.read_text(encoding="utf-8")
+    result = pv._maybe_ast_outline(
+        large_py_file, "large.py", content,
+    )
+    assert result is not None
+    assert "[AST-OUTLINE:" in result
+    assert "[AST-SKELETON:" in result
+
+
+def test_dispatcher_parse_error_returns_none_records_fallback(
+    broken_py_file: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("JARVIS_GEN_AST_SLICE_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_SLICING_METRICS_PATH", str(tmp_path / "m.jsonl"),
+    )
+    content = broken_py_file.read_text(encoding="utf-8")
+    # File is large enough to hit threshold
+    assert len(content) > 8000
+    result = pv._maybe_ast_outline(
+        broken_py_file, "broken.py", content,
+    )
+    assert result is None
+    # Fallback row recorded
+    rows = list(_read_jsonl(tmp_path / "m.jsonl"))
+    assert any(
+        r["fallback_reason"] == "parse_failed_or_empty" for r in rows
+    )
+
+
+# ---------------------------------------------------------------------------
+# §5 — Slicing metrics integration
+# ---------------------------------------------------------------------------
+
+
+def _read_jsonl(p: Path):
+    if not p.exists():
+        return
+    for line in p.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            yield json.loads(line)
+
+
+def test_dispatcher_records_success_metric(
+    large_py_file: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("JARVIS_GEN_AST_SLICE_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_SLICING_METRICS_PATH", str(tmp_path / "m.jsonl"),
+    )
+    content = large_py_file.read_text(encoding="utf-8")
+    result = pv._maybe_ast_outline(
+        large_py_file, "large.py", content, op_id="op-test-113",
+    )
+    assert result is not None
+    rows = list(_read_jsonl(tmp_path / "m.jsonl"))
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["target_symbol"] == "__codegen_outline__"
+    assert row["outcome"] == "ok"
+    assert row["op_id"] == "op-test-113"
+    assert row["sliced_chars"] < row["full_chars"]
+    assert row["savings_ratio"] > 0
+
+
+def test_dispatcher_no_metric_for_master_flag_off(
+    large_py_file: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Master-flag-off path doesn't record metrics — would dilute
+    the ledger with sub-threshold non-events."""
+    monkeypatch.delenv("JARVIS_GEN_AST_SLICE_ENABLED", raising=False)
+    monkeypatch.setenv(
+        "JARVIS_SLICING_METRICS_PATH", str(tmp_path / "m.jsonl"),
+    )
+    content = large_py_file.read_text(encoding="utf-8")
+    pv._maybe_ast_outline(large_py_file, "large.py", content)
+    # Ledger should not exist or have zero rows.
+    rows = list(_read_jsonl(tmp_path / "m.jsonl"))
+    assert len(rows) == 0
+
+
+def test_dispatcher_no_metric_for_small_file(
+    small_py_file: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("JARVIS_GEN_AST_SLICE_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_SLICING_METRICS_PATH", str(tmp_path / "m.jsonl"),
+    )
+    content = small_py_file.read_text(encoding="utf-8")
+    pv._maybe_ast_outline(small_py_file, "small.py", content)
+    rows = list(_read_jsonl(tmp_path / "m.jsonl"))
+    assert len(rows) == 0
+
+
+# ---------------------------------------------------------------------------
+# §6 — _build_codegen_prompt integration (source-level pin)
+# ---------------------------------------------------------------------------
+
+
+def test_build_codegen_prompt_imports_dispatcher() -> None:
+    """Source-level pin: _build_codegen_prompt must call
+    _maybe_ast_outline. Catches a refactor that strips the wiring."""
+    src = inspect.getsource(pv._build_codegen_prompt)
+    assert "_maybe_ast_outline" in src
+
+
+def test_build_codegen_prompt_emits_slice_marker_on_outline() -> None:
+    src = inspect.getsource(pv._build_codegen_prompt)
+    # The header carries [AST-SLICED] marker when slicing fires.
+    assert "[AST-SLICED]" in src
+
+
+def test_outline_branch_precedes_legacy_truncation() -> None:
+    """Source-level pin: the AST outline check is BEFORE the legacy
+    _read_with_truncation call so sliced output wins when applicable."""
+    src = inspect.getsource(pv._build_codegen_prompt)
+    outline_idx = src.index("_maybe_ast_outline")
+    truncation_idx = src.index("_read_with_truncation")
+    assert outline_idx < truncation_idx
+
+
+def test_outline_marker_only_on_outline_path() -> None:
+    """The slice_marker is empty string for the legacy paths (BG +
+    default truncation). Pinned by code structure."""
+    src = inspect.getsource(pv._build_codegen_prompt)
+    # slice_marker = "" for the legacy paths
+    assert 'slice_marker = ""' in src
+
+
+# ---------------------------------------------------------------------------
+# §7 — Authority + boundary pins
+# ---------------------------------------------------------------------------
+
+
+def test_outline_function_lazy_imports_ast_slicer() -> None:
+    """Lazy import — keeps providers.py module-import path clean for
+    callers that don't enable slicing."""
+    src = inspect.getsource(pv._ast_outline_python_file)
+    assert (
+        "from backend.core.ouroboros.governance.ast_slicer import"
+        in src
+    )
+
+
+def test_outline_dispatcher_lazy_imports_metrics() -> None:
+    src = inspect.getsource(pv._maybe_ast_outline)
+    assert (
+        "from backend.core.ouroboros.governance.slicing_metrics import"
+        in src
+    )
+
+
+def test_outline_function_uses_no_op_token_counter() -> None:
+    """Outline doesn't need accurate token counts — uses a local
+    NoOp counter to avoid dragging in smart_context.TokenCounter
+    bootstrap cost during prompt building."""
+    src = inspect.getsource(pv._ast_outline_python_file)
+    # Local stub class.
+    assert "class _NoOpCounter" in src
+    # Doesn't import the heavyweight smart_context counter.
+    assert "smart_context.TokenCounter" not in src
+
+
+def test_outline_function_never_raises() -> None:
+    """Defensive smoke: the function returns None on any internal
+    failure rather than raising — caller depends on this."""
+    # Pass garbage source — must not raise.
+    result = pv._ast_outline_python_file(
+        "completely \x00 bogus \x01 source", Path("/tmp/fake.py"),
+    )
+    # Either None (parse failed) OR a string. Must NOT raise.
+    assert result is None or isinstance(result, str)


### PR DESCRIPTION
## Summary

Phase 11 P11.3 — wires `_build_codegen_prompt` to inject **AST-sliced file content** for large Python files instead of raw fenced content blocks. **Master flag `JARVIS_GEN_AST_SLICE_ENABLED` default false** → master-flag-off path is byte-identical legacy.

## Architecture (composes Slice 11.1's shared module — zero duplicates)

| Component | What | Default |
|---|---|---|
| `_gen_ast_slice_enabled()` | Master flag check | `false` |
| `_gen_ast_slice_min_chars()` | Min file size to bother slicing | `8000` chars |
| `_gen_ast_slice_fn_max_chars()` | Per-function threshold for full-body inclusion | `1500` chars |
| `_ast_outline_python_file()` | Walks `ast_slicer.ASTChunker` chunks; emits full bodies for small fns + skeletons for large ones | n/a |
| `_maybe_ast_outline()` | Dispatcher with 3 short-circuits (master flag off / non-Python / small file) | n/a |

## Behavior

When master flag on + Python + large file (>min_chars):

```
File: large_module.py [SHA-256: ...] [25840 bytes, 612 lines] [AST-SLICED]
```
"""Module docstring."""
import os
from typing import List

def small_helper(x: int) -> int:
    """Add one."""
    return x + 1

class BigService:
    """A big class."""

    def method_0(self, value: int) -> int:
        """Method number 0."""
        ...  # [AST-SKELETON: 1820 chars omitted]

    def method_1(self, value: int) -> int:
        ...  # [AST-SKELETON: 1820 chars omitted]
    ...

# [AST-OUTLINE: 1 fn/method full bodies, 30 skeletons]
```

## Token economics

| Scenario | Before | After |
|---|---|---|
| 25KB file with 30 large methods | ~25,000 chars (~6,250 tokens) | ~5–7 KB outline (~1,500 tokens) |
| 5KB file (under threshold) | unchanged — full content | unchanged — full content |
| Non-Python file | unchanged — full content | unchanged — full content |

**~3–5× input-token reduction on large files** when master flag on. Tracked per-op in `slicing_metrics.jsonl` with `target_symbol="__codegen_outline__"` for empirical verification before P11.7 graduation.

## Test plan

- [x] **31 Slice 11.3 tests** (`test_codegen_prompt_ast_slicing.py`):
  - Master flag (3): default off, truthy/falsy parsing
  - Threshold knobs (5): defaults, env override, invalid fallback, fn floor
  - Outline behavior (7): summary marker, module header preserved, small fn full body, large method skeletonized, parse error → None, empty file → None, smaller-than-full guarantee
  - Dispatcher (5): master flag off, non-Python, small file, large Python, parse error fallback
  - Metrics integration (3): success row, no row when flag off, no row for small file
  - `_build_codegen_prompt` source-level pins (4): imports dispatcher, emits `[AST-SLICED]` marker, outline branch precedes legacy, slice_marker empty for legacy paths
  - Authority pins (4): lazy imports ast_slicer, lazy imports metrics, uses local `_NoOpCounter` not `smart_context.TokenCounter`, never-raises smoke

- [x] **369/369 combined regression green** — no existing test broken

## Master-flag-off invariant (regression-pinned)

Without `JARVIS_GEN_AST_SLICE_ENABLED`, `_maybe_ast_outline` returns None unconditionally → caller takes the legacy `_read_with_truncation` path with empty slice_marker. Byte-identical pre/post-Slice-11.3.

## Out of scope (deferred to follow-ups)

- `_build_lean_codegen_prompt` (sister function, smaller variant)
- `SmartContextSelector` relevance-scoring integration (current Slice 11.3 emits ALL chunks; a future slice can add query-relevance filtering)
- DAG dependency tracing (directive's subsystem #3 — separate arc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AST-aware slicing to `_build_codegen_prompt` for large Python files, replacing raw content with an outline that keeps small functions and skeletonizes large ones. This cuts GENERATE input tokens by ~3–5x on big files and is gated by `JARVIS_GEN_AST_SLICE_ENABLED` (default off) to keep legacy behavior unchanged.

- **New Features**
  - Master flag `JARVIS_GEN_AST_SLICE_ENABLED` (default false).
  - Applies to `.py` files larger than `JARVIS_GEN_AST_SLICE_MIN_CHARS` (default 8000).
  - Per-function threshold `JARVIS_GEN_AST_SLICE_FN_MAX_CHARS` (default 1500, floor 100) controls skeletonization.
  - Uses `ast_slicer.ASTChunker`; preserves module header; emits signature/docstring/ellipsis for large functions with `[AST-SKELETON: N chars omitted]`.
  - File headers include `[AST-SLICED]` when an outline is injected; otherwise unchanged.
  - Records metrics via `slicing_metrics` (`target_symbol="__codegen_outline__"`), with graceful fallback on parse errors; no metrics when the flag is off or file is below threshold.
  - Added tests covering flags, thresholds, outline behavior, dispatcher, metrics, and prompt wiring.

- **Migration**
  - Enable with `JARVIS_GEN_AST_SLICE_ENABLED=true`.
  - Optional tuning: `JARVIS_GEN_AST_SLICE_MIN_CHARS`, `JARVIS_GEN_AST_SLICE_FN_MAX_CHARS`.
  - Verify savings in `slicing_metrics.jsonl` (path set by `JARVIS_SLICING_METRICS_PATH`).

<sup>Written for commit e80e5a5467475e9e74e080c36746de7a4252b070. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/26132?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

