### PR TITLE
feat(governance): GitIndexGuard Phase C Slice 2 — boot wiring + SSE git_index_anomaly

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -726,6 +726,15 @@ class BattleTestHarness:
         _boot_mark("harness_run_pre_boot_done")
         try:
             # Boot sequence — each phase wrapped for boot-timing visibility
+            # GitIndexGuard (Phase C Slice 2) MUST be the first phase:
+            # a missing .git/index (the background-Cursor-Agent unlink
+            # failure mode) corrupts every git-touching subsystem
+            # downstream. §2 Progressive Awakening — mirrors
+            # WorktreeManager.reap_orphans boot recovery. Master-
+            # gated inside the guard (default-OFF → DISABLED no-op);
+            # NEVER raises into boot.
+            with _BootPhase("boot_git_index_guard"):
+                await self._boot_git_index_guard()
             with _BootPhase("boot_oracle"):
                 await self.boot_oracle()
             with _BootPhase("boot_governance_stack"):
@@ -2030,6 +2039,71 @@ class BattleTestHarness:
         except Exception:  # noqa: BLE001
             pass
         return True
+
+    async def _boot_git_index_guard(self) -> None:
+        """GitIndexGuard boot recovery (Phase C Slice 2).
+
+        Detects a **missing** ``.git/index`` (the background-
+        Cursor-Agent unlink failure mode that produces the false
+        "7856 staged deletions" in Source Control) and advisorily
+        rebuilds it from HEAD via ``git read-tree HEAD`` — working
+        tree untouched, a present index is never modified.
+
+        Pure composition, zero new logic here:
+          * ``git_index_guard.detect_and_rebuild`` does the work
+            (master-gated inside: ``JARVIS_GIT_INDEX_GUARD_ENABLED``
+            default-OFF → ``DISABLED`` no-op, byte-identical boot).
+          * The ``on_anomaly`` seam is wired to
+            ``ide_observability_stream.publish_git_index_anomaly``
+            so a rebuilt/failed index surfaces as a
+            ``git_index_anomaly`` SSE frame. The guard imports NO
+            governance module; the harness owns this wiring.
+
+        NEVER raises into the boot path (mirrors ``_boot_mark`` /
+        ``reap_orphans`` discipline) — a guard failure must not
+        abort the organism boot.
+        """
+        try:
+            from backend.core.ouroboros.governance import (
+                git_index_guard as _gig,
+            )
+
+            def _on_anomaly(anomaly: Any) -> None:
+                try:
+                    from backend.core.ouroboros.governance import (
+                        ide_observability_stream as _stream,
+                    )
+                    _stream.publish_git_index_anomaly(
+                        anomaly.to_dict()
+                    )
+                except Exception:  # noqa: BLE001 — fail-silent seam
+                    logger.debug(
+                        "publish_git_index_anomaly failed",
+                        exc_info=True,
+                    )
+
+            outcome = _gig.detect_and_rebuild(
+                Path(self._config.repo_path),
+                on_anomaly=_on_anomaly,
+            )
+            if outcome.outcome is (
+                _gig.GitIndexGuardOutcome.MISSING_REBUILT
+            ):
+                logger.warning(
+                    "[GitIndexGuard] boot: .git/index was missing "
+                    "— rebuilt from HEAD (working tree untouched)"
+                )
+            elif outcome.outcome is (
+                _gig.GitIndexGuardOutcome.MISSING_REBUILD_FAILED
+            ):
+                logger.error(
+                    "[GitIndexGuard] boot: .git/index missing AND "
+                    "rebuild failed: %s", outcome.detail,
+                )
+        except Exception:  # noqa: BLE001 — never abort boot
+            logger.debug(
+                "_boot_git_index_guard degraded", exc_info=True,
+            )
 
     async def _boot_ledger_sovereignty_workspace(self) -> None:
         """Create the auto-commit worktree under the Ledger

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -135,6 +135,14 @@ EVENT_TYPE_GOVERNOR_THROTTLE_APPLIED = "governor_throttle_applied"
 EVENT_TYPE_GOVERNOR_EMERGENCY_BRAKE = "governor_emergency_brake"
 EVENT_TYPE_MEMORY_PRESSURE_CHANGED = "memory_pressure_changed"
 
+# GitIndexGuard (Phase C Slice 2) — a missing .git/index was
+# detected at boot and advisorily rebuilt (or the rebuild failed /
+# the probe failed). Single event; payload carries the full
+# GitIndexAnomaly.to_dict() (outcome / index_path / detail). Keyed
+# by the constant "git_index" (organism property, no op_id —
+# matches the posture_changed keying convention).
+EVENT_TYPE_GIT_INDEX_ANOMALY = "git_index_anomaly"
+
 # Upgrade 1 Bounded Epistemic Loop (PRD §31.2) Slice 4 vocabulary.
 # Single event covering all 7 BudgetOutcome branches — payload
 # carries outcome string + reason + per-op snapshot. Operators
@@ -1297,6 +1305,7 @@ _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_GOVERNOR_THROTTLE_APPLIED,
     EVENT_TYPE_GOVERNOR_EMERGENCY_BRAKE,
     EVENT_TYPE_MEMORY_PRESSURE_CHANGED,
+    EVENT_TYPE_GIT_INDEX_ANOMALY,
     EVENT_TYPE_MEMORY_FANOUT_DECISION,
     EVENT_TYPE_CANCEL_ORIGIN_EMITTED,  # W3(7) Slice 6
     EVENT_TYPE_CURIOSITY_QUESTION_EMITTED,  # W2(4) Slice 3
@@ -2495,6 +2504,40 @@ def publish_posture_event(
         )
     except Exception:  # noqa: BLE001 — best-effort
         logger.debug("[Stream] publish_posture_event exception", exc_info=True)
+        return None
+
+
+def publish_git_index_anomaly(
+    anomaly: Mapping[str, Any],
+) -> Optional[str]:
+    """Best-effort publisher for ``git_index_anomaly`` SSE frames.
+
+    ``anomaly`` is :meth:`GitIndexAnomaly.to_dict` output (outcome /
+    repo_root / index_path / detail / schema_version). Returns the
+    event_id on success, None when the stream is disabled / broker
+    missing / publish raised / payload is not a mapping. Never
+    raises into the GitIndexGuard boot hot path — it is the
+    fail-silent ``on_anomaly`` callback the guard invokes (the
+    guard imports NO governance module; this is the wiring seam).
+
+    Keyed by the constant ``"git_index"`` (organism property, no
+    op_id) so ``?op_id=git_index`` filters cleanly — identical
+    convention to :func:`publish_posture_event`.
+    """
+    if not stream_enabled():
+        return None
+    try:
+        if not isinstance(anomaly, Mapping):
+            return None
+        payload: Dict[str, Any] = dict(anomaly)
+        return get_default_broker().publish(
+            EVENT_TYPE_GIT_INDEX_ANOMALY, "git_index", payload,
+        )
+    except Exception:  # noqa: BLE001 — best-effort
+        logger.debug(
+            "[Stream] publish_git_index_anomaly exception",
+            exc_info=True,
+        )
         return None
 
 

--- a/tests/governance/test_git_index_guard_slice2.py
+++ b/tests/governance/test_git_index_guard_slice2.py
@@ -1,0 +1,234 @@
+"""GitIndexGuard Slice 2 — boot wiring + SSE regression spine.
+
+Slice 1 shipped the pure-stdlib substrate (default-OFF). Slice 2
+wires it:
+  * ``ide_observability_stream`` gains ``git_index_anomaly`` event
+    type + ``publish_git_index_anomaly`` (mirrors the
+    ``posture_changed`` publisher; composes ``get_default_broker``)
+  * ``BattleTestHarness._boot_git_index_guard`` — FIRST boot phase,
+    composes ``detect_and_rebuild`` with the SSE callback as the
+    ``on_anomaly`` seam (the guard imports NO governance module;
+    the harness owns the wiring). NEVER raises into boot.
+
+Coverage:
+  * event type value + membership in _VALID_EVENT_TYPES
+  * publish_git_index_anomaly: stream-disabled / non-mapping /
+    happy publish / never-raises
+  * boot hook: missing index → rebuilt + SSE seam fired; bogus
+    repo path → never raises; master-off → DISABLED no-op (no SSE)
+  * AST pin: boot hook is the first _BootPhase, composes
+    detect_and_rebuild + publish_git_index_anomaly; event type in
+    _VALID_EVENT_TYPES
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from backend.core.ouroboros.governance import (
+    ide_observability_stream as stream,
+)
+from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+
+
+# --------------------------------------------------------------------------
+# SSE vocabulary
+# --------------------------------------------------------------------------
+
+
+def test_event_type_value_and_membership():
+    assert stream.EVENT_TYPE_GIT_INDEX_ANOMALY == "git_index_anomaly"
+    assert (
+        stream.EVENT_TYPE_GIT_INDEX_ANOMALY
+        in stream._VALID_EVENT_TYPES
+    )
+
+
+def test_publish_stream_disabled_returns_none(monkeypatch):
+    monkeypatch.setattr(stream, "stream_enabled", lambda: False)
+    assert stream.publish_git_index_anomaly({"outcome": "x"}) is None
+
+
+def test_publish_non_mapping_returns_none(monkeypatch):
+    monkeypatch.setattr(stream, "stream_enabled", lambda: True)
+    assert stream.publish_git_index_anomaly("not-a-mapping") is None  # type: ignore[arg-type]
+
+
+def test_publish_happy_path(monkeypatch):
+    monkeypatch.setattr(stream, "stream_enabled", lambda: True)
+    seen = {}
+
+    class _Broker:
+        def publish(self, etype, opid, payload):
+            seen["etype"] = etype
+            seen["opid"] = opid
+            seen["payload"] = payload
+            return "evt-1"
+
+    monkeypatch.setattr(stream, "get_default_broker", lambda: _Broker())
+    out = stream.publish_git_index_anomaly(
+        {"outcome": "missing_rebuilt", "detail": "d"}
+    )
+    assert out == "evt-1"
+    assert seen["etype"] == "git_index_anomaly"
+    assert seen["opid"] == "git_index"
+    assert seen["payload"]["outcome"] == "missing_rebuilt"
+
+
+def test_publish_never_raises(monkeypatch):
+    monkeypatch.setattr(stream, "stream_enabled", lambda: True)
+
+    def _boom():
+        raise RuntimeError("broker exploded")
+
+    monkeypatch.setattr(stream, "get_default_broker", _boom)
+    # Must swallow and return None, not propagate.
+    assert stream.publish_git_index_anomaly({"outcome": "x"}) is None
+
+
+# --------------------------------------------------------------------------
+# Boot hook
+# --------------------------------------------------------------------------
+
+
+def _git_repo(p: Path) -> Path:
+    p.mkdir(parents=True, exist_ok=True)
+
+    def run(*a):
+        subprocess.run(
+            ["git", *a], cwd=str(p), check=True,
+            capture_output=True, text=True,
+        )
+    run("init", "-q")
+    run("config", "user.email", "t@t.t")
+    run("config", "user.name", "t")
+    (p / "f.txt").write_text("payload\n")
+    run("add", "f.txt")
+    run("commit", "-q", "-m", "seed")
+    return p
+
+
+async def test_boot_hook_rebuilds_and_fires_sse(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("JARVIS_GIT_INDEX_GUARD_ENABLED", "true")
+    repo = _git_repo(tmp_path / "repo")
+    (repo / ".git" / "index").unlink()
+    assert not (repo / ".git" / "index").is_file()
+
+    fired = []
+    monkeypatch.setattr(
+        stream, "publish_git_index_anomaly",
+        lambda d: fired.append(d),
+    )
+
+    stub = SimpleNamespace(_config=SimpleNamespace(repo_path=str(repo)))
+    # Call the unbound coroutine with our minimal stub.
+    await BattleTestHarness._boot_git_index_guard(stub)  # type: ignore[arg-type]
+
+    assert (repo / ".git" / "index").is_file()  # rebuilt
+    assert (repo / "f.txt").read_text() == "payload\n"  # WT intact
+    assert len(fired) == 1
+    assert fired[0]["outcome"] == "missing_rebuilt"
+
+
+async def test_boot_hook_master_off_is_noop_no_sse(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.delenv("JARVIS_GIT_INDEX_GUARD_ENABLED", raising=False)
+    repo = _git_repo(tmp_path / "repo")
+    (repo / ".git" / "index").unlink()
+    fired = []
+    monkeypatch.setattr(
+        stream, "publish_git_index_anomaly",
+        lambda d: fired.append(d),
+    )
+    stub = SimpleNamespace(_config=SimpleNamespace(repo_path=str(repo)))
+    await BattleTestHarness._boot_git_index_guard(stub)  # type: ignore[arg-type]
+    # DISABLED → no rebuild, no SSE (byte-identical boot).
+    assert not (repo / ".git" / "index").is_file()
+    assert fired == []
+
+
+async def test_boot_hook_never_raises_on_bogus_repo(monkeypatch):
+    monkeypatch.setenv("JARVIS_GIT_INDEX_GUARD_ENABLED", "true")
+    stub = SimpleNamespace(
+        _config=SimpleNamespace(repo_path="/nonexistent/zzz/repo")
+    )
+    # Must not raise into boot.
+    await BattleTestHarness._boot_git_index_guard(stub)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# AST pins — wiring cannot silently regress
+# --------------------------------------------------------------------------
+
+
+def test_ast_pin_boot_hook_first_phase_and_composition():
+    import backend.core.ouroboros.battle_test.harness as hm
+
+    src = Path(hm.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    # (a) _boot_git_index_guard method exists and composes
+    #     detect_and_rebuild.
+    fn = next(
+        (
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef)
+            and n.name == "_boot_git_index_guard"
+        ),
+        None,
+    )
+    assert fn is not None, "_boot_git_index_guard method missing"
+    body_src = ast.unparse(fn)
+    assert "detect_and_rebuild" in body_src, (
+        "boot hook must compose git_index_guard.detect_and_rebuild"
+    )
+    assert "publish_git_index_anomaly" in body_src, (
+        "boot hook must wire the SSE on_anomaly seam"
+    )
+
+    # (b) the hook is invoked as the FIRST _BootPhase (before
+    #     boot_oracle) — a missing index corrupts everything else.
+    run_fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "run"
+    )
+    phase_order = [
+        node.args[0].value
+        for node in ast.walk(run_fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_BootPhase"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+    ]
+    assert phase_order, "no _BootPhase calls found in run()"
+    assert phase_order[0] == "boot_git_index_guard", (
+        f"git index guard must be the FIRST boot phase, got "
+        f"{phase_order[:3]}"
+    )
+
+
+def test_ast_pin_event_type_registered():
+    s_src = Path(stream.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(s_src)
+    # The constant assignment exists with the stable value.
+    found_const = any(
+        isinstance(n, ast.Assign)
+        and any(
+            isinstance(t, ast.Name)
+            and t.id == "EVENT_TYPE_GIT_INDEX_ANOMALY"
+            for t in n.targets
+        )
+        and isinstance(n.value, ast.Constant)
+        and n.value.value == "git_index_anomaly"
+        for n in ast.walk(tree)
+    )
+    assert found_const, "EVENT_TYPE_GIT_INDEX_ANOMALY const missing"
+    # And it is a member of the frozenset (runtime check is the
+    # authoritative one; this pins the source too).
+    assert stream.EVENT_TYPE_GIT_INDEX_ANOMALY in stream._VALID_EVENT_TYPES


### PR DESCRIPTION
Builds on PR #42212 (Slice 1 substrate + OCA structural channel resolution, merged).

## Slice 2 — wire the guard into the organism (no duplication)

- **SSE vocabulary** (`ide_observability_stream`): `EVENT_TYPE_GIT_INDEX_ANOMALY` + `publish_git_index_anomaly()` mirroring the `posture_changed` publisher (composes `get_default_broker()`, keyed by constant `"git_index"`, never raises). Added to `_VALID_EVENT_TYPES`.
- **Boot hook** (`BattleTestHarness._boot_git_index_guard`): the **first** boot phase — a missing `.git/index` corrupts every git-touching subsystem downstream (§2 Progressive Awakening; mirrors `WorktreeManager.reap_orphans`). Pure composition of `git_index_guard.detect_and_rebuild` with the SSE publisher as the fail-silent `on_anomaly` seam. The guard imports **no** governance module — the harness owns the wiring. NEVER raises into boot.
- Master-gated inside the guard (`JARVIS_GIT_INDEX_GUARD_ENABLED` default-**OFF** → `DISABLED` no-op → byte-identical boot). Graduation (default-TRUE) is a deliberately separate later slice.

## Tests
`tests/governance/test_git_index_guard_slice2.py` (10): SSE disabled/non-mapping/happy/never-raises; boot rebuild+SSE / master-off no-op / bogus-path never-raises; **2 AST pins** (boot hook is the first `_BootPhase` + composes `detect_and_rebuild` + `publish_git_index_anomaly`; event type registered). 161 green across guard + stream + OCA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires GitIndexGuard into boot and adds an SSE `git_index_anomaly` event so missing `.git/index` is detected and reported at startup without blocking boot. Behind `JARVIS_GIT_INDEX_GUARD_ENABLED` (default OFF).

- **New Features**
  - Added `EVENT_TYPE_GIT_INDEX_ANOMALY` and `publish_git_index_anomaly()` to `ide_observability_stream`; keyed by `"git_index"`, uses `get_default_broker()`, best-effort, added to `_VALID_EVENT_TYPES`.
  - Introduced `BattleTestHarness._boot_git_index_guard` as the first boot phase; composes `git_index_guard.detect_and_rebuild` and wires `on_anomaly` to `publish_git_index_anomaly`; never raises and keeps the guard decoupled from governance imports.
  - Master-gated via `JARVIS_GIT_INDEX_GUARD_ENABLED` (default OFF → disabled no-op, byte-identical boot).
  - Tests added to cover the SSE publisher, boot rebuild path, disabled no-op, bogus repo safety, and AST pins for phase order and event registration.

<sup>Written for commit 477a1e19dcbe0fc67379deb5ae7ff9553a604b99. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/42218?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

