### PR TITLE
refactor(providers): extract _create_with_*_pair — Slice 2B-ii (substrate dormancy preserved; 1011→977 lines)

### DIFF
--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -6532,6 +6532,148 @@ class ClaudeProvider:
         except Exception:  # noqa: BLE001 — retrieval only
             pass
 
+    # ---------------------------------------------------------------------
+    # Slice 2B-ii — paired extraction from _generate_raw closure.
+    #
+    # _claude_create_with_prefill_fallback and _claude_create_with_resilience
+    # are the non-streaming dispatch + retry pair. Preflight AST audit
+    # confirmed both helpers touch ONLY:
+    #
+    #   * _messages         (list — mutated via .pop() on prefill reject)
+    #   * _create_kwargs    (dict — mutated via ["timeout"] = ...)
+    #   * _use_prefill      (bool — read-only flag)
+    #   * deadline          (datetime — read-only)
+    #   * timeout_s         (float  — read-only fallback)
+    #
+    # Neither touches any of the 5 nonlocals (raw_content / input_tokens /
+    # output_tokens / cached_input / total_cost) or the 4 outer captures
+    # (first_token_ms / last_msg / thinking_reason_out / token_usage)
+    # that the _ClaudeDispatchState substrate targets — token accounting
+    # happens AFTER the create returns, in the surrounding _generate_raw
+    # body. So this slice preserves substrate dormancy honestly:
+    # the substrate goes live in whichever later slice extracts the
+    # post-call token-accounting code (likely 2C-i when _do_stream
+    # extracts, since that's the heavy mutator).
+    # ---------------------------------------------------------------------
+
+    async def _claude_create_with_prefill_fallback(
+        self,
+        *,
+        create_kwargs: Dict[str, Any],
+        messages: List[Dict[str, Any]],
+        use_prefill: bool,
+        deadline: datetime,
+        timeout_s: float,
+    ) -> Any:
+        """Non-streaming dispatch with prefill-rejection fallback.
+
+        Behavior is byte-equivalent to the pre-extraction inline
+        ``async def _create_with_prefill_fallback`` inside
+        ``_generate_raw``:
+
+          1. Re-acquire the client on every attempt via
+             ``self._ensure_client()`` — closure-captured clients go
+             stale after ``_recycle_client()`` fires (Session-13).
+          2. Derive a live per-request HTTPX timeout from the
+             ``deadline`` (floor 1.0s, ``timeout_s`` fallback when
+             the budget helper returns ``None``) and stamp it into
+             ``create_kwargs["timeout"]`` before each SDK call.
+          3. Attempt the create; on success, return the message.
+          4. On exception, detect the prefill-rejection pattern
+             (``"prefill" in str(exc).lower()`` AND ``use_prefill``
+             AND a trailing assistant turn in ``messages``); if all
+             three hold, pop the trailing assistant turn, re-derive
+             the timeout, and retry exactly once.
+          5. Any other exception propagates.
+
+        Mutation contract — kept identical to the original:
+
+          * ``create_kwargs`` is mutated in place; the caller sees
+            the final ``timeout`` value after this call returns.
+          * ``messages`` is mutated in place via ``.pop()`` on the
+            prefill retry; the caller's reference reflects the
+            popped state when this method returns.
+
+        NEVER raises out except for exceptions the SDK or the
+        prefill-rejection branch deliberately re-raises."""
+        _current_client = self._ensure_client()
+        _live_create = _remaining_utc_budget_s(deadline, floor_s=1.0)
+        _live_create = float(
+            _live_create if _live_create is not None else timeout_s,
+        )
+        create_kwargs["timeout"] = _derive_per_request_httpx_timeout(
+            _live_create,
+        )
+        try:
+            return await _current_client.messages.create(**create_kwargs)
+        except Exception as _exc:
+            _msg = str(_exc).lower()
+            if (
+                use_prefill
+                and "prefill" in _msg
+                and len(messages) >= 2
+                and messages[-1].get("role") == "assistant"
+            ):
+                logger.warning(
+                    "[ClaudeProvider] prefill rejected by model "
+                    "(%s) — retrying without assistant prefill",
+                    type(_exc).__name__,
+                )
+                messages.pop()
+                _live_create = _remaining_utc_budget_s(
+                    deadline, floor_s=1.0,
+                )
+                _live_create = float(
+                    _live_create if _live_create is not None
+                    else timeout_s,
+                )
+                create_kwargs["timeout"] = (
+                    _derive_per_request_httpx_timeout(_live_create)
+                )
+                return await _current_client.messages.create(
+                    **create_kwargs
+                )
+            raise
+
+    async def _claude_create_with_resilience(
+        self,
+        *,
+        create_kwargs: Dict[str, Any],
+        messages: List[Dict[str, Any]],
+        use_prefill: bool,
+        deadline: datetime,
+        timeout_s: float,
+    ) -> Any:
+        """Non-streaming dispatch with prefill fallback + backoff retry.
+
+        Composes :meth:`_claude_create_with_prefill_fallback` inside
+        :meth:`_call_with_backoff` — the non-stream path is fully
+        idempotent (no partial emission to callers), so the backoff
+        wrapper can retry freely. ``deadline`` propagates so the
+        backoff respects the remaining generation budget (Task #4
+        cascade hardening).
+
+        The inner ``_do_create`` thunk bridges from this method's
+        keyword-only signature to the 0-arg async-callable shape
+        :meth:`_call_with_backoff` requires (``fn: Callable[[],
+        Awaitable[Any]]``). Mirrors the pre-extraction pattern
+        exactly (the original had a nested ``async def
+        _create_with_resilience`` whose body did the same
+        pass-through)."""
+        async def _do_create() -> Any:
+            return await self._claude_create_with_prefill_fallback(
+                create_kwargs=create_kwargs,
+                messages=messages,
+                use_prefill=use_prefill,
+                deadline=deadline,
+                timeout_s=timeout_s,
+            )
+        return await self._call_with_backoff(
+            _do_create,
+            label="claude_create",
+            deadline=deadline,
+        )
+
     async def generate(
         self,
         context: OperationContext,
@@ -7479,59 +7621,25 @@ class ClaudeProvider:
                 if _thinking_param is not None:
                     _create_kwargs["thinking"] = _thinking_param
 
-                async def _create_with_prefill_fallback() -> Any:
-                    """Same prefill-rejection fallback as the stream path."""
-                    # Re-acquire the client on every attempt — see the
-                    # matching comment in _do_stream. Closure-captured
-                    # clients go stale after _recycle_client() fires.
-                    _current_client = self._ensure_client()
-                    _live_create = _remaining_utc_budget_s(deadline, floor_s=1.0)
-                    _live_create = float(_live_create if _live_create is not None else timeout_s)
-                    _create_kwargs["timeout"] = _derive_per_request_httpx_timeout(
-                        _live_create,
-                    )
-                    try:
-                        return await _current_client.messages.create(**_create_kwargs)
-                    except Exception as _exc:
-                        _msg = str(_exc).lower()
-                        if (
-                            _use_prefill
-                            and "prefill" in _msg
-                            and len(_messages) >= 2
-                            and _messages[-1].get("role") == "assistant"
-                        ):
-                            logger.warning(
-                                "[ClaudeProvider] prefill rejected by model "
-                                "(%s) — retrying without assistant prefill",
-                                type(_exc).__name__,
-                            )
-                            _messages.pop()
-                            _live_create = _remaining_utc_budget_s(deadline, floor_s=1.0)
-                            _live_create = float(
-                                _live_create if _live_create is not None else timeout_s,
-                            )
-                            _create_kwargs["timeout"] = _derive_per_request_httpx_timeout(
-                                _live_create,
-                            )
-                            return await _current_client.messages.create(**_create_kwargs)
-                        raise
-
-                # Reinforced transport: non-stream path is fully idempotent
-                # (no partial emission to callers), so we can retry freely.
-                # Deadline propagates so the backoff respects the remaining
+                # Slice 2B-ii — the inline create-pair was extracted to
+                # ClaudeProvider._claude_create_with_prefill_fallback +
+                # ClaudeProvider._claude_create_with_resilience class
+                # methods. Reinforced transport: non-stream path is
+                # fully idempotent (no partial emission to callers),
+                # so the backoff wrapper can retry freely. Deadline
+                # propagates so the backoff respects the remaining
                 # generation budget (Task #4 cascade hardening).
-                async def _create_with_resilience() -> Any:
-                    return await self._call_with_backoff(
-                        _create_with_prefill_fallback,
-                        label="claude_create",
-                        deadline=deadline,
-                    )
-
                 try:
                     _live_outer = _remaining_utc_budget_s(deadline, floor_s=1.0)
                     _live_outer = float(_live_outer if _live_outer is not None else timeout_s)
                     msg = await asyncio.wait_for(
-                        _create_with_resilience(),
+                        self._claude_create_with_resilience(
+                            create_kwargs=_create_kwargs,
+                            messages=_messages,
+                            use_prefill=_use_prefill,
+                            deadline=deadline,
+                            timeout_s=timeout_s,
+                        ),
                         timeout=_live_outer,
                     )
                 except asyncio.TimeoutError as _te:

--- a/tests/test_ouroboros_governance/test_claude_dispatch_state.py
+++ b/tests/test_ouroboros_governance/test_claude_dispatch_state.py
@@ -59,18 +59,28 @@ _PROVIDERS_FILE = Path(
 # ``test_ast_pin_providers_file_sha_matches_lock`` tracks the
 # provenance of each successive update.
 #
-# Slice 2A-ii  (PR #48860): a33f9fb67fdcf8e10f8e47fbd3a6b8075aea8a7d
-#                           (providers.py byte-identical to main)
-# Slice 2A-iii (PR #48912): d3e409ce032ae3954dbd98d0102682fef968206b
-#                           (_boundary_audit_sampler extracted as
-#                           ClaudeProvider class method; closure
-#                           1036 → 1012 lines, 8 → 7 nested helpers)
-# Slice 2B-i   (this PR):   b2bfe35fe831786e71c56e371f2870fa6b62928d
-#                           (_retrieve_stream_exc extracted as
-#                           ClaudeProvider @staticmethod; closure
-#                           1012 → 1011 lines, 7 → 6 nested helpers)
+# Slice 2A-ii   (PR #48860): a33f9fb67fdcf8e10f8e47fbd3a6b8075aea8a7d
+#                            (providers.py byte-identical to main)
+# Slice 2A-iii  (PR #48912): d3e409ce032ae3954dbd98d0102682fef968206b
+#                            (_boundary_audit_sampler extracted as
+#                            ClaudeProvider class method; closure
+#                            1036 → 1012 lines, 8 → 7 nested helpers)
+# Slice 2B-i    (PR #49578): b2bfe35fe831786e71c56e371f2870fa6b62928d
+#                            (_retrieve_stream_exc extracted as
+#                            ClaudeProvider @staticmethod; closure
+#                            1012 → 1011 lines, 7 → 6 nested helpers)
+# Slice 2B-ii   (this PR):   1be2caaddce0809910deb4e9782499da9eea4b2e
+#                            (_create_with_prefill_fallback +
+#                            _create_with_resilience PAIRED extracted
+#                            as ClaudeProvider async class methods;
+#                            closure 1011 → 977 lines (-34),
+#                            6 → 4 nested helpers. Substrate-import
+#                            dormancy preserved: AST preflight
+#                            confirmed neither helper touches the
+#                            5 nonlocals or 4 outer captures the
+#                            _ClaudeDispatchState substrate targets.)
 _PROVIDERS_SHA_LOCK = (
-    "b2bfe35fe831786e71c56e371f2870fa6b62928d"
+    "1be2caaddce0809910deb4e9782499da9eea4b2e"
 )
 
 
@@ -451,15 +461,35 @@ def test_ast_pin_providers_does_not_import_dispatch_state_yet():
     NOT import from ``claude_dispatch_state`` until a STATEFUL
     helper extraction lands.
 
-    Slice 2A-iii (this slice's predecessor) extracted
-    ``_boundary_audit_sampler`` — a PURE telemetry observer that
-    does not touch any of the 5 nonlocals / 4 outer captures the
-    substrate targets — so the import was not introduced. The pin
-    will flip in whichever slice first extracts a helper that DOES
-    mutate dispatch state (likely 2B-ii when
-    ``_create_with_resilience`` + ``_create_with_prefill_fallback``
-    extract, since those touch ``input_tokens`` /
-    ``output_tokens`` / ``cached_input``)."""
+    Slice 2A-iii extracted ``_boundary_audit_sampler`` — a PURE
+    telemetry observer that does not touch any of the 5 nonlocals /
+    4 outer captures the substrate targets.
+
+    Slice 2B-i extracted ``_retrieve_stream_exc`` — a stateless
+    hygiene callback (``@staticmethod``, zero captures, zero
+    ``nonlocal``).
+
+    Slice 2B-ii (this slice) extracted the
+    ``_create_with_prefill_fallback`` + ``_create_with_resilience``
+    pair. AST preflight CONFIRMED neither helper touches
+    ``input_tokens`` / ``output_tokens`` / ``cached_input`` /
+    ``raw_content`` / ``total_cost`` / ``last_msg`` /
+    ``first_token_ms`` / ``thinking_reason_out`` / ``token_usage``.
+    The pair mutates only ``_messages`` (list ``.pop()``) and
+    ``_create_kwargs`` (dict ``["timeout"] = ...``) — both are
+    sub-helper bookkeeping, not the substrate's frozen 8-field
+    taxonomy. Token accounting happens AFTER the create returns,
+    in the surrounding ``_generate_raw`` body — that's the
+    extraction that finally flips this pin (likely 2C-i when
+    ``_do_stream`` extracts, since it mutates four of the five
+    nonlocals).
+
+    The substrate-import dormancy pin therefore HOLDS across
+    Slices 2A-iii / 2B-i / 2B-ii — the substrate exists, its
+    45-test green bar exists, but no caller imports it. The
+    dataclass + accumulator stay genuinely unused until a
+    STATEFUL extraction proves the substrate's design lock-step
+    with reality."""
     tree = _load_module_ast(_PROVIDERS_FILE)
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -634,17 +664,19 @@ def test_ast_pin_boundary_audit_sampler_no_longer_nested_in_generate_raw():
     # later slices will need to update this pin.
 
 
-def test_ast_pin_generate_raw_size_after_2b_i():
+def test_ast_pin_generate_raw_size_after_2b_ii():
     """Per-slice closure-size envelope. Tightened on each slice that
     actually shrinks ``_generate_raw``.
 
     Slice 2A-iii (PR #48912) opened at [950, 1025] for size 1012.
-    Slice 2B-i (this PR) shrinks to 1011 (extracted the 7-line
-    inline ``_retrieve_stream_exc`` + 1-line ``add_done_callback``
-    call site → call site rewritten as a 3-line multi-line call).
-    Tightened envelope [1000, 1015]: floor protects against
-    accidental over-extraction; ceiling protects against accidental
-    re-bloat. Each future slice re-tightens this in-place."""
+    Slice 2B-i   (PR #49578) tightened to [1000, 1015] for size 1011.
+    Slice 2B-ii  (this PR) shrinks 1011 → 977 by extracting the
+    paired create-path helpers (``_create_with_prefill_fallback``
+    36 lines + ``_create_with_resilience`` 6 lines + their blank +
+    call-site rewrite → net −34 inside the closure). Envelope
+    tightens to [965, 990]: floor protects against accidental
+    over-extraction; ceiling protects against accidental re-bloat.
+    Each future slice re-tightens this in-place."""
     tree = _load_module_ast(_PROVIDERS_FILE)
     for node in ast.walk(tree):
         if (
@@ -664,13 +696,213 @@ def test_ast_pin_generate_raw_size_after_2b_i():
                             size = (
                                 sub.end_lineno - sub.lineno + 1
                             )
-                            assert 1000 <= size <= 1015, (
+                            assert 965 <= size <= 990, (
                                 f"_generate_raw size after Slice "
-                                f"2B-i is {size}; expected window "
-                                f"[1000, 1015]. If this slice "
+                                f"2B-ii is {size}; expected window "
+                                f"[965, 990]. If this slice "
                                 f"intentionally moved more, update "
                                 f"the envelope."
                             )
+                            return
+
+
+def test_ast_pin_generate_raw_nested_helper_count_after_2b_ii():
+    """Per-slice nested-helper-count envelope. Slice 2B-ii drops
+    the count from 6 → 4 (both ``_create_with_*`` extracted).
+
+    Remaining nested helpers (4): ``_stream_fanout``,
+    ``_do_stream``, ``_stream_with_prefill_fallback``,
+    ``_stream_with_resilience``. Each subsequent slice removes
+    at least one entry; this pin is updated in-place."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "generate"
+                ):
+                    for sub in ast.walk(child):
+                        if (
+                            isinstance(sub, ast.AsyncFunctionDef)
+                            and sub.name == "_generate_raw"
+                        ):
+                            nested = [
+                                n for n in ast.walk(sub)
+                                if isinstance(
+                                    n,
+                                    (
+                                        ast.FunctionDef,
+                                        ast.AsyncFunctionDef,
+                                    ),
+                                )
+                                and n is not sub
+                            ]
+                            count = len(nested)
+                            assert count == 4, (
+                                f"_generate_raw has {count} nested "
+                                f"helpers after Slice 2B-ii; "
+                                f"expected exactly 4. Remaining "
+                                f"should be _stream_fanout, "
+                                f"_do_stream, "
+                                f"_stream_with_prefill_fallback, "
+                                f"_stream_with_resilience. Got: "
+                                f"{sorted(n.name for n in nested)}"
+                            )
+                            return
+
+
+def test_ast_pin_create_with_prefill_fallback_is_async_method_on_claude_provider():
+    """Slice 2B-ii extraction proof — positive presence pin (1/2).
+
+    ``_claude_create_with_prefill_fallback`` MUST exist as an
+    ``async def`` method directly under ``class ClaudeProvider``.
+    Distinct from ``@staticmethod`` (which 2B-i used for the
+    stateless retrieval callback) because this method composes
+    ``self._ensure_client()`` and may compose other ``self``
+    surfaces in future hardening (e.g. cache reasoning, route
+    stamping). Future slices that move or restructure this method
+    MUST update this pin in the same commit."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name
+                    == "_claude_create_with_prefill_fallback"
+                ):
+                    return
+            pytest.fail(
+                "ClaudeProvider._claude_create_with_prefill_fallback "
+                "not found as async method — Slice 2B-ii "
+                "extraction missing"
+            )
+    pytest.fail("ClaudeProvider class not found in providers.py")
+
+
+def test_ast_pin_create_with_resilience_is_async_method_on_claude_provider():
+    """Slice 2B-ii extraction proof — positive presence pin (2/2).
+
+    ``_claude_create_with_resilience`` MUST exist as an
+    ``async def`` method directly under ``class ClaudeProvider``.
+    Composes ``self._call_with_backoff`` (the canonical backoff
+    surface) around the prefill-fallback method."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "_claude_create_with_resilience"
+                ):
+                    return
+            pytest.fail(
+                "ClaudeProvider._claude_create_with_resilience "
+                "not found as async method — Slice 2B-ii "
+                "extraction missing"
+            )
+    pytest.fail("ClaudeProvider class not found in providers.py")
+
+
+def test_ast_pin_create_with_prefill_fallback_no_longer_nested_in_generate_raw():
+    """Slice 2B-ii extraction proof — negative absence pin (1/2).
+
+    The original nested ``async def _create_with_prefill_fallback``
+    MUST NOT exist anywhere inside ``_generate_raw``."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "generate"
+                ):
+                    for sub in ast.walk(child):
+                        if (
+                            isinstance(sub, ast.AsyncFunctionDef)
+                            and sub.name == "_generate_raw"
+                        ):
+                            for deeper in ast.walk(sub):
+                                if deeper is sub:
+                                    continue
+                                if (
+                                    isinstance(
+                                        deeper,
+                                        (
+                                            ast.FunctionDef,
+                                            ast.AsyncFunctionDef,
+                                        ),
+                                    )
+                                    and deeper.name
+                                    == "_create_with_prefill_fallback"
+                                ):
+                                    pytest.fail(
+                                        f"_create_with_prefill_"
+                                        f"fallback is still nested "
+                                        f"in _generate_raw at line "
+                                        f"{deeper.lineno} — Slice "
+                                        f"2B-ii extraction "
+                                        f"incomplete"
+                                    )
+                            return
+
+
+def test_ast_pin_create_with_resilience_no_longer_nested_in_generate_raw():
+    """Slice 2B-ii extraction proof — negative absence pin (2/2).
+
+    The original nested ``async def _create_with_resilience``
+    MUST NOT exist anywhere inside ``_generate_raw``."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "generate"
+                ):
+                    for sub in ast.walk(child):
+                        if (
+                            isinstance(sub, ast.AsyncFunctionDef)
+                            and sub.name == "_generate_raw"
+                        ):
+                            for deeper in ast.walk(sub):
+                                if deeper is sub:
+                                    continue
+                                if (
+                                    isinstance(
+                                        deeper,
+                                        (
+                                            ast.FunctionDef,
+                                            ast.AsyncFunctionDef,
+                                        ),
+                                    )
+                                    and deeper.name
+                                    == "_create_with_resilience"
+                                ):
+                                    pytest.fail(
+                                        f"_create_with_resilience "
+                                        f"is still nested in "
+                                        f"_generate_raw at line "
+                                        f"{deeper.lineno} — Slice "
+                                        f"2B-ii extraction "
+                                        f"incomplete"
+                                    )
                             return
 
 

--- a/tests/test_ouroboros_governance/test_claude_generate_raw_baseline.py
+++ b/tests/test_ouroboros_governance/test_claude_generate_raw_baseline.py
@@ -801,19 +801,40 @@ def test_ast_pin_generate_raw_calls_messages_stream_at_one_site():
 
 def test_ast_pin_generate_raw_calls_messages_create_at_two_sites():
     """PHASE_2_UPDATE: non-stream paths may consolidate or split in
-    Phase 2 — site count may change."""
-    node = _claude_generate_raw_node()
+    Phase 2 — site count may change.
+
+    Slice 2B-ii update: both ``messages.create`` call sites moved
+    OUT of ``_generate_raw`` when
+    ``_create_with_prefill_fallback`` extracted to
+    ``ClaudeProvider._claude_create_with_prefill_fallback``. The
+    contract this pin now asserts: somewhere inside the
+    ``ClaudeProvider`` class body (either the closure OR an
+    extracted ``_claude_*`` method) there exists at least one
+    ``messages.create`` reference. Future slices that move the
+    create path further MUST update this pin accordingly."""
+    import inspect as _inspect
+    from backend.core.ouroboros.governance import providers as _p
+    src = _inspect.getsource(_p.ClaudeProvider)
+    tree = ast.parse(
+        # ast.parse needs a module-level wrapper; classdef body
+        # parses fine via wrapping.
+        f"class _Wrap:\n" + "\n".join(
+            "    " + line for line in src.splitlines()
+        )
+    )
     create_sites = []
-    for sub in ast.walk(node):
-        if isinstance(sub, ast.Attribute) and sub.attr == "create":
-            if (
-                isinstance(sub.value, ast.Attribute)
-                and sub.value.attr == "messages"
-            ):
-                create_sites.append(sub.lineno)
+    for sub in ast.walk(tree):
+        if (
+            isinstance(sub, ast.Attribute)
+            and sub.attr == "create"
+            and isinstance(sub.value, ast.Attribute)
+            and sub.value.attr == "messages"
+        ):
+            create_sites.append(sub.lineno)
     assert len(create_sites) >= 1, (
-        "PHASE-1 pin: _generate_raw must contain at least one "
-        "`messages.create` reference"
+        "PHASE-1 pin (Slice 2B-ii update): ClaudeProvider must "
+        "contain at least one `messages.create` reference across "
+        "the closure OR extracted class methods"
     )
 
 
@@ -821,7 +842,16 @@ def test_ast_pin_generate_raw_has_nested_helper_functions():
     """PHASE_2_UPDATE: the 8 nested helpers (_do_stream,
     _create_with_prefill_fallback, etc.) will either be inlined,
     moved out, or restructured. Phase 1 pins that they exist as
-    closure-local helpers."""
+    closure-local helpers.
+
+    Slice 2A-iii update: ``_boundary_audit_sampler`` extracted.
+    Slice 2B-i  update: ``_retrieve_stream_exc`` extracted.
+    Slice 2B-ii update: ``_create_with_prefill_fallback`` +
+    ``_create_with_resilience`` paired-extracted to
+    ``ClaudeProvider._claude_create_with_*`` methods. This pin's
+    required-list shrinks accordingly. The remaining anchor
+    (``_do_stream``) is the heaviest nested helper and the last to
+    extract (Slice 2C-i)."""
     node = _claude_generate_raw_node()
     nested_names = set()
     for sub in ast.walk(node):
@@ -831,14 +861,10 @@ def test_ast_pin_generate_raw_has_nested_helper_functions():
         ):
             nested_names.add(sub.name)
     # We do not pin the EXACT set (over-constrains Phase 2). We pin
-    # that AT LEAST the streaming + create-prefill helpers exist.
+    # that AT LEAST the heaviest remaining helper exists.
     assert "_do_stream" in nested_names, (
         f"PHASE-1 pin: _do_stream helper missing. Found: "
         f"{sorted(nested_names)}"
-    )
-    assert "_create_with_prefill_fallback" in nested_names, (
-        f"PHASE-1 pin: _create_with_prefill_fallback helper missing. "
-        f"Found: {sorted(nested_names)}"
     )
 
 

--- a/tests/test_ouroboros_governance/test_claude_generate_raw_safety_net.py
+++ b/tests/test_ouroboros_governance/test_claude_generate_raw_safety_net.py
@@ -1594,11 +1594,22 @@ def test_ast_pin_no_provider_mutation_in_this_pr():
                             )
                             break
     assert found_size is not None
-    # Documents the closure size at safety-net time. Phase 2 will
-    # reduce this; THIS test will need a paired update at that point.
-    assert 1000 <= found_size <= 1100, (
-        f"_generate_raw size shifted: {found_size}; safety net "
-        f"assumed ~1036 lines"
+    # Documents the closure size; Phase 2 reduces this per slice and
+    # THIS test envelope updates in coordination.
+    #
+    #   safety-net @ Slice 2A-i (PR #48857): [1000, 1100] for size 1036
+    #   Slice 2A-iii (PR #48912): 1036 → 1012 (still in envelope)
+    #   Slice 2B-i   (PR #49578): 1012 → 1011 (still in envelope)
+    #   Slice 2B-ii  (this PR):   1011 →  977 — envelope retracts to
+    #                             [800, 1015] to track the per-slice
+    #                             shrinkage. Slice 2C-i (when
+    #                             _do_stream extracts) will retract
+    #                             further; this pin's floor stays low
+    #                             until Slice 2D's final tightening.
+    assert 800 <= found_size <= 1015, (
+        f"_generate_raw size shifted: {found_size}; safety-net "
+        f"envelope after Slice 2B-ii is [800, 1015] (was "
+        f"[1000, 1100] at Slice 2A-i; reduced as extractions land)"
     )
 
 


### PR DESCRIPTION
## What

Slice 2B-ii of the Claude `_generate_raw` decomposition arc — **paired extraction** of the non-streaming dispatch pair.

Both helpers move up to `ClaudeProvider` as async class methods:
- `_claude_create_with_prefill_fallback` (dispatch + prefill-rejection retry)
- `_claude_create_with_resilience` (backoff wrapper)

**Stacked on [PR #49578](https://github.com/drussell23/JARVIS/pull/49578)** (Slice 2B-i).

## Operator-mandated preflight findings

| Helper | Size | `nonlocal` | Captures from `_generate_raw` | Substrate-targeted cells |
|---|---|---|---|---|
| `_create_with_prefill_fallback` | 36 lines | NONE | `_use_prefill` (read), `_messages` (mutated via `.pop()`), `_create_kwargs` (mutated via `["timeout"]=`), `deadline`/`timeout_s` (read) | **NONE** |
| `_create_with_resilience` | 6 lines | NONE | sibling helper + `deadline` | **NONE** |

**Honest verdict** matching the operator's exact criterion ("If the helpers only touch `_messages`, `_create_kwargs`, deadline/timeout, and return `msg`, keep dispatch-state dormancy"):

**Substrate-import dormancy STAYS DORMANT for Slice 2B-ii.** Token accounting (`input_tokens` / `output_tokens` / `cached_input` / `last_msg` mutation) happens AFTER the create returns, in the surrounding `_generate_raw` body — that's the extraction that finally flips the dormancy pin (likely 2C-i when `_do_stream` extracts).

## Structural delta

| Metric | Before (2B-i on stack) | After (2B-ii) | Δ |
|---|---|---|---|
| `_generate_raw` size | 1011 lines | **977 lines** | **−34** |
| Nested helpers in closure | 6 | **4** | −2 |
| `ClaudeProvider._claude_*` extracted methods (cumulative) | 2 | **4** | +2 |
| `providers.py` SHA | `b2bfe35f...` | **`1be2caad...`** | (locked) |

Remaining nested helpers (4):
`_stream_fanout` / `_do_stream` / `_stream_with_prefill_fallback` / `_stream_with_resilience`

## Method signatures (5 explicit keyword-only params per method)

```python
async def _claude_create_with_prefill_fallback(
    self, *,
    create_kwargs: Dict[str, Any],          # mutated in place: kwargs["timeout"]
    messages: List[Dict[str, Any]],         # mutated in place: pop() on prefill reject
    use_prefill: bool,
    deadline: datetime,
    timeout_s: float,
) -> Any: ...

async def _claude_create_with_resilience(
    self, *,
    create_kwargs, messages, use_prefill, deadline, timeout_s,
) -> Any:
    async def _do_create() -> Any:          # 3-line bridge thunk to 0-arg shape
        return await self._claude_create_with_prefill_fallback(
            create_kwargs=create_kwargs, messages=messages,
            use_prefill=use_prefill, deadline=deadline, timeout_s=timeout_s,
        )
    return await self._call_with_backoff(
        _do_create, label="claude_create", deadline=deadline,
    )
```

Module-level helpers (`_remaining_utc_budget_s`, `_derive_per_request_httpx_timeout`) stay as module-level calls — no new imports.

## Byte-equivalence (operator-mandated checklist)

| Operator requirement | Preserved? |
|---|---|
| re-acquire client on every attempt via `_ensure_client()` | ✓ |
| derive live timeout from deadline before each SDK call | ✓ |
| keep prefill rejection detection identical | ✓ (`str(exc).lower()` + `"prefill"` + `use_prefill` + `len(messages) >= 2` + `messages[-1].get("role") == "assistant"`) |
| mutate/pop `_messages` exactly once on prefill retry | ✓ |
| preserve `_call_with_backoff(label="claude_create", deadline=deadline)` | ✓ |
| preserve outer `asyncio.wait_for` and timeout message OUTSIDE the helper | ✓ |
| Explicit parameters over hidden global/state coupling | ✓ (5 keyword-only params) |

## What lands

### `backend/core/ouroboros/governance/providers.py`
- 2 NEW class methods on `ClaudeProvider` (~130 lines including docstrings)
- 2 REMOVED inline `async def` helpers inside `_generate_raw` (42 lines)
- 1 UPDATED call site (now `self._claude_create_with_resilience(...)` with 5 kwargs)

### `tests/test_ouroboros_governance/test_claude_dispatch_state.py`
- UPDATED: `_PROVIDERS_SHA_LOCK` to `1be2caaddce0809910deb4e9782499da9eea4b2e` + provenance entry for 2B-ii
- UPDATED: dormancy-pin docstring (honest current state — substrate import still NOT introduced)
- RENAMED: `test_ast_pin_generate_raw_size_after_2b_i` → `..._after_2b_ii` with envelope `[965, 990]` for size 977
- NEW (×5): nested-helper-count pin, 2 positive-presence pins, 2 negative-absence pins

### Phase-1 SNAPSHOT pins updated as "directly related test metadata"

Both files contain pins explicitly documented as `PHASE_2_UPDATE` snapshots:

- `test_claude_generate_raw_baseline.py::test_ast_pin_generate_raw_calls_messages_create_at_two_sites` — contract shifts from "_generate_raw must contain >= 1 sites" to "ClaudeProvider must contain >= 1 sites across closure OR extracted class methods"
- `test_claude_generate_raw_baseline.py::test_ast_pin_generate_raw_has_nested_helper_functions` — drops `_create_with_prefill_fallback` from required-list; remaining anchor is `_do_stream`
- `test_claude_generate_raw_safety_net.py::test_ast_pin_no_provider_mutation_in_this_pr` — envelope retracts `[1000, 1100]` → `[800, 1015]` tracking per-slice shrinkage

## Green bar

| Surface | Count |
|---|---|
| Substrate (this PR's test file) | **50 passed** (was 45 in 2B-i) |
| Phase 1 baseline (PR #46868) | **33 passed + 2 xfailed** (PHASE_2_UPDATE pins updated) |
| Safety net (PR #48857) | **55 passed** (envelope pin updated for 2B-ii) |
| **Combined** | **138 passed + 2 xfailed** — zero regressions |

## Standing constraints — all held

- ✅ Touch only the two operator-scoped files + directly-related test metadata
- ✅ Zero touch of newly-deployed surfaces (evaluator_trace, session_budget, swe_bench_pro, commit_authority, DW heavy lane, OCA, sovereignty, git-index)
- ✅ No master flags introduced
- ✅ No authority imports added
- ✅ No provider spend
- ✅ Telemetry byte-equivalent (re-client / live-timeout / prefill-detect / pop-once / backoff-label all identical)
- ✅ Outer `asyncio.wait_for` + timeout-error message preserved OUTSIDE the helper
- ✅ Iron Gate respected
- ✅ Substrate dormancy honestly preserved (no cosmetic import to "make it go live")

## Slice arc status

| Slice | Status | PR |
|---|---|---|
| 2A-i (safety net) | merged | [#48857](https://github.com/drussell23/JARVIS/pull/48857) |
| 2A-ii (dormant substrate) | merged | [#48860](https://github.com/drussell23/JARVIS/pull/48860) |
| 2A-iii (`_boundary_audit_sampler`) | merged | [#48912](https://github.com/drussell23/JARVIS/pull/48912) |
| 2B-i (`_retrieve_stream_exc`) | open | [#49578](https://github.com/drussell23/JARVIS/pull/49578) |
| **2B-ii (this PR — `_create_with_*` pair)** | **shipped** | this PR |
| 2B-iii (`_stream_with_*` pair) | deferred | TBD |
| 2C-i (`_do_stream` — heaviest, 317 lines, **substrate goes live**) | deferred | TBD |
| 2C-ii (`_stream_fanout` + dispatcher shell) | deferred | TBD |
| 2D (AST-pin tightening) | deferred | TBD |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the non-stream `messages.create` path from `_generate_raw` into `ClaudeProvider` async methods for clarity and reuse, with no behavior changes. `_generate_raw` shrinks by 34 lines (1011→977); dispatch‑state substrate remains dormant.

- **Refactors**
  - Added `_claude_create_with_prefill_fallback` (prefill retry) and `_claude_create_with_resilience` (backoff).
  - Switched call site to `self._claude_create_with_resilience(...)` within the existing `asyncio.wait_for`.
  - Preserved client re-acquire, live-timeout derivation, prefill-detect + pop-once, and `label="claude_create"` backoff.
  - Reduced nested helpers in `_generate_raw` from 6 to 4; no new imports.
  - Updated tests: SHA lock, nested-helper count pin, presence/absence pins, and size envelopes.

<sup>Written for commit 1c684a03649cbcd04249711c78a3288da54de5e7. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/49606?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

