### PR TITLE
feat(governance): Zero-Waste S1 — ProviderResponseCache substrate + composable gate (dormant)

### DIFF
--- a/backend/core/ouroboros/governance/provider_response_cache.py
+++ b/backend/core/ouroboros/governance/provider_response_cache.py
@@ -1,0 +1,715 @@
+"""ProviderResponseCache — S1 of the Zero-Waste & Predictive Routing arc.
+
+Stop paying for redundant tokens. A persistent, byte-budgeted,
+repo-state-keyed cache of provider RESPONSE TRAJECTORIES. An exact
+repeat of a request (same assembled prompt + model + route + repo
+state) returns the cached :class:`GenerationResult` **without
+calling the provider — cost $0.00**.
+
+Composition (extends, never duplicates — PRD audit):
+  * :mod:`prompt_cache` — imported as the acknowledged cache-family
+    substrate; its canonical ``PromptCache._make_key`` SHA-256
+    discipline is REUSED for key hashing, and its RLock + monotonic
+    TTL eviction *shape* is mirrored. This module does NOT define a
+    second ``PromptCache`` nor a parallel prompt-text cache; it
+    adds the dimensions ``prompt_cache`` lacks: a RESPONSE value, a
+    **serialized-byte LRU budget** (entry-count is insufficient —
+    trajectories are large), and **repo-state-digest
+    invalidation**.
+  * :func:`cross_process_jsonl.flock_append_line` — the canonical
+    persistence primitive; the on-disk append-log is replayed into
+    the in-mem byte-LRU ring on first use (survives restart).
+
+Correctness posture (load-bearing):
+  * Key = ``SHA-256(prompt || model || route || repo_state_digest)``.
+  * ``repo_state_digest`` = ``git HEAD`` + ``SHA-256(git diff HEAD)``
+    (tracked staged+working). ANY staged/HEAD change re-keys → a
+    real call (no stale-fix application).
+  * **Fail-CLOSED on correctness:** if repo state is undeterminable
+    the digest is a unique per-call nonce → guaranteed miss. We
+    never serve a possibly-stale trajectory when we cannot prove
+    the code is unchanged.
+  * **Fail-OPEN on availability:** any miss / IO / parse / HMAC
+    fault → caller's normal generate path. The cache NEVER raises
+    into the provider and NEVER blocks an op.
+
+Authority asymmetry (AST-pinned): imports stdlib +
+``prompt_cache`` / ``cross_process_jsonl`` ONLY (the
+``GenerationResult`` import is a TYPE_CHECKING/runtime-light dto) —
+never ``orchestrator`` / ``iron_gate`` / ``candidate_generator``.
+
+Master ``JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED`` default **FALSE**
+— off ⇒ every entry point is a no-op and the provider path is
+byte-identical to today. Graduation-gated per the PRD.
+"""
+from __future__ import annotations
+
+import enum
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import threading
+import time
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.ProviderResponseCache")
+
+PROVIDER_RESPONSE_CACHE_SCHEMA_VERSION: str = "provider_response_cache.v1"
+
+_ENV_MASTER = "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED"
+_ENV_MAX_BYTES = "JARVIS_PROVIDER_CACHE_MAX_BYTES"
+_ENV_TTL_S = "JARVIS_PROVIDER_CACHE_TTL_S"
+_ENV_PATH = "JARVIS_PROVIDER_CACHE_PATH"
+
+# 256 MiB in-mem default — 16GB-M1-safe. Clamped.
+_DEFAULT_MAX_BYTES = 268_435_456
+_MIN_MAX_BYTES = 1_048_576           # 1 MiB floor
+_MAX_MAX_BYTES = 4_294_967_296       # 4 GiB ceiling
+_DEFAULT_TTL_S = 86_400.0            # 24h (monotonic, like prompt_cache)
+_DEFAULT_REL_PATH = (".jarvis", "provider_response_cache", "trajectories.jsonl")
+# Bounded replay so a huge on-disk log can't blow boot RAM.
+_MAX_REPLAY_LINES = 50_000
+
+
+def response_cache_enabled() -> bool:
+    """Master switch, default-FALSE (PRD §7). Re-read each call so a
+    flip hot-reverts. NEVER raises."""
+    return os.environ.get(_ENV_MASTER, "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def cache_max_bytes() -> int:
+    raw = os.environ.get(_ENV_MAX_BYTES, "").strip()
+    try:
+        v = int(raw) if raw else _DEFAULT_MAX_BYTES
+    except (TypeError, ValueError):
+        v = _DEFAULT_MAX_BYTES
+    return max(_MIN_MAX_BYTES, min(_MAX_MAX_BYTES, v))
+
+
+def cache_ttl_s() -> float:
+    raw = os.environ.get(_ENV_TTL_S, "").strip()
+    try:
+        v = float(raw) if raw else _DEFAULT_TTL_S
+    except (TypeError, ValueError):
+        v = _DEFAULT_TTL_S
+    return max(1.0, v)
+
+
+def _cache_path() -> Path:
+    raw = os.environ.get(_ENV_PATH, "").strip()
+    if raw:
+        try:
+            return Path(raw).expanduser()
+        except Exception:  # noqa: BLE001
+            pass
+    return Path(*_DEFAULT_REL_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Closed lookup taxonomy
+# ---------------------------------------------------------------------------
+
+
+class CacheLookupOutcome(str, enum.Enum):
+    """Closed taxonomy. ``SEMANTIC_HIT`` is RESERVED for the S1.x
+    semantic tier and is never produced in v1 (exact-only)."""
+
+    EXACT_HIT = "exact_hit"
+    SEMANTIC_HIT = "semantic_hit"            # reserved (S1.x)
+    MISS = "miss"
+    DISABLED = "disabled"
+    INVALIDATED_REPO_CHANGE = "invalidated_repo_change"
+    FAULT_FAIL_OPEN = "fault_fail_open"
+
+
+# ---------------------------------------------------------------------------
+# Repo-state digest (fail-CLOSED on correctness)
+# ---------------------------------------------------------------------------
+
+
+def _run_git(args: List[str], repo_root: Path, timeout_s: float = 5.0):
+    try:
+        return subprocess.run(
+            ["git", *args], cwd=str(repo_root),
+            capture_output=True, text=True, timeout=timeout_s,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def repo_state_digest(repo_root: Path) -> str:
+    """``HEAD`` + ``SHA-256(git diff HEAD)`` (tracked staged+working).
+    On ANY failure to determine state → a unique per-call nonce so
+    the resulting key can NEVER match a prior entry (fail-closed on
+    correctness: a wrong reuse is unacceptable; a miss is safe).
+    NEVER raises."""
+    try:
+        head = _run_git(["rev-parse", "HEAD"], Path(repo_root))
+        diff = _run_git(["diff", "HEAD"], Path(repo_root))
+        if (
+            head is None or head.returncode != 0
+            or diff is None or diff.returncode != 0
+        ):
+            return "UNDETERMINED-" + uuid.uuid4().hex
+        h = (head.stdout or "").strip()
+        d = hashlib.sha256(
+            (diff.stdout or "").encode("utf-8", "replace")
+        ).hexdigest()
+        return f"{h}:{d}"
+    except Exception:  # noqa: BLE001
+        return "UNDETERMINED-" + uuid.uuid4().hex
+
+
+def _prefix_key(prompt: str, model: str, route: str) -> str:
+    """Request identity WITHOUT repo state — composes the canonical
+    ``prompt_cache`` key discipline (no parallel hasher)."""
+    try:
+        from backend.core.ouroboros.governance.prompt_cache import (
+            PromptCache,
+        )
+        return PromptCache._make_key(
+            str(prompt), f"{model}\x00{route}",
+        )
+    except Exception:  # noqa: BLE001
+        # Last-resort stdlib SHA-256 (same algorithm prompt_cache
+        # itself uses); never raise.
+        raw = f"{prompt}\x00{model}\x00{route}"
+        return hashlib.sha256(
+            raw.encode("utf-8", "replace")
+        ).hexdigest()
+
+
+def compute_cache_key(
+    prompt: str, model: str, route: str, repo_root: Path,
+) -> Tuple[str, str]:
+    """Return ``(full_key, prefix_key)``. ``full_key`` binds repo
+    state; ``prefix_key`` lets :func:`lookup` distinguish a
+    code-changed near-miss (INVALIDATED_REPO_CHANGE) from a true
+    MISS. NEVER raises."""
+    pref = _prefix_key(prompt, model, route)
+    digest = repo_state_digest(repo_root)
+    full = hashlib.sha256(
+        f"{pref}\x00{digest}".encode("utf-8", "replace")
+    ).hexdigest()
+    return full, pref
+
+
+# ---------------------------------------------------------------------------
+# Cached trajectory (frozen, lossless roundtrip)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CachedTrajectory:
+    """Serializable projection of a GenerationResult. Stores the
+    load-bearing payload (candidates + the JSON-able trajectory
+    metadata); non-serializable tool objects are dropped (a partial
+    replay of `candidates` is the value — fail-open)."""
+
+    full_key: str
+    prefix_key: str
+    candidates: Tuple[Dict[str, Any], ...]
+    provider_name: str
+    model_id: str
+    is_noop: bool
+    prompt_preloaded_files: Tuple[str, ...]
+    total_input_tokens: int
+    total_output_tokens: int
+    n_bytes: int
+    created_at: float = field(default_factory=time.monotonic)
+    schema_version: str = PROVIDER_RESPONSE_CACHE_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "full_key": self.full_key,
+            "prefix_key": self.prefix_key,
+            "candidates": list(self.candidates),
+            "provider_name": self.provider_name,
+            "model_id": self.model_id,
+            "is_noop": self.is_noop,
+            "prompt_preloaded_files": list(self.prompt_preloaded_files),
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "n_bytes": self.n_bytes,
+            "created_at": self.created_at,
+            "schema_version": self.schema_version,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> Optional["CachedTrajectory"]:
+        try:
+            return cls(
+                full_key=str(d["full_key"]),
+                prefix_key=str(d.get("prefix_key", "")),
+                candidates=tuple(d.get("candidates", []) or ()),
+                provider_name=str(d.get("provider_name", "")),
+                model_id=str(d.get("model_id", "")),
+                is_noop=bool(d.get("is_noop", False)),
+                prompt_preloaded_files=tuple(
+                    d.get("prompt_preloaded_files", []) or ()
+                ),
+                total_input_tokens=int(d.get("total_input_tokens", 0)),
+                total_output_tokens=int(d.get("total_output_tokens", 0)),
+                n_bytes=int(d.get("n_bytes", 0)),
+                created_at=float(d.get("created_at", time.monotonic())),
+                schema_version=str(
+                    d.get("schema_version",
+                          PROVIDER_RESPONSE_CACHE_SCHEMA_VERSION)
+                ),
+            )
+        except Exception:  # noqa: BLE001
+            return None
+
+
+def _trajectory_from_generation_result(
+    full_key: str, prefix_key: str, gr: Any,
+) -> Optional[CachedTrajectory]:
+    """Project a GenerationResult → CachedTrajectory. NEVER raises;
+    returns None if it cannot be serialized (→ caller skips store,
+    which is fail-safe: a missed store is just a future miss)."""
+    try:
+        cands = tuple(getattr(gr, "candidates", ()) or ())
+        # Only cache JSON-serializable candidates (drop the rest —
+        # partial is fine; correctness > completeness).
+        try:
+            payload = json.dumps(list(cands))
+        except (TypeError, ValueError):
+            return None
+        return CachedTrajectory(
+            full_key=full_key,
+            prefix_key=prefix_key,
+            candidates=cands,
+            provider_name=str(getattr(gr, "provider_name", "")),
+            model_id=str(getattr(gr, "model_id", "")),
+            is_noop=bool(getattr(gr, "is_noop", False)),
+            prompt_preloaded_files=tuple(
+                getattr(gr, "prompt_preloaded_files", ()) or ()
+            ),
+            total_input_tokens=int(
+                getattr(gr, "total_input_tokens", 0) or 0
+            ),
+            total_output_tokens=int(
+                getattr(gr, "total_output_tokens", 0) or 0
+            ),
+            n_bytes=len(payload.encode("utf-8", "replace")),
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def reconstruct_generation_result(traj: CachedTrajectory) -> Optional[Any]:
+    """Rebuild a GenerationResult from a cached trajectory with
+    ``cost_usd=0.0`` and a cache-served provider tag (telemetry can
+    see it was free). NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.op_context import (
+            GenerationResult,
+        )
+        return GenerationResult(
+            candidates=tuple(traj.candidates),
+            provider_name=(traj.provider_name or "unknown") + "+cache",
+            generation_duration_s=0.0,
+            model_id=traj.model_id,
+            is_noop=traj.is_noop,
+            prompt_preloaded_files=tuple(traj.prompt_preloaded_files),
+            total_input_tokens=traj.total_input_tokens,
+            total_output_tokens=traj.total_output_tokens,
+            cost_usd=0.0,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Byte-budget LRU ring (the NEW dimension prompt_cache lacks)
+# ---------------------------------------------------------------------------
+
+
+class ProviderResponseCache:
+    """In-mem byte-budgeted LRU of CachedTrajectory. Mirrors
+    prompt_cache's RLock + monotonic-TTL discipline; eviction is by
+    serialized-BYTE budget (drop-oldest), not entry count. NEVER
+    raises out of any public method."""
+
+    def __init__(
+        self,
+        *,
+        max_bytes: Optional[int] = None,
+        ttl_s: Optional[float] = None,
+    ) -> None:
+        self._max_bytes = (
+            max_bytes if max_bytes is not None else cache_max_bytes()
+        )
+        self._ttl_s = ttl_s if ttl_s is not None else cache_ttl_s()
+        self._items: "OrderedDict[str, CachedTrajectory]" = OrderedDict()
+        self._bytes = 0
+        self._lock = threading.RLock()
+        self._loaded = False
+
+    # -- persistence (compose cross_process_jsonl) ----------------------
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        with self._lock:
+            if self._loaded:
+                return
+            self._loaded = True
+            try:
+                p = _cache_path()
+                if not p.exists():
+                    return
+                lines = p.read_text(
+                    encoding="utf-8", errors="replace"
+                ).splitlines()
+                for ln in lines[-_MAX_REPLAY_LINES:]:
+                    ln = ln.strip()
+                    if not ln:
+                        continue
+                    try:
+                        t = CachedTrajectory.from_dict(json.loads(ln))
+                    except Exception:  # noqa: BLE001
+                        continue
+                    if t is not None:
+                        self._put_locked(t, persist=False)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[PRC] replay degraded: %s", exc)
+
+    def _persist(self, t: CachedTrajectory) -> None:
+        try:
+            from backend.core.ouroboros.governance.cross_process_jsonl import (  # noqa: E501
+                flock_append_line,
+            )
+            p = _cache_path()
+            try:
+                p.parent.mkdir(parents=True, exist_ok=True)
+            except Exception:  # noqa: BLE001
+                pass
+            flock_append_line(p, json.dumps(t.to_dict(), sort_keys=True))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[PRC] persist degraded: %s", exc)
+
+    # -- internal -------------------------------------------------------
+
+    def _expired(self, t: CachedTrajectory) -> bool:
+        return (time.monotonic() - t.created_at) > self._ttl_s
+
+    def _put_locked(
+        self, t: CachedTrajectory, *, persist: bool,
+    ) -> None:
+        old = self._items.pop(t.full_key, None)
+        if old is not None:
+            self._bytes -= max(0, old.n_bytes)
+        self._items[t.full_key] = t
+        self._bytes += max(0, t.n_bytes)
+        # Drop-oldest until within the byte budget.
+        while self._bytes > self._max_bytes and self._items:
+            _k, ev = self._items.popitem(last=False)
+            self._bytes -= max(0, ev.n_bytes)
+        if persist:
+            self._persist(t)
+
+    # -- public API -----------------------------------------------------
+
+    def lookup(
+        self, full_key: str, prefix_key: str,
+    ) -> Tuple[CacheLookupOutcome, Optional[CachedTrajectory]]:
+        try:
+            self._ensure_loaded()
+            with self._lock:
+                t = self._items.get(full_key)
+                if t is not None and not self._expired(t):
+                    self._items.move_to_end(full_key)  # LRU bump
+                    return CacheLookupOutcome.EXACT_HIT, t
+                if t is not None:  # expired
+                    self._items.pop(full_key, None)
+                    self._bytes -= max(0, t.n_bytes)
+                # Distinguish "same request, code changed" from a
+                # cold miss (forensic; proves no stale-fix served).
+                for other in self._items.values():
+                    if other.prefix_key == prefix_key:
+                        return (
+                            CacheLookupOutcome.INVALIDATED_REPO_CHANGE,
+                            None,
+                        )
+                return CacheLookupOutcome.MISS, None
+        except Exception as exc:  # noqa: BLE001 — fail-open
+            logger.debug("[PRC] lookup fault (fail-open): %s", exc)
+            return CacheLookupOutcome.FAULT_FAIL_OPEN, None
+
+    def store(self, t: Optional[CachedTrajectory]) -> bool:
+        try:
+            if t is None:
+                return False
+            self._ensure_loaded()
+            with self._lock:
+                self._put_locked(t, persist=True)
+            return True
+        except Exception as exc:  # noqa: BLE001 — never block
+            logger.debug("[PRC] store fault (ignored): %s", exc)
+            return False
+
+    def stats(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "entries": len(self._items),
+                "bytes": self._bytes,
+                "max_bytes": self._max_bytes,
+                "ttl_s": self._ttl_s,
+            }
+
+
+_singleton: Optional[ProviderResponseCache] = None
+_singleton_lock = threading.Lock()
+
+
+def get_default_cache() -> ProviderResponseCache:
+    global _singleton
+    if _singleton is not None:
+        return _singleton
+    with _singleton_lock:
+        if _singleton is None:
+            _singleton = ProviderResponseCache()
+        return _singleton
+
+
+def reset_default_cache_for_tests() -> None:
+    global _singleton
+    with _singleton_lock:
+        _singleton = None
+
+
+# ---------------------------------------------------------------------------
+# The ONE composable gate seam (providers call this; no deep surgery)
+# ---------------------------------------------------------------------------
+
+
+async def cached_or_generate(
+    *,
+    prompt: str,
+    model: str,
+    route: str,
+    repo_root: Path,
+    produce,
+):
+    """Pre-call gate. If disabled → just ``await produce()`` (byte-
+    identical). Else: exact-key hit → return the reconstructed
+    GenerationResult ($0.00, provider skipped); miss/invalidated/
+    fault → ``await produce()`` then best-effort store on success.
+    ``produce`` is a 0-arg async callable returning a
+    GenerationResult. NEVER raises out of the cache logic — any
+    cache fault degrades to ``produce()``.
+
+    Returns ``(GenerationResult, CacheLookupOutcome)``."""
+    if not response_cache_enabled():
+        return await produce(), CacheLookupOutcome.DISABLED
+    full: str = ""
+    pref: str = ""
+    outcome: CacheLookupOutcome = CacheLookupOutcome.MISS
+    try:
+        full, pref = compute_cache_key(
+            str(prompt), str(model), str(route), Path(repo_root),
+        )
+        cache = get_default_cache()
+        outcome, traj = cache.lookup(full, pref)
+        if outcome is CacheLookupOutcome.EXACT_HIT and traj is not None:
+            gr = reconstruct_generation_result(traj)
+            if gr is not None:
+                logger.info(
+                    "[PRC] EXACT_HIT — provider skipped, $0.00 "
+                    "(model=%s route=%s)", model, route,
+                )
+                return gr, CacheLookupOutcome.EXACT_HIT
+            # reconstruction failed → fall through to real call
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.debug("[PRC] gate fault (fail-open): %s", exc)
+        return await produce(), CacheLookupOutcome.FAULT_FAIL_OPEN
+    # Miss / invalidated / reconstruction-failed → real generation,
+    # then best-effort store (store-omission is fail-safe).
+    gr = await produce()
+    try:
+        if (
+            full
+            and gr is not None
+            and not getattr(gr, "is_noop", False)
+        ):
+            t = _trajectory_from_generation_result(full, pref, gr)
+            get_default_cache().store(t)
+    except Exception as exc:  # noqa: BLE001 — store never blocks
+        logger.debug("[PRC] post-store skipped: %s", exc)
+    return gr, outcome
+
+
+__all__ = [
+    "PROVIDER_RESPONSE_CACHE_SCHEMA_VERSION",
+    "CacheLookupOutcome",
+    "CachedTrajectory",
+    "ProviderResponseCache",
+    "response_cache_enabled",
+    "cache_max_bytes",
+    "cache_ttl_s",
+    "repo_state_digest",
+    "compute_cache_key",
+    "reconstruct_generation_result",
+    "cached_or_generate",
+    "get_default_cache",
+    "reset_default_cache_for_tests",
+    "register_flags",
+    "register_shipped_invariants",
+]
+
+
+def register_flags(registry) -> int:  # noqa: ANN001
+    try:
+        from backend.core.ouroboros.governance.flag_registry import (
+            Category, FlagSpec, FlagType,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[PRC] register_flags degraded: %s", exc)
+        return 0
+    tgt = "backend/core/ouroboros/governance/provider_response_cache.py"
+    specs = [
+        FlagSpec(
+            name=_ENV_MASTER, type=FlagType.BOOL, default=False,
+            category=Category.SAFETY, source_file=tgt,
+            example=f"{_ENV_MASTER}=true",
+            description=(
+                "Master for the zero-waste provider response cache. "
+                "OFF (default, §33.1) ⇒ provider path byte-identical."
+            ),
+        ),
+        FlagSpec(
+            name=_ENV_MAX_BYTES, type=FlagType.INT,
+            default=_DEFAULT_MAX_BYTES, category=Category.CAPACITY,
+            source_file=tgt, example=f"{_ENV_MAX_BYTES}=268435456",
+            description=(
+                "In-mem byte budget (LRU drop-oldest). 16GB-M1-safe "
+                f"default 256MiB; clamped [{_MIN_MAX_BYTES},"
+                f"{_MAX_MAX_BYTES}]."
+            ),
+        ),
+        FlagSpec(
+            name=_ENV_TTL_S, type=FlagType.FLOAT,
+            default=_DEFAULT_TTL_S, category=Category.TIMING,
+            source_file=tgt, example=f"{_ENV_TTL_S}=86400",
+            description=(
+                "Trajectory TTL seconds (monotonic, sleep-immune — "
+                "same discipline as prompt_cache)."
+            ),
+        ),
+    ]
+    n = 0
+    for s in specs:
+        try:
+            registry.register(s)
+            n += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[PRC] seed %s skipped: %s", s.name, exc)
+    return n
+
+
+def register_shipped_invariants() -> list:
+    """Pins: composes prompt_cache (no parallel PromptCache / no
+    second _make_key), byte-budget LRU present, closed enum,
+    authority-asymmetric, NEVER-raises gate."""
+    import ast as _ast
+    try:
+        from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+            ShippedCodeInvariant,
+        )
+    except ImportError:
+        return []
+
+    def _validate(tree: "_ast.Module", source: str) -> tuple:
+        v: list = []
+        if "prompt_cache" not in source:
+            v.append("must compose prompt_cache (no parallel cache)")
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.ClassDef) and (
+                node.name == "PromptCache"
+            ):
+                v.append("must NOT define a parallel class PromptCache")
+            if isinstance(node, _ast.FunctionDef) and (
+                node.name == "_make_key"
+            ):
+                v.append(
+                    "must NOT re-implement _make_key — reuse "
+                    "PromptCache._make_key"
+                )
+            if isinstance(node, _ast.ImportFrom):
+                m = node.module or ""
+                for forbidden in (
+                    "orchestrator", "iron_gate",
+                    "candidate_generator",
+                ):
+                    if forbidden in m:
+                        v.append(
+                            f"authority-asymmetry: must not import "
+                            f"{forbidden!r}"
+                        )
+        if "max_bytes" not in source or "_max_bytes" not in source:
+            v.append("byte-budget LRU dimension absent")
+        required = {
+            "EXACT_HIT", "SEMANTIC_HIT", "MISS", "DISABLED",
+            "INVALIDATED_REPO_CHANGE", "FAULT_FAIL_OPEN",
+        }
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.ClassDef) and (
+                node.name == "CacheLookupOutcome"
+            ):
+                seen = {
+                    t.id for st in node.body
+                    if isinstance(st, _ast.Assign)
+                    for t in st.targets
+                    if isinstance(t, _ast.Name)
+                }
+                if required - seen:
+                    v.append(
+                        f"CacheLookupOutcome missing "
+                        f"{sorted(required - seen)}"
+                    )
+                if seen - required:
+                    v.append(
+                        f"CacheLookupOutcome unexpected "
+                        f"{sorted(seen - required)}"
+                    )
+        gate = next(
+            (n for n in _ast.walk(tree)
+             if isinstance(n, _ast.AsyncFunctionDef)
+             and n.name == "cached_or_generate"),
+            None,
+        )
+        if gate is None:
+            v.append("cached_or_generate gate missing")
+        elif not any(
+            isinstance(n, _ast.ExceptHandler)
+            for n in _ast.walk(gate)
+        ):
+            v.append("cached_or_generate must be NEVER-raise")
+        return tuple(v)
+
+    return [
+        ShippedCodeInvariant(
+            invariant_name="provider_response_cache_composed_safe",
+            target_file=(
+                "backend/core/ouroboros/governance/"
+                "provider_response_cache.py"
+            ),
+            description=(
+                "S1 cache composes prompt_cache (no parallel "
+                "PromptCache/_make_key), keeps the byte-budget LRU "
+                "dimension, the closed CacheLookupOutcome taxonomy, "
+                "authority-asymmetry, and a NEVER-raise gate."
+            ),
+            validate=_validate,
+        ),
+    ]

--- a/docs/architecture/ZERO_WASTE_PREDICTIVE_ROUTING.md
+++ b/docs/architecture/ZERO_WASTE_PREDICTIVE_ROUTING.md
@@ -1,0 +1,161 @@
+# Zero-Waste Substrate & Predictive Routing Arc — PRD
+
+Status: **DRAFT for operator review. No implementation until "implement S1".**
+NEW arc — NOT an OCA slice. OCA / git-index / sovereignty / cursor-agent-ban
+are CLOSED and untouched.
+
+---
+
+## 1. Problem statement
+
+Phase-1 SWE-Bench-Pro wiring soak was **INCONCLUSIVE** and burned the full
+**$2.00** cap (estimate was ~cents). Three root causes, none a swe_bench_pro
+code defect:
+
+1. **Compute waste.** Redundant prompts were paid for; no response reuse.
+2. **Budget cannibalization.** Autonomous sensors (OpportunityMiner /
+   DocStaleness) spent the entire budget on JARVIS's own code before the
+   injected fixture was ever reached. No predictive preemption.
+3. **Environmental fragility.** Host sleep -> wall/monotonic clock skew ->
+   `WallClockWatchdog` hard-killed (`stop_reason=wall_clock_cap`) before the
+   fixture ran.
+
+The fix is architectural, not a bespoke isolation script (symptom) or a hard
+sensor throttle (workaround). The system must reuse compute, predict cost,
+and dynamically route resources — composing existing substrates, not
+duplicating them.
+
+## 2. Compose diagram (extend, never parallel)
+
+```
+            EXISTING (compose)                  ARC ADDS (extend only)
+  prompt_cache.PromptCache  --------------->  S1 ProviderResponseCache
+   (OrderedDict LRU + TTL, get/put,             (response trajectory value,
+    get_prompt_cache singleton)                  byte-budget LRU, repo-state key)
+  semantic_index (embed+cosine) ----------->     `- semantic-similar tier
+  cross_process_jsonl.flock_append_line ---->     `- cross-session persistence
+                                                  v
+  providers.ClaudeProvider.generate  <----- pre-call gate (hit => $0, skip API)
+  doubleword_provider.generate       <----- pre-call gate
+
+  admission_gate / admission_estimator ---->  S2 Forecasted_Cost dimension
+   (budget-vs-projected-wait, EWMA)             (spend + forecast vs budget)
+  sensor_governor (weighted caps,    <-----     `- ACTUATION: drive existing
+   emergency brake, quarantine)                    quarantine; NO new router
+
+  battle WallClockWatchdog (wall-cap) ------>  S3 monotonic-authoritative
+   (time.time ages, wall-authoritative)          budget deadline + wall backstop
+                                                 + sleep-vs-runaway skew classify
+```
+
+## 3. Audit — substrate -> extend -> forbidden duplication
+
+| Substrate (file:line) | S? extends | MUST NOT duplicate |
+|---|---|---|
+| `prompt_cache.py:71 PromptCache` (`get`:106 `put`:127 `_evict_expired`:200 `_make_key`:210 `get_prompt_cache`:297; env `JARVIS_PROMPT_CACHE_MAX_ENTRIES`:41) | S1 | a second OrderedDict-LRU / TTL evictor / key-hash; reuse the eviction discipline |
+| `providers.py` `ClaudeProvider.generate` + `GenerationResult` (import :34; parsers return GenerationResult :3782/:3855); `doubleword_provider.py:874 async def generate` | S1 (pre-call gate seam) | no fork of the provider classes; gate wraps, returns the same `GenerationResult` |
+| `semantic_index.py` (fastembed->stdlib-tfidf embed + cosine) | S1 (semantic tier) | no new embedder / no hardcoded cosine constant |
+| `cross_process_jsonl.flock_append_line` | S1 (persistence) | no new flock/JSONL primitive |
+| `admission_gate.py:120 admission_gate_enabled` (+ gate fn ~:468); `admission_estimator.py:94 WaitTimeEstimator` (:363 `get_default_estimator`, EWMA) | S2 | no parallel admission/forecast engine |
+| `sensor_governor.py:98 is_enabled` (emergency brake :148/:156/:540 `_emergency_brake_active`, weighted caps) | S2 (actuation) | **no new router**; drive the existing quarantine/brake |
+| battle `WallClockWatchdog` (`scripts/ouroboros_battle_test.py:1305` arms `max_wall_seconds_s`; kill path emits `stop_reason=wall_clock_cap` + skew log; `time.time()` ages :242/:423) — exact watchdog module pinned at S3 kickoff (read-only locate, deferred to keep this review tight) | S3 | not `s/time.time/monotonic/`; dual-clock + skew classify |
+
+## 4. S1 — Zero-Waste ProviderResponseCache (load-bearing constraints)
+
+A design that violates ANY of these is rejected:
+
+- Cache the **RESPONSE trajectory** (final text + tool-rounds metadata),
+  not prompt-only.
+- Key = `SHA-256(prompt + model + repo-state-digest + route)`. The repo
+  digest **MUST** incorporate `git HEAD` + a staged/working dirty-hash so
+  **any** staged/HEAD change invalidates the entry (no stale-fix
+  application — correctness over savings).
+- Eviction: **LRU by serialized BYTE budget** (`JARVIS_PROVIDER_CACHE_MAX_BYTES`,
+  conservative default, 16GB-M1-safe) — entry count is insufficient
+  (trajectories are large).
+- **Exact hit -> skip the API, $0.00.** Optional semantic-similar tier
+  composes `semantic_index` (env-tunable cosine threshold, NEVER a
+  hardcoded constant; default conservative; advisory).
+- Persistence: `cross_process_jsonl` or a bounded file under `.jarvis/`
+  (compose the existing pattern; survives restart -> "persistent local").
+- **fail-open**: any miss / IO error / HMAC fault -> normal `generate`
+  path. The cache NEVER blocks an op and NEVER raises into the provider.
+- **Authority asymmetry**: substrate imports stdlib +
+  `prompt_cache`/`semantic_index`/`cross_process_jsonl` ONLY — never
+  `orchestrator`/`iron_gate`/`candidate_generator`.
+- Master `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED` default **FALSE**.
+- AST pins: composes-not-duplicates `prompt_cache`; NEVER-raises; byte-budget
+  LRU present; no hardcoded cosine; authority-asymmetric.
+- ~25 spine tests: exact-hit->$0 / miss->passthrough / TTL / byte-evict
+  under M1 bound / repo-state-change invalidates / semantic tier /
+  fail-open (IO+HMAC) / persistence roundtrip / master-off no-op.
+
+### S1 acceptance
+Exact-repeat op returns the cached trajectory with **zero provider tokens
+billed**; any staged/HEAD change forces a real call; cache memory stays
+within `JARVIS_PROVIDER_CACHE_MAX_BYTES`; master-off is byte-identical to
+today; 25 spine green; AST pins green.
+
+## 5. S2 — Predictive Budget Preemption (design only; no impl until "implement S2")
+
+Extend `admission_gate` with a `Forecasted_Cost` term: compose
+`admission_estimator.WaitTimeEstimator` EWMA + the predictive-resilience
+TTFT forecaster + a token->USD model. Before dispatch, if
+`current_spend + forecasted_cost` approaches `session_budget` **or** a
+higher-priority op is queued (compose UnifiedIntakeRouter priority queue +
+`urgency_router`), **drive the existing `sensor_governor` quarantine** to
+dynamically starve low-priority sensors. No new router; no hard throttle.
+Master default FALSE. Acceptance: under tight budget, low-prio sensors
+quarantine while a high-urgency op still admits; over-budget never;
+governor composed (AST-pinned), not duplicated.
+
+## 6. S3 — Monotonic-resilient WallClockWatchdog (design only)
+
+NOT `s/time.time/monotonic/` (Darwin `CLOCK_MONOTONIC` pauses during
+suspend — that IS the desired soak behavior). Make the **budget/liveness
+deadline monotonic-authoritative** (host sleep cleanly *pauses* the
+budget) with a **separate absolute wall ceiling** as a runaway backstop;
+classify skew: monotonic-stalled-while-wall-jumps = benign host-sleep
+(resume) vs monotonic-advancing-past-budget = real runaway (kill).
+Behavior-flag default preserves today's safety; graduation flips
+monotonic-authoritative. Independent of S1/S2 (may land in parallel).
+
+## 7. Graduation contract (Phase-9 cadence, PRD evidence row)
+
+Each slice graduates default-FALSE -> default-TRUE only with a recorded
+evidence row (operator-referenced "§41.6" Phase-9 cadence; cross-linked to
+the main PRD graduation register at graduation time):
+
+| Slice | Graduation evidence required |
+|---|---|
+| S1 | A real op repeated with identical repo-state returns cached trajectory at **$0.00** (provider-call count delta = 0) across a soak; cache RSS within byte budget; zero stale-fix incidents (repo-change-invalidation proven) |
+| S2 | A soak where budget pressure quarantines low-prio sensors while every high-urgency op still admits; spend stays under cap without a hard kill |
+| S3 | A soak with a simulated host-sleep produces NO premature kill; a true runaway IS killed; forward-NTP-jump still safe |
+
+Soak never auto-graduates a flag — flipping default-TRUE is a separate
+operator-authorized PR.
+
+## 8. NON-goals (explicit; reject scope creep)
+
+- No new cache / router / budget / forecast substrate (extend only).
+- No bespoke Phase-1 isolation script; no hard sensor throttle.
+- No OCA / git-index / sovereignty / cursor-agent-ban changes (CLOSED).
+- No Phase-1 re-run or any provider spend without explicit operator
+  approval. No capability/euphoria claims.
+- S2/S3 are design-only here; no S2 code until S1 graduates or operator
+  says "implement S2".
+
+## 9. Open questions (operator decision)
+
+1. **Semantic tier in S1 v1, or exact-hash only first?** Exact-only is
+   strictly correct and simplest; the `semantic_index` similar-tier adds
+   reuse but needs a conservative env threshold + a correctness story.
+2. **Byte budget default** for `JARVIS_PROVIDER_CACHE_MAX_BYTES` on a
+   16GB M1 — propose 256MB (in-mem) + a larger on-disk persistence tier?
+3. **Repo-state digest scope**: HEAD + tracked dirty only, or also
+   untracked? (untracked rarely affects a fix but widens invalidation).
+4. **Persistence medium**: `cross_process_jsonl` append-log (replayed to
+   an in-mem ring on boot) vs a single bounded JSON file — both compose
+   existing patterns; which do you want as v1?
+5. **S3 sequencing**: land S3 in parallel with S1 (independent), or strict
+   S1 -> S2 -> S3?

--- a/tests/governance/test_provider_response_cache.py
+++ b/tests/governance/test_provider_response_cache.py
@@ -1,0 +1,311 @@
+"""S1 spine — ProviderResponseCache (Zero-Waste arc).
+
+Pins every load-bearing PRD constraint: exact-hit->$0, repo-state
+invalidation (no stale-fix), byte-budget LRU (16GB-M1), TTL,
+persistence roundtrip, fail-open, fail-closed-on-correctness,
+master-off byte-identical, composes-prompt_cache AST pin.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    provider_response_cache as prc,
+)
+from backend.core.ouroboros.governance.op_context import (
+    GenerationResult,
+)
+
+
+@pytest.fixture(autouse=True)
+def _iso(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "JARVIS_PROVIDER_CACHE_PATH", str(tmp_path / "t.jsonl"),
+    )
+    monkeypatch.setenv("JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED", "true")
+    for k in ("JARVIS_PROVIDER_CACHE_MAX_BYTES",
+              "JARVIS_PROVIDER_CACHE_TTL_S"):
+        monkeypatch.delenv(k, raising=False)
+    prc.reset_default_cache_for_tests()
+    yield
+    prc.reset_default_cache_for_tests()
+
+
+def _gr(content="print(1)", noop=False):
+    return GenerationResult(
+        candidates=({"file_path": "x.py", "full_content": content},),
+        provider_name="dw", generation_duration_s=1.0,
+        model_id="m", is_noop=noop,
+        total_input_tokens=10, total_output_tokens=5, cost_usd=0.5,
+    )
+
+
+# -- flags / knobs ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw,exp", [
+    (None, False), ("", False), ("1", True), ("true", True),
+    ("YES", True), ("0", False), ("garbage", False)])
+def test_master_default_false_asymmetric(monkeypatch, raw, exp):
+    if raw is None:
+        monkeypatch.delenv(
+            "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv(
+            "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED", raw)
+    assert prc.response_cache_enabled() is exp
+
+
+@pytest.mark.parametrize("raw,exp", [
+    (None, 268_435_456), ("", 268_435_456), ("x", 268_435_456),
+    ("100", 1_048_576), ("999999999999", 4_294_967_296),
+    ("268435456", 268_435_456)])
+def test_max_bytes_clamp(monkeypatch, raw, exp):
+    if raw is None:
+        monkeypatch.delenv(
+            "JARVIS_PROVIDER_CACHE_MAX_BYTES", raising=False)
+    else:
+        monkeypatch.setenv("JARVIS_PROVIDER_CACHE_MAX_BYTES", raw)
+    assert prc.cache_max_bytes() == exp
+
+
+def test_ttl_clamp(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_CACHE_TTL_S", "0")
+    assert prc.cache_ttl_s() == 1.0
+    monkeypatch.setenv("JARVIS_PROVIDER_CACHE_TTL_S", "junk")
+    assert prc.cache_ttl_s() == 86_400.0
+
+
+# -- repo digest / key (correctness) ---------------------------------------
+
+
+def test_repo_digest_stable_and_failclosed():
+    d = prc.repo_state_digest(Path("."))
+    assert d and not d.startswith("UNDETERMINED-")
+    assert prc.repo_state_digest(Path(".")) == d  # stable, same state
+    bad1 = prc.repo_state_digest(Path("/nonexistent/zz"))
+    bad2 = prc.repo_state_digest(Path("/nonexistent/zz"))
+    assert bad1.startswith("UNDETERMINED-")
+    assert bad1 != bad2  # unique nonce each call -> guaranteed miss
+
+
+def test_key_stable_full_differs_prefix():
+    a = prc.compute_cache_key("P", "m", "ide", Path("."))
+    b = prc.compute_cache_key("P", "m", "ide", Path("."))
+    assert a == b and a[0] != a[1]
+    c = prc.compute_cache_key("P", "m2", "ide", Path("."))
+    assert c[1] != a[1]  # model change -> different prefix
+
+
+# -- trajectory dto --------------------------------------------------------
+
+
+def test_trajectory_roundtrip_and_baddict():
+    t = prc._trajectory_from_generation_result("F", "P", _gr())
+    assert t is not None
+    d = t.to_dict()
+    t2 = prc.CachedTrajectory.from_dict(d)
+    assert t2 is not None and t2.full_key == "F" and t2.candidates == t.candidates
+    assert prc.CachedTrajectory.from_dict({"bogus": 1}) is None
+    with pytest.raises(Exception):
+        t.full_key = "z"  # frozen
+
+
+def test_unserializable_candidates_not_cached():
+    class Weird:  # not JSON-serializable
+        pass
+    gr = GenerationResult(
+        candidates=({"obj": Weird()},), provider_name="dw",
+        generation_duration_s=1.0, model_id="m")
+    assert prc._trajectory_from_generation_result("F", "P", gr) is None
+
+
+def test_reconstruct_zero_cost_cache_tag():
+    t = prc._trajectory_from_generation_result("F", "P", _gr())
+    gr = prc.reconstruct_generation_result(t)
+    assert gr.cost_usd == 0.0
+    assert gr.provider_name.endswith("+cache")
+    assert gr.generation_duration_s == 0.0
+
+
+# -- ring: hit / miss / invalidate / ttl / byte-LRU ------------------------
+
+
+def test_store_then_exact_hit():
+    c = prc.ProviderResponseCache()
+    t = prc._trajectory_from_generation_result("F1", "P1", _gr())
+    assert c.store(t)
+    o, got = c.lookup("F1", "P1")
+    assert o is prc.CacheLookupOutcome.EXACT_HIT and got.full_key == "F1"
+
+
+def test_cold_miss_vs_invalidated_repo_change():
+    c = prc.ProviderResponseCache()
+    c.store(prc._trajectory_from_generation_result("F1", "PFX", _gr()))
+    # different full key, SAME prefix => repo changed, not cold miss
+    o, _ = c.lookup("F2", "PFX")
+    assert o is prc.CacheLookupOutcome.INVALIDATED_REPO_CHANGE
+    o2, _ = c.lookup("F9", "OTHER")
+    assert o2 is prc.CacheLookupOutcome.MISS
+
+
+def test_ttl_expiry(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_CACHE_TTL_S", "1")
+    c = prc.ProviderResponseCache()
+    t = prc._trajectory_from_generation_result("F", "P", _gr())
+    # force created_at into the past
+    object.__setattr__(t, "created_at", t.created_at - 100.0)
+    c.store(t)
+    o, _ = c.lookup("F", "P")
+    assert o in (prc.CacheLookupOutcome.MISS,
+                 prc.CacheLookupOutcome.INVALIDATED_REPO_CHANGE)
+
+
+def test_byte_lru_drop_oldest_within_budget():
+    c = prc.ProviderResponseCache(max_bytes=120, ttl_s=9999)
+    for i in range(6):
+        c.store(prc._trajectory_from_generation_result(
+            f"F{i}", f"P{i}", _gr(content="z" * 30)))
+    st = c.stats()
+    assert st["bytes"] <= 120  # never exceeds byte budget
+    assert c.lookup("F0", "P0")[0] is not prc.CacheLookupOutcome.EXACT_HIT
+    assert c.lookup("F5", "P5")[0] is prc.CacheLookupOutcome.EXACT_HIT
+
+
+def test_lru_bump_on_hit():
+    # Size the budget from the ACTUAL entry bytes (non-brittle):
+    # a budget that holds exactly 2 entries.
+    sample = prc._trajectory_from_generation_result(
+        "S", "S", _gr(content="z" * 40))
+    c = prc.ProviderResponseCache(
+        max_bytes=2 * sample.n_bytes, ttl_s=9999)
+    c.store(prc._trajectory_from_generation_result(
+        "F0", "P0", _gr(content="z" * 40)))
+    c.store(prc._trajectory_from_generation_result(
+        "F1", "P1", _gr(content="z" * 40)))  # cache full (2 entries)
+    c.lookup("F0", "P0")                      # bump F0 to MRU
+    c.store(prc._trajectory_from_generation_result(
+        "F2", "P2", _gr(content="z" * 40)))   # evicts LRU == F1
+    assert c.lookup("F0", "P0")[0] is prc.CacheLookupOutcome.EXACT_HIT
+    assert c.lookup("F1", "P1")[0] is not prc.CacheLookupOutcome.EXACT_HIT
+
+
+# -- persistence (cross-session) -------------------------------------------
+
+
+def test_persistence_replay_new_instance(tmp_path):
+    c1 = prc.ProviderResponseCache()
+    c1.store(prc._trajectory_from_generation_result("F", "P", _gr()))
+    assert Path(tmp_path / "t.jsonl").exists()
+    c2 = prc.ProviderResponseCache()  # fresh -> replays from disk
+    o, got = c2.lookup("F", "P")
+    assert o is prc.CacheLookupOutcome.EXACT_HIT and got is not None
+
+
+# -- gate (the seam) -------------------------------------------------------
+
+
+def test_gate_disabled_byte_identical(monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED", "false")
+    n = {"c": 0}
+
+    async def produce():
+        n["c"] += 1
+        return _gr()
+
+    gr, o = asyncio.run(prc.cached_or_generate(
+        prompt="P", model="m", route="ide",
+        repo_root=Path("."), produce=produce))
+    assert o is prc.CacheLookupOutcome.DISABLED and n["c"] == 1
+    assert gr.cost_usd == 0.5  # untouched real result
+
+
+def test_gate_miss_then_exact_hit_zero_cost():
+    n = {"c": 0}
+
+    async def produce():
+        n["c"] += 1
+        return _gr()
+
+    async def run():
+        g1, o1 = await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce)
+        g2, o2 = await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce)
+        return (o1, g1, o2, g2)
+
+    o1, g1, o2, g2 = asyncio.run(run())
+    assert o1 is prc.CacheLookupOutcome.MISS and g1.cost_usd == 0.5
+    assert o2 is prc.CacheLookupOutcome.EXACT_HIT
+    assert g2.cost_usd == 0.0 and g2.provider_name.endswith("+cache")
+    assert n["c"] == 1  # provider skipped on the 2nd call
+
+
+def test_gate_noop_not_stored():
+    async def produce():
+        return _gr(noop=True)
+
+    async def run():
+        await prc.cached_or_generate(
+            prompt="Q", model="m", route="ide",
+            repo_root=Path("."), produce=produce)
+        # 2nd call must still miss (noop never cached)
+        return await prc.cached_or_generate(
+            prompt="Q", model="m", route="ide",
+            repo_root=Path("."), produce=produce)
+
+    _, o = asyncio.run(run())
+    assert o is not prc.CacheLookupOutcome.EXACT_HIT
+
+
+def test_gate_fail_open_on_lookup_fault(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("cache exploded")
+
+    monkeypatch.setattr(prc, "compute_cache_key", boom)
+    n = {"c": 0}
+
+    async def produce():
+        n["c"] += 1
+        return _gr()
+
+    gr, o = asyncio.run(prc.cached_or_generate(
+        prompt="P", model="m", route="ide",
+        repo_root=Path("."), produce=produce))
+    assert o is prc.CacheLookupOutcome.FAULT_FAIL_OPEN
+    assert n["c"] == 1 and gr is not None  # real path still ran
+
+
+def test_store_never_raises():
+    c = prc.ProviderResponseCache()
+    assert c.store(None) is False  # no raise
+
+
+# -- registration contract -------------------------------------------------
+
+
+def test_register_flags_three():
+    seen = []
+
+    class _R:
+        def register(self, s):
+            seen.append(s.name)
+
+    assert prc.register_flags(_R()) == 3
+    assert "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED" in seen
+
+
+def test_ast_pin_self_validates_green():
+    invs = prc.register_shipped_invariants()
+    assert len(invs) == 1
+    src = Path(prc.__file__).read_text(encoding="utf-8")
+    assert invs[0].validate(ast.parse(src), src) == ()


### PR DESCRIPTION
S1 of the Zero-Waste & Predictive Routing arc. NEW arc (not OCA Slice N; OCA/git-index/sovereignty/cursor-agent-ban CLOSED & untouched).

**Substrate landed (dormant — master default-FALSE → byte-identical until graduated):**
`provider_response_cache.py` — persistent, byte-budgeted (256MiB, 16GB-M1-safe, clamped), repo-state-keyed cache of provider response trajectories. Exact repeat → cached `GenerationResult`, provider skipped, **$0.00**. Composes `prompt_cache` (reuses `PromptCache._make_key`, mirrors RLock+monotonic-TTL; AST-pinned no parallel `PromptCache`/`_make_key`) + `cross_process_jsonl` (persistence, bounded replay). New dimensions: response value, **byte-LRU**, **repo-digest invalidation** (HEAD+SHA(git diff HEAD); any staged/HEAD change re-keys → no stale-fix; **fail-CLOSED** on undeterminable repo; **fail-OPEN** on any fault — never raises/blocks). Composable async gate `cached_or_generate(...)`; DISABLED → byte-identical. 3 flag seeds + AST pin.

**Tests:** `test_provider_response_cache.py` **(32, green)** — flags/clamp, repo-digest fail-closed, key invalidation, byte-LRU drop-oldest within budget, TTL, cross-session persistence replay, gate disabled-byte-identical, miss→hit-$0-provider-skipped, noop-not-cached, fail-open, store-never-raises, AST self-validate.

**NOT end-to-end (explicit, no euphoria):** the gate is **not yet wired** into `ClaudeProvider.generate` / `DoubleWordProvider.generate` — those hot-path methods get a focused, reviewed restructure (seams pre-located in `docs/architecture/ZERO_WASTE_PREDICTIVE_ROUTING.md`). Dormant master ⇒ unwired = correct/byte-identical. Graduation-gated per PRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent, repo-state-keyed response cache and a composable `cached_or_generate` gate to skip identical provider calls and return a cached `GenerationResult` at $0. Default is off and providers are not yet wired, so runtime behavior is unchanged.

- New Features
  - Response-trajectory cache with byte-budgeted LRU and TTL; persists via `cross_process_jsonl` to `.jarvis/provider_response_cache/trajectories.jsonl`.
  - Cache key binds prompt, model, route, and repo digest (`HEAD` + SHA-256 of `git diff HEAD`); undeterminable repo → guaranteed miss (fail-closed).
  - Async gate `cached_or_generate(...)`: exact-hit returns a reconstructed, zero-cost result; miss/fault falls back to real generation; never raises; noop results not stored. Closed outcomes: `EXACT_HIT`, `MISS`, `INVALIDATED_REPO_CHANGE`, `DISABLED`, `FAULT_FAIL_OPEN`.
  - Composes `prompt_cache` keying via `PromptCache._make_key`; AST invariants ensure no parallel cache and authority asymmetry.
  - Architecture doc added at `docs/architecture/ZERO_WASTE_PREDICTIVE_ROUTING.md`; tests cover TTL, byte-LRU, persistence, invalidation, fail-open, and disabled passthrough.

- Migration
  - No change by default: `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED` is false and providers are not wired to the gate.
  - To trial, call `cached_or_generate(...)` from provider `generate` paths and set `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED=true`.
  - Optional knobs: `JARVIS_PROVIDER_CACHE_MAX_BYTES`, `JARVIS_PROVIDER_CACHE_TTL_S`, `JARVIS_PROVIDER_CACHE_PATH`.

<sup>Written for commit 240533f4922f96d8d3cb8ce3851f579927b8e972. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/43170?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

