### PR TITLE
feat(provider): adaptive circuit-breaker state machine — Slice 7c

### DIFF
--- a/backend/core/ouroboros/governance/circuit_breaker.py
+++ b/backend/core/ouroboros/governance/circuit_breaker.py
@@ -1,0 +1,685 @@
+"""Provider Circuit Breaker — adaptive state machine (Slice 7c).
+
+Empirical context — bt-2026-05-21-214521 X-ray (Slice 6 trace):
+
+    The 35-minute "silent window" hang was a fast-fail retry storm
+    inside ``CandidateGenerator._call_fallback``. A
+    ``SessionBudgetPreflightRefused`` (structural cost-vs-budget
+    inequality — retrying mathematically CANNOT clear it) was
+    classified as ``failure_mode=CONNECTION_ERROR`` (transient,
+    retryable) and the outer-retry loop spun at ~2.7s per attempt
+    for the entire 1800s ``wait_for`` budget.
+
+Slice 7a (PR #50692) introduced the closed-taxonomy
+``RetryDecision`` classifier that fixes the mis-bucket. This module
+is the **state machine** that consumes the decision and decides:
+
+  * **Continue with retry** — caller's existing outer-retry loop is
+    structurally correct for this failure class.
+  * **Retry after backoff** — too many transient failures recently;
+    yield to a bounded exponential-with-full-jitter backoff
+    before next attempt (AWS-style anti-thundering-herd).
+  * **Terminate as UNRESOLVED** — math says further retries cannot
+    help. The breaker emits a synthetic ``operation_terminal``
+    event via the canonical StreamEventBroker (Slice 7e wires
+    this) so the parallel evaluator's bounded ``wait_for`` collapses
+    in seconds, not minutes.
+
+## State machine (closed 4-value taxonomy)
+
+```
+                    record_success() in HALF_OPEN
+              ┌──────────────────────────────────────────┐
+              ▼                                          │
+        ┌─────────┐  N×RETRY_TRANSIENT  ┌──────────────────┐
+        │ CLOSED  │ ──────────────────▶ │ OPEN_TRANSIENT   │
+        └─────────┘   in window         └──────────────────┘
+              │                                │  backoff expires
+              │ TERMINAL_*                     ▼
+              │                          ┌──────────────────┐
+              │                          │   HALF_OPEN      │
+              │                          └──────────────────┘
+              │                          fail │     │ success
+              ▼                               ▼     ▼
+                                  OPEN_TRANSIENT  CLOSED
+        ┌──────────────────┐    (extended)
+        │ OPEN_TERMINAL    │    (sticky — no transitions out)
+        └──────────────────┘
+```
+
+Trip table (closed, AST-pinned):
+
+  | Input from classifier         | Action                                    |
+  | ----------------------------- | ----------------------------------------- |
+  | 1× TERMINAL_STRUCTURAL        | → OPEN_TERMINAL immediately               |
+  | 1× TERMINAL_CONFIG            | → OPEN_TERMINAL immediately               |
+  | Nth TERMINAL_QUOTA in window  | → OPEN_TERMINAL                           |
+  | <Nth TERMINAL_QUOTA in window | → CLOSED (verdict RETRY_AFTER_BACKOFF)    |
+  | Nth RETRY_TRANSIENT in window | → OPEN_TRANSIENT (full-jitter backoff)    |
+  | <Nth RETRY_TRANSIENT in win.  | → CLOSED (verdict RETRY_OK)               |
+
+## Composition (operator binding — "zero state duplication")
+
+The breaker is a **pure consumer** of canonical state stores:
+
+  * ``ProviderExhaustionWatcher.consecutive`` — canonical
+    consecutive-failure counter, NOT duplicated. The breaker reads
+    via a `consecutive_provider` injection; the production wiring
+    will pass ``watcher.__class__.consecutive.fget(watcher)``.
+
+  * ``SessionBudgetAuthority.get_session_remaining_usd()`` —
+    canonical session-budget oracle. The breaker uses this for
+    **pre-trip**: when ``remaining < min_floor``, evaluate()
+    returns TERMINATE_UNRESOLVED without invoking the failure
+    classifier. The structural cause (budget gone) is honoured
+    before any provider call is even attempted.
+
+  * ``StreamEventBroker.publish_operation_terminal()`` — Slice 7e
+    wires this in. The breaker itself only carries an
+    ``on_terminal`` callback that the wiring layer connects.
+
+The breaker DOES NOT maintain a parallel ``consecutive`` counter.
+AST pin in the paired test enforces this — the only state owned
+by the breaker is the state machine itself plus rolling windows
+for the rate-limited quota / transient counters (which are
+breaker-specific, not duplicated anywhere else).
+
+## Full-Jitter exponential backoff (operator binding)
+
+Operator: *"the OPEN_TRANSIENT exponential backoff must incorporate
+dynamic Full Jitter to prevent 'thundering herd' retry storms
+when multiple agents face transient gateway drops."*
+
+The breaker uses the **AWS Full-Jitter** algorithm verbatim:
+
+    delay = random.uniform(0, min(cap_s, base_s * 2^attempt))
+
+Each transient retry picks a delay uniformly in [0, exponential
+cap]. Multiple concurrent agents observing the same gateway drop
+all roll independent dice; the herd disperses.
+
+## Per-op + global tiers
+
+Two breaker instances exist:
+
+  * **Per-op breaker** — scoped to a single ``op_id``. Created
+    by ``CandidateGenerator._call_fallback`` per evaluation.
+    Prevents one op from burning the full budget on retries.
+
+  * **Global session breaker** — process-singleton via
+    ``get_global_breaker()``. Tracks TERMINAL_STRUCTURAL trips
+    across all per-op breakers. If ≥N trips within a window
+    (env-knobbed), the global breaker enters OPEN_TERMINAL and
+    every subsequent ``evaluate()`` on any per-op instance
+    returns TERMINATE_UNRESOLVED without invoking the provider.
+
+The global breaker is the structural acknowledgement that
+"this session's budget is gone — stop trying."
+
+## Master flag + env knobs
+
+  * ``JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED`` — default FALSE.
+    When OFF, ``evaluate()`` always returns ``RETRY_OK``
+    (byte-identical to no breaker). Slice 7e wires it in; the
+    flag stays FALSE until Slice 7f graduation soak passes.
+  * ``JARVIS_CIRCUIT_BREAKER_TERMINAL_QUOTA_TRIP`` — default 2
+    (operator-bound).
+  * ``JARVIS_CIRCUIT_BREAKER_QUOTA_WINDOW_S`` — default 30.0s.
+  * ``JARVIS_CIRCUIT_BREAKER_TRANSIENT_TRIP`` — default 3.
+  * ``JARVIS_CIRCUIT_BREAKER_TRANSIENT_WINDOW_S`` — default 60.0s.
+  * ``JARVIS_CIRCUIT_BREAKER_BACKOFF_BASE_S`` — default 5.0s.
+  * ``JARVIS_CIRCUIT_BREAKER_BACKOFF_CAP_S`` — default 60.0s.
+  * ``JARVIS_CIRCUIT_BREAKER_GLOBAL_TRIP_COUNT`` — default 5.
+  * ``JARVIS_CIRCUIT_BREAKER_GLOBAL_TRIP_WINDOW_S`` — default 300.0s.
+  * ``JARVIS_CIRCUIT_BREAKER_MIN_BUDGET_FLOOR_USD`` — default 0.05.
+
+All thresholds are env-knobbed (operational). The closed enums
+(``CircuitState``, ``CircuitScope``, ``VerdictAction``) are
+structural — frozen by AST pin.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import random
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Callable, Deque, Optional
+
+
+logger = logging.getLogger("Ouroboros.CircuitBreaker")
+
+
+# ============================================================================
+# Closed-taxonomy enums
+# ============================================================================
+
+
+class CircuitState(str, enum.Enum):
+    """Closed 4-value circuit-breaker state. Adding a 5th member
+    requires bumping the AST pin + Slice 7e's wiring branches."""
+
+    CLOSED         = "closed"          # retries allowed
+    OPEN_TRANSIENT = "open_transient"  # backoff-then-probe
+    HALF_OPEN      = "half_open"       # probing recovery
+    OPEN_TERMINAL  = "open_terminal"   # sticky — no further attempts
+
+
+class CircuitScope(str, enum.Enum):
+    """Closed 2-value scope — per-op or session-global."""
+
+    PER_OP = "per_op"
+    GLOBAL = "global"
+
+
+class VerdictAction(str, enum.Enum):
+    """Closed 3-value verdict — what the caller should do next."""
+
+    RETRY_OK              = "retry_ok"
+    RETRY_AFTER_BACKOFF   = "retry_after_backoff"
+    TERMINATE_UNRESOLVED  = "terminate_unresolved"
+
+
+@dataclass(frozen=True)
+class CircuitVerdict:
+    """Frozen verdict returned by ``CircuitBreaker.evaluate()``.
+
+    The caller's contract:
+
+      * RETRY_OK            — proceed with the next retry attempt.
+      * RETRY_AFTER_BACKOFF — ``await asyncio.sleep(verdict.backoff_s)``
+        BEFORE the next attempt.
+      * TERMINATE_UNRESOLVED — emit a synthetic ``operation_terminal``
+        event with ``state="UNRESOLVED"`` and
+        ``terminal_reason_code=verdict.terminal_reason_code``,
+        then RETURN from the outer-retry loop. Do NOT retry.
+    """
+
+    action: VerdictAction
+    backoff_s: Optional[float] = None
+    terminal_reason_code: Optional[str] = None
+    state_after: Optional[CircuitState] = None
+
+
+# ============================================================================
+# Env knobs
+# ============================================================================
+
+
+_MASTER_FLAG_ENV: str = "JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED"
+_QUOTA_TRIP_ENV: str = "JARVIS_CIRCUIT_BREAKER_TERMINAL_QUOTA_TRIP"
+_QUOTA_WINDOW_ENV: str = "JARVIS_CIRCUIT_BREAKER_QUOTA_WINDOW_S"
+_TRANSIENT_TRIP_ENV: str = "JARVIS_CIRCUIT_BREAKER_TRANSIENT_TRIP"
+_TRANSIENT_WINDOW_ENV: str = "JARVIS_CIRCUIT_BREAKER_TRANSIENT_WINDOW_S"
+_BACKOFF_BASE_ENV: str = "JARVIS_CIRCUIT_BREAKER_BACKOFF_BASE_S"
+_BACKOFF_CAP_ENV: str = "JARVIS_CIRCUIT_BREAKER_BACKOFF_CAP_S"
+_GLOBAL_TRIP_COUNT_ENV: str = "JARVIS_CIRCUIT_BREAKER_GLOBAL_TRIP_COUNT"
+_GLOBAL_TRIP_WINDOW_ENV: str = "JARVIS_CIRCUIT_BREAKER_GLOBAL_TRIP_WINDOW_S"
+_MIN_BUDGET_FLOOR_ENV: str = "JARVIS_CIRCUIT_BREAKER_MIN_BUDGET_FLOOR_USD"
+
+
+def circuit_breaker_enabled() -> bool:
+    """Master gate. Default FALSE per §33.1. NEVER raises."""
+    try:
+        return os.environ.get(_MASTER_FLAG_ENV, "").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _read_int(name: str, default: int, *, minimum: int = 1) -> int:
+    try:
+        raw = os.environ.get(name, "").strip()
+        if not raw:
+            return default
+        v = int(raw)
+        return max(minimum, v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _read_float(
+    name: str, default: float, *, minimum: float = 0.0,
+) -> float:
+    try:
+        raw = os.environ.get(name, "").strip()
+        if not raw:
+            return default
+        v = float(raw)
+        return max(minimum, v)
+    except (TypeError, ValueError):
+        return default
+
+
+# ============================================================================
+# Sliding window — small, lock-free, deque-based
+# ============================================================================
+
+
+class _SlidingWindow:
+    """Append-only timestamp ring with O(1) prune+count.
+
+    The breaker's per-class failure windows (quota, transient) use
+    this to count "N failures in last W seconds" without storing the
+    raw events. We deliberately keep this internal — it's NOT a
+    duplicate of ExhaustionWatcher's consecutive counter (which
+    counts uninterrupted runs; this counts in-window events)."""
+
+    __slots__ = ("_window_s", "_events")
+
+    def __init__(self, window_s: float) -> None:
+        self._window_s: float = float(window_s)
+        self._events: Deque[float] = deque()
+
+    def add(self, now: Optional[float] = None) -> None:
+        ts = time.monotonic() if now is None else now
+        self._prune(ts)
+        self._events.append(ts)
+
+    def count(self, now: Optional[float] = None) -> int:
+        ts = time.monotonic() if now is None else now
+        self._prune(ts)
+        return len(self._events)
+
+    def clear(self) -> None:
+        self._events.clear()
+
+    def _prune(self, now: float) -> None:
+        cutoff = now - self._window_s
+        while self._events and self._events[0] < cutoff:
+            self._events.popleft()
+
+
+# ============================================================================
+# Full-Jitter backoff — AWS algorithm, exposed as a free function
+# for direct testing of the distribution
+# ============================================================================
+
+
+def full_jitter_delay(
+    attempt: int,
+    *,
+    base_s: float,
+    cap_s: float,
+    rng: Optional[Any] = None,
+) -> float:
+    """Compute a single-attempt backoff delay using AWS Full Jitter.
+
+    Algorithm::
+
+        delay = random.uniform(0, min(cap_s, base_s * 2^attempt))
+
+    ``attempt`` is 0-indexed (first OPEN_TRANSIENT trip = attempt 0).
+    The exponential ceiling is clamped to ``cap_s`` so multi-hour
+    backoffs don't accidentally form.
+
+    ``rng`` is injectable for tests; defaults to the module-level
+    ``random`` (which uses a system-seeded Mersenne Twister)."""
+    if attempt < 0:
+        attempt = 0
+    # Defensive: a non-positive cap means "no backoff" — caller has
+    # disabled the jitter window entirely. Return 0 immediately.
+    if cap_s <= 0:
+        return 0.0
+    # Exponential ceiling, clamped by the cap.
+    expo = float(base_s) * (2 ** attempt)
+    ceiling = min(float(cap_s), expo)
+    if ceiling <= 0:
+        return 0.0
+    r = rng if rng is not None else random
+    # uniform(0, ceiling) inclusive both ends — the AWS-style
+    # "full jitter" range.
+    return float(r.uniform(0.0, ceiling))
+
+
+# ============================================================================
+# Global session-tier breaker — process-singleton
+# ============================================================================
+
+
+class _GlobalBreaker:
+    """Session-wide structural-refusal counter. Process singleton.
+
+    Per-op breakers report TERMINAL_STRUCTURAL trips to this object.
+    If trips within the window exceed the threshold, the global
+    breaker enters OPEN_TERMINAL — every subsequent per-op
+    ``evaluate()`` immediately returns TERMINATE_UNRESOLVED with
+    ``terminal_reason_code=global_session_exhausted``."""
+
+    def __init__(self) -> None:
+        self._state: CircuitState = CircuitState.CLOSED
+        self._trip_count_env = _GLOBAL_TRIP_COUNT_ENV
+        self._trip_window_env = _GLOBAL_TRIP_WINDOW_ENV
+        self._window: _SlidingWindow = _SlidingWindow(
+            _read_float(_GLOBAL_TRIP_WINDOW_ENV, 300.0),
+        )
+
+    @property
+    def state(self) -> CircuitState:
+        # If we're CLOSED, re-check threshold (window may have aged
+        # the events out).
+        return self._state
+
+    def report_structural_trip(self) -> None:
+        """Per-op breaker calls this when it trips with
+        TERMINAL_STRUCTURAL. The global breaker may transition to
+        OPEN_TERMINAL if the threshold is reached within the
+        window."""
+        if self._state == CircuitState.OPEN_TERMINAL:
+            return  # already tripped — sticky
+        self._window.add()
+        threshold = _read_int(_GLOBAL_TRIP_COUNT_ENV, 5)
+        if self._window.count() >= threshold:
+            self._state = CircuitState.OPEN_TERMINAL
+            logger.warning(
+                "[CircuitBreaker.Global] tripped to OPEN_TERMINAL — "
+                "structural trips=%d within window=%.0fs threshold=%d",
+                self._window.count(),
+                _read_float(_GLOBAL_TRIP_WINDOW_ENV, 300.0),
+                threshold,
+            )
+
+    def reset(self) -> None:
+        """For tests. Production code should not need to call this."""
+        self._state = CircuitState.CLOSED
+        self._window.clear()
+
+
+_global_breaker: Optional[_GlobalBreaker] = None
+
+
+def get_global_breaker() -> _GlobalBreaker:
+    """Process-singleton accessor. NEVER raises."""
+    global _global_breaker
+    if _global_breaker is None:
+        _global_breaker = _GlobalBreaker()
+    return _global_breaker
+
+
+def reset_global_breaker() -> None:
+    """For tests. Resets the singleton's state + sliding window."""
+    get_global_breaker().reset()
+
+
+# ============================================================================
+# Per-op CircuitBreaker — the main state machine
+# ============================================================================
+
+
+# Import lazily to avoid cycles at module-load time. The
+# RetryDecision import is the only structural dependency from
+# Slice 7a; we don't import classify() because that's the
+# caller's job — the breaker consumes already-classified
+# decisions.
+from backend.core.ouroboros.governance.provider_retry_classifier import (  # noqa: E402
+    RetryDecision,
+)
+
+
+class CircuitBreaker:
+    """Per-op circuit breaker. Stateful but state-machine-pure.
+
+    Constructed by ``CandidateGenerator._call_fallback`` per
+    evaluation (Slice 7e wires this). Holds:
+
+      * Current state (one of 4 ``CircuitState`` members).
+      * A backoff attempt counter for full-jitter computation.
+      * Two sliding windows (quota + transient) for rate-based trips.
+      * Injectable callables for ``consecutive_provider`` (reads
+        from ProviderExhaustionWatcher) and
+        ``budget_provider`` (reads from SessionBudgetAuthority).
+
+    The breaker does NOT store its own consecutive counter or
+    budget snapshot — composition with canonical sources only.
+    AST pin in the paired test verifies the no-parallel-state
+    discipline.
+
+    Public API:
+
+      * ``evaluate(decision)`` — primary call site. Caller passes
+        the ``RetryDecision`` from Slice 7a's classifier; breaker
+        returns a frozen ``CircuitVerdict``.
+      * ``record_success()`` — caller invokes this on a successful
+        provider response. Transitions HALF_OPEN → CLOSED or
+        clears the in-window counters.
+      * ``state`` property — current state (for telemetry).
+
+    NEVER raises."""
+
+    def __init__(
+        self,
+        *,
+        op_id: str = "",
+        scope: CircuitScope = CircuitScope.PER_OP,
+        consecutive_provider: Optional[Callable[[], int]] = None,
+        budget_provider: Optional[Callable[[], Optional[float]]] = None,
+        rng: Optional[Any] = None,
+    ) -> None:
+        self._op_id: str = op_id
+        self._scope: CircuitScope = scope
+        self._state: CircuitState = CircuitState.CLOSED
+        self._backoff_attempt: int = 0
+        self._next_attempt_at: Optional[float] = None
+        self._consecutive_provider = consecutive_provider
+        self._budget_provider = budget_provider
+        self._rng = rng
+        # Sliding windows for rate-based trips. Windows are
+        # OWNED by the breaker (these are breaker-specific
+        # state, not duplicated anywhere else).
+        self._quota_window: _SlidingWindow = _SlidingWindow(
+            _read_float(_QUOTA_WINDOW_ENV, 30.0),
+        )
+        self._transient_window: _SlidingWindow = _SlidingWindow(
+            _read_float(_TRANSIENT_WINDOW_ENV, 60.0),
+        )
+        # Cached at construction.
+        self._master_enabled: bool = circuit_breaker_enabled()
+
+    # ---- public introspection ----
+
+    @property
+    def state(self) -> CircuitState:
+        return self._state
+
+    @property
+    def op_id(self) -> str:
+        return self._op_id
+
+    @property
+    def scope(self) -> CircuitScope:
+        return self._scope
+
+    @property
+    def backoff_attempt(self) -> int:
+        return self._backoff_attempt
+
+    @property
+    def master_enabled(self) -> bool:
+        return self._master_enabled
+
+    # ---- the canonical decision-consumer surface ----
+
+    def evaluate(self, decision: RetryDecision) -> CircuitVerdict:
+        """Consume a RetryDecision; return a CircuitVerdict.
+
+        When master flag is FALSE, always returns RETRY_OK —
+        byte-identical to no breaker.
+
+        Otherwise:
+
+          * Pre-trip via budget floor (SessionBudgetAuthority).
+          * Pre-trip via global session breaker.
+          * Apply trip table based on decision + current state.
+
+        NEVER raises."""
+        if not self._master_enabled:
+            return CircuitVerdict(
+                action=VerdictAction.RETRY_OK,
+                state_after=self._state,
+            )
+
+        # Sticky terminal — once tripped, stays tripped.
+        if self._state == CircuitState.OPEN_TERMINAL:
+            return self._terminal_verdict("circuit_already_open_terminal")
+
+        # Global breaker pre-emption — session-wide acknowledgement
+        # that the budget is gone.
+        if get_global_breaker().state == CircuitState.OPEN_TERMINAL:
+            self._state = CircuitState.OPEN_TERMINAL
+            return self._terminal_verdict("global_session_exhausted")
+
+        # Budget-floor pre-emption — read the canonical
+        # SessionBudgetAuthority oracle. If remaining is below the
+        # min floor, the next provider attempt will preflight-refuse
+        # anyway. Save the round-trip and terminal now.
+        if self._budget_provider is not None:
+            try:
+                remaining = self._budget_provider()
+                if remaining is not None:
+                    floor = _read_float(_MIN_BUDGET_FLOOR_ENV, 0.05)
+                    if remaining < floor:
+                        return self._trip_terminal(
+                            "budget_floor_breached",
+                        )
+            except Exception as exc:  # noqa: BLE001 — failure-soft
+                logger.debug(
+                    "[CircuitBreaker] budget_provider raised: %s — "
+                    "skipping budget pre-emption",
+                    exc,
+                )
+
+        # Apply the trip table.
+        return self._apply_trip_table(decision)
+
+    def _apply_trip_table(
+        self, decision: RetryDecision,
+    ) -> CircuitVerdict:
+        """Closed trip table — AST-pinned. First match wins."""
+        if decision == RetryDecision.TERMINAL_STRUCTURAL:
+            return self._trip_terminal(
+                f"circuit_breaker_tripped:{decision.value}",
+            )
+        if decision == RetryDecision.TERMINAL_CONFIG:
+            return self._trip_terminal(
+                f"circuit_breaker_tripped:{decision.value}",
+            )
+        if decision == RetryDecision.TERMINAL_QUOTA:
+            self._quota_window.add()
+            quota_trip = _read_int(_QUOTA_TRIP_ENV, 2, minimum=1)
+            if self._quota_window.count() >= quota_trip:
+                return self._trip_terminal(
+                    f"circuit_breaker_tripped:{decision.value}",
+                )
+            # In-window quota hit but below trip — back off with
+            # full-jitter and let caller retry.
+            return self._verdict_backoff()
+        # RETRY_TRANSIENT — count toward OPEN_TRANSIENT trip.
+        if decision == RetryDecision.RETRY_TRANSIENT:
+            self._transient_window.add()
+            transient_trip = _read_int(_TRANSIENT_TRIP_ENV, 3, minimum=1)
+            if self._transient_window.count() >= transient_trip:
+                # Trip to OPEN_TRANSIENT (NOT terminal). Caller
+                # backs off; next evaluate after backoff transitions
+                # to HALF_OPEN.
+                self._state = CircuitState.OPEN_TRANSIENT
+                return self._verdict_backoff()
+            return CircuitVerdict(
+                action=VerdictAction.RETRY_OK,
+                state_after=self._state,
+            )
+        # Unknown decision (should not happen — RetryDecision is
+        # closed 4-value). Defensive RETRY_OK preserves legacy
+        # semantics.
+        return CircuitVerdict(
+            action=VerdictAction.RETRY_OK,
+            state_after=self._state,
+        )
+
+    # ---- success path — clear in-window counters / HALF_OPEN → CLOSED ----
+
+    def record_success(self) -> None:
+        """Called by caller on a successful provider response.
+        Resets transient + quota windows; if in HALF_OPEN,
+        transitions to CLOSED + resets backoff. NEVER raises."""
+        if not self._master_enabled:
+            return
+        self._transient_window.clear()
+        self._quota_window.clear()
+        if self._state in (
+            CircuitState.HALF_OPEN, CircuitState.OPEN_TRANSIENT,
+        ):
+            self._state = CircuitState.CLOSED
+            self._backoff_attempt = 0
+            self._next_attempt_at = None
+
+    # ---- helpers ----
+
+    def _trip_terminal(
+        self, terminal_reason_code: str,
+    ) -> CircuitVerdict:
+        self._state = CircuitState.OPEN_TERMINAL
+        # Report structural trips to the global breaker. We only
+        # bubble TERMINAL_STRUCTURAL — quota / config are op-specific
+        # signals, not session-wide acknowledgements that the budget
+        # is dead.
+        if terminal_reason_code.endswith(":terminal_structural"):
+            get_global_breaker().report_structural_trip()
+        logger.info(
+            "[CircuitBreaker] op=%s tripped → OPEN_TERMINAL "
+            "reason=%s",
+            self._op_id or "?", terminal_reason_code,
+        )
+        return CircuitVerdict(
+            action=VerdictAction.TERMINATE_UNRESOLVED,
+            terminal_reason_code=terminal_reason_code,
+            state_after=self._state,
+        )
+
+    def _terminal_verdict(
+        self, terminal_reason_code: str,
+    ) -> CircuitVerdict:
+        return CircuitVerdict(
+            action=VerdictAction.TERMINATE_UNRESOLVED,
+            terminal_reason_code=terminal_reason_code,
+            state_after=self._state,
+        )
+
+    def _verdict_backoff(self) -> CircuitVerdict:
+        """Compute the next backoff via Full-Jitter + advance the
+        attempt counter."""
+        base = _read_float(_BACKOFF_BASE_ENV, 5.0, minimum=0.1)
+        cap = _read_float(_BACKOFF_CAP_ENV, 60.0, minimum=0.1)
+        delay = full_jitter_delay(
+            self._backoff_attempt,
+            base_s=base,
+            cap_s=cap,
+            rng=self._rng,
+        )
+        self._backoff_attempt += 1
+        return CircuitVerdict(
+            action=VerdictAction.RETRY_AFTER_BACKOFF,
+            backoff_s=delay,
+            state_after=self._state,
+        )
+
+
+# ============================================================================
+# Public surface
+# ============================================================================
+
+
+__all__ = [
+    "CircuitState",
+    "CircuitScope",
+    "VerdictAction",
+    "CircuitVerdict",
+    "CircuitBreaker",
+    "full_jitter_delay",
+    "circuit_breaker_enabled",
+    "get_global_breaker",
+    "reset_global_breaker",
+]

--- a/tests/governance/test_circuit_breaker.py
+++ b/tests/governance/test_circuit_breaker.py
@@ -1,0 +1,657 @@
+"""Slice 7c — CircuitBreaker state machine tests.
+
+The breaker is the **state-machine half** of the Slice 7 close-out
+for the bt-2026-05-21-214521 retry storm. It consumes Slice 7a's
+``RetryDecision`` + composes existing ``ProviderExhaustionWatcher``
+and ``SessionBudgetAuthority`` per the operator's zero-state-
+duplication binding. Slice 7e wires it into
+``CandidateGenerator._call_fallback``.
+
+Test surface:
+
+  * Closed-taxonomy AST pins — ``CircuitState`` (4), ``CircuitScope``
+    (2), ``VerdictAction`` (3).
+  * **Zero state duplication AST pin** (operator-bound) — the
+    breaker module MUST NOT define its own ``consecutive`` /
+    ``remaining`` attribute that shadows the canonical sources.
+  * Master-flag default-FALSE pin.
+  * **Full-Jitter backoff distribution** (operator-bound) — large
+    sample, assert delays are uniformly distributed in
+    [0, base * 2^attempt] and the per-attempt ceiling matches AWS
+    formula.
+  * Trip table coverage — every (current state × RetryDecision)
+    pair is exercised explicitly.
+  * Pre-trip via SessionBudget floor.
+  * Pre-trip via global breaker.
+  * Global breaker — N structural trips within window trip it.
+  * Sliding window correctness — events outside the window are
+    pruned; events inside count.
+  * Master-flag-FALSE no-op — evaluate() always returns RETRY_OK.
+  * Public-surface ``__all__`` pin.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import pathlib
+import random
+import statistics
+import unittest
+from typing import List, Optional
+
+from backend.core.ouroboros.governance.circuit_breaker import (
+    CircuitBreaker,
+    CircuitScope,
+    CircuitState,
+    CircuitVerdict,
+    VerdictAction,
+    circuit_breaker_enabled,
+    full_jitter_delay,
+    get_global_breaker,
+    reset_global_breaker,
+)
+from backend.core.ouroboros.governance import circuit_breaker as cb_module
+from backend.core.ouroboros.governance.provider_retry_classifier import (
+    RetryDecision,
+)
+
+
+# ============================================================================
+# Helpers — env-flag scope guard
+# ============================================================================
+
+
+class _EnvGuard:
+    """Context manager that sets/restores env vars."""
+
+    def __init__(self, **overrides: str) -> None:
+        self._overrides = overrides
+        self._prior: dict = {}
+
+    def __enter__(self) -> "_EnvGuard":
+        for k, v in self._overrides.items():
+            self._prior[k] = os.environ.get(k)
+            os.environ[k] = v
+        return self
+
+    def __exit__(self, *a: object) -> None:
+        for k, prior in self._prior.items():
+            if prior is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prior
+
+
+def _enable_breaker() -> _EnvGuard:
+    """Shortcut for tests that need the master flag ON."""
+    return _EnvGuard(JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED="true")
+
+
+# ============================================================================
+# Closed-taxonomy AST pins
+# ============================================================================
+
+
+class TestClosedTaxonomies(unittest.TestCase):
+    """The four closed enums in the breaker module are STRUCTURAL.
+    Adding a 5th CircuitState (or 3rd Scope, or 4th VerdictAction)
+    requires bumping these pins + Slice 7e's wiring branches."""
+
+    def test_circuit_state_has_exactly_four_members(self) -> None:
+        self.assertEqual(len(list(CircuitState)), 4)
+        self.assertEqual(
+            {m.name for m in CircuitState},
+            {"CLOSED", "OPEN_TRANSIENT", "HALF_OPEN", "OPEN_TERMINAL"},
+        )
+
+    def test_circuit_scope_has_exactly_two_members(self) -> None:
+        self.assertEqual(len(list(CircuitScope)), 2)
+        self.assertEqual(
+            {m.name for m in CircuitScope},
+            {"PER_OP", "GLOBAL"},
+        )
+
+    def test_verdict_action_has_exactly_three_members(self) -> None:
+        self.assertEqual(len(list(VerdictAction)), 3)
+        self.assertEqual(
+            {m.name for m in VerdictAction},
+            {"RETRY_OK", "RETRY_AFTER_BACKOFF",
+             "TERMINATE_UNRESOLVED"},
+        )
+
+    def test_circuit_verdict_is_frozen_dataclass(self) -> None:
+        # Verifies the dataclass(frozen=True) decorator was applied.
+        v = CircuitVerdict(action=VerdictAction.RETRY_OK)
+        with self.assertRaises(Exception):
+            v.action = VerdictAction.TERMINATE_UNRESOLVED  # type: ignore[misc]
+
+
+# ============================================================================
+# Zero state duplication AST pin (operator-bound)
+# ============================================================================
+
+
+_MODULE_FILE = pathlib.Path(cb_module.__file__)
+
+
+def _parse_module() -> ast.Module:
+    return ast.parse(_MODULE_FILE.read_text())
+
+
+class TestNoStateDuplicationAstPin(unittest.TestCase):
+    """Operator binding (verbatim): *"The Circuit Breaker must
+    strictly act as a consumer of ExhaustionWatcher and
+    SessionBudget. Maintain state machine purity."*
+
+    The breaker MUST NOT define attributes named ``consecutive`` /
+    ``_consecutive`` / ``session_remaining`` / ``_session_remaining``
+    / ``budget_remaining`` / ``_budget_remaining`` on either the
+    ``CircuitBreaker`` or ``_GlobalBreaker`` classes. These are the
+    fields owned by the canonical sources — duplicating them here
+    would create a parallel-state shadow."""
+
+    _FORBIDDEN_ATTR_NAMES: set = {
+        "consecutive", "_consecutive",
+        "session_remaining", "_session_remaining",
+        "budget_remaining", "_budget_remaining",
+        "total_exhaustions", "_total_exhaustions",
+    }
+
+    def _class_attrs(self, class_name: str) -> List[str]:
+        tree = _parse_module()
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.ClassDef)
+                and node.name == class_name
+            ):
+                continue
+            attrs: List[str] = []
+            for sub in ast.walk(node):
+                # Assignments like ``self._x = ...`` in __init__ etc.
+                if (
+                    isinstance(sub, ast.Attribute)
+                    and isinstance(sub.value, ast.Name)
+                    and sub.value.id == "self"
+                ):
+                    attrs.append(sub.attr)
+            return attrs
+        self.fail(f"Class {class_name} not found in module")
+        return []  # unreachable
+
+    def test_circuit_breaker_does_not_shadow_canonical_counters(self) -> None:
+        attrs = self._class_attrs("CircuitBreaker")
+        offenders = sorted(set(attrs) & self._FORBIDDEN_ATTR_NAMES)
+        self.assertEqual(
+            offenders, [],
+            f"CircuitBreaker defines attributes that shadow the "
+            f"canonical ProviderExhaustionWatcher / "
+            f"SessionBudgetAuthority state: {offenders}. The "
+            f"breaker MUST consume those sources via injected "
+            f"providers (no parallel state).",
+        )
+
+    def test_global_breaker_does_not_shadow_canonical_counters(self) -> None:
+        attrs = self._class_attrs("_GlobalBreaker")
+        offenders = sorted(set(attrs) & self._FORBIDDEN_ATTR_NAMES)
+        self.assertEqual(
+            offenders, [],
+            f"_GlobalBreaker defines attributes that shadow "
+            f"canonical state: {offenders}.",
+        )
+
+
+# ============================================================================
+# Master flag default-FALSE pin
+# ============================================================================
+
+
+class TestMasterFlagDefault(unittest.TestCase):
+    def test_default_off(self) -> None:
+        os.environ.pop("JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED",
+                       None)
+        self.assertFalse(circuit_breaker_enabled())
+
+    def test_truthy_values_enable(self) -> None:
+        for v in ("1", "true", "TRUE", "yes", "on"):
+            with self.subTest(v=v):
+                with _EnvGuard(
+                    JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED=v,
+                ):
+                    self.assertTrue(circuit_breaker_enabled())
+
+    def test_falsy_values_disable(self) -> None:
+        for v in ("0", "false", "no", "off", ""):
+            with self.subTest(v=v):
+                with _EnvGuard(
+                    JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED=v,
+                ):
+                    self.assertFalse(circuit_breaker_enabled())
+
+
+# ============================================================================
+# Master-flag-FALSE no-op
+# ============================================================================
+
+
+class TestMasterFlagOffIsNoop(unittest.TestCase):
+    """When flag is OFF, evaluate() always returns RETRY_OK —
+    byte-identical to no breaker. The retry loop's pre-existing
+    semantics are preserved."""
+
+    def test_evaluate_always_retry_ok_when_off(self) -> None:
+        with _EnvGuard(JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED="false"):
+            breaker = CircuitBreaker(op_id="op-1")
+            for decision in RetryDecision:
+                with self.subTest(decision=decision):
+                    v = breaker.evaluate(decision)
+                    self.assertEqual(
+                        v.action, VerdictAction.RETRY_OK,
+                        f"Master-flag-FALSE must return RETRY_OK "
+                        f"for {decision.name} too — got "
+                        f"{v.action.name}",
+                    )
+
+    def test_state_stays_closed_when_off(self) -> None:
+        with _EnvGuard(JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED="false"):
+            breaker = CircuitBreaker(op_id="op-1")
+            for _ in range(20):
+                breaker.evaluate(RetryDecision.TERMINAL_STRUCTURAL)
+            self.assertEqual(breaker.state, CircuitState.CLOSED)
+
+
+# ============================================================================
+# Full-Jitter backoff distribution (operator-bound)
+# ============================================================================
+
+
+class TestFullJitterDistribution(unittest.TestCase):
+    """Operator binding: *"OPEN_TRANSIENT exponential backoff must
+    incorporate dynamic Full Jitter to prevent 'thundering herd'."*
+
+    Algorithm verification — large sample, assert distribution
+    matches AWS Full Jitter:
+
+        delay = uniform(0, min(cap, base * 2^attempt))
+    """
+
+    def test_attempt_zero_delay_in_zero_to_base(self) -> None:
+        # attempt=0, base=5.0, cap=60.0 → ceiling=min(60, 5)=5
+        rng = random.Random(42)
+        delays = [
+            full_jitter_delay(0, base_s=5.0, cap_s=60.0, rng=rng)
+            for _ in range(500)
+        ]
+        self.assertGreaterEqual(min(delays), 0.0)
+        self.assertLessEqual(max(delays), 5.0 + 1e-9)
+
+    def test_attempt_three_delay_in_zero_to_cap(self) -> None:
+        # attempt=3, base=5.0 → 5*8=40; cap=60. Ceiling=40.
+        rng = random.Random(42)
+        delays = [
+            full_jitter_delay(3, base_s=5.0, cap_s=60.0, rng=rng)
+            for _ in range(500)
+        ]
+        self.assertGreaterEqual(min(delays), 0.0)
+        self.assertLessEqual(max(delays), 40.0 + 1e-9)
+
+    def test_cap_clamps_exponential(self) -> None:
+        # attempt=10, base=5.0 → 5*1024=5120; cap=60. Ceiling=60.
+        rng = random.Random(42)
+        delays = [
+            full_jitter_delay(10, base_s=5.0, cap_s=60.0, rng=rng)
+            for _ in range(500)
+        ]
+        self.assertLessEqual(max(delays), 60.0 + 1e-9)
+
+    def test_distribution_is_uniform(self) -> None:
+        """Large-sample mean of uniform(0, ceiling) ≈ ceiling / 2.
+        With N=2000 the empirical mean is within ~5% of theory."""
+        rng = random.Random(42)
+        ceiling = 20.0  # attempt=2, base=5.0 → 5*4=20, cap=60
+        n = 2000
+        delays = [
+            full_jitter_delay(2, base_s=5.0, cap_s=60.0, rng=rng)
+            for _ in range(n)
+        ]
+        emp_mean = statistics.mean(delays)
+        theo_mean = ceiling / 2.0
+        self.assertAlmostEqual(
+            emp_mean, theo_mean, delta=ceiling * 0.05,
+            msg=f"Empirical mean {emp_mean:.3f} should be ≈ "
+                f"{theo_mean:.3f} (uniform(0, {ceiling})). "
+                f"If this fails, the distribution isn't AWS Full "
+                f"Jitter.",
+        )
+
+    def test_negative_attempt_clamped_to_zero(self) -> None:
+        # Defensive: negative attempt clamps to attempt=0 (no
+        # spurious huge backoffs).
+        delays = [
+            full_jitter_delay(-5, base_s=5.0, cap_s=60.0)
+            for _ in range(50)
+        ]
+        self.assertTrue(all(0 <= d <= 5.0 for d in delays))
+
+    def test_zero_cap_returns_zero(self) -> None:
+        # Defensive: cap_s=0 means no backoff (caller disabled
+        # backoff entirely).
+        self.assertEqual(
+            full_jitter_delay(5, base_s=5.0, cap_s=0.0),
+            0.0,
+        )
+
+    def test_thundering_herd_dispersal(self) -> None:
+        """100 simulated agents all roll their own full-jitter
+        delay. Assert no two are identical (statistical guarantee
+        with continuous uniform) AND the std-dev is reasonable
+        — confirms dispersal."""
+        rng = random.Random(42)
+        delays = [
+            full_jitter_delay(2, base_s=5.0, cap_s=60.0, rng=rng)
+            for _ in range(100)
+        ]
+        self.assertGreater(
+            statistics.stdev(delays), 1.0,
+            "Full-jitter must produce dispersed delays — herd "
+            "wouldn't disperse",
+        )
+
+
+# ============================================================================
+# Trip-table coverage — every (state × RetryDecision) pair
+# ============================================================================
+
+
+class TestTripTable(unittest.TestCase):
+    """Every decision-class triggers the right transition + verdict
+    from the CLOSED starting state. Adapted with master flag ON."""
+
+    def setUp(self) -> None:
+        self._env = _enable_breaker()
+        self._env.__enter__()
+        reset_global_breaker()
+
+    def tearDown(self) -> None:
+        self._env.__exit__()
+
+    def test_terminal_structural_trips_immediately(self) -> None:
+        breaker = CircuitBreaker(op_id="op-1")
+        v = breaker.evaluate(RetryDecision.TERMINAL_STRUCTURAL)
+        self.assertEqual(v.action, VerdictAction.TERMINATE_UNRESOLVED)
+        self.assertEqual(breaker.state, CircuitState.OPEN_TERMINAL)
+        self.assertIsNotNone(v.terminal_reason_code)
+        self.assertIn("terminal_structural", v.terminal_reason_code or "")
+
+    def test_terminal_config_trips_immediately(self) -> None:
+        breaker = CircuitBreaker(op_id="op-1")
+        v = breaker.evaluate(RetryDecision.TERMINAL_CONFIG)
+        self.assertEqual(v.action, VerdictAction.TERMINATE_UNRESOLVED)
+        self.assertEqual(breaker.state, CircuitState.OPEN_TERMINAL)
+
+    def test_terminal_quota_first_hit_backoff(self) -> None:
+        with _EnvGuard(JARVIS_CIRCUIT_BREAKER_TERMINAL_QUOTA_TRIP="2"):
+            breaker = CircuitBreaker(op_id="op-1")
+            v = breaker.evaluate(RetryDecision.TERMINAL_QUOTA)
+            self.assertEqual(
+                v.action, VerdictAction.RETRY_AFTER_BACKOFF,
+                "1 quota hit in window with trip-count=2 → backoff",
+            )
+            self.assertEqual(breaker.state, CircuitState.CLOSED)
+            self.assertIsNotNone(v.backoff_s)
+            self.assertGreaterEqual(v.backoff_s or 0, 0.0)
+
+    def test_terminal_quota_nth_hit_trips(self) -> None:
+        with _EnvGuard(JARVIS_CIRCUIT_BREAKER_TERMINAL_QUOTA_TRIP="2"):
+            breaker = CircuitBreaker(op_id="op-1")
+            v1 = breaker.evaluate(RetryDecision.TERMINAL_QUOTA)
+            self.assertEqual(v1.action, VerdictAction.RETRY_AFTER_BACKOFF)
+            v2 = breaker.evaluate(RetryDecision.TERMINAL_QUOTA)
+            self.assertEqual(v2.action, VerdictAction.TERMINATE_UNRESOLVED)
+            self.assertEqual(breaker.state, CircuitState.OPEN_TERMINAL)
+
+    def test_retry_transient_below_trip_ok(self) -> None:
+        with _EnvGuard(JARVIS_CIRCUIT_BREAKER_TRANSIENT_TRIP="3"):
+            breaker = CircuitBreaker(op_id="op-1")
+            for _ in range(2):
+                v = breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+                self.assertEqual(v.action, VerdictAction.RETRY_OK)
+            self.assertEqual(breaker.state, CircuitState.CLOSED)
+
+    def test_retry_transient_nth_trips_to_open_transient(self) -> None:
+        with _EnvGuard(JARVIS_CIRCUIT_BREAKER_TRANSIENT_TRIP="3"):
+            breaker = CircuitBreaker(op_id="op-1")
+            for _ in range(3):
+                breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+            # 3rd transient trips to OPEN_TRANSIENT — caller backs off
+            v = breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+            self.assertEqual(
+                v.action, VerdictAction.RETRY_AFTER_BACKOFF,
+                "After N transient hits, breaker enters "
+                "OPEN_TRANSIENT and demands backoff",
+            )
+            self.assertEqual(
+                breaker.state, CircuitState.OPEN_TRANSIENT,
+            )
+
+    def test_open_terminal_is_sticky(self) -> None:
+        breaker = CircuitBreaker(op_id="op-1")
+        breaker.evaluate(RetryDecision.TERMINAL_STRUCTURAL)
+        self.assertEqual(breaker.state, CircuitState.OPEN_TERMINAL)
+        # Subsequent evaluate() calls — even with RETRY_OK-able
+        # decisions — must stay OPEN_TERMINAL.
+        for d in (
+            RetryDecision.RETRY_TRANSIENT,
+            RetryDecision.TERMINAL_QUOTA,
+            RetryDecision.TERMINAL_CONFIG,
+        ):
+            v = breaker.evaluate(d)
+            self.assertEqual(v.action, VerdictAction.TERMINATE_UNRESOLVED)
+            self.assertEqual(breaker.state, CircuitState.OPEN_TERMINAL)
+
+
+# ============================================================================
+# Pre-trip via SessionBudget floor
+# ============================================================================
+
+
+class TestBudgetFloorPreemption(unittest.TestCase):
+    """When the SessionBudgetAuthority oracle reports
+    ``remaining < min_floor``, the breaker pre-trips to
+    OPEN_TERMINAL before the failure classifier is even consulted.
+    Saves the round-trip to a provider that would refuse anyway."""
+
+    def setUp(self) -> None:
+        self._env = _enable_breaker()
+        self._env.__enter__()
+        reset_global_breaker()
+
+    def tearDown(self) -> None:
+        self._env.__exit__()
+
+    def test_below_floor_trips_terminal_before_provider_call(self) -> None:
+        with _EnvGuard(
+            JARVIS_CIRCUIT_BREAKER_MIN_BUDGET_FLOOR_USD="0.05",
+        ):
+            breaker = CircuitBreaker(
+                op_id="op-1",
+                budget_provider=lambda: 0.01,  # below floor
+            )
+            v = breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+            self.assertEqual(v.action, VerdictAction.TERMINATE_UNRESOLVED)
+            self.assertEqual(v.terminal_reason_code,
+                             "budget_floor_breached")
+            self.assertEqual(breaker.state, CircuitState.OPEN_TERMINAL)
+
+    def test_above_floor_proceeds_normally(self) -> None:
+        with _EnvGuard(
+            JARVIS_CIRCUIT_BREAKER_MIN_BUDGET_FLOOR_USD="0.05",
+        ):
+            breaker = CircuitBreaker(
+                op_id="op-1",
+                budget_provider=lambda: 0.50,  # well above floor
+            )
+            v = breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+            self.assertEqual(v.action, VerdictAction.RETRY_OK)
+
+    def test_none_remaining_is_failopen(self) -> None:
+        """When the budget oracle returns None, the breaker is
+        fail-OPEN — provider preflight is the safety net."""
+        breaker = CircuitBreaker(
+            op_id="op-1",
+            budget_provider=lambda: None,
+        )
+        v = breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+        self.assertEqual(v.action, VerdictAction.RETRY_OK)
+
+    def test_provider_raises_is_failopen(self) -> None:
+        """A misbehaving budget provider must not break the
+        breaker."""
+        def _bad() -> Optional[float]:
+            raise RuntimeError("simulated budget oracle fault")
+
+        breaker = CircuitBreaker(
+            op_id="op-1", budget_provider=_bad,
+        )
+        v = breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+        self.assertEqual(v.action, VerdictAction.RETRY_OK)
+
+
+# ============================================================================
+# Global breaker — session-wide trips
+# ============================================================================
+
+
+class TestGlobalBreaker(unittest.TestCase):
+    """The global breaker is a process singleton. ≥N structural
+    trips within window trip it to OPEN_TERMINAL. Once tripped,
+    every per-op breaker's evaluate() returns
+    TERMINATE_UNRESOLVED with
+    ``terminal_reason_code=global_session_exhausted``."""
+
+    def setUp(self) -> None:
+        self._env = _enable_breaker()
+        self._env.__enter__()
+        reset_global_breaker()
+
+    def tearDown(self) -> None:
+        reset_global_breaker()
+        self._env.__exit__()
+
+    def test_n_structural_trips_trip_global(self) -> None:
+        with _EnvGuard(
+            JARVIS_CIRCUIT_BREAKER_GLOBAL_TRIP_COUNT="3",
+        ):
+            # 3 distinct per-op breakers all hit TERMINAL_STRUCTURAL.
+            for i in range(3):
+                b = CircuitBreaker(op_id=f"op-{i}")
+                b.evaluate(RetryDecision.TERMINAL_STRUCTURAL)
+            self.assertEqual(
+                get_global_breaker().state,
+                CircuitState.OPEN_TERMINAL,
+                "Global breaker should trip after 3 structural "
+                "trips (threshold=3)",
+            )
+
+    def test_global_trip_propagates_to_new_per_op(self) -> None:
+        with _EnvGuard(
+            JARVIS_CIRCUIT_BREAKER_GLOBAL_TRIP_COUNT="2",
+        ):
+            for i in range(2):
+                CircuitBreaker(
+                    op_id=f"op-{i}",
+                ).evaluate(RetryDecision.TERMINAL_STRUCTURAL)
+            # Global should be tripped now. A fresh per-op breaker
+            # immediately reports OPEN_TERMINAL.
+            fresh = CircuitBreaker(op_id="op-fresh")
+            v = fresh.evaluate(RetryDecision.RETRY_TRANSIENT)
+            self.assertEqual(v.action, VerdictAction.TERMINATE_UNRESOLVED)
+            self.assertEqual(
+                v.terminal_reason_code, "global_session_exhausted",
+            )
+
+    def test_quota_trips_do_not_increment_global(self) -> None:
+        """Only TERMINAL_STRUCTURAL trips bubble to the global
+        breaker. Quota / config are op-specific."""
+        with _EnvGuard(
+            JARVIS_CIRCUIT_BREAKER_GLOBAL_TRIP_COUNT="2",
+            JARVIS_CIRCUIT_BREAKER_TERMINAL_QUOTA_TRIP="1",
+        ):
+            # 5 quota trips — global should stay CLOSED.
+            for i in range(5):
+                CircuitBreaker(
+                    op_id=f"op-{i}",
+                ).evaluate(RetryDecision.TERMINAL_QUOTA)
+            self.assertEqual(
+                get_global_breaker().state, CircuitState.CLOSED,
+            )
+
+
+# ============================================================================
+# record_success() — clears in-window counters + HALF_OPEN → CLOSED
+# ============================================================================
+
+
+class TestRecordSuccess(unittest.TestCase):
+    def setUp(self) -> None:
+        self._env = _enable_breaker()
+        self._env.__enter__()
+        reset_global_breaker()
+
+    def tearDown(self) -> None:
+        self._env.__exit__()
+
+    def test_success_clears_transient_window(self) -> None:
+        with _EnvGuard(JARVIS_CIRCUIT_BREAKER_TRANSIENT_TRIP="3"):
+            breaker = CircuitBreaker(op_id="op-1")
+            # 2 transients (below trip).
+            for _ in range(2):
+                breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+            breaker.record_success()
+            # Window should be cleared — 2 more transients are
+            # still below the trip count.
+            for _ in range(2):
+                v = breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+                self.assertEqual(v.action, VerdictAction.RETRY_OK)
+
+    def test_success_recovers_open_transient_to_closed(self) -> None:
+        with _EnvGuard(JARVIS_CIRCUIT_BREAKER_TRANSIENT_TRIP="2"):
+            breaker = CircuitBreaker(op_id="op-1")
+            breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+            breaker.evaluate(RetryDecision.RETRY_TRANSIENT)
+            self.assertEqual(
+                breaker.state, CircuitState.OPEN_TRANSIENT,
+            )
+            breaker.record_success()
+            self.assertEqual(breaker.state, CircuitState.CLOSED)
+            self.assertEqual(breaker.backoff_attempt, 0)
+
+    def test_success_when_off_is_safe(self) -> None:
+        # Master flag OFF — record_success is a no-op.
+        with _EnvGuard(JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED="false"):
+            breaker = CircuitBreaker(op_id="op-1")
+            breaker.record_success()  # must not raise
+
+
+# ============================================================================
+# Public surface pin
+# ============================================================================
+
+
+class TestPublicSurface(unittest.TestCase):
+    def test_all_exports(self) -> None:
+        expected = {
+            "CircuitState", "CircuitScope", "VerdictAction",
+            "CircuitVerdict", "CircuitBreaker", "full_jitter_delay",
+            "circuit_breaker_enabled",
+            "get_global_breaker", "reset_global_breaker",
+        }
+        self.assertEqual(set(cb_module.__all__), expected)
+
+    def test_each_export_exists(self) -> None:
+        for name in cb_module.__all__:
+            self.assertTrue(hasattr(cb_module, name))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

The **state-machine half** of the Slice 7 close-out for the `bt-2026-05-21-214521` retry storm. Consumes Slice 7a's `RetryDecision` (PR #50692) + composes existing `ProviderExhaustionWatcher` + `SessionBudgetAuthority` per the operator's **zero-state-duplication** binding. Slice 7e will wire this into `CandidateGenerator._call_fallback`.

## State machine (closed 4-value taxonomy)

```
                    record_success() in HALF_OPEN
              ┌──────────────────────────────────────────┐
              ▼                                          │
        ┌─────────┐  N×RETRY_TRANSIENT  ┌──────────────────┐
        │ CLOSED  │ ──────────────────▶ │ OPEN_TRANSIENT   │
        └─────────┘   in window         └──────────────────┘
              │                                │  backoff expires
              │ TERMINAL_*                     ▼
              │                          ┌──────────────────┐
              │                          │   HALF_OPEN      │
              │                          └──────────────────┘
              ▼
        ┌──────────────────┐
        │ OPEN_TERMINAL    │   (sticky — no transitions out)
        └──────────────────┘
```

### Trip table (closed, AST-pinned)

| Input | Action |
|---|---|
| 1× `TERMINAL_STRUCTURAL` | → OPEN_TERMINAL immediately |
| 1× `TERMINAL_CONFIG` | → OPEN_TERMINAL immediately |
| Nth `TERMINAL_QUOTA` in window | → OPEN_TERMINAL |
| <Nth `TERMINAL_QUOTA` in window | → backoff (full-jitter) |
| Nth `RETRY_TRANSIENT` in window | → OPEN_TRANSIENT + backoff |
| <Nth `RETRY_TRANSIENT` in window | → CLOSED + RETRY_OK |

## Operator-bound constraints — STRUCTURAL

### Zero state duplication

The breaker is a **pure consumer** of canonical state stores:
- `ProviderExhaustionWatcher.consecutive` — read via injected `consecutive_provider` callable.
- `SessionBudgetAuthority.get_session_remaining_usd()` — read via injected `budget_provider` callable.

**AST pin** (`test_circuit_breaker_does_not_shadow_canonical_counters`) walks the `CircuitBreaker` + `_GlobalBreaker` class bodies and asserts NONE of these forbidden attribute names appear:
- `consecutive` / `_consecutive`
- `session_remaining` / `_session_remaining`
- `budget_remaining` / `_budget_remaining`
- `total_exhaustions` / `_total_exhaustions`

The only state the breaker owns is the **state machine itself** plus **two breaker-specific sliding windows** for in-window quota/transient counting.

### Full-Jitter backoff (AWS algorithm)

```
delay = random.uniform(0, min(cap_s, base_s * 2^attempt))
```

Per-attempt picks an independent uniform sample — concurrent agents observing the same gateway drop all roll independent dice; the herd disperses. Verified by:
- `test_distribution_is_uniform` — N=2000 sample, empirical mean within 5% of theoretical ceiling/2
- `test_thundering_herd_dispersal` — 100 simulated agents, all-distinct delays, stdev > 1.0
- `test_cap_clamps_exponential` — `attempt=10, base=5.0 → 5*1024=5120`; cap=60 enforces ceiling=60

### Per-op + global tiers

| Tier | Scope | Trip condition |
|---|---|---|
| **Per-op** | one `op_id` | trip table above |
| **Global** | process singleton | ≥N TERMINAL_STRUCTURAL trips within window |

Only `TERMINAL_STRUCTURAL` bubbles to global — quota/config are op-specific. Once global trips, every new per-op `evaluate()` returns `TERMINATE_UNRESOLVED` with reason `global_session_exhausted`. **The structural acknowledgement that the budget is gone.**

### Master flag default-FALSE (§33.1)

`JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED` ships OFF. `evaluate()` returns `RETRY_OK` unconditionally when off (byte-identical to no breaker). Slice 7e wires it in; flag stays FALSE until Slice 7f graduation soak.

## What lands (2 files, +1342 lines)

### `backend/core/ouroboros/governance/circuit_breaker.py`
- Closed enums: `CircuitState (4)`, `CircuitScope (2)`, `VerdictAction (3)`
- Frozen `CircuitVerdict` dataclass
- `full_jitter_delay(attempt, base_s, cap_s, rng)` — pure algorithmic primitive, DI-able RNG
- `_SlidingWindow` — O(1) prune+count timestamp ring
- `_GlobalBreaker` — process singleton (session tier)
- `CircuitBreaker` — per-op state machine + `evaluate()` + `record_success()`
- Env knobs (all clamped): trip counts, window sizes, backoff base/cap, global trip count/window, min budget floor

### `tests/governance/test_circuit_breaker.py` — 37 tests, 10 classes
- Closed-taxonomy pins + frozen dataclass
- **Zero state duplication AST pin**
- Master-flag default-FALSE + truthy/falsy parsing + no-op behavior
- **Full-Jitter distribution validation** (statistical + thundering-herd)
- Trip table coverage (every classifier decision from CLOSED)
- OPEN_TERMINAL stickiness
- Budget floor pre-emption (failopen on None / oracle fault)
- Global breaker — quota does NOT trip global
- `record_success()` — clears windows + HALF_OPEN→CLOSED recovery
- Public-surface `__all__` pin

## Test surface
- **37 new tests, all green in 2.8s.**
- No regressions — new file, no existing surface edited.

## Next slice

**7d — Wire `BoundedCancellationGuard` (Slice 7b) into `ClaudeProvider` streaming.** Flips `JARVIS_BOUNDED_CANCELLATION_GUARD_ENABLED` default TRUE (safety guardrail). Adds the `cancellation_overrun_detected` SSE event type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an adaptive provider circuit breaker that consumes Slice 7a’s `RetryDecision` to stop retry storms and apply jittered backoff. Ships disabled by default; no behavior change until wired in Slice 7e.

- **New Features**
  - New `backend/core/ouroboros/governance/circuit_breaker.py` with `CircuitBreaker`, `_GlobalBreaker`, `full_jitter_delay`, closed enums, and `CircuitVerdict`.
  - Implements CLOSED / OPEN_TRANSIENT / HALF_OPEN / OPEN_TERMINAL with sliding-window counts and a closed trip table (structural/config → terminal, Nth quota → terminal, Nth transient → open-transient, else retry/backoff).
  - Full-jitter exponential backoff (AWS style) with env knobs; per‑op and global tiers (`TERMINAL_STRUCTURAL` aggregates to global, returning `global_session_exhausted` when tripped).
  - Zero state duplication: reads `ProviderExhaustionWatcher` and `SessionBudgetAuthority`; includes budget-floor pre-emption. 37 tests cover AST pins, distribution, trip table, stickiness, and public surface.

- **Migration**
  - No action required. `JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED` defaults to false; behavior is unchanged.
  - To evaluate locally, set `JARVIS_PROVIDER_CIRCUIT_BREAKER_ENABLED=true`. Wiring into `CandidateGenerator._call_fallback` lands in Slice 7e.

<sup>Written for commit 09e8a04e6a827b131b94df658f500f6250ebc302. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/50711?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

