### PR TITLE
refactor(providers): extract _stream_with_*_pair — Slice 2B-iii (substrate dormancy preserved; 977→953 lines)

### DIFF
--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -28,7 +28,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 from backend.core.ouroboros.governance.op_context import (
     GenerationResult,
@@ -6674,6 +6674,140 @@ class ClaudeProvider:
             deadline=deadline,
         )
 
+    # ---------------------------------------------------------------------
+    # Slice 2B-iii — paired extraction from _generate_raw closure
+    # (streaming-path analog of the create pair that landed in 2B-ii).
+    #
+    # _claude_stream_with_prefill_fallback and
+    # _claude_stream_with_resilience are the streaming dispatch +
+    # retry pair. Preflight AST audit confirmed:
+    #
+    #   * _claude_stream_with_prefill_fallback touches ONLY:
+    #       - messages       (list — mutated via .pop() on prefill reject)
+    #       - use_prefill    (bool — read-only flag)
+    #       - do_stream_fn   (caller-supplied 0-arg async callable —
+    #                         the closure's _do_stream is passed in)
+    #
+    #   * _claude_stream_with_resilience touches ONLY the parameters
+    #       above + progress_probe (caller-supplied Callable[[], bool])
+    #       + deadline (read-only).
+    #
+    # Critical: the original ``_stream_with_resilience`` captured the
+    # closure's ``raw_content`` via ``progress_probe=lambda:
+    # bool(raw_content)``. That lambda STAYS AT THE CALL SITE inside
+    # _generate_raw — the extracted method accepts the probe as a
+    # ``Callable[[], bool]`` parameter and treats it opaquely. So
+    # neither extracted method directly touches the 5 nonlocals or
+    # 4 outer captures the _ClaudeDispatchState substrate targets —
+    # substrate-import dormancy is honestly preserved through this
+    # slice (per operator's criterion: "If the helpers only touch
+    # _messages, _create_kwargs, deadline/timeout, and return msg,
+    # keep dispatch-state dormancy").
+    #
+    # The substrate goes live in 2C-i when ``_do_stream`` extracts —
+    # that's the heavy mutator of input_tokens / output_tokens /
+    # cached_input / raw_content (4 of the 5 substrate-targeted
+    # nonlocals).
+    # ---------------------------------------------------------------------
+
+    async def _claude_stream_with_prefill_fallback(
+        self,
+        *,
+        do_stream_fn: "Callable[[], Awaitable[None]]",
+        messages: List[Dict[str, Any]],
+        use_prefill: bool,
+    ) -> None:
+        """Streaming dispatch with prefill-rejection fallback.
+
+        Behavior is byte-equivalent to the pre-extraction inline
+        ``async def _stream_with_prefill_fallback`` inside
+        ``_generate_raw``:
+
+          1. Invoke ``do_stream_fn()`` — the caller-supplied 0-arg
+             async callable that wraps the closure's ``_do_stream``
+             (still nested in ``_generate_raw`` until Slice 2C-i).
+          2. On exception, detect the prefill-rejection pattern
+             (``"prefill" in str(exc).lower()`` AND ``use_prefill``
+             AND a trailing assistant turn in ``messages``); if all
+             three hold, ``.pop()`` the trailing assistant turn and
+             retry exactly once.
+          3. Any other exception propagates.
+
+        Mutation contract — kept identical to the original:
+
+          * ``messages`` is mutated in place via ``.pop()`` on the
+            prefill retry. The caller's reference reflects the
+            popped state when this method returns.
+
+        Some model versions reject assistant message prefill even
+        when thinking is off (battle test bt-2026-04-10-073056).
+        This method's contract makes the failure graceful instead
+        of dead-op."""
+        try:
+            await do_stream_fn()
+        except Exception as _exc:
+            _msg = str(_exc).lower()
+            # Anthropic returns BadRequestError subclassed from
+            # APIStatusError; we match on the message signature to
+            # avoid importing the SDK class conditionally.
+            if (
+                use_prefill
+                and "prefill" in _msg
+                and len(messages) >= 2
+                and messages[-1].get("role") == "assistant"
+            ):
+                logger.warning(
+                    "[ClaudeProvider] prefill rejected by model "
+                    "(%s) — retrying without assistant prefill",
+                    type(_exc).__name__,
+                )
+                # Strip the assistant prefill and retry in-place.
+                # do_stream_fn reads messages from the caller's scope,
+                # so modifying the list is visible on retry.
+                messages.pop()
+                await do_stream_fn()
+            else:
+                raise
+
+    async def _claude_stream_with_resilience(
+        self,
+        *,
+        do_stream_fn: "Callable[[], Awaitable[None]]",
+        messages: List[Dict[str, Any]],
+        use_prefill: bool,
+        progress_probe: "Callable[[], bool]",
+        deadline: datetime,
+    ) -> None:
+        """Streaming dispatch with prefill fallback + backoff retry.
+
+        Composes :meth:`_claude_stream_with_prefill_fallback` inside
+        :meth:`_call_with_backoff`. ``progress_probe`` is passed
+        opaquely to the backoff helper — the caller (inside
+        ``_generate_raw``) constructs it as a closure over the
+        ``raw_content`` nonlocal so the backoff can decide whether
+        any partial content has emitted before considering a retry
+        (do-not-retry-after-partial-output discipline).
+
+        The inner ``_do_prefill`` thunk bridges from this method's
+        keyword-only signature to the 0-arg async-callable shape
+        :meth:`_call_with_backoff` requires (``fn: Callable[[],
+        Awaitable[Any]]``). Mirrors the pre-extraction pattern
+        exactly (the original had a nested ``async def
+        _stream_with_resilience`` whose body did the same
+        pass-through)."""
+        async def _do_prefill() -> None:
+            await self._claude_stream_with_prefill_fallback(
+                do_stream_fn=do_stream_fn,
+                messages=messages,
+                use_prefill=use_prefill,
+            )
+        await self._call_with_backoff(
+            _do_prefill,
+            label="claude_stream",
+            progress_probe=progress_probe,
+            deadline=deadline,
+        )
+
     async def generate(
         self,
         context: OperationContext,
@@ -7411,52 +7545,20 @@ class ClaudeProvider:
                         except (TypeError, ValueError):
                             _cached_input = 0
 
-                async def _stream_with_prefill_fallback() -> None:
-                    """Run _do_stream; on prefill-rejection 400, strip the
-                    prefill and retry once. Some model versions reject
-                    assistant message prefill even when thinking is off
-                    (battle test bt-2026-04-10-073056). This makes the
-                    failure graceful instead of dead-op.
-                    """
-                    try:
-                        await _do_stream()
-                    except Exception as _exc:
-                        _msg = str(_exc).lower()
-                        # Anthropic returns BadRequestError subclassed from
-                        # APIStatusError; we match on the message signature
-                        # to avoid importing the SDK class conditionally.
-                        if (
-                            _use_prefill
-                            and "prefill" in _msg
-                            and len(_messages) >= 2
-                            and _messages[-1].get("role") == "assistant"
-                        ):
-                            logger.warning(
-                                "[ClaudeProvider] prefill rejected by model "
-                                "(%s) — retrying without assistant prefill",
-                                type(_exc).__name__,
-                            )
-                            # Strip the assistant prefill and retry in-place.
-                            # _do_stream reads _messages from enclosing scope,
-                            # so modifying the list is visible on retry.
-                            _messages.pop()
-                            await _do_stream()
-                        else:
-                            raise
-
-                # Reinforced transport: wrap the prefill-fallback in an
-                # exponential-backoff retry. Only retries when no tokens
-                # have streamed yet (progress_probe) — mid-stream failures
-                # are fatal because re-running would duplicate output.
-                # Deadline propagates so the backoff respects the remaining
-                # generation budget (Task #4 cascade hardening).
-                async def _stream_with_resilience() -> None:
-                    await self._call_with_backoff(
-                        _stream_with_prefill_fallback,
-                        label="claude_stream",
-                        progress_probe=lambda: bool(raw_content),
-                        deadline=deadline,
-                    )
+                # Slice 2B-iii — the inline stream-pair was extracted to
+                # ClaudeProvider._claude_stream_with_prefill_fallback +
+                # ClaudeProvider._claude_stream_with_resilience class
+                # methods. Reinforced transport: wraps the prefill-
+                # fallback in an exponential-backoff retry, retrying
+                # only when no tokens have streamed yet (progress_probe)
+                # — mid-stream failures are fatal because re-running
+                # would duplicate output. Deadline propagates so the
+                # backoff respects the remaining generation budget
+                # (Task #4 cascade hardening). The progress_probe
+                # lambda STAYS HERE in the closure scope — it captures
+                # ``raw_content`` (a substrate-targeted nonlocal); the
+                # extracted method accepts it opaquely as a
+                # ``Callable[[], bool]`` parameter.
 
                 # Hard-kill wrapper (Option C — Manifesto §3 Disciplined
                 # Concurrency, Derek 2026-04-18). Session 13
@@ -7480,7 +7582,15 @@ class ClaudeProvider:
                 _hard_kill_budget_s = (
                     _soft_wall_rem + _CLAUDE_STREAM_HARD_KILL_GRACE_S
                 )
-                _stream_task = asyncio.create_task(_stream_with_resilience())
+                _stream_task = asyncio.create_task(
+                    self._claude_stream_with_resilience(
+                        do_stream_fn=_do_stream,
+                        messages=_messages,
+                        use_prefill=_use_prefill,
+                        progress_probe=lambda: bool(raw_content),
+                        deadline=deadline,
+                    ),
+                )
 
                 # Hygiene: retrieve the task's exception even on the
                 # paths that abandon it without `await _stream_task`

--- a/tests/test_ouroboros_governance/test_claude_dispatch_state.py
+++ b/tests/test_ouroboros_governance/test_claude_dispatch_state.py
@@ -59,28 +59,33 @@ _PROVIDERS_FILE = Path(
 # ``test_ast_pin_providers_file_sha_matches_lock`` tracks the
 # provenance of each successive update.
 #
-# Slice 2A-ii   (PR #48860): a33f9fb67fdcf8e10f8e47fbd3a6b8075aea8a7d
-#                            (providers.py byte-identical to main)
-# Slice 2A-iii  (PR #48912): d3e409ce032ae3954dbd98d0102682fef968206b
-#                            (_boundary_audit_sampler extracted as
-#                            ClaudeProvider class method; closure
-#                            1036 → 1012 lines, 8 → 7 nested helpers)
-# Slice 2B-i    (PR #49578): b2bfe35fe831786e71c56e371f2870fa6b62928d
-#                            (_retrieve_stream_exc extracted as
-#                            ClaudeProvider @staticmethod; closure
-#                            1012 → 1011 lines, 7 → 6 nested helpers)
-# Slice 2B-ii   (this PR):   1be2caaddce0809910deb4e9782499da9eea4b2e
-#                            (_create_with_prefill_fallback +
-#                            _create_with_resilience PAIRED extracted
-#                            as ClaudeProvider async class methods;
-#                            closure 1011 → 977 lines (-34),
-#                            6 → 4 nested helpers. Substrate-import
-#                            dormancy preserved: AST preflight
-#                            confirmed neither helper touches the
-#                            5 nonlocals or 4 outer captures the
-#                            _ClaudeDispatchState substrate targets.)
+# Slice 2A-ii    (PR #48860): a33f9fb67fdcf8e10f8e47fbd3a6b8075aea8a7d
+#                             (providers.py byte-identical to main)
+# Slice 2A-iii   (PR #48912): d3e409ce032ae3954dbd98d0102682fef968206b
+#                             (_boundary_audit_sampler extracted; closure
+#                             1036 → 1012 lines, 8 → 7 nested helpers)
+# Slice 2B-i     (PR #49578): b2bfe35fe831786e71c56e371f2870fa6b62928d
+#                             (_retrieve_stream_exc extracted as
+#                             @staticmethod; closure 1012 → 1011 lines,
+#                             7 → 6 nested helpers)
+# Slice 2B-ii    (PR #49606): 1be2caaddce0809910deb4e9782499da9eea4b2e
+#                             (_create_with_prefill_fallback +
+#                             _create_with_resilience PAIRED extracted;
+#                             closure 1011 → 977 lines (-34),
+#                             6 → 4 nested helpers)
+# Slice 2B-iii   (this PR):   12e0e0f314d8370918858c38d667601c91aa0130
+#                             (_stream_with_prefill_fallback +
+#                             _stream_with_resilience PAIRED extracted
+#                             as ClaudeProvider async class methods;
+#                             closure 977 → 953 lines (-24), 4 → 2
+#                             nested helpers. Substrate-import dormancy
+#                             preserved: the progress_probe lambda
+#                             over raw_content stays at the call site
+#                             inside _generate_raw; the extracted
+#                             method accepts the probe as an opaque
+#                             Callable[[], bool] parameter.)
 _PROVIDERS_SHA_LOCK = (
-    "1be2caaddce0809910deb4e9782499da9eea4b2e"
+    "12e0e0f314d8370918858c38d667601c91aa0130"
 )
 
 
@@ -469,24 +474,35 @@ def test_ast_pin_providers_does_not_import_dispatch_state_yet():
     hygiene callback (``@staticmethod``, zero captures, zero
     ``nonlocal``).
 
-    Slice 2B-ii (this slice) extracted the
+    Slice 2B-ii extracted the
     ``_create_with_prefill_fallback`` + ``_create_with_resilience``
-    pair. AST preflight CONFIRMED neither helper touches
-    ``input_tokens`` / ``output_tokens`` / ``cached_input`` /
-    ``raw_content`` / ``total_cost`` / ``last_msg`` /
-    ``first_token_ms`` / ``thinking_reason_out`` / ``token_usage``.
-    The pair mutates only ``_messages`` (list ``.pop()``) and
-    ``_create_kwargs`` (dict ``["timeout"] = ...``) — both are
-    sub-helper bookkeeping, not the substrate's frozen 8-field
-    taxonomy. Token accounting happens AFTER the create returns,
-    in the surrounding ``_generate_raw`` body — that's the
-    extraction that finally flips this pin (likely 2C-i when
+    pair. AST preflight CONFIRMED neither helper touches the
+    substrate-targeted cells; pair mutates only ``_messages``
+    (list ``.pop()``) and ``_create_kwargs`` (dict
+    ``["timeout"] = ...``).
+
+    Slice 2B-iii (this slice) extracted the
+    ``_stream_with_prefill_fallback`` + ``_stream_with_resilience``
+    pair — the streaming-path analog. AST preflight surfaced ONE
+    nuance: ``_stream_with_resilience`` carried
+    ``progress_probe=lambda: bool(raw_content)`` which READS
+    ``raw_content`` (a substrate-targeted nonlocal). The extraction
+    resolves this honestly: the lambda STAYS AT THE CALL SITE
+    inside ``_generate_raw``, and the extracted method accepts the
+    probe as an opaque ``Callable[[], bool]`` parameter. So the
+    extracted method itself does NOT touch any substrate-targeted
+    cell.
+
+    Token accounting (input_tokens / output_tokens / cached_input
+    / raw_content MUTATION / last_msg) happens INSIDE ``_do_stream``
+    and in the post-stream body of ``_generate_raw`` — that's the
+    extraction that finally flips this pin (Slice 2C-i when
     ``_do_stream`` extracts, since it mutates four of the five
     nonlocals).
 
     The substrate-import dormancy pin therefore HOLDS across
-    Slices 2A-iii / 2B-i / 2B-ii — the substrate exists, its
-    45-test green bar exists, but no caller imports it. The
+    Slices 2A-iii / 2B-i / 2B-ii / 2B-iii — the substrate exists,
+    its 50-test green bar exists, but no caller imports it. The
     dataclass + accumulator stay genuinely unused until a
     STATEFUL extraction proves the substrate's design lock-step
     with reality."""
@@ -664,17 +680,18 @@ def test_ast_pin_boundary_audit_sampler_no_longer_nested_in_generate_raw():
     # later slices will need to update this pin.
 
 
-def test_ast_pin_generate_raw_size_after_2b_ii():
+def test_ast_pin_generate_raw_size_after_2b_iii():
     """Per-slice closure-size envelope. Tightened on each slice that
     actually shrinks ``_generate_raw``.
 
     Slice 2A-iii (PR #48912) opened at [950, 1025] for size 1012.
     Slice 2B-i   (PR #49578) tightened to [1000, 1015] for size 1011.
-    Slice 2B-ii  (this PR) shrinks 1011 → 977 by extracting the
-    paired create-path helpers (``_create_with_prefill_fallback``
-    36 lines + ``_create_with_resilience`` 6 lines + their blank +
-    call-site rewrite → net −34 inside the closure). Envelope
-    tightens to [965, 990]: floor protects against accidental
+    Slice 2B-ii  (PR #49606) tightened to [965, 990] for size 977.
+    Slice 2B-iii (this PR) shrinks 977 → 953 by extracting the
+    paired stream-path helpers (``_stream_with_prefill_fallback``
+    32 lines + ``_stream_with_resilience`` 7 lines + their blanks +
+    call-site rewrite → net −24 inside the closure). Envelope
+    tightens to [940, 965]: floor protects against accidental
     over-extraction; ceiling protects against accidental re-bloat.
     Each future slice re-tightens this in-place."""
     tree = _load_module_ast(_PROVIDERS_FILE)
@@ -696,24 +713,25 @@ def test_ast_pin_generate_raw_size_after_2b_ii():
                             size = (
                                 sub.end_lineno - sub.lineno + 1
                             )
-                            assert 965 <= size <= 990, (
+                            assert 940 <= size <= 965, (
                                 f"_generate_raw size after Slice "
-                                f"2B-ii is {size}; expected window "
-                                f"[965, 990]. If this slice "
+                                f"2B-iii is {size}; expected window "
+                                f"[940, 965]. If this slice "
                                 f"intentionally moved more, update "
                                 f"the envelope."
                             )
                             return
 
 
-def test_ast_pin_generate_raw_nested_helper_count_after_2b_ii():
-    """Per-slice nested-helper-count envelope. Slice 2B-ii drops
-    the count from 6 → 4 (both ``_create_with_*`` extracted).
+def test_ast_pin_generate_raw_nested_helper_count_after_2b_iii():
+    """Per-slice nested-helper-count envelope. Slice 2B-iii drops
+    the count from 4 → 2 (both ``_stream_with_*`` extracted).
 
-    Remaining nested helpers (4): ``_stream_fanout``,
-    ``_do_stream``, ``_stream_with_prefill_fallback``,
-    ``_stream_with_resilience``. Each subsequent slice removes
-    at least one entry; this pin is updated in-place."""
+    Remaining nested helpers (2): ``_stream_fanout``, ``_do_stream``.
+    ``_do_stream`` is the heavy mutator (4 nonlocals across 317
+    lines) — its extraction (Slice 2C-i) is the slice that finally
+    flips the substrate-import dormancy pin. ``_stream_fanout`` is
+    a tiny 9-line helper that extracts alongside 2C-i or in 2C-ii."""
     tree = _load_module_ast(_PROVIDERS_FILE)
     for node in ast.walk(tree):
         if (
@@ -742,16 +760,164 @@ def test_ast_pin_generate_raw_nested_helper_count_after_2b_ii():
                                 and n is not sub
                             ]
                             count = len(nested)
-                            assert count == 4, (
+                            assert count == 2, (
                                 f"_generate_raw has {count} nested "
-                                f"helpers after Slice 2B-ii; "
-                                f"expected exactly 4. Remaining "
-                                f"should be _stream_fanout, "
-                                f"_do_stream, "
-                                f"_stream_with_prefill_fallback, "
-                                f"_stream_with_resilience. Got: "
+                                f"helpers after Slice 2B-iii; "
+                                f"expected exactly 2. Remaining "
+                                f"should be _stream_fanout + "
+                                f"_do_stream. Got: "
                                 f"{sorted(n.name for n in nested)}"
                             )
+                            return
+
+
+def test_ast_pin_stream_with_prefill_fallback_is_async_method_on_claude_provider():
+    """Slice 2B-iii extraction proof — positive presence pin (1/2).
+
+    ``_claude_stream_with_prefill_fallback`` MUST exist as an
+    ``async def`` method directly under ``class ClaudeProvider``.
+    Accepts ``do_stream_fn`` as a caller-supplied 0-arg async
+    callable; the closure's ``_do_stream`` is passed in (still
+    nested in ``_generate_raw`` until Slice 2C-i)."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name
+                    == "_claude_stream_with_prefill_fallback"
+                ):
+                    return
+            pytest.fail(
+                "ClaudeProvider._claude_stream_with_prefill_fallback "
+                "not found as async method — Slice 2B-iii "
+                "extraction missing"
+            )
+    pytest.fail("ClaudeProvider class not found in providers.py")
+
+
+def test_ast_pin_stream_with_resilience_is_async_method_on_claude_provider():
+    """Slice 2B-iii extraction proof — positive presence pin (2/2).
+
+    ``_claude_stream_with_resilience`` MUST exist as an
+    ``async def`` method directly under ``class ClaudeProvider``.
+    Accepts a ``progress_probe: Callable[[], bool]`` parameter
+    that the caller constructs as a lambda over the closure's
+    ``raw_content`` nonlocal — the extracted method itself does
+    not touch any substrate-targeted cell."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "_claude_stream_with_resilience"
+                ):
+                    return
+            pytest.fail(
+                "ClaudeProvider._claude_stream_with_resilience "
+                "not found as async method — Slice 2B-iii "
+                "extraction missing"
+            )
+    pytest.fail("ClaudeProvider class not found in providers.py")
+
+
+def test_ast_pin_stream_with_prefill_fallback_no_longer_nested_in_generate_raw():
+    """Slice 2B-iii extraction proof — negative absence pin (1/2).
+
+    The original nested ``async def _stream_with_prefill_fallback``
+    MUST NOT exist anywhere inside ``_generate_raw``."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "generate"
+                ):
+                    for sub in ast.walk(child):
+                        if (
+                            isinstance(sub, ast.AsyncFunctionDef)
+                            and sub.name == "_generate_raw"
+                        ):
+                            for deeper in ast.walk(sub):
+                                if deeper is sub:
+                                    continue
+                                if (
+                                    isinstance(
+                                        deeper,
+                                        (
+                                            ast.FunctionDef,
+                                            ast.AsyncFunctionDef,
+                                        ),
+                                    )
+                                    and deeper.name
+                                    == "_stream_with_prefill_fallback"
+                                ):
+                                    pytest.fail(
+                                        f"_stream_with_prefill_"
+                                        f"fallback is still nested "
+                                        f"in _generate_raw at line "
+                                        f"{deeper.lineno} — Slice "
+                                        f"2B-iii extraction "
+                                        f"incomplete"
+                                    )
+                            return
+
+
+def test_ast_pin_stream_with_resilience_no_longer_nested_in_generate_raw():
+    """Slice 2B-iii extraction proof — negative absence pin (2/2).
+
+    The original nested ``async def _stream_with_resilience``
+    MUST NOT exist anywhere inside ``_generate_raw``."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "generate"
+                ):
+                    for sub in ast.walk(child):
+                        if (
+                            isinstance(sub, ast.AsyncFunctionDef)
+                            and sub.name == "_generate_raw"
+                        ):
+                            for deeper in ast.walk(sub):
+                                if deeper is sub:
+                                    continue
+                                if (
+                                    isinstance(
+                                        deeper,
+                                        (
+                                            ast.FunctionDef,
+                                            ast.AsyncFunctionDef,
+                                        ),
+                                    )
+                                    and deeper.name
+                                    == "_stream_with_resilience"
+                                ):
+                                    pytest.fail(
+                                        f"_stream_with_resilience "
+                                        f"is still nested in "
+                                        f"_generate_raw at line "
+                                        f"{deeper.lineno} — Slice "
+                                        f"2B-iii extraction "
+                                        f"incomplete"
+                                    )
                             return
 
 


### PR DESCRIPTION
## What

Slice 2B-iii of the Claude `_generate_raw` decomposition arc — **paired extraction of the streaming dispatch pair**. The streaming-path analog of the create-pair that landed in 2B-ii.

Both helpers move up to `ClaudeProvider` as async class methods:
- `_claude_stream_with_prefill_fallback` (wraps the closure's `_do_stream` with prefill-rejection 400 + one-shot retry)
- `_claude_stream_with_resilience` (backoff wrapper)

**Branched off main** at `de794b9be2` (post-2B-ii merge state).

## Operator-mandated preflight findings

| Helper | Size | Captures | Substrate-targeted cells |
|---|---|---|---|
| `_stream_with_prefill_fallback` | 32 lines | `_do_stream`, `_messages`, `_use_prefill` | **NONE** |
| `_stream_with_resilience` | 7 lines | `_stream_with_prefill_fallback`, `deadline`, **`raw_content`** | `raw_content` (READ via `progress_probe` lambda) |

**One nuance** (surfaced honestly, not glossed over): `_stream_with_resilience` carried `progress_probe=lambda: bool(raw_content)` — the lambda READS `raw_content` (one of the 5 substrate-targeted nonlocals).

**Resolution**: the lambda **stays AT THE CALL SITE** inside `_generate_raw`. The extracted method accepts `progress_probe` as an opaque `Callable[[], bool]` parameter. So the extracted method itself does NOT directly touch any substrate-targeted cell. **Substrate-import dormancy STAYS DORMANT for Slice 2B-iii.**

The token-accounting MUTATION of `raw_content` / `input_tokens` / `output_tokens` / `cached_input` / `last_msg` happens inside `_do_stream` (still nested, ~317 lines) and in the post-stream body of `_generate_raw`. Those extractions (Slice 2C-i) are where the substrate finally goes live.

## Method signatures (5 explicit keyword-only params per method)

```python
async def _claude_stream_with_prefill_fallback(
    self, *,
    do_stream_fn: Callable[[], Awaitable[None]],
    messages: List[Dict[str, Any]],         # mutated in place: pop() on prefill reject
    use_prefill: bool,
) -> None: ...

async def _claude_stream_with_resilience(
    self, *,
    do_stream_fn, messages, use_prefill,
    progress_probe: Callable[[], bool],     # caller constructs lambda over raw_content
    deadline,
) -> None:
    async def _do_prefill() -> None:         # inside class method, NOT _generate_raw
        await self._claude_stream_with_prefill_fallback(
            do_stream_fn=do_stream_fn, messages=messages, use_prefill=use_prefill,
        )
    await self._call_with_backoff(
        _do_prefill, label="claude_stream",
        progress_probe=progress_probe, deadline=deadline,
    )
```

Call site (inside `_generate_raw`) — single `asyncio.create_task` with lambda over `raw_content`:

```python
_stream_task = asyncio.create_task(
    self._claude_stream_with_resilience(
        do_stream_fn=_do_stream,
        messages=_messages,
        use_prefill=_use_prefill,
        progress_probe=lambda: bool(raw_content),  # closure capture preserved at call site
        deadline=deadline,
    ),
)
```

## Structural delta

| Metric | Before (2B-ii on main) | After (2B-iii) | Δ |
|---|---|---|---|
| `_generate_raw` size | 977 lines | **953 lines** | **−24** |
| Nested helpers in closure | 4 | **2** | **−2** |
| `ClaudeProvider._claude_*` methods (cumulative) | 4 | **6** | +2 |
| `providers.py` SHA | `1be2caad...` | **`12e0e0f3...`** | (locked) |

Remaining nested helpers (2):
`_stream_fanout` (9 lines — small) + `_do_stream` (317 lines — the heavy mutator; extracts in 2C-i)

## Byte-equivalence

| Behavior | Pre | Post |
|---|---|---|
| Re-acquire client per attempt (in `_do_stream`) | preserved | preserved (caller-supplied `do_stream_fn` is the closure's `_do_stream`, unchanged) |
| Prefill-rejection detection | `"prefill" in str(exc).lower()` + `_use_prefill` + `len(_messages) >= 2` + role==assistant | (identical, on `messages` param) |
| `_messages.pop()` + retry-once | preserved | `messages.pop()` (caller's list mutated in place) |
| `_call_with_backoff(label="claude_stream", progress_probe=..., deadline=...)` | preserved | preserved |
| `progress_probe=lambda: bool(raw_content)` | captures from closure | constructed at call site, passed opaquely |
| Hard-kill wrapper / asyncio.wait timeout / soft+hard budget | OUTSIDE the helper | UNCHANGED (still at call-site layer) |

## What lands

### `backend/core/ouroboros/governance/providers.py`
- `typing.Awaitable` added to imports
- 2 NEW class methods (~135 lines including docstrings)
- 2 REMOVED inline `async def` helpers inside `_generate_raw` (39 lines)
- 1 UPDATED `asyncio.create_task` call site (now invokes `self._claude_stream_with_resilience(...)`)

### `tests/test_ouroboros_governance/test_claude_dispatch_state.py`
- UPDATED: `_PROVIDERS_SHA_LOCK` to `12e0e0f314d8370918858c38d667601c91aa0130` + provenance entry
- UPDATED: dormancy-pin docstring (honest current state — progress_probe nuance documented)
- RENAMED: `test_ast_pin_generate_raw_size_after_2b_ii` → `..._after_2b_iii` with envelope `[940, 965]` for size 953
- RENAMED: `test_ast_pin_generate_raw_nested_helper_count_after_2b_ii` → `..._after_2b_iii` with expected count **2**
- NEW (×4): 2 positive-presence pins, 2 negative-absence pins

(Safety-net envelope from 2B-ii's `[800, 1015]` still accommodates size 953 — no further safety-net / baseline-pin update needed in this slice.)

## Green bar

| Surface | Count |
|---|---|
| Substrate (this PR's test file) | **54 passed** (was 50 in 2B-ii) |
| Phase 1 baseline (PR #46868) | **33 passed + 2 xfailed** (unchanged) |
| Safety net (PR #48857) | **55 passed** (envelope still accommodates size 953) |
| **Combined** | **142 passed + 2 xfailed** — zero regressions |

## Standing constraints — all held

- ✅ Zero touch of newly-deployed surfaces (evaluator_trace, session_budget, swe_bench_pro, commit_authority, DW heavy lane, OCA, sovereignty, git-index) — AST-pin enforced
- ✅ No master flags introduced
- ✅ No authority imports added
- ✅ No provider spend
- ✅ Telemetry byte-equivalent (prefill-detect / pop-once / backoff-label / progress_probe semantics all identical)
- ✅ Outer `asyncio.wait_for` + timeout-error message preserved OUTSIDE the helper
- ✅ Hard-kill wrapper / SIGKILL discipline preserved at call-site layer
- ✅ Substrate dormancy honestly preserved — no cosmetic import to "make it go live"; `progress_probe` is an opaque callable param, not a state access

## Slice arc status

| Slice | Status | PR |
|---|---|---|
| 2A-i (safety net) | merged | [#48857](https://github.com/drussell23/JARVIS/pull/48857) |
| 2A-ii (dormant substrate) | merged | [#48860](https://github.com/drussell23/JARVIS/pull/48860) |
| 2A-iii (`_boundary_audit_sampler`) | merged | [#48912](https://github.com/drussell23/JARVIS/pull/48912) |
| 2B-i (`_retrieve_stream_exc`) | merged | [#49578](https://github.com/drussell23/JARVIS/pull/49578) |
| 2B-ii (`_create_with_*` pair) | merged | [#49606](https://github.com/drussell23/JARVIS/pull/49606) |
| **2B-iii (this PR — `_stream_with_*` pair)** | **shipped** | this PR |
| 2C-i (`_do_stream` — heaviest, **substrate goes live**) | deferred | TBD |
| 2C-ii (`_stream_fanout` + dispatcher shell) | deferred | TBD |
| 2D (AST-pin tightening) | deferred | TBD |

## What Phase 2C-i inherits

When `_do_stream` extracts (the heaviest helper, ~317 lines, mutates 4 of the 5 substrate-targeted nonlocals):
- 142-test green bar stays green
- SHA lock updates + provenance line for Slice 2C-i
- **The substrate-import dormancy pin FINALLY FLIPS** — `_do_stream` is the primary mutator of `raw_content` / `input_tokens` / `output_tokens` / `cached_input`. The `_ClaudeDispatchState` substrate becomes a live consumer for the first time.
- Closure size expected `~600 lines` after 2C-i (the heaviest cut of the entire arc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the streaming dispatch pair from `_generate_raw` into `ClaudeProvider` async methods to simplify the closure with no behavior changes. Keeps substrate dormancy; the `progress_probe` lambda stays at the call site.

- **Refactors**
  - Moved `_stream_with_prefill_fallback` and `_stream_with_resilience` to `ClaudeProvider` as `_claude_stream_with_prefill_fallback` and `_claude_stream_with_resilience`.
  - Signatures accept `do_stream_fn`, `messages`, `use_prefill`; resilience also takes `progress_probe` and `deadline` (probe is provided by the caller as `lambda: bool(raw_content)`).
  - Call site now uses `asyncio.create_task(self._claude_stream_with_resilience(...))`.
  - Behavior unchanged: same prefill rejection detection and single retry via `messages.pop()`, same `_call_with_backoff(label="claude_stream", ...)`. Outer timeout and hard-kill logic remain at the call site.
  - Structure: `_generate_raw` shrinks 977 → 953 lines; nested helpers drop 4 → 2 (remaining: `_stream_fanout`, `_do_stream`).
  - Added `Awaitable` to `typing` imports.
  - Tests updated: provider SHA lock, size/helper-count pins adjusted, and presence/absence pins added for the new methods.

<sup>Written for commit a3b79b729e144be1e58e5b46ec7b3c54ec7cd2d6. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/49641?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

