### PR TITLE
fix: SWE-bench cognition feed — empty target_files and COMPLEX route

### DIFF
--- a/backend/core/ouroboros/governance/complexity_classifier.py
+++ b/backend/core/ouroboros/governance/complexity_classifier.py
@@ -83,6 +83,24 @@ _ARCHITECTURAL_KEYWORDS = frozenset({
 _PERSISTENCE_FREQUENCY_THRESHOLD = 3
 
 
+# Signal sources whose ops are inherently COMPLEX regardless of
+# surface file-count. The file-count heuristic below is calibrated
+# for organic self-development ops (where target_files is a real
+# pre-known edit set). It is structurally wrong for benchmark
+# sources: a SWE-bench problem carries NO target_files (the agent
+# must localize from the issue — see intent_envelope
+# ``_EMPTY_TARGET_FILES_EXEMPT_SOURCES``), so file_count==0 would
+# misclassify it SIMPLE and starve it of the PLAN phase + COMPLEX
+# route budget. Flooring these sources to COMPLEX is honest
+# semantics — localize-then-multi-file-source-fix from an issue IS
+# Claude's planning-strength class. Closed set (mirrors the
+# _VALID_SOURCES / _EMPTY_TARGET_FILES_EXEMPT_SOURCES discipline) —
+# additive, AST-pinnable, no per-call hardcoding.
+_COMPLEX_FLOOR_SOURCES = frozenset({
+    "swe_bench_pro",
+})
+
+
 class OperationComplexityClassifier:
     """Classifies operations by complexity and persistence at CLASSIFY phase.
 
@@ -103,6 +121,8 @@ class OperationComplexityClassifier:
         description: str,
         target_files: List[str],
         op_history: Optional[List[Any]] = None,
+        *,
+        source: str = "",
     ) -> ClassificationResult:
         """Classify an operation's complexity, persistence, and auto-approve eligibility.
 
@@ -110,8 +130,16 @@ class OperationComplexityClassifier:
             description: Human-readable operation description
             target_files: List of file paths being modified
             op_history: Optional list of recent LedgerEntries for frequency analysis
+            source: Signal source (e.g. ``ctx.signal_source``). Sources
+                in :data:`_COMPLEX_FLOOR_SOURCES` are floored to COMPLEX
+                regardless of file-count — the file heuristic is
+                miscalibrated for benchmark envelopes that carry no
+                target_files. Default "" preserves pre-fix behaviour for
+                every organic source (byte-identical).
         """
-        complexity = self._classify_complexity(description, target_files)
+        complexity = self._classify_complexity(
+            description, target_files, source=source,
+        )
         persistence, matched_cap, freq = self._classify_persistence(
             description, target_files, op_history,
         )
@@ -139,14 +167,29 @@ class OperationComplexityClassifier:
 
     def _classify_complexity(
         self, description: str, target_files: List[str],
+        *, source: str = "",
     ) -> ComplexityClass:
-        """Determine operation complexity from file count + description signals."""
+        """Determine operation complexity from file count + description signals.
+
+        ``source`` floor: a source in :data:`_COMPLEX_FLOOR_SOURCES` is
+        clamped to at-least-COMPLEX. Architectural keywords still win
+        (ARCHITECTURAL > COMPLEX) — the floor only prevents the
+        file-count heuristic from *under*-classifying a benchmark op
+        that carries no target_files.
+        """
         desc_lower = description.lower()
         file_count = len(target_files)
 
         # Check for architectural indicators first (highest priority)
         if any(kw in desc_lower for kw in _ARCHITECTURAL_KEYWORDS):
             return ComplexityClass.ARCHITECTURAL
+
+        # Source floor — benchmark sources are inherently COMPLEX; the
+        # file-count heuristic below is calibrated for organic ops with
+        # a real pre-known edit set and would misclassify a no-target
+        # localize-from-issue task as SIMPLE (starving PLAN + budget).
+        if source in _COMPLEX_FLOOR_SOURCES:
+            return ComplexityClass.COMPLEX
 
         # Check for trivial indicators
         if file_count <= 1:

--- a/backend/core/ouroboros/governance/intake/intent_envelope.py
+++ b/backend/core/ouroboros/governance/intake/intent_envelope.py
@@ -100,6 +100,23 @@ _VALID_ROUTING_OVERRIDES = frozenset({
 })
 
 
+# Sources whose ops genuinely do NOT know their target files at
+# envelope-build time and must localize downstream. ``vision_sensor``:
+# "there's a traceback on screen", not "fix file X". ``swe_bench_pro``:
+# the authentic SWE-bench task is *localize the bug from the issue
+# text* — surfacing the test_patch paths as target_files inverts the
+# task (the agent is forbidden to edit tests; the scorer rejects test
+# edits as cheating) AND surfacing gold_patch paths would leak the
+# solution. So a SWE-bench envelope carries NO target_files; the
+# exploration-first Iron Gate forces honest localization. Closed set
+# (mirrors _VALID_SOURCES discipline) — additive, AST-pinnable,
+# orthogonal to the evidence.user_attachments exemption below.
+_EMPTY_TARGET_FILES_EXEMPT_SOURCES = frozenset({
+    "vision_sensor",
+    "swe_bench_pro",
+})
+
+
 class EnvelopeValidationError(ValueError):
     """Raised when an IntentEnvelope fails schema validation."""
 
@@ -157,10 +174,14 @@ class IntentEnvelope:
             _has_user_att = bool(
                 (self.evidence or {}).get("user_attachments")
             )
-            if self.source != "vision_sensor" and not _has_user_att:
+            if (
+                self.source not in _EMPTY_TARGET_FILES_EXEMPT_SOURCES
+                and not _has_user_att
+            ):
                 raise EnvelopeValidationError(
-                    "target_files must be non-empty "
-                    "(exempt: vision_sensor source, or evidence.user_attachments present)"
+                    "target_files must be non-empty (exempt: sources "
+                    f"{sorted(_EMPTY_TARGET_FILES_EXEMPT_SOURCES)}, "
+                    "or evidence.user_attachments present)"
                 )
         # F2 Slice 2: validate routing_override. Empty = no override;
         # non-empty must be a known ProviderRoute value. Invalid values

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -2036,6 +2036,7 @@ class GovernedOrchestrator:
                 _complexity_result = _classifier.classify(
                     description=ctx.description,
                     target_files=list(ctx.target_files),
+                    source=getattr(ctx, "signal_source", "") or "",
                 )
                 # Stamp complexity on context for downstream routing decisions.
                 # task_complexity is a declared field on OperationContext, so

--- a/backend/core/ouroboros/governance/swe_bench_pro/envelope_builder.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/envelope_builder.py
@@ -234,7 +234,23 @@ def build_evaluation_envelope(
       drives router-side dedup so two near-simultaneous builds for
       the same problem don't both fire — only the first lands.
     """
-    target_files: Tuple[str, ...] = tuple(prepared.target_paths)
+    # Cognition-feed fix (soak bt-2026-05-17-194855: psf__requests-3362
+    # terminated as a CLASSIFY no-op because this builder handed the
+    # agent the test file as its target).
+    # Authentic SWE-bench protocol: the agent must LOCALIZE the bug
+    # from the issue text alone (exploration-first Iron Gate), NOT be
+    # handed a target. ``prepared.target_paths`` are the *test_patch*
+    # paths — surfacing them inverts the task (the agent is forbidden
+    # to edit tests; Phase C scorer rejects test edits as cheating),
+    # and surfacing gold_patch paths would leak the solution. So a
+    # SWE-bench envelope carries NO target_files. This is honoured by
+    # intent_envelope's ``_EMPTY_TARGET_FILES_EXEMPT_SOURCES`` (same
+    # epistemic class as vision_sensor). Dedup still works: _dedup_key
+    # composes evidence["signature"] (== problem.instance_id), so two
+    # near-simultaneous builds for the same problem still collapse.
+    # The test_patch remains worktree state for scoring only — never
+    # the agent's stated target.
+    target_files: Tuple[str, ...] = ()
     evidence = _build_evidence(problem, prepared)
     description = _safe_str(problem.problem_statement)
     repo = _safe_str(problem.repo) or _safe_str(problem.repo_url)

--- a/tests/governance/test_swe_bench_envelope_cognition_fix.py
+++ b/tests/governance/test_swe_bench_envelope_cognition_fix.py
@@ -1,0 +1,338 @@
+"""SWE-bench cognition-feed fix — spine.
+
+Closes the capability-layer defect diagnosed from soak
+``bt-2026-05-17-194855`` where ``psf__requests-3362`` terminated as a
+CLASSIFY/GENERATE NO-OP. Root cause was an architecturally incoherent
+task hand-off, NOT model cognition:
+
+  Fix (1a) — the SWE-Bench envelope surfaced ``prepared.target_paths``
+  (the *test_patch* paths) as ``target_files``. The agent is forbidden
+  to edit tests (Phase C scorer rejects test edits as cheating) and
+  surfacing gold_patch paths would leak the solution. The authentic
+  SWE-bench task is *localize the bug from the issue text*. So a
+  SWE-bench envelope now carries NO target_files, honoured by
+  ``intent_envelope._EMPTY_TARGET_FILES_EXEMPT_SOURCES`` (same
+  epistemic class as ``vision_sensor``).
+
+  Fix (2/3) — the file-count complexity heuristic classified the op
+  ``simple`` (1 file) → STANDARD route → PLAN skipped
+  (``insufficient_budget``). With empty target_files it would be
+  *worse* (0 files → still simple). ``complexity_classifier``
+  ``_COMPLEX_FLOOR_SOURCES`` now floors benchmark sources to COMPLEX,
+  routing them via the urgency_router's always-on Priority-4 matrix
+  (no feature flag) → Claude-plans + full PLAN budget.
+
+Both fixes COMPOSE existing closed-set patterns (no new code paths,
+no feature flags, no hardcoded routing tables). The AST pins are the
+load-bearing structural defense; the behavioural tests prove the
+end-to-end task hand-off is now coherent.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance.complexity_classifier import (
+    ComplexityClass,
+    OperationComplexityClassifier,
+    _COMPLEX_FLOOR_SOURCES,
+)
+from backend.core.ouroboros.governance.intake.intent_envelope import (
+    EnvelopeValidationError,
+    _EMPTY_TARGET_FILES_EXEMPT_SOURCES,
+    make_envelope,
+)
+from backend.core.ouroboros.governance.swe_bench_pro import envelope_builder
+from backend.core.ouroboros.governance.swe_bench_pro.dataset_loader import (
+    ProblemSpec,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.envelope_builder import (
+    build_evaluation_envelope,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.per_problem_harness import (
+    PreparedProblem,
+)
+from backend.core.ouroboros.governance.urgency_router import (
+    ProviderRoute,
+    UrgencyRouter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror tests/governance/test_swe_bench_pro_envelope_builder.py —
+# reuse the established construction pattern, no duplication of intent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def problem() -> ProblemSpec:
+    return ProblemSpec(
+        instance_id="psf__requests-3362",
+        repo="psf/requests",
+        base_commit="36453b95b130",
+        problem_statement=(
+            "Uncertain about content/text vs "
+            "iter_content(decode_unicode=True/False)."
+        ),
+        test_patch=(
+            "--- a/tests/test_requests.py\n"
+            "+++ b/tests/test_requests.py\n"
+            "@@ -1 +1 @@\n-old\n+new\n"
+        ),
+        gold_patch="--- a/requests/models.py\n+++ b/requests/models.py\n",
+        repo_url="https://github.com/psf/requests",
+    )
+
+
+@pytest.fixture
+def prepared(problem: ProblemSpec, tmp_path: Path) -> PreparedProblem:
+    wt = tmp_path / "wt-psf"
+    wt.mkdir()
+    # NOTE target_paths is deliberately the test file — the whole point
+    # of Fix (1a) is that build_evaluation_envelope IGNORES this.
+    return PreparedProblem(
+        problem_instance_id=problem.instance_id,
+        worktree_path=wt,
+        base_commit=problem.base_commit,
+        repo_url=problem.repo_url,
+        branch_name="swebp/psf__requests-3362",
+        target_paths=("tests/test_requests.py",),
+        elapsed_s=0.8,
+    )
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch):
+    # Prove the COMPLEX route via the ALWAYS-ON Priority-4 matrix, not
+    # the default-OFF F2 envelope_routing_override flag.
+    monkeypatch.delenv("JARVIS_BACKLOG_URGENCY_HINT_ENABLED", raising=False)
+    monkeypatch.delenv(
+        "JARVIS_URGENCY_ROUTER_RESPECT_PRE_STAMPED", raising=False
+    )
+    monkeypatch.delenv(
+        envelope_builder.ENVELOPE_URGENCY_ENV_VAR, raising=False
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# AST pins — structural regression defense
+# ---------------------------------------------------------------------------
+
+
+def _fn_source(module, name: str) -> str:
+    src = inspect.getsource(module)
+    tree = ast.parse(src)
+    node = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == name
+    )
+    seg = ast.get_source_segment(src, node)
+    assert seg is not None
+    return seg
+
+
+def test_ast_pin_builder_never_surfaces_test_patch_targets():
+    """build_evaluation_envelope MUST NOT thread prepared.target_paths
+    into target_files — that is the exact inversion that caused the
+    bt-2026-05-17-194855 no-op. target_files MUST be the empty tuple."""
+    seg = _fn_source(envelope_builder, "build_evaluation_envelope")
+    assert "tuple(prepared.target_paths)" not in seg, (
+        "REGRESSION: builder re-surfaced the test_patch paths as the "
+        "agent's target — re-opens the no-op vector"
+    )
+    assert "target_files: Tuple[str, ...] = ()" in seg, (
+        "SWE-bench envelope MUST carry an empty target_files tuple "
+        "(authentic localize-from-issue protocol)"
+    )
+    # bt session cited for postmortem discoverability.
+    assert "bt-2026-05-17" in inspect.getsource(envelope_builder), (
+        "builder MUST cite the diagnosing soak session"
+    )
+
+
+def test_ast_pin_intent_envelope_exempt_set_closed_and_correct():
+    """The empty-target_files exemption MUST be a closed frozenset
+    containing BOTH the pre-existing vision_sensor exemption AND the
+    new swe_bench_pro one (no inline string drift)."""
+    assert isinstance(_EMPTY_TARGET_FILES_EXEMPT_SOURCES, frozenset)
+    assert "swe_bench_pro" in _EMPTY_TARGET_FILES_EXEMPT_SOURCES
+    assert "vision_sensor" in _EMPTY_TARGET_FILES_EXEMPT_SOURCES
+
+
+def test_ast_pin_complexity_floor_set_closed_and_correct():
+    assert isinstance(_COMPLEX_FLOOR_SOURCES, frozenset)
+    assert "swe_bench_pro" in _COMPLEX_FLOOR_SOURCES
+
+
+def test_ast_pin_orchestrator_threads_source_into_complexity_classify():
+    """The orchestrator's complexity classify() call MUST pass a
+    ``source=`` kwarg — without it the floor can never engage and the
+    fix is silently dead."""
+    from backend.core.ouroboros.governance import orchestrator
+
+    tree = ast.parse(inspect.getsource(orchestrator))
+    classify_calls = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "classify"
+        and {kw.arg for kw in n.keywords} >= {"description", "target_files"}
+    ]
+    assert classify_calls, (
+        "could not locate the OperationComplexityClassifier.classify "
+        "call in orchestrator"
+    )
+    assert any(
+        "source" in {kw.arg for kw in c.keywords} for c in classify_calls
+    ), (
+        "REGRESSION: orchestrator stopped threading source= into the "
+        "complexity classifier — _COMPLEX_FLOOR_SOURCES is now dead"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavioural — Fix (1a): empty target_files, coherent hand-off
+# ---------------------------------------------------------------------------
+
+
+def test_swe_bench_envelope_has_empty_target_files_and_constructs(
+    problem, prepared, clean_env,
+):
+    env = build_evaluation_envelope(problem, prepared)
+    assert env.source == "swe_bench_pro"
+    assert env.target_files == (), (
+        "SWE-bench envelope MUST NOT carry target_files — the agent "
+        "localizes from the issue (test_patch paths were "
+        f"{prepared.target_paths!r}, correctly ignored)"
+    )
+    # evidence still carries the worktree + signature for advisor +
+    # dedup (Fix 1a must not regress evidence composition).
+    assert env.evidence["signature"] == problem.instance_id
+
+
+def test_intent_envelope_exemption_boundary():
+    """swe_bench_pro + empty target_files constructs; a non-exempt
+    source with empty target_files (no user_attachments) still fails
+    closed — the exemption is precise, not a blanket hole."""
+    ok = make_envelope(
+        source="swe_bench_pro",
+        description="localize from issue",
+        target_files=(),
+        repo="psf/requests",
+        confidence=1.0,
+        urgency="low",
+        evidence={"signature": "psf__requests-3362"},
+        requires_human_ack=False,
+    )
+    assert ok.target_files == ()
+
+    with pytest.raises(EnvelopeValidationError):
+        make_envelope(
+            source="backlog",  # valid source, NOT empty-target exempt
+            description="no targets, no attachments",
+            target_files=(),
+            repo="r",
+            confidence=1.0,
+            urgency="low",
+            evidence={},
+            requires_human_ack=False,
+        )
+
+
+def test_dedup_key_stable_despite_empty_target_files(
+    problem, prepared, clean_env,
+):
+    """Empty target_files MUST NOT break dedup — the evidence
+    signature (== instance_id) carries it. Two builds for the same
+    problem still collapse to one dedup_key."""
+    a = build_evaluation_envelope(problem, prepared)
+    b = build_evaluation_envelope(problem, prepared)
+    assert a.dedup_key == b.dedup_key
+    assert a.causal_id != b.causal_id  # distinct ops, shared dedup
+
+
+# ---------------------------------------------------------------------------
+# Behavioural — Fix (2/3): complexity floor + COMPLEX route, no flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("targets", [[], ["requests/models.py"]])
+def test_complexity_floor_swe_bench_pro_to_complex(targets):
+    c = OperationComplexityClassifier()
+    res = c.classify(
+        "fix iter_content unicode mismatch", targets,
+        source="swe_bench_pro",
+    )
+    assert res.complexity is ComplexityClass.COMPLEX, (
+        "swe_bench_pro MUST floor to COMPLEX regardless of file count "
+        "(0 files would otherwise misclassify SIMPLE → no PLAN budget)"
+    )
+
+
+@pytest.mark.parametrize("targets", [[], ["foo.py"]])
+def test_generic_source_byte_identical_pre_fix(targets):
+    """Non-floored sources MUST be unchanged: <=1 file still SIMPLE.
+    The fix is additive — zero behaviour change for organic ops."""
+    c = OperationComplexityClassifier()
+    res = c.classify("fix a bug", targets, source="test_failure")
+    assert res.complexity is ComplexityClass.SIMPLE
+    # default source="" also preserved
+    assert c.classify("fix a bug", targets).complexity is (
+        ComplexityClass.SIMPLE
+    )
+
+
+def test_floor_does_not_override_architectural():
+    """Architectural keywords MUST still win (ARCHITECTURAL > COMPLEX)
+    — the floor only prevents UNDER-classification."""
+    c = OperationComplexityClassifier()
+    res = c.classify(
+        "introduce a new capability / system design change", [],
+        source="swe_bench_pro",
+    )
+    assert res.complexity is ComplexityClass.ARCHITECTURAL
+
+
+def _ctx(*, urgency: str, source: str, complexity: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        signal_urgency=urgency,
+        signal_source=source,
+        task_complexity=complexity,
+        target_files=[],
+        cross_repo=False,
+    )
+
+
+def test_urgency_router_swe_bench_complex_routes_COMPLEX_no_flag(
+    clean_env,
+):
+    """task_complexity='complex' + source='swe_bench_pro' + low
+    urgency MUST route COMPLEX via the always-on Priority-4 matrix —
+    NOT the default-OFF F2 envelope_routing_override flag (proven by
+    clean_env clearing it)."""
+    router = UrgencyRouter()
+    route, reason = router.classify(
+        _ctx(urgency="low", source="swe_bench_pro", complexity="complex")
+    )
+    assert route is ProviderRoute.COMPLEX, (
+        f"expected COMPLEX (Claude-plans + full PLAN budget); "
+        f"got {route} reason={reason!r}"
+    )
+
+
+def test_urgency_router_pre_fix_simple_would_not_be_complex(clean_env):
+    """Regression baseline: the PRE-FIX classification (complexity=
+    'simple') does NOT route COMPLEX — this is exactly the budget
+    starvation that skipped PLAN and produced the no-op."""
+    router = UrgencyRouter()
+    route, _ = router.classify(
+        _ctx(urgency="low", source="swe_bench_pro", complexity="simple")
+    )
+    assert route is not ProviderRoute.COMPLEX, (
+        "if 'simple' routed COMPLEX the fix would be unfalsifiable"
+    )

--- a/tests/governance/test_swe_bench_pro_envelope_builder.py
+++ b/tests/governance/test_swe_bench_pro_envelope_builder.py
@@ -153,11 +153,20 @@ def test_source_is_swe_bench_pro(
     assert env.source == "swe_bench_pro"
 
 
-def test_target_files_match_prepared_target_paths(
+def test_target_files_is_empty_not_test_patch_paths(
     problem: ProblemSpec, prepared: PreparedProblem, clean_env: None,
 ) -> None:
+    """Cognition-feed fix (soak bt-2026-05-17-194855).
+
+    The OLD contract asserted ``target_files == prepared.target_paths``
+    — but those are the *test_patch* paths; surfacing them inverted the
+    agent's task (forbidden to edit tests; scorer rejects test edits as
+    cheating) → CLASSIFY no-op. A SWE-bench envelope now carries NO
+    target_files; the agent localizes from the issue via the
+    exploration-first Iron Gate. This test now guards the FIX."""
     env = build_evaluation_envelope(problem, prepared)
-    assert env.target_files == tuple(prepared.target_paths)
+    assert env.target_files == ()
+    assert env.target_files != tuple(prepared.target_paths)
 
 
 def test_evidence_carries_canonical_repo_root_key(
@@ -504,12 +513,18 @@ def test_envelope_roundtrips_through_unified_intake_router_create_context(
     assert parsed["problem_instance_id"] == problem.instance_id
 
 
-def test_envelope_target_files_non_empty(
+def test_envelope_target_files_empty_localize_from_issue(
     problem: ProblemSpec, prepared: PreparedProblem, clean_env: None,
 ) -> None:
-    """Vision-sensor and user-attachment envelopes are exempt from
-    the non-empty target_files invariant, but SWE-Bench-Pro envelopes
-    always carry at least one target path (parsed from the
-    test_patch's ``+++ b/<path>`` headers)."""
+    """Cognition-feed fix (soak bt-2026-05-17-194855).
+
+    The OLD docstring claimed "SWE-Bench-Pro envelopes always carry at
+    least one target path (parsed from the test_patch)". That WAS the
+    defect — the test_patch paths are not the agent's target. SWE-bench
+    is now in the same epistemic class as vision_sensor: NO target
+    files; the agent localizes from the issue. The envelope still
+    constructs (intent_envelope's _EMPTY_TARGET_FILES_EXEMPT_SOURCES
+    honours source='swe_bench_pro')."""
     env = build_evaluation_envelope(problem, prepared)
-    assert len(env.target_files) >= 1
+    assert env.target_files == ()
+    assert env.source == "swe_bench_pro"


### PR DESCRIPTION
## SWE-bench cognition feed — empty target_files + COMPLEX route

Single commit on `main` (post Phase D + integration). Fixes the
capability-layer defect from soak `bt-2026-05-17-194855`
(psf__requests-3362 → CLASSIFY no-op). Root cause was an
architecturally incoherent task hand-off, NOT model cognition.

### Fix (1a) — authentic localize-from-issue
The envelope surfaced `prepared.target_paths` (the *test_patch*
paths) as `target_files`. The agent is forbidden to edit tests
(Phase C scorer rejects test edits as cheating); gold_patch paths
would leak the solution. `intent_envelope` now promotes the inline
`vision_sensor` exemption to a named closed
`_EMPTY_TARGET_FILES_EXEMPT_SOURCES` + adds `swe_bench_pro`;
`envelope_builder` sets `target_files=()`. Dedup still composes the
evidence signature (== instance_id).

### Fix (2/3) — COMPLEX route, no flag
File-count heuristic mislabeled it `simple` → STANDARD → PLAN
skipped (`insufficient_budget`). `complexity_classifier` adds a
closed `_COMPLEX_FLOOR_SOURCES` + optional `source` param; floors
benchmark sources to COMPLEX (architectural still wins).
`orchestrator` threads `source=ctx.signal_source`. Routes via the
urgency_router always-on Priority-4 matrix — **no feature flag**.
`source=""` default → byte-identical for every organic source.

Both fixes compose existing closed-set patterns — no new code
paths, no flags, no hardcoded tables, no duplication.

### Spine
`test_swe_bench_envelope_cognition_fix.py` (14: 4 AST pins + 10
behavioral). The 2 B.2.1 tests that pinned the *defect* are
corrected to guard the *fix*. 147 adjacent regression green; 1
pre-existing urgency_router schema-coverage debt deselected (proven
unrelated via stash-isolation; separate tech-debt PR).

### Merge order
After Phase D (#35180 ✅) + integration (#35154 ✅). Squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SWE-bench cognition feed by sending empty target_files and flooring complexity to COMPLEX for `swe_bench_pro`. This prevents CLASSIFY no-ops and restores the PLAN phase budget via the standard routing path.

- **Bug Fixes**
  - Envelope: Added `_EMPTY_TARGET_FILES_EXEMPT_SOURCES` and included `swe_bench_pro`; validation now allows empty `target_files` for exempt sources. `swe_bench_pro` envelopes now set `target_files=()` to avoid leaking test or solution paths; dedup still uses the evidence signature.
  - Complexity: Added `_COMPLEX_FLOOR_SOURCES` (includes `swe_bench_pro`) and a `source` param to classification; `orchestrator` now passes `source`. Floors to COMPLEX (architectural still wins) so PLAN runs; routing uses the always-on Priority-4 matrix, no flags. Default `source=""` keeps other sources unchanged.
  - Tests: Added spine covering AST pins and behavior; updated SWE-bench builder tests to guard the fix.

<sup>Written for commit 33bf4b539d297631e52fcf0d94fc3fe76482aab1. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/35585?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

