### PR TITLE
feat(governance): Slice 12Y — Dynamic Budget Reservation + WAL-second Telemetry Seal

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -6534,6 +6534,54 @@ class BattleTestHarness:
                 "JARVIS_SHUTDOWN_WAL_FIRST_ENABLED", "true",
             ).strip().lower()
             if _wal_second_raw in {"1", "true", "yes", "on"}:
+                # ── Slice 12Y Part 2 — WAL-second telemetry seal ──
+                #
+                # bt-2026-05-23-211212 surfaced that the WAL-second
+                # "fired" log line never appeared in debug.log even
+                # though the WAL-second code path was clearly
+                # reachable. Root cause: when the harness's cleanup
+                # chain hangs upstream (e.g., intake_service.stop()
+                # wedged at step 2 in that soak), execution can
+                # reach WAL-second through a degraded path where
+                # the standard logger handlers are already in a
+                # questionable state OR the atexit fallback fired
+                # first and the _summary_written latch wasn't
+                # actually reset early enough.
+                #
+                # Slice 12Y makes the telemetry airtight via THREE
+                # log emissions:
+                #
+                #   (1) entry-marker logged BEFORE any potentially
+                #       failing operation, so we know WAL-second
+                #       was REACHED even if the write throws
+                #   (2) stderr direct-write (bypasses the logger
+                #       handler chain entirely — survives wedged
+                #       handlers, lands in tee/pipe redirects)
+                #   (3) success-marker via the standard logger
+                #       after the write completes
+                #
+                # All three are individually try-wrapped so a
+                # single failure can't mask the others.
+                try:
+                    sys.stderr.write(
+                        "[Slice12Y.WALSecond.REACHED] "
+                        "Slice 12W WAL-second path entered "
+                        "(post-GLS.stop) — about to persist "
+                        "summary.json with operations[] snapshot\n"
+                    )
+                    sys.stderr.flush()
+                except Exception:  # noqa: BLE001
+                    pass
+                try:
+                    logger.info(
+                        "[Harness] Slice 12W WAL-second: ENTRY "
+                        "marker — about to call "
+                        "_atexit_fallback_write with "
+                        "session_outcome=in_flight_shutdown_wal_second"
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+
                 # Reset the _summary_written latch so the
                 # fallback writer re-fires (the WAL-first path
                 # set it to True; without reset, this would
@@ -6543,23 +6591,45 @@ class BattleTestHarness:
                     self._summary_written = False
                 except Exception:  # noqa: BLE001
                     pass
+                _wal_second_succeeded = False
                 try:
                     self._atexit_fallback_write(
                         session_outcome="in_flight_shutdown_wal_second",
                     )
-                    logger.info(
-                        "[Harness] Slice 12W WAL-second: "
-                        "post-orchestrator summary.json persisted "
-                        "(operations[] now reflects final "
-                        "_active_ops drain)",
-                    )
+                    _wal_second_succeeded = True
                 except Exception:  # noqa: BLE001
-                    logger.debug(
-                        "[Harness] Slice 12W WAL-second write "
-                        "raised (swallowed) — proceeding with "
-                        "remaining cleanup",
-                        exc_info=True,
+                    try:
+                        logger.warning(
+                            "[Harness] Slice 12W WAL-second "
+                            "write raised (swallowed) — "
+                            "proceeding with remaining cleanup",
+                            exc_info=True,
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
+
+                # Slice 12Y — success log AND stderr backstop
+                # always emitted (only the write outcome differs).
+                try:
+                    if _wal_second_succeeded:
+                        logger.info(
+                            "[Harness] Slice 12W WAL-second: "
+                            "post-orchestrator summary.json "
+                            "persisted (operations[] now "
+                            "reflects final _active_ops drain)"
+                        )
+                except Exception:  # noqa: BLE001
+                    pass
+                try:
+                    sys.stderr.write(
+                        "[Slice12Y.WALSecond.RESULT] "
+                        "succeeded=%s\n" % str(
+                            _wal_second_succeeded,
+                        ),
                     )
+                    sys.stderr.flush()
+                except Exception:  # noqa: BLE001
+                    pass
         except Exception:  # noqa: BLE001 — defensive
             pass
 

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -682,9 +682,15 @@ class DoublewordProvider:
             from backend.core.ouroboros.governance.session_budget_authority import (  # noqa: E501
                 check_preflight as _sba_check_preflight,
             )
+            # Slice 12Y Part 1 — pass signal_source so the SBA
+            # can apply the background-spend ceiling for sensor
+            # ops. No-op when source is None or non-background-tier.
             _sba_check_preflight(
                 provider_name="doubleword",
                 estimated_cost_usd=float(self._max_cost_per_op or 0.0),
+                signal_source=(
+                    getattr(context, "signal_source", None)
+                ),
             )
         except ImportError:
             # Module absent on this build — graceful fall-through to

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -7396,10 +7396,18 @@ class ClaudeProvider:
             from backend.core.ouroboros.governance.session_budget_authority import (  # noqa: E501
                 check_preflight as _sba_check_preflight,
             )
+            # Slice 12Y Part 1 — pass signal_source so the SBA
+            # can apply the background-spend ceiling for sensor
+            # ops while leaving foreground/complex calls
+            # unchanged. The check is no-op when signal_source
+            # is None or non-background-tier.
             _sba_check_preflight(
                 provider_name="claude",
                 estimated_cost_usd=float(
                     self._max_cost_per_op or 0.0,
+                ),
+                signal_source=(
+                    getattr(context, "signal_source", None)
                 ),
             )
         except ImportError:

--- a/backend/core/ouroboros/governance/session_budget_authority.py
+++ b/backend/core/ouroboros/governance/session_budget_authority.py
@@ -164,6 +164,104 @@ def reset_for_tests() -> None:
 # ---------------------------------------------------------------------------
 
 
+def get_session_total_cap_usd() -> Optional[float]:
+    """Slice 12Y Part 1 — return the total session budget cap
+    (NOT the remaining). Composed as ``total_spent + remaining``
+    from the registered provider so the value reflects the
+    operator's original session budget irrespective of current
+    spend.
+
+    Returns ``None`` when no provider is registered (fail-OPEN).
+    NEVER raises.
+
+    Used by the background-spend ceiling: foreground ops always
+    get a reserved runway of ``total_cap * (1 - limit_pct)``
+    regardless of how much background ops have already burned.
+    """
+    try:
+        provider = get_session_budget_provider()
+        if provider is None:
+            return None
+        try:
+            spent = float(getattr(provider, "total_spent", 0.0) or 0.0)
+        except Exception:  # noqa: BLE001
+            spent = 0.0
+        try:
+            remaining = float(getattr(provider, "remaining", 0.0) or 0.0)
+        except Exception:  # noqa: BLE001
+            remaining = 0.0
+        return max(0.0, spent + remaining)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ── Slice 12Y Part 1 — Background Spend Limit ──
+#
+# Default fraction of total session cap that BACKGROUND-tier ops
+# (TodoScanner, OpportunityMiner, DocStaleness, AI Miner, etc.,
+# per urgency_router._BACKGROUND_SOURCES + _SPECULATIVE_SOURCES)
+# may consume cumulatively. The complement (1 - limit_pct) is the
+# RESERVED RUNWAY for foreground ops (complex / immediate /
+# benchmark-source ops like SWE-Bench-Pro fixtures).
+#
+# bt-2026-05-23-211212 showed the fixture op refused at
+# session_budget_preflight_refused: claude_est=$0.5000 >
+# session_remaining=$0.4863 — sensor ops had consumed $0.514 of
+# the $1.00 cap concurrently, leaving the fixture in a starvation
+# window. With default 0.5 + cap=$1.00, sensors are capped at
+# $0.50 cumulatively; the foreground fixture always sees
+# remaining >= $0.50.
+#
+# Default 0.5 (sensors can use up to 50% of cap). Bounded to
+# [0.0, 1.0] at read time; out-of-range falls back to default.
+# Set to 1.0 to disable the reservation (pre-Slice-12Y behavior).
+BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR: str = (
+    "JARVIS_BACKGROUND_SPEND_LIMIT_PCT"
+)
+
+
+def get_background_spend_limit_pct() -> float:
+    """Resolve the background-spend-limit fraction from env.
+    Default 0.5. Bounded to [0.0, 1.0]. NEVER raises."""
+    try:
+        raw = os.environ.get(
+            BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR, "",
+        ).strip()
+        v = float(raw) if raw else 0.5
+        return max(0.0, min(1.0, v))
+    except (TypeError, ValueError):
+        return 0.5
+
+
+# Closed set of signal_source values that are considered
+# "background-tier" for the spend-ceiling check. Mirrors
+# urgency_router._BACKGROUND_SOURCES + _SPECULATIVE_SOURCES (those
+# are the cost-tier taxonomies). Duplicated here so the SBA never
+# imports from urgency_router (avoid a layering loop — SBA is a
+# lower-level primitive). The Slice 12Y test surface AST-pins
+# these to stay in sync with urgency_router.
+_BACKGROUND_TIER_SIGNAL_SOURCES: frozenset = frozenset({
+    # _BACKGROUND_SOURCES mirror.
+    "ai_miner",
+    "exploration",
+    "backlog",
+    "architecture",
+    "todo_scanner",
+    "doc_staleness",
+    # _SPECULATIVE_SOURCES mirror.
+    "intent_discovery",
+})
+
+
+def is_background_tier_source(signal_source: Optional[str]) -> bool:
+    """Return True iff the signal_source identifies a
+    BACKGROUND or SPECULATIVE tier op (per the mirrored
+    urgency_router taxonomy). NEVER raises."""
+    if not isinstance(signal_source, str) or not signal_source:
+        return False
+    return signal_source.strip().lower() in _BACKGROUND_TIER_SIGNAL_SOURCES
+
+
 def get_session_remaining_usd() -> Optional[float]:
     """Authoritative source of remaining session budget USD.
 
@@ -218,6 +316,7 @@ def check_preflight(
     *,
     provider_name: str,
     estimated_cost_usd: float,
+    signal_source: Optional[str] = None,
 ) -> None:
     """Hard wallet gate. Call BEFORE provider dispatch.
 
@@ -225,6 +324,33 @@ def check_preflight(
     remaining session budget cannot accommodate ``estimated_cost_usd``.
     The caller's ``_max_cost_per_op`` is a reasonable conservative
     upper bound when no finer estimate is available.
+
+    Slice 12Y Part 1 — Background Spend Ceiling
+    --------------------------------------------
+    When ``signal_source`` identifies a BACKGROUND or SPECULATIVE
+    tier op (per :func:`is_background_tier_source`), an ADDITIONAL
+    check applies: the op is refused if accepting it would push
+    cumulative session spend above the reserved-foreground
+    threshold:
+
+        foreground_reserve_usd = total_cap * (1 - limit_pct)
+        background_max_remaining = max(0, remaining - foreground_reserve_usd)
+        refuse if est > background_max_remaining
+
+    With default ``limit_pct=0.5`` and ``cap=$1.00``:
+      * sensors can collectively burn up to $0.50 → at that point
+        their per-call preflight refuses
+      * foreground (complex / fixture / immediate / non-tier) ops
+        always see the full ``remaining``, so the original $0.50
+        reserve stays available for at least one Claude complex
+        call ($0.50 estimate)
+
+    Closes the bt-2026-05-23-211212 failure mode where concurrent
+    sensor ops consumed budget and the fixture's $0.50 Claude
+    estimate hit ``session_remaining=$0.4863``.
+
+    When ``signal_source`` is None (default — all callers
+    pre-Slice-12Y), behavior is byte-identical to the legacy gate.
 
     No-op when :func:`get_session_remaining_usd` returns ``None`` —
     preserves byte-identical pre-PR behavior in environments without
@@ -250,6 +376,46 @@ def check_preflight(
             estimated_cost_usd,
         )
         return
+
+    # ── Slice 12Y Part 1 — Background spend ceiling ──
+    # Computed BEFORE the legacy `est > remaining` check so the
+    # background-specific refusal carries a distinct telemetry
+    # tag ("background_spend_ceiling") instead of falling through
+    # to the generic preflight refusal.
+    if is_background_tier_source(signal_source):
+        try:
+            total_cap = get_session_total_cap_usd()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "[SBA] preflight: total_cap read fault: %s", exc,
+            )
+            total_cap = None
+        if total_cap is not None and total_cap > 0.0:
+            limit_pct = get_background_spend_limit_pct()
+            # Foreground reserve = total_cap * (1 - limit_pct).
+            # Background ops only see the surplus above this
+            # reserve as their available budget.
+            foreground_reserve = total_cap * (1.0 - limit_pct)
+            bg_remaining = max(0.0, remaining - foreground_reserve)
+            if est > bg_remaining:
+                logger.info(
+                    "[SBA] preflight REFUSED (background_spend_ceiling): "
+                    "provider=%s signal_source=%s est=$%.4f > "
+                    "bg_remaining=$%.4f (total_cap=$%.4f "
+                    "foreground_reserve=$%.4f limit_pct=%.2f)",
+                    provider_name, signal_source, est, bg_remaining,
+                    total_cap, foreground_reserve, limit_pct,
+                )
+                raise SessionBudgetPreflightRefused(
+                    provider=str(provider_name),
+                    estimated_cost_usd=est,
+                    session_remaining_usd=bg_remaining,
+                    reason=(
+                        "session_budget_preflight_refused:"
+                        "background_spend_ceiling"
+                    ),
+                )
+
     if est > remaining:
         logger.info(
             "[SBA] preflight REFUSED: provider=%s est=$%.4f > "
@@ -264,11 +430,16 @@ def check_preflight(
 
 
 __all__ = [
+    "BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR",
     "SESSION_BUDGET_AUTHORITY_SCHEMA_VERSION",
     "SessionBudgetPreflightRefused",
-    "set_session_budget_provider",
-    "get_session_budget_provider",
-    "reset_for_tests",
-    "get_session_remaining_usd",
+    "_BACKGROUND_TIER_SIGNAL_SOURCES",
     "check_preflight",
+    "get_background_spend_limit_pct",
+    "get_session_budget_provider",
+    "get_session_remaining_usd",
+    "get_session_total_cap_usd",
+    "is_background_tier_source",
+    "reset_for_tests",
+    "set_session_budget_provider",
 ]

--- a/tests/governance/test_slice12w_teardown_exorcism.py
+++ b/tests/governance/test_slice12w_teardown_exorcism.py
@@ -552,12 +552,19 @@ class TestPhase3WALSecond:
         """``_atexit_fallback_write`` has an early-return on
         ``_summary_written=True``. WAL-first sets the latch; if
         WAL-second doesn't reset it, the second write becomes a
-        no-op and operations[] still lands empty."""
+        no-op and operations[] still lands empty.
+
+        Slice 12Y extended the surrounding block with additional
+        telemetry — search the broader window (8000 chars) to
+        survive future expansions; the position-pin tests
+        guarantee the reset is still INSIDE the WAL-second
+        block (between Phase 3 marker and step 5)."""
         src = Path(
             "backend/core/ouroboros/battle_test/harness.py"
         ).read_text()
         wal_second_idx = src.find("Slice 12W Phase 3")
-        block = src[wal_second_idx:wal_second_idx + 3000]
+        step5_idx = src.find("# 5. Governance stack")
+        block = src[wal_second_idx:step5_idx]
         assert "_summary_written = False" in block, (
             "WAL-second does not reset the _summary_written "
             "latch — the atexit fallback's early-return will "

--- a/tests/governance/test_slice12y_budget_reservation.py
+++ b/tests/governance/test_slice12y_budget_reservation.py
@@ -1,0 +1,490 @@
+"""Slice 12Y — Dynamic Budget Reservation & WAL-second Telemetry Seal.
+
+bt-2026-05-23-211212 (Slice 12X validation soak) achieved the historic
+``operations[]=19`` populated milestone via Slice 12V WAL-first and
+proved clean shutdown via Slices 12U+12V+12W+12X — but the fixture op
+itself was refused at preflight:
+
+  session_budget_preflight_refused:
+    claude_est=$0.5000 > session_remaining=$0.4863
+
+Concurrent BACKGROUND-tier sensor ops (todo_scanner, doc_staleness,
+opportunity_miner, etc.) had collectively consumed $0.514 of the
+$1.00 session cap, leaving the foreground fixture in a starvation
+window between sensor budget consumption and its own $0.50 per-call
+Claude estimate.
+
+Slice 12Y closes this via two composable parts:
+
+# Part 1 — Dynamic Background Spend Ceiling
+
+New env knob ``JARVIS_BACKGROUND_SPEND_LIMIT_PCT`` (default 0.5)
+defines the fraction of total session cap that BACKGROUND-tier ops
+may consume cumulatively. The complement (1 - limit_pct) is the
+RESERVED RUNWAY for foreground / complex / fixture ops.
+
+``check_preflight`` gains an optional ``signal_source`` kwarg. When
+the source matches the mirrored urgency_router taxonomy
+(_BACKGROUND_SOURCES + _SPECULATIVE_SOURCES) the gate applies an
+additional check BEFORE the legacy ``est > remaining`` refusal:
+
+  foreground_reserve = total_cap * (1 - limit_pct)
+  bg_remaining = max(0, remaining - foreground_reserve)
+  refuse if est > bg_remaining
+
+With default 0.5 + cap=$1.00:
+  * sensors collectively burn up to $0.50 → at that point their
+    per-call preflight refuses with the structured reason
+    ``session_budget_preflight_refused:background_spend_ceiling``
+  * foreground ops always see the full ``remaining`` so the
+    original $0.50 reserve stays available for at least one
+    complex Claude call
+
+When ``signal_source`` is None (default — all pre-Slice-12Y
+callers), behavior is byte-identical to the legacy gate.
+
+# Part 2 — WAL-second Telemetry Seal
+
+bt-2026-05-23-211212 also showed that Slice 12W WAL-second's
+success log line never appeared in debug.log even though the
+WAL-second code was reachable. Root cause: when the cleanup chain
+hangs upstream (``intake_service.stop()`` wedged at step 2 in that
+soak), execution reaches WAL-second through a degraded path where
+logger handlers are in questionable state.
+
+Slice 12Y makes the telemetry airtight via THREE emissions:
+
+  (1) entry-marker logged BEFORE any potentially failing operation
+      — proves WAL-second was REACHED even if the write throws
+  (2) stderr direct-write (bypasses logger handler chain entirely
+      — survives wedged handlers, lands in tee/pipe redirects)
+  (3) success-marker via standard logger after write completes
+
+All three are individually try-wrapped so a single failure can't
+mask the others.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from backend.core.ouroboros.governance import session_budget_authority
+from backend.core.ouroboros.governance.session_budget_authority import (
+    BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR,
+    SessionBudgetPreflightRefused,
+    _BACKGROUND_TIER_SIGNAL_SOURCES,
+    check_preflight,
+    get_background_spend_limit_pct,
+    get_session_total_cap_usd,
+    is_background_tier_source,
+    reset_for_tests,
+    set_session_budget_provider,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Shared fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for var in (
+        BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR,
+        "JARVIS_S2_SESSION_BUDGET_USD",
+        "OUROBOROS_BATTLE_COST_CAP",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+class _FakeProvider:
+    """Duck-typed SBA provider with mutable total_spent + remaining."""
+
+    def __init__(self, total_spent: float, remaining: float):
+        self.total_spent = total_spent
+        self.remaining = remaining
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Part 1 — Env knob + helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPart1EnvKnob:
+    def test_default_is_half(self, monkeypatch):
+        monkeypatch.delenv(
+            BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR, raising=False,
+        )
+        assert get_background_spend_limit_pct() == 0.5
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("0.0", 0.0), ("0.25", 0.25), ("0.5", 0.5),
+            ("0.75", 0.75), ("1.0", 1.0),
+            # Out-of-range clamps to [0, 1].
+            ("-0.5", 0.0), ("2.0", 1.0),
+            # Garbage falls back to default.
+            ("garbage", 0.5), ("", 0.5),
+        ],
+    )
+    def test_value_parsing_and_clamping(
+        self, monkeypatch, raw, expected,
+    ):
+        monkeypatch.setenv(
+            BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR, raw,
+        )
+        assert get_background_spend_limit_pct() == expected
+
+
+class TestPart1IsBackgroundTier:
+    @pytest.mark.parametrize(
+        "src",
+        list(_BACKGROUND_TIER_SIGNAL_SOURCES),
+    )
+    def test_all_canonical_sources_match(self, src):
+        assert is_background_tier_source(src) is True
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            "swe_bench_pro", "voice_human", "runtime_health",
+            "github_issue", None, "", "unknown",
+        ],
+    )
+    def test_non_background_sources_do_not_match(self, src):
+        assert is_background_tier_source(src) is False
+
+    def test_case_insensitive(self):
+        assert is_background_tier_source("TODO_SCANNER") is True
+        assert is_background_tier_source("Todo_Scanner") is True
+
+    def test_taxonomy_matches_urgency_router(self):
+        """Defensive duplication pin — _BACKGROUND_TIER_SIGNAL_SOURCES
+        MUST stay in sync with urgency_router._BACKGROUND_SOURCES +
+        _SPECULATIVE_SOURCES. The SBA can't import urgency_router
+        (layering loop), so the two tables must be manually kept
+        in sync; this test fails loudly if they drift."""
+        from backend.core.ouroboros.governance.urgency_router import (
+            _BACKGROUND_SOURCES,
+            _SPECULATIVE_SOURCES,
+        )
+        canonical = set(_BACKGROUND_SOURCES) | set(
+            _SPECULATIVE_SOURCES
+        )
+        assert _BACKGROUND_TIER_SIGNAL_SOURCES == frozenset(
+            canonical,
+        ), (
+            f"SBA tier set {_BACKGROUND_TIER_SIGNAL_SOURCES} "
+            f"drifted from urgency_router {canonical} — update "
+            "session_budget_authority._BACKGROUND_TIER_SIGNAL_SOURCES"
+        )
+
+
+class TestPart1TotalCap:
+    def test_returns_none_when_no_provider(self):
+        reset_for_tests()
+        assert get_session_total_cap_usd() is None
+
+    def test_returns_total_spent_plus_remaining(self):
+        set_session_budget_provider(
+            _FakeProvider(total_spent=0.50, remaining=0.50),
+        )
+        assert get_session_total_cap_usd() == 1.0
+
+    def test_handles_provider_exceptions(self):
+        class _Broken:
+            @property
+            def total_spent(self):
+                raise RuntimeError("boom")
+            @property
+            def remaining(self):
+                raise RuntimeError("also broken")
+
+        set_session_budget_provider(_Broken())
+        # Both reads fail → 0 + 0 = 0 (NEVER raises).
+        assert get_session_total_cap_usd() == 0.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Part 1 — check_preflight background-spend ceiling
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPart1Ceiling:
+    """The load-bearing claim: background ops are refused when
+    they would push cumulative spend above
+    ``total_cap * limit_pct``, while foreground ops still see the
+    full ``remaining``."""
+
+    def test_background_op_refused_when_reserve_breached(
+        self, monkeypatch,
+    ):
+        """Cap=$1.00, spent=$0.50, remaining=$0.50, limit_pct=0.5
+        → foreground_reserve=$0.50 → bg_remaining=$0.00
+        → background $0.10 op MUST refuse with structured reason."""
+        monkeypatch.setenv(
+            BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR, "0.5",
+        )
+        set_session_budget_provider(
+            _FakeProvider(total_spent=0.50, remaining=0.50),
+        )
+        with pytest.raises(SessionBudgetPreflightRefused) as excinfo:
+            check_preflight(
+                provider_name="dw",
+                estimated_cost_usd=0.10,
+                signal_source="todo_scanner",
+            )
+        # Structured reason distinct from generic preflight.
+        assert excinfo.value.reason == (
+            "session_budget_preflight_refused:"
+            "background_spend_ceiling"
+        )
+
+    def test_foreground_op_admitted_at_same_state(self, monkeypatch):
+        """SAME budget state as above — foreground op (no signal
+        in background tier) MUST be admitted up to the full
+        $0.50 remaining."""
+        monkeypatch.setenv(
+            BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR, "0.5",
+        )
+        set_session_budget_provider(
+            _FakeProvider(total_spent=0.50, remaining=0.50),
+        )
+        # Foreground op estimated $0.50 — exactly within remaining,
+        # MUST NOT raise.
+        check_preflight(
+            provider_name="claude",
+            estimated_cost_usd=0.50,
+            signal_source="swe_bench_pro",
+        )
+
+    def test_legacy_path_unchanged_when_signal_source_none(
+        self, monkeypatch,
+    ):
+        """When signal_source is None (default — all pre-Slice-12Y
+        callers), behavior MUST be byte-identical to the legacy
+        gate."""
+        monkeypatch.setenv(
+            BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR, "0.5",
+        )
+        set_session_budget_provider(
+            _FakeProvider(total_spent=0.50, remaining=0.50),
+        )
+        # No signal_source → no background ceiling → admits $0.50.
+        check_preflight(
+            provider_name="claude",
+            estimated_cost_usd=0.50,
+        )
+
+    def test_background_op_admitted_when_room_remains(
+        self, monkeypatch,
+    ):
+        """Cap=$1.00, spent=$0.10, remaining=$0.90, limit_pct=0.5
+        → foreground_reserve=$0.50 → bg_remaining=$0.40
+        → background $0.20 op MUST be admitted (room left)."""
+        monkeypatch.setenv(
+            BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR, "0.5",
+        )
+        set_session_budget_provider(
+            _FakeProvider(total_spent=0.10, remaining=0.90),
+        )
+        check_preflight(
+            provider_name="dw",
+            estimated_cost_usd=0.20,
+            signal_source="opportunity_miner",
+        )
+
+    def test_limit_pct_one_disables_reservation(self, monkeypatch):
+        """limit_pct=1.0 → foreground_reserve=0 → background ops
+        see the full remaining (pre-Slice-12Y rollback path)."""
+        monkeypatch.setenv(
+            BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR, "1.0",
+        )
+        set_session_budget_provider(
+            _FakeProvider(total_spent=0.50, remaining=0.50),
+        )
+        # Background op CAN use full $0.50 remaining when ceiling
+        # is disabled.
+        check_preflight(
+            provider_name="dw",
+            estimated_cost_usd=0.50,
+            signal_source="todo_scanner",
+        )
+
+    def test_limit_pct_zero_blocks_all_background(self, monkeypatch):
+        """limit_pct=0.0 → foreground_reserve=total_cap →
+        bg_remaining always 0 → every background op refused."""
+        monkeypatch.setenv(
+            BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR, "0.0",
+        )
+        set_session_budget_provider(
+            _FakeProvider(total_spent=0.0, remaining=1.0),
+        )
+        with pytest.raises(SessionBudgetPreflightRefused):
+            check_preflight(
+                provider_name="dw",
+                estimated_cost_usd=0.01,
+                signal_source="todo_scanner",
+            )
+
+    def test_no_provider_no_op(self, monkeypatch):
+        """When no SBA provider registered (env-only configs,
+        tests, headless rigs), preflight fails OPEN regardless of
+        signal_source — preserves pre-Slice-12Y behavior."""
+        monkeypatch.setenv(
+            BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR, "0.5",
+        )
+        reset_for_tests()
+        # Must NOT raise.
+        check_preflight(
+            provider_name="dw",
+            estimated_cost_usd=10.0,
+            signal_source="todo_scanner",
+        )
+
+
+class TestPart1ASTPin:
+    def _read(self, path: str) -> str:
+        return Path(path).read_text()
+
+    def test_providers_pass_signal_source_to_preflight(self):
+        """The provider call sites MUST forward signal_source from
+        the ProviderContext so the SBA can apply the ceiling.
+        Pinned because Slice 12W's similar oversight let posthog
+        spawn unattributed."""
+        src = self._read(
+            "backend/core/ouroboros/governance/providers.py"
+        )
+        # Find the check_preflight call site.
+        idx = src.find("_sba_check_preflight(")
+        assert idx > 0, "check_preflight call missing from providers.py"
+        block = src[idx:idx + 800]
+        assert "signal_source" in block, (
+            "providers.py check_preflight call doesn't pass "
+            "signal_source — background spend ceiling can't fire"
+        )
+
+    def test_doubleword_provider_passes_signal_source(self):
+        src = self._read(
+            "backend/core/ouroboros/governance/doubleword_provider.py"
+        )
+        idx = src.find("_sba_check_preflight(")
+        assert idx > 0
+        block = src[idx:idx + 800]
+        assert "signal_source" in block, (
+            "doubleword_provider.py check_preflight call doesn't "
+            "pass signal_source"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Part 2 — WAL-second telemetry seal
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPart2WALSecondTelemetry:
+    """The seal must guarantee 3 emissions: stderr entry-marker,
+    logger entry-marker, success-or-failure stderr+logger pair."""
+
+    def _read_harness(self) -> str:
+        return Path(
+            "backend/core/ouroboros/battle_test/harness.py"
+        ).read_text()
+
+    def test_wal_second_has_entry_stderr_marker(self):
+        """A direct stderr write MUST precede the WAL-second call
+        so we know it was reached even if the logger is wedged."""
+        src = self._read_harness()
+        idx = src.find("Slice 12W Phase 3")
+        assert idx > 0
+        block = src[idx:idx + 5000]
+        assert "Slice12Y.WALSecond.REACHED" in block, (
+            "Slice 12Y entry-stderr marker missing — wedged "
+            "logger handlers will silently swallow attribution"
+        )
+
+    def test_wal_second_has_entry_logger_marker(self):
+        """A logger.info ENTRY marker fires BEFORE the write so
+        we see WAL-second was reached even if the write throws."""
+        src = self._read_harness()
+        idx = src.find("Slice 12W Phase 3")
+        block = src[idx:idx + 5000]
+        assert "ENTRY" in block, (
+            "Slice 12Y logger entry-marker missing — only the "
+            "success path emits; failures invisible"
+        )
+
+    def test_wal_second_has_result_stderr_marker(self):
+        """A stderr RESULT marker fires AFTER the write with
+        succeeded=True/False so operators see the outcome.
+
+        Match against the full harness file (the WAL-second
+        block is large enough that the marker can land outside
+        any fixed-size search window after the Phase 3 header)."""
+        src = self._read_harness()
+        assert "Slice12Y.WALSecond.RESULT" in src, (
+            "Slice 12Y stderr result-marker missing — operators "
+            "can't see whether the WAL-second write succeeded "
+            "when logger is wedged"
+        )
+
+    def test_wal_second_tracks_succeeded_flag(self):
+        """The success path must set ``_wal_second_succeeded =
+        True`` ONLY after the write returns cleanly. Failure
+        path falls through with the flag still False."""
+        src = self._read_harness()
+        idx = src.find("Slice 12W Phase 3")
+        block = src[idx:idx + 5000]
+        assert "_wal_second_succeeded = False" in block
+        assert "_wal_second_succeeded = True" in block
+
+
+class TestPart2HarnessPosition:
+    """Position pin: WAL-second still lives between step 4
+    (GovernedLoopService.stop) and step 5 (GovernanceStack.stop).
+    Slice 12W's positioning is preserved; Slice 12Y only adds
+    telemetry emissions."""
+
+    def test_wal_second_still_between_step_4_and_step_5(self):
+        src = Path(
+            "backend/core/ouroboros/battle_test/harness.py"
+        ).read_text()
+        idx_step4 = src.find("# 4. Governed loop service")
+        idx_wal_second = src.find("Slice 12W Phase 3")
+        idx_step5 = src.find("# 5. Governance stack")
+        assert idx_step4 > 0
+        assert idx_wal_second > 0
+        assert idx_step5 > 0
+        assert idx_step4 < idx_wal_second < idx_step5
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Public surface
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestPart1PublicSurface:
+    def test_exports(self):
+        for name in (
+            "BACKGROUND_SPEND_LIMIT_PCT_ENV_VAR",
+            "_BACKGROUND_TIER_SIGNAL_SOURCES",
+            "check_preflight",
+            "get_background_spend_limit_pct",
+            "get_session_total_cap_usd",
+            "is_background_tier_source",
+        ):
+            assert hasattr(session_budget_authority, name), (
+                f"session_budget_authority.{name} missing"
+            )
+            assert name in session_budget_authority.__all__, (
+                f"{name} missing from __all__"
+            )


### PR DESCRIPTION
## Summary

Closes the budget-starvation wedge from `bt-2026-05-23-211212` (Slice 12X validation soak) — fixture refused at preflight because concurrent BACKGROUND-tier sensor ops consumed the budget. Plus surgically seals the WAL-second telemetry blind-spot.

## Part 1 — Dynamic Background Spend Ceiling (per operator: NOT a disable-sensors workaround)

New `JARVIS_BACKGROUND_SPEND_LIMIT_PCT` (default 0.5). `check_preflight` gains optional `signal_source` — when source matches the mirrored urgency_router BACKGROUND/SPECULATIVE taxonomy, applies an additional check:

```
foreground_reserve = total_cap * (1 - limit_pct)
bg_remaining = max(0, remaining - foreground_reserve)
refuse if est > bg_remaining
```

With default 0.5 + cap=$1.00: sensors cap at $0.50 cumulatively; foreground (complex / fixture / immediate) always sees ≥$0.50 available. Refusal carries distinct structured reason `session_budget_preflight_refused:background_spend_ceiling`.

`_BACKGROUND_TIER_SIGNAL_SOURCES` is mirrored in SBA (not imported from urgency_router — layering loop) and **AST-pinned to stay in sync**.

## Part 2 — WAL-second Telemetry Seal

Slice 12W WAL-second's log line was invisible in `bt-2026-05-23-211212` due to wedged-handler degraded-path. Slice 12Y adds **3 emissions**:
1. Entry stderr marker (`[Slice12Y.WALSecond.REACHED]`) — bypasses logger
2. Entry logger marker
3. Result marker (stderr + logger) with `succeeded=True/False`

All 3 individually try-wrapped.

## Test verdict

- **44/44** Slice 12Y green (1.4s)
- **439/439** cross-arc 12N–Y green (33.7s)

## Test coverage (44 tests, 5 areas)

- 8 env knob (parse + clamp)
- 10 is_background_tier (canonical + non-matches + case-insensitive)
- **1 taxonomy sync pin** (SBA tier set MUST equal urgency_router union)
- 3 total_cap (None / sum / broken-provider tolerance)
- **7 ceiling** LOAD-BEARING (background refused; foreground admitted at same state; legacy None unchanged; room-remains; pct=1.0 disables; pct=0.0 blocks all; no-provider fail-OPEN)
- 2 provider AST pins (Claude + DW pass signal_source)
- 4 WAL-second telemetry markers
- 1 WAL-second position pin (still between step 4 and step 5)
- 1 public surface

## Post-merge expectation

Path A with $1.00 cap. **First fixture COMPLETE in the entire arc** if Part 1 carves the reserve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserves foreground budget by capping cumulative BACKGROUND-tier spend, and hardens WAL-second visibility with stderr+logger markers to prevent silent gaps.

- **New Features**
  - Added background spend ceiling in `check_preflight` using `signal_source` and `JARVIS_BACKGROUND_SPEND_LIMIT_PCT` (default 0.5); refuses with `session_budget_preflight_refused:background_spend_ceiling`.
  - Computes reserve from total cap via `get_session_total_cap_usd`; background ops only use `remaining - foreground_reserve`.
  - Providers (`claude`, `doubleword`) now pass `signal_source`; SBA mirrors `_BACKGROUND_TIER_SIGNAL_SOURCES` (AST-pinned) and exposes `get_background_spend_limit_pct` and `is_background_tier_source`.
  - Defaults preserve legacy behavior: `signal_source=None` is no-op; `limit_pct=1.0` disables; no provider → fail-open.

- **Bug Fixes**
  - WAL-second telemetry seal: adds three try-wrapped emissions—stderr entry `[Slice12Y.WALSecond.REACHED]`, entry logger marker, and stderr+logger result with `succeeded=True/False`—to ensure visibility even with wedged handlers.

<sup>Written for commit f01b7285c21c4f50d966ad075919d37f97fa1e8e. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/53810?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

