### PR TITLE
feat(phase2): Slice 2.4 — VerificationPostmortem (closes the RSI loop)

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/complete_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/complete_runner.py
@@ -161,6 +161,44 @@ class COMPLETERunner(PhaseRunner):
                 pass
         # ---- end verbatim transcription --------------------------------
 
+        # Phase 2 Slice 2.4 — verification postmortem (loop-closing).
+        # Walk recorded claims (Slice 2.3) for this op, evaluate each
+        # via the Oracle (Slice 2.1) using ctx-derived evidence,
+        # aggregate into a VerificationPostmortem, persist it via
+        # Slice 1.3's capture_phase_decision so the lesson is
+        # permanent in the per-session ledger.
+        #
+        # Defensive at every layer — postmortem failure NEVER blocks
+        # op closure. The op already succeeded; this is consequence
+        # tracking, not gate enforcement (auto-revert on blocking
+        # failures is a future-phase concern).
+        try:
+            from backend.core.ouroboros.governance.verification.postmortem import (
+                log_postmortem_summary,
+                persist_postmortem,
+                produce_verification_postmortem,
+            )
+            _pm = await produce_verification_postmortem(
+                op_id=ctx.op_id, ctx=ctx,
+            )
+            log_postmortem_summary(_pm)
+            await persist_postmortem(pm=_pm, op_id=ctx.op_id, ctx=ctx)
+            if _pm.has_blocking_failures:
+                # Surface the blocking signal at WARNING — operator
+                # sees that must_hold claims diverged. Future phase
+                # may auto-revert; for now, audit only.
+                logger.warning(
+                    "[Orchestrator] verification postmortem reports "
+                    "blocking failures: op=%s must_hold_failed=%d/%d",
+                    ctx.op_id, _pm.must_hold_failed, _pm.must_hold_count,
+                )
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[Orchestrator] verification postmortem failed for "
+                "op=%s — op closure unaffected",
+                ctx.op_id, exc_info=True,
+            )
+
         return PhaseResult(
             next_ctx=ctx,
             next_phase=None,

--- a/backend/core/ouroboros/governance/verification/__init__.py
+++ b/backend/core/ouroboros/governance/verification/__init__.py
@@ -48,6 +48,16 @@ from backend.core.ouroboros.governance.verification.property_capture import (
     property_capture_enabled,
     synthesize_claims_from_plan,
 )
+from backend.core.ouroboros.governance.verification.postmortem import (
+    ClaimOutcome,
+    VerificationPostmortem,
+    ctx_evidence_collector,
+    get_recorded_postmortem,
+    log_postmortem_summary,
+    persist_postmortem,
+    postmortem_enabled,
+    produce_verification_postmortem,
+)
 from backend.core.ouroboros.governance.verification.repeat_runner import (
     EvidenceCollector,
     RepeatRunner,
@@ -59,6 +69,7 @@ from backend.core.ouroboros.governance.verification.repeat_runner import (
 
 __all__ = [
     "CANONICAL_SEVERITIES",
+    "ClaimOutcome",
     "EvidenceCollector",
     "Property",
     "PropertyClaim",
@@ -72,12 +83,19 @@ __all__ = [
     "SEVERITY_MUST_HOLD",
     "SEVERITY_SHOULD_HOLD",
     "VerdictKind",
+    "VerificationPostmortem",
     "capture_claims",
+    "ctx_evidence_collector",
     "filter_load_bearing",
     "get_default_oracle",
     "get_default_runner",
     "get_recorded_claims",
+    "get_recorded_postmortem",
+    "log_postmortem_summary",
     "oracle_enabled",
+    "persist_postmortem",
+    "postmortem_enabled",
+    "produce_verification_postmortem",
     "property_capture_enabled",
     "register_evaluator",
     "repeat_runner_enabled",

--- a/backend/core/ouroboros/governance/verification/postmortem.py
+++ b/backend/core/ouroboros/governance/verification/postmortem.py
@@ -1,0 +1,830 @@
+"""Phase 2 Slice 2.4 — Verification Postmortem (the loop-closing slice).
+
+This is the slice that turns Phase 2 from "infrastructure that records
+claims" into a CLOSED LOOP. Without this, captured claims sit in the
+ledger as data but don't affect op outcomes — operators have to
+manually grep the ledger to know if a claim failed. Slice 2.4 closes
+the loop:
+
+  PLAN time     → claims captured (Slice 2.3)
+  APPLY time    → change committed (existing)
+  VERIFY time   → tests run (existing)
+  COMPLETE time → walk claims, evaluate against post-APPLY evidence,
+                  produce structured VerificationPostmortem,
+                  persist it as a permanent ledger lesson (THIS SLICE)
+
+This is the third RSI gear from PRD §24.10 — Closed-Loop Memory.
+Quoting Gemini's framing of I.J. Good's intelligence-explosion thesis:
+
+  > "Suppose O+V merges a change to its own TopologySentinel to
+  > make it faster. 72 hours later, the Post-Merge Auditor wakes up
+  > and checks if the codebase is still stable. If it is, O+V logs
+  > a permanent 'lesson' that this new routing logic is successful."
+
+Slice 2.4 IS that lesson-logging machinery for the immediate (op-
+close) horizon. Antigravity's parallel ``post_merge_auditor.py``
+covers the 72-hour horizon. Together they bracket the consequence-
+tracking surface.
+
+LAYERING (no duplication):
+
+  * Slice 1.1 — entropy: deterministic record IDs
+  * Slice 1.2 — DecisionRuntime: per-session ledger (postmortem
+    persisted here, kind="verification_postmortem")
+  * Slice 1.3 — capture_phase_decision: phase-shaped wrapper
+  * Slice 2.1 — PropertyOracle: single-claim dispatcher
+  * Slice 2.2 — RepeatRunner: NOT used here (postmortem is one-pass
+    per claim; statistical re-verification is the next-phase
+    enhancement)
+  * Slice 2.3 — get_recorded_claims: source of claim list
+
+Slice 2.4 ships:
+  * VerificationPostmortem schema (frozen + hashable)
+  * ClaimOutcome (per-claim result)
+  * produce_verification_postmortem (pure async producer)
+  * persist_postmortem (Slice 1.2 ledger writer)
+  * get_recorded_postmortem (Slice 1.2 ledger reader)
+  * Default ``ctx_evidence_collector`` — pulls common signals from
+    OperationContext so the postmortem is useful out-of-the-box
+    without requiring operators to write evidence collectors
+
+EVIDENCE COLLECTION STRATEGY:
+
+Slice 2.4's challenge: at COMPLETE time, where does evidence come
+from? Some claims need fresh test runs (out of scope — that's
+Slice 2.2 RepeatRunner with a real collector). Some can be answered
+from already-captured signals on the ctx (validation_passed,
+target_files, etc.). Some require deeper observation (file content,
+function signatures).
+
+The DEFAULT evidence collector inspects the OperationContext for
+common signal fields:
+
+  * test_passes claims: ctx.validation_passed → exit_code (0 or 1)
+  * key_present claims: defaults to "present"=True if VERIFY passed
+  * string_matches claims: signature_invariant claims fall through
+    to INSUFFICIENT_EVIDENCE (need fresh signature inspection —
+    operators wire richer collectors as needed)
+
+INSUFFICIENT_EVIDENCE verdicts are honest — they say "we recorded
+this claim but couldn't verify it from available signals." That's
+better than silent passes. Operators see the audit trail and know
+which claims need richer collection.
+
+OPERATOR'S DESIGN CONSTRAINTS APPLIED:
+
+  * Asynchronous — producer is async; uses Slice 2.1 Oracle (sync)
+    + Slice 2.3 reader (sync) under the hood
+  * Dynamic — evidence_collector is a free-form callable; default
+    is provided but operators can inject custom logic
+  * Adaptive — INSUFFICIENT_EVIDENCE preserves audit value when
+    evidence is missing; doesn't fake-pass to avoid noise
+  * Intelligent — uses canonical evidence-hash via Antigravity's
+    canonical_serialize (transitively via Slice 2.1 Oracle)
+  * Robust — every public method NEVER raises. Defensive at every
+    layer (Slice 1.2 reader, Slice 2.1 Oracle, Slice 2.3 claim
+    reader, the producer itself).
+  * No hardcoding — schema fields named explicitly, no enum
+    constants for verdict outcome categories beyond Slice 2.1's
+    VerdictKind.
+  * Leverages existing — Slices 1.1/1.2/1.3/2.1/2.3 + Antigravity's
+    canonical hashing. ZERO duplication.
+
+AUTHORITY INVARIANTS (pinned by tests):
+  * NEVER imports orchestrator / phase_runner (base) /
+    candidate_generator
+  * NEVER imports providers
+  * Every public method NEVER raises
+  * Postmortem persistence is best-effort — failure surfaces in
+    the return value, not as exception
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time as _time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import (
+    Any, Awaitable, Callable, List, Mapping, Optional, Tuple,
+)
+
+from backend.core.ouroboros.governance.verification.property_capture import (
+    PropertyClaim,
+    SEVERITY_IDEAL,
+    SEVERITY_MUST_HOLD,
+    SEVERITY_SHOULD_HOLD,
+    get_recorded_claims,
+)
+from backend.core.ouroboros.governance.verification.property_oracle import (
+    PropertyOracle,
+    PropertyVerdict,
+    VerdictKind,
+    get_default_oracle,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Master flag
+# ---------------------------------------------------------------------------
+
+
+def postmortem_enabled() -> bool:
+    """``JARVIS_VERIFICATION_POSTMORTEM_ENABLED`` (default ``false``).
+
+    Phase 2 Slice 2.4 master flag. Re-read at call time so monkeypatch
+    works in tests + operators can flip live without re-init. Default
+    flips to ``true`` at Phase 2 Slice 2.5 graduation.
+
+    When ``false``: producer returns an empty postmortem; persistence
+    is a no-op. When ``true``: full closed-loop verification fires."""
+    raw = os.environ.get(
+        "JARVIS_VERIFICATION_POSTMORTEM_ENABLED", "",
+    ).strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+VERIFICATION_POSTMORTEM_SCHEMA_VERSION = "verification_postmortem.1"
+CLAIM_OUTCOME_SCHEMA_VERSION = "claim_outcome.1"
+
+
+@dataclass(frozen=True)
+class ClaimOutcome:
+    """One claim's verification outcome.
+
+    Frozen + hashable for safe ledger persistence + cross-thread
+    sharing. ``evidence_used_repr`` is a JSON string for replay-
+    safety (the Mapping itself isn't hashable; the canonical repr
+    is)."""
+    claim: PropertyClaim
+    verdict: PropertyVerdict
+    evidence_used_repr: str = ""
+    schema_version: str = CLAIM_OUTCOME_SCHEMA_VERSION
+
+    @property
+    def passed(self) -> bool:
+        return self.verdict.passed
+
+    @property
+    def is_terminal(self) -> bool:
+        """True iff the verdict is PASSED or FAILED (not insufficient
+        / error). Non-terminal outcomes don't count as evidence
+        either way."""
+        return self.verdict.is_terminal
+
+    @property
+    def is_blocking(self) -> bool:
+        """True iff this outcome should block the op:
+        must_hold severity AND verdict is FAILED. INSUFFICIENT /
+        ERROR don't block — operator gets the diagnostic but the
+        op still completes."""
+        return (
+            self.claim.severity == SEVERITY_MUST_HOLD
+            and self.verdict.verdict is VerdictKind.FAILED
+        )
+
+
+@dataclass(frozen=True)
+class VerificationPostmortem:
+    """Structured postmortem record of all claim verifications for
+    one op.
+
+    Frozen + hashable. Persisted via Slice 1.2 decision-runtime
+    ledger as kind="verification_postmortem", one record per op.
+
+    Field semantics:
+      * ``op_id`` — operation identifier
+      * ``session_id`` — session identifier
+      * ``total_claims`` — count of claims read from the ledger
+      * ``must_hold/should_hold/ideal_count`` — by-severity counts
+      * ``must_hold/should_hold/ideal_failed`` — failure counts
+        (FAILED verdict only — INSUFFICIENT/ERROR not counted)
+      * ``insufficient_count`` — claims that couldn't be verified
+        from available evidence (operator should investigate)
+      * ``error_count`` — claims where the evaluator raised
+      * ``outcomes`` — per-claim outcomes for forensics
+      * ``has_blocking_failures`` — True iff any must_hold FAILED
+        (this is THE summary signal)
+      * ``started_unix/completed_unix`` — wall-clock bounds for
+        latency telemetry
+    """
+    op_id: str
+    session_id: str
+    total_claims: int = 0
+    must_hold_count: int = 0
+    should_hold_count: int = 0
+    ideal_count: int = 0
+    must_hold_failed: int = 0
+    should_hold_failed: int = 0
+    ideal_failed: int = 0
+    insufficient_count: int = 0
+    error_count: int = 0
+    outcomes: Tuple[ClaimOutcome, ...] = field(default_factory=tuple)
+    has_blocking_failures: bool = False
+    started_unix: float = 0.0
+    completed_unix: float = 0.0
+    schema_version: str = VERIFICATION_POSTMORTEM_SCHEMA_VERSION
+
+    @property
+    def total_failed(self) -> int:
+        """All FAILED verdicts (any severity)."""
+        return (
+            self.must_hold_failed
+            + self.should_hold_failed
+            + self.ideal_failed
+        )
+
+    @property
+    def total_passed(self) -> int:
+        """All PASSED verdicts (any severity)."""
+        return sum(1 for o in self.outcomes if o.passed)
+
+    @property
+    def is_clean(self) -> bool:
+        """True iff zero failures across all severities + zero
+        insufficient/error. The ideal outcome — every claim verified
+        and passed."""
+        return (
+            self.total_failed == 0
+            and self.insufficient_count == 0
+            and self.error_count == 0
+        )
+
+    def to_dict(self) -> dict:
+        """JSON-friendly serialization for the ledger."""
+        return {
+            "schema_version": self.schema_version,
+            "op_id": self.op_id,
+            "session_id": self.session_id,
+            "total_claims": self.total_claims,
+            "must_hold_count": self.must_hold_count,
+            "should_hold_count": self.should_hold_count,
+            "ideal_count": self.ideal_count,
+            "must_hold_failed": self.must_hold_failed,
+            "should_hold_failed": self.should_hold_failed,
+            "ideal_failed": self.ideal_failed,
+            "insufficient_count": self.insufficient_count,
+            "error_count": self.error_count,
+            "has_blocking_failures": self.has_blocking_failures,
+            "started_unix": self.started_unix,
+            "completed_unix": self.completed_unix,
+            "outcomes": [
+                _claim_outcome_to_dict(o) for o in self.outcomes
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> Optional["VerificationPostmortem"]:
+        """Parse from a ledger record. NEVER raises — returns None
+        on unparseable input."""
+        try:
+            if not isinstance(raw, Mapping):
+                return None
+            if raw.get("schema_version") != VERIFICATION_POSTMORTEM_SCHEMA_VERSION:
+                return None
+            outcomes_raw = raw.get("outcomes") or []
+            outcomes: List[ClaimOutcome] = []
+            for o in outcomes_raw:
+                co = _claim_outcome_from_dict(o)
+                if co is not None:
+                    outcomes.append(co)
+            return cls(
+                op_id=str(raw.get("op_id", "")),
+                session_id=str(raw.get("session_id", "")),
+                total_claims=int(raw.get("total_claims", 0) or 0),
+                must_hold_count=int(
+                    raw.get("must_hold_count", 0) or 0,
+                ),
+                should_hold_count=int(
+                    raw.get("should_hold_count", 0) or 0,
+                ),
+                ideal_count=int(raw.get("ideal_count", 0) or 0),
+                must_hold_failed=int(
+                    raw.get("must_hold_failed", 0) or 0,
+                ),
+                should_hold_failed=int(
+                    raw.get("should_hold_failed", 0) or 0,
+                ),
+                ideal_failed=int(raw.get("ideal_failed", 0) or 0),
+                insufficient_count=int(
+                    raw.get("insufficient_count", 0) or 0,
+                ),
+                error_count=int(raw.get("error_count", 0) or 0),
+                outcomes=tuple(outcomes),
+                has_blocking_failures=bool(
+                    raw.get("has_blocking_failures", False),
+                ),
+                started_unix=float(
+                    raw.get("started_unix", 0.0) or 0.0,
+                ),
+                completed_unix=float(
+                    raw.get("completed_unix", 0.0) or 0.0,
+                ),
+            )
+        except (TypeError, ValueError, KeyError):
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Internal serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def _claim_outcome_to_dict(co: ClaimOutcome) -> dict:
+    """Serialize a ClaimOutcome (NEVER raises)."""
+    try:
+        return {
+            "schema_version": co.schema_version,
+            "claim": co.claim.to_dict(),
+            "verdict": {
+                "property_name": co.verdict.property_name,
+                "kind": co.verdict.kind,
+                "verdict": (
+                    co.verdict.verdict.value
+                    if hasattr(co.verdict.verdict, "value")
+                    else str(co.verdict.verdict)
+                ),
+                "confidence": co.verdict.confidence,
+                "reason": co.verdict.reason,
+                "evidence_hash": co.verdict.evidence_hash,
+                "evaluation_ts_unix": co.verdict.evaluation_ts_unix,
+            },
+            "evidence_used_repr": co.evidence_used_repr,
+        }
+    except Exception:  # noqa: BLE001 — defensive
+        return {"_unparseable": True}
+
+
+def _claim_outcome_from_dict(raw: Any) -> Optional[ClaimOutcome]:
+    """Parse a ClaimOutcome (NEVER raises)."""
+    try:
+        if not isinstance(raw, Mapping):
+            return None
+        if raw.get("schema_version") != CLAIM_OUTCOME_SCHEMA_VERSION:
+            return None
+        claim = PropertyClaim.from_dict(raw.get("claim") or {})
+        if claim is None:
+            return None
+        v_raw = raw.get("verdict") or {}
+        if not isinstance(v_raw, Mapping):
+            return None
+        verdict_str = str(v_raw.get("verdict", "evaluator_error"))
+        try:
+            verdict_kind = VerdictKind(verdict_str)
+        except ValueError:
+            verdict_kind = VerdictKind.EVALUATOR_ERROR
+        verdict = PropertyVerdict(
+            property_name=str(v_raw.get("property_name", "")),
+            kind=str(v_raw.get("kind", "")),
+            verdict=verdict_kind,
+            confidence=float(v_raw.get("confidence", 0.0) or 0.0),
+            reason=str(v_raw.get("reason", "")),
+            evidence_hash=str(v_raw.get("evidence_hash", "")),
+            evaluation_ts_unix=float(
+                v_raw.get("evaluation_ts_unix", 0.0) or 0.0,
+            ),
+        )
+        return ClaimOutcome(
+            claim=claim,
+            verdict=verdict,
+            evidence_used_repr=str(raw.get("evidence_used_repr", "")),
+        )
+    except (TypeError, ValueError, KeyError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Default evidence collector
+# ---------------------------------------------------------------------------
+
+
+# An evidence collector takes a PropertyClaim + an optional
+# OperationContext and returns the evidence Mapping for that
+# claim. Returning an empty mapping is fine — Oracle will return
+# INSUFFICIENT_EVIDENCE which is the honest answer.
+EvidenceCollector = Callable[
+    [PropertyClaim, Any], Awaitable[Mapping[str, Any]],
+]
+
+
+async def ctx_evidence_collector(
+    claim: PropertyClaim, ctx: Any,
+) -> Mapping[str, Any]:
+    """Default evidence collector. Pulls common signals from
+    OperationContext for the four canonical claim kinds.
+
+    Returns empty mapping for unknown kinds — Oracle will return
+    INSUFFICIENT_EVIDENCE. NEVER raises.
+
+    The mapping per claim kind:
+
+      * ``test_passes`` — ctx.validation_passed → exit_code (0 or 1)
+        (assumes a passing op had its test_strategy.tests_to_pass
+        actually exercised)
+      * ``key_present`` — ctx.validation_passed AND op didn't fail
+        → present=True (best-effort signal that no regression
+        materialized)
+      * ``string_matches`` — empty (signature inspection requires
+        live AST parsing — operators wire richer collectors)
+      * ``set_subset`` — empty (custom claim — operator-specific)
+      * Unknown kind — empty
+    """
+    kind = claim.property.kind if claim and claim.property else ""
+
+    try:
+        if kind == "test_passes":
+            # If validation_passed is True on ctx, we treat that as
+            # exit_code=0 for any test_passes claim. This is a
+            # best-effort signal — for true per-test verification,
+            # operators wire a fresh pytest-spawn collector via
+            # Slice 2.2 RepeatRunner.
+            validated = bool(getattr(ctx, "validation_passed", False))
+            return {"exit_code": 0 if validated else 1}
+
+        if kind == "key_present":
+            validated = bool(getattr(ctx, "validation_passed", False))
+            return {"present": validated}
+
+        # Other kinds: return empty → INSUFFICIENT_EVIDENCE
+        return {}
+    except Exception:  # noqa: BLE001 — defensive
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Producer — walk recorded claims, evaluate each, aggregate
+# ---------------------------------------------------------------------------
+
+
+async def produce_verification_postmortem(
+    *,
+    op_id: str,
+    ctx: Any = None,
+    evidence_collector: Optional[EvidenceCollector] = None,
+    oracle: Optional[PropertyOracle] = None,
+    session_id: Optional[str] = None,
+) -> VerificationPostmortem:
+    """Produce the verification postmortem for ``op_id``.
+
+    Walks the recorded claims (Slice 2.3 reader), evaluates each
+    via the Oracle (Slice 2.1) using evidence from the supplied
+    collector (default: ``ctx_evidence_collector``), aggregates
+    outcomes into a frozen ``VerificationPostmortem``.
+
+    NEVER raises. When ``postmortem_enabled()`` returns False, the
+    function returns an EMPTY postmortem — operators can call this
+    safely from any production path; flag-off → no work, no signal.
+
+    Empty claim list → empty postmortem (``has_blocking_failures
+    == False``, ``is_clean == True``)."""
+    started = _time.time()
+
+    # Resolve session_id (mirrors Slice 2.3 reader's resolution)
+    sid = session_id
+    if sid is None or not str(sid).strip():
+        sid = os.environ.get(
+            "OUROBOROS_BATTLE_SESSION_ID", "",
+        ).strip() or "default"
+
+    if not postmortem_enabled():
+        return VerificationPostmortem(
+            op_id=str(op_id), session_id=sid,
+            started_unix=started, completed_unix=_time.time(),
+        )
+
+    if not op_id or not str(op_id).strip():
+        return VerificationPostmortem(
+            op_id="", session_id=sid,
+            started_unix=started, completed_unix=_time.time(),
+        )
+
+    oracle = oracle or get_default_oracle()
+    collector = evidence_collector or ctx_evidence_collector
+
+    # Read recorded claims
+    try:
+        claims = get_recorded_claims(op_id=op_id, session_id=sid)
+    except Exception:  # noqa: BLE001 — defensive
+        claims = ()
+
+    outcomes: List[ClaimOutcome] = []
+    must_hold_count = should_hold_count = ideal_count = 0
+    must_hold_failed = should_hold_failed = ideal_failed = 0
+    insufficient_count = error_count = 0
+    has_blocking = False
+
+    for claim in claims:
+        try:
+            evidence = await collector(claim, ctx)
+        except Exception:  # noqa: BLE001 — defensive
+            evidence = {}
+        if not isinstance(evidence, Mapping):
+            evidence = {}
+
+        try:
+            verdict = oracle.evaluate(
+                prop=claim.property, evidence=evidence,
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive
+            verdict = PropertyVerdict(
+                property_name=claim.property.name,
+                kind=claim.property.kind,
+                verdict=VerdictKind.EVALUATOR_ERROR,
+                confidence=0.0,
+                reason=f"oracle.evaluate raised: {type(exc).__name__}: {exc}",
+            )
+
+        try:
+            evidence_repr = json.dumps(
+                dict(evidence), sort_keys=True, ensure_ascii=True,
+            )
+        except (TypeError, ValueError):
+            evidence_repr = "{}"
+
+        outcome = ClaimOutcome(
+            claim=claim,
+            verdict=verdict,
+            evidence_used_repr=evidence_repr,
+        )
+        outcomes.append(outcome)
+
+        # Tally by severity
+        sev = claim.severity
+        if sev == SEVERITY_MUST_HOLD:
+            must_hold_count += 1
+        elif sev == SEVERITY_SHOULD_HOLD:
+            should_hold_count += 1
+        elif sev == SEVERITY_IDEAL:
+            ideal_count += 1
+
+        # Tally by verdict
+        if verdict.verdict is VerdictKind.FAILED:
+            if sev == SEVERITY_MUST_HOLD:
+                must_hold_failed += 1
+                has_blocking = True
+            elif sev == SEVERITY_SHOULD_HOLD:
+                should_hold_failed += 1
+            elif sev == SEVERITY_IDEAL:
+                ideal_failed += 1
+        elif verdict.verdict is VerdictKind.INSUFFICIENT_EVIDENCE:
+            insufficient_count += 1
+        elif verdict.verdict is VerdictKind.EVALUATOR_ERROR:
+            error_count += 1
+
+    return VerificationPostmortem(
+        op_id=str(op_id),
+        session_id=sid,
+        total_claims=len(outcomes),
+        must_hold_count=must_hold_count,
+        should_hold_count=should_hold_count,
+        ideal_count=ideal_count,
+        must_hold_failed=must_hold_failed,
+        should_hold_failed=should_hold_failed,
+        ideal_failed=ideal_failed,
+        insufficient_count=insufficient_count,
+        error_count=error_count,
+        outcomes=tuple(outcomes),
+        has_blocking_failures=has_blocking,
+        started_unix=started,
+        completed_unix=_time.time(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persister — record postmortem via Slice 1.2 decision runtime
+# ---------------------------------------------------------------------------
+
+
+async def persist_postmortem(
+    *,
+    pm: VerificationPostmortem,
+    op_id: Optional[str] = None,
+    ctx: Any = None,
+) -> bool:
+    """Persist a verification postmortem to the per-session decision
+    ledger as kind="verification_postmortem".
+
+    Returns True on success, False on failure. NEVER raises.
+
+    Uses Slice 1.3's ``capture_phase_decision`` so the record gets
+    canonical hashing + atomic flock-protected append for free."""
+    if not postmortem_enabled() or pm is None:
+        return False
+
+    try:
+        from backend.core.ouroboros.governance.determinism.phase_capture import (
+            capture_phase_decision,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug(
+            "[verification.postmortem] phase_capture unavailable: %s",
+            exc,
+        )
+        return False
+
+    target_op = op_id or pm.op_id
+    if not target_op:
+        return False
+
+    try:
+        pm_dict = pm.to_dict()
+
+        async def _emit() -> Any:
+            return pm_dict
+
+        await capture_phase_decision(
+            op_id=target_op,
+            phase="COMPLETE",
+            kind="verification_postmortem",
+            ctx=ctx,
+            compute=_emit,
+            extra_inputs={
+                "total_claims": pm.total_claims,
+                "must_hold_failed": pm.must_hold_failed,
+                "has_blocking_failures": pm.has_blocking_failures,
+            },
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug(
+            "[verification.postmortem] persist failed for op_id=%s: %s",
+            target_op, exc,
+        )
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Reader — fetch the recorded postmortem
+# ---------------------------------------------------------------------------
+
+
+def _ledger_path_for_session(session_id: Optional[str] = None) -> Path:
+    """Resolve the per-session decisions.jsonl path. Mirrors Slice
+    1.2 + 2.3 conventions. NEVER raises."""
+    sid = (str(session_id).strip() if session_id else "")
+    if not sid:
+        sid = os.environ.get(
+            "OUROBOROS_BATTLE_SESSION_ID", "",
+        ).strip() or "default"
+    base = os.environ.get(
+        "JARVIS_DETERMINISM_LEDGER_DIR",
+        ".jarvis/determinism",
+    ).strip()
+    return Path(base) / sid / "decisions.jsonl"
+
+
+def get_recorded_postmortem(
+    *,
+    op_id: str,
+    session_id: Optional[str] = None,
+) -> Optional[VerificationPostmortem]:
+    """Read the most recent recorded verification postmortem for
+    ``op_id``. Returns None if not found or unparseable.
+
+    NEVER raises. Walks the per-session JSONL directly (mirrors
+    Slice 2.3 reader pattern). When multiple postmortems exist for
+    the same op (operator re-ran COMPLETE in some non-standard
+    flow), returns the LAST one — most recent state wins."""
+    if not op_id or not str(op_id).strip():
+        return None
+    path = _ledger_path_for_session(session_id)
+    if not path.exists():
+        return None
+    safe_op = str(op_id).strip()
+    last_pm: Optional[VerificationPostmortem] = None
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for raw_line in fh:
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    record = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, Mapping):
+                    continue
+                if record.get("op_id") != safe_op:
+                    continue
+                if record.get("phase") != "COMPLETE":
+                    continue
+                if record.get("kind") != "verification_postmortem":
+                    continue
+                output_repr = record.get("output_repr", "")
+                if not isinstance(output_repr, str):
+                    continue
+                try:
+                    pm_dict = json.loads(output_repr)
+                except json.JSONDecodeError:
+                    continue
+                pm = VerificationPostmortem.from_dict(pm_dict)
+                if pm is not None:
+                    last_pm = pm
+    except OSError as exc:
+        logger.debug(
+            "[verification.postmortem] read failed at %s: %s",
+            path, exc,
+        )
+        return None
+    return last_pm
+
+
+# ---------------------------------------------------------------------------
+# Adapter for the decision-runtime registry (Slice 1.3 integration)
+# ---------------------------------------------------------------------------
+
+
+def _register_postmortem_adapter() -> None:
+    """Register the (COMPLETE, verification_postmortem) adapter at
+    module load. Idempotent. Defensive (NEVER raises)."""
+    try:
+        from backend.core.ouroboros.governance.determinism.phase_capture import (
+            OutputAdapter,
+            register_adapter,
+        )
+
+        def _serialize(pm_dict: Any) -> Any:
+            try:
+                if isinstance(pm_dict, dict):
+                    return pm_dict
+                if isinstance(pm_dict, VerificationPostmortem):
+                    return pm_dict.to_dict()
+                return {"_unparseable": str(pm_dict)[:200]}
+            except Exception:  # noqa: BLE001 — defensive
+                return {"_unparseable": "exception"}
+
+        def _deserialize(stored: Any) -> Any:
+            try:
+                if isinstance(stored, dict):
+                    pm = VerificationPostmortem.from_dict(stored)
+                    if pm is not None:
+                        return pm
+                return stored
+            except Exception:  # noqa: BLE001 — defensive
+                return stored
+
+        register_adapter(
+            phase="COMPLETE",
+            kind="verification_postmortem",
+            adapter=OutputAdapter(
+                serialize=_serialize,
+                deserialize=_deserialize,
+                name="verification_postmortem_adapter",
+            ),
+        )
+    except Exception:  # noqa: BLE001 — defensive (import-time)
+        pass
+
+
+_register_postmortem_adapter()
+
+
+# ---------------------------------------------------------------------------
+# Convenience: log a structured summary for operator visibility
+# ---------------------------------------------------------------------------
+
+
+def log_postmortem_summary(pm: VerificationPostmortem) -> None:
+    """Emit a single structured INFO log line for operator visibility.
+
+    Format: ``[VerifyPostmortem] op=X claims=N pass=P fail=F insuff=I
+    err=E blocking=B``
+
+    Only emits if claims > 0 (no noise on opes that produced no
+    claims). NEVER raises."""
+    try:
+        if pm is None or pm.total_claims == 0:
+            return
+        logger.info(
+            "[VerifyPostmortem] op=%s claims=%d pass=%d fail=%d "
+            "insuff=%d err=%d must_hold_failed=%d blocking=%s",
+            pm.op_id, pm.total_claims, pm.total_passed,
+            pm.total_failed, pm.insufficient_count, pm.error_count,
+            pm.must_hold_failed,
+            "true" if pm.has_blocking_failures else "false",
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        pass
+
+
+__all__ = [
+    "CLAIM_OUTCOME_SCHEMA_VERSION",
+    "ClaimOutcome",
+    "EvidenceCollector",
+    "VERIFICATION_POSTMORTEM_SCHEMA_VERSION",
+    "VerificationPostmortem",
+    "ctx_evidence_collector",
+    "get_recorded_postmortem",
+    "log_postmortem_summary",
+    "persist_postmortem",
+    "postmortem_enabled",
+    "produce_verification_postmortem",
+]

--- a/tests/governance/test_verification_postmortem.py
+++ b/tests/governance/test_verification_postmortem.py
@@ -1,0 +1,866 @@
+"""Phase 2 Slice 2.4 — Verification Postmortem regression spine.
+
+The loop-closing slice. Pins:
+
+  §1   postmortem_enabled flag — default false; case-tolerant
+  §2   VerificationPostmortem — frozen + helper accessors
+  §3   ClaimOutcome — frozen + .passed + .is_terminal + .is_blocking
+  §4   to_dict / from_dict round-trip (postmortem)
+  §5   to_dict / from_dict round-trip (claim outcome)
+  §6   from_dict rejects bad input (schema mismatch, non-mapping)
+  §7   produce — flag-off → empty postmortem
+  §8   produce — empty op_id → empty postmortem
+  §9   produce — no recorded claims → empty postmortem (clean)
+  §10  produce — all PASSED → has_blocking_failures=False, is_clean=True
+  §11  produce — must_hold FAILED → has_blocking_failures=True
+  §12  produce — should_hold FAILED → not blocking
+  §13  produce — ideal FAILED → not blocking
+  §14  produce — INSUFFICIENT_EVIDENCE counted separately
+  §15  produce — collector raises → ERROR verdict, no propagation
+  §16  produce — non-Mapping evidence → empty (defensive)
+  §17  ctx_evidence_collector — test_passes from validation_passed
+  §18  ctx_evidence_collector — key_present from validation_passed
+  §19  ctx_evidence_collector — string_matches → empty (Slice 2.4 honest)
+  §20  ctx_evidence_collector — defensive on None ctx
+  §21  Persist — flag-off → False, no disk traffic
+  §22  Persist — happy path → True, ledger contains record
+  §23  Reader — empty op_id → None
+  §24  Reader — no record → None
+  §25  Reader — round-trip via persist → get_recorded_postmortem
+  §26  Reader — most recent wins (multiple postmortems)
+  §27  log_postmortem_summary — empty postmortem → no log
+  §28  log_postmortem_summary — populated → structured INFO line
+  §29  Adapter registered at module load
+  §30  Adapter round-trip (VerificationPostmortem ↔ dict)
+  §31  Authority invariants — no orchestrator/phase_runner/provider imports
+  §32  Public API exposed from package __init__
+  §33  Schema versions pinned
+  §34  COMPLETE runner wiring source pin
+  §35  Total counts (failed/passed) accessor consistency
+  §36  Empty postmortem is_clean=True; populated all-pass is_clean=True;
+       any failure or insufficient → is_clean=False
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+import pytest
+
+from backend.core.ouroboros.governance.verification import (
+    ClaimOutcome,
+    Property,
+    PropertyClaim,
+    PropertyVerdict,
+    SEVERITY_IDEAL,
+    SEVERITY_MUST_HOLD,
+    SEVERITY_SHOULD_HOLD,
+    VerdictKind,
+    VerificationPostmortem,
+    capture_claims,
+    ctx_evidence_collector,
+    get_recorded_postmortem,
+    log_postmortem_summary,
+    persist_postmortem,
+    postmortem_enabled,
+    produce_verification_postmortem,
+)
+from backend.core.ouroboros.governance.verification.postmortem import (
+    CLAIM_OUTCOME_SCHEMA_VERSION,
+    VERIFICATION_POSTMORTEM_SCHEMA_VERSION,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_LEDGER_DIR", str(tmp_path / "det"),
+    )
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", "true",
+    )
+    monkeypatch.setenv(
+        "JARVIS_VERIFICATION_PROPERTY_CAPTURE_ENABLED", "true",
+    )
+    monkeypatch.setenv(
+        "JARVIS_VERIFICATION_POSTMORTEM_ENABLED", "true",
+    )
+    monkeypatch.setenv("OUROBOROS_BATTLE_SESSION_ID", "test-session")
+    monkeypatch.delenv("JARVIS_DETERMINISM_LEDGER_MODE", raising=False)
+    from backend.core.ouroboros.governance.determinism.decision_runtime import (
+        reset_all_for_tests,
+    )
+    reset_all_for_tests()
+    yield tmp_path / "det"
+    reset_all_for_tests()
+
+
+def _make_claim(
+    name: str = "test_x",
+    *,
+    kind: str = "test_passes",
+    severity: str = SEVERITY_MUST_HOLD,
+    op_id: str = "op-1",
+) -> PropertyClaim:
+    return PropertyClaim(
+        op_id=op_id,
+        claimed_at_phase="PLAN",
+        property=Property.make(
+            kind=kind, name=name,
+            evidence_required=("exit_code",) if kind == "test_passes" else ("present",),
+        ),
+        rationale="test rationale",
+        severity=severity,
+        claim_id=f"claim-{name}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# §1 — Master flag
+# ---------------------------------------------------------------------------
+
+
+def test_postmortem_default_false(monkeypatch) -> None:
+    monkeypatch.delenv(
+        "JARVIS_VERIFICATION_POSTMORTEM_ENABLED", raising=False,
+    )
+    assert postmortem_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_postmortem_truthy(monkeypatch, val) -> None:
+    monkeypatch.setenv("JARVIS_VERIFICATION_POSTMORTEM_ENABLED", val)
+    assert postmortem_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage", ""])
+def test_postmortem_falsy(monkeypatch, val) -> None:
+    monkeypatch.setenv("JARVIS_VERIFICATION_POSTMORTEM_ENABLED", val)
+    assert postmortem_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# §2-§3 — Schemas (frozen + helpers)
+# ---------------------------------------------------------------------------
+
+
+def test_postmortem_is_frozen() -> None:
+    pm = VerificationPostmortem(op_id="op-1", session_id="sess-1")
+    with pytest.raises(Exception):
+        pm.op_id = "different"  # type: ignore[misc]
+
+
+def test_postmortem_is_clean_helper() -> None:
+    """Empty postmortem (no claims) is is_clean=True."""
+    pm = VerificationPostmortem(op_id="op-1", session_id="sess-1")
+    assert pm.is_clean is True
+    assert pm.has_blocking_failures is False
+
+
+def test_postmortem_total_passed_failed_accessors() -> None:
+    """total_passed counts PASSED outcomes; total_failed counts
+    FAILED across all severities."""
+    claim = _make_claim()
+    passed_outcome = ClaimOutcome(
+        claim=claim,
+        verdict=PropertyVerdict(
+            property_name="x", kind="test_passes",
+            verdict=VerdictKind.PASSED,
+        ),
+    )
+    failed_outcome = ClaimOutcome(
+        claim=claim,
+        verdict=PropertyVerdict(
+            property_name="x", kind="test_passes",
+            verdict=VerdictKind.FAILED,
+        ),
+    )
+    pm = VerificationPostmortem(
+        op_id="op-1", session_id="sess-1",
+        outcomes=(passed_outcome, passed_outcome, failed_outcome),
+        must_hold_failed=1, must_hold_count=3,
+        has_blocking_failures=True,
+    )
+    assert pm.total_passed == 2
+    assert pm.total_failed == 1
+    assert pm.is_clean is False
+
+
+def test_claim_outcome_helpers() -> None:
+    must_hold_failed = ClaimOutcome(
+        claim=_make_claim(severity=SEVERITY_MUST_HOLD),
+        verdict=PropertyVerdict(
+            property_name="x", kind="test_passes",
+            verdict=VerdictKind.FAILED,
+        ),
+    )
+    assert must_hold_failed.passed is False
+    assert must_hold_failed.is_terminal is True
+    assert must_hold_failed.is_blocking is True
+
+    should_hold_failed = ClaimOutcome(
+        claim=_make_claim(severity=SEVERITY_SHOULD_HOLD),
+        verdict=PropertyVerdict(
+            property_name="x", kind="test_passes",
+            verdict=VerdictKind.FAILED,
+        ),
+    )
+    # should_hold failure is NOT blocking (only must_hold is)
+    assert should_hold_failed.is_blocking is False
+
+    insufficient = ClaimOutcome(
+        claim=_make_claim(severity=SEVERITY_MUST_HOLD),
+        verdict=PropertyVerdict(
+            property_name="x", kind="test_passes",
+            verdict=VerdictKind.INSUFFICIENT_EVIDENCE,
+        ),
+    )
+    assert insufficient.is_blocking is False  # not FAILED → not blocking
+    assert insufficient.is_terminal is False
+
+
+# ---------------------------------------------------------------------------
+# §4-§6 — Round-trip serialization
+# ---------------------------------------------------------------------------
+
+
+def test_postmortem_round_trip() -> None:
+    claim = _make_claim()
+    outcome = ClaimOutcome(
+        claim=claim,
+        verdict=PropertyVerdict(
+            property_name=claim.property.name, kind=claim.property.kind,
+            verdict=VerdictKind.FAILED, confidence=1.0,
+            reason="exit_code=1",
+        ),
+        evidence_used_repr='{"exit_code": 1}',
+    )
+    original = VerificationPostmortem(
+        op_id="op-42", session_id="sess-x",
+        total_claims=1, must_hold_count=1, must_hold_failed=1,
+        has_blocking_failures=True,
+        outcomes=(outcome,),
+    )
+    parsed = VerificationPostmortem.from_dict(original.to_dict())
+    assert parsed is not None
+    assert parsed.op_id == "op-42"
+    assert parsed.has_blocking_failures is True
+    assert parsed.must_hold_failed == 1
+    assert len(parsed.outcomes) == 1
+    assert parsed.outcomes[0].claim.severity == SEVERITY_MUST_HOLD
+    assert parsed.outcomes[0].verdict.verdict is VerdictKind.FAILED
+
+
+def test_postmortem_from_dict_rejects_bad() -> None:
+    assert VerificationPostmortem.from_dict("not a mapping") is None  # type: ignore[arg-type]
+    assert VerificationPostmortem.from_dict({}) is None
+    assert VerificationPostmortem.from_dict({
+        "schema_version": "wrong.0",
+    }) is None
+
+
+def test_postmortem_from_dict_handles_missing_fields() -> None:
+    """Defensive: missing optional fields use safe defaults."""
+    pm = VerificationPostmortem.from_dict({
+        "schema_version": VERIFICATION_POSTMORTEM_SCHEMA_VERSION,
+        "op_id": "op-1",
+        "session_id": "sess-1",
+    })
+    assert pm is not None
+    assert pm.total_claims == 0
+    assert pm.outcomes == ()
+
+
+# ---------------------------------------------------------------------------
+# §7-§16 — Producer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_produce_flag_off_returns_empty(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "JARVIS_VERIFICATION_POSTMORTEM_ENABLED", "false",
+    )
+    pm = await produce_verification_postmortem(op_id="op-1")
+    assert pm.total_claims == 0
+    assert pm.has_blocking_failures is False
+
+
+@pytest.mark.asyncio
+async def test_produce_empty_op_id(isolated) -> None:
+    pm = await produce_verification_postmortem(op_id="")
+    assert pm.total_claims == 0
+    assert pm.op_id == ""
+
+
+@pytest.mark.asyncio
+async def test_produce_no_claims(isolated) -> None:
+    """Op with no recorded claims → clean empty postmortem."""
+    pm = await produce_verification_postmortem(op_id="op-never-claimed")
+    assert pm.total_claims == 0
+    assert pm.is_clean is True
+    assert pm.has_blocking_failures is False
+
+
+@pytest.mark.asyncio
+async def test_produce_all_passed(isolated) -> None:
+    """Capture must_hold claims, all pass via collector → no blocking."""
+    claims = [
+        _make_claim(name=f"t{i}", severity=SEVERITY_MUST_HOLD)
+        for i in range(3)
+    ]
+    await capture_claims(op_id="op-1", claims=claims)
+
+    class _CtxAllPassed:
+        validation_passed = True
+
+    pm = await produce_verification_postmortem(
+        op_id="op-1", ctx=_CtxAllPassed(),
+    )
+    assert pm.total_claims == 3
+    assert pm.must_hold_count == 3
+    assert pm.must_hold_failed == 0
+    assert pm.has_blocking_failures is False
+    assert pm.is_clean is True
+    assert pm.total_passed == 3
+
+
+@pytest.mark.asyncio
+async def test_produce_must_hold_failed_blocks(isolated) -> None:
+    claims = [_make_claim(severity=SEVERITY_MUST_HOLD)]
+    await capture_claims(op_id="op-1", claims=claims)
+
+    class _CtxFailed:
+        validation_passed = False
+
+    pm = await produce_verification_postmortem(
+        op_id="op-1", ctx=_CtxFailed(),
+    )
+    assert pm.must_hold_failed == 1
+    assert pm.has_blocking_failures is True
+    assert pm.is_clean is False
+
+
+@pytest.mark.asyncio
+async def test_produce_should_hold_failed_not_blocking(isolated) -> None:
+    claims = [_make_claim(severity=SEVERITY_SHOULD_HOLD)]
+    await capture_claims(op_id="op-1", claims=claims)
+
+    class _CtxFailed:
+        validation_passed = False
+
+    pm = await produce_verification_postmortem(
+        op_id="op-1", ctx=_CtxFailed(),
+    )
+    assert pm.should_hold_failed == 1
+    assert pm.must_hold_failed == 0
+    assert pm.has_blocking_failures is False
+
+
+@pytest.mark.asyncio
+async def test_produce_ideal_failed_not_blocking(isolated) -> None:
+    claims = [_make_claim(severity=SEVERITY_IDEAL)]
+    await capture_claims(op_id="op-1", claims=claims)
+
+    class _CtxFailed:
+        validation_passed = False
+
+    pm = await produce_verification_postmortem(
+        op_id="op-1", ctx=_CtxFailed(),
+    )
+    assert pm.ideal_failed == 1
+    assert pm.has_blocking_failures is False
+
+
+@pytest.mark.asyncio
+async def test_produce_insufficient_evidence(isolated) -> None:
+    """Claim with kind that isn't covered by ctx_evidence_collector
+    → INSUFFICIENT_EVIDENCE."""
+    claim = PropertyClaim(
+        op_id="op-1", claimed_at_phase="PLAN",
+        property=Property.make(
+            kind="set_subset", name="x",
+            evidence_required=("actual", "allowed"),
+        ),
+        severity=SEVERITY_MUST_HOLD,
+    )
+    await capture_claims(op_id="op-1", claims=[claim])
+
+    pm = await produce_verification_postmortem(op_id="op-1")
+    assert pm.insufficient_count == 1
+    # INSUFFICIENT is not FAILED → not blocking
+    assert pm.must_hold_failed == 0
+    assert pm.has_blocking_failures is False
+
+
+@pytest.mark.asyncio
+async def test_produce_collector_raises_becomes_error(isolated) -> None:
+    """Custom collector that raises → outcome is EVALUATOR_ERROR,
+    no propagation."""
+    claims = [_make_claim()]
+    await capture_claims(op_id="op-1", claims=claims)
+
+    async def boom(claim, ctx):
+        raise RuntimeError("simulated collector fault")
+
+    pm = await produce_verification_postmortem(
+        op_id="op-1", evidence_collector=boom,
+    )
+    # Empty evidence from the safe-collector path means
+    # exit_code missing → INSUFFICIENT_EVIDENCE (not ERROR).
+    # The producer's defensive try/except returns {} on collector
+    # raise, then the Oracle dispatcher returns INSUFFICIENT.
+    assert pm.insufficient_count == 1
+
+
+@pytest.mark.asyncio
+async def test_produce_non_mapping_evidence(isolated) -> None:
+    """Collector returning non-Mapping → empty evidence → INSUFFICIENT."""
+    claims = [_make_claim()]
+    await capture_claims(op_id="op-1", claims=claims)
+
+    async def bad_collector(claim, ctx):
+        return "not a mapping"
+
+    pm = await produce_verification_postmortem(
+        op_id="op-1", evidence_collector=bad_collector,
+    )
+    assert pm.insufficient_count == 1
+
+
+# ---------------------------------------------------------------------------
+# §17-§20 — ctx_evidence_collector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ctx_collector_test_passes_validated() -> None:
+    class Ctx:
+        validation_passed = True
+
+    claim = _make_claim(kind="test_passes")
+    evidence = await ctx_evidence_collector(claim, Ctx())
+    assert evidence == {"exit_code": 0}
+
+
+@pytest.mark.asyncio
+async def test_ctx_collector_test_passes_not_validated() -> None:
+    class Ctx:
+        validation_passed = False
+
+    claim = _make_claim(kind="test_passes")
+    evidence = await ctx_evidence_collector(claim, Ctx())
+    assert evidence == {"exit_code": 1}
+
+
+@pytest.mark.asyncio
+async def test_ctx_collector_key_present_validated() -> None:
+    class Ctx:
+        validation_passed = True
+
+    claim = _make_claim(kind="key_present")
+    evidence = await ctx_evidence_collector(claim, Ctx())
+    assert evidence == {"present": True}
+
+
+@pytest.mark.asyncio
+async def test_ctx_collector_string_matches_empty() -> None:
+    """Slice 2.4's default collector is honest about not having
+    signature evidence — returns empty → INSUFFICIENT_EVIDENCE."""
+    class Ctx:
+        validation_passed = True
+
+    claim = PropertyClaim(
+        op_id="x", claimed_at_phase="PLAN",
+        property=Property.make(
+            kind="string_matches", name="sig",
+            evidence_required=("actual", "expected"),
+        ),
+    )
+    evidence = await ctx_evidence_collector(claim, Ctx())
+    assert evidence == {}
+
+
+@pytest.mark.asyncio
+async def test_ctx_collector_handles_none_ctx() -> None:
+    """None ctx → collector doesn't crash."""
+    claim = _make_claim()
+    evidence = await ctx_evidence_collector(claim, None)
+    assert isinstance(evidence, Mapping)
+
+
+@pytest.mark.asyncio
+async def test_ctx_collector_handles_missing_attrs() -> None:
+    """ctx without validation_passed attr → defaults to False."""
+    class Ctx:
+        pass  # no validation_passed
+
+    claim = _make_claim(kind="test_passes")
+    evidence = await ctx_evidence_collector(claim, Ctx())
+    assert evidence == {"exit_code": 1}  # defaults False → 1
+
+
+# ---------------------------------------------------------------------------
+# §21-§22 — Persister
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persist_flag_off_returns_false(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "JARVIS_VERIFICATION_POSTMORTEM_ENABLED", "false",
+    )
+    pm = VerificationPostmortem(op_id="op-1", session_id="sess-1")
+    result = await persist_postmortem(pm=pm)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_persist_happy_path(isolated) -> None:
+    pm = VerificationPostmortem(
+        op_id="op-1", session_id="test-session",
+        total_claims=2, must_hold_count=2, must_hold_failed=1,
+        has_blocking_failures=True,
+    )
+    result = await persist_postmortem(pm=pm)
+    assert result is True
+
+    # Verify ledger contains the record
+    ledger_path = isolated / "test-session" / "decisions.jsonl"
+    assert ledger_path.exists()
+    raw = ledger_path.read_text(encoding="utf-8")
+    assert "verification_postmortem" in raw
+    assert '"op_id":"op-1"' in raw or '"op_id": "op-1"' in raw
+
+
+@pytest.mark.asyncio
+async def test_persist_empty_op_id_fails(isolated) -> None:
+    pm = VerificationPostmortem(op_id="", session_id="sess-1")
+    result = await persist_postmortem(pm=pm)
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# §23-§26 — Reader
+# ---------------------------------------------------------------------------
+
+
+def test_reader_empty_op_id() -> None:
+    assert get_recorded_postmortem(op_id="") is None
+
+
+def test_reader_no_record(isolated) -> None:
+    assert get_recorded_postmortem(op_id="op-never-recorded") is None
+
+
+@pytest.mark.asyncio
+async def test_reader_round_trip(isolated) -> None:
+    original = VerificationPostmortem(
+        op_id="op-rt", session_id="test-session",
+        total_claims=1, must_hold_count=1, must_hold_failed=1,
+        has_blocking_failures=True,
+    )
+    persisted = await persist_postmortem(pm=original)
+    assert persisted is True
+
+    recovered = get_recorded_postmortem(op_id="op-rt")
+    assert recovered is not None
+    assert recovered.op_id == "op-rt"
+    assert recovered.has_blocking_failures is True
+    assert recovered.must_hold_failed == 1
+
+
+@pytest.mark.asyncio
+async def test_reader_most_recent_wins(isolated) -> None:
+    """Multiple postmortems for same op → reader returns the LAST."""
+    pm1 = VerificationPostmortem(
+        op_id="op-multi", session_id="test-session",
+        total_claims=1, must_hold_failed=1,
+        has_blocking_failures=True,
+    )
+    pm2 = VerificationPostmortem(
+        op_id="op-multi", session_id="test-session",
+        total_claims=2, must_hold_failed=0,
+        has_blocking_failures=False,
+    )
+    await persist_postmortem(pm=pm1)
+    await persist_postmortem(pm=pm2)
+
+    recovered = get_recorded_postmortem(op_id="op-multi")
+    assert recovered is not None
+    assert recovered.total_claims == 2  # last one wins
+    assert recovered.has_blocking_failures is False
+
+
+# ---------------------------------------------------------------------------
+# §27-§28 — log_postmortem_summary
+# ---------------------------------------------------------------------------
+
+
+def test_log_postmortem_empty_no_log(caplog) -> None:
+    """Empty postmortem (no claims) doesn't log — no noise."""
+    caplog.set_level(logging.INFO)
+    pm = VerificationPostmortem(op_id="op-1", session_id="sess-1")
+    log_postmortem_summary(pm)
+    matched = [
+        r for r in caplog.records if "VerifyPostmortem" in r.getMessage()
+    ]
+    assert matched == []
+
+
+def test_log_postmortem_populated_emits_info(caplog) -> None:
+    caplog.set_level(logging.INFO)
+    pm = VerificationPostmortem(
+        op_id="op-1", session_id="sess-1",
+        total_claims=3, must_hold_count=2, must_hold_failed=1,
+        has_blocking_failures=True,
+    )
+    log_postmortem_summary(pm)
+    matched = [
+        r for r in caplog.records if "VerifyPostmortem" in r.getMessage()
+    ]
+    assert len(matched) == 1
+    msg = matched[0].getMessage()
+    assert "op=op-1" in msg
+    assert "claims=3" in msg
+    assert "blocking=true" in msg
+
+
+def test_log_postmortem_none_no_crash() -> None:
+    """Defensive: None argument doesn't crash."""
+    log_postmortem_summary(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# §29-§30 — Adapter integration
+# ---------------------------------------------------------------------------
+
+
+def test_postmortem_adapter_registered() -> None:
+    from backend.core.ouroboros.governance.determinism.phase_capture import (
+        get_adapter,
+        _IDENTITY_ADAPTER,
+    )
+    import backend.core.ouroboros.governance.verification.postmortem  # noqa
+    adapter = get_adapter(
+        phase="COMPLETE", kind="verification_postmortem",
+    )
+    assert adapter is not _IDENTITY_ADAPTER
+    assert adapter.name == "verification_postmortem_adapter"
+
+
+def test_postmortem_adapter_round_trip() -> None:
+    from backend.core.ouroboros.governance.determinism.phase_capture import (
+        get_adapter,
+    )
+    adapter = get_adapter(
+        phase="COMPLETE", kind="verification_postmortem",
+    )
+    original = VerificationPostmortem(
+        op_id="op-1", session_id="sess-1",
+        total_claims=2, must_hold_failed=1,
+    )
+    serialized = adapter.serialize(original.to_dict())
+    deserialized = adapter.deserialize(serialized)
+    assert isinstance(deserialized, VerificationPostmortem)
+    assert deserialized.must_hold_failed == 1
+
+
+# ---------------------------------------------------------------------------
+# §31 — Authority invariants
+# ---------------------------------------------------------------------------
+
+
+def test_no_orchestrator_imports() -> None:
+    import ast
+    import inspect
+    from backend.core.ouroboros.governance.verification import postmortem
+    tree = ast.parse(inspect.getsource(postmortem))
+    forbidden = (
+        "backend.core.ouroboros.governance.orchestrator",
+        "backend.core.ouroboros.governance.candidate_generator",
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for f in forbidden:
+                assert f != node.module, (
+                    f"postmortem must NOT import from {f}"
+                )
+
+
+def test_no_phase_runners_imports() -> None:
+    import ast
+    import inspect
+    from backend.core.ouroboros.governance.verification import postmortem
+    tree = ast.parse(inspect.getsource(postmortem))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert "phase_runners" not in node.module
+
+
+def test_no_provider_imports() -> None:
+    import inspect
+    from backend.core.ouroboros.governance.verification import postmortem
+    src = inspect.getsource(postmortem)
+    assert "doubleword_provider" not in src
+    assert "claude_provider" not in src.lower()
+
+
+# ---------------------------------------------------------------------------
+# §32-§33 — Public API + schema versions
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exposure() -> None:
+    from backend.core.ouroboros.governance import verification
+    expected = {
+        "VerificationPostmortem", "ClaimOutcome",
+        "produce_verification_postmortem", "persist_postmortem",
+        "get_recorded_postmortem", "log_postmortem_summary",
+        "ctx_evidence_collector", "postmortem_enabled",
+    }
+    for name in expected:
+        assert name in verification.__all__, f"missing: {name}"
+
+
+def test_schema_versions_pinned() -> None:
+    assert VERIFICATION_POSTMORTEM_SCHEMA_VERSION == "verification_postmortem.1"
+    assert CLAIM_OUTCOME_SCHEMA_VERSION == "claim_outcome.1"
+
+
+# ---------------------------------------------------------------------------
+# §34 — COMPLETE runner wiring
+# ---------------------------------------------------------------------------
+
+
+def test_complete_runner_wires_postmortem() -> None:
+    src = open(
+        "backend/core/ouroboros/governance/phase_runners/complete_runner.py",
+        encoding="utf-8",
+    ).read()
+    assert "Slice 2.4" in src
+    assert "produce_verification_postmortem" in src
+    assert "persist_postmortem" in src
+
+
+def test_complete_runner_imports_postmortem_lazily() -> None:
+    """Import must be inside function body, not module top level."""
+    src = open(
+        "backend/core/ouroboros/governance/phase_runners/complete_runner.py",
+        encoding="utf-8",
+    ).read()
+    lines = src.split("\n")
+    top_level = [
+        ln for ln in lines
+        if ln.startswith(
+            "from backend.core.ouroboros.governance.verification.postmortem"
+        )
+    ]
+    assert top_level == []
+
+
+def test_complete_runner_postmortem_has_try_except() -> None:
+    src = open(
+        "backend/core/ouroboros/governance/phase_runners/complete_runner.py",
+        encoding="utf-8",
+    ).read()
+    pm_idx = src.index("produce_verification_postmortem")
+    preceding = src[max(0, pm_idx - 1500):pm_idx]
+    assert "try:" in preceding
+    following = src[pm_idx:pm_idx + 2000]
+    assert "except Exception" in following
+
+
+def test_complete_runner_postmortem_after_apply() -> None:
+    """Postmortem call must come after _publish_outcome (op marked
+    APPLIED) and before the success-path PhaseResult return."""
+    src = open(
+        "backend/core/ouroboros/governance/phase_runners/complete_runner.py",
+        encoding="utf-8",
+    ).read()
+    apply_idx = src.index("_publish_outcome")
+    pm_idx = src.index("produce_verification_postmortem")
+    return_idx = src.index('reason="complete"')
+    assert apply_idx < pm_idx < return_idx
+
+
+# ---------------------------------------------------------------------------
+# §35-§36 — Aggregation correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_total_passed_failed_consistency(isolated) -> None:
+    """total_passed + total_failed + insufficient + error = total_claims
+    for any postmortem (Slice 2.4 invariant)."""
+    claims = [
+        _make_claim(name=f"t{i}", severity=SEVERITY_MUST_HOLD)
+        for i in range(2)
+    ] + [
+        _make_claim(name="t-should", severity=SEVERITY_SHOULD_HOLD),
+        # one INSUFFICIENT claim
+        PropertyClaim(
+            op_id="op-1", claimed_at_phase="PLAN",
+            property=Property.make(
+                kind="set_subset", name="ss",
+                evidence_required=("actual", "allowed"),
+            ),
+            severity=SEVERITY_IDEAL,
+        ),
+    ]
+    await capture_claims(op_id="op-1", claims=claims)
+
+    class Ctx:
+        validation_passed = True
+
+    pm = await produce_verification_postmortem(
+        op_id="op-1", ctx=Ctx(),
+    )
+    assert pm.total_claims == 4
+    # Conservation invariant
+    accounted = (
+        pm.total_passed + pm.total_failed
+        + pm.insufficient_count + pm.error_count
+    )
+    assert accounted == pm.total_claims
+
+
+@pytest.mark.asyncio
+async def test_all_pass_is_clean_true(isolated) -> None:
+    """All-pass + no insufficient/error → is_clean=True."""
+    claims = [_make_claim(name="t1", severity=SEVERITY_MUST_HOLD)]
+    await capture_claims(op_id="op-1", claims=claims)
+
+    class Ctx:
+        validation_passed = True
+
+    pm = await produce_verification_postmortem(
+        op_id="op-1", ctx=Ctx(),
+    )
+    assert pm.is_clean is True
+
+
+@pytest.mark.asyncio
+async def test_any_failure_is_clean_false(isolated) -> None:
+    claims = [_make_claim(severity=SEVERITY_IDEAL)]
+    await capture_claims(op_id="op-1", claims=claims)
+
+    class Ctx:
+        validation_passed = False
+
+    pm = await produce_verification_postmortem(
+        op_id="op-1", ctx=Ctx(),
+    )
+    assert pm.is_clean is False
+    # ideal failure doesn't block but is_clean reflects ANY failure
+    assert pm.has_blocking_failures is False


### PR DESCRIPTION
## Summary

**The loop-closing slice.** Slice 2.4 turns Phase 2 from "infrastructure that records claims" into a CLOSED LOOP — the third RSI gear from PRD §24.10.

Per Gemini's framing of I.J. Good's intelligence-explosion thesis:

> "Suppose O+V merges a change to its own TopologySentinel to make it faster. 72 hours later, the Post-Merge Auditor wakes up and checks if the codebase is still stable. If it is, O+V logs a permanent 'lesson' that this new routing logic is successful."

Slice 2.4 is that **lesson-logging machinery for the immediate (op-close) horizon**. Antigravity's parallel `post_merge_auditor.py` covers the 72-hour horizon. Together they bracket the consequence-tracking surface — every op leaves a structured record of what was claimed versus what was delivered.

## Root problem solved

```
PLAN time     → claims captured (Slice 2.3)
APPLY time    → change committed (existing)
VERIFY time   → tests run (existing)
COMPLETE time → walk claims, evaluate against post-APPLY evidence,
                produce structured VerificationPostmortem,
                persist as permanent ledger lesson (THIS SLICE)
```

## What Slice 2.4 ships

| Component | Purpose |
|---|---|
| `VerificationPostmortem` | Frozen+hashable schema; aggregated outcome with `has_blocking_failures` summary signal |
| `ClaimOutcome` | Per-claim outcome (claim + verdict + evidence used) with `.passed/.is_terminal/.is_blocking` helpers |
| `produce_verification_postmortem(...)` | Async producer: walks claims (Slice 2.3) → dispatches each via Oracle (Slice 2.1) → aggregates |
| `persist_postmortem(...)` | Async persister via Slice 1.3 `capture_phase_decision` |
| `get_recorded_postmortem(...)` | Sync reader from per-session JSONL (most-recent-wins) |
| `ctx_evidence_collector(claim, ctx)` | Default evidence collector pulling signals from `ctx.validation_passed` etc. |
| `log_postmortem_summary(pm)` | Structured INFO log line for operator visibility |
| COMPLETE runner wiring | Closure-over-`ctx` at success path; defensive try/except |

## Blocking signal

`has_blocking_failures = (any must_hold claim has FAILED verdict)`

INSUFFICIENT and ERROR don't block — they're **"we couldn't tell"** not "we know it failed." This preserves Bayesian validity at the postmortem level (consistent with Slice 2.2 RepeatRunner's verdict→LR mapping).

## Evidence collection — honest by default

The default `ctx_evidence_collector` pulls signals from OperationContext for the four canonical claim kinds:

| Claim kind | Evidence source | Note |
|---|---|---|
| `test_passes` | `ctx.validation_passed` → `exit_code` (0/1) | Best-effort signal |
| `key_present` | `ctx.validation_passed` → `present` | Best-effort signal |
| `string_matches` | empty | Signature inspection requires live AST — operators wire richer collectors |
| Unknown kinds | empty | → `INSUFFICIENT_EVIDENCE` |

`INSUFFICIENT_EVIDENCE` verdicts are **honest** — they say "we recorded this claim but couldn't verify it from available signals." Better than silent passes. Operators see the audit trail and know which claims need richer collection.

## COMPLETE runner wiring (closure-over-ctx, defensive)

```python
# After _publish_outcome (op marked APPLIED), before PhaseResult return:
try:
    _pm = await produce_verification_postmortem(op_id=ctx.op_id, ctx=ctx)
    log_postmortem_summary(_pm)
    await persist_postmortem(pm=_pm, op_id=ctx.op_id, ctx=ctx)
    if _pm.has_blocking_failures:
        logger.warning("[Orchestrator] verification postmortem reports "
                       "blocking failures: op=%s ...", ctx.op_id)
except Exception:
    logger.debug(...)  # NEVER blocks op closure
```

**Postmortem failure NEVER blocks op closure.** Op already succeeded; this is **consequence tracking**, not gate enforcement (auto-revert is a future-phase concern).

## Operator's design constraints applied

| Constraint | How |
|---|---|
| **Asynchronous** | Producer + persister async; reader sync one-shot file walk |
| **Dynamic** | `evidence_collector` is free-form; default provided + operator-overridable |
| **Adaptive** | `INSUFFICIENT_EVIDENCE` preserves audit value; doesn't fake-pass |
| **Intelligent** | Canonical evidence-hash via Antigravity (transitively); claim_id deterministic |
| **Robust** | Every method NEVER raises; postmortem failure NEVER blocks op |
| **No hardcoding** | Severity constants from Slice 2.3 (free-form); claim kinds dynamic |
| **Leverages existing** | Slices 1.1/1.2/1.3/2.1/2.3 + Antigravity. ZERO duplication |

## Authority invariants (pinned)

- NEVER imports `orchestrator` / `phase_runner` (base) / `candidate_generator`
- NEVER imports providers
- Every public method NEVER raises
- `complete_runner` imports `postmortem` LAZILY (inside function body)
- Source pins: `Slice 2.4` + `produce_verification_postmortem` + `persist_postmortem` markers
- Postmortem call AFTER `_publish_outcome`, BEFORE success-path return
- try/except wraps the whole postmortem call

## Test plan

- [x] **59 new tests** covering 36 pin sections
- [x] **746/746 green** across full Phase 1 + Phase 2 + 12 + 12.2 regression suite
- [x] All four severity × verdict combinations exercised (must_hold/should_hold/ideal × PASSED/FAILED/INSUFFICIENT/ERROR)
- [x] Conservation invariant: `passed + failed + insufficient + error = total_claims`
- [x] Defensive paths: collector raises, non-Mapping evidence, None ctx, missing attrs
- [x] Round-trip: produce → persist → reader returns equivalent postmortem
- [x] Multiple postmortems for same op → most-recent-wins
- [x] COMPLETE runner wiring source-level pins (lazy import, ordering, try/except)

## Master flag

`JARVIS_VERIFICATION_POSTMORTEM_ENABLED` (default **false** until Slice 2.5)

## Phase 2 status

| Slice | Status |
|---|---|
| 2.1 PropertyOracle | ✅ merged |
| 2.2 RepeatRunner | ✅ merged |
| 2.3 property_capture | ✅ merged |
| **2.4 VerificationPostmortem** | ✅ **THIS PR — RSI LOOP CLOSED** |
| 2.5 Graduation flip | held |

## RSI gears alignment

Per the operator's directive on I.J. Good's intelligence explosion:

| Gear | Status post-Slice-2.4 |
|---|---|
| **1. Determinism** (measuring stick) | ✅ Phase 1 graduated (entropy + clock + ledger + replay CLI) |
| **2. Bounded Curiosity** (efficiency engine) | ⏳ Phase 3 prep shipped by Antigravity (`exploration_calculus` + `convergence_governor`); Slice 2.2 RepeatRunner already CONSUMES Bayesian primitives |
| **3. Closed-Loop Memory** (consequence tracker) | ✅ **THIS SLICE.** Phase 2 architecturally complete pending 2.5 graduation flip |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a verification postmortem that evaluates recorded claims after each successful op, persists a `VerificationPostmortem`, and warns on blocking must_hold failures without blocking op closure.

- New Features
  - Postmortem schemas (`VerificationPostmortem`, `ClaimOutcome`) and async producer `produce_verification_postmortem`.
  - Helpers: `persist_postmortem`, `get_recorded_postmortem`, `log_postmortem_summary`, and default `ctx_evidence_collector` (uses `ctx.validation_passed` for `test_passes`/`key_present`; unknown kinds → insufficient).
  - Blocking rule: `has_blocking_failures` is true when any must_hold claim FAILED; insufficient/error do not block.
  - Wired into `complete_runner`: lazy import inside try/except, logs summary, warns on blocking, never blocks closure. Public API updated in `verification/__init__.py`. Comprehensive tests added.

- Migration
  - Gate via `JARVIS_VERIFICATION_POSTMORTEM_ENABLED` (default `false`). Set to `true` to enable.
  - When enabled, records are persisted to the session ledger via `capture_phase_decision`; behavior is unchanged when the flag is off.

<sup>Written for commit 2b1cbeff1e4ad7c769c76e19d266265349f32181. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29162?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

