### PR TITLE
feat: Integrate swe-path preflight (cb282 folded) and path hardening; drop redundant provider_preflight

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -2175,6 +2175,56 @@ class BattleTestHarness:
                         exc_info=True,
                     )
 
+                # ── SWE-Bench Path↔Advisor pre-flight (cb2825326a) ──
+                # Strict advisor-envelope fail-closed: asserts the
+                # SWE-Bench worktree base + repo cache resolve UNDER
+                # the operation_advisor anchor (project_root). A
+                # TMPDIR base that escaped the anchor is exactly what
+                # contaminated the shared tree in bt-2026-05-17-002318.
+                # Folded into the SAME canonical _preflight_refused
+                # gate (no parallel guard). §33.1 default-FALSE →
+                # byte-identical no-op when off. NEVER raises.
+                try:
+                    from backend.core.ouroboros.battle_test.swe_path_preflight import (  # noqa: E501
+                        SwePathVerdict,
+                        assess_swe_path_readiness,
+                    )
+
+                    _gls = self._governed_loop_service
+                    _cfg = (
+                        getattr(_gls, "_config", None)
+                        if _gls is not None
+                        else None
+                    )
+                    _proj_root = (
+                        getattr(_cfg, "project_root", None) or Path.cwd()
+                    )
+                    _swe_path_verdict = await assess_swe_path_readiness(
+                        str(self._session_dir),
+                        project_root=Path(_proj_root),
+                    )
+                    logger.info(
+                        "[Harness] swe-path preflight: verdict=%s",
+                        _swe_path_verdict.value,
+                    )
+                    if _swe_path_verdict == (
+                        SwePathVerdict.REFUSE_OUTSIDE_ANCHOR
+                    ):
+                        logger.error(
+                            "[Harness] swe-path preflight REFUSED — "
+                            "worktree base outside advisor anchor; "
+                            "skipping SWE-Bench-Pro inject (drop "
+                            "TMPDIR overrides).",
+                        )
+                        _preflight_refused = True
+                except Exception:  # noqa: BLE001 — gate never fails boot
+                    logger.debug(
+                        "[Harness] swe-path preflight raised — "
+                        "proceeding (runtime fail-closed guard is "
+                        "authoritative)",
+                        exc_info=True,
+                    )
+
                 if _preflight_refused:
                     _swebp_verdict = (
                         SWEBenchProInjectionVerdict.SKIPPED_DISABLED

--- a/backend/core/ouroboros/battle_test/swe_path_preflight.py
+++ b/backend/core/ouroboros/battle_test/swe_path_preflight.py
@@ -1,0 +1,181 @@
+"""
+SWE-Bench path↔advisor preflight (canonical, single seam)
+=========================================================
+Boot-time assertion that the effective SWE-Bench worktree base + repo
+cache resolve UNDER the operation_advisor allowed-prefix anchor (the
+orchestrator project_root).  Runs strictly before the SWE-Bench-Pro
+inject (the spend path), beside the provider-readiness gate.
+
+Root cause it closes (session bt-2026-05-17-002318): a ``$TMPDIR``
+worktree base escaped the advisor anchor, ``resolve_envelope_repo_root``
+returned None, the advisor + generator fell back to the JARVIS tree, the
+model edited the wrong repo.  This refuses the spend before a dollar
+burns when the configuration would put worktrees outside the anchor.
+
+Composition only — no parallel prefix math:
+  * worktree base / cache  : per_problem_harness.worktree_base_path /
+                             repo_cache_path  (canonical env knobs)
+  * anchor classification  : operation_advisor.envelope_repo_root_status
+                             (the single status owner)
+
+NEVER raises.  Default-FALSE master flag → byte-identical no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+
+from backend.core.ouroboros.governance.operation_advisor import (
+    EVIDENCE_REPO_ROOT_KEY,
+    RepoRootPromiseStatus,
+    envelope_repo_root_status,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.per_problem_harness import (  # noqa: E501
+    repo_cache_path,
+    worktree_base_path,
+)
+
+logger = logging.getLogger(__name__)
+
+_MASTER_ENV = "JARVIS_BATTLE_PREFLIGHT_SWE_PATH_ENABLED"
+
+
+class SwePathVerdict(Enum):
+    PROCEED = "proceed"
+    PROCEED_DISABLED = "proceed_disabled_by_env"
+    PROCEED_FEATURE_OFF = "proceed_advisor_worktree_feature_off"
+    REFUSE_OUTSIDE_ANCHOR = "refuse_worktree_base_outside_anchor"
+
+
+@dataclass
+class SwePathReadinessReport:
+    timestamp: str
+    verdict: str
+    under_project_root: bool
+    project_root: str
+    worktree_base: str
+    repo_cache: str
+    details: str
+
+
+def _classify(base: Path, project_root: Path) -> RepoRootPromiseStatus:
+    """Classify one base dir via the canonical status owner.
+
+    The base is ensured to exist (mkdir) so ``resolve_envelope_repo_root``'s
+    ``exists()/is_dir()`` check is meaningful — a not-yet-created default
+    dir must not masquerade as a rejection.
+    """
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    evidence = json.dumps({EVIDENCE_REPO_ROOT_KEY: str(base)})
+    status, _resolved, _raw = envelope_repo_root_status(
+        evidence, project_root=project_root
+    )
+    return status
+
+
+async def assess_swe_path_readiness(
+    session_dir: str, *, project_root: Path
+) -> SwePathVerdict:
+    """Assert the SWE-Bench worktree/cache bases sit under the advisor
+    anchor. NEVER raises.
+
+    REFUSE_OUTSIDE_ANCHOR iff a base is *promised + rejected* (the
+    contamination configuration).  Feature-off → PROCEED_FEATURE_OFF
+    (warn; the runtime fail-closed guard is authoritative either way).
+    """
+    if os.environ.get(_MASTER_ENV, "false").lower() != "true":
+        return SwePathVerdict.PROCEED_DISABLED
+
+    report = SwePathReadinessReport(
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        verdict="",
+        under_project_root=False,
+        project_root="",
+        worktree_base="",
+        repo_cache="",
+        details="",
+    )
+    try:
+        anchor = Path(project_root).resolve(strict=False)
+        wt = worktree_base_path().resolve(strict=False)
+        rc = repo_cache_path().resolve(strict=False)
+        report.project_root = str(anchor)
+        report.worktree_base = str(wt)
+        report.repo_cache = str(rc)
+
+        statuses = {
+            "worktree_base": _classify(wt, anchor),
+            "repo_cache": _classify(rc, anchor),
+        }
+        rejected = [k for k, v in statuses.items()
+                    if v is RepoRootPromiseStatus.REJECTED]
+        feature_off = any(
+            v is RepoRootPromiseStatus.NO_PROMISE for v in statuses.values()
+        )
+
+        if rejected:
+            report.verdict = SwePathVerdict.REFUSE_OUTSIDE_ANCHOR.value
+            report.under_project_root = False
+            report.details = (
+                f"{rejected} escaped the advisor anchor — refusing "
+                f"SWE-Bench inject (would contaminate the shared tree). "
+                f"Drop TMPDIR WORKTREE_BASE_PATH/REPO_CACHE_PATH overrides."
+            )
+            _write_report(session_dir, report)
+            logger.warning(
+                "[SwePathPreflight] REFUSE — %s outside anchor %s",
+                rejected, anchor,
+            )
+            return SwePathVerdict.REFUSE_OUTSIDE_ANCHOR
+
+        if feature_off:
+            report.verdict = SwePathVerdict.PROCEED_FEATURE_OFF.value
+            report.under_project_root = True
+            report.details = (
+                "Advisor worktree-aware feature OFF — boot anchor assert "
+                "indeterminate; runtime fail-closed guard authoritative."
+            )
+            _write_report(session_dir, report)
+            logger.info("[SwePathPreflight] feature-off — PROCEED + WARN")
+            return SwePathVerdict.PROCEED_FEATURE_OFF
+
+        report.verdict = SwePathVerdict.PROCEED.value
+        report.under_project_root = True
+        report.details = "Worktree base + repo cache under project_root."
+        _write_report(session_dir, report)
+        logger.info(
+            "[SwePathPreflight] PROCEED — under_project_root=True"
+        )
+        return SwePathVerdict.PROCEED
+
+    except Exception as e:  # noqa: BLE001 — gate MUST NEVER raise
+        logger.error(
+            "[SwePathPreflight] internal error: %s — PROCEED+WARN "
+            "(runtime guard authoritative)", e,
+        )
+        report.verdict = SwePathVerdict.PROCEED_FEATURE_OFF.value
+        report.under_project_root = True
+        report.details = f"Internal exception: {e!s}"
+        _write_report(session_dir, report)
+        return SwePathVerdict.PROCEED_FEATURE_OFF
+
+
+def _write_report(session_dir: str, report: SwePathReadinessReport) -> None:
+    """Write forensic JSON to the session dir. Never raises."""
+    try:
+        if not os.path.exists(session_dir):
+            os.makedirs(session_dir, exist_ok=True)
+        path = os.path.join(session_dir, "swe_path_readiness.json")
+        with open(path, "w") as f:
+            json.dump(asdict(report), f, indent=2)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Failed to write swe_path_readiness.json: %s", e)

--- a/backend/core/ouroboros/governance/operation_advisor.py
+++ b/backend/core/ouroboros/governance/operation_advisor.py
@@ -667,6 +667,127 @@ def resolve_envelope_repo_root(
     return None
 
 
+# ===========================================================================
+# Phase B — envelope repo_root PROMISE status (single canonical seam)
+# ===========================================================================
+#
+# ``resolve_envelope_repo_root`` returns ``None`` for THREE distinct
+# situations callers previously could not tell apart — and the silent
+# collapse of the third into a byte-identical project_root fallback is
+# the contamination root cause (session bt-2026-05-17-002318: a $TMPDIR
+# worktree escaped the anchor, the resolver returned None, advisor +
+# generator fell back to the JARVIS tree, the model edited the wrong
+# repo).  This is the ONE place that classifies the three:
+#
+#   NO_PROMISE  — feature off OR no ``repo_root`` in evidence.  A
+#                 byte-identical project_root fallback is CORRECT here.
+#   RESOLVED    — a ``repo_root`` was promised AND resolves under the
+#                 anchor.  Use the returned path.
+#   REJECTED    — a ``repo_root`` was promised, the worktree-aware
+#                 feature is ON, but the path escaped every allowed
+#                 prefix.  Isolation promised and broken: callers MUST
+#                 fail closed (§1 Boundary / §6 Iron Gate mirror of the
+#                 L3 subagent_scheduler / RepairTree discipline — NEVER
+#                 fall back to the shared tree).
+#
+# Both advisor sites (orchestrator.py parallel path + classify_runner.py
+# primary production path) compose this, so the "threaded one site but
+# not the other" bug class the classify_runner comment documents cannot
+# recur — one prefix-math owner (``resolve_envelope_repo_root``), one
+# status owner (this).
+
+
+class RepoRootPromiseStatus(str, Enum):
+    """Closed taxonomy for the envelope repo_root promise."""
+
+    NO_PROMISE = "no_promise"   # byte-identical legacy fallback OK
+    RESOLVED = "resolved"       # promised + trusted
+    REJECTED = "rejected"       # promised + escaped anchor → fail closed
+
+
+class EnvelopeRepoRootRejected(Exception):
+    """A promised isolated ``repo_root`` escaped the advisor anchor.
+
+    Callers convert this into the canonical infra-terminal (advance to
+    POSTMORTEM, ``failure_class='infra'``) — they MUST NOT fall back to
+    the shared project_root tree.
+    """
+
+    def __init__(self, raw_repo_root: str) -> None:
+        self.raw_repo_root = raw_repo_root
+        super().__init__(
+            f"swebp_repo_root_rejected: promised isolated repo_root "
+            f"{raw_repo_root!r} escaped the advisor allowed-prefix "
+            f"anchor — refusing silent fallback to the shared tree"
+        )
+
+
+def envelope_repo_root_status(
+    intake_evidence_json: str,
+    *,
+    project_root: Path,
+    extra_allowlist: Optional[Tuple[Path, ...]] = None,
+) -> Tuple["RepoRootPromiseStatus", Optional[Path], str]:
+    """Classify the envelope repo_root promise. NEVER raises.
+
+    Returns ``(status, resolved_path_or_None, raw_repo_root_str)``.
+    Composes :func:`resolve_envelope_repo_root` verbatim — no parallel
+    prefix math.  Feature-off / no-promise collapse to ``NO_PROMISE`` so
+    byte-identity holds when the worktree-aware advisor flag is OFF
+    (only a promised-AND-rejected path under an enabled feature is
+    ``REJECTED``).
+    """
+    raw = ""
+    try:
+        if intake_evidence_json:
+            _ev = json.loads(intake_evidence_json)
+            if isinstance(_ev, dict):
+                _r = _ev.get(EVIDENCE_REPO_ROOT_KEY)
+                if isinstance(_r, str):
+                    raw = _r.strip()
+    except (ValueError, TypeError):
+        raw = ""
+
+    if not raw:
+        return RepoRootPromiseStatus.NO_PROMISE, None, ""
+
+    resolved = resolve_envelope_repo_root(
+        intake_evidence_json,
+        project_root=project_root,
+        extra_allowlist=extra_allowlist,
+    )
+    if resolved is not None:
+        return RepoRootPromiseStatus.RESOLVED, resolved, raw
+
+    if not _worktree_aware_enabled():
+        return RepoRootPromiseStatus.NO_PROMISE, None, raw
+    return RepoRootPromiseStatus.REJECTED, None, raw
+
+
+def guard_envelope_repo_root(
+    intake_evidence_json: str,
+    *,
+    project_root: Path,
+    extra_allowlist: Optional[Tuple[Path, ...]] = None,
+) -> Optional[Path]:
+    """Composable fail-closed guard for the two advisor call sites.
+
+    Returns the trusted path (RESOLVED) or ``None`` (NO_PROMISE — caller
+    falls back byte-identically, unchanged).  Raises
+    :class:`EnvelopeRepoRootRejected` on REJECTED so the caller drives
+    the canonical infra-terminal instead of silently editing the shared
+    tree.
+    """
+    status, resolved, raw = envelope_repo_root_status(
+        intake_evidence_json,
+        project_root=project_root,
+        extra_allowlist=extra_allowlist,
+    )
+    if status is RepoRootPromiseStatus.REJECTED:
+        raise EnvelopeRepoRootRejected(raw)
+    return resolved
+
+
 class AdvisoryDecision(str, Enum):
     RECOMMEND = "recommend"            # Proceed normally
     CAUTION = "caution"                # Proceed but inject warnings into prompt
@@ -1270,4 +1391,8 @@ __all__ = [
     "infer_read_only_intent",
     "register_flags",
     "resolve_envelope_repo_root",
+    "RepoRootPromiseStatus",
+    "EnvelopeRepoRootRejected",
+    "envelope_repo_root_status",
+    "guard_envelope_repo_root",
 ]

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -1900,7 +1900,8 @@ class GovernedOrchestrator:
                     OperationAdvisor,
                     AdvisoryDecision,
                     infer_read_only_intent,
-                    resolve_envelope_repo_root,
+                    guard_envelope_repo_root,
+                    EnvelopeRepoRootRejected,
                 )
                 # Stamp read-only intent onto the hash-chained context BEFORE
                 # advising. The Advisor's bypass of blast_radius + test_coverage
@@ -1926,7 +1927,10 @@ class GovernedOrchestrator:
                 # category. Returns None when the flag is off / evidence is
                 # missing / the path fails the untrusted-input safety
                 # validation; advise() then falls back byte-identically.
-                _adv_repo_root = resolve_envelope_repo_root(
+                # B2 fail-closed: a promised-but-anchor-rejected repo_root
+                # raises EnvelopeRepoRootRejected (handled below) instead
+                # of silently falling back to the shared project_root tree.
+                _adv_repo_root = guard_envelope_repo_root(
                     ctx.intake_evidence_json,
                     project_root=self._config.project_root,
                 )
@@ -1993,6 +1997,22 @@ class GovernedOrchestrator:
                         _advisory.decision.value, _advisory.risk_score,
                         _advisory.reasons[0] if _advisory.reasons else "no specific reason",
                     )
+            except EnvelopeRepoRootRejected as _rr_exc:
+                # §1 Boundary / §6 Iron Gate: isolation was promised and
+                # broken — terminate infra-FAILED, NEVER fall back to the
+                # shared tree (the bt-2026-05-17-002318 contamination).
+                logger.warning(
+                    "[Orchestrator] FAIL-CLOSED op=%s: %s — advancing "
+                    "POSTMORTEM (no shared-tree fallback)",
+                    ctx.op_id, _rr_exc,
+                )
+                if _serpent:
+                    await _serpent.stop(success=False)
+                ctx = ctx.advance(
+                    OperationPhase.POSTMORTEM,
+                    terminal_reason_code="swebp_repo_root_rejected",
+                )
+                return ctx
             except ImportError:
                 pass
             except Exception:

--- a/backend/core/ouroboros/governance/phase_runners/classify_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/classify_runner.py
@@ -260,7 +260,7 @@ class CLASSIFYRunner(PhaseRunner):
         try:
             from backend.core.ouroboros.governance.operation_advisor import (
                 OperationAdvisor, AdvisoryDecision, infer_read_only_intent,
-                resolve_envelope_repo_root,
+                guard_envelope_repo_root, EnvelopeRepoRootRejected,
             )
             # Stamp read-only intent onto the hash-chained context BEFORE
             # advising. The Advisor's bypass of blast_radius + test_coverage
@@ -294,7 +294,10 @@ class CLASSIFYRunner(PhaseRunner):
             # classify_runner path that actually runs in production —
             # did not, so the 6-file SWE-Bench-Pro worktree silently
             # triggered a full project_root scan.
-            _adv_repo_root = resolve_envelope_repo_root(
+            # B2 fail-closed: promised-but-anchor-rejected repo_root raises
+            # EnvelopeRepoRootRejected (handled below) — no silent
+            # fallback to the shared project_root tree.
+            _adv_repo_root = guard_envelope_repo_root(
                 ctx.intake_evidence_json,
                 project_root=orch._config.project_root,
             )
@@ -433,6 +436,28 @@ class CLASSIFYRunner(PhaseRunner):
                     _advisory.decision.value, _advisory.risk_score,
                     _advisory.reasons[0] if _advisory.reasons else "no specific reason",
                 )
+        except EnvelopeRepoRootRejected as _rr_exc:
+            # §1 Boundary / §6 Iron Gate: isolation promised + broken —
+            # terminate infra-FAILED, NEVER fall back to the shared tree
+            # (the bt-2026-05-17-002318 contamination root cause).
+            logger.warning(
+                "[Orchestrator] FAIL-CLOSED op=%s: %s — POSTMORTEM "
+                "(no shared-tree fallback)",
+                ctx.op_id, _rr_exc,
+            )
+            if _serpent:
+                await _serpent.stop(success=False)
+            ctx = ctx.advance(
+                OperationPhase.POSTMORTEM,
+                terminal_reason_code="swebp_repo_root_rejected",
+            )
+            return PhaseResult(
+                next_ctx=ctx,
+                next_phase=None,
+                status="fail",
+                reason="swebp_repo_root_rejected",
+                artifacts={"advisory": None, "consciousness_bridge": None},
+            )
         except ImportError:
             pass
         except Exception:

--- a/backend/core/ouroboros/governance/swe_bench_pro/per_problem_harness.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/per_problem_harness.py
@@ -118,7 +118,14 @@ class HarnessOutcome(str, enum.Enum):
     READY = "ready"
     MASTER_FLAG_OFF = "master_flag_off"
     CLONE_FAILED = "clone_failed"
-    CHECKOUT_FAILED = "checkout_failed"
+    # Renamed from the legacy CHECKOUT_FAILED misnomer (Phase C): there
+    # is no `git checkout` step — the worktree is created via
+    # `git worktree add -b <branch> <path> <commit>`. Every failure this
+    # covers (invalid base_commit, orphan branch-exists, path nesting,
+    # generic) IS a worktree-creation failure. Mirrors the L3
+    # `worktree_create_failed:` precedent. Pure diagnostic label — no
+    # consumer switches on it (all check `!= READY`).
+    WORKTREE_CREATE_FAILED = "worktree_create_failed"
     TEST_PATCH_FAILED = "test_patch_failed"
 
 
@@ -362,7 +369,18 @@ async def _ensure_repo_cached(repo_url: str) -> Optional[Path]:
 
 
 def _worktree_path_for(instance_id: str) -> Path:
-    return worktree_base_path() / _sanitize_for_filename(instance_id)
+    # ABSOLUTE (Phase C root-cause fix): `git worktree add` runs with
+    # cwd=cached_repo, so a RELATIVE base resolves against the cache dir
+    # and nests the worktree INSIDE the cache (the bt-2026-05-17-013346
+    # root cause: nested worktree → _apply_test_patch ran in an empty
+    # cwd → spurious test_patch_failed + orphan-branch cache poisoning).
+    # .resolve() anchors it at the process root — the SAME resolution
+    # B1 swe_path_preflight + operation_advisor already apply, so all
+    # three agree on one absolute location. Idempotent for an absolute
+    # operator override (sandbox-ON TMPDIR case). No hardcoding.
+    return (
+        worktree_base_path() / _sanitize_for_filename(instance_id)
+    ).resolve()
 
 
 def _branch_name_for(instance_id: str) -> str:
@@ -377,16 +395,44 @@ async def _create_problem_worktree(
     wt_path = _worktree_path_for(instance_id)
     branch_name = _branch_name_for(instance_id)
     try:
+        # Hardened cleanup (Phase C): rc-check both removals and SURFACE
+        # failures — silent orphaning is what poisoned the cache and
+        # cost a diagnostic cycle.
         if wt_path.is_dir():
-            await _run_git(
+            _rm_rc, _rm_out, _rm_err = await _run_git(
                 ["worktree", "remove", "--force", str(wt_path)],
                 cwd=cached_repo,
             )
+            if _rm_rc != 0:
+                logger.warning(
+                    "[SWEBenchPro] worktree remove rc=%d for %r: %s",
+                    _rm_rc, str(wt_path), _rm_err.strip()[:200],
+                )
             shutil.rmtree(str(wt_path), ignore_errors=True)
-        await _run_git(
+        _br_rc, _br_out, _br_err = await _run_git(
             ["branch", "-D", branch_name],
             cwd=cached_repo,
         )
+        # Canonical orphan reap — mirrors L3
+        # WorktreeManager.reap_orphans `git worktree prune`. Clears
+        # dangling admin entries that would otherwise make the next
+        # `worktree add -b` fail on a phantom path.
+        await _run_git(["worktree", "prune"], cwd=cached_repo)
+        # A non-zero `branch -D` is benign ONLY if the branch is truly
+        # gone (normal first run: branch never existed). If it still
+        # exists, the upcoming `worktree add -b` WILL fail — make that
+        # loud now instead of silently orphaning.
+        _ls_rc, _ls_out, _ls_err = await _run_git(
+            ["branch", "--list", branch_name],
+            cwd=cached_repo,
+        )
+        if _ls_out.strip():
+            logger.warning(
+                "[SWEBenchPro] orphan branch %r persists after cleanup "
+                "(branch -D rc=%d) — surfacing; `worktree add` will fail "
+                "loudly as WORKTREE_CREATE_FAILED, NOT silently orphan",
+                branch_name, _br_rc,
+            )
         wt_path.parent.mkdir(parents=True, exist_ok=True)
         rc, _stdout, stderr = await _run_git(
             [
@@ -493,7 +539,7 @@ async def prepare_problem(
             cached, problem.base_commit, problem.instance_id,
         )
         if wt_pair is None:
-            return None, HarnessOutcome.CHECKOUT_FAILED
+            return None, HarnessOutcome.WORKTREE_CREATE_FAILED
         worktree_path, branch_name = wt_pair
         if not await _apply_test_patch(worktree_path, problem.test_patch):
             return None, HarnessOutcome.TEST_PATCH_FAILED
@@ -522,7 +568,7 @@ async def prepare_problem(
             "[SWEBenchPro] prepare_problem raised for %r",
             problem.instance_id, exc_info=True,
         )
-        return None, HarnessOutcome.CHECKOUT_FAILED
+        return None, HarnessOutcome.WORKTREE_CREATE_FAILED
 
 
 # ===========================================================================

--- a/backend/core/ouroboros/governance/swe_bench_pro/per_problem_harness.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/per_problem_harness.py
@@ -624,7 +624,14 @@ def register_flags(registry: Any) -> int:
                 "Per-repo clone cache directory for SWE-Bench-Pro "
                 "Phase B harness.  One clone per upstream URL, "
                 "shared across all instances of that repo.  "
-                f"Defaults to {_DEFAULT_REPO_CACHE_PATH}."
+                f"Defaults to {_DEFAULT_REPO_CACHE_PATH}.  "
+                "RUNBOOK: a $TMPDIR override is SANDBOX-ON-ONLY (for "
+                "envs that block repo-root .git writes).  Under "
+                "sandbox-OFF it escapes the operation_advisor "
+                "allowed-prefix anchor (project_root) and the "
+                "swe-path preflight (B1) REFUSES the spend; the "
+                "runtime guard (B2) fails the op infra-closed.  Keep "
+                "the default (under repo root) for sandbox-OFF runs."
             ),
             category=Category.INTEGRATION,
             source_file=(
@@ -642,7 +649,12 @@ def register_flags(registry: Any) -> int:
                 "Per-problem worktree base directory.  One worktree "
                 "per problem instance, branch-named "
                 f"'{_BRANCH_PREFIX}<sanitized-id>'.  Distinct from "
-                "L3 'unit-*' branches + L2 exercise branches."
+                "L3 'unit-*' branches + L2 exercise branches.  "
+                "RUNBOOK: a $TMPDIR override is SANDBOX-ON-ONLY.  "
+                "Under sandbox-OFF it escapes the operation_advisor "
+                "anchor → B1 swe-path preflight REFUSES the spend, B2 "
+                "runtime guard fails the op infra-closed (no shared- "
+                "tree fallback).  Keep the default for sandbox-OFF."
             ),
             category=Category.INTEGRATION,
             source_file=(

--- a/tests/battle_test/test_swe_path_preflight_phase_b.py
+++ b/tests/battle_test/test_swe_path_preflight_phase_b.py
@@ -1,0 +1,279 @@
+"""Phase B spine — SWE path↔advisor preflight (B1) + envelope fail-closed (B2).
+
+Mathematically proves:
+  * B2 helper taxonomy: NO_PROMISE / RESOLVED / REJECTED + feature-off
+    byte-identity (the byte-identity-preserving distinction that stops
+    B2 shattering when the worktree-aware advisor flag is OFF)
+  * guard_envelope_repo_root: path on RESOLVED, None on NO_PROMISE,
+    raises EnvelopeRepoRootRejected on REJECTED (no shared-tree fallback)
+  * B1 assess_swe_path_readiness: default-FALSE byte-identity,
+    anchor-pass→PROCEED(under_project_root True), anchor-fail→REFUSE,
+    feature-off→PROCEED_FEATURE_OFF, never-raises
+  * AST pins: helper composes resolve_envelope_repo_root (no parallel
+    prefix math); both advisor sites swapped to guard + carry an
+    except EnvelopeRepoRootRejected POSTMORTEM handler; B1 never-raises;
+    single B1 seam in harness.py
+
+pytest.ini asyncio_mode=auto — async tests need no decorator.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import operation_advisor as oa
+from backend.core.ouroboros.governance.operation_advisor import (
+    EnvelopeRepoRootRejected,
+    RepoRootPromiseStatus,
+    envelope_repo_root_status,
+    guard_envelope_repo_root,
+)
+from backend.core.ouroboros.battle_test import swe_path_preflight as sp
+from backend.core.ouroboros.battle_test.swe_path_preflight import (
+    SwePathVerdict,
+    assess_swe_path_readiness,
+)
+
+_WT_AWARE = "JARVIS_ADVISOR_WORKTREE_AWARE_ENABLED"
+_B1_MASTER = "JARVIS_BATTLE_PREFLIGHT_SWE_PATH_ENABLED"
+_GOV = "backend/core/ouroboros/governance"
+
+
+def _ev(p) -> str:
+    return json.dumps({"repo_root": str(p)})
+
+
+@pytest.fixture
+def anchor(tmp_path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def outside(tmp_path_factory) -> Path:
+    d = tmp_path_factory.mktemp("outside_anchor")
+    return Path(d)
+
+
+@pytest.fixture
+def feature_on(monkeypatch):
+    monkeypatch.setenv(_WT_AWARE, "true")
+
+
+# ── B2 helper taxonomy ─────────────────────────────────────────────────
+def test_no_promise_empty(anchor):
+    assert envelope_repo_root_status("", project_root=anchor) == (
+        RepoRootPromiseStatus.NO_PROMISE, None, ""
+    )
+
+
+def test_no_promise_no_key(anchor):
+    s, p, raw = envelope_repo_root_status(
+        json.dumps({"other": "x"}), project_root=anchor
+    )
+    assert s is RepoRootPromiseStatus.NO_PROMISE and p is None and raw == ""
+
+
+def test_no_promise_malformed_json(anchor):
+    s, _, _ = envelope_repo_root_status("{not json", project_root=anchor)
+    assert s is RepoRootPromiseStatus.NO_PROMISE
+
+
+def test_resolved_under_anchor(anchor, feature_on):
+    sub = anchor / "wt"
+    sub.mkdir()
+    s, p, raw = envelope_repo_root_status(_ev(sub), project_root=anchor)
+    assert s is RepoRootPromiseStatus.RESOLVED
+    assert p == sub.resolve() and raw == str(sub)
+
+
+def test_rejected_outside_anchor(anchor, outside, feature_on):
+    s, p, raw = envelope_repo_root_status(_ev(outside), project_root=anchor)
+    assert s is RepoRootPromiseStatus.REJECTED
+    assert p is None and raw == str(outside)
+
+
+def test_feature_off_byte_identity(anchor, outside, monkeypatch):
+    # Feature OFF: a promised outside path must NOT be REJECTED — it
+    # collapses to NO_PROMISE so byte-identical legacy fallback holds.
+    monkeypatch.setenv(_WT_AWARE, "false")
+    s, _, _ = envelope_repo_root_status(_ev(outside), project_root=anchor)
+    assert s is RepoRootPromiseStatus.NO_PROMISE
+
+
+# ── B2 guard ───────────────────────────────────────────────────────────
+def test_guard_returns_path_resolved(anchor, feature_on):
+    sub = anchor / "wt"
+    sub.mkdir()
+    assert guard_envelope_repo_root(_ev(sub), project_root=anchor) == (
+        sub.resolve()
+    )
+
+
+def test_guard_none_on_no_promise(anchor):
+    assert guard_envelope_repo_root("", project_root=anchor) is None
+
+
+def test_guard_raises_on_rejected(anchor, outside, feature_on):
+    with pytest.raises(EnvelopeRepoRootRejected) as ei:
+        guard_envelope_repo_root(_ev(outside), project_root=anchor)
+    assert str(outside) in str(ei.value)
+    assert ei.value.raw_repo_root == str(outside)
+
+
+# ── B1 assess_swe_path_readiness ───────────────────────────────────────
+def _rpt(d) -> Path:
+    return Path(d) / "swe_path_readiness.json"
+
+
+async def test_b1_default_false_byte_identity(tmp_path, anchor, monkeypatch):
+    monkeypatch.delenv(_B1_MASTER, raising=False)
+    v = await assess_swe_path_readiness(str(tmp_path), project_root=anchor)
+    assert v is SwePathVerdict.PROCEED_DISABLED
+    assert not _rpt(tmp_path).exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+async def test_b1_explicit_false(tmp_path, anchor, monkeypatch):
+    monkeypatch.setenv(_B1_MASTER, "false")
+    v = await assess_swe_path_readiness(str(tmp_path), project_root=anchor)
+    assert v is SwePathVerdict.PROCEED_DISABLED
+
+
+async def test_b1_anchor_pass(tmp_path, anchor, monkeypatch, feature_on):
+    monkeypatch.setenv(_B1_MASTER, "true")
+    monkeypatch.setattr(sp, "worktree_base_path", lambda: anchor / "wt")
+    monkeypatch.setattr(sp, "repo_cache_path", lambda: anchor / "rc")
+    v = await assess_swe_path_readiness(str(tmp_path), project_root=anchor)
+    assert v is SwePathVerdict.PROCEED
+    rpt = json.loads(_rpt(tmp_path).read_text())
+    assert rpt["under_project_root"] is True
+    assert rpt["verdict"] == "proceed"
+
+
+async def test_b1_anchor_fail_refuses(
+    tmp_path, anchor, outside, monkeypatch, feature_on
+):
+    monkeypatch.setenv(_B1_MASTER, "true")
+    monkeypatch.setattr(sp, "worktree_base_path", lambda: outside / "wt")
+    monkeypatch.setattr(sp, "repo_cache_path", lambda: outside / "rc")
+    v = await assess_swe_path_readiness(str(tmp_path), project_root=anchor)
+    assert v is SwePathVerdict.REFUSE_OUTSIDE_ANCHOR
+    rpt = json.loads(_rpt(tmp_path).read_text())
+    assert rpt["under_project_root"] is False
+
+
+async def test_b1_feature_off_proceeds_warn(
+    tmp_path, anchor, outside, monkeypatch
+):
+    monkeypatch.setenv(_B1_MASTER, "true")
+    monkeypatch.setenv(_WT_AWARE, "false")
+    monkeypatch.setattr(sp, "worktree_base_path", lambda: outside / "wt")
+    monkeypatch.setattr(sp, "repo_cache_path", lambda: outside / "rc")
+    v = await assess_swe_path_readiness(str(tmp_path), project_root=anchor)
+    assert v is SwePathVerdict.PROCEED_FEATURE_OFF
+
+
+async def test_b1_never_raises(tmp_path, anchor, monkeypatch, feature_on):
+    monkeypatch.setenv(_B1_MASTER, "true")
+
+    def _boom():
+        raise RuntimeError("worktree path explode")
+
+    monkeypatch.setattr(sp, "worktree_base_path", _boom)
+    v = await assess_swe_path_readiness(str(tmp_path), project_root=anchor)
+    assert v is SwePathVerdict.PROCEED_FEATURE_OFF  # degraded, not raised
+
+
+# ── AST pins ───────────────────────────────────────────────────────────
+def _fn(tree, name):
+    for n in ast.walk(tree):
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+            n.name == name
+        ):
+            return n
+    raise AssertionError(f"function {name} not found")
+
+
+def test_ast_pin_helper_composes_resolver_no_parallel_math():
+    tree = ast.parse(Path(oa.__file__).read_text())
+    fn = _fn(tree, "envelope_repo_root_status")
+    calls = {
+        n.func.id
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+    }
+    assert "resolve_envelope_repo_root" in calls, (
+        "helper MUST compose the canonical resolver (single prefix-math "
+        "owner) — no parallel allowlist logic"
+    )
+    # no reimplemented prefix math (_is_under / relative_to) in the helpers
+    for fname in ("envelope_repo_root_status", "guard_envelope_repo_root"):
+        body = ast.unparse(_fn(tree, fname))
+        assert "_is_under" not in body and "relative_to" not in body
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        f"{_GOV}/orchestrator.py",
+        f"{_GOV}/phase_runners/classify_runner.py",
+    ],
+)
+def test_ast_pin_advisor_sites_swapped_and_failclosed(rel):
+    root = Path(__file__).resolve().parents[2]
+    src = (root / rel).read_text()
+    tree = ast.parse(src)
+    call_names = [
+        n.func.id
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+    ]
+    assert "guard_envelope_repo_root" in call_names, (
+        f"{rel}: must call the fail-closed guard"
+    )
+    assert "resolve_envelope_repo_root" not in call_names, (
+        f"{rel}: bare resolver call must be GONE (silent-fallback path)"
+    )
+    handlers = [
+        h
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Try)
+        for h in n.handlers
+        if h.type is not None
+        and (
+            (isinstance(h.type, ast.Name)
+             and h.type.id == "EnvelopeRepoRootRejected")
+        )
+    ]
+    assert handlers, f"{rel}: must carry an except EnvelopeRepoRootRejected"
+    # the handler body must drive a POSTMORTEM terminal (no fallback)
+    assert any(
+        "POSTMORTEM" in ast.unparse(h) for h in handlers
+    ), f"{rel}: fail-closed handler must advance POSTMORTEM"
+
+
+def test_ast_pin_b1_never_raises():
+    tree = ast.parse(Path(sp.__file__).read_text())
+    fn = _fn(tree, "assess_swe_path_readiness")
+    assert [n for n in ast.walk(fn) if isinstance(n, ast.Raise)] == [], (
+        "assess_swe_path_readiness must never raise"
+    )
+
+
+def test_ast_pin_b1_single_seam():
+    root = Path(__file__).resolve().parents[2]
+    tree = ast.parse(
+        (root / "backend/core/ouroboros/battle_test/harness.py").read_text()
+    )
+    calls = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "assess_swe_path_readiness"
+    ]
+    assert len(calls) == 1, f"expected ONE B1 seam, found {len(calls)}"

--- a/tests/governance/test_swe_bench_pro_per_problem_harness.py
+++ b/tests/governance/test_swe_bench_pro_per_problem_harness.py
@@ -74,7 +74,7 @@ def test_harness_outcome_taxonomy_is_closed_five_values():
     values = {m.value for m in HarnessOutcome}
     assert values == {
         "ready", "master_flag_off", "clone_failed",
-        "checkout_failed", "test_patch_failed",
+        "worktree_create_failed", "test_patch_failed",
     }, f"HarnessOutcome taxonomy drift; got {sorted(values)}"
 
 
@@ -93,7 +93,7 @@ def test_harness_outcome_class_body_ast_bytes_pinned():
     ]
     assert names == [
         "READY", "MASTER_FLAG_OFF", "CLONE_FAILED",
-        "CHECKOUT_FAILED", "TEST_PATCH_FAILED",
+        "WORKTREE_CREATE_FAILED", "TEST_PATCH_FAILED",
     ]
 
 
@@ -495,9 +495,13 @@ def test_prepare_problem_clone_failed_on_invalid_url(monkeypatch, tmp_path):
     assert outcome == HarnessOutcome.CLONE_FAILED
 
 
-def test_prepare_problem_checkout_failed_on_invalid_commit(
+def test_prepare_problem_worktree_create_failed_on_invalid_commit(
     monkeypatch, tmp_path,
 ):
+    # Phase C: an invalid base_commit fails at `git worktree add -b
+    # <branch> <path> <commit>` — that IS a worktree-creation failure
+    # (there is no `git checkout` step). Renamed from the legacy
+    # CHECKOUT_FAILED misnomer.
     _isolated_env(monkeypatch, tmp_path)
     upstream, _sha = _make_tiny_repo(tmp_path)
     spec = ProblemSpec(
@@ -509,7 +513,7 @@ def test_prepare_problem_checkout_failed_on_invalid_commit(
     )
     result, outcome = asyncio.run(prepare_problem(spec))
     assert result is None
-    assert outcome == HarnessOutcome.CHECKOUT_FAILED
+    assert outcome == HarnessOutcome.WORKTREE_CREATE_FAILED
 
 
 def test_prepare_problem_test_patch_failed_on_malformed_diff(

--- a/tests/governance/test_swe_bench_pro_phase_c.py
+++ b/tests/governance/test_swe_bench_pro_phase_c.py
@@ -1,0 +1,215 @@
+"""Phase C spine — path resolution & orphan-reap hardening.
+
+Proves:
+  * Absolute-path invariant — _worktree_path_for() is absolute for the
+    relative default AND idempotent for an absolute operator override
+    (the bt-2026-05-17-013346 root-cause fix: relative path × cwd=cache
+    nested the worktree → spurious test_patch_failed + cache poison)
+  * rc-check / surface — worktree-remove failure + persistent orphan
+    branch SURFACE as WARNINGs and the canonical `git worktree prune`
+    reap fires (no silent orphaning)
+  * Outcome relabel — worktree-create failure → WORKTREE_CREATE_FAILED
+    (not the legacy CHECKOUT_FAILED misnomer); a genuine apply failure
+    still → TEST_PATCH_FAILED (no over-relabel)
+  * AST pins — .resolve() in _worktree_path_for; rename complete
+    (WORKTREE_CREATE_FAILED present, CHECKOUT_FAILED gone); cleanup
+    rc-captured + `worktree prune` present; prepare_problem returns
+    WORKTREE_CREATE_FAILED at the wt_pair-None branch
+
+pytest.ini asyncio_mode=auto.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+from backend.core.ouroboros.governance.swe_bench_pro import (
+    per_problem_harness as pph,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.per_problem_harness import (  # noqa: E501
+    HarnessOutcome,
+    _worktree_path_for,
+    prepare_problem,
+    worktree_base_path,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.dataset_loader import (
+    ProblemSpec,
+)
+
+_SRC = Path(inspect.getfile(pph)).read_text()
+_AST = ast.parse(_SRC)
+_WT_ENV = "JARVIS_SWE_BENCH_PRO_WORKTREE_BASE_PATH"
+_MASTER = "JARVIS_SWE_BENCH_PRO_ENABLED"
+
+
+def _fn(name):
+    for n in ast.walk(_AST):
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+            n.name == name
+        ):
+            return n
+    raise AssertionError(f"{name} not found")
+
+
+# ── Absolute-path invariant ────────────────────────────────────────────
+def test_worktree_path_absolute_relative_default(monkeypatch):
+    monkeypatch.delenv(_WT_ENV, raising=False)
+    p = _worktree_path_for("psf__requests-3362")
+    assert p.is_absolute()
+    assert p == (
+        worktree_base_path() / "psf__requests-3362"
+    ).resolve()
+
+
+def test_worktree_path_absolute_with_absolute_override(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv(_WT_ENV, str(tmp_path / "wt"))
+    p = _worktree_path_for("django__django-16255")
+    assert p.is_absolute()
+    assert p == (tmp_path / "wt" / "django__django-16255").resolve()
+
+
+def test_worktree_path_never_nests_in_cwd_relative(monkeypatch):
+    # The defect: a relative path. Assert the result is NOT relative.
+    monkeypatch.delenv(_WT_ENV, raising=False)
+    p = _worktree_path_for("x__y-1")
+    assert p.is_absolute() and ".." not in p.parts
+
+
+# ── rc-check / surface (no silent orphan) ──────────────────────────────
+async def test_cleanup_rc_surfaces_and_prunes(
+    monkeypatch, tmp_path, caplog
+):
+    calls: list[list[str]] = []
+    wt_dir = tmp_path / "wt" / "inst-1"
+    wt_dir.mkdir(parents=True)
+    monkeypatch.setattr(pph, "worktree_base_path", lambda: tmp_path / "wt")
+
+    async def fake_run_git(args, cwd=None, stdin_input=None, timeout_s=None):
+        calls.append(list(args))
+        if args[:2] == ["worktree", "remove"]:
+            return 1, "", "fatal: cannot remove"          # FAIL → surface
+        if args[:2] == ["branch", "-D"]:
+            return 1, "", "error: not found"
+        if args[:2] == ["branch", "--list"]:
+            return 0, "  inst-1\n", ""                      # orphan persists
+        if args[:2] == ["worktree", "add"]:
+            return 1, "", "fatal: already exists"
+        return 0, "", ""
+
+    monkeypatch.setattr(pph, "_run_git", fake_run_git)
+    import logging
+    with caplog.at_level(logging.WARNING):
+        out = await pph._create_problem_worktree(
+            tmp_path / "cache", "deadbeef", "inst-1"
+        )
+    assert out is None
+    log = caplog.text
+    assert "worktree remove rc=1" in log, "remove failure must surface"
+    assert "orphan branch" in log and "persists" in log, (
+        "persistent orphan must surface, not silently proceed"
+    )
+    assert ["worktree", "prune"] in calls, (
+        "canonical L3-mirror reap (`git worktree prune`) must fire"
+    )
+
+
+# ── Outcome relabel ────────────────────────────────────────────────────
+async def test_relabel_worktree_create_failed(monkeypatch):
+    monkeypatch.setenv(_MASTER, "true")
+
+    async def _ok_cache(url):
+        return Path("/tmp/cache")
+
+    async def _wt_none(c, b, i):
+        return None
+
+    monkeypatch.setattr(pph, "_ensure_repo_cached", _ok_cache)
+    monkeypatch.setattr(pph, "_create_problem_worktree", _wt_none)
+    spec = ProblemSpec(
+        instance_id="i-1", repo="o/r", repo_url="file:///x",
+        base_commit="abc", problem_statement="", test_patch="",
+        gold_patch="",
+    )
+    result, outcome = await prepare_problem(spec)
+    assert result is None
+    assert outcome is HarnessOutcome.WORKTREE_CREATE_FAILED
+    assert not hasattr(HarnessOutcome, "CHECKOUT_FAILED")
+
+
+async def test_no_over_relabel_apply_failure_still_test_patch_failed(
+    monkeypatch
+):
+    monkeypatch.setenv(_MASTER, "true")
+
+    async def _ok_cache(url):
+        return Path("/tmp/cache")
+
+    async def _wt_ok(c, b, i):
+        return Path("/tmp/wt"), "br-1"
+
+    async def _apply_fail(wt, patch):
+        return False
+
+    monkeypatch.setattr(pph, "_ensure_repo_cached", _ok_cache)
+    monkeypatch.setattr(pph, "_create_problem_worktree", _wt_ok)
+    monkeypatch.setattr(pph, "_apply_test_patch", _apply_fail)
+    spec = ProblemSpec(
+        instance_id="i-2", repo="o/r", repo_url="file:///x",
+        base_commit="abc", problem_statement="", test_patch="diff x",
+        gold_patch="",
+    )
+    result, outcome = await prepare_problem(spec)
+    assert result is None
+    assert outcome is HarnessOutcome.TEST_PATCH_FAILED  # NOT over-relabeled
+
+
+# ── AST pins ───────────────────────────────────────────────────────────
+def test_ast_pin_worktree_path_resolved():
+    body = ast.unparse(_fn("_worktree_path_for"))
+    assert ".resolve()" in body, (
+        "_worktree_path_for MUST .resolve() to absolute (root-cause)"
+    )
+
+
+def test_ast_pin_rename_complete():
+    names = {
+        a.targets[0].id
+        for n in ast.walk(_AST)
+        if isinstance(n, ast.ClassDef) and n.name == "HarnessOutcome"
+        for a in n.body
+        if isinstance(a, ast.Assign) and isinstance(a.targets[0], ast.Name)
+    }
+    assert "WORKTREE_CREATE_FAILED" in names
+    assert "CHECKOUT_FAILED" not in names, "legacy misnomer must be gone"
+
+
+def test_ast_pin_cleanup_rc_captured_and_prunes():
+    fn = _fn("_create_problem_worktree")
+    src = ast.unparse(fn)
+    # canonical L3-mirror reap present
+    assert "'worktree', 'prune'" in src or '"worktree", "prune"' in src, (
+        "cleanup must invoke `git worktree prune`"
+    )
+    # rc captured (assignment) for the removal commands — not discarded
+    assigns = [
+        n for n in ast.walk(fn)
+        if isinstance(n, ast.Assign)
+        and any(
+            isinstance(t, ast.Tuple) for t in n.targets
+        )
+        and isinstance(n.value, ast.Await)
+    ]
+    assert len(assigns) >= 3, (
+        "worktree-remove / branch-D / branch--list _run_git results "
+        "must be rc-captured (>=3 tuple-assigned awaits), not bare"
+    )
+
+
+def test_ast_pin_prepare_returns_worktree_create_failed():
+    src = ast.unparse(_fn("prepare_problem"))
+    assert "HarnessOutcome.WORKTREE_CREATE_FAILED" in src
+    assert "HarnessOutcome.CHECKOUT_FAILED" not in src


### PR DESCRIPTION
## Integration: `cb282` (folded) + `17ae95d7`, onto `origin/main`; `27ef2efb` dropped

Rebases the local `main` divergence onto `origin/main`. Branch is **ahead 2, behind 0**.

### Commits
- `feat(governance): implement strict advisor envelope fail-closed` (`cb2825326a` → rebased) — `swe_path_preflight.py` + test, `operation_advisor.py`, `orchestrator.py`, `classify_runner.py`, `per_problem_harness.py`, harness fold.
- `fix(harness): harden absolute path resolution and orphan reap` (`17ae95d7d6` → rebased, clean — no conflict) — `per_problem_harness.py` + phase_c/per_problem tests.

### Dropped
- `27ef2efbca feat(battle_test): implement canonical provider preflight gate` — **redundant**. `origin/main` is the strict superset: it already has the canonical `provider_readiness_gate` boot phase **and** an inline `provider_preflight.assess_provider_readiness()` call in its SWE-Bench-Pro hook. Confirmed not an ancestor of this branch.

### Conflict resolution (`harness.py`) — single-seam fold

cb282 originally inserted a *parallel* gate block (its own `_preflight_block_spend` variable + a duplicate `provider_preflight` call + `swe_path_preflight`). `origin/main` already gates via `_preflight_refused`. Rather than reintroduce a parallel variable, cb282's redundant `provider_preflight` sub-block was **dropped** and its real contribution — `swe_path_preflight` (strict advisor-envelope fail-closed) — was **folded into origin/main's existing `_preflight_refused` gate** (same variable, same `SKIPPED_DISABLED` skip path). Honors the zero-shortcut / canonical-substrate mandate.

Resolved hunk (`harness.py`, inside the SWE-Bench-Pro boot hook, after origin's provider pre-flight, before `if _preflight_refused:`):

```python
                # ── SWE-Bench Path↔Advisor pre-flight (cb2825326a) ──
                # Strict advisor-envelope fail-closed ... Folded into
                # the SAME canonical _preflight_refused gate (no
                # parallel guard). §33.1 default-FALSE → no-op. NEVER raises.
                try:
                    from backend.core.ouroboros.battle_test.swe_path_preflight import (
                        SwePathVerdict, assess_swe_path_readiness,
                    )
                    _gls = self._governed_loop_service
                    _cfg = getattr(_gls, "_config", None) if _gls is not None else None
                    _proj_root = getattr(_cfg, "project_root", None) or Path.cwd()
                    _swe_path_verdict = await assess_swe_path_readiness(
                        str(self._session_dir), project_root=Path(_proj_root),
                    )
                    logger.info("[Harness] swe-path preflight: verdict=%s", _swe_path_verdict.value)
                    if _swe_path_verdict == SwePathVerdict.REFUSE_OUTSIDE_ANCHOR:
                        logger.error("[Harness] swe-path preflight REFUSED ... skipping SWE-Bench-Pro inject")
                        _preflight_refused = True
                except Exception:  # noqa: BLE001 — gate never fails boot
                    logger.debug("[Harness] swe-path preflight raised — proceeding", exc_info=True)

                if _preflight_refused:
                    _swebp_verdict = SWEBenchProInjectionVerdict.SKIPPED_DISABLED
```

### Verification (local)
- `harness.py` `py_compile` OK; `import backend...harness` OK.
- Spine: `test_swe_path_preflight_phase_b.py` + `test_swe_bench_pro_phase_c.py` + `test_provider_readiness_gate_wiring.py` + `test_swe_bench_pro_per_problem_harness.py` → **80/80 green**.
- CI should re-run the full touched `battle_test` + `governance` paths (local run was targeted, treat as yellow until CI green).

### Merge order
This PR merges **first**. Phase D + §42 PRs rebase onto post-merge `main` afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail-closed advisor repo_root guard and a boot-time SWE path preflight to keep SWE-Bench worktrees under the project anchor and prevent shared-tree contamination. Also hardens SWE-Bench-Pro worktree paths and orphan cleanup for more reliable runs.

- New Features
  - Advisor guard: `guard_envelope_repo_root` classifies NO_PROMISE/RESOLVED/REJECTED and fails closed on REJECTED; `orchestrator` and `classify_runner` catch it and advance to POSTMORTEM (no shared-tree fallback).
  - Preflight: `assess_swe_path_readiness` checks worktree base and repo cache against the advisor anchor; integrated into the existing `_preflight_refused` gate in `harness.py`, controlled by `JARVIS_BATTLE_PREFLIGHT_SWE_PATH_ENABLED`, never raises, and writes a JSON report.

- Bug Fixes
  - Worktree path is now absolute in `_worktree_path_for()` to avoid nesting under the repo cache when the base is relative.
  - Cleanup surfaces non-zero rc for `git worktree remove`, checks for persistent orphan branches, and runs `git worktree prune` before create to prevent silent orphaning. 

- Migration
  - Replace `HarnessOutcome.CHECKOUT_FAILED` with `HarnessOutcome.WORKTREE_CREATE_FAILED` in any consumers.
  - Operator overrides for `JARVIS_SWE_BENCH_PRO_WORKTREE_BASE_PATH` and repo cache path should remain under the repo root; TMPDIR-style overrides are sandbox-ON only, or preflight will refuse and the runtime guard will fail infra-closed.

<sup>Written for commit 77b02812b45db0cd2650936bc80ece222e20b2ec. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/35154?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

