### PR TITLE
fix: SWE-bench op-isolation and routing — coalesce, complexity floor, PLAN

### DIFF
--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -928,8 +928,33 @@ class UnifiedIntakeRouter:
     # ------------------------------------------------------------------
 
     def _coalesce_key(self, envelope: IntentEnvelope) -> str:
-        """Key for grouping envelopes that target overlapping files."""
-        return "|".join(sorted(envelope.target_files)) if envelope.target_files else ""
+        """Key for grouping envelopes that target overlapping files.
+
+        Empty ``target_files`` (localize-from-issue sources —
+        ``swe_bench_pro`` / ``vision_sensor``; see intent_envelope
+        ``_EMPTY_TARGET_FILES_EXEMPT_SOURCES``) must NOT collapse to the
+        shared ``""`` key. Soak bt-2026-05-17-213727 proved that fused
+        DISTINCT problems (psf__requests-3362 + django__django-16255)
+        into one Frankenstein op (``" | ".join(descs)``). Fall back to
+        the envelope's EXISTING provenance signature — B.2.1 sets
+        ``evidence["signature"] = problem.instance_id`` expressly for
+        router-side identity — so distinct problems stay strictly
+        distinct ops. Absent a signature, key on the unique
+        ``idempotency_key`` (each envelope its own op; never coalesces).
+        No new key invented; reuses existing provenance.
+        """
+        if envelope.target_files:
+            return "|".join(sorted(envelope.target_files))
+        _sig = ""
+        try:
+            _sig = str(
+                (envelope.evidence or {}).get("signature", "")
+            ).strip()
+        except Exception:  # noqa: BLE001 — never raise in dispatch hot path
+            _sig = ""
+        if _sig:
+            return f"sig:{envelope.source}:{_sig}"
+        return f"uniq:{envelope.idempotency_key}"
 
     def _flush_coalesced(self, key: str) -> Optional[IntentEnvelope]:
         """Merge buffered envelopes for *key* into a single multi-goal envelope.
@@ -1241,6 +1266,28 @@ class UnifiedIntakeRouter:
             provider_route=_pre_route,
             provider_route_reason=_pre_route_reason,
         )
+
+        # SWE-bench op-isolation + routing fix (#2): stamp the
+        # complexity floor at the EARLIEST point — here, before the op
+        # is submitted and the provider route + budget are computed.
+        # Sources in _COMPLEX_FLOOR_SOURCES are inherently COMPLEX
+        # (localize + multi-file source fix from an issue, no
+        # target_files); the downstream file-count heuristic would
+        # mislabel a no-target envelope "simple" and starve PLAN +
+        # budget (soaks bt-2026-05-17-194855 / -213727). create()
+        # hardcodes task_complexity="" so we set it post-construction.
+        # envelope.source is definitionally present here — robust to
+        # the coalesce/BG-pool ctx path that left signal_source
+        # unreadable at the orchestrator classify site. Composes the
+        # existing closed set; no new key, no flag. NEVER fails intake.
+        try:
+            from backend.core.ouroboros.governance.complexity_classifier import (  # noqa: E501
+                _COMPLEX_FLOOR_SOURCES,
+            )
+            if envelope.source in _COMPLEX_FLOOR_SOURCES:
+                object.__setattr__(ctx, "task_complexity", "complex")
+        except Exception:  # noqa: BLE001 — floor is best-effort; never block intake
+            pass
 
         # Manifesto §1 — the Tri-Partite Microkernel must bridge Senses→Mind.
         # When a vision-originated envelope carries a frame_path, hoist it

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -2042,7 +2042,30 @@ class GovernedOrchestrator:
                 # task_complexity is a declared field on OperationContext, so
                 # object.__setattr__ values survive dataclasses.replace() in
                 # advance() and all with_*() methods.
-                object.__setattr__(ctx, "task_complexity", _complexity_result.complexity.value)
+                #
+                # NO-DOWNGRADE (SWE-bench op-isolation fix #2b): intake
+                # stamps task_complexity="complex" for
+                # _COMPLEX_FLOOR_SOURCES BEFORE route/budget. The
+                # coalesce/BG-pool ctx path can leave signal_source
+                # unreadable at THIS site (exactly how the floor was
+                # silently lost in soak bt-2026-05-17-213727), so the
+                # classifier here could otherwise clobber the pre-stamp
+                # back to "simple". Take the STRONGER of (pre-stamped,
+                # freshly-classified) — a general robustness property
+                # (classification must never downgrade an already-higher
+                # complexity), not a swe_bench special case.
+                _CX_RANK = {
+                    "trivial": 0, "simple": 1, "light": 1, "moderate": 2,
+                    "heavy_code": 3, "complex": 4, "architectural": 5,
+                }
+                _prev_cx = (getattr(ctx, "task_complexity", "") or "").lower()
+                _new_cx = _complexity_result.complexity.value
+                _eff_cx = (
+                    _prev_cx
+                    if _CX_RANK.get(_prev_cx, -1) > _CX_RANK.get(_new_cx, -1)
+                    else _new_cx
+                )
+                object.__setattr__(ctx, "task_complexity", _eff_cx)
 
                 logger.info(
                     "[Orchestrator] \U0001f4ca Complexity: %s, Persistence: %s, auto_approve=%s, fast_path=%s [%s]",

--- a/backend/core/ouroboros/governance/plan_generator.py
+++ b/backend/core/ouroboros/governance/plan_generator.py
@@ -752,6 +752,27 @@ class PlanGenerator:
 
     def _should_skip(self, ctx: OperationContext) -> str:
         """Return a skip reason string, or empty string if planning should proceed."""
+        # SWE-bench op-isolation + routing fix (#3): localize-from-issue
+        # sources (swe_bench_pro / vision_sensor — see intent_envelope
+        # _EMPTY_TARGET_FILES_EXEMPT_SOURCES) carry NO target_files BY
+        # DESIGN. The agent MUST run PLAN to reason about its
+        # localization strategy from the issue text. Letting the
+        # n_files==0 gate below skip PLAN for them is exactly the
+        # starvation behind soak bt-2026-05-17-213727's no-rubric.
+        # Reuse the existing closed set — no new flag. Lazy import keeps
+        # plan_generator free of an intake import cycle.
+        try:
+            from backend.core.ouroboros.governance.intake.intent_envelope import (  # noqa: E501
+                _EMPTY_TARGET_FILES_EXEMPT_SOURCES,
+            )
+            if (
+                getattr(ctx, "signal_source", "")
+                in _EMPTY_TARGET_FILES_EXEMPT_SOURCES
+            ):
+                return ""
+        except Exception:  # noqa: BLE001 — exemption is best-effort
+            pass
+
         n_files = len(ctx.target_files)
 
         # Single-file trivial ops with short descriptions

--- a/tests/governance/test_swe_bench_op_isolation_routing.py
+++ b/tests/governance/test_swe_bench_op_isolation_routing.py
@@ -1,0 +1,204 @@
+"""SWE-bench op-isolation + routing fix — spine.
+
+Closes the regression + latent gaps diagnosed from soak
+bt-2026-05-17-213727 (psf__requests-3362 + django__django-16255 fused
+into one Frankenstein op; complexity stayed 'simple'; PLAN skipped):
+
+  #1  _coalesce_key collapsed every empty-target envelope to the shared
+      "" key -> distinct SWE-bench problems coalesced into one op
+      (" | ".join(descs)). Fix: empty target_files falls back to the
+      EXISTING evidence["signature"] provenance (B.2.1) else the unique
+      idempotency_key. Distinct instance_ids => strictly distinct ops.
+
+  #2  task_complexity was 'simple' (file-count heuristic) -> STANDARD
+      route -> PLAN starved. Fix #2a: intake stamps the
+      _COMPLEX_FLOOR_SOURCES floor at ctx-creation (earliest point,
+      before route/budget). Fix #2b: the orchestrator classify must NOT
+      DOWNGRADE a pre-stamped floor (general no-downgrade property).
+
+  #3  PlanGenerator._should_skip returned 'no_target_files' for
+      empty-target envelopes. Fix: sources in the existing
+      _EMPTY_TARGET_FILES_EXEMPT_SOURCES never skip PLAN (localize-from-
+      issue NEEDS PLAN).
+
+All fixes compose existing closed-set / signature mechanisms — no new
+keys, no flags, no hardcoded tables, no duplication.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance.complexity_classifier import (
+    ComplexityClass,
+    OperationComplexityClassifier,
+    _COMPLEX_FLOOR_SOURCES,
+)
+from backend.core.ouroboros.governance.intake.intent_envelope import (
+    _EMPTY_TARGET_FILES_EXEMPT_SOURCES,
+    make_envelope,
+)
+from backend.core.ouroboros.governance.intake import unified_intake_router
+from backend.core.ouroboros.governance.intake.unified_intake_router import (
+    UnifiedIntakeRouter,
+)
+from backend.core.ouroboros.governance import orchestrator as _orch_mod
+from backend.core.ouroboros.governance.plan_generator import PlanGenerator
+
+
+def _env(source: str, *, sig: str = "", tfiles=(), desc: str = "issue text"):
+    ev = {"signature": sig} if sig else {}
+    return make_envelope(
+        source=source, description=desc, target_files=tuple(tfiles),
+        repo="r", confidence=1.0, urgency="low", evidence=ev,
+        requires_human_ack=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1 — coalesce-key: distinct SWE-bench problems never fuse
+# ---------------------------------------------------------------------------
+
+
+def test_distinct_swe_bench_instances_get_distinct_coalesce_keys():
+    ck = UnifiedIntakeRouter._coalesce_key
+    s = SimpleNamespace()
+    psf = _env("swe_bench_pro", sig="psf__requests-3362")
+    dj = _env("swe_bench_pro", sig="django__django-16255")
+    k_psf, k_dj = ck(s, psf), ck(s, dj)
+    assert k_psf != k_dj, (
+        "REGRESSION: distinct SWE-bench problems share a coalesce key "
+        "-> they fuse into one Frankenstein op (bt-2026-05-17-213727)"
+    )
+    assert ck(s, _env("swe_bench_pro", sig="psf__requests-3362")) == k_psf
+
+
+def test_empty_target_key_is_never_the_shared_empty_string():
+    """Regression pin: empty target_files MUST NOT key to "" (the old
+    behavior that collapsed the key-space)."""
+    ck = UnifiedIntakeRouter._coalesce_key
+    s = SimpleNamespace()
+    assert ck(s, _env("swe_bench_pro", sig="x")) != ""
+    assert ck(s, _env("vision_sensor")) != ""
+
+
+def test_nonempty_target_files_coalesce_key_unchanged():
+    """Byte-identical for the normal path: file-set keying preserved."""
+    ck = UnifiedIntakeRouter._coalesce_key
+    s = SimpleNamespace()
+    assert ck(s, _env("backlog", tfiles=("b.py", "a.py"))) == "a.py|b.py"
+
+
+def test_empty_target_no_signature_is_unique_never_coalesces():
+    ck = UnifiedIntakeRouter._coalesce_key
+    s = SimpleNamespace()
+    assert ck(s, _env("vision_sensor")) != ck(s, _env("vision_sensor"))
+
+
+def test_flush_coalesced_single_env_returns_it_unmerged():
+    """A buffer holding one envelope (post-fix steady state for
+    distinct SWE-bench problems) is returned verbatim — never the
+    " | ".join Frankenstein merge path."""
+    r = SimpleNamespace(_coalesce_buffer={}, _coalesce_timestamps={})
+    psf = _env("swe_bench_pro", sig="psf__requests-3362", desc="psf only")
+    key = UnifiedIntakeRouter._coalesce_key(r, psf)
+    r._coalesce_buffer[key] = [psf]
+    out = UnifiedIntakeRouter._flush_coalesced(r, key)
+    assert out is psf
+    assert " | " not in out.description
+
+
+# ---------------------------------------------------------------------------
+# #2 — complexity floor stamped at intake (pre-route) + no-downgrade
+# ---------------------------------------------------------------------------
+
+
+def test_ast_intake_stamps_complexity_floor_after_ctx_create():
+    """unified_intake_router MUST import _COMPLEX_FLOOR_SOURCES and
+    stamp task_complexity='complex' when envelope.source is in it,
+    AFTER OperationContext.create (earliest pre-route point)."""
+    src = inspect.getsource(unified_intake_router)
+    assert "_COMPLEX_FLOOR_SOURCES" in src
+    assert 'object.__setattr__(ctx, "task_complexity", "complex")' in src
+    assert "envelope.source in _COMPLEX_FLOOR_SOURCES" in src
+    i_create = src.index("OperationContext.create(")
+    i_stamp = src.index(
+        'object.__setattr__(ctx, "task_complexity", "complex")'
+    )
+    assert i_stamp > i_create, (
+        "floor stamp MUST run AFTER ctx creation (earliest pre-route "
+        "point; create() hardcodes task_complexity='')"
+    )
+
+
+def test_ast_orchestrator_has_no_downgrade_guard():
+    src = inspect.getsource(_orch_mod)
+    assert "_CX_RANK" in src and "NO-DOWNGRADE" in src
+    i_rank = src.index("_CX_RANK = {")
+    i_set = src.index(
+        'object.__setattr__(ctx, "task_complexity", _eff_cx)'
+    )
+    assert i_rank < i_set, "rank logic MUST precede the stamp"
+
+
+def test_no_downgrade_rank_semantics_preserve_floor():
+    """Re-derive the exact rank table from source via ast.literal_eval
+    (safe — literal only) and prove a 'complex' pre-stamp is NOT
+    downgraded by a 'simple' classification, but IS upgraded."""
+    src = inspect.getsource(_orch_mod)
+    start = src.index("_CX_RANK = {") + len("_CX_RANK = ")
+    end = src.index("}", start) + 1
+    rank = ast.literal_eval(src[start:end])
+    assert isinstance(rank, dict) and rank["complex"] > rank["simple"]
+
+    def stronger(prev, new):
+        return prev if rank.get(prev, -1) > rank.get(new, -1) else new
+
+    assert stronger("complex", "simple") == "complex"      # floor held
+    assert stronger("simple", "architectural") == "architectural"  # upgrade
+
+
+@pytest.mark.parametrize("tfiles", [(), ("requests/models.py",)])
+def test_classifier_floors_swe_bench_pro_complex(tfiles):
+    res = OperationComplexityClassifier().classify(
+        "fix bug", list(tfiles), source="swe_bench_pro",
+    )
+    assert res.complexity is ComplexityClass.COMPLEX
+    assert "swe_bench_pro" in _COMPLEX_FLOOR_SOURCES
+
+
+# ---------------------------------------------------------------------------
+# #3 — PLAN never skipped for localize-from-issue sources
+# ---------------------------------------------------------------------------
+
+
+def _skip(source: str, tfiles=(), desc: str = "short"):
+    ctx = SimpleNamespace(
+        signal_source=source, target_files=tuple(tfiles), description=desc,
+    )
+    return PlanGenerator._should_skip(SimpleNamespace(), ctx)
+
+
+def test_plan_not_skipped_for_localize_from_issue_sources():
+    # Empty target_files + long issue text: pre-fix returned
+    # "no_target_files"; now PLAN MUST run.
+    assert _skip("swe_bench_pro", (), "x" * 5000) == ""
+    assert _skip("vision_sensor", (), "x" * 5000) == ""
+
+
+def test_plan_skip_unchanged_for_non_exempt_sources():
+    # Byte-identical for organic sources: 0 files still skips PLAN.
+    assert _skip("test_failure", (), "x" * 5000) == "no_target_files"
+    assert "swe_bench_pro" in _EMPTY_TARGET_FILES_EXEMPT_SOURCES
+    assert "test_failure" not in _EMPTY_TARGET_FILES_EXEMPT_SOURCES
+
+
+def test_ast_plan_skip_reuses_existing_closed_set():
+    src = inspect.getsource(PlanGenerator._should_skip)
+    assert "_EMPTY_TARGET_FILES_EXEMPT_SOURCES" in src, (
+        "PLAN-skip exemption MUST reuse the existing closed set, not a "
+        "new hardcoded source list"
+    )


### PR DESCRIPTION
## SWE-bench op-isolation + routing — coalesce / floor / PLAN

Single commit on `main`. Closes the regression + latent gaps from soak
`bt-2026-05-17-213727` (psf + django fused into one Frankenstein op;
complexity stayed `simple`; PLAN skipped). All fixes **compose existing
closed-set / signature mechanisms** — no new keys, no flags, no
hardcoded tables.

- **#1 `_coalesce_key`** — empty `target_files` no longer collapses to
  the shared `""` key. Falls back to the existing
  `evidence["signature"]` (B.2.1 = instance_id) → else unique
  `idempotency_key`. Distinct SWE-bench problems stay strictly distinct
  ops; the file-set key path is byte-identical for organic sources.
- **#2a intake floor** — `unified_intake_router` stamps
  `task_complexity="complex"` for `_COMPLEX_FLOOR_SOURCES` immediately
  after `OperationContext.create` (earliest pre-route point; robust to
  the coalesce/BG-pool ctx path that lost `signal_source`).
- **#2b no-downgrade** — orchestrator classify takes the stronger of
  (pre-stamped, classified). General robustness property.
- **#3 PLAN-skip exemption** — `_should_skip` exempts
  `_EMPTY_TARGET_FILES_EXEMPT_SOURCES`; localize-from-issue ops MUST
  run PLAN. Non-exempt sources unchanged.

### Verification
- Spine `test_swe_bench_op_isolation_routing.py` **13/13**; with
  cognition spine **27/27**. 128 + 22 adjacent regression green.
- 4 broader-sweep failures **proven pre-existing** via stash-isolation
  (2 `unified_intake_router` debt + 2 `MemoryType` emoji debt) —
  flagged, not bundled (clean-scope discipline).

### Merge order
After cognition fix (#35585 ✅). Squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SWE-bench op isolation and routing. Distinct problems no longer merge, complexity is floored correctly, and PLAN runs when target files are empty by design.

- **Bug Fixes**
  - Coalescing: `_coalesce_key` no longer maps empty `target_files` to a shared key. Falls back to `evidence["signature"]` (else `idempotency_key`) so different SWE-bench instances stay separate.
  - Complexity: intake stamps `task_complexity="complex"` for `_COMPLEX_FLOOR_SOURCES` right after `OperationContext.create`; the orchestrator now takes the stronger of any pre-stamp and the classifier result (no downgrade).
  - Planning: `PlanGenerator._should_skip` exempts `_EMPTY_TARGET_FILES_EXEMPT_SOURCES`, ensuring PLAN runs for localize-from-issue sources; added regression tests in `tests/governance/test_swe_bench_op_isolation_routing.py`.

<sup>Written for commit c0298e1efa3c5a38975de117f1f3d54b3a83cb55. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/35890?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

