### PR TITLE
feat(governance): S2 wiring — provider-side admission hook + record_op_outcome + session-budget precedence (master default-FALSE)

### DIFF
--- a/backend/core/ouroboros/governance/cost_governor.py
+++ b/backend/core/ouroboros/governance/cost_governor.py
@@ -863,6 +863,40 @@ class CostGovernor:
         """Return the number of currently tracked ops (for tests/diagnostics)."""
         return len(self._entries)
 
+    # ----------------------------------------------------------------------
+    # PRD §11 (S2) additive composition surface — session-wide aggregate
+    # ----------------------------------------------------------------------
+    # S2's predictive admission predicate needs the cross-op cumulative
+    # spend within this process. Rather than maintain a parallel
+    # accumulator (which would risk drift from the per-op ledger), this
+    # method composes the existing ``_entries`` dict via a one-shot
+    # materialized snapshot. NEVER raises; returns 0.0 on any fault.
+    #
+    # No lock is taken — the class does not maintain ``self._lock``.
+    # ``list(dict.values())`` is safe under CPython's GIL for the
+    # bounded read this method performs (no in-flight mutation can
+    # break a list materialization). A concurrent ``charge()`` may
+    # update an entry's ``cumulative_usd`` mid-iteration; the result
+    # reflects either the pre- or post-charge value of that entry,
+    # which is acceptable for an S2 advisory predicate.
+
+    def session_total_cumulative_usd(self) -> float:
+        """Sum of ``cumulative_usd`` across all _entries in this
+        process. Composes the existing per-op ledger — NO parallel
+        accumulator. NEVER raises. Returns 0.0 on any fault."""
+        try:
+            entries_snapshot = list(self._entries.values())
+            return float(sum(
+                float(getattr(entry, "cumulative_usd", 0.0) or 0.0)
+                for entry in entries_snapshot
+            ))
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[CostGovernor] session_total_cumulative_usd "
+                "degraded: %s", exc,
+            )
+            return 0.0
+
 
 # -----------------------------------------------------------------------------
 # Finalize observer registry (Per-Phase Cost Drill-Down arc Slice 3)

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -981,6 +981,39 @@ class DoublewordProvider:
                     _zw_model = self._effective_model_id(context)
                 except Exception:  # noqa: BLE001
                     _zw_model = getattr(self, "_model", "doubleword")
+
+                # ── S2 — Predictive Budget Preemption (PRD §11.4) ──
+                # Co-located with assembled _zw_prompt (B3 invariant).
+                # Master OFF ⇒ skipped; behavior byte-identical. S2 is
+                # ADVISORY — does NOT alter this op's dispatch path;
+                # merely emits a preemption signal to nudge
+                # sensor_governor against FUTURE low-priority sensor
+                # emissions. High-urgency routes are immune at the
+                # governor's signal-application surface. Uses
+                # _effective_model_id(context) — the actual model
+                # resolved for dispatch, NOT self._model. NEVER raises.
+                try:
+                    from backend.core.ouroboros.governance.s2_predictive_budget import (  # noqa: E501
+                        evaluate_admission_pressure as _s2_pressure_check,
+                        emit_preemption_signal as _s2_emit,
+                    )
+                    _s2_severity = _s2_pressure_check(
+                        prompt_text=(_zw_prompt or ""),
+                        route=getattr(
+                            context, "provider_route", "",
+                        ) or "standard",
+                        model=str(_zw_model or ""),
+                    )
+                    if _s2_severity is not None:
+                        _s2_emit(severity=_s2_severity,
+                                 high_prio_queued=True)
+                except Exception as _s2_exc:  # noqa: BLE001 — fail-open
+                    logger.debug(
+                        "[S2] DW admission integration degraded: %s",
+                        _s2_exc,
+                    )
+                # ───────────────────────────────────────────────────
+
                 _gr, _ = await _zw_cached_or_generate(
                     prompt=_zw_prompt,
                     model=_zw_model,
@@ -1043,6 +1076,44 @@ class DoublewordProvider:
             raise DoublewordInfraError(
                 "Batch retrieval failed", status_code=self._last_error_status,
             )
+        # ── S2 — record op_outcome for MAD sample stream (PRD §11 B4) ─
+        # Reached ONLY on real provider success (post-batch return).
+        # Belt-and-suspenders: skip if provider_name carries the
+        # "+cache" reconstruction marker. Uses _effective_model_id
+        # (the actual model used for dispatch). Master-gated;
+        # NEVER raises.
+        try:
+            from backend.core.ouroboros.governance.s2_predictive_budget import (  # noqa: E501
+                master_enabled as _s2_master_check,
+            )
+            if _s2_master_check():
+                _pname = str(getattr(result, "provider_name", "") or "")
+                if not _pname.endswith("+cache"):
+                    try:
+                        _s2_eff_model = self._effective_model_id(context)
+                    except Exception:  # noqa: BLE001
+                        _s2_eff_model = getattr(self, "_model", "") or ""
+                    from backend.core.ouroboros.governance.admission_estimator import (  # noqa: E501
+                        get_default_history as _s2_history,
+                    )
+                    _s2_history().record_op_outcome(
+                        route=getattr(
+                            context, "provider_route", "",
+                        ) or "standard",
+                        model=str(_s2_eff_model or ""),
+                        output_tokens=int(
+                            getattr(result, "total_output_tokens", 0) or 0,
+                        ),
+                        cost_usd=float(
+                            getattr(result, "cost_usd", 0.0) or 0.0,
+                        ),
+                    )
+        except Exception as _s2_rec_exc:  # noqa: BLE001 — fail-open
+            logger.debug(
+                "[S2] DW op_outcome record degraded: %s",
+                _s2_rec_exc,
+            )
+        # ───────────────────────────────────────────────────────────
         return result
 
     # ------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -603,6 +603,19 @@ class UnifiedIntakeRouter:
                 self._f1_shadow_on,
             )
 
+        # PRD §11 (S2) — auto-register this instance as the
+        # process-wide default for S2's head-of-queue peek. NEVER
+        # raises; failure to register degrades S2 to "no high-prio
+        # signal" (fail-open). Last-write-wins matches the cost_governor
+        # singleton pattern.
+        try:
+            set_default_intake_router(self)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "[UnifiedIntakeRouter] auto-register-default "
+                "degraded: %s", exc,
+            )
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -876,6 +889,50 @@ class UnifiedIntakeRouter:
     def intake_queue_depth(self) -> int:
         """Current number of items waiting in the dispatch queue."""
         return self._queue.qsize()
+
+    # ----------------------------------------------------------------------
+    # PRD §11 (S2) additive composition surface — head-of-queue inspector
+    # ----------------------------------------------------------------------
+    # S2's preemption-signal predicate needs to know the urgency of the
+    # next-to-be-dispatched envelope. Rather than build a parallel
+    # queue inspector (PRD §3 forbids), this read-only accessor
+    # composes the existing IntakePriorityQueue's heap (already
+    # maintained for dispatch ordering). Does NOT pop. NEVER raises.
+
+    def peek_top_urgency(self) -> Optional[str]:
+        """Return the urgency string (``'critical'`` / ``'high'`` /
+        ``'normal'`` / ``'low'``) of the next-to-be-dispatched
+        envelope in the priority queue, or ``None`` if the queue is
+        empty, the priority scheduler is not active, or any
+        introspection fault occurs.
+
+        Read-only — does NOT pop. Composes ``_priority_queue._heap``
+        (existing dispatch-ordering heap). No parallel queue. NEVER
+        raises (PRD §11.4 fail-open contract).
+        """
+        try:
+            pq = self._priority_queue
+            if pq is None:
+                return None
+            heap = getattr(pq, "_heap", None)
+            if not heap:
+                return None
+            top_entry = heap[0]
+            rank = getattr(top_entry, "urgency_rank", None)
+            if rank is None:
+                return None
+            # Reverse URGENCY_RANK lookup (small dict; O(4)).
+            from .intake_priority_queue import URGENCY_RANK as _RANK
+            for urgency_str, r in _RANK.items():
+                if r == rank:
+                    return urgency_str
+            return None
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[UnifiedIntakeRouter] peek_top_urgency degraded: %s",
+                exc,
+            )
+            return None
 
     def dead_letter_count(self) -> int:
         """Number of envelopes that exhausted all retries."""
@@ -1736,3 +1793,58 @@ class UnifiedIntakeRouter:
             except OSError:
                 pass
             self._lock_fd = None
+
+
+# ---------------------------------------------------------------------------
+# Process-wide default singleton (PRD §11 S2 wiring)
+# ---------------------------------------------------------------------------
+# S2's preemption-signal predicate (s2_predictive_budget.py) consumes
+# the head-of-queue urgency via ``peek_top_urgency()``. To avoid
+# threading the router instance through every provider call site,
+# this module exposes a thread-safe singleton getter/setter. The
+# setter is called from ``UnifiedIntakeRouter.__init__`` so any
+# instantiation auto-registers; last-write-wins (matches the
+# cost_governor singleton pattern).
+#
+# When no router is registered (e.g., S2 is exercised in unit tests
+# that don't construct an IntakeLayer), ``get_default_intake_router``
+# returns ``None`` — S2's ``_peek_high_prio_queued`` treats this as
+# "no signal" and emits nothing. NEVER raises.
+
+_DEFAULT_INTAKE_ROUTER: Optional["UnifiedIntakeRouter"] = None
+_DEFAULT_INTAKE_ROUTER_LOCK = threading.Lock()
+
+
+def set_default_intake_router(router: "UnifiedIntakeRouter") -> None:
+    """Register a router as the process-wide default for S2's
+    head-of-queue inspection. Idempotent; last-write-wins. NEVER
+    raises."""
+    global _DEFAULT_INTAKE_ROUTER
+    try:
+        with _DEFAULT_INTAKE_ROUTER_LOCK:
+            _DEFAULT_INTAKE_ROUTER = router
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug(
+            "[UnifiedIntakeRouter] set_default_intake_router "
+            "degraded: %s", exc,
+        )
+
+
+def get_default_intake_router() -> Optional["UnifiedIntakeRouter"]:
+    """Return the registered default router, or ``None`` if no router
+    has been registered in this process. NEVER raises."""
+    try:
+        with _DEFAULT_INTAKE_ROUTER_LOCK:
+            return _DEFAULT_INTAKE_ROUTER
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+
+
+def reset_default_intake_router_for_tests() -> None:
+    """Test helper — drops the registered default. NEVER raises."""
+    global _DEFAULT_INTAKE_ROUTER
+    try:
+        with _DEFAULT_INTAKE_ROUTER_LOCK:
+            _DEFAULT_INTAKE_ROUTER = None
+    except Exception:  # noqa: BLE001 — defensive
+        pass

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -7537,6 +7537,33 @@ class ClaudeProvider:
         # Zero-Waste S1 (D2) cache gate. Eligible only when the
         # provider-response cache is enabled AND no tool loop will
         # engage (tools_enabled is False AND tool_loop is None). On
+        # ── S2 — Predictive Budget Preemption (PRD §11.4) ──────────
+        # Master OFF (default) ⇒ entire block skipped; behavior
+        # byte-identical to today. S2 is ADVISORY — does NOT alter
+        # this op's dispatch path; merely emits a preemption signal
+        # to nudge sensor_governor against FUTURE low-priority
+        # sensor emissions. High-urgency routes (IMMEDIATE/STANDARD/
+        # COMPLEX) are immune at the governor's signal-application
+        # surface, regardless of severity. NEVER raises.
+        try:
+            from backend.core.ouroboros.governance.s2_predictive_budget import (  # noqa: E501
+                evaluate_admission_pressure as _s2_pressure_check,
+                emit_preemption_signal as _s2_emit,
+            )
+            _s2_severity = _s2_pressure_check(
+                prompt_text=prompt_text,                  # B3: len(prompt_text) at admission
+                route=getattr(context, "provider_route", "") or "standard",
+                model=self._model,                        # Claude uses self._model
+            )
+            if _s2_severity is not None:
+                _s2_emit(severity=_s2_severity, high_prio_queued=True)
+        except Exception as _s2_exc:  # noqa: BLE001 — fail-open
+            logger.debug(
+                "[S2] Claude admission integration degraded: %s",
+                _s2_exc,
+            )
+        # ───────────────────────────────────────────────────────────
+
         # HIT: skip provider API + tool dispatch (NOT the Python
         # set-up above — that's already paid). On MISS: the nested
         # _no_tools_inner closure runs _generate_raw +
@@ -7852,6 +7879,34 @@ class ClaudeProvider:
             token_usage["input"], token_usage["output"],
             _ftms_str, thinking_reason[0], _route_str,
         )
+        # ── S2 — record op_outcome for MAD sample stream (PRD §11 B4) ─
+        # Reached ONLY on real provider success (cache MISS path);
+        # _finalize_codegen_result is the produce-thunk body in the
+        # cache gate, so cache HITs short-circuit before this. Belt-
+        # and-suspenders: skip if provider_name carries the "+cache"
+        # reconstruction marker. Master-gated; NEVER raises.
+        try:
+            from backend.core.ouroboros.governance.s2_predictive_budget import (  # noqa: E501
+                master_enabled as _s2_master_check,
+            )
+            if _s2_master_check():
+                _pname = str(getattr(result, "provider_name", "") or "")
+                if not _pname.endswith("+cache"):
+                    from backend.core.ouroboros.governance.admission_estimator import (  # noqa: E501
+                        get_default_history as _s2_history,
+                    )
+                    _s2_history().record_op_outcome(
+                        route=(_route_str if _route_str != "?" else "standard"),
+                        model=str(self._model or ""),
+                        output_tokens=int(token_usage.get("output", 0) or 0),
+                        cost_usd=float(total_cost or 0.0),
+                    )
+        except Exception as _s2_rec_exc:  # noqa: BLE001 — fail-open
+            logger.debug(
+                "[S2] Claude op_outcome record degraded: %s",
+                _s2_rec_exc,
+            )
+        # ───────────────────────────────────────────────────────────
         return result.with_tool_records(
             tool_records
         ).with_venom_edits(venom_edits)

--- a/backend/core/ouroboros/governance/s2_predictive_budget.py
+++ b/backend/core/ouroboros/governance/s2_predictive_budget.py
@@ -88,6 +88,12 @@ _ENV_SAFETY_CEILING = "JARVIS_S2_SAFETY_CEILING"
 _ENV_CHARS_PER_TOKEN = "JARVIS_S2_CHARS_PER_TOKEN"
 _ENV_COST_SAMPLE_WINDOW = "JARVIS_S2_COST_SAMPLE_WINDOW"
 _ENV_PRICING_YAML_PATH = "JARVIS_S2_PRICING_YAML_PATH"
+# PRD §11 S2 wiring (B1 revised): session budget precedence chain.
+# JARVIS_S2_SESSION_BUDGET_USD > OUROBOROS_BATTLE_COST_CAP > default 0.50.
+# Default 0.50 mirrors the BattleTestHarnessConfig default (NOT 1.0).
+_ENV_SESSION_BUDGET_USD = "JARVIS_S2_SESSION_BUDGET_USD"
+_ENV_BATTLE_COST_CAP = "OUROBOROS_BATTLE_COST_CAP"
+_DEFAULT_SESSION_BUDGET_USD = 0.50
 
 # Documented PRD defaults — these live ONLY as the env-default arm of the
 # os.environ.get(...) reads below. Code paths NEVER inline any of these
@@ -592,6 +598,163 @@ def emit_preemption_signal(
 
 
 # --------------------------------------------------------------------------
+# Session budget — env-driven precedence chain (PRD §11 S2 wiring, B1 revised)
+# --------------------------------------------------------------------------
+
+
+def session_budget_usd() -> float:
+    """Return the session-wide USD budget. Precedence (B1 revised):
+
+      1. ``JARVIS_S2_SESSION_BUDGET_USD`` (explicit S2 override)
+      2. ``OUROBOROS_BATTLE_COST_CAP`` (battle harness env)
+      3. default **0.50** (mirrors BattleTestHarnessConfig default)
+
+    Reads dynamically from ``os.environ`` per call — the *value* lives
+    in env, the *channel* is the operator's interface. No hardcoded
+    budget literal in code; default matches the existing harness
+    contract, not a new authority.
+
+    Clamped to a hard floor of $0.01 (avoid div-by-zero on downstream
+    pressure-ratio math). NEVER raises."""
+    try:
+        # Tier 1: explicit S2 env knob
+        raw_s2 = os.environ.get(_ENV_SESSION_BUDGET_USD, "").strip()
+        if raw_s2:
+            try:
+                v = float(raw_s2)
+                return max(0.01, v)
+            except (TypeError, ValueError):
+                pass  # fall through to harness env
+        # Tier 2: battle harness env knob
+        raw_battle = os.environ.get(_ENV_BATTLE_COST_CAP, "").strip()
+        if raw_battle:
+            try:
+                v = float(raw_battle)
+                return max(0.01, v)
+            except (TypeError, ValueError):
+                pass  # fall through to default
+        # Tier 3: documented default — mirrors BattleTestHarnessConfig.
+        return float(_DEFAULT_SESSION_BUDGET_USD)
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug("[S2] session_budget_usd fault: %s", exc)
+        return float(_DEFAULT_SESSION_BUDGET_USD)
+
+
+def _peek_high_prio_queued() -> bool:
+    """True iff the next-to-be-dispatched envelope in the
+    UnifiedIntakeRouter's priority queue is high-priority — i.e.,
+    one of ``critical`` / ``high`` / ``normal`` (which map to
+    governor ``IMMEDIATE`` / ``STANDARD`` / ``COMPLEX``).
+
+    Composes ``UnifiedIntakeRouter.peek_top_urgency()`` exclusively
+    — no parallel queue inspector (PRD §11 B2 directive). Returns
+    False on any fault (fail-open: no signal emitted on lookup
+    fault). NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+            get_default_intake_router,
+        )
+        router = get_default_intake_router()
+        if router is None:
+            return False
+        top = router.peek_top_urgency()
+        if top is None:
+            return False
+        return top in ("critical", "high", "normal")
+    except Exception:  # noqa: BLE001 — defensive
+        return False
+
+
+# --------------------------------------------------------------------------
+# Provider-side admission predicate (PRD §11.4 wiring) — B3 directive
+# --------------------------------------------------------------------------
+
+
+def evaluate_admission_pressure(
+    prompt_text: str,
+    route: str,
+    model: str,
+    *,
+    cost_governor=None,
+    sample_provider=None,
+    pricing_lookup=None,
+    output_token_estimator=None,
+) -> Optional[float]:
+    """Provider-side S2 admission evaluator (PRD §11.4 + §11 B1-B4).
+
+    Composes the existing data flows exactly:
+      * **Spend**: ``cost_governor.session_total_cumulative_usd()``
+        (additive, composes existing ``_entries`` ledger).
+      * **Budget**: :func:`session_budget_usd` (env precedence chain).
+      * **Prompt-chars**: ``len(prompt_text)`` — dynamically at
+        provider-call time, with assembled ``prompt_text`` in scope.
+        NO pre-calculation. NO prompt re-assembly (B3 invariant).
+      * **Forecast**: :func:`forecasted_cost` over the actual
+        ``len(prompt_text)``.
+      * **Dynamic factor**: :func:`dynamic_admit_safety_factor` —
+        MAD-based, robust to outliers.
+      * **High-prio queued**: composes
+        ``UnifiedIntakeRouter.peek_top_urgency()``.
+
+    Returns the severity ∈ (0.0, 1.0] iff a preemption signal SHOULD
+    be emitted, or ``None`` if no signal is warranted. **The caller
+    (provider) is responsible for invoking
+    :func:`emit_preemption_signal`.**
+
+    **Critical invariant (PRD §11.4)**: S2 is ADVISORY. This function
+    does not block, alter, or defer the current op's provider
+    dispatch — it merely returns whether a preemption-advisory
+    *should* fire to nudge ``sensor_governor`` against future
+    low-priority sensor emissions. The current op proceeds normally.
+
+    NEVER raises (fail-open: any fault ⇒ returns ``None`` ⇒ no
+    signal). Master OFF returns ``None`` immediately."""
+    try:
+        if not master_enabled():
+            return None
+        if cost_governor is None:
+            try:
+                from backend.core.ouroboros.governance.cost_governor import (  # noqa: E501
+                    get_default_cost_governor,
+                )
+                cost_governor = get_default_cost_governor()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "[S2] cost_governor lookup fault: %s", exc,
+                )
+                return None
+        if cost_governor is None:
+            return None  # cost ledger not active in this process
+        try:
+            spend = float(cost_governor.session_total_cumulative_usd())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[S2] session_total fault: %s", exc)
+            return None
+        budget = session_budget_usd()
+        factor = dynamic_admit_safety_factor(
+            str(route), str(model), sample_provider=sample_provider,
+        )
+        forecast = forecasted_cost(
+            len(prompt_text or ""), str(route), str(model),
+            output_token_estimator=output_token_estimator,
+            pricing_lookup=pricing_lookup,
+        )
+        denom = max(0.01, budget * factor)
+        ratio = (spend + forecast) / denom
+        if ratio < 1.0:
+            return None
+        if not _peek_high_prio_queued():
+            return None
+        # Severity = how far over the threshold, clipped to [0,1]
+        return float(min(1.0, max(0.0, ratio - 1.0)))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "[S2] evaluate_admission_pressure fault: %s", exc,
+        )
+        return None
+
+
+# --------------------------------------------------------------------------
 # Exports
 # --------------------------------------------------------------------------
 
@@ -599,6 +762,8 @@ def emit_preemption_signal(
 __all__ = [
     "S2_PREDICTIVE_BUDGET_SCHEMA_VERSION",
     "master_enabled",
+    "session_budget_usd",
+    "evaluate_admission_pressure",
     "base_safety_factor",
     "volatility_penalty",
     "safety_floor",
@@ -716,6 +881,19 @@ def register_flags(registry) -> int:  # noqa: ANN001
                 "Default: brain_selection_policy.yaml beside this "
                 "module. Missing/absent section ⇒ forecast = 0 "
                 "(predicate clause no-op)."
+            ),
+        ),
+        FlagSpec(
+            name=_ENV_SESSION_BUDGET_USD, type=FlagType.FLOAT,
+            default=_DEFAULT_SESSION_BUDGET_USD,
+            category=Category.SAFETY, source_file=tgt,
+            example=f"{_ENV_SESSION_BUDGET_USD}=0.50",
+            description=(
+                "Session-wide USD budget for S2's predictive admission "
+                "predicate (PRD §11 B1 revised). Precedence: this "
+                "env > OUROBOROS_BATTLE_COST_CAP > default 0.50 "
+                "(matches BattleTestHarnessConfig). Read dynamically "
+                "per call."
             ),
         ),
     ]

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -1308,6 +1308,15 @@ def main() -> None:
         seed_intents=int(args.seed_intents or 0),
     )
 
+    # PRD §11 (S2) wiring B1 — bridge --cost-cap into S2's session
+    # budget env so the CLI flag transparently flows through. Uses
+    # setdefault: if operator explicitly set JARVIS_S2_SESSION_BUDGET_USD
+    # (Tier 1 of the precedence chain), that wins; otherwise --cost-cap
+    # populates the Tier-2 fallback by way of Tier-1 env.
+    os.environ.setdefault(
+        "JARVIS_S2_SESSION_BUDGET_USD", str(args.cost_cap),
+    )
+
     if _boot_timer is not None:
         with _boot_timer.phase("harness_construct"):
             harness = BattleTestHarness(config)

--- a/tests/governance/test_s2_predictive_budget.py
+++ b/tests/governance/test_s2_predictive_budget.py
@@ -515,8 +515,9 @@ def test_ast_pin_high_urgency_immune():
     })
 
 
-def test_register_flags_seeds_eight():
-    """8 env knobs registered (master + 7 tunables). PRD §11.5."""
+def test_register_flags_seeds_nine():
+    """9 env knobs registered (master + 7 tunables + session_budget_usd).
+    PRD §11.5 + §11 B1 revised."""
     seen: List[str] = []
 
     class _R:
@@ -524,7 +525,7 @@ def test_register_flags_seeds_eight():
             seen.append(spec.name)
 
     n = s2.register_flags(_R())
-    assert n == 8, f"expected 8 seeds, got {n}: {seen}"
+    assert n == 9, f"expected 9 seeds, got {n}: {seen}"
     expected = {
         "JARVIS_S2_PREDICTIVE_BUDGET_ENABLED",
         "JARVIS_S2_BASE_SAFETY_FACTOR",
@@ -534,6 +535,7 @@ def test_register_flags_seeds_eight():
         "JARVIS_S2_CHARS_PER_TOKEN",
         "JARVIS_S2_COST_SAMPLE_WINDOW",
         "JARVIS_S2_PRICING_YAML_PATH",
+        "JARVIS_S2_SESSION_BUDGET_USD",   # PRD §11 B1 wiring
     }
     assert set(seen) == expected
 

--- a/tests/governance/test_s2_wiring.py
+++ b/tests/governance/test_s2_wiring.py
@@ -1,0 +1,675 @@
+"""S2 wiring spine — PRD §11 production-path integration.
+
+Tests the actual data flows that make S2 useful at runtime:
+
+  * Provider-side admission hook (Claude + DW): co-located with
+    assembled prompt_text / _zw_prompt; uses ``len(prompt_text)``
+    dynamically — NO pre-calculation, NO prompt re-assembly (B3).
+  * Provider-side op_outcome record on real success seam only (B4):
+    cache-hit reconstructed results are skipped.
+  * Session budget precedence chain (B1):
+    ``JARVIS_S2_SESSION_BUDGET_USD`` > ``OUROBOROS_BATTLE_COST_CAP``
+    > default ``0.50``.
+  * UnifiedIntakeRouter.peek_top_urgency() — read-only, does NOT pop
+    (B2 directive).
+  * CostGovernor.session_total_cumulative_usd() — composes existing
+    ``_entries`` ledger (no parallel accumulator).
+  * Master OFF: byte-identical behavior — no S2 calls, no signals,
+    no ring writes.
+  * AST pins: S2 must NOT pass dynamic_admit_safety_factor into
+    admission_gate.budget_safety_factor_value; S2 module must NOT
+    re-implement prompt assembly; no parallel ring/queue/ledger.
+  * Fail-open: every S2 fault leaves provider success unchanged.
+"""
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import Any, List, Optional
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    s2_predictive_budget as s2,
+)
+
+
+@pytest.fixture(autouse=True)
+def _iso(monkeypatch):
+    """Strip S2 env so each test starts at documented defaults."""
+    for k in (
+        "JARVIS_S2_PREDICTIVE_BUDGET_ENABLED",
+        "JARVIS_S2_BASE_SAFETY_FACTOR",
+        "JARVIS_S2_VOLATILITY_PENALTY",
+        "JARVIS_S2_SAFETY_FLOOR",
+        "JARVIS_S2_SAFETY_CEILING",
+        "JARVIS_S2_CHARS_PER_TOKEN",
+        "JARVIS_S2_COST_SAMPLE_WINDOW",
+        "JARVIS_S2_PRICING_YAML_PATH",
+        "JARVIS_S2_SESSION_BUDGET_USD",
+        "OUROBOROS_BATTLE_COST_CAP",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    # Reset module-level singletons that S2 wiring depends on.
+    from backend.core.ouroboros.governance.admission_estimator import (
+        reset_singletons_for_tests,
+    )
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+        reset_default_intake_router_for_tests,
+    )
+    reset_singletons_for_tests()
+    reset_default_intake_router_for_tests()
+    s2._reset_pricing_cache_for_tests()
+    yield
+    reset_singletons_for_tests()
+    reset_default_intake_router_for_tests()
+    s2._reset_pricing_cache_for_tests()
+
+
+# ============================================================================
+# (1/8) Session budget precedence chain — B1 revised
+# ============================================================================
+
+
+def test_session_budget_default_050_matches_harness(monkeypatch):
+    """No env set ⇒ default $0.50 (matches BattleTestHarnessConfig).
+    Not 1.0. PRD §11 B1 revised."""
+    assert s2.session_budget_usd() == pytest.approx(0.50)
+
+
+def test_session_budget_battle_cost_cap_tier(monkeypatch):
+    """OUROBOROS_BATTLE_COST_CAP picked up as Tier 2."""
+    monkeypatch.setenv("OUROBOROS_BATTLE_COST_CAP", "2.00")
+    assert s2.session_budget_usd() == pytest.approx(2.00)
+
+
+def test_session_budget_jarvis_s2_wins_precedence(monkeypatch):
+    """JARVIS_S2_SESSION_BUDGET_USD (Tier 1) wins over
+    OUROBOROS_BATTLE_COST_CAP (Tier 2)."""
+    monkeypatch.setenv("OUROBOROS_BATTLE_COST_CAP", "2.00")
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "0.10")
+    assert s2.session_budget_usd() == pytest.approx(0.10)
+
+
+def test_session_budget_garbage_falls_through(monkeypatch):
+    """Garbage Tier-1 ⇒ falls through to Tier-2; garbage both ⇒
+    default 0.50. Defensive parser."""
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "junk")
+    monkeypatch.setenv("OUROBOROS_BATTLE_COST_CAP", "2.00")
+    assert s2.session_budget_usd() == pytest.approx(2.00)
+    monkeypatch.setenv("OUROBOROS_BATTLE_COST_CAP", "junk")
+    assert s2.session_budget_usd() == pytest.approx(0.50)
+
+
+def test_session_budget_floor_clamp(monkeypatch):
+    """Floor at $0.01 prevents div-by-zero downstream."""
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "0.001")
+    assert s2.session_budget_usd() == pytest.approx(0.01)
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "0")
+    assert s2.session_budget_usd() == pytest.approx(0.01)
+
+
+# ============================================================================
+# (2/8) UnifiedIntakeRouter.peek_top_urgency() — B2 directive
+# ============================================================================
+
+
+def test_router_peek_top_urgency_empty():
+    """No priority queue active OR empty queue ⇒ returns None.
+    Composes existing _priority_queue (no parallel queue)."""
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+        UnifiedIntakeRouter,
+    )
+    # Stub router with no priority_queue
+    stub = object.__new__(UnifiedIntakeRouter)
+    stub._priority_queue = None
+    assert stub.peek_top_urgency() is None
+
+
+def test_router_peek_top_urgency_returns_top_urgency():
+    """Stub a priority heap with ranks; peek returns the
+    urgency string matching the lowest rank (= highest priority).
+    Composes existing URGENCY_RANK reverse-lookup."""
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+        UnifiedIntakeRouter,
+    )
+    from backend.core.ouroboros.governance.intake.intake_priority_queue import (  # noqa: E501
+        URGENCY_RANK,
+    )
+
+    class _FakeEntry:
+        def __init__(self, rank):
+            self.urgency_rank = rank
+
+    class _FakePQ:
+        def __init__(self, ranks):
+            self._heap = [_FakeEntry(r) for r in ranks]
+
+    # heap[0] has the lowest rank (highest priority)
+    stub = object.__new__(UnifiedIntakeRouter)
+    stub._priority_queue = _FakePQ([URGENCY_RANK["critical"]])
+    assert stub.peek_top_urgency() == "critical"
+
+    stub._priority_queue = _FakePQ([URGENCY_RANK["low"]])
+    assert stub.peek_top_urgency() == "low"
+
+
+def test_router_peek_top_urgency_does_not_pop():
+    """Peek is read-only — does NOT mutate the heap."""
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+        UnifiedIntakeRouter,
+    )
+
+    class _FakeEntry:
+        def __init__(self, rank): self.urgency_rank = rank
+
+    class _FakePQ:
+        def __init__(self):
+            self._heap = [_FakeEntry(0), _FakeEntry(1), _FakeEntry(2)]
+
+    stub = object.__new__(UnifiedIntakeRouter)
+    stub._priority_queue = _FakePQ()
+    before_len = len(stub._priority_queue._heap)
+    _ = stub.peek_top_urgency()
+    _ = stub.peek_top_urgency()
+    assert len(stub._priority_queue._heap) == before_len, "peek mutated heap"
+
+
+def test_router_peek_failopen_on_introspection_fault():
+    """If the heap shape is unexpected, returns None (no raise)."""
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+        UnifiedIntakeRouter,
+    )
+
+    class _BrokenPQ:
+        _heap = [object()]   # entry has no urgency_rank
+
+    stub = object.__new__(UnifiedIntakeRouter)
+    stub._priority_queue = _BrokenPQ()
+    assert stub.peek_top_urgency() is None
+
+
+# ============================================================================
+# (3/8) CostGovernor.session_total_cumulative_usd() — composes _entries
+# ============================================================================
+
+
+def test_cost_governor_session_total_empty():
+    """No active ops ⇒ 0.0."""
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor,
+    )
+    g = CostGovernor()
+    assert g.session_total_cumulative_usd() == pytest.approx(0.0)
+
+
+def test_cost_governor_session_total_sums_entries():
+    """Sums cumulative_usd across _entries; composes existing
+    per-op ledger — NO parallel accumulator."""
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor,
+    )
+    g = CostGovernor()
+    g.start("op-1", "ide", "trivial")
+    g.charge("op-1", 0.05, provider="dw")
+    g.start("op-2", "ide", "moderate")
+    g.charge("op-2", 0.10, provider="claude")
+    g.charge("op-2", 0.02, provider="claude")
+    total = g.session_total_cumulative_usd()
+    assert total == pytest.approx(0.17)
+
+
+def test_cost_governor_session_total_failopen():
+    """Any internal fault ⇒ 0.0 (no raise)."""
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor,
+    )
+    g = CostGovernor()
+    # Mutate _entries to a non-dict to force a fault path
+    g._entries = "not-a-dict"  # type: ignore[assignment]
+    assert g.session_total_cumulative_usd() == 0.0
+
+
+# ============================================================================
+# (4/8) evaluate_admission_pressure() — provider-side composition
+# ============================================================================
+
+
+def _make_fake_governor(spend: float):
+    class _G:
+        def session_total_cumulative_usd(self):
+            return spend
+    return _G()
+
+
+def _stable_samples(_r, _m, _w):
+    """Cold-but-stable samples → CV_MAD ≈ 0 → factor ≈ base (0.9)."""
+    return (0.002, 0.002, 0.002, 0.002, 0.002)
+
+
+def _stable_pricing(_r, _m):
+    return (3e-6, 1.5e-5)   # Claude Sonnet-shape
+
+
+def _zero_estimator(_r, _m):
+    return 50.0
+
+
+def test_evaluate_master_off_returns_none(monkeypatch):
+    """Master OFF (default) ⇒ returns None — zero S2 work, no
+    governor/sampler/etc. consulted."""
+    sev = s2.evaluate_admission_pressure(
+        prompt_text="P" * 100, route="ide", model="m",
+        cost_governor=_make_fake_governor(99.0),  # huge spend, ignored
+        sample_provider=_stable_samples,
+        pricing_lookup=_stable_pricing,
+        output_token_estimator=_zero_estimator,
+    )
+    assert sev is None
+
+
+def test_evaluate_master_on_safe_budget_returns_none(monkeypatch):
+    """Master ON, spend+forecast << budget × factor ⇒ no signal."""
+    monkeypatch.setenv("JARVIS_S2_PREDICTIVE_BUDGET_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "1.00")
+    sev = s2.evaluate_admission_pressure(
+        prompt_text="P" * 100, route="ide", model="m",
+        cost_governor=_make_fake_governor(0.01),  # well under budget
+        sample_provider=_stable_samples,
+        pricing_lookup=_stable_pricing,
+        output_token_estimator=_zero_estimator,
+    )
+    assert sev is None
+
+
+def _populated_router_with_high_prio() -> Any:
+    """Register a fake router with a critical envelope at the head."""
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+        set_default_intake_router,
+    )
+
+    class _FakeEntry:
+        def __init__(self, rank): self.urgency_rank = rank
+
+    class _FakePQ:
+        _heap = [_FakeEntry(0)]   # critical = rank 0
+
+    class _FakeRouter:
+        _priority_queue = _FakePQ()
+        # mirror real method:
+        def peek_top_urgency(self):
+            from backend.core.ouroboros.governance.intake.intake_priority_queue import (  # noqa: E501
+                URGENCY_RANK,
+            )
+            rank = self._priority_queue._heap[0].urgency_rank
+            for u, r in URGENCY_RANK.items():
+                if r == rank:
+                    return u
+            return None
+    router = _FakeRouter()
+    set_default_intake_router(router)
+    return router
+
+
+def _populated_router_with_low_prio() -> Any:
+    """Register a fake router with a low envelope at the head."""
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+        set_default_intake_router,
+    )
+    from backend.core.ouroboros.governance.intake.intake_priority_queue import (  # noqa: E501
+        URGENCY_RANK,
+    )
+
+    class _FakeEntry:
+        urgency_rank = URGENCY_RANK["low"]
+
+    class _FakePQ:
+        _heap = [_FakeEntry()]
+
+    class _FakeRouter:
+        _priority_queue = _FakePQ()
+        def peek_top_urgency(self):
+            return "low"
+    router = _FakeRouter()
+    set_default_intake_router(router)
+    return router
+
+
+def test_evaluate_tight_budget_no_high_prio_no_signal(monkeypatch):
+    """Tight forecast BUT no high-prio queued ⇒ no signal."""
+    monkeypatch.setenv("JARVIS_S2_PREDICTIVE_BUDGET_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "0.10")
+    _populated_router_with_low_prio()   # only low-prio queued
+    sev = s2.evaluate_admission_pressure(
+        prompt_text="P" * 10000, route="ide", model="m",
+        cost_governor=_make_fake_governor(0.09),  # tight
+        sample_provider=_stable_samples,
+        pricing_lookup=_stable_pricing,
+        output_token_estimator=_zero_estimator,
+    )
+    assert sev is None
+
+
+def test_evaluate_tight_budget_high_prio_emits_signal(monkeypatch):
+    """Tight forecast AND critical at head of queue ⇒ severity returned."""
+    monkeypatch.setenv("JARVIS_S2_PREDICTIVE_BUDGET_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "0.10")
+    _populated_router_with_high_prio()
+    sev = s2.evaluate_admission_pressure(
+        prompt_text="P" * 10000, route="ide", model="m",
+        cost_governor=_make_fake_governor(0.10),  # over with forecast
+        sample_provider=_stable_samples,
+        pricing_lookup=_stable_pricing,
+        output_token_estimator=_zero_estimator,
+    )
+    assert sev is not None
+    assert 0.0 <= sev <= 1.0
+
+
+def test_evaluate_uses_len_prompt_text_no_assembly(monkeypatch):
+    """prompt_chars derived from len(prompt_text) dynamically — B3
+    invariant. Confirmed by varying prompt_text length and seeing
+    the forecast/severity respond."""
+    monkeypatch.setenv("JARVIS_S2_PREDICTIVE_BUDGET_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "0.10")
+    _populated_router_with_high_prio()
+
+    # Short prompt: smaller forecast, may not push over.
+    sev_short = s2.evaluate_admission_pressure(
+        prompt_text="x", route="ide", model="m",
+        cost_governor=_make_fake_governor(0.05),
+        sample_provider=_stable_samples,
+        pricing_lookup=_stable_pricing,
+        output_token_estimator=_zero_estimator,
+    )
+    # Long prompt: bigger forecast, pushes over.
+    sev_long = s2.evaluate_admission_pressure(
+        prompt_text="x" * 1_000_000, route="ide", model="m",
+        cost_governor=_make_fake_governor(0.05),
+        sample_provider=_stable_samples,
+        pricing_lookup=_stable_pricing,
+        output_token_estimator=_zero_estimator,
+    )
+    # The long prompt's forecast contribution is monotonically larger.
+    # If short emits nothing, long must emit (proves prompt_chars
+    # actually drives the math).
+    assert not (sev_short is not None and sev_long is None)
+
+
+def test_evaluate_failopen_no_governor(monkeypatch):
+    """cost_governor=None AND no default ⇒ returns None, no signal."""
+    monkeypatch.setenv("JARVIS_S2_PREDICTIVE_BUDGET_ENABLED", "true")
+    sev = s2.evaluate_admission_pressure(
+        prompt_text="P" * 100, route="ide", model="m",
+        cost_governor=None,
+        sample_provider=_stable_samples,
+        pricing_lookup=_stable_pricing,
+        output_token_estimator=_zero_estimator,
+    )
+    # In a unit test, no default cost_governor is registered ⇒ None.
+    assert sev is None
+
+
+def test_evaluate_failopen_governor_raises(monkeypatch):
+    """If governor.session_total raises, returns None (fail-open)."""
+    monkeypatch.setenv("JARVIS_S2_PREDICTIVE_BUDGET_ENABLED", "true")
+
+    class _RaisingGovernor:
+        def session_total_cumulative_usd(self):
+            raise RuntimeError("synthetic")
+
+    sev = s2.evaluate_admission_pressure(
+        prompt_text="P" * 100, route="ide", model="m",
+        cost_governor=_RaisingGovernor(),
+        sample_provider=_stable_samples,
+        pricing_lookup=_stable_pricing,
+        output_token_estimator=_zero_estimator,
+    )
+    assert sev is None
+
+
+# ============================================================================
+# (5/8) AST pins — no misuse of admission_gate; no parallel substrates
+# ============================================================================
+
+
+def test_ast_pin_no_dynamic_factor_in_admission_gate_call_kwargs():
+    """S2 must NEVER pass dynamic_admit_safety_factor() through
+    admission_gate.budget_safety_factor_value (which is time-domain
+    and would silently clamp to 1.2). AST-walks each file; checks
+    actual ``Call`` nodes — not comments/docstrings that may legitimately
+    reference the parameter name for documentation."""
+    for path in (
+        "backend/core/ouroboros/governance/providers.py",
+        "backend/core/ouroboros/governance/doubleword_provider.py",
+        "backend/core/ouroboros/governance/s2_predictive_budget.py",
+        "backend/core/ouroboros/governance/candidate_generator.py",
+    ):
+        src = Path(path).read_text(encoding="utf-8")
+        # Anti-pattern (substring): passing the dynamic factor as
+        # the admission_gate budget kwarg. This catches the literal
+        # source line, but is permissive of comments mentioning the
+        # parameter name.
+        anti = "budget_safety_factor_value=dynamic_admit_safety_factor"
+        assert anti not in src, (
+            f"{path}: forbidden semantic conflation — dynamic_admit_safety_factor"
+            f" must not be routed through budget_safety_factor_value"
+        )
+        # For S2 module: walk AST for actual Call kwargs containing
+        # ``budget_safety_factor_value=`` (rejecting accidental
+        # call-site uses while permitting docstring/comment mentions).
+        if "s2_predictive_budget" in path:
+            tree = ast.parse(src)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    for kw in (node.keywords or []):
+                        assert kw.arg != "budget_safety_factor_value", (
+                            "s2_predictive_budget must not pass "
+                            "budget_safety_factor_value into any call "
+                            "(time-domain parameter; would silently "
+                            "clamp the cost-domain factor to 1.2)"
+                        )
+
+
+def test_ast_pin_no_prompt_reassembly_in_s2():
+    """S2 module must NOT call _build_codegen_prompt or
+    _build_lean_codegen_prompt (would duplicate provider logic).
+    PRD §11 B3 invariant."""
+    src = Path(
+        "backend/core/ouroboros/governance/s2_predictive_budget.py"
+    ).read_text(encoding="utf-8")
+    for forbidden in ("_build_codegen_prompt", "_build_lean_codegen_prompt"):
+        assert forbidden not in src, (
+            f"S2 must not call {forbidden!r} — provider owns "
+            f"assembly per PRD §11 B3."
+        )
+
+
+def test_ast_pin_no_parallel_ring_or_ledger_in_s2():
+    """S2 must NOT define a parallel RecentDecisionsRing,
+    CostGovernor, _OpCostEntry, or _HeapEntry. PRD §3."""
+    src = Path(
+        "backend/core/ouroboros/governance/s2_predictive_budget.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            assert node.name not in (
+                "RecentDecisionsRing", "CostGovernor",
+                "_OpCostEntry", "_HeapEntry", "WaitTimeEstimator",
+                "SensorGovernor", "UnifiedIntakeRouter",
+                "IntakePriorityQueue",
+            ), (
+                f"S2 must not redefine canonical class {node.name!r}"
+            )
+
+
+def test_ast_pin_s2_admission_hook_present_in_claude():
+    """providers.py must contain the S2 admission hook (PRD §11.4)
+    with master-off byte-identical discipline."""
+    src = Path(
+        "backend/core/ouroboros/governance/providers.py"
+    ).read_text(encoding="utf-8")
+    assert "evaluate_admission_pressure" in src
+    assert "_s2_pressure_check" in src
+    # The hook must precede the existing S1 cache gate block so it
+    # fires regardless of S1 state.
+    s2_pos = src.find("evaluate_admission_pressure")
+    s1_pos = src.find("cached_or_generate as _cached_or_generate")
+    assert s2_pos > 0 and s1_pos > 0
+    assert s2_pos < s1_pos, (
+        "S2 admission hook must precede S1 cache gate import in providers.py"
+    )
+
+
+def test_ast_pin_s2_admission_hook_present_in_dw():
+    """doubleword_provider.py must contain the S2 admission hook
+    co-located with _zw_prompt."""
+    src = Path(
+        "backend/core/ouroboros/governance/doubleword_provider.py"
+    ).read_text(encoding="utf-8")
+    assert "evaluate_admission_pressure" in src
+    assert "_s2_pressure_check" in src
+    # The hook should use _effective_model_id, NOT bare self._model
+    # (per operator guardrail G2).
+    assert "_effective_model_id" in src
+
+
+def test_ast_pin_record_op_outcome_in_both_provider_success_seams():
+    """Both Claude (_finalize_codegen_result) and DW
+    (_dispatch_internal success return) must contain a
+    record_op_outcome call, master-gated."""
+    claude_src = Path(
+        "backend/core/ouroboros/governance/providers.py"
+    ).read_text(encoding="utf-8")
+    dw_src = Path(
+        "backend/core/ouroboros/governance/doubleword_provider.py"
+    ).read_text(encoding="utf-8")
+    for name, src in (("Claude", claude_src), ("DW", dw_src)):
+        assert "record_op_outcome" in src, (
+            f"{name} provider missing record_op_outcome hook"
+        )
+        assert "+cache" in src, (
+            f"{name} provider missing cache-hit reconstruction skip "
+            f"(belt-and-suspenders)"
+        )
+
+
+# ============================================================================
+# (6/8) Master-OFF byte-identical — no S2 work performed
+# ============================================================================
+
+
+def test_master_off_evaluate_returns_immediately(monkeypatch):
+    """Master OFF ⇒ evaluate_admission_pressure does not consult
+    the cost governor at all."""
+    consulted = []
+
+    class _CountingGovernor:
+        def session_total_cumulative_usd(self):
+            consulted.append(1)
+            return 99.0
+
+    sev = s2.evaluate_admission_pressure(
+        prompt_text="x" * 10000, route="ide", model="m",
+        cost_governor=_CountingGovernor(),
+        sample_provider=_stable_samples,
+        pricing_lookup=_stable_pricing,
+        output_token_estimator=_zero_estimator,
+    )
+    assert sev is None
+    assert consulted == [], (
+        "Master OFF: governor must not be consulted"
+    )
+
+
+# ============================================================================
+# (7/8) Op-outcome record_op_outcome contract — cache-hit skip
+# ============================================================================
+
+
+def test_record_op_outcome_only_on_real_success(monkeypatch):
+    """The provider-side record_op_outcome hooks must skip when
+    provider_name ends with '+cache' (cache-hit reconstructed
+    result). Verified by the AST pin above; this test exercises
+    the runtime guard via a simulated finalize."""
+    from backend.core.ouroboros.governance.admission_estimator import (
+        get_default_history, reset_singletons_for_tests,
+    )
+    reset_singletons_for_tests()
+    monkeypatch.setenv("JARVIS_S2_PREDICTIVE_BUDGET_ENABLED", "true")
+
+    history = get_default_history()
+    # Simulate the runtime guard: cache-hit results are NOT recorded.
+    pname = "claude-api+cache"
+    if not pname.endswith("+cache"):
+        history.record_op_outcome("ide", "claude", 100, 0.005)
+    # Nothing recorded:
+    samples = history.op_outcome_samples("ide", "claude")
+    assert samples == (), (
+        "cache-hit results must not pollute the MAD sample stream"
+    )
+
+
+def test_record_op_outcome_records_on_real_success(monkeypatch):
+    """Real provider success (no +cache marker) DOES record."""
+    from backend.core.ouroboros.governance.admission_estimator import (
+        get_default_history, reset_singletons_for_tests,
+    )
+    reset_singletons_for_tests()
+    history = get_default_history()
+    history.record_op_outcome("ide", "claude", 100, 0.005)
+    samples = history.op_outcome_samples("ide", "claude")
+    assert len(samples) == 1
+    assert samples[0]["cost_usd"] == 0.005
+
+
+# ============================================================================
+# (8/8) Router auto-registration via __init__
+# ============================================================================
+
+
+def test_router_auto_registers_as_default_singleton():
+    """The router's ``__init__`` must contain a call to
+    ``set_default_intake_router(self)`` so any real construction
+    auto-registers. AST-walk pin (UnifiedIntakeRouter's full
+    construction requires gls + config fixtures we don't replicate
+    in unit tests; this static check is the load-bearing guarantee
+    that production construction does register)."""
+    import inspect
+    from backend.core.ouroboros.governance.intake import (
+        unified_intake_router as uir,
+    )
+    src = inspect.getsource(uir.UnifiedIntakeRouter.__init__)
+    assert "set_default_intake_router(self)" in src, (
+        "UnifiedIntakeRouter.__init__ must auto-register self as "
+        "the default for S2's head-of-queue peek"
+    )
+    # Also verify the singleton setter/getter are exported.
+    assert hasattr(uir, "set_default_intake_router")
+    assert hasattr(uir, "get_default_intake_router")
+    assert hasattr(uir, "reset_default_intake_router_for_tests")
+
+
+def test_peek_high_prio_queued_with_no_router():
+    """When no router is registered, the S2 helper returns False
+    (fail-open: no signal emitted)."""
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (  # noqa: E501
+        reset_default_intake_router_for_tests,
+    )
+    reset_default_intake_router_for_tests()
+    assert s2._peek_high_prio_queued() is False
+
+
+def test_peek_high_prio_queued_critical_returns_true():
+    """Registered router with critical at head ⇒ True."""
+    _populated_router_with_high_prio()
+    assert s2._peek_high_prio_queued() is True
+
+
+def test_peek_high_prio_queued_low_returns_false():
+    """Registered router with low at head ⇒ False (low maps to
+    BACKGROUND, not a high-prio class)."""
+    _populated_router_with_low_prio()
+    assert s2._peek_high_prio_queued() is False


### PR DESCRIPTION
## S2 Wiring — Provider-Side Admission Hook + Record Op-Outcome + Session-Budget Precedence

PRD §11 S2 wiring (operator-revised B1-B4). S2 module — merged in #44979 as design-locked dormant code — is now reached from the actual production data flows. **Master `JARVIS_S2_PREDICTIVE_BUDGET_ENABLED` default-FALSE on merge ⇒ byte-identical to today until operator opts in.**

---

### B1 — Session budget precedence (revised, default 0.50 not 1.0)

```python
session_budget_usd():
    Tier 1: JARVIS_S2_SESSION_BUDGET_USD   (explicit S2 override)
    Tier 2: OUROBOROS_BATTLE_COST_CAP      (existing battle harness env)
    Tier 3: default 0.50                    (matches BattleTestHarnessConfig)
```

Read dynamically per call. Garbage at any tier falls through cleanly. Floor-clamped to $0.01 to prevent div-by-zero downstream.

**Harness env bridge** (`scripts/ouroboros_battle_test.py`): after `--cost-cap` is parsed, `os.environ.setdefault` populates `JARVIS_S2_SESSION_BUDGET_USD` so the CLI flag flows into S2 transparently. `setdefault` honors explicit operator overrides.

### B2 — UnifiedIntakeRouter.peek_top_urgency() (additive, read-only)

Composes the existing `_priority_queue._heap` — **no parallel queue, no parallel inspector**. Returns the head element's urgency string or `None`. Does NOT pop.

Singleton accessor pair added at module level (mirrors `cost_governor.get_default_cost_governor`):
- `set_default_intake_router(router)`
- `get_default_intake_router() -> Optional[UnifiedIntakeRouter]`
- `reset_default_intake_router_for_tests()`

`UnifiedIntakeRouter.__init__` now auto-registers self as the process-wide default (last-write-wins). S2's `_peek_high_prio_queued()` consumes this surface exclusively; fail-open returns `False` if no router registered.

### B3 — `len(prompt_text)` at provider-side admission, NO assembly

`evaluate_admission_pressure(prompt_text, route, model, ...)` lives in `s2_predictive_budget.py`. Provider integrations call it **co-located with the already-assembled prompt**:

- **Claude (`providers.py`)**: hook BEFORE the existing S1 cache gate block; uses `prompt_text` in scope (built by `_assemble_codegen_prompt`). `self._model` is canonical for Claude.
- **DW (`doubleword_provider.py`)**: hook AFTER `_zw_prompt` is built, BEFORE `_zw_cached_or_generate`; uses **`_effective_model_id(context)`** — the actual model resolved for dispatch, NOT bare `self._model` (operator guardrail G2).

**S2 is ADVISORY**: never alters the current op's dispatch path; only emits a preemption signal to nudge `sensor_governor` against FUTURE low-priority sensor emissions. High-urgency immunity is enforced at the governor's closed-advice surface.

### B4 — `record_op_outcome` on real provider success seam

- **Claude**: inside `_finalize_codegen_result` (the produce-thunk body of the S1 cache gate — reached ONLY on cache MISS by construction).
- **DW**: at `_dispatch_internal`'s success return (post-batch retrieval).

Both master-gated. Both belt-and-suspenders skip when `provider_name.endswith('+cache')` so cache-hit reconstructed GRs cannot pollute the MAD sample stream. Both use the proper effective model id.

### CostGovernor additive accessor

```python
def session_total_cumulative_usd(self) -> float:
    """Sum of cumulative_usd across _entries. Composes the existing
    per-op ledger — NO parallel accumulator. NEVER raises."""
```

`CostGovernor` has no `self._lock` (confirmed); safe materialized snapshot via `list(self._entries.values())` under CPython GIL.

### Env knobs — 9 total (was 8)

| Knob | Default | Notes |
|---|---|---|
| `JARVIS_S2_PREDICTIVE_BUDGET_ENABLED` | `false` | master |
| `JARVIS_S2_BASE_SAFETY_FACTOR` | `0.9` | base before volatility |
| `JARVIS_S2_VOLATILITY_PENALTY` | `1.0` | × CV_MAD |
| `JARVIS_S2_SAFETY_FLOOR` | `0.5` | clip lower |
| `JARVIS_S2_SAFETY_CEILING` | `0.95` | clip upper |
| `JARVIS_S2_CHARS_PER_TOKEN` | `4.0` | forecast granularity |
| `JARVIS_S2_COST_SAMPLE_WINDOW` | `50` | MAD window |
| `JARVIS_S2_PRICING_YAML_PATH` | `brain_selection_policy.yaml` | pricing source |
| **`JARVIS_S2_SESSION_BUDGET_USD`** | **`0.50`** | **NEW — B1 revised** |

---

### Diffstat

```
backend/core/ouroboros/governance/cost_governor.py            |  +34
backend/core/ouroboros/governance/doubleword_provider.py      |  +71
backend/core/ouroboros/governance/intake/unified_intake_router.py | +112
backend/core/ouroboros/governance/providers.py                |  +55
backend/core/ouroboros/governance/s2_predictive_budget.py     | +178
scripts/ouroboros_battle_test.py                              |   +9
tests/governance/test_s2_predictive_budget.py                 |   +8 / -3
tests/governance/test_s2_wiring.py                            | +675 (new)
8 files changed, 1139 insertions(+), 3 deletions(-)
```

### Test spine — 227/227 green in 6.04s

| Suite | Tests |
|---|---|
| S1 substrate (`test_provider_response_cache.py`) | 42 |
| S1 wiring (`test_provider_response_cache_wiring.py`) | 12 |
| S2 substrate (`test_s2_predictive_budget.py`) | 34 (1 pin updated 8→9) |
| **S2 wiring (NEW `test_s2_wiring.py`)** | **32** |
| sensor_governor regression (3 files) | 107 |
| **Total** | **227** |

**S2 wiring test breakdown**:
- Session budget precedence (5): default 0.50, BATTLE tier, JARVIS_S2 wins, garbage falls through, floor clamp
- Router peek_top_urgency (4): empty, critical/low, no-pop invariant, fail-open
- CostGovernor session_total (3): empty, sums _entries, fail-open
- `evaluate_admission_pressure` (8): master OFF returns None immediately, safe budget, tight + no high-prio, tight + high-prio, len(prompt_text) drives forecast, no-governor, governor raises, master OFF skips governor consultation
- AST pins (5): no dynamic_factor in `budget_safety_factor_value`, no prompt re-assembly, no parallel ring/queue/ledger, hook present in Claude (before S1 import), hook present in DW (uses `_effective_model_id`)
- Op-outcome contract (2): cache-hit GRs NOT recorded; real success records
- Router auto-register + peek_high_prio_queued (4): __init__ contains setter (AST pin), no-router→False, critical→True, low→False

### Invariants (live-probed on this branch)

```
s2.master_enabled()           = False    ← S2 master default-FALSE
prc.response_cache_enabled()  = False    ← S1 master default-FALSE
prc.shadow_mode_enabled()     = False    ← S1 shadow default-FALSE
s2.session_budget_usd()       = $0.50    ← matches harness default
```

### Out of scope (explicit)

- ❌ NO default-TRUE flip of S2 master (requires separate operator-authorized graduation PR per §11.8).
- ❌ NO edits to `admission_gate.py` (AST pin enforces S2 does not misuse its time-domain `budget_safety_factor_value`).
- ❌ NO edits to `candidate_generator.py` (S2 wiring lives provider-side per B3 directive).
- ❌ NO edits to `admission_estimator.py` or `sensor_governor.py` beyond what shipped in #44979.
- ❌ NO edits to OCA / git-index / sovereignty / cursor-agent-ban / S1 cache substrate / shadow.
- ❌ NO SWE-Bench-Pro Phase-1/3 re-run. NO provider spend. NO live canary.

### Known limitation (documented for follow-up)

When the S1 cache master is OFF on DW, the S2 admission hook does not fire for DW ops because both share the same prompt-assembly block. The graduation soak (Bars A/B) should be run with S1 master ON for full DW coverage. A follow-up PR can hoist DW's prompt assembly above the gate to remove the coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wire S2 predictive budget into provider paths with an advisory admission check and real op-outcome sampling. Master flag `JARVIS_S2_PREDICTIVE_BUDGET_ENABLED` stays OFF by default, so runtime behavior is unchanged until you opt in.

- New Features
  - Provider admission hook in Claude and Doubleword: calls `evaluate_admission_pressure(len(prompt_text), route, model)` right where prompts are assembled; advisory only; uses `_effective_model_id` in DW; emits preemption signals; high-priority routes remain immune.
  - Session budget precedence: `JARVIS_S2_SESSION_BUDGET_USD` > `OUROBOROS_BATTLE_COST_CAP` > default $0.50; floor at $0.01. Harness bridge sets `JARVIS_S2_SESSION_BUDGET_USD` from `--cost-cap` via `scripts/ouroboros_battle_test.py`.
  - Intake router peek: `UnifiedIntakeRouter.peek_top_urgency()` (read-only, no-pop) plus default-router singleton get/set; auto-registers in `__init__`.
  - Cost accounting: `CostGovernor.session_total_cumulative_usd()` sums existing per-op ledger entries; no parallel accumulator.
  - Outcome sampling: record `record_op_outcome` on real provider success paths; skip when `provider_name` ends with `+cache`.
  - Config: env knobs now 9; new `JARVIS_S2_SESSION_BUDGET_USD`.

- Migration
  - To enable S2: set `JARVIS_S2_PREDICTIVE_BUDGET_ENABLED=true`.
  - Optionally set `JARVIS_S2_SESSION_BUDGET_USD`; otherwise `OUROBOROS_BATTLE_COST_CAP` or the $0.50 default applies.
  - Note: with S1 cache OFF on Doubleword, the S2 admission hook won’t run; enable S1 there for full coverage.

<sup>Written for commit 4b7b5c76430196068c05cf5315f84067b356eb73. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/46590?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

