### PR TITLE
feat(dispatcher): Option E — universal terminal postmortem

### DIFF
--- a/backend/core/ouroboros/governance/phase_dispatcher.py
+++ b/backend/core/ouroboros/governance/phase_dispatcher.py
@@ -78,6 +78,7 @@ is pure routing — runners still own their own authority domains.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
@@ -452,6 +453,142 @@ def build_default_registry() -> PhaseRunnerRegistry:
 
 
 # ---------------------------------------------------------------------------
+# Universal Terminal Postmortem (Option E)
+# ---------------------------------------------------------------------------
+
+
+_TERMINAL_POSTMORTEM_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _terminal_postmortem_enabled() -> bool:
+    """``JARVIS_TERMINAL_POSTMORTEM_ENABLED`` (default ``true``).
+
+    Independent kill switch for the universal terminal postmortem hook.
+    When off, the dispatcher exits without firing postmortems for
+    non-COMPLETE terminations. Hot-revert path: ``export
+    JARVIS_TERMINAL_POSTMORTEM_ENABLED=false``."""
+    raw = os.environ.get(
+        "JARVIS_TERMINAL_POSTMORTEM_ENABLED", "true",
+    ).strip().lower()
+    return raw in _TERMINAL_POSTMORTEM_TRUTHY
+
+
+async def _fire_terminal_postmortem(
+    *,
+    ctx: Any,
+    terminal_phase: "OperationPhase",
+    status: str,
+    reason: Optional[str],
+) -> None:
+    """Universal terminal postmortem — async, never blocks, never raises.
+
+    Fires for EVERY op termination EXCEPT COMPLETE (which has its own
+    postmortem wiring in COMPLETERunner). Dynamically captures the
+    terminal context:
+
+      * ``terminal_phase`` — which phase killed the op
+      * ``status`` — "fail" / "ok" / "skip" from PhaseResult
+      * ``reason`` — the runner's reason string (e.g.,
+        ``"background_accepted"``, ``"is_noop"``,
+        ``"validate_failed"``, ``"gate_blocked"``)
+
+    Produces a VerificationPostmortem and persists it via
+    ``capture_phase_decision`` so the record is Merkle-linked to
+    the op's decision chain (Slice 1.3 DAG edge).
+
+    Authority invariant: NEVER imports orchestrator / candidate_generator.
+    NEVER raises out of the public surface."""
+    try:
+        if not _terminal_postmortem_enabled():
+            return
+
+        op_id = getattr(ctx, "op_id", None)
+        if not op_id:
+            return
+
+        # Produce the postmortem (walks recorded claims + evaluates)
+        from backend.core.ouroboros.governance.verification.postmortem import (
+            log_postmortem_summary,
+            persist_postmortem,
+            postmortem_enabled,
+            produce_verification_postmortem,
+        )
+        if not postmortem_enabled():
+            return
+
+        pm = await produce_verification_postmortem(
+            op_id=op_id, ctx=ctx,
+        )
+
+        log_postmortem_summary(pm)
+
+        # Persist via capture_phase_decision for Merkle DAG linkage.
+        # We use phase=terminal_phase.name and kind="terminal_postmortem"
+        # so the record hashes into the op's decision chain at the
+        # correct phase vertex.
+        try:
+            from backend.core.ouroboros.governance.determinism.phase_capture import (
+                capture_phase_decision,
+            )
+            _phase_name = (
+                terminal_phase.name
+                if hasattr(terminal_phase, "name")
+                else str(terminal_phase)
+            )
+
+            pm_dict = pm.to_dict()
+            # Enrich with terminal context — the dynamic signal that
+            # distinguishes this from a COMPLETE postmortem.
+            pm_dict["_terminal_context"] = {
+                "terminal_phase": _phase_name,
+                "status": str(status),
+                "reason": str(reason) if reason else None,
+                "is_success": status == "ok",
+            }
+
+            async def _emit() -> Any:
+                return pm_dict
+
+            await capture_phase_decision(
+                op_id=op_id,
+                phase=_phase_name,
+                kind="terminal_postmortem",
+                ctx=ctx,
+                compute=_emit,
+                extra_inputs={
+                    "terminal_phase": _phase_name,
+                    "status": str(status),
+                    "reason": str(reason) if reason else None,
+                    "total_claims": pm.total_claims,
+                    "must_hold_failed": pm.must_hold_failed,
+                    "has_blocking_failures": pm.has_blocking_failures,
+                },
+            )
+        except Exception:  # noqa: BLE001 — defensive
+            # Merkle persistence failed — fall back to basic persist.
+            # The postmortem is still recorded, just without the DAG
+            # edge. Better than losing the lesson entirely.
+            await persist_postmortem(pm=pm, op_id=op_id, ctx=ctx)
+
+        if pm.has_blocking_failures:
+            logger.warning(
+                "[PhaseDispatcher] terminal postmortem reports blocking "
+                "failures: op=%s phase=%s reason=%s must_hold_failed=%d/%d",
+                op_id[:16] if op_id else "?",
+                terminal_phase.name if hasattr(terminal_phase, "name") else "?",
+                reason or "?",
+                pm.must_hold_failed, pm.must_hold_count,
+            )
+
+    except Exception:  # noqa: BLE001 — NEVER raises, NEVER blocks
+        logger.debug(
+            "[PhaseDispatcher] terminal postmortem failed — "
+            "op closure unaffected",
+            exc_info=True,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher — the main event
 # ---------------------------------------------------------------------------
 
@@ -587,6 +724,19 @@ async def dispatch_pipeline(
                 "exiting loop",
                 dispatch_phase.name,
             )
+            # Option E: universal terminal postmortem for unregistered
+            # terminal phases (CANCELLED / EXPIRED / POSTMORTEM).
+            # These exits have no runner PhaseResult, so status/reason
+            # are inferred from the phase itself.
+            if dispatch_phase != OperationPhase.COMPLETE:
+                asyncio.ensure_future(
+                    _fire_terminal_postmortem(
+                        ctx=ctx,
+                        terminal_phase=dispatch_phase,
+                        status="fail",
+                        reason=dispatch_phase.name.lower(),
+                    )
+                )
             return ctx
 
         try:
@@ -721,6 +871,20 @@ async def dispatch_pipeline(
                 "(status=%s reason=%r) — terminal",
                 result.status, result.reason,
             )
+            # Option E: universal terminal postmortem. Fire for
+            # every non-COMPLETE termination so the organism learns
+            # from every death, not just its successes.
+            # COMPLETE is skipped: COMPLETERunner already fires its
+            # own postmortem (lines 164-200 of complete_runner.py).
+            if dispatch_phase != OperationPhase.COMPLETE:
+                asyncio.ensure_future(
+                    _fire_terminal_postmortem(
+                        ctx=result.next_ctx,
+                        terminal_phase=dispatch_phase,
+                        status=result.status,
+                        reason=result.reason,
+                    )
+                )
             return result.next_ctx
 
         ctx = result.next_ctx

--- a/tests/governance/phase_runner/test_universal_terminal_postmortem.py
+++ b/tests/governance/phase_runner/test_universal_terminal_postmortem.py
@@ -1,0 +1,580 @@
+"""Tests for Option E — Universal Terminal Postmortem.
+
+Verifies that EVERY op termination (not just COMPLETE) produces a
+VerificationPostmortem, dynamically captures the terminal context,
+persists via capture_phase_decision for Merkle DAG linkage, and
+executes asynchronously without blocking the dispatcher.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.core.ouroboros.governance.op_context import (
+    OperationContext,
+    OperationPhase,
+)
+from backend.core.ouroboros.governance.phase_dispatcher import (
+    PhaseContext,
+    PhaseRunnerRegistry,
+    _fire_terminal_postmortem,
+    _terminal_postmortem_enabled,
+    dispatch_pipeline,
+)
+from backend.core.ouroboros.governance.phase_runner import (
+    PhaseResult,
+    PhaseRunner,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _enable_flags(monkeypatch):
+    """Enable all relevant flags for every test."""
+    monkeypatch.setenv("JARVIS_TERMINAL_POSTMORTEM_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_VERIFICATION_POSTMORTEM_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_PHASE_RUNNER_DISPATCHER_ENABLED", "true")
+
+
+@dataclass
+class _FakeCtx:
+    """Minimal duck-typed OperationContext for testing."""
+    op_id: str = "test-op-001"
+    phase: OperationPhase = OperationPhase.CLASSIFY
+    validation_passed: bool = False
+    target_files: list = field(default_factory=list)
+    signal_urgency: str = ""
+    signal_source: str = ""
+    task_complexity: str = ""
+    cross_repo: bool = False
+    is_read_only: bool = False
+    risk_tier: Any = None
+    generation: Any = None
+
+    def advance(self, phase, **kwargs):
+        return _FakeCtx(op_id=self.op_id, phase=phase, **{
+            k: v for k, v in kwargs.items()
+            if k in self.__dataclass_fields__
+        })
+
+
+class _TerminalRunner(PhaseRunner):
+    """Runner that terminates immediately with configurable status/reason."""
+    phase = OperationPhase.CLASSIFY
+
+    def __init__(self, status="fail", reason="test_terminated"):
+        self._status = status
+        self._reason = reason
+
+    async def run(self, ctx):
+        return PhaseResult(
+            next_ctx=ctx,
+            next_phase=None,
+            status=self._status,
+            reason=self._reason,
+        )
+
+
+class _PassthroughRunner(PhaseRunner):
+    """Runner that advances to the next phase."""
+    phase = OperationPhase.CLASSIFY
+
+    def __init__(self, next_phase):
+        self._next_phase = next_phase
+
+    async def run(self, ctx):
+        return PhaseResult(
+            next_ctx=ctx,
+            next_phase=self._next_phase,
+            status="ok",
+            reason="advanced",
+        )
+
+
+class _FakeOrchestrator:
+    """Minimal duck-typed Orchestrator."""
+    _cancel_token_registry = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_registry_with_terminal(phase: OperationPhase, **kwargs):
+    """Build a registry with a single terminal runner at the given phase."""
+    reg = PhaseRunnerRegistry()
+    reg.register(phase, lambda o, s, p, c: _TerminalRunner(**kwargs))
+    return reg
+
+
+def _build_chain_to_terminal(
+    *phases: OperationPhase,
+    terminal_status="fail",
+    terminal_reason="chain_end",
+):
+    """Build a registry where phases chain into each other, with the last
+    one terminating."""
+    reg = PhaseRunnerRegistry()
+    for i, phase in enumerate(phases):
+        if i == len(phases) - 1:
+            reg.register(
+                phase,
+                lambda o, s, p, c, st=terminal_status, r=terminal_reason: (
+                    _TerminalRunner(status=st, reason=r)
+                ),
+            )
+        else:
+            next_p = phases[i + 1]
+            reg.register(
+                phase,
+                lambda o, s, p, c, np=next_p: _PassthroughRunner(np),
+            )
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# 1. Core: Every non-COMPLETE terminal fires postmortem
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalPhasesFire:
+    """Each non-COMPLETE phase that returns next_phase=None fires the
+    universal postmortem."""
+
+    @pytest.mark.parametrize("phase,reason", [
+        (OperationPhase.CLASSIFY, "background_accepted"),
+        (OperationPhase.ROUTE, "route_rejected"),
+        (OperationPhase.PLAN, "is_noop"),
+        (OperationPhase.GENERATE, "provider_error"),
+        (OperationPhase.VALIDATE, "validate_failed"),
+        (OperationPhase.GATE, "gate_blocked"),
+        (OperationPhase.APPROVE, "apply_rejected"),
+    ])
+    @pytest.mark.asyncio
+    async def test_fires_for_phase(self, phase, reason):
+        reg = _build_registry_with_terminal(phase, reason=reason)
+        ctx = _FakeCtx(phase=phase)
+        orch = _FakeOrchestrator()
+
+        with patch(
+            "backend.core.ouroboros.governance.phase_dispatcher"
+            "._fire_terminal_postmortem",
+            new_callable=AsyncMock,
+        ) as mock_fire:
+            await dispatch_pipeline(
+                orch, None, ctx, registry=reg,
+            )
+            mock_fire.assert_called_once()
+            call_kwargs = mock_fire.call_args.kwargs
+            assert call_kwargs["terminal_phase"] == phase
+            assert call_kwargs["reason"] == reason
+
+
+class TestCompleteDoesNotDoubleFire:
+    """COMPLETE runner already fires its own postmortem — the universal
+    hook must NOT fire for COMPLETE."""
+
+    @pytest.mark.asyncio
+    async def test_complete_skipped(self):
+        reg = PhaseRunnerRegistry()
+        reg.register(
+            OperationPhase.COMPLETE,
+            lambda o, s, p, c: _TerminalRunner(
+                status="ok", reason="complete",
+            ),
+        )
+        ctx = _FakeCtx(phase=OperationPhase.COMPLETE)
+        orch = _FakeOrchestrator()
+
+        with patch(
+            "backend.core.ouroboros.governance.phase_dispatcher"
+            "._fire_terminal_postmortem",
+            new_callable=AsyncMock,
+        ) as mock_fire:
+            await dispatch_pipeline(
+                orch, None, ctx, registry=reg,
+            )
+            mock_fire.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Dynamic terminal context capture
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicContext:
+    """The postmortem captures status and reason dynamically from the
+    PhaseResult — not hardcoded."""
+
+    @pytest.mark.asyncio
+    async def test_status_captured(self):
+        reg = _build_registry_with_terminal(
+            OperationPhase.GATE, status="fail", reason="security_reject",
+        )
+        ctx = _FakeCtx(phase=OperationPhase.GATE)
+        orch = _FakeOrchestrator()
+
+        with patch(
+            "backend.core.ouroboros.governance.phase_dispatcher"
+            "._fire_terminal_postmortem",
+            new_callable=AsyncMock,
+        ) as mock_fire:
+            await dispatch_pipeline(
+                orch, None, ctx, registry=reg,
+            )
+            kw = mock_fire.call_args.kwargs
+            assert kw["status"] == "fail"
+            assert kw["reason"] == "security_reject"
+
+    @pytest.mark.asyncio
+    async def test_skip_status_captured(self):
+        reg = PhaseRunnerRegistry()
+        reg.register(
+            OperationPhase.PLAN,
+            lambda o, s, p, c: _TerminalRunner(
+                status="skip", reason="trivial_op",
+            ),
+        )
+        ctx = _FakeCtx(phase=OperationPhase.PLAN)
+        orch = _FakeOrchestrator()
+
+        with patch(
+            "backend.core.ouroboros.governance.phase_dispatcher"
+            "._fire_terminal_postmortem",
+            new_callable=AsyncMock,
+        ) as mock_fire:
+            await dispatch_pipeline(
+                orch, None, ctx, registry=reg,
+            )
+            kw = mock_fire.call_args.kwargs
+            assert kw["status"] == "skip"
+            assert kw["reason"] == "trivial_op"
+
+
+# ---------------------------------------------------------------------------
+# 3. Unregistered terminal phases
+# ---------------------------------------------------------------------------
+
+
+class TestUnregisteredTerminals:
+    """Unregistered terminal phases (CANCELLED, EXPIRED, POSTMORTEM)
+    also fire the postmortem via the unregistered exit path."""
+
+    @pytest.mark.parametrize("phase", [
+        OperationPhase.CANCELLED,
+        OperationPhase.EXPIRED,
+        OperationPhase.POSTMORTEM,
+    ])
+    @pytest.mark.asyncio
+    async def test_unregistered_terminal_fires(self, phase):
+        # Build a CLASSIFY runner that routes to an unregistered terminal
+        reg = PhaseRunnerRegistry()
+        reg.register(
+            OperationPhase.CLASSIFY,
+            lambda o, s, p, c, tp=phase: _PassthroughRunner(tp),
+        )
+        ctx = _FakeCtx(phase=OperationPhase.CLASSIFY)
+        orch = _FakeOrchestrator()
+
+        with patch(
+            "backend.core.ouroboros.governance.phase_dispatcher"
+            "._fire_terminal_postmortem",
+            new_callable=AsyncMock,
+        ) as mock_fire:
+            await dispatch_pipeline(
+                orch, None, ctx, registry=reg,
+            )
+            mock_fire.assert_called_once()
+            kw = mock_fire.call_args.kwargs
+            assert kw["terminal_phase"] == phase
+            assert kw["status"] == "fail"
+            assert kw["reason"] == phase.name.lower()
+
+
+# ---------------------------------------------------------------------------
+# 4. Async non-blocking
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncNonBlocking:
+    """The dispatcher returns BEFORE the postmortem completes."""
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_returns_immediately(self):
+        # Use a slow postmortem to prove the dispatcher doesn't wait
+        _pm_started = asyncio.Event()
+        _pm_done = asyncio.Event()
+
+        original = _fire_terminal_postmortem
+
+        async def _slow_pm(**kwargs):
+            _pm_started.set()
+            await asyncio.sleep(0.1)
+            _pm_done.set()
+
+        reg = _build_registry_with_terminal(OperationPhase.CLASSIFY)
+        ctx = _FakeCtx(phase=OperationPhase.CLASSIFY)
+        orch = _FakeOrchestrator()
+
+        with patch(
+            "backend.core.ouroboros.governance.phase_dispatcher"
+            "._fire_terminal_postmortem",
+            side_effect=_slow_pm,
+        ):
+            result = await dispatch_pipeline(
+                orch, None, ctx, registry=reg,
+            )
+            # Dispatcher returned, but postmortem may still be running
+            assert result is not None
+
+        # Allow the event loop to process the background task
+        await asyncio.sleep(0.2)
+        assert _pm_done.is_set()
+
+
+# ---------------------------------------------------------------------------
+# 5. Never raises on postmortem failure
+# ---------------------------------------------------------------------------
+
+
+class TestNeverRaises:
+    """If the postmortem itself raises, the dispatcher still returns
+    normally."""
+
+    @pytest.mark.asyncio
+    async def test_postmortem_exception_suppressed(self):
+        async def _exploding_pm(**kwargs):
+            raise RuntimeError("postmortem kaboom")
+
+        reg = _build_registry_with_terminal(OperationPhase.VALIDATE)
+        ctx = _FakeCtx(phase=OperationPhase.VALIDATE)
+        orch = _FakeOrchestrator()
+
+        with patch(
+            "backend.core.ouroboros.governance.phase_dispatcher"
+            "._fire_terminal_postmortem",
+            side_effect=_exploding_pm,
+        ):
+            # Should NOT raise — the exception is suppressed
+            result = await dispatch_pipeline(
+                orch, None, ctx, registry=reg,
+            )
+            assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# 6. Master flag control
+# ---------------------------------------------------------------------------
+
+
+class TestMasterFlag:
+    """The terminal postmortem flag independently gates the hook."""
+
+    def test_default_enabled(self):
+        import os
+        os.environ["JARVIS_TERMINAL_POSTMORTEM_ENABLED"] = "true"
+        assert _terminal_postmortem_enabled() is True
+
+    def test_disabled(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TERMINAL_POSTMORTEM_ENABLED", "false")
+        assert _terminal_postmortem_enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_disabled_skips_postmortem(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TERMINAL_POSTMORTEM_ENABLED", "false")
+        ctx = _FakeCtx()
+
+        with patch(
+            "backend.core.ouroboros.governance.verification.postmortem"
+            ".produce_verification_postmortem",
+            new_callable=AsyncMock,
+        ) as mock_produce:
+            await _fire_terminal_postmortem(
+                ctx=ctx,
+                terminal_phase=OperationPhase.CLASSIFY,
+                status="fail",
+                reason="test",
+            )
+            mock_produce.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 7. _fire_terminal_postmortem integration
+# ---------------------------------------------------------------------------
+
+
+class TestFireTerminalPostmortem:
+    """Integration tests for the core postmortem function."""
+
+    @pytest.mark.asyncio
+    async def test_produces_and_persists(self):
+        from backend.core.ouroboros.governance.verification.postmortem import (
+            VerificationPostmortem,
+        )
+        _pm = VerificationPostmortem(
+            op_id="test-op", session_id="test",
+        )
+        ctx = _FakeCtx()
+
+        with patch(
+            "backend.core.ouroboros.governance.verification.postmortem"
+            ".produce_verification_postmortem",
+            new_callable=AsyncMock,
+            return_value=_pm,
+        ) as mock_produce, patch(
+            "backend.core.ouroboros.governance.determinism.phase_capture"
+            ".capture_phase_decision",
+            new_callable=AsyncMock,
+        ) as mock_capture:
+            await _fire_terminal_postmortem(
+                ctx=ctx,
+                terminal_phase=OperationPhase.GATE,
+                status="fail",
+                reason="gate_blocked",
+            )
+            mock_produce.assert_called_once()
+            mock_capture.assert_called_once()
+            # Verify phase and kind in the capture call
+            kw = mock_capture.call_args.kwargs
+            assert kw["phase"] == "GATE"
+            assert kw["kind"] == "terminal_postmortem"
+            assert kw["extra_inputs"]["terminal_phase"] == "GATE"
+            assert kw["extra_inputs"]["status"] == "fail"
+            assert kw["extra_inputs"]["reason"] == "gate_blocked"
+
+    @pytest.mark.asyncio
+    async def test_no_op_id_skips(self, monkeypatch):
+        ctx = _FakeCtx(op_id="")
+
+        with patch(
+            "backend.core.ouroboros.governance.verification.postmortem"
+            ".produce_verification_postmortem",
+            new_callable=AsyncMock,
+        ) as mock_produce:
+            await _fire_terminal_postmortem(
+                ctx=ctx,
+                terminal_phase=OperationPhase.CLASSIFY,
+                status="fail",
+                reason="test",
+            )
+            mock_produce.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_merkle_fallback_on_capture_failure(self):
+        """When capture_phase_decision fails, falls back to basic persist."""
+        from backend.core.ouroboros.governance.verification.postmortem import (
+            VerificationPostmortem,
+        )
+        _pm = VerificationPostmortem(
+            op_id="test-op", session_id="test",
+        )
+        ctx = _FakeCtx()
+
+        with patch(
+            "backend.core.ouroboros.governance.verification.postmortem"
+            ".produce_verification_postmortem",
+            new_callable=AsyncMock,
+            return_value=_pm,
+        ), patch(
+            "backend.core.ouroboros.governance.determinism.phase_capture"
+            ".capture_phase_decision",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("capture exploded"),
+        ), patch(
+            "backend.core.ouroboros.governance.verification.postmortem"
+            ".persist_postmortem",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            await _fire_terminal_postmortem(
+                ctx=ctx,
+                terminal_phase=OperationPhase.PLAN,
+                status="fail",
+                reason="plan_error",
+            )
+            # Fallback persist should fire
+            mock_persist.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_terminal_context_enriched_in_payload(self):
+        """The postmortem dict is enriched with _terminal_context."""
+        from backend.core.ouroboros.governance.verification.postmortem import (
+            VerificationPostmortem,
+        )
+        _pm = VerificationPostmortem(
+            op_id="test-op", session_id="test",
+        )
+        ctx = _FakeCtx()
+        _captured_payload = {}
+
+        async def _capture_spy(**kwargs):
+            # Execute compute to get the enriched payload
+            payload = await kwargs["compute"]()
+            _captured_payload.update(payload)
+            return payload
+
+        with patch(
+            "backend.core.ouroboros.governance.verification.postmortem"
+            ".produce_verification_postmortem",
+            new_callable=AsyncMock,
+            return_value=_pm,
+        ), patch(
+            "backend.core.ouroboros.governance.determinism.phase_capture"
+            ".capture_phase_decision",
+            side_effect=_capture_spy,
+        ):
+            await _fire_terminal_postmortem(
+                ctx=ctx,
+                terminal_phase=OperationPhase.VALIDATE,
+                status="fail",
+                reason="validate_failed",
+            )
+            assert "_terminal_context" in _captured_payload
+            tc = _captured_payload["_terminal_context"]
+            assert tc["terminal_phase"] == "VALIDATE"
+            assert tc["status"] == "fail"
+            assert tc["reason"] == "validate_failed"
+            assert tc["is_success"] is False
+
+
+# ---------------------------------------------------------------------------
+# 8. Multi-phase chain terminates at non-COMPLETE
+# ---------------------------------------------------------------------------
+
+
+class TestMultiPhaseChain:
+    """When a chain of phases terminates at a non-COMPLETE phase,
+    the universal postmortem fires at the correct terminal point."""
+
+    @pytest.mark.asyncio
+    async def test_classify_to_plan_terminal(self):
+        reg = _build_chain_to_terminal(
+            OperationPhase.CLASSIFY,
+            OperationPhase.PLAN,
+            terminal_reason="plan_rejected",
+        )
+        ctx = _FakeCtx(phase=OperationPhase.CLASSIFY)
+        orch = _FakeOrchestrator()
+
+        with patch(
+            "backend.core.ouroboros.governance.phase_dispatcher"
+            "._fire_terminal_postmortem",
+            new_callable=AsyncMock,
+        ) as mock_fire:
+            await dispatch_pipeline(
+                orch, None, ctx, registry=reg,
+            )
+            mock_fire.assert_called_once()
+            kw = mock_fire.call_args.kwargs
+            assert kw["terminal_phase"] == OperationPhase.PLAN
+            assert kw["reason"] == "plan_rejected"


### PR DESCRIPTION
## Summary

Closes survivor bias in Phase 2 self-verification. Postmortem hook now fires for **every** op termination, not just successful COMPLETE.

Drafted by Antigravity per architectural directive; verified + integrated here.

## Why

Phase 2 graduation soak #2 produced **0 verification_postmortem records** despite 14 ops terminating. Phase distribution: 14 CLASSIFY, 5 GENERATE, **0 COMPLETE**. The Slice 2.4 hook lived only in `complete_runner.py`'s success path — non-COMPLETE terminations (`background_accepted`, `is_noop`, `validate_failed`, etc.) silently dropped their lessons.

A self-improving system that only learns from success cannot achieve recursive improvement.

## What

`phase_dispatcher.py` now fires `_fire_terminal_postmortem()` at both terminal exit gates (unregistered phase fall-through + runner-returned-None). Skips COMPLETE to avoid double-fire with the existing Slice 2.4 hook.

### Directive constraints — all met
- **Zero duplication**: refactor of existing PhaseDispatcher, no new module
- **Dynamic terminal context**: captures `terminal_phase`, `status`, `reason` from live PhaseResult — not hardcoded
- **Merkle DAG integration**: persisted via Slice 1.3's `capture_phase_decision`, hashed at the terminal_phase vertex with `kind="terminal_postmortem"`
- **Async**: `asyncio.ensure_future` fire-and-forget; dispatcher never blocks
- **Never raises**: outer try/except — postmortem failure cannot block op closure
- **Kill switch**: `JARVIS_TERMINAL_POSTMORTEM_ENABLED=false` for hot revert

## Test plan

- [x] 23 new tests in `test_universal_terminal_postmortem.py` — all green
- [x] Regression: same 20 pre-existing `test_phase_dispatcher_terminals` failures with vs without changes (verified via git stash). **Zero new regressions; +23 new passing tests.**
- [x] Pre-commit file integrity: clean
- [ ] CI green
- [ ] Soak #3 — first non-zero `verification_postmortem` ledger harvest with `terminal_phase` distribution across BG/IMMEDIATE termination types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a universal terminal postmortem so we learn from every operation that ends, not just those that reach COMPLETE. The dispatcher now fires an async postmortem on all non-COMPLETE terminations and on unregistered terminal phases.

- **New Features**
  - Fires postmortem at both terminal gates: unregistered terminal phases and runners that return `next_phase=None` (skips COMPLETE to avoid double-fire).
  - Captures `terminal_phase`, `status`, and `reason` from the live `PhaseResult`; persists via `capture_phase_decision` with `kind="terminal_postmortem"` and falls back to basic persist on failure.
  - Runs async (fire-and-forget) and never blocks or raises; gated by `JARVIS_TERMINAL_POSTMORTEM_ENABLED` (default true).
  - Adds 23 tests covering terminal phases, unregistered exits, async behavior, and failure suppression.

<sup>Written for commit a7aa0fbbf651079304ab7bec614a1380cc38aff1. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29581?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

