### PR TITLE
Phase 12.2 Slice A: Full-Jitter Exponential Backoff helper

### DIFF
--- a/backend/core/ouroboros/governance/full_jitter.py
+++ b/backend/core/ouroboros/governance/full_jitter.py
@@ -1,0 +1,174 @@
+"""Phase 12.2 Slice A — Full-Jitter Exponential Backoff.
+
+Single-source-of-truth helper for retry desynchronization. Replaces
+exact-exponential backoff at every retry site so our retry waveform
+doesn't synchronize with the global thundering herd of similar
+agentic systems retrying the same DW endpoint.
+
+The math (operator directive 2026-04-27):
+
+    delay = random.uniform(0, min(cap_s, base_s * 2^attempt))
+
+vs the rejected exact-exponential form:
+
+    delay = min(cap_s, base_s * 2^attempt)
+
+Why full jitter beats exact exponential under Little's Law:
+
+  After a transient outage, every client doing exact-exponential
+  retries synchronizes at the same offsets (t+10s, t+30s, t+70s ...).
+  The recovered endpoint sees retry pulses each containing thousands
+  of synchronized arrivals — queue depth = arrival rate × service
+  time blows past server capacity instantly, the endpoint crashes
+  again, the cycle repeats.
+
+  Full jitter desynchronizes the waveform. Each retry falls into a
+  uniform random window across the entire backoff range. Our payloads
+  slip into the micro-gaps of DW's queue backlog instead of stacking
+  on the herd's arrival wavefronts.
+
+Authority surface:
+  * ``full_jitter_backoff_s(attempt, *, base_s, cap_s, rng=None)`` —
+    pure function, NEVER raises, deterministic when ``rng`` is a
+    seeded ``random.Random`` instance.
+  * ``full_jitter_enabled()`` — re-read at call time.
+
+NEVER imports network code, NEVER allocates state, NEVER raises.
+Pure stdlib (``random`` only).
+"""
+from __future__ import annotations
+
+import os
+import random as _random
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Master flag
+# ---------------------------------------------------------------------------
+
+
+def full_jitter_enabled() -> bool:
+    """``JARVIS_TOPOLOGY_FULL_JITTER_ENABLED`` (default ``false``).
+
+    Re-read at call time so monkeypatch works in tests + operators
+    can flip live without re-init. Default flips to ``true`` at
+    Phase 12.2 Slice E graduation. Hot-revert path: ``export
+    JARVIS_TOPOLOGY_FULL_JITTER_ENABLED=false`` returns retry sites
+    to exact-exponential behavior immediately.
+
+    The flag governs whether callers USE full_jitter_backoff_s. The
+    function itself works regardless — callers branch on this flag
+    when integrating it as a drop-in replacement for legacy backoff
+    formulas, so a single env var unifies the rollout."""
+    raw = os.environ.get(
+        "JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+# ---------------------------------------------------------------------------
+# Tunables (env-readable defaults; callers may override per-callsite)
+# ---------------------------------------------------------------------------
+
+
+def _default_base_s() -> float:
+    """``JARVIS_TOPOLOGY_BACKOFF_BASE_S`` (default 10.0)."""
+    try:
+        return float(
+            os.environ.get(
+                "JARVIS_TOPOLOGY_BACKOFF_BASE_S", "10.0",
+            ).strip()
+        )
+    except (ValueError, TypeError):
+        return 10.0
+
+
+def _default_cap_s() -> float:
+    """``JARVIS_TOPOLOGY_BACKOFF_CAP_S`` (default 300.0).
+
+    Maximum delay regardless of attempt count. A sentinel circuit
+    breaker that keeps failing for 5+ minutes has bigger problems
+    than a longer backoff can solve."""
+    try:
+        return float(
+            os.environ.get(
+                "JARVIS_TOPOLOGY_BACKOFF_CAP_S", "300.0",
+            ).strip()
+        )
+    except (ValueError, TypeError):
+        return 300.0
+
+
+# ---------------------------------------------------------------------------
+# Core function
+# ---------------------------------------------------------------------------
+
+
+def full_jitter_backoff_s(
+    attempt: int,
+    *,
+    base_s: Optional[float] = None,
+    cap_s: Optional[float] = None,
+    rng: Optional[_random.Random] = None,
+) -> float:
+    """Compute a full-jitter backoff delay in seconds.
+
+    Returns a uniform random float in ``[0, min(cap_s, base_s *
+    2^max(0, attempt))]``.
+
+    Parameters
+    ----------
+    attempt : int
+        Retry attempt number (0-indexed). Negative values are clamped
+        to 0 for safety. attempt=0 → range [0, base_s]. attempt=1 →
+        [0, 2*base_s]. attempt=N → [0, min(cap, base*2^N)].
+    base_s : float, optional
+        Base delay scalar. Defaults to env ``JARVIS_TOPOLOGY_BACKOFF_BASE_S``
+        (10.0).
+    cap_s : float, optional
+        Maximum delay regardless of attempt. Defaults to env
+        ``JARVIS_TOPOLOGY_BACKOFF_CAP_S`` (300.0).
+    rng : random.Random, optional
+        Random source. ``None`` uses the module-level ``random``,
+        which is non-deterministic. For test pinning, pass a seeded
+        ``random.Random(seed)`` — same seed produces same delay
+        sequence.
+
+    Returns
+    -------
+    float
+        Backoff delay in seconds, in [0, min(cap_s, base_s*2^attempt)].
+
+    Notes
+    -----
+    NEVER raises. Negative ``attempt`` clamps to 0. Non-positive
+    ``base_s`` / ``cap_s`` coerce to env defaults. Overflow on
+    ``2^attempt`` clamps to ``cap_s``."""
+    a = max(0, int(attempt) if not isinstance(attempt, bool) else 0)
+    if base_s is None or base_s <= 0:
+        base_s = _default_base_s()
+    if cap_s is None or cap_s <= 0:
+        cap_s = _default_cap_s()
+
+    # 2^attempt overflow protection — for attempt large enough that
+    # 2^attempt > cap_s/base_s, the upper bound is just cap_s. This
+    # avoids OverflowError on absurd attempt values (e.g. attempt=1000)
+    # without polluting the formula.
+    try:
+        scaled = base_s * (2 ** a)
+    except OverflowError:
+        scaled = cap_s
+    upper = min(cap_s, scaled)
+
+    if upper <= 0:
+        return 0.0
+
+    source = rng if rng is not None else _random
+    return source.uniform(0.0, upper)
+
+
+__all__ = [
+    "full_jitter_backoff_s",
+    "full_jitter_enabled",
+]

--- a/tests/governance/test_full_jitter.py
+++ b/tests/governance/test_full_jitter.py
@@ -1,0 +1,353 @@
+"""Phase 12.2 Slice A — full-jitter backoff regression spine.
+
+Pins:
+  §1 Master flag default off + truthy/falsy parsing
+  §2 attempt=0 → [0, base_s]
+  §3 attempt=N → [0, min(cap, base * 2^N)]
+  §4 Cap enforced (large attempt clamped to cap_s)
+  §5 Determinism with seeded rng (same seed → same sequence)
+  §6 Non-determinism without rng (different calls → different values)
+  §7 Negative attempt → clamped to 0
+  §8 Overflow on huge attempt → clamped to cap_s, not OverflowError
+  §9 Non-positive base_s / cap_s → coerced to env defaults
+  §10 Env override of base_s / cap_s
+  §11 NEVER raises on garbage input
+  §12 Statistical: distribution is uniform across [0, upper]
+"""
+from __future__ import annotations
+
+import random
+from typing import Any  # noqa: F401
+
+import pytest
+
+from backend.core.ouroboros.governance.full_jitter import (
+    full_jitter_backoff_s,
+    full_jitter_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# §1 — Master flag
+# ---------------------------------------------------------------------------
+
+
+def test_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", raising=False)
+    assert full_jitter_enabled() is False
+
+
+def test_flag_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    for v in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", v)
+        assert full_jitter_enabled() is True
+
+
+def test_flag_falsy_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    for v in ("0", "false", "no", "off", "", "garbage"):
+        monkeypatch.setenv("JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", v)
+        assert full_jitter_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# §2 — attempt=0 → [0, base_s]
+# ---------------------------------------------------------------------------
+
+
+def test_attempt_zero_within_base() -> None:
+    rng = random.Random(42)
+    delays = [
+        full_jitter_backoff_s(0, base_s=10.0, cap_s=300.0, rng=rng)
+        for _ in range(50)
+    ]
+    for d in delays:
+        assert 0.0 <= d <= 10.0, f"delay {d} out of [0, 10] for attempt=0"
+
+
+# ---------------------------------------------------------------------------
+# §3 — attempt=N → [0, min(cap, base*2^N)]
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("attempt,expected_upper", [
+    (0, 10.0),    # 10 * 2^0 = 10
+    (1, 20.0),    # 10 * 2^1 = 20
+    (2, 40.0),    # 10 * 2^2 = 40
+    (3, 80.0),    # 10 * 2^3 = 80
+    (4, 160.0),   # 10 * 2^4 = 160
+    (5, 300.0),   # 10 * 2^5 = 320 > cap=300 → clamped
+    (10, 300.0),  # cap dominates
+])
+def test_upper_bound_per_attempt(attempt: int, expected_upper: float) -> None:
+    rng = random.Random(42)
+    delays = [
+        full_jitter_backoff_s(
+            attempt, base_s=10.0, cap_s=300.0, rng=rng,
+        )
+        for _ in range(100)
+    ]
+    for d in delays:
+        assert 0.0 <= d <= expected_upper, (
+            f"delay {d} exceeds upper {expected_upper} at attempt={attempt}"
+        )
+    # The MAX observed should be near the upper bound (high enough N
+    # that uniform sampling will land near the top).
+    assert max(delays) > expected_upper * 0.7, (
+        f"max delay {max(delays)} suspiciously low for upper {expected_upper}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# §4 — Cap enforced (large attempt clamped)
+# ---------------------------------------------------------------------------
+
+
+def test_huge_attempt_clamped_to_cap() -> None:
+    """attempt=1000 would overflow 2^N → must clamp to cap_s, not raise."""
+    rng = random.Random(0)
+    for _ in range(20):
+        d = full_jitter_backoff_s(
+            1000, base_s=10.0, cap_s=300.0, rng=rng,
+        )
+        assert 0.0 <= d <= 300.0
+
+
+def test_attempt_exactly_at_cap_boundary() -> None:
+    """Find the attempt where base*2^N == cap. attempt=5 with base=10
+    cap=320 has scaled=320; cap=300 means upper=300 always."""
+    rng = random.Random(0)
+    for _ in range(20):
+        d = full_jitter_backoff_s(5, base_s=10.0, cap_s=320.0, rng=rng)
+        assert 0.0 <= d <= 320.0
+
+
+# ---------------------------------------------------------------------------
+# §5 — Determinism with seeded rng
+# ---------------------------------------------------------------------------
+
+
+def test_seeded_rng_produces_deterministic_sequence() -> None:
+    """Same seed → same delay sequence. Pin source-level so a
+    refactor that changes the rng calling convention fails."""
+    rng1 = random.Random(12345)
+    rng2 = random.Random(12345)
+    seq1 = [
+        full_jitter_backoff_s(i, base_s=5.0, cap_s=100.0, rng=rng1)
+        for i in range(10)
+    ]
+    seq2 = [
+        full_jitter_backoff_s(i, base_s=5.0, cap_s=100.0, rng=rng2)
+        for i in range(10)
+    ]
+    assert seq1 == seq2, "seeded rng must produce deterministic delays"
+
+
+def test_different_seeds_produce_different_sequences() -> None:
+    rng1 = random.Random(1)
+    rng2 = random.Random(2)
+    seq1 = [
+        full_jitter_backoff_s(0, base_s=10.0, cap_s=100.0, rng=rng1)
+        for _ in range(5)
+    ]
+    seq2 = [
+        full_jitter_backoff_s(0, base_s=10.0, cap_s=100.0, rng=rng2)
+        for _ in range(5)
+    ]
+    assert seq1 != seq2
+
+
+# ---------------------------------------------------------------------------
+# §6 — Non-determinism without rng
+# ---------------------------------------------------------------------------
+
+
+def test_no_rng_produces_varying_values() -> None:
+    """Without seeded rng, repeated calls produce different delays
+    (statistically — extremely unlikely all 50 are equal)."""
+    delays = [
+        full_jitter_backoff_s(2, base_s=10.0, cap_s=300.0)
+        for _ in range(50)
+    ]
+    distinct = set(delays)
+    assert len(distinct) > 30, (
+        f"expected variation; got only {len(distinct)} distinct values"
+    )
+
+
+# ---------------------------------------------------------------------------
+# §7 — Negative attempt → clamped to 0
+# ---------------------------------------------------------------------------
+
+
+def test_negative_attempt_clamps_to_zero() -> None:
+    rng = random.Random(0)
+    for _ in range(20):
+        d = full_jitter_backoff_s(-5, base_s=10.0, cap_s=300.0, rng=rng)
+        # attempt=-5 should behave as attempt=0 → upper=10
+        assert 0.0 <= d <= 10.0
+
+
+# ---------------------------------------------------------------------------
+# §8 — Overflow protection
+# ---------------------------------------------------------------------------
+
+
+def test_extreme_attempt_no_overflow_error() -> None:
+    """attempt=10000 in 2^attempt would overflow; we catch it."""
+    d = full_jitter_backoff_s(10000, base_s=10.0, cap_s=300.0)
+    assert 0.0 <= d <= 300.0
+
+
+# ---------------------------------------------------------------------------
+# §9 — Non-positive base/cap coerced
+# ---------------------------------------------------------------------------
+
+
+def test_zero_base_s_coerces_to_env_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKOFF_BASE_S", "5.0")
+    rng = random.Random(0)
+    d = full_jitter_backoff_s(0, base_s=0, cap_s=100.0, rng=rng)
+    # base coerced to 5.0 → upper=5.0 for attempt=0
+    assert 0.0 <= d <= 5.0
+
+
+def test_zero_cap_s_coerces_to_env_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKOFF_CAP_S", "50.0")
+    rng = random.Random(0)
+    d = full_jitter_backoff_s(10, base_s=10.0, cap_s=0, rng=rng)
+    # cap coerced to 50 → upper=50
+    assert 0.0 <= d <= 50.0
+
+
+def test_negative_base_s_coerces() -> None:
+    rng = random.Random(0)
+    d = full_jitter_backoff_s(0, base_s=-5.0, cap_s=100.0, rng=rng)
+    # negative coerces to default → 10.0
+    assert 0.0 <= d <= 10.0
+
+
+# ---------------------------------------------------------------------------
+# §10 — Env override defaults
+# ---------------------------------------------------------------------------
+
+
+def test_env_base_s_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKOFF_BASE_S", "20.0")
+    rng = random.Random(0)
+    delays = [
+        full_jitter_backoff_s(0, rng=rng)
+        for _ in range(50)
+    ]
+    # Should be in [0, 20] now
+    for d in delays:
+        assert 0.0 <= d <= 20.0
+
+
+def test_env_cap_s_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKOFF_BASE_S", "100.0")
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKOFF_CAP_S", "150.0")
+    rng = random.Random(0)
+    # attempt=10 → 100*1024=102400, capped at 150
+    for _ in range(20):
+        d = full_jitter_backoff_s(10, rng=rng)
+        assert 0.0 <= d <= 150.0
+
+
+def test_invalid_env_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Garbage env values don't crash — coerce to default."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKOFF_BASE_S", "not-a-number")
+    rng = random.Random(0)
+    d = full_jitter_backoff_s(0, rng=rng)
+    # Default base=10 → upper=10
+    assert 0.0 <= d <= 10.0
+
+
+# ---------------------------------------------------------------------------
+# §11 — NEVER raises on garbage
+# ---------------------------------------------------------------------------
+
+
+def test_never_raises_on_bool_attempt() -> None:
+    """Python booleans are int subtypes — make sure True/False don't
+    accidentally produce different output than 1/0."""
+    d_true = full_jitter_backoff_s(True, base_s=10.0, cap_s=100.0,
+                                    rng=random.Random(0))
+    d_false = full_jitter_backoff_s(False, base_s=10.0, cap_s=100.0,
+                                     rng=random.Random(0))
+    # Both should be in [0, 10] (clamped to attempt=0 by isinstance check)
+    assert 0.0 <= d_true <= 10.0
+    assert 0.0 <= d_false <= 10.0
+
+
+def test_never_raises_on_float_attempt() -> None:
+    """Python's int() coerces 2.7 → 2."""
+    d = full_jitter_backoff_s(2.7, base_s=10.0, cap_s=300.0,  # type: ignore[arg-type]
+                               rng=random.Random(0))
+    # int(2.7)=2 → upper = 10*4 = 40
+    assert 0.0 <= d <= 40.0
+
+
+# ---------------------------------------------------------------------------
+# §12 — Statistical: distribution is uniform
+# ---------------------------------------------------------------------------
+
+
+def test_distribution_is_approximately_uniform() -> None:
+    """Run 10000 calls at attempt=2 (upper=40), check that the
+    distribution histogram is roughly flat (no exponential bias)."""
+    rng = random.Random(7)
+    delays = [
+        full_jitter_backoff_s(2, base_s=10.0, cap_s=300.0, rng=rng)
+        for _ in range(10000)
+    ]
+    # Bucket into 4 quartiles of [0, 40]
+    bins = [0, 0, 0, 0]
+    for d in delays:
+        idx = min(3, int(d / 10))
+        bins[idx] += 1
+    # Each bucket should have ~2500 samples (10000/4) — within 15%
+    for count in bins:
+        assert 2125 < count < 2875, (
+            f"non-uniform distribution: bins={bins} (expected ~2500 each)"
+        )
+
+
+def test_mean_is_approximately_half_of_upper() -> None:
+    """For a uniform distribution on [0, U], expected mean = U/2."""
+    rng = random.Random(7)
+    delays = [
+        full_jitter_backoff_s(0, base_s=10.0, cap_s=300.0, rng=rng)
+        for _ in range(5000)
+    ]
+    mean = sum(delays) / len(delays)
+    # Expected mean = 5.0; allow 5% tolerance (Central Limit Theorem
+    # gives stddev of mean ~= 10/sqrt(12*5000) ≈ 0.04)
+    assert 4.7 < mean < 5.3, f"mean {mean:.3f} not near 5.0"
+
+
+# ---------------------------------------------------------------------------
+# §13 — Source-level pin: the math
+# ---------------------------------------------------------------------------
+
+
+def test_source_uses_uniform_not_exponential() -> None:
+    """Pin the literal random.uniform(0, upper) call — a refactor
+    that switches to .gauss() or another distribution would silently
+    break the desync property."""
+    import inspect
+    src = inspect.getsource(full_jitter_backoff_s)
+    assert ".uniform(0.0, upper)" in src or ".uniform(0, upper)" in src
+
+
+def test_source_uses_two_to_attempt_power() -> None:
+    """The exponential expansion formula must be 2^attempt — pin it
+    so a refactor doesn't silently change the backoff curve."""
+    import inspect
+    src = inspect.getsource(full_jitter_backoff_s)
+    assert "2 ** a" in src or "2**a" in src


### PR DESCRIPTION
## Summary

Operator directive 2026-04-27: defeat Little's Law thundering-herd amplification at every retry site. Single-source-of-truth helper implements:

```python
delay = random.uniform(0, min(cap_s, base_s * 2**attempt))
```

vs the rejected exact-exponential form:

```python
delay = min(cap_s, base_s * 2**attempt)
```

## Why full jitter beats exact-exponential under Little's Law

After a transient outage, every client doing exact-exponential retries synchronizes at the same offsets (t+10s, t+30s, t+70s, ...). The recovered endpoint sees retry pulses, each containing thousands of synchronized arrivals — queue depth = arrival rate × service time blows past server capacity, the endpoint crashes again, cycle repeats.

**Full jitter desynchronizes the waveform.** Each retry falls into a uniform random window across the entire backoff range. Our payloads slip into the micro-gaps of DW's queue backlog instead of stacking on the herd's arrival wavefronts.

## What ships

`backend/core/ouroboros/governance/full_jitter.py` (~135 lines):

```python
def full_jitter_backoff_s(
    attempt: int,
    *,
    base_s: Optional[float] = None,
    cap_s: Optional[float] = None,
    rng: Optional[random.Random] = None,
) -> float:
```

- Pure function. **NEVER raises.**
- `attempt` clamped to `>= 0`; bool/float coerced to int safely
- `base_s` / `cap_s` coerced to env defaults when non-positive
- `OverflowError` on `2**attempt` clamps to `cap_s` (handles `attempt=10000`)
- `rng=None` uses module-level `random` (non-deterministic)
- `rng=Random(seed)` for deterministic test pinning

`full_jitter_enabled()` — `JARVIS_TOPOLOGY_FULL_JITTER_ENABLED` master flag, default `false` until Phase 12.2 Slice E graduation.

## Env tunables

| Flag | Default | Purpose |
|---|---|---|
| `JARVIS_TOPOLOGY_FULL_JITTER_ENABLED` | `false` | Master flag |
| `JARVIS_TOPOLOGY_BACKOFF_BASE_S` | `10.0` | Per-attempt base |
| `JARVIS_TOPOLOGY_BACKOFF_CAP_S` | `300.0` | 5-min ceiling |

## Test plan

- [x] **30/30 tests green** across 13 sections
- [x] §12 statistical: distribution uniform across `[0, upper]` (10k samples, 4-quartile bin variance <15%; mean ~U/2 within Central Limit Theorem bounds)
- [x] §13 source-level pins: `random.uniform(0, upper)` + `2**a` present in function body (catches refactors that change distribution shape or backoff curve)
- [x] §11 NEVER raises on `bool`/`float` garbage `attempt`
- [x] §8 overflow protection — `attempt=10000` doesn't raise

## What this does NOT do

Slice A is purely additive — **no retrofit at retry sites yet**. Slice C will replace exact-exponential at the 4 callsites (sentinel circuit-breaker probe schedule, DW provider transient retries, `candidate_generator` inter-model rotation, `batch_future_registry` adaptive poll) once full-jitter is field-proven.

## Phase 12.2 progression

| Slice | Status |
|---|---|
| **A — full-jitter helper (this PR)** | **review** |
| B — `TtftObserver` + dynamic-promotion math (replaces hardcoded count) | next |
| C — promotion + cold-storage wiring + retry retrofits | after B |
| D — heavy probe (VRAM allocation verification) | after C |
| E — graduation flip | last |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a full-jitter exponential backoff helper to desynchronize retries and reduce thundering-herd spikes. Adds a pure function and a feature flag; no retry sites are switched yet.

- **New Features**
  - Added `backend/core/ouroboros/governance/full_jitter.py` with `full_jitter_backoff_s(attempt, *, base_s=None, cap_s=None, rng=None)` and `full_jitter_enabled()`.
  - Backoff uses `random.uniform(0, min(cap_s, base_s * 2**attempt))`; negative attempts clamp to 0; overflow on `2**attempt` clamps to `cap_s`; optional `rng` enables deterministic tests.
  - Env flags: `JARVIS_TOPOLOGY_FULL_JITTER_ENABLED` (default `false`), `JARVIS_TOPOLOGY_BACKOFF_BASE_S` (default `10.0`), `JARVIS_TOPOLOGY_BACKOFF_CAP_S` (default `300.0`).
  - Added tests covering flag parsing, bounds per attempt, overflow safety, determinism, env coercion, and basic uniformity checks.

<sup>Written for commit a03bbacc83f77e292f2597a3885a41b1959ef738. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/27424?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

