### PR TITLE
feat(provider): bounded cancellation guard primitive — Slice 7b

### DIFF
--- a/backend/core/ouroboros/governance/bounded_cancellation_guard.py
+++ b/backend/core/ouroboros/governance/bounded_cancellation_guard.py
@@ -1,0 +1,428 @@
+"""Bounded cancellation guard — surgical socket abort primitive (Slice 7b).
+
+Empirical context — bt-2026-05-21-214521 X-ray (Slice 6 trace):
+
+    14:55:03  → ClaudeProvider stream timeout=188.1s
+    14:58:58  ← stream terminated via CancelledError:
+                  elapsed=234.9s  budget=188.1s  ← +47s OVERRUN
+
+The provider stream survived 47 seconds past its ``asyncio.wait_for``
+budget. The mechanism: when ``wait_for`` cancels the inner streaming
+coroutine, the ``CancelledError`` propagates DOWN the await chain.
+Inside aiohttp's ``response.__aexit__`` / ``session.__aexit__`` the
+cleanup path may attempt to drain remaining bytes from the socket.
+If the server has gone silent, that drain blocks on the OS ``recv()``
+syscall — which does not honour Python-level cancellation. The
+coroutine can't propagate the ``CancelledError`` until ``recv()``
+returns (e.g. on TCP keepalive timeout, many seconds later).
+
+``asyncio.wait_for`` is a cooperative request, not a guarantee.
+
+This module is the surgical primitive. The mechanism:
+
+  * **Capture** the response's ``connection.transport`` reference at
+    ``arm()`` time (after the response is available but before the
+    streaming body is consumed).
+  * **Schedule** a ``loop.call_later(deadline_s + grace_s, fire)``
+    callback at ``__aenter__`` time — independent of any task, runs
+    directly from the event loop.
+  * **On clean exit**: ``__aexit__`` cancels the scheduled callback.
+    No abort fires.
+  * **On overrun**: the event loop fires ``_fire_abort`` synchronously
+    at the scheduled instant. It calls ``transport.abort()`` — the
+    canonical aiohttp Transport method that **surgically severs the
+    socket file descriptor** without touching any other connection
+    in the pool. The next ``recv()`` returns EOF immediately,
+    unblocking every parent ``__aexit__`` in the chain within
+    microseconds.
+
+The shared-pool binding (operator):
+
+    "If the ClientSession is shared across concurrent agents, calling
+    session._connector.close() will violently terminate ALL active
+    connections in the pool. You must ensure the severance is
+    surgical to the specific stalled stream. Prioritize using
+    response.connection.transport.abort() (or an equivalent targeted
+    transport severance) to kill the specific file descriptor
+    without nuking healthy concurrent streams in a shared pool."
+
+This module HONOURS that binding structurally — the only abort call
+in the entire file is ``transport.abort()`` on the captured per-stream
+transport. ``connector.close()``, ``session.close()``, and any other
+pool-wide operation is forbidden by the Slice 7b AST pin.
+
+Design properties (operator-bound):
+
+  * **Single primitive — no polling, no watchdog task, no asyncio.sleep
+    loop.** ``loop.call_later`` is the canonical asyncio scheduler for
+    a one-shot future callback.
+  * **Master-flag default FALSE.** When ``JARVIS_BOUNDED_CANCELLATION
+    _GUARD_ENABLED`` is off, the guard is a strict no-op — wrapping
+    existing code is byte-identical to no guard at all. The flag
+    flips to TRUE in Slice 7d (the wiring slice) only after the
+    primitive itself has been merged + tested.
+  * **NEVER raises.** Every internal step is wrapped; an aborted
+    abort silently degrades to the legacy 47s ghost path.
+  * **Pure-data plus event-loop integration.** No I/O, no
+    ``os.environ`` reads (env knobs resolved once at construction).
+    No new threads. No new HTTP client.
+  * **Callback-shaped telemetry.** The guard takes an
+    ``on_overrun`` callable that fires when abort triggers; Slice 7d
+    wires this to ``StreamEventBroker.publish_cancellation_overrun``.
+    The primitive itself is broker-free.
+
+Slice 7b is the PRIMITIVE. Wiring into ``ClaudeProvider`` happens
+in Slice 7d behind the same master flag (which flips to TRUE on
+that PR — safety guardrail per §33.1)."""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import os
+import time
+from typing import Any, Callable, Optional
+
+
+logger = logging.getLogger("Ouroboros.BoundedCancellationGuard")
+
+
+# ============================================================================
+# Closed taxonomy — guard lifecycle states
+# ============================================================================
+
+
+class GuardState(str, enum.Enum):
+    """Closed 4-value lifecycle state. Adding a 5th state requires
+    bumping the AST pin in the paired test."""
+
+    PENDING       = "pending"        # constructed, not yet entered
+    ARMED         = "armed"          # __aenter__ done, deadline scheduled
+    DISARMED      = "disarmed"       # clean exit, callback cancelled
+    ABORTED       = "aborted"        # deadline fired, transport.abort() called
+
+
+# ============================================================================
+# Env knobs
+# ============================================================================
+
+
+_MASTER_FLAG_ENV: str = "JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED"
+_GRACE_MS_ENV: str = "JARVIS_PROVIDER_CANCELLATION_GRACE_MS"
+
+_DEFAULT_GRACE_MS: int = 500
+_GRACE_MS_MIN: int = 50      # below this, false positives explode
+_GRACE_MS_MAX: int = 5000    # above this, the bound stops being meaningful
+
+
+def guard_enabled() -> bool:
+    """Master gate. Default FALSE per §33.1 (substrate ships first;
+    wiring slice 7d flips this TRUE). NEVER raises."""
+    try:
+        return os.environ.get(_MASTER_FLAG_ENV, "").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _resolve_grace_ms() -> int:
+    """Read the grace-period env knob with clamp. NEVER raises."""
+    try:
+        raw = os.environ.get(_GRACE_MS_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_GRACE_MS
+        v = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_GRACE_MS
+    return max(_GRACE_MS_MIN, min(_GRACE_MS_MAX, v))
+
+
+# ============================================================================
+# Transport extraction — defensive across aiohttp response shapes
+# ============================================================================
+
+
+def _extract_transport(response_or_transport: Any) -> Any:
+    """Return the per-FD transport reference from an aiohttp
+    ``ClientResponse`` (preferred) or a raw transport object
+    (defensive). Returns None if neither shape applies.
+
+    The aiohttp ClientResponse exposes ``.connection`` after the
+    response is open; ``connection.transport`` is the per-stream
+    transport. After ``release()`` the connection becomes None.
+    NEVER raises — failure-soft."""
+    try:
+        # ClientResponse path — preferred.
+        connection = getattr(response_or_transport, "connection", None)
+        if connection is not None:
+            transport = getattr(connection, "transport", None)
+            if transport is not None and hasattr(transport, "abort"):
+                return transport
+        # Raw transport / TransportLike duck path — defensive.
+        if hasattr(response_or_transport, "abort") and hasattr(
+            response_or_transport, "is_closing"
+        ):
+            return response_or_transport
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+# ============================================================================
+# Primitive — BoundedCancellationGuard
+# ============================================================================
+
+
+class BoundedCancellationGuard:
+    """Surgical-severance async context manager for aiohttp streams.
+
+    Use:
+
+        guard = BoundedCancellationGuard(
+            deadline_s=stream_timeout_s,
+            grace_ms=500,
+            on_overrun=publish_cancellation_overrun,
+        )
+        async with guard:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, ...) as response:
+                    guard.arm(response)
+                    async for chunk in response.content:
+                        ...
+
+    If the stream completes normally before ``deadline_s + grace_ms``,
+    the scheduled abort is cancelled and the guard exits as DISARMED.
+
+    If the stream is still ongoing at ``deadline_s + grace_ms`` (the
+    47-second ghost scenario), the event loop fires ``_fire_abort``
+    synchronously, which calls ``response.connection.transport.abort()``.
+    The socket FD is gone instantly; any pending ``recv()`` returns
+    EOF; aiohttp's ``__aexit__`` chains unwind within microseconds.
+    The guard exits as ABORTED.
+
+    Master flag ``JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED`` default
+    FALSE — when off, the guard is a strict no-op (no scheduling,
+    no arming, no abort). Slice 7d's wiring flips this TRUE."""
+
+    def __init__(
+        self,
+        *,
+        deadline_s: float,
+        grace_ms: Optional[int] = None,
+        on_overrun: Optional[Callable[[float], None]] = None,
+    ) -> None:
+        self._deadline_s: float = float(deadline_s)
+        self._grace_ms: int = (
+            grace_ms if grace_ms is not None else _resolve_grace_ms()
+        )
+        self._on_overrun = on_overrun
+        self._transport: Any = None
+        self._abort_handle: Optional[asyncio.TimerHandle] = None
+        self._started_at: Optional[float] = None
+        self._state: GuardState = GuardState.PENDING
+        # Cached at construction so the contract is sticky for this
+        # guard instance — flipping the env mid-stream does not
+        # mutate behaviour.
+        self._master_enabled: bool = guard_enabled()
+
+    # ---- public introspection ----
+
+    @property
+    def state(self) -> GuardState:
+        return self._state
+
+    @property
+    def is_armed(self) -> bool:
+        return self._state == GuardState.ARMED
+
+    @property
+    def aborted(self) -> bool:
+        return self._state == GuardState.ABORTED
+
+    @property
+    def grace_ms(self) -> int:
+        return self._grace_ms
+
+    @property
+    def deadline_s(self) -> float:
+        return self._deadline_s
+
+    @property
+    def master_enabled(self) -> bool:
+        return self._master_enabled
+
+    # ---- arm — capture transport, schedule abort callback ----
+
+    def arm(self, response_or_transport: Any) -> bool:
+        """Capture the per-stream transport for potential surgical
+        abort. Returns True iff a transport was successfully captured.
+
+        Idempotent — calling arm() twice on the same guard is safe;
+        the second call is a no-op. NEVER raises."""
+        if not self._master_enabled:
+            return False
+        if self._transport is not None:
+            return True  # already armed — idempotent
+        transport = _extract_transport(response_or_transport)
+        if transport is None:
+            logger.debug(
+                "[BoundedCancellationGuard] arm(): could not extract "
+                "transport from %r — abort callback will be a no-op",
+                type(response_or_transport).__name__,
+            )
+            return False
+        self._transport = transport
+        return True
+
+    # ---- context-manager surface ----
+
+    async def __aenter__(self) -> "BoundedCancellationGuard":
+        if not self._master_enabled:
+            # Strict no-op when master flag OFF — byte-identical to
+            # not wrapping the call at all.
+            return self
+        self._started_at = time.monotonic()
+        # Schedule the surgical-abort callback at
+        # deadline_s + grace. loop.call_later is the canonical
+        # asyncio primitive for one-shot future callbacks — runs
+        # directly from the event loop, independent of any task,
+        # no polling, no watchdog overhead.
+        try:
+            loop = asyncio.get_running_loop()
+            self._abort_handle = loop.call_later(
+                self._deadline_s + (self._grace_ms / 1000.0),
+                self._fire_abort,
+            )
+            self._state = GuardState.ARMED
+        except RuntimeError:
+            # No running loop — defensive. Should never happen in
+            # production (we're inside an async-with). Stay PENDING.
+            logger.debug(
+                "[BoundedCancellationGuard] __aenter__: no running "
+                "loop — guard degraded to no-op",
+            )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type],
+        exc: Optional[BaseException],
+        tb: Optional[Any],
+    ) -> bool:
+        # Cancel the scheduled abort regardless of how we exit. If
+        # the abort already fired (state == ABORTED), TimerHandle.
+        # cancel() is a no-op.
+        if self._abort_handle is not None:
+            try:
+                self._abort_handle.cancel()
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[BoundedCancellationGuard] __aexit__: abort "
+                    "handle cancel raised — ignoring",
+                )
+            self._abort_handle = None
+        # Only mark DISARMED if we were ARMED + the abort didn't
+        # already fire. ABORTED is terminal.
+        if self._state == GuardState.ARMED:
+            self._state = GuardState.DISARMED
+        # Never suppress.
+        return False
+
+    # ---- the surgical-severance primitive itself ----
+
+    def _fire_abort(self) -> None:
+        """Synchronously sever the captured transport. Called from
+        the event loop via ``loop.call_later`` when the deadline +
+        grace expires before the stream completes.
+
+        The abort is **surgical** — ``transport.abort()`` is the
+        per-FD aiohttp Transport method (NOT
+        ``connector.close()`` which would nuke every active
+        connection in a shared pool). The operator's
+        shared-pool binding is enforced by the Slice 7b AST pin
+        in the paired test.
+
+        NEVER raises — defensive at every step. A failed abort
+        silently degrades to the legacy ghost-cancellation path."""
+        # Guard against double-fire (e.g. __aexit__ raced with the
+        # callback). TimerHandle.cancel() makes this unlikely but
+        # not impossible.
+        if self._state != GuardState.ARMED:
+            return
+        # No transport captured — nothing to abort. The deadline
+        # still expired but there's nothing surgical to do.
+        if self._transport is None:
+            self._state = GuardState.ABORTED
+            return
+        try:
+            # Pre-check: aiohttp may have closed the transport on
+            # its own (e.g. a clean server close arrived right at
+            # the deadline). is_closing() is the canonical
+            # stdlib-Transport check.
+            if hasattr(self._transport, "is_closing"):
+                try:
+                    if self._transport.is_closing():
+                        # Already gone — record state, skip abort.
+                        self._state = GuardState.ABORTED
+                        return
+                except Exception:  # noqa: BLE001
+                    pass
+            # SURGICAL SEVERANCE.
+            #
+            # transport.abort() closes the file descriptor at the
+            # OS level WITHOUT a graceful shutdown. Any pending
+            # recv() in aiohttp's stream-reader returns EOF
+            # immediately. The cancellation propagates through the
+            # entire __aexit__ chain within microseconds.
+            #
+            # This is a SYNC method on asyncio.Transport. We are
+            # already running on the event loop (call_later
+            # callback) so this executes inline.
+            self._transport.abort()
+            self._state = GuardState.ABORTED
+            overrun_s = 0.0
+            if self._started_at is not None:
+                overrun_s = (
+                    time.monotonic() - self._started_at - self._deadline_s
+                )
+            logger.info(
+                "[BoundedCancellationGuard] surgical abort fired — "
+                "overrun=%.3fs grace=%dms (transport=%s)",
+                overrun_s, self._grace_ms,
+                type(self._transport).__name__,
+            )
+            # Fire the overrun callback (Slice 7d wires this to the
+            # StreamEventBroker SSE publish). Callback is sync —
+            # caller may schedule async work via create_task if
+            # needed.
+            if self._on_overrun is not None:
+                try:
+                    self._on_overrun(overrun_s)
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "[BoundedCancellationGuard] on_overrun "
+                        "callback raised — ignoring",
+                    )
+        except Exception:  # noqa: BLE001
+            # Whatever went wrong — log and stay quiet. The legacy
+            # 47-second ghost path is the fallback.
+            logger.debug(
+                "[BoundedCancellationGuard] _fire_abort: abort "
+                "raised — degrading to legacy path",
+                exc_info=True,
+            )
+            self._state = GuardState.ABORTED
+
+
+# ============================================================================
+# Public surface
+# ============================================================================
+
+
+__all__ = [
+    "BoundedCancellationGuard",
+    "GuardState",
+    "guard_enabled",
+]

--- a/tests/governance/test_bounded_cancellation_guard.py
+++ b/tests/governance/test_bounded_cancellation_guard.py
@@ -1,0 +1,662 @@
+"""Slice 7b — BoundedCancellationGuard primitive tests.
+
+Closes the second empirical fault from bt-2026-05-21-214521 (the
+47-second cancellation overrun on the ClaudeProvider stream). The
+primitive in this module is the structural substrate; Slice 7d wires
+it into ``ClaudeProvider`` behind the same master flag.
+
+Test surface:
+
+  * Master-flag default-FALSE AST pin — wrapping existing code with
+    the guard is byte-identical to no guard when off.
+  * **Shared-pool binding AST pin** (operator-bound) — the primitive
+    MUST use ``transport.abort()`` (per-FD) and NEVER
+    ``connector.close()`` / ``session.close()`` (pool-wide).
+  * **No polling-loop AST pin** — operator binding "no asyncio.sleep
+    loops". Single primitive only (``loop.call_later``).
+  * Closed-taxonomy AST pin — ``GuardState`` has exactly 4 members.
+  * **Behavioral: surgical abort on overrun** — using a controlled
+    fake aiohttp connection, exercise the deadline + grace path
+    and assert ``transport.abort()`` was called once + at the
+    expected delay.
+  * Behavioral: clean exit cancels the scheduled abort.
+  * Behavioral: master-flag-FALSE skips the entire mechanism.
+  * Behavioral: ``arm()`` idempotency.
+  * Behavioral: defensive transport extraction across response
+    shapes (ClientResponse-like, raw-transport, None).
+  * Behavioral: ``is_closing()`` pre-check prevents double-abort.
+  * Behavioral: on_overrun callback fires with measured overrun.
+  * Defensive: failed abort silently degrades; never raises.
+  * Env-knob clamp — JARVIS_PROVIDER_CANCELLATION_GRACE_MS bounded
+    to [50, 5000] ms.
+  * Public-surface ``__all__`` pin.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+import pathlib
+import unittest
+from typing import List, Optional
+from unittest.mock import MagicMock
+
+from backend.core.ouroboros.governance.bounded_cancellation_guard import (
+    BoundedCancellationGuard,
+    GuardState,
+    guard_enabled,
+)
+from backend.core.ouroboros.governance import bounded_cancellation_guard
+
+
+# ============================================================================
+# Helpers — controlled fake aiohttp surfaces
+# ============================================================================
+
+
+class _FakeTransport:
+    """Minimal asyncio.Transport surface that records abort() calls
+    and supports is_closing()."""
+
+    def __init__(self) -> None:
+        self.abort_called: int = 0
+        self.close_called: int = 0  # should ALWAYS stay 0 (operator binding)
+        self._closing: bool = False
+
+    def abort(self) -> None:
+        self.abort_called += 1
+        self._closing = True
+
+    def close(self) -> None:
+        self.close_called += 1
+        self._closing = True
+
+    def is_closing(self) -> bool:
+        return self._closing
+
+
+class _FakeConnection:
+    """Mimics aiohttp.connector.Connection — exposes a transport."""
+
+    def __init__(self, transport: _FakeTransport) -> None:
+        self.transport = transport
+
+
+class _FakeResponse:
+    """Mimics aiohttp.ClientResponse — exposes a connection."""
+
+    def __init__(self, transport: Optional[_FakeTransport] = None) -> None:
+        self.connection = (
+            _FakeConnection(transport) if transport is not None else None
+        )
+
+
+# Helper context that flips the master flag for one test.
+class _MasterFlag:
+    def __init__(self, value: bool) -> None:
+        self._value = value
+        self._prior: Optional[str] = None
+
+    def __enter__(self) -> "_MasterFlag":
+        self._prior = os.environ.get(
+            "JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED"
+        )
+        os.environ["JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED"] = (
+            "true" if self._value else "false"
+        )
+        return self
+
+    def __exit__(self, *a: object) -> None:
+        if self._prior is None:
+            os.environ.pop(
+                "JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED", None,
+            )
+        else:
+            os.environ["JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED"] = (
+                self._prior
+            )
+
+
+# ============================================================================
+# Closed-taxonomy AST pin — GuardState
+# ============================================================================
+
+
+class TestGuardStateClosedTaxonomy(unittest.TestCase):
+    """``GuardState`` is a closed 4-value taxonomy. Adding a 5th
+    requires bumping this pin + Slice 7d's wiring code that
+    branches on state."""
+
+    def test_four_members(self) -> None:
+        self.assertEqual(
+            len(list(GuardState)), 4,
+            f"GuardState is closed; found "
+            f"{[m.name for m in GuardState]}",
+        )
+
+    def test_exact_member_names(self) -> None:
+        self.assertEqual(
+            {m.name for m in GuardState},
+            {"PENDING", "ARMED", "DISARMED", "ABORTED"},
+        )
+
+
+# ============================================================================
+# Master flag default-FALSE pin
+# ============================================================================
+
+
+class TestMasterFlagDefault(unittest.TestCase):
+    """The master flag MUST default FALSE in Slice 7b. The wiring
+    slice (7d) flips it to TRUE — but only after this slice has
+    soaked."""
+
+    def test_guard_enabled_default_is_false(self) -> None:
+        prior = os.environ.pop(
+            "JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED", None,
+        )
+        try:
+            self.assertFalse(
+                guard_enabled(),
+                "JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED default "
+                "should be FALSE in Slice 7b",
+            )
+        finally:
+            if prior is not None:
+                os.environ[
+                    "JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED"
+                ] = prior
+
+    def test_guard_enabled_truthy_values(self) -> None:
+        truthy = ["1", "true", "TRUE", "yes", "on", "True"]
+        for v in truthy:
+            with self.subTest(v=v):
+                with _MasterFlag(False):
+                    # Direct override for the truthy probe
+                    os.environ[
+                        "JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED"
+                    ] = v
+                    self.assertTrue(guard_enabled())
+
+    def test_guard_enabled_falsy_values(self) -> None:
+        falsy = ["0", "false", "FALSE", "no", "off", ""]
+        for v in falsy:
+            with self.subTest(v=v):
+                os.environ[
+                    "JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED"
+                ] = v
+                self.assertFalse(guard_enabled())
+
+
+# ============================================================================
+# Shared-pool binding AST pin (operator-bound) — no connector.close
+# ============================================================================
+
+
+_MODULE_FILE = pathlib.Path(bounded_cancellation_guard.__file__)
+
+
+def _parse_module() -> ast.Module:
+    return ast.parse(_MODULE_FILE.read_text())
+
+
+class TestSurgicalSeveranceAstPin(unittest.TestCase):
+    """Operator binding (verbatim): *"prioritize using
+    response.connection.transport.abort() ... without nuking
+    healthy concurrent streams in a shared pool."* This AST pin
+    enforces structurally that the module uses ONLY
+    ``transport.abort()`` — never ``connector.close()`` /
+    ``session.close()`` / any other pool-wide operation."""
+
+    def test_calls_transport_abort_not_connector_close(self) -> None:
+        tree = _parse_module()
+        seen_calls: List[str] = []
+        forbidden_attrs = {
+            ("_connector", "close"),
+            ("connector", "close"),
+        }
+        # 1. Confirm transport.abort() appears at least once in the
+        #    module (the surgical-severance call site).
+        abort_count = 0
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "abort"
+            ):
+                # We don't try to type-narrow the receiver (it's
+                # `self._transport` in the source); the attr name
+                # is enough.
+                abort_count += 1
+        self.assertGreaterEqual(
+            abort_count, 1,
+            "Module must call .abort() at least once — the "
+            "surgical-severance primitive.",
+        )
+        # 2. Confirm NO calls to connector.close / session.close
+        #    anywhere in the module.
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr == "close":
+                # Scan the qualifier chain
+                cur: Optional[ast.AST] = func.value
+                chain: List[str] = []
+                while isinstance(cur, ast.Attribute):
+                    chain.append(cur.attr)
+                    cur = cur.value
+                if isinstance(cur, ast.Name):
+                    chain.append(cur.id)
+                # Forbidden if chain contains "connector" or
+                # "_connector" or "session" anywhere.
+                if any(
+                    seg in ("connector", "_connector", "session")
+                    for seg in chain
+                ):
+                    seen_calls.append(".".join(reversed(chain)) + ".close")
+        self.assertEqual(
+            seen_calls, [],
+            f"Slice 7b shared-pool binding violated — found "
+            f"forbidden pool-wide close() calls: {seen_calls}. "
+            f"Use transport.abort() ONLY.",
+        )
+
+
+# ============================================================================
+# No-polling AST pin (operator-bound)
+# ============================================================================
+
+
+class TestNoPollingAstPin(unittest.TestCase):
+    """Operator binding: *"No hardcoded ``asyncio.sleep()`` loops."*
+    The single primitive in Slice 7b is ``loop.call_later`` — no
+    while-loop polling, no asyncio.sleep retries.
+
+    The module is allowed to ``import asyncio`` and use
+    ``asyncio.TimerHandle`` (via ``loop.call_later``), but it must
+    NOT contain any ``await asyncio.sleep(...)`` calls."""
+
+    def test_no_asyncio_sleep_calls(self) -> None:
+        tree = _parse_module()
+        offenders: List[int] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "sleep"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "asyncio"
+            ):
+                offenders.append(node.lineno)
+        self.assertEqual(
+            offenders, [],
+            f"Slice 7b no-polling binding violated — found "
+            f"asyncio.sleep at line(s) {offenders}. Use "
+            f"loop.call_later for deadline scheduling.",
+        )
+
+    def test_no_while_true_loops(self) -> None:
+        tree = _parse_module()
+        offenders: List[int] = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.While)
+                and isinstance(node.test, ast.Constant)
+                and node.test.value is True
+            ):
+                offenders.append(node.lineno)
+        self.assertEqual(
+            offenders, [],
+            f"Slice 7b no-polling binding violated — found "
+            f"while True at line(s) {offenders}.",
+        )
+
+    def test_uses_loop_call_later(self) -> None:
+        tree = _parse_module()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "call_later"
+            ):
+                return
+        self.fail(
+            "Slice 7b MUST schedule the abort via loop.call_later "
+            "(the canonical asyncio one-shot scheduler). Not found."
+        )
+
+
+# ============================================================================
+# Behavioral — clean exit cancels the scheduled abort
+# ============================================================================
+
+
+class TestCleanExit(unittest.IsolatedAsyncioTestCase):
+    """When the guarded block completes before the deadline + grace,
+    the scheduled abort callback MUST be cancelled. transport.abort()
+    is never called."""
+
+    async def test_clean_exit_does_not_call_abort(self) -> None:
+        with _MasterFlag(True):
+            transport = _FakeTransport()
+            response = _FakeResponse(transport)
+            # deadline 10s, grace 500ms — never reached in this test.
+            guard = BoundedCancellationGuard(
+                deadline_s=10.0, grace_ms=500,
+            )
+            async with guard:
+                guard.arm(response)
+                # Simulate stream completing fast.
+                await asyncio.sleep(0.01)
+            self.assertEqual(transport.abort_called, 0)
+            self.assertEqual(transport.close_called, 0)
+            self.assertEqual(guard.state, GuardState.DISARMED)
+
+    async def test_clean_exit_with_no_arm_is_safe(self) -> None:
+        with _MasterFlag(True):
+            guard = BoundedCancellationGuard(
+                deadline_s=10.0, grace_ms=500,
+            )
+            async with guard:
+                # Never arm — guard exits as DISARMED, no abort.
+                pass
+            self.assertEqual(guard.state, GuardState.DISARMED)
+
+
+# ============================================================================
+# Behavioral — surgical abort fires on overrun
+# ============================================================================
+
+
+class TestSurgicalAbortOnOverrun(unittest.IsolatedAsyncioTestCase):
+    """When the guarded block exceeds deadline + grace, the event
+    loop fires _fire_abort, which calls transport.abort()
+    surgically. transport.close() must NEVER be called."""
+
+    async def test_deadline_expired_calls_transport_abort(self) -> None:
+        with _MasterFlag(True):
+            transport = _FakeTransport()
+            response = _FakeResponse(transport)
+            overrun_recorded: List[float] = []
+
+            def _on_overrun(overrun_s: float) -> None:
+                overrun_recorded.append(overrun_s)
+
+            # Very short deadline + grace — abort should fire fast.
+            guard = BoundedCancellationGuard(
+                deadline_s=0.05,
+                grace_ms=50,
+                on_overrun=_on_overrun,
+            )
+            async with guard:
+                guard.arm(response)
+                # Sleep past deadline + grace.
+                await asyncio.sleep(0.25)
+            # transport.abort() should have been called exactly once.
+            self.assertEqual(
+                transport.abort_called, 1,
+                "transport.abort() should be called exactly once "
+                "when the deadline + grace expires",
+            )
+            # transport.close() MUST NEVER be called (operator
+            # shared-pool binding).
+            self.assertEqual(
+                transport.close_called, 0,
+                "transport.close() must NEVER be called by the "
+                "guard — operator shared-pool binding",
+            )
+            self.assertEqual(guard.state, GuardState.ABORTED)
+            # Overrun callback fired with positive overrun.
+            self.assertEqual(len(overrun_recorded), 1)
+            self.assertGreater(overrun_recorded[0], 0.0)
+
+    async def test_unarmed_guard_marks_aborted_without_calling_transport(self) -> None:
+        """When the deadline expires but no transport was armed, the
+        state still transitions to ABORTED (the deadline DID fire)
+        but no .abort() call is made."""
+        with _MasterFlag(True):
+            transport = _FakeTransport()  # never armed
+            guard = BoundedCancellationGuard(
+                deadline_s=0.05, grace_ms=50,
+            )
+            async with guard:
+                # never arm
+                await asyncio.sleep(0.25)
+            self.assertEqual(guard.state, GuardState.ABORTED)
+            self.assertEqual(transport.abort_called, 0)
+
+
+# ============================================================================
+# Behavioral — master-flag-FALSE no-op
+# ============================================================================
+
+
+class TestMasterFlagFalseIsNoop(unittest.IsolatedAsyncioTestCase):
+    """When the master flag is FALSE, the guard is a strict no-op.
+    Wrapping existing code is byte-identical to not wrapping it."""
+
+    async def test_no_schedule_when_flag_false(self) -> None:
+        with _MasterFlag(False):
+            transport = _FakeTransport()
+            response = _FakeResponse(transport)
+            guard = BoundedCancellationGuard(
+                deadline_s=0.01, grace_ms=10,
+            )
+            async with guard:
+                guard.arm(response)
+                # Wait FAR past what would be the deadline+grace.
+                await asyncio.sleep(0.1)
+            # Nothing should have happened — strict no-op.
+            self.assertEqual(transport.abort_called, 0)
+            self.assertEqual(transport.close_called, 0)
+            self.assertEqual(guard.state, GuardState.PENDING)
+
+    async def test_arm_returns_false_when_flag_false(self) -> None:
+        with _MasterFlag(False):
+            guard = BoundedCancellationGuard(
+                deadline_s=10.0, grace_ms=500,
+            )
+            response = _FakeResponse(_FakeTransport())
+            armed = guard.arm(response)
+            self.assertFalse(
+                armed,
+                "arm() must return False when master flag is OFF",
+            )
+
+
+# ============================================================================
+# Behavioral — arm() idempotency + defensive extraction
+# ============================================================================
+
+
+class TestArmIdempotency(unittest.IsolatedAsyncioTestCase):
+    """arm() can be called multiple times — only the first capture
+    is honoured (idempotent). Defensive across response shapes."""
+
+    async def test_double_arm_is_noop(self) -> None:
+        with _MasterFlag(True):
+            transport1 = _FakeTransport()
+            transport2 = _FakeTransport()
+            r1 = _FakeResponse(transport1)
+            r2 = _FakeResponse(transport2)
+            guard = BoundedCancellationGuard(
+                deadline_s=10.0, grace_ms=500,
+            )
+            async with guard:
+                self.assertTrue(guard.arm(r1))
+                self.assertTrue(guard.arm(r2))  # idempotent
+                # First arm wins — only r1's transport is captured.
+            self.assertEqual(transport1.abort_called, 0)
+            self.assertEqual(transport2.abort_called, 0)
+
+    async def test_arm_accepts_raw_transport(self) -> None:
+        """Defensive: arm() accepts a raw transport-like object
+        (not just a ClientResponse)."""
+        with _MasterFlag(True):
+            transport = _FakeTransport()
+            guard = BoundedCancellationGuard(
+                deadline_s=0.05, grace_ms=50,
+            )
+            async with guard:
+                self.assertTrue(guard.arm(transport))
+                await asyncio.sleep(0.25)
+            self.assertEqual(transport.abort_called, 1)
+
+    async def test_arm_rejects_none_safely(self) -> None:
+        with _MasterFlag(True):
+            guard = BoundedCancellationGuard(
+                deadline_s=10.0, grace_ms=500,
+            )
+            async with guard:
+                # None has no transport — arm returns False, no
+                # exception.
+                self.assertFalse(guard.arm(None))
+
+    async def test_arm_rejects_unrelated_object_safely(self) -> None:
+        with _MasterFlag(True):
+            guard = BoundedCancellationGuard(
+                deadline_s=10.0, grace_ms=500,
+            )
+            async with guard:
+                self.assertFalse(guard.arm("not a response"))
+                self.assertFalse(guard.arm(object()))
+
+
+# ============================================================================
+# Behavioral — is_closing() pre-check
+# ============================================================================
+
+
+class TestIsClosingPrecheck(unittest.IsolatedAsyncioTestCase):
+    """If aiohttp closed the transport on its own between arm() and
+    the deadline firing, _fire_abort must NOT call .abort() again
+    (it's a no-op anyway, but cleanliness matters)."""
+
+    async def test_skip_abort_when_already_closing(self) -> None:
+        with _MasterFlag(True):
+            transport = _FakeTransport()
+            response = _FakeResponse(transport)
+            guard = BoundedCancellationGuard(
+                deadline_s=0.05, grace_ms=50,
+            )
+            async with guard:
+                guard.arm(response)
+                # Simulate aiohttp closing the transport itself
+                # before the deadline fires.
+                transport._closing = True
+                await asyncio.sleep(0.25)
+            # State still ABORTED (deadline DID fire), but .abort()
+            # was NOT called because is_closing() short-circuited.
+            self.assertEqual(transport.abort_called, 0)
+            self.assertEqual(guard.state, GuardState.ABORTED)
+
+
+# ============================================================================
+# Behavioral — overrun callback never raises out of the guard
+# ============================================================================
+
+
+class TestOverrunCallbackDefensive(unittest.IsolatedAsyncioTestCase):
+    """A misbehaving on_overrun callback must not propagate
+    exceptions out of the guard. NEVER raises contract."""
+
+    async def test_callback_raises_silently_logged(self) -> None:
+        with _MasterFlag(True):
+            transport = _FakeTransport()
+            response = _FakeResponse(transport)
+
+            def _bad_callback(overrun_s: float) -> None:
+                raise RuntimeError("simulated callback fault")
+
+            guard = BoundedCancellationGuard(
+                deadline_s=0.05,
+                grace_ms=50,
+                on_overrun=_bad_callback,
+            )
+            # Should NOT raise.
+            async with guard:
+                guard.arm(response)
+                await asyncio.sleep(0.25)
+            # abort still fired, state still ABORTED.
+            self.assertEqual(transport.abort_called, 1)
+            self.assertEqual(guard.state, GuardState.ABORTED)
+
+
+# ============================================================================
+# Env-knob clamp
+# ============================================================================
+
+
+class TestGraceMsEnvClamp(unittest.TestCase):
+    """JARVIS_PROVIDER_CANCELLATION_GRACE_MS is clamped to
+    [50, 5000] — below 50 is false-positive heavy, above 5000 is
+    not a useful bound."""
+
+    def _make_guard(self) -> BoundedCancellationGuard:
+        return BoundedCancellationGuard(deadline_s=1.0)
+
+    def test_default_grace_ms_is_500(self) -> None:
+        os.environ.pop("JARVIS_PROVIDER_CANCELLATION_GRACE_MS", None)
+        guard = self._make_guard()
+        self.assertEqual(guard.grace_ms, 500)
+
+    def test_clamp_low(self) -> None:
+        os.environ["JARVIS_PROVIDER_CANCELLATION_GRACE_MS"] = "10"
+        guard = self._make_guard()
+        self.assertEqual(
+            guard.grace_ms, 50,
+            "grace_ms below the floor must clamp to 50",
+        )
+
+    def test_clamp_high(self) -> None:
+        os.environ["JARVIS_PROVIDER_CANCELLATION_GRACE_MS"] = "99999"
+        guard = self._make_guard()
+        self.assertEqual(
+            guard.grace_ms, 5000,
+            "grace_ms above the ceiling must clamp to 5000",
+        )
+
+    def test_invalid_env_uses_default(self) -> None:
+        os.environ["JARVIS_PROVIDER_CANCELLATION_GRACE_MS"] = "not-an-int"
+        guard = self._make_guard()
+        self.assertEqual(guard.grace_ms, 500)
+
+    def test_explicit_grace_overrides_env(self) -> None:
+        os.environ["JARVIS_PROVIDER_CANCELLATION_GRACE_MS"] = "200"
+        guard = BoundedCancellationGuard(
+            deadline_s=1.0, grace_ms=750,
+        )
+        self.assertEqual(guard.grace_ms, 750)
+
+
+# ============================================================================
+# Public surface pin
+# ============================================================================
+
+
+class TestPublicSurface(unittest.TestCase):
+    """``__all__`` stability — Slice 7d consumes these names."""
+
+    def test_all_exports(self) -> None:
+        self.assertEqual(
+            set(bounded_cancellation_guard.__all__),
+            {
+                "BoundedCancellationGuard",
+                "GuardState",
+                "guard_enabled",
+            },
+        )
+
+    def test_each_export_resolves(self) -> None:
+        for name in bounded_cancellation_guard.__all__:
+            self.assertTrue(
+                hasattr(bounded_cancellation_guard, name),
+            )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the **47-second cancellation overrun** from `bt-2026-05-21-214521` (Slice 6 X-ray):

```
14:55:03  → ClaudeProvider stream timeout=188.1s
14:58:58  ← stream terminated via CancelledError:
              elapsed=234.9s  budget=188.1s  ← +47s OVERRUN
```

aiohttp's `__aexit__` chain hangs on socket `recv()` during cancellation — Python-level `CancelledError` can't propagate until the OS-level `recv()` returns. `asyncio.wait_for` is a cooperative request, not a guarantee. This slice ships the **surgical-severance primitive** that bypasses the cooperative path.

## Mechanism (single primitive — no polling)

| Step | API | Behaviour |
|---|---|---|
| 1 | `BoundedCancellationGuard(deadline_s, grace_ms, on_overrun)` | Construct with the stream's timeout + grace |
| 2 | `async with guard:` | `__aenter__` schedules `loop.call_later(deadline_s + grace_ms, _fire_abort)` |
| 3 | `guard.arm(response)` | Captures `response.connection.transport` (per-FD) |
| 4a | Stream completes normally | `__aexit__` cancels the scheduled callback. State → DISARMED |
| 4b | Stream hangs past deadline + grace | `_fire_abort` runs **synchronously from the event loop**, calls `transport.abort()`. Socket FD gone instantly; pending `recv()` returns EOF; aiohttp `__aexit__` chains unwind in microseconds. State → ABORTED |

## Operator-bound constraints — STRUCTURAL

### 1. Surgical severance (shared-pool binding)

> *"prioritize using `response.connection.transport.abort()` ... without nuking healthy concurrent streams in a shared pool."*

**AST pin** (`test_calls_transport_abort_not_connector_close`) enforces:
- ✅ `transport.abort()` appears at least once (positive presence)
- ✅ No call to `connector.close()` / `_connector.close()` / `session.close()` anywhere in the module

Test fakes track `close_called` and assert it **stays 0** through every code path.

### 2. No polling-loop binding

> *"No hardcoded `asyncio.sleep()` loops."*

**AST pins** reject `asyncio.sleep(...)` and `while True:`. Positive-presence pin requires `loop.call_later` — the canonical one-shot scheduler that runs directly from the event loop (no task, no polling).

### 3. Master flag default-FALSE (§33.1)

`JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED` ships OFF. Slice 7d (the wiring slice) flips it TRUE — primitive soaks for one slice cycle before going hot. When OFF, the guard is **strict no-op** — wrapping existing code is byte-identical to no wrap.

## What lands (2 files, +1090 lines)

### `backend/core/ouroboros/governance/bounded_cancellation_guard.py`
- Closed 4-value `GuardState` enum: PENDING / ARMED / DISARMED / ABORTED
- `BoundedCancellationGuard` async context manager
- `guard_enabled()` env helper
- `_resolve_grace_ms()` clamped to [50, 5000] ms
- `_extract_transport(...)` defensive across `ClientResponse` (preferred) + raw transport (fallback)
- NEVER raises

### `tests/governance/test_bounded_cancellation_guard.py` (28 tests, 11 classes)
- Closed-taxonomy AST pin
- Master-flag default-FALSE + truthy/falsy parsing
- **Surgical-severance AST pin** (close NEVER called)
- **No-polling AST pin** (no `asyncio.sleep`, no `while True`; `loop.call_later` required)
- Clean exit cancels the schedule
- **Behavioral: surgical abort fires on overrun** — controlled fake aiohttp; `abort==1, close==0`
- Unarmed-guard overrun safe
- Master-flag-FALSE strict no-op
- `arm()` idempotency + defensive shapes
- `is_closing()` pre-check prevents double-abort
- Overrun callback failure-soft
- Env-knob clamp `[50, 5000]` ms
- Public-surface `__all__` pin

## Composition (existing primitives only)
- `asyncio.AbstractEventLoop.call_later` — canonical one-shot scheduler
- aiohttp `Transport.abort()` + `is_closing()` — canonical stdlib surface
- No new HTTP client, no new connector, no new thread, no new coroutine spawned

## Standing constraints
- No new SSE event types (Slice 7d adds `cancellation_overrun_detected`)
- No wiring into ClaudeProvider (Slice 7d)
- Master flag default-FALSE — byte-identical when off
- No DW provider edits (§44 lockdown)
- Only env knob: `grace_ms` (clamped)

## Test surface
- **28 new tests, all green in 4.5s.**
- No regressions — new file, no existing surface edited.

## Next slice

**7c — CircuitBreaker state machine.** Closed 4-value `CircuitState` (CLOSED / OPEN_TRANSIENT / HALF_OPEN / OPEN_TERMINAL). Composes Slice 7a's `RetryDecision` + existing `ProviderExhaustionWatcher.consecutive` (canonical counter) + `SessionBudgetAuthority.remaining` (canonical budget oracle). Full-jitter exponential backoff per operator binding. State-machine purity AST-pinned (no parallel state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded cancellation guard for `aiohttp` streams that surgically aborts the stalled socket on timeout to stop long cancellation overruns. Default-off behind `JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED`; no runtime change until wired and enabled.

- New Features
  - `BoundedCancellationGuard` async context manager for provider streams.
  - Schedules a one-shot abort with `loop.call_later(deadline_s + grace_ms)`, no polling.
  - `arm(response)` captures `response.connection.transport`; on overrun calls `transport.abort()` only (shared-pool safe).
  - Env knobs: `JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED` (master, default off), `JARVIS_PROVIDER_CANCELLATION_GRACE_MS` (50–5000 ms clamp). Optional `on_overrun` callback. Never raises.
  - Safety rails via tests/AST pins: forbid `connector.close()`/`session.close()`, forbid `asyncio.sleep`/`while True`, require `loop.call_later`. 28 tests added.

- Bug Fixes
  - Addresses the 47s cancellation overrun by force-closing the specific socket when deadline + grace is exceeded, unblocking `__aexit__` immediately. Gated by the master flag and wiring.

<sup>Written for commit af569eeb471fe5328e9dcd4281230b3648629064. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/50696?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

