### PR TITLE
docs(governance): OCA arc-closing operator runbook + read-only verification smoke

### DIFF
--- a/docs/operations/operator_commit_authority.md
+++ b/docs/operations/operator_commit_authority.md
@@ -1,0 +1,114 @@
+# Operator Commit Authority (OCA) — Operator Runbook
+
+**Status:** OCA arc (Slices 1→4) + `git_index_guard` + `persistent_master` +
+`harness_sovereignty_pin` — **CLOSED** (all merged to `main`).
+One page. If something blocks a Cursor commit, this page is the fix.
+
+---
+
+## TL;DR daily ritual
+
+Before a Cursor Source-Control commit session, establish operator presence
+**once** (any one of these — all compose the same substrate, no shell token):
+
+| Surface | Command | Use when |
+|---|---|---|
+| Daemon (one-click) | start `commit_authority_daemon` (master ON) → IDE/helper sends `{"verb":"refresh","repo_root":"<repo>","branch":"<b>"}` | IDE has no shell env |
+| REPL | `/commit grant --branch <branch>` | inside Serpent REPL |
+| CLI | `python3 -m backend.core.ouroboros.governance.commit_authority_cli grant --channel ide --branch <branch> --minutes 480` | terminal |
+| Whole-repo arming | `… commit_authority_cli enable` | one marker valid on **every** branch this session |
+
+`enable` mints a **whole-repo** presence entry (matches any branch); a
+branch `grant` mints a branch entry. Multi-entry presence means these
+**coexist** — a branch grant never clobbers your whole-repo arming, and
+no other repo/agent clobbers you. Default presence TTL 900 s
+(`JARVIS_COMMIT_PRESENCE_TTL_S`); the rituals above use 8 h.
+
+## After PRs land
+
+```
+git checkout main && git fetch origin && git merge --ff-only origin/main
+```
+
+If you work on a named branch, fast-forward it to `main` so it runs the
+current OCA/sovereignty/presence code (the enforcement only protects code
+that *is* the new code).
+
+## Keep Cursor background Agents STOPPED on the operator main checkout
+
+A Cursor background Agent autonomously `git commit`s WIP / duplicate work
+onto whatever branch is checked out (observed multiple times — verbose
+LLM-prose messages + `[integrity-verified:` trailer). The structural
+defenses (sovereignty + presence + multi-entry + daemon) are the durable
+system, but **operator policy is still required**: do not run background
+Agents on this repo root. The daemon gives one-click grant refresh so you
+never need an Agent for the commit ritual.
+
+## What the refusal messages mean
+
+| Message | Meaning | Fix |
+|---|---|---|
+| `denied_sovereignty — autonomous commit into non-owned tree` | Channel resolved to **autonomous** (no valid operator-presence marker for this repo+branch) and `ledger_sovereignty` is ON for an unmarked tree (the operator main). This is the gate working — it's how a rogue Agent commit is refused. | Run the daily ritual (presence + grant) for the branch you're committing on. |
+| `denied_no_grant` | Presence is valid (channel resolved **ide**) but there is no matching unexpired signed grant for this repo/branch/channel. | `/commit grant --branch <branch>` (or daemon `refresh`). |
+| `IRON GATE — Commit blocked: <verdict> …` | The pre-commit dispatcher's operator-facing wrapper around any non-authorized verdict. The `<verdict>` token is one of the above — read it and apply the matching fix. | Per the verdict token. |
+| `Missing operator cryptographic authorization` | Legacy path: OCA master is OFF and no shell token. | Graduate OCA (`commit_authority_cli enable`) — do not reintroduce the shell-token hack. |
+
+`denied_no_grant` is the *good* failure (presence proven, just needs a
+grant — one command). `denied_sovereignty` means presence is absent —
+re-run the ritual.
+
+## Recover from Agent branch contamination
+
+If a branch diverged because a background Agent autonomously committed
+work already on `main` (verbose-LLM message + `[integrity-verified:`
+trailer, byte-identical to `main`):
+
+1. **Confirm zero unique content** (do **not** blind-force):
+   ```
+   git fetch origin
+   git diff --stat origin/main <branch>          # only main-newer commits should differ
+   git diff --quiet origin/main <rogue-sha> -- <files>   # exit 0 == byte-identical
+   ```
+2. Only if every rogue file is byte-identical to `origin/main` and the
+   branch has **no unique content**:
+   ```
+   git checkout <branch> && git reset --hard origin/main
+   ```
+   This is verified-equivalent cleanup, not blind force. If anything is
+   unique, **merge** `main` instead and review the unique commit.
+3. Re-establish presence (ritual) — `reset --hard` doesn't touch
+   `~/.jarvis/`, but confirm with the verification script below.
+
+Never `reset --hard` without step 1 proving equivalence.
+
+## Verify
+
+```
+python3 scripts/verify_oca.py
+```
+
+Read-only smoke (no grants issued, no commits, uses throwaway tmp repos):
+hook authorizes with the active ritual + no shell token; a presence-less
+forged-`ide` context → `denied_sovereignty`; daemon `status` → authorized.
+All three PASS = the system is healthy and your ritual is active.
+
+## Key env flags (FlagRegistry-seeded)
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED` | (env) | OCA master (also via signed persistent-enable record — GUI-reachable) |
+| `JARVIS_LEDGER_SOVEREIGNTY_ENABLED` | false (env) OR signed `persistent_master` record | Sovereignty gate; ON ⇒ unowned-tree autonomous commits refused |
+| `JARVIS_COMMIT_PRESENCE_TTL_S` | 900 | Operator-presence marker lifetime |
+| `JARVIS_COMMIT_PRESENCE_MAX_ENTRIES` | 64 | Multi-entry presence store bound (drop-oldest) |
+| `JARVIS_COMMIT_AUTHORITY_DAEMON_ENABLED` | false | Unix-socket daemon master |
+| `JARVIS_COMMIT_AUTHORITY_SOCK` | `~/.jarvis/commit_authority/daemon.sock` | Daemon socket (0o600 in 0o700 dir) |
+| `JARVIS_COMMIT_AUTHORITY_DAEMON_TIMEOUT_S` | 5.0 | Daemon per-connection timeout |
+| `JARVIS_COMMIT_AUTHORITY_ARCHIVE_ENABLED` | false | OCA decision ring + JSONL ledger |
+| `JARVIS_GIT_INDEX_GUARD_ENABLED` | false | Missing-`.git/index` advisory rebuild guard |
+
+## Observability
+
+- REPL: `/commit status | recent`
+- HTTP: `GET /observability/commit-authority[?limit=N]`
+- SSE: `commit_authority_decision_recorded`, `git_index_anomaly`
+- Archive ring refs: `c-N` (`/commit recent`)

--- a/scripts/verify_oca.py
+++ b/scripts/verify_oca.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""OCA health smoke — READ-ONLY.
+
+Run: ``python3 scripts/verify_oca.py``
+
+Verifies the closed OCA arc (Slices 1→4 + git_index_guard +
+persistent_master + harness_sovereignty_pin) is healthy and the
+operator's ritual is active. THREE checks:
+
+  1. pre-commit hook authorizes with NO shell token (your active
+     presence+grant ritual is working).
+  2. a presence-less, forged ``ide`` context → ``denied_sovereignty``
+     (the rogue-Agent defense bites).
+  3. the Unix-socket daemon answers ``status`` → authorized.
+
+Read-only: issues NO grants, makes NO commits, never writes to the
+operator's ``~/.jarvis`` presence/grant state. Checks 2 & 3 use
+throwaway tmp repos / a tmp socket. Exit 0 iff all three PASS.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+REPO = subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"],
+    capture_output=True, text=True,
+).stdout.strip() or os.getcwd()
+
+# Self-bootstrap: make `backend` importable when run as
+# `python3 scripts/verify_oca.py` (no PYTHONPATH needed — the
+# operator shouldn't have to know about it).
+if REPO not in sys.path:
+    sys.path.insert(0, REPO)
+
+
+def _ok(name: str, passed: bool, detail: str = "") -> bool:
+    mark = "PASS" if passed else "FAIL"
+    print(f"  [{mark}] {name}{(' — ' + detail) if detail else ''}")
+    return passed
+
+
+def check_hook_authorizes() -> bool:
+    """1. cli hook pre-commit, NO token → exit 0 (ritual active).
+    Read-only: the dispatcher authorizes + chains the integrity
+    check; with nothing staged it mutates nothing."""
+    env = dict(os.environ)
+    env.pop("JARVIS_AUTHORIZE_COMMIT_TOKEN", None)
+    try:
+        r = subprocess.run(
+            [sys.executable, "-m",
+             "backend.core.ouroboros.governance.commit_authority_cli",
+             "hook", "pre-commit"],
+            cwd=REPO, env={**env, "PYTHONPATH": REPO},
+            capture_output=True, text=True, timeout=30,
+        )
+        return _ok(
+            "hook authorizes with grant, no shell token",
+            r.returncode == 0,
+            f"exit={r.returncode}"
+            + ("" if r.returncode == 0
+               else " — run the ritual: `commit_authority_cli "
+                    "grant --channel ide --branch <branch>`"),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _ok("hook authorizes", False, f"error {exc!r}")
+
+
+def check_forged_ide_denied() -> bool:
+    """2. presence-less forged ``ide`` + sovereignty ON →
+    ``denied_sovereignty``. Deterministic: sovereignty master is
+    forced ON *in this process only* (no file/record writes); a
+    throwaway tmp git repo has no presence."""
+    try:
+        from backend.core.ouroboros.governance import (
+            operator_commit_authority as oca,
+        )
+        os.environ["JARVIS_LEDGER_SOVEREIGNTY_ENABLED"] = "true"
+        d = tempfile.mkdtemp()
+        r = Path(d) / "x"
+        r.mkdir()
+        for a in (["init", "-q"], ["config", "user.email", "t@t"],
+                  ["config", "user.name", "t"]):
+            subprocess.run(["git", *a], cwd=r, capture_output=True)
+        (r / "f").write_text("x")
+        subprocess.run(["git", "add", "f"], cwd=r,
+                        capture_output=True)
+        subprocess.run(["git", "commit", "-qm", "s"], cwd=r,
+                        capture_output=True)
+        ch = oca.resolve_commit_channel(r, "main", env_channel="ide")
+        v = oca.verify_pre_commit(
+            oca.CommitAuthorityContext(
+                channel=ch.value, repo_root=str(r), branch="main",
+            )
+        )
+        import shutil
+        shutil.rmtree(d, ignore_errors=True)
+        passed = (
+            ch.value == "autonomous"
+            and v.verdict.value == "denied_sovereignty"
+        )
+        return _ok(
+            "forged ide + no presence → denied_sovereignty",
+            passed, f"channel={ch.value} verdict={v.verdict.value}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _ok("forged ide denied", False, f"error {exc!r}")
+
+
+def check_daemon_status() -> bool:
+    """3. daemon ``status`` (read-only verb) → authorized for the
+    real repo. Tmp socket, started + shut down here."""
+    try:
+        from backend.core.ouroboros.governance import (
+            commit_authority_daemon as dmn,
+        )
+        sock = f"/tmp/ocad_verify_{os.getpid()}_{uuid.uuid4().hex[:8]}.sock"
+        os.environ["JARVIS_COMMIT_AUTHORITY_DAEMON_ENABLED"] = "true"
+        os.environ["JARVIS_COMMIT_AUTHORITY_SOCK"] = sock
+        branch = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=REPO, capture_output=True, text=True,
+        ).stdout.strip() or "main"
+
+        async def _run():
+            s = await dmn.serve()
+            if s is None:
+                return None
+            try:
+                rd, wr = await asyncio.open_unix_connection(sock)
+                wr.write((json.dumps({
+                    "verb": "status", "repo_root": REPO,
+                    "branch": branch,
+                }) + "\n").encode())
+                await wr.drain()
+                raw = await asyncio.wait_for(rd.readline(), 5)
+                wr.close()
+                return json.loads(raw.decode())
+            finally:
+                await dmn.shutdown(s)
+
+        resp = asyncio.run(_run())
+        if resp is None:
+            return _ok("daemon status", False, "serve() returned None")
+        passed = (
+            resp.get("ok") is True
+            and resp.get("dry_verdict") == "authorized"
+        )
+        return _ok(
+            "daemon status → authorized", passed,
+            f"presence={resp.get('presence_valid')} "
+            f"verdict={resp.get('dry_verdict')}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _ok("daemon status", False, f"error {exc!r}")
+
+
+def main() -> int:
+    print(f"OCA health smoke (read-only) — repo={REPO}")
+    results = [
+        check_hook_authorizes(),
+        check_forged_ide_denied(),
+        check_daemon_status(),
+    ]
+    n_pass = sum(1 for x in results if x)
+    print(f"\n{n_pass}/{len(results)} checks passed.")
+    if n_pass != len(results):
+        print(
+            "Not all green — see docs/operations/"
+            "operator_commit_authority.md for the matching fix."
+        )
+        return 1
+    print("OCA arc healthy; operator ritual active.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Arc-closing artifacts only (docs + read-only tooling; zero behavior change). OCA Slices 1→4 + git_index_guard + persistent_master + harness_sovereignty_pin: CLOSED.

- `docs/operations/operator_commit_authority.md` — one-page runbook (daily ritual, merge-main, Agents-stopped policy, refusal-message decode + fixes, verified-equivalent contamination recovery, flag table, observability).
- `scripts/verify_oca.py` — read-only 3-check smoke (hook-authorizes-no-token / forged-ide→denied_sovereignty / daemon status→authorized). Self-bootstraps sys.path; issues no grants, makes no commits. **3/3 PASS** verified.

Daemon's 3 FlagRegistry seeds already registered (no dup work). PR #42956 + #42975 already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-page Operator Commit Authority runbook and a read-only health smoke script to help operators verify authorization and sovereignty are working. No behavior changes; docs and tooling only.

- **New Features**
  - `docs/operations/operator_commit_authority.md`: Daily ritual, when to merge `main`, keep background agents stopped, how to fix `denied_sovereignty` vs `denied_no_grant`, safe recovery from agent-committed duplicates, key `JARVIS_*` flags, and observability endpoints.
  - `scripts/verify_oca.py`: Read-only smoke that checks (1) pre-commit authorizes with no shell token, (2) forged `ide` without presence → `denied_sovereignty`, (3) daemon `status` → authorized; self-bootstraps `sys.path`, uses temp repos/sockets, writes nothing to `~/.jarvis`.

<sup>Written for commit 758f4d0aa8790d502a135bb840bacb02f6114970. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/42976?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

