### PR TITLE
feat(governance): Zero-Waste S1 — Shadow Mode (telemetry-only, dormant default-FALSE)

### DIFF
--- a/backend/core/ouroboros/governance/provider_response_cache.py
+++ b/backend/core/ouroboros/governance/provider_response_cache.py
@@ -63,6 +63,7 @@ logger = logging.getLogger("Ouroboros.ProviderResponseCache")
 PROVIDER_RESPONSE_CACHE_SCHEMA_VERSION: str = "provider_response_cache.v1"
 
 _ENV_MASTER = "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED"
+_ENV_SHADOW = "JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW"
 _ENV_MAX_BYTES = "JARVIS_PROVIDER_CACHE_MAX_BYTES"
 _ENV_TTL_S = "JARVIS_PROVIDER_CACHE_TTL_S"
 _ENV_PATH = "JARVIS_PROVIDER_CACHE_PATH"
@@ -81,6 +82,19 @@ def response_cache_enabled() -> bool:
     """Master switch, default-FALSE (PRD §7). Re-read each call so a
     flip hot-reverts. NEVER raises."""
     return os.environ.get(_ENV_MASTER, "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def shadow_mode_enabled() -> bool:
+    """Independent of master. When BOTH master ON AND shadow ON, a
+    cache HIT is logged as ``[PRC] SHADOW_HIT cost_would_have_saved=$X``
+    and the request still falls through to ``produce()`` (no behavior
+    change to the upstream provider). When master is OFF, shadow is
+    a no-op regardless of this flag (master takes precedence).
+    Default-FALSE (PRD §10.10). Re-read each call so a flip hot-
+    reverts. NEVER raises."""
+    return os.environ.get(_ENV_SHADOW, "false").strip().lower() in (
         "1", "true", "yes", "on",
     )
 
@@ -128,6 +142,7 @@ class CacheLookupOutcome(str, enum.Enum):
     DISABLED = "disabled"
     INVALIDATED_REPO_CHANGE = "invalidated_repo_change"
     FAULT_FAIL_OPEN = "fault_fail_open"
+    SHADOW_HIT_PASSTHROUGH = "shadow_hit_passthrough"  # PRD §10.10 — observed but not acted on
 
 
 # ---------------------------------------------------------------------------
@@ -225,6 +240,11 @@ class CachedTrajectory:
     total_input_tokens: int
     total_output_tokens: int
     n_bytes: int
+    # PRD §10.10: original ``cost_usd`` at store time. Powers shadow-mode
+    # ``cost_would_have_saved`` telemetry. Additive: default 0.0 means
+    # "unknown" (older serialized entries without this field roundtrip
+    # cleanly as 0.0; their would-save is reported as $0.000000).
+    original_cost_usd: float = 0.0
     created_at: float = field(default_factory=time.monotonic)
     schema_version: str = PROVIDER_RESPONSE_CACHE_SCHEMA_VERSION
 
@@ -240,6 +260,7 @@ class CachedTrajectory:
             "total_input_tokens": self.total_input_tokens,
             "total_output_tokens": self.total_output_tokens,
             "n_bytes": self.n_bytes,
+            "original_cost_usd": self.original_cost_usd,
             "created_at": self.created_at,
             "schema_version": self.schema_version,
         }
@@ -260,6 +281,8 @@ class CachedTrajectory:
                 total_input_tokens=int(d.get("total_input_tokens", 0)),
                 total_output_tokens=int(d.get("total_output_tokens", 0)),
                 n_bytes=int(d.get("n_bytes", 0)),
+                # Additive field: missing in legacy entries → 0.0 fallback.
+                original_cost_usd=float(d.get("original_cost_usd", 0.0) or 0.0),
                 created_at=float(d.get("created_at", time.monotonic())),
                 schema_version=str(
                     d.get("schema_version",
@@ -301,6 +324,13 @@ def _trajectory_from_generation_result(
                 getattr(gr, "total_output_tokens", 0) or 0
             ),
             n_bytes=len(payload.encode("utf-8", "replace")),
+            # PRD §10.10: capture original spend for shadow telemetry.
+            # Clamp negatives to 0.0 defensively (provider should never
+            # report negative cost; this guarantees the would-save log
+            # never displays a misleading negative).
+            original_cost_usd=max(
+                0.0, float(getattr(gr, "cost_usd", 0.0) or 0.0),
+            ),
         )
     except Exception:  # noqa: BLE001
         return None
@@ -515,6 +545,10 @@ async def cached_or_generate(
     full: str = ""
     pref: str = ""
     outcome: CacheLookupOutcome = CacheLookupOutcome.MISS
+    # PRD §10.10: shadow-mode flag captured ONCE per call so a mid-call
+    # env flip cannot make us return cached on the HIT branch but skip
+    # the store on the MISS branch (or vice-versa).
+    shadow: bool = shadow_mode_enabled()
     try:
         full, pref = compute_cache_key(
             str(prompt), str(model), str(route), Path(repo_root),
@@ -522,25 +556,42 @@ async def cached_or_generate(
         cache = get_default_cache()
         outcome, traj = cache.lookup(full, pref)
         if outcome is CacheLookupOutcome.EXACT_HIT and traj is not None:
-            gr = reconstruct_generation_result(traj)
-            if gr is not None:
+            if shadow:
+                # Shadow mode: observe, log, but DO NOT return cached —
+                # fall through to produce() so the upstream provider is
+                # still hit (application state integrity guaranteed).
+                # MISS-path post-store skipped (entry already present).
                 logger.info(
-                    "[PRC] EXACT_HIT — provider skipped, $0.00 "
-                    "(model=%s route=%s)", model, route,
+                    "[PRC] SHADOW_HIT cost_would_have_saved=$%.6f "
+                    "(model=%s route=%s)",
+                    float(traj.original_cost_usd or 0.0), model, route,
                 )
-                return gr, CacheLookupOutcome.EXACT_HIT
-            # reconstruction failed → fall through to real call
+                outcome = CacheLookupOutcome.SHADOW_HIT_PASSTHROUGH
+                # Intentional fall-through: do NOT return here.
+            else:
+                gr = reconstruct_generation_result(traj)
+                if gr is not None:
+                    logger.info(
+                        "[PRC] EXACT_HIT — provider skipped, $0.00 "
+                        "(model=%s route=%s)", model, route,
+                    )
+                    return gr, CacheLookupOutcome.EXACT_HIT
+                # reconstruction failed → fall through to real call
     except Exception as exc:  # noqa: BLE001 — fail-open
         logger.debug("[PRC] gate fault (fail-open): %s", exc)
         return await produce(), CacheLookupOutcome.FAULT_FAIL_OPEN
-    # Miss / invalidated / reconstruction-failed → real generation,
-    # then best-effort store (store-omission is fail-safe).
+    # Miss / invalidated / reconstruction-failed / SHADOW_HIT_PASSTHROUGH
+    # → real generation, then best-effort store (store-omission is
+    # fail-safe). On SHADOW_HIT_PASSTHROUGH the entry already exists at
+    # this key — skip the store to avoid an idempotent re-write thrash
+    # against the LRU.
     gr = await produce()
     try:
         if (
             full
             and gr is not None
             and not getattr(gr, "is_noop", False)
+            and outcome is not CacheLookupOutcome.SHADOW_HIT_PASSTHROUGH
         ):
             t = _trajectory_from_generation_result(full, pref, gr)
             get_default_cache().store(t)
@@ -555,6 +606,7 @@ __all__ = [
     "CachedTrajectory",
     "ProviderResponseCache",
     "response_cache_enabled",
+    "shadow_mode_enabled",
     "cache_max_bytes",
     "cache_ttl_s",
     "repo_state_digest",
@@ -585,6 +637,20 @@ def register_flags(registry) -> int:  # noqa: ANN001
             description=(
                 "Master for the zero-waste provider response cache. "
                 "OFF (default, §33.1) ⇒ provider path byte-identical."
+            ),
+        ),
+        FlagSpec(
+            name=_ENV_SHADOW, type=FlagType.BOOL, default=False,
+            category=Category.SAFETY, source_file=tgt,
+            example=f"{_ENV_SHADOW}=true",
+            description=(
+                "Shadow-mode telemetry (PRD §10.10). Independent of "
+                "master. When master ON AND shadow ON, a cache HIT is "
+                "logged as `[PRC] SHADOW_HIT cost_would_have_saved=$X` "
+                "and the request still falls through to the upstream "
+                "provider (no behavior change). Use to gather real-"
+                "workload hit-rate evidence before any default-TRUE "
+                "flip of the master."
             ),
         ),
         FlagSpec(
@@ -661,6 +727,8 @@ def register_shipped_invariants() -> list:
         required = {
             "EXACT_HIT", "SEMANTIC_HIT", "MISS", "DISABLED",
             "INVALIDATED_REPO_CHANGE", "FAULT_FAIL_OPEN",
+            # PRD §10.10 — observed-but-not-acted shadow outcome.
+            "SHADOW_HIT_PASSTHROUGH",
         }
         for node in _ast.walk(tree):
             if isinstance(node, _ast.ClassDef) and (

--- a/tests/governance/test_provider_response_cache.py
+++ b/tests/governance/test_provider_response_cache.py
@@ -293,15 +293,18 @@ def test_store_never_raises():
 # -- registration contract -------------------------------------------------
 
 
-def test_register_flags_three():
+def test_register_flags_four():
+    """Seed count pin. Master + shadow + max_bytes + ttl_s = 4.
+    PRD §10.10: shadow added as the 4th seed."""
     seen = []
 
     class _R:
         def register(self, s):
             seen.append(s.name)
 
-    assert prc.register_flags(_R()) == 3
+    assert prc.register_flags(_R()) == 4
     assert "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED" in seen
+    assert "JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW" in seen
 
 
 def test_ast_pin_self_validates_green():
@@ -309,3 +312,242 @@ def test_ast_pin_self_validates_green():
     assert len(invs) == 1
     src = Path(prc.__file__).read_text(encoding="utf-8")
     assert invs[0].validate(ast.parse(src), src) == ()
+
+
+# -- shadow mode (PRD §10.10) ----------------------------------------------
+
+
+def _gr_with_cost(cost_usd=0.5, content="print(1)"):
+    """Builds a GenerationResult with a specific cost_usd, used to
+    verify ``original_cost_usd`` is captured at store time and surfaced
+    as the shadow-mode ``cost_would_have_saved`` telemetry value."""
+    return GenerationResult(
+        candidates=({"file_path": "x.py", "full_content": content},),
+        provider_name="dw", generation_duration_s=1.0,
+        model_id="m", is_noop=False,
+        total_input_tokens=10, total_output_tokens=5,
+        cost_usd=cost_usd,
+    )
+
+
+def test_shadow_mode_default_false(monkeypatch):
+    """Independent of master; default-FALSE; case-insensitive parser
+    matches master's discipline."""
+    monkeypatch.delenv("JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW",
+                       raising=False)
+    assert prc.shadow_mode_enabled() is False
+    for val, exp in [("true", True), ("1", True), ("YES", True),
+                     ("on", True), ("false", False), ("", False),
+                     ("garbage", False)]:
+        monkeypatch.setenv("JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW", val)
+        assert prc.shadow_mode_enabled() is exp, val
+
+
+def test_shadow_enum_value_exists_and_distinct():
+    """SHADOW_HIT_PASSTHROUGH is in the closed taxonomy and is
+    distinct from every other outcome."""
+    assert hasattr(prc.CacheLookupOutcome, "SHADOW_HIT_PASSTHROUGH")
+    s = prc.CacheLookupOutcome.SHADOW_HIT_PASSTHROUGH
+    for other in (
+        prc.CacheLookupOutcome.EXACT_HIT,
+        prc.CacheLookupOutcome.SEMANTIC_HIT,
+        prc.CacheLookupOutcome.MISS,
+        prc.CacheLookupOutcome.DISABLED,
+        prc.CacheLookupOutcome.INVALIDATED_REPO_CHANGE,
+        prc.CacheLookupOutcome.FAULT_FAIL_OPEN,
+    ):
+        assert s is not other
+
+
+def test_trajectory_carries_original_cost(monkeypatch, tmp_path):
+    """``CachedTrajectory.original_cost_usd`` captures
+    ``gr.cost_usd`` at store time. Roundtrip preserves it."""
+    full, pref = prc.compute_cache_key(
+        "P", "m", "ide", Path(tmp_path),
+    )
+    gr = _gr_with_cost(cost_usd=0.123456)
+    t = prc._trajectory_from_generation_result(full, pref, gr)
+    assert t is not None
+    assert t.original_cost_usd == pytest.approx(0.123456)
+    # Roundtrip preserves the field
+    t2 = prc.CachedTrajectory.from_dict(t.to_dict())
+    assert t2 is not None
+    assert t2.original_cost_usd == pytest.approx(0.123456)
+
+
+def test_legacy_trajectory_dict_defaults_zero():
+    """An older serialized entry without ``original_cost_usd`` must
+    deserialize cleanly with 0.0 (means 'unknown would-save')."""
+    d = {
+        "full_key": "k", "prefix_key": "p", "candidates": [],
+        "provider_name": "dw", "model_id": "m", "is_noop": False,
+        "prompt_preloaded_files": [], "total_input_tokens": 0,
+        "total_output_tokens": 0, "n_bytes": 0,
+        # original_cost_usd intentionally absent
+        "created_at": 0.0,
+        "schema_version": prc.PROVIDER_RESPONSE_CACHE_SCHEMA_VERSION,
+    }
+    t = prc.CachedTrajectory.from_dict(d)
+    assert t is not None
+    assert t.original_cost_usd == 0.0
+
+
+def test_shadow_hit_does_not_short_circuit_provider(monkeypatch):
+    """Master ON + shadow ON: identical 2nd call must run produce()
+    (no cache short-circuit), return the fresh GR, and the outcome
+    must be SHADOW_HIT_PASSTHROUGH (not EXACT_HIT)."""
+    monkeypatch.setenv("JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW", "true")
+    calls = {"n": 0}
+
+    async def produce():
+        calls["n"] += 1
+        return _gr_with_cost(cost_usd=0.42)
+
+    async def run():
+        g1, o1 = await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+        g2, o2 = await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+        return g1, o1, g2, o2
+
+    g1, o1, g2, o2 = asyncio.run(run())
+    assert o1 is prc.CacheLookupOutcome.MISS
+    # Hit at lookup time, but flow goes through produce — outcome
+    # signals "observed but not acted upon".
+    assert o2 is prc.CacheLookupOutcome.SHADOW_HIT_PASSTHROUGH
+    # produce was called BOTH times (no short-circuit).
+    assert calls["n"] == 2
+    # Both responses come from produce (fresh provider call), so the
+    # 2nd response has the full cost_usd, NOT 0.0.
+    assert g1.cost_usd == pytest.approx(0.42)
+    assert g2.cost_usd == pytest.approx(0.42)
+    # provider_name is NOT tagged "+cache" — upstream was hit.
+    assert not g2.provider_name.endswith("+cache")
+
+
+def test_shadow_passthrough_does_not_overwrite_store(monkeypatch):
+    """On SHADOW_HIT_PASSTHROUGH the key is already present; the post-
+    produce store path is skipped to avoid LRU re-write thrash."""
+    monkeypatch.setenv("JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW", "true")
+    call_log = []
+    real_store = prc.ProviderResponseCache.store
+
+    def counting_store(self, t):
+        call_log.append(t.full_key if t is not None else None)
+        return real_store(self, t)
+
+    monkeypatch.setattr(prc.ProviderResponseCache, "store", counting_store)
+
+    async def produce():
+        return _gr_with_cost(cost_usd=0.42)
+
+    async def run():
+        await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+        return await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+
+    g2, o2 = asyncio.run(run())
+    assert o2 is prc.CacheLookupOutcome.SHADOW_HIT_PASSTHROUGH
+    # Exactly ONE store call — the cold MISS path. The shadow-HIT
+    # call#2 must NOT trigger a second store.
+    assert len(call_log) == 1
+
+
+def test_shadow_off_master_on_normal_hit():
+    """Sanity: with shadow OFF (default), master-ON behavior is the
+    canonical EXACT_HIT path — no shadow code interferes."""
+    calls = {"n": 0}
+
+    async def produce():
+        calls["n"] += 1
+        return _gr_with_cost(cost_usd=0.42)
+
+    async def run():
+        await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+        return await prc.cached_or_generate(
+            prompt="P", model="m", route="ide",
+            repo_root=Path("."), produce=produce,
+        )
+
+    g2, o2 = asyncio.run(run())
+    assert o2 is prc.CacheLookupOutcome.EXACT_HIT
+    assert calls["n"] == 1                 # produce called once
+    assert g2.cost_usd == 0.0
+    assert g2.provider_name.endswith("+cache")
+
+
+def test_shadow_on_master_off_is_disabled(monkeypatch):
+    """Master takes precedence: shadow-mode is meaningless without
+    master ON. When master OFF, outcome is DISABLED regardless of
+    shadow."""
+    monkeypatch.setenv("JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW", "true")
+
+    async def produce():
+        return _gr_with_cost(cost_usd=0.42)
+
+    g, o = asyncio.run(prc.cached_or_generate(
+        prompt="P", model="m", route="ide",
+        repo_root=Path("."), produce=produce,
+    ))
+    assert o is prc.CacheLookupOutcome.DISABLED
+    assert g.cost_usd == pytest.approx(0.42)
+
+
+def test_shadow_hit_logs_cost_would_have_saved(caplog, monkeypatch):
+    """The `[PRC] SHADOW_HIT cost_would_have_saved=$X` log line is
+    emitted on the 2nd identical call with shadow ON, and X equals
+    the stored ``original_cost_usd`` from call #1."""
+    import logging as _logging
+    monkeypatch.setenv("JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW", "true")
+
+    async def produce():
+        return _gr_with_cost(cost_usd=0.071234)
+
+    with caplog.at_level(_logging.INFO,
+                         logger="Ouroboros.ProviderResponseCache"):
+        async def run():
+            await prc.cached_or_generate(
+                prompt="P", model="m", route="ide",
+                repo_root=Path("."), produce=produce,
+            )
+            return await prc.cached_or_generate(
+                prompt="P", model="m", route="ide",
+                repo_root=Path("."), produce=produce,
+            )
+
+        asyncio.run(run())
+
+    shadow_lines = [
+        r.getMessage() for r in caplog.records
+        if "SHADOW_HIT" in r.getMessage()
+    ]
+    assert len(shadow_lines) == 1, shadow_lines
+    # Cost rendered with 6-decimal precision (PRD §10.10 format).
+    assert "cost_would_have_saved=$0.071234" in shadow_lines[0]
+    assert "model=m" in shadow_lines[0]
+    assert "route=ide" in shadow_lines[0]
+
+
+def test_shadow_negative_cost_clamped_to_zero(monkeypatch):
+    """Defensive: a (hypothetical) negative provider cost is clamped
+    to 0.0 at store time so the would-save log is never misleading."""
+    full, pref = prc.compute_cache_key(
+        "P", "m", "ide", Path("."),
+    )
+    bad = _gr_with_cost(cost_usd=-1.0)
+    t = prc._trajectory_from_generation_result(full, pref, bad)
+    assert t is not None
+    assert t.original_cost_usd == 0.0


### PR DESCRIPTION
## S1 Shadow Mode — telemetry-only path, dormant default-FALSE

PRD §10.10 — adds an opt-in shadow-mode telemetry path to the wired `ProviderResponseCache`. Lets operators measure real-workload cache-hit-rate without touching upstream provider behavior, ahead of any default-TRUE flip of the master.

**Composes everything; duplicates nothing.** No new cache class, no new persistence layer, no new gate. One new branch in the existing `cached_or_generate` gate, one new env knob, one new closed-taxonomy outcome value, one additive field on `CachedTrajectory`.

---

### Behavior matrix

| `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED` | `JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW` | Effect |
|---|---|---|
| FALSE *(default)* | * (ignored) | **Byte-identical to today.** Gate not invoked. |
| TRUE | FALSE *(default)* | Existing behavior: EXACT_HIT short-circuits provider with `cost_usd=0.0` + `+cache` tag. |
| TRUE | TRUE | **Shadow mode**: lookup proceeds; on HIT, log `[PRC] SHADOW_HIT cost_would_have_saved=$X` AND **fall through to `produce()`** (real provider call still fires; application state integrity guaranteed). Outcome reported as `SHADOW_HIT_PASSTHROUGH`. |
| FALSE | TRUE | Master precedence: shadow is a no-op (master OFF wins). |

### Load-bearing invariants (AST-pinned + tested)

- `shadow_mode_enabled()` is independent of master; default-FALSE; re-read per call; never raises.
- `CacheLookupOutcome` closed taxonomy now includes `SHADOW_HIT_PASSTHROUGH` (exact-set equality enforced by AST pin: both `required - seen` AND `seen - required` arms).
- `CachedTrajectory.original_cost_usd` is **additive** (default 0.0). Legacy serialized entries deserialize cleanly with the 0.0 fallback; their would-save is reported as `$0.000000`. Schema version unchanged.
- Cost at store time is `max(0.0, gr.cost_usd)` — negative-cost defensive clamp so the would-save log can never display a misleading negative.
- The shadow-bool is captured **once per gate call** so a mid-call env flip can't half-fire the path (shadow-on-HIT but not-shadow-on-store, or vice-versa).
- `SHADOW_HIT_PASSTHROUGH` skips the post-produce store path (entry already at this key; no LRU re-write thrash).

### Memory profile — fits the 72-hour soak within 16 GB

| Component | Memory class | Growth pattern under 72h shadow |
|---|---|---|
| Shadow `logger.info()` calls | O(1) per emission | LogRecord garbage-collected after emit; no accumulation in the logger path |
| `ProviderResponseCache` in-mem ring | bounded byte-LRU | Capped at `JARVIS_PROVIDER_CACHE_MAX_BYTES` (default **256 MiB**, clamped to `[1 MiB, 4 GiB]`) — pre-existing discipline; shadow adds no new in-memory state |
| `original_cost_usd` per entry | +8 bytes (float64) | Negligible (256 MiB / 877-byte typical entry = ~300k entries × 8B = ~2.4 MiB at full LRU) |
| Persistence | `cross_process_jsonl` append-log | Bounded replay on boot (50k lines max) |

Net under shadow ON for 72h: at-most one on-disk trajectory per unique `(prompt, model, route, repo-state)` tuple, capped by the existing byte-LRU. **No new memory growth surface introduced by this PR.**

### Diff stats

```
backend/core/ouroboros/governance/provider_response_cache.py | +84 / -10
tests/governance/test_provider_response_cache.py             | +246 / -1
2 files changed, 320 insertions(+), 11 deletions(-)
```

### Test spine — 54/54 green

| Test | What it pins |
|---|---|
| `test_shadow_mode_default_false` | env parser is case-insensitive; absent/empty/garbage → FALSE |
| `test_shadow_enum_value_exists_and_distinct` | `SHADOW_HIT_PASSTHROUGH` in closed taxonomy, distinct from every other outcome |
| `test_trajectory_carries_original_cost` | `original_cost_usd` captured at store time + survives roundtrip |
| `test_legacy_trajectory_dict_defaults_zero` | older serialized entries (no `original_cost_usd` key) deserialize cleanly |
| `test_shadow_hit_does_not_short_circuit_provider` | **load-bearing**: shadow ON + identical 2nd call → produce() IS called, outcome = `SHADOW_HIT_PASSTHROUGH`, fresh GR returned |
| `test_shadow_passthrough_does_not_overwrite_store` | post-produce store skipped on shadow hit (no LRU thrash) |
| `test_shadow_off_master_on_normal_hit` | regression on canonical EXACT_HIT path (shadow code doesn't interfere when shadow=OFF) |
| `test_shadow_on_master_off_is_disabled` | master precedence: master OFF + shadow ON → outcome = `DISABLED` |
| `test_shadow_hit_logs_cost_would_have_saved` | exact log format pin: `cost_would_have_saved=$0.071234`, `model=`, `route=` |
| `test_shadow_negative_cost_clamped_to_zero` | defensive: negative provider cost clamps to 0.0 at store time |
| existing 44 tests | substrate + wiring — all unchanged; `test_register_flags_three` renamed `_four` with shadow-included pin |

### Out of scope (explicit)

- ❌ No default-TRUE flip of master (`JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED` stays FALSE)
- ❌ No default-TRUE flip of shadow (`JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW` stays FALSE) — both flags must be opt-in
- ❌ No PRD §10.10 doc row on this branch (deferred to follow-up PR after PR #44604 merges, to avoid two-PR doc conflicts)
- ❌ No S2 code (Predictive Budget Preemption — design-only per PRD §5; in-conversation finalization with dynamic MAD-based safety factor)
- ❌ No edits to OCA / git-index / sovereignty / cursor-agent-ban / Visual VERIFY / Orange-tier / Iron Gate / SemanticGuardian / SWE-Bench-Pro

### Operator usage (post-merge, post-PR #44604-merge for full evidence trail)

```bash
# 72-hour real-workload telemetry gathering:
export JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED=true   # master ON
export JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW=true    # shadow ON

# Then run JARVIS normally. Grep aggregates over the log:
grep -F '[PRC] SHADOW_HIT cost_would_have_saved=$' debug.log \
  | awk -F'\\$' '{ s+=$2 } END { printf "hits=%d total_would_save=$%.6f\n", NR, s }'

# At any point, master+shadow can be flipped back to FALSE without restart
# (re-read per call); the cache stays warm for the next shadow window.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in shadow mode to the provider response cache to measure real hit rate and “would‑save” cost without changing upstream provider behavior. Defaults off; no behavior changes unless `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED=true` and `JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW=true`.

- **New Features**
  - New env flag `JARVIS_PROVIDER_RESPONSE_CACHE_SHADOW` (default false). Effective only when `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED` is true; master flag takes precedence.
  - Shadow exact hit: logs `[PRC] SHADOW_HIT cost_would_have_saved=$X (model=..., route=...)`, still calls the provider, and returns outcome `SHADOW_HIT_PASSTHROUGH`; skips post-produce store to avoid LRU rewrite.
  - Added `original_cost_usd` to `CachedTrajectory` (additive, default 0.0; negatives clamped to 0.0) to power the cost telemetry.
  - Added `shadow_mode_enabled()` and snapshot the flag once per call to avoid mid-call flips.
  - Closed taxonomy extended and AST invariant updated; tests cover env parsing, schema compatibility, logging format, and behavior on hits/misses.

<sup>Written for commit 819be59028a455a235f46a34c4679164549b1093. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/44716?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

