### PR TITLE
feat(phase1): Slice 1.3 — Phase capture wiring (ROUTE) + Antigravity bundled ConvergenceGovernor

### DIFF
--- a/backend/core/ouroboros/governance/adaptation/convergence_governor.py
+++ b/backend/core/ouroboros/governance/adaptation/convergence_governor.py
@@ -1,0 +1,445 @@
+"""Slice 3.2 — ConvergenceGovernor: formal halting layer.
+
+Per ``OUROBOROS_VENOM_PRD.md`` §24.10.3 (Priority 3):
+
+  > Formal termination is the difference between "could improve
+  > forever" (good) and "will hang forever on the wrong input"
+  > (catastrophic).
+
+The ConvergenceGovernor sits between ``CuriosityScheduler`` and
+``CuriosityEngine``. It tracks per-hypothesis ``BeliefState`` across
+cycles and enforces four halting conditions — at least one MUST fire
+for every hypothesis.
+
+## Halting conditions (all mathematically derived)
+
+  1. **Convergence**: H(posterior) < ε where ε derives from prior
+  2. **Budget**: cost_spent ≥ budget_per_hypothesis
+  3. **Max probes**: observations ≥ O(log₂(1/ε))
+  4. **Diminishing returns**: |entropy_delta| < threshold for N
+     consecutive observations
+
+## Integration contract
+
+  CuriosityScheduler.tick()
+    → ConvergenceGovernor.should_explore(hypothesis_id)
+    → CuriosityEngine.run_cycle(filtered)
+      → HypothesisProbe.test()
+      → ConvergenceGovernor.record_observation(hypothesis_id, verdict, cost)
+        → Bayesian update → ConvergenceProof if halted
+
+## Cooling schedule
+
+  ``global_cooling_factor()`` returns the mean cooling factor across
+  all active (non-converged) hypotheses. CuriosityScheduler reads
+  this to modulate its fire rate. As hypotheses converge →
+  cooling_factor → 0 → scheduler self-quiets.
+
+## Cage rules (load-bearing)
+
+  * Imports only: ``exploration_calculus``, ``_file_lock``.
+  * **NEVER raises** into the caller.
+  * **Master flag**: ``JARVIS_CONVERGENCE_GOVERNOR_ENABLED``
+    (default false).
+  * JSONL persistence at ``.jarvis/convergence_state.jsonl``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+    BeliefState,
+    ConvergenceProof,
+    STATE_CONVERGED,
+    cooling_factor,
+    epsilon_from_prior,
+    initial_belief,
+    make_convergence_proof,
+    max_probes_for_epsilon,
+    parse_belief_state,
+    update_belief,
+)
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+# ---------------------------------------------------------------------------
+# Hard caps
+# ---------------------------------------------------------------------------
+
+MAX_TRACKED_HYPOTHESES: int = 200
+MAX_STATE_FILE_BYTES: int = 4 * 1024 * 1024
+MAX_PROOFS_RETAINED: int = 500
+
+# ---------------------------------------------------------------------------
+# Master flag + configuration
+# ---------------------------------------------------------------------------
+
+
+def is_governor_enabled() -> bool:
+    """Master flag — ``JARVIS_CONVERGENCE_GOVERNOR_ENABLED``."""
+    return os.environ.get(
+        "JARVIS_CONVERGENCE_GOVERNOR_ENABLED", "",
+    ).strip().lower() in _TRUTHY
+
+
+def _state_path() -> Path:
+    raw = os.environ.get("JARVIS_CONVERGENCE_GOVERNOR_PATH")
+    if raw:
+        return Path(raw)
+    return Path(".jarvis") / "convergence_state.jsonl"
+
+
+def _proofs_path() -> Path:
+    raw = os.environ.get("JARVIS_CONVERGENCE_PROOFS_PATH")
+    if raw:
+        return Path(raw)
+    return Path(".jarvis") / "convergence_proofs.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# ConvergenceGovernor
+# ---------------------------------------------------------------------------
+
+
+class ConvergenceGovernor:
+    """Per-hypothesis convergence tracker with formal halting proofs.
+
+    Maintains a ``BeliefState`` for each tracked hypothesis. Exposes
+    advisory signals (``should_explore``, ``global_cooling_factor``)
+    that CuriosityScheduler consults. Emits ``ConvergenceProof``
+    records when hypotheses halt.
+
+    Thread-safety: not thread-safe. Designed for tick-driven
+    orchestrator loop (single-threaded heartbeat), consistent with
+    Phase 2 modules.
+    """
+
+    def __init__(
+        self,
+        state_path: Optional[Path] = None,
+        proofs_path: Optional[Path] = None,
+    ) -> None:
+        self._state_path = state_path or _state_path()
+        self._proofs_path = proofs_path or _proofs_path()
+        self._beliefs: Dict[str, BeliefState] = {}
+        self._proofs: List[ConvergenceProof] = []
+        self._loaded = False
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        self._loaded = True
+        self._load_beliefs()
+        self._load_proofs()
+
+    def _load_beliefs(self) -> None:
+        if not self._state_path.exists():
+            return
+        try:
+            size = self._state_path.stat().st_size
+            if size > MAX_STATE_FILE_BYTES:
+                logger.warning(
+                    "[ConvergenceGovernor] state file too large (%d bytes) "
+                    "— starting empty", size,
+                )
+                return
+            text = self._state_path.read_text(encoding="utf-8")
+        except OSError:
+            return
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict):
+                continue
+            bs = parse_belief_state(obj)
+            if bs and bs.hypothesis_id:
+                self._beliefs[bs.hypothesis_id] = bs
+                if len(self._beliefs) >= MAX_TRACKED_HYPOTHESES:
+                    break
+
+    def _load_proofs(self) -> None:
+        if not self._proofs_path.exists():
+            return
+        try:
+            text = self._proofs_path.read_text(encoding="utf-8")
+        except OSError:
+            return
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict):
+                continue
+            try:
+                proof = ConvergenceProof(
+                    hypothesis_id=str(obj.get("hypothesis_id", "")),
+                    halted=bool(obj.get("halted", False)),
+                    halt_reason=str(obj.get("halt_reason", "")),
+                    probes_used=int(obj.get("probes_used", 0)),
+                    theoretical_max_probes=int(
+                        obj.get("theoretical_max_probes", 0)),
+                    cost_spent=float(obj.get("cost_spent", 0.0)),
+                    final_belief=float(obj.get("final_belief", 0.0)),
+                    final_entropy=float(obj.get("final_entropy", 0.0)),
+                    epsilon=float(obj.get("epsilon", 0.0)),
+                    ts_unix=float(obj.get("ts_unix", 0.0)),
+                )
+                self._proofs.append(proof)
+            except (TypeError, ValueError):
+                continue
+            if len(self._proofs) >= MAX_PROOFS_RETAINED:
+                break
+
+    def _persist_beliefs(self) -> Tuple[bool, str]:
+        try:
+            self._state_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._state_path.open("w", encoding="utf-8") as f:
+                for bs in self._beliefs.values():
+                    line = json.dumps(bs.to_dict(), separators=(",", ":"))
+                    f.write(line + "\n")
+                f.flush()
+                try:
+                    os.fsync(f.fileno())
+                except OSError:
+                    pass
+        except OSError as exc:
+            return (False, f"persist_beliefs_failed:{exc}")
+        return (True, "ok")
+
+    def _persist_proof(self, proof: ConvergenceProof) -> Tuple[bool, str]:
+        try:
+            self._proofs_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._proofs_path.open("a", encoding="utf-8") as f:
+                line = json.dumps(proof.to_dict(), separators=(",", ":"))
+                f.write(line + "\n")
+                f.flush()
+        except OSError as exc:
+            return (False, f"persist_proof_failed:{exc}")
+        return (True, "ok")
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+
+    def track_hypothesis(
+        self,
+        hypothesis_id: str,
+        prior: float = 0.5,
+        now_unix: Optional[float] = None,
+    ) -> BeliefState:
+        """Begin tracking a new hypothesis. NEVER raises."""
+        self._ensure_loaded()
+        ts = now_unix or time.time()
+        if hypothesis_id in self._beliefs:
+            return self._beliefs[hypothesis_id]
+        if len(self._beliefs) >= MAX_TRACKED_HYPOTHESES:
+            # Evict the oldest converged hypothesis.
+            self._evict_oldest_converged()
+        bs = initial_belief(hypothesis_id, prior=prior, now_unix=ts)
+        self._beliefs[hypothesis_id] = bs
+        self._persist_beliefs()
+        return bs
+
+    def _evict_oldest_converged(self) -> None:
+        """Evict the oldest converged hypothesis to make room."""
+        converged = [
+            (hid, bs) for hid, bs in self._beliefs.items()
+            if bs.convergence_state == STATE_CONVERGED
+        ]
+        if converged:
+            converged.sort(key=lambda x: x[1].ts_unix)
+            del self._beliefs[converged[0][0]]
+        elif self._beliefs:
+            # No converged hypotheses — evict oldest by timestamp.
+            oldest = min(self._beliefs.items(), key=lambda x: x[1].ts_unix)
+            del self._beliefs[oldest[0]]
+
+    def should_explore(self, hypothesis_id: str) -> bool:
+        """True iff this hypothesis should receive another probe.
+
+        Returns False if:
+          - hypothesis not tracked
+          - any halt condition is met
+          - governor is disabled
+
+        NEVER raises.
+        """
+        if not is_governor_enabled():
+            return False
+        self._ensure_loaded()
+        bs = self._beliefs.get(hypothesis_id)
+        if bs is None:
+            return False
+        eps = epsilon_from_prior(bs.prior)
+        return not bs.is_halted(eps)
+
+    def record_observation(
+        self,
+        hypothesis_id: str,
+        verdict: str,
+        cost_usd: float = 0.0,
+        now_unix: Optional[float] = None,
+    ) -> Tuple[BeliefState, Optional[ConvergenceProof]]:
+        """Record a probe observation, update belief, check halting.
+
+        Returns (updated BeliefState, ConvergenceProof if halted).
+        NEVER raises.
+        """
+        self._ensure_loaded()
+        ts = now_unix or time.time()
+        bs = self._beliefs.get(hypothesis_id)
+        if bs is None:
+            # Auto-track with default prior.
+            bs = initial_belief(hypothesis_id, now_unix=ts)
+
+        new_bs = update_belief(
+            bs, verdict=verdict, cost_usd=cost_usd, now_unix=ts,
+        )
+        self._beliefs[hypothesis_id] = new_bs
+
+        eps = epsilon_from_prior(new_bs.prior)
+        proof: Optional[ConvergenceProof] = None
+        if new_bs.is_halted(eps):
+            proof = make_convergence_proof(new_bs, now_unix=ts)
+            self._proofs.append(proof)
+            if len(self._proofs) > MAX_PROOFS_RETAINED:
+                self._proofs = self._proofs[-MAX_PROOFS_RETAINED:]
+            self._persist_proof(proof)
+
+        self._persist_beliefs()
+        return (new_bs, proof)
+
+    # ------------------------------------------------------------------
+    # Cooling schedule
+    # ------------------------------------------------------------------
+
+    def global_cooling_factor(self) -> float:
+        """Mean cooling factor across all active (non-converged)
+        hypotheses.
+
+        Returns 1.0 if no hypotheses are tracked (full curiosity).
+        Returns 0.0 if all hypotheses are converged (no curiosity).
+        Returns the mean entropy-based cooling factor otherwise.
+
+        Used by CuriosityScheduler to modulate fire rate.
+        NEVER raises.
+        """
+        self._ensure_loaded()
+        if not self._beliefs:
+            return 1.0
+        active = [
+            bs for bs in self._beliefs.values()
+            if bs.convergence_state != STATE_CONVERGED
+        ]
+        if not active:
+            return 0.0
+        total = sum(cooling_factor(bs.entropy) for bs in active)
+        return total / len(active)
+
+    # ------------------------------------------------------------------
+    # Query API
+    # ------------------------------------------------------------------
+
+    def get_belief(self, hypothesis_id: str) -> Optional[BeliefState]:
+        """Return the current BeliefState for a hypothesis."""
+        self._ensure_loaded()
+        return self._beliefs.get(hypothesis_id)
+
+    def active_hypotheses(self) -> List[str]:
+        """Hypothesis IDs still open for exploration."""
+        self._ensure_loaded()
+        result = []
+        for hid, bs in self._beliefs.items():
+            eps = epsilon_from_prior(bs.prior)
+            if not bs.is_halted(eps):
+                result.append(hid)
+        return sorted(result)
+
+    def converged_hypotheses(self) -> List[str]:
+        """Hypothesis IDs that have converged."""
+        self._ensure_loaded()
+        return sorted(
+            hid for hid, bs in self._beliefs.items()
+            if bs.convergence_state == STATE_CONVERGED
+        )
+
+    def all_proofs(self) -> Tuple[ConvergenceProof, ...]:
+        """All convergence proofs emitted so far."""
+        self._ensure_loaded()
+        return tuple(self._proofs)
+
+    def stats(self) -> Dict[str, Any]:
+        """Summary statistics for diagnostics."""
+        self._ensure_loaded()
+        active = self.active_hypotheses()
+        converged = self.converged_hypotheses()
+        return {
+            "total_tracked": len(self._beliefs),
+            "active": len(active),
+            "converged": len(converged),
+            "proofs_emitted": len(self._proofs),
+            "global_cooling_factor": round(self.global_cooling_factor(), 4),
+        }
+
+    def reset(self) -> None:
+        """Clear all state. Test-only."""
+        self._beliefs.clear()
+        self._proofs.clear()
+        self._loaded = False
+
+
+# ---------------------------------------------------------------------------
+# Default singleton
+# ---------------------------------------------------------------------------
+
+_DEFAULT_GOVERNOR: Optional[ConvergenceGovernor] = None
+
+
+def get_default_governor(
+    state_path: Optional[Path] = None,
+    proofs_path: Optional[Path] = None,
+) -> ConvergenceGovernor:
+    global _DEFAULT_GOVERNOR
+    if _DEFAULT_GOVERNOR is None:
+        _DEFAULT_GOVERNOR = ConvergenceGovernor(
+            state_path=state_path,
+            proofs_path=proofs_path,
+        )
+    return _DEFAULT_GOVERNOR
+
+
+def reset_default_governor() -> None:
+    global _DEFAULT_GOVERNOR
+    _DEFAULT_GOVERNOR = None
+
+
+__all__ = [
+    "ConvergenceGovernor",
+    "MAX_PROOFS_RETAINED",
+    "MAX_STATE_FILE_BYTES",
+    "MAX_TRACKED_HYPOTHESES",
+    "get_default_governor",
+    "is_governor_enabled",
+    "reset_default_governor",
+]

--- a/backend/core/ouroboros/governance/adaptation/exploration_calculus.py
+++ b/backend/core/ouroboros/governance/adaptation/exploration_calculus.py
@@ -1,0 +1,607 @@
+"""Slice 3.1 — ExplorationCalculus: Bayesian belief engine.
+
+Per ``OUROBOROS_VENOM_PRD.md`` §24.10.3 (Priority 3):
+
+  > Every exploration state has a measurable ``epistemic_uncertainty``
+  > (entropy of belief). Each probe produces an observation that
+  > updates belief via Bayesian update. Termination proof: at any
+  > cost cap C, exploration MUST halt within ``O(log(1/ε))`` probes.
+
+This module ships the **pure-function mathematical core** that gives
+every hypothesis a measurable epistemic state and proves convergence.
+
+## Mathematical foundations
+
+### Bayesian update
+
+  P(H|E) = P(E|H) · P(H) / [P(E|H) · P(H) + P(E|¬H) · (1-P(H))]
+
+  likelihood_ratio = P(E|H) / P(E|¬H)
+
+### Shannon entropy (Bernoulli)
+
+  H(p) = −p·log₂(p) − (1−p)·log₂(1−p)
+
+  Maximum at p=0.5 (H=1.0 bit). Zero at p=0 or p=1.
+
+### Convergence criterion
+
+  Converged when H(posterior) < ε, where ε derives from the prior:
+    ε = H(prior) × convergence_ratio    (env-tunable, default 0.1)
+
+### Theoretical max probes
+
+  O(log₂(1/ε)) — each probe halves the entropy in the worst case
+  (adversarial alternation). This derives the upper bound on probe
+  count for any hypothesis.
+
+### Cooling schedule
+
+  cooling_factor = H(posterior) / 1.0    (normalized to [0,1])
+  As belief converges → cooling_factor → 0 → scheduler self-quiets.
+
+## Generalization of TtftObserver
+
+TtftObserver (Phase 12.2 Slice B) encodes: ``N > (CV / threshold)²``
+— math derives the required sample count. We generalize from "model
+TTFT consistency" to "epistemic belief convergence" — same structural
+pattern (bounds derived, not hardcoded), different domain.
+
+## Cage rules (load-bearing)
+
+  * **Stdlib-only** (``math``, ``json``, ``hashlib``, ``logging``).
+  * **Pure functions** — no side effects, no I/O. Callers persist.
+  * **NEVER raises** — invalid inputs → safe defaults.
+  * **Master flag**: ``JARVIS_EXPLORATION_CALCULUS_ENABLED`` (default false).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+# ---------------------------------------------------------------------------
+# Hard caps
+# ---------------------------------------------------------------------------
+
+MAX_OBSERVATIONS: int = 200
+MAX_BELIEF_STATES: int = 500
+MIN_PRIOR: float = 0.001
+MAX_PRIOR: float = 0.999
+MIN_LIKELIHOOD_RATIO: float = 0.01
+MAX_LIKELIHOOD_RATIO: float = 100.0
+
+# ---------------------------------------------------------------------------
+# Master flag + configuration
+# ---------------------------------------------------------------------------
+
+
+def is_calculus_enabled() -> bool:
+    """Master flag — ``JARVIS_EXPLORATION_CALCULUS_ENABLED``."""
+    return os.environ.get(
+        "JARVIS_EXPLORATION_CALCULUS_ENABLED", "",
+    ).strip().lower() in _TRUTHY
+
+
+def _convergence_ratio() -> float:
+    """``JARVIS_EXPLORATION_CONVERGENCE_RATIO`` (default 0.1).
+
+    ε = H(prior) × convergence_ratio. Tighter ratio → more probes
+    needed for convergence, but higher confidence in the final belief.
+    """
+    try:
+        v = float(os.environ.get(
+            "JARVIS_EXPLORATION_CONVERGENCE_RATIO", "0.1",
+        ).strip())
+        return max(0.01, min(0.99, v))
+    except (ValueError, TypeError):
+        return 0.1
+
+
+def _confirmed_lr() -> float:
+    """Likelihood ratio for CONFIRMED evidence (default 3.0)."""
+    try:
+        v = float(os.environ.get(
+            "JARVIS_EXPLORATION_CONFIRMED_LR", "3.0",
+        ).strip())
+        return max(MIN_LIKELIHOOD_RATIO, min(MAX_LIKELIHOOD_RATIO, v))
+    except (ValueError, TypeError):
+        return 3.0
+
+
+def _refuted_lr() -> float:
+    """Likelihood ratio for REFUTED evidence (default 0.33)."""
+    try:
+        v = float(os.environ.get(
+            "JARVIS_EXPLORATION_REFUTED_LR", "0.33",
+        ).strip())
+        return max(MIN_LIKELIHOOD_RATIO, min(MAX_LIKELIHOOD_RATIO, v))
+    except (ValueError, TypeError):
+        return 0.33
+
+
+def _inconclusive_lr() -> float:
+    """Likelihood ratio for INCONCLUSIVE evidence (default 1.0)."""
+    try:
+        v = float(os.environ.get(
+            "JARVIS_EXPLORATION_INCONCLUSIVE_LR", "1.0",
+        ).strip())
+        return max(MIN_LIKELIHOOD_RATIO, min(MAX_LIKELIHOOD_RATIO, v))
+    except (ValueError, TypeError):
+        return 1.0
+
+
+def _min_entropy_delta() -> float:
+    """Minimum entropy change to avoid diminishing-returns halt
+    (default 0.01)."""
+    try:
+        v = float(os.environ.get(
+            "JARVIS_EXPLORATION_MIN_ENTROPY_DELTA", "0.01",
+        ).strip())
+        return max(0.001, min(0.5, v))
+    except (ValueError, TypeError):
+        return 0.01
+
+
+def _diminishing_window() -> int:
+    """Consecutive observations below min_entropy_delta to trigger
+    diminishing-returns halt (default 3)."""
+    try:
+        v = int(os.environ.get(
+            "JARVIS_EXPLORATION_DIMINISHING_WINDOW", "3",
+        ).strip())
+        return max(1, min(20, v))
+    except (ValueError, TypeError):
+        return 3
+
+
+def _budget_per_hypothesis() -> float:
+    """Maximum budget per hypothesis in USD (default 0.15)."""
+    try:
+        v = float(os.environ.get(
+            "JARVIS_EXPLORATION_BUDGET_PER_HYPOTHESIS", "0.15",
+        ).strip())
+        return max(0.01, v)
+    except (ValueError, TypeError):
+        return 0.15
+
+
+# ---------------------------------------------------------------------------
+# Convergence state constants
+# ---------------------------------------------------------------------------
+
+STATE_EXPLORING = "exploring"
+STATE_CONVERGING = "converging"
+STATE_CONVERGED = "converged"
+STATE_DIVERGING = "diverging"
+
+HALT_CONVERGED = "converged"
+HALT_BUDGET = "budget_exhausted"
+HALT_MAX_PROBES = "max_probes_reached"
+HALT_DIMINISHING = "diminishing_returns"
+
+
+# ---------------------------------------------------------------------------
+# Core math — pure functions
+# ---------------------------------------------------------------------------
+
+
+def entropy(p: float) -> float:
+    """Shannon entropy of a Bernoulli random variable.
+
+    H(p) = −p·log₂(p) − (1−p)·log₂(1−p)
+
+    Returns 0.0 at p=0 or p=1 (certainty), 1.0 at p=0.5 (max
+    uncertainty). NEVER raises.
+    """
+    if p <= 0.0 or p >= 1.0:
+        return 0.0
+    try:
+        return -(p * math.log2(p) + (1.0 - p) * math.log2(1.0 - p))
+    except (ValueError, OverflowError):
+        return 0.0
+
+
+def bayesian_update(prior: float, likelihood_ratio: float) -> float:
+    """Bayesian update of a Bernoulli belief.
+
+    P(H|E) = lr · P(H) / [lr · P(H) + (1 − P(H))]
+
+    where lr = P(E|H) / P(E|¬H) is the likelihood ratio.
+
+    Clamps result to [MIN_PRIOR, MAX_PRIOR] to prevent degenerate
+    posteriors (exactly 0 or 1 cannot be updated further).
+
+    NEVER raises.
+    """
+    p = max(MIN_PRIOR, min(MAX_PRIOR, prior))
+    lr = max(MIN_LIKELIHOOD_RATIO, min(MAX_LIKELIHOOD_RATIO, likelihood_ratio))
+
+    try:
+        numerator = lr * p
+        denominator = lr * p + (1.0 - p)
+        if denominator <= 0.0:
+            return p
+        posterior = numerator / denominator
+    except (ZeroDivisionError, OverflowError):
+        return p
+
+    return max(MIN_PRIOR, min(MAX_PRIOR, posterior))
+
+
+def epsilon_from_prior(prior: float) -> float:
+    """Derive the convergence threshold ε from the prior's initial
+    entropy.
+
+    ε = H(prior) × convergence_ratio
+
+    A hypothesis starting at high uncertainty (prior ≈ 0.5, H ≈ 1.0)
+    gets a proportionally larger ε — it needs to resolve more
+    uncertainty. A hypothesis starting confident (prior ≈ 0.9, H ≈ 0.47)
+    gets a tighter ε — less uncertainty to resolve.
+
+    NEVER raises.
+    """
+    h = entropy(prior)
+    ratio = _convergence_ratio()
+    eps = h * ratio
+    # Floor: never set epsilon to 0 (would mean instant convergence)
+    return max(0.001, eps)
+
+
+def max_probes_for_epsilon(eps: float) -> int:
+    """Theoretical maximum probes to achieve convergence.
+
+    O(log₂(1/ε)) — each probe halves entropy in the worst case.
+
+    This is the derived upper bound, not a hardcoded cap. A well-
+    behaved hypothesis converges much faster; this is the adversarial
+    worst case.
+
+    NEVER raises.
+    """
+    if eps <= 0.0:
+        return MAX_OBSERVATIONS
+    try:
+        raw = math.ceil(math.log2(1.0 / eps))
+        return max(1, min(MAX_OBSERVATIONS, raw))
+    except (ValueError, OverflowError):
+        return MAX_OBSERVATIONS
+
+
+def cooling_factor(current_entropy: float) -> float:
+    """Cooling factor for the exploration schedule.
+
+    Returns [0.0, 1.0]:
+      - 1.0 at maximum uncertainty (entropy = 1.0)
+      - 0.0 at convergence (entropy ≈ 0.0)
+
+    Used by ConvergenceGovernor to modulate CuriosityScheduler's
+    fire rate. As hypotheses converge, exploration intensity
+    decreases.
+
+    NEVER raises.
+    """
+    max_entropy = 1.0  # entropy(0.5) for Bernoulli
+    if max_entropy <= 0.0:
+        return 0.0
+    return max(0.0, min(1.0, current_entropy / max_entropy))
+
+
+def classify_convergence(
+    *,
+    current_entropy: float,
+    previous_entropy: float,
+    epsilon: float,
+) -> str:
+    """Classify the convergence state based on entropy trajectory.
+
+    - ``converged``: entropy < ε
+    - ``converging``: entropy decreased
+    - ``diverging``: entropy increased
+    - ``exploring``: first observation or no change
+
+    NEVER raises.
+    """
+    if current_entropy < epsilon:
+        return STATE_CONVERGED
+    delta = current_entropy - previous_entropy
+    if delta < -0.001:
+        return STATE_CONVERGING
+    if delta > 0.001:
+        return STATE_DIVERGING
+    return STATE_EXPLORING
+
+
+def verdict_to_likelihood_ratio(verdict: str) -> float:
+    """Map a probe verdict string to a likelihood ratio.
+
+    Uses env-tunable ratios:
+      - ``CONFIRMED`` → confirmed_lr (default 3.0)
+      - ``REFUTED`` → refuted_lr (default 0.33)
+      - anything else → inconclusive_lr (default 1.0)
+
+    NEVER raises.
+    """
+    v = (verdict or "").upper().strip()
+    if v in ("CONFIRMED", "VALIDATED"):
+        return _confirmed_lr()
+    if v in ("REFUTED", "INVALIDATED"):
+        return _refuted_lr()
+    return _inconclusive_lr()
+
+
+# ---------------------------------------------------------------------------
+# BeliefState — one hypothesis's epistemic state
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BeliefState:
+    """Epistemic state of a single hypothesis.
+
+    Tracks the Bayesian posterior, Shannon entropy, convergence
+    classification, and cost. Frozen — each update produces a new
+    instance.
+    """
+
+    hypothesis_id: str
+    prior: float
+    posterior: float
+    observations: int
+    entropy: float
+    entropy_delta: float
+    convergence_state: str
+    cost_spent: float
+    consecutive_diminishing: int = 0
+    ts_unix: float = 0.0
+
+    def is_converged(self) -> bool:
+        return self.convergence_state == STATE_CONVERGED
+
+    def is_halted(self, epsilon: float) -> bool:
+        """True if any halt condition is met."""
+        if self.entropy < epsilon:
+            return True
+        if self.cost_spent >= _budget_per_hypothesis():
+            return True
+        max_p = max_probes_for_epsilon(epsilon)
+        if self.observations >= max_p:
+            return True
+        if self.consecutive_diminishing >= _diminishing_window():
+            return True
+        return False
+
+    def halt_reason(self, epsilon: float) -> str:
+        """Return the reason for halting, or empty string."""
+        if self.entropy < epsilon:
+            return HALT_CONVERGED
+        if self.cost_spent >= _budget_per_hypothesis():
+            return HALT_BUDGET
+        max_p = max_probes_for_epsilon(epsilon)
+        if self.observations >= max_p:
+            return HALT_MAX_PROBES
+        if self.consecutive_diminishing >= _diminishing_window():
+            return HALT_DIMINISHING
+        return ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "hypothesis_id": self.hypothesis_id,
+            "prior": round(self.prior, 6),
+            "posterior": round(self.posterior, 6),
+            "observations": self.observations,
+            "entropy": round(self.entropy, 6),
+            "entropy_delta": round(self.entropy_delta, 6),
+            "convergence_state": self.convergence_state,
+            "cost_spent": round(self.cost_spent, 6),
+            "consecutive_diminishing": self.consecutive_diminishing,
+            "ts_unix": self.ts_unix,
+        }
+
+
+# ---------------------------------------------------------------------------
+# ConvergenceProof — emitted when a hypothesis halts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConvergenceProof:
+    """Formal proof that exploration terminated for a hypothesis.
+
+    Emitted by ``ConvergenceGovernor`` when any halt condition fires.
+    Immutable audit record.
+    """
+
+    hypothesis_id: str
+    halted: bool
+    halt_reason: str
+    probes_used: int
+    theoretical_max_probes: int
+    cost_spent: float
+    final_belief: float
+    final_entropy: float
+    epsilon: float
+    ts_unix: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "hypothesis_id": self.hypothesis_id,
+            "halted": self.halted,
+            "halt_reason": self.halt_reason,
+            "probes_used": self.probes_used,
+            "theoretical_max_probes": self.theoretical_max_probes,
+            "cost_spent": round(self.cost_spent, 6),
+            "final_belief": round(self.final_belief, 6),
+            "final_entropy": round(self.final_entropy, 6),
+            "epsilon": round(self.epsilon, 6),
+            "ts_unix": self.ts_unix,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Belief update — the core operation
+# ---------------------------------------------------------------------------
+
+
+def initial_belief(
+    hypothesis_id: str,
+    prior: float = 0.5,
+    now_unix: float = 0.0,
+) -> BeliefState:
+    """Create the initial BeliefState for a new hypothesis.
+
+    Default prior is 0.5 (maximum uncertainty). Callers may supply
+    a different prior based on the hypothesis source's confidence.
+
+    NEVER raises.
+    """
+    p = max(MIN_PRIOR, min(MAX_PRIOR, prior))
+    h = entropy(p)
+    return BeliefState(
+        hypothesis_id=hypothesis_id,
+        prior=p,
+        posterior=p,
+        observations=0,
+        entropy=h,
+        entropy_delta=0.0,
+        convergence_state=STATE_EXPLORING,
+        cost_spent=0.0,
+        consecutive_diminishing=0,
+        ts_unix=now_unix,
+    )
+
+
+def update_belief(
+    state: BeliefState,
+    *,
+    verdict: str,
+    cost_usd: float = 0.0,
+    now_unix: float = 0.0,
+) -> BeliefState:
+    """Apply one Bayesian update to a BeliefState.
+
+    Takes the previous state + a probe verdict, computes the new
+    posterior, entropy, convergence classification, and returns a
+    fresh frozen BeliefState.
+
+    NEVER raises.
+    """
+    lr = verdict_to_likelihood_ratio(verdict)
+    new_posterior = bayesian_update(state.posterior, lr)
+    new_entropy = entropy(new_posterior)
+    prev_entropy = state.entropy
+    delta = new_entropy - prev_entropy
+
+    eps = epsilon_from_prior(state.prior)
+    conv_state = classify_convergence(
+        current_entropy=new_entropy,
+        previous_entropy=prev_entropy,
+        epsilon=eps,
+    )
+
+    # Track consecutive diminishing-returns observations.
+    abs_delta = abs(delta)
+    if abs_delta < _min_entropy_delta():
+        consec = state.consecutive_diminishing + 1
+    else:
+        consec = 0
+
+    return BeliefState(
+        hypothesis_id=state.hypothesis_id,
+        prior=state.prior,
+        posterior=new_posterior,
+        observations=state.observations + 1,
+        entropy=new_entropy,
+        entropy_delta=delta,
+        convergence_state=conv_state,
+        cost_spent=state.cost_spent + max(0.0, cost_usd),
+        consecutive_diminishing=consec,
+        ts_unix=now_unix,
+    )
+
+
+def make_convergence_proof(
+    state: BeliefState,
+    now_unix: float = 0.0,
+) -> ConvergenceProof:
+    """Generate a ConvergenceProof from a halted BeliefState.
+
+    NEVER raises.
+    """
+    eps = epsilon_from_prior(state.prior)
+    return ConvergenceProof(
+        hypothesis_id=state.hypothesis_id,
+        halted=True,
+        halt_reason=state.halt_reason(eps),
+        probes_used=state.observations,
+        theoretical_max_probes=max_probes_for_epsilon(eps),
+        cost_spent=state.cost_spent,
+        final_belief=state.posterior,
+        final_entropy=state.entropy,
+        epsilon=eps,
+        ts_unix=now_unix,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_belief_state(obj: Dict[str, Any]) -> Optional[BeliefState]:
+    """Parse a dict into a BeliefState. NEVER raises."""
+    try:
+        return BeliefState(
+            hypothesis_id=str(obj.get("hypothesis_id", "")),
+            prior=float(obj.get("prior", 0.5)),
+            posterior=float(obj.get("posterior", 0.5)),
+            observations=int(obj.get("observations", 0)),
+            entropy=float(obj.get("entropy", 0.0)),
+            entropy_delta=float(obj.get("entropy_delta", 0.0)),
+            convergence_state=str(obj.get("convergence_state", STATE_EXPLORING)),
+            cost_spent=float(obj.get("cost_spent", 0.0)),
+            consecutive_diminishing=int(obj.get("consecutive_diminishing", 0)),
+            ts_unix=float(obj.get("ts_unix", 0.0)),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "BeliefState",
+    "ConvergenceProof",
+    "HALT_BUDGET",
+    "HALT_CONVERGED",
+    "HALT_DIMINISHING",
+    "HALT_MAX_PROBES",
+    "MAX_LIKELIHOOD_RATIO",
+    "MAX_OBSERVATIONS",
+    "MAX_PRIOR",
+    "MIN_LIKELIHOOD_RATIO",
+    "MIN_PRIOR",
+    "STATE_CONVERGED",
+    "STATE_CONVERGING",
+    "STATE_DIVERGING",
+    "STATE_EXPLORING",
+    "bayesian_update",
+    "classify_convergence",
+    "cooling_factor",
+    "entropy",
+    "epsilon_from_prior",
+    "initial_belief",
+    "is_calculus_enabled",
+    "make_convergence_proof",
+    "max_probes_for_epsilon",
+    "parse_belief_state",
+    "update_belief",
+    "verdict_to_likelihood_ratio",
+]

--- a/backend/core/ouroboros/governance/determinism/__init__.py
+++ b/backend/core/ouroboros/governance/determinism/__init__.py
@@ -48,6 +48,12 @@ from backend.core.ouroboros.governance.determinism.entropy import (
     entropy_enabled,
     entropy_for,
 )
+from backend.core.ouroboros.governance.determinism.phase_capture import (
+    OutputAdapter,
+    capture_phase_decision,
+    phase_capture_enabled,
+    register_adapter,
+)
 
 __all__ = [
     "DecisionMismatchError",
@@ -56,15 +62,19 @@ __all__ = [
     "DeterministicEntropy",
     "FrozenClock",
     "LedgerMode",
+    "OutputAdapter",
     "RealClock",
     "SessionEntropy",
     "VerifyResult",
+    "capture_phase_decision",
     "clock_enabled",
     "clock_for_session",
     "decide",
     "entropy_enabled",
     "entropy_for",
     "ledger_enabled",
+    "phase_capture_enabled",
+    "register_adapter",
     "runtime_for_session",
     "runtime_session",
 ]

--- a/backend/core/ouroboros/governance/determinism/phase_capture.py
+++ b/backend/core/ouroboros/governance/determinism/phase_capture.py
@@ -1,0 +1,358 @@
+"""Phase 1 Slice 1.3 — Phase capture integration helper.
+
+The PRODUCTION-CALLSITE adapter for the Determinism Substrate.
+
+Phase 1 layering recap:
+
+  * Slice 1.1 — entropy + clock primitives
+  * Slice 1.2 — DecisionRuntime + ``decide(...)`` integration runtime
+  * Slice 1.3 (THIS module) — phase-runner-shaped wrapper that
+    decorates production decision sites with capture semantics.
+
+Slice 1.2 ships ``decide(...)`` as the universal record/replay/
+verify integration. Slice 1.3 ships ``capture_phase_decision(...)`` —
+a phase-runner-shaped adapter that:
+
+  1. Adds the master-flag short-circuit for cheap PASSTHROUGH.
+  2. Builds a canonical ``inputs`` dict from common phase ctx fields
+     so every wired phase emits a consistent shape.
+  3. Coerces non-JSON-serializable outputs (Enum, dataclass, tuple)
+     into canonical-friendly representations via the registered
+     adapter.
+  4. Provides a dynamic registry so each phase + kind has explicit
+     adapters (not hardcoded enum). New decision kinds register at
+     module load.
+
+The wiring discipline at production callsites:
+
+    from backend.core.ouroboros.governance.determinism.phase_capture import (
+        capture_phase_decision,
+    )
+
+    # Existing code:
+    route, reason = router.classify(ctx)
+
+    # Slice 1.3 wiring (one async call):
+    captured = await capture_phase_decision(
+        op_id=ctx.op_id,
+        phase="ROUTE",
+        kind="route_assignment",
+        ctx=ctx,
+        compute=lambda: router.classify(ctx),
+        output_adapter=route_adapter,
+    )
+    route, reason = captured
+
+Master flag ``JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED`` (default
+false until Phase 1 graduation). When off, ``capture_phase_decision``
+short-circuits to a pure call of ``compute()`` — bit-for-bit legacy.
+
+NEVER imports orchestrator / phase_runner / candidate_generator.
+NEVER raises out of any public method.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Tuple
+
+from backend.core.ouroboros.governance.determinism.decision_runtime import (
+    LedgerMode,
+    decide,
+    ledger_enabled as _ledger_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Master flag — independent of the underlying ledger flag
+# ---------------------------------------------------------------------------
+
+
+def phase_capture_enabled() -> bool:
+    """``JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED`` (default ``false``).
+
+    Slice 1.3 master flag. Independent from
+    ``JARVIS_DETERMINISM_LEDGER_ENABLED`` (Slice 1.2) so operators
+    can record decisions WITHOUT firing the phase capture wrappers
+    (shadow recording on the runtime layer only) OR enable phase
+    capture WITHOUT fully enabling the ledger (PASSTHROUGH mode for
+    the wrappers themselves — no-op everywhere).
+
+    Both flags must be ``true`` for capture to actually record; if
+    either is off, ``capture_phase_decision`` is a pure passthrough.
+
+    Re-read at call time so monkeypatch works in tests + operators
+    can flip live without re-init."""
+    raw = os.environ.get(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+# ---------------------------------------------------------------------------
+# Output adapter registry — dynamic, no hardcoded enum
+# ---------------------------------------------------------------------------
+
+
+# An output adapter takes whatever ``compute()`` returned and produces:
+#   1. A JSON-serializable representation for storage
+#   2. A "rehydrate" function that reconstructs the original shape
+#      when REPLAY returns the stored representation
+#
+# Adapters are explicit per (phase, kind) — phases register their own
+# at module load. We use this two-step pattern so REPLAY can produce
+# the SAME rich Python object (e.g., ProviderRoute enum) instead of
+# a generic dict, making the capture transparent to callers.
+@dataclass(frozen=True)
+class OutputAdapter:
+    """Bidirectional serializer for one phase's decision output.
+
+    Attributes
+    ----------
+    serialize : Callable[[Any], Any]
+        Convert the live output into a JSON-safe representation.
+        Result must be JSON-serializable via canonical_serialize.
+    deserialize : Callable[[Any], Any]
+        Reconstruct the original output shape from the JSON-safe
+        representation. Used by REPLAY to return the same Python
+        object the caller would have gotten from compute().
+    name : str
+        Human-readable identifier for telemetry.
+    """
+    serialize: Callable[[Any], Any]
+    deserialize: Callable[[Any], Any]
+    name: str = "default"
+
+
+# Identity adapter — passthrough for outputs that are already
+# JSON-friendly (str, int, float, bool, None, list, dict of those).
+_IDENTITY_ADAPTER = OutputAdapter(
+    serialize=lambda x: x,
+    deserialize=lambda x: x,
+    name="identity",
+)
+
+
+_adapter_registry: Dict[Tuple[str, str], OutputAdapter] = {}
+
+
+def register_adapter(
+    *, phase: str, kind: str, adapter: OutputAdapter,
+) -> None:
+    """Register an adapter for ``(phase, kind)``. Idempotent —
+    re-registering the same key with the same adapter is a no-op;
+    re-registering with a DIFFERENT adapter logs a warning + replaces
+    (operators tweaking adapters during dev shouldn't be silently
+    ignored). NEVER raises."""
+    if not phase or not kind:
+        return
+    key = (str(phase), str(kind))
+    existing = _adapter_registry.get(key)
+    if existing is not None and existing is not adapter:
+        logger.info(
+            "[determinism] adapter for (%s, %s) replaced "
+            "(was=%s, new=%s)",
+            phase, kind, existing.name, adapter.name,
+        )
+    _adapter_registry[key] = adapter
+
+
+def get_adapter(*, phase: str, kind: str) -> OutputAdapter:
+    """Return the registered adapter for ``(phase, kind)`` or the
+    identity passthrough if none registered. NEVER raises."""
+    return _adapter_registry.get(
+        (str(phase), str(kind)), _IDENTITY_ADAPTER,
+    )
+
+
+def iter_registered() -> Tuple[Tuple[str, str], ...]:
+    """Snapshot of all registered ``(phase, kind)`` pairs.
+    Diagnostic — used by ``/determinism adapters`` REPL surface."""
+    return tuple(sorted(_adapter_registry.keys()))
+
+
+def reset_registry_for_tests() -> None:
+    """Drop all registered adapters. Production code MUST NOT call
+    this. Tests use it to isolate adapter registration between
+    test functions."""
+    _adapter_registry.clear()
+
+
+# ---------------------------------------------------------------------------
+# Common ctx → inputs canonicalization
+# ---------------------------------------------------------------------------
+
+
+def _build_ctx_inputs(
+    ctx: Any, *, extra: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a canonical inputs dict from common ctx fields.
+
+    Phase callsites that have an ``OperationContext``-shaped object
+    can pass it directly; this helper extracts the standard fields
+    that downstream decisions branch on (signal_urgency,
+    signal_source, task_complexity, target_files, cross_repo).
+    Extra phase-specific inputs merge on top.
+
+    Defensive: missing attrs return empty strings / empty lists.
+    NEVER raises."""
+    out: Dict[str, Any] = {}
+    if ctx is not None:
+        try:
+            out["signal_urgency"] = (
+                getattr(ctx, "signal_urgency", "") or ""
+            )
+            out["signal_source"] = (
+                getattr(ctx, "signal_source", "") or ""
+            )
+            out["task_complexity"] = (
+                getattr(ctx, "task_complexity", "") or ""
+            )
+            out["cross_repo"] = bool(getattr(ctx, "cross_repo", False))
+            out["is_read_only"] = bool(
+                getattr(ctx, "is_read_only", False),
+            )
+            tfs = getattr(ctx, "target_files", None)
+            if tfs:
+                # Normalize to a sorted tuple of strings. Same
+                # canonical hash regardless of original ordering.
+                try:
+                    out["target_files"] = sorted(
+                        str(f) for f in tfs
+                    )
+                except (TypeError, ValueError):
+                    out["target_files"] = []
+            else:
+                out["target_files"] = []
+        except Exception:  # noqa: BLE001 — defensive
+            pass
+    if extra:
+        try:
+            for k, v in extra.items():
+                out[str(k)] = v
+        except Exception:  # noqa: BLE001 — defensive
+            pass
+    return out
+
+
+# ---------------------------------------------------------------------------
+# capture_phase_decision — the public phase-shaped wrapper
+# ---------------------------------------------------------------------------
+
+
+async def capture_phase_decision(
+    *,
+    op_id: str,
+    phase: str,
+    kind: str,
+    ctx: Any = None,
+    compute: Callable[[], Any],
+    extra_inputs: Optional[Mapping[str, Any]] = None,
+    output_adapter: Optional[OutputAdapter] = None,
+) -> Any:
+    """Phase-runner-shaped wrapper around Slice 1.2's ``decide(...)``.
+
+    Behavior:
+      * If either master flag is OFF → call ``compute()`` and return
+        its result. Bit-for-bit legacy. Negligible overhead (one env
+        var read + one truthy check).
+      * If both flags ON → dispatch through ``decide(...)`` with the
+        canonicalized ctx-inputs, registered output adapter, and
+        full RECORD/REPLAY/VERIFY semantics.
+
+    Parameters
+    ----------
+    op_id : str
+        The operation identifier from the OperationContext.
+    phase : str
+        Phase name (e.g., ``"ROUTE"``, ``"CLASSIFY"``, ``"GENERATE"``).
+    kind : str
+        Decision kind within the phase (e.g., ``"route_assignment"``).
+        Free-form string — register an adapter via ``register_adapter``
+        if your output isn't JSON-friendly.
+    ctx : Any, optional
+        OperationContext (or duck-typed equivalent). Used to extract
+        common decision inputs (signal_urgency, etc.).
+    compute : Callable[[], Any]
+        The decision function. Sync, sync-returning-awaitable, or
+        async — Slice 1.2's ``decide`` handles all three.
+    extra_inputs : Mapping[str, Any], optional
+        Additional inputs that aren't on ctx (phase-specific
+        signals). Merged on top of ctx-extracted inputs.
+    output_adapter : OutputAdapter, optional
+        Override the registered adapter for this call only.
+        Useful for one-off decision shapes.
+
+    Returns
+    -------
+    Any
+        The decision output, in its original shape (post-deserialize
+        when in REPLAY mode and the output had a non-trivial adapter).
+
+    NEVER raises beyond what compute() raises in PASSTHROUGH mode,
+    or DecisionMismatchError in VERIFY-strict mode."""
+    # Fast path — both flags must be on for capture to engage. The
+    # ledger flag governs whether decide() does anything; the
+    # capture flag governs whether the wrapper engages at all. Two
+    # gates so operators can rollback either independently.
+    if not phase_capture_enabled() or not _ledger_enabled():
+        return await _call_compute(compute)
+
+    adapter = output_adapter or get_adapter(phase=phase, kind=kind)
+    inputs = _build_ctx_inputs(ctx, extra=extra_inputs)
+
+    # Wrap compute to apply the output adapter on the live path.
+    async def _adapted_compute() -> Any:
+        live = await _call_compute(compute)
+        try:
+            return adapter.serialize(live)
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.warning(
+                "[determinism] phase_capture serialize failed for "
+                "phase=%s kind=%s: %s — falling back to identity",
+                phase, kind, exc,
+            )
+            return live  # storage may fail, caller still gets value
+
+    serialized = await decide(
+        op_id=op_id, phase=phase, kind=kind,
+        inputs=inputs, compute=_adapted_compute,
+    )
+
+    # Apply the deserialize step so the caller gets back the original
+    # shape (e.g., ProviderRoute enum, not raw string). REPLAY mode
+    # returns the stored serialized form; deserialize reconstitutes.
+    try:
+        return adapter.deserialize(serialized)
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.warning(
+            "[determinism] phase_capture deserialize failed for "
+            "phase=%s kind=%s: %s — returning raw stored repr",
+            phase, kind, exc,
+        )
+        return serialized
+
+
+async def _call_compute(compute: Callable[[], Any]) -> Any:
+    """Same flexible call pattern as Slice 1.2's _maybe_await but
+    duplicated here to avoid coupling on a private helper. Accepts
+    sync, sync-returning-awaitable, or async."""
+    import asyncio
+    result = compute()
+    if asyncio.iscoroutine(result) or hasattr(result, "__await__"):
+        return await result
+    return result
+
+
+__all__ = [
+    "OutputAdapter",
+    "capture_phase_decision",
+    "get_adapter",
+    "iter_registered",
+    "phase_capture_enabled",
+    "register_adapter",
+    "reset_registry_for_tests",
+]

--- a/backend/core/ouroboros/governance/phase_runners/route_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/route_runner.py
@@ -64,6 +64,66 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger("Ouroboros.Orchestrator")
 
 
+# Phase 1 Slice 1.3 — register the route-decision adapter at module
+# load. The adapter converts a ``(ProviderRoute, reason_str)`` tuple
+# into a JSON-friendly dict for storage, and reconstitutes the tuple
+# on REPLAY so callers receive the same Python shape they'd have
+# received from the live UrgencyRouter call.
+def _register_route_adapter() -> None:
+    """Idempotent — safe to import multiple times. Defensive
+    (NEVER raises) so a missing determinism module doesn't break
+    the route runner import chain."""
+    try:
+        from backend.core.ouroboros.governance.determinism.phase_capture import (
+            OutputAdapter,
+            register_adapter,
+        )
+        from backend.core.ouroboros.governance.urgency_router import (
+            ProviderRoute,
+        )
+
+        def _serialize(route_tuple: Any) -> Any:
+            try:
+                route, reason = route_tuple
+                return {
+                    "route": str(route.value) if hasattr(route, "value")
+                    else str(route),
+                    "reason": str(reason or ""),
+                }
+            except Exception:  # noqa: BLE001 — defensive
+                return {"route": "", "reason": str(route_tuple)[:200]}
+
+        def _deserialize(stored: Any) -> Any:
+            try:
+                if not isinstance(stored, dict):
+                    return stored
+                route_str = str(stored.get("route", ""))
+                reason = str(stored.get("reason", ""))
+                # ProviderRoute is a str-Enum so this constructor
+                # accepts the raw string value.
+                return (ProviderRoute(route_str), reason)
+            except (ValueError, KeyError, TypeError):
+                return stored
+
+        register_adapter(
+            phase="ROUTE",
+            kind="route_assignment",
+            adapter=OutputAdapter(
+                serialize=_serialize,
+                deserialize=_deserialize,
+                name="route_assignment_adapter",
+            ),
+        )
+    except Exception:  # noqa: BLE001 — defensive (import-time)
+        # Determinism module unavailable — wiring still works as a
+        # pure passthrough via capture_phase_decision's internal
+        # short-circuit. No log spam at import time.
+        pass
+
+
+_register_route_adapter()
+
+
 class ROUTERunner(PhaseRunner):
     """Verbatim transcription of orchestrator.py ROUTE block (~2048-2141/2257)."""
 
@@ -108,10 +168,47 @@ class ROUTERunner(PhaseRunner):
         # ── Urgency-aware provider routing (Manifesto §5 Tier 0) ──
         try:
             from backend.core.ouroboros.governance.urgency_router import (
+                ProviderRoute,
                 UrgencyRouter,
             )
             _urgency_router = UrgencyRouter()
-            _provider_route, _route_reason = _urgency_router.classify(ctx)
+
+            # Phase 1 Slice 1.3 — wrap the route decision in
+            # capture_phase_decision so RECORD/REPLAY/VERIFY work.
+            # When the master flag is off, this is a pure passthrough
+            # that calls _urgency_router.classify(ctx) directly with
+            # negligible overhead. Adapter is registered at module
+            # load below.
+            try:
+                from backend.core.ouroboros.governance.determinism.phase_capture import (
+                    capture_phase_decision,
+                )
+
+                async def _classify_route() -> Any:
+                    return _urgency_router.classify(ctx)
+
+                _route_tuple = await capture_phase_decision(
+                    op_id=ctx.op_id,
+                    phase="ROUTE",
+                    kind="route_assignment",
+                    ctx=ctx,
+                    compute=_classify_route,
+                )
+                _provider_route, _route_reason = _route_tuple
+            except Exception:  # noqa: BLE001 — defensive
+                # Capture wrapper failed → fall back to direct call.
+                # Determinism is best-effort; routing must always
+                # succeed. Operators see the warning in capture's
+                # internal logging.
+                logger.debug(
+                    "[Orchestrator] capture_phase_decision failed; "
+                    "falling back to direct UrgencyRouter call",
+                    exc_info=True,
+                )
+                _provider_route, _route_reason = (
+                    _urgency_router.classify(ctx)
+                )
+
             object.__setattr__(ctx, "provider_route", _provider_route.value)
             object.__setattr__(ctx, "provider_route_reason", _route_reason)
             logger.info(

--- a/tests/governance/test_determinism_phase_capture.py
+++ b/tests/governance/test_determinism_phase_capture.py
@@ -1,0 +1,624 @@
+"""Phase 1 Slice 1.3 — Phase capture wiring regression spine.
+
+Two scopes:
+
+  1. Phase capture helper itself (master flag, adapter registry,
+     ctx canonicalization, RECORD/REPLAY/VERIFY semantics through
+     the phase_capture wrapper).
+
+  2. ROUTE phase wiring — proves the production callsite in
+     phase_runners/route_runner.py correctly engages the substrate
+     and degrades to passthrough cleanly.
+
+Pins:
+  §1   phase_capture_enabled flag — default false; case-tolerant
+  §2   Both flags must be ON for capture to engage
+  §3   Master flag off → pure passthrough (no disk, no recording)
+  §4   register_adapter — idempotent + log-on-replace
+  §5   register_adapter — defensive on bad input
+  §6   get_adapter — falls back to identity
+  §7   _build_ctx_inputs — canonicalizes ctx fields
+  §8   _build_ctx_inputs — target_files sorted (canonical hash stable)
+  §9   _build_ctx_inputs — missing ctx fields default safely
+  §10  capture_phase_decision — RECORD path writes ledger
+  §11  capture_phase_decision — REPLAY path returns adapter-deserialized
+  §12  capture_phase_decision — adapter serialize fault → identity fallback
+  §13  capture_phase_decision — adapter deserialize fault → raw repr
+  §14  ROUTE wiring — adapter registered at module load
+  §15  ROUTE wiring — passthrough preserves direct UrgencyRouter call
+  §16  ROUTE wiring — capture failure falls back to direct call
+  §17  Authority invariants — phase_capture imports
+  §18  Authority invariants — route_runner doesn't break on import
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.determinism import (
+    DecisionRuntime,
+    OutputAdapter,
+    capture_phase_decision,
+    phase_capture_enabled,
+    register_adapter,
+)
+from backend.core.ouroboros.governance.determinism.decision_runtime import (
+    reset_all_for_tests as reset_runtime_for_tests,
+)
+from backend.core.ouroboros.governance.determinism.phase_capture import (
+    _build_ctx_inputs,
+    _IDENTITY_ADAPTER,
+    get_adapter,
+    iter_registered,
+    reset_registry_for_tests,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_LEDGER_DIR", str(tmp_path / "det"),
+    )
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", "true",
+    )
+    monkeypatch.delenv("JARVIS_DETERMINISM_LEDGER_MODE", raising=False)
+    monkeypatch.setenv("OUROBOROS_BATTLE_SESSION_ID", "test-session")
+    reset_runtime_for_tests()
+    reset_registry_for_tests()
+    yield tmp_path / "det"
+    reset_runtime_for_tests()
+    reset_registry_for_tests()
+
+
+@pytest.fixture
+def isolated_passthrough(tmp_path, monkeypatch):
+    """Capture flag OFF → pure passthrough."""
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_LEDGER_DIR", str(tmp_path / "det"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", "false",
+    )
+    reset_runtime_for_tests()
+    reset_registry_for_tests()
+    yield tmp_path
+    reset_runtime_for_tests()
+    reset_registry_for_tests()
+
+
+def _ctx_stub(**kwargs):
+    """Minimal OperationContext-shaped stub."""
+    ctx = MagicMock()
+    ctx.op_id = kwargs.get("op_id", "op-test")
+    ctx.signal_urgency = kwargs.get("signal_urgency", "normal")
+    ctx.signal_source = kwargs.get("signal_source", "test_source")
+    ctx.task_complexity = kwargs.get("task_complexity", "moderate")
+    ctx.target_files = kwargs.get("target_files", ())
+    ctx.cross_repo = kwargs.get("cross_repo", False)
+    ctx.is_read_only = kwargs.get("is_read_only", False)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# §1 — Master flag
+# ---------------------------------------------------------------------------
+
+
+def test_phase_capture_default_false(monkeypatch) -> None:
+    monkeypatch.delenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", raising=False,
+    )
+    assert phase_capture_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_phase_capture_truthy(monkeypatch, val) -> None:
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", val,
+    )
+    assert phase_capture_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage", ""])
+def test_phase_capture_falsy(monkeypatch, val) -> None:
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", val,
+    )
+    assert phase_capture_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# §2 — Both flags must be ON for capture to engage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capture_flag_off_engages_passthrough(
+    monkeypatch, isolated_passthrough,
+) -> None:
+    """Capture off + ledger on → still passthrough."""
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", "false",
+    )
+
+    counter = {"n": 0}
+
+    def compute():
+        counter["n"] += 1
+        return "X"
+
+    out = await capture_phase_decision(
+        op_id="op-1", phase="P", kind="K", compute=compute,
+    )
+    assert out == "X"
+    assert counter["n"] == 1
+    # No disk artifacts created
+    decisions = isolated_passthrough / "det" / "test-session" / "decisions.jsonl"
+    assert not decisions.exists()
+
+
+@pytest.mark.asyncio
+async def test_ledger_flag_off_engages_passthrough(
+    monkeypatch, tmp_path,
+) -> None:
+    """Capture on + ledger off → passthrough (defensive)."""
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_LEDGER_DIR", str(tmp_path / "det"),
+    )
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_ENABLED", "false")
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", "true",
+    )
+    reset_runtime_for_tests()
+
+    out = await capture_phase_decision(
+        op_id="op-1", phase="P", kind="K",
+        compute=lambda: "Y",
+    )
+    assert out == "Y"
+    assert not (tmp_path / "det").exists()
+
+
+# ---------------------------------------------------------------------------
+# §3 — Master flag off path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_master_off_no_disk_traffic(
+    isolated_passthrough,
+) -> None:
+    counter = {"n": 0}
+
+    async def compute():
+        counter["n"] += 1
+        return {"route": "STANDARD"}
+
+    out = await capture_phase_decision(
+        op_id="op-1", phase="ROUTE", kind="route_assignment",
+        compute=compute,
+    )
+    assert out == {"route": "STANDARD"}
+    assert counter["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# §4-§6 — Adapter registry
+# ---------------------------------------------------------------------------
+
+
+def test_register_adapter_basic() -> None:
+    reset_registry_for_tests()
+    a = OutputAdapter(
+        serialize=lambda x: x, deserialize=lambda x: x, name="test1",
+    )
+    register_adapter(phase="P", kind="K", adapter=a)
+    assert get_adapter(phase="P", kind="K") is a
+
+
+def test_register_adapter_replace_logs(caplog) -> None:
+    import logging
+    reset_registry_for_tests()
+    a = OutputAdapter(
+        serialize=lambda x: x, deserialize=lambda x: x, name="first",
+    )
+    b = OutputAdapter(
+        serialize=lambda x: x, deserialize=lambda x: x, name="second",
+    )
+    register_adapter(phase="P", kind="K", adapter=a)
+    caplog.set_level(logging.INFO)
+    register_adapter(phase="P", kind="K", adapter=b)
+    assert get_adapter(phase="P", kind="K") is b
+    replace_logs = [
+        r for r in caplog.records if "replaced" in r.getMessage()
+    ]
+    assert len(replace_logs) >= 1
+
+
+def test_register_adapter_same_instance_silent(caplog) -> None:
+    """Re-registering the SAME adapter is a silent no-op (no warning)."""
+    import logging
+    reset_registry_for_tests()
+    a = OutputAdapter(
+        serialize=lambda x: x, deserialize=lambda x: x, name="same",
+    )
+    register_adapter(phase="P", kind="K", adapter=a)
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+    register_adapter(phase="P", kind="K", adapter=a)
+    # No "replaced" log on identical re-registration
+    replace_logs = [
+        r for r in caplog.records if "replaced" in r.getMessage()
+    ]
+    assert replace_logs == []
+
+
+def test_register_adapter_empty_keys_rejected() -> None:
+    reset_registry_for_tests()
+    a = OutputAdapter(
+        serialize=lambda x: x, deserialize=lambda x: x,
+    )
+    register_adapter(phase="", kind="K", adapter=a)
+    register_adapter(phase="P", kind="", adapter=a)
+    # Neither registered → identity fallback
+    assert get_adapter(phase="", kind="K") is _IDENTITY_ADAPTER
+    assert get_adapter(phase="P", kind="") is _IDENTITY_ADAPTER
+
+
+def test_get_adapter_unknown_falls_back_to_identity() -> None:
+    reset_registry_for_tests()
+    a = get_adapter(phase="UNREGISTERED", kind="UNKNOWN")
+    assert a is _IDENTITY_ADAPTER
+    assert a.serialize(42) == 42
+    assert a.deserialize(42) == 42
+
+
+def test_iter_registered_returns_sorted_pairs() -> None:
+    reset_registry_for_tests()
+    a = OutputAdapter(
+        serialize=lambda x: x, deserialize=lambda x: x,
+    )
+    register_adapter(phase="ZED", kind="K", adapter=a)
+    register_adapter(phase="ALPHA", kind="K", adapter=a)
+    register_adapter(phase="ALPHA", kind="L", adapter=a)
+    pairs = iter_registered()
+    assert pairs == (("ALPHA", "K"), ("ALPHA", "L"), ("ZED", "K"))
+
+
+# ---------------------------------------------------------------------------
+# §7-§9 — _build_ctx_inputs
+# ---------------------------------------------------------------------------
+
+
+def test_build_ctx_inputs_basic() -> None:
+    ctx = _ctx_stub(
+        signal_urgency="critical", signal_source="test_failure",
+        task_complexity="heavy_code",
+    )
+    inputs = _build_ctx_inputs(ctx)
+    assert inputs["signal_urgency"] == "critical"
+    assert inputs["signal_source"] == "test_failure"
+    assert inputs["task_complexity"] == "heavy_code"
+    assert inputs["target_files"] == []
+    assert inputs["cross_repo"] is False
+    assert inputs["is_read_only"] is False
+
+
+def test_build_ctx_inputs_target_files_sorted() -> None:
+    """Same set of files in different order → same canonical inputs."""
+    ctx1 = _ctx_stub(target_files=["b.py", "a.py", "c.py"])
+    ctx2 = _ctx_stub(target_files=["c.py", "a.py", "b.py"])
+    i1 = _build_ctx_inputs(ctx1)
+    i2 = _build_ctx_inputs(ctx2)
+    assert i1["target_files"] == i2["target_files"]
+    assert i1["target_files"] == ["a.py", "b.py", "c.py"]
+
+
+def test_build_ctx_inputs_extra_overrides() -> None:
+    ctx = _ctx_stub()
+    inputs = _build_ctx_inputs(
+        ctx, extra={"phase_specific": "value", "signal_urgency": "OVERRIDDEN"},
+    )
+    assert inputs["phase_specific"] == "value"
+    assert inputs["signal_urgency"] == "OVERRIDDEN"
+
+
+def test_build_ctx_inputs_none_ctx() -> None:
+    """None ctx → empty dict (NEVER raises)."""
+    inputs = _build_ctx_inputs(None)
+    assert inputs == {}
+
+
+def test_build_ctx_inputs_handles_garbage_target_files() -> None:
+    ctx = _ctx_stub(target_files=[1, "valid.py", None])
+    inputs = _build_ctx_inputs(ctx)
+    # Coerced to strings; sorted order
+    assert "valid.py" in inputs["target_files"]
+
+
+# ---------------------------------------------------------------------------
+# §10-§13 — capture_phase_decision RECORD/REPLAY paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_capture_record_writes_jsonl(isolated) -> None:
+    ctx = _ctx_stub(op_id="op-1", signal_urgency="critical")
+
+    async def compute():
+        return {"route": "IMMEDIATE"}
+
+    out = await capture_phase_decision(
+        op_id="op-1", phase="ROUTE", kind="route_assignment",
+        ctx=ctx, compute=compute,
+    )
+    assert out == {"route": "IMMEDIATE"}
+    ledger = isolated / "test-session" / "decisions.jsonl"
+    assert ledger.exists()
+    import json as _json
+    rows = [
+        _json.loads(l) for l in
+        ledger.read_text(encoding="utf-8").strip().split("\n")
+    ]
+    assert len(rows) == 1
+    assert rows[0]["phase"] == "ROUTE"
+    assert rows[0]["kind"] == "route_assignment"
+
+
+@pytest.mark.asyncio
+async def test_capture_replay_returns_adapter_deserialized(
+    isolated, monkeypatch,
+) -> None:
+    """Register a non-trivial adapter that converts route dict to
+    a tuple shape, then replay returns the tuple."""
+    register_adapter(
+        phase="ROUTE", kind="route_assignment",
+        adapter=OutputAdapter(
+            serialize=lambda t: {"route": t[0], "reason": t[1]},
+            deserialize=lambda d: (d["route"], d["reason"]),
+            name="test_route_adapter",
+        ),
+    )
+
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_MODE", "record")
+    out_record = await capture_phase_decision(
+        op_id="op-1", phase="ROUTE", kind="route_assignment",
+        ctx=_ctx_stub(),
+        compute=lambda: ("STANDARD", "default cascade"),
+    )
+    assert out_record == ("STANDARD", "default cascade")
+
+    # Reset runtimes so REPLAY reads from disk fresh
+    reset_runtime_for_tests()
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_MODE", "replay")
+
+    canary = {"called": False}
+
+    def should_not_run():
+        canary["called"] = True
+        return ("LIVE", "should not be returned")
+
+    out_replay = await capture_phase_decision(
+        op_id="op-1", phase="ROUTE", kind="route_assignment",
+        ctx=_ctx_stub(), compute=should_not_run,
+    )
+    assert out_replay == ("STANDARD", "default cascade")
+    assert canary["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_capture_serialize_fault_falls_back(
+    isolated, caplog,
+) -> None:
+    """If the adapter's serialize() raises, capture logs + falls
+    back to identity (live output is still returned)."""
+    import logging
+
+    def bad_serialize(x):
+        raise RuntimeError("simulated serialize fault")
+
+    register_adapter(
+        phase="X", kind="Y",
+        adapter=OutputAdapter(
+            serialize=bad_serialize,
+            deserialize=lambda x: x, name="bad_ser",
+        ),
+    )
+
+    caplog.set_level(logging.WARNING)
+    out = await capture_phase_decision(
+        op_id="op-1", phase="X", kind="Y",
+        ctx=_ctx_stub(), compute=lambda: {"data": "value"},
+    )
+    # Live path returned — caller gets the value
+    assert out == {"data": "value"}
+    fallback_logs = [
+        r for r in caplog.records
+        if "serialize failed" in r.getMessage()
+    ]
+    assert len(fallback_logs) >= 1
+
+
+@pytest.mark.asyncio
+async def test_capture_deserialize_fault_returns_raw_repr(
+    isolated, caplog, monkeypatch,
+) -> None:
+    """If the adapter's deserialize() raises during REPLAY, capture
+    logs + returns the raw stored repr (still useful for caller)."""
+    import logging
+
+    def bad_deserialize(x):
+        raise RuntimeError("simulated deserialize fault")
+
+    register_adapter(
+        phase="X", kind="Y",
+        adapter=OutputAdapter(
+            serialize=lambda x: x,
+            deserialize=bad_deserialize, name="bad_des",
+        ),
+    )
+
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_MODE", "record")
+    await capture_phase_decision(
+        op_id="op-1", phase="X", kind="Y",
+        ctx=_ctx_stub(), compute=lambda: {"data": "value"},
+    )
+
+    reset_runtime_for_tests()
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_MODE", "replay")
+
+    caplog.set_level(logging.WARNING)
+    out = await capture_phase_decision(
+        op_id="op-1", phase="X", kind="Y",
+        ctx=_ctx_stub(), compute=lambda: "should-not-run",
+    )
+    # Raw stored repr returned (could be dict or already-decoded
+    # JSON), not the raised exception
+    assert out is not None
+    fallback_logs = [
+        r for r in caplog.records
+        if "deserialize failed" in r.getMessage()
+    ]
+    assert len(fallback_logs) >= 1
+
+
+# ---------------------------------------------------------------------------
+# §14 — ROUTE wiring: adapter registered at module load
+# ---------------------------------------------------------------------------
+
+
+def test_route_adapter_registered_at_module_load() -> None:
+    """Importing route_runner registers the route adapter."""
+    reset_registry_for_tests()
+    # Force re-import to trigger the module-load registration
+    import importlib
+    from backend.core.ouroboros.governance.phase_runners import (
+        route_runner,
+    )
+    importlib.reload(route_runner)
+    adapter = get_adapter(phase="ROUTE", kind="route_assignment")
+    assert adapter is not _IDENTITY_ADAPTER
+    assert adapter.name == "route_assignment_adapter"
+
+
+def test_route_adapter_round_trip() -> None:
+    """The route adapter serializes (ProviderRoute, str) tuples to
+    {"route": str, "reason": str} and deserializes back."""
+    reset_registry_for_tests()
+    import importlib
+    from backend.core.ouroboros.governance.phase_runners import (
+        route_runner,
+    )
+    importlib.reload(route_runner)
+    adapter = get_adapter(phase="ROUTE", kind="route_assignment")
+
+    from backend.core.ouroboros.governance.urgency_router import (
+        ProviderRoute,
+    )
+    original = (ProviderRoute.STANDARD, "default cascade")
+    serialized = adapter.serialize(original)
+    assert serialized == {
+        "route": "standard", "reason": "default cascade",
+    }
+    deserialized = adapter.deserialize(serialized)
+    assert deserialized == original
+
+
+def test_route_adapter_serialize_fallback_on_garbage() -> None:
+    """Garbage input doesn't raise — defensive."""
+    reset_registry_for_tests()
+    import importlib
+    from backend.core.ouroboros.governance.phase_runners import (
+        route_runner,
+    )
+    importlib.reload(route_runner)
+    adapter = get_adapter(phase="ROUTE", kind="route_assignment")
+
+    # Pass non-tuple — should NOT raise
+    out = adapter.serialize("not a tuple")
+    assert "route" in out
+
+
+def test_route_adapter_deserialize_fallback_on_garbage() -> None:
+    """Garbage stored input doesn't raise."""
+    reset_registry_for_tests()
+    import importlib
+    from backend.core.ouroboros.governance.phase_runners import (
+        route_runner,
+    )
+    importlib.reload(route_runner)
+    adapter = get_adapter(phase="ROUTE", kind="route_assignment")
+
+    out = adapter.deserialize("not a dict")
+    # Falls back to returning the raw input
+    assert out == "not a dict"
+
+    out2 = adapter.deserialize({"route": "invalid_route", "reason": ""})
+    # Invalid ProviderRoute value falls through; stored dict returned
+    assert out2 == {"route": "invalid_route", "reason": ""}
+
+
+# ---------------------------------------------------------------------------
+# §17-§18 — Authority invariants
+# ---------------------------------------------------------------------------
+
+
+def test_phase_capture_no_orchestrator_imports() -> None:
+    """phase_capture.py MUST NOT import orchestrator / phase_runner
+    base / candidate_generator. It's a substrate primitive, not a
+    cognitive consumer."""
+    import inspect
+    from backend.core.ouroboros.governance.determinism import phase_capture
+    src = inspect.getsource(phase_capture)
+    forbidden = (
+        "from backend.core.ouroboros.governance.orchestrator",
+        "from backend.core.ouroboros.governance.phase_runner ",
+        "from backend.core.ouroboros.governance.candidate_generator",
+    )
+    for f in forbidden:
+        assert f not in src, f"phase_capture must NOT contain {f!r}"
+
+
+def test_route_runner_imports_phase_capture_lazily() -> None:
+    """route_runner imports phase_capture INSIDE the function body
+    (lazy) so that import failures don't break the runner module
+    itself. The adapter registration helper does its own try/except."""
+    src = open(
+        "backend/core/ouroboros/governance/phase_runners/route_runner.py",
+        encoding="utf-8",
+    ).read()
+    # The capture_phase_decision import should be inside a function
+    # body (indented) — not at the module top level
+    lines = src.split("\n")
+    top_level_imports = [
+        ln for ln in lines
+        if ln.startswith("from backend.core.ouroboros.governance.determinism.phase_capture")
+    ]
+    # No TOP-LEVEL imports of phase_capture (must be lazy/indented)
+    assert top_level_imports == [], (
+        "route_runner must import phase_capture lazily, not at top level"
+    )
+
+
+def test_route_runner_imports_cleanly() -> None:
+    """route_runner module imports without error even if Slice 1.1
+    or 1.2 modules are unavailable. Defensive try/except wraps the
+    adapter registration."""
+    import importlib
+    from backend.core.ouroboros.governance.phase_runners import (
+        route_runner,
+    )
+    # Should not raise — module exists + ROUTERunner class accessible
+    assert hasattr(route_runner, "ROUTERunner")
+    importlib.reload(route_runner)
+    assert hasattr(route_runner, "ROUTERunner")

--- a/tests/governance/test_exploration_calculus.py
+++ b/tests/governance/test_exploration_calculus.py
@@ -1,0 +1,497 @@
+"""Tests for Slice 3.1 — ExplorationCalculus: Bayesian belief engine."""
+from __future__ import annotations
+
+import ast
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch):
+    monkeypatch.setenv("JARVIS_EXPLORATION_CALCULUS_ENABLED", "true")
+
+
+# ---------------------------------------------------------------------------
+# 1. Shannon entropy
+# ---------------------------------------------------------------------------
+
+class TestEntropy:
+    def test_max_uncertainty(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import entropy
+        assert entropy(0.5) == pytest.approx(1.0, abs=1e-9)
+
+    def test_certainty_at_zero(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import entropy
+        assert entropy(0.0) == 0.0
+
+    def test_certainty_at_one(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import entropy
+        assert entropy(1.0) == 0.0
+
+    def test_symmetry(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import entropy
+        assert entropy(0.3) == pytest.approx(entropy(0.7), abs=1e-9)
+
+    def test_mid_range(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import entropy
+        h = entropy(0.9)
+        assert 0.0 < h < 1.0
+
+    def test_negative_returns_zero(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import entropy
+        assert entropy(-0.5) == 0.0
+
+    def test_above_one_returns_zero(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import entropy
+        assert entropy(1.5) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 2. Bayesian update
+# ---------------------------------------------------------------------------
+
+class TestBayesianUpdate:
+    def test_confirmed_increases_belief(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import bayesian_update
+        posterior = bayesian_update(0.5, 3.0)
+        assert posterior > 0.5
+
+    def test_refuted_decreases_belief(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import bayesian_update
+        posterior = bayesian_update(0.5, 0.33)
+        assert posterior < 0.5
+
+    def test_neutral_preserves_belief(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import bayesian_update
+        posterior = bayesian_update(0.5, 1.0)
+        assert posterior == pytest.approx(0.5, abs=1e-6)
+
+    def test_clamped_to_valid_range(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            bayesian_update, MIN_PRIOR, MAX_PRIOR,
+        )
+        # Extreme confirmation
+        posterior = bayesian_update(0.99, 100.0)
+        assert posterior <= MAX_PRIOR
+        # Extreme refutation
+        posterior = bayesian_update(0.01, 0.01)
+        assert posterior >= MIN_PRIOR
+
+    def test_monotonic_with_confirmed(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import bayesian_update
+        p = 0.5
+        for _ in range(10):
+            new_p = bayesian_update(p, 3.0)
+            assert new_p >= p
+            p = new_p
+
+    def test_monotonic_with_refuted(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import bayesian_update
+        p = 0.5
+        for _ in range(10):
+            new_p = bayesian_update(p, 0.33)
+            assert new_p <= p
+            p = new_p
+
+    def test_idempotent_with_lr_one(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import bayesian_update
+        for prior in [0.1, 0.3, 0.5, 0.7, 0.9]:
+            posterior = bayesian_update(prior, 1.0)
+            assert posterior == pytest.approx(prior, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 3. Epsilon derivation
+# ---------------------------------------------------------------------------
+
+class TestEpsilon:
+    def test_not_hardcoded(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import epsilon_from_prior
+        # Different priors → different epsilons
+        e1 = epsilon_from_prior(0.5)
+        e2 = epsilon_from_prior(0.9)
+        assert e1 != e2
+
+    def test_higher_uncertainty_larger_epsilon(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import epsilon_from_prior
+        e_high = epsilon_from_prior(0.5)
+        e_low = epsilon_from_prior(0.9)
+        assert e_high > e_low
+
+    def test_never_zero(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import epsilon_from_prior
+        # Even at extreme priors, epsilon should be > 0
+        for p in [0.001, 0.01, 0.5, 0.99, 0.999]:
+            assert epsilon_from_prior(p) > 0
+
+    def test_env_ratio_overridable(self, monkeypatch):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import epsilon_from_prior
+        monkeypatch.setenv("JARVIS_EXPLORATION_CONVERGENCE_RATIO", "0.5")
+        e_wide = epsilon_from_prior(0.5)
+        monkeypatch.setenv("JARVIS_EXPLORATION_CONVERGENCE_RATIO", "0.05")
+        e_tight = epsilon_from_prior(0.5)
+        assert e_wide > e_tight
+
+
+# ---------------------------------------------------------------------------
+# 4. Max probes derivation
+# ---------------------------------------------------------------------------
+
+class TestMaxProbes:
+    def test_derived_from_epsilon(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import max_probes_for_epsilon
+        p1 = max_probes_for_epsilon(0.1)
+        p2 = max_probes_for_epsilon(0.01)
+        # Tighter epsilon needs more probes
+        assert p2 > p1
+
+    def test_log_relationship(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import max_probes_for_epsilon
+        # O(log2(1/ε))
+        eps = 0.1
+        expected = math.ceil(math.log2(1.0 / eps))
+        assert max_probes_for_epsilon(eps) == expected
+
+    def test_at_least_one(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import max_probes_for_epsilon
+        assert max_probes_for_epsilon(0.9) >= 1
+
+    def test_bounded_by_max(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            max_probes_for_epsilon, MAX_OBSERVATIONS,
+        )
+        assert max_probes_for_epsilon(1e-100) <= MAX_OBSERVATIONS
+
+
+# ---------------------------------------------------------------------------
+# 5. Cooling factor
+# ---------------------------------------------------------------------------
+
+class TestCooling:
+    def test_max_at_full_uncertainty(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import cooling_factor
+        assert cooling_factor(1.0) == 1.0
+
+    def test_zero_at_convergence(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import cooling_factor
+        assert cooling_factor(0.0) == 0.0
+
+    def test_monotonic_decrease(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import cooling_factor
+        values = [cooling_factor(h) for h in [1.0, 0.8, 0.5, 0.2, 0.0]]
+        for i in range(len(values) - 1):
+            assert values[i] >= values[i + 1]
+
+    def test_clamped(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import cooling_factor
+        assert cooling_factor(2.0) == 1.0
+        assert cooling_factor(-1.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 6. Convergence classification
+# ---------------------------------------------------------------------------
+
+class TestConvergenceClassification:
+    def test_converged_below_epsilon(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            classify_convergence, STATE_CONVERGED,
+        )
+        assert classify_convergence(
+            current_entropy=0.01, previous_entropy=0.1, epsilon=0.05,
+        ) == STATE_CONVERGED
+
+    def test_converging_on_decrease(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            classify_convergence, STATE_CONVERGING,
+        )
+        assert classify_convergence(
+            current_entropy=0.5, previous_entropy=0.8, epsilon=0.01,
+        ) == STATE_CONVERGING
+
+    def test_diverging_on_increase(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            classify_convergence, STATE_DIVERGING,
+        )
+        assert classify_convergence(
+            current_entropy=0.8, previous_entropy=0.5, epsilon=0.01,
+        ) == STATE_DIVERGING
+
+    def test_exploring_on_no_change(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            classify_convergence, STATE_EXPLORING,
+        )
+        assert classify_convergence(
+            current_entropy=0.5, previous_entropy=0.5, epsilon=0.01,
+        ) == STATE_EXPLORING
+
+
+# ---------------------------------------------------------------------------
+# 7. Verdict to likelihood ratio
+# ---------------------------------------------------------------------------
+
+class TestVerdictMapping:
+    def test_confirmed(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import verdict_to_likelihood_ratio
+        lr = verdict_to_likelihood_ratio("CONFIRMED")
+        assert lr > 1.0
+
+    def test_refuted(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import verdict_to_likelihood_ratio
+        lr = verdict_to_likelihood_ratio("REFUTED")
+        assert lr < 1.0
+
+    def test_inconclusive(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import verdict_to_likelihood_ratio
+        lr = verdict_to_likelihood_ratio("INCONCLUSIVE")
+        assert lr == pytest.approx(1.0, abs=0.01)
+
+    def test_case_insensitive(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import verdict_to_likelihood_ratio
+        assert verdict_to_likelihood_ratio("confirmed") == verdict_to_likelihood_ratio("CONFIRMED")
+
+    def test_unknown_maps_to_inconclusive(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import verdict_to_likelihood_ratio
+        lr = verdict_to_likelihood_ratio("UNKNOWN_VERDICT")
+        assert lr == pytest.approx(1.0, abs=0.01)
+
+    def test_env_overridable(self, monkeypatch):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import verdict_to_likelihood_ratio
+        monkeypatch.setenv("JARVIS_EXPLORATION_CONFIRMED_LR", "5.0")
+        assert verdict_to_likelihood_ratio("CONFIRMED") == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# 8. BeliefState lifecycle
+# ---------------------------------------------------------------------------
+
+class TestBeliefLifecycle:
+    def test_initial_belief_defaults(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, STATE_EXPLORING,
+        )
+        bs = initial_belief("h1")
+        assert bs.prior == pytest.approx(0.5)
+        assert bs.posterior == pytest.approx(0.5)
+        assert bs.observations == 0
+        assert bs.convergence_state == STATE_EXPLORING
+
+    def test_update_shifts_posterior(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, update_belief,
+        )
+        bs = initial_belief("h1")
+        bs2 = update_belief(bs, verdict="CONFIRMED")
+        assert bs2.posterior > bs.posterior
+        assert bs2.observations == 1
+
+    def test_convergence_after_many_confirmations(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, update_belief, epsilon_from_prior,
+        )
+        bs = initial_belief("h1")
+        eps = epsilon_from_prior(bs.prior)
+        for _ in range(50):
+            bs = update_belief(bs, verdict="CONFIRMED")
+            if bs.is_converged():
+                break
+        assert bs.is_converged() or bs.entropy < eps
+
+    def test_to_dict_round_trip(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, parse_belief_state,
+        )
+        bs = initial_belief("h1", prior=0.7)
+        d = bs.to_dict()
+        json_str = json.dumps(d)
+        parsed = parse_belief_state(json.loads(json_str))
+        assert parsed is not None
+        assert parsed.hypothesis_id == "h1"
+        assert parsed.prior == pytest.approx(0.7, abs=0.001)
+
+    def test_cost_accumulates(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, update_belief,
+        )
+        bs = initial_belief("h1")
+        bs = update_belief(bs, verdict="CONFIRMED", cost_usd=0.03)
+        bs = update_belief(bs, verdict="CONFIRMED", cost_usd=0.05)
+        assert bs.cost_spent == pytest.approx(0.08)
+
+
+# ---------------------------------------------------------------------------
+# 9. Halting conditions
+# ---------------------------------------------------------------------------
+
+class TestHalting:
+    def test_halt_on_convergence(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, update_belief, epsilon_from_prior, HALT_CONVERGED,
+        )
+        bs = initial_belief("h1")
+        eps = epsilon_from_prior(bs.prior)
+        for _ in range(100):
+            bs = update_belief(bs, verdict="CONFIRMED")
+            if bs.is_halted(eps):
+                break
+        assert bs.halt_reason(eps) == HALT_CONVERGED
+
+    def test_halt_on_budget(self, monkeypatch):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, update_belief, epsilon_from_prior, HALT_BUDGET,
+        )
+        monkeypatch.setenv("JARVIS_EXPLORATION_BUDGET_PER_HYPOTHESIS", "0.10")
+        bs = initial_belief("h1")
+        eps = epsilon_from_prior(bs.prior)
+        # Spend lots via INCONCLUSIVE (doesn't converge belief much)
+        for _ in range(50):
+            bs = update_belief(bs, verdict="INCONCLUSIVE", cost_usd=0.05)
+            if bs.is_halted(eps):
+                break
+        assert bs.halt_reason(eps) == HALT_BUDGET
+
+    def test_halt_on_max_probes(self, monkeypatch):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, update_belief, epsilon_from_prior,
+            max_probes_for_epsilon, HALT_MAX_PROBES, HALT_CONVERGED,
+            HALT_DIMINISHING,
+        )
+        # Use very tight convergence so max probes is small
+        monkeypatch.setenv("JARVIS_EXPLORATION_CONVERGENCE_RATIO", "0.01")
+        monkeypatch.setenv("JARVIS_EXPLORATION_BUDGET_PER_HYPOTHESIS", "999")
+        bs = initial_belief("h1")
+        eps = epsilon_from_prior(bs.prior)
+        max_p = max_probes_for_epsilon(eps)
+        for _ in range(max_p + 10):
+            bs = update_belief(bs, verdict="INCONCLUSIVE")
+            if bs.is_halted(eps):
+                break
+        reason = bs.halt_reason(eps)
+        assert reason in (HALT_MAX_PROBES, HALT_CONVERGED, "diminishing_returns")
+
+    def test_halt_on_diminishing_returns(self, monkeypatch):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, update_belief, epsilon_from_prior, HALT_DIMINISHING,
+        )
+        monkeypatch.setenv("JARVIS_EXPLORATION_DIMINISHING_WINDOW", "2")
+        monkeypatch.setenv("JARVIS_EXPLORATION_BUDGET_PER_HYPOTHESIS", "999")
+        bs = initial_belief("h1")
+        eps = epsilon_from_prior(bs.prior)
+        # Many INCONCLUSIVE probes → minimal entropy change → diminishing
+        for _ in range(50):
+            bs = update_belief(bs, verdict="INCONCLUSIVE")
+            if bs.is_halted(eps):
+                break
+        assert bs.halt_reason(eps) == HALT_DIMINISHING
+
+
+# ---------------------------------------------------------------------------
+# 10. ConvergenceProof
+# ---------------------------------------------------------------------------
+
+class TestConvergenceProof:
+    def test_proof_emitted_on_halt(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, update_belief, epsilon_from_prior,
+            make_convergence_proof,
+        )
+        bs = initial_belief("h1")
+        for _ in range(50):
+            bs = update_belief(bs, verdict="CONFIRMED", cost_usd=0.01)
+        proof = make_convergence_proof(bs)
+        assert proof.halted is True
+        assert proof.halt_reason != ""
+        assert proof.probes_used == bs.observations
+        assert proof.final_belief == bs.posterior
+        assert proof.theoretical_max_probes >= 1
+
+    def test_proof_serializable(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            initial_belief, make_convergence_proof,
+        )
+        bs = initial_belief("h1")
+        proof = make_convergence_proof(bs)
+        d = proof.to_dict()
+        json_str = json.dumps(d)
+        assert isinstance(json_str, str)
+
+
+# ---------------------------------------------------------------------------
+# 11. Master flag
+# ---------------------------------------------------------------------------
+
+class TestMasterFlag:
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+    def test_truthy(self, monkeypatch, val):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import is_calculus_enabled
+        monkeypatch.setenv("JARVIS_EXPLORATION_CALCULUS_ENABLED", val)
+        assert is_calculus_enabled() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_falsy(self, monkeypatch, val):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import is_calculus_enabled
+        monkeypatch.setenv("JARVIS_EXPLORATION_CALCULUS_ENABLED", val)
+        assert is_calculus_enabled() is False
+
+    def test_default_disabled(self, monkeypatch):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import is_calculus_enabled
+        monkeypatch.delenv("JARVIS_EXPLORATION_CALCULUS_ENABLED", raising=False)
+        assert is_calculus_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# 12. Pure function invariants
+# ---------------------------------------------------------------------------
+
+class TestPureFunctions:
+    def test_same_input_same_output(self):
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            bayesian_update, entropy, epsilon_from_prior,
+        )
+        for _ in range(10):
+            assert bayesian_update(0.5, 3.0) == bayesian_update(0.5, 3.0)
+            assert entropy(0.3) == entropy(0.3)
+            assert epsilon_from_prior(0.5) == epsilon_from_prior(0.5)
+
+
+# ---------------------------------------------------------------------------
+# 13. Cage authority invariants
+# ---------------------------------------------------------------------------
+
+class TestCage:
+    _BANNED = frozenset({
+        "orchestrator", "policy", "iron_gate", "risk_tier",
+        "change_engine", "candidate_generator", "gate", "semantic_guardian",
+    })
+
+    def test_no_banned_imports(self):
+        src = Path("backend/core/ouroboros/governance/adaptation/exploration_calculus.py")
+        if not src.exists():
+            pytest.skip("source not found")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                mod = ""
+                if isinstance(node, ast.ImportFrom) and node.module:
+                    mod = node.module
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        mod = alias.name
+                for b in self._BANNED:
+                    assert b not in mod
+
+
+# ---------------------------------------------------------------------------
+# 14. Constants pinned
+# ---------------------------------------------------------------------------
+
+class TestConstants:
+    def test_pinned(self):
+        from backend.core.ouroboros.governance.adaptation import exploration_calculus as mod
+        assert mod.MAX_OBSERVATIONS == 200
+        assert mod.MAX_BELIEF_STATES == 500
+        assert mod.MIN_PRIOR == pytest.approx(0.001)
+        assert mod.MAX_PRIOR == pytest.approx(0.999)


### PR DESCRIPTION
## Summary

**Phase 1 Slice 1.3** — wire the first production decision site (ROUTE phase / `route_assignment`) to the Determinism Substrate via a new `phase_capture` integration helper. ROUTE is the highest-leverage single decision in the pipeline; this slice proves the pattern end-to-end so subsequent slices (1.3.x) can adopt it incrementally for CLASSIFY / GENERATE / GATE without architectural rework.

## Coordination note

This branch contains **bundled work** from a single Antigravity auto-commit `16eacb8236` that grabbed both my Slice 1.3 changes AND a parallel ConvergenceGovernor + ExplorationCalculus contribution (Phase 3 / §24.10 Critical Path #3 prep — *Bounded Curiosity with Provable Termination*).

Files split by namespace:

| Namespace | Owner | Purpose |
|---|---|---|
| `determinism/phase_capture.py` (NEW, 358 lines) | Slice 1.3 (mine) | Production-callsite adapter wrapping Slice 1.2's `decide(...)` |
| `phase_runners/route_runner.py` (+99 lines) | Slice 1.3 (mine) | ROUTE phase wiring + adapter registration |
| `tests/governance/test_determinism_phase_capture.py` (NEW, 624 lines) | Slice 1.3 (mine) | 37 tests, 18 pin sections |
| `adaptation/convergence_governor.py` (NEW, 445 lines) | Antigravity / Phase 3 prep | Formal halting layer |
| `adaptation/exploration_calculus.py` (NEW, 607 lines) | Antigravity / Phase 3 prep | Bayesian belief engine |
| `tests/governance/test_exploration_calculus.py` (NEW, 497 lines) | Antigravity | Test suite |

Different namespaces, no functional overlap. The operator authorized Phase 1 (mine) and §24 work (Antigravity) in parallel — bundling reflects the actual collaboration timeline.

## What Slice 1.3 ships (my contribution)

### `determinism/phase_capture.py`

| Component | Purpose |
|---|---|
| `phase_capture_enabled()` flag | `JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED` (default false). Independent from Slice 1.2's ledger flag — both must be on for capture to engage |
| `OutputAdapter` | Bidirectional serializer (live shape ↔ JSON-friendly storage) per (phase, kind) |
| `register_adapter` / `get_adapter` / `iter_registered` | Dynamic registry — no hardcoded enum |
| `_build_ctx_inputs(ctx)` | Canonical input dict from common ctx fields (signal_urgency, signal_source, task_complexity, target_files SORTED, cross_repo, is_read_only) |
| `capture_phase_decision(...)` | The phase-runner-shaped wrapper around Slice 1.2's `decide()` |

### ROUTE phase wiring

`phase_runners/route_runner.py` line 113-114 — the original direct call:
```python
_provider_route, _route_reason = _urgency_router.classify(ctx)
```

is now wrapped:
```python
async def _classify_route() -> Any:
    return _urgency_router.classify(ctx)

_route_tuple = await capture_phase_decision(
    op_id=ctx.op_id, phase="ROUTE", kind="route_assignment",
    ctx=ctx, compute=_classify_route,
)
_provider_route, _route_reason = _route_tuple
```

with a defensive `try/except` fallback to the direct call if the capture wrapper itself raises.

### Adapter registered at module load

`_register_route_adapter()` runs once on import — converts `(ProviderRoute, reason_str)` ↔ `{"route": str, "reason": str}` so REPLAY returns the same Python tuple shape callers expect.

## Operator's design constraints applied

| Constraint | How |
|---|---|
| **Asynchronous** | All capture goes through async `decide()`; PASSTHROUGH is one env-var check + sync return |
| **Dynamic** | Decision kinds are free-form strings; adapters registered at runtime, no enum |
| **Adaptive** | Master flag has TWO independent gates (capture + ledger); operator can flip independently for granular rollback |
| **Intelligent** | `target_files` sorted in canonical inputs so dict-ordering and list-ordering don't cause hash drift |
| **Robust** | Every public method NEVER raises; ROUTE wiring has explicit fallback to direct call if capture errors |
| **No hardcoding** | No enum of decision kinds; adapters registered per-(phase, kind); env-tunable everything |
| **Leverages existing** | Imports Slice 1.2's `decide()` + Slice 1.1's entropy/clock; uses Antigravity's canonical_serialize transitively. ZERO duplication |

## Authority invariants (pinned by tests)

- `phase_capture.py` NEVER imports `orchestrator` / `phase_runner` (base) / `candidate_generator`
- `route_runner.py` imports `phase_capture` LAZILY (inside function body) so module-level import failures don't break the runner module
- `route_runner.py` imports cleanly even when determinism modules are reloaded
- Adapter registration is idempotent on identical re-registration; logs INFO on adapter replacement

## Test plan

- [x] **37 new tests** covering 18 pin sections
- [x] **615/615 green** across full Phase 12 + 12.2 + 1 regression suite
- [x] Adapter round-trip pinned: `(ProviderRoute.STANDARD, "default cascade") → {"route": "standard", "reason": "default cascade"} → (ProviderRoute.STANDARD, "default cascade")`
- [x] Garbage input handled defensively (non-tuple serialize, non-dict deserialize, invalid route value)
- [x] One pre-existing urgency router test fails (unrelated — `_VALID_SOURCES` schema enforcement on `auto_proposed`/`vision_sensor`); confirmed pre-existing via stash diff

## Roadmap (held — operator-gated)

| Slice | Scope |
|---|---|
| 1.3.x | CLASSIFY phase wiring (`classify_verdict` decision via SemanticTriage) |
| 1.3.y | GENERATE phase wiring (`provider_selection` via CandidateGenerator) |
| 1.3.z | GATE phase wiring (`risk_tier_assignment`) |
| 1.4 | Replay harness CLI flag — `--replay <session-id>` |
| 1.5 | Graduation flip — defaults to true |
| 1.X cleanup | Unify master flags under `JARVIS_DETERMINISM_ENABLED` umbrella |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the ROUTE phase (`route_assignment`) into the Determinism Substrate via `capture_phase_decision` for record/replay/verify with a safe passthrough when disabled. Also bundles the Antigravity `ExplorationCalculus` and `ConvergenceGovernor` to add a Bayesian belief engine and formal halting for curiosity.

- **New Features**
  - Determinism phase capture: adds `determinism/phase_capture.py` with `capture_phase_decision`, `OutputAdapter` registry, and ctx input canonicalization. Independent flag `JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED`; returns original output shapes via adapter; degrades to direct compute if capture or ledger is off.
  - ROUTE wiring: wraps `_urgency_router.classify(ctx)` in `route_runner.py` and registers a module-load adapter mapping `(ProviderRoute, reason)` ↔ `{"route": str, "reason": str}`; lazy import with fallback to the direct call.
  - Antigravity: `adaptation/exploration_calculus.py` (entropy, Bayesian update, epsilon, cooling; pure functions) and `adaptation/convergence_governor.py` (tracks hypotheses; halts on convergence/budget/max-probes/diminishing returns; JSONL persistence; global cooling signal). Flags `JARVIS_EXPLORATION_CALCULUS_ENABLED` and `JARVIS_CONVERGENCE_GOVERNOR_ENABLED`. New tests cover adapters, ROUTE wiring, and calculus.

- **Migration**
  - To capture ROUTE: set `JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED=true` and `JARVIS_DETERMINISM_LEDGER_ENABLED=true`. Otherwise behavior is unchanged.
  - To add more phases: register an adapter with `register_adapter(phase, kind, adapter)` and wrap the call with `capture_phase_decision(...)`.
  - To enable curiosity halting: set `JARVIS_EXPLORATION_CALCULUS_ENABLED=true` and `JARVIS_CONVERGENCE_GOVERNOR_ENABLED=true` (optional paths via `JARVIS_CONVERGENCE_GOVERNOR_PATH` / `JARVIS_CONVERGENCE_PROOFS_PATH`).

<sup>Written for commit 16eacb82361229a9afb11c2af339a09e68da2ba4. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29074?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

