### PR TITLE
feat(plan_runner): Priority A Slice A3 — instrument every PLAN exit (CLOSES Priority A)

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/plan_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/plan_runner.py
@@ -86,6 +86,111 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger("Ouroboros.Orchestrator")
 
 
+# ---------------------------------------------------------------------------
+# Priority A Slice A3 — Mandatory claim density at every PLAN exit
+# ---------------------------------------------------------------------------
+#
+# Per PRD §25.5.1: every PLAN exit (success path AND every failure
+# terminal) MUST capture default must_hold claims so post-APPLY
+# verification has signal to evaluate. The pre-A3 wiring captured
+# claims ONLY on the success path AND ONLY when _plan_result was
+# non-skipped — which silently zeroed claim coverage for the entire
+# trivial-op population (every op in soak #3).
+#
+# This helper is the single chokepoint: every `return PhaseResult(...)`
+# that exits PLAN is preceded by `await _capture_default_claims_at_plan_exit`.
+# The helper is master-flag-gated at the synthesizer level
+# (JARVIS_DEFAULT_CLAIMS_ENABLED → Slice A2's `default_claims_enabled`),
+# so when off it is a pure no-op without runner-side branches.
+
+
+async def _capture_default_claims_at_plan_exit(
+    ctx: Any, *, exit_reason: str,
+) -> int:
+    """Synthesize + persist the default must_hold claims for this op.
+
+    Walks the default-claim registry (verification.default_claims),
+    applies per-spec filters (file_pattern + posture), persists each
+    surviving claim via Slice 2.3's ``capture_claims`` (which routes
+    through Slice 1.3's Merkle DAG ledger).
+
+    NEVER raises. Best-effort — capture failures are logged at DEBUG
+    and counted as zero. Master flag ``JARVIS_DEFAULT_CLAIMS_ENABLED``
+    governs whether the synthesizer materializes anything; when off,
+    this returns 0 without touching the ledger.
+
+    Posture is read best-effort via the posture_observer singleton.
+    Unavailable / not-yet-initialized → ``None``, which means any
+    posture-filtered specs are skipped on this exit.
+
+    Returns the count of default claims successfully persisted.
+    """
+    try:
+        from backend.core.ouroboros.governance.verification.default_claims import (
+            synthesize_default_claims,
+        )
+        from backend.core.ouroboros.governance.verification.property_capture import (
+            capture_claims,
+        )
+    except Exception:  # noqa: BLE001 — verification package missing
+        logger.debug(
+            "[PLANRunner] verification module unavailable at exit_reason=%s",
+            exit_reason, exc_info=True,
+        )
+        return 0
+    # Best-effort posture read — never raise into the runner path.
+    posture: Optional[str] = None
+    try:
+        from backend.core.ouroboros.governance.posture_observer import (
+            get_default_store,
+        )
+        reading = get_default_store().load_current()
+        if reading is not None:
+            posture = reading.posture.value
+    except Exception:  # noqa: BLE001
+        posture = None
+    op_id = str(getattr(ctx, "op_id", "") or "")
+    if not op_id:
+        return 0
+    target_files = tuple(getattr(ctx, "target_files", ()) or ())
+    try:
+        claims = synthesize_default_claims(
+            op_id=op_id,
+            target_files=target_files,
+            posture=posture,
+        )
+    except Exception:  # noqa: BLE001 — defensive (synthesizer should
+        # itself never raise; this is belt-and-suspenders)
+        logger.debug(
+            "[PLANRunner] synthesize_default_claims raised at "
+            "exit_reason=%s op=%s",
+            exit_reason, op_id, exc_info=True,
+        )
+        return 0
+    if not claims:
+        return 0
+    try:
+        captured = await capture_claims(
+            op_id=op_id, claims=claims, ctx=ctx,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "[PLANRunner] capture_claims raised at exit_reason=%s op=%s",
+            exit_reason, op_id, exc_info=True,
+        )
+        return 0
+    if captured:
+        # §8 observability — one structured INFO line per exit so
+        # operators can audit "did the loop close?" via grep without
+        # reading the determinism ledger.
+        logger.info(
+            "[PLANRunner] default_claims_captured count=%d "
+            "exit_reason=%s op=%s",
+            captured, exit_reason, op_id,
+        )
+    return captured
+
+
 class PLANRunner(PhaseRunner):
     """Verbatim transcription of orchestrator.py PLAN block (~2259-3012)."""
 
@@ -206,6 +311,9 @@ class PLANRunner(PhaseRunner):
                     "detail": _skip_reason,
                 },
             )
+            await _capture_default_claims_at_plan_exit(
+                ctx, exit_reason="plan_required_unavailable",
+            )
             return PhaseResult(
                 next_ctx=ctx, next_phase=None, status="fail",
                 reason="plan_required_unavailable",
@@ -280,6 +388,10 @@ class PLANRunner(PhaseRunner):
                             "reason": "plan_review_unavailable",
                             "detail": "approval_provider_missing",
                         },
+                    )
+                    await _capture_default_claims_at_plan_exit(
+                        ctx,
+                        exit_reason="plan_review_unavailable:provider_missing",
                     )
                     return PhaseResult(
                         next_ctx=ctx, next_phase=None, status="fail",
@@ -394,6 +506,10 @@ class PLANRunner(PhaseRunner):
                                 "detail": str(_gate_exc)[:200],
                             },
                         )
+                        await _capture_default_claims_at_plan_exit(
+                            ctx,
+                            exit_reason="plan_review_unavailable:gate_infra",
+                        )
                         return PhaseResult(
                             next_ctx=ctx, next_phase=None, status="fail",
                             reason="plan_review_unavailable",
@@ -488,6 +604,9 @@ class PLANRunner(PhaseRunner):
                             f"Reconsider strategy before retry.",
                             op_id=ctx.op_id,
                         )
+                        await _capture_default_claims_at_plan_exit(
+                            ctx, exit_reason="plan_rejected",
+                        )
                         return PhaseResult(
                             next_ctx=ctx, next_phase=None, status="fail",
                             reason="plan_rejected",
@@ -514,6 +633,9 @@ class PLANRunner(PhaseRunner):
                                 ctx,
                                 OperationState.FAILED,
                                 {"reason": "plan_approval_expired"},
+                            )
+                            await _capture_default_claims_at_plan_exit(
+                                ctx, exit_reason="plan_approval_expired",
                             )
                             return PhaseResult(
                                 next_ctx=ctx, next_phase=None, status="fail",
@@ -856,6 +978,9 @@ class PLANRunner(PhaseRunner):
         if orch._is_cancel_requested(ctx.op_id):
             ctx = ctx.advance(OperationPhase.CANCELLED, terminal_reason_code="user_cancelled")
             await orch._record_ledger(ctx, OperationState.FAILED, {"reason": "user_cancelled"})
+            await _capture_default_claims_at_plan_exit(
+                ctx, exit_reason="user_cancelled",
+            )
             return PhaseResult(
                 next_ctx=ctx, next_phase=None, status="fail",
                 reason="user_cancelled",
@@ -898,6 +1023,16 @@ class PLANRunner(PhaseRunner):
                 "plan still applies",
                 exc_info=True,
             )
+
+        # Priority A Slice A3 — default must_hold claims fire on the
+        # success path too, additive to whatever synthesize_claims_-
+        # from_plan produced above. Trivial-op skips silently captured
+        # zero claims pre-A3; this guarantees verification_postmortem
+        # records have signal even when the LLM-reasoned plan is
+        # absent.
+        await _capture_default_claims_at_plan_exit(
+            ctx, exit_reason="planned",
+        )
 
         return PhaseResult(
             next_ctx=ctx,

--- a/tests/governance/phase_runner/test_plan_runner_default_claims_wiring.py
+++ b/tests/governance/phase_runner/test_plan_runner_default_claims_wiring.py
@@ -1,0 +1,353 @@
+"""Priority A Slice A3 — PLAN-runner default-claim wiring spine.
+
+Closes the silent-disable gap that nuked Phase 2 in soak #3: the
+trivial-op short-circuit (and every failure exit path) now captures
+the default must_hold claims unconditionally via a single chokepoint
+helper.
+
+Pins:
+  §1   Helper exists at module level (not just class-private)
+  §2   Helper is async (capture_claims is async)
+  §3   Helper is master-flag-gated (returns 0 when off)
+  §4   Helper returns 0 when op_id is empty
+  §5   Helper never raises on garbage ctx
+  §6   Helper writes one ledger record per default claim on happy path
+  §7   Helper is called before EVERY `return PhaseResult` exit in
+       plan_runner.py (source-grep invariant — catches future
+       refactors that re-introduce the silent-disable gap)
+  §8   Helper is called for all 7 distinct exit_reason values:
+       plan_required_unavailable / plan_review_unavailable:provider_missing /
+       plan_review_unavailable:gate_infra / plan_rejected /
+       plan_approval_expired / user_cancelled / planned
+  §9   Helper diagnostic log line includes count + exit_reason + op_id
+  §10  Master-off (JARVIS_DEFAULT_CLAIMS_ENABLED=false) → no ledger
+       writes from helper; no behavior change at runner level
+  §11  Helper composes with Slice 2.3's plan-synthesizer on success
+       path (default claims ADD to plan-synthesized claims, never
+       replace)
+  §12  Helper does NOT import orchestrator / candidate_generator
+       (authority invariant)
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+from types import SimpleNamespace
+from typing import List
+
+import pytest
+
+from backend.core.ouroboros.governance.phase_runners import plan_runner as pr_mod
+from backend.core.ouroboros.governance.phase_runners.plan_runner import (
+    _capture_default_claims_at_plan_exit,
+)
+
+
+# ---------------------------------------------------------------------------
+# §1-§2 — Helper surface
+# ---------------------------------------------------------------------------
+
+
+def test_helper_exists_at_module_level() -> None:
+    assert hasattr(pr_mod, "_capture_default_claims_at_plan_exit")
+    assert callable(pr_mod._capture_default_claims_at_plan_exit)
+
+
+def test_helper_is_async() -> None:
+    assert inspect.iscoroutinefunction(_capture_default_claims_at_plan_exit)
+
+
+# ---------------------------------------------------------------------------
+# §3-§5 — Defensive contracts
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_ledger(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_LEDGER_DIR", str(tmp_path / "det"),
+    )
+    monkeypatch.setenv("JARVIS_DETERMINISM_LEDGER_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_DETERMINISM_PHASE_CAPTURE_ENABLED", "true",
+    )
+    monkeypatch.setenv(
+        "JARVIS_VERIFICATION_PROPERTY_CAPTURE_ENABLED", "true",
+    )
+    monkeypatch.setenv("JARVIS_DEFAULT_CLAIMS_ENABLED", "true")
+    monkeypatch.setenv(
+        "OUROBOROS_BATTLE_SESSION_ID", "plan-runner-a3-test",
+    )
+    from backend.core.ouroboros.governance.determinism.decision_runtime import (
+        reset_all_for_tests,
+    )
+    reset_all_for_tests()
+    yield tmp_path
+    reset_all_for_tests()
+
+
+def test_helper_master_off_returns_zero(isolated_ledger, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_DEFAULT_CLAIMS_ENABLED", "false")
+    ctx = SimpleNamespace(op_id="op-a3-1", target_files=("a.py",))
+    n = asyncio.run(
+        _capture_default_claims_at_plan_exit(ctx, exit_reason="planned"),
+    )
+    assert n == 0
+
+
+def test_helper_empty_op_id_returns_zero(isolated_ledger) -> None:
+    ctx = SimpleNamespace(op_id="", target_files=("a.py",))
+    n = asyncio.run(
+        _capture_default_claims_at_plan_exit(ctx, exit_reason="planned"),
+    )
+    assert n == 0
+
+
+def test_helper_never_raises_on_garbage_ctx(isolated_ledger) -> None:
+    # ctx without op_id attr at all → returns 0, no raise
+    class BadCtx:
+        pass
+    n = asyncio.run(
+        _capture_default_claims_at_plan_exit(
+            BadCtx(), exit_reason="planned",
+        ),
+    )
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# §6 — Happy path writes ledger records
+# ---------------------------------------------------------------------------
+
+
+def test_helper_writes_three_ledger_records_on_happy_path(
+    isolated_ledger,
+) -> None:
+    """Per Slice A2 seed registry: 3 default claims for an op
+    touching .py files."""
+    ctx = SimpleNamespace(
+        op_id="op-a3-happy", target_files=("backend/foo.py",),
+    )
+    n = asyncio.run(
+        _capture_default_claims_at_plan_exit(ctx, exit_reason="planned"),
+    )
+    # 3 default claims: file_parses_after_change (matches *.py),
+    # test_set_hash_stable (no filter), no_new_credential_shapes (no filter)
+    assert n == 3
+    # Verify they round-tripped through the ledger
+    from backend.core.ouroboros.governance.verification import (
+        get_recorded_claims,
+    )
+    claims = get_recorded_claims(
+        op_id="op-a3-happy", session_id="plan-runner-a3-test",
+    )
+    kinds = sorted(c.property.kind for c in claims)
+    assert kinds == [
+        "file_parses_after_change",
+        "no_new_credential_shapes",
+        "test_set_hash_stable",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# §7 — Source-grep invariant: every return PhaseResult is guarded
+# ---------------------------------------------------------------------------
+
+
+_RETURN_PHASE_RESULT_RE = re.compile(r"^\s*return PhaseResult\(")
+
+
+def _scan_phase_result_returns(src: str) -> List[int]:
+    """Return line numbers of every `return PhaseResult(` at code
+    indentation. Filters out comments + docstrings + backtick-quoted
+    mentions (e.g., `return PhaseResult(...)` inside a comment is not
+    a real return statement)."""
+    lines = []
+    for i, line in enumerate(src.splitlines(), start=1):
+        if _RETURN_PHASE_RESULT_RE.match(line):
+            lines.append(i)
+    return lines
+
+
+def _has_helper_call_within_n_lines_above(
+    src: str, target_line: int, *, n: int = 30,
+) -> bool:
+    """Check if `_capture_default_claims_at_plan_exit` is called in
+    the n lines preceding `target_line`."""
+    lines = src.splitlines()
+    start = max(0, target_line - 1 - n)
+    end = target_line - 1  # exclusive — return line itself doesn't count
+    window = "\n".join(lines[start:end])
+    return "_capture_default_claims_at_plan_exit(" in window
+
+
+def test_every_phase_result_return_is_preceded_by_helper_call() -> None:
+    """The structural invariant — every PLAN exit captures default
+    claims. A future refactor that reintroduces the silent-disable
+    gap fails this test."""
+    src = inspect.getsource(pr_mod)
+    return_lines = _scan_phase_result_returns(src)
+    # Sanity: PLAN runner has 7 exit points (6 fail + 1 success)
+    assert len(return_lines) >= 7, (
+        f"expected >=7 PhaseResult returns, found {len(return_lines)}"
+    )
+    failures = []
+    for line_no in return_lines:
+        if not _has_helper_call_within_n_lines_above(src, line_no, n=30):
+            # Read the line + 5 surrounding for diagnostic
+            ctx_lines = src.splitlines()[max(0, line_no - 5):line_no + 2]
+            failures.append(
+                f"line {line_no}: no helper call within 30 lines above\n"
+                f"context:\n  " + "\n  ".join(ctx_lines)
+            )
+    assert not failures, (
+        "Slice A3 invariant violated — every PLAN exit must capture "
+        "default claims:\n\n" + "\n\n".join(failures)
+    )
+
+
+# ---------------------------------------------------------------------------
+# §8 — All 7 distinct exit_reason values used
+# ---------------------------------------------------------------------------
+
+
+def test_seven_distinct_exit_reasons_in_source() -> None:
+    """Each PLAN exit path tags itself with a distinct exit_reason
+    so observability can distinguish failure modes."""
+    src = inspect.getsource(pr_mod)
+    expected_reasons = (
+        "plan_required_unavailable",
+        "plan_review_unavailable:provider_missing",
+        "plan_review_unavailable:gate_infra",
+        "plan_rejected",
+        "plan_approval_expired",
+        "user_cancelled",
+        "planned",
+    )
+    for reason in expected_reasons:
+        assert f'exit_reason="{reason}"' in src, (
+            f"PLAN exit for {reason!r} must call helper with "
+            f"exit_reason={reason!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# §9 — Diagnostic logging
+# ---------------------------------------------------------------------------
+
+
+def test_helper_log_line_includes_count_and_reason(
+    isolated_ledger, caplog,
+) -> None:
+    import logging
+    caplog.set_level(logging.INFO, logger="Ouroboros.Orchestrator")
+    ctx = SimpleNamespace(op_id="op-a3-log", target_files=("a.py",))
+    asyncio.run(
+        _capture_default_claims_at_plan_exit(
+            ctx, exit_reason="plan_rejected",
+        ),
+    )
+    log_text = "\n".join(r.getMessage() for r in caplog.records)
+    assert "default_claims_captured" in log_text
+    assert "exit_reason=plan_rejected" in log_text
+    assert "op=op-a3-log" in log_text
+
+
+# ---------------------------------------------------------------------------
+# §10 — Master-off → no ledger writes
+# ---------------------------------------------------------------------------
+
+
+def test_master_off_writes_zero_records(
+    isolated_ledger, monkeypatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_DEFAULT_CLAIMS_ENABLED", "false")
+    ctx = SimpleNamespace(op_id="op-a3-off", target_files=("a.py",))
+    n = asyncio.run(
+        _capture_default_claims_at_plan_exit(
+            ctx, exit_reason="planned",
+        ),
+    )
+    assert n == 0
+    from backend.core.ouroboros.governance.verification import (
+        get_recorded_claims,
+    )
+    claims = get_recorded_claims(
+        op_id="op-a3-off", session_id="plan-runner-a3-test",
+    )
+    assert claims == ()
+
+
+# ---------------------------------------------------------------------------
+# §11 — Composes additively with Slice 2.3 plan-synthesizer
+# ---------------------------------------------------------------------------
+
+
+def test_default_claims_add_to_plan_synthesized_claims(
+    isolated_ledger,
+) -> None:
+    """Both Slice 2.3 plan claims AND Slice A3 default claims should
+    land in the ledger for the same op when both are present."""
+    from backend.core.ouroboros.governance.verification import (
+        capture_claims,
+        get_recorded_claims,
+        synthesize_claims_from_plan,
+    )
+
+    # synthesize_claims_from_plan expects a list of test-name STRINGS
+    # under test_strategy.tests_to_pass (per Slice 2.3 contract).
+    plan = {
+        "test_strategy": {
+            "tests_to_pass": ["test_foo_works"],
+        },
+    }
+    plan_claims = synthesize_claims_from_plan(plan, op_id="op-additive")
+    assert len(plan_claims) >= 1
+
+    async def _run():
+        await capture_claims(op_id="op-additive", claims=plan_claims)
+        await _capture_default_claims_at_plan_exit(
+            SimpleNamespace(
+                op_id="op-additive", target_files=("a.py",),
+            ),
+            exit_reason="planned",
+        )
+        return get_recorded_claims(
+            op_id="op-additive", session_id="plan-runner-a3-test",
+        )
+
+    recovered = asyncio.run(_run())
+    # Plan synthesized at least 1 + default 3 = at least 4
+    assert len(recovered) >= 4
+    kinds = {c.property.kind for c in recovered}
+    # Plan claim kind
+    assert "test_passes" in kinds
+    # All 3 default claim kinds
+    assert "file_parses_after_change" in kinds
+    assert "test_set_hash_stable" in kinds
+    assert "no_new_credential_shapes" in kinds
+
+
+# ---------------------------------------------------------------------------
+# §12 — Authority invariant
+# ---------------------------------------------------------------------------
+
+
+def test_helper_does_not_import_authority_modules() -> None:
+    """The helper must not import orchestrator / candidate_generator /
+    iron_gate / change_engine. Default-claim capture is a verification-
+    layer concern; it must not couple PLAN runner to authority modules
+    via this code path."""
+    src = inspect.getsource(_capture_default_claims_at_plan_exit)
+    forbidden = (
+        "orchestrator", "candidate_generator", "iron_gate", "change_engine",
+        "policy",
+    )
+    for token in forbidden:
+        assert (
+            f"from backend.core.ouroboros.governance.{token}" not in src
+        ), f"helper must not import {token}"
+        assert (
+            f"import backend.core.ouroboros.governance.{token}" not in src
+        ), f"helper must not import {token}"


### PR DESCRIPTION
## Summary

**Closes Priority A — Mandatory Claim Density** (PRD §25.5.1).

Wires the Slice A2 default-claim registry + synthesizer into the PLAN runner at every exit. After this slice, every op produces ≥1 `must_hold` PropertyClaim, which means every `verification_postmortem` record will have signal to evaluate.

## What's new

**Single-chokepoint helper** `_capture_default_claims_at_plan_exit(ctx, *, exit_reason)` in `plan_runner.py`:
- Late-imports verification modules; never raises
- Reads posture best-effort via posture_observer singleton
- Master-flag-gated at synthesizer level (zero runtime branches when off)
- Logs structured INFO line with count + exit_reason

**Wired at all 7 PLAN exit paths**: `plan_required_unavailable`, `plan_review_unavailable:provider_missing`, `plan_review_unavailable:gate_infra`, `plan_rejected`, `plan_approval_expired`, `user_cancelled`, `planned`.

**Source-grep invariant test** (Slice E foundation): walks plan_runner.py, regex-anchors every `return PhaseResult(` at code indentation, asserts the helper is called within 30 lines above each one. Future refactors that re-introduce the silent-disable gap will fail this test.

## Test plan

- [x] **12 new wiring tests** + **11/11 PLAN runner parity** still green (zero behavior change on existing paths)
- [x] **353/353 combined** across full Priority A (A1+A2+A3) + Phase 2 graduation pins + property_oracle + property_capture + postmortem
- [x] Pre-commit file integrity: clean
- [ ] CI green
- [ ] Soak #4 — first non-zero `total_claims` in `verification_postmortem` records

## Architecture compliance

- ✅ Zero hardcoding — wires to runtime registry
- ✅ Zero duplication — late-imports existing capture/synthesize primitives
- ✅ Asynchronous — helper is async; never blocks dispatcher
- ✅ Defensive — never raises; capture failure logged at DEBUG only
- ✅ Authority invariant — no orchestrator/candidate_generator imports in helper
- ✅ Hot-revert: single env knob (JARVIS_DEFAULT_CLAIMS_ENABLED=false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instruments the PLAN runner to capture default must_hold claims at every exit via a single helper, so every operation yields ≥1 claim and `verification_postmortem` has signal. Closes Priority A — Mandatory Claim Density (PRD §25.5.1).

- **New Features**
  - Added `_capture_default_claims_at_plan_exit(ctx, *, exit_reason)` in `plan_runner.py`; late-imports verification modules, reads posture best-effort, never raises, gated by `JARVIS_DEFAULT_CLAIMS_ENABLED`, logs INFO with count and reason.
  - Called the helper before all 7 exits: `plan_required_unavailable`, `plan_review_unavailable:provider_missing`, `plan_review_unavailable:gate_infra`, `plan_rejected`, `plan_approval_expired`, `user_cancelled`, `planned` (additive to plan-synthesized claims).
  - Added invariant test to ensure the helper precedes every `return PhaseResult(` and coverage tests for all exit reasons; master-off keeps behavior unchanged.

<sup>Written for commit c9c8cfc4fb9ea3db239042bc16a6659ba508bcaa. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29640?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

