### PR TITLE
feat(providers): dormant ClaudeDispatchState substrate — Slice 2A-ii (providers.py byte-identical)

### DIFF
--- a/backend/core/ouroboros/governance/claude_dispatch_state.py
+++ b/backend/core/ouroboros/governance/claude_dispatch_state.py
@@ -1,0 +1,268 @@
+"""Phase 2A-ii — dormant per-dispatch state substrate for the
+upcoming ClaudeProvider._generate_raw decomposition.
+
+This module introduces two pure-data primitives that will replace
+the closure's implicit state cells when Phase 2A-iii through 2C-ii
+land their per-helper extractions:
+
+  * :class:`_ClaudeDispatchState` — the 8-field mutable record
+    that, in the refactored code path, carries the per-dispatch
+    state currently held in the closure's 5 nonlocals
+    (``raw_content`` / ``input_tokens`` / ``output_tokens`` /
+    ``_cached_input``) plus 4 of the 5 outer ``generate()``-scope
+    captures (``_first_token_ms`` / ``_last_msg`` /
+    ``_thinking_reason_out`` / ``_token_usage``).
+
+    Reset semantic: every ``_dispatch_raw`` invocation gets a fresh
+    instance (today this is implicit via closure-cell re-allocation;
+    the refactor makes it explicit via construction).
+
+  * :class:`_CumulativeCost` — a small accumulator that carries the
+    fifth nonlocal (``total_cost``). Unlike the other state, this
+    one survives multiple ``_dispatch_raw`` calls within a single
+    ``generate()`` (e.g. the ``tool_loop.run`` multi-round path).
+    The refactor models this by constructing one instance per
+    ``generate()`` call and threading it explicitly into each
+    dispatch.
+
+DORMANCY INVARIANT — Slice 2A-ii ships this module **completely
+unused** by ``providers.py``. AST pin
+:func:`test_ast_pin_providers_does_not_import_dispatch_state_yet`
+enforces that ``providers.py`` is byte-identical to main: the
+substrate exists, the green-bar test surface for it exists, but
+no caller imports it yet. Phase 2A-iii (extracting
+``_boundary_audit_sampler`` as the proof-of-concept first
+extraction) is the first PR allowed to flip that pin.
+
+Architectural invariants (AST-pinned):
+
+  * No import of ``providers.py``, the orchestrator, the iron gate,
+    the candidate generator, or any authority surface. This module
+    is pure data, no dependency cycles, no behavior.
+
+  * No import of any newly-deployed surface
+    (evaluator_trace_observer, session_budget_authority,
+    provider_response_cache, s2_predictive_budget, swe_bench_pro/*,
+    commit_authority).
+
+  * Closed 8-field shape on the dataclass; closed 3-method interface
+    on the cost accumulator. Adding a field requires bumping
+    :data:`CLAUDE_DISPATCH_STATE_SCHEMA_VERSION` and a paired AST
+    pin update.
+
+  * Mutable dataclass (NOT frozen) — the refactor mutates these in
+    place across the helper extractions, mirroring exactly what the
+    closure's nonlocals do today. ``to_dict()`` / ``from_dict()``
+    provide debug snapshots without compromising mutability.
+
+  * ``_CumulativeCost.add(...)`` clamps non-positive inputs to a
+    no-op. This matches the closure's defensive accounting (a
+    negative cost is the SDK reporting unusable usage; the closure
+    today doesn't subtract from ``total_cost``).
+"""
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional
+
+
+CLAUDE_DISPATCH_STATE_SCHEMA_VERSION: str = (
+    "claude_dispatch_state.v1"
+)
+
+
+# Closed field set for the dispatch state — adding requires schema
+# bump + paired AST pin update.
+_CLAUDE_DISPATCH_STATE_FIELD_NAMES: tuple = (
+    "raw_content",
+    "input_tokens",
+    "output_tokens",
+    "cached_input",
+    "first_token_ms",
+    "last_msg",
+    "thinking_reason_out",
+    "token_usage",
+)
+
+
+@dataclass
+class _ClaudeDispatchState:
+    """Per-dispatch mutable state for ClaudeProvider._generate_raw.
+
+    Replaces (when the extraction lands) the 5 closure nonlocals
+    + 4 of the 5 outer-``generate()`` captures with explicit
+    fields. The fifth outer capture (``total_cost``) is carried
+    separately by :class:`_CumulativeCost` because its lifetime
+    spans multiple dispatches.
+
+    Mutable by design — the refactored helper methods will mutate
+    fields in place exactly as the current nested closures mutate
+    their nonlocals. Tests rely on the mutability to characterize
+    per-helper state transitions.
+
+    Field semantics (one-to-one with the closure's current cells):
+
+      * ``raw_content`` — accumulated text content across stream
+        deltas or the final non-streaming message body.
+      * ``input_tokens`` — Claude server-side tokenizer input count
+        (from ``message.usage.input_tokens``).
+      * ``output_tokens`` — Claude server-side tokenizer output
+        count (from ``message_delta.usage.output_tokens``).
+      * ``cached_input`` — cache-read input tokens
+        (``message.usage.cache_read_input_tokens``).
+      * ``first_token_ms`` — monotonic ms timestamp of the first
+        text-delta event (None until first delta lands).
+      * ``last_msg`` — the final ``Message`` object (or its
+        equivalent on the create path) returned by the SDK.
+      * ``thinking_reason_out`` — extracted reason text from
+        thinking blocks (None when thinking is disabled).
+      * ``token_usage`` — open dict of additional per-dispatch
+        token telemetry the closure's outer scope reads after
+        return (kept as a dict to mirror the closure's open
+        shape; the refactor may close this in a later phase).
+    """
+
+    raw_content: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_input: int = 0
+    first_token_ms: Optional[float] = None
+    last_msg: Optional[Any] = None
+    thinking_reason_out: Optional[str] = None
+    token_usage: Dict[str, int] = field(default_factory=dict)
+
+    def reset_for_next_dispatch(self) -> None:
+        """Restore every field to its default. Mirrors what the
+        closure achieves implicitly today via closure-cell
+        re-allocation on each ``_dispatch_raw`` invocation.
+
+        Used by call sites that want to reuse a state instance
+        across two dispatches without re-allocating; the canonical
+        path is to construct a fresh state. NEVER raises."""
+        self.raw_content = ""
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.cached_input = 0
+        self.first_token_ms = None
+        self.last_msg = None
+        self.thinking_reason_out = None
+        self.token_usage = {}
+
+    def to_dict(self) -> Mapping[str, Any]:
+        """Snapshot the current state as a plain-dict for logging /
+        debugging / SSE pretty-print. ``last_msg`` is coerced to a
+        repr-string when present (the raw Message object is not
+        JSON-friendly). NEVER raises."""
+        try:
+            last_msg_repr = (
+                repr(self.last_msg) if self.last_msg is not None else None
+            )
+        except Exception:  # noqa: BLE001 — defensive
+            last_msg_repr = "<unrenderable>"
+        return {
+            "schema_version": CLAUDE_DISPATCH_STATE_SCHEMA_VERSION,
+            "raw_content_len": len(self.raw_content),
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cached_input": self.cached_input,
+            "first_token_ms": self.first_token_ms,
+            "last_msg_repr": last_msg_repr,
+            "thinking_reason_out": self.thinking_reason_out,
+            "token_usage": dict(self.token_usage),
+        }
+
+    @classmethod
+    def from_dict(
+        cls, payload: Mapping[str, Any],
+    ) -> "_ClaudeDispatchState":
+        """Reconstruct from a ``to_dict()`` snapshot. Note: the
+        round-trip is LOSSY on two fields:
+
+          * ``raw_content`` cannot be recovered from
+            ``raw_content_len``; it is restored to ``""``.
+          * ``last_msg`` cannot be recovered from its repr;
+            it is restored to ``None``.
+
+        Other fields round-trip exactly. The asymmetry is
+        intentional — :meth:`to_dict` is a debug snapshot, not a
+        persistence format. NEVER raises."""
+        try:
+            return cls(
+                raw_content="",  # lossy; see docstring
+                input_tokens=int(payload.get("input_tokens", 0) or 0),
+                output_tokens=int(payload.get("output_tokens", 0) or 0),
+                cached_input=int(payload.get("cached_input", 0) or 0),
+                first_token_ms=(
+                    float(payload["first_token_ms"])
+                    if payload.get("first_token_ms") is not None else None
+                ),
+                last_msg=None,  # lossy; see docstring
+                thinking_reason_out=(
+                    str(payload["thinking_reason_out"])
+                    if payload.get("thinking_reason_out") is not None
+                    else None
+                ),
+                token_usage=dict(payload.get("token_usage") or {}),
+            )
+        except (TypeError, ValueError, KeyError):
+            return cls()
+
+
+class _CumulativeCost:
+    """Per-``generate()`` cumulative cost accumulator.
+
+    Replaces (when the extraction lands) the ``total_cost``
+    nonlocal in the closure. One instance per ``generate()`` call;
+    survives multiple ``_dispatch_raw`` invocations within that
+    call (the ``tool_loop.run`` multi-round path); discarded when
+    ``generate()`` returns.
+
+    Thread-safety: this primitive uses an internal lock because
+    the refactored helper methods will be class methods that can
+    in principle be called concurrently in tests or future
+    parallel-fanout paths. The closure today is single-threaded
+    async (no lock needed); we add the lock as cheap insurance
+    for the refactor's wider call surface — the per-add overhead
+    is sub-microsecond. NEVER raises."""
+
+    def __init__(self) -> None:
+        self._total: float = 0.0
+        self._lock: threading.Lock = threading.Lock()
+
+    @property
+    def total(self) -> float:
+        """Current cumulative total. Race-tolerant read (no lock —
+        a stale snapshot is acceptable for telemetry; the lock is
+        held only by :meth:`add`)."""
+        return self._total
+
+    def add(self, cost: float) -> None:
+        """Add ``cost`` to the cumulative total. Non-positive
+        inputs (zero or negative) are silently dropped — matches
+        the closure's defensive accounting where a negative
+        SDK-reported cost cannot subtract from
+        ``provider._daily_spend``. NEVER raises."""
+        try:
+            value = float(cost)
+        except (TypeError, ValueError):
+            return  # defensive; ignore non-numeric input
+        if value <= 0.0:
+            return
+        with self._lock:
+            self._total += value
+
+    def reset(self) -> None:
+        """Zero the accumulator. Used between ``generate()`` calls
+        in test paths that reuse one accumulator across multiple
+        characterization runs. NEVER raises."""
+        with self._lock:
+            self._total = 0.0
+
+
+__all__ = [
+    "CLAUDE_DISPATCH_STATE_SCHEMA_VERSION",
+    "_CLAUDE_DISPATCH_STATE_FIELD_NAMES",
+    "_ClaudeDispatchState",
+    "_CumulativeCost",
+]

--- a/tests/test_ouroboros_governance/test_claude_dispatch_state.py
+++ b/tests/test_ouroboros_governance/test_claude_dispatch_state.py
@@ -1,0 +1,561 @@
+"""Slice 2A-ii — dormant substrate spine for ``claude_dispatch_state``.
+
+Verifies:
+
+  * Closed 8-field shape on :class:`_ClaudeDispatchState` (AST + runtime).
+  * Closed 3-method interface on :class:`_CumulativeCost` (add / total /
+    reset). ``add`` is positive-only; ``total`` is monotone after
+    multiple adds; ``reset`` zeroes.
+  * Per-dispatch reset semantics on :meth:`reset_for_next_dispatch`.
+  * Lossy round-trip on :meth:`to_dict` / :meth:`from_dict` (documented).
+  * **Dormancy invariant**: ``providers.py`` SHA at branch HEAD is
+    identical to main@72444cc031 ('a33f9fb6...'); the substrate exists
+    but no caller imports it yet.
+
+The 6 AST pins enforce the structural boundaries the Phase 2A-iii
+through 2C-ii extractions must respect.
+
+Hard guardrails (Slice 2A-ii):
+
+  * ``providers.py`` is READ-ONLY. AST pin
+    :func:`test_ast_pin_providers_does_not_import_dispatch_state_yet`
+    enforces dormancy.
+
+  * Zero touch of newly-deployed surfaces. AST pin
+    :func:`test_ast_pin_no_locked_surface_imports`.
+
+  * The dataclass is mutable (NOT frozen) — the refactor mutates
+    in place. AST pin
+    :func:`test_ast_pin_dispatch_state_is_not_frozen`.
+"""
+from __future__ import annotations
+
+import ast
+import dataclasses
+import hashlib
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from backend.core.ouroboros.governance.claude_dispatch_state import (
+    CLAUDE_DISPATCH_STATE_SCHEMA_VERSION,
+    _CLAUDE_DISPATCH_STATE_FIELD_NAMES,
+    _ClaudeDispatchState,
+    _CumulativeCost,
+)
+
+
+_THIS_FILE = Path(__file__)
+_MODULE_FILE = Path(
+    "backend/core/ouroboros/governance/claude_dispatch_state.py"
+)
+_PROVIDERS_FILE = Path(
+    "backend/core/ouroboros/governance/providers.py"
+)
+# Locked from the branch-creation audit; updates ONLY in the PR that
+# starts importing the substrate (Phase 2A-iii at the earliest).
+_PROVIDERS_SHA_AT_2A_II = (
+    "a33f9fb67fdcf8e10f8e47fbd3a6b8075aea8a7d"
+)
+
+
+# ============================================================================
+# Schema + field-name invariants
+# ============================================================================
+
+
+class TestSchemaAndFieldNames:
+
+    def test_schema_version_is_v1(self) -> None:
+        assert CLAUDE_DISPATCH_STATE_SCHEMA_VERSION == (
+            "claude_dispatch_state.v1"
+        )
+
+    def test_field_names_tuple_has_exactly_eight_entries(self) -> None:
+        assert isinstance(_CLAUDE_DISPATCH_STATE_FIELD_NAMES, tuple)
+        assert len(_CLAUDE_DISPATCH_STATE_FIELD_NAMES) == 8
+
+    def test_field_names_exact_set(self) -> None:
+        assert set(_CLAUDE_DISPATCH_STATE_FIELD_NAMES) == {
+            "raw_content", "input_tokens", "output_tokens",
+            "cached_input", "first_token_ms", "last_msg",
+            "thinking_reason_out", "token_usage",
+        }
+
+    def test_dataclass_field_count_matches_declaration(self) -> None:
+        runtime_fields = dataclasses.fields(_ClaudeDispatchState)
+        assert len(runtime_fields) == 8
+
+    def test_dataclass_field_names_match_declaration(self) -> None:
+        runtime_names = {f.name for f in dataclasses.fields(_ClaudeDispatchState)}
+        assert runtime_names == set(_CLAUDE_DISPATCH_STATE_FIELD_NAMES)
+
+
+# ============================================================================
+# Dispatch-state defaults + mutability
+# ============================================================================
+
+
+class TestDispatchStateDefaultsAndMutability:
+
+    def test_default_construction_yields_documented_defaults(self) -> None:
+        s = _ClaudeDispatchState()
+        assert s.raw_content == ""
+        assert s.input_tokens == 0
+        assert s.output_tokens == 0
+        assert s.cached_input == 0
+        assert s.first_token_ms is None
+        assert s.last_msg is None
+        assert s.thinking_reason_out is None
+        assert s.token_usage == {}
+
+    def test_token_usage_default_is_independent_per_instance(self) -> None:
+        """Per the dataclass ``field(default_factory=dict)`` invariant —
+        two fresh instances MUST have independent dicts (no shared
+        mutable default)."""
+        s1 = _ClaudeDispatchState()
+        s2 = _ClaudeDispatchState()
+        s1.token_usage["mutated"] = 1
+        assert "mutated" not in s2.token_usage
+
+    def test_mutation_visible_on_same_instance(self) -> None:
+        s = _ClaudeDispatchState()
+        s.raw_content = "hello"
+        s.input_tokens = 42
+        s.cached_input = 7
+        assert s.raw_content == "hello"
+        assert s.input_tokens == 42
+        assert s.cached_input == 7
+
+    def test_two_instances_have_independent_raw_content(self) -> None:
+        s1 = _ClaudeDispatchState()
+        s2 = _ClaudeDispatchState()
+        s1.raw_content = "one"
+        s2.raw_content = "two"
+        assert s1.raw_content == "one"
+        assert s2.raw_content == "two"
+
+    def test_dataclass_eq_compares_by_value(self) -> None:
+        s1 = _ClaudeDispatchState()
+        s2 = _ClaudeDispatchState()
+        assert s1 == s2  # default == default
+        s1.raw_content = "x"
+        assert s1 != s2
+
+
+# ============================================================================
+# reset_for_next_dispatch
+# ============================================================================
+
+
+class TestResetForNextDispatch:
+
+    def test_reset_restores_all_fields_to_defaults(self) -> None:
+        s = _ClaudeDispatchState()
+        s.raw_content = "x"
+        s.input_tokens = 1
+        s.output_tokens = 2
+        s.cached_input = 3
+        s.first_token_ms = 12.5
+        s.last_msg = object()
+        s.thinking_reason_out = "because"
+        s.token_usage = {"a": 1}
+        s.reset_for_next_dispatch()
+        assert s == _ClaudeDispatchState()
+
+    def test_reset_token_usage_is_fresh_dict_not_shared(self) -> None:
+        s = _ClaudeDispatchState()
+        s.token_usage["mutated"] = 1
+        original_dict_id = id(s.token_usage)
+        s.reset_for_next_dispatch()
+        # Must be a fresh dict — otherwise a callsite holding the old
+        # ref could leak state across dispatches.
+        assert id(s.token_usage) != original_dict_id
+        assert s.token_usage == {}
+
+    def test_reset_is_idempotent(self) -> None:
+        s = _ClaudeDispatchState()
+        s.reset_for_next_dispatch()
+        s.reset_for_next_dispatch()
+        assert s == _ClaudeDispatchState()
+
+
+# ============================================================================
+# to_dict / from_dict (lossy by design)
+# ============================================================================
+
+
+class TestToDictFromDictLossyRoundtrip:
+
+    def test_to_dict_returns_documented_keys(self) -> None:
+        s = _ClaudeDispatchState()
+        d = s.to_dict()
+        for key in (
+            "schema_version", "raw_content_len", "input_tokens",
+            "output_tokens", "cached_input", "first_token_ms",
+            "last_msg_repr", "thinking_reason_out", "token_usage",
+        ):
+            assert key in d, f"missing key: {key}"
+
+    def test_to_dict_carries_schema_version(self) -> None:
+        s = _ClaudeDispatchState()
+        assert s.to_dict()["schema_version"] == (
+            CLAUDE_DISPATCH_STATE_SCHEMA_VERSION
+        )
+
+    def test_to_dict_raw_content_is_length_not_body(self) -> None:
+        """Privacy / log-bloat protection — never dump raw_content
+        verbatim into telemetry."""
+        s = _ClaudeDispatchState()
+        s.raw_content = "supersecretpayload"
+        d = s.to_dict()
+        assert "supersecretpayload" not in repr(d)
+        assert d["raw_content_len"] == len("supersecretpayload")
+
+    def test_to_dict_last_msg_is_repr_not_object(self) -> None:
+        s = _ClaudeDispatchState()
+        s.last_msg = "fake-msg-obj"
+        d = s.to_dict()
+        # repr returns a string — JSON-safe.
+        assert isinstance(d["last_msg_repr"], str)
+
+    def test_to_dict_last_msg_none_when_unset(self) -> None:
+        s = _ClaudeDispatchState()
+        assert s.to_dict()["last_msg_repr"] is None
+
+    def test_from_dict_recovers_scalar_fields(self) -> None:
+        d = {
+            "schema_version": CLAUDE_DISPATCH_STATE_SCHEMA_VERSION,
+            "raw_content_len": 100,
+            "input_tokens": 42,
+            "output_tokens": 21,
+            "cached_input": 7,
+            "first_token_ms": 12.5,
+            "last_msg_repr": "<some-repr>",
+            "thinking_reason_out": "because",
+            "token_usage": {"x": 1},
+        }
+        s = _ClaudeDispatchState.from_dict(d)
+        assert s.input_tokens == 42
+        assert s.output_tokens == 21
+        assert s.cached_input == 7
+        assert s.first_token_ms == 12.5
+        assert s.thinking_reason_out == "because"
+        assert s.token_usage == {"x": 1}
+
+    def test_from_dict_loses_raw_content_body_by_design(self) -> None:
+        d = {"raw_content_len": 100, "input_tokens": 0}
+        s = _ClaudeDispatchState.from_dict(d)
+        assert s.raw_content == ""  # lossy
+
+    def test_from_dict_loses_last_msg_by_design(self) -> None:
+        d = {"last_msg_repr": "<msg>"}
+        s = _ClaudeDispatchState.from_dict(d)
+        assert s.last_msg is None  # lossy
+
+    def test_from_dict_on_bad_payload_returns_defaults(self) -> None:
+        """Defensive — non-mapping input does NOT raise."""
+        s = _ClaudeDispatchState.from_dict({"input_tokens": "not-a-number"})
+        # Either defaults OR the converted value if str-int worked.
+        assert isinstance(s, _ClaudeDispatchState)
+
+    def test_from_dict_handles_empty_dict(self) -> None:
+        s = _ClaudeDispatchState.from_dict({})
+        assert s == _ClaudeDispatchState()
+
+
+# ============================================================================
+# _CumulativeCost
+# ============================================================================
+
+
+class TestCumulativeCost:
+
+    def test_initial_total_is_zero(self) -> None:
+        c = _CumulativeCost()
+        assert c.total == 0.0
+
+    def test_add_positive_increments_total(self) -> None:
+        c = _CumulativeCost()
+        c.add(1.5)
+        assert c.total == 1.5
+
+    def test_add_zero_is_no_op(self) -> None:
+        c = _CumulativeCost()
+        c.add(0.0)
+        assert c.total == 0.0
+
+    def test_add_negative_is_no_op(self) -> None:
+        """Mirrors closure's defensive accounting — a negative
+        SDK-reported cost cannot subtract from total_cost."""
+        c = _CumulativeCost()
+        c.add(-1.0)
+        assert c.total == 0.0
+        c.add(2.0)
+        c.add(-99.0)
+        assert c.total == 2.0  # unchanged by the negative
+
+    def test_add_non_numeric_is_no_op(self) -> None:
+        """Defensive — ``add("not-a-number")`` does NOT raise."""
+        c = _CumulativeCost()
+        c.add("nope")  # type: ignore[arg-type]
+        c.add(None)    # type: ignore[arg-type]
+        assert c.total == 0.0
+
+    def test_total_monotone_across_multiple_adds(self) -> None:
+        c = _CumulativeCost()
+        c.add(0.5)
+        c.add(0.25)
+        c.add(0.10)
+        c.add(0.05)
+        assert c.total == pytest.approx(0.90, abs=1e-9)
+
+    def test_reset_zeroes_after_accumulation(self) -> None:
+        c = _CumulativeCost()
+        c.add(1.0)
+        c.add(2.0)
+        assert c.total == 3.0
+        c.reset()
+        assert c.total == 0.0
+
+    def test_reset_then_add_works(self) -> None:
+        c = _CumulativeCost()
+        c.add(5.0)
+        c.reset()
+        c.add(2.5)
+        assert c.total == 2.5
+
+    def test_two_instances_are_independent(self) -> None:
+        c1 = _CumulativeCost()
+        c2 = _CumulativeCost()
+        c1.add(1.0)
+        c2.add(2.0)
+        assert c1.total == 1.0
+        assert c2.total == 2.0
+
+
+# ============================================================================
+# AST pins — structural + dormancy invariants
+# ============================================================================
+
+
+def _load_module_ast(path: Path) -> ast.AST:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+def test_ast_pin_dispatch_state_has_exactly_eight_fields():
+    """The dataclass body MUST declare exactly 8 annotated fields.
+    Adding a field requires bumping
+    :data:`CLAUDE_DISPATCH_STATE_SCHEMA_VERSION` + updating this pin
+    + updating :data:`_CLAUDE_DISPATCH_STATE_FIELD_NAMES`."""
+    tree = _load_module_ast(_MODULE_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "_ClaudeDispatchState"
+        ):
+            # Count annotated assignments (the dataclass fields).
+            annotated = [
+                stmt for stmt in node.body
+                if isinstance(stmt, ast.AnnAssign)
+            ]
+            assert len(annotated) == 8, (
+                f"_ClaudeDispatchState has {len(annotated)} fields, "
+                f"expected 8 (frozen taxonomy)"
+            )
+            return
+    pytest.fail("_ClaudeDispatchState not found")
+
+
+def test_ast_pin_dispatch_state_is_not_frozen():
+    """The refactor mutates fields in place; the dataclass MUST NOT
+    be ``frozen=True``."""
+    tree = _load_module_ast(_MODULE_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "_ClaudeDispatchState"
+        ):
+            for deco in node.decorator_list:
+                # @dataclass (bare) — no keywords → not frozen.
+                if isinstance(deco, ast.Name) and deco.id == "dataclass":
+                    return  # bare @dataclass — implicitly not frozen
+                # @dataclass(frozen=True, ...) — check keyword
+                if (
+                    isinstance(deco, ast.Call)
+                    and isinstance(deco.func, ast.Name)
+                    and deco.func.id == "dataclass"
+                ):
+                    for kw in deco.keywords:
+                        if kw.arg == "frozen":
+                            if (
+                                isinstance(kw.value, ast.Constant)
+                                and kw.value.value is True
+                            ):
+                                pytest.fail(
+                                    "_ClaudeDispatchState is frozen; "
+                                    "refactor mutates in place"
+                                )
+            return
+    pytest.fail("_ClaudeDispatchState not found")
+
+
+def test_ast_pin_cumulative_cost_has_closed_interface():
+    """:class:`_CumulativeCost` MUST expose the closed 3-method +
+    1-property interface (``add`` / ``reset`` / ``total``) — no
+    others. ``__init__`` is permitted."""
+    tree = _load_module_ast(_MODULE_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "_CumulativeCost"
+        ):
+            method_names = {
+                m.name for m in node.body
+                if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+            required = {"__init__", "add", "reset", "total"}
+            # ``total`` may be a @property (still a FunctionDef in AST).
+            missing = required - method_names
+            assert not missing, (
+                f"_CumulativeCost missing interface methods: {missing}"
+            )
+            # No public mutation surface beyond add/reset.
+            forbidden = {"subtract", "set", "increment", "decrement"}
+            present_forbidden = forbidden & method_names
+            assert not present_forbidden, (
+                f"_CumulativeCost has forbidden method(s): "
+                f"{present_forbidden}"
+            )
+            return
+    pytest.fail("_CumulativeCost not found")
+
+
+def test_ast_pin_providers_does_not_import_dispatch_state_yet():
+    """Dormancy invariant: Slice 2A-ii ships the substrate
+    completely unused. ``providers.py`` MUST NOT import from
+    ``claude_dispatch_state`` until Phase 2A-iii (first extraction)
+    lands.
+
+    This pin will be the FIRST one Phase 2A-iii flips."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            assert "claude_dispatch_state" not in module, (
+                f"providers.py prematurely imports claude_dispatch_state "
+                f"(line {node.lineno}); Slice 2A-ii must keep "
+                f"providers.py byte-identical to main"
+            )
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert "claude_dispatch_state" not in alias.name
+
+
+def test_ast_pin_providers_file_sha_matches_2a_ii_baseline():
+    """Stronger dormancy invariant: providers.py byte-identical to
+    main@72444cc031. This is the canonical proof that Slice 2A-ii
+    introduces zero behavioral change.
+
+    Phase 2A-iii will update this SHA in the same commit that flips
+    the import-yet pin above."""
+    actual_sha = hashlib.sha1(_PROVIDERS_FILE.read_bytes()).hexdigest()
+    assert actual_sha == _PROVIDERS_SHA_AT_2A_II, (
+        f"providers.py SHA shifted: {actual_sha} (expected "
+        f"{_PROVIDERS_SHA_AT_2A_II}). Slice 2A-ii must keep "
+        f"providers.py byte-identical; any change belongs in "
+        f"Phase 2A-iii or later."
+    )
+
+
+def test_ast_pin_no_locked_surface_imports():
+    """Operator lockdown enforcement: the substrate module MUST NOT
+    import from any newly-deployed surface (evaluator_trace_observer,
+    session_budget_authority, provider_response_cache,
+    s2_predictive_budget, swe_bench_pro/*, commit_authority,
+    auto_committer)."""
+    locked = (
+        "evaluator_trace_observer",
+        "evaluator_trace_observability",
+        "session_budget_authority",
+        "provider_response_cache",
+        "s2_predictive_budget",
+        "swe_bench_pro",
+        "commit_authority",
+        "auto_committer",
+    )
+    tree = _load_module_ast(_MODULE_FILE)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for surface in locked:
+                assert surface not in module, (
+                    f"forbidden locked-surface import in substrate: "
+                    f"{module}"
+                )
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                for surface in locked:
+                    assert surface not in alias.name, (
+                        f"forbidden locked-surface import in substrate: "
+                        f"{alias.name}"
+                    )
+
+
+def test_ast_pin_substrate_module_has_no_authority_imports():
+    """The substrate module MUST NOT import providers.py, the
+    orchestrator, the iron gate, the candidate generator, or any
+    authority surface. It is pure data, no dependency cycles, no
+    behavior."""
+    forbidden_modules = (
+        "providers",
+        "orchestrator",
+        "iron_gate",
+        "candidate_generator",
+        "urgency_router",
+        "tool_executor",
+        "policy",
+        "change_engine",
+        "subagent_scheduler",
+        "auto_action_router",
+        "strategic_direction",
+    )
+    tree = _load_module_ast(_MODULE_FILE)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for surface in forbidden_modules:
+                # Match end-of-module-path or full path
+                assert not module.endswith(f".{surface}"), (
+                    f"forbidden authority import in substrate: {module}"
+                )
+
+
+def test_ast_pin_substrate_exports_via_explicit_all():
+    """The module MUST declare ``__all__`` listing both classes plus
+    the schema constant — explicit export surface protects against
+    accidental name-leak into consumers."""
+    tree = _load_module_ast(_MODULE_FILE)
+    found_all = False
+    expected_names = {
+        "CLAUDE_DISPATCH_STATE_SCHEMA_VERSION",
+        "_ClaudeDispatchState",
+        "_CumulativeCost",
+    }
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == "__all__":
+                    found_all = True
+                    # Extract the string values from the list literal.
+                    if isinstance(node.value, ast.List):
+                        names = {
+                            elt.value for elt in node.value.elts
+                            if isinstance(elt, ast.Constant)
+                        }
+                        missing = expected_names - names
+                        assert not missing, (
+                            f"__all__ missing required names: {missing}"
+                        )
+    assert found_all, "substrate module must declare __all__"


### PR DESCRIPTION
## What

Slice 2A-ii of the Claude `_generate_raw` decomposition arc.

Introduces two pure-data primitives that will replace the closure's implicit state cells when Phase 2A-iii through 2C-ii land their per-helper extractions. **Ships completely UNUSED** by `providers.py` — the substrate exists, its 40-test green bar exists, but no caller imports it yet. Phase 2A-iii (first helper extraction, `_boundary_audit_sampler` at ~30 lines) is the first PR allowed to flip the dormancy AST pin.

**providers.py is byte-identical to main** — SHA `a33f9fb67fdcf8e10f8e47fbd3a6b8075aea8a7d` locked via AST pin.

## Why this is its own PR

Single-responsibility extraction pattern: substrate first, consumers later. Reviewers can audit the dataclass shape + cost-accumulator contract in isolation without having to read 300+ lines of closure-extraction diff next to it. Each subsequent slice (2A-iii, 2B-i, 2B-ii, etc.) then becomes a small `add import + delete N closure lines + use the substrate` patch.

## What lands

| File | Change | Lines |
|------|--------|-------|
| `backend/core/ouroboros/governance/claude_dispatch_state.py` | NEW | +268 |
| `tests/test_ouroboros_governance/test_claude_dispatch_state.py` | NEW | +561 |

### `_ClaudeDispatchState` — 8 mutable fields replacing the closure's state cells

| Field | Type | Replaces (closure cell) |
|---|---|---|
| `raw_content` | `str` | `nonlocal raw_content` (`_do_stream` accumulator) |
| `input_tokens` | `int` | `nonlocal input_tokens` (message.usage.input_tokens) |
| `output_tokens` | `int` | `nonlocal output_tokens` (message_delta.usage.output_tokens) |
| `cached_input` | `int` | `nonlocal _cached_input` (message.usage.cache_read_input_tokens) |
| `first_token_ms` | `Optional[float]` | outer-capture `_first_token_ms` |
| `last_msg` | `Optional[Any]` | outer-capture `_last_msg` |
| `thinking_reason_out` | `Optional[str]` | outer-capture `_thinking_reason_out` |
| `token_usage` | `Dict[str, int]` | outer-capture `_token_usage` |

Mutable by design — the refactored helper methods will mutate fields in place exactly as the current nested closures mutate their nonlocals. `to_dict()`/`from_dict()` provide debug snapshots without compromising mutability. Privacy protection: `raw_content` is exposed in snapshots as `raw_content_len`, never its body.

### `_CumulativeCost` — accumulator for the fifth nonlocal (`total_cost`)

Carries the lifetime mismatch: every other nonlocal resets per `_dispatch_raw` invocation, but `total_cost` survives multiple dispatches within a single `generate()` (the `tool_loop.run` multi-round path). The refactor models this by constructing **one accumulator per `generate()` call** and threading it explicitly into each dispatch.

| Method | Behavior |
|---|---|
| `.add(cost)` | Positive-only; non-positive inputs silently dropped (mirrors closure's defensive accounting — a negative SDK-reported cost cannot subtract from `provider._daily_spend`); non-numeric input silently dropped |
| `.reset()` | Zeros the accumulator (test/reuse helper) |
| `.total` | Race-tolerant read property (no lock — stale snapshots are acceptable for telemetry) |

Thread-safety: internal `threading.Lock` on `add`/`reset`. Closure is single-threaded async (no lock needed); the lock is cheap insurance for the refactor's wider call surface — sub-microsecond per-add overhead — and documents the broader thread-safety the refactor unlocks.

## 8 AST pins (structural + dormancy)

1. `test_ast_pin_dispatch_state_has_exactly_eight_fields` — frozen taxonomy; adding requires schema bump + paired pin update
2. `test_ast_pin_dispatch_state_is_not_frozen` — `@dataclass(frozen=False)` (default); refactor mutates in place
3. `test_ast_pin_cumulative_cost_has_closed_interface` — exactly `__init__`/`add`/`reset`/`total`; no `subtract`/`set`/`increment` leak surface
4. **`test_ast_pin_providers_does_not_import_dispatch_state_yet`** — the dormancy invariant
5. **`test_ast_pin_providers_file_sha_matches_2a_ii_baseline`** — `providers.py` SHA equals `a33f9fb6...` (byte-identical to main; the strongest dormancy proof)
6. `test_ast_pin_no_locked_surface_imports` — no evaluator_trace / session_budget / swe_bench_pro / commit_authority / etc.
7. `test_ast_pin_substrate_module_has_no_authority_imports` — no providers / orchestrator / iron_gate / candidate_generator / etc. (pure data, no dependency cycles)
8. `test_ast_pin_substrate_exports_via_explicit_all` — protected name-leak surface

Two of these (#4 and #5) flip together in Phase 2A-iii.

## Test surface

| Surface | Count |
|---|---|
| Family tests (schema, mutability, reset, roundtrip, cost accumulator) | 33 |
| AST pins (structural + dormancy) | 7 |
| **Total this PR** | **40 / 40 PASS** |
| Phase 1 baseline (PR #46868) regression | **33 passed + 2 xfailed** (zero regressions) |
| Combined surface | **73 passed + 2 xfailed** |
| Provider edits | **0** — `providers.py` byte-identical (AST-pinned) |

## Standing constraint chain — all held

- ✅ Zero touch of all newly-deployed surfaces (evaluator_trace, session_budget, provider_response_cache, s2_predictive_budget, swe_bench_pro/*, commit_authority, auto_committer, DW heavy lane) — AST-pin enforced
- ✅ Zero provider edits — `providers.py` SHA-pinned at `a33f9fb6...`
- ✅ Master flags untouched (no flag introduced; dormant module needs none)
- ✅ Substrate is dormant — no consumers — providers.py byte-identical
- ✅ No authority imports (no orchestrator / iron_gate / candidate_generator / etc.)
- ✅ Iron Gate respected
- ✅ Slice 5 graduation deferred for evaluator_trace observer (Bars A/B/C still gate it)

## What Phase 2A-iii inherits

When the first helper extraction (`_boundary_audit_sampler`, ~30 lines) lands:

- **Two AST pins flip in the same commit** — `test_ast_pin_providers_does_not_import_dispatch_state_yet` and `test_ast_pin_providers_file_sha_matches_2a_ii_baseline`. Both pins document the precise commit that ends dormancy.
- The 88-test green bar (baseline + safety net from PR #48857) and the 40-test substrate green bar (this PR) must all stay green.
- The dataclass + accumulator become live consumers for the first time.

## Slice 2A-iii through 2D — DEFERRED

Per operator authorization, this PR is Slice 2A-ii only. Subsequent slices each require fresh authorization and land as separate PRs:

| Slice | Status | Scope |
|---|---|---|
| 2A-i | merged-ready ([#48857](https://github.com/drussell23/JARVIS/pull/48857)) | Safety net |
| **2A-ii** | **THIS PR** | Dormant substrate |
| 2A-iii | deferred | Extract `_boundary_audit_sampler` (proof-of-concept first extraction) |
| 2B-i | deferred | Extract `_retrieve_stream_exc` |
| 2B-ii | deferred | Extract `_create_with_resilience` + `_create_with_prefill_fallback` |
| 2B-iii | deferred | Extract `_stream_with_resilience` + `_stream_with_prefill_fallback` |
| 2C-i | deferred | Extract `_do_stream` (heaviest helper — main rot) |
| 2C-ii | deferred | Extract `_stream_fanout` + reduce `_generate_raw` to dispatcher shell |
| 2D | deferred | Final AST-pin tightening |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dormant state substrate for the Claude provider to prep the `_generate_raw` refactor. Ships new pure-data classes and tests only; no behavior change and `providers.py` remains byte-identical.

- **New Features**
  - New module `backend/core/ouroboros/governance/claude_dispatch_state.py` with `_ClaudeDispatchState` (8 mutable fields) and helpers `.reset_for_next_dispatch()`, `.to_dict()`/`.from_dict()`; `to_dict` exposes `raw_content_len` only.
  - `_CumulativeCost` accumulator with `add`, `reset`, and `total`; ignores non-positive inputs and is thread-safe.
  - 40 tests (33 unit + 7 AST pins) lock schema and closed interfaces, enforce dormancy (no `providers.py` import), and verify `providers.py` is unchanged.

<sup>Written for commit 8d01725a831cdd024a1bea4bfbaa28c51238bad9. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/48860?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

