### PR TITLE
feat(topology): Slices 3a + 3c — self-healing recovery + sensor backpressure

### DIFF
--- a/backend/core/ouroboros/governance/dw_discovery_runner.py
+++ b/backend/core/ouroboros/governance/dw_discovery_runner.py
@@ -150,6 +150,37 @@ async def run_discovery(
             f"catalog_fetch_failed:{snapshot.fetch_failure_reason}"
         )
 
+    # Step 1.4: Slice 3a — active topology recovery.
+    # The catalog GET /models *is* the lightweight reachability probe
+    # the architectural directive calls for: same auth, same session,
+    # same endpoint, zero new infrastructure. When fetch succeeds AND
+    # returns a populated model list, lift transient blocks via the
+    # sentinel's apply_health_probe_result() helper. The 30-min refresh
+    # cadence (JARVIS_DW_CATALOG_REFRESH_S) doubles as the recovery
+    # cadence — operator-tunable; not hardcoded.
+    if (
+        snapshot.fetch_failure_reason is None
+        and len(snapshot.models) > 0
+    ):
+        try:
+            from backend.core.ouroboros.governance.topology_sentinel import (
+                get_default_sentinel as _get_sent,
+                topology_active_recovery_enabled as _ar_enabled,
+            )
+            if _ar_enabled():
+                _recovered = _get_sent().apply_health_probe_result(
+                    success=True,
+                )
+                if _recovered:
+                    diagnostics.append(
+                        f"topology_active_recovery:transitions={_recovered}"
+                    )
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[DiscoveryRunner] active topology recovery failed",
+                exc_info=True,
+            )
+
     # Step 1.5: Slice G — modality verification (metadata + probes)
     # Runs BEFORE classify so the ledger is populated with verdicts
     # the classifier can consult. Gated by master flag — when off,

--- a/backend/core/ouroboros/governance/sensor_governor.py
+++ b/backend/core/ouroboros/governance/sensor_governor.py
@@ -161,6 +161,30 @@ def emergency_postmortem_threshold() -> float:
     return min(1.0, raw)
 
 
+def topology_backpressure_enabled() -> bool:
+    """Slice 3c — TopologySentinel-aware throttle for low-urgency
+    sensors. ``JARVIS_TOPOLOGY_BACKPRESSURE_ENABLED`` (default
+    ``true``). When on, a SensorGovernor whose injected
+    ``topology_state_fn`` reports any DW endpoint blocked applies an
+    additional multiplier to the weighted cap of BACKGROUND and
+    SPECULATIVE urgency requests. IMMEDIATE/STANDARD/COMPLEX caps
+    are untouched (those routes can fall back to Claude). Hot-revert:
+    ``export JARVIS_TOPOLOGY_BACKPRESSURE_ENABLED=false`` returns the
+    cap math to posture × urgency × brake (the pre-3c formula)."""
+    return _env_bool("JARVIS_TOPOLOGY_BACKPRESSURE_ENABLED", True)
+
+
+def topology_backpressure_mult() -> float:
+    """Multiplier applied to BG/SPEC weighted caps when topology is
+    blocked. Default 0.2 = throttle to 20% of the unblocked cap.
+    ``JARVIS_TOPOLOGY_BACKPRESSURE_MULT``. Floor at 0.0 (full halt
+    is allowed); ceiling at 1.0 (no-op upper bound)."""
+    raw = _env_float(
+        "JARVIS_TOPOLOGY_BACKPRESSURE_MULT", 0.2, minimum=0.0,
+    )
+    return min(1.0, raw)
+
+
 # ---------------------------------------------------------------------------
 # Vocabulary
 # ---------------------------------------------------------------------------
@@ -235,6 +259,13 @@ class BudgetDecision:
     emergency_brake: bool = False
     global_cap: int = 0
     global_count: int = 0
+    # Slice 3c — set when topology-backpressure factor was applied to
+    # this sensor's weighted_cap (DW blocked + urgency in BG/SPEC).
+    # Independent of `allowed` — the cap may still leave headroom even
+    # under backpressure; the field is purely observability so SSE
+    # consumers can distinguish "throttled by topology" from "throttled
+    # by capacity".
+    topology_blocked: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -249,6 +280,7 @@ class BudgetDecision:
             "emergency_brake": self.emergency_brake,
             "global_cap": self.global_cap,
             "global_count": self.global_count,
+            "topology_blocked": self.topology_blocked,
         }
 
 
@@ -293,6 +325,24 @@ def _default_signal_bundle_fn() -> Optional[Any]:
         return None
 
 
+def _default_topology_state_fn() -> Tuple[str, ...]:
+    """Slice 3c — default reader for the TopologySentinel singleton.
+
+    Returns the tuple of model_ids currently OPEN/TERMINAL_OPEN. When
+    the sentinel module isn't importable (Slice 1 isolation) OR the
+    sentinel master flag is off, returns ``()`` so backpressure is a
+    no-op and the cap math collapses to the pre-3c formula. NEVER
+    raises — backpressure is advisory; sentinel outage must not break
+    the governor."""
+    try:
+        from backend.core.ouroboros.governance.topology_sentinel import (
+            get_default_sentinel,
+        )
+        return get_default_sentinel().list_blocked_endpoints()
+    except Exception:  # noqa: BLE001
+        return ()
+
+
 # ---------------------------------------------------------------------------
 # SensorGovernor
 # ---------------------------------------------------------------------------
@@ -319,6 +369,9 @@ class SensorGovernor:
         *,
         posture_fn: Optional[Callable[[], Optional[str]]] = None,
         signal_bundle_fn: Optional[Callable[[], Optional[Any]]] = None,
+        topology_state_fn: Optional[
+            Callable[[], Tuple[str, ...]]
+        ] = None,
     ) -> None:
         self._specs: Dict[str, SensorBudgetSpec] = {}
         # Per-sensor deques of emission timestamps (monotonic seconds)
@@ -329,6 +382,11 @@ class SensorGovernor:
         self._decisions: Deque[BudgetDecision] = deque(maxlen=512)
         self._posture_fn = posture_fn or _default_posture_fn
         self._signal_bundle_fn = signal_bundle_fn or _default_signal_bundle_fn
+        # Slice 3c — TopologySentinel-aware backpressure. Returns the
+        # tuple of blocked model_ids; truthy → throttle BG/SPEC caps.
+        self._topology_state_fn = (
+            topology_state_fn or _default_topology_state_fn
+        )
         self._lock = threading.Lock()
 
     # -- registration -------------------------------------------------------
@@ -387,17 +445,45 @@ class SensorGovernor:
         return (cost_burn >= emergency_cost_threshold()
                 or pm_rate >= emergency_postmortem_threshold())
 
+    def _topology_blocking(self, urgency: Urgency) -> bool:
+        """Slice 3c — predicate for "should the topology factor apply
+        to this request?". Returns True iff:
+          * the master flag is on, AND
+          * urgency is BACKGROUND or SPECULATIVE (high-urgency routes
+            cascade to Claude and must not throttle on DW health), AND
+          * the injected ``topology_state_fn`` reports any blocked
+            endpoint.
+
+        The state-fn callable is permitted to raise — we swallow and
+        return False so a sentinel outage never breaks the governor.
+        """
+        if not topology_backpressure_enabled():
+            return False
+        if urgency not in (Urgency.BACKGROUND, Urgency.SPECULATIVE):
+            return False
+        try:
+            blocked = self._topology_state_fn()
+        except Exception:  # noqa: BLE001
+            return False
+        return bool(blocked)
+
     def _weighted_cap(
         self,
         spec: SensorBudgetSpec,
         urgency: Urgency,
         posture: Optional[str],
         brake: bool,
+        topology_blocked: bool = False,
     ) -> int:
         base = spec.base_cap_per_hour
         posture_mult = spec.weight_for_posture(posture)
         urgency_mult = spec.urgency_mult(urgency)
         cap = base * posture_mult * urgency_mult
+        # Slice 3c — topology backpressure factor applied BEFORE the
+        # emergency brake so the two compose (DW blocked + cost-burn
+        # high → 0.2 × 0.2 = 0.04× throttle on BG/SPEC).
+        if topology_blocked:
+            cap *= topology_backpressure_mult()
         if brake:
             cap *= emergency_reduction_pct()
         # Floor at 1 so brake + low-weight sensor isn't fully zeroed
@@ -443,7 +529,11 @@ class SensorGovernor:
             self._evict_expired(now)
 
             brake = self._emergency_brake_active()
-            weighted_cap = self._weighted_cap(spec, urgency, posture, brake)
+            topology_blocked = self._topology_blocking(urgency)
+            weighted_cap = self._weighted_cap(
+                spec, urgency, posture, brake,
+                topology_blocked=topology_blocked,
+            )
             current = len(self._per_sensor.get(sensor_name, ()))
             remaining = max(0, weighted_cap - current)
 
@@ -453,6 +543,12 @@ class SensorGovernor:
                 gcap = max(1, int(gcap * emergency_reduction_pct()))
             gremaining = max(0, gcap - gcount)
 
+            # Slice 3c — when the cap was reduced by topology AND the
+            # reduction is what exhausted the per-sensor budget, stamp
+            # a more specific reason_code so SSE/REPL consumers can
+            # distinguish "throttled by DW health" from "throttled by
+            # capacity". reason_code is otherwise unchanged when the
+            # topology factor wasn't load-bearing.
             if gremaining <= 0:
                 decision = BudgetDecision(
                     allowed=False, sensor_name=sensor_name, urgency=urgency,
@@ -460,14 +556,21 @@ class SensorGovernor:
                     current_count=current, remaining=remaining,
                     reason_code="governor.global_cap_exhausted",
                     emergency_brake=brake, global_cap=gcap, global_count=gcount,
+                    topology_blocked=topology_blocked,
                 )
             elif remaining <= 0:
+                _reason = (
+                    "governor.topology_backpressure"
+                    if topology_blocked
+                    else "governor.sensor_cap_exhausted"
+                )
                 decision = BudgetDecision(
                     allowed=False, sensor_name=sensor_name, urgency=urgency,
                     posture=posture, weighted_cap=weighted_cap,
                     current_count=current, remaining=remaining,
-                    reason_code="governor.sensor_cap_exhausted",
+                    reason_code=_reason,
                     emergency_brake=brake, global_cap=gcap, global_count=gcount,
+                    topology_blocked=topology_blocked,
                 )
             else:
                 decision = BudgetDecision(
@@ -476,6 +579,7 @@ class SensorGovernor:
                     current_count=current, remaining=remaining,
                     reason_code="governor.ok",
                     emergency_brake=brake, global_cap=gcap, global_count=gcount,
+                    topology_blocked=topology_blocked,
                 )
 
             self._decisions.append(decision)

--- a/backend/core/ouroboros/governance/topology_sentinel.py
+++ b/backend/core/ouroboros/governance/topology_sentinel.py
@@ -194,6 +194,8 @@ _SENTINEL_PROPAGATED_VARS: Tuple[str, ...] = (
     # Master flag
     "JARVIS_TOPOLOGY_SENTINEL_ENABLED",
     "JARVIS_TOPOLOGY_FORCE_SEVERED",
+    # Slice 3a — active recovery from successful catalog probes
+    "JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED",
     # Threshold + decay
     "JARVIS_TOPOLOGY_SEVERED_THRESHOLD_WEIGHTED",
     "JARVIS_TOPOLOGY_SUCCESS_DECAY",
@@ -286,6 +288,23 @@ def is_sentinel_enabled() -> bool:
     ``model_id`` and consumers MUST treat the verdict as advisory
     (legacy static yaml stays authoritative)."""
     return _env_bool("JARVIS_TOPOLOGY_SENTINEL_ENABLED", default=False)
+
+
+def topology_active_recovery_enabled() -> bool:
+    """Slice 3a — self-healing recovery from a successful catalog probe.
+
+    ``JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED`` (default ``true``).
+    When on, ``apply_health_probe_result(success=True)`` resets every
+    ``TERMINAL_OPEN`` breaker (the catalog probe itself just proved
+    reachability — auth/modality verdicts may have been transient or
+    are stale under a new snapshot) AND calls ``record_success`` on
+    every ``HALF_OPEN`` breaker (decays the weighted streak; pushes
+    HALF_OPEN→CLOSED). Hot-revert path: ``export
+    JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED=false`` returns the runner
+    to legacy "reset only on snapshot id change" behavior."""
+    return _env_bool(
+        "JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED", default=True,
+    )
 
 
 def severed_threshold_weighted() -> float:
@@ -1476,6 +1495,99 @@ class TopologySentinel:
             return count
         except Exception:  # noqa: BLE001 — defensive
             return 0
+
+    def list_blocked_endpoints(self) -> Tuple[str, ...]:
+        """Slice 3c — return the model_ids currently in OPEN or
+        TERMINAL_OPEN. Stable-sorted. Used by SensorGovernor for
+        topology-aware backpressure (low-urgency sensors throttle when
+        any DW endpoint is blocked).
+
+        When the master flag is off, returns ``()`` because
+        ``get_state`` collapses every endpoint to CLOSED in that case
+        (legacy yaml authoritative). NEVER raises."""
+        if not is_sentinel_enabled():
+            return ()
+        try:
+            with self._lock:
+                blocked = [
+                    mid for mid, b in self._breakers.items()
+                    if b.state.value in ("OPEN", "TERMINAL_OPEN")
+                ]
+            return tuple(sorted(blocked))
+        except Exception:  # noqa: BLE001 — defensive
+            return ()
+
+    def apply_health_probe_result(self, *, success: bool) -> int:
+        """Slice 3a — active recovery from a lightweight catalog probe.
+
+        Called by ``dw_discovery_runner.run_discovery`` after the
+        ``GET /models`` fetch. The fetch IS the probe — when DW returns
+        a populated catalog, the endpoint is reachable, and any
+        transient block deserves a fresh chance.
+
+        On ``success=True``:
+          * Every ``TERMINAL_OPEN`` breaker is reset (auth/modality
+            verdicts that survived persistence get a fresh probe path)
+          * Every ``HALF_OPEN`` breaker has ``record_success`` called
+            on it (decays weighted streak; transitions HALF_OPEN→CLOSED
+            via the existing rate_limiter state machine)
+          * ``OPEN`` breakers are left alone — the rate_limiter's
+            time-based ``recovery_timeout_s`` (default 30s) handles
+            OPEN→HALF_OPEN auto-transition; the next live call probes
+            it and triggers HALF_OPEN→CLOSED via the existing path.
+            Forcing OPEN→CLOSED here would race the post-failure cool-
+            down and could mask a real fault.
+
+        On ``success=False``:
+          * No-op. Probe failure is a catalog-layer signal, not a
+            model-layer signal — penalising every model for a single
+            catalog timeout would double-count failures and risks a
+            cascade-storm on transient network blips.
+
+        Both master flags are honoured: when
+        ``JARVIS_TOPOLOGY_SENTINEL_ENABLED=false`` OR
+        ``JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED=false``, this method
+        is a no-op returning 0.
+
+        Returns the count of breakers transitioned (TERMINAL_OPEN
+        resets + HALF_OPEN→CLOSED transitions). NEVER raises."""
+        if not success:
+            return 0
+        if not is_sentinel_enabled():
+            return 0
+        if not topology_active_recovery_enabled():
+            return 0
+        transitions = 0
+        # Step 1: TERMINAL_OPEN resets — explicit method already exists
+        try:
+            transitions += self.reset_all_terminal_breakers()
+        except Exception:  # noqa: BLE001 — defensive
+            pass
+        # Step 2: HALF_OPEN → CLOSED via record_success on each
+        try:
+            with self._lock:
+                half_open_ids = [
+                    mid for mid, b in self._breakers.items()
+                    if b.state.value == "HALF_OPEN"
+                ]
+            for mid in half_open_ids:
+                pre_state = self.get_state(mid)
+                self.report_success(mid)
+                post_state = self.get_state(mid)
+                if pre_state != post_state:
+                    transitions += 1
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[TopologySentinel] HALF_OPEN recovery failed",
+                exc_info=True,
+            )
+        if transitions:
+            logger.info(
+                "[TopologySentinel] active recovery: %d breaker(s) "
+                "transitioned after successful catalog probe",
+                transitions,
+            )
+        return transitions
 
     def force_severed(self, model_id: str, reason: str) -> None:
         """Operator override — pin the endpoint OPEN immediately."""

--- a/tests/governance/test_sensor_governor_topology_backpressure.py
+++ b/tests/governance/test_sensor_governor_topology_backpressure.py
@@ -1,0 +1,351 @@
+"""Slice 3c — SensorGovernor topology-aware backpressure.
+
+When TopologySentinel reports any DW endpoint blocked
+(``state in {OPEN, TERMINAL_OPEN}``), the governor applies an
+additional multiplier to the weighted cap of BACKGROUND and
+SPECULATIVE urgency requests. IMMEDIATE / STANDARD / COMPLEX caps
+stay untouched — those routes can fall back to Claude and must keep
+firing even with DW down.
+
+Pins:
+  §1   topology_backpressure_enabled flag — default true; case-tolerant
+  §2   topology_backpressure_mult — default 0.2; case-tolerant; clamped
+  §3   _default_topology_state_fn returns () when sentinel unavailable
+  §4   __init__ accepts topology_state_fn injection (mirrors posture_fn)
+  §5   BG urgency cap reduced when state_fn reports blocked
+  §6   SPEC urgency cap reduced when state_fn reports blocked
+  §7   IMMEDIATE urgency cap UNCHANGED (cascade route)
+  §8   STANDARD urgency cap UNCHANGED (cascade route)
+  §9   COMPLEX urgency cap UNCHANGED (cascade route)
+  §10  No reduction when state_fn returns ()
+  §11  Master flag off → backpressure no-op
+  §12  BudgetDecision.topology_blocked field reflects whether factor applied
+  §13  reason_code = "governor.topology_backpressure" when topology
+       caused per-sensor exhaustion
+  §14  reason_code unchanged when topology factor wasn't load-bearing
+  §15  Composes with emergency brake (multiplicative)
+  §16  state_fn that raises is swallowed (governor never breaks on outage)
+  §17  to_dict includes topology_blocked
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.sensor_governor import (
+    BudgetDecision,
+    SensorBudgetSpec,
+    SensorGovernor,
+    Urgency,
+    topology_backpressure_enabled,
+    topology_backpressure_mult,
+    _default_topology_state_fn,
+)
+
+
+def _spec(name="X", cap=10):
+    return SensorBudgetSpec(sensor_name=name, base_cap_per_hour=cap)
+
+
+# ===========================================================================
+# §1-§2 — Master flag + multiplier env contract
+# ===========================================================================
+
+
+def test_backpressure_default_true(monkeypatch) -> None:
+    """Master flag default: env unset → True. Note: this module uses
+    the strict ``_env_bool`` convention where empty-string is False
+    (not the asymmetric verification/determinism convention)."""
+    monkeypatch.delenv("JARVIS_TOPOLOGY_BACKPRESSURE_ENABLED", raising=False)
+    assert topology_backpressure_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_backpressure_truthy(monkeypatch, val) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKPRESSURE_ENABLED", val)
+    assert topology_backpressure_enabled() is True
+
+
+@pytest.mark.parametrize(
+    "val", ["", " ", "0", "false", "no", "off", "garbage"],
+)
+def test_backpressure_falsy(monkeypatch, val) -> None:
+    """Strict convention — empty-string AND whitespace AND any
+    non-truthy string returns False. Matches sensor_governor module
+    style."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKPRESSURE_ENABLED", val)
+    assert topology_backpressure_enabled() is False
+
+
+def test_backpressure_mult_default_0_2(monkeypatch) -> None:
+    monkeypatch.delenv("JARVIS_TOPOLOGY_BACKPRESSURE_MULT", raising=False)
+    assert topology_backpressure_mult() == 0.2
+
+
+def test_backpressure_mult_clamped_to_1(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKPRESSURE_MULT", "5.0")
+    assert topology_backpressure_mult() == 1.0
+
+
+def test_backpressure_mult_floored_at_zero(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKPRESSURE_MULT", "-0.5")
+    # min=0.0 floor in _env_float
+    assert topology_backpressure_mult() == 0.0
+
+
+# ===========================================================================
+# §3-§4 — Defaults + injection
+# ===========================================================================
+
+
+def test_default_topology_state_fn_returns_tuple() -> None:
+    """When sentinel isn't engaged or master-off, returns () so
+    backpressure is a no-op."""
+    result = _default_topology_state_fn()
+    assert isinstance(result, tuple)
+
+
+def test_governor_accepts_topology_state_fn_injection() -> None:
+    """Mirror of posture_fn / signal_bundle_fn injection. Mock state-fn."""
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: ("dw-1",),
+    )
+    assert g._topology_state_fn() == ("dw-1",)  # noqa: SLF001
+
+
+# ===========================================================================
+# §5-§9 — Cap math: throttled urgencies vs cascade urgencies
+# ===========================================================================
+
+
+def test_bg_cap_reduced_when_topology_blocked(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKPRESSURE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKPRESSURE_MULT", "0.2")
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: ("dw-1",),
+    )
+    g.register(_spec("DocStaleness", cap=10))
+    d = g.request_budget("DocStaleness", Urgency.BACKGROUND)
+    # 10 * 1.0 (posture) * 0.5 (BG urgency) * 0.2 (topology) = 1.0 → 1
+    assert d.weighted_cap == 1
+    assert d.topology_blocked is True
+
+
+def test_spec_cap_reduced_when_topology_blocked(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: ("dw-1",),
+    )
+    g.register(_spec("IntentDiscovery", cap=20))
+    d = g.request_budget("IntentDiscovery", Urgency.SPECULATIVE)
+    # 20 * 1.0 * 0.3 (SPEC urgency) * 0.2 (topology) = 1.2 → 1
+    assert d.weighted_cap == 1
+    assert d.topology_blocked is True
+
+
+def test_immediate_cap_unchanged_under_topology_block(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: ("dw-1",),
+    )
+    g.register(_spec("VoiceCommand", cap=10))
+    d = g.request_budget("VoiceCommand", Urgency.IMMEDIATE)
+    # 10 * 1.0 * 2.0 (IMMEDIATE) = 20; topology factor NOT applied
+    assert d.weighted_cap == 20
+    assert d.topology_blocked is False
+
+
+def test_standard_cap_unchanged_under_topology_block(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: ("dw-1",),
+    )
+    g.register(_spec("S", cap=10))
+    d = g.request_budget("S", Urgency.STANDARD)
+    # 10 * 1.0 * 1.0 = 10; topology factor NOT applied
+    assert d.weighted_cap == 10
+    assert d.topology_blocked is False
+
+
+def test_complex_cap_unchanged_under_topology_block(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: ("dw-1",),
+    )
+    g.register(_spec("S", cap=10))
+    d = g.request_budget("S", Urgency.COMPLEX)
+    # 10 * 1.0 * 0.8 = 8; topology factor NOT applied
+    assert d.weighted_cap == 8
+    assert d.topology_blocked is False
+
+
+# ===========================================================================
+# §10-§11 — No-op paths
+# ===========================================================================
+
+
+def test_no_reduction_when_state_fn_returns_empty(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: (),
+    )
+    g.register(_spec("DocStaleness", cap=10))
+    d = g.request_budget("DocStaleness", Urgency.BACKGROUND)
+    # 10 * 0.5 (BG) = 5; no topology factor
+    assert d.weighted_cap == 5
+    assert d.topology_blocked is False
+
+
+def test_master_flag_off_disables_backpressure(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TOPOLOGY_BACKPRESSURE_ENABLED", "false")
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: ("dw-1",),
+    )
+    g.register(_spec("DocStaleness", cap=10))
+    d = g.request_budget("DocStaleness", Urgency.BACKGROUND)
+    # Master flag off → topology factor not applied even though state_fn
+    # reports blocked. 10 * 0.5 (BG) = 5
+    assert d.weighted_cap == 5
+    assert d.topology_blocked is False
+
+
+# ===========================================================================
+# §12-§14 — Decision field + reason_code
+# ===========================================================================
+
+
+def test_topology_blocked_field_set_when_factor_applied(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: ("dw-1",),
+    )
+    g.register(_spec("DocStaleness", cap=10))
+    d = g.request_budget("DocStaleness", Urgency.BACKGROUND)
+    assert d.topology_blocked is True
+    d2 = g.request_budget("DocStaleness", Urgency.IMMEDIATE)
+    assert d2.topology_blocked is False
+
+
+def test_reason_code_topology_when_topology_caused_exhaustion(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: ("dw-1",),
+    )
+    g.register(_spec("DocStaleness", cap=10))
+    # Burn through the cap (BG cap = 10 * 0.5 * 0.2 = 1)
+    g.request_budget("DocStaleness", Urgency.BACKGROUND)
+    g.record_emission("DocStaleness", Urgency.BACKGROUND)
+    d = g.request_budget("DocStaleness", Urgency.BACKGROUND)
+    assert d.allowed is False
+    assert d.reason_code == "governor.topology_backpressure"
+    assert d.topology_blocked is True
+
+
+def test_reason_code_normal_when_topology_factor_not_applied(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=lambda: (),  # nothing blocked
+    )
+    g.register(_spec("S", cap=1))
+    g.request_budget("S", Urgency.STANDARD)
+    g.record_emission("S", Urgency.STANDARD)
+    d = g.request_budget("S", Urgency.STANDARD)
+    assert d.allowed is False
+    assert d.reason_code == "governor.sensor_cap_exhausted"
+    assert d.topology_blocked is False
+
+
+# ===========================================================================
+# §15 — Composability with emergency brake
+# ===========================================================================
+
+
+def test_topology_factor_composes_with_emergency_brake(monkeypatch) -> None:
+    """Both factors apply multiplicatively. 100 * 0.5 (BG) * 0.2
+    (topology) * 0.2 (brake) = 2.0 → 2."""
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_SENSOR_GOVERNOR_EMERGENCY_REDUCTION_PCT", "0.2",
+    )
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: {
+            "cost_burn_normalized": 1.0,
+            "postmortem_failure_rate": 0.0,
+        },
+        topology_state_fn=lambda: ("dw-1",),
+    )
+    g.register(_spec("DocStaleness", cap=100))
+    d = g.request_budget("DocStaleness", Urgency.BACKGROUND)
+    assert d.weighted_cap == 2
+    assert d.topology_blocked is True
+    assert d.emergency_brake is True
+
+
+# ===========================================================================
+# §16 — Defensive — state_fn raises
+# ===========================================================================
+
+
+def test_topology_state_fn_raises_swallowed(monkeypatch) -> None:
+    """A sentinel outage must not break the governor — backpressure
+    silently disables when state_fn raises."""
+    monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+
+    def _raise():
+        raise RuntimeError("sentinel outage")
+
+    g = SensorGovernor(
+        posture_fn=lambda: None,
+        signal_bundle_fn=lambda: None,
+        topology_state_fn=_raise,
+    )
+    g.register(_spec("DocStaleness", cap=10))
+    d = g.request_budget("DocStaleness", Urgency.BACKGROUND)
+    # No backpressure applied (factor swallowed); BG cap = 10 * 0.5 = 5
+    assert d.weighted_cap == 5
+    assert d.topology_blocked is False
+
+
+# ===========================================================================
+# §17 — to_dict serialisation
+# ===========================================================================
+
+
+def test_to_dict_includes_topology_blocked() -> None:
+    d = BudgetDecision(
+        allowed=False, sensor_name="X", urgency=Urgency.BACKGROUND,
+        posture=None, weighted_cap=1, current_count=1, remaining=0,
+        reason_code="governor.topology_backpressure",
+        topology_blocked=True,
+    )
+    payload = d.to_dict()
+    assert payload["topology_blocked"] is True
+    assert payload["reason_code"] == "governor.topology_backpressure"

--- a/tests/governance/test_topology_active_recovery.py
+++ b/tests/governance/test_topology_active_recovery.py
@@ -1,0 +1,276 @@
+"""Slice 3a — TopologySentinel active-recovery regression spine.
+
+The catalog ``GET /models`` IS the lightweight reachability probe the
+architectural directive calls for. After a successful fetch,
+``apply_health_probe_result(success=True)`` lifts transient blocks
+without burning a separate probe. The discovery runner is the only
+caller; cadence is the existing ``JARVIS_DW_CATALOG_REFRESH_S`` (30 min
+default — operator-tunable, not hardcoded).
+
+Pins:
+  §1   topology_active_recovery_enabled flag — default true; case-tolerant
+  §2   apply_health_probe_result(success=False) is a no-op
+  §3   apply_health_probe_result(success=True) when sentinel master off → 0
+  §4   apply_health_probe_result(success=True) when active-recovery off → 0
+  §5   TERMINAL_OPEN breakers reset on probe success
+  §6   HALF_OPEN breakers transition to CLOSED on probe success
+  §7   OPEN breakers are LEFT ALONE (rate_limiter time-based recovery owns it)
+  §8   CLOSED breakers are unaffected (no spurious transitions)
+  §9   Mixed-state recovery: counts add up (TERMINAL + HALF_OPEN)
+  §10  list_blocked_endpoints returns sorted tuple of OPEN/TERMINAL_OPEN
+  §11  list_blocked_endpoints returns () when sentinel master off
+  §12  list_blocked_endpoints excludes HALF_OPEN + CLOSED
+  §13  apply_health_probe_result NEVER raises — defensive on internal errors
+  §14  Public API exposed from module
+  §15  Source-level pin: function reads the env var
+  §16  Propagated-vars contract includes the new flag
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import topology_sentinel as ts
+
+
+# ---------------------------------------------------------------------------
+# Fixture: fresh sentinel + sentinel master flag on
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_sentinel(monkeypatch, tmp_path):
+    """Construct a sentinel with master flag on + a tmp state dir."""
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path / "topo"),
+    )
+    sentinel = ts.TopologySentinel()
+    yield sentinel
+
+
+def _set_breaker_state(sentinel, model_id, state):
+    """Force a breaker into a specific state for testing.
+
+    Uses the same pattern force_severed uses — register endpoint then
+    mutate state directly. Mirrors the prod failure paths."""
+    sentinel.register_endpoint(model_id)
+    breaker = sentinel._breakers[model_id]  # noqa: SLF001
+    BreakerState = sentinel._BreakerStateCls()
+    breaker._state = getattr(BreakerState, state)  # noqa: SLF001
+    snap = sentinel._snapshots[model_id]  # noqa: SLF001
+    snap.state = state
+
+
+# ===========================================================================
+# §1 — Master flag
+# ===========================================================================
+
+
+def test_active_recovery_enabled_default_true(monkeypatch) -> None:
+    monkeypatch.delenv(
+        "JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED", raising=False,
+    )
+    assert ts.topology_active_recovery_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", " ", "  "])
+def test_active_recovery_empty_reads_as_default_true(
+    monkeypatch, val,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED", val,
+    )
+    assert ts.topology_active_recovery_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+def test_active_recovery_truthy(monkeypatch, val) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED", val,
+    )
+    assert ts.topology_active_recovery_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage"])
+def test_active_recovery_falsy(monkeypatch, val) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED", val,
+    )
+    assert ts.topology_active_recovery_enabled() is False
+
+
+# ===========================================================================
+# §2-§4 — Disabled paths
+# ===========================================================================
+
+
+def test_probe_failure_is_noop(fresh_sentinel) -> None:
+    """A probe FAILURE must not penalise breakers — that would double-
+    count failures (model-layer report_failure already covered)."""
+    _set_breaker_state(fresh_sentinel, "m1", "TERMINAL_OPEN")
+    n = fresh_sentinel.apply_health_probe_result(success=False)
+    assert n == 0
+    assert fresh_sentinel.get_state("m1") == "TERMINAL_OPEN"
+
+
+def test_recovery_noop_when_sentinel_master_off(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "false")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path / "topo"),
+    )
+    sentinel = ts.TopologySentinel()
+    _set_breaker_state(sentinel, "m1", "TERMINAL_OPEN")
+    n = sentinel.apply_health_probe_result(success=True)
+    assert n == 0
+
+
+def test_recovery_noop_when_active_recovery_off(
+    fresh_sentinel, monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED", "false",
+    )
+    _set_breaker_state(fresh_sentinel, "m1", "TERMINAL_OPEN")
+    n = fresh_sentinel.apply_health_probe_result(success=True)
+    assert n == 0
+    assert fresh_sentinel.get_state("m1") == "TERMINAL_OPEN"
+
+
+# ===========================================================================
+# §5-§9 — Recovery semantics
+# ===========================================================================
+
+
+def test_terminal_open_resets_on_probe_success(fresh_sentinel) -> None:
+    _set_breaker_state(fresh_sentinel, "m1", "TERMINAL_OPEN")
+    assert fresh_sentinel.get_state("m1") == "TERMINAL_OPEN"
+    n = fresh_sentinel.apply_health_probe_result(success=True)
+    assert n >= 1
+    assert fresh_sentinel.get_state("m1") == "CLOSED"
+
+
+def test_half_open_transitions_to_closed_on_probe_success(
+    fresh_sentinel,
+) -> None:
+    _set_breaker_state(fresh_sentinel, "m1", "HALF_OPEN")
+    assert fresh_sentinel.get_state("m1") == "HALF_OPEN"
+    n = fresh_sentinel.apply_health_probe_result(success=True)
+    assert n >= 1
+    assert fresh_sentinel.get_state("m1") == "CLOSED"
+
+
+def test_open_left_alone_on_probe_success(fresh_sentinel) -> None:
+    """OPEN recovery is owned by rate_limiter's time-based 30s
+    auto-transition. Forcing OPEN→CLOSED here would race the cooldown
+    and could mask a real fault — the directive's "structural repair,
+    not bypasses" rule applies."""
+    _set_breaker_state(fresh_sentinel, "m1", "OPEN")
+    n = fresh_sentinel.apply_health_probe_result(success=True)
+    # State preserved — recovery_timeout_s owns this transition
+    assert fresh_sentinel.get_state("m1") == "OPEN"
+    assert n == 0
+
+
+def test_closed_unaffected_on_probe_success(fresh_sentinel) -> None:
+    _set_breaker_state(fresh_sentinel, "m1", "CLOSED")
+    n = fresh_sentinel.apply_health_probe_result(success=True)
+    assert fresh_sentinel.get_state("m1") == "CLOSED"
+    assert n == 0
+
+
+def test_mixed_state_recovery_counts_correctly(fresh_sentinel) -> None:
+    _set_breaker_state(fresh_sentinel, "term1", "TERMINAL_OPEN")
+    _set_breaker_state(fresh_sentinel, "term2", "TERMINAL_OPEN")
+    _set_breaker_state(fresh_sentinel, "half1", "HALF_OPEN")
+    _set_breaker_state(fresh_sentinel, "open1", "OPEN")
+    _set_breaker_state(fresh_sentinel, "closed1", "CLOSED")
+    n = fresh_sentinel.apply_health_probe_result(success=True)
+    # 2 terminal resets + 1 half_open transition = 3
+    assert n == 3
+    assert fresh_sentinel.get_state("term1") == "CLOSED"
+    assert fresh_sentinel.get_state("term2") == "CLOSED"
+    assert fresh_sentinel.get_state("half1") == "CLOSED"
+    assert fresh_sentinel.get_state("open1") == "OPEN"  # untouched
+    assert fresh_sentinel.get_state("closed1") == "CLOSED"  # untouched
+
+
+# ===========================================================================
+# §10-§12 — list_blocked_endpoints contract
+# ===========================================================================
+
+
+def test_list_blocked_endpoints_returns_sorted_tuple(fresh_sentinel) -> None:
+    _set_breaker_state(fresh_sentinel, "z_open", "OPEN")
+    _set_breaker_state(fresh_sentinel, "a_terminal", "TERMINAL_OPEN")
+    _set_breaker_state(fresh_sentinel, "m_closed", "CLOSED")
+    _set_breaker_state(fresh_sentinel, "k_half", "HALF_OPEN")
+    blocked = fresh_sentinel.list_blocked_endpoints()
+    # Sorted, only OPEN/TERMINAL_OPEN
+    assert blocked == ("a_terminal", "z_open")
+
+
+def test_list_blocked_endpoints_returns_empty_when_master_off(
+    monkeypatch, tmp_path,
+) -> None:
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "false")
+    monkeypatch.setenv(
+        "JARVIS_TOPOLOGY_SENTINEL_STATE_DIR", str(tmp_path / "topo"),
+    )
+    sentinel = ts.TopologySentinel()
+    _set_breaker_state(sentinel, "m1", "OPEN")
+    # Master flag off → list_blocked returns () (legacy yaml authoritative)
+    assert sentinel.list_blocked_endpoints() == ()
+
+
+def test_list_blocked_endpoints_excludes_half_open_and_closed(
+    fresh_sentinel,
+) -> None:
+    _set_breaker_state(fresh_sentinel, "open1", "OPEN")
+    _set_breaker_state(fresh_sentinel, "half1", "HALF_OPEN")
+    _set_breaker_state(fresh_sentinel, "closed1", "CLOSED")
+    blocked = fresh_sentinel.list_blocked_endpoints()
+    assert "open1" in blocked
+    assert "half1" not in blocked
+    assert "closed1" not in blocked
+
+
+# ===========================================================================
+# §13 — Defensive — never raises
+# ===========================================================================
+
+
+def test_apply_health_probe_result_never_raises(fresh_sentinel) -> None:
+    """Even if internal state is corrupt, the method returns 0."""
+    # Empty sentinel — no breakers registered
+    n = fresh_sentinel.apply_health_probe_result(success=True)
+    assert n == 0
+
+
+def test_list_blocked_endpoints_never_raises(fresh_sentinel) -> None:
+    blocked = fresh_sentinel.list_blocked_endpoints()
+    assert isinstance(blocked, tuple)
+
+
+# ===========================================================================
+# §14-§16 — Surface contracts
+# ===========================================================================
+
+
+def test_public_api_exposed() -> None:
+    assert hasattr(ts, "topology_active_recovery_enabled")
+    assert callable(ts.topology_active_recovery_enabled)
+
+
+def test_source_reads_env_var() -> None:
+    import inspect
+    src = inspect.getsource(ts.topology_active_recovery_enabled)
+    assert "JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED" in src
+
+
+def test_propagated_vars_includes_active_recovery_flag() -> None:
+    """The harness env-propagation contract must include the new flag
+    so subprocess soaks see operator-set values."""
+    assert (
+        "JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED"
+        in ts.sentinel_propagated_vars()
+    )


### PR DESCRIPTION
## Summary

Closes the catalog-blocked starvation loop diagnosed in Phase 2 graduation soak #1 (session `bt-2026-04-28-232426`): 11 ops were CLASSIFY/ROUTE/PLAN-clean, then BG-route GENERATE hit `background_dw_blocked_by_topology` (TopologySentinel had blocked DW on a transient timeout; BG-route policy forbids Claude fallback for unit economics; no recovery path; idle_timeout fired 23 min later with `stats.attempted=0`).

### Slice 3a — Active topology recovery (self-healing)
- New `TopologySentinel.apply_health_probe_result(success)` — on probe success, resets every TERMINAL_OPEN breaker + calls `record_success()` on HALF_OPEN breakers (transitions toward CLOSED via existing rate_limiter state machine). OPEN breakers left alone — rate_limiter time-based `recovery_timeout_s` (30s) owns OPEN→HALF_OPEN; forcing OPEN→CLOSED here would race the cooldown.
- Hooked into existing `dw_discovery_runner.run_discovery` after the catalog `GET /models` fetch — same auth, same session, same endpoint, **zero new infrastructure**. Cadence is the existing `JARVIS_DW_CATALOG_REFRESH_S` (default 1800s, operator-tunable). Per directive: tied to existing pacemaker, not hardcoded.
- New `TopologySentinel.list_blocked_endpoints()` for Slice 3c consumption.

### Slice 3c — Topology-aware backpressure
- `SensorGovernor.__init__` accepts `topology_state_fn` injection (mirrors `posture_fn`/`signal_bundle_fn`).
- `_weighted_cap` applies a new `topology_backpressure_mult` factor (default 0.2×) to BACKGROUND and SPECULATIVE urgency caps when any DW endpoint is blocked.
- IMMEDIATE / STANDARD / COMPLEX urgencies untouched — those routes cascade to Claude and must keep firing under DW outage.
- `BudgetDecision.topology_blocked: bool` for SSE observability; rides existing `governor_throttle_applied` rail.
- New reason_code `governor.topology_backpressure` distinguishes topology-driven exhaustion from capacity exhaustion.

### Why this fixes the soak

- **3c** prevents the queue from filling with un-runnable BG ops while DW is blocked — sensors throttle to 20% emission rate.
- **3a** actively lifts transient blocks on each catalog refresh cycle, so the system self-heals without operator intervention.
- Combined: even if a refresh interval passes, the queue stays drainable when DW recovers; idle_timeout no longer cliff-drops on a queue full of stuck BG ops.

## Test plan

- [x] **61 new tests** across 33 pin sections: 30 in `test_topology_active_recovery.py`, 31 in `test_sensor_governor_topology_backpressure.py`
- [x] **396/396** existing regression: sensor_governor + topology_sentinel_preflight + Phase 1/2/12/12.2 graduation pins
- [x] **113/113** discovery regression: dw_discovery_runner + dw_catalog_*
- [x] Pre-commit file-integrity hook clean
- [ ] CI green
- [ ] Live battle-test soak post-merge (`JARVIS_DW_CATALOG_REFRESH_S=300` for 5-min recovery cadence within 40-min wall-cap)

## Hot-revert paths

```bash
# Slice 3a — restore "reset only on snapshot id change" pre-3a behavior
export JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED=false

# Slice 3c — restore pre-3c cap math (posture × urgency × brake)
export JARVIS_TOPOLOGY_BACKPRESSURE_ENABLED=false
```

## Architectural directive compliance

- ✅ Zero new circuit breakers — leverages existing TopologySentinel + rate_limiter state machine
- ✅ Recovery cadence not hardcoded — uses `JARVIS_DW_CATALOG_REFRESH_S` (existing pacemaker)
- ✅ No new loops — recovery rides existing 30-min refresh; backpressure rides existing per-request decision path
- ✅ Probe is the existing catalog `GET /models` (reuses auth + session)
- ✅ SensorGovernor backpressure halts low-urgency sensor emission when DW blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add self-healing topology recovery and topology-aware sensor backpressure to stop BG queue starvation when DW endpoints are transiently blocked. Recovery rides the catalog refresh; low-urgency sensors throttle to 20% when any DW endpoint is blocked; high-urgency paths are unchanged.

- **New Features**
  - Slice 3a — Active recovery
    - `TopologySentinel.apply_health_probe_result(success)` resets `TERMINAL_OPEN` breakers and records success on `HALF_OPEN`; leaves `OPEN` to time-based cooldowns.
    - Wired into `dw_discovery_runner.run_discovery` after a successful catalog `GET /models` fetch (uses existing session/pacemaker).
    - `TopologySentinel.list_blocked_endpoints()` exposes `OPEN`/`TERMINAL_OPEN` model IDs for consumers.
  - Slice 3c — Topology backpressure
    - `SensorGovernor` accepts `topology_state_fn`; when any DW endpoint is blocked, applies `topology_backpressure_mult` (default 0.2×) to BACKGROUND and SPECULATIVE caps.
    - IMMEDIATE/STANDARD/COMPLEX caps are unchanged.
    - Adds `BudgetDecision.topology_blocked` and reason code `governor.topology_backpressure` for observability.

- **Migration**
  - `JARVIS_TOPOLOGY_ACTIVE_RECOVERY_ENABLED` (default true) toggles 3a.
  - `JARVIS_TOPOLOGY_BACKPRESSURE_ENABLED` (default true) and `JARVIS_TOPOLOGY_BACKPRESSURE_MULT` (default 0.2) control 3c. Set the flag to false to hot-revert pre-3c cap math.

<sup>Written for commit 1f746b59a05fa36b49379c64784b3688984035df. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29498?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

