### PR TITLE
feat(governance): Session-Budget Preflight Authority — hard wallet gate before provider dispatch

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -263,6 +263,22 @@ class BattleTestHarness:
             budget_usd=config.cost_cap_usd,
             persist_path=self._session_dir / "cost_tracker.json",
         )
+        # PRD §session-budget-preflight: register the CostTracker as
+        # the authoritative session-budget provider for governance.
+        # Adapter pattern — governance never imports battle_test; this
+        # harness side calls the registration. The duck-typed protocol
+        # (.remaining) means no type-import dependency either.
+        # NEVER raises (helper is defensive).
+        try:
+            from backend.core.ouroboros.governance.session_budget_authority import (  # noqa: E501
+                set_session_budget_provider,
+            )
+            set_session_budget_provider(self._cost_tracker)
+        except Exception as _sba_reg_exc:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[Harness] session_budget_authority registration "
+                "degraded: %s", _sba_reg_exc,
+            )
         self._idle_watchdog = IdleWatchdog(timeout_s=config.idle_timeout_s)
         self._session_recorder = SessionRecorder(session_id=self._session_id)
         # Session-liveness probes — zero-arg callables returning True

--- a/backend/core/ouroboros/governance/cost_governor.py
+++ b/backend/core/ouroboros/governance/cost_governor.py
@@ -76,6 +76,34 @@ logger = logging.getLogger(__name__)
 
 
 # -----------------------------------------------------------------------------
+# Session-aware clamp (PRD §session-budget-preflight)
+# -----------------------------------------------------------------------------
+# When the session_budget_authority has an active provider AND this
+# master is ON (default TRUE — fail-closed per operator), the per-op
+# cap derived by `_derive_cap` is clamped down to the remaining
+# session budget. This prevents the route × headroom × readonly
+# multipliers from authorizing a single op to exceed the session cap
+# (the load-bearing $0.10 → $0.1281 overage observed in
+# bt-2026-05-21-010600).
+#
+# Operator emergency override: set =false to revert to legacy
+# unclamped behavior. NEVER raises.
+
+_ENV_SESSION_CLAMP_ENABLED = "JARVIS_COST_GOVERNOR_SESSION_CLAMP_ENABLED"
+
+
+def _session_clamp_enabled() -> bool:
+    """Default TRUE per operator's 'fail-closed for spend authority
+    when a real session cap is active'. NEVER raises."""
+    try:
+        return os.environ.get(
+            _ENV_SESSION_CLAMP_ENABLED, "true",
+        ).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001 — defensive
+        return True  # fail-closed default
+
+
+# -----------------------------------------------------------------------------
 # Env-var helpers
 # -----------------------------------------------------------------------------
 
@@ -437,6 +465,34 @@ class CostGovernor:
 
         # Clamp into [min_cap_usd, max_cap_usd]; protects against env typos.
         cap = max(cfg.min_cap_usd, min(cfg.max_cap_usd, raw_cap))
+
+        # PRD §session-budget-preflight: session-aware clamp.
+        # When a session_budget_authority provider is active (e.g. battle
+        # harness CostTracker) AND the master clamp env is ON (default),
+        # the per-op cap MUST NOT exceed remaining session budget. This
+        # closes the load-bearing $0.10 → $0.1281 overage observed in
+        # bt-2026-05-21-010600 where route[immediate]=5.0 × complexity ×
+        # headroom=3.0 authorized $1.20 per op against a $0.10 session cap.
+        if _session_clamp_enabled():
+            try:
+                from backend.core.ouroboros.governance.session_budget_authority import (  # noqa: E501
+                    get_session_remaining_usd,
+                )
+                session_remaining = get_session_remaining_usd()
+                if (
+                    session_remaining is not None
+                    and session_remaining < cap
+                ):
+                    # Honor min_cap_usd floor even under session pressure —
+                    # going below min_cap_usd would starve ops below the
+                    # operator's documented operational floor.
+                    cap = max(cfg.min_cap_usd, session_remaining)
+            except Exception as exc:  # noqa: BLE001 — defensive
+                logger.debug(
+                    "[CostGovernor] session-aware clamp degraded: %s",
+                    exc,
+                )
+
         return cap, route_factor, complexity_factor
 
     # --------------------------------------------------------------

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -662,7 +662,10 @@ class DoublewordProvider:
             self._budget_reset_date = today
 
     def _check_budget(self) -> None:
-        """Raise if daily budget is exhausted. Called before each generation."""
+        """Raise if daily budget is exhausted OR session-budget preflight
+        refuses. Called before each generation (including from
+        ``complete_sync``, which means the DW heavy non-streaming lane
+        inherits the gate transparently)."""
         self._maybe_reset_daily_budget()
         if self._daily_spend >= self._daily_budget:
             raise DoublewordInfraError(
@@ -670,6 +673,26 @@ class DoublewordProvider:
                 f">= budget ${self._daily_budget:.2f}",
                 status_code=0,
             )
+        # PRD §session-budget-preflight: hard wallet gate. Refuses BEFORE
+        # any network dispatch when the estimated cost (per-op cap as
+        # conservative upper bound) exceeds remaining session budget.
+        # Composes the duck-typed session_budget_authority — no parallel
+        # ledger. No-op when no session authority is active (fail-OPEN).
+        try:
+            from backend.core.ouroboros.governance.session_budget_authority import (  # noqa: E501
+                check_preflight as _sba_check_preflight,
+            )
+            _sba_check_preflight(
+                provider_name="doubleword",
+                estimated_cost_usd=float(self._max_cost_per_op or 0.0),
+            )
+        except ImportError:
+            # Module absent on this build — graceful fall-through to
+            # legacy daily-only gate.
+            pass
+        # SessionBudgetPreflightRefused: NOT caught — propagates to
+        # the orchestrator's cascade machinery which routes on the
+        # structured `reason` field.
 
     def _record_cost(self, cost: float) -> None:
         """Record cost from a completed batch and check per-op limit."""

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -6447,6 +6447,33 @@ class ClaudeProvider:
         if self._daily_spend >= self._daily_budget:
             raise RuntimeError("claude_budget_exhausted")
 
+        # PRD §session-budget-preflight: hard wallet gate. Refuses
+        # BEFORE any client construction / network dispatch if the
+        # estimated cost of this call (self._max_cost_per_op as the
+        # conservative upper bound) exceeds remaining session budget.
+        # Composes the duck-typed session_budget_authority — no
+        # parallel ledger, no battle_test import. No-op when no
+        # session authority is active (fail-OPEN). Closes the load-
+        # bearing $0.10 → $0.1281 overage observed 2026-05-21.
+        try:
+            from backend.core.ouroboros.governance.session_budget_authority import (  # noqa: E501
+                check_preflight as _sba_check_preflight,
+            )
+            _sba_check_preflight(
+                provider_name="claude",
+                estimated_cost_usd=float(
+                    self._max_cost_per_op or 0.0,
+                ),
+            )
+        except ImportError:
+            # Module absent on this build (graceful) — fall through to
+            # legacy behavior.
+            pass
+        # SessionBudgetPreflightRefused: deliberately NOT caught here —
+        # propagates to the orchestrator's cascade machinery, which
+        # recognizes the structured `reason` field and routes the
+        # refusal appropriately.
+
         client = self._ensure_client()
         repo_root = _resolve_effective_repo_root(
             context,

--- a/backend/core/ouroboros/governance/session_budget_authority.py
+++ b/backend/core/ouroboros/governance/session_budget_authority.py
@@ -1,0 +1,274 @@
+"""Pre-call session-budget hard authority (PRD §session-budget-preflight).
+
+Closes the load-bearing gap surfaced by Step-1 verification soak
+(2026-05-21 ``bt-2026-05-21-010600``): a single Claude call at
+``route=immediate complexity=simple`` consumed ``$0.1281`` against a
+``$0.10`` session cap because ``CostGovernor._derive_cap`` permits
+per-op caps up to ``baseline_usd × route_factor × complexity_factor
+× retry_headroom × readonly_factor`` ($1.20 in that example) — far
+in excess of the session cap. ``CostTracker.record()`` fires its
+``budget_event`` *after* the spend lands, which is too late to
+prevent the overage.
+
+This module is the hard wallet gate. Composes:
+
+  * ``battle_test.cost_tracker.CostTracker`` via a duck-typed
+    protocol (any object with a ``.remaining`` numeric property).
+    The harness registers its tracker at construction; governance
+    never imports ``battle_test``.
+
+  * Env fallback chain when no provider is registered:
+        Tier 1: ``JARVIS_S2_SESSION_BUDGET_USD`` (S2 wiring chain)
+        Tier 2: ``OUROBOROS_BATTLE_COST_CAP`` (battle harness env)
+        Tier 3: ``None`` — no authority active; preflight fail-OPEN
+
+S2 remains advisory (operator constraint). This module is the hard
+gate. S2 may inform forecasts but spend authority belongs here.
+
+Architectural invariants:
+
+  * No parallel cost ledger.
+  * No hardcoded model prices.
+  * No import of ``battle_test`` from this module (cycle-free).
+  * Fail-CLOSED when authority is active; fail-OPEN when not (so
+    environments without a session cap retain byte-identical
+    pre-PR behavior).
+  * NEVER raises any exception class OTHER than
+    :class:`SessionBudgetPreflightRefused`.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger("Ouroboros.SessionBudgetAuthority")
+
+SESSION_BUDGET_AUTHORITY_SCHEMA_VERSION: str = (
+    "session_budget_authority.v1"
+)
+
+# Env fallback chain — reuses S2 + battle harness env knobs already
+# in place. No new env knob for the budget value itself; this module
+# only introduces the master clamp knob (consumed by CostGovernor).
+_ENV_S2_SESSION_BUDGET = "JARVIS_S2_SESSION_BUDGET_USD"
+_ENV_BATTLE_COST_CAP = "OUROBOROS_BATTLE_COST_CAP"
+
+
+@runtime_checkable
+class _SessionBudgetProvider(Protocol):
+    """Duck-typed protocol: any object with a numeric ``.remaining``
+    property satisfies it. ``CostTracker`` does today (verified at
+    :file:`backend/core/ouroboros/battle_test/cost_tracker.py`).
+    NO governance → battle_test import dependency."""
+
+    @property
+    def remaining(self) -> float: ...
+
+
+# ---------------------------------------------------------------------------
+# Structured refusal exception (orchestrator-introspectable)
+# ---------------------------------------------------------------------------
+
+
+class SessionBudgetPreflightRefused(Exception):
+    """Raised by provider preflight when the estimated/authorized
+    cost of a pending call exceeds remaining session budget.
+
+    Carries structured fields so the orchestrator's cascade machinery
+    can distinguish a hard-wallet refusal from a model/transport
+    failure:
+
+      * ``provider`` — short provider name (``"claude"`` / ``"doubleword"``)
+      * ``estimated_cost_usd`` — the upper bound used by preflight
+        (typically the caller's ``_max_cost_per_op``)
+      * ``session_remaining_usd`` — authoritative remaining budget
+        at the time of refusal
+      * ``reason`` — short opaque token (``"session_budget_preflight_refused"``
+        by default); orchestrator log filters / postmortem classifiers
+        match on this verbatim
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        estimated_cost_usd: float,
+        session_remaining_usd: float,
+        reason: str = "session_budget_preflight_refused",
+    ) -> None:
+        super().__init__(
+            f"{reason}: provider={provider} "
+            f"est=${float(estimated_cost_usd):.4f} > "
+            f"session_remaining=${float(session_remaining_usd):.4f}"
+        )
+        self.provider = str(provider)
+        self.estimated_cost_usd = float(estimated_cost_usd)
+        self.session_remaining_usd = float(session_remaining_usd)
+        self.reason = str(reason)
+
+
+# ---------------------------------------------------------------------------
+# Process-wide registration (mirrors cost_governor singleton pattern)
+# ---------------------------------------------------------------------------
+
+
+_default_provider: Optional[_SessionBudgetProvider] = None
+_lock = threading.Lock()
+
+
+def set_session_budget_provider(
+    provider: Optional[_SessionBudgetProvider],
+) -> None:
+    """Register the authoritative session-budget provider. Idempotent
+    and last-write-wins (matches ``cost_governor`` singleton pattern).
+    Passing ``None`` clears the registration (test helper / shutdown).
+
+    Called from the battle harness immediately after the harness's
+    ``CostTracker`` is constructed. Governance does NOT call this.
+
+    NEVER raises."""
+    global _default_provider
+    try:
+        with _lock:
+            _default_provider = provider
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug(
+            "[SBA] set_session_budget_provider degraded: %s", exc,
+        )
+
+
+def get_session_budget_provider() -> Optional[_SessionBudgetProvider]:
+    """Return the registered authoritative provider, or ``None`` when
+    no provider has been registered in this process. NEVER raises."""
+    try:
+        with _lock:
+            return _default_provider
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+
+
+def reset_for_tests() -> None:
+    """Test helper — drops the registered provider. NEVER raises."""
+    global _default_provider
+    try:
+        with _lock:
+            _default_provider = None
+    except Exception:  # noqa: BLE001 — defensive
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Authoritative remaining-budget read
+# ---------------------------------------------------------------------------
+
+
+def get_session_remaining_usd() -> Optional[float]:
+    """Authoritative source of remaining session budget USD.
+
+    Precedence (per design lock):
+
+      1. Registered provider's ``.remaining`` (e.g. battle harness's
+         ``CostTracker``).
+      2. ``JARVIS_S2_SESSION_BUDGET_USD`` (S2 wiring chain Tier 1).
+      3. ``OUROBOROS_BATTLE_COST_CAP`` (battle harness env).
+      4. ``None`` — no authority active; downstream preflight
+         fail-OPEN (preserves byte-identical pre-PR behavior in
+         environments without a session cap).
+
+    Returned value is non-negative. NEVER raises."""
+    try:
+        provider = get_session_budget_provider()
+        if provider is not None:
+            try:
+                value = float(provider.remaining)
+                return max(0.0, value)
+            except Exception as exc:  # noqa: BLE001 — defensive
+                logger.debug(
+                    "[SBA] provider.remaining read fault: %s", exc,
+                )
+        # Env fallback (no registered provider — tests, CLI-less paths,
+        # operator-driven manual invocations).
+        for env_name in (_ENV_S2_SESSION_BUDGET, _ENV_BATTLE_COST_CAP):
+            try:
+                raw = os.environ.get(env_name, "").strip()
+            except Exception:  # noqa: BLE001
+                continue
+            if not raw:
+                continue
+            try:
+                return max(0.0, float(raw))
+            except (TypeError, ValueError):
+                continue
+        return None
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug(
+            "[SBA] get_session_remaining_usd fault: %s", exc,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Hard preflight gate (call BEFORE any provider dispatch)
+# ---------------------------------------------------------------------------
+
+
+def check_preflight(
+    *,
+    provider_name: str,
+    estimated_cost_usd: float,
+) -> None:
+    """Hard wallet gate. Call BEFORE provider dispatch.
+
+    Refuses (raises :class:`SessionBudgetPreflightRefused`) when the
+    remaining session budget cannot accommodate ``estimated_cost_usd``.
+    The caller's ``_max_cost_per_op`` is a reasonable conservative
+    upper bound when no finer estimate is available.
+
+    No-op when :func:`get_session_remaining_usd` returns ``None`` —
+    preserves byte-identical pre-PR behavior in environments without
+    an active session cap.
+
+    NEVER raises any exception class OTHER than
+    :class:`SessionBudgetPreflightRefused`."""
+    try:
+        remaining = get_session_remaining_usd()
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug("[SBA] preflight: remaining read fault: %s", exc)
+        return  # fail-OPEN on adapter fault
+    if remaining is None:
+        return  # no authority active
+    try:
+        est = float(max(0.0, estimated_cost_usd or 0.0))
+    except (TypeError, ValueError):
+        # Bad estimate input — fail-OPEN so a misformed caller doesn't
+        # block ops. The post-hoc CostTracker.budget_event remains the
+        # safety net.
+        logger.debug(
+            "[SBA] preflight: bad estimated_cost_usd %r — fail-open",
+            estimated_cost_usd,
+        )
+        return
+    if est > remaining:
+        logger.info(
+            "[SBA] preflight REFUSED: provider=%s est=$%.4f > "
+            "session_remaining=$%.4f",
+            provider_name, est, remaining,
+        )
+        raise SessionBudgetPreflightRefused(
+            provider=str(provider_name),
+            estimated_cost_usd=est,
+            session_remaining_usd=remaining,
+        )
+
+
+__all__ = [
+    "SESSION_BUDGET_AUTHORITY_SCHEMA_VERSION",
+    "SessionBudgetPreflightRefused",
+    "set_session_budget_provider",
+    "get_session_budget_provider",
+    "reset_for_tests",
+    "get_session_remaining_usd",
+    "check_preflight",
+]

--- a/tests/governance/test_session_budget_authority.py
+++ b/tests/governance/test_session_budget_authority.py
@@ -1,0 +1,590 @@
+"""Session-Budget Preflight Authority spine.
+
+Pins the load-bearing wallet gate added in response to the Step-1
+verification soak (2026-05-21 ``bt-2026-05-21-010600``) where a single
+Claude call consumed $0.1281 against a $0.10 session cap because
+CostGovernor's per-op cap derivation produced a $1.20 ceiling that
+exceeded the session budget.
+
+Covers:
+  * Adapter / protocol surface (set / get / reset / env fallback).
+  * Preflight gate semantics (refuse / pass / fail-OPEN when no
+    authority).
+  * Structured ``SessionBudgetPreflightRefused`` shape.
+  * CostGovernor session-aware clamp (fail-closed default).
+  * AST pin: no governance → battle_test import cycle.
+  * Harness registration is wired at construction.
+  * Claude and DW providers both fire preflight before dispatch.
+  * Master-OFF byte-identical behavior preserved.
+"""
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.session_budget_authority import (
+    SESSION_BUDGET_AUTHORITY_SCHEMA_VERSION,
+    SessionBudgetPreflightRefused,
+    check_preflight,
+    get_session_budget_provider,
+    get_session_remaining_usd,
+    reset_for_tests,
+    set_session_budget_provider,
+)
+
+
+@pytest.fixture(autouse=True)
+def _iso(monkeypatch):
+    """Strip every relevant env knob + clear singleton between tests."""
+    for k in (
+        "JARVIS_S2_SESSION_BUDGET_USD",
+        "OUROBOROS_BATTLE_COST_CAP",
+        "JARVIS_COST_GOVERNOR_SESSION_CLAMP_ENABLED",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+# ============================================================================
+# (1) Adapter / protocol — registration + env fallback
+# ============================================================================
+
+
+class _FakeProvider:
+    """Duck-typed satisfies the protocol via `.remaining`."""
+    def __init__(self, remaining: float):
+        self._r = float(remaining)
+
+    @property
+    def remaining(self) -> float:
+        return self._r
+
+    def set_remaining(self, v: float) -> None:
+        self._r = float(v)
+
+
+def test_get_remaining_no_provider_no_env_returns_none():
+    """Clean process default = None ⇒ preflight fail-OPEN
+    (preserves byte-identical pre-PR behavior)."""
+    assert get_session_budget_provider() is None
+    assert get_session_remaining_usd() is None
+
+
+def test_get_remaining_with_registered_provider():
+    p = _FakeProvider(0.42)
+    set_session_budget_provider(p)
+    assert get_session_budget_provider() is p
+    assert get_session_remaining_usd() == pytest.approx(0.42)
+
+
+def test_get_remaining_env_fallback_s2_budget(monkeypatch):
+    """Tier 1: JARVIS_S2_SESSION_BUDGET_USD."""
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "0.30")
+    assert get_session_remaining_usd() == pytest.approx(0.30)
+
+
+def test_get_remaining_env_fallback_battle_cost_cap(monkeypatch):
+    """Tier 2: OUROBOROS_BATTLE_COST_CAP (when Tier 1 absent)."""
+    monkeypatch.setenv("OUROBOROS_BATTLE_COST_CAP", "0.50")
+    assert get_session_remaining_usd() == pytest.approx(0.50)
+
+
+def test_get_remaining_provider_overrides_env(monkeypatch):
+    """Registered provider beats env (operator-defined precedence)."""
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "0.99")
+    monkeypatch.setenv("OUROBOROS_BATTLE_COST_CAP", "0.88")
+    set_session_budget_provider(_FakeProvider(0.10))
+    assert get_session_remaining_usd() == pytest.approx(0.10)
+
+
+def test_get_remaining_provider_raises_falls_back_to_env(
+    monkeypatch,
+):
+    """If provider.remaining raises, fall through to env fallback —
+    fail-safe."""
+
+    class _Raises:
+        @property
+        def remaining(self) -> float:
+            raise RuntimeError("synthetic")
+
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "0.25")
+    set_session_budget_provider(_Raises())
+    # Falls through env-fallback chain after provider read fails
+    assert get_session_remaining_usd() == pytest.approx(0.25)
+
+
+def test_get_remaining_provider_negative_clamped_to_zero():
+    """Negative remaining clamped to 0 (no underflow into preflight)."""
+    set_session_budget_provider(_FakeProvider(-1.0))
+    assert get_session_remaining_usd() == 0.0
+
+
+def test_get_remaining_garbage_env_falls_through(monkeypatch):
+    """Garbage in Tier 1 falls through to Tier 2; garbage in both ⇒ None."""
+    monkeypatch.setenv("JARVIS_S2_SESSION_BUDGET_USD", "not-a-number")
+    monkeypatch.setenv("OUROBOROS_BATTLE_COST_CAP", "0.40")
+    assert get_session_remaining_usd() == pytest.approx(0.40)
+    monkeypatch.setenv("OUROBOROS_BATTLE_COST_CAP", "junk")
+    assert get_session_remaining_usd() is None
+
+
+# ============================================================================
+# (2) Preflight gate semantics
+# ============================================================================
+
+
+def test_check_preflight_no_authority_is_noop():
+    """No registered provider AND no env ⇒ no-op (fail-OPEN).
+    Preserves byte-identical pre-PR behavior in environments without
+    a session cap."""
+    # Must not raise
+    check_preflight(provider_name="claude", estimated_cost_usd=999.0)
+
+
+def test_check_preflight_under_budget_passes():
+    set_session_budget_provider(_FakeProvider(0.20))
+    check_preflight(provider_name="claude", estimated_cost_usd=0.05)
+    # No raise — passes
+
+
+def test_check_preflight_over_budget_raises_structured():
+    set_session_budget_provider(_FakeProvider(0.10))
+    with pytest.raises(SessionBudgetPreflightRefused) as excinfo:
+        check_preflight(
+            provider_name="claude", estimated_cost_usd=0.50,
+        )
+    exc = excinfo.value
+    assert exc.provider == "claude"
+    assert exc.estimated_cost_usd == pytest.approx(0.50)
+    assert exc.session_remaining_usd == pytest.approx(0.10)
+    assert exc.reason == "session_budget_preflight_refused"
+
+
+def test_check_preflight_equal_estimate_passes():
+    """Boundary: est == remaining ⇒ pass (strict >). Allows the last
+    op to fit at the line if no overage is expected."""
+    set_session_budget_provider(_FakeProvider(0.10))
+    check_preflight(provider_name="dw", estimated_cost_usd=0.10)
+    # No raise
+
+
+def test_check_preflight_bad_estimate_fails_open():
+    """A misformed estimate (NaN-like / non-numeric) should fail-OPEN —
+    don't block ops over a caller bug. Post-hoc CostTracker.budget_event
+    remains the safety net."""
+    set_session_budget_provider(_FakeProvider(0.10))
+    # Strings / None: bad input
+    check_preflight(
+        provider_name="claude", estimated_cost_usd=float("nan"),
+    )
+    # No raise — fail-open
+
+
+# ============================================================================
+# (3) SessionBudgetPreflightRefused exception shape
+# ============================================================================
+
+
+def test_refused_exception_default_reason():
+    exc = SessionBudgetPreflightRefused(
+        provider="dw",
+        estimated_cost_usd=0.50,
+        session_remaining_usd=0.10,
+    )
+    assert exc.reason == "session_budget_preflight_refused"
+    assert exc.provider == "dw"
+    assert exc.estimated_cost_usd == 0.50
+    assert exc.session_remaining_usd == 0.10
+    assert "session_budget_preflight_refused" in str(exc)
+    assert "$0.5000" in str(exc)
+
+
+def test_refused_exception_custom_reason():
+    exc = SessionBudgetPreflightRefused(
+        provider="claude",
+        estimated_cost_usd=1.0,
+        session_remaining_usd=0.10,
+        reason="custom_refusal_token",
+    )
+    assert exc.reason == "custom_refusal_token"
+    assert "custom_refusal_token" in str(exc)
+
+
+# ============================================================================
+# (4) CostGovernor session-aware clamp
+# ============================================================================
+
+
+def test_cost_governor_clamp_to_session_remaining(monkeypatch):
+    """Per-op cap derived by CostGovernor MUST be clamped down to
+    session_remaining when authority is active. This is the load-
+    bearing fix for the $0.10 → $0.1281 overage."""
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor, CostGovernorConfig,
+    )
+    # Register tight $0.10 session authority
+    set_session_budget_provider(_FakeProvider(0.10))
+    cfg = CostGovernorConfig()  # defaults
+    g = CostGovernor(cfg)
+    # Same conditions as bt-2026-05-21-010600: route=immediate
+    # complexity=simple → baseline 0.10 × 5.00 × 0.80 × 3.00 = $1.20
+    # Without clamp: cap should be $1.20.
+    # With clamp: cap must be <= $0.10 (clamped to session_remaining)
+    cap, _r, _c = g._derive_cap(
+        route="immediate",
+        complexity="simple",
+        is_read_only=False,
+        parallel_factor=1.0,
+    )
+    assert cap <= 0.10 + 1e-9, (
+        f"Clamp failed: cap={cap} exceeds session_remaining=0.10. "
+        f"The $0.1281 overage WOULD recur."
+    )
+
+
+def test_cost_governor_clamp_disabled_via_env(monkeypatch):
+    """Operator emergency override: =false ⇒ legacy unclamped behavior."""
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor, CostGovernorConfig,
+    )
+    monkeypatch.setenv(
+        "JARVIS_COST_GOVERNOR_SESSION_CLAMP_ENABLED", "false",
+    )
+    set_session_budget_provider(_FakeProvider(0.10))
+    cfg = CostGovernorConfig()
+    g = CostGovernor(cfg)
+    cap, _, _ = g._derive_cap(
+        route="immediate", complexity="simple",
+        is_read_only=False, parallel_factor=1.0,
+    )
+    # With clamp disabled, cap reverts to derived multipliers:
+    # 0.10 × 5.0 × 0.8 × 3.0 = 1.20 (clamped only to cfg.max_cap_usd)
+    assert cap > 0.5, (
+        f"Disabled clamp should NOT cap to session_remaining; cap={cap}"
+    )
+
+
+def test_cost_governor_clamp_master_default_true():
+    """Verify default fail-closed (master ON unless operator opts out)."""
+    from backend.core.ouroboros.governance.cost_governor import (
+        _session_clamp_enabled,
+    )
+    assert _session_clamp_enabled() is True
+
+
+def test_cost_governor_clamp_no_authority_no_change(monkeypatch):
+    """When NO session authority is active AND clamp ON, behavior
+    is unchanged (preserves byte-identical pre-PR behavior)."""
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor, CostGovernorConfig,
+    )
+    # No provider registered, no env knobs
+    cfg = CostGovernorConfig()
+    g = CostGovernor(cfg)
+    cap_with, _, _ = g._derive_cap(
+        route="standard", complexity="moderate",
+        is_read_only=False, parallel_factor=1.0,
+    )
+    monkeypatch.setenv(
+        "JARVIS_COST_GOVERNOR_SESSION_CLAMP_ENABLED", "false",
+    )
+    cap_without, _, _ = g._derive_cap(
+        route="standard", complexity="moderate",
+        is_read_only=False, parallel_factor=1.0,
+    )
+    assert cap_with == cap_without
+
+
+def test_cost_governor_clamp_respects_min_cap_floor():
+    """Even under tight session pressure, cap must not fall below
+    cfg.min_cap_usd (operational floor — going lower starves ops)."""
+    from backend.core.ouroboros.governance.cost_governor import (
+        CostGovernor, CostGovernorConfig,
+    )
+    # Session remaining well below min_cap_usd
+    set_session_budget_provider(_FakeProvider(0.001))
+    cfg = CostGovernorConfig()
+    g = CostGovernor(cfg)
+    cap, _, _ = g._derive_cap(
+        route="standard", complexity="light",
+        is_read_only=False, parallel_factor=1.0,
+    )
+    assert cap >= cfg.min_cap_usd, (
+        f"Cap {cap} fell below cfg.min_cap_usd={cfg.min_cap_usd}"
+    )
+
+
+# ============================================================================
+# (5) AST pins — composition discipline
+# ============================================================================
+
+
+_SBA_PATH = Path(
+    "backend/core/ouroboros/governance/session_budget_authority.py"
+)
+_CG_PATH = Path(
+    "backend/core/ouroboros/governance/cost_governor.py"
+)
+_PROVIDERS_PATH = Path(
+    "backend/core/ouroboros/governance/providers.py"
+)
+_DW_PATH = Path(
+    "backend/core/ouroboros/governance/doubleword_provider.py"
+)
+_HARNESS_PATH = Path(
+    "backend/core/ouroboros/battle_test/harness.py"
+)
+_COST_TRACKER_PATH = Path(
+    "backend/core/ouroboros/battle_test/cost_tracker.py"
+)
+
+
+def test_ast_pin_no_battle_test_import_in_session_budget_authority():
+    """The new module must NOT import from battle_test (would create
+    a governance → battle_test cycle)."""
+    src = _SBA_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert "battle_test" not in alias.name, (
+                    f"session_budget_authority must not import battle_test "
+                    f"(found: {alias.name})"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            assert "battle_test" not in mod, (
+                f"session_budget_authority must not import from "
+                f"battle_test (found: {mod})"
+            )
+
+
+def test_ast_pin_cost_tracker_does_not_depend_on_session_budget_authority():
+    """The DIRECTION of the dependency must be harness → governance,
+    not cost_tracker ↔ governance. cost_tracker.py itself stays free
+    of session_budget_authority references — only the harness wires
+    them together."""
+    src = _COST_TRACKER_PATH.read_text(encoding="utf-8")
+    assert "session_budget_authority" not in src, (
+        "cost_tracker.py must not import session_budget_authority; "
+        "the harness wires them together"
+    )
+
+
+def test_ast_pin_harness_registers_cost_tracker_at_init():
+    """harness.py must call set_session_budget_provider(self._cost_tracker)
+    AFTER constructing self._cost_tracker."""
+    src = _HARNESS_PATH.read_text(encoding="utf-8")
+    # The init sequence is on linear order: assignment first, then
+    # registration. Confirm via substring + ordering.
+    assign_idx = src.find("self._cost_tracker = CostTracker(")
+    reg_idx = src.find("set_session_budget_provider(self._cost_tracker)")
+    assert assign_idx > 0, "harness assignment to self._cost_tracker missing"
+    assert reg_idx > assign_idx, (
+        "set_session_budget_provider must appear AFTER the CostTracker "
+        "assignment in harness.__init__"
+    )
+
+
+def test_ast_pin_cost_governor_imports_session_budget_authority():
+    """CostGovernor's clamp logic must compose session_budget_authority,
+    not re-implement remaining-budget reads."""
+    src = _CG_PATH.read_text(encoding="utf-8")
+    assert "session_budget_authority" in src
+    assert "get_session_remaining_usd" in src
+
+
+def test_ast_pin_claude_provider_calls_preflight():
+    """ClaudeProvider.generate() body must invoke check_preflight
+    BEFORE any provider dispatch / client construction."""
+    src = _PROVIDERS_PATH.read_text(encoding="utf-8")
+    assert "session_budget_authority" in src
+    # The preflight call site must precede the first
+    # _ensure_client / messages.* invocation.
+    pre_idx = src.find("check_preflight")
+    ensure_idx = src.find("client = self._ensure_client()")
+    assert pre_idx > 0 and ensure_idx > 0
+    assert pre_idx < ensure_idx, (
+        "Claude preflight call must precede _ensure_client invocation"
+    )
+
+
+def test_ast_pin_dw_provider_extends_check_budget():
+    """DW _check_budget body must invoke session_budget_authority
+    after the daily budget check."""
+    src = _DW_PATH.read_text(encoding="utf-8")
+    # Find _check_budget block
+    cb_idx = src.find("def _check_budget(self)")
+    assert cb_idx > 0
+    next_def = src.find("def _record_cost", cb_idx)
+    body = src[cb_idx:next_def]
+    assert "session_budget_authority" in body, (
+        "DW _check_budget body must call session_budget_authority"
+    )
+    assert "check_preflight" in body
+    # And the structural ordering: daily check first, preflight second
+    daily_idx = body.find("doubleword_budget_exhausted")
+    pre_idx = body.find("check_preflight")
+    assert 0 < daily_idx < pre_idx, (
+        "Daily-budget check must precede preflight call in _check_budget"
+    )
+
+
+def test_ast_pin_no_parallel_cost_ledger_in_session_budget_authority():
+    """The new module must NOT define its own cost/budget ledger class
+    — it only adapts existing surfaces."""
+    src = _SBA_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            assert node.name not in (
+                "CostTracker", "CostGovernor", "_CostLedger",
+                "BudgetLedger", "SessionLedger",
+            ), (
+                f"session_budget_authority must not define parallel "
+                f"ledger class {node.name!r}"
+            )
+
+
+def test_schema_version_pinned():
+    assert SESSION_BUDGET_AUTHORITY_SCHEMA_VERSION == (
+        "session_budget_authority.v1"
+    )
+
+
+# ============================================================================
+# (6) Provider-side preflight integration (mock at preflight seam)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_claude_preflight_refuses_before_client_construction(
+    tmp_path,
+):
+    """Load-bearing: $0.10 remaining + Claude max_cost_per_op=$0.50
+    → SessionBudgetPreflightRefused BEFORE _ensure_client is called."""
+    from backend.core.ouroboros.governance.providers import (
+        ClaudeProvider,
+    )
+    from backend.core.ouroboros.governance.op_context import (
+        OperationContext,
+    )
+    import dataclasses
+    from datetime import datetime, timedelta, timezone
+
+    provider = ClaudeProvider(
+        api_key="test-key",
+        repo_root=tmp_path,
+        max_cost_per_op=0.50,
+        daily_budget=10.0,
+    )
+    # Spy on _ensure_client — it should NEVER be called
+    ensure_calls: list = []
+    real_ensure = provider._ensure_client
+
+    def _spy_ensure():
+        ensure_calls.append(1)
+        return real_ensure()
+    provider._ensure_client = _spy_ensure  # type: ignore[assignment]
+
+    set_session_budget_provider(_FakeProvider(0.10))
+
+    ctx = OperationContext.create(
+        target_files=("x.py",),
+        description="preflight test",
+        op_id="op-preflight-refuse",
+    )
+    ctx = dataclasses.replace(ctx, provider_route="ide")
+    deadline = datetime.now(tz=timezone.utc) + timedelta(seconds=60)
+
+    with pytest.raises(SessionBudgetPreflightRefused) as excinfo:
+        await provider.generate(ctx, deadline)
+    assert excinfo.value.provider == "claude"
+    assert excinfo.value.session_remaining_usd == pytest.approx(0.10)
+    assert ensure_calls == [], (
+        "_ensure_client must NOT be called when preflight refuses; "
+        f"saw {len(ensure_calls)} call(s)"
+    )
+
+
+def test_dw_check_budget_raises_session_refused_when_authority_tight(
+    tmp_path,
+):
+    """DW _check_budget must raise SessionBudgetPreflightRefused
+    (NOT DoublewordInfraError) when session authority refuses."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordProvider,
+    )
+
+    provider = DoublewordProvider(
+        api_key="test-dw-key",
+        repo_root=tmp_path,
+        max_cost_per_op=0.50,
+        daily_budget=10.0,
+    )
+    set_session_budget_provider(_FakeProvider(0.10))
+
+    with pytest.raises(SessionBudgetPreflightRefused) as excinfo:
+        provider._check_budget()
+    assert excinfo.value.provider == "doubleword"
+    assert excinfo.value.session_remaining_usd == pytest.approx(0.10)
+
+
+def test_dw_check_budget_unchanged_when_no_authority(tmp_path):
+    """No session authority registered AND no env ⇒ DW _check_budget
+    behaves byte-identically to pre-PR (only daily check fires)."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordProvider,
+    )
+
+    provider = DoublewordProvider(
+        api_key="test-dw-key",
+        repo_root=tmp_path,
+        max_cost_per_op=0.50,
+        daily_budget=10.0,
+    )
+    # No provider registered, no env
+    # _check_budget should pass cleanly (daily_spend=0 < daily_budget=10)
+    provider._check_budget()
+    # No raise
+
+
+def test_dw_complete_sync_inherits_preflight_via_check_budget(tmp_path):
+    """The DW heavy lane composes complete_sync() which calls
+    _check_budget at line 2529 — verify the preflight propagates
+    through that composition."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordProvider,
+    )
+
+    provider = DoublewordProvider(
+        api_key="test-dw-key",
+        repo_root=tmp_path,
+        max_cost_per_op=0.50,
+        daily_budget=10.0,
+    )
+    set_session_budget_provider(_FakeProvider(0.10))
+
+    # Spy on _get_session — must not be called if preflight refuses
+    session_calls: list = []
+    provider._get_session = AsyncMock(  # type: ignore[assignment]
+        side_effect=lambda *a, **kw: session_calls.append(1),
+    )
+
+    import asyncio
+    with pytest.raises(SessionBudgetPreflightRefused):
+        asyncio.run(provider.complete_sync(
+            prompt="x", system_prompt="y", caller_id="test_caller",
+            timeout_s=10.0,
+        ))
+    assert session_calls == [], (
+        "complete_sync must refuse via _check_budget BEFORE opening a session"
+    )


### PR DESCRIPTION
## Session-Budget Preflight Authority — hard wallet gate before provider dispatch

Closes the load-bearing gap surfaced by the 2026-05-21 Step-1 verification soak (`bt-2026-05-21-010600`): a single Claude call consumed **$0.1281 against a $0.10 session cap (28% overage)** because `CostGovernor._derive_cap` permitted a per-op cap of $1.20 (baseline × route_factor=5 × complexity × headroom=3) and `CostTracker.record()` fires `budget_event` *after* the spend lands.

This PR adds a hard pre-call session-budget authority. Composes existing `CostTracker` and `CostGovernor` surfaces via an adapter (duck-typed protocol). **No parallel cost ledger. No hardcoded prices. No governance → battle_test import.**

### Architecture

```
                  ┌────────────────────────────────────────────┐
                  │  governance/session_budget_authority.py    │
                  │  (NEW — duck-typed Protocol + singleton)   │
                  │                                            │
                  │  precedence: registered provider           │
                  │       → JARVIS_S2_SESSION_BUDGET_USD       │
                  │       → OUROBOROS_BATTLE_COST_CAP          │
                  │       → None (fail-OPEN)                   │
                  └──┬──────────────┬───────────────┬─────────┘
                     │ register     │ read           │ read
              ┌──────┴───┐   ┌──────┴──────┐  ┌─────┴───────────┐
              │ harness  │   │ providers/  │  │ governance/     │
              │ (3 lines)│   │ Claude + DW │  │ cost_governor.py│
              │          │   │ preflight   │  │ _derive_cap     │
              │          │   │ before any  │  │ clamps to       │
              │          │   │ dispatch    │  │ session_remain  │
              └──────────┘   └─────────────┘  └─────────────────┘
```

`harness.py` is the **only** site that imports from `governance/session_budget_authority`. Governance never imports `battle_test`. **No cycle.**

### Key behaviors

| Behavior | Verdict |
|---|---|
| `bt-2026-05-21-010600` reproduction ($0.10 cap, route=immediate) | per-op cap now clamped to ≤ $0.10 (was $1.20) — overage **impossible** |
| Outside the harness, no env, no provider registered | preflight is no-op → **byte-identical pre-PR behavior** |
| `JARVIS_COST_GOVERNOR_SESSION_CLAMP_ENABLED=false` | legacy unclamped derivation restored (operator emergency override) |
| Claude `generate()` with insufficient remaining | raises `SessionBudgetPreflightRefused` **before** `_ensure_client()` |
| DW heavy non-streaming lane (composes `complete_sync` → `_check_budget`) | inherits gate transparently |
| S2 advisory role | unchanged — S2 still nudges `sensor_governor`; this PR owns hard spend authority |

### 5 dormant-by-default invariants (live-probed pre-commit)

```
S2 master:                          False
PRC master:                          False
PRC shadow:                          False
DW heavy lane master:                False
Session-budget provider registered:  False (no harness running)
CostGovernor session clamp:          True  (default-TRUE — fail-closed per operator)
```

### Diffstat — 6 files, +987 / −1

```
backend/core/ouroboros/governance/session_budget_authority.py   | +274 (NEW)
backend/core/ouroboros/governance/cost_governor.py              |  +56
backend/core/ouroboros/governance/providers.py                  |  +27
backend/core/ouroboros/governance/doubleword_provider.py        |  +25 / -1
backend/core/ouroboros/battle_test/harness.py                   |  +16
tests/governance/test_session_budget_authority.py               | +590 (NEW)
6 files changed, 987 insertions(+), 1 deletion(-)
```

### Test counts — 32 NEW + 339 total

| Suite | Count | Status |
|---|---|---|
| **NEW** `test_session_budget_authority.py` | **32** | ✅ 1.11s |
| S1 substrate + wiring + shadow | 54 | ✅ |
| S2 substrate + wiring | 66 | ✅ |
| DW heavy lane | 28 | ✅ |
| CompactionCaller (byte-identical proof) | 17 | ✅ |
| Sensor governor regression | 107 | ✅ |
| Phase-1 baseline (claude generate_raw) | 33 + 2 xfail | ✅ (same xfails preserved) |
| **Total governance** | **339 + 2 xfail** | ✅ |

### Architectural fix verified at the source

`test_cost_governor_clamp_to_session_remaining` reproduces the exact soak conditions (route=immediate, complexity=simple, $0.10 session remaining) and verifies the per-op cap is clamped to ≤ $0.10. **The $0.10 → $0.1281 overage would not recur.**

### Out of scope (verbatim from operator)

- ❌ No provider spend
- ❌ No default flips (S1 / S2 / shadow / DW-heavy-lane all stay FALSE)
- ❌ No SWE-Bench-Pro run, no Bar A/B, no Shadow soak
- ❌ No tuning multipliers to hide the issue (closed at the source)
- ❌ No weakening of IMMEDIATE semantics — IMMEDIATE ops still high-urgency, just must respect hard wallet authority
- ❌ No OCA / git-index / sovereignty / cursor-agent-ban changes
- ❌ No parallel cost ledger
- ❌ No hardcoded model prices
- ❌ No edits to `cost_tracker.py` / `s2_predictive_budget.py` / `admission_estimator.py` / `sensor_governor.py` / `candidate_generator.py` / `admission_gate.py` / `provider_response_cache.py` / shadow / `brain_selection_policy.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pre-call session-budget gate that refuses provider calls exceeding the remaining session cap and clamps per-op caps to the session remainder, preventing the $0.10 → $0.1281 overage seen in bt-2026-05-21-010600. Calls with insufficient budget fail before any client is created; behavior is unchanged when no session cap is active.

- **New Features**
  - New `governance/session_budget_authority.py`: duck-typed provider registration (`.remaining`), env fallback (`JARVIS_S2_SESSION_BUDGET_USD` → `OUROBOROS_BATTLE_COST_CAP`), `check_preflight`, and `SessionBudgetPreflightRefused`.
  - Harness registers `CostTracker` via `set_session_budget_provider` (no governance → battle_test import).
  - Claude `generate()` and DW `_check_budget` call `check_preflight` before any network dispatch; DW heavy lane inherits via `complete_sync`.
  - `CostGovernor._derive_cap` clamps per-op cap to session remaining when `JARVIS_COST_GOVERNOR_SESSION_CLAMP_ENABLED` is true (default), honoring `min_cap_usd`.

- **Migration**
  - No action needed; when no session authority is present, behavior is unchanged.
  - To temporarily disable the clamp, set `JARVIS_COST_GOVERNOR_SESSION_CLAMP_ENABLED=false`.

<sup>Written for commit 59f0d5c8fa23b68f006c418747244532996e2cd2. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/47604?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

