### PR TITLE
feat(verification): Priority A Slice A1 — three default-claim evaluators

### DIFF
--- a/backend/core/ouroboros/governance/semantic_firewall.py
+++ b/backend/core/ouroboros/governance/semantic_firewall.py
@@ -126,6 +126,19 @@ _RISK_TIER_FLOOR_NAME = os.environ.get(
 # scanning is fast (GENERAL invocation happens synchronously inside
 # dispatch_general() hot path).
 
+# §24.8.5 — Credential / secret shapes. Extracted as a named module
+# constant so the verification subsystem (Priority A — mandatory claim
+# density) can reuse the same regex set for `no_new_credential_shapes`
+# without duplicating the patterns. The single source of truth lives
+# here; both the firewall and the oracle import it.
+_CREDENTIAL_SHAPE_PATTERNS: Tuple[re.Pattern, ...] = (
+    re.compile(r"\bsk-[A-Za-z0-9_\-]{20,}", re.UNICODE),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b", re.UNICODE),
+    re.compile(r"\bghp_[A-Za-z0-9]{20,}\b", re.UNICODE),
+    re.compile(r"\bxox[bp]-[A-Za-z0-9\-]{10,}\b", re.UNICODE),
+    re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----", re.UNICODE),
+)
+
 _INJECTION_PATTERNS: Tuple[re.Pattern, ...] = (
     # Role-override attempts
     re.compile(r"(?i)\b(ignore|disregard|forget)\s+(previous|prior|all|above)\s+(instruction|prompt|message|directive)", re.UNICODE),
@@ -146,15 +159,10 @@ _INJECTION_PATTERNS: Tuple[re.Pattern, ...] = (
     re.compile(r"(?i)\bset\s+(risk.?tier|approval|gate|validation)\s+(to\s+)?(safe.?auto|none|disabled|off|skip)\b", re.UNICODE),
     re.compile(r"(?i)\b(force|always)\s+(approve|accept|pass|allow|merge|commit|apply)\b", re.UNICODE),
     re.compile(r"(?i)\bwithout\s+(human|manual|operator|approval|review|validation|verification|gate|check)\b", re.UNICODE),
-    # Credential / secret shapes (overlap with sanitize_for_log; we
-    # check here so the rejection is at dispatch time, not buried
-    # inside sanitized output).
-    re.compile(r"\bsk-[A-Za-z0-9_\-]{20,}", re.UNICODE),
-    re.compile(r"\bAKIA[0-9A-Z]{16}\b", re.UNICODE),
-    re.compile(r"\bghp_[A-Za-z0-9]{20,}\b", re.UNICODE),
-    re.compile(r"\bxox[bp]-[A-Za-z0-9\-]{10,}\b", re.UNICODE),
-    re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----", re.UNICODE),
-)
+    # Credential / secret shapes — sourced from the canonical
+    # _CREDENTIAL_SHAPE_PATTERNS tuple above so both firewall and
+    # verification share one definition (no duplication).
+) + _CREDENTIAL_SHAPE_PATTERNS
 
 
 # ============================================================================

--- a/backend/core/ouroboros/governance/verification/property_oracle.py
+++ b/backend/core/ouroboros/governance/verification/property_oracle.py
@@ -683,8 +683,216 @@ def _eval_set_subset(
     )
 
 
+# ---------------------------------------------------------------------------
+# Default-claim evaluators (Priority A — mandatory claim density)
+# ---------------------------------------------------------------------------
+#
+# These three evaluators back the default claims that EVERY op captures
+# at PLAN exit. They are intentionally:
+#   - Pure stdlib (ast / hashlib / re) — zero LLM, zero network
+#   - Deterministic — same evidence → same verdict (replay-stable)
+#   - Defensive — never raise; missing evidence → INSUFFICIENT_EVIDENCE
+#
+# Per PRD §25.5.1 — without these, every verification_postmortem record
+# has total_claims=0 and Phase 2 is theatrical.
+
+
+def _eval_file_parses_after_change(
+    prop: Property, evidence: Mapping[str, Any],
+) -> PropertyVerdict:
+    """Verify each file in ``target_files_post`` is syntactically
+    valid Python after APPLY. Pure-stdlib AST parse — no execution,
+    no import side-effects.
+
+    Required evidence keys:
+      * ``target_files_post`` — sequence of {path, content} mappings
+        captured post-APPLY. Each entry must carry the file's actual
+        on-disk content (caller reads it). Non-Python files (extension
+        not ``.py``) are silently skipped (no false-fail on YAML/JSON).
+
+    Verdict:
+      * PASSED iff every Python file in ``target_files_post`` parses
+        cleanly via ``ast.parse``.
+      * FAILED with the first SyntaxError (line + offset) on any
+        parse failure.
+      * INSUFFICIENT_EVIDENCE if the key is missing or not iterable."""
+    try:
+        files = list(evidence["target_files_post"])
+    except (KeyError, TypeError) as exc:
+        return PropertyVerdict(
+            property_name=prop.name, kind=prop.kind,
+            verdict=VerdictKind.INSUFFICIENT_EVIDENCE,
+            confidence=0.0,
+            reason=f"missing/non-iterable target_files_post: {exc}",
+        )
+    import ast as _ast
+    parsed_count = 0
+    for entry in files:
+        try:
+            path = str(entry.get("path", "") or "")
+            content = entry.get("content", "")
+        except AttributeError:
+            continue  # malformed entry — skip silently
+        if not path or not isinstance(content, (str, bytes)):
+            continue
+        # Slice A1: only Python files are subject to AST parse.
+        # Other text files (YAML / JSON / Markdown) bypass cleanly.
+        if not path.endswith(".py"):
+            continue
+        text = (
+            content.decode("utf-8", errors="replace")
+            if isinstance(content, bytes) else content
+        )
+        try:
+            _ast.parse(text, filename=path)
+            parsed_count += 1
+        except SyntaxError as exc:
+            return PropertyVerdict(
+                property_name=prop.name, kind=prop.kind,
+                verdict=VerdictKind.FAILED,
+                confidence=1.0,
+                reason=(
+                    f"SyntaxError in {path}:{exc.lineno or 0}:"
+                    f"{exc.offset or 0}: {(exc.msg or '')[:120]}"
+                ),
+            )
+    return PropertyVerdict(
+        property_name=prop.name, kind=prop.kind,
+        verdict=VerdictKind.PASSED,
+        confidence=1.0,
+        reason=f"parsed_ok={parsed_count}",
+    )
+
+
+def _eval_test_set_hash_stable(
+    prop: Property, evidence: Mapping[str, Any],
+) -> PropertyVerdict:
+    """Verify the test-file inventory is unchanged across the op.
+
+    The op shouldn't silently delete or rename existing test files.
+    Adding new tests is fine (the post-set is a superset of the pre-
+    set). Removing tests fails the claim — operators must explicitly
+    re-classify the op as test-touching to do so.
+
+    Required evidence keys:
+      * ``test_files_pre`` — sequence of test file paths captured
+        before APPLY (sorted, normalized).
+      * ``test_files_post`` — sequence of test file paths post-APPLY.
+
+    Verdict:
+      * PASSED iff every entry in pre is present in post (additions OK,
+        deletions/renames flagged).
+      * FAILED with the first missing path (truncated to 5).
+      * INSUFFICIENT_EVIDENCE if either key is missing."""
+    try:
+        pre = list(evidence["test_files_pre"])
+        post = set(evidence["test_files_post"])
+    except (KeyError, TypeError) as exc:
+        return PropertyVerdict(
+            property_name=prop.name, kind=prop.kind,
+            verdict=VerdictKind.INSUFFICIENT_EVIDENCE,
+            confidence=0.0,
+            reason=f"missing/non-iterable test_files_pre/post: {exc}",
+        )
+    missing = [p for p in pre if p not in post]
+    if missing:
+        return PropertyVerdict(
+            property_name=prop.name, kind=prop.kind,
+            verdict=VerdictKind.FAILED,
+            confidence=1.0,
+            reason=(
+                f"removed {len(missing)} test file(s); first 5: "
+                f"{sorted(str(p) for p in missing)[:5]}"
+            ),
+        )
+    # Hash both sets and report the digest pair so replay can verify
+    # the same observation produced the same verdict.
+    import hashlib as _hashlib
+    pre_digest = _hashlib.sha256(
+        ("\n".join(sorted(str(p) for p in pre))).encode("utf-8"),
+    ).hexdigest()[:16]
+    post_digest = _hashlib.sha256(
+        ("\n".join(sorted(str(p) for p in post))).encode("utf-8"),
+    ).hexdigest()[:16]
+    return PropertyVerdict(
+        property_name=prop.name, kind=prop.kind,
+        verdict=VerdictKind.PASSED,
+        confidence=1.0,
+        reason=f"pre_sha={pre_digest} post_sha={post_digest} additions={max(0, len(post) - len(pre))}",
+    )
+
+
+def _eval_no_new_credential_shapes(
+    prop: Property, evidence: Mapping[str, Any],
+) -> PropertyVerdict:
+    """Verify the diff text does NOT introduce any credential-shape
+    secret. Reuses the canonical ``_CREDENTIAL_SHAPE_PATTERNS`` tuple
+    from ``semantic_firewall.py`` — single source of truth.
+
+    Required evidence keys:
+      * ``diff_text`` — the unified diff (or full new-file content)
+        produced by APPLY. Empty string is acceptable (no diff = no
+        credentials added).
+
+    Verdict:
+      * PASSED iff none of the 5 credential regexes match.
+      * FAILED with the first matching pattern's name (truncated
+        match preview, no actual secret echoed back to logs).
+      * INSUFFICIENT_EVIDENCE if the key is missing."""
+    if "diff_text" not in evidence:
+        return PropertyVerdict(
+            property_name=prop.name, kind=prop.kind,
+            verdict=VerdictKind.INSUFFICIENT_EVIDENCE,
+            confidence=0.0,
+            reason="missing key: diff_text",
+        )
+    diff_text = evidence.get("diff_text") or ""
+    if not isinstance(diff_text, (str, bytes)):
+        return PropertyVerdict(
+            property_name=prop.name, kind=prop.kind,
+            verdict=VerdictKind.INSUFFICIENT_EVIDENCE,
+            confidence=0.0,
+            reason=f"diff_text is not str/bytes: {type(diff_text).__name__}",
+        )
+    if isinstance(diff_text, bytes):
+        diff_text = diff_text.decode("utf-8", errors="replace")
+    # Late import — semantic_firewall pulls in heavier deps; keep
+    # property_oracle lightweight at module load.
+    try:
+        from backend.core.ouroboros.governance.semantic_firewall import (
+            _CREDENTIAL_SHAPE_PATTERNS,
+        )
+    except ImportError as exc:
+        return PropertyVerdict(
+            property_name=prop.name, kind=prop.kind,
+            verdict=VerdictKind.EVALUATOR_ERROR,
+            confidence=0.0,
+            reason=f"semantic_firewall unavailable: {exc}",
+        )
+    for pattern in _CREDENTIAL_SHAPE_PATTERNS:
+        match = pattern.search(diff_text)
+        if match is not None:
+            # Do NOT echo the matched secret back. Report the pattern
+            # source (its source string) and the match offset only.
+            return PropertyVerdict(
+                property_name=prop.name, kind=prop.kind,
+                verdict=VerdictKind.FAILED,
+                confidence=1.0,
+                reason=(
+                    f"credential shape detected at offset "
+                    f"{match.start()}; pattern={pattern.pattern[:48]!r}"
+                ),
+            )
+    return PropertyVerdict(
+        property_name=prop.name, kind=prop.kind,
+        verdict=VerdictKind.PASSED,
+        confidence=1.0,
+        reason=f"no credential shapes in {len(diff_text)} chars",
+    )
+
+
 def _register_seed_evaluators() -> None:
-    """Module-load: register the six seed evaluators. Idempotent —
+    """Module-load: register the seed evaluators. Idempotent —
     re-registering the same callable is a silent no-op."""
     register_evaluator(
         kind="test_passes", evaluate=_eval_test_passes,
@@ -711,6 +919,31 @@ def _register_seed_evaluators() -> None:
     register_evaluator(
         kind="set_subset", evaluate=_eval_set_subset,
         description="Verify actual ⊆ allowed (allowlist check).",
+    )
+    # Priority A — Mandatory Claim Density evaluators (Slice A1).
+    register_evaluator(
+        kind="file_parses_after_change",
+        evaluate=_eval_file_parses_after_change,
+        description=(
+            "Verify every Python file in target_files_post parses "
+            "cleanly via ast.parse (default must_hold claim)."
+        ),
+    )
+    register_evaluator(
+        kind="test_set_hash_stable",
+        evaluate=_eval_test_set_hash_stable,
+        description=(
+            "Verify the existing test file inventory is preserved "
+            "across the op (additions OK; deletions flagged)."
+        ),
+    )
+    register_evaluator(
+        kind="no_new_credential_shapes",
+        evaluate=_eval_no_new_credential_shapes,
+        description=(
+            "Verify the diff_text contains no credential/secret "
+            "regex shape (5 canonical patterns from semantic_firewall)."
+        ),
     )
 
 

--- a/tests/governance/test_default_claim_evaluators.py
+++ b/tests/governance/test_default_claim_evaluators.py
@@ -1,0 +1,367 @@
+"""Priority A Slice A1 — Default-claim evaluators regression spine.
+
+Three deterministic evaluators back the mandatory `must_hold` claims
+that every op captures at PLAN exit. Without these, every
+verification_postmortem record has total_claims=0 and Phase 2 is
+theatrical.
+
+Pins:
+  §1   All three new evaluators registered at module load
+  §2   `file_parses_after_change` — happy path: every .py file parses
+  §3   `file_parses_after_change` — fails on SyntaxError with
+       deterministic reason (line + offset + truncated message)
+  §4   `file_parses_after_change` — non-Python files (yaml/json/md)
+       are silently skipped (no false-fail)
+  §5   `file_parses_after_change` — INSUFFICIENT_EVIDENCE on missing
+       target_files_post key
+  §6   `file_parses_after_change` — bytes content decoded as utf-8
+  §7   `file_parses_after_change` — malformed entries (missing path)
+       skipped without raising
+  §8   `file_parses_after_change` — empty file list passes
+  §9   `test_set_hash_stable` — happy path: post is superset of pre
+  §10  `test_set_hash_stable` — fails on file removal/rename with
+       missing-list (truncated to 5)
+  §11  `test_set_hash_stable` — additions OK (more files in post)
+  §12  `test_set_hash_stable` — INSUFFICIENT_EVIDENCE on missing key
+  §13  `test_set_hash_stable` — sha digests in reason for replay
+  §14  `no_new_credential_shapes` — happy path: clean diff
+  §15  `no_new_credential_shapes` — detects each of the 5 patterns
+       (sk-*, AKIA*, ghp_*, xoxb-*, PEM)
+  §16  `no_new_credential_shapes` — secret value NEVER echoed in
+       reason (defensive — only pattern + offset)
+  §17  `no_new_credential_shapes` — INSUFFICIENT_EVIDENCE on missing
+       diff_text
+  §18  `no_new_credential_shapes` — bytes diff decoded as utf-8
+  §19  `no_new_credential_shapes` — empty diff_text passes
+  §20  `no_new_credential_shapes` — reuses canonical
+       `_CREDENTIAL_SHAPE_PATTERNS` from semantic_firewall (single
+       source of truth — no pattern duplication in property_oracle)
+  §21  All three evaluators NEVER raise (defensive — exception →
+       caller sees EVALUATOR_ERROR via dispatch wrapper)
+  §22  All three evaluators return PropertyVerdict with confidence=1.0
+       on definitive verdicts (PASSED / FAILED)
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from backend.core.ouroboros.governance.verification.property_oracle import (
+    Property,
+    PropertyVerdict,
+    VerdictKind,
+    _eval_file_parses_after_change,
+    _eval_no_new_credential_shapes,
+    _eval_test_set_hash_stable,
+    is_kind_registered,
+    known_kinds,
+)
+
+
+def _prop(kind: str, name: str = "default") -> Property:
+    return Property.make(kind=kind, name=name)
+
+
+# ===========================================================================
+# §1 — Registration
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "file_parses_after_change",
+        "test_set_hash_stable",
+        "no_new_credential_shapes",
+    ],
+)
+def test_evaluator_registered_at_module_load(kind) -> None:
+    assert is_kind_registered(kind), f"{kind!r} must be registered"
+    assert kind in known_kinds()
+
+
+# ===========================================================================
+# §2-§8 — file_parses_after_change
+# ===========================================================================
+
+
+def test_file_parses_happy_path() -> None:
+    evidence = {
+        "target_files_post": [
+            {"path": "a.py", "content": "x = 1\n"},
+            {"path": "b.py", "content": "def f():\n    pass\n"},
+        ]
+    }
+    v = _eval_file_parses_after_change(_prop("file_parses_after_change"), evidence)
+    assert v.verdict is VerdictKind.PASSED
+    assert "parsed_ok=2" in v.reason
+    assert v.confidence == 1.0
+
+
+def test_file_parses_fails_on_syntax_error() -> None:
+    evidence = {
+        "target_files_post": [
+            {"path": "good.py", "content": "x = 1\n"},
+            {"path": "bad.py", "content": "def f(:\n    pass\n"},  # SyntaxError
+        ]
+    }
+    v = _eval_file_parses_after_change(_prop("file_parses_after_change"), evidence)
+    assert v.verdict is VerdictKind.FAILED
+    assert "SyntaxError" in v.reason
+    assert "bad.py" in v.reason
+    assert v.confidence == 1.0
+
+
+def test_file_parses_skips_non_python() -> None:
+    evidence = {
+        "target_files_post": [
+            {"path": "config.yaml", "content": "::: not yaml :::"},
+            {"path": "data.json", "content": "{ broken json"},
+            {"path": "README.md", "content": "# title\n"},
+            {"path": "real.py", "content": "x = 1\n"},
+        ]
+    }
+    v = _eval_file_parses_after_change(_prop("file_parses_after_change"), evidence)
+    assert v.verdict is VerdictKind.PASSED
+    # Only one .py file actually parsed
+    assert "parsed_ok=1" in v.reason
+
+
+def test_file_parses_insufficient_on_missing_key() -> None:
+    v = _eval_file_parses_after_change(_prop("file_parses_after_change"), {})
+    assert v.verdict is VerdictKind.INSUFFICIENT_EVIDENCE
+
+
+def test_file_parses_decodes_bytes_content() -> None:
+    evidence = {
+        "target_files_post": [
+            {"path": "a.py", "content": b"x = 1\n"},
+        ]
+    }
+    v = _eval_file_parses_after_change(_prop("file_parses_after_change"), evidence)
+    assert v.verdict is VerdictKind.PASSED
+
+
+def test_file_parses_skips_malformed_entries() -> None:
+    evidence = {
+        "target_files_post": [
+            {"path": "good.py", "content": "x = 1\n"},
+            "this is a bare string not a dict",  # malformed
+            {"content": "missing path"},  # missing path
+            {"path": "skip.py", "content": None},  # non-str content
+        ]
+    }
+    v = _eval_file_parses_after_change(_prop("file_parses_after_change"), evidence)
+    # Only the good entry parsed; malformed ones skipped silently
+    assert v.verdict is VerdictKind.PASSED
+    assert "parsed_ok=1" in v.reason
+
+
+def test_file_parses_empty_list_passes() -> None:
+    v = _eval_file_parses_after_change(
+        _prop("file_parses_after_change"), {"target_files_post": []},
+    )
+    assert v.verdict is VerdictKind.PASSED
+    assert "parsed_ok=0" in v.reason
+
+
+# ===========================================================================
+# §9-§13 — test_set_hash_stable
+# ===========================================================================
+
+
+def test_test_set_hash_stable_happy_path() -> None:
+    evidence = {
+        "test_files_pre": ("tests/test_a.py", "tests/test_b.py"),
+        "test_files_post": ("tests/test_a.py", "tests/test_b.py"),
+    }
+    v = _eval_test_set_hash_stable(_prop("test_set_hash_stable"), evidence)
+    assert v.verdict is VerdictKind.PASSED
+    assert "pre_sha=" in v.reason
+    assert "post_sha=" in v.reason
+    assert "additions=0" in v.reason
+
+
+def test_test_set_hash_stable_fails_on_removal() -> None:
+    evidence = {
+        "test_files_pre": ("tests/test_a.py", "tests/test_b.py", "tests/test_c.py"),
+        "test_files_post": ("tests/test_a.py",),
+    }
+    v = _eval_test_set_hash_stable(_prop("test_set_hash_stable"), evidence)
+    assert v.verdict is VerdictKind.FAILED
+    assert "removed 2" in v.reason
+    assert "test_b.py" in v.reason
+    assert "test_c.py" in v.reason
+
+
+def test_test_set_hash_stable_additions_pass() -> None:
+    evidence = {
+        "test_files_pre": ("tests/test_a.py",),
+        "test_files_post": ("tests/test_a.py", "tests/test_new.py"),
+    }
+    v = _eval_test_set_hash_stable(_prop("test_set_hash_stable"), evidence)
+    assert v.verdict is VerdictKind.PASSED
+    assert "additions=1" in v.reason
+
+
+def test_test_set_hash_stable_insufficient_on_missing_key() -> None:
+    v = _eval_test_set_hash_stable(
+        _prop("test_set_hash_stable"), {"test_files_post": ()},
+    )
+    assert v.verdict is VerdictKind.INSUFFICIENT_EVIDENCE
+
+
+def test_test_set_hash_stable_sha_digests_for_replay() -> None:
+    evidence = {
+        "test_files_pre": ("tests/a.py", "tests/b.py"),
+        "test_files_post": ("tests/a.py", "tests/b.py"),
+    }
+    v1 = _eval_test_set_hash_stable(_prop("test_set_hash_stable"), evidence)
+    v2 = _eval_test_set_hash_stable(_prop("test_set_hash_stable"), evidence)
+    # Same input → same digest (replay-stable)
+    assert v1.reason == v2.reason
+
+
+# ===========================================================================
+# §14-§20 — no_new_credential_shapes
+# ===========================================================================
+
+
+def test_no_new_credentials_clean_diff() -> None:
+    diff = (
+        "+++ b/foo.py\n"
+        "+def hello():\n"
+        "+    return 'world'\n"
+    )
+    v = _eval_no_new_credential_shapes(
+        _prop("no_new_credential_shapes"), {"diff_text": diff},
+    )
+    assert v.verdict is VerdictKind.PASSED
+    assert "no credential shapes" in v.reason
+
+
+@pytest.mark.parametrize(
+    "secret_text, label",
+    [
+        # 5 canonical patterns; each must be detected
+        ("API_KEY = 'sk-AbCdEfGhIjKlMnOpQrStUvWxYz123456'", "openai"),
+        ("AWS_KEY = 'AKIAIOSFODNN7EXAMPLE'", "aws"),
+        ("GH_TOKEN = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz12345'", "github"),
+        ("SLACK = 'xoxb-1234567890-foo-bar-baz-1234567890'", "slack"),
+        ("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCA...", "pem"),
+    ],
+)
+def test_no_new_credentials_detects_all_5_patterns(secret_text, label) -> None:
+    v = _eval_no_new_credential_shapes(
+        _prop("no_new_credential_shapes"), {"diff_text": secret_text},
+    )
+    assert v.verdict is VerdictKind.FAILED, f"{label} pattern must trip"
+    assert "credential shape detected" in v.reason
+    assert "offset" in v.reason
+
+
+def test_no_new_credentials_secret_value_never_echoed() -> None:
+    # Defensive: the actual secret must NEVER appear in the verdict
+    # reason — only the pattern + offset. Otherwise the verdict log
+    # leaks the secret operators just tried to keep out.
+    secret = "sk-VerySecretValueDoNotLeakIt-1234567890"
+    v = _eval_no_new_credential_shapes(
+        _prop("no_new_credential_shapes"), {"diff_text": f"key = '{secret}'"},
+    )
+    assert v.verdict is VerdictKind.FAILED
+    assert secret not in v.reason
+    assert "VerySecretValue" not in v.reason
+
+
+def test_no_new_credentials_insufficient_on_missing_key() -> None:
+    v = _eval_no_new_credential_shapes(_prop("no_new_credential_shapes"), {})
+    assert v.verdict is VerdictKind.INSUFFICIENT_EVIDENCE
+    assert "diff_text" in v.reason
+
+
+def test_no_new_credentials_decodes_bytes() -> None:
+    diff_bytes = b"+def f(): pass\n"
+    v = _eval_no_new_credential_shapes(
+        _prop("no_new_credential_shapes"), {"diff_text": diff_bytes},
+    )
+    assert v.verdict is VerdictKind.PASSED
+
+
+def test_no_new_credentials_empty_diff_passes() -> None:
+    v = _eval_no_new_credential_shapes(
+        _prop("no_new_credential_shapes"), {"diff_text": ""},
+    )
+    assert v.verdict is VerdictKind.PASSED
+
+
+def test_no_new_credentials_reuses_canonical_patterns() -> None:
+    """Single source of truth invariant: the evaluator must import
+    the credential patterns from semantic_firewall, NOT redefine them
+    locally. Source-grep pin enforces this."""
+    src = inspect.getsource(_eval_no_new_credential_shapes)
+    # Must import the canonical tuple
+    assert "_CREDENTIAL_SHAPE_PATTERNS" in src
+    assert "from backend.core.ouroboros.governance.semantic_firewall" in src
+    # Must NOT redefine the regexes locally — none of the canonical
+    # token shapes appear as raw string literals in this evaluator.
+    forbidden_local_definitions = (
+        r"\bsk-",
+        r"\bAKIA",
+        r"\bghp_",
+        r"\bxox[bp]-",
+        "BEGIN RSA",
+    )
+    for token in forbidden_local_definitions:
+        assert token not in src, (
+            f"evaluator must reuse semantic_firewall patterns, not "
+            f"redefine {token!r} locally"
+        )
+
+
+# ===========================================================================
+# §21 — Defensive (never raises)
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "evaluator, evidence",
+    [
+        (_eval_file_parses_after_change, {"target_files_post": [None, 42, []]}),
+        (_eval_test_set_hash_stable, {"test_files_pre": None, "test_files_post": None}),
+        (_eval_no_new_credential_shapes, {"diff_text": 12345}),
+    ],
+)
+def test_evaluators_never_raise_on_garbage_input(evaluator, evidence) -> None:
+    """Each evaluator must return a verdict, never raise. The dispatch
+    wrapper assumes this contract."""
+    v = evaluator(_prop("test"), evidence)
+    assert isinstance(v, PropertyVerdict)
+    # Non-PASSED outcome on garbage input is fine — what matters is no raise
+    assert v.verdict in (
+        VerdictKind.PASSED, VerdictKind.FAILED,
+        VerdictKind.INSUFFICIENT_EVIDENCE, VerdictKind.EVALUATOR_ERROR,
+    )
+
+
+# ===========================================================================
+# §22 — Definitive verdicts have confidence=1.0
+# ===========================================================================
+
+
+def test_definitive_verdicts_have_full_confidence() -> None:
+    # PASSED case
+    v_pass = _eval_file_parses_after_change(
+        _prop("file_parses_after_change"),
+        {"target_files_post": [{"path": "a.py", "content": "x=1\n"}]},
+    )
+    assert v_pass.verdict is VerdictKind.PASSED
+    assert v_pass.confidence == 1.0
+
+    # FAILED case
+    v_fail = _eval_test_set_hash_stable(
+        _prop("test_set_hash_stable"),
+        {"test_files_pre": ("a.py",), "test_files_post": ()},
+    )
+    assert v_fail.verdict is VerdictKind.FAILED
+    assert v_fail.confidence == 1.0


### PR DESCRIPTION
## Summary

First slice of **Priority A — Mandatory Claim Density** (PRD §25.5.1).

Without this primitive, every `verification_postmortem` record harvested in soak #3 had `total_claims=0` — Phase 2 was theatrical despite being graduated default-true. This slice adds the three deterministic evaluators that back the mandatory `must_hold` claims; Slice A2 wires them via a registry; Slice A3 instruments the PLAN runner exit paths.

## What's new

### Three new evaluators (`property_oracle.py`)

- **`file_parses_after_change`** — pure-stdlib `ast.parse()` per .py file in `target_files_post`. Non-Python files silently skipped (no false-fail on config-only ops).
- **`test_set_hash_stable`** — preserves existing test inventory across the op (additions OK; deletions/renames flagged). SHA-256 digests in reason for replay determinism.
- **`no_new_credential_shapes`** — scans `diff_text` against the 5 canonical credential regexes. Defensive: never echoes the matched secret in the verdict reason.

### Refactor (`semantic_firewall.py`)

- Extracted `_CREDENTIAL_SHAPE_PATTERNS` as a named module-level tuple (5 patterns).
- `_INJECTION_PATTERNS` rewritten as concatenation including this tuple. Byte-equivalent to prior.
- **Single source of truth** for the 5 credential patterns. The property_oracle evaluator imports the canonical tuple — no duplication.

## Test plan

- [x] **30 new tests** in `test_default_claim_evaluators.py` across 22 pin sections (registration, happy/fail/insufficient paths per evaluator, bytes decoding, malformed-input defenses, source-grep pin enforcing credential pattern reuse, never-raises, confidence=1.0 invariants)
- [x] **331/331 green** across full verification subsystem (oracle + capture + repeat_runner + postmortem) + Phase 2 graduation pins + new evaluator suite
- [x] Pre-commit file integrity: clean
- [ ] CI green

## Architecture compliance

- ✅ Zero hardcoding — credential patterns sourced from canonical tuple
- ✅ Zero duplication — semantic_firewall is the single source of truth
- ✅ Pure stdlib (ast / hashlib / re); zero LLM, zero network
- ✅ Replay-deterministic (confidence=1.0; same evidence → same verdict)
- ✅ Defensive (never raises on garbage input; INSUFFICIENT_EVIDENCE on missing keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three deterministic default-claim evaluators and registers them to populate mandatory must_hold claims at PLAN exit. Centralizes credential regexes in `semantic_firewall` so verification and firewall share one source.

- **New Features**
  - `file_parses_after_change` — AST-parse each `.py` in `target_files_post`; skip non-Python; fail on first `SyntaxError`; deterministic reason.
  - `test_set_hash_stable` — ensure `test_files_pre` ⊆ `test_files_post`; additions OK; fail on removals; includes short SHA digests for replay.
  - `no_new_credential_shapes` — scan `diff_text` for 5 canonical secret shapes; never echo secrets; imports patterns from `semantic_firewall`.

- **Refactors**
  - Extracted `_CREDENTIAL_SHAPE_PATTERNS` in `semantic_firewall`; `_INJECTION_PATTERNS` now includes this tuple (byte-equivalent behavior).
  - `property_oracle` reuses the canonical tuple (no duplicated regexes).

<sup>Written for commit fda4600cf026a78bc0617deac3d1376d32c439c6. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29635?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

