### PR TITLE
feat(governance): OCA Slice 3 (#1–#6) + multi-entry presence lockout root-fix

### DIFF
--- a/backend/core/ouroboros/governance/auto_committer.py
+++ b/backend/core/ouroboros/governance/auto_committer.py
@@ -118,6 +118,19 @@ def ov_coauthor_line() -> str:
     return _OV_COAUTHOR
 
 
+def _archive_authority_event(kind: str, detail: dict) -> None:
+    """Best-effort append to the OCA observability ring (Slice 3
+    #2). Archive absence/disable is silent (telemetry, never
+    authority). NEVER raises into the commit path."""
+    try:
+        from backend.core.ouroboros.governance import (
+            commit_authority_archive as _arch,
+        )
+        _arch.record(kind=kind, detail=detail)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Result type
 # ---------------------------------------------------------------------------
@@ -251,6 +264,73 @@ class AutoCommitter:
             return CommitResult(
                 committed=False,
                 skipped_reason="no_target_files",
+            )
+
+        # OCA Slice 3 #4 — Unified commit-authority gate. The
+        # AutoCommitter IS the autonomous path by definition, so
+        # the channel is the LITERAL "autonomous" — NEVER env,
+        # NEVER resolve_commit_channel (that seam exists only for
+        # the IDE/operator surface; an autonomous committer that
+        # sniffed env could be tricked into an operator channel).
+        # verify_pre_commit(autonomous) internally composes
+        # ledger_sovereignty + the governance hash-cap under ONE
+        # verdict taxonomy (the "unify human + autonomous paths"
+        # principle). The legacy per-concern blocks below remain
+        # as redundant defense — they compose the same substrates
+        # so they agree. Substrate-unavailable → fall through to
+        # the legacy gates (rollback discipline). NEVER raises.
+        try:
+            from backend.core.ouroboros.governance import (
+                operator_commit_authority as _oca,
+            )
+            _root, _branch = _oca.resolve_repo_root_and_branch(
+                self._effective_repo_root()
+            )
+            _verdict = _oca.verify_pre_commit(
+                _oca.CommitAuthorityContext(
+                    channel="autonomous",
+                    repo_root=str(
+                        _root or self._effective_repo_root()
+                    ),
+                    branch=_branch,
+                    staged_files=tuple(target_files),
+                )
+            )
+            _archive_authority_event(
+                "verify_verdict",
+                {
+                    "op_id": op_id, "channel": "autonomous",
+                    "verdict": _verdict.verdict.value,
+                },
+            )
+            if not _verdict.authorized() and (
+                _verdict.verdict
+                is not _oca.CommitAuthorityVerdict.DISABLED
+            ):
+                _reason = {
+                    _oca.CommitAuthorityVerdict.DENIED_SOVEREIGNTY:
+                        "ledger_sovereignty_refused",
+                    _oca.CommitAuthorityVerdict.DENIED_GOVERNANCE_DRIFT:
+                        "governance_manifest_drift",
+                }.get(
+                    _verdict.verdict,
+                    f"oca_denied:{_verdict.verdict.value}",
+                )
+                logger.warning(
+                    "[AutoCommitter] OCA autonomous gate refused "
+                    "commit op=%s verdict=%s — %s",
+                    op_id, _verdict.verdict.value,
+                    _verdict.detail[:200],
+                )
+                return CommitResult(
+                    committed=False,
+                    skipped_reason=_reason,
+                    error=_verdict.detail[:512],
+                )
+        except Exception as _oca_exc:  # noqa: BLE001 — fall through
+            logger.debug(
+                "[AutoCommitter] OCA autonomous gate degraded "
+                "(legacy gates still apply): %s", _oca_exc,
             )
 
         # P1 Slice 2 — Ledger Sovereignty structural boundary.

--- a/backend/core/ouroboros/governance/commit_authority_archive.py
+++ b/backend/core/ouroboros/governance/commit_authority_archive.py
@@ -220,6 +220,7 @@ class BoundedCommitAuthorityArchive:
                 while len(self._items) > self._capacity:
                     self._items.popitem(last=False)  # drop oldest
             _append_ledger(rec)
+            _publish_sse(rec)
             return rec
         except Exception as exc:  # noqa: BLE001 — never into authority
             logger.debug(
@@ -260,6 +261,22 @@ def _append_ledger(rec: CommitAuthorityRecord) -> None:
         flock_append_line(path, json.dumps(rec.to_dict(), sort_keys=True))
     except Exception as exc:  # noqa: BLE001
         logger.debug("[CommitAuthorityArchive] ledger append: %s", exc)
+
+
+def _publish_sse(rec: CommitAuthorityRecord) -> None:
+    """Emit the ``commit_authority_decision_recorded`` SSE frame.
+    Best-effort, fail-silent — mirrors the git_index_guard
+    on_anomaly seam. Stream absence/disable never affects the ring
+    or the authority path. NEVER raises. (ide_observability_stream
+    is observability, not a decision-side module — no
+    authority-asymmetry violation.)"""
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: E501
+            publish_commit_authority_decision,
+        )
+        publish_commit_authority_decision(rec.to_dict())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[CommitAuthorityArchive] sse publish: %s", exc)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/commit_authority_archive.py
+++ b/backend/core/ouroboros/governance/commit_authority_archive.py
@@ -1,0 +1,476 @@
+"""CommitAuthorityArchive — OCA observability ring (Slice 3 #2).
+
+Read-side observability for Operator Commit Authority decisions.
+Mirrors :class:`permission_decision_archive.BoundedDecisionArchive`
+EXACTLY — the single canonical ring shape across the cross-substrate
+``/expand <ref>`` family (``t-N``/``d-N``/``o-N``/``n-N``/``p-N``);
+this arc adds ``c-N``.
+
+Two layers, composed (zero parallel logic):
+
+  * **In-memory ring** — bounded FIFO, monotonic ``c-N`` refs,
+    drop-oldest, ``threading.RLock``. Powers ``/commit recent``.
+  * **Durable JSONL ledger** — every record is also appended via
+    the canonical :func:`cross_process_jsonl.flock_append_line`
+    (NO parallel ``fcntl``; the single cross-process-safe append
+    primitive). Survives process restarts; cross-soak audit.
+
+Recorded event kinds (closed taxonomy, AST-pinned):
+``grant_issue`` / ``revoke`` / ``verify_verdict`` / ``consume`` /
+``bypass_suspected`` / ``enable``.
+
+This is OBSERVABILITY ONLY. It records projections of authority
+decisions; it has zero say in any verdict. Authority asymmetry
+(AST-pinned): no orchestrator / iron_gate / providers /
+change_engine / candidate_generator import. Master-flag-gated
+(default-FALSE per §33.1 — recording is a no-op when off). NEVER
+raises into the authority path.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.CommitAuthorityArchive")
+
+
+COMMIT_AUTHORITY_ARCHIVE_SCHEMA_VERSION: str = (
+    "commit_authority_archive.v1"
+)
+
+MASTER_FLAG_ENV_VAR: str = "JARVIS_COMMIT_AUTHORITY_ARCHIVE_ENABLED"
+ARCHIVE_SIZE_ENV_VAR: str = "JARVIS_COMMIT_AUTHORITY_ARCHIVE_SIZE"
+LEDGER_PATH_ENV_VAR: str = "JARVIS_COMMIT_AUTHORITY_ARCHIVE_PATH"
+
+_DEFAULT_ARCHIVE_SIZE: int = 50
+_MIN_ARCHIVE_SIZE: int = 1
+_MAX_ARCHIVE_SIZE: int = 10_000
+
+# Exposed publicly so REPL parsers / tests build refs without
+# string-munging this module's literals (mirrors REF_PREFIX
+# convention in permission_decision_archive).
+REF_PREFIX: str = "c-"
+
+_DEFAULT_LEDGER_RELATIVE = ".jarvis/commit_authority/archive.jsonl"
+
+
+class CommitAuthorityEventKind(str, enum.Enum):
+    """Closed taxonomy of archivable OCA events (AST-pinned)."""
+
+    GRANT_ISSUE = "grant_issue"
+    REVOKE = "revoke"
+    VERIFY_VERDICT = "verify_verdict"
+    CONSUME = "consume"
+    BYPASS_SUSPECTED = "bypass_suspected"
+    ENABLE = "enable"
+
+    @classmethod
+    def parse(cls, value: object) -> Optional["CommitAuthorityEventKind"]:
+        try:
+            return cls(str(value).strip().lower())
+        except Exception:  # noqa: BLE001
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Master flag + env knobs
+# ---------------------------------------------------------------------------
+
+
+def commit_authority_archive_enabled() -> bool:
+    """Master switch. Default-FALSE per §33.1 graduation contract —
+    recording is a no-op when off (telemetry, never authority).
+    Re-read every call so a flip hot-reverts."""
+    return os.environ.get(
+        MASTER_FLAG_ENV_VAR, "false",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _capacity_from_env() -> int:
+    raw = os.environ.get(ARCHIVE_SIZE_ENV_VAR, "").strip()
+    if not raw:
+        return _DEFAULT_ARCHIVE_SIZE
+    try:
+        return max(_MIN_ARCHIVE_SIZE, min(_MAX_ARCHIVE_SIZE, int(raw)))
+    except (TypeError, ValueError):
+        return _DEFAULT_ARCHIVE_SIZE
+
+
+def _ledger_path() -> Path:
+    raw = os.environ.get(LEDGER_PATH_ENV_VAR, "").strip()
+    if raw:
+        try:
+            return Path(raw).expanduser()
+        except Exception:  # noqa: BLE001
+            pass
+    return Path(_DEFAULT_LEDGER_RELATIVE)
+
+
+def _safe_str(raw: object) -> str:
+    try:
+        return str(raw)
+    except Exception:  # noqa: BLE001
+        return "<unprintable>"
+
+
+# ---------------------------------------------------------------------------
+# Frozen record
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CommitAuthorityRecord:
+    """One archived OCA event. ``ref`` is a stable monotonic
+    ``c-N``. ``detail`` is a shallow projection dict (read-only —
+    consumers MUST NOT mutate)."""
+
+    ref: str
+    kind: str
+    detail: Dict[str, Any]
+    inserted_at: float
+    schema_version: str = COMMIT_AUTHORITY_ARCHIVE_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ref": self.ref,
+            "kind": self.kind,
+            "detail": dict(self.detail),
+            "inserted_at": self.inserted_at,
+            "schema_version": self.schema_version,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Bounded ring
+# ---------------------------------------------------------------------------
+
+
+class BoundedCommitAuthorityArchive:
+    """Thread-safe bounded FIFO of OCA events. Mirrors
+    :class:`permission_decision_archive.BoundedDecisionArchive`
+    semantics: drop-oldest, monotonic ``c-N`` refs that never
+    reuse, reentrant lock. NEVER raises."""
+
+    def __init__(self, *, capacity: Optional[int] = None) -> None:
+        if capacity is None:
+            cap = _capacity_from_env()
+        else:
+            try:
+                cap = max(
+                    _MIN_ARCHIVE_SIZE,
+                    min(_MAX_ARCHIVE_SIZE, int(capacity)),
+                )
+            except (TypeError, ValueError):
+                cap = _DEFAULT_ARCHIVE_SIZE
+        self._capacity = cap
+        self._items: "OrderedDict[str, CommitAuthorityRecord]" = (
+            OrderedDict()
+        )
+        self._next_seq = 1
+        self._lock = threading.RLock()
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._items)
+
+    def record(
+        self, *, kind: object, detail: Optional[dict] = None,
+    ) -> Optional[CommitAuthorityRecord]:
+        """Park one event. Master-gated → ``None`` when off.
+        Unknown kind (outside the closed taxonomy) → ``None``
+        (never pollute the ring). NEVER raises into the caller."""
+        if not commit_authority_archive_enabled():
+            return None
+        parsed = CommitAuthorityEventKind.parse(kind)
+        if parsed is None:
+            logger.debug(
+                "[CommitAuthorityArchive] unknown kind %r — skipped",
+                kind,
+            )
+            return None
+        safe_detail: Dict[str, Any] = {}
+        if isinstance(detail, dict):
+            for k, v in detail.items():
+                safe_detail[_safe_str(k)] = (
+                    v if isinstance(v, (str, int, float, bool))
+                    or v is None else _safe_str(v)
+                )
+        try:
+            with self._lock:
+                ref = f"{REF_PREFIX}{self._next_seq}"
+                self._next_seq += 1
+                rec = CommitAuthorityRecord(
+                    ref=ref,
+                    kind=parsed.value,
+                    detail=safe_detail,
+                    inserted_at=time.time(),
+                )
+                self._items[ref] = rec
+                while len(self._items) > self._capacity:
+                    self._items.popitem(last=False)  # drop oldest
+            _append_ledger(rec)
+            return rec
+        except Exception as exc:  # noqa: BLE001 — never into authority
+            logger.debug(
+                "[CommitAuthorityArchive] record failed: %s", exc,
+            )
+            return None
+
+    def lookup(self, ref: str) -> Optional[CommitAuthorityRecord]:
+        with self._lock:
+            return self._items.get(ref)
+
+    def recent(self, n: int = 10) -> List[Dict[str, Any]]:
+        """Return up to ``n`` newest records (chronological,
+        newest last) as ``to_dict`` projections. NEVER raises."""
+        try:
+            cnt = max(1, min(_MAX_ARCHIVE_SIZE, int(n)))
+        except (TypeError, ValueError):
+            cnt = 10
+        with self._lock:
+            vals = list(self._items.values())
+        return [r.to_dict() for r in vals[-cnt:]]
+
+
+def _append_ledger(rec: CommitAuthorityRecord) -> None:
+    """Durable append via the canonical cross-process primitive.
+    Best-effort; ledger failure never affects the in-memory ring
+    or the authority path. NEVER raises."""
+    try:
+        import json
+        from backend.core.ouroboros.governance.cross_process_jsonl import (  # noqa: E501
+            flock_append_line,
+        )
+        path = _ledger_path()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        except Exception:  # noqa: BLE001
+            pass
+        flock_append_line(path, json.dumps(rec.to_dict(), sort_keys=True))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[CommitAuthorityArchive] ledger append: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (mirrors get_default_broker / store pattern)
+# ---------------------------------------------------------------------------
+
+
+_default_archive: Optional[BoundedCommitAuthorityArchive] = None
+_default_lock = threading.Lock()
+
+
+def get_default_archive() -> BoundedCommitAuthorityArchive:
+    global _default_archive
+    with _default_lock:
+        if _default_archive is None:
+            _default_archive = BoundedCommitAuthorityArchive()
+        return _default_archive
+
+
+def reset_default_archive_for_tests() -> None:
+    global _default_archive
+    with _default_lock:
+        _default_archive = None
+
+
+def record(
+    *, kind: object, detail: Optional[dict] = None,
+) -> Optional[CommitAuthorityRecord]:
+    """Module-level convenience — record onto the default archive.
+    NEVER raises."""
+    try:
+        return get_default_archive().record(kind=kind, detail=detail)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def recent(n: int = 10) -> List[Dict[str, Any]]:
+    """Module-level convenience — newest N from the default
+    archive. NEVER raises."""
+    try:
+        return get_default_archive().recent(n)
+    except Exception:  # noqa: BLE001
+        return []
+
+
+__all__ = [
+    "COMMIT_AUTHORITY_ARCHIVE_SCHEMA_VERSION",
+    "MASTER_FLAG_ENV_VAR",
+    "ARCHIVE_SIZE_ENV_VAR",
+    "LEDGER_PATH_ENV_VAR",
+    "REF_PREFIX",
+    "CommitAuthorityEventKind",
+    "CommitAuthorityRecord",
+    "BoundedCommitAuthorityArchive",
+    "commit_authority_archive_enabled",
+    "get_default_archive",
+    "reset_default_archive_for_tests",
+    "record",
+    "recent",
+    "register_flags",
+    "register_shipped_invariants",
+]
+
+
+# ---------------------------------------------------------------------------
+# Module-owned FlagRegistry seeds
+# ---------------------------------------------------------------------------
+
+
+def register_flags(registry) -> int:  # noqa: ANN001
+    try:
+        from backend.core.ouroboros.governance.flag_registry import (
+            Category, FlagSpec, FlagType,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "[CommitAuthorityArchive] register_flags degraded: %s", exc,
+        )
+        return 0
+    tgt = (
+        "backend/core/ouroboros/governance/commit_authority_archive.py"
+    )
+    specs = [
+        FlagSpec(
+            name=MASTER_FLAG_ENV_VAR, type=FlagType.BOOL,
+            default=False, category=Category.OBSERVABILITY,
+            source_file=tgt,
+            example=f"{MASTER_FLAG_ENV_VAR}=true",
+            description=(
+                "Master switch for the OCA observability ring + "
+                "durable JSONL ledger. Default-FALSE per §33.1 — "
+                "recording is a no-op when off (telemetry, never "
+                "authority)."
+            ),
+        ),
+        FlagSpec(
+            name=ARCHIVE_SIZE_ENV_VAR, type=FlagType.INT,
+            default=_DEFAULT_ARCHIVE_SIZE, category=Category.CAPACITY,
+            source_file=tgt,
+            example=f"{ARCHIVE_SIZE_ENV_VAR}=100",
+            description=(
+                "In-memory c-N ring capacity (drop-oldest). Floor "
+                f"{_MIN_ARCHIVE_SIZE}, ceiling {_MAX_ARCHIVE_SIZE}."
+            ),
+        ),
+    ]
+    count = 0
+    for spec in specs:
+        try:
+            registry.register(spec)
+            count += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "[CommitAuthorityArchive] seed %s skipped: %s",
+                spec.name, exc,
+            )
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Module-owned shipped_code_invariants (AST pins)
+# ---------------------------------------------------------------------------
+
+
+def register_shipped_invariants() -> list:
+    """Pins: authority asymmetry (no decision-side imports), the
+    closed event-kind taxonomy, composes the canonical
+    flock_append_line (no parallel fcntl)."""
+    import ast as _ast
+    try:
+        from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+            ShippedCodeInvariant,
+        )
+    except ImportError:
+        return []
+
+    def _validate(tree: "_ast.Module", source: str) -> tuple:
+        violations: list = []
+        forbidden = (
+            "orchestrator", "iron_gate", "providers",
+            "change_engine", "candidate_generator",
+            "semantic_guardian", "urgency_router",
+        )
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.ImportFrom):
+                mod = node.module or ""
+                for f in forbidden:
+                    if f in mod:
+                        violations.append(
+                            f"line {getattr(node, 'lineno', '?')}: "
+                            f"authority-asymmetry violation — "
+                            f"archive must not import {f!r}"
+                        )
+                if (node.module or "").endswith("fcntl"):
+                    violations.append(
+                        "must NOT import fcntl — compose the "
+                        "canonical flock_append_line"
+                    )
+            if isinstance(node, _ast.Import):
+                for a in node.names:
+                    if a.name == "fcntl":
+                        violations.append(
+                            "must NOT import fcntl — compose "
+                            "flock_append_line"
+                        )
+        if "flock_append_line" not in source:
+            violations.append(
+                "durable ledger must compose the canonical "
+                "cross_process_jsonl.flock_append_line"
+            )
+        required = {
+            "GRANT_ISSUE", "REVOKE", "VERIFY_VERDICT",
+            "CONSUME", "BYPASS_SUSPECTED", "ENABLE",
+        }
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.ClassDef) and (
+                node.name == "CommitAuthorityEventKind"
+            ):
+                seen = {
+                    t.id
+                    for stmt in node.body
+                    if isinstance(stmt, _ast.Assign)
+                    for t in stmt.targets
+                    if isinstance(t, _ast.Name)
+                }
+                if required - seen:
+                    violations.append(
+                        f"CommitAuthorityEventKind missing "
+                        f"{sorted(required - seen)}"
+                    )
+                if seen - required:
+                    violations.append(
+                        f"CommitAuthorityEventKind unexpected "
+                        f"(closed-taxonomy) {sorted(seen - required)}"
+                    )
+        return tuple(violations)
+
+    tgt = (
+        "backend/core/ouroboros/governance/commit_authority_archive.py"
+    )
+    return [
+        ShippedCodeInvariant(
+            invariant_name="commit_authority_archive_asymmetry_taxonomy",
+            target_file=tgt,
+            description=(
+                "OCA observability ring stays authority-asymmetric "
+                "(no orchestrator/iron_gate/providers/... import), "
+                "composes the canonical flock_append_line (no "
+                "parallel fcntl), and CommitAuthorityEventKind is "
+                "the closed 6-value taxonomy."
+            ),
+            validate=_validate,
+        ),
+    ]

--- a/backend/core/ouroboros/governance/commit_authority_cli.py
+++ b/backend/core/ouroboros/governance/commit_authority_cli.py
@@ -226,6 +226,17 @@ def cmd_hook_pre_commit() -> int:
             f"{_DIM}# OCA: {verdict.verdict.value} "
             f"({verdict.detail}){_RESET}\n"
         )
+        # OCA Slice 3 #5 — additive verified-marker. Written ONLY
+        # after authorization succeeds; consumed + cleared by the
+        # post-commit hook. Its ABSENCE/staleness after a commit
+        # is the structural bypass_suspected signal (a --no-verify
+        # commit skips this whole dispatcher → no fresh marker).
+        # Additive observability — does NOT alter the verdict.
+        _write_verified_marker(
+            root,
+            channel=channel,
+            matched_grant_id=verdict.matched_grant_id,
+        )
     else:
         ok, reason = legacy_token_ok()
         if not ok:
@@ -241,6 +252,160 @@ def cmd_hook_pre_commit() -> int:
             return 1
 
     return _chain_project_hook(root)
+
+
+# ---------------------------------------------------------------------------
+# OCA Slice 3 #5 — verified-marker + post-commit hook
+# ---------------------------------------------------------------------------
+
+
+_VERIFIED_MARKER_REL = (
+    ".jarvis", "commit_authority", ".last_verified",
+)
+# Max age (s) between pre-commit authorization and the post-commit
+# hook firing for the same commit. A real commit's post-commit
+# runs within milliseconds of pre-commit; a stale/absent marker
+# means the pre-commit dispatcher never ran (--no-verify / bypass).
+_VERIFIED_MARKER_MAX_AGE_S = 60.0
+
+
+def _verified_marker_path(root: str) -> Path:
+    return Path(root, *_VERIFIED_MARKER_REL)
+
+
+def _write_verified_marker(
+    root: str, *, channel: str, matched_grant_id: str,
+) -> None:
+    """Best-effort one-shot marker. NEVER raises into the gate."""
+    try:
+        import json
+        import time as _t
+        p = _verified_marker_path(root)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            json.dumps({
+                "ts": _t.time(),
+                "channel": str(channel),
+                "matched_grant_id": str(matched_grant_id or ""),
+            }),
+            encoding="utf-8",
+        )
+    except Exception:  # noqa: BLE001 — observability, never the gate
+        pass
+
+
+def _read_and_clear_verified_marker(root: str) -> Optional[dict]:
+    """Read + unlink the marker (one-shot). Returns the dict or
+    None (absent/corrupt). NEVER raises."""
+    try:
+        import json
+        p = _verified_marker_path(root)
+        if not p.exists():
+            return None
+        raw = json.loads(p.read_text(encoding="utf-8"))
+        try:
+            p.unlink()
+        except OSError:
+            pass
+        return raw if isinstance(raw, dict) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _archive_post_commit(kind: str, detail: dict) -> None:
+    """Best-effort append to the OCA observability ring (#2).
+    Archive absence/disable is silent. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance import (
+            commit_authority_archive as _arch,
+        )
+        _arch.record(kind=kind, detail=detail)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def cmd_hook_post_commit() -> int:
+    """``hook post-commit`` — runs AFTER a commit lands. Two
+    best-effort, detect-only duties (NEVER blocks; a commit has
+    already happened; NEVER auto-reverts per the operator
+    constraint):
+
+      1. **bypass detection** — a fresh verified-marker proves the
+         pre-commit gate authorized this commit. Absent/stale →
+         ``bypass_suspected`` (``--no-verify`` or a hook bypass).
+         Detect + archive only.
+      2. **grant consume** — when one-shot grants are enabled
+         (``JARVIS_COMMIT_GRANT_ONESHOT`` truthy; default OFF so
+         session-lived grants keep working), the matched grant
+         from the marker is consumed via the canonical
+         :func:`consume_grant`.
+
+    Always returns 0 — a post-commit hook must never fail the
+    (already-completed) commit. NEVER raises.
+    """
+    try:
+        root = _repo_root()
+        try:
+            from backend.core.ouroboros.governance import (
+                operator_commit_authority as oca,
+            )
+            master = oca.master_enabled()
+        except Exception:  # noqa: BLE001
+            return 0
+        if not master:
+            return 0  # OCA not governing — nothing to observe.
+
+        head = ""
+        try:
+            r = _git(["rev-parse", "HEAD"], root)
+            if r is not None and r.returncode == 0:
+                head = (r.stdout or "").strip()[:40]
+        except Exception:  # noqa: BLE001
+            pass
+
+        marker = _read_and_clear_verified_marker(root)
+        import time as _t
+        fresh = bool(
+            marker
+            and isinstance(marker.get("ts"), (int, float))
+            and (_t.time() - float(marker["ts"]))
+            <= _VERIFIED_MARKER_MAX_AGE_S
+        )
+        if not fresh:
+            _archive_post_commit(
+                "bypass_suspected",
+                {
+                    "head": head,
+                    "reason": (
+                        "verified-marker absent" if not marker
+                        else "verified-marker stale"
+                    ),
+                },
+            )
+            sys.stderr.write(
+                f"{_DIM}# OCA post-commit: bypass_suspected "
+                f"(no fresh pre-commit authorization for "
+                f"{head[:12]}){_RESET}\n"
+            )
+            return 0
+
+        # Authorized commit. Optional one-shot consume.
+        oneshot = os.environ.get(
+            "JARVIS_COMMIT_GRANT_ONESHOT", "",
+        ).strip().lower() in ("1", "true", "yes", "on")
+        gid = str(marker.get("matched_grant_id", "")).strip()
+        if oneshot and gid:
+            try:
+                oca.consume_grant(gid)
+                _archive_post_commit(
+                    "consume",
+                    {"head": head, "grant_id": gid},
+                )
+            except Exception:  # noqa: BLE001
+                pass
+        return 0
+    except Exception:  # noqa: BLE001 — post-commit MUST NOT fail
+        return 0
 
 
 def cmd_grant(args: argparse.Namespace) -> int:
@@ -389,7 +554,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     h = sub.add_parser("hook", help="git hook dispatcher")
     h.add_argument(
-        "phase", choices=["pre-commit"], help="hook phase"
+        "phase", choices=["pre-commit", "post-commit"],
+        help="hook phase",
     )
 
     g = sub.add_parser("grant", help="issue a signed commit grant")
@@ -444,6 +610,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = build_parser().parse_args(argv)
     if args.cmd == "hook" and args.phase == "pre-commit":
         return cmd_hook_pre_commit()
+    if args.cmd == "hook" and args.phase == "post-commit":
+        return cmd_hook_post_commit()
     if args.cmd == "grant":
         return cmd_grant(args)
     if args.cmd == "revoke":

--- a/backend/core/ouroboros/governance/commit_repl.py
+++ b/backend/core/ouroboros/governance/commit_repl.py
@@ -1,0 +1,432 @@
+"""``/commit`` — Operator Commit Authority REPL surface (Slice 3 #1).
+
+Auto-discovered via the §32.11 naming-cage convention: file
+``commit_repl.py`` → verb ``/commit`` → dispatcher
+``dispatch_commit_command(line)``. ZERO edits to
+``repl_dispatch_registry.py`` (the basename-minus-``_repl`` rule
+maps it; ``commit`` is not in the custom-handler exclusion list).
+
+**Subcommands**
+
+  * ``/commit`` / ``/commit status`` — gate state + dry verify
+    for the ``ide`` channel on the current repo/branch.
+  * ``/commit grant [--minutes N] [--branch B] [--label L]`` —
+    issue a signed, branch-bound ``ide`` grant. ``--branch``
+    DEFAULTS to the current git branch (NEVER an empty
+    whole-repo grant). Composes :func:`issue_grant`, which also
+    mints the operator-presence marker (the channel-resolution
+    seam) — so a single ``/commit grant`` is the full operator
+    ritual.
+  * ``/commit revoke [--id ID | --all]`` — append a revocation
+    tombstone (the ledger is append-only). Composes
+    :func:`revoke_grants`.
+  * ``/commit enable [--label L]`` — write the OCA persistent
+    signed master-enable record (the Cursor-SCM-button fix).
+    Composes :func:`enable_authority`. NOTE: this is the OCA
+    enable; sovereignty's persistent enable is a SEPARATE record
+    (``persistent_master``) — the two stay decoupled by design.
+  * ``/commit recent [N]`` — last N archived authority events
+    (composes :mod:`commit_authority_archive`; graceful when the
+    archive substrate is absent / disabled).
+  * ``/commit help`` — usage.
+
+**Composition** — operator-facing browser pattern (mirrors
+``mode_repl`` / ``posture_repl``): composes ONLY
+:mod:`operator_commit_authority` public surface +
+:mod:`commit_authority_archive` (read side). The operator's
+grant/revoke/enable writes ARE the authority state; this module
+holds zero parallel state and NEVER reimplements verification,
+the grant ledger, or the HMAC.
+
+**Authority asymmetry** (AST-pinned in the spine): NO orchestrator
+/ iron_gate / providers / change_engine / semantic_guardian /
+candidate_generator / urgency_router import. Read/issue authority
+only — never a commit decision side-channel.
+
+**NEVER raises** — every path defensive; degrades to a friendly
+message rather than propagating.
+"""
+from __future__ import annotations
+
+import logging
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger("Ouroboros.CommitREPL")
+
+
+_VERBS = ("/commit",)
+_VALID_SUBCOMMANDS = {
+    "status", "grant", "revoke", "enable", "recent", "help",
+}
+
+
+@dataclass
+class CommitDispatchResult:
+    """Auto-discovery contract: ``ok: bool``, ``text: str``,
+    ``matched: bool`` (mirrors ``ModeDispatchResult``)."""
+
+    ok: bool
+    text: str
+    matched: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _matches(line: str) -> bool:
+    if not line:
+        return False
+    return line.split(None, 1)[0] in _VERBS
+
+
+def _repo_root() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except Exception:  # noqa: BLE001
+        pass
+    return "."
+
+
+def _current_branch(repo_root: str) -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=repo_root, capture_output=True, text=True,
+            timeout=5, check=False,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except Exception:  # noqa: BLE001
+        pass
+    return ""
+
+
+def _parse_opts(args: List[str]) -> dict:
+    """Tiny ``--k v`` / ``--flag`` parser. NEVER raises."""
+    opts: dict = {}
+    i = 0
+    while i < len(args):
+        tok = args[i]
+        if tok.startswith("--"):
+            key = tok[2:]
+            if i + 1 < len(args) and not args[i + 1].startswith("--"):
+                opts[key] = args[i + 1]
+                i += 2
+            else:
+                opts[key] = True
+                i += 1
+        else:
+            i += 1
+    return opts
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+def dispatch_commit_command(line: str) -> CommitDispatchResult:
+    """Parse a ``/commit`` line and dispatch. ``matched=False``
+    short-circuit lets the registry fall through. NEVER raises."""
+    if not _matches(line):
+        return CommitDispatchResult(ok=False, text="", matched=False)
+    try:
+        tokens = shlex.split(line)
+    except ValueError as exc:
+        return CommitDispatchResult(
+            ok=False, text=f"/commit: parse error — {exc}",
+        )
+    args = tokens[1:]
+    if not args:
+        return _render_status()
+    sub = args[0].lower()
+    if sub not in _VALID_SUBCOMMANDS:
+        return CommitDispatchResult(
+            ok=False,
+            text=(
+                f"/commit: unknown subcommand {sub!r}. "
+                f"Try /commit help."
+            ),
+        )
+    rest = args[1:]
+    try:
+        if sub == "help":
+            return _render_help()
+        if sub == "status":
+            return _render_status()
+        if sub == "grant":
+            return _handle_grant(rest)
+        if sub == "revoke":
+            return _handle_revoke(rest)
+        if sub == "enable":
+            return _handle_enable(rest)
+        if sub == "recent":
+            return _handle_recent(rest)
+    except Exception as exc:  # noqa: BLE001 — NEVER raise into REPL
+        logger.debug("[CommitREPL] %s failed: %s", sub, exc)
+        return CommitDispatchResult(
+            ok=False, text=f"/commit {sub}: failed (non-fatal): {exc}",
+        )
+    return CommitDispatchResult(
+        ok=False, text=f"/commit: unhandled subcommand {sub!r}",
+    )
+
+
+def _render_help() -> CommitDispatchResult:
+    return CommitDispatchResult(ok=True, text=(
+        "/commit — Operator Commit Authority surface (Slice 3)\n"
+        "\n"
+        "  /commit [status]                gate state + dry "
+        "verify (ide, current branch)\n"
+        "  /commit grant [--minutes N]     issue signed ide "
+        "grant + mint presence\n"
+        "          [--branch B] [--label L]  (--branch defaults "
+        "to current branch)\n"
+        "  /commit revoke [--id ID|--all]  append revocation "
+        "tombstone\n"
+        "  /commit enable [--label L]      OCA persistent "
+        "master-enable (Cursor SCM)\n"
+        "  /commit recent [N]              last N archived "
+        "authority events\n"
+        "  /commit help                    this message\n"
+        "\n"
+        "Composes operator_commit_authority (no parallel state). "
+        "A single `/commit grant` is the full operator ritual "
+        "(grant + presence)."
+    ))
+
+
+def _oca():
+    """Lazy import of the substrate. Returns the module or None."""
+    try:
+        from backend.core.ouroboros.governance import (
+            operator_commit_authority as oca,
+        )
+        return oca
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _render_status() -> CommitDispatchResult:
+    oca = _oca()
+    if oca is None:
+        return CommitDispatchResult(
+            ok=False, text="/commit: OCA substrate unavailable",
+        )
+    root = _repo_root()
+    branch = _current_branch(root)
+    try:
+        master = oca.master_enabled()
+        ctx = oca.CommitAuthorityContext(
+            channel=oca.resolve_commit_channel(
+                Path(root), branch, env_channel="",
+            ).value,
+            repo_root=root,
+            branch=branch,
+        )
+        verdict = oca.verify_pre_commit(ctx)
+    except Exception as exc:  # noqa: BLE001
+        return CommitDispatchResult(
+            ok=False, text=f"/commit status: read failed: {exc}",
+        )
+    return CommitDispatchResult(ok=True, text=(
+        f"/commit status:\n"
+        f"  master_enabled  = {master}\n"
+        f"  repo_root       = {root}\n"
+        f"  branch          = {branch or '(detached/unknown)'}\n"
+        f"  resolved_channel= {ctx.channel}\n"
+        f"  dry_verify      = {verdict.verdict.value}"
+        f"{(' — ' + verdict.detail) if verdict.detail else ''}"
+    ))
+
+
+def _handle_grant(rest: List[str]) -> CommitDispatchResult:
+    oca = _oca()
+    if oca is None:
+        return CommitDispatchResult(
+            ok=False, text="/commit: OCA substrate unavailable",
+        )
+    opts = _parse_opts(rest)
+    root = _repo_root()
+    branch = (
+        str(opts.get("branch")).strip()
+        if isinstance(opts.get("branch"), str)
+        else _current_branch(root)
+    )
+    if not branch:
+        return CommitDispatchResult(ok=False, text=(
+            "/commit grant: cannot resolve current branch and no "
+            "--branch given. Refusing an empty whole-repo grant "
+            "(structural: grants are branch-bound by default)."
+        ))
+    minutes_raw = opts.get("minutes")
+    ttl_s: Optional[int] = None
+    if isinstance(minutes_raw, str):
+        try:
+            ttl_s = max(1, int(float(minutes_raw))) * 60
+        except (TypeError, ValueError):
+            return CommitDispatchResult(
+                ok=False,
+                text=f"/commit grant: bad --minutes {minutes_raw!r}",
+            )
+    label = (
+        str(opts.get("label")).strip()
+        if isinstance(opts.get("label"), str)
+        else "repl-commit-grant"
+    )
+    try:
+        out = oca.issue_grant(
+            channel="ide",
+            operator_label=label,
+            ttl_s=ttl_s,
+            branch=branch,
+            repo_root=Path(root),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return CommitDispatchResult(
+            ok=False, text=f"/commit grant: failed: {exc}",
+        )
+    if not getattr(out, "ok", False):
+        return CommitDispatchResult(
+            ok=False,
+            text=f"/commit grant: refused — {getattr(out, 'error', '?')}",
+        )
+    _archive_best_effort(
+        "grant_issue",
+        {
+            "grant_id": out.grant_id, "channel": "ide",
+            "branch": branch, "label": label,
+        },
+    )
+    return CommitDispatchResult(ok=True, text=(
+        f"/commit grant: issued ide grant {out.grant_id[:12]}… "
+        f"branch={branch} (presence minted). "
+        f"expires_at_unix={out.expires_at_unix:.0f}"
+    ))
+
+
+def _handle_revoke(rest: List[str]) -> CommitDispatchResult:
+    oca = _oca()
+    if oca is None:
+        return CommitDispatchResult(
+            ok=False, text="/commit: OCA substrate unavailable",
+        )
+    opts = _parse_opts(rest)
+    revoke_all = bool(opts.get("all"))
+    gid = opts.get("id")
+    if not revoke_all and not isinstance(gid, str):
+        return CommitDispatchResult(ok=False, text=(
+            "/commit revoke: need --id <grant_id> or --all"
+        ))
+    try:
+        n = oca.revoke_grants(
+            grant_id=gid if isinstance(gid, str) else None,
+            revoke_all=revoke_all,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return CommitDispatchResult(
+            ok=False, text=f"/commit revoke: failed: {exc}",
+        )
+    _archive_best_effort(
+        "revoke",
+        {"all": revoke_all, "grant_id": gid if isinstance(gid, str) else ""},
+    )
+    target = "ALL grants" if revoke_all else f"grant {gid}"
+    return CommitDispatchResult(
+        ok=bool(n),
+        text=(
+            f"/commit revoke: {target} — "
+            f"{'tombstone appended' if n else 'append failed'}"
+        ),
+    )
+
+
+def _handle_enable(rest: List[str]) -> CommitDispatchResult:
+    oca = _oca()
+    if oca is None:
+        return CommitDispatchResult(
+            ok=False, text="/commit: OCA substrate unavailable",
+        )
+    opts = _parse_opts(rest)
+    label = (
+        str(opts.get("label")).strip()
+        if isinstance(opts.get("label"), str)
+        else "repl-commit-enable"
+    )
+    try:
+        ok = oca.enable_authority(label)
+    except Exception as exc:  # noqa: BLE001
+        return CommitDispatchResult(
+            ok=False, text=f"/commit enable: failed: {exc}",
+        )
+    _archive_best_effort("enable", {"label": label, "ok": ok})
+    return CommitDispatchResult(ok=bool(ok), text=(
+        "/commit enable: OCA persistently enabled (signed) — "
+        "Cursor SCM works with no shell env"
+        if ok else
+        "/commit enable: failed (secret/crypto unavailable)"
+    ))
+
+
+def _handle_recent(rest: List[str]) -> CommitDispatchResult:
+    n = 10
+    if rest:
+        try:
+            n = max(1, min(200, int(rest[0])))
+        except (TypeError, ValueError):
+            pass
+    try:
+        from backend.core.ouroboros.governance import (
+            commit_authority_archive as arch,
+        )
+    except Exception:  # noqa: BLE001
+        return CommitDispatchResult(
+            ok=True,
+            text="/commit recent: archive substrate not present",
+        )
+    try:
+        records = arch.recent(n)
+    except Exception as exc:  # noqa: BLE001
+        return CommitDispatchResult(
+            ok=False, text=f"/commit recent: read failed: {exc}",
+        )
+    if not records:
+        return CommitDispatchResult(
+            ok=True, text="/commit recent: (no archived events)",
+        )
+    lines = [f"/commit recent (last {len(records)}):"]
+    for r in records:
+        lines.append(
+            f"  {r.get('ref', '?')}  {r.get('kind', '?')}  "
+            f"{r.get('detail', '')}"[:160]
+        )
+    return CommitDispatchResult(ok=True, text="\n".join(lines))
+
+
+def _archive_best_effort(kind: str, detail: dict) -> None:
+    """Append to the authority archive if present. NEVER raises;
+    archive absence/disable is silent (telemetry, not authority)."""
+    try:
+        from backend.core.ouroboros.governance import (
+            commit_authority_archive as arch,
+        )
+        arch.record(kind=kind, detail=detail)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+__all__ = [
+    "CommitDispatchResult",
+    "dispatch_commit_command",
+]

--- a/backend/core/ouroboros/governance/ide_observability.py
+++ b/backend/core/ouroboros/governance/ide_observability.py
@@ -269,6 +269,12 @@ class IDEObservabilityRouter:
         app.router.add_get(
             "/observability/verbs", self._handle_verbs_list,
         )
+        # OCA Slice 3 #3 — Operator Commit Authority decision ring
+        # projection (read-only; composes commit_authority_archive).
+        app.router.add_get(
+            "/observability/commit-authority",
+            self._handle_commit_authority,
+        )
         # MissionInferrer Slice C — current InferenceResult projection.
         app.router.add_get(
             "/observability/goal-inference",
@@ -490,6 +496,61 @@ class IDEObservabilityRouter:
         we're loopback-only anyway, but some clients still set it)."""
         peer = getattr(request, "remote", "") or "unknown"
         return str(peer)
+
+    async def _handle_commit_authority(
+        self, request: "web.Request",
+    ) -> Any:
+        """GET /observability/commit-authority[?limit=N] — read-only
+        projection of the OCA decision ring.
+
+        Shape::
+
+            {
+              "schema_version": "1.0",
+              "count": 3,
+              "records": [{"ref": "c-1", "kind": "grant_issue",
+                           "detail": {...}, "inserted_at": 1.0,
+                           "schema_version": "..."}, ...]
+            }
+
+        Composes :func:`commit_authority_archive.recent` (single
+        source — when the archive master flag is off, ``recent``
+        returns ``[]`` so this is an empty 200, NOT a 403; the
+        route's own gate is the global ide_observability flag).
+        ``?limit=N`` clamped to [1, 200]; default 50.
+        """
+        if not ide_observability_enabled():
+            return self._error_response(
+                request, 403, "ide_observability.disabled",
+            )
+        if not self._check_rate_limit(self._client_key(request)):
+            return self._error_response(
+                request, 429, "ide_observability.rate_limited",
+            )
+        limit = 50
+        raw = request.query.get("limit", "").strip()
+        if raw:
+            try:
+                limit = max(1, min(200, int(raw)))
+            except (TypeError, ValueError):
+                return self._error_response(
+                    request, 400, "commit_authority.bad_limit",
+                )
+        try:
+            from backend.core.ouroboros.governance import (
+                commit_authority_archive as _arch,
+            )
+            records = _arch.recent(limit)
+        except Exception:  # noqa: BLE001 — empty rather than 500
+            logger.debug(
+                "[IDEObservability] commit_authority projection failed",
+                exc_info=True,
+            )
+            records = []
+        return self._json_response(
+            request, 200,
+            {"count": len(records), "records": records},
+        )
 
     def _check_rate_limit(self, client_key: str) -> bool:
         """Returns True iff this call is within the sliding-window

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -143,6 +143,16 @@ EVENT_TYPE_MEMORY_PRESSURE_CHANGED = "memory_pressure_changed"
 # matches the posture_changed keying convention).
 EVENT_TYPE_GIT_INDEX_ANOMALY = "git_index_anomaly"
 
+# OCA Slice 3 #3 — an Operator Commit Authority event was archived
+# (grant_issue / revoke / verify_verdict / consume /
+# bypass_suspected / enable). Single event; payload carries the
+# CommitAuthorityRecord.to_dict() (ref / kind / detail). Keyed by
+# the constant "commit_authority" (organism property, no op_id —
+# same convention as posture_changed / git_index_anomaly).
+EVENT_TYPE_COMMIT_AUTHORITY_DECISION_RECORDED = (
+    "commit_authority_decision_recorded"
+)
+
 # Upgrade 1 Bounded Epistemic Loop (PRD §31.2) Slice 4 vocabulary.
 # Single event covering all 7 BudgetOutcome branches — payload
 # carries outcome string + reason + per-op snapshot. Operators
@@ -1306,6 +1316,7 @@ _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_GOVERNOR_EMERGENCY_BRAKE,
     EVENT_TYPE_MEMORY_PRESSURE_CHANGED,
     EVENT_TYPE_GIT_INDEX_ANOMALY,
+    EVENT_TYPE_COMMIT_AUTHORITY_DECISION_RECORDED,
     EVENT_TYPE_MEMORY_FANOUT_DECISION,
     EVENT_TYPE_CANCEL_ORIGIN_EMITTED,  # W3(7) Slice 6
     EVENT_TYPE_CURIOSITY_QUESTION_EMITTED,  # W2(4) Slice 3
@@ -2536,6 +2547,41 @@ def publish_git_index_anomaly(
     except Exception:  # noqa: BLE001 — best-effort
         logger.debug(
             "[Stream] publish_git_index_anomaly exception",
+            exc_info=True,
+        )
+        return None
+
+
+def publish_commit_authority_decision(
+    record: Mapping[str, Any],
+) -> Optional[str]:
+    """Best-effort publisher for
+    ``commit_authority_decision_recorded`` SSE frames.
+
+    ``record`` is :meth:`CommitAuthorityRecord.to_dict` output
+    (ref / kind / detail / inserted_at / schema_version). Returns
+    the event_id on success, None when the stream is disabled /
+    broker missing / publish raised / payload is not a mapping.
+    Never raises — it is the fail-silent seam the
+    :mod:`commit_authority_archive` invokes after parking a record.
+
+    Keyed by the constant ``"commit_authority"`` (organism
+    property, no op_id) — identical convention to
+    :func:`publish_posture_event` / :func:`publish_git_index_anomaly`.
+    """
+    if not stream_enabled():
+        return None
+    try:
+        if not isinstance(record, Mapping):
+            return None
+        payload: Dict[str, Any] = dict(record)
+        return get_default_broker().publish(
+            EVENT_TYPE_COMMIT_AUTHORITY_DECISION_RECORDED,
+            "commit_authority", payload,
+        )
+    except Exception:  # noqa: BLE001 — best-effort
+        logger.debug(
+            "[Stream] publish_commit_authority_decision exception",
             exc_info=True,
         )
         return None

--- a/backend/core/ouroboros/governance/operator_commit_authority.py
+++ b/backend/core/ouroboros/governance/operator_commit_authority.py
@@ -136,6 +136,17 @@ _DEFAULT_PRESENCE_TTL_S = 900  # 15 min
 _MIN_PRESENCE_TTL_S = 60
 _MAX_PRESENCE_TTL_S = 86_400  # 24h ceiling
 
+# Multi-entry presence store bound. Presence is keyed by
+# (repo_fingerprint, branch) so concurrent legitimate actors
+# (operator on branch X, an autonomous-ish writer on branch Y,
+# a whole-repo "" arming) COEXIST instead of clobbering a single
+# global record — the production-lockout root fix. Bounded so the
+# store can't grow unboundedly; drop-oldest by issued_at.
+_ENV_PRESENCE_MAX_ENTRIES = "JARVIS_COMMIT_PRESENCE_MAX_ENTRIES"
+_DEFAULT_PRESENCE_MAX_ENTRIES = 64
+_MIN_PRESENCE_MAX_ENTRIES = 1
+_MAX_PRESENCE_MAX_ENTRIES = 1000
+
 _GIT_OP_TIMEOUT_S = 5.0
 
 _TRUTHY: FrozenSet[str] = frozenset({"1", "true", "yes", "on"})
@@ -552,6 +563,97 @@ def _presence_signed_payload(
     }
 
 
+def _presence_max_entries() -> int:
+    raw = os.environ.get(_ENV_PRESENCE_MAX_ENTRIES, "").strip()
+    try:
+        v = int(raw) if raw else _DEFAULT_PRESENCE_MAX_ENTRIES
+    except (TypeError, ValueError):
+        v = _DEFAULT_PRESENCE_MAX_ENTRIES
+    return max(
+        _MIN_PRESENCE_MAX_ENTRIES,
+        min(_MAX_PRESENCE_MAX_ENTRIES, v),
+    )
+
+
+def _presence_entry_key(repo_fp: str, branch: str) -> str:
+    """Composite key — (repo fingerprint, branch). ``\\x1f`` (unit
+    separator) cannot occur in a fingerprint hex or a git ref, so
+    the join is unambiguous."""
+    return f"{repo_fp}\x1f{str(branch or '').strip()}"
+
+
+def _load_presence_store(target: Path) -> Dict[str, Any]:
+    """Return ``{"entries": {key: {"record":..,"signature":..}}}``.
+
+    Tolerant: a legacy single-record file
+    (``{"record":..,"signature":..}``) is migrated *in memory*
+    into one entry so an in-flight operator presence survives the
+    multi-entry upgrade (read-side back-compat). NEVER raises."""
+    try:
+        if not target.exists():
+            return {"entries": {}}
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return {"entries": {}}
+    if not isinstance(raw, dict):
+        return {"entries": {}}
+    entries = raw.get("entries")
+    if isinstance(entries, dict):
+        return {"entries": entries}
+    # Legacy single-record shape → synthesize one entry.
+    rec = raw.get("record")
+    sig = raw.get("signature")
+    if isinstance(rec, dict) and isinstance(sig, str):
+        key = _presence_entry_key(
+            str(rec.get("repo_root_sha256", "")),
+            str(rec.get("branch", "")),
+        )
+        return {"entries": {key: {"record": rec, "signature": sig}}}
+    return {"entries": {}}
+
+
+def _presence_entry_valid(
+    entry: Any,
+    *,
+    repo_fp: str,
+    branch: str,
+    now: float,
+    secret: str,
+) -> bool:
+    """Verify one store entry against (repo_fp, branch). A blank
+    record-branch == whole-repo arming (matches any branch). NEVER
+    raises."""
+    if not isinstance(entry, dict):
+        return False
+    record = entry.get("record")
+    signature = entry.get("signature")
+    if not isinstance(record, dict) or not isinstance(signature, str):
+        return False
+    if record.get("kind") != "operator_presence":
+        return False
+    try:
+        issued = float(record.get("issued_at_unix", 0.0))
+        ttl = int(record.get("ttl_s", 0))
+    except (TypeError, ValueError):
+        return False
+    rec_repo = str(record.get("repo_root_sha256", ""))
+    rec_branch = str(record.get("branch", ""))
+    payload = _presence_signed_payload(
+        issued, ttl, rec_repo, rec_branch,
+        str(record.get("operator_label", "")),
+    )
+    if not _verify(payload, signature, secret):
+        return False
+    if ttl <= 0 or now >= issued + float(ttl):
+        return False
+    if rec_repo and rec_repo != repo_fp:
+        return False
+    cur_branch = str(branch or "").strip()
+    if rec_branch and cur_branch and rec_branch != cur_branch:
+        return False
+    return True
+
+
 def mint_operator_presence(
     repo_root: Path,
     branch: str,
@@ -560,10 +662,17 @@ def mint_operator_presence(
     ttl_s: Optional[int] = None,
     now_unix: Optional[float] = None,
 ) -> bool:
-    """Operator-only: write the signed presence marker bound to
-    ``(repo_root, branch)``. Atomic write, 0600 (mirrors
-    :func:`enable_authority`). Bootstraps the per-machine secret on
-    first use. Returns ``True`` on success. NEVER raises."""
+    """Operator-only: ADD/refresh the signed presence entry for
+    ``(repo_root, branch)`` WITHOUT clobbering other entries.
+
+    Production-lockout root fix: presence is a multi-entry store
+    keyed by (repo fingerprint, branch). A branch-bound grant on
+    one branch no longer wipes the operator's whole-repo or
+    other-branch presence (the single-global-last-write-wins
+    defect that produced ``denied_sovereignty`` on the operator's
+    own commit). Expired entries are pruned and the store is
+    drop-oldest bounded on every write. Atomic, 0600. Bootstraps
+    the per-machine secret. NEVER raises."""
     label = str(operator_label or "").strip()
     if not label:
         return False
@@ -581,19 +690,67 @@ def mint_operator_presence(
         else presence_ttl_s()
     )
     eff_ttl = max(_MIN_PRESENCE_TTL_S, min(_MAX_PRESENCE_TTL_S, eff_ttl))
+    norm_branch = str(branch or "").strip()
     payload = _presence_signed_payload(
-        now, eff_ttl, fp, str(branch or "").strip(), label,
+        now, eff_ttl, fp, norm_branch, label,
     )
     signature = _sign(payload, secret)
     if not signature:
         return False
     target = presence_file_path()
     try:
+        store = _load_presence_store(target)
+        entries: Dict[str, Any] = dict(store.get("entries", {}))
+        # Prune expired entries (keeps the store self-cleaning).
+        kept: Dict[str, Any] = {}
+        for k, v in entries.items():
+            try:
+                rec = v.get("record", {}) if isinstance(v, dict) else {}
+                iss = float(rec.get("issued_at_unix", 0.0))
+                t = int(rec.get("ttl_s", 0))
+                if t > 0 and now < iss + float(t):
+                    kept[k] = v
+            except Exception:  # noqa: BLE001
+                continue
+        kept[_presence_entry_key(fp, norm_branch)] = {
+            "record": payload, "signature": signature,
+        }
+        # Drop-oldest hard cap by issued_at.
+        cap = _presence_max_entries()
+        if len(kept) > cap:
+            ordered = sorted(
+                kept.items(),
+                key=lambda kv: float(
+                    kv[1].get("record", {}).get(
+                        "issued_at_unix", 0.0,
+                    )
+                ),
+            )
+            kept = dict(ordered[-cap:])
+        # Transitional dual-format bridge: pre-multi-entry code
+        # reads ``raw["record"]`` (single-record shape). Until all
+        # checkouts realign, ALSO emit a signed top-level
+        # whole-repo (blank-branch) record so old readers on ANY
+        # branch stay satisfied — it is HMAC-signed (unforgeable),
+        # and new readers ignore it (entries-first in
+        # _load_presence_store). Remove once realignment completes.
+        legacy_payload = _presence_signed_payload(
+            now, eff_ttl, fp, "", label,
+        )
+        legacy_sig = _sign(legacy_payload, secret)
         target.parent.mkdir(parents=True, exist_ok=True)
         tmp = target.with_suffix(target.suffix + ".tmp")
         tmp.write_text(
             json.dumps(
-                {"record": payload, "signature": signature},
+                {
+                    "schema_version": (
+                        OPERATOR_COMMIT_AUTHORITY_SCHEMA_VERSION
+                    ),
+                    "entries": kept,
+                    # Old-reader compatibility bridge (signed).
+                    "record": legacy_payload,
+                    "signature": legacy_sig,
+                },
                 sort_keys=True,
             ),
             encoding="utf-8",
@@ -620,59 +777,46 @@ def valid_operator_presence(
     *,
     now_unix: Optional[float] = None,
 ) -> bool:
-    """Return ``True`` iff a valid, HMAC-signed, unexpired
-    presence marker exists for ``(repo_root, branch)``. NEVER
-    raises. Missing file / missing secret / malformed JSON / bad
-    signature / expired TTL / repo mismatch / branch mismatch all
-    → ``False`` (fail closed — the commit then resolves to
-    AUTONOMOUS and the sovereignty gate decides)."""
+    """Return ``True`` iff a valid, HMAC-signed, unexpired presence
+    entry exists for the committing ``(repo_root, branch)`` — the
+    exact-branch entry OR a whole-repo (blank-branch) entry.
+    Multi-entry: other branches'/repos' entries are independent
+    and never cause a false negative here. Fail-closed on missing
+    file / secret / malformed JSON / bad signature / expiry / repo
+    mismatch. NEVER raises."""
     target = presence_file_path()
-    try:
-        if not target.exists():
-            return False
-        raw = json.loads(target.read_text(encoding="utf-8"))
-    except Exception:  # noqa: BLE001
-        return False
-    if not isinstance(raw, dict):
-        return False
-    record = raw.get("record")
-    signature = raw.get("signature")
-    if not isinstance(record, dict) or not isinstance(signature, str):
-        return False
-    if record.get("kind") != "operator_presence":
-        return False
     secret = _read_secret()
     if not secret:
-        return False
-    try:
-        issued = float(record.get("issued_at_unix", 0.0))
-        ttl = int(record.get("ttl_s", 0))
-    except (TypeError, ValueError):
-        return False
-    rec_repo = str(record.get("repo_root_sha256", ""))
-    rec_branch = str(record.get("branch", ""))
-    payload = _presence_signed_payload(
-        issued, ttl, rec_repo, rec_branch,
-        str(record.get("operator_label", "")),
-    )
-    if not _verify(payload, signature, secret):
-        return False
-    now = float(now_unix) if now_unix is not None else time.time()
-    if ttl <= 0 or now >= issued + float(ttl):
         return False
     try:
         fp = repo_root_fingerprint(Path(repo_root))
     except Exception:  # noqa: BLE001
         return False
-    if rec_repo and rec_repo != fp:
+    now = float(now_unix) if now_unix is not None else time.time()
+    store = _load_presence_store(target)
+    entries = store.get("entries", {})
+    if not isinstance(entries, dict):
         return False
-    cur_branch = str(branch or "").strip()
-    # An empty marker branch == operator armed the whole repo this
-    # session (branch-agnostic presence). A non-empty marker branch
-    # must match the committing branch.
-    if rec_branch and cur_branch and rec_branch != cur_branch:
-        return False
-    return True
+    norm_branch = str(branch or "").strip()
+    # Candidate keys: exact (repo, branch) + whole-repo (repo, "").
+    for key in (
+        _presence_entry_key(fp, norm_branch),
+        _presence_entry_key(fp, ""),
+    ):
+        if key in entries and _presence_entry_valid(
+            entries[key],
+            repo_fp=fp, branch=norm_branch, now=now, secret=secret,
+        ):
+            return True
+    # Defensive: also scan any entry (covers legacy-migrated single
+    # record whose synthesized key used a possibly-empty repo fp).
+    for entry in entries.values():
+        if _presence_entry_valid(
+            entry,
+            repo_fp=fp, branch=norm_branch, now=now, secret=secret,
+        ):
+            return True
+    return False
 
 
 # ===========================================================================

--- a/tests/governance/test_commit_repl_and_archive.py
+++ b/tests/governance/test_commit_repl_and_archive.py
@@ -1,0 +1,215 @@
+"""Slice 3 #1+#2 spine — /commit REPL + CommitAuthorityArchive.
+
+Pins:
+  * commit_repl auto-discovery contract (verb basename rule,
+    dispatch_commit_command, ok/text/matched, NEVER raises,
+    matched=False fall-through)
+  * /commit grant refuses empty-branch whole-repo; defaults
+    --branch to current; status/recent/help/revoke/enable
+  * archive: closed c-N ring, monotonic refs, drop-oldest,
+    master-gated default-FALSE, durable flock ledger, recent()
+  * AST pins: repl naming-cage (file→verb→dispatcher), archive
+    authority-asymmetry + closed taxonomy + canonical flock,
+    no `or "ide"` regression anywhere in the new modules
+"""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import commit_repl as cr
+from backend.core.ouroboros.governance import (
+    commit_authority_archive as ca,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_ARCHIVE_PATH",
+        str(tmp_path / "archive.jsonl"),
+    )
+    ca.reset_default_archive_for_tests()
+    yield
+    ca.reset_default_archive_for_tests()
+
+
+# --------------------------------------------------------------------------
+# commit_repl auto-discovery contract
+# --------------------------------------------------------------------------
+
+
+def test_non_commit_line_falls_through():
+    r = cr.dispatch_commit_command("/mode status")
+    assert r.matched is False and r.ok is False
+
+
+def test_bare_and_help_match():
+    assert cr.dispatch_commit_command("/commit").matched is True
+    h = cr.dispatch_commit_command("/commit help")
+    assert h.ok and "Operator Commit Authority" in h.text
+
+
+def test_unknown_subcommand():
+    r = cr.dispatch_commit_command("/commit frobnicate")
+    assert r.matched is True and r.ok is False
+    assert "unknown subcommand" in r.text
+
+
+def test_status_never_raises_and_reports():
+    r = cr.dispatch_commit_command("/commit status")
+    assert r.matched is True
+    assert "master_enabled" in r.text or "unavailable" in r.text
+
+
+def test_grant_refuses_empty_branch(monkeypatch):
+    # Force branch resolution to fail → must refuse, not issue a
+    # whole-repo grant.
+    monkeypatch.setattr(cr, "_current_branch", lambda _r: "")
+    r = cr.dispatch_commit_command("/commit grant")
+    assert r.ok is False
+    assert "Refusing an empty whole-repo grant" in r.text
+
+
+def test_grant_bad_minutes(monkeypatch):
+    monkeypatch.setattr(cr, "_current_branch", lambda _r: "feat")
+    r = cr.dispatch_commit_command("/commit grant --minutes abc")
+    assert r.ok is False and "bad --minutes" in r.text
+
+
+def test_revoke_requires_target():
+    r = cr.dispatch_commit_command("/commit revoke")
+    assert r.ok is False and "--id" in r.text
+
+
+def test_parse_error_is_graceful():
+    r = cr.dispatch_commit_command('/commit grant --label "unterminated')
+    assert r.matched is True and r.ok is False
+    assert "parse error" in r.text
+
+
+# --------------------------------------------------------------------------
+# CommitAuthorityArchive
+# --------------------------------------------------------------------------
+
+
+def test_archive_master_off_is_noop(monkeypatch):
+    monkeypatch.delenv(ca.MASTER_FLAG_ENV_VAR, raising=False)
+    assert ca.record(kind="grant_issue", detail={"x": 1}) is None
+    assert ca.recent(10) == []
+
+
+def test_archive_records_cN_monotonic(monkeypatch, tmp_path):
+    monkeypatch.setenv(ca.MASTER_FLAG_ENV_VAR, "true")
+    r1 = ca.record(kind="grant_issue", detail={"grant_id": "g1"})
+    r2 = ca.record(kind="revoke", detail={"all": True})
+    assert r1.ref == "c-1" and r2.ref == "c-2"
+    rec = ca.recent(10)
+    assert [x["ref"] for x in rec] == ["c-1", "c-2"]
+    assert rec[0]["kind"] == "grant_issue"
+    # Durable ledger written via canonical flock primitive.
+    led = Path(tmp_path / "archive.jsonl")
+    assert led.exists()
+    lines = [json.loads(x) for x in led.read_text().splitlines() if x]
+    assert {l["ref"] for l in lines} == {"c-1", "c-2"}
+
+
+def test_archive_unknown_kind_skipped(monkeypatch):
+    monkeypatch.setenv(ca.MASTER_FLAG_ENV_VAR, "true")
+    assert ca.record(kind="not_a_kind", detail={}) is None
+    assert ca.recent(10) == []
+
+
+def test_archive_drop_oldest(monkeypatch):
+    monkeypatch.setenv(ca.MASTER_FLAG_ENV_VAR, "true")
+    arch = ca.BoundedCommitAuthorityArchive(capacity=2)
+    arch.record(kind="grant_issue", detail={})
+    arch.record(kind="revoke", detail={})
+    arch.record(kind="consume", detail={})
+    refs = [r["ref"] for r in arch.recent(10)]
+    assert refs == ["c-2", "c-3"]  # c-1 evicted, refs never reused
+    assert arch.lookup("c-1") is None
+
+
+def test_archive_closed_taxonomy():
+    assert {k.value for k in ca.CommitAuthorityEventKind} == {
+        "grant_issue", "revoke", "verify_verdict",
+        "consume", "bypass_suspected", "enable",
+    }
+
+
+def test_record_roundtrip_frozen():
+    monkeypatch_env = ca.CommitAuthorityRecord(
+        ref="c-9", kind="enable", detail={"label": "x"},
+        inserted_at=1.0,
+    )
+    d = monkeypatch_env.to_dict()
+    assert d["ref"] == "c-9" and d["kind"] == "enable"
+    with pytest.raises(Exception):
+        monkeypatch_env.ref = "c-10"  # frozen
+
+
+# --------------------------------------------------------------------------
+# AST pins
+# --------------------------------------------------------------------------
+
+
+def test_ast_pin_repl_naming_cage():
+    src = Path(cr.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    # file commit_repl.py → verb /commit → dispatch_commit_command
+    assert any(
+        isinstance(n, ast.FunctionDef)
+        and n.name == "dispatch_commit_command"
+        for n in ast.walk(tree)
+    ), "naming-cage: dispatch_commit_command must exist"
+    assert '"/commit"' in src or "'/commit'" in src
+    # authority asymmetry — no decision-side imports
+    for bad in (
+        "orchestrator", "iron_gate", "candidate_generator",
+        "change_engine", "semantic_guardian", "urgency_router",
+    ):
+        for n in ast.walk(tree):
+            if isinstance(n, ast.ImportFrom):
+                assert bad not in (n.module or ""), (
+                    f"commit_repl must not import {bad}"
+                )
+
+
+def test_ast_pin_archive_invariant_self_validates():
+    invs = ca.register_shipped_invariants()
+    assert len(invs) == 1
+    src = Path(ca.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    assert invs[0].validate(tree, src) == ()
+
+
+def test_ast_pin_no_hardcoded_ide_default_regression():
+    # Slice 3 modules must not reintroduce the `or "ide"` bug.
+    for mod in (cr, ca):
+        src = Path(mod.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.BoolOp) and isinstance(
+                node.op, ast.Or
+            ):
+                for v in node.values:
+                    assert not (
+                        isinstance(v, ast.Constant)
+                        and v.value == "ide"
+                    ), f"{mod.__name__}: `or \"ide\"` regression"
+
+
+def test_register_flags_two_seeds():
+    seen = []
+
+    class _R:
+        def register(self, s):
+            seen.append(s.name)
+
+    assert ca.register_flags(_R()) == 2
+    assert ca.MASTER_FLAG_ENV_VAR in seen
+    assert ca.ARCHIVE_SIZE_ENV_VAR in seen

--- a/tests/governance/test_ledger_sovereignty.py
+++ b/tests/governance/test_ledger_sovereignty.py
@@ -52,8 +52,18 @@ _MASTER_FLAG = "JARVIS_LEDGER_SOVEREIGNTY_ENABLED"
 
 
 @pytest.fixture(autouse=True)
-def _isolate(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+def _isolate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path,
+) -> Iterator[None]:
     monkeypatch.delenv(_MASTER_FLAG, raising=False)
+    # master_enabled() is now `env OR persistent_master signed
+    # record`. These tests assert the ENV-only contract, so the
+    # persistent input must be isolated (point its dir at an empty
+    # tmp path → no record → env-only behavior). The persistent
+    # path has its own suite: test_persistent_master.py.
+    monkeypatch.setenv(
+        "JARVIS_PERSISTENT_MASTER_DIR", str(tmp_path / "pm_iso"),
+    )
     yield
 
 

--- a/tests/governance/test_oca_channel_resolution.py
+++ b/tests/governance/test_oca_channel_resolution.py
@@ -112,7 +112,11 @@ def test_presence_tamper_invalidates():
     pf = oca.presence_file_path()
     import json
     blob = json.loads(pf.read_text())
-    blob["record"]["operator_label"] = "attacker"  # forge a field
+    # Multi-entry store: forge a field inside an entry's record —
+    # the recomputed-from-trusted-fields HMAC must reject it.
+    entries = blob["entries"]
+    k = next(iter(entries))
+    entries[k]["record"]["operator_label"] = "attacker"
     pf.write_text(json.dumps(blob))
     assert oca.valid_operator_presence(REPO, "br", now_unix=1100.0) is False
 

--- a/tests/governance/test_oca_slice3_autocommit_postcommit.py
+++ b/tests/governance/test_oca_slice3_autocommit_postcommit.py
@@ -1,0 +1,255 @@
+"""Slice 3 #4+#5 spine — AutoCommitter unified gate + post-commit hook.
+
+#4 pins (AST — the behavioral path needs a full git repo + many
+preconditions; the load-bearing invariants are structural):
+  * auto_committer composes operator_commit_authority.verify_pre_commit
+  * the channel is the LITERAL "autonomous" (never env, never
+    resolve_commit_channel — an autonomous committer must not be
+    env-trickable into an operator channel)
+  * verdict → skipped_reason mapping present
+
+#5 behavioral + AST:
+  * verified-marker write / read-and-clear (one-shot)
+  * cmd_hook_post_commit: no marker → bypass_suspected archived;
+    fresh marker + oneshot → consume; OCA-off → no-op; always
+    returns 0; NEVER raises
+  * post-commit subcommand wired into the parser + dispatch
+"""
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import auto_committer as ac
+from backend.core.ouroboros.governance import commit_authority_cli as cli
+from backend.core.ouroboros.governance import (
+    commit_authority_archive as ca,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_ARCHIVE_PATH",
+        str(tmp_path / "a.jsonl"),
+    )
+    monkeypatch.setenv(ca.MASTER_FLAG_ENV_VAR, "true")
+    ca.reset_default_archive_for_tests()
+    yield
+    ca.reset_default_archive_for_tests()
+
+
+# --------------------------------------------------------------------------
+# #4 — AutoCommitter unified gate (AST invariants)
+# --------------------------------------------------------------------------
+
+
+def test_ast_autocommitter_uses_literal_autonomous_channel():
+    src = Path(ac.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    # Find the verify_pre_commit call; its CommitAuthorityContext
+    # must pass channel="autonomous" as a literal Constant.
+    found = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "CommitAuthorityContext"
+        ):
+            for kw in node.keywords:
+                if kw.arg == "channel":
+                    assert isinstance(kw.value, ast.Constant), (
+                        "channel must be a literal, not computed "
+                        "(no env / resolve_commit_channel)"
+                    )
+                    assert kw.value.value == "autonomous"
+                    found = True
+    assert found, "auto_committer must call verify_pre_commit via " \
+        "CommitAuthorityContext(channel='autonomous', ...)"
+    assert "verify_pre_commit" in src
+    # The autonomous committer must NEVER *call* resolve_commit_channel
+    # nor read JARVIS_COMMIT_CHANNEL (a doc-comment naming the
+    # constraint is fine — we assert on AST usage, not substrings).
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            assert node.attr != "resolve_commit_channel", (
+                "auto_committer must not call resolve_commit_channel"
+            )
+        if isinstance(node, ast.Name):
+            assert node.id != "resolve_commit_channel"
+        if isinstance(node, ast.Constant) and isinstance(
+            node.value, str
+        ):
+            assert node.value != "JARVIS_COMMIT_CHANNEL", (
+                "auto_committer must not read JARVIS_COMMIT_CHANNEL"
+            )
+
+
+def test_ast_autocommitter_maps_verdict_to_skipped_reason():
+    src = Path(ac.__file__).read_text(encoding="utf-8")
+    assert "ledger_sovereignty_refused" in src
+    assert "governance_manifest_drift" in src
+    assert "skipped_reason" in src
+
+
+# --------------------------------------------------------------------------
+# #5 — verified-marker primitives
+# --------------------------------------------------------------------------
+
+
+def test_marker_write_read_clear_oneshot(tmp_path):
+    root = str(tmp_path)
+    cli._write_verified_marker(
+        root, channel="ide", matched_grant_id="g-1",
+    )
+    p = cli._verified_marker_path(root)
+    assert p.exists()
+    m = cli._read_and_clear_verified_marker(root)
+    assert m is not None
+    assert m["channel"] == "ide" and m["matched_grant_id"] == "g-1"
+    assert "ts" in m
+    # One-shot: gone after read.
+    assert not p.exists()
+    assert cli._read_and_clear_verified_marker(root) is None
+
+
+def test_marker_corrupt_returns_none(tmp_path):
+    root = str(tmp_path)
+    p = cli._verified_marker_path(root)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not json")
+    assert cli._read_and_clear_verified_marker(root) is None
+
+
+# --------------------------------------------------------------------------
+# #5 — cmd_hook_post_commit behavior (real tmp repo)
+# --------------------------------------------------------------------------
+
+
+def _git_repo(p: Path) -> Path:
+    p.mkdir(parents=True, exist_ok=True)
+    for a in (
+        ["init", "-q"], ["config", "user.email", "t@t.t"],
+        ["config", "user.name", "t"],
+    ):
+        subprocess.run(["git", *a], cwd=p, check=True,
+                        capture_output=True)
+    (p / "f.txt").write_text("x")
+    subprocess.run(["git", "add", "f.txt"], cwd=p, check=True,
+                    capture_output=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=p,
+                    check=True, capture_output=True)
+    return p
+
+
+def test_post_commit_oca_off_is_noop(tmp_path, monkeypatch):
+    repo = _git_repo(tmp_path / "r")
+    monkeypatch.setattr(cli, "_repo_root", lambda: str(repo))
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.operator_commit_authority"
+        ".master_enabled", lambda: False,
+    )
+    assert cli.cmd_hook_post_commit() == 0
+    assert ca.recent(10) == []  # nothing observed when OCA off
+
+
+def test_post_commit_bypass_suspected_when_no_marker(
+    tmp_path, monkeypatch,
+):
+    repo = _git_repo(tmp_path / "r")
+    monkeypatch.setattr(cli, "_repo_root", lambda: str(repo))
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.operator_commit_authority"
+        ".master_enabled", lambda: True,
+    )
+    rc = cli.cmd_hook_post_commit()
+    assert rc == 0  # post-commit never fails the commit
+    rec = ca.recent(10)
+    assert len(rec) == 1
+    assert rec[0]["kind"] == "bypass_suspected"
+    assert "absent" in rec[0]["detail"]["reason"]
+
+
+def test_post_commit_fresh_marker_no_bypass(tmp_path, monkeypatch):
+    repo = _git_repo(tmp_path / "r")
+    monkeypatch.setattr(cli, "_repo_root", lambda: str(repo))
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.operator_commit_authority"
+        ".master_enabled", lambda: True,
+    )
+    cli._write_verified_marker(
+        str(repo), channel="ide", matched_grant_id="g-9",
+    )
+    assert cli.cmd_hook_post_commit() == 0
+    # No bypass archived; marker consumed (one-shot).
+    kinds = [r["kind"] for r in ca.recent(10)]
+    assert "bypass_suspected" not in kinds
+    assert cli._read_and_clear_verified_marker(str(repo)) is None
+
+
+def test_post_commit_oneshot_consume(tmp_path, monkeypatch):
+    repo = _git_repo(tmp_path / "r")
+    monkeypatch.setattr(cli, "_repo_root", lambda: str(repo))
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.operator_commit_authority"
+        ".master_enabled", lambda: True,
+    )
+    consumed = []
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.operator_commit_authority"
+        ".consume_grant", lambda gid, **kw: consumed.append(gid),
+    )
+    monkeypatch.setenv("JARVIS_COMMIT_GRANT_ONESHOT", "true")
+    cli._write_verified_marker(
+        str(repo), channel="ide", matched_grant_id="g-42",
+    )
+    assert cli.cmd_hook_post_commit() == 0
+    assert consumed == ["g-42"]
+    assert "consume" in [r["kind"] for r in ca.recent(10)]
+
+
+def test_post_commit_default_no_consume(tmp_path, monkeypatch):
+    repo = _git_repo(tmp_path / "r")
+    monkeypatch.setattr(cli, "_repo_root", lambda: str(repo))
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.operator_commit_authority"
+        ".master_enabled", lambda: True,
+    )
+    consumed = []
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.operator_commit_authority"
+        ".consume_grant", lambda gid, **kw: consumed.append(gid),
+    )
+    monkeypatch.delenv("JARVIS_COMMIT_GRANT_ONESHOT", raising=False)
+    cli._write_verified_marker(
+        str(repo), channel="ide", matched_grant_id="g-1",
+    )
+    assert cli.cmd_hook_post_commit() == 0
+    # Default: session-lived grants — NOT consumed per commit.
+    assert consumed == []
+
+
+def test_ast_post_commit_wired():
+    src = Path(cli.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    assert any(
+        isinstance(n, ast.FunctionDef)
+        and n.name == "cmd_hook_post_commit"
+        for n in ast.walk(tree)
+    )
+    # parser accepts post-commit + main dispatches it
+    p = cli.build_parser()
+    ns = p.parse_args(["hook", "post-commit"])
+    assert ns.cmd == "hook" and ns.phase == "post-commit"
+    assert '"post-commit"' in src and "post-commit" in src
+
+
+def test_post_commit_never_raises(monkeypatch):
+    # Even with a totally broken repo root, returns 0, no raise.
+    monkeypatch.setattr(cli, "_repo_root", lambda: "/nonexistent/zz")
+    assert cli.cmd_hook_post_commit() == 0

--- a/tests/governance/test_oca_slice3_observability.py
+++ b/tests/governance/test_oca_slice3_observability.py
@@ -1,0 +1,137 @@
+"""Slice 3 #3 spine — SSE commit_authority_decision_recorded +
+GET /observability/commit-authority wiring.
+
+Pins:
+  * EVENT_TYPE_COMMIT_AUTHORITY_DECISION_RECORDED value +
+    membership in _VALID_EVENT_TYPES (the stream-pin convention)
+  * publish_commit_authority_decision: disabled / non-mapping /
+    happy / never-raises (mirrors publish_git_index_anomaly)
+  * archive.record() emits the SSE (single source — every parked
+    record auto-publishes), fail-silent
+  * AST pin: the GET route is registered in
+    IDEObservabilityRouter.register_routes; the handler composes
+    commit_authority_archive.recent (no parallel projection)
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    ide_observability_stream as stream,
+)
+from backend.core.ouroboros.governance import (
+    commit_authority_archive as ca,
+)
+from backend.core.ouroboros.governance import ide_observability as ido
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_ARCHIVE_PATH",
+        str(tmp_path / "a.jsonl"),
+    )
+    ca.reset_default_archive_for_tests()
+    yield
+    ca.reset_default_archive_for_tests()
+
+
+def test_event_type_value_and_membership():
+    assert (
+        stream.EVENT_TYPE_COMMIT_AUTHORITY_DECISION_RECORDED
+        == "commit_authority_decision_recorded"
+    )
+    assert (
+        stream.EVENT_TYPE_COMMIT_AUTHORITY_DECISION_RECORDED
+        in stream._VALID_EVENT_TYPES
+    )
+
+
+def test_publish_disabled_returns_none(monkeypatch):
+    monkeypatch.setattr(stream, "stream_enabled", lambda: False)
+    assert stream.publish_commit_authority_decision({"ref": "c-1"}) is None
+
+
+def test_publish_non_mapping_none(monkeypatch):
+    monkeypatch.setattr(stream, "stream_enabled", lambda: True)
+    assert stream.publish_commit_authority_decision("x") is None  # type: ignore[arg-type]
+
+
+def test_publish_happy(monkeypatch):
+    monkeypatch.setattr(stream, "stream_enabled", lambda: True)
+    seen = {}
+
+    class _B:
+        def publish(self, et, oid, pl):
+            seen.update(et=et, oid=oid, pl=pl)
+            return "evt-9"
+
+    monkeypatch.setattr(stream, "get_default_broker", lambda: _B())
+    out = stream.publish_commit_authority_decision(
+        {"ref": "c-1", "kind": "grant_issue"}
+    )
+    assert out == "evt-9"
+    assert seen["et"] == "commit_authority_decision_recorded"
+    assert seen["oid"] == "commit_authority"
+    assert seen["pl"]["kind"] == "grant_issue"
+
+
+def test_publish_never_raises(monkeypatch):
+    monkeypatch.setattr(stream, "stream_enabled", lambda: True)
+
+    def _boom():
+        raise RuntimeError("x")
+
+    monkeypatch.setattr(stream, "get_default_broker", _boom)
+    assert stream.publish_commit_authority_decision({"ref": "c"}) is None
+
+
+def test_archive_record_emits_sse(monkeypatch):
+    monkeypatch.setenv(ca.MASTER_FLAG_ENV_VAR, "true")
+    fired = []
+    monkeypatch.setattr(
+        stream, "publish_commit_authority_decision",
+        lambda d: fired.append(d),
+    )
+    rec = ca.record(kind="grant_issue", detail={"grant_id": "g1"})
+    assert rec is not None
+    assert len(fired) == 1
+    assert fired[0]["ref"] == rec.ref
+    assert fired[0]["kind"] == "grant_issue"
+
+
+def test_archive_sse_failure_never_breaks_ring(monkeypatch):
+    monkeypatch.setenv(ca.MASTER_FLAG_ENV_VAR, "true")
+
+    def _boom(_d):
+        raise RuntimeError("sse exploded")
+
+    monkeypatch.setattr(
+        stream, "publish_commit_authority_decision", _boom,
+    )
+    # Ring insert must still succeed despite the SSE seam blowing up.
+    rec = ca.record(kind="revoke", detail={})
+    assert rec is not None and rec.ref == "c-1"
+
+
+def test_ast_pin_route_registered_and_composes_recent():
+    src = Path(ido.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    # route string present
+    assert '"/observability/commit-authority"' in src
+    # handler exists + composes commit_authority_archive.recent
+    fn = next(
+        (
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef)
+            and n.name == "_handle_commit_authority"
+        ),
+        None,
+    )
+    assert fn is not None, "_handle_commit_authority missing"
+    body = ast.unparse(fn)
+    assert "commit_authority_archive" in body
+    assert "recent" in body


### PR DESCRIPTION
Builds on the merged OCA presence-resolution (#42212) + persistent_master (#42240).

## Slice 3 (#1–#6)
- **#1 commit_repl.py** — auto-discovered `/commit` (grant/revoke/status/enable/recent/help); composes only `operator_commit_authority` + archive; `/commit grant` branch-defaulted, refuses empty whole-repo; one `/commit grant` = full ritual.
- **#2 commit_authority_archive.py** — bounded `c-N` ring (mirrors `permission_decision_archive`) + durable JSONL via canonical `flock_append_line`; closed 6-value taxonomy; master default-FALSE; 2 flag seeds + AST pin.
- **#3** — SSE `commit_authority_decision_recorded` (mirrors `publish_git_index_anomaly`) + `GET /observability/commit-authority`; archive emits SSE on every record (single source, fail-silent).
- **#4 auto_committer** — unified `verify_pre_commit(channel="autonomous")` before staging (LITERAL channel, never env/resolve — AST-pinned); verdict→`skipped_reason`; DISABLED→fall-through.
- **#5** — `commit_authority_cli hook post-commit` + additive signed verified-marker; absent/stale → `bypass_suspected` (detect-only, NO auto-revert); fresh + `JARVIS_COMMIT_GRANT_ONESHOT` → `consume_grant` (default OFF preserves session grants); always exit 0.
- **#6** — flag seeds auto-discovered; `test_ledger_sovereignty` fixture isolates the persistent-master input.

## Multi-entry presence — production lockout root-fix
A Cursor SCM commit was refused `denied_sovereignty`. Root cause: presence was a **single global last-write-wins file** — a branch-bound `/commit grant` clobbered the operator's presence; their commit on another branch → no presence → AUTONOMOUS → DENIED. Fixed: presence is now a **multi-entry store keyed by (repo_fingerprint, branch)** (composes existing `_sign`/`_verify`/fingerprint — zero new crypto). mint adds/refreshes only its entry; prunes expired; drop-oldest bounded. `valid_operator_presence` matches exact-branch OR whole-repo entry. Concurrent actors/branches/repos coexist — no clobber. Includes a **signed transitional dual-format bridge** (top-level whole-repo `record` for pre-realignment readers; entries-first for new readers).

## Tests
252 green across all OCA + sovereignty + guard + Slice 3 suites (test_commit_repl_and_archive 18, test_oca_slice3_observability 8, test_oca_slice3_autocommit_postcommit 11, + updated multi-entry tamper test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OCA Slice 3: a `/commit` REPL, an observability archive + SSE + endpoint, a unified autonomous commit gate, and a post-commit verified-marker to detect bypasses. Fixes production lockouts by switching operator presence to a multi-entry store keyed by repo and branch.

- **New Features**
  - `/commit` REPL (status/grant/revoke/enable/recent/help). `grant` defaults to the current branch and refuses empty whole-repo. Composes `operator_commit_authority` and `commit_authority_archive`. Auto-discovered.
  - `commit_authority_archive`: bounded in-memory `c-N` ring + durable JSONL via `flock_append_line`. Closed event taxonomy. Master flag `JARVIS_COMMIT_AUTHORITY_ARCHIVE_ENABLED`. Emits SSE `commit_authority_decision_recorded` and adds GET `/observability/commit-authority?limit=N`.
  - AutoCommitter runs `verify_pre_commit` with channel "autonomous" (literal). Archives `verify_verdict` and maps denials to `skipped_reason`. `commit_authority_cli` adds a post-commit hook + verified-marker; archives `bypass_suspected`; optional grant consume under `JARVIS_COMMIT_GRANT_ONESHOT`; always exits 0.

- **Bug Fixes**
  - Presence is now multi-entry, keyed by `(repo_fingerprint, branch)`. Mints/refreshes only its entry, prunes expired, and drop-oldest bounded by `JARVIS_COMMIT_PRESENCE_MAX_ENTRIES`. `valid_operator_presence` matches exact-branch or whole-repo. Includes a signed dual-format bridge for legacy readers.

<sup>Written for commit 280e86a9a9075d7ff6671797e410603edcc5e4b3. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/42396?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

