### PR TITLE
refactor(providers): extract _stream_fanout — Slice 2C-ii (closure structurally clean; 0 nested helpers)

### DIFF
--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -7151,6 +7151,71 @@ class ClaudeProvider:
             except (TypeError, ValueError):
                 state.cached_input = 0
 
+    # ---------------------------------------------------------------------
+    # Slice 2C-ii — extract _stream_fanout (the last nested helper).
+    #
+    # _claude_make_stream_fanout is a factory @staticmethod that, given
+    # two per-text callbacks (tool-loop's on_token + the operator-visible
+    # StreamRenderer's on_token, or the Slice-7 ReasoningStream proxy),
+    # returns a single callable that fans the token text to BOTH with
+    # per-call exception swallow.
+    #
+    # Pre-extraction, this was a nested ``def _stream_fanout(text)``
+    # inline-defined inside ``_generate_raw`` under the
+    # ``if _tool_cb is not None and _render_cb is not None:`` branch
+    # of the stream-callback resolution block. The closure captured
+    # _tool_cb + _render_cb from its enclosing scope.
+    #
+    # Post-extraction:
+    #   * The factory is a @staticmethod (zero self usage); the
+    #     returned closure captures tool_cb + render_cb from the
+    #     factory's parameter scope, not from _generate_raw.
+    #   * _generate_raw's nested-helper count drops 1 → 0 — the
+    #     closure is now structurally clean of inner def's at its
+    #     own scope (a small residual inner closure lives inside
+    #     this @staticmethod, but it's scoped to the factory's body,
+    #     not _generate_raw's).
+    #   * Stream callback resolution branches are byte-equivalent:
+    #     when both callbacks exist, use the factory; otherwise
+    #     pass through to whichever single callback exists, or None.
+    # ---------------------------------------------------------------------
+
+    @staticmethod
+    def _claude_make_stream_fanout(
+        tool_cb: Callable[[str], None],
+        render_cb: Callable[[str], None],
+    ) -> Callable[[str], None]:
+        """Build a stream callback that fans token text to BOTH the
+        tool-loop and the render path with per-call exception swallow.
+
+        Behavior is byte-equivalent to the pre-extraction nested
+        ``def _stream_fanout(text)`` closure inside ``_generate_raw``:
+
+          * Invoke ``tool_cb(text)`` wrapped in try/except — failure
+            does not block the render path.
+          * Invoke ``render_cb(text)`` wrapped in try/except — failure
+            does not break the stream consumer.
+
+        Both swallows are deliberately broad ``except Exception`` —
+        a buggy on_token must NOT tear down a live stream. Matches
+        the closure's existing contract.
+
+        Used only when BOTH ``tool_cb`` and ``render_cb`` are non-None
+        (a tool-loop round with an operator watching). When only one
+        callback exists the caller selects it directly; when neither
+        exists the caller falls through to the non-streaming
+        create() path."""
+        def _fanout(text: str) -> None:
+            try:
+                tool_cb(text)
+            except Exception:
+                pass
+            try:
+                render_cb(text)
+            except Exception:
+                pass
+        return _fanout
+
     async def generate(
         self,
         context: OperationContext,
@@ -7473,17 +7538,14 @@ class ClaudeProvider:
             except Exception:  # noqa: BLE001 — defensive fallback
                 pass
 
+            # Slice 2C-ii — the inline _stream_fanout closure was
+            # extracted to ClaudeProvider._claude_make_stream_fanout as
+            # a @staticmethod factory. Per-call swallow semantics
+            # preserved exactly.
             if _tool_cb is not None and _render_cb is not None:
-                def _stream_fanout(text: str) -> None:
-                    try:
-                        _tool_cb(text)
-                    except Exception:
-                        pass
-                    try:
-                        _render_cb(text)
-                    except Exception:
-                        pass
-                _stream_callback = _stream_fanout
+                _stream_callback = self._claude_make_stream_fanout(
+                    _tool_cb, _render_cb,
+                )
             elif _tool_cb is not None:
                 _stream_callback = _tool_cb
             elif _render_cb is not None:

--- a/tests/test_ouroboros_governance/test_claude_dispatch_state.py
+++ b/tests/test_ouroboros_governance/test_claude_dispatch_state.py
@@ -77,18 +77,20 @@ _PROVIDERS_FILE = Path(
 #                             (_stream_with_prefill_fallback +
 #                             _stream_with_resilience PAIRED extracted;
 #                             closure 977 → 953 lines, 4 → 2 nested)
-# Slice 2C-i     (this PR):   42ba72372c7024d61c7f545c7c9994eccea774f5
-#                             (_do_stream extracted as ClaudeProvider
-#                             ._claude_do_stream(state, ctx) — the
-#                             heaviest cut. Closure 953 → 712 lines
-#                             (-241), 2 → 1 nested helpers. SUBSTRATE
-#                             GOES LIVE: providers.py now imports
-#                             _ClaudeDispatchState + _ClaudeStreamContext;
-#                             the dormancy AST pin is DELIBERATELY
-#                             FLIPPED in this same commit to a
-#                             positive-presence import pin.)
+# Slice 2C-i     (PR #49833): 42ba72372c7024d61c7f545c7c9994eccea774f5
+#                             (_do_stream extracted; closure 953 →
+#                             712, 2 → 1 nested; SUBSTRATE WENT LIVE)
+# Slice 2C-ii    (this PR):   1090feb3734a4e235cc40a947da5026e13dfeca5
+#                             (_stream_fanout extracted as
+#                             ClaudeProvider._claude_make_stream_fanout
+#                             @staticmethod factory; closure 712 → 709
+#                             (-3), 1 → 0 nested helpers. _generate_raw
+#                             is now structurally clean of nested
+#                             defs — the closure-extraction phase of
+#                             the arc is COMPLETE. 8 _claude_* class
+#                             methods extracted cumulatively.)
 _PROVIDERS_SHA_LOCK = (
-    "42ba72372c7024d61c7f545c7c9994eccea774f5"
+    "1090feb3734a4e235cc40a947da5026e13dfeca5"
 )
 
 
@@ -669,7 +671,7 @@ def test_ast_pin_boundary_audit_sampler_no_longer_nested_in_generate_raw():
     # later slices will need to update this pin.
 
 
-def test_ast_pin_generate_raw_size_after_2c_i():
+def test_ast_pin_generate_raw_size_after_2c_ii():
     """Per-slice closure-size envelope. Tightened on each slice that
     actually shrinks ``_generate_raw``.
 
@@ -677,13 +679,13 @@ def test_ast_pin_generate_raw_size_after_2c_i():
     Slice 2B-i   (PR #49578) tightened to [1000, 1015] for size 1011.
     Slice 2B-ii  (PR #49606) tightened to [965, 990] for size 977.
     Slice 2B-iii (PR #49641) tightened to [940, 965] for size 953.
-    Slice 2C-i (this PR) is the HEAVIEST CUT of the arc: 953 → 712
-    (-241) by extracting the 317-line ``_do_stream`` helper to the
-    ``_claude_do_stream`` class method (offset by ~70 lines of new
-    state+ctx construction, boundary translation, and call-site
-    rewrite). Envelope tightens to [690, 740]: floor protects
-    against accidental over-extraction; ceiling protects against
-    accidental re-bloat."""
+    Slice 2C-i   (PR #49833) tightened to [690, 740] for size 712.
+    Slice 2C-ii (this PR) extracts the last nested helper
+    ``_stream_fanout`` to the ``_claude_make_stream_fanout``
+    @staticmethod factory. Net closure delta is small (712 → 709)
+    because the factory invocation replaces the 9-line inline def.
+    The structural value is that ``_generate_raw`` now has ZERO
+    nested helpers. Envelope tightens to [695, 720]."""
     tree = _load_module_ast(_PROVIDERS_FILE)
     for node in ast.walk(tree):
         if (
@@ -703,25 +705,26 @@ def test_ast_pin_generate_raw_size_after_2c_i():
                             size = (
                                 sub.end_lineno - sub.lineno + 1
                             )
-                            assert 690 <= size <= 740, (
+                            assert 695 <= size <= 720, (
                                 f"_generate_raw size after Slice "
-                                f"2C-i is {size}; expected window "
-                                f"[690, 740]. If this slice "
+                                f"2C-ii is {size}; expected window "
+                                f"[695, 720]. If this slice "
                                 f"intentionally moved more, update "
                                 f"the envelope."
                             )
                             return
 
 
-def test_ast_pin_generate_raw_nested_helper_count_after_2c_i():
-    """Per-slice nested-helper-count envelope. Slice 2C-i drops
-    the count from 2 → 1 (``_do_stream`` extracted to
-    ``_claude_do_stream``).
+def test_ast_pin_generate_raw_nested_helper_count_after_2c_ii():
+    """Per-slice nested-helper-count envelope. Slice 2C-ii drops
+    the count from 1 → 0 (``_stream_fanout`` extracted to
+    ``_claude_make_stream_fanout``).
 
-    Remaining nested helper (1): ``_stream_fanout`` — a small
-    9-line text-fanout helper that's set as ``_stream_callback``
-    when both tool-loop and render callbacks coexist. Extracts
-    in Slice 2C-ii alongside the dispatcher-shell reduction."""
+    ``_generate_raw`` is now STRUCTURALLY CLEAN of nested ``def`` /
+    ``async def`` helpers. The closure-extraction phase of the arc
+    is COMPLETE. Any future slice that re-introduces a nested
+    helper inside ``_generate_raw`` MUST update this pin
+    deliberately."""
     tree = _load_module_ast(_PROVIDERS_FILE)
     for node in ast.walk(tree):
         if (
@@ -750,13 +753,96 @@ def test_ast_pin_generate_raw_nested_helper_count_after_2c_i():
                                 and n is not sub
                             ]
                             count = len(nested)
-                            assert count == 1, (
+                            assert count == 0, (
                                 f"_generate_raw has {count} nested "
-                                f"helpers after Slice 2C-i; "
-                                f"expected exactly 1. Remaining "
-                                f"should be _stream_fanout. Got: "
-                                f"{sorted(n.name for n in nested)}"
+                                f"helpers after Slice 2C-ii; "
+                                f"expected exactly 0. The closure "
+                                f"is structurally clean post-arc. "
+                                f"Got: {sorted(n.name for n in nested)}"
                             )
+                            return
+
+
+def test_ast_pin_make_stream_fanout_is_static_method_on_claude_provider():
+    """Slice 2C-ii extraction proof — positive presence pin.
+
+    ``_claude_make_stream_fanout`` MUST exist as a ``@staticmethod``
+    directly under ``class ClaudeProvider``. The @staticmethod
+    decorator is load-bearing: the factory has zero ``self`` usage
+    and returns a closure that captures only its two parameters."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.FunctionDef)
+                    and child.name == "_claude_make_stream_fanout"
+                ):
+                    deco_names = []
+                    for deco in child.decorator_list:
+                        if isinstance(deco, ast.Name):
+                            deco_names.append(deco.id)
+                        elif isinstance(deco, ast.Attribute):
+                            deco_names.append(deco.attr)
+                    assert "staticmethod" in deco_names, (
+                        f"_claude_make_stream_fanout missing "
+                        f"@staticmethod decorator (got: {deco_names})"
+                    )
+                    return
+            pytest.fail(
+                "ClaudeProvider._claude_make_stream_fanout not "
+                "found — Slice 2C-ii extraction missing"
+            )
+    pytest.fail("ClaudeProvider class not found in providers.py")
+
+
+def test_ast_pin_stream_fanout_no_longer_nested_in_generate_raw():
+    """Slice 2C-ii extraction proof — negative absence pin.
+
+    The original nested ``def _stream_fanout`` MUST NOT exist
+    anywhere inside ``_generate_raw``. With this pin enforced,
+    ``_generate_raw`` is now structurally clean of nested defs
+    (count == 0, verified by the sibling pin
+    ``test_ast_pin_generate_raw_nested_helper_count_after_2c_ii``)."""
+    tree = _load_module_ast(_PROVIDERS_FILE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ClassDef)
+            and node.name == "ClaudeProvider"
+        ):
+            for child in node.body:
+                if (
+                    isinstance(child, ast.AsyncFunctionDef)
+                    and child.name == "generate"
+                ):
+                    for sub in ast.walk(child):
+                        if (
+                            isinstance(sub, ast.AsyncFunctionDef)
+                            and sub.name == "_generate_raw"
+                        ):
+                            for deeper in ast.walk(sub):
+                                if deeper is sub:
+                                    continue
+                                if (
+                                    isinstance(
+                                        deeper,
+                                        (
+                                            ast.FunctionDef,
+                                            ast.AsyncFunctionDef,
+                                        ),
+                                    )
+                                    and deeper.name == "_stream_fanout"
+                                ):
+                                    pytest.fail(
+                                        f"_stream_fanout is still "
+                                        f"nested in _generate_raw "
+                                        f"at line {deeper.lineno} "
+                                        f"— Slice 2C-ii extraction "
+                                        f"incomplete"
+                                    )
                             return
 
 

--- a/tests/test_ouroboros_governance/test_claude_generate_raw_baseline.py
+++ b/tests/test_ouroboros_governance/test_claude_generate_raw_baseline.py
@@ -874,11 +874,15 @@ def test_ast_pin_generate_raw_has_nested_helper_functions():
     Slice 2B-i   update: ``_retrieve_stream_exc`` extracted.
     Slice 2B-ii  update: ``_create_with_*`` pair extracted.
     Slice 2B-iii update: ``_stream_with_*`` pair extracted.
-    Slice 2C-i   update: ``_do_stream`` extracted to
-    ``ClaudeProvider._claude_do_stream``. The required-list
-    contracts to ``_stream_fanout`` (the last small nested helper,
-    Slice 2C-ii's target). Future slices that extract or restructure
-    that helper MUST update this pin in tandem."""
+    Slice 2C-i   update: ``_do_stream`` extracted.
+    Slice 2C-ii  update: ``_stream_fanout`` extracted to
+    ``ClaudeProvider._claude_make_stream_fanout``. With this last
+    extraction, ``_generate_raw`` is STRUCTURALLY CLEAN of nested
+    helpers (count == 0). The Phase-1 SNAPSHOT contract this pin
+    asserts inverts: it now requires the nested-helper set to be
+    EMPTY (proving the closure-extraction phase is complete).
+    Future slices that re-introduce a nested helper MUST flip this
+    pin deliberately."""
     node = _claude_generate_raw_node()
     nested_names = set()
     for sub in ast.walk(node):
@@ -887,11 +891,10 @@ def test_ast_pin_generate_raw_has_nested_helper_functions():
             and sub is not node
         ):
             nested_names.add(sub.name)
-    # We do not pin the EXACT set (over-constrains Phase 2). We pin
-    # that AT LEAST the last remaining anchor exists.
-    assert "_stream_fanout" in nested_names, (
-        f"PHASE-1 pin (Slice 2C-i update): _stream_fanout helper "
-        f"missing. Found: {sorted(nested_names)}"
+    assert nested_names == set(), (
+        f"PHASE-1 pin (Slice 2C-ii update): _generate_raw must be "
+        f"structurally clean of nested helpers after Slice 2C-ii. "
+        f"Found: {sorted(nested_names)}"
     )
 
 


### PR DESCRIPTION
## What

**Final closure-extraction slice** of the Claude `_generate_raw` decomposition arc. Extracts the last remaining nested helper (`_stream_fanout`, a 9-line text-fanout closure) to `ClaudeProvider._claude_make_stream_fanout` as a `@staticmethod` factory.

After this slice, **`_generate_raw` has ZERO nested helpers** — the closure-extraction phase of the arc is COMPLETE.

**Branched off main** at `840784fa9b` (post-2C-i merge state).

## Structural delta — the milestone

| Metric | Before | After | Δ |
|---|---|---|---|
| `_generate_raw` size | 712 lines | **709 lines** | −3 |
| Nested helpers in closure | 1 | **0** ✓ closure structurally clean | −1 |
| `ClaudeProvider._claude_*` extracted methods | 7 | **8** | +1 |
| `providers.py` SHA | `42ba72372c...` | **`1090feb373...`** | (locked) |
| Substrate tests | 60 | **62** | +2 new pins |
| Combined green bar | 152 | **154 passed + 2 xfailed** | zero regressions |

## Why `@staticmethod` (load-bearing)

`_claude_make_stream_fanout` has **zero `self` usage** — it's a pure factory that captures only its two parameters. Declaring it as `@staticmethod` is the honest declaration, matching the pattern Slice 2B-i used for `_claude_retrieve_stream_exc`.

The decorator is AST-pinned by `test_ast_pin_make_stream_fanout_is_static_method_on_claude_provider`.

## Method signature

```python
@staticmethod
def _claude_make_stream_fanout(
    tool_cb: Callable[[str], None],
    render_cb: Callable[[str], None],
) -> Callable[[str], None]:
    """Build a stream callback that fans token text to BOTH the
    tool-loop and the render path with per-call exception swallow."""
    def _fanout(text: str) -> None:
        try:
            tool_cb(text)
        except Exception:
            pass
        try:
            render_cb(text)
        except Exception:
            pass
    return _fanout
```

The returned closure captures `tool_cb` + `render_cb` from the **factory's parameter scope** (not from `_generate_raw`).

## Byte-equivalence

| Behavior | Pre | Post |
|---|---|---|
| Both callbacks → fanout wrapper | inline `def _stream_fanout(text)` closure | factory invocation returns equivalent closure |
| `tool_cb(text)` wrapped in try/except (broad) | preserved | preserved |
| `render_cb(text)` wrapped in try/except (broad) | preserved | preserved |
| Single-callback passthrough | unchanged | unchanged |
| No-callback → `None` | unchanged | unchanged |

## Closure-extraction phase: COMPLETE

Across the full arc:

| Slice | Lines extracted | Cumulative `_claude_*` methods |
|---|---|---|
| 2A-iii (`_boundary_audit_sampler`) | ~38 | 1 |
| 2B-i (`_retrieve_stream_exc`) | ~7 | 2 |
| 2B-ii (`_create_with_*` pair) | ~42 | 4 |
| 2B-iii (`_stream_with_*` pair) | ~39 | 6 |
| 2C-i (`_do_stream` — heaviest) | ~317 | 7 |
| **2C-ii (this PR — `_stream_fanout`)** | ~9 | **8** |

`_generate_raw` shrank from **1036 lines / 8 nested helpers** → **709 lines / 0 nested helpers**. The substrate (`_ClaudeDispatchState` + `_ClaudeStreamContext`) is live in `_claude_do_stream`. The 152-test green bar held across every slice.

Phase 2D (final AST-pin tightening + envelope ceiling consolidation) remains, but Phase 2's structural goal of "no nested helpers in `_generate_raw`" is **now achieved**.

## What lands (3 files)

| File | Change |
|---|---|
| `backend/core/ouroboros/governance/providers.py` | NEW `_claude_make_stream_fanout` `@staticmethod` (~30 lines including docstring) + inline `_stream_fanout` removed + call site rewritten to use factory |
| `tests/test_ouroboros_governance/test_claude_dispatch_state.py` | SHA lock + provenance, size pin rename `_after_2c_i` → `_after_2c_ii` (envelope `[695, 720]` for 709), nested-helper-count pin rename + expect 0, 2 new positive/negative pins |
| `tests/test_ouroboros_governance/test_claude_generate_raw_baseline.py` | Inverts the nested-helper-functions pin from "required-list anchor" to "EMPTY set" |

## Standing constraints — all held

- ✅ No master flags introduced
- ✅ No authority imports added
- ✅ No provider spend
- ✅ No OCA / git-index / sovereignty changes
- ✅ Zero touch of newly-deployed surfaces (evaluator_trace, session_budget, swe_bench_pro, commit_authority, DW heavy lane)
- ✅ Telemetry byte-equivalent (per-call swallow / both-callbacks-fanout semantics identical)
- ✅ Iron Gate respected

## Out-of-scope scripts disclosure

Three unrelated DW-stall isolation scripts (`scripts/dw_concurrent_stress.py`, `scripts/dw_sse_stall_isolation.sh`, `scripts/dw_tool_loop_stress.py`) remain in the working tree as **untracked files** (background-process artifacts from prior sessions). They are explicitly excluded from this commit per the operator's "Touch only providers.py + test_*" directive — left for separate operator handling.

## Slice arc status

| Slice | Status | PR |
|---|---|---|
| 2A-i (safety net) | merged | [#48857](https://github.com/drussell23/JARVIS/pull/48857) |
| 2A-ii (dormant substrate) | merged | [#48860](https://github.com/drussell23/JARVIS/pull/48860) |
| 2A-iii (`_boundary_audit_sampler`) | merged | [#48912](https://github.com/drussell23/JARVIS/pull/48912) |
| 2B-i (`_retrieve_stream_exc`) | merged | [#49578](https://github.com/drussell23/JARVIS/pull/49578) |
| 2B-ii (`_create_with_*` pair) | merged | [#49606](https://github.com/drussell23/JARVIS/pull/49606) |
| 2B-iii (`_stream_with_*` pair) | merged | [#49641](https://github.com/drussell23/JARVIS/pull/49641) |
| 2C-i (`_do_stream` + substrate live) | merged | [#49833](https://github.com/drussell23/JARVIS/pull/49833) |
| **2C-ii (this PR — `_stream_fanout`)** | **shipped** | this PR |
| 2D (AST-pin tightening + envelope consolidation) | deferred | TBD |

## What Phase 2D inherits

- 154-test green bar
- AST-pin tightening: collapse per-slice rename chain (`_after_2c_ii`) to a stable `_post_extraction` pin name
- Envelope ceiling consolidation: tighten the `[695, 720]` envelope to a tighter post-arc range now that no further extractions are expected
- Optional: collapse the `_last_msg[0]` / `_first_token_ms[0]` list-cell-pattern remaining in `_generate_raw` into substrate fields (would require small surrounding-code refactors but produces structural cleanliness)
- Optional: extract larger sub-blocks of the remaining 709-line `_generate_raw` (image-content assembly, thinking-param computation, post-call finalize) — separate slices

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the last nested helper from Claude `_generate_raw` by moving `_stream_fanout` to a `@staticmethod` factory on `ClaudeProvider` (`_claude_make_stream_fanout`). Behavior is unchanged; the fanout and exception-swallowing semantics are preserved.

- **Refactors**
  - Added `ClaudeProvider._claude_make_stream_fanout` (`@staticmethod`) to build a two-callback fanout closure.
  - Replaced the inline `_stream_fanout` in `_generate_raw` with a call to the factory, reducing size 712 → 709 and nested helpers 1 → 0.
  - Updated AST pins and tests to assert the new static method, confirm no nested helpers remain in `_generate_raw`, and adjust the size envelope.

<sup>Written for commit 880c2c9d9a433fd0037dc3965ab2a6b841a8f2ee. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/49897?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

