### PR TITLE
feat(phase1): Slice 1.5 — Graduation flip — CLOSES PHASE 1

### DIFF
--- a/backend/core/ouroboros/governance/determinism/clock.py
+++ b/backend/core/ouroboros/governance/determinism/clock.py
@@ -66,20 +66,24 @@ logger = logging.getLogger(__name__)
 
 
 def clock_enabled() -> bool:
-    """``JARVIS_DETERMINISM_CLOCK_ENABLED`` (default ``false``).
+    """``JARVIS_DETERMINISM_CLOCK_ENABLED`` (default ``true`` —
+    graduated in Phase 1 Slice 1.5).
 
-    Phase 1 Slice 1.1 master flag. Re-read at call time so monkeypatch
-    works in tests + operators can flip live without re-init. Default
-    flips to ``true`` at Phase 1 graduation slice.
+    Re-read at call time so monkeypatch works in tests + operators
+    can flip live without re-init. Hot-revert path: ``export
+    JARVIS_DETERMINISM_CLOCK_ENABLED=false`` returns ``clock_for_session``
+    to passthrough mode — RealClock without recording, bit-for-bit
+    identical to legacy ``time.monotonic()`` / ``time.time()``.
 
     When ``true``: ``clock_for_session`` returns a ``RealClock`` in
     RECORD mode (live) or ``FrozenClock`` (replay), depending on
     requested mode. When ``false``: returns a passthrough ``RealClock``
-    with recording disabled (bit-for-bit identical to legacy
-    ``time.monotonic()`` / ``time.time()``)."""
+    with recording disabled."""
     raw = os.environ.get(
         "JARVIS_DETERMINISM_CLOCK_ENABLED", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/determinism/decision_runtime.py
+++ b/backend/core/ouroboros/governance/determinism/decision_runtime.py
@@ -85,17 +85,23 @@ logger = logging.getLogger(__name__)
 
 
 def ledger_enabled() -> bool:
-    """``JARVIS_DETERMINISM_LEDGER_ENABLED`` (default ``false``).
+    """``JARVIS_DETERMINISM_LEDGER_ENABLED`` (default ``true`` —
+    graduated in Phase 1 Slice 1.5).
 
-    Phase 1 Slice 1.2 master kill switch. Re-read at call time so
-    monkeypatch works in tests + operators can flip live without
-    re-init. Default flips to ``true`` at Phase 1 graduation.
+    Re-read at call time so monkeypatch works in tests + operators
+    can flip live without re-init. Hot-revert path: ``export
+    JARVIS_DETERMINISM_LEDGER_ENABLED=false`` short-circuits
+    ``decide()`` to PASSTHROUGH (compute runs, no recording, no
+    lookup) regardless of mode env.
 
-    When ``false``: ``decide()`` short-circuits to PASSTHROUGH (just
-    runs compute, no recording, no lookup) regardless of mode env."""
+    When ``true``: ``decide()`` engages the configured mode
+    (RECORD/REPLAY/VERIFY/PASSTHROUGH per
+    JARVIS_DETERMINISM_LEDGER_MODE)."""
     raw = os.environ.get(
         "JARVIS_DETERMINISM_LEDGER_ENABLED", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/determinism/entropy.py
+++ b/backend/core/ouroboros/governance/determinism/entropy.py
@@ -74,19 +74,22 @@ logger = logging.getLogger(__name__)
 
 
 def entropy_enabled() -> bool:
-    """``JARVIS_DETERMINISM_ENTROPY_ENABLED`` (default ``false``).
+    """``JARVIS_DETERMINISM_ENTROPY_ENABLED`` (default ``true`` —
+    graduated in Phase 1 Slice 1.5).
 
-    Phase 1 Slice 1.1 master flag. Re-read at call time so monkeypatch
-    works in tests + operators can flip live without re-init. Default
-    flips to ``true`` at Phase 1 graduation slice.
+    Re-read at call time so monkeypatch works in tests + operators
+    can flip live without re-init. Hot-revert path: ``export
+    JARVIS_DETERMINISM_ENTROPY_ENABLED=false`` returns ``entropy_for``
+    to fresh non-deterministic streams (legacy bit-for-bit behavior).
 
     When ``true``: ``entropy_for(op_id)`` returns a deterministic
     stream. Replay-safe. When ``false``: returns a fresh non-
-    deterministic ``random.Random`` instance per call (legacy
-    behavior preserved bit-for-bit)."""
+    deterministic ``random.Random`` instance per call."""
     raw = os.environ.get(
         "JARVIS_DETERMINISM_ENTROPY_ENABLED", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/determinism/phase_capture.py
+++ b/backend/core/ouroboros/governance/determinism/phase_capture.py
@@ -72,23 +72,28 @@ logger = logging.getLogger(__name__)
 
 
 def phase_capture_enabled() -> bool:
-    """``JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED`` (default ``false``).
+    """``JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED`` (default ``true`` —
+    graduated in Phase 1 Slice 1.5).
 
-    Slice 1.3 master flag. Independent from
-    ``JARVIS_DETERMINISM_LEDGER_ENABLED`` (Slice 1.2) so operators
-    can record decisions WITHOUT firing the phase capture wrappers
-    (shadow recording on the runtime layer only) OR enable phase
-    capture WITHOUT fully enabling the ledger (PASSTHROUGH mode for
-    the wrappers themselves — no-op everywhere).
+    Independent from ``JARVIS_DETERMINISM_LEDGER_ENABLED`` (Slice 1.2)
+    so operators can record decisions WITHOUT firing the phase capture
+    wrappers (shadow recording on the runtime layer only) OR enable
+    phase capture WITHOUT fully enabling the ledger (PASSTHROUGH mode
+    for the wrappers themselves — no-op everywhere).
 
     Both flags must be ``true`` for capture to actually record; if
     either is off, ``capture_phase_decision`` is a pure passthrough.
 
     Re-read at call time so monkeypatch works in tests + operators
-    can flip live without re-init."""
+    can flip live without re-init. Hot-revert path: ``export
+    JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED=false`` returns the
+    wrappers to pure passthrough — production callsites continue to
+    work with bit-for-bit legacy behavior."""
     raw = os.environ.get(
         "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", "",
     ).strip().lower()
+    if raw == "":
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/tests/governance/test_determinism_clock.py
+++ b/tests/governance/test_determinism_clock.py
@@ -58,8 +58,17 @@ def clean_clock_state(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_flag_default_false(clean_clock_state) -> None:
-    assert clock_enabled() is False
+def test_flag_default_true(clean_clock_state) -> None:
+    """Phase 1 Slice 1.5 graduated default — env unset → True."""
+    assert clock_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", " ", "  "])
+def test_flag_empty_reads_as_default_true(
+    monkeypatch, clean_clock_state, val,
+) -> None:
+    monkeypatch.setenv("JARVIS_DETERMINISM_CLOCK_ENABLED", val)
+    assert clock_enabled() is True
 
 
 @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "On"])
@@ -68,8 +77,10 @@ def test_flag_truthy(monkeypatch, clean_clock_state, val) -> None:
     assert clock_enabled() is True
 
 
-@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage", ""])
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage"])
 def test_flag_falsy(monkeypatch, clean_clock_state, val) -> None:
+    """Hot-revert: explicit false-class strings disable. Empty/
+    whitespace are no longer falsy post-graduation."""
     monkeypatch.setenv("JARVIS_DETERMINISM_CLOCK_ENABLED", val)
     assert clock_enabled() is False
 
@@ -102,8 +113,13 @@ def test_master_flag_default_when_no_overrides(
     assert _resolve_mode(None) is ClockMode.RECORD
 
 
-def test_passthrough_when_flag_off(clean_clock_state) -> None:
-    """No env, flag off → PASSTHROUGH."""
+def test_passthrough_when_flag_off(
+    clean_clock_state, monkeypatch,
+) -> None:
+    """Explicit ``false`` for the master flag → PASSTHROUGH.
+    Post-Slice-1.5 the default is True, so 'flag off' must be set
+    explicitly via the hot-revert path."""
+    monkeypatch.setenv("JARVIS_DETERMINISM_CLOCK_ENABLED", "false")
     assert _resolve_mode(None) is ClockMode.PASSTHROUGH
 
 

--- a/tests/governance/test_determinism_decision_runtime.py
+++ b/tests/governance/test_determinism_decision_runtime.py
@@ -80,9 +80,16 @@ def isolated(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_ledger_default_false(monkeypatch) -> None:
+def test_ledger_default_true(monkeypatch) -> None:
+    """Phase 1 Slice 1.5 graduated default — env unset → True."""
     monkeypatch.delenv("JARVIS_DETERMINISM_LEDGER_ENABLED", raising=False)
-    assert ledger_enabled() is False
+    assert ledger_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", " ", "  "])
+def test_ledger_empty_reads_as_default_true(monkeypatch, val) -> None:
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_ENABLED", val)
+    assert ledger_enabled() is True
 
 
 @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
@@ -91,8 +98,10 @@ def test_ledger_truthy(monkeypatch, val) -> None:
     assert ledger_enabled() is True
 
 
-@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage", ""])
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage"])
 def test_ledger_falsy(monkeypatch, val) -> None:
+    """Hot-revert: explicit false-class strings disable. Empty/
+    whitespace map to graduated default True post-Slice-1.5."""
     monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_ENABLED", val)
     assert ledger_enabled() is False
 

--- a/tests/governance/test_determinism_entropy.py
+++ b/tests/governance/test_determinism_entropy.py
@@ -70,9 +70,17 @@ def isolated_state_dir(tmp_path, monkeypatch) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def test_flag_default_false(monkeypatch) -> None:
+def test_flag_default_true(monkeypatch) -> None:
+    """Phase 1 Slice 1.5 graduated default — env unset → True."""
     monkeypatch.delenv("JARVIS_DETERMINISM_ENTROPY_ENABLED", raising=False)
-    assert entropy_enabled() is False
+    assert entropy_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", " ", "  "])
+def test_flag_empty_reads_as_default_true(monkeypatch, val) -> None:
+    """Empty/whitespace values are the unset marker post-graduation."""
+    monkeypatch.setenv("JARVIS_DETERMINISM_ENTROPY_ENABLED", val)
+    assert entropy_enabled() is True
 
 
 @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on", "On"])
@@ -81,8 +89,11 @@ def test_flag_truthy(monkeypatch, val) -> None:
     assert entropy_enabled() is True
 
 
-@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage", "", " "])
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage"])
 def test_flag_falsy(monkeypatch, val) -> None:
+    """Hot-revert: explicit false-class strings disable the feature.
+    Empty/whitespace are no longer falsy post-graduation — they map
+    to the graduated default True."""
     monkeypatch.setenv("JARVIS_DETERMINISM_ENTROPY_ENABLED", val)
     assert entropy_enabled() is False
 

--- a/tests/governance/test_determinism_phase_capture.py
+++ b/tests/governance/test_determinism_phase_capture.py
@@ -113,11 +113,22 @@ def _ctx_stub(**kwargs):
 # ---------------------------------------------------------------------------
 
 
-def test_phase_capture_default_false(monkeypatch) -> None:
+def test_phase_capture_default_true(monkeypatch) -> None:
+    """Phase 1 Slice 1.5 graduated default — env unset → True."""
     monkeypatch.delenv(
         "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", raising=False,
     )
-    assert phase_capture_enabled() is False
+    assert phase_capture_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", " ", "  "])
+def test_phase_capture_empty_reads_as_default_true(
+    monkeypatch, val,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", val,
+    )
+    assert phase_capture_enabled() is True
 
 
 @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
@@ -128,8 +139,10 @@ def test_phase_capture_truthy(monkeypatch, val) -> None:
     assert phase_capture_enabled() is True
 
 
-@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage", ""])
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage"])
 def test_phase_capture_falsy(monkeypatch, val) -> None:
+    """Hot-revert: explicit false-class strings disable. Empty/
+    whitespace map to graduated default True post-Slice-1.5."""
     monkeypatch.setenv(
         "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", val,
     )

--- a/tests/governance/test_phase1_graduation_pins.py
+++ b/tests/governance/test_phase1_graduation_pins.py
@@ -1,0 +1,315 @@
+"""Phase 1 Slice 1.5 — graduation pin suite.
+
+Pins the graduated state of the four Phase 1 Determinism Substrate
+master flags. These were introduced default-false in Slices 1.1
+(entropy + clock), 1.2 (decision runtime), 1.3 (phase capture) and
+flipped to default-true in Slice 1.5.
+
+The pin suite enforces:
+
+  * defaults are True when env is unset OR empty-string OR whitespace
+  * each ``"false"``-class override returns False (hot-revert path)
+  * full-revert matrix: flipping one flag off doesn't cross-couple
+    any of the others
+  * source-level pins: each function literally returns ``True`` from
+    the empty-string branch (catches accidental refactor regression)
+
+All four flags can be hot-reverted independently. The flags govern
+distinct subsystems with independent rollback authority:
+
+  * JARVIS_DETERMINISM_ENTROPY_ENABLED       — Slice 1.1: per-op RNG streams
+  * JARVIS_DETERMINISM_CLOCK_ENABLED         — Slice 1.1: time recording
+  * JARVIS_DETERMINISM_LEDGER_ENABLED        — Slice 1.2: decision runtime
+  * JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED — Slice 1.3: callsite wrapper
+
+Pin sections:
+  §1  Defaults are True when env unset
+  §2  Empty-string env reads as default-True (unset marker)
+  §3  Whitespace-only env reads as default-True
+  §4  Each ``"false"``-class override returns False
+  §5  Full-revert matrix (one-off flip doesn't cross-couple)
+  §6  Garbage / unknown values revert to False (strict opt-in)
+  §7  Source-level pin: each function has the graduated branch
+  §8  Public API surface — graduated readers callable from module
+  §9  CLI surface (Slice 1.4 --rerun) still works post-graduation
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from backend.core.ouroboros.governance.determinism.clock import (
+    clock_enabled,
+)
+from backend.core.ouroboros.governance.determinism.decision_runtime import (
+    ledger_enabled,
+)
+from backend.core.ouroboros.governance.determinism.entropy import (
+    entropy_enabled,
+)
+from backend.core.ouroboros.governance.determinism.phase_capture import (
+    phase_capture_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Centralized graduated-flag list — single source of truth
+# ---------------------------------------------------------------------------
+
+
+_GRADUATED_FLAGS = [
+    ("JARVIS_DETERMINISM_ENTROPY_ENABLED", entropy_enabled),
+    ("JARVIS_DETERMINISM_CLOCK_ENABLED", clock_enabled),
+    ("JARVIS_DETERMINISM_LEDGER_ENABLED", ledger_enabled),
+    ("JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", phase_capture_enabled),
+]
+
+
+# ===========================================================================
+# §1 — Defaults are True when env unset
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_default_is_true_when_env_unset(
+    env_name: str, reader, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delenv → reader returns True. The graduated default."""
+    monkeypatch.delenv(env_name, raising=False)
+    assert reader() is True, (
+        f"Slice 1.5 graduation: {env_name} must default True"
+    )
+
+
+# ===========================================================================
+# §2 — Empty string is the unset marker
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_empty_string_reads_as_default_true(
+    env_name: str, reader, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setenv("", "")`` matches delenv. Operators commonly clear via
+    shell ``export FOO=`` (which sets to empty string)."""
+    monkeypatch.setenv(env_name, "")
+    assert reader() is True
+
+
+# ===========================================================================
+# §3 — Whitespace-only reads as default-True
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+@pytest.mark.parametrize("ws", [" ", "  ", "\t", " \t "])
+def test_whitespace_reads_as_default_true(
+    env_name: str, reader, ws: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``.strip()`` collapses whitespace to empty → graduated default."""
+    monkeypatch.setenv(env_name, ws)
+    assert reader() is True
+
+
+# ===========================================================================
+# §4 — Hot-revert: explicit false-class strings disable
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+@pytest.mark.parametrize("falsy", ["false", "0", "no", "off", "FALSE"])
+def test_false_class_string_reverts(
+    env_name: str, reader, falsy: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The four operator-visible false-class spellings still disable
+    the feature post-graduation. Critical for emergency rollback."""
+    monkeypatch.setenv(env_name, falsy)
+    assert reader() is False, (
+        f"{env_name}={falsy!r} should disable the feature"
+    )
+
+
+# ===========================================================================
+# §5 — Full-revert matrix
+# ===========================================================================
+
+
+def test_full_revert_matrix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flip each flag off in turn; verify ONLY that one flag flips
+    while the other three stay True. Catches accidental cross-coupling
+    (e.g., a refactor that gates the phase capture behind the ledger
+    flag would fail this matrix)."""
+    for env_off, _ in _GRADUATED_FLAGS:
+        # Reset all to default (delenv) — graduated state
+        for env_name, _r in _GRADUATED_FLAGS:
+            monkeypatch.delenv(env_name, raising=False)
+        # Flip exactly one off
+        monkeypatch.setenv(env_off, "false")
+        # Verify the flipped one is off, the rest still True
+        for env_name, reader in _GRADUATED_FLAGS:
+            expected = (env_name != env_off)
+            actual = reader()
+            assert actual is expected, (
+                f"After flipping {env_off}=false, {env_name} reader "
+                f"returned {actual} (expected {expected})"
+            )
+
+
+# ===========================================================================
+# §6 — Garbage values revert to False (strict opt-in to non-default)
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+@pytest.mark.parametrize("garbage", ["maybe", "unknown", "2", "ENABLED"])
+def test_garbage_values_revert_to_false(
+    env_name: str, reader, garbage: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-graduation: any non-truthy string returned False. Post-
+    graduation: empty/whitespace are now True (unset marker), but any
+    NON-empty string that isn't in the truthy set still returns False.
+    Asymmetric on purpose — operators must explicitly opt-in to
+    non-default values via the truthy strings."""
+    monkeypatch.setenv(env_name, garbage)
+    assert reader() is False, (
+        f"{env_name}={garbage!r} should revert to False — only the "
+        f"explicit truthy strings + the unset marker yield True"
+    )
+
+
+# ===========================================================================
+# §7 — Source-level pins (catches refactor regression)
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_source_has_graduated_branch(env_name: str, reader) -> None:
+    """Pin: each flag function has the ``if raw == "": return True``
+    graduated branch. Catches accidental revert via refactor."""
+    src = inspect.getsource(reader)
+    assert 'if raw == ""' in src, (
+        f"{reader.__name__} source must contain the graduated empty-"
+        f"string branch (Slice 1.5 pin)"
+    )
+    assert "return True" in src, (
+        f"{reader.__name__} source must contain `return True` for the "
+        f"graduated default"
+    )
+    # The function must still consult the truthy set so explicit
+    # opt-in values keep working.
+    assert '"true"' in src or "'true'" in src, (
+        f"{reader.__name__} source must still recognize 'true' as "
+        f"explicit truthy value"
+    )
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_source_documents_graduated_default(env_name: str, reader) -> None:
+    """Each docstring documents the graduated default. Operators
+    grepping for "default ``true``" find the four Slice 1.5 flags."""
+    src = inspect.getsource(reader)
+    # Either the docstring explicitly says "default ``true``" OR
+    # references the graduation slice. Allow both since style varies.
+    has_doc = (
+        "default ``true``" in src
+        or "graduated in Phase 1 Slice 1.5" in src
+    )
+    assert has_doc, (
+        f"{reader.__name__} docstring must document the graduated "
+        f"default (Slice 1.5)"
+    )
+
+
+# ===========================================================================
+# §8 — Public API surface
+# ===========================================================================
+
+
+@pytest.mark.parametrize("env_name,reader", _GRADUATED_FLAGS)
+def test_reader_is_callable_no_args(env_name: str, reader) -> None:
+    """Each flag function is callable with no arguments + returns a
+    bool. Stable contract for cross-module consumers."""
+    result = reader()
+    assert isinstance(result, bool), (
+        f"{reader.__name__} must return bool, got {type(result)}"
+    )
+
+
+def test_all_four_flags_exposed_from_package() -> None:
+    """``backend.core.ouroboros.governance.determinism`` __all__
+    exposes the four readers."""
+    from backend.core.ouroboros.governance import determinism
+    assert "entropy_enabled" in determinism.__all__
+    assert "clock_enabled" in determinism.__all__
+    assert "ledger_enabled" in determinism.__all__
+    assert "phase_capture_enabled" in determinism.__all__
+
+
+# ===========================================================================
+# §9 — Slice 1.4 CLI surface still works post-graduation
+# ===========================================================================
+
+
+def test_replay_cli_still_default_on(monkeypatch) -> None:
+    """The Slice 1.4 CLI master flag was already default-true before
+    graduation. Slice 1.5 should not have touched it."""
+    from backend.core.ouroboros.governance.determinism.session_replay import (
+        replay_cli_enabled,
+    )
+    monkeypatch.delenv(
+        "JARVIS_DETERMINISM_REPLAY_CLI_ENABLED", raising=False,
+    )
+    assert replay_cli_enabled() is True
+
+
+def test_replay_cli_hot_revert_still_works(monkeypatch) -> None:
+    from backend.core.ouroboros.governance.determinism.session_replay import (
+        replay_cli_enabled,
+    )
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_REPLAY_CLI_ENABLED", "false",
+    )
+    assert replay_cli_enabled() is False
+
+
+# ===========================================================================
+# §10 — Composability: all four flags engaged simultaneously
+# ===========================================================================
+
+
+def test_all_flags_engaged_simultaneously(monkeypatch) -> None:
+    """Default-on means all four substrates engage by default. Pin
+    that no flag silently disables itself when others are off
+    (cross-coupling regression check)."""
+    for env_name, _ in _GRADUATED_FLAGS:
+        monkeypatch.delenv(env_name, raising=False)
+    # All four readers should return True
+    assert entropy_enabled() is True
+    assert clock_enabled() is True
+    assert ledger_enabled() is True
+    assert phase_capture_enabled() is True
+
+
+def test_independent_subsystem_rollback(monkeypatch) -> None:
+    """Operator can roll back ANY single subsystem without affecting
+    the others. Critical for granular debugging in production."""
+    # Roll back ledger, keep others on
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_ENABLED", "false")
+    monkeypatch.delenv(
+        "JARVIS_DETERMINISM_ENTROPY_ENABLED", raising=False,
+    )
+    monkeypatch.delenv(
+        "JARVIS_DETERMINISM_CLOCK_ENABLED", raising=False,
+    )
+    monkeypatch.delenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", raising=False,
+    )
+
+    assert entropy_enabled() is True       # still on
+    assert clock_enabled() is True         # still on
+    assert ledger_enabled() is False       # rolled back
+    assert phase_capture_enabled() is True  # still on


### PR DESCRIPTION
## Summary

Phase 1 Slice 1.5 flips four master flags from default-false to default-true, **graduating the entire Determinism Substrate arc**. All four flags retain hot-revert paths — operators can roll back any subsystem independently.

## Graduated flags

| Flag | Slice | Subsystem |
|---|---|---|
| `JARVIS_DETERMINISM_ENTROPY_ENABLED` | 1.1 | Per-op deterministic RNG streams |
| `JARVIS_DETERMINISM_CLOCK_ENABLED` | 1.1 | Time recording + replay clock |
| `JARVIS_DETERMINISM_LEDGER_ENABLED` | 1.2 | DecisionRuntime + `decide()` |
| `JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED` | 1.3 | Production callsite wrapper |

## Gate semantics post-graduation (mirrors Phase 12.2 Slice E)

| Env value | Result | Notes |
|---|---|---|
| unset / `""` / whitespace | **True** | graduated default (unset marker) |
| `"1"` / `"true"` / `"yes"` / `"on"` | True | explicit opt-in |
| `"0"` / `"false"` / `"no"` / `"off"` | **False** | hot-revert path |
| any other non-empty string | False | strict opt-in to non-default |

The asymmetric mapping is deliberate: empty/whitespace become the unset marker post-graduation so operators clearing via shell `export FOO=` get the graduated default rather than accidentally reverting.

## What graduated-on means

Every JARVIS session now defaults to:
- Per-session deterministic seed at `.jarvis/determinism/<sid>/seed.json`
- Per-op TTFT samples via Slice 1.1 clock RECORD mode
- Per-op decisions written to `.jarvis/determinism/<sid>/decisions.jsonl`
- Phase capture wrapping at ROUTE / CLASSIFY / GENERATE / GATE
- `--rerun <session-id>` CLI immediately functional for any past session

The four phase wirings all have defensive `try/except` fallbacks to their pre-Slice behavior, so graduation is **safe** — if anything fails, the legacy path runs.

## Test updates (each Slice's flag-test contract evolves)

- `test_determinism_entropy.py` — `test_flag_default_false` → `test_flag_default_true` + new `test_flag_empty_reads_as_default_true`
- `test_determinism_clock.py` — same pattern; `test_passthrough_when_flag_off` updated to explicitly set the flag false (post-graduation "flag off" requires explicit false-class)
- `test_determinism_decision_runtime.py` — same pattern for `ledger_enabled`
- `test_determinism_phase_capture.py` — same pattern for `phase_capture_enabled`

## New graduation pin file (`test_phase1_graduation_pins.py`, 35+ pins)

10 pin sections following Phase 12.2 Slice E precedent:

- **§1** Defaults are True when env unset (4 flags × parametrize)
- **§2** Empty-string env reads as default-True (4 flags)
- **§3** Whitespace-only reads as default-True (4 flags × 4 ws variants)
- **§4** Each "false"-class override returns False (4 flags × 5 falsy)
- **§5** Full-revert matrix — flipping one flag doesn't cross-couple any others
- **§6** Garbage values revert to False (strict opt-in to non-default)
- **§7** Source-level pins — each function has the `if raw == "": return True` graduated branch + truthy set preserved + docstring documents Slice 1.5 graduation
- **§8** Public API surface — 4 flags exposed from `determinism` package
- **§9** Slice 1.4 CLI surface (`--rerun`) still works post-graduation
- **§10** Composability + independent rollback verified

## Test plan

- [x] **785/785 green** across full Phase 1 + 12 + 12.2 regression suite
- [x] **352/352 green** on the Phase 1 sub-suite specifically
- [x] Source-level pin proves the graduated branch exists in source (catches refactor-revert regression)
- [x] Full-revert matrix proves no cross-coupling between the 4 flags
- [x] Hot-revert path verified for every flag × every false-class spelling (4 × 5 = 20 cases)
- [x] Independent subsystem rollback test proves operators can disable any single subsystem without breaking the others

## Phase 1 architecturally complete

7 slices merged in this arc:

| Slice | Description | PR |
|---|---|---|
| 1.1 | Entropy + clock primitives | #29012 |
| 1.2 | DecisionRuntime + `decide()` | #29035 |
| 1.3 | phase_capture + ROUTE wired | #29074 |
| 1.3.a | CLASSIFY wired (`advisor_verdict`) | #29098 |
| 1.3.b | GENERATE wired (`provider_selection`) | #29099 |
| 1.3.c | GATE wired (`risk_tier_assignment`) | #29102 |
| 1.4 | Replay CLI (`--rerun`) | #29097 |
| **1.5** | **Graduation flip** | **this PR** |

## Notes

- Master-off byte-for-byte path preserved per slice — flipping any single flag back to "false" returns that subsystem to pre-Slice behavior immediately, no re-init required.
- Antigravity's parallel work (canonical_serialize, decision_trace_ledger, replay_harness, ConvergenceGovernor, ExplorationCalculus) has its own master flags — those graduate via Antigravity's own slice. This commit only touches my four flags.
- Phase 2 (Closed-Loop Self-Verification, §24.10 Critical Path #2) **NOT YET AUTHORIZED** — remains held per directive 2026-04-28.

## Roadmap (held — operator-gated)

| Slice | Scope |
|---|---|
| 1.X cleanup | Unify master flags under `JARVIS_DETERMINISM_ENABLED` umbrella; coordinate naming with Antigravity's `observability/determinism_substrate.py` |
| Phase 2 | Closed-Loop Self-Verification (operator authorization required) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates Phase 1 Determinism Substrate by flipping the four master flags to default true, with safe per-flag hot-revert. Sessions now record seeds, clock samples, decisions, and phase capture by default; `--rerun <session-id>` works out of the box.

- New Features
  - Default-on for entropy, clock, ledger, and phase capture.
  - Every session records deterministic seed, time samples (record mode), decisions, and wraps ROUTE/CLASSIFY/GENERATE/GATE; `--rerun <session-id>` works by default.
  - Safe rollback: set any flag to false to restore legacy behavior; subsystems are independent and keep defensive fallbacks.

- Migration
  - Unset or empty/whitespace env values now evaluate to True (graduated default).
  - "1/true/yes/on" => True; "0/false/no/off" => False; any other non-empty string => False.
  - To disable a subsystem in production, explicitly set its flag to a false-class value.

<sup>Written for commit c8775d56d8b60c03c658f61c4d570e35804d3f8c. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29106?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

