### PR TITLE
docs(swe-bench-pro): Phase-0 soak runbook + spend-gated launcher

### DIFF
--- a/docs/operations/swe_bench_pro_soak_runbook.md
+++ b/docs/operations/swe_bench_pro_soak_runbook.md
@@ -1,0 +1,129 @@
+# SWE-Bench-Pro Soak Runbook — putting Ouroboros+Venom to the test
+
+**This is a RUN/soak, not a build.** The `swe_bench_pro/` package
+(Phases A→F) is CLOSED & soak-ready. No new modules pre-soak. A
+soak-surfaced bug is a *separate triage arc* (precedent:
+loader-enumeration-union / clone-template-bypass). Operator approves
+spend per phase. No pre-result euphoria: methodology-validation ≠
+capability measurement; claims move only on the rendered
+`report_card` + `results.jsonl` + session `debug.log`.
+
+Driver: `scripts/swe_bench_pro_soak.sh` (composes
+`scripts/ouroboros_battle_test.py` — it does **not** reimplement the
+cost/wall/idle/headless caps; it passes them).
+
+---
+
+## Pre-soak operator checklist (run before ANY spend)
+
+1. `git fetch`; on `main@9a4baff258` or later; **clean index** (no
+   "7856 staged deletions" illusion — if seen, `git reset` first;
+   see `operator_commit_authority.md`).
+2. OCA presence+grant active for this branch:
+   `python3 -m backend.core.ouroboros.governance.commit_authority_cli grant --channel ide --branch "$(git branch --show-current)" --minutes 120`
+   (or daemon `refresh`). **Cursor background Agents STOPPED on the
+   repo root** (cursor-agent-git-ban rule is advisory only).
+3. Phase-3 only: `huggingface-cli whoami` succeeds OR `HF_TOKEN`
+   exported (HF dataset access for real instance picks).
+4. Phase-3 only: `unset JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH`
+   (real run reads the HF source, not the wiring fixture).
+
+---
+
+## Phase 0 — rails (no spend)
+
+Restricted-env knobs are **mandatory** (sandbox blocks `.git/config`
+under the repo root): cache + worktree base point at `$TMPDIR`.
+Caps are **mandatory** (retry storms defeat `--idle-timeout`, so a
+hard wall-clock ceiling is required):
+
+| Cap | Value | Why |
+|---|---|---|
+| `--cost-cap` | `2.00` | operator-bound USD ceiling |
+| `--max-wall-seconds` | `2400` | hard wall ceiling (retry-storm-proof) |
+| `--idle-timeout` | `1800` | per-op liveness |
+| `--headless` | (set) | agent-conducted; no interactive REPL |
+
+Masters stay default-FALSE globally; the soak bundle is **single
+session, never persisted**. Only the flags listed per phase are set.
+
+## Phase 1 — wiring dry-run (~$0.01–0.10, operator runs locally)
+
+```
+bash scripts/swe_bench_pro_soak.sh phase1
+```
+
+Runs the checked-in fixture `jarvis__harness-smoke-001`
+(octocat/Hello-World, trivially-passing `test_patch`) end-to-end:
+loader → prepare → envelope → intake → evaluator → scorer →
+result_store → report_card.
+
+**Proof of wiring (the gate to proceed):**
+- `.jarvis/swe_bench_pro/results.jsonl` has a row with
+  `envelope.source == "swe_bench_pro"` and a terminal outcome.
+- session `debug.log` (`.ouroboros/sessions/<id>/`) contains
+  `swe_bench_pro` injection lines.
+
+**STOP and report. Do not proceed to Phase 3 without explicit
+"Phase 3 go" + confirmed instance ids.**
+
+## Phase 2 — selection (no spend)
+
+`geometric_sampler` (composed, not reinvented) proposes stratified
+**known-good** (small, single-file-ish → expected RESOLVED) and
+**known-hard** (multi-file/architectural → expected UNRESOLVED)
+candidates from HF metadata. 5–10 ids presented with rationale
+(file count / patch size / repo). **Operator picks the final set.**
+No instance ids are hardcoded in repo code or this runbook — the
+rubric sanity floor requires *both poles*, but the specific ids are
+operator-selected from the dataset.
+
+## Phase 3 — soak (ONLY after "Phase 3 go" + confirmed ids)
+
+```
+SWEBP_INSTANCE_IDS="<id1>,<id2>,..." \
+  bash scripts/swe_bench_pro_soak.sh phase3 --confirm-spend
+```
+
+The script **refuses** to run Phase 3 without both `SWEBP_INSTANCE_IDS`
+and `--confirm-spend` (anti-accidental-spend). Default **Path B**
+(harness-inject + full autonomous GENERATE→APPLY→VERIFY — the truer
+"put O+V to the test"); `SWEBP_PATH=A` selects the cheaper
+`parallel_evaluate` rubric-only path. `SCORE_REJECT_TEST_MODS=true`
+(cheat-detection on) + R2 rubric soak profile (serial / high-urgency
+/ sensor-throttled / adaptive). One session, $2.00 cap, **no auto
+re-spend**.
+
+## Phase 4 — verdict ($0)
+
+Source of truth: `.jarvis/swe_bench_pro/results.jsonl` (Phase D
+store) + session `debug.log`. **`summary.json` has a known
+`attempted` counter bug — do not trust it alone.** Render
+`report_card.build_report_card(store)` → Markdown/JSON:
+per-instance ScoreOutcome + EvaluationOutcome + pass_rate (excludes
+SKIPPED).
+
+- **Provider EXHAUSTION / timeout → INCONCLUSIVE in the report
+  card, NEVER FAIL.** Infra failure ≠ capability failure (no
+  euphoria in either direction).
+
+## Phase 5 — graduation ($0)
+
+Rubric sanity floor **MET iff: ≥1 known-good → RESOLVED AND ≥1
+known-hard → UNRESOLVED**. Floor MET validates rubric+wiring, **not
+capability** (capability = resolve-rate over a representative
+sample — a separate, larger, later effort). Document the evidence
+row for PRD §41.6. **Masters stay default-FALSE; the soak never
+auto-graduates a flag** — flipping `JARVIS_SWE_BENCH_PRO_ENABLED`
+toward default-TRUE is a separate, operator-authorized graduation
+PR.
+
+---
+
+## Non-goals
+
+No new `swe_bench_pro` modules pre-soak. No duplication of
+`battle_test` caps (composed via flags). No conflation with OCA /
+sovereignty / git-index (CLOSED — untouched unless soak triage
+finds a regression). No Phase-3 run without operator spend
+approval. No capability claim from a 5–10-problem rubric-floor run.

--- a/scripts/swe_bench_pro_soak.sh
+++ b/scripts/swe_bench_pro_soak.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# =============================================================================
+# SWE-Bench-Pro soak launcher — composes scripts/ouroboros_battle_test.py.
+#
+# This script does NOT reimplement the cost/wall/idle/headless caps; it
+# PASSES them to the existing battle-test harness. It only sets the
+# swe_bench_pro env bundle around that harness. No new modules, no
+# duplicated logic, no hardcoded instance ids or absolute paths.
+#
+# Usage:
+#   bash scripts/swe_bench_pro_soak.sh phase1
+#       Wiring dry-run on the checked-in fixture (~$0.01-0.10).
+#
+#   SWEBP_INSTANCE_IDS="id1,id2" \
+#     bash scripts/swe_bench_pro_soak.sh phase3 --confirm-spend
+#       Real soak. REFUSES to run without BOTH SWEBP_INSTANCE_IDS and
+#       --confirm-spend (anti-accidental-spend). $2.00 cap, one session.
+#
+# See docs/operations/swe_bench_pro_soak_runbook.md for the full plan
+# and the pre-soak operator checklist.
+# =============================================================================
+set -euo pipefail
+
+REPO="$(git rev-parse --show-toplevel)"
+cd "$REPO"
+
+# ---- Phase 0 rails (MANDATORY; composed via battle-test flags) -------------
+COST_CAP="2.00"          # operator-bound USD ceiling
+MAX_WALL="2400"          # hard wall-clock seconds (retry-storm-proof)
+IDLE_TIMEOUT="1800"      # per-op liveness seconds
+# Restricted-env: sandbox blocks .git/config under the repo root, so the
+# benchmark repo cache + worktrees live under TMPDIR (NOT the repo).
+SWEBP_CACHE="${TMPDIR:-/tmp}/swebp_cache"
+SWEBP_WT="${TMPDIR:-/tmp}/swebp_wt"
+mkdir -p "$SWEBP_CACHE" "$SWEBP_WT"
+
+PHASE="${1:-}"; shift || true
+CONFIRM_SPEND="no"
+for a in "$@"; do [ "$a" = "--confirm-spend" ] && CONFIRM_SPEND="yes"; done
+
+# Common swe_bench_pro env (default-FALSE everywhere EXCEPT what each
+# phase explicitly sets below). Documented per flag.
+export JARVIS_SWE_BENCH_PRO_REPO_CACHE_PATH="$SWEBP_CACHE"     # benchmark clones (TMPDIR)
+export JARVIS_SWE_BENCH_PRO_WORKTREE_BASE_PATH="$SWEBP_WT"     # per-problem worktrees (TMPDIR)
+
+_battle() {
+  # Single composition point. The harness owns the caps.
+  echo ">>> python3 scripts/ouroboros_battle_test.py \
+--cost-cap $COST_CAP --max-wall-seconds $MAX_WALL \
+--idle-timeout $IDLE_TIMEOUT --headless -v"
+  python3 scripts/ouroboros_battle_test.py \
+    --cost-cap "$COST_CAP" --max-wall-seconds "$MAX_WALL" \
+    --idle-timeout "$IDLE_TIMEOUT" --headless -v
+}
+
+case "$PHASE" in
+  phase1)
+    # Wiring-validation: checked-in fixture, trivially-passing test_patch.
+    export JARVIS_SWE_BENCH_PRO_ENABLED=true                    # Phase A master (session-only)
+    export JARVIS_SWE_BENCH_PRO_HARNESS_INJECT_ENABLED=true     # boot auto-inject (session-only)
+    export JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH="tests/fixtures/swe_bench_pro/problems.jsonl"
+    export JARVIS_SWE_BENCH_PRO_INJECT_COUNT=1                  # first-1 from the fixture
+    echo "=== Phase 1 — wiring dry-run (~\$0.01-0.10) ==="
+    echo "fixture : $JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH"
+    echo "cache   : $SWEBP_CACHE"
+    echo "worktree: $SWEBP_WT"
+    echo "caps    : cost=$COST_CAP wall=$MAX_WALL idle=$IDLE_TIMEOUT headless"
+    _battle
+    echo
+    echo "=== Phase 1 proof (verdict source — NOT stdout) ==="
+    echo "  jq -c 'select(.envelope.source==\"swe_bench_pro\")' .jarvis/swe_bench_pro/results.jsonl 2>/dev/null | tail -3"
+    echo "  grep -i swe_bench_pro .ouroboros/sessions/*/debug.log | tail -5"
+    echo "STOP. Report results. Do NOT run phase3 without operator 'Phase 3 go' + ids."
+    ;;
+
+  phase3)
+    if [ "${SWEBP_INSTANCE_IDS:-}" = "" ] || [ "$CONFIRM_SPEND" != "yes" ]; then
+      echo "REFUSING phase3: requires BOTH" >&2
+      echo "  SWEBP_INSTANCE_IDS=\"id1,id2,...\"   (operator-selected; none hardcoded)" >&2
+      echo "  --confirm-spend                      (explicit spend acknowledgement)" >&2
+      echo "This is the anti-accidental-spend gate. See the runbook." >&2
+      exit 2
+    fi
+    export JARVIS_SWE_BENCH_PRO_ENABLED=true                    # Phase A master (session-only)
+    export JARVIS_SWE_BENCH_PRO_HARNESS_INJECT_ENABLED=true     # Path B: full autonomous loop
+    export JARVIS_SWE_BENCH_PRO_INJECT_INSTANCE_IDS="$SWEBP_INSTANCE_IDS"  # operator-chosen
+    export JARVIS_SWE_BENCH_PRO_SCORE_REJECT_TEST_MODS=true     # cheat-detection ON (rubric integrity)
+    # Path A (cheaper, rubric-only) opt-in; Path B is default.
+    if [ "${SWEBP_PATH:-B}" = "A" ]; then
+      export JARVIS_SWE_BENCH_PRO_HARNESS_INJECT_ENABLED=false
+      export JARVIS_SWE_BENCH_PRO_PARALLEL_CONCURRENCY="${SWEBP_CONCURRENCY:-2}"
+      echo "(Path A: parallel_evaluate rubric-only, concurrency=${SWEBP_CONCURRENCY:-2})"
+    fi
+    # R2 rubric soak profile — serial / high-urgency / sensor-throttled
+    # / adaptive (see project_rubric_soak_profile memory). Compose, do
+    # not reinvent; these are the documented controlled-soak knobs.
+    export OUROBOROS_BATTLE_HEADLESS=1
+    echo "=== Phase 3 — soak (\$$COST_CAP cap, one session, no re-spend) ==="
+    echo "ids   : $SWEBP_INSTANCE_IDS"
+    echo "path  : ${SWEBP_PATH:-B}  (B = harness-inject full GENERATE->APPLY->VERIFY)"
+    echo "rubric: SCORE_REJECT_TEST_MODS=true"
+    [ -n "${JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH:-}" ] && \
+      echo "WARNING: JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH still set — unset it for the HF source (checklist #4)" >&2
+    _battle
+    echo
+    echo "=== Phase 4 verdict (run after the session ends) ==="
+    echo "  python3 -c \"from backend.core.ouroboros.governance.swe_bench_pro.report_card import build_report_card, render_markdown; from backend.core.ouroboros.governance.swe_bench_pro.result_store import get_default_store; print(render_markdown(build_report_card(get_default_store())))\""
+    echo "  + cross-check .ouroboros/sessions/*/debug.log (NOT summary.json alone)"
+    echo "EXHAUSTION/timeout => INCONCLUSIVE, never FAIL. No capability claims."
+    ;;
+
+  *)
+    echo "usage: bash scripts/swe_bench_pro_soak.sh {phase1|phase3 --confirm-spend}" >&2
+    echo "phase2 (selection) and phase4/5 (verdict/graduation) are no-spend," >&2
+    echo "operator+assistant steps — see docs/operations/swe_bench_pro_soak_runbook.md" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Phase-0 SWE-Bench-Pro soak deliverables (no LLM spend, no behavior change, no new modules). `swe_bench_pro_soak_runbook.md` (5-phase + pre-soak checklist; verdict from results.jsonl/debug.log; EXHAUSTION→INCONCLUSIVE; rubric floor; masters stay default-FALSE) + `swe_bench_pro_soak.sh` (composes ouroboros_battle_test.py — caps passed not reimplemented; TMPDIR-safe; phase3 hard-refuses without SWEBP_INSTANCE_IDS + --confirm-spend, proven in 3 unsafe combos; no hardcoded ids/paths). OCA/sovereignty/git-index/cursor-agent-ban untouched (CLOSED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Phase-0 SWE-Bench-Pro soak runbook and a spend-gated launcher that composes the existing battle test harness. No behavior changes or new `swe_bench_pro` modules; all masters stay default-FALSE.

- **New Features**
  - Runbook (`docs/operations/swe_bench_pro_soak_runbook.md`): 5-phase plan + pre-soak checklist; verdict from `results.jsonl` and session `debug.log` (not `summary.json`); EXHAUSTION → INCONCLUSIVE; rubric floor (≥1 known-good RESOLVED and ≥1 known-hard UNRESOLVED).
  - Launcher (`scripts/swe_bench_pro_soak.sh`): passes caps to `scripts/ouroboros_battle_test.py` (`--cost-cap 2.00`, `--max-wall-seconds 2400`, `--idle-timeout 1800`, `--headless`); TMPDIR-safe repo cache/worktrees; no hardcoded IDs/paths.
  - Spend gate: Phase 3 hard-refuses without both `SWEBP_INSTANCE_IDS` and `--confirm-spend`; default Path B (harness-inject full GENERATE→APPLY→VERIFY), Path A via `SWEBP_PATH=A`; `SCORE_REJECT_TEST_MODS=true`.
  - Usage: `bash scripts/swe_bench_pro_soak.sh phase1` (wiring) and `SWEBP_INSTANCE_IDS="id1,id2" bash scripts/swe_bench_pro_soak.sh phase3 --confirm-spend` (soak).

<sup>Written for commit 6c6b1cb719cd9c8a3824e213412f050662b86ae2. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/42985?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

