### PR TITLE
Slice 11.6.c: OpportunityMinerSensor consults Merkle cartographer (subtree-scoped)

### DIFF
--- a/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
@@ -79,6 +79,43 @@ _OPP_MINER_FALLBACK_INTERVAL_S: float = float(
     os.environ.get("JARVIS_OPPORTUNITY_MINER_FALLBACK_INTERVAL_S", "21600")
 )
 
+
+# ---------------------------------------------------------------------------
+# Slice 11.6.c — Merkle Cartographer consultation (subtree-scoped)
+# ---------------------------------------------------------------------------
+#
+# When the per-sensor flag JARVIS_OPPMINER_USE_MERKLE is on AND the
+# cartographer's master flag is on, the scan loop short-circuits to the
+# cached prior selection when nothing under the sensor's _scan_paths has
+# changed since the last successful scan.
+#
+# Beef vs. Slices 11.6.a/b: this sensor uses *per-watched-path* subtree
+# hashes rather than a single root hash. A change in ``docs/`` (outside
+# the miner's scope) does NOT invalidate the cache. Only mutations under
+# a watched path bust short-circuit. This matters because the miner runs
+# AST-heavy analysis across multiple strategies — every avoided no-op
+# scan saves real CPU, not just a directory walk.
+#
+# The cache stores the *full ingested-candidate list* from the last scan.
+# A short-circuit replays nothing through the router (envelopes are not
+# re-emitted; the dedup ledger handled them already). The cycle counter
+# DOES still advance so the strategy-rotation index advances on every
+# call — the next non-short-circuit cycle picks up the rotated strategy
+# without skipping any.
+#
+# Default false to preserve byte-identical legacy behavior. Per-sensor
+# graduation: each Slice 11.6.{a,b,c,d} flag flips independently after
+# its own forced-clean once-proof cadence.
+
+
+def merkle_consult_enabled() -> bool:
+    """Re-read ``JARVIS_OPPMINER_USE_MERKLE`` at call time so monkeypatch
+    works in tests + operator can flip live without re-init."""
+    raw = os.environ.get(
+        "JARVIS_OPPMINER_USE_MERKLE", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
 # Per-file debounce: suppress repeat events on the same file within this
 # window. 30s is long enough to absorb an editor's atomic-save spray
 # (save → backup → rename → chmod → fsync) but short enough that a genuine
@@ -471,6 +508,19 @@ class OpportunityMinerSensor:
         self._storm_window_count: int = 0
         self._storm_active_until: float = 0.0
 
+        # --- Slice 11.6.c — Merkle cartographer consultation ----------
+        # Per-watched-path baseline: { rel_scan_path → subtree_hash }.
+        # Short-circuit only when ALL watched subtree hashes match.
+        # Empty dict on cold-start → first scan always runs.
+        self._merkle_last_seen_subtree_hashes: Dict[str, str] = {}
+        # Cached candidate list from the last full scan. Replayed on
+        # short-circuit cycles so caller sees the same prior result.
+        # Stored regardless of merkle flag so flipping the flag mid-
+        # session doesn't blank state.
+        self._merkle_cached_candidates: List[StaticCandidate] = []
+        self._merkle_short_circuits: int = 0
+        self._merkle_full_scans: int = 0
+
     # v350.4: Third-party / non-project directory segments
     _NON_PROJECT_SEGMENTS = frozenset({
         "venv", ".venv", "env", ".env",
@@ -598,7 +648,27 @@ class OpportunityMinerSensor:
 
         Rotates through analysis strategies each cycle, applies cooldowns,
         and uses exploit/explore selection for diverse coverage.
+
+        Slice 11.6.c — when ``JARVIS_OPPMINER_USE_MERKLE=true`` AND the
+        Merkle Cartographer reports ALL watched scan-path subtree hashes
+        unchanged since the last successful scan, short-circuit to the
+        cached candidate list (skip filesystem walk + AST parse + ingest).
+        Subtree-scoped: a change outside the miner's ``_scan_paths`` does
+        NOT bust the cache.
         """
+        current_subtree_hashes = self._merkle_subtree_hashes()
+        if self._merkle_should_short_circuit(current_subtree_hashes):
+            self._merkle_short_circuits += 1
+            logger.debug(
+                "OpportunityMinerSensor: Merkle short-circuit "
+                "(scan #%d skipped, %d cached candidates, %d watched paths)",
+                self._merkle_short_circuits + self._merkle_full_scans,
+                len(self._merkle_cached_candidates),
+                len(current_subtree_hashes),
+            )
+            return list(self._merkle_cached_candidates)
+
+        self._merkle_full_scans += 1
         self._scan_cycle += 1
 
         # Pick the strategy for this cycle (round-robin)
@@ -663,6 +733,9 @@ class OpportunityMinerSensor:
                         ingested, errors, skipped_non_package,
                     )
                     self._emit_cycle_summary(counters, strategy_name)
+                    self._merkle_refresh_baseline(
+                        ingested, current_subtree_hashes,
+                    )
                     return ingested
                 # Coalescing envelope was rejected — fall through to per-file
                 # ingest as a best-effort fallback.
@@ -745,7 +818,144 @@ class OpportunityMinerSensor:
             ingested, errors, skipped_non_package,
         )
         self._emit_cycle_summary(counters, strategy_name)
+        self._merkle_refresh_baseline(ingested, current_subtree_hashes)
         return ingested
+
+    # ------------------------------------------------------------------
+    # Slice 11.6.c — Merkle Cartographer consultation (subtree-scoped)
+    # ------------------------------------------------------------------
+
+    def _merkle_normalized_scan_paths(self) -> List[str]:
+        """Project ``self._scan_paths`` into the cartographer's relpath
+        namespace (POSIX, no leading/trailing slash, ``"."`` → root).
+
+        Stable order: same iteration order as ``_scan_paths`` so the
+        baseline dict stays comparable across cycles even if the path
+        list is reordered (it shouldn't be, but defensive)."""
+        out: List[str] = []
+        for raw in self._scan_paths:
+            s = str(raw).replace("\\", "/").strip()
+            if s in ("", ".", "./"):
+                out.append("")  # root marker
+                continue
+            out.append(s.strip("/"))
+        return out
+
+    def _merkle_subtree_hashes(self) -> Dict[str, str]:
+        """Read per-watched-path subtree hashes from the cartographer.
+        Empty dict on any failure path — fail-safe to legacy scan.
+
+        For each scan path: empty-string relpath means "use root hash"
+        (i.e. ``_scan_paths == ["."]``); any other relpath uses
+        ``subtree_hash(relpath)``. A missing/unhashable subtree returns
+        empty string, which the comparison treats as 'always changed'
+        (fail-safe).
+        """
+        if not merkle_consult_enabled():
+            return {}
+        try:
+            from backend.core.ouroboros.governance.merkle_cartographer import (
+                get_default_cartographer,
+            )
+            c = get_default_cartographer(repo_root=self._repo_root)
+            out: Dict[str, str] = {}
+            for relpath in self._merkle_normalized_scan_paths():
+                if relpath == "":
+                    out[relpath] = c.current_root_hash()
+                else:
+                    out[relpath] = c.subtree_hash(relpath)
+            return out
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "OpportunityMinerSensor: subtree hash read failed; "
+                "falling through to full scan", exc_info=True,
+            )
+            return {}
+
+    def _merkle_should_short_circuit(
+        self, current_hashes: Dict[str, str],
+    ) -> bool:
+        """Decide whether to skip the multi-strategy scan based on
+        cartographer state. Returns False (i.e. proceed with full scan)
+        on any failure path — fail-safe to legacy behavior.
+
+        Conditions for short-circuit (ALL must hold):
+          1. Per-sensor flag ``JARVIS_OPPMINER_USE_MERKLE`` is true
+          2. Cartographer master flag enabled (empty hashes dict from
+             ``_merkle_subtree_hashes`` indicates flag off / error /
+             cold-cartographer → fail-safe)
+          3. Every watched subtree hash matches the recorded baseline
+          4. We have a recorded baseline (cold-start guard — the
+             baseline dict is empty until the first full scan
+             completes; an *empty cache* with a populated baseline
+             is a legitimate "scan found 0 candidates" state and
+             SHOULD short-circuit)
+          5. The set of watched paths is unchanged since last scan
+             (operator may have added/removed paths via reconfig —
+             a different shape means we cannot trust the baseline)
+          6. No watched subtree returned an empty hash (would mean
+             cartographer cannot resolve that path — e.g. it doesn't
+             exist on disk yet, fail-safe to full scan)
+        """
+        if not merkle_consult_enabled():
+            return False
+        if not current_hashes:
+            return False  # cartographer disabled / cold-start / error
+        if not self._merkle_last_seen_subtree_hashes:
+            return False  # cold start — no baseline yet
+        if (
+            set(current_hashes.keys())
+            != set(self._merkle_last_seen_subtree_hashes.keys())
+        ):
+            return False  # scan-path topology changed
+        if any(not h for h in current_hashes.values()):
+            return False  # at least one subtree unresolved
+        return all(
+            current_hashes[k] == self._merkle_last_seen_subtree_hashes[k]
+            for k in current_hashes
+        )
+
+    def _merkle_refresh_baseline(
+        self,
+        ingested: List[StaticCandidate],
+        current_hashes: Dict[str, str],
+    ) -> None:
+        """Snapshot the freshly-scanned cartographer state + ingested
+        candidates as the new baseline for the next cycle's
+        short-circuit decision. Always-safe — never raises."""
+        try:
+            self._merkle_cached_candidates = list(ingested)
+            self._merkle_last_seen_subtree_hashes = dict(current_hashes)
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "OpportunityMinerSensor: merkle baseline refresh failed",
+                exc_info=True,
+            )
+
+    def health(self) -> Dict[str, Any]:
+        """Operator-visible health snapshot. Slice 11.6.c added — exposes
+        merkle short-circuit telemetry for graduation observability."""
+        return {
+            "sensor": "OpportunityMinerSensor",
+            "repo": self._repo,
+            "running": self._running,
+            "scan_cycle": self._scan_cycle,
+            "cooldown_files": len(self._cooldown_map),
+            "seen_files": len(self._seen_file_paths),
+            "fs_events_mode": self._fs_events_mode,
+            "fs_events_handled": self._fs_events_handled,
+            "fs_events_ignored": self._fs_events_ignored,
+            "fs_events_debounced": self._fs_events_debounced,
+            "fs_events_storm_dropped": self._fs_events_storm_dropped,
+            # Slice 11.6.c — Merkle consultation telemetry
+            "merkle_consult_enabled": merkle_consult_enabled(),
+            "merkle_short_circuits": self._merkle_short_circuits,
+            "merkle_full_scans": self._merkle_full_scans,
+            "merkle_watched_paths": list(
+                self._merkle_last_seen_subtree_hashes.keys()
+            ),
+            "merkle_cached_candidates": len(self._merkle_cached_candidates),
+        }
 
     # ------------------------------------------------------------------
     # Internal helpers (shared between coalesced and per-file paths)

--- a/tests/governance/test_opp_miner_merkle.py
+++ b/tests/governance/test_opp_miner_merkle.py
@@ -1,0 +1,532 @@
+"""Slice 11.6.c regression spine — OpportunityMinerSensor + Merkle Cartographer.
+
+Subtree-scoped beef-up vs. 11.6.a/b: this sensor consults *per-watched-path*
+subtree hashes, not just a single root hash. A change in ``docs/`` (outside
+the miner's ``_scan_paths``) does NOT bust short-circuit. Only mutations
+under a watched subtree force a full scan.
+
+Pins:
+  §1 Per-sensor flag — JARVIS_OPPMINER_USE_MERKLE default false +
+                       truthy/falsy parsing
+  §2 Cold-start: full scan even with merkle on (cache empty)
+  §3 Steady state, no changes: short-circuit; cached candidates returned;
+                               no router calls; no cycle counter advance
+  §4 Watched-subtree change: full scan; cache + baseline refreshed
+  §5 OUT-OF-SCOPE change does NOT bust cache (the beef)
+  §6 Master flag off (cartographer): fail-safe to full scan
+  §7 Cartographer error: fail-safe to full scan (NEVER raises)
+  §8 Empty subtree hash (path doesn't exist) → fail-safe full scan
+  §9 health() exposes merkle metrics + watched paths
+  §10 Backward compat: merkle flag off → byte-identical legacy
+  §11 Source-level pins
+  §12 Path normalization (POSIX, ./ → root, trailing slash stripped)
+"""
+from __future__ import annotations
+
+import asyncio  # noqa: F401  — pytest-asyncio plugin contract
+import os  # noqa: F401  — env-var reads in fixtures
+from pathlib import Path
+from typing import Any, List  # noqa: F401  — used in body, not header
+from unittest.mock import AsyncMock, MagicMock  # noqa: F401
+
+import pytest
+
+from backend.core.ouroboros.governance.intake.sensors import (
+    opportunity_miner_sensor as oms,
+)
+from backend.core.ouroboros.governance.intake.sensors.opportunity_miner_sensor import (
+    OpportunityMinerSensor,
+    StaticCandidate,  # noqa: F401  — type ref for readers
+    merkle_consult_enabled,
+)
+from backend.core.ouroboros.governance import (
+    merkle_cartographer as mc,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _complex_module(num_branches: int = 12) -> str:
+    """A module dense enough to clear the miner's complexity threshold
+    (default 10). Series of nested ifs in a single function."""
+    body = "    pass\n"
+    for i in range(num_branches):
+        body = f"    if x == {i}:\n    " + body.replace("\n", "\n    ").rstrip() + "\n"
+    return (
+        '"""Synthetic complex module for Slice 11.6.c tests."""\n\n'
+        "def __init__(self):\n    pass\n\n"
+        f"def complex_fn(x):\n{body}\n    return x\n"
+    )
+
+
+@pytest.fixture
+def repo_with_opportunities(tmp_path: Path) -> Path:
+    """Synthetic repo with two complex modules under ``backend/`` and
+    one decoy file under ``docs/`` (outside the miner's scan scope but
+    inside the cartographer's default include list)."""
+    backend = tmp_path / "backend"
+    backend.mkdir()
+    # Make backend a package + add complex modules
+    (backend / "__init__.py").write_text("")
+    (backend / "complex_a.py").write_text(_complex_module(15))
+    (backend / "complex_b.py").write_text(_complex_module(13))
+
+    # docs/ — inside cartographer's default include but outside miner's
+    # scan_paths. Used by §5 to prove out-of-scope changes don't bust cache.
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "readme.md").write_text("# initial readme\n")
+
+    return tmp_path
+
+
+@pytest.fixture
+def make_sensor(repo_with_opportunities: Path):
+    """Factory: produces OpportunityMinerSensors rooted at the synthetic
+    repo, scoped to ``backend/`` only."""
+
+    def _make(**kwargs) -> OpportunityMinerSensor:
+        router = AsyncMock()
+        router.ingest = AsyncMock(return_value="enqueued")
+        return OpportunityMinerSensor(
+            repo_root=repo_with_opportunities,
+            router=router,
+            scan_paths=["backend"],
+            complexity_threshold=5,  # low threshold so synthetic files clear it
+            repo="JARVIS",
+            **kwargs,
+        )
+
+    return _make
+
+
+@pytest.fixture
+def isolated_cartographer(
+    repo_with_opportunities: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Fresh cartographer rooted at the synthetic repo + isolated state dir."""
+    monkeypatch.setenv("JARVIS_MERKLE_STATE_DIR", str(repo_with_opportunities))
+    mc.reset_default_cartographer_for_tests()
+    yield
+    mc.reset_default_cartographer_for_tests()
+
+
+# ===========================================================================
+# §1 — Per-sensor flag
+# ===========================================================================
+
+
+def test_merkle_consult_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_OPPMINER_USE_MERKLE", raising=False)
+    assert merkle_consult_enabled() is False
+
+
+def test_merkle_consult_truthy_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for val in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", val)
+        assert merkle_consult_enabled() is True
+
+
+def test_merkle_consult_falsy_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for val in ("0", "false", "no", "off", "", "garbage"):
+        monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", val)
+        assert merkle_consult_enabled() is False
+
+
+# ===========================================================================
+# §2 — Cold-start: must full-scan even with merkle on
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cold_start_full_scan_even_with_merkle_on(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+    isolated_cartographer,
+) -> None:
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    sensor = make_sensor()
+    candidates = await sensor.scan_once()
+    assert sensor._merkle_full_scans == 1  # noqa: SLF001
+    assert sensor._merkle_short_circuits == 0  # noqa: SLF001
+    assert sensor._merkle_cached_candidates == candidates  # noqa: SLF001
+    # Baseline now populated for next cycle
+    assert "backend" in sensor._merkle_last_seen_subtree_hashes  # noqa: SLF001
+
+
+# ===========================================================================
+# §3 — Steady state: no changes → short-circuit
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_when_no_changes(
+    make_sensor, repo_with_opportunities: Path,
+    monkeypatch: pytest.MonkeyPatch, isolated_cartographer,
+) -> None:
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    cart = mc.get_default_cartographer(repo_root=repo_with_opportunities)
+    await cart.update_full()
+
+    sensor = make_sensor()
+    first = await sensor.scan_once()
+    cycle_after_first = sensor._scan_cycle  # noqa: SLF001
+
+    # Snapshot router call count before second scan
+    router_calls_before = sensor._router.ingest.call_count
+
+    second = await sensor.scan_once()
+    assert sensor._merkle_short_circuits == 1  # noqa: SLF001
+    assert sensor._merkle_full_scans == 1  # noqa: SLF001 (unchanged)
+    assert second == first
+    # Cycle counter MUST NOT advance on short-circuit (no work was done)
+    assert sensor._scan_cycle == cycle_after_first  # noqa: SLF001
+    # Router was NOT called on the short-circuit cycle
+    assert sensor._router.ingest.call_count == router_calls_before
+
+
+# ===========================================================================
+# §4 — Watched-subtree change → full scan + cache refreshed
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_full_scan_when_watched_subtree_changes(
+    make_sensor, repo_with_opportunities: Path,
+    monkeypatch: pytest.MonkeyPatch, isolated_cartographer,
+) -> None:
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    cart = mc.get_default_cartographer(repo_root=repo_with_opportunities)
+    await cart.update_full()
+
+    sensor = make_sensor()
+    await sensor.scan_once()
+    baseline = dict(sensor._merkle_last_seen_subtree_hashes)  # noqa: SLF001
+    assert baseline.get("backend"), "backend subtree hash must be populated"
+
+    # Mutate something INSIDE backend/ → cartographer must report change
+    (repo_with_opportunities / "backend" / "complex_c.py").write_text(
+        _complex_module(20),
+    )
+    await cart.update_full()
+    assert cart.subtree_hash("backend") != baseline["backend"]
+
+    await sensor.scan_once()
+    assert sensor._merkle_full_scans >= 2  # noqa: SLF001
+    # Baseline updated to fresh subtree hash
+    new_baseline = sensor._merkle_last_seen_subtree_hashes  # noqa: SLF001
+    assert new_baseline["backend"] != baseline["backend"]
+
+
+# ===========================================================================
+# §5 — THE BEEF: out-of-scope change does NOT bust cache
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_out_of_scope_change_does_not_bust_cache(
+    make_sensor, repo_with_opportunities: Path,
+    monkeypatch: pytest.MonkeyPatch, isolated_cartographer,
+) -> None:
+    """The cartographer's root hash includes ``docs/``, but the miner
+    only watches ``backend/``. A change to ``docs/readme.md`` MUST NOT
+    invalidate the miner's short-circuit — the subtree hash for
+    ``backend/`` is unchanged."""
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    cart = mc.get_default_cartographer(repo_root=repo_with_opportunities)
+    await cart.update_full()
+
+    sensor = make_sensor()
+    await sensor.scan_once()
+    pre_root = cart.current_root_hash()
+    pre_backend = cart.subtree_hash("backend")
+
+    # Mutate OUTSIDE the miner's scope — root hash WILL change but
+    # backend subtree hash MUST NOT
+    (repo_with_opportunities / "docs" / "readme.md").write_text(
+        "# different readme content\n"
+    )
+    await cart.update_full()
+    post_root = cart.current_root_hash()
+    post_backend = cart.subtree_hash("backend")
+
+    assert post_root != pre_root, (
+        "root hash should change when any tracked dir changes"
+    )
+    assert post_backend == pre_backend, (
+        "backend subtree hash MUST NOT change when only docs/ changed"
+    )
+
+    # Sensor must short-circuit despite the root-hash change
+    await sensor.scan_once()
+    assert sensor._merkle_short_circuits == 1  # noqa: SLF001
+    assert sensor._merkle_full_scans == 1  # noqa: SLF001 (unchanged)
+
+
+# ===========================================================================
+# §6 — Master flag off → fail-safe full scan
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cartographer_master_flag_off_falls_through_to_full_scan(
+    make_sensor, monkeypatch: pytest.MonkeyPatch, isolated_cartographer,
+) -> None:
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "true")
+    monkeypatch.delenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", raising=False)
+    sensor = make_sensor()
+
+    await sensor.scan_once()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    assert sensor._merkle_full_scans == 3  # noqa: SLF001
+    assert sensor._merkle_short_circuits == 0  # noqa: SLF001
+
+
+# ===========================================================================
+# §7 — Cartographer error → fail-safe full scan (NEVER raises)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cartographer_error_falls_through_to_full_scan(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    sensor = make_sensor()
+    await sensor.scan_once()  # cold scan to populate cache
+
+    def _broken_subtree(self, *args, **kwargs):
+        raise RuntimeError("simulated cartographer crash")
+
+    monkeypatch.setattr(
+        mc.MerkleCartographer, "subtree_hash", _broken_subtree,
+    )
+    monkeypatch.setattr(
+        mc.MerkleCartographer, "current_root_hash", _broken_subtree,
+    )
+
+    candidates = await sensor.scan_once()
+    assert isinstance(candidates, list)
+    assert sensor._merkle_full_scans >= 2  # noqa: SLF001
+
+
+# ===========================================================================
+# §8 — Empty subtree hash (path missing) → fail-safe
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_empty_subtree_hash_falls_through_to_full_scan(
+    make_sensor, monkeypatch: pytest.MonkeyPatch, isolated_cartographer,
+) -> None:
+    """If the cartographer can't resolve a watched subtree (path doesn't
+    exist on disk yet, hasn't been hydrated, etc.) the sensor must fail
+    safe and full-scan rather than treating empty hash as 'unchanged'."""
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    sensor = make_sensor()
+    # Cold scan to seed cache
+    await sensor.scan_once()
+
+    # Inject empty subtree hash via monkeypatch
+    def _empty_hash(self, *args, **kwargs):
+        return ""
+
+    monkeypatch.setattr(
+        mc.MerkleCartographer, "subtree_hash", _empty_hash,
+    )
+
+    await sensor.scan_once()
+    assert sensor._merkle_full_scans >= 2  # noqa: SLF001
+    assert sensor._merkle_short_circuits == 0  # noqa: SLF001
+
+
+# ===========================================================================
+# §9 — health() exposes merkle metrics + watched paths
+# ===========================================================================
+
+
+def test_health_exposes_merkle_metrics(make_sensor) -> None:
+    sensor = make_sensor()
+    h = sensor.health()
+    assert h["sensor"] == "OpportunityMinerSensor"
+    assert "merkle_consult_enabled" in h
+    assert "merkle_short_circuits" in h
+    assert "merkle_full_scans" in h
+    assert "merkle_watched_paths" in h
+    assert "merkle_cached_candidates" in h
+    assert h["merkle_short_circuits"] == 0
+    assert h["merkle_full_scans"] == 0
+    assert h["merkle_cached_candidates"] == 0
+
+
+@pytest.mark.asyncio
+async def test_health_after_scan_reflects_metrics(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+    isolated_cartographer,
+) -> None:
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    sensor = make_sensor()
+    await sensor.scan_once()
+    h = sensor.health()
+    assert h["merkle_full_scans"] == 1
+    assert "backend" in h["merkle_watched_paths"]
+
+
+# ===========================================================================
+# §10 — Backward compat: merkle flag off → byte-identical legacy
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_merkle_flag_off_full_scan_every_cycle(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_OPPMINER_USE_MERKLE", raising=False)
+    sensor = make_sensor()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    assert sensor._merkle_full_scans == 3  # noqa: SLF001
+    assert sensor._merkle_short_circuits == 0  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_merkle_flag_off_does_not_call_cartographer(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JARVIS_OPPMINER_USE_MERKLE", raising=False)
+
+    call_count = 0
+    original_get = mc.get_default_cartographer
+
+    def _spy(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_get(*args, **kwargs)
+
+    monkeypatch.setattr(mc, "get_default_cartographer", _spy)
+    sensor = make_sensor()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    assert call_count == 0
+
+
+# ===========================================================================
+# §11 — Source-level pins
+# ===========================================================================
+
+
+def test_source_imports_cartographer_lazily() -> None:
+    """The cartographer import must be inside the consult method, NOT
+    at module top level — keeps opportunity_miner_sensor's module load
+    path independent of the cartographer module."""
+    import inspect
+    src = inspect.getsource(
+        OpportunityMinerSensor._merkle_subtree_hashes,
+    )
+    assert (
+        "from backend.core.ouroboros.governance.merkle_cartographer"
+        in src
+    )
+
+
+def test_source_short_circuit_branch_in_scan_once() -> None:
+    """The merkle short-circuit branch must fire BEFORE the
+    `loop.run_in_executor(self._scan_files_sync, ...)` call so the AST
+    sweep is genuinely skipped."""
+    import inspect
+    src = inspect.getsource(OpportunityMinerSensor.scan_once)
+    sc_idx = src.index("_merkle_should_short_circuit")
+    walk_idx = src.index("run_in_executor")
+    assert sc_idx < walk_idx
+
+
+def test_source_no_top_level_cartographer_import() -> None:
+    """Module top-level imports must NOT include merkle_cartographer."""
+    import inspect
+    src = inspect.getsource(oms)
+    header_end = min(
+        (i for i in (src.find("\ndef "), src.find("\nclass "))
+         if i > 0),
+        default=len(src),
+    )
+    header = src[:header_end]
+    assert "from backend.core.ouroboros.governance.merkle_cartographer" not in header
+
+
+def test_source_uses_subtree_hash_not_just_root_hash() -> None:
+    """The beef: this sensor MUST consult subtree_hash, not just
+    current_root_hash. Pins the subtree-scoped contract source-level."""
+    import inspect
+    src = inspect.getsource(OpportunityMinerSensor._merkle_subtree_hashes)
+    assert "subtree_hash" in src, (
+        "Slice 11.6.c contract: subtree-scoped consultation required"
+    )
+
+
+# ===========================================================================
+# §12 — Path normalization
+# ===========================================================================
+
+
+def test_normalized_scan_paths_dot_becomes_root(
+    make_sensor,
+) -> None:
+    sensor = make_sensor()
+    sensor._scan_paths = ["."]  # noqa: SLF001
+    norm = sensor._merkle_normalized_scan_paths()  # noqa: SLF001
+    assert norm == [""]
+
+
+def test_normalized_scan_paths_strips_trailing_slash(
+    make_sensor,
+) -> None:
+    sensor = make_sensor()
+    sensor._scan_paths = ["backend/", "/tests/", "scripts"]  # noqa: SLF001
+    norm = sensor._merkle_normalized_scan_paths()  # noqa: SLF001
+    assert norm == ["backend", "tests", "scripts"]
+
+
+def test_normalized_scan_paths_handles_windows_seps(
+    make_sensor,
+) -> None:
+    sensor = make_sensor()
+    sensor._scan_paths = ["backend\\subdir"]  # noqa: SLF001
+    norm = sensor._merkle_normalized_scan_paths()  # noqa: SLF001
+    assert norm == ["backend/subdir"]
+
+
+@pytest.mark.asyncio
+async def test_scan_path_topology_change_busts_cache(
+    make_sensor, monkeypatch: pytest.MonkeyPatch, isolated_cartographer,
+) -> None:
+    """If operator reconfigures _scan_paths between scans, the baseline
+    keys won't match the current keys — must fail-safe to full scan."""
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "true")
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    sensor = make_sensor()
+    await sensor.scan_once()
+    assert sensor._merkle_full_scans == 1  # noqa: SLF001
+
+    # Simulate operator adding a new watched path mid-session
+    sensor._scan_paths = ["backend", "tests"]  # noqa: SLF001
+
+    await sensor.scan_once()
+    # Topology changed → full scan, no short-circuit
+    assert sensor._merkle_full_scans == 2  # noqa: SLF001
+    assert sensor._merkle_short_circuits == 0  # noqa: SLF001


### PR DESCRIPTION
## Summary

OpportunityMinerSensor now skips its multi-strategy AST sweep when the cartographer reports no change under any of its watched scan paths. **Beefed up vs. 11.6.a/b**: per-watched-path subtree hashes, not a single root hash — a mutation in `docs/` (outside the miner's scope) does NOT invalidate the cache.

## The beef: subtree-scoped consultation

The miner watches specific paths (e.g. `["backend"]`). The cartographer's root hash includes everything (`backend/`, `tests/`, `docs/`, `config/`). Tracking root hash would invalidate the miner's cache on every doc edit — wasted CPU on unrelated mutations. Subtree consultation cuts that out:

```
backend/foo.py changed       → backend subtree hash changes → full scan
docs/readme.md changed       → backend subtree hash unchanged → short-circuit
config/policy.yaml changed   → backend subtree hash unchanged → short-circuit
```

Pinned in §5 of the test suite (`test_out_of_scope_change_does_not_bust_cache`).

## Six fail-safes (all-or-nothing short-circuit)

1. Per-sensor flag (`JARVIS_OPPMINER_USE_MERKLE`) off → legacy full scan
2. Cartographer master flag off / error → empty hashes → legacy
3. Cold-start (no recorded baseline) → legacy
4. Scan-path topology changed (operator reconfig) → legacy
5. Any watched subtree returns empty hash (path missing) → legacy
6. Any watched subtree hash differs from baseline → legacy

## Cycle-counter invariant

Scan-cycle counter does NOT advance on short-circuit, preserving the strategy-rotation invariant: `scan_once #N+1` after a short-circuit picks up the same strategy that `#N+1` would have picked, not a skipped one.

## Cold-start guard correction

11.6.a/b included a `not self._merkle_cached_items` guard that treated "scan found 0 items" identically to "no scan has happened yet." That's wrong — an empty result *with a populated baseline* is a legitimate steady state. 11.6.c uses only the baseline-dict guard for cold-start, which is the authoritative signal. (Existing 11.6.a/b behavior unchanged — this is the new sensor's correct semantic from day one.)

## Other additions

- New `health()` method exposes `merkle_consult_enabled` / `merkle_short_circuits` / `merkle_full_scans` / `merkle_watched_paths` / `merkle_cached_candidates` plus all pre-existing FS-event telemetry
- `_merkle_normalized_scan_paths()` handles `./` → root, trailing `/`, and Windows backslash seps

## Test plan

- [x] Slice 11.6.c tests: `tests/governance/test_opp_miner_merkle.py` — 22/22 green
- [x] Combined Phase 11 spine + miner full regression suites (cycle_summary, auto_ack_lane, fs_events, sensor base, doc_staleness webhook) — 205/205 green
- [ ] Once-proof after Slice 11.6.d lands (BacklogSensor) — Phase 11 graduation per Slice 11.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds subtree-scoped Merkle consultation to `OpportunityMinerSensor` to skip heavy scans when watched paths are unchanged. Changes outside the sensor’s scope (like `docs/`) no longer bust the cache, improving performance without losing correctness.

- New Features
  - Consults `merkle_cartographer` per watched path and short-circuits when all subtree hashes match the baseline; only in-scope changes trigger a full scan.
  - Fail-safe to full scan on: flag off, cartographer off/error, cold start, watched paths changed, missing subtree hash, or any hash diff.
  - Preserves strategy rotation on short-circuit and fixes the cold-start guard (empty cached results with a baseline now short-circuit correctly).
  - Adds `health()` metrics: `merkle_consult_enabled`, `merkle_short_circuits`, `merkle_full_scans`, `merkle_watched_paths`, `merkle_cached_candidates`.
  - Normalizes scan paths (handles `./`, trailing slashes, Windows separators).
  - Controlled by `JARVIS_OPPMINER_USE_MERKLE` (per-sensor) and `JARVIS_MERKLE_CARTOGRAPHER_ENABLED` (master). Tests added; full suite green.

<sup>Written for commit c8fce768443f98bd69642f65e8c70c8b007938a7. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/26304?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

