### PR TITLE
feat(governance): GitIndexGuard (Phase C Slice 1) + OCA structural channel resolution

### DIFF
--- a/backend/core/ouroboros/governance/commit_authority_cli.py
+++ b/backend/core/ouroboros/governance/commit_authority_cli.py
@@ -193,10 +193,19 @@ def cmd_hook_pre_commit() -> int:
         return 1
 
     if oca.master_enabled():
-        channel = (
-            os.environ.get("JARVIS_COMMIT_CHANNEL", "").strip().lower()
-            or "ide"
-        )
+        # Structural, evidence-based channel resolution. The legacy
+        # ``env or "ide"`` blanket default let a Cursor *Agent*'s
+        # headless git commit borrow the operator's interactive
+        # ``ide`` grant (same process tree / identical env as a
+        # human SCM commit). resolve_commit_channel requires a
+        # signed operator-presence marker to earn an operator
+        # channel; absent it the commit resolves to AUTONOMOUS and
+        # the existing ledger_sovereignty gate decides.
+        channel = oca.resolve_commit_channel(
+            repo_root=Path(root),
+            branch=_branch(root),
+            env_channel=os.environ.get("JARVIS_COMMIT_CHANNEL", ""),
+        ).value
         ctx = oca.CommitAuthorityContext(
             channel=channel,
             repo_root=root,

--- a/backend/core/ouroboros/governance/git_index_guard.py
+++ b/backend/core/ouroboros/governance/git_index_guard.py
@@ -1,0 +1,595 @@
+"""GitIndexGuard -- Slice 1 of the git-index-integrity arc.
+=========================================================
+
+Pure-stdlib subprocess primitive that detects a **missing**
+``.git/index`` and performs an advisory, *non-destructive*
+rebuild from ``HEAD``.
+
+Why this exists
+---------------
+
+A background Cursor Agent (operator soak 2026-05-19) repeatedly
+unlinked ``.git/index`` on the operator's ``main`` checkout. With
+no index, ``git status`` reports every HEAD-tracked file as a
+staged deletion -- the infamous "7856 staged / 2144 changes"
+illusion in the Cursor Source Control panel. No content is ever
+lost (the working tree is intact); the *index* is simply gone.
+``git read-tree HEAD`` rebuilds the index from the HEAD tree
+**without touching the working tree** -- the exact one-shot,
+content-safe recovery.
+
+Load-bearing safety contract
+----------------------------
+
+* **Acts ONLY on total absence.** If ``.git/index`` is present,
+  the guard returns ``HEALTHY`` and does *nothing*. It MUST NOT
+  rebuild a present index -- the operator may have legitimately
+  staged work, and ``read-tree HEAD`` would silently discard it.
+* **``read-tree HEAD`` only.** The rebuild NEVER uses a
+  working-tree-destructive command (``reset --hard``,
+  ``checkout``, ``clean``, ``rm --cached``). AST-pinned.
+* **Advisory, authority-free.** Mirrors ``gitignore_guard``:
+  closed-5 outcome enum, frozen anomaly dataclass, NEVER-raise
+  IO discipline, master flag default-off until graduation. The
+  guard observes + repairs index *absence*; it has zero say over
+  any governance decision.
+
+SSE seam without coupling
+-------------------------
+
+The arc plan calls for an SSE ``git_index_anomaly`` event. To
+keep this module pure-stdlib (so it stays AST-pinnable like
+``gitignore_guard`` -- no governance imports at the hot path),
+the SSE emission is *not* performed here. Instead
+:func:`detect_and_rebuild` accepts an injected ``on_anomaly``
+callback (fail-silent). A future Slice-2 consumer passes the
+``StreamEventBroker`` emitter; this module never imports it. The
+Slice-1 signal is the structured WARNING log line
+``[GitIndexGuard] git_index_anomaly ...`` -- identical
+discipline to ``cross_process_jsonl``'s ``stale_lock_detected``.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Sequence
+
+logger = logging.getLogger("Ouroboros.GitIndexGuard")
+
+
+GIT_INDEX_GUARD_SCHEMA_VERSION: str = "git_index_guard.v1"
+
+
+# ---------------------------------------------------------------------------
+# Master flag + env knobs
+# ---------------------------------------------------------------------------
+
+
+def git_index_guard_enabled() -> bool:
+    """``JARVIS_GIT_INDEX_GUARD_ENABLED`` (default ``false`` --
+    Slice 1 substrate, graduates to default-true after a stable
+    soak per the arc plan).
+
+    When off, :func:`detect_and_rebuild` returns ``DISABLED``
+    immediately and launches no subprocess; :func:`git_index_present`
+    still works (it is a pure stdlib stat, no git, useful for
+    diagnostics regardless of the master flag).
+
+    Asymmetric env semantics -- empty/whitespace = unset = current
+    default; explicit truthy overrides. Re-read on every call so a
+    flag flip hot-reverts.
+    """
+    raw = os.environ.get("JARVIS_GIT_INDEX_GUARD_ENABLED", "").strip().lower()
+    if raw == "":
+        return False  # Slice 1 default-off until graduation
+    return raw in ("1", "true", "yes", "on")
+
+
+def git_index_guard_timeout_s() -> float:
+    """``JARVIS_GIT_INDEX_GUARD_TIMEOUT_S`` (default 5.0, floor
+    1.0, ceiling 30.0). Subprocess timeout for the ``git read-tree
+    HEAD`` rebuild. Bounded so a hung git binary cannot stall the
+    caller."""
+    raw = os.environ.get("JARVIS_GIT_INDEX_GUARD_TIMEOUT_S", "").strip()
+    try:
+        n = float(raw) if raw else 5.0
+    except ValueError:
+        n = 5.0
+    return max(1.0, min(30.0, n))
+
+
+# ---------------------------------------------------------------------------
+# Closed-5-value taxonomy
+# ---------------------------------------------------------------------------
+
+
+class GitIndexGuardOutcome(str, enum.Enum):
+    """Closed taxonomy for guard verdicts.
+
+    * ``HEALTHY`` -- ``.git/index`` is present; guard did nothing
+      (the safe common case)
+    * ``MISSING_REBUILT`` -- index was absent; advisory
+      ``read-tree HEAD`` rebuild succeeded
+    * ``MISSING_REBUILD_FAILED`` -- index was absent; the rebuild
+      subprocess failed (git missing / unborn HEAD / timeout)
+    * ``DISABLED`` -- master flag off; no probe, no subprocess
+    * ``FAILED`` -- could not even determine index presence
+      (non-repo / unreadable .git); fail-open, caller proceeds
+    """
+
+    HEALTHY = "healthy"
+    MISSING_REBUILT = "missing_rebuilt"
+    MISSING_REBUILD_FAILED = "missing_rebuild_failed"
+    DISABLED = "disabled"
+    FAILED = "failed"
+
+
+# ---------------------------------------------------------------------------
+# Frozen anomaly dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GitIndexAnomaly:
+    """One observation of the ``.git/index`` integrity check.
+
+    ``outcome`` is the closed-5 verdict. ``index_path`` is the
+    resolved absolute path the guard probed (handles linked
+    worktrees, where ``.git`` is a gitfile, not a directory).
+    ``detail`` carries a short human string (git stderr tail on
+    failure, empty on the healthy path).
+    """
+
+    repo_root: str
+    index_path: str
+    outcome: GitIndexGuardOutcome
+    detail: str = ""
+    schema_version: str = GIT_INDEX_GUARD_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "repo_root": self.repo_root,
+            "index_path": self.index_path,
+            "outcome": self.outcome.value,
+            "detail": self.detail,
+            "schema_version": self.schema_version,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Internal stdlib helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_git(
+    args: Sequence[str],
+    *,
+    repo_root: Path,
+    timeout_s: float,
+) -> Optional[subprocess.CompletedProcess]:
+    """Run a git command with bounded timeout. Returns None on any
+    subprocess failure (FileNotFoundError, TimeoutExpired, OSError).
+    NEVER raises."""
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("[GitIndexGuard] git %s degraded: %s", args[0], exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 -- last-resort defensive
+        logger.debug(
+            "[GitIndexGuard] git %s last-resort degraded: %s",
+            args[0], exc,
+        )
+        return None
+
+
+def _resolve_index_path(repo_root: Path) -> Optional[Path]:
+    """Resolve the absolute path of the git index for ``repo_root``.
+
+    Handles both layouts purely with stdlib (no git subprocess):
+
+      * ``.git`` is a directory  -> ``<root>/.git/index``
+      * ``.git`` is a gitfile    -> ``gitdir: <path>`` -> ``<path>/index``
+        (linked worktree case)
+
+    Returns None when ``.git`` is absent or unparseable (the guard
+    reports FAILED -- it cannot reason about a non-repo path).
+    NEVER raises.
+    """
+    try:
+        dot_git = Path(repo_root) / ".git"
+        if dot_git.is_dir():
+            return dot_git / "index"
+        if dot_git.is_file():
+            text = dot_git.read_text(encoding="utf-8", errors="replace")
+            for line in text.splitlines():
+                line = line.strip()
+                if line.startswith("gitdir:"):
+                    gd = line.split(":", 1)[1].strip()
+                    if not gd:
+                        return None
+                    gd_path = Path(gd)
+                    if not gd_path.is_absolute():
+                        gd_path = (Path(repo_root) / gd_path).resolve()
+                    return gd_path / "index"
+            return None
+        return None
+    except (OSError, ValueError) as exc:
+        logger.debug("[GitIndexGuard] _resolve_index_path degraded: %s", exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 -- last-resort defensive
+        logger.debug(
+            "[GitIndexGuard] _resolve_index_path last-resort: %s", exc,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def git_index_present(repo_root: Path) -> bool:
+    """Return True iff the resolved ``.git/index`` file exists.
+
+    Pure stdlib stat -- no git subprocess, independent of the
+    master flag (useful for diagnostics in any state). Returns
+    False when ``.git`` is absent/unparseable or the index file is
+    missing. NEVER raises.
+    """
+    idx = _resolve_index_path(Path(repo_root))
+    if idx is None:
+        return False
+    try:
+        return idx.is_file()
+    except OSError:
+        return False
+
+
+def detect_and_rebuild(
+    repo_root: Path,
+    *,
+    on_anomaly: Optional[Callable[["GitIndexAnomaly"], None]] = None,
+    timeout_s: Optional[float] = None,
+) -> GitIndexAnomaly:
+    """Detect a missing ``.git/index`` and advisorily rebuild it
+    from HEAD via ``git read-tree HEAD``. NEVER raises.
+
+    Safety contract (load-bearing):
+
+      * If the index is **present**, returns ``HEALTHY`` and does
+        nothing. The guard MUST NOT rebuild a present index --
+        ``read-tree HEAD`` would silently discard legitimately
+        staged operator work.
+      * The rebuild is ``git read-tree HEAD`` ONLY. It writes the
+        index from the HEAD tree and does **not** modify the
+        working tree. No ``reset --hard`` / ``checkout`` / ``clean``
+        / ``rm --cached`` is ever issued.
+
+    ``on_anomaly`` (optional) is invoked exactly once with the
+    resulting :class:`GitIndexAnomaly` whenever the outcome is NOT
+    ``HEALTHY`` and NOT ``DISABLED`` (i.e. an actual anomaly was
+    observed -- rebuilt, rebuild-failed, or probe-failed). The
+    callback is fail-silent: any exception it raises is swallowed
+    so a misbehaving SSE emitter cannot break the guard. This is
+    the dependency-injection seam that keeps the module
+    pure-stdlib while letting a Slice-2 consumer wire the
+    ``StreamEventBroker`` ``git_index_anomaly`` event.
+
+    Outcomes: ``DISABLED`` (master off) / ``HEALTHY`` (index
+    present) / ``MISSING_REBUILT`` / ``MISSING_REBUILD_FAILED`` /
+    ``FAILED`` (cannot resolve .git -- non-repo).
+    """
+    root = Path(repo_root)
+    idx = _resolve_index_path(root)
+
+    def _emit(anomaly: "GitIndexAnomaly") -> None:
+        # Structured WARNING is the Slice-1 signal (mirrors
+        # cross_process_jsonl stale_lock_detected). Then the
+        # injected SSE seam, fail-silent.
+        logger.warning(
+            "[GitIndexGuard] git_index_anomaly repo=%s outcome=%s "
+            "index_path=%s detail=%s",
+            anomaly.repo_root, anomaly.outcome.value,
+            anomaly.index_path, anomaly.detail[:200],
+        )
+        if on_anomaly is not None:
+            try:
+                on_anomaly(anomaly)
+            except Exception as exc:  # noqa: BLE001 -- fail-silent seam
+                logger.debug(
+                    "[GitIndexGuard] on_anomaly callback raised "
+                    "(swallowed): %s", exc,
+                )
+
+    if not git_index_guard_enabled():
+        return GitIndexAnomaly(
+            repo_root=str(root),
+            index_path=str(idx) if idx is not None else "",
+            outcome=GitIndexGuardOutcome.DISABLED,
+        )
+
+    if idx is None:
+        anomaly = GitIndexAnomaly(
+            repo_root=str(root),
+            index_path="",
+            outcome=GitIndexGuardOutcome.FAILED,
+            detail="could not resolve .git/index (non-repo or "
+            "unparseable gitfile)",
+        )
+        _emit(anomaly)
+        return anomaly
+
+    try:
+        index_exists = idx.is_file()
+    except OSError:
+        index_exists = False
+
+    if index_exists:
+        # Common safe path -- do NOT touch a present index.
+        return GitIndexAnomaly(
+            repo_root=str(root),
+            index_path=str(idx),
+            outcome=GitIndexGuardOutcome.HEALTHY,
+        )
+
+    # Index is absent -> advisory non-destructive rebuild.
+    timeout = (
+        timeout_s if timeout_s is not None
+        else git_index_guard_timeout_s()
+    )
+    result = _run_git(
+        ["read-tree", "HEAD"], repo_root=root, timeout_s=timeout,
+    )
+    if result is not None and result.returncode == 0 and idx.is_file():
+        anomaly = GitIndexAnomaly(
+            repo_root=str(root),
+            index_path=str(idx),
+            outcome=GitIndexGuardOutcome.MISSING_REBUILT,
+            detail="index was absent; rebuilt from HEAD "
+            "(working tree untouched)",
+        )
+        _emit(anomaly)
+        return anomaly
+
+    detail = "read-tree HEAD failed"
+    if result is not None:
+        stderr_tail = (result.stderr or "").strip()[:200]
+        detail = f"read-tree HEAD rc={result.returncode}: {stderr_tail}"
+    anomaly = GitIndexAnomaly(
+        repo_root=str(root),
+        index_path=str(idx),
+        outcome=GitIndexGuardOutcome.MISSING_REBUILD_FAILED,
+        detail=detail,
+    )
+    _emit(anomaly)
+    return anomaly
+
+
+__all__ = [
+    "GIT_INDEX_GUARD_SCHEMA_VERSION",
+    "GitIndexAnomaly",
+    "GitIndexGuardOutcome",
+    "detect_and_rebuild",
+    "git_index_guard_enabled",
+    "git_index_guard_timeout_s",
+    "git_index_present",
+    "register_flags",
+    "register_shipped_invariants",
+]
+
+
+# ---------------------------------------------------------------------------
+# Module-owned FlagRegistry seeds
+# ---------------------------------------------------------------------------
+
+
+def register_flags(registry) -> int:  # noqa: ANN001
+    try:
+        from backend.core.ouroboros.governance.flag_registry import (
+            Category, FlagSpec, FlagType,
+        )
+    except Exception as exc:  # noqa: BLE001 -- defensive
+        logger.warning("[GitIndexGuard] register_flags degraded: %s", exc)
+        return 0
+    target = "backend/core/ouroboros/governance/git_index_guard.py"
+    specs = [
+        FlagSpec(
+            name="JARVIS_GIT_INDEX_GUARD_ENABLED",
+            type=FlagType.BOOL, default=False,
+            category=Category.SAFETY,
+            source_file=target,
+            example="JARVIS_GIT_INDEX_GUARD_ENABLED=true",
+            description=(
+                "Master switch for the git-index integrity guard. "
+                "When on, detect_and_rebuild() detects a MISSING "
+                ".git/index (the Cursor-Agent unlink failure mode "
+                "that produces the false '7856 staged deletions' "
+                "in Source Control) and advisorily rebuilds it from "
+                "HEAD via 'git read-tree HEAD' -- working tree "
+                "untouched, present indexes never modified. Slice 1 "
+                "default-false until soak graduation."
+            ),
+        ),
+        FlagSpec(
+            name="JARVIS_GIT_INDEX_GUARD_TIMEOUT_S",
+            type=FlagType.FLOAT, default=5.0,
+            category=Category.TIMING,
+            source_file=target,
+            example="JARVIS_GIT_INDEX_GUARD_TIMEOUT_S=10.0",
+            description=(
+                "Subprocess timeout for the 'git read-tree HEAD' "
+                "rebuild. Bounded so a hung git binary cannot stall "
+                "the caller. Floor 1.0, ceiling 30.0."
+            ),
+        ),
+    ]
+    count = 0
+    for spec in specs:
+        try:
+            registry.register(spec)
+            count += 1
+        except Exception as exc:  # noqa: BLE001 -- defensive
+            logger.debug(
+                "[GitIndexGuard] register_flags spec %s skipped: %s",
+                spec.name, exc,
+            )
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Module-owned shipped_code_invariants (AST pins)
+# ---------------------------------------------------------------------------
+
+
+def register_shipped_invariants() -> list:
+    """Slice 1 invariants: pure-stdlib at hot path + closed-5
+    outcome taxonomy + the load-bearing non-destructive-rebuild
+    property (``read-tree`` present; no working-tree-destructive
+    git verb anywhere outside the registration contract)."""
+    import ast as _ast
+    try:
+        from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+            ShippedCodeInvariant,
+        )
+    except ImportError:
+        return []
+
+    def _validate(tree: "_ast.Module", source: str) -> tuple:
+        # ``source`` is part of the ShippedCodeInvariant protocol
+        # signature; this validator works on the AST exclusively
+        # (string-Constant scan) so destructive-token literals in
+        # this very function cannot self-match a raw substring.
+        _ = source
+        violations: list = []
+        registration_funcs = {
+            "register_flags", "register_shipped_invariants",
+        }
+        exempt_ranges = []
+        for fnode in _ast.walk(tree):
+            if isinstance(fnode, _ast.FunctionDef):
+                if fnode.name in registration_funcs:
+                    start = getattr(fnode, "lineno", 0)
+                    end = getattr(fnode, "end_lineno", start) or start
+                    exempt_ranges.append((start, end))
+
+        def _in_exempt(lineno: int) -> bool:
+            return any(s <= lineno <= e for s, e in exempt_ranges)
+
+        # (1) Pure-stdlib at hot path: no governance/backend imports
+        #     outside the registration contract.
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.ImportFrom):
+                module = node.module or ""
+                if "backend." in module or "governance" in module:
+                    lineno = getattr(node, "lineno", 0)
+                    if _in_exempt(lineno):
+                        continue
+                    violations.append(
+                        f"line {lineno}: git_index_guard must be "
+                        f"pure-stdlib at hot path -- found {module!r}"
+                    )
+            if isinstance(node, _ast.Call) and isinstance(
+                node.func, _ast.Name
+            ):
+                if node.func.id in ("exec", "eval", "compile"):
+                    violations.append(
+                        f"line {getattr(node, 'lineno', '?')}: "
+                        f"git_index_guard MUST NOT {node.func.id}()"
+                    )
+
+        # (2) Closed-5 GitIndexGuardOutcome taxonomy.
+        required = {
+            "HEALTHY", "MISSING_REBUILT", "MISSING_REBUILD_FAILED",
+            "DISABLED", "FAILED",
+        }
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.ClassDef) and (
+                node.name == "GitIndexGuardOutcome"
+            ):
+                seen = set()
+                for stmt in node.body:
+                    if isinstance(stmt, _ast.Assign):
+                        for tgt in stmt.targets:
+                            if isinstance(tgt, _ast.Name):
+                                seen.add(tgt.id)
+                missing = required - seen
+                extras = seen - required
+                if missing:
+                    violations.append(
+                        f"GitIndexGuardOutcome missing required "
+                        f"values: {sorted(missing)}"
+                    )
+                if extras:
+                    violations.append(
+                        f"GitIndexGuardOutcome has unexpected values "
+                        f"(closed-taxonomy violation): {sorted(extras)}"
+                    )
+
+        # (3) Load-bearing non-destructive-rebuild property.
+        #     The rebuild MUST use read-tree; it MUST NOT issue any
+        #     working-tree-destructive git verb. We scan string
+        #     Constants OUTSIDE the registration/invariant ranges so
+        #     the destructive-token literals in THIS validator (which
+        #     live inside register_shipped_invariants) never self-
+        #     match. Tokens are assembled from fragments as a second
+        #     belt against source-substring false positives.
+        read_tree_seen = False
+        destructive = {
+            "--" + "hard", "check" + "out", "cle" + "an",
+            "--" + "cached", "reset",
+        }
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.Constant) and isinstance(
+                node.value, str
+            ):
+                lineno = getattr(node, "lineno", 0)
+                if _in_exempt(lineno):
+                    continue
+                val = node.value.strip()
+                if val == "read-tree":
+                    read_tree_seen = True
+                if val in destructive:
+                    violations.append(
+                        f"line {lineno}: git_index_guard issues a "
+                        f"working-tree-destructive git token "
+                        f"{val!r} -- rebuild must be read-tree-only "
+                        f"(content-safety invariant)"
+                    )
+        if not read_tree_seen:
+            violations.append(
+                "git_index_guard rebuild MUST use 'read-tree' "
+                "(the non-destructive HEAD->index recovery); the "
+                "literal is absent outside the registration contract"
+            )
+        return tuple(violations)
+
+    target = "backend/core/ouroboros/governance/git_index_guard.py"
+    return [
+        ShippedCodeInvariant(
+            invariant_name="git_index_guard_purity_and_nondestructive",
+            target_file=target,
+            description=(
+                "Slice 1 primitive stays pure-stdlib at the hot "
+                "path (no backend/governance imports outside "
+                "register_flags / register_shipped_invariants); "
+                "GitIndexGuardOutcome is the closed-5 taxonomy; the "
+                "rebuild is read-tree-only -- NO reset --hard / "
+                "checkout / clean / --cached anywhere (rebuilding a "
+                "missing index must never touch the working tree or "
+                "discard staged work)."
+            ),
+            validate=_validate,
+        ),
+    ]

--- a/backend/core/ouroboros/governance/operator_commit_authority.py
+++ b/backend/core/ouroboros/governance/operator_commit_authority.py
@@ -112,15 +112,29 @@ _ENV_PLAN_TTL_S = "JARVIS_COMMIT_GRANT_PLAN_TTL_S"
 _ENV_GRANTS_PATH = "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH"
 _ENV_SECRET_PATH = "JARVIS_COMMIT_AUTHORITY_SECRET_PATH"
 _ENV_ENABLE_FILE = "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE"
+_ENV_PRESENCE_FILE = "JARVIS_COMMIT_AUTHORITY_PRESENCE_FILE"
+_ENV_PRESENCE_TTL_S = "JARVIS_COMMIT_PRESENCE_TTL_S"
 
 _DEFAULT_GRANTS_RELATIVE = ".jarvis/commit_authority/grants.jsonl"
 _DEFAULT_SECRET_RELATIVE = ("commit_authority", "secret")  # under ~/.jarvis
 _DEFAULT_ENABLE_RELATIVE = ("commit_authority", "enabled")  # under ~/.jarvis
+_DEFAULT_PRESENCE_RELATIVE = (
+    "commit_authority", "presence.json",
+)  # under ~/.jarvis
 
 _DEFAULT_TTL_S = 3600
 _MIN_TTL_S = 60
 _MAX_TTL_S = 86_400  # 24h ceiling
 _DEFAULT_PLAN_TTL_S = 900  # PLAN/ANALYZE modes: shorter grants
+
+# Operator-presence marker lifetime. Short by design: it is a
+# "the operator is actively here this session" proof, re-minted
+# every time the operator issues a grant / re-enables. An Agent
+# cannot forge it (needs the per-machine secret + a deliberate
+# operator entry point).
+_DEFAULT_PRESENCE_TTL_S = 900  # 15 min
+_MIN_PRESENCE_TTL_S = 60
+_MAX_PRESENCE_TTL_S = 86_400  # 24h ceiling
 
 _GIT_OP_TIMEOUT_S = 5.0
 
@@ -419,6 +433,23 @@ def enable_authority(
         except Exception:  # noqa: BLE001 — best effort
             pass
         os.replace(str(tmp), str(target))
+        # Operator-only entry point: also mint a presence marker so
+        # an operator channel can be earned without a separate
+        # arming step (branch-agnostic — `enable` is a "the
+        # operator is here on this machine" act). Best-effort;
+        # never blocks enablement.
+        try:
+            _root, _branch = resolve_repo_root_and_branch(
+                _resolve_repo_root() or Path(".")
+            )
+            mint_operator_presence(
+                _root or (_resolve_repo_root() or Path(".")),
+                _branch,
+                label,
+                now_unix=now,
+            )
+        except Exception:  # noqa: BLE001 — never block enable
+            pass
         return True
     except Exception as exc:  # noqa: BLE001
         logger.warning(
@@ -442,6 +473,206 @@ def disable_authority() -> bool:
         return not target.exists()
     except Exception:  # noqa: BLE001
         return False
+
+
+# ===========================================================================
+# Operator-presence marker — the structural channel discriminator
+# ===========================================================================
+#
+# Root cause this closes: ``commit_authority_cli`` inferred the
+# commit channel from an env var that *hardcoded-defaulted to
+# "ide"*. A human clicking Cursor's Commit button and a Cursor
+# *Agent* running ``git commit`` are the SAME process tree with
+# identical env → both resolved to ``ide`` → both matched the
+# operator's interactive ``ide`` grant. The ``autonomous`` channel
+# (bounded by :mod:`ledger_sovereignty`) existed but was never
+# reached for IDE-spawned commits.
+#
+# You cannot reliably tell "human SCM commit" from "Agent git
+# commit" by ambient environment (they look identical). So the
+# authorization must NOT depend on that distinction. Instead, an
+# operator channel must be *earned* by a positive, unforgeable
+# proof of operator presence: a short-TTL JSON record signed with
+# the SAME per-machine secret as grants/enable (composes
+# :func:`_sign` / :func:`_verify` / :func:`_read_secret` — ZERO new
+# crypto). It is minted ONLY at operator-only entry points
+# (:func:`issue_grant`, :func:`enable_authority`). Absent a valid
+# marker, :func:`resolve_commit_channel` returns ``AUTONOMOUS`` →
+# the existing sovereignty path refuses the commit on a non-owned
+# tree (the operator main checkout). Fail-closed, no ambient
+# sniffing, no hardcoded default.
+
+
+def presence_file_path() -> Path:
+    """Operator-presence marker location. Lives OUTSIDE the repo
+    (``~/.jarvis/commit_authority/presence.json``) for the same
+    reason the secret/enable record do — GUI git inherits no shell
+    env. Operator override via
+    ``JARVIS_COMMIT_AUTHORITY_PRESENCE_FILE``. NEVER raises."""
+    raw = os.environ.get(_ENV_PRESENCE_FILE, "").strip()
+    if raw:
+        try:
+            return Path(raw).expanduser().resolve()
+        except Exception:  # noqa: BLE001
+            pass
+    return Path.home() / ".jarvis" / Path(*_DEFAULT_PRESENCE_RELATIVE)
+
+
+def presence_ttl_s() -> int:
+    """``JARVIS_COMMIT_PRESENCE_TTL_S`` (default 900s = 15 min,
+    floor 60s, ceiling 86400s). Garbage/empty → default. NEVER
+    raises."""
+    raw = os.environ.get(_ENV_PRESENCE_TTL_S, "").strip()
+    try:
+        v = int(float(raw)) if raw else _DEFAULT_PRESENCE_TTL_S
+    except (TypeError, ValueError):
+        v = _DEFAULT_PRESENCE_TTL_S
+    return max(_MIN_PRESENCE_TTL_S, min(_MAX_PRESENCE_TTL_S, v))
+
+
+def _presence_signed_payload(
+    issued_at_unix: float,
+    ttl_s: int,
+    repo_root_sha256: str,
+    branch: str,
+    operator_label: str,
+) -> Dict[str, Any]:
+    """Canonical dict the presence HMAC covers. Deterministic —
+    recomputed from trusted fields on verify so a tampered/extra
+    field cannot ride an old signature (same discipline as the
+    enable record)."""
+    return {
+        "kind": "operator_presence",
+        "issued_at_unix": float(issued_at_unix),
+        "ttl_s": int(ttl_s),
+        "repo_root_sha256": str(repo_root_sha256),
+        "branch": str(branch),
+        "operator_label": str(operator_label),
+        "schema_version": OPERATOR_COMMIT_AUTHORITY_SCHEMA_VERSION,
+    }
+
+
+def mint_operator_presence(
+    repo_root: Path,
+    branch: str,
+    operator_label: str,
+    *,
+    ttl_s: Optional[int] = None,
+    now_unix: Optional[float] = None,
+) -> bool:
+    """Operator-only: write the signed presence marker bound to
+    ``(repo_root, branch)``. Atomic write, 0600 (mirrors
+    :func:`enable_authority`). Bootstraps the per-machine secret on
+    first use. Returns ``True`` on success. NEVER raises."""
+    label = str(operator_label or "").strip()
+    if not label:
+        return False
+    secret = _ensure_secret()
+    if not secret:
+        return False
+    try:
+        fp = repo_root_fingerprint(Path(repo_root))
+    except Exception:  # noqa: BLE001
+        return False
+    now = float(now_unix) if now_unix is not None else time.time()
+    eff_ttl = (
+        int(ttl_s)
+        if (ttl_s is not None and int(ttl_s) > 0)
+        else presence_ttl_s()
+    )
+    eff_ttl = max(_MIN_PRESENCE_TTL_S, min(_MAX_PRESENCE_TTL_S, eff_ttl))
+    payload = _presence_signed_payload(
+        now, eff_ttl, fp, str(branch or "").strip(), label,
+    )
+    signature = _sign(payload, secret)
+    if not signature:
+        return False
+    target = presence_file_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(
+                {"record": payload, "signature": signature},
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        try:
+            os.chmod(tmp, 0o600)
+        except Exception:  # noqa: BLE001 — best effort
+            pass
+        os.replace(str(tmp), str(target))
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[operator_commit_authority] presence write failed at "
+            "%s: %s",
+            target,
+            type(exc).__name__,
+        )
+        return False
+
+
+def valid_operator_presence(
+    repo_root: Path,
+    branch: str,
+    *,
+    now_unix: Optional[float] = None,
+) -> bool:
+    """Return ``True`` iff a valid, HMAC-signed, unexpired
+    presence marker exists for ``(repo_root, branch)``. NEVER
+    raises. Missing file / missing secret / malformed JSON / bad
+    signature / expired TTL / repo mismatch / branch mismatch all
+    → ``False`` (fail closed — the commit then resolves to
+    AUTONOMOUS and the sovereignty gate decides)."""
+    target = presence_file_path()
+    try:
+        if not target.exists():
+            return False
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return False
+    if not isinstance(raw, dict):
+        return False
+    record = raw.get("record")
+    signature = raw.get("signature")
+    if not isinstance(record, dict) or not isinstance(signature, str):
+        return False
+    if record.get("kind") != "operator_presence":
+        return False
+    secret = _read_secret()
+    if not secret:
+        return False
+    try:
+        issued = float(record.get("issued_at_unix", 0.0))
+        ttl = int(record.get("ttl_s", 0))
+    except (TypeError, ValueError):
+        return False
+    rec_repo = str(record.get("repo_root_sha256", ""))
+    rec_branch = str(record.get("branch", ""))
+    payload = _presence_signed_payload(
+        issued, ttl, rec_repo, rec_branch,
+        str(record.get("operator_label", "")),
+    )
+    if not _verify(payload, signature, secret):
+        return False
+    now = float(now_unix) if now_unix is not None else time.time()
+    if ttl <= 0 or now >= issued + float(ttl):
+        return False
+    try:
+        fp = repo_root_fingerprint(Path(repo_root))
+    except Exception:  # noqa: BLE001
+        return False
+    if rec_repo and rec_repo != fp:
+        return False
+    cur_branch = str(branch or "").strip()
+    # An empty marker branch == operator armed the whole repo this
+    # session (branch-agnostic presence). A non-empty marker branch
+    # must match the committing branch.
+    if rec_branch and cur_branch and rec_branch != cur_branch:
+        return False
+    return True
 
 
 # ===========================================================================
@@ -475,6 +706,63 @@ class CommitChannel(str, enum.Enum):
             return cls(str(value).strip().lower())
         except Exception:  # noqa: BLE001
             return None
+
+
+def resolve_commit_channel(
+    repo_root: Path,
+    branch: str,
+    *,
+    env_channel: str = "",
+    now_unix: Optional[float] = None,
+) -> CommitChannel:
+    """Structural, evidence-based commit-channel resolution.
+
+    Replaces the blind ``or "ide"`` default in
+    ``commit_authority_cli`` that let a Cursor *Agent*'s headless
+    git commit borrow the operator's interactive ``ide`` grant.
+
+    Rule (fail-closed, no ambient sniffing, no hardcoded default):
+
+      1. Explicit ``autonomous`` → :attr:`CommitChannel.AUTONOMOUS`.
+         The safe sink — :func:`verify_pre_commit` delegates it to
+         :mod:`ledger_sovereignty` (composed, never reimplemented).
+      2. No valid operator-presence marker for ``(repo_root,
+         branch)`` → :attr:`CommitChannel.AUTONOMOUS`. A human
+         Cursor SCM commit *earns* an operator channel because the
+         operator minted a short-TTL signed presence marker
+         (:func:`issue_grant` / :func:`enable_authority` do so). An
+         Agent cannot forge it. So an Agent's commit on the
+         operator main checkout falls here → AUTONOMOUS → the
+         sovereignty gate refuses it on the non-owned tree. Exactly
+         the design behavior, finally reached.
+      3. Valid presence + explicit operator channel
+         (``repl``/``cli``/``ide``/``daemon``) → that channel.
+      4. Valid presence + unset/unparseable env → ``IDE`` — the
+         *earned* interactive default (presence proves the operator
+         is here), never a hardcoded blanket default.
+
+    ``env_channel`` is the raw ``JARVIS_COMMIT_CHANNEL`` value. It
+    is honored ONLY when operator presence is valid (case 3) or it
+    is ``autonomous`` (case 1) — a forged ``JARVIS_COMMIT_CHANNEL=
+    ide`` without presence does NOT yield an operator channel.
+    NEVER raises.
+    """
+    raw = str(env_channel or "").strip()
+    parsed = CommitChannel.parse(raw) if raw else None
+    if parsed is CommitChannel.AUTONOMOUS:
+        return CommitChannel.AUTONOMOUS
+    if not valid_operator_presence(
+        repo_root, branch, now_unix=now_unix,
+    ):
+        return CommitChannel.AUTONOMOUS
+    if parsed in (
+        CommitChannel.REPL,
+        CommitChannel.CLI,
+        CommitChannel.IDE,
+        CommitChannel.DAEMON,
+    ):
+        return parsed  # type: ignore[return-value]
+    return CommitChannel.IDE
 
 
 class CommitAuthorityVerdict(str, enum.Enum):
@@ -1178,6 +1466,21 @@ def issue_grant(
             grants_path_str=str(grants_path()),
             error="grant ledger append failed",
         )
+    # Operator-only entry point: mint a presence marker bound to
+    # this grant's repo+branch so resolve_commit_channel can earn
+    # an operator channel for the interactive operator. An Agent
+    # commit, lacking presence, falls to AUTONOMOUS →
+    # ledger_sovereignty. Best-effort: a presence-write failure
+    # must not fail an otherwise-successful grant.
+    try:
+        mint_operator_presence(
+            root,
+            str(branch).strip(),
+            str(operator_label).strip(),
+            now_unix=now,
+        )
+    except Exception:  # noqa: BLE001 — never block a valid grant
+        pass
     return GrantIssueOutcome(
         ok=True,
         grant_id=grant.grant_id,
@@ -1644,6 +1947,11 @@ __all__ = [
     "persistent_enabled",
     "enable_authority",
     "disable_authority",
+    "presence_file_path",
+    "presence_ttl_s",
+    "mint_operator_presence",
+    "valid_operator_presence",
+    "resolve_commit_channel",
     "resolve_repo_root_and_branch",
     "repo_root_fingerprint",
     "verify_pre_commit",

--- a/tests/governance/test_commit_authority_cli.py
+++ b/tests/governance/test_commit_authority_cli.py
@@ -137,10 +137,37 @@ class TestHookMasterOff:
 
 
 class TestHookMasterOn:
-    def test_no_grant_blocks(self, monkeypatch):
+    def test_no_grant_no_presence_new_model(self, monkeypatch):
+        """Re-encoded for the structural channel-resolution fix
+        (2026-05-19). The legacy ``or "ide"`` default meant
+        master-on + no-grant ALWAYS blocked. Now: no operator-
+        presence marker → channel resolves to AUTONOMOUS, and the
+        verdict is delegated to ledger_sovereignty (composed, NOT
+        reimplemented). Hence the gate is sound ONLY when
+        sovereignty enforcement is also on:
+
+          * sovereignty OFF → autonomous legacy contract authorizes
+            (the documented AutoCommitter behavior; this is WHY
+            operator hygiene mandates enabling sovereignty)
+          * sovereignty ON + unowned tree → DENIED_SOVEREIGNTY,
+            still blocks (the real "no authority ⇒ blocked"
+            guarantee, under the sound configuration)
+        """
         monkeypatch.setenv(
             "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true"
         )
+        # No JARVIS_COMMIT_CHANNEL, no grant, no presence minted.
+        # Sovereignty OFF → autonomous legacy pass-through.
+        monkeypatch.setenv("JARVIS_LEDGER_SOVEREIGNTY_ENABLED", "false")
+        assert cli.cmd_hook_pre_commit() == 0
+
+        # Sovereignty ON + tree not owned → blocked via the
+        # composed sovereignty gate (no parallel denial logic).
+        from backend.core.ouroboros.governance import (
+            ledger_sovereignty as _ls,
+        )
+        monkeypatch.setenv("JARVIS_LEDGER_SOVEREIGNTY_ENABLED", "true")
+        monkeypatch.setattr(_ls, "is_owned", lambda _p: False)
         assert cli.cmd_hook_pre_commit() == 1
 
     def test_signed_grant_authorizes_without_env_token(

--- a/tests/governance/test_git_index_guard.py
+++ b/tests/governance/test_git_index_guard.py
@@ -1,0 +1,317 @@
+"""GitIndexGuard Slice 1 -- regression spine.
+
+Pins the pure-stdlib primitive that detects a MISSING
+``.git/index`` (the background-Cursor-Agent unlink failure mode
+that produced the false "7856 staged deletions" in Source
+Control, operator soak 2026-05-19) and advisorily rebuilds it
+from HEAD with ``git read-tree HEAD`` -- working tree untouched,
+present indexes NEVER modified.
+
+Coverage:
+  * Master flag asymmetric env semantics (default false until
+    graduation)
+  * Timeout env knob clamping (floor / ceiling / garbage)
+  * Closed-5 GitIndexGuardOutcome taxonomy + exact value set
+  * Frozen GitIndexAnomaly dataclass + to_dict round-trip
+  * _resolve_index_path: .git dir / .git gitfile worktree /
+    absent / unparseable
+  * git_index_present: present / absent / non-repo
+  * detect_and_rebuild: DISABLED / HEALTHY (and the load-bearing
+    "present index is never rebuilt -- no subprocess" safety pin)
+    / MISSING_REBUILT (real repo) / MISSING_REBUILD_FAILED /
+    FAILED (non-repo)
+  * on_anomaly seam: fired for anomalies, NOT for HEALTHY /
+    DISABLED, callback exception swallowed
+  * NEVER raises across every IO boundary
+  * register_flags seeds 2 specs; register_shipped_invariants
+    self-validates green against the shipped source
+"""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import List
+from unittest import mock
+
+import pytest
+
+from backend.core.ouroboros.governance.git_index_guard import (
+    GIT_INDEX_GUARD_SCHEMA_VERSION,
+    GitIndexAnomaly,
+    GitIndexGuardOutcome,
+    detect_and_rebuild,
+    git_index_guard_enabled,
+    git_index_guard_timeout_s,
+    git_index_present,
+    register_flags,
+    register_shipped_invariants,
+)
+from backend.core.ouroboros.governance import git_index_guard as gig
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for k in (
+        "JARVIS_GIT_INDEX_GUARD_ENABLED",
+        "JARVIS_GIT_INDEX_GUARD_TIMEOUT_S",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """A real, minimal git repo with one commit on HEAD."""
+    def _run(*args: str) -> None:
+        subprocess.run(
+            ["git", *args], cwd=str(tmp_path),
+            check=True, capture_output=True, text=True,
+        )
+    _run("init", "-q")
+    _run("config", "user.email", "t@t.t")
+    _run("config", "user.name", "t")
+    (tmp_path / "keep.txt").write_text("payload\n", encoding="utf-8")
+    _run("add", "keep.txt")
+    _run("commit", "-q", "-m", "seed")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Master flag + timeout knob
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, False), ("", False), ("   ", False),
+        ("1", True), ("true", True), ("YES", True), ("on", True),
+        ("0", False), ("false", False), ("garbage", False),
+    ],
+)
+def test_master_flag_asymmetric(monkeypatch, raw, expected):
+    if raw is None:
+        monkeypatch.delenv("JARVIS_GIT_INDEX_GUARD_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("JARVIS_GIT_INDEX_GUARD_ENABLED", raw)
+    assert git_index_guard_enabled() is expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, 5.0), ("", 5.0), ("garbage", 5.0),
+        ("0.0", 1.0), ("0.5", 1.0), ("-9", 1.0),
+        ("10", 10.0), ("999", 30.0), ("30", 30.0),
+    ],
+)
+def test_timeout_clamp(monkeypatch, raw, expected):
+    if raw is None:
+        monkeypatch.delenv(
+            "JARVIS_GIT_INDEX_GUARD_TIMEOUT_S", raising=False,
+        )
+    else:
+        monkeypatch.setenv("JARVIS_GIT_INDEX_GUARD_TIMEOUT_S", raw)
+    assert git_index_guard_timeout_s() == expected
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy + dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_closed_5_taxonomy():
+    assert {m.value for m in GitIndexGuardOutcome} == {
+        "healthy", "missing_rebuilt", "missing_rebuild_failed",
+        "disabled", "failed",
+    }
+
+
+def test_anomaly_frozen_and_roundtrip():
+    a = GitIndexAnomaly(
+        repo_root="/r", index_path="/r/.git/index",
+        outcome=GitIndexGuardOutcome.MISSING_REBUILT, detail="d",
+    )
+    assert a.schema_version == GIT_INDEX_GUARD_SCHEMA_VERSION
+    assert a.to_dict() == {
+        "repo_root": "/r",
+        "index_path": "/r/.git/index",
+        "outcome": "missing_rebuilt",
+        "detail": "d",
+        "schema_version": GIT_INDEX_GUARD_SCHEMA_VERSION,
+    }
+    with pytest.raises(FrozenInstanceError):
+        a.detail = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# _resolve_index_path / git_index_present
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_index_dir_layout(git_repo):
+    idx = gig._resolve_index_path(git_repo)
+    assert idx == git_repo / ".git" / "index"
+    assert git_index_present(git_repo) is True
+
+
+def test_resolve_index_gitfile_worktree(tmp_path):
+    # Simulate a linked-worktree .git *file*.
+    real_gitdir = tmp_path / "realgit" / "worktrees" / "wt"
+    real_gitdir.mkdir(parents=True)
+    (real_gitdir / "index").write_bytes(b"x")
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    (wt / ".git").write_text(
+        f"gitdir: {real_gitdir}\n", encoding="utf-8",
+    )
+    assert gig._resolve_index_path(wt) == real_gitdir / "index"
+    assert git_index_present(wt) is True
+
+
+def test_resolve_index_non_repo(tmp_path):
+    assert gig._resolve_index_path(tmp_path) is None
+    assert git_index_present(tmp_path) is False
+
+
+def test_resolve_index_unparseable_gitfile(tmp_path):
+    (tmp_path / ".git").write_text("not a gitdir line\n")
+    assert gig._resolve_index_path(tmp_path) is None
+    assert git_index_present(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# detect_and_rebuild
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_when_master_off(git_repo):
+    out = detect_and_rebuild(git_repo)
+    assert out.outcome is GitIndexGuardOutcome.DISABLED
+
+
+def test_healthy_present_index_never_rebuilds(monkeypatch, git_repo):
+    """Load-bearing safety pin: a present index must NEVER trigger
+    a rebuild -- no git subprocess may run (read-tree HEAD would
+    discard legitimately staged work)."""
+    monkeypatch.setenv("JARVIS_GIT_INDEX_GUARD_ENABLED", "true")
+    with mock.patch.object(
+        gig, "_run_git", side_effect=AssertionError("must not run git"),
+    ):
+        out = detect_and_rebuild(git_repo)
+    assert out.outcome is GitIndexGuardOutcome.HEALTHY
+
+
+def test_missing_index_rebuilt_workingtree_untouched(
+    monkeypatch, git_repo,
+):
+    monkeypatch.setenv("JARVIS_GIT_INDEX_GUARD_ENABLED", "true")
+    idx = git_repo / ".git" / "index"
+    idx.unlink()
+    assert not idx.is_file()
+
+    fired: List[GitIndexAnomaly] = []
+    out = detect_and_rebuild(git_repo, on_anomaly=fired.append)
+
+    assert out.outcome is GitIndexGuardOutcome.MISSING_REBUILT
+    assert idx.is_file()  # index back
+    # Working tree content untouched.
+    assert (git_repo / "keep.txt").read_text() == "payload\n"
+    # git status agrees: clean (no spurious deletions).
+    st = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=str(git_repo),
+        capture_output=True, text=True,
+    )
+    assert st.stdout.strip() == ""
+    assert len(fired) == 1
+    assert fired[0].outcome is GitIndexGuardOutcome.MISSING_REBUILT
+
+
+def test_missing_rebuild_failed(monkeypatch, git_repo):
+    monkeypatch.setenv("JARVIS_GIT_INDEX_GUARD_ENABLED", "true")
+    (git_repo / ".git" / "index").unlink()
+    fired: List[GitIndexAnomaly] = []
+    fake = subprocess.CompletedProcess(
+        args=["git"], returncode=128, stdout="", stderr="boom",
+    )
+    with mock.patch.object(gig, "_run_git", return_value=fake):
+        out = detect_and_rebuild(git_repo, on_anomaly=fired.append)
+    assert out.outcome is GitIndexGuardOutcome.MISSING_REBUILD_FAILED
+    assert "rc=128" in out.detail and "boom" in out.detail
+    assert len(fired) == 1
+
+
+def test_failed_non_repo(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_GIT_INDEX_GUARD_ENABLED", "true")
+    fired: List[GitIndexAnomaly] = []
+    out = detect_and_rebuild(tmp_path, on_anomaly=fired.append)
+    assert out.outcome is GitIndexGuardOutcome.FAILED
+    assert len(fired) == 1
+
+
+def test_on_anomaly_not_fired_for_healthy_or_disabled(
+    monkeypatch, git_repo,
+):
+    calls: List[GitIndexAnomaly] = []
+    # DISABLED
+    detect_and_rebuild(git_repo, on_anomaly=calls.append)
+    # HEALTHY
+    monkeypatch.setenv("JARVIS_GIT_INDEX_GUARD_ENABLED", "true")
+    detect_and_rebuild(git_repo, on_anomaly=calls.append)
+    assert calls == []
+
+
+def test_on_anomaly_exception_swallowed(monkeypatch, git_repo):
+    monkeypatch.setenv("JARVIS_GIT_INDEX_GUARD_ENABLED", "true")
+    (git_repo / ".git" / "index").unlink()
+
+    def _boom(_a):
+        raise RuntimeError("emitter exploded")
+
+    # Must not raise despite the misbehaving SSE seam.
+    out = detect_and_rebuild(git_repo, on_anomaly=_boom)
+    assert out.outcome is GitIndexGuardOutcome.MISSING_REBUILT
+
+
+def test_never_raises_on_garbage_inputs():
+    # Non-path-ish, None-ish, etc. -- defensive across boundary.
+    for bad in ("", "/nonexistent/zzz", "."):
+        out = detect_and_rebuild(Path(bad))
+        assert isinstance(out, GitIndexAnomaly)
+    assert git_index_present(Path("/nonexistent/zzz")) is False
+
+
+# ---------------------------------------------------------------------------
+# Registration contract
+# ---------------------------------------------------------------------------
+
+
+def test_register_flags_seeds_two():
+    seen = []
+
+    class _Reg:
+        def register(self, spec):
+            seen.append(spec.name)
+
+    assert register_flags(_Reg()) == 2
+    assert set(seen) == {
+        "JARVIS_GIT_INDEX_GUARD_ENABLED",
+        "JARVIS_GIT_INDEX_GUARD_TIMEOUT_S",
+    }
+
+
+def test_shipped_invariant_self_validates_green():
+    import ast
+
+    invs = register_shipped_invariants()
+    assert len(invs) == 1
+    src = Path(gig.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    violations = invs[0].validate(tree, src)
+    assert violations == (), f"self-validate not green: {violations}"

--- a/tests/governance/test_oca_channel_resolution.py
+++ b/tests/governance/test_oca_channel_resolution.py
@@ -1,0 +1,350 @@
+"""OCA structural channel resolution — regression spine.
+
+Closes the root cause of the autonomous-commit incident
+(2026-05-19): ``commit_authority_cli`` inferred the commit
+channel from ``JARVIS_COMMIT_CHANNEL`` *hardcoded-defaulting to
+"ide"*. A Cursor *Agent*'s headless ``git commit`` runs in the
+same process tree / identical env as a human Cursor SCM commit,
+so both resolved to ``ide`` and the Agent borrowed the
+operator's interactive grant.
+
+The structural fix: an operator channel must be *earned* by a
+signed, short-TTL **operator-presence marker** (composes the
+SAME ``_sign``/``_verify``/secret as grants — zero new crypto),
+minted only at operator-only entry points. Absent a valid
+marker, the commit resolves to ``AUTONOMOUS`` and the existing
+:mod:`ledger_sovereignty` gate refuses it on a non-owned tree.
+
+Coverage:
+  * presence_ttl_s clamp (default / garbage / floor / ceiling)
+  * mint → valid roundtrip; tamper / expired / wrong-repo /
+    wrong-branch / empty-marker-branch / missing-secret
+  * resolve_commit_channel: every case in the closed rule
+    (autonomous-env / no-presence / forged-ide / earned-ide /
+    explicit-repl / garbage-env)
+  * issue_grant + enable_authority MINT presence (operator-only
+    entry points)
+  * AST pin: cmd_hook_pre_commit has NO ``or "ide"`` and DOES
+    call resolve_commit_channel
+  * end-to-end verify_pre_commit: forged ide w/o presence +
+    sovereignty-on + unowned tree → DENIED_SOVEREIGNTY (the
+    Agent-commit-denied proof); earned ide + grant → AUTHORIZED
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    operator_commit_authority as oca,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_oca(monkeypatch, tmp_path):
+    """Redirect every OCA artifact into a throwaway dir so tests
+    never read/write the operator's real ~/.jarvis."""
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
+        str(tmp_path / "secret"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_PRESENCE_FILE",
+        str(tmp_path / "presence.json"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE",
+        str(tmp_path / "enabled"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH",
+        str(tmp_path / "grants.jsonl"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true",
+    )
+    for k in ("JARVIS_COMMIT_CHANNEL", "JARVIS_COMMIT_PRESENCE_TTL_S"):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+REPO = Path("/Users/op/checkout-A")
+OTHER = Path("/Users/op/checkout-B")
+C = oca.CommitChannel
+
+
+# --------------------------------------------------------------------------
+# presence_ttl_s clamp
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, 900), ("", 900), ("garbage", 900),
+        ("10", 60), ("0", 60), ("-5", 60),
+        ("1200", 1200), ("999999", 86_400),
+    ],
+)
+def test_presence_ttl_clamp(monkeypatch, raw, expected):
+    if raw is None:
+        monkeypatch.delenv("JARVIS_COMMIT_PRESENCE_TTL_S", raising=False)
+    else:
+        monkeypatch.setenv("JARVIS_COMMIT_PRESENCE_TTL_S", raw)
+    assert oca.presence_ttl_s() == expected
+
+
+# --------------------------------------------------------------------------
+# presence mint / verify
+# --------------------------------------------------------------------------
+
+
+def test_mint_then_valid_roundtrip():
+    assert oca.mint_operator_presence(REPO, "br", "op", now_unix=1000.0)
+    assert oca.valid_operator_presence(REPO, "br", now_unix=1100.0)
+
+
+def test_presence_tamper_invalidates():
+    assert oca.mint_operator_presence(REPO, "br", "op", now_unix=1000.0)
+    pf = oca.presence_file_path()
+    import json
+    blob = json.loads(pf.read_text())
+    blob["record"]["operator_label"] = "attacker"  # forge a field
+    pf.write_text(json.dumps(blob))
+    assert oca.valid_operator_presence(REPO, "br", now_unix=1100.0) is False
+
+
+def test_presence_expired():
+    assert oca.mint_operator_presence(
+        REPO, "br", "op", ttl_s=900, now_unix=1000.0,
+    )
+    # 901s later — past the 900s TTL.
+    assert oca.valid_operator_presence(
+        REPO, "br", now_unix=1000.0 + 901,
+    ) is False
+
+
+def test_presence_wrong_repo():
+    assert oca.mint_operator_presence(REPO, "br", "op", now_unix=1000.0)
+    assert oca.valid_operator_presence(
+        OTHER, "br", now_unix=1100.0,
+    ) is False
+
+
+def test_presence_wrong_branch():
+    assert oca.mint_operator_presence(REPO, "feat", "op", now_unix=1000.0)
+    assert oca.valid_operator_presence(
+        REPO, "main", now_unix=1100.0,
+    ) is False
+
+
+def test_presence_empty_marker_branch_matches_any():
+    assert oca.mint_operator_presence(REPO, "", "op", now_unix=1000.0)
+    assert oca.valid_operator_presence(REPO, "anything", now_unix=1100.0)
+    assert oca.valid_operator_presence(REPO, "", now_unix=1100.0)
+
+
+def test_presence_missing_secret_fails_closed(tmp_path, monkeypatch):
+    assert oca.mint_operator_presence(REPO, "br", "op", now_unix=1000.0)
+    # Remove the per-machine secret — verification must fail closed.
+    Path(tmp_path / "secret").unlink()
+    assert oca.valid_operator_presence(REPO, "br", now_unix=1100.0) is False
+
+
+# --------------------------------------------------------------------------
+# resolve_commit_channel — the closed rule
+# --------------------------------------------------------------------------
+
+
+def test_resolve_env_autonomous_always_autonomous():
+    # No presence needed — autonomous is the safe sink.
+    assert oca.resolve_commit_channel(
+        REPO, "br", env_channel="autonomous",
+    ) is C.AUTONOMOUS
+
+
+def test_resolve_no_env_no_presence_is_autonomous():
+    assert oca.resolve_commit_channel(REPO, "br") is C.AUTONOMOUS
+
+
+def test_resolve_no_env_valid_presence_is_ide():
+    oca.mint_operator_presence(REPO, "br", "op", now_unix=1000.0)
+    assert oca.resolve_commit_channel(
+        REPO, "br", now_unix=1100.0,
+    ) is C.IDE
+
+
+def test_resolve_forged_ide_without_presence_is_autonomous():
+    # The exact attack: Agent sets/inherits JARVIS_COMMIT_CHANNEL=ide
+    # but never minted presence → must NOT get an operator channel.
+    assert oca.resolve_commit_channel(
+        REPO, "br", env_channel="ide",
+    ) is C.AUTONOMOUS
+
+
+def test_resolve_earned_ide_with_presence():
+    oca.mint_operator_presence(REPO, "br", "op", now_unix=1000.0)
+    assert oca.resolve_commit_channel(
+        REPO, "br", env_channel="ide", now_unix=1100.0,
+    ) is C.IDE
+
+
+def test_resolve_explicit_repl_with_presence():
+    oca.mint_operator_presence(REPO, "br", "op", now_unix=1000.0)
+    assert oca.resolve_commit_channel(
+        REPO, "br", env_channel="repl", now_unix=1100.0,
+    ) is C.REPL
+
+
+def test_resolve_explicit_repl_without_presence_is_autonomous():
+    assert oca.resolve_commit_channel(
+        REPO, "br", env_channel="repl",
+    ) is C.AUTONOMOUS
+
+
+def test_resolve_garbage_env_with_presence_is_ide():
+    oca.mint_operator_presence(REPO, "br", "op", now_unix=1000.0)
+    assert oca.resolve_commit_channel(
+        REPO, "br", env_channel="not-a-channel", now_unix=1100.0,
+    ) is C.IDE
+
+
+# --------------------------------------------------------------------------
+# operator-only entry points mint presence
+# --------------------------------------------------------------------------
+
+
+def test_issue_grant_mints_presence():
+    out = oca.issue_grant(
+        channel="ide", operator_label="op",
+        ttl_s=60, branch="feat", repo_root=REPO,
+        now_unix=1000.0,
+    )
+    assert out.ok
+    assert oca.valid_operator_presence(
+        REPO, "feat", now_unix=1010.0,
+    ) is True
+
+
+def test_enable_authority_mints_presence(monkeypatch):
+    # enable resolves repo/branch via git; force a deterministic
+    # answer so the test is hermetic.
+    monkeypatch.setattr(
+        oca, "_resolve_repo_root", lambda: REPO,
+    )
+    monkeypatch.setattr(
+        oca, "resolve_repo_root_and_branch",
+        lambda _r: (REPO, ""),
+    )
+    assert oca.enable_authority("op", now_unix=1000.0)
+    # Empty marker branch (whole-repo arming) → any branch valid.
+    assert oca.valid_operator_presence(
+        REPO, "whatever", now_unix=1010.0,
+    ) is True
+
+
+# --------------------------------------------------------------------------
+# AST pin — the root-cause line must be gone
+# --------------------------------------------------------------------------
+
+
+def test_ast_pin_no_hardcoded_ide_default():
+    cli = Path(
+        oca.__file__,
+    ).parent / "commit_authority_cli.py"
+    tree = ast.parse(cli.read_text(encoding="utf-8"))
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef)
+        and n.name == "cmd_hook_pre_commit"
+    )
+    # (a) no ``<x> or "ide"`` BoolOp anywhere in the hook.
+    for node in ast.walk(fn):
+        if isinstance(node, ast.BoolOp) and isinstance(
+            node.op, ast.Or
+        ):
+            for v in node.values:
+                assert not (
+                    isinstance(v, ast.Constant) and v.value == "ide"
+                ), "hardcoded `or \"ide\"` channel default is back"
+    # (b) it MUST delegate to resolve_commit_channel.
+    calls = [
+        n for n in ast.walk(fn)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "resolve_commit_channel"
+    ]
+    assert calls, "cmd_hook_pre_commit must call resolve_commit_channel"
+
+
+# --------------------------------------------------------------------------
+# End-to-end through verify_pre_commit (real verdict path)
+# --------------------------------------------------------------------------
+
+
+def _tmp_git_repo(tmp_path: Path) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    def run(*a):
+        subprocess.run(
+            ["git", *a], cwd=str(tmp_path),
+            check=True, capture_output=True, text=True,
+        )
+    run("init", "-q")
+    run("config", "user.email", "t@t.t")
+    run("config", "user.name", "t")
+    (tmp_path / "f.txt").write_text("x\n")
+    run("add", "f.txt")
+    run("commit", "-q", "-m", "seed")
+    return tmp_path
+
+
+def test_e2e_agent_forged_ide_denied_by_sovereignty(
+    tmp_path, monkeypatch,
+):
+    """Forged JARVIS_COMMIT_CHANNEL=ide + NO presence + sovereignty
+    master ON + unowned tree → resolve→AUTONOMOUS → DENIED_SOVEREIGNTY.
+    This is the exact Agent-commit-on-main scenario, now refused."""
+    monkeypatch.setenv("JARVIS_LEDGER_SOVEREIGNTY_ENABLED", "true")
+    repo = _tmp_git_repo(tmp_path / "repo")
+    ch = oca.resolve_commit_channel(
+        repo, "main", env_channel="ide",
+    )
+    assert ch is C.AUTONOMOUS
+    verdict = oca.verify_pre_commit(
+        oca.CommitAuthorityContext(
+            channel=ch.value, repo_root=str(repo), branch="main",
+        )
+    )
+    assert (
+        verdict.verdict
+        is oca.CommitAuthorityVerdict.DENIED_SOVEREIGNTY
+    )
+    assert not verdict.authorized()
+
+
+def test_e2e_operator_earned_ide_with_grant_authorized(
+    tmp_path, monkeypatch,
+):
+    """Operator path: issue_grant (mints presence) → resolve earns
+    IDE → matching grant → AUTHORIZED."""
+    repo = _tmp_git_repo(tmp_path / "repo")
+    out = oca.issue_grant(
+        channel="ide", operator_label="op", ttl_s=600,
+        branch="main", repo_root=repo, now_unix=2000.0,
+    )
+    assert out.ok
+    ch = oca.resolve_commit_channel(
+        repo, "main", env_channel="ide", now_unix=2010.0,
+    )
+    assert ch is C.IDE
+    verdict = oca.verify_pre_commit(
+        oca.CommitAuthorityContext(
+            channel=ch.value, repo_root=str(repo), branch="main",
+            now_unix=2010.0,
+        )
+    )
+    assert verdict.authorized(), verdict.detail


### PR DESCRIPTION
## Two structural fixes from the 2026-05-19 incident

### 1. GitIndexGuard (Phase C Slice 1) — `a267b6713e`
Pure-stdlib, authority-free guard (mirrors `gitignore_guard`). Detects a **missing** `.git/index` (the background-Cursor-Agent unlink that produced the false "7856 staged deletions") and advisorily rebuilds via **`git read-tree HEAD` only** — working tree never touched, a *present* index is never rebuilt. Closed-5 taxonomy, worktree-aware, SSE seam via injected callback (no governance import → AST-pinnable). Default-OFF (Slice-1 discipline). 35 spine tests + AST pin.

### 2. OCA structural channel resolution — `a73a8761dc`
**Root cause:** `commit_authority_cli` inferred the commit channel from `JARVIS_COMMIT_CHANNEL` *hardcoded-defaulting to `"ide"`*. A Cursor Agent's headless `git commit` shares the same process tree / env as a human Cursor SCM commit → both resolved to `ide` → the Agent borrowed the operator's interactive grant (it auto-committed WIP mid-session).

**Fix (composes existing architecture, no parallel logic):** `resolve_commit_channel()` — an operator channel must be *earned* by a signed, short-TTL **operator-presence marker** (reuses the SAME `_sign`/`_verify`/secret as grants/enable — zero new crypto), minted only at operator-only entry points (`issue_grant`/`enable_authority`). Absent it → `AUTONOMOUS` → existing `ledger_sovereignty` gate decides. Replaced the `or "ide"` default.

**Soundness coupling (explicit, not silent):** OCA-master-on is a real gate only when `JARVIS_LEDGER_SOVEREIGNTY_ENABLED` is on (unowned tree + no presence → `DENIED_SOVEREIGNTY`). `test_no_grant_blocks` re-encoded across both sovereignty states. AST pin: `cmd_hook_pre_commit` has no `or "ide"` and must call `resolve_commit_channel`.

## Tests
240 green: `test_oca_channel_resolution` (28, new) + `test_git_index_guard` (35) + re-encoded `test_commit_authority_cli` + unchanged `test_operator_commit_authority`/`test_ledger_sovereignty`/`test_gitignore_guard`.

## Operator hygiene (post-merge)
- Keep Cursor background Agents stopped on this repo root until Slice 3.
- Enable `JARVIS_LEDGER_SOVEREIGNTY_ENABLED=true` for the gate to bite (presence TTL default 900s; tune `JARVIS_COMMIT_PRESENCE_TTL_S`).

## Follow-up
Slice 2: wire `git_index_guard.detect_and_rebuild()` at boot + SSE consumer for `git_index_anomaly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe Git index guard and fixes commit channel resolution to stop agents from borrowing operator grants. This prevents false “mass deletions” when `.git/index` disappears and routes agent commits through the sovereignty gate unless a signed operator presence is proven.

- **Bug Fixes**
  - Replaced the `JARVIS_COMMIT_CHANNEL` fallback with `resolve_commit_channel()`. Operator channels now require a signed, short‑TTL presence marker; otherwise commits resolve to `AUTONOMOUS` and `ledger_sovereignty` decides.
  - Presence is minted only at operator entry points (`issue_grant`, `enable_authority`) using the existing secret and signing. The pre‑commit hook now calls the resolver (AST‑pinned).
  - Updated tests to cover sovereignty ON/OFF paths and end‑to‑end denial of forged `ide` commits on unowned trees.

- **New Features**
  - Added `git_index_guard`: detects a missing `.git/index` and advisorily rebuilds it from `HEAD` via `git read-tree HEAD`. It never touches the working tree and never rebuilds a present index.
  - Pure stdlib, default OFF via `JARVIS_GIT_INDEX_GUARD_ENABLED`; timeout via `JARVIS_GIT_INDEX_GUARD_TIMEOUT_S`. Optional `on_anomaly` callback for SSE wiring; invariants pin the non‑destructive contract.
  - Added targeted tests and AST pins for outcome taxonomy, safety, and purity.

<sup>Written for commit a73a8761dcd85255de087b22ba5ec2af23a2cf06. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/42212?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

