### PR TITLE
fix(governance): Trace-1 root fix — CLASSIFY parity in classify_runner

### DIFF
--- a/_ghost_quarantine/p2_misdirect/test_requests.py
+++ b/_ghost_quarantine/p2_misdirect/test_requests.py
@@ -1,0 +1,246 @@
+# [Ouroboros] Modified by Ouroboros (op=op-019e3353-) at 2026-05-17 00:30 UTC
+# Reason: Uncertain about content/text vs iter_content(decode_unicode=True/False) When requesting an application/json document, I'
+
+from __future__ import annotations
+
+"""Tests verifying iter_content(decode_unicode=True) returns str, not bytes.
+
+Background: When decode_unicode=True is passed to iter_content(), each chunk
+should be a unicode str, matching the behaviour of r.text.  This test suite
+falsifies the regression described in op-019e3353 where iter_content returned
+bytes even with decode_unicode=True for application/json responses.
+"""
+
+import io
+import unittest.mock as mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal stub that reproduces the requests.Response surface we care about
+# ---------------------------------------------------------------------------
+
+class _FakeRawResponse:
+    """Minimal urllib3-like raw response stub."""
+
+    def __init__(self, body: bytes, encoding: str = "utf-8") -> None:
+        self._stream = io.BytesIO(body)
+        self.headers: dict[str, str] = {"content-type": f"application/json; charset={encoding}"}
+
+    def read(self, amt: int | None = None) -> bytes:
+        if amt is None:
+            return self._stream.read()
+        return self._stream.read(amt)
+
+    def stream(self, chunk_size: int, decode_content: bool = True):
+        while True:
+            chunk = self._stream.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+
+
+def _make_response(body: str, encoding: str = "utf-8"):
+    """Return a minimal requests.Response-like object backed by *body*.
+
+    We avoid importing the real `requests` library so the test is hermetic and
+    runs without network access.  The logic under test is the decode_unicode
+    path inside iter_content, which we replicate faithfully below.
+    """
+    try:
+        import requests  # type: ignore[import]
+        resp = requests.Response()
+        resp.encoding = encoding
+        resp.headers["content-type"] = f"application/json; charset={encoding}"
+        resp.raw = _FakeRawResponse(body.encode(encoding), encoding)
+        resp._content = False  # force streaming path
+        resp._content_consumed = False
+        return resp
+    except ImportError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Pure-logic helper that mirrors what requests.utils.stream_decode_response_unicode
+# is supposed to do - used to unit-test the decode path in isolation.
+# ---------------------------------------------------------------------------
+
+def _iter_content_decode_unicode(
+    chunks: list[bytes],
+    encoding: str,
+) -> list[str | bytes]:
+    """Replicate the decode_unicode=True path from requests.models.Response.
+
+    The real implementation delegates to
+    ``requests.utils.stream_decode_response_unicode`` which wraps
+    ``codecs.getincrementaldecoder``.  We reproduce the same contract here so
+    we can assert on it without a live HTTP server.
+    """
+    import codecs
+
+    decoder = codecs.getincrementaldecoder(encoding)(errors="replace")
+    results: list[str | bytes] = []
+    for chunk in chunks:
+        decoded = decoder.decode(chunk)
+        if decoded:
+            results.append(decoded)
+    # flush
+    tail = decoder.decode(b"", final=True)
+    if tail:
+        results.append(tail)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestIterContentDecodeUnicode:
+    """Verify that decode_unicode=True yields str chunks, not bytes."""
+
+    def test_decoded_chunks_are_str_not_bytes(self) -> None:
+        """Each chunk from the decode path must be a str instance."""
+        body_bytes = [b'{"hello": "world"}']
+        results = _iter_content_decode_unicode(body_bytes, "utf-8")
+        assert results, "Expected at least one decoded chunk"
+        for chunk in results:
+            assert isinstance(chunk, str), (
+                f"Expected str chunk, got {type(chunk).__name__!r}: {chunk!r}"
+            )
+
+    def test_decoded_content_matches_original_text(self) -> None:
+        """Reassembled decoded chunks must equal the original unicode string."""
+        original = '{"key": "value", "num": 42}'
+        body_bytes = [original.encode("utf-8")]
+        results = _iter_content_decode_unicode(body_bytes, "utf-8")
+        reassembled = "".join(str(c) for c in results)
+        assert reassembled == original
+
+    def test_multi_chunk_decode_produces_str(self) -> None:
+        """Multi-chunk streaming must still yield str, not bytes."""
+        original = '{"a": 1, "b": 2, "c": 3}'
+        encoded = original.encode("utf-8")
+        # Split into 4-byte chunks to simulate small chunk_size
+        chunks = [encoded[i:i + 4] for i in range(0, len(encoded), 4)]
+        results = _iter_content_decode_unicode(chunks, "utf-8")
+        for chunk in results:
+            assert isinstance(chunk, str), (
+                f"Multi-chunk: expected str, got {type(chunk).__name__!r}"
+            )
+        assert "".join(str(c) for c in results) == original
+
+    def test_latin1_encoding_decode_unicode(self) -> None:
+        """decode_unicode=True must work for non-UTF-8 encodings too."""
+        original = "cafe"
+        body_bytes = [original.encode("latin-1")]
+        results = _iter_content_decode_unicode(body_bytes, "latin-1")
+        assert results
+        for chunk in results:
+            assert isinstance(chunk, str)
+        assert "".join(str(c) for c in results) == original
+
+    def test_empty_body_decode_unicode(self) -> None:
+        """Empty body with decode_unicode=True must yield no chunks (not crash)."""
+        results = _iter_content_decode_unicode([], "utf-8")
+        # May be empty or contain an empty string from the flush - either is fine
+        for chunk in results:
+            assert isinstance(chunk, str)
+
+    def test_raw_bytes_without_decode_unicode_are_bytes(self) -> None:
+        """Sanity check: without decoding, chunks remain bytes."""
+        raw_chunks: list[bytes] = [b'{"x": 1}', b'{"y": 2}']
+        for chunk in raw_chunks:
+            assert isinstance(chunk, bytes), (
+                f"Without decode_unicode, expected bytes, got {type(chunk).__name__!r}"
+            )
+
+    def test_decode_unicode_true_vs_false_type_difference(self) -> None:
+        """Demonstrate the type difference: decode_unicode=True -> str, False -> bytes."""
+        body = b'{"hello": "world"}'
+        # decode_unicode=False path: raw bytes pass through unchanged
+        raw_chunk: bytes = body
+        assert isinstance(raw_chunk, bytes)
+
+        # decode_unicode=True path: must be str
+        decoded_chunks = _iter_content_decode_unicode([body], "utf-8")
+        assert decoded_chunks
+        assert isinstance(decoded_chunks[0], str)
+
+    def test_unicode_characters_survive_decode(self) -> None:
+        """Non-ASCII unicode characters must survive the decode_unicode path intact."""
+        original = '{"emoji": "hello world", "accented": "cafe"}'
+        body_bytes = [original.encode("utf-8")]
+        results = _iter_content_decode_unicode(body_bytes, "utf-8")
+        reassembled = "".join(str(c) for c in results)
+        assert reassembled == original
+
+
+class TestIterContentWithRealRequests:
+    """Integration tests using the real requests library (skipped if unavailable)."""
+
+    @pytest.fixture(autouse=True)
+    def _require_requests(self) -> None:
+        pytest.importorskip("requests")
+
+    def test_iter_content_decode_unicode_returns_str(self) -> None:
+        """iter_content(decode_unicode=True) must yield str, not bytes.
+
+        This is the exact scenario from the bug report: application/json
+        response with decode_unicode=True was returning bytes instead of str.
+        """
+        import requests  # type: ignore[import]
+
+        body = b'{"hello": "world"}'
+        resp = requests.Response()
+        resp.encoding = "utf-8"
+        resp.headers["content-type"] = "application/json; charset=utf-8"
+        resp._content = body
+        resp._content_consumed = True
+
+        chunks = list(resp.iter_content(chunk_size=16 * 1024, decode_unicode=True))
+        assert chunks, "Expected at least one chunk from iter_content"
+        for chunk in chunks:
+            assert isinstance(chunk, str), (
+                f"iter_content(decode_unicode=True) returned {type(chunk).__name__!r}, "
+                f"expected str.  This is the regression from op-019e3353."
+            )
+
+    def test_iter_content_decode_unicode_matches_text(self) -> None:
+        """Reassembled iter_content(decode_unicode=True) must equal r.text."""
+        import requests  # type: ignore[import]
+
+        body = b'{"key": "value"}'
+        resp = requests.Response()
+        resp.encoding = "utf-8"
+        resp.headers["content-type"] = "application/json; charset=utf-8"
+        resp._content = body
+        resp._content_consumed = True
+
+        text_via_property = resp.text
+        chunks = list(resp.iter_content(chunk_size=16 * 1024, decode_unicode=True))
+        text_via_iter = "".join(chunks)
+
+        assert text_via_iter == text_via_property, (
+            f"iter_content(decode_unicode=True) gave {text_via_iter!r} "
+            f"but r.text gave {text_via_property!r}"
+        )
+
+    def test_iter_content_without_decode_unicode_returns_bytes(self) -> None:
+        """iter_content(decode_unicode=False) must still return bytes (regression guard)."""
+        import requests  # type: ignore[import]
+
+        body = b'{"hello": "world"}'
+        resp = requests.Response()
+        resp.encoding = "utf-8"
+        resp.headers["content-type"] = "application/json; charset=utf-8"
+        resp._content = body
+        resp._content_consumed = True
+
+        chunks = list(resp.iter_content(chunk_size=16 * 1024, decode_unicode=False))
+        assert chunks
+        for chunk in chunks:
+            assert isinstance(chunk, bytes), (
+                f"iter_content(decode_unicode=False) returned {type(chunk).__name__!r}, "
+                f"expected bytes."
+            )

--- a/scripts/diagnose_prepare_problem.py
+++ b/scripts/diagnose_prepare_problem.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Zero-cost standalone diagnostic for prepare_problem `test_patch_failed`.
+
+COMPOSES the canonical Phase B.1 primitives — no reimplemented clone /
+checkout / apply logic, no API spend, reuses the existing repo cache:
+
+    load_problem (dataset_loader)            -> ProblemSpec
+    _ensure_repo_cached (per_problem_harness)-> cached clone (idempotent)
+    _create_problem_worktree                 -> worktree @ base_commit
+    _run_git                                 -> the SAME git runner the
+                                                production apply uses
+
+The production `_apply_test_patch` runs `git apply --index -` and
+truncates stderr to 300 chars in the log — that truncation is exactly
+why the real failure was invisible.  Here we run a battery of
+`git apply --check` variants against the canonical worktree and dump
+FULL untruncated stderr to classify the failure:
+  strip-level (-p0/-p1) · 3-way · recount · which hunks reject ·
+  upstream-convention mismatch.
+
+Usage: python3 scripts/diagnose_prepare_problem.py [instance_id]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Canonical surface — discriminator corpus is the local JSONL we staged.
+os.environ.setdefault("JARVIS_SWE_BENCH_PRO_ENABLED", "true")
+os.environ.setdefault(
+    "JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH",
+    "./.jarvis/swe_bench_pro/discriminator.jsonl",
+)
+
+from backend.core.ouroboros.governance.swe_bench_pro.dataset_loader import (  # noqa: E501
+    load_problem,
+)
+from backend.core.ouroboros.governance.swe_bench_pro import (
+    per_problem_harness as pph,
+)
+
+
+def _hr(t: str) -> None:
+    print(f"\n{'=' * 12} {t} {'=' * 12}")
+
+
+async def _git(args, cwd, patch=None):
+    """Compose the canonical _run_git → (rc, stdout, stderr) FULL."""
+    return await pph._run_git(
+        args,
+        cwd=cwd,
+        stdin_input=(patch.encode("utf-8") if patch is not None else None),
+    )
+
+
+async def main(instance_id: str) -> int:
+    _hr(f"LOAD {instance_id}")
+    spec, outcome = load_problem(instance_id)
+    if spec is None:
+        print(f"ABORT: load_problem outcome={outcome.value}")
+        return 2
+    print(
+        f"repo={spec.repo} repo_url={spec.repo_url} "
+        f"base_commit={spec.base_commit[:12]} "
+        f"|test_patch|={len(spec.test_patch)}"
+    )
+
+    _hr("TEST_PATCH HEAD (first 40 lines — headers/paths/strip-level)")
+    for ln in spec.test_patch.splitlines()[:40]:
+        print(f"  | {ln}")
+
+    _hr("CANONICAL CLONE (cached, idempotent — no re-download)")
+    cached = await pph._ensure_repo_cached(spec.repo_url)
+    if cached is None:
+        print("ABORT: _ensure_repo_cached returned None")
+        return 3
+    print(f"cached_repo={cached}")
+
+    _hr("CANONICAL WORKTREE @ base_commit")
+    wt = await pph._create_problem_worktree(
+        cached, spec.base_commit, spec.instance_id
+    )
+    if wt is None:
+        print("ABORT: _create_problem_worktree returned None")
+        return 4
+    wt_path, branch = wt
+    print(f"worktree={wt_path} branch={branch}")
+
+    try:
+        # The canonical production command, with --check + FULL stderr.
+        battery = [
+            ("PROD: apply --index --check", ["apply", "--index", "--check", "-"]),
+            ("apply --check (no --index)", ["apply", "--check", "-"]),
+            ("apply --check -p0", ["apply", "--check", "-p0", "-"]),
+            ("apply --check -p1", ["apply", "--check", "-p1", "-"]),
+            ("apply --check --3way", ["apply", "--check", "--3way", "-"]),
+            ("apply --check --recount", ["apply", "--check", "--recount", "-"]),
+            ("apply --stat (parse-only)", ["apply", "--stat", "-"]),
+            ("apply --check --reject --verbose",
+             ["apply", "--check", "--reject", "--verbose", "-"]),
+        ]
+        for label, args in battery:
+            rc, out, err = await _git(args, wt_path, patch=spec.test_patch)
+            _hr(f"{label}  →  rc={rc}")
+            if out.strip():
+                print("  STDOUT:")
+                for ln in out.strip().splitlines()[:20]:
+                    print(f"    {ln}")
+            if err.strip():
+                print("  STDERR (FULL, untruncated):")
+                for ln in err.strip().splitlines()[:30]:
+                    print(f"    {ln}")
+            if not out.strip() and not err.strip():
+                print("  (no output — clean)")
+
+        # What paths does the patch target, and do they exist at base?
+        _hr("TARGET PATH EXISTENCE @ base_commit")
+        for p in pph._extract_target_paths_from_patch(spec.test_patch):
+            exists = (wt_path / p).exists()
+            print(f"  {'OK ' if exists else 'MISSING'}  {p}")
+    finally:
+        _hr("CLEANUP (canonical worktree teardown)")
+        await _git(
+            ["worktree", "remove", "--force", str(wt_path)], cached
+        )
+        await _git(["branch", "-D", branch], cached)
+        print("cleaned")
+
+    return 0
+
+
+if __name__ == "__main__":
+    iid = sys.argv[1] if len(sys.argv) > 1 else "psf__requests-3362"
+    raise SystemExit(asyncio.run(main(iid)))

--- a/scripts/stage_swe_bench_discriminator.py
+++ b/scripts/stage_swe_bench_discriminator.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Stage a SWE-Bench discriminator corpus by COMPOSING the canonical loader.
+
+This is deliberately NOT a parallel fetcher. It sets the canonical HF env
+knobs and delegates every byte of acquisition + schema normalization to the
+existing ``dataset_loader.load_problem`` path:
+
+    load_problem(id)
+      -> _load_from_huggingface(id)
+        -> _iter_hf_records()         (single datasets.load_dataset seam)
+          -> ProblemSpec.from_dict()  (single canonical normalizer:
+                                       patch->gold_patch alias, repo_url
+                                       derivation, metadata fold)
+    ProblemSpec.to_dict()             (single canonical serializer,
+                                       schema swe_bench_pro_problem.v1)
+
+Discipline:
+  * No hardcoding — instance ids / output path / dataset / split are argv.
+  * No silent substitution — any id not resolvable aborts with a non-zero
+    exit and writes NOTHING (the named id failing is a signal, not noise).
+  * Atomic — composes into a tmp file, fsync, os.replace; a partial or
+    garbage corpus never lands at the target path.
+  * Integrity gate — every staged spec must have non-empty
+    problem_statement / test_patch / gold_patch or the run aborts (a
+    malformed corpus would waste the downstream live-fire budget).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Stage SWE-Bench discriminator corpus")
+    p.add_argument(
+        "--instance-ids",
+        required=True,
+        help="Comma-separated instance ids (e.g. good_id,hard_id)",
+    )
+    p.add_argument(
+        "--out",
+        required=True,
+        help="Output JSONL path (atomic write)",
+    )
+    p.add_argument(
+        "--hf-dataset",
+        required=True,
+        help="HuggingFace dataset name (e.g. princeton-nlp/SWE-bench_Lite)",
+    )
+    p.add_argument("--hf-split", default="test", help="HF split (default: test)")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    ns = _parse_args(argv)
+    ids = [s.strip() for s in ns.instance_ids.split(",") if s.strip()]
+    if len(ids) < 2:
+        print(f"ABORT: need >=2 instance ids, got {ids!r}", file=sys.stderr)
+        return 2
+
+    # Canonical env knobs — the loader reads these at call time.
+    os.environ["JARVIS_SWE_BENCH_PRO_ENABLED"] = "true"
+    os.environ["JARVIS_SWE_BENCH_PRO_HF_DATASET"] = ns.hf_dataset
+    os.environ["JARVIS_SWE_BENCH_PRO_HF_SPLIT"] = ns.hf_split
+
+    # Import AFTER env is set (loader reads env lazily, but be explicit).
+    from backend.core.ouroboros.governance.swe_bench_pro.dataset_loader import (  # noqa: E501
+        load_problem,
+    )
+
+    staged: list[dict] = []
+    for iid in ids:
+        spec, outcome = load_problem(iid)
+        if spec is None:
+            print(
+                f"ABORT: instance {iid!r} not resolvable "
+                f"(outcome={outcome.value}) — NO silent substitution. "
+                f"Verify the id exists in {ns.hf_dataset}:{ns.hf_split}.",
+                file=sys.stderr,
+            )
+            return 3
+        d = spec.to_dict()
+        # Integrity gate — a corpus with empty bodies wastes live-fire $.
+        missing = [
+            f
+            for f in ("problem_statement", "test_patch", "gold_patch")
+            if not str(d.get(f, "")).strip()
+        ]
+        if missing:
+            print(
+                f"ABORT: instance {iid!r} has empty {missing} — "
+                f"unusable discriminator corpus.",
+                file=sys.stderr,
+            )
+            return 4
+        staged.append(d)
+        print(
+            f"  staged {iid}  outcome={outcome.value}  repo={d['repo']}  "
+            f"base={d['base_commit'][:12]}  "
+            f"|stmt|={len(d['problem_statement'])}  "
+            f"|test_patch|={len(d['test_patch'])}  "
+            f"|gold_patch|={len(d['gold_patch'])}  "
+            f"difficulty={d['difficulty']}"
+        )
+
+    out = Path(ns.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic: write tmp in the same dir, fsync, os.replace.
+    fd, tmp = tempfile.mkstemp(prefix=".discriminator.", dir=str(out.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            for d in staged:
+                f.write(json.dumps(d) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, out)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+    print(f"OK: staged {len(staged)} instance(s) -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Operator-pinpointed root fix from soak `bt-2026-05-18-010430`: the orchestrator's inline CLASSIFY block is **dead** under the phase dispatcher (`JARVIS_PHASE_RUNNER_DISPATCHER_ENABLED=true`) — production runs `CLASSIFYRunner`. The op-isolation arc's `source=` + `_CX_RANK` no-downgrade landed only on the dead inline block, so the live `classify_runner` still:

- called `OperationComplexityClassifier.classify()` with **no `source=`** → the `_COMPLEX_FLOOR_SOURCES` floor never fired for `swe_bench_pro`
- stamped `task_complexity` unconditionally → clobbered intake's pre-stamped `complex` back to `simple`

This is why swe_bench ops kept classifying simple → routing STANDARD despite Trace-2's validated `urgency=normal`.

## Root fix (mirror the orchestrator verbatim — parity, no new mechanism, no hardcoding)

- `classify_runner`: pass `source=getattr(ctx,"signal_source","") or ""` into `classify()`
- `classify_runner`: same `_CX_RANK` NO-DOWNGRADE `_eff_cx` stamp — take the stronger of (pre-stamped, freshly-classified); general robustness property, not a swe_bench special case
- dead-diagnostic cleanup: env-gated `[Trace1Probe]` removed from the orchestrator inline block (proven dead under the dispatcher)

## Spine (beef, not bypass)

- 2 AST pins (`test_swe_bench_op_isolation_routing.py`): `classify_runner` threads `source=` into `classify()`; carries `_CX_RANK` no-downgrade with a rank table identical to the orchestrator (parity — no per-path drift)
- 2 behavioral (`test_classify_runner_parity.py`): swe_bench_pro + empty target_files + intake pre-stamp `complex` → live `CLASSIFYRunner` keeps `task_complexity="complex"`; general no-downgrade preserves a higher pre-stamp for any source
- de-pinned the now-stale probe-presence test → asserts the dead inline probe stays removed
- 125 arc-regression tests green

## Notes

- Pre-existing operator-authored commit (`[integrity-verified: dbd58c297a7d]`), unrelated to the §43 docs PR. Routed via branch+PR because direct push to `main` is refused by branch protection.
- Verification next: soak + inspect `debug.log` for `📊 Complexity: complex` / reason_code `...:complex` on swe_bench ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes complexity classification parity in the runner so source-aware floors apply and pre-stamped complexity is not downgraded, preventing misrouting of SWE-Bench tasks. Adds small diagnostic helpers and a quarantine test to improve debugging and data staging.

- **Bug Fixes**
  - Pass `source` from context into `OperationComplexityClassifier.classify()`.
  - Apply `_CX_RANK` no-downgrade when stamping `task_complexity` (keeps the stronger of pre-stamped vs classified).
  - Remove the dead env-gated inline CLASSIFY probe under the phase dispatcher.

- **New Features**
  - `scripts/diagnose_prepare_problem.py`: Repro and classify `git apply` failures with full stderr on the canonical worktree.
  - `scripts/stage_swe_bench_discriminator.py`: Stage a JSONL discriminator corpus via the canonical loader with atomic write and integrity checks.
  - `_ghost_quarantine/p2_misdirect/test_requests.py`: Quarantine tests ensuring `requests.Response.iter_content(decode_unicode=True)` yields `str` (not bytes).

<sup>Written for commit f96a41f88a54e014b548f58ebffa448befe31eba. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/36949?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

