### PR TITLE
fix: SWE-bench anti-starvation urgency and Trace-1 diagnostic probe

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -2038,6 +2038,32 @@ class GovernedOrchestrator:
                     target_files=list(ctx.target_files),
                     source=getattr(ctx, "signal_source", "") or "",
                 )
+                # Trace-1 surgical probe (soak bt-2026-05-17-225244):
+                # static analysis says this path MUST yield COMPLEX for
+                # swe_bench_pro yet production yields simple. Capture the
+                # exact runtime state at the contradiction site. Gated
+                # behind JARVIS_DEBUG_CLASSIFY_PROBE (default off →
+                # byte-identical). NEVER raises into the pipeline.
+                try:
+                    if os.environ.get(
+                        "JARVIS_DEBUG_CLASSIFY_PROBE", "",
+                    ).strip().lower() in {"1", "true", "yes", "on"}:
+                        import backend.core.ouroboros.governance.complexity_classifier as _cc_probe  # noqa: E501
+                        logger.info(
+                            "[Trace1Probe] op=%s signal_source=%r "
+                            "task_complexity=%r id(ctx)=%s in_floor=%r "
+                            "classified=%r cc_module=%s",
+                            getattr(ctx, "op_id", "")[:24],
+                            getattr(ctx, "signal_source", None),
+                            getattr(ctx, "task_complexity", None),
+                            id(ctx),
+                            (getattr(ctx, "signal_source", "") or "")
+                            in _cc_probe._COMPLEX_FLOOR_SOURCES,
+                            _complexity_result.complexity.value,
+                            getattr(_cc_probe, "__file__", "?"),
+                        )
+                except Exception:  # noqa: BLE001 — probe is best-effort
+                    pass
                 # Stamp complexity on context for downstream routing decisions.
                 # task_complexity is a declared field on OperationContext, so
                 # object.__setattr__ values survive dataclasses.replace() in

--- a/backend/core/ouroboros/governance/swe_bench_pro/envelope_builder.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/envelope_builder.py
@@ -39,12 +39,15 @@ Composition discipline
 
   * **Honest urgency derivation**: ``_derive_urgency()`` is a
     deterministic helper backed by an env override
-    (``JARVIS_SWE_BENCH_PRO_ENVELOPE_URGENCY``, default "low" → routes
-    BACKGROUND via UrgencyRouter). External benchmark workloads ARE
-    background by their nature — they are batch evaluations, never
-    interrupts to in-flight work. Operators tuning for interactive
-    scoring can flip to "normal" (→ STANDARD) or "high" (→ IMMEDIATE)
-    without touching the builder body.
+    (``JARVIS_SWE_BENCH_PRO_ENVELOPE_URGENCY``, default "normal" →
+    routes STANDARD via UrgencyRouter). Trace-2 (soak
+    bt-2026-05-17-225244): the prior "low" default gave the injected
+    op the lowest priority-queue rank with deadline=inf, so it was
+    structurally starved by the background-sensor flood and never
+    dequeued. "normal" earns a finite deadline + starvation-guard
+    protection. Operators wanting the old DW-only bulk economics can
+    set the env to "low" explicitly (accepting the starvation risk for
+    non-interactive bulk runs); "high"/"critical" → IMMEDIATE.
 
 §7 fail-closed contract
 -----------------------
@@ -100,10 +103,20 @@ ENVELOPE_URGENCY_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_ENVELOPE_URGENCY"
 #   * critical / high → IMMEDIATE (Claude direct, $0.03/op)
 #   * normal          → STANDARD (DW primary → Claude fallback)
 #   * low             → BACKGROUND (DW-only, $0.002/op)
-# External benchmark workloads ARE background work. The default
-# routes to DW only — never burning Claude budget on bulk
-# benchmark runs. Operators can flip for interactive scoring.
-_DEFAULT_URGENCY: str = "low"
+#
+# Trace-2 fix (soak bt-2026-05-17-225244): "low" gives the injected
+# benchmark op the LOWEST intake_priority_queue rank (urgency_rank=3)
+# with deadline=inf — it NEVER force-dequeues and is structurally
+# starved by higher-urgency background-sensor ops (django saw 0 BG
+# submissions while 46 sensor ops flooded the dispatch loop). The
+# queue's own starvation guard protects urgency>=normal *from* low
+# floods — the opposite of what a benchmark op needs. So the default
+# is "normal": a finite per-urgency deadline + starvation-guard
+# protection guarantee the op actually dequeues. Operators who want
+# the old DW-only bulk-cost economics can still set
+# JARVIS_SWE_BENCH_PRO_ENVELOPE_URGENCY=low explicitly (accepting the
+# starvation risk for non-interactive bulk runs).
+_DEFAULT_URGENCY: str = "normal"
 
 
 # ===========================================================================
@@ -115,7 +128,8 @@ def _derive_urgency() -> str:
     """Return a deterministic envelope urgency value.
 
     Reads the ``JARVIS_SWE_BENCH_PRO_ENVELOPE_URGENCY`` env override.
-    When unset or invalid, returns ``_DEFAULT_URGENCY`` ("low").
+    When unset or invalid, returns ``_DEFAULT_URGENCY`` ("normal" —
+    Trace-2 anti-starvation default; see the constant's rationale).
     NEVER raises.
 
     The env value is normalized to lowercase + stripped. Invalid
@@ -292,13 +306,15 @@ def register_flags(registry: Any) -> int:
             description=(
                 "Override the urgency stamped on SWE-Bench-Pro Phase "
                 "B.2.1 evaluator envelopes. Allowed values: critical "
-                "/ high / normal / low. Defaults to 'low' so external "
-                "benchmark workloads route BACKGROUND via UrgencyRouter "
-                "(DW-only; never burns Claude budget). Flip to 'normal' "
-                "for interactive scoring; 'high'/'critical' would route "
-                "IMMEDIATE (Claude direct) — appropriate only when "
-                "evaluating latency-sensitive scenarios. Invalid values "
-                "log a WARN and fall back to default."
+                "/ high / normal / low. Defaults to 'normal' (→ "
+                "STANDARD) — Trace-2 anti-starvation: 'low' gave the "
+                "injected op the lowest priority-queue rank with no "
+                "deadline so it was starved by background-sensor ops "
+                "and never dequeued (soak bt-2026-05-17-225244). Set "
+                "'low' for old DW-only bulk economics (accepts "
+                "starvation risk on non-interactive bulk runs); "
+                "'high'/'critical' route IMMEDIATE (Claude direct). "
+                "Invalid values log a WARN and fall back to default."
             ),
             category=Category.INTEGRATION,
             source_file=(

--- a/tests/governance/test_swe_bench_pro_envelope_builder.py
+++ b/tests/governance/test_swe_bench_pro_envelope_builder.py
@@ -208,13 +208,18 @@ def test_description_is_problem_statement(
 # ---------------------------------------------------------------------------
 
 
-def test_urgency_default_is_low(
+def test_urgency_default_is_normal(
     problem: ProblemSpec, prepared: PreparedProblem, clean_env: None,
 ) -> None:
-    """External benchmark workloads route BACKGROUND by default —
-    operator binding: no Claude budget burn on bulk eval."""
+    """Trace-2 fix (soak bt-2026-05-17-225244): the OLD default "low"
+    gave the injected op the lowest priority-queue rank with
+    deadline=inf — structurally starved by the background-sensor
+    flood (django: 0 dispatches). Default is now "normal" (finite
+    deadline + starvation-guard protection). Operators keep the env
+    escape hatch for bulk DW-only economics. This test now guards the
+    FIX, not the defect."""
     env = build_evaluation_envelope(problem, prepared)
-    assert env.urgency == "low"
+    assert env.urgency == "normal"
 
 
 @pytest.mark.parametrize("urgency", sorted(_VALID_URGENCIES))
@@ -233,10 +238,11 @@ def test_urgency_env_override_invalid_falls_back_to_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Invalid urgency value MUST NOT crash the build — falls back to
-    "low" with a WARN log. Keeps benchmark robust to operator typos."""
+    the default with a WARN log. Keeps benchmark robust to operator
+    typos. Trace-2: the default is now "normal" (anti-starvation)."""
     monkeypatch.setenv(ENVELOPE_URGENCY_ENV_VAR, "URGENT_NOW")
     env = build_evaluation_envelope(problem, prepared)
-    assert env.urgency == "low"
+    assert env.urgency == "normal"
 
 
 def test_urgency_env_override_case_insensitive(
@@ -478,7 +484,8 @@ def test_register_flags_returns_one_spec() -> None:
     count = register_flags(_Capturer())
     assert count == 1
     assert captured[0].name == ENVELOPE_URGENCY_ENV_VAR
-    assert captured[0].default == "low"
+    # Trace-2 fix (bt-2026-05-17-225244): anti-starvation default.
+    assert captured[0].default == "normal"
 
 
 def test_register_flags_never_raises_when_registry_register_throws() -> None:

--- a/tests/governance/test_swe_bench_starvation_urgency_fix.py
+++ b/tests/governance/test_swe_bench_starvation_urgency_fix.py
@@ -1,0 +1,105 @@
+"""Trace-2 fix spine — SWE-bench envelope anti-starvation urgency.
+
+Soak bt-2026-05-17-225244: the injected benchmark op defaulted to
+``urgency="low"`` -> lowest intake_priority_queue rank (urgency_rank=3)
+with deadline=inf -> structurally starved by higher-urgency
+background-sensor ops (django: 0 BG submissions vs 46 sensor ops). Fix:
+``_DEFAULT_URGENCY="normal"`` so the op gets a finite per-urgency
+deadline + starvation-guard protection. Operators keep the env escape
+hatch (``JARVIS_SWE_BENCH_PRO_ENVELOPE_URGENCY=low``) for the old
+DW-only bulk economics.
+
+Also pins the Trace-1 diagnostic probe as flag-gated + crash-safe.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from backend.core.ouroboros.governance.swe_bench_pro import (
+    envelope_builder as eb,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.dataset_loader import (
+    ProblemSpec,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.per_problem_harness import (
+    PreparedProblem,
+)
+
+
+@pytest.fixture
+def _clean(monkeypatch):
+    monkeypatch.delenv(eb.ENVELOPE_URGENCY_ENV_VAR, raising=False)
+    yield
+
+
+def test_default_urgency_is_normal_not_low(_clean):
+    """The anti-starvation default — load-bearing assertion."""
+    assert eb._DEFAULT_URGENCY == "normal"
+    assert eb._derive_urgency() == "normal"
+
+
+def test_low_is_no_longer_the_default_regression_pin():
+    """Regression pin: reverting to 'low' re-opens the
+    bt-2026-05-17-225244 starvation vector."""
+    assert eb._DEFAULT_URGENCY not in ("low",)
+
+
+def test_env_override_still_honored(monkeypatch):
+    # Operators can still opt back into low for bulk DW-only economics.
+    monkeypatch.setenv(eb.ENVELOPE_URGENCY_ENV_VAR, "low")
+    assert eb._derive_urgency() == "low"
+    monkeypatch.setenv(eb.ENVELOPE_URGENCY_ENV_VAR, "high")
+    assert eb._derive_urgency() == "high"
+
+
+def test_invalid_env_falls_back_to_normal(monkeypatch):
+    monkeypatch.setenv(eb.ENVELOPE_URGENCY_ENV_VAR, "bogus-urgency")
+    assert eb._derive_urgency() == "normal"
+
+
+def test_built_envelope_carries_normal_urgency(tmp_path, _clean):
+    problem = ProblemSpec(
+        instance_id="psf__requests-3362",
+        repo="psf/requests",
+        base_commit="36453b95b130",
+        problem_statement="iter_content vs text",
+        test_patch="--- a/t.py\n+++ b/t.py\n@@ -1 +1 @@\n-a\n+b\n",
+        gold_patch="--- a/requests/models.py\n+++ b/requests/models.py\n",
+        repo_url="https://github.com/psf/requests",
+    )
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    prepared = PreparedProblem(
+        problem_instance_id=problem.instance_id,
+        worktree_path=wt,
+        base_commit=problem.base_commit,
+        repo_url=problem.repo_url,
+        branch_name="swebp/psf__requests-3362",
+        target_paths=("tests/test_requests.py",),
+        elapsed_s=0.8,
+    )
+    env = eb.build_evaluation_envelope(problem, prepared)
+    assert env.urgency == "normal", (
+        "injected SWE-bench envelope MUST be 'normal' urgency so it is "
+        "not starved at the lowest priority-queue rank"
+    )
+    from backend.core.ouroboros.governance.intake.intent_envelope import (
+        _VALID_URGENCIES,
+    )
+    assert env.urgency in _VALID_URGENCIES
+
+
+def test_probe_is_gated_default_off_and_crash_safe():
+    """The Trace-1 probe MUST be flag-gated (byte-identical when unset)
+    and wrapped so it can never raise into the pipeline."""
+    from backend.core.ouroboros.governance import orchestrator as orch
+    src = inspect.getsource(orch)
+    assert "JARVIS_DEBUG_CLASSIFY_PROBE" in src
+    assert "[Trace1Probe]" in src
+    i = src.index("[Trace1Probe]")
+    assert "except Exception:" in src[i:i + 1400], (
+        "probe MUST be wrapped in try/except — never raise into the "
+        "classify path"
+    )


### PR DESCRIPTION
## SWE-bench anti-starvation urgency + Trace-1 diagnostic probe

Single commit on `main`. From the soak `bt-2026-05-17-225244` forensic
(two traces; the #1 op-isolation regression already merged via #35890).

### Trace-2 — queue starvation: **ROOT FIXED**
The injected benchmark envelope defaulted to `urgency="low"` → lowest
`intake_priority_queue` rank (urgency_rank=3) with `deadline=inf`: it
never force-dequeues and was structurally starved by the
background-sensor flood (django: **0** BG submissions vs **46** sensor
ops). The queue's starvation guard protects `urgency>=normal` *from*
low floods — the opposite of what a benchmark op needs.
**Fix:** `envelope_builder._DEFAULT_URGENCY` `"low"` → `"normal"`
(finite per-urgency deadline + starvation-guard protection). The
FlagRegistry seed composes the constant; operator-facing description +
module docstring corrected (no stale dead-doc). Env escape hatch
`JARVIS_SWE_BENCH_PRO_ENVELOPE_URGENCY=low` preserved for old DW-only
bulk economics. Composes the existing urgency taxonomy + guard — no
new lane/key/flag.

### Trace-1 — context drop: **SURGICAL PROBE (not a fix)**
Static analysis proves the classify path *must* yield COMPLEX for
swe_bench_pro yet production yields `simple` — an unresolvable
static/runtime contradiction. Added a single-line diagnostic at the
orchestrator classify site (`signal_source`/`task_complexity`/
`id(ctx)`/`in_floor`/`classified`/`cc_module`), gated behind
`JARVIS_DEBUG_CLASSIFY_PROBE` (default off → byte-identical),
`try/except`-wrapped (never raises into the pipeline). A short cheap
run will pin the exact loss line. **No Trace-1 fix is fabricated.**

### Verification
- Spine `test_swe_bench_starvation_urgency_fix.py` **6/6**.
- 3 B.2.1 tests that pinned the OLD `low` default corrected to guard
  the FIX (cited, not bent-to-pass).
- **112/112** SWE-bench-arc regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops SWE-bench Pro queue starvation by changing the default envelope urgency to "normal" and adds a small, flag-gated probe to diagnose classification mismatches.

- **Bug Fixes**
  - Default urgency changed from "low" to "normal" so benchmark ops get a finite deadline and are protected by the starvation guard.
  - `JARVIS_SWE_BENCH_PRO_ENVELOPE_URGENCY` override is still honored; docs and flag default updated. No new lanes/keys.
  - Tests updated and a regression spine added to pin the anti-starvation behavior.

- **New Features**
  - Trace-1 diagnostic probe in `orchestrator` to log classification context; gated by `JARVIS_DEBUG_CLASSIFY_PROBE`, off by default, and wrapped to never raise.

<sup>Written for commit bbf8b0e3bc48db6d8883afeb9e0ccfe97bd634bf. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/36184?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

