### PR TITLE
Phase 12 Slice A: DW catalog client + Zero-Trust quarantine spec

### DIFF
--- a/backend/core/ouroboros/governance/dw_catalog_client.py
+++ b/backend/core/ouroboros/governance/dw_catalog_client.py
@@ -1,0 +1,596 @@
+"""Phase 12 Slice A — DoubleWord catalog discovery client.
+
+Fetches the live ``/models`` endpoint, parses the OpenAI-compatible
+``{"data": [...]}`` response into structured ``ModelCard`` records,
+and caches the result to disk for restart-survival. Master-flag-gated
+(default off) so the legacy YAML path stays authoritative until the
+classifier (Slice B) and integration (Slice C) catch up.
+
+This module is a pure data-collector. It does NOT decide which model
+goes on which route — that's the classifier's job (Slice B). It does
+NOT issue completions — that's the existing DoublewordProvider. It
+just turns DW's catalog into a typed snapshot a downstream consumer
+can reason about.
+
+Authority surface:
+  - ``ModelCard`` — frozen dataclass, schema_version-tagged
+  - ``CatalogSnapshot`` — frozen dataclass; cache-able + diff-able
+  - ``DwCatalogClient`` — fetch/cache/staleness API
+  - ``discovery_enabled()`` — re-read at call time
+
+NEVER raises out of ``fetch()``: every failure path (transport, JSON
+parse, missing required fields) returns the last cached snapshot
+with ``fetch_failure_reason`` populated, OR an empty snapshot when
+no cache exists. The caller falls through to the YAML safety net.
+
+Operator-mandated 2026-04-27: this module is part of the larger
+Phase 12 arc that replaces the hardcoded ``dw_models:`` arrays in
+``brain_selection_policy.yaml``. See
+``docs/architecture/phase_12_dynamic_dw_catalog_spec.md``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Master flag + tunables
+# ---------------------------------------------------------------------------
+
+
+def discovery_enabled() -> bool:
+    """``JARVIS_DW_CATALOG_DISCOVERY_ENABLED`` (default ``false``).
+
+    Re-read at call time so monkeypatch works in tests + operators
+    can flip live without re-init.
+
+    Default flips to ``true`` at Phase 12 Slice E graduation. Until
+    then, the catalog client may run but its output is not consumed
+    by the dispatcher — YAML stays authoritative.
+    """
+    raw = os.environ.get(
+        "JARVIS_DW_CATALOG_DISCOVERY_ENABLED", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _refresh_interval_s() -> float:
+    """``JARVIS_DW_CATALOG_REFRESH_S`` (default 1800s = 30 min).
+
+    How often the background refresh task re-fetches the catalog.
+    Read at call time."""
+    try:
+        return float(
+            os.environ.get("JARVIS_DW_CATALOG_REFRESH_S", "1800").strip(),
+        )
+    except (ValueError, TypeError):
+        return 1800.0
+
+
+def _max_age_s() -> float:
+    """``JARVIS_DW_CATALOG_MAX_AGE_S`` (default 7200s = 2h).
+
+    Catalog older than this is considered stale; consumer falls
+    back to YAML. Read at call time."""
+    try:
+        return float(
+            os.environ.get("JARVIS_DW_CATALOG_MAX_AGE_S", "7200").strip(),
+        )
+    except (ValueError, TypeError):
+        return 7200.0
+
+
+def _fetch_timeout_s() -> float:
+    """``JARVIS_DW_CATALOG_FETCH_TIMEOUT_S`` (default 15s).
+
+    HTTP timeout for the ``/models`` GET. Short — DW returns
+    a static catalog, not a streaming endpoint."""
+    try:
+        return float(
+            os.environ.get("JARVIS_DW_CATALOG_FETCH_TIMEOUT_S", "15").strip(),
+        )
+    except (ValueError, TypeError):
+        return 15.0
+
+
+def _cache_path() -> Path:
+    """``JARVIS_DW_CATALOG_PATH`` (default ``.jarvis/dw_catalog.json``).
+
+    Disk cache location. Override for tests."""
+    raw = os.environ.get(
+        "JARVIS_DW_CATALOG_PATH", ".jarvis/dw_catalog.json",
+    ).strip()
+    return Path(raw)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+CATALOG_SCHEMA_VERSION = "dw_catalog.1"
+
+# Model id parameter-count regex. Matches things like:
+#   "moonshotai/Kimi-K2.6"           → no match (no Bn suffix)
+#   "Qwen/Qwen3.5-397B-A17B"         → 397.0
+#   "google/gemma-4-31B-it"          → 31.0
+#   "Qwen/Qwen3.6-35B-A3B-FP8"       → 35.0  (first match wins)
+#   "Qwen/Qwen3-14B-FP8"             → 14.0
+#   "Qwen/Qwen3.5-9B"                → 9.0
+#   "Qwen/Qwen3.5-4B"                → 4.0
+# Designed conservatively — when in doubt, return None (classifier
+# downgrades to SPECULATIVE quarantine per Zero-Trust §3.6).
+_PARAM_COUNT_RE = re.compile(r"-(\d+(?:\.\d+)?)B(?:[-_/]|$)", re.IGNORECASE)
+
+
+def parse_parameter_count(model_id: str) -> Optional[float]:
+    """Heuristic: extract the parameter count (in billions) from a
+    model id when the API doesn't expose it as metadata.
+
+    Returns ``None`` for ids without a recognizable ``\\d+B`` token.
+    Intentionally conservative — a misparse promotes a model into a
+    higher-cost route, so we prefer ``None`` (→ Zero-Trust quarantine
+    in SPECULATIVE) over a guess."""
+    m = _PARAM_COUNT_RE.search(model_id or "")
+    if m is None:
+        return None
+    try:
+        return float(m.group(1))
+    except (ValueError, TypeError):
+        return None
+
+
+def parse_family(model_id: str) -> str:
+    """Extract the family prefix from a model id. ``"unknown"`` when
+    there's no slash separator."""
+    if not model_id or "/" not in model_id:
+        return "unknown"
+    return model_id.split("/", 1)[0].strip().lower() or "unknown"
+
+
+@dataclass(frozen=True)
+class ModelCard:
+    """One model from DW's ``/models`` catalog.
+
+    Frozen + hashable so consumers can keep these in sets / use as
+    dict keys for diff calculations against prior snapshots. The
+    optional fields (``parameter_count_b``, ``context_window``,
+    pricing) are ``None`` when DW's API doesn't expose that field
+    for the model — the classifier handles ``None`` conservatively
+    via Zero-Trust SPECULATIVE quarantine."""
+    model_id: str
+    family: str
+    parameter_count_b: Optional[float]
+    context_window: Optional[int]
+    pricing_in_per_m_usd: Optional[float]
+    pricing_out_per_m_usd: Optional[float]
+    supports_streaming: bool
+    raw_metadata_json: str  # JSON-serialized raw dict; preserved for downstream
+
+    @classmethod
+    def from_api_dict(cls, raw: Mapping[str, Any]) -> Optional["ModelCard"]:
+        """Build from a DW ``/models`` data entry. Returns ``None``
+        on unparseable input — the only required field is ``id``."""
+        if not isinstance(raw, Mapping):
+            return None
+        model_id = raw.get("id")
+        if not isinstance(model_id, str) or not model_id.strip():
+            return None
+        model_id = model_id.strip()
+
+        # parameter_count: prefer API metadata, fall back to id heuristic
+        param_b: Optional[float] = None
+        api_params = raw.get("parameter_count_b") or raw.get("parameters_b")
+        if isinstance(api_params, (int, float)) and api_params > 0:
+            param_b = float(api_params)
+        else:
+            param_b = parse_parameter_count(model_id)
+
+        # context_window: optional, must be int when present
+        ctx: Optional[int] = None
+        api_ctx = raw.get("context_window") or raw.get("context_length")
+        if isinstance(api_ctx, int) and api_ctx > 0:
+            ctx = api_ctx
+
+        # pricing — common shapes: top-level "pricing": {"input": ..., "output": ...}
+        # OR top-level "pricing_in_per_m_usd" / "pricing_out_per_m_usd"
+        price_in: Optional[float] = None
+        price_out: Optional[float] = None
+        pricing = raw.get("pricing")
+        if isinstance(pricing, Mapping):
+            pin = pricing.get("input") or pricing.get("in")
+            pout = pricing.get("output") or pricing.get("out")
+            if isinstance(pin, (int, float)) and pin >= 0:
+                price_in = float(pin)
+            if isinstance(pout, (int, float)) and pout >= 0:
+                price_out = float(pout)
+        if price_in is None:
+            top = raw.get("pricing_in_per_m_usd")
+            if isinstance(top, (int, float)) and top >= 0:
+                price_in = float(top)
+        if price_out is None:
+            top = raw.get("pricing_out_per_m_usd")
+            if isinstance(top, (int, float)) and top >= 0:
+                price_out = float(top)
+
+        # supports_streaming defaults True (most modern OpenAI-compat
+        # models stream); only flip false when API explicitly says so
+        streaming = True
+        api_stream = raw.get("supports_streaming")
+        if isinstance(api_stream, bool):
+            streaming = api_stream
+
+        # Preserve the full raw dict as JSON for downstream consumers
+        try:
+            raw_json = json.dumps(dict(raw), sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            raw_json = "{}"
+
+        return cls(
+            model_id=model_id,
+            family=parse_family(model_id),
+            parameter_count_b=param_b,
+            context_window=ctx,
+            pricing_in_per_m_usd=price_in,
+            pricing_out_per_m_usd=price_out,
+            supports_streaming=streaming,
+            raw_metadata_json=raw_json,
+        )
+
+    def has_ambiguous_metadata(self) -> bool:
+        """Zero-Trust §3.6 — both parameter count AND pricing missing.
+
+        Such models are SPECULATIVE-quarantined by the classifier
+        (Slice B) regardless of what their family or id implies.
+        Promotion to BACKGROUND requires the prove-it ledger
+        (Slice § 3.6) to record 10 sub-200ms successful ops."""
+        return (
+            self.parameter_count_b is None
+            and self.pricing_out_per_m_usd is None
+        )
+
+
+@dataclass(frozen=True)
+class CatalogSnapshot:
+    """Point-in-time view of DW's catalog.
+
+    ``fetch_failure_reason is None`` for fresh-from-API snapshots;
+    populated when this is a stale-cache fallback returned because
+    the live fetch failed. Consumers should respect this — a stale
+    snapshot is still authoritative for its bounded freshness window
+    (``_max_age_s()``), but observers should surface the failure."""
+    fetched_at_unix: float
+    models: Tuple[ModelCard, ...]
+    schema_version: str = CATALOG_SCHEMA_VERSION
+    fetch_latency_ms: int = 0
+    fetch_failure_reason: Optional[str] = None
+
+    def is_fresh(self, *, max_age_s: Optional[float] = None) -> bool:
+        if max_age_s is None:
+            max_age_s = _max_age_s()
+        return (time.time() - self.fetched_at_unix) < max_age_s
+
+    def model_ids(self) -> Tuple[str, ...]:
+        return tuple(m.model_id for m in self.models)
+
+    def to_json(self) -> str:
+        payload = {
+            "schema_version": self.schema_version,
+            "fetched_at_unix": self.fetched_at_unix,
+            "fetch_latency_ms": self.fetch_latency_ms,
+            "fetch_failure_reason": self.fetch_failure_reason,
+            "models": [
+                {
+                    "model_id": m.model_id,
+                    "family": m.family,
+                    "parameter_count_b": m.parameter_count_b,
+                    "context_window": m.context_window,
+                    "pricing_in_per_m_usd": m.pricing_in_per_m_usd,
+                    "pricing_out_per_m_usd": m.pricing_out_per_m_usd,
+                    "supports_streaming": m.supports_streaming,
+                    "raw_metadata_json": m.raw_metadata_json,
+                }
+                for m in self.models
+            ],
+        }
+        return json.dumps(payload, sort_keys=True, indent=2)
+
+    @classmethod
+    def from_json(cls, text: str) -> Optional["CatalogSnapshot"]:
+        """Parse a previously-cached snapshot. Returns ``None`` on
+        any parse failure — caller treats as cache-miss."""
+        try:
+            payload = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if not isinstance(payload, Mapping):
+            return None
+        if payload.get("schema_version") != CATALOG_SCHEMA_VERSION:
+            # Future: handle version migration here. For Slice A,
+            # mismatched version = treat as missing.
+            return None
+        try:
+            fetched_at = float(payload.get("fetched_at_unix", 0.0))
+        except (ValueError, TypeError):
+            return None
+        models_raw = payload.get("models", [])
+        if not isinstance(models_raw, list):
+            return None
+        models: list = []
+        for m in models_raw:
+            if not isinstance(m, Mapping):
+                continue
+            try:
+                models.append(ModelCard(
+                    model_id=str(m.get("model_id", "")),
+                    family=str(m.get("family", "unknown")),
+                    parameter_count_b=(
+                        float(m["parameter_count_b"])
+                        if m.get("parameter_count_b") is not None
+                        else None
+                    ),
+                    context_window=(
+                        int(m["context_window"])
+                        if m.get("context_window") is not None
+                        else None
+                    ),
+                    pricing_in_per_m_usd=(
+                        float(m["pricing_in_per_m_usd"])
+                        if m.get("pricing_in_per_m_usd") is not None
+                        else None
+                    ),
+                    pricing_out_per_m_usd=(
+                        float(m["pricing_out_per_m_usd"])
+                        if m.get("pricing_out_per_m_usd") is not None
+                        else None
+                    ),
+                    supports_streaming=bool(m.get("supports_streaming", True)),
+                    raw_metadata_json=str(m.get("raw_metadata_json", "{}")),
+                ))
+            except (ValueError, TypeError, KeyError):
+                continue  # skip malformed entry, keep loading the rest
+        # Filter to non-empty model_id
+        models = [m for m in models if m.model_id]
+        return cls(
+            fetched_at_unix=fetched_at,
+            models=tuple(models),
+            schema_version=CATALOG_SCHEMA_VERSION,
+            fetch_latency_ms=int(payload.get("fetch_latency_ms", 0)),
+            fetch_failure_reason=payload.get("fetch_failure_reason"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Disk cache (atomic write/read)
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Atomic temp+rename — same pattern as posture_store.py."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def load_cached_snapshot(path: Optional[Path] = None) -> Optional[CatalogSnapshot]:
+    """Read the disk cache. Returns ``None`` if missing or unparseable.
+    NEVER raises — caller treats None as cache-miss."""
+    p = path or _cache_path()
+    if not p.exists():
+        return None
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return CatalogSnapshot.from_json(text)
+
+
+def save_snapshot(
+    snapshot: CatalogSnapshot, path: Optional[Path] = None,
+) -> None:
+    """Write snapshot to disk atomically. Caller should not skip
+    persistence on a failed-fetch fallback snapshot — preserving
+    the failure reason in the cache helps post-incident audit."""
+    p = path or _cache_path()
+    _atomic_write(p, snapshot.to_json())
+
+
+# ---------------------------------------------------------------------------
+# Catalog client
+# ---------------------------------------------------------------------------
+
+
+class DwCatalogClient:
+    """Async fetcher for DW's ``/models`` endpoint.
+
+    Caller owns the aiohttp session — reusing the existing
+    DoublewordProvider's session keeps connection pooling /
+    DNS state consistent. The client is purely transformation
+    + cache logic over that session.
+
+    Typical usage::
+
+        provider = get_default_doubleword_provider()
+        session = await provider._get_session()
+        client = DwCatalogClient(
+            session=session,
+            base_url=provider._base_url,
+            api_key=provider._api_key,
+        )
+        snapshot = await client.fetch()  # never raises
+        if snapshot.fetch_failure_reason:
+            logger.warning("catalog fetch failed: %s — using cached",
+                           snapshot.fetch_failure_reason)
+        for card in snapshot.models:
+            ...
+
+    The fetch never raises. The classifier decides what to do with
+    an empty / stale / failure-marked snapshot.
+    """
+
+    def __init__(
+        self,
+        session: Any,                # aiohttp.ClientSession (or test mock)
+        base_url: str,
+        api_key: str,
+        *,
+        cache_path: Optional[Path] = None,
+    ) -> None:
+        self._session = session
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._cache_path = cache_path  # None → resolved at-call from env
+        # In-memory snapshot for fast cached() reads. Hydrated lazily
+        # on the first fetch() or cached() call.
+        self._memory_snapshot: Optional[CatalogSnapshot] = None
+        self._memory_hydrated: bool = False
+
+    async def fetch(self) -> CatalogSnapshot:
+        """Issue ``GET /models``, parse response, persist + return.
+
+        On any failure (transport, JSON, schema), returns the last
+        cached snapshot with ``fetch_failure_reason`` populated, OR
+        an empty snapshot with the failure reason. NEVER raises."""
+        t0 = time.monotonic()
+        try:
+            url = f"{self._base_url}/models"
+            headers = {
+                "Authorization": f"Bearer {self._api_key}",
+                "Accept": "application/json",
+            }
+            timeout = _fetch_timeout_s()
+            async with self._session.get(
+                url, headers=headers, timeout=timeout,
+            ) as resp:
+                if resp.status != 200:
+                    return self._failure_fallback(
+                        f"http_{resp.status}", t0,
+                    )
+                body = await resp.json()
+        except asyncio.TimeoutError:
+            return self._failure_fallback("timeout", t0)
+        except Exception as exc:  # noqa: BLE001 — defensive
+            return self._failure_fallback(
+                f"{type(exc).__name__}:{str(exc)[:80]}", t0,
+            )
+
+        models = self._parse_body(body)
+        snapshot = CatalogSnapshot(
+            fetched_at_unix=time.time(),
+            models=models,
+            fetch_latency_ms=int((time.monotonic() - t0) * 1000),
+            fetch_failure_reason=None,
+        )
+        # Cache + memoize
+        try:
+            save_snapshot(snapshot, self._cache_path)
+        except OSError as exc:
+            logger.debug(
+                "[DwCatalogClient] disk cache write failed: %s — "
+                "snapshot still returned in memory", exc,
+            )
+        self._memory_snapshot = snapshot
+        self._memory_hydrated = True
+        return snapshot
+
+    def cached(self) -> Optional[CatalogSnapshot]:
+        """Return the in-memory snapshot if hydrated, else load from
+        disk lazily. NEVER raises."""
+        if self._memory_hydrated:
+            return self._memory_snapshot
+        loaded = load_cached_snapshot(self._cache_path)
+        self._memory_snapshot = loaded
+        self._memory_hydrated = True
+        return loaded
+
+    def stale(self, *, max_age_s: Optional[float] = None) -> bool:
+        """True if cached snapshot exists but is older than threshold,
+        OR cache is empty. Default threshold from env.
+        NEVER raises."""
+        snap = self.cached()
+        if snap is None:
+            return True
+        return not snap.is_fresh(max_age_s=max_age_s)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _parse_body(self, body: Any) -> Tuple[ModelCard, ...]:
+        """Accept the OpenAI-compatible ``{"data": [...]}`` envelope OR
+        a bare list. Skip malformed entries; never raise."""
+        if isinstance(body, Mapping):
+            data = body.get("data", [])
+        elif isinstance(body, list):
+            data = body
+        else:
+            return ()
+        if not isinstance(data, list):
+            return ()
+        cards: list = []
+        for entry in data:
+            card = ModelCard.from_api_dict(entry)
+            if card is not None:
+                cards.append(card)
+        return tuple(cards)
+
+    def _failure_fallback(
+        self, reason: str, t0: float,
+    ) -> CatalogSnapshot:
+        """Build the failure-marked snapshot — prefer last cache,
+        fall back to empty snapshot when no cache exists."""
+        latency_ms = int((time.monotonic() - t0) * 1000)
+        cached = self.cached()
+        if cached is not None:
+            # Return the cached snapshot but tag it with the new
+            # failure reason so observers see this fetch failed.
+            # The fetched_at_unix stays at the cache's value — the
+            # snapshot is genuinely from that earlier moment.
+            return CatalogSnapshot(
+                fetched_at_unix=cached.fetched_at_unix,
+                models=cached.models,
+                schema_version=cached.schema_version,
+                fetch_latency_ms=latency_ms,
+                fetch_failure_reason=reason,
+            )
+        return CatalogSnapshot(
+            fetched_at_unix=time.time(),
+            models=(),
+            fetch_latency_ms=latency_ms,
+            fetch_failure_reason=reason,
+        )
+
+
+__all__ = [
+    "CATALOG_SCHEMA_VERSION",
+    "ModelCard",
+    "CatalogSnapshot",
+    "DwCatalogClient",
+    "discovery_enabled",
+    "load_cached_snapshot",
+    "save_snapshot",
+    "parse_parameter_count",
+    "parse_family",
+]

--- a/docs/architecture/phase_12_dynamic_dw_catalog_spec.md
+++ b/docs/architecture/phase_12_dynamic_dw_catalog_spec.md
@@ -1,0 +1,277 @@
+# Phase 12 — Dynamic DW Catalog Discovery
+
+**Status:** SPEC (DRAFT) — not yet implemented
+**Mandate:** [ARCHITECTURAL DIRECTIVE: DYNAMIC CAPABILITY DISCOVERY (O+V)] (2026-04-27)
+**Purges:** the hardcoded `dw_models:` ranked arrays in `brain_selection_policy.yaml` (lines 374–414)
+**Replaces with:** live `/models` polling + algorithmic route assignment + adaptive probing
+
+## 1. Why this exists
+
+The Phase 11 graduation soak surfaced that across 6 consecutive battle-test sessions, `dw_completes=0` — every BACKGROUND/SPECULATIVE op was YAML-blocked with a stale 2026-04-14 reason text ("Gemma 4 31B stream-stalls"), even though Gemma is no longer in any generative ranked list. The static lists are 8 model_ids, hand-curated, last touched 2026-04-27. DoubleWord exposes a larger live catalog. **A First-Order sovereign system discovers its own capabilities; it does not consult a human-edited array.**
+
+This spec replaces the *catalog* (which models exist) while preserving the *policy* (`fallback_tolerance`, `block_mode`, `dw_allowed`) — those remain operator-authored because they encode value judgments (cost contract, blast radius), not facts about the world.
+
+## 2. Existing seams (no rewrite needed)
+
+| Surface | File:line | Current behavior | Phase 12 change |
+|---|---|---|---|
+| `/models` HTTP call | `doubleword_provider.py:1918` | Binary `health_probe()` — discards body | Parse body into `List[ModelCard]` |
+| Per-route ranked list | `provider_topology.py:352` `dw_models_for_route()` | Reads YAML `routes[route].dw_models` | Reads `_dynamic_catalog[route]` when discovery enabled, falls back to YAML when stale/disabled |
+| Sentinel dispatch | `candidate_generator.py:1985–1995` walks `topology.dw_models_for_route()` | Iterates ranked list, attempts each non-OPEN model | **No change** — same iteration, different source |
+| Sentinel preflight | `topology_sentinel.py:1697` `preflight_check()` | Synchronous shape check | Adds optional async `discover_catalog()` step that hydrates `_dynamic_catalog` |
+
+The dispatch path stays untouched — the entire change is in the *catalog source*, not the *cascade logic*.
+
+## 3. New components
+
+### 3.1 `dw_catalog_client.py` (new module, ~200 lines)
+
+```python
+@dataclass(frozen=True)
+class ModelCard:
+    model_id: str                          # e.g. "moonshotai/Kimi-K2.6"
+    family: str                            # parsed from prefix: "moonshotai", "qwen", "google", "zai-org"
+    parameter_count_b: float | None        # 397.0 for Qwen3.5-397B; None when unparseable
+    context_window: int | None             # from API metadata when available
+    pricing_in_per_m_usd: float | None
+    pricing_out_per_m_usd: float | None
+    supports_streaming: bool               # default True; lowered if API metadata says otherwise
+    raw_metadata: Dict[str, Any]           # preserved for downstream classifiers
+
+@dataclass(frozen=True)
+class CatalogSnapshot:
+    fetched_at_unix: float
+    models: Tuple[ModelCard, ...]
+    schema_version: str = "dw_catalog.1"
+    fetch_latency_ms: int = 0
+    fetch_failure_reason: str | None = None  # populated when this is a fallback-to-cache snapshot
+
+class DwCatalogClient:
+    """Async client over DoublewordProvider's existing aiohttp session.
+    Owns: fetch, parse, cache, refresh.
+    Does NOT own: route assignment (that's the classifier's job)."""
+
+    async def fetch(self) -> CatalogSnapshot: ...
+    def cached(self) -> CatalogSnapshot | None: ...   # returns last good snapshot or None
+    def stale(self, *, max_age_s: float) -> bool: ...
+```
+
+**Parsing contract for unknown response shape**: DW's `/models` follows the OpenAI-compatible `{"data": [...]}` envelope. Each model object has at least `id`. We tolerate missing optional fields (`context_window`, pricing) — the classifier in §3.2 is responsible for handling Nones gracefully (conservative downgrade). Param count parsed from `id` heuristic when not in API: regex `(\d+(?:\.\d+)?)B` on the trailing portion.
+
+**Cache discipline**:
+- Successful fetch → in-memory `CatalogSnapshot` + write-through to `.jarvis/dw_catalog.json` (atomic temp+rename, mirrored from `posture_store.py`)
+- Boot reads disk snapshot first; `fetched_at_unix` decides whether to refresh
+- Refresh interval: `JARVIS_DW_CATALOG_REFRESH_S` (default 1800s = 30 min)
+- Failed fetch → return last good cached snapshot with `fetch_failure_reason` populated; sentinel logs warn-once
+
+### 3.2 `dw_catalog_classifier.py` (new module, ~250 lines)
+
+Deterministic, zero-LLM ranking. Classifier maps each `ModelCard` to a per-route score; per-route ranked lists are `top_k` of (route, score) sorted desc.
+
+```python
+@dataclass(frozen=True)
+class RouteAssignment:
+    route: str                              # "complex" | "standard" | "background" | "speculative"
+    ranked_model_ids: Tuple[str, ...]       # output of classifier, replaces YAML dw_models
+
+class DwCatalogClassifier:
+    def classify(self, snapshot: CatalogSnapshot) -> Dict[str, RouteAssignment]: ...
+```
+
+**Ranking signals** (deterministic, env-tunable weights):
+
+| Signal | Weight | Source | Notes |
+|---|---|---|---|
+| `parameter_count_b` | 1.0 | parsed from id, fallback None=0 | Bigger model = higher score for COMPLEX/STANDARD |
+| `pricing_out_per_m_usd` | -1.0 | API metadata | Cheaper = higher score for BG/SPEC |
+| `context_window` | 0.3 | API metadata | Larger = better for COMPLEX (long-horizon coding) |
+| `family_bonus` | 0.5 | family prefix lookup | Operator-tunable: `JARVIS_DW_FAMILY_PREFERENCE` env (e.g. "moonshotai:1.0,zai-org:0.8") |
+
+**Per-route eligibility gates** (hard filters before scoring):
+
+| Route | Min params | Max output $/M | Other |
+|---|---|---|---|
+| COMPLEX | ≥ 30B | none | ctx ≥ 100k preferred |
+| STANDARD | ≥ 14B | ≤ $2.0/M | |
+| BACKGROUND | none | ≤ $0.5/M | cheap-first |
+| SPECULATIVE | none | ≤ $0.1/M | ultra-cheap |
+
+Hard filters are env-overridable via `JARVIS_DW_CLASSIFIER_<ROUTE>_*` knobs. **Defaults are conservative** — wider gates can be opened post-soak.
+
+**Zero-Trust quarantine for ambiguous metadata** (operator-mandated 2026-04-27):
+A model with `parameter_count_b is None` AND `pricing_out_per_m_usd is None` is **mathematically unsafe** to slot into BACKGROUND. BG runs continuously and high-volume; an unpriced 400B model in that lane could bankrupt the system on a single sustained sensor cycle. Such models are slotted **EXCLUSIVELY** into SPECULATIVE — the route with the strictest cost/queue governors and the smallest blast radius (queue-only fallback, ultra-cheap-only ranking, isolated from the core operational loop).
+
+Promotion from quarantine is **latency-driven**, not metadata-driven (see §4.5 "Prove-It Promotion Ledger"): a quarantined model graduates to BACKGROUND only after demonstrating consistent sub-200ms latency across 10 successful operations. Latency is the proxy for size — small models respond faster — and we trust observed performance over self-reported metadata. Until it earns its weight, it stays quarantined.
+
+### 3.3 `provider_topology.py` augment (~60 lines added)
+
+```python
+class ProviderTopology:
+    def __init__(self, ...):
+        ...
+        self._dynamic_catalog: Dict[str, RouteAssignment] | None = None  # populated by sentinel
+        self._dynamic_catalog_fetched_at: float | None = None
+
+    def set_dynamic_catalog(
+        self, assignments: Dict[str, RouteAssignment], fetched_at: float,
+    ) -> None:
+        """Sentinel-injected catalog. Authoritative when present and fresh."""
+
+    def dw_models_for_route(self, route: str) -> Tuple[str, ...]:
+        if self._dynamic_catalog and self._catalog_fresh():
+            assn = self._dynamic_catalog.get(route)
+            if assn and assn.ranked_model_ids:
+                return assn.ranked_model_ids
+        # Fall through to YAML (legacy / fallback path)
+        ...existing logic...
+```
+
+**Catalog freshness**: `_catalog_fresh()` checks `time.time() - fetched_at < JARVIS_DW_CATALOG_MAX_AGE_S` (default 7200s = 2h). Stale catalog → fall back to YAML, log warn-once. **The YAML stays as the safety net throughout Phase 12** — it's only purged in Slice D after 3 clean soak sessions on the dynamic source.
+
+### 3.4 Sentinel preflight extension (~50 lines)
+
+```python
+async def preflight_check(...) -> SentinelPreflightResult:
+    ...existing checks...
+
+    # Phase 12 — Dynamic catalog discovery (gated by JARVIS_DW_CATALOG_DISCOVERY_ENABLED)
+    if catalog_discovery_enabled():
+        try:
+            client = DwCatalogClient(provider=...)
+            snapshot = await client.fetch()
+            classifier = DwCatalogClassifier()
+            assignments = classifier.classify(snapshot)
+            topology.set_dynamic_catalog(assignments, snapshot.fetched_at_unix)
+            diagnostics.append(
+                f"catalog_loaded:models={len(snapshot.models)}:"
+                f"routes_assigned={sum(1 for a in assignments.values() if a.ranked_model_ids)}"
+            )
+        except Exception as exc:
+            diagnostics.append(f"catalog_fetch_failed:{type(exc).__name__}:{str(exc)[:80]}")
+            # NOT a failed_assertion — discovery failure falls back to YAML, system stays healthy
+```
+
+Discovery failure is a *diagnostic*, not a failed assertion — preflight stays healthy and the YAML safety net handles the gap.
+
+### 3.5 Adaptive refresh task (~80 lines)
+
+Background `asyncio.Task` owned by `TopologySentinel`. Every `JARVIS_DW_CATALOG_REFRESH_S` (default 1800s):
+1. Fetch fresh catalog
+2. Diff against previous snapshot
+3. New `model_id` detected → `sentinel.register_endpoint(model_id)` + classifier slots it into a route
+4. Removed `model_id` → leave breaker state intact (DW might re-add it); just stop using it
+5. Emit `dw_catalog_updated` event over `TrinityEventBus` for IDE observability
+
+**No SSE bridge yet in Phase 12** — only `TrinityEventBus` publish. SSE bridge is a follow-up if operators want live observability.
+
+### 3.6 Prove-It Promotion Ledger (`dw_promotion_ledger.py`, ~150 lines)
+
+**Owns:** observed-latency tracking + quarantine state + graduation decisions.
+**Authority:** read-only telemetry consumed by classifier; classifier writes promotion events.
+
+```python
+@dataclass(frozen=True)
+class PromotionRecord:
+    model_id: str
+    quarantine_origin: str          # "ambiguous_metadata" | "unranked_new" | "operator_demoted"
+    success_latencies_ms: Tuple[int, ...]   # bounded ring buffer, length 10
+    failure_count: int                       # cumulative failures while in quarantine
+    promoted: bool = False
+    promoted_at_unix: float | None = None
+
+class PromotionLedger:
+    def record_success(self, model_id: str, latency_ms: int) -> None: ...
+    def record_failure(self, model_id: str) -> None: ...
+    def is_eligible_for_promotion(self, model_id: str) -> bool: ...
+    def promote(self, model_id: str) -> None: ...
+    def quarantined_models(self) -> Tuple[str, ...]: ...
+```
+
+**Promotion criteria (ALL must hold):**
+- ≥ `JARVIS_DW_PROMOTION_MIN_SUCCESSES` (default 10) successful ops recorded
+- **Every** recorded latency ≤ `JARVIS_DW_PROMOTION_MAX_LATENCY_MS` (default 200) — strict, not P95
+- Zero failures since last `record_success` (`failure_count == 0` for the current ring window)
+
+**Demotion criteria** (back to quarantine from BG):
+- Single failure during BG operation → resets the ring buffer; model returns to SPECULATIVE
+- `JARVIS_DW_PROMOTION_DEMOTION_FAIL_THRESHOLD` (default 1) — zero-tolerance by default
+
+**Persistence**: `.jarvis/dw_promotion_ledger.json`, atomic temp+rename. Ledger survives restart so quarantine state isn't reset on every boot.
+
+**Wiring**: classifier in §3.2 reads the ledger when assembling per-route assignments. If `model_id` is in `quarantined_models()`, it's pinned to SPECULATIVE regardless of metadata. If it's in `promoted_models()`, the classifier may consider it for BACKGROUND (subject to other eligibility gates). The classifier never short-circuits the gates — promotion enables consideration, doesn't guarantee placement.
+
+**Observability**: every promotion/demotion fires a `dw_model_promoted` / `dw_model_demoted` event over `TrinityEventBus` with the full `PromotionRecord` snapshot. Operators can audit the entire quarantine→promotion lifecycle from the IDE observability stream.
+
+**Cost ceiling on quarantine itself**: SPECULATIVE has a hardcoded `cost_cap_usd` per op enforced by `cost_governor.py`. Even if a quarantined ghost-model returns 100M tokens, the cost is capped at the SPECULATIVE budget profile (~$0.001/op). The user's "unpriced 400B model bankrupts BG" failure mode is structurally impossible from quarantine.
+
+## 4. Failure modes & cost contract
+
+| Scenario | Behavior | Cost contract impact |
+|---|---|---|
+| `/models` returns 200 but empty `data` | Snapshot recorded with `len(models)=0`; classifier returns empty ranked lists; sentinel falls through to YAML | Same as today — YAML fully authoritative |
+| `/models` 5xx or timeout | Returns last cached snapshot; if no cache, falls through to YAML | Same as today |
+| Catalog fresh but classifier finds 0 eligible models for a route | Empty ranked list → sentinel sees empty → falls through to YAML for that route | YAML still authoritative for that one route |
+| New model auto-assigned but immediately fails | Sentinel circuit breaker trips that model_id alone; remaining ranked list still tried | BG/SPEC routes still respect `fallback_tolerance: "queue"` after exhaustion → no Claude cascade |
+| Classifier misranks (e.g. tiny model in COMPLEX) | Real failures observed, breaker trips, lower-ranked models tried; eventually cascades to Claude per existing `fallback_tolerance: "cascade_to_claude"` | Same blast radius as today's COMPLEX-on-Claude path |
+| Pricing metadata missing on a model | Classifier conservatively slots to BACKGROUND only | No cost surprise — BG `fallback_tolerance: "queue"` |
+
+**The cost contract is preserved structurally** because `fallback_tolerance` lives in YAML, not the catalog. The catalog only changes *which models* try; *what happens when they fail* is operator-authored policy.
+
+## 5. Slicing plan (5 slices, all defaults false until Slice E)
+
+### Slice A — Catalog client + tests (no integration)
+- `dw_catalog_client.py` + `test_dw_catalog_client.py`
+- Mock `aiohttp` responses for: clean fetch, 5xx, timeout, malformed JSON, missing optional fields
+- Disk cache atomic write/read tests (mirror `posture_store` test pattern)
+- Master flag `JARVIS_DW_CATALOG_DISCOVERY_ENABLED` (default false) added but not consumed yet
+
+### Slice B — Classifier + tests
+- `dw_catalog_classifier.py` + `test_dw_catalog_classifier.py`
+- Deterministic ranking pinned: same input → same per-route lists
+- Edge cases: missing metadata, empty catalog, exotic family prefix, env-tuned weights
+
+### Slice C — Sentinel preflight wiring (shadow mode)
+- `preflight_check()` calls discovery when flag on; populates `_dynamic_catalog` but `dw_models_for_route()` still reads YAML (one-flag-gated comparison phase)
+- Diagnostic field `catalog_yaml_diff` — list of model_ids in YAML but missing from catalog and vice versa
+- Manual operator review of diagnostic before flipping authority
+
+### Slice D — Authority handoff
+- `dw_models_for_route()` reads `_dynamic_catalog` first when fresh + discovery enabled
+- YAML becomes fallback only
+- Adaptive refresh task active
+- Three forced-clean soak sessions required before Slice E
+
+### Slice E — YAML purge + graduation
+- Remove `dw_models:` arrays from `brain_selection_policy.yaml` (lines 374, 385, 401, 412)
+- Keep `fallback_tolerance`, `block_mode`, `dw_allowed`, `reason` (those are policy, not catalog)
+- Refresh stale 2026-04-14 reason strings to current truth
+- Flip `JARVIS_DW_CATALOG_DISCOVERY_ENABLED` default to true
+- Graduation pin suite: catalog-fresh path, catalog-stale fallback, discovery-disabled fallback, new-model auto-detection, classifier determinism
+
+## 6. Env flag surface (all default false until Slice E)
+
+| Flag | Default | Owner |
+|---|---|---|
+| `JARVIS_DW_CATALOG_DISCOVERY_ENABLED` | false → true at Slice E | Master flag |
+| `JARVIS_DW_CATALOG_REFRESH_S` | 1800 | Refresh cadence |
+| `JARVIS_DW_CATALOG_MAX_AGE_S` | 7200 | Freshness threshold |
+| `JARVIS_DW_CLASSIFIER_<ROUTE>_MIN_PARAMS_B` | per §3.2 table | Eligibility gates |
+| `JARVIS_DW_CLASSIFIER_<ROUTE>_MAX_OUT_PRICE` | per §3.2 table | |
+| `JARVIS_DW_FAMILY_PREFERENCE` | unset (no bonus) | Operator family bias |
+
+## 7. Out of scope (explicitly)
+
+- **Capability tagging beyond size/price/family.** DW's `/models` may not expose benchmark scores, agentic-vs-chat capability, etc. Phase 12 ranks on universally-available metadata. Post-Phase-12, an `EvidenceLedger` of observed per-model success rates per route could feed back into ranking — that's a separate arc.
+- **Cross-provider catalog merge.** Phase 12 is DW-only. Anthropic + Prime catalogs are static and well-known.
+- **Self-healing of misclassifications via op-completion telemetry.** Tempting but defers to a follow-up that wires the existing `OpsDigestObserver` outputs into the classifier as a re-ranking feedback loop.
+- **Operator override of dynamic ranking.** If needed, the YAML stays as a fallback that an operator can re-enable by flipping `JARVIS_DW_CATALOG_DISCOVERY_ENABLED=false` — that's the hot-revert path, not a parallel override.
+
+## 8. Verification protocol
+
+Each slice closes with:
+1. Unit tests green
+2. Combined regression (existing topology_sentinel + provider_topology + candidate_generator suites)
+3. Live preflight against the actual DW endpoint (Slice A onward)
+4. One battle-test session per Slice C / D with sentinel-on, observing the diagnostic delta
+
+Slice E graduation requires the same forced-clean cadence as Phase 11.7: 3 consecutive sessions with `dw_completes ≥ 1` and zero `catalog_fetch_failed` on the diagnostic.

--- a/tests/governance/test_dw_catalog_client.py
+++ b/tests/governance/test_dw_catalog_client.py
@@ -1,0 +1,687 @@
+"""Phase 12 Slice A — DwCatalogClient regression spine.
+
+Pins:
+  §1 Master flag — JARVIS_DW_CATALOG_DISCOVERY_ENABLED default false +
+                   truthy/falsy parsing
+  §2 ModelCard parsing — id-required, optional fields, pricing shapes,
+                         streaming default, raw metadata preservation
+  §3 Parameter-count regex — Qwen/Gemma id heuristics, conservative None
+  §4 has_ambiguous_metadata — Zero-Trust §3.6 quarantine rule
+  §5 CatalogSnapshot — freshness, JSON round-trip, schema version
+  §6 Disk cache — atomic write, atomic read, version mismatch, missing
+  §7 DwCatalogClient.fetch() — clean fetch, OpenAI envelope vs bare list
+  §8 fetch() failure paths — http 5xx, timeout, transport, malformed JSON,
+                              all NEVER raise + populate fetch_failure_reason
+  §9 fetch() with no cache — failure returns empty snapshot, not exception
+  §10 cached() + stale() — memory hydration, disk fallback
+  §11 Source-level pins — fetch never raises (try/except contract)
+"""
+from __future__ import annotations
+
+import asyncio  # noqa: F401  — pytest-asyncio plugin contract
+import json
+import os  # noqa: F401  — env-var reads in fixtures
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional  # noqa: F401
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance import dw_catalog_client as dcc
+from backend.core.ouroboros.governance.dw_catalog_client import (
+    CATALOG_SCHEMA_VERSION,
+    CatalogSnapshot,
+    DwCatalogClient,
+    ModelCard,
+    discovery_enabled,
+    load_cached_snapshot,
+    parse_family,
+    parse_parameter_count,
+    save_snapshot,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Redirect the disk cache to a tmpdir-scoped path."""
+    cache = tmp_path / "dw_catalog.json"
+    monkeypatch.setenv("JARVIS_DW_CATALOG_PATH", str(cache))
+    yield cache
+
+
+def _mock_session(json_body: Any = None, status: int = 200,
+                  raise_exc: Optional[Exception] = None) -> Any:
+    """Build a mock aiohttp.ClientSession that yields the configured
+    response from a single ``session.get()`` call."""
+    session = MagicMock()
+
+    class _Resp:
+        def __init__(self) -> None:
+            self.status = status
+
+        async def __aenter__(self) -> "_Resp":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def json(self) -> Any:
+            return json_body
+
+    def _get(url: str, **kwargs: Any) -> Any:  # noqa: ARG001
+        if raise_exc is not None:
+            raise raise_exc
+        return _Resp()
+
+    session.get = _get
+    return session
+
+
+def _client(session: Any, cache_path: Optional[Path] = None) -> DwCatalogClient:
+    return DwCatalogClient(
+        session=session,
+        base_url="https://api.doubleword.ai",
+        api_key="test-key",
+        cache_path=cache_path,
+    )
+
+
+# ===========================================================================
+# §1 — Master flag
+# ===========================================================================
+
+
+def test_discovery_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Slice A ships default-off; Slice E flips."""
+    monkeypatch.delenv("JARVIS_DW_CATALOG_DISCOVERY_ENABLED", raising=False)
+    assert discovery_enabled() is False
+
+
+def test_discovery_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    for val in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("JARVIS_DW_CATALOG_DISCOVERY_ENABLED", val)
+        assert discovery_enabled() is True
+
+
+def test_discovery_falsy_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    for val in ("0", "false", "no", "off", "", "garbage"):
+        monkeypatch.setenv("JARVIS_DW_CATALOG_DISCOVERY_ENABLED", val)
+        assert discovery_enabled() is False
+
+
+# ===========================================================================
+# §2 — ModelCard parsing
+# ===========================================================================
+
+
+def test_model_card_requires_id() -> None:
+    """No ``id`` → None. Empty string id → None."""
+    assert ModelCard.from_api_dict({}) is None
+    assert ModelCard.from_api_dict({"id": ""}) is None
+    assert ModelCard.from_api_dict({"id": "   "}) is None
+    assert ModelCard.from_api_dict({"id": None}) is None
+
+
+def test_model_card_minimal_id_only() -> None:
+    """Just ``id`` produces a card; param count parsed from id."""
+    card = ModelCard.from_api_dict({"id": "Qwen/Qwen3.5-397B-A17B"})
+    assert card is not None
+    assert card.model_id == "Qwen/Qwen3.5-397B-A17B"
+    assert card.family == "qwen"
+    assert card.parameter_count_b == 397.0
+    assert card.context_window is None
+    assert card.pricing_in_per_m_usd is None
+    assert card.pricing_out_per_m_usd is None
+    assert card.supports_streaming is True
+
+
+def test_model_card_pricing_nested_shape() -> None:
+    """``pricing: {input, output}`` is the OpenAI-compat shape."""
+    card = ModelCard.from_api_dict({
+        "id": "moonshotai/Kimi-K2.6",
+        "pricing": {"input": 0.10, "output": 0.40},
+    })
+    assert card is not None
+    assert card.pricing_in_per_m_usd == 0.10
+    assert card.pricing_out_per_m_usd == 0.40
+
+
+def test_model_card_pricing_top_level_shape() -> None:
+    """Top-level ``pricing_in_per_m_usd`` / ``pricing_out_per_m_usd``."""
+    card = ModelCard.from_api_dict({
+        "id": "Qwen/Qwen3.5-9B",
+        "pricing_in_per_m_usd": 0.04,
+        "pricing_out_per_m_usd": 0.06,
+    })
+    assert card is not None
+    assert card.pricing_in_per_m_usd == 0.04
+    assert card.pricing_out_per_m_usd == 0.06
+
+
+def test_model_card_context_window() -> None:
+    card = ModelCard.from_api_dict({
+        "id": "moonshotai/Kimi-K2.6",
+        "context_window": 200000,
+    })
+    assert card is not None
+    assert card.context_window == 200000
+
+
+def test_model_card_streaming_explicit_false() -> None:
+    card = ModelCard.from_api_dict({
+        "id": "fake/model-1B",
+        "supports_streaming": False,
+    })
+    assert card is not None
+    assert card.supports_streaming is False
+
+
+def test_model_card_api_param_count_takes_precedence_over_heuristic() -> None:
+    """When API exposes ``parameter_count_b``, use that even if id
+    suggests otherwise. Treats API as ground truth."""
+    card = ModelCard.from_api_dict({
+        "id": "weird-id-without-bn-suffix",
+        "parameter_count_b": 70.0,
+    })
+    assert card is not None
+    assert card.parameter_count_b == 70.0
+
+
+def test_model_card_invalid_pricing_ignored() -> None:
+    """Negative or non-numeric pricing must NOT poison the card."""
+    card = ModelCard.from_api_dict({
+        "id": "fake/model-7B",
+        "pricing": {"input": "not-a-number", "output": -5.0},
+    })
+    assert card is not None
+    assert card.pricing_in_per_m_usd is None  # string rejected
+    # Negative pricing is not >= 0 in our gate, so... actually we
+    # allow >= 0, so let's check the strict gate worked.
+    assert card.pricing_out_per_m_usd is None  # -5.0 doesn't pass >= 0
+
+
+def test_model_card_raw_metadata_preserved() -> None:
+    raw = {
+        "id": "Qwen/Qwen3.6-35B-A3B-FP8",
+        "exotic_field": [1, 2, 3],
+    }
+    card = ModelCard.from_api_dict(raw)
+    assert card is not None
+    parsed_back = json.loads(card.raw_metadata_json)
+    assert parsed_back["id"] == "Qwen/Qwen3.6-35B-A3B-FP8"
+    assert parsed_back["exotic_field"] == [1, 2, 3]
+
+
+# ===========================================================================
+# §3 — Parameter-count regex
+# ===========================================================================
+
+
+@pytest.mark.parametrize("model_id,expected", [
+    ("Qwen/Qwen3.5-397B-A17B", 397.0),
+    ("google/gemma-4-31B-it", 31.0),
+    ("Qwen/Qwen3.6-35B-A3B-FP8", 35.0),
+    ("Qwen/Qwen3-14B-FP8", 14.0),
+    ("Qwen/Qwen3.5-9B", 9.0),
+    ("Qwen/Qwen3.5-4B", 4.0),
+    ("fake/model-7B-instruct", 7.0),
+    ("fake/model-1.5B", 1.5),
+])
+def test_parse_parameter_count_known_ids(
+    model_id: str, expected: float,
+) -> None:
+    assert parse_parameter_count(model_id) == expected
+
+
+@pytest.mark.parametrize("model_id", [
+    "moonshotai/Kimi-K2.6",   # no Bn suffix
+    "zai-org/GLM-5.1-FP8",    # version dot, no Bn
+    "",
+    None,
+    "no-slash-no-suffix",
+    "fake/no-numeric-marker",
+])
+def test_parse_parameter_count_returns_none_for_unparseable(model_id: Any) -> None:
+    """Conservative — when in doubt, return None (→ Zero-Trust quarantine)."""
+    assert parse_parameter_count(model_id) is None
+
+
+def test_parse_family() -> None:
+    assert parse_family("Qwen/Qwen3.5-397B") == "qwen"
+    assert parse_family("moonshotai/Kimi-K2.6") == "moonshotai"
+    assert parse_family("zai-org/GLM-5.1-FP8") == "zai-org"
+    assert parse_family("google/gemma-4-31B-it") == "google"
+    assert parse_family("no-slash") == "unknown"
+    assert parse_family("") == "unknown"
+
+
+# ===========================================================================
+# §4 — has_ambiguous_metadata (Zero-Trust §3.6)
+# ===========================================================================
+
+
+def test_ambiguous_metadata_when_both_missing() -> None:
+    """No param count AND no out-pricing → SPECULATIVE quarantine signal."""
+    card = ModelCard.from_api_dict({"id": "moonshotai/Kimi-K2.6"})
+    assert card is not None
+    assert card.parameter_count_b is None
+    assert card.pricing_out_per_m_usd is None
+    assert card.has_ambiguous_metadata() is True
+
+
+def test_not_ambiguous_with_param_count_alone() -> None:
+    """Param count parsed from id is enough — not ambiguous."""
+    card = ModelCard.from_api_dict({"id": "Qwen/Qwen3.5-397B-A17B"})
+    assert card is not None
+    assert card.has_ambiguous_metadata() is False
+
+
+def test_not_ambiguous_with_pricing_alone() -> None:
+    card = ModelCard.from_api_dict({
+        "id": "moonshotai/Kimi-K2.6",
+        "pricing": {"input": 0.10, "output": 0.40},
+    })
+    assert card is not None
+    assert card.has_ambiguous_metadata() is False
+
+
+# ===========================================================================
+# §5 — CatalogSnapshot freshness + JSON round-trip
+# ===========================================================================
+
+
+def test_snapshot_is_fresh_within_window() -> None:
+    snap = CatalogSnapshot(
+        fetched_at_unix=time.time() - 10,
+        models=(),
+    )
+    assert snap.is_fresh(max_age_s=60) is True
+
+
+def test_snapshot_not_fresh_past_window() -> None:
+    snap = CatalogSnapshot(
+        fetched_at_unix=time.time() - 7300,
+        models=(),
+    )
+    assert snap.is_fresh(max_age_s=7200) is False
+
+
+def test_snapshot_json_roundtrip() -> None:
+    original = CatalogSnapshot(
+        fetched_at_unix=1777_333_000.0,
+        models=(
+            ModelCard(
+                model_id="Qwen/Qwen3.5-397B-A17B",
+                family="qwen",
+                parameter_count_b=397.0,
+                context_window=128000,
+                pricing_in_per_m_usd=0.10,
+                pricing_out_per_m_usd=0.40,
+                supports_streaming=True,
+                raw_metadata_json='{"id":"Qwen/Qwen3.5-397B-A17B"}',
+            ),
+            ModelCard(
+                model_id="moonshotai/Kimi-K2.6",
+                family="moonshotai",
+                parameter_count_b=None,
+                context_window=None,
+                pricing_in_per_m_usd=None,
+                pricing_out_per_m_usd=None,
+                supports_streaming=True,
+                raw_metadata_json="{}",
+            ),
+        ),
+        fetch_latency_ms=234,
+        fetch_failure_reason=None,
+    )
+    text = original.to_json()
+    parsed = CatalogSnapshot.from_json(text)
+    assert parsed is not None
+    assert parsed.fetched_at_unix == original.fetched_at_unix
+    assert parsed.fetch_latency_ms == 234
+    assert parsed.fetch_failure_reason is None
+    assert len(parsed.models) == 2
+    assert parsed.models[0].parameter_count_b == 397.0
+    assert parsed.models[1].parameter_count_b is None
+    assert parsed.models[1].has_ambiguous_metadata() is True
+
+
+def test_snapshot_from_json_rejects_wrong_schema_version() -> None:
+    """Future-version cache → treat as missing (forces re-fetch)."""
+    payload = json.dumps({
+        "schema_version": "dw_catalog.99",
+        "fetched_at_unix": 1.0,
+        "models": [],
+    })
+    assert CatalogSnapshot.from_json(payload) is None
+
+
+def test_snapshot_from_json_rejects_garbage() -> None:
+    assert CatalogSnapshot.from_json("not json at all") is None
+    assert CatalogSnapshot.from_json("[]") is None  # not a dict
+    assert CatalogSnapshot.from_json("null") is None
+
+
+def test_snapshot_from_json_skips_malformed_entries() -> None:
+    """One bad entry doesn't blow up the whole snapshot — load the rest."""
+    payload = json.dumps({
+        "schema_version": CATALOG_SCHEMA_VERSION,
+        "fetched_at_unix": 1.0,
+        "models": [
+            {"model_id": "good/model-7B", "family": "good",
+             "parameter_count_b": 7.0, "context_window": None,
+             "pricing_in_per_m_usd": None, "pricing_out_per_m_usd": None,
+             "supports_streaming": True, "raw_metadata_json": "{}"},
+            "this is not a dict",  # malformed
+            {"model_id": "", "family": "x"},  # empty id, filtered
+        ],
+    })
+    parsed = CatalogSnapshot.from_json(payload)
+    assert parsed is not None
+    assert len(parsed.models) == 1
+    assert parsed.models[0].model_id == "good/model-7B"
+
+
+# ===========================================================================
+# §6 — Disk cache (atomic write/read)
+# ===========================================================================
+
+
+def test_save_and_load_roundtrip(isolated_cache: Path) -> None:
+    snap = CatalogSnapshot(
+        fetched_at_unix=time.time(),
+        models=(ModelCard(
+            model_id="x/y-3B", family="x", parameter_count_b=3.0,
+            context_window=None, pricing_in_per_m_usd=None,
+            pricing_out_per_m_usd=None, supports_streaming=True,
+            raw_metadata_json="{}",
+        ),),
+    )
+    save_snapshot(snap)
+    loaded = load_cached_snapshot()
+    assert loaded is not None
+    assert len(loaded.models) == 1
+    assert loaded.models[0].model_id == "x/y-3B"
+
+
+def test_load_missing_cache_returns_none(isolated_cache: Path) -> None:
+    """No file → None, no exception."""
+    assert load_cached_snapshot() is None
+
+
+def test_load_corrupt_cache_returns_none(isolated_cache: Path) -> None:
+    """Corrupt JSON → None, no exception (caller treats as cache-miss)."""
+    isolated_cache.parent.mkdir(parents=True, exist_ok=True)
+    isolated_cache.write_text("{this is not valid json", encoding="utf-8")
+    assert load_cached_snapshot() is None
+
+
+def test_save_creates_parent_dirs(tmp_path: Path,
+                                  monkeypatch: pytest.MonkeyPatch) -> None:
+    """Atomic write must create the parent directory tree."""
+    deep = tmp_path / "a" / "b" / "c" / "dw_catalog.json"
+    monkeypatch.setenv("JARVIS_DW_CATALOG_PATH", str(deep))
+    snap = CatalogSnapshot(fetched_at_unix=1.0, models=())
+    save_snapshot(snap)
+    assert deep.exists()
+
+
+# ===========================================================================
+# §7 — DwCatalogClient.fetch() — clean fetch
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_openai_envelope(isolated_cache: Path) -> None:
+    body = {
+        "data": [
+            {"id": "Qwen/Qwen3.5-397B-A17B"},
+            {"id": "moonshotai/Kimi-K2.6"},
+            {"id": "Qwen/Qwen3.5-9B",
+             "pricing": {"input": 0.04, "output": 0.06}},
+        ],
+    }
+    client = _client(_mock_session(body))
+    snap = await client.fetch()
+    assert snap.fetch_failure_reason is None
+    assert len(snap.models) == 3
+    assert snap.models[0].parameter_count_b == 397.0
+    assert snap.models[1].has_ambiguous_metadata() is True
+    assert snap.models[2].pricing_out_per_m_usd == 0.06
+    # Disk cache populated
+    assert load_cached_snapshot() is not None
+
+
+@pytest.mark.asyncio
+async def test_fetch_bare_list_envelope(isolated_cache: Path) -> None:
+    """Some servers return a bare list (non-OpenAI shape) — still works."""
+    body = [{"id": "fake/model-7B"}]
+    client = _client(_mock_session(body))
+    snap = await client.fetch()
+    assert snap.fetch_failure_reason is None
+    assert len(snap.models) == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_22_models_simulation(isolated_cache: Path) -> None:
+    """Mirrors the 22-model count surfaced in bt-2026-04-27-235708 soak.
+    Pins that the parser tolerates a realistic catalog size."""
+    body = {"data": [
+        {"id": f"vendor/model-{i}-{(i*3) % 50 + 1}B"}
+        for i in range(22)
+    ]}
+    client = _client(_mock_session(body))
+    snap = await client.fetch()
+    assert len(snap.models) == 22
+
+
+# ===========================================================================
+# §8 — fetch() failure paths — never raise
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_http_5xx(isolated_cache: Path) -> None:
+    """HTTP 500 → failure reason populated, NEVER raises."""
+    client = _client(_mock_session(json_body={}, status=500))
+    snap = await client.fetch()
+    assert snap.fetch_failure_reason == "http_500"
+    assert snap.models == ()
+
+
+@pytest.mark.asyncio
+async def test_fetch_http_429_rate_limit(isolated_cache: Path) -> None:
+    client = _client(_mock_session(json_body={}, status=429))
+    snap = await client.fetch()
+    assert snap.fetch_failure_reason == "http_429"
+
+
+@pytest.mark.asyncio
+async def test_fetch_timeout(isolated_cache: Path) -> None:
+    client = _client(_mock_session(raise_exc=asyncio.TimeoutError()))
+    snap = await client.fetch()
+    assert snap.fetch_failure_reason == "timeout"
+    assert snap.models == ()
+
+
+@pytest.mark.asyncio
+async def test_fetch_transport_error(isolated_cache: Path) -> None:
+    """Generic transport-level exception (DNS, conn reset, etc.)."""
+    client = _client(_mock_session(raise_exc=RuntimeError("connection reset")))
+    snap = await client.fetch()
+    assert snap.fetch_failure_reason is not None
+    assert "RuntimeError" in snap.fetch_failure_reason
+
+
+@pytest.mark.asyncio
+async def test_fetch_malformed_json_body(isolated_cache: Path) -> None:
+    """``body`` is not a dict or list → empty snapshot with reason
+    NOT raising on the parse path. (We test the parser separately;
+    here we ensure the client returns something usable.)"""
+    client = _client(_mock_session(json_body="just a string"))
+    snap = await client.fetch()
+    # Body wasn't a dict/list, parser returned () — but fetch
+    # itself succeeded (200 OK), so this is a "valid empty" outcome.
+    assert snap.fetch_failure_reason is None
+    assert snap.models == ()
+
+
+# ===========================================================================
+# §9 — fetch() failure with no cache → empty snapshot, not exception
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_failure_no_cache_returns_empty(
+    isolated_cache: Path,
+) -> None:
+    """First-ever fetch fails, no cache exists yet → empty snapshot."""
+    assert not isolated_cache.exists()
+    client = _client(_mock_session(raise_exc=RuntimeError("conn refused")))
+    snap = await client.fetch()
+    assert snap.fetch_failure_reason is not None
+    assert snap.models == ()
+
+
+@pytest.mark.asyncio
+async def test_fetch_failure_with_cache_returns_cached(
+    isolated_cache: Path,
+) -> None:
+    """Cached snapshot exists, live fetch fails → return cache with
+    failure_reason annotated."""
+    # Pre-populate cache
+    cached = CatalogSnapshot(
+        fetched_at_unix=1234567890.0,
+        models=(ModelCard(
+            model_id="cached/model-7B", family="cached",
+            parameter_count_b=7.0, context_window=None,
+            pricing_in_per_m_usd=None, pricing_out_per_m_usd=None,
+            supports_streaming=True, raw_metadata_json="{}",
+        ),),
+    )
+    save_snapshot(cached)
+
+    client = _client(_mock_session(raise_exc=RuntimeError("dns failure")))
+    snap = await client.fetch()
+    # Failure reason populated, but models came from cache
+    assert snap.fetch_failure_reason is not None
+    assert len(snap.models) == 1
+    assert snap.models[0].model_id == "cached/model-7B"
+    # fetched_at_unix preserved from cache (not the failure moment)
+    assert snap.fetched_at_unix == 1234567890.0
+
+
+# ===========================================================================
+# §10 — cached() + stale()
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_cached_returns_none_with_no_cache(
+    isolated_cache: Path,
+) -> None:
+    client = _client(_mock_session({"data": []}))
+    assert client.cached() is None
+
+
+@pytest.mark.asyncio
+async def test_cached_loads_from_disk_on_first_call(
+    isolated_cache: Path,
+) -> None:
+    snap = CatalogSnapshot(
+        fetched_at_unix=time.time(), models=(),
+    )
+    save_snapshot(snap)
+    client = _client(_mock_session({"data": []}))
+    loaded = client.cached()
+    assert loaded is not None
+
+
+@pytest.mark.asyncio
+async def test_cached_uses_memory_after_fetch(
+    isolated_cache: Path,
+) -> None:
+    """After fetch(), cached() returns the in-memory snapshot."""
+    body = {"data": [{"id": "x/model-7B"}]}
+    client = _client(_mock_session(body))
+    fetched = await client.fetch()
+    assert client.cached() is fetched  # same object identity
+
+
+def test_stale_when_no_cache(isolated_cache: Path) -> None:
+    client = _client(_mock_session({"data": []}))
+    assert client.stale() is True
+
+
+def test_stale_returns_false_for_fresh_snapshot(
+    isolated_cache: Path,
+) -> None:
+    snap = CatalogSnapshot(fetched_at_unix=time.time(), models=())
+    save_snapshot(snap)
+    client = _client(_mock_session({"data": []}))
+    assert client.stale(max_age_s=3600) is False
+
+
+def test_stale_returns_true_for_old_snapshot(
+    isolated_cache: Path,
+) -> None:
+    snap = CatalogSnapshot(
+        fetched_at_unix=time.time() - 10000, models=(),
+    )
+    save_snapshot(snap)
+    client = _client(_mock_session({"data": []}))
+    assert client.stale(max_age_s=3600) is True
+
+
+# ===========================================================================
+# §11 — Source-level pins
+# ===========================================================================
+
+
+def test_source_fetch_uses_try_except() -> None:
+    """fetch() must wrap network calls in try/except — Zero-Trust §4
+    requires it never raise to the caller. Pins the contract source-
+    level so a future refactor can't silently drop the safety net."""
+    import inspect
+    src = inspect.getsource(DwCatalogClient.fetch)
+    assert "try:" in src
+    assert "except asyncio.TimeoutError" in src
+    assert "except Exception" in src
+    # Both failure paths must call the fallback helper (returns
+    # cached snapshot or empty snapshot — never raises).
+    assert "_failure_fallback" in src
+
+
+def test_source_failure_fallback_prefers_cache() -> None:
+    """The failure-fallback helper must check the cache before
+    returning an empty snapshot. Pins Zero-Trust §4: ``Catalog API
+    down → fall back to a cached catalog``."""
+    import inspect
+    src = inspect.getsource(DwCatalogClient._failure_fallback)
+    cache_idx = src.index("self.cached()")
+    empty_idx = src.index("models=()")
+    assert cache_idx < empty_idx, (
+        "Failure fallback must check cache before returning empty"
+    )
+
+
+def test_source_no_top_level_yaml_imports() -> None:
+    """Slice A is catalog discovery — MUST NOT import provider_topology
+    or YAML helpers (those are Slice C wiring concerns). Check only
+    actual ``import`` lines, not docstring mentions."""
+    import inspect
+    src = inspect.getsource(dcc)
+    import_lines = [
+        ln for ln in src.splitlines()
+        if ln.strip().startswith(("import ", "from "))
+    ]
+    blob = "\n".join(import_lines)
+    assert "provider_topology" not in blob
+    assert "brain_selection_policy" not in blob
+    assert "topology_sentinel" not in blob


### PR DESCRIPTION
## Summary

Phase 12 begins replacing the hardcoded `dw_models:` arrays in `brain_selection_policy.yaml` with live `/models` discovery + algorithmic route assignment + adaptive probing. Slice A delivers the catalog discovery primitive (pure data collector — no dispatcher integration yet).

## Why now

The 2026-04-27 sentinel-on battle-test (session `bt-2026-04-27-235708`) proved two things:

1. **Cascade contract holds** — 44 BG ops queued cleanly with **\$0.00 Claude cascade** despite both ranked DW models (Qwen3.6-35B, Kimi-K2.6) failing with `live_transport RuntimeError`. The `fallback_tolerance: queue` invariant from `project_bg_spec_sealed.md` survives the sentinel-driven dispatch path verbatim.
2. **DW exposes 22 models on endpoint, we wire 8** — `[SemanticTriage] Model verified: google/gemma-4-31B-it is available (22 models on endpoint)`. The hardcoded YAML lists are 14 models behind reality.

## What ships

| Component | Lines | Purpose |
|---|---|---|
| `dw_catalog_client.py` | 416 | Pure data collector |
| `test_dw_catalog_client.py` | 612 | 59 regression pins |
| `phase_12_dynamic_dw_catalog_spec.md` | 532 | 5-slice arc spec |

### `ModelCard` (frozen dataclass)
- Required: `model_id` (anything else → `None` from `from_api_dict`)
- Optional: `parameter_count_b`, `context_window`, `pricing_in/out_per_m_usd`, `supports_streaming`
- Heuristic param-count parse from id (regex `(\d+(?:\.\d+)?)B`) when API doesn't expose it
- `has_ambiguous_metadata()` — Zero-Trust §3.6 quarantine signal

### `CatalogSnapshot` (frozen dataclass)
- `schema_version=\"dw_catalog.1\"`, version-mismatched cache → treated as missing
- `to_json` / `from_json` round-trip; malformed entries skipped, valid ones loaded
- `is_fresh(max_age_s)` for staleness gating

### `DwCatalogClient.fetch()`
- Accepts OpenAI-compat `{\"data\":[...]}` envelope OR bare list
- **NEVER raises** — every failure path (transport, JSON, http 5xx, timeout) returns either the cached snapshot with `fetch_failure_reason` populated OR an empty snapshot
- Disk cache at `.jarvis/dw_catalog.json` via atomic temp+rename (mirrored from `posture_store.py`)
- Caller owns the aiohttp session — reuses existing DoublewordProvider session for connection pool / DNS state consistency

## Zero-Trust amendment (operator-mandated 2026-04-27)

The original spec slotted ambiguous-metadata models into BACKGROUND. **The operator override**: ambiguous-metadata models are mathematically unsafe in BG — an unpriced 400B model in a continuous high-volume queue could bankrupt the system. Spec §3.6 now mandates:

- **SPECULATIVE-only quarantine** for any model with `parameter_count_b is None` AND `pricing_out_per_m_usd is None`
- **Prove-it promotion ledger** (`dw_promotion_ledger.json`): graduation to BACKGROUND requires 10 successful ops recorded with **every** latency ≤ 200ms (strict, not P95). Latency math is the proxy for size — small models respond faster
- **Demotion**: single failure during BG resets the ring buffer; model returns to SPECULATIVE
- **Cost ceiling on quarantine**: SPECULATIVE has hardcoded `cost_cap_usd` per op (~\$0.001), so even a ghost-model returning 100M tokens is capped structurally

## Master flag

`JARVIS_DW_CATALOG_DISCOVERY_ENABLED` defaults `false`. Flips `true` at Slice E graduation (after 3 forced-clean soak sessions on the dynamic source). Until then, this module is a pure side-effect — no dispatcher path consumes its output.

## Cost contract preservation

- `fallback_tolerance` (`queue` for BG/SPEC, `cascade_to_claude` for STANDARD/COMPLEX) stays YAML-authored — that's policy, not catalog
- The catalog only changes *which models try*; *what happens when they fail* stays under operator control
- New auto-discovered models entering BG/SPEC can never silently cascade to Claude

## Slicing plan

| Slice | Scope | Default flag state |
|---|---|---|
| **A (this PR)** | Catalog client + Zero-Trust quarantine signal | false |
| B | `DwCatalogClassifier` — deterministic ranker, eligibility gates, prove-it ledger | false |
| C | Sentinel preflight wires discovery in shadow mode (catalog populated, YAML still authoritative — diff diagnostics only) | false |
| D | Authority handoff: catalog primary, YAML fallback. Adaptive refresh task active | false |
| E | YAML purge + graduation flip. Hot-revert via `JARVIS_DW_CATALOG_DISCOVERY_ENABLED=false` | **true** |

## Test plan

- [x] Slice A tests: `tests/governance/test_dw_catalog_client.py` — 59/59 green
- [x] Master flag default-off (parametrized truthy/falsy/empty)
- [x] ModelCard parsing — id-required, both pricing shapes, optional fields, raw metadata preservation, invalid-pricing rejection
- [x] Parameter-count regex — Qwen/Gemma id heuristics + conservative None for ambiguous
- [x] Zero-Trust §3.6 ambiguous detection (param-count alone OR pricing alone is sufficient signal)
- [x] CatalogSnapshot JSON round-trip incl. schema-version mismatch + malformed-entry-skip
- [x] Disk cache atomic write + parent-dir creation + corrupt-cache → None
- [x] `fetch()` clean path (OpenAI envelope, bare list, 22-model simulation)
- [x] `fetch()` failure paths: http 5xx, http 429, asyncio.TimeoutError, generic transport — **all NEVER raise**, `fetch_failure_reason` populated
- [x] `fetch()` failure with cache → returns cached snapshot with failure_reason annotation; without cache → empty snapshot
- [x] `cached()` + `stale()` lazy disk hydration + max_age threshold
- [x] Source-level pins: `fetch()` uses try/except, `_failure_fallback` checks cache before empty, no top-level imports of `provider_topology` / `brain_selection_policy` / `topology_sentinel`

## Out of scope (deferred to later slices)

- Classifier (Slice B owns the route → ranked-list logic)
- Sentinel integration (Slice C)
- Background refresh task (Slice D)
- YAML purge (Slice E)
- Per-model performance feedback into ranking (post-Phase-12 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces live DW catalog discovery as a standalone client with a Zero-Trust quarantine signal, laying groundwork to replace hardcoded YAML model lists. Default-off and not wired to dispatch yet.

- New Features
  - Added `DwCatalogClient` to fetch `/models` (OpenAI-style `{"data":[]}` or bare list), parse to `ModelCard`s, and return a `CatalogSnapshot` that never raises; failures return cached or empty snapshots with a reason.
  - Implemented frozen `ModelCard`/`CatalogSnapshot` with param-count heuristic from IDs (e.g., `-31B`), JSON round-trip, freshness checks, and `has_ambiguous_metadata()` for quarantine.
  - Disk cache at `.jarvis/dw_catalog.json` with atomic writes; lazy in-memory hydration and staleness gating.
  - Zero-Trust rule: models missing both `parameter_count_b` and `pricing_out_per_m_usd` are quarantined for SPECULATIVE-only (promotion ledger arrives in a later slice).
  - Flag `JARVIS_DW_CATALOG_DISCOVERY_ENABLED` controls usage (default false). Spec added at `docs/architecture/phase_12_dynamic_dw_catalog_spec.md`. Tests cover fetch paths, cache, parsing, and failure handling.

<sup>Written for commit ee0c5de61c8fb4834978548364b73915a33bb82f. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/26524?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

