### PR TITLE
feat(verification): Priority F — evidence collector extension (CLOSES Priority F)

### DIFF
--- a/backend/core/ouroboros/governance/verification/__init__.py
+++ b/backend/core/ouroboros/governance/verification/__init__.py
@@ -85,12 +85,20 @@ from backend.core.ouroboros.governance.verification.hypothesis_probe import (
     list_test_strategies,
     register_test_strategy,
 )
+from backend.core.ouroboros.governance.verification.evidence_collectors import (
+    EvidenceGatherer,
+    dispatch_evidence_gather,
+    evidence_collectors_enabled,
+    list_evidence_gatherers,
+    register_evidence_gatherer,
+)
 
 __all__ = [
     "CANONICAL_SEVERITIES",
     "ClaimOutcome",
     "DefaultClaimSpec",
     "EvidenceCollector",
+    "EvidenceGatherer",
     "Property",
     "PropertyClaim",
     "PropertyEvaluator",
@@ -107,6 +115,8 @@ __all__ = [
     "capture_claims",
     "ctx_evidence_collector",
     "default_claims_enabled",
+    "dispatch_evidence_gather",
+    "evidence_collectors_enabled",
     "Hypothesis",
     "HypothesisProbe",
     "ProbeResult",
@@ -119,6 +129,7 @@ __all__ = [
     "get_recorded_claims",
     "get_recorded_postmortem",
     "list_default_claim_specs",
+    "list_evidence_gatherers",
     "list_recent_postmortems",
     "list_test_strategies",
     "log_postmortem_summary",
@@ -129,6 +140,7 @@ __all__ = [
     "property_capture_enabled",
     "register_default_claim_spec",
     "register_evaluator",
+    "register_evidence_gatherer",
     "register_test_strategy",
     "repeat_runner_enabled",
     "synthesize_claims_from_plan",

--- a/backend/core/ouroboros/governance/verification/evidence_collectors.py
+++ b/backend/core/ouroboros/governance/verification/evidence_collectors.py
@@ -1,0 +1,423 @@
+"""Priority F — Evidence collector extension.
+
+Closes the verification loop end-to-end. Pre-F, soak #4 produced
+postmortems with `total_claims=3` (good — Priority A working) but
+ALL claims evaluated to `INSUFFICIENT_EVIDENCE` because the existing
+`ctx_evidence_collector` (Slice 2.4) only knows about the ORIGINAL
+claim kinds (`test_passes`, `key_present`) — not the three Priority A
+default kinds:
+
+  * `file_parses_after_change` (needs `target_files_post`)
+  * `test_set_hash_stable` (needs `test_files_pre` + `test_files_post`)
+  * `no_new_credential_shapes` (needs `diff_text`)
+
+This module ships the canonical surface for evidence gathering:
+
+  * `EvidenceGatherer` — frozen, hashable spec (kind + description +
+    async gather function).
+  * Registry pattern (mirrors A2 default_claims, B1 dormancy
+    detectors, C test strategies, E shipped-code invariants):
+    `register_evidence_gatherer` / `unregister` / `list` /
+    `reset_for_tests`. Idempotent on identical re-register; rejects
+    different-callable without `overwrite=True`.
+  * `dispatch_evidence_gather(claim, ctx)` — pure async dispatcher:
+    looks up the registered gatherer for `claim.property.kind`,
+    invokes it, returns the evidence mapping. Falls back to empty
+    mapping for unregistered kinds (caller's existing fallback chain
+    runs).
+  * Three default gatherers for Priority A kinds, each with a
+    self-gathering fallback when ctx attrs aren't pre-stamped:
+    - `file_parses_after_change` reads `ctx.target_files_post` if
+      stamped; falls back to reading `ctx.target_files` from disk
+    - `test_set_hash_stable` reads `ctx.test_files_pre` /
+      `ctx.test_files_post` if stamped; falls back to globbing
+      `tests/**/*.py` (post only, no pre fallback — pre-state must
+      be captured at PLAN time)
+    - `no_new_credential_shapes` reads `ctx.diff_text` if stamped;
+      no self-gather fallback (diff is unavailable post-APPLY
+      without explicit capture)
+
+Authority invariants (AST-pinned by tests):
+  * No imports of orchestrator / phase_runner / candidate_generator /
+    iron_gate / change_engine / policy / semantic_guardian.
+  * Pure stdlib + verification.* (own slice family).
+  * NEVER raises out of any public method.
+  * Read-only over the filesystem — never writes back.
+
+Master flag `JARVIS_EVIDENCE_COLLECTORS_ENABLED` (default `true`).
+When off, `dispatch_evidence_gather` returns `{}` for every claim
+and the legacy ctx_evidence_collector hardcoded paths run.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+)
+
+logger = logging.getLogger(__name__)
+
+
+EVIDENCE_COLLECTOR_SCHEMA_VERSION: str = "evidence_collector.1"
+
+
+# ---------------------------------------------------------------------------
+# Master flag
+# ---------------------------------------------------------------------------
+
+
+def evidence_collectors_enabled() -> bool:
+    """``JARVIS_EVIDENCE_COLLECTORS_ENABLED`` (default ``true``).
+
+    When off, ``dispatch_evidence_gather`` returns an empty mapping
+    for every claim and the legacy ctx_evidence_collector hardcoded
+    paths run. Hot-revert: a single env knob."""
+    raw = os.environ.get(
+        "JARVIS_EVIDENCE_COLLECTORS_ENABLED", "",
+    ).strip().lower()
+    if raw == "":
+        return True  # graduated default
+    return raw in ("1", "true", "yes", "on")
+
+
+# ---------------------------------------------------------------------------
+# EvidenceGatherer — registry value type
+# ---------------------------------------------------------------------------
+
+
+# An evidence gatherer takes (claim, ctx) and returns an evidence
+# mapping (claim.property.evidence_required keys → values). NEVER
+# raises — gatherers must catch their own errors and return {} on
+# failure (the caller's INSUFFICIENT_EVIDENCE path handles missing
+# evidence cleanly).
+EvidenceGatherFn = Callable[
+    [Any, Any],
+    "Coroutine[Any, Any, Mapping[str, Any]]",
+]
+
+
+@dataclass(frozen=True)
+class EvidenceGatherer:
+    """One evidence-gathering spec. Frozen + hashable for safe
+    registry storage."""
+
+    kind: str
+    description: str
+    gather: EvidenceGatherFn
+    schema_version: str = EVIDENCE_COLLECTOR_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+_REGISTRY: Dict[str, EvidenceGatherer] = {}
+_REGISTRY_LOCK = threading.RLock()
+
+
+def register_evidence_gatherer(
+    gatherer: EvidenceGatherer, *, overwrite: bool = False,
+) -> None:
+    """Install an evidence gatherer. NEVER raises. Idempotent on
+    identical re-register; rejects different-callable without
+    overwrite=True."""
+    if not isinstance(gatherer, EvidenceGatherer):
+        return
+    safe_kind = (
+        str(gatherer.kind).strip() if gatherer.kind else ""
+    )
+    if not safe_kind:
+        return
+    with _REGISTRY_LOCK:
+        existing = _REGISTRY.get(safe_kind)
+        if existing is not None:
+            if existing == gatherer:
+                return
+            if not overwrite:
+                logger.info(
+                    "[EvidenceCollectors] gatherer %r already registered",
+                    safe_kind,
+                )
+                return
+        _REGISTRY[safe_kind] = gatherer
+
+
+def unregister_evidence_gatherer(kind: str) -> bool:
+    """Remove a gatherer. Returns True if removed. NEVER raises."""
+    safe_kind = str(kind).strip() if kind else ""
+    if not safe_kind:
+        return False
+    with _REGISTRY_LOCK:
+        return _REGISTRY.pop(safe_kind, None) is not None
+
+
+def list_evidence_gatherers() -> Tuple[EvidenceGatherer, ...]:
+    """Return all gatherers in stable alphabetical order."""
+    with _REGISTRY_LOCK:
+        return tuple(_REGISTRY[k] for k in sorted(_REGISTRY.keys()))
+
+
+def is_kind_registered(kind: str) -> bool:
+    """True iff a gatherer is registered for ``kind``."""
+    safe_kind = str(kind).strip() if kind else ""
+    if not safe_kind:
+        return False
+    with _REGISTRY_LOCK:
+        return safe_kind in _REGISTRY
+
+
+def reset_registry_for_tests() -> None:
+    """Test isolation."""
+    with _REGISTRY_LOCK:
+        _REGISTRY.clear()
+    _register_seed_gatherers()
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher — pure async; gates on master flag + claim shape
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_evidence_gather(
+    claim: Any, ctx: Any,
+) -> Mapping[str, Any]:
+    """Dispatch evidence gathering for ``claim`` via the registered
+    gatherer for ``claim.property.kind``. NEVER raises.
+
+    Returns:
+      * Empty mapping when the master flag is off
+      * Empty mapping when the claim or its property is malformed
+      * Empty mapping when no gatherer is registered for the kind
+        (caller falls back to legacy hardcoded paths)
+      * Whatever the gatherer returns on success (also a mapping;
+        gatherers swallow their own errors and return {} on failure)
+    """
+    if not evidence_collectors_enabled():
+        return {}
+    if claim is None:
+        return {}
+    prop = getattr(claim, "property", None)
+    if prop is None:
+        return {}
+    kind = getattr(prop, "kind", "")
+    if not kind:
+        return {}
+    safe_kind = str(kind).strip()
+    with _REGISTRY_LOCK:
+        gatherer = _REGISTRY.get(safe_kind)
+    if gatherer is None:
+        return {}
+    try:
+        result = await gatherer.gather(claim, ctx)
+    except Exception:  # noqa: BLE001 — defensive (gatherer should
+        # itself never raise, but defense-in-depth)
+        logger.debug(
+            "[EvidenceCollectors] gatherer %r raised", safe_kind,
+            exc_info=True,
+        )
+        return {}
+    if not isinstance(result, Mapping):
+        return {}
+    return dict(result)
+
+
+# ---------------------------------------------------------------------------
+# Default gatherers for Priority A claim kinds
+# ---------------------------------------------------------------------------
+
+
+async def _gather_file_parses_after_change(
+    claim: Any, ctx: Any,
+) -> Mapping[str, Any]:
+    """Gather evidence for the ``file_parses_after_change`` claim.
+
+    Resolution chain:
+      1. If ``ctx.target_files_post`` is already stamped (by future
+         APPLY-phase enrichment), pass through as-is.
+      2. Else, self-gather: read each file in ``ctx.target_files``
+         from disk and produce ``[{path, content}, ...]``.
+
+    NEVER raises. On any I/O failure, returns ``{}`` (Oracle returns
+    INSUFFICIENT_EVIDENCE — honest about the gap)."""
+    try:
+        # Priority 1 — pre-stamped (future Slice F2 wiring)
+        stamped = getattr(ctx, "target_files_post", None)
+        if stamped is not None:
+            return {"target_files_post": list(stamped)}
+
+        # Priority 2 — self-gather from disk
+        targets = getattr(ctx, "target_files", None)
+        if not targets:
+            return {}
+        out: List[Dict[str, Any]] = []
+        for path_str in targets:
+            try:
+                p = Path(str(path_str))
+                if not p.exists():
+                    # File doesn't exist post-op — record without
+                    # content; the evaluator will treat absent .py
+                    # as a SyntaxError-equivalent if relevant.
+                    out.append({"path": str(p), "content": ""})
+                    continue
+                if not p.is_file():
+                    continue
+                content = p.read_text(
+                    encoding="utf-8", errors="replace",
+                )
+                out.append({"path": str(p), "content": content})
+            except OSError:
+                continue
+        return {"target_files_post": out}
+    except Exception:  # noqa: BLE001 — defensive
+        return {}
+
+
+async def _gather_test_set_hash_stable(
+    claim: Any, ctx: Any,
+) -> Mapping[str, Any]:
+    """Gather evidence for the ``test_set_hash_stable`` claim.
+
+    Resolution chain:
+      1. If both ``ctx.test_files_pre`` AND ``ctx.test_files_post``
+         are stamped, pass through.
+      2. Else, self-gather post-state by globbing ``tests/**/*.py``
+         under ``ctx.target_dir`` (or project root). Pre-state has
+         no self-gather fallback — without a PLAN-time snapshot the
+         claim correctly evaluates to INSUFFICIENT_EVIDENCE.
+
+    NEVER raises."""
+    try:
+        pre = getattr(ctx, "test_files_pre", None)
+        post = getattr(ctx, "test_files_post", None)
+        if pre is not None and post is not None:
+            return {
+                "test_files_pre": list(pre),
+                "test_files_post": list(post),
+            }
+
+        # Pre-state cannot be self-gathered post-APPLY (the original
+        # state is gone). Honest INSUFFICIENT_EVIDENCE.
+        if pre is None:
+            return {}
+
+        # Post can self-gather.
+        target_dir = getattr(ctx, "target_dir", None) or "."
+        try:
+            base = Path(str(target_dir))
+        except Exception:  # noqa: BLE001
+            base = Path(".")
+        if not base.exists() or not base.is_dir():
+            return {}
+        post_set: List[str] = []
+        try:
+            for p in base.glob("tests/**/*.py"):
+                if p.is_file():
+                    post_set.append(str(p))
+        except (OSError, ValueError):
+            pass
+        return {
+            "test_files_pre": list(pre),
+            "test_files_post": post_set,
+        }
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+async def _gather_no_new_credential_shapes(
+    claim: Any, ctx: Any,
+) -> Mapping[str, Any]:
+    """Gather evidence for the ``no_new_credential_shapes`` claim.
+
+    Resolution chain:
+      1. If ``ctx.diff_text`` is stamped (by future APPLY-phase
+         enrichment), pass through as-is.
+      2. No self-gather fallback — without an explicit diff we
+         can't faithfully detect "newly introduced" credentials
+         (full file content would flag pre-existing credentials).
+         Honest INSUFFICIENT_EVIDENCE.
+
+    NEVER raises."""
+    try:
+        diff = getattr(ctx, "diff_text", None)
+        if diff is None:
+            return {}
+        # Coerce to string defensively
+        if isinstance(diff, bytes):
+            diff_str = diff.decode("utf-8", errors="replace")
+        else:
+            diff_str = str(diff)
+        return {"diff_text": diff_str}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _register_seed_gatherers() -> None:
+    """Module-load: register the three Priority A seed gatherers.
+    Idempotent — re-registering the same callable is a silent no-op."""
+    register_evidence_gatherer(
+        EvidenceGatherer(
+            kind="file_parses_after_change",
+            description=(
+                "Gathers target_files_post from ctx (pre-stamped by "
+                "APPLY) or self-gathers by reading ctx.target_files "
+                "from disk."
+            ),
+            gather=_gather_file_parses_after_change,
+        ),
+    )
+    register_evidence_gatherer(
+        EvidenceGatherer(
+            kind="test_set_hash_stable",
+            description=(
+                "Gathers test_files_pre + test_files_post from ctx; "
+                "post can self-gather via tests/**/*.py glob, pre "
+                "must be PLAN-time stamped."
+            ),
+            gather=_gather_test_set_hash_stable,
+        ),
+    )
+    register_evidence_gatherer(
+        EvidenceGatherer(
+            kind="no_new_credential_shapes",
+            description=(
+                "Gathers diff_text from ctx; no self-gather fallback "
+                "because full-file scan would flag pre-existing "
+                "credentials."
+            ),
+            gather=_gather_no_new_credential_shapes,
+        ),
+    )
+
+
+_register_seed_gatherers()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+__all__ = [
+    "EVIDENCE_COLLECTOR_SCHEMA_VERSION",
+    "EvidenceGatherer",
+    "EvidenceGatherFn",
+    "dispatch_evidence_gather",
+    "evidence_collectors_enabled",
+    "is_kind_registered",
+    "list_evidence_gatherers",
+    "register_evidence_gatherer",
+    "reset_registry_for_tests",
+    "unregister_evidence_gatherer",
+]

--- a/backend/core/ouroboros/governance/verification/postmortem.py
+++ b/backend/core/ouroboros/governance/verification/postmortem.py
@@ -422,27 +422,60 @@ async def ctx_evidence_collector(
     claim: PropertyClaim, ctx: Any,
 ) -> Mapping[str, Any]:
     """Default evidence collector. Pulls common signals from
-    OperationContext for the four canonical claim kinds.
+    OperationContext for the canonical claim kinds.
 
-    Returns empty mapping for unknown kinds — Oracle will return
-    INSUFFICIENT_EVIDENCE. NEVER raises.
+    Priority F (2026-04-29): now dispatches FIRST through the
+    ``evidence_collectors`` registry (Priority A claim kinds plus
+    operator-registered extensions), then falls back to the legacy
+    hardcoded paths for the original Slice 2.4 kinds (``test_passes``
+    / ``key_present``). Returns empty mapping for unknown kinds —
+    Oracle returns INSUFFICIENT_EVIDENCE. NEVER raises.
 
     The mapping per claim kind:
 
-      * ``test_passes`` — ctx.validation_passed → exit_code (0 or 1)
-        (assumes a passing op had its test_strategy.tests_to_pass
-        actually exercised)
-      * ``key_present`` — ctx.validation_passed AND op didn't fail
-        → present=True (best-effort signal that no regression
-        materialized)
-      * ``string_matches`` — empty (signature inspection requires
-        live AST parsing — operators wire richer collectors)
-      * ``set_subset`` — empty (custom claim — operator-specific)
-      * Unknown kind — empty
+      Priority A (via registry):
+        * ``file_parses_after_change`` — target_files_post (pre-
+          stamped by APPLY) or self-gathered from disk
+        * ``test_set_hash_stable`` — test_files_pre + test_files_post
+        * ``no_new_credential_shapes`` — diff_text (pre-stamped)
+      Slice 2.4 legacy:
+        * ``test_passes`` — ctx.validation_passed → exit_code (0 or 1)
+        * ``key_present`` — ctx.validation_passed → present
+        * Unknown kind — empty
     """
     kind = claim.property.kind if claim and claim.property else ""
 
     try:
+        # Priority F — dispatch via registry. When the registry
+        # returns a non-empty mapping, we trust it as authoritative
+        # and skip the legacy hardcoded paths (the registry's
+        # gatherers are typed; legacy paths are best-effort).
+        try:
+            from backend.core.ouroboros.governance.verification.evidence_collectors import (
+                dispatch_evidence_gather,
+                is_kind_registered,
+            )
+            if is_kind_registered(kind):
+                gathered = await dispatch_evidence_gather(claim, ctx)
+                if gathered:
+                    return gathered
+                # Registry returned empty — let legacy paths try
+                # only if the kind ISN'T in the Priority A set
+                # (those have honest INSUFFICIENT_EVIDENCE semantics
+                # we don't want to mask with a false-positive legacy
+                # signal).
+                priority_a_kinds = {
+                    "file_parses_after_change",
+                    "test_set_hash_stable",
+                    "no_new_credential_shapes",
+                }
+                if kind in priority_a_kinds:
+                    return {}
+        except Exception:  # noqa: BLE001 — defensive
+            # Registry import / dispatch failed — fall through to
+            # legacy hardcoded paths.
+            pass
+
         if kind == "test_passes":
             # If validation_passed is True on ctx, we treat that as
             # exit_code=0 for any test_passes claim. This is a

--- a/tests/governance/test_evidence_collectors.py
+++ b/tests/governance/test_evidence_collectors.py
@@ -1,0 +1,616 @@
+"""Priority F — Evidence collector extension regression spine.
+
+Closes the verification loop end-to-end. Pre-F, postmortems carried
+the right claims (Priority A working) but every claim evaluated to
+INSUFFICIENT_EVIDENCE because the legacy ctx_evidence_collector
+didn't know how to populate the three Priority A evidence shapes.
+
+Pins:
+  §1   Master flag default true (graduated; hot-revert path)
+  §2   Master flag empty/whitespace reads as default true
+  §3   Master flag false-class disables
+  §4   EvidenceGatherer is frozen + hashable
+  §5   Registry — idempotent + overwrite + alphabetical-stable
+  §6   Three seed gatherers registered at module load
+  §7   is_kind_registered returns True for seeds
+  §8   reset_for_tests clears + re-seeds
+  §9   dispatch — master-off returns empty
+  §10  dispatch — None claim returns empty
+  §11  dispatch — claim with no property returns empty
+  §12  dispatch — unknown kind returns empty
+  §13  dispatch — gatherer that raises swallowed; returns empty
+  §14  dispatch — gatherer that returns non-mapping coerced to {}
+  §15  file_parses_after_change — pre-stamped ctx pass-through
+  §16  file_parses_after_change — self-gathers from disk when
+       ctx.target_files set but target_files_post not stamped
+  §17  file_parses_after_change — handles missing files (records
+       with empty content)
+  §18  file_parses_after_change — non-existent ctx.target_files
+       returns empty mapping
+  §19  test_set_hash_stable — pre+post stamped pass-through
+  §20  test_set_hash_stable — pre missing returns empty (honest
+       INSUFFICIENT — pre cannot self-gather post-APPLY)
+  §21  test_set_hash_stable — pre stamped + post self-gathered
+       via tests/**/*.py glob
+  §22  no_new_credential_shapes — diff_text pre-stamped pass-through
+  §23  no_new_credential_shapes — bytes diff decoded
+  §24  no_new_credential_shapes — no diff → empty (honest
+       INSUFFICIENT)
+  §25  Integration — ctx_evidence_collector dispatches via registry
+       FIRST for Priority A kinds
+  §26  Integration — ctx_evidence_collector falls back to legacy
+       hardcoded paths for test_passes / key_present
+  §27  Integration — Priority A kind with empty registry result
+       returns empty (does NOT mask with legacy false-positive)
+  §28  Authority invariants — no orchestrator/policy/iron_gate imports
+  §29  Public API surface
+  §30  All gatherers NEVER raise on garbage ctx
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import FrozenInstanceError
+from types import SimpleNamespace
+from typing import Any, Mapping
+
+import pytest
+
+from backend.core.ouroboros.governance.verification.evidence_collectors import (
+    EVIDENCE_COLLECTOR_SCHEMA_VERSION,
+    EvidenceGatherer,
+    dispatch_evidence_gather,
+    evidence_collectors_enabled,
+    is_kind_registered,
+    list_evidence_gatherers,
+    register_evidence_gatherer,
+    reset_registry_for_tests,
+    unregister_evidence_gatherer,
+)
+
+
+@pytest.fixture
+def fresh_registry():
+    reset_registry_for_tests()
+    yield
+    reset_registry_for_tests()
+
+
+def _make_claim(kind: str, name: str = "test"):
+    """Synthesize a minimal claim shape for dispatch tests. The
+    dispatcher only reads claim.property.kind."""
+    return SimpleNamespace(
+        property=SimpleNamespace(kind=kind, name=name),
+    )
+
+
+# ===========================================================================
+# §1-§3 — Master flag
+# ===========================================================================
+
+
+def test_master_flag_default_true(monkeypatch) -> None:
+    monkeypatch.delenv(
+        "JARVIS_EVIDENCE_COLLECTORS_ENABLED", raising=False,
+    )
+    assert evidence_collectors_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", " ", "  ", "\t"])
+def test_master_flag_empty_reads_default_true(monkeypatch, val) -> None:
+    monkeypatch.setenv("JARVIS_EVIDENCE_COLLECTORS_ENABLED", val)
+    assert evidence_collectors_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on"])
+def test_master_flag_truthy(monkeypatch, val) -> None:
+    monkeypatch.setenv("JARVIS_EVIDENCE_COLLECTORS_ENABLED", val)
+    assert evidence_collectors_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "garbage"])
+def test_master_flag_falsy(monkeypatch, val) -> None:
+    monkeypatch.setenv("JARVIS_EVIDENCE_COLLECTORS_ENABLED", val)
+    assert evidence_collectors_enabled() is False
+
+
+# ===========================================================================
+# §4 — Frozen schema
+# ===========================================================================
+
+
+def test_gatherer_is_frozen() -> None:
+    async def fn(c, ctx):
+        return {}
+    g = EvidenceGatherer(
+        kind="x", description="d", gather=fn,
+    )
+    with pytest.raises((AttributeError, FrozenInstanceError, TypeError)):
+        g.kind = "y"  # type: ignore[misc]
+    assert g.schema_version == EVIDENCE_COLLECTOR_SCHEMA_VERSION
+
+
+# ===========================================================================
+# §5 — Registry surface
+# ===========================================================================
+
+
+def test_register_idempotent_on_identical(fresh_registry) -> None:
+    async def fn(c, ctx):
+        return {}
+    g = EvidenceGatherer(
+        kind="custom", description="d", gather=fn,
+    )
+    register_evidence_gatherer(g)
+    register_evidence_gatherer(g)
+    custom = [
+        x for x in list_evidence_gatherers()
+        if x.kind == "custom"
+    ]
+    assert len(custom) == 1
+
+
+def test_register_rejects_different_without_overwrite(
+    fresh_registry,
+) -> None:
+    async def f1(c, ctx):
+        return {"a": 1}
+
+    async def f2(c, ctx):
+        return {"b": 2}
+    g1 = EvidenceGatherer(
+        kind="custom", description="A", gather=f1,
+    )
+    g2 = EvidenceGatherer(
+        kind="custom", description="B", gather=f2,
+    )
+    register_evidence_gatherer(g1)
+    register_evidence_gatherer(g2)
+    custom = [
+        x for x in list_evidence_gatherers()
+        if x.kind == "custom"
+    ]
+    assert len(custom) == 1
+    assert custom[0].description == "A"
+
+
+def test_register_overwrite_replaces(fresh_registry) -> None:
+    async def f1(c, ctx):
+        return {}
+
+    async def f2(c, ctx):
+        return {}
+    g1 = EvidenceGatherer(
+        kind="custom", description="A", gather=f1,
+    )
+    g2 = EvidenceGatherer(
+        kind="custom", description="B", gather=f2,
+    )
+    register_evidence_gatherer(g1)
+    register_evidence_gatherer(g2, overwrite=True)
+    custom = [
+        x for x in list_evidence_gatherers()
+        if x.kind == "custom"
+    ]
+    assert len(custom) == 1
+    assert custom[0].description == "B"
+
+
+def test_unregister_returns_correct_status(fresh_registry) -> None:
+    async def fn(c, ctx):
+        return {}
+    register_evidence_gatherer(
+        EvidenceGatherer(
+            kind="ephemeral", description="d", gather=fn,
+        ),
+    )
+    assert unregister_evidence_gatherer("ephemeral") is True
+    assert unregister_evidence_gatherer("ephemeral") is False
+    assert unregister_evidence_gatherer("never") is False
+
+
+def test_list_alphabetical_stable(fresh_registry) -> None:
+    gs = list_evidence_gatherers()
+    kinds = [g.kind for g in gs]
+    assert kinds == sorted(kinds)
+
+
+# ===========================================================================
+# §6-§8 — Seed gatherers
+# ===========================================================================
+
+
+def test_three_seed_gatherers_registered(fresh_registry) -> None:
+    kinds = sorted(g.kind for g in list_evidence_gatherers())
+    assert kinds == [
+        "file_parses_after_change",
+        "no_new_credential_shapes",
+        "test_set_hash_stable",
+    ]
+
+
+def test_is_kind_registered_for_seeds(fresh_registry) -> None:
+    assert is_kind_registered("file_parses_after_change") is True
+    assert is_kind_registered("no_new_credential_shapes") is True
+    assert is_kind_registered("test_set_hash_stable") is True
+    assert is_kind_registered("nonexistent") is False
+    assert is_kind_registered("") is False
+
+
+def test_reset_for_tests_clears_and_reseeds(fresh_registry) -> None:
+    async def fn(c, ctx):
+        return {}
+    register_evidence_gatherer(
+        EvidenceGatherer(
+            kind="extra", description="d", gather=fn,
+        ),
+    )
+    assert is_kind_registered("extra") is True
+    reset_registry_for_tests()
+    assert is_kind_registered("extra") is False
+    # Seeds re-registered
+    assert is_kind_registered("file_parses_after_change") is True
+
+
+# ===========================================================================
+# §9-§14 — Dispatcher contracts
+# ===========================================================================
+
+
+def test_dispatch_master_off_returns_empty(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_EVIDENCE_COLLECTORS_ENABLED", "false")
+    claim = _make_claim("file_parses_after_change")
+    ctx = SimpleNamespace(target_files=("a.py",))
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    assert result == {}
+
+
+def test_dispatch_none_claim_returns_empty() -> None:
+    result = asyncio.run(
+        dispatch_evidence_gather(None, SimpleNamespace()),
+    )
+    assert result == {}
+
+
+def test_dispatch_claim_no_property_returns_empty() -> None:
+    claim = SimpleNamespace(property=None)
+    result = asyncio.run(
+        dispatch_evidence_gather(claim, SimpleNamespace()),
+    )
+    assert result == {}
+
+
+def test_dispatch_unknown_kind_returns_empty(fresh_registry) -> None:
+    claim = _make_claim("unknown-not-registered")
+    result = asyncio.run(
+        dispatch_evidence_gather(claim, SimpleNamespace()),
+    )
+    assert result == {}
+
+
+def test_dispatch_gatherer_raises_swallowed(fresh_registry) -> None:
+    async def boom(c, ctx):
+        raise RuntimeError("boom")
+    register_evidence_gatherer(
+        EvidenceGatherer(
+            kind="bad", description="d", gather=boom,
+        ),
+    )
+    claim = _make_claim("bad")
+    result = asyncio.run(
+        dispatch_evidence_gather(claim, SimpleNamespace()),
+    )
+    assert result == {}
+
+
+def test_dispatch_non_mapping_result_coerced_to_empty(
+    fresh_registry,
+) -> None:
+    async def returns_list(c, ctx):
+        return [1, 2, 3]  # type: ignore[return-value]
+    register_evidence_gatherer(
+        EvidenceGatherer(
+            kind="list_returner", description="d",
+            gather=returns_list,
+        ),
+    )
+    claim = _make_claim("list_returner")
+    result = asyncio.run(
+        dispatch_evidence_gather(claim, SimpleNamespace()),
+    )
+    assert result == {}
+
+
+# ===========================================================================
+# §15-§18 — file_parses_after_change gatherer
+# ===========================================================================
+
+
+def test_file_parses_pre_stamped_pass_through(fresh_registry) -> None:
+    """When ctx.target_files_post is already stamped, the gatherer
+    passes through without re-reading from disk."""
+    pre_stamped = [
+        {"path": "a.py", "content": "x = 1\n"},
+        {"path": "b.py", "content": "def f(): pass\n"},
+    ]
+    ctx = SimpleNamespace(
+        target_files_post=pre_stamped,
+        target_files=("a.py", "b.py"),  # ignored when post stamped
+    )
+    claim = _make_claim("file_parses_after_change")
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    assert "target_files_post" in result
+    assert result["target_files_post"] == pre_stamped
+
+
+def test_file_parses_self_gathers_from_disk(
+    fresh_registry, tmp_path,
+) -> None:
+    """When target_files_post is NOT stamped but ctx.target_files is
+    set, the gatherer reads each file from disk."""
+    # Create real files on disk
+    f1 = tmp_path / "a.py"
+    f1.write_text("x = 1\n")
+    f2 = tmp_path / "b.py"
+    f2.write_text("def hello(): return 'world'\n")
+    ctx = SimpleNamespace(
+        target_files=(str(f1), str(f2)),
+    )
+    claim = _make_claim("file_parses_after_change")
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    assert "target_files_post" in result
+    files = result["target_files_post"]
+    assert len(files) == 2
+    paths = {f["path"] for f in files}
+    assert str(f1) in paths
+    assert str(f2) in paths
+    # Content should be read from disk
+    contents = {f["path"]: f["content"] for f in files}
+    assert contents[str(f1)] == "x = 1\n"
+    assert "hello" in contents[str(f2)]
+
+
+def test_file_parses_handles_missing_files(
+    fresh_registry, tmp_path,
+) -> None:
+    """Missing files get recorded with empty content (so the
+    evaluator can detect their absence as a regression)."""
+    nonexistent = tmp_path / "ghost.py"
+    ctx = SimpleNamespace(
+        target_files=(str(nonexistent),),
+    )
+    claim = _make_claim("file_parses_after_change")
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    files = result["target_files_post"]
+    assert len(files) == 1
+    assert files[0]["path"] == str(nonexistent)
+    assert files[0]["content"] == ""
+
+
+def test_file_parses_no_targets_returns_empty(fresh_registry) -> None:
+    """No target_files → no evidence to gather → INSUFFICIENT."""
+    ctx = SimpleNamespace()  # no attrs at all
+    claim = _make_claim("file_parses_after_change")
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    assert result == {}
+
+
+# ===========================================================================
+# §19-§21 — test_set_hash_stable gatherer
+# ===========================================================================
+
+
+def test_test_set_pre_post_stamped_pass_through(fresh_registry) -> None:
+    pre = ("tests/test_a.py", "tests/test_b.py")
+    post = ("tests/test_a.py", "tests/test_b.py", "tests/test_c.py")
+    ctx = SimpleNamespace(
+        test_files_pre=pre, test_files_post=post,
+    )
+    claim = _make_claim("test_set_hash_stable")
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    assert result["test_files_pre"] == list(pre)
+    assert result["test_files_post"] == list(post)
+
+
+def test_test_set_pre_missing_returns_empty(fresh_registry) -> None:
+    """Without a PLAN-time pre-stamp, the claim cannot be evaluated
+    (we cannot reconstruct the pre-state post-APPLY). Honest
+    INSUFFICIENT_EVIDENCE."""
+    ctx = SimpleNamespace(target_dir=".")  # no test_files_pre
+    claim = _make_claim("test_set_hash_stable")
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    assert result == {}
+
+
+def test_test_set_pre_stamped_post_self_gathered(
+    fresh_registry, tmp_path,
+) -> None:
+    """Pre is stamped at PLAN; post is self-gathered by globbing
+    tests/**/*.py under ctx.target_dir."""
+    # Create a fake project tree
+    (tmp_path / "tests").mkdir()
+    f1 = tmp_path / "tests" / "test_one.py"
+    f2 = tmp_path / "tests" / "test_two.py"
+    f1.write_text("def test_x(): pass\n")
+    f2.write_text("def test_y(): pass\n")
+
+    pre = ("tests/test_one.py",)
+    ctx = SimpleNamespace(
+        test_files_pre=pre,
+        target_dir=str(tmp_path),
+    )
+    claim = _make_claim("test_set_hash_stable")
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    assert result["test_files_pre"] == list(pre)
+    # Post should contain BOTH files (one + two, glob discovered)
+    post = result["test_files_post"]
+    assert len(post) == 2
+    assert any("test_one.py" in p for p in post)
+    assert any("test_two.py" in p for p in post)
+
+
+# ===========================================================================
+# §22-§24 — no_new_credential_shapes gatherer
+# ===========================================================================
+
+
+def test_no_new_credentials_diff_pass_through(fresh_registry) -> None:
+    diff = "+def hello(): return 'world'\n"
+    ctx = SimpleNamespace(diff_text=diff)
+    claim = _make_claim("no_new_credential_shapes")
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    assert result == {"diff_text": diff}
+
+
+def test_no_new_credentials_bytes_diff_decoded(fresh_registry) -> None:
+    diff_bytes = b"+def f(): pass\n"
+    ctx = SimpleNamespace(diff_text=diff_bytes)
+    claim = _make_claim("no_new_credential_shapes")
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    assert isinstance(result["diff_text"], str)
+    assert "def f()" in result["diff_text"]
+
+
+def test_no_new_credentials_no_diff_returns_empty(
+    fresh_registry,
+) -> None:
+    """Without diff_text, the gatherer cannot faithfully detect
+    'newly introduced' credentials. Honest INSUFFICIENT_EVIDENCE."""
+    ctx = SimpleNamespace()  # no diff_text
+    claim = _make_claim("no_new_credential_shapes")
+    result = asyncio.run(dispatch_evidence_gather(claim, ctx))
+    assert result == {}
+
+
+# ===========================================================================
+# §25-§27 — Integration with ctx_evidence_collector
+# ===========================================================================
+
+
+def test_ctx_collector_dispatches_via_registry_for_priority_a(
+    fresh_registry, tmp_path,
+) -> None:
+    """ctx_evidence_collector now calls dispatch_evidence_gather
+    FIRST for Priority A claim kinds."""
+    from backend.core.ouroboros.governance.verification import (
+        ctx_evidence_collector,
+    )
+    f1 = tmp_path / "a.py"
+    f1.write_text("x = 1\n")
+    ctx = SimpleNamespace(target_files=(str(f1),))
+    claim = _make_claim("file_parses_after_change")
+    result = asyncio.run(ctx_evidence_collector(claim, ctx))
+    # Priority A path engaged → registry self-gathered the file content
+    assert "target_files_post" in result
+    assert len(result["target_files_post"]) == 1
+
+
+def test_ctx_collector_falls_back_to_legacy_for_test_passes(
+    fresh_registry,
+) -> None:
+    """test_passes is NOT registered in the new evidence_collectors
+    registry — falls through to the legacy hardcoded path that
+    reads ctx.validation_passed."""
+    from backend.core.ouroboros.governance.verification import (
+        ctx_evidence_collector,
+    )
+    ctx = SimpleNamespace(validation_passed=True)
+    claim = _make_claim("test_passes")
+    result = asyncio.run(ctx_evidence_collector(claim, ctx))
+    # Legacy path stamped exit_code=0
+    assert result == {"exit_code": 0}
+
+
+def test_ctx_collector_priority_a_empty_does_not_mask_with_legacy(
+    fresh_registry,
+) -> None:
+    """When a Priority A kind's gatherer returns empty (honest
+    INSUFFICIENT), the integration MUST NOT mask with a false-
+    positive legacy path. The post-A semantics are: empty for
+    Priority A means 'we honestly can't evaluate' — not 'fake
+    a key from validation_passed'."""
+    from backend.core.ouroboros.governance.verification import (
+        ctx_evidence_collector,
+    )
+    # No diff_text → no_new_credential_shapes returns empty
+    # AND validation_passed is True (legacy might falsely say "yes")
+    ctx = SimpleNamespace(validation_passed=True)  # no diff_text
+    claim = _make_claim("no_new_credential_shapes")
+    result = asyncio.run(ctx_evidence_collector(claim, ctx))
+    # MUST be empty — honest INSUFFICIENT_EVIDENCE, not faked
+    assert result == {}
+
+
+# ===========================================================================
+# §28 — Authority invariants
+# ===========================================================================
+
+
+def test_no_authority_imports() -> None:
+    from backend.core.ouroboros.governance.verification import (
+        evidence_collectors,
+    )
+    src = inspect.getsource(evidence_collectors)
+    forbidden = (
+        "orchestrator", "phase_runner", "candidate_generator",
+        "iron_gate", "change_engine", "policy", "semantic_guardian",
+    )
+    for token in forbidden:
+        assert (
+            f"from backend.core.ouroboros.governance.{token}" not in src
+        ), f"evidence_collectors must not import {token}"
+        assert (
+            f"import backend.core.ouroboros.governance.{token}" not in src
+        ), f"evidence_collectors must not import {token}"
+
+
+# ===========================================================================
+# §29 — Public API surface
+# ===========================================================================
+
+
+def test_public_api_exposed_from_package() -> None:
+    from backend.core.ouroboros.governance import verification
+    expected = {
+        "EvidenceGatherer",
+        "dispatch_evidence_gather",
+        "evidence_collectors_enabled",
+        "list_evidence_gatherers",
+        "register_evidence_gatherer",
+    }
+    for name in expected:
+        assert name in verification.__all__
+
+
+# ===========================================================================
+# §30 — Defensive — never raises on garbage ctx
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "file_parses_after_change",
+        "test_set_hash_stable",
+        "no_new_credential_shapes",
+    ],
+)
+def test_gatherers_never_raise_on_garbage_ctx(fresh_registry, kind) -> None:
+    """Each gatherer must return a mapping (possibly empty), never
+    raise. Probe with: None ctx, ctx with missing attrs, ctx with
+    wrong-typed attrs."""
+    claim = _make_claim(kind)
+    for ctx in [
+        None,
+        SimpleNamespace(),
+        SimpleNamespace(
+            target_files=42,  # not iterable
+            test_files_pre="not-a-tuple",
+            test_files_post=None,
+            diff_text={"not": "a string"},
+        ),
+    ]:
+        result = asyncio.run(
+            dispatch_evidence_gather(claim, ctx),
+        )
+        assert isinstance(result, Mapping)


### PR DESCRIPTION
## Summary

**Closes Priority F** — the post-soak-#4 finding that postmortems carried Priority A's three default claims correctly (`total_claims=3`) but ALL evaluated to `INSUFFICIENT_EVIDENCE` because the legacy `ctx_evidence_collector` only knew about original Slice 2.4 claim kinds.

## What's new

**NEW module** `verification/evidence_collectors.py`:
- `EvidenceGatherer` frozen registry (mirrors A2 + B1 + C + E patterns)
- `dispatch_evidence_gather(claim, ctx)` — pure async dispatcher
- Three default gatherers for Priority A claim kinds, each with a self-gather fallback when ctx isn't pre-stamped:
  - `file_parses_after_change` — reads from disk if `ctx.target_files_post` not stamped
  - `test_set_hash_stable` — globs `tests/**/*.py` for post; pre needs PLAN-time stamp (honest INSUFFICIENT otherwise)
  - `no_new_credential_shapes` — needs `ctx.diff_text` (honest INSUFFICIENT otherwise — full-file scan would flag pre-existing credentials)

**Integration**: `ctx_evidence_collector` now dispatches FIRST through the registry for Priority A kinds, then falls back to legacy hardcoded paths for `test_passes` / `key_present`. **CRITICAL invariant pinned**: Priority A empty results MUST NOT mask with false-positive legacy paths.

## Test plan

- [x] **47 new Priority F tests** across 30 pin sections
- [x] **608/608 combined** across A+B+C+D+E+F + Phase 2 + verification suite
- [x] Pre-commit file integrity: clean
- [ ] CI green

## Architecture compliance

- ✅ Mirrors all prior priority registry patterns (A2, B1, C, E) — same ergonomics
- ✅ Zero hardcoding — registry is runtime-extensible
- ✅ Zero duplication — reuses existing PropertyClaim shape + ctx attrs
- ✅ Authority invariants AST-pinned (no orchestrator/policy/iron_gate imports)
- ✅ Defensive — never raises; gatherers swallow their own errors
- ✅ Hot-revert: single env knob (`JARVIS_EVIDENCE_COLLECTORS_ENABLED=false`)

## Future follow-ups (not in this PR)

- F2: APPLY-phase ctx enrichment (stamp `target_files_post` / `diff_text` at APPLY-success)
- F3: Pre-PLAN `test_files_pre` stamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime-extensible evidence collector registry and wires it into verification so Priority A claims no longer return INSUFFICIENT_EVIDENCE. Closes Priority F by completing evidence gathering for three default claim kinds.

- **New Features**
  - New module `verification/evidence_collectors.py` with `EvidenceGatherer` registry and async `dispatch_evidence_gather`.
  - Default gatherers added for `file_parses_after_change`, `test_set_hash_stable`, and `no_new_credential_shapes` with sensible fallbacks.
  - `ctx_evidence_collector` now dispatches to the registry first, then falls back to legacy `test_passes`/`key_present`; empty Priority A results are not masked.
  - Master flag `JARVIS_EVIDENCE_COLLECTORS_ENABLED` (default true) enables hot-revert.
  - 47 new tests in `tests/governance/test_evidence_collectors.py`; public API re-exported via `verification.__init__`.

<sup>Written for commit 4da71157c44be808329fd985cb321957157cb23e. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29661?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

