### PR TITLE
docs: fix phase-count (10->11) and align O+V paper title to (O+V)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Focus-preserving UI automation. Ghost Hands executes actions on background windo
 
 **`backend/core/ouroboros/`**
 
-The self-developing code pipeline — the organism's immune system and neuroplasticity layer. Ouroboros runs a 10-phase governance pipeline (CLASSIFY → ROUTE → CONTEXT_EXPANSION → GENERATE → VALIDATE → GATE → APPROVE → APPLY → VERIFY → COMPLETE) that detects improvement opportunities, generates multi-repo patches, validates them in sandboxed worktrees, applies them through branch-isolated sagas, and narrates every decision via voice and TUI.
+The self-developing code pipeline — the organism's immune system and neuroplasticity layer. Ouroboros runs an 11-phase governance pipeline (CLASSIFY → ROUTE → CONTEXT_EXPANSION → PLAN → GENERATE → VALIDATE → GATE → APPROVE → APPLY → VERIFY → COMPLETE) that detects improvement opportunities, generates multi-repo patches, validates them in sandboxed worktrees, applies them through branch-isolated sagas, and narrates every decision via voice and TUI.
 
 **Status (2026-04-15):** The governed complex-route arc has closed end-to-end. Session `bt-2026-04-15-175547` (Session O of the April 14-15 Sessions A–O battle-test arc) produced the first autonomously-generated Python file to land on disk through the full enforcement pipeline: `tests/governance/intake/sensors/test_test_failure_sensor_dedup.py` (4,986 bytes), written by the ChangeEngine after the `ExplorationLedger` scored the retry at `would_pass=True (score=11.00, 4 categories)`, `GATE can_write=True`, approval auto-approved via headless bypass, `ChangeEngine.RollbackArtifact.capture()` handled the new-file creation path, VERIFY found test critiques, L2 Repair converged on iteration 1/5, and `DECISION outcome=applied reason_code=safe_auto_passed` with a clean `POSTMORTEM root_cause=none`. Full 15-session arc postmortem with quoted terminal logs is in [`docs/architecture/OUROBOROS.md`](docs/architecture/OUROBOROS.md#battle-test-breakthrough-log). The eight distinct failure modes surfaced during the arc (TTY-less approval crash, risk-engine `too_many_files` escalation, L3 `READ_ONLY_PLANNING` mode switch from ambient probe failures, new-file `RollbackArtifact.capture()` ENOENT, 900s pool ceiling, 180s fallback cap on 5-tool-round retries, intake WAL cross-session coalescing, and the one-file-of-four multi-file fan-out gap) are each documented in the breakthrough log with their fix commits and env overrides. The end-to-end enforcement loop is now empirically validated; multi-file coordinated APPLY fan-out is the next product item.
 
@@ -713,7 +713,7 @@ JARVIS-AI-Agent/
 |   |   `-- ouroboros/              # Self-developing governance engine
 |   |       |-- governance/
 |   |       |   |-- governed_loop_service.py  # Main autonomous loop (Zone 6.8)
-|   |       |   |-- orchestrator.py           # 10-phase FSM pipeline (180s generation timeout)
+|   |       |   |-- orchestrator.py           # 11-phase FSM pipeline (180s generation timeout)
 |   |       |   |-- brain_selector.py         # Model selection + boot handshake
 |   |       |   |-- brain_selection_policy.yaml  # Single source of truth for all model routing
 |   |       |   |-- providers.py              # PrimeProvider + ClaudeProvider (asyncio.wait_for streaming)

--- a/docs/architecture/OV_RESEARCH_PAPER_2026-04-16.md
+++ b/docs/architecture/OV_RESEARCH_PAPER_2026-04-16.md
@@ -1,11 +1,11 @@
 ---
-title: "Ouroboros + Venom: A Governed Architecture for Autonomous Self-Development"
+title: "Ouroboros + Venom (O+V): A Governed Architecture for Autonomous Self-Development"
 subtitle: "The JARVIS Trinity's self-evolving engine — design, implementation, and battle-tested evidence"
 author: "Derek J. Russell — JARVIS Trinity Architect, RSI/AGI Researcher"
 date: "2026-04-16"
 ---
 
-# Ouroboros + Venom: A Governed Architecture for Autonomous Self-Development
+# Ouroboros + Venom (O+V): A Governed Architecture for Autonomous Self-Development
 
 > **Prepared by:** Derek J. Russell
 > **Report date:** 2026-04-16
@@ -5042,7 +5042,7 @@ pandoc docs/architecture/OV_RESEARCH_PAPER_2026-04-16.md \
   -o docs/architecture/OV_RESEARCH_PAPER_2026-04-16.html \
   --from=gfm --to=html5 --standalone \
   --toc --toc-depth=3 \
-  --metadata title="Ouroboros + Venom: A Governed Architecture for Autonomous Self-Development" \
+  --metadata title="Ouroboros + Venom (O+V): A Governed Architecture for Autonomous Self-Development" \
   --css=docs/benchmarks/_report_style.css \
   --embed-resources
 ```


### PR DESCRIPTION
Cross-document consistency fix (Anthropic Fellows application surface).

- README.md: 10-phase -> 11-phase governance pipeline (adds missing PLAN phase) at L246 + L716
- docs/architecture/OV_RESEARCH_PAPER_2026-04-16.{md,html}: title -> 'Ouroboros + Venom (O+V): A Governed Architecture for Autonomous Self-Development' (matches resume + canonical naming; updates title tag, both h1s, frontmatter, and documented pandoc build-command examples)

Docs only, no code touched (pre-commit integrity hook confirmed no Python staged). GitHub Pages rebuilds the live paper page on merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cross-document inconsistencies: switch Ouroboros to an 11‑phase pipeline (adds PLAN) and standardize the paper title to “Ouroboros + Venom (O+V): A Governed Architecture for Autonomous Self-Development”. Docs only; no code changes.

- **Bug Fixes**
  - README: 10-phase → 11-phase governance pipeline (adds PLAN) in description and orchestrator comment.
  - OV research paper: updated title to include “(O+V)” in frontmatter, H1s, HTML <title>, and pandoc build-command examples.

<sup>Written for commit 373d0f1878e1337ba31c9c2ca12e3f2eb36a0774. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/39726?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

