### PR TITLE
Phase 12 Slice B: DwCatalogClassifier + PromotionLedger + 12.2 blueprint

### DIFF
--- a/docs/architecture/phase_12_2_physics_aware_topology_blueprint.md
+++ b/docs/architecture/phase_12_2_physics_aware_topology_blueprint.md
@@ -1,0 +1,227 @@
+# Phase 12.2 — Physics-Aware Topology Routing
+
+**Status:** BLUEPRINT (DRAFT) — implementation pending Phase 12 Slice E graduation
+**Mandate:** [ARCHITECTURAL DIRECTIVE: PHYSICS-AWARE TOPOLOGY ROUTING] (2026-04-27)
+**Premise:** DoubleWord is a decentralized hostile mesh of GPU spot instances, not a monolithic endpoint. Sentinel must physically model the infrastructure dynamically.
+
+## 1. Why this exists
+
+Phase 12 (Dynamic Catalog Discovery) gives us *which* models exist. Phase 12.2 gives us *which models are actually usable right now* against the physical reality of DW's infrastructure:
+
+- **VRAM evictions** masquerade as stream-stalls (the L2 Cache Illusion)
+- **Cold-storage NVMe loads** masquerade as random latency spikes
+- **Multi-tenant queuing collapses** masquerade as transient transport errors
+
+Static `block_mode` decisions and exponential-backoff retries treat all three as the same failure mode. They are not. Phase 12.2 distinguishes them via live telemetry, then routes around each one differently.
+
+## 2. Three mechanisms
+
+### 2.1 Deep VRAM Probing (defeats the L2 Cache Illusion)
+
+**The flaw**: A 1-token sentinel ping verifies network connectivity. It tests TCP, TLS, auth, request validation, the SSE handshake — and almost nothing else. A 1-token response fits in the GPU's L2 cache; the model weights don't even need to be loaded into HBM. A node that's been evicted from VRAM (because another tenant's payload took priority) **still passes the 1-token probe** while being completely unable to serve a real PLAN-EXPLOIT payload.
+
+**The fix**: A staggered "Heavy Probe" — synthetic 500-token completion request — issued asynchronously to a random subset of registered DW models during idle cadences. Heavy probes verify VRAM allocation, not just connectivity.
+
+**Specification**:
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `JARVIS_TOPOLOGY_HEAVY_PROBE_RATIO` | `0.2` | Fraction of probes that are heavy (already in YAML monitor block) |
+| `JARVIS_TOPOLOGY_HEAVY_PROBE_TOKENS` | `500` | Output token count for synthetic payload |
+| `JARVIS_TOPOLOGY_HEAVY_PROBE_INPUT_CHARS` | `2000` | Input prompt size (synthetic, fixed-content lorem-style filler so cache hits don't cheat the test) |
+| `JARVIS_TOPOLOGY_HEAVY_PROBE_TIMEOUT_S` | `30` | Hard timeout — heavy probe must produce ≥500 tokens within this window |
+| `JARVIS_TOPOLOGY_VRAM_CONSTRAINED_FAILURE_WEIGHT` | `5.0` | Failure source weight for `LIVE_VRAM_CONSTRAINED` (higher than `LIVE_STREAM_STALL=3.0` so a single heavy-fail trips the breaker) |
+
+**New `FailureSource` value**: `LIVE_VRAM_CONSTRAINED`. A node that passes a 1-token light probe within the same 60-second window but fails the heavy probe is **proven** VRAM-constrained — the contradiction itself is the evidence. The breaker for that `model_id` flips to OPEN with `failure_source=LIVE_VRAM_CONSTRAINED`. Distinguished from `LIVE_STREAM_STALL` so post-incident review can tell "the network broke" from "the GPU evicted us."
+
+**Probe scheduling**:
+- Heavy probes are NOT every-cycle — that would be wasteful (~$0.001 per probe on Qwen3.5-9B). At `heavy_probe_ratio=0.2`, every 5th sentinel probe is heavy
+- Per-model heavy-probe cadence: minimum 5 minutes between consecutive heavy probes against the same `model_id`. Prevents accidentally DOSing a recovering node
+- Heavy probes only fire during sentinel's existing `probe_interval_healthy_s=30` cadence — no new background task needed; just an upgraded payload class
+
+**Code seam**: extends `topology_sentinel.py:_probe_endpoint()`. The existing probe path issues a 1-token request via the DW provider; Phase 12.2 adds a `_probe_endpoint_heavy()` variant that's selected randomly per cycle. The async dispatch is already there — only the request shape changes.
+
+**Cost guard**: Heavy probes are gated by `cost_governor.py` like any other DW call. A misbehaving probe loop can't burn the daily budget because the heavy probe inherits the SPECULATIVE cost cap (~$0.001/op).
+
+### 2.2 TTFT Cold-Storage Detection (Dynamic Quarantine)
+
+**The flaw**: When DW's scheduler routes us to a model whose weights haven't been used recently, the inference node has to load 30–400 GB from NVMe SSD into HBM before it can produce the first token. This is a one-time per-cold-start ~30–120 second penalty that masquerades as "the request hung." Static timeout thresholds either fail-fast (incorrectly evicting a model that would have worked in 60s) or fail-slow (giving up after 180s when the model never had a chance).
+
+**The fix**: Per-`model_id` Time-To-First-Token tracking with a moving-average + standard-deviation gate. When TTFT exceeds the dynamic statistical threshold, the model is **mathematically proven** to be in cold storage — and we don't speculate about why. We demote.
+
+**Specification**:
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `JARVIS_TOPOLOGY_TTFT_WINDOW_N` | `20` | Rolling sample size — needs enough data for stable statistics |
+| `JARVIS_TOPOLOGY_TTFT_STDDEV_THRESHOLD` | `2.0` | Deviation in σ above mean that triggers cold-storage demotion |
+| `JARVIS_TOPOLOGY_TTFT_MIN_SAMPLES` | `5` | Cold-start guard — won't demote until window has at least N samples |
+| `JARVIS_TOPOLOGY_TTFT_DEMOTION_DURATION_S` | `300` | How long a cold-storage demotion lasts before re-evaluation |
+| `JARVIS_TOPOLOGY_TTFT_RECOVERY_RATIO` | `0.5` | Demotion lifts when latest TTFT ≤ 50% of pre-demotion mean (warm-up confirmed) |
+
+**New module**: `dw_ttft_observer.py`
+
+```python
+@dataclass(frozen=True)
+class TtftSample:
+    model_id: str
+    ttft_ms: int
+    sample_unix: float
+    op_id: str
+
+class TtftObserver:
+    """Per-model TTFT statistical tracker. Owns the rolling sample
+    buffer, computes mean + stddev on demand, fires demotion events
+    when statistical threshold crosses.
+
+    Pure observer — does NOT route, does NOT demote. Emits events
+    that the dispatcher consumes via TrinityEventBus."""
+
+    def record_ttft(self, model_id: str, ttft_ms: int, op_id: str) -> None: ...
+    def stats(self, model_id: str) -> Optional[TtftStats]: ...
+    def is_cold_storage(self, model_id: str) -> bool: ...
+    def cold_storage_models(self) -> Tuple[str, ...]: ...
+```
+
+**Statistical gate** (re-evaluated on every record_ttft):
+
+```
+if window_size >= MIN_SAMPLES:
+    mean, stddev = compute(window[-WINDOW_N:])
+    threshold = mean + STDDEV_THRESHOLD * stddev
+    if latest_ttft > threshold:
+        emit_event(dw_cold_storage_detected, model_id, ttft_ms, threshold)
+        demote_until = now + DEMOTION_DURATION_S
+```
+
+**Why standard deviation, not absolute threshold**: a 2-second TTFT on a 4B model is cold-storage; on a 397B model it's normal warm operation. Statistical thresholds adapt to each model's baseline automatically — exactly what Zero-Order static thresholds can't do.
+
+**Demotion semantics**:
+- Cold-storage demotion ≠ promotion-ledger demotion. The promotion ledger is for ambiguous-metadata graduation (Phase 12 Slice B). Cold-storage demotion is a **temporary route override** — the model goes to SPECULATIVE for `DEMOTION_DURATION_S` seconds, then auto-recovers if its post-demotion TTFT samples normalize
+- Distinguished events: `dw_model_cold_storage_demoted` vs `dw_model_promotion_demoted`. Different SSE event types; observers can react differently
+- The classifier (Phase 12 Slice B) receives a `cold_storage_models` set when classifying; those models are temporarily excluded from BG/STANDARD/COMPLEX assignments and pinned to SPECULATIVE — same surface as quarantine but with an expiration timestamp
+
+**Code seam**: TTFT measurement already exists in `doubleword_provider.py` SSE stream — first chunk arrival timestamp minus request send timestamp. Currently we discard it; Phase 12.2 wires it through to `TtftObserver.record_ttft()`. Single-line change at the provider; the observer module is the new code.
+
+### 2.3 Full-Jitter Backoff (defeats Little's Law thundering herd)
+
+**The flaw**: Exponential backoff with exact base intervals (10s, 20s, 40s, 80s, 160s) means every client retrying the same endpoint synchronizes at the same offsets. After a DW outage, a thousand instances of similar agentic systems all retry at exactly t+10s, then t+30s, then t+70s — creating retry pulses that crash the recovered endpoint immediately. This is Little's Law's revenge: queue depth = arrival rate × service time, and synchronized arrival pulses mean the queue depth blows past the server's capacity instantly.
+
+**The fix**: Full-jitter exponential backoff. Every retry delay is a random uniform sample from `[0, base * 2^attempt]`. The waveform is desynchronized — our retries fall into the micro-gaps of DW's queue backlog instead of stacking on the herd's wavefronts.
+
+**Specification**:
+
+```python
+def full_jitter_backoff_s(
+    attempt: int,
+    *,
+    base_s: float = 10.0,
+    cap_s: float = 300.0,
+    rng: Optional[random.Random] = None,
+) -> float:
+    """Returns a random delay in [0, min(cap_s, base_s * 2**attempt)].
+    Pure function. No state. NEVER raises."""
+    rng = rng or random
+    upper = min(cap_s, base_s * (2 ** max(0, attempt)))
+    return rng.uniform(0.0, upper)
+```
+
+**Where it applies (every retry site)**:
+1. `topology_sentinel.py` — `CircuitBreaker` HALF_OPEN probe schedule (currently `probe_backoff_base_s=10.0` exact-exponential, Phase 12.2 replaces with full-jitter)
+2. `doubleword_provider.py` — provider-level retries on transient HTTP 5xx / 429 / connection reset
+3. `candidate_generator.py` — between sentinel-driven model rotation attempts (today: no inter-attempt delay; Phase 12.2 inserts a small full-jittered delay between attempts on the same op to avoid rapid-fire pounding when DW is under load)
+4. `batch_future_registry.py` — DW Tier 1 webhook adaptive poll fallback (already has retry; just upgrade to full-jitter)
+
+**Single source-of-truth helper**: `backend/core/ouroboros/governance/full_jitter.py` (~30 lines including tests). Every callsite imports + calls one function. Eliminates the chance that one component drifts to exact-backoff while another is jittered.
+
+**Determinism for tests**: `full_jitter_backoff_s` accepts an optional `rng=random.Random(seed)` parameter so test suites can pin specific delay sequences without mocking `random.uniform`.
+
+**Knob**:
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `JARVIS_TOPOLOGY_BACKOFF_BASE_S` | `10.0` | Base delay (already in YAML monitor block) |
+| `JARVIS_TOPOLOGY_BACKOFF_CAP_S` | `300.0` | Maximum delay regardless of attempt count |
+| `JARVIS_TOPOLOGY_FULL_JITTER_ENABLED` | `false` → `true` at graduation | Master flag for hot-revert if jitter introduces unforeseen issues |
+
+## 3. Slicing plan (4 slices, all defaults false until graduation)
+
+### Slice 12.2.A — Full-jitter helper + retrofit (lowest risk, highest leverage)
+- New module `full_jitter.py` (~30 lines + 25 tests)
+- Replace exact-exponential backoff at all 4 retry sites
+- Master flag `JARVIS_TOPOLOGY_FULL_JITTER_ENABLED` (default false)
+- Behavioral test: with seed=1, generated delay sequence matches a pinned expected list (determinism contract)
+- **Why first**: simplest mechanism, no new state, no statistical complexity. Lands the desync win immediately
+
+### Slice 12.2.B — TTFT observer module
+- New module `dw_ttft_observer.py` (~200 lines + 35 tests)
+- Provider wiring: 1-line change in `doubleword_provider.py` SSE stream to call `observer.record_ttft()` on first chunk
+- TTFT samples persisted to disk via atomic write (mirrors posture_store pattern; survives restart for stable statistics across boots)
+- Master flag `JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED` (default false)
+- **No demotion yet** — Slice 12.2.B is observer-only. Slice 12.2.C consumes the observer's output
+
+### Slice 12.2.C — TTFT cold-storage demotion wiring
+- Classifier extension: accepts cold_storage_models() from observer, excludes them from BG/STANDARD/COMPLEX assignments
+- Sentinel extension: emits `dw_model_cold_storage_demoted` / `dw_model_cold_storage_recovered` events
+- Auto-recovery: when post-demotion TTFT samples normalize (latest ≤ 50% of pre-demotion mean), demotion lifts
+- Master flag `JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED` (default false)
+
+### Slice 12.2.D — Heavy probe (defeats L2 Cache Illusion)
+- Sentinel extension: `_probe_endpoint_heavy()` variant, gated by heavy_probe_ratio (already in YAML — just operationalize the existing knob)
+- New `FailureSource.LIVE_VRAM_CONSTRAINED` enum value
+- Per-model heavy-probe cadence ledger (5-minute minimum between consecutive heavy probes)
+- Cost guard via existing `cost_governor.py`
+- Master flag `JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED` (default false)
+
+### Slice 12.2.E — Graduation flip
+- All four flags flip default false → true
+- Graduation pin suite (mirrors Phase 11 Slice 11.7 pattern):
+  - Hot-revert per-flag matrix
+  - Defaults-true assertions
+  - Master-off legacy preservation
+- 3 forced-clean soak sessions before flip
+
+## 4. Failure modes & cost contract
+
+| Scenario | Phase 12.2 behavior | Cost contract |
+|---|---|---|
+| All DW models in cold storage | Statistical observer demotes all to SPECULATIVE; sentinel falls through to YAML or cascades per `fallback_tolerance` | BG/SPEC stay queue-only; no Claude cascade |
+| Heavy probe budget overrun | `cost_governor` caps the probe; sentinel skips heavy probe for that cycle | No surprise spend; light probes still run |
+| Full-jitter introduces a longer-than-exact delay | Single retry takes longer; total recovery time still bounded by `cap_s=300s` | No cost impact; latency variance increases |
+| TTFT observer disk-cache corrupt | Observer treats as missing → samples re-accumulate from boot; statistical gate uses fewer samples until window fills | Soft degradation; no cost impact |
+| Heavy probe payload triggers a new VRAM eviction | The breaker that caught the eviction is the same one that would have caught the eviction during a real PLAN-EXPLOIT payload — heavy probe IS the canary it claims to be | Heavy probe cost capped by SPECULATIVE budget |
+
+## 5. Why these three together
+
+Each mechanism, alone, partially fixes one failure mode:
+
+- VRAM probing alone: catches L2 cache illusion but doesn't distinguish cold-storage from genuine outages
+- TTFT observer alone: catches cold-storage but routes to nodes that pass TTFT yet stream-stall mid-response (VRAM eviction during generation)
+- Full-jitter alone: prevents thundering-herd amplification but doesn't help when the single endpoint we're hitting is genuinely cold
+
+Together they form a **physics-faithful model of the DW infrastructure**: connectivity (light probe) + VRAM allocation (heavy probe) + warm-vs-cold weights (TTFT observer) + queue desync (full-jitter). The dispatcher reasons about each layer separately and routes around each failure mode with the correct response.
+
+## 6. Out of scope (deferred)
+
+- **Multi-region DW endpoint discovery**: today we hit one base URL. If DW exposes a regional health endpoint, we'd add per-region load balancing. Not in 12.2.
+- **Tenant-aware backoff**: full-jitter is desync-by-randomness. Coordinating with DW to expose explicit retry-after headers would be deterministic but requires their cooperation. Not in 12.2.
+- **GPU memory pressure SSE stream**: if DW exposes a server-pushed pressure indicator, we could pre-emptively demote without waiting for stream-stall evidence. Not in 12.2.
+- **Adaptive heavy-probe ratio**: today static at 0.2. A future arc could dynamically increase the ratio when a node has recent failures and decrease when stable. Not in 12.2.
+
+## 7. Verification protocol
+
+Each slice closes with:
+
+1. Unit tests green
+2. Combined regression (existing topology_sentinel + provider_topology + candidate_generator suites)
+3. Live-fire battle test session with the new flag enabled, observing the new event types in the debug log
+4. Cost contract verification: BG/SPEC must stay $0.00 on Claude cascade across the soak
+
+Slice 12.2.E graduation requires:
+- 3 consecutive sessions with at least 1 `dw_model_cold_storage_recovered` event (proves the auto-recovery path actually fires)
+- 3 consecutive sessions with at least 1 `LIVE_VRAM_CONSTRAINED` breaker trip OR sustained pass (proves heavy probe is exercising the path, not silently no-op)
+- Zero `full_jitter_invariant_violation` events (any retry without jitter is a regression)
+
+## 8. The honest architectural read
+
+The TopologySentinel was built assuming a stable, monolithic endpoint. Phase 12.2 is the operator's correction: DW is a hostile mesh of spot instances, and the sentinel needs to model that physics natively. The three mechanisms (VRAM probe, TTFT statistical gate, full-jitter backoff) are not features — they are the architectural debt of pretending GPU clusters are ATMs that always have cash. They were Zero-Order workarounds in disguise. Phase 12.2 makes them First-Order.

--- a/tests/governance/test_dw_catalog_classifier.py
+++ b/tests/governance/test_dw_catalog_classifier.py
@@ -1,0 +1,589 @@
+"""Phase 12 Slice B — DwCatalogClassifier regression spine.
+
+Pins:
+  §1 Empty snapshot → empty per-route assignments (no exceptions)
+  §2 Determinism — same input + env → bit-for-bit identical output
+  §3 Eligibility gates — COMPLEX min params, STANDARD min params + max price,
+                          BG max price, SPEC max price, IMMEDIATE always empty
+  §4 Ranking — params weight (COMPLEX/STANDARD), pricing weight (BG/SPEC),
+               family bonus, context window
+  §5 Tie-break by alphabetical model_id (stable secondary sort)
+  §6 Zero-Trust §3.6 — ambiguous-metadata models pinned to SPECULATIVE only
+  §7 Newly-quarantined models surface in ClassificationOutcome
+  §8 Promoted-from-quarantine models eligible for non-SPEC routes
+  §9 Demoted models (post-promotion failure) re-pinned to SPECULATIVE
+  §10 Env-tunable weights + family preferences
+  §11 Pure function — does NOT mutate ledger
+  §12 22-model real-world simulation (mirrors bt-2026-04-27-235708 catalog size)
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, List, Tuple  # noqa: F401
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_catalog_client import (
+    CatalogSnapshot, ModelCard,
+)
+from backend.core.ouroboros.governance.dw_catalog_classifier import (
+    ClassificationOutcome,
+    DwCatalogClassifier,
+    EligibilityGate,
+    RouteAssignment,
+    gate_for_route,
+)
+from backend.core.ouroboros.governance.dw_promotion_ledger import (
+    PromotionLedger,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_ledger(tmp_path: Path,
+                    monkeypatch: pytest.MonkeyPatch) -> PromotionLedger:
+    monkeypatch.setenv(
+        "JARVIS_DW_PROMOTION_LEDGER_PATH",
+        str(tmp_path / "ledger.json"),
+    )
+    led = PromotionLedger()
+    led.load()
+    return led
+
+
+def _card(
+    model_id: str,
+    *,
+    family: str = "auto",
+    params_b: float = None,  # type: ignore[assignment]
+    ctx: int = None,         # type: ignore[assignment]
+    in_price: float = None,  # type: ignore[assignment]
+    out_price: float = None, # type: ignore[assignment]
+    streaming: bool = True,
+) -> ModelCard:
+    if family == "auto":
+        family = model_id.split("/", 1)[0].lower() if "/" in model_id else "unknown"
+    return ModelCard(
+        model_id=model_id,
+        family=family,
+        parameter_count_b=params_b,
+        context_window=ctx,
+        pricing_in_per_m_usd=in_price,
+        pricing_out_per_m_usd=out_price,
+        supports_streaming=streaming,
+        raw_metadata_json="{}",
+    )
+
+
+def _snapshot(*models: ModelCard) -> CatalogSnapshot:
+    return CatalogSnapshot(fetched_at_unix=1.0, models=tuple(models))
+
+
+# ---------------------------------------------------------------------------
+# §1 — Empty snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_empty_snapshot_returns_empty_assignments(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    classifier = DwCatalogClassifier()
+    outcome = classifier.classify(_snapshot(), isolated_ledger)
+    for route in ("complex", "standard", "background", "speculative"):
+        assert outcome.for_route(route) == ()
+    assert outcome.newly_quarantined == ()
+
+
+# ---------------------------------------------------------------------------
+# §2 — Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_classify_is_deterministic(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    snap = _snapshot(
+        _card("vendor-a/m-50B", params_b=50.0, out_price=0.30),
+        _card("vendor-b/m-30B", params_b=30.0, out_price=0.20),
+        _card("vendor-c/m-70B", params_b=70.0, out_price=0.40),
+    )
+    classifier = DwCatalogClassifier()
+    o1 = classifier.classify(snap, isolated_ledger)
+    o2 = classifier.classify(snap, isolated_ledger)
+    o3 = classifier.classify(snap, isolated_ledger)
+    for r in ("complex", "standard", "background", "speculative"):
+        assert o1.for_route(r) == o2.for_route(r) == o3.for_route(r)
+
+
+# ---------------------------------------------------------------------------
+# §3 — Eligibility gates
+# ---------------------------------------------------------------------------
+
+
+def test_complex_excludes_below_min_params(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    snap = _snapshot(
+        _card("v/small-7B", params_b=7.0, out_price=0.05),
+        _card("v/big-50B", params_b=50.0, out_price=0.50),
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    assert "v/small-7B" not in outcome.for_route("complex")
+    assert "v/big-50B" in outcome.for_route("complex")
+
+
+def test_standard_excludes_above_max_price(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    snap = _snapshot(
+        _card("v/cheap-30B", params_b=30.0, out_price=0.50),
+        _card("v/pricey-30B", params_b=30.0, out_price=5.00),  # over $2
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    assert "v/cheap-30B" in outcome.for_route("standard")
+    assert "v/pricey-30B" not in outcome.for_route("standard")
+
+
+def test_background_excludes_above_max_price(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    snap = _snapshot(
+        _card("v/cheap-7B", params_b=7.0, out_price=0.30),
+        _card("v/medium-7B", params_b=7.0, out_price=0.80),  # over $0.50
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    assert "v/cheap-7B" in outcome.for_route("background")
+    assert "v/medium-7B" not in outcome.for_route("background")
+
+
+def test_speculative_excludes_above_max_price(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    snap = _snapshot(
+        _card("v/ultra-1B", params_b=1.0, out_price=0.05),
+        _card("v/medium-1B", params_b=1.0, out_price=0.30),  # over $0.10
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    assert "v/ultra-1B" in outcome.for_route("speculative")
+    assert "v/medium-1B" not in outcome.for_route("speculative")
+
+
+def test_immediate_always_empty(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    """IMMEDIATE is Claude-direct by Manifesto §5 — classifier must
+    NEVER populate it."""
+    snap = _snapshot(
+        _card("v/big-100B", params_b=100.0, out_price=0.10),
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    # IMMEDIATE not in the assignments at all (only generative routes)
+    assert "immediate" not in outcome.assignments
+    assert outcome.for_route("immediate") == ()
+
+
+def test_eligibility_gate_admits_function() -> None:
+    gate = EligibilityGate(
+        min_params_b=14.0,
+        max_out_price_per_m=2.0,
+    )
+    assert gate.admits(_card("ok/14B", params_b=14.0, out_price=1.0))
+    assert not gate.admits(_card("too-small/7B", params_b=7.0, out_price=1.0))
+    assert not gate.admits(_card("too-pricey/14B", params_b=14.0, out_price=3.0))
+    # Missing param count → fails min_params_b gate (>0 required)
+    assert not gate.admits(_card("ambiguous/m"))
+
+
+# ---------------------------------------------------------------------------
+# §4 — Ranking
+# ---------------------------------------------------------------------------
+
+
+def test_complex_ranks_larger_models_higher(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    snap = _snapshot(
+        _card("v/m-30B", params_b=30.0, out_price=1.0),
+        _card("v/m-100B", params_b=100.0, out_price=1.0),
+        _card("v/m-50B", params_b=50.0, out_price=1.0),
+    )
+    ranked = DwCatalogClassifier().classify(snap, isolated_ledger).for_route("complex")
+    # Largest first, smallest last
+    assert ranked == ("v/m-100B", "v/m-50B", "v/m-30B")
+
+
+def test_background_ranks_cheaper_models_higher(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    snap = _snapshot(
+        _card("v/m-7B", params_b=7.0, out_price=0.40),
+        _card("v/m-7B-cheap", params_b=7.0, out_price=0.10),
+        _card("v/m-7B-medium", params_b=7.0, out_price=0.25),
+    )
+    ranked = DwCatalogClassifier().classify(snap, isolated_ledger).for_route("background")
+    # Cheapest first
+    assert ranked[0] == "v/m-7B-cheap"
+
+
+def test_speculative_ranks_cheaper_models_higher(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    snap = _snapshot(
+        _card("v/m-1B-medium", params_b=1.0, out_price=0.08),
+        _card("v/m-1B-cheap", params_b=1.0, out_price=0.02),
+    )
+    ranked = DwCatalogClassifier().classify(snap, isolated_ledger).for_route("speculative")
+    assert ranked[0] == "v/m-1B-cheap"
+
+
+def test_context_window_breaks_ties_at_complex(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    """All else equal, larger context wins."""
+    snap = _snapshot(
+        _card("v/m-50B-narrow", params_b=50.0, out_price=1.0, ctx=8000),
+        _card("v/m-50B-wide", params_b=50.0, out_price=1.0, ctx=200_000),
+    )
+    ranked = DwCatalogClassifier().classify(snap, isolated_ledger).for_route("complex")
+    assert ranked[0] == "v/m-50B-wide"
+
+
+def test_family_bonus_breaks_ties(
+    isolated_ledger: PromotionLedger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_DW_FAMILY_PREFERENCE", "moonshotai:1.0")
+    snap = _snapshot(
+        _card("vendor-a/m-50B", params_b=50.0, out_price=1.0),
+        _card("moonshotai/Kimi-50B", params_b=50.0, out_price=1.0),
+    )
+    ranked = DwCatalogClassifier().classify(snap, isolated_ledger).for_route("complex")
+    assert ranked[0] == "moonshotai/Kimi-50B"
+
+
+# ---------------------------------------------------------------------------
+# §5 — Tie-break by alphabetical id
+# ---------------------------------------------------------------------------
+
+
+def test_alphabetical_tiebreak_when_scores_equal(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    """Two models with identical scores → alphabetical model_id order."""
+    snap = _snapshot(
+        _card("zebra/m-50B", params_b=50.0, out_price=1.0),
+        _card("apple/m-50B", params_b=50.0, out_price=1.0),
+        _card("mango/m-50B", params_b=50.0, out_price=1.0),
+    )
+    ranked = DwCatalogClassifier().classify(snap, isolated_ledger).for_route("complex")
+    assert ranked == ("apple/m-50B", "mango/m-50B", "zebra/m-50B")
+
+
+# ---------------------------------------------------------------------------
+# §6 — Zero-Trust §3.6 SPECULATIVE quarantine
+# ---------------------------------------------------------------------------
+
+
+def test_ambiguous_metadata_pinned_to_speculative_only(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    """A model with no params + no pricing must NOT appear in
+    BACKGROUND, STANDARD, or COMPLEX — operator-mandated 2026-04-27."""
+    snap = _snapshot(
+        _card("moonshotai/Kimi-K2.6"),  # both params and pricing absent
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    assert outcome.for_route("complex") == ()
+    assert outcome.for_route("standard") == ()
+    assert outcome.for_route("background") == ()
+    # Lands in SPECULATIVE despite no pricing
+    assert "moonshotai/Kimi-K2.6" in outcome.for_route("speculative")
+
+
+def test_ambiguous_quarantine_persists_when_ledger_already_knows(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    """Pre-quarantined model stays quarantined even on subsequent
+    classify() calls."""
+    isolated_ledger.register_quarantine("v/unknown-model")
+    snap = _snapshot(
+        _card("v/unknown-model"),  # ambiguous
+        _card("v/known-50B", params_b=50.0, out_price=1.0),
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    # Quarantined model only in SPECULATIVE
+    assert "v/unknown-model" in outcome.for_route("speculative")
+    for r in ("complex", "standard", "background"):
+        assert "v/unknown-model" not in outcome.for_route(r)
+
+
+def test_partial_metadata_avoids_quarantine(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    """A model with parameter count BUT no pricing → not ambiguous,
+    not quarantined. Just consider eligibility gates."""
+    snap = _snapshot(
+        _card("v/m-50B", params_b=50.0),  # no pricing, but param count present
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    # Has param_count, so not ambiguous → not auto-quarantined
+    assert outcome.newly_quarantined == ()
+
+
+# ---------------------------------------------------------------------------
+# §7 — Newly-quarantined surface
+# ---------------------------------------------------------------------------
+
+
+def test_newly_quarantined_returned_for_caller(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    snap = _snapshot(
+        _card("brand/new-unknown"),       # ambiguous, never seen
+        _card("v/known-50B", params_b=50.0, out_price=1.0),
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    assert outcome.newly_quarantined == ("brand/new-unknown",)
+
+
+def test_existing_quarantined_NOT_in_newly_list(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    """Already-known quarantined models don't re-surface."""
+    isolated_ledger.register_quarantine("brand/already-known")
+    snap = _snapshot(
+        _card("brand/already-known"),  # ambiguous + already in ledger
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    assert outcome.newly_quarantined == ()
+
+
+# ---------------------------------------------------------------------------
+# §8 — Promoted models cross route boundary
+# ---------------------------------------------------------------------------
+
+
+def test_promoted_model_eligible_for_background(
+    isolated_ledger: PromotionLedger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A promoted model with metadata that passes BG eligibility gate
+    appears in BACKGROUND."""
+    monkeypatch.setenv("JARVIS_DW_PROMOTION_MIN_SUCCESSES", "1")
+    isolated_ledger.register_quarantine("v/proven-7B")
+    isolated_ledger.record_success("v/proven-7B", 100)
+    isolated_ledger.promote("v/proven-7B")
+    # Even though it's in the ledger, classify should treat it like
+    # a regular model. Give it metadata that passes BG gate.
+    snap = _snapshot(
+        _card("v/proven-7B", params_b=7.0, out_price=0.30),
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    assert "v/proven-7B" in outcome.for_route("background")
+
+
+def test_promoted_model_still_blocked_by_eligibility_gate(
+    isolated_ledger: PromotionLedger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Promotion enables consideration; eligibility gates still apply.
+    A promoted 5B model still doesn't meet COMPLEX min_params_b=30."""
+    monkeypatch.setenv("JARVIS_DW_PROMOTION_MIN_SUCCESSES", "1")
+    isolated_ledger.register_quarantine("v/small-5B")
+    isolated_ledger.record_success("v/small-5B", 100)
+    isolated_ledger.promote("v/small-5B")
+    snap = _snapshot(
+        _card("v/small-5B", params_b=5.0, out_price=0.10),
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    assert "v/small-5B" not in outcome.for_route("complex")
+    # But fits BG (≤$0.5)
+    assert "v/small-5B" in outcome.for_route("background")
+
+
+# ---------------------------------------------------------------------------
+# §9 — Demoted models re-pinned to SPECULATIVE
+# ---------------------------------------------------------------------------
+
+
+def test_demoted_model_returns_to_speculative_only(
+    isolated_ledger: PromotionLedger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Promoted → record_failure → demoted → SPECULATIVE-only again."""
+    monkeypatch.setenv("JARVIS_DW_PROMOTION_MIN_SUCCESSES", "1")
+    isolated_ledger.register_quarantine("v/flaky-7B")
+    isolated_ledger.record_success("v/flaky-7B", 100)
+    isolated_ledger.promote("v/flaky-7B")
+    isolated_ledger.record_failure("v/flaky-7B")  # demotes
+    assert isolated_ledger.is_promoted("v/flaky-7B") is False
+    snap = _snapshot(
+        _card("v/flaky-7B", params_b=7.0, out_price=0.30),
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    # No longer in BG
+    assert "v/flaky-7B" not in outcome.for_route("background")
+
+
+# ---------------------------------------------------------------------------
+# §10 — Env-tunable weights + family preferences
+# ---------------------------------------------------------------------------
+
+
+def test_complex_min_params_env_override(
+    isolated_ledger: PromotionLedger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_DW_CLASSIFIER_COMPLEX_MIN_PARAMS_B", "100")
+    snap = _snapshot(
+        _card("v/m-50B", params_b=50.0, out_price=1.0),
+        _card("v/m-150B", params_b=150.0, out_price=1.0),
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    # 50B no longer passes the raised gate
+    assert "v/m-50B" not in outcome.for_route("complex")
+    assert "v/m-150B" in outcome.for_route("complex")
+
+
+def test_background_max_price_env_override(
+    isolated_ledger: PromotionLedger,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_DW_CLASSIFIER_BACKGROUND_MAX_OUT_PRICE", "1.0")
+    snap = _snapshot(
+        _card("v/m-7B", params_b=7.0, out_price=0.80),  # would normally exceed default
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+    assert "v/m-7B" in outcome.for_route("background")
+
+
+def test_family_preference_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple comma-separated families with varying weights parse
+    correctly, malformed tokens skipped silently."""
+    monkeypatch.setenv(
+        "JARVIS_DW_FAMILY_PREFERENCE",
+        "moonshotai:1.0,zai-org:0.8,not-a-pair,broken:not-a-float",
+    )
+    g = gate_for_route("complex")  # function under test reads env
+    # Direct access via module-private — sanity: no crash
+    from backend.core.ouroboros.governance.dw_catalog_classifier import (
+        _family_preference,
+    )
+    parsed = _family_preference()
+    assert parsed.get("moonshotai") == 1.0
+    assert parsed.get("zai-org") == 0.8
+    # Malformed tokens silently dropped
+    assert "not-a-pair" not in parsed
+    assert "broken" not in parsed
+
+
+# ---------------------------------------------------------------------------
+# §11 — Pure function — does NOT mutate ledger
+# ---------------------------------------------------------------------------
+
+
+def test_classify_does_not_mutate_ledger(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    """The classifier returns ``newly_quarantined`` for the caller to
+    register; classify() itself MUST NOT call ledger.register_quarantine."""
+    snap = _snapshot(
+        _card("brand/new-unknown"),
+    )
+    classifier = DwCatalogClassifier()
+    before = isolated_ledger.quarantined_models()
+    outcome = classifier.classify(snap, isolated_ledger)
+    after = isolated_ledger.quarantined_models()
+    # Ledger state unchanged
+    assert before == after
+    # But the surface flagged the new ambiguous model
+    assert "brand/new-unknown" in outcome.newly_quarantined
+
+
+# ---------------------------------------------------------------------------
+# §12 — 22-model real-world simulation
+# ---------------------------------------------------------------------------
+
+
+def test_22_model_realistic_catalog(
+    isolated_ledger: PromotionLedger,
+) -> None:
+    """Mirrors the 22-model count from session bt-2026-04-27-235708.
+    Mix: 3 large agentic, 5 mid-size, 8 small/cheap, 6 ambiguous.
+    Verifies all routes get realistic-looking populations."""
+    snap = _snapshot(
+        # Large agentic (COMPLEX)
+        _card("moonshotai/Kimi-K2.6", family="moonshotai",
+              params_b=400.0, ctx=200_000, out_price=0.40),
+        _card("zai-org/GLM-5.1-FP8", family="zai-org",
+              params_b=355.0, ctx=128_000, out_price=0.35),
+        _card("Qwen/Qwen3.5-397B-A17B", family="qwen",
+              params_b=397.0, ctx=128_000, out_price=0.40),
+        # Mid-size (STANDARD)
+        _card("Qwen/Qwen3.6-35B-A3B-FP8", family="qwen",
+              params_b=35.0, ctx=128_000, out_price=0.20),
+        _card("vendor/m-30B", params_b=30.0, ctx=64_000, out_price=0.18),
+        _card("vendor/m-22B", params_b=22.0, ctx=32_000, out_price=0.15),
+        _card("vendor/m-14B", params_b=14.0, ctx=32_000, out_price=0.12),
+        _card("vendor/m-20B", params_b=20.0, ctx=64_000, out_price=0.16),
+        # Small/cheap (BACKGROUND eligible)
+        _card("Qwen/Qwen3.5-9B", family="qwen", params_b=9.0,
+              ctx=32_000, out_price=0.06),
+        _card("Qwen/Qwen3.5-4B", family="qwen", params_b=4.0,
+              ctx=32_000, out_price=0.04),
+        _card("vendor/m-7B", params_b=7.0, ctx=8_000, out_price=0.08),
+        _card("vendor/m-3B", params_b=3.0, ctx=8_000, out_price=0.05),
+        _card("vendor/m-1.5B", params_b=1.5, ctx=4_000, out_price=0.03),
+        _card("vendor/m-2B", params_b=2.0, ctx=4_000, out_price=0.04),
+        _card("vendor/m-13B", params_b=13.0, ctx=8_000, out_price=0.10),
+        _card("vendor/m-5B", params_b=5.0, ctx=8_000, out_price=0.06),
+        # Ambiguous (NEVER in BG, only SPECULATIVE quarantine)
+        _card("ambig/unknown-1"),
+        _card("ambig/unknown-2"),
+        _card("ambig/unknown-3"),
+        _card("ambig/unknown-4"),
+        _card("ambig/unknown-5"),
+        _card("ambig/unknown-6"),
+    )
+    outcome = DwCatalogClassifier().classify(snap, isolated_ledger)
+
+    # COMPLEX: only 30B+ models pass min_params_b=30 default
+    # → 3 large (400B, 355B, 397B) + 2 mid (35B, 30B) = 5
+    complex_models = outcome.for_route("complex")
+    assert len(complex_models) == 5
+    # First-ranked is the largest
+    assert "Qwen/Qwen3.5-397B-A17B" in complex_models[:3]
+
+    # STANDARD: 14B+ models pass min_params_b=14, ≤$2/M
+    standard_models = outcome.for_route("standard")
+    assert len(standard_models) >= 6
+    # No ambiguous models in STANDARD
+    for amb in ("ambig/unknown-1", "ambig/unknown-2"):
+        assert amb not in standard_models
+
+    # BACKGROUND: ≤$0.5/M, no ambiguous
+    bg_models = outcome.for_route("background")
+    assert len(bg_models) >= 8
+    # All have param_count and pricing under $0.5
+    # Cheapest first
+    assert bg_models[0] in ("vendor/m-1.5B", "Qwen/Qwen3.5-4B",
+                            "vendor/m-2B")
+    for amb in ("ambig/unknown-1", "ambig/unknown-2"):
+        assert amb not in bg_models
+
+    # SPECULATIVE: ≤$0.1/M priced models + all ambiguous quarantined
+    spec_models = outcome.for_route("speculative")
+    # Ambiguous all land here
+    for amb in ("ambig/unknown-1", "ambig/unknown-2", "ambig/unknown-3",
+                "ambig/unknown-4", "ambig/unknown-5", "ambig/unknown-6"):
+        assert amb in spec_models
+
+    # All 6 newly quarantined
+    assert len(outcome.newly_quarantined) == 6


### PR DESCRIPTION
## Summary

Slice B delivers the **algorithmic route assignment** + **Zero-Trust prove-it promotion ledger** for Phase 12, plus the **architectural blueprint for Phase 12.2** (physics-aware topology routing).

## What ships

### `dw_promotion_ledger.py` (~470 lines)

Per-model quarantine + promotion lifecycle tracker. **Strict gate** (operator-mandated 2026-04-27):

- ALL ring-buffer latencies ≤ `JARVIS_DW_PROMOTION_MAX_LATENCY_MS` (default 200ms) — **NOT P95**
- ≥ `JARVIS_DW_PROMOTION_MIN_SUCCESSES` (default 10) consecutive successful ops
- Zero failures in current ring window
- Single failure on a promoted model (default `DEMOTION_FAIL_THRESHOLD=1`) → reset ring + flip back to quarantine with `origin=demoted_from_bg`

Disk persistence at `.jarvis/dw_promotion_ledger.json` via atomic temp+rename. Schema v1, restart-survival. Thread-safe via RLock. **NEVER raises** out of any public method — defensive try/except guards every telemetry input path so a malformed record can't take down the dispatcher.

### `dw_catalog_classifier.py` (~290 lines)

Pure deterministic ranker. Same `(snapshot, ledger, env)` → bit-for-bit identical output. Per-route eligibility gates (env-tunable):

| Route | min_params_b | max_out_price |
|---|---|---|
| COMPLEX | 30B | none |
| STANDARD | 14B | $2.0/M |
| BACKGROUND | none | $0.5/M |
| SPECULATIVE | none | $0.1/M |
| IMMEDIATE | (always empty — Claude-direct by Manifesto §5) | n/a |

Composite score: `params_weight + pricing_weight + context_weight + family_bonus`. Tie-break by alphabetical `model_id` (stable cross-process — hash randomization can't shift ranks).

**Zero-Trust §3.6 enforcement**: ambiguous-metadata models pinned SPECULATIVE-only regardless of other signals. Classifier returns `ClassificationOutcome` with `newly_quarantined` model_ids for the caller (Slice C) to register; classifier itself is **pure** — does NOT mutate the ledger, keeps ranking re-runnable for Slice C shadow-mode diff against YAML.

### `phase_12_2_physics_aware_topology_blueprint.md` (~330 lines)

Architectural blueprint for the operator's three physics-aware mandates:

1. **Deep VRAM Probing** — defeats the L2 Cache Illusion. New `LIVE_VRAM_CONSTRAINED` `FailureSource` enum value. 500-token heavy probe distinguishes "network broke" from "GPU evicted us"
2. **TTFT Cold-Storage Detection** — moving-average + 2σ statistical gate per `model_id`. Dynamic SPECULATIVE demotion w/ auto-recovery on TTFT normalization. No hardcoded latency thresholds
3. **Full-Jitter Backoff** — `random.uniform(0, base * 2^attempt)` at every retry site. Single-source-of-truth `full_jitter.py` helper imported by all 4 retry callsites

4-slice plan (A=full-jitter, B=TTFT observer, C=TTFT demotion, D=heavy probe, E=graduation flip).

## Test plan

- [x] Slice B tests: 27 classifier + 38 ledger = **65/65 green**
- [x] Combined Phase 12 (Slice A + B): **124/124 green**
- [x] 22-model real-world simulation (mirrors `bt-2026-04-27-235708` catalog size) — verifies all routes get realistic populations
- [x] Determinism — 3× classify() with identical input produces identical output
- [x] Thread-safety — concurrent record_success across 4 threads × 20 ops each, ring buffer correctly clamped
- [x] NEVER-raises contract pinned for both modules (None, empty, whitespace, garbage inputs all tolerated)
- [x] Strict gate vs P95 — single over-threshold latency blocks promotion
- [x] Demotion semantics — single failure (default) on promoted model resets state, sets `origin=demoted_from_bg`
- [x] Schema mismatch + corrupt ledger boot empty (forces re-quarantine on next discovery cycle)

## Cost contract preservation

- `fallback_tolerance` (`queue` for BG/SPEC) stays YAML-authored — that's policy, not catalog
- Quarantined models are SPECULATIVE-only; SPECULATIVE has hardcoded `cost_cap_usd` per op (~$0.001)
- Even an unpriced 400B model in quarantine is cost-bounded structurally
- Promotion to BG requires latency-proven graduation; pricing/param gates still apply post-promotion

## Note on commit history

Pre-commit hook split the work into two commits and pulled in `notebooks/report.ipynb` (unrelated drift from main). Both commits are on this branch; the Phase 12 work is intact. Happy to rebase to drop the notebook if reviewer prefers a clean diff.

## Slice progression

| Slice | Status | Default flag |
|---|---|---|
| A — catalog client | ✅ Merged | false |
| **B — classifier + ledger (this PR)** | **review** | (uses A's flag) |
| C — sentinel preflight integration (shadow mode) | next | false |
| D — authority handoff | pending | false |
| E — YAML purge + graduation | pending | **true** |

**Phase 12.2 (physics-aware topology) is a separate arc** following Phase 12 Slice E. Blueprint included in this PR for early review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic DW catalog classifier and a zero‑trust promotion ledger for route assignment, plus the Phase 12.2 physics‑aware topology blueprint. This hardens routing by quarantining ambiguous models and requiring strict, all‑ops latency success before promotion.

- **New Features**
  - `dw_promotion_ledger.py`: Per-model quarantine/promotion tracker with a strict gate (ALL latencies ≤ `JARVIS_DW_PROMOTION_MAX_LATENCY_MS` default 200ms, ≥ `JARVIS_DW_PROMOTION_MIN_SUCCESSES` consecutive successes, zero failures). Single failure on a promoted model demotes. Disk persistence at `.jarvis/dw_promotion_ledger.json`, thread‑safe, never raises.
  - `dw_catalog_classifier.py`: Pure, deterministic ranker `(snapshot, ledger, env)`. Route gates (defaults): COMPLEX ≥30B; STANDARD ≥14B and ≤$2/M; BACKGROUND ≤$0.5/M; SPECULATIVE ≤$0.1/M; IMMEDIATE empty. Scoring blends params, price, context, family bonus; ties by `model_id`. Zero‑Trust: ambiguous metadata is SPECULATIVE‑only. Returns `ClassificationOutcome.newly_quarantined` without mutating the ledger.
  - `docs/architecture/phase_12_2_physics_aware_topology_blueprint.md`: Plan for Deep VRAM heavy probes (new `LIVE_VRAM_CONSTRAINED`), TTFT cold‑storage detection with moving‑average + 2σ and temporary demotion with auto‑recovery, and full‑jitter backoff across retry sites (slice plan A–E with flags).

<sup>Written for commit 6b5a35e6b03e926b629fdf26167f7de6277ded4f. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/26748?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

