### PR TITLE
feat(governance): OCA Slice 4 #2 — structural §1 closure (harness sovereignty AST pin)

### DIFF
--- a/backend/core/ouroboros/governance/harness_sovereignty_pin.py
+++ b/backend/core/ouroboros/governance/harness_sovereignty_pin.py
@@ -1,0 +1,229 @@
+"""HarnessSovereigntyPin — Slice 4 #2: structural §1 closure.
+
+The §1 root cause (documented verbatim in :mod:`ledger_sovereignty`'s
+header): ``HarnessConfig.repo_path`` defaults to ``Path(".")`` and
+``AutoCommitter`` accepts any ``repo_root``; during scheduled soaks
+that resolved to the operator's live checkout → 4× franken-commits
+racing operator work.
+
+Runtime defenses already exist and are tested:
+  * ``AutoCommitter.commit()`` invokes the OCA autonomous gate
+    (``verify_pre_commit(channel="autonomous")``) **before** any
+    staging — Slice 3 #4.
+  * ``AutoCommitter._assert_commit_target_sovereign`` composes
+    ``ledger_sovereignty.assert_ledger_sovereignty`` — Slice 2.
+  * The harness boot runs ``_boot_ledger_sovereignty_workspace``
+    which stamps an owned worktree + sets
+    ``JARVIS_AUTO_COMMIT_WORKSPACE`` so commits never land on the
+    ``.``-defaulted operator main.
+
+This module makes those defenses **structurally un-removable**: a
+refactor that drops the pre-staging sovereignty gate, or removes
+the harness's owned-workspace boot phase, fails the auto-discovered
+shipped-code invariant (CI / meta-validation red) — it never
+silently regresses to the §1 franken-commit failure mode.
+
+Pure AST analysis. Composes the canonical
+:mod:`meta.shipped_code_invariants` registry (auto-discovered by
+``module_discovery`` via the ``register_shipped_invariants`` name —
+zero registry edits). NEVER raises; ImportError-tolerant.
+"""
+from __future__ import annotations
+
+import ast as _ast
+import logging
+from typing import Tuple
+
+logger = logging.getLogger("Ouroboros.HarnessSovereigntyPin")
+
+
+HARNESS_SOVEREIGNTY_PIN_SCHEMA_VERSION: str = (
+    "harness_sovereignty_pin.v1"
+)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 — AutoCommitter gates BEFORE staging
+# ---------------------------------------------------------------------------
+
+
+def _validate_autocommitter_pre_stage_gate(
+    tree: "_ast.Module", source: str,
+) -> Tuple[str, ...]:
+    """``commit()`` MUST invoke the OCA autonomous verdict gate
+    (``verify_pre_commit``) AND the sovereignty assert
+    (``_assert_commit_target_sovereign``) BEFORE the first
+    git-staging call (``git add`` / a ``"add"`` subprocess arg).
+
+    Source-order is load-bearing: a guard that runs *after*
+    staging is no guard at all (the franken-commit already
+    touched the index). We assert the gate Call nodes precede the
+    first staging token by line number within ``commit``.
+    """
+    violations = []
+    commit_fn = None
+    for node in _ast.walk(tree):
+        if (
+            isinstance(node, _ast.AsyncFunctionDef)
+            and node.name == "commit"
+        ):
+            commit_fn = node
+            break
+    if commit_fn is None:
+        return (
+            "auto_committer: async def commit() not found — the "
+            "§1 pin cannot verify the pre-stage gate ordering",
+        )
+
+    gate_line = None        # first verify_pre_commit / sovereignty assert
+    stage_line = None       # first 'add' staging token
+    for n in _ast.walk(commit_fn):
+        ln = getattr(n, "lineno", None)
+        if ln is None:
+            continue
+        if isinstance(n, _ast.Call):
+            fn = n.func
+            name = (
+                fn.attr if isinstance(fn, _ast.Attribute)
+                else fn.id if isinstance(fn, _ast.Name) else ""
+            )
+            if name in (
+                "verify_pre_commit",
+                "_assert_commit_target_sovereign",
+            ):
+                gate_line = ln if gate_line is None else min(
+                    gate_line, ln,
+                )
+        if isinstance(n, _ast.Constant) and n.value == "add":
+            stage_line = ln if stage_line is None else min(
+                stage_line, ln,
+            )
+
+    if gate_line is None:
+        violations.append(
+            "auto_committer.commit() does NOT compose the "
+            "pre-stage sovereignty/OCA gate (verify_pre_commit / "
+            "_assert_commit_target_sovereign) — §1 regression"
+        )
+    if (
+        gate_line is not None
+        and stage_line is not None
+        and gate_line >= stage_line
+    ):
+        violations.append(
+            f"auto_committer.commit(): sovereignty/OCA gate "
+            f"(line {gate_line}) does NOT precede the first git "
+            f"staging token (line {stage_line}) — a post-stage "
+            f"guard cannot prevent a franken-commit"
+        )
+    # Defense-in-depth: the literal autonomous channel must be the
+    # one fed to the gate (never env/resolve — Slice 3 #4).
+    if '"autonomous"' not in source and "'autonomous'" not in source:
+        violations.append(
+            "auto_committer must gate with the LITERAL "
+            "channel='autonomous' (never env / resolve_commit_"
+            "channel for the autonomous committer)"
+        )
+    return tuple(violations)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — harness boot stamps an owned workspace
+# ---------------------------------------------------------------------------
+
+
+def _validate_harness_owned_workspace_boot(
+    tree: "_ast.Module", source: str,
+) -> Tuple[str, ...]:
+    """The harness boot sequence MUST invoke
+    ``_boot_ledger_sovereignty_workspace`` — the phase that stamps
+    a ``ledger_sovereignty`` owned worktree and sets
+    ``JARVIS_AUTO_COMMIT_WORKSPACE`` so AutoCommitter never commits
+    into the ``Path(".")``-defaulted operator main. Removing that
+    phase silently reopens §1.
+    """
+    violations = []
+    called = any(
+        (
+            isinstance(n, _ast.Call)
+            and isinstance(n.func, _ast.Attribute)
+            and n.func.attr == "_boot_ledger_sovereignty_workspace"
+        )
+        for n in _ast.walk(tree)
+    )
+    defined = any(
+        isinstance(n, _ast.AsyncFunctionDef)
+        and n.name == "_boot_ledger_sovereignty_workspace"
+        for n in _ast.walk(tree)
+    )
+    if not defined:
+        violations.append(
+            "harness: _boot_ledger_sovereignty_workspace method "
+            "removed — §1 owned-workspace stamping gone"
+        )
+    if not called:
+        violations.append(
+            "harness: _boot_ledger_sovereignty_workspace is never "
+            "invoked in the boot sequence — AutoCommitter would "
+            "commit into the Path('.')-defaulted operator main "
+            "(the §1 franken-commit root cause)"
+        )
+    # The env seam name is the single indirection point — pin it
+    # so a rename can't silently sever harness↔AutoCommitter.
+    if "JARVIS_AUTO_COMMIT_WORKSPACE" not in source:
+        violations.append(
+            "harness no longer references "
+            "JARVIS_AUTO_COMMIT_WORKSPACE — the owned-worktree "
+            "commit-cwd seam is severed"
+        )
+    return tuple(violations)
+
+
+# ---------------------------------------------------------------------------
+# Auto-discovered registration
+# ---------------------------------------------------------------------------
+
+
+def register_shipped_invariants() -> list:
+    try:
+        from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+            ShippedCodeInvariant,
+        )
+    except ImportError:
+        return []
+
+    ac = "backend/core/ouroboros/governance/auto_committer.py"
+    hn = "backend/core/ouroboros/battle_test/harness.py"
+    return [
+        ShippedCodeInvariant(
+            invariant_name="autocommitter_pre_stage_sovereignty_gate",
+            target_file=ac,
+            description=(
+                "AutoCommitter.commit() composes the OCA "
+                "autonomous gate + sovereignty assert BEFORE the "
+                "first git staging token (source-order pinned); "
+                "the autonomous channel is the literal string. "
+                "Closes §1 structurally — a post-stage or absent "
+                "guard fails CI."
+            ),
+            validate=_validate_autocommitter_pre_stage_gate,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="harness_owned_workspace_boot_phase",
+            target_file=hn,
+            description=(
+                "The harness boot sequence invokes "
+                "_boot_ledger_sovereignty_workspace and references "
+                "JARVIS_AUTO_COMMIT_WORKSPACE — AutoCommitter "
+                "never commits into the Path('.')-defaulted "
+                "operator main (§1 root cause)."
+            ),
+            validate=_validate_harness_owned_workspace_boot,
+        ),
+    ]
+
+
+__all__ = [
+    "HARNESS_SOVEREIGNTY_PIN_SCHEMA_VERSION",
+    "register_shipped_invariants",
+]

--- a/tests/governance/test_harness_sovereignty_pin.py
+++ b/tests/governance/test_harness_sovereignty_pin.py
@@ -1,0 +1,136 @@
+"""Slice 4 #2 spine — structural §1 closure pin.
+
+Proves BOTH directions:
+  * GREEN on the real shipped auto_committer.py + harness.py today
+    (the §1 runtime defenses are structurally present)
+  * RED on synthetic regressions (gate-after-staging / no-gate /
+    missing-literal-autonomous / harness-without-owned-workspace)
+    — a pin that cannot fail is worthless
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from backend.core.ouroboros.governance import (
+    harness_sovereignty_pin as pin,
+)
+from backend.core.ouroboros.governance import auto_committer as ac
+
+import backend.core.ouroboros.battle_test.harness as hn
+
+
+def _invs():
+    invs = pin.register_shipped_invariants()
+    return {i.invariant_name: i for i in invs}
+
+
+def test_registers_two_invariants():
+    invs = pin.register_shipped_invariants()
+    assert {i.invariant_name for i in invs} == {
+        "autocommitter_pre_stage_sovereignty_gate",
+        "harness_owned_workspace_boot_phase",
+    }
+
+
+def test_green_on_real_autocommitter_source():
+    src = Path(ac.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    inv = _invs()["autocommitter_pre_stage_sovereignty_gate"]
+    assert inv.validate(tree, src) == (), (
+        "§1 pre-stage gate must be structurally present today"
+    )
+
+
+def test_green_on_real_harness_source():
+    src = Path(hn.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    inv = _invs()["harness_owned_workspace_boot_phase"]
+    assert inv.validate(tree, src) == (), (
+        "harness owned-workspace boot phase must be present today"
+    )
+
+
+# --------------------------------------------------------------------------
+# Negative: the pin MUST catch §1 regressions
+# --------------------------------------------------------------------------
+
+
+def test_catches_gate_after_staging():
+    bad = (
+        "async def commit(self):\n"
+        "    await self._run(['git', 'add', '.'])\n"
+        "    verify_pre_commit(ctx)  # too late — index already touched\n"
+        "    x = 'autonomous'\n"
+    )
+    inv = _invs()["autocommitter_pre_stage_sovereignty_gate"]
+    v = inv.validate(ast.parse(bad), bad)
+    assert any("does NOT precede" in s for s in v), v
+
+
+def test_catches_missing_gate():
+    bad = (
+        "async def commit(self):\n"
+        "    await self._run(['git', 'add', '.'])\n"
+        "    x = 'autonomous'\n"
+    )
+    inv = _invs()["autocommitter_pre_stage_sovereignty_gate"]
+    v = inv.validate(ast.parse(bad), bad)
+    assert any("does NOT compose" in s for s in v), v
+
+
+def test_catches_missing_literal_autonomous():
+    bad = (
+        "async def commit(self):\n"
+        "    verify_pre_commit(ctx)\n"
+        "    await self._run(['git', 'add', '.'])\n"
+    )
+    inv = _invs()["autocommitter_pre_stage_sovereignty_gate"]
+    v = inv.validate(ast.parse(bad), bad)
+    assert any("LITERAL channel='autonomous'" in s for s in v), v
+
+
+def test_catches_missing_commit_fn():
+    bad = "def something_else():\n    pass\n"
+    inv = _invs()["autocommitter_pre_stage_sovereignty_gate"]
+    v = inv.validate(ast.parse(bad), bad)
+    assert any("commit() not found" in s for s in v), v
+
+
+def test_catches_harness_without_owned_workspace_call():
+    bad = (
+        "class H:\n"
+        "    async def _boot_ledger_sovereignty_workspace(self):\n"
+        "        pass\n"
+        "    async def run(self):\n"
+        "        await self.boot_oracle()\n"
+        "JARVIS_AUTO_COMMIT_WORKSPACE = 'x'\n"
+    )
+    inv = _invs()["harness_owned_workspace_boot_phase"]
+    v = inv.validate(ast.parse(bad), bad)
+    assert any("never invoked" in s for s in v), v
+
+
+def test_catches_harness_without_env_seam():
+    bad = (
+        "class H:\n"
+        "    async def _boot_ledger_sovereignty_workspace(self):\n"
+        "        pass\n"
+        "    async def run(self):\n"
+        "        await self._boot_ledger_sovereignty_workspace()\n"
+    )
+    inv = _invs()["harness_owned_workspace_boot_phase"]
+    v = inv.validate(ast.parse(bad), bad)
+    assert any("JARVIS_AUTO_COMMIT_WORKSPACE" in s for s in v), v
+
+
+def test_catches_harness_method_removed():
+    bad = (
+        "class H:\n"
+        "    async def run(self):\n"
+        "        pass\n"
+        "JARVIS_AUTO_COMMIT_WORKSPACE = 'x'\n"
+    )
+    inv = _invs()["harness_owned_workspace_boot_phase"]
+    v = inv.validate(ast.parse(bad), bad)
+    assert any("method removed" in s for s in v), v


### PR DESCRIPTION
Slice 4 part #2 (the self-contained, highest-safety-value piece). Part #1 (commit-authority Unix-socket daemon) follows as a focused next PR — a local IPC auth endpoint is a new attack surface that warrants concentrated security attention rather than a rushed tail-end.

## What
`harness_sovereignty_pin.py` — two auto-discovered shipped-code invariants making the §1 franken-commit defenses **structurally un-removable** (composes `meta.shipped_code_invariants`; zero registry edits; pure AST; NEVER raises):

1. **autocommitter_pre_stage_sovereignty_gate** — `AutoCommitter.commit()` composes `verify_pre_commit` / `_assert_commit_target_sovereign` **before** the first git staging token (source-order pinned — a post-stage guard can't stop a franken-commit) + the literal `channel="autonomous"`.
2. **harness_owned_workspace_boot_phase** — boot invokes `_boot_ledger_sovereignty_workspace` and references `JARVIS_AUTO_COMMIT_WORKSPACE` (the owned-worktree commit-cwd seam).

The §1 root cause (`HarnessConfig.repo_path` defaults to `Path(".")` → AutoCommitter committed into the operator's live checkout) had runtime defenses (Slices 2 + 3 #4); this pin guarantees a refactor can never silently reopen it — CI goes red.

## Tests
`test_harness_sovereignty_pin.py` (10): GREEN on real shipped `auto_committer.py` + `harness.py` today (defenses present) **and** RED on 7 synthetic regressions (gate-after-staging / no-gate / missing-literal / no-commit-fn / harness-no-call / no-env-seam / method-removed). A pin that cannot fail is worthless — this provably fails on the §1 regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AST-enforced invariants that pin our sovereignty checks and harness boot so the §1 franken-commit defense can’t be removed by refactor. CI now fails if `AutoCommitter.commit()` gates after staging or if the harness drops the owned-workspace seam.

- **New Features**
  - Adds `backend/core/ouroboros/governance/harness_sovereignty_pin.py`, auto-registered via `register_shipped_invariants` in `meta.shipped_code_invariants`.
  - `autocommitter_pre_stage_sovereignty_gate`: `commit()` must call `verify_pre_commit` and `_assert_commit_target_sovereign` before any staging token, with literal `channel="autonomous"`.
  - `harness_owned_workspace_boot_phase`: harness must call `_boot_ledger_sovereignty_workspace` and reference `JARVIS_AUTO_COMMIT_WORKSPACE`.
  - Tests validate current sources and fail on 7 targeted regressions.

<sup>Written for commit 6d9f0d962f485bc867f07532a74e75913f423900. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/42956?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

