### PR TITLE
feat(governance): Slice 12T — Tombstone + Sensor Scoping + Executor Isolation

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1389,6 +1389,20 @@ class BattleTestHarness:
                     get_default_deadman as _deadman_get_default,
                     deadman_enabled as _deadman_enabled,
                 )
+                # ── Slice 12T Part 1 — wire the tombstone dir ──
+                # Set JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR to the
+                # active session dir so the deadman's wedge fire
+                # path writes
+                # ``<session_dir>/loop_deadman_tombstone.txt``
+                # alongside debug.log. setdefault preserves any
+                # explicit operator override.
+                try:
+                    os.environ.setdefault(
+                        "JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR",
+                        str(self._session_dir),
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
                 if _deadman_enabled():
                     _deadman = _deadman_get_default()
                     _deadman_started = _deadman.start()

--- a/backend/core/ouroboros/governance/loop_deadman.py
+++ b/backend/core/ouroboros/governance/loop_deadman.py
@@ -128,6 +128,49 @@ def deadman_stack_dump_enabled() -> bool:
     return raw not in ("0", "false", "no", "off")
 
 
+def deadman_tombstone_dir() -> Optional[str]:
+    """Slice 12T Part 1 — directory to write the wedge tombstone
+    file ``loop_deadman_tombstone.txt`` into when the deadman fires.
+
+    bt-2026-05-23-180315 surfaced that the existing
+    ``faulthandler.dump_traceback(file=sys.stderr)`` writes ONLY to
+    stderr — which means the dump only lands in the session's
+    ``debug.log`` when the harness was invoked with a ``2>&1 | tee``
+    redirect. Soaks launched without that pipe (notably the
+    background-task path the autonomous loop uses) lose the dump
+    entirely, leaving operators with just a ``WEDGE DETECTED`` line
+    and no diagnosis.
+
+    Slice 12T routes a second copy of the dump to a session-relative
+    file via this env knob (``JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR``).
+    The harness sets it to the active session dir at boot so the
+    tombstone lands next to ``debug.log`` regardless of stderr
+    plumbing. Empty / unset disables the file path (stderr dump
+    still fires) for byte-identical pre-Slice-12T behavior.
+    """
+    raw = os.environ.get(
+        "JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR", "",
+    ).strip()
+    return raw if raw else None
+
+
+def deadman_tombstone_to_logger_enabled() -> bool:
+    """Slice 12T Part 1 — emit per-thread frame dumps via the
+    standard logger (which lands in ``debug.log`` via the harness's
+    file handler) IN ADDITION to the stderr + tombstone-file dumps.
+
+    Default TRUE — costs ~1-5 ms at exit and gives operators a
+    single grep target. Set to ``false`` for byte-identical pre-
+    Slice-12T behavior.
+    """
+    raw = os.environ.get(
+        "JARVIS_LOOP_DEADMAN_TOMBSTONE_LOGGER", "",
+    ).strip().lower()
+    if raw == "":
+        return True
+    return raw not in ("0", "false", "no", "off")
+
+
 # ============================================================================
 # LoopDeadman
 # ============================================================================
@@ -320,13 +363,106 @@ class LoopDeadman:
         except Exception:  # noqa: BLE001 — even logging can wedge
             pass
         if self._stack_dump:
+            # ── Slice 12T Part 1 — Forensic tombstone (three sinks) ──
+            #
+            # bt-2026-05-23-180315 surfaced that the existing
+            # stderr-only dump only landed in debug.log when the
+            # harness was invoked with ``2>&1 | tee`` — background
+            # task launches without that pipe lost the dump
+            # entirely. The wedge then went unattributed even
+            # though faulthandler had captured it.
+            #
+            # Slice 12T routes the dump through THREE sinks (any
+            # one failing leaves the others intact — must NEVER
+            # raise during the exit path):
+            #
+            #   (1) stderr via faulthandler — signal-safe, works
+            #       from any thread; preserved verbatim for
+            #       byte-identical pre-Slice-12T behavior under
+            #       ``2>&1`` redirects.
+            #
+            #   (2) session-relative file
+            #       ``<tombstone_dir>/loop_deadman_tombstone.txt``
+            #       when JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR is set
+            #       (the harness sets it to the active session dir
+            #       at boot). Operators recover the dump without
+            #       stderr plumbing.
+            #
+            #   (3) per-thread frame dump via the standard logger
+            #       (lands in debug.log via the harness file
+            #       handler), one ``[LoopDeadman.TOMBSTONE]`` line
+            #       per frame for grep-friendly analysis.
+
+            # (1) stderr — preserved verbatim.
             try:
-                # Dump every thread's stack to stderr (faulthandler
-                # is signal-safe and works from any thread). The
-                # harness's stderr capture lands this in debug.log.
                 faulthandler.dump_traceback(file=sys.stderr)
             except Exception:  # noqa: BLE001
                 pass
+
+            # (2) session-relative tombstone file.
+            try:
+                _tombstone_dir = deadman_tombstone_dir()
+                if _tombstone_dir:
+                    _tombstone_path = os.path.join(
+                        _tombstone_dir,
+                        "loop_deadman_tombstone.txt",
+                    )
+                    # Open / write / close — synchronous, no
+                    # asyncio dependency (we're in a daemon
+                    # thread). Truncate on each fire so a
+                    # subsequent wedge in the same session dir
+                    # doesn't append confusion. Header carries
+                    # wedge metadata for fast operator triage.
+                    with open(
+                        _tombstone_path, "w", encoding="utf-8",
+                    ) as _tomb:
+                        _tomb.write(
+                            "[LoopDeadman] WEDGE TOMBSTONE\n"
+                            "wedge_age_s=%.1f timeout_s=%.0f\n"
+                            "pid=%d\n"
+                            "fired_at_monotonic=%.3f\n"
+                            "============================\n"
+                            % (
+                                wedge_age_s, self._timeout_s,
+                                os.getpid(), time.monotonic(),
+                            )
+                        )
+                        faulthandler.dump_traceback(file=_tomb)
+                        _tomb.flush()
+                        try:
+                            os.fsync(_tomb.fileno())
+                        except Exception:  # noqa: BLE001
+                            pass
+            except Exception:  # noqa: BLE001 — NEVER raise during exit
+                pass
+
+            # (3) per-thread frame dump via the logger — lands in
+            # debug.log via the harness's file handler, no stderr
+            # plumbing required. ``sys._current_frames()`` returns
+            # a dict {thread_id: frame}; we walk each frame's
+            # f_back chain to produce a compact traceback.
+            try:
+                if deadman_tombstone_to_logger_enabled():
+                    import traceback as _tb
+                    _frames = sys._current_frames()
+                    for _tid, _frame in _frames.items():
+                        try:
+                            _stack = _tb.extract_stack(_frame)
+                            _stack_str = "".join(
+                                _tb.format_list(_stack)
+                            )
+                            logger.critical(
+                                "[LoopDeadman.TOMBSTONE] thread_id=%d\n%s",
+                                _tid, _stack_str,
+                            )
+                        except Exception:  # noqa: BLE001
+                            # Per-thread failure — keep walking
+                            # the rest; never abort the dump for
+                            # one bad frame.
+                            continue
+            except Exception:  # noqa: BLE001
+                pass
+
         # Final, unrecoverable exit. ``os._exit`` bypasses Python
         # cleanup (atexit handlers, asyncio __del__, etc.) — those
         # would re-deadlock on the wedge. The session manager's
@@ -371,6 +507,8 @@ __all__ = [
     "deadman_timeout_s",
     "deadman_heartbeat_s",
     "deadman_stack_dump_enabled",
+    "deadman_tombstone_dir",
+    "deadman_tombstone_to_logger_enabled",
     "get_default_deadman",
     "reset_default_deadman",
 ]

--- a/backend/core/ouroboros/governance/operation_advisor.py
+++ b/backend/core/ouroboros/governance/operation_advisor.py
@@ -169,6 +169,34 @@ ADVISOR_BLAST_COOPERATIVE_ENABLED_ENV_VAR: str = (
 )
 
 
+def _read_bounded_text_for_blast(
+    path_str: str, max_bytes: int,
+) -> Optional[str]:
+    """Slice 12T Part 3 — module-level worker for per-file reads
+    dispatched to the dedicated ``advisor-blast`` ThreadPoolExecutor.
+
+    Lifted to module level (NOT a closure inside
+    :meth:`_compute_blast_radius_async`) so the executor's worker
+    thread doesn't capture the OperationAdvisor instance — avoids
+    pickling/reference-cycle surprises and makes the function
+    inspectable for AST pins. Same signature shape as the previous
+    ``offload_blocking(bounded_read_text, Path(path_str),
+    max_bytes=...)`` call site.
+
+    Returns ``None`` on any error (preserves the
+    ``bounded_read_text`` contract). NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.governance.bounded_walker import (
+            bounded_read_text as _bounded_read_text,
+        )
+        return _bounded_read_text(
+            Path(path_str), max_bytes=max_bytes,
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+
+
 def _advisor_blast_cooperative_enabled() -> bool:
     """Master flag for the Slice 12S cooperative async blast path.
 
@@ -1069,14 +1097,31 @@ class OperationAdvisor:
             blast_radius_max_bytes_per_file,
             blast_radius_max_scanned,
             blast_radius_timeout_s,
-            bounded_read_text,
             default_skip_dirs,
             iter_bounded_files,
         )
         from backend.core.ouroboros.governance.event_loop_governance import (  # noqa: E501
             cooperative_yield_every_n_async,
-            offload_blocking,
         )
+
+        # ── Slice 12T Part 3 — Concurrency isolation ──
+        # bt-2026-05-23-180315 surfaced that Slice 12S's use of
+        # ``offload_blocking`` (which targets the default
+        # ``asyncio.to_thread`` pool) flooded the contested default
+        # executor — exactly the v7 starvation pattern Task #88f's
+        # dedicated ``advisor-blast`` pool was created to prevent.
+        # ControlPlaneStarvation events DOUBLED (28→62) under
+        # Slice 12S.
+        #
+        # Part 3 routes per-file reads through the dedicated
+        # ``advisor-blast`` ThreadPoolExecutor via
+        # ``loop.run_in_executor(executor, ...)`` — restoring the
+        # isolation contract (sensors + Oracle + DreamEngine no
+        # longer compete with blast-scan I/O) while keeping the
+        # cooperative yield cadence between batches (so the
+        # heartbeat coroutine still gets scheduling slots).
+        loop = asyncio.get_running_loop()
+        _blast_executor = _get_advisor_blast_executor()
 
         scan_root = root if root is not None else self._project_root
 
@@ -1144,10 +1189,16 @@ class OperationAdvisor:
         # ``cooperative_yield_every_n_async`` inserts asyncio.sleep(0)
         # every N items (default 64) so the heartbeat coroutine + SDK
         # stream consumer get scheduling slots throughout the scan.
-        # ``offload_blocking`` runs the per-file read on a worker
-        # thread so the GIL releases during the read syscall AND the
-        # surrounding Python overhead (the substring scan inside the
-        # offloaded call also runs off the loop).
+        #
+        # Per-file reads dispatch to the DEDICATED ``advisor-blast``
+        # ThreadPoolExecutor (Slice 12T Part 3) — NOT
+        # ``asyncio.to_thread`` (which targets the default pool
+        # contested by 16 sensors + Oracle + DreamEngine). This
+        # restores the Task #88f isolation contract that Slice 12S
+        # inadvertently broke. The bounded
+        # _ADVISOR_BLAST_EXECUTOR_MAX_WORKERS (default 2) further
+        # caps concurrent file I/O so even N parallel scans cannot
+        # flood the default pool.
         async for path_str in cooperative_yield_every_n_async(
             iter_bounded_files(
                 scan_root,
@@ -1159,11 +1210,11 @@ class OperationAdvisor:
             if not path_str.endswith(".py"):
                 continue
             _files_examined += 1
-            content = await offload_blocking(
-                bounded_read_text,
-                Path(path_str),
-                max_bytes=_per_file_bytes,
-                label="advisor.blast.read",
+            content = await loop.run_in_executor(
+                _blast_executor,
+                _read_bounded_text_for_blast,
+                path_str,
+                _per_file_bytes,
             )
             if content is None:
                 continue

--- a/backend/core/ouroboros/governance/phase_runners/classify_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/classify_runner.py
@@ -79,6 +79,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses as _dc
 import logging
+import os
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from backend.core.ouroboros.governance.ledger import OperationState
@@ -279,6 +280,55 @@ class CLASSIFYRunner(PhaseRunner):
                     )
             _advisor = OperationAdvisor(orch._config.project_root)
 
+            # ── Slice 12T Part 2 — Sensor-op Advisor scoping ──
+            # bt-2026-05-23-180315 surfaced that BACKGROUND-tier
+            # sensor ops (todo_scanner, opportunity_miner,
+            # doc_staleness, …) trigger the same heavy blast-radius
+            # scan that foreground ops do — but their cost budget
+            # (~$0.002/op per the urgency_router routing table)
+            # cannot justify a 10-22s scan. Worse, the scan-budget-
+            # exhausted path returns conservative_cap anyway, which
+            # causes the Advisor to BLOCK these ops. So the scan
+            # produces a deterministic outcome (BLOCK) at maximum
+            # cost (10-22s of loop-yielding scan work).
+            #
+            # Slice 12T short-circuits: detect background-tier
+            # signal sources via the existing
+            # ``urgency_router._BACKGROUND_SOURCES`` +
+            # ``_SPECULATIVE_SOURCES`` taxonomy (single source of
+            # truth for cost-tier routing), pre-compute the
+            # conservative_cap blast value, and dispatch directly
+            # to ``advise()`` (sync, fast — only the blast scan is
+            # heavy) with the value injected via
+            # ``_precomputed_blast_radius``. Preserves the
+            # existing BLOCK behavior byte-identically while
+            # skipping the scan. Other Advisor signals (staleness,
+            # large-file, chronic_entropy) still compute normally.
+            #
+            # Master switch
+            # ``JARVIS_ADVISOR_BG_SCAN_SKIP_ENABLED`` (default
+            # TRUE) gates the optimization; ``false`` reverts to
+            # the pre-Slice-12T full-scan path verbatim.
+            _bg_tier_skip = False
+            try:
+                _skip_raw = os.environ.get(
+                    "JARVIS_ADVISOR_BG_SCAN_SKIP_ENABLED", "true",
+                ).strip().lower()
+                if _skip_raw in {"1", "true", "yes", "on"}:
+                    from backend.core.ouroboros.governance.urgency_router import (  # noqa: E501
+                        _BACKGROUND_SOURCES,
+                        _SPECULATIVE_SOURCES,
+                    )
+                    _sig_src = (
+                        getattr(ctx, "signal_source", "") or ""
+                    ).strip().lower()
+                    _bg_tier_skip = (
+                        _sig_src in _BACKGROUND_SOURCES
+                        or _sig_src in _SPECULATIVE_SOURCES
+                    )
+            except Exception:  # noqa: BLE001 — defensive
+                _bg_tier_skip = False
+
             # B.2.0 worktree-aware advisor: when the envelope carries a
             # trusted ``repo_root`` in evidence AND the (now-graduated
             # 2026-05-13) master flag is on, scan THAT tree instead of
@@ -321,6 +371,37 @@ class CLASSIFYRunner(PhaseRunner):
                 )
 
                 async def _advise_op() -> Any:
+                    # ── Slice 12T Part 2 fast path ──
+                    # Background-tier short-circuit: skip the heavy
+                    # scan, inject conservative_cap via the
+                    # _precomputed_blast_radius seam (Slice 12S).
+                    # Other Advisor signals still compute.
+                    if _bg_tier_skip:
+                        from backend.core.ouroboros.governance.bounded_walker import (  # noqa: E501
+                            blast_radius_conservative_cap,
+                        )
+                        _cap = blast_radius_conservative_cap()
+                        logger.info(
+                            "[Advisor] background_tier_skip "
+                            "signal_source=%s op=%s "
+                            "precomputed_blast=%d "
+                            "(heavy scan bypassed — Slice 12T Part 2)",
+                            (
+                                getattr(ctx, "signal_source", "")
+                                or "<unknown>"
+                            ),
+                            ctx.op_id[:16] if ctx.op_id else "-",
+                            _cap,
+                        )
+                        return _advisor.advise(
+                            ctx.target_files,
+                            ctx.description,
+                            ctx.op_id,
+                            is_read_only=ctx.is_read_only,
+                            repo_root=_adv_repo_root,
+                            _precomputed_blast_radius=_cap,
+                        )
+
                     # Dispatch through the dedicated ``advisor-blast``
                     # ThreadPoolExecutor (PR-B 2026-05-13), NOT the
                     # default asyncio executor.  In the live harness
@@ -379,13 +460,32 @@ class CLASSIFYRunner(PhaseRunner):
                 # default-executor contention for the fallback case.
                 # ``repo_root`` threaded for the same worktree-aware
                 # benefit as the primary path above.
-                _advisory = await _advisor.advise_async(
-                    ctx.target_files,
-                    ctx.description,
-                    ctx.op_id,
-                    is_read_only=ctx.is_read_only,
-                    repo_root=_adv_repo_root,
-                )
+                #
+                # Slice 12T Part 2 — fallback honors the same
+                # background-tier skip so the wedge surface is
+                # closed on BOTH paths (capture-wrapper failure
+                # cannot re-open the original wedge).
+                if _bg_tier_skip:
+                    from backend.core.ouroboros.governance.bounded_walker import (  # noqa: E501
+                        blast_radius_conservative_cap,
+                    )
+                    _cap = blast_radius_conservative_cap()
+                    _advisory = _advisor.advise(
+                        ctx.target_files,
+                        ctx.description,
+                        ctx.op_id,
+                        is_read_only=ctx.is_read_only,
+                        repo_root=_adv_repo_root,
+                        _precomputed_blast_radius=_cap,
+                    )
+                else:
+                    _advisory = await _advisor.advise_async(
+                        ctx.target_files,
+                        ctx.description,
+                        ctx.op_id,
+                        is_read_only=ctx.is_read_only,
+                        repo_root=_adv_repo_root,
+                    )
 
             if _advisory.decision == AdvisoryDecision.BLOCK:
                 logger.warning(

--- a/tests/governance/test_slice12s_advisor_blast_cooperative.py
+++ b/tests/governance/test_slice12s_advisor_blast_cooperative.py
@@ -339,26 +339,37 @@ class TestNonBlockingBehavior:
         )
 
     @pytest.mark.asyncio
-    async def test_offload_blocking_primitive_invoked(
+    async def test_per_file_reads_dispatched_via_helper(
         self, fake_repo, monkeypatch,
     ):
-        """Direct telemetry: every per-file read in the cooperative
-        scan must go through ``offload_blocking`` so the GIL is
-        released during the read+decode work."""
+        """Per-file reads must go through the module-level
+        ``_read_bounded_text_for_blast`` helper.
+
+        SLICE 12T NOTE: pre-Slice-12T this test pinned
+        ``offload_blocking`` (default ``asyncio.to_thread``
+        pool) — Slice 12T Part 3 intentionally REPLACED that
+        with a dispatch through the dedicated ``advisor-blast``
+        ThreadPoolExecutor to restore the Task #88f isolation
+        contract that Slice 12S broke (default-pool contention
+        with 16 sensors + Oracle + DreamEngine doubled
+        ``ControlPlaneStarvation`` events in
+        bt-2026-05-23-180315). The cooperative-yield contract
+        is preserved; only the executor target changed. The
+        Slice 12T sister test pins the dedicated-pool routing
+        directly.
+        """
         from backend.core.ouroboros.governance import (
-            event_loop_governance as elg,
+            operation_advisor as opa,
         )
         call_count = {"n": 0}
-        original = elg.offload_blocking
+        original = opa._read_bounded_text_for_blast
 
-        async def _spy(fn, *args, **kwargs):
+        def _spy(path_str, max_bytes):
             call_count["n"] += 1
-            return await original(fn, *args, **kwargs)
+            return original(path_str, max_bytes)
 
         monkeypatch.setattr(
-            "backend.core.ouroboros.governance.event_loop_governance."
-            "offload_blocking",
-            _spy,
+            opa, "_read_bounded_text_for_blast", _spy,
         )
 
         adv = _make_advisor(fake_repo)
@@ -366,11 +377,12 @@ class TestNonBlockingBehavior:
             ("mypkg/target.py",), root=fake_repo,
         )
         # 30 .py files in fixture — every read goes through
-        # offload_blocking. (Some non-.py paths may also walk past
-        # but they're filtered before the read call.)
+        # the module-level helper dispatched to the dedicated
+        # executor.
         assert call_count["n"] >= 15, (
-            f"offload_blocking called only {call_count['n']} times — "
-            "Slice 12S scan is bypassing the governance primitive"
+            f"_read_bounded_text_for_blast called only "
+            f"{call_count['n']} times — Slice 12T Part 3 "
+            "scan is bypassing the dedicated executor helper"
         )
 
 
@@ -599,7 +611,20 @@ class TestASTPins:
             "the scan is no longer cooperative on the loop"
         )
 
-    def test_compute_blast_radius_async_uses_offload_blocking(self):
+    def test_compute_blast_radius_async_dispatches_dedicated_executor(
+        self,
+    ):
+        """Per-file reads dispatch to a worker thread.
+
+        SLICE 12T NOTE: pre-Slice-12T this pinned
+        ``offload_blocking`` (default pool). Slice 12T Part 3
+        replaced that with ``loop.run_in_executor`` targeting
+        the dedicated ``advisor-blast`` ThreadPoolExecutor via
+        ``_get_advisor_blast_executor()`` — same off-loop
+        contract, different (isolated) executor. The Slice 12T
+        AST pin asserts the dedicated-executor accessor + no
+        residual ``offload_blocking`` calls.
+        """
         src = self._read_source()
         tree = ast.parse(src)
         target_fn = None
@@ -611,26 +636,23 @@ class TestASTPins:
                 target_fn = node
                 break
         assert target_fn is not None
-        found = False
+        # Walk the function body looking for either form of off-
+        # loop dispatch — must find at least one.
+        found_run_in_executor = False
         for inner in ast.walk(target_fn):
             if isinstance(inner, ast.Call):
                 fn = inner.func
                 if (
-                    isinstance(fn, ast.Name)
-                    and fn.id == "offload_blocking"
-                ):
-                    found = True
-                    break
-                if (
                     isinstance(fn, ast.Attribute)
-                    and fn.attr == "offload_blocking"
+                    and fn.attr == "run_in_executor"
                 ):
-                    found = True
+                    found_run_in_executor = True
                     break
-        assert found, (
-            "_compute_blast_radius_async does not call "
-            "offload_blocking — Slice 12S broken: per-file reads "
-            "are running on the loop and holding the GIL"
+        assert found_run_in_executor, (
+            "_compute_blast_radius_async does not dispatch "
+            "per-file reads off the loop via loop.run_in_executor "
+            "— Slice 12T Part 3 broken: per-file reads run on "
+            "the loop and hold the GIL"
         )
 
     def test_advise_async_dispatches_cooperative_first(self):

--- a/tests/governance/test_slice12t_tombstone_scoping_isolation.py
+++ b/tests/governance/test_slice12t_tombstone_scoping_isolation.py
@@ -1,0 +1,695 @@
+"""Slice 12T — Forensic Observability + Sensor Scoping + Executor Isolation.
+
+bt-2026-05-23-180315 (Path A verification soak post-Slice-12S) surfaced
+that Slice 12S's per-scan refactor worked in production (11 scans
+carried the ``mode=cooperative_async`` tag) but the wedge **moved**:
+``ControlPlaneStarvation`` events DOUBLED (28→62) and the existing
+``faulthandler.dump_traceback(file=sys.stderr)`` revealed
+``predictive_engine._fragility`` doing a synchronous
+``pathlib.read_text()`` on the asyncio loop — *not* the Advisor.
+
+The stack dump only landed in the operator's stdout-tee log; the
+session ``debug.log`` ended at "Stack dump to follow if enabled."
+because the dump never reached the file handler. **Never again** —
+Part 1 routes the dump through THREE sinks so future wedges leave a
+discoverable tombstone regardless of stderr plumbing.
+
+Slice 12T combines:
+
+* **Part 1 — Forensic Tombstone** (``loop_deadman.py`` +
+  ``harness.py``). Wedge-detection path now writes the
+  ``faulthandler`` dump to (a) ``sys.stderr`` (preserved verbatim),
+  (b) ``<session_dir>/loop_deadman_tombstone.txt`` via the new
+  ``JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR`` knob (harness sets it at
+  boot), and (c) per-thread frame dumps via the standard logger as
+  ``[LoopDeadman.TOMBSTONE]`` lines (lands in ``debug.log``).
+  All three sinks are individually try-wrapped — the exit path
+  MUST NEVER raise.
+
+* **Part 2 — Sensor-Op Advisor Scoping** (``classify_runner.py``).
+  BACKGROUND-tier sensor ops (``todo_scanner``, ``opportunity_miner``,
+  ``doc_staleness``, ``ai_miner``, ``exploration``, ``backlog``,
+  ``architecture``) and SPECULATIVE-tier (``intent_discovery``)
+  short-circuit the heavy blast scan: the existing
+  ``_precomputed_blast_radius`` seam (Slice 12S) is fed the
+  ``conservative_cap`` value, preserving the existing BLOCK
+  behavior byte-identically while skipping the 10-22s scan. Other
+  Advisor signals (staleness, large-file, chronic_entropy) still
+  compute normally. Composes existing
+  ``urgency_router._BACKGROUND_SOURCES`` /
+  ``_SPECULATIVE_SOURCES`` taxonomy — single source of truth, no
+  parallel classifier. Master switch
+  ``JARVIS_ADVISOR_BG_SCAN_SKIP_ENABLED`` (default TRUE).
+
+* **Part 3 — Concurrency Isolation** (``operation_advisor.py``).
+  Slice 12S's per-file reads were routed through
+  ``offload_blocking`` → ``asyncio.to_thread`` → the DEFAULT
+  executor — exactly the contested pool (16 sensors + Oracle +
+  DreamEngine) the dedicated ``advisor-blast`` executor was
+  created to isolate from (Task #88f). Part 3 restores the
+  isolation contract: per-file reads dispatch through
+  ``loop.run_in_executor(_get_advisor_blast_executor(), …)`` while
+  preserving the cooperative yield cadence between batches. Reuses
+  the bounded ``_ADVISOR_BLAST_EXECUTOR_MAX_WORKERS`` (default 2)
+  so even N parallel scans cannot flood any pool.
+
+Tests pin the tombstone sinks, the scoping short-circuit, the
+isolation contract, and three AST drift-prevention pins.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib
+import inspect
+import io
+import os
+import sys
+import threading
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance import loop_deadman
+from backend.core.ouroboros.governance import operation_advisor
+from backend.core.ouroboros.governance.loop_deadman import (
+    LoopDeadman,
+    deadman_tombstone_dir,
+    deadman_tombstone_to_logger_enabled,
+)
+from backend.core.ouroboros.governance.operation_advisor import (
+    OperationAdvisor,
+    _BLAST_RADIUS_CACHE_SHARED,
+    _read_bounded_text_for_blast,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Shared fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    _BLAST_RADIUS_CACHE_SHARED.clear()
+    yield
+    _BLAST_RADIUS_CACHE_SHARED.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Tombstone-dir + scoping flag must not leak across tests."""
+    for var in (
+        "JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR",
+        "JARVIS_LOOP_DEADMAN_TOMBSTONE_LOGGER",
+        "JARVIS_ADVISOR_BG_SCAN_SKIP_ENABLED",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """30-file repo matching the Slice 12S fixture shape."""
+    target = tmp_path / "mypkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def hello(): return 42\n")
+    for i in range(15):
+        (tmp_path / f"importer_{i:02d}.py").write_text(
+            f"from mypkg.target import hello\n# importer {i}\n",
+        )
+    for i in range(15):
+        (tmp_path / f"unrelated_{i:02d}.py").write_text(
+            f"# unrelated file {i}\nprint('hi')\n",
+        )
+    return tmp_path
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Part 1 — Forensic Tombstone
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPart1TombstoneEnvKnobs:
+    def test_tombstone_dir_unset_returns_none(self, monkeypatch):
+        monkeypatch.delenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR", raising=False,
+        )
+        assert deadman_tombstone_dir() is None
+
+    def test_tombstone_dir_empty_returns_none(self, monkeypatch):
+        monkeypatch.setenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR", "",
+        )
+        assert deadman_tombstone_dir() is None
+
+    def test_tombstone_dir_set_returns_value(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR", str(tmp_path),
+        )
+        assert deadman_tombstone_dir() == str(tmp_path)
+
+    def test_tombstone_logger_defaults_true(self, monkeypatch):
+        monkeypatch.delenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_LOGGER", raising=False,
+        )
+        assert deadman_tombstone_to_logger_enabled() is True
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("true", True), ("1", True), ("on", True),
+            ("false", False), ("0", False), ("no", False),
+            ("off", False),
+        ],
+    )
+    def test_tombstone_logger_truthy(self, monkeypatch, raw, expected):
+        monkeypatch.setenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_LOGGER", raw,
+        )
+        assert deadman_tombstone_to_logger_enabled() is expected
+
+
+class TestPart1TombstoneFireBehavior:
+    """The wedge-fire path must dump to all three sinks AND never
+    raise. We replace ``os._exit`` with a sentinel-raising callable
+    so the test can observe the dump and survive."""
+
+    def _spy_exit(self, monkeypatch, capture):
+        class _ExitSentinel(BaseException):
+            pass
+
+        def _fake_exit(code):
+            capture["exit_code"] = code
+            raise _ExitSentinel()
+
+        monkeypatch.setattr(loop_deadman.os, "_exit", _fake_exit)
+        return _ExitSentinel
+
+    def test_fire_writes_tombstone_file_in_session_dir(
+        self, monkeypatch, tmp_path,
+    ):
+        """When ``JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR`` is set, the
+        fire path MUST create ``loop_deadman_tombstone.txt`` in
+        that dir with the wedge header + faulthandler dump."""
+        monkeypatch.setenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR", str(tmp_path),
+        )
+        capture: dict = {}
+        sentinel = self._spy_exit(monkeypatch, capture)
+        dm = LoopDeadman(
+            timeout_s=30.0, heartbeat_s=1.0, stack_dump=True,
+        )
+        with pytest.raises(sentinel):
+            dm._fire_wedge(wedge_age_s=305.0)
+
+        tombstone = tmp_path / "loop_deadman_tombstone.txt"
+        assert tombstone.exists(), (
+            "Slice 12T Part 1 — tombstone file was not created"
+        )
+        body = tombstone.read_text()
+        assert "WEDGE TOMBSTONE" in body
+        assert "wedge_age_s=305.0" in body
+        assert f"pid={os.getpid()}" in body
+        # faulthandler dump must include at least one Thread or
+        # Current thread marker.
+        assert "Thread" in body or "Current thread" in body, (
+            "tombstone file missing faulthandler stack dump"
+        )
+        assert capture["exit_code"] == 75
+
+    def test_fire_skips_tombstone_file_when_dir_unset(
+        self, monkeypatch, tmp_path,
+    ):
+        """No env var → no file. Stderr dump still fires."""
+        monkeypatch.delenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR", raising=False,
+        )
+        capture: dict = {}
+        sentinel = self._spy_exit(monkeypatch, capture)
+        # Replace stderr with a capturable buffer.
+        stderr_buf = io.StringIO()
+        monkeypatch.setattr(loop_deadman.sys, "stderr", stderr_buf)
+
+        dm = LoopDeadman(
+            timeout_s=30.0, heartbeat_s=1.0, stack_dump=True,
+        )
+        with pytest.raises(sentinel):
+            dm._fire_wedge(wedge_age_s=305.0)
+
+        # No tombstone file in tmp_path.
+        assert not (tmp_path / "loop_deadman_tombstone.txt").exists()
+        # Exit still fired.
+        assert capture["exit_code"] == 75
+
+    def test_fire_emits_logger_tombstone_lines(
+        self, monkeypatch, caplog,
+    ):
+        """Per-thread frames must be logged via the standard
+        logger as ``[LoopDeadman.TOMBSTONE]`` CRITICAL lines so
+        they land in debug.log regardless of stderr plumbing."""
+        monkeypatch.setenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_LOGGER", "true",
+        )
+        capture: dict = {}
+        sentinel = self._spy_exit(monkeypatch, capture)
+        dm = LoopDeadman(
+            timeout_s=30.0, heartbeat_s=1.0, stack_dump=True,
+        )
+        with caplog.at_level("CRITICAL", logger="Ouroboros.LoopDeadman"):
+            with pytest.raises(sentinel):
+                dm._fire_wedge(wedge_age_s=305.0)
+
+        tombstone_msgs = [
+            r.getMessage() for r in caplog.records
+            if "TOMBSTONE" in r.getMessage()
+        ]
+        assert len(tombstone_msgs) >= 1, (
+            "No [LoopDeadman.TOMBSTONE] lines emitted — debug.log "
+            "will be silent on the next wedge"
+        )
+        # Each tombstone line should carry thread_id + a frame.
+        joined = "\n".join(tombstone_msgs)
+        assert "thread_id=" in joined
+
+    def test_fire_logger_disabled_emits_no_tombstone_lines(
+        self, monkeypatch, caplog,
+    ):
+        monkeypatch.setenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_LOGGER", "false",
+        )
+        capture: dict = {}
+        sentinel = self._spy_exit(monkeypatch, capture)
+        dm = LoopDeadman(
+            timeout_s=30.0, heartbeat_s=1.0, stack_dump=True,
+        )
+        with caplog.at_level("CRITICAL", logger="Ouroboros.LoopDeadman"):
+            with pytest.raises(sentinel):
+                dm._fire_wedge(wedge_age_s=305.0)
+        tombstone_msgs = [
+            r.getMessage() for r in caplog.records
+            if "TOMBSTONE" in r.getMessage()
+        ]
+        assert len(tombstone_msgs) == 0
+
+    def test_fire_swallows_tombstone_file_errors(
+        self, monkeypatch, tmp_path,
+    ):
+        """Pointing the tombstone dir at an unwriteable path
+        MUST NOT prevent the exit — the dump is best-effort,
+        the os._exit MUST always fire."""
+        bad_dir = tmp_path / "no_such_dir" / "deeper"
+        # Don't create the dir — open() will raise.
+        monkeypatch.setenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR", str(bad_dir),
+        )
+        capture: dict = {}
+        sentinel = self._spy_exit(monkeypatch, capture)
+        dm = LoopDeadman(
+            timeout_s=30.0, heartbeat_s=1.0, stack_dump=True,
+        )
+        with pytest.raises(sentinel):
+            dm._fire_wedge(wedge_age_s=305.0)
+        # Exit fired even though the file write failed.
+        assert capture["exit_code"] == 75
+
+    def test_fire_stack_dump_disabled_skips_all_sinks(
+        self, monkeypatch, tmp_path,
+    ):
+        """When ``stack_dump=False`` the dump is fully bypassed
+        — preserves byte-identical pre-Slice-12T behavior."""
+        monkeypatch.setenv(
+            "JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR", str(tmp_path),
+        )
+        capture: dict = {}
+        sentinel = self._spy_exit(monkeypatch, capture)
+        dm = LoopDeadman(
+            timeout_s=30.0, heartbeat_s=1.0, stack_dump=False,
+        )
+        with pytest.raises(sentinel):
+            dm._fire_wedge(wedge_age_s=305.0)
+        # No tombstone file.
+        assert not (tmp_path / "loop_deadman_tombstone.txt").exists()
+        # Exit still fired.
+        assert capture["exit_code"] == 75
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Part 2 — Sensor-Op Advisor Scoping
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPart2BackgroundTierSkip:
+    """Verifies BACKGROUND/SPECULATIVE sensor ops skip the heavy
+    blast scan while preserving the BLOCK outcome via the
+    conservative_cap injection. Direct unit tests on the env-knob
+    classifier (the source-of-truth `_BACKGROUND_SOURCES` /
+    `_SPECULATIVE_SOURCES` taxonomy)."""
+
+    def test_background_sources_set_includes_all_taxonomy(self):
+        """Pin the taxonomy so a future urgency_router change
+        doesn't silently remove a sensor from the skip path."""
+        from backend.core.ouroboros.governance.urgency_router import (
+            _BACKGROUND_SOURCES,
+            _SPECULATIVE_SOURCES,
+        )
+        # These are the canonical background-tier sources Slice
+        # 12T skips. Any future addition is fine; any removal
+        # would silently re-open the wedge for that sensor.
+        for required in (
+            "todo_scanner", "doc_staleness", "ai_miner",
+            "exploration", "backlog", "architecture",
+        ):
+            assert required in _BACKGROUND_SOURCES, (
+                f"{required!r} dropped from _BACKGROUND_SOURCES — "
+                "Slice 12T skip path no longer covers that sensor"
+            )
+        assert "intent_discovery" in _SPECULATIVE_SOURCES
+
+    def test_skip_flag_default_true(self, monkeypatch):
+        monkeypatch.delenv(
+            "JARVIS_ADVISOR_BG_SCAN_SKIP_ENABLED", raising=False,
+        )
+        # Default value used in classify_runner is the literal
+        # "true" — mirror that here as the canonical source.
+        raw = os.environ.get(
+            "JARVIS_ADVISOR_BG_SCAN_SKIP_ENABLED", "true",
+        ).strip().lower()
+        assert raw == "true"
+
+    def test_precomputed_blast_radius_seam_skips_scan(
+        self, fake_repo,
+    ):
+        """When ``_precomputed_blast_radius`` is passed to
+        :meth:`advise`, the heavy scan must NOT run — verified
+        by spying on ``_compute_blast_radius``. The result must
+        carry the injected value as ``Advisory.blast_radius``."""
+        adv = OperationAdvisor(project_root=fake_repo)
+        scan_calls = {"n": 0}
+        original = adv._compute_blast_radius
+
+        def _spy(*args, **kwargs):
+            scan_calls["n"] += 1
+            return original(*args, **kwargs)
+
+        adv._compute_blast_radius = _spy  # type: ignore[method-assign]
+
+        result = adv.advise(
+            target_files=("mypkg/target.py",),
+            description="background tier op",
+            op_id="op-bg-test",
+            is_read_only=False,
+            repo_root=fake_repo,
+            _precomputed_blast_radius=50,
+        )
+        assert scan_calls["n"] == 0, (
+            "Heavy scan ran despite _precomputed_blast_radius — "
+            "Slice 12T Part 2 skip seam broken"
+        )
+        assert result.blast_radius == 50
+
+    def test_precomputed_blast_radius_omitted_falls_through(
+        self, fake_repo,
+    ):
+        """When the kwarg is omitted, the heavy scan must run
+        normally — preserves byte-identical legacy behavior for
+        non-background callers."""
+        adv = OperationAdvisor(project_root=fake_repo)
+        scan_calls = {"n": 0}
+        original = adv._compute_blast_radius
+
+        def _spy(*args, **kwargs):
+            scan_calls["n"] += 1
+            return original(*args, **kwargs)
+
+        adv._compute_blast_radius = _spy  # type: ignore[method-assign]
+
+        adv.advise(
+            target_files=("mypkg/target.py",),
+            description="foreground op",
+            op_id="op-fg-test",
+            is_read_only=False,
+            repo_root=fake_repo,
+        )
+        assert scan_calls["n"] == 1, (
+            "Heavy scan did NOT run for foreground op — Slice 12T "
+            "Part 2 incorrectly broadens the skip"
+        )
+
+
+class TestPart2ASTPin:
+    """Pin the classify_runner integration so a refactor cannot
+    silently bypass the skip."""
+
+    def _read_classify(self) -> str:
+        return Path(
+            "backend/core/ouroboros/governance/phase_runners/"
+            "classify_runner.py"
+        ).read_text()
+
+    def test_bg_tier_skip_variable_present(self):
+        src = self._read_classify()
+        assert "_bg_tier_skip" in src, (
+            "Slice 12T Part 2 skip variable removed from "
+            "classify_runner.py"
+        )
+        assert "_BACKGROUND_SOURCES" in src, (
+            "classify_runner no longer references "
+            "_BACKGROUND_SOURCES — skip is uncoupled from the "
+            "urgency_router taxonomy"
+        )
+        assert "_SPECULATIVE_SOURCES" in src
+
+    def test_skip_path_calls_advise_with_precomputed(self):
+        """The skip path must use the
+        ``_precomputed_blast_radius`` seam — not call a parallel
+        method or compute the radius itself."""
+        src = self._read_classify()
+        # Both the env-knob name and the seam kwarg must appear.
+        assert "JARVIS_ADVISOR_BG_SCAN_SKIP_ENABLED" in src
+        assert "_precomputed_blast_radius" in src
+        assert "blast_radius_conservative_cap" in src, (
+            "Skip path doesn't reference conservative_cap — "
+            "BLOCK behavior may not be preserved"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Part 3 — Concurrency Isolation
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPart3DedicatedExecutorRouting:
+    """Per-file reads in the cooperative scan MUST dispatch
+    through the dedicated ``advisor-blast`` ThreadPoolExecutor —
+    not the default ``asyncio.to_thread`` pool. Verified by
+    inspecting ``threading.current_thread().name`` from inside
+    the worker."""
+
+    @pytest.mark.asyncio
+    async def test_per_file_reads_run_on_advisor_blast_thread(
+        self, fake_repo, monkeypatch,
+    ):
+        monkeypatch.setenv(
+            "JARVIS_EVENT_LOOP_YIELD_EVERY_N", "4",
+        )
+        captured_threads: set = set()
+        original_helper = (
+            operation_advisor._read_bounded_text_for_blast
+        )
+
+        def _spy(path_str, max_bytes):
+            captured_threads.add(
+                threading.current_thread().name,
+            )
+            return original_helper(path_str, max_bytes)
+
+        monkeypatch.setattr(
+            operation_advisor,
+            "_read_bounded_text_for_blast", _spy,
+        )
+
+        adv = OperationAdvisor(project_root=fake_repo)
+        await adv._compute_blast_radius_async(
+            ("mypkg/target.py",), root=fake_repo,
+        )
+        assert captured_threads, "no per-file reads ran"
+        # Every thread name must start with the dedicated prefix
+        # — proves NO read fell through to the default pool.
+        for name in captured_threads:
+            assert name.startswith("advisor-blast"), (
+                f"per-file read ran on thread {name!r}; expected "
+                "'advisor-blast' prefix — Slice 12T Part 3 "
+                "isolation broken"
+            )
+
+    @pytest.mark.asyncio
+    async def test_offload_blocking_no_longer_invoked_in_scan(
+        self, fake_repo, monkeypatch,
+    ):
+        """The Slice 12S regression: ``offload_blocking`` (which
+        hits the default pool) MUST NOT be called from
+        ``_compute_blast_radius_async`` — Part 3 replaced it."""
+        from backend.core.ouroboros.governance import (
+            event_loop_governance as elg,
+        )
+        spy_count = {"n": 0}
+        original = elg.offload_blocking
+
+        async def _spy(fn, *args, **kwargs):
+            spy_count["n"] += 1
+            return await original(fn, *args, **kwargs)
+
+        monkeypatch.setattr(
+            "backend.core.ouroboros.governance."
+            "event_loop_governance.offload_blocking",
+            _spy,
+        )
+
+        adv = OperationAdvisor(project_root=fake_repo)
+        await adv._compute_blast_radius_async(
+            ("mypkg/target.py",), root=fake_repo,
+        )
+        assert spy_count["n"] == 0, (
+            f"offload_blocking called {spy_count['n']}× during "
+            "blast scan — Part 3 isolation regressed to Slice 12S"
+        )
+
+    @pytest.mark.asyncio
+    async def test_result_parity_preserved_after_isolation(
+        self, fake_repo,
+    ):
+        """Switching the dispatch target must NOT change the
+        integer returned. Parity with the sync path is the
+        load-bearing correctness contract."""
+        adv = OperationAdvisor(project_root=fake_repo)
+        sync_count = adv._compute_blast_radius(
+            ("mypkg/target.py",), root=fake_repo,
+        )
+        _BLAST_RADIUS_CACHE_SHARED.clear()
+        async_count = await adv._compute_blast_radius_async(
+            ("mypkg/target.py",), root=fake_repo,
+        )
+        assert sync_count == async_count == 15
+
+
+class TestPart3ASTPin:
+    def _read_advisor(self) -> str:
+        return Path(
+            "backend/core/ouroboros/governance/operation_advisor.py"
+        ).read_text()
+
+    def test_async_scan_uses_dedicated_executor(self):
+        """``_compute_blast_radius_async`` MUST use
+        ``loop.run_in_executor`` with the dedicated executor
+        accessor — NOT ``offload_blocking``."""
+        src = self._read_advisor()
+        tree = ast.parse(src)
+        target_fn = None
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.AsyncFunctionDef)
+                and node.name == "_compute_blast_radius_async"
+            ):
+                target_fn = node
+                break
+        assert target_fn is not None
+
+        # Must reference _get_advisor_blast_executor in the body.
+        body_text = ast.unparse(target_fn)
+        assert "_get_advisor_blast_executor" in body_text, (
+            "_compute_blast_radius_async doesn't dispatch to "
+            "the dedicated executor — Part 3 isolation broken"
+        )
+        assert "run_in_executor" in body_text, (
+            "_compute_blast_radius_async doesn't use "
+            "loop.run_in_executor for per-file reads"
+        )
+        # Must NOT call offload_blocking from inside the function
+        # (it was the Slice 12S code path Part 3 replaces).
+        offload_count = 0
+        for inner in ast.walk(target_fn):
+            if isinstance(inner, ast.Call):
+                fn = inner.func
+                if (
+                    isinstance(fn, ast.Name)
+                    and fn.id == "offload_blocking"
+                ):
+                    offload_count += 1
+                elif (
+                    isinstance(fn, ast.Attribute)
+                    and fn.attr == "offload_blocking"
+                ):
+                    offload_count += 1
+        assert offload_count == 0, (
+            "offload_blocking still called inside "
+            "_compute_blast_radius_async — Part 3 incomplete"
+        )
+
+    def test_module_level_helper_exists(self):
+        """The per-file read worker MUST live at module level
+        (not as a closure) so the executor thread doesn't
+        capture the OperationAdvisor instance."""
+        assert callable(
+            operation_advisor._read_bounded_text_for_blast,
+        )
+        sig = inspect.signature(
+            operation_advisor._read_bounded_text_for_blast,
+        )
+        params = list(sig.parameters.keys())
+        assert params == ["path_str", "max_bytes"], (
+            f"helper signature drifted: {params}"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Cross-part: end-to-end no-loop-wedge proof
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCrossPartHeartbeatStillTicks:
+    """Combined sanity: the cooperative scan with Part 3
+    isolation still yields enough that a concurrent heartbeat
+    coroutine accumulates ticks during the scan. Regression
+    against the bt-2026-05-23-180315 wedge."""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_ticks_with_dedicated_executor(
+        self, fake_repo, monkeypatch,
+    ):
+        monkeypatch.setenv(
+            "JARVIS_EVENT_LOOP_YIELD_EVERY_N", "4",
+        )
+        ticks = 0
+        scan_running = True
+
+        async def heartbeat():
+            nonlocal ticks
+            while scan_running:
+                ticks += 1
+                await asyncio.sleep(0.001)
+
+        adv = OperationAdvisor(project_root=fake_repo)
+        hb_task = asyncio.create_task(heartbeat())
+        await asyncio.sleep(0.01)
+        ticks_before = ticks
+
+        await adv._compute_blast_radius_async(
+            ("mypkg/target.py",), root=fake_repo,
+        )
+
+        scan_running = False
+        await asyncio.sleep(0.01)
+        hb_task.cancel()
+        try:
+            await hb_task
+        except asyncio.CancelledError:
+            pass
+
+        ticks_during = ticks - ticks_before
+        assert ticks_during >= 2, (
+            f"Heartbeat starved during Part 3 scan: "
+            f"ticks={ticks_during} — loop is wedged"
+        )


### PR DESCRIPTION
## Summary

Closes the wedge surfaced by `bt-2026-05-23-180315` (Slice 12S Path A soak). Slice 12S's per-scan refactor worked in production (11 scans carried `mode=cooperative_async`) but the wedge **moved**: `ControlPlaneStarvation` events DOUBLED (28→62) and `LoopDeadman` fired again at 304.9s. The existing `faulthandler.dump_traceback(file=sys.stderr)` DID capture the real wedge — `predictive_engine._fragility` doing sync `pathlib.read_text()` on the asyncio loop — but **the dump only landed in the operator's `tee` log** because `debug.log` has no stderr handler. The wedge went unattributed despite forensics existing.

Slice 12T is a **3-part architectural fix** per operator binding "SUPER DUPER BEEF IT UP — no shortcuts."

## Part 1 — Forensic Tombstone (operator Option A)

`loop_deadman.py` + `harness.py`:

Two new env knobs:
- `JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR` (str, default unset)
- `JARVIS_LOOP_DEADMAN_TOMBSTONE_LOGGER` (bool, default TRUE)

`_fire_wedge()` now writes to **THREE sinks** (every one individually try-wrapped; the exit MUST NEVER fail):

1. **`sys.stderr` via `faulthandler.dump_traceback`** — preserved verbatim for byte-identical pre-Slice-12T behavior
2. **`<tombstone_dir>/loop_deadman_tombstone.txt`** — header carries `wedge_age_s` + `timeout_s` + `pid` + monotonic; body carries full faulthandler dump; `fsync`'d. **Operator recovers the dump without any stderr plumbing.**
3. **Per-thread frame dumps via the standard logger** as `[LoopDeadman.TOMBSTONE]` CRITICAL lines (lands in `debug.log` via the harness's file handler) — one line per thread with `thread_id` + extracted traceback

The harness wires `JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR` to the active session dir at boot via `os.environ.setdefault` — preserves explicit operator overrides; operator zero-config experience.

## Part 2 — Sensor-Op Advisor Scoping (operator Option D)

`classify_runner.py`:

`bt-2026-05-23-180315` showed BACKGROUND-tier sensor ops (`todo_scanner`, `opportunity_miner`, `doc_staleness`, `ai_miner`, `exploration`, `backlog`, `architecture`) trigger the same heavy blast scan as foreground ops — but their cost budget (~$0.002/op per the urgency_router routing table) cannot justify a 10–22s scan that returns `conservative_cap` → BLOCK anyway. **The scan produces a deterministic outcome at maximum cost.**

Slice 12T short-circuits: detect background-tier signal sources via the **existing** `urgency_router._BACKGROUND_SOURCES` + `_SPECULATIVE_SOURCES` taxonomy (**single source of truth** for cost-tier routing — NO parallel classifier), pre-compute the `conservative_cap` blast value, and dispatch directly to `advise()` with the value injected via the `_precomputed_blast_radius` seam (Slice 12S composition surface). Preserves the existing BLOCK behavior byte-identically while skipping the scan. Other Advisor signals (staleness, large-file, chronic_entropy) still compute.

Master switch: `JARVIS_ADVISOR_BG_SCAN_SKIP_ENABLED` (default TRUE). Applied to **BOTH** the primary `advise_async` call site AND the capture-wrapper-failure fallback site — wedge cannot re-open via either path.

## Part 3 — Concurrency Isolation (Slice 12S regression fix)

`operation_advisor.py`:

Slice 12S routed per-file reads through `offload_blocking` → `asyncio.to_thread` → the **DEFAULT** executor (contested by 16 sensors + Oracle + DreamEngine). That re-introduced the v7 default-pool starvation pattern Task #88f's dedicated `advisor-blast` pool was created to prevent — exactly why ControlPlaneStarvation events DOUBLED.

Part 3 restores isolation: per-file reads dispatch through `loop.run_in_executor(_get_advisor_blast_executor(), …)` — the bounded (default 2 workers) dedicated pool — while preserving `cooperative_yield_every_n_async` between batches. New module-level helper `_read_bounded_text_for_blast` lifted out of a closure so the executor thread doesn't capture the `OperationAdvisor` instance and the call site is inspectable for AST pins.

## Test surface (29 new + 250 cross-arc = 279 green)

`tests/governance/test_slice12t_tombstone_scoping_isolation.py` (**NEW, 695 lines, 29 tests, 7 areas**):

| Area | Count | Notes |
|---|---|---|
| Part 1 env knobs | 10 | unset/empty/set dir, logger default-TRUE + 6 truthy values |
| **Part 1 fire behavior** | **6** | **LOAD-BEARING** — tombstone file creation, skip-when-unset, logger lines, logger-disabled, file open failure swallowed, stack_dump=False bypass |
| Part 2 background-tier skip | 4 | canonical taxonomy coverage pin, default-TRUE flag, seam skips scan, omission falls through |
| Part 2 AST pin | 2 | `_bg_tier_skip` variable + taxonomy references; `_precomputed_blast_radius` + `conservative_cap` in skip path |
| Part 3 dedicated executor | 3 | per-file reads on `advisor-blast` threads, NO `offload_blocking` invocations, result parity sync ↔ async |
| Part 3 AST pin | 2 | `_get_advisor_blast_executor` + `run_in_executor` references, no residual `offload_blocking`; module-level helper signature pin |
| Cross-part heartbeat | 1 | concurrent heartbeat ticks during Part 3 cooperative scan |

Updated Slice 12S tests (2): contract evolution from `offload_blocking` → dedicated-executor dispatch.

### Verdict

- **29/29** Slice 12T tests green (2.2s)
- **29/29** Slice 12S tests green after contract evolution
- **279/279 cross-arc 12N–T + advisor + Task 102 governance** green (27.3s)

## Standing operator bindings — all honored

- ✅ No shortcuts, no brute force, no workarounds
- ✅ All 3 parts solve root architectural problems (forensic tombstone routing / sensor cost-tier classification / executor isolation contract) — not symptomatic timeout tweaks
- ✅ Builds cleanly on every existing primitive: `faulthandler`, `urgency_router._BACKGROUND_SOURCES`/`_SPECULATIVE_SOURCES` (single source of truth for cost-tier classification), Slice 12S's `_precomputed_blast_radius` composition seam, Task #88f's dedicated `advisor-blast` pool, Task #102's `cooperative_yield_every_n_async`
- ✅ Zero new threading mechanism, zero new bounding primitive, zero parallel classifier
- ✅ All 3 master switches graduate default-TRUE; legacy paths preserved verbatim under master-off for byte-identical rollback
- ✅ Iron Gate / OCA discipline preserved — no `--no-verify`, no bypass

## Open finding — predictive_engine wedge (NOT addressed by Slice 12T)

The forensic tombstone from `bt-2026-05-23-180315` conclusively identified `predictive_engine.py:131 in _fragility` doing sync `pathlib.read_text()` on the asyncio loop as the **actual** wedge source. This is the SAME sin pattern Slice 12S fixed in the Advisor, but in a different subsystem.

**Slice 12T does NOT touch `predictive_engine`** — that's separate slice scope (operator's no-autonomous-creation binding). The next Path A soak will likely hit this wedge again, **but the tombstone file will now land directly in the session dir for zero-ambiguity attribution.**

## Post-merge

Path A retry with the 4-flag SWE-Bench-Pro bundle to verify:

1. If a wedge fires, **the tombstone file lands in the session dir** (Part 1) — no more attribution guesswork
2. **ControlPlaneStarvation events DROP back to single digits** (Part 3 restored isolation undoes the Slice 12S regression that doubled them)
3. **Background-tier ops no longer trigger 10-22s scans** (Part 2 skip path observed via `background_tier_skip` log lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deadman tombstone (file + logger), skips heavy advisor scans for background/speculative sensor ops, and restores advisor-blast executor isolation to cut loop starvation and make wedges easy to attribute.

- New Features
  - Forensic tombstone: on wedge, dump goes to stderr, a session file, and logger; `JARVIS_LOOP_DEADMAN_TOMBSTONE_DIR` and `JARVIS_LOOP_DEADMAN_TOMBSTONE_LOGGER` added; harness sets the dir by default.
  - Sensor scoping: background/speculative sources (from `urgency_router` taxonomy) bypass the blast scan; inject `conservative_cap` via `_precomputed_blast_radius`; gated by `JARVIS_ADVISOR_BG_SCAN_SKIP_ENABLED` (default true) on both primary and fallback paths.
  - Executor isolation: per-file reads now use `loop.run_in_executor(_get_advisor_blast_executor(), ...)` with `_read_bounded_text_for_blast`; preserves cooperative yields.

- Bug Fixes
  - Reverses default-executor contention that doubled `ControlPlaneStarvation` events.
  - Wedge dumps now land in the session dir and `debug.log` without relying on `2>&1 | tee`.
  - Background-tier ops no longer spend 10–22s scanning; decision behavior is unchanged.

<sup>Written for commit 6d295f5a380feba49f9dd2d97594d68b71d3d95b. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/53062?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

