### PR TITLE
feat(meta): Priority E — shipped-code structural invariants + Order-2 promotion (CLOSES Priority E)

### DIFF
--- a/.jarvis/order2_manifest.yaml
+++ b/.jarvis/order2_manifest.yaml
@@ -74,6 +74,25 @@ entries:
     added: "2026-04-26"
     added_by: operator
 
+  # --- Priority A + E (default-claim density + structural pins, 2026-04-29) ---
+  - repo: jarvis
+    path_glob: backend/core/ouroboros/governance/verification/default_claims.py
+    rationale: Default-claim seed registry (Priority A.2) — changing what's mandatory is governance
+    added: "2026-04-29"
+    added_by: operator
+
+  - repo: jarvis
+    path_glob: backend/core/ouroboros/governance/plan_generator.py
+    rationale: trivial-op classifier — changing the threshold alters PLAN-skip surface (Priority E)
+    added: "2026-04-29"
+    added_by: operator
+
+  - repo: jarvis
+    path_glob: backend/core/ouroboros/governance/meta/shipped_code_invariants.py
+    rationale: Shipped-code structural pins — disabling these breaks the cage (Priority E)
+    added: "2026-04-29"
+    added_by: operator
+
   # --- Self-reference ---
   - repo: jarvis
     path_glob: .jarvis/order2_manifest.yaml

--- a/backend/core/ouroboros/governance/meta/shipped_code_invariants.py
+++ b/backend/core/ouroboros/governance/meta/shipped_code_invariants.py
@@ -1,0 +1,385 @@
+"""Priority E — Shipped-code structural invariants.
+
+Pass B's ``ast_phase_runner_validator`` validates *candidate* code
+before it's allowed to ship. This module pins structural invariants
+on **already-shipped** code — preventing future refactors from
+silently regressing load-bearing wiring.
+
+The seed invariant (Priority E completion per PRD §25.5.5) closes
+the soak #3 silent-disable gap structurally:
+
+  * Every ``return PhaseResult(...)`` in
+    ``phase_runners/plan_runner.py`` MUST be preceded by a call to
+    ``_capture_default_claims_at_plan_exit`` within the same
+    containing block. Without this, a refactor that silently removes
+    the helper call from one exit path would re-introduce the
+    "Phase 2 is theatrical because PLAN-time claim capture is
+    skipped" pattern that produced 120 empty postmortems in soak #3.
+
+Design discipline (mirrors Pass B Slice 3 — different scope):
+  * Pure ``ast.parse`` walk. Zero runtime introspection, zero
+    network, zero subprocess. Deterministic for the same source
+    bytes.
+  * Hybrid AST + bytes window: AST locates Return-PhaseResult
+    nodes (filtering docstring/comment false-positives), then
+    a source-byte scan over the K-line window preceding each
+    Return verifies the helper call.
+  * Registry pattern (mirrors Slice A2 default_claims registry).
+    Operators register additional invariants from their own
+    modules; the seed set is amend-via-Pass-B governance (this
+    module added to the Order-2 manifest by E2).
+  * Master flag ``JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED`` —
+    default ``true``. Hot-revert: ``export JARVIS_SHIPPED_CODE_-
+    INVARIANTS_ENABLED=false`` returns ``validate_all`` to a
+    pure no-op (returns ``()``).
+
+Authority invariants (AST-pinned by tests):
+  * No imports of orchestrator / policy / iron_gate / risk_tier /
+    change_engine / candidate_generator / gate / semantic_guardian /
+    semantic_firewall.
+  * Pure stdlib (``ast``, ``logging``, ``os``, ``pathlib``).
+  * NEVER raises out of any public method — defensive everywhere.
+  * Read-only over source files — never writes back.
+
+Per PRD §25.5.5: "Future refactors that re-introduce the silent-
+disable gap will fail this test." This module promotes the test-
+time check shipped in Slice A3 to a runtime-callable structural
+primitive.
+"""
+from __future__ import annotations
+
+import ast
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+logger = logging.getLogger(__name__)
+
+
+SHIPPED_CODE_INVARIANTS_SCHEMA_VERSION: str = "shipped_code_invariant.1"
+
+# Default lookback window for the helper-call check (in source lines).
+# 30 lines is enough to span the typical setup-then-return block in
+# PLAN runner exit paths without false-matching across distant returns.
+_DEFAULT_LOOKBACK_LINES: int = 30
+
+
+# ---------------------------------------------------------------------------
+# Master flag
+# ---------------------------------------------------------------------------
+
+
+def shipped_code_invariants_enabled() -> bool:
+    """``JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED`` (default ``true``).
+
+    When off, ``validate_all`` returns an empty tuple — operators
+    can disable structural enforcement at boot time without removing
+    the registry. Hot-revert: a single env knob."""
+    raw = os.environ.get(
+        "JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED", "",
+    ).strip().lower()
+    if raw == "":
+        return True  # graduated default
+    return raw in ("1", "true", "yes", "on")
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+# A validator function takes (parsed_ast_module, source_bytes) and
+# returns a tuple of human-readable violation strings (empty tuple
+# means "invariant holds"). NEVER raises — defensive contract.
+ShippedCodeValidator = Callable[
+    [ast.Module, str], Tuple[str, ...],
+]
+
+
+@dataclass(frozen=True)
+class ShippedCodeInvariant:
+    """One pin on shipped code's structural shape. Frozen + hashable."""
+
+    invariant_name: str
+    target_file: str  # repo-relative path
+    description: str
+    validate: ShippedCodeValidator
+    schema_version: str = SHIPPED_CODE_INVARIANTS_SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class InvariantViolation:
+    """One violation report. Frozen for safe propagation across
+    threads / serialization."""
+
+    invariant_name: str
+    target_file: str
+    detail: str
+    schema_version: str = SHIPPED_CODE_INVARIANTS_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "invariant_name": self.invariant_name,
+            "target_file": self.target_file,
+            "detail": self.detail,
+            "schema_version": self.schema_version,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+_REGISTRY: Dict[str, ShippedCodeInvariant] = {}
+_REGISTRY_LOCK = threading.RLock()
+
+
+def register_shipped_code_invariant(
+    inv: ShippedCodeInvariant, *, overwrite: bool = False,
+) -> None:
+    """Install an invariant. NEVER raises. Idempotent on identical
+    re-register; rejects different-callable re-register without
+    overwrite=True."""
+    if not isinstance(inv, ShippedCodeInvariant):
+        return
+    safe_name = (
+        str(inv.invariant_name).strip() if inv.invariant_name else ""
+    )
+    if not safe_name:
+        return
+    with _REGISTRY_LOCK:
+        existing = _REGISTRY.get(safe_name)
+        if existing is not None:
+            if existing == inv:
+                return
+            if not overwrite:
+                logger.info(
+                    "[ShippedCodeInvariants] %r already registered",
+                    safe_name,
+                )
+                return
+        _REGISTRY[safe_name] = inv
+
+
+def unregister_shipped_code_invariant(invariant_name: str) -> bool:
+    """Remove an invariant. Returns True if removed. NEVER raises."""
+    safe_name = str(invariant_name).strip() if invariant_name else ""
+    if not safe_name:
+        return False
+    with _REGISTRY_LOCK:
+        return _REGISTRY.pop(safe_name, None) is not None
+
+
+def list_shipped_code_invariants() -> Tuple[ShippedCodeInvariant, ...]:
+    """Return all registered invariants in stable alphabetical order."""
+    with _REGISTRY_LOCK:
+        return tuple(_REGISTRY[k] for k in sorted(_REGISTRY.keys()))
+
+
+def reset_registry_for_tests() -> None:
+    """Test isolation."""
+    with _REGISTRY_LOCK:
+        _REGISTRY.clear()
+    _register_seed_invariants()
+
+
+# ---------------------------------------------------------------------------
+# AST helpers — shared across validators
+# ---------------------------------------------------------------------------
+
+
+def _is_phase_result_call(node: ast.AST) -> bool:
+    """True iff ``node`` is ``ast.Call`` whose func is a Name
+    ``PhaseResult``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == "PhaseResult":
+        return True
+    return False
+
+
+def _is_return_phase_result(stmt: ast.AST) -> bool:
+    """True iff ``stmt`` is ``return PhaseResult(...)``."""
+    return (
+        isinstance(stmt, ast.Return)
+        and stmt.value is not None
+        and _is_phase_result_call(stmt.value)
+    )
+
+
+def _bytes_window_above(
+    source: str, target_line: int, *, lookback: int,
+) -> str:
+    """Extract the source bytes window spanning ``lookback`` lines
+    above ``target_line`` (1-indexed). Used to check for textual
+    presence of a helper call without re-walking the AST per check."""
+    lines = source.splitlines()
+    start = max(0, target_line - 1 - lookback)
+    end = max(0, target_line - 1)  # exclude the target line itself
+    return "\n".join(lines[start:end])
+
+
+# ---------------------------------------------------------------------------
+# Seed invariant — PLAN runner default-claim wiring (Priority E)
+# ---------------------------------------------------------------------------
+
+
+def _validate_plan_runner_default_claims(
+    tree: ast.Module, source: str,
+) -> Tuple[str, ...]:
+    """Every ``return PhaseResult(...)`` in plan_runner.py must be
+    preceded by a call to ``_capture_default_claims_at_plan_exit``
+    within the prior ``_DEFAULT_LOOKBACK_LINES`` source lines.
+
+    AST locates real Return-PhaseResult nodes (filters docstrings/
+    comments containing the substring); bytes-scan over the source
+    window preceding each Return verifies the helper call.
+
+    Returns a tuple of violation descriptions; empty tuple means
+    the invariant holds. NEVER raises."""
+    violations: List[str] = []
+    for node in ast.walk(tree):
+        if not _is_return_phase_result(node):
+            continue
+        # ast.Return has .lineno on Py 3.8+; defensive check anyway.
+        lineno = getattr(node, "lineno", None)
+        if not isinstance(lineno, int) or lineno < 1:
+            continue
+        window = _bytes_window_above(
+            source, lineno, lookback=_DEFAULT_LOOKBACK_LINES,
+        )
+        if "_capture_default_claims_at_plan_exit(" not in window:
+            # Diagnostic: include the line number so operators can
+            # pinpoint the offending exit.
+            violations.append(
+                f"line {lineno}: return PhaseResult without preceding "
+                f"_capture_default_claims_at_plan_exit call within "
+                f"{_DEFAULT_LOOKBACK_LINES} lines"
+            )
+    return tuple(violations)
+
+
+# ---------------------------------------------------------------------------
+# Validation engine
+# ---------------------------------------------------------------------------
+
+
+def _resolve_target_path(target_file: str) -> Path:
+    """Resolve a repo-relative path against the project root.
+
+    Mirrors the pattern used by ``meta/order2_manifest.py`` —
+    project root is the directory containing ``CLAUDE.md`` searched
+    walking up from this module's location."""
+    here = Path(__file__).resolve().parent
+    cur = here
+    while cur != cur.parent:
+        if (cur / "CLAUDE.md").exists():
+            return cur / target_file
+        cur = cur.parent
+    # Fall back to CWD-relative
+    return Path(target_file)
+
+
+def validate_invariant(
+    inv: ShippedCodeInvariant,
+) -> Tuple[InvariantViolation, ...]:
+    """Run a single invariant. Returns tuple of violations.
+    NEVER raises."""
+    if not shipped_code_invariants_enabled():
+        return ()
+    try:
+        path = _resolve_target_path(inv.target_file)
+        if not path.exists():
+            logger.debug(
+                "[ShippedCodeInvariants] target missing: %s", path,
+            )
+            return ()
+        source = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(source, filename=str(path))
+        details = inv.validate(tree, source)
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug(
+            "[ShippedCodeInvariants] validator %r raised: %s",
+            inv.invariant_name, exc, exc_info=True,
+        )
+        return ()
+    return tuple(
+        InvariantViolation(
+            invariant_name=inv.invariant_name,
+            target_file=inv.target_file,
+            detail=str(d),
+        )
+        for d in details
+    )
+
+
+def validate_all() -> Tuple[InvariantViolation, ...]:
+    """Run every registered invariant. Returns the concatenated
+    violation list across all pins. NEVER raises.
+
+    Master-flag-gated: when off, returns ``()`` immediately."""
+    if not shipped_code_invariants_enabled():
+        return ()
+    out: List[InvariantViolation] = []
+    for inv in list_shipped_code_invariants():
+        out.extend(validate_invariant(inv))
+    return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# Seed registration
+# ---------------------------------------------------------------------------
+
+
+def _register_seed_invariants() -> None:
+    register_shipped_code_invariant(
+        ShippedCodeInvariant(
+            invariant_name="plan_runner_default_claims_wiring",
+            target_file=(
+                "backend/core/ouroboros/governance/phase_runners/"
+                "plan_runner.py"
+            ),
+            description=(
+                "Every `return PhaseResult(...)` in PLAN runner must "
+                "be preceded by a call to "
+                "_capture_default_claims_at_plan_exit (Priority A "
+                "wiring; without this Phase 2 is theatrical)."
+            ),
+            validate=_validate_plan_runner_default_claims,
+        ),
+    )
+
+
+_register_seed_invariants()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+__all__ = [
+    "InvariantViolation",
+    "SHIPPED_CODE_INVARIANTS_SCHEMA_VERSION",
+    "ShippedCodeInvariant",
+    "ShippedCodeValidator",
+    "list_shipped_code_invariants",
+    "register_shipped_code_invariant",
+    "reset_registry_for_tests",
+    "shipped_code_invariants_enabled",
+    "unregister_shipped_code_invariant",
+    "validate_all",
+    "validate_invariant",
+]

--- a/tests/governance/test_shipped_code_invariants.py
+++ b/tests/governance/test_shipped_code_invariants.py
@@ -1,0 +1,455 @@
+"""Priority E — Shipped-code structural invariants regression spine.
+
+Pins the structural enforcement that prevents future refactors from
+silently regressing Priority A wiring (the soak #3 silent-disable
+gap). This module promotes the source-grep test in A3 to a runtime-
+callable structural primitive callable from CI / battle-test boot.
+
+Pins:
+  §1   Master flag default true; case-tolerant
+  §2   Frozen ShippedCodeInvariant + InvariantViolation schemas
+  §3   Registry — idempotent + overwrite contract + alphabetical-
+       stable list + reset_for_tests
+  §4   Seed invariant `plan_runner_default_claims_wiring` registered
+       at module load
+  §5   AST helper _is_phase_result_call detects ast.Call with Name
+       'PhaseResult'
+  §6   AST helper _is_return_phase_result detects Return with
+       PhaseResult value
+  §7   Bytes window helper extracts correct lookback range
+  §8   Live invariant check passes against shipped plan_runner.py
+       (proves Priority A wiring is intact)
+  §9   Live invariant check FAILS on a synthetic plan_runner-shaped
+       file with a Return PhaseResult and NO helper call (proves
+       the validator detects regressions)
+  §10  validate_invariant returns empty when target file missing
+  §11  validate_invariant returns empty when validator raises
+  §12  validate_all master-off returns empty
+  §13  Order-2 manifest extended with the new entries
+  §14  Authority invariants — no orchestrator/policy/iron_gate imports
+  §15  Public API surface
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance.meta.shipped_code_invariants import (
+    InvariantViolation,
+    SHIPPED_CODE_INVARIANTS_SCHEMA_VERSION,
+    ShippedCodeInvariant,
+    list_shipped_code_invariants,
+    register_shipped_code_invariant,
+    reset_registry_for_tests,
+    shipped_code_invariants_enabled,
+    unregister_shipped_code_invariant,
+    validate_all,
+    validate_invariant,
+)
+from backend.core.ouroboros.governance.meta.shipped_code_invariants import (
+    _bytes_window_above,
+    _is_phase_result_call,
+    _is_return_phase_result,
+    _validate_plan_runner_default_claims,
+)
+
+
+@pytest.fixture
+def fresh_registry():
+    reset_registry_for_tests()
+    yield
+    reset_registry_for_tests()
+
+
+# ===========================================================================
+# §1 — Master flag
+# ===========================================================================
+
+
+def test_master_flag_default_true(monkeypatch) -> None:
+    monkeypatch.delenv(
+        "JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED", raising=False,
+    )
+    assert shipped_code_invariants_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", " ", "  ", "\t"])
+def test_master_flag_empty_reads_default_true(monkeypatch, val) -> None:
+    monkeypatch.setenv(
+        "JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED", val,
+    )
+    assert shipped_code_invariants_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_master_flag_truthy(monkeypatch, val) -> None:
+    monkeypatch.setenv(
+        "JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED", val,
+    )
+    assert shipped_code_invariants_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage"])
+def test_master_flag_falsy(monkeypatch, val) -> None:
+    monkeypatch.setenv(
+        "JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED", val,
+    )
+    assert shipped_code_invariants_enabled() is False
+
+
+# ===========================================================================
+# §2 — Frozen schemas
+# ===========================================================================
+
+
+def test_invariant_dataclass_frozen() -> None:
+    inv = ShippedCodeInvariant(
+        invariant_name="x", target_file="y.py",
+        description="d", validate=lambda t, s: (),
+    )
+    with pytest.raises(Exception):
+        inv.invariant_name = "z"  # type: ignore[misc]
+
+
+def test_violation_dataclass_frozen_and_serialises() -> None:
+    v = InvariantViolation(
+        invariant_name="x", target_file="y.py", detail="d",
+    )
+    with pytest.raises(Exception):
+        v.detail = "other"  # type: ignore[misc]
+    d = v.to_dict()
+    assert d["invariant_name"] == "x"
+    assert d["target_file"] == "y.py"
+    assert d["detail"] == "d"
+    assert d["schema_version"] == SHIPPED_CODE_INVARIANTS_SCHEMA_VERSION
+
+
+# ===========================================================================
+# §3 — Registry surface
+# ===========================================================================
+
+
+def test_register_idempotent_on_identical(fresh_registry) -> None:
+    fn = lambda t, s: ()
+    inv = ShippedCodeInvariant(
+        invariant_name="custom", target_file="foo.py",
+        description="d", validate=fn,
+    )
+    register_shipped_code_invariant(inv)
+    register_shipped_code_invariant(inv)
+    assert sum(
+        1 for i in list_shipped_code_invariants()
+        if i.invariant_name == "custom"
+    ) == 1
+
+
+def test_register_rejects_different_without_overwrite(
+    fresh_registry,
+) -> None:
+    inv1 = ShippedCodeInvariant(
+        invariant_name="custom", target_file="foo.py",
+        description="A", validate=lambda t, s: (),
+    )
+    inv2 = ShippedCodeInvariant(
+        invariant_name="custom", target_file="foo.py",
+        description="B", validate=lambda t, s: (),
+    )
+    register_shipped_code_invariant(inv1)
+    register_shipped_code_invariant(inv2)
+    custom = [
+        i for i in list_shipped_code_invariants()
+        if i.invariant_name == "custom"
+    ]
+    assert len(custom) == 1
+    assert custom[0].description == "A"
+
+
+def test_unregister_returns_correct_status(fresh_registry) -> None:
+    register_shipped_code_invariant(
+        ShippedCodeInvariant(
+            invariant_name="ephemeral", target_file="foo.py",
+            description="d", validate=lambda t, s: (),
+        ),
+    )
+    assert unregister_shipped_code_invariant("ephemeral") is True
+    assert unregister_shipped_code_invariant("ephemeral") is False
+    assert unregister_shipped_code_invariant("never") is False
+
+
+def test_list_alphabetical_stable(fresh_registry) -> None:
+    invs = list_shipped_code_invariants()
+    names = [i.invariant_name for i in invs]
+    assert names == sorted(names)
+
+
+# ===========================================================================
+# §4 — Seed invariant
+# ===========================================================================
+
+
+def test_seed_plan_runner_invariant_registered(fresh_registry) -> None:
+    invs = list_shipped_code_invariants()
+    names = [i.invariant_name for i in invs]
+    assert "plan_runner_default_claims_wiring" in names
+
+
+# ===========================================================================
+# §5-§7 — AST + bytes helpers
+# ===========================================================================
+
+
+def test_is_phase_result_call_detects_real_call() -> None:
+    src = "PhaseResult(next_ctx=ctx, next_phase=None)"
+    tree = ast.parse(src, mode="eval")
+    assert _is_phase_result_call(tree.body)
+
+
+def test_is_phase_result_call_rejects_other_calls() -> None:
+    for src in [
+        "OtherFunc(x)", "x.PhaseResult()", "func()", "1 + 2",
+    ]:
+        tree = ast.parse(src, mode="eval")
+        assert not _is_phase_result_call(tree.body)
+
+
+def test_is_return_phase_result_detects_correctly() -> None:
+    src = "def f():\n    return PhaseResult(x=1)\n"
+    tree = ast.parse(src)
+    rets = [n for n in ast.walk(tree) if isinstance(n, ast.Return)]
+    assert len(rets) == 1
+    assert _is_return_phase_result(rets[0])
+
+
+def test_is_return_phase_result_rejects_other_returns() -> None:
+    src = "def f():\n    return 42\n    return None\n"
+    tree = ast.parse(src)
+    for ret in [n for n in ast.walk(tree) if isinstance(n, ast.Return)]:
+        assert not _is_return_phase_result(ret)
+
+
+def test_bytes_window_extracts_correctly() -> None:
+    src = "\n".join(f"line{i}" for i in range(1, 11))  # 10 lines
+    window = _bytes_window_above(src, target_line=8, lookback=3)
+    # Lines 5, 6, 7 (lookback=3 above line 8, exclusive of 8)
+    assert "line5" in window
+    assert "line6" in window
+    assert "line7" in window
+    assert "line8" not in window
+
+
+# ===========================================================================
+# §8 — Live invariant against shipped plan_runner.py PASSES
+# ===========================================================================
+
+
+def test_live_invariant_passes_on_shipped_plan_runner(
+    fresh_registry,
+) -> None:
+    """Priority E's central guarantee: the shipped plan_runner.py
+    has the helper call before every PhaseResult exit."""
+    violations = validate_all()
+    plan_runner_violations = [
+        v for v in violations
+        if v.invariant_name == "plan_runner_default_claims_wiring"
+    ]
+    assert plan_runner_violations == []
+
+
+# ===========================================================================
+# §9 — Synthetic regression PROVES the validator catches refactors
+# ===========================================================================
+
+
+def test_validator_detects_missing_helper_call(tmp_path) -> None:
+    """Synthesize a plan_runner-shaped file with a Return PhaseResult
+    but NO helper call. Validator should flag it."""
+    bad_source = textwrap.dedent("""
+        from backend.core.ouroboros.governance.phase_runner import (
+            PhaseResult, PhaseRunner,
+        )
+
+        class BadRunner(PhaseRunner):
+            async def run(self, ctx):
+                # No _capture_default_claims_at_plan_exit call here —
+                # this is the regression we want to catch.
+                return PhaseResult(
+                    next_ctx=ctx, next_phase=None, status="fail",
+                    reason="silent_disable",
+                )
+    """)
+    tree = ast.parse(bad_source)
+    violations = _validate_plan_runner_default_claims(tree, bad_source)
+    assert len(violations) == 1
+    assert "_capture_default_claims_at_plan_exit" in violations[0]
+
+
+def test_validator_passes_when_helper_present(tmp_path) -> None:
+    """Sanity: synthesized file WITH the helper call before each
+    return passes."""
+    good_source = textwrap.dedent("""
+        from backend.core.ouroboros.governance.phase_runner import (
+            PhaseResult, PhaseRunner,
+        )
+
+        class GoodRunner(PhaseRunner):
+            async def run(self, ctx):
+                # Helper call precedes the return — invariant holds.
+                await _capture_default_claims_at_plan_exit(
+                    ctx, exit_reason="planned",
+                )
+                return PhaseResult(
+                    next_ctx=ctx, next_phase=None, status="ok",
+                    reason="planned",
+                )
+    """)
+    tree = ast.parse(good_source)
+    violations = _validate_plan_runner_default_claims(tree, good_source)
+    assert violations == ()
+
+
+def test_validator_filters_docstring_false_positives(tmp_path) -> None:
+    """A docstring containing 'return PhaseResult(...)' must NOT
+    trigger the validator (AST filters this; bytes-only regex
+    couldn't)."""
+    source_with_docstring = textwrap.dedent('''
+        """The PLAN runner has 7 exit paths, each with
+        `return PhaseResult(...)`. Documenting in a docstring
+        must not be flagged as an exit point."""
+        # No actual return statements at all.
+    ''')
+    tree = ast.parse(source_with_docstring)
+    violations = _validate_plan_runner_default_claims(
+        tree, source_with_docstring,
+    )
+    assert violations == ()
+
+
+# ===========================================================================
+# §10-§12 — Defensive contracts
+# ===========================================================================
+
+
+def test_validate_invariant_missing_target_returns_empty(
+    fresh_registry,
+) -> None:
+    inv = ShippedCodeInvariant(
+        invariant_name="missing",
+        target_file="nonexistent/path.py",
+        description="d",
+        validate=lambda t, s: ("would have flagged",),
+    )
+    register_shipped_code_invariant(inv)
+    violations = validate_invariant(inv)
+    assert violations == ()
+
+
+def test_validate_invariant_validator_raises_returns_empty(
+    fresh_registry,
+) -> None:
+    def boom(tree, source):
+        raise RuntimeError("boom")
+
+    inv = ShippedCodeInvariant(
+        invariant_name="boom",
+        target_file=(
+            "backend/core/ouroboros/governance/phase_runners/"
+            "plan_runner.py"
+        ),
+        description="d",
+        validate=boom,
+    )
+    register_shipped_code_invariant(inv)
+    violations = validate_invariant(inv)
+    assert violations == ()
+
+
+def test_validate_all_master_off_returns_empty(
+    fresh_registry, monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED", "false",
+    )
+    violations = validate_all()
+    assert violations == ()
+
+
+# ===========================================================================
+# §13 — Order-2 manifest extension
+# ===========================================================================
+
+
+def test_order2_manifest_includes_priority_e_entries() -> None:
+    """The 3 Priority A/E governance entries are pinned in the
+    manifest. Operator amendment of these files now requires the
+    Pass B amend protocol."""
+    here = Path(__file__).resolve().parent
+    cur = here
+    while cur != cur.parent and not (cur / "CLAUDE.md").exists():
+        cur = cur.parent
+    manifest = cur / ".jarvis" / "order2_manifest.yaml"
+    assert manifest.exists()
+    text = manifest.read_text(encoding="utf-8")
+    assert "verification/default_claims.py" in text
+    assert "plan_generator.py" in text
+    assert "shipped_code_invariants.py" in text
+
+
+# ===========================================================================
+# §14 — Authority invariants
+# ===========================================================================
+
+
+def test_no_authority_imports() -> None:
+    from backend.core.ouroboros.governance.meta import shipped_code_invariants
+    src = inspect.getsource(shipped_code_invariants)
+    forbidden = (
+        "orchestrator", "policy", "iron_gate", "risk_tier",
+        "change_engine", "candidate_generator", "gate",
+        "semantic_guardian", "semantic_firewall",
+    )
+    for token in forbidden:
+        assert (
+            f"from backend.core.ouroboros.governance.{token}" not in src
+        ), f"shipped_code_invariants must not import {token}"
+        assert (
+            f"import backend.core.ouroboros.governance.{token}" not in src
+        ), f"shipped_code_invariants must not import {token}"
+
+
+def test_pure_stdlib_imports() -> None:
+    """Only stdlib + meta package may be imported."""
+    from backend.core.ouroboros.governance.meta import shipped_code_invariants
+    src = inspect.getsource(shipped_code_invariants)
+    # No subprocess, no network, no LLM
+    assert "import subprocess" not in src
+    assert "import socket" not in src
+    assert "anthropic" not in src
+    assert "openai" not in src
+
+
+# ===========================================================================
+# §15 — Public API
+# ===========================================================================
+
+
+def test_public_api_exposed() -> None:
+    from backend.core.ouroboros.governance.meta import shipped_code_invariants
+    expected = {
+        "InvariantViolation",
+        "ShippedCodeInvariant",
+        "ShippedCodeValidator",
+        "list_shipped_code_invariants",
+        "register_shipped_code_invariant",
+        "reset_registry_for_tests",
+        "shipped_code_invariants_enabled",
+        "unregister_shipped_code_invariant",
+        "validate_all",
+        "validate_invariant",
+    }
+    for name in expected:
+        assert name in shipped_code_invariants.__all__


### PR DESCRIPTION
## Summary

**Closes Priority E** per PRD §25.5.5. Promotes the source-grep invariant test shipped in Slice A3 to a runtime-callable structural primitive, and pins three new files to the Order-2 governance manifest.

## What's new

**NEW module** \`meta/shipped_code_invariants.py\`:
- \`ShippedCodeInvariant\` + \`InvariantViolation\` frozen schemas
- Registry surface (mirrors Slice A2 + B1 patterns)
- \`validate_invariant\` / \`validate_all\` — pure functions; never raise
- Hybrid AST + bytes-window approach (AST filters docstring false-positives that pure regex would catch)
- Master flag graduated default-true with hot-revert

**ONE seed invariant**: \`plan_runner_default_claims_wiring\` — every \`return PhaseResult(...)\` in plan_runner.py must be preceded by \`_capture_default_claims_at_plan_exit\` within the prior 30 lines. Future refactors that re-introduce the soak #3 silent-disable gap fail this validator.

**Order-2 manifest extension** — 3 new entries:
- \`verification/default_claims.py\` (default-claim seed registry — Priority A.2)
- \`plan_generator.py\` (trivial-op classifier — Priority E)
- \`meta/shipped_code_invariants.py\` (self-reference — Priority E)

## Test plan

- [x] **37 new Priority E tests** + **285/285 combined** across A+B+D+E + Phase 2
- [x] Live validation: 0 violations against shipped plan_runner.py
- [x] Synthetic regression: validator correctly detects refactors that omit the helper
- [x] Docstring filter: \`return PhaseResult(...)\` in docstrings/comments NOT flagged
- [x] Order-2 manifest extension verified
- [x] Pre-commit file integrity: clean
- [ ] CI green

## Architecture compliance

- ✅ Mirrors Slice A2 + B1 registry pattern — same ergonomics
- ✅ Pure stdlib (ast, logging, os, pathlib); no LLM/network/subprocess
- ✅ Authority invariants AST-pinned (no orchestrator/policy/iron_gate/etc imports)
- ✅ Read-only over source files
- ✅ Defensive — never raises; per-validator failures swallowed silently
- ✅ Hot-revert: single env knob (\`JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED=false\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime-enforced shipped‑code structural invariants and promotes the PLAN runner default‑claims check from tests to a callable validator. Also pins critical governance files to the Order‑2 manifest to guard against unsafe refactors.

- **New Features**
  - New module `backend/core/ouroboros/governance/meta/shipped_code_invariants.py`:
    - Frozen schemas `ShippedCodeInvariant` and `InvariantViolation`.
    - Registry plus `validate_invariant` / `validate_all` (never raise; stdlib-only).
    - Hybrid AST + bytes-window matcher that ignores docstrings/comments.
    - Master flag `JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED` (default true; hot-revert).
  - Seed invariant `plan_runner_default_claims_wiring`:
    - Every `return PhaseResult(...)` in `backend/core/ouroboros/governance/phase_runners/plan_runner.py` must be preceded by `_capture_default_claims_at_plan_exit` within the prior 30 lines.
  - Order‑2 manifest update (`.jarvis/order2_manifest.yaml`):
    - Adds `backend/core/ouroboros/governance/verification/default_claims.py`, `backend/core/ouroboros/governance/plan_generator.py`, and `backend/core/ouroboros/governance/meta/shipped_code_invariants.py`.

<sup>Written for commit 16fa5e41e96539251d8f1b70ea7cf55b82a555c7. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29655?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

