### PR TITLE
fix: Trace-1 root fix — CLASSIFY parity in classify_runner

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -2038,32 +2038,11 @@ class GovernedOrchestrator:
                     target_files=list(ctx.target_files),
                     source=getattr(ctx, "signal_source", "") or "",
                 )
-                # Trace-1 surgical probe (soak bt-2026-05-17-225244):
-                # static analysis says this path MUST yield COMPLEX for
-                # swe_bench_pro yet production yields simple. Capture the
-                # exact runtime state at the contradiction site. Gated
-                # behind JARVIS_DEBUG_CLASSIFY_PROBE (default off →
-                # byte-identical). NEVER raises into the pipeline.
-                try:
-                    if os.environ.get(
-                        "JARVIS_DEBUG_CLASSIFY_PROBE", "",
-                    ).strip().lower() in {"1", "true", "yes", "on"}:
-                        import backend.core.ouroboros.governance.complexity_classifier as _cc_probe  # noqa: E501
-                        logger.info(
-                            "[Trace1Probe] op=%s signal_source=%r "
-                            "task_complexity=%r id(ctx)=%s in_floor=%r "
-                            "classified=%r cc_module=%s",
-                            getattr(ctx, "op_id", "")[:24],
-                            getattr(ctx, "signal_source", None),
-                            getattr(ctx, "task_complexity", None),
-                            id(ctx),
-                            (getattr(ctx, "signal_source", "") or "")
-                            in _cc_probe._COMPLEX_FLOOR_SOURCES,
-                            _complexity_result.complexity.value,
-                            getattr(_cc_probe, "__file__", "?"),
-                        )
-                except Exception:  # noqa: BLE001 — probe is best-effort
-                    pass
+                # (Trace-1 probe removed: it sat on this orchestrator
+                # inline CLASSIFY block, which is DEAD under the phase
+                # dispatcher — production runs CLASSIFYRunner. The root
+                # fix is CLASSIFY parity in classify_runner.py, not a
+                # diagnostic here. soak bt-2026-05-18-010430.)
                 # Stamp complexity on context for downstream routing decisions.
                 # task_complexity is a declared field on OperationContext, so
                 # object.__setattr__ values survive dataclasses.replace() in

--- a/backend/core/ouroboros/governance/phase_runners/classify_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/classify_runner.py
@@ -481,12 +481,38 @@ class CLASSIFYRunner(PhaseRunner):
             _complexity_result = _classifier.classify(
                 description=ctx.description,
                 target_files=list(ctx.target_files),
+                source=getattr(ctx, "signal_source", "") or "",
             )
             # Stamp complexity on context for downstream routing decisions.
             # task_complexity is a declared field on OperationContext, so
             # object.__setattr__ values survive dataclasses.replace() in
             # advance() and all with_*() methods.
-            object.__setattr__(ctx, "task_complexity", _complexity_result.complexity.value)
+            #
+            # CLASSIFY PARITY (Trace-1 root fix, soak bt-2026-05-18-
+            # 010430): this CLASSIFYRunner is the LIVE path under the
+            # phase dispatcher (JARVIS_PHASE_RUNNER_DISPATCHER_ENABLED
+            # =true). The orchestrator's inline CLASSIFY block carried
+            # source= + the NO-DOWNGRADE stamp; this runner did NOT —
+            # so intake's task_complexity="complex" for
+            # _COMPLEX_FLOOR_SOURCES was clobbered back to "simple"
+            # here, exactly why swe_bench ops kept routing STANDARD.
+            # Mirror the orchestrator verbatim: pass source= (above)
+            # and take the STRONGER of (pre-stamped, freshly-
+            # classified) — classification must never downgrade an
+            # already-higher complexity (general property, not a
+            # swe_bench special case).
+            _CX_RANK = {
+                "trivial": 0, "simple": 1, "light": 1, "moderate": 2,
+                "heavy_code": 3, "complex": 4, "architectural": 5,
+            }
+            _prev_cx = (getattr(ctx, "task_complexity", "") or "").lower()
+            _new_cx = _complexity_result.complexity.value
+            _eff_cx = (
+                _prev_cx
+                if _CX_RANK.get(_prev_cx, -1) > _CX_RANK.get(_new_cx, -1)
+                else _new_cx
+            )
+            object.__setattr__(ctx, "task_complexity", _eff_cx)
 
             logger.info(
                 "[Orchestrator] \U0001f4ca Complexity: %s, Persistence: %s, auto_approve=%s, fast_path=%s [%s]",

--- a/tests/governance/phase_runner/test_classify_runner_parity.py
+++ b/tests/governance/phase_runner/test_classify_runner_parity.py
@@ -621,4 +621,66 @@ async def test_none_serpent_emergency_path(ctx, tmp_path):
     assert result.next_ctx.phase is OperationPhase.CANCELLED
 
 
+# ---------------------------------------------------------------------------
+# Trace-1 root fix — CLASSIFY parity for _COMPLEX_FLOOR_SOURCES
+# (soak bt-2026-05-18-010430). This runner is the LIVE phase-dispatcher
+# path; it MUST thread source= + apply the _CX_RANK NO-DOWNGRADE stamp
+# so intake's task_complexity="complex" for swe_bench_pro is not
+# clobbered back to "simple" (the exact cause of swe_bench ops routing
+# STANDARD instead of COMPLEX).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_swe_bench_complexity_floor_survives_classify_runner(
+    tmp_path,
+):
+    """signal_source='swe_bench_pro' + empty target_files + intake
+    pre-stamp task_complexity='complex' → after the LIVE CLASSIFYRunner
+    runs, task_complexity is STILL 'complex' (source-floor fires AND
+    the no-downgrade stamp preserves the pre-stamp). Pre-fix this
+    runner clobbered it to 'simple'."""
+    ctx = OperationContext.create(
+        target_files=(),  # localize-from-issue: no targets by design
+        description="Uncertain about iter_content vs text decode_unicode",
+        signal_source="swe_bench_pro",
+    )
+    # Intake stamps the floor before route/budget (#2a).
+    object.__setattr__(ctx, "task_complexity", "complex")
+
+    orch = _orch(tmp_path)
+    result = await CLASSIFYRunner(orch, None).run(ctx)
+
+    assert result.status == "ok"
+    assert result.next_ctx.task_complexity == "complex", (
+        "CLASSIFYRunner clobbered the swe_bench_pro complexity floor "
+        "back to "
+        f"{result.next_ctx.task_complexity!r} — Trace-1 regression: "
+        "the live dispatcher path lost source=/no-downgrade parity"
+    )
+
+
+@pytest.mark.asyncio
+async def test_classify_runner_no_downgrade_preserves_higher_prestamp(
+    tmp_path,
+):
+    """General no-downgrade property (not swe_bench-specific): a
+    pre-stamped 'complex' is never downgraded even for a non-floor
+    source whose file-count heuristic would say 'simple'."""
+    (tmp_path / "a.py").write_text("x = 1\n")
+    ctx = OperationContext.create(
+        target_files=(str(tmp_path / "a.py"),),  # 1 file → heuristic 'simple'
+        description="fix a bug",
+        signal_source="test_failure",  # NOT a floor source
+    )
+    object.__setattr__(ctx, "task_complexity", "complex")
+    orch = _orch(tmp_path)
+    result = await CLASSIFYRunner(orch, None).run(ctx)
+    assert result.status == "ok"
+    assert result.next_ctx.task_complexity == "complex", (
+        "no-downgrade MUST preserve a higher pre-stamp regardless of "
+        "source"
+    )
+
+
 __all__ = []

--- a/tests/governance/test_swe_bench_op_isolation_routing.py
+++ b/tests/governance/test_swe_bench_op_isolation_routing.py
@@ -46,6 +46,9 @@ from backend.core.ouroboros.governance.intake.unified_intake_router import (
     UnifiedIntakeRouter,
 )
 from backend.core.ouroboros.governance import orchestrator as _orch_mod
+from backend.core.ouroboros.governance.phase_runners import (
+    classify_runner as _classify_runner_mod,
+)
 from backend.core.ouroboros.governance.plan_generator import PlanGenerator
 
 
@@ -142,6 +145,56 @@ def test_ast_orchestrator_has_no_downgrade_guard():
         'object.__setattr__(ctx, "task_complexity", _eff_cx)'
     )
     assert i_rank < i_set, "rank logic MUST precede the stamp"
+
+
+def test_ast_classify_runner_threads_source_into_classify():
+    """Trace-1 root fix: CLASSIFYRunner is the LIVE phase-dispatcher
+    path. It MUST pass source= into the complexity classifier or the
+    _COMPLEX_FLOOR_SOURCES floor can never fire (the orchestrator
+    inline block is dead under the dispatcher)."""
+    src = inspect.getsource(_classify_runner_mod)
+    classify_calls = [
+        n for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "classify"
+        and {kw.arg for kw in n.keywords} >= {"description", "target_files"}
+    ]
+    assert classify_calls, (
+        "could not locate the OperationComplexityClassifier.classify "
+        "call in classify_runner"
+    )
+    assert any(
+        "source" in {kw.arg for kw in c.keywords} for c in classify_calls
+    ), (
+        "REGRESSION: classify_runner stopped threading source= into "
+        "the complexity classifier — _COMPLEX_FLOOR_SOURCES is dead on "
+        "the live path (Trace-1)"
+    )
+
+
+def test_ast_classify_runner_has_no_downgrade_guard_parity():
+    """classify_runner MUST carry the SAME _CX_RANK no-downgrade stamp
+    as the orchestrator inline block (parity) so a pre-stamped floor
+    cannot be clobbered on the live path."""
+    src = inspect.getsource(_classify_runner_mod)
+    assert "_CX_RANK" in src, (
+        "classify_runner missing _CX_RANK no-downgrade parity (Trace-1)"
+    )
+    i_rank = src.index("_CX_RANK = {")
+    i_set = src.index(
+        'object.__setattr__(ctx, "task_complexity", _eff_cx)'
+    )
+    assert i_rank < i_set, "rank logic MUST precede the stamp"
+    # Identical rank table to the orchestrator (no drift between paths).
+    import ast as _ast
+    def _rank(mod_src):
+        s = mod_src.index("_CX_RANK = {") + len("_CX_RANK = ")
+        return _ast.literal_eval(mod_src[s:mod_src.index("}", s) + 1])
+    assert _rank(src) == _rank(inspect.getsource(_orch_mod)), (
+        "classify_runner _CX_RANK MUST match orchestrator _CX_RANK "
+        "(parity — no per-path divergence)"
+    )
 
 
 def test_no_downgrade_rank_semantics_preserve_floor():

--- a/tests/governance/test_swe_bench_starvation_urgency_fix.py
+++ b/tests/governance/test_swe_bench_starvation_urgency_fix.py
@@ -91,15 +91,18 @@ def test_built_envelope_carries_normal_urgency(tmp_path, _clean):
     assert env.urgency in _VALID_URGENCIES
 
 
-def test_probe_is_gated_default_off_and_crash_safe():
-    """The Trace-1 probe MUST be flag-gated (byte-identical when unset)
-    and wrapped so it can never raise into the pipeline."""
+def test_trace1_probe_removed_from_dead_inline_path():
+    """The Trace-1 env-gated probe was a diagnostic that sat on the
+    orchestrator's inline CLASSIFY block — proven DEAD under the phase
+    dispatcher (production runs CLASSIFYRunner). Soak
+    bt-2026-05-18-010430 confirmed it never fired. It was ratified-
+    deleted; the root fix is CLASSIFY parity in classify_runner.py.
+    This pin guards against a dead env-gated diagnostic being
+    re-introduced on the inline path."""
     from backend.core.ouroboros.governance import orchestrator as orch
     src = inspect.getsource(orch)
-    assert "JARVIS_DEBUG_CLASSIFY_PROBE" in src
-    assert "[Trace1Probe]" in src
-    i = src.index("[Trace1Probe]")
-    assert "except Exception:" in src[i:i + 1400], (
-        "probe MUST be wrapped in try/except — never raise into the "
-        "classify path"
+    assert "JARVIS_DEBUG_CLASSIFY_PROBE" not in src, (
+        "dead env-gated Trace-1 probe re-introduced on the orchestrator "
+        "inline path (which is dead under the phase dispatcher)"
     )
+    assert "[Trace1Probe]" not in src


### PR DESCRIPTION
## Trace-1 root fix — CLASSIFY parity in classify_runner

Single commit on `main`. Closes Trace-1 (soak `bt-2026-05-18-010430`).

**Root cause (operator-pinpointed):** the orchestrator's inline
CLASSIFY block is **dead under the phase dispatcher**
(`JARVIS_PHASE_RUNNER_DISPATCHER_ENABLED=true`) — production runs
`CLASSIFYRunner`. The op-isolation arc's `source=` + `_CX_RANK`
no-downgrade landed only on that dead block, so the LIVE
`classify_runner.py` still called `classify()` with **no `source=`**
(floor never fired) and **clobbered** intake's pre-stamped `"complex"`
→ `"simple"`. That is exactly why swe_bench ops kept classifying
`simple` → routing STANDARD despite Trace-2's validated
`urgency=normal`.

**Fix (parity — mirror the orchestrator verbatim, no new mechanism,
no hardcoding):**
- `classify_runner`: pass `source=getattr(ctx,"signal_source","") or ""`
- `classify_runner`: same `_CX_RANK` NO-DOWNGRADE `_eff_cx` stamp
  (general robustness property, not swe_bench-specific)
- Removed the dead env-gated `[Trace1Probe]` from the orchestrator
  inline block (proven never fired; no diagnostic hack kept)

### Spine (beef, not bypass)
- 2 AST pins: `classify_runner` threads `source=`; `_CX_RANK` table
  **identical** to the orchestrator (parity, no per-path drift).
- 2 behavioral: swe_bench_pro + empty targets + pre-stamp `complex` →
  LIVE `CLASSIFYRunner` keeps `complex`; general no-downgrade.
- De-pinned the stale probe-presence test → asserts the dead inline
  probe stays removed.
- **125** arc-regression tests green.

### Merge order
Small governance PR atop the integration stack (post #36184). Squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a routing bug where the live `CLASSIFYRunner` ignored `signal_source` and overwrote a pre-stamped complexity, downgrading some tasks to "simple". The runner now mirrors the orchestrator so complexity floors are respected and no-downgrade is enforced.

- **Bug Fixes**
  - `classify_runner`: pass `source=getattr(ctx, "signal_source", "") or ""` to the classifier.
  - `classify_runner`: apply `_CX_RANK` no-downgrade and stamp the effective complexity.
  - Orchestrator: remove the dead env-gated `[Trace1Probe]` from the inline CLASSIFY path (dispatcher runs the runner).
  - Tests: add AST and behavioral pins to ensure `source` is threaded, rank parity is identical to the orchestrator, and pre-stamped "complex" is never downgraded.

<sup>Written for commit 67a80561b354271b78857f14498f3acd0592f782. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/36317?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

