### PR TITLE
Slice 11.7: Phase 11 graduation flip — 5 flags default false→true

### DIFF
--- a/backend/core/ouroboros/governance/intake/sensors/backlog_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/backlog_sensor.py
@@ -104,10 +104,16 @@ _BACKLOG_FALLBACK_INTERVAL_S: float = float(
 
 def short_circuit_enabled() -> bool:
     """Re-read ``JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED`` at call time so
-    monkeypatch works in tests + operator can flip live without re-init."""
+    monkeypatch works in tests + operator can flip live without re-init.
+
+    Default ``true`` — graduated in Phase 11 Slice 11.7 alongside the
+    cartographer master + 3 merkle consumers (Todo, Doc, OppMiner).
+    Hot-revert: ``export JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED=false``."""
     raw = os.environ.get(
         "JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 
@@ -366,30 +372,37 @@ class BacklogSensor:
 
         Slice 11.6.d — when ``JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED=true``
         AND the (mtime_ns, size, exists) stat tuple of every watched
-        file is unchanged since the last scan, short-circuit to the
-        cached envelope list (skip read + JSON parse + envelope build).
-        File-stat is the analogue of the cartographer hash for state
-        files that the cartographer correctly excludes from its tree.
+        file is unchanged since the last scan, short-circuit to an
+        empty result (skip read + JSON parse + envelope build).
+
+        Why empty (not the cached prior envelope list)? ``scan_once``'s
+        contract is "envelopes ingested THIS cycle". On unchanged input
+        the dedup ledger (``_seen_task_ids``) would suppress every
+        re-emission anyway → real re-scan returns ``[]``. Returning the
+        cached list would lie about what the cycle ingested. File-stat
+        is the analogue of the cartographer hash for state files that
+        the cartographer correctly excludes from its tree.
         """
         current_state = self._sc_current_state()
         if self._sc_should_short_circuit(current_state):
             self._sc_short_circuits += 1
             logger.debug(
                 "[BacklogSensor] Stat short-circuit "
-                "(scan #%d skipped, %d cached envelopes)",
+                "(scan #%d skipped, returning [] — dedup-equivalent)",
                 self._sc_short_circuits + self._sc_full_scans,
-                len(self._sc_cached_envelopes),
             )
-            return list(self._sc_cached_envelopes)
+            return []
 
         self._sc_full_scans += 1
         produced: List[IntentEnvelope] = []
         produced.extend(await self._scan_backlog_json())
         if _auto_proposed_enabled():
             produced.extend(await self._scan_proposals_ledger())
-        # Refresh cache + baseline AFTER the scan completes so the next
-        # cycle's stat read sees the same files we just digested.
-        self._sc_refresh_baseline(produced, current_state)
+        # Refresh baseline AFTER the scan completes so the next cycle's
+        # stat read sees the same files we just digested. We don't
+        # cache the produced envelopes — short-circuit returns [] to
+        # match the dedup-filtered re-scan semantic (see docstring).
+        self._sc_refresh_baseline(current_state)
         return produced
 
     async def _scan_backlog_json(self) -> List[IntentEnvelope]:
@@ -743,15 +756,18 @@ class BacklogSensor:
             return False  # cold start — no baseline yet
         return current_state == self._sc_last_state
 
-    def _sc_refresh_baseline(
-        self,
-        produced: List[IntentEnvelope],
-        current_state: tuple,
-    ) -> None:
-        """Snapshot the freshly-scanned envelopes + stat signature as
-        the new baseline. Always-safe — never raises."""
+    def _sc_refresh_baseline(self, current_state: tuple) -> None:
+        """Snapshot the stat signature as the new baseline for the
+        next cycle's short-circuit decision. Always-safe — never
+        raises.
+
+        The cached envelope list is intentionally NOT updated here
+        (see ``scan_once`` docstring): ``scan_once``'s contract is
+        "ingested THIS cycle", and on a no-change re-scan the dedup
+        ledger would yield ``[]``. Short-circuit returns ``[]``
+        directly to match that semantic; the cache stays whatever it
+        was set to last (default ``[]``)."""
         try:
-            self._sc_cached_envelopes = list(produced)
             self._sc_last_state = current_state
         except Exception:  # noqa: BLE001 — defensive
             logger.debug(

--- a/backend/core/ouroboros/governance/intake/sensors/doc_staleness_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/doc_staleness_sensor.py
@@ -85,10 +85,15 @@ def webhook_enabled() -> bool:
 
 def merkle_consult_enabled() -> bool:
     """Re-read ``JARVIS_DOCSTALE_USE_MERKLE`` at call time so monkeypatch
-    works in tests + operator can flip live without re-init."""
+    works in tests + operator can flip live without re-init.
+
+    Default ``true`` — graduated in Phase 11 Slice 11.7. Hot-revert:
+    ``export JARVIS_DOCSTALE_USE_MERKLE=false``."""
     raw = os.environ.get(
         "JARVIS_DOCSTALE_USE_MERKLE", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
@@ -110,10 +110,15 @@ _OPP_MINER_FALLBACK_INTERVAL_S: float = float(
 
 def merkle_consult_enabled() -> bool:
     """Re-read ``JARVIS_OPPMINER_USE_MERKLE`` at call time so monkeypatch
-    works in tests + operator can flip live without re-init."""
+    works in tests + operator can flip live without re-init.
+
+    Default ``true`` — graduated in Phase 11 Slice 11.7. Hot-revert:
+    ``export JARVIS_OPPMINER_USE_MERKLE=false``."""
     raw = os.environ.get(
         "JARVIS_OPPMINER_USE_MERKLE", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 # Per-file debounce: suppress repeat events on the same file within this

--- a/backend/core/ouroboros/governance/intake/sensors/todo_scanner_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/todo_scanner_sensor.py
@@ -116,10 +116,17 @@ _SKIP_DIRS = frozenset({
 
 def merkle_consult_enabled() -> bool:
     """Re-read ``JARVIS_TODO_USE_MERKLE`` at call time so monkeypatch
-    works in tests + operator can flip live without re-init."""
+    works in tests + operator can flip live without re-init.
+
+    Default ``true`` — graduated in Phase 11 Slice 11.7 alongside the
+    cartographer master, DocStaleness consumer, OpportunityMiner
+    consumer, and Backlog stat consumer. Hot-revert: ``export
+    JARVIS_TODO_USE_MERKLE=false``."""
     raw = os.environ.get(
         "JARVIS_TODO_USE_MERKLE", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/merkle_cartographer.py
+++ b/backend/core/ouroboros/governance/merkle_cartographer.py
@@ -152,13 +152,18 @@ def _env_int(name: str, default: int, minimum: int = 0) -> int:
 
 
 def is_cartographer_enabled() -> bool:
-    """``JARVIS_MERKLE_CARTOGRAPHER_ENABLED`` (default ``false``).
+    """``JARVIS_MERKLE_CARTOGRAPHER_ENABLED`` (default ``true`` — graduated
+    in Phase 11 Slice 11.7).
 
     When off, callers consulting ``has_changed`` get an unconditional
     ``True`` so existing O(N) sensor scans run as before — no false
-    negatives possible during graduation."""
+    negatives possible. Hot-revert: ``export
+    JARVIS_MERKLE_CARTOGRAPHER_ENABLED=false`` returns the entire
+    Phase 11 cartographer stack to dormant (per-sensor consumers all
+    fail-safe to legacy when ``current_root_hash``/``subtree_hash``
+    return empty)."""
     return _env_bool(
-        "JARVIS_MERKLE_CARTOGRAPHER_ENABLED", default=False,
+        "JARVIS_MERKLE_CARTOGRAPHER_ENABLED", default=True,
     )
 
 

--- a/tests/governance/test_backlog_sensor_short_circuit.py
+++ b/tests/governance/test_backlog_sensor_short_circuit.py
@@ -105,9 +105,12 @@ def _disable_auto_proposed_by_default(monkeypatch: pytest.MonkeyPatch):
 # ===========================================================================
 
 
-def test_short_circuit_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_short_circuit_default_on_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slice 11.7 graduation flip: unset/empty env returns True."""
     monkeypatch.delenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", raising=False)
-    assert short_circuit_enabled() is False
+    assert short_circuit_enabled() is True
 
 
 def test_short_circuit_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -117,7 +120,9 @@ def test_short_circuit_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_short_circuit_falsy_values(monkeypatch: pytest.MonkeyPatch) -> None:
-    for val in ("0", "false", "no", "off", "", "garbage"):
+    """Post-graduation: empty string is the unset-marker for default
+    True. Hot-revert requires an explicit ``false``-class string."""
+    for val in ("0", "false", "no", "off", "garbage"):
         monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", val)
         assert short_circuit_enabled() is False
 
@@ -136,7 +141,11 @@ async def test_cold_start_full_scan_even_with_flag_on(
     envelopes = await sensor.scan_once()
     assert sensor._sc_full_scans == 1  # noqa: SLF001
     assert sensor._sc_short_circuits == 0  # noqa: SLF001
-    assert sensor._sc_cached_envelopes == envelopes  # noqa: SLF001
+    # Cold scan emits real envelopes (router calls bypass dedup the
+    # first time). The cache itself is intentionally not populated —
+    # short-circuit returns [] (dedup-equivalent), so _sc_cached_envelopes
+    # stays default-empty (see scan_once docstring).
+    assert len(envelopes) >= 1
     # Baseline populated for next cycle
     assert sensor._sc_last_state  # noqa: SLF001
 
@@ -150,16 +159,23 @@ async def test_cold_start_full_scan_even_with_flag_on(
 async def test_short_circuit_when_no_changes(
     make_sensor, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Short-circuit returns [] (NOT the cached prior list).
+    ``scan_once``'s contract is ``envelopes ingested THIS cycle`` —
+    on unchanged input dedup would yield 0 anyway, so [] is the
+    semantically correct return."""
     monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "true")
     sensor = make_sensor()
     first = await sensor.scan_once()
+    assert len(first) >= 1  # cold scan emitted real envelopes
 
     router_calls_before = sensor._router.ingest.call_count
 
     second = await sensor.scan_once()
     assert sensor._sc_short_circuits == 1  # noqa: SLF001
     assert sensor._sc_full_scans == 1  # noqa: SLF001 (unchanged)
-    assert second == first
+    # Short-circuit returns [] — matches the dedup-filtered semantic
+    # of the legacy scan path on a no-change cycle.
+    assert second == []
     # Router NOT called on short-circuit
     assert sensor._router.ingest.call_count == router_calls_before
 
@@ -363,9 +379,7 @@ async def test_health_after_scan_reflects_metrics(
 async def test_flag_off_full_scan_every_cycle(
     make_sensor, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv(
-        "JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", raising=False,
-    )
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "false")
     sensor = make_sensor()
     await sensor.scan_once()
     await sensor.scan_once()
@@ -380,9 +394,7 @@ async def test_flag_off_does_not_stat_watched_files(
 ) -> None:
     """When the per-sensor flag is off, _sc_current_state returns ()
     immediately — the stat syscalls are skipped entirely."""
-    monkeypatch.delenv(
-        "JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", raising=False,
-    )
+    monkeypatch.setenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", "false")
     sensor = make_sensor()
     state = sensor._sc_current_state()  # noqa: SLF001
     assert state == ()

--- a/tests/governance/test_doc_staleness_merkle.py
+++ b/tests/governance/test_doc_staleness_merkle.py
@@ -106,9 +106,12 @@ def isolated_cartographer(
 # ===========================================================================
 
 
-def test_merkle_consult_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_merkle_consult_default_on_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slice 11.7 graduation flip: unset/empty env returns True."""
     monkeypatch.delenv("JARVIS_DOCSTALE_USE_MERKLE", raising=False)
-    assert merkle_consult_enabled() is False
+    assert merkle_consult_enabled() is True
 
 
 def test_merkle_consult_truthy_values(
@@ -122,7 +125,9 @@ def test_merkle_consult_truthy_values(
 def test_merkle_consult_falsy_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    for val in ("0", "false", "no", "off", "", "garbage"):
+    """Post-graduation: empty string is the unset-marker for default
+    True. Hot-revert requires an explicit ``false``-class string."""
+    for val in ("0", "false", "no", "off", "garbage"):
         monkeypatch.setenv("JARVIS_DOCSTALE_USE_MERKLE", val)
         assert merkle_consult_enabled() is False
 
@@ -330,7 +335,7 @@ async def test_merkle_flag_off_full_scan_every_cycle(
 ) -> None:
     """When per-sensor flag is off, sensor must NEVER consult
     cartographer — legacy behavior preserved."""
-    monkeypatch.delenv("JARVIS_DOCSTALE_USE_MERKLE", raising=False)
+    monkeypatch.setenv("JARVIS_DOCSTALE_USE_MERKLE", "false")
     sensor = make_sensor()
     await sensor.scan_once()
     await sensor.scan_once()
@@ -347,7 +352,7 @@ async def test_merkle_flag_off_does_not_call_cartographer(
 
     Pinned at runtime by checking the monkeypatched import path
     isn't called."""
-    monkeypatch.delenv("JARVIS_DOCSTALE_USE_MERKLE", raising=False)
+    monkeypatch.setenv("JARVIS_DOCSTALE_USE_MERKLE", "false")
 
     call_count = 0
     original_get = mc.get_default_cartographer

--- a/tests/governance/test_merkle_cartographer_incremental.py
+++ b/tests/governance/test_merkle_cartographer_incremental.py
@@ -399,7 +399,9 @@ async def test_subscriber_master_flag_off_handle_noop(
     repo: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("JARVIS_MERKLE_STATE_DIR", str(repo))
-    monkeypatch.delenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", raising=False)
+    # Slice 11.7 graduation: master flag default-true, so explicit
+    # false-set is required to exercise the master-off path.
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "false")
     c = MerkleCartographer(repo_root=repo)
     sub = MerkleEventSubscriber(c)
     await sub.handle("fs.changed.modified", {

--- a/tests/governance/test_opp_miner_merkle.py
+++ b/tests/governance/test_opp_miner_merkle.py
@@ -120,9 +120,12 @@ def isolated_cartographer(
 # ===========================================================================
 
 
-def test_merkle_consult_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_merkle_consult_default_on_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slice 11.7 graduation flip: unset/empty env returns True."""
     monkeypatch.delenv("JARVIS_OPPMINER_USE_MERKLE", raising=False)
-    assert merkle_consult_enabled() is False
+    assert merkle_consult_enabled() is True
 
 
 def test_merkle_consult_truthy_values(
@@ -136,7 +139,9 @@ def test_merkle_consult_truthy_values(
 def test_merkle_consult_falsy_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    for val in ("0", "false", "no", "off", "", "garbage"):
+    """Post-graduation: empty string is the unset-marker for default
+    True. Hot-revert requires an explicit ``false``-class string."""
+    for val in ("0", "false", "no", "off", "garbage"):
         monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", val)
         assert merkle_consult_enabled() is False
 
@@ -396,7 +401,7 @@ async def test_health_after_scan_reflects_metrics(
 async def test_merkle_flag_off_full_scan_every_cycle(
     make_sensor, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("JARVIS_OPPMINER_USE_MERKLE", raising=False)
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "false")
     sensor = make_sensor()
     await sensor.scan_once()
     await sensor.scan_once()
@@ -409,7 +414,7 @@ async def test_merkle_flag_off_full_scan_every_cycle(
 async def test_merkle_flag_off_does_not_call_cartographer(
     make_sensor, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("JARVIS_OPPMINER_USE_MERKLE", raising=False)
+    monkeypatch.setenv("JARVIS_OPPMINER_USE_MERKLE", "false")
 
     call_count = 0
     original_get = mc.get_default_cartographer

--- a/tests/governance/test_phase11_graduation_pins.py
+++ b/tests/governance/test_phase11_graduation_pins.py
@@ -1,0 +1,215 @@
+"""Slice 11.7 — Phase 11 graduation pin suite.
+
+Pins the graduated state of the Merkle Cartographer + Phase 11.6.{a,b,c,d}
+sensor consumers. Five flags flip together (master + 3 merkle consumers
++ 1 file-stat consumer):
+
+  1. JARVIS_MERKLE_CARTOGRAPHER_ENABLED   — master
+  2. JARVIS_TODO_USE_MERKLE               — TodoScannerSensor (11.6.a)
+  3. JARVIS_DOCSTALE_USE_MERKLE           — DocStalenessSensor (11.6.b)
+  4. JARVIS_OPPMINER_USE_MERKLE           — OpportunityMinerSensor (11.6.c)
+  5. JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED — BacklogSensor (11.6.d, file-stat)
+
+Pin sections:
+  §1 All five defaults are True (delenv → True)
+  §2 Empty-string env reads as default-True (the unset marker)
+  §3 Each ``"false"``-class override returns False (hot-revert path)
+  §4 Full-revert matrix — flipping each flag off independently flips
+     ONLY that one flag (no cross-coupling)
+  §5 Master-off legacy invariant — when the cartographer master is off,
+     all three merkle consumers fail-safe to legacy (the per-sensor flag
+     state doesn't matter; subtree_hash returns "" → fail-safe)
+  §6 Backlog stat consumer is independent of the cartographer master —
+     it never consults cartographer (architectural divergence pinned in
+     11.6.d)
+  §7 Module-level public API surface — graduation must not have changed
+     the function signatures the orchestrator and tests rely on
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    merkle_cartographer as mc,
+)
+from backend.core.ouroboros.governance.intake.sensors import (
+    backlog_sensor as bls,
+)
+from backend.core.ouroboros.governance.intake.sensors import (
+    doc_staleness_sensor as dss,
+)
+from backend.core.ouroboros.governance.intake.sensors import (
+    opportunity_miner_sensor as oms,
+)
+from backend.core.ouroboros.governance.intake.sensors import (
+    todo_scanner_sensor as tss,
+)
+
+
+# Centralized list of all 5 graduated flags + their reader callable.
+_GRADUATED_FLAGS = [
+    ("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", mc.is_cartographer_enabled),
+    ("JARVIS_TODO_USE_MERKLE", tss.merkle_consult_enabled),
+    ("JARVIS_DOCSTALE_USE_MERKLE", dss.merkle_consult_enabled),
+    ("JARVIS_OPPMINER_USE_MERKLE", oms.merkle_consult_enabled),
+    ("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", bls.short_circuit_enabled),
+]
+
+
+# ===========================================================================
+# §1 — All five defaults are True
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_default_is_true_when_env_unset(
+    env_name: str, reader, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delenv → reader returns True. Pinned per-flag so a regression
+    on any single flag fails its own test, not the whole batch."""
+    monkeypatch.delenv(env_name, raising=False)
+    assert reader() is True, (
+        f"Slice 11.7 graduation: {env_name} must default True"
+    )
+
+
+# ===========================================================================
+# §2 — Empty string is the unset marker
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_empty_string_reads_as_default_true(
+    env_name: str, reader, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``setenv("", "")`` must behave the same as delenv —
+    operators commonly clear flags by exporting them empty in shells."""
+    monkeypatch.setenv(env_name, "")
+    assert reader() is True
+
+
+# ===========================================================================
+# §3 — Hot-revert: each false-class string returns False
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+@pytest.mark.parametrize("falsy", ["false", "0", "no", "off", "FALSE"])
+def test_false_class_string_reverts(
+    env_name: str, reader, falsy: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hot-revert path — operator sets the flag to a recognized
+    false-class string, reader flips off."""
+    monkeypatch.setenv(env_name, falsy)
+    assert reader() is False, (
+        f"{env_name}={falsy!r} should disable the feature"
+    )
+
+
+# ===========================================================================
+# §4 — Full-revert matrix: each flag flips independently
+# ===========================================================================
+
+
+def test_full_revert_matrix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flip each flag off in turn; verify ONLY that one flag flips
+    while the other four stay True. Catches accidental cross-coupling
+    where one flag's reader peeks at another's state."""
+    for env_off, reader_off in _GRADUATED_FLAGS:
+        # Reset all to default (delenv) — graduated state is True
+        for env_name, _ in _GRADUATED_FLAGS:
+            monkeypatch.delenv(env_name, raising=False)
+        # Flip exactly one off
+        monkeypatch.setenv(env_off, "false")
+        # Verify the flipped one is off, the rest still True
+        for env_name, reader in _GRADUATED_FLAGS:
+            expected = (env_name != env_off)
+            actual = reader()
+            assert actual is expected, (
+                f"After flipping {env_off}=false, {env_name} reader "
+                f"returned {actual} (expected {expected})"
+            )
+
+
+# ===========================================================================
+# §5 — Master-off legacy invariant
+# ===========================================================================
+
+
+def test_master_off_disables_root_hash(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> None:
+    """When the cartographer master is off, ``current_root_hash`` and
+    ``subtree_hash`` return empty string — the fail-safe sentinel that
+    forces every per-sensor consumer to fall through to legacy.
+
+    This is the single guarantee that keeps the per-sensor flags
+    semantically dependent on the master flag without requiring the
+    sensors to read the master flag themselves."""
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_MERKLE_STATE_DIR", str(tmp_path))
+    mc.reset_default_cartographer_for_tests()
+    try:
+        c = mc.MerkleCartographer(repo_root=tmp_path)
+        assert c.current_root_hash() == ""
+        assert c.subtree_hash("backend") == ""
+    finally:
+        mc.reset_default_cartographer_for_tests()
+
+
+# ===========================================================================
+# §6 — Backlog stat consumer is master-flag-independent
+# ===========================================================================
+
+
+def test_backlog_stat_consumer_independent_of_cartographer_master(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BacklogSensor uses file-stat, not cartographer (architectural
+    divergence pinned in 11.6.d). Flipping the cartographer master OFF
+    must NOT disable the backlog stat consumer — the two are
+    independent layers, not stacked."""
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED", raising=False)
+    assert mc.is_cartographer_enabled() is False
+    assert bls.short_circuit_enabled() is True
+
+
+# ===========================================================================
+# §7 — Module-level public API surface
+# ===========================================================================
+
+
+def test_module_level_readers_callable_with_no_args() -> None:
+    """Each reader is a zero-arg callable returning bool. Pins the
+    contract that the orchestrator and observability surfaces rely
+    on for read-time flag introspection (no captured-at-init values
+    that go stale on hot-revert)."""
+    for _, reader in _GRADUATED_FLAGS:
+        result = reader()
+        assert isinstance(result, bool)
+
+
+def test_master_default_docstring_references_graduation() -> None:
+    """The master-flag docstring must call out the Slice 11.7
+    graduation flip — operator-facing documentation is the surface
+    that explains why the default changed."""
+    assert mc.is_cartographer_enabled.__doc__ is not None
+    assert "Slice 11.7" in mc.is_cartographer_enabled.__doc__
+    assert "true" in mc.is_cartographer_enabled.__doc__.lower()
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS[1:])
+def test_consumer_default_docstring_references_graduation(
+    env_name: str, reader,
+) -> None:
+    """Each per-sensor consumer reader's docstring must reference the
+    graduation. Ensures hot-revert instructions stay co-located with
+    the reader so operators discovering the flag via ``help()`` see
+    the rollback path."""
+    doc = reader.__doc__ or ""
+    assert "Slice 11.7" in doc, (
+        f"{reader.__qualname__} docstring should reference Slice 11.7 "
+        "graduation + hot-revert path"
+    )

--- a/tests/governance/test_todo_scanner_merkle.py
+++ b/tests/governance/test_todo_scanner_merkle.py
@@ -94,9 +94,12 @@ def isolated_cartographer(
 # ===========================================================================
 
 
-def test_merkle_consult_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_merkle_consult_default_on_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slice 11.7 graduation flip: unset/empty env returns True."""
     monkeypatch.delenv("JARVIS_TODO_USE_MERKLE", raising=False)
-    assert merkle_consult_enabled() is False
+    assert merkle_consult_enabled() is True
 
 
 def test_merkle_consult_truthy_values(
@@ -110,7 +113,10 @@ def test_merkle_consult_truthy_values(
 def test_merkle_consult_falsy_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    for val in ("0", "false", "no", "off", "", "garbage"):
+    """Post-graduation: empty string is the unset-marker for default
+    True, so it's NOT in the falsy list. Hot-revert requires an
+    explicit ``false``-class string."""
+    for val in ("0", "false", "no", "off", "garbage"):
         monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", val)
         assert merkle_consult_enabled() is False
 
@@ -316,8 +322,8 @@ async def test_merkle_flag_off_full_scan_every_cycle(
     make_sensor, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When per-sensor flag is off, sensor must NEVER consult
-    cartographer — legacy behavior preserved."""
-    monkeypatch.delenv("JARVIS_TODO_USE_MERKLE", raising=False)
+    cartographer — legacy behavior preserved. Hot-revert path."""
+    monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", "false")
     sensor = make_sensor()
     await sensor.scan_once()
     await sensor.scan_once()
@@ -333,8 +339,9 @@ async def test_merkle_flag_off_does_not_call_cartographer(
     """Source-level guarantee: flag off → cartographer never imported.
 
     Pinned at runtime by checking the monkeypatched import path
-    isn't called."""
-    monkeypatch.delenv("JARVIS_TODO_USE_MERKLE", raising=False)
+    isn't called. Post-graduation, must explicitly set the flag false
+    (delenv now defaults to True)."""
+    monkeypatch.setenv("JARVIS_TODO_USE_MERKLE", "false")
 
     call_count = 0
     original_get = mc.get_default_cartographer


### PR DESCRIPTION
## Summary

Closes Phase 11. Flips five flags simultaneously — the cartographer master + three merkle consumers + one file-stat consumer — to default `true`. Per-flag hot-revert paths preserved.

| Flag                                       | Owner                                  | Mechanism      | Slice  |
|--------------------------------------------|----------------------------------------|----------------|--------|
| `JARVIS_MERKLE_CARTOGRAPHER_ENABLED`       | MerkleCartographer (master)            | merkle hash    | 11.4-5 |
| `JARVIS_TODO_USE_MERKLE`                   | TodoScannerSensor                      | merkle hash    | 11.6.a |
| `JARVIS_DOCSTALE_USE_MERKLE`               | DocStalenessSensor                     | merkle hash    | 11.6.b |
| `JARVIS_OPPMINER_USE_MERKLE`               | OpportunityMinerSensor (subtree-scoped)| merkle hash    | 11.6.c |
| `JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED`     | BacklogSensor                          | file stat      | 11.6.d |

## Why all five together

With master OFF, per-sensor merkle consumers compute empty hashes → fail-safe full scan every cycle. The feature would be dormant but still walking the fail-safe path. True graduation = master + all consumers on. The backlog stat consumer is intentionally master-independent (architectural divergence from 11.6.d, pinned in §6).

## Bug surfaced + fixed: BacklogSensor short-circuit returned wrong type

The dedup-test suite (`test_dedup_same_signature_not_reemitted` + `test_dedup_distinct_signatures_each_emit_once`) caught a real semantic bug in 11.6.d when the flag flipped on. `scan_once`'s contract is *"envelopes ingested THIS cycle"*; on unchanged input the dedup ledger (`_seen_task_ids`) would suppress all re-emission and yield `[]`. My 11.6.d implementation cached the first-scan output and replayed it on short-circuit — that's *inconsistent* with the dedup semantic.

Fix: short-circuit returns `[]` directly (the dedup-equivalent), and `_sc_refresh_baseline` no longer caches the envelope list (only the stat signature).

## Graduation pin suite (44 tests, 7 sections)

- **§1** All five defaults are `True` (delenv → True), parametrized per-flag
- **§2** Empty string reads as default-True (the unset marker — operators commonly clear via `export FOO=`)
- **§3** Hot-revert: each false-class string (`false`, `0`, `no`, `off`, `FALSE`) returns False, parametrized per-flag × per-string
- **§4** Full-revert matrix — flipping each flag off independently flips ONLY that one flag (catches accidental cross-coupling)
- **§5** Master-off legacy invariant — `current_root_hash` + `subtree_hash` return `""` when master off, forcing per-sensor fail-safe without sensors needing to read master flag
- **§6** Backlog stat consumer is master-flag-independent (preserves the 11.6.d architectural divergence)
- **§7** Module-level reader API surface + docstring graduation references (operators discovering flags via `help()` see hot-revert path)

## Test plan

- [x] Slice 11.7 graduation pins: `tests/governance/test_phase11_graduation_pins.py` — 44/44 green
- [x] Combined Phase 11 spine + full sensor regression suites (Todo/Doc/Miner/Backlog dedicated + cartographer incremental + backlog auto-proposed + miner cycle_summary + auto_ack_lane + sensor base + fs_events + urgency_hint + urgency_override + doc_staleness webhook) — 736/737 green
- [x] Pre-existing test_sensor_start_stop failure (unrelated to graduation, was already broken on main: calls `sensor.stop()` without `await` on async method) — flagged for follow-up
- [ ] Battle-test once-proof against the merged HEAD — operator discretion (each per-sensor flag is independently revertible, so a single-sensor regression doesn't require a full Phase 11 rollback)

## Hot-revert paths (documented per-reader)

```bash
# Disable entire stack (3 merkle consumers go dormant, backlog stat continues independently)
export JARVIS_MERKLE_CARTOGRAPHER_ENABLED=false

# Disable a single sensor consumer
export JARVIS_TODO_USE_MERKLE=false
export JARVIS_DOCSTALE_USE_MERKLE=false
export JARVIS_OPPMINER_USE_MERKLE=false
export JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates Phase 11 (Slice 11.7) by flipping five flags to default on and fixing BacklogSensor’s short-circuit return to match the scan contract. This enables Merkle Cartographer + consumers by default, with explicit hot-revert paths preserved.

- **New Features**
  - Default-on flips: `JARVIS_MERKLE_CARTOGRAPHER_ENABLED`, `JARVIS_TODO_USE_MERKLE`, `JARVIS_DOCSTALE_USE_MERKLE`, `JARVIS_OPPMINER_USE_MERKLE`, `JARVIS_BACKLOG_SHORT_CIRCUIT_ENABLED`.
  - Hot-revert remains: set any flag to a false-class string (`false`, `0`, `no`, `off`) to disable; empty string now reads as “unset” and returns default-true.
  - Master-off behavior: cartographer returns empty hashes, so merkle consumers fall back to legacy scans; Backlog short-circuit is independent of the master flag.

- **Bug Fixes**
  - BacklogSensor short-circuit now returns `[]` on unchanged input to honor “ingested THIS cycle”; removed caching of prior envelopes and updated tests to pin this behavior.

<sup>Written for commit 5141ccab7d2d6bb823d52f822fc2e2b2e4304f87. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/26320?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

