### PR TITLE
Slice 11.6.d: BacklogSensor file-stat short-circuit (peer of merkle consult)

### DIFF
--- a/backend/core/ouroboros/governance/intake/sensors/backlog_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/backlog_sensor.py
@@ -74,6 +74,43 @@ _BACKLOG_FALLBACK_INTERVAL_S: float = float(
 )
 
 
+# ---------------------------------------------------------------------------
+# Slice 11.6.d — File-stat short-circuit (peer of 11.6.a/b/c merkle consult)
+# ---------------------------------------------------------------------------
+#
+# Why stat instead of MerkleCartographer? BacklogSensor's two watched files
+# live under ``.jarvis/`` (state, not code) — outside the cartographer's
+# tracked include set ``("backend", "tests", "scripts", "docs", "config")``.
+# Hidden dot-dirs are correctly excluded from the cartographer (they store
+# session blobs, posture history, etc. — high churn, no semantic value).
+# The cartographer can't see backlog.json; subtree_hash(".jarvis/backlog.json")
+# returns "" by design.
+#
+# Same architectural spirit as 11.6.a/b/c: cheap pre-emption of an expensive
+# read + JSON parse + envelope build. Different mechanism appropriate to the
+# watched data class:
+#
+#   11.6.a/b/c: code subtrees → merkle hash (handles N files cheaply)
+#   11.6.d:     state files   → file stat (handles 2 files trivially)
+#
+# Stat tuple: (exists, mtime_ns, size). A change in any field → full scan.
+# Atomic-rename (write-temp + os.rename) flips inode → mtime resets → stat
+# changes. Identical-content rewrite still triggers full scan via mtime
+# delta — caught and dedup'd by ``_seen_task_ids`` ledger downstream.
+#
+# Default false to preserve byte-identical legacy behavior. Phase 11.7
+# graduation flips this alongside the three merkle flags.
+
+
+def short_circuit_enabled() -> bool:
+    """Re-read ``JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED`` at call time so
+    monkeypatch works in tests + operator can flip live without re-init."""
+    raw = os.environ.get(
+        "JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
 _PRIORITY_URGENCY: Dict[int, str] = {
     5: "high",
     4: "high",
@@ -305,6 +342,17 @@ class BacklogSensor:
         self._fs_events_handled: int = 0
         self._fs_events_ignored: int = 0
 
+        # --- Slice 11.6.d — File-stat short-circuit state ------------
+        # Tuple-of-tuples baseline: stat snapshot for each watched file.
+        # Empty tuple = cold start. A mismatch on the next scan triggers
+        # a full read; equal stats short-circuit to the cached envelope
+        # list. The (auto_proposed_enabled,) suffix captures the env flag
+        # so flipping the proposals-ledger source busts the cache.
+        self._sc_last_state: tuple = ()
+        self._sc_cached_envelopes: List[IntentEnvelope] = []
+        self._sc_short_circuits: int = 0
+        self._sc_full_scans: int = 0
+
     async def scan_once(self) -> List[IntentEnvelope]:
         """Run one scan. Returns list of envelopes produced and ingested
         across BOTH the manual ``backlog.json`` source and (P1 Slice 3,
@@ -314,11 +362,34 @@ class BacklogSensor:
         The two scans are independent — a missing ``backlog.json`` does
         not block the proposals scan, and vice versa — so operators can
         rely on the auto-proposed pipeline even before they create their
-        first manual backlog entry."""
+        first manual backlog entry.
+
+        Slice 11.6.d — when ``JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED=true``
+        AND the (mtime_ns, size, exists) stat tuple of every watched
+        file is unchanged since the last scan, short-circuit to the
+        cached envelope list (skip read + JSON parse + envelope build).
+        File-stat is the analogue of the cartographer hash for state
+        files that the cartographer correctly excludes from its tree.
+        """
+        current_state = self._sc_current_state()
+        if self._sc_should_short_circuit(current_state):
+            self._sc_short_circuits += 1
+            logger.debug(
+                "[BacklogSensor] Stat short-circuit "
+                "(scan #%d skipped, %d cached envelopes)",
+                self._sc_short_circuits + self._sc_full_scans,
+                len(self._sc_cached_envelopes),
+            )
+            return list(self._sc_cached_envelopes)
+
+        self._sc_full_scans += 1
         produced: List[IntentEnvelope] = []
         produced.extend(await self._scan_backlog_json())
         if _auto_proposed_enabled():
             produced.extend(await self._scan_proposals_ledger())
+        # Refresh cache + baseline AFTER the scan completes so the next
+        # cycle's stat read sees the same files we just digested.
+        self._sc_refresh_baseline(produced, current_state)
         return produced
 
     async def _scan_backlog_json(self) -> List[IntentEnvelope]:
@@ -590,6 +661,128 @@ class BacklogSensor:
                 emitted_log_count,
             )
         return produced
+
+    # ------------------------------------------------------------------
+    # Slice 11.6.d — File-stat short-circuit (peer of 11.6.a/b/c merkle)
+    # ------------------------------------------------------------------
+
+    def _sc_watched_paths(self) -> List[Path]:
+        """Files whose stat tuples form the short-circuit baseline.
+
+        Always includes the manual ``backlog.json``. The proposals
+        ledger is only watched when its source is enabled — flipping
+        ``JARVIS_BACKLOG_AUTO_PROPOSED_ENABLED`` mid-session adds/drops
+        the file from the watch set, which is captured in the state
+        signature via the auto-proposed flag suffix below."""
+        paths: List[Path] = [self._backlog_path]
+        if _auto_proposed_enabled():
+            paths.append(self._proposals_ledger_path)
+        return paths
+
+    def _sc_stat_tuple(self, path: Path) -> tuple:
+        """(exists, mtime_ns, size) snapshot for a single file.
+        Returns (False, 0, 0) for any read error — fail-safe."""
+        try:
+            st = path.stat()
+            return (True, st.st_mtime_ns, st.st_size)
+        except FileNotFoundError:
+            return (False, 0, 0)
+        except OSError:  # noqa: BLE001 — defensive (perm errors etc.)
+            logger.debug(
+                "[BacklogSensor] stat failed for %s; "
+                "falling through to full scan", path, exc_info=True,
+            )
+            # Sentinel that won't equal any real stat tuple → forces
+            # full scan on the comparison branch.
+            return ("__sc_error__",)
+
+    def _sc_current_state(self) -> tuple:
+        """Frozen, hashable signature of the watched file set.
+
+        Returns empty tuple if short-circuit is disabled — sentinel
+        consumed by ``_sc_should_short_circuit`` to fail-safe."""
+        if not short_circuit_enabled():
+            return ()
+        try:
+            file_stats = tuple(
+                (str(p), self._sc_stat_tuple(p))
+                for p in self._sc_watched_paths()
+            )
+            # Suffix the auto-proposed flag so flipping the source set
+            # busts the cache (watched-path topology changed — same
+            # invariant as the OpportunityMiner scan-path topology guard).
+            return (file_stats, _auto_proposed_enabled())
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[BacklogSensor] current_state read failed; "
+                "falling through to full scan", exc_info=True,
+            )
+            return ()
+
+    def _sc_should_short_circuit(self, current_state: tuple) -> bool:
+        """Decide whether to skip the read+JSON+envelope build.
+        Returns False (i.e. proceed with full scan) on any failure
+        path — fail-safe to legacy behavior.
+
+        Conditions for short-circuit (ALL must hold):
+          1. Per-sensor flag ``JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED``
+             is true (empty current_state from
+             ``_sc_current_state`` indicates flag off → fail-safe)
+          2. We have a recorded baseline (cold-start guard)
+          3. The current state tuple equals the recorded baseline
+
+        Note: an empty cached envelope list with a populated baseline
+        IS a valid short-circuit state (correct semantic ported from
+        Slice 11.6.c — "scan found 0 envelopes" is a legitimate
+        steady-state answer, not a cold-start signal)."""
+        if not short_circuit_enabled():
+            return False
+        if not current_state:
+            return False  # short-circuit disabled / error
+        if not self._sc_last_state:
+            return False  # cold start — no baseline yet
+        return current_state == self._sc_last_state
+
+    def _sc_refresh_baseline(
+        self,
+        produced: List[IntentEnvelope],
+        current_state: tuple,
+    ) -> None:
+        """Snapshot the freshly-scanned envelopes + stat signature as
+        the new baseline. Always-safe — never raises."""
+        try:
+            self._sc_cached_envelopes = list(produced)
+            self._sc_last_state = current_state
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[BacklogSensor] short-circuit baseline refresh failed",
+                exc_info=True,
+            )
+
+    def health(self) -> Dict[str, Any]:
+        """Operator-visible health snapshot. Slice 11.6.d added —
+        exposes file-stat short-circuit telemetry for graduation
+        observability, alongside pre-existing FS-event counters."""
+        return {
+            "sensor": "BacklogSensor",
+            "running": self._running,
+            "seen_tasks": len(self._seen_task_ids),
+            "poll_interval_s": self._poll_interval_s,
+            "fs_events_mode": self._fs_events_mode,
+            "fs_events_handled": self._fs_events_handled,
+            "fs_events_ignored": self._fs_events_ignored,
+            # Slice 11.6.d — short-circuit telemetry (peer of merkle metrics
+            # on Todo / Doc / Miner; uses file-stat instead of merkle hash
+            # because watched files live under .jarvis/ which the
+            # cartographer correctly excludes by design).
+            "short_circuit_enabled": short_circuit_enabled(),
+            "short_circuit_short_circuits": self._sc_short_circuits,
+            "short_circuit_full_scans": self._sc_full_scans,
+            "short_circuit_watched_files": [
+                str(p) for p in self._sc_watched_paths()
+            ],
+            "short_circuit_cached_envelopes": len(self._sc_cached_envelopes),
+        }
 
     async def start(self) -> None:
         """Start background polling loop."""

--- a/tests/governance/test_backlog_sensor_short_circuit.py
+++ b/tests/governance/test_backlog_sensor_short_circuit.py
@@ -1,0 +1,432 @@
+"""Slice 11.6.d regression spine — BacklogSensor + file-stat short-circuit.
+
+Architectural note: BacklogSensor's watched files live under ``.jarvis/``,
+which the MerkleCartographer correctly excludes (state, not code). So this
+slice uses file-stat short-circuit (mtime_ns + size + exists) as the
+analogue of cartographer hash for state files. Same architectural spirit
+as 11.6.a/b/c (cheap pre-emption of expensive read+parse), different
+mechanism appropriate to the watched data class.
+
+Pins:
+  §1 Per-sensor flag — JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED default false +
+                       truthy/falsy parsing
+  §2 Cold-start: full scan even with flag on (no baseline)
+  §3 Steady state, no changes: short-circuit; cached envelopes returned
+  §4 backlog.json mtime change → full scan; cache + baseline refreshed
+  §5 backlog.json size change → full scan
+  §6 backlog.json deleted → full scan (existence flip)
+  §7 proposals.jsonl change (when auto-proposed on) → full scan
+  §8 auto-proposed flag flipped → full scan (topology change)
+  §9 OS error on stat → fail-safe full scan (NEVER raises)
+  §10 health() exposes short-circuit metrics + watched files
+  §11 Backward compat: flag off → byte-identical legacy
+  §12 Source-level pins
+"""
+from __future__ import annotations
+
+import asyncio  # noqa: F401  — pytest-asyncio plugin contract
+import json
+import os  # noqa: F401  — env-var reads in fixtures
+import time
+from pathlib import Path
+from typing import Any, List  # noqa: F401  — used in body, not header
+from unittest.mock import AsyncMock, MagicMock  # noqa: F401
+
+import pytest
+
+from backend.core.ouroboros.governance.intake.sensors import (
+    backlog_sensor as bls,
+)
+from backend.core.ouroboros.governance.intake.sensors.backlog_sensor import (
+    BacklogSensor,
+    short_circuit_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _backlog_payload(num_tasks: int = 2) -> str:
+    """JSON payload matching BacklogSensor's expected schema."""
+    return json.dumps([
+        {
+            "task_id": f"task-{i}",
+            "description": f"synthetic task {i}",
+            "target_files": [f"backend/file_{i}.py"],
+            "priority": 3,
+            "repo": "JARVIS",
+            "status": "pending",
+        }
+        for i in range(num_tasks)
+    ])
+
+
+@pytest.fixture
+def repo_with_backlog(tmp_path: Path) -> Path:
+    """Synthetic repo with a populated .jarvis/backlog.json."""
+    jarvis_dir = tmp_path / ".jarvis"
+    jarvis_dir.mkdir()
+    (jarvis_dir / "backlog.json").write_text(_backlog_payload(2))
+    # Empty proposals ledger so the auto-proposed scan is deterministic
+    # (returns 0 envelopes when the flag is on).
+    (jarvis_dir / "self_goal_formation_proposals.jsonl").write_text("")
+    return tmp_path
+
+
+@pytest.fixture
+def make_sensor(repo_with_backlog: Path):
+    """Factory: produces BacklogSensors rooted at the synthetic repo."""
+
+    def _make(**kwargs) -> BacklogSensor:
+        router = AsyncMock()
+        router.ingest = AsyncMock(return_value="enqueued")
+        return BacklogSensor(
+            backlog_path=repo_with_backlog / ".jarvis" / "backlog.json",
+            repo_root=repo_with_backlog,
+            router=router,
+            poll_interval_s=60.0,
+            **kwargs,
+        )
+
+    return _make
+
+
+@pytest.fixture(autouse=True)
+def _disable_auto_proposed_by_default(monkeypatch: pytest.MonkeyPatch):
+    """Most tests assume only backlog.json is watched. Tests that
+    specifically exercise the proposals path enable it explicitly."""
+    monkeypatch.setenv("JARVIS_BACKLOG_AUTO_PROPOSED_ENABLED", "false")
+
+
+# ===========================================================================
+# §1 — Per-sensor flag
+# ===========================================================================
+
+
+def test_short_circuit_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", raising=False)
+    assert short_circuit_enabled() is False
+
+
+def test_short_circuit_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    for val in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", val)
+        assert short_circuit_enabled() is True
+
+
+def test_short_circuit_falsy_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    for val in ("0", "false", "no", "off", "", "garbage"):
+        monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", val)
+        assert short_circuit_enabled() is False
+
+
+# ===========================================================================
+# §2 — Cold-start: must full-scan even with flag on
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cold_start_full_scan_even_with_flag_on(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "true")
+    sensor = make_sensor()
+    envelopes = await sensor.scan_once()
+    assert sensor._sc_full_scans == 1  # noqa: SLF001
+    assert sensor._sc_short_circuits == 0  # noqa: SLF001
+    assert sensor._sc_cached_envelopes == envelopes  # noqa: SLF001
+    # Baseline populated for next cycle
+    assert sensor._sc_last_state  # noqa: SLF001
+
+
+# ===========================================================================
+# §3 — Steady state: no changes → short-circuit
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_when_no_changes(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "true")
+    sensor = make_sensor()
+    first = await sensor.scan_once()
+
+    router_calls_before = sensor._router.ingest.call_count
+
+    second = await sensor.scan_once()
+    assert sensor._sc_short_circuits == 1  # noqa: SLF001
+    assert sensor._sc_full_scans == 1  # noqa: SLF001 (unchanged)
+    assert second == first
+    # Router NOT called on short-circuit
+    assert sensor._router.ingest.call_count == router_calls_before
+
+
+# ===========================================================================
+# §4 — backlog.json mtime change → full scan
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_full_scan_when_mtime_changes(
+    make_sensor, repo_with_backlog: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "true")
+    sensor = make_sensor()
+    await sensor.scan_once()
+    assert sensor._sc_full_scans == 1  # noqa: SLF001
+    baseline = sensor._sc_last_state  # noqa: SLF001
+
+    # Bump mtime without changing size — same content rewritten
+    backlog = repo_with_backlog / ".jarvis" / "backlog.json"
+    time.sleep(0.01)  # ensure mtime tick
+    backlog.write_text(backlog.read_text())
+
+    await sensor.scan_once()
+    assert sensor._sc_full_scans == 2  # noqa: SLF001
+    new_baseline = sensor._sc_last_state  # noqa: SLF001
+    assert new_baseline != baseline
+
+
+# ===========================================================================
+# §5 — backlog.json size change → full scan
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_full_scan_when_size_changes(
+    make_sensor, repo_with_backlog: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "true")
+    sensor = make_sensor()
+    await sensor.scan_once()
+
+    # Add a third task — size grows even if mtime didn't tick
+    backlog = repo_with_backlog / ".jarvis" / "backlog.json"
+    backlog.write_text(_backlog_payload(3))
+
+    await sensor.scan_once()
+    assert sensor._sc_full_scans == 2  # noqa: SLF001
+
+
+# ===========================================================================
+# §6 — backlog.json deleted → existence flip → full scan
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_full_scan_when_backlog_deleted(
+    make_sensor, repo_with_backlog: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "true")
+    sensor = make_sensor()
+    await sensor.scan_once()
+
+    (repo_with_backlog / ".jarvis" / "backlog.json").unlink()
+
+    envelopes = await sensor.scan_once()
+    assert sensor._sc_full_scans == 2  # noqa: SLF001
+    # Sensor returns [] on missing file — but DOES full-scan to verify
+    assert envelopes == []
+
+
+# ===========================================================================
+# §7 — proposals.jsonl change → full scan (when auto-proposed on)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_full_scan_when_proposals_change(
+    make_sensor, repo_with_backlog: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_BACKLOG_AUTO_PROPOSED_ENABLED", "true")
+    sensor = make_sensor()
+    await sensor.scan_once()
+    assert sensor._sc_full_scans == 1  # noqa: SLF001
+
+    # Append a proposal entry — file mtime + size both change
+    proposals = repo_with_backlog / ".jarvis" / "self_goal_formation_proposals.jsonl"
+    time.sleep(0.01)
+    proposals.write_text(
+        json.dumps({
+            "proposal_id": "prop-001",
+            "description": "synthetic proposal",
+            "target_files": ["backend/x.py"],
+        }) + "\n"
+    )
+
+    await sensor.scan_once()
+    assert sensor._sc_full_scans == 2  # noqa: SLF001
+
+
+# ===========================================================================
+# §8 — auto-proposed flag flipped → topology change → full scan
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_full_scan_when_auto_proposed_flag_flipped(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The (auto_proposed_enabled,) suffix in the state tuple captures
+    the env flag — flipping it mid-session must bust the cache."""
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_BACKLOG_AUTO_PROPOSED_ENABLED", "false")
+    sensor = make_sensor()
+    await sensor.scan_once()
+    assert sensor._sc_full_scans == 1  # noqa: SLF001
+
+    # Operator flips the flag mid-session — adds proposals.jsonl to
+    # the watched set
+    monkeypatch.setenv("JARVIS_BACKLOG_AUTO_PROPOSED_ENABLED", "true")
+
+    await sensor.scan_once()
+    # Topology changed → full scan, no short-circuit
+    assert sensor._sc_full_scans == 2  # noqa: SLF001
+    assert sensor._sc_short_circuits == 0  # noqa: SLF001
+
+
+# ===========================================================================
+# §9 — OS error on stat → fail-safe full scan (NEVER raises)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_os_error_on_stat_falls_through_to_full_scan(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "true")
+    sensor = make_sensor()
+    await sensor.scan_once()  # cold scan
+
+    # Patch _sc_stat_tuple to simulate a permission error
+    orig_stat = BacklogSensor._sc_stat_tuple
+
+    def _broken_stat(self, path):
+        return ("__sc_error__",)
+
+    monkeypatch.setattr(BacklogSensor, "_sc_stat_tuple", _broken_stat)
+
+    envelopes = await sensor.scan_once()
+    assert isinstance(envelopes, list)
+    # State signature now contains error sentinels — won't equal baseline
+    assert sensor._sc_full_scans == 2  # noqa: SLF001
+
+
+# ===========================================================================
+# §10 — health() exposes short-circuit metrics
+# ===========================================================================
+
+
+def test_health_exposes_short_circuit_metrics(make_sensor) -> None:
+    sensor = make_sensor()
+    h = sensor.health()
+    assert h["sensor"] == "BacklogSensor"
+    assert "short_circuit_enabled" in h
+    assert "short_circuit_short_circuits" in h
+    assert "short_circuit_full_scans" in h
+    assert "short_circuit_watched_files" in h
+    assert "short_circuit_cached_envelopes" in h
+    assert h["short_circuit_short_circuits"] == 0
+    assert h["short_circuit_full_scans"] == 0
+    assert h["short_circuit_cached_envelopes"] == 0
+
+
+@pytest.mark.asyncio
+async def test_health_after_scan_reflects_metrics(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "true")
+    sensor = make_sensor()
+    await sensor.scan_once()
+    h = sensor.health()
+    assert h["short_circuit_full_scans"] == 1
+    assert any(
+        "backlog.json" in p
+        for p in h["short_circuit_watched_files"]
+    )
+
+
+# ===========================================================================
+# §11 — Backward compat: flag off → byte-identical legacy
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_flag_off_full_scan_every_cycle(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(
+        "JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", raising=False,
+    )
+    sensor = make_sensor()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    await sensor.scan_once()
+    assert sensor._sc_full_scans == 3  # noqa: SLF001
+    assert sensor._sc_short_circuits == 0  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_flag_off_does_not_stat_watched_files(
+    make_sensor, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the per-sensor flag is off, _sc_current_state returns ()
+    immediately — the stat syscalls are skipped entirely."""
+    monkeypatch.delenv(
+        "JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", raising=False,
+    )
+    sensor = make_sensor()
+    state = sensor._sc_current_state()  # noqa: SLF001
+    assert state == ()
+
+
+# ===========================================================================
+# §12 — Source-level pins
+# ===========================================================================
+
+
+def test_source_short_circuit_branch_in_scan_once() -> None:
+    """The short-circuit branch must fire BEFORE the
+    `_scan_backlog_json` call so the read + JSON parse is genuinely
+    skipped."""
+    import inspect
+    src = inspect.getsource(BacklogSensor.scan_once)
+    sc_idx = src.index("_sc_should_short_circuit")
+    read_idx = src.index("_scan_backlog_json")
+    assert sc_idx < read_idx
+
+
+def test_source_no_top_level_cartographer_import() -> None:
+    """BacklogSensor must NOT import merkle_cartographer at all —
+    Slice 11.6.d uses file-stat instead. Pinned at module level."""
+    import inspect
+    src = inspect.getsource(bls)
+    assert "merkle_cartographer" not in src, (
+        "Slice 11.6.d contract: BacklogSensor uses file-stat, not "
+        "cartographer (watched files are .jarvis/ state, not code)"
+    )
+
+
+def test_source_stat_tuple_includes_exists_mtime_size() -> None:
+    """Pin the stat-tuple shape (exists, mtime_ns, size) so a future
+    refactor can't silently drop a discriminator."""
+    import inspect
+    src = inspect.getsource(BacklogSensor._sc_stat_tuple)
+    assert "st_mtime_ns" in src
+    assert "st_size" in src
+
+
+def test_source_state_tuple_includes_auto_proposed_flag() -> None:
+    """Pin that the auto-proposed flag is captured in the state
+    signature — flipping it must bust the cache (§8 invariant)."""
+    import inspect
+    src = inspect.getsource(BacklogSensor._sc_current_state)
+    assert "_auto_proposed_enabled" in src


### PR DESCRIPTION
## Architectural divergence from 11.6.a/b/c

BacklogSensor's two watched files (`.jarvis/backlog.json`, `.jarvis/self_goal_formation_proposals.jsonl`) live under `.jarvis/`, which the `MerkleCartographer` **correctly excludes** from its tracked tree. Hidden dot-dirs are session blobs / posture history / state — high churn, no semantic value, would poison the cartographer's signal.

So this slice uses **file-stat short-circuit** as the analogue of cartographer hash for state files. Same architectural spirit (cheap pre-emption of expensive read+JSON+envelope build on no-op cycles), different mechanism appropriate to the watched data class:

| Slice  | Watched class    | Mechanism             | Granularity |
|--------|------------------|-----------------------|-------------|
| 11.6.a | code subtree     | merkle root hash      | tree-wide   |
| 11.6.b | code subtree     | merkle root hash      | tree-wide   |
| 11.6.c | code subtrees    | merkle subtree hashes | per-path    |
| 11.6.d | state files      | file stat tuples      | per-file    |

## State signature

Tuple of `(exists, mtime_ns, size)` per watched file + `(auto_proposed_enabled,)` suffix. The flag suffix is the analogue of 11.6.c's scan-path topology guard: flipping `JARVIS_BACKLOG_AUTO_PROPOSED_ENABLED` mid-session adds/drops the proposals ledger from the watch set, and the cache must invalidate.

## Five fail-safes

1. Per-sensor flag (`JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED`) off → legacy full scan
2. OS error on stat → sentinel signature → forces full scan
3. Cold-start (no recorded baseline) → legacy
4. Watched-file-set topology change (auto-proposed flag flip) → legacy
5. Any stat tuple differs from baseline → legacy

## Edge cases pinned

- §4 mtime change without size change (same content rewritten) → full scan
- §5 size change without mtime tick (rare, but possible) → full scan
- §6 file deletion (existence flip) → full scan
- §7 proposals-ledger mutation when auto-proposed enabled → full scan
- §8 auto-proposed flag flipped mid-session → topology guard fires
- §9 OS error path on stat (perm denied etc.) → sentinel → full scan

## Source-level pins

- §12 `_sc_stat_tuple` MUST include `st_mtime_ns` AND `st_size` (no silent discriminator drop in future refactors)
- §12 `_sc_current_state` MUST capture `_auto_proposed_enabled` (topology guard contract)
- §12 BacklogSensor module MUST NOT import `merkle_cartographer` at all (architectural divergence pin — file-stat is the chosen mechanism, not an oversight)

## Test plan

- [x] Slice 11.6.d tests: `tests/governance/test_backlog_sensor_short_circuit.py` — 19/19 green
- [x] Combined Phase 11 spine + full backlog regression suites — 259/260 green. The one failure (`test_sensor_start_stop`) is pre-existing on main: test calls `sensor.stop()` without `await` on an async method. Out of scope for this slice.
- [ ] Phase 11.7 graduation flip will turn on `JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED` alongside the three merkle flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add file-stat short-circuit to BacklogSensor to skip read/parse when `.jarvis` state files are unchanged, reducing polling work while staying fail-safe. Adds health telemetry and keeps the feature behind a flag by default.

- **New Features**
  - Short-circuits when per-file signature `(exists, mtime_ns, size)` and the auto-proposed flag are unchanged; returns cached envelopes.
  - Falls back to full scan on cold start, any stat difference, watched-set change (flag flip), or stat error.
  - Adds health() metrics: `short_circuit_enabled`, `short_circuit_short_circuits`, `short_circuit_full_scans`, `short_circuit_watched_files`, `short_circuit_cached_envelopes`.
  - New tests cover mtime/size changes, file deletion, proposals mutations, flag flips, and OS error paths.

- **Migration**
  - Default off. To enable: set `JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED=true` (optional: `JARVIS_BACKLOG_AUTO_PROPOSED_ENABLED=true` to include the proposals ledger).
  - Safe to disable any time by unsetting the env var.

<sup>Written for commit ecc86f7b468a371f8234e477e970068da1819a36. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/26311?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

