### PR TITLE
Slice 11.6.a: TodoScannerSensor consults Merkle cartographer

### DIFF
--- a/backend/core/ouroboros/governance/intake/sensors/todo_scanner_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/todo_scanner_sensor.py
@@ -102,6 +102,27 @@ _SKIP_DIRS = frozenset({
 })
 
 
+# Slice 11.6.a — Merkle Cartographer consultation. When the per-sensor
+# flag JARVIS_TODO_USE_MERKLE is on AND the cartographer's master flag
+# is on, the scan loop short-circuits to the cached prior result when
+# nothing under _SCAN_DIRS has changed since the last successful scan.
+# Cuts O(N) disk reads to O(1) on the steady state — most poll cycles
+# in JARVIS are no-op (no code changed in the last 24h between scans).
+#
+# Default false to preserve byte-identical legacy behavior. Per-sensor
+# graduation: each Slice 11.6.{a,b,c,d} flag flips independently after
+# its own forced-clean once-proof cadence.
+
+
+def merkle_consult_enabled() -> bool:
+    """Re-read ``JARVIS_TODO_USE_MERKLE`` at call time so monkeypatch
+    works in tests + operator can flip live without re-init."""
+    raw = os.environ.get(
+        "JARVIS_TODO_USE_MERKLE", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
 @dataclass
 class TodoItem:
     """One TODO/FIXME/HACK found in the codebase."""
@@ -170,6 +191,21 @@ class TodoScannerSensor:
         self._fs_events_mode: bool = fs_events_enabled()
         self._fs_events_handled: int = 0
         self._fs_events_ignored: int = 0
+        # Slice 11.6.a — cached scan result for merkle short-circuit.
+        # When JARVIS_TODO_USE_MERKLE is on AND the cartographer's
+        # current root hash matches what we recorded after the last
+        # full scan, we skip the disk walk and return cached items.
+        # The "baseline tracking" pattern: sensor records the
+        # cartographer's root hash at the END of each successful scan,
+        # then compares against current_root_hash() at the start of
+        # the next cycle. Decoupled from cartographer's persisted-vs-
+        # in-memory comparison so sensors detect changes between two
+        # sensor cycles regardless of whether the persisted snapshot
+        # has been updated.
+        self._merkle_cached_items: List[TodoItem] = []
+        self._merkle_last_seen_root_hash: str = ""
+        self._merkle_short_circuits: int = 0
+        self._merkle_full_scans: int = 0
 
     async def start(self) -> None:
         self._running = True
@@ -312,11 +348,85 @@ class TodoScannerSensor:
                 break
 
     async def scan_once(self) -> List[TodoItem]:
-        """Scan all Python files for TODO markers. Returns found items."""
+        """Scan all Python files for TODO markers. Returns found items.
+
+        Slice 11.6.a — when ``JARVIS_TODO_USE_MERKLE=true`` AND the
+        Merkle Cartographer says nothing has changed under ``_SCAN_DIRS``
+        since the last successful scan, short-circuit to the cached
+        items (skip disk walk + emission). Reduces O(N) full-tree walks
+        to O(1) for the typical no-change case (most poll cycles in
+        JARVIS find no new TODOs between intervals).
+
+        When master flag(s) off OR cartographer reports change → full
+        scan as legacy behavior.
+        """
+        current_hash = self._merkle_current_root_hash()
+        if self._merkle_should_short_circuit(current_hash):
+            self._merkle_short_circuits += 1
+            logger.debug(
+                "[TodoScanner] Merkle short-circuit "
+                "(scan #%d skipped, %d cached items)",
+                self._merkle_short_circuits + self._merkle_full_scans,
+                len(self._merkle_cached_items),
+            )
+            return list(self._merkle_cached_items)
+
+        self._merkle_full_scans += 1
         loop = asyncio.get_running_loop()
         items = await loop.run_in_executor(None, self._scan_files_sync)
+        # Cache the result so a subsequent merkle-says-no-change cycle
+        # has accurate state to return. Stored regardless of merkle
+        # flag so flipping the flag mid-session doesn't blank state.
+        self._merkle_cached_items = list(items)
+        # Refresh baseline AFTER the scan completes — captures the
+        # cartographer's current state so the next cycle can detect
+        # post-scan changes.
+        self._merkle_last_seen_root_hash = current_hash
         await self._emit_items(items)
         return items
+
+    def _merkle_current_root_hash(self) -> str:
+        """Read the cartographer's current root hash. Returns empty
+        string on any failure path — fail-safe to legacy scan."""
+        if not merkle_consult_enabled():
+            return ""
+        try:
+            from backend.core.ouroboros.governance.merkle_cartographer import (
+                get_default_cartographer,
+            )
+            c = get_default_cartographer(repo_root=self._root)
+            return c.current_root_hash()
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[TodoScanner] current_root_hash read failed; "
+                "falling through to full scan", exc_info=True,
+            )
+            return ""
+
+    def _merkle_should_short_circuit(self, current_hash: str) -> bool:
+        """Decide whether to skip the disk walk based on cartographer
+        state. Returns False (i.e. proceed with full scan) on any
+        failure path — fail-safe to legacy behavior.
+
+        Conditions for short-circuit:
+          1. Per-sensor flag ``JARVIS_TODO_USE_MERKLE`` is true
+          2. Cartographer master flag enabled (its
+             ``current_root_hash`` returns "" when off — sensor
+             treats empty as "always changed" → fail-safe)
+          3. The cartographer's current root hash equals the hash
+             we recorded after the last full scan
+          4. We have a prior cached scan result (no point short-
+             circuiting on cold-start since cache is empty)
+        """
+        if not merkle_consult_enabled():
+            return False
+        if not self._merkle_cached_items:
+            return False  # cold start — must populate cache
+        if not current_hash:
+            return False  # cartographer disabled / cold-start / error
+        if not self._merkle_last_seen_root_hash:
+            return False  # first scan — no baseline yet
+        return current_hash == self._merkle_last_seen_root_hash
 
     def _scan_files_sync(self) -> List[TodoItem]:
         """CPU-bound scan — runs in a thread via run_in_executor."""
@@ -459,4 +569,9 @@ class TodoScannerSensor:
             "repo": self._repo,
             "running": self._running,
             "items_seen": len(self._seen),
+            # Slice 11.6.a — Merkle consultation observability
+            "merkle_consult_enabled": merkle_consult_enabled(),
+            "merkle_short_circuits": self._merkle_short_circuits,
+            "merkle_full_scans": self._merkle_full_scans,
+            "merkle_cached_items": len(self._merkle_cached_items),
         }

--- a/backend/core/ouroboros/governance/merkle_cartographer.py
+++ b/backend/core/ouroboros/governance/merkle_cartographer.py
@@ -603,12 +603,57 @@ class MerkleCartographer:
             self._leaf_index = self._build_leaf_index(loaded)
         return len(self._leaf_index)
 
+    def current_root_hash(self) -> str:
+        """O(1) — the current Merkle root hash. Empty string when the
+        cartographer hasn't been hydrated / walked yet, or when the
+        master flag is off (no caching authority).
+
+        Sensors (Slice 11.6.x) use this for baseline-based change
+        detection: store the hash from one scan, compare against
+        ``current_root_hash()`` on the next; if they differ, do a
+        full scan AND refresh the baseline.
+
+        Master-flag-off → returns empty string. Sensors treat that
+        as "always changed" so legacy O(N) scans preserved.
+        """
+        if not is_cartographer_enabled():
+            return ""
+        with self._lock:
+            if self._root is None:
+                return ""
+            return self._root.hash
+
+    def subtree_hash(self, relpath: str) -> str:
+        """O(log N) — hash of a subtree rooted at ``relpath``. Empty
+        string when the path isn't in the tree OR master flag is off.
+
+        Mirrors ``current_root_hash`` but scoped to a directory so
+        sensors can baseline-track only the dirs they care about
+        (e.g. ``backend/`` + ``tests/`` + ``scripts/``)."""
+        if not is_cartographer_enabled():
+            return ""
+        with self._lock:
+            if self._root is None:
+                return ""
+            node = self._find_node(
+                relpath.replace("\\", "/").strip("/"),
+            )
+            if node is None:
+                return ""
+            return node.hash
+
     def has_changed(self, paths: Optional[Sequence[str]] = None) -> bool:
         """O(1) — has any leaf under any of ``paths`` changed since
         the last persisted snapshot?
 
         Master-flag-off short-circuit: returns True so the caller's
         legacy O(N) scan path runs (no false negatives possible).
+
+        **Note**: this compares in-memory tree to last-persisted
+        snapshot. Sensors should prefer ``current_root_hash()`` /
+        ``subtree_hash(relpath)`` + their own baseline tracking —
+        which lets them detect changes that happened between two
+        sensor cycles, not just changes that haven't been persisted.
         """
         if not is_cartographer_enabled():
             return True
@@ -623,15 +668,6 @@ class MerkleCartographer:
                 node = self._find_node(normalized)
                 if node is None:
                     return True   # path unmapped — assume changed
-                # Compare to the cached subtree hash from the same
-                # tree. Since we always update_full() before persist,
-                # the in-memory tree IS the cached state; this method
-                # is effectively "is the root different from what's
-                # been observed?" — which is True iff a pending
-                # update_incremental hasn't been persisted yet.
-                # Without external evidence the answer is False; the
-                # contract is "changed since the LAST update_*".
-                pass
             return False
 
     def changed_descendants(self, relpath: str) -> Set[str]:

--- a/tests/governance/test_todo_scanner_merkle.py
+++ b/tests/governance/test_todo_scanner_merkle.py
@@ -1,0 +1,384 @@
+"""Slice 11.6.a regression spine — TodoScannerSensor + Merkle Cartographer.
+
+Pins:
+  §1 Per-sensor flag — JARVIS_TODO_USE_MERKLE default false +
+                       truthy/falsy parsing
+  §2 Cold-start: full scan even with merkle on (cache empty)
+  §3 Steady state with no changes: short-circuit; cached items returned
+  §4 Steady state with changes: full scan; cache refreshed
+  §5 Master flag off (cartographer): fail-safe to full scan
+  §6 Cartographer error: fail-safe to full scan (NEVER raises)
+  §7 health() exposes merkle_short_circuits + merkle_full_scans
+  §8 Backward compat: merkle flag off → byte-identical legacy
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.intake.sensors import (
+    todo_scanner_sensor as tss,
+)
+from backend.core.ouroboros.governance.intake.sensors.todo_scanner_sensor import (
+    TodoScannerSensor,
+    TodoItem,
+    merkle_consult_enabled,
+)
+from backend.core.ouroboros.governance import (
+    merkle_cartographer as mc,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def repo_with_todos(tmp_path: Path) -> Path:
+    """Synthetic repo with a few TODO/FIXME markers."""
+    backend = tmp_path / "backend"
+    backend.mkdir()
+    (backend / "foo.py").write_text(
+        "def foo():\n    # TODO: refactor this\n    return 1\n"
+    )
+    (backend / "bar.py").write_text(
+        "def bar():\n    # FIXME: handle edge case\n    return 2\n"
+    )
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_foo.py").write_text(
+        "def test_foo():\n    pass  # HACK: mock this\n"
+    )
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "tool.py").write_text("# clean script\nx = 1\n")
+    return tmp_path
+
+
+@pytest.fixture
+def make_sensor(repo_with_todos: Path):
+    """Factory: produces TodoScannerSensors rooted at the synthetic repo."""
+
+    def _make(**kwargs) -> TodoScannerSensor:
+        router = AsyncMock()
+        return TodoScannerSensor(
+            repo="JARVIS",
+            router=router,
+            project_root=repo_with_todos,
+            **kwargs,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def isolated_cartographer(
+    repo_with_todos: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Fresh cartographer rooted at the synthetic repo + isolated state dir."""
+    monkeypatch.setenv("JARVIS_MERKLE_STATE_DIR", str(repo_with_todos))
+    mc.reset_default_cartographer_for_tests()
+    yield
+    mc.reset_default_cartographer_for_tests()
+
+
+# ===========================================================================
+# §1 — Per-sensor flag
+# ===========================================================================
+
+
+def test_merkle_consult_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_TODO_USE_MERKLE", raising=False)
+    assert merkle_consult_enabled() is False
+
+
+def test_merkle_consult_truthy_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for val in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", val)
+        assert merkle_consult_enabled() is True
+
+
+def test_merkle_consult_falsy_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for val in ("0", "false", "no", "off", "", "garbage"):
+        monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", val)
+        assert merkle_consult_enabled() is False
+
+
+# ===========================================================================
+# §2 — Cold-start: must full-scan even with merkle on
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cold_start_full_scan_even_with_merkle_on(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+    isolated_cartographer,
+) -> None:
+    """First scan must walk disk to populate the cache. Subsequent
+    cycles can short-circuit."""
+    monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    sensor = make_sensor()
+    items = await sensor.scan_once()
+    assert len(items) >= 3  # TODO + FIXME + HACK from fixture
+    assert sensor._merkle_full_scans == 1  # noqa: SLF001
+    assert sensor._merkle_short_circuits == 0  # noqa: SLF001
+    assert len(sensor._merkle_cached_items) == len(items)  # noqa: SLF001
+
+
+# ===========================================================================
+# §3 — Steady state: cartographer says no change → short-circuit
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_when_no_changes(
+    make_sensor, repo_with_todos: Path,
+    monkeypatch: pytest.MonkeyPatch, isolated_cartographer,
+) -> None:
+    monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    # Build the cartographer's tree FIRST so the sensor's first scan
+    # captures a stable baseline.
+    cart = mc.get_default_cartographer(repo_root=repo_with_todos)
+    await cart.update_full()
+
+    sensor = make_sensor()
+
+    # First scan — cold start: walks disk + records baseline
+    first_items = await sensor.scan_once()
+    initial_count = len(first_items)
+    assert sensor._merkle_full_scans == 1  # noqa: SLF001
+    assert sensor._merkle_last_seen_root_hash != ""  # noqa: SLF001
+
+    # Second scan — no changes happened, cartographer's root hash
+    # unchanged, sensor short-circuits using the stored baseline.
+    second_items = await sensor.scan_once()
+    assert sensor._merkle_short_circuits == 1  # noqa: SLF001
+    assert sensor._merkle_full_scans == 1  # noqa: SLF001 (unchanged)
+    assert len(second_items) == initial_count
+    # Cached items returned (a NEW list — but same content)
+    assert second_items == first_items
+
+
+# ===========================================================================
+# §4 — has_changed=True → full scan, cache refreshed
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_full_scan_when_cartographer_reports_change(
+    make_sensor, repo_with_todos: Path,
+    monkeypatch: pytest.MonkeyPatch, isolated_cartographer,
+) -> None:
+    monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    # Build cartographer's tree first
+    cart = mc.get_default_cartographer(repo_root=repo_with_todos)
+    await cart.update_full()
+
+    sensor = make_sensor()
+
+    # Cold-start scan — captures baseline = cart.current_root_hash()
+    await sensor.scan_once()
+    assert sensor._merkle_full_scans == 1  # noqa: SLF001
+    baseline_hash = sensor._merkle_last_seen_root_hash  # noqa: SLF001
+    assert baseline_hash != ""
+
+    # Add a NEW TODO somewhere — file system genuinely changes
+    (repo_with_todos / "backend" / "new.py").write_text(
+        "# TODO: extra item\nx = 2\n"
+    )
+    # Refresh cartographer to pick up the new file → root hash changes
+    await cart.update_full()
+    new_hash = cart.current_root_hash()
+    assert new_hash != baseline_hash, (
+        "cartographer root hash should change when a new file is added"
+    )
+
+    # Next scan: cartographer's hash differs from sensor's baseline
+    # → no short-circuit, full scan + baseline refreshed.
+    second_items = await sensor.scan_once()
+    assert sensor._merkle_full_scans >= 2  # noqa: SLF001
+    file_paths = {item.file_path for item in second_items}
+    assert any("new.py" in p for p in file_paths)
+    # Baseline updated to new hash
+    assert sensor._merkle_last_seen_root_hash == new_hash  # noqa: SLF001
+
+
+# ===========================================================================
+# §5 — Master flag off → fail-safe full scan
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cartographer_master_flag_off_falls_through_to_full_scan(
+    make_sensor, repo_with_todos: Path,
+    monkeypatch: pytest.MonkeyPatch, isolated_cartographer,
+) -> None:
+    """Per-sensor flag on, but cartographer master flag OFF →
+    current_root_hash returns "" → sensor treats as 'always changed'
+    → full scan every cycle (legacy behavior preserved)."""
+    monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", "true")
+    monkeypatch.delenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", raising=False)
+    sensor = make_sensor()
+
+    # Multiple scans: each one full-scans because cartographer disabled
+    await sensor.scan_once()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    assert sensor._merkle_full_scans == 3  # noqa: SLF001
+    assert sensor._merkle_short_circuits == 0  # noqa: SLF001
+
+
+# ===========================================================================
+# §6 — Cartographer error → fail-safe full scan
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cartographer_error_falls_through_to_full_scan(
+    make_sensor, repo_with_todos: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If cartographer module fails to import / current_root_hash
+    raises, sensor falls through to legacy full scan. NEVER blocks."""
+    monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    sensor = make_sensor()
+    # Cold scan first to populate cache
+    await sensor.scan_once()
+
+    # Monkey-patch current_root_hash to raise
+    def _broken_current(self, *args, **kwargs):
+        raise RuntimeError("simulated cartographer crash")
+
+    monkeypatch.setattr(
+        mc.MerkleCartographer, "current_root_hash", _broken_current,
+    )
+
+    # Next scan must NOT raise; must fall through to full scan
+    items = await sensor.scan_once()
+    assert isinstance(items, list)
+    assert sensor._merkle_full_scans >= 2  # noqa: SLF001
+
+
+# ===========================================================================
+# §7 — health() exposes merkle metrics
+# ===========================================================================
+
+
+def test_health_exposes_merkle_metrics(make_sensor) -> None:
+    sensor = make_sensor()
+    h = sensor.health()
+    assert "merkle_consult_enabled" in h
+    assert "merkle_short_circuits" in h
+    assert "merkle_full_scans" in h
+    assert "merkle_cached_items" in h
+    # Cold sensor — zero metrics
+    assert h["merkle_short_circuits"] == 0
+    assert h["merkle_full_scans"] == 0
+    assert h["merkle_cached_items"] == 0
+
+
+@pytest.mark.asyncio
+async def test_health_after_scan_reflects_metrics(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+    isolated_cartographer,
+) -> None:
+    monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    sensor = make_sensor()
+    await sensor.scan_once()
+    h = sensor.health()
+    assert h["merkle_full_scans"] == 1
+    assert h["merkle_cached_items"] >= 1
+
+
+# ===========================================================================
+# §8 — Backward compat: merkle flag off → byte-identical legacy
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_merkle_flag_off_full_scan_every_cycle(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When per-sensor flag is off, sensor must NEVER consult
+    cartographer — legacy behavior preserved."""
+    monkeypatch.delenv("JARVIS_TODO_USE_MERKLE", raising=False)
+    sensor = make_sensor()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    assert sensor._merkle_full_scans == 3  # noqa: SLF001
+    assert sensor._merkle_short_circuits == 0  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_merkle_flag_off_does_not_call_cartographer(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Source-level guarantee: flag off → cartographer never imported.
+
+    Pinned at runtime by checking the monkeypatched import path
+    isn't called."""
+    monkeypatch.delenv("JARVIS_TODO_USE_MERKLE", raising=False)
+
+    call_count = 0
+    original_get = mc.get_default_cartographer
+
+    def _spy(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_get(*args, **kwargs)
+
+    monkeypatch.setattr(
+        mc, "get_default_cartographer", _spy,
+    )
+    sensor = make_sensor()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    # Flag off → cartographer get_default never called
+    assert call_count == 0
+
+
+# ===========================================================================
+# §9 — Source-level pins
+# ===========================================================================
+
+
+def test_source_imports_cartographer_lazily() -> None:
+    """The cartographer import must be inside the consult method,
+    NOT at module top level — keeps todo_scanner_sensor's module
+    load path independent of the cartographer module."""
+    import inspect
+    src = inspect.getsource(
+        TodoScannerSensor._merkle_current_root_hash,
+    )
+    assert (
+        "from backend.core.ouroboros.governance.merkle_cartographer"
+        in src
+    )
+
+
+def test_source_short_circuit_branch_in_scan_once() -> None:
+    """The merkle short-circuit branch must fire BEFORE the
+    `loop.run_in_executor(self._scan_files_sync)` call so the disk
+    walk is genuinely skipped."""
+    import inspect
+    src = inspect.getsource(TodoScannerSensor.scan_once)
+    sc_idx = src.index("_merkle_should_short_circuit")
+    walk_idx = src.index("run_in_executor")
+    assert sc_idx < walk_idx


### PR DESCRIPTION
## Summary

- Wraps `TodoScannerSensor._scan_files_sync` in a baseline-tracking change-detection guard backed by `MerkleCartographer`. When the cartographer's current root hash matches the sensor's `_last_seen_root_hash`, the disk walk is skipped (O(1) short-circuit) and the cached `_merkle_cached_items` are re-emitted.
- Adds two read accessors to `MerkleCartographer`: `current_root_hash()` (O(1)) and `subtree_hash(relpath)` (O(log N)). Both return empty string when the master flag is off — fail-safe.
- Per-sensor flag `JARVIS_TODO_USE_MERKLE` defaults `false`; cartographer master flag `JARVIS_MERKLE_CARTOGRAPHER_ENABLED` remains global authority. `health()` exposes `merkle_short_circuits` / `merkle_full_scans` / `merkle_last_seen_root_hash`.

## Architectural pins

- Cold-start, master-flag-off, per-sensor-flag-off, and any cartographer error path all fall through to the legacy full scan
- Cartographer import is lazy (inside `_merkle_current_root_hash`) — sensor module load remains independent of the cartographer module
- Short-circuit branch fires before `loop.run_in_executor(self._scan_files_sync)` so the disk walk is genuinely skipped
- Source-level grep pin in tests guards against accidental top-level import or branch reordering

## Test plan

- [x] Slice 11.6.a tests: `tests/governance/test_todo_scanner_merkle.py` — 14/14 green
- [x] Combined Phase 11 spine: `test_merkle_cartographer_incremental.py` + `test_codegen_prompt_ast_slicing.py` + `test_todo_scanner_merkle.py` — 83/83 green
- [ ] Once-proof after Slices 11.6.b/c/d land (DocStaleness, OpportunityMiner, Backlog) — Phase 11 graduation per Slice 11.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
TodoScannerSensor now consults the Merkle cartographer to skip no-op scans by comparing root hashes, turning most steady-state polls from O(N) disk walks into O(1) cache hits. Adds safe, read-only hash accessors and metrics; flags default off and all failure paths fall back to legacy scans.

- **New Features**
  - Merkle short-circuit in `TodoScannerSensor.scan_once`: if `current_root_hash` matches the last baseline, skip the disk walk and return cached items.
  - New cartographer accessors: `current_root_hash()` (O(1)) and `subtree_hash(relpath)` (O(log N)); return empty string when disabled.
  - Flags: per-sensor `JARVIS_TODO_USE_MERKLE` (default false) and master `JARVIS_MERKLE_CARTOGRAPHER_ENABLED`; cold start and any error paths fall through to a full scan.
  - `health()` now reports `merkle_short_circuits`, `merkle_full_scans`, and `merkle_cached_items`; cartographer import is lazy to keep the sensor decoupled.

- **Migration**
  - Opt-in by setting `JARVIS_MERKLE_CARTOGRAPHER_ENABLED=true` and `JARVIS_TODO_USE_MERKLE=true`.
  - First scan always walks the tree to warm the cache; subsequent scans short-circuit if unchanged.

<sup>Written for commit da83df463eb681e803403c0d21814d4b9d47a8d2. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/26289?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

