### PR TITLE
fix(governance): off-loop analysis + telemetry truth — Slice 11B-fix

### DIFF
--- a/backend/core/ouroboros/governance/ast_compile_helper.py
+++ b/backend/core/ouroboros/governance/ast_compile_helper.py
@@ -1,80 +1,90 @@
-"""Canonical AST/compile helper — Slice 11 Phase 11B.
+"""Canonical AST/compile helper — Slice 11 Phase 11B (+ 11B-fix).
 
 Closes the empirical wedge from bt-2026-05-22-013824 (Slice 11A
-provenance soak). The diagnostic captured **85 on-loop
-``ast.parse()`` calls totalling 101.3 seconds** of asyncio
-event-loop blocking time. The dominant caller was
-``opportunity_miner_sensor._scan_module`` — synchronous
-``ast.parse()`` on 19-31KB files taking 4-7 seconds each because
-CPython's GIL-held ``gc_collect_main`` cascade triggers during
-large-source AST construction.
+provenance soak): 85 on-loop ``ast.parse()`` calls totalling 101.3
+seconds of asyncio event-loop blocking time, dominant caller
+``opportunity_miner_sensor._scan_module``.
 
-## Phase 11B fix (operator-bound)
+## 11B → 11B-fix (operator-bound, bt-2026-05-22-055230)
 
-This module is the canonical helper that runs heavy AST/compile
-work **off the main asyncio control plane**. Architecture:
+The original 11B helper routed parse off-loop but **still returned
+an ``ast.AST`` across the IPC boundary**, and OpportunityMiner then
+ran ``_analyze_file`` (six AST walks) on the main thread. The
+acceptance soak proved the residual starvation: 31
+``[ControlPlaneStarvation]`` events, max lag 37.7 s, 171.7 s of
+loop-block time.
 
-  * ``await parse_python_source(caller, source, ...)`` — single
-    async entry point.
-  * **Process pool** isolation for source above a byte threshold
-    (default 4 KB). Each worker has its own GIL; the main asyncio
-    thread continues to tick during the parse.
-  * **Inline tiny** path for source below the threshold —
-    ``ast.parse()`` returns in <5ms for small files; the
-    process-pool IPC overhead would dominate.
-  * **Closed-taxonomy result** — ``ParseOutcome`` 5-value enum
-    (``OK / SYNTAX_ERROR / TIMEOUT / TOO_LARGE / INTERNAL_ERROR``).
-    Every call returns a populated ``ParseResult``; the helper
-    NEVER raises into the caller.
-  * **Bounded timeout** via ``asyncio.wait_for`` around the
-    executor future. On timeout the future is cancelled cleanly
-    and the result carries ``TIMEOUT`` outcome.
-  * **Bounded input size** via ``max_bytes`` (default 1 MB). Source
-    over the cap returns ``TOO_LARGE`` without touching the pool.
-  * **Provenance integration** — composes Slice 11A's
-    ``measure()`` so every call is captured in the same telemetry
-    ring. The ``execution_mode`` field distinguishes
-    ``inline_tiny`` vs ``process`` paths.
+**11B-fix scope (operator-authorized):**
 
-## IPC
+  1. Off-loop parse **and** heavy analysis for OpportunityMiner via
+     ``analyze_python_source_for_opportunity_miner`` — the worker
+     returns a small primitive payload (``OpportunityAnalysisPayload``),
+     never an ``ast.AST``.
+  2. Telemetry truth: the process path **no longer** wraps the await
+     in ``measure(AST_PARSE)`` (that records misleading
+     ``on_loop=True ast_parse`` events for IPC roundtrip time). The
+     inline-tiny path still records via ``measure()`` because the
+     parse genuinely happens on-loop. Process-mode telemetry is now
+     emitted as structured ``[AstCompileHelper]`` log lines carrying
+     ``execution_mode=process`` + ``worker_elapsed_ms`` (provenance
+     stays auditable without conflating IPC time with parse time).
+  3. Default ``max_workers=1`` so two CPU-burning workers can't
+     starve the parent's I/O on a laptop-class control plane.
+  4. ``parse_python_source`` retained for narrow callers that
+     genuinely need the AST — but its docstring carries a loud
+     warning: it is **not enough** for callers that immediately
+     perform heavy AST walks (those are the real loop killers).
 
-  * ``concurrent.futures.ProcessPoolExecutor`` handles all
-    inter-process serialization internally via its standard
-    Python machinery — the worker function returns a tuple, the
-    executor ships it to the main process automatically. No
-    explicit serialization in this module's source.
-  * The pool uses ``multiprocessing.get_context("spawn")`` for
-    portability + safety (fork-from-asyncio edge cases avoided).
+## Architecture
+
+  * **Process pool** isolation via ``concurrent.futures.ProcessPoolExecutor``
+    with ``multiprocessing.get_context("spawn")``. Each worker has its
+    own GIL; the asyncio main thread keeps ticking during the parse.
+  * **Inline tiny** path for sources ≤ 4 KB — ``ast.parse()`` returns
+    in <5 ms and IPC overhead would dominate.
+  * **Closed taxonomies**: ``ParseOutcome`` (5) + ``AnalyzeOutcome`` (5)
+    + ``ExecutionMode`` (3). Adding a 6th value requires bumping the
+    paired AST pins and every consumer branch.
+  * **Bounded** by timeout (``asyncio.wait_for``) + max_bytes.
+  * **Fail-closed**: every code path returns a populated result —
+    helpers NEVER raise into the caller.
+
+## Public API (after 11B-fix)
+
+  * ``await parse_python_source(caller, source, ...)`` — returns
+    ``ParseResult`` including ``ast.AST`` on OK. Use ONLY when the
+    caller has a real need for the parsed tree AND will not perform
+    a heavy walk on the main thread afterwards.
+  * ``await analyze_python_source_for_opportunity_miner(caller,
+    source, ...)`` — returns ``AnalysisResult`` with the 7
+    ``OpportunityAnalysisPayload`` fields the sensor needs. Parse +
+    all six dimension calculations happen in the worker; no
+    ``ast.AST`` ever crosses the IPC boundary.
 
 ## Discipline (AST-pinned in the test surface)
 
-  * The ONLY ``ast.parse()`` call site in this module is inside
-    ``_worker_parse_in_process`` (the process-pool worker
-    function). Every other ast.parse call in OpportunityMiner is
-    forbidden when the function is an ``async def`` — operators
-    must route through ``parse_python_source``.
-  * The pool is a lazy module-level singleton; the first call
-    pays the spawn cost, subsequent calls reuse workers.
-  * Tiny-path threshold is env-knobbed
-    (``JARVIS_AST_HELPER_TINY_THRESHOLD_BYTES``, default 4096).
-  * Default timeout is env-knobbed
-    (``JARVIS_AST_HELPER_DEFAULT_TIMEOUT_S``, default 10.0).
-  * Default max-bytes cap is env-knobbed
-    (``JARVIS_AST_HELPER_MAX_BYTES``, default 1_000_000).
+  * The ONLY ``ast.parse()`` call sites in this module are
+    ``_worker_parse_in_process``, ``_worker_analyze_in_process``,
+    and ``_inline_tiny_parse``.
+  * The ONLY ``ast.walk`` / ``ast.iter_child_nodes`` call sites are
+    inside ``_worker_analyze_in_process`` — heavy AST walks happen
+    only across the process boundary for the analyze helper.
+  * The pool is a lazy module-level singleton; first call pays the
+    spawn cost, subsequent calls reuse workers.
+  * Tiny-path threshold env-knobbed (``JARVIS_AST_HELPER_TINY_THRESHOLD_BYTES``, default 4096).
+  * Default timeout env-knobbed (``JARVIS_AST_HELPER_DEFAULT_TIMEOUT_S``, default 10.0).
+  * Default max-bytes cap env-knobbed (``JARVIS_AST_HELPER_MAX_BYTES``, default 1_000_000).
+  * Default pool max workers env-knobbed (``JARVIS_AST_HELPER_POOL_MAX_WORKERS``, default **1**).
 
-## What this module does NOT do (operator-bound)
+## What this module does NOT do
 
   * Does NOT migrate ``provider_topology._validate_*`` /
     ``shipped_code_invariants.validate_invariant`` /
-    ``cross_kingdom_boundary._scan_one_file`` — those are
-    11C/11D targets, not this PR.
-  * Does NOT disable any other subsystem.
+    ``cross_kingdom_boundary._scan_one_file`` — those remain 11C/11D
+    targets per operator scope.
   * Does NOT install global ``compile()`` / ``ast.parse()``
     monkey-patches — that's Slice 11A's diagnostic probe.
-  * Does NOT introduce a master flag for rollback (the helper's
-    behavior is byte-equivalent on the OK path; on failure
-    paths it returns a strict superset of legacy
-    ``SyntaxError``/``OSError`` semantics).
+  * Does NOT disable any other subsystem.
 """
 
 from __future__ import annotations
@@ -111,10 +121,22 @@ class ParseOutcome(str, enum.Enum):
     INTERNAL_ERROR  = "internal_error"
 
 
+class AnalyzeOutcome(str, enum.Enum):
+    """Closed 5-value outcome taxonomy for the analyze helper
+    (mirror of ParseOutcome). Adding a 6th value requires bumping
+    the AST pin + every consumer branch."""
+
+    OK              = "ok"
+    SYNTAX_ERROR    = "syntax_error"
+    TIMEOUT         = "timeout"
+    TOO_LARGE       = "too_large"
+    INTERNAL_ERROR  = "internal_error"
+
+
 class ExecutionMode(str, enum.Enum):
     """Closed 3-value mode taxonomy. ``THREAD`` is reserved for
-    future use; this module's ``parse_python_source`` routes only
-    to ``INLINE_TINY`` (below threshold) or ``PROCESS`` (above)."""
+    future use; this module's helpers route only to
+    ``INLINE_TINY`` (below threshold) or ``PROCESS`` (above)."""
 
     INLINE_TINY = "inline_tiny"
     THREAD      = "thread"
@@ -140,6 +162,47 @@ class ParseResult:
     error_detail: str = ""            # syntax_error message / internal err
 
 
+@dataclass(frozen=True)
+class OpportunityAnalysisPayload:
+    """Small, primitive-only payload returned by the analyze
+    helper's worker. Mirrors the seven fields of OpportunityMiner's
+    legacy ``_FileAnalysis``. Picklable by trivial IPC — NO
+    ``ast.AST`` ever crosses the process boundary.
+
+    Field semantics match ``backend/core/ouroboros/governance/
+    intake/sensors/opportunity_miner_sensor.py::_FileAnalysis``
+    byte-for-byte; the worker computes the same six dimensions
+    with the same helper logic (re-implemented inside the worker
+    so the worker doesn't have to import the sensor module).
+    """
+
+    cyclomatic_complexity: int = 0
+    max_function_length: int = 0
+    cognitive_complexity: int = 0
+    duplicate_block_count: int = 0
+    import_fan_out: int = 0
+    todo_fixme_count: int = 0
+    total_lines: int = 0
+
+
+@dataclass(frozen=True)
+class AnalysisResult:
+    """Closed-taxonomy result from
+    ``analyze_python_source_for_opportunity_miner``. NEVER raises
+    into the caller. ``payload`` is populated only on OK; on
+    failure outcomes it carries the zero-value payload (sentinel
+    that the caller should skip the file)."""
+
+    outcome: AnalyzeOutcome
+    payload: OpportunityAnalysisPayload
+    elapsed_ms: float                 # total parent-await wall-clock
+    worker_elapsed_ms: float          # worker-side measured time (0.0 when not in worker)
+    source_bytes: int
+    caller: str
+    execution_mode: ExecutionMode
+    error_detail: str = ""
+
+
 # ============================================================================
 # Env knobs (operational; closed taxonomy is structural)
 # ============================================================================
@@ -153,7 +216,10 @@ _POOL_MAX_WORKERS_ENV: str = "JARVIS_AST_HELPER_POOL_MAX_WORKERS"
 _DEFAULT_TINY_THRESHOLD: int = 4096           # 4 KB
 _DEFAULT_TIMEOUT_S: float = 10.0
 _DEFAULT_MAX_BYTES: int = 1_000_000           # 1 MB
-_DEFAULT_POOL_MAX_WORKERS: int = 2            # small; ast.parse is bursty
+# 11B-fix: one worker by default. Two CPU-burning workers can
+# starve the parent's I/O on a laptop-class control plane; operators
+# with multi-core headroom can raise via JARVIS_AST_HELPER_POOL_MAX_WORKERS.
+_DEFAULT_POOL_MAX_WORKERS: int = 1
 
 
 def _resolve_tiny_threshold() -> int:
@@ -222,9 +288,9 @@ def _worker_parse_in_process(
     crash the pool worker and propagate ``BrokenProcessPool`` to
     the main process.
 
-    This is the SINGLE permitted ``ast.parse()`` call site in
-    this module. The AST pin in the paired test enforces that
-    invariant."""
+    Permitted ``ast.parse()`` call site. The AST pin in the paired
+    test enforces that this + ``_worker_analyze_in_process`` +
+    ``_inline_tiny_parse`` are the only sites."""
     try:
         tree = _ast_mod.parse(source, filename=filename, mode=mode)
         return ("ok", tree)
@@ -234,6 +300,162 @@ def _worker_parse_in_process(
     except Exception as exc:  # noqa: BLE001 — never crash worker
         detail = f"{type(exc).__name__}: {exc}"
         return ("internal_error", detail)
+
+
+# ---- Worker-side analysis primitives (11B-fix) ---------------------
+#
+# These are re-implementations of OpportunityMiner's six dimension
+# helpers, lifted into the worker so the parent process never
+# performs an AST walk. The semantics are byte-equivalent to
+# ``opportunity_miner_sensor._cyclomatic_complexity`` etc., enforced
+# by a metrics-parity unit test in the paired test surface.
+#
+# The functions are deliberately self-contained (no sensor-module
+# import) so the spawn worker can resolve them on import of this
+# module alone. ``ast.walk`` + ``ast.iter_child_nodes`` are
+# AST-pinned to live only inside ``_worker_analyze_in_process``.
+
+
+def _worker_cyclomatic_complexity(tree: Any) -> int:
+    """Count branching nodes (if/for/while/with/except/and/or)."""
+    branch_types = (
+        _ast_mod.If, _ast_mod.For, _ast_mod.While, _ast_mod.With,
+        _ast_mod.ExceptHandler, _ast_mod.BoolOp,
+    )
+    count = 1  # baseline (legacy contract)
+    for node in _ast_mod.walk(tree):
+        if isinstance(node, branch_types):
+            count += 1
+    return count
+
+
+def _worker_max_function_length(tree: Any) -> int:
+    """Longest function/method body in lines."""
+    max_len = 0
+    fn_types = (_ast_mod.FunctionDef, _ast_mod.AsyncFunctionDef)
+    for node in _ast_mod.walk(tree):
+        if isinstance(node, fn_types):
+            end_lineno = getattr(node, "end_lineno", None)
+            lineno = getattr(node, "lineno", None)
+            if end_lineno and lineno:
+                length = end_lineno - lineno + 1
+                if length > max_len:
+                    max_len = length
+    return max_len
+
+
+def _worker_cognitive_complexity(tree: Any) -> int:
+    """Simplified cognitive complexity — branches weighted by
+    nesting depth. Matches the sensor's recursive ``_walk`` body
+    line for line. The inner helper is named with the ``_worker_``
+    prefix so the AST cage pin (no ``ast.iter_child_nodes`` outside
+    ``_worker_*``) accepts it."""
+    score = 0
+    nesting_types = (
+        _ast_mod.If, _ast_mod.For, _ast_mod.While, _ast_mod.With,
+        _ast_mod.ExceptHandler,
+    )
+    increment_types = (
+        _ast_mod.If, _ast_mod.For, _ast_mod.While, _ast_mod.With,
+        _ast_mod.ExceptHandler, _ast_mod.BoolOp,
+    )
+
+    def _worker_cognitive_walk(node: Any, depth: int) -> None:
+        nonlocal score
+        child_depth = depth
+        if isinstance(node, nesting_types):
+            child_depth = depth + 1
+        if isinstance(node, increment_types):
+            score += 1 + depth
+        for child in _ast_mod.iter_child_nodes(node):
+            _worker_cognitive_walk(child, child_depth)
+
+    _worker_cognitive_walk(tree, 0)
+    return score
+
+
+def _worker_duplicate_block_count(source: str) -> int:
+    """Count near-duplicate 4-line windows by md5. No AST work."""
+    import hashlib as _hashlib
+    from collections import defaultdict as _defaultdict
+
+    lines = [
+        ln.strip() for ln in source.splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+    if len(lines) < 4:
+        return 0
+
+    window_hashes = _defaultdict(int)
+    for i in range(len(lines) - 3):
+        window = "\n".join(lines[i:i + 4])
+        h = _hashlib.md5(window.encode(), usedforsecurity=False).hexdigest()
+        window_hashes[h] += 1
+    return sum(1 for cnt in window_hashes.values() if cnt > 1)
+
+
+def _worker_import_fan_out(tree: Any) -> int:
+    """Distinct top-level modules imported."""
+    modules = set()
+    for node in _ast_mod.walk(tree):
+        if isinstance(node, _ast_mod.Import):
+            for alias in node.names:
+                modules.add(alias.name.split(".")[0])
+        elif isinstance(node, _ast_mod.ImportFrom):
+            if node.module:
+                modules.add(node.module.split(".")[0])
+    return len(modules)
+
+
+def _worker_todo_fixme_count(source: str) -> int:
+    """TODO/FIXME/HACK/XXX comment markers."""
+    import re as _re
+    return len(
+        _re.findall(
+            r"#\s*(?:TODO|FIXME|HACK|XXX)\b", source, _re.IGNORECASE,
+        )
+    )
+
+
+def _worker_analyze_in_process(
+    source: str,
+    filename: str,
+) -> Tuple[str, Any]:
+    """Process-pool worker — parses + computes all 7 OpportunityMiner
+    metrics inside the worker process. The worker returns a
+    primitive-only payload (``Tuple[int, ...]``) ; **no ast.AST
+    crosses the IPC boundary**.
+
+    Outcome labels: ``"ok"`` / ``"syntax_error"`` / ``"internal_error"``.
+    On OK the payload is a 8-tuple:
+      (worker_elapsed_ms, cc, mfl, cog, dup, fanout, todos, total_lines).
+
+    NEVER raises out of the worker. Permitted ``ast.parse`` + walk
+    site (AST-pinned)."""
+    t0 = time.monotonic()
+    try:
+        tree = _ast_mod.parse(source, filename=filename, mode="exec")
+    except SyntaxError as exc:
+        return ("syntax_error", f"{type(exc).__name__}: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        return ("internal_error", f"{type(exc).__name__}: {exc}")
+
+    try:
+        cc = _worker_cyclomatic_complexity(tree)
+        mfl = _worker_max_function_length(tree)
+        cog = _worker_cognitive_complexity(tree)
+        dup = _worker_duplicate_block_count(source)
+        fanout = _worker_import_fan_out(tree)
+        todos = _worker_todo_fixme_count(source)
+        total_lines = len(source.splitlines())
+    except Exception as exc:  # noqa: BLE001
+        return ("internal_error", f"analyze: {type(exc).__name__}: {exc}")
+
+    worker_elapsed_ms = (time.monotonic() - t0) * 1000.0
+    return (
+        "ok",
+        (worker_elapsed_ms, cc, mfl, cog, dup, fanout, todos, total_lines),
+    )
 
 
 # ============================================================================
@@ -297,6 +519,18 @@ async def parse_python_source(
     tiny_threshold_override: Optional[int] = None,
 ) -> ParseResult:
     """Async-safe Python source parser — Slice 11B canonical helper.
+
+    .. warning::
+
+        **Not sufficient for callers that immediately perform a
+        heavy AST walk.** The ``ast.AST`` returned via ``result.tree``
+        crosses the IPC boundary (large pickle + GIL-held unpickle in
+        the parent), and any subsequent ``ast.walk`` on the main
+        thread will starve the asyncio control plane — this is exactly
+        the wedge that motivated 11B-fix. If your caller is going to
+        walk the tree, route through
+        ``analyze_python_source_for_opportunity_miner`` (or a sibling
+        purpose-built helper that returns a small primitive payload).
 
     Parameters
     ----------
@@ -454,51 +688,47 @@ async def _process_pool_parse(
     ``ProcessPoolExecutor`` handles inter-process serialization
     via its standard implementation — the worker returns a Python
     tuple, the executor ships it back to the main process
-    automatically. No explicit serialization in this module."""
+    automatically. No explicit serialization in this module.
+
+    11B-fix: the previous version wrapped this await in
+    ``measure(AST_PARSE)`` which produced misleading
+    ``on_loop=True ast_parse`` provenance records — the await DOES
+    run on the loop thread but does NOT do the parse. The wrap is
+    gone. Process-mode telemetry is emitted at outcome boundary as
+    a single ``[AstCompileHelper] execution_mode=process …``
+    structured log line. The loop-block oracle is
+    ``[ControlPlaneStarvation]`` from
+    ``control_plane_watchdog.py``."""
     loop = asyncio.get_running_loop()
     pool = _get_pool()
 
-    # Provenance — composes Slice 11A measure() so the ring still
-    # captures the caller + elapsed_ms. The recorded
-    # ``on_loop_thread`` will be True (because measure() runs on
-    # the main thread alongside the await), but the actual parse
-    # work happens in the worker process; the await yields
-    # control to the event loop while the worker runs.
-    from backend.core.ouroboros.governance.ast_compile_telemetry import (
-        CallKind as _S11_CK,
-        measure as _s11_measure,
-    )
-
     try:
-        with _s11_measure(
-            caller, _S11_CK.AST_PARSE, source_bytes=source_bytes,
-        ):
-            try:
-                outcome_payload = await asyncio.wait_for(
-                    loop.run_in_executor(
-                        pool, _worker_parse_in_process,
-                        source, filename, mode,
-                    ),
-                    timeout=timeout_s,
-                )
-            except asyncio.TimeoutError:
-                elapsed_ms = (time.monotonic() - t0) * 1000.0
-                logger.warning(
-                    "[AstCompileHelper] caller=%s outcome=timeout "
-                    "source_bytes=%d timeout_s=%.1f elapsed_ms=%.1f",
-                    caller, source_bytes, timeout_s, elapsed_ms,
-                )
-                return ParseResult(
-                    outcome=ParseOutcome.TIMEOUT,
-                    tree=None,
-                    elapsed_ms=elapsed_ms,
-                    source_bytes=source_bytes,
-                    caller=caller,
-                    execution_mode=ExecutionMode.PROCESS,
-                    error_detail=(
-                        f"parse exceeded {timeout_s:.1f}s in pool"
-                    ),
-                )
+        outcome_payload = await asyncio.wait_for(
+            loop.run_in_executor(
+                pool, _worker_parse_in_process,
+                source, filename, mode,
+            ),
+            timeout=timeout_s,
+        )
+    except asyncio.TimeoutError:
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+        logger.warning(
+            "[AstCompileHelper] caller=%s outcome=timeout "
+            "execution_mode=process source_bytes=%d "
+            "timeout_s=%.1f parent_await_ms=%.1f",
+            caller, source_bytes, timeout_s, elapsed_ms,
+        )
+        return ParseResult(
+            outcome=ParseOutcome.TIMEOUT,
+            tree=None,
+            elapsed_ms=elapsed_ms,
+            source_bytes=source_bytes,
+            caller=caller,
+            execution_mode=ExecutionMode.PROCESS,
+            error_detail=(
+                f"parse exceeded {timeout_s:.1f}s in pool"
+            ),
+        )
     except asyncio.CancelledError:
         raise
     except Exception as exc:  # noqa: BLE001
@@ -529,6 +759,15 @@ async def _process_pool_parse(
             error_detail=f"worker returned unexpected shape: {type(outcome_payload).__name__}",
         )
     if outcome_label == "ok":
+        # 11B-fix: structured process-mode log line at outcome
+        # boundary; replaces the misleading measure(AST_PARSE) ring
+        # entry. Logged at debug threshold to avoid flooding.
+        logger.debug(
+            "[AstCompileHelper] caller=%s outcome=ok "
+            "execution_mode=process source_bytes=%d "
+            "parent_await_ms=%.1f",
+            caller, source_bytes, elapsed_ms,
+        )
         return ParseResult(
             outcome=ParseOutcome.OK,
             tree=payload,           # ast.AST object — auto-IPC'd by pool
@@ -561,14 +800,333 @@ async def _process_pool_parse(
 
 
 # ============================================================================
+# Public API — analyze helper (11B-fix)
+# ============================================================================
+
+
+_ZERO_PAYLOAD = OpportunityAnalysisPayload()
+
+
+async def analyze_python_source_for_opportunity_miner(
+    caller: str,
+    source: str,
+    *,
+    filename: str = "<unknown>",
+    timeout_s: Optional[float] = None,
+    max_bytes: Optional[int] = None,
+    tiny_threshold_override: Optional[int] = None,
+) -> AnalysisResult:
+    """Off-loop parse + 6-dimension analysis for OpportunityMiner.
+
+    The worker performs the parse **and** the six AST-walk-based
+    dimension calculations (cyclomatic, max-fn-length, cognitive,
+    duplicate-block, import-fan-out, todo-fixme) in a separate
+    process. The parent receives a small primitive payload — **no
+    ``ast.AST`` ever crosses the IPC boundary**.
+
+    Parameters mirror ``parse_python_source``: ``caller`` is a
+    mandatory provenance label; ``filename`` is logical (for error
+    messages); ``timeout_s`` defaults to
+    ``JARVIS_AST_HELPER_DEFAULT_TIMEOUT_S``; ``max_bytes`` defaults
+    to ``JARVIS_AST_HELPER_MAX_BYTES``.
+
+    Returns ``AnalysisResult`` — outcome ∈ ``AnalyzeOutcome`` plus
+    ``payload: OpportunityAnalysisPayload``. NEVER raises into the
+    caller; failure outcomes carry the zero-value payload and the
+    caller should skip the file (mirrors legacy ``errors += 1;
+    continue`` semantics).
+
+    Execution mode follows the same tiny-threshold logic as
+    ``parse_python_source``: sources ≤ ``tiny_threshold`` are
+    parsed + analyzed inline (the work is genuinely cheap and IPC
+    overhead would dominate), sources above the threshold go
+    through the process pool. The inline path still records via
+    Slice 11A ``measure()`` because it really runs on-loop; the
+    process path emits a single structured log line.
+    """
+    t0 = time.monotonic()
+    source_bytes = len(source.encode("utf-8")) if isinstance(source, str) else 0
+    effective_timeout = (
+        float(timeout_s) if timeout_s is not None
+        else _resolve_default_timeout_s()
+    )
+    effective_max_bytes = (
+        int(max_bytes) if max_bytes is not None
+        else _resolve_default_max_bytes()
+    )
+    tiny_threshold = (
+        int(tiny_threshold_override) if tiny_threshold_override is not None
+        else _resolve_tiny_threshold()
+    )
+
+    # Too-large fast-path.
+    if source_bytes > effective_max_bytes:
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+        logger.info(
+            "[AstCompileHelper] caller=%s outcome=too_large kind=analyze "
+            "source_bytes=%d max_bytes=%d elapsed_ms=%.2f",
+            caller, source_bytes, effective_max_bytes, elapsed_ms,
+        )
+        return AnalysisResult(
+            outcome=AnalyzeOutcome.TOO_LARGE,
+            payload=_ZERO_PAYLOAD,
+            elapsed_ms=elapsed_ms,
+            worker_elapsed_ms=0.0,
+            source_bytes=source_bytes,
+            caller=caller,
+            execution_mode=ExecutionMode.INLINE_TINY,  # nominal; not invoked
+            error_detail=(
+                f"source {source_bytes}B exceeds max_bytes "
+                f"{effective_max_bytes}B"
+            ),
+        )
+
+    # Inline-tiny path. ast.parse + the six dimension calcs are
+    # cheap for small sources; IPC overhead would dominate. The
+    # measure() wrapper is genuine here — the work truly runs
+    # on-loop.
+    if source_bytes <= tiny_threshold:
+        return _inline_tiny_analyze(
+            caller=caller, source=source, filename=filename,
+            source_bytes=source_bytes, t0=t0,
+        )
+
+    # Process-pool path — the heavy case.
+    return await _process_pool_analyze(
+        caller=caller, source=source, filename=filename,
+        source_bytes=source_bytes, t0=t0,
+        timeout_s=effective_timeout,
+    )
+
+
+def _inline_tiny_analyze(
+    *,
+    caller: str,
+    source: str,
+    filename: str,
+    source_bytes: int,
+    t0: float,
+) -> AnalysisResult:
+    """Inline path for tiny sources. Parses + analyzes on the
+    caller's thread. Composes Slice 11A's ``measure()`` because the
+    work truly runs on-loop."""
+    from backend.core.ouroboros.governance.ast_compile_telemetry import (
+        CallKind as _S11_CK,
+        measure as _s11_measure,
+    )
+    try:
+        with _s11_measure(
+            caller, _S11_CK.AST_PARSE, source_bytes=source_bytes,
+        ):
+            outcome_label, payload = _worker_analyze_in_process(
+                source, filename,
+            )
+    except Exception as exc:  # noqa: BLE001 — fault isolation
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+        return AnalysisResult(
+            outcome=AnalyzeOutcome.INTERNAL_ERROR,
+            payload=_ZERO_PAYLOAD,
+            elapsed_ms=elapsed_ms,
+            worker_elapsed_ms=0.0,
+            source_bytes=source_bytes,
+            caller=caller,
+            execution_mode=ExecutionMode.INLINE_TINY,
+            error_detail=f"{type(exc).__name__}: {exc}",
+        )
+
+    elapsed_ms = (time.monotonic() - t0) * 1000.0
+    return _result_from_worker_payload(
+        outcome_label=outcome_label,
+        payload=payload,
+        caller=caller,
+        source_bytes=source_bytes,
+        elapsed_ms=elapsed_ms,
+        execution_mode=ExecutionMode.INLINE_TINY,
+    )
+
+
+async def _process_pool_analyze(
+    *,
+    caller: str,
+    source: str,
+    filename: str,
+    source_bytes: int,
+    t0: float,
+    timeout_s: float,
+) -> AnalysisResult:
+    """Process-pool path — parse + analysis in worker, primitive
+    payload only across IPC. NO ``measure(AST_PARSE)`` wrapper —
+    the await runs on-loop but the work does not, and
+    ``measure()`` would record misleading on-loop ast_parse
+    events. Telemetry is emitted as structured log lines at
+    outcome boundary instead."""
+    loop = asyncio.get_running_loop()
+    pool = _get_pool()
+
+    try:
+        worker_tuple = await asyncio.wait_for(
+            loop.run_in_executor(
+                pool, _worker_analyze_in_process, source, filename,
+            ),
+            timeout=timeout_s,
+        )
+    except asyncio.TimeoutError:
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+        logger.warning(
+            "[AstCompileHelper] caller=%s outcome=timeout kind=analyze "
+            "execution_mode=process source_bytes=%d timeout_s=%.1f "
+            "parent_await_ms=%.1f",
+            caller, source_bytes, timeout_s, elapsed_ms,
+        )
+        return AnalysisResult(
+            outcome=AnalyzeOutcome.TIMEOUT,
+            payload=_ZERO_PAYLOAD,
+            elapsed_ms=elapsed_ms,
+            worker_elapsed_ms=0.0,
+            source_bytes=source_bytes,
+            caller=caller,
+            execution_mode=ExecutionMode.PROCESS,
+            error_detail=f"analyze exceeded {timeout_s:.1f}s in pool",
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+        return AnalysisResult(
+            outcome=AnalyzeOutcome.INTERNAL_ERROR,
+            payload=_ZERO_PAYLOAD,
+            elapsed_ms=elapsed_ms,
+            worker_elapsed_ms=0.0,
+            source_bytes=source_bytes,
+            caller=caller,
+            execution_mode=ExecutionMode.PROCESS,
+            error_detail=f"pool dispatch failed: {type(exc).__name__}: {exc}",
+        )
+
+    elapsed_ms = (time.monotonic() - t0) * 1000.0
+    try:
+        outcome_label, payload = worker_tuple
+    except (ValueError, TypeError):
+        return AnalysisResult(
+            outcome=AnalyzeOutcome.INTERNAL_ERROR,
+            payload=_ZERO_PAYLOAD,
+            elapsed_ms=elapsed_ms,
+            worker_elapsed_ms=0.0,
+            source_bytes=source_bytes,
+            caller=caller,
+            execution_mode=ExecutionMode.PROCESS,
+            error_detail=(
+                f"worker returned unexpected shape: "
+                f"{type(worker_tuple).__name__}"
+            ),
+        )
+
+    result = _result_from_worker_payload(
+        outcome_label=outcome_label,
+        payload=payload,
+        caller=caller,
+        source_bytes=source_bytes,
+        elapsed_ms=elapsed_ms,
+        execution_mode=ExecutionMode.PROCESS,
+    )
+
+    # Process-mode telemetry: single structured log line. Threshold
+    # at debug to keep the log clean unless ops are tuning.
+    if result.outcome == AnalyzeOutcome.OK:
+        logger.debug(
+            "[AstCompileHelper] caller=%s outcome=ok kind=analyze "
+            "execution_mode=process source_bytes=%d "
+            "worker_elapsed_ms=%.1f parent_await_ms=%.1f",
+            caller, source_bytes,
+            result.worker_elapsed_ms, elapsed_ms,
+        )
+    return result
+
+
+def _result_from_worker_payload(
+    *,
+    outcome_label: str,
+    payload: Any,
+    caller: str,
+    source_bytes: int,
+    elapsed_ms: float,
+    execution_mode: ExecutionMode,
+) -> AnalysisResult:
+    """Decode the worker's (label, payload) tuple into an
+    ``AnalysisResult``. Shared by inline-tiny and process paths so
+    the decode logic lives in exactly one place."""
+    if outcome_label == "ok":
+        try:
+            (worker_elapsed_ms, cc, mfl, cog, dup, fanout, todos,
+             total_lines) = payload
+        except (ValueError, TypeError):
+            return AnalysisResult(
+                outcome=AnalyzeOutcome.INTERNAL_ERROR,
+                payload=_ZERO_PAYLOAD,
+                elapsed_ms=elapsed_ms,
+                worker_elapsed_ms=0.0,
+                source_bytes=source_bytes,
+                caller=caller,
+                execution_mode=execution_mode,
+                error_detail=(
+                    f"ok payload shape unexpected: "
+                    f"{type(payload).__name__}"
+                ),
+            )
+        return AnalysisResult(
+            outcome=AnalyzeOutcome.OK,
+            payload=OpportunityAnalysisPayload(
+                cyclomatic_complexity=int(cc),
+                max_function_length=int(mfl),
+                cognitive_complexity=int(cog),
+                duplicate_block_count=int(dup),
+                import_fan_out=int(fanout),
+                todo_fixme_count=int(todos),
+                total_lines=int(total_lines),
+            ),
+            elapsed_ms=elapsed_ms,
+            worker_elapsed_ms=float(worker_elapsed_ms),
+            source_bytes=source_bytes,
+            caller=caller,
+            execution_mode=execution_mode,
+        )
+    if outcome_label == "syntax_error":
+        return AnalysisResult(
+            outcome=AnalyzeOutcome.SYNTAX_ERROR,
+            payload=_ZERO_PAYLOAD,
+            elapsed_ms=elapsed_ms,
+            worker_elapsed_ms=0.0,
+            source_bytes=source_bytes,
+            caller=caller,
+            execution_mode=execution_mode,
+            error_detail=str(payload),
+        )
+    # ``internal_error`` or anything unexpected → INTERNAL_ERROR.
+    return AnalysisResult(
+        outcome=AnalyzeOutcome.INTERNAL_ERROR,
+        payload=_ZERO_PAYLOAD,
+        elapsed_ms=elapsed_ms,
+        worker_elapsed_ms=0.0,
+        source_bytes=source_bytes,
+        caller=caller,
+        execution_mode=execution_mode,
+        error_detail=str(payload),
+    )
+
+
+# ============================================================================
 # Public surface
 # ============================================================================
 
 
 __all__ = [
+    "AnalysisResult",
+    "AnalyzeOutcome",
     "ExecutionMode",
+    "OpportunityAnalysisPayload",
     "ParseOutcome",
     "ParseResult",
+    "analyze_python_source_for_opportunity_miner",
     "parse_python_source",
     "shutdown_pool",
 ]

--- a/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
@@ -496,33 +496,39 @@ class OpportunityMinerSensor:
                 except (OSError, UnicodeDecodeError):
                     errors += 1
                     continue
-                # Slice 11B — route through canonical helper.
-                # Off-loop process-pool parse for source above the
-                # tiny threshold (~4KB); inline-tiny otherwise.
-                # The Slice 11A measure() telemetry is composed
-                # inside the helper — every call still flows into
-                # the provenance ring with caller label.
+                # Slice 11B-fix — route through analyze helper.
+                # Parse + all six dimension AST walks run in a
+                # worker process; the parent receives only a small
+                # primitive payload. NO ast.AST crosses the IPC
+                # boundary, so the main asyncio thread never blocks
+                # on a heavy walk. SyntaxError / TIMEOUT / TOO_LARGE
+                # / INTERNAL_ERROR all map to the legacy
+                # "errors += 1; continue" semantics: failed
+                # parse/analysis → skip file, increment error
+                # counter, never produce a candidate.
                 from backend.core.ouroboros.governance.ast_compile_helper import (  # noqa: E501
-                    ParseOutcome as _S11_PO,
-                    parse_python_source as _s11_parse,
+                    AnalyzeOutcome as _S11B_AO,
+                    analyze_python_source_for_opportunity_miner as _s11b_analyze,
                 )
-                _s11_result = await _s11_parse(
+                _s11b_result = await _s11b_analyze(
                     "opportunity_miner_sensor.scan_once",
                     source,
                     filename=str(py_file),
                 )
-                if _s11_result.outcome != _S11_PO.OK:
-                    # SyntaxError / TIMEOUT / TOO_LARGE /
-                    # INTERNAL_ERROR all fall into the legacy
-                    # "errors += 1; continue" semantics. The
-                    # OpportunityMiner contract: failed parse →
-                    # skip file, increment error counter, never
-                    # produce a candidate.
+                if _s11b_result.outcome != _S11B_AO.OK:
                     errors += 1
                     continue
-                tree = _s11_result.tree
 
-                analysis = _analyze_file(rel, source, tree)
+                analysis = _FileAnalysis(
+                    file_path=rel,
+                    cyclomatic_complexity=_s11b_result.payload.cyclomatic_complexity,
+                    max_function_length=_s11b_result.payload.max_function_length,
+                    cognitive_complexity=_s11b_result.payload.cognitive_complexity,
+                    duplicate_block_count=_s11b_result.payload.duplicate_block_count,
+                    import_fan_out=_s11b_result.payload.import_fan_out,
+                    todo_fixme_count=_s11b_result.payload.todo_fixme_count,
+                    total_lines=_s11b_result.payload.total_lines,
+                )
                 self._analysis_cache[rel] = analysis
 
                 # Strategy-specific threshold gate
@@ -866,23 +872,33 @@ class OpportunityMinerSensor:
             source = py_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             return None
-        # Slice 11B — route through canonical helper. SyntaxError +
-        # TIMEOUT + TOO_LARGE + INTERNAL_ERROR all return None
-        # (legacy semantics: failed parse → no candidate).
+        # Slice 11B-fix — analyze helper: parse + all six dimension
+        # walks in a worker process; only a primitive payload
+        # returns to the main thread. SyntaxError / TIMEOUT /
+        # TOO_LARGE / INTERNAL_ERROR all return None (legacy
+        # semantics: failed parse → no candidate).
         from backend.core.ouroboros.governance.ast_compile_helper import (  # noqa: E501
-            ParseOutcome as _S11_PO,
-            parse_python_source as _s11_parse,
+            AnalyzeOutcome as _S11B_AO,
+            analyze_python_source_for_opportunity_miner as _s11b_analyze,
         )
-        _s11_result = await _s11_parse(
+        _s11b_result = await _s11b_analyze(
             "opportunity_miner_sensor.scan_file",
             source,
             filename=str(py_file),
         )
-        if _s11_result.outcome != _S11_PO.OK:
+        if _s11b_result.outcome != _S11B_AO.OK:
             return None
-        tree = _s11_result.tree
 
-        analysis = _analyze_file(rel, source, tree)
+        analysis = _FileAnalysis(
+            file_path=rel,
+            cyclomatic_complexity=_s11b_result.payload.cyclomatic_complexity,
+            max_function_length=_s11b_result.payload.max_function_length,
+            cognitive_complexity=_s11b_result.payload.cognitive_complexity,
+            duplicate_block_count=_s11b_result.payload.duplicate_block_count,
+            import_fan_out=_s11b_result.payload.import_fan_out,
+            todo_fixme_count=_s11b_result.payload.todo_fixme_count,
+            total_lines=_s11b_result.payload.total_lines,
+        )
         self._analysis_cache[rel] = analysis
 
         # Gate on composite score for event-driven path

--- a/tests/governance/test_slice11_ast_compile_helper.py
+++ b/tests/governance/test_slice11_ast_compile_helper.py
@@ -159,13 +159,25 @@ class TestHelperAstCage(unittest.TestCase):
         tree = _parse_module(_HELPER_FILE)
         calls = self._find_ast_parse_calls(tree)
         self.assertGreater(len(calls), 0, "helper must call ast.parse")
+        # 11B-fix extends the allowed set to include
+        # ``_worker_analyze_in_process`` (parse + analyze in the
+        # same worker call, returning a primitive payload).
+        # ``_inline_tiny_parse`` remains for the parse helper's
+        # tiny-source path; ``_inline_tiny_analyze`` is the analyze
+        # helper's tiny-source path (which calls
+        # ``_worker_analyze_in_process`` inline, so it never calls
+        # ast.parse directly).
         for (lineno,) in calls:
             fn_name = self._enclosing_function(tree, lineno)
             self.assertIn(
                 fn_name,
-                {"_worker_parse_in_process", "_inline_tiny_parse"},
+                {
+                    "_worker_parse_in_process",
+                    "_worker_analyze_in_process",
+                    "_inline_tiny_parse",
+                },
                 f"helper ast.parse at L{lineno} in function "
-                f"{fn_name!r} — must be in worker or inline-tiny "
+                f"{fn_name!r} — must be in a worker or inline-tiny "
                 f"path",
             )
 
@@ -365,11 +377,17 @@ class TestOpportunityMinerMigration(unittest.TestCase):
 
     def test_scan_once_imports_helper(self) -> None:
         """The helper import must be present in the scan_once body
-        (lazy import, mirrors the Slice 10 pattern)."""
+        (lazy import, mirrors the Slice 10 pattern). 11B-fix
+        replaces the parse-only entry with the analyze entry —
+        scan_once now imports
+        ``analyze_python_source_for_opportunity_miner`` /
+        ``AnalyzeOutcome`` (no ast.AST consumption)."""
         src = _MINER_FILE.read_text()
         self.assertIn("ast_compile_helper", src)
-        self.assertIn("parse_python_source", src)
-        self.assertIn("ParseOutcome", src)
+        self.assertIn(
+            "analyze_python_source_for_opportunity_miner", src,
+        )
+        self.assertIn("AnalyzeOutcome", src)
 
     def test_scan_once_routes_caller_label(self) -> None:
         """The caller label passed to parse_python_source
@@ -478,10 +496,17 @@ def _fake_result(outcome: ParseOutcome) -> ParseResult:
 
 class TestPublicSurface(unittest.TestCase):
     def test_all_exports(self) -> None:
+        # 11B-fix extends the public surface with the analyze
+        # helper's taxonomy + result types + entry point. The
+        # parse-only API stays exposed for narrow non-walking
+        # callers.
         self.assertEqual(
             set(helper_mod.__all__),
             {
-                "ExecutionMode", "ParseOutcome", "ParseResult",
+                "AnalysisResult", "AnalyzeOutcome",
+                "ExecutionMode", "OpportunityAnalysisPayload",
+                "ParseOutcome", "ParseResult",
+                "analyze_python_source_for_opportunity_miner",
                 "parse_python_source", "shutdown_pool",
             },
         )

--- a/tests/governance/test_slice11b_fix_analyze_helper.py
+++ b/tests/governance/test_slice11b_fix_analyze_helper.py
@@ -1,0 +1,570 @@
+"""Slice 11B-fix — analyze helper + OpportunityMiner deep migration.
+
+Closes the empirical wedge from bt-2026-05-22-055230 (post-Slice-11B
+acceptance soak): 31 ``[ControlPlaneStarvation]`` events with max lag
+37.7 s and 171.7 s of cumulative loop-block time. Root cause:
+
+  * ``parse_python_source`` returned ``ast.AST`` across the IPC
+    boundary (large serialize+deserialize, GIL-held in parent), AND
+  * OpportunityMiner ran ``_analyze_file`` (six AST walks) on the
+    main asyncio thread after the await.
+
+11B-fix ships:
+
+  * ``analyze_python_source_for_opportunity_miner`` — worker does
+    parse + all six dimension calcs, parent receives a small
+    primitive ``OpportunityAnalysisPayload``. NO ``ast.AST`` crosses
+    the IPC boundary.
+  * Telemetry truth: process path no longer wraps the await in
+    ``measure(AST_PARSE)`` — those records reported misleading
+    ``on_loop=True ast_parse`` for IPC roundtrip time.
+  * Default ``max_workers=1``.
+
+## Test surface
+
+### Closed taxonomies
+  * ``AnalyzeOutcome`` exactly 5 values
+  * ``OpportunityAnalysisPayload`` frozen + 7 fields
+  * ``AnalysisResult`` frozen
+
+### Helper AST cage extension
+  * ``ast.walk`` + ``ast.iter_child_nodes`` only inside ``_worker_*``
+    helpers — heavy AST walks live across the process boundary
+  * Default ``max_workers`` is 1
+
+### Behavioural
+  * OK path on tiny + large sources, both modes
+  * Syntax error / too-large / timeout fail-closed
+  * Metrics parity: analyze helper returns the same six dimensions
+    as legacy ``_analyze_file`` on a representative source
+
+### Migration pins
+  * OpportunityMiner async methods do NOT call ``_analyze_file``
+  * OpportunityMiner async methods do NOT access ``.tree`` attr
+    on the helper result (no ast.AST consumption)
+  * OpportunityMiner async methods route through
+    ``analyze_python_source_for_opportunity_miner``
+
+### Telemetry truth
+  * Process-mode analyze does NOT emit ``[CompileProvenance]``
+    measure() records (would falsely label on-loop ast_parse)
+"""
+
+from __future__ import annotations
+
+import ast as _ast
+import os
+import pathlib
+import unittest
+from typing import List
+
+from backend.core.ouroboros.governance.ast_compile_helper import (
+    AnalysisResult,
+    AnalyzeOutcome,
+    ExecutionMode,
+    OpportunityAnalysisPayload,
+    analyze_python_source_for_opportunity_miner,
+)
+from backend.core.ouroboros.governance import ast_compile_helper as helper_mod
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_HELPER_FILE = (
+    _REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "ast_compile_helper.py"
+)
+_MINER_FILE = (
+    _REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "intake" / "sensors" / "opportunity_miner_sensor.py"
+)
+
+
+def _parse_module(path: pathlib.Path) -> _ast.Module:
+    return _ast.parse(path.read_text())
+
+
+# ============================================================================
+# Closed taxonomy pins
+# ============================================================================
+
+
+class TestClosedTaxonomies(unittest.TestCase):
+
+    def test_analyze_outcome_five_values(self) -> None:
+        self.assertEqual(len(list(AnalyzeOutcome)), 5)
+        self.assertEqual(
+            {m.name for m in AnalyzeOutcome},
+            {"OK", "SYNTAX_ERROR", "TIMEOUT", "TOO_LARGE",
+             "INTERNAL_ERROR"},
+        )
+
+    def test_opportunity_analysis_payload_is_frozen(self) -> None:
+        p = OpportunityAnalysisPayload()
+        with self.assertRaises(Exception):
+            p.cyclomatic_complexity = 99  # type: ignore[misc]
+
+    def test_opportunity_analysis_payload_seven_fields(self) -> None:
+        fields = list(OpportunityAnalysisPayload.__dataclass_fields__.keys())
+        self.assertEqual(
+            set(fields),
+            {
+                "cyclomatic_complexity", "max_function_length",
+                "cognitive_complexity", "duplicate_block_count",
+                "import_fan_out", "todo_fixme_count", "total_lines",
+            },
+        )
+        # Strict count guard — adding a 8th field requires bumping
+        # this pin AND the worker's return tuple shape.
+        self.assertEqual(len(fields), 7)
+
+    def test_analysis_result_is_frozen(self) -> None:
+        r = AnalysisResult(
+            outcome=AnalyzeOutcome.OK,
+            payload=OpportunityAnalysisPayload(),
+            elapsed_ms=1.0,
+            worker_elapsed_ms=0.5,
+            source_bytes=10,
+            caller="t",
+            execution_mode=ExecutionMode.INLINE_TINY,
+        )
+        with self.assertRaises(Exception):
+            r.outcome = AnalyzeOutcome.SYNTAX_ERROR  # type: ignore[misc]
+
+
+# ============================================================================
+# Helper AST cage extension — ast.walk + ast.iter_child_nodes only in workers
+# ============================================================================
+
+
+class TestAstWalkCage(unittest.TestCase):
+    """11B-fix invariant: ``ast.walk`` + ``ast.iter_child_nodes`` may
+    only appear inside functions whose name starts with
+    ``_worker_``. Heavy AST traversal happens across the process
+    boundary, never on the main asyncio thread."""
+
+    def _find_calls_to(
+        self, tree: _ast.Module, attr_names: set,
+    ) -> List[tuple]:
+        out = []
+        for node in _ast.walk(tree):
+            if not isinstance(node, _ast.Call):
+                continue
+            f = node.func
+            if not isinstance(f, _ast.Attribute):
+                continue
+            if f.attr not in attr_names:
+                continue
+            if not (
+                isinstance(f.value, _ast.Name)
+                and f.value.id in {"ast", "_ast_mod", "_ast"}
+            ):
+                continue
+            out.append((node.lineno,))
+        return out
+
+    def _enclosing_function(
+        self, tree: _ast.Module, lineno: int,
+    ) -> str:
+        best_name = "<module>"
+        best_span = float("inf")
+        for node in _ast.walk(tree):
+            if not isinstance(
+                node, (_ast.FunctionDef, _ast.AsyncFunctionDef),
+            ):
+                continue
+            end = getattr(node, "end_lineno", None) or lineno
+            if node.lineno <= lineno <= end:
+                span = end - node.lineno
+                if span < best_span:
+                    best_span = span
+                    best_name = node.name
+        return best_name
+
+    def test_ast_walk_only_in_workers(self) -> None:
+        tree = _parse_module(_HELPER_FILE)
+        calls = self._find_calls_to(tree, {"walk"})
+        self.assertGreater(
+            len(calls), 0, "helper must use ast.walk somewhere",
+        )
+        for (lineno,) in calls:
+            fn_name = self._enclosing_function(tree, lineno)
+            self.assertTrue(
+                fn_name.startswith("_worker_"),
+                f"helper ast.walk at L{lineno} in function "
+                f"{fn_name!r} — heavy walks must live in "
+                f"_worker_* helpers (process boundary)",
+            )
+
+    def test_iter_child_nodes_only_in_workers(self) -> None:
+        tree = _parse_module(_HELPER_FILE)
+        calls = self._find_calls_to(tree, {"iter_child_nodes"})
+        self.assertGreater(
+            len(calls), 0,
+            "helper must use ast.iter_child_nodes for cognitive complexity",
+        )
+        for (lineno,) in calls:
+            fn_name = self._enclosing_function(tree, lineno)
+            self.assertTrue(
+                fn_name.startswith("_worker_"),
+                f"helper ast.iter_child_nodes at L{lineno} in "
+                f"function {fn_name!r} — must live in _worker_* "
+                f"helpers (process boundary)",
+            )
+
+    def test_default_pool_max_workers_is_one(self) -> None:
+        """11B-fix: default to one worker — two CPU-burners can
+        starve the parent's I/O on a laptop-class control plane."""
+        self.assertEqual(helper_mod._DEFAULT_POOL_MAX_WORKERS, 1)
+
+
+# ============================================================================
+# Helper behavioural tests — exercise real ProcessPoolExecutor workers
+# ============================================================================
+
+
+class TestAnalyzeHelperBehavioural(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncTearDown(self) -> None:
+        # Don't tear down the pool between tests (it's a singleton);
+        # module-level teardown is enough.
+        pass
+
+    async def test_ok_small_source_inline_tiny(self) -> None:
+        src = (
+            "def f(x):\n"
+            "    if x > 0:\n"
+            "        for i in range(x):\n"
+            "            print(i)\n"
+            "    return x\n"
+        )
+        result = await analyze_python_source_for_opportunity_miner(
+            "test.ok_small", src,
+        )
+        self.assertEqual(result.outcome, AnalyzeOutcome.OK)
+        self.assertEqual(
+            result.execution_mode, ExecutionMode.INLINE_TINY,
+        )
+        # Function-length, complexity counters populated.
+        self.assertGreater(
+            result.payload.cyclomatic_complexity, 1,
+        )
+        self.assertGreaterEqual(
+            result.payload.max_function_length, 5,
+        )
+        self.assertGreaterEqual(result.payload.total_lines, 5)
+        # No ast.AST anywhere on the result (payload is primitives).
+        self.assertNotIsInstance(result.payload, _ast.AST)
+
+    async def test_ok_large_source_process_pool(self) -> None:
+        # Generate >4KB of valid Python with branching + functions.
+        body_lines = [
+            f"def f_{i}(x):\n"
+            f"    if x > {i}:\n"
+            f"        for j in range({i}):\n"
+            f"            if j % 2 == 0:\n"
+            f"                yield j\n"
+            for i in range(300)
+        ]
+        src = "".join(body_lines)
+        self.assertGreater(len(src.encode("utf-8")), 4096)
+
+        result = await analyze_python_source_for_opportunity_miner(
+            "test.ok_large", src,
+        )
+        self.assertEqual(result.outcome, AnalyzeOutcome.OK)
+        self.assertEqual(
+            result.execution_mode, ExecutionMode.PROCESS,
+        )
+        # Worker reports its own elapsed time (positive but bounded).
+        self.assertGreater(result.worker_elapsed_ms, 0.0)
+        self.assertLess(result.worker_elapsed_ms, 30_000.0)
+        # Per-dimension sanity.
+        self.assertGreater(
+            result.payload.cyclomatic_complexity, 100,
+        )
+        self.assertGreater(result.payload.import_fan_out, -1)
+        self.assertGreater(result.payload.total_lines, 100)
+
+    async def test_syntax_error_inline_tiny_fail_closed(self) -> None:
+        result = await analyze_python_source_for_opportunity_miner(
+            "test.syntax_err_small", "def broken(:\n",
+        )
+        self.assertEqual(
+            result.outcome, AnalyzeOutcome.SYNTAX_ERROR,
+        )
+        # Zero-value payload on failure.
+        self.assertEqual(result.payload, OpportunityAnalysisPayload())
+        self.assertIn("SyntaxError", result.error_detail)
+
+    async def test_syntax_error_process_pool_fail_closed(self) -> None:
+        large_bad = "\n".join(
+            ["def f1(x): return x"] * 500
+        ) + "\ndef broken(:\n"
+        result = await analyze_python_source_for_opportunity_miner(
+            "test.syntax_err_large", large_bad,
+        )
+        self.assertEqual(
+            result.outcome, AnalyzeOutcome.SYNTAX_ERROR,
+        )
+        self.assertEqual(
+            result.execution_mode, ExecutionMode.PROCESS,
+        )
+
+    async def test_too_large_fail_closed_without_pool(self) -> None:
+        result = await analyze_python_source_for_opportunity_miner(
+            "test.too_large", "x = 1\n" * 100, max_bytes=10,
+        )
+        self.assertEqual(result.outcome, AnalyzeOutcome.TOO_LARGE)
+        self.assertIn("max_bytes", result.error_detail)
+
+    async def test_timeout_fail_closed(self) -> None:
+        src = "\n".join(f"x_{i} = {i}" for i in range(500))
+        result = await analyze_python_source_for_opportunity_miner(
+            "test.timeout", src, timeout_s=0.001,
+        )
+        self.assertEqual(
+            result.outcome, AnalyzeOutcome.TIMEOUT,
+            f"Expected TIMEOUT for 1ms deadline; got "
+            f"{result.outcome.name}",
+        )
+        self.assertEqual(
+            result.execution_mode, ExecutionMode.PROCESS,
+        )
+        self.assertLess(result.elapsed_ms, 3000.0)
+
+
+# ============================================================================
+# Metrics parity: analyze helper matches legacy _analyze_file
+# ============================================================================
+
+
+class TestMetricsParity(unittest.IsolatedAsyncioTestCase):
+    """Acceptance gate: the analyze helper must return byte-equivalent
+    metrics to the legacy ``_analyze_file`` for a representative
+    real-world source. Drift here would be a behaviour regression."""
+
+    async def test_metrics_match_legacy_analyze_file(self) -> None:
+        # Use a real source from the codebase: the helper itself is
+        # ~800 LOC with mixed branching + functions + imports +
+        # TODOs — broad coverage across all six dimensions.
+        source = _HELPER_FILE.read_text()
+
+        # Helper path.
+        result = await analyze_python_source_for_opportunity_miner(
+            "test.metrics_parity", source,
+        )
+        self.assertEqual(result.outcome, AnalyzeOutcome.OK)
+
+        # Legacy path (forces sync ast.parse + _analyze_file in the
+        # test process; that's fine — we're computing the reference).
+        from backend.core.ouroboros.governance.intake.sensors.opportunity_miner_sensor import (  # noqa: E501
+            _analyze_file as _legacy_analyze_file,
+        )
+        legacy_tree = _ast.parse(source)
+        legacy = _legacy_analyze_file(str(_HELPER_FILE), source, legacy_tree)
+
+        p = result.payload
+        self.assertEqual(
+            p.cyclomatic_complexity, legacy.cyclomatic_complexity,
+            "cyclomatic_complexity drift",
+        )
+        self.assertEqual(
+            p.max_function_length, legacy.max_function_length,
+            "max_function_length drift",
+        )
+        self.assertEqual(
+            p.cognitive_complexity, legacy.cognitive_complexity,
+            "cognitive_complexity drift",
+        )
+        self.assertEqual(
+            p.duplicate_block_count, legacy.duplicate_block_count,
+            "duplicate_block_count drift",
+        )
+        self.assertEqual(
+            p.import_fan_out, legacy.import_fan_out,
+            "import_fan_out drift",
+        )
+        self.assertEqual(
+            p.todo_fixme_count, legacy.todo_fixme_count,
+            "todo_fixme_count drift",
+        )
+        self.assertEqual(
+            p.total_lines, legacy.total_lines,
+            "total_lines drift",
+        )
+
+
+# ============================================================================
+# OpportunityMiner migration pins
+# ============================================================================
+
+
+class TestOpportunityMinerMigration(unittest.TestCase):
+    """11B-fix: scan_once + scan_file must route through
+    ``analyze_python_source_for_opportunity_miner``. They must NOT:
+      * call ``_analyze_file`` (heavy on-loop walk)
+      * touch ``.tree`` on the helper result (no ast.AST consumption)
+      * call ``parse_python_source`` (returns ast.AST across IPC)
+    """
+
+    def _miner_body(self, method_name: str) -> _ast.AsyncFunctionDef:
+        tree = _parse_module(_MINER_FILE)
+        for node in _ast.walk(tree):
+            if (
+                isinstance(node, _ast.AsyncFunctionDef)
+                and node.name == method_name
+            ):
+                return node
+        raise AssertionError(f"no async method {method_name!r} found")
+
+    def _find_calls_to_named(
+        self, body: _ast.AsyncFunctionDef, name: str,
+    ) -> List[int]:
+        out = []
+        for sub in _ast.walk(body):
+            if not isinstance(sub, _ast.Call):
+                continue
+            f = sub.func
+            if isinstance(f, _ast.Name) and f.id == name:
+                out.append(sub.lineno)
+            elif (
+                isinstance(f, _ast.Attribute) and f.attr == name
+            ):
+                out.append(sub.lineno)
+        return out
+
+    def _find_attribute_access(
+        self, body: _ast.AsyncFunctionDef, attr: str,
+    ) -> List[int]:
+        out = []
+        for sub in _ast.walk(body):
+            if (
+                isinstance(sub, _ast.Attribute) and sub.attr == attr
+            ):
+                out.append(sub.lineno)
+        return out
+
+    def test_scan_once_does_not_call_analyze_file(self) -> None:
+        body = self._miner_body("scan_once")
+        offenders = self._find_calls_to_named(body, "_analyze_file")
+        self.assertEqual(
+            offenders, [],
+            f"scan_once still calls _analyze_file at L{offenders} — "
+            f"must use AnalysisResult.payload instead",
+        )
+
+    def test_scan_file_does_not_call_analyze_file(self) -> None:
+        body = self._miner_body("scan_file")
+        offenders = self._find_calls_to_named(body, "_analyze_file")
+        self.assertEqual(
+            offenders, [],
+            f"scan_file still calls _analyze_file at L{offenders} — "
+            f"must use AnalysisResult.payload instead",
+        )
+
+    def test_scan_once_does_not_use_tree_attribute(self) -> None:
+        """No `.tree` attribute access in scan_once — that would
+        indicate ast.AST consumption from a parse helper result."""
+        body = self._miner_body("scan_once")
+        offenders = self._find_attribute_access(body, "tree")
+        self.assertEqual(
+            offenders, [],
+            f"scan_once accesses .tree at L{offenders} — must not "
+            f"consume ast.AST from helper",
+        )
+
+    def test_scan_file_does_not_use_tree_attribute(self) -> None:
+        body = self._miner_body("scan_file")
+        offenders = self._find_attribute_access(body, "tree")
+        self.assertEqual(
+            offenders, [],
+            f"scan_file accesses .tree at L{offenders} — must not "
+            f"consume ast.AST from helper",
+        )
+
+    def test_miner_imports_analyze_helper(self) -> None:
+        src = _MINER_FILE.read_text()
+        self.assertIn(
+            "analyze_python_source_for_opportunity_miner", src,
+            "OpportunityMiner must import the 11B-fix analyze helper",
+        )
+        self.assertIn("AnalyzeOutcome", src)
+
+    def test_miner_does_not_import_parse_python_source(self) -> None:
+        """Belt-and-suspenders — the parse-only helper returns
+        ast.AST across IPC and is the wrong tool here. Pin against
+        accidental regression to the 11B (pre-fix) shape."""
+        src = _MINER_FILE.read_text()
+        # Search for the actual import name; substring will match
+        # even when imported with an alias.
+        self.assertNotIn("parse_python_source", src)
+        self.assertNotIn("ParseOutcome", src)
+
+
+# ============================================================================
+# Telemetry truth — process mode does NOT emit measure() AST_PARSE records
+# ============================================================================
+
+
+class TestProcessModeTelemetryDoesNotMislead(
+    unittest.IsolatedAsyncioTestCase,
+):
+    """The pre-fix 11B helper wrapped the process-mode await in
+    ``measure(CallKind.AST_PARSE)``. That produced
+    ``[CompileProvenance] on_loop=True ast_parse`` records whose
+    elapsed_ms equalled the IPC roundtrip — misleading operators
+    into believing the loop was blocked when in fact the parse ran
+    in a worker.
+
+    11B-fix removes that wrap. This test exercises the process
+    path and asserts the telemetry ring receives NO new
+    ``ast_parse`` record for the call.
+    """
+
+    async def test_process_mode_no_ast_parse_provenance_record(
+        self,
+    ) -> None:
+        from backend.core.ouroboros.governance import (
+            ast_compile_telemetry as _tel,
+        )
+        # Force provenance ON for this test (master flag default-true
+        # but env-controllable).
+        os.environ.pop("JARVIS_COMPILE_PROVENANCE_ENABLED", None)
+
+        # Snapshot the ring before + after; the analyze helper's
+        # process path must add zero ast_parse records.
+        baseline = len(_tel._ring)
+
+        big = "\n".join(
+            f"def f_{i}(x): return x + {i}" for i in range(500)
+        )
+        self.assertGreater(len(big.encode("utf-8")), 4096)
+
+        result = await analyze_python_source_for_opportunity_miner(
+            "test.process_telemetry", big,
+        )
+        self.assertEqual(result.outcome, AnalyzeOutcome.OK)
+        self.assertEqual(
+            result.execution_mode, ExecutionMode.PROCESS,
+        )
+
+        after = list(_tel._ring)[baseline:]
+        # ZERO ast_parse records should land here. The process path
+        # emits structured log lines only, not provenance ring
+        # entries.
+        ast_parse_records = [
+            r for r in after
+            if r.kind == _tel.CallKind.AST_PARSE
+            and r.caller == "test.process_telemetry"
+        ]
+        self.assertEqual(
+            ast_parse_records, [],
+            "process-mode analyze must NOT add measure(AST_PARSE) "
+            "records — those falsely label IPC roundtrip time as "
+            "on-loop ast_parse. Found: "
+            f"{[(r.caller, r.elapsed_ms) for r in ast_parse_records]}",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the empirical wedge from acceptance soak `bt-2026-05-22-055230`:
**31 `[ControlPlaneStarvation]` events / max lag 37.7 s / 171.7 s of loop-block time / session terminated by RESOURCE-ZERO HARD KILL.**

The original Slice 11B routed parse off-loop but **still returned `ast.AST` across the IPC boundary**, and `_analyze_file` ran six AST walks on the main thread after the await. The heavy work was never off-loaded.

## What changed

1. **New helper** `analyze_python_source_for_opportunity_miner` — worker does parse + all six dimension calcs in a single call; parent receives a primitive `OpportunityAnalysisPayload` (7 ints). **No `ast.AST` ever crosses the IPC boundary.**
2. **OpportunityMiner migration** — `scan_once` + `scan_file` route through the analyze helper. Heavy walks live in the worker; the sensor reads only primitives.
3. **Telemetry truth** — `_process_pool_parse` + `_process_pool_analyze` no longer wrap their await in `measure(AST_PARSE)`. Process-mode telemetry is now structured `[AstCompileHelper] execution_mode=process worker_elapsed_ms=… parent_await_ms=…` log lines. The inline-tiny paths still record via `measure()` because they truly run on-loop. `[ControlPlaneStarvation]` remains the acceptance oracle.
4. **`_DEFAULT_POOL_MAX_WORKERS = 1`** (was 2). Two CPU-burning workers can starve the parent's I/O on a laptop-class control plane.
5. **`parse_python_source`** retained for narrow callers that need the AST; docstring carries a loud warning about heavy walks.

## Discipline

**Closed taxonomies:**
- `AnalyzeOutcome` (5): `OK` / `SYNTAX_ERROR` / `TIMEOUT` / `TOO_LARGE` / `INTERNAL_ERROR`
- `OpportunityAnalysisPayload` frozen, 7 fields

**AST pins (paired test surface):**
- `ast.parse` only in `_worker_parse_in_process`, `_worker_analyze_in_process`, `_inline_tiny_parse`
- `ast.walk` + `ast.iter_child_nodes` only inside `_worker_*` helpers
- OpportunityMiner async methods: no `_analyze_file` call, no `.tree` attribute access, no `parse_python_source` import
- Default pool max_workers == 1

## Tests

| File | Tests | Result |
|---|---|---|
| `tests/governance/test_slice11b_fix_analyze_helper.py` (new) | 21 | ✓ green |
| `tests/governance/test_slice11_ast_compile_helper.py` (updated pins) | 23 | ✓ green |
| `tests/test_ouroboros_governance/test_opportunity_miner_cycle_summary.py` (regression) | 23 | ✓ green |
| **Total** | **67** | **✓ green** |

Key tests:
- **Metrics parity** — helper computes byte-identical 7-dim metrics vs legacy `_analyze_file` on a real ~800-LOC source.
- **Process-mode telemetry truth** — exercises the process path; asserts zero new `measure(AST_PARSE)` ring records (would falsely label IPC roundtrip as on-loop ast_parse).
- **AST cage extension** — `ast.walk` + `ast.iter_child_nodes` only inside `_worker_*` functions.

## Acceptance criteria (next soak)

- zero on-loop AST/compile events >500ms from OpportunityMiner
- zero `[ControlPlaneStarvation]` events during scan phase
- breaker reaches GENERATE and trips attempt 1 (Slice 7 still wired)
- `session_outcome=complete` without manual kill

If clean → unlocks Slice 7g default-TRUE graduation path.
If a different caller emerges as dominant: stop and report (per operator binding) — do not auto-migrate `provider_topology` / `shipped_code_invariants` / `cross_kingdom_boundary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Python source analysis fully off the event loop and fixes misleading telemetry to eliminate control-plane starvation in OpportunityMiner. Adds a process-based analyze helper that returns primitives instead of `ast.AST`.

- **Bug Fixes**
  - Added `analyze_python_source_for_opportunity_miner`: parses and computes all six metrics in a worker; returns `OpportunityAnalysisPayload` (7 ints). No `ast.AST` crosses IPC.
  - Migrated `OpportunityMiner` (`scan_once`, `scan_file`) to use the helper; removed on-loop AST walks and `.tree` usage.
  - Corrected telemetry: removed `measure(AST_PARSE)` around process awaits; now emit `[AstCompileHelper]` structured logs with `execution_mode=process`, `worker_elapsed_ms`, and `parent_await_ms`. Inline-tiny paths still use `measure()`.
  - Set `_DEFAULT_POOL_MAX_WORKERS = 1` to avoid starving the parent’s I/O; retained `parse_python_source` for narrow AST callers with a clear warning about heavy walks.

<sup>Written for commit e287316ad1b14b1af9b197872d5a9e49919490aa. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/51389?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

