### PR TITLE
refactor(providers): extract _boundary_audit_sampler — Slice 2A-iii (proof-of-concept first extraction)

### DIFF
--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -6389,6 +6389,100 @@ class ClaudeProvider:
         needed = max(needed, self._max_tokens, _CLAUDE_OUTPUT_FLOOR)
         return min(needed, self._output_ceiling)
 
+    # ---------------------------------------------------------------------
+    # Slice 2A-iii — first extraction from _generate_raw closure.
+    #
+    # _claude_boundary_audit_sampler is the proof-of-concept first
+    # extraction in the _generate_raw decomposition arc. It is a PURE
+    # telemetry observer with no mutation of the 5 nonlocals or 4 outer
+    # captures targeted by the dispatch_state substrate — its inputs
+    # are passed explicitly as keyword-only parameters to eliminate the
+    # closure-capture surface.
+    #
+    # No dispatch_state import yet (that lands when the first stateful
+    # helper extracts — likely 2B-ii); this slice proves only the
+    # mechanical extraction pattern (nested closure → class method).
+    # ---------------------------------------------------------------------
+
+    async def _claude_boundary_audit_sampler(
+        self,
+        *,
+        interval_s: float,
+        first_raw_event_logged: List[bool],
+        deadline: float,
+        t0: float,
+        thinking_label: str,
+        op_id: str,
+    ) -> None:
+        """Periodic asyncio task-topology audit log for the streaming
+        boundary diagnostic — env-gated by
+        ``JARVIS_CLAUDE_STREAM_BOUNDARY_AUDIT_ENABLED`` at the call
+        site (this method assumes the env check already passed; it
+        does not re-check).
+
+        Self-terminating + hard-capped:
+
+          * Returns on ``asyncio.CancelledError`` mid-sleep.
+          * Returns when ``first_raw_event_logged[0]`` flips True
+            (the stream consumer's "first raw event seen" signal —
+            the audit's whole job is to surface the silence BEFORE
+            that signal, so it must stop the instant it lands).
+          * Returns when ``time.monotonic() >= deadline``.
+          * Hard cap at 60 emitted samples regardless of cadence
+            (defense against pathological long-deadline configs).
+
+        Log-only; NEVER raises out of any iteration — the inner
+        introspection is wrapped so a failed ``asyncio.all_tasks``
+        call doesn't tear down the sampler.
+
+        Inputs are passed explicitly (no closure capture):
+
+          * ``interval_s`` — sleep cadence between samples.
+          * ``first_raw_event_logged`` — list-of-bool used as a
+            shared closure-cell between the audit task and the
+            stream consumer loop; the consumer flips ``[0] = True``
+            on the first raw event and this sampler terminates on
+            its next wake.
+          * ``deadline`` — monotonic-time absolute deadline.
+          * ``t0`` — monotonic-time start (for elapsed_ms log).
+          * ``thinking_label`` — ``"on"`` or ``"off"`` for the log.
+          * ``op_id`` — short op-id slice for the log (already
+            truncated by the caller).
+        """
+        _seq = 0
+        while True:
+            try:
+                await asyncio.sleep(interval_s)
+            except asyncio.CancelledError:
+                return
+            # Stop conditions (any) — never leak.
+            if first_raw_event_logged[0]:
+                return
+            if time.monotonic() >= deadline:
+                return
+            _seq += 1
+            if _seq > 60:  # absolute hard cap
+                return
+            try:
+                _loop = asyncio.get_running_loop()
+                _all = asyncio.all_tasks(_loop)
+                _nd = [t for t in _all if not t.done()]
+                _names = [t.get_name() for t in _nd[:16]]
+                logger.info(
+                    "[ClaudeProvider.stream.boundary.audit]"
+                    " seq=%d elapsed_ms=%d "
+                    "thinking=%s tasks_total=%d "
+                    "tasks_not_done=%d op_id=%s "
+                    "tasks_sample=%s",
+                    _seq,
+                    int((time.monotonic() - t0) * 1000),
+                    thinking_label,
+                    len(_all), len(_nd),
+                    op_id, _names,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+
     async def generate(
         self,
         context: OperationContext,
@@ -6921,49 +7015,25 @@ class ClaudeProvider:
                                 float(timeout_s) + 30.0, 900.0,
                             )
 
-                            async def _boundary_audit_sampler() -> None:
-                                _seq = 0
-                                while True:
-                                    try:
-                                        await asyncio.sleep(_audit_interval_s)
-                                    except asyncio.CancelledError:
-                                        return
-                                    # Stop conditions (any) — never leak.
-                                    if _first_raw_event_logged[0]:
-                                        return
-                                    if time.monotonic() >= _audit_deadline:
-                                        return
-                                    _seq += 1
-                                    if _seq > 60:  # absolute hard cap
-                                        return
-                                    try:
-                                        _loop = asyncio.get_running_loop()
-                                        _all = asyncio.all_tasks(_loop)
-                                        _nd = [t for t in _all if not t.done()]
-                                        _names = [
-                                            t.get_name() for t in _nd[:16]
-                                        ]
-                                        logger.info(
-                                            "[ClaudeProvider.stream.boundary.audit]"
-                                            " seq=%d elapsed_ms=%d "
-                                            "thinking=%s tasks_total=%d "
-                                            "tasks_not_done=%d op_id=%s "
-                                            "tasks_sample=%s",
-                                            _seq,
-                                            int(
-                                                (time.monotonic()
-                                                 - _audit_t0) * 1000
-                                            ),
-                                            _audit_thinking,
-                                            len(_all), len(_nd),
-                                            _audit_op_id, _names,
-                                        )
-                                    except Exception:  # noqa: BLE001
-                                        pass
-
+                            # Slice 2A-iii — the sampler body extracted to
+                            # ClaudeProvider._claude_boundary_audit_sampler
+                            # as a class method; all six captures threaded
+                            # explicitly (no closure-cell capture beyond the
+                            # single shared `first_raw_event_logged` list).
+                            # Byte-equivalent telemetry; cleaner extraction
+                            # seam for the upcoming _do_stream refactor.
                             try:
                                 _audit_task = asyncio.create_task(
-                                    _boundary_audit_sampler(),
+                                    self._claude_boundary_audit_sampler(
+                                        interval_s=_audit_interval_s,
+                                        first_raw_event_logged=(
+                                            _first_raw_event_logged
+                                        ),
+                                        deadline=_audit_deadline,
+                                        t0=_audit_t0,
+                                        thinking_label=_audit_thinking,
+                                        op_id=_audit_op_id,
+                                    ),
                                     name="claude_stream_boundary_audit",
                                 )
                             except Exception:  # noqa: BLE001

--- a/tests/test_ouroboros_governance/test_claude_dispatch_state.py
+++ b/tests/test_ouroboros_governance/test_claude_dispatch_state.py
@@ -53,10 +53,20 @@ _MODULE_FILE = Path(
 _PROVIDERS_FILE = Path(
     "backend/core/ouroboros/governance/providers.py"
 )
-# Locked from the branch-creation audit; updates ONLY in the PR that
-# starts importing the substrate (Phase 2A-iii at the earliest).
-_PROVIDERS_SHA_AT_2A_II = (
-    "a33f9fb67fdcf8e10f8e47fbd3a6b8075aea8a7d"
+# Per-slice SHA lock — updated by EVERY slice that mutates
+# providers.py. The constant name does not change across slices; the
+# value does. The docstring on
+# ``test_ast_pin_providers_file_sha_matches_lock`` tracks the
+# provenance of each successive update.
+#
+# Slice 2A-ii (PR #48860): a33f9fb67fdcf8e10f8e47fbd3a6b8075aea8a7d
+#                          (providers.py byte-identical to main)
+# Slice 2A-iii (this PR):  d3e409ce032ae3954dbd98d0102682fef968206b
+#                          (_boundary_audit_sampler extracted as
+#                          ClaudeProvider class method; closure
+#                          1036 → 1012 lines, 8 → 7 nested helpers)
+_PROVIDERS_SHA_LOCK = (
+    "d3e409ce032ae3954dbd98d0102682fef968206b"
 )
 
 
@@ -433,39 +443,49 @@ def test_ast_pin_cumulative_cost_has_closed_interface():
 
 
 def test_ast_pin_providers_does_not_import_dispatch_state_yet():
-    """Dormancy invariant: Slice 2A-ii ships the substrate
-    completely unused. ``providers.py`` MUST NOT import from
-    ``claude_dispatch_state`` until Phase 2A-iii (first extraction)
-    lands.
+    """Substrate-import dormancy invariant. ``providers.py`` MUST
+    NOT import from ``claude_dispatch_state`` until a STATEFUL
+    helper extraction lands.
 
-    This pin will be the FIRST one Phase 2A-iii flips."""
+    Slice 2A-iii (this slice's predecessor) extracted
+    ``_boundary_audit_sampler`` — a PURE telemetry observer that
+    does not touch any of the 5 nonlocals / 4 outer captures the
+    substrate targets — so the import was not introduced. The pin
+    will flip in whichever slice first extracts a helper that DOES
+    mutate dispatch state (likely 2B-ii when
+    ``_create_with_resilience`` + ``_create_with_prefill_fallback``
+    extract, since those touch ``input_tokens`` /
+    ``output_tokens`` / ``cached_input``)."""
     tree = _load_module_ast(_PROVIDERS_FILE)
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
             assert "claude_dispatch_state" not in module, (
-                f"providers.py prematurely imports claude_dispatch_state "
-                f"(line {node.lineno}); Slice 2A-ii must keep "
-                f"providers.py byte-identical to main"
+                f"providers.py imports claude_dispatch_state at "
+                f"line {node.lineno}; if this is the slice that "
+                f"first extracts a stateful helper, flip this pin "
+                f"deliberately."
             )
         if isinstance(node, ast.Import):
             for alias in node.names:
                 assert "claude_dispatch_state" not in alias.name
 
 
-def test_ast_pin_providers_file_sha_matches_2a_ii_baseline():
-    """Stronger dormancy invariant: providers.py byte-identical to
-    main@72444cc031. This is the canonical proof that Slice 2A-ii
-    introduces zero behavioral change.
+def test_ast_pin_providers_file_sha_matches_lock():
+    """Per-slice SHA lock: providers.py SHA1 equals the constant
+    above. EVERY slice that mutates providers.py updates the
+    constant (see provenance comments at top of file).
 
-    Phase 2A-iii will update this SHA in the same commit that flips
-    the import-yet pin above."""
+    Slice 2A-iii update: ``_boundary_audit_sampler`` extracted to
+    ``ClaudeProvider._claude_boundary_audit_sampler`` — the nested
+    closure (~38 lines) is gone from ``_generate_raw``; the class
+    method (~75 lines including docstring) is the new home.
+    Closure shrunk 1036 → 1012 lines."""
     actual_sha = hashlib.sha1(_PROVIDERS_FILE.read_bytes()).hexdigest()
-    assert actual_sha == _PROVIDERS_SHA_AT_2A_II, (
-        f"providers.py SHA shifted: {actual_sha} (expected "
-        f"{_PROVIDERS_SHA_AT_2A_II}). Slice 2A-ii must keep "
-        f"providers.py byte-identical; any change belongs in "
-        f"Phase 2A-iii or later."
+    assert actual_sha == _PROVIDERS_SHA_LOCK, (
+        f"providers.py SHA shifted: {actual_sha}. Update "
+        f"_PROVIDERS_SHA_LOCK in this file to the new value AND "
+        f"document the provenance in the comment above it."
     )
 
 
@@ -530,6 +550,118 @@ def test_ast_pin_substrate_module_has_no_authority_imports():
                 assert not module.endswith(f".{surface}"), (
                     f"forbidden authority import in substrate: {module}"
                 )
+
+
+def test_ast_pin_boundary_audit_sampler_is_class_method_on_claude_provider():
+    """Slice 2A-iii extraction proof — positive presence pin.
+
+    ``_claude_boundary_audit_sampler`` MUST exist as an
+    ``async def`` method directly under ``class ClaudeProvider``.
+    Future slices that move this method (e.g. into a stream-helper
+    mixin class) MUST update this pin in the same commit."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "_claude_boundary_audit_sampler"
+                ):
+                    return
+            pytest.fail(
+                "ClaudeProvider._claude_boundary_audit_sampler not "
+                "found — Slice 2A-iii extraction missing"
+            )
+    pytest.fail("ClaudeProvider class not found in providers.py")
+
+
+def test_ast_pin_boundary_audit_sampler_no_longer_nested_in_generate_raw():
+    """Slice 2A-iii extraction proof — negative absence pin.
+
+    The original nested ``async def _boundary_audit_sampler`` MUST
+    NOT exist anywhere inside ``_generate_raw``. The closure should
+    only call ``self._claude_boundary_audit_sampler(...)``."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "generate"
+                ):
+                    # Find _generate_raw inside generate.
+                    for sub in ast.walk(child):
+                        if (
+                            isinstance(sub, ast.AsyncFunctionDef)
+                            and sub.name == "_generate_raw"
+                        ):
+                            # Walk _generate_raw for any nested def
+                            # named _boundary_audit_sampler.
+                            for deeper in ast.walk(sub):
+                                if deeper is sub:
+                                    continue
+                                if (
+                                    isinstance(
+                                        deeper,
+                                        (
+                                            ast.FunctionDef,
+                                            ast.AsyncFunctionDef,
+                                        ),
+                                    )
+                                    and deeper.name
+                                    == "_boundary_audit_sampler"
+                                ):
+                                    pytest.fail(
+                                        f"_boundary_audit_sampler is "
+                                        f"still nested in "
+                                        f"_generate_raw at line "
+                                        f"{deeper.lineno} — Slice "
+                                        f"2A-iii extraction "
+                                        f"incomplete"
+                                    )
+                            return  # _generate_raw walked clean
+    # Reaching here means the structure changed beyond expectation;
+    # later slices will need to update this pin.
+
+
+def test_ast_pin_generate_raw_size_after_2a_iii():
+    """Slice 2A-iii closure-size envelope: the extraction shaved
+    ~24 lines from ``_generate_raw`` (1036 → ~1012). Future slices
+    will shrink this further; the envelope ceiling drops per slice.
+    Floor protects against accidental over-extraction."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "generate"
+                ):
+                    for sub in ast.walk(child):
+                        if (
+                            isinstance(sub, ast.AsyncFunctionDef)
+                            and sub.name == "_generate_raw"
+                        ):
+                            size = (
+                                sub.end_lineno - sub.lineno + 1
+                            )
+                            assert 950 <= size <= 1025, (
+                                f"_generate_raw size after Slice "
+                                f"2A-iii is {size}; expected window "
+                                f"[950, 1025]. If this slice "
+                                f"intentionally moved more, update "
+                                f"the envelope."
+                            )
+                            return
 
 
 def test_ast_pin_substrate_exports_via_explicit_all():


### PR DESCRIPTION
## What

Slice 2A-iii of the Claude `_generate_raw` decomposition arc — **the proof-of-concept first extraction**.

Moves the deepest-nested closure helper (`_boundary_audit_sampler`, defined inside `_do_stream` inside `_generate_raw`) up to a class method on `ClaudeProvider`, threading all six captures explicitly as keyword-only parameters. Byte-equivalent telemetry; no behavior change.

**Stacked on [PR #48860](https://github.com/drussell23/JARVIS/pull/48860)** (dispatch-state substrate). Merge order: #48860 first, then this.

## Structural delta

| Metric | Before (2A-ii) | After (2A-iii) | Δ |
|---|---|---|---|
| `_generate_raw` size | 1036 lines | **1012 lines** | −24 |
| Nested helpers in closure | 8 | **7** | −1 |
| `ClaudeProvider` class methods (Claude-extracted) | 0 | **1** | +1 |
| `providers.py` SHA | `a33f9fb6...` | **`d3e409ce...`** | (locked) |

Remaining nested helpers (each future slice's extraction target):
`_stream_fanout` / `_do_stream` / `_stream_with_prefill_fallback` / `_stream_with_resilience` / `_retrieve_stream_exc` / `_create_with_prefill_fallback` / `_create_with_resilience`

## Why no `dispatch_state` import yet (honest dormancy)

`_boundary_audit_sampler` is **pure telemetry** — it reads task topology via `asyncio.all_tasks()` and emits a log line; it does NOT touch any of the 5 nonlocals (`raw_content` / `input_tokens` / `output_tokens` / `cached_input` / `total_cost`) or the 4 outer captures (`first_token_ms` / `last_msg` / `thinking_reason_out` / `token_usage`) that the `_ClaudeDispatchState` substrate targets.

Its only shared state with the stream consumer is the existing `first_raw_event_logged: List[bool]` cell — which is a sub-helper hack, not part of the substrate's frozen 8-field taxonomy.

The `claude_dispatch_state` import lands in whichever slice first extracts a helper that mutates one of those 5+4 cells — likely **Slice 2B-ii** when `_create_with_resilience` + `_create_with_prefill_fallback` extract (they touch `input_tokens` / `output_tokens` / `cached_input`).

The dormancy-AST-pin docstring is updated in this PR to reflect this honestly.

## What lands

### `backend/core/ouroboros/governance/providers.py`

- **NEW**: `ClaudeProvider._claude_boundary_audit_sampler` async method (~75 lines including docstring) — explicit-parameter version of the previously nested closure. All 6 captures (`interval_s` / `first_raw_event_logged` / `deadline` / `t0` / `thinking_label` / `op_id`) passed as keyword-only arguments.
- **REMOVED**: nested `async def _boundary_audit_sampler() -> None` body inside `_do_stream` (~38 lines).
- **UPDATED**: the env-gated `create_task` call site now invokes `self._claude_boundary_audit_sampler(...)`.

### `tests/test_ouroboros_governance/test_claude_dispatch_state.py`

- **RENAMED**: `_PROVIDERS_SHA_AT_2A_II` → `_PROVIDERS_SHA_LOCK` with per-slice provenance comment block (each future slice updates the constant + adds a provenance line).
- **UPDATED**: SHA to `d3e409ce032ae3954dbd98d0102682fef968206b`.
- **UPDATED**: docstring on `test_ast_pin_providers_does_not_import_dispatch_state_yet` to reflect the honest current state.
- **NEW**: `test_ast_pin_boundary_audit_sampler_is_class_method_on_claude_provider` — positive presence pin.
- **NEW**: `test_ast_pin_boundary_audit_sampler_no_longer_nested_in_generate_raw` — negative absence pin.
- **NEW**: `test_ast_pin_generate_raw_size_after_2a_iii` — closure-size envelope `[950, 1025]` for this slice.

## Telemetry byte-equivalence (no behavior drift)

The extracted method preserves every observable from the original closure:

| Behavior | Pre-extraction | Post-extraction |
|---|---|---|
| Env-flag gate | `JARVIS_CLAUDE_STREAM_BOUNDARY_AUDIT_ENABLED` | (same — checked at call site, not method) |
| Cadence env knob | `JARVIS_CLAUDE_STREAM_BOUNDARY_AUDIT_INTERVAL_S` | (same — read at call site) |
| Hard cap | 60 cycles | 60 cycles |
| Stop conditions | CancelledError / first_raw_event / deadline / hard cap | (same, identical order) |
| Log format string | `[ClaudeProvider.stream.boundary.audit] seq=...` | (byte-identical) |
| Log arg order | `seq / elapsed_ms / thinking / total / not_done / op_id / sample` | (byte-identical) |

## Green bar

| Surface | Count |
|---|---|
| Substrate (this PR's test file) | **43 passed** (was 40 in 2A-ii) |
| Phase 1 baseline (PR #46868) | **33 passed + 2 xfailed** (unchanged) |
| **Combined** | **76 passed + 2 xfailed** — zero regressions |

The two xfails are pre-existing graduation criteria (model_id propagation, hardcoded 8.0s floor) — Phase 2 must transition them xfail → pass naturally.

## Standing constraints — all held

- ✅ Zero touch of newly-deployed surfaces (evaluator_trace, session_budget, swe_bench_pro, commit_authority, DW heavy lane) — AST-pin enforced
- ✅ No master flags introduced
- ✅ No authority imports added to the substrate module
- ✅ Telemetry byte-equivalent to pre-extraction behavior
- ✅ Iron Gate respected (stopped, reported verbatim, waited for unblock, never bypassed)

## Note for safety-net PR coordination

PR [#48857](https://github.com/drussell23/JARVIS/pull/48857) (safety net) contains an AST pin `test_ast_pin_no_provider_mutation_in_this_pr` that asserts `1000 <= found_size <= 1100` for `_generate_raw`. After this PR's extraction the size is **1012** — still in envelope. Future slices that drop below 1000 will need to update that pin in coordination.

## What Phase 2B-i inherits

When the next extraction (`_retrieve_stream_exc`, ~50 lines, no nonlocal mutation) lands:

- 76-test green bar stays green
- SHA lock updates with new commit's SHA
- The same per-slice pattern: positive-presence + negative-absence + size envelope all updated in one commit
- Closure size expected ~960 lines after 2B-i

## Slice arc status

| Slice | Status | PR |
|---|---|---|
| 2A-i (safety net) | merged-ready | [#48857](https://github.com/drussell23/JARVIS/pull/48857) |
| 2A-ii (dormant substrate) | merged-ready | [#48860](https://github.com/drussell23/JARVIS/pull/48860) |
| **2A-iii (this PR)** | **shipped** | **this PR** |
| 2B-i (`_retrieve_stream_exc`) | deferred | TBD |
| 2B-ii (`_create_with_*` pair) | deferred | TBD |
| 2B-iii (`_stream_with_*` pair) | deferred | TBD |
| 2C-i (`_do_stream` — heaviest) | deferred | TBD |
| 2C-ii (`_stream_fanout` + dispatcher shell) | deferred | TBD |
| 2D (AST-pin tightening) | deferred | TBD |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the nested `_boundary_audit_sampler` into `ClaudeProvider._claude_boundary_audit_sampler` to reduce closure nesting and prep for future stream refactors. No behavior changes; telemetry is byte-identical.

- **Refactors**
  - Moved the sampler to an async class method; threads six keyword-only params: `interval_s`, `first_raw_event_logged`, `deadline`, `t0`, `thinking_label`, `op_id`.
  - Updated the env-gated `create_task` call to `self._claude_boundary_audit_sampler(...)`.
  - Preserved cadence, stop conditions, 60-sample cap, and log format/args.
  - `_generate_raw` shrank from 1036 to 1012 lines; nested helpers drop from 8 to 7.
  - Tests: switched to a per-slice `_PROVIDERS_SHA_LOCK`, updated value, and added AST pins for class-method presence, no nested def, and a size window for `_generate_raw`; kept the `claude_dispatch_state` import absent since the sampler is pure telemetry.

<sup>Written for commit baab9fbc5dfc225061cd62715180eea813d158e4. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/48912?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

