### PR TITLE
refactor(providers): extract _retrieve_stream_exc — Slice 2B-i (@staticmethod; second extraction)

### DIFF
--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -6483,6 +6483,55 @@ class ClaudeProvider:
             except Exception:  # noqa: BLE001
                 pass
 
+    # ---------------------------------------------------------------------
+    # Slice 2B-i — second extraction from _generate_raw closure.
+    #
+    # _claude_retrieve_stream_exc drains a wedged asyncio.Task's stored
+    # exception so the GC "Task exception was never retrieved" warning
+    # does not surface when the stream consumer task finishes carrying
+    # an unawaited exception (Session-13 deadlock-protection path:
+    # fire cancel but do NOT await the task's completion).
+    #
+    # Self-contained: zero outer captures, zero state mutation, zero
+    # `self` reference — declared @staticmethod to make that explicit.
+    # No dispatch_state import yet (the substrate-import dormancy pin
+    # holds: this helper does not touch any of the 5 nonlocals or 4
+    # outer captures that the substrate targets).
+    # ---------------------------------------------------------------------
+
+    @staticmethod
+    def _claude_retrieve_stream_exc(task: "asyncio.Task[Any]") -> None:
+        """Drain an asyncio Task's stored exception without raising.
+
+        Used as a done-callback on the stream consumer task to silence
+        the "Task exception was never retrieved" GC warning that fires
+        when the task finishes with a stored exception (e.g., an
+        Anthropic ``APIStatusError``) but we are NOT awaiting its
+        completion. Preserves the Session-13 deadlock-protection
+        contract: the cancel is fired but never awaited; this
+        callback drains the exception so the GC stays quiet.
+
+        Extracted from the inline ``def _retrieve_stream_exc`` inside
+        ``_generate_raw`` per Slice 2B-i of the decomposition arc.
+
+        Semantics — exactly as before:
+
+          * Cancelled task → return immediately (the cancel sentinel
+            is not an "exception" we need to drain).
+          * Any other terminal state → invoke ``task.exception()`` to
+            retrieve and discard whatever the task stored.
+          * Any exception raised BY the retrieval itself is caught
+            and dropped — this is a hygiene callback, never a fault
+            site. NEVER raises.
+
+        NEVER raises out of any path."""
+        if task.cancelled():
+            return
+        try:
+            task.exception()
+        except Exception:  # noqa: BLE001 — retrieval only
+            pass
+
     async def generate(
         self,
         context: OperationContext,
@@ -7304,15 +7353,14 @@ class ClaudeProvider:
                 # preserved AND the explicit HARD-KILL logger.error
                 # below still provides the §8 visibility. Visibility
                 # via the explicit log; hygiene via retrieval.
-                def _retrieve_stream_exc(_t: "asyncio.Task") -> None:
-                    if _t.cancelled():
-                        return
-                    try:
-                        _t.exception()
-                    except Exception:  # noqa: BLE001 — retrieval only
-                        pass
-
-                _stream_task.add_done_callback(_retrieve_stream_exc)
+                # Slice 2B-i — the inline retrieval helper was extracted
+                # to ClaudeProvider._claude_retrieve_stream_exc as a
+                # @staticmethod (zero closure capture, zero `self`
+                # use). Byte-equivalent hygiene callback; cleaner
+                # extraction seam for the upcoming _do_stream refactor.
+                _stream_task.add_done_callback(
+                    self._claude_retrieve_stream_exc
+                )
                 try:
                     done, pending = await asyncio.wait(
                         {_stream_task},

--- a/tests/test_ouroboros_governance/test_claude_dispatch_state.py
+++ b/tests/test_ouroboros_governance/test_claude_dispatch_state.py
@@ -59,14 +59,18 @@ _PROVIDERS_FILE = Path(
 # ``test_ast_pin_providers_file_sha_matches_lock`` tracks the
 # provenance of each successive update.
 #
-# Slice 2A-ii (PR #48860): a33f9fb67fdcf8e10f8e47fbd3a6b8075aea8a7d
-#                          (providers.py byte-identical to main)
-# Slice 2A-iii (this PR):  d3e409ce032ae3954dbd98d0102682fef968206b
-#                          (_boundary_audit_sampler extracted as
-#                          ClaudeProvider class method; closure
-#                          1036 → 1012 lines, 8 → 7 nested helpers)
+# Slice 2A-ii  (PR #48860): a33f9fb67fdcf8e10f8e47fbd3a6b8075aea8a7d
+#                           (providers.py byte-identical to main)
+# Slice 2A-iii (PR #48912): d3e409ce032ae3954dbd98d0102682fef968206b
+#                           (_boundary_audit_sampler extracted as
+#                           ClaudeProvider class method; closure
+#                           1036 → 1012 lines, 8 → 7 nested helpers)
+# Slice 2B-i   (this PR):   b2bfe35fe831786e71c56e371f2870fa6b62928d
+#                           (_retrieve_stream_exc extracted as
+#                           ClaudeProvider @staticmethod; closure
+#                           1012 → 1011 lines, 7 → 6 nested helpers)
 _PROVIDERS_SHA_LOCK = (
-    "d3e409ce032ae3954dbd98d0102682fef968206b"
+    "b2bfe35fe831786e71c56e371f2870fa6b62928d"
 )
 
 
@@ -630,11 +634,17 @@ def test_ast_pin_boundary_audit_sampler_no_longer_nested_in_generate_raw():
     # later slices will need to update this pin.
 
 
-def test_ast_pin_generate_raw_size_after_2a_iii():
-    """Slice 2A-iii closure-size envelope: the extraction shaved
-    ~24 lines from ``_generate_raw`` (1036 → ~1012). Future slices
-    will shrink this further; the envelope ceiling drops per slice.
-    Floor protects against accidental over-extraction."""
+def test_ast_pin_generate_raw_size_after_2b_i():
+    """Per-slice closure-size envelope. Tightened on each slice that
+    actually shrinks ``_generate_raw``.
+
+    Slice 2A-iii (PR #48912) opened at [950, 1025] for size 1012.
+    Slice 2B-i (this PR) shrinks to 1011 (extracted the 7-line
+    inline ``_retrieve_stream_exc`` + 1-line ``add_done_callback``
+    call site → call site rewritten as a 3-line multi-line call).
+    Tightened envelope [1000, 1015]: floor protects against
+    accidental over-extraction; ceiling protects against accidental
+    re-bloat. Each future slice re-tightens this in-place."""
     tree = _load_module_ast(_PROVIDERS_FILE)
     for node in ast.walk(tree):
         if (
@@ -654,13 +664,100 @@ def test_ast_pin_generate_raw_size_after_2a_iii():
                             size = (
                                 sub.end_lineno - sub.lineno + 1
                             )
-                            assert 950 <= size <= 1025, (
+                            assert 1000 <= size <= 1015, (
                                 f"_generate_raw size after Slice "
-                                f"2A-iii is {size}; expected window "
-                                f"[950, 1025]. If this slice "
+                                f"2B-i is {size}; expected window "
+                                f"[1000, 1015]. If this slice "
                                 f"intentionally moved more, update "
                                 f"the envelope."
                             )
+                            return
+
+
+def test_ast_pin_retrieve_stream_exc_is_static_method_on_claude_provider():
+    """Slice 2B-i extraction proof — positive presence pin.
+
+    ``_claude_retrieve_stream_exc`` MUST exist as a ``@staticmethod``
+    directly under ``class ClaudeProvider``. The ``@staticmethod``
+    decorator is load-bearing: the helper has zero ``self`` usage and
+    is registered as a done-callback (which the asyncio runtime calls
+    with one positional argument). Future slices that change this
+    decorator MUST update this pin in the same commit."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.FunctionDef)
+                    and child.name == "_claude_retrieve_stream_exc"
+                ):
+                    # Confirm @staticmethod decorator present.
+                    deco_names = []
+                    for deco in child.decorator_list:
+                        if isinstance(deco, ast.Name):
+                            deco_names.append(deco.id)
+                        elif isinstance(deco, ast.Attribute):
+                            deco_names.append(deco.attr)
+                    assert "staticmethod" in deco_names, (
+                        f"_claude_retrieve_stream_exc missing "
+                        f"@staticmethod decorator (got: {deco_names})"
+                    )
+                    return
+            pytest.fail(
+                "ClaudeProvider._claude_retrieve_stream_exc not "
+                "found — Slice 2B-i extraction missing"
+            )
+    pytest.fail("ClaudeProvider class not found in providers.py")
+
+
+def test_ast_pin_retrieve_stream_exc_no_longer_nested_in_generate_raw():
+    """Slice 2B-i extraction proof — negative absence pin.
+
+    The original nested ``def _retrieve_stream_exc`` MUST NOT exist
+    anywhere inside ``_generate_raw``. The closure should only call
+    ``self._claude_retrieve_stream_exc`` (passed to
+    ``add_done_callback``)."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "generate"
+                ):
+                    for sub in ast.walk(child):
+                        if (
+                            isinstance(sub, ast.AsyncFunctionDef)
+                            and sub.name == "_generate_raw"
+                        ):
+                            for deeper in ast.walk(sub):
+                                if deeper is sub:
+                                    continue
+                                if (
+                                    isinstance(
+                                        deeper,
+                                        (
+                                            ast.FunctionDef,
+                                            ast.AsyncFunctionDef,
+                                        ),
+                                    )
+                                    and deeper.name
+                                    == "_retrieve_stream_exc"
+                                ):
+                                    pytest.fail(
+                                        f"_retrieve_stream_exc is "
+                                        f"still nested in "
+                                        f"_generate_raw at line "
+                                        f"{deeper.lineno} — Slice "
+                                        f"2B-i extraction "
+                                        f"incomplete"
+                                    )
                             return
 
 


### PR DESCRIPTION
## What

Slice 2B-i of the Claude `_generate_raw` decomposition arc — **second extraction**.

Moves the inline 7-line `def _retrieve_stream_exc` (a pure hygiene callback that drains a wedged stream task's stored exception so the GC stays quiet) up to `ClaudeProvider` as `@staticmethod`. The `@staticmethod` decorator is load-bearing — the helper has zero `self` usage and is registered as an asyncio `add_done_callback`. Byte-equivalent hygiene; no behavior change.

**Branched off main** at `e124a09a99` (post-merge state of the 2A-i/ii/iii stack).

## Structural delta

| Metric | Before (2A-iii on main) | After (2B-i) | Δ |
|---|---|---|---|
| `_generate_raw` size | 1012 lines | **1011 lines** | −1 |
| Nested helpers in closure | 7 | **6** | −1 |
| `ClaudeProvider._claude_*` extracted methods (cumulative) | 1 | **2** | +1 |
| `providers.py` SHA | `d3e409ce...` | **`b2bfe35f...`** | (locked) |

Remaining nested helpers:
`_stream_fanout` / `_do_stream` / `_stream_with_prefill_fallback` / `_stream_with_resilience` / `_create_with_prefill_fallback` / `_create_with_resilience`

## Why `@staticmethod` (load-bearing)

`_retrieve_stream_exc` has **zero `self` usage**. Declaring it as a regular instance method would imply behavior coupling that does not exist. `@staticmethod` is the honest declaration; matches what the function actually does.

`asyncio`'s `add_done_callback` calls the callable with one positional argument (the task). A staticmethod accessed through an instance returns the underlying function — so `self._claude_retrieve_stream_exc` (passed to `add_done_callback`) is invoked as `_claude_retrieve_stream_exc(task)`. Identical to pre-extraction.

The `@staticmethod` decorator is pinned by `test_ast_pin_retrieve_stream_exc_is_static_method_on_claude_provider` — future slices that change this decorator MUST update the pin in the same commit.

## Why no `dispatch_state` import yet (honest dormancy continues)

Same as 2A-iii: `_retrieve_stream_exc` has **zero outer captures, zero `nonlocal` declarations**. It does NOT touch any of the 5 nonlocals (`raw_content` / `input_tokens` / `output_tokens` / `cached_input` / `total_cost`) or the 4 outer captures (`first_token_ms` / `last_msg` / `thinking_reason_out` / `token_usage`) that the `_ClaudeDispatchState` substrate targets.

The substrate-import dormancy pin still holds. It flips in whichever slice first extracts a STATEFUL helper — **likely Slice 2B-ii** when `_create_with_resilience` + `_create_with_prefill_fallback` extract (they touch `input_tokens` / `output_tokens` / `cached_input`).

## Byte-equivalence (no behavior change)

| Pre-extraction | Post-extraction |
|---|---|
| `def _retrieve_stream_exc(_t)` (inline) | `@staticmethod` `_claude_retrieve_stream_exc(task)` (class method) |
| `if _t.cancelled(): return` | `if task.cancelled(): return` |
| `try: _t.exception()` | `try: task.exception()` |
| `except Exception: pass` | `except Exception: pass` |
| `add_done_callback(_retrieve_stream_exc)` | `add_done_callback(self._claude_retrieve_stream_exc)` |
| Cancelled task → no-op | (same) |
| Other terminal → drain via `.exception()` | (same) |
| Retrieval raise → silently swallowed | (same) |

## What lands

### `backend/core/ouroboros/governance/providers.py`

- **NEW**: `ClaudeProvider._claude_retrieve_stream_exc` `@staticmethod` — drains an `asyncio.Task`'s stored exception without raising
- **REMOVED**: the inline `def _retrieve_stream_exc(_t)` body inside `_generate_raw`
- **UPDATED**: `add_done_callback(...)` call site now passes `self._claude_retrieve_stream_exc`

### `tests/test_ouroboros_governance/test_claude_dispatch_state.py`

- **UPDATED**: `_PROVIDERS_SHA_LOCK` to `b2bfe35fe831786e71c56e371f2870fa6b62928d` + provenance line appended
- **RENAMED**: `test_ast_pin_generate_raw_size_after_2a_iii` → `test_ast_pin_generate_raw_size_after_2b_i` with envelope tightened `[950, 1025]` → `[1000, 1015]`
- **NEW**: `test_ast_pin_retrieve_stream_exc_is_static_method_on_claude_provider` — positive presence pin (decorator-enforced)
- **NEW**: `test_ast_pin_retrieve_stream_exc_no_longer_nested_in_generate_raw` — negative absence pin

## Green bar

| Surface | Count |
|---|---|
| Substrate (this PR's test file) | **45 passed** (was 43 in 2A-iii) |
| Phase 1 baseline (PR #46868) | **33 passed + 2 xfailed** (unchanged) |
| Safety net (PR #48857) | **55 passed** (unchanged) |
| **Combined** | **133 passed + 2 xfailed** — zero regressions |

## Standing constraints — all held

- ✅ Zero touch of newly-deployed surfaces (evaluator_trace, session_budget, swe_bench_pro, commit_authority, DW heavy lane) — AST-pin enforced
- ✅ No master flags introduced
- ✅ No authority imports added
- ✅ No provider spend
- ✅ No OCA / git-index / sovereignty changes
- ✅ Telemetry byte-equivalent to pre-extraction behavior
- ✅ Iron Gate respected (stopped, reported verbatim, waited for unblock, never bypassed)

## Slice arc status

| Slice | Status | PR |
|---|---|---|
| 2A-i (safety net) | merged | [#48857](https://github.com/drussell23/JARVIS/pull/48857) |
| 2A-ii (dormant substrate) | merged | [#48860](https://github.com/drussell23/JARVIS/pull/48860) |
| 2A-iii (`_boundary_audit_sampler`) | merged | [#48912](https://github.com/drussell23/JARVIS/pull/48912) |
| **2B-i (this PR — `_retrieve_stream_exc`)** | **shipped** | this PR |
| 2B-ii (`_create_with_*` pair) | deferred — likely flips substrate dormancy | TBD |
| 2B-iii (`_stream_with_*` pair) | deferred | TBD |
| 2C-i (`_do_stream` — heaviest, 317 lines) | deferred | TBD |
| 2C-ii (`_stream_fanout` + dispatcher shell) | deferred | TBD |
| 2D (AST-pin tightening) | deferred | TBD |

## What Phase 2B-ii inherits

When the next extraction (`_create_with_resilience` + `_create_with_prefill_fallback` paired — they interact closely on the create-path) lands:

- 133-test green bar stays green
- SHA lock updates with new commit's SHA + provenance line
- **The substrate-import dormancy pin LIKELY flips for the first time** (these helpers DO mutate `input_tokens` / `output_tokens` / `cached_input` — the substrate becomes a live consumer)
- Closure size expected `~960 lines` after 2B-ii

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the stream exception drain helper from `_generate_raw` to `ClaudeProvider._claude_retrieve_stream_exc` as a `@staticmethod` to simplify the closure and keep asyncio callback behavior identical. No functional changes; it still drains task exceptions to prevent GC warnings.

- **Refactors**
  - Moved `_retrieve_stream_exc` to `ClaudeProvider._claude_retrieve_stream_exc` (`@staticmethod`) and pass it to `add_done_callback`.
  - Removed the nested helper from `_generate_raw`, reducing one nested function and shrinking the closure slightly.
  - Updated AST-pin tests to enforce the staticmethod location/decorator and its non-nested status, and tightened the `_generate_raw` size envelope.

<sup>Written for commit 20f692fa135b3312062fcce1542efae27fc8ab9e. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/49578?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

