### PR TITLE
Phase 12 Slice F: Substrate Error Unmasking — bubble HTTP status + body to dispatcher

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2081,35 +2081,94 @@ class CandidateGenerator:
 
             if _attempt_exc is not None:
                 exc = _attempt_exc
-                # Classify the failure for the sentinel. Stream-stall
-                # exceptions get LIVE_STREAM_STALL (weight 3.0 — single
-                # occurrence trips); transport/HTTP get LIVE_TRANSPORT;
-                # everything else falls through to LIVE_TRANSPORT as a
-                # catch-all (better to over-trip than under-trip on
-                # uncategorized errors).
                 err_str = str(exc)
                 err_lower = err_str.lower()
-                if (
-                    "stream" in err_lower
-                    and ("stall" in err_lower or "timeout" in err_lower)
-                ) or "streamtimeouterror" in err_lower:
-                    failure_source = FailureSource.LIVE_STREAM_STALL
-                elif "429" in err_str:
-                    failure_source = FailureSource.LIVE_HTTP_429
-                elif "5" in err_str[:5] and (
-                    "500" in err_str or "502" in err_str
-                    or "503" in err_str or "504" in err_str
-                ):
-                    failure_source = FailureSource.LIVE_HTTP_5XX
-                elif "parse" in err_lower or "json" in err_lower:
-                    failure_source = FailureSource.LIVE_PARSE_ERROR
-                else:
+
+                # Phase 12 Slice F — Substrate Error Unmasking. When
+                # the exception is a DoublewordInfraError (or any
+                # structurally-unmasked equivalent that carries a
+                # ``status_code`` attribute), classify FROM THE
+                # STRUCTURED FIELD instead of regex on str(exc). This
+                # is the substrate of Slice H's terminal-vs-transient
+                # distinction — we MUST know the actual HTTP status to
+                # decide TERMINAL_OPEN vs OPEN.
+                _status_code = getattr(exc, "status_code", None)
+                _response_body = getattr(exc, "response_body", "") or ""
+                _is_modality = bool(
+                    getattr(exc, "is_modality_error", lambda: False)()
+                )
+                _is_auth_terminal = bool(
+                    getattr(exc, "is_terminal_auth_error", lambda: False)()
+                )
+
+                if _is_modality or _is_auth_terminal:
+                    # Slice H — terminal failure class. Even though we
+                    # report it as LIVE_HTTP_5XX semantics here for
+                    # back-compat, the breaker (Slice H wiring) will
+                    # read the structured exception fields when
+                    # available and flip the model's state to
+                    # TERMINAL_OPEN. For now, classify with a body-
+                    # accurate failure source so observers can audit
+                    # the unmasked status.
                     failure_source = FailureSource.LIVE_TRANSPORT
+                elif _status_code is not None:
+                    # Structured HTTP status drives classification
+                    if _status_code == 429:
+                        failure_source = FailureSource.LIVE_HTTP_429
+                    elif _status_code in (500, 502, 503, 504):
+                        failure_source = FailureSource.LIVE_HTTP_5XX
+                    elif _status_code == 0:
+                        # Non-HTTP failure: stream stall / DNS / TLS
+                        if (
+                            "stream" in err_lower
+                            and ("stall" in err_lower or "timeout" in err_lower)
+                        ) or "streamtimeouterror" in err_lower:
+                            failure_source = FailureSource.LIVE_STREAM_STALL
+                        else:
+                            failure_source = FailureSource.LIVE_TRANSPORT
+                    else:
+                        failure_source = FailureSource.LIVE_TRANSPORT
+                else:
+                    # No status_code attribute → fall back to regex on
+                    # str(exc) (legacy path for non-DW exceptions).
+                    if (
+                        "stream" in err_lower
+                        and ("stall" in err_lower or "timeout" in err_lower)
+                    ) or "streamtimeouterror" in err_lower:
+                        failure_source = FailureSource.LIVE_STREAM_STALL
+                    elif "429" in err_str:
+                        failure_source = FailureSource.LIVE_HTTP_429
+                    elif "5" in err_str[:5] and (
+                        "500" in err_str or "502" in err_str
+                        or "503" in err_str or "504" in err_str
+                    ):
+                        failure_source = FailureSource.LIVE_HTTP_5XX
+                    elif "parse" in err_lower or "json" in err_lower:
+                        failure_source = FailureSource.LIVE_PARSE_ERROR
+                    else:
+                        failure_source = FailureSource.LIVE_TRANSPORT
                 try:
-                    sentinel.report_failure(
-                        model_id, failure_source,
-                        f"{type(exc).__name__}:{err_str[:120]}",
-                    )
+                    # Pass structured fields to the sentinel so Slice H
+                    # can use them for terminal-vs-transient decisions.
+                    # Backward-compatible: legacy report_failure
+                    # signature is preserved; structured fields are
+                    # added via best-effort kwargs that the sentinel
+                    # silently drops if it doesn't yet support them.
+                    try:
+                        sentinel.report_failure(
+                            model_id, failure_source,
+                            f"{type(exc).__name__}:{err_str[:120]}",
+                            status_code=_status_code,
+                            response_body=_response_body,
+                            is_terminal=(_is_modality or _is_auth_terminal),
+                        )
+                    except TypeError:
+                        # Sentinel doesn't accept new kwargs yet (pre-
+                        # Slice-H sentinel) — fall back to legacy call
+                        sentinel.report_failure(
+                            model_id, failure_source,
+                            f"{type(exc).__name__}:{err_str[:120]}",
+                        )
                 except Exception:
                     logger.debug(
                         "[CandidateGenerator] sentinel.report_failure raised",
@@ -2119,12 +2178,27 @@ class CandidateGenerator:
                     f"{model_id}:{failure_source.value}:"
                     f"{type(exc).__name__}"
                 )
-                logger.warning(
-                    "[CandidateGenerator] Sentinel dispatch: model=%s "
-                    "FAILED (source=%s, exc=%s) — trying next (op=%s)",
-                    model_id, failure_source.value,
-                    type(exc).__name__, op_id_short,
-                )
+                # Slice F — log the unmasked status_code + body excerpt
+                # alongside the legacy WARNING line so operators see
+                # ground truth in debug.log immediately.
+                if _status_code is not None and _status_code > 0:
+                    logger.warning(
+                        "[CandidateGenerator] Sentinel dispatch: model=%s "
+                        "FAILED (source=%s, http_%d, body=%r%s%s) — "
+                        "trying next (op=%s)",
+                        model_id, failure_source.value, _status_code,
+                        _response_body[:160],
+                        ", modality_terminal=true" if _is_modality else "",
+                        ", auth_terminal=true" if _is_auth_terminal else "",
+                        op_id_short,
+                    )
+                else:
+                    logger.warning(
+                        "[CandidateGenerator] Sentinel dispatch: model=%s "
+                        "FAILED (source=%s, exc=%s) — trying next (op=%s)",
+                        model_id, failure_source.value,
+                        type(exc).__name__, op_id_short,
+                    )
                 attempts[-1] = f"{model_id}:failed:{failure_source.value}"
                 continue
         # All DW models exhausted (either OPEN or failed). The
@@ -2458,6 +2532,16 @@ class CandidateGenerator:
         _dw_error: Optional[str] = None
 
         # DW attempt — RT SSE preferred, batch fallback.
+        # Phase 12 Slice F — Substrate Error Unmasking. Preserve the
+        # underlying DoublewordInfraError on this attempt so the
+        # sentinel-driven dispatcher can read its status_code +
+        # response_body fields directly. The exception is still
+        # caught here (so the legacy non-sentinel path can fall
+        # through to Claude as before via _dw_error string), but
+        # _structured_error captures the structured object for the
+        # caller — when present, the caller re-raises it instead of
+        # stringifying it through RuntimeError(_dw_error).
+        _structured_error: Optional[Exception] = None
         if getattr(self._tier0, "_realtime_enabled", False):
             try:
                 result = await asyncio.wait_for(
@@ -2477,9 +2561,21 @@ class CandidateGenerator:
             except asyncio.TimeoutError:
                 _dw_error = f"background_dw_timeout:{_dw_timeout:.0f}s"
             except Exception as exc:
-                _dw_error = (
-                    f"background_dw_error:{type(exc).__name__}:{exc}"
-                )
+                _structured_error = exc  # Slice F preserves the object
+                # Build a richer _dw_error that surfaces status_code
+                # + a body excerpt when available (DoublewordInfraError),
+                # so legacy log-line consumers see ground truth too.
+                _status = getattr(exc, "status_code", None)
+                _body = getattr(exc, "response_body", "") or ""
+                if _status is not None:
+                    _dw_error = (
+                        f"background_dw_error:{type(exc).__name__}:"
+                        f"http_{_status}:{_body[:120]}"
+                    )
+                else:
+                    _dw_error = (
+                        f"background_dw_error:{type(exc).__name__}:{exc}"
+                    )
         else:
             # Legacy batch path
             try:
@@ -2522,6 +2618,15 @@ class CandidateGenerator:
                     f"{type(exc).__name__}:{str(exc)[:80]}"
                 ) from exc
 
+        # Phase 12 Slice F — Substrate Error Unmasking. When DW raised
+        # a structured DoublewordInfraError (status_code + response_body
+        # available), re-raise the ORIGINAL object so the sentinel
+        # dispatch classifier can introspect status_code directly
+        # without regex on str(exc). Falls through to RuntimeError when
+        # the failure was a timeout / empty-result (no structured
+        # exception to preserve).
+        if _structured_error is not None:
+            raise _structured_error
         raise RuntimeError(_dw_error)
 
     async def _generate_speculative(

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -97,11 +97,83 @@ class DoublewordInfraError(Exception):
     classify the failure mode (rate limit vs timeout vs connection error)
     and predict recovery timing.  The ``status_code`` field carries the
     HTTP status (429, 500, etc.) or 0 for non-HTTP failures.
+
+    Phase 12 Slice F — Substrate Error Unmasking (operator-mandated
+    2026-04-27): added ``response_body`` and ``model_id`` so the
+    sentinel + classifier can distinguish 4xx modality errors (NON_CHAT
+    models silently slotted into generative routes) from 5xx transport
+    errors (genuine endpoint instability) without regex-matching on the
+    string repr.
+
+    Failure-class taxonomy carried structurally:
+      * ``status_code in (400, 404, 422)`` AND modality body markers
+        → terminal/modality error, model permanently excluded by
+        Slice H breaker until next catalog refresh
+      * ``status_code in (429, 503)`` → rate limit / overload, retry
+      * ``status_code in (500, 502, 504)`` → transient transport
+      * ``status_code == 401`` / ``403`` → auth failure, terminal
+      * ``status_code == 0`` → non-HTTP (DNS/TLS/timeout)
     """
 
-    def __init__(self, reason: str, status_code: int = 0) -> None:
+    def __init__(
+        self,
+        reason: str,
+        status_code: int = 0,
+        *,
+        response_body: str = "",
+        model_id: str = "",
+    ) -> None:
         super().__init__(reason)
         self.status_code = status_code
+        self.response_body = (response_body or "")[:1024]  # bounded
+        self.model_id = (model_id or "")[:128]
+
+    def is_modality_error(self) -> bool:
+        """True iff the response indicates the model can't accept
+        ``/chat/completions`` payloads. Used by Slice H breaker to
+        decide TERMINAL_OPEN vs transient.
+
+        Heuristic on KNOWN-AT-RUNTIME signals (NOT regex on model id):
+          * status_code in {400, 404, 422} — bad request / not found /
+            unprocessable entity (classic OpenAI-compat modality 4xx)
+          * AND response_body contains a modality marker the DW server
+            actually emits
+        Both required: a 400 about a bad max_tokens is NOT modality.
+        """
+        if self.status_code not in (400, 404, 422):
+            return False
+        body_lower = (self.response_body or "").lower()
+        # These markers are observed in DW + OpenAI-compat error
+        # responses for modality-mismatched calls. Matched on the
+        # SERVER's response body (which is ground truth from DW),
+        # NOT on our local model_id string. If DW returns a body
+        # without these markers, we conservatively treat it as
+        # transient — we don't infer modality from absence.
+        markers = (
+            "does not support chat",
+            "not a chat model",
+            "endpoint not supported",
+            "embedding only",
+            "model_not_chat",
+            "task mismatch",
+            "wrong endpoint",
+            "unsupported endpoint",
+            "model is not available for chat",
+        )
+        return any(m in body_lower for m in markers)
+
+    def is_terminal_auth_error(self) -> bool:
+        """401/403 → permanent auth failure for this model_id."""
+        return self.status_code in (401, 403)
+
+    def is_transient(self) -> bool:
+        """5xx + 429 → transient; should retry per backoff schedule."""
+        if self.status_code in (429, 503, 500, 502, 504):
+            return True
+        # Non-HTTP failures (status_code == 0) — DNS/TLS/timeout —
+        # treated as transient unless the reason text indicates
+        # something terminal. Conservative: assume transient.
+        return self.status_code == 0
 
 
 @dataclass
@@ -985,9 +1057,16 @@ class DoublewordProvider:
                     if resp.status >= 300:
                         self._last_error_status = resp.status
                         err_body = await resp.text()
+                        # Phase 12 Slice F — Substrate Error Unmasking.
+                        # Preserve full response body + model_id so
+                        # downstream classifier can distinguish modality
+                        # 4xx from transient 5xx without regex on str(exc).
                         raise DoublewordInfraError(
-                            f"Chat completions (stream) failed: {resp.status} {err_body[:200]}",
+                            f"Chat completions (stream) failed: "
+                            f"{resp.status} {err_body[:200]}",
                             status_code=resp.status,
+                            response_body=err_body,
+                            model_id=_effective_model,
                         )
 
                     # Parse SSE stream with per-chunk timeout to detect stalled streams
@@ -1036,9 +1115,13 @@ class DoublewordProvider:
                     if resp.status >= 300:
                         self._last_error_status = resp.status
                         err_body = await resp.text()
+                        # Slice F — preserve full body + model_id
                         raise DoublewordInfraError(
-                            f"Chat completions failed: {resp.status} {err_body[:200]}",
+                            f"Chat completions failed: "
+                            f"{resp.status} {err_body[:200]}",
                             status_code=resp.status,
+                            response_body=err_body,
+                            model_id=_effective_model,
                         )
 
                     data = await resp.json()

--- a/tests/governance/test_dw_substrate_error_unmasking.py
+++ b/tests/governance/test_dw_substrate_error_unmasking.py
@@ -1,0 +1,349 @@
+"""Phase 12 Slice F — Substrate Error Unmasking regression spine.
+
+Pins the ground-truth-error contract:
+  * DoublewordInfraError carries status_code + response_body + model_id
+  * is_modality_error() / is_terminal_auth_error() / is_transient()
+    classify FROM STRUCTURED FIELDS, never regex on model_id
+  * candidate_generator._generate_background re-raises the structured
+    exception instead of stringifying through RuntimeError(_dw_error)
+  * Sentinel dispatch classifier reads status_code attribute first,
+    falling back to str(exc) regex only when status_code is absent
+
+Pins:
+  §1 DoublewordInfraError carries the new structured fields
+  §2 Bounded buffers — response_body capped at 1024, model_id capped at 128
+  §3 is_modality_error: 4xx + body marker required (NOT regex on id)
+  §4 is_modality_error: 4xx alone with no marker → False (conservative)
+  §5 is_modality_error: status_code outside 400/404/422 → False
+  §6 is_terminal_auth_error: 401 / 403 → True
+  §7 is_transient: 429/5xx + non-HTTP → True; modality 4xx → False
+  §8 _generate_background re-raises structured exception (preserves
+     status_code through the dispatcher chain)
+  §9 _generate_background non-structured exceptions still raise
+     RuntimeError (legacy path preserved)
+  §10 Sentinel dispatch classifier prefers structured status_code over
+      str(exc) regex match (HTTP 503 in body but status_code=400 →
+      LIVE_TRANSPORT, not LIVE_HTTP_5XX)
+  §11 Modality marker bodies — observed DW + OpenAI-compat strings
+  §12 No regex on model_id anywhere — Slice G enforces this; Slice F
+      pins that the unmasking layer doesn't introduce it
+"""
+from __future__ import annotations
+
+import inspect
+from typing import Any  # noqa: F401
+
+import pytest
+
+from backend.core.ouroboros.governance import candidate_generator as cg
+from backend.core.ouroboros.governance.doubleword_provider import (
+    DoublewordInfraError,
+)
+
+
+# ---------------------------------------------------------------------------
+# §1 — Structured fields present on DoublewordInfraError
+# ---------------------------------------------------------------------------
+
+
+def test_infra_error_carries_status_response_body_model_id() -> None:
+    err = DoublewordInfraError(
+        "Chat completions failed: 400 task mismatch",
+        status_code=400,
+        response_body='{"error": "model does not support chat"}',
+        model_id="Qwen/Qwen3-Embedding-8B",
+    )
+    assert err.status_code == 400
+    assert "does not support chat" in err.response_body
+    assert err.model_id == "Qwen/Qwen3-Embedding-8B"
+
+
+def test_infra_error_legacy_two_arg_construction_still_works() -> None:
+    """Pre-Slice-F callers passing only (reason, status_code) must
+    continue to work. New fields default to empty string."""
+    err = DoublewordInfraError("Chat completions failed", status_code=503)
+    assert err.status_code == 503
+    assert err.response_body == ""
+    assert err.model_id == ""
+
+
+# ---------------------------------------------------------------------------
+# §2 — Bounded buffers
+# ---------------------------------------------------------------------------
+
+
+def test_response_body_bounded_to_1024_chars() -> None:
+    body = "x" * 5000
+    err = DoublewordInfraError("oops", status_code=500, response_body=body)
+    assert len(err.response_body) == 1024
+
+
+def test_model_id_bounded_to_128_chars() -> None:
+    err = DoublewordInfraError(
+        "oops", status_code=500, model_id="z" * 500,
+    )
+    assert len(err.model_id) == 128
+
+
+def test_none_inputs_coerce_to_empty_string() -> None:
+    err = DoublewordInfraError(
+        "oops",
+        status_code=500,
+        response_body=None,    # type: ignore[arg-type]
+        model_id=None,         # type: ignore[arg-type]
+    )
+    assert err.response_body == ""
+    assert err.model_id == ""
+
+
+# ---------------------------------------------------------------------------
+# §3 — is_modality_error: requires 4xx AND body marker (no regex on id)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("body_marker", [
+    "model does not support chat",
+    "Not a chat model — this is an OCR specialist",
+    "endpoint not supported for this model",
+    "Embedding only — please use /v1/embeddings",
+    "MODEL_NOT_CHAT",
+    "Task mismatch: request was for chat",
+    "Wrong endpoint",
+    "Unsupported endpoint",
+    "model is not available for chat",
+])
+def test_modality_error_4xx_with_marker(body_marker: str) -> None:
+    """All observed DW + OpenAI-compat modality markers."""
+    err = DoublewordInfraError(
+        f"Chat completions failed: 400 {body_marker}",
+        status_code=400,
+        response_body=body_marker,
+        model_id="lightonai/LightOnOCR-2-1B-bbox-soup",
+    )
+    assert err.is_modality_error() is True
+
+
+@pytest.mark.parametrize("status", [400, 404, 422])
+def test_modality_error_accepts_400_404_422(status: int) -> None:
+    err = DoublewordInfraError(
+        "model does not support chat",
+        status_code=status,
+        response_body="model does not support chat",
+    )
+    assert err.is_modality_error() is True
+
+
+# ---------------------------------------------------------------------------
+# §4 — Conservative: 4xx without marker → NOT modality
+# ---------------------------------------------------------------------------
+
+
+def test_modality_error_400_without_marker_is_not_terminal() -> None:
+    """A 400 about bad max_tokens must NOT be classified as modality
+    — that would permanently kill an otherwise-healthy model."""
+    err = DoublewordInfraError(
+        "Chat completions failed: 400 max_tokens out of range",
+        status_code=400,
+        response_body="max_tokens must be <= 8192",
+        model_id="Qwen/Qwen3.5-9B",
+    )
+    assert err.is_modality_error() is False
+
+
+def test_modality_error_400_empty_body_is_not_terminal() -> None:
+    err = DoublewordInfraError(
+        "Bad request",
+        status_code=400,
+        response_body="",
+    )
+    assert err.is_modality_error() is False
+
+
+# ---------------------------------------------------------------------------
+# §5 — Non-modality status codes never modality
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [200, 401, 403, 429, 500, 502, 503, 504])
+def test_modality_error_non_4xx_modality_codes_are_false(status: int) -> None:
+    """Even with a body that says 'does not support chat', if the
+    status is 503, it's not a modality verdict — server is overloaded."""
+    err = DoublewordInfraError(
+        "oops",
+        status_code=status,
+        response_body="model does not support chat",
+    )
+    assert err.is_modality_error() is False
+
+
+# ---------------------------------------------------------------------------
+# §6 — is_terminal_auth_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_terminal_auth_error_for_401_403(status: int) -> None:
+    err = DoublewordInfraError("auth failed", status_code=status)
+    assert err.is_terminal_auth_error() is True
+
+
+@pytest.mark.parametrize("status", [400, 404, 422, 429, 500, 503, 0])
+def test_terminal_auth_error_false_for_others(status: int) -> None:
+    err = DoublewordInfraError("oops", status_code=status)
+    assert err.is_terminal_auth_error() is False
+
+
+# ---------------------------------------------------------------------------
+# §7 — is_transient
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
+def test_transient_for_5xx_and_429(status: int) -> None:
+    err = DoublewordInfraError("oops", status_code=status)
+    assert err.is_transient() is True
+
+
+def test_transient_for_non_http_zero() -> None:
+    """status_code=0 = DNS/TLS/network — conservative: assume transient."""
+    err = DoublewordInfraError("connection refused", status_code=0)
+    assert err.is_transient() is True
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+def test_transient_false_for_modality_and_auth_4xx(status: int) -> None:
+    err = DoublewordInfraError("oops", status_code=status)
+    assert err.is_transient() is False
+
+
+# ---------------------------------------------------------------------------
+# §8 — _generate_background re-raises structured exception
+# ---------------------------------------------------------------------------
+
+
+def test_source_generate_background_preserves_structured_error() -> None:
+    """Source-level pin: ``_generate_background`` MUST re-raise the
+    structured DoublewordInfraError (or any exception with status_code)
+    instead of stringifying it through RuntimeError(_dw_error).
+
+    This is the substrate of Slice H's terminal-vs-transient breaker
+    — without the structured object surviving, the breaker can't read
+    status_code."""
+    src = inspect.getsource(cg.CandidateGenerator._generate_background)
+    # The new path must capture the original exception
+    assert "_structured_error" in src
+    # And re-raise it before the legacy RuntimeError fallback
+    structured_idx = src.index("raise _structured_error")
+    legacy_idx = src.index("raise RuntimeError(_dw_error)")
+    assert structured_idx < legacy_idx, (
+        "structured exception must re-raise BEFORE the legacy "
+        "RuntimeError fallback so DoublewordInfraError reaches the "
+        "dispatcher with status_code intact"
+    )
+
+
+def test_source_generate_background_captures_status_code() -> None:
+    """The _dw_error string must surface status_code when available
+    so legacy log-line consumers see ground truth too."""
+    src = inspect.getsource(cg.CandidateGenerator._generate_background)
+    assert "status_code" in src
+    assert "response_body" in src
+
+
+# ---------------------------------------------------------------------------
+# §9 — Legacy path preserved for non-structured exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_source_generate_background_legacy_runtime_error_path() -> None:
+    """Non-structured exceptions (timeouts, empty results) still raise
+    RuntimeError as before — Slice F doesn't change the shape of the
+    legacy path, only adds the structured-preserve branch."""
+    src = inspect.getsource(cg.CandidateGenerator._generate_background)
+    # Both raise paths exist
+    assert "raise _structured_error" in src
+    assert "raise RuntimeError(_dw_error)" in src
+
+
+# ---------------------------------------------------------------------------
+# §10 — Sentinel classifier prefers structured status_code
+# ---------------------------------------------------------------------------
+
+
+def test_source_sentinel_dispatch_uses_status_code_first() -> None:
+    """Source-level pin: the sentinel dispatch classifier MUST check
+    ``getattr(exc, 'status_code', None)`` BEFORE falling back to
+    str(exc) regex. Pin the ordering."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    status_idx = src.index('"status_code"')
+    # The legacy regex check ("429" in err_str) is the fallback path —
+    # it must appear AFTER the structured check
+    legacy_idx = src.rindex('"429" in err_str')
+    assert status_idx < legacy_idx, (
+        "sentinel dispatch must check structured status_code BEFORE "
+        "falling back to str(exc) regex match"
+    )
+
+
+def test_source_sentinel_dispatch_logs_unmasked_status() -> None:
+    """The unmasked status_code must appear in the WARNING log line
+    so operators see ground truth in debug.log without further
+    introspection. Pin source-level."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert "http_%d" in src or "http_{" in src, (
+        "sentinel WARNING line must include unmasked status code"
+    )
+    assert "body=" in src, (
+        "sentinel WARNING line must include response body excerpt"
+    )
+
+
+# ---------------------------------------------------------------------------
+# §11 — Sentinel classifier passes structured fields to report_failure
+# ---------------------------------------------------------------------------
+
+
+def test_source_sentinel_dispatch_forwards_structured_to_report() -> None:
+    """report_failure() is called with status_code + response_body
+    + is_terminal kwargs. Slice H breaker reads those to decide
+    TERMINAL_OPEN vs OPEN. Slice F pre-wires this so Slice H is a
+    drop-in addition on the sentinel side."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert "status_code=_status_code" in src
+    assert "response_body=_response_body" in src
+    assert "is_terminal=" in src
+
+
+def test_source_sentinel_dispatch_falls_back_on_typeerror() -> None:
+    """Pre-Slice-H sentinels don't accept the new kwargs — the dispatch
+    must fall back to the legacy 3-arg call on TypeError so we don't
+    break any in-flight rollout."""
+    src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+    assert "except TypeError" in src
+    # Legacy fallback present
+    fallback_window = src[src.index("except TypeError"):]
+    assert "report_failure" in fallback_window[:500]
+
+
+# ---------------------------------------------------------------------------
+# §12 — No regex on model_id in unmasking layer
+# ---------------------------------------------------------------------------
+
+
+def test_no_regex_on_model_id_in_unmasking_layer() -> None:
+    """Operator-mandated: capability/modality decisions MUST NOT be
+    derived from regex pattern-matching on model_id (e.g. checking
+    'Embedding' or 'OCR' in id). Slice F's classification reads
+    status_code + response_body markers ONLY. Pin this source-level
+    so a future PR can't silently re-introduce the Zero-Order shortcut."""
+    src = inspect.getsource(DoublewordInfraError.is_modality_error)
+    # The function must not import re or do pattern-match on model_id
+    assert "self.model_id" not in src, (
+        "is_modality_error must NOT read self.model_id — that would be "
+        "regex-on-id, the Zero-Order shortcut the operator rejected"
+    )
+    assert "import re" not in src
+    # It MUST read self.response_body (the server-side ground truth)
+    assert "self.response_body" in src
+    # And status_code (the structured field)
+    assert "self.status_code" in src


### PR DESCRIPTION
## Summary

Operator directive 2026-04-27: stop swallowing DW HTTP errors into generic `RuntimeError("live_transport")`. Bubble actual `status_code` + `response_body` up to the dispatcher so Slice H breaker can distinguish terminal modality 4xx from transient 5xx **structurally — no regex on model_id allowed**.

## What the once-proof exposed

Session `bt-2026-04-28-024216` showed every dynamically-discovered DW model failing within ~1 second with a generic `RuntimeError`. The 1-second timing ruled out stream-stall (those take 30s); the underlying error was being **stringified and lost** at `candidate_generator.py:2479-2482, 2525`:

```python
except Exception as exc:
    _dw_error = f"background_dw_error:{type(exc).__name__}:{exc}"  # ← lost status_code
...
raise RuntimeError(_dw_error)  # ← generic re-wrap
```

The DoublewordInfraError carrying `status_code=400` was decomposed into a string and re-raised as `RuntimeError`. The dispatcher's classifier saw `exc=RuntimeError`, regex'd on `str(exc)`, and fell through to `LIVE_TRANSPORT` — losing all signal about *why* DW rejected the call.

## What ships

### `DoublewordInfraError` extended (~70 lines added)
- `response_body: str` (bounded 1024 chars), `model_id: str` (bounded 128 chars)
- `is_modality_error()` — 4xx (400/404/422) AND body marker required:

```python
markers = (
    "does not support chat", "not a chat model",
    "endpoint not supported", "embedding only",
    "model_not_chat", "task mismatch", "wrong endpoint",
    "unsupported endpoint", "model is not available for chat",
)
```

  **NEVER reads `self.model_id`** — operator-rejected Zero-Order shortcut. Server-side response body markers are the ground truth.
- `is_terminal_auth_error()` — 401/403
- `is_transient()` — 5xx + 429 + non-HTTP failures

### `_generate_realtime` raise sites (streaming + non-streaming)
Both populate `response_body` + `model_id`:
```python
raise DoublewordInfraError(
    f"Chat completions failed: {resp.status} {err_body[:200]}",
    status_code=resp.status,
    response_body=err_body,
    model_id=_effective_model,
)
```

### `_generate_background` — preserves structured exception
Captures the original exception as `_structured_error` and re-raises it BEFORE the legacy `RuntimeError(_dw_error)` fallback. The structured object survives the dispatcher chain with `status_code` + `response_body` intact.

### `_dispatch_via_sentinel` — structured-first classifier
Failure classifier reads `getattr(exc, "status_code", None)` FIRST. Structured HTTP status drives `FailureSource` deterministically:

| Status | FailureSource |
|---|---|
| 429 | `LIVE_HTTP_429` |
| 500/502/503/504 | `LIVE_HTTP_5XX` |
| 0 + stream-stall text | `LIVE_STREAM_STALL` |
| 400/404/422 + modality marker, OR 401/403 | terminal (Slice H wires) |
| else | `LIVE_TRANSPORT` |

Falls back to legacy `str(exc)` regex only when `status_code` attribute is absent.

`sentinel.report_failure()` now passes `status_code` + `response_body` + `is_terminal` kwargs. **Pre-Slice-H sentinels** that don't accept the new kwargs catch `TypeError` and fall back to the legacy 3-arg call — backward-compatible drop-in for Slice H.

WARNING log line surfaces unmasked status:
```
Sentinel dispatch: model=Qwen/Qwen3-Embedding-8B FAILED 
(source=live_transport, http_400, body='{"error": "model does not support chat"}',
 modality_terminal=true) — trying next (op=op-019dd1f7)
```

Operators see ground truth in `debug.log` immediately, no introspection needed.

## Test plan

- [x] Slice F dedicated tests: **55/55 green**
- [x] Combined Phase 11+12 + topology + sentinel + provider_topology suites: **547/547 green** (zero regressions)
- [x] §12 source-level pin: `is_modality_error` MUST NOT read `self.model_id` — protects against future PR silently re-introducing regex-on-id

## What this does NOT do

- Does NOT decide what to do with terminal failures — that's Slice H (TERMINAL_OPEN breaker state)
- Does NOT verify model capability before dispatch — that's Slice G (metadata parsing + micro-probe)
- Does NOT change cost contract — BG/SPEC still queue, IMMEDIATE still goes to Claude direct

Slice F is the **substrate** — ground-truth observability that Slices G + H build on.

## Slice progression

| Slice | Status |
|---|---|
| A — catalog client | ✅ Merged |
| B — classifier + ledger | ✅ Merged |
| C — discovery runner + holder (shadow) | ✅ Merged |
| D — authority handoff | ✅ Merged |
| E — graduation flip + boot hook + YAML purge | ✅ Merged |
| **F — Substrate Error Unmasking (this PR)** | **review** |
| G — Dynamic Capability Verification + Modality Micro-Probe | next |
| H — Terminal vs Transient Breaker States | after G |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unmasked DW HTTP errors by bubbling the real status code and response body to the dispatcher. This lets the breaker distinguish terminal 4xx (modality/auth) from transient 5xx/429 without regex on `model_id`.

- **New Features**
  - Extended `DoublewordInfraError` with `response_body` (<=1024 chars) and `model_id` (<=128 chars), plus helpers: `is_modality_error()`, `is_terminal_auth_error()`, `is_transient()`. Modality detection requires 400/404/422 AND body markers (e.g., “does not support chat”); never reads `model_id`.
  - Both realtime raise sites now populate `response_body` and `model_id`.
  - `_generate_background` preserves and re-raises the original structured exception; falls back to legacy `RuntimeError` only for non-structured failures. `_dw_error` string now includes `http_<status>` and a body excerpt for logs.
  - `_dispatch_via_sentinel` classifies using `exc.status_code` first (429 → `LIVE_HTTP_429`, 5xx → `LIVE_HTTP_5XX`, 0+stall → `LIVE_STREAM_STALL`; modality 4xx or 401/403 flagged as terminal). Forwards `status_code`, `response_body`, and `is_terminal` to `sentinel.report_failure` with a safe TypeError fallback. Warning logs show `http_<status>` and body excerpt.
  - Tests: added 55 focused tests pinning structured error flow and “no regex on model_id”. All suites green (547/547).

<sup>Written for commit 7b554df62a80e23950afac2e499a3f9ff5c9964d. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/27201?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

