### PR TITLE
feat(governance): priority QoS gate + budget-aware dispatch floor — Slice 12F

### DIFF
--- a/backend/core/ouroboros/governance/_governance_state.py
+++ b/backend/core/ouroboros/governance/_governance_state.py
@@ -171,7 +171,14 @@ class GeneratorState:
     """
 
     primary_sem: asyncio.Semaphore
-    fallback_sem: asyncio.Semaphore
+    # Slice 12F-A: ``fallback_sem`` is either a stdlib
+    # ``asyncio.Semaphore`` (legacy / hot-revert path with
+    # ``JARVIS_PRIORITY_SEM_ENABLED=false``) or a
+    # ``priority_semaphore.PrioritySemaphore`` (graduated default).
+    # Both expose ``__aenter__`` / ``__aexit__`` / ``_value`` so
+    # existing callers are byte-equivalent. Annotated as ``Any``
+    # since stdlib ``asyncio.Semaphore`` is not a Protocol.
+    fallback_sem: Any
     fsm: "FailbackStateMachine"
     latency_tracker: "DwLatencyTracker"
     completed_batches: Dict[str, Any] = field(default_factory=dict)
@@ -201,10 +208,29 @@ class GeneratorState:
         """
         from .candidate_generator import FailbackStateMachine
         from .dw_latency_tracker import get_default_tracker
+        # Slice 12F-A — priority-aware fallback semaphore.
+        # Lazy import to keep this module's import graph minimal
+        # (mirrors the FailbackStateMachine import pattern above).
+        # The PrioritySemaphore is a drop-in shape: legacy
+        # ``async with self._fallback_sem:`` still works (defaults
+        # to STANDARD priority, FIFO-equivalent) — call sites that
+        # opt into priority use ``acquire_for_route(route)``.
+        from .priority_semaphore import (
+            PrioritySemaphore,
+            priority_sem_enabled,
+        )
+
+        fallback_sem: object
+        if priority_sem_enabled():
+            fallback_sem = PrioritySemaphore(
+                fallback_concurrency, name="fallback_sem",
+            )
+        else:  # explicit hot-revert via JARVIS_PRIORITY_SEM_ENABLED=false
+            fallback_sem = asyncio.Semaphore(fallback_concurrency)
 
         return cls(
             primary_sem=asyncio.Semaphore(primary_concurrency),
-            fallback_sem=asyncio.Semaphore(fallback_concurrency),
+            fallback_sem=fallback_sem,
             fsm=FailbackStateMachine(),
             latency_tracker=latency_tracker or get_default_tracker(),
         )

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1091,10 +1091,20 @@ class FailbackStateMachine:
         # provider_stream_rupture:... message. Classify as TRANSIENT_TRANSPORT
         # so the FSM uses the short 5s/30s recovery profile and cascades
         # to Tier 1 immediately.
+        #
+        # Slice 12F-B (2026-05-22) — StreamBudgetTooShortError is the
+        # diagnostic sibling: not a network-side rupture, but a local
+        # decision to refuse dispatch when wall_remaining < the
+        # JARVIS_STREAM_MINIMUM_READ_BUDGET_S floor. Same classifier
+        # mapping (TRANSIENT_TRANSPORT) — same Slice 7 fallback
+        # behaviour — but the postmortem can tell the two apart.
         from backend.core.ouroboros.governance.stream_rupture import (
+            StreamBudgetTooShortError,
             StreamRuptureError,
         )
-        if isinstance(exc, StreamRuptureError):
+        if isinstance(
+            exc, (StreamRuptureError, StreamBudgetTooShortError),
+        ):
             return FailureMode.TRANSIENT_TRANSPORT
 
         chain = _walk_exception_chain(exc)
@@ -3362,7 +3372,19 @@ class CandidateGenerator:
             "[CandidateGenerator] Plan fallback sem acquire: slots_free=%d/%d",
             self._fallback_sem._value, self._fallback_concurrency,
         )
-        async with self._fallback_sem:
+        # Slice 12F-A — priority-aware acquisition. The plan() entry
+        # point doesn't carry context (the prompt was already
+        # composed by the orchestrator), so we use the empty-route
+        # default which falls through to DEFAULT_PRIORITY (STANDARD
+        # bucket — FIFO-equivalent within the bucket). The dominant
+        # starvation wedge is on the call() path which DOES have
+        # _op_route in scope. plan() acquisitions are rare relative
+        # to call() acquisitions in the soak; keeping them at default
+        # priority is structurally safe.
+        from backend.core.ouroboros.governance.priority_semaphore import (  # noqa: E501
+            acquire_priority_aware as _slice12f_acquire,
+        )
+        async with _slice12f_acquire(self._fallback_sem, ""):
             _sem_wait_s = time.monotonic() - _sem_t0
             _parent_remaining = self._remaining_seconds(deadline)
             _budget_target = max(_parent_remaining, _FALLBACK_MIN_GUARANTEED_S)
@@ -3999,7 +4021,17 @@ class CandidateGenerator:
             )
 
         try:
-            async with self._fallback_sem:
+            # Slice 12F-A — priority-aware fallback sem acquire.
+            # urgency=high SWE-Bench-Pro foreground ops (IMMEDIATE
+            # route, priority=0) now preempt urgency=low /
+            # BACKGROUND OpportunityMiner ops (priority=4) on slot
+            # release. Hard concurrency cap preserved by the
+            # underlying PrioritySemaphore counter. Hot-revert via
+            # JARVIS_PRIORITY_SEM_ENABLED=false returns to FIFO.
+            from backend.core.ouroboros.governance.priority_semaphore import (  # noqa: E501
+                acquire_priority_aware as _slice12f_acquire,
+            )
+            async with _slice12f_acquire(self._fallback_sem, _op_route):
                 _sem_wait_s = time.monotonic() - _sem_t0
                 _parent_remaining = self._remaining_seconds(deadline)
 
@@ -4023,24 +4055,46 @@ class CandidateGenerator:
                 # CancelledError 130s later (httpx connect+read
                 # surrender latency).  Fast-fail here is observability +
                 # cost win.
-                if _parent_remaining <= 0.0:
+                #
+                # Slice 12F-B (2026-05-22) — raise the D2 floor from
+                # absolute-zero to JARVIS_STREAM_MINIMUM_READ_BUDGET_S
+                # (default 10s). Phase 3A acceptance (bt-2026-05-22-
+                # 184422) proved the gap: sem_wait_total=142.2s drained
+                # the op's wall to ~0.01s — JUST above the 0.0 floor —
+                # so D2 didn't fire and the stream opened with a
+                # 0.01-second read budget. The subsequent inter-chunk
+                # watchdog fired a misleading "no event for 0s" rupture.
+                # That was a budget-too-short refusal masquerading as a
+                # network rupture. Slice 12F-B raises the typed
+                # StreamBudgetTooShortError BEFORE dispatch, which the
+                # classifier maps to TRANSIENT_TRANSPORT →
+                # RetryDecision.RETRY_TRANSIENT (NOT terminal
+                # structural — Slice 7 fallback handles it as a
+                # transient transport fault).
+                from backend.core.ouroboros.governance.stream_rupture import (  # noqa: E501
+                    StreamBudgetTooShortError,
+                    stream_minimum_read_budget_s,
+                )
+                _min_read_budget_s = stream_minimum_read_budget_s()
+                if _parent_remaining < _min_read_budget_s:
                     logger.info(
-                        "[CandidateGenerator] Post-sem fast-fail: "
-                        "sem_wait=%.1fs drained pre_sem_remaining=%.1fs → "
-                        "parent_remaining=0s.  Honest enforcement per D2 "
-                        "operator binding 2026-05-14 — refusing to open "
-                        "a stream that would violate outer wait_for.",
+                        "[CandidateGenerator] Post-sem budget-floor "
+                        "shed (Slice 12F-B): sem_wait=%.1fs drained "
+                        "pre_sem_remaining=%.1fs → parent_remaining=%.2fs "
+                        "below floor=%.1fs (route=%s). Refusing to "
+                        "dispatch a stream that the wall budget cannot "
+                        "honor; raising StreamBudgetTooShortError → "
+                        "RETRY_TRANSIENT (Slice 7 fallback).",
                         _sem_wait_s, _pre_sem_remaining,
+                        _parent_remaining, _min_read_budget_s, _op_route,
                     )
-                    self._raise_exhausted(
-                        "sem_exhausted_zero_budget",
-                        context=context,
-                        deadline=deadline,
+                    raise StreamBudgetTooShortError(
+                        provider="claude-api",
+                        op_id=str(getattr(context, "op_id", ""))[:48],
+                        wall_remaining_s=round(_parent_remaining, 2),
+                        minimum_required_s=_min_read_budget_s,
                         sem_wait_s=round(_sem_wait_s, 2),
-                        pre_sem_remaining_s=round(_pre_sem_remaining, 2),
-                        parent_remaining_s=0.0,
-                        phase=_phase_hint,
-                        route=_op_route,
+                        route=str(_op_route or ""),
                     )
 
                 # AdmissionGate Slice 2 — feed observed wait

--- a/backend/core/ouroboros/governance/priority_semaphore.py
+++ b/backend/core/ouroboros/governance/priority_semaphore.py
@@ -1,0 +1,336 @@
+"""Priority-aware asyncio semaphore — Slice 12F.
+
+Drop-in replacement for ``asyncio.Semaphore`` that orders waiters by
+priority instead of FIFO. Built specifically to solve the wedge
+observed in Phase 3A acceptance (``bt-2026-05-22-184422``):
+
+    Fallback sem acquire: slots_free=1/3 ... route=immediate ...
+    sem_wait_total_s=142.2  (urgency=high SWE-Bench-Pro op)
+
+A foreground SWE-Bench-Pro envelope with ``urgency=high`` and
+``route=IMMEDIATE`` waited 142.2 s behind low-priority background
+OpportunityMiner ops on the existing FIFO semaphore. By the time
+Claude was finally reachable, the op's wall budget was exhausted
+and the request immediately ruptured. That's a starvation pattern
+the FIFO contract cannot fix — operator binding (Slice 12F-A):
+upgrade the gate.
+
+## Design
+
+  * **Drop-in shape** — exposes the same ``async with sem:`` /
+    ``acquire()`` / ``release()`` surface the existing
+    ``asyncio.Semaphore`` provided, so consumers that don't care
+    about priority keep working byte-equivalent.
+  * **Priority API** — ``acquire_for(priority)`` async context
+    manager. Lower priority value = higher dispatch precedence.
+  * **Stable ordering** — within the same priority bucket, waiters
+    fire FIFO (monotonic ``_seq`` counter breaks ties), so
+    same-class ops can't reorder amongst themselves.
+  * **Cancel-safe** — a cancelled waiter is silently dropped from
+    the heap so the next ``release()`` doesn't try to wake a
+    dead future.
+  * **Counter accurate** — slots transfer directly from
+    ``release()`` to the highest-priority waiter (counter stays
+    at 0 during transfer), so observers like
+    ``_fallback_sem._value`` see real-time slot occupancy.
+  * **Pure stdlib** — ``heapq`` + ``asyncio``. No new
+    dependencies. Compatible with Python 3.9+ per project
+    convention (no ``asyncio.timeout``).
+
+## Priority mapping (from ProviderRoute, derived deterministically)
+
+The canonical priority numbers below match the operator-bound
+ordering. Lower = preempts higher.
+
+    IMMEDIATE      → 0  (critical fast reflex — voice / test fail /
+                         runtime health critical / SWE-Bench-Pro
+                         foreground capability probes)
+    INFORMATIONAL  → 1  (interactive Q&A; user is waiting)
+    STANDARD       → 2  (default cascade)
+    COMPLEX        → 3  (Claude reasoning + DW execution; OK to wait)
+    BACKGROUND     → 4  (OpportunityMiner / doc staleness — cheap pool)
+    SPECULATIVE    → 5  (pre-compute for idle time)
+
+Unknown / unset route falls into ``DEFAULT_PRIORITY`` (the
+``STANDARD`` bucket) so misconfigured callers don't accidentally
+preempt foreground traffic.
+
+## Discipline
+
+  * NEVER raises into the caller from the release path (a
+    cancellation race must not leak into other waiters).
+  * The slot-transfer protocol on ``release()`` is the single
+    invariant: when waiters exist, decrement count + wake head
+    of heap atomically; when no waiters, increment count.
+  * Cancellation cleanup is bounded — at most one ``heapify``
+    pass per cancellation, no scanning costs paid by the hot
+    path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import heapq
+import logging
+from contextlib import asynccontextmanager
+from typing import List, Optional, Tuple
+
+
+logger = logging.getLogger("Ouroboros.PrioritySemaphore")
+
+
+# ============================================================================
+# Closed priority map — derived deterministically from ProviderRoute
+# ============================================================================
+#
+# These integers are the structural priority of each route. They
+# are NOT env-tunable on purpose — the operator binding pinned the
+# IMMEDIATE→BACKGROUND ordering as a structural contract. Operators
+# can disable Slice 12F via ``JARVIS_PRIORITY_SEM_ENABLED=false``,
+# which falls back to the legacy FIFO ``asyncio.Semaphore`` shape.
+
+
+DEFAULT_PRIORITY: int = 2  # corresponds to STANDARD route
+
+
+_ROUTE_PRIORITY_MAP: dict = {
+    "immediate":     0,
+    "informational": 1,
+    "standard":      2,
+    "complex":       3,
+    "background":    4,
+    "speculative":   5,
+}
+
+
+def priority_for_route(route: object) -> int:
+    """Resolve a ProviderRoute (or its string value) into a
+    structural priority integer. Falls through to
+    ``DEFAULT_PRIORITY`` (STANDARD bucket) for unknown values.
+    NEVER raises."""
+    try:
+        raw = (
+            route.value if hasattr(route, "value") else route
+        )
+        key = str(raw or "").strip().lower()
+    except Exception:  # noqa: BLE001 — defensive
+        return DEFAULT_PRIORITY
+    return _ROUTE_PRIORITY_MAP.get(key, DEFAULT_PRIORITY)
+
+
+# ============================================================================
+# PrioritySemaphore
+# ============================================================================
+
+
+class PrioritySemaphore:
+    """Priority-aware asyncio semaphore.
+
+    Behaves like ``asyncio.Semaphore`` when no priority is supplied
+    (default ``STANDARD`` bucket). When callers use
+    ``acquire_for(priority=...)`` or the ``acquire_for_route(...)``
+    helper, the lowest priority value wins on slot release —
+    foreground (IMMEDIATE) ops preempt waiting BACKGROUND ops
+    without violating the hard concurrency cap.
+    """
+
+    __slots__ = ("_value", "_initial", "_waiters", "_seq", "_name")
+
+    def __init__(
+        self,
+        value: int = 1,
+        *,
+        name: str = "fallback_sem",
+    ) -> None:
+        if value < 0:
+            raise ValueError("PrioritySemaphore value must be >= 0")
+        self._value: int = int(value)
+        self._initial: int = int(value)
+        # Heap of (priority, seq, future). Lower priority pops first;
+        # within same priority, lower seq pops first (FIFO tiebreak).
+        self._waiters: List[Tuple[int, int, asyncio.Future]] = []
+        self._seq: int = 0
+        self._name: str = name
+
+    # ---- introspection (mirrors asyncio.Semaphore.locked / _value)
+
+    @property
+    def _value_compat(self) -> int:
+        """Legacy callers read ``sem._value`` to compute slots-free.
+        Preserve that shape exactly."""
+        return self._value
+
+    def locked(self) -> bool:
+        """Mirrors ``asyncio.Semaphore.locked``: True iff no slots
+        are free (a new acquire would wait)."""
+        return self._value <= 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def waiter_count(self) -> int:
+        """Number of currently-waiting acquirers."""
+        return len(self._waiters)
+
+    # ---- the core acquire / release pair ---------------------------
+
+    async def acquire(self, priority: int = DEFAULT_PRIORITY) -> None:
+        """Acquire a slot, possibly waiting. Lower ``priority``
+        value preempts higher-value waiters on slot release.
+
+        Raises ``asyncio.CancelledError`` if cancelled while
+        waiting. The waiter is silently removed from the heap so
+        the next release doesn't try to wake a dead future."""
+        if self._value > 0:
+            # Fast path — slot available, no need to queue.
+            self._value -= 1
+            return
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        seq = self._seq
+        self._seq += 1
+        heapq.heappush(self._waiters, (int(priority), seq, fut))
+        try:
+            await fut
+        except asyncio.CancelledError:
+            self._drop_waiter(fut)
+            raise
+        # When release() set our future, the slot was transferred
+        # directly to us — counter stays at 0 (no double-decrement).
+
+    def release(self) -> None:
+        """Release a slot. When waiters exist, slot transfers
+        directly to the highest-priority waiter (counter stays at
+        0). When no waiters, counter increments. NEVER raises."""
+        while self._waiters:
+            try:
+                _priority, _seq, fut = heapq.heappop(self._waiters)
+            except IndexError:
+                break
+            if fut.done():
+                # Cancellation race — this waiter went away before
+                # we got to it. Drop + try the next one.
+                continue
+            try:
+                fut.set_result(None)
+                return  # slot transferred; counter stays at 0
+            except (asyncio.InvalidStateError, Exception):  # noqa: BLE001
+                # Future raced to "done" between done() check and
+                # set_result. Drop + try next waiter.
+                continue
+        # No waiter to hand the slot to — increment counter.
+        self._value = min(self._value + 1, self._initial)
+
+    def _drop_waiter(self, fut: asyncio.Future) -> None:
+        """Remove a cancelled waiter's tuple from the heap.
+        Bounded one-pass scan + heapify."""
+        try:
+            self._waiters = [
+                w for w in self._waiters if w[2] is not fut
+            ]
+            heapq.heapify(self._waiters)
+        except Exception:  # noqa: BLE001 — never raise on cleanup
+            pass
+
+    # ---- context-manager surface (legacy FIFO shape) ---------------
+
+    async def __aenter__(self) -> "PrioritySemaphore":
+        """Legacy ``async with sem:`` path — uses
+        ``DEFAULT_PRIORITY`` (STANDARD bucket). Callers that
+        care about priority should use ``acquire_for`` instead."""
+        await self.acquire(DEFAULT_PRIORITY)
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.release()
+
+    # ---- priority-aware acquisition --------------------------------
+
+    @asynccontextmanager
+    async def acquire_for(self, priority: int):
+        """Priority-aware context manager. Lower priority value
+        preempts higher-value waiters on slot release.
+
+            async with sem.acquire_for(priority=0) as gate:
+                # urgent / IMMEDIATE work runs here
+                ...
+        """
+        await self.acquire(priority)
+        try:
+            yield self
+        finally:
+            self.release()
+
+    @asynccontextmanager
+    async def acquire_for_route(self, route: object):
+        """Convenience wrapper: derive priority from a
+        ``ProviderRoute`` instance (or its string ``value``).
+        Unknown routes fall through to ``DEFAULT_PRIORITY``."""
+        priority = priority_for_route(route)
+        async with self.acquire_for(priority):
+            yield self
+
+
+# ============================================================================
+# Env knob — hot-revert path
+# ============================================================================
+#
+# Default TRUE per Slice 12F: the priority gate is on by default
+# because the FIFO shape demonstrably starved foreground SWE-Bench-Pro
+# traffic. Explicit ``=false`` returns to the legacy FIFO behaviour
+# (the PrioritySemaphore still works, but defaults to DEFAULT_PRIORITY
+# for every acquire, which is FIFO-equivalent).
+
+
+def priority_sem_enabled() -> bool:
+    """``JARVIS_PRIORITY_SEM_ENABLED`` — default TRUE.
+    NEVER raises."""
+    import os
+    raw = os.environ.get(
+        "JARVIS_PRIORITY_SEM_ENABLED", "",
+    ).strip().lower()
+    if raw == "":
+        return True
+    return raw not in ("0", "false", "no", "off")
+
+
+# ============================================================================
+# Drop-in helper for call sites — handles both shapes uniformly
+# ============================================================================
+
+
+def acquire_priority_aware(sem: object, route: object):
+    """Return an async context manager that acquires ``sem``
+    priority-aware when the underlying semaphore exposes the
+    ``acquire_for_route`` method (PrioritySemaphore), and falls
+    through to the legacy ``async with sem`` shape when it does
+    not (stdlib ``asyncio.Semaphore`` under the hot-revert path).
+
+    Lets call sites stay clean:
+
+        async with acquire_priority_aware(self._fallback_sem, route):
+            ...
+
+    No branching at the call site; no behavior change when the
+    Slice 12F master flag is off."""
+    method = getattr(sem, "acquire_for_route", None)
+    if method is not None:
+        return method(route)
+    # Legacy stdlib asyncio.Semaphore — context manager IS the
+    # semaphore itself.
+    return sem
+
+
+# ============================================================================
+# Public surface
+# ============================================================================
+
+
+__all__ = [
+    "DEFAULT_PRIORITY",
+    "PrioritySemaphore",
+    "priority_for_route",
+    "priority_sem_enabled",
+]

--- a/backend/core/ouroboros/governance/stream_rupture.py
+++ b/backend/core/ouroboros/governance/stream_rupture.py
@@ -93,6 +93,37 @@ def stream_inter_chunk_timeout_s() -> float:
 
 
 # ---------------------------------------------------------------------------
+# Slice 12F-B — Budget-aware dispatch floor
+# ---------------------------------------------------------------------------
+
+
+def stream_minimum_read_budget_s() -> float:
+    """Phase 3 (Budget Floor): the minimum ``wall_remaining`` budget
+    required before dispatching a request to the provider.
+
+    When semaphore wait or upstream cascade burns the op's wall
+    budget down to a sliver, opening a stream is futile — the
+    very first ``await __anext__`` will fire the inter-chunk
+    watchdog at a misleading "no event for 0s" timeout. That
+    looks like a network-side stream rupture but the actual cause
+    is local: we never gave the stream a chance to talk.
+
+    Slice 12F-B's contract: refuse to dispatch when
+    ``wall_remaining < this floor`` — raise
+    ``StreamBudgetTooShortError`` so the orchestrator's existing
+    Slice 7 fallback handles it as a transient transport fault
+    (RETRY_TRANSIENT, NOT terminal structural).
+
+    Default: 10s — generous enough to cover Claude's typical
+    TTFT for warm sessions; tight enough to fail fast when the
+    op is genuinely starved.
+    """
+    return float(
+        os.environ.get("JARVIS_STREAM_MINIMUM_READ_BUDGET_S", "10")
+    )
+
+
+# ---------------------------------------------------------------------------
 # Exception
 # ---------------------------------------------------------------------------
 
@@ -137,4 +168,72 @@ class StreamRuptureError(RuntimeError):
             f"elapsed={elapsed_s:.1f}s:"
             f"bytes={bytes_received}:"
             f"timeout={rupture_timeout_s:.0f}s"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Slice 12F-B — Budget-too-short diagnostic exception
+# ---------------------------------------------------------------------------
+
+
+class StreamBudgetTooShortError(RuntimeError):
+    """Raised when the orchestrator declines to dispatch a stream
+    because ``wall_remaining`` after semaphore acquisition is
+    below the ``stream_minimum_read_budget_s`` floor.
+
+    This is structurally distinct from ``StreamRuptureError``:
+    a rupture is a *network-side* fault (the provider stopped
+    sending bytes); a budget-too-short refusal is a *local*
+    decision (we never gave the stream a chance to talk).
+    Conflating the two in the previous "no event for 0s"
+    rupture log was the diagnostic noise Slice 12F-B closes.
+
+    Both errors map to ``FailureMode.TRANSIENT_TRANSPORT`` →
+    ``RetryDecision.RETRY_TRANSIENT`` in the classifier, so the
+    Slice 7 fallback handles them with the same backoff /
+    failover profile. The distinction lives in the postmortem
+    and in IDE / dashboard telemetry, not in the breaker policy.
+
+    Attributes
+    ----------
+    provider : str
+        Target provider that would have received the dispatch.
+    op_id : str
+        Truncated op_id for correlation.
+    wall_remaining_s : float
+        ``wall_rem`` measured *after* semaphore acquisition.
+    minimum_required_s : float
+        The ``stream_minimum_read_budget_s()`` floor at decision
+        time (env-knobbed, default 10s).
+    sem_wait_s : float
+        How long the op waited on the semaphore — the dominant
+        contributor to wall-budget consumption.
+    route : str
+        The op's ``ProviderRoute`` value, for postmortem
+        correlation with the priority-gate ordering.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        op_id: str,
+        wall_remaining_s: float,
+        minimum_required_s: float,
+        sem_wait_s: float,
+        route: str = "",
+    ) -> None:
+        self.provider = provider
+        self.op_id = op_id
+        self.wall_remaining_s = wall_remaining_s
+        self.minimum_required_s = minimum_required_s
+        self.sem_wait_s = sem_wait_s
+        self.route = route
+        super().__init__(
+            f"provider_stream_budget_too_short:{provider}:"
+            f"op={op_id}:"
+            f"wall_remaining={wall_remaining_s:.2f}s:"
+            f"floor={minimum_required_s:.1f}s:"
+            f"sem_wait={sem_wait_s:.1f}s:"
+            f"route={route}"
         )

--- a/tests/governance/test_slice12f_priority_qos_budget_floor.py
+++ b/tests/governance/test_slice12f_priority_qos_budget_floor.py
@@ -1,0 +1,569 @@
+"""Slice 12F — Priority QoS gating + budget-aware dispatch floor.
+
+Closes the Phase 3A starvation wedge (``bt-2026-05-22-184422``):
+
+  * Foreground SWE-Bench-Pro envelope (``urgency=high``,
+    ``route=IMMEDIATE``) waited 142.2 s behind low-priority
+    OpportunityMiner / RuntimeHealth ops on the FIFO fallback
+    semaphore.
+  * By the time Claude was reachable, the op's wall budget had
+    shrunk to ~0.01 s — just above the existing D2 ``<= 0.0``
+    fast-fail floor — so a stream was opened with a fractional
+    read budget. The inter-chunk watchdog fired a misleading
+    "no event for 0s" rupture log.
+
+## 12F-A — PrioritySemaphore
+
+Drop-in replacement for ``asyncio.Semaphore``. Lower priority
+value preempts higher-value waiters on slot release. Hard
+concurrency cap preserved.
+
+## 12F-B — StreamBudgetTooShortError + minimum read floor
+
+After semaphore acquisition, check ``_parent_remaining``. When
+the wall budget is below
+``JARVIS_STREAM_MINIMUM_READ_BUDGET_S`` (default 10s), raise
+``StreamBudgetTooShortError`` BEFORE dispatching to the
+provider. The classifier maps it to
+``FailureMode.TRANSIENT_TRANSPORT`` →
+``RetryDecision.RETRY_TRANSIENT`` so the Slice 7 fallback
+handles it as a transient transport fault (NOT terminal
+structural — does NOT feed the global breaker).
+
+## Test surface
+
+### PrioritySemaphore — concurrency contract
+  * Hard concurrency cap honoured (N+1th acquirer waits)
+  * FIFO within same priority bucket (monotonic ``_seq`` tiebreak)
+  * Lower priority value preempts higher-value waiter on release
+  * Cancelled waiter cleaned from heap (next release doesn't wake
+    a dead future)
+  * ``_value`` introspection mirrors stdlib ``asyncio.Semaphore``
+  * Legacy ``async with sem:`` shape still works (default priority)
+  * ``priority_for_route`` covers every ProviderRoute member
+
+### StreamBudgetTooShortError — diagnostic + classifier
+  * Exception carries full diagnostic (provider / op_id /
+    wall_remaining / floor / sem_wait / route)
+  * Frozen-style — constructor pins the attributes
+  * Distinct from StreamRuptureError (different concept, same
+    classifier mapping)
+  * Classifier maps StreamBudgetTooShortError →
+    FailureMode.TRANSIENT_TRANSPORT
+  * provider_retry_classifier maps TRANSIENT_TRANSPORT →
+    RetryDecision.RETRY_TRANSIENT (NEVER terminal_structural)
+
+### AST pins
+  * candidate_generator.py imports priority_semaphore at the
+    two sem-acquire sites (call + plan)
+  * candidate_generator.py raises StreamBudgetTooShortError when
+    wall_remaining < floor (Slice 12F-B replacement for D2's
+    ``<= 0.0`` check)
+  * _governance_state.py uses PrioritySemaphore when
+    JARVIS_PRIORITY_SEM_ENABLED is on (graduated default)
+
+### Env knob
+  * JARVIS_PRIORITY_SEM_ENABLED default TRUE
+  * Explicit ``=false`` disables the gate (hot-revert)
+  * JARVIS_STREAM_MINIMUM_READ_BUDGET_S honoured at runtime
+"""
+
+from __future__ import annotations
+
+import ast as _ast
+import asyncio
+import os
+import pathlib
+import unittest
+from typing import List
+
+
+from backend.core.ouroboros.governance.priority_semaphore import (
+    DEFAULT_PRIORITY,
+    PrioritySemaphore,
+    acquire_priority_aware,
+    priority_for_route,
+    priority_sem_enabled,
+)
+from backend.core.ouroboros.governance.stream_rupture import (
+    StreamBudgetTooShortError,
+    StreamRuptureError,
+    stream_minimum_read_budget_s,
+)
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_CG_FILE = (
+    _REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "candidate_generator.py"
+)
+_STATE_FILE = (
+    _REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "_governance_state.py"
+)
+_PSEM_FILE = (
+    _REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "priority_semaphore.py"
+)
+
+
+def _parse_module(path: pathlib.Path) -> _ast.Module:
+    return _ast.parse(path.read_text())
+
+
+# ============================================================================
+# PrioritySemaphore — concurrency contract
+# ============================================================================
+
+
+class TestPrioritySemaphoreConcurrencyContract(
+    unittest.IsolatedAsyncioTestCase,
+):
+
+    async def test_hard_concurrency_cap_honoured(self) -> None:
+        sem = PrioritySemaphore(2)
+        in_flight: List[str] = []
+
+        async def worker(tag: str) -> None:
+            async with sem.acquire_for(DEFAULT_PRIORITY):
+                in_flight.append(tag)
+                await asyncio.sleep(0.02)
+                in_flight.remove(tag)
+
+        await asyncio.gather(
+            worker("a"), worker("b"), worker("c"), worker("d"),
+        )
+        # max in-flight should never exceed sem capacity
+        # (asserted indirectly via the fact that asyncio.gather
+        # completed cleanly + no exceptions). Explicit check:
+        # confirm slots_free returns to initial after all done.
+        self.assertEqual(sem._value, 2)
+
+    async def test_fifo_within_same_priority(self) -> None:
+        sem = PrioritySemaphore(1)
+        order: List[str] = []
+
+        async def hold() -> None:
+            async with sem.acquire_for(DEFAULT_PRIORITY):
+                await asyncio.sleep(0.05)
+
+        async def waiter(tag: str, delay: float) -> None:
+            await asyncio.sleep(delay)
+            async with sem.acquire_for(DEFAULT_PRIORITY):
+                order.append(tag)
+
+        await asyncio.gather(
+            hold(),
+            waiter("first", 0.005),
+            waiter("second", 0.010),
+            waiter("third", 0.015),
+        )
+        self.assertEqual(
+            order, ["first", "second", "third"],
+            "same-priority waiters must run FIFO",
+        )
+
+    async def test_lower_priority_preempts_higher_on_release(
+        self,
+    ) -> None:
+        """The headline behaviour: a high-priority waiter that
+        arrives AFTER a low-priority waiter still wins the next
+        slot release."""
+        sem = PrioritySemaphore(1)
+        order: List[str] = []
+
+        async def holder() -> None:
+            async with sem.acquire_for(DEFAULT_PRIORITY):
+                await asyncio.sleep(0.05)
+
+        async def low_prio_late() -> None:
+            await asyncio.sleep(0.005)  # arrives first
+            async with sem.acquire_for(priority=4):  # BACKGROUND
+                order.append("low")
+
+        async def high_prio_later() -> None:
+            await asyncio.sleep(0.020)  # arrives AFTER low_prio
+            async with sem.acquire_for(priority=0):  # IMMEDIATE
+                order.append("high")
+
+        await asyncio.gather(
+            holder(), low_prio_late(), high_prio_later(),
+        )
+        self.assertEqual(
+            order[0], "high",
+            "IMMEDIATE (priority=0) must preempt BACKGROUND "
+            "(priority=4) even though BACKGROUND arrived first",
+        )
+
+    async def test_cancelled_waiter_cleaned_from_heap(self) -> None:
+        sem = PrioritySemaphore(1)
+
+        async def holder() -> None:
+            async with sem.acquire_for(DEFAULT_PRIORITY):
+                await asyncio.sleep(0.10)
+
+        async def cancel_me() -> None:
+            try:
+                async with sem.acquire_for(priority=0):
+                    pass
+            except asyncio.CancelledError:
+                raise
+
+        async def normal() -> None:
+            await asyncio.sleep(0.02)
+            async with sem.acquire_for(priority=4):
+                pass
+
+        holder_task = asyncio.create_task(holder())
+        cancel_task = asyncio.create_task(cancel_me())
+        # Let cancel_task register in the heap then cancel it.
+        await asyncio.sleep(0.01)
+        cancel_task.cancel()
+        try:
+            await cancel_task
+        except asyncio.CancelledError:
+            pass
+        # Confirm heap doesn't contain the dead future + the
+        # subsequent normal waiter still acquires cleanly.
+        await asyncio.gather(holder_task, normal())
+        self.assertEqual(sem._value, 1, "slot should return to free")
+        self.assertEqual(
+            sem.waiter_count, 0,
+            "heap must be empty after cancelled waiter cleanup",
+        )
+
+    async def test_value_introspection_mirrors_stdlib(self) -> None:
+        """Existing log sites read ``sem._value`` to compute
+        slots-free. PrioritySemaphore must expose the same
+        attribute with the same semantics."""
+        sem = PrioritySemaphore(3)
+        self.assertEqual(sem._value, 3)
+        self.assertFalse(sem.locked())
+
+        async def hold():
+            async with sem.acquire_for(DEFAULT_PRIORITY):
+                self.assertEqual(sem._value, 2)
+                await asyncio.sleep(0.01)
+
+        await hold()
+        self.assertEqual(sem._value, 3)
+
+    async def test_legacy_async_with_shape_works(self) -> None:
+        """``async with sem:`` (no priority arg) must work —
+        backward-compat for callers that don't yet know about
+        priority."""
+        sem = PrioritySemaphore(1)
+        async with sem:
+            self.assertEqual(sem._value, 0)
+        self.assertEqual(sem._value, 1)
+
+
+class TestPriorityForRoute(unittest.TestCase):
+    """Coverage pin: every ProviderRoute member must map cleanly."""
+
+    def test_all_routes_have_distinct_priorities(self) -> None:
+        from backend.core.ouroboros.governance.urgency_router import (
+            ProviderRoute,
+        )
+        priorities = {}
+        for r in ProviderRoute:
+            p = priority_for_route(r)
+            priorities[r.value] = p
+        # Six routes → six members → IMMEDIATE wins
+        self.assertEqual(priorities["immediate"], 0)
+        self.assertLessEqual(
+            priorities["informational"], priorities["standard"],
+        )
+        self.assertLess(
+            priorities["standard"], priorities["complex"],
+        )
+        self.assertLess(
+            priorities["complex"], priorities["background"],
+        )
+        self.assertLess(
+            priorities["background"], priorities["speculative"],
+        )
+
+    def test_unknown_route_defaults_to_standard(self) -> None:
+        self.assertEqual(
+            priority_for_route("nonexistent"), DEFAULT_PRIORITY,
+        )
+        self.assertEqual(
+            priority_for_route(""), DEFAULT_PRIORITY,
+        )
+        self.assertEqual(
+            priority_for_route(None), DEFAULT_PRIORITY,
+        )
+
+    def test_string_or_enum_both_accepted(self) -> None:
+        from backend.core.ouroboros.governance.urgency_router import (
+            ProviderRoute,
+        )
+        self.assertEqual(
+            priority_for_route(ProviderRoute.IMMEDIATE),
+            priority_for_route("immediate"),
+        )
+
+
+class TestAcquirePriorityAwareDuckType(
+    unittest.IsolatedAsyncioTestCase,
+):
+
+    async def test_priority_semaphore_uses_priority_path(self) -> None:
+        sem = PrioritySemaphore(1)
+        order: List[str] = []
+
+        async def holder():
+            async with sem:
+                await asyncio.sleep(0.05)
+
+        async def low():
+            await asyncio.sleep(0.005)
+            async with acquire_priority_aware(sem, "background"):
+                order.append("low")
+
+        async def high():
+            await asyncio.sleep(0.020)
+            async with acquire_priority_aware(sem, "immediate"):
+                order.append("high")
+
+        await asyncio.gather(holder(), low(), high())
+        self.assertEqual(order[0], "high")
+
+    async def test_stdlib_semaphore_fallthrough(self) -> None:
+        """Legacy ``asyncio.Semaphore`` doesn't expose
+        ``acquire_for_route`` — the helper must fall through to
+        plain ``async with sem`` without crashing."""
+        sem = asyncio.Semaphore(1)
+        async with acquire_priority_aware(sem, "immediate"):
+            self.assertEqual(sem._value, 0)
+        self.assertEqual(sem._value, 1)
+
+
+# ============================================================================
+# StreamBudgetTooShortError — shape + classifier mapping
+# ============================================================================
+
+
+class TestStreamBudgetTooShortError(unittest.TestCase):
+
+    def test_carries_full_diagnostic(self) -> None:
+        err = StreamBudgetTooShortError(
+            provider="claude-api",
+            op_id="op-019e5103-abcd",
+            wall_remaining_s=0.42,
+            minimum_required_s=10.0,
+            sem_wait_s=142.2,
+            route="immediate",
+        )
+        self.assertEqual(err.provider, "claude-api")
+        self.assertEqual(err.op_id, "op-019e5103-abcd")
+        self.assertAlmostEqual(err.wall_remaining_s, 0.42)
+        self.assertAlmostEqual(err.minimum_required_s, 10.0)
+        self.assertAlmostEqual(err.sem_wait_s, 142.2)
+        self.assertEqual(err.route, "immediate")
+        msg = str(err)
+        self.assertIn("op=op-019e5103-abcd", msg)
+        self.assertIn("wall_remaining=0.42s", msg)
+        self.assertIn("floor=10.0s", msg)
+        self.assertIn("sem_wait=142.2s", msg)
+        self.assertIn("route=immediate", msg)
+
+    def test_distinct_from_stream_rupture_error(self) -> None:
+        """The two errors are siblings, not the same. Pinned so a
+        future refactor can't quietly collapse them into one type
+        (which would lose the diagnostic distinction operators
+        rely on)."""
+        budget_err = StreamBudgetTooShortError(
+            provider="claude-api", op_id="x",
+            wall_remaining_s=0.1, minimum_required_s=10.0,
+            sem_wait_s=100.0, route="",
+        )
+        rupture_err = StreamRuptureError(
+            provider="claude-api", elapsed_s=120.0,
+            bytes_received=13994, rupture_timeout_s=30.0,
+            phase="inter_chunk",
+        )
+        self.assertNotIsInstance(budget_err, StreamRuptureError)
+        self.assertNotIsInstance(rupture_err, StreamBudgetTooShortError)
+
+
+class TestClassifierMapping(unittest.TestCase):
+    """Both stream errors must map to RETRY_TRANSIENT — NOT
+    terminal_structural. Pinned at every layer."""
+
+    def test_failure_mode_classifier_routes_budget_too_short(
+        self,
+    ) -> None:
+        from backend.core.ouroboros.governance.candidate_generator import (  # noqa: E501
+            FailbackStateMachine,
+            FailureMode,
+        )
+        err = StreamBudgetTooShortError(
+            provider="claude-api", op_id="x",
+            wall_remaining_s=0.1, minimum_required_s=10.0,
+            sem_wait_s=100.0, route="",
+        )
+        mode = FailbackStateMachine.classify_exception(err)
+        self.assertEqual(
+            mode, FailureMode.TRANSIENT_TRANSPORT,
+            "StreamBudgetTooShortError must classify as "
+            "TRANSIENT_TRANSPORT (sibling of StreamRuptureError)",
+        )
+
+    def test_failure_mode_classifier_routes_stream_rupture(
+        self,
+    ) -> None:
+        """Sibling check: StreamRuptureError still routes the same
+        way (the Slice 12F-B change must not break it)."""
+        from backend.core.ouroboros.governance.candidate_generator import (  # noqa: E501
+            FailbackStateMachine,
+            FailureMode,
+        )
+        err = StreamRuptureError(
+            provider="claude-api", elapsed_s=120.0,
+            bytes_received=13994, rupture_timeout_s=30.0,
+            phase="inter_chunk",
+        )
+        mode = FailbackStateMachine.classify_exception(err)
+        self.assertEqual(mode, FailureMode.TRANSIENT_TRANSPORT)
+
+    def test_retry_classifier_transient_transport_is_retry_transient(
+        self,
+    ) -> None:
+        from backend.core.ouroboros.governance.provider_retry_classifier import (  # noqa: E501
+            RetryDecision,
+            classify,
+        )
+        decision = classify(
+            failure_class="StreamBudgetTooShortError",
+            failure_mode="TRANSIENT_TRANSPORT",
+        )
+        self.assertEqual(
+            decision, RetryDecision.RETRY_TRANSIENT,
+            "TRANSIENT_TRANSPORT must map to RETRY_TRANSIENT — "
+            "NOT terminal_structural (must NOT feed global "
+            "breaker; Slice 7 fallback handles it)",
+        )
+
+
+# ============================================================================
+# Env knob — graduated default
+# ============================================================================
+
+
+class TestEnvKnobs(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self._prior = os.environ.pop(
+            "JARVIS_PRIORITY_SEM_ENABLED", None,
+        )
+
+    def tearDown(self) -> None:
+        if self._prior is None:
+            os.environ.pop("JARVIS_PRIORITY_SEM_ENABLED", None)
+        else:
+            os.environ["JARVIS_PRIORITY_SEM_ENABLED"] = self._prior
+
+    def test_default_true(self) -> None:
+        os.environ.pop("JARVIS_PRIORITY_SEM_ENABLED", None)
+        self.assertTrue(priority_sem_enabled())
+
+    def test_explicit_false_disables(self) -> None:
+        for v in ("0", "false", "no", "off"):
+            os.environ["JARVIS_PRIORITY_SEM_ENABLED"] = v
+            self.assertFalse(priority_sem_enabled())
+
+    def test_minimum_read_budget_env_honoured(self) -> None:
+        prior = os.environ.pop(
+            "JARVIS_STREAM_MINIMUM_READ_BUDGET_S", None,
+        )
+        try:
+            os.environ.pop(
+                "JARVIS_STREAM_MINIMUM_READ_BUDGET_S", None,
+            )
+            self.assertAlmostEqual(
+                stream_minimum_read_budget_s(), 10.0,
+            )
+            os.environ["JARVIS_STREAM_MINIMUM_READ_BUDGET_S"] = "5"
+            self.assertAlmostEqual(
+                stream_minimum_read_budget_s(), 5.0,
+            )
+        finally:
+            if prior is None:
+                os.environ.pop(
+                    "JARVIS_STREAM_MINIMUM_READ_BUDGET_S", None,
+                )
+            else:
+                os.environ[
+                    "JARVIS_STREAM_MINIMUM_READ_BUDGET_S"
+                ] = prior
+
+
+# ============================================================================
+# AST pins
+# ============================================================================
+
+
+class TestAstPins(unittest.TestCase):
+
+    def test_candidate_generator_imports_priority_semaphore(
+        self,
+    ) -> None:
+        src = _CG_FILE.read_text()
+        self.assertIn(
+            "from backend.core.ouroboros.governance.priority_semaphore import",
+            src,
+            "candidate_generator.py must import the priority "
+            "semaphore (Slice 12F-A)",
+        )
+        self.assertIn(
+            "acquire_priority_aware",
+            src,
+            "candidate_generator.py must use acquire_priority_aware "
+            "at the fallback-sem call sites",
+        )
+
+    def test_candidate_generator_raises_budget_too_short_error(
+        self,
+    ) -> None:
+        src = _CG_FILE.read_text()
+        self.assertIn(
+            "StreamBudgetTooShortError",
+            src,
+            "candidate_generator.py must raise "
+            "StreamBudgetTooShortError when wall_remaining < floor "
+            "(Slice 12F-B)",
+        )
+        self.assertIn(
+            "stream_minimum_read_budget_s",
+            src,
+            "candidate_generator.py must reference the env-knobbed "
+            "minimum-read-budget floor",
+        )
+
+    def test_governance_state_wires_priority_semaphore(self) -> None:
+        src = _STATE_FILE.read_text()
+        self.assertIn(
+            "PrioritySemaphore", src,
+            "_governance_state.py must instantiate "
+            "PrioritySemaphore for fallback_sem (Slice 12F-A)",
+        )
+        self.assertIn(
+            "priority_sem_enabled", src,
+            "_governance_state.py must guard PrioritySemaphore "
+            "behind the master env-knob",
+        )
+
+    def test_priority_semaphore_exports(self) -> None:
+        from backend.core.ouroboros.governance import (
+            priority_semaphore as _ps_mod,
+        )
+        self.assertIn("PrioritySemaphore", _ps_mod.__all__)
+        self.assertIn("priority_for_route", _ps_mod.__all__)
+        self.assertIn("priority_sem_enabled", _ps_mod.__all__)
+        self.assertIn("DEFAULT_PRIORITY", _ps_mod.__all__)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the Phase 3A starvation wedge (`bt-2026-05-22-184422`):
- Foreground SWE-Bench-Pro envelope (`urgency=high`, `route=IMMEDIATE`) waited **142.2s** behind low-priority OpportunityMiner / RuntimeHealth ops on the FIFO fallback semaphore.
- By dispatch time, wall budget shrank to ~0.01s — JUST above the existing D2 `<= 0.0` fast-fail floor — so a stream opened with a fractional read budget and the inter-chunk watchdog fired a misleading `"no event for 0s"` rupture.

**Two distinct failures were being conflated:**
- (a) network-side stream rupture (genuine provider silence)
- (b) local refusal to dispatch (we never gave the stream a chance to talk)

Slice 12F separates them at the source AND prevents the starvation that creates (b).

## Phase A — Priority QoS Gate (`priority_semaphore.py`)

- **`PrioritySemaphore`** drop-in replacement for `asyncio.Semaphore`. Internal heap of `(priority, seq, future)`. Lower priority value preempts higher-value waiters on slot release. FIFO within same bucket via monotonic `_seq` tiebreak. Hard concurrency cap preserved by counter-transfer protocol on `release()`.
- **`acquire_priority_aware(sem, route)`** duck-type-safe helper. Uses the priority path on `PrioritySemaphore`; falls through to legacy `async with sem` on `asyncio.Semaphore` (hot-revert).
- **Deterministic priority map:**
  ```
  IMMEDIATE      → 0   (foreground capability probes / critical)
  INFORMATIONAL  → 1
  STANDARD       → 2   (default cascade)
  COMPLEX        → 3
  BACKGROUND     → 4   (OpportunityMiner / doc staleness)
  SPECULATIVE    → 5
  ```
- **`JARVIS_PRIORITY_SEM_ENABLED`** default TRUE; `=false` returns to legacy FIFO.
- Cancellation-safe: bounded one-pass heapify on cancelled waiter cleanup.

## Phase B — Budget-Aware Dispatch Floor

- **`StreamBudgetTooShortError`** (sibling of `StreamRuptureError`). Distinct class on purpose — a rupture is network-side, a budget-too-short is local. Both classify as `FailureMode.TRANSIENT_TRANSPORT` → `RetryDecision.RETRY_TRANSIENT`. NEVER feeds the global breaker.
- **`JARVIS_STREAM_MINIMUM_READ_BUDGET_S`** default 10s. D2 fast-fail floor raised from `<= 0.0` to `< minimum_read_budget_s()`.
- Raises **before** dispatching to the provider — no wasted semaphore-slot churn or network round-trip on dead ops.

## Tests

**105 + 13 subtests green** across Slice 7 / 7e / 7g+12D / 12F.

23 new tests cover:
- Priority preemption (headline behaviour proven)
- FIFO within bucket
- Cancellation cleanup
- Hard concurrency cap
- Route → priority mapping (every ProviderRoute member)
- Duck-type helper (both shapes)
- StreamBudgetTooShortError diagnostic shape
- Classifier mapping (both errors → TRANSIENT_TRANSPORT)
- Env knob honour
- AST pins (4 — both call sites + state wiring + exports)

## Acceptance criteria (Phase 3A relaunch)

- urgency=high SWE-Bench-Pro foreground op preempts background ops on the fallback semaphore (`sem_wait_total < 30s` foreground, NOT 142s)
- When sem wait does burn budget, dispatch refuses cleanly with `StreamBudgetTooShortError` (NOT misleading "no event for 0s")
- Both errors bubble into Slice 7 fallback as `RETRY_TRANSIENT` — global breaker terminal_structural counter NOT incremented
- Phase 3A reaches a real evaluation verdict (RESOLVED / UNRESOLVED / TERMINAL_TIMEOUT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Priority-gated fallback dispatch plus a minimum stream budget to stop foreground starvation and avoid misleading “no event for 0s” ruptures. High-urgency routes preempt background work; if wall time is too low, we fail fast with a typed, transient error.

- **New Features**
  - Added `PrioritySemaphore` and `acquire_priority_aware` to order fallback acquisitions by route priority (IMMEDIATE → BACKGROUND), FIFO within a bucket, hard cap preserved.
  - Wired `PrioritySemaphore` in `_governance_state` with `JARVIS_PRIORITY_SEM_ENABLED` (default true); `candidate_generator.py` now acquires via `acquire_priority_aware` (plan uses default, call uses route).
  - Introduced `StreamBudgetTooShortError` and `stream_minimum_read_budget_s` (default 10s). If `wall_remaining < floor`, raise before dispatch; classifier treats it like `StreamRuptureError` (transient, retried).

- **Migration**
  - No action needed; defaults are safe.
  - To revert to FIFO, set `JARVIS_PRIORITY_SEM_ENABLED=false`.
  - To tune the floor, set `JARVIS_STREAM_MINIMUM_READ_BUDGET_S`.

<sup>Written for commit f61a50655ff356f04c6a396f3460569182150f19. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/51394?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

