### PR TITLE
feat(governance): DW Heavy Non-Streaming Lane — Functions-not-Agents for codegen (master default-FALSE)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -94,6 +94,142 @@ _DW_OUTPUT_COST_PER_M = float(os.environ.get("DOUBLEWORD_OUTPUT_COST_PER_M", "0.
 _DW_MAX_COST_PER_OP = float(os.environ.get("DOUBLEWORD_MAX_COST_PER_OP", "0.10"))
 _DW_DAILY_BUDGET = float(os.environ.get("DOUBLEWORD_DAILY_BUDGET", "5.00"))
 
+# ---------------------------------------------------------------------------
+# DW Heavy Non-Streaming Lane — "Functions, Not Agents" for codegen
+# ---------------------------------------------------------------------------
+# Composes the existing ``DoublewordProvider.complete_sync()`` primitive
+# (the canonical Functions-not-Agents path, already used by
+# ``CompactionCaller``, ``BlastRadius``, ``FailureClustering``,
+# ``DreamSeed``) and adds a codegen-shaped wrapper that:
+#   * keeps the ``prompt_override`` / S1-cache prompt seam intact,
+#   * parses the response through the existing
+#     ``_parse_generation_response`` (no parallel parser),
+#   * uses ``_resolve_effective_model(context)`` (no hardcoded models),
+#   * returns ``GenerationResult`` (not ``CompleteSyncResult``).
+#
+# Architectural correction (per operator design lock, 2026-05-21):
+# DW heavy routing is constrained by **streaming transport reliability**,
+# not by model reasoning quality. This lane unlocks DW reasoning via a
+# stream-free path; ``enable_thinking=True`` is the default for heavy
+# ops because the lane exists precisely to make DW reasoning reachable
+# without the SSE stall surface.
+#
+# Master flag and all knobs default-FALSE / dormant on merge. Existing
+# behavior unchanged until operator explicitly enables.
+
+_DW_HEAVY_FN_LANE_ENABLED = (
+    os.environ.get("JARVIS_DW_HEAVY_FN_LANE_ENABLED", "false").strip().lower()
+    in ("1", "true", "yes", "on")
+)
+_DW_HEAVY_FN_LANE_ELIGIBLE_COMPLEXITIES: tuple = tuple(
+    s.strip().lower()
+    for s in os.environ.get(
+        "JARVIS_DW_HEAVY_FN_LANE_ELIGIBLE_COMPLEXITIES",
+        "complex,heavy_code",
+    ).split(",")
+    if s.strip()
+)
+_DW_HEAVY_FN_LANE_PREFER_OVER_SSE = (
+    os.environ.get(
+        "JARVIS_DW_HEAVY_FN_LANE_PREFER_OVER_SSE", "false",
+    ).strip().lower()
+    in ("1", "true", "yes", "on")
+)
+_DW_HEAVY_FN_LANE_PREFER_ON_SSE_STALL = (
+    os.environ.get(
+        "JARVIS_DW_HEAVY_FN_LANE_PREFER_ON_SSE_STALL", "true",
+    ).strip().lower()
+    in ("1", "true", "yes", "on")
+)
+_DW_HEAVY_FN_LANE_TIMEOUT_S = float(
+    os.environ.get("JARVIS_DW_HEAVY_FN_LANE_TIMEOUT_S", "120.0")
+)
+_DW_HEAVY_FN_LANE_MAX_TOKENS = int(
+    os.environ.get("JARVIS_DW_HEAVY_FN_LANE_MAX_TOKENS", "16384")
+)
+# Default TRUE: the lane exists to unlock DW reasoning over a
+# stream-free transport. Operators can flip to FALSE per-ops if needed.
+_DW_HEAVY_FN_LANE_ENABLE_THINKING = (
+    os.environ.get(
+        "JARVIS_DW_HEAVY_FN_LANE_ENABLE_THINKING", "true",
+    ).strip().lower()
+    in ("1", "true", "yes", "on")
+)
+
+
+def _dw_heavy_fn_lane_master_enabled() -> bool:
+    """Re-read env per call so a flip hot-reverts. NEVER raises."""
+    try:
+        return os.environ.get(
+            "JARVIS_DW_HEAVY_FN_LANE_ENABLED", "false",
+        ).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001 — defensive
+        return False
+
+
+def _dw_heavy_fn_lane_eligible_complexities() -> tuple:
+    """Re-read env per call. Default complex,heavy_code."""
+    try:
+        return tuple(
+            s.strip().lower()
+            for s in os.environ.get(
+                "JARVIS_DW_HEAVY_FN_LANE_ELIGIBLE_COMPLEXITIES",
+                "complex,heavy_code",
+            ).split(",")
+            if s.strip()
+        )
+    except Exception:  # noqa: BLE001
+        return ("complex", "heavy_code")
+
+
+def _dw_heavy_fn_lane_prefer_over_sse() -> bool:
+    try:
+        return os.environ.get(
+            "JARVIS_DW_HEAVY_FN_LANE_PREFER_OVER_SSE", "false",
+        ).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _dw_heavy_fn_lane_prefer_on_sse_stall() -> bool:
+    try:
+        return os.environ.get(
+            "JARVIS_DW_HEAVY_FN_LANE_PREFER_ON_SSE_STALL", "true",
+        ).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _dw_heavy_fn_lane_timeout_s() -> float:
+    try:
+        v = float(os.environ.get(
+            "JARVIS_DW_HEAVY_FN_LANE_TIMEOUT_S", "120.0",
+        ))
+        return max(5.0, min(600.0, v))
+    except Exception:  # noqa: BLE001
+        return 120.0
+
+
+def _dw_heavy_fn_lane_max_tokens() -> int:
+    try:
+        v = int(os.environ.get(
+            "JARVIS_DW_HEAVY_FN_LANE_MAX_TOKENS", "16384",
+        ))
+        return max(256, min(32768, v))
+    except Exception:  # noqa: BLE001
+        return 16384
+
+
+def _dw_heavy_fn_lane_enable_thinking() -> bool:
+    """Default TRUE — the lane exists to unlock DW reasoning over a
+    stream-free transport. NEVER raises."""
+    try:
+        return os.environ.get(
+            "JARVIS_DW_HEAVY_FN_LANE_ENABLE_THINKING", "true",
+        ).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001
+        return True
+
 
 class DoublewordInfraError(Exception):
     """Infrastructure failure from DoublewordProvider.
@@ -1045,6 +1181,40 @@ class DoublewordProvider:
         invoke the same dispatch path without duplicating it
         (single source of dispatch truth). Behavior is byte-
         identical to the pre-extraction body."""
+        # ── DW Heavy Non-Streaming Lane (PRD: "Functions, Not Agents") ─
+        # Master OFF (default) ⇒ entire block skipped; behavior
+        # byte-identical to today. When master ON AND op eligibility
+        # holds AND PREFER_OVER_SSE is on: skip SSE entirely and
+        # dispatch via the non-streaming compose-of-complete_sync lane.
+        # Failures cascade naturally (the wrapper raises
+        # DoublewordInfraError which the orchestrator already handles).
+        try:
+            if (
+                _dw_heavy_fn_lane_master_enabled()
+                and self._should_use_heavy_nonstreaming_lane(
+                    context, sentinel_recent_sse_stall=False,
+                )
+            ):
+                logger.info(
+                    "[DoublewordProvider] heavy-nonstreaming lane "
+                    "engaged (PREFER_OVER_SSE) for op=%s route=%s "
+                    "complexity=%s",
+                    getattr(context, "op_id", "")[:24],
+                    getattr(context, "provider_route", "") or "",
+                    getattr(context, "task_complexity", "") or "",
+                )
+                return await self._generate_heavy_nonstreaming(
+                    context, deadline, prompt_override=prompt_override,
+                )
+        except Exception as _heavy_exc:  # noqa: BLE001
+            # Master-gated; any fault degrades to the legacy SSE/batch
+            # path. We do NOT silently swallow — log + cascade.
+            logger.warning(
+                "[DoublewordProvider] heavy-nonstreaming lane "
+                "degraded; falling through to legacy dispatch: %s",
+                _heavy_exc,
+            )
+
         # Real-time mode: /v1/chat/completions with SSE streaming + Venom tool loop
         # On 429/503, fall back to batch within DW (stay cheap) instead of
         # cascading to the 150x more expensive Claude fallback.
@@ -1115,6 +1285,193 @@ class DoublewordProvider:
             )
         # ───────────────────────────────────────────────────────────
         return result
+
+    # ------------------------------------------------------------------
+    # DW Heavy Non-Streaming Lane — composes complete_sync()
+    # ------------------------------------------------------------------
+    # See module-level docstring above ``_dw_heavy_fn_lane_master_enabled``
+    # for architectural framing. These two methods are the only
+    # provider-side additions; the existing ``complete_sync`` primitive
+    # is reused verbatim (only additively extended with
+    # ``enable_thinking`` per operator design lock).
+
+    def _should_use_heavy_nonstreaming_lane(
+        self,
+        context: Any,
+        *,
+        sentinel_recent_sse_stall: bool,
+    ) -> bool:
+        """Deterministic routing predicate composing EXISTING state —
+        no new ``OperationContext`` fields. NEVER raises (fail-safe
+        to ``False``).
+
+        Eligibility derives from:
+          * ``context.task_complexity`` ∈ env-configured set
+            (default ``{complex, heavy_code}``)
+          * ``self._tool_loop`` — if a Venom-style multi-turn loop
+            is wired AND the op is heavy, the SSE path is the right
+            tool unless SSE has demonstrably stalled
+          * ``sentinel_recent_sse_stall`` — externally observed
+            transport state from existing
+            ``dw_topology_circuit_breaker`` / ``topology_sentinel``
+            surfaces (caller passes in)
+
+        Returns ``True`` only when the heavy lane should fire.
+        Master-flag check must be done by the caller (this predicate
+        assumes master ON; centralizing the master read at the
+        caller keeps the predicate test-friendly)."""
+        try:
+            complexity = (
+                getattr(context, "task_complexity", "") or ""
+            ).strip().lower()
+            eligible = set(_dw_heavy_fn_lane_eligible_complexities())
+            if complexity not in eligible:
+                return False
+            has_active_tool_loop = (
+                self._tool_loop is not None
+                and complexity in eligible
+            )
+            if has_active_tool_loop:
+                # Multi-turn agent op: stay on SSE unless transport
+                # has stalled AND the operator opts-in via
+                # PREFER_ON_SSE_STALL.
+                return bool(
+                    sentinel_recent_sse_stall
+                    and _dw_heavy_fn_lane_prefer_on_sse_stall()
+                )
+            # No tool loop = naturally single-shot eligible.
+            if _dw_heavy_fn_lane_prefer_over_sse():
+                return True
+            return bool(sentinel_recent_sse_stall)
+        except Exception:  # noqa: BLE001 — defensive
+            return False
+
+    async def _generate_heavy_nonstreaming(
+        self,
+        context: Any,
+        deadline: Any = None,
+        *,
+        prompt_override: Optional[str] = None,
+    ) -> GenerationResult:
+        """Heavy codegen non-streaming lane (PRD: "Functions, Not Agents"
+        for codegen workloads). Composes the existing
+        :meth:`complete_sync` primitive — does NOT duplicate the
+        ``stream=false`` POST logic. Parses the response via the
+        existing ``_parse_generation_response`` (no parallel parser).
+        Returns :class:`GenerationResult` (not
+        :class:`CompleteSyncResult`).
+
+        Model resolved via :meth:`_resolve_effective_model` —
+        **no hardcoded model name**. Prompt assembly composes the
+        existing ``prompt_override`` / ``_build_codegen_prompt`` seam
+        (S1 cache key compatibility preserved).
+
+        Failure modes:
+          * The wrapper raises the same exceptions ``complete_sync``
+            does (``DoublewordInfraError``, ``asyncio.TimeoutError``,
+            ``ValueError``). The orchestrator's existing
+            cascade-to-Claude branch handles them unchanged.
+        """
+        from backend.core.ouroboros.governance.providers import (
+            _build_codegen_prompt,
+            _parse_generation_response,
+        )
+
+        if prompt_override is not None:
+            assembled_prompt = prompt_override
+        else:
+            assembled_prompt = _build_codegen_prompt(
+                context,
+                repo_root=self._repo_root,
+                repo_roots=self._repo_roots or None,
+                force_full_content=True,
+                mcp_tools=None,
+                provider_route=getattr(
+                    context, "provider_route", "",
+                ) or "",
+            )
+
+        try:
+            effective_model = self._resolve_effective_model(context)
+        except Exception:  # noqa: BLE001 — defensive
+            effective_model = getattr(self, "_model", "") or ""
+
+        # Hand off to the canonical Functions-not-Agents primitive.
+        # ``enable_thinking=True`` (env-driven; default TRUE) unlocks
+        # DW reasoning over the stream-free transport — the whole
+        # point of this lane.
+        from backend.core.ouroboros.governance.providers import (
+            _CODEGEN_SYSTEM_PROMPT,
+        )
+        t0 = time.monotonic()
+        sync_result = await self.complete_sync(
+            prompt=assembled_prompt,
+            system_prompt=_CODEGEN_SYSTEM_PROMPT,
+            caller_id="heavy_codegen",
+            model=effective_model or None,
+            max_tokens=_dw_heavy_fn_lane_max_tokens(),
+            timeout_s=_dw_heavy_fn_lane_timeout_s(),
+            temperature=None,                # use _DW_TEMPERATURE default
+            response_format=None,
+            enable_thinking=_dw_heavy_fn_lane_enable_thinking(),
+        )
+
+        # Parse the raw text through the existing codegen parser —
+        # NO parallel parser. The parser builds the multi-candidate
+        # GenerationResult shape the orchestrator expects.
+        source_path = (
+            context.target_files[0]
+            if getattr(context, "target_files", None) else ""
+        )
+        source_hash = ""
+        if source_path:
+            try:
+                from backend.core.ouroboros.governance.providers import (
+                    _file_source_hash,
+                )
+                abs_path = (
+                    (self._repo_root / source_path)
+                    if self._repo_root else Path(source_path)
+                )
+                if abs_path.is_file():
+                    source_hash = _file_source_hash(
+                        abs_path.read_text(
+                            encoding="utf-8", errors="replace",
+                        )
+                    )
+            except Exception:  # noqa: BLE001 — best-effort
+                pass
+
+        duration = time.monotonic() - t0
+        parsed = _parse_generation_response(
+            sync_result.content,
+            "doubleword-heavy-nonstreaming",
+            duration,
+            context,
+            source_hash,
+            source_path,
+            repo_roots=self._repo_roots,
+            repo_root=self._repo_root,
+        )
+        # Attach token usage + cost from CompleteSyncResult so the
+        # downstream orchestrator sees the same accounting fields it
+        # gets from the legacy RT / batch paths.
+        import dataclasses as _dc
+        parsed = _dc.replace(
+            parsed,
+            total_input_tokens=int(sync_result.input_tokens or 0),
+            total_output_tokens=int(sync_result.output_tokens or 0),
+            cost_usd=float(sync_result.cost_usd or 0.0),
+            model_id=str(sync_result.model or effective_model or ""),
+        )
+        logger.info(
+            "[DoublewordProvider] heavy-nonstreaming ok in %.2fs: "
+            "%d candidates, %d+%d tokens, cost=$%.4f (model=%s)",
+            duration, len(parsed.candidates),
+            parsed.total_input_tokens, parsed.total_output_tokens,
+            parsed.cost_usd, effective_model,
+        )
+        return parsed
 
     # ------------------------------------------------------------------
     # Real-time generation via /v1/chat/completions (Venom-compatible)
@@ -2459,6 +2816,7 @@ class DoublewordProvider:
         timeout_s: float = 10.0,
         response_format: Optional[Dict[str, Any]] = None,
         temperature: Optional[float] = None,
+        enable_thinking: Optional[bool] = None,
     ) -> CompleteSyncResult:
         """Non-streaming, short-output, caller-timed synchronous completion.
 
@@ -2507,6 +2865,16 @@ class DoublewordProvider:
             ``{"type": "json_object"}`` for JSON-mode output.
         temperature:
             Override sampling temperature. Defaults to ``_DW_TEMPERATURE``.
+        enable_thinking:
+            Optional override for the per-request ``chat_template_kwargs``
+            ``enable_thinking`` flag. ``None`` (default) preserves the
+            legacy behavior of disabling DW's reasoning mode for
+            short structured-function callers (CompactionCaller,
+            BlastRadius, FailureClustering, DreamSeed). The heavy
+            codegen non-streaming lane passes ``True`` to unlock
+            DW reasoning over a stream-free transport. Existing
+            callers that omit this parameter remain byte-identical
+            to pre-extension behavior.
 
         Returns
         -------
@@ -2533,6 +2901,14 @@ class DoublewordProvider:
             temperature if temperature is not None else _DW_TEMPERATURE
         )
 
+        # Heavy-codegen non-streaming lane needs DW reasoning; legacy
+        # Functions callers (CompactionCaller, BlastRadius, etc.) call
+        # with enable_thinking=None and get the byte-identical legacy
+        # behavior (False). The new heavy lane explicitly passes True.
+        _effective_enable_thinking: bool = (
+            bool(enable_thinking) if enable_thinking is not None
+            else False
+        )
         body: Dict[str, Any] = {
             "model": effective_model,
             "messages": [
@@ -2542,7 +2918,9 @@ class DoublewordProvider:
             "max_tokens": max_tokens,
             "temperature": effective_temperature,
             "stream": False,
-            "chat_template_kwargs": {"enable_thinking": False},
+            "chat_template_kwargs": {
+                "enable_thinking": _effective_enable_thinking,
+            },
         }
         if response_format is not None:
             body["response_format"] = response_format

--- a/tests/test_ouroboros_governance/test_dw_heavy_fn_lane.py
+++ b/tests/test_ouroboros_governance/test_dw_heavy_fn_lane.py
@@ -1,0 +1,685 @@
+"""DW Heavy Non-Streaming Lane — spine tests (Functions, Not Agents for codegen).
+
+Pins the operator-approved design:
+  * Composes existing ``DoublewordProvider.complete_sync()`` — does NOT
+    duplicate the ``stream=false`` POST.
+  * Returns ``GenerationResult`` (parsed via the existing
+    ``_parse_generation_response``), NOT ``CompleteSyncResult``.
+  * Resolves model via ``_resolve_effective_model`` — NO hardcoded models.
+  * Master + 6 satellite knobs all default-FALSE / dormant on merge;
+    operator opts in.
+  * ``complete_sync()`` extension is **byte-identical for existing
+    callers** when ``enable_thinking`` is omitted.
+
+ALL helpers local to this file. ZERO real provider calls. ZERO spend.
+S2 / S1 / OCA / admission / governor / sentinel substrates untouched.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any, List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    doubleword_provider as dw_module,
+)
+from backend.core.ouroboros.governance.doubleword_provider import (
+    CompleteSyncResult,
+    DoublewordProvider,
+)
+from backend.core.ouroboros.governance.op_context import (
+    GenerationResult,
+    OperationContext,
+)
+
+
+# ============================================================================
+# Local helpers — no imports from other test modules
+# ============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _iso(monkeypatch):
+    """Strip every DW-heavy-lane env knob so each test starts at the
+    documented defaults. NEVER touches existing provider state."""
+    for k in (
+        "JARVIS_DW_HEAVY_FN_LANE_ENABLED",
+        "JARVIS_DW_HEAVY_FN_LANE_ELIGIBLE_COMPLEXITIES",
+        "JARVIS_DW_HEAVY_FN_LANE_PREFER_OVER_SSE",
+        "JARVIS_DW_HEAVY_FN_LANE_PREFER_ON_SSE_STALL",
+        "JARVIS_DW_HEAVY_FN_LANE_TIMEOUT_S",
+        "JARVIS_DW_HEAVY_FN_LANE_MAX_TOKENS",
+        "JARVIS_DW_HEAVY_FN_LANE_ENABLE_THINKING",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def _prime_2b1_response(
+    *, file_path: str = "x.py",
+    content: str = "def f():\n    return 1\n",
+) -> str:
+    return json.dumps({
+        "schema_version": "2b.1",
+        "candidates": [{
+            "candidate_id": "c1",
+            "file_path": file_path,
+            "full_content": content,
+            "rationale": "heavy-lane test",
+        }],
+    })
+
+
+def _make_dw_provider(
+    tmp_path: Path,
+    *,
+    realtime_enabled: bool = False,
+    tool_loop: Any = None,
+) -> DoublewordProvider:
+    """Construct a DW provider stub with the bare minimum surface for
+    these tests. Avoids real network setup."""
+    p = DoublewordProvider(
+        api_key="test-dw-key",
+        repo_root=tmp_path,
+        realtime_enabled=realtime_enabled,
+        tool_loop=tool_loop,
+    )
+    return p
+
+
+def _make_ctx(
+    *,
+    op_id: str = "op-dw-heavy-baseline-001",
+    route: str = "ide",
+    task_complexity: str = "complex",
+    target_files: tuple = ("x.py",),
+    description: str = "heavy codegen op",
+) -> OperationContext:
+    import dataclasses
+    ctx = OperationContext.create(
+        target_files=target_files,
+        description=description,
+        op_id=op_id,
+    )
+    return dataclasses.replace(
+        ctx,
+        provider_route=route,
+        task_complexity=task_complexity,
+    )
+
+
+# ============================================================================
+# (1) complete_sync byte-identical for existing callers when enable_thinking
+#     omitted — load-bearing additive-parameter test.
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_complete_sync_default_preserves_enable_thinking_false(
+    tmp_path,
+):
+    """Existing callers (CompactionCaller et al.) call ``complete_sync``
+    without ``enable_thinking``. The body must send
+    ``enable_thinking: False`` — byte-identical to pre-extension
+    behavior."""
+    provider = _make_dw_provider(tmp_path)
+
+    captured: dict = {}
+
+    def _fake_post(url, **kwargs):
+        """aiohttp.ClientSession.post is SYNC — returns an async ctx mgr
+        directly. NOT a coroutine."""
+        captured["json"] = kwargs.get("json")
+        resp = MagicMock()
+        resp.status = 200
+        # complete_sync calls await resp.json() (NOT resp.text)
+        resp.json = AsyncMock(return_value={
+            "choices": [{"message": {"content": _prime_2b1_response()}}],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+        })
+        resp.text = AsyncMock(return_value="")
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    # Patch the provider's session getter (used by complete_sync)
+    fake_session = MagicMock()
+    fake_session.post = MagicMock(side_effect=_fake_post)
+    provider._get_session = AsyncMock(return_value=fake_session)  # type: ignore[assignment]
+
+    result = await provider.complete_sync(
+        prompt="hello",
+        system_prompt="you are a test",
+        caller_id="compaction-style-test",
+        timeout_s=10.0,
+        # NOTE: enable_thinking deliberately omitted
+    )
+
+    assert isinstance(result, CompleteSyncResult)
+    body = captured.get("json") or {}
+    chat_template = body.get("chat_template_kwargs", {})
+    assert chat_template.get("enable_thinking") is False, (
+        f"Byte-identical legacy contract broken: expected "
+        f"enable_thinking=False when omitted, got {chat_template!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_complete_sync_enable_thinking_true_threads_through(
+    tmp_path,
+):
+    """When the heavy lane explicitly passes ``enable_thinking=True``,
+    the wire body MUST carry that value."""
+    provider = _make_dw_provider(tmp_path)
+    captured: dict = {}
+
+    def _fake_post(url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        resp = MagicMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value={
+            "choices": [{"message": {"content": _prime_2b1_response()}}],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+        })
+        resp.text = AsyncMock(return_value="")
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    fake_session = MagicMock()
+    fake_session.post = MagicMock(side_effect=_fake_post)
+    provider._get_session = AsyncMock(return_value=fake_session)  # type: ignore[assignment]
+
+    await provider.complete_sync(
+        prompt="heavy reasoning op",
+        system_prompt="heavy codegen system prompt",
+        caller_id="heavy_codegen",
+        timeout_s=120.0,
+        enable_thinking=True,
+    )
+
+    body = captured.get("json") or {}
+    chat_template = body.get("chat_template_kwargs", {})
+    assert chat_template.get("enable_thinking") is True
+
+
+# ============================================================================
+# (2) Routing predicate — _should_use_heavy_nonstreaming_lane
+# ============================================================================
+
+
+class TestRoutingPredicate:
+    """The predicate composes existing context state + sentinel SSE
+    state — no new OperationContext fields. Master-flag check is the
+    CALLER's responsibility per the predicate's docstring."""
+
+    def test_ineligible_complexity_returns_false(self, tmp_path):
+        provider = _make_dw_provider(tmp_path)
+        ctx = _make_ctx(task_complexity="trivial")
+        assert provider._should_use_heavy_nonstreaming_lane(
+            ctx, sentinel_recent_sse_stall=False,
+        ) is False
+        assert provider._should_use_heavy_nonstreaming_lane(
+            ctx, sentinel_recent_sse_stall=True,
+        ) is False
+
+    def test_heavy_no_tool_loop_no_prefer_no_stall_returns_false(
+        self, tmp_path,
+    ):
+        provider = _make_dw_provider(tmp_path, tool_loop=None)
+        ctx = _make_ctx(task_complexity="complex")
+        assert provider._should_use_heavy_nonstreaming_lane(
+            ctx, sentinel_recent_sse_stall=False,
+        ) is False
+
+    def test_heavy_no_tool_loop_prefer_over_sse_returns_true(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setenv(
+            "JARVIS_DW_HEAVY_FN_LANE_PREFER_OVER_SSE", "true",
+        )
+        provider = _make_dw_provider(tmp_path, tool_loop=None)
+        ctx = _make_ctx(task_complexity="complex")
+        assert provider._should_use_heavy_nonstreaming_lane(
+            ctx, sentinel_recent_sse_stall=False,
+        ) is True
+
+    def test_heavy_no_tool_loop_sse_stall_returns_true(self, tmp_path):
+        provider = _make_dw_provider(tmp_path, tool_loop=None)
+        ctx = _make_ctx(task_complexity="heavy_code")
+        assert provider._should_use_heavy_nonstreaming_lane(
+            ctx, sentinel_recent_sse_stall=True,
+        ) is True
+
+    def test_heavy_with_tool_loop_no_stall_returns_false(self, tmp_path):
+        """Multi-turn agent op — stay on SSE absent transport stall."""
+        provider = _make_dw_provider(
+            tmp_path, tool_loop=MagicMock(),  # any truthy
+        )
+        ctx = _make_ctx(task_complexity="complex")
+        assert provider._should_use_heavy_nonstreaming_lane(
+            ctx, sentinel_recent_sse_stall=False,
+        ) is False
+
+    def test_heavy_with_tool_loop_sse_stall_routes_to_heavy_lane(
+        self, tmp_path,
+    ):
+        """SSE stall + heavy op + PREFER_ON_SSE_STALL (default True)
+        → heavy lane fires. Does NOT mark DW model weak; the
+        decision is purely transport-driven."""
+        provider = _make_dw_provider(tmp_path, tool_loop=MagicMock())
+        ctx = _make_ctx(task_complexity="complex")
+        assert provider._should_use_heavy_nonstreaming_lane(
+            ctx, sentinel_recent_sse_stall=True,
+        ) is True
+
+    def test_heavy_with_tool_loop_sse_stall_but_prefer_disabled(
+        self, tmp_path, monkeypatch,
+    ):
+        """Operator can disable the SSE-stall-triggered lane via env."""
+        monkeypatch.setenv(
+            "JARVIS_DW_HEAVY_FN_LANE_PREFER_ON_SSE_STALL", "false",
+        )
+        provider = _make_dw_provider(tmp_path, tool_loop=MagicMock())
+        ctx = _make_ctx(task_complexity="complex")
+        assert provider._should_use_heavy_nonstreaming_lane(
+            ctx, sentinel_recent_sse_stall=True,
+        ) is False
+
+    def test_predicate_never_raises_on_garbage_context(self, tmp_path):
+        provider = _make_dw_provider(tmp_path)
+
+        class _BadCtx:
+            # Force AttributeError on task_complexity access? Use
+            # a property that raises:
+            @property
+            def task_complexity(self):
+                raise RuntimeError("synthetic")
+        # Predicate must catch and return False
+        assert provider._should_use_heavy_nonstreaming_lane(
+            _BadCtx(), sentinel_recent_sse_stall=True,
+        ) is False
+
+
+# ============================================================================
+# (3) _generate_heavy_nonstreaming wrapper — calls complete_sync exactly
+#     once and returns GenerationResult
+# ============================================================================
+
+
+def _patch_complete_sync(provider, *, return_text: str,
+                         input_tokens: int = 100,
+                         output_tokens: int = 50,
+                         cost_usd: float = 0.001,
+                         model: str = "Qwen/Qwen3.5-397B-A17B-FP8") -> List[dict]:
+    """Replace ``provider.complete_sync`` with a spy that captures
+    every call kwarg + returns a fake ``CompleteSyncResult``."""
+    calls: List[dict] = []
+
+    async def _spy(**kwargs):
+        calls.append(dict(kwargs))
+        return CompleteSyncResult(
+            content=return_text,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+            latency_s=0.01,
+            model=model,
+        )
+
+    provider.complete_sync = _spy  # type: ignore[assignment]
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_calls_complete_sync_exactly_once(tmp_path):
+    provider = _make_dw_provider(tmp_path)
+    calls = _patch_complete_sync(
+        provider, return_text=_prime_2b1_response(),
+    )
+    ctx = _make_ctx()
+    result = await provider._generate_heavy_nonstreaming(ctx, None)
+    assert len(calls) == 1, f"expected exactly 1 complete_sync call, got {len(calls)}"
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_returns_generation_result_not_complete_sync_result(
+    tmp_path,
+):
+    provider = _make_dw_provider(tmp_path)
+    _patch_complete_sync(provider, return_text=_prime_2b1_response())
+    ctx = _make_ctx()
+    result = await provider._generate_heavy_nonstreaming(ctx, None)
+    assert isinstance(result, GenerationResult)
+    assert not isinstance(result, CompleteSyncResult)
+    assert len(result.candidates) >= 1
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_uses_codegen_system_prompt(tmp_path):
+    """The wrapper passes ``_CODEGEN_SYSTEM_PROMPT`` (the shared
+    codegen prompt), NOT a synthetic per-caller prompt."""
+    from backend.core.ouroboros.governance.providers import (
+        _CODEGEN_SYSTEM_PROMPT,
+    )
+    provider = _make_dw_provider(tmp_path)
+    calls = _patch_complete_sync(
+        provider, return_text=_prime_2b1_response(),
+    )
+    ctx = _make_ctx()
+    await provider._generate_heavy_nonstreaming(ctx, None)
+    assert calls[0]["system_prompt"] == _CODEGEN_SYSTEM_PROMPT
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_uses_caller_id_heavy_codegen(tmp_path):
+    provider = _make_dw_provider(tmp_path)
+    calls = _patch_complete_sync(
+        provider, return_text=_prime_2b1_response(),
+    )
+    ctx = _make_ctx()
+    await provider._generate_heavy_nonstreaming(ctx, None)
+    assert calls[0]["caller_id"] == "heavy_codegen"
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_passes_enable_thinking_per_env(
+    tmp_path, monkeypatch,
+):
+    """The wrapper threads the env-driven enable_thinking into
+    complete_sync. Default TRUE for the heavy lane."""
+    provider = _make_dw_provider(tmp_path)
+    calls = _patch_complete_sync(
+        provider, return_text=_prime_2b1_response(),
+    )
+    ctx = _make_ctx()
+    # default: TRUE per design
+    await provider._generate_heavy_nonstreaming(ctx, None)
+    assert calls[-1]["enable_thinking"] is True
+    # Override to FALSE
+    monkeypatch.setenv(
+        "JARVIS_DW_HEAVY_FN_LANE_ENABLE_THINKING", "false",
+    )
+    await provider._generate_heavy_nonstreaming(ctx, None)
+    assert calls[-1]["enable_thinking"] is False
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_threads_timeout_env(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_DW_HEAVY_FN_LANE_TIMEOUT_S", "45.0",
+    )
+    provider = _make_dw_provider(tmp_path)
+    calls = _patch_complete_sync(
+        provider, return_text=_prime_2b1_response(),
+    )
+    ctx = _make_ctx()
+    await provider._generate_heavy_nonstreaming(ctx, None)
+    assert calls[-1]["timeout_s"] == pytest.approx(45.0)
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_threads_max_tokens_env(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_DW_HEAVY_FN_LANE_MAX_TOKENS", "8192",
+    )
+    provider = _make_dw_provider(tmp_path)
+    calls = _patch_complete_sync(
+        provider, return_text=_prime_2b1_response(),
+    )
+    ctx = _make_ctx()
+    await provider._generate_heavy_nonstreaming(ctx, None)
+    assert calls[-1]["max_tokens"] == 8192
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_token_usage_threaded_into_result(tmp_path):
+    provider = _make_dw_provider(tmp_path)
+    _patch_complete_sync(
+        provider, return_text=_prime_2b1_response(),
+        input_tokens=999, output_tokens=222, cost_usd=0.0042,
+    )
+    ctx = _make_ctx()
+    result = await provider._generate_heavy_nonstreaming(ctx, None)
+    assert result.total_input_tokens == 999
+    assert result.total_output_tokens == 222
+    assert result.cost_usd == pytest.approx(0.0042)
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_model_id_propagates_from_complete_sync(
+    tmp_path,
+):
+    provider = _make_dw_provider(tmp_path)
+    _patch_complete_sync(
+        provider, return_text=_prime_2b1_response(),
+        model="Qwen/Qwen3.5-397B-A17B-FP8",
+    )
+    ctx = _make_ctx()
+    result = await provider._generate_heavy_nonstreaming(ctx, None)
+    assert result.model_id == "Qwen/Qwen3.5-397B-A17B-FP8"
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_provider_name_distinguishes_lane(tmp_path):
+    """Provider name in result must distinguish this lane from RT/batch
+    so downstream telemetry can attribute correctly."""
+    provider = _make_dw_provider(tmp_path)
+    _patch_complete_sync(provider, return_text=_prime_2b1_response())
+    ctx = _make_ctx()
+    result = await provider._generate_heavy_nonstreaming(ctx, None)
+    assert "doubleword" in result.provider_name.lower()
+    # The exact tag is implementation-defined; pin only the
+    # heavy/nonstreaming distinction.
+    assert (
+        "heavy" in result.provider_name.lower()
+        or "nonstream" in result.provider_name.lower()
+    )
+
+
+# ============================================================================
+# (4) Master OFF byte-identical
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_master_off_skips_heavy_lane_in_dispatch_internal(tmp_path):
+    """Master OFF (default) ⇒ _dispatch_internal must NOT consult
+    the heavy-lane predicate; behavior byte-identical to today.
+    Verified by spying on the predicate via monkeypatch."""
+    provider = _make_dw_provider(tmp_path, realtime_enabled=True)
+    # Make sure master is OFF (autouse fixture already strips env)
+    assert not dw_module._dw_heavy_fn_lane_master_enabled()
+
+    predicate_calls = []
+    original_predicate = provider._should_use_heavy_nonstreaming_lane
+
+    def _spy(*args, **kwargs):
+        predicate_calls.append((args, kwargs))
+        return original_predicate(*args, **kwargs)
+
+    provider._should_use_heavy_nonstreaming_lane = _spy  # type: ignore[assignment]
+
+    # Stub _generate_realtime to short-circuit + return a fake result
+    async def _stub_rt(*args, **kwargs):
+        return GenerationResult(
+            candidates=(),
+            provider_name="doubleword-rt-stub",
+            generation_duration_s=0.0,
+        )
+    provider._generate_realtime = _stub_rt  # type: ignore[assignment]
+
+    ctx = _make_ctx()
+    await provider._dispatch_internal(ctx, None)
+    assert predicate_calls == [], (
+        "Master OFF must not invoke the heavy-lane predicate; "
+        f"saw {len(predicate_calls)} call(s)"
+    )
+
+
+# ============================================================================
+# (5) AST pins
+# ============================================================================
+
+
+def test_ast_pin_no_hardcoded_model_names_in_heavy_lane():
+    """Heavy lane MUST NOT carry literal model strings — model
+    resolved via ``_resolve_effective_model(context)``."""
+    src = Path(
+        "backend/core/ouroboros/governance/doubleword_provider.py"
+    ).read_text(encoding="utf-8")
+    # Isolate the heavy lane method body
+    import re
+    match = re.search(
+        r"async def _generate_heavy_nonstreaming\(.*?\n(.*?)\n    "
+        r"# -+\n    # Real-time generation",
+        src, re.DOTALL,
+    )
+    assert match is not None, "could not isolate _generate_heavy_nonstreaming"
+    body = match.group(1)
+    # Reject obvious model-name patterns inside the body
+    forbidden_patterns = [
+        '"Qwen/', "'Qwen/",
+        '"claude-', "'claude-",
+        '"gpt-', "'gpt-",
+        '"deepseek', "'deepseek",
+    ]
+    for fp in forbidden_patterns:
+        assert fp not in body, (
+            f"heavy lane body contains hardcoded model literal {fp!r}"
+        )
+
+
+def test_ast_pin_heavy_lane_composes_complete_sync():
+    """The wrapper MUST call ``self.complete_sync(...)`` — not
+    duplicate the ``stream=false`` POST logic."""
+    src = Path(
+        "backend/core/ouroboros/governance/doubleword_provider.py"
+    ).read_text(encoding="utf-8")
+    import re
+    match = re.search(
+        r"async def _generate_heavy_nonstreaming\(.*?\n(.*?)\n    "
+        r"# -+\n    # Real-time generation",
+        src, re.DOTALL,
+    )
+    assert match is not None
+    body = match.group(1)
+    assert "self.complete_sync(" in body, (
+        "heavy lane must compose self.complete_sync — found no call site"
+    )
+    # And MUST NOT contain its own /v1/chat/completions wire setup
+    assert "/v1/chat/completions" not in body, (
+        "heavy lane must not duplicate /v1/chat/completions wire code"
+    )
+    assert '"stream": False' not in body, (
+        "heavy lane must not have its own stream=False body assembly"
+    )
+
+
+def test_ast_pin_heavy_lane_uses_existing_parse_response():
+    src = Path(
+        "backend/core/ouroboros/governance/doubleword_provider.py"
+    ).read_text(encoding="utf-8")
+    import re
+    match = re.search(
+        r"async def _generate_heavy_nonstreaming\(.*?\n(.*?)\n    "
+        r"# -+\n    # Real-time generation",
+        src, re.DOTALL,
+    )
+    assert match is not None
+    body = match.group(1)
+    assert "_parse_generation_response" in body, (
+        "heavy lane must use the existing _parse_generation_response parser"
+    )
+
+
+def test_ast_pin_no_duplicate_prompt_builder():
+    """Heavy lane uses prompt_override OR composes _build_codegen_prompt
+    — must NOT define its own prompt-assembly helper."""
+    src = Path(
+        "backend/core/ouroboros/governance/doubleword_provider.py"
+    ).read_text(encoding="utf-8")
+    import re
+    match = re.search(
+        r"async def _generate_heavy_nonstreaming\(.*?\n(.*?)\n    "
+        r"# -+\n    # Real-time generation",
+        src, re.DOTALL,
+    )
+    assert match is not None
+    body = match.group(1)
+    # Must reuse the existing helper
+    assert "_build_codegen_prompt" in body, (
+        "heavy lane must reuse _build_codegen_prompt (no parallel "
+        "prompt builder)"
+    )
+    # Must NOT define a new local function with prompt assembly intent
+    assert "def _build_heavy_prompt" not in body
+    assert "def _assemble_heavy_prompt" not in body
+
+
+def test_ast_pin_complete_sync_signature_extension():
+    """``complete_sync`` was extended additively with
+    ``enable_thinking: Optional[bool] = None`` — new param at end,
+    default None, preserves call-site compatibility."""
+    import inspect
+    sig = inspect.signature(DoublewordProvider.complete_sync)
+    params = sig.parameters
+    assert "enable_thinking" in params
+    p = params["enable_thinking"]
+    assert p.default is None, (
+        "enable_thinking must default to None to preserve byte-"
+        "identical legacy behavior for existing callers"
+    )
+    # Pin the existing parameters are unchanged (additive extension)
+    for legacy in (
+        "prompt", "system_prompt", "caller_id", "model",
+        "max_tokens", "timeout_s", "response_format", "temperature",
+    ):
+        assert legacy in params, (
+            f"complete_sync missing legacy param {legacy!r}"
+        )
+
+
+# ============================================================================
+# (6) Failure cascading — heavy lane failures propagate; orchestrator
+#     cascades to Claude unchanged
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_complete_sync_timeout_propagates(tmp_path):
+    """If ``complete_sync`` raises ``asyncio.TimeoutError``, the
+    wrapper must let it propagate — orchestrator handles cascade."""
+    provider = _make_dw_provider(tmp_path)
+
+    async def _timeout(**kwargs):
+        raise asyncio.TimeoutError("synthetic timeout")
+    provider.complete_sync = _timeout  # type: ignore[assignment]
+
+    ctx = _make_ctx()
+    with pytest.raises(asyncio.TimeoutError):
+        await provider._generate_heavy_nonstreaming(ctx, None)
+
+
+@pytest.mark.asyncio
+async def test_heavy_lane_complete_sync_dw_infra_error_propagates(tmp_path):
+    """``DoublewordInfraError`` from complete_sync propagates; the
+    orchestrator's existing cascade-to-Claude branch handles it
+    unchanged."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordInfraError,
+    )
+    provider = _make_dw_provider(tmp_path)
+
+    async def _err(**kwargs):
+        raise DoublewordInfraError("synthetic", status_code=500)
+    provider.complete_sync = _err  # type: ignore[assignment]
+
+    ctx = _make_ctx()
+    with pytest.raises(DoublewordInfraError):
+        await provider._generate_heavy_nonstreaming(ctx, None)


### PR DESCRIPTION
## DW Heavy Non-Streaming Lane — "Functions, Not Agents" for codegen

Composes the existing `DoublewordProvider.complete_sync()` Functions-not-Agents primitive (used today by `CompactionCaller`, `BlastRadius`, `FailureClustering`, `DreamSeed`) and adds a codegen-shaped wrapper that returns `GenerationResult`. **Master default-FALSE on merge — byte-identical to today until you opt in.**

### Architectural correction (load-bearing)

> *"DW heavy routing is constrained by streaming transport reliability, NOT by model reasoning quality."*

This lane unlocks DW reasoning via a stream-free path. `enable_thinking` defaults to **TRUE** for the heavy lane because the lane exists precisely to make DW reasoning reachable without the SSE stall surface.

### Composition discipline (no duplication, no new substrate)

| Existing primitive | How this PR composes it |
|---|---|
| `DoublewordProvider.complete_sync()` | **additive** `enable_thinking: Optional[bool] = None` at end of kwargs; default `None` ⇒ legacy `False` (byte-identical for existing callers) |
| `_build_codegen_prompt` / `prompt_override` | reused via S1 cache key seam |
| `_parse_generation_response` | reused for codegen parsing |
| `_resolve_effective_model(context)` | reused — no hardcoded models |
| `_CODEGEN_SYSTEM_PROMPT` | reused — same shared codegen prompt |

### New surface (additive, master-gated)

- `_should_use_heavy_nonstreaming_lane(context, *, sentinel_recent_sse_stall)` — routing predicate; **no new `OperationContext` field**
- `_generate_heavy_nonstreaming()` — wrapper that composes `complete_sync` and returns `GenerationResult`
- `_dispatch_internal` wiring — fails open to legacy SSE/batch on any heavy-lane fault

### 7 env knobs (all dormant on merge)

```
JARVIS_DW_HEAVY_FN_LANE_ENABLED=false   (master)
JARVIS_DW_HEAVY_FN_LANE_ELIGIBLE_COMPLEXITIES=complex,heavy_code
JARVIS_DW_HEAVY_FN_LANE_PREFER_OVER_SSE=false
JARVIS_DW_HEAVY_FN_LANE_PREFER_ON_SSE_STALL=true
JARVIS_DW_HEAVY_FN_LANE_TIMEOUT_S=120.0     [clamped 5..600]
JARVIS_DW_HEAVY_FN_LANE_MAX_TOKENS=16384    [clamped 256..32768]
JARVIS_DW_HEAVY_FN_LANE_ENABLE_THINKING=true
```

### Diffstat

```
backend/core/ouroboros/governance/doubleword_provider.py        | +380 / -1
tests/test_ouroboros_governance/test_dw_heavy_fn_lane.py (NEW)  | +685
2 files changed, 1064 insertions(+), 1 deletion(-)
```

### Test counts (verified)

| Suite | Count | Status |
|---|---|---|
| NEW `test_dw_heavy_fn_lane.py` | **28** | ✅ all green in 1.33s |
| Existing CompactionCaller regression (byte-identical proof) | **17** | ✅ all green |
| S1 substrate + wiring + shadow | 54 | ✅ |
| S2 substrate + wiring | 66 | ✅ |
| Sensor governor regression | 107 | ✅ |
| **Total governance spine** | **272** | ✅ **green** |

### Confirmation: same 2 xfails on Phase 1 baseline remain xfailed

This PR does NOT touch `tests/test_ouroboros_governance/test_claude_generate_raw_baseline.py`. The Claude `_generate_raw` characterization spine (Phase 1, in PR #46868) is unaffected. The 2 Phase-1 xfails (model_id propagation, hardcoded 8.0s floor) are unchanged.

### Confirmation: tool_loop.run continues to receive `async prompt → raw` callable

This PR doesn't restructure ClaudeProvider's tool_loop wiring. DW's heavy lane lives at the dispatch-method level, not the tool-loop level.

### Confirmation: multi-round cost/tokens preserved

Heavy lane is single-shot by design (non-streaming, one POST → one response). Multi-round token/cost accumulation lives in the existing SSE path which this PR does not touch.

### Out of scope (explicit)

- ❌ No live provider spend
- ❌ No default flip of any flag
- ❌ No removal of Claude fallback (cascade safety preserved)
- ❌ No claim DW is stable over SSE for agent workloads
- ❌ No weakening of timeouts; no brute-force retry loops
- ❌ No OCA / git-index / sovereignty / cursor-agent-ban changes
- ❌ No new `OperationContext` field (predicate uses existing state only)
- ❌ No duplicate `/chat/completions` stream=false POST logic
- ❌ No new parallel prompt builder; no parallel parser
- ❌ No edits to `complete_sync()` semantics — only additive `enable_thinking` param
- ❌ No edits to `providers.py` / `provider_response_cache.py` / `s2_predictive_budget.py` / `admission_*` / `sensor_governor.py` / `candidate_generator.py` / `brain_selection_policy.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DW heavy non‑streaming lane that runs codegen via `DoublewordProvider.complete_sync()` (Functions‑not‑Agents) and returns `GenerationResult` to avoid SSE stall issues. The master switch is off by default, so behavior is unchanged unless enabled.

- **New Features**
  - Added `_generate_heavy_nonstreaming()` that composes `complete_sync`, reuses `_build_codegen_prompt`, `_CODEGEN_SYSTEM_PROMPT`, `_parse_generation_response`, and `_resolve_effective_model`, and threads tokens/cost/model into the `GenerationResult`.
  - Added `_should_use_heavy_nonstreaming_lane(...)` using existing context (no new fields) with env‑configured eligibility; can prefer over SSE or on SSE stall; any fault falls back to legacy SSE/batch.
  - Wired `_dispatch_internal` to call the heavy lane only when `JARVIS_DW_HEAVY_FN_LANE_ENABLED` is true and the predicate passes.
  - Extended `complete_sync()` with `enable_thinking: Optional[bool] = None` (defaults to legacy False); the heavy lane passes `True`.
  - New env knobs: `JARVIS_DW_HEAVY_FN_LANE_ENABLED`, `JARVIS_DW_HEAVY_FN_LANE_ELIGIBLE_COMPLEXITIES`, `JARVIS_DW_HEAVY_FN_LANE_PREFER_OVER_SSE`, `JARVIS_DW_HEAVY_FN_LANE_PREFER_ON_SSE_STALL`, `JARVIS_DW_HEAVY_FN_LANE_TIMEOUT_S` (5..600), `JARVIS_DW_HEAVY_FN_LANE_MAX_TOKENS` (256..32768), `JARVIS_DW_HEAVY_FN_LANE_ENABLE_THINKING`.

- **Migration**
  - Enable with `JARVIS_DW_HEAVY_FN_LANE_ENABLED=true`; optionally tune the other envs to fit your workload.
  - No code changes needed and no new `OperationContext` fields; existing fallbacks remain intact.

<sup>Written for commit 4fe3d02974e08de4e5351c1ae411b29f9b8af56c. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/47413?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

