### PR TITLE
feat(phase12.2): Slice E — Graduation flip — CLOSES PHASE 12.2

### DIFF
--- a/backend/core/ouroboros/governance/dw_heavy_probe.py
+++ b/backend/core/ouroboros/governance/dw_heavy_probe.py
@@ -62,15 +62,18 @@ logger = logging.getLogger(__name__)
 
 
 def heavy_probe_enabled() -> bool:
-    """``JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED`` (default ``false``).
+    """``JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED`` (default ``true`` —
+    graduated in Phase 12.2 Slice E).
 
-    Master kill switch. Off → scheduler refuses to spawn, ad-hoc
-    ``HeavyProber.probe()`` calls return a no-op result, budget ledger
-    untouched. Default flips to ``true`` at Phase 12.2 Slice E
-    graduation."""
+    Master kill switch. Hot-revert path: ``export
+    JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED=false`` → scheduler refuses
+    to spawn, ad-hoc ``HeavyProber.probe()`` calls return a no-op
+    result with ``error=master_flag_off``, budget ledger untouched."""
     raw = os.environ.get(
         "JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/dw_ttft_observer.py
+++ b/backend/core/ouroboros/governance/dw_ttft_observer.py
@@ -67,19 +67,25 @@ logger = logging.getLogger(__name__)
 
 
 def tracking_enabled() -> bool:
-    """``JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED`` (default ``false``).
+    """``JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED`` (default ``true`` —
+    graduated in Phase 12.2 Slice E).
 
     Re-read at call time so monkeypatch works in tests + operators
-    can flip live without re-init. Default flips to ``true`` at
-    Phase 12.2 Slice E graduation."""
+    can flip live without re-init. Hot-revert path: ``export
+    JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED=false`` returns the
+    observer to dormant — record_ttft becomes a no-op + the
+    promotion / cold-storage gates short-circuit to False."""
     raw = os.environ.get(
         "JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 
 def ttft_demotion_enabled() -> bool:
-    """``JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED`` (default ``false``).
+    """``JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED`` (default ``true`` —
+    graduated in Phase 12.2 Slice E).
 
     Phase 12.2 Slice C master flag. When ``true``:
 
@@ -90,14 +96,16 @@ def ttft_demotion_enabled() -> bool:
         as a soft gate — cold-storage models temporarily route to
         SPECULATIVE only until TTFT normalizes (auto-recovery).
 
-    When ``false``: legacy count-gate behavior preserved bit-for-bit.
-    Independent from ``tracking_enabled()`` — operators can record
-    TTFT samples without acting on them (shadow-mode observation).
-
-    Default flips to ``true`` at Phase 12.2 Slice E graduation."""
+    Hot-revert path: ``export JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED=
+    false`` returns the gate to legacy count-based behavior +
+    classifier ignores cold-storage signal. Independent from
+    ``tracking_enabled()`` — operators can disable acting on TTFT
+    without losing the observation stream."""
     raw = os.environ.get(
         "JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/full_jitter.py
+++ b/backend/core/ouroboros/governance/full_jitter.py
@@ -49,11 +49,11 @@ from typing import Optional
 
 
 def full_jitter_enabled() -> bool:
-    """``JARVIS_TOPOLOGY_FULL_JITTER_ENABLED`` (default ``false``).
+    """``JARVIS_TOPOLOGY_FULL_JITTER_ENABLED`` (default ``true`` —
+    graduated in Phase 12.2 Slice E).
 
     Re-read at call time so monkeypatch works in tests + operators
-    can flip live without re-init. Default flips to ``true`` at
-    Phase 12.2 Slice E graduation. Hot-revert path: ``export
+    can flip live without re-init. Hot-revert path: ``export
     JARVIS_TOPOLOGY_FULL_JITTER_ENABLED=false`` returns retry sites
     to exact-exponential behavior immediately.
 
@@ -64,6 +64,8 @@ def full_jitter_enabled() -> bool:
     raw = os.environ.get(
         "JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/tests/governance/test_dw_heavy_probe.py
+++ b/tests/governance/test_dw_heavy_probe.py
@@ -71,11 +71,20 @@ def heavy_probe_on(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_flag_default_false(monkeypatch) -> None:
+def test_flag_default_on(monkeypatch) -> None:
+    """Phase 12.2 Slice E graduated default — env unset → True."""
     monkeypatch.delenv(
         "JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", raising=False,
     )
-    assert heavy_probe_enabled() is False
+    assert heavy_probe_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", " "])
+def test_flag_empty_reads_as_default_on(monkeypatch, val) -> None:
+    """Empty/whitespace values are the unset marker — read as True
+    post-graduation."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", val)
+    assert heavy_probe_enabled() is True
 
 
 @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "On"])
@@ -84,8 +93,9 @@ def test_flag_truthy_values(monkeypatch, val) -> None:
     assert heavy_probe_enabled() is True
 
 
-@pytest.mark.parametrize("val", ["0", "false", "no", "off", "", " "])
+@pytest.mark.parametrize("val", ["0", "false", "no", "off"])
 def test_flag_falsy_values(monkeypatch, val) -> None:
+    """Hot-revert: explicit false-class strings disable the feature."""
     monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", val)
     assert heavy_probe_enabled() is False
 

--- a/tests/governance/test_dw_ttft_observer.py
+++ b/tests/governance/test_dw_ttft_observer.py
@@ -63,16 +63,26 @@ def make_observer(isolated_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_tracking_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_tracking_default_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Phase 12.2 Slice E graduated default — env unset → True."""
     monkeypatch.delenv("JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED", raising=False)
-    assert tracking_enabled() is False
+    assert tracking_enabled() is True
+
+
+def test_tracking_empty_string_reads_as_default_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED", "")
+    assert tracking_enabled() is True
 
 
 def test_tracking_truthy_falsy(monkeypatch: pytest.MonkeyPatch) -> None:
     for v in ("1", "true", "yes", "on", "TRUE"):
         monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED", v)
         assert tracking_enabled() is True
-    for v in ("0", "false", "no", "off", "", "garbage"):
+    # Empty/whitespace values map to graduated default True;
+    # only explicit false-class strings still revert.
+    for v in ("0", "false", "no", "off", "garbage"):
         monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED", v)
         assert tracking_enabled() is False
 

--- a/tests/governance/test_dw_ttft_wiring_slice_c.py
+++ b/tests/governance/test_dw_ttft_wiring_slice_c.py
@@ -103,9 +103,18 @@ def _make_snapshot(*cards: ModelCard) -> CatalogSnapshot:
 # ---------------------------------------------------------------------------
 
 
-def test_demotion_flag_default_false(monkeypatch) -> None:
+def test_demotion_flag_default_on(monkeypatch) -> None:
+    """Phase 12.2 Slice E graduated default — env unset → True."""
     monkeypatch.delenv("JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED", raising=False)
-    assert ttft_demotion_enabled() is False
+    assert ttft_demotion_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", " "])
+def test_demotion_flag_empty_reads_as_default_on(monkeypatch, val) -> None:
+    """Empty/whitespace values are the unset marker — read as True
+    post-graduation."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED", val)
+    assert ttft_demotion_enabled() is True
 
 
 @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "YES", "on", "On"])
@@ -114,8 +123,9 @@ def test_demotion_flag_truthy_values(monkeypatch, val) -> None:
     assert ttft_demotion_enabled() is True
 
 
-@pytest.mark.parametrize("val", ["0", "false", "FALSE", "no", "off", "", " "])
+@pytest.mark.parametrize("val", ["0", "false", "FALSE", "no", "off"])
 def test_demotion_flag_falsy_values(monkeypatch, val) -> None:
+    """Hot-revert: explicit false-class strings disable the feature."""
     monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED", val)
     assert ttft_demotion_enabled() is False
 

--- a/tests/governance/test_full_jitter.py
+++ b/tests/governance/test_full_jitter.py
@@ -32,9 +32,17 @@ from backend.core.ouroboros.governance.full_jitter import (
 # ---------------------------------------------------------------------------
 
 
-def test_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_flag_default_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Phase 12.2 Slice E graduated default — env unset → True."""
     monkeypatch.delenv("JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", raising=False)
-    assert full_jitter_enabled() is False
+    assert full_jitter_enabled() is True
+
+
+def test_flag_empty_string_reads_as_default_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", "")
+    assert full_jitter_enabled() is True
 
 
 def test_flag_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -44,7 +52,10 @@ def test_flag_truthy_values(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_flag_falsy_values(monkeypatch: pytest.MonkeyPatch) -> None:
-    for v in ("0", "false", "no", "off", "", "garbage"):
+    """Hot-revert: explicit false-class strings disable the feature.
+    Empty string and whitespace are now the unset marker → graduated
+    default True; only explicit false-class strings still revert."""
+    for v in ("0", "false", "no", "off", "garbage"):
         monkeypatch.setenv("JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", v)
         assert full_jitter_enabled() is False
 

--- a/tests/governance/test_phase12_2_graduation_pins.py
+++ b/tests/governance/test_phase12_2_graduation_pins.py
@@ -1,0 +1,254 @@
+"""Phase 12.2 Slice E — graduation pin suite.
+
+Pins the graduated state of the four Phase 12.2 master flags. These
+were introduced default-false in Slices A/B/C/D and flipped to
+default-true in Slice E. The pin suite enforces:
+
+  * defaults are True when env is unset OR empty-string OR whitespace
+  * each ``"false"``-class override returns False (hot-revert path)
+  * full-revert matrix: flipping one flag off doesn't cross-couple
+    any of the others
+  * source-level pins: each function literally returns ``True`` from
+    the empty-string branch (catches accidental refactor regression)
+
+All four flags can be hot-reverted independently. The flags govern
+distinct subsystems with independent rollback authority:
+
+  * JARVIS_TOPOLOGY_FULL_JITTER_ENABLED   — retry-site backoff
+  * JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED — observer record-on-write
+  * JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED — promotion + cold-storage
+  * JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED   — VRAM-warming probes
+
+Pin sections:
+  §1  Defaults are True when env unset
+  §2  Empty-string env reads as default-True (unset marker)
+  §3  Whitespace-only env reads as default-True
+  §4  Each ``"false"``-class override returns False
+  §5  Full-revert matrix (one-off flip doesn't cross-couple)
+  §6  Garbage / unknown values revert to False (strict opt-in)
+  §7  Source-level pin: each function has the graduated branch
+  §8  Public API surface — graduated readers callable from module
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_heavy_probe import (
+    heavy_probe_enabled,
+)
+from backend.core.ouroboros.governance.dw_ttft_observer import (
+    tracking_enabled,
+    ttft_demotion_enabled,
+)
+from backend.core.ouroboros.governance.full_jitter import (
+    full_jitter_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Centralized graduated-flag list — single source of truth for the suite
+# ---------------------------------------------------------------------------
+
+
+_GRADUATED_FLAGS = [
+    ("JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", full_jitter_enabled),
+    ("JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED", tracking_enabled),
+    ("JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED", ttft_demotion_enabled),
+    ("JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", heavy_probe_enabled),
+]
+
+
+# ===========================================================================
+# §1 — Defaults are True when env unset
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_default_is_true_when_env_unset(
+    env_name: str, reader, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delenv → reader returns True. The graduated default."""
+    monkeypatch.delenv(env_name, raising=False)
+    assert reader() is True, (
+        f"Slice E graduation: {env_name} must default True"
+    )
+
+
+# ===========================================================================
+# §2 — Empty string is the unset marker
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_empty_string_reads_as_default_true(
+    env_name: str, reader, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setenv("", "")`` matches delenv. Operators commonly clear via
+    shell ``export FOO=`` (which sets to empty string). Pre-graduation
+    "" was a falsy value; post-graduation it's the unset marker."""
+    monkeypatch.setenv(env_name, "")
+    assert reader() is True
+
+
+# ===========================================================================
+# §3 — Whitespace-only reads as default-True
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+@pytest.mark.parametrize("ws", [" ", "  ", "\t", " \t "])
+def test_whitespace_reads_as_default_true(
+    env_name: str, reader, ws: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``.strip()`` collapses whitespace to empty → graduated default."""
+    monkeypatch.setenv(env_name, ws)
+    assert reader() is True
+
+
+# ===========================================================================
+# §4 — Hot-revert: explicit false-class strings disable
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+@pytest.mark.parametrize("falsy", ["false", "0", "no", "off", "FALSE"])
+def test_false_class_string_reverts(
+    env_name: str, reader, falsy: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The four operator-visible false-class spellings still disable
+    the feature post-graduation. Critical for emergency rollback."""
+    monkeypatch.setenv(env_name, falsy)
+    assert reader() is False, (
+        f"{env_name}={falsy!r} should disable the feature"
+    )
+
+
+# ===========================================================================
+# §5 — Full-revert matrix
+# ===========================================================================
+
+
+def test_full_revert_matrix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flip each flag off in turn; verify ONLY that one flag flips
+    while the other three stay True. Catches accidental cross-coupling
+    (e.g., a refactor that gates the heavy probe behind the TTFT flag
+    would fail this matrix)."""
+    for env_off, _ in _GRADUATED_FLAGS:
+        # Reset all to default (delenv) — graduated state
+        for env_name, _r in _GRADUATED_FLAGS:
+            monkeypatch.delenv(env_name, raising=False)
+        # Flip exactly one off
+        monkeypatch.setenv(env_off, "false")
+        # Verify the flipped one is off, the rest still True
+        for env_name, reader in _GRADUATED_FLAGS:
+            expected = (env_name != env_off)
+            actual = reader()
+            assert actual is expected, (
+                f"After flipping {env_off}=false, {env_name} reader "
+                f"returned {actual} (expected {expected})"
+            )
+
+
+# ===========================================================================
+# §6 — Garbage values revert to False (strict opt-in to non-default)
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+@pytest.mark.parametrize("garbage", ["maybe", "unknown", "2", "ENABLED"])
+def test_garbage_values_revert_to_false(
+    env_name: str, reader, garbage: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-graduation: any non-truthy string returned False. Post-
+    graduation: empty/whitespace are now True (unset marker), but any
+    NON-empty string that isn't in the truthy set still returns False.
+    Asymmetric on purpose — operators must explicitly opt-in to
+    non-default values via the truthy strings."""
+    monkeypatch.setenv(env_name, garbage)
+    assert reader() is False, (
+        f"{env_name}={garbage!r} should revert to False — only the "
+        f"explicit truthy strings + the unset marker yield True"
+    )
+
+
+# ===========================================================================
+# §7 — Source-level pins (catches refactor regression)
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_source_has_graduated_branch(env_name: str, reader) -> None:
+    """Pin: each flag function has the ``if raw == "": return True``
+    graduated branch. Catches accidental revert via refactor."""
+    src = inspect.getsource(reader)
+    assert 'if raw == ""' in src, (
+        f"{reader.__name__} source must contain the graduated empty-"
+        f"string branch (Slice E pin)"
+    )
+    assert "return True" in src, (
+        f"{reader.__name__} source must contain `return True` for the "
+        f"graduated default"
+    )
+    # The function must still consult the truthy set so explicit
+    # opt-in values keep working.
+    assert '"true"' in src or "'true'" in src, (
+        f"{reader.__name__} source must still recognize 'true' as "
+        f"explicit truthy value"
+    )
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_source_documents_graduated_default(env_name: str, reader) -> None:
+    """Each docstring documents the graduated default. Operators
+    grepping for "default ``true`` —" find the four Slice E flags."""
+    src = inspect.getsource(reader)
+    # Either the docstring explicitly says "default ``true``" OR
+    # references the graduation slice. Allow both since style varies.
+    has_doc = (
+        "default ``true``" in src
+        or "graduated in Phase 12.2 Slice E" in src
+    )
+    assert has_doc, (
+        f"{reader.__name__} docstring must document the graduated "
+        f"default (Slice E)"
+    )
+
+
+# ===========================================================================
+# §8 — Public API surface
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_reader_is_callable_no_args(env_name: str, reader) -> None:
+    """Each flag function is callable with no arguments + returns a
+    bool. Stable contract for cross-module consumers."""
+    result = reader()
+    assert isinstance(result, bool), (
+        f"{reader.__name__} must return bool, got {type(result)}"
+    )
+
+
+def test_full_jitter_helper_unaffected_by_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``full_jitter_backoff_s`` is a pure function — flag governs
+    whether CALLERS use it, not whether the helper itself works.
+    Pin: helper still computes a valid uniform delay regardless of
+    flag state."""
+    from backend.core.ouroboros.governance.full_jitter import (
+        full_jitter_backoff_s,
+    )
+    # Flag off
+    monkeypatch.setenv("JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", "false")
+    delay = full_jitter_backoff_s(2, base_s=10, cap_s=300)
+    assert 0 <= delay <= 40  # min(300, 10*2^2) = 40
+    # Flag on (or default)
+    monkeypatch.delenv("JARVIS_TOPOLOGY_FULL_JITTER_ENABLED", raising=False)
+    delay = full_jitter_backoff_s(2, base_s=10, cap_s=300)
+    assert 0 <= delay <= 40


### PR DESCRIPTION
## Summary

Phase 12.2 Slice E flips four master flags from default-false to default-true, graduating the entire Physics-Aware Topology Routing arc. All four flags retain their hot-revert paths — operators can roll back any subsystem independently via explicit "false"-class strings.

### Graduated flags

| Flag | Subsystem | Slice |
|---|---|---|
| `JARVIS_TOPOLOGY_FULL_JITTER_ENABLED` | Retry desync at 3 callsites | A |
| `JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED` | TtftObserver record-on-write | B |
| `JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED` | Promotion + cold-storage gate | C |
| `JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED` | VRAM-warming probes | D |

### Gate semantics post-graduation (mirrors Phase 12 Slice E pattern)

| Env value | Result | Notes |
|---|---|---|
| unset / `""` / whitespace | **True** | graduated default (unset marker) |
| `"1"` / `"true"` / `"yes"` / `"on"` | True | explicit opt-in |
| `"0"` / `"false"` / `"no"` / `"off"` | **False** | hot-revert path |
| any other non-empty string | False | strict opt-in to non-default |

The asymmetric mapping is deliberate: empty/whitespace become the unset marker post-graduation so operators clearing via shell `export FOO=` get the graduated default rather than accidentally reverting.

### Test updates (each Slice's flag-test contract evolves)

- `test_full_jitter.py` — `test_flag_default_off` → `test_flag_default_on` + new `test_flag_empty_string_reads_as_default_on`. `""` / `" "` removed from falsy_values list.
- `test_dw_ttft_observer.py` — same pattern for `tracking_enabled`.
- `test_dw_ttft_wiring_slice_c.py` — same pattern for `ttft_demotion_enabled`.
- `test_dw_heavy_probe.py` — same pattern for `heavy_probe_enabled`.

### New graduation pin file (`test_phase12_2_graduation_pins.py`, 35 pins)

8 pin sections following the Phase 12 Slice E precedent:

- **§1** Defaults are True when env unset (4 flags × parametrize)
- **§2** Empty-string env reads as default-True (4 flags)
- **§3** Whitespace-only reads as default-True (4 flags × 4 ws variants)
- **§4** Each "false"-class override returns False (4 flags × 5 falsy)
- **§5** Full-revert matrix — flipping one flag doesn't cross-couple any of the others
- **§6** Garbage values revert to False (strict opt-in to non-default)
- **§7** Source-level pins — each function literally has the `if raw == "": return True` graduated branch + truthy set preserved + docstring documents graduation
- **§8** Public API surface — readers callable + return bool; `full_jitter_backoff_s` helper still pure regardless of flag

## Test plan

- [x] 402/402 green across full Phase 12 + 12.2 regression suite
- [x] Source-level pin proves the graduated branch exists in source (catches refactor-revert regression)
- [x] Full-revert matrix proves no cross-coupling between the 4 flags
- [x] Hot-revert path verified for every flag × every false-class spelling (4 × 5 = 20 cases)
- [x] Both Phase 12 + Phase 12.2 graduation pin files run together (no flag-name collisions)

## Notes

- Master-off byte-for-byte path preserved per slice — flipping any single flag back to "false" returns that subsystem to pre-Slice-A/B/C/D behavior immediately, no re-init required.
- `full_jitter_backoff_s` is a pure helper — flag governs whether CALLERS use it, not whether the function works. Pin §8 verifies this.
- After this merge, the recommended graduation cadence is 3 clean once-proofs over ~1 week before considering the Phase 12.2 arc fully closed (matches the Wave 1 / Phase 12 closure pattern).
- Slice E touches 8 files: 3 production (flag flip + docstring), 4 test (default-state updates), 1 new pin file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates Phase 12.2 by flipping four topology flags to default-true. Empty/whitespace now mean “unset” (True), and each subsystem still supports hot-revert with explicit false values.

- New Features
  - Graduated flags: JARVIS_TOPOLOGY_FULL_JITTER_ENABLED (retry desync), JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED (observer), JARVIS_TOPOLOGY_TTFT_DEMOTION_ENABLED (promotion/cold-storage), JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED (VRAM-warming probes).
  - Gate semantics: unset/empty/whitespace → True; "1"/"true"/"yes"/"on" → True; "0"/"false"/"no"/"off" or any other non-empty → False.
  - Tests: added tests/governance/test_phase12_2_graduation_pins.py (matrix + source pins) and updated flag tests to default-on.

- Migration
  - No action needed; clearing an env var (export FOO=) now yields True.
  - To disable any subsystem, set its flag to "false" (or "0"/"no"/"off"); takes effect immediately.

<sup>Written for commit ce56dcf81fa65e938750b84ac79386a653b803eb. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/28444?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

