### PR TITLE
Phase 12 Slice E: graduation flip + boot hook + YAML purge — CLOSES PHASE 12

### DIFF
--- a/backend/core/ouroboros/governance/brain_selection_policy.yaml
+++ b/backend/core/ouroboros/governance/brain_selection_policy.yaml
@@ -340,15 +340,32 @@ gates:
 # callers (semantic_triage, ouroboros_plan) until DoubleWord repairs
 # their SSE generation endpoint.
 doubleword_topology:
-  # Bumped to topology.2 (PRD §3.7 + §9 Phase 10 P10.2, 2026-04-27).
-  # v2 adds per-route `dw_models:` ranked lists + `fallback_tolerance:`
-  # so the AsyncTopologySentinel can walk multiple DW model candidates
-  # before any Claude cascade. v1 keys (`dw_allowed`, `block_mode`)
-  # remain authoritative when JARVIS_TOPOLOGY_SENTINEL_ENABLED is off
-  # (current default). Slice 3 wires `candidate_generator` to consult
-  # the sentinel under that flag; Slice 5 (THE PURGE) deletes the v1
-  # keys after 3 forced-clean once-proofs prove the dynamic path
-  # produces correct routing decisions.
+  # Schema topology.2 — graduated 2026-04-27 at Phase 12 Slice E.
+  #
+  # PURGE NOTE (Slice E, 2026-04-27): the per-route `dw_models:` arrays
+  # have been DELIBERATELY REMOVED. The dynamic catalog discovery
+  # pipeline (dw_catalog_client + dw_catalog_classifier + dw_discovery_
+  # runner) now owns the ranking — fetched live from DW's /models
+  # endpoint, classified by deterministic per-route eligibility gates,
+  # surfaced via ProviderTopology._DYNAMIC_CATALOG, and consulted by
+  # dw_models_for_route() when both flags are on (default true post-
+  # graduation):
+  #
+  #   JARVIS_DW_CATALOG_DISCOVERY_ENABLED   (default true)
+  #   JARVIS_DW_CATALOG_AUTHORITATIVE        (default true)
+  #
+  # Hot-revert path: setting EITHER flag to false returns dw_models_for_
+  # route() to ``effective_dw_models`` from this YAML, which is now ()
+  # for every generative route (no static list to fall back on). Empty
+  # list means the dispatcher cascades per ``fallback_tolerance``:
+  #   * BG/SPEC stay queue-only (no Claude cascade — cost contract
+  #     preserved structurally per project_bg_spec_sealed.md)
+  #   * STANDARD/COMPLEX cascade to Claude until DISCOVERY is re-enabled
+  #
+  # The fields BELOW (dw_allowed, block_mode, reason, fallback_tolerance)
+  # are POLICY, not catalog. They encode operator-controlled cost
+  # contract decisions and stay YAML-authored. Only the *which models*
+  # decision is dynamic.
   schema_version: "topology.2"
   enabled: true
   routes:
@@ -356,62 +373,40 @@ doubleword_topology:
       dw_allowed: false
       block_mode: "cascade_to_claude"
       reason: "Prefrontal cortex — Claude only. 120s DW RT budget is insufficient for fast-reflex ops with Venom tool loops."
-      # v2 — IMMEDIATE intentionally has NO dw_models. Manifesto §5
+      # IMMEDIATE intentionally has NO dw_models — Manifesto §5
       # ("survival and execution speed permanently supersede cost
       # optimization") makes this a Claude-direct route by design,
-      # NOT a degradation seal. Preserved across the purge.
+      # NOT a degradation seal. The classifier (Phase 12 Slice B)
+      # never populates IMMEDIATE; this stays empty across the purge.
       dw_models: []
       fallback_tolerance: "cascade_to_claude"
     complex:
       dw_allowed: false
       block_mode: "cascade_to_claude"
-      reason: "Prefrontal cortex — Claude only. Live-fire bbpst3ebf proved DW (both 397B and Gemma 4 31B) times out on architectural COMPLEX GENERATE within 120s Tier 0 RT."
-      # v2 — ranked DW model list per PRD §3.7.3. The sentinel walks
-      # this list trying each healthy model before cascading to Claude.
-      # All three primary picks are different model families than the
-      # 397B that originally stream-stalled — different runtimes,
-      # different streaming pipelines.
-      dw_models:
-        - "moonshotai/Kimi-K2.6"           # Primary — "long-horizon coding, agents, swarm" — exact match for autonomous multi-file
-        - "zai-org/GLM-5.1-FP8"            # Secondary — leads SWE-Bench Pro, "agentic engineering, repo gen, terminal"
-        - "Qwen/Qwen3.6-35B-A3B-FP8"       # Budget tertiary — newer family than 397B
-        - "Qwen/Qwen3.5-397B-A17B"         # Legacy primary — demoted to last DW attempt
+      reason: "Catalog-driven (Phase 12). Static list purged; ranking authority is dw_catalog_classifier with per-route eligibility gates (default min_params_b=30B). When discovery is off, this empty list cascades per fallback_tolerance."
+      # PURGED 2026-04-27 — see header note
+      dw_models: []
       fallback_tolerance: "cascade_to_claude"
     standard:
       dw_allowed: false
       block_mode: "cascade_to_claude"
-      reason: "Qwen 397B verified stream-stalling without candidate generation in bt-2026-04-14-203740. DW Tier 0 sealed to prevent latency debt."
-      # v2 — same ranked list as COMPLEX (per PRD §3.7.3).
-      dw_models:
-        - "moonshotai/Kimi-K2.6"
-        - "zai-org/GLM-5.1-FP8"
-        - "Qwen/Qwen3.6-35B-A3B-FP8"
-        - "Qwen/Qwen3.5-397B-A17B"
+      reason: "Catalog-driven (Phase 12). Static list purged; ranking authority is dw_catalog_classifier (default min_params_b=14B, max_out_price=$2/M). When discovery is off, this empty list cascades per fallback_tolerance."
+      # PURGED 2026-04-27
+      dw_models: []
       fallback_tolerance: "cascade_to_claude"
     background:
       dw_allowed: false
       block_mode: "skip_and_queue"
-      reason: "Gemma 4 31B stream-stalls on DW endpoint even at <2K tokens. Background generation paused to preserve Claude compute runway."
-      # v2 — BG is cost-sensitive; cheap-first ranking. Kimi-K2.6 is
-      # second because long-horizon BG ops (e.g. doc staleness drafts)
-      # benefit from its agentic surface when 35B is unhealthy.
-      # `fallback_tolerance: "queue"` preserves the project_bg_spec_
-      # sealed.md contract — BG ops NEVER cascade to Claude on full
-      # DW failure; they queue and the sensor re-detects.
-      dw_models:
-        - "Qwen/Qwen3.6-35B-A3B-FP8"
-        - "moonshotai/Kimi-K2.6"
+      reason: "Catalog-driven (Phase 12). Static list purged; ranking authority is dw_catalog_classifier (default max_out_price=$0.5/M). fallback_tolerance: queue preserves the project_bg_spec_sealed.md contract — BG NEVER cascades to Claude on full DW failure."
+      # PURGED 2026-04-27
+      dw_models: []
       fallback_tolerance: "queue"
     speculative:
       dw_allowed: false
       block_mode: "skip_and_queue"
-      reason: "Gemma 4 31B stream-stalls on DW endpoint even at <2K tokens. Background generation paused to preserve Claude compute runway."
-      # v2 — SPECULATIVE is fire-and-forget pre-computation; ultra-cheap
-      # picks only. Qwen3.5-4B at $0.04/$0.06 per M is the cheapest
-      # usable model in the catalog. Same `queue` fallback contract.
-      dw_models:
-        - "Qwen/Qwen3.5-9B"
-        - "Qwen/Qwen3.5-4B"
+      reason: "Catalog-driven (Phase 12). Static list purged; ranking authority is dw_catalog_classifier (default max_out_price=$0.1/M). Same queue fallback contract as BACKGROUND. Zero-Trust §3.6 quarantine lands ambiguous-metadata models here."
+      # PURGED 2026-04-27
+      dw_models: []
       fallback_tolerance: "queue"
   monitor:
     # AsyncTopologySentinel tunables — yaml-driven so operators can

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1948,6 +1948,37 @@ class CandidateGenerator:
             set_dw_model_override as _set_override,
         )
 
+        # Phase 12 Slice E — boot-time discovery hook. Idempotent:
+        # only the first dispatch in a process boots; subsequent
+        # calls fast-path return None. When discovery is off (hot-
+        # revert path), this is a no-op. Boot includes both an
+        # inline first cycle (catalog populated before the read
+        # below) AND spawning the periodic refresh task.
+        try:
+            from backend.core.ouroboros.governance.dw_discovery_runner import (
+                boot_discovery_once as _boot_discovery_once,
+            )
+            _dw_provider = self._tier0
+            if (
+                _dw_provider is not None
+                and hasattr(_dw_provider, "_get_session")
+                and hasattr(_dw_provider, "_base_url")
+                and hasattr(_dw_provider, "_api_key")
+                and getattr(_dw_provider, "is_available", True)
+            ):
+                _session = await _dw_provider._get_session()  # noqa: SLF001
+                await _boot_discovery_once(
+                    session=_session,
+                    base_url=_dw_provider._base_url,  # noqa: SLF001
+                    api_key=_dw_provider._api_key,    # noqa: SLF001
+                )
+        except Exception:  # noqa: BLE001 — defensive; boot hook NEVER blocks dispatch
+            logger.debug(
+                "[CandidateGenerator] boot_discovery_once raised "
+                "unexpectedly — dispatch continues with current state",
+                exc_info=True,
+            )
+
         topology = _get_topology()
         if not topology.enabled:
             return None

--- a/backend/core/ouroboros/governance/dw_catalog_client.py
+++ b/backend/core/ouroboros/governance/dw_catalog_client.py
@@ -50,18 +50,20 @@ logger = logging.getLogger(__name__)
 
 
 def discovery_enabled() -> bool:
-    """``JARVIS_DW_CATALOG_DISCOVERY_ENABLED`` (default ``false``).
+    """``JARVIS_DW_CATALOG_DISCOVERY_ENABLED`` (default ``true`` —
+    graduated in Phase 12 Slice E).
 
     Re-read at call time so monkeypatch works in tests + operators
-    can flip live without re-init.
-
-    Default flips to ``true`` at Phase 12 Slice E graduation. Until
-    then, the catalog client may run but its output is not consumed
-    by the dispatcher — YAML stays authoritative.
-    """
+    can flip live without re-init. Hot-revert: ``export
+    JARVIS_DW_CATALOG_DISCOVERY_ENABLED=false`` returns the entire
+    Phase 12 catalog pipeline to dormant (per-route fallbacks all
+    return ``()`` since YAML's dw_models arrays were purged at
+    graduation; dispatcher cascades per ``fallback_tolerance``)."""
     raw = os.environ.get(
         "JARVIS_DW_CATALOG_DISCOVERY_ENABLED", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/dw_discovery_runner.py
+++ b/backend/core/ouroboros/governance/dw_discovery_runner.py
@@ -267,8 +267,183 @@ def _failed_result(
     )
 
 
+# ---------------------------------------------------------------------------
+# Phase 12 Slice E — Boot-time hook + periodic refresh loop
+# ---------------------------------------------------------------------------
+#
+# The dispatcher (candidate_generator._dispatch_via_sentinel) calls
+# ``boot_discovery_once`` on every dispatch when discovery is enabled.
+# The first call:
+#   1. Acquires the boot lock
+#   2. Ensures the singleton ledger is hydrated from disk
+#   3. Awaits one full discovery cycle inline (~200ms typical) so the
+#      catalog holder is populated BEFORE the dispatcher's first
+#      cascade walks dw_models_for_route
+#   4. Spawns a background refresh task on JARVIS_DW_CATALOG_REFRESH_S
+#      cadence (default 1800s = 30min)
+# Subsequent calls in the same process see the boot flag set and
+# return immediately — idempotent, hot-path-safe.
+#
+# When discovery is OFF, ``boot_discovery_once`` is a no-op — Phase 12
+# graduation hot-revert path stays clean.
+#
+# The refresh loop NEVER raises out of an iteration; every cycle's
+# exceptions are caught + logged + the next refresh fires on schedule.
+# Operator can hot-revert via JARVIS_DW_CATALOG_DISCOVERY_ENABLED=false
+# at runtime; the loop checks the flag each cycle and skips the fetch
+# when off (it does NOT cancel itself — staying alive lets a re-flip
+# pick up immediately without process restart).
+
+import asyncio
+import threading
+
+from backend.core.ouroboros.governance.dw_catalog_client import (
+    _refresh_interval_s as _refresh_interval_s_internal,
+)
+
+
+_BOOT_DISCOVERY_LOCK = asyncio.Lock()
+_BOOT_DISCOVERY_DONE: bool = False
+_REFRESH_TASK: Optional[asyncio.Task] = None
+_LEDGER_SINGLETON: Optional[PromotionLedger] = None
+# Sync lock around the singleton hydration + boot flag — protects the
+# very first-call window before the asyncio.Lock has been touched.
+_BOOT_SYNC_LOCK = threading.Lock()
+
+
+def _get_or_create_ledger() -> PromotionLedger:
+    """Lazy singleton — hydrates from disk on first access."""
+    global _LEDGER_SINGLETON
+    with _BOOT_SYNC_LOCK:
+        if _LEDGER_SINGLETON is None:
+            led = PromotionLedger()
+            led.load()
+            _LEDGER_SINGLETON = led
+        return _LEDGER_SINGLETON
+
+
+def reset_boot_state_for_tests() -> None:
+    """Test hook — clears the boot flag, cancels any refresh task,
+    drops the ledger singleton. Production code MUST NOT call this."""
+    global _BOOT_DISCOVERY_DONE, _REFRESH_TASK, _LEDGER_SINGLETON
+    with _BOOT_SYNC_LOCK:
+        _BOOT_DISCOVERY_DONE = False
+        if _REFRESH_TASK is not None and not _REFRESH_TASK.done():
+            _REFRESH_TASK.cancel()
+        _REFRESH_TASK = None
+        _LEDGER_SINGLETON = None
+
+
+async def boot_discovery_once(
+    *,
+    session: Any,
+    base_url: str,
+    api_key: str,
+) -> Optional[DiscoveryResult]:
+    """Fire-once boot hook. Idempotent: subsequent calls in the same
+    process see the boot flag set and return None immediately
+    (hot-path-safe).
+
+    The first call:
+      * runs one full discovery cycle inline (caller awaits)
+      * populates the dynamic catalog holder
+      * spawns the periodic refresh task
+
+    NEVER raises. Discovery off → returns None. Discovery enabled but
+    fetch failed → returns the failure-marked DiscoveryResult; refresh
+    task is still spawned so a recovering DW endpoint gets re-tried."""
+    global _BOOT_DISCOVERY_DONE, _REFRESH_TASK
+    if not catalog_discovery_enabled():
+        return None
+    # Fast-path no-op when already booted (avoids acquiring the lock
+    # on every dispatch).
+    if _BOOT_DISCOVERY_DONE:
+        return None
+    async with _BOOT_DISCOVERY_LOCK:
+        if _BOOT_DISCOVERY_DONE:
+            return None
+        ledger = _get_or_create_ledger()
+        first_result = await run_discovery(
+            session=session,
+            base_url=base_url,
+            api_key=api_key,
+            ledger=ledger,
+        )
+        _BOOT_DISCOVERY_DONE = True
+        # Spawn the refresh loop. We DON'T await; it runs forever
+        # until cancellation. Capture in module-level for shutdown.
+        try:
+            _REFRESH_TASK = asyncio.create_task(
+                _discovery_refresh_loop(
+                    session=session,
+                    base_url=base_url,
+                    api_key=api_key,
+                    ledger=ledger,
+                ),
+                name="dw_discovery_refresh_loop",
+            )
+        except RuntimeError:
+            # No running loop → caller is sync-only; refresh disabled.
+            # Boot still counts as done; operator can re-enable via
+            # reset_boot_state_for_tests + re-call from async ctx.
+            logger.debug(
+                "[DiscoveryRunner] no running loop — refresh skipped",
+            )
+        logger.info(
+            "[DiscoveryRunner] boot complete: ok=%s models=%d "
+            "newly_quarantined=%d routes_assigned=%s",
+            first_result.ok, first_result.model_count,
+            len(first_result.newly_quarantined),
+            list(first_result.routes_assigned),
+        )
+        return first_result
+
+
+async def _discovery_refresh_loop(
+    *,
+    session: Any,
+    base_url: str,
+    api_key: str,
+    ledger: PromotionLedger,
+) -> None:
+    """Periodic refresh. Each cycle:
+      1. Sleeps for JARVIS_DW_CATALOG_REFRESH_S (default 1800s)
+      2. Re-checks discovery flag (operator may have flipped off)
+      3. Runs a full discovery cycle
+      4. NEVER raises — all exceptions caught + logged
+
+    Loop survives forever until task cancellation (which happens on
+    process shutdown via reset_boot_state_for_tests or natural
+    asyncio cleanup)."""
+    while True:
+        try:
+            await asyncio.sleep(_refresh_interval_s_internal())
+        except asyncio.CancelledError:
+            return
+        if not catalog_discovery_enabled():
+            # Hot-revert in flight — skip the fetch but stay alive
+            # so a re-flip picks up immediately.
+            continue
+        try:
+            await run_discovery(
+                session=session,
+                base_url=base_url,
+                api_key=api_key,
+                ledger=ledger,
+            )
+        except asyncio.CancelledError:
+            return
+        except Exception:  # noqa: BLE001 — defensive
+            logger.exception(
+                "[DiscoveryRunner] refresh cycle failed; "
+                "next cycle will retry on schedule",
+            )
+
+
 __all__ = [
     "DiscoveryResult",
+    "boot_discovery_once",
     "catalog_discovery_enabled",
+    "reset_boot_state_for_tests",
     "run_discovery",
 ]

--- a/backend/core/ouroboros/governance/provider_topology.py
+++ b/backend/core/ouroboros/governance/provider_topology.py
@@ -724,16 +724,23 @@ def reload_topology() -> ProviderTopology:
 
 
 def catalog_authoritative_enabled() -> bool:
-    """``JARVIS_DW_CATALOG_AUTHORITATIVE`` (default ``false``).
+    """``JARVIS_DW_CATALOG_AUTHORITATIVE`` (default ``true`` —
+    graduated in Phase 12 Slice E alongside DISCOVERY_ENABLED).
 
     Re-read at call time so monkeypatch works in tests + operators
-    can flip live without re-init. Default flips to ``true`` at
-    Phase 12 Slice E graduation. Hot-revert path: ``export
+    can flip live without re-init. Hot-revert path: ``export
     JARVIS_DW_CATALOG_AUTHORITATIVE=false`` returns dispatcher to
-    YAML-authored dw_models lists immediately."""
+    YAML-authored dw_models lists. Note: at graduation, YAML's
+    dw_models arrays were purged — so the hot-revert lands on
+    ``effective_dw_models = ()`` per route, which means the
+    dispatcher cascades per ``fallback_tolerance``. BG/SPEC stay
+    queue-only (no Claude burn); STANDARD/COMPLEX cascade to
+    Claude until DISCOVERY is re-enabled."""
     raw = os.environ.get(
         "JARVIS_DW_CATALOG_AUTHORITATIVE", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/topology_sentinel.py
+++ b/backend/core/ouroboros/governance/topology_sentinel.py
@@ -1772,7 +1772,23 @@ def preflight_check(
     if not topology_loaded:
         failed.append("topology_not_loaded")
     if require_routes and not routes_with_dw_models:
-        failed.append("no_routes_have_dw_models")
+        # Phase 12 Slice E — post-purge YAML has empty dw_models on
+        # all generative routes; discovery populates the catalog
+        # asynchronously after the boot hook fires. Preflight runs
+        # BEFORE the boot hook, so empty-routes is the legitimate
+        # cold-start state when discovery is enabled. Tolerate it as
+        # a diagnostic; treat as failed only when discovery is OFF
+        # AND YAML has nothing — that's a genuine misconfiguration.
+        try:
+            from backend.core.ouroboros.governance.dw_catalog_client import (
+                discovery_enabled as _disc_enabled,
+            )
+            if _disc_enabled():
+                diagnostics.append("dw_models_pending_discovery")
+            else:
+                failed.append("no_routes_have_dw_models")
+        except Exception:  # noqa: BLE001 — fail closed on import error
+            failed.append("no_routes_have_dw_models")
 
     # Event-loop binding probe — the directive's "async event loop
     # binding" check. ``asyncio.get_running_loop()`` raises

--- a/tests/governance/test_candidate_generator_boot_hook.py
+++ b/tests/governance/test_candidate_generator_boot_hook.py
@@ -1,0 +1,146 @@
+"""Phase 12 Slice E — candidate_generator boot-hook integration pins.
+
+Source-level pins on the wiring of ``boot_discovery_once()`` into
+``CandidateGenerator._dispatch_via_sentinel``. The boot hook fires on
+the first dispatch and is idempotent for subsequent dispatches in
+the same process.
+
+Pins:
+  §1 Boot hook is called inside _dispatch_via_sentinel
+  §2 Boot hook fires BEFORE topology.dw_models_for_route is read
+     (otherwise first dispatch sees empty catalog)
+  §3 Boot hook is wrapped in try/except — NEVER blocks dispatch
+  §4 Boot hook gracefully skips when self._tier0 is None or
+     missing required attributes
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import candidate_generator as cg
+
+
+CANDIDATE_GEN_PATH = Path(cg.__file__)
+
+
+# ---------------------------------------------------------------------------
+# §1 — Boot hook called inside _dispatch_via_sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_boot_discovery_imported_inside_dispatch_via_sentinel() -> None:
+    """The dispatcher MUST call ``boot_discovery_once`` — pinned at
+    source level so a future refactor that lazy-imports / removes
+    the call site fails this test."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert "boot_discovery_once" in src, (
+        "Phase 12 Slice E: _dispatch_via_sentinel must invoke "
+        "boot_discovery_once for the first-dispatch boot hook"
+    )
+
+
+# ---------------------------------------------------------------------------
+# §2 — Boot hook fires BEFORE the catalog read
+# ---------------------------------------------------------------------------
+
+
+def test_boot_discovery_fires_before_dw_models_read() -> None:
+    """If the boot hook runs AFTER topology.dw_models_for_route, the
+    first dispatch sees an empty catalog and falls through to YAML
+    (which is purged in Slice E). Pin source ordering."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    boot_idx = src.index("boot_discovery_once")
+    read_idx = src.index("dw_models_for_route")
+    assert boot_idx < read_idx, (
+        "boot_discovery_once must run BEFORE the dw_models_for_route "
+        "read so the catalog is populated for the first dispatch"
+    )
+
+
+# ---------------------------------------------------------------------------
+# §3 — Boot hook wrapped in defensive try/except
+# ---------------------------------------------------------------------------
+
+
+def test_boot_discovery_wrapped_in_try_except() -> None:
+    """The boot hook MUST be defensive — any exception during boot
+    (network, import, ledger, anything) cannot block dispatch.
+    Pin the try/except wrapper at source level."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    # Find the boot_discovery_once call site
+    boot_call_idx = src.index("await _boot_discovery_once")
+    # Walk backwards to find the enclosing try:
+    preceding = src[:boot_call_idx]
+    try_idx = preceding.rfind("try:")
+    assert try_idx != -1, (
+        "boot_discovery_once must be inside a try/except — any "
+        "boot failure must not propagate to dispatch"
+    )
+    # Walk forward from the call to find the except:
+    following = src[boot_call_idx:]
+    except_idx = following.find("except")
+    assert except_idx != -1
+    # The except must catch the broadest reasonable exception type
+    # (Exception or BaseException) — boot is best-effort, not strict
+    except_window = following[except_idx:except_idx + 80]
+    assert (
+        "Exception" in except_window
+        or "BaseException" in except_window
+    ), "boot_discovery_once except clause must catch Exception"
+
+
+# ---------------------------------------------------------------------------
+# §4 — Boot hook tolerates missing tier0
+# ---------------------------------------------------------------------------
+
+
+def test_boot_discovery_skipped_when_tier0_none() -> None:
+    """When the candidate generator was constructed without a tier0
+    DW provider (test contexts, J-Prime-only deployments, etc.), the
+    boot hook must NOT crash. Pin source-level guard for self._tier0
+    is None."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    # The hook code reads self._tier0 then guards against None
+    boot_block_start = src.index("boot_discovery_once")
+    # Walk up to find _tier0 access
+    boot_block_window = src[
+        max(0, boot_block_start - 1500):boot_block_start + 500
+    ]
+    assert "self._tier0" in boot_block_window
+    assert (
+        "is not None" in boot_block_window
+        or "_dw_provider is not None" in boot_block_window
+    ), (
+        "boot hook must guard against self._tier0 is None to avoid "
+        "AttributeError when DW provider isn't configured"
+    )
+
+
+def test_boot_discovery_uses_provider_session_lazily() -> None:
+    """The hook fetches the aiohttp session via _get_session() — it
+    MUST NOT cache it on self (sessions can rotate, tests use mocks).
+    Pin that we await _get_session() inline at the call site."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert "_get_session()" in src, (
+        "boot hook must call _dw_provider._get_session() lazily to "
+        "respect session rotation + test mocks"
+    )
+
+
+def test_boot_discovery_passes_provider_credentials() -> None:
+    """The hook passes session + base_url + api_key from the
+    DoublewordProvider — pin at source so a refactor can't break
+    the wiring contract."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    # Find the actual await call site (NOT the import binding above it)
+    call_marker = "await _boot_discovery_once("
+    call_start = src.index(call_marker)
+    # Walk forward to the matching close paren
+    call_window = src[call_start:src.index(")", call_start) + 1]
+    for kw in ("session=", "base_url=", "api_key="):
+        assert kw in call_window, (
+            f"boot_discovery_once invocation must pass {kw}"
+        )

--- a/tests/governance/test_dw_catalog_client.py
+++ b/tests/governance/test_dw_catalog_client.py
@@ -97,10 +97,12 @@ def _client(session: Any, cache_path: Optional[Path] = None) -> DwCatalogClient:
 # ===========================================================================
 
 
-def test_discovery_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Slice A ships default-off; Slice E flips."""
+def test_discovery_default_on_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slice E graduation flip: unset/empty env returns True."""
     monkeypatch.delenv("JARVIS_DW_CATALOG_DISCOVERY_ENABLED", raising=False)
-    assert discovery_enabled() is False
+    assert discovery_enabled() is True
 
 
 def test_discovery_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -110,7 +112,10 @@ def test_discovery_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_discovery_falsy_values(monkeypatch: pytest.MonkeyPatch) -> None:
-    for val in ("0", "false", "no", "off", "", "garbage"):
+    """Post-graduation: empty string is the unset-marker for default
+    True, so it's NOT in the falsy list. Hot-revert requires an
+    explicit ``false``-class string."""
+    for val in ("0", "false", "no", "off", "garbage"):
         monkeypatch.setenv("JARVIS_DW_CATALOG_DISCOVERY_ENABLED", val)
         assert discovery_enabled() is False
 

--- a/tests/governance/test_dw_discovery_runner.py
+++ b/tests/governance/test_dw_discovery_runner.py
@@ -100,11 +100,12 @@ def _mock_session(json_body: Any = None, status: int = 200,
 # ---------------------------------------------------------------------------
 
 
-def test_catalog_discovery_enabled_default_off(
+def test_catalog_discovery_enabled_default_on_post_graduation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Slice E graduation flip: unset/empty env returns True."""
     monkeypatch.delenv("JARVIS_DW_CATALOG_DISCOVERY_ENABLED", raising=False)
-    assert catalog_discovery_enabled() is False
+    assert catalog_discovery_enabled() is True
 
 
 def test_catalog_discovery_enabled_truthy(
@@ -112,6 +113,14 @@ def test_catalog_discovery_enabled_truthy(
 ) -> None:
     monkeypatch.setenv("JARVIS_DW_CATALOG_DISCOVERY_ENABLED", "true")
     assert catalog_discovery_enabled() is True
+
+
+def test_catalog_discovery_enabled_falsy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hot-revert path."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_DISCOVERY_ENABLED", "false")
+    assert catalog_discovery_enabled() is False
 
 
 # ---------------------------------------------------------------------------
@@ -362,12 +371,20 @@ async def test_run_discovery_returns_discovery_result_type(
 
 
 @pytest.mark.asyncio
-async def test_run_discovery_does_not_change_dispatcher_view(
+async def test_run_discovery_authoritative_off_yaml_still_authoritative(
     isolated_cache: Path,
     isolated_ledger: PromotionLedger,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SHADOW MODE: discovery populates the holder; dispatcher's
-    ``dw_models_for_route`` still returns YAML-authored lists."""
+    """Hot-revert path post-graduation: with authoritative flag OFF,
+    discovery populates the holder but dispatcher's
+    ``dw_models_for_route`` still returns YAML's purged-empty list.
+
+    Originally pinned Slice C shadow-mode invariant (authoritative
+    didn't exist yet); rewritten at Slice E to pin the explicit-off
+    hot-revert path. Same architectural invariant: holder is NOT
+    consulted when authoritative is off."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "false")
     body = {"data": [
         {"id": "dynamic-vendor/m-99B", "parameter_count_b": 99,
          "pricing": {"output": 0.30}},
@@ -384,10 +401,11 @@ async def test_run_discovery_does_not_change_dispatcher_view(
         ledger=isolated_ledger,
         cache_path=isolated_cache,
     )
-    # YAML view UNCHANGED
+    # YAML view UNCHANGED (post-purge it's () — same before + after)
     yaml_complex_after = yaml_topo.dw_models_for_route("complex")
     assert yaml_complex_before == yaml_complex_after
-    # But the dynamic holder now has the new model
+    # But the dynamic holder DOES have the new model — discovery
+    # populated it; the authoritative flag just gated the read
     holder = get_dynamic_catalog()
     assert holder is not None
     assert (

--- a/tests/governance/test_phase12_graduation_pins.py
+++ b/tests/governance/test_phase12_graduation_pins.py
@@ -1,0 +1,427 @@
+"""Phase 12 Slice E — graduation pin suite.
+
+Pins the graduated state of the Phase 12 catalog discovery pipeline.
+Two flags flip together:
+
+  1. JARVIS_DW_CATALOG_DISCOVERY_ENABLED   — does discovery RUN?
+  2. JARVIS_DW_CATALOG_AUTHORITATIVE        — does dispatcher READ holder?
+
+Pin sections:
+  §1 All defaults are True (delenv → True)
+  §2 Empty-string env reads as default-True (the unset marker)
+  §3 Each ``"false"``-class override returns False (hot-revert path)
+  §4 Full-revert matrix — flipping each flag independently
+  §5 YAML purge invariant — dw_models arrays are empty for generative routes
+  §6 YAML policy fields preserved — fallback_tolerance, dw_allowed,
+                                     block_mode, reason all still YAML
+  §7 Boot-hook idempotence — second call in same process is a no-op
+  §8 Boot-hook respects discovery flag — disabled → returns None
+  §9 Boot-hook NEVER raises on transport failure
+  §10 Module-level public API surface — graduated readers callable
+"""
+from __future__ import annotations
+
+import os  # noqa: F401
+from pathlib import Path
+from typing import Any  # noqa: F401
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    dw_catalog_client as dcc,
+    dw_discovery_runner as ddr,
+    provider_topology as pt,
+)
+from backend.core.ouroboros.governance.dw_catalog_client import (
+    discovery_enabled,
+)
+from backend.core.ouroboros.governance.provider_topology import (
+    catalog_authoritative_enabled,
+    clear_dynamic_catalog,
+    get_topology,
+)
+
+
+# Centralized list of all 2 graduated flags + their reader callable.
+_GRADUATED_FLAGS = [
+    ("JARVIS_DW_CATALOG_DISCOVERY_ENABLED", discovery_enabled),
+    ("JARVIS_DW_CATALOG_AUTHORITATIVE", catalog_authoritative_enabled),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    clear_dynamic_catalog()
+    ddr.reset_boot_state_for_tests()
+    yield
+    clear_dynamic_catalog()
+    ddr.reset_boot_state_for_tests()
+
+
+@pytest.fixture
+def isolated_cache(tmp_path: Path,
+                   monkeypatch: pytest.MonkeyPatch) -> Path:
+    cache = tmp_path / "dw_catalog.json"
+    monkeypatch.setenv("JARVIS_DW_CATALOG_PATH", str(cache))
+    return cache
+
+
+@pytest.fixture
+def isolated_ledger_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    p = tmp_path / "ledger.json"
+    monkeypatch.setenv("JARVIS_DW_PROMOTION_LEDGER_PATH", str(p))
+    return p
+
+
+def _mock_session(json_body: Any = None, status: int = 200,
+                  raise_exc=None) -> Any:
+    session = MagicMock()
+
+    class _Resp:
+        def __init__(self) -> None:
+            self.status = status
+
+        async def __aenter__(self) -> "_Resp":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def json(self) -> Any:
+            return json_body
+
+    def _get(url: str, **kwargs: Any) -> Any:  # noqa: ARG001
+        if raise_exc is not None:
+            raise raise_exc
+        return _Resp()
+
+    session.get = _get
+    return session
+
+
+# ===========================================================================
+# §1 — All defaults are True
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_default_is_true_when_env_unset(
+    env_name: str, reader, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delenv → reader returns True."""
+    monkeypatch.delenv(env_name, raising=False)
+    assert reader() is True, (
+        f"Slice E graduation: {env_name} must default True"
+    )
+
+
+# ===========================================================================
+# §2 — Empty string is the unset marker
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_empty_string_reads_as_default_true(
+    env_name: str, reader, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setenv("", "")`` matches delenv. Operators commonly clear via
+    shell ``export FOO=`` (which sets to empty string)."""
+    monkeypatch.setenv(env_name, "")
+    assert reader() is True
+
+
+# ===========================================================================
+# §3 — Hot-revert: each false-class string returns False
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+@pytest.mark.parametrize("falsy", ["false", "0", "no", "off", "FALSE"])
+def test_false_class_string_reverts(
+    env_name: str, reader, falsy: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(env_name, falsy)
+    assert reader() is False, (
+        f"{env_name}={falsy!r} should disable the feature"
+    )
+
+
+# ===========================================================================
+# §4 — Full-revert matrix
+# ===========================================================================
+
+
+def test_full_revert_matrix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flip each flag off in turn; verify ONLY that one flag flips
+    while the other stays True. Catches accidental cross-coupling."""
+    for env_off, _ in _GRADUATED_FLAGS:
+        # Reset all to default (delenv) — graduated state
+        for env_name, _r in _GRADUATED_FLAGS:
+            monkeypatch.delenv(env_name, raising=False)
+        # Flip exactly one off
+        monkeypatch.setenv(env_off, "false")
+        # Verify the flipped one is off, the rest still True
+        for env_name, reader in _GRADUATED_FLAGS:
+            expected = (env_name != env_off)
+            actual = reader()
+            assert actual is expected, (
+                f"After flipping {env_off}=false, {env_name} reader "
+                f"returned {actual} (expected {expected})"
+            )
+
+
+# ===========================================================================
+# §5 — YAML purge invariant
+# ===========================================================================
+
+
+def test_yaml_dw_models_purged_for_generative_routes() -> None:
+    """Slice E PURGE: dw_models arrays in YAML are () for the four
+    generative routes. The catalog supplies them dynamically."""
+    topo = get_topology()
+    if not topo.enabled:
+        pytest.skip("yaml topology disabled")
+    for route in ("standard", "complex", "background", "speculative"):
+        # Pre-graduation YAML had non-empty lists. Post-graduation:
+        # empty (catalog is the source of truth).
+        # We can't read effective_dw_models here directly because
+        # the catalog might be populated. Instead, verify the YAML
+        # entry's raw dw_models field is empty.
+        entry = topo.routes.get(route)
+        assert entry is not None, f"route {route} missing from yaml"
+        assert entry.dw_models == (), (
+            f"Slice E purge: yaml's dw_models for {route!r} should be "
+            f"empty post-graduation, got {entry.dw_models}"
+        )
+
+
+def test_yaml_immediate_route_stays_empty() -> None:
+    """IMMEDIATE was empty pre-purge AND post-purge — Manifesto §5
+    Claude-direct route. Pinned to prevent accidental re-population."""
+    topo = get_topology()
+    if not topo.enabled:
+        pytest.skip("yaml topology disabled")
+    entry = topo.routes.get("immediate")
+    assert entry is not None
+    assert entry.dw_models == ()
+
+
+# ===========================================================================
+# §6 — YAML policy fields preserved (fallback_tolerance / block_mode / ...)
+# ===========================================================================
+
+
+def test_yaml_fallback_tolerance_preserved() -> None:
+    """Cost contract policy: fallback_tolerance stays YAML-authored
+    even after the dw_models purge. BG/SPEC must still be ``queue``;
+    STANDARD/COMPLEX must still be ``cascade_to_claude``."""
+    topo = get_topology()
+    if not topo.enabled:
+        pytest.skip("yaml topology disabled")
+    assert topo.fallback_tolerance_for_route("background") == "queue"
+    assert topo.fallback_tolerance_for_route("speculative") == "queue"
+    assert (
+        topo.fallback_tolerance_for_route("complex")
+        == "cascade_to_claude"
+    )
+    assert (
+        topo.fallback_tolerance_for_route("standard")
+        == "cascade_to_claude"
+    )
+
+
+def test_yaml_dw_allowed_preserved() -> None:
+    topo = get_topology()
+    if not topo.enabled:
+        pytest.skip("yaml topology disabled")
+    # All routes block legacy DW cascade — operator-controlled gate
+    # untouched by Slice E
+    for route in ("standard", "complex", "background", "speculative",
+                  "immediate"):
+        assert topo.dw_allowed_for_route(route) is False, (
+            f"dw_allowed for {route} should still be False post-purge"
+        )
+
+
+def test_yaml_block_mode_preserved() -> None:
+    topo = get_topology()
+    if not topo.enabled:
+        pytest.skip("yaml topology disabled")
+    assert topo.block_mode_for_route("background") == "skip_and_queue"
+    assert topo.block_mode_for_route("speculative") == "skip_and_queue"
+    assert topo.block_mode_for_route("standard") == "cascade_to_claude"
+    assert topo.block_mode_for_route("complex") == "cascade_to_claude"
+
+
+def test_yaml_reason_strings_present() -> None:
+    """``reason`` strings remain populated — they're operator-facing
+    documentation. Slice E refreshed them; pin they're non-empty."""
+    topo = get_topology()
+    if not topo.enabled:
+        pytest.skip("yaml topology disabled")
+    for route in ("standard", "complex", "background", "speculative"):
+        reason = topo.reason_for_route(route)
+        assert reason and len(reason) > 10, (
+            f"reason for {route!r} suspiciously short: {reason!r}"
+        )
+
+
+# ===========================================================================
+# §7 — Boot-hook idempotence
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_boot_discovery_only_runs_once(
+    isolated_cache: Path, isolated_ledger_path: Path,
+) -> None:
+    body = {"data": [
+        {"id": "vendor/m-50B", "parameter_count_b": 50,
+         "pricing": {"output": 0.5}},
+    ]}
+    session = _mock_session(body)
+    first = await ddr.boot_discovery_once(
+        session=session,
+        base_url="https://api.doubleword.ai",
+        api_key="test-key",
+    )
+    assert first is not None
+    assert first.ok is True
+    assert first.model_count == 1
+
+    # Second call must be a no-op (idempotent)
+    second = await ddr.boot_discovery_once(
+        session=session,
+        base_url="https://api.doubleword.ai",
+        api_key="test-key",
+    )
+    assert second is None  # idempotent skip marker
+
+
+@pytest.mark.asyncio
+async def test_boot_discovery_resets_via_test_helper(
+    isolated_cache: Path, isolated_ledger_path: Path,
+) -> None:
+    """``reset_boot_state_for_tests`` clears the boot flag so a
+    subsequent call runs again. Production code MUST NOT call this;
+    test pin only."""
+    session = _mock_session({"data": []})
+    first = await ddr.boot_discovery_once(
+        session=session,
+        base_url="https://api.doubleword.ai",
+        api_key="test-key",
+    )
+    assert first is not None
+    ddr.reset_boot_state_for_tests()
+    # After reset, boot fires again
+    second = await ddr.boot_discovery_once(
+        session=session,
+        base_url="https://api.doubleword.ai",
+        api_key="test-key",
+    )
+    assert second is not None
+
+
+# ===========================================================================
+# §8 — Boot-hook respects discovery flag
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_boot_discovery_skipped_when_disabled(
+    isolated_cache: Path, isolated_ledger_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hot-revert path: discovery off → boot returns None, never
+    issues the /models GET, never spawns refresh task."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_DISCOVERY_ENABLED", "false")
+    session = _mock_session({"data": []})
+    result = await ddr.boot_discovery_once(
+        session=session,
+        base_url="https://api.doubleword.ai",
+        api_key="test-key",
+    )
+    assert result is None
+
+
+# ===========================================================================
+# §9 — Boot-hook NEVER raises
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_boot_discovery_handles_transport_failure(
+    isolated_cache: Path, isolated_ledger_path: Path,
+) -> None:
+    """Transport-level exception during /models GET → boot still
+    returns a DiscoveryResult with failure_reason populated. NEVER
+    raises to caller (dispatcher safety pin)."""
+    session = _mock_session(raise_exc=RuntimeError("conn refused"))
+    result = await ddr.boot_discovery_once(
+        session=session,
+        base_url="https://api.doubleword.ai",
+        api_key="test-key",
+    )
+    assert result is not None
+    assert result.ok is False
+    assert result.fetch_failure_reason is not None
+
+
+@pytest.mark.asyncio
+async def test_boot_discovery_handles_5xx(
+    isolated_cache: Path, isolated_ledger_path: Path,
+) -> None:
+    session = _mock_session(json_body={}, status=503)
+    result = await ddr.boot_discovery_once(
+        session=session,
+        base_url="https://api.doubleword.ai",
+        api_key="test-key",
+    )
+    assert result is not None
+    assert result.ok is False
+    assert result.fetch_failure_reason == "http_503"
+
+
+# ===========================================================================
+# §10 — Module-level public API surface
+# ===========================================================================
+
+
+def test_module_level_readers_callable_with_no_args() -> None:
+    """Each reader is a zero-arg callable returning bool. Pins the
+    contract that the dispatcher relies on for read-time flag
+    introspection (no captured-at-init values that go stale on
+    hot-revert)."""
+    for _, reader in _GRADUATED_FLAGS:
+        result = reader()
+        assert isinstance(result, bool)
+
+
+def test_discovery_default_docstring_references_graduation() -> None:
+    """The reader's docstring must call out the Slice E graduation
+    flip — operator-facing documentation is the surface that
+    explains why the default changed."""
+    assert discovery_enabled.__doc__ is not None
+    assert "Slice E" in discovery_enabled.__doc__
+    assert "true" in discovery_enabled.__doc__.lower()
+
+
+def test_authoritative_default_docstring_references_graduation() -> None:
+    assert catalog_authoritative_enabled.__doc__ is not None
+    assert "Slice E" in catalog_authoritative_enabled.__doc__
+
+
+def test_boot_discovery_once_in_module_exports() -> None:
+    """The boot hook must be in __all__ — pinning the public API
+    surface so future refactors don't accidentally hide it."""
+    assert "boot_discovery_once" in ddr.__all__
+    assert "reset_boot_state_for_tests" in ddr.__all__

--- a/tests/governance/test_provider_topology_authority_handoff.py
+++ b/tests/governance/test_provider_topology_authority_handoff.py
@@ -60,9 +60,12 @@ def _yaml_has_complex_models() -> bool:
 # ---------------------------------------------------------------------------
 
 
-def test_authoritative_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_authoritative_default_on_post_graduation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slice E graduation flip: unset/empty env returns True."""
     monkeypatch.delenv("JARVIS_DW_CATALOG_AUTHORITATIVE", raising=False)
-    assert catalog_authoritative_enabled() is False
+    assert catalog_authoritative_enabled() is True
 
 
 def test_authoritative_truthy_values(
@@ -76,7 +79,9 @@ def test_authoritative_truthy_values(
 def test_authoritative_falsy_values(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    for val in ("0", "false", "no", "off", "", "garbage"):
+    """Post-graduation: empty string is the unset-marker for default
+    True. Hot-revert requires an explicit ``false``-class string."""
+    for val in ("0", "false", "no", "off", "garbage"):
         monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", val)
         assert catalog_authoritative_enabled() is False
 

--- a/tests/governance/test_provider_topology_dynamic_catalog.py
+++ b/tests/governance/test_provider_topology_dynamic_catalog.py
@@ -281,11 +281,19 @@ def test_yaml_diff_excludes_immediate_route() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_shadow_mode_dw_models_for_route_still_reads_yaml() -> None:
-    """The whole point of Slice C: populating the dynamic catalog
-    must NOT change what the dispatcher sees. ``dw_models_for_route``
-    continues returning the YAML-authored list even with the holder
-    populated. Slice D will flip this to read the holder first."""
+def test_authoritative_off_dw_models_for_route_still_reads_yaml(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hot-revert path post-graduation: with ``JARVIS_DW_CATALOG_
+    AUTHORITATIVE=false``, populating the dynamic catalog must NOT
+    change what the dispatcher sees. ``dw_models_for_route`` returns
+    YAML's empty list (post-purge ``dw_models: []``).
+
+    Originally pinned the Slice C shadow-mode contract; rewritten at
+    Slice E to pin the new authoritative-flag-off contract while
+    preserving the same architectural invariant: holder is NOT
+    consulted when authoritative is off."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "false")
     set_dynamic_catalog(
         {"complex": ("dynamic-only/exotic-99B",)},
         fetched_at_unix=time.time(),

--- a/tests/governance/test_provider_topology_v2.py
+++ b/tests/governance/test_provider_topology_v2.py
@@ -539,33 +539,29 @@ def test_production_yaml_parses_as_v2(
     assert topo.schema_version == pt.SCHEMA_VERSION_V2
 
 
-def test_production_yaml_routes_have_audit_recommended_dw_models() -> None:
-    """Slice 3 populated each route's v2 ``dw_models`` ranked list per
-    PRD §3.7.3 audit recommendations. Pin the exact rank order so an
-    accidental yaml refactor can't silently swap models."""
+def test_production_yaml_routes_post_purge_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phase 12 Slice E — YAML's per-route ``dw_models`` arrays were
+    purged. Catalog is now the source of truth. With authoritative=
+    false (hot-revert) AND no dynamic catalog populated, every route
+    returns ().
+
+    Pre-purge this test pinned the audit-recommended Kimi/GLM/Qwen
+    rank order; that ranking is now the deterministic classifier's
+    responsibility (covered by tests/governance/test_dw_catalog_
+    classifier.py). Slice E's responsibility is the purge invariant."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "false")
     pt._CACHED_TOPOLOGY = None
+    pt.clear_dynamic_catalog()
     topo = pt.get_topology()
-    # IMMEDIATE intentionally has NO dw_models (Manifesto §5 — Claude direct by design).
+    # IMMEDIATE was always empty by design (Manifesto §5 Claude-direct)
     assert topo.dw_models_for_route("immediate") == ()
-    # STANDARD + COMPLEX share the same ranked list.
-    expected_prefrontal = (
-        "moonshotai/Kimi-K2.6",
-        "zai-org/GLM-5.1-FP8",
-        "Qwen/Qwen3.6-35B-A3B-FP8",
-        "Qwen/Qwen3.5-397B-A17B",
-    )
-    assert topo.dw_models_for_route("standard") == expected_prefrontal
-    assert topo.dw_models_for_route("complex") == expected_prefrontal
-    # BACKGROUND is cost-sensitive — cheap-first ordering.
-    assert topo.dw_models_for_route("background") == (
-        "Qwen/Qwen3.6-35B-A3B-FP8",
-        "moonshotai/Kimi-K2.6",
-    )
-    # SPECULATIVE is fire-and-forget — ultra-cheap only.
-    assert topo.dw_models_for_route("speculative") == (
-        "Qwen/Qwen3.5-9B",
-        "Qwen/Qwen3.5-4B",
-    )
+    # The four generative routes are now empty post-purge
+    assert topo.dw_models_for_route("standard") == ()
+    assert topo.dw_models_for_route("complex") == ()
+    assert topo.dw_models_for_route("background") == ()
+    assert topo.dw_models_for_route("speculative") == ()
 
 
 def test_production_yaml_v1_block_mode_methods_unchanged() -> None:

--- a/tests/governance/test_topology_sentinel_dispatch.py
+++ b/tests/governance/test_topology_sentinel_dispatch.py
@@ -179,7 +179,9 @@ def test_circuit_breaker_master_off_legacy_path_unchanged(
 ) -> None:
     """When master flag is OFF, the breaker's verdict for a sealed
     BG route must be byte-identical to pre-Slice-3 (skip_and_queue
-    + non-read-only → True with topology_reason)."""
+    + non-read-only → True with topology_reason). Slice E refreshed
+    the reason text — no longer says 'Gemma'; says 'catalog-driven'
+    instead. The breaker logic itself is unchanged."""
     monkeypatch.delenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", raising=False)
     pt._CACHED_TOPOLOGY = None
     fired, reason = cb.should_circuit_break(
@@ -187,7 +189,15 @@ def test_circuit_breaker_master_off_legacy_path_unchanged(
         is_read_only=False,
     )
     assert fired is True
-    assert "Gemma" in reason or "stream-stall" in reason or "topology" in reason.lower()
+    # Post-Slice-E reason text variants — match either old or new
+    # reason wording so the test survives reason-string refreshes
+    rl = reason.lower()
+    assert (
+        "gemma" in rl
+        or "stream-stall" in rl
+        or "topology" in rl
+        or "catalog" in rl
+    )
 
 
 def test_circuit_breaker_master_off_read_only_carve_out_preserved(
@@ -207,12 +217,22 @@ def test_circuit_breaker_sentinel_on_all_severed_queue_fires(
 ) -> None:
     """With sentinel ON + every model in the route OPEN + fallback=queue,
     the breaker MUST fire (`sentinel_all_severed:...`). This is the
-    new evidence path that defends BG/SPEC unit economics."""
+    new evidence path that defends BG/SPEC unit economics.
+
+    Phase 12 Slice E — YAML's dw_models is purged; populate the
+    dynamic catalog with the test's model_ids so dw_models_for_route
+    has a list to walk. JARVIS_DW_CATALOG_AUTHORITATIVE is on by
+    default post-graduation."""
+    import time as _time
     monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
     monkeypatch.setenv(
         "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
     )
     pt._CACHED_TOPOLOGY = None
+    pt.set_dynamic_catalog(
+        {"background": ("Qwen/Qwen3.6-35B-A3B-FP8", "moonshotai/Kimi-K2.6")},
+        fetched_at_unix=_time.time(),
+    )
     ts.reset_default_sentinel_for_tests()
     sentinel = ts.get_default_sentinel()
     # Force every BG model to OPEN.
@@ -225,18 +245,26 @@ def test_circuit_breaker_sentinel_on_all_severed_queue_fires(
     assert fired is True
     assert "sentinel_all_severed" in reason
     ts.reset_default_sentinel_for_tests()
+    pt.clear_dynamic_catalog()
 
 
 def test_circuit_breaker_sentinel_on_one_model_healthy_holds_fire(
     monkeypatch: pytest.MonkeyPatch, tmp_path,
 ) -> None:
     """Sentinel ON + at least one BG model not OPEN → breaker does
-    NOT fire. The dispatcher will try that model."""
+    NOT fire. The dispatcher will try that model.
+
+    Phase 12 Slice E — populate dynamic catalog (YAML purged)."""
+    import time as _time
     monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
     monkeypatch.setenv(
         "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
     )
     pt._CACHED_TOPOLOGY = None
+    pt.set_dynamic_catalog(
+        {"background": ("Qwen/Qwen3.6-35B-A3B-FP8", "moonshotai/Kimi-K2.6")},
+        fetched_at_unix=_time.time(),
+    )
     ts.reset_default_sentinel_for_tests()
     sentinel = ts.get_default_sentinel()
     # Force only the first BG model OPEN; second remains CLOSED.
@@ -249,6 +277,7 @@ def test_circuit_breaker_sentinel_on_one_model_healthy_holds_fire(
     assert fired is False
     assert reason == "sentinel_dw_available"
     ts.reset_default_sentinel_for_tests()
+    pt.clear_dynamic_catalog()
 
 
 def test_circuit_breaker_sentinel_on_severed_cascade_holds_fire(
@@ -256,12 +285,24 @@ def test_circuit_breaker_sentinel_on_severed_cascade_holds_fire(
 ) -> None:
     """Sentinel ON + every STANDARD model OPEN + fallback=cascade_to_claude:
     breaker does NOT fire (cascade is the contract). The caller's
-    late-detection path will route to Claude."""
+    late-detection path will route to Claude.
+
+    Phase 12 Slice E — populate dynamic catalog (YAML purged)."""
+    import time as _time
     monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
     monkeypatch.setenv(
         "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
     )
     pt._CACHED_TOPOLOGY = None
+    pt.set_dynamic_catalog(
+        {"standard": (
+            "moonshotai/Kimi-K2.6",
+            "zai-org/GLM-5.1-FP8",
+            "Qwen/Qwen3.6-35B-A3B-FP8",
+            "Qwen/Qwen3.5-397B-A17B",
+        )},
+        fetched_at_unix=_time.time(),
+    )
     ts.reset_default_sentinel_for_tests()
     sentinel = ts.get_default_sentinel()
     # Force every STANDARD model OPEN.
@@ -279,6 +320,7 @@ def test_circuit_breaker_sentinel_on_severed_cascade_holds_fire(
     assert fired is False
     assert "sentinel_severed_cascade_to_claude" in reason
     ts.reset_default_sentinel_for_tests()
+    pt.clear_dynamic_catalog()
 
 
 # ---------------------------------------------------------------------------
@@ -292,49 +334,72 @@ def test_production_yaml_immediate_has_no_dw_models() -> None:
     assert topo.dw_models_for_route("immediate") == ()
 
 
-def test_production_yaml_standard_complex_share_ranked_list() -> None:
+def test_production_yaml_standard_complex_post_purge_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phase 12 Slice E — STANDARD/COMPLEX YAML dw_models lists are
+    purged (catalog is the source). With authoritative=false (hot-
+    revert) AND no catalog populated, both routes return ().
+
+    Pre-purge this test pinned 'Kimi-K2.6 first in STANDARD'; that
+    ranking is now the classifier's responsibility (covered by
+    test_dw_catalog_classifier.py)."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "false")
     pt._CACHED_TOPOLOGY = None
+    pt.clear_dynamic_catalog()
     topo = pt.get_topology()
-    assert topo.dw_models_for_route("standard") == (
-        topo.dw_models_for_route("complex")
-    )
-    # Pin first model to Kimi-K2.6 — the audit's primary pick.
-    assert topo.dw_models_for_route("standard")[0] == "moonshotai/Kimi-K2.6"
+    assert topo.dw_models_for_route("standard") == ()
+    assert topo.dw_models_for_route("complex") == ()
 
 
-def test_production_yaml_bg_cheap_first_ordering() -> None:
-    """BG is cost-sensitive; cheapest model first per PRD §3.7.3."""
+def test_production_yaml_bg_post_purge_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phase 12 Slice E — BG YAML dw_models is purged. Cheap-first
+    ordering is now classifier's responsibility (BACKGROUND gate
+    max_out_price=$0.5/M)."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "false")
     pt._CACHED_TOPOLOGY = None
+    pt.clear_dynamic_catalog()
     topo = pt.get_topology()
-    bg_models = topo.dw_models_for_route("background")
-    # Qwen3.6-35B is the cheapest in the BG list ($0.25/$2.00 per M).
-    assert bg_models[0] == "Qwen/Qwen3.6-35B-A3B-FP8"
+    assert topo.dw_models_for_route("background") == ()
 
 
-def test_production_yaml_speculative_only_ultra_cheap() -> None:
-    """SPECULATIVE must contain only the cheapest models in the
-    catalog — fire-and-forget pre-computation can't justify $1/M
-    output spend."""
+def test_production_yaml_speculative_post_purge_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phase 12 Slice E — SPECULATIVE YAML dw_models is purged.
+    Ultra-cheap-only constraint is now classifier's responsibility
+    (SPECULATIVE gate max_out_price=$0.1/M + Zero-Trust §3.6
+    quarantine pin for ambiguous-metadata models)."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "false")
     pt._CACHED_TOPOLOGY = None
+    pt.clear_dynamic_catalog()
     topo = pt.get_topology()
-    spec_models = topo.dw_models_for_route("speculative")
-    assert "Qwen/Qwen3.5-9B" in spec_models
-    assert "Qwen/Qwen3.5-4B" in spec_models
-    # No frontier-tier models slip in.
-    assert "moonshotai/Kimi-K2.6" not in spec_models
-    assert "Qwen/Qwen3.5-397B-A17B" not in spec_models
+    assert topo.dw_models_for_route("speculative") == ()
 
 
-def test_production_yaml_legacy_397b_demoted_to_last() -> None:
-    """The model that originally stream-stalled (Qwen3.5-397B) must
-    not be promoted ahead of the newer model families. Pin it last
-    in the STANDARD/COMPLEX rank — present (operators may want to
-    re-test it once stabilized) but not preferred."""
+def test_production_yaml_post_purge_no_static_curation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phase 12 Slice E PURGE invariant: no model_ids hardcoded in
+    YAML for any generative route. Catalog is the source. This test
+    is the source-level pin that prevents accidental re-introduction
+    of static curation in a future PR.
+
+    Pre-purge variants asserted 'Qwen3.5-397B-A17B demoted to last'
+    in STANDARD; that's now covered by classifier ranking weights."""
+    monkeypatch.setenv("JARVIS_DW_CATALOG_AUTHORITATIVE", "false")
     pt._CACHED_TOPOLOGY = None
+    pt.clear_dynamic_catalog()
     topo = pt.get_topology()
-    standard = topo.dw_models_for_route("standard")
-    if "Qwen/Qwen3.5-397B-A17B" in standard:
-        assert standard[-1] == "Qwen/Qwen3.5-397B-A17B"
+    for route in ("standard", "complex", "background", "speculative"):
+        entry = topo.routes.get(route)
+        assert entry is not None
+        assert entry.dw_models == (), (
+            f"Slice E purge: yaml dw_models for {route!r} should be "
+            f"empty — got {entry.dw_models}"
+        )
 
 
 def test_production_yaml_no_claude_models_in_dw_lists() -> None:

--- a/tests/governance/test_topology_sentinel_preflight.py
+++ b/tests/governance/test_topology_sentinel_preflight.py
@@ -68,6 +68,10 @@ def test_sentinel_init_error_empty_assertions() -> None:
 def test_preflight_returns_healthy_with_master_flag_on(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
+    """Phase 12 Slice E — post-purge YAML has empty dw_models on all
+    generative routes; preflight tolerates this with a
+    ``dw_models_pending_discovery`` diagnostic when discovery is
+    enabled. Healthy still True (boot hook fires after preflight)."""
     monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
     monkeypatch.setenv(
         "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
@@ -81,7 +85,10 @@ def test_preflight_returns_healthy_with_master_flag_on(
     assert result.flag_enabled is True
     assert result.topology_loaded is True
     assert result.schema_version == "topology.2"
-    assert "background" in result.routes_with_dw_models
+    # Post-purge: no routes have YAML-authored dw_models. Discovery
+    # populates them async; preflight runs before boot hook.
+    assert result.routes_with_dw_models == ()
+    assert "dw_models_pending_discovery" in result.diagnostics
     assert result.monitor_config_present is True
     assert result.state_dir_writable is True
     ts.reset_default_sentinel_for_tests()
@@ -102,11 +109,14 @@ def test_preflight_with_master_flag_off_still_returns_result(
     assert "master_flag_off" in result.diagnostics
 
 
-def test_preflight_routes_with_dw_models_drops_immediate(
+def test_preflight_routes_with_dw_models_post_purge(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
-    """IMMEDIATE has empty dw_models by design (Manifesto §5 — Claude
-    direct). It must NOT appear in routes_with_dw_models."""
+    """Phase 12 Slice E — post-purge YAML has empty dw_models on
+    every generative route. The dynamic catalog populates them after
+    boot. Pre-purge this test pinned ``standard`` and ``background``
+    in routes_with_dw_models; that assertion is now the catalog's
+    job (covered by Phase 12 graduation pin suite)."""
     monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
     monkeypatch.setenv(
         "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path),
@@ -115,9 +125,13 @@ def test_preflight_routes_with_dw_models_drops_immediate(
     pt._CACHED_TOPOLOGY = None
     ts.reset_default_sentinel_for_tests()
     result = ts.preflight_check()
+    # IMMEDIATE has empty dw_models by Manifesto §5 design (NOT just
+    # by purge) — that invariant survives Slice E
     assert "immediate" not in result.routes_with_dw_models
-    assert "standard" in result.routes_with_dw_models
-    assert "background" in result.routes_with_dw_models
+    # Post-purge YAML: all generative routes are empty until catalog
+    # populates them. preflight tolerates with a pending diagnostic
+    assert result.routes_with_dw_models == ()
+    assert "dw_models_pending_discovery" in result.diagnostics
     ts.reset_default_sentinel_for_tests()
 
 


### PR DESCRIPTION
## Summary

**Closes Phase 12.** Three things ship together:

1. **Flag graduation** — both `JARVIS_DW_CATALOG_DISCOVERY_ENABLED` and `JARVIS_DW_CATALOG_AUTHORITATIVE` flip default `false` → `true`
2. **Real boot-time hook** — `boot_discovery_once()` wired into `_dispatch_via_sentinel`, fires inline on first dispatch, spawns periodic refresh task
3. **YAML purge** — the hardcoded `dw_models:` arrays are removed from `brain_selection_policy.yaml`. Classifier owns ranking; YAML keeps only operator-controlled policy (`fallback_tolerance` / `block_mode` / `dw_allowed` / `reason`)

## (1) Flag graduation

| Flag | Pre-Slice-E default | Post-Slice-E default |
|---|---|---|
| `JARVIS_DW_CATALOG_DISCOVERY_ENABLED` | false | **true** |
| `JARVIS_DW_CATALOG_AUTHORITATIVE` | false | **true** |

Empty string is the unset marker (returns True). Hot-revert paths: setting either flag to `false` / `0` / `no` / `off` returns dispatcher to YAML-fallback semantics immediately.

## (2) Boot-time hook

```python
# candidate_generator.py:_dispatch_via_sentinel — first lines
try:
    from .dw_discovery_runner import boot_discovery_once
    if self._tier0 is not None and getattr(self._tier0, "is_available", True):
        session = await self._tier0._get_session()
        await boot_discovery_once(
            session=session,
            base_url=self._tier0._base_url,
            api_key=self._tier0._api_key,
        )
except Exception:  # NEVER blocks dispatch
    logger.debug(...)
```

- **Inline-awaited on first dispatch** so catalog is populated *before* `dw_models_for_route` is read. First op gets ~200ms boot latency; subsequent ops fast-path return None
- **Idempotent**: module-level boot flag + `asyncio.Lock` prevent double-init
- **Spawns periodic refresh task** (`JARVIS_DW_CATALOG_REFRESH_S`, default 1800s) via `asyncio.create_task` — runs forever, NEVER raises out of an iteration
- **Defensive**: try/except wrap means boot failures never propagate to dispatch. `self._tier0 is None` (J-Prime-only deployments) silently skips the hook
- Refresh loop **re-checks the discovery flag each cycle** so a hot-revert mid-process takes effect immediately without restart

## (3) YAML purge

```yaml
# brain_selection_policy.yaml — every generative route now:
complex:
  dw_allowed: false              # ← preserved (operator policy)
  block_mode: "cascade_to_claude"  # ← preserved
  reason: "Catalog-driven (Phase 12). Static list purged; ranking authority is dw_catalog_classifier..."
  dw_models: []                   # ← PURGED 2026-04-27
  fallback_tolerance: "cascade_to_claude"  # ← preserved
```

The four policy fields stay YAML-authored. Only `dw_models` swaps source. IMMEDIATE keeps `dw_models: []` (Manifesto §5 Claude-direct, never populated by classifier).

## Architectural fix: preflight cold-start tolerance

Pre-Slice-E preflight required `routes_with_dw_models` non-empty. Post-purge YAML is empty until the boot hook populates the catalog. Preflight runs *before* the boot hook fires, so we'd hit a chicken-and-egg.

Fix: preflight tolerates empty `routes_with_dw_models` when discovery is enabled — surfaces a `dw_models_pending_discovery` diagnostic instead of failing. When discovery is OFF *and* YAML is empty, that's still a genuine misconfiguration → `failed_assertions` populated.

## Cost contract preservation (three layers)

1. `fallback_tolerance` stays YAML-authored. BG/SPEC remain `queue` (no Claude cascade) regardless of catalog state
2. Hot-revert via either flag → YAML's empty list → cascade per `fallback_tolerance`:
   - BG/SPEC: queue (zero Claude burn)
   - STANDARD/COMPLEX: cascade_to_claude (operator-accepted degradation)
3. Source-level pins from Slice D survive: `fallback_tolerance` / `dw_allowed` / `block_mode` accessors NEVER read the dynamic holder

The Phase 11 cost contract (44 BG ops queued cleanly at $0.00 Claude burn in `bt-2026-04-27-235708`) is preserved structurally end-to-end.

## Graduation pin suite (30 tests + 6 boot-hook integration pins)

**Graduation pins** (`test_phase12_graduation_pins.py`):
- §1 Defaults true (delenv → True), parametrized per flag
- §2 Empty string reads as default-True (unset marker)
- §3 Hot-revert: each false-class string returns False
- §4 Full-revert matrix — each flag flippable independently
- §5 YAML purge invariant — all 4 generative routes have `dw_models == ()`
- §6 YAML policy fields preserved
- §7 Boot-hook idempotence
- §8 Boot-hook respects discovery flag
- §9 Boot-hook NEVER raises (transport failure, http 5xx)
- §10 Module-level public API surface preserved

**Boot-hook integration pins** (`test_candidate_generator_boot_hook.py`):
- §1 Boot hook called inside `_dispatch_via_sentinel`
- §2 Boot hook fires BEFORE `topology.dw_models_for_route` is read
- §3 Try/except wrap — NEVER blocks dispatch
- §4 Tolerates `self._tier0 is None`
- §5 Lazy session via `_get_session()`
- §6 Passes session + base_url + api_key

## Test plan

- [x] Slice E graduation pins: **30/30 green**
- [x] Boot hook integration pins: **6/6 green**
- [x] Combined Phase 12 (A+B+C+D+E): **199/199 green**
- [x] Existing topology + sentinel + provider_topology suites: **492/492 green** (zero regressions)
- [x] Phase 11 graduation pins: still green (unaffected — Phase 12 is orthogonal)
- [ ] Battle-test once-proof against merged HEAD — operator discretion

## Updated existing tests

- Slice C/D shadow-mode invariants rewritten as `authoritative=false` hot-revert pins
- `production_yaml_*` tests rewritten to assert post-purge state (empty lists)
- Circuit breaker tests populate dynamic catalog before forcing sentinel state (since YAML is purged)
- `test_preflight_returns_healthy_with_master_flag_on` updated to expect `dw_models_pending_discovery` diagnostic on cold-start

## Hot-revert paths (operator runbook)

```bash
# Disable entire Phase 12 stack — dispatcher returns to YAML fallback
export JARVIS_DW_CATALOG_DISCOVERY_ENABLED=false
# (BG/SPEC stay queue-only; STANDARD/COMPLEX cascade to Claude)

# Disable just the read-side, keep populating the holder for audit
export JARVIS_DW_CATALOG_AUTHORITATIVE=false

# Adjust refresh cadence
export JARVIS_DW_CATALOG_REFRESH_S=900   # 15 min

# Tune freshness threshold
export JARVIS_DW_CATALOG_MAX_AGE_S=3600  # 1h
```

## Phase 12 closure

Phase 12 ships the architectural arc end-to-end:

| Slice | Delivered | Status |
|---|---|---|
| A | Catalog client + Zero-Trust spec | ✅ Merged |
| B | Classifier + Promotion ledger + 12.2 blueprint | ✅ Merged |
| C | Discovery runner + dynamic catalog holder (shadow) | ✅ Merged |
| D | Authority handoff (catalog reads first, YAML fallback) | ✅ Merged |
| **E** | **Graduation + boot hook + YAML purge (this PR)** | **review** |

**Phase 12.2 (physics-aware topology routing)** — heavy probes, TTFT cold-storage detection, full-jitter backoff — remains the next architectural arc per `phase_12_2_physics_aware_topology_blueprint.md`. Independent of Phase 12; can ship anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates Phase 12: turns the dynamic DW catalog on by default and makes it authoritative, adds a boot-time discovery hook, and removes static `dw_models` from YAML. Preserves BG/SPEC queue-only cost behavior and makes preflight tolerant of cold-start discovery.

- **New Features**
  - Defaults on: `JARVIS_DW_CATALOG_DISCOVERY_ENABLED` and `JARVIS_DW_CATALOG_AUTHORITATIVE` now default to true; empty env equals “unset”.
  - Boot hook: `boot_discovery_once()` runs inside `_dispatch_via_sentinel`, awaits on first dispatch, then schedules periodic refresh (`JARVIS_DW_CATALOG_REFRESH_S`, default 1800s). Idempotent, try/except guarded, and skips cleanly if Tier0 is absent.
  - YAML purge: per-route `dw_models` lists removed; YAML keeps policy only (`fallback_tolerance`, `block_mode`, `dw_allowed`, `reason`). IMMEDIATE remains empty by design.
  - Preflight: tolerates empty `routes_with_dw_models` when discovery is enabled and adds `dw_models_pending_discovery` diagnostic.

- **Migration**
  - Hot-revert: set `JARVIS_DW_CATALOG_DISCOVERY_ENABLED=false` or `JARVIS_DW_CATALOG_AUTHORITATIVE=false` to fall back to YAML (now empty) and cascade per `fallback_tolerance`.
  - Cost contract unchanged: BG/SPEC queue; STANDARD/COMPLEX cascade to Claude if the catalog is unavailable.
  - Tunables: `JARVIS_DW_CATALOG_REFRESH_S` (refresh cadence) and `JARVIS_DW_CATALOG_MAX_AGE_S` (freshness).

<sup>Written for commit 0707e7d2a8bbab7af641ee32738fa4f685006848. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/26994?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

