### PR TITLE
feat(governance): OCA Slice 3 #0 — persistent signed master-enable (Cursor SCM fix)

### DIFF
--- a/backend/core/ouroboros/governance/commit_authority_cli.py
+++ b/backend/core/ouroboros/governance/commit_authority_cli.py
@@ -284,6 +284,47 @@ def cmd_revoke(args: argparse.Namespace) -> int:
     return 0 if n == 1 else 1
 
 
+def cmd_enable(args: argparse.Namespace) -> int:
+    """Persistently graduate OCA (signed, out-of-repo). This is what
+    makes the Cursor/VS Code SCM button work -- no shell env needed."""
+    from backend.core.ouroboros.governance import (
+        operator_commit_authority as oca,
+    )
+
+    label = (
+        args.label
+        or os.environ.get("USER")
+        or "operator"
+    )
+    if oca.enable_authority(label):
+        print(
+            "OCA persistently ENABLED (signed) at "
+            f"{oca.enable_file_path()} -- master is now ON for GUI "
+            "git (Cursor SCM) with no shell env. label=" + label
+        )
+        return 0
+    print(
+        "enable FAILED (could not bootstrap secret or write record)",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def cmd_disable(_args: argparse.Namespace) -> int:
+    from backend.core.ouroboros.governance import (
+        operator_commit_authority as oca,
+    )
+
+    if oca.disable_authority():
+        print(
+            "OCA persistently DISABLED (enable record removed); "
+            "master reverts to env-only (default FALSE)."
+        )
+        return 0
+    print("disable FAILED (enable record still present)", file=sys.stderr)
+    return 1
+
+
 def cmd_status(_args: argparse.Namespace) -> int:
     from backend.core.ouroboros.governance import (
         operator_commit_authority as oca,
@@ -291,8 +332,13 @@ def cmd_status(_args: argparse.Namespace) -> int:
 
     root = _repo_root()
     sp = oca.secret_path()
+    ep = oca.enable_file_path()
     print("Operator Commit Authority -- status")
     print(f"  master_enabled        : {oca.master_enabled()}")
+    print(
+        f"  persistent enable     : {oca.persistent_enabled()} "
+        f"({ep} {'present' if ep.exists() else 'absent'})"
+    )
     print(f"  grants ledger         : {oca.grants_path()}")
     print(
         f"  per-machine secret    : {sp} "
@@ -370,6 +416,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--all", action="store_true", help="revoke all grants"
     )
 
+    e = sub.add_parser(
+        "enable",
+        help="persistently graduate OCA (signed, out-of-repo) -- "
+        "makes Cursor/VS Code SCM work with no shell env",
+    )
+    e.add_argument("--label", default="", help="operator audit label")
+
+    sub.add_parser(
+        "disable", help="remove the persistent enable record"
+    )
+
     sub.add_parser("status", help="show gate state + dry verify")
     return p
 
@@ -382,6 +439,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         return cmd_grant(args)
     if args.cmd == "revoke":
         return cmd_revoke(args)
+    if args.cmd == "enable":
+        return cmd_enable(args)
+    if args.cmd == "disable":
+        return cmd_disable(args)
     if args.cmd == "status":
         return cmd_status(args)
     return 2

--- a/backend/core/ouroboros/governance/operator_commit_authority.py
+++ b/backend/core/ouroboros/governance/operator_commit_authority.py
@@ -231,6 +231,22 @@ def secret_path() -> Path:
     return Path.home() / ".jarvis" / Path(*_DEFAULT_SECRET_RELATIVE)
 
 
+def enable_file_path() -> Path:
+    """Persistent master-enable record location. Lives OUTSIDE the
+    repo (``~/.jarvis/commit_authority/enabled``) so the gate's
+    enablement does not depend on a shell env export — that is what
+    makes the Cursor/VS Code Source Control button work (GUI git
+    inherits no shell env). Operator override via
+    ``JARVIS_COMMIT_AUTHORITY_ENABLE_FILE``. NEVER raises."""
+    raw = os.environ.get(_ENV_ENABLE_FILE, "").strip()
+    if raw:
+        try:
+            return Path(raw).expanduser().resolve()
+        except Exception:  # noqa: BLE001
+            pass
+    return Path.home() / ".jarvis" / Path(*_DEFAULT_ENABLE_RELATIVE)
+
+
 # ===========================================================================
 # Per-machine HMAC secret (auto-generated on first issuance)
 # ===========================================================================
@@ -306,6 +322,123 @@ def _verify(payload: Mapping[str, Any], signature_hex: str, secret: str) -> bool
             verify_signature,
         )
         return verify_signature(payload, signature_hex, secret)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# ===========================================================================
+# Persistent master enable (Slice 3 #0) — the Cursor SCM-button fix
+# ===========================================================================
+#
+# An env-only master flag can never be ON for a GUI git subprocess
+# (Cursor / VS Code Source Control inherit no shell env). The signed,
+# out-of-repo enable record lets the hook subprocess resolve master=ON
+# independent of how git was spawned. Signed with the SAME per-machine
+# secret as grants (composes _sign/_verify — zero new crypto): a hand-
+# created empty file does NOT flip the gate; tamper is signature-
+# evident; absent file/secret → OFF (default-FALSE preserved).
+
+
+def _enable_signed_payload(
+    issued_at_unix: float, operator_label: str,
+) -> Dict[str, Any]:
+    """Canonical dict the enable HMAC covers. Deterministic."""
+    return {
+        "enabled": True,
+        "issued_at_unix": float(issued_at_unix),
+        "operator_label": str(operator_label),
+        "schema_version": OPERATOR_COMMIT_AUTHORITY_SCHEMA_VERSION,
+    }
+
+
+def persistent_enabled() -> bool:
+    """Return ``True`` iff a valid, HMAC-signed enable record exists.
+    NEVER raises. Missing file, missing secret, malformed JSON, bad
+    signature, or ``enabled != True`` all → ``False`` (fail closed to
+    the safe default — the legacy token gate still applies)."""
+    target = enable_file_path()
+    try:
+        if not target.exists():
+            return False
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return False
+    if not isinstance(raw, dict):
+        return False
+    record = raw.get("record")
+    signature = raw.get("signature")
+    if not isinstance(record, dict) or not isinstance(signature, str):
+        return False
+    if record.get("enabled") is not True:
+        return False
+    secret = _read_secret()
+    if not secret:
+        return False
+    # Recompute the canonical payload from the trusted fields so a
+    # tampered/extra field cannot ride along under an old signature.
+    payload = _enable_signed_payload(
+        issued_at_unix=float(record.get("issued_at_unix", 0.0)),
+        operator_label=str(record.get("operator_label", "")),
+    )
+    return _verify(payload, signature, secret)
+
+
+def enable_authority(
+    operator_label: str,
+    *,
+    now_unix: Optional[float] = None,
+) -> bool:
+    """Operator-only: write the signed persistent enable record
+    (bootstraps the per-machine secret on first use). Atomic write,
+    0600. Returns ``True`` on success. NEVER raises."""
+    label = str(operator_label or "").strip()
+    if not label:
+        return False
+    secret = _ensure_secret()
+    if not secret:
+        return False
+    now = float(now_unix) if now_unix is not None else time.time()
+    payload = _enable_signed_payload(now, label)
+    signature = _sign(payload, secret)
+    if not signature:
+        return False
+    target = enable_file_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(
+                {"record": payload, "signature": signature},
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        try:
+            os.chmod(tmp, 0o600)
+        except Exception:  # noqa: BLE001 — best effort
+            pass
+        os.replace(str(tmp), str(target))
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[operator_commit_authority] enable write failed at %s: "
+            "%s",
+            target,
+            type(exc).__name__,
+        )
+        return False
+
+
+def disable_authority() -> bool:
+    """Operator-only: remove the persistent enable record. Master
+    then reverts to env-only (default FALSE). Idempotent. Returns
+    ``True`` iff the gate is persistently-disabled afterwards (file
+    absent). NEVER raises."""
+    target = enable_file_path()
+    try:
+        if target.exists():
+            target.unlink()
+        return not target.exists()
     except Exception:  # noqa: BLE001
         return False
 
@@ -1461,6 +1594,25 @@ def register_flags(registry: Any) -> int:
             source_file=src,
             example=f"{_ENV_SECRET_PATH}=/etc/jarvis/oca.secret",
         ),
+        FlagSpec(
+            name=_ENV_ENABLE_FILE,
+            type=FlagType.STR,
+            default="",
+            description=(
+                "Operator override for the persistent master-"
+                "enable record path. Defaults to "
+                "~/.jarvis/commit_authority/enabled (signed, "
+                "out-of-repo). Its presence (valid signature) is "
+                "what makes master ON for GUI git subprocesses "
+                "(Cursor/VS Code SCM) that inherit no shell env. "
+                "Absent + env unset → master FALSE (§33.1)."
+            ),
+            category=Category.SAFETY,
+            source_file=src,
+            example=(
+                f"{_ENV_ENABLE_FILE}=/etc/jarvis/oca.enabled"
+            ),
+        ),
     ]
 
     count = 0
@@ -1487,6 +1639,10 @@ __all__ = [
     "plan_mode_ttl_s",
     "grants_path",
     "secret_path",
+    "enable_file_path",
+    "persistent_enabled",
+    "enable_authority",
+    "disable_authority",
     "resolve_repo_root_and_branch",
     "repo_root_fingerprint",
     "verify_pre_commit",

--- a/backend/core/ouroboros/governance/operator_commit_authority.py
+++ b/backend/core/ouroboros/governance/operator_commit_authority.py
@@ -110,9 +110,11 @@ _ENV_DEFAULT_TTL_S = "JARVIS_COMMIT_GRANT_DEFAULT_TTL_S"
 _ENV_PLAN_TTL_S = "JARVIS_COMMIT_GRANT_PLAN_TTL_S"
 _ENV_GRANTS_PATH = "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH"
 _ENV_SECRET_PATH = "JARVIS_COMMIT_AUTHORITY_SECRET_PATH"
+_ENV_ENABLE_FILE = "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE"
 
 _DEFAULT_GRANTS_RELATIVE = ".jarvis/commit_authority/grants.jsonl"
 _DEFAULT_SECRET_RELATIVE = ("commit_authority", "secret")  # under ~/.jarvis
+_DEFAULT_ENABLE_RELATIVE = ("commit_authority", "enabled")  # under ~/.jarvis
 
 _DEFAULT_TTL_S = 3600
 _MIN_TTL_S = 60
@@ -136,11 +138,20 @@ def _flag(name: str, *, default: bool = False) -> bool:
 def master_enabled() -> bool:
     """§33.1 opt-in safety gate — default-**FALSE**.
 
-    When off, :func:`verify_pre_commit` returns ``DISABLED`` and the
-    hook chain is byte-identical to the pre-substrate world. The
-    operator graduates this flag deliberately after Slice 2 wiring.
+    Master is ON iff EITHER the env flag is truthy OR a valid,
+    HMAC-signed persistent enable record exists (Slice 3 #0). The
+    persistent path is the load-bearing fix for the Cursor/VS Code
+    Source Control button: a GUI git subprocess inherits **no shell
+    env**, so an env-only master could never be ON for it — it would
+    fall back to the legacy token gate and stay blocked. The
+    out-of-repo signed enable file (mirroring how the per-machine
+    secret already lives outside the repo) lets the hook subprocess
+    resolve master=ON regardless of how git was spawned.
+
+    Default remains **FALSE**: no env flag AND no valid enable record
+    → byte-identical to the pre-substrate world. NEVER raises.
     """
-    return _flag(_ENV_MASTER, default=False)
+    return _flag(_ENV_MASTER, default=False) or persistent_enabled()
 
 
 def _read_clamped_int(name: str, default: int, lo: int, hi: int) -> int:

--- a/tests/governance/test_commit_authority_cli.py
+++ b/tests/governance/test_commit_authority_cli.py
@@ -28,6 +28,7 @@ def _isolate(monkeypatch, tmp_path):
         "JARVIS_COMMIT_CHANNEL",
         "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH",
         "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
+        "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE",
         "JARVIS_LEDGER_SOVEREIGNTY_ENABLED",
         "JARVIS_GOVERNANCE_MANIFEST_ENABLED",
     ):
@@ -39,6 +40,10 @@ def _isolate(monkeypatch, tmp_path):
     monkeypatch.setenv(
         "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
         str(tmp_path / "secret"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE",
+        str(tmp_path / "enabled"),
     )
     # Pin repo introspection to a deterministic tmp root and stub the
     # chained integrity hook so we test authority in isolation.
@@ -218,3 +223,49 @@ class TestSubcommands:
         assert cli.main(
             ["grant", "--channel", "zzz", "--label", "t"]
         ) == 1
+
+
+class TestEnableDisableCli:
+    def test_enable_then_hook_authorizes_with_no_env(
+        self, monkeypatch, tmp_path
+    ):
+        # No JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED — Cursor SCM
+        # scenario. enable -> persistent master ON -> grant -> hook 0.
+        assert "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED" not in (
+            __import__("os").environ
+        )
+        assert cli.main(["enable", "--label", "cursor"]) == 0
+        from backend.core.ouroboros.governance import (
+            operator_commit_authority as oca,
+        )
+        assert oca.master_enabled() is True
+        oca.issue_grant(
+            channel="ide",
+            operator_label="cursor",
+            repo_root=tmp_path,
+        )
+        assert cli.cmd_hook_pre_commit() == 0
+
+    def test_disable_reverts(self, monkeypatch, tmp_path):
+        cli.main(["enable", "--label", "x"])
+        assert cli.main(["disable"]) == 0
+        from backend.core.ouroboros.governance import (
+            operator_commit_authority as oca,
+        )
+        assert oca.master_enabled() is False
+        # master off + no token -> hook blocked (legacy path)
+        assert cli.cmd_hook_pre_commit() == 1
+
+    def test_status_reports_persistent_enable(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        cli.main(["enable", "--label", "x"])
+        assert cli.main(["status"]) == 0
+        out = capsys.readouterr().out
+        assert "persistent enable" in out
+        assert "master_enabled        : True" in out
+
+    def test_parser_has_enable_disable(self):
+        p = cli.build_parser()
+        assert p.parse_args(["enable", "--label", "z"]) is not None
+        assert p.parse_args(["disable"]) is not None

--- a/tests/governance/test_operator_commit_authority.py
+++ b/tests/governance/test_operator_commit_authority.py
@@ -742,8 +742,9 @@ class TestFlagRegistrySeeds:
                 captured.append(spec.name)
 
         n = oca.register_flags(_Reg())
-        assert n == 5
+        assert n == 6  # Slice 3 #0 added the enable-file seed
         assert "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED" in captured
+        assert "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE" in captured
 
     def test_master_seed_default_false(self):
         captured = {}

--- a/tests/governance/test_operator_commit_authority.py
+++ b/tests/governance/test_operator_commit_authority.py
@@ -32,6 +32,7 @@ def _isolate(monkeypatch, tmp_path):
         "JARVIS_COMMIT_GRANT_PLAN_TTL_S",
         "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH",
         "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
+        "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE",
         "JARVIS_LEDGER_SOVEREIGNTY_ENABLED",
         "JARVIS_GOVERNANCE_MANIFEST_ENABLED",
         "JARVIS_OPERATION_MODE",
@@ -47,6 +48,10 @@ def _isolate(monkeypatch, tmp_path):
     monkeypatch.setenv(
         "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
         str(tmp_path / "secret"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE",
+        str(tmp_path / "enabled"),
     )
     yield
 
@@ -750,3 +755,114 @@ class TestFlagRegistrySeeds:
         oca.register_flags(_Reg())
         master = captured["JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED"]
         assert master.default is False
+
+
+# ---------------------------------------------------------------------------
+# Slice 3 #0 — persistent file-based master enable (Cursor SCM fix)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistentEnable:
+    def test_default_off_no_env_no_file(self):
+        assert oca.persistent_enabled() is False
+        assert oca.master_enabled() is False
+
+    def test_enable_authority_turns_master_on_without_env(self):
+        # No JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED in env at all —
+        # this is exactly the Cursor-SCM (no shell env) scenario.
+        assert oca.enable_authority("cursor-test") is True
+        assert oca.persistent_enabled() is True
+        assert oca.master_enabled() is True
+
+    def test_enable_requires_label(self):
+        assert oca.enable_authority("   ") is False
+        assert oca.persistent_enabled() is False
+
+    def test_disable_reverts_to_default_false(self):
+        oca.enable_authority("x")
+        assert oca.master_enabled() is True
+        assert oca.disable_authority() is True
+        assert oca.persistent_enabled() is False
+        assert oca.master_enabled() is False
+
+    def test_tampered_enable_file_is_rejected(self, tmp_path):
+        oca.enable_authority("x")
+        ef = tmp_path / "enabled"
+        raw = json.loads(ef.read_text())
+        raw["record"]["operator_label"] = "ATTACKER"  # tamper
+        ef.write_text(json.dumps(raw))
+        # signature no longer matches recomputed payload -> off
+        assert oca.persistent_enabled() is False
+        assert oca.master_enabled() is False
+
+    def test_empty_file_does_not_enable(self, tmp_path):
+        (tmp_path / "enabled").write_text("")
+        assert oca.persistent_enabled() is False
+
+    def test_enabled_false_record_does_not_enable(self, tmp_path):
+        oca.enable_authority("x")
+        ef = tmp_path / "enabled"
+        raw = json.loads(ef.read_text())
+        raw["record"]["enabled"] = False
+        ef.write_text(json.dumps(raw))
+        assert oca.persistent_enabled() is False
+
+    def test_enable_file_without_secret_is_fail_closed(
+        self, tmp_path
+    ):
+        oca.enable_authority("x")
+        (tmp_path / "secret").unlink()  # secret gone -> unverifiable
+        assert oca.persistent_enabled() is False
+        assert oca.master_enabled() is False
+
+    def test_env_flag_still_independently_enables(self, monkeypatch):
+        # No enable file; env path must still work (back-compat).
+        assert oca.persistent_enabled() is False
+        monkeypatch.setenv(
+            "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true"
+        )
+        assert oca.master_enabled() is True
+
+    def test_verify_pre_commit_honors_persistent_enable_no_env(
+        self, tmp_path
+    ):
+        # The end-to-end Cursor-SCM proof at substrate level: NO env
+        # master flag, persistent enable + signed grant -> AUTHORIZED.
+        assert "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED" not in (
+            __import__("os").environ
+        )
+        assert oca.enable_authority("cursor-scm") is True
+        out = oca.issue_grant(
+            channel="ide",
+            operator_label="cursor-scm",
+            repo_root=tmp_path,
+            now_unix=1000.0,
+        )
+        assert out.ok
+        v = oca.verify_pre_commit(
+            _ctx(tmp_path, channel="ide", now_unix=1100.0)
+        )
+        assert v.verdict is oca.CommitAuthorityVerdict.AUTHORIZED
+
+    def test_enable_file_path_env_override(self, monkeypatch, tmp_path):
+        custom = tmp_path / "custom" / "oca.enabled"
+        monkeypatch.setenv(
+            "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE", str(custom)
+        )
+        assert oca.enable_file_path() == custom.resolve() or str(
+            oca.enable_file_path()
+        ) == str(custom)
+        assert oca.enable_authority("x") is True
+        assert custom.exists()
+
+    def test_master_default_false_ast_pin_still_passes(self):
+        import ast as _ast
+
+        src = Path(oca.__file__).read_text(encoding="utf-8")
+        pin = next(
+            p
+            for p in oca.register_shipped_invariants()
+            if p.invariant_name
+            == "operator_commit_authority_master_default_false"
+        )
+        assert not pin.validate(_ast.parse(src), src)


### PR DESCRIPTION
## Operator Commit Authority — Slice 3 #0: persistent signed master-enable (the Cursor SCM fix)

Builds on #41674 (Slices 1+2, merged `506eb034fe`).

### Problem this closes
Slices 1+2 made commits authorize from a signed on-disk grant instead of `JARVIS_AUTHORIZE_COMMIT_TOKEN`. But `master_enabled()` still read **only** `JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED` from the env. The Cursor / VS Code **Source Control button** spawns git with no shell env, so master was always OFF for it → it fell back to the legacy token gate and stayed blocked. The env-inheritance seam just moved from the token to the enable bit.

### Fix (compose, zero duplication, no hardcoding)
- `master_enabled()` = env flag **OR** a valid HMAC-signed persistent enable record. **Default remains FALSE** (no env AND no record → byte-identical; the `master-default-false` AST pin is still green).
- `persistent_enabled()` / `enable_authority()` / `disable_authority()` — signed with the **same per-machine secret** as grants (composes existing `_sign`/`_verify`; **zero new crypto**). Out-of-repo at `~/.jarvis/commit_authority/enabled`. Tamper is signature-evident; an empty/hand-made file does not flip the gate; absent secret/file → OFF (fail-closed to the safe default).
- `commit_authority_cli`: `enable` / `disable` verbs; `status` reflects persistent state. FlagRegistry seed for the enable-file path (6 seeds).

### End-to-end proof
Every commit on this branch (`da08b9ba85`, `b778952754`, `ab544b1b76`) was authorized with **no `JARVIS_AUTHORIZE_COMMIT_TOKEN` and no `JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED` in env** — purely the persistent signed enable + a signed grant + the chained file-integrity guardian. That is exactly the Cursor SCM path.

### Posture
Operator graduation is a deliberate, **reversible** opt-in (`enable` / `disable`); the in-code default stays FALSE per §33.1. Iron Gate stays fail-closed — the enable record gates *enablement*, the signed grant gates *authorization*; neither removes the gate.

### Tests
+12 substrate tests + 4 CLI tests covering: default-off, enable→on without env, tamper rejection, empty-file rejection, `enabled:false` rejection, missing-secret fail-closed, env-still-works, `verify_pre_commit` honoring persistent enable with no env, env-override path, and the master-default-FALSE AST pin still passing. **88 cumulative OCA tests green; all 6 AST pins green.**

### Follow-ups on this branch (Slice 3 remainder)
#1 `commit_authority_repl.py` · #2 `commit_authority_archive.py` · #3 SSE `commit_authority_decision_recorded` + `GET /observability/commit-authority` · #4 `AutoCommitter` composing `verify_pre_commit(channel=autonomous)` · #5 post-commit grant-consume + bypass-detect · #6 memory + remaining tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent, HMAC‑signed master-enable for Operator Commit Authority so GUI git (Cursor/VS Code SCM) can authorize commits without shell env. Default remains off; safety and token/grant gates are unchanged.

- New Features
  - `master_enabled()` now returns true if the env flag is set or a valid signed enable record exists.
  - Signed enable record stored at `~/.jarvis/commit_authority/enabled` (override with `JARVIS_COMMIT_AUTHORITY_ENABLE_FILE`); uses the existing per‑machine secret; tamper‑evident and fail‑closed.
  - CLI: `enable --label` and `disable`; `status` prints persistent state and file path.
  - Public helpers: `enable_file_path()`, `persistent_enabled()`, `enable_authority()`, `disable_authority()`; new flag seed registered.

- Migration
  - No change if you rely on env-only; master still defaults to false.
  - To enable for GUI tools: run `commit_authority_cli enable --label <your-label>`; revert with `commit_authority_cli disable`.

<sup>Written for commit ab544b1b76b6a429d2c3c90e2c4eb4e7cd9aa418. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/41852?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

