### PR TITLE
Phase 12 Slice D: authority handoff (catalog reads first, YAML fallback)

### DIFF
--- a/backend/core/ouroboros/governance/provider_topology.py
+++ b/backend/core/ouroboros/governance/provider_topology.py
@@ -352,6 +352,25 @@ class ProviderTopology:
     def dw_models_for_route(self, route: str) -> Tuple[str, ...]:
         """Return the v2 ranked ``dw_models`` list for *route*.
 
+        Phase 12 Slice D — when ``JARVIS_DW_CATALOG_AUTHORITATIVE=true``
+        AND the dynamic catalog holder is fresh AND the route has a
+        non-empty assignment, the holder is consulted FIRST. YAML
+        remains the fallback for every other path:
+
+          * authoritative flag off → YAML
+          * holder is None (no discovery cycle has populated it) → YAML
+          * holder is stale (older than ``JARVIS_DW_CATALOG_MAX_AGE_S``,
+            default 7200s = 2h) → YAML
+          * route missing from holder → YAML
+          * route present but empty list → YAML
+
+        ``fallback_tolerance``, ``block_mode``, ``dw_allowed``, and the
+        ``reason`` strings stay YAML-authored throughout — those encode
+        cost-contract policy, not catalog facts. Only the ``dw_models``
+        ranked list is dynamically substituted. BG/SPEC routes still
+        respect ``fallback_tolerance: queue`` after sentinel exhaustion
+        regardless of which models populated them.
+
         Backward-compat: when the yaml is v1 (no ``dw_models`` key for
         the route), returns a single-element tuple ``(dw_model,)`` if DW
         is allowed AND a ``dw_model`` is configured; empty tuple
@@ -364,6 +383,19 @@ class ProviderTopology:
         """
         if not self.enabled:
             return ()
+
+        # Phase 12 Slice D — catalog-first read with YAML fallback
+        if catalog_authoritative_enabled():
+            holder = get_dynamic_catalog()
+            if holder is not None and _holder_is_fresh(holder):
+                key = (route or "").strip().lower()
+                ranked = holder.assignments_by_route.get(key, ())
+                if ranked:
+                    return ranked
+            # Fall through to YAML — cold-start, stale, route missing,
+            # or route empty in catalog. YAML stays authoritative for
+            # all four fallback conditions
+
         entry = self.routes.get((route or "").strip().lower())
         if entry is None:
             return ()
@@ -663,6 +695,73 @@ def reload_topology() -> ProviderTopology:
 
 
 # ---------------------------------------------------------------------------
+# Phase 12 Slice D — Authoritative-mode flag + freshness helper
+# ---------------------------------------------------------------------------
+#
+# Two-flag separation (operator-controllable independently):
+#
+#   JARVIS_DW_CATALOG_DISCOVERY_ENABLED  (Slice A) — does discovery RUN?
+#                                                    fetch + classify + populate
+#                                                    holder. Master flag for the
+#                                                    end-to-end pipeline.
+#   JARVIS_DW_CATALOG_AUTHORITATIVE      (Slice D) — does dw_models_for_route
+#                                                    READ the holder first?
+#                                                    Slice C kept holder pure
+#                                                    observation; Slice D flips
+#                                                    the read order.
+#
+# Flag matrix (post-Slice-D, pre-Slice-E graduation):
+#
+#   discovery=off, authoritative=off  → legacy YAML-only (current main as of A)
+#   discovery=on,  authoritative=off  → shadow mode (Slice C — holder populated,
+#                                       dispatcher still reads YAML, operator
+#                                       can audit yaml_diff diagnostic)
+#   discovery=off, authoritative=on   → no-op in practice — holder stays empty,
+#                                       dw_models_for_route falls through to YAML
+#                                       on every call. Cost-safe by construction.
+#   discovery=on,  authoritative=on   → full Phase 12 (Slice E target). Catalog
+#                                       reads first, YAML is the fallback layer.
+
+
+def catalog_authoritative_enabled() -> bool:
+    """``JARVIS_DW_CATALOG_AUTHORITATIVE`` (default ``false``).
+
+    Re-read at call time so monkeypatch works in tests + operators
+    can flip live without re-init. Default flips to ``true`` at
+    Phase 12 Slice E graduation. Hot-revert path: ``export
+    JARVIS_DW_CATALOG_AUTHORITATIVE=false`` returns dispatcher to
+    YAML-authored dw_models lists immediately."""
+    raw = os.environ.get(
+        "JARVIS_DW_CATALOG_AUTHORITATIVE", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _catalog_max_age_s() -> float:
+    """Re-read ``JARVIS_DW_CATALOG_MAX_AGE_S`` (default 7200s = 2h)
+    at call time. Used by ``_holder_is_fresh``. Mirrors the same env
+    knob in ``dw_catalog_client.py`` so a single operator-tuned value
+    governs both the client cache + the dispatcher freshness gate."""
+    try:
+        return float(
+            os.environ.get("JARVIS_DW_CATALOG_MAX_AGE_S", "7200").strip(),
+        )
+    except (ValueError, TypeError):
+        return 7200.0
+
+
+def _holder_is_fresh(holder: "_DynamicCatalogHolder") -> bool:
+    """``True`` when the holder was populated within
+    ``_catalog_max_age_s`` seconds ago. Stale holder → caller falls
+    back to YAML. NEVER raises."""
+    import time as _time
+    try:
+        return (_time.time() - holder.fetched_at_unix) < _catalog_max_age_s()
+    except Exception:  # noqa: BLE001 — defensive
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Phase 12 Slice C — Dynamic catalog holder (shadow mode)
 # ---------------------------------------------------------------------------
 #
@@ -812,6 +911,7 @@ __all__ = [
     "ProviderTopology",
     "RouteTopology",
     "RouteDiff",
+    "catalog_authoritative_enabled",
     "compute_yaml_diff",
     "get_topology",
     "reload_topology",

--- a/tests/governance/test_provider_topology_authority_handoff.py
+++ b/tests/governance/test_provider_topology_authority_handoff.py
@@ -1,0 +1,429 @@
+"""Phase 12 Slice D — provider_topology authority handoff regression spine.
+
+The flip: when JARVIS_DW_CATALOG_AUTHORITATIVE=true AND the dynamic
+catalog holder is fresh AND the route has a non-empty assignment, the
+holder is consulted FIRST. YAML remains the fallback.
+
+Pins:
+  §1 catalog_authoritative_enabled flag — default off, truthy/falsy parsing
+  §2 Authoritative OFF → YAML still authoritative even when holder populated
+                         (Slice C shadow-mode invariant preserved)
+  §3 Authoritative ON, no holder → YAML (cold-start fallback)
+  §4 Authoritative ON, holder fresh, route present → catalog wins
+  §5 Authoritative ON, holder fresh, route MISSING → YAML
+  §6 Authoritative ON, holder fresh, route empty → YAML
+  §7 Authoritative ON, holder STALE → YAML
+  §8 fallback_tolerance / block_mode / dw_allowed / reason
+                          stay YAML-authored regardless of authoritative
+                          (only dw_models swaps source)
+  §9 Hot-revert — flipping authoritative=false mid-session immediately
+                  returns dispatcher to YAML
+  §10 Topology disabled (yaml absent) — return () regardless
+  §11 IMMEDIATE route — empty in YAML AND empty in catalog → ()
+  §12 Source-level pin — fallback_tolerance NEVER reads dynamic holder
+"""
+from __future__ import annotations
+
+import time
+from typing import Any  # noqa: F401
+
+import pytest
+
+from backend.core.ouroboros.governance.provider_topology import (
+    catalog_authoritative_enabled,
+    clear_dynamic_catalog,
+    get_topology,
+    set_dynamic_catalog,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_holder():
+    clear_dynamic_catalog()
+    yield
+    clear_dynamic_catalog()
+
+
+def _yaml_has_complex_models() -> bool:
+    """Test environments where YAML is loaded with complex dw_models."""
+    t = get_topology()
+    return t.enabled and bool(t.dw_models_for_route("complex"))
+
+
+# ---------------------------------------------------------------------------
+# §1 — Master flag
+# ---------------------------------------------------------------------------
+
+
+def test_authoritative_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_DW_CATALOG_AUTHORITATIVE", raising=False)
+    assert catalog_authoritative_enabled() is False
+
+
+def test_authoritative_truthy_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for val in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", val)
+        assert catalog_authoritative_enabled() is True
+
+
+def test_authoritative_falsy_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for val in ("0", "false", "no", "off", "", "garbage"):
+        monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", val)
+        assert catalog_authoritative_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# §2 — Authoritative OFF preserves Slice C shadow-mode invariant
+# ---------------------------------------------------------------------------
+
+
+def test_off_preserves_yaml_when_holder_populated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slice C contract pinned: holder populated, authoritative off
+    → dispatcher reads YAML."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "false")
+    if not _yaml_has_complex_models():
+        pytest.skip("yaml topology lacks complex models in this env")
+    set_dynamic_catalog(
+        {"complex": ("dynamic-only/should-not-win",)},
+        fetched_at_unix=time.time(),
+    )
+    yaml_models = get_topology().dw_models_for_route("complex")
+    assert "dynamic-only/should-not-win" not in yaml_models
+
+
+# ---------------------------------------------------------------------------
+# §3 — Authoritative ON, no holder → YAML
+# ---------------------------------------------------------------------------
+
+
+def test_on_no_holder_falls_back_to_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cold-start safety: discovery hasn't run yet, dispatcher must
+    NOT see an empty list — that would crash the sentinel cascade."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    if not _yaml_has_complex_models():
+        pytest.skip("yaml topology lacks complex models")
+    yaml_models = get_topology().dw_models_for_route("complex")
+    assert yaml_models  # non-empty, from YAML
+
+
+# ---------------------------------------------------------------------------
+# §4 — Authoritative ON, holder fresh, route present → catalog wins
+# ---------------------------------------------------------------------------
+
+
+def test_on_fresh_holder_with_assignment_overrides_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The handoff: with both flags on + fresh holder + non-empty
+    route assignment → catalog wins."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    set_dynamic_catalog(
+        {"complex": ("dynamic-vendor/Kimi-99B",
+                     "dynamic-vendor/GLM-50B")},
+        fetched_at_unix=time.time(),
+    )
+    result = get_topology().dw_models_for_route("complex")
+    assert result == ("dynamic-vendor/Kimi-99B", "dynamic-vendor/GLM-50B")
+
+
+def test_on_fresh_holder_returns_full_catalog_ranking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Order preserved end-to-end — what the classifier ranked is
+    what the dispatcher iterates."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    ranked = ("a/m-50B", "b/m-30B", "c/m-14B")
+    set_dynamic_catalog(
+        {"complex": ranked},
+        fetched_at_unix=time.time(),
+    )
+    assert get_topology().dw_models_for_route("complex") == ranked
+
+
+# ---------------------------------------------------------------------------
+# §5 — Authoritative ON, route missing from holder → YAML
+# ---------------------------------------------------------------------------
+
+
+def test_on_holder_route_missing_falls_back_to_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Holder has 'complex' but not 'background' → background reads YAML."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    if not _yaml_has_complex_models():
+        pytest.skip("yaml topology lacks models")
+    set_dynamic_catalog(
+        {"complex": ("dynamic-only/m-99B",)},
+        fetched_at_unix=time.time(),
+    )
+    yaml_bg = get_topology().dw_models_for_route("background")
+    # background was NOT in the holder → falls through to YAML
+    assert "dynamic-only/m-99B" not in yaml_bg
+
+
+# ---------------------------------------------------------------------------
+# §6 — Authoritative ON, route present but empty → YAML
+# ---------------------------------------------------------------------------
+
+
+def test_on_holder_route_empty_falls_back_to_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty list signals 'classifier found nothing' → caller still
+    needs SOMETHING to try, so YAML wins for that route. Prevents a
+    misclassified empty list from disabling DW for a route entirely."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    if not _yaml_has_complex_models():
+        pytest.skip("yaml topology lacks complex models")
+    yaml_models = get_topology().dw_models_for_route("complex")
+    set_dynamic_catalog(
+        {"complex": ()},  # explicitly empty
+        fetched_at_unix=time.time(),
+    )
+    after = get_topology().dw_models_for_route("complex")
+    # Falls back to YAML, NOT the empty catalog list
+    assert after == yaml_models
+
+
+# ---------------------------------------------------------------------------
+# §7 — Authoritative ON, holder STALE → YAML
+# ---------------------------------------------------------------------------
+
+
+def test_on_stale_holder_falls_back_to_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Holder older than max_age_s → caller must NOT trust it. YAML
+    wins until the next discovery cycle refreshes."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    monkeypatch.setenv("JARVIS_DW_CATALOG_MAX_AGE_S", "1")  # 1-sec freshness
+    if not _yaml_has_complex_models():
+        pytest.skip("yaml topology lacks complex models")
+    yaml_models = get_topology().dw_models_for_route("complex")
+    # Populate holder, then "wait" by setting old timestamp
+    set_dynamic_catalog(
+        {"complex": ("dynamic-only/stale-99B",)},
+        fetched_at_unix=time.time() - 10.0,  # 10 sec old, > 1-sec threshold
+    )
+    after = get_topology().dw_models_for_route("complex")
+    assert "dynamic-only/stale-99B" not in after
+    assert after == yaml_models
+
+
+def test_on_holder_within_freshness_window_used(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Holder just under max_age_s → still used."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    monkeypatch.setenv("JARVIS_DW_CATALOG_MAX_AGE_S", "60")
+    set_dynamic_catalog(
+        {"complex": ("dynamic-only/m-99B",)},
+        fetched_at_unix=time.time() - 30.0,  # 30 sec old, well under 60
+    )
+    after = get_topology().dw_models_for_route("complex")
+    assert after == ("dynamic-only/m-99B",)
+
+
+# ---------------------------------------------------------------------------
+# §8 — Policy fields stay YAML-authored
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_tolerance_unaffected_by_authoritative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cost contract: fallback_tolerance is policy, not catalog.
+    Flipping authoritative MUST NOT change BG/SPEC's queue contract."""
+    topo = get_topology()
+    if not topo.enabled:
+        pytest.skip("yaml topology disabled")
+    # Capture YAML truth
+    before_bg = topo.fallback_tolerance_for_route("background")
+    before_spec = topo.fallback_tolerance_for_route("speculative")
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    set_dynamic_catalog(
+        {"background": ("malicious-injection/m-99B",),
+         "speculative": ("another/m-1B",)},
+        fetched_at_unix=time.time(),
+    )
+    # Same answers — fallback_tolerance never touched the holder
+    assert topo.fallback_tolerance_for_route("background") == before_bg
+    assert topo.fallback_tolerance_for_route("speculative") == before_spec
+
+
+def test_dw_allowed_unaffected_by_authoritative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dw_allowed is YAML-only — operator-controlled cost gate."""
+    topo = get_topology()
+    if not topo.enabled:
+        pytest.skip("yaml topology disabled")
+    before = topo.dw_allowed_for_route("background")
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    set_dynamic_catalog(
+        {"background": ("any/m-7B",)},
+        fetched_at_unix=time.time(),
+    )
+    assert topo.dw_allowed_for_route("background") == before
+
+
+def test_block_mode_unaffected_by_authoritative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    topo = get_topology()
+    if not topo.enabled:
+        pytest.skip("yaml topology disabled")
+    before = topo.block_mode_for_route("background")
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    set_dynamic_catalog(
+        {"background": ("any/m-7B",)},
+        fetched_at_unix=time.time(),
+    )
+    assert topo.block_mode_for_route("background") == before
+
+
+def test_reason_unaffected_by_authoritative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    topo = get_topology()
+    if not topo.enabled:
+        pytest.skip("yaml topology disabled")
+    before = topo.reason_for_route("background")
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    set_dynamic_catalog(
+        {"background": ("any/m-7B",)},
+        fetched_at_unix=time.time(),
+    )
+    assert topo.reason_for_route("background") == before
+
+
+# ---------------------------------------------------------------------------
+# §9 — Hot-revert
+# ---------------------------------------------------------------------------
+
+
+def test_flag_flip_takes_effect_mid_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator flips authoritative=false at runtime — next call goes
+    immediately to YAML, no re-init needed."""
+    if not _yaml_has_complex_models():
+        pytest.skip("yaml topology lacks complex models")
+    yaml_models = get_topology().dw_models_for_route("complex")
+    set_dynamic_catalog(
+        {"complex": ("dynamic-only/winning",)},
+        fetched_at_unix=time.time(),
+    )
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    assert (
+        get_topology().dw_models_for_route("complex")[0]
+        == "dynamic-only/winning"
+    )
+    # Hot-revert
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "false")
+    assert get_topology().dw_models_for_route("complex") == yaml_models
+
+
+# ---------------------------------------------------------------------------
+# §10 — Topology disabled
+# ---------------------------------------------------------------------------
+
+
+def test_topology_disabled_returns_empty_regardless(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the YAML's doubleword_topology section is missing, the
+    topology object is enabled=False. dw_models_for_route returns ()
+    on the very first check — catalog branch is skipped entirely."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    set_dynamic_catalog(
+        {"complex": ("dynamic-only/should-not-leak",)},
+        fetched_at_unix=time.time(),
+    )
+    # Manually construct a disabled topology — emulates yaml-absent
+    from backend.core.ouroboros.governance.provider_topology import (
+        ProviderTopology,
+    )
+    disabled = ProviderTopology(enabled=False)
+    assert disabled.dw_models_for_route("complex") == ()
+
+
+# ---------------------------------------------------------------------------
+# §11 — IMMEDIATE route
+# ---------------------------------------------------------------------------
+
+
+def test_immediate_route_stays_empty_under_authoritative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IMMEDIATE has empty dw_models in YAML AND classifier never
+    populates it. Both flags on → still ()."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "true")
+    set_dynamic_catalog({}, fetched_at_unix=time.time())  # empty holder
+    assert get_topology().dw_models_for_route("immediate") == ()
+
+
+# ---------------------------------------------------------------------------
+# §12 — Source-level pins
+# ---------------------------------------------------------------------------
+
+
+def test_source_fallback_tolerance_does_not_read_holder() -> None:
+    """fallback_tolerance is policy, NOT catalog. The implementation
+    must NOT consult get_dynamic_catalog or catalog_authoritative_enabled.
+    Source-level pin so a future refactor can't accidentally couple
+    the cost contract to the catalog."""
+    import inspect
+    from backend.core.ouroboros.governance.provider_topology import (
+        ProviderTopology,
+    )
+    src = inspect.getsource(ProviderTopology.fallback_tolerance_for_route)
+    assert "get_dynamic_catalog" not in src
+    assert "catalog_authoritative_enabled" not in src
+
+
+def test_source_dw_allowed_does_not_read_holder() -> None:
+    import inspect
+    from backend.core.ouroboros.governance.provider_topology import (
+        ProviderTopology,
+    )
+    src = inspect.getsource(ProviderTopology.dw_allowed_for_route)
+    assert "get_dynamic_catalog" not in src
+    assert "catalog_authoritative_enabled" not in src
+
+
+def test_source_block_mode_does_not_read_holder() -> None:
+    import inspect
+    from backend.core.ouroboros.governance.provider_topology import (
+        ProviderTopology,
+    )
+    src = inspect.getsource(ProviderTopology.block_mode_for_route)
+    assert "get_dynamic_catalog" not in src
+
+
+def test_source_dw_models_for_route_consults_holder_first() -> None:
+    """The catalog-first branch must fire BEFORE the YAML lookup
+    (otherwise YAML always wins, defeating the purpose of Slice D)."""
+    import inspect
+    from backend.core.ouroboros.governance.provider_topology import (
+        ProviderTopology,
+    )
+    src = inspect.getsource(ProviderTopology.dw_models_for_route)
+    holder_idx = src.index("get_dynamic_catalog")
+    yaml_idx = src.index("self.routes.get")
+    assert holder_idx < yaml_idx, (
+        "dynamic catalog branch must fire before YAML fallback"
+    )


### PR DESCRIPTION
## Summary

`dw_models_for_route()` flips to read the dynamic catalog holder **FIRST** when `JARVIS_DW_CATALOG_AUTHORITATIVE=true` AND the holder is fresh AND the route has a non-empty assignment. YAML remains the fallback for every other path. Both flags stay default-false until Slice E graduation.

## The flip

```python
# Before (Slice C — shadow mode):
def dw_models_for_route(self, route):
    return self.routes[route].effective_dw_models   # always YAML

# After (Slice D — authoritative mode):
def dw_models_for_route(self, route):
    if catalog_authoritative_enabled():
        holder = get_dynamic_catalog()
        if holder and _holder_is_fresh(holder):
            ranked = holder.assignments_by_route.get(route)
            if ranked:
                return ranked   # ← catalog wins
    return self.routes[route].effective_dw_models   # YAML fallback
```

## Two-flag separation

Operator gets independent control over discovery and authority:

| `JARVIS_DW_CATALOG_DISCOVERY_ENABLED` | `JARVIS_DW_CATALOG_AUTHORITATIVE` | Behavior |
|---|---|---|
| off | off | Legacy YAML-only (current main as of Slice A merge) |
| **on** | off | **Slice C shadow mode** (holder populated, dispatcher reads YAML — for `yaml_diff` audit) |
| off | on | No-op (empty holder falls through to YAML every call) |
| **on** | **on** | **Full Phase 12** (Slice E graduation target) |

Slice D ships the gate; Slice E flips both defaults.

## Five YAML fallback paths (each test-pinned)

1. `JARVIS_DW_CATALOG_AUTHORITATIVE=false` → YAML (Slice C invariant preserved)
2. Holder is `None` (cold-start, no discovery has run) → YAML
3. Holder is **stale** (older than `JARVIS_DW_CATALOG_MAX_AGE_S`, default 7200s) → YAML
4. Route **missing** from holder → YAML
5. Route present but **empty list** → YAML (classifier-misclassification safety net)

## Cost contract preservation (the big invariant)

`fallback_tolerance`, `block_mode`, `dw_allowed`, and `reason` stay YAML-authored throughout. **Only `dw_models` swaps source.** That's enforced three ways:

- Implementation: only `dw_models_for_route` consults `get_dynamic_catalog`. The other four accessors don't touch it
- **Source-level test pins** (§12) — `fallback_tolerance_for_route`, `dw_allowed_for_route`, `block_mode_for_route` all grep'd to ensure they NEVER reference `get_dynamic_catalog` or `catalog_authoritative_enabled`. Future refactor that accidentally couples cost contract to catalog will fail this test
- Test §8 — `test_*_unaffected_by_authoritative` for all four policy fields, with malicious-injection holder values

BG/SPEC routes still respect `fallback_tolerance: queue` after sentinel exhaustion regardless of which models populated them. The Phase 11 cost contract (44 BG ops queued cleanly with $0.00 Claude burn in `bt-2026-04-27-235708`) is preserved structurally.

## Test plan

- [x] Slice D tests: **22/22 green** covering all 5 fallback paths + 4 cost-contract isolations + hot-revert + 4 source-level pins
- [x] Combined Phase 12 (A+B+C+D): **176/176 green**
- [x] Existing topology + sentinel + provider_topology suites: **283/283 green** (zero regressions)
- [x] Hot-revert pinned: `JARVIS_DW_CATALOG_AUTHORITATIVE=false` mid-session returns dispatcher to YAML on next call — no re-init needed
- [x] Per-route empty-list safety net: an empty catalog list for a route falls back to YAML rather than disabling DW for that route
- [x] Topology disabled (yaml absent) returns `()` regardless of holder content — first-line check

## What Slice D does NOT do

- Does NOT flip the default flags. Both stay false. Slice E flips them
- Does NOT change `fallback_tolerance` / `block_mode` / `dw_allowed` reads. Those remain YAML-authored
- Does NOT touch the candidate_generator dispatcher path. The sentinel-driven cascade walks the result of `dw_models_for_route` exactly as before — Slice D just changes where that result comes from
- Does NOT add a discovery refresh loop. Slice C's `run_discovery` is the populate-holder primitive; wiring it into a background refresh task is Slice E (or a follow-up)

## Slice progression

| Slice | Status | Default flag(s) |
|---|---|---|
| A — catalog client | ✅ Merged | false |
| B — classifier + ledger | ✅ Merged | (uses A's flag) |
| C — discovery runner + holder (shadow) | ✅ Merged | (uses A's flag) |
| **D — authority handoff (this PR)** | **review** | both false |
| E — YAML purge + graduation | next | **both true** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the dynamic catalog authoritative for `dw_models_for_route` when `JARVIS_DW_CATALOG_AUTHORITATIVE=true` and the holder is fresh, with YAML as a safe fallback in all other cases. Both flags stay default-off and all cost-policy fields remain YAML-only.

- New Features
  - `dw_models_for_route` reads the dynamic catalog first when `JARVIS_DW_CATALOG_AUTHORITATIVE` is on and the holder is fresh and non-empty.
  - Safe YAML fallbacks: flag off, no holder, stale holder (uses `JARVIS_DW_CATALOG_MAX_AGE_S`), route missing, or empty assignment.
  - Two-flag control: `JARVIS_DW_CATALOG_DISCOVERY_ENABLED` populates; `JARVIS_DW_CATALOG_AUTHORITATIVE` reads. Full mode requires both on.
  - Cost policy unchanged: `fallback_tolerance`, `block_mode`, `dw_allowed`, and `reason` still read from YAML only.
  - Hot-revert: setting `JARVIS_DW_CATALOG_AUTHORITATIVE=false` sends reads back to YAML on the next call (no restart).

<sup>Written for commit 4c647fdbd0c7652bbc1ef8713c8b9988097fb323. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/26827?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

