### PR TITLE
feat(venom): Priority C consumer — hypothesize tool integration

### DIFF
--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -970,6 +970,44 @@ _L1_MANIFESTS: Dict[str, ToolManifest] = {
         },
         capabilities=frozenset({"subagent", "read"}),
     ),
+    # Priority C — bounded HypothesisProbe Venom tool. Lets the model
+    # autonomously resolve epistemic ambiguity ("does file X exist?",
+    # "does function Y still call Z?") via a bounded read-only probe
+    # WITHOUT falling back to ask_human. AST-cage enforced read-only
+    # at the strategy level (Slice C primitive); the tool dispatch
+    # itself is gated by JARVIS_HYPOTHESIS_PROBE_ENABLED.
+    "hypothesize": ToolManifest(
+        name="hypothesize", version="1.0",
+        description=(
+            "Probe a hypothesis about the codebase autonomously. Pass "
+            "claim (the proposition), confidence_prior (0..1, your "
+            "current belief), test_strategy ('lookup' / "
+            "'subagent_explore' / 'dry_run'), and expected_signal "
+            "(format depends on strategy: 'file_exists:<path>', "
+            "'contains:<path>:<substring>', 'not_contains:<path>:"
+            "<substring>'). Returns posterior confidence + "
+            "convergence_state ('stable' / 'inconclusive' / "
+            "'budget_exhausted' / 'memorialized_dead' / etc). Use "
+            "this BEFORE making structural decisions you're "
+            "uncertain about — the probe is bounded "
+            "(max 3 iterations, $0.05/probe budget, 30s wall-clock) "
+            "and read-only by AST enforcement. Failed hypotheses "
+            "memorialize so retries on cosmetic-only variants "
+            "short-circuit."
+        ),
+        arg_schema={
+            "claim": {"type": "string"},
+            "confidence_prior": {"type": "number", "default": 0.5},
+            "test_strategy": {
+                "type": "string", "default": "lookup",
+            },
+            "expected_signal": {"type": "string"},
+            "max_iterations": {"type": "integer", "default": 3},
+            "budget_usd": {"type": "number", "default": 0.05},
+            "max_wall_s": {"type": "integer", "default": 30},
+        },
+        capabilities=frozenset({"read"}),
+    ),
 }
 
 
@@ -2921,6 +2959,7 @@ class AsyncProcessToolBackend:
                 "task_create",     # Gap #5 Slice 2 — TaskBoard-backed
                 "task_update",     # Gap #5 Slice 2
                 "task_complete",   # Gap #5 Slice 2
+                "hypothesize",     # Priority C — bounded probe primitive
             ):
                 return await self._run_async_native_tool(call, policy_ctx, timeout, cap)
             return await self._run_sync_tool_async(
@@ -3122,6 +3161,85 @@ class AsyncProcessToolBackend:
                 return await run_task_tool(
                     call, policy_ctx, timeout, cap,
                 )
+
+            elif call.name == "hypothesize":
+                # Priority C — bounded HypothesisProbe. Routes to the
+                # Slice C primitive with the model-supplied claim +
+                # strategy + bounds. Read-only by AST enforcement at
+                # the strategy level; this handler is a thin adapter
+                # that translates ToolCall args → Hypothesis.
+                from backend.core.ouroboros.governance.verification.hypothesis_probe import (
+                    Hypothesis as _Hyp,
+                    get_default_probe as _get_probe,
+                    hypothesis_probe_enabled as _probe_enabled,
+                )
+                if not _probe_enabled():
+                    return ToolResult(
+                        tool_call=call, output="",
+                        error=(
+                            "hypothesize disabled "
+                            "(JARVIS_HYPOTHESIS_PROBE_ENABLED=false)"
+                        ),
+                        status=ToolExecStatus.POLICY_DENIED,
+                    )
+                args = call.arguments or {}
+                try:
+                    claim_text = str(args.get("claim", "") or "").strip()
+                    if not claim_text:
+                        return ToolResult(
+                            tool_call=call, output="",
+                            error="hypothesize requires non-empty claim",
+                            status=ToolExecStatus.EXEC_ERROR,
+                        )
+                    h = _Hyp(
+                        claim=claim_text,
+                        confidence_prior=float(
+                            args.get("confidence_prior", 0.5),
+                        ),
+                        test_strategy=str(
+                            args.get("test_strategy", "lookup") or "lookup",
+                        ).strip().lower(),
+                        expected_signal=str(
+                            args.get("expected_signal", "") or "",
+                        ),
+                        parent_op_id=str(policy_ctx.op_id or ""),
+                        budget_usd=float(
+                            args.get("budget_usd", -1) or -1,
+                        ),
+                        max_iterations=int(
+                            args.get("max_iterations", -1) or -1,
+                        ),
+                        max_wall_s=int(
+                            args.get("max_wall_s", -1) or -1,
+                        ),
+                    )
+                    probe_runner = _get_probe()
+                    result = await asyncio.wait_for(
+                        probe_runner.test(h), timeout=timeout,
+                    )
+                    payload = {
+                        "claim": claim_text,
+                        "confidence_prior": h.confidence_prior,
+                        "confidence_posterior": result.confidence_posterior,
+                        "convergence_state": result.convergence_state,
+                        "iterations_used": result.iterations_used,
+                        "cost_usd": result.cost_usd,
+                        "observation_summary": (
+                            result.observation_summary
+                        ),
+                        "evidence_hash": result.evidence_hash,
+                    }
+                    return ToolResult(
+                        tool_call=call,
+                        output=json.dumps(payload, indent=2)[:cap],
+                        status=ToolExecStatus.SUCCESS,
+                    )
+                except (TypeError, ValueError) as exc:
+                    return ToolResult(
+                        tool_call=call, output="",
+                        error="hypothesize bad arg: " + str(exc)[:120],
+                        status=ToolExecStatus.EXEC_ERROR,
+                    )
 
             return ToolResult(
                 tool_call=call, output=output[:cap],

--- a/tests/governance/test_venom_hypothesize_tool.py
+++ b/tests/governance/test_venom_hypothesize_tool.py
@@ -1,0 +1,389 @@
+"""Priority C consumer — Venom `hypothesize` tool integration tests.
+
+Pins the model-callable HypothesisProbe surface. The model uses the
+``hypothesize`` tool during generation to autonomously resolve
+epistemic ambiguity before making structural decisions.
+
+Pins:
+  §1   Tool manifest registered in _L1_MANIFESTS
+  §2   Manifest declares read-only capability (no subprocess/write/network)
+  §3   Manifest's arg_schema covers all 7 args (claim/prior/strategy/
+       expected_signal/max_iterations/budget_usd/max_wall_s)
+  §4   Tool listed in async-native dispatch path
+  §5   Disabled probe (master flag off) returns POLICY_DENIED
+  §6   Empty claim returns EXEC_ERROR
+  §7   Bad arg types return EXEC_ERROR (no crash)
+  §8   Happy path returns SUCCESS with structured JSON payload
+  §9   Payload contains posterior + convergence_state + iterations
+  §10  Unknown strategy → SUCCESS with convergence_state=unknown_strategy
+       (probe handles gracefully; tool surfaces it correctly)
+  §11  Memorialized hypothesis short-circuits to memorialized_dead
+  §12  Tool respects upstream timeout
+  §13  Tool capability set forbids mutating capabilities
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+# Regrettably long import path — the tool_executor module is hefty.
+from backend.core.ouroboros.governance.tool_executor import (
+    _L1_MANIFESTS,
+    AsyncProcessToolBackend,
+    ToolCall,
+    ToolExecStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# §1-§3 — Manifest contract
+# ---------------------------------------------------------------------------
+
+
+def test_hypothesize_manifest_registered() -> None:
+    assert "hypothesize" in _L1_MANIFESTS
+    m = _L1_MANIFESTS["hypothesize"]
+    assert m.name == "hypothesize"
+    assert m.version == "1.0"
+
+
+def test_hypothesize_capability_is_read_only() -> None:
+    m = _L1_MANIFESTS["hypothesize"]
+    assert m.capabilities == frozenset({"read"})
+    # Defensive: explicitly forbid any mutating capability
+    forbidden = {"write", "subprocess", "network", "mutation"}
+    assert not (m.capabilities & forbidden)
+
+
+def test_hypothesize_arg_schema_covers_seven_args() -> None:
+    m = _L1_MANIFESTS["hypothesize"]
+    expected_args = {
+        "claim",
+        "confidence_prior",
+        "test_strategy",
+        "expected_signal",
+        "max_iterations",
+        "budget_usd",
+        "max_wall_s",
+    }
+    assert set(m.arg_schema.keys()) >= expected_args
+
+
+# ---------------------------------------------------------------------------
+# §4 — Async-native dispatch wiring
+# ---------------------------------------------------------------------------
+
+
+def test_hypothesize_in_async_native_dispatch_path() -> None:
+    """The tool name must be listed in execute_async's async-native
+    tools tuple so it routes to _run_async_native_tool (which calls
+    HypothesisProbe). If this regresses, the handler chain skips
+    hypothesize entirely."""
+    from backend.core.ouroboros.governance import tool_executor as te
+    src = inspect.getsource(te.AsyncProcessToolBackend.execute_async)
+    assert '"hypothesize"' in src
+
+
+# ---------------------------------------------------------------------------
+# §5-§9 — Tool execution paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def probe_enabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_HYPOTHESIS_PROBE_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_HYPOTHESIS_LEDGER_PATH",
+        str(tmp_path / "failed_hypotheses.jsonl"),
+    )
+    yield
+
+
+@pytest.fixture
+def probe_disabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_HYPOTHESIS_PROBE_ENABLED", "false")
+    yield
+
+
+def _build_backend():
+    """Construct a minimal AsyncProcessToolBackend for testing the
+    handler in isolation."""
+    sem = asyncio.Semaphore(1)
+    return AsyncProcessToolBackend(
+        semaphore=sem,
+        approval_provider=None,
+        mcp_client=None,
+    )
+
+
+def _build_policy_ctx(repo_root: Path = Path(".")):
+    """Build a PolicyContext for the handler. Real signature: repo +
+    repo_root + op_id + call_id + round_index + risk_tier."""
+    from backend.core.ouroboros.governance.tool_executor import (
+        PolicyContext,
+    )
+    return PolicyContext(
+        repo="jarvis",
+        repo_root=repo_root,
+        op_id="op-test",
+        call_id="op-test:r0:hypothesize",
+        round_index=0,
+        risk_tier=None,
+    )
+
+
+def test_hypothesize_master_off_returns_policy_denied(
+    probe_disabled,
+) -> None:
+    backend = _build_backend()
+    policy_ctx = _build_policy_ctx()
+    call = ToolCall(
+        name="hypothesize",
+        arguments={
+            "claim": "x exists",
+            "expected_signal": "file_exists:foo.py",
+        },
+    )
+    result = asyncio.run(
+        backend._run_async_native_tool(
+            call, policy_ctx, timeout=30.0, cap=8192,
+        ),
+    )
+    assert result.status == ToolExecStatus.POLICY_DENIED
+    assert "disabled" in result.error.lower()
+
+
+def test_hypothesize_empty_claim_returns_exec_error(
+    probe_enabled,
+) -> None:
+    backend = _build_backend()
+    policy_ctx = _build_policy_ctx()
+    call = ToolCall(
+        name="hypothesize",
+        arguments={"claim": "", "expected_signal": "x"},
+    )
+    result = asyncio.run(
+        backend._run_async_native_tool(
+            call, policy_ctx, timeout=30.0, cap=8192,
+        ),
+    )
+    assert result.status == ToolExecStatus.EXEC_ERROR
+    assert "non-empty" in result.error.lower() or "claim" in result.error.lower()
+
+
+def test_hypothesize_bad_arg_type_returns_exec_error(
+    probe_enabled,
+) -> None:
+    backend = _build_backend()
+    policy_ctx = _build_policy_ctx()
+    call = ToolCall(
+        name="hypothesize",
+        arguments={
+            "claim": "test",
+            "expected_signal": "x",
+            "confidence_prior": "not-a-number",  # bad
+        },
+    )
+    result = asyncio.run(
+        backend._run_async_native_tool(
+            call, policy_ctx, timeout=30.0, cap=8192,
+        ),
+    )
+    # Should NOT crash; should EXEC_ERROR cleanly
+    assert result.status == ToolExecStatus.EXEC_ERROR
+
+
+def test_hypothesize_happy_path_returns_structured_json(
+    probe_enabled, tmp_path,
+) -> None:
+    """End-to-end: real file exists → CONFIRMED → posterior > prior."""
+    target = tmp_path / "real.py"
+    target.write_text("x = 1\n")
+    backend = _build_backend()
+    policy_ctx = _build_policy_ctx()
+    call = ToolCall(
+        name="hypothesize",
+        arguments={
+            "claim": "real.py exists",
+            "confidence_prior": 0.5,
+            "test_strategy": "lookup",
+            "expected_signal": f"file_exists:{target}",
+            "max_iterations": 1,
+        },
+    )
+    result = asyncio.run(
+        backend._run_async_native_tool(
+            call, policy_ctx, timeout=30.0, cap=8192,
+        ),
+    )
+    assert result.status == ToolExecStatus.SUCCESS
+    payload = json.loads(result.output)
+    assert payload["claim"] == "real.py exists"
+    assert payload["confidence_prior"] == 0.5
+    assert payload["confidence_posterior"] > 0.5  # CONFIRMED moves up
+    assert payload["iterations_used"] == 1
+    assert "convergence_state" in payload
+    assert "evidence_hash" in payload
+
+
+def test_hypothesize_payload_contract(probe_enabled, tmp_path) -> None:
+    """Verify the JSON payload has all the required keys for the
+    model to parse the result."""
+    target = tmp_path / "x.py"
+    target.write_text("y = 2\n")
+    backend = _build_backend()
+    policy_ctx = _build_policy_ctx()
+    call = ToolCall(
+        name="hypothesize",
+        arguments={
+            "claim": "x.py contains y",
+            "confidence_prior": 0.6,
+            "test_strategy": "lookup",
+            "expected_signal": f"contains:{target}:y =",
+        },
+    )
+    result = asyncio.run(
+        backend._run_async_native_tool(
+            call, policy_ctx, timeout=30.0, cap=8192,
+        ),
+    )
+    payload = json.loads(result.output)
+    expected_keys = {
+        "claim", "confidence_prior", "confidence_posterior",
+        "convergence_state", "iterations_used", "cost_usd",
+        "observation_summary", "evidence_hash",
+    }
+    assert set(payload.keys()) == expected_keys
+
+
+# ---------------------------------------------------------------------------
+# §10 — Unknown strategy graceful handling
+# ---------------------------------------------------------------------------
+
+
+def test_hypothesize_unknown_strategy_succeeds_with_diagnostic(
+    probe_enabled,
+) -> None:
+    backend = _build_backend()
+    policy_ctx = _build_policy_ctx()
+    call = ToolCall(
+        name="hypothesize",
+        arguments={
+            "claim": "x",
+            "test_strategy": "no-such-strategy",
+            "expected_signal": "file_exists:foo",
+        },
+    )
+    result = asyncio.run(
+        backend._run_async_native_tool(
+            call, policy_ctx, timeout=30.0, cap=8192,
+        ),
+    )
+    # Tool succeeds; the probe's convergence_state encodes the failure
+    assert result.status == ToolExecStatus.SUCCESS
+    payload = json.loads(result.output)
+    assert payload["convergence_state"] == "unknown_strategy"
+
+
+# ---------------------------------------------------------------------------
+# §11 — Memorialization short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_hypothesize_memorialized_short_circuits(
+    probe_enabled, tmp_path,
+) -> None:
+    """When a hypothesis was previously declared dead, retrying the
+    same hypothesis (cosmetic-variant or not) short-circuits to
+    memorialized_dead — the cage's adversarial-retry defense."""
+    from backend.core.ouroboros.governance.verification.hypothesis_probe import (
+        Hypothesis as _Hyp,
+        memorialize_hypothesis,
+        ProbeResult as _PR,
+    )
+    h = _Hyp(
+        claim="dead-on-arrival",
+        confidence_prior=0.5,
+        test_strategy="lookup",
+        expected_signal="file_exists:nope",
+    )
+    fake_result = _PR(
+        confidence_posterior=0.5, observation_summary="dead",
+        cost_usd=0.0, iterations_used=3,
+        convergence_state="inconclusive", evidence_hash="x",
+    )
+    memorialize_hypothesis(h, fake_result)
+
+    backend = _build_backend()
+    policy_ctx = _build_policy_ctx()
+    call = ToolCall(
+        name="hypothesize",
+        arguments={
+            "claim": "dead-on-arrival",
+            "test_strategy": "lookup",
+            "expected_signal": "file_exists:nope",
+        },
+    )
+    result = asyncio.run(
+        backend._run_async_native_tool(
+            call, policy_ctx, timeout=30.0, cap=8192,
+        ),
+    )
+    assert result.status == ToolExecStatus.SUCCESS
+    payload = json.loads(result.output)
+    assert payload["convergence_state"] == "memorialized_dead"
+    assert payload["iterations_used"] == 0
+    assert payload["cost_usd"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# §12 — Timeout handling
+# ---------------------------------------------------------------------------
+
+
+def test_hypothesize_respects_upstream_timeout(probe_enabled) -> None:
+    """Tool wraps probe.test in asyncio.wait_for with the upstream
+    timeout. Verifying that's hooked up correctly — small timeout
+    should bound the call."""
+    backend = _build_backend()
+    policy_ctx = _build_policy_ctx()
+    call = ToolCall(
+        name="hypothesize",
+        arguments={
+            "claim": "x",
+            "test_strategy": "lookup",
+            "expected_signal": "file_exists:foo",
+        },
+    )
+    # 0.001s timeout — should TIMEOUT or complete extremely fast
+    # since the probe is lightweight; either way no crash
+    result = asyncio.run(
+        backend._run_async_native_tool(
+            call, policy_ctx, timeout=0.001, cap=8192,
+        ),
+    )
+    assert result.status in (
+        ToolExecStatus.SUCCESS,
+        ToolExecStatus.TIMEOUT,
+        ToolExecStatus.EXEC_ERROR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# §13 — Authority invariant: capability set forbids mutating
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_capability_is_strictly_read() -> None:
+    """The hypothesize tool must declare ONLY 'read' capability.
+    This is the cage's contract — any future addition of 'write',
+    'subprocess', 'network', etc. would break the authority
+    promise that hypothesize is bounded read-only."""
+    m = _L1_MANIFESTS["hypothesize"]
+    assert m.capabilities == frozenset({"read"})


### PR DESCRIPTION
## Summary

Model-callable HypothesisProbe surface. The model can now call \`hypothesize\` during generation to autonomously resolve epistemic ambiguity ("does file X exist?", "does function Y still call Z?") via a bounded read-only probe — WITHOUT falling back to ask_human and WITHOUT violating the Zero-Trust boundary.

## What's new

Three integration sites in \`tool_executor.py\`:

1. **ToolManifest** registered in \`_L1_MANIFESTS\` with strict \`capabilities=frozenset({"read"})\` (test-pinned invariant)
2. **Async-native dispatch** — \`"hypothesize"\` added to the routing tuple
3. **Handler** in \`_run_async_native_tool\` — translates ToolCall args → Hypothesis → \`get_default_probe().test()\` → structured JSON payload

## Tool contract (model perspective)

```json
{
  "claim": "real.py exists",
  "confidence_prior": 0.5,
  "test_strategy": "lookup",
  "expected_signal": "file_exists:real.py"
}
```
Returns:
```json
{
  "claim": "...",
  "confidence_prior": 0.5,
  "confidence_posterior": 0.75,
  "convergence_state": "stable",
  "iterations_used": 1,
  "cost_usd": 0.0,
  "observation_summary": "...",
  "evidence_hash": "..."
}
```

## Test plan

- [x] **13 new tests** across 13 pin sections (manifest + read-only invariant + arg schema + dispatch wiring + master-off + empty-claim + bad-arg + happy path + payload contract + unknown strategy + memorialized short-circuit + timeout + capability strictly-read)
- [x] **225/225 combined** across F + F2/F3 + C + Venom tool + Phase 2 + verification
- [ ] CI green

## Hot-revert

\`JARVIS_HYPOTHESIS_PROBE_ENABLED=false\` — tool returns \`POLICY_DENIED\` uniformly; model falls back to pre-C reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a model-callable hypothesize tool that lets the model verify codebase claims via a bounded, read-only probe. This removes ask_human fallbacks for simple checks while respecting our zero‑trust boundary.

- **New Features**
  - Register "hypothesize" in `_L1_MANIFESTS` with capabilities `{"read"}` and a 7‑arg schema.
  - Route via async-native dispatch and handle in `_run_async_native_tool`.
  - Gate with `JARVIS_HYPOTHESIS_PROBE_ENABLED`; when off, return `POLICY_DENIED`.
  - Validate args and call `get_default_probe().test()` under the upstream timeout.
  - Return structured JSON: claim, prior, posterior, convergence_state, iterations_used, cost_usd, observation_summary, evidence_hash; memorialized hypotheses short‑circuit and unknown strategies surface as `convergence_state: "unknown_strategy"`.

<sup>Written for commit 967ef3b117b76ca35f8c0fa58edddbfb814bd424. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29683?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

