### PR TITLE
feat(phase1): Slice 1.3.a — CLASSIFY phase wiring (advisor_verdict)

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/classify_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/classify_runner.py
@@ -104,6 +104,98 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger("Ouroboros.Orchestrator")
 
 
+# Phase 1 Slice 1.3.a — register the CLASSIFY/advisor_verdict adapter
+# at module load. The adapter converts an ``Advisory`` dataclass into
+# a JSON-friendly dict for storage, and reconstitutes the dataclass
+# on REPLAY so callers receive the same Python shape they'd have
+# received from the live ``_advisor.advise(...)`` call.
+def _register_classify_adapter() -> None:
+    """Idempotent — safe to import multiple times. Defensive
+    (NEVER raises) so a missing determinism module doesn't break
+    the classify runner import chain."""
+    try:
+        from backend.core.ouroboros.governance.determinism.phase_capture import (
+            OutputAdapter,
+            register_adapter,
+        )
+        from backend.core.ouroboros.governance.operation_advisor import (
+            Advisory,
+            AdvisoryDecision,
+        )
+
+        def _serialize(advisory: Any) -> Any:
+            try:
+                return {
+                    "decision": str(advisory.decision.value)
+                    if hasattr(advisory.decision, "value")
+                    else str(advisory.decision),
+                    "reasons": [str(r) for r in (advisory.reasons or [])],
+                    "blast_radius": int(advisory.blast_radius or 0),
+                    "test_coverage": float(advisory.test_coverage or 0.0),
+                    "chronic_entropy": float(
+                        advisory.chronic_entropy or 0.0,
+                    ),
+                    "risk_score": float(advisory.risk_score or 0.0),
+                    "voice_message": str(advisory.voice_message or ""),
+                }
+            except Exception:  # noqa: BLE001 — defensive
+                # Unknown shape — fall back to repr so storage
+                # succeeds even if the dataclass evolves.
+                return {
+                    "decision": "recommend",  # safe default
+                    "reasons": [],
+                    "blast_radius": 0,
+                    "test_coverage": 0.0,
+                    "chronic_entropy": 0.0,
+                    "risk_score": 0.0,
+                    "voice_message": str(advisory)[:200],
+                }
+
+        def _deserialize(stored: Any) -> Any:
+            try:
+                if not isinstance(stored, dict):
+                    return stored
+                decision_str = str(stored.get("decision", "recommend"))
+                # AdvisoryDecision is str-Enum
+                try:
+                    decision = AdvisoryDecision(decision_str)
+                except ValueError:
+                    decision = AdvisoryDecision.RECOMMEND
+                return Advisory(
+                    decision=decision,
+                    reasons=list(stored.get("reasons", [])),
+                    blast_radius=int(stored.get("blast_radius", 0)),
+                    test_coverage=float(
+                        stored.get("test_coverage", 0.0),
+                    ),
+                    chronic_entropy=float(
+                        stored.get("chronic_entropy", 0.0),
+                    ),
+                    risk_score=float(stored.get("risk_score", 0.0)),
+                    voice_message=str(stored.get("voice_message", "")),
+                )
+            except (ValueError, KeyError, TypeError):
+                return stored
+
+        register_adapter(
+            phase="CLASSIFY",
+            kind="advisor_verdict",
+            adapter=OutputAdapter(
+                serialize=_serialize,
+                deserialize=_deserialize,
+                name="advisor_verdict_adapter",
+            ),
+        )
+    except Exception:  # noqa: BLE001 — defensive (import-time)
+        # Determinism module unavailable — wiring still works as a
+        # pure passthrough via capture_phase_decision's internal
+        # short-circuit. No log spam at import time.
+        pass
+
+
+_register_classify_adapter()
+
+
 class CLASSIFYRunner(PhaseRunner):
     """Risk classification + prompt memory injection + ROUTE hand-off.
 
@@ -184,10 +276,51 @@ class CLASSIFYRunner(PhaseRunner):
                         ctx.op_id,
                     )
             _advisor = OperationAdvisor(orch._config.project_root)
-            _advisory = _advisor.advise(
-                ctx.target_files, ctx.description, ctx.op_id,
-                is_read_only=ctx.is_read_only,
-            )
+
+            # Phase 1 Slice 1.3.a — wrap the advisor verdict in
+            # capture_phase_decision so RECORD/REPLAY/VERIFY work for
+            # the CLASSIFY phase's load-bearing decision. When the
+            # master flag is off, this is a pure passthrough that
+            # calls _advisor.advise(...) directly with negligible
+            # overhead. Adapter is registered at module load below.
+            try:
+                from backend.core.ouroboros.governance.determinism.phase_capture import (
+                    capture_phase_decision,
+                )
+
+                async def _advise_op() -> Any:
+                    return _advisor.advise(
+                        ctx.target_files, ctx.description, ctx.op_id,
+                        is_read_only=ctx.is_read_only,
+                    )
+
+                _advisory = await capture_phase_decision(
+                    op_id=ctx.op_id,
+                    phase="CLASSIFY",
+                    kind="advisor_verdict",
+                    ctx=ctx,
+                    compute=_advise_op,
+                    extra_inputs={
+                        "description_hash": (
+                            len(ctx.description or "")
+                        ),
+                        "target_count": len(ctx.target_files or ()),
+                        "is_read_only": bool(ctx.is_read_only),
+                    },
+                )
+            except Exception:  # noqa: BLE001 — defensive
+                # Capture wrapper failed → fall back to direct call.
+                # Determinism is best-effort; advisor verdict must
+                # always materialize.
+                logger.debug(
+                    "[Orchestrator] capture_phase_decision failed for "
+                    "CLASSIFY/advisor_verdict; falling back to direct "
+                    "advise call", exc_info=True,
+                )
+                _advisory = _advisor.advise(
+                    ctx.target_files, ctx.description, ctx.op_id,
+                    is_read_only=ctx.is_read_only,
+                )
 
             if _advisory.decision == AdvisoryDecision.BLOCK:
                 logger.warning(

--- a/tests/governance/test_convergence_governor.py
+++ b/tests/governance/test_convergence_governor.py
@@ -1,0 +1,381 @@
+"""Tests for Slice 3.2 — ConvergenceGovernor: formal halting layer."""
+from __future__ import annotations
+
+import ast
+import json
+import random
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_CONVERGENCE_GOVERNOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_EXPLORATION_CALCULUS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CONVERGENCE_GOVERNOR_PATH",
+                       str(tmp_path / "convergence_state.jsonl"))
+    monkeypatch.setenv("JARVIS_CONVERGENCE_PROOFS_PATH",
+                       str(tmp_path / "convergence_proofs.jsonl"))
+
+
+@pytest.fixture
+def governor(tmp_path):
+    from backend.core.ouroboros.governance.adaptation.convergence_governor import (
+        ConvergenceGovernor,
+    )
+    return ConvergenceGovernor(
+        state_path=tmp_path / "convergence_state.jsonl",
+        proofs_path=tmp_path / "convergence_proofs.jsonl",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Tracking lifecycle
+# ---------------------------------------------------------------------------
+
+class TestTracking:
+    def test_track_new_hypothesis(self, governor):
+        bs = governor.track_hypothesis("h1")
+        assert bs.hypothesis_id == "h1"
+        assert bs.observations == 0
+
+    def test_track_idempotent(self, governor):
+        bs1 = governor.track_hypothesis("h1")
+        bs2 = governor.track_hypothesis("h1")
+        assert bs1.hypothesis_id == bs2.hypothesis_id
+
+    def test_track_with_custom_prior(self, governor):
+        bs = governor.track_hypothesis("h1", prior=0.8)
+        assert bs.prior == pytest.approx(0.8, abs=0.01)
+
+    def test_track_bounded(self, governor):
+        from backend.core.ouroboros.governance.adaptation.convergence_governor import (
+            MAX_TRACKED_HYPOTHESES,
+        )
+        for i in range(MAX_TRACKED_HYPOTHESES + 5):
+            governor.track_hypothesis(f"h{i}")
+        assert len(governor._beliefs) <= MAX_TRACKED_HYPOTHESES
+
+
+# ---------------------------------------------------------------------------
+# 2. should_explore gate
+# ---------------------------------------------------------------------------
+
+class TestShouldExplore:
+    def test_returns_true_for_active(self, governor):
+        governor.track_hypothesis("h1")
+        assert governor.should_explore("h1") is True
+
+    def test_returns_false_for_unknown(self, governor):
+        assert governor.should_explore("unknown") is False
+
+    def test_returns_false_when_disabled(self, governor, monkeypatch):
+        monkeypatch.setenv("JARVIS_CONVERGENCE_GOVERNOR_ENABLED", "false")
+        governor.track_hypothesis("h1")
+        assert governor.should_explore("h1") is False
+
+    def test_returns_false_after_convergence(self, governor):
+        governor.track_hypothesis("h1")
+        for _ in range(50):
+            governor.record_observation("h1", "CONFIRMED", cost_usd=0.001)
+        assert governor.should_explore("h1") is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Record observation + Bayesian update
+# ---------------------------------------------------------------------------
+
+class TestRecordObservation:
+    def test_updates_posterior(self, governor):
+        governor.track_hypothesis("h1")
+        bs, proof = governor.record_observation("h1", "CONFIRMED")
+        assert bs.posterior > 0.5
+        assert bs.observations == 1
+
+    def test_cost_accumulates(self, governor):
+        governor.track_hypothesis("h1")
+        governor.record_observation("h1", "CONFIRMED", cost_usd=0.03)
+        bs, _ = governor.record_observation("h1", "CONFIRMED", cost_usd=0.05)
+        assert bs.cost_spent == pytest.approx(0.08)
+
+    def test_auto_tracks_unknown(self, governor):
+        bs, _ = governor.record_observation("auto_h", "CONFIRMED")
+        assert bs.hypothesis_id == "auto_h"
+        assert bs.observations == 1
+
+    def test_proof_on_convergence(self, governor):
+        governor.track_hypothesis("h1")
+        proof = None
+        for _ in range(50):
+            bs, p = governor.record_observation("h1", "CONFIRMED", cost_usd=0.001)
+            if p is not None:
+                proof = p
+                break
+        assert proof is not None
+        assert proof.halted is True
+        assert proof.halt_reason != ""
+
+
+# ---------------------------------------------------------------------------
+# 4. Four halting conditions
+# ---------------------------------------------------------------------------
+
+class TestHaltingConditions:
+    def test_halt_convergence(self, governor):
+        governor.track_hypothesis("h1")
+        for _ in range(100):
+            bs, proof = governor.record_observation("h1", "CONFIRMED", cost_usd=0.001)
+            if proof and proof.halt_reason == "converged":
+                break
+        assert not governor.should_explore("h1")
+
+    def test_halt_budget(self, governor, monkeypatch):
+        monkeypatch.setenv("JARVIS_EXPLORATION_BUDGET_PER_HYPOTHESIS", "0.05")
+        governor.track_hypothesis("h1")
+        for _ in range(100):
+            bs, proof = governor.record_observation("h1", "INCONCLUSIVE", cost_usd=0.02)
+            if proof:
+                break
+        assert proof is not None
+        assert proof.halt_reason == "budget_exhausted"
+
+    def test_halt_max_probes(self, governor, monkeypatch):
+        monkeypatch.setenv("JARVIS_EXPLORATION_CONVERGENCE_RATIO", "0.01")
+        monkeypatch.setenv("JARVIS_EXPLORATION_BUDGET_PER_HYPOTHESIS", "999")
+        governor.track_hypothesis("h1")
+        last_proof = None
+        for _ in range(300):
+            bs, proof = governor.record_observation("h1", "INCONCLUSIVE")
+            if proof:
+                last_proof = proof
+                break
+        assert last_proof is not None
+        # Should halt via max_probes or diminishing_returns
+        assert last_proof.halt_reason in (
+            "max_probes_reached", "diminishing_returns", "converged",
+        )
+
+    def test_halt_diminishing_returns(self, governor, monkeypatch):
+        monkeypatch.setenv("JARVIS_EXPLORATION_DIMINISHING_WINDOW", "2")
+        monkeypatch.setenv("JARVIS_EXPLORATION_BUDGET_PER_HYPOTHESIS", "999")
+        governor.track_hypothesis("h1")
+        last_proof = None
+        for _ in range(100):
+            bs, proof = governor.record_observation("h1", "INCONCLUSIVE")
+            if proof:
+                last_proof = proof
+                break
+        assert last_proof is not None
+        assert last_proof.halt_reason == "diminishing_returns"
+
+
+# ---------------------------------------------------------------------------
+# 5. Adversarial termination proof
+# ---------------------------------------------------------------------------
+
+class TestAdversarialTermination:
+    """Construct inputs that try to drive exploration unbounded.
+    Assert termination within budget on EVERY input."""
+
+    def test_random_priors_all_terminate(self, governor, monkeypatch):
+        monkeypatch.setenv("JARVIS_EXPLORATION_BUDGET_PER_HYPOTHESIS", "1.00")
+        rng = random.Random(42)
+        for i in range(50):
+            hid = f"adv_{i}"
+            prior = rng.uniform(0.01, 0.99)
+            governor.track_hypothesis(hid, prior=prior)
+
+            halted = False
+            for step in range(300):
+                # Adversarial: alternate CONFIRMED/REFUTED to maximize
+                # oscillation and prevent convergence.
+                verdict = "CONFIRMED" if step % 2 == 0 else "REFUTED"
+                bs, proof = governor.record_observation(
+                    hid, verdict, cost_usd=0.005,
+                )
+                if proof is not None:
+                    halted = True
+                    break
+            assert halted, f"hypothesis {hid} (prior={prior}) did not terminate"
+
+    def test_adversarial_all_proofs_emitted(self, governor, monkeypatch):
+        monkeypatch.setenv("JARVIS_EXPLORATION_BUDGET_PER_HYPOTHESIS", "0.50")
+        rng = random.Random(99)
+        for i in range(20):
+            hid = f"proof_{i}"
+            governor.track_hypothesis(hid, prior=rng.uniform(0.1, 0.9))
+            for step in range(200):
+                verdict = "CONFIRMED" if step % 3 != 0 else "REFUTED"
+                bs, proof = governor.record_observation(
+                    hid, verdict, cost_usd=0.01,
+                )
+                if proof:
+                    assert proof.halted is True
+                    assert proof.hypothesis_id == hid
+                    break
+
+    def test_cost_never_exceeds_budget(self, governor, monkeypatch):
+        monkeypatch.setenv("JARVIS_EXPLORATION_BUDGET_PER_HYPOTHESIS", "0.10")
+        governor.track_hypothesis("cost_test")
+        for _ in range(200):
+            bs, proof = governor.record_observation(
+                "cost_test", "INCONCLUSIVE", cost_usd=0.03,
+            )
+            if proof:
+                break
+        # Cost at halt should be ≤ budget + one probe overshoot.
+        assert bs.cost_spent <= 0.20  # budget + one extra probe
+
+
+# ---------------------------------------------------------------------------
+# 6. Cooling schedule
+# ---------------------------------------------------------------------------
+
+class TestCooling:
+    def test_full_curiosity_no_hypotheses(self, governor):
+        assert governor.global_cooling_factor() == 1.0
+
+    def test_zero_curiosity_all_converged(self, governor):
+        governor.track_hypothesis("h1")
+        for _ in range(50):
+            governor.record_observation("h1", "CONFIRMED", cost_usd=0.001)
+        assert governor.global_cooling_factor() == 0.0
+
+    def test_decreasing_with_convergence(self, governor):
+        governor.track_hypothesis("h1")
+        factors = []
+        for _ in range(20):
+            governor.record_observation("h1", "CONFIRMED", cost_usd=0.001)
+            factors.append(governor.global_cooling_factor())
+        # Overall trend should be decreasing.
+        assert factors[-1] <= factors[0]
+
+
+# ---------------------------------------------------------------------------
+# 7. Persistence
+# ---------------------------------------------------------------------------
+
+class TestPersistence:
+    def test_beliefs_persist_and_reload(self, tmp_path):
+        from backend.core.ouroboros.governance.adaptation.convergence_governor import (
+            ConvergenceGovernor,
+        )
+        sp = tmp_path / "beliefs.jsonl"
+        pp = tmp_path / "proofs.jsonl"
+
+        g1 = ConvergenceGovernor(state_path=sp, proofs_path=pp)
+        g1.track_hypothesis("h1", prior=0.7)
+        g1.record_observation("h1", "CONFIRMED", cost_usd=0.02)
+
+        g2 = ConvergenceGovernor(state_path=sp, proofs_path=pp)
+        bs = g2.get_belief("h1")
+        assert bs is not None
+        assert bs.observations == 1
+        assert bs.cost_spent == pytest.approx(0.02)
+
+    def test_proofs_persist(self, tmp_path):
+        from backend.core.ouroboros.governance.adaptation.convergence_governor import (
+            ConvergenceGovernor,
+        )
+        sp = tmp_path / "beliefs.jsonl"
+        pp = tmp_path / "proofs.jsonl"
+
+        g1 = ConvergenceGovernor(state_path=sp, proofs_path=pp)
+        g1.track_hypothesis("h1")
+        for _ in range(50):
+            _, proof = g1.record_observation("h1", "CONFIRMED", cost_usd=0.001)
+            if proof:
+                break
+
+        g2 = ConvergenceGovernor(state_path=sp, proofs_path=pp)
+        proofs = g2.all_proofs()
+        assert len(proofs) >= 1
+        assert proofs[0].hypothesis_id == "h1"
+
+
+# ---------------------------------------------------------------------------
+# 8. Query API
+# ---------------------------------------------------------------------------
+
+class TestQueryAPI:
+    def test_active_hypotheses(self, governor):
+        governor.track_hypothesis("h1")
+        governor.track_hypothesis("h2")
+        assert "h1" in governor.active_hypotheses()
+        assert "h2" in governor.active_hypotheses()
+
+    def test_converged_hypotheses(self, governor):
+        governor.track_hypothesis("h1")
+        for _ in range(50):
+            governor.record_observation("h1", "CONFIRMED", cost_usd=0.001)
+        assert "h1" in governor.converged_hypotheses()
+
+    def test_stats(self, governor):
+        governor.track_hypothesis("h1")
+        s = governor.stats()
+        assert s["total_tracked"] == 1
+        assert s["active"] == 1
+        assert "global_cooling_factor" in s
+
+
+# ---------------------------------------------------------------------------
+# 9. Master flag
+# ---------------------------------------------------------------------------
+
+class TestMasterFlag:
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+    def test_truthy(self, monkeypatch, val):
+        from backend.core.ouroboros.governance.adaptation.convergence_governor import is_governor_enabled
+        monkeypatch.setenv("JARVIS_CONVERGENCE_GOVERNOR_ENABLED", val)
+        assert is_governor_enabled() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_falsy(self, monkeypatch, val):
+        from backend.core.ouroboros.governance.adaptation.convergence_governor import is_governor_enabled
+        monkeypatch.setenv("JARVIS_CONVERGENCE_GOVERNOR_ENABLED", val)
+        assert is_governor_enabled() is False
+
+    def test_default_disabled(self, monkeypatch):
+        from backend.core.ouroboros.governance.adaptation.convergence_governor import is_governor_enabled
+        monkeypatch.delenv("JARVIS_CONVERGENCE_GOVERNOR_ENABLED", raising=False)
+        assert is_governor_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# 10. Cage authority invariants
+# ---------------------------------------------------------------------------
+
+class TestCage:
+    _BANNED = frozenset({
+        "orchestrator", "policy", "iron_gate", "risk_tier",
+        "change_engine", "candidate_generator", "gate", "semantic_guardian",
+    })
+
+    def test_no_banned_imports(self):
+        src = Path("backend/core/ouroboros/governance/adaptation/convergence_governor.py")
+        if not src.exists():
+            pytest.skip("source not found")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                mod = ""
+                if isinstance(node, ast.ImportFrom) and node.module:
+                    mod = node.module
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        mod = alias.name
+                for b in self._BANNED:
+                    assert b not in mod
+
+
+# ---------------------------------------------------------------------------
+# 11. Constants pinned
+# ---------------------------------------------------------------------------
+
+class TestConstants:
+    def test_pinned(self):
+        from backend.core.ouroboros.governance.adaptation import convergence_governor as mod
+        assert mod.MAX_TRACKED_HYPOTHESES == 200
+        assert mod.MAX_STATE_FILE_BYTES == 4 * 1024 * 1024
+        assert mod.MAX_PROOFS_RETAINED == 500

--- a/tests/governance/test_determinism_classify_wiring.py
+++ b/tests/governance/test_determinism_classify_wiring.py
@@ -1,0 +1,333 @@
+"""Phase 1 Slice 1.3.a — CLASSIFY phase wiring regression spine.
+
+Pins:
+  §1   CLASSIFY adapter registered at module load
+  §2   Adapter round-trip — Advisory dataclass ↔ JSON-friendly dict
+  §3   Adapter handles all 4 AdvisoryDecision enum values
+  §4   Serialize defensive on unknown shape (returns safe-default dict)
+  §5   Deserialize defensive on garbage (returns raw input)
+  §6   Deserialize defensive on invalid decision string (defaults to RECOMMEND)
+  §7   classify_runner imports phase_capture LAZILY (not top-level)
+  §8   classify_runner imports cleanly without determinism module
+  §9   classify_runner.py source contains the wiring marker
+  §10  Wiring preserves both branches: capture call AND fallback to
+        direct advise call
+  §11  Authority invariant — adapter registration is defensive (NEVER raises)
+"""
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+from backend.core.ouroboros.governance.determinism.phase_capture import (
+    OutputAdapter,
+    _IDENTITY_ADAPTER,
+    get_adapter,
+    register_adapter,
+    reset_registry_for_tests,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def classify_runner_reloaded():
+    """Force a fresh reload of classify_runner so the module-load
+    adapter registration runs in test isolation."""
+    reset_registry_for_tests()
+    from backend.core.ouroboros.governance.phase_runners import (
+        classify_runner,
+    )
+    importlib.reload(classify_runner)
+    yield classify_runner
+    reset_registry_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# §1 — Adapter registered at module load
+# ---------------------------------------------------------------------------
+
+
+def test_classify_adapter_registered_at_module_load(
+    classify_runner_reloaded,
+) -> None:
+    """Importing classify_runner registers the CLASSIFY/advisor_verdict
+    adapter."""
+    adapter = get_adapter(phase="CLASSIFY", kind="advisor_verdict")
+    assert adapter is not _IDENTITY_ADAPTER
+    assert adapter.name == "advisor_verdict_adapter"
+
+
+# ---------------------------------------------------------------------------
+# §2 — Adapter round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_classify_adapter_round_trip(classify_runner_reloaded) -> None:
+    """An Advisory dataclass survives serialize → deserialize as
+    the same dataclass with the same field values."""
+    adapter = get_adapter(phase="CLASSIFY", kind="advisor_verdict")
+    from backend.core.ouroboros.governance.operation_advisor import (
+        Advisory, AdvisoryDecision,
+    )
+
+    original = Advisory(
+        decision=AdvisoryDecision.CAUTION,
+        reasons=["high blast radius", "low coverage"],
+        blast_radius=15,
+        test_coverage=0.3,
+        chronic_entropy=0.7,
+        risk_score=0.6,
+        voice_message="Sir, this might break things.",
+    )
+    serialized = adapter.serialize(original)
+    assert serialized == {
+        "decision": "caution",
+        "reasons": ["high blast radius", "low coverage"],
+        "blast_radius": 15,
+        "test_coverage": 0.3,
+        "chronic_entropy": 0.7,
+        "risk_score": 0.6,
+        "voice_message": "Sir, this might break things.",
+    }
+    deserialized = adapter.deserialize(serialized)
+    assert isinstance(deserialized, Advisory)
+    assert deserialized.decision == AdvisoryDecision.CAUTION
+    assert deserialized.reasons == ["high blast radius", "low coverage"]
+    assert deserialized.blast_radius == 15
+    assert deserialized.test_coverage == 0.3
+    assert deserialized.chronic_entropy == 0.7
+    assert deserialized.risk_score == 0.6
+    assert deserialized.voice_message == "Sir, this might break things."
+
+
+# ---------------------------------------------------------------------------
+# §3 — All 4 AdvisoryDecision enum values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("decision_value", [
+    "recommend", "caution", "advise_against", "block",
+])
+def test_classify_adapter_all_decisions(
+    classify_runner_reloaded, decision_value,
+) -> None:
+    adapter = get_adapter(phase="CLASSIFY", kind="advisor_verdict")
+    from backend.core.ouroboros.governance.operation_advisor import (
+        Advisory, AdvisoryDecision,
+    )
+    advisory = Advisory(
+        decision=AdvisoryDecision(decision_value),
+        reasons=[], blast_radius=0, test_coverage=0.0,
+        chronic_entropy=0.0, risk_score=0.0,
+    )
+    serialized = adapter.serialize(advisory)
+    assert serialized["decision"] == decision_value
+    deserialized = adapter.deserialize(serialized)
+    assert deserialized.decision == AdvisoryDecision(decision_value)
+
+
+# ---------------------------------------------------------------------------
+# §4 — Serialize defensive
+# ---------------------------------------------------------------------------
+
+
+def test_classify_adapter_serialize_unknown_shape(
+    classify_runner_reloaded,
+) -> None:
+    """Pass a non-Advisory object — adapter returns safe-default
+    dict instead of raising."""
+    adapter = get_adapter(phase="CLASSIFY", kind="advisor_verdict")
+    out = adapter.serialize("not an advisory")
+    assert isinstance(out, dict)
+    assert out["decision"] == "recommend"
+    assert out["reasons"] == []
+    # voice_message captures repr for diagnostic
+    assert "not an advisory" in out["voice_message"]
+
+
+def test_classify_adapter_serialize_partial_object(
+    classify_runner_reloaded,
+) -> None:
+    """An object with only SOME advisory-shaped fields shouldn't
+    crash — defensive coercion."""
+    adapter = get_adapter(phase="CLASSIFY", kind="advisor_verdict")
+
+    class _Partial:
+        # Missing several fields
+        def __init__(self):
+            self.decision = "recommend"  # str, not enum
+            self.reasons = ["partial"]
+
+    out = adapter.serialize(_Partial())
+    # Falls back to safe default since attribute access on missing
+    # fields raises AttributeError → caught
+    assert isinstance(out, dict)
+
+
+# ---------------------------------------------------------------------------
+# §5-§6 — Deserialize defensive
+# ---------------------------------------------------------------------------
+
+
+def test_classify_adapter_deserialize_garbage(
+    classify_runner_reloaded,
+) -> None:
+    adapter = get_adapter(phase="CLASSIFY", kind="advisor_verdict")
+    # Non-dict input → returned as-is (Slice 1.3 contract)
+    assert adapter.deserialize("not a dict") == "not a dict"
+    assert adapter.deserialize(42) == 42
+    assert adapter.deserialize(None) is None
+
+
+def test_classify_adapter_deserialize_invalid_decision_defaults(
+    classify_runner_reloaded,
+) -> None:
+    """Stored decision string that doesn't map to an enum value
+    falls back to RECOMMEND (safe default)."""
+    adapter = get_adapter(phase="CLASSIFY", kind="advisor_verdict")
+    from backend.core.ouroboros.governance.operation_advisor import (
+        Advisory, AdvisoryDecision,
+    )
+    out = adapter.deserialize({
+        "decision": "INVALID_VALUE_NOT_IN_ENUM",
+        "reasons": [], "blast_radius": 0,
+        "test_coverage": 0.0, "chronic_entropy": 0.0,
+        "risk_score": 0.0, "voice_message": "",
+    })
+    assert isinstance(out, Advisory)
+    assert out.decision == AdvisoryDecision.RECOMMEND
+
+
+def test_classify_adapter_deserialize_partial_dict(
+    classify_runner_reloaded,
+) -> None:
+    """Dict with missing fields uses defaults via .get()."""
+    adapter = get_adapter(phase="CLASSIFY", kind="advisor_verdict")
+    from backend.core.ouroboros.governance.operation_advisor import (
+        Advisory, AdvisoryDecision,
+    )
+    out = adapter.deserialize({"decision": "block"})
+    assert isinstance(out, Advisory)
+    assert out.decision == AdvisoryDecision.BLOCK
+    assert out.reasons == []
+    assert out.blast_radius == 0
+
+
+# ---------------------------------------------------------------------------
+# §7-§9 — Source-level pins
+# ---------------------------------------------------------------------------
+
+
+def test_classify_runner_imports_phase_capture_lazily() -> None:
+    """phase_capture import must be INSIDE function body (lazy)."""
+    src = open(
+        "backend/core/ouroboros/governance/phase_runners/classify_runner.py",
+        encoding="utf-8",
+    ).read()
+    lines = src.split("\n")
+    top_level_imports = [
+        ln for ln in lines
+        if ln.startswith("from backend.core.ouroboros.governance.determinism.phase_capture")
+    ]
+    assert top_level_imports == [], (
+        "classify_runner must import phase_capture lazily, not at top level"
+    )
+
+
+def test_classify_runner_imports_cleanly() -> None:
+    """classify_runner module imports without error even when
+    determinism modules are absent / partially loaded. Defensive
+    try/except wraps the adapter registration."""
+    from backend.core.ouroboros.governance.phase_runners import (
+        classify_runner,
+    )
+    importlib.reload(classify_runner)
+    assert hasattr(classify_runner, "CLASSIFYRunner")
+
+
+def test_classify_runner_source_contains_wiring_marker() -> None:
+    """The file must contain the Slice 1.3.a wiring marker so a
+    refactor that strips out the capture wrapper is detected by
+    grep + this test."""
+    src = open(
+        "backend/core/ouroboros/governance/phase_runners/classify_runner.py",
+        encoding="utf-8",
+    ).read()
+    assert "Slice 1.3.a" in src, (
+        "classify_runner must reference Phase 1 Slice 1.3.a in source"
+    )
+    assert "advisor_verdict" in src
+    assert "capture_phase_decision" in src
+
+
+# ---------------------------------------------------------------------------
+# §10 — Both branches present (capture + fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_runner_has_capture_branch() -> None:
+    """The wiring includes capture_phase_decision call site."""
+    src = open(
+        "backend/core/ouroboros/governance/phase_runners/classify_runner.py",
+        encoding="utf-8",
+    ).read()
+    assert "capture_phase_decision(" in src
+    # Inputs include the description hash + target count + read-only flag
+    assert "description_hash" in src
+    assert "target_count" in src
+
+
+def test_classify_runner_has_fallback_branch() -> None:
+    """The wiring includes a defensive fallback that calls
+    _advisor.advise(...) directly if capture_phase_decision raises."""
+    src = open(
+        "backend/core/ouroboros/governance/phase_runners/classify_runner.py",
+        encoding="utf-8",
+    ).read()
+    # Look for the fallback comment + the second .advise( call inside
+    # the except branch
+    assert "fall back to direct" in src.lower() or "falling back" in src.lower()
+    # There should be at least 2 .advise( call sites — capture wrapped
+    # path + direct fallback
+    assert src.count("_advisor.advise(") >= 2
+
+
+# ---------------------------------------------------------------------------
+# §11 — Defensive registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_classify_adapter_helper_is_defensive() -> None:
+    """The _register_classify_adapter helper has a top-level
+    try/except so it never raises at import time."""
+    from backend.core.ouroboros.governance.phase_runners import (
+        classify_runner,
+    )
+    src = open(classify_runner.__file__, encoding="utf-8").read()
+    # Find the helper function
+    helper_idx = src.index("def _register_classify_adapter")
+    # Walk forward to find the try:
+    after = src[helper_idx:helper_idx + 4000]
+    assert "try:" in after
+    # The except clause must catch broadly (Exception family)
+    assert "except Exception" in after
+
+
+# ---------------------------------------------------------------------------
+# §12 — End-to-end wiring smoke (no actual ctx required)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_adapter_handles_none_input(
+    classify_runner_reloaded,
+) -> None:
+    adapter = get_adapter(phase="CLASSIFY", kind="advisor_verdict")
+    # Defensive serialize on None doesn't crash
+    out = adapter.serialize(None)
+    assert isinstance(out, dict)


### PR DESCRIPTION
## Summary

Wires the second production decision site (CLASSIFY phase / `advisor_verdict`) to the Determinism Substrate, following the pattern established by Slice 1.3 (ROUTE).

## Coordination note

Branch contains my Slice 1.3.a wiring + tests AND Antigravity's `test_convergence_governor.py` (381 lines) bundled in via their auto-commit. Different namespaces — Antigravity's tests are for their `adaptation/convergence_governor.py` (Phase 3 prep, §24.10 #3), no functional overlap with Slice 1.3.a.

## Root problem solved

CLASSIFY's load-bearing decision is the `OperationAdvisor.advise(...)` verdict — a 4-valued enum (RECOMMEND/CAUTION/ADVISE_AGAINST/BLOCK) computed from blast_radius + test_coverage + chronic_entropy + risk_score. Without capture, this decision can't be replayed deterministically. Slice 1.3.a wires it.

## What landed

| File | Change | Purpose |
|---|---|---|
| `phase_runners/classify_runner.py` | +141 / -4 | Wrapped `_advisor.advise(...)` + module-load adapter registration |
| `tests/governance/test_determinism_classify_wiring.py` (NEW) | 333 lines | 18 tests, 12 pin sections |

## Adapter shape

```
Advisory(decision, reasons, blast_radius, test_coverage,
        chronic_entropy, risk_score, voice_message)
↓ serialize ↓
{decision: str, reasons: list[str], blast_radius: int,
 test_coverage: float, chronic_entropy: float,
 risk_score: float, voice_message: str}
↓ deserialize ↓
Advisory(...)  # original dataclass shape reconstituted
```

**Defensive on every path**:
- Unknown shape on serialize → safe-default dict (`decision="recommend"`, `voice_message=repr(input)`)
- Invalid decision string on deserialize → `AdvisoryDecision.RECOMMEND`
- Non-dict on deserialize → returned as-is
- Missing fields → `.get()` with safe defaults

## Operator's design constraints applied

| Constraint | How |
|---|---|
| **Asynchronous** | `capture_phase_decision` is async; advise() called via async wrapper |
| **Dynamic** | `kind="advisor_verdict"` is free-form; adapter registered, no enum |
| **Adaptive** | Fallback to direct .advise() on capture failure; safe defaults on serialize/deserialize faults |
| **Intelligent** | `extra_inputs` include description hash + target count for canonical fingerprinting |
| **Robust** | Every method NEVER raises; defensive try/except at registration |
| **No hardcoding** | Phase + kind dynamic; enum values not hardcoded (uses .value lookup) |
| **Leverages existing** | Reuses Slice 1.3 capture_phase_decision + Slice 1.2 decide + Slice 1.1 entropy/clock. Zero duplication |

## Authority invariants (pinned)

- classify_runner imports phase_capture **LAZILY** (inside function body)
- classify_runner imports cleanly with `importlib.reload`
- Source contains `Slice 1.3.a` + `advisor_verdict` + `capture_phase_decision` markers
- **Both branches present**: capture wrapper + fallback direct call
- `_register_classify_adapter` helper has top-level try/except (import-time defense)

## Test plan

- [x] 18 new tests covering 12 pin sections
- [x] **671/671 green** across full Phase 1 + 12 + 12.2 regression suite
- [x] All 4 `AdvisoryDecision` enum values round-trip correctly
- [x] Defensive paths tested: serialize on unknown shape / partial object / None; deserialize on garbage / invalid decision / partial dict

## Roadmap (operator-gated)

| Slice | Scope |
|---|---|
| 1.3.b | GENERATE phase wiring (`provider_selection`) |
| 1.3.c | GATE phase wiring (`risk_tier_assignment`) |
| 1.5 | Graduation flip |
| 1.X cleanup | Unify master flags under `JARVIS_DETERMINISM_ENABLED` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the CLASSIFY phase decision (`advisor_verdict`) into the determinism layer so we can record, replay, and verify the advisor’s verdict without changing runtime behavior. Adds a safe adapter and lazy, defensive wiring with a direct-call fallback.

- Wraps `_advisor.advise(...)` with `capture_phase_decision(phase="CLASSIFY", kind="advisor_verdict")`; on failure, falls back to the direct call.
- Registers `advisor_verdict_adapter` at module load: serializes `Advisory` to a JSON-friendly dict and rehydrates back; safe defaults on unknown shapes; non-dict passthrough; invalid decision strings default to `RECOMMEND`.
- Uses lazy import for determinism and top-level try/except around adapter registration to keep imports clean and never raise.
- Captures extra inputs for fingerprinting: description length, target file count, and read-only flag.
- Adds `tests/governance/test_determinism_classify_wiring.py` (18 tests) covering adapter round-trip, all enum values, defensive paths, and source pins; includes `tests/governance/test_convergence_governor.py` (Phase 3 prep) in a separate namespace with no overlap.

<sup>Written for commit 16b472783a81d093d82679c0cebd5c0a12ebeb91. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29098?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

