### PR TITLE
fix(governance): allowlist session_exhausted in SSE broker — Slice 12D hotfix

### DIFF
--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -1479,6 +1479,12 @@ _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_CIRCUIT_BREAKER_TRIPPED,           # Slice 7e (OPEN_TERMINAL trip — carries the
                                                   # terminal_reason_code; consumers may collapse
                                                   # early instead of waiting on operation_terminal)
+    EVENT_TYPE_SESSION_EXHAUSTED,                 # Slice 12D (global breaker session-wide trip
+                                                  # — fires once at CLOSED → OPEN_TERMINAL with
+                                                  # trip_count + window_s + threshold; the
+                                                  # in-process on_trip callback drives harness
+                                                  # graceful shutdown, this SSE is the IDE
+                                                  # observability surface)
 })
 
 

--- a/tests/governance/test_slice7g_slice12d_graceful_shutdown.py
+++ b/tests/governance/test_slice7g_slice12d_graceful_shutdown.py
@@ -344,11 +344,35 @@ class TestSlice12DSsePublish(unittest.TestCase):
         )
         self.assertTrue(callable(publish_session_exhausted))
 
+    def test_event_type_is_in_broker_allowlist(self) -> None:
+        """The broker's ``_VALID_EVENT_TYPES`` allowlist must
+        include ``session_exhausted``. Missed in the initial Slice
+        12D commit — the in-process callback shutdown chain still
+        worked (it's the authoritative channel), but every SSE
+        publish was rejected with ``[Stream] publish rejected
+        unknown event_type='session_exhausted'``. Pinned so a
+        future refactor that re-derives the allowlist can't drop
+        this entry silently."""
+        from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: E501
+            EVENT_TYPE_SESSION_EXHAUSTED,
+            _VALID_EVENT_TYPES,
+        )
+        self.assertIn(
+            EVENT_TYPE_SESSION_EXHAUSTED, _VALID_EVENT_TYPES,
+            "EVENT_TYPE_SESSION_EXHAUSTED must be in the broker's "
+            "allowlist so publish_session_exhausted can actually "
+            "ship the event (Slice 12D observability)",
+        )
+
     def test_publish_helper_best_effort_on_malformed_payload(
         self,
     ) -> None:
         """A malformed payload must not crash the publish helper —
-        observability is non-authoritative."""
+        observability is non-authoritative. The contract is
+        explicit: NEVER raises. The return value is whatever the
+        broker hands back (an event_id when the publish lands, or
+        ``None`` when the broker is disabled / publish errors out)
+        — both are acceptable degradation modes."""
         from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: E501
             publish_session_exhausted,
         )
@@ -356,7 +380,6 @@ class TestSlice12DSsePublish(unittest.TestCase):
         class _NoAttrs:
             pass
 
-        # Should return None without raising.
         try:
             result = publish_session_exhausted(_NoAttrs())
         except Exception as exc:  # pragma: no cover
@@ -364,8 +387,14 @@ class TestSlice12DSsePublish(unittest.TestCase):
                 f"publish_session_exhausted must be best-effort; "
                 f"got {type(exc).__name__}: {exc}",
             )
-        # When the broker is disabled the helper returns None.
-        self.assertIn(result, (None, ), "best-effort must degrade silently")
+        # Either degradation mode is fine: None (broker disabled /
+        # publish error) OR an event_id string (broker accepted
+        # zero-valued payload). What matters is no raise.
+        self.assertTrue(
+            result is None or isinstance(result, str),
+            f"publish must return None or event_id string; got "
+            f"{type(result).__name__}: {result!r}",
+        )
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Surgical hotfix for the one observability nit spotted in the Slice 7g+12D acceptance soak `bt-2026-05-22-182355`:

```
[Stream] publish rejected unknown event_type='session_exhausted'
```

The new `EVENT_TYPE_SESSION_EXHAUSTED` constant was defined and `publish_session_exhausted` was wired, but the broker's `_VALID_EVENT_TYPES` allowlist was not updated. The **in-process callback shutdown path was unaffected** (and delivered the 30-min wall-cap-margin win) — only the SSE observability publish was rejected.

## What changed

- `_VALID_EVENT_TYPES` allowlist gains `EVENT_TYPE_SESSION_EXHAUSTED`
- New AST pin `test_event_type_is_in_broker_allowlist` prevents silent regression
- Updated `test_publish_helper_best_effort_on_malformed_payload` to assert the actual contract (NEVER raises; either None or event_id is valid)

## Tests

**24/24** Slice 7g+12D tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allowlisted the `session_exhausted` event in the SSE broker so Slice 12D IDE observability publishes are accepted. The in-process shutdown path was already correct; this fixes only the rejected SSE publish.

- **Bug Fixes**
  - Added `EVENT_TYPE_SESSION_EXHAUSTED` to `_VALID_EVENT_TYPES`.
  - Added `test_event_type_is_in_broker_allowlist` to prevent regression.
  - Updated `test_publish_helper_best_effort_on_malformed_payload` to assert "never raises" with `None` or event_id return.

<sup>Written for commit 7668d0c604396fef8e90d8cadada8d1b52367b85. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/51393?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

