### PR TITLE
feat(phase1): Slice 1.3.c — GATE phase wiring (risk_tier_assignment)

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/gate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/gate_runner.py
@@ -671,6 +671,44 @@ class GATERunner(PhaseRunner):
                     )
         # ---- end verbatim transcription ----
 
+        # Phase 1 Slice 1.3.c — capture the GATE risk-tier verdict.
+        # Audit-only: risk_tier mutates through 7+ sites inside this
+        # runner (SimilarityGate, frozen_tier, RISK_CEILING,
+        # SemanticGuardian, MutationGate, MIN_RISK_TIER floor); we
+        # capture the FINAL value at the success path. Fail paths
+        # have their own structured reason codes already.
+        # Closure-over-risk_tier means REPLAY does NOT alter the
+        # mutation flow — gate logic always runs live; only the
+        # terminal verdict is recorded/replayed/verified.
+        try:
+            from backend.core.ouroboros.governance.determinism.phase_capture import (
+                capture_phase_decision,
+            )
+
+            async def _gate_digest_compute() -> Any:
+                return {
+                    "risk_tier": (
+                        risk_tier.name
+                        if hasattr(risk_tier, "name")
+                        else str(risk_tier)
+                    ),
+                    "has_best_candidate": bool(best_candidate),
+                }
+
+            await capture_phase_decision(
+                op_id=ctx.op_id,
+                phase="GATE",
+                kind="risk_tier_assignment",
+                ctx=ctx,
+                compute=_gate_digest_compute,
+            )
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[Orchestrator] capture_phase_decision failed for "
+                "GATE/risk_tier_assignment; gate verdict still applies",
+                exc_info=True,
+            )
+
         return PhaseResult(
             next_ctx=ctx,
             next_phase=OperationPhase.APPROVE,

--- a/backend/core/ouroboros/governance/pressure_convergence_prover.py
+++ b/backend/core/ouroboros/governance/pressure_convergence_prover.py
@@ -1,0 +1,472 @@
+"""Slice T1.2 — PressureConvergenceProver: formal convergence proof.
+
+Per ``OUROBOROS_VENOM_PRD.md`` §24.7.1 (Memory pressure positive feedback):
+
+  > Memory pressure → MemoryPressureGate clamps fan-out → fewer
+  > subagents complete → backlog grows → memory pressure increases.
+  > Mitigated only if pressure-relief activates faster than backlog-
+  > growth rate. **Untested at sustained load.**
+  >
+  > Fix path: a synthetic load-test sensor that injects backlog at
+  > controlled rate while inducing memory pressure (mock); assert
+  > pressure-relief activates within RELIEF_DEADLINE_S.
+
+This module ships a **pure-function mathematical simulator** that
+models the pressure↔backlog↔fanout feedback loop and proves
+convergence (or correctly identifies overload conditions requiring
+load-shedding).
+
+## Model
+
+  State at tick t:
+    backlog(t)     — pending tasks
+    pressure(t)    — simulated memory pressure level
+    fanout_cap(t)  — max parallel workers at pressure(t)
+    completion(t)  — tasks completed = min(backlog, fanout_cap)
+    arrival(t)     — new tasks arriving per tick (caller-supplied)
+
+  Transition:
+    backlog(t+1)   = max(0, backlog(t) - completion(t) + arrival(t))
+    pressure(t+1)  = pressure_from_backlog(backlog(t+1))
+    fanout_cap(t+1)= fanout_cap_at(pressure(t+1))
+
+## Convergence criterion
+
+  The system converges when backlog reaches steady-state (oscillation
+  bounded) OR drains to zero. For arrival_rate < fanout_cap(OK), the
+  system always converges. For arrival_rate > fanout_cap(CRITICAL),
+  backlog grows unbounded — the prover reports this as OVERLOADED
+  and emits a ShedLoadRecommendation.
+
+## Cage rules
+
+  * Stdlib-only
+  * Pure functions — no side effects, no I/O
+  * Never raises
+  * Master flag: ``JARVIS_PRESSURE_CONVERGENCE_PROVER_ENABLED``
+    (default false)
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+# ---------------------------------------------------------------------------
+# Hard caps
+# ---------------------------------------------------------------------------
+
+MAX_SIMULATION_TICKS: int = 10_000
+DEFAULT_RELIEF_DEADLINE_TICKS: int = 500
+DEFAULT_STEADY_STATE_WINDOW: int = 20
+
+# ---------------------------------------------------------------------------
+# Master flag + configuration
+# ---------------------------------------------------------------------------
+
+
+def is_prover_enabled() -> bool:
+    return os.environ.get(
+        "JARVIS_PRESSURE_CONVERGENCE_PROVER_ENABLED", "",
+    ).strip().lower() in _TRUTHY
+
+
+def _relief_deadline_ticks() -> int:
+    try:
+        v = int(os.environ.get(
+            "JARVIS_PRESSURE_RELIEF_DEADLINE_TICKS",
+            str(DEFAULT_RELIEF_DEADLINE_TICKS),
+        ).strip())
+        return max(1, min(MAX_SIMULATION_TICKS, v))
+    except (ValueError, TypeError):
+        return DEFAULT_RELIEF_DEADLINE_TICKS
+
+
+def _steady_state_window() -> int:
+    try:
+        v = int(os.environ.get(
+            "JARVIS_PRESSURE_STEADY_STATE_WINDOW",
+            str(DEFAULT_STEADY_STATE_WINDOW),
+        ).strip())
+        return max(2, min(200, v))
+    except (ValueError, TypeError):
+        return DEFAULT_STEADY_STATE_WINDOW
+
+
+# ---------------------------------------------------------------------------
+# Pressure simulation vocabulary
+# ---------------------------------------------------------------------------
+
+
+class SimPressureLevel(str, enum.Enum):
+    OK = "ok"
+    WARN = "warn"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ConvergenceVerdict(str, enum.Enum):
+    CONVERGED = "converged"
+    DRAINED = "drained"
+    OVERLOADED = "overloaded"
+    INCONCLUSIVE = "inconclusive"
+
+
+# ---------------------------------------------------------------------------
+# Configuration — mirrors MemoryPressureGate's real thresholds
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PressureConfig:
+    """Simulation parameters — mirrors MemoryPressureGate defaults.
+
+    Backlog thresholds map backlog size → pressure level, simulating
+    the real-world relationship between memory consumption (which
+    grows with backlog) and pressure level.
+    """
+
+    # Backlog thresholds — above these, pressure escalates.
+    backlog_warn: int = 10
+    backlog_high: int = 25
+    backlog_critical: int = 50
+
+    # Fanout caps per pressure level (from MemoryPressureGate).
+    fanout_ok: int = 16
+    fanout_warn: int = 8
+    fanout_high: int = 3
+    fanout_critical: int = 1
+
+
+DEFAULT_CONFIG = PressureConfig()
+
+
+# ---------------------------------------------------------------------------
+# Simulation state
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TickState:
+    """State at one simulation tick."""
+    tick: int
+    backlog: int
+    pressure: SimPressureLevel
+    fanout_cap: int
+    completed: int
+    arrived: int
+
+
+@dataclass(frozen=True)
+class ConvergenceResult:
+    """Terminal result of a convergence simulation."""
+    verdict: ConvergenceVerdict
+    ticks_simulated: int
+    ticks_to_drain: int
+    peak_backlog: int
+    peak_pressure: SimPressureLevel
+    steady_state_backlog: int
+    final_pressure: SimPressureLevel
+    arrival_rate: int
+    initial_backlog: int
+    within_deadline: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "verdict": self.verdict.value,
+            "ticks_simulated": self.ticks_simulated,
+            "ticks_to_drain": self.ticks_to_drain,
+            "peak_backlog": self.peak_backlog,
+            "peak_pressure": self.peak_pressure.value,
+            "steady_state_backlog": self.steady_state_backlog,
+            "final_pressure": self.final_pressure.value,
+            "arrival_rate": self.arrival_rate,
+            "initial_backlog": self.initial_backlog,
+            "within_deadline": self.within_deadline,
+        }
+
+
+@dataclass(frozen=True)
+class ShedLoadRecommendation:
+    """Emitted when arrival_rate exceeds all fanout caps."""
+    arrival_rate: int
+    max_sustainable_rate: int
+    excess: int
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Core simulation — pure functions
+# ---------------------------------------------------------------------------
+
+
+def pressure_from_backlog(
+    backlog: int,
+    config: PressureConfig = DEFAULT_CONFIG,
+) -> SimPressureLevel:
+    """Map backlog size to a pressure level. Pure function."""
+    if backlog >= config.backlog_critical:
+        return SimPressureLevel.CRITICAL
+    if backlog >= config.backlog_high:
+        return SimPressureLevel.HIGH
+    if backlog >= config.backlog_warn:
+        return SimPressureLevel.WARN
+    return SimPressureLevel.OK
+
+
+def fanout_cap_at(
+    pressure: SimPressureLevel,
+    config: PressureConfig = DEFAULT_CONFIG,
+) -> int:
+    """Fanout cap for a given pressure level. Pure function."""
+    if pressure is SimPressureLevel.OK:
+        return config.fanout_ok
+    if pressure is SimPressureLevel.WARN:
+        return config.fanout_warn
+    if pressure is SimPressureLevel.HIGH:
+        return config.fanout_high
+    if pressure is SimPressureLevel.CRITICAL:
+        return config.fanout_critical
+    return config.fanout_ok
+
+
+def simulate_tick(
+    state: TickState,
+    arrival_rate: int,
+    config: PressureConfig = DEFAULT_CONFIG,
+) -> TickState:
+    """Advance one tick. Pure function."""
+    completed = min(state.backlog, state.fanout_cap)
+    new_backlog = max(0, state.backlog - completed + arrival_rate)
+    new_pressure = pressure_from_backlog(new_backlog, config)
+    new_fanout = fanout_cap_at(new_pressure, config)
+    return TickState(
+        tick=state.tick + 1,
+        backlog=new_backlog,
+        pressure=new_pressure,
+        fanout_cap=new_fanout,
+        completed=completed,
+        arrived=arrival_rate,
+    )
+
+
+def _is_steady_state(
+    history: List[int],
+    window: int,
+) -> Tuple[bool, int]:
+    """Check if the last `window` backlog values are bounded (no growth).
+
+    Returns (is_steady, steady_backlog) where steady_backlog is the
+    max over the window.
+    """
+    if len(history) < window:
+        return (False, 0)
+    recent = history[-window:]
+    first_half = recent[:window // 2]
+    second_half = recent[window // 2:]
+    max_first = max(first_half)
+    max_second = max(second_half)
+    # Steady state: second half not growing beyond first half.
+    if max_second <= max_first + 1:
+        return (True, max(recent))
+    return (False, 0)
+
+
+# ---------------------------------------------------------------------------
+# Main prover
+# ---------------------------------------------------------------------------
+
+
+def prove_convergence(
+    *,
+    arrival_rate: int,
+    initial_backlog: int = 0,
+    config: PressureConfig = DEFAULT_CONFIG,
+    max_ticks: Optional[int] = None,
+    deadline_ticks: Optional[int] = None,
+    steady_window: Optional[int] = None,
+) -> ConvergenceResult:
+    """Run the feedback loop simulation and determine convergence.
+
+    Three possible verdicts:
+      * ``DRAINED`` — backlog reaches 0 (system recovered)
+      * ``CONVERGED`` — backlog stabilizes at bounded steady state
+      * ``OVERLOADED`` — backlog grows unbounded within max_ticks
+
+    NEVER raises.
+    """
+    arrival_rate = max(0, int(arrival_rate))
+    initial_backlog = max(0, int(initial_backlog))
+    mt = max_ticks or min(MAX_SIMULATION_TICKS, _relief_deadline_ticks() * 3)
+    deadline = deadline_ticks or _relief_deadline_ticks()
+    window = steady_window or _steady_state_window()
+
+    # Initial state.
+    pressure = pressure_from_backlog(initial_backlog, config)
+    fanout = fanout_cap_at(pressure, config)
+    state = TickState(
+        tick=0, backlog=initial_backlog, pressure=pressure,
+        fanout_cap=fanout, completed=0, arrived=0,
+    )
+
+    peak_backlog = initial_backlog
+    peak_pressure = pressure
+    backlog_history: List[int] = [initial_backlog]
+    drain_tick = -1
+
+    for _ in range(mt):
+        state = simulate_tick(state, arrival_rate, config)
+        backlog_history.append(state.backlog)
+
+        if state.backlog > peak_backlog:
+            peak_backlog = state.backlog
+        if _pressure_rank(state.pressure) > _pressure_rank(peak_pressure):
+            peak_pressure = state.pressure
+
+        # Check drain.
+        if state.backlog == 0 and drain_tick < 0:
+            drain_tick = state.tick
+            return ConvergenceResult(
+                verdict=ConvergenceVerdict.DRAINED,
+                ticks_simulated=state.tick,
+                ticks_to_drain=drain_tick,
+                peak_backlog=peak_backlog,
+                peak_pressure=peak_pressure,
+                steady_state_backlog=0,
+                final_pressure=state.pressure,
+                arrival_rate=arrival_rate,
+                initial_backlog=initial_backlog,
+                within_deadline=drain_tick <= deadline,
+            )
+
+        # Check steady state.
+        is_steady, steady_bl = _is_steady_state(backlog_history, window)
+        if is_steady:
+            return ConvergenceResult(
+                verdict=ConvergenceVerdict.CONVERGED,
+                ticks_simulated=state.tick,
+                ticks_to_drain=state.tick,
+                peak_backlog=peak_backlog,
+                peak_pressure=peak_pressure,
+                steady_state_backlog=steady_bl,
+                final_pressure=state.pressure,
+                arrival_rate=arrival_rate,
+                initial_backlog=initial_backlog,
+                within_deadline=state.tick <= deadline,
+            )
+
+    # Didn't converge within max_ticks.
+    return ConvergenceResult(
+        verdict=ConvergenceVerdict.OVERLOADED,
+        ticks_simulated=mt,
+        ticks_to_drain=-1,
+        peak_backlog=peak_backlog,
+        peak_pressure=peak_pressure,
+        steady_state_backlog=state.backlog,
+        final_pressure=state.pressure,
+        arrival_rate=arrival_rate,
+        initial_backlog=initial_backlog,
+        within_deadline=False,
+    )
+
+
+def _pressure_rank(level: SimPressureLevel) -> int:
+    _RANK = {
+        SimPressureLevel.OK: 0,
+        SimPressureLevel.WARN: 1,
+        SimPressureLevel.HIGH: 2,
+        SimPressureLevel.CRITICAL: 3,
+    }
+    return _RANK.get(level, 0)
+
+
+# ---------------------------------------------------------------------------
+# Load-shedding recommendation
+# ---------------------------------------------------------------------------
+
+
+def check_overload(
+    arrival_rate: int,
+    config: PressureConfig = DEFAULT_CONFIG,
+) -> Optional[ShedLoadRecommendation]:
+    """Check if arrival_rate exceeds the system's sustainable throughput.
+
+    The maximum sustainable rate is ``fanout_cap(OK)`` — if arrival
+    exceeds this, even under zero pressure the system can't keep up.
+    Under pressure, the sustainable rate drops further.
+
+    Returns ``ShedLoadRecommendation`` if overloaded, None if sustainable.
+    NEVER raises.
+    """
+    max_rate = config.fanout_ok
+    if arrival_rate <= max_rate:
+        return None
+    return ShedLoadRecommendation(
+        arrival_rate=arrival_rate,
+        max_sustainable_rate=max_rate,
+        excess=arrival_rate - max_rate,
+        message=(
+            f"Arrival rate {arrival_rate}/tick exceeds max sustainable "
+            f"throughput {max_rate}/tick (fanout_cap at OK pressure). "
+            f"Excess: {arrival_rate - max_rate}/tick. Load shedding required."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch prover (parameter sweep)
+# ---------------------------------------------------------------------------
+
+
+def prove_batch(
+    scenarios: List[Tuple[int, int]],
+    config: PressureConfig = DEFAULT_CONFIG,
+) -> List[ConvergenceResult]:
+    """Run convergence proof for a list of (arrival_rate, initial_backlog)
+    pairs. Returns one ConvergenceResult per scenario. NEVER raises."""
+    results: List[ConvergenceResult] = []
+    for arrival, backlog in scenarios:
+        try:
+            r = prove_convergence(
+                arrival_rate=arrival,
+                initial_backlog=backlog,
+                config=config,
+            )
+            results.append(r)
+        except Exception:  # noqa: BLE001
+            results.append(ConvergenceResult(
+                verdict=ConvergenceVerdict.INCONCLUSIVE,
+                ticks_simulated=0, ticks_to_drain=-1,
+                peak_backlog=0, peak_pressure=SimPressureLevel.OK,
+                steady_state_backlog=0, final_pressure=SimPressureLevel.OK,
+                arrival_rate=arrival, initial_backlog=backlog,
+                within_deadline=False,
+            ))
+    return results
+
+
+__all__ = [
+    "ConvergenceResult",
+    "ConvergenceVerdict",
+    "DEFAULT_CONFIG",
+    "DEFAULT_RELIEF_DEADLINE_TICKS",
+    "DEFAULT_STEADY_STATE_WINDOW",
+    "MAX_SIMULATION_TICKS",
+    "PressureConfig",
+    "ShedLoadRecommendation",
+    "SimPressureLevel",
+    "TickState",
+    "check_overload",
+    "fanout_cap_at",
+    "is_prover_enabled",
+    "pressure_from_backlog",
+    "prove_batch",
+    "prove_convergence",
+    "simulate_tick",
+]

--- a/tests/governance/test_determinism_gate_wiring.py
+++ b/tests/governance/test_determinism_gate_wiring.py
@@ -1,0 +1,279 @@
+"""Phase 1 Slice 1.3.c — GATE phase wiring regression spine.
+
+Pins:
+  §1   GATE wiring captures risk_tier_assignment digest
+  §2   Source-level pin: capture_phase_decision invoked
+  §3   Source-level pin: kind="risk_tier_assignment"
+  §4   Source-level pin: phase="GATE"
+  §5   Source-level pin: capture happens BEFORE the success-path return
+  §6   Source-level pin: closure-over-risk_tier pattern (no re-mutate)
+  §7   Source-level pin: try/except fallback present
+  §8   Source-level pin: logger.debug on failure (not warning)
+  §9   Wiring marker: Slice 1.3.c reference in source
+  §10  gate_runner imports phase_capture LAZILY (not top-level)
+  §11  gate_runner imports cleanly with importlib.reload
+  §12  Identity adapter sufficient — digest is JSON-friendly primitives
+  §13  End-to-end RECORD then REPLAY proves digest captured + replayed
+  §14  RiskTier serialization uses .name (uppercase enum identifier)
+  §15  Capture only on success path — fail paths bypass capture
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from backend.core.ouroboros.governance.determinism import (
+    capture_phase_decision,
+)
+from backend.core.ouroboros.governance.determinism.decision_runtime import (
+    reset_all_for_tests as reset_runtime_for_tests,
+)
+from backend.core.ouroboros.governance.determinism.phase_capture import (
+    reset_registry_for_tests,
+)
+
+
+GATE_RUNNER_PATH = (
+    "backend/core/ouroboros/governance/phase_runners/gate_runner.py"
+)
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_LEDGER_DIR", str(tmp_path / "det"),
+    )
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", "true",
+    )
+    monkeypatch.setenv("OUROBOROS_BATTLE_SESSION_ID", "test-session")
+    monkeypatch.delenv("JARVIS_DETERMINISM_LEDGER_MODE", raising=False)
+    reset_runtime_for_tests()
+    reset_registry_for_tests()
+    yield tmp_path / "det"
+    reset_runtime_for_tests()
+    reset_registry_for_tests()
+
+
+def _read_runner_source() -> str:
+    return open(GATE_RUNNER_PATH, encoding="utf-8").read()
+
+
+# ---------------------------------------------------------------------------
+# §1-§9 — Source-level pins
+# ---------------------------------------------------------------------------
+
+
+def test_gate_wiring_invokes_capture_phase_decision() -> None:
+    src = _read_runner_source()
+    assert "capture_phase_decision(" in src
+
+
+def test_gate_wiring_uses_risk_tier_assignment_kind() -> None:
+    src = _read_runner_source()
+    assert 'kind="risk_tier_assignment"' in src
+
+
+def test_gate_wiring_uses_phase_gate() -> None:
+    src = _read_runner_source()
+    assert 'phase="GATE"' in src
+
+
+def test_gate_wiring_captures_before_success_return() -> None:
+    """The capture call must come BEFORE the terminal success
+    PhaseResult return at line ~674. Source ordering pin."""
+    src = _read_runner_source()
+    capture_idx = src.index('kind="risk_tier_assignment"')
+    # Find the success-path return (status="ok", reason="gated")
+    success_return = src.index('reason="gated"')
+    assert capture_idx < success_return, (
+        "capture must happen BEFORE the success PhaseResult return"
+    )
+
+
+def test_gate_wiring_uses_closure_over_risk_tier() -> None:
+    """The capture wrapper's compute() reads from `risk_tier` outer
+    scope — does NOT re-execute the gate mutation flow."""
+    src = _read_runner_source()
+    digest_idx = src.index("_gate_digest_compute")
+    after = src[digest_idx:digest_idx + 1500]
+    # Must reference risk_tier (closure over outer var)
+    assert "risk_tier" in after
+    # Must NOT re-call risk-tier-mutating gates
+    closure_end = after.find("await capture_phase_decision")
+    closure_body = after[:closure_end] if closure_end > 0 else after
+    forbidden_calls = (
+        "SimilarityGate", "SemanticGuardian", "MutationGate",
+        "frozen_tier", "RISK_CEILING",
+    )
+    for f in forbidden_calls:
+        assert f not in closure_body, (
+            f"capture compute closure must NOT re-invoke gate logic ({f})"
+        )
+
+
+def test_gate_wiring_has_try_except_fallback() -> None:
+    src = _read_runner_source()
+    capture_idx = src.index('kind="risk_tier_assignment"')
+    preceding = src[max(0, capture_idx - 4000):capture_idx]
+    try_idx = preceding.rfind("try:")
+    assert try_idx != -1
+    following = src[capture_idx:capture_idx + 4000]
+    except_idx = following.find("except")
+    assert except_idx != -1
+    except_window = following[except_idx:except_idx + 80]
+    assert "Exception" in except_window
+
+
+def test_gate_wiring_uses_logger_debug() -> None:
+    """The fallback path uses logger.debug, NOT logger.warning, so
+    flag-off operators don't see capture noise."""
+    src = _read_runner_source()
+    capture_idx = src.index('kind="risk_tier_assignment"')
+    following = src[capture_idx:capture_idx + 4000]
+    except_idx = following.find("except Exception")
+    assert except_idx != -1
+    body = following[except_idx:except_idx + 500]
+    assert "logger.debug" in body
+
+
+def test_gate_wiring_marker_present() -> None:
+    src = _read_runner_source()
+    assert "Slice 1.3.c" in src
+    assert "audit-only" in src.lower() or "audit_only" in src.lower()
+
+
+# ---------------------------------------------------------------------------
+# §10-§11 — Lazy import + clean reload
+# ---------------------------------------------------------------------------
+
+
+def test_gate_runner_imports_phase_capture_lazily() -> None:
+    src = _read_runner_source()
+    lines = src.split("\n")
+    top_level_imports = [
+        ln for ln in lines
+        if ln.startswith(
+            "from backend.core.ouroboros.governance.determinism.phase_capture"
+        )
+    ]
+    assert top_level_imports == []
+
+
+def test_gate_runner_imports_cleanly() -> None:
+    from backend.core.ouroboros.governance.phase_runners import (
+        gate_runner,
+    )
+    importlib.reload(gate_runner)
+    assert hasattr(gate_runner, "GATERunner")
+
+
+# ---------------------------------------------------------------------------
+# §12-§14 — End-to-end behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_risk_tier_digest_round_trip(isolated) -> None:
+    """The digest dict (risk_tier as enum-name str + bool) round-trips
+    cleanly through the identity adapter."""
+    digest = {
+        "risk_tier": "NOTIFY_APPLY",
+        "has_best_candidate": True,
+    }
+    out = await capture_phase_decision(
+        op_id="op-1", phase="GATE", kind="risk_tier_assignment",
+        compute=lambda: digest,
+    )
+    assert out == digest
+
+
+@pytest.mark.asyncio
+async def test_risk_tier_record_then_replay(
+    isolated, monkeypatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_MODE", "record")
+
+    # Simulate the GATE closure pattern
+    fake_risk_tier_name = "APPROVAL_REQUIRED"
+
+    async def _digest_compute():
+        return {
+            "risk_tier": fake_risk_tier_name,
+            "has_best_candidate": True,
+        }
+
+    await capture_phase_decision(
+        op_id="op-1", phase="GATE", kind="risk_tier_assignment",
+        compute=_digest_compute,
+    )
+
+    # REPLAY pass
+    reset_runtime_for_tests()
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_MODE", "replay")
+
+    canary = {"called": False}
+
+    async def _should_not_run():
+        canary["called"] = True
+        return {"risk_tier": "BLOCKED", "has_best_candidate": False}
+
+    out = await capture_phase_decision(
+        op_id="op-1", phase="GATE", kind="risk_tier_assignment",
+        compute=_should_not_run,
+    )
+    assert out["risk_tier"] == "APPROVAL_REQUIRED"
+    assert out["has_best_candidate"] is True
+    assert canary["called"] is False
+
+
+def test_risk_tier_serialization_uses_name() -> None:
+    """Source-level pin: the closure uses risk_tier.name (uppercase
+    enum identifier), not str(risk_tier) which prints
+    'RiskTier.NOTIFY_APPLY' with the class prefix."""
+    src = _read_runner_source()
+    digest_idx = src.index("_gate_digest_compute")
+    after = src[digest_idx:digest_idx + 1500]
+    assert "risk_tier.name" in after, (
+        "closure must use risk_tier.name (NOT str(risk_tier))"
+    )
+
+
+# ---------------------------------------------------------------------------
+# §15 — Capture only on success path
+# ---------------------------------------------------------------------------
+
+
+def test_capture_only_on_success_path() -> None:
+    """The capture is positioned just before the SUCCESS-path return.
+    Fail paths (lines 155, 185, 559, 667) have their own structured
+    reason codes and bypass the audit capture."""
+    src = _read_runner_source()
+    # Count capture_phase_decision occurrences — should be exactly 1
+    # (the success-path capture; this slice doesn't wire fail paths)
+    count = src.count("await capture_phase_decision(")
+    assert count == 1, (
+        f"expected exactly 1 capture call (success-path only), got {count}"
+    )
+
+
+def test_capture_emits_after_all_mutation_sites() -> None:
+    """The capture is positioned AFTER all 7 risk_tier mutation
+    sites — proves the captured digest reflects the FINAL verdict
+    after every gate has had its say."""
+    src = _read_runner_source()
+    capture_idx = src.index('kind="risk_tier_assignment"')
+    # Mutation site references that should appear BEFORE the capture
+    earlier_mutations = (
+        "SimilarityGate",  # one of the 7 mutation sites
+        "frozen_tier",      # another
+        "RISK_CEILING",     # another
+    )
+    for marker in earlier_mutations:
+        if marker in src:
+            mutation_idx = src.index(marker)
+            assert mutation_idx < capture_idx, (
+                f"capture must come AFTER {marker} mutation site"
+            )

--- a/tests/governance/test_pressure_convergence_prover.py
+++ b/tests/governance/test_pressure_convergence_prover.py
@@ -1,0 +1,373 @@
+"""Tests for Slice T1.2 — PressureConvergenceProver.
+
+Proves that MemoryPressureGate's pressure→backlog→fanout feedback loop
+converges under sustained load (§24.7.1).
+"""
+from __future__ import annotations
+
+import random
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESSURE_CONVERGENCE_PROVER_ENABLED", "true")
+
+
+# ---------------------------------------------------------------------------
+# 1. Draining proof — arrival < fanout_cap(OK)
+# ---------------------------------------------------------------------------
+
+class TestDrainingProof:
+    def test_zero_arrival_drains_immediately(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict,
+        )
+        r = prove_convergence(arrival_rate=0, initial_backlog=50)
+        assert r.verdict == ConvergenceVerdict.DRAINED
+        assert r.steady_state_backlog == 0
+
+    def test_low_arrival_drains(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict, DEFAULT_CONFIG,
+        )
+        # arrival must be <= fanout_cap(CRITICAL) to guarantee drain
+        # from any initial backlog. arrival=1 == critical cap.
+        r = prove_convergence(
+            arrival_rate=DEFAULT_CONFIG.fanout_critical,
+            initial_backlog=100,
+        )
+        assert r.verdict in (ConvergenceVerdict.DRAINED, ConvergenceVerdict.CONVERGED)
+        assert r.ticks_to_drain > 0 or r.verdict == ConvergenceVerdict.CONVERGED
+
+    def test_arrival_above_critical_cap_with_large_backlog_overloads(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict, DEFAULT_CONFIG,
+        )
+        # arrival=2 > fanout_cap(CRITICAL)=1, large backlog traps at CRITICAL
+        r = prove_convergence(
+            arrival_rate=DEFAULT_CONFIG.fanout_critical + 1,
+            initial_backlog=100,
+            max_ticks=500,
+        )
+        # This correctly detects the feedback trap
+        assert r.verdict in (
+            ConvergenceVerdict.OVERLOADED, ConvergenceVerdict.CONVERGED,
+        )
+
+    def test_arrival_below_ok_cap_drains(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict, DEFAULT_CONFIG,
+        )
+        # arrival < fanout_ok → system always drains
+        rate = DEFAULT_CONFIG.fanout_ok - 1
+        r = prove_convergence(arrival_rate=rate, initial_backlog=200)
+        assert r.verdict in (ConvergenceVerdict.DRAINED, ConvergenceVerdict.CONVERGED)
+
+    def test_zero_backlog_zero_arrival(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict,
+        )
+        r = prove_convergence(arrival_rate=0, initial_backlog=0)
+        assert r.verdict == ConvergenceVerdict.DRAINED
+        assert r.ticks_to_drain <= 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Steady-state proof — arrival = fanout_cap(WARN)
+# ---------------------------------------------------------------------------
+
+class TestSteadyState:
+    def test_arrival_equals_warn_cap_stabilizes(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict, DEFAULT_CONFIG,
+        )
+        # Arrival rate exactly matches WARN cap → system stabilizes
+        r = prove_convergence(
+            arrival_rate=DEFAULT_CONFIG.fanout_warn,
+            initial_backlog=DEFAULT_CONFIG.backlog_warn,
+        )
+        assert r.verdict in (ConvergenceVerdict.CONVERGED, ConvergenceVerdict.DRAINED)
+
+    def test_steady_state_backlog_bounded(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict, DEFAULT_CONFIG,
+        )
+        r = prove_convergence(
+            arrival_rate=DEFAULT_CONFIG.fanout_warn,
+            initial_backlog=0,
+        )
+        assert r.verdict in (ConvergenceVerdict.CONVERGED, ConvergenceVerdict.DRAINED)
+        # Steady-state backlog should be bounded
+        assert r.steady_state_backlog <= DEFAULT_CONFIG.backlog_critical * 2
+
+
+# ---------------------------------------------------------------------------
+# 3. Overload detection
+# ---------------------------------------------------------------------------
+
+class TestOverloadDetection:
+    def test_extreme_arrival_detected(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict, DEFAULT_CONFIG,
+        )
+        # Arrival >> all fanout caps → overloaded
+        r = prove_convergence(
+            arrival_rate=DEFAULT_CONFIG.fanout_ok * 3,
+            initial_backlog=0,
+            max_ticks=200,
+        )
+        assert r.verdict == ConvergenceVerdict.OVERLOADED
+        assert r.within_deadline is False
+
+    def test_check_overload_recommendation(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            check_overload, DEFAULT_CONFIG,
+        )
+        rec = check_overload(DEFAULT_CONFIG.fanout_ok + 5)
+        assert rec is not None
+        assert rec.excess == 5
+        assert rec.max_sustainable_rate == DEFAULT_CONFIG.fanout_ok
+
+    def test_check_overload_none_when_sustainable(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            check_overload, DEFAULT_CONFIG,
+        )
+        rec = check_overload(DEFAULT_CONFIG.fanout_ok - 1)
+        assert rec is None
+
+    def test_check_overload_at_exactly_cap(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            check_overload, DEFAULT_CONFIG,
+        )
+        rec = check_overload(DEFAULT_CONFIG.fanout_ok)
+        assert rec is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Deadline enforcement
+# ---------------------------------------------------------------------------
+
+class TestDeadlineEnforcement:
+    def test_fast_drain_within_deadline(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence,
+        )
+        r = prove_convergence(
+            arrival_rate=0, initial_backlog=10, deadline_ticks=100,
+        )
+        assert r.within_deadline is True
+
+    def test_slow_drain_exceeds_deadline(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, DEFAULT_CONFIG,
+        )
+        # Large backlog + arrival close to cap → slow drain
+        r = prove_convergence(
+            arrival_rate=DEFAULT_CONFIG.fanout_ok - 1,
+            initial_backlog=5000,
+            deadline_ticks=10,
+        )
+        assert r.within_deadline is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Pressure transition correctness
+# ---------------------------------------------------------------------------
+
+class TestPressureTransitions:
+    def test_backlog_below_warn_is_ok(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            pressure_from_backlog, SimPressureLevel, DEFAULT_CONFIG,
+        )
+        assert pressure_from_backlog(0) == SimPressureLevel.OK
+        assert pressure_from_backlog(DEFAULT_CONFIG.backlog_warn - 1) == SimPressureLevel.OK
+
+    def test_backlog_at_warn_is_warn(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            pressure_from_backlog, SimPressureLevel, DEFAULT_CONFIG,
+        )
+        assert pressure_from_backlog(DEFAULT_CONFIG.backlog_warn) == SimPressureLevel.WARN
+
+    def test_backlog_at_high_is_high(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            pressure_from_backlog, SimPressureLevel, DEFAULT_CONFIG,
+        )
+        assert pressure_from_backlog(DEFAULT_CONFIG.backlog_high) == SimPressureLevel.HIGH
+
+    def test_backlog_at_critical_is_critical(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            pressure_from_backlog, SimPressureLevel, DEFAULT_CONFIG,
+        )
+        assert pressure_from_backlog(DEFAULT_CONFIG.backlog_critical) == SimPressureLevel.CRITICAL
+
+    def test_fanout_caps_correct(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            fanout_cap_at, SimPressureLevel, DEFAULT_CONFIG,
+        )
+        assert fanout_cap_at(SimPressureLevel.OK) == DEFAULT_CONFIG.fanout_ok
+        assert fanout_cap_at(SimPressureLevel.WARN) == DEFAULT_CONFIG.fanout_warn
+        assert fanout_cap_at(SimPressureLevel.HIGH) == DEFAULT_CONFIG.fanout_high
+        assert fanout_cap_at(SimPressureLevel.CRITICAL) == DEFAULT_CONFIG.fanout_critical
+
+
+# ---------------------------------------------------------------------------
+# 6. Monotonic drain
+# ---------------------------------------------------------------------------
+
+class TestMonotonicDrain:
+    def test_drain_without_respike(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            simulate_tick, TickState, pressure_from_backlog, fanout_cap_at,
+        )
+        # Zero arrival — backlog should monotonically decrease
+        p = pressure_from_backlog(100)
+        state = TickState(
+            tick=0, backlog=100, pressure=p,
+            fanout_cap=fanout_cap_at(p), completed=0, arrived=0,
+        )
+        prev_backlog = state.backlog
+        for _ in range(200):
+            state = simulate_tick(state, arrival_rate=0)
+            assert state.backlog <= prev_backlog
+            prev_backlog = state.backlog
+            if state.backlog == 0:
+                break
+        assert state.backlog == 0
+
+
+# ---------------------------------------------------------------------------
+# 7. Parameter sweep — adversarial
+# ---------------------------------------------------------------------------
+
+class TestParameterSweep:
+    def test_50_random_scenarios(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_batch, ConvergenceVerdict, DEFAULT_CONFIG,
+        )
+        rng = random.Random(42)
+        scenarios = []
+        for _ in range(50):
+            arrival = rng.randint(0, DEFAULT_CONFIG.fanout_ok + 10)
+            backlog = rng.randint(0, 500)
+            scenarios.append((arrival, backlog))
+
+        results = prove_batch(scenarios)
+        assert len(results) == 50
+
+        for r in results:
+            if r.arrival_rate <= DEFAULT_CONFIG.fanout_critical:
+                # arrival <= min fanout cap → system ALWAYS drains
+                # regardless of initial backlog and pressure
+                assert r.verdict in (
+                    ConvergenceVerdict.DRAINED,
+                    ConvergenceVerdict.CONVERGED,
+                ), (
+                    f"arrival={r.arrival_rate} backlog={r.initial_backlog} "
+                    f"should converge but got {r.verdict}"
+                )
+            # All scenarios produce a valid verdict
+            assert r.verdict in (
+                ConvergenceVerdict.DRAINED,
+                ConvergenceVerdict.CONVERGED,
+                ConvergenceVerdict.OVERLOADED,
+                ConvergenceVerdict.INCONCLUSIVE,
+            )
+
+
+# ---------------------------------------------------------------------------
+# 8. Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_arrival_zero_initial_zero(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict,
+        )
+        r = prove_convergence(arrival_rate=0, initial_backlog=0)
+        assert r.verdict == ConvergenceVerdict.DRAINED
+
+    def test_fanout_cap_one(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, PressureConfig, ConvergenceVerdict,
+        )
+        config = PressureConfig(
+            fanout_ok=1, fanout_warn=1, fanout_high=1, fanout_critical=1,
+        )
+        r = prove_convergence(
+            arrival_rate=0, initial_backlog=10, config=config,
+        )
+        assert r.verdict == ConvergenceVerdict.DRAINED
+        assert r.ticks_to_drain == 10
+
+    def test_negative_arrival_clamped(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict,
+        )
+        r = prove_convergence(arrival_rate=-5, initial_backlog=10)
+        assert r.verdict == ConvergenceVerdict.DRAINED
+
+    def test_result_serializable(self):
+        import json
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence,
+        )
+        r = prove_convergence(arrival_rate=5, initial_backlog=50)
+        d = r.to_dict()
+        json_str = json.dumps(d)
+        assert isinstance(json_str, str)
+
+
+# ---------------------------------------------------------------------------
+# 9. Custom config
+# ---------------------------------------------------------------------------
+
+class TestCustomConfig:
+    def test_tight_thresholds(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, PressureConfig, ConvergenceVerdict,
+        )
+        config = PressureConfig(
+            backlog_warn=3, backlog_high=6, backlog_critical=10,
+            fanout_ok=8, fanout_warn=4, fanout_high=2, fanout_critical=1,
+        )
+        r = prove_convergence(
+            arrival_rate=3, initial_backlog=50, config=config,
+        )
+        assert r.verdict in (ConvergenceVerdict.DRAINED, ConvergenceVerdict.CONVERGED)
+
+
+# ---------------------------------------------------------------------------
+# 10. Master flag
+# ---------------------------------------------------------------------------
+
+class TestMasterFlag:
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+    def test_truthy(self, monkeypatch, val):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import is_prover_enabled
+        monkeypatch.setenv("JARVIS_PRESSURE_CONVERGENCE_PROVER_ENABLED", val)
+        assert is_prover_enabled() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_falsy(self, monkeypatch, val):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import is_prover_enabled
+        monkeypatch.setenv("JARVIS_PRESSURE_CONVERGENCE_PROVER_ENABLED", val)
+        assert is_prover_enabled() is False
+
+    def test_default_disabled(self, monkeypatch):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import is_prover_enabled
+        monkeypatch.delenv("JARVIS_PRESSURE_CONVERGENCE_PROVER_ENABLED", raising=False)
+        assert is_prover_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# 11. Constants pinned
+# ---------------------------------------------------------------------------
+
+class TestConstants:
+    def test_pinned(self):
+        from backend.core.ouroboros.governance import pressure_convergence_prover as mod
+        assert mod.MAX_SIMULATION_TICKS == 10_000
+        assert mod.DEFAULT_RELIEF_DEADLINE_TICKS == 500
+        assert mod.DEFAULT_STEADY_STATE_WINDOW == 20

--- a/tests/governance/test_pressure_convergence_prover.py
+++ b/tests/governance/test_pressure_convergence_prover.py
@@ -56,14 +56,34 @@ class TestDrainingProof:
             ConvergenceVerdict.OVERLOADED, ConvergenceVerdict.CONVERGED,
         )
 
-    def test_arrival_below_ok_cap_drains(self):
+    def test_arrival_below_ok_cap_drains_from_ok_pressure(self):
         from backend.core.ouroboros.governance.pressure_convergence_prover import (
             prove_convergence, ConvergenceVerdict, DEFAULT_CONFIG,
         )
-        # arrival < fanout_ok → system always drains
-        rate = DEFAULT_CONFIG.fanout_ok - 1
-        r = prove_convergence(arrival_rate=rate, initial_backlog=200)
+        # arrival < fanout_ok AND initial_backlog low enough to stay at OK
+        # → system drains because fanout_cap(OK)=16 > arrival=5
+        rate = 5
+        r = prove_convergence(
+            arrival_rate=rate,
+            initial_backlog=DEFAULT_CONFIG.backlog_warn - 1,
+        )
         assert r.verdict in (ConvergenceVerdict.DRAINED, ConvergenceVerdict.CONVERGED)
+
+    def test_arrival_below_ok_but_above_critical_trap(self):
+        from backend.core.ouroboros.governance.pressure_convergence_prover import (
+            prove_convergence, ConvergenceVerdict, DEFAULT_CONFIG,
+        )
+        # THIS IS THE §24.7.1 FEEDBACK TRAP:
+        # arrival=15 < fanout_ok=16, but initial_backlog=200 pushes to
+        # CRITICAL (cap=1). 15 > 1, so backlog grows forever.
+        # The prover correctly identifies this as overloaded.
+        rate = DEFAULT_CONFIG.fanout_ok - 1  # 15
+        r = prove_convergence(
+            arrival_rate=rate,
+            initial_backlog=200,
+            max_ticks=500,
+        )
+        assert r.verdict == ConvergenceVerdict.OVERLOADED
 
     def test_zero_backlog_zero_arrival(self):
         from backend.core.ouroboros.governance.pressure_convergence_prover import (

--- a/tests/governance/test_semantic_guardian_quine_patterns.py
+++ b/tests/governance/test_semantic_guardian_quine_patterns.py
@@ -1,0 +1,316 @@
+"""Tests for §24.8.1 — dynamic_import_chain pattern (20 Quine variants).
+
+Per OUROBOROS_VENOM_PRD.md §24.8.1:
+
+  > Plus a dedicated test suite with 20 hand-crafted Quine variants.
+
+Each test provides an ``old_content`` (benign) and a ``new_content``
+(containing the attack variant). The pattern must:
+
+  * DETECT the variant (severity ``hard``)
+  * NOT fire on pre-existing usage (old == new)
+  * NOT fire on normal ``import os`` (false positive guard)
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.semantic_guardian import (
+    SemanticGuardian,
+    Detection,
+)
+
+
+@pytest.fixture
+def guardian():
+    return SemanticGuardian()
+
+
+# Benign old content shared across most variants.
+_BENIGN_OLD = '''\
+import os
+import json
+
+def process(data):
+    return json.loads(data)
+'''
+
+
+def _detect(guardian, new_content, old_content=_BENIGN_OLD):
+    findings = guardian.inspect(
+        file_path="target.py",
+        old_content=old_content,
+        new_content=new_content,
+    )
+    chain_hits = [f for f in findings if f.pattern == "dynamic_import_chain"]
+    return chain_hits
+
+
+# ---------------------------------------------------------------------------
+# 20 Quine variants — each must be CAUGHT
+# ---------------------------------------------------------------------------
+
+
+class TestQuineVariants:
+    """20 hand-crafted attack patterns covering every known dynamic
+    execution obfuscation class."""
+
+    # 1. Direct __import__
+    def test_variant_01_direct_dunder_import(self, guardian):
+        new = _BENIGN_OLD + '\nm = __import__("subprocess")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+        assert hits[0].severity == "hard"
+
+    # 2. Chained __import__ with method call
+    def test_variant_02_chained_dunder_import(self, guardian):
+        new = _BENIGN_OLD + '\n__import__("subprocess").run(["ls"])\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 3. eval wrapping import
+    def test_variant_03_eval_wrapping_import(self, guardian):
+        new = _BENIGN_OLD + '\neval("__import__(\'os\')")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 4. exec with embedded import
+    def test_variant_04_exec_with_import(self, guardian):
+        new = _BENIGN_OLD + '\nexec("import os\\nos.system(\'id\')")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 5. compile + exec chain
+    def test_variant_05_compile_exec_chain(self, guardian):
+        new = _BENIGN_OLD + '''
+code = compile("import os\\nos.system('id')", "<string>", "exec")
+exec(code)
+'''
+        hits = _detect(guardian, new)
+        # compile + exec = 2 nodes
+        assert len(hits) >= 1
+
+    # 6. getattr on __import__ result
+    def test_variant_06_getattr_dynamic_dispatch(self, guardian):
+        new = _BENIGN_OLD + '\ngetattr(__import__("os"), "system")("id")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 7. base64-encoded payload + exec
+    def test_variant_07_base64_decode_exec(self, guardian):
+        new = _BENIGN_OLD + '''
+import base64
+exec(base64.b64decode("cHJpbnQoJ293bmVkJyk=").decode())
+'''
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 8. codecs-encoded payload + exec
+    def test_variant_08_codecs_decode_exec(self, guardian):
+        new = _BENIGN_OLD + '''
+import codecs
+exec(codecs.decode("cHJpbnQoJ293bmVkJyk=", "base64").decode())
+'''
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 9. importlib.import_module
+    def test_variant_09_importlib_import_module(self, guardian):
+        new = _BENIGN_OLD + '''
+import importlib
+m = importlib.import_module("subprocess")
+m.run(["id"])
+'''
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 10. builtins.__import__
+    def test_variant_10_builtins_dunder_import(self, guardian):
+        new = _BENIGN_OLD + '''
+import builtins
+m = builtins.__import__("os")
+m.system("id")
+'''
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 11. globals chain (eval wrapping)
+    def test_variant_11_globals_chain(self, guardian):
+        new = _BENIGN_OLD + '\neval("globals()")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 12. chr-code obfuscation (eval wrapping)
+    def test_variant_12_chr_code_obfuscation(self, guardian):
+        new = _BENIGN_OLD + '\neval(chr(105)+chr(109)+"port os")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 13. bytes decode + exec
+    def test_variant_13_bytes_decode_exec(self, guardian):
+        new = _BENIGN_OLD + '\nexec(bytes([105,109,112,111,114,116]).decode())\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 14. nested getattr chain
+    def test_variant_14_nested_getattr(self, guardian):
+        new = _BENIGN_OLD + '\ngetattr(getattr(__import__("os"), "path"), "exists")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 15. metaclass injection via exec
+    def test_variant_15_metaclass_exec(self, guardian):
+        new = _BENIGN_OLD + '\nexec("class Evil: pass")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 16. lambda wrapping __import__
+    def test_variant_16_lambda_import(self, guardian):
+        new = _BENIGN_OLD + '\nf = lambda: __import__("os")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 17. list comprehension wrapping
+    def test_variant_17_list_comprehension(self, guardian):
+        new = _BENIGN_OLD + '\nx = [__import__("os")]\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 18. dict comprehension wrapping
+    def test_variant_18_dict_comprehension(self, guardian):
+        new = _BENIGN_OLD + '\nx = {k: __import__(k) for k in ["os"]}\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 19. ternary wrapping
+    def test_variant_19_ternary_import(self, guardian):
+        new = _BENIGN_OLD + '\nx = __import__("os") if True else None\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+    # 20. exec + open().read() chain
+    def test_variant_20_exec_open_read(self, guardian):
+        new = _BENIGN_OLD + '\nexec(open("/tmp/payload.py").read())\n'
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+
+
+# ---------------------------------------------------------------------------
+# False positive guards — MUST NOT fire
+# ---------------------------------------------------------------------------
+
+
+class TestFalsePositiveGuards:
+    """Normal Python patterns that MUST NOT trigger the detector."""
+
+    def test_normal_import_statement(self, guardian):
+        new = _BENIGN_OLD + '\nimport subprocess\n'
+        hits = _detect(guardian, new)
+        assert len(hits) == 0
+
+    def test_from_import(self, guardian):
+        new = _BENIGN_OLD + '\nfrom os.path import join\n'
+        hits = _detect(guardian, new)
+        assert len(hits) == 0
+
+    def test_normal_function_call(self, guardian):
+        new = _BENIGN_OLD + '\nresult = json.dumps({"key": "value"})\n'
+        hits = _detect(guardian, new)
+        assert len(hits) == 0
+
+    def test_getattr_with_safe_target(self, guardian):
+        new = _BENIGN_OLD + '\nx = getattr(obj, "name")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) == 0
+
+    def test_open_for_reading_no_exec(self, guardian):
+        new = _BENIGN_OLD + '\nwith open("data.txt") as f:\n    data = f.read()\n'
+        hits = _detect(guardian, new)
+        assert len(hits) == 0
+
+    def test_compile_regex(self, guardian):
+        """re.compile() must NOT trigger — only builtin compile()."""
+        new = _BENIGN_OLD + '\nimport re\npat = re.compile(r"\\d+")\n'
+        hits = _detect(guardian, new)
+        assert len(hits) == 0
+
+    def test_empty_old_and_new(self, guardian):
+        hits = _detect(guardian, "", "")
+        assert len(hits) == 0
+
+
+# ---------------------------------------------------------------------------
+# Delta logic — pre-existing chains must NOT trigger
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaLogic:
+    """The pattern fires on introductions, not pre-existing usage."""
+
+    def test_preexisting_eval_not_flagged(self, guardian):
+        code = _BENIGN_OLD + '\nresult = eval("1 + 1")\n'
+        # old and new are identical — no delta
+        hits = _detect(guardian, code, old_content=code)
+        assert len(hits) == 0
+
+    def test_preexisting_import_not_flagged(self, guardian):
+        code = _BENIGN_OLD + '\nm = __import__("json")\n'
+        hits = _detect(guardian, code, old_content=code)
+        assert len(hits) == 0
+
+    def test_removing_eval_not_flagged(self, guardian):
+        old = _BENIGN_OLD + '\nresult = eval("1 + 1")\n'
+        # new removes the eval — count goes DOWN, no flag
+        hits = _detect(guardian, _BENIGN_OLD, old_content=old)
+        assert len(hits) == 0
+
+    def test_additional_chain_flagged(self, guardian):
+        old = _BENIGN_OLD + '\nx = eval("1")\n'
+        new = old + '\ny = exec("print(1)")\n'
+        hits = _detect(guardian, new, old_content=old)
+        assert len(hits) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Pattern registration check
+# ---------------------------------------------------------------------------
+
+
+class TestPatternRegistration:
+    def test_pattern_in_all_patterns(self):
+        from backend.core.ouroboros.governance.semantic_guardian import all_pattern_names
+        assert "dynamic_import_chain" in all_pattern_names()
+
+    def test_env_gate_respected(self, guardian, monkeypatch):
+        monkeypatch.setenv("JARVIS_SEMGUARD_DYNAMIC_IMPORT_CHAIN_ENABLED", "0")
+        new = _BENIGN_OLD + '\neval("bad")\n'
+        # The guardian should skip the disabled pattern.
+        findings = guardian.inspect(
+            file_path="test.py", old_content=_BENIGN_OLD, new_content=new,
+        )
+        chain_hits = [f for f in findings if f.pattern == "dynamic_import_chain"]
+        assert len(chain_hits) == 0
+
+    def test_severity_is_hard(self, guardian):
+        new = _BENIGN_OLD + '\nexec("bad")\n'
+        hits = _detect(guardian, new)
+        assert all(h.severity == "hard" for h in hits)
+
+
+# ---------------------------------------------------------------------------
+# Multi-chain accumulation
+# ---------------------------------------------------------------------------
+
+
+class TestMultiChain:
+    def test_multiple_chains_counted(self, guardian):
+        new = _BENIGN_OLD + '''
+x = __import__("os")
+y = eval("1+1")
+z = exec("pass")
+w = compile("1", "", "eval")
+'''
+        hits = _detect(guardian, new)
+        assert len(hits) >= 1
+        # The delta should report 4 new nodes.
+        assert "4" in hits[0].snippet or "delta=4" in hits[0].snippet


### PR DESCRIPTION
## Summary

Wires the FOURTH production decision site (GATE phase / `risk_tier_assignment`) to the Determinism Substrate. **Closes the 1.3.x sequence** — every load-bearing decision in the 11-phase pipeline (ROUTE, CLASSIFY, GENERATE, GATE) now writes structured digests to the per-session ledger.

## Root problem solved

GATE's `risk_tier` mutates through **7+ sites** inside the runner — SimilarityGate, frozen_tier, RISK_CEILING, SemanticGuardian, MutationGate, MIN_RISK_TIER floor, NOTIFY_APPLY elevation paths. Without capture, post-mortem audit of WHY a particular op landed in a particular tier requires correlating multiple INFO logs by timestamp. With this slice, the **FINAL verdict** writes to the ledger as a structured digest.

## Wiring (closure-over-risk_tier pattern, mirrors Slice 1.3.b)

```python
# All 7 mutation sites run unchanged...

async def _gate_digest_compute() -> Any:
    return {
        "risk_tier": risk_tier.name,  # uppercase enum: "NOTIFY_APPLY"
        "has_best_candidate": bool(best_candidate),
    }

await capture_phase_decision(
    op_id=ctx.op_id, phase="GATE", kind="risk_tier_assignment",
    ctx=ctx, compute=_gate_digest_compute,
)

return PhaseResult(
    next_ctx=ctx, next_phase=APPROVE, status="ok", reason="gated",
    artifacts={"risk_tier": risk_tier, "best_candidate": ...},
)
```

## Capture placement

Capture is positioned **AFTER** all 7 mutation sites and **BEFORE** the success-path PhaseResult return at line 674. Fail paths (lines 155, 185, 559, 667) have their own structured reason codes and bypass the audit capture (avoids noise without signal).

## Digest shape

```
{risk_tier: str, has_best_candidate: bool}
```

`risk_tier.name` (uppercase enum identifier like `"NOTIFY_APPLY"`) — NOT `str(risk_tier)` which would print `"RiskTier.NOTIFY_APPLY"` with the class prefix. Identity adapter sufficient — pure JSON-friendly primitives.

## Authority invariants (pinned)

- `gate_runner` imports `phase_capture` **LAZILY** (inside function body)
- Capture happens **BEFORE** the success-path PhaseResult return (source ordering pin)
- Capture happens **AFTER** all known mutation sites (SimilarityGate, frozen_tier, RISK_CEILING — source ordering pin)
- Closure compute does **NOT** re-invoke gate mutation logic (source pin)
- Exactly **ONE** `capture_phase_decision` call (success path only)
- `risk_tier.name` used (not `str(risk_tier)`) — source pin

## Test plan

- [x] 15 new tests covering 15 pin sections
- [x] **700/700 green** across full Phase 1 + 12 + 12.2 regression suite
- [x] End-to-end RECORD-then-REPLAY pin proves recorded digest returned without re-invoking compute closure

## 1.3.x sequence COMPLETE

| Slice | Phase | Decision kind | Status |
|---|---|---|---|
| 1.3 | ROUTE | `route_assignment` | ✅ merged |
| 1.3.a | CLASSIFY | `advisor_verdict` | ✅ merged |
| 1.3.b | GENERATE | `provider_selection` | ✅ merged |
| **1.3.c** | **GATE** | **`risk_tier_assignment`** | **this PR** |

Every load-bearing decision in the 11-phase pipeline now captures to the per-session ledger.

## Roadmap (operator-gated)

| Slice | Scope |
|---|---|
| 1.5 | Graduation flip — defaults to true |
| 1.X cleanup | Unify master flags under `JARVIS_DETERMINISM_ENABLED` umbrella |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Captures the GATE phase’s final `risk_tier_assignment` verdict to the determinism ledger and adds a pure-function `PressureConvergenceProver` to model memory-pressure convergence. Completes the 1.3.x decision-capture sequence across ROUTE, CLASSIFY, GENERATE, and GATE.

- **New Features**
  - GATE wiring: records a digest `{ risk_tier: str, has_best_candidate: bool }` via `capture_phase_decision` after all mutation sites and before the success return; uses `risk_tier.name`; lazy import; try/except with `logger.debug`; success path only.
  - `pressure_convergence_prover.py`: pure, stdlib-only simulator for backlog ↔ pressure ↔ fanout; emits `CONVERGED`, `DRAINED`, or `OVERLOADED`; `check_overload` helper; batch runs; gated by `JARVIS_PRESSURE_CONVERGENCE_PROVER_ENABLED`.
  - Tests: 15 pins for GATE wiring incl. record→replay; full prover suite (convergence, deadlines, overload, config); 20 `SemanticGuardian` “dynamic_import_chain” quine variants plus false-positive guards and pattern registration.

<sup>Written for commit c88492a2d56ef725e36117e3cf84dd233d2bb131. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29102?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

