### PR TITLE
feat(phase2): Slice 2.2 — RepeatRunner (Bayesian statistical re-verification)

### DIFF
--- a/backend/core/ouroboros/governance/verification/__init__.py
+++ b/backend/core/ouroboros/governance/verification/__init__.py
@@ -36,14 +36,28 @@ from backend.core.ouroboros.governance.verification.property_oracle import (
     oracle_enabled,
     register_evaluator,
 )
+from backend.core.ouroboros.governance.verification.repeat_runner import (
+    EvidenceCollector,
+    RepeatRunner,
+    RepeatVerdict,
+    RunBudget,
+    get_default_runner,
+    repeat_runner_enabled,
+)
 
 __all__ = [
+    "EvidenceCollector",
     "Property",
     "PropertyEvaluator",
     "PropertyOracle",
     "PropertyVerdict",
+    "RepeatRunner",
+    "RepeatVerdict",
+    "RunBudget",
     "VerdictKind",
     "get_default_oracle",
+    "get_default_runner",
     "oracle_enabled",
     "register_evaluator",
+    "repeat_runner_enabled",
 ]

--- a/backend/core/ouroboros/governance/verification/repeat_runner.py
+++ b/backend/core/ouroboros/governance/verification/repeat_runner.py
@@ -1,0 +1,673 @@
+"""Phase 2 Slice 2.2 — RepeatRunner (statistical re-verification).
+
+Closes the second half of Slice 2.1's ``PropertyOracle`` foundation.
+Where the Oracle gives a deterministic single-run verdict, the
+RepeatRunner runs the verification N times against fresh evidence
+and aggregates the results into a Bayesian posterior — turning
+"this test passed once" into "this property holds with confidence
+P".
+
+ROOT PROBLEM SOLVED:
+
+A single PASSED verdict isn't enough for flaky tests. A single
+FAILED verdict could be variance noise. To claim "this property
+holds" with confidence, the system must:
+
+  1. Run the verification N times (each producing fresh evidence)
+  2. Aggregate the verdicts via Bayesian update
+  3. Stop early when confidence threshold is crossed
+  4. Report the final posterior + confidence interval
+
+Symptoms today (pre-Slice-2.2):
+  * "fixes flaky test Y" → VERIFY runs once and passes → op closes →
+    Y still flakes 5% in the wild.
+  * "improves runtime by 20%" → one run hits 18% (variance) → op
+    closes mistaking variance for gain.
+  * "regression-free refactor" → test suite passes once → caller
+    can't tell if the affected path is even covered.
+
+LAYERING (no duplication):
+
+  Slice 2.1 (mine, merged) — PropertyOracle: pure single-run
+                              dispatcher with 4-valued verdict
+  Slice 2.2 (this slice)    — RepeatRunner: Bayesian aggregator
+                              over N Oracle dispatches
+  Antigravity adaptation    — exploration_calculus: Bayesian
+                              primitives (bayesian_update, entropy,
+                              verdict_to_likelihood_ratio)
+
+The RepeatRunner IMPORTS Antigravity's primitives directly.
+Zero re-implementation of Bayesian math.
+
+Mapping from Slice 2.1's VerdictKind to Antigravity's LR:
+
+  PASSED                → "CONFIRMED" → LR ~3.0 (env-tunable)
+  FAILED                → "REFUTED"   → LR ~0.33
+  INSUFFICIENT_EVIDENCE → "INCONCLUSIVE" → LR 1.0 (no update)
+  EVALUATOR_ERROR       → "INCONCLUSIVE" → LR 1.0 (no update)
+
+OPERATOR'S DESIGN CONSTRAINTS APPLIED:
+
+  * Asynchronous — evidence_collector is async; runs execute in
+    parallel batches via asyncio.gather. Per-batch concurrency
+    env-tunable.
+  * Dynamic — confidence threshold, min/max runs, batch size all
+    env-readable at call time. Prior + evidence_collector are
+    free-form callables (no enum, no hardcoded property kinds).
+  * Adaptive — early-stop when confidence threshold crossed; max
+    runs as worst-case ceiling; insufficient/error verdicts don't
+    update the belief (preserve Bayesian validity).
+  * Intelligent — Bayesian update via Antigravity's bayesian_update
+    + verdict_to_likelihood_ratio. Posterior automatically clamped
+    to [MIN_PRIOR, MAX_PRIOR] to prevent degenerate beliefs.
+  * Robust — every public method NEVER raises. Individual run
+    failures become EVALUATOR_ERROR verdicts (don't poison the
+    belief). asyncio.gather wrapped to swallow per-task exceptions.
+  * No hardcoding — every threshold env-tunable; LR values come
+    from exploration_calculus's _confirmed_lr / _refuted_lr.
+  * Leverages existing — Antigravity's exploration_calculus +
+    Slice 2.1 Oracle. Zero duplication.
+
+AUTHORITY INVARIANTS (pinned by tests):
+  * NEVER imports orchestrator / phase_runner / candidate_generator
+  * NEVER imports any phase_runners/* module
+  * NEVER imports providers
+  * Every public method NEVER raises (except VERIFY-strict in
+    decide(), which doesn't apply here)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time as _time
+import traceback
+from dataclasses import dataclass, field
+from typing import (
+    Any, Awaitable, Callable, List, Mapping, Optional, Tuple,
+)
+
+from backend.core.ouroboros.governance.verification.property_oracle import (
+    Property,
+    PropertyOracle,
+    PropertyVerdict,
+    VerdictKind,
+    get_default_oracle,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Master flag + env-tunable defaults
+# ---------------------------------------------------------------------------
+
+
+def repeat_runner_enabled() -> bool:
+    """``JARVIS_VERIFICATION_REPEAT_RUNNER_ENABLED`` (default
+    ``false``).
+
+    Phase 2 Slice 2.2 master flag. Re-read at call time so monkey-
+    patch works in tests + operators can flip live without re-init.
+    Default flips to ``true`` at Phase 2 Slice 2.5 graduation.
+
+    When ``false``: callers can still construct + invoke the runner
+    (the dispatcher always works); production callers should treat
+    output as advisory only. Slice 2.5 flips production wiring at
+    the same time as the default flag flip — until then this is
+    shadow-mode infrastructure."""
+    raw = os.environ.get(
+        "JARVIS_VERIFICATION_REPEAT_RUNNER_ENABLED", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _default_min_runs() -> int:
+    """``JARVIS_VERIFICATION_REPEAT_MIN_RUNS`` (default 5).
+
+    The minimum number of runs required before early-stop is
+    eligible. Prevents the runner from declaring "PASSED with high
+    confidence" after a single PASS that happened to land in the
+    right region of the prior."""
+    try:
+        return max(1, int(
+            os.environ.get(
+                "JARVIS_VERIFICATION_REPEAT_MIN_RUNS", "5",
+            ).strip()
+        ))
+    except (ValueError, TypeError):
+        return 5
+
+
+def _default_max_runs() -> int:
+    """``JARVIS_VERIFICATION_REPEAT_MAX_RUNS`` (default 50).
+
+    Hard ceiling on runs regardless of belief state. Bounds cost +
+    wall time. Operators with deeper budgets can raise this; the
+    Bayesian math gracefully tightens the credible interval as N
+    grows but each run has cost."""
+    try:
+        return max(1, int(
+            os.environ.get(
+                "JARVIS_VERIFICATION_REPEAT_MAX_RUNS", "50",
+            ).strip()
+        ))
+    except (ValueError, TypeError):
+        return 50
+
+
+def _default_confidence_threshold() -> float:
+    """``JARVIS_VERIFICATION_REPEAT_CONFIDENCE`` (default 0.95).
+
+    Posterior threshold for early-stop. The runner stops when:
+      * posterior >= threshold (high-confidence PASS), OR
+      * (1 - posterior) >= threshold (high-confidence FAIL)
+
+    Default 0.95 → 95% credible interval that the property holds."""
+    try:
+        v = float(
+            os.environ.get(
+                "JARVIS_VERIFICATION_REPEAT_CONFIDENCE", "0.95",
+            ).strip()
+        )
+        # Clamp to (0.5, 1.0) — values <= 0.5 would be meaningless
+        return max(0.51, min(0.999, v))
+    except (ValueError, TypeError):
+        return 0.95
+
+
+def _default_concurrency() -> int:
+    """``JARVIS_VERIFICATION_REPEAT_CONCURRENCY`` (default 4).
+
+    Number of evidence_collector calls launched in parallel per
+    batch. After each batch the runner aggregates verdicts +
+    decides whether to launch another batch (early-stop check).
+    Higher concurrency → faster wall-time but more peak load on
+    the collector."""
+    try:
+        return max(1, int(
+            os.environ.get(
+                "JARVIS_VERIFICATION_REPEAT_CONCURRENCY", "4",
+            ).strip()
+        ))
+    except (ValueError, TypeError):
+        return 4
+
+
+# ---------------------------------------------------------------------------
+# RunBudget — caller-overridable runtime config
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RunBudget:
+    """Per-call configuration. Frozen — pass an explicit instance
+    to override the env-tunable defaults.
+
+    All fields are validated + clamped to safe ranges. NEVER raises
+    on bad input."""
+    min_runs: int = -1  # sentinel: read from env
+    max_runs: int = -1
+    confidence_threshold: float = -1.0
+    early_stop: bool = True
+    parallel_concurrency: int = -1
+    initial_prior: float = 0.5
+
+    def resolved_min_runs(self) -> int:
+        return self.min_runs if self.min_runs > 0 else _default_min_runs()
+
+    def resolved_max_runs(self) -> int:
+        return self.max_runs if self.max_runs > 0 else _default_max_runs()
+
+    def resolved_confidence(self) -> float:
+        return (
+            self.confidence_threshold
+            if 0.5 < self.confidence_threshold <= 1.0
+            else _default_confidence_threshold()
+        )
+
+    def resolved_concurrency(self) -> int:
+        return (
+            self.parallel_concurrency
+            if self.parallel_concurrency > 0
+            else _default_concurrency()
+        )
+
+    def resolved_prior(self) -> float:
+        # Clamp to (0, 1) per Antigravity's MIN_PRIOR/MAX_PRIOR
+        # convention — exact 0 or 1 are non-updatable beliefs.
+        return max(0.001, min(0.999, self.initial_prior))
+
+
+# ---------------------------------------------------------------------------
+# RepeatVerdict schema
+# ---------------------------------------------------------------------------
+
+
+REPEAT_VERDICT_SCHEMA_VERSION = "repeat_verdict.1"
+
+
+@dataclass(frozen=True)
+class RepeatVerdict:
+    """Aggregated verdict over N runs. Frozen + hashable.
+
+    Fields:
+      * runs_completed — actual number of evidence collections
+        (could be < max_runs if early-stopped; always >= min_runs
+        unless individual runs raised before reaching min)
+      * pass/fail/insufficient/error counts — verdict tally
+      * initial_prior — what the runner started with
+      * posterior — final Bayesian posterior P(property holds)
+      * confidence — distance from 0.5 (max(p, 1-p)); 0.5 = max
+        uncertainty, 1.0 = max certainty
+      * final_verdict — PASSED if posterior >= threshold; FAILED
+        if (1-posterior) >= threshold; INSUFFICIENT_EVIDENCE
+        otherwise
+      * early_stopped — true if the runner halted before max_runs
+        because confidence threshold was crossed
+      * halted_reason — diagnostic string (converged_pass /
+        converged_fail / max_runs_reached / collector_exhausted)
+      * individual_verdicts — per-run verdicts for forensics
+
+    Hashable — safe to use as dict keys + write to ledger."""
+    property_name: str
+    kind: str
+    runs_completed: int
+    pass_count: int
+    fail_count: int
+    insufficient_count: int
+    error_count: int
+    initial_prior: float
+    posterior: float
+    confidence: float
+    final_verdict: VerdictKind
+    early_stopped: bool
+    halted_reason: str
+    individual_verdicts: Tuple[PropertyVerdict, ...] = field(
+        default_factory=tuple,
+    )
+    schema_version: str = REPEAT_VERDICT_SCHEMA_VERSION
+    started_unix: float = 0.0
+    completed_unix: float = 0.0
+
+    @property
+    def passed(self) -> bool:
+        """Convenience: True iff final_verdict is PASSED."""
+        return self.final_verdict is VerdictKind.PASSED
+
+    @property
+    def is_terminal(self) -> bool:
+        """True iff final_verdict is PASSED or FAILED.
+        INSUFFICIENT_EVIDENCE is non-terminal — caller may want to
+        retry with more runs or fall back."""
+        return self.final_verdict in (
+            VerdictKind.PASSED, VerdictKind.FAILED,
+        )
+
+    @property
+    def total_decisive_runs(self) -> int:
+        """Pass+fail. Excludes insufficient/error since those don't
+        update the belief."""
+        return self.pass_count + self.fail_count
+
+
+# ---------------------------------------------------------------------------
+# Lazy adapters for Antigravity primitives (defensive)
+# ---------------------------------------------------------------------------
+
+
+def _bayesian_update_safely(
+    prior: float, verdict: VerdictKind,
+) -> float:
+    """Lazy import of Antigravity's bayesian_update. Falls back to
+    a stdlib-only Bernoulli update if the adaptation module is
+    unavailable. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.adaptation.exploration_calculus import (
+            bayesian_update,
+            verdict_to_likelihood_ratio,
+        )
+        verdict_str = _verdict_to_calculus_str(verdict)
+        lr = verdict_to_likelihood_ratio(verdict_str)
+        return bayesian_update(prior, lr)
+    except Exception:  # noqa: BLE001 — defensive
+        # Fallback: pure-stdlib LR convention (matches Antigravity's
+        # defaults). Operator who customized exploration_calculus
+        # via env will see drift, but the fallback math is sound.
+        return _fallback_bayesian_update(prior, verdict)
+
+
+def _verdict_to_calculus_str(v: VerdictKind) -> str:
+    if v is VerdictKind.PASSED:
+        return "CONFIRMED"
+    if v is VerdictKind.FAILED:
+        return "REFUTED"
+    return "INCONCLUSIVE"
+
+
+def _fallback_bayesian_update(
+    prior: float, verdict: VerdictKind,
+) -> float:
+    """Pure-stdlib Bernoulli posterior. Used only when
+    exploration_calculus unavailable. Matches the default LR
+    constants (CONFIRMED=3.0, REFUTED=0.33, else 1.0).
+
+    NEVER raises."""
+    p = max(0.001, min(0.999, float(prior)))
+    if v_lr := _DEFAULT_LR.get(verdict):
+        lr = v_lr
+    else:
+        lr = 1.0
+    try:
+        num = lr * p
+        den = lr * p + (1.0 - p)
+        if den <= 0.0:
+            return p
+        post = num / den
+        return max(0.001, min(0.999, post))
+    except (ZeroDivisionError, OverflowError):
+        return p
+
+
+_DEFAULT_LR = {
+    VerdictKind.PASSED: 3.0,
+    VerdictKind.FAILED: 0.33,
+    # INSUFFICIENT_EVIDENCE / EVALUATOR_ERROR → no entry → 1.0 (no update)
+}
+
+
+# ---------------------------------------------------------------------------
+# RepeatRunner — async batched aggregator
+# ---------------------------------------------------------------------------
+
+
+# An evidence_collector is an async callable that, given a run
+# index, returns the evidence mapping for that run. The collector
+# encapsulates the side effect (running pytest, taking a
+# measurement, querying state, etc.) — RepeatRunner orchestrates
+# the collector + Oracle dance N times with budget control.
+EvidenceCollector = Callable[[int], Awaitable[Mapping[str, Any]]]
+
+
+class RepeatRunner:
+    """Statistical re-verification orchestrator.
+
+    Stateless. Construction is cheap. Safe to share across threads /
+    async tasks. All state lives in the (immutable) ``RepeatVerdict``
+    return value.
+
+    Workflow:
+      1. Resolve RunBudget from env if defaults requested
+      2. Initialize posterior to prior
+      3. Loop:
+         a. Compute next batch size (min(concurrency, remaining))
+         b. Launch batch via asyncio.gather (per-task defensive)
+         c. For each verdict: increment counters, update posterior
+         d. Check early-stop (after min_runs)
+         e. If converged or out of budget, exit loop
+      4. Determine final_verdict from posterior
+      5. Return frozen RepeatVerdict
+    """
+
+    async def run(
+        self,
+        *,
+        prop: Property,
+        evidence_collector: EvidenceCollector,
+        budget: Optional[RunBudget] = None,
+        oracle: Optional[PropertyOracle] = None,
+    ) -> RepeatVerdict:
+        """Execute repeat verification. NEVER raises.
+
+        Parameters
+        ----------
+        prop : Property
+            The claim. Must have a registered ``kind`` in the Oracle
+            (otherwise every run returns INSUFFICIENT_EVIDENCE).
+        evidence_collector : EvidenceCollector
+            ``async (run_index: int) -> Mapping[str, Any]``. Called
+            once per run with a 0-indexed run number. The collector
+            owns the side effect of producing fresh evidence (e.g.,
+            spawning a subprocess to run pytest, taking a fresh
+            latency measurement).
+        budget : RunBudget, optional
+            Override env-tunable defaults. ``None`` → read from env.
+        oracle : PropertyOracle, optional
+            Override the Oracle instance. ``None`` → use the
+            module-level singleton.
+
+        Returns
+        -------
+        RepeatVerdict (always — never raises)."""
+        started = _time.time()
+        oracle = oracle or get_default_oracle()
+        budget = budget or RunBudget()
+
+        if prop is None:
+            return self._build_verdict(
+                prop_name="<None>", kind="<None>",
+                pass_count=0, fail_count=0, insuff_count=0,
+                err_count=0, prior=0.5, posterior=0.5,
+                final_verdict=VerdictKind.EVALUATOR_ERROR,
+                early_stopped=False,
+                halted_reason="property_is_none",
+                individual=tuple(),
+                started=started,
+            )
+
+        prior = budget.resolved_prior()
+        max_runs = budget.resolved_max_runs()
+        min_runs = min(budget.resolved_min_runs(), max_runs)
+        confidence = budget.resolved_confidence()
+        concurrency = budget.resolved_concurrency()
+
+        posterior = prior
+        pass_count = fail_count = insuff_count = err_count = 0
+        individual: List[PropertyVerdict] = []
+        early_stopped = False
+        halted_reason = "max_runs_reached"
+
+        runs_done = 0
+        while runs_done < max_runs:
+            remaining = max_runs - runs_done
+            batch_size = min(concurrency, remaining)
+
+            verdicts = await self._run_batch(
+                oracle=oracle,
+                prop=prop,
+                evidence_collector=evidence_collector,
+                start_index=runs_done,
+                batch_size=batch_size,
+            )
+
+            for v in verdicts:
+                individual.append(v)
+                if v.verdict is VerdictKind.PASSED:
+                    pass_count += 1
+                elif v.verdict is VerdictKind.FAILED:
+                    fail_count += 1
+                elif v.verdict is VerdictKind.INSUFFICIENT_EVIDENCE:
+                    insuff_count += 1
+                else:  # EVALUATOR_ERROR
+                    err_count += 1
+                posterior = _bayesian_update_safely(posterior, v.verdict)
+
+            runs_done += batch_size
+
+            # Early-stop check (after min_runs floor satisfied)
+            if budget.early_stop and runs_done >= min_runs:
+                if posterior >= confidence:
+                    early_stopped = True
+                    halted_reason = "converged_pass"
+                    break
+                if (1.0 - posterior) >= confidence:
+                    early_stopped = True
+                    halted_reason = "converged_fail"
+                    break
+
+        # Determine final verdict from posterior + counts
+        final_verdict = self._classify_final(
+            posterior=posterior, confidence=confidence,
+            pass_count=pass_count, fail_count=fail_count,
+            insuff_count=insuff_count, err_count=err_count,
+        )
+
+        return self._build_verdict(
+            prop_name=prop.name, kind=prop.kind,
+            pass_count=pass_count, fail_count=fail_count,
+            insuff_count=insuff_count, err_count=err_count,
+            prior=prior, posterior=posterior,
+            final_verdict=final_verdict,
+            early_stopped=early_stopped,
+            halted_reason=halted_reason,
+            individual=tuple(individual),
+            started=started,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _run_batch(
+        self,
+        *,
+        oracle: PropertyOracle,
+        prop: Property,
+        evidence_collector: EvidenceCollector,
+        start_index: int,
+        batch_size: int,
+    ) -> List[PropertyVerdict]:
+        """Launch a batch of runs in parallel. Returns one verdict
+        per slot. Per-task exceptions become EVALUATOR_ERROR
+        verdicts so the batch always returns batch_size results."""
+        tasks = [
+            self._single_run(
+                oracle=oracle, prop=prop,
+                evidence_collector=evidence_collector,
+                run_index=start_index + i,
+            )
+            for i in range(batch_size)
+        ]
+        return await asyncio.gather(*tasks)
+
+    async def _single_run(
+        self,
+        *,
+        oracle: PropertyOracle,
+        prop: Property,
+        evidence_collector: EvidenceCollector,
+        run_index: int,
+    ) -> PropertyVerdict:
+        """Collect evidence + dispatch to Oracle. Defensive everywhere.
+        Returns a PropertyVerdict regardless of what happens."""
+        try:
+            evidence = await evidence_collector(run_index)
+        except Exception as exc:  # noqa: BLE001 — defensive
+            tb = traceback.format_exc(limit=3)
+            return PropertyVerdict(
+                property_name=prop.name, kind=prop.kind,
+                verdict=VerdictKind.EVALUATOR_ERROR,
+                confidence=0.0,
+                reason=(
+                    f"evidence_collector raised {type(exc).__name__} "
+                    f"on run_index={run_index}: {exc}\n{tb}"
+                ),
+            )
+        if not isinstance(evidence, Mapping):
+            return PropertyVerdict(
+                property_name=prop.name, kind=prop.kind,
+                verdict=VerdictKind.EVALUATOR_ERROR,
+                confidence=0.0,
+                reason=(
+                    f"evidence_collector returned "
+                    f"{type(evidence).__name__} (expected Mapping) "
+                    f"on run_index={run_index}"
+                ),
+            )
+        return oracle.evaluate(prop=prop, evidence=evidence)
+
+    @staticmethod
+    def _classify_final(
+        *,
+        posterior: float,
+        confidence: float,
+        pass_count: int,
+        fail_count: int,
+        insuff_count: int,
+        err_count: int,
+    ) -> VerdictKind:
+        """Map posterior → final VerdictKind."""
+        if posterior >= confidence:
+            return VerdictKind.PASSED
+        if (1.0 - posterior) >= confidence:
+            return VerdictKind.FAILED
+        # Below threshold either way — uncertain.
+        # If insuff/err dominated, attribute to insufficient.
+        # If pass+fail dominated but neither hit threshold, also
+        # insufficient (we ran but couldn't decide).
+        return VerdictKind.INSUFFICIENT_EVIDENCE
+
+    def _build_verdict(
+        self,
+        *,
+        prop_name: str,
+        kind: str,
+        pass_count: int,
+        fail_count: int,
+        insuff_count: int,
+        err_count: int,
+        prior: float,
+        posterior: float,
+        final_verdict: VerdictKind,
+        early_stopped: bool,
+        halted_reason: str,
+        individual: Tuple[PropertyVerdict, ...],
+        started: float,
+    ) -> RepeatVerdict:
+        runs_completed = (
+            pass_count + fail_count + insuff_count + err_count
+        )
+        confidence = max(posterior, 1.0 - posterior)
+        return RepeatVerdict(
+            property_name=prop_name,
+            kind=kind,
+            runs_completed=runs_completed,
+            pass_count=pass_count,
+            fail_count=fail_count,
+            insufficient_count=insuff_count,
+            error_count=err_count,
+            initial_prior=prior,
+            posterior=posterior,
+            confidence=confidence,
+            final_verdict=final_verdict,
+            early_stopped=early_stopped,
+            halted_reason=halted_reason,
+            individual_verdicts=individual,
+            started_unix=started,
+            completed_unix=_time.time(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Singleton accessor
+# ---------------------------------------------------------------------------
+
+
+_default_runner = RepeatRunner()
+
+
+def get_default_runner() -> RepeatRunner:
+    """Public accessor for the module-level RepeatRunner. Stateless,
+    so the singleton is just for cache locality + test mocking."""
+    return _default_runner
+
+
+__all__ = [
+    "EvidenceCollector",
+    "REPEAT_VERDICT_SCHEMA_VERSION",
+    "RepeatRunner",
+    "RepeatVerdict",
+    "RunBudget",
+    "get_default_runner",
+    "repeat_runner_enabled",
+]

--- a/tests/governance/test_verification_property_oracle.py
+++ b/tests/governance/test_verification_property_oracle.py
@@ -570,16 +570,20 @@ def test_no_provider_imports() -> None:
 
 
 def test_six_seed_evaluators_present_after_import() -> None:
-    """Fresh import must register the six seed evaluators."""
-    import importlib
-    import backend.core.ouroboros.governance.verification.property_oracle as po
-    importlib.reload(po)
+    """Module-level import must register the six seed evaluators.
+
+    Avoid importlib.reload: it breaks the cross-module reference
+    graph (RepeatRunner + package __init__ still hold stale
+    references to the OLD _EVALUATORS dict). Instead, verify the
+    seed kinds are present after a fresh registry reset (which
+    re-runs _register_seed_evaluators on the LIVE module)."""
+    reset_registry_for_tests()
     expected = {
         "test_passes", "key_present",
         "numeric_below_threshold", "numeric_above_threshold",
         "string_matches", "set_subset",
     }
-    assert expected <= set(po.known_kinds())
+    assert expected <= set(known_kinds())
 
 
 def test_oracle_singleton_returns_same_instance() -> None:

--- a/tests/governance/test_verification_repeat_runner.py
+++ b/tests/governance/test_verification_repeat_runner.py
@@ -1,0 +1,717 @@
+"""Phase 2 Slice 2.2 — RepeatRunner regression spine.
+
+Pins:
+  §1   repeat_runner_enabled flag — default false; case-tolerant
+  §2   RunBudget — sentinels resolve to env defaults
+  §3   RunBudget — explicit values override defaults
+  §4   RunBudget — clamps invalid values gracefully
+  §5   RepeatVerdict — frozen + .passed + .is_terminal helpers
+  §6   RepeatVerdict — total_decisive_runs accessor
+  §7   Single all-pass batch → PASSED with high confidence
+  §8   Single all-fail batch → FAILED with high confidence
+  §9   Mixed pass/fail → INSUFFICIENT_EVIDENCE if neither hits threshold
+  §10  Early-stop on converged_pass triggers before max_runs
+  §11  Early-stop on converged_fail triggers before max_runs
+  §12  early_stop=False runs full max_runs even when converged
+  §13  min_runs gate prevents premature early-stop
+  §14  Non-Mapping evidence → EVALUATOR_ERROR (run-level defensive)
+  §15  Collector raises → EVALUATOR_ERROR (no propagation)
+  §16  None Property → graceful EVALUATOR_ERROR top-level
+  §17  Insufficient/error verdicts don't update belief
+  §18  Parallel batch concurrency (env-tunable)
+  §19  Bayesian update integration with Antigravity exploration_calculus
+  §20  Fallback Bayesian update when calculus unavailable
+  §21  RepeatVerdict.individual_verdicts captures all runs
+  §22  Authority invariants — no orchestrator/phase_runner/provider imports
+  §23  Verdict→calculus-string mapping (PASSED/FAILED/INSUFFICIENT)
+  §24  Public API exposed from package __init__
+  §25  Singleton accessor returns same instance
+  §26  Posterior clamped to (0, 1) — no degenerate beliefs
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Mapping
+from unittest.mock import patch
+
+import pytest
+
+from backend.core.ouroboros.governance.verification import (
+    Property,
+    PropertyVerdict,
+    RepeatRunner,
+    RepeatVerdict,
+    RunBudget,
+    VerdictKind,
+    get_default_oracle,
+    get_default_runner,
+    register_evaluator,
+    repeat_runner_enabled,
+)
+from backend.core.ouroboros.governance.verification.property_oracle import (
+    reset_registry_for_tests,
+)
+from backend.core.ouroboros.governance.verification.repeat_runner import (
+    REPEAT_VERDICT_SCHEMA_VERSION,
+    _bayesian_update_safely,
+    _fallback_bayesian_update,
+    _verdict_to_calculus_str,
+)
+
+
+@pytest.fixture
+def fresh_registry():
+    reset_registry_for_tests()
+    yield
+    reset_registry_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# §1 — Master flag
+# ---------------------------------------------------------------------------
+
+
+def test_runner_default_false(monkeypatch) -> None:
+    monkeypatch.delenv(
+        "JARVIS_VERIFICATION_REPEAT_RUNNER_ENABLED", raising=False,
+    )
+    assert repeat_runner_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_runner_truthy(monkeypatch, val) -> None:
+    monkeypatch.setenv(
+        "JARVIS_VERIFICATION_REPEAT_RUNNER_ENABLED", val,
+    )
+    assert repeat_runner_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage", ""])
+def test_runner_falsy(monkeypatch, val) -> None:
+    monkeypatch.setenv(
+        "JARVIS_VERIFICATION_REPEAT_RUNNER_ENABLED", val,
+    )
+    assert repeat_runner_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# §2-§4 — RunBudget
+# ---------------------------------------------------------------------------
+
+
+def test_run_budget_sentinels_resolve_to_env_defaults() -> None:
+    b = RunBudget()
+    assert b.resolved_min_runs() == 5
+    assert b.resolved_max_runs() == 50
+    assert abs(b.resolved_confidence() - 0.95) < 1e-6
+    assert b.resolved_concurrency() == 4
+    assert abs(b.resolved_prior() - 0.5) < 1e-6
+
+
+def test_run_budget_explicit_overrides() -> None:
+    b = RunBudget(
+        min_runs=2, max_runs=10, confidence_threshold=0.99,
+        early_stop=False, parallel_concurrency=8, initial_prior=0.7,
+    )
+    assert b.resolved_min_runs() == 2
+    assert b.resolved_max_runs() == 10
+    assert abs(b.resolved_confidence() - 0.99) < 1e-6
+    assert b.early_stop is False
+    assert b.resolved_concurrency() == 8
+    assert abs(b.resolved_prior() - 0.7) < 1e-6
+
+
+def test_run_budget_clamps_invalid_confidence() -> None:
+    """Confidence ≤ 0.5 falls through to env default (meaningless)."""
+    b = RunBudget(confidence_threshold=0.3)
+    # Falls through to env default 0.95
+    assert abs(b.resolved_confidence() - 0.95) < 1e-6
+
+
+def test_run_budget_clamps_invalid_prior() -> None:
+    """Prior is clamped to (0.001, 0.999) per Antigravity convention."""
+    assert abs(RunBudget(initial_prior=0.0).resolved_prior() - 0.001) < 1e-3
+    assert abs(RunBudget(initial_prior=1.0).resolved_prior() - 0.999) < 1e-3
+    assert abs(
+        RunBudget(initial_prior=-5.0).resolved_prior() - 0.001
+    ) < 1e-3
+
+
+def test_run_budget_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_VERIFICATION_REPEAT_MIN_RUNS", "3")
+    monkeypatch.setenv("JARVIS_VERIFICATION_REPEAT_MAX_RUNS", "20")
+    monkeypatch.setenv("JARVIS_VERIFICATION_REPEAT_CONFIDENCE", "0.90")
+    monkeypatch.setenv("JARVIS_VERIFICATION_REPEAT_CONCURRENCY", "2")
+    b = RunBudget()
+    assert b.resolved_min_runs() == 3
+    assert b.resolved_max_runs() == 20
+    assert abs(b.resolved_confidence() - 0.90) < 1e-6
+    assert b.resolved_concurrency() == 2
+
+
+# ---------------------------------------------------------------------------
+# §5-§6 — RepeatVerdict
+# ---------------------------------------------------------------------------
+
+
+def test_repeat_verdict_is_frozen() -> None:
+    v = RepeatVerdict(
+        property_name="x", kind="y", runs_completed=5,
+        pass_count=4, fail_count=1, insufficient_count=0, error_count=0,
+        initial_prior=0.5, posterior=0.95, confidence=0.95,
+        final_verdict=VerdictKind.PASSED, early_stopped=True,
+        halted_reason="converged_pass",
+    )
+    with pytest.raises(Exception):
+        v.runs_completed = 10  # type: ignore[misc]
+
+
+def test_repeat_verdict_passed_helper() -> None:
+    v = RepeatVerdict(
+        property_name="x", kind="y", runs_completed=5,
+        pass_count=5, fail_count=0, insufficient_count=0, error_count=0,
+        initial_prior=0.5, posterior=0.99, confidence=0.99,
+        final_verdict=VerdictKind.PASSED, early_stopped=True,
+        halted_reason="converged_pass",
+    )
+    assert v.passed is True
+    assert v.is_terminal is True
+
+
+def test_repeat_verdict_total_decisive_runs() -> None:
+    v = RepeatVerdict(
+        property_name="x", kind="y", runs_completed=10,
+        pass_count=5, fail_count=2, insufficient_count=2, error_count=1,
+        initial_prior=0.5, posterior=0.7, confidence=0.7,
+        final_verdict=VerdictKind.INSUFFICIENT_EVIDENCE,
+        early_stopped=False, halted_reason="max_runs_reached",
+    )
+    assert v.total_decisive_runs == 7  # 5 + 2 (excludes insuff/err)
+
+
+def test_repeat_verdict_schema_version_pinned() -> None:
+    assert REPEAT_VERDICT_SCHEMA_VERSION == "repeat_verdict.1"
+
+
+# ---------------------------------------------------------------------------
+# §7-§9 — All-pass / all-fail / mixed runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_pass_yields_passed(fresh_registry) -> None:
+    """10 runs all PASS → posterior > 0.95 → final PASSED."""
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return {"exit_code": 0}
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(min_runs=5, max_runs=20),
+    )
+    assert result.final_verdict is VerdictKind.PASSED
+    assert result.pass_count >= 5  # at least min_runs
+    assert result.fail_count == 0
+    assert result.posterior > 0.95
+    assert result.passed is True
+
+
+@pytest.mark.asyncio
+async def test_all_fail_yields_failed(fresh_registry) -> None:
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return {"exit_code": 1}
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(min_runs=5, max_runs=20),
+    )
+    assert result.final_verdict is VerdictKind.FAILED
+    assert result.fail_count >= 5
+    assert result.pass_count == 0
+    assert result.posterior < 0.05
+    assert (1.0 - result.posterior) > 0.95
+
+
+@pytest.mark.asyncio
+async def test_balanced_mix_insufficient_evidence(
+    fresh_registry,
+) -> None:
+    """Alternating pass/fail → posterior stays near prior → INSUFFICIENT."""
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return {"exit_code": 0 if idx % 2 == 0 else 1}
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(min_runs=10, max_runs=10, early_stop=False),
+    )
+    # Alternating pass/fail → ~50/50 → no high-confidence verdict
+    assert result.final_verdict is VerdictKind.INSUFFICIENT_EVIDENCE
+    assert result.pass_count == 5
+    assert result.fail_count == 5
+
+
+# ---------------------------------------------------------------------------
+# §10-§13 — Early-stop semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_early_stop_on_converged_pass(fresh_registry) -> None:
+    """All-pass triggers early-stop after min_runs."""
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+    call_count = {"n": 0}
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        call_count["n"] += 1
+        return {"exit_code": 0}
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(
+            min_runs=5, max_runs=100,
+            confidence_threshold=0.95, early_stop=True,
+            parallel_concurrency=1,  # sequential for clean accounting
+        ),
+    )
+    assert result.early_stopped is True
+    assert result.halted_reason == "converged_pass"
+    assert result.runs_completed < 100
+    # All-pass → 5 runs of LR=3.0 starting from prior=0.5:
+    # posterior ~= 0.996, well above 0.95 — converges by run 5
+    assert result.runs_completed >= 5
+
+
+@pytest.mark.asyncio
+async def test_early_stop_on_converged_fail(fresh_registry) -> None:
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return {"exit_code": 1}
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(
+            min_runs=5, max_runs=100,
+            confidence_threshold=0.95, early_stop=True,
+            parallel_concurrency=1,
+        ),
+    )
+    assert result.early_stopped is True
+    assert result.halted_reason == "converged_fail"
+    assert result.runs_completed >= 5
+    assert result.runs_completed < 100
+
+
+@pytest.mark.asyncio
+async def test_early_stop_disabled_runs_full_budget(
+    fresh_registry,
+) -> None:
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return {"exit_code": 0}
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(
+            min_runs=5, max_runs=15, early_stop=False,
+            parallel_concurrency=1,
+        ),
+    )
+    assert result.early_stopped is False
+    assert result.runs_completed == 15
+
+
+@pytest.mark.asyncio
+async def test_min_runs_floors_early_stop(fresh_registry) -> None:
+    """Even with all-pass + tight confidence, can't early-stop
+    before min_runs."""
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return {"exit_code": 0}
+
+    # min_runs=10 forces at least 10 runs even though convergence
+    # would happen by run 5
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(
+            min_runs=10, max_runs=20, early_stop=True,
+            parallel_concurrency=1,
+        ),
+    )
+    assert result.runs_completed >= 10
+
+
+# ---------------------------------------------------------------------------
+# §14-§16 — Defensive paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_mapping_evidence_becomes_error(fresh_registry) -> None:
+    """Collector returning non-Mapping → EVALUATOR_ERROR per run."""
+    runner = RepeatRunner()
+    p = Property.make(kind="test_passes", name="t")
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return "not a mapping"  # type: ignore[return-value]
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(min_runs=3, max_runs=3, early_stop=False),
+    )
+    assert result.error_count == 3
+    # Errors don't update belief — posterior stays at prior
+    assert abs(result.posterior - 0.5) < 1e-6
+    # Insuff/error dominated → INSUFFICIENT_EVIDENCE
+    assert result.final_verdict is VerdictKind.INSUFFICIENT_EVIDENCE
+
+
+@pytest.mark.asyncio
+async def test_collector_raises_becomes_error(fresh_registry) -> None:
+    """Collector exception → EVALUATOR_ERROR with traceback."""
+    runner = RepeatRunner()
+    p = Property.make(kind="test_passes", name="t")
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        raise RuntimeError(f"simulated fault on run {idx}")
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(min_runs=3, max_runs=3, early_stop=False),
+    )
+    assert result.error_count == 3
+    # Reasons should mention the runtime error
+    assert any(
+        "simulated fault" in v.reason
+        for v in result.individual_verdicts
+    )
+
+
+@pytest.mark.asyncio
+async def test_none_property_graceful() -> None:
+    runner = RepeatRunner()
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return {}
+
+    result = await runner.run(
+        prop=None, evidence_collector=collector,  # type: ignore[arg-type]
+    )
+    assert result.final_verdict is VerdictKind.EVALUATOR_ERROR
+    assert result.halted_reason == "property_is_none"
+
+
+# ---------------------------------------------------------------------------
+# §17 — Insufficient/error verdicts don't update belief
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insufficient_verdicts_dont_move_belief(
+    fresh_registry,
+) -> None:
+    """If all runs return INSUFFICIENT_EVIDENCE (e.g., missing
+    evidence keys), posterior stays at prior."""
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return {}  # missing exit_code → INSUFFICIENT_EVIDENCE
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(
+            min_runs=5, max_runs=5, early_stop=False,
+            initial_prior=0.7,
+        ),
+    )
+    assert result.insufficient_count == 5
+    assert result.pass_count == 0
+    assert result.fail_count == 0
+    # Belief stayed at prior = 0.7 (no LR updates)
+    assert abs(result.posterior - 0.7) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# §18 — Parallel batching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parallel_concurrency_actually_parallel(
+    fresh_registry,
+) -> None:
+    """concurrency=4 with 4 slow collectors should complete in
+    ~1× the slow time, not 4×."""
+    import time
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+
+    async def slow_collector(idx: int) -> Mapping[str, Any]:
+        await asyncio.sleep(0.05)  # 50ms simulated work
+        return {"exit_code": 0}
+
+    started = time.monotonic()
+    await runner.run(
+        prop=p, evidence_collector=slow_collector,
+        budget=RunBudget(
+            min_runs=4, max_runs=4, early_stop=False,
+            parallel_concurrency=4,
+        ),
+    )
+    elapsed = time.monotonic() - started
+    # 4 runs at 50ms in parallel → ~50ms total, not ~200ms
+    # Allow generous slack for scheduling overhead
+    assert elapsed < 0.15, f"runs not parallel — elapsed={elapsed:.3f}s"
+
+
+@pytest.mark.asyncio
+async def test_concurrency_eq_one_sequential(fresh_registry) -> None:
+    """concurrency=1 forces sequential execution — useful for
+    clean ordinal-tracking tests."""
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+    indices_seen = []
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        indices_seen.append(idx)
+        return {"exit_code": 0}
+
+    await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(
+            min_runs=5, max_runs=5, early_stop=False,
+            parallel_concurrency=1,
+        ),
+    )
+    # Each call gets a unique 0-indexed run number
+    assert sorted(indices_seen) == [0, 1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# §19-§20 — Bayesian update integration + fallback
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_to_calculus_string_mapping() -> None:
+    assert _verdict_to_calculus_str(VerdictKind.PASSED) == "CONFIRMED"
+    assert _verdict_to_calculus_str(VerdictKind.FAILED) == "REFUTED"
+    assert _verdict_to_calculus_str(
+        VerdictKind.INSUFFICIENT_EVIDENCE,
+    ) == "INCONCLUSIVE"
+    assert _verdict_to_calculus_str(
+        VerdictKind.EVALUATOR_ERROR,
+    ) == "INCONCLUSIVE"
+
+
+def test_bayesian_update_via_antigravity_calculus() -> None:
+    """A PASSED verdict moves posterior up; FAILED moves down."""
+    # Prior 0.5, PASSED → posterior > 0.5
+    p_after_pass = _bayesian_update_safely(0.5, VerdictKind.PASSED)
+    assert p_after_pass > 0.5
+    # Prior 0.5, FAILED → posterior < 0.5
+    p_after_fail = _bayesian_update_safely(0.5, VerdictKind.FAILED)
+    assert p_after_fail < 0.5
+    # INSUFFICIENT/ERROR → no change
+    assert (
+        _bayesian_update_safely(0.5, VerdictKind.INSUFFICIENT_EVIDENCE)
+        == 0.5
+    )
+    assert (
+        _bayesian_update_safely(0.5, VerdictKind.EVALUATOR_ERROR)
+        == 0.5
+    )
+
+
+def test_fallback_bayesian_update_works_without_calculus() -> None:
+    """When exploration_calculus is unavailable, the fallback math
+    produces sound results matching the default LR convention."""
+    p_after_pass = _fallback_bayesian_update(0.5, VerdictKind.PASSED)
+    assert p_after_pass > 0.5
+    p_after_fail = _fallback_bayesian_update(0.5, VerdictKind.FAILED)
+    assert p_after_fail < 0.5
+
+
+def test_bayesian_update_falls_back_on_import_failure() -> None:
+    """If the adaptation module is patched to fail import,
+    _bayesian_update_safely uses the fallback."""
+    # Use a ModuleNotFoundError raised at import to simulate
+    with patch.dict(
+        "sys.modules",
+        {"backend.core.ouroboros.governance.adaptation.exploration_calculus": None},
+    ):
+        # Force re-import path to fail
+        result = _bayesian_update_safely(0.5, VerdictKind.PASSED)
+        # Must still return a valid posterior
+        assert 0.001 <= result <= 0.999
+
+
+# ---------------------------------------------------------------------------
+# §21 — individual_verdicts captured
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_individual_verdicts_captured(fresh_registry) -> None:
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return {"exit_code": 0 if idx < 3 else 1}
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(
+            min_runs=5, max_runs=5, early_stop=False,
+            parallel_concurrency=1,
+        ),
+    )
+    assert len(result.individual_verdicts) == 5
+    # First 3 PASSED, last 2 FAILED
+    pass_idx = [
+        i for i, v in enumerate(result.individual_verdicts)
+        if v.verdict is VerdictKind.PASSED
+    ]
+    fail_idx = [
+        i for i, v in enumerate(result.individual_verdicts)
+        if v.verdict is VerdictKind.FAILED
+    ]
+    assert pass_idx == [0, 1, 2]
+    assert fail_idx == [3, 4]
+
+
+# ---------------------------------------------------------------------------
+# §22 — Authority invariants
+# ---------------------------------------------------------------------------
+
+
+def test_no_orchestrator_imports() -> None:
+    import inspect
+    from backend.core.ouroboros.governance.verification import (
+        repeat_runner,
+    )
+    src = inspect.getsource(repeat_runner)
+    forbidden = (
+        "from backend.core.ouroboros.governance.orchestrator",
+        "from backend.core.ouroboros.governance.phase_runner ",
+        "from backend.core.ouroboros.governance.candidate_generator",
+    )
+    for f in forbidden:
+        assert f not in src, f"repeat_runner must NOT contain {f!r}"
+
+
+def test_no_phase_runners_imports() -> None:
+    """AST-walk: no actual import statements pull from phase_runners.
+    Docstring mentions of 'phase_runners' (e.g., "we do not import
+    any phase_runners/* module") are not import sites — use AST."""
+    import ast
+    import inspect
+    from backend.core.ouroboros.governance.verification import (
+        repeat_runner,
+    )
+    tree = ast.parse(inspect.getsource(repeat_runner))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert "phase_runners" not in node.module, (
+                f"forbidden import: from {node.module} ..."
+            )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                assert "phase_runners" not in alias.name, (
+                    f"forbidden import: import {alias.name}"
+                )
+
+
+def test_no_provider_imports() -> None:
+    import inspect
+    from backend.core.ouroboros.governance.verification import (
+        repeat_runner,
+    )
+    src = inspect.getsource(repeat_runner)
+    assert "doubleword_provider" not in src
+    assert "claude_provider" not in src.lower()
+
+
+# ---------------------------------------------------------------------------
+# §23 — Public API + singleton
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_via_package_init() -> None:
+    from backend.core.ouroboros.governance import verification
+    assert "RepeatRunner" in verification.__all__
+    assert "RepeatVerdict" in verification.__all__
+    assert "RunBudget" in verification.__all__
+    assert "EvidenceCollector" in verification.__all__
+    assert "get_default_runner" in verification.__all__
+    assert "repeat_runner_enabled" in verification.__all__
+
+
+def test_runner_singleton_returns_same_instance() -> None:
+    r1 = get_default_runner()
+    r2 = get_default_runner()
+    assert r1 is r2
+
+
+# ---------------------------------------------------------------------------
+# §26 — Posterior clamped — no degenerate beliefs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_posterior_never_exact_zero_or_one(fresh_registry) -> None:
+    """Even after 50 all-pass runs, posterior is clamped below 1.0
+    so further updates remain meaningful."""
+    runner = RepeatRunner()
+    p = Property.make(
+        kind="test_passes", name="t", evidence_required=("exit_code",),
+    )
+
+    async def collector(idx: int) -> Mapping[str, Any]:
+        return {"exit_code": 0}
+
+    result = await runner.run(
+        prop=p, evidence_collector=collector,
+        budget=RunBudget(
+            min_runs=50, max_runs=50, early_stop=False,
+            parallel_concurrency=10,
+        ),
+    )
+    assert 0.001 <= result.posterior <= 0.999
+    assert result.passed is True


### PR DESCRIPTION
## Summary

Closes the second half of Slice 2.1's `PropertyOracle` foundation. Where the Oracle gives a **deterministic single-run verdict**, the RepeatRunner runs the verification **N times against fresh evidence** and aggregates results into a **Bayesian posterior** — turning "this test passed once" into "this property holds with confidence P".

## Root problem solved

A single PASSED verdict isn't enough for flaky tests. A single FAILED verdict could be variance noise. Slice 2.2 closes the "single-run verification can't tell variance from gain" gap.

| Today | After Slice 2.2 |
|---|---|
| "fixes flaky test Y" → VERIFY runs once → op closes → Y still flakes 5% | RepeatRunner 50× → confidence interval → verified or regressed |
| "improves runtime by 20%" → one run hits 18% (variance) → op closes | RepeatRunner aggregates N measurements → Bayesian estimate of true mean |
| "regression-free refactor" → suite passes once | Repeat-N exercises affected path multiple times |

## Layering (no duplication)

| Layer | Module | Purpose |
|---|---|---|
| Single-run dispatcher | Slice 2.1 (mine, merged) | `PropertyOracle` |
| Bayesian aggregator | **Slice 2.2 (this PR)** | **`RepeatRunner`** |
| Bayesian primitives | Antigravity `exploration_calculus` | `bayesian_update`, `verdict_to_likelihood_ratio`, `entropy` |

The RepeatRunner imports Antigravity's primitives directly via `_bayesian_update_safely` — defensive lazy adapter with stdlib fallback. **Zero re-implementation of Bayes.**

## Verdict → likelihood ratio mapping

| `VerdictKind` | Calculus string | LR (default) | Effect |
|---|---|---|---|
| `PASSED` | `"CONFIRMED"` | ~3.0 | Belief moves up |
| `FAILED` | `"REFUTED"` | ~0.33 | Belief moves down |
| `INSUFFICIENT_EVIDENCE` | `"INCONCLUSIVE"` | 1.0 | No update |
| `EVALUATOR_ERROR` | `"INCONCLUSIVE"` | 1.0 | No update |

**Insufficient + error verdicts deliberately don't move the belief** — they're "no signal", not "negative signal". Operators see counts in the verdict but the posterior reflects only decisive runs. This preserves Bayesian validity in face of evaluator malfunctions or missing-evidence collectors.

## Design patterns

- **`RunBudget`**: caller-overridable runtime config. Sentinel (negative) values resolve to env-tunable defaults at call time.
- **`EvidenceCollector`**: free-form async callable `(run_index → Mapping)`. Operators supply ANY collector — no enum, no hardcoded property kinds.
- **Parallel batched execution**: launch K runs via `asyncio.gather`, aggregate, check early-stop, decide next batch. Batch size = `min(concurrency, remaining)`.
- **Early-stop on convergence**: posterior ≥ threshold (high-conf PASS) OR (1−posterior) ≥ threshold (high-conf FAIL), gated by `min_runs` floor.
- **Posterior clamped** to (0.001, 0.999) per Antigravity convention — exact 0 or 1 are non-updatable.

## Operator's design constraints applied

| Constraint | How |
|---|---|
| **Asynchronous** | Evidence_collector is async; runs in parallel batches via asyncio.gather |
| **Dynamic** | Confidence + min/max runs + batch size env-readable per-call |
| **Adaptive** | Early-stop when threshold crossed; insufficient/error don't poison belief |
| **Intelligent** | Bayesian update via Antigravity's `bayesian_update`; posterior auto-clamped |
| **Robust** | Every public method NEVER raises; per-run exceptions → EVALUATOR_ERROR verdicts |
| **No hardcoding** | Every threshold env-tunable; LR from `exploration_calculus._confirmed_lr/_refuted_lr` |
| **Leverages existing** | Antigravity's `exploration_calculus` + Slice 2.1 Oracle. Zero duplication |

## Authority invariants (pinned)

- NEVER imports `orchestrator` / `phase_runner` / `candidate_generator`
- NEVER imports any `phase_runners/*` module
- NEVER imports providers
- Every public method NEVER raises
- **AST-walked** import-ban check (docstring mentions don't count)

## Test plan

- [x] **45 new tests** covering 26 pin sections
- [x] **631/631 green** across full Phase 1 + Phase 2 + 12 + 12.2 regression suite
- [x] All four `VerdictKind` outcomes round-trip through Bayesian update
- [x] Parallel concurrency actually parallel (50ms × 4 in 4-concurrent ≈ 50ms total, NOT 200ms)
- [x] Early-stop on PASS / FAIL / no-stop-when-disabled / min_runs-floors-stop all verified
- [x] Defensive paths: collector raises, returns non-Mapping, None Property
- [x] Fallback Bayesian update works when `exploration_calculus` unavailable

## Bonus fix

`test_verification_property_oracle.py::test_six_seed_evaluators_present_after_import` previously used `importlib.reload(po)` which broke the cross-module reference graph (RepeatRunner held stale references to the OLD `_EVALUATORS` dict). Caused test contamination when 2.1 + 2.2 suites ran together. Replaced with `reset_registry_for_tests()` — same semantic, no module-graph poisoning.

## Roadmap (operator-gated)

| Slice | Scope |
|---|---|
| 2.3 | `property_capture` — PLAN-time claim recording into Slice 1.2 decision runtime |
| 2.4 | POSTMORTEM verification-failure integration |
| 2.5 | Graduation flip — defaults to true |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce `RepeatRunner` for Bayesian statistical re-verification. It reruns properties with fresh evidence, aggregates verdicts into a posterior, and returns confidence-based PASS/FAIL to reduce flakiness.

- New Features
  - `RepeatRunner`: async batched runs via `EvidenceCollector (run_index -> Mapping)`; configurable with `RunBudget`; returns `RepeatVerdict`.
  - Early-stop on convergence after `min_runs`; parallel batching via `parallel_concurrency`.
  - Posterior clamped (0.001–0.999); `INSUFFICIENT_EVIDENCE`/`EVALUATOR_ERROR` don’t change belief; public methods never raise.
  - Integrates with Antigravity `exploration_calculus` for updates; safe stdlib fallback if unavailable.
  - Feature flag `JARVIS_VERIFICATION_REPEAT_RUNNER_ENABLED` (default off); exports added in `backend.core.ouroboros.governance.verification` (`RepeatRunner`, `RepeatVerdict`, `RunBudget`, `EvidenceCollector`, `get_default_runner`, `repeat_runner_enabled`).

- Bug Fixes
  - Replace `importlib.reload` with `reset_registry_for_tests()` in `test_verification_property_oracle` to avoid stale evaluator registries and cross-module contamination.

<sup>Written for commit 006a16ab8df9a5ea1dcdf52f565c32edb5ca51aa. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29133?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

