### PR TITLE
feat(swe-bench): Task #22 verdict-flush teardown coherence

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -985,6 +985,19 @@ class BattleTestHarness:
                 self._wall_clock_monitor_task = asyncio.ensure_future(
                     self._monitor_wall_clock(_wall_cap)
                 )
+                # Task #21 — Dynamic Timeout Coherence seam. Publish
+                # the absolute monotonic wall deadline so the
+                # governance layer (swe_bench_pro.evaluator) can
+                # structurally clamp its inner eval timeout BELOW the
+                # outer bounded-shutdown WITHOUT importing battle_test
+                # (env-var seam; mirrors the strategic_direction
+                # session-id module-global precedent). Composes the
+                # already-computed _wall_cap; additive; only set when a
+                # wall cap is armed — absent env ⇒ evaluator no-ops
+                # (byte-identical legacy for non-battle-test callers).
+                os.environ["OUROBOROS_BATTLE_WALL_DEADLINE_MONOTONIC"] = (
+                    repr(time.monotonic() + float(_wall_cap))
+                )
                 # Defect #1 Slice B (2026-05-03) — thread-based safety
                 # net immune to asyncio starvation. The asyncio task
                 # above is the primary path (handles normal termination
@@ -5344,7 +5357,41 @@ class BattleTestHarness:
             )
             _wdg = getattr(self, "_shutdown_watchdog", None)
             if _wdg is not None:
-                _wdg.arm(reason="wall_clock_cap", deadline_s=_bsw_deadline_s())
+                # Task #22 — composed-deadline coherence. The bounded
+                # watchdog arms here IN PARALLEL with the autoscore
+                # drain that runs later in _shutdown_components; with
+                # the bare default_deadline_s() the os._exit(75) can
+                # fire BEFORE harness_inject logs the verdict under a
+                # heavy session (deep-run bt-2026-05-19-011003). When
+                # closed-loop autoscore work is still in flight, extend
+                # the watchdog deadline by the autoscore grace + margin
+                # so the drain (which the evaluator already reserved
+                # via Task #21) completes first. Composes existing
+                # env knobs; no hardcode; bare path unchanged otherwise.
+                _arm_deadline = _bsw_deadline_s()
+                try:
+                    from backend.core.ouroboros.governance.swe_bench_pro.harness_inject import (  # noqa: E501
+                        autoscore_work_in_flight,
+                    )
+                    if autoscore_work_in_flight():
+                        _grace = float(os.environ.get(
+                            "JARVIS_SWE_BENCH_PRO_AUTOSCORE_SHUTDOWN_GRACE_S",
+                            "30",
+                        ) or "30")
+                        _margin = float(os.environ.get(
+                            "JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_MARGIN_S",
+                            "15",
+                        ) or "15")
+                        if _grace <= 0:
+                            _grace = 30.0
+                        if _margin <= 0:
+                            _margin = 15.0
+                        _arm_deadline = _arm_deadline + _grace + _margin
+                except Exception:  # noqa: BLE001 — never block the arm
+                    pass
+                _wdg.arm(
+                    reason="wall_clock_cap", deadline_s=_arm_deadline,
+                )
         except Exception:  # noqa: BLE001
             pass
         self._wall_clock_event.set()

--- a/backend/core/ouroboros/governance/swe_bench_pro/evaluator.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/evaluator.py
@@ -133,6 +133,131 @@ EVAL_TIMEOUT_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_EVAL_TIMEOUT_S"
 _DEFAULT_TIMEOUT_S: float = 1800.0
 
 
+# Task #21 — Dynamic Timeout Coherence. The harness publishes its
+# absolute monotonic WallClockWatchdog deadline here at arm time.
+# Reading it (NOT importing battle_test) lets the inner eval timeout
+# structurally end + emit TERMINAL_TIMEOUT BEFORE the outer bounded-
+# shutdown — so a verdict ALWAYS lands (A″ proved the 1800==1800
+# inversion otherwise yields zero verdicts). Absent ⇒ no clamp
+# (byte-identical legacy; non-battle-test callers unaffected).
+WALL_DEADLINE_ENV_VAR: str = "OUROBOROS_BATTLE_WALL_DEADLINE_MONOTONIC"
+_AUTOSCORE_GRACE_ENV_VAR: str = (
+    "JARVIS_SWE_BENCH_PRO_AUTOSCORE_SHUTDOWN_GRACE_S"
+)
+_DRAIN_BUFFER_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_BUFFER_S"
+# Task #22 — drain must cover the REAL post-eval teardown chain, not
+# a 2× heuristic. Env-string PARITY with
+# ``shutdown_watchdog.default_deadline_s`` (deliberately NOT imported
+# — preserves the "evaluator never imports battle_test" AST pin; the
+# parity is documented + pinned by a regression test instead).
+_SHUTDOWN_DEADLINE_ENV_VAR: str = "JARVIS_BATTLE_SHUTDOWN_DEADLINE_S"
+_DRAIN_MARGIN_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_MARGIN_S"
+_DEFAULT_SHUTDOWN_DEADLINE_S: float = 30.0   # parity w/ watchdog default
+_DEFAULT_AUTOSCORE_GRACE_S: float = 30.0
+_DEFAULT_DRAIN_MARGIN_S: float = 15.0
+# Never return <=0: a near-expired session still does the smallest
+# bounded wait so wait_for raises TERMINAL_TIMEOUT (a verdict) fast,
+# rather than a 0/negative timeout that would crash asyncio.wait_for.
+_MIN_EVAL_FLOOR_S: float = 10.0
+
+
+def _env_pos_float(name: str, default: float) -> float:
+    """Read a positive float env; fall back to ``default`` on
+    unset / invalid / non-positive. NEVER raises."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        v = float(raw)
+        return v if v > 0 else default
+    except (ValueError, TypeError):
+        return default
+
+
+def _eval_drain_buffer_s() -> float:
+    """Wall time the session needs AFTER the inner eval wait so the
+    verdict ALWAYS flushes before the process exits.
+
+    Task #22 root fix — composes the REAL post-eval teardown chain
+    (deep-run bt-2026-05-19-011003 proved the prior 2×autoscore-grace
+    =60s was undersized: bounded-shutdown arms its 30s deadline IN
+    PARALLEL with the autoscore drain, so under a heavy 950k-node
+    session ``os._exit(75)`` fired before ``harness_inject`` logged
+    the verdict)::
+
+        drain = shutdown_deadline + autoscore_grace + margin
+
+    - ``shutdown_deadline`` = ``JARVIS_BATTLE_SHUTDOWN_DEADLINE_S``
+      (env-string parity with ``shutdown_watchdog.default_deadline_s``
+      — documented + test-pinned, NOT imported).
+    - ``autoscore_grace`` = ``JARVIS_SWE_BENCH_PRO_AUTOSCORE_SHUTDOWN_
+      GRACE_S`` (the existing drain knob — single source of truth).
+    - ``margin`` = ``JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_MARGIN_S`` (slack
+      for GC / asyncio teardown / log flush).
+
+    Explicit ``JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_BUFFER_S`` still wins
+    (operator override). No hardcoded magic — every term is an
+    env-composed, individually-tunable structural component. NEVER
+    raises.
+    """
+    explicit = os.environ.get(_DRAIN_BUFFER_ENV_VAR, "").strip()
+    if explicit:
+        try:
+            v = float(explicit)
+            if v > 0:
+                return v
+        except (ValueError, TypeError):
+            pass
+    shutdown_deadline = _env_pos_float(
+        _SHUTDOWN_DEADLINE_ENV_VAR, _DEFAULT_SHUTDOWN_DEADLINE_S,
+    )
+    autoscore_grace = _env_pos_float(
+        _AUTOSCORE_GRACE_ENV_VAR, _DEFAULT_AUTOSCORE_GRACE_S,
+    )
+    margin = _env_pos_float(
+        _DRAIN_MARGIN_ENV_VAR, _DEFAULT_DRAIN_MARGIN_S,
+    )
+    return shutdown_deadline + autoscore_grace + margin
+
+
+def _apply_wall_coherence(configured: float) -> float:
+    """Clamp ``configured`` below the published session wall deadline.
+
+    ``eval = min(configured, wall_remaining - drain_buffer)``. No
+    deadline env ⇒ return ``configured`` unchanged (byte-identical
+    legacy). Coherent budget <=0 ⇒ ``_MIN_EVAL_FLOOR_S`` (still a
+    fast bounded wait → TERMINAL_TIMEOUT, never 0/negative). NEVER
+    raises; NEVER imports battle_test (env-var seam only).
+    """
+    raw = os.environ.get(WALL_DEADLINE_ENV_VAR, "").strip()
+    if not raw:
+        return configured
+    try:
+        deadline = float(raw)
+    except (ValueError, TypeError):
+        return configured
+    remaining = deadline - time.monotonic()
+    drain = _eval_drain_buffer_s()
+    coherent = remaining - drain
+    if coherent <= 0:
+        logger.info(
+            "[SWEBenchPro] wall budget exhausted (remaining=%.1fs "
+            "drain=%.1fs) — eval floored to %.1fs so wait_for still "
+            "emits TERMINAL_TIMEOUT (Task #21)",
+            remaining, drain, _MIN_EVAL_FLOOR_S,
+        )
+        return _MIN_EVAL_FLOOR_S
+    clamped = min(configured, coherent)
+    if clamped < configured:
+        logger.info(
+            "[SWEBenchPro] eval timeout clamped %.1fs -> %.1fs "
+            "(wall_remaining=%.1fs drain_buffer=%.1fs) — Dynamic "
+            "Timeout Coherence (Task #21)",
+            configured, clamped, remaining, drain,
+        )
+    return clamped
+
+
 # Terminal OperationState values that translate to "the model
 # produced a working fix" (RESOLVED) vs "the model failed" (UNRESOLVED).
 # Mirrors B.2.0.5's TERMINAL_OPERATION_STATES split. Closed taxonomy
@@ -231,25 +356,33 @@ def _resolve_timeout_s(explicit: Optional[float]) -> float:
     """Resolve the bounded-wait timeout.
 
     Precedence: explicit argument > env var > default. Invalid
-    env values fall back to the default with a WARN log.
-    NEVER raises.
+    env values fall back to the default with a WARN log. The
+    resolved value is then passed through Task #21 Dynamic Timeout
+    Coherence (:func:`_apply_wall_coherence`) so the inner wait
+    ALWAYS ends + emits TERMINAL_TIMEOUT before the outer bounded-
+    shutdown when a session wall deadline is published (no-op
+    otherwise — byte-identical legacy). NEVER raises.
     """
     if explicit is not None and explicit > 0:
-        return float(explicit)
-    raw = os.environ.get(EVAL_TIMEOUT_ENV_VAR, "").strip()
-    if not raw:
-        return _DEFAULT_TIMEOUT_S
-    try:
-        value = float(raw)
-        if value <= 0:
-            raise ValueError("must be > 0")
-        return value
-    except (ValueError, TypeError):
-        logger.warning(
-            "[SWEBenchPro] invalid %s=%r — using default %.1fs",
-            EVAL_TIMEOUT_ENV_VAR, raw, _DEFAULT_TIMEOUT_S,
-        )
-        return _DEFAULT_TIMEOUT_S
+        configured = float(explicit)
+    else:
+        raw = os.environ.get(EVAL_TIMEOUT_ENV_VAR, "").strip()
+        if not raw:
+            configured = _DEFAULT_TIMEOUT_S
+        else:
+            try:
+                value = float(raw)
+                if value <= 0:
+                    raise ValueError("must be > 0")
+                configured = value
+            except (ValueError, TypeError):
+                logger.warning(
+                    "[SWEBenchPro] invalid %s=%r — using default "
+                    "%.1fs",
+                    EVAL_TIMEOUT_ENV_VAR, raw, _DEFAULT_TIMEOUT_S,
+                )
+                configured = _DEFAULT_TIMEOUT_S
+    return _apply_wall_coherence(configured)
 
 
 # ===========================================================================
@@ -616,6 +749,47 @@ def register_flags(registry: Any) -> int:
             ),
             example=str(int(_DEFAULT_TIMEOUT_S)),
             since="v3.7 Phase 2 Phase B.2.2 (2026-05-12)",
+        ),
+        FlagSpec(
+            name=_DRAIN_BUFFER_ENV_VAR,
+            type=FlagType.INT,
+            default=0,
+            description=(
+                "Explicit override (seconds) for the post-eval drain "
+                "buffer Task #21/#22 Dynamic Timeout Coherence "
+                "subtracts from wall-remaining. 0/unset ⇒ COMPOSED = "
+                "JARVIS_BATTLE_SHUTDOWN_DEADLINE_S + "
+                "JARVIS_SWE_BENCH_PRO_AUTOSCORE_SHUTDOWN_GRACE_S + "
+                "JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_MARGIN_S. >0 wins "
+                "verbatim. Seeded by Task #22 (was env-only since #21)."
+            ),
+            category=Category.CAPACITY,
+            source_file=(
+                "backend/core/ouroboros/governance/swe_bench_pro/"
+                "evaluator.py"
+            ),
+            example="0",
+            since="v3.7 Task #21/#22 (2026-05-18)",
+        ),
+        FlagSpec(
+            name=_DRAIN_MARGIN_ENV_VAR,
+            type=FlagType.INT,
+            default=int(_DEFAULT_DRAIN_MARGIN_S),
+            description=(
+                "Slack (seconds) added to the composed drain buffer "
+                "for GC / asyncio teardown / log flush so the "
+                "autoscore verdict ALWAYS flushes before os._exit. "
+                "Task #22 root fix — deep-run bt-2026-05-19-011003 "
+                "proved the prior 2×autoscore-grace heuristic "
+                "undersized vs real bounded-shutdown latency."
+            ),
+            category=Category.CAPACITY,
+            source_file=(
+                "backend/core/ouroboros/governance/swe_bench_pro/"
+                "evaluator.py"
+            ),
+            example=str(int(_DEFAULT_DRAIN_MARGIN_S)),
+            since="v3.7 Task #22 (2026-05-18)",
         ),
     ]
 

--- a/tests/governance/test_swe_bench_pro_evaluator.py
+++ b/tests/governance/test_swe_bench_pro_evaluator.py
@@ -735,9 +735,15 @@ def test_register_flags_seeds_timeout() -> None:
             captured.append(spec)
 
     count = register_flags(_Capturer())
-    assert count == 1
+    # Task #22: register_flags now also seeds the drain-buffer +
+    # drain-margin knobs (were env-only since #21). EVAL_TIMEOUT
+    # remains the first spec with its 1800 default.
+    assert count == 3
+    names = {s.name for s in captured}
     assert captured[0].name == EVAL_TIMEOUT_ENV_VAR
     assert captured[0].default == 1800
+    assert "JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_BUFFER_S" in names
+    assert "JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_MARGIN_S" in names
 
 
 def test_register_flags_never_raises_on_capturer_failure() -> None:

--- a/tests/governance/test_swebench_eval_timeout_coherence.py
+++ b/tests/governance/test_swebench_eval_timeout_coherence.py
@@ -1,0 +1,257 @@
+"""Task #21 regression spine — Dynamic Timeout Coherence.
+
+A″ proved the inversion: inner SWE-Bench eval timeout (default 1800s)
+>= outer session wall cap ⇒ the session is killed before
+``evaluate_problem``'s ``wait_for`` raises ⇒ NO autoscore verdict
+EVER. Structural fix (NOT a config workaround): the harness publishes
+its absolute WallClockWatchdog deadline to an env var; the evaluator
+clamps ``eval = min(configured, wall_remaining - drain_buffer)`` so
+the inner wait ALWAYS ends + emits TERMINAL_TIMEOUT before the outer
+bounded-shutdown — removing human config-error from the threat model.
+
+Pins:
+  * no deadline env → byte-identical legacy (configured passthrough,
+    all precedence paths: explicit / env / default / invalid)
+  * far deadline (remaining ≫ configured) → configured (min)
+  * near deadline → clamped to remaining − drain_buffer
+  * expired/negative budget → _MIN_EVAL_FLOOR_S (never <=0)
+  * invalid deadline env → legacy passthrough (fail-open)
+  * drain_buffer composes the EXISTING autoscore grace knob
+  * AST: evaluator never imports battle_test; _resolve_timeout_s
+    composes _apply_wall_coherence; uses min(); reads the named
+    env const (no literal); harness publishes it at the arm site
+"""
+from __future__ import annotations
+
+import ast
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.swe_bench_pro import evaluator as E
+from backend.core.ouroboros.governance.swe_bench_pro.evaluator import (
+    _apply_wall_coherence,
+    _eval_drain_buffer_s,
+    _resolve_timeout_s,
+    _MIN_EVAL_FLOOR_S,
+    _DEFAULT_TIMEOUT_S,
+    _SHUTDOWN_DEADLINE_ENV_VAR,
+    _DRAIN_MARGIN_ENV_VAR,
+    _DEFAULT_SHUTDOWN_DEADLINE_S,
+    _DEFAULT_AUTOSCORE_GRACE_S,
+    _DEFAULT_DRAIN_MARGIN_S,
+    WALL_DEADLINE_ENV_VAR,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+_EVAL_SRC = _REPO / "backend/core/ouroboros/governance/swe_bench_pro/evaluator.py"
+_HARNESS_SRC = _REPO / "backend/core/ouroboros/battle_test/harness.py"
+_WATCHDOG_SRC = _REPO / "backend/core/ouroboros/battle_test/shutdown_watchdog.py"
+_DEADLINE = WALL_DEADLINE_ENV_VAR
+_GRACE = "JARVIS_SWE_BENCH_PRO_AUTOSCORE_SHUTDOWN_GRACE_S"
+_DRAIN = "JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_BUFFER_S"
+_EVT = "JARVIS_SWE_BENCH_PRO_EVAL_TIMEOUT_S"
+_SHUT = _SHUTDOWN_DEADLINE_ENV_VAR
+_MARGIN = _DRAIN_MARGIN_ENV_VAR
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    for k in (_DEADLINE, _GRACE, _DRAIN, _EVT, _SHUT, _MARGIN):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+# --------------------------------------------------------------------------
+# Legacy passthrough (no deadline ⇒ byte-identical pre-#21 behaviour)
+# --------------------------------------------------------------------------
+
+def test_legacy_default_passthrough():
+    assert _resolve_timeout_s(None) == _DEFAULT_TIMEOUT_S
+
+
+def test_legacy_explicit_passthrough():
+    assert _resolve_timeout_s(123.0) == 123.0
+
+
+def test_legacy_env_passthrough(monkeypatch):
+    monkeypatch.setenv(_EVT, "777")
+    assert _resolve_timeout_s(None) == 777.0
+
+
+def test_legacy_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(_EVT, "not-a-number")
+    assert _resolve_timeout_s(None) == _DEFAULT_TIMEOUT_S
+
+
+# --------------------------------------------------------------------------
+# Coherence clamp
+# --------------------------------------------------------------------------
+
+def test_far_deadline_returns_configured(monkeypatch):
+    monkeypatch.setenv(_DEADLINE, repr(time.monotonic() + 100_000))
+    assert _resolve_timeout_s(300.0) == 300.0  # min picks configured
+
+
+def test_near_deadline_clamps_to_remaining_minus_drain(monkeypatch):
+    monkeypatch.setenv(_DEADLINE, repr(time.monotonic() + 200.0))
+    drain = _eval_drain_buffer_s()           # 2*30 default = 60
+    v = _resolve_timeout_s(1800.0)
+    assert 0 < v < 1800.0
+    assert abs(v - (200.0 - drain)) < 5.0     # ~140s
+
+
+def test_expired_budget_returns_floor_never_negative(monkeypatch):
+    monkeypatch.setenv(_DEADLINE, repr(time.monotonic() - 50.0))
+    v = _resolve_timeout_s(1800.0)
+    assert v == _MIN_EVAL_FLOOR_S and v > 0
+
+
+def test_invalid_deadline_env_is_failopen_passthrough(monkeypatch):
+    monkeypatch.setenv(_DEADLINE, "garbage")
+    assert _resolve_timeout_s(1800.0) == 1800.0
+
+
+def test_drain_buffer_is_composed_sum_not_2x_grace(monkeypatch):
+    # Task #22: drain = shutdown_deadline + autoscore_grace + margin
+    # (NOT the old 2×grace heuristic). Distinct values prove the sum.
+    assert _eval_drain_buffer_s() == (
+        _DEFAULT_SHUTDOWN_DEADLINE_S
+        + _DEFAULT_AUTOSCORE_GRACE_S
+        + _DEFAULT_DRAIN_MARGIN_S
+    )  # 30 + 30 + 15 = 75 (NOT 2*30=60)
+    monkeypatch.setenv(_SHUT, "50")
+    monkeypatch.setenv(_GRACE, "40")
+    monkeypatch.setenv(_MARGIN, "20")
+    assert _eval_drain_buffer_s() == 110.0      # 50+40+20, not 2*40
+    monkeypatch.setenv(_DRAIN, "12.5")          # explicit override wins
+    assert _eval_drain_buffer_s() == 12.5
+    monkeypatch.delenv(_DRAIN, raising=False)
+    # invalid components fall back to per-term defaults (never raises)
+    monkeypatch.setenv(_SHUT, "nope")
+    monkeypatch.setenv(_GRACE, "-5")
+    monkeypatch.setenv(_MARGIN, "")
+    assert _eval_drain_buffer_s() == (
+        _DEFAULT_SHUTDOWN_DEADLINE_S
+        + _DEFAULT_AUTOSCORE_GRACE_S
+        + _DEFAULT_DRAIN_MARGIN_S
+    )
+
+
+def test_apply_wall_coherence_is_pure_no_deadline(monkeypatch):
+    # Direct helper: absent env → unchanged.
+    assert _apply_wall_coherence(999.0) == 999.0
+
+
+# --------------------------------------------------------------------------
+# AST / structural pins
+# --------------------------------------------------------------------------
+
+def test_ast_pin_evaluator_never_imports_battle_test():
+    tree = ast.parse(_EVAL_SRC.read_text())
+    for node in ast.walk(tree):
+        mod = None
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+        elif isinstance(node, ast.Import):
+            mod = ",".join(a.name for a in node.names)
+        if mod and "battle_test" in mod:
+            pytest.fail(
+                f"evaluator must NOT import battle_test ({mod}) — "
+                f"the wall deadline is an env-var seam, not an import"
+            )
+
+
+def test_ast_pin_resolve_composes_coherence_and_min():
+    src = _EVAL_SRC.read_text()
+    tree = ast.parse(src)
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_resolve_timeout_s"
+    )
+    body = ast.unparse(fn)
+    assert "_apply_wall_coherence" in body, (
+        "_resolve_timeout_s must route through the coherence clamp"
+    )
+    coh = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_apply_wall_coherence"
+    )
+    coh_src = ast.unparse(coh)
+    assert "min(" in coh_src, "coherence must be min(configured, ...)"
+    assert "WALL_DEADLINE_ENV_VAR" in coh_src, (
+        "must read the named deadline env const, not a literal"
+    )
+
+
+def test_ast_pin_harness_publishes_deadline_at_arm():
+    src = _HARNESS_SRC.read_text()
+    assert 'os.environ["OUROBOROS_BATTLE_WALL_DEADLINE_MONOTONIC"]' in src
+    # Published only inside the wall-cap-armed branch (composes _wall_cap).
+    arm = src.index("if _wall_cap is not None and _wall_cap > 0:")
+    pub = src.index('os.environ["OUROBOROS_BATTLE_WALL_DEADLINE_MONOTONIC"]')
+    nxt = src.index("def ", arm)
+    assert arm < pub < nxt, (
+        "deadline publish must be inside the wall-cap-armed branch"
+    )
+
+
+# --------------------------------------------------------------------------
+# Task #22 — teardown-coherence pins
+# --------------------------------------------------------------------------
+
+def test_ast_pin_shutdown_deadline_env_parity_no_import():
+    """evaluator's shutdown-deadline env string MUST equal the one
+    shutdown_watchdog.default_deadline_s reads — proven by parity,
+    NOT by importing battle_test (the AST pin below still holds)."""
+    wd = _WATCHDOG_SRC.read_text()
+    # shutdown_watchdog.default_deadline_s uses this exact literal.
+    assert 'os.environ.get("JARVIS_BATTLE_SHUTDOWN_DEADLINE_S"' in wd, (
+        "shutdown_watchdog env string changed — update evaluator "
+        "_SHUTDOWN_DEADLINE_ENV_VAR parity + this pin together"
+    )
+    assert _SHUTDOWN_DEADLINE_ENV_VAR == "JARVIS_BATTLE_SHUTDOWN_DEADLINE_S"
+
+
+def test_ast_pin_drain_composes_three_terms_not_2x():
+    tree = ast.parse(_EVAL_SRC.read_text())
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "_eval_drain_buffer_s"
+    )
+    body = ast.unparse(fn)
+    assert "_SHUTDOWN_DEADLINE_ENV_VAR" in body
+    assert "_AUTOSCORE_GRACE_ENV_VAR" in body
+    assert "_DRAIN_MARGIN_ENV_VAR" in body
+    assert "* 2" not in body and "*2" not in body, (
+        "the 2×grace heuristic must be gone (Task #22)"
+    )
+
+
+def test_ast_pin_harness_wall_path_composes_deadline_when_autoscore_inflight():
+    src = _HARNESS_SRC.read_text()
+    # The wall_clock_cap bounded-watchdog arm must consult
+    # autoscore_work_in_flight and extend the deadline by grace+margin
+    # so os._exit cannot fire before the drain flushes the verdict.
+    arm = src.index('_wdg.arm(\n                    reason="wall_clock_cap"')
+    region = src[src.rindex("try:", 0, arm) - 200: arm]
+    assert "autoscore_work_in_flight" in region, (
+        "wall-cap arm must consult autoscore_work_in_flight"
+    )
+    assert "_arm_deadline" in region and (
+        "_grace + _margin" in region or "_grace" in region
+    ), "wall-cap arm must extend deadline by grace(+margin) in-flight"
+
+
+def test_ast_pin_evaluator_still_never_imports_battle_test_after_22():
+    tree = ast.parse(_EVAL_SRC.read_text())
+    for node in ast.walk(tree):
+        mod = None
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+        elif isinstance(node, ast.Import):
+            mod = ",".join(a.name for a in node.names)
+        if mod and "battle_test" in mod:
+            pytest.fail(f"evaluator imported battle_test ({mod}) — #22 "
+                        f"must keep the env-string-parity seam")


### PR DESCRIPTION
## Summary
Completes the ratified Dynamic Timeout Coherence arc (Task #21). Deep-run `bt-2026-05-19-011003` proved #21's dynamic clamp works (86400s → 5337.6s, wall-derived) but the autoscore verdict still never flushed: the inner eval timed out ~60s before the wall (by design) yet bounded-shutdown + parallel_evaluate-yield + harness_inject verdict-log + await_autoscore_drain exceeded the 60s `drain_buffer` under a heavy 950k-node session → `os._exit(75)` fired before the verdict logged. Mechanism correct; the `2×autoscore-grace` buffer heuristic was undersized vs real production teardown latency.

## Changes
- **A — `evaluator._eval_drain_buffer_s`**: `drain = JARVIS_BATTLE_SHUTDOWN_DEADLINE_S + JARVIS_SWE_BENCH_PRO_AUTOSCORE_SHUTDOWN_GRACE_S + JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_MARGIN_S` (default 30+30+15=75). Env-string **parity** with `shutdown_watchdog.default_deadline_s` — deliberately **NOT imported** (evaluator-never-imports-`battle_test` AST pin preserved). 2×grace heuristic removed; explicit `EVAL_DRAIN_BUFFER_S` override still wins.
- **B — harness `wall_clock_cap` arm**: when `autoscore_work_in_flight()`, extend the `BoundedShutdownWatchdog` deadline by `grace+margin` so `os._exit` cannot precede the drain. Bare path byte-unchanged otherwise. Composed, no hardcode.
- **C — durability**: confirmed `parallel_eval.store.record()` already precedes the `yield` (EvaluationRecord persisted before harness_inject logs) — ordering correct by construction; no code change.
- **D — tests**: rewrote the #21 `2×grace` pin → composed 3-term sum; +4 #22 AST pins (shutdown-env parity / 3-term compose / harness composed-deadline-when-inflight / evaluator-no-`battle_test`).
- **E — FlagRegistry**: `register_flags` now also seeds `EVAL_DRAIN_BUFFER_S` + `EVAL_DRAIN_MARGIN_S` (env-only since #21); count pin updated 1 → 3.

## Tests
**17** coherence-spine + **131** scoped regression green (evaluator / parallel_eval / autoscore wiring+liveness / flag_registry_seed_truth / harness wall-clock-cap / process_memory_watchdog / partial-shutdown). Zero regression. evaluator-never-imports-`battle_test` AST pin holds.

## Scope / honesty
- Closes the **#21 teardown-flush gap**. Does **NOT** close **#19-CAPABILITY** (O+V's real solve capability remains unmeasured — no real verdict has flushed yet; the post-merge deep re-run will measure it).
- **NOTE:** the branch commit `cd24100e01` carries a stale reused message (ProcessMemoryWatchdog/P3/P4) — wrong on the branch only; this PR title/body is the accurate record and the squash-merge to `main` uses it.
- Out of scope (excluded, flagged): `requirements.txt` drift (recorded checkpoint-stash landmine); untracked `test_swe_bench_pro_wiring_validation.py` (unknown provenance — to be triaged separately, not committed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures SWE-Bench autoscore verdicts always flush before shutdown by aligning the inner eval timeout with the wall-clock watchdog and composing a real teardown buffer. Prevents `os._exit(75)` from preempting verdict logging under heavy sessions.

- **Bug Fixes**
  - Compose drain buffer as `shutdown_deadline + autoscore_grace + margin` (defaults 30+30+15=75); `JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_BUFFER_S` still overrides.
  - Clamp eval timeout to `wall_remaining - drain` using `OUROBOROS_BATTLE_WALL_DEADLINE_MONOTONIC`; floor to a small positive value when exhausted; no `battle_test` imports.
  - Harness publishes the wall deadline when a wall cap is armed and extends the bounded watchdog by `grace + margin` when `autoscore_work_in_flight()` so the drain can finish first.
  - Register flags for `JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_BUFFER_S` and `JARVIS_SWE_BENCH_PRO_EVAL_DRAIN_MARGIN_S`.
  - Add a regression suite for timeout/drain coherence and update flag registry tests.

<sup>Written for commit cd24100e01868910b295a6ccf7d225a44cde42b7. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/40617?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

