### PR TITLE
feat(governance): PersistentMaster — sound (GUI-git-reachable) ledger_sovereignty enable

### DIFF
--- a/backend/core/ouroboros/governance/ledger_sovereignty.py
+++ b/backend/core/ouroboros/governance/ledger_sovereignty.py
@@ -85,12 +85,30 @@ _MASTER_FLAG = "JARVIS_LEDGER_SOVEREIGNTY_ENABLED"
 def master_enabled() -> bool:
     """Return ``True`` iff the sovereignty gate is master-ON.
 
-    Default is ``False`` per §33.1 — the substrate is pure-add and
-    the operator graduates it deliberately. The whole module is a
-    structural assertion that's only load-bearing when the operator
-    has explicitly turned it on.
+    Two independent enable sources (OR-composed):
+
+      1. ``JARVIS_LEDGER_SOVEREIGNTY_ENABLED=true`` env (byte-
+         identical legacy behavior — when set, returns True
+         without touching disk).
+      2. A signed, out-of-repo persistent enable record (composes
+         :mod:`persistent_master`). This is the ONLY way the gate
+         can be ON for a Cursor/VS Code GUI-git subprocess, which
+         inherits no shell env — the same structural reason OCA
+         needed its persistent enable. Tamper-evident, fail-closed.
+
+    Default remains ``False`` per §33.1 (no env + no signed
+    record). The persistent path NEVER raises and degrades to
+    env-only if the substrate is unavailable.
     """
-    return os.environ.get(_MASTER_FLAG, "false").lower() == "true"
+    if os.environ.get(_MASTER_FLAG, "false").lower() == "true":
+        return True
+    try:
+        from backend.core.ouroboros.governance.persistent_master import (
+            is_persistently_enabled,
+        )
+        return is_persistently_enabled("ledger_sovereignty")
+    except Exception:  # noqa: BLE001 — fail closed to env-only
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/persistent_master.py
+++ b/backend/core/ouroboros/governance/persistent_master.py
@@ -1,0 +1,381 @@
+"""PersistentMaster — generic signed, out-of-repo master-enable.
+================================================================
+
+The problem this closes (generalized from OCA Slice 3 #0):
+
+  An env-only master flag can NEVER be ON for a GUI git subprocess.
+  Cursor / VS Code Source Control inherit no shell env, so any
+  ``JARVIS_*_ENABLED`` env flag is invisible to the pre-commit
+  hook they spawn. OCA solved this for its own master via a
+  signed, out-of-repo enable record. ``ledger_sovereignty`` (and
+  any future operator-graduated master) has the SAME need: it must
+  be enable-able for the GUI path, not just for a shell that
+  happens to export the var.
+
+This module is the single, reusable substrate for that pattern —
+factored out so ``ledger_sovereignty`` composes it now and OCA can
+adopt it later WITHOUT churning the shipped, safety-critical
+``operator_commit_authority`` module.
+
+Design (zero crypto duplication, single source of truth):
+
+  * Crypto: composes :func:`roadmap_reader.compute_signature` /
+    :func:`verify_signature` — the canonical constant-time HMAC.
+    NO parallel ``hmac`` anywhere (AST-pinned).
+  * Secret: composes the ONE per-machine secret OCA already
+    bootstraps (``operator_commit_authority._ensure_secret`` /
+    ``_read_secret`` at ``~/.jarvis/commit_authority/secret``,
+    0600, O_EXCL, out-of-repo). A second secret would be
+    duplication AND a second thing to back up — there is exactly
+    one machine secret.
+  * Record: ``{"record": <canonical payload>, "signature": <hmac>}``
+    at ``~/.jarvis/persistent_master/<flag_key>.json`` (0600,
+    atomic replace). On verify the canonical payload is recomputed
+    from the trusted fields so a tampered/extra field cannot ride
+    an old signature (identical discipline to OCA's enable record).
+  * Fail-closed: missing file / missing secret / malformed JSON /
+    bad signature / ``enabled != True`` all → ``False`` (the
+    default-FALSE safety posture is preserved — a hand-created
+    empty file does NOT flip a gate).
+  * NEVER raises out of any public function.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("Ouroboros.PersistentMaster")
+
+
+PERSISTENT_MASTER_SCHEMA_VERSION: str = "persistent_master.1"
+
+_ENV_DIR = "JARVIS_PERSISTENT_MASTER_DIR"
+_DEFAULT_DIR_RELATIVE = ("persistent_master",)  # under ~/.jarvis
+_SAFE_KEY = re.compile(r"[^a-z0-9_]+")
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_key(flag_key: str) -> str:
+    """Lowercase, collapse any non ``[a-z0-9_]`` run to a single
+    ``_``. Keeps the on-disk filename a stable, injection-free
+    token regardless of caller input. NEVER raises."""
+    try:
+        s = _SAFE_KEY.sub("_", str(flag_key).strip().lower()).strip("_")
+        return s or "unnamed"
+    except Exception:  # noqa: BLE001
+        return "unnamed"
+
+
+def enable_record_dir() -> Path:
+    """Directory holding per-flag enable records. Lives OUTSIDE the
+    repo (``~/.jarvis/persistent_master/``) — that out-of-repo,
+    no-shell-env property is precisely what makes the GUI-git path
+    work. Operator override via ``JARVIS_PERSISTENT_MASTER_DIR``.
+    NEVER raises."""
+    raw = os.environ.get(_ENV_DIR, "").strip()
+    if raw:
+        try:
+            return Path(raw).expanduser().resolve()
+        except Exception:  # noqa: BLE001
+            pass
+    return Path.home() / ".jarvis" / Path(*_DEFAULT_DIR_RELATIVE)
+
+
+def enable_record_path(flag_key: str) -> Path:
+    """Absolute path of the signed enable record for ``flag_key``.
+    NEVER raises."""
+    try:
+        return enable_record_dir() / f"{_sanitize_key(flag_key)}.json"
+    except Exception:  # noqa: BLE001 — NEVER-raise contract
+        return Path.home() / ".jarvis" / "persistent_master" / "unnamed.json"
+
+
+# ---------------------------------------------------------------------------
+# Composed canonical crypto + the ONE per-machine secret
+# ---------------------------------------------------------------------------
+
+
+def _read_secret() -> Optional[str]:
+    """Compose OCA's single per-machine secret reader (no second
+    secret — single source of truth). NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.operator_commit_authority import (  # noqa: E501
+            _read_secret as _oca_read_secret,
+        )
+        return _oca_read_secret()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _ensure_secret() -> Optional[str]:
+    """Compose OCA's single per-machine secret bootstrap (0600,
+    O_EXCL). NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.operator_commit_authority import (  # noqa: E501
+            _ensure_secret as _oca_ensure_secret,
+        )
+        return _oca_ensure_secret()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _sign(payload: Dict[str, Any], secret: str) -> str:
+    """Compose the canonical HMAC. NEVER raises. ``""`` on
+    unavailable crypto → callers treat as fail-closed."""
+    try:
+        from backend.core.ouroboros.governance.roadmap_reader import (
+            compute_signature,
+        )
+        return compute_signature(payload, secret)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _verify(payload: Dict[str, Any], signature_hex: str, secret: str) -> bool:
+    """Compose the canonical constant-time verify. NEVER raises.
+    ``False`` (fail closed) on unavailable crypto."""
+    try:
+        from backend.core.ouroboros.governance.roadmap_reader import (
+            verify_signature,
+        )
+        return verify_signature(payload, signature_hex, secret)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _signed_payload(
+    flag_key: str, issued_at_unix: float, operator_label: str,
+) -> Dict[str, Any]:
+    """Canonical dict the HMAC covers. Deterministic — recomputed
+    from trusted fields on verify."""
+    return {
+        "enabled": True,
+        "flag_key": _sanitize_key(flag_key),
+        "issued_at_unix": float(issued_at_unix),
+        "operator_label": str(operator_label),
+        "schema_version": PERSISTENT_MASTER_SCHEMA_VERSION,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def is_persistently_enabled(flag_key: str) -> bool:
+    """Return ``True`` iff a valid, HMAC-signed enable record
+    exists for ``flag_key``. NEVER raises. Missing file / missing
+    secret / malformed JSON / bad signature / ``enabled != True``
+    / flag-key mismatch all → ``False`` (fail closed; the
+    default-FALSE safety posture is preserved)."""
+    target = enable_record_path(flag_key)
+    try:
+        if not target.exists():
+            return False
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return False
+    if not isinstance(raw, dict):
+        return False
+    record = raw.get("record")
+    signature = raw.get("signature")
+    if not isinstance(record, dict) or not isinstance(signature, str):
+        return False
+    if record.get("enabled") is not True:
+        return False
+    key = _sanitize_key(flag_key)
+    if str(record.get("flag_key", "")) != key:
+        return False
+    secret = _read_secret()
+    if not secret:
+        return False
+    payload = _signed_payload(
+        key,
+        float(record.get("issued_at_unix", 0.0))
+        if _is_number(record.get("issued_at_unix"))
+        else 0.0,
+        str(record.get("operator_label", "")),
+    )
+    return _verify(payload, signature, secret)
+
+
+def enable_persistent_master(
+    flag_key: str,
+    operator_label: str,
+    *,
+    now_unix: Optional[float] = None,
+) -> bool:
+    """Operator-only: write the signed persistent enable record for
+    ``flag_key`` (bootstraps the per-machine secret on first use).
+    Atomic write, 0600. Returns ``True`` on success. NEVER raises."""
+    label = str(operator_label or "").strip()
+    if not label:
+        return False
+    key = _sanitize_key(flag_key)
+    secret = _ensure_secret()
+    if not secret:
+        return False
+    now = float(now_unix) if now_unix is not None else time.time()
+    payload = _signed_payload(key, now, label)
+    signature = _sign(payload, secret)
+    if not signature:
+        return False
+    target = enable_record_path(key)
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(
+                {"record": payload, "signature": signature},
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        try:
+            os.chmod(tmp, 0o600)
+        except Exception:  # noqa: BLE001 — best effort
+            pass
+        os.replace(str(tmp), str(target))
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[PersistentMaster] enable write failed for %s at %s: %s",
+            key, target, type(exc).__name__,
+        )
+        return False
+
+
+def disable_persistent_master(flag_key: str) -> bool:
+    """Operator-only: remove the persistent enable record for
+    ``flag_key``. Master then reverts to env-only (default FALSE).
+    Idempotent. Returns ``True`` iff the record is absent
+    afterwards. NEVER raises."""
+    target = enable_record_path(flag_key)
+    try:
+        if target.exists():
+            target.unlink()
+        return not target.exists()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _is_number(v: Any) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+__all__ = [
+    "PERSISTENT_MASTER_SCHEMA_VERSION",
+    "enable_record_dir",
+    "enable_record_path",
+    "is_persistently_enabled",
+    "enable_persistent_master",
+    "disable_persistent_master",
+    "register_shipped_invariants",
+]
+
+
+# ---------------------------------------------------------------------------
+# Module-owned shipped_code_invariants (AST pins)
+# ---------------------------------------------------------------------------
+
+
+def register_shipped_invariants() -> list:
+    """Pins: composes the canonical roadmap_reader HMAC (NO parallel
+    ``hmac``/``hashlib`` signing), composes the ONE OCA per-machine
+    secret (no second secret), and every public function is
+    NEVER-raise (defensive try/except discipline)."""
+    import ast as _ast
+    try:
+        from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+            ShippedCodeInvariant,
+        )
+    except ImportError:
+        return []
+
+    def _validate(tree: "_ast.Module", source: str) -> tuple:
+        _ = source
+        violations: list = []
+
+        # (1) No parallel crypto — canonical compute/verify only.
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.Import):
+                for a in node.names:
+                    if a.name in ("hmac",):
+                        violations.append(
+                            f"line {getattr(node, 'lineno', '?')}: "
+                            "persistent_master must NOT import hmac "
+                            "(compose roadmap_reader canonical HMAC)"
+                        )
+            if isinstance(node, _ast.ImportFrom):
+                if (node.module or "") == "hmac":
+                    violations.append(
+                        f"line {getattr(node, 'lineno', '?')}: "
+                        "persistent_master must NOT import from hmac"
+                    )
+
+        # (2) Composes the canonical crypto + the OCA secret (the
+        #     single source of truth — no second secret/crypto).
+        if "compute_signature" not in source:
+            violations.append(
+                "must compose roadmap_reader.compute_signature"
+            )
+        if "verify_signature" not in source:
+            violations.append(
+                "must compose roadmap_reader.verify_signature"
+            )
+        if "operator_commit_authority" not in source:
+            violations.append(
+                "must compose the single OCA per-machine secret "
+                "(no second machine secret)"
+            )
+
+        # (3) Every public function is NEVER-raise: each must
+        #     contain at least one ExceptHandler.
+        public = {
+            "is_persistently_enabled",
+            "enable_persistent_master",
+            "disable_persistent_master",
+            "enable_record_dir",
+            "enable_record_path",
+        }
+        for fnode in _ast.walk(tree):
+            if (
+                isinstance(fnode, _ast.FunctionDef)
+                and fnode.name in public
+            ):
+                has_try = any(
+                    isinstance(n, _ast.ExceptHandler)
+                    for n in _ast.walk(fnode)
+                )
+                if not has_try:
+                    violations.append(
+                        f"public fn {fnode.name!r} missing "
+                        "defensive try/except (NEVER-raise contract)"
+                    )
+        return tuple(violations)
+
+    target = (
+        "backend/core/ouroboros/governance/persistent_master.py"
+    )
+    return [
+        ShippedCodeInvariant(
+            invariant_name="persistent_master_canonical_crypto_single_secret",
+            target_file=target,
+            description=(
+                "persistent_master composes the canonical "
+                "roadmap_reader HMAC (no parallel hmac) + the ONE "
+                "OCA per-machine secret (no duplicate secret); "
+                "every public function is NEVER-raise."
+            ),
+            validate=_validate,
+        ),
+    ]

--- a/tests/governance/test_persistent_master.py
+++ b/tests/governance/test_persistent_master.py
@@ -1,0 +1,170 @@
+"""PersistentMaster — regression spine.
+
+Generic signed, out-of-repo master-enable (factored from OCA Slice
+3 #0). The ONLY way a master gate can be ON for a Cursor/VS Code
+GUI-git subprocess (no shell env). Composes the canonical
+roadmap_reader HMAC + the ONE OCA per-machine secret — zero crypto
+duplication, fail-closed, NEVER raises.
+
+Coverage:
+  * _sanitize_key (injection-free filename token)
+  * enable_record_dir/path + env override
+  * enable → is_persistently_enabled roundtrip; disable idempotent
+  * tamper / flag-key-mismatch / enabled!=True / missing-secret
+    / empty-label all → fail-closed
+  * independent flag_keys
+  * NEVER raises on garbage
+  * ledger_sovereignty.master_enabled(): env-true short-circuit
+    (no disk) / env-unset+signed-record → True / neither → False
+  * AST pin self-validates green
+"""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import persistent_master as pm
+from backend.core.ouroboros.governance import ledger_sovereignty as ls
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "JARVIS_PERSISTENT_MASTER_DIR", str(tmp_path / "pm"),
+    )
+    # Route OCA's single per-machine secret to the throwaway dir.
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
+        str(tmp_path / "secret"),
+    )
+    monkeypatch.delenv("JARVIS_LEDGER_SOVEREIGNTY_ENABLED", raising=False)
+    yield
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("ledger_sovereignty", "ledger_sovereignty"),
+        ("JARVIS_LEDGER_SOVEREIGNTY_ENABLED",
+         "jarvis_ledger_sovereignty_enabled"),
+        ("a/b\\c..d", "a_b_c_d"),
+        ("  Mixed-CASE!! ", "mixed_case"),
+        ("", "unnamed"),
+        ("///", "unnamed"),
+    ],
+)
+def test_sanitize_key(raw, expected):
+    assert pm._sanitize_key(raw) == expected
+
+
+def test_record_path_and_env_override(tmp_path):
+    p = pm.enable_record_path("ledger_sovereignty")
+    assert p == tmp_path / "pm" / "ledger_sovereignty.json"
+
+
+def test_enable_roundtrip_and_disable():
+    assert pm.is_persistently_enabled("ledger_sovereignty") is False
+    assert pm.enable_persistent_master(
+        "ledger_sovereignty", "op", now_unix=1000.0,
+    )
+    assert pm.is_persistently_enabled("ledger_sovereignty") is True
+    # Idempotent disable.
+    assert pm.disable_persistent_master("ledger_sovereignty")
+    assert pm.is_persistently_enabled("ledger_sovereignty") is False
+    assert pm.disable_persistent_master("ledger_sovereignty")
+
+
+def test_tamper_invalidates():
+    pm.enable_persistent_master("k", "op", now_unix=1000.0)
+    f = pm.enable_record_path("k")
+    blob = json.loads(f.read_text())
+    blob["record"]["operator_label"] = "attacker"
+    f.write_text(json.dumps(blob))
+    assert pm.is_persistently_enabled("k") is False
+
+
+def test_flag_key_mismatch_rejected():
+    pm.enable_persistent_master("k", "op", now_unix=1000.0)
+    f = pm.enable_record_path("k")
+    blob = json.loads(f.read_text())
+    # File is k.json but record claims a different flag_key.
+    blob["record"]["flag_key"] = "other"
+    f.write_text(json.dumps(blob))
+    assert pm.is_persistently_enabled("k") is False
+
+
+def test_enabled_not_true_rejected():
+    pm.enable_persistent_master("k", "op", now_unix=1000.0)
+    f = pm.enable_record_path("k")
+    blob = json.loads(f.read_text())
+    blob["record"]["enabled"] = False
+    f.write_text(json.dumps(blob))
+    assert pm.is_persistently_enabled("k") is False
+
+
+def test_missing_secret_fails_closed(tmp_path):
+    pm.enable_persistent_master("k", "op", now_unix=1000.0)
+    Path(tmp_path / "secret").unlink()
+    assert pm.is_persistently_enabled("k") is False
+
+
+def test_empty_label_refused():
+    assert pm.enable_persistent_master("k", "  ") is False
+    assert pm.is_persistently_enabled("k") is False
+
+
+def test_independent_flag_keys():
+    pm.enable_persistent_master("alpha", "op", now_unix=1000.0)
+    assert pm.is_persistently_enabled("alpha") is True
+    assert pm.is_persistently_enabled("beta") is False
+
+
+def test_never_raises_on_garbage(tmp_path):
+    # Corrupt record file → False, no raise.
+    f = pm.enable_record_path("k")
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text("{not json")
+    assert pm.is_persistently_enabled("k") is False
+    assert pm.is_persistently_enabled("///") is False
+
+
+# --------------------------------------------------------------------------
+# ledger_sovereignty.master_enabled() composition
+# --------------------------------------------------------------------------
+
+
+def test_sovereignty_env_true_short_circuits(monkeypatch):
+    monkeypatch.setenv("JARVIS_LEDGER_SOVEREIGNTY_ENABLED", "true")
+    # No signed record exists, but env wins (legacy byte-identical).
+    assert ls.master_enabled() is True
+
+
+def test_sovereignty_persistent_record_enables(monkeypatch):
+    monkeypatch.delenv("JARVIS_LEDGER_SOVEREIGNTY_ENABLED", raising=False)
+    assert ls.master_enabled() is False
+    assert pm.enable_persistent_master(
+        "ledger_sovereignty", "op", now_unix=1000.0,
+    )
+    assert ls.master_enabled() is True
+
+
+def test_sovereignty_default_false(monkeypatch):
+    monkeypatch.delenv("JARVIS_LEDGER_SOVEREIGNTY_ENABLED", raising=False)
+    assert ls.master_enabled() is False
+
+
+# --------------------------------------------------------------------------
+# Registration contract
+# --------------------------------------------------------------------------
+
+
+def test_shipped_invariant_self_validates_green():
+    invs = pm.register_shipped_invariants()
+    assert len(invs) == 1
+    src = Path(pm.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    violations = invs[0].validate(tree, src)
+    assert violations == (), f"not green: {violations}"


### PR DESCRIPTION
**Root problem:** `ledger_sovereignty.master_enabled()` was env-ONLY. A shell `export JARVIS_LEDGER_SOVEREIGNTY_ENABLED=true` can never reach a Cursor/VS Code GUI-git subprocess (no shell env) — so the OCA structural fix (PR #42212), which *delegates* the no-presence case to the sovereignty gate, stayed **toothless for GUI commits** (the gate it delegates to was never ON there). Enabling sovereignty the shortcut way (env export) would not actually contain a Cursor Agent.

**Root fix (no duplication, composes existing architecture):**
- New `persistent_master.py` — generic signed, out-of-repo master-enable, factored from OCA Slice 3 #0's proven pattern so **both** `ledger_sovereignty` (now) and OCA (later, no churn to the shipped safety module) compose **one** substrate. Composes the canonical `roadmap_reader` HMAC + the **one** OCA per-machine secret — zero crypto duplication. Tamper-evident, fail-closed, default-FALSE preserved. AST-pinned (no parallel `hmac`; must compose `compute/verify_signature` + OCA secret; every public fn NEVER-raise).
- `ledger_sovereignty.master_enabled()` = env **OR** `persistent_master.is_persistently_enabled("ledger_sovereignty")`. Byte-identical when env set (short-circuits, no disk).

**Tests:** `test_persistent_master.py` (19) + composition + AST self-validate. 215 green across persistent_master + sovereignty + OCA + git_index_guard.

**Post-merge operator realignment required** (same as the OCA arc): the operator's Cursor checkout must contain this code for the persistent path to exist in its running `ledger_sovereignty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the sovereignty gate in GUI Git clients by adding a signed, out-of-repo persistent master flag and wiring it into `ledger_sovereignty.master_enabled()`. Env behavior stays the same; when env is absent, a signed record can turn the gate on, tamper‑evidently and fail‑closed.

- **New Features**
  - Added `persistent_master.py`: signed persistent enable using canonical `roadmap_reader` HMAC and the single OCA machine secret; atomic 0600 JSON at `~/.jarvis/persistent_master/<flag>.json`; public fns never raise.
  - Updated `ledger_sovereignty.master_enabled()` to OR env `JARVIS_LEDGER_SOVEREIGNTY_ENABLED` with `persistent_master.is_persistently_enabled("ledger_sovereignty")`; env true short-circuits (no disk).
  - Added shipped-code invariant and tests covering roundtrip, tamper/mismatch, default-false, GUI path, and AST validation.

- **Migration**
  - For GUI Git, enable once per machine: call `enable_persistent_master("ledger_sovereignty", "<operator>")` (writes `~/.jarvis/persistent_master/ledger_sovereignty.json`).
  - Ensure the GUI uses a workspace that includes this code; otherwise it remains env-only.

<sup>Written for commit e1a3c5d14dbb98ef44d26a549a0397169220aeb6. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/42240?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

