### PR TITLE
feat(harness): wire EvaluatorTraceObserver ignition — Slice 5

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1142,6 +1142,105 @@ class BattleTestHarness:
                     "%s", _po_exc, exc_info=True,
                 )
 
+            # ──────────────────────────────────────────────────────────
+            # Slice 5 — EvaluatorTraceObserver ignition.
+            # ──────────────────────────────────────────────────────────
+            # Wires the structural-probe observer (Slices 1-4 — PR #48711)
+            # into the harness boot path. Composes existing primitives
+            # only:
+            #   * StreamEventBroker (Gap #6 Slice 2) — observer publishes
+            #     ``evaluator_trace_frame`` events via the canonical
+            #     ``get_default_broker().publish`` surface (NOT a parallel
+            #     bus).
+            #   * PostureObserver (Wave 1 #1) — posture-aware cadence via
+            #     the same store-load pattern the ProductionOracleObserver
+            #     above uses (fail-soft default ``"EXPLORE"``).
+            #
+            # Master flag ``JARVIS_EVALUATOR_TRACE_ENABLED`` default-FALSE
+            # per §33.1 (byte-equivalent boot when the flag is off:
+            # ``evaluator_trace_enabled()`` short-circuits + nothing
+            # else runs). Started here AFTER the broker singleton is
+            # known to be lazily-available + AFTER the production-oracle
+            # observer is wired (preserving boot ordering invariants).
+            #
+            # Fail-soft contract: every call is wrapped — a degraded
+            # observer must NEVER block the main loop's boot. Failures
+            # downgrade to DEBUG, the attribute stays ``None``, and
+            # ``_shutdown_components`` step 0d3 gracefully skips when
+            # the attribute is missing.
+            self._evaluator_trace_observer = None
+            try:
+                from backend.core.ouroboros.governance.swe_bench_pro.evaluator_trace_observer import (  # noqa: E501
+                    EvaluatorTraceObserver,
+                    evaluator_trace_enabled,
+                )
+                if evaluator_trace_enabled():
+                    # Canonical broker singleton (Gap #6 Slice 2).
+                    # NEVER raises; lazily-constructed on first call.
+                    _eto_broker = None
+                    try:
+                        from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: E501
+                            get_default_broker as _eto_get_broker,
+                        )
+                        _eto_broker = _eto_get_broker()
+                    except Exception as _eto_b_exc:  # noqa: BLE001
+                        logger.debug(
+                            "[EvaluatorTraceObserver] broker lookup "
+                            "degraded: %s — observer will run without "
+                            "SSE publish (JSONL persistence still active)",
+                            _eto_b_exc,
+                        )
+
+                    def _eto_posture_provider() -> "Optional[str]":
+                        """Fail-soft posture reader. Mirrors the
+                        ProductionOracleObserver pattern above. Returns
+                        ``None`` (= base interval) on any failure —
+                        defensive default keeps the observer ticking
+                        under degraded posture-store conditions."""
+                        try:
+                            from backend.core.ouroboros.governance.posture_observer import (  # noqa: E501
+                                get_default_store as _ps_get_store,
+                            )
+                            store = _ps_get_store()
+                            reading = store.load_current()
+                            if reading is None:
+                                return None
+                            return str(reading.posture.value)
+                        except Exception:  # noqa: BLE001
+                            return None
+
+                    self._evaluator_trace_observer = EvaluatorTraceObserver(
+                        session_id=self._session_id,
+                        broker_publish=(
+                            _eto_broker.publish if _eto_broker is not None
+                            else None
+                        ),
+                        posture_provider=_eto_posture_provider,
+                    )
+                    # start() is sync; returns True on spawn, False on
+                    # master-flag-off OR no running loop. Logs INFO line
+                    # internally on success.
+                    _eto_started = self._evaluator_trace_observer.start()
+                    if not _eto_started:
+                        # Couldn't spawn (most likely no running loop);
+                        # clear the attribute so shutdown step 0d3
+                        # skips it.
+                        self._evaluator_trace_observer = None
+                else:
+                    logger.debug(
+                        "[EvaluatorTraceObserver] master flag "
+                        "JARVIS_EVALUATOR_TRACE_ENABLED is FALSE — "
+                        "observer not started (default behavior)"
+                    )
+            except Exception as _eto_exc:  # noqa: BLE001
+                logger.debug(
+                    "[EvaluatorTraceObserver] boot wire-up degraded: "
+                    "%s — observer not started; investigation will "
+                    "need a separate diagnostic path",
+                    _eto_exc, exc_info=True,
+                )
+                self._evaluator_trace_observer = None
+
             # Register signal handlers
             try:
                 loop = asyncio.get_running_loop()
@@ -5933,6 +6032,30 @@ class BattleTestHarness:
                 except asyncio.CancelledError:
                     pass
         except Exception:
+            pass
+
+        # 0d3. EvaluatorTraceObserver (Slice 5 — PR #48711 ignition wire).
+        # Stop the structural-probe observer BEFORE broker/intake teardown
+        # so its final SSE publish lands cleanly. Master-flag-off boots
+        # leave _evaluator_trace_observer as None (gracefully skipped
+        # here). CancelledError propagates per asyncio contract; every
+        # other exception swallowed defensively (a degraded observer
+        # MUST NOT block the rest of shutdown).
+        try:
+            _eto = getattr(self, "_evaluator_trace_observer", None)
+            if _eto is not None:
+                try:
+                    await _eto.stop()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as _eto_stop_exc:  # noqa: BLE001
+                    logger.debug(
+                        "[EvaluatorTraceObserver] stop degraded: %s",
+                        _eto_stop_exc,
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — defensive
             pass
 
         # 0e. Wall-clock watchdog (Ticket A Guard 2) — may be None when

--- a/tests/governance/swe_bench_pro/test_evaluator_trace_observer.py
+++ b/tests/governance/swe_bench_pro/test_evaluator_trace_observer.py
@@ -960,3 +960,256 @@ class TestSlice4ReplVerb:
             "SerpentREPL must define _handle_trace for /trace verb "
             "auto-discovery"
         )
+
+
+# ============================================================================
+# Slice 5 — Harness boot-wire pins
+# ============================================================================
+#
+# These pins enforce the 4 operator-mandated invariants for the
+# EvaluatorTraceObserver ignition:
+#
+#   1. The harness wires the observer when JARVIS_EVALUATOR_TRACE_ENABLED=true
+#   2. The harness does NOT start the observer when the master flag is false
+#   3. The harness composes the EXISTING StreamEventBroker via
+#      get_default_broker(), not a parallel bus
+#   4. The harness stops the observer in _shutdown_components BEFORE
+#      broker/intake teardown
+#
+# All pins are AST-based reads of the static harness source; they make
+# no live runtime claims about behavior under load (the smoke-test
+# diagnostic is the empirical validator). The pins catch DRIFT —
+# accidental removal, re-routing through a new bus, or shutdown-order
+# regression — without needing to boot the harness.
+
+_HARNESS_FILE = Path(
+    "backend/core/ouroboros/battle_test/harness.py"
+)
+
+
+def test_ast_pin_harness_wires_evaluator_trace_observer_when_enabled():
+    """Slice 5 ignition proof — positive presence pin.
+
+    The harness MUST contain:
+
+      * An import of ``EvaluatorTraceObserver`` + ``evaluator_trace_enabled``
+        from the canonical observer module.
+      * A master-flag guard (``if evaluator_trace_enabled():``)
+        wrapping the observer instantiation.
+      * An ``EvaluatorTraceObserver(...)`` instantiation site.
+      * A ``.start()`` call (sync — observer returns bool).
+      * Storage on ``self._evaluator_trace_observer``.
+
+    Any drift on these breaks the wiring contract."""
+    src = _HARNESS_FILE.read_text()
+    # Canonical observer import
+    assert (
+        "from backend.core.ouroboros.governance.swe_bench_pro."
+        "evaluator_trace_observer import"
+    ) in src, (
+        "harness.py must import from "
+        "swe_bench_pro.evaluator_trace_observer"
+    )
+    assert "EvaluatorTraceObserver" in src, (
+        "harness.py must reference EvaluatorTraceObserver"
+    )
+    assert "evaluator_trace_enabled" in src, (
+        "harness.py must reference evaluator_trace_enabled "
+        "(master-flag gate)"
+    )
+    # Master-flag guard present
+    tree = ast.parse(src, filename=str(_HARNESS_FILE))
+    found_guard = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            test = node.test
+            # Match ``if evaluator_trace_enabled():`` — bare Call node
+            if (
+                isinstance(test, ast.Call)
+                and isinstance(test.func, ast.Name)
+                and test.func.id == "evaluator_trace_enabled"
+            ):
+                found_guard = True
+                break
+    assert found_guard, (
+        "harness.py must guard the observer instantiation with "
+        "``if evaluator_trace_enabled():`` (master-flag gate)"
+    )
+    # Instantiation site
+    found_instantiation = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "EvaluatorTraceObserver"
+        ):
+            found_instantiation = True
+            break
+    assert found_instantiation, (
+        "harness.py must instantiate EvaluatorTraceObserver "
+        "(positive presence pin)"
+    )
+    # Attribute storage
+    assert "self._evaluator_trace_observer" in src, (
+        "harness.py must store the observer on "
+        "self._evaluator_trace_observer (consistent with shutdown "
+        "step 0d3's getattr)"
+    )
+    # start() call
+    assert "_evaluator_trace_observer.start()" in src, (
+        "harness.py must call self._evaluator_trace_observer.start() "
+        "after instantiation"
+    )
+
+
+def test_ast_pin_harness_does_not_start_observer_when_master_flag_false():
+    """Slice 5 invariant — when JARVIS_EVALUATOR_TRACE_ENABLED is
+    FALSE (default), the observer MUST stay None.
+
+    Runtime-equivalent check: the harness's master-flag-gate
+    short-circuits BEFORE instantiation. We verify this structurally
+    by confirming there is no path that bypasses the
+    ``evaluator_trace_enabled()`` check and instantiates the observer
+    unconditionally."""
+    src = _HARNESS_FILE.read_text()
+    tree = ast.parse(src, filename=str(_HARNESS_FILE))
+    # Walk every EvaluatorTraceObserver(...) Call site and verify
+    # each is INSIDE the master-flag-gated If body.
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "EvaluatorTraceObserver"
+        ):
+            # Walk up the AST to find the enclosing If.
+            ancestors = []
+            for parent in ast.walk(tree):
+                if not isinstance(parent, ast.If):
+                    continue
+                # Check if `node` is somewhere in parent.body subtree.
+                for descendant in ast.walk(parent):
+                    if descendant is node:
+                        ancestors.append(parent)
+                        break
+            # At least one enclosing If must test
+            # ``evaluator_trace_enabled()``.
+            gated = False
+            for parent in ancestors:
+                test = parent.test
+                if (
+                    isinstance(test, ast.Call)
+                    and isinstance(test.func, ast.Name)
+                    and test.func.id == "evaluator_trace_enabled"
+                ):
+                    gated = True
+                    break
+            assert gated, (
+                f"EvaluatorTraceObserver instantiation at line "
+                f"{node.lineno} is NOT enclosed by an "
+                f"``if evaluator_trace_enabled():`` guard — master-"
+                f"flag default-FALSE byte-equivalence is broken"
+            )
+
+
+def test_ast_pin_harness_uses_canonical_stream_broker_not_parallel_bus():
+    """Slice 5 invariant — the harness composes the EXISTING
+    StreamEventBroker (Gap #6 Slice 2) via the canonical singleton
+    accessor ``get_default_broker()`` rather than constructing a
+    parallel bus for the observer.
+
+    Drift this catches:
+      * A new ``StreamEventBroker(...)`` instantiation site in the
+        Slice 5 wiring (would imply a parallel bus).
+      * Importing a non-canonical broker source.
+      * Using ``broker_publish=None`` unconditionally (would silently
+        defeat the SSE surface)."""
+    src = _HARNESS_FILE.read_text()
+    # Canonical broker import on the Slice 5 path
+    assert (
+        "from backend.core.ouroboros.governance.ide_observability_stream "
+        "import"
+    ) in src or (
+        "from backend.core.ouroboros.governance."
+        "ide_observability_stream import"
+    ) in src, (
+        "harness.py must import from the canonical "
+        "ide_observability_stream module (the single broker source)"
+    )
+    assert "get_default_broker" in src, (
+        "harness.py must use get_default_broker() — the canonical "
+        "broker singleton accessor (NOT a parallel bus construction)"
+    )
+    # The broker_publish kwarg must be threaded through (not hardcoded
+    # to None on the live-observer path).
+    tree = ast.parse(src, filename=str(_HARNESS_FILE))
+    found_broker_publish_threaded = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "EvaluatorTraceObserver"
+        ):
+            for kw in node.keywords:
+                if kw.arg == "broker_publish":
+                    # Must be SOMETHING other than a bare None constant
+                    # (a conditional expression is fine — e.g.
+                    # ``_eto_broker.publish if _eto_broker is not None
+                    # else None``).
+                    if isinstance(kw.value, ast.Constant) and (
+                        kw.value.value is None
+                    ):
+                        continue  # bare None — bad
+                    found_broker_publish_threaded = True
+                    break
+    assert found_broker_publish_threaded, (
+        "EvaluatorTraceObserver MUST be instantiated with a "
+        "``broker_publish`` kwarg that resolves to a real callable "
+        "(typically ``broker.publish``) — passing bare ``None`` "
+        "would defeat the SSE surface"
+    )
+
+
+def test_ast_pin_harness_shutdown_stops_evaluator_trace_observer():
+    """Slice 5 invariant — ``_shutdown_components`` calls
+    ``self._evaluator_trace_observer.stop()`` (await) BEFORE broker
+    and intake teardown.
+
+    Step 0d3 is the canonical slot (operator-mandated: "Stop it in
+    _shutdown_components before broker/intake teardown"). The pin
+    verifies:
+
+      * A ``0d3`` section comment is present (documentation anchor).
+      * An ``await _eto.stop()`` (or equivalent) is invoked in
+        _shutdown_components.
+      * That call appears BEFORE the canonical intake stop (``# 2.
+        Intake`` section comment)."""
+    src = _HARNESS_FILE.read_text()
+    # 0d3 section comment present (documentation anchor)
+    assert "# 0d3." in src, (
+        "_shutdown_components must have a ``# 0d3.`` section comment "
+        "documenting the EvaluatorTraceObserver stop step"
+    )
+    # await stop on _evaluator_trace_observer appears
+    assert ".stop()" in src, (
+        "_shutdown_components must call .stop() on the observer"
+    )
+    # Ordering check — 0d3 must appear BEFORE the intake step (# 2.)
+    idx_0d3 = src.find("# 0d3.")
+    idx_intake = src.find("# 2. Intake")
+    assert idx_0d3 > 0, "0d3 anchor not found"
+    assert idx_intake > 0, "# 2. Intake anchor not found"
+    assert idx_0d3 < idx_intake, (
+        f"_shutdown_components step 0d3 (EvaluatorTraceObserver stop) "
+        f"at char {idx_0d3} appears AFTER ``# 2. Intake`` at char "
+        f"{idx_intake} — operator-mandated order is "
+        f"observer-stop BEFORE intake/broker teardown"
+    )
+    # The stop is on _evaluator_trace_observer (not some other observer)
+    # — grep for the attribute reference near the .stop() invocation.
+    assert (
+        "_evaluator_trace_observer"
+        in src.split("# 0d3.")[1].split("# 0e.")[0]
+    ), (
+        "0d3 section must reference _evaluator_trace_observer "
+        "specifically (not a sibling observer)"
+    )


### PR DESCRIPTION
## Summary

Closes the dead-code gap left by Slices 1-4 (PR #48711): the `EvaluatorTraceObserver` module + observability routes + SSE event type + REPL `/trace` verb all shipped, but **nothing called `EvaluatorTraceObserver.start()`**. The master flag `JARVIS_EVALUATOR_TRACE_ENABLED=true` was inert — the diagnostic engine had no ignition wire.

This slice wires the observer into `BattleTestHarness.run()` boot path immediately after the existing `ProductionOracleObserver` and BEFORE signal-handler registration. **Composes ONLY existing primitives** — no new bus, no parallel observer infrastructure.

## Composition surface (existing primitives only)

- **StreamEventBroker** — canonical broker via `ide_observability_stream.get_default_broker()`. Observer publishes `evaluator_trace_frame` events through the same surface the rest of the IDE SSE stream uses (Gap #6 Slice 2). `broker_publish` kwarg is threaded with the broker's bound `.publish` method (NOT a parallel bus, NOT bare `None`).
- **PostureObserver** — fail-soft posture reader mirrors the existing `ProductionOracleObserver` pattern at L1107-1124. Reads `posture_observer.get_default_store().load_current().posture.value`; returns `None` on any failure (= base interval cadence).
- **Session ID** — uses `self._session_id` (canonical harness session token).
- **JSONL persistence** — already wired in the observer itself (executor-wrapped flock; never blocks main loop).

## What lands (2 files)

### `backend/core/ouroboros/battle_test/harness.py` (+ ~100 lines)
- Boot wiring at L1145 — master-flag-gated instantiation + `start()`. Default `JARVIS_EVALUATOR_TRACE_ENABLED=false` → observer stays `None` → byte-equivalent to pre-Slice-5 boot.
- Shutdown step 0d3 in `_shutdown_components` — stops the observer BEFORE broker/intake teardown (step 2 onwards). `asyncio.CancelledError` propagates per contract; all other exceptions swallowed defensively.

### `tests/governance/swe_bench_pro/test_evaluator_trace_observer.py` (+ 4 AST pins)
1. `test_ast_pin_harness_wires_evaluator_trace_observer_when_enabled` — positive presence (import + guard + instantiation + start + `self._evaluator_trace_observer` storage)
2. `test_ast_pin_harness_does_not_start_observer_when_master_flag_false` — every `EvaluatorTraceObserver()` Call site MUST be inside an `if evaluator_trace_enabled():` `If` (structural byte-equivalence guarantee)
3. `test_ast_pin_harness_uses_canonical_stream_broker_not_parallel_bus` — canonical broker import + `get_default_broker` reference + `broker_publish` kwarg threaded, NOT bare `None`
4. `test_ast_pin_harness_shutdown_stops_evaluator_trace_observer` — `0d3` section comment present + `.stop()` invoked + section appears BEFORE `# 2. Intake` (operator-mandated ordering)

## Fail-soft contract

Boot-side:
- Master flag false → observer stays `None` (byte-equivalent default).
- Broker lookup fails → observer still constructs with `broker_publish=None` (JSONL persistence remains active).
- Posture-store lookup fails → `posture_provider` returns `None` (base interval).
- `Observer.start()` returns `False` → attribute cleared.
- Any uncaught exception during boot wire-up → logged at DEBUG, attribute stays `None`, harness boot continues uninterrupted.

Shutdown-side:
- `asyncio.CancelledError` → propagates (asyncio contract).
- Every other exception → swallowed at DEBUG.

## Test surface

- 80 existing observer tests (Slices 1-4) — all pass unchanged.
- 4 new Slice 5 ignition pins — all pass.
- **Combined: 84 passed.**

## Standing constraints — all held

- No master flags introduced (uses existing `JARVIS_EVALUATOR_TRACE_ENABLED`, still default-FALSE).
- No authority imports added.
- No provider spend (boot wiring only).
- Zero touch of DW provider code (§44 lockdown honored).
- Zero touch of any newly-deployed surface (session_budget, swe_bench_pro evaluator extraction, etc.).
- Master flag default-FALSE → byte-equivalent boot for everyone who does NOT explicitly opt in.

## Diagnostic enablement (what this unlocks)

With Slice 5 merged, the operator can reproduce the original 35-minute silent-window deadlock from PR #48711's diagnostic gap:

```bash
export JARVIS_EVALUATOR_TRACE_ENABLED=true
python3 scripts/ouroboros_battle_test.py --headless ...
```

The observer will:
- Tick every 30s (posture-aware cadence).
- Walk `asyncio.all_tasks()` filtered by `swe_bench_pro:` / `evaluator:` / `scorer:` / `prepare:` prefixes.
- Classify each task's top stack frame by `BlockedOnKind` taxonomy (8 closed values).
- Persist frames to `.jarvis/evaluator_trace.jsonl` (executor-wrapped flock append).
- Publish `evaluator_trace_frame` SSE events via the canonical broker.

When the silent-window deadlock recurs, the JSONL frames + SSE stream provide empirical proof of WHICH subprocess / queue / network-socket is wedged — no log-blind diagnostic gap, no wall-cap brute-force bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires `EvaluatorTraceObserver` into the harness boot/shutdown so `JARVIS_EVALUATOR_TRACE_ENABLED` actually starts it and publishes `evaluator_trace_frame` via the canonical stream. Enables posture‑aware task tracing with no new buses and no default behavior change.

- **New Features**
  - Start `EvaluatorTraceObserver` in `BattleTestHarness.run()` after `ProductionOracleObserver`, gated by `evaluator_trace_enabled()`.
  - Use `ide_observability_stream.get_default_broker()` and pass `broker_publish=broker.publish`; degrade to JSONL-only if broker lookup fails.
  - Provide posture cadence via `posture_observer.get_default_store()`; fall back to base interval on errors.
  - Stop the observer in shutdown step 0d3 before broker/intake teardown; swallow non-cancel exceptions.

- **Migration**
  - Off by default; no changes for existing runs.
  - To enable: set `JARVIS_EVALUATOR_TRACE_ENABLED=true` and run the harness.

<sup>Written for commit 7114ecac5c2a297caa0b685a074e0e07b5f0e929. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/50189?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

