### PR TITLE
feat(phase12.2): Slice G — Absolute Ceiling + Failure Ignorance

### DIFF
--- a/backend/core/ouroboros/governance/dw_heavy_probe.py
+++ b/backend/core/ouroboros/governance/dw_heavy_probe.py
@@ -467,19 +467,31 @@ class HeavyProber:
                 error=f"unhandled:{type(exc).__name__}:{str(exc)[:80]}",
             )
 
-        # Feed observer on success. On failure we still feed a "slow"
-        # ttft signal asymmetrically — the goal is cold-storage
-        # detection, and a failed probe is at least as cold as a slow
-        # one. Caller can disambiguate via result.error.
+        # Slice G — Failure Ignorance (operator directive 2026-04-28).
+        # ConnectionTimeoutError + transport failures + empty-stream
+        # cases are NETWORK FAILURES, not TTFT measurements. Feeding
+        # them to the observer would poison the rolling stats — a
+        # uniform-30s-timeout sample stream looks "consistent" by CV
+        # math but is functionally meaningless. Only record genuine
+        # first-chunk arrival measurements.
+        #
+        # The asymmetric ceiling-on-failure pattern from initial Slice D
+        # was rejected: cold-storage detection should fall to the
+        # modality ledger / terminal breaker for "endpoint dead" cases,
+        # not to the TTFT observer.
+        if ok:
+            try:
+                self._feed_observer(
+                    model_id=model_id, ttft_ms=ttft_ms,
+                    explicit_observer=observer,
+                )
+            except Exception:  # noqa: BLE001 — defensive
+                pass
+        # On failure: the observer is NOT updated. The HeavyProbeResult
+        # still reports the timeout-ceiling ttft_ms for caller
+        # introspection (logs, telemetry, debugging), but no sample
+        # enters the warmth dataset.
         recorded_ttft = ttft_ms if ok else int(_probe_timeout_s() * 1000)
-        try:
-            self._feed_observer(
-                model_id=model_id, ttft_ms=recorded_ttft,
-                explicit_observer=observer,
-            )
-        except Exception:  # noqa: BLE001 — defensive
-            pass
-
         return HeavyProbeResult(
             model_id=model_id,
             success=ok,

--- a/backend/core/ouroboros/governance/dw_ttft_observer.py
+++ b/backend/core/ouroboros/governance/dw_ttft_observer.py
@@ -143,6 +143,36 @@ def _rel_sem_threshold() -> float:
         return 0.05
 
 
+def _promotion_ceiling_ms() -> int:
+    """``JARVIS_TOPOLOGY_TTFT_PROMOTION_CEILING_MS`` (default 5000).
+
+    Phase 12.2 Slice G — Absolute Ceiling Gate. A model whose mean
+    TTFT exceeds this ceiling is **functionally dead** regardless of
+    how tight its variance is. Mathematical stability (low CV, low
+    rel_SEM) is necessary but NOT sufficient for promotion — the
+    mean itself must indicate the model is actually responsive.
+
+    Operator directive 2026-04-28: a model returning uniform 30-second
+    timeouts has CV=0 and rel_SEM=0, which would pass the variance
+    gates trivially, but it is not warm — it is dead. The absolute
+    ceiling fires BEFORE variance math to reject this class of false
+    positive.
+
+    5000ms default chosen to be generous: a typical warm-VRAM DW model
+    returns first chunk in <500ms; a model loading from cold NVMe can
+    take 2-3s; anything above 5s is so far outside the warm distribution
+    that promotion would be a routing error. Operators can tune via
+    env if their endpoint has different latency characteristics."""
+    try:
+        return max(1, int(
+            os.environ.get(
+                "JARVIS_TOPOLOGY_TTFT_PROMOTION_CEILING_MS", "5000",
+            ).strip()
+        ))
+    except (ValueError, TypeError):
+        return 5000
+
+
 def _cold_sigma() -> float:
     """``JARVIS_TOPOLOGY_TTFT_COLD_SIGMA`` (default 2.0).
 
@@ -478,7 +508,16 @@ class TtftObserver:
         """True iff ``model_id`` has demonstrated TTFT consistency
         sufficient for graduation from SPECULATIVE to BACKGROUND.
 
-        Two gates, both must hold:
+        Three gates, all must hold:
+
+          * **Absolute ceiling gate** (Phase 12.2 Slice G): mean_ms <
+            promotion_ceiling_ms. A model whose mean TTFT exceeds the
+            ceiling is functionally dead — uniform 30-second timeouts
+            have CV=0 (trivially "consistent") but are not warm. The
+            ceiling rejects this class of false positive BEFORE any
+            variance math runs. Mathematical stability is necessary
+            but NOT sufficient — the mean itself must indicate the
+            model is actually responsive.
 
           * **Coefficient of variation gate**: CV < cv_threshold.
             The model's TTFT noise (1σ) is bounded relative to its
@@ -490,10 +529,11 @@ class TtftObserver:
             trustworthy. Mathematically equivalent to:
               N > (CV / sem_threshold)^2
 
-        Together they encode: "the mean is stable AND the model is
-        consistent." NO hardcoded count required — the math derives N
-        dynamically from observed CV. A consistent model graduates
-        with few samples; a noisy model needs more.
+        Together they encode: "the mean is stable AND below the
+        responsiveness ceiling AND the model is consistent." NO
+        hardcoded count required — the math derives N dynamically
+        from observed CV. A consistent model graduates with few
+        samples; a noisy model needs more.
 
         NEVER raises."""
         if not tracking_enabled():
@@ -502,6 +542,12 @@ class TtftObserver:
         if s is None:
             return False
         if s.mean_ms <= 0 or s.n < 2:
+            return False
+        # Slice G — Absolute Ceiling Gate (operator directive 2026-04-28).
+        # Fires BEFORE variance math so a uniform-timeout false positive
+        # cannot pass through the CV gate. Critical: a model returning
+        # 30s timeouts has CV=0 but is not warm — it is dead.
+        if s.mean_ms >= _promotion_ceiling_ms():
             return False
         return s.cv < _cv_threshold() and s.rel_sem < _rel_sem_threshold()
 

--- a/tests/governance/test_dw_heavy_probe.py
+++ b/tests/governance/test_dw_heavy_probe.py
@@ -313,8 +313,14 @@ async def test_prober_success_records_into_observer(
 async def test_prober_failure_records_ceiling_ttft(
     isolated_budget: HeavyProbeBudget, heavy_probe_on, monkeypatch,
 ) -> None:
-    """A 500 response → prober records the timeout ceiling as TTFT
-    (asymmetric cold-storage signal)."""
+    """Phase 12.2 Slice G — Failure Ignorance.
+
+    A 500 response (or transport error / empty stream) is a NETWORK
+    FAILURE, not a TTFT measurement. The observer MUST NOT receive a
+    sample for failed probes — the rolling stats would be poisoned by
+    uniform-timeout false positives. The HeavyProbeResult still
+    reports the timeout ceiling for caller introspection (logs,
+    debugging) but no sample enters the warmth dataset."""
     monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_TIMEOUT_S", "5")
     fake_session = _SessionWith(status=500, chunks=())
     fake_obs = MagicMock()
@@ -328,10 +334,10 @@ async def test_prober_failure_records_ceiling_ttft(
     )
     assert result.success is False
     assert "status_500" in result.error
-    fake_obs.record_ttft.assert_called_once()
-    args, _ = fake_obs.record_ttft.call_args
-    # Ceiling = timeout_ms (5000)
-    assert args[1] == 5000
+    # Slice G: observer NOT called on failure (failure ignorance)
+    fake_obs.record_ttft.assert_not_called()
+    # But the result still reports the ceiling for introspection
+    assert result.ttft_ms == 5000
 
 
 @pytest.mark.asyncio

--- a/tests/governance/test_dw_ttft_slice_g.py
+++ b/tests/governance/test_dw_ttft_slice_g.py
@@ -1,0 +1,431 @@
+"""Phase 12.2 Slice G — Absolute Ceiling Gate + Failure Ignorance.
+
+Closes the zero-order flaw discovered during the once-proof of
+``bt-2026-04-28-201119``: a model returning uniform 30-second
+timeouts has CV=0 and rel_SEM=0 (trivially "consistent") which
+would pass the variance gates and falsely promote a functionally
+dead model.
+
+Two surfaces:
+
+  1. ``TtftObserver.is_promotion_ready`` — adds an absolute mean_ms
+     ceiling check BEFORE the variance math. Rejects models whose
+     mean is above ``JARVIS_TOPOLOGY_TTFT_PROMOTION_CEILING_MS``
+     (default 5000ms).
+
+  2. ``HeavyProber.probe`` — failure ignorance. ConnectionTimeoutError
+     and other transport failures are NOT recorded into the observer.
+     The HeavyProbeResult still reports the ceiling for introspection,
+     but no sample poisons the warmth dataset.
+
+Pins:
+  §1  promotion_ceiling_ms env reader — default 5000ms, case-tolerant
+  §2  Ceiling gate fires on mean_ms == ceiling
+  §3  Ceiling gate fires on mean_ms > ceiling
+  §4  Ceiling gate uniform-timeout false positive REJECTED (the bug)
+  §5  Ceiling gate composes with CV gate (both must pass)
+  §6  Ceiling gate composes with rel_SEM gate (both must pass)
+  §7  Ceiling gate respects env override (operator can lower)
+  §8  Heavy probe failure ignorance — 500 response → no observer call
+  §9  Heavy probe failure ignorance — transport error → no observer call
+  §10 Heavy probe failure ignorance — empty stream → no observer call
+  §11 Heavy probe success ignorance preserved — real chunk → observer recorded
+  §12 Result still reports ceiling for caller introspection (telemetry)
+  §13 Source-level pin: ceiling check fires BEFORE variance math
+"""
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_heavy_probe import (
+    HeavyProbeBudget, HeavyProber,
+)
+from backend.core.ouroboros.governance.dw_ttft_observer import (
+    TtftObserver, _promotion_ceiling_ms,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_observer(tmp_path, monkeypatch) -> TtftObserver:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_TTFT_STATE_PATH",
+        str(tmp_path / "ttft.json"),
+    )
+    monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED", "true")
+    obs = TtftObserver()
+    obs.load()
+    return obs
+
+
+@pytest.fixture
+def isolated_budget(tmp_path, monkeypatch) -> HeavyProbeBudget:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_HEAVY_PROBE_BUDGET_PATH",
+        str(tmp_path / "budget.json"),
+    )
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED", "true")
+    bud = HeavyProbeBudget()
+    bud.load()
+    return bud
+
+
+# ---------------------------------------------------------------------------
+# §1 — promotion_ceiling_ms env reader
+# ---------------------------------------------------------------------------
+
+
+def test_promotion_ceiling_default(monkeypatch) -> None:
+    monkeypatch.delenv(
+        "JARVIS_TOPOLOGY_TTFT_PROMOTION_CEILING_MS", raising=False,
+    )
+    assert _promotion_ceiling_ms() == 5000
+
+
+@pytest.mark.parametrize("val,expected", [
+    ("3000", 3000), ("10000", 10000), ("100", 100),
+])
+def test_promotion_ceiling_env_override(monkeypatch, val, expected) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_PROMOTION_CEILING_MS", val)
+    assert _promotion_ceiling_ms() == expected
+
+
+@pytest.mark.parametrize("val", ["garbage", "", "  "])
+def test_promotion_ceiling_invalid_falls_back_to_default(
+    monkeypatch, val,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_PROMOTION_CEILING_MS", val)
+    assert _promotion_ceiling_ms() == 5000
+
+
+# ---------------------------------------------------------------------------
+# §2-§4 — The bug we're fixing: uniform-timeout false positive
+# ---------------------------------------------------------------------------
+
+
+def test_ceiling_rejects_uniform_30s_timeouts(
+    isolated_observer: TtftObserver,
+) -> None:
+    """THE BUG: a model returning uniform 30-second timeouts has
+    CV=0, rel_SEM=0, both pass variance gates trivially. Slice G
+    rejects this via the absolute ceiling. Empirical evidence from
+    bt-2026-04-28-201119: DeepSeek-OCR-2 had two 30000ms samples
+    after Slice D's ceiling-on-failure (now removed)."""
+    for _ in range(3):
+        isolated_observer.record_ttft("vendor/dead-model", 30000)
+    s = isolated_observer.stats("vendor/dead-model")
+    assert s is not None
+    assert s.mean_ms == 30000
+    assert s.cv == 0.0  # uniform → zero variance
+    assert s.rel_sem == 0.0
+    # Without ceiling: CV<0.15 ✓ AND rel_SEM<0.05 ✓ → would WRONGLY return True
+    # With ceiling: 30000 > 5000 → returns False (correctly rejects)
+    assert isolated_observer.is_promotion_ready("vendor/dead-model") is False
+
+
+def test_ceiling_rejects_mean_at_ceiling(
+    isolated_observer: TtftObserver,
+) -> None:
+    """Edge case: mean_ms == ceiling. The ``>=`` comparison rejects
+    this (boundary-inclusive on the rejection side — defensive)."""
+    for _ in range(3):
+        isolated_observer.record_ttft("vendor/at-ceiling", 5000)
+    assert isolated_observer.is_promotion_ready("vendor/at-ceiling") is False
+
+
+def test_ceiling_rejects_mean_above_ceiling(
+    isolated_observer: TtftObserver,
+) -> None:
+    """mean_ms > ceiling → rejected even with perfect consistency."""
+    for ms in (5500, 5500, 5500):
+        isolated_observer.record_ttft("vendor/slow", ms)
+    assert isolated_observer.is_promotion_ready("vendor/slow") is False
+
+
+def test_ceiling_admits_mean_below_ceiling(
+    isolated_observer: TtftObserver,
+) -> None:
+    """A genuinely fast + consistent model passes all three gates."""
+    for ms in (100, 102, 99, 101, 100):
+        isolated_observer.record_ttft("vendor/fast-warm", ms)
+    s = isolated_observer.stats("vendor/fast-warm")
+    assert s is not None
+    assert s.mean_ms < 5000
+    assert s.cv < 0.15
+    assert s.rel_sem < 0.05
+    assert isolated_observer.is_promotion_ready("vendor/fast-warm") is True
+
+
+# ---------------------------------------------------------------------------
+# §5-§6 — Composition with existing gates
+# ---------------------------------------------------------------------------
+
+
+def test_ceiling_composes_with_cv_gate(
+    isolated_observer: TtftObserver,
+) -> None:
+    """A model below ceiling but with high CV still rejected."""
+    for ms in (400, 1200, 600, 1800, 800):  # mean ~960, high variance
+        isolated_observer.record_ttft("vendor/noisy-fast", ms)
+    s = isolated_observer.stats("vendor/noisy-fast")
+    assert s is not None
+    assert s.mean_ms < 5000  # passes ceiling
+    assert s.cv > 0.15  # fails CV gate
+    assert isolated_observer.is_promotion_ready("vendor/noisy-fast") is False
+
+
+def test_ceiling_composes_with_rel_sem_gate(
+    isolated_observer: TtftObserver,
+    monkeypatch,
+) -> None:
+    """A model below ceiling + low CV but too few samples still rejected.
+    rel_SEM = CV / sqrt(N), so small N fails the gate."""
+    # 2 samples, low CV but rel_SEM = CV / sqrt(2) might exceed threshold
+    monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_REL_SEM_THRESHOLD", "0.001")
+    for ms in (100, 110):
+        isolated_observer.record_ttft("vendor/tight-N2", ms)
+    s = isolated_observer.stats("vendor/tight-N2")
+    assert s is not None
+    assert s.mean_ms < 5000  # passes ceiling
+    assert s.cv < 0.15      # passes CV
+    # rel_SEM with the tightened threshold must fail
+    assert isolated_observer.is_promotion_ready("vendor/tight-N2") is False
+
+
+# ---------------------------------------------------------------------------
+# §7 — Operator override
+# ---------------------------------------------------------------------------
+
+
+def test_ceiling_respects_env_override_lower(
+    isolated_observer: TtftObserver, monkeypatch,
+) -> None:
+    """Operator can lower the ceiling for stricter promotion gating
+    (e.g., for latency-sensitive deployments)."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_PROMOTION_CEILING_MS", "200")
+    for ms in (300, 305, 295):
+        isolated_observer.record_ttft("vendor/borderline", ms)
+    # Default ceiling 5000 → would promote
+    # Lowered ceiling 200 → mean (≈300) > 200 → reject
+    assert isolated_observer.is_promotion_ready("vendor/borderline") is False
+
+
+def test_ceiling_respects_env_override_higher(
+    isolated_observer: TtftObserver, monkeypatch,
+) -> None:
+    """Operator can raise the ceiling for endpoints that legitimately
+    have high baseline latency (rare but legal)."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_TTFT_PROMOTION_CEILING_MS", "10000")
+    for ms in (8000, 8100, 7900, 8050):
+        isolated_observer.record_ttft("vendor/slow-but-stable", ms)
+    s = isolated_observer.stats("vendor/slow-but-stable")
+    assert s is not None
+    assert s.mean_ms < 10000  # under raised ceiling
+    assert s.cv < 0.15
+    assert isolated_observer.is_promotion_ready(
+        "vendor/slow-but-stable",
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# §8-§10 — Heavy probe failure ignorance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failure_500_does_not_feed_observer(
+    isolated_budget: HeavyProbeBudget,
+) -> None:
+    """A 500 response is a server error, not a TTFT measurement."""
+    fake_session = _SessionWith(status=500, chunks=())
+    fake_obs = MagicMock()
+    prober = HeavyProber(budget=isolated_budget)
+    result = await prober.probe(
+        session=fake_session, model_id="vendor/m-7B",
+        base_url="https://test.example", api_key="key",
+        observer=fake_obs,
+    )
+    assert result.success is False
+    fake_obs.record_ttft.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_failure_transport_does_not_feed_observer(
+    isolated_budget: HeavyProbeBudget,
+) -> None:
+    """A transport-class error (connection reset, timeout) is a network
+    failure, not a TTFT measurement. Observer MUST NOT receive a
+    sample — would poison the rolling stats with the 30s ceiling
+    pattern that triggered Slice G."""
+    fake_session = _SessionRaises(_ConnectionResetError())
+    fake_obs = MagicMock()
+    prober = HeavyProber(budget=isolated_budget)
+    result = await prober.probe(
+        session=fake_session, model_id="vendor/m-7B",
+        base_url="https://test.example", api_key="key",
+        observer=fake_obs,
+    )
+    assert result.success is False
+    fake_obs.record_ttft.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_failure_empty_stream_does_not_feed_observer(
+    isolated_budget: HeavyProbeBudget,
+) -> None:
+    """[DONE] arriving before any content chunk = empty stream.
+    Server responded but didn't emit content. NOT a TTFT measurement."""
+    fake_session = _SessionWith(
+        chunks=(b"data: [DONE]\n",),
+    )
+    fake_obs = MagicMock()
+    prober = HeavyProber(budget=isolated_budget)
+    result = await prober.probe(
+        session=fake_session, model_id="vendor/m-7B",
+        base_url="https://test.example", api_key="key",
+        observer=fake_obs,
+    )
+    assert result.success is False
+    fake_obs.record_ttft.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# §11-§12 — Success path preserved + result introspection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_still_feeds_observer(
+    isolated_budget: HeavyProbeBudget,
+) -> None:
+    """Slice G changes failure semantics; success path still records
+    the real TTFT. Pin the success path is preserved."""
+    fake_session = _SessionWith(
+        chunks=(b"data: {\"choices\":[{\"delta\":{\"content\":\"H\"}}]}\n",),
+    )
+    fake_obs = MagicMock()
+    prober = HeavyProber(budget=isolated_budget)
+    result = await prober.probe(
+        session=fake_session, model_id="vendor/m-7B",
+        base_url="https://test.example", api_key="key",
+        observer=fake_obs,
+    )
+    assert result.success is True
+    fake_obs.record_ttft.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_failure_result_still_reports_ceiling_ttft(
+    isolated_budget: HeavyProbeBudget, monkeypatch,
+) -> None:
+    """The result.ttft_ms field still reports the timeout ceiling on
+    failure for caller introspection (logs, telemetry, dashboards).
+    Only the OBSERVER feed is suppressed; the RESULT is for human-
+    readable diagnostics."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_HEAVY_PROBE_TIMEOUT_S", "8")
+    fake_session = _SessionWith(status=503, chunks=())
+    prober = HeavyProber(budget=isolated_budget)
+    result = await prober.probe(
+        session=fake_session, model_id="vendor/m-7B",
+        base_url="https://test.example", api_key="key",
+    )
+    assert result.success is False
+    assert result.ttft_ms == 8000  # ceiling for caller introspection
+
+
+# ---------------------------------------------------------------------------
+# §13 — Source-level pin: ceiling check ordering
+# ---------------------------------------------------------------------------
+
+
+def test_ceiling_check_fires_before_variance_math() -> None:
+    """Source-level pin: the ceiling check MUST fire BEFORE the CV/
+    rel_SEM math. Otherwise the variance gates would short-circuit
+    the path and never reach the ceiling. Pin source ordering so a
+    refactor can't accidentally invert the gates."""
+    src = inspect.getsource(TtftObserver.is_promotion_ready)
+    ceiling_idx = src.index("_promotion_ceiling_ms()")
+    cv_idx = src.index("_cv_threshold()")
+    sem_idx = src.index("_rel_sem_threshold()")
+    assert ceiling_idx < cv_idx, (
+        "Slice G: ceiling check must fire BEFORE CV gate"
+    )
+    assert ceiling_idx < sem_idx, (
+        "Slice G: ceiling check must fire BEFORE rel_SEM gate"
+    )
+
+
+def test_ceiling_check_documented_in_docstring() -> None:
+    """The is_promotion_ready docstring documents the three-gate
+    composition (ceiling + CV + rel_SEM) so future readers don't
+    re-introduce the uniform-timeout false positive."""
+    doc = TtftObserver.is_promotion_ready.__doc__
+    assert doc is not None
+    assert "Absolute ceiling" in doc or "ceiling" in doc.lower()
+    assert "Slice G" in doc or "promotion_ceiling" in doc
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror those in test_dw_heavy_probe.py)
+# ---------------------------------------------------------------------------
+
+
+class _SessionWith:
+    def __init__(self, *, status: int = 200, chunks=()) -> None:
+        self._status = status
+        self._chunks = list(chunks) + [b""]
+
+    def post(self, *a, **kw):
+        return _RespCM(self._status, self._chunks)
+
+
+class _SessionRaises:
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def post(self, *a, **kw):
+        raise self._exc
+
+
+class _ConnectionResetError(OSError):
+    def __init__(self) -> None:
+        super().__init__(54, "Connection reset by peer")
+
+
+class _RespCM:
+    def __init__(self, status, chunks):
+        self._status = status
+        self._chunks = chunks
+
+    async def __aenter__(self):
+        return _Resp(self._status, self._chunks)
+
+    async def __aexit__(self, *a):
+        return None
+
+
+class _Resp:
+    def __init__(self, status, chunks):
+        self.status = status
+        self.content = _Content(chunks)
+
+    async def text(self) -> str:
+        return f"HTTP {self.status}"
+
+
+class _Content:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def readline(self) -> bytes:
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)


### PR DESCRIPTION
## Summary

Closes the zero-order flaw discovered during the live once-proof of `bt-2026-04-28-201119`: a model returning uniform 30-second timeouts has CV=0 and rel_SEM=0 (trivially "consistent") which would pass the variance gates trivially and falsely promote a **functionally dead** model.

### Two surfaces, one root fix

**1. `TtftObserver.is_promotion_ready` — Absolute Ceiling Gate**

```python
# Slice G — fires BEFORE variance math
if s.mean_ms >= _promotion_ceiling_ms():
    return False
return s.cv < _cv_threshold() and s.rel_sem < _rel_sem_threshold()
```

Default ceiling: **5000ms** (env `JARVIS_TOPOLOGY_TTFT_PROMOTION_CEILING_MS`). A model averaging 30-second timeouts instantly returns False regardless of variance tightness. Source-level ordering pin ensures the ceiling check fires BEFORE CV / rel_SEM math.

**2. `HeavyProber.probe` — Failure Ignorance**

Removes the asymmetric ceiling-on-failure pattern from initial Slice D:

| Outcome | Observer fed? | Result.ttft_ms |
|---|---|---|
| Success (real chunk) | ✅ real TTFT | real TTFT |
| Failure (500/transport/empty) | ❌ NOT fed | ceiling (introspection only) |

ConnectionTimeoutError, transport errors, empty-stream cases are **network failures, not TTFT measurements**. Feeding them poisoned rolling stats with the uniform-30s pattern that triggered Slice G. Cold-storage detection for "endpoint dead" cases now falls to the modality ledger / terminal breaker where it belongs.

### Empirical motivation

`bt-2026-04-28-201119` produced this state file:

```json
{
  "samples": {
    "deepseek-ai/DeepSeek-OCR-2": [
      {"ttft_ms": 30000, ...}, {"ttft_ms": 30000, ...}
    ],
    "deepseek-ai/DeepSeek-V4-Flash": [
      {"ttft_ms": 30000, ...}
    ]
  }
}
```

Without Slice G, two such samples mathematically pass: CV=0/30000=0 ✓, rel_SEM=0 ✓ → **promotion ready = True for a dead model**. Slice G rejects this via the absolute ceiling.

## Test plan

- [x] 22 new tests in `test_dw_ttft_slice_g.py` covering 13 pin sections:
  - Env reader (default + override + invalid)
  - Ceiling boundary cases (==, >, <)
  - The bug we're fixing: uniform-30s false positive
  - Composition with CV gate (high variance still rejected)
  - Composition with rel_SEM gate (small N still rejected)
  - Operator override (lower for strict, higher for high-baseline)
  - Heavy probe failure ignorance (500, transport, empty stream)
  - Success path preserved
  - Result introspection still reports ceiling on failure
  - Source-level pin: ceiling check fires BEFORE variance math
  - Docstring documents three-gate composition
- [x] `test_dw_heavy_probe.py::test_prober_failure_records_ceiling_ttft` inverted to assert observer is NOT called on failure (new Slice G contract)
- [x] **433/433 green** across full Phase 12 + 12.2 regression suite

## Notes

- The asymmetric ceiling-on-failure pattern in Slice D was rejected by the operator after live evidence demonstrated it poisons the warmth dataset. Cold-storage detection for "consistently dead" models now flows through:
  - **Modality ledger** (Slice G of Phase 12) — when DW returns 4xx with modality marker
  - **Terminal breaker** (Slice H of Phase 12) — when DW returns persistent auth/404 failures
- This restructuring is consistent with the Phase 12 zero-trust doctrine: each signal layer owns its own kind of evidence, no double-counting across layers.
- After this merge, Phase 12.2 closure note will be written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an absolute TTFT ceiling and ignore failed probe samples to prevent promoting dead models. This blocks uniform 30s timeouts from passing variance gates and keeps warmth stats clean.

- **Bug Fixes**
  - TtftObserver: reject promotion when mean_ms >= `JARVIS_TOPOLOGY_TTFT_PROMOTION_CEILING_MS` (default 5000ms), checked before CV/rel_SEM.
  - HeavyProber: on 500s, transport errors, or empty streams, do not feed the observer; still return timeout-ceiling ttft_ms for introspection.
  - Tests: added coverage for ceiling, failure ignorance, env overrides, and ordering; updated the prober failure test to assert the observer is not called.

<sup>Written for commit 0f90dd546fdd87c6c01e19a97796fbf5fcace0ac. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/28964?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

