### PR TITLE
feat(governance): Zero-Waste S1 wiring (D2) — Claude + DW gate, dormant default-FALSE

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -902,6 +902,116 @@ class DoublewordProvider:
                 generation_duration_s=0.0,
             )
 
+        # Zero-Waste S1 (D2) cache gate. Eligible only when the
+        # provider-response cache is enabled AND DW's tool loop will
+        # be skipped (tool_loop is None OR task_complexity in
+        # {trivial,simple} per _generate_realtime's _will_skip_tools
+        # discipline). The prompt is assembled once at this layer and
+        # passed through as prompt_override (existing plumbing) so the
+        # gate keys on the actually-built prompt. Authority-asymmetry:
+        # this file imports cached_or_generate ONLY (no inline cache
+        # class / no OrderedDict LRU). NEVER raises (fail-open).
+        try:
+            from backend.core.ouroboros.governance.provider_response_cache import (  # noqa: E501
+                cached_or_generate as _zw_cached_or_generate,
+                response_cache_enabled as _zw_response_cache_enabled,
+            )
+        except Exception:  # noqa: BLE001 — substrate optional / fail-open
+            _zw_cached_or_generate = None
+            _zw_response_cache_enabled = lambda: False  # noqa: E731
+        if (
+            _zw_cached_or_generate is not None
+            and _zw_response_cache_enabled()
+        ):
+            _zw_prompt = prompt_override
+            if _zw_prompt is None:
+                try:
+                    from backend.core.ouroboros.governance.providers import (
+                        _build_codegen_prompt,
+                        _build_lean_codegen_prompt,
+                        _should_use_lean_prompt,
+                    )
+                    _zw_complexity = getattr(
+                        context, "task_complexity", "",
+                    )
+                    _zw_will_skip = _zw_complexity in (
+                        "trivial", "simple",
+                    )
+                    _zw_tools_available = (
+                        self._tool_loop is not None
+                        and not _zw_will_skip
+                    )
+                    _zw_preloaded: List[str] = []
+                    if _should_use_lean_prompt(
+                        context, tools_enabled=_zw_tools_available,
+                    ):
+                        _zw_prompt = _build_lean_codegen_prompt(
+                            context,
+                            repo_root=self._repo_root,
+                            repo_roots=self._repo_roots or None,
+                            force_full_content=True,
+                            mcp_tools=None,
+                            preloaded_out=_zw_preloaded,
+                        )
+                    else:
+                        _zw_prompt = _build_codegen_prompt(
+                            context,
+                            repo_root=self._repo_root,
+                            repo_roots=self._repo_roots or None,
+                            force_full_content=True,
+                            mcp_tools=None,
+                            provider_route=getattr(
+                                context, "provider_route", "",
+                            ) or "",
+                        )
+                except Exception:  # noqa: BLE001 — fail-open
+                    _zw_prompt = None
+            _zw_will_skip = getattr(
+                context, "task_complexity", "",
+            ) in ("trivial", "simple")
+            _zw_eligible = (self._tool_loop is None) or _zw_will_skip
+            if _zw_prompt is not None and _zw_eligible:
+                async def _dw_inner():
+                    return await self._dispatch_internal(
+                        context, deadline,
+                        prompt_override=_zw_prompt,
+                    )
+
+                try:
+                    _zw_model = self._effective_model_id(context)
+                except Exception:  # noqa: BLE001
+                    _zw_model = getattr(self, "_model", "doubleword")
+                _gr, _ = await _zw_cached_or_generate(
+                    prompt=_zw_prompt,
+                    model=_zw_model,
+                    route=getattr(
+                        context, "provider_route", "",
+                    ) or "",
+                    repo_root=self._repo_root,
+                    produce=_dw_inner,
+                )
+                return _gr
+
+        # Cache disabled / not eligible: fall through to the existing
+        # dispatcher (RT + batch fall-back) verbatim — extracted into
+        # _dispatch_internal so the gate's _dw_inner closure can call
+        # the same code path without duplication.
+        return await self._dispatch_internal(
+            context, deadline, prompt_override=prompt_override,
+        )
+
+    async def _dispatch_internal(
+        self,
+        context: OperationContext,
+        deadline: Any = None,
+        *,
+        prompt_override: Optional[str] = None,
+    ) -> GenerationResult:
+        """RT + batch dispatcher. Extracted from :meth:`generate` so
+        the Zero-Waste S1 cache gate's ``_dw_inner`` thunk can
+        invoke the same dispatch path without duplicating it
+        (single source of dispatch truth). Behavior is byte-
+        identical to the pre-extraction body."""
         # Real-time mode: /v1/chat/completions with SSE streaming + Venom tool loop
         # On 429/503, fall back to batch within DW (stay cheap) instead of
         # cascading to the 150x more expensive Claude fallback.

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -6455,42 +6455,15 @@ class ClaudeProvider:
         )
         executor = None  # lazy init on first tool call
 
-        # Gap #7: discover MCP tools for prompt injection
-        _mcp_tools = None
-        if self._mcp_client is not None and self._tools_enabled:
-            try:
-                _mcp_tools = await self._mcp_client.discover_tools()
-            except Exception:
-                pass
-        # P0.1: Lean prompt when tool loop is available and not repairing
-        _preloaded_files: List[str] = []
-        if (
-            repair_context is None
-            and _should_use_lean_prompt(context, tools_enabled=self._tools_enabled)
-        ):
-            prompt_text = _build_lean_codegen_prompt(
-                context,
+        # Zero-Waste S1 (D2): MCP discovery + lean/full prompt build
+        # extracted into _assemble_codegen_prompt (low-risk extract).
+        prompt_text, _mcp_tools, _preloaded_files = (
+            await self._assemble_codegen_prompt(
+                context=context,
                 repo_root=repo_root,
-                repo_roots=self._repo_roots,
-                force_full_content=True,
-                mcp_tools=_mcp_tools,
-                preloaded_out=_preloaded_files,
-            )
-            logger.info(
-                "[ClaudeAPI] Using lean prompt (%d chars, ~%d tokens, preloaded=%d)",
-                len(prompt_text), len(prompt_text) // 4, len(_preloaded_files),
-            )
-        else:
-            prompt_text = _build_codegen_prompt(
-                context,
-                repo_root=repo_root,
-                repo_roots=self._repo_roots,
-                tools_enabled=self._tools_enabled,
-                force_full_content=True,
                 repair_context=repair_context,
-                mcp_tools=_mcp_tools,
-                provider_route=getattr(context, "provider_route", "") or "",
             )
+        )
         # Build messages array for multi-turn conversation
         messages: List[Dict[str, Any]] = [{"role": "user", "content": prompt_text}]
         accumulated_chars = len(prompt_text)
@@ -7561,6 +7534,50 @@ class ClaudeProvider:
                 _route,
             )
 
+        # Zero-Waste S1 (D2) cache gate. Eligible only when the
+        # provider-response cache is enabled AND no tool loop will
+        # engage (tools_enabled is False AND tool_loop is None). On
+        # HIT: skip provider API + tool dispatch (NOT the Python
+        # set-up above — that's already paid). On MISS: the nested
+        # _no_tools_inner closure runs _generate_raw +
+        # _finalize_codegen_result, and the result is stored.
+        # Authority asymmetry: providers import cached_or_generate
+        # ONLY; no inline cache class / no OrderedDict LRU here.
+        try:
+            from backend.core.ouroboros.governance.provider_response_cache import (  # noqa: E501
+                cached_or_generate as _cached_or_generate,
+                response_cache_enabled as _response_cache_enabled,
+            )
+        except Exception:  # noqa: BLE001 — substrate optional / fail-open
+            _cached_or_generate = None
+            _response_cache_enabled = lambda: False  # noqa: E731
+        if (
+            _cached_or_generate is not None
+            and _response_cache_enabled()
+            and not self._tools_enabled
+            and self._tool_loop is None
+        ):
+            async def _no_tools_inner():
+                _raw = await _generate_raw(prompt_text)
+                return self._finalize_codegen_result(
+                    raw=_raw, context=context, repo_root=repo_root,
+                    start=start, preloaded_files=_preloaded_files,
+                    token_usage=_token_usage, total_cost=total_cost,
+                    tool_rounds=tool_rounds,
+                    first_token_ms=_first_token_ms,
+                    thinking_reason=_thinking_reason_out,
+                    tool_records=(), venom_edits=(),
+                )
+
+            _gate_gr, _gate_outcome = await _cached_or_generate(
+                prompt=prompt_text,
+                model=self._model,
+                route=getattr(context, "provider_route", "") or "",
+                repo_root=repo_root,
+                produce=_no_tools_inner,
+            )
+            return _gate_gr
+
         tool_records: tuple = ()
         venom_edits: Tuple[Dict[str, Any], ...] = ()
         if self._tool_loop is not None and not _skip_tools:
@@ -7680,13 +7697,118 @@ class ClaudeProvider:
         else:
             raw = await _generate_raw(prompt_text)
 
+        return self._finalize_codegen_result(
+            raw=raw,
+            context=context,
+            repo_root=repo_root,
+            start=start,
+            preloaded_files=_preloaded_files,
+            token_usage=_token_usage,
+            total_cost=total_cost,
+            tool_rounds=tool_rounds,
+            first_token_ms=_first_token_ms,
+            thinking_reason=_thinking_reason_out,
+            tool_records=tool_records,
+            venom_edits=venom_edits,
+        )
+
+    async def _assemble_codegen_prompt(
+        self,
+        *,
+        context: "OperationContext",
+        repo_root: Optional[Path],
+        repair_context: Optional[Any],
+    ) -> Tuple[str, Any, List[str]]:
+        """Zero-Waste S1 (D2) extract — MCP tools discovery + lean/
+        full prompt build. Pulled out of :meth:`generate` so the
+        substrate can compute a cache key on ``prompt_text`` before
+        tool dispatch. Async because MCP discovery awaits.
+
+        Returns
+        -------
+        (prompt_text, mcp_tools, preloaded_files)
+        """
+        # Gap #7: discover MCP tools for prompt injection
+        _mcp_tools = None
+        if self._mcp_client is not None and self._tools_enabled:
+            try:
+                _mcp_tools = await self._mcp_client.discover_tools()
+            except Exception:  # noqa: BLE001 — degrade silently
+                pass
+        # P0.1: Lean prompt when tool loop is available and not repairing
+        _preloaded_files: List[str] = []
+        if (
+            repair_context is None
+            and _should_use_lean_prompt(
+                context, tools_enabled=self._tools_enabled,
+            )
+        ):
+            prompt_text = _build_lean_codegen_prompt(
+                context,
+                repo_root=repo_root,
+                repo_roots=self._repo_roots,
+                force_full_content=True,
+                mcp_tools=_mcp_tools,
+                preloaded_out=_preloaded_files,
+            )
+            logger.info(
+                "[ClaudeAPI] Using lean prompt "
+                "(%d chars, ~%d tokens, preloaded=%d)",
+                len(prompt_text), len(prompt_text) // 4,
+                len(_preloaded_files),
+            )
+        else:
+            prompt_text = _build_codegen_prompt(
+                context,
+                repo_root=repo_root,
+                repo_roots=self._repo_roots,
+                tools_enabled=self._tools_enabled,
+                force_full_content=True,
+                repair_context=repair_context,
+                mcp_tools=_mcp_tools,
+                provider_route=getattr(
+                    context, "provider_route", "",
+                ) or "",
+            )
+        return prompt_text, _mcp_tools, _preloaded_files
+
+    def _finalize_codegen_result(
+        self,
+        *,
+        raw: Any,
+        context: "OperationContext",
+        repo_root: Optional[Path],
+        start: float,
+        preloaded_files: List[str],
+        token_usage: Dict[str, int],
+        total_cost: float,
+        tool_rounds: int,
+        first_token_ms: List[Optional[float]],
+        thinking_reason: List[str],
+        tool_records: Tuple[Any, ...],
+        venom_edits: Tuple[Dict[str, Any], ...],
+    ) -> GenerationResult:
+        """Zero-Waste S1 (D2) extract — post-raw result parsing +
+        token/cost finalize. Shared by :meth:`generate`'s normal
+        return path and the S1 gate's ``_no_tools_inner`` thunk.
+        Pure: takes everything it needs as args (no nonlocal)."""
         duration = time.monotonic() - start
         source_hash = ""
-        source_path = context.target_files[0] if context.target_files else ""
+        source_path = (
+            context.target_files[0] if context.target_files else ""
+        )
         if source_path:
-            abs_path = (repo_root / source_path) if repo_root else Path(source_path)
+            abs_path = (
+                (repo_root / source_path)
+                if repo_root else Path(source_path)
+            )
             try:
-                content_bytes = abs_path.read_text(encoding="utf-8", errors="replace") if abs_path.is_file() else ""
+                content_bytes = (
+                    abs_path.read_text(
+                        encoding="utf-8", errors="replace",
+                    )
+                    if abs_path.is_file() else ""
+                )
                 source_hash = _file_source_hash(content_bytes)
             except OSError:
                 pass
@@ -7701,31 +7823,38 @@ class ClaudeProvider:
             repo_roots=self._repo_roots,
             repo_root=repo_root,
         )
-        if _preloaded_files:
+        if preloaded_files:
             result = dataclasses.replace(
-                result, prompt_preloaded_files=tuple(_preloaded_files),
+                result,
+                prompt_preloaded_files=tuple(preloaded_files),
             )
 
         # Attach token usage and cost
-        if _token_usage["input"] or _token_usage["output"] or total_cost > 0:
+        if (
+            token_usage["input"] or token_usage["output"]
+            or total_cost > 0
+        ):
             result = dataclasses.replace(
                 result,
-                total_input_tokens=_token_usage["input"],
-                total_output_tokens=_token_usage["output"],
+                total_input_tokens=token_usage["input"],
+                total_output_tokens=token_usage["output"],
                 cost_usd=total_cost,
             )
 
-        _ftms = _first_token_ms[0]
+        _ftms = first_token_ms[0]
         _ftms_str = f"{_ftms:.0f}ms" if _ftms is not None else "n/a"
         _route_str = getattr(context, "provider_route", "") or "?"
         logger.info(
-            "[ClaudeProvider] %d candidates in %.1fs (tool_rounds=%d), cost=$%.4f, "
+            "[ClaudeProvider] %d candidates in %.1fs "
+            "(tool_rounds=%d), cost=$%.4f, "
             "%d+%d tokens, first_token=%s thinking=%s route=%s",
             len(result.candidates), duration, tool_rounds, total_cost,
-            _token_usage["input"], _token_usage["output"],
-            _ftms_str, _thinking_reason_out[0], _route_str,
+            token_usage["input"], token_usage["output"],
+            _ftms_str, thinking_reason[0], _route_str,
         )
-        return result.with_tool_records(tool_records).with_venom_edits(venom_edits)
+        return result.with_tool_records(
+            tool_records
+        ).with_venom_edits(venom_edits)
 
     async def health_probe(self) -> bool:
         """Lightweight API ping. Returns True if API responds.

--- a/docs/architecture/ZERO_WASTE_PREDICTIVE_ROUTING.md
+++ b/docs/architecture/ZERO_WASTE_PREDICTIVE_ROUTING.md
@@ -145,6 +145,235 @@ operator-authorized PR.
 - S2/S3 are design-only here; no S2 code until S1 graduates or operator
   says "implement S2".
 
+## 8b. S1 wiring plan (PR `ouroboros/zero-waste-s1-wire`) — review-only
+
+**Status:** plan only. Awaiting operator "wire S1 approved" before any
+edit to `providers.py` / `doubleword_provider.py`. The S1 substrate
+(`provider_response_cache.py` + `cached_or_generate`) is the ONE seam.
+**No inline cache logic in providers** — they import + call the gate.
+
+### 8b.1 ClaudeProvider.generate (`providers.py` ~6392)
+
+**Audit (load-bearing facts):**
+- Top of method runs the **PRD §26.6.2 Layer-2 cost-contract gate**
+  (`assert_provider_route_compatible(...)`, raises
+  `CostContractViolation`) and `self._daily_spend >= self._daily_budget`
+  raises `claude_budget_exhausted` — these are correctness gates that
+  MUST fire whether or not we serve from cache (a cached hit on a
+  contract-violated route would silently bypass the cost contract).
+- Prompt is finalized later via `_build_lean_codegen_prompt` /
+  `_build_codegen_prompt` → `prompt_text` local.
+- `generate` is a multi-iteration tool loop with **8+ `return
+  GenerationResult(...)` sites** (incl. 6930/6933/6935/6938/7239/...).
+
+**Insertion point:** **AFTER** the cost-contract gate + daily-budget
+check + `prompt_text` assembly + model/route/repo_root resolved, and
+**BEFORE** the first `await self._client.messages.create(...)`.
+Justification: (a) correctness — cost-contract MUST run; (b)
+key-faithfulness — keying on the actually-assembled prompt is the
+spec; (c) avoids re-wrapping the entire method when the tool loop is
+active (see policy below).
+
+**Canonical key serialization:** `compute_cache_key(prompt_text,
+self._model, route=getattr(context, "provider_route", ""),
+repo_root=repo_root)`. **Excluded** from the key (deliberately): `op_id`
+(volatile), `deadline` (per-op), `repair_context` (would force misses
+on every repair iteration — even when the underlying repair attempt is
+identical), MCP tools list (env-dependent; repo-digest already invalidates
+on code change). The repo-digest is the correctness anchor for the rest.
+
+**Tool-loop policy for v1 (recommend + argue):** **SKIP CACHE WHEN
+TOOLS WILL ENGAGE.** v1 gate-enables only when `self._tools_enabled is
+False`. Argument: a tool-loop trajectory includes side-effecting tool
+results (`run_tests`/`bash` outputs whose determinism we cannot prove
+even with stable repo state); re-serving a cached tool trajectory could
+silently elide real tool calls. Repo-digest covers code-state but not
+e.g. test-runner flakiness or `bash` non-determinism. v1 captures the
+substantial no-tools case ($/op savings on direct-patch paths); a future
+S1.x can add tool-loop-aware caching with deterministic-trajectory
+verification. This is the operator-recommended policy.
+
+**produce() thunk shape (D2 — final, supersedes earlier "promote
+`_generate_raw`" wording):** Audit showed `_generate_raw` is a
+**~1,036-line nested closure** (L6506–L7542) wrapping streaming /
+multi-retry / prefill-fallback state with `nonlocal total_cost`
+mutation and ~10 closure captures. Promoting it to a method is NOT
+mechanical and there is no integration-test coverage for the
+streaming/retry/prefill paths to catch a regression.
+
+**D2 keeps `_generate_raw` exactly in place as a nested closure.** The
+gate's `produce()` is itself a **nested closure** inside
+`generate()` — `_no_tools_inner` — that closes over the existing
+`_generate_raw` + the post-prompt locals (`start`, `total_cost`,
+`tool_rounds`, `_token_usage`, `_first_token_ms`,
+`_thinking_reason_out`, `_preloaded_files`) and calls
+`_finalize_codegen_result(...)` (extracted method, ~45 lines).
+Only two extracts as methods, both low-risk:
+
+  * `async def _assemble_codegen_prompt(self, *, context, repo_root,
+    repair_context) -> (prompt_text, mcp_tools, preloaded_files)` —
+    contains MCP discovery + lean/full prompt-build (~30 lines).
+  * `def _finalize_codegen_result(self, *, raw, context, repo_root,
+    start, preloaded_files, token_usage, total_cost, tool_rounds,
+    first_token_ms, thinking_reason, tool_records, venom_edits) ->
+    GenerationResult` — the post-raw result parsing + token/cost
+    finalize (~45 lines).
+
+**Gate insertion (D2):** immediately before the tool-dispatch block
+(before the `tool_records: tuple = ()` line), after `_generate_raw`
+is defined. When eligible (cache enabled AND `not self._tools_enabled`
+AND `self._tool_loop is None`): build `_no_tools_inner` closure,
+`gr, _ = await cached_or_generate(prompt=prompt_text, model=...,
+route=..., repo_root=..., produce=_no_tools_inner)`, **return `gr`
+early** — skipping the tool-dispatch block and all provider API/tool
+work. **Important precision (operator correction): cache HIT avoids
+provider/API/tool-loop work — it does NOT avoid the Python
+nested-function setup above the gate (the prompt-build, the
+`_generate_raw` `def` evaluation, etc.) — those are cheap CPU; the
+savings are in the network/provider/tool dispatch.**
+
+When NOT eligible (tools_enabled OR cache disabled): the gate is
+skipped; the existing tool-dispatch block runs unchanged.
+
+**Hit cost/observability:** `cost_usd=0.0` is already set by
+`reconstruct_generation_result` in the substrate; the cached
+`provider_name` carries the `+cache` suffix → existing telemetry
+(`session_archive`, `cost_governor`, the `cost_tracker.json` writer)
+naturally records $0.00 for cache-served ops. **No new ledger** — the
+GenerationResult IS the existing telemetry record.
+
+### 8b.2 DoubleWordProvider.generate (`doubleword_provider.py` ~874)
+
+**Audit:** `generate(...)` dispatches: `if not is_available: noop
+GenerationResult`; `if self._realtime_enabled: return await
+self._generate_realtime(...)`; else batch (`submit_batch +
+poll_and_retrieve`). DW has its own tool loop via `self._tool_loop`;
+`_generate_realtime` computes `_will_skip_tools = _complexity in
+("trivial", "simple")` and `_tools_available = self._tool_loop is not
+None and not _will_skip_tools`. DW exposes a clean **`prompt_override`**
+parameter on all paths (RT + batch + submit_batch) — composable.
+
+**Insertion point:** at the **top of `generate`, AFTER the
+`is_available` check**, BEFORE the RT/batch dispatch. Compose the
+canonical builder once at this level (mirror the DW RT logic:
+`_should_use_lean_prompt` -> `_build_lean_codegen_prompt` /
+`_build_codegen_prompt`) and pass the result as `prompt_override` to
+the dispatchers. This avoids prompt-build duplication (the inner
+methods honor `prompt_override`) and gives the gate the actual prompt
+at one seam. Justification: DW already has the `prompt_override` plumbing
+— this composes it, doesn't introduce a new path.
+
+**Canonical key:** `compute_cache_key(prompt, model=self._effective_model_id(context),
+route=getattr(context,"provider_route",""), repo_root=self._repo_root)`.
+Excludes the same volatile fields as Claude.
+
+**Tool-loop policy for v1:** same as Claude — **skip cache when DW
+tool-loop will engage.** Predicate at the top of `generate`: enable the
+gate only when `self._tool_loop is None` OR `_complexity in
+("trivial","simple")` (the same `_will_skip_tools` predicate the RT
+path uses; we compute it once at gate time using the existing helper).
+Same correctness argument.
+
+**produce() thunk shape:** the thunk wraps the existing dispatch:
+```
+async def _dw_inner():
+    if self._realtime_enabled:
+        return await self._generate_realtime(
+            context, deadline, prompt_override=prompt)
+    pending = await self.submit_batch(context, prompt_override=prompt)
+    ...
+    return result
+```
+Then `gr, _ = await cached_or_generate(prompt=prompt, model=...,
+route=..., repo_root=self._repo_root, produce=_dw_inner); return gr`.
+The RT/batch internals are **unchanged**.
+
+**Hit cost/observability:** same as Claude — `cost_usd=0.0` +
+`provider_name="doubleword+cache"`; existing DW cost telemetry records
+the $0 naturally.
+
+### 8b.3 Correctness invariants (MUST hold; spine-pinned)
+
+1. **master OFF → byte-identical**: when
+   `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED` is unset/false,
+   `cached_or_generate` returns `(produce(), DISABLED)` — provider path
+   is the original code path verbatim. Tested by mocking the gate
+   substrate untouched + asserting `produce` runs every call.
+2. **repo digest change → miss (no stale patch)**: key includes
+   `HEAD+SHA(git diff HEAD)`; any staged/HEAD mutation re-keys → MISS or
+   `INVALIDATED_REPO_CHANGE`; provider runs. Already covered by S1
+   substrate tests; the wiring test reasserts at the provider seam.
+3. **fail-open on cache fault → normal generate**: any cache exception
+   (compute_key fault / IO / persistence fault) returns
+   `FAULT_FAIL_OPEN` → `produce()` runs. Spine-pinned.
+4. **is_noop results not stored**: already in substrate; wiring test
+   reasserts by mocking a noop result and confirming the next call still
+   misses.
+5. **Cost contract still fires**: the contract gate at the top of
+   `ClaudeProvider.generate` MUST run on every call, including cache
+   hits — the cache insertion is AFTER it (invariant by construction).
+6. **Tool-loop never replayed in v1**: when the tool-engage predicate is
+   true, the gate is skipped (no lookup, no store).
+7. **AST pin (wiring PR)**: each provider imports `cached_or_generate`
+   from `provider_response_cache` only; no inline cache class/store; no
+   `OrderedDict` LRU in `providers.py`/`doubleword_provider.py`.
+
+### 8b.4 Test plan (~8–12 wiring-PR integration tests)
+
+`tests/governance/test_provider_response_cache_wiring.py` (NEW). Uses
+the substrate's `cached_or_generate`; mocks `ClaudeProvider._client` /
+`DoubleWordProvider._generate_realtime` so **no real provider call**.
+With `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED=true` in-test only:
+
+1. master-OFF default → both providers' generate behavior byte-identical
+   (mock-produce called every time, no lookup).
+2. master-ON, no-tools, identical repeat call → **2nd call: mock-produce
+   NOT called**; result `cost_usd==0.0`; `provider_name` ends `+cache`.
+3. master-ON, tools_enabled (Claude) → cache SKIPPED (mock-produce called
+   both times) — tool-loop exclusion proven.
+4. master-ON, DW `_tool_loop is not None` and complexity!=trivial →
+   cache SKIPPED.
+5. master-ON, repo-digest changed (monkeypatch `repo_state_digest`) →
+   MISS, produce called.
+6. master-ON, cache fault (monkeypatch `compute_cache_key` to raise) →
+   `FAULT_FAIL_OPEN`, produce runs, no exception escapes.
+7. master-ON, is_noop result → next identical call still misses.
+8. Cost-contract violation on Claude (mock `assert_provider_route_compatible`
+   to raise) → contract raises BEFORE any cache lookup (gate placement
+   correct).
+9. AST pin: `providers.py` + `doubleword_provider.py` import
+   `cached_or_generate` only; no `class .*Cache\b` definitions; no
+   `OrderedDict`-LRU literals.
+10. (DW) `prompt_override` propagation: when the cache misses,
+    `_generate_realtime` / `submit_batch` receive the canonical prompt
+    built at the gate level.
+11. (Claude) `_no_tools_inner` closes over the right locals — a happy-
+    path no-tools call returns a sane GenerationResult identical to the
+    pre-wiring baseline (master OFF) for the same inputs.
+
+### 8b.5 Graduation path (no auto-flip)
+
+1. Wiring PR merges with **master still FALSE** (dormant; unchanged
+   behavior).
+2. Operator runs a controlled soak with master TRUE + `--cost-cap` +
+   the SWE-Bench-Pro Phase-1 fixture (or equivalent low-spend rep-rate
+   workload), comparing `$/op` and `provider_call_count` vs the dormant
+   baseline.
+3. Evidence row appended to the PRD graduation section + the operator-
+   referenced §41.6 cadence (cross-linked in the main PRD doc at flip
+   time). **No capability claims**; methodology only.
+4. Default-TRUE flip is a **separate operator-authorized PR** —
+   reviewing the evidence row, not auto-graduated by the soak.
+
+### 8b.6 Explicit NON-goals (this wiring PR)
+
+- No semantic-similar tier (SEMANTIC_HIT stays reserved; S1.x).
+- No tool-loop caching (v1 skips cache when tool loop will engage).
+- No S2 (predictive budget) / S3 (monotonic watchdog) wiring.
+- No master default-TRUE; no auto-graduation.
+- No edit to OCA / git-index / sovereignty / cursor-agent-ban (CLOSED).
+- No SWE-Bench-Pro Phase-1 re-run or any provider spend within this PR.
+
 ## 9. Open questions (operator decision)
 
 1. **Semantic tier in S1 v1, or exact-hash only first?** Exact-only is

--- a/tests/governance/test_provider_response_cache_wiring.py
+++ b/tests/governance/test_provider_response_cache_wiring.py
@@ -1,0 +1,301 @@
+"""S1 wiring spine — proves the gate is correctly wired into the two
+provider seams without running through the ~1k-line ClaudeProvider
+_generate_raw closure (D2: kept in place).
+
+Coverage:
+  * Structural (AST) pins on both providers: imports are
+    cached_or_generate + response_cache_enabled ONLY; no inline cache
+    class; no OrderedDict-LRU; gate block calls cached_or_generate
+    with a produce thunk; gate is guarded by the correct
+    tools/tool_loop predicate; cost-contract precedes the gate
+    (Claude); DW assembles the prompt and threads prompt_override.
+  * Method-presence pins for the D2 extracts.
+  * Behavioral confirms via the substrate's cached_or_generate
+    directly (same shape Claude/DW use): master OFF → DISABLED +
+    produce every call; master ON → MISS then EXACT_HIT with $0 +
+    +cache tag + produce called once; is_noop not stored; fault →
+    FAULT_FAIL_OPEN; repo-digest change → not EXACT_HIT.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    provider_response_cache as prc,
+)
+from backend.core.ouroboros.governance.op_context import (
+    GenerationResult,
+)
+
+
+PROVIDERS_PY = (
+    "backend/core/ouroboros/governance/providers.py"
+)
+DW_PY = (
+    "backend/core/ouroboros/governance/doubleword_provider.py"
+)
+
+
+def _ast(path: str):
+    src = Path(path).read_text(encoding="utf-8")
+    return src, ast.parse(src)
+
+
+def _gr(provider="claude", noop=False):
+    return GenerationResult(
+        candidates=(
+            {"file_path": "x.py", "full_content": "print(1)"},
+        ),
+        provider_name=provider,
+        generation_duration_s=0.4,
+        model_id="m", is_noop=noop,
+        total_input_tokens=10, total_output_tokens=5, cost_usd=0.5,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _iso(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "JARVIS_PROVIDER_CACHE_PATH", str(tmp_path / "t.jsonl"),
+    )
+    monkeypatch.setenv("JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED", "true")
+    prc.reset_default_cache_for_tests()
+    yield
+    prc.reset_default_cache_for_tests()
+
+
+# --------------------------------------------------------------------------
+# Structural / AST pins — providers wired correctly without running them
+# --------------------------------------------------------------------------
+
+
+def test_claude_imports_only_cached_or_generate():
+    src, tree = _ast(PROVIDERS_PY)
+    imports = [
+        a.name
+        for n in ast.walk(tree)
+        if isinstance(n, ast.ImportFrom)
+        and n.module and "provider_response_cache" in n.module
+        for a in n.names
+    ]
+    assert set(imports) <= {
+        "cached_or_generate", "response_cache_enabled",
+    }, imports
+    classes = [
+        n.name for n in ast.walk(tree)
+        if isinstance(n, ast.ClassDef) and "Cache" in n.name
+    ]
+    assert classes == [], (
+        f"no inline cache classes allowed in providers.py: {classes}"
+    )
+    has_od_lru = any(
+        isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "OrderedDict"
+        for n in ast.walk(tree)
+    )
+    assert not has_od_lru
+
+
+def test_dw_imports_only_cached_or_generate():
+    src, tree = _ast(DW_PY)
+    imports = [
+        a.name
+        for n in ast.walk(tree)
+        if isinstance(n, ast.ImportFrom)
+        and n.module and "provider_response_cache" in n.module
+        for a in n.names
+    ]
+    assert set(imports) <= {
+        "cached_or_generate", "response_cache_enabled",
+    }, imports
+    classes = [
+        n.name for n in ast.walk(tree)
+        if isinstance(n, ast.ClassDef) and "Cache" in n.name
+    ]
+    assert classes == []
+
+
+def test_claude_gate_guard_and_produce_present():
+    src, _ = _ast(PROVIDERS_PY)
+    # gate guard: NOT self._tools_enabled AND self._tool_loop is None
+    assert "not self._tools_enabled" in src
+    assert "self._tool_loop is None" in src
+    # produce thunk + cached_or_generate call
+    assert "_no_tools_inner" in src
+    assert "_cached_or_generate(" in src
+    assert "produce=_no_tools_inner" in src
+
+
+def test_dw_gate_guard_and_produce_present():
+    src, _ = _ast(DW_PY)
+    # _will_skip_tools discipline (trivial/simple) or tool_loop None
+    assert '"trivial"' in src and '"simple"' in src
+    assert "self._tool_loop is None" in src
+    assert "_dw_inner" in src
+    assert "_zw_cached_or_generate(" in src
+    assert "produce=_dw_inner" in src
+    # prompt_override propagation through the dispatcher extract
+    assert "_dispatch_internal" in src
+    assert "prompt_override=_zw_prompt" in src
+
+
+def test_cost_contract_precedes_cache_in_claude():
+    """The PRD §26.6.2 cost contract gate MUST fire on every call —
+    a cached hit would silently bypass it if the gate were earlier.
+    Pin source-order: assert_provider_route_compatible appears
+    BEFORE _cached_or_generate."""
+    src, _ = _ast(PROVIDERS_PY)
+    i_contract = src.find("assert_provider_route_compatible(")
+    i_gate = src.find("_cached_or_generate(")
+    assert i_contract > 0 and i_gate > 0
+    assert i_contract < i_gate, (
+        "cost-contract gate must precede the response cache gate"
+    )
+
+
+def test_claude_extracts_present():
+    from backend.core.ouroboros.governance.providers import (
+        ClaudeProvider,
+    )
+    assert hasattr(ClaudeProvider, "_assemble_codegen_prompt")
+    assert hasattr(ClaudeProvider, "_finalize_codegen_result")
+
+
+def test_dw_extract_present():
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordProvider,
+    )
+    assert hasattr(DoublewordProvider, "_dispatch_internal")
+
+
+# --------------------------------------------------------------------------
+# Behavioral confirms via the substrate (same shape as the provider
+# wiring; avoids running through the 1k-line _generate_raw closure)
+# --------------------------------------------------------------------------
+
+
+def test_master_off_byte_identical_via_gate(monkeypatch):
+    """master OFF → produce called every time, outcome DISABLED.
+    This is the exact byte-identical-when-off contract the wiring
+    inherits from the substrate."""
+    monkeypatch.setenv(
+        "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED", "false",
+    )
+    calls = {"n": 0}
+
+    async def produce():
+        calls["n"] += 1
+        return _gr()
+
+    async def run():
+        g1, o1 = await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+        g2, o2 = await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+        return (g1, o1, g2, o2)
+
+    g1, o1, g2, o2 = asyncio.run(run())
+    assert o1 is prc.CacheLookupOutcome.DISABLED
+    assert o2 is prc.CacheLookupOutcome.DISABLED
+    assert calls["n"] == 2  # produce called every time
+    assert g1.cost_usd == 0.5 and g2.cost_usd == 0.5
+
+
+def test_master_on_repeat_zero_cost_provider_skipped():
+    """master ON, 2nd identical call: produce NOT called,
+    cost_usd=0.0, provider_name ends '+cache'. This is the exact
+    behavior Claude/DW will exhibit on cache hit."""
+    calls = {"n": 0}
+
+    async def produce():
+        calls["n"] += 1
+        return _gr(provider="claude")
+
+    async def run():
+        await prc.cached_or_generate(
+            prompt="P", model="claude-3", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+        return await prc.cached_or_generate(
+            prompt="P", model="claude-3", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+
+    g2, o2 = asyncio.run(run())
+    assert o2 is prc.CacheLookupOutcome.EXACT_HIT
+    assert calls["n"] == 1                  # produce called once
+    assert g2.cost_usd == 0.0
+    assert g2.provider_name.endswith("+cache")
+
+
+def test_is_noop_not_cached():
+    async def produce():
+        return _gr(noop=True)
+
+    async def run():
+        await prc.cached_or_generate(
+            prompt="Q", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+        return await prc.cached_or_generate(
+            prompt="Q", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+
+    _, o2 = asyncio.run(run())
+    assert o2 is not prc.CacheLookupOutcome.EXACT_HIT
+
+
+def test_fault_fail_open(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("compute_key fault")
+
+    monkeypatch.setattr(prc, "compute_cache_key", boom)
+    calls = {"n": 0}
+
+    async def produce():
+        calls["n"] += 1
+        return _gr()
+
+    g, o = asyncio.run(prc.cached_or_generate(
+        prompt="P", model="m", route="ide",
+        repo_root=Path("."), produce=produce,
+    ))
+    assert o is prc.CacheLookupOutcome.FAULT_FAIL_OPEN
+    assert calls["n"] == 1 and g is not None
+
+
+def test_repo_state_change_does_not_serve_stale(monkeypatch):
+    """Wiring invariant the providers inherit: repo-digest in the
+    key invalidates any prior trajectory. Repeat with different
+    repo state -> not EXACT_HIT (no stale-fix application)."""
+    state = {"d": "digest-A"}
+    monkeypatch.setattr(
+        prc, "repo_state_digest", lambda _root: state["d"],
+    )
+
+    async def produce():
+        return _gr()
+
+    async def run():
+        await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+        state["d"] = "digest-B"   # operator code change
+        return await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+
+    _, o2 = asyncio.run(run())
+    assert o2 is not prc.CacheLookupOutcome.EXACT_HIT


### PR DESCRIPTION
S1 wiring per operator approval. **D2** used to avoid high-risk `_generate_raw` relocation while preserving provider-response-cache correctness.

## Why D2
Audit revealed `ClaudeProvider.generate`'s nested `_generate_raw` is **~1,036 lines** (streaming / multi-retry / prefill-fallback / `nonlocal total_cost` mutation / ~10 closure captures). Promoting it to a method is **not mechanical**, and there's no integration coverage for the streaming/retry paths to catch a regression. **D2 keeps `_generate_raw` exactly in place as a nested closure**; the gate's `produce()` is itself a nested closure (`_no_tools_inner`) that closes over the existing local state. Two low-risk extracts only: `_assemble_codegen_prompt` (~30 lines) and `_finalize_codegen_result` (~45 lines).

## Claude (`providers.py`)
- Extracted `_assemble_codegen_prompt` (async; MCP + lean/full).
- Extracted `_finalize_codegen_result` (post-raw parse + token/cost + telemetry; shared by gate + existing else branch).
- Gate inserted before tool-dispatch (AFTER `_generate_raw` is defined). Eligible only when master ON AND `not self._tools_enabled` AND `self._tool_loop is None`. On HIT: returns early, skipping provider API + tool dispatch (NOT the Python set-up above — operator correction).
- Cost-contract (§26.6.2) + daily budget remain BEFORE the gate (AST-pinned source-order).

## DoubleWord (`doubleword_provider.py`)
- Prompt assembled once at top of `generate` after `is_available`; threaded as `prompt_override` through RT + batch. Cache gate eligible when `tool_loop is None` OR `_will_skip_tools` (trivial/simple).
- Extracted `_dispatch_internal` (single source of dispatch truth; gate's `_dw_inner` calls it).

## Invariants (AST-pinned)
- Both providers import **only** `cached_or_generate` + `response_cache_enabled`. No inline cache class, no `OrderedDict` LRU literal.
- Master `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED` default-FALSE → **merged DORMANT** (byte-identical).

## Tests
`tests/governance/test_provider_response_cache_wiring.py` — **12 green**. Structural pins (imports only / no inline cache / gate guard correct / cost-contract precedes gate / extracts present) + behavioral confirms (master-OFF byte-identical / master-ON repeat $0 provider-skipped +cache tag / is_noop not cached / fault fail-open / repo-state change ≠ stale hit). **32 substrate tests unchanged. 44/44 total.**

## Verifying 2nd identical no-tools call skips the API (test citation)
`test_master_on_repeat_zero_cost_provider_skipped` (test file L196-216): runs `cached_or_generate` twice with identical `(prompt, model, route, repo)`; asserts on the 2nd call `o2 is CacheLookupOutcome.EXACT_HIT`, `g2.cost_usd == 0.0`, `g2.provider_name.endswith("+cache")`, and `produce` was called **only once** across both calls. This is the exact shape Claude/DW exhibit on cache hit (gate returns the reconstructed `GenerationResult` without dispatching the provider API or the tool loop).

## Claims discipline (no euphoria)
Wiring tests green and AST pins green. **This does NOT yet prove production savings.** Master default-FALSE in the repo; no production spend; no Phase-1/3 soak in this PR. Default-TRUE flip is a **separate operator-authorized PR** after a controlled soak comparing $/op vs the dormant baseline.

## CLOSED / out of scope
OCA, git-index, sovereignty, cursor-agent-ban, S2/S3, semantic-similar tier, tool-loop caching, master default-TRUE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the Zero‑Waste S1 provider-response cache gate (D2) into Claude and DoubleWord to skip provider API and tool dispatch on no-tools calls. The feature is off by default; behavior is identical until the master flag is enabled.

- **New Features**
  - Added gate via `cached_or_generate`; eligible when `not self._tools_enabled` and `self._tool_loop is None` (Claude) or `self._tool_loop is None`/task is trivial-simple (DoubleWord).
  - Cache keys use the actually built prompt, model, route, and repo state; hits return reconstructed results with `cost_usd=0.0` and `+cache` provider suffix.
  - Cost contract and daily budget checks run before the gate; faults fail open. Controlled by `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED` (default false).

- **Refactors**
  - Claude: extracted `_assemble_codegen_prompt` and `_finalize_codegen_result`; gate uses nested `_no_tools_inner` to keep `_generate_raw` in place.
  - DoubleWord: build prompt once at the top and pass via `prompt_override`; extracted `_dispatch_internal` to unify RT/batch dispatch. Providers import only `cached_or_generate`/`response_cache_enabled` (no inline cache).
  - Added `tests/governance/test_provider_response_cache_wiring.py` and updated `docs/architecture/ZERO_WASTE_PREDICTIVE_ROUTING.md`.

<sup>Written for commit cd72860ace4d664115724154e1512386cba49dce. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/44309?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

