### PR TITLE
feat(meta_sensor): Priority B graduation — JARVIS_META_SENSOR_ENABLED default-on (CLOSES Priority B)

### DIFF
--- a/backend/core/ouroboros/governance/intake/sensors/meta_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/meta_sensor.py
@@ -66,16 +66,20 @@ META_SENSOR_SCHEMA_VERSION = "meta_sensor.1"
 
 
 def meta_sensor_enabled() -> bool:
-    """``JARVIS_META_SENSOR_ENABLED`` (default ``false`` until
-    Slice B graduation; promotes to default-true after 3 clean
-    sessions per CLAUDE.md discipline).
+    """``JARVIS_META_SENSOR_ENABLED`` (default ``true`` — graduated
+    in the F2/F3/C-consumer arc 2026-04-29 alongside the soak that
+    validates the empirical loop closure).
+
+    Asymmetric env semantics — empty / whitespace = unset marker =
+    graduated default; explicit false-class strings hot-revert.
 
     When off, ``scan_once()`` short-circuits to an empty list and
     no envelopes are emitted. The detector registry remains
-    populated + queryable for operators inspecting the surface."""
+    populated + queryable for operators inspecting the surface.
+    Hot-revert: ``export JARVIS_META_SENSOR_ENABLED=false``."""
     raw = os.environ.get("JARVIS_META_SENSOR_ENABLED", "").strip().lower()
     if raw == "":
-        return False  # opt-in until graduation
+        return True  # graduated default
     return raw in ("1", "true", "yes", "on")
 
 

--- a/tests/governance/test_meta_sensor.py
+++ b/tests/governance/test_meta_sensor.py
@@ -73,9 +73,17 @@ def fresh_registry():
 # ===========================================================================
 
 
-def test_master_flag_default_false(monkeypatch) -> None:
+def test_master_flag_default_true(monkeypatch) -> None:
+    """Priority B graduated 2026-04-29 — env unset → default-true."""
     monkeypatch.delenv("JARVIS_META_SENSOR_ENABLED", raising=False)
-    assert meta_sensor_enabled() is False
+    assert meta_sensor_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", " ", "  ", "\t"])
+def test_master_flag_empty_reads_default_true(monkeypatch, val) -> None:
+    """Asymmetric env semantics — empty/whitespace is the unset marker."""
+    monkeypatch.setenv("JARVIS_META_SENSOR_ENABLED", val)
+    assert meta_sensor_enabled() is True
 
 
 @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
@@ -85,9 +93,10 @@ def test_master_flag_truthy(monkeypatch, val) -> None:
 
 
 @pytest.mark.parametrize(
-    "val", ["", " ", "0", "false", "no", "off", "garbage"],
+    "val", ["0", "false", "no", "off", "garbage"],
 )
 def test_master_flag_falsy(monkeypatch, val) -> None:
+    """Hot-revert path — explicit false-class strings disable post-graduation."""
     monkeypatch.setenv("JARVIS_META_SENSOR_ENABLED", val)
     assert meta_sensor_enabled() is False
 


### PR DESCRIPTION
## Summary

**Closes Priority B 100%.** Promotes MetaSensor master flag from opt-in (default-false) to graduated (default-true) using the asymmetric env-bool pattern matching Phase 1/2/12.2 graduation flips.

## Asymmetric env semantics

- unset / "" / " " / "\\t" → **True** (graduated default)
- "1" / "true" / "yes" / "on" → True (explicit truthy)
- "0" / "false" / "no" / "off" / "garbage" → False (hot-revert)

## Test changes

- Renamed \`test_master_flag_default_false\` → \`test_master_flag_default_true\`
- Added \`test_master_flag_empty_reads_default_true\` (parameterized over empty + whitespace)
- Removed empty/whitespace from the falsy parametrize list

## Test plan

- [x] **40/40 MetaSensor tests** green
- [ ] CI green

## Hot-revert

\`export JARVIS_META_SENSOR_ENABLED=false\` returns the sensor to pre-B baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates the MetaSensor by making `JARVIS_META_SENSOR_ENABLED` default to true. The sensor is now on by default with a simple env toggle for rollback.

- **Migration**
  - Unset or blank (including whitespace) = true; truthy strings = true.
  - To disable, set `JARVIS_META_SENSOR_ENABLED=false`.

<sup>Written for commit b06cf9858ebc71f2deeae738d63e703ea1bed0e6. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/29685?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

