### PR TITLE
feat(phase12.2): Slice D — Heavy probe (VRAM allocation verification)

### DIFF
--- a/backend/core/ouroboros/governance/dw_discovery_runner.py
+++ b/backend/core/ouroboros/governance/dw_discovery_runner.py
@@ -428,9 +428,11 @@ from backend.core.ouroboros.governance.dw_catalog_client import (
 _BOOT_DISCOVERY_LOCK = asyncio.Lock()
 _BOOT_DISCOVERY_DONE: bool = False
 _REFRESH_TASK: Optional[asyncio.Task] = None
+_HEAVY_PROBE_TASK: Optional[asyncio.Task] = None  # Slice 12.2.D
 _LEDGER_SINGLETON: Optional[PromotionLedger] = None
 _MODALITY_LEDGER_SINGLETON: Optional[Any] = None  # Slice G
 _TTFT_OBSERVER_SINGLETON: Optional[Any] = None  # Slice 12.2.C
+_HEAVY_PROBE_BUDGET_SINGLETON: Optional[Any] = None  # Slice 12.2.D
 # Sync lock around the singleton hydration + boot flag — protects the
 # very first-call window before the asyncio.Lock has been touched.
 _BOOT_SYNC_LOCK = threading.Lock()
@@ -500,20 +502,55 @@ def get_ttft_observer() -> Optional[Any]:
     return _get_or_create_ttft_observer()
 
 
+def _get_or_create_heavy_probe_budget() -> Optional[Any]:
+    """Slice 12.2.D — lazy HeavyProbeBudget singleton.
+
+    Returns None when ``heavy_probe_enabled()`` is ``false`` OR import
+    fails. Hydrates from disk on first access. Defensive for older
+    deploys that haven't shipped the module yet."""
+    global _HEAVY_PROBE_BUDGET_SINGLETON
+    try:
+        from backend.core.ouroboros.governance.dw_heavy_probe import (
+            HeavyProbeBudget,
+            heavy_probe_enabled,
+        )
+    except ImportError:
+        return None
+    if not heavy_probe_enabled():
+        return None
+    with _BOOT_SYNC_LOCK:
+        if _HEAVY_PROBE_BUDGET_SINGLETON is None:
+            bud = HeavyProbeBudget()
+            bud.load()
+            _HEAVY_PROBE_BUDGET_SINGLETON = bud
+        return _HEAVY_PROBE_BUDGET_SINGLETON
+
+
+def get_heavy_probe_budget() -> Optional[Any]:
+    """Public accessor for the HeavyProbeBudget singleton. Returns
+    None when the heavy-probe master flag is off."""
+    return _get_or_create_heavy_probe_budget()
+
+
 def reset_boot_state_for_tests() -> None:
     """Test hook — clears the boot flag, cancels any refresh task,
     drops the ledger singletons. Production code MUST NOT call this."""
     global _BOOT_DISCOVERY_DONE, _REFRESH_TASK, _LEDGER_SINGLETON
     global _MODALITY_LEDGER_SINGLETON, _TTFT_OBSERVER_SINGLETON
+    global _HEAVY_PROBE_TASK, _HEAVY_PROBE_BUDGET_SINGLETON
     global _LAST_SNAPSHOT_ID
     with _BOOT_SYNC_LOCK:
         _BOOT_DISCOVERY_DONE = False
         if _REFRESH_TASK is not None and not _REFRESH_TASK.done():
             _REFRESH_TASK.cancel()
         _REFRESH_TASK = None
+        if _HEAVY_PROBE_TASK is not None and not _HEAVY_PROBE_TASK.done():
+            _HEAVY_PROBE_TASK.cancel()
+        _HEAVY_PROBE_TASK = None
         _LEDGER_SINGLETON = None
         _MODALITY_LEDGER_SINGLETON = None
         _TTFT_OBSERVER_SINGLETON = None
+        _HEAVY_PROBE_BUDGET_SINGLETON = None
         _LAST_SNAPSHOT_ID = ""
 
 
@@ -578,6 +615,34 @@ async def boot_discovery_once(
             logger.debug(
                 "[DiscoveryRunner] no running loop — refresh skipped",
             )
+
+        # Slice 12.2.D — spawn heavy-probe scheduler when master flag
+        # is on. Same pattern as refresh loop: best-effort, swallows
+        # missing-loop errors. Skipped silently when flag off so
+        # master-off boot is bit-for-bit identical to pre-Slice-D.
+        global _HEAVY_PROBE_TASK
+        try:
+            from backend.core.ouroboros.governance.dw_heavy_probe import (
+                heavy_probe_enabled,
+            )
+            if heavy_probe_enabled():
+                _HEAVY_PROBE_TASK = asyncio.create_task(
+                    _heavy_probe_loop(
+                        session=session,
+                        base_url=base_url,
+                        api_key=api_key,
+                    ),
+                    name="dw_heavy_probe_loop",
+                )
+        except RuntimeError:
+            logger.debug(
+                "[DiscoveryRunner] no running loop — heavy probe skipped",
+            )
+        except Exception:  # noqa: BLE001 — defensive (import / other)
+            logger.debug(
+                "[DiscoveryRunner] heavy probe spawn failed",
+                exc_info=True,
+            )
         logger.info(
             "[DiscoveryRunner] boot complete: ok=%s models=%d "
             "newly_quarantined=%d routes_assigned=%s",
@@ -633,10 +698,90 @@ async def _discovery_refresh_loop(
             )
 
 
+async def _heavy_probe_loop(
+    *,
+    session: Any,
+    base_url: str,
+    api_key: str,
+) -> None:
+    """Slice 12.2.D — heavy-probe scheduler loop.
+
+    Each cycle:
+      1. Sleeps for ``_scheduler_cycle_s()`` (default 120s)
+      2. Re-checks the master flag (operator may have flipped off)
+      3. Reads the dynamic catalog for SPECULATIVE-route candidates
+         (the exact set we want VRAM-warmth signal on — promoted +
+         cold-storage models are skipped via HeavyProbeScheduler's
+         eligibility rules)
+      4. Calls scheduler.run_cycle to fire at most one probe
+
+    NEVER raises out — every failure caught + logged + continues.
+    Loop survives until task cancellation."""
+    try:
+        from backend.core.ouroboros.governance.dw_heavy_probe import (
+            HeavyProber,
+            HeavyProbeScheduler,
+            _scheduler_cycle_s,
+            heavy_probe_enabled,
+        )
+    except ImportError:
+        logger.debug(
+            "[HeavyProbeLoop] module unavailable — exiting cleanly",
+        )
+        return
+
+    budget = _get_or_create_heavy_probe_budget()
+    if budget is None:
+        logger.debug(
+            "[HeavyProbeLoop] budget unavailable — exiting cleanly",
+        )
+        return
+    prober = HeavyProber(budget=budget)
+    scheduler = HeavyProbeScheduler(prober=prober, budget=budget)
+
+    while True:
+        try:
+            await asyncio.sleep(_scheduler_cycle_s())
+        except asyncio.CancelledError:
+            return
+        if not heavy_probe_enabled():
+            # Hot-revert in flight — keep loop alive so re-flip picks
+            # up immediately. Same pattern as discovery refresh.
+            continue
+        try:
+            from backend.core.ouroboros.governance.provider_topology import (
+                get_dynamic_catalog,
+            )
+            cat = get_dynamic_catalog()
+            # Heavy probes target the SPECULATIVE route — those are
+            # the models in quarantine / cold-storage / unknown state
+            # for which we want VRAM-warm signal.
+            if cat is not None:
+                candidates = cat.assignments_by_route.get(
+                    "speculative", (),
+                )
+            else:
+                candidates = ()
+            await scheduler.run_cycle(
+                session=session,
+                base_url=base_url,
+                api_key=api_key,
+                candidate_ids=tuple(candidates),
+            )
+        except asyncio.CancelledError:
+            return
+        except Exception:  # noqa: BLE001 — defensive
+            logger.exception(
+                "[HeavyProbeLoop] cycle failed; "
+                "next cycle will retry on schedule",
+            )
+
+
 __all__ = [
     "DiscoveryResult",
     "boot_discovery_once",
     "catalog_discovery_enabled",
+    "get_heavy_probe_budget",
     "get_ttft_observer",
     "reset_boot_state_for_tests",
     "run_discovery",

--- a/backend/core/ouroboros/governance/dw_heavy_probe.py
+++ b/backend/core/ouroboros/governance/dw_heavy_probe.py
@@ -1,0 +1,775 @@
+"""Phase 12.2 Slice D — Heavy Probe (VRAM allocation verification).
+
+Closes the chicken-and-egg gap between Slice G (modality micro-probe,
+1 token, proves schema acceptance only) and Slice B/C (TtftObserver,
+records TTFT from real ops — empty until production use).
+
+A model that passes the 1-token Slice G probe AND has zero observer
+samples can still be in cold storage when a real op hits it. The
+heavy probe issues a deliberate sized completion (50-200 tokens by
+default) under cost+rate guards and feeds TTFT into the same observer
+Slice C consumes for cold-storage detection + promotion gating.
+
+Design invariants:
+
+  * **Cost-bounded** — daily USD budget atomic on disk; probes refuse
+    when exhausted. NOT a tuning parameter; a hard fence.
+  * **Rate-bounded** — per-model probe interval (default 10 min) so a
+    single model can't dominate the budget. Globally rate-bounded by
+    scheduler cadence + per-cycle limits.
+  * **Read-only authority** — heavy prober NEVER mutates
+    PromotionLedger directly. It only feeds TtftObserver. Promotion
+    decisions remain Slice C's surface, classifier's authority.
+  * **Skip-when-redundant** — already-promoted models skipped (signal
+    proven); cold-storage flagged models skipped (signal already
+    present); TERMINAL_OPEN breakered models skipped (probe won't
+    help and may waste budget).
+  * **NEVER raises out of public methods.** Defensive try/except at
+    every external surface; observer / sentinel / breaker faults are
+    swallowed at the seam.
+
+Authority surface:
+  * ``heavy_probe_enabled()`` — master flag, re-read at call time.
+  * ``HeavyProbeResult`` — frozen dataclass.
+  * ``HeavyProbeBudget`` — daily-rollover USD ledger with atomic disk.
+  * ``HeavyProber`` — fires one probe, no scheduling.
+  * ``HeavyProbeScheduler`` — async loop calling HeavyProber per model.
+
+Default flips to ``true`` at Phase 12.2 Slice E graduation. Hot-revert:
+``export JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED=false`` immediately
+disables the scheduler + new probes (in-flight probe completes).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Master flag + tunables
+# ---------------------------------------------------------------------------
+
+
+def heavy_probe_enabled() -> bool:
+    """``JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED`` (default ``false``).
+
+    Master kill switch. Off → scheduler refuses to spawn, ad-hoc
+    ``HeavyProber.probe()`` calls return a no-op result, budget ledger
+    untouched. Default flips to ``true`` at Phase 12.2 Slice E
+    graduation."""
+    raw = os.environ.get(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _probe_tokens() -> int:
+    """``JARVIS_TOPOLOGY_HEAVY_PROBE_TOKENS`` (default 50).
+
+    Completion size of the heavy probe. Larger = more confident
+    VRAM-warm signal but more cost. 50 tokens at $0.40/M output is
+    $0.00002 per probe — negligible per-call but bounds the daily
+    sweep cost predictably."""
+    try:
+        return max(1, int(
+            os.environ.get(
+                "JARVIS_TOPOLOGY_HEAVY_PROBE_TOKENS", "50",
+            ).strip()
+        ))
+    except (ValueError, TypeError):
+        return 50
+
+
+def _probe_interval_s() -> int:
+    """``JARVIS_TOPOLOGY_HEAVY_PROBE_INTERVAL_S`` (default 600).
+
+    Per-model minimum interval between heavy probes. A model probed
+    in the last ``interval_s`` seconds is skipped. 600s = 10 minutes
+    matches the typical VRAM eviction window of self-hosted endpoints."""
+    try:
+        return max(60, int(
+            os.environ.get(
+                "JARVIS_TOPOLOGY_HEAVY_PROBE_INTERVAL_S", "600",
+            ).strip()
+        ))
+    except (ValueError, TypeError):
+        return 600
+
+
+def _probe_timeout_s() -> float:
+    """``JARVIS_TOPOLOGY_HEAVY_PROBE_TIMEOUT_S`` (default 30).
+
+    Single-probe wall-clock timeout. A probe that doesn't return
+    first content within this window is treated as cold-storage
+    grade slow (records the timeout as a ``ttft_ms`` ceiling so the
+    observer's cold-storage gate fires)."""
+    try:
+        return max(1.0, float(
+            os.environ.get(
+                "JARVIS_TOPOLOGY_HEAVY_PROBE_TIMEOUT_S", "30",
+            ).strip()
+        ))
+    except (ValueError, TypeError):
+        return 30.0
+
+
+def _budget_daily_usd() -> float:
+    """``JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY`` (default 0.05).
+
+    Daily USD ceiling. Auto-resets at UTC midnight (rolling
+    calendar-day, not 24h sliding window — operators reason about
+    day-boundary spend, not floating intervals)."""
+    try:
+        return max(0.0, float(
+            os.environ.get(
+                "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY", "0.05",
+            ).strip()
+        ))
+    except (ValueError, TypeError):
+        return 0.05
+
+
+def _scheduler_cycle_s() -> int:
+    """``JARVIS_TOPOLOGY_HEAVY_PROBE_CYCLE_S`` (default 120).
+
+    How often the scheduler wakes to look for probe candidates.
+    Smaller = more reactive, larger = less overhead. The probe
+    interval governs which models are eligible; cycle just sets
+    the polling cadence."""
+    try:
+        return max(10, int(
+            os.environ.get(
+                "JARVIS_TOPOLOGY_HEAVY_PROBE_CYCLE_S", "120",
+            ).strip()
+        ))
+    except (ValueError, TypeError):
+        return 120
+
+
+def _budget_state_path() -> Path:
+    """``JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH`` (default
+    ``.jarvis/dw_heavy_probe_budget.json``)."""
+    raw = os.environ.get(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH",
+        ".jarvis/dw_heavy_probe_budget.json",
+    ).strip()
+    return Path(raw)
+
+
+# DW pricing (read at call time so test fixtures can pin)
+def _dw_input_per_m() -> float:
+    try:
+        return float(os.environ.get(
+            "JARVIS_DW_INPUT_COST_PER_M", "0.10",
+        ).strip())
+    except (ValueError, TypeError):
+        return 0.10
+
+
+def _dw_output_per_m() -> float:
+    try:
+        return float(os.environ.get(
+            "JARVIS_DW_OUTPUT_COST_PER_M", "0.40",
+        ).strip())
+    except (ValueError, TypeError):
+        return 0.40
+
+
+# Probe prompt is fixed + minimal so input cost stays ~constant. The
+# completion size dominates output cost. Prompt is deliberately
+# generic — we want VRAM-warm observation, not capability discovery.
+_PROBE_PROMPT = "Reply with one short sentence about clouds."
+_PROBE_PROMPT_INPUT_TOKENS = 10  # generous estimate for prompt+system
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+BUDGET_SCHEMA_VERSION = "heavy_probe_budget.1"
+
+
+@dataclass(frozen=True)
+class HeavyProbeResult:
+    """One heavy-probe outcome. Frozen + hashable.
+
+    ``success`` is True iff a content chunk was received within the
+    probe timeout. ``ttft_ms`` is set on success; on timeout/failure
+    it's the timeout ceiling (signals cold-storage to the observer
+    asymmetrically — slow OR failed both register as "not warm")."""
+    model_id: str
+    success: bool
+    ttft_ms: int
+    total_latency_ms: int
+    cost_usd: float
+    error: str = ""
+    sample_unix: float = field(default_factory=time.time)
+
+
+# ---------------------------------------------------------------------------
+# Atomic disk I/O (mirrored from posture_store.py / dw_promotion_ledger.py)
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Budget — daily-rollover USD ledger
+# ---------------------------------------------------------------------------
+
+
+def _utc_today() -> str:
+    """Calendar day in UTC as ``YYYY-MM-DD``. Used as the rollover
+    key — at UTC midnight the per-day spend resets."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+class HeavyProbeBudget:
+    """Daily-USD heavy-probe spend ledger.
+
+    Auto-rollover at UTC midnight (compares ``current_day`` against
+    today; mismatch → reset). Atomic temp+rename persistence so a
+    crashed process doesn't lose accumulation.
+
+    NEVER raises out of public methods. ``check_and_charge`` returns
+    True iff the charge fits within remaining daily budget; on True
+    the spend is committed + persisted, on False budget remains
+    untouched."""
+
+    def __init__(
+        self,
+        *,
+        path: Optional[Path] = None,
+    ) -> None:
+        self._path = path
+        self._lock = threading.RLock()
+        self._current_day: str = _utc_today()
+        self._spent_today_usd: float = 0.0
+        self._loaded = False
+
+    def _resolved_path(self) -> Path:
+        return self._path if self._path is not None else _budget_state_path()
+
+    def load(self) -> None:
+        """Hydrate from disk. Missing/corrupt → start fresh.
+        NEVER raises."""
+        with self._lock:
+            self._loaded = True
+            p = self._resolved_path()
+            if not p.exists():
+                return
+            try:
+                payload = json.loads(p.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning(
+                    "[HeavyProbeBudget] corrupt ledger at %s — starting "
+                    "fresh (%s)", p, exc,
+                )
+                return
+            if not isinstance(payload, Mapping):
+                return
+            if payload.get("schema_version") != BUDGET_SCHEMA_VERSION:
+                return
+            day = str(payload.get("current_day", "")).strip()
+            try:
+                spent = float(payload.get("spent_today_usd", 0.0) or 0.0)
+            except (ValueError, TypeError):
+                spent = 0.0
+            today = _utc_today()
+            if day != today:
+                # Stale day — discard accumulated spend
+                self._current_day = today
+                self._spent_today_usd = 0.0
+            else:
+                self._current_day = day
+                self._spent_today_usd = max(0.0, spent)
+
+    def _save(self) -> None:
+        try:
+            _atomic_write(
+                self._resolved_path(),
+                json.dumps({
+                    "schema_version": BUDGET_SCHEMA_VERSION,
+                    "current_day": self._current_day,
+                    "spent_today_usd": self._spent_today_usd,
+                }, sort_keys=True, indent=2),
+            )
+        except OSError as exc:
+            logger.warning(
+                "[HeavyProbeBudget] save failed: %s — accumulated "
+                "spend remains in memory only", exc,
+            )
+
+    def _ensure_loaded(self) -> None:
+        if not self._loaded:
+            self.load()
+
+    def _maybe_rollover(self) -> None:
+        """Reset accumulator if calendar day flipped since last touch.
+        Called inside the lock by all mutators."""
+        today = _utc_today()
+        if today != self._current_day:
+            self._current_day = today
+            self._spent_today_usd = 0.0
+
+    def remaining_usd(self) -> float:
+        """Daily budget minus today's spend (post-rollover). NEVER
+        raises."""
+        self._ensure_loaded()
+        with self._lock:
+            self._maybe_rollover()
+            cap = _budget_daily_usd()
+            return max(0.0, cap - self._spent_today_usd)
+
+    def spent_today_usd(self) -> float:
+        self._ensure_loaded()
+        with self._lock:
+            self._maybe_rollover()
+            return self._spent_today_usd
+
+    def check_and_charge(self, cost_usd: float) -> bool:
+        """Atomically check whether ``cost_usd`` fits + charge.
+        Returns True iff committed. NEVER raises."""
+        try:
+            cost = float(cost_usd)
+        except (ValueError, TypeError):
+            return False
+        if cost < 0:
+            return False
+        self._ensure_loaded()
+        with self._lock:
+            self._maybe_rollover()
+            cap = _budget_daily_usd()
+            if self._spent_today_usd + cost > cap:
+                return False
+            self._spent_today_usd += cost
+            self._save()
+            return True
+
+
+# ---------------------------------------------------------------------------
+# HeavyProber — fires one probe
+# ---------------------------------------------------------------------------
+
+
+class HeavyProber:
+    """Single-shot heavy probe.
+
+    Uses the supplied aiohttp session + DW base_url + api_key to issue
+    a chat-completions request with ``max_tokens=_probe_tokens()``.
+    Records first-chunk TTFT into the supplied observer (or the
+    discovery-runner singleton when ``observer=None``).
+
+    NEVER raises out of public methods. Returns a HeavyProbeResult
+    with ``success=False`` + populated ``error`` on any failure path."""
+
+    def __init__(
+        self,
+        *,
+        budget: Optional[HeavyProbeBudget] = None,
+    ) -> None:
+        self._budget = budget
+
+    async def probe(
+        self,
+        *,
+        session: Any,
+        model_id: str,
+        base_url: str,
+        api_key: str,
+        observer: Optional[Any] = None,
+    ) -> HeavyProbeResult:
+        """Fire one heavy probe. Returns a result regardless of
+        success — caller can branch on ``result.success``."""
+        if not heavy_probe_enabled():
+            return HeavyProbeResult(
+                model_id=model_id,
+                success=False,
+                ttft_ms=0,
+                total_latency_ms=0,
+                cost_usd=0.0,
+                error="master_flag_off",
+            )
+        if not model_id or not model_id.strip():
+            return HeavyProbeResult(
+                model_id="",
+                success=False,
+                ttft_ms=0,
+                total_latency_ms=0,
+                cost_usd=0.0,
+                error="empty_model_id",
+            )
+
+        # Pre-flight cost estimate. Real cost may be slightly different
+        # if the model emits fewer tokens than max_tokens, but the
+        # ceiling check guards against a runaway probe.
+        max_tokens = _probe_tokens()
+        est_cost = self._estimate_cost(max_tokens)
+        budget = self._budget
+        if budget is not None and not budget.check_and_charge(est_cost):
+            return HeavyProbeResult(
+                model_id=model_id,
+                success=False,
+                ttft_ms=0,
+                total_latency_ms=0,
+                cost_usd=0.0,
+                error="budget_exhausted",
+            )
+
+        # Issue probe. Defensive try/except — every failure path
+        # yields a well-formed result, never a raised exception.
+        t_start = time.monotonic()
+        try:
+            ttft_ms, total_ms, ok, err = await self._do_probe(
+                session=session, model_id=model_id,
+                base_url=base_url, api_key=api_key,
+                max_tokens=max_tokens,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — defense-in-depth
+            return HeavyProbeResult(
+                model_id=model_id,
+                success=False,
+                ttft_ms=int(_probe_timeout_s() * 1000),
+                total_latency_ms=int((time.monotonic() - t_start) * 1000),
+                cost_usd=est_cost,
+                error=f"unhandled:{type(exc).__name__}:{str(exc)[:80]}",
+            )
+
+        # Feed observer on success. On failure we still feed a "slow"
+        # ttft signal asymmetrically — the goal is cold-storage
+        # detection, and a failed probe is at least as cold as a slow
+        # one. Caller can disambiguate via result.error.
+        recorded_ttft = ttft_ms if ok else int(_probe_timeout_s() * 1000)
+        try:
+            self._feed_observer(
+                model_id=model_id, ttft_ms=recorded_ttft,
+                explicit_observer=observer,
+            )
+        except Exception:  # noqa: BLE001 — defensive
+            pass
+
+        return HeavyProbeResult(
+            model_id=model_id,
+            success=ok,
+            ttft_ms=recorded_ttft,
+            total_latency_ms=total_ms,
+            cost_usd=est_cost,
+            error=err,
+        )
+
+    @staticmethod
+    def _estimate_cost(max_tokens: int) -> float:
+        """Conservative upper-bound cost estimate: full max_tokens
+        emitted + fixed prompt input. Real cost tracked by provider's
+        own ledger; this is for budget pre-check only."""
+        in_cost = (_PROBE_PROMPT_INPUT_TOKENS / 1_000_000.0) * _dw_input_per_m()
+        out_cost = (max_tokens / 1_000_000.0) * _dw_output_per_m()
+        return in_cost + out_cost
+
+    @staticmethod
+    def _feed_observer(
+        *,
+        model_id: str,
+        ttft_ms: int,
+        explicit_observer: Optional[Any],
+    ) -> None:
+        """Feed TTFT into the supplied observer or, when None, the
+        discovery-runner singleton. Both paths defensive — observer
+        faults swallowed."""
+        if explicit_observer is not None:
+            try:
+                explicit_observer.record_ttft(model_id, ttft_ms)
+            except Exception:  # noqa: BLE001 — defensive
+                pass
+            return
+        try:
+            from backend.core.ouroboros.governance.dw_discovery_runner import (
+                get_ttft_observer,
+            )
+            obs = get_ttft_observer()
+            if obs is not None:
+                obs.record_ttft(model_id, ttft_ms)
+        except Exception:  # noqa: BLE001 — defensive
+            pass
+
+    @staticmethod
+    async def _do_probe(
+        *,
+        session: Any,
+        model_id: str,
+        base_url: str,
+        api_key: str,
+        max_tokens: int,
+    ) -> Tuple[int, int, bool, str]:
+        """Issue the SSE request + read until first content chunk OR
+        timeout OR done. Returns (ttft_ms, total_ms, ok, error_str)."""
+        body = {
+            "model": model_id,
+            "messages": [
+                {"role": "user", "content": _PROBE_PROMPT},
+            ],
+            "max_tokens": max_tokens,
+            "stream": True,
+            "temperature": 0.0,
+        }
+        url = f"{base_url.rstrip('/')}/chat/completions"
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        timeout_s = _probe_timeout_s()
+        t_start = time.monotonic()
+        ttft_ms = 0
+        first_chunk_seen = False
+        try:
+            async with session.post(
+                url, json=body, headers=headers,
+            ) as resp:
+                if resp.status >= 300:
+                    body_text = ""
+                    try:
+                        body_text = (await resp.text())[:200]
+                    except Exception:  # noqa: BLE001 — defensive
+                        pass
+                    return (
+                        int(timeout_s * 1000),
+                        int((time.monotonic() - t_start) * 1000),
+                        False,
+                        f"status_{resp.status}:{body_text}",
+                    )
+                # Read SSE until first non-empty content chunk
+                while True:
+                    try:
+                        line = await asyncio.wait_for(
+                            resp.content.readline(), timeout=timeout_s,
+                        )
+                    except asyncio.TimeoutError:
+                        return (
+                            int(timeout_s * 1000),
+                            int((time.monotonic() - t_start) * 1000),
+                            False,
+                            "ttft_timeout",
+                        )
+                    if not line:
+                        # Stream closed before first chunk → cold/dead
+                        return (
+                            int(timeout_s * 1000),
+                            int((time.monotonic() - t_start) * 1000),
+                            False,
+                            "stream_closed_early",
+                        )
+                    text = line.decode("utf-8", errors="replace").strip()
+                    if not text or not text.startswith("data: "):
+                        continue
+                    data_str = text[6:]
+                    if data_str == "[DONE]":
+                        if not first_chunk_seen:
+                            return (
+                                int(timeout_s * 1000),
+                                int((time.monotonic() - t_start) * 1000),
+                                False,
+                                "done_before_content",
+                            )
+                        break
+                    try:
+                        chunk = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+                    delta = (chunk.get("choices") or [{}])[0].get(
+                        "delta", {},
+                    )
+                    token = delta.get("content", "")
+                    if token:
+                        if not first_chunk_seen:
+                            first_chunk_seen = True
+                            ttft_ms = int(
+                                (time.monotonic() - t_start) * 1000
+                            )
+                            # First chunk is the only one we need —
+                            # close stream early to bound cost.
+                            break
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — defense-in-depth
+            return (
+                int(timeout_s * 1000),
+                int((time.monotonic() - t_start) * 1000),
+                False,
+                f"transport:{type(exc).__name__}:{str(exc)[:80]}",
+            )
+        if not first_chunk_seen:
+            return (
+                int(timeout_s * 1000),
+                int((time.monotonic() - t_start) * 1000),
+                False,
+                "no_content",
+            )
+        return (
+            ttft_ms,
+            int((time.monotonic() - t_start) * 1000),
+            True,
+            "",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scheduler — picks candidates, respects intervals + budget
+# ---------------------------------------------------------------------------
+
+
+class HeavyProbeScheduler:
+    """Async loop that picks probe candidates from the catalog +
+    fires probes via ``HeavyProber``.
+
+    Skip rules (composable):
+      * model already promoted (signal proven, no need)
+      * model in cold-storage state (signal already present)
+      * model in TERMINAL_OPEN breaker (probe would waste budget)
+      * model probed within ``_probe_interval_s()`` (cooldown)
+      * daily budget exhausted
+
+    Cycle cadence: ``_scheduler_cycle_s()`` (default 120s). Each cycle
+    walks the catalog, picks at most one model per cycle (cap on
+    aggressive probing), fires the probe, sleeps until next cycle.
+
+    NEVER raises. Cancellation honored at every await boundary."""
+
+    def __init__(
+        self,
+        *,
+        prober: HeavyProber,
+        budget: HeavyProbeBudget,
+    ) -> None:
+        self._prober = prober
+        self._budget = budget
+        self._last_probed_at_unix: Dict[str, float] = {}
+        self._lock = threading.RLock()
+
+    async def run_cycle(
+        self,
+        *,
+        session: Any,
+        base_url: str,
+        api_key: str,
+        candidate_ids: Tuple[str, ...],
+    ) -> Optional[HeavyProbeResult]:
+        """One scheduler tick. Picks the first eligible candidate
+        from ``candidate_ids`` (preserving caller's ranking) + fires
+        a probe. Returns the probe result or None if nothing eligible.
+        NEVER raises."""
+        if not heavy_probe_enabled():
+            return None
+        for mid in candidate_ids:
+            if not self._is_eligible(mid):
+                continue
+            try:
+                with self._lock:
+                    self._last_probed_at_unix[mid] = time.time()
+                result = await self._prober.probe(
+                    session=session,
+                    model_id=mid,
+                    base_url=base_url,
+                    api_key=api_key,
+                )
+                logger.info(
+                    "[HeavyProbe] model=%s success=%s ttft_ms=%d "
+                    "total_ms=%d cost_usd=%.6f error=%s",
+                    mid, result.success, result.ttft_ms,
+                    result.total_latency_ms, result.cost_usd,
+                    result.error or "-",
+                )
+                return result
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — defensive
+                logger.debug(
+                    "[HeavyProbe] cycle failed for model=%s: %s",
+                    mid, exc, exc_info=True,
+                )
+                continue
+        return None
+
+    def _is_eligible(self, model_id: str) -> bool:
+        """Apply skip rules. NEVER raises."""
+        if not model_id or not model_id.strip():
+            return False
+        # Cooldown
+        with self._lock:
+            last = self._last_probed_at_unix.get(model_id)
+        if last is not None and (time.time() - last) < _probe_interval_s():
+            return False
+        # Budget
+        if self._budget.remaining_usd() <= 0:
+            return False
+        # Already-promoted / TERMINAL_OPEN / cold-storage skip rules.
+        # Lazy lookups so test harnesses that don't wire these still work.
+        try:
+            from backend.core.ouroboros.governance.dw_discovery_runner import (
+                _get_or_create_ledger, get_ttft_observer,
+            )
+            led = _get_or_create_ledger()
+            if led is not None and led.is_promoted(model_id):
+                return False
+            obs = get_ttft_observer()
+            if obs is not None:
+                try:
+                    if obs.is_cold_storage(model_id):
+                        return False
+                except Exception:  # noqa: BLE001 — defensive
+                    pass
+        except Exception:  # noqa: BLE001 — defensive
+            pass
+        # TERMINAL_OPEN breaker check
+        try:
+            from backend.core.ouroboros.governance.topology_sentinel import (
+                get_default_sentinel,
+            )
+            sent = get_default_sentinel()
+            if sent is not None and hasattr(sent, "is_terminal_open"):
+                try:
+                    if sent.is_terminal_open(model_id):
+                        return False
+                except Exception:  # noqa: BLE001 — defensive
+                    pass
+        except Exception:  # noqa: BLE001 — defensive
+            pass
+        return True
+
+
+__all__ = [
+    "BUDGET_SCHEMA_VERSION",
+    "HeavyProbeBudget",
+    "HeavyProbeResult",
+    "HeavyProber",
+    "HeavyProbeScheduler",
+    "heavy_probe_enabled",
+]

--- a/tests/governance/test_dw_heavy_probe.py
+++ b/tests/governance/test_dw_heavy_probe.py
@@ -1,0 +1,677 @@
+"""Phase 12.2 Slice D — Heavy probe regression spine.
+
+Pins:
+  §1  ``heavy_probe_enabled()`` flag — default false; case-tolerance
+  §2  HeavyProbeBudget — daily-USD ledger + UTC midnight rollover
+  §3  HeavyProbeBudget — atomic disk persistence
+  §4  HeavyProbeBudget — corrupt/missing → empty start (NEVER raises)
+  §5  HeavyProber — flag-off short-circuit returns no-op result
+  §6  HeavyProber — empty model_id rejected
+  §7  HeavyProber — budget pre-flight refuses + doesn't charge
+  §8  HeavyProber — success path records TTFT into observer
+  §9  HeavyProber — failure path records ceiling TTFT (cold-storage signal)
+  §10 HeavyProber — broken observer doesn't take down probe
+  §11 HeavyProbeScheduler — picks first eligible candidate
+  §12 HeavyProbeScheduler — skips already-promoted models
+  §13 HeavyProbeScheduler — skips cold-storage flagged models
+  §14 HeavyProbeScheduler — skips models within cooldown window
+  §15 HeavyProbeScheduler — skips when budget exhausted
+  §16 HeavyProbeScheduler — flag-off short-circuit
+  §17 dw_discovery_runner — get_heavy_probe_budget singleton + reset
+  §18 Authority invariants — heavy prober never mutates ledger
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_heavy_probe import (
+    BUDGET_SCHEMA_VERSION,
+    HeavyProbeBudget,
+    HeavyProber,
+    HeavyProbeResult,
+    HeavyProbeScheduler,
+    heavy_probe_enabled,
+)
+from backend.core.ouroboros.governance.dw_promotion_ledger import (
+    PromotionLedger,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_budget(tmp_path, monkeypatch) -> HeavyProbeBudget:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH",
+        str(tmp_path / "budget.json"),
+    )
+    bud = HeavyProbeBudget()
+    bud.load()
+    return bud
+
+
+@pytest.fixture
+def heavy_probe_on(monkeypatch):
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", "true")
+
+
+# ---------------------------------------------------------------------------
+# §1 — heavy_probe_enabled flag
+# ---------------------------------------------------------------------------
+
+
+def test_flag_default_false(monkeypatch) -> None:
+    monkeypatch.delenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", raising=False,
+    )
+    assert heavy_probe_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "On"])
+def test_flag_truthy_values(monkeypatch, val) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", val)
+    assert heavy_probe_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "", " "])
+def test_flag_falsy_values(monkeypatch, val) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", val)
+    assert heavy_probe_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# §2-§4 — HeavyProbeBudget
+# ---------------------------------------------------------------------------
+
+
+def test_budget_starts_with_full_remaining(
+    isolated_budget: HeavyProbeBudget, monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY", "0.10",
+    )
+    assert isolated_budget.spent_today_usd() == 0.0
+    assert isolated_budget.remaining_usd() == 0.10
+
+
+def test_budget_check_and_charge_commits(
+    isolated_budget: HeavyProbeBudget, monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY", "0.10",
+    )
+    assert isolated_budget.check_and_charge(0.04) is True
+    assert isolated_budget.spent_today_usd() == pytest.approx(0.04)
+    assert isolated_budget.remaining_usd() == pytest.approx(0.06)
+
+
+def test_budget_check_and_charge_refuses_overflow(
+    isolated_budget: HeavyProbeBudget, monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY", "0.05",
+    )
+    assert isolated_budget.check_and_charge(0.04) is True
+    # Second 0.04 charge would bust; refused + ledger unchanged
+    assert isolated_budget.check_and_charge(0.04) is False
+    assert isolated_budget.spent_today_usd() == pytest.approx(0.04)
+
+
+def test_budget_negative_charge_refused(
+    isolated_budget: HeavyProbeBudget,
+) -> None:
+    assert isolated_budget.check_and_charge(-0.01) is False
+    assert isolated_budget.spent_today_usd() == 0.0
+
+
+def test_budget_persists_across_instances(
+    tmp_path, monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH",
+        str(tmp_path / "b.json"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY", "0.10",
+    )
+    bud1 = HeavyProbeBudget()
+    bud1.load()
+    bud1.check_and_charge(0.03)
+
+    bud2 = HeavyProbeBudget()
+    bud2.load()
+    assert bud2.spent_today_usd() == pytest.approx(0.03)
+
+
+def test_budget_rollover_resets_at_utc_midnight(
+    tmp_path, monkeypatch,
+) -> None:
+    """A persisted ledger from yesterday auto-resets on next access."""
+    p = tmp_path / "b.json"
+    yesterday = (
+        datetime.now(timezone.utc) - timedelta(days=1)
+    ).strftime("%Y-%m-%d")
+    p.write_text(json.dumps({
+        "schema_version": BUDGET_SCHEMA_VERSION,
+        "current_day": yesterday,
+        "spent_today_usd": 0.99,
+    }))
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH", str(p),
+    )
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY", "0.10",
+    )
+    bud = HeavyProbeBudget()
+    bud.load()
+    # Stale day discarded → fresh budget today
+    assert bud.spent_today_usd() == 0.0
+    assert bud.remaining_usd() == pytest.approx(0.10)
+
+
+def test_budget_corrupt_json_starts_fresh(
+    tmp_path, monkeypatch,
+) -> None:
+    p = tmp_path / "b.json"
+    p.write_text("{ bad json")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH", str(p),
+    )
+    bud = HeavyProbeBudget()
+    bud.load()  # NEVER raises
+    assert bud.spent_today_usd() == 0.0
+
+
+def test_budget_schema_mismatch_starts_fresh(
+    tmp_path, monkeypatch,
+) -> None:
+    p = tmp_path / "b.json"
+    p.write_text(json.dumps({
+        "schema_version": "wrong.0",
+        "current_day": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "spent_today_usd": 0.99,
+    }))
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH", str(p),
+    )
+    bud = HeavyProbeBudget()
+    bud.load()
+    assert bud.spent_today_usd() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# §5-§10 — HeavyProber
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prober_flag_off_returns_noop(
+    isolated_budget: HeavyProbeBudget, monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", "false",
+    )
+    prober = HeavyProber(budget=isolated_budget)
+    result = await prober.probe(
+        session=MagicMock(),
+        model_id="vendor/m-7B",
+        base_url="https://test.example",
+        api_key="key",
+    )
+    assert result.success is False
+    assert result.error == "master_flag_off"
+    # Budget untouched
+    assert isolated_budget.spent_today_usd() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_prober_empty_model_id_rejected(
+    isolated_budget: HeavyProbeBudget, heavy_probe_on,
+) -> None:
+    prober = HeavyProber(budget=isolated_budget)
+    result = await prober.probe(
+        session=MagicMock(),
+        model_id="",
+        base_url="https://test.example",
+        api_key="key",
+    )
+    assert result.success is False
+    assert result.error == "empty_model_id"
+
+
+@pytest.mark.asyncio
+async def test_prober_budget_exhausted_refuses(
+    tmp_path, monkeypatch, heavy_probe_on,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH",
+        str(tmp_path / "b.json"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY", "0.0",
+    )
+    bud = HeavyProbeBudget()
+    bud.load()
+    prober = HeavyProber(budget=bud)
+    result = await prober.probe(
+        session=MagicMock(),
+        model_id="vendor/m-7B",
+        base_url="https://test.example",
+        api_key="key",
+    )
+    assert result.success is False
+    assert result.error == "budget_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_prober_success_records_into_observer(
+    isolated_budget: HeavyProbeBudget, heavy_probe_on,
+) -> None:
+    """When the SSE stream returns content, the prober records TTFT
+    into the supplied observer."""
+    fake_session = _SessionWith(
+        chunks=(b"data: {\"choices\":[{\"delta\":{\"content\":\"H\"}}]}\n",),
+    )
+    fake_obs = MagicMock()
+    prober = HeavyProber(budget=isolated_budget)
+    result = await prober.probe(
+        session=fake_session,
+        model_id="vendor/m-7B",
+        base_url="https://test.example",
+        api_key="key",
+        observer=fake_obs,
+    )
+    assert result.success is True
+    assert result.ttft_ms >= 0
+    fake_obs.record_ttft.assert_called_once()
+    args, _ = fake_obs.record_ttft.call_args
+    assert args[0] == "vendor/m-7B"
+
+
+@pytest.mark.asyncio
+async def test_prober_failure_records_ceiling_ttft(
+    isolated_budget: HeavyProbeBudget, heavy_probe_on, monkeypatch,
+) -> None:
+    """A 500 response → prober records the timeout ceiling as TTFT
+    (asymmetric cold-storage signal)."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_TIMEOUT_S", "5")
+    fake_session = _SessionWith(status=500, chunks=())
+    fake_obs = MagicMock()
+    prober = HeavyProber(budget=isolated_budget)
+    result = await prober.probe(
+        session=fake_session,
+        model_id="vendor/m-7B",
+        base_url="https://test.example",
+        api_key="key",
+        observer=fake_obs,
+    )
+    assert result.success is False
+    assert "status_500" in result.error
+    fake_obs.record_ttft.assert_called_once()
+    args, _ = fake_obs.record_ttft.call_args
+    # Ceiling = timeout_ms (5000)
+    assert args[1] == 5000
+
+
+@pytest.mark.asyncio
+async def test_prober_broken_observer_doesnt_break_probe(
+    isolated_budget: HeavyProbeBudget, heavy_probe_on,
+) -> None:
+    fake_session = _SessionWith(
+        chunks=(b"data: {\"choices\":[{\"delta\":{\"content\":\"H\"}}]}\n",),
+    )
+
+    class _Broken:
+        def record_ttft(self, *a, **kw):
+            raise RuntimeError("observer faulted")
+
+    prober = HeavyProber(budget=isolated_budget)
+    # Should NOT raise
+    result = await prober.probe(
+        session=fake_session,
+        model_id="vendor/m-7B",
+        base_url="https://test.example",
+        api_key="key",
+        observer=_Broken(),
+    )
+    assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# §11-§16 — HeavyProbeScheduler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scheduler_picks_first_eligible(
+    isolated_budget: HeavyProbeBudget, heavy_probe_on,
+) -> None:
+    """Scheduler walks candidates in order, fires probe on first
+    eligible one."""
+    fake_session = _SessionWith(
+        chunks=(b"data: {\"choices\":[{\"delta\":{\"content\":\"H\"}}]}\n",),
+    )
+    prober = _StubProber(budget=isolated_budget)
+    sched = HeavyProbeScheduler(prober=prober, budget=isolated_budget)
+    result = await sched.run_cycle(
+        session=fake_session,
+        base_url="https://test.example",
+        api_key="key",
+        candidate_ids=("vendor/m-7B", "vendor/m-13B"),
+    )
+    assert result is not None
+    assert prober.probed_ids == ["vendor/m-7B"]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_skips_promoted(
+    isolated_budget: HeavyProbeBudget, heavy_probe_on,
+    tmp_path, monkeypatch,
+) -> None:
+    """Already-promoted model is skipped by eligibility check."""
+    from backend.core.ouroboros.governance import dw_discovery_runner as ddr
+    monkeypatch.setenv(
+        "JARVIS_DW_PROMOTION_LEDGER_PATH", str(tmp_path / "led.json"),
+    )
+    ddr.reset_boot_state_for_tests()
+    led = ddr._get_or_create_ledger()
+    led.register_quarantine("vendor/m-7B")
+    # Force-promote bypass eligibility — we want is_promoted=True
+    rec = led._records["vendor/m-7B"]
+    rec.promoted = True
+    rec.promoted_at_unix = time.time()
+
+    prober = _StubProber(budget=isolated_budget)
+    sched = HeavyProbeScheduler(prober=prober, budget=isolated_budget)
+    await sched.run_cycle(
+        session=MagicMock(),
+        base_url="https://test.example",
+        api_key="key",
+        candidate_ids=("vendor/m-7B",),
+    )
+    assert prober.probed_ids == []
+    ddr.reset_boot_state_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_skips_cold_storage(
+    isolated_budget: HeavyProbeBudget, heavy_probe_on,
+    tmp_path, monkeypatch,
+) -> None:
+    """Model already flagged as cold-storage by the observer is
+    skipped (signal is already present)."""
+    from backend.core.ouroboros.governance import dw_discovery_runner as ddr
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED", "true",
+    )
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_TTFT_STATE_PATH",
+        str(tmp_path / "ttft.json"),
+    )
+    ddr.reset_boot_state_for_tests()
+    obs = ddr.get_ttft_observer()
+    # Build a stable mean + cold-storage spike
+    for ms in (100, 102, 99, 101, 100):
+        obs.record_ttft("vendor/m-7B", ms)
+    obs.record_ttft("vendor/m-7B", 1000)
+    assert obs.is_cold_storage("vendor/m-7B") is True
+
+    prober = _StubProber(budget=isolated_budget)
+    sched = HeavyProbeScheduler(prober=prober, budget=isolated_budget)
+    await sched.run_cycle(
+        session=MagicMock(),
+        base_url="https://test.example",
+        api_key="key",
+        candidate_ids=("vendor/m-7B",),
+    )
+    assert prober.probed_ids == []
+    ddr.reset_boot_state_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_scheduler_skips_within_cooldown(
+    isolated_budget: HeavyProbeBudget, heavy_probe_on, monkeypatch,
+) -> None:
+    """A model probed within ``_probe_interval_s`` is skipped."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_INTERVAL_S", "300")
+    prober = _StubProber(budget=isolated_budget)
+    sched = HeavyProbeScheduler(prober=prober, budget=isolated_budget)
+    # First probe fires
+    await sched.run_cycle(
+        session=MagicMock(),
+        base_url="https://test.example",
+        api_key="key",
+        candidate_ids=("vendor/m-7B",),
+    )
+    assert prober.probed_ids == ["vendor/m-7B"]
+    # Second probe within cooldown — skipped
+    await sched.run_cycle(
+        session=MagicMock(),
+        base_url="https://test.example",
+        api_key="key",
+        candidate_ids=("vendor/m-7B",),
+    )
+    assert prober.probed_ids == ["vendor/m-7B"]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_skips_when_budget_exhausted(
+    tmp_path, monkeypatch, heavy_probe_on,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH",
+        str(tmp_path / "b.json"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY", "0.0",
+    )
+    bud = HeavyProbeBudget()
+    bud.load()
+    prober = _StubProber(budget=bud)
+    sched = HeavyProbeScheduler(prober=prober, budget=bud)
+    result = await sched.run_cycle(
+        session=MagicMock(),
+        base_url="https://test.example",
+        api_key="key",
+        candidate_ids=("vendor/m-7B",),
+    )
+    assert result is None
+    assert prober.probed_ids == []
+
+
+@pytest.mark.asyncio
+async def test_scheduler_flag_off_short_circuit(
+    isolated_budget: HeavyProbeBudget, monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", "false",
+    )
+    prober = _StubProber(budget=isolated_budget)
+    sched = HeavyProbeScheduler(prober=prober, budget=isolated_budget)
+    result = await sched.run_cycle(
+        session=MagicMock(),
+        base_url="https://test.example",
+        api_key="key",
+        candidate_ids=("vendor/m-7B",),
+    )
+    assert result is None
+    assert prober.probed_ids == []
+
+
+# ---------------------------------------------------------------------------
+# §17 — dw_discovery_runner singleton + reset
+# ---------------------------------------------------------------------------
+
+
+def test_get_heavy_probe_budget_returns_none_when_off(
+    monkeypatch, tmp_path,
+) -> None:
+    from backend.core.ouroboros.governance import dw_discovery_runner as ddr
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", "false")
+    ddr.reset_boot_state_for_tests()
+    assert ddr.get_heavy_probe_budget() is None
+
+
+def test_get_heavy_probe_budget_singleton_when_on(
+    monkeypatch, tmp_path,
+) -> None:
+    from backend.core.ouroboros.governance import dw_discovery_runner as ddr
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH",
+        str(tmp_path / "b.json"),
+    )
+    ddr.reset_boot_state_for_tests()
+    bud1 = ddr.get_heavy_probe_budget()
+    bud2 = ddr.get_heavy_probe_budget()
+    assert bud1 is not None
+    assert bud1 is bud2
+
+
+def test_reset_drops_heavy_probe_budget_singleton(
+    monkeypatch, tmp_path,
+) -> None:
+    from backend.core.ouroboros.governance import dw_discovery_runner as ddr
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH",
+        str(tmp_path / "b.json"),
+    )
+    ddr.reset_boot_state_for_tests()
+    bud1 = ddr.get_heavy_probe_budget()
+    ddr.reset_boot_state_for_tests()
+    bud2 = ddr.get_heavy_probe_budget()
+    assert bud1 is not bud2
+
+
+# ---------------------------------------------------------------------------
+# §18 — Authority invariants
+# ---------------------------------------------------------------------------
+
+
+def test_heavy_prober_never_mutates_ledger() -> None:
+    """Heavy prober reads observer + ledger but never mutates the
+    ledger. Same authority invariant as Slice C classifier."""
+    import ast
+    import inspect
+    from backend.core.ouroboros.governance import dw_heavy_probe
+    src = inspect.getsource(dw_heavy_probe)
+    tree = ast.parse(src)
+    forbidden = {
+        "register_quarantine",
+        "record_success",
+        "record_failure",
+        "promote",
+        "demote",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            target = node.func
+            if (
+                isinstance(target.value, ast.Name)
+                and target.value.id in {"led", "ledger", "promotion_ledger"}
+                and target.attr in forbidden
+            ):
+                raise AssertionError(
+                    f"heavy prober calls forbidden ledger.{target.attr} "
+                    f"at line {node.lineno}"
+                )
+
+
+def test_heavy_probe_never_imports_orchestrator() -> None:
+    """Heavy probe is a discovery-layer primitive — it must not
+    reach into orchestrator / phase_runner authority."""
+    import inspect
+    from backend.core.ouroboros.governance import dw_heavy_probe
+    src = inspect.getsource(dw_heavy_probe)
+    for forbidden in (
+        "from backend.core.ouroboros.governance.orchestrator",
+        "from backend.core.ouroboros.governance.phase_runner",
+        "from backend.core.ouroboros.governance.iron_gate",
+        "from backend.core.ouroboros.governance.semantic_guardian",
+    ):
+        assert forbidden not in src, f"heavy probe imports {forbidden}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _SessionWith:
+    """Minimal aiohttp.ClientSession-shaped stub that returns the
+    given chunks from resp.content.readline()."""
+    def __init__(
+        self,
+        *,
+        status: int = 200,
+        chunks: Tuple[bytes, ...] = (),
+    ) -> None:
+        self._status = status
+        self._chunks: List[bytes] = list(chunks) + [b""]  # EOF sentinel
+
+    def post(self, *a, **kw):
+        return _RespCM(status=self._status, chunks=self._chunks)
+
+
+class _RespCM:
+    def __init__(self, *, status: int, chunks: List[bytes]) -> None:
+        self._status = status
+        self._chunks = chunks
+
+    async def __aenter__(self):
+        return _Resp(status=self._status, chunks=self._chunks)
+
+    async def __aexit__(self, *a):
+        return None
+
+
+class _Resp:
+    def __init__(self, *, status: int, chunks: List[bytes]) -> None:
+        self.status = status
+        self.content = _Content(chunks=chunks)
+
+    async def text(self) -> str:
+        return f"HTTP {self.status}"
+
+
+class _Content:
+    def __init__(self, *, chunks: List[bytes]) -> None:
+        self._chunks = chunks
+
+    async def readline(self) -> bytes:
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
+
+
+class _StubProber:
+    """A HeavyProber-shaped stub that records which model_ids it
+    was asked to probe. Used to verify scheduler behavior without
+    needing a real HTTP path."""
+    def __init__(self, *, budget: HeavyProbeBudget) -> None:
+        self._budget = budget
+        self.probed_ids: List[str] = []
+
+    async def probe(self, *, session, model_id, base_url, api_key,
+                    observer=None):
+        self.probed_ids.append(model_id)
+        return HeavyProbeResult(
+            model_id=model_id,
+            success=True,
+            ttft_ms=100,
+            total_latency_ms=200,
+            cost_usd=0.001,
+            error="",
+        )


### PR DESCRIPTION
## Summary

Phase 12.2 Slice D closes the chicken-and-egg between **Slice G** (1-token modality micro-probe — proves schema acceptance only) and **Slice B/C** (TtftObserver — empty until production use). A model that passes Slice G AND has zero observer samples can still be in cold storage when a real op hits it. Slice D fills the gap with deliberate, cost-bounded periodic probes that actively warm VRAM and feed TTFT into the observer Slice C consumes.

All gated behind master flag `JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED` (default **false** until Slice E graduation). Master-off path is bit-for-bit identical to pre-Slice-D boot.

### What ships

| Component | Surface |
|---|---|
| `HeavyProbeResult` | Frozen dataclass capturing one probe outcome |
| `HeavyProbeBudget` | Daily-USD ledger with UTC-midnight rollover + atomic disk persist |
| `HeavyProber` | Single-shot probe — issues sized completion, records TTFT |
| `HeavyProbeScheduler` | Async loop with composable skip rules (promoted, cold-storage, TERMINAL_OPEN, cooldown, budget) |
| `dw_discovery_runner._heavy_probe_loop` | Optional task spawned at boot when flag on |

### Skip rules (composable, all checked per scheduler tick)

- Already-promoted models (signal proven, no need to probe)
- Cold-storage flagged models (signal already present from observer)
- TERMINAL_OPEN breakered models (probe would waste budget)
- Within-cooldown models (per-model interval, default 600s)
- Daily budget exhausted (atomic check + charge, never goes negative)

### Tunables

```
JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED          (default false)
JARVIS_TOPOLOGY_HEAVY_PROBE_TOKENS           (default 50)
JARVIS_TOPOLOGY_HEAVY_PROBE_INTERVAL_S       (default 600)
JARVIS_TOPOLOGY_HEAVY_PROBE_TIMEOUT_S        (default 30)
JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY (default 0.05)
JARVIS_TOPOLOGY_HEAVY_PROBE_CYCLE_S          (default 120)
JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH      (default .jarvis/dw_heavy_probe_budget.json)
```

### Authority invariants (pinned by tests)

- Heavy prober **never** mutates `PromotionLedger` (AST-walked, not text-grepped — docstring examples don't count). Promotion authority stays in Slice C's `is_eligible_for_promotion(observer=…)` surface.
- Heavy probe module **never** imports `orchestrator` / `phase_runner` / `iron_gate` / `semantic_guardian`. It's a discovery-layer primitive, not a cognitive-substrate consumer.
- Failed probes record the **timeout ceiling** as TTFT (asymmetric cold-storage signal). Slow OR failed both register as "not warm" — caller can disambiguate via `result.error`.

### Cost economics

At default settings (50 tokens × $0.40/M output + 10 tokens × $0.10/M input ≈ $0.000021 per probe), the daily $0.05 budget supports ~2,300 probes — far more than a 22-model catalog at 10-min intervals would consume. The budget is a fence against runaway, not a normal operating constraint.

## Test plan

- [x] 37 new tests in `test_dw_heavy_probe.py` covering 18 pin sections
- [x] 296/296 green across full Phase 12 + 12.2 regression suite (`test_dw_*` + `test_full_jitter` + `test_terminal_breaker_states`)
- [x] AST-walked authority invariant (no `ledger.mutator(…)` calls anywhere in `dw_heavy_probe.py`)
- [x] Budget UTC-midnight rollover tested with explicit yesterday-stamped fixture
- [x] Broken-observer defense tested (observer that raises on `record_ttft` doesn't break probe)
- [x] Singleton lifecycle tested (`reset_boot_state_for_tests` drops budget singleton)

## Notes

- Heavy probes target the **SPECULATIVE route** specifically — those are the models in quarantine / unknown / cold-storage state where we want VRAM-warm signal. Promoted models in BACKGROUND/STANDARD/COMPLEX already have the signal proven.
- The probe prompt is fixed and minimal (`"Reply with one short sentence about clouds."`) — we want VRAM-warm observation, not capability discovery. Capability discovery is Slice G's surface.
- DW provider's adaptive poll already has `+/-25%` jitter (noted in Slice C); Slice D doesn't touch it.
- Slice E (graduation flip — defaults to true on master + sub-flags) remains pending. After Slice D merges, the recommended cadence is 3 clean once-proofs over 1 week before flipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a cost-bounded “heavy probe” that warms VRAM and records TTFT for SPECULATIVE-route models, closing the gap before real traffic hits. It runs behind the `JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED` flag (default false) and leaves the master-off path unchanged.

- New Features
  - `dw_heavy_probe.py`: `HeavyProbeResult`, `HeavyProbeBudget` (daily USD ledger with UTC-midnight rollover, atomic disk), `HeavyProber` (single-shot probe measuring TTFT on first streamed token), `HeavyProbeScheduler` (async loop).
  - Discovery runner integration: optional `_heavy_probe_loop` task and `get_heavy_probe_budget()` singleton; hot-revert respected by the flag.
  - Skip rules: already promoted, cold-storage, `TERMINAL_OPEN`, per-model cooldown, and daily budget.

- Migration
  - Off by default. Enable with `JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED=true`.
  - Optional tuning via:
    - `JARVIS_TOPOLOGY_HEAVY_PROBE_TOKENS`, `JARVIS_TOPOLOGY_HEAVY_PROBE_INTERVAL_S`, `JARVIS_TOPOLOGY_HEAVY_PROBE_TIMEOUT_S`
    - `JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_USD_DAILY`, `JARVIS_TOPOLOGY_HEAVY_PROBE_CYCLE_S`, `JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH`

<sup>Written for commit 7795972db479edffbac0f37847c546a2d8e65e94. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/28355">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

