### PR TITLE
feat(governance): Operator Commit Authority (Slices 1+2) — fixes Cursor IDE commit gate

### DIFF
--- a/backend/core/ouroboros/governance/commit_authority_cli.py
+++ b/backend/core/ouroboros/governance/commit_authority_cli.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""
+Operator Commit Authority -- CLI + hook dispatcher (Slice 2)
+============================================================
+
+Consumer of the :mod:`operator_commit_authority` substrate. This is
+the versioned replacement for the untracked bash Iron Gate wrapper.
+It is a *consumer* (not the substrate) so it may freely compose the
+substrate, run git, exec the chained integrity hook, and read env.
+
+Subcommands
+-----------
+* ``hook pre-commit`` -- the gate dispatcher git invokes.
+* ``grant``           -- issue a signed, time-bounded commit grant.
+* ``revoke``          -- revoke a grant (by id or all).
+* ``status``          -- show gate state + a dry verify.
+
+Behavior contract (zero behavior change until graduated)
+--------------------------------------------------------
+* OCA master **OFF** (default ``JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED``
+  unset): the legacy operator token check is enforced with the *same*
+  SHA-256 semantics as the retired bash hook (sha256 of the exact
+  ``JARVIS_AUTHORIZE_COMMIT_TOKEN`` bytes vs the trimmed contents of
+  ``~/.jarvis/commit_token.sha256``, constant-time compare). The gate
+  is byte-equivalent to pre-Slice-2 -- nothing changes for the
+  operator until they opt in.
+* OCA master **ON**: operator channels (repl/cli/ide/daemon) require a
+  signed grant on disk; **no env-var export is needed for the IDE
+  GUI** -- that is the entire point of OCA.
+* On authority pass (either path), the dispatcher chains to the
+  file-integrity guardian ``pre-commit.project`` -- existing
+  protection is preserved, not replaced.
+
+The legacy token check lives **here, once**. The bash file is retired
+by ``install_hooks.py``; there is no parallel copy of the logic.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Legacy operator-token compatibility (single source -- retires the bash)
+# ---------------------------------------------------------------------------
+
+_LEGACY_TOKEN_ENV = "JARVIS_AUTHORIZE_COMMIT_TOKEN"
+_LEGACY_HASH_FILE_ENV = "JARVIS_COMMIT_TOKEN_HASH_FILE"
+_DEFAULT_HASH_FILE = "~/.jarvis/commit_token.sha256"
+
+_RED = "\033[1;31m"
+_DIM = "\033[2m"
+_RESET = "\033[0m"
+
+
+def _refuse(reason: str, hint: str = "") -> None:
+    sys.stderr.write(
+        f"\n{_RED}# IRON GATE -- Commit blocked: {reason}{_RESET}\n"
+    )
+    if hint:
+        sys.stderr.write(f"   {hint}\n")
+    sys.stderr.write("\n")
+
+
+def legacy_token_ok() -> Tuple[bool, str]:
+    """Mirror the retired bash hook exactly. NEVER raises.
+
+    bash: ``sha256(printf '%s' "$TOKEN")`` vs trimmed hash-file
+    contents, length+constant-time compare, fail-closed on any gap.
+    """
+    token = os.environ.get(_LEGACY_TOKEN_ENV, "")
+    if not token:
+        return False, f"{_LEGACY_TOKEN_ENV} unset"
+    hash_file = (
+        os.environ.get(_LEGACY_HASH_FILE_ENV, "").strip()
+        or os.path.expanduser(_DEFAULT_HASH_FILE)
+    )
+    try:
+        expected = (
+            Path(hash_file)
+            .expanduser()
+            .read_text(encoding="utf-8")
+            .strip()
+        )
+    except Exception:  # noqa: BLE001
+        return False, (
+            f"expected-hash file missing/unreadable: {hash_file}"
+        )
+    if not expected:
+        return False, "expected-hash file empty (fail-closed)"
+    actual = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    if len(actual) != len(expected) or not hmac.compare_digest(
+        actual, expected
+    ):
+        return False, "token hash mismatch"
+    return True, "legacy operator token verified"
+
+
+# ---------------------------------------------------------------------------
+# Git introspection (bounded; never shell=True)
+# ---------------------------------------------------------------------------
+
+
+def _git(args: List[str], root: str) -> Optional[subprocess.CompletedProcess]:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _repo_root() -> str:
+    r = _git(["rev-parse", "--show-toplevel"], os.getcwd())
+    if r is not None and r.returncode == 0 and r.stdout.strip():
+        return r.stdout.strip()
+    return os.getcwd()
+
+
+def _branch(root: str) -> str:
+    r = _git(["rev-parse", "--abbrev-ref", "HEAD"], root)
+    return r.stdout.strip() if r and r.returncode == 0 else ""
+
+
+def _staged_files(root: str) -> Tuple[str, ...]:
+    r = _git(
+        ["diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        root,
+    )
+    if r is None or r.returncode != 0:
+        return ()
+    return tuple(
+        ln.strip() for ln in r.stdout.splitlines() if ln.strip()
+    )
+
+
+def _chain_project_hook(root: str) -> int:
+    """Run the file-integrity guardian after authority passes.
+    Mirrors the bash ``exec "$_NEXT"`` chain. If no integrity hook is
+    installed, do not block (authority already passed)."""
+    candidates: List[Path] = []
+    r = _git(["rev-parse", "--git-path", "hooks"], root)
+    if r is not None and r.returncode == 0 and r.stdout.strip():
+        hp = Path(r.stdout.strip())
+        if not hp.is_absolute():
+            hp = Path(root) / hp
+        candidates.append(hp / "pre-commit.project")
+    candidates.append(Path(root) / "scripts" / "hooks" / "pre-commit.project")
+    for cand in candidates:
+        if cand.exists():
+            try:
+                return subprocess.run(
+                    [sys.executable, str(cand)],
+                    cwd=root,
+                    check=False,
+                ).returncode
+            except Exception as exc:  # noqa: BLE001 — fail closed
+                _refuse(
+                    f"file-integrity hook failed to run: "
+                    f"{type(exc).__name__}"
+                )
+                return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+def cmd_hook_pre_commit() -> int:
+    root = _repo_root()
+    # Late import so the dispatcher works even if the substrate moves.
+    try:
+        from backend.core.ouroboros.governance import (
+            operator_commit_authority as oca,
+        )
+    except Exception as exc:  # noqa: BLE001 — fail closed
+        _refuse(
+            f"OCA substrate unavailable: {type(exc).__name__}",
+            "fail closed -- commit blocked",
+        )
+        return 1
+
+    if oca.master_enabled():
+        channel = (
+            os.environ.get("JARVIS_COMMIT_CHANNEL", "").strip().lower()
+            or "ide"
+        )
+        ctx = oca.CommitAuthorityContext(
+            channel=channel,
+            repo_root=root,
+            branch=_branch(root),
+            staged_files=_staged_files(root),
+        )
+        verdict = oca.verify_pre_commit(ctx)
+        if not verdict.authorized():
+            _refuse(
+                f"{verdict.verdict.value} -- {verdict.detail}",
+                "operator: issue a grant -> "
+                "`/commit grant <minutes>` (Serpent REPL) or "
+                "`python3 -m backend.core.ouroboros.governance"
+                ".commit_authority_cli grant --minutes 60`",
+            )
+            return 1
+        sys.stderr.write(
+            f"{_DIM}# OCA: {verdict.verdict.value} "
+            f"({verdict.detail}){_RESET}\n"
+        )
+    else:
+        ok, reason = legacy_token_ok()
+        if not ok:
+            _refuse(
+                f"Missing operator cryptographic authorization "
+                f"({reason})",
+                "operator: export "
+                "JARVIS_AUTHORIZE_COMMIT_TOKEN before an "
+                "authorized commit (or graduate OCA: set "
+                "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED=true "
+                "and use signed grants).",
+            )
+            return 1
+
+    return _chain_project_hook(root)
+
+
+def cmd_grant(args: argparse.Namespace) -> int:
+    from backend.core.ouroboros.governance import (
+        operator_commit_authority as oca,
+    )
+
+    root = _repo_root()
+    ttl_s = int(args.minutes) * 60 if args.minutes else None
+    outcome = oca.issue_grant(
+        channel=args.channel,
+        operator_label=(
+            args.label
+            or os.environ.get("USER")
+            or "operator"
+        ),
+        ttl_s=ttl_s,
+        scopes=tuple(args.scope or ()),
+        branch=args.branch or "",
+        governance_amend=bool(args.governance_amend),
+        repo_root=Path(root),
+    )
+    if not outcome.ok:
+        print(f"grant FAILED: {outcome.error}", file=sys.stderr)
+        return 1
+    print(
+        "grant issued: "
+        f"id={outcome.grant_id} "
+        f"channel={args.channel} "
+        f"expires_at_unix={outcome.expires_at_unix:.0f} "
+        f"ledger={outcome.grants_path_str}"
+    )
+    return 0
+
+
+def cmd_revoke(args: argparse.Namespace) -> int:
+    from backend.core.ouroboros.governance import (
+        operator_commit_authority as oca,
+    )
+
+    n = oca.revoke_grants(
+        grant_id=args.id,
+        revoke_all=bool(args.all),
+    )
+    print(
+        "revoked all grants"
+        if args.all
+        else f"revoke recorded: id={args.id} (n={n})"
+    )
+    return 0 if n == 1 else 1
+
+
+def cmd_status(_args: argparse.Namespace) -> int:
+    from backend.core.ouroboros.governance import (
+        operator_commit_authority as oca,
+    )
+
+    root = _repo_root()
+    sp = oca.secret_path()
+    print("Operator Commit Authority -- status")
+    print(f"  master_enabled        : {oca.master_enabled()}")
+    print(f"  grants ledger         : {oca.grants_path()}")
+    print(
+        f"  per-machine secret    : {sp} "
+        f"({'present' if sp.exists() else 'absent'})"
+    )
+    print(f"  default grant TTL (s) : {oca.default_ttl_s()}")
+    if oca.master_enabled():
+        ctx = oca.CommitAuthorityContext(
+            channel="ide",
+            repo_root=root,
+            branch=_branch(root),
+            staged_files=_staged_files(root),
+        )
+        v = oca.verify_pre_commit(ctx)
+        print(
+            f"  dry verify (ide)      : {v.verdict.value} "
+            f"-- {v.detail}"
+        )
+    else:
+        ok, reason = legacy_token_ok()
+        print(
+            f"  legacy token path     : "
+            f"{'OK' if ok else 'NOT SATISFIED'} ({reason})"
+        )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# argparse
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="commit_authority_cli",
+        description="Operator Commit Authority CLI + hook dispatcher",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    h = sub.add_parser("hook", help="git hook dispatcher")
+    h.add_argument(
+        "phase", choices=["pre-commit"], help="hook phase"
+    )
+
+    g = sub.add_parser("grant", help="issue a signed commit grant")
+    g.add_argument(
+        "--minutes",
+        type=int,
+        default=None,
+        help="grant lifetime in minutes (default: adaptive TTL)",
+    )
+    g.add_argument(
+        "--channel",
+        default="ide",
+        help="commit channel (repl/cli/ide/daemon/autonomous)",
+    )
+    g.add_argument(
+        "--scope",
+        action="append",
+        default=[],
+        help="repo-relative path prefix the grant covers "
+        "(repeatable; default: whole repo)",
+    )
+    g.add_argument("--branch", default="", help="bind to a branch")
+    g.add_argument("--label", default="", help="operator audit label")
+    g.add_argument(
+        "--governance-amend",
+        action="store_true",
+        help="permit a governance/ drift commit",
+    )
+
+    r = sub.add_parser("revoke", help="revoke grant(s)")
+    r.add_argument("--id", default=None, help="grant id to revoke")
+    r.add_argument(
+        "--all", action="store_true", help="revoke all grants"
+    )
+
+    sub.add_parser("status", help="show gate state + dry verify")
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.cmd == "hook" and args.phase == "pre-commit":
+        return cmd_hook_pre_commit()
+    if args.cmd == "grant":
+        return cmd_grant(args)
+    if args.cmd == "revoke":
+        return cmd_revoke(args)
+    if args.cmd == "status":
+        return cmd_status(args)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/core/ouroboros/governance/operator_commit_authority.py
+++ b/backend/core/ouroboros/governance/operator_commit_authority.py
@@ -1,0 +1,1487 @@
+"""
+Operator Commit Authority (OCA) — unified human + autonomous commit gate
+=========================================================================
+
+**Why this exists** — the repo carried TWO commit-authorization paths
+with incompatible plumbing:
+
+  1. ``AutoCommitter`` (autonomous) already composes typed substrates:
+     :mod:`ledger_sovereignty` (owned-worktree boundary),
+     :mod:`governance_manifest` (hash-cap on governance/ drift),
+     :mod:`gitignore_guard` (tracked-but-ignored breach).
+  2. The human operator went through an *untracked* bash
+     ``.git/hooks/pre-commit`` that required a shell env var
+     (``JARVIS_AUTHORIZE_COMMIT_TOKEN``). GUI git (Cursor Source
+     Control) does not inherit shell env → every IDE commit was
+     refused with ``⛔ IRON GATE — Commit blocked``.
+
+That is not a Cursor bug — it is an architectural seam: authorization
+logic lived in an untracked bash hook + env var while the rest of O+V
+uses typed substrates, append-only ledgers, and graduation flags. OCA
+closes the seam: ONE verifier, ONE verdict taxonomy, every channel
+(IDE GUI / terminal / REPL / autonomous daemon) routed through it.
+
+Operator workflow (graduated state)
+-----------------------------------
+1. ``python3 scripts/install_hooks.py install``  (Slice 2 — versioned
+   hook chain replaces the untracked bash wrapper).
+2. Issue a time-bounded grant before an IDE session, either:
+     * Serpent REPL: ``/commit grant 60``  (Slice 3), or
+     * CLI: ``python3 -m backend.core.ouroboros.governance\
+.commit_authority_cli grant --minutes 60``  (Slice 2).
+3. Commit from Cursor freely until the grant TTL expires — no shell
+   env export, because the grant lives in a signed file the Python
+   verifier reads directly.
+4. Autonomous soaks keep using worktree + sovereignty (unchanged);
+   the autonomous channel does NOT need an operator grant — it is
+   authorized by the :mod:`ledger_sovereignty` marker exactly as
+   before.
+
+Composition (zero duplication)
+------------------------------
+* :mod:`ledger_sovereignty` — autonomous channel ownership decision
+  (we delegate, never reimplement).
+* :mod:`governance_manifest` — governance/ drift hash-cap, composed
+  via ``verify_governance_state`` / ``is_refusal_verdict``.
+* :mod:`cross_process_jsonl` — append-only grant ledger writes
+  (``flock_append_line``), the canonical cross-process primitive.
+* :mod:`roadmap_reader` — HMAC sign/verify (``compute_signature`` /
+  ``verify_signature``), the canonical constant-time crypto. A
+  hand-edited grant line fails signature verification and is treated
+  as no grant. **No parallel HMAC logic** is defined here — if the
+  canonical crypto cannot be imported the verifier fails *closed*.
+* :mod:`operation_mode` — read-only adaptive TTL (PLAN/ANALYZE modes
+  shorten freshly-issued grants).
+
+Authority asymmetry (AST-pinned)
+--------------------------------
+Substrate imports stdlib + the four composed substrates ONLY. It does
+NOT import orchestrator / iron_gate / policy / providers /
+candidate_generator / urgency_router / change_engine /
+semantic_guardian / auto_committer / risk_tier_floor / tool_executor.
+Consumers (Slice 2 hook CLI + AutoCommitter) lazy-import THIS module.
+
+Master flag ``JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED`` default-
+**FALSE** per §33.1 — until graduated, ``verify_pre_commit`` returns
+the ``DISABLED`` verdict and the hook chain behaves byte-identically
+to the pre-substrate world. Pure substrate — public API NEVER raises.
+
+Manifesto: §6 Iron Gate, §8 absolute observability, §33.1 default-
+FALSE graduation, Reverse Russian Doll (operator authority at the
+outer shell, O+V bounded inside).
+"""
+from __future__ import annotations
+
+import ast
+import enum
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+logger = logging.getLogger(__name__)
+
+
+OPERATOR_COMMIT_AUTHORITY_SCHEMA_VERSION: str = "operator_commit_authority.1"
+
+
+# ===========================================================================
+# Env knobs
+# ===========================================================================
+
+
+_ENV_MASTER = "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED"
+_ENV_DEFAULT_TTL_S = "JARVIS_COMMIT_GRANT_DEFAULT_TTL_S"
+_ENV_PLAN_TTL_S = "JARVIS_COMMIT_GRANT_PLAN_TTL_S"
+_ENV_GRANTS_PATH = "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH"
+_ENV_SECRET_PATH = "JARVIS_COMMIT_AUTHORITY_SECRET_PATH"
+
+_DEFAULT_GRANTS_RELATIVE = ".jarvis/commit_authority/grants.jsonl"
+_DEFAULT_SECRET_RELATIVE = ("commit_authority", "secret")  # under ~/.jarvis
+
+_DEFAULT_TTL_S = 3600
+_MIN_TTL_S = 60
+_MAX_TTL_S = 86_400  # 24h ceiling
+_DEFAULT_PLAN_TTL_S = 900  # PLAN/ANALYZE modes: shorter grants
+
+_GIT_OP_TIMEOUT_S = 5.0
+
+_TRUTHY: FrozenSet[str] = frozenset({"1", "true", "yes", "on"})
+
+_REVOKE_ALL_TOKEN = "*"
+
+
+def _flag(name: str, *, default: bool = False) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in _TRUTHY
+
+
+def master_enabled() -> bool:
+    """§33.1 opt-in safety gate — default-**FALSE**.
+
+    When off, :func:`verify_pre_commit` returns ``DISABLED`` and the
+    hook chain is byte-identical to the pre-substrate world. The
+    operator graduates this flag deliberately after Slice 2 wiring.
+    """
+    return _flag(_ENV_MASTER, default=False)
+
+
+def _read_clamped_int(name: str, default: int, lo: int, hi: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, n))
+
+
+def default_ttl_s() -> int:
+    """Default grant lifetime. Clamped to [60, 86_400]."""
+    return _read_clamped_int(
+        _ENV_DEFAULT_TTL_S, _DEFAULT_TTL_S, _MIN_TTL_S, _MAX_TTL_S
+    )
+
+
+def plan_mode_ttl_s() -> int:
+    """Grant lifetime when the operator is in PLAN/ANALYZE mode —
+    shorter by default (analysis sessions shouldn't leave a long
+    commit window open). Clamped to [60, 86_400]."""
+    return _read_clamped_int(
+        _ENV_PLAN_TTL_S, _DEFAULT_PLAN_TTL_S, _MIN_TTL_S, _MAX_TTL_S
+    )
+
+
+# ===========================================================================
+# Path resolution
+# ===========================================================================
+
+
+def _resolve_repo_root() -> Optional[Path]:
+    """Walk up from this module to find the .git anchor. NEVER raises."""
+    try:
+        here = Path(__file__).resolve()
+        for ancestor in (here, *here.parents):
+            try:
+                if (ancestor / ".git").exists():
+                    return ancestor
+            except Exception:  # noqa: BLE001
+                continue
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def grants_path() -> Path:
+    """Canonical append-only grant ledger. Operator override via
+    ``JARVIS_COMMIT_AUTHORITY_GRANTS_PATH``. NEVER raises."""
+    raw = os.environ.get(_ENV_GRANTS_PATH, "").strip()
+    if raw:
+        try:
+            return Path(raw).expanduser().resolve()
+        except Exception:  # noqa: BLE001
+            pass
+    root = _resolve_repo_root()
+    if root is None:
+        return Path(_DEFAULT_GRANTS_RELATIVE)
+    return root / _DEFAULT_GRANTS_RELATIVE
+
+
+def secret_path() -> Path:
+    """Per-machine HMAC secret location. Lives OUTSIDE the repo
+    (``~/.jarvis/commit_authority/secret``) so it is never committed
+    and never depends on a shell env export — that is precisely what
+    makes the IDE-GUI path work. Operator override via
+    ``JARVIS_COMMIT_AUTHORITY_SECRET_PATH``. NEVER raises."""
+    raw = os.environ.get(_ENV_SECRET_PATH, "").strip()
+    if raw:
+        try:
+            return Path(raw).expanduser().resolve()
+        except Exception:  # noqa: BLE001
+            pass
+    return Path.home() / ".jarvis" / Path(*_DEFAULT_SECRET_RELATIVE)
+
+
+# ===========================================================================
+# Per-machine HMAC secret (auto-generated on first issuance)
+# ===========================================================================
+
+
+def _read_secret() -> Optional[str]:
+    """Read the per-machine secret. Returns ``None`` when absent or
+    unreadable — verification then fails *closed* (every grant is
+    unverifiable, so no grant authorizes). NEVER raises."""
+    target = secret_path()
+    try:
+        if not target.exists():
+            return None
+        value = target.read_text(encoding="utf-8").strip()
+        return value or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _ensure_secret() -> Optional[str]:
+    """Read the secret, generating it (0600, O_EXCL) on first use.
+    Only the issuance path calls this — verification never creates
+    state. Returns the secret, or ``None`` on I/O failure."""
+    existing = _read_secret()
+    if existing is not None:
+        return existing
+    target = secret_path()
+    new_secret = os.urandom(32).hex()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(
+            str(target),
+            os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+            0o600,
+        )
+        try:
+            os.write(fd, new_secret.encode("utf-8"))
+        finally:
+            os.close(fd)
+        return new_secret
+    except FileExistsError:
+        # Lost a race — another issuance created it. Re-read.
+        return _read_secret()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[operator_commit_authority] secret create failed at %s: "
+            "%s — issuance will fail closed",
+            target,
+            type(exc).__name__,
+        )
+        return None
+
+
+def _sign(payload: Mapping[str, Any], secret: str) -> str:
+    """Compose the canonical HMAC from :mod:`roadmap_reader`. NEVER
+    raises. Returns ``""`` when the canonical crypto is unavailable —
+    callers treat an empty signature as a fail-closed condition."""
+    try:
+        from backend.core.ouroboros.governance.roadmap_reader import (
+            compute_signature,
+        )
+        return compute_signature(payload, secret)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _verify(payload: Mapping[str, Any], signature_hex: str, secret: str) -> bool:
+    """Compose the canonical constant-time verify from
+    :mod:`roadmap_reader`. NEVER raises. Returns ``False`` (fail
+    closed) when the canonical crypto is unavailable."""
+    try:
+        from backend.core.ouroboros.governance.roadmap_reader import (
+            verify_signature,
+        )
+        return verify_signature(payload, signature_hex, secret)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# ===========================================================================
+# Closed taxonomies (AST-pinned)
+# ===========================================================================
+
+
+class CommitChannel(str, enum.Enum):
+    """Closed 5-value commit channel — bytes-pinned via AST.
+
+    * ``REPL`` — Serpent REPL ``/commit`` issuance + commits.
+    * ``CLI`` — ``commit_authority_cli`` operator tool.
+    * ``IDE`` — Cursor / VS Code Source Control GUI (the path that
+      cannot inherit shell env — OCA's reason to exist).
+    * ``DAEMON`` — long-running operator-side issuer (Slice 4 socket).
+    * ``AUTONOMOUS`` — O+V ``AutoCommitter``; authorized by the
+      :mod:`ledger_sovereignty` marker, NOT an operator grant.
+    """
+
+    REPL = "repl"
+    CLI = "cli"
+    IDE = "ide"
+    DAEMON = "daemon"
+    AUTONOMOUS = "autonomous"
+
+    @classmethod
+    def parse(cls, value: object) -> Optional["CommitChannel"]:
+        """Strict parse — returns ``None`` on unknown (caller maps
+        that to the ``CHANNEL_UNKNOWN`` verdict). NEVER raises."""
+        try:
+            return cls(str(value).strip().lower())
+        except Exception:  # noqa: BLE001
+            return None
+
+
+class CommitAuthorityVerdict(str, enum.Enum):
+    """Closed 8-value verdict — bytes-pinned via AST.
+
+    * ``AUTHORIZED`` — commit may proceed (hook chain continues to
+      the file-integrity layer).
+    * ``DENIED_NO_GRANT`` — no valid signed grant for this
+      repo/branch/channel (a hand-edited / forged grant lands here
+      because its signature fails to verify).
+    * ``DENIED_EXPIRED`` — a matching grant exists but its TTL
+      elapsed.
+    * ``DENIED_SCOPE`` — a matching unexpired grant exists but its
+      path scopes do not cover the staged files.
+    * ``DENIED_GOVERNANCE_DRIFT`` — staged files touch governance/
+      and drift from the operator-signed manifest without a
+      ``governance_amend`` grant.
+    * ``DENIED_SOVEREIGNTY`` — autonomous channel committing into a
+      tree it does not own (sovereignty master on).
+    * ``DISABLED`` — OCA master flag off; gate skipped.
+    * ``CHANNEL_UNKNOWN`` — unrecognized channel string (fail
+      closed — an unknown channel is never authorized).
+    """
+
+    AUTHORIZED = "authorized"
+    DENIED_NO_GRANT = "denied_no_grant"
+    DENIED_EXPIRED = "denied_expired"
+    DENIED_SCOPE = "denied_scope"
+    DENIED_GOVERNANCE_DRIFT = "denied_governance_drift"
+    DENIED_SOVEREIGNTY = "denied_sovereignty"
+    DISABLED = "disabled"
+    CHANNEL_UNKNOWN = "channel_unknown"
+
+
+def is_authorized_verdict(verdict: object) -> bool:
+    """Return True iff the verdict permits the commit. Only
+    ``AUTHORIZED`` and ``DISABLED`` (gate skipped) pass. Centralized
+    so the Slice 2 hook composes ONE predicate (no parallel string
+    comparison). NEVER raises."""
+    try:
+        val = getattr(verdict, "value", None) or str(verdict)
+        return val in (
+            CommitAuthorityVerdict.AUTHORIZED.value,
+            CommitAuthorityVerdict.DISABLED.value,
+        )
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# ===========================================================================
+# §33.5 frozen versioned artifacts
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class CommitGrant:
+    """One time-bounded operator commit grant. The signed payload
+    (everything except the out-of-band signature) is what the HMAC
+    covers — a hand-edited line fails verification."""
+
+    grant_id: str
+    issued_at_unix: float
+    expires_at_unix: float
+    repo_root_sha256: str
+    branch: str  # empty string = any branch
+    channel: str  # CommitChannel value
+    scopes: Tuple[str, ...]  # repo-relative posix prefixes; () = whole repo
+    operator_label: str
+    governance_amend: bool = False
+    schema_version: str = OPERATOR_COMMIT_AUTHORITY_SCHEMA_VERSION
+
+    def signed_payload(self) -> Dict[str, Any]:
+        """Canonical dict the HMAC is computed over. Deterministic
+        (scopes sorted) so re-serialization round-trips."""
+        return {
+            "grant_id": self.grant_id,
+            "issued_at_unix": float(self.issued_at_unix),
+            "expires_at_unix": float(self.expires_at_unix),
+            "repo_root_sha256": self.repo_root_sha256,
+            "branch": self.branch,
+            "channel": self.channel,
+            "scopes": sorted(self.scopes),
+            "operator_label": self.operator_label,
+            "governance_amend": bool(self.governance_amend),
+            "schema_version": self.schema_version,
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self.signed_payload()
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> Optional["CommitGrant"]:
+        """Defensive parser. Returns None on structural violation.
+        NEVER raises."""
+        try:
+            gid = str(raw.get("grant_id", "")).strip()
+            if not gid:
+                return None
+            scopes_raw = raw.get("scopes", []) or []
+            scopes = tuple(
+                str(s).strip()
+                for s in scopes_raw
+                if str(s).strip()
+            )
+            return cls(
+                grant_id=gid,
+                issued_at_unix=float(raw.get("issued_at_unix", 0.0)),
+                expires_at_unix=float(raw.get("expires_at_unix", 0.0)),
+                repo_root_sha256=str(
+                    raw.get("repo_root_sha256", "")
+                ).strip().lower(),
+                branch=str(raw.get("branch", "")).strip(),
+                channel=str(raw.get("channel", "")).strip().lower(),
+                scopes=scopes,
+                operator_label=str(raw.get("operator_label", "")),
+                governance_amend=bool(raw.get("governance_amend", False)),
+                schema_version=str(
+                    raw.get(
+                        "schema_version",
+                        OPERATOR_COMMIT_AUTHORITY_SCHEMA_VERSION,
+                    )
+                ),
+            )
+        except Exception:  # noqa: BLE001
+            return None
+
+
+@dataclass(frozen=True)
+class CommitAuthorityContext:
+    """Verifier input. Frozen so the verdict can't be racing a
+    mutated context."""
+
+    channel: str
+    repo_root: str
+    branch: str = ""
+    staged_files: Tuple[str, ...] = ()
+    now_unix: Optional[float] = None
+
+    def effective_now(self) -> float:
+        return (
+            float(self.now_unix)
+            if self.now_unix is not None
+            else time.time()
+        )
+
+
+@dataclass(frozen=True)
+class CommitAuthorityVerdictResult:
+    """Verifier output. NEVER constructed by raising — every public
+    failure mode maps to a verdict here."""
+
+    schema_version: str
+    verdict: CommitAuthorityVerdict
+    channel: str
+    matched_grant_id: str
+    detail: str
+    governance_verdict: str = ""  # ManifestVerdict.value when consulted
+
+    def authorized(self) -> bool:
+        return is_authorized_verdict(self.verdict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "verdict": self.verdict.value,
+            "channel": self.channel,
+            "matched_grant_id": self.matched_grant_id,
+            "detail": self.detail[:512],
+            "governance_verdict": self.governance_verdict,
+        }
+
+
+@dataclass(frozen=True)
+class GrantIssueOutcome:
+    """Result of an operator-driven grant issuance."""
+
+    ok: bool
+    grant_id: str
+    expires_at_unix: float
+    grants_path_str: str
+    error: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "grant_id": self.grant_id,
+            "expires_at_unix": float(self.expires_at_unix),
+            "grants_path_str": self.grants_path_str,
+            "error": self.error,
+        }
+
+
+def _verdict(
+    verdict: CommitAuthorityVerdict,
+    channel: str,
+    detail: str,
+    *,
+    matched_grant_id: str = "",
+    governance_verdict: str = "",
+) -> CommitAuthorityVerdictResult:
+    return CommitAuthorityVerdictResult(
+        schema_version=OPERATOR_COMMIT_AUTHORITY_SCHEMA_VERSION,
+        verdict=verdict,
+        channel=channel,
+        matched_grant_id=matched_grant_id,
+        detail=detail,
+        governance_verdict=governance_verdict,
+    )
+
+
+# ===========================================================================
+# Git introspection (subprocess discipline — mirrors gitignore_guard)
+# ===========================================================================
+
+
+def _run_git(
+    args: Sequence[str],
+    *,
+    repo_root: Path,
+    timeout_s: float = _GIT_OP_TIMEOUT_S,
+) -> Optional[subprocess.CompletedProcess]:
+    """Bounded git invocation. Array args only — NEVER ``shell=True``.
+    Returns ``None`` on any failure. NEVER raises."""
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def resolve_repo_root_and_branch(
+    repo_root: Path,
+) -> Tuple[Optional[Path], str]:
+    """Resolve the canonical toplevel + current branch. Falls back to
+    the provided ``repo_root`` when git can't answer. NEVER raises."""
+    top = _run_git(
+        ["rev-parse", "--show-toplevel"], repo_root=repo_root
+    )
+    resolved_root: Optional[Path]
+    if top is not None and top.returncode == 0 and top.stdout.strip():
+        try:
+            resolved_root = Path(top.stdout.strip()).resolve()
+        except Exception:  # noqa: BLE001
+            resolved_root = None
+    else:
+        try:
+            resolved_root = Path(repo_root).resolve()
+        except Exception:  # noqa: BLE001
+            resolved_root = None
+
+    branch = ""
+    head = _run_git(
+        ["rev-parse", "--abbrev-ref", "HEAD"], repo_root=repo_root
+    )
+    if head is not None and head.returncode == 0:
+        branch = head.stdout.strip()
+    return resolved_root, branch
+
+
+def repo_root_fingerprint(repo_root: Path) -> str:
+    """SHA-256 of the resolved absolute repo-root path. A grant is
+    bound to a specific checkout — a grant for the operator's main
+    checkout never authorizes commits in a different clone."""
+    try:
+        resolved = str(Path(repo_root).resolve())
+    except Exception:  # noqa: BLE001
+        resolved = str(repo_root)
+    return hashlib.sha256(resolved.encode("utf-8")).hexdigest()
+
+
+# ===========================================================================
+# Append-only grant ledger (composes cross_process_jsonl)
+# ===========================================================================
+
+
+def _append_record(record: Mapping[str, Any]) -> bool:
+    """Append one JSON record to the grant ledger via the canonical
+    cross-process primitive. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.cross_process_jsonl import (
+            flock_append_line,
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    target = grants_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except Exception:  # noqa: BLE001
+        return False
+    try:
+        line = json.dumps(record, sort_keys=True)
+    except Exception:  # noqa: BLE001
+        return False
+    return flock_append_line(target, line)
+
+
+def _read_ledger() -> List[Dict[str, Any]]:
+    """Read every ledger record. Malformed lines are skipped. NEVER
+    raises — an unreadable ledger yields ``[]`` (fail closed: no
+    grant means no authorization)."""
+    target = grants_path()
+    try:
+        if not target.exists():
+            return []
+        text = target.read_text(encoding="utf-8")
+    except Exception:  # noqa: BLE001
+        return []
+    out: List[Dict[str, Any]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:  # noqa: BLE001
+            continue
+        if isinstance(obj, dict):
+            out.append(obj)
+    return out
+
+
+def _scope_covers(scopes: Tuple[str, ...], staged: Sequence[str]) -> bool:
+    """Empty scopes → whole repo. Otherwise every staged file must
+    sit under at least one scope prefix (posix, repo-relative)."""
+    if not scopes:
+        return True
+    norm_scopes = [s.strip().strip("/") for s in scopes if s.strip()]
+    if not norm_scopes:
+        return True
+    for f in staged:
+        ff = str(f).replace(os.sep, "/").strip().lstrip("./")
+        covered = False
+        for sc in norm_scopes:
+            if ff == sc or ff.startswith(sc + "/"):
+                covered = True
+                break
+        if not covered:
+            return False
+    return True
+
+
+# ===========================================================================
+# Public API — verify (NEVER raises)
+# ===========================================================================
+
+
+def _autonomous_verdict(
+    ctx: CommitAuthorityContext,
+    repo_root: Path,
+) -> CommitAuthorityVerdictResult:
+    """Autonomous channel: delegate the ownership decision to
+    :mod:`ledger_sovereignty` — never reimplement it. No operator
+    grant is required for an owned worktree (legacy behavior)."""
+    try:
+        from backend.core.ouroboros.governance import (
+            ledger_sovereignty as ls,
+        )
+    except Exception:  # noqa: BLE001
+        # Cannot consult sovereignty → fail closed for autonomous.
+        return _verdict(
+            CommitAuthorityVerdict.DENIED_SOVEREIGNTY,
+            ctx.channel,
+            "ledger_sovereignty unavailable — autonomous commit "
+            "refused (fail closed)",
+        )
+    if ls.master_enabled() and not ls.is_owned(repo_root):
+        return _verdict(
+            CommitAuthorityVerdict.DENIED_SOVEREIGNTY,
+            ctx.channel,
+            f"autonomous commit into non-owned tree {repo_root} — "
+            "sovereignty marker absent",
+        )
+    return _verdict(
+        CommitAuthorityVerdict.AUTHORIZED,
+        ctx.channel,
+        "autonomous channel — sovereignty owned (or sovereignty "
+        "master off); no operator grant required",
+    )
+
+
+def _governance_gate(
+    ctx: CommitAuthorityContext,
+    grant: Optional[CommitGrant],
+) -> Optional[CommitAuthorityVerdictResult]:
+    """Compose :mod:`governance_manifest`. Returns a DENY verdict iff
+    staged files drift from the operator-signed manifest and the
+    matched grant lacks ``governance_amend``. ``None`` = pass."""
+    if not ctx.staged_files:
+        return None
+    try:
+        from backend.core.ouroboros.governance import (
+            governance_manifest as gm,
+        )
+        comparison = gm.verify_governance_state(
+            target_files=list(ctx.staged_files)
+        )
+        gov_val = comparison.verdict.value
+        if gm.is_refusal_verdict(comparison.verdict):
+            if grant is not None and grant.governance_amend:
+                return None  # operator explicitly authorized the amend
+            return _verdict(
+                CommitAuthorityVerdict.DENIED_GOVERNANCE_DRIFT,
+                ctx.channel,
+                "staged files drift from operator-signed governance "
+                "manifest; issue a grant with governance_amend=True "
+                "or refresh the manifest",
+                matched_grant_id=grant.grant_id if grant else "",
+                governance_verdict=gov_val,
+            )
+        return None
+    except Exception:  # noqa: BLE001
+        # Manifest substrate unavailable — do NOT block on its
+        # absence (it has its own opt-in master flag). Pass through.
+        return None
+
+
+def verify_pre_commit(
+    ctx: CommitAuthorityContext,
+) -> CommitAuthorityVerdictResult:
+    """The single commit-authorization verifier. NEVER raises.
+
+    Off-master → ``DISABLED`` (byte-identical legacy hook chain).
+    Autonomous channel → delegated to :mod:`ledger_sovereignty`.
+    Operator channels → require a valid signed, unexpired, in-scope
+    grant; governance/ drift additionally requires a
+    ``governance_amend`` grant.
+    """
+    if not master_enabled():
+        return _verdict(
+            CommitAuthorityVerdict.DISABLED,
+            str(ctx.channel),
+            f"OCA disabled via {_ENV_MASTER}=false — legacy hook "
+            "chain proceeds unchanged",
+        )
+
+    channel = CommitChannel.parse(ctx.channel)
+    if channel is None:
+        return _verdict(
+            CommitAuthorityVerdict.CHANNEL_UNKNOWN,
+            str(ctx.channel),
+            f"unrecognized commit channel {ctx.channel!r} — fail "
+            "closed (known: repl/cli/ide/daemon/autonomous)",
+        )
+
+    try:
+        repo_root = Path(ctx.repo_root).resolve()
+    except Exception:  # noqa: BLE001
+        repo_root = Path(ctx.repo_root or ".")
+
+    # Autonomous channel never needs an operator grant; it is bounded
+    # by the sovereignty marker (composed, not reimplemented). The
+    # governance hash-cap still applies (autonomous ops touching
+    # governance/ must match the signed manifest).
+    if channel is CommitChannel.AUTONOMOUS:
+        sov = _autonomous_verdict(ctx, repo_root)
+        if not sov.authorized():
+            return sov
+        gov = _governance_gate(ctx, grant=None)
+        if gov is not None:
+            return gov
+        return sov
+
+    # Operator channels (repl/cli/ide/daemon): require a valid grant.
+    secret = _read_secret()
+    if not secret:
+        return _verdict(
+            CommitAuthorityVerdict.DENIED_NO_GRANT,
+            channel.value,
+            "no per-machine secret present — cannot verify any "
+            "grant (fail closed). Issue a grant first to "
+            "bootstrap the secret.",
+        )
+
+    fp = repo_root_fingerprint(repo_root)
+    now = ctx.effective_now()
+    records = _read_ledger()
+
+    # Build revocation/consume sets from the append-only ledger.
+    explicitly_revoked: set = set()
+    revoke_all_at: float = -1.0
+    consumed: set = set()
+    for rec in records:
+        rtype = str(rec.get("type", "")).strip().lower()
+        if rtype == "revoke":
+            gid = str(rec.get("grant_id", "")).strip()
+            if gid == _REVOKE_ALL_TOKEN:
+                try:
+                    revoke_all_at = max(
+                        revoke_all_at, float(rec.get("at_unix", 0.0))
+                    )
+                except Exception:  # noqa: BLE001
+                    continue
+            elif gid:
+                explicitly_revoked.add(gid)
+        elif rtype == "consume":
+            gid = str(rec.get("grant_id", "")).strip()
+            if gid:
+                consumed.add(gid)
+
+    # Walk grant records newest-last; track the best near-miss so the
+    # operator gets the most actionable verdict.
+    saw_expired = False
+    saw_scope_miss = False
+    matched: Optional[CommitGrant] = None
+    for rec in records:
+        if str(rec.get("type", "")).strip().lower() != "grant":
+            continue
+        grant = CommitGrant.from_dict(rec.get("grant", {}))
+        if grant is None:
+            continue
+        signature = str(rec.get("signature", ""))
+        if not _verify(grant.signed_payload(), signature, secret):
+            # Forged / tampered / wrong-secret line — treat as absent.
+            continue
+        if grant.grant_id in explicitly_revoked:
+            continue
+        if grant.grant_id in consumed:
+            continue
+        if revoke_all_at >= 0.0 and grant.issued_at_unix <= revoke_all_at:
+            continue
+        if grant.repo_root_sha256 and grant.repo_root_sha256 != fp:
+            continue
+        if grant.branch and ctx.branch and grant.branch != ctx.branch:
+            continue
+        if grant.channel and grant.channel != channel.value:
+            continue
+        if grant.expires_at_unix <= now:
+            saw_expired = True
+            continue
+        if not _scope_covers(grant.scopes, ctx.staged_files):
+            saw_scope_miss = True
+            continue
+        matched = grant  # keep walking — latest valid grant wins
+
+    if matched is None:
+        if saw_scope_miss:
+            return _verdict(
+                CommitAuthorityVerdict.DENIED_SCOPE,
+                channel.value,
+                "a valid unexpired grant exists but its path "
+                "scopes do not cover the staged files",
+            )
+        if saw_expired:
+            return _verdict(
+                CommitAuthorityVerdict.DENIED_EXPIRED,
+                channel.value,
+                "the matching grant has expired — issue a fresh "
+                "grant (/commit grant <minutes>)",
+            )
+        return _verdict(
+            CommitAuthorityVerdict.DENIED_NO_GRANT,
+            channel.value,
+            "no valid signed commit grant for this "
+            "repo/branch/channel — issue one via /commit grant "
+            "or commit_authority_cli",
+        )
+
+    gov = _governance_gate(ctx, matched)
+    if gov is not None:
+        return gov
+
+    return _verdict(
+        CommitAuthorityVerdict.AUTHORIZED,
+        channel.value,
+        f"authorized by grant {matched.grant_id} "
+        f"(operator={matched.operator_label!r})",
+        matched_grant_id=matched.grant_id,
+    )
+
+
+# ===========================================================================
+# Public API — issue / revoke / consume (operator-only; NEVER raises)
+# ===========================================================================
+
+
+def _adaptive_ttl_s() -> int:
+    """Default TTL, shortened when the operator is in a PLAN/ANALYZE
+    operation mode (read-only compose of :mod:`operation_mode`). A
+    long commit window during an analysis session is a footgun."""
+    base = default_ttl_s()
+    try:
+        from backend.core.ouroboros.governance import operation_mode as om
+        mode = om.resolve_mode_from_env()
+        mode_val = getattr(mode, "value", str(mode)).strip().lower()
+        if mode_val in ("plan", "analyze"):
+            return min(base, plan_mode_ttl_s())
+    except Exception:  # noqa: BLE001
+        pass
+    return base
+
+
+def issue_grant(
+    *,
+    channel: str,
+    operator_label: str,
+    ttl_s: Optional[int] = None,
+    scopes: Sequence[str] = (),
+    branch: str = "",
+    governance_amend: bool = False,
+    repo_root: Optional[Path] = None,
+    now_unix: Optional[float] = None,
+) -> GrantIssueOutcome:
+    """Issue a time-bounded operator commit grant. Operator-only
+    entry point (REPL/CLI compose this). Bootstraps the per-machine
+    secret on first use. NEVER raises."""
+    if not operator_label or not str(operator_label).strip():
+        return GrantIssueOutcome(
+            ok=False,
+            grant_id="",
+            expires_at_unix=0.0,
+            grants_path_str=str(grants_path()),
+            error="operator_label required (audit string)",
+        )
+
+    parsed = CommitChannel.parse(channel)
+    if parsed is None:
+        return GrantIssueOutcome(
+            ok=False,
+            grant_id="",
+            expires_at_unix=0.0,
+            grants_path_str=str(grants_path()),
+            error=(
+                f"unknown channel {channel!r} "
+                "(repl/cli/ide/daemon/autonomous)"
+            ),
+        )
+
+    secret = _ensure_secret()
+    if not secret:
+        return GrantIssueOutcome(
+            ok=False,
+            grant_id="",
+            expires_at_unix=0.0,
+            grants_path_str=str(grants_path()),
+            error=(
+                "could not create/read per-machine secret at "
+                f"{secret_path()} — issuance fails closed"
+            ),
+        )
+
+    root = (
+        Path(repo_root)
+        if repo_root is not None
+        else (_resolve_repo_root() or Path("."))
+    )
+    fp = repo_root_fingerprint(root)
+
+    effective_ttl = (
+        int(ttl_s)
+        if ttl_s is not None and int(ttl_s) > 0
+        else _adaptive_ttl_s()
+    )
+    effective_ttl = max(_MIN_TTL_S, min(_MAX_TTL_S, effective_ttl))
+
+    now = float(now_unix) if now_unix is not None else time.time()
+    grant = CommitGrant(
+        grant_id=uuid.uuid4().hex,
+        issued_at_unix=now,
+        expires_at_unix=now + float(effective_ttl),
+        repo_root_sha256=fp,
+        branch=str(branch).strip(),
+        channel=parsed.value,
+        scopes=tuple(
+            str(s).strip() for s in scopes if str(s).strip()
+        ),
+        operator_label=str(operator_label).strip(),
+        governance_amend=bool(governance_amend),
+    )
+    signature = _sign(grant.signed_payload(), secret)
+    if not signature:
+        return GrantIssueOutcome(
+            ok=False,
+            grant_id="",
+            expires_at_unix=0.0,
+            grants_path_str=str(grants_path()),
+            error=(
+                "canonical HMAC unavailable (roadmap_reader) — "
+                "refusing to write an unsigned grant (fail closed)"
+            ),
+        )
+
+    record = {
+        "type": "grant",
+        "at_unix": now,
+        "grant": grant.to_dict(),
+        "signature": signature,
+    }
+    if not _append_record(record):
+        return GrantIssueOutcome(
+            ok=False,
+            grant_id="",
+            expires_at_unix=0.0,
+            grants_path_str=str(grants_path()),
+            error="grant ledger append failed",
+        )
+    return GrantIssueOutcome(
+        ok=True,
+        grant_id=grant.grant_id,
+        expires_at_unix=grant.expires_at_unix,
+        grants_path_str=str(grants_path()),
+    )
+
+
+def revoke_grants(
+    *,
+    grant_id: Optional[str] = None,
+    revoke_all: bool = False,
+    now_unix: Optional[float] = None,
+) -> int:
+    """Append a revocation tombstone (the ledger is append-only per
+    §8). ``revoke_all`` revokes every grant issued at or before now.
+    Returns 1 on a successful append, 0 on failure. NEVER raises."""
+    now = float(now_unix) if now_unix is not None else time.time()
+    if revoke_all:
+        ok = _append_record(
+            {
+                "type": "revoke",
+                "at_unix": now,
+                "grant_id": _REVOKE_ALL_TOKEN,
+            }
+        )
+        return 1 if ok else 0
+    gid = str(grant_id or "").strip()
+    if not gid or gid == _REVOKE_ALL_TOKEN:
+        return 0
+    ok = _append_record(
+        {"type": "revoke", "at_unix": now, "grant_id": gid}
+    )
+    return 1 if ok else 0
+
+
+def consume_grant(
+    grant_id: str,
+    *,
+    now_unix: Optional[float] = None,
+) -> bool:
+    """Mark a grant one-shot-consumed (append a consume event). A
+    consumed grant no longer authorizes. NEVER raises."""
+    gid = str(grant_id or "").strip()
+    if not gid:
+        return False
+    now = float(now_unix) if now_unix is not None else time.time()
+    return _append_record(
+        {"type": "consume", "at_unix": now, "grant_id": gid}
+    )
+
+
+# ===========================================================================
+# §33.3 AST pins
+# ===========================================================================
+
+
+_TARGET_FILE = (
+    "backend/core/ouroboros/governance/operator_commit_authority.py"
+)
+
+
+def register_shipped_invariants() -> list:
+    """Auto-discovered AST invariant pins."""
+    try:
+        from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+            ShippedCodeInvariant,
+        )
+    except ImportError:
+        return []
+
+    _EXPECTED_VERDICTS = {
+        "authorized",
+        "denied_no_grant",
+        "denied_expired",
+        "denied_scope",
+        "denied_governance_drift",
+        "denied_sovereignty",
+        "disabled",
+        "channel_unknown",
+    }
+    _EXPECTED_CHANNELS = {"repl", "cli", "ide", "daemon", "autonomous"}
+
+    def _enum_values(tree: ast.AST, class_name: str) -> set:
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ClassDef)
+                and node.name == class_name
+            ):
+                found = set()
+                for sub in node.body:
+                    if (
+                        isinstance(sub, ast.Assign)
+                        and len(sub.targets) == 1
+                        and isinstance(sub.targets[0], ast.Name)
+                        and isinstance(sub.value, ast.Constant)
+                        and isinstance(sub.value.value, str)
+                    ):
+                        found.add(sub.value.value)
+                return found
+        return set()
+
+    def _validate_verdict_taxonomy(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        found = _enum_values(tree, "CommitAuthorityVerdict")
+        if not found:
+            return ("CommitAuthorityVerdict class not found",)
+        missing = _EXPECTED_VERDICTS - found
+        extra = found - _EXPECTED_VERDICTS
+        if missing:
+            return (f"CommitAuthorityVerdict missing: {sorted(missing)}",)
+        if extra:
+            return (f"CommitAuthorityVerdict drift: {sorted(extra)}",)
+        return ()
+
+    def _validate_channel_taxonomy(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        found = _enum_values(tree, "CommitChannel")
+        if not found:
+            return ("CommitChannel class not found",)
+        missing = _EXPECTED_CHANNELS - found
+        extra = found - _EXPECTED_CHANNELS
+        if missing:
+            return (f"CommitChannel missing: {sorted(missing)}",)
+        if extra:
+            return (f"CommitChannel drift: {sorted(extra)}",)
+        return ()
+
+    def _validate_authority_asymmetry(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        forbidden = (
+            "backend.core.ouroboros.governance.orchestrator",
+            "backend.core.ouroboros.governance.iron_gate",
+            "backend.core.ouroboros.governance.policy",
+            "backend.core.ouroboros.governance.policy_engine",
+            "backend.core.ouroboros.governance.providers",
+            "backend.core.ouroboros.governance.candidate_generator",
+            "backend.core.ouroboros.governance.urgency_router",
+            "backend.core.ouroboros.governance.change_engine",
+            "backend.core.ouroboros.governance.semantic_guardian",
+            "backend.core.ouroboros.governance.auto_committer",
+            "backend.core.ouroboros.governance.risk_tier_floor",
+            "backend.core.ouroboros.governance.tool_executor",
+        )
+        violations: List[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                if any(mod == f for f in forbidden):
+                    violations.append(
+                        f"forbidden authority import: {mod}"
+                    )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in forbidden:
+                        violations.append(
+                            f"forbidden authority import: {alias.name}"
+                        )
+        return tuple(violations)
+
+    def _validate_master_default_false(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.FunctionDef)
+                and node.name == "master_enabled"
+            ):
+                for sub in ast.walk(node):
+                    if (
+                        isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Name)
+                        and sub.func.id == "_flag"
+                    ):
+                        for kw in sub.keywords:
+                            if (
+                                kw.arg == "default"
+                                and isinstance(kw.value, ast.Constant)
+                                and kw.value.value is False
+                            ):
+                                return ()
+                return (
+                    "master_enabled() must call _flag(..., "
+                    "default=False) per §33.1",
+                )
+        return ("master_enabled() not found",)
+
+    def _validate_composes_canonical(
+        tree: ast.AST, source: str,
+    ) -> tuple:
+        required = (
+            "ledger_sovereignty",
+            "governance_manifest",
+            "cross_process_jsonl",
+            "roadmap_reader",
+        )
+        missing = [r for r in required if r not in source]
+        if missing:
+            return (
+                "must compose canonical substrates (no parallel "
+                f"logic) — missing references: {missing}",
+            )
+        return ()
+
+    def _validate_subprocess_discipline(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        """Every subprocess.run call MUST pass a timeout and MUST
+        NOT pass shell=True — mirrors gitignore_guard's bounded git
+        discipline. A shelled-out / unbounded git call is a hang
+        and an injection surface in a security-critical gate."""
+        violations: List[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_subprocess_run = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "run"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "subprocess"
+            )
+            if not is_subprocess_run:
+                continue
+            kwargs = {kw.arg: kw.value for kw in node.keywords}
+            if "timeout" not in kwargs:
+                violations.append(
+                    "subprocess.run missing timeout kwarg"
+                )
+            shell = kwargs.get("shell")
+            if (
+                isinstance(shell, ast.Constant)
+                and shell.value is True
+            ):
+                violations.append("subprocess.run uses shell=True")
+        return tuple(violations)
+
+    return [
+        ShippedCodeInvariant(
+            invariant_name=(
+                "operator_commit_authority_verdict_taxonomy_closed"
+            ),
+            target_file=_TARGET_FILE,
+            description=(
+                "CommitAuthorityVerdict 8-value taxonomy bytes-"
+                "pinned — the single closed verdict vocabulary "
+                "every channel maps onto."
+            ),
+            validate=_validate_verdict_taxonomy,
+        ),
+        ShippedCodeInvariant(
+            invariant_name=(
+                "operator_commit_authority_channel_taxonomy_closed"
+            ),
+            target_file=_TARGET_FILE,
+            description=(
+                "CommitChannel 5-value taxonomy bytes-pinned — "
+                "repl/cli/ide/daemon/autonomous. An unknown "
+                "channel must map to CHANNEL_UNKNOWN, never an "
+                "implicit pass."
+            ),
+            validate=_validate_channel_taxonomy,
+        ),
+        ShippedCodeInvariant(
+            invariant_name=(
+                "operator_commit_authority_authority_asymmetry"
+            ),
+            target_file=_TARGET_FILE,
+            description=(
+                "Substrate purity — OCA MUST NOT import "
+                "orchestrator / iron_gate / policy / providers / "
+                "candidate_generator / urgency_router / "
+                "change_engine / semantic_guardian / "
+                "auto_committer / risk_tier_floor / tool_executor. "
+                "Consumers (hook CLI + AutoCommitter) lazy-import "
+                "OCA, never vice versa."
+            ),
+            validate=_validate_authority_asymmetry,
+        ),
+        ShippedCodeInvariant(
+            invariant_name=(
+                "operator_commit_authority_master_default_false"
+            ),
+            target_file=_TARGET_FILE,
+            description=(
+                "§33.1 — master_enabled() default-FALSE so the "
+                "hook chain is byte-identical until the operator "
+                "graduates OCA after Slice 2 wiring."
+            ),
+            validate=_validate_master_default_false,
+        ),
+        ShippedCodeInvariant(
+            invariant_name=(
+                "operator_commit_authority_composes_canonical"
+            ),
+            target_file=_TARGET_FILE,
+            description=(
+                "Zero duplication — OCA composes "
+                "ledger_sovereignty (ownership), "
+                "governance_manifest (drift hash-cap), "
+                "cross_process_jsonl (append-only ledger), and "
+                "roadmap_reader (canonical constant-time HMAC). "
+                "No parallel sovereignty / manifest / flock / "
+                "HMAC logic."
+            ),
+            validate=_validate_composes_canonical,
+        ),
+        ShippedCodeInvariant(
+            invariant_name=(
+                "operator_commit_authority_subprocess_discipline"
+            ),
+            target_file=_TARGET_FILE,
+            description=(
+                "Every subprocess.run is bounded (timeout kwarg) "
+                "and never shell=True — a security-critical gate "
+                "must not hang or expose a shell-injection "
+                "surface on git introspection."
+            ),
+            validate=_validate_subprocess_discipline,
+        ),
+    ]
+
+
+# ===========================================================================
+# FlagRegistry seeds
+# ===========================================================================
+
+
+def register_flags(registry: Any) -> int:
+    """Auto-discovered via §33.3. Fail-open per §33.1."""
+    try:
+        from backend.core.ouroboros.governance.flag_registry import (
+            Category,
+            FlagSpec,
+            FlagType,
+        )
+    except ImportError:
+        return 0
+
+    src = (
+        "backend/core/ouroboros/governance/"
+        "operator_commit_authority.py"
+    )
+
+    seeds = [
+        FlagSpec(
+            name=_ENV_MASTER,
+            type=FlagType.BOOL,
+            default=False,
+            description=(
+                "Operator Commit Authority master switch. "
+                "Default-FALSE per §33.1 — when off, "
+                "verify_pre_commit() returns DISABLED and the "
+                "commit hook chain is byte-identical to the "
+                "pre-substrate world. Graduate only after Slice "
+                "2 hook + AutoCommitter wiring."
+            ),
+            category=Category.SAFETY,
+            source_file=src,
+            example=f"{_ENV_MASTER}=true",
+        ),
+        FlagSpec(
+            name=_ENV_DEFAULT_TTL_S,
+            type=FlagType.INT,
+            default=_DEFAULT_TTL_S,
+            description=(
+                "Default operator commit-grant lifetime in "
+                "seconds. Clamped to [60, 86_400]."
+            ),
+            category=Category.CAPACITY,
+            source_file=src,
+            example=f"{_ENV_DEFAULT_TTL_S}=3600",
+        ),
+        FlagSpec(
+            name=_ENV_PLAN_TTL_S,
+            type=FlagType.INT,
+            default=_DEFAULT_PLAN_TTL_S,
+            description=(
+                "Grant lifetime when the operator is in "
+                "PLAN/ANALYZE operation mode — shorter so an "
+                "analysis session doesn't leave a long commit "
+                "window open. Clamped to [60, 86_400]."
+            ),
+            category=Category.CAPACITY,
+            source_file=src,
+            example=f"{_ENV_PLAN_TTL_S}=900",
+        ),
+        FlagSpec(
+            name=_ENV_GRANTS_PATH,
+            type=FlagType.STR,
+            default="",
+            description=(
+                "Operator override for the append-only grant "
+                "ledger path. Defaults to "
+                "<repo>/.jarvis/commit_authority/grants.jsonl."
+            ),
+            category=Category.OBSERVABILITY,
+            source_file=src,
+            example=f"{_ENV_GRANTS_PATH}=/var/jarvis/grants.jsonl",
+        ),
+        FlagSpec(
+            name=_ENV_SECRET_PATH,
+            type=FlagType.STR,
+            default="",
+            description=(
+                "Operator override for the per-machine HMAC "
+                "secret path. Defaults to "
+                "~/.jarvis/commit_authority/secret (0600, "
+                "out-of-repo, no shell-env dependency)."
+            ),
+            category=Category.SAFETY,
+            source_file=src,
+            example=f"{_ENV_SECRET_PATH}=/etc/jarvis/oca.secret",
+        ),
+    ]
+
+    count = 0
+    for spec in seeds:
+        try:
+            registry.register(spec)
+            count += 1
+        except Exception:  # noqa: BLE001 — fail-open per §33.1
+            continue
+    return count
+
+
+__all__ = [
+    "OPERATOR_COMMIT_AUTHORITY_SCHEMA_VERSION",
+    "CommitChannel",
+    "CommitAuthorityVerdict",
+    "CommitGrant",
+    "CommitAuthorityContext",
+    "CommitAuthorityVerdictResult",
+    "GrantIssueOutcome",
+    "is_authorized_verdict",
+    "master_enabled",
+    "default_ttl_s",
+    "plan_mode_ttl_s",
+    "grants_path",
+    "secret_path",
+    "resolve_repo_root_and_branch",
+    "repo_root_fingerprint",
+    "verify_pre_commit",
+    "issue_grant",
+    "revoke_grants",
+    "consume_grant",
+    "register_shipped_invariants",
+    "register_flags",
+]

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,371 +1,71 @@
 #!/usr/bin/env python3
 """
-JARVIS Pre-Commit Hook - File Integrity Guardian
-=================================================
+JARVIS Pre-Commit Dispatcher -> Operator Commit Authority (OCA)
+===============================================================
 
-This hook runs before every commit to:
-1. Validate Python file syntax
-2. Detect truncated/corrupted files
-3. Check for common truncation patterns
-4. Block commits that would introduce broken files
+Versioned, installable replacement for the untracked bash Iron Gate
+wrapper. This thin dispatcher delegates the authorization decision to
+the OCA consumer CLI and, on pass, chains to the file-integrity
+guardian (``pre-commit.project``) so existing protection is preserved.
 
-Install:
-    ./scripts/install_hooks.py
+Behavior contract (zero behavior change until graduated):
+  * OCA master OFF (default): the CLI enforces the legacy operator
+    SHA-256 token check (byte-equivalent to the retired bash hook).
+  * OCA master ON: operator channels require a signed grant on disk
+    (no JARVIS_AUTHORIZE_COMMIT_TOKEN export needed -- the IDE fix).
 
-Usage:
-    - Automatically runs on git commit
-    - Use --no-verify to bypass (not recommended)
-
-Exit Codes:
-    0 - All files pass validation
-    1 - Issues detected, commit blocked
+Install:  python3 scripts/install_hooks.py install
 """
-
-import ast
 import os
-import re
 import subprocess
 import sys
-from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
-
-# ANSI colors for terminal output
-class Colors:
-    RED = '\033[91m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    BLUE = '\033[94m'
-    MAGENTA = '\033[95m'
-    CYAN = '\033[96m'
-    WHITE = '\033[97m'
-    BOLD = '\033[1m'
-    RESET = '\033[0m'
 
 
-def color(text: str, *styles: str) -> str:
-    """Apply color styles to text."""
-    return ''.join(styles) + text + Colors.RESET
-
-
-# =============================================================================
-# TRUNCATION DETECTION PATTERNS
-# =============================================================================
-
-TRUNCATION_PATTERNS = {
-    "unclosed_docstring": [
-        re.compile(r'"""[^"]*$', re.MULTILINE),
-        re.compile(r"'''[^']*$", re.MULTILINE),
-    ],
-    "unclosed_string": [
-        re.compile(r'"[^"\n\\]*$', re.MULTILINE),
-        re.compile(r"'[^'\n\\]*$", re.MULTILINE),
-        re.compile(r'f"[^"]*\{[^}]*$', re.MULTILINE),
-    ],
-    "incomplete_function": [
-        re.compile(r'^\s*def\s+\w+\s*\([^)]*$', re.MULTILINE),
-        re.compile(r'^\s*async\s+def\s+\w+\s*\([^)]*$', re.MULTILINE),
-    ],
-    "incomplete_import": [
-        re.compile(r'^\s*from\s+\w+\s*$', re.MULTILINE),
-        re.compile(r'^\s*import\s*$', re.MULTILINE),
-    ],
-    "unclosed_bracket": [
-        re.compile(r'\[\s*$', re.MULTILINE),
-        re.compile(r'\{\s*$', re.MULTILINE),
-        re.compile(r'\(\s*$', re.MULTILINE),
-    ],
-}
-
-SUSPICIOUS_EOF_PATTERNS = [
-    re.compile(r'#.*truncat', re.IGNORECASE),
-    re.compile(r'#\s*TODO\s*$', re.IGNORECASE),
-    re.compile(r'^\s*\.\.\.\s*$'),
-]
-
-
-# =============================================================================
-# VALIDATION FUNCTIONS
-# =============================================================================
-
-def get_staged_python_files() -> List[str]:
-    """Get list of staged Python files."""
+def _repo_root() -> str:
     try:
-        result = subprocess.run(
-            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
-            timeout=10
+            timeout=10,
+            check=False,
         )
-        
-        if result.returncode != 0:
-            return []
-        
-        return [f.strip() for f in result.stdout.split('\n') 
-                if f.strip().endswith('.py') and os.path.exists(f.strip())]
+        if r.returncode == 0 and r.stdout.strip():
+            return r.stdout.strip()
     except Exception:
-        return []
-
-
-def get_staged_content(file_path: str) -> Optional[str]:
-    """Get the staged content of a file (what will be committed)."""
-    try:
-        result = subprocess.run(
-            ["git", "show", f":{file_path}"],
-            capture_output=True,
-            text=True,
-            timeout=10
-        )
-        
-        if result.returncode == 0:
-            return result.stdout
-        return None
-    except Exception:
-        return None
-
-
-def check_syntax(content: str, file_path: str) -> Tuple[bool, Optional[str], Optional[int]]:
-    """Check Python syntax using AST."""
-    try:
-        ast.parse(content)
-        return True, None, None
-    except SyntaxError as e:
-        return False, str(e.msg), e.lineno
-    except Exception as e:
-        return False, str(e), None
-
-
-def detect_truncation_patterns(content: str) -> List[str]:
-    """Detect common truncation patterns in content."""
-    detected = []
-    
-    for pattern_name, patterns in TRUNCATION_PATTERNS.items():
-        for pattern in patterns:
-            if pattern.search(content):
-                detected.append(pattern_name)
-                break
-    
-    # Check last few lines for suspicious endings
-    lines = content.strip().split('\n')
-    if lines:
-        last_lines = '\n'.join(lines[-5:])
-        for pattern in SUSPICIOUS_EOF_PATTERNS:
-            if pattern.search(last_lines):
-                detected.append("suspicious_ending")
-                break
-    
-    return list(set(detected))
-
-
-def check_bracket_balance(content: str) -> Tuple[bool, str]:
-    """Check if brackets are balanced."""
-    stack = []
-    pairs = {'(': ')', '[': ']', '{': '}'}
-    
-    in_string = False
-    string_char = None
-    escape_next = False
-    in_triple_string = False
-    
-    i = 0
-    while i < len(content):
-        char = content[i]
-        
-        if escape_next:
-            escape_next = False
-            i += 1
-            continue
-        
-        if char == '\\':
-            escape_next = True
-            i += 1
-            continue
-        
-        # Handle triple-quoted strings
-        if i + 2 < len(content) and content[i:i+3] in ('"""', "'''"):
-            if in_triple_string and content[i:i+3] == string_char:
-                in_triple_string = False
-                string_char = None
-                i += 3
-                continue
-            elif not in_string:
-                in_triple_string = True
-                string_char = content[i:i+3]
-                i += 3
-                continue
-        
-        # Handle single-quoted strings
-        if char in ('"', "'") and not in_triple_string:
-            if in_string:
-                if char == string_char:
-                    in_string = False
-                    string_char = None
-            else:
-                in_string = True
-                string_char = char
-            i += 1
-            continue
-        
-        # Skip if inside string
-        if in_string or in_triple_string:
-            i += 1
-            continue
-        
-        # Skip comments
-        if char == '#':
-            while i < len(content) and content[i] != '\n':
-                i += 1
-            i += 1
-            continue
-        
-        # Check brackets
-        if char in pairs:
-            stack.append(char)
-        elif char in pairs.values():
-            if not stack:
-                return False, f"Unexpected closing '{char}'"
-            expected = pairs[stack.pop()]
-            if char != expected:
-                return False, f"Mismatched brackets: expected '{expected}', got '{char}'"
-        
-        i += 1
-    
-    if in_string or in_triple_string:
-        return False, "Unclosed string literal"
-    
-    if stack:
-        return False, f"Unclosed brackets: {stack}"
-    
-    return True, ""
-
-
-def check_file_completeness(content: str) -> Tuple[bool, List[str]]:
-    """Check if file appears complete."""
-    issues = []
-    
-    lines = content.strip().split('\n')
-    
-    if not lines:
-        return False, ["Empty file"]
-    
-    # Check minimum size for non-empty files
-    if len(content) < 50 and len(lines) < 5:
-        # Very small files might be stubs - check if intentional
-        if not any(kw in content for kw in ['pass', '...', 'raise NotImplementedError']):
-            issues.append("File appears truncated (very small)")
-    
-    return len(issues) == 0, issues
-
-
-# =============================================================================
-# MAIN VALIDATION
-# =============================================================================
-
-def validate_file(file_path: str) -> Dict:
-    """
-    Validate a single file for integrity issues.
-    
-    Key insight: If syntax is valid, the file is almost certainly NOT truncated.
-    Truncation virtually always causes syntax errors. Only check patterns
-    for files with syntax errors.
-    """
-    result = {
-        "file": file_path,
-        "passed": True,
-        "errors": [],
-        "warnings": [],
-    }
-    
-    # Get staged content
-    content = get_staged_content(file_path)
-    
-    if content is None:
-        # Fallback to reading file directly
-        try:
-            content = Path(file_path).read_text(encoding='utf-8')
-        except Exception as e:
-            result["passed"] = False
-            result["errors"].append(f"Cannot read file: {e}")
-            return result
-    
-    # 1. Primary check: Syntax validation
-    # If syntax is valid, the file is healthy - no further checks needed
-    is_valid, error, line = check_syntax(content, file_path)
-    
-    if is_valid:
-        # Valid syntax = healthy file
-        return result
-    
-    # Syntax error found - this is where truncation is likely
-    result["passed"] = False
-    result["errors"].append(f"Syntax error at line {line}: {error}")
-    
-    # 2. Pattern detection only for files with syntax errors
-    patterns = detect_truncation_patterns(content)
-    if patterns:
-        result["errors"].append(f"Truncation patterns detected: {', '.join(patterns)}")
-    
-    # 3. Bracket balance check (provides more detail for syntax errors)
-    balanced, bracket_error = check_bracket_balance(content)
-    if not balanced:
-        result["errors"].append(f"Bracket issue: {bracket_error}")
-    
-    return result
+        pass
+    return os.getcwd()
 
 
 def main() -> int:
-    """Main pre-commit hook logic."""
-    print(color("\n🔍 JARVIS File Integrity Pre-Commit Hook", Colors.CYAN, Colors.BOLD))
-    print(color("=" * 50, Colors.CYAN))
-    
-    # Get staged Python files
-    files = get_staged_python_files()
-    
-    if not files:
-        print(color("✓ No Python files staged for commit", Colors.GREEN))
-        return 0
-    
-    print(f"\nChecking {color(str(len(files)), Colors.YELLOW)} Python file(s)...\n")
-    
-    # Validate each file
-    passed = 0
-    failed = 0
-    all_results = []
-    
-    for file_path in files:
-        result = validate_file(file_path)
-        all_results.append(result)
-        
-        if result["passed"]:
-            passed += 1
-            print(f"  {color('✓', Colors.GREEN)} {file_path}")
-        else:
-            failed += 1
-            print(f"  {color('✗', Colors.RED)} {file_path}")
-            for error in result["errors"]:
-                print(f"    {color('→', Colors.RED)} {error}")
-    
-    print()
-    
-    # Summary
-    if failed > 0:
-        print(color("=" * 50, Colors.RED))
-        print(color(f"❌ COMMIT BLOCKED: {failed} file(s) failed validation", Colors.RED, Colors.BOLD))
-        print()
-        print(color("Options:", Colors.YELLOW))
-        print("  1. Fix the issues and try again")
-        print("  2. Use 'git commit --no-verify' to bypass (not recommended)")
-        print()
-        print(color("💡 Tip: Run 'python backend/core/file_integrity_guardian.py check <path>'", Colors.CYAN))
-        print(color("   for detailed analysis of problematic files.", Colors.CYAN))
-        print()
+    root = _repo_root()
+    env = dict(os.environ)
+    env["PYTHONPATH"] = (
+        root + os.pathsep + env["PYTHONPATH"]
+        if env.get("PYTHONPATH")
+        else root
+    )
+    try:
+        return subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "backend.core.ouroboros.governance.commit_authority_cli",
+                "hook",
+                "pre-commit",
+            ],
+            cwd=root,
+            env=env,
+            check=False,
+        ).returncode
+    except Exception as exc:  # noqa: BLE001 — fail closed
+        sys.stderr.write(
+            "\n\033[1;31m# IRON GATE -- dispatcher failed to invoke "
+            f"OCA: {type(exc).__name__}: {exc}\033[0m\n"
+            "   (fail closed -- commit blocked)\n\n"
+        )
         return 1
-    else:
-        print(color("=" * 50, Colors.GREEN))
-        print(color(f"✅ All {passed} file(s) passed integrity check", Colors.GREEN, Colors.BOLD))
-        print()
-        return 0
 
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/scripts/hooks/pre-commit.project
+++ b/scripts/hooks/pre-commit.project
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+JARVIS Pre-Commit Hook - File Integrity Guardian
+=================================================
+
+This hook runs before every commit to:
+1. Validate Python file syntax
+2. Detect truncated/corrupted files
+3. Check for common truncation patterns
+4. Block commits that would introduce broken files
+
+Install:
+    ./scripts/install_hooks.py
+
+Usage:
+    - Automatically runs on git commit
+    - Use --no-verify to bypass (not recommended)
+
+Exit Codes:
+    0 - All files pass validation
+    1 - Issues detected, commit blocked
+"""
+
+import ast
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+# ANSI colors for terminal output
+class Colors:
+    RED = '\033[91m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    BLUE = '\033[94m'
+    MAGENTA = '\033[95m'
+    CYAN = '\033[96m'
+    WHITE = '\033[97m'
+    BOLD = '\033[1m'
+    RESET = '\033[0m'
+
+
+def color(text: str, *styles: str) -> str:
+    """Apply color styles to text."""
+    return ''.join(styles) + text + Colors.RESET
+
+
+# =============================================================================
+# TRUNCATION DETECTION PATTERNS
+# =============================================================================
+
+TRUNCATION_PATTERNS = {
+    "unclosed_docstring": [
+        re.compile(r'"""[^"]*$', re.MULTILINE),
+        re.compile(r"'''[^']*$", re.MULTILINE),
+    ],
+    "unclosed_string": [
+        re.compile(r'"[^"\n\\]*$', re.MULTILINE),
+        re.compile(r"'[^'\n\\]*$", re.MULTILINE),
+        re.compile(r'f"[^"]*\{[^}]*$', re.MULTILINE),
+    ],
+    "incomplete_function": [
+        re.compile(r'^\s*def\s+\w+\s*\([^)]*$', re.MULTILINE),
+        re.compile(r'^\s*async\s+def\s+\w+\s*\([^)]*$', re.MULTILINE),
+    ],
+    "incomplete_import": [
+        re.compile(r'^\s*from\s+\w+\s*$', re.MULTILINE),
+        re.compile(r'^\s*import\s*$', re.MULTILINE),
+    ],
+    "unclosed_bracket": [
+        re.compile(r'\[\s*$', re.MULTILINE),
+        re.compile(r'\{\s*$', re.MULTILINE),
+        re.compile(r'\(\s*$', re.MULTILINE),
+    ],
+}
+
+SUSPICIOUS_EOF_PATTERNS = [
+    re.compile(r'#.*truncat', re.IGNORECASE),
+    re.compile(r'#\s*TODO\s*$', re.IGNORECASE),
+    re.compile(r'^\s*\.\.\.\s*$'),
+]
+
+
+# =============================================================================
+# VALIDATION FUNCTIONS
+# =============================================================================
+
+def get_staged_python_files() -> List[str]:
+    """Get list of staged Python files."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        
+        if result.returncode != 0:
+            return []
+        
+        return [f.strip() for f in result.stdout.split('\n') 
+                if f.strip().endswith('.py') and os.path.exists(f.strip())]
+    except Exception:
+        return []
+
+
+def get_staged_content(file_path: str) -> Optional[str]:
+    """Get the staged content of a file (what will be committed)."""
+    try:
+        result = subprocess.run(
+            ["git", "show", f":{file_path}"],
+            capture_output=True,
+            text=True,
+            timeout=10
+        )
+        
+        if result.returncode == 0:
+            return result.stdout
+        return None
+    except Exception:
+        return None
+
+
+def check_syntax(content: str, file_path: str) -> Tuple[bool, Optional[str], Optional[int]]:
+    """Check Python syntax using AST."""
+    try:
+        ast.parse(content)
+        return True, None, None
+    except SyntaxError as e:
+        return False, str(e.msg), e.lineno
+    except Exception as e:
+        return False, str(e), None
+
+
+def detect_truncation_patterns(content: str) -> List[str]:
+    """Detect common truncation patterns in content."""
+    detected = []
+    
+    for pattern_name, patterns in TRUNCATION_PATTERNS.items():
+        for pattern in patterns:
+            if pattern.search(content):
+                detected.append(pattern_name)
+                break
+    
+    # Check last few lines for suspicious endings
+    lines = content.strip().split('\n')
+    if lines:
+        last_lines = '\n'.join(lines[-5:])
+        for pattern in SUSPICIOUS_EOF_PATTERNS:
+            if pattern.search(last_lines):
+                detected.append("suspicious_ending")
+                break
+    
+    return list(set(detected))
+
+
+def check_bracket_balance(content: str) -> Tuple[bool, str]:
+    """Check if brackets are balanced."""
+    stack = []
+    pairs = {'(': ')', '[': ']', '{': '}'}
+    
+    in_string = False
+    string_char = None
+    escape_next = False
+    in_triple_string = False
+    
+    i = 0
+    while i < len(content):
+        char = content[i]
+        
+        if escape_next:
+            escape_next = False
+            i += 1
+            continue
+        
+        if char == '\\':
+            escape_next = True
+            i += 1
+            continue
+        
+        # Handle triple-quoted strings
+        if i + 2 < len(content) and content[i:i+3] in ('"""', "'''"):
+            if in_triple_string and content[i:i+3] == string_char:
+                in_triple_string = False
+                string_char = None
+                i += 3
+                continue
+            elif not in_string:
+                in_triple_string = True
+                string_char = content[i:i+3]
+                i += 3
+                continue
+        
+        # Handle single-quoted strings
+        if char in ('"', "'") and not in_triple_string:
+            if in_string:
+                if char == string_char:
+                    in_string = False
+                    string_char = None
+            else:
+                in_string = True
+                string_char = char
+            i += 1
+            continue
+        
+        # Skip if inside string
+        if in_string or in_triple_string:
+            i += 1
+            continue
+        
+        # Skip comments
+        if char == '#':
+            while i < len(content) and content[i] != '\n':
+                i += 1
+            i += 1
+            continue
+        
+        # Check brackets
+        if char in pairs:
+            stack.append(char)
+        elif char in pairs.values():
+            if not stack:
+                return False, f"Unexpected closing '{char}'"
+            expected = pairs[stack.pop()]
+            if char != expected:
+                return False, f"Mismatched brackets: expected '{expected}', got '{char}'"
+        
+        i += 1
+    
+    if in_string or in_triple_string:
+        return False, "Unclosed string literal"
+    
+    if stack:
+        return False, f"Unclosed brackets: {stack}"
+    
+    return True, ""
+
+
+def check_file_completeness(content: str) -> Tuple[bool, List[str]]:
+    """Check if file appears complete."""
+    issues = []
+    
+    lines = content.strip().split('\n')
+    
+    if not lines:
+        return False, ["Empty file"]
+    
+    # Check minimum size for non-empty files
+    if len(content) < 50 and len(lines) < 5:
+        # Very small files might be stubs - check if intentional
+        if not any(kw in content for kw in ['pass', '...', 'raise NotImplementedError']):
+            issues.append("File appears truncated (very small)")
+    
+    return len(issues) == 0, issues
+
+
+# =============================================================================
+# MAIN VALIDATION
+# =============================================================================
+
+def validate_file(file_path: str) -> Dict:
+    """
+    Validate a single file for integrity issues.
+    
+    Key insight: If syntax is valid, the file is almost certainly NOT truncated.
+    Truncation virtually always causes syntax errors. Only check patterns
+    for files with syntax errors.
+    """
+    result = {
+        "file": file_path,
+        "passed": True,
+        "errors": [],
+        "warnings": [],
+    }
+    
+    # Get staged content
+    content = get_staged_content(file_path)
+    
+    if content is None:
+        # Fallback to reading file directly
+        try:
+            content = Path(file_path).read_text(encoding='utf-8')
+        except Exception as e:
+            result["passed"] = False
+            result["errors"].append(f"Cannot read file: {e}")
+            return result
+    
+    # 1. Primary check: Syntax validation
+    # If syntax is valid, the file is healthy - no further checks needed
+    is_valid, error, line = check_syntax(content, file_path)
+    
+    if is_valid:
+        # Valid syntax = healthy file
+        return result
+    
+    # Syntax error found - this is where truncation is likely
+    result["passed"] = False
+    result["errors"].append(f"Syntax error at line {line}: {error}")
+    
+    # 2. Pattern detection only for files with syntax errors
+    patterns = detect_truncation_patterns(content)
+    if patterns:
+        result["errors"].append(f"Truncation patterns detected: {', '.join(patterns)}")
+    
+    # 3. Bracket balance check (provides more detail for syntax errors)
+    balanced, bracket_error = check_bracket_balance(content)
+    if not balanced:
+        result["errors"].append(f"Bracket issue: {bracket_error}")
+    
+    return result
+
+
+def main() -> int:
+    """Main pre-commit hook logic."""
+    print(color("\n🔍 JARVIS File Integrity Pre-Commit Hook", Colors.CYAN, Colors.BOLD))
+    print(color("=" * 50, Colors.CYAN))
+    
+    # Get staged Python files
+    files = get_staged_python_files()
+    
+    if not files:
+        print(color("✓ No Python files staged for commit", Colors.GREEN))
+        return 0
+    
+    print(f"\nChecking {color(str(len(files)), Colors.YELLOW)} Python file(s)...\n")
+    
+    # Validate each file
+    passed = 0
+    failed = 0
+    all_results = []
+    
+    for file_path in files:
+        result = validate_file(file_path)
+        all_results.append(result)
+        
+        if result["passed"]:
+            passed += 1
+            print(f"  {color('✓', Colors.GREEN)} {file_path}")
+        else:
+            failed += 1
+            print(f"  {color('✗', Colors.RED)} {file_path}")
+            for error in result["errors"]:
+                print(f"    {color('→', Colors.RED)} {error}")
+    
+    print()
+    
+    # Summary
+    if failed > 0:
+        print(color("=" * 50, Colors.RED))
+        print(color(f"❌ COMMIT BLOCKED: {failed} file(s) failed validation", Colors.RED, Colors.BOLD))
+        print()
+        print(color("Options:", Colors.YELLOW))
+        print("  1. Fix the issues and try again")
+        print("  2. Use 'git commit --no-verify' to bypass (not recommended)")
+        print()
+        print(color("💡 Tip: Run 'python backend/core/file_integrity_guardian.py check <path>'", Colors.CYAN))
+        print(color("   for detailed analysis of problematic files.", Colors.CYAN))
+        print()
+        return 1
+    else:
+        print(color("=" * 50, Colors.GREEN))
+        print(color(f"✅ All {passed} file(s) passed integrity check", Colors.GREEN, Colors.BOLD))
+        print()
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/scripts/install_hooks.py
+++ b/scripts/install_hooks.py
@@ -23,10 +23,11 @@ Author: JARVIS System
 import os
 import shutil
 import stat
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple
+from typing import Optional, Tuple
 
 # ANSI colors
 class Colors:
@@ -57,10 +58,41 @@ def get_project_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def _git_hooks_dir() -> Optional[Path]:
+    """Resolve the *real* hooks directory via git itself.
+
+    This is correct in plain checkouts AND linked worktrees (where
+    ``.git`` is a gitdir-pointer file, not a directory, and hooks
+    live in the shared common git dir). No hardcoded ``.git/hooks``
+    assumption -- git is the single source of truth for its own
+    layout.
+    """
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--git-path", "hooks"],
+            cwd=str(get_project_root()),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            hp = Path(r.stdout.strip())
+            if not hp.is_absolute():
+                hp = get_project_root() / hp
+            return hp.resolve()
+    except Exception:
+        pass
+    return None
+
+
 def get_hooks_dir() -> Path:
-    """Get the git hooks directory."""
-    root = get_project_root()
-    return root / ".git" / "hooks"
+    """Get the git hooks directory (worktree-aware)."""
+    resolved = _git_hooks_dir()
+    if resolved is not None:
+        return resolved
+    # Fallback: legacy plain-checkout assumption.
+    return get_project_root() / ".git" / "hooks"
 
 
 def get_source_hooks_dir() -> Path:
@@ -68,7 +100,15 @@ def get_source_hooks_dir() -> Path:
     return Path(__file__).resolve().parent / "hooks"
 
 
-HOOKS_TO_INSTALL = ["pre-commit", "commit-msg", "post-commit"]
+# "pre-commit" is now the OCA dispatcher; "pre-commit.project" is the
+# file-integrity guardian it chains to after authority passes. Both
+# are versioned + installable so there is no orphan bash-only logic.
+HOOKS_TO_INSTALL = [
+    "pre-commit",
+    "pre-commit.project",
+    "commit-msg",
+    "post-commit",
+]
 
 
 def backup_hook(hooks_dir: Path, hook_name: str) -> bool:

--- a/tests/governance/test_commit_authority_cli.py
+++ b/tests/governance/test_commit_authority_cli.py
@@ -1,0 +1,220 @@
+"""Regression spine — Operator Commit Authority CLI / hook dispatcher
+(Slice 2).
+
+Proves the behavior contract: master-OFF preserves the legacy
+operator-token gate byte-equivalently; master-ON authorizes via a
+signed grant with NO env token (the Cursor IDE fix); authority pass
+chains to the file-integrity guardian.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import commit_authority_cli as cli
+from backend.core.ouroboros.governance import (
+    operator_commit_authority as oca,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    for env in (
+        "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED",
+        "JARVIS_AUTHORIZE_COMMIT_TOKEN",
+        "JARVIS_COMMIT_TOKEN_HASH_FILE",
+        "JARVIS_COMMIT_CHANNEL",
+        "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH",
+        "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
+        "JARVIS_LEDGER_SOVEREIGNTY_ENABLED",
+        "JARVIS_GOVERNANCE_MANIFEST_ENABLED",
+    ):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH",
+        str(tmp_path / "grants.jsonl"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
+        str(tmp_path / "secret"),
+    )
+    # Pin repo introspection to a deterministic tmp root and stub the
+    # chained integrity hook so we test authority in isolation.
+    monkeypatch.setattr(cli, "_repo_root", lambda: str(tmp_path))
+    monkeypatch.setattr(cli, "_branch", lambda root: "main")
+    monkeypatch.setattr(cli, "_staged_files", lambda root: ())
+    monkeypatch.setattr(
+        cli, "_chain_project_hook", lambda root: 0
+    )
+    yield
+
+
+def _hash_file(tmp_path, token: str) -> Path:
+    hf = tmp_path / "commit_token.sha256"
+    hf.write_text(
+        hashlib.sha256(token.encode()).hexdigest() + "\n"
+    )
+    return hf
+
+
+# ---------------------------------------------------------------------------
+# Legacy token compat (single source -- retires the bash hook)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyToken:
+    def test_unset_fails(self):
+        ok, reason = cli.legacy_token_ok()
+        assert ok is False and "unset" in reason
+
+    def test_correct_token_ok(self, monkeypatch, tmp_path):
+        hf = _hash_file(tmp_path, "s3cr3t")
+        monkeypatch.setenv("JARVIS_COMMIT_TOKEN_HASH_FILE", str(hf))
+        monkeypatch.setenv("JARVIS_AUTHORIZE_COMMIT_TOKEN", "s3cr3t")
+        ok, _ = cli.legacy_token_ok()
+        assert ok is True
+
+    def test_wrong_token_mismatch(self, monkeypatch, tmp_path):
+        hf = _hash_file(tmp_path, "right")
+        monkeypatch.setenv("JARVIS_COMMIT_TOKEN_HASH_FILE", str(hf))
+        monkeypatch.setenv("JARVIS_AUTHORIZE_COMMIT_TOKEN", "wrong")
+        ok, reason = cli.legacy_token_ok()
+        assert ok is False and "mismatch" in reason
+
+    def test_missing_hash_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(
+            "JARVIS_COMMIT_TOKEN_HASH_FILE",
+            str(tmp_path / "nope.sha256"),
+        )
+        monkeypatch.setenv("JARVIS_AUTHORIZE_COMMIT_TOKEN", "x")
+        ok, reason = cli.legacy_token_ok()
+        assert ok is False and "missing" in reason
+
+
+# ---------------------------------------------------------------------------
+# Hook dispatcher -- master OFF (legacy gate preserved byte-equivalently)
+# ---------------------------------------------------------------------------
+
+
+class TestHookMasterOff:
+    def test_legacy_ok_chains_and_passes(
+        self, monkeypatch, tmp_path
+    ):
+        hf = _hash_file(tmp_path, "tok")
+        monkeypatch.setenv("JARVIS_COMMIT_TOKEN_HASH_FILE", str(hf))
+        monkeypatch.setenv("JARVIS_AUTHORIZE_COMMIT_TOKEN", "tok")
+        assert cli.cmd_hook_pre_commit() == 0
+
+    def test_legacy_missing_blocks(self, monkeypatch):
+        # No JARVIS_AUTHORIZE_COMMIT_TOKEN -> Iron Gate refusal.
+        assert cli.cmd_hook_pre_commit() == 1
+
+    def test_chain_invoked_only_after_auth(
+        self, monkeypatch, tmp_path
+    ):
+        called = {"n": 0}
+        monkeypatch.setattr(
+            cli,
+            "_chain_project_hook",
+            lambda root: called.__setitem__("n", called["n"] + 1)
+            or 0,
+        )
+        # auth fails -> chain must NOT run
+        assert cli.cmd_hook_pre_commit() == 1
+        assert called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Hook dispatcher -- master ON (the Cursor IDE fix: NO env token)
+# ---------------------------------------------------------------------------
+
+
+class TestHookMasterOn:
+    def test_no_grant_blocks(self, monkeypatch):
+        monkeypatch.setenv(
+            "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true"
+        )
+        assert cli.cmd_hook_pre_commit() == 1
+
+    def test_signed_grant_authorizes_without_env_token(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv(
+            "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true"
+        )
+        # Critical: NO JARVIS_AUTHORIZE_COMMIT_TOKEN in env.
+        assert "JARVIS_AUTHORIZE_COMMIT_TOKEN" not in __import__(
+            "os"
+        ).environ
+        out = oca.issue_grant(
+            channel="ide",
+            operator_label="derek",
+            repo_root=tmp_path,
+        )
+        assert out.ok
+        assert cli.cmd_hook_pre_commit() == 0
+
+    def test_channel_env_override_respected(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv(
+            "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true"
+        )
+        monkeypatch.setenv("JARVIS_COMMIT_CHANNEL", "cli")
+        oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            repo_root=tmp_path,
+        )
+        # grant was for ide, commit channel is cli -> blocked
+        assert cli.cmd_hook_pre_commit() == 1
+        oca.issue_grant(
+            channel="cli",
+            operator_label="d",
+            repo_root=tmp_path,
+        )
+        assert cli.cmd_hook_pre_commit() == 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+class TestSubcommands:
+    def test_parser_has_all_verbs(self):
+        p = cli.build_parser()
+        # argparse raises SystemExit on unknown; valid ones parse.
+        for argv in (
+            ["hook", "pre-commit"],
+            ["grant", "--minutes", "30"],
+            ["revoke", "--all"],
+            ["status"],
+        ):
+            assert p.parse_args(argv) is not None
+
+    def test_grant_then_status_then_revoke(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv(
+            "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true"
+        )
+        assert cli.main(
+            ["grant", "--minutes", "60", "--channel", "ide",
+             "--label", "t"]
+        ) == 0
+        assert cli.main(["status"]) == 0
+        assert cli.main(["revoke", "--all"]) == 0
+        # after revoke-all, hook is blocked again
+        assert cli.cmd_hook_pre_commit() == 1
+
+    def test_grant_failure_returns_1(self, monkeypatch):
+        monkeypatch.setenv(
+            "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true"
+        )
+        # unknown channel -> issue_grant fails -> exit 1
+        assert cli.main(
+            ["grant", "--channel", "zzz", "--label", "t"]
+        ) == 1

--- a/tests/governance/test_operator_commit_authority.py
+++ b/tests/governance/test_operator_commit_authority.py
@@ -1,0 +1,752 @@
+"""Regression spine — Operator Commit Authority (OCA) Slice 1.
+
+Mirrors ``test_governance_manifest.py`` structure: isolation fixture,
+master-flag matrix, closed taxonomy, grant lifecycle, IDE-no-env path,
+concurrent append, AST pins (canonical pass + synthetic regression),
+FlagRegistry seeds.
+"""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    operator_commit_authority as oca,
+)
+
+
+# ---------------------------------------------------------------------------
+# Isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    """Point grant ledger + secret at tmp; clear OCA env."""
+    for env in (
+        "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED",
+        "JARVIS_COMMIT_GRANT_DEFAULT_TTL_S",
+        "JARVIS_COMMIT_GRANT_PLAN_TTL_S",
+        "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH",
+        "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
+        "JARVIS_LEDGER_SOVEREIGNTY_ENABLED",
+        "JARVIS_GOVERNANCE_MANIFEST_ENABLED",
+        "JARVIS_OPERATION_MODE",
+        "JARVIS_OPERATION_MODE_ENABLED",
+        # The legacy shell token must be irrelevant — never set it.
+        "JARVIS_AUTHORIZE_COMMIT_TOKEN",
+    ):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH",
+        str(tmp_path / "grants.jsonl"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
+        str(tmp_path / "secret"),
+    )
+    yield
+
+
+def _on(monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true"
+    )
+
+
+def _ctx(tmp_path, **kw):
+    kw.setdefault("channel", "ide")
+    kw.setdefault("repo_root", str(tmp_path))
+    return oca.CommitAuthorityContext(**kw)
+
+
+# ---------------------------------------------------------------------------
+# Master flag
+# ---------------------------------------------------------------------------
+
+
+class TestMasterFlag:
+    def test_default_false(self):
+        assert oca.master_enabled() is False
+
+    @pytest.mark.parametrize("truthy", ["1", "true", "yes", "on", "TRUE"])
+    def test_truthy(self, monkeypatch, truthy):
+        monkeypatch.setenv(
+            "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", truthy
+        )
+        assert oca.master_enabled() is True
+
+    def test_off_returns_disabled(self, tmp_path):
+        v = oca.verify_pre_commit(_ctx(tmp_path))
+        assert v.verdict is oca.CommitAuthorityVerdict.DISABLED
+        assert v.authorized() is True  # DISABLED = legacy pass-through
+
+
+# ---------------------------------------------------------------------------
+# Closed taxonomies
+# ---------------------------------------------------------------------------
+
+
+class TestTaxonomy:
+    def test_verdict_exactly_8(self):
+        assert {v.value for v in oca.CommitAuthorityVerdict} == {
+            "authorized",
+            "denied_no_grant",
+            "denied_expired",
+            "denied_scope",
+            "denied_governance_drift",
+            "denied_sovereignty",
+            "disabled",
+            "channel_unknown",
+        }
+
+    def test_channel_exactly_5(self):
+        assert {c.value for c in oca.CommitChannel} == {
+            "repl",
+            "cli",
+            "ide",
+            "daemon",
+            "autonomous",
+        }
+
+    @pytest.mark.parametrize(
+        "raw,exp",
+        [
+            ("ide", oca.CommitChannel.IDE),
+            ("REPL", oca.CommitChannel.REPL),
+            (" cli ", oca.CommitChannel.CLI),
+            ("bogus", None),
+            ("", None),
+        ],
+    )
+    def test_channel_parse(self, raw, exp):
+        assert oca.CommitChannel.parse(raw) is exp
+
+    def test_is_authorized_predicate(self):
+        V = oca.CommitAuthorityVerdict
+        assert oca.is_authorized_verdict(V.AUTHORIZED)
+        assert oca.is_authorized_verdict(V.DISABLED)
+        assert not oca.is_authorized_verdict(V.DENIED_NO_GRANT)
+        assert not oca.is_authorized_verdict(V.CHANNEL_UNKNOWN)
+        assert not oca.is_authorized_verdict("garbage")
+
+
+# ---------------------------------------------------------------------------
+# Dataclass roundtrip (§33.5)
+# ---------------------------------------------------------------------------
+
+
+class TestRoundtrip:
+    def test_grant_roundtrip_lossless(self):
+        g = oca.CommitGrant(
+            grant_id="abc",
+            issued_at_unix=100.0,
+            expires_at_unix=200.0,
+            repo_root_sha256="deadbeef",
+            branch="main",
+            channel="ide",
+            scopes=("docs/", "src/"),  # already canonical (sorted)
+            operator_label="derek",
+            governance_amend=True,
+        )
+        back = oca.CommitGrant.from_dict(g.to_dict())
+        assert back == g
+
+    def test_scopes_normalized_for_stable_hmac(self):
+        """Scope order must not change the signed payload — two
+        grants differing only in scope order sign identically (the
+        HMAC is over sorted scopes)."""
+        a = oca.CommitGrant.from_dict(
+            oca.CommitGrant(
+                grant_id="x",
+                issued_at_unix=1.0,
+                expires_at_unix=2.0,
+                repo_root_sha256="f",
+                branch="",
+                channel="ide",
+                scopes=("src/", "docs/"),
+                operator_label="d",
+            ).to_dict()
+        )
+        b = oca.CommitGrant.from_dict(
+            oca.CommitGrant(
+                grant_id="x",
+                issued_at_unix=1.0,
+                expires_at_unix=2.0,
+                repo_root_sha256="f",
+                branch="",
+                channel="ide",
+                scopes=("docs/", "src/"),
+                operator_label="d",
+            ).to_dict()
+        )
+        assert a == b
+        # Idempotent: a normalized grant round-trips exactly.
+        assert oca.CommitGrant.from_dict(a.to_dict()) == a
+
+    def test_from_dict_rejects_empty_id(self):
+        assert oca.CommitGrant.from_dict({"grant_id": ""}) is None
+
+    def test_verdict_result_to_dict(self, tmp_path):
+        v = oca.verify_pre_commit(_ctx(tmp_path))
+        d = v.to_dict()
+        assert d["verdict"] == "disabled"
+        assert "schema_version" in d
+
+
+# ---------------------------------------------------------------------------
+# Channel-unknown fail-closed
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_channel_denied(monkeypatch, tmp_path):
+    _on(monkeypatch)
+    v = oca.verify_pre_commit(_ctx(tmp_path, channel="banana"))
+    assert v.verdict is oca.CommitAuthorityVerdict.CHANNEL_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Operator grant lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestGrantLifecycle:
+    def test_no_grant_denied(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        v = oca.verify_pre_commit(_ctx(tmp_path))
+        assert v.verdict is oca.CommitAuthorityVerdict.DENIED_NO_GRANT
+
+    def test_issue_then_authorized_no_shell_env(
+        self, monkeypatch, tmp_path
+    ):
+        """The core acceptance scenario: a grant file alone (no
+        JARVIS_AUTHORIZE_COMMIT_TOKEN export) authorizes an IDE
+        commit."""
+        _on(monkeypatch)
+        out = oca.issue_grant(
+            channel="ide",
+            operator_label="derek",
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        assert out.ok and out.grant_id
+        assert "JARVIS_AUTHORIZE_COMMIT_TOKEN" not in __import__(
+            "os"
+        ).environ
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="ide", now_unix=1100.0)
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.AUTHORIZED
+        assert v.matched_grant_id == out.grant_id
+
+    def test_expired_grant_denied(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            ttl_s=60,
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="ide", now_unix=999_999.0)
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.DENIED_EXPIRED
+
+    def test_scope_miss_denied(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            scopes=["src/"],
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        v = oca.verify_pre_commit(
+            _ctx(
+                tmp_path,
+                channel="ide",
+                staged_files=("docs/readme.md",),
+                now_unix=1100.0,
+            )
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.DENIED_SCOPE
+
+    def test_scope_hit_authorized(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            scopes=["src/"],
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        v = oca.verify_pre_commit(
+            _ctx(
+                tmp_path,
+                channel="ide",
+                staged_files=("src/app/main.py",),
+                now_unix=1100.0,
+            )
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.AUTHORIZED
+
+    def test_channel_mismatch_not_matched(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="cli", now_unix=1100.0)
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.DENIED_NO_GRANT
+
+    def test_wrong_repo_root_not_matched(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            repo_root=tmp_path / "repoA",
+            now_unix=1000.0,
+        )
+        v = oca.verify_pre_commit(
+            oca.CommitAuthorityContext(
+                channel="ide",
+                repo_root=str(tmp_path / "repoB"),
+                now_unix=1100.0,
+            )
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.DENIED_NO_GRANT
+
+    def test_forged_signature_treated_as_no_grant(
+        self, monkeypatch, tmp_path
+    ):
+        _on(monkeypatch)
+        oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        ledger = tmp_path / "grants.jsonl"
+        rec = json.loads(ledger.read_text().splitlines()[0])
+        rec["grant"]["expires_at_unix"] = 9_999_999_999.0  # tamper
+        ledger.write_text(json.dumps(rec) + "\n")
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="ide", now_unix=1100.0)
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.DENIED_NO_GRANT
+
+    def test_revoke_by_id(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        out = oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        assert oca.revoke_grants(grant_id=out.grant_id) == 1
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="ide", now_unix=1100.0)
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.DENIED_NO_GRANT
+
+    def test_revoke_all(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        assert oca.revoke_grants(revoke_all=True, now_unix=1050.0) == 1
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="ide", now_unix=1100.0)
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.DENIED_NO_GRANT
+
+    def test_consume_one_shot(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        out = oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        assert oca.consume_grant(out.grant_id) is True
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="ide", now_unix=1100.0)
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.DENIED_NO_GRANT
+
+    def test_latest_grant_wins_concurrent_append(
+        self, monkeypatch, tmp_path
+    ):
+        _on(monkeypatch)
+        oca.issue_grant(
+            channel="ide",
+            operator_label="first",
+            ttl_s=60,
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        out2 = oca.issue_grant(
+            channel="ide",
+            operator_label="second",
+            ttl_s=3600,
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        lines = (tmp_path / "grants.jsonl").read_text().splitlines()
+        assert len(lines) == 2
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="ide", now_unix=1200.0)
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.AUTHORIZED
+        assert v.matched_grant_id == out2.grant_id
+
+    def test_issue_requires_operator_label(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        out = oca.issue_grant(
+            channel="ide", operator_label="  ", repo_root=tmp_path
+        )
+        assert out.ok is False and "operator_label" in out.error
+
+    def test_issue_rejects_unknown_channel(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        out = oca.issue_grant(
+            channel="zzz", operator_label="d", repo_root=tmp_path
+        )
+        assert out.ok is False and "channel" in out.error
+
+    def test_no_secret_fail_closed(self, monkeypatch, tmp_path):
+        """Operator channel with no secret bootstrapped → deny."""
+        _on(monkeypatch)
+        v = oca.verify_pre_commit(_ctx(tmp_path, channel="cli"))
+        assert v.verdict is oca.CommitAuthorityVerdict.DENIED_NO_GRANT
+        assert not (tmp_path / "secret").exists()
+
+
+# ---------------------------------------------------------------------------
+# Autonomous channel — delegated to ledger_sovereignty
+# ---------------------------------------------------------------------------
+
+
+class TestAutonomousChannel:
+    def test_sovereignty_off_authorized_without_grant(
+        self, monkeypatch, tmp_path
+    ):
+        _on(monkeypatch)
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="autonomous")
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.AUTHORIZED
+
+    def test_sovereignty_on_unowned_denied(
+        self, monkeypatch, tmp_path
+    ):
+        _on(monkeypatch)
+        monkeypatch.setenv("JARVIS_LEDGER_SOVEREIGNTY_ENABLED", "true")
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="autonomous")
+        )
+        assert (
+            v.verdict is oca.CommitAuthorityVerdict.DENIED_SOVEREIGNTY
+        )
+
+    def test_sovereignty_on_owned_authorized(
+        self, monkeypatch, tmp_path
+    ):
+        _on(monkeypatch)
+        monkeypatch.setenv("JARVIS_LEDGER_SOVEREIGNTY_ENABLED", "true")
+        from backend.core.ouroboros.governance import (
+            ledger_sovereignty as ls,
+        )
+        ls.mark_owned(
+            tmp_path, session_id="s1", branch_name="b1"
+        )
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="autonomous")
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.AUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Governance drift gate (composes governance_manifest)
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceGate:
+    def test_drift_without_amend_denied(
+        self, monkeypatch, tmp_path
+    ):
+        _on(monkeypatch)
+        from backend.core.ouroboros.governance import (
+            governance_manifest as gm,
+        )
+
+        class _Cmp:
+            verdict = gm.ManifestVerdict.DRIFT
+
+        monkeypatch.setattr(
+            gm, "verify_governance_state", lambda **k: _Cmp()
+        )
+        oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        v = oca.verify_pre_commit(
+            _ctx(
+                tmp_path,
+                channel="ide",
+                staged_files=(
+                    "backend/core/ouroboros/governance/x.py",
+                ),
+                now_unix=1100.0,
+            )
+        )
+        assert (
+            v.verdict
+            is oca.CommitAuthorityVerdict.DENIED_GOVERNANCE_DRIFT
+        )
+        assert v.governance_verdict == "drift"
+
+    def test_drift_with_amend_grant_authorized(
+        self, monkeypatch, tmp_path
+    ):
+        _on(monkeypatch)
+        from backend.core.ouroboros.governance import (
+            governance_manifest as gm,
+        )
+
+        class _Cmp:
+            verdict = gm.ManifestVerdict.DRIFT
+
+        monkeypatch.setattr(
+            gm, "verify_governance_state", lambda **k: _Cmp()
+        )
+        oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            governance_amend=True,
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        v = oca.verify_pre_commit(
+            _ctx(
+                tmp_path,
+                channel="ide",
+                staged_files=(
+                    "backend/core/ouroboros/governance/x.py",
+                ),
+                now_unix=1100.0,
+            )
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.AUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Adaptive TTL (composes operation_mode, read-only)
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveTtl:
+    def test_plan_mode_shortens_grant(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        monkeypatch.setenv("JARVIS_COMMIT_GRANT_DEFAULT_TTL_S", "3600")
+        monkeypatch.setenv("JARVIS_COMMIT_GRANT_PLAN_TTL_S", "120")
+        monkeypatch.setenv("JARVIS_OPERATION_MODE", "plan")
+        out = oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        assert out.expires_at_unix == 1000.0 + 120
+
+    def test_explicit_ttl_overrides_adaptive(
+        self, monkeypatch, tmp_path
+    ):
+        _on(monkeypatch)
+        monkeypatch.setenv("JARVIS_OPERATION_MODE", "plan")
+        out = oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            ttl_s=300,
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        assert out.expires_at_unix == 1000.0 + 300
+
+    def test_ttl_clamped(self, monkeypatch, tmp_path):
+        _on(monkeypatch)
+        out = oca.issue_grant(
+            channel="ide",
+            operator_label="d",
+            ttl_s=10**9,
+            repo_root=tmp_path,
+            now_unix=0.0,
+        )
+        assert out.expires_at_unix == float(oca._MAX_TTL_S)
+
+
+# ---------------------------------------------------------------------------
+# AST pins
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def canonical_source():
+    src = Path(oca.__file__).read_text(encoding="utf-8")
+    return src, ast.parse(src)
+
+
+@pytest.fixture
+def pins():
+    return oca.register_shipped_invariants()
+
+
+class TestAstPinsCanonicalPass:
+    def test_6_pins_registered(self, pins):
+        assert {p.invariant_name for p in pins} == {
+            "operator_commit_authority_verdict_taxonomy_closed",
+            "operator_commit_authority_channel_taxonomy_closed",
+            "operator_commit_authority_authority_asymmetry",
+            "operator_commit_authority_master_default_false",
+            "operator_commit_authority_composes_canonical",
+            "operator_commit_authority_subprocess_discipline",
+        }
+
+    @pytest.mark.parametrize(
+        "pin_name",
+        [
+            "operator_commit_authority_verdict_taxonomy_closed",
+            "operator_commit_authority_channel_taxonomy_closed",
+            "operator_commit_authority_authority_asymmetry",
+            "operator_commit_authority_master_default_false",
+            "operator_commit_authority_composes_canonical",
+            "operator_commit_authority_subprocess_discipline",
+        ],
+    )
+    def test_pin_passes_on_canonical(
+        self, canonical_source, pins, pin_name
+    ):
+        src, tree = canonical_source
+        pin = next(
+            p for p in pins if p.invariant_name == pin_name
+        )
+        assert not pin.validate(tree, src)
+
+
+class TestAstPinsSyntheticRegression:
+    def _pin(self, pins, name):
+        return next(
+            p for p in pins if p.invariant_name == name
+        )
+
+    def test_verdict_drift_fires(self, pins):
+        src = (
+            "import enum\n"
+            "class CommitAuthorityVerdict(str, enum.Enum):\n"
+            "    EXTRA = 'extra'\n"
+        )
+        v = self._pin(
+            pins,
+            "operator_commit_authority_verdict_taxonomy_closed",
+        ).validate(ast.parse(src), src)
+        assert v
+
+    def test_channel_drift_fires(self, pins):
+        src = (
+            "import enum\n"
+            "class CommitChannel(str, enum.Enum):\n"
+            "    REPL = 'repl'\n"
+        )
+        v = self._pin(
+            pins,
+            "operator_commit_authority_channel_taxonomy_closed",
+        ).validate(ast.parse(src), src)
+        assert v
+
+    def test_authority_import_fires(self, pins):
+        src = (
+            "from backend.core.ouroboros.governance.auto_committer "
+            "import x\n"
+        )
+        v = self._pin(
+            pins,
+            "operator_commit_authority_authority_asymmetry",
+        ).validate(ast.parse(src), src)
+        assert v and "auto_committer" in v[0]
+
+    def test_master_default_true_fires(self, pins):
+        src = (
+            "def master_enabled():\n"
+            "    return _flag('X', default=True)\n"
+        )
+        v = self._pin(
+            pins,
+            "operator_commit_authority_master_default_false",
+        ).validate(ast.parse(src), src)
+        assert v
+
+    def test_composes_missing_fires(self, pins):
+        src = "x = 1\n"
+        v = self._pin(
+            pins,
+            "operator_commit_authority_composes_canonical",
+        ).validate(ast.parse(src), src)
+        assert v
+
+    def test_subprocess_shell_true_fires(self, pins):
+        src = "import subprocess\nsubprocess.run(['git'], shell=True)\n"
+        v = self._pin(
+            pins,
+            "operator_commit_authority_subprocess_discipline",
+        ).validate(ast.parse(src), src)
+        assert v
+
+    def test_subprocess_missing_timeout_fires(self, pins):
+        src = "import subprocess\nsubprocess.run(['git'])\n"
+        v = self._pin(
+            pins,
+            "operator_commit_authority_subprocess_discipline",
+        ).validate(ast.parse(src), src)
+        assert v
+
+
+# ---------------------------------------------------------------------------
+# FlagRegistry seeds
+# ---------------------------------------------------------------------------
+
+
+class TestFlagRegistrySeeds:
+    def test_seeds_register(self):
+        captured = []
+
+        class _Reg:
+            def register(self, spec):
+                captured.append(spec.name)
+
+        n = oca.register_flags(_Reg())
+        assert n == 5
+        assert "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED" in captured
+
+    def test_master_seed_default_false(self):
+        captured = {}
+
+        class _Reg:
+            def register(self, spec):
+                captured[spec.name] = spec
+
+        oca.register_flags(_Reg())
+        master = captured["JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED"]
+        assert master.default is False


### PR DESCRIPTION
## Operator Commit Authority (OCA) — Slices 1 + 2

Closes the architectural seam that made **Cursor / VS Code Source Control commits fail** (`⛔ IRON GATE — Commit blocked`). Root cause: commit authorization lived in an *untracked* bash `.git/hooks/pre-commit` requiring the `JARVIS_AUTHORIZE_COMMIT_TOKEN` shell env var, which GUI git cannot inherit. OCA replaces the env-var seam with a signed, time-bounded grant the Python verifier reads directly — no shell export.

### Slice 1 — substrate (`1b3874384a`)
- `operator_commit_authority.py`: pure substrate, master `JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED` **default-FALSE** (§33.1 — byte-identical until graduated).
- Closed AST-pinned taxonomies: `CommitAuthorityVerdict` (8), `CommitChannel` (5).
- Composes (zero duplication): `ledger_sovereignty` (autonomous ownership), `governance_manifest` (drift hash-cap), `cross_process_jsonl` (append-only grant ledger), `roadmap_reader` HMAC (canonical constant-time crypto — fail-closed if unimportable).
- Per-machine secret at `~/.jarvis/commit_authority/secret` (0600, out-of-repo, **no shell-env dependency**); HMAC-signed grants at `.jarvis/commit_authority/grants.jsonl`. Forged/edited grant → signature fails → `DENIED_NO_GRANT`.
- 59 spine tests + 6 AST pins + 5 FlagRegistry seeds.

### Slice 2 — versioned hook chain + CLI (`4d64bac0f5`)
- `commit_authority_cli.py`: hook dispatcher + `grant`/`revoke`/`status`. The legacy operator SHA-256 token check lives here **once** (bash logic retired, not duplicated).
- `scripts/hooks/pre-commit` → thin Python dispatcher; `scripts/hooks/pre-commit.project` → file-integrity guardian (now tracked + installable); chain preserved (authority passes → integrity runs).
- `install_hooks.py`: worktree-aware hooks-dir resolution via `git rev-parse` (no hardcoded `.git/hooks`); installs the full chain; backs up the retired bash wrapper.
- **Behavior contract:** master OFF (default) enforces the legacy token gate **byte-equivalently** — zero behavior change until the operator opts in. Master ON: operator channels authorize via signed on-disk grant with **no env-token export** (the Cursor/IDE fix).
- 13 CLI regression tests; **72 cumulative OCA tests green**.

### End-to-end proof (this branch)
Slice 2 was committed with the new dispatcher live, **master ON, `JARVIS_AUTHORIZE_COMMIT_TOKEN` unset**, authorized purely by a signed grant + chained integrity guardian. No `--no-verify`, no `git ac`.

### Iron Gate posture
Fail-closed preserved: grants *replace env-only auth*, they do not remove the gate. Autonomous channel still delegates to `ledger_sovereignty`; governance/ drift still blocked via `governance_manifest`.

### Follow-ups (not in this PR)
Slice 3: `commit_authority_repl.py` (`/commit` verbs), `commit_authority_archive` + SSE + `GET /observability/commit-authority`, `AutoCommitter` composition of `verify_pre_commit(channel=autonomous)`, post-commit bypass-detect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the untracked bash commit gate with Operator Commit Authority (OCA): a versioned Python hook dispatcher and signed, time‑bounded commit grants. Removes the env‑var requirement that broke Cursor/VS Code commits while keeping legacy behavior as the default.

- **New Features**
  - `operator_commit_authority.py`: HMAC-signed grants with per-machine secret and append-only ledger.
  - `commit_authority_cli.py`: hook dispatcher plus `grant`/`revoke`/`status`; legacy SHA-256 token check centralized here.
  - `scripts/hooks/pre-commit`: thin dispatcher; adds tracked `pre-commit.project` integrity hook; chain preserved.
  - `scripts/install_hooks.py`: resolves real hooks dir via `git rev-parse`; installs the chain; worktree-safe.
  - 72 tests across substrate and CLI.

- **Migration**
  - Install hooks: `python scripts/install_hooks.py`.
  - Opt in: set `JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED=true` and issue a grant via `commit_authority_cli grant`.
  - Commit from IDE; `JARVIS_AUTHORIZE_COMMIT_TOKEN` is no longer needed.

<sup>Written for commit 4d64bac0f5f9f53231c4bd95836657988cc56b30. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/41674?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

