### PR TITLE
Slice Aegis-1 — Arc #1 dark substrate (out-of-process egress + budget chokepoint)

### DIFF
--- a/backend/core/ouroboros/aegis/__init__.py
+++ b/backend/core/ouroboros/aegis/__init__.py
@@ -1,0 +1,27 @@
+"""Aegis — Arc #1 out-of-process egress + budget chokepoint.
+
+§43.7 spine made physical: a separate OS process, minted before any
+autonomous code runs, that owns the upstream API credentials and the
+authoritative budget ledger.
+
+JARVIS can rewrite anything inside its own process. It cannot mint a
+credential it does not have, and it cannot debit a ledger it cannot
+reach.
+
+Slice 1 — dark substrate. Master flag ``JARVIS_AEGIS_ENABLED`` default
+**false**. Endpoints in Slice 1:
+
+  * ``GET  /health``              — liveness + version + port
+  * ``POST /session/establish``   — bootstrap PSK -> scoped session token
+  * ``POST /lease/acquire``       — session token -> lease (cap-checked)
+  * ``POST /lease/redeem``        — lease + actual cost -> reconciled verdict
+
+Slice 1 contains **no** ``/v1/*`` upstream proxy routes. AST-pinned.
+Provider forwarding lands in Slice 2.
+
+This package is the ONLY surface that may hold raw upstream credentials
+or the HMAC signing key K. The JARVIS process is unprivileged.
+"""
+from __future__ import annotations
+
+AEGIS_SCHEMA_VERSION: str = "aegis.1"

--- a/backend/core/ouroboros/aegis/bootstrap.py
+++ b/backend/core/ouroboros/aegis/bootstrap.py
@@ -1,0 +1,251 @@
+"""Bootstrap handshake — atomic 0600 tempfile carrying PSK + port + pid.
+
+Aegis writes this payload exactly once at boot. The harness reads it
+exactly once, then unlinks it. No forensic trace of the PSK remains on
+disk after handshake completion.
+
+Payload fields (per operator's binding directives):
+
+  * ``aegis_url``      — ``http://127.0.0.1:<ephemeral_port>``
+  * ``bootstrap_psk``  — high-entropy single-use string (``secrets.token_urlsafe``)
+  * ``daemon_pid``     — Aegis subprocess PID (for harness lifecycle)
+  * ``expires_at``     — unix timestamp; harness rejects payload past
+                         this point (defense against stale-file replay)
+  * ``schema_version`` — bumpable additive contract
+
+Atomic write protocol: write the full payload to a sibling temp file
+(``<final>.tmp.<random>``), fsync + close, then ``os.rename`` onto the
+final path. POSIX guarantees ``rename`` is atomic *and* the final path
+is only visible to other processes AFTER the rename completes. This
+closes the read-during-write race the harness's poll loop would
+otherwise hit if we used ``O_CREAT`` directly on the final path
+(create happens before write — observable empty file).
+
+The temp file is created with ``O_CREAT|O_EXCL|0o600`` so the same
+discipline (atomic, owner-only) still holds, and the random suffix
+prevents collisions between concurrent boots in the same dir.
+
+Stdlib only. No async — this is one-shot file I/O at boot, sub-millisecond.
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+
+BOOTSTRAP_PAYLOAD_SCHEMA_VERSION: str = "aegis_bootstrap.1"
+
+# Tempfile mode: owner read/write only. Anyone else (incl. another
+# user on the same machine) cannot read the PSK.
+_PAYLOAD_FILE_MODE: int = 0o600
+
+# Bootstrap PSK entropy: 48 bytes -> ~64 url-safe chars -> 384 bits.
+# Comfortably above the operator's binding "high-entropy" bar.
+_PSK_ENTROPY_BYTES: int = 48
+
+# Default expiry window: 60s. Long enough for harness to read +
+# unlink even on a busy machine; short enough that a stale payload
+# discovered later cannot be replayed.
+_DEFAULT_EXPIRY_WINDOW_S: int = 60
+
+
+@dataclass(frozen=True)
+class BootstrapPayload:
+    """Frozen single-use handshake artifact written by Aegis, read by harness.
+
+    Equality + hash are content-based (frozen dataclass). ``to_dict`` /
+    ``from_dict`` are §33.5 lossless roundtrip.
+    """
+
+    aegis_url: str
+    bootstrap_psk: str
+    daemon_pid: int
+    expires_at: float
+    schema_version: str = BOOTSTRAP_PAYLOAD_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "aegis_url": self.aegis_url,
+            "bootstrap_psk": self.bootstrap_psk,
+            "daemon_pid": self.daemon_pid,
+            "expires_at": self.expires_at,
+            "schema_version": self.schema_version,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "BootstrapPayload":
+        return cls(
+            aegis_url=str(raw["aegis_url"]),
+            bootstrap_psk=str(raw["bootstrap_psk"]),
+            daemon_pid=int(raw["daemon_pid"]),
+            expires_at=float(raw["expires_at"]),
+            schema_version=str(raw.get(
+                "schema_version", BOOTSTRAP_PAYLOAD_SCHEMA_VERSION,
+            )),
+        )
+
+
+def mint_bootstrap_psk() -> str:
+    """Return a fresh high-entropy bootstrap PSK.
+
+    URL-safe so the harness can transport it via env var without
+    escaping. ~384 bits of entropy — significantly higher than the
+    HMAC key the daemon protects (256 bits) because the PSK is the
+    only thing standing between any localhost process and a session
+    token until /session/establish is called.
+    """
+    return secrets.token_urlsafe(_PSK_ENTROPY_BYTES)
+
+
+def default_expiry(*, now_s: float, window_s: int = _DEFAULT_EXPIRY_WINDOW_S) -> float:
+    """Compute the absolute expiry timestamp from ``now``.
+
+    Caller supplies ``now_s`` (typically ``time.time()``) so tests can
+    inject deterministic clocks.
+    """
+    return now_s + float(window_s)
+
+
+def atomic_write_payload(payload: BootstrapPayload, path: Path) -> None:
+    """Atomically write ``payload`` to ``path`` with mode 0o600.
+
+    Implementation: write the full payload to a sibling temp file
+    (``<path>.tmp.<random>``) with ``O_CREAT|O_EXCL|O_WRONLY`` + 0o600,
+    fsync + close, then ``os.rename`` onto the final path. POSIX
+    ``rename`` is atomic AND the final path becomes visible to other
+    processes only AFTER the rename — so a poller cannot observe the
+    file in an empty/partial state.
+
+    Parent directory is created with mode 0o700 if missing.
+
+    Raises:
+        OSError: on any filesystem failure (permission denied, disk
+            full, etc.). Caller treats as session-fatal.
+        FileExistsError: if ``path`` already exists at the moment of
+            rename. Aegis refuses to overwrite — the harness must
+            always supply a fresh path.
+    """
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    # On most systems mkdir respects the requested mode only if the
+    # parent didn't already exist; tighten existing parent dir to 0o700
+    # if it was looser.
+    try:
+        st = target.parent.stat()
+        if (st.st_mode & 0o777) != 0o700:
+            os.chmod(target.parent, 0o700)
+    except OSError:
+        pass
+
+    if target.exists():
+        # Mirror the previous O_EXCL semantic: the harness contract is
+        # "fresh path per boot." A pre-existing target is a hard error.
+        raise FileExistsError(
+            f"refusing to overwrite existing bootstrap payload: {target}"
+        )
+
+    # Temp file in the same directory so rename is intra-filesystem.
+    tmp_path = target.parent / f"{target.name}.tmp.{secrets.token_hex(8)}"
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    fd = os.open(str(tmp_path), flags, _PAYLOAD_FILE_MODE)
+    try:
+        data = json.dumps(payload.to_dict(), separators=(",", ":")).encode("utf-8")
+        written = 0
+        view = memoryview(data)
+        while written < len(data):
+            n = os.write(fd, view[written:])
+            if n <= 0:
+                raise OSError("short write while atomic-writing bootstrap payload")
+            written += n
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+    # Belt and suspenders: temp file mode pre-rename.
+    try:
+        current_mode = stat.S_IMODE(tmp_path.stat().st_mode)
+        if current_mode != _PAYLOAD_FILE_MODE:
+            os.chmod(tmp_path, _PAYLOAD_FILE_MODE)
+    except OSError:
+        pass
+
+    # Atomic flip — the final path becomes visible to readers as a
+    # fully-written file in one syscall.
+    try:
+        os.rename(str(tmp_path), str(target))
+    except OSError:
+        # Best-effort cleanup of the temp file if rename failed.
+        try:
+            os.unlink(str(tmp_path))
+        except OSError:
+            pass
+        raise
+
+    # Final mode confirmation post-rename (POSIX preserves mode across
+    # rename, but tighten if any filesystem layer drifted).
+    try:
+        current_mode = stat.S_IMODE(target.stat().st_mode)
+        if current_mode != _PAYLOAD_FILE_MODE:
+            os.chmod(target, _PAYLOAD_FILE_MODE)
+    except OSError:
+        pass
+
+
+def read_and_unlink_payload(path: Path) -> BootstrapPayload:
+    """Read ``path``, unlink it, and return the parsed payload.
+
+    The unlink happens AFTER the read returns successfully — if the
+    read fails (parse error, missing field, etc.) the file is left in
+    place so the operator can inspect what went wrong, but Aegis-side
+    expiry will still invalidate it shortly.
+
+    Raises:
+        FileNotFoundError: payload file missing (Aegis never wrote, or
+            another process already consumed it).
+        ValueError: JSON parse failure or missing required field.
+        OSError: filesystem error during read.
+    """
+    target = Path(path)
+    raw_bytes = target.read_bytes()
+    try:
+        raw_obj = json.loads(raw_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            f"bootstrap payload at {target} is not valid JSON: {exc}"
+        ) from exc
+    if not isinstance(raw_obj, dict):
+        raise ValueError(
+            f"bootstrap payload at {target} is not a JSON object"
+        )
+    try:
+        payload = BootstrapPayload.from_dict(raw_obj)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"bootstrap payload at {target} missing/malformed field: {exc}"
+        ) from exc
+
+    # Unlink only after successful parse. Forensic-trace-free per
+    # operator directive.
+    try:
+        target.unlink()
+    except OSError:
+        # If unlink fails the payload is still single-use because
+        # the Aegis-side PSK ledger only honors it once.
+        pass
+
+    return payload
+
+
+__all__ = [
+    "BOOTSTRAP_PAYLOAD_SCHEMA_VERSION",
+    "BootstrapPayload",
+    "atomic_write_payload",
+    "default_expiry",
+    "mint_bootstrap_psk",
+    "read_and_unlink_payload",
+]

--- a/backend/core/ouroboros/aegis/budget_state_machine.py
+++ b/backend/core/ouroboros/aegis/budget_state_machine.py
@@ -1,0 +1,634 @@
+"""ImmutableBudgetStateMachine — the authoritative spend ledger.
+
+§43.6.1's load-bearing primitive, relocated **out of process** per §43.7
+spine principle. JARVIS cannot reach this object because Aegis runs in
+a separate OS process. The in-process aspect of this state machine
+(``immutable``, ``no public mutator``, ``env-loosen rejected``) is
+defense; the cross-process aspect is the guarantee.
+
+Closed taxonomy (AST-pinned in tests):
+
+  * :class:`RejectReason` — 6 values, exactly matches §43.6.1 spec.
+
+Caps composition (strictest-wins):
+
+  An ``admit(...)`` call returns ``BudgetVerdict(admitted=True, ...)``
+  iff **all three** caps allow it (route AND session AND hourly). Any
+  one cap exceeded → ``BudgetVerdict(admitted=False, reason=...)`` and
+  nothing is debited.
+
+Reserve model:
+
+  * On admit: debit ``reserve = estimated_cost_usd * overrun_multiplier``
+    against all three caps.
+  * On reconcile: debit ``actual_cost_usd`` instead, refund the
+    difference. If actual exceeds reserve, the extra is debited and
+    the caps may go negative — Slice 2 will add the streaming guillotine
+    that prevents this at the wire level. Slice 1 just records faithfully.
+
+Monotonic-tightening (composes ``adaptation/ledger.py`` discipline):
+
+  ``tighten(...)`` accepts kwargs for any subset of caps. A new value
+  is accepted only if it is strictly less than the current value
+  (``<=`` for the per-route map; an entry not present is treated as
+  unset/permissive). Any attempt to loosen raises
+  :class:`MonotonicTighteningViolationError`.
+
+No public mutator outside :meth:`tighten`. Caps are stored in a frozen
+inner dataclass; setting them post-init requires invoking ``tighten``,
+which validates direction.
+
+NEVER reads ``os.environ`` after ``__init__``. The daemon reads env
+once at boot, passes values in. Future cap changes come through
+``tighten``, not env re-reads.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Deque, Dict, Mapping, Optional, Tuple
+
+from backend.core.ouroboros.aegis.spend_wal import (
+    SpendEntry,
+    admit_entry,
+    append_entry,
+    boot_entry,
+    reconcile_entry,
+    replay_wal,
+)
+
+logger = logging.getLogger(__name__)
+
+
+BUDGET_STATE_MACHINE_SCHEMA_VERSION: str = "aegis_budget.1"
+
+
+# ---------------------------------------------------------------------------
+# Closed taxonomy
+# ---------------------------------------------------------------------------
+
+
+class RejectReason(str, enum.Enum):
+    """Closed 6-value rejection taxonomy. AST-pinned: bytes-identical
+    membership across slices. New rejection causes require explicit
+    taxonomy extension + spine test update."""
+
+    EMISSION_CAP_EXCEEDED = "emission_cap_exceeded"
+    FANOUT_CAP_EXCEEDED = "fanout_cap_exceeded"
+    COST_CEILING_EXCEEDED = "cost_ceiling_exceeded"
+    CAUSAL_DEPTH_EXCEEDED = "causal_depth_exceeded"
+    LINEAGE_FORGERY = "lineage_forgery"
+    BUDGET_AUTHORITY_UNAVAILABLE = "budget_authority_unavailable"
+
+
+# Routes the urgency router can stamp. Slice 1 doesn't validate route
+# membership at admit (caller-trusted) but the per-route cap map keys
+# off these names. Single-seam reference list.
+KNOWN_ROUTES: Tuple[str, ...] = (
+    "IMMEDIATE",
+    "STANDARD",
+    "COMPLEX",
+    "BACKGROUND",
+    "SPECULATIVE",
+)
+
+
+HOURLY_BURN_WINDOW_S: int = 3600
+
+
+# ---------------------------------------------------------------------------
+# Frozen verdict
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BudgetVerdict:
+    """Frozen admit/reconcile result. §33.5 lossless to_dict/from_dict.
+
+    On admit-rejection, ``reason`` is populated and ``debit_usd`` is 0.0.
+    On admit-success, ``reason`` is None and ``debit_usd`` equals the
+    reserve.
+    """
+
+    admitted: bool
+    reason: Optional[RejectReason]
+    debit_usd: float
+    remaining_session_usd: float
+    remaining_hourly_usd: float
+    remaining_route_usd: float
+    detail: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "admitted": self.admitted,
+            "reason": self.reason.value if self.reason is not None else None,
+            "debit_usd": self.debit_usd,
+            "remaining_session_usd": self.remaining_session_usd,
+            "remaining_hourly_usd": self.remaining_hourly_usd,
+            "remaining_route_usd": self.remaining_route_usd,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping[str, object]) -> "BudgetVerdict":
+        reason_raw = d.get("reason")
+        reason = RejectReason(reason_raw) if reason_raw is not None else None
+        return cls(
+            admitted=bool(d["admitted"]),
+            reason=reason,
+            debit_usd=float(d["debit_usd"]),  # type: ignore[arg-type]
+            remaining_session_usd=float(d["remaining_session_usd"]),  # type: ignore[arg-type]
+            remaining_hourly_usd=float(d["remaining_hourly_usd"]),  # type: ignore[arg-type]
+            remaining_route_usd=float(d["remaining_route_usd"]),  # type: ignore[arg-type]
+            detail=(None if d.get("detail") is None else str(d["detail"])),
+        )
+
+
+@dataclass(frozen=True)
+class BudgetCaps:
+    """Frozen cap-set. The state machine holds one of these and replaces
+    it whole on each ``tighten`` (frozen → no in-place mutation)."""
+
+    session_cap_usd: float
+    hourly_burn_cap_usd: float
+    # Per-route cap map. Missing route -> route cap not enforced
+    # (only session + hourly apply). Slice 1 expects all 5 KNOWN_ROUTES
+    # to be configured for "real" deployments; for tests, partial maps
+    # are tolerated.
+    route_caps_usd: Mapping[str, float] = field(default_factory=dict)
+    overrun_multiplier: float = 1.5
+
+    def route_cap(self, route: str) -> Optional[float]:
+        """Return the configured cap for ``route`` or None if unconfigured."""
+        return self.route_caps_usd.get(route)
+
+
+class MonotonicTighteningViolationError(RuntimeError):
+    """Raised by :meth:`ImmutableBudgetStateMachine.tighten` when an
+    attempt is made to set a cap value greater than the current value
+    (i.e., loosen the budget).
+
+    Composes ``adaptation/ledger.py`` discipline: governance state
+    moves in the tightening direction only; loosening requires the
+    out-of-band operator amendment path.
+    """
+
+
+# ---------------------------------------------------------------------------
+# State machine
+# ---------------------------------------------------------------------------
+
+
+class ImmutableBudgetStateMachine:
+    """Per-Aegis-process authoritative ledger.
+
+    Construction takes the initial caps + WAL path. After construction
+    no environment is read — the daemon mints one instance at boot
+    and passes references; subsequent runtime changes only via
+    :meth:`tighten`.
+
+    Concurrency: every mutating method (``admit``, ``reconcile``,
+    ``tighten``) takes the same ``asyncio.Lock``. The daemon's event
+    loop serializes them naturally, but the lock makes the boundary
+    explicit and survives any future task-fanout.
+
+    Persistence: every admit + reconcile + boot lifecycle event writes
+    one row to ``wal_path`` via ``spend_wal.append_entry`` (which wraps
+    ``cross_process_jsonl.flock_append_line``).
+    """
+
+    def __init__(
+        self,
+        *,
+        caps: BudgetCaps,
+        wal_path: Path,
+    ) -> None:
+        self._caps: BudgetCaps = caps
+        self._wal_path: Path = Path(wal_path)
+
+        # Cumulative running totals (frozen state moves only through
+        # admit/reconcile/tighten — never set directly externally).
+        self._session_debit_usd: float = 0.0
+        # Per-route cumulative debit. Lazy-initialized so unknown
+        # routes don't surface KeyError on first admit.
+        self._route_debit_usd: Dict[str, float] = {}
+        # Sliding 1h window of (ts, usd) for hourly burn cap.
+        # Evict-on-scan; bounded only by the window length × admit rate.
+        self._hourly_window: Deque[Tuple[float, float]] = deque()
+        # Track reserves per lease nonce so reconcile can refund.
+        self._open_reserves: Dict[str, float] = {}
+
+        self._lock = asyncio.Lock()
+
+    # -- caps read-only access ------------------------------------------------
+
+    @property
+    def caps(self) -> BudgetCaps:
+        """Return the current (frozen) caps. Read-only by virtue of
+        ``BudgetCaps`` being a frozen dataclass."""
+        return self._caps
+
+    @property
+    def wal_path(self) -> Path:
+        return self._wal_path
+
+    # -- lifecycle ------------------------------------------------------------
+
+    async def record_boot(self, *, detail: str) -> bool:
+        """Write a BOOT row to the WAL. Best-effort; returns False on
+        WAL failure (caller may surface a startup warning)."""
+        entry = boot_entry(ts=time.time(), detail=detail)
+        return await append_entry(self._wal_path, entry)
+
+    def replay_for_recovery(self) -> None:
+        """Replay the WAL synchronously and reconstruct in-memory
+        cumulative state. Called by the daemon at boot, BEFORE the
+        event loop starts handling requests.
+
+        Idempotent. Tolerates corrupt rows (``replay_wal`` skips them).
+        Hourly-window entries older than the window are dropped during
+        replay (their cumulative effect is preserved in
+        ``_session_debit_usd``).
+        """
+        entries = replay_wal(self._wal_path)
+        now = time.time()
+        for entry in entries:
+            self._apply_entry_to_state(entry, now=now)
+
+    def _apply_entry_to_state(self, entry: SpendEntry, *, now: float) -> None:
+        """Apply one WAL entry to in-memory state. Used by replay."""
+        if entry.kind.value == "admit":
+            usd = entry.reserve_cost_usd or 0.0
+            self._session_debit_usd += usd
+            if entry.route is not None:
+                self._route_debit_usd[entry.route] = (
+                    self._route_debit_usd.get(entry.route, 0.0) + usd
+                )
+            # Only carry into the hourly window if still within range.
+            if entry.ts >= (now - HOURLY_BURN_WINDOW_S):
+                self._hourly_window.append((entry.ts, usd))
+            if entry.lease_nonce is not None:
+                self._open_reserves[entry.lease_nonce] = usd
+        elif entry.kind.value == "reconcile":
+            actual = entry.actual_cost_usd or 0.0
+            reserve = entry.reserve_cost_usd or 0.0
+            delta = actual - reserve  # positive = overrun, negative = refund
+            self._session_debit_usd += delta
+            if entry.route is not None:
+                self._route_debit_usd[entry.route] = (
+                    self._route_debit_usd.get(entry.route, 0.0) + delta
+                )
+            if entry.ts >= (now - HOURLY_BURN_WINDOW_S):
+                self._hourly_window.append((entry.ts, delta))
+            if entry.lease_nonce is not None:
+                self._open_reserves.pop(entry.lease_nonce, None)
+        # BOOT entries don't affect state.
+
+    # -- admission ------------------------------------------------------------
+
+    async def admit(
+        self,
+        *,
+        route: str,
+        estimated_cost_usd: float,
+        lease_nonce: str,
+        op_id: str,
+    ) -> BudgetVerdict:
+        """Reserve budget for one upcoming provider call.
+
+        Strictest-wins: rejected if **any** cap (route, session, hourly)
+        would be exceeded by the reserve. On success, all three caps
+        are debited by ``reserve = estimated * overrun_multiplier`` and
+        the WAL is appended.
+        """
+        if estimated_cost_usd < 0:
+            return _denied(
+                self._caps,
+                reason=RejectReason.COST_CEILING_EXCEEDED,
+                detail=f"estimated_cost_usd must be >= 0, got {estimated_cost_usd}",
+            )
+
+        reserve = max(0.0, float(estimated_cost_usd) * float(self._caps.overrun_multiplier))
+
+        async with self._lock:
+            now = time.time()
+            self._evict_expired_hourly_locked(now=now)
+
+            session_remaining = self._caps.session_cap_usd - self._session_debit_usd
+            hourly_used = sum(usd for _, usd in self._hourly_window)
+            hourly_remaining = self._caps.hourly_burn_cap_usd - hourly_used
+            route_cap = self._caps.route_cap(route)
+            route_debit = self._route_debit_usd.get(route, 0.0)
+            route_remaining = (
+                (route_cap - route_debit) if route_cap is not None else float("inf")
+            )
+
+            # Strictest-wins.
+            if route_cap is not None and reserve > route_remaining:
+                return BudgetVerdict(
+                    admitted=False,
+                    reason=RejectReason.COST_CEILING_EXCEEDED,
+                    debit_usd=0.0,
+                    remaining_session_usd=max(0.0, session_remaining),
+                    remaining_hourly_usd=max(0.0, hourly_remaining),
+                    remaining_route_usd=max(0.0, route_remaining),
+                    detail=f"route {route} cap exceeded",
+                )
+            if reserve > session_remaining:
+                return BudgetVerdict(
+                    admitted=False,
+                    reason=RejectReason.COST_CEILING_EXCEEDED,
+                    debit_usd=0.0,
+                    remaining_session_usd=max(0.0, session_remaining),
+                    remaining_hourly_usd=max(0.0, hourly_remaining),
+                    remaining_route_usd=max(0.0, route_remaining),
+                    detail="session cap exceeded",
+                )
+            if reserve > hourly_remaining:
+                return BudgetVerdict(
+                    admitted=False,
+                    reason=RejectReason.COST_CEILING_EXCEEDED,
+                    debit_usd=0.0,
+                    remaining_session_usd=max(0.0, session_remaining),
+                    remaining_hourly_usd=max(0.0, hourly_remaining),
+                    remaining_route_usd=max(0.0, route_remaining),
+                    detail="hourly burn cap exceeded",
+                )
+
+            # Admit: debit + WAL.
+            self._session_debit_usd += reserve
+            self._route_debit_usd[route] = route_debit + reserve
+            self._hourly_window.append((now, reserve))
+            self._open_reserves[lease_nonce] = reserve
+
+            verdict = BudgetVerdict(
+                admitted=True,
+                reason=None,
+                debit_usd=reserve,
+                remaining_session_usd=session_remaining - reserve,
+                remaining_hourly_usd=hourly_remaining - reserve,
+                remaining_route_usd=(
+                    (route_remaining - reserve) if route_cap is not None
+                    else float("inf")
+                ),
+            )
+
+            entry = admit_entry(
+                ts=now,
+                lease_nonce=lease_nonce,
+                op_id=op_id,
+                route=route,
+                estimated_cost_usd=float(estimated_cost_usd),
+                reserve_cost_usd=reserve,
+            )
+
+        # WAL append OUTSIDE the lock — flock + thread offload would
+        # otherwise hold our async lock through disk I/O.
+        ok = await append_entry(self._wal_path, entry)
+        if not ok:
+            logger.warning(
+                "[AegisBudget] WAL append failed for admit (nonce=%s); "
+                "in-memory state still reflects the admit",
+                lease_nonce,
+            )
+
+        return verdict
+
+    # -- reconciliation -------------------------------------------------------
+
+    async def reconcile(
+        self,
+        *,
+        lease_nonce: str,
+        op_id: str,
+        route: str,
+        actual_cost_usd: float,
+    ) -> BudgetVerdict:
+        """Replace the reserved debit with the actual one. Refund the
+        difference (positive if actual < reserve) or take the overrun
+        (negative refund → additional debit).
+
+        Slice 1 contract: this is informational. Slice 2 will add the
+        streaming guillotine that prevents actual > reserve at the wire
+        level. Here we just record faithfully.
+
+        Returns a fresh ``BudgetVerdict`` reflecting post-reconcile
+        remaining caps. ``admitted`` is True iff the lease was open
+        (was admitted previously); False with
+        BUDGET_AUTHORITY_UNAVAILABLE if the lease nonce is unknown
+        (replay or never admitted).
+        """
+        async with self._lock:
+            now = time.time()
+            self._evict_expired_hourly_locked(now=now)
+
+            reserve = self._open_reserves.pop(lease_nonce, None)
+            if reserve is None:
+                # Unknown lease — caller asked us to reconcile something
+                # we never admitted. Could be replay or a JARVIS-side
+                # bug. Don't mutate state; just return.
+                session_remaining = self._caps.session_cap_usd - self._session_debit_usd
+                hourly_used = sum(usd for _, usd in self._hourly_window)
+                hourly_remaining = self._caps.hourly_burn_cap_usd - hourly_used
+                route_cap = self._caps.route_cap(route)
+                route_debit = self._route_debit_usd.get(route, 0.0)
+                route_remaining = (
+                    (route_cap - route_debit) if route_cap is not None
+                    else float("inf")
+                )
+                return BudgetVerdict(
+                    admitted=False,
+                    reason=RejectReason.BUDGET_AUTHORITY_UNAVAILABLE,
+                    debit_usd=0.0,
+                    remaining_session_usd=max(0.0, session_remaining),
+                    remaining_hourly_usd=max(0.0, hourly_remaining),
+                    remaining_route_usd=max(0.0, route_remaining),
+                    detail="unknown lease nonce",
+                )
+
+            delta = float(actual_cost_usd) - reserve  # positive = overrun
+            self._session_debit_usd += delta
+            self._route_debit_usd[route] = (
+                self._route_debit_usd.get(route, 0.0) + delta
+            )
+            self._hourly_window.append((now, delta))
+
+            session_remaining = self._caps.session_cap_usd - self._session_debit_usd
+            hourly_used = sum(usd for _, usd in self._hourly_window)
+            hourly_remaining = self._caps.hourly_burn_cap_usd - hourly_used
+            route_cap = self._caps.route_cap(route)
+            route_debit = self._route_debit_usd.get(route, 0.0)
+            route_remaining = (
+                (route_cap - route_debit) if route_cap is not None
+                else float("inf")
+            )
+
+            verdict = BudgetVerdict(
+                admitted=True,
+                reason=None,
+                debit_usd=float(actual_cost_usd),
+                remaining_session_usd=session_remaining,
+                remaining_hourly_usd=hourly_remaining,
+                remaining_route_usd=route_remaining,
+            )
+
+            entry = reconcile_entry(
+                ts=now,
+                lease_nonce=lease_nonce,
+                op_id=op_id,
+                route=route,
+                actual_cost_usd=float(actual_cost_usd),
+                reserve_cost_usd=reserve,
+            )
+
+        ok = await append_entry(self._wal_path, entry)
+        if not ok:
+            logger.warning(
+                "[AegisBudget] WAL append failed for reconcile (nonce=%s)",
+                lease_nonce,
+            )
+
+        return verdict
+
+    # -- monotonic tightening -------------------------------------------------
+
+    async def tighten(
+        self,
+        *,
+        session_cap_usd: Optional[float] = None,
+        hourly_burn_cap_usd: Optional[float] = None,
+        route_caps_usd: Optional[Mapping[str, float]] = None,
+        overrun_multiplier: Optional[float] = None,
+    ) -> BudgetCaps:
+        """Update caps in the tightening direction only.
+
+        Each provided value must be strictly less than the current cap
+        (``<=`` is treated as no-op for per-route map keys not present;
+        any new value lower than current is accepted, any equal-or-higher
+        raises).
+
+        Returns the new (frozen) :class:`BudgetCaps` post-tighten.
+
+        Raises:
+            :class:`MonotonicTighteningViolationError` if any provided
+            value would loosen.
+        """
+        async with self._lock:
+            new_caps = self._caps
+
+            if session_cap_usd is not None:
+                if session_cap_usd >= new_caps.session_cap_usd:
+                    raise MonotonicTighteningViolationError(
+                        f"session_cap_usd: {session_cap_usd} would not tighten "
+                        f"current {new_caps.session_cap_usd}"
+                    )
+                new_caps = replace(new_caps, session_cap_usd=float(session_cap_usd))
+
+            if hourly_burn_cap_usd is not None:
+                if hourly_burn_cap_usd >= new_caps.hourly_burn_cap_usd:
+                    raise MonotonicTighteningViolationError(
+                        f"hourly_burn_cap_usd: {hourly_burn_cap_usd} would not "
+                        f"tighten current {new_caps.hourly_burn_cap_usd}"
+                    )
+                new_caps = replace(
+                    new_caps, hourly_burn_cap_usd=float(hourly_burn_cap_usd),
+                )
+
+            if route_caps_usd is not None:
+                merged: Dict[str, float] = dict(new_caps.route_caps_usd)
+                for route, new_val in route_caps_usd.items():
+                    current = merged.get(route)
+                    if current is None:
+                        # Adding a previously-unset cap is a tightening:
+                        # unset = unlimited, set = bounded.
+                        merged[route] = float(new_val)
+                        continue
+                    if new_val >= current:
+                        raise MonotonicTighteningViolationError(
+                            f"route_caps_usd[{route!r}]: {new_val} would not "
+                            f"tighten current {current}"
+                        )
+                    merged[route] = float(new_val)
+                new_caps = replace(new_caps, route_caps_usd=dict(merged))
+
+            if overrun_multiplier is not None:
+                if overrun_multiplier >= new_caps.overrun_multiplier:
+                    raise MonotonicTighteningViolationError(
+                        f"overrun_multiplier: {overrun_multiplier} would not "
+                        f"tighten current {new_caps.overrun_multiplier}"
+                    )
+                new_caps = replace(
+                    new_caps, overrun_multiplier=float(overrun_multiplier),
+                )
+
+            self._caps = new_caps
+            return new_caps
+
+    # -- introspection (read-only) -------------------------------------------
+
+    def snapshot(self) -> Dict[str, object]:
+        """Return a read-only point-in-time view for /health /aegis/spend."""
+        now = time.time()
+        # Compute hourly used outside the lock — single-int reads are
+        # safe and this method must not block. Worst case: a value
+        # drifts by one in-flight admit; this is an observability
+        # surface, not an authority decision.
+        hourly_used = sum(
+            usd for ts, usd in self._hourly_window
+            if ts >= (now - HOURLY_BURN_WINDOW_S)
+        )
+        return {
+            "session_cap_usd": self._caps.session_cap_usd,
+            "session_debit_usd": self._session_debit_usd,
+            "hourly_burn_cap_usd": self._caps.hourly_burn_cap_usd,
+            "hourly_burn_used_usd": hourly_used,
+            "route_caps_usd": dict(self._caps.route_caps_usd),
+            "route_debit_usd": dict(self._route_debit_usd),
+            "open_reserve_count": len(self._open_reserves),
+            "overrun_multiplier": self._caps.overrun_multiplier,
+            "schema_version": BUDGET_STATE_MACHINE_SCHEMA_VERSION,
+        }
+
+    # -- internal -------------------------------------------------------------
+
+    def _evict_expired_hourly_locked(self, *, now: float) -> None:
+        """Drop hourly-window entries older than HOURLY_BURN_WINDOW_S.
+
+        Must be called with the lock held."""
+        cutoff = now - HOURLY_BURN_WINDOW_S
+        while self._hourly_window and self._hourly_window[0][0] < cutoff:
+            self._hourly_window.popleft()
+
+
+# ---------------------------------------------------------------------------
+# Helper for synth verdicts (used by admit-validation pre-lock)
+# ---------------------------------------------------------------------------
+
+
+def _denied(caps: BudgetCaps, *, reason: RejectReason, detail: str) -> BudgetVerdict:
+    return BudgetVerdict(
+        admitted=False,
+        reason=reason,
+        debit_usd=0.0,
+        remaining_session_usd=caps.session_cap_usd,
+        remaining_hourly_usd=caps.hourly_burn_cap_usd,
+        remaining_route_usd=0.0,
+        detail=detail,
+    )
+
+
+__all__ = [
+    "BUDGET_STATE_MACHINE_SCHEMA_VERSION",
+    "BudgetCaps",
+    "BudgetVerdict",
+    "HOURLY_BURN_WINDOW_S",
+    "ImmutableBudgetStateMachine",
+    "KNOWN_ROUTES",
+    "MonotonicTighteningViolationError",
+    "RejectReason",
+]

--- a/backend/core/ouroboros/aegis/credential_registry.py
+++ b/backend/core/ouroboros/aegis/credential_registry.py
@@ -1,0 +1,48 @@
+"""Credential env var registry — single source of truth.
+
+Per Slice Aegis-1 binding correction #2: env scrub MUST NOT dynamically
+import provider modules just to learn credential env var names (heavy
+imports cause side-effects + pollute preflight). Instead, every component
+that needs to know "which env vars carry upstream credentials" composes
+this single lightweight constants module.
+
+Sources of truth this list mirrors:
+
+  * ``governance/doubleword_provider.py:43`` — ``DOUBLEWORD_API_KEY``
+  * ``governance/providers.py:5408`` — ``ANTHROPIC_API_KEY`` (Anthropic SDK
+    convention; also read by various harness preflight checks)
+  * ``battle_test/presentation_restraint.py:479,518`` — both above
+
+Adding a new upstream provider:
+
+  1. Add the env var name to ``_UPSTREAM_CREDENTIAL_ENV_VARS`` below.
+  2. The Aegis env_scrub will pick it up at next boot — no other change.
+
+Authority posture: zero imports beyond stdlib. AST-pinned. No
+``os.environ`` reads here; that's the scrub's job. This module is a
+pure declarative manifest.
+"""
+from __future__ import annotations
+
+from typing import FrozenSet
+
+
+_UPSTREAM_CREDENTIAL_ENV_VARS: FrozenSet[str] = frozenset({
+    "ANTHROPIC_API_KEY",
+    "DOUBLEWORD_API_KEY",
+})
+
+
+def upstream_credential_env_vars() -> FrozenSet[str]:
+    """Return the frozen set of env var names that carry upstream
+    LLM provider credentials.
+
+    Aegis env scrub pops each of these from the JARVIS process
+    environment before the supervisor boots. Providers (in Slice 2)
+    will discover this list rather than hardcoding their own env
+    var names.
+    """
+    return _UPSTREAM_CREDENTIAL_ENV_VARS
+
+
+__all__ = ["upstream_credential_env_vars"]

--- a/backend/core/ouroboros/aegis/daemon.py
+++ b/backend/core/ouroboros/aegis/daemon.py
@@ -1,0 +1,567 @@
+"""Aegis daemon — out-of-process aiohttp app, ephemeral-port loopback.
+
+§43.7 spine: this process runs separately from JARVIS, owns upstream
+credentials + HMAC key K + spend WAL. Slice 1 ships the substrate;
+no upstream forwarding. AST-pin enforces "no /v1/* routes in Slice 1".
+
+Endpoint surface (Slice 1):
+
+  * ``GET  /health``             — liveness + bind info + redacted snapshot
+  * ``POST /session/establish``  — bootstrap PSK -> scoped session token
+  * ``POST /lease/acquire``      — session token -> lease (cap-checked)
+  * ``POST /lease/redeem``       — lease + actual cost -> reconciled verdict
+
+Process invariants:
+
+  * Binds to ``daemon_bind_host()`` only (default 127.0.0.1).
+  * HMAC key K is generated per-boot via ``secrets.token_bytes(32)``,
+    held in ``app["_hmac_key"]``, **never** included in any HTTP
+    response body, log line, exception message, or repr.
+  * Bootstrap PSK is one-shot: after a successful ``/session/establish``
+    that consumes it, the PSK is dropped from app state and any future
+    request bearing it gets 403. The session-token path becomes the
+    only auth surface.
+  * No mutable singleton state — every piece lives in ``app[...]``
+    so reset-for-tests is a single ``aiohttp.web.Application()``.
+
+Run modes:
+
+  * Library:   ``app = build_app(...); await aiohttp.web._run_app(app)``
+  * CLI:       ``python -m backend.core.ouroboros.aegis.daemon
+                       --bootstrap-out /tmp/aegis-xxx.json``
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import secrets
+import socket
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+from aiohttp import web
+
+from backend.core.ouroboros.aegis import AEGIS_SCHEMA_VERSION
+from backend.core.ouroboros.aegis.bootstrap import (
+    BootstrapPayload,
+    atomic_write_payload,
+    default_expiry,
+    mint_bootstrap_psk,
+)
+from backend.core.ouroboros.aegis.budget_state_machine import (
+    BudgetCaps,
+    ImmutableBudgetStateMachine,
+)
+from backend.core.ouroboros.aegis.lease import (
+    DEFAULT_LEASE_TTL_S,
+    DEFAULT_NONCE_LEDGER_CAPACITY,
+    DEFAULT_SESSION_TOKEN_TTL_S,
+    Lease,
+    NonceLedger,
+    SessionToken,
+    TokenVerdictKind,
+    mint_lease_token,
+    mint_session_token,
+    validate_lease_token,
+    validate_session_token,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# App state keys — single seam so the AST pin can grep for them.
+# ---------------------------------------------------------------------------
+
+_K_HMAC_KEY = "_hmac_key"
+_K_BOOTSTRAP_PSK = "_bootstrap_psk"
+_K_PSK_CONSUMED = "_psk_consumed"
+_K_ACTIVE_SESSIONS = "_active_sessions"
+_K_NONCE_LEDGER = "_nonce_ledger"
+_K_BUDGET = "_budget"
+_K_LEASE_TTL_S = "_lease_ttl_s"
+_K_SESSION_TTL_S = "_session_ttl_s"
+_K_BIND_PORT = "_bind_port"
+_K_BIND_HOST = "_bind_host"
+_K_BOOT_TS = "_boot_ts"
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+
+def build_app(
+    *,
+    budget: ImmutableBudgetStateMachine,
+    bootstrap_psk: str,
+    lease_ttl_s: int = DEFAULT_LEASE_TTL_S,
+    session_ttl_s: int = DEFAULT_SESSION_TOKEN_TTL_S,
+    nonce_ledger_capacity: int = DEFAULT_NONCE_LEDGER_CAPACITY,
+) -> web.Application:
+    """Construct the aiohttp Application with all routes wired.
+
+    The HMAC key K is generated here per call so each ``build_app``
+    invocation produces an independently-keyed instance — useful for
+    tests, mandatory for production (one K per Aegis boot).
+
+    Routes registered:
+      - GET  /health
+      - POST /session/establish
+      - POST /lease/acquire
+      - POST /lease/redeem
+
+    NO ``/v1/*`` routes. AST-pinned in tests.
+    """
+    app = web.Application()
+
+    # K is generated INSIDE the factory, never returned, never logged.
+    # AST pin confirms K is referenced only via app[_K_HMAC_KEY] in the
+    # handlers below.
+    app[_K_HMAC_KEY] = secrets.token_bytes(32)
+    app[_K_BOOTSTRAP_PSK] = bootstrap_psk
+    app[_K_PSK_CONSUMED] = False
+    active_sessions: Dict[str, SessionToken] = {}
+    app[_K_ACTIVE_SESSIONS] = active_sessions
+    app[_K_NONCE_LEDGER] = NonceLedger(capacity=nonce_ledger_capacity)
+    app[_K_BUDGET] = budget
+    app[_K_LEASE_TTL_S] = int(lease_ttl_s)
+    app[_K_SESSION_TTL_S] = int(session_ttl_s)
+    app[_K_BIND_HOST] = ""
+    app[_K_BIND_PORT] = 0
+    app[_K_BOOT_TS] = time.time()
+
+    app.router.add_get("/health", _handle_health)
+    app.router.add_post("/session/establish", _handle_session_establish)
+    app.router.add_post("/lease/acquire", _handle_lease_acquire)
+    app.router.add_post("/lease/redeem", _handle_lease_redeem)
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+
+def _bearer_token(request: web.Request) -> Optional[str]:
+    raw = request.headers.get("Authorization", "")
+    if not raw or not raw.lower().startswith("bearer "):
+        return None
+    return raw[7:].strip() or None
+
+
+# ---------------------------------------------------------------------------
+# Route handlers
+# ---------------------------------------------------------------------------
+
+
+async def _handle_health(request: web.Request) -> web.Response:
+    """Liveness + bound port + redacted snapshot.
+
+    NEVER includes the HMAC key, the bootstrap PSK, or any session
+    token. Snapshot reflects budget state machine introspection.
+    """
+    app = request.app
+    budget: ImmutableBudgetStateMachine = app[_K_BUDGET]
+    snapshot = budget.snapshot()
+    body = {
+        "ok": True,
+        "schema_version": AEGIS_SCHEMA_VERSION,
+        "bind_host": app[_K_BIND_HOST],
+        "bind_port": app[_K_BIND_PORT],
+        "psk_consumed": app[_K_PSK_CONSUMED],
+        "active_session_count": len(app[_K_ACTIVE_SESSIONS]),
+        "nonce_ledger_size": app[_K_NONCE_LEDGER].size(),
+        "boot_ts": app[_K_BOOT_TS],
+        "uptime_s": time.time() - app[_K_BOOT_TS],
+        "budget": snapshot,
+    }
+    return web.json_response(body, headers={"Cache-Control": "no-store"})
+
+
+async def _handle_session_establish(request: web.Request) -> web.Response:
+    """Consume the one-shot bootstrap PSK, mint a scoped session token.
+
+    Auth: ``Authorization: Bearer <BOOTSTRAP_PSK>``. The PSK is consumed
+    irrevocably on the first successful call. Any subsequent call (with
+    the same or any PSK) returns 403.
+    """
+    app = request.app
+    presented = _bearer_token(request)
+    if presented is None:
+        return web.json_response(
+            {"ok": False, "error": "missing_bearer"}, status=401,
+        )
+
+    if app[_K_PSK_CONSUMED]:
+        # Single-use: any subsequent attempt is rejected without
+        # disclosing whether the PSK matched.
+        return web.json_response(
+            {"ok": False, "error": "psk_already_consumed"}, status=403,
+        )
+
+    # Constant-time compare so a timing-attack on the PSK is not possible.
+    expected = app[_K_BOOTSTRAP_PSK]
+    if not secrets.compare_digest(presented, expected):
+        # Do NOT mark consumed on failure — operator may have a
+        # legitimate retry. Log at WARNING (no PSK values, just the
+        # remote info).
+        logger.warning(
+            "[AegisDaemon] /session/establish bearer mismatch from %s",
+            request.remote,
+        )
+        return web.json_response(
+            {"ok": False, "error": "psk_mismatch"}, status=403,
+        )
+
+    # Mint the session token. Mark PSK consumed FIRST so a concurrent
+    # second request gets the consumed-path response.
+    app[_K_PSK_CONSUMED] = True
+    now = time.time()
+    K: bytes = app[_K_HMAC_KEY]
+    wire, payload = mint_session_token(
+        K, now_s=now, ttl_s=app[_K_SESSION_TTL_S],
+    )
+    app[_K_ACTIVE_SESSIONS][payload.jti] = payload
+
+    # K is not in the response body — only the wire token.
+    return web.json_response({
+        "ok": True,
+        "session_token": wire,
+        "issued_at": payload.issued_at,
+        "expires_at": payload.expires_at,
+        "ttl_s": app[_K_SESSION_TTL_S],
+    })
+
+
+async def _handle_lease_acquire(request: web.Request) -> web.Response:
+    """Mint a lease for one upcoming provider call.
+
+    Auth: ``Authorization: Bearer <SESSION_TOKEN>``.
+
+    JSON body:
+        {
+            "op_id": "<str>",
+            "route": "<IMMEDIATE|STANDARD|COMPLEX|BACKGROUND|SPECULATIVE>",
+            "estimated_cost_usd": <float>,
+            "causal_lineage_hash": "<str>"   # stub for Arc #4
+        }
+
+    Returns:
+        200 with {ok:true, lease_token, lease:<frozen Lease as dict>,
+                  verdict:<BudgetVerdict>}
+        OR
+        200 with {ok:false, verdict:<BudgetVerdict with reason>}
+            — the verdict carries the cap-exceeded reason; not a 500.
+        OR
+        401/403 on auth failure.
+    """
+    app = request.app
+    K: bytes = app[_K_HMAC_KEY]
+    now = time.time()
+
+    presented = _bearer_token(request)
+    if presented is None:
+        return web.json_response(
+            {"ok": False, "error": "missing_bearer"}, status=401,
+        )
+
+    verdict = validate_session_token(
+        K, presented, now_s=now, active_jti=set(app[_K_ACTIVE_SESSIONS].keys()),
+    )
+    if verdict.kind is not TokenVerdictKind.VALID:
+        return web.json_response(
+            {"ok": False, "error": f"session_token_{verdict.kind.value}"},
+            status=403,
+        )
+
+    try:
+        body = await request.json()
+    except (ValueError, web.HTTPException):
+        return web.json_response(
+            {"ok": False, "error": "invalid_json_body"}, status=400,
+        )
+    if not isinstance(body, dict):
+        return web.json_response(
+            {"ok": False, "error": "body_not_object"}, status=400,
+        )
+
+    try:
+        op_id = str(body["op_id"])
+        route = str(body["route"])
+        estimated = float(body["estimated_cost_usd"])
+        lineage = str(body.get("causal_lineage_hash", ""))
+    except (KeyError, ValueError, TypeError) as exc:
+        return web.json_response(
+            {"ok": False, "error": f"invalid_body_field:{exc}"},
+            status=400,
+        )
+
+    budget: ImmutableBudgetStateMachine = app[_K_BUDGET]
+    nonce = secrets.token_urlsafe(16)
+    budget_verdict = await budget.admit(
+        route=route,
+        estimated_cost_usd=estimated,
+        lease_nonce=nonce,
+        op_id=op_id,
+    )
+
+    if not budget_verdict.admitted:
+        return web.json_response({
+            "ok": False,
+            "verdict": budget_verdict.to_dict(),
+        })
+
+    # Construct the Lease and mint its wire token. K stays inside
+    # mint_lease_token.
+    lease_ttl = app[_K_LEASE_TTL_S]
+    lease = Lease(
+        nonce=nonce,
+        op_id=op_id,
+        route=route,
+        estimated_cost_usd=estimated,
+        max_cost_usd=budget_verdict.debit_usd,
+        causal_lineage_hash=lineage,
+        issued_at=now,
+        expires_at=now + float(lease_ttl),
+    )
+    lease_token = mint_lease_token(K, lease)
+
+    return web.json_response({
+        "ok": True,
+        "lease_token": lease_token,
+        "lease": lease.to_dict(),
+        "verdict": budget_verdict.to_dict(),
+    })
+
+
+async def _handle_lease_redeem(request: web.Request) -> web.Response:
+    """Mark a lease redeemed and reconcile actual cost against reserve.
+
+    Auth: ``Authorization: Bearer <SESSION_TOKEN>``.
+
+    JSON body:
+        {
+            "lease_token": "<wire>",
+            "actual_cost_usd": <float>
+        }
+
+    Slice 1 contract: redemption is a separate explicit step (Slice 2
+    will fold it into the /v1/* upstream-forwarding return path).
+    Returns the post-reconcile verdict OR a token-verdict-failure
+    payload.
+    """
+    app = request.app
+    K: bytes = app[_K_HMAC_KEY]
+    now = time.time()
+
+    presented = _bearer_token(request)
+    if presented is None:
+        return web.json_response(
+            {"ok": False, "error": "missing_bearer"}, status=401,
+        )
+
+    session_verdict = validate_session_token(
+        K, presented, now_s=now, active_jti=set(app[_K_ACTIVE_SESSIONS].keys()),
+    )
+    if session_verdict.kind is not TokenVerdictKind.VALID:
+        return web.json_response(
+            {"ok": False, "error": f"session_token_{session_verdict.kind.value}"},
+            status=403,
+        )
+
+    try:
+        body = await request.json()
+    except (ValueError, web.HTTPException):
+        return web.json_response(
+            {"ok": False, "error": "invalid_json_body"}, status=400,
+        )
+    if not isinstance(body, dict):
+        return web.json_response(
+            {"ok": False, "error": "body_not_object"}, status=400,
+        )
+    try:
+        lease_token = str(body["lease_token"])
+        actual = float(body["actual_cost_usd"])
+    except (KeyError, ValueError, TypeError) as exc:
+        return web.json_response(
+            {"ok": False, "error": f"invalid_body_field:{exc}"},
+            status=400,
+        )
+
+    lease_verdict = validate_lease_token(
+        K, lease_token, now_s=now,
+        nonce_ledger=app[_K_NONCE_LEDGER],
+    )
+    if lease_verdict.kind is not TokenVerdictKind.VALID:
+        return web.json_response({
+            "ok": False,
+            "error": f"lease_token_{lease_verdict.kind.value}",
+            "detail": lease_verdict.detail,
+        })
+
+    assert lease_verdict.payload is not None
+    try:
+        lease = Lease.from_dict(lease_verdict.payload)
+    except (KeyError, ValueError, TypeError) as exc:
+        return web.json_response({
+            "ok": False, "error": f"lease_payload_invalid:{exc}",
+        })
+
+    budget: ImmutableBudgetStateMachine = app[_K_BUDGET]
+    reconcile_verdict = await budget.reconcile(
+        lease_nonce=lease.nonce,
+        op_id=lease.op_id,
+        route=lease.route,
+        actual_cost_usd=actual,
+    )
+
+    return web.json_response({
+        "ok": True,
+        "verdict": reconcile_verdict.to_dict(),
+        "lease": lease.to_dict(),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Bind helpers — ephemeral port via socket.bind((host, 0))
+# ---------------------------------------------------------------------------
+
+
+def bind_ephemeral_socket(host: str) -> socket.socket:
+    """Create + bind a TCP socket on an ephemeral port on ``host``.
+
+    Returns the socket; caller is responsible for either passing it to
+    aiohttp ``_run_app(..., sock=...)`` or closing it.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((host, 0))
+    sock.setblocking(False)
+    return sock
+
+
+# ---------------------------------------------------------------------------
+# CLI entry — invoked by the harness via `python -m`.
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: Optional[list] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="aegis-daemon",
+        description="Aegis out-of-process egress + budget chokepoint daemon",
+    )
+    parser.add_argument(
+        "--bootstrap-out", type=Path, required=True,
+        help="Path to write the one-time bootstrap payload (0600).",
+    )
+    parser.add_argument(
+        "--bind-host", type=str, default="",
+        help="Loopback host to bind (default from JARVIS_AEGIS_DAEMON_BIND_HOST or 127.0.0.1).",
+    )
+    return parser.parse_args(argv)
+
+
+async def _serve(args: argparse.Namespace) -> None:
+    # Lazy-import flags here so the test surface doesn't pay the
+    # FlagRegistry-singleton cost when just importing build_app.
+    from backend.core.ouroboros.aegis.flags import (
+        daemon_bind_host,
+        hourly_burn_cap_usd,
+        lease_expiry_s,
+        lease_overrun_multiplier,
+        nonce_ledger_capacity,
+        register_aegis_flags,
+        route_caps_usd,
+        session_cap_usd,
+        session_token_ttl_s,
+        wal_path,
+    )
+
+    register_aegis_flags()
+
+    host = args.bind_host or daemon_bind_host()
+
+    caps = BudgetCaps(
+        session_cap_usd=session_cap_usd(),
+        hourly_burn_cap_usd=hourly_burn_cap_usd(),
+        route_caps_usd=route_caps_usd(),
+        overrun_multiplier=lease_overrun_multiplier(),
+    )
+    wal = wal_path()
+    wal.parent.mkdir(parents=True, exist_ok=True)
+    budget = ImmutableBudgetStateMachine(caps=caps, wal_path=wal)
+    budget.replay_for_recovery()
+    await budget.record_boot(detail="aegis daemon boot")
+
+    psk = mint_bootstrap_psk()
+    app = build_app(
+        budget=budget,
+        bootstrap_psk=psk,
+        lease_ttl_s=lease_expiry_s(),
+        session_ttl_s=session_token_ttl_s(),
+        nonce_ledger_capacity=nonce_ledger_capacity(),
+    )
+
+    sock = bind_ephemeral_socket(host)
+    port = sock.getsockname()[1]
+    app[_K_BIND_HOST] = host
+    app[_K_BIND_PORT] = port
+
+    payload = BootstrapPayload(
+        aegis_url=f"http://{host}:{port}",
+        bootstrap_psk=psk,
+        daemon_pid=os.getpid(),
+        expires_at=default_expiry(now_s=time.time()),
+    )
+    atomic_write_payload(payload, args.bootstrap_out)
+    logger.info(
+        "[AegisDaemon] bootstrap payload written: %s (pid=%d, url=%s)",
+        args.bootstrap_out, os.getpid(), payload.aegis_url,
+    )
+
+    runner = web.AppRunner(app, access_log=None)
+    await runner.setup()
+    site = web.SockSite(runner, sock)
+    await site.start()
+    logger.info("[AegisDaemon] serving on %s:%d", host, port)
+
+    # Run until cancelled (SIGTERM via signal handler below, or
+    # subprocess kill from harness).
+    stop_event = asyncio.Event()
+    try:
+        await stop_event.wait()
+    finally:
+        await runner.cleanup()
+
+
+def main(argv: Optional[list] = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s aegis-daemon %(levelname)s %(message)s",
+    )
+    args = _parse_args(argv)
+    try:
+        asyncio.run(_serve(args))
+        return 0
+    except KeyboardInterrupt:
+        return 0
+    except Exception as exc:  # noqa: BLE001 — top-level entry
+        logger.exception("[AegisDaemon] fatal: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())
+
+
+__all__ = [
+    "bind_ephemeral_socket",
+    "build_app",
+    "main",
+]

--- a/backend/core/ouroboros/aegis/env_scrub.py
+++ b/backend/core/ouroboros/aegis/env_scrub.py
@@ -1,0 +1,103 @@
+"""Env scrub — remove upstream credentials from JARVIS process env.
+
+Per binding correction #2, this module discovers credential env names
+from the lightweight :mod:`credential_registry` constants module — not
+from dynamic provider imports (which would cause side effects + bloat
+preflight).
+
+Per binding correction #6, ``assert_no_upstream_credentials`` is a
+hard invariant: when Aegis is enabled, the JARVIS process must boot
+with **zero** upstream credentials in its environment. Any presence is
+session-fatal.
+
+Functions take the env mapping as an explicit argument so tests can
+pass synthetic dicts without mutating the real ``os.environ``.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, MutableMapping, Optional
+
+from backend.core.ouroboros.aegis.credential_registry import (
+    upstream_credential_env_vars,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class UpstreamCredentialPresentError(RuntimeError):
+    """Raised by :func:`assert_no_upstream_credentials` when one or more
+    upstream credential env vars are still present in the supplied env.
+
+    The exception message lists the offending KEYS only — never the
+    values. Even logging the values briefly would defeat the purpose
+    of the scrub.
+    """
+
+
+def scrub_upstream_credentials(
+    env: MutableMapping[str, str],
+    *,
+    extra: Optional[Iterable[str]] = None,
+) -> Dict[str, str]:
+    """Pop every known upstream credential env var from ``env`` and
+    return a dict of the captured ``{name: value}`` pairs.
+
+    The returned dict is meant for the harness to pass the credentials
+    into the Aegis subprocess at spawn time — across the fork — and
+    then discard. After that pair (return + spawn handoff), no Python
+    object in the JARVIS process should retain the value.
+
+    ``extra`` lets callers add env names that aren't in the registry
+    (e.g., a one-off provider used by a test harness).
+
+    Returns:
+        Dict[name -> value] of every variable that was present and
+        popped. If the env contained none of the registered names,
+        returns an empty dict.
+    """
+    names = set(upstream_credential_env_vars())
+    if extra is not None:
+        names.update(extra)
+
+    captured: Dict[str, str] = {}
+    for name in sorted(names):
+        if name in env:
+            captured[name] = env.pop(name)
+            logger.info(
+                "[AegisEnvScrub] popped credential env var: %s "
+                "(value redacted)", name,
+            )
+    return captured
+
+
+def assert_no_upstream_credentials(
+    env: MutableMapping[str, str],
+    *,
+    extra: Optional[Iterable[str]] = None,
+) -> None:
+    """Raise :class:`UpstreamCredentialPresentError` if ``env`` still
+    contains any known upstream credential env var.
+
+    Called by the harness AFTER ``scrub_upstream_credentials`` to
+    enforce the binding-correction #6 invariant. Never logs the
+    credential value — only the variable name.
+    """
+    names = set(upstream_credential_env_vars())
+    if extra is not None:
+        names.update(extra)
+
+    present = sorted(n for n in names if n in env)
+    if present:
+        raise UpstreamCredentialPresentError(
+            "upstream credential env vars still present after Aegis "
+            f"preflight scrub: {present}. "
+            "JARVIS must boot unprivileged when JARVIS_AEGIS_ENABLED=true."
+        )
+
+
+__all__ = [
+    "UpstreamCredentialPresentError",
+    "assert_no_upstream_credentials",
+    "scrub_upstream_credentials",
+]

--- a/backend/core/ouroboros/aegis/flags.py
+++ b/backend/core/ouroboros/aegis/flags.py
@@ -1,0 +1,386 @@
+"""Aegis FlagRegistry seeds + typed env-read helpers.
+
+Single seam to read Aegis-specific env vars. The daemon boot path
+imports from here; never reads ``os.environ`` for an Aegis flag
+directly. This lets the FlagRegistry record usage + surface typos.
+
+Per binding correction "fail-closed defaults": every cap defaults to
+0.0 USD (= nothing admitted). Operator must set caps explicitly to
+allow any spend at all. This is the §43.6.1 safety-gate polarity.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from backend.core.ouroboros.governance.flag_registry import (
+    Category,
+    FlagRegistry,
+    FlagSpec,
+    FlagType,
+    get_default_registry,
+)
+
+from backend.core.ouroboros.aegis.budget_state_machine import KNOWN_ROUTES
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Env var names — single source of truth
+# ---------------------------------------------------------------------------
+
+ENV_AEGIS_ENABLED: str = "JARVIS_AEGIS_ENABLED"
+ENV_AEGIS_BOOTSTRAP_DIR: str = "JARVIS_AEGIS_BOOTSTRAP_DIR"
+ENV_AEGIS_BOOTSTRAP_TIMEOUT_S: str = "JARVIS_AEGIS_BOOTSTRAP_TIMEOUT_S"
+ENV_AEGIS_DAEMON_BIND_HOST: str = "JARVIS_AEGIS_DAEMON_BIND_HOST"
+ENV_AEGIS_LEASE_EXPIRY_S: str = "JARVIS_AEGIS_LEASE_EXPIRY_S"
+ENV_AEGIS_LEASE_OVERRUN_MULTIPLIER: str = "JARVIS_AEGIS_LEASE_OVERRUN_MULTIPLIER"
+ENV_AEGIS_SESSION_TOKEN_TTL_S: str = "JARVIS_AEGIS_SESSION_TOKEN_TTL_S"
+ENV_AEGIS_NONCE_LEDGER_CAPACITY: str = "JARVIS_AEGIS_NONCE_LEDGER_CAPACITY"
+ENV_AEGIS_WAL_PATH: str = "JARVIS_AEGIS_WAL_PATH"
+ENV_AEGIS_SESSION_CAP_USD: str = "JARVIS_AEGIS_SESSION_CAP_USD"
+ENV_AEGIS_HOURLY_BURN_CAP_USD: str = "JARVIS_AEGIS_HOURLY_BURN_CAP_USD"
+
+
+def env_route_cap(route: str) -> str:
+    """Compose the per-route cap env var name. Single seam."""
+    return f"JARVIS_AEGIS_ROUTE_CAP_{route.upper()}_USD"
+
+
+# ---------------------------------------------------------------------------
+# Defaults (the fail-closed bar)
+# ---------------------------------------------------------------------------
+
+DEFAULT_BOOTSTRAP_TIMEOUT_S: int = 10
+DEFAULT_DAEMON_BIND_HOST: str = "127.0.0.1"
+DEFAULT_NONCE_LEDGER_CAPACITY: int = 8192
+DEFAULT_WAL_PATH_REL: str = ".jarvis/aegis/spend.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Typed helpers — every Aegis env read goes through these
+# ---------------------------------------------------------------------------
+
+
+def is_enabled() -> bool:
+    """Master switch. Default **false** (Slice 1 dark)."""
+    return get_default_registry().get_bool(ENV_AEGIS_ENABLED, default=False)
+
+
+def daemon_bind_host() -> str:
+    raw = os.environ.get(ENV_AEGIS_DAEMON_BIND_HOST, "").strip()
+    return raw or DEFAULT_DAEMON_BIND_HOST
+
+
+def bootstrap_dir() -> Path:
+    """Directory where Aegis writes the bootstrap-payload tempfile.
+    Defaults to ``$TMPDIR/aegis-bootstrap`` (or ``/tmp/aegis-bootstrap``
+    if TMPDIR unset)."""
+    raw = os.environ.get(ENV_AEGIS_BOOTSTRAP_DIR, "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    tmpdir = os.environ.get("TMPDIR", "/tmp").rstrip("/")
+    return Path(tmpdir) / "aegis-bootstrap"
+
+
+def bootstrap_timeout_s() -> int:
+    return get_default_registry().get_int(
+        ENV_AEGIS_BOOTSTRAP_TIMEOUT_S,
+        default=DEFAULT_BOOTSTRAP_TIMEOUT_S,
+        minimum=1,
+    )
+
+
+def lease_expiry_s() -> int:
+    from backend.core.ouroboros.aegis.lease import DEFAULT_LEASE_TTL_S
+    return get_default_registry().get_int(
+        ENV_AEGIS_LEASE_EXPIRY_S, default=DEFAULT_LEASE_TTL_S, minimum=1,
+    )
+
+
+def lease_overrun_multiplier() -> float:
+    return get_default_registry().get_float(
+        ENV_AEGIS_LEASE_OVERRUN_MULTIPLIER, default=1.5, minimum=1.0,
+    )
+
+
+def session_token_ttl_s() -> int:
+    from backend.core.ouroboros.aegis.lease import DEFAULT_SESSION_TOKEN_TTL_S
+    return get_default_registry().get_int(
+        ENV_AEGIS_SESSION_TOKEN_TTL_S,
+        default=DEFAULT_SESSION_TOKEN_TTL_S,
+        minimum=1,
+    )
+
+
+def nonce_ledger_capacity() -> int:
+    return get_default_registry().get_int(
+        ENV_AEGIS_NONCE_LEDGER_CAPACITY,
+        default=DEFAULT_NONCE_LEDGER_CAPACITY,
+        minimum=1,
+    )
+
+
+def wal_path() -> Path:
+    raw = os.environ.get(ENV_AEGIS_WAL_PATH, "").strip()
+    return Path(raw).expanduser() if raw else Path(DEFAULT_WAL_PATH_REL)
+
+
+def session_cap_usd() -> float:
+    return get_default_registry().get_float(
+        ENV_AEGIS_SESSION_CAP_USD, default=0.0, minimum=0.0,
+    )
+
+
+def hourly_burn_cap_usd() -> float:
+    return get_default_registry().get_float(
+        ENV_AEGIS_HOURLY_BURN_CAP_USD, default=0.0, minimum=0.0,
+    )
+
+
+def route_caps_usd() -> Dict[str, float]:
+    """Read per-route caps via :func:`env_route_cap`. Returns a dict
+    keyed by route name (e.g., ``"IMMEDIATE"``). Routes with unset
+    env vars are still included with value 0.0 (fail-closed)."""
+    registry = get_default_registry()
+    out: Dict[str, float] = {}
+    for route in KNOWN_ROUTES:
+        out[route] = registry.get_float(env_route_cap(route), default=0.0, minimum=0.0)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# FlagSpec seeds
+# ---------------------------------------------------------------------------
+
+
+_SRC_AEGIS: str = "backend/core/ouroboros/aegis/flags.py"
+
+
+def _seeds() -> List[FlagSpec]:
+    specs: List[FlagSpec] = [
+        FlagSpec(
+            name=ENV_AEGIS_ENABLED,
+            type=FlagType.BOOL,
+            default=False,
+            description=(
+                "Arc #1 master switch. **Slice 1 dark by default.** "
+                "When false (default), Aegis daemon is not spawned, no "
+                "credential scrub, no behavior change. When true (post "
+                "Slice 4 graduation), harness spawns Aegis pre-supervisor, "
+                "scrubs upstream credentials from JARVIS env, and routes "
+                "all provider traffic through the localhost proxy."
+            ),
+            category=Category.SAFETY,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_ENABLED}=true",
+        ),
+        FlagSpec(
+            name=ENV_AEGIS_BOOTSTRAP_DIR,
+            type=FlagType.STR,
+            default="",
+            description=(
+                "Directory where Aegis writes the one-time bootstrap "
+                "payload tempfile (0600). Empty default resolves to "
+                "$TMPDIR/aegis-bootstrap. Override for sandboxed envs."
+            ),
+            category=Category.INTEGRATION,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_BOOTSTRAP_DIR}=/run/aegis",
+        ),
+        FlagSpec(
+            name=ENV_AEGIS_BOOTSTRAP_TIMEOUT_S,
+            type=FlagType.INT,
+            default=DEFAULT_BOOTSTRAP_TIMEOUT_S,
+            description=(
+                "Max seconds the harness waits for Aegis to write its "
+                "bootstrap payload before treating spawn as failed."
+            ),
+            category=Category.TIMING,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_BOOTSTRAP_TIMEOUT_S}=30",
+        ),
+        FlagSpec(
+            name=ENV_AEGIS_DAEMON_BIND_HOST,
+            type=FlagType.STR,
+            default=DEFAULT_DAEMON_BIND_HOST,
+            description=(
+                "Loopback interface Aegis binds to. **Must be a loopback "
+                "address.** Changing this away from 127.0.0.1 exposes the "
+                "lease + budget surface to non-loopback callers — "
+                "operator-only override."
+            ),
+            category=Category.INTEGRATION,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_DAEMON_BIND_HOST}=127.0.0.1",
+        ),
+        FlagSpec(
+            name=ENV_AEGIS_LEASE_EXPIRY_S,
+            type=FlagType.INT,
+            default=300,
+            description=(
+                "Lease TTL in seconds. Default 300 (5 min) — long enough "
+                "for an extended-thinking call, short enough that leaked "
+                "leases self-expire."
+            ),
+            category=Category.TIMING,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_LEASE_EXPIRY_S}=120",
+        ),
+        FlagSpec(
+            name=ENV_AEGIS_LEASE_OVERRUN_MULTIPLIER,
+            type=FlagType.FLOAT,
+            default=1.5,
+            description=(
+                "Pre-flight cost reserve = estimated_cost_usd × this. "
+                "Sized to absorb token-count drift between estimate and "
+                "actual without forcing mid-stream re-leasing."
+            ),
+            category=Category.CAPACITY,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_LEASE_OVERRUN_MULTIPLIER}=2.0",
+        ),
+        FlagSpec(
+            name=ENV_AEGIS_SESSION_TOKEN_TTL_S,
+            type=FlagType.INT,
+            default=3600,
+            description=(
+                "Session-token TTL in seconds. Default 1h — JARVIS re-"
+                "establishes after expiry via the bootstrap PSK only if "
+                "the PSK has not been consumed (single-use)."
+            ),
+            category=Category.TIMING,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_SESSION_TOKEN_TTL_S}=7200",
+        ),
+        FlagSpec(
+            name=ENV_AEGIS_NONCE_LEDGER_CAPACITY,
+            type=FlagType.INT,
+            default=DEFAULT_NONCE_LEDGER_CAPACITY,
+            description=(
+                "Bounded FIFO capacity of the redeemed-nonce ledger. "
+                "Drop-oldest eviction; sized to comfortably hold the "
+                "lease-TTL × peak-rate window."
+            ),
+            category=Category.CAPACITY,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_NONCE_LEDGER_CAPACITY}=16384",
+        ),
+        FlagSpec(
+            name=ENV_AEGIS_WAL_PATH,
+            type=FlagType.STR,
+            default=DEFAULT_WAL_PATH_REL,
+            description=(
+                "Path to the spend WAL (JSONL). Aegis owns this path. "
+                "Slice 2 will add it to JARVIS FORBIDDEN_PATH."
+            ),
+            category=Category.INTEGRATION,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_WAL_PATH}=/var/lib/aegis/spend.jsonl",
+        ),
+        FlagSpec(
+            name=ENV_AEGIS_SESSION_CAP_USD,
+            type=FlagType.FLOAT,
+            default=0.0,
+            description=(
+                "Total session spend ceiling in USD. **Fail-closed: "
+                "default 0.0 means nothing admitted.** Operator must set "
+                "explicitly to allow any spend."
+            ),
+            category=Category.SAFETY,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_SESSION_CAP_USD}=1.50",
+        ),
+        FlagSpec(
+            name=ENV_AEGIS_HOURLY_BURN_CAP_USD,
+            type=FlagType.FLOAT,
+            default=0.0,
+            description=(
+                "Rolling 1-hour burn cap in USD. Strictest-wins with the "
+                "session + per-route caps. Default 0.0 = no admit."
+            ),
+            category=Category.SAFETY,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_HOURLY_BURN_CAP_USD}=0.50",
+        ),
+    ]
+
+    # Per-route caps — one spec per known route.
+    for route in KNOWN_ROUTES:
+        name = env_route_cap(route)
+        specs.append(FlagSpec(
+            name=name,
+            type=FlagType.FLOAT,
+            default=0.0,
+            description=(
+                f"Per-route spend cap for {route} in USD. Default 0.0 = "
+                f"no admit on {route}. Composes strictest-wins with "
+                "session + hourly caps."
+            ),
+            category=Category.SAFETY,
+            source_file=_SRC_AEGIS,
+            example=f"{name}=0.10",
+        ))
+
+    return specs
+
+
+_seeds_applied: bool = False
+
+
+def register_aegis_flags(registry: FlagRegistry | None = None) -> Tuple[int, int]:
+    """Register every Aegis FlagSpec with the FlagRegistry singleton.
+
+    Idempotent — repeated calls override existing specs (FlagRegistry's
+    own contract). Returns ``(seeds_registered, total_specs_in_seed)``.
+    """
+    global _seeds_applied
+    reg = registry if registry is not None else get_default_registry()
+    seeds = _seeds()
+    count = 0
+    for spec in seeds:
+        try:
+            reg.register(spec)
+            count += 1
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "[AegisFlags] failed to register %s: %s", spec.name, exc,
+            )
+    _seeds_applied = True
+    return count, len(seeds)
+
+
+__all__ = [
+    "DEFAULT_BOOTSTRAP_TIMEOUT_S",
+    "DEFAULT_DAEMON_BIND_HOST",
+    "DEFAULT_NONCE_LEDGER_CAPACITY",
+    "DEFAULT_WAL_PATH_REL",
+    "ENV_AEGIS_BOOTSTRAP_DIR",
+    "ENV_AEGIS_BOOTSTRAP_TIMEOUT_S",
+    "ENV_AEGIS_DAEMON_BIND_HOST",
+    "ENV_AEGIS_ENABLED",
+    "ENV_AEGIS_HOURLY_BURN_CAP_USD",
+    "ENV_AEGIS_LEASE_EXPIRY_S",
+    "ENV_AEGIS_LEASE_OVERRUN_MULTIPLIER",
+    "ENV_AEGIS_NONCE_LEDGER_CAPACITY",
+    "ENV_AEGIS_SESSION_CAP_USD",
+    "ENV_AEGIS_SESSION_TOKEN_TTL_S",
+    "ENV_AEGIS_WAL_PATH",
+    "bootstrap_dir",
+    "bootstrap_timeout_s",
+    "daemon_bind_host",
+    "env_route_cap",
+    "hourly_burn_cap_usd",
+    "is_enabled",
+    "lease_expiry_s",
+    "lease_overrun_multiplier",
+    "nonce_ledger_capacity",
+    "register_aegis_flags",
+    "route_caps_usd",
+    "session_cap_usd",
+    "session_token_ttl_s",
+    "wal_path",
+]

--- a/backend/core/ouroboros/aegis/lease.py
+++ b/backend/core/ouroboros/aegis/lease.py
@@ -1,0 +1,433 @@
+"""Lease + SessionToken cryptographic surface.
+
+Per Slice Aegis-1 binding correction #1, the auth lifecycle is **Model B**:
+
+  1. Aegis mints a single-use bootstrap PSK at boot.
+  2. JARVIS calls ``POST /session/establish`` with ``Authorization:
+     Bearer <BOOTSTRAP_PSK>``. Aegis validates, marks the PSK consumed
+     irrevocably, mints a **scoped session token** (HMAC, TTL).
+  3. JARVIS calls ``POST /lease/acquire`` with ``Authorization: Bearer
+     <SESSION_TOKEN>``. Aegis validates the session token, mints a
+     **lease token** describing a single upcoming provider call.
+  4. (Slice 2) JARVIS calls a provider endpoint via Aegis with the
+     lease token as ``X-JARVIS-Lease``. Aegis redeems the lease once.
+
+Per binding correction #3, the HMAC key K never appears in:
+
+  * ``json.dumps`` output (verdicts/tokens never embed it)
+  * ``repr`` / ``str`` / log lines (no formatter ever sees it)
+  * HTTP responses (no route handler returns it)
+  * Any non-aegis module's namespace (passed only into this module's
+    functions from the daemon's per-instance state)
+
+K is a per-instance argument to every signing/validation function in
+this module. The daemon constructs K once at boot via
+``secrets.token_bytes(32)`` and holds it in its aiohttp ``Application``
+state. AST-pinned: no module-level K variable.
+
+Token wire format (lighter JWT, no algorithm flexibility — single
+algorithm baked in to avoid the ``alg=none`` family of JWT footguns):
+
+    <base64url(compact-json-payload)>.<base64url(HMAC-SHA256(K, payload_b64))>
+
+Compact JSON: ``json.dumps(d, separators=(",", ":"), sort_keys=True)``
+so token bytes are deterministic for the same payload (tests can pin
+exact strings if useful).
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import enum
+import hashlib
+import hmac
+import json
+import secrets
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Deque, Dict, Optional, Set
+
+
+LEASE_SCHEMA_VERSION: str = "aegis_lease.1"
+
+# Default session-token TTL: 1 hour. Operators tighten via env at
+# daemon boot; the daemon passes the effective value into mint calls.
+DEFAULT_SESSION_TOKEN_TTL_S: int = 3600
+
+# Default lease TTL: 5 minutes. Long enough for a provider call to
+# complete including extended-thinking budgets; short enough that
+# leaked leases self-expire quickly.
+DEFAULT_LEASE_TTL_S: int = 300
+
+# Default nonce ledger capacity. Bounded to prevent unbounded memory
+# growth under replay-probe load. Drop-oldest eviction. At 60s burst
+# of 100 ops/s the LRU comfortably holds 1 minute of nonces.
+DEFAULT_NONCE_LEDGER_CAPACITY: int = 8192
+
+
+# ---------------------------------------------------------------------------
+# Verdict taxonomy — frozen closed sets per §33 / §43 discipline.
+# ---------------------------------------------------------------------------
+
+
+class TokenVerdictKind(str, enum.Enum):
+    """Closed 5-value taxonomy for any token validation outcome."""
+
+    VALID = "valid"
+    INVALID_FORMAT = "invalid_format"
+    INVALID_SIGNATURE = "invalid_signature"
+    EXPIRED = "expired"
+    REPLAYED = "replayed"
+
+
+@dataclass(frozen=True)
+class TokenVerdict:
+    """Generic token validation result. Used by both session-token
+    and lease-token validation. Carries the decoded payload only on
+    ``VALID``; on failure payload is ``None`` (we never leak parsed
+    fields from an invalid token)."""
+
+    kind: TokenVerdictKind
+    payload: Optional[Dict[str, Any]] = None
+    detail: Optional[str] = None  # short human-readable note; never K
+
+
+# ---------------------------------------------------------------------------
+# SessionToken + Lease payloads
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SessionToken:
+    """Scoped session-token payload. Issued by /session/establish.
+
+    Equality + hash are content-based (frozen). §33.5 lossless roundtrip
+    via to_dict/from_dict.
+    """
+
+    jti: str          # token id; nonce for the session-token ledger
+    issued_at: float
+    expires_at: float
+    schema_version: str = LEASE_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": "session",
+            "jti": self.jti,
+            "iat": self.issued_at,
+            "exp": self.expires_at,
+            "v": self.schema_version,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SessionToken":
+        if d.get("kind") != "session":
+            raise ValueError(f"payload kind != session: {d.get('kind')!r}")
+        return cls(
+            jti=str(d["jti"]),
+            issued_at=float(d["iat"]),
+            expires_at=float(d["exp"]),
+            schema_version=str(d.get("v", LEASE_SCHEMA_VERSION)),
+        )
+
+
+@dataclass(frozen=True)
+class Lease:
+    """Lease payload — describes one upcoming provider call.
+
+    ``causal_lineage_hash`` is a stub for Arc #4 (Causal-Lineage Depth-N
+    stamp). Slice 1 accepts opaque str; Arc #4 will validate it against
+    the inherited hash chain.
+    """
+
+    nonce: str
+    op_id: str
+    route: str                     # IMMEDIATE | STANDARD | COMPLEX | BACKGROUND | SPECULATIVE
+    estimated_cost_usd: float
+    max_cost_usd: float
+    causal_lineage_hash: str
+    issued_at: float
+    expires_at: float
+    schema_version: str = LEASE_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": "lease",
+            "nonce": self.nonce,
+            "op_id": self.op_id,
+            "route": self.route,
+            "est_usd": self.estimated_cost_usd,
+            "max_usd": self.max_cost_usd,
+            "lineage": self.causal_lineage_hash,
+            "iat": self.issued_at,
+            "exp": self.expires_at,
+            "v": self.schema_version,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "Lease":
+        if d.get("kind") != "lease":
+            raise ValueError(f"payload kind != lease: {d.get('kind')!r}")
+        return cls(
+            nonce=str(d["nonce"]),
+            op_id=str(d["op_id"]),
+            route=str(d["route"]),
+            estimated_cost_usd=float(d["est_usd"]),
+            max_cost_usd=float(d["max_usd"]),
+            causal_lineage_hash=str(d["lineage"]),
+            issued_at=float(d["iat"]),
+            expires_at=float(d["exp"]),
+            schema_version=str(d.get("v", LEASE_SCHEMA_VERSION)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Token wire codec (lighter JWT-shape).
+# ---------------------------------------------------------------------------
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    # Re-pad to multiple of 4 — urlsafe_b64decode requires it.
+    pad = (-len(s)) % 4
+    return base64.urlsafe_b64decode(s + ("=" * pad))
+
+
+def _canonical_json(payload: Dict[str, Any]) -> bytes:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _sign(K: bytes, payload_b64: str) -> str:
+    """Compute HMAC-SHA256(K, payload_b64).encode and base64-url-encode.
+
+    Signs the encoded payload bytes rather than the raw JSON — defends
+    against any future JSON canonicalization drift between mint and
+    validate.
+    """
+    mac = hmac.new(K, payload_b64.encode("ascii"), hashlib.sha256).digest()
+    return _b64url_encode(mac)
+
+
+def _encode_token(K: bytes, payload: Dict[str, Any]) -> str:
+    payload_b64 = _b64url_encode(_canonical_json(payload))
+    sig_b64 = _sign(K, payload_b64)
+    return f"{payload_b64}.{sig_b64}"
+
+
+def _decode_token(K: bytes, token: str) -> TokenVerdict:
+    """Decode + verify a token. Returns a verdict; never raises.
+
+    Failure modes (closed):
+      * INVALID_FORMAT — not <b64>.<b64>, base64 decode fails, JSON
+        not a dict
+      * INVALID_SIGNATURE — HMAC mismatch (constant-time compare)
+      * (caller checks EXPIRED + REPLAYED — we just decode here)
+    """
+    if not isinstance(token, str) or token.count(".") != 1:
+        return TokenVerdict(TokenVerdictKind.INVALID_FORMAT, detail="missing dot")
+
+    payload_b64, sig_b64 = token.split(".", 1)
+    if not payload_b64 or not sig_b64:
+        return TokenVerdict(TokenVerdictKind.INVALID_FORMAT, detail="empty segment")
+
+    expected_sig = _sign(K, payload_b64)
+    if not hmac.compare_digest(expected_sig, sig_b64):
+        return TokenVerdict(TokenVerdictKind.INVALID_SIGNATURE)
+
+    try:
+        payload_bytes = _b64url_decode(payload_b64)
+        payload = json.loads(payload_bytes.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return TokenVerdict(TokenVerdictKind.INVALID_FORMAT, detail="payload decode")
+
+    if not isinstance(payload, dict):
+        return TokenVerdict(TokenVerdictKind.INVALID_FORMAT, detail="payload not dict")
+
+    return TokenVerdict(TokenVerdictKind.VALID, payload=payload)
+
+
+# ---------------------------------------------------------------------------
+# SessionToken minting + validation
+# ---------------------------------------------------------------------------
+
+
+def mint_session_token(
+    K: bytes,
+    *,
+    now_s: float,
+    ttl_s: int = DEFAULT_SESSION_TOKEN_TTL_S,
+) -> tuple[str, SessionToken]:
+    """Mint a fresh session token signed by ``K``.
+
+    Returns ``(wire_token, payload)`` — caller (the daemon) stores
+    ``payload.jti`` in its active-sessions ledger and returns the wire
+    string to the client.
+    """
+    jti = secrets.token_urlsafe(16)
+    payload = SessionToken(
+        jti=jti,
+        issued_at=now_s,
+        expires_at=now_s + float(ttl_s),
+    )
+    wire = _encode_token(K, payload.to_dict())
+    return wire, payload
+
+
+def validate_session_token(
+    K: bytes,
+    token: str,
+    *,
+    now_s: float,
+    active_jti: Set[str],
+) -> TokenVerdict:
+    """Validate a session token. Returns a verdict; never raises.
+
+    ``active_jti`` is the daemon's set of currently-valid session ids.
+    A token whose ``jti`` is not in the set is treated as REPLAYED
+    (the daemon revoked it; e.g., session expired and was reaped).
+    """
+    verdict = _decode_token(K, token)
+    if verdict.kind is not TokenVerdictKind.VALID:
+        return verdict
+    assert verdict.payload is not None  # for type checker; VALID guarantees it
+
+    try:
+        st = SessionToken.from_dict(verdict.payload)
+    except (KeyError, ValueError, TypeError) as exc:
+        return TokenVerdict(TokenVerdictKind.INVALID_FORMAT, detail=str(exc))
+
+    if now_s >= st.expires_at:
+        return TokenVerdict(TokenVerdictKind.EXPIRED, detail=f"exp={st.expires_at}")
+
+    if st.jti not in active_jti:
+        return TokenVerdict(TokenVerdictKind.REPLAYED, detail="jti not active")
+
+    return TokenVerdict(TokenVerdictKind.VALID, payload=verdict.payload)
+
+
+# ---------------------------------------------------------------------------
+# Lease minting + validation
+# ---------------------------------------------------------------------------
+
+
+def mint_lease_token(K: bytes, lease: Lease) -> str:
+    """Encode a fully-formed ``Lease`` as a wire token signed by K."""
+    return _encode_token(K, lease.to_dict())
+
+
+def validate_lease_token(
+    K: bytes,
+    token: str,
+    *,
+    now_s: float,
+    nonce_ledger: "NonceLedger",
+) -> TokenVerdict:
+    """Validate a lease token. Returns a verdict; never raises.
+
+    Replay protection: nonces are registered into the ledger on the
+    FIRST successful validation. A second validation of the same lease
+    is rejected as REPLAYED.
+
+    Note: ``validate_lease_token`` records the nonce as redeemed. This
+    is the policy boundary for "a lease is used exactly once."
+    """
+    verdict = _decode_token(K, token)
+    if verdict.kind is not TokenVerdictKind.VALID:
+        return verdict
+    assert verdict.payload is not None
+
+    try:
+        lease = Lease.from_dict(verdict.payload)
+    except (KeyError, ValueError, TypeError) as exc:
+        return TokenVerdict(TokenVerdictKind.INVALID_FORMAT, detail=str(exc))
+
+    if now_s >= lease.expires_at:
+        return TokenVerdict(TokenVerdictKind.EXPIRED, detail=f"exp={lease.expires_at}")
+
+    # Single-redeem invariant.
+    if not nonce_ledger.try_register(lease.nonce):
+        return TokenVerdict(TokenVerdictKind.REPLAYED, detail="nonce already redeemed")
+
+    return TokenVerdict(TokenVerdictKind.VALID, payload=verdict.payload)
+
+
+# ---------------------------------------------------------------------------
+# Bounded nonce ledger
+# ---------------------------------------------------------------------------
+
+
+class NonceLedger:
+    """Bounded FIFO set of redeemed nonces. Async-safe.
+
+    Drop-oldest eviction when capacity is exceeded — older nonces
+    "expire" by ejection rather than wall-clock. Safe because lease
+    TTL is short (5 minutes default) and capacity (8192) sustains
+    ~27 redemptions/sec for the entire 5-minute window without ever
+    evicting a still-live lease.
+
+    Capacity is env-tunable via daemon construction; do not import env
+    here (single-seam discipline — daemon reads env, passes value in).
+    """
+
+    def __init__(self, *, capacity: int = DEFAULT_NONCE_LEDGER_CAPACITY) -> None:
+        if capacity < 1:
+            raise ValueError(f"NonceLedger capacity must be >= 1, got {capacity}")
+        self._capacity: int = int(capacity)
+        self._set: Set[str] = set()
+        self._fifo: Deque[str] = deque()
+        self._lock = asyncio.Lock()
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    def size(self) -> int:
+        # Read-only; no lock needed for a single int read on CPython.
+        return len(self._fifo)
+
+    def try_register_sync(self, nonce: str) -> bool:
+        """Sync variant for non-async callers (tests). Returns True if
+        the nonce was newly registered, False if it was already present
+        (replay)."""
+        if nonce in self._set:
+            return False
+        self._set.add(nonce)
+        self._fifo.append(nonce)
+        while len(self._fifo) > self._capacity:
+            evicted = self._fifo.popleft()
+            self._set.discard(evicted)
+        return True
+
+    def try_register(self, nonce: str) -> bool:
+        """Async-API alias. NonceLedger does not actually need the
+        lock for try_register because set+deque CPython operations
+        are GIL-atomic at this granularity, and the daemon serializes
+        validation through a single event loop. Lock retained for
+        future multi-task callers and audit clarity."""
+        # Synchronous body is fine; provided for symmetry with future
+        # I/O-bearing operations. Validate functions call this from
+        # within request handlers (event loop), so no contention.
+        return self.try_register_sync(nonce)
+
+    def contains(self, nonce: str) -> bool:
+        return nonce in self._set
+
+
+__all__ = [
+    "DEFAULT_LEASE_TTL_S",
+    "DEFAULT_NONCE_LEDGER_CAPACITY",
+    "DEFAULT_SESSION_TOKEN_TTL_S",
+    "LEASE_SCHEMA_VERSION",
+    "Lease",
+    "NonceLedger",
+    "SessionToken",
+    "TokenVerdict",
+    "TokenVerdictKind",
+    "mint_lease_token",
+    "mint_session_token",
+    "validate_lease_token",
+    "validate_session_token",
+]

--- a/backend/core/ouroboros/aegis/preflight.py
+++ b/backend/core/ouroboros/aegis/preflight.py
@@ -1,0 +1,320 @@
+"""Harness preflight — spawn Aegis subprocess + scrub JARVIS env.
+
+This module is the SINGLE seam by which the harness wires up Aegis.
+The outer entry point (``scripts/ouroboros_battle_test.py``) calls
+:func:`aegis_preflight` **before** importing any provider module
+(otherwise providers would already have captured the credential env
+vars into module-level constants — e.g.,
+``doubleword_provider.py:43`` reads ``DOUBLEWORD_API_KEY`` at import
+time).
+
+Bootstrap dance (matches the §43 spine):
+
+  1. Generate a unique bootstrap-out path under :func:`bootstrap_dir`.
+  2. Snapshot upstream credentials currently in the harness env.
+  3. Spawn the Aegis daemon subprocess (``python -m
+     backend.core.ouroboros.aegis.daemon``) with credentials in
+     **its** env. Use ``close_fds=True`` and ``stdin=DEVNULL`` so the
+     subprocess starts clean.
+  4. Wait (poll-with-backoff) for the daemon to write its bootstrap
+     payload to the chosen path. Timeout via
+     ``JARVIS_AEGIS_BOOTSTRAP_TIMEOUT_S``.
+  5. Read the payload, unlink it (forensic-trace-free).
+  6. Validate ``expires_at`` is still in the future (rejects stale).
+  7. Scrub the upstream credential env vars from the harness env.
+  8. Assert post-scrub absence (binding-correction #6 hard invariant).
+  9. Return the preflight result for the harness to consume.
+
+Default-off: if :func:`flags.is_enabled` returns False, the function
+short-circuits with a SKIPPED result and zero behavior change.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import os
+import secrets
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional
+
+from backend.core.ouroboros.aegis.bootstrap import (
+    BootstrapPayload,
+    read_and_unlink_payload,
+)
+from backend.core.ouroboros.aegis.credential_registry import (
+    upstream_credential_env_vars,
+)
+from backend.core.ouroboros.aegis.env_scrub import (
+    UpstreamCredentialPresentError,
+    assert_no_upstream_credentials,
+    scrub_upstream_credentials,
+)
+from backend.core.ouroboros.aegis.flags import (
+    bootstrap_dir,
+    bootstrap_timeout_s,
+    is_enabled,
+    register_aegis_flags,
+)
+
+logger = logging.getLogger(__name__)
+
+
+PREFLIGHT_SCHEMA_VERSION: str = "aegis_preflight.1"
+
+
+class PreflightOutcome(str, enum.Enum):
+    """Closed 5-value outcome taxonomy for the preflight."""
+
+    SKIPPED_DISABLED = "skipped_disabled"
+    READY = "ready"
+    FAILED_SPAWN = "failed_spawn"
+    FAILED_BOOTSTRAP_TIMEOUT = "failed_bootstrap_timeout"
+    FAILED_CREDENTIAL_SCRUB = "failed_credential_scrub"
+
+
+@dataclass(frozen=True)
+class AegisPreflightResult:
+    """Frozen preflight result. Lossless §33.5 to_dict/from_dict.
+
+    On non-READY outcomes, ``aegis_url`` / ``bootstrap_psk`` are None
+    and ``subprocess_pid`` is None. The harness inspects ``outcome``
+    to decide whether to proceed (READY) or abort the session
+    (any FAILED_* — Aegis is enabled but unhealthy is fatal per the
+    operator's binding directive "Aegis death = session ends").
+    """
+
+    outcome: PreflightOutcome
+    aegis_url: Optional[str] = None
+    bootstrap_psk: Optional[str] = None
+    subprocess_pid: Optional[int] = None
+    detail: Optional[str] = None
+    schema_version: str = PREFLIGHT_SCHEMA_VERSION
+
+    def to_dict(self) -> dict:
+        return {
+            "outcome": self.outcome.value,
+            "aegis_url": self.aegis_url,
+            # NEVER include bootstrap_psk in to_dict output — it's a
+            # credential. Caller has access via the dataclass field
+            # directly; we don't put it in any payload that might be
+            # logged or persisted.
+            "subprocess_pid": self.subprocess_pid,
+            "detail": self.detail,
+            "schema_version": self.schema_version,
+        }
+
+
+def _unique_bootstrap_path(dir_: Path) -> Path:
+    """Generate a fresh bootstrap-out path with high-entropy suffix.
+
+    Random suffix means concurrent harness invocations (e.g., parallel
+    test runs) never collide on the O_EXCL atomic write.
+    """
+    dir_.mkdir(parents=True, exist_ok=True, mode=0o700)
+    suffix = secrets.token_hex(8)
+    return dir_ / f"aegis-{os.getpid()}-{suffix}.json"
+
+
+def _spawn_daemon(
+    *,
+    bootstrap_out: Path,
+    credentials: Mapping[str, str],
+    bind_host_override: Optional[str] = None,
+) -> subprocess.Popen:
+    """Spawn the Aegis daemon subprocess. Caller owns the lifecycle."""
+    # Build the subprocess env: start from the current env (so PATH,
+    # PYTHONPATH, etc. survive) BUT inject the credentials (which the
+    # harness env is about to lose).
+    sub_env = dict(os.environ)
+    sub_env.update(credentials)
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "backend.core.ouroboros.aegis.daemon",
+        "--bootstrap-out",
+        str(bootstrap_out),
+    ]
+    if bind_host_override:
+        cmd.extend(["--bind-host", bind_host_override])
+
+    return subprocess.Popen(
+        cmd,
+        env=sub_env,
+        stdin=subprocess.DEVNULL,
+        # stdout/stderr go to the harness's tty/log — operator can
+        # tail them. The daemon's logging format is prefixed
+        # `aegis-daemon` for easy grep.
+        close_fds=True,
+    )
+
+
+async def _await_bootstrap_payload(
+    path: Path,
+    *,
+    timeout_s: int,
+    proc: subprocess.Popen,
+) -> Optional[BootstrapPayload]:
+    """Poll for the bootstrap-payload file to appear.
+
+    Returns the parsed payload on success, None on timeout or
+    subprocess death.
+
+    Polls with exponential backoff capped at 100ms — fast enough
+    that a quick boot (<50ms) is observed promptly, slow enough
+    that a hung boot doesn't burn CPU.
+    """
+    deadline = time.monotonic() + float(timeout_s)
+    backoff = 0.010  # 10ms initial
+    max_backoff = 0.100
+
+    while time.monotonic() < deadline:
+        # Subprocess crashed?
+        ret = proc.poll()
+        if ret is not None:
+            logger.error(
+                "[AegisPreflight] daemon subprocess exited prematurely "
+                "with code %d before writing payload", ret,
+            )
+            return None
+
+        if path.exists():
+            try:
+                payload = read_and_unlink_payload(path)
+                return payload
+            except (FileNotFoundError, ValueError, OSError) as exc:
+                logger.warning(
+                    "[AegisPreflight] payload at %s failed to parse: %s",
+                    path, exc,
+                )
+                # Don't loop on a malformed payload — return None
+                # so the caller can treat as failure.
+                return None
+
+        await asyncio.sleep(backoff)
+        backoff = min(max_backoff, backoff * 1.5)
+
+    return None
+
+
+async def aegis_preflight(
+    *,
+    env: Optional[dict] = None,
+    bind_host_override: Optional[str] = None,
+) -> AegisPreflightResult:
+    """Run the full Aegis preflight handshake.
+
+    ``env`` defaults to ``os.environ``. When passed explicitly (tests),
+    the scrub mutates that dict only — handy for asserting "JARVIS
+    env is empty of upstream creds post-preflight" without touching
+    the real environment.
+
+    Always async (we await the bootstrap-payload poll). On success,
+    returns READY with ``aegis_url`` + ``bootstrap_psk`` + ``pid``.
+    On any failure, returns a FAILED_* outcome with ``detail``.
+    Never raises.
+    """
+    target_env = os.environ if env is None else env
+
+    register_aegis_flags()  # idempotent
+
+    if not is_enabled():
+        return AegisPreflightResult(
+            outcome=PreflightOutcome.SKIPPED_DISABLED,
+            detail="JARVIS_AEGIS_ENABLED is false (Slice 1 default)",
+        )
+
+    # Snapshot credentials — we need them to hand to the subprocess
+    # BEFORE we strip them from our env.
+    creds = {
+        name: target_env[name]
+        for name in upstream_credential_env_vars()
+        if name in target_env
+    }
+
+    bootstrap_out = _unique_bootstrap_path(bootstrap_dir())
+
+    try:
+        proc = _spawn_daemon(
+            bootstrap_out=bootstrap_out,
+            credentials=creds,
+            bind_host_override=bind_host_override,
+        )
+    except (OSError, ValueError) as exc:
+        return AegisPreflightResult(
+            outcome=PreflightOutcome.FAILED_SPAWN,
+            detail=f"subprocess spawn failed: {exc}",
+        )
+
+    payload = await _await_bootstrap_payload(
+        bootstrap_out, timeout_s=bootstrap_timeout_s(), proc=proc,
+    )
+    if payload is None:
+        try:
+            proc.terminate()
+        except OSError:
+            pass
+        return AegisPreflightResult(
+            outcome=PreflightOutcome.FAILED_BOOTSTRAP_TIMEOUT,
+            subprocess_pid=proc.pid,
+            detail=(
+                f"daemon did not write bootstrap payload within "
+                f"{bootstrap_timeout_s()}s"
+            ),
+        )
+
+    # Defense: reject a stale payload (a previous boot's leftover the
+    # daemon somehow re-served). Should never happen given O_EXCL +
+    # unique-path, but cheap to check.
+    if time.time() >= payload.expires_at:
+        try:
+            proc.terminate()
+        except OSError:
+            pass
+        return AegisPreflightResult(
+            outcome=PreflightOutcome.FAILED_BOOTSTRAP_TIMEOUT,
+            subprocess_pid=proc.pid,
+            detail="bootstrap payload expired before harness read it",
+        )
+
+    # Scrub credentials from the harness env. ``creds`` already holds
+    # the values; the env is now safe to lose them.
+    scrub_upstream_credentials(target_env)
+    try:
+        assert_no_upstream_credentials(target_env)
+    except UpstreamCredentialPresentError as exc:
+        try:
+            proc.terminate()
+        except OSError:
+            pass
+        return AegisPreflightResult(
+            outcome=PreflightOutcome.FAILED_CREDENTIAL_SCRUB,
+            subprocess_pid=proc.pid,
+            detail=str(exc),
+        )
+
+    # Expose Aegis coordinates to JARVIS via env. Slice 2's provider
+    # rewrite will consume these.
+    target_env["JARVIS_AEGIS_URL"] = payload.aegis_url
+    target_env["JARVIS_AEGIS_BOOTSTRAP_PSK"] = payload.bootstrap_psk
+
+    return AegisPreflightResult(
+        outcome=PreflightOutcome.READY,
+        aegis_url=payload.aegis_url,
+        bootstrap_psk=payload.bootstrap_psk,
+        subprocess_pid=payload.daemon_pid,
+        detail=f"daemon pid={payload.daemon_pid}",
+    )
+
+
+__all__ = [
+    "AegisPreflightResult",
+    "PREFLIGHT_SCHEMA_VERSION",
+    "PreflightOutcome",
+    "aegis_preflight",
+]

--- a/backend/core/ouroboros/aegis/spend_wal.py
+++ b/backend/core/ouroboros/aegis/spend_wal.py
@@ -1,0 +1,260 @@
+"""Spend WAL — Aegis-owned append-only audit ledger.
+
+Composes ``governance/cross_process_jsonl.flock_append_line`` verbatim
+(per binding correction "leverage the existing cross_process_jsonl for
+atomic WAL appending to ensure the spend ledger is mathematically
+sealed"). No new locking primitive. No new file-handle discipline.
+
+Posture:
+
+  * **Aegis-owned.** WAL path lives under ``.jarvis/aegis/`` which
+    Slice 2 will add to the JARVIS-side ``FORBIDDEN_PATH`` list.
+    From JARVIS's perspective, the WAL is unreachable.
+  * **Authoritative.** Every lease that admits and every reconciliation
+    that updates the in-memory state machine writes here. Crash
+    recovery replays the WAL.
+  * **Append-only.** No update, no delete, no rotation in Slice 1.
+    Operator-paced rotation is a future arc (composes Anti-Venom
+    corpus-rotation patterns).
+  * **NEVER raises.** flock_append_line is contract-bound to return
+    False on any failure; we surface that to the caller as a bool.
+
+Schema v1 (one JSON object per line):
+
+    {
+      "kind": "admit" | "reconcile" | "boot",
+      "schema_version": "aegis_spend_wal.1",
+      "ts": <unix epoch float>,
+      "lease_nonce": "<str>" | null,
+      "op_id": "<str>" | null,
+      "route": "<str>" | null,
+      "estimated_cost_usd": <float> | null,
+      "actual_cost_usd": <float> | null,
+      "reserve_cost_usd": <float> | null,
+      "detail": "<str>" | null
+    }
+
+"boot" rows mark the daemon's lifecycle (boot + clean-shutdown). They
+let crash recovery distinguish "WAL is from previous session" vs.
+"WAL is mid-session" without parsing every preceding row.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from backend.core.ouroboros.governance.cross_process_jsonl import flock_append_line
+
+logger = logging.getLogger(__name__)
+
+
+SPEND_WAL_SCHEMA_VERSION: str = "aegis_spend_wal.1"
+
+
+class SpendEntryKind(str, enum.Enum):
+    """Closed 3-value taxonomy of WAL row kinds in Slice 1."""
+
+    BOOT = "boot"
+    ADMIT = "admit"
+    RECONCILE = "reconcile"
+
+
+@dataclass(frozen=True)
+class SpendEntry:
+    """Single WAL row. Frozen + §33.5 to_dict/from_dict.
+
+    Optional fields are ``None`` when not applicable to the entry's
+    kind (e.g., BOOT has no lease_nonce). Use the convenience
+    constructors below.
+    """
+
+    kind: SpendEntryKind
+    ts: float
+    lease_nonce: Optional[str] = None
+    op_id: Optional[str] = None
+    route: Optional[str] = None
+    estimated_cost_usd: Optional[float] = None
+    actual_cost_usd: Optional[float] = None
+    reserve_cost_usd: Optional[float] = None
+    detail: Optional[str] = None
+    schema_version: str = SPEND_WAL_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "schema_version": self.schema_version,
+            "ts": self.ts,
+            "lease_nonce": self.lease_nonce,
+            "op_id": self.op_id,
+            "route": self.route,
+            "estimated_cost_usd": self.estimated_cost_usd,
+            "actual_cost_usd": self.actual_cost_usd,
+            "reserve_cost_usd": self.reserve_cost_usd,
+            "detail": self.detail,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "SpendEntry":
+        kind_raw = str(d["kind"])
+        try:
+            kind = SpendEntryKind(kind_raw)
+        except ValueError as exc:
+            raise ValueError(f"unknown spend entry kind: {kind_raw!r}") from exc
+        return cls(
+            kind=kind,
+            ts=float(d["ts"]),
+            lease_nonce=_optional_str(d.get("lease_nonce")),
+            op_id=_optional_str(d.get("op_id")),
+            route=_optional_str(d.get("route")),
+            estimated_cost_usd=_optional_float(d.get("estimated_cost_usd")),
+            actual_cost_usd=_optional_float(d.get("actual_cost_usd")),
+            reserve_cost_usd=_optional_float(d.get("reserve_cost_usd")),
+            detail=_optional_str(d.get("detail")),
+            schema_version=str(d.get("schema_version", SPEND_WAL_SCHEMA_VERSION)),
+        )
+
+
+def _optional_str(v: Any) -> Optional[str]:
+    return None if v is None else str(v)
+
+
+def _optional_float(v: Any) -> Optional[float]:
+    return None if v is None else float(v)
+
+
+# ---------------------------------------------------------------------------
+# Convenience constructors
+# ---------------------------------------------------------------------------
+
+
+def boot_entry(*, ts: float, detail: str) -> SpendEntry:
+    return SpendEntry(kind=SpendEntryKind.BOOT, ts=ts, detail=detail)
+
+
+def admit_entry(
+    *,
+    ts: float,
+    lease_nonce: str,
+    op_id: str,
+    route: str,
+    estimated_cost_usd: float,
+    reserve_cost_usd: float,
+) -> SpendEntry:
+    return SpendEntry(
+        kind=SpendEntryKind.ADMIT,
+        ts=ts,
+        lease_nonce=lease_nonce,
+        op_id=op_id,
+        route=route,
+        estimated_cost_usd=estimated_cost_usd,
+        reserve_cost_usd=reserve_cost_usd,
+    )
+
+
+def reconcile_entry(
+    *,
+    ts: float,
+    lease_nonce: str,
+    op_id: str,
+    route: str,
+    actual_cost_usd: float,
+    reserve_cost_usd: float,
+) -> SpendEntry:
+    return SpendEntry(
+        kind=SpendEntryKind.RECONCILE,
+        ts=ts,
+        lease_nonce=lease_nonce,
+        op_id=op_id,
+        route=route,
+        actual_cost_usd=actual_cost_usd,
+        reserve_cost_usd=reserve_cost_usd,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Append + replay
+# ---------------------------------------------------------------------------
+
+
+def append_entry_sync(wal_path: Path, entry: SpendEntry) -> bool:
+    """Append ``entry`` to ``wal_path`` under flock. Returns True on
+    success, False on any failure (lock timeout, write error, etc.).
+    NEVER raises."""
+    line = json.dumps(entry.to_dict(), separators=(",", ":"), sort_keys=True)
+    return flock_append_line(Path(wal_path), line)
+
+
+async def append_entry(wal_path: Path, entry: SpendEntry) -> bool:
+    """Async wrapper. flock_append_line is sync-blocking but its
+    critical section is microsecond-scale; we route it through a
+    worker thread anyway so a busy filesystem cannot stall the event
+    loop. Returns True on success, False on any failure."""
+    return await asyncio.to_thread(append_entry_sync, wal_path, entry)
+
+
+def replay_wal(wal_path: Path) -> List[SpendEntry]:
+    """Read ``wal_path`` line-by-line and reconstruct entries.
+
+    Malformed lines (JSON parse error, missing required field, unknown
+    kind) are SKIPPED with a DEBUG log. WAL recovery is best-effort —
+    a corrupt tail (e.g., from SIGKILL mid-write) must not strand the
+    daemon at boot. Caller (BudgetStateMachine) tolerates partial
+    state by treating unknown spend as un-debited (fail-safe-by-loss).
+
+    Returns entries in WAL order. Empty WAL or missing file returns
+    empty list (not an error — first-ever boot)."""
+    target = Path(wal_path)
+    if not target.exists():
+        return []
+
+    entries: List[SpendEntry] = []
+    try:
+        with target.open("r", encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, start=1):
+                raw = raw.rstrip("\n")
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    logger.debug(
+                        "[AegisSpendWAL] skip malformed line %d: %s",
+                        lineno, exc,
+                    )
+                    continue
+                if not isinstance(obj, dict):
+                    logger.debug(
+                        "[AegisSpendWAL] skip non-object line %d", lineno,
+                    )
+                    continue
+                try:
+                    entries.append(SpendEntry.from_dict(obj))
+                except (KeyError, ValueError, TypeError) as exc:
+                    logger.debug(
+                        "[AegisSpendWAL] skip unparseable entry line %d: %s",
+                        lineno, exc,
+                    )
+                    continue
+    except OSError as exc:
+        logger.debug("[AegisSpendWAL] read failed at %s: %s", target, exc)
+        return entries
+
+    return entries
+
+
+__all__ = [
+    "SPEND_WAL_SCHEMA_VERSION",
+    "SpendEntry",
+    "SpendEntryKind",
+    "admit_entry",
+    "append_entry",
+    "append_entry_sync",
+    "boot_entry",
+    "reconcile_entry",
+    "replay_wal",
+]

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -1335,6 +1335,38 @@ def main() -> None:
         _boot_timer = None
 
     # ------------------------------------------------------------------
+    # Aegis preflight (Arc #1 — out-of-process egress + budget chokepoint)
+    # ------------------------------------------------------------------
+    # Gated on JARVIS_AEGIS_ENABLED. Slice 1 dark substrate, default
+    # FALSE — returns SKIPPED_DISABLED with zero behavior change. When
+    # operator opts in, spawns the Aegis subprocess, atomic-reads its
+    # bootstrap payload, scrubs upstream credentials from this process,
+    # and exposes JARVIS_AEGIS_URL + JARVIS_AEGIS_BOOTSTRAP_PSK for the
+    # Slice 2 provider rewire. Runs BEFORE the harness import so any
+    # provider module that captures creds at import time (e.g.,
+    # doubleword_provider.py:43) sees a scrubbed env.
+    from backend.core.ouroboros.aegis.preflight import (
+        PreflightOutcome as _AegisPreflightOutcome,
+        aegis_preflight as _aegis_preflight,
+    )
+    _aegis_result = asyncio.run(_aegis_preflight())
+    if _aegis_result.outcome not in (
+        _AegisPreflightOutcome.READY,
+        _AegisPreflightOutcome.SKIPPED_DISABLED,
+    ):
+        print(
+            f"[Aegis] preflight failed: {_aegis_result.outcome.value} — "
+            f"{_aegis_result.detail}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if _aegis_result.outcome is _AegisPreflightOutcome.READY:
+        print(
+            f"[Aegis] daemon ready at {_aegis_result.aegis_url} "
+            f"(pid={_aegis_result.subprocess_pid})"
+        )
+
+    # ------------------------------------------------------------------
     # Build config + harness
     # ------------------------------------------------------------------
     if _boot_timer is not None:

--- a/tests/aegis/test_ast_pins.py
+++ b/tests/aegis/test_ast_pins.py
@@ -1,0 +1,245 @@
+"""AST pins for Slice Aegis-1 binding directives.
+
+Pin set (each is a deliberate Slice-1 invariant):
+
+  1. Aegis daemon has NO ``/v1/*`` routes — Slice 1 does NOT forward
+     provider traffic. AST-pin enforced at the route-registration site.
+  2. ``ImmutableBudgetStateMachine`` has NO public mutator beyond
+     ``admit`` / ``reconcile`` / ``tighten`` (the audited surface).
+  3. The HMAC key ``K`` never appears in any ``return`` payload of a
+     route handler, never in ``logger.*`` / ``logging.*`` calls,
+     never in ``json.dumps`` / ``repr`` / ``str.format`` — only
+     passed as positional arg to lease minting/validation functions.
+  4. No ``anthropic`` / ``openai`` SDK import inside the ``aegis``
+     package (forwarding is Slice 2; substrate stays SDK-free).
+  5. ``RejectReason`` taxonomy is exactly the 6-value §43.6.1 set.
+  6. ``credential_registry`` exports exactly the central frozenset
+     of upstream credential env var names.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+AEGIS_ROOT = Path(__file__).resolve().parents[2] / "backend" / "core" / "ouroboros" / "aegis"
+DAEMON_FILE = AEGIS_ROOT / "daemon.py"
+STATE_MACHINE_FILE = AEGIS_ROOT / "budget_state_machine.py"
+
+
+def _aegis_modules() -> list:
+    return sorted(p for p in AEGIS_ROOT.glob("*.py") if p.name != "__init__.py")
+
+
+# ---------------------------------------------------------------------------
+# Pin 1: NO /v1/* routes in Slice 1
+# ---------------------------------------------------------------------------
+
+
+def test_ast_pin_no_v1_routes_in_daemon():
+    """daemon.py must register NO route whose path starts with /v1/.
+    Slice 2 will remove this pin (or scope it more narrowly) when it
+    adds /v1/messages + /v1/chat/completions."""
+    tree = ast.parse(DAEMON_FILE.read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match calls like app.router.add_post("/path", ...)
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if not node.func.attr.startswith("add_"):
+            continue
+        # First arg should be the path string literal.
+        if not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            assert not first.value.startswith("/v1/"), (
+                f"daemon.py registers a /v1/* route ({first.value!r}) — "
+                f"this is forbidden in Slice 1. Slice 2 will add provider "
+                f"forwarding."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Pin 2: ImmutableBudgetStateMachine has no setter beyond tighten()
+# ---------------------------------------------------------------------------
+
+
+def test_ast_pin_state_machine_no_public_setter():
+    """Walk the class body. Public methods must be one of the audited
+    surface set. Anything else (esp. names starting with ``set_``) is
+    a violation."""
+    tree = ast.parse(STATE_MACHINE_FILE.read_text())
+    audited = {
+        "__init__",
+        "caps",                 # @property — read-only
+        "wal_path",             # @property — read-only
+        "record_boot",
+        "replay_for_recovery",
+        "admit",
+        "reconcile",
+        "tighten",
+        "snapshot",
+    }
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if node.name != "ImmutableBudgetStateMachine":
+            continue
+        for item in node.body:
+            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                name = item.name
+                if name.startswith("_"):
+                    continue  # private helpers OK
+                assert name in audited, (
+                    f"ImmutableBudgetStateMachine has unaudited public "
+                    f"method: {name!r}. Add to the audited set in this "
+                    f"test OR remove from the class."
+                )
+                assert not name.startswith("set_"), (
+                    f"setter-shaped method on state machine: {name!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Pin 3: HMAC K never in returns / logs / format calls
+# ---------------------------------------------------------------------------
+
+
+def test_ast_pin_hmac_key_never_returned_or_logged():
+    """Scan daemon.py for any place that might leak the HMAC key.
+
+    The key is stored as ``app[_K_HMAC_KEY]`` and bound to local ``K``
+    in handlers. We confirm:
+      - No ``return`` statement whose payload directly contains
+        ``app[_K_HMAC_KEY]`` or a bare ``K`` reference.
+      - No ``logger.*`` / ``logging.*`` call references K.
+    """
+    tree = ast.parse(DAEMON_FILE.read_text())
+
+    def _names_in(node: ast.AST) -> set:
+        out = set()
+        for child in ast.walk(node):
+            if isinstance(child, ast.Name):
+                out.add(child.id)
+        return out
+
+    for node in ast.walk(tree):
+        # Return statement: ``return X`` — X must not contain K.
+        if isinstance(node, ast.Return) and node.value is not None:
+            names = _names_in(node.value)
+            assert "K" not in names, (
+                f"return statement at line {node.lineno} references K — "
+                f"HMAC key leak risk"
+            )
+        # logger.X(...) / logging.X(...) calls — args must not contain K.
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if isinstance(node.func.value, ast.Name) and node.func.value.id in (
+                "logger", "logging",
+            ):
+                for arg in node.args:
+                    names = _names_in(arg)
+                    assert "K" not in names, (
+                        f"logger call at line {node.lineno} references K"
+                    )
+
+
+def test_ast_pin_no_hmac_key_attr_in_health_response_keys():
+    """/health response body must not contain a field that hints at K."""
+    src = DAEMON_FILE.read_text()
+    # Cheap textual pin — any future field added to the /health body
+    # must not contain these tokens.
+    forbidden = ['"hmac"', "'hmac'", '"k_hmac"', "'k_hmac'", '"_hmac_key"']
+    # Find the _handle_health body and check.
+    start = src.find("async def _handle_health(")
+    assert start >= 0, "_handle_health handler missing"
+    # The next function definition (handler) bounds the search.
+    next_def = src.find("async def ", start + 1)
+    body = src[start:next_def] if next_def > start else src[start:]
+    for token in forbidden:
+        assert token not in body, (
+            f"/health body contains forbidden token {token}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pin 4: No anthropic/openai SDK in aegis package
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("module_file", _aegis_modules())
+def test_ast_pin_no_anthropic_or_openai_sdk_import(module_file: Path):
+    """The Aegis substrate stays SDK-free until Slice 2 adds forwarding."""
+    tree = ast.parse(module_file.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                assert root not in ("anthropic", "openai"), (
+                    f"{module_file.name} imports {alias.name} — "
+                    f"provider SDKs are Slice 2 territory"
+                )
+        if isinstance(node, ast.ImportFrom) and node.module:
+            root = node.module.split(".")[0]
+            assert root not in ("anthropic", "openai"), (
+                f"{module_file.name} imports from {node.module} — "
+                f"provider SDKs are Slice 2 territory"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Pin 5 + 6: closed taxonomies / canonical exports
+# ---------------------------------------------------------------------------
+
+
+def test_credential_registry_exports_canonical_set():
+    from backend.core.ouroboros.aegis.credential_registry import (
+        upstream_credential_env_vars,
+    )
+    names = upstream_credential_env_vars()
+    # Hard pin on the names we know carry credentials right now.
+    # Adding a provider == updating this test + the registry together.
+    assert names == frozenset({
+        "ANTHROPIC_API_KEY",
+        "DOUBLEWORD_API_KEY",
+    })
+
+
+def test_reject_reason_taxonomy_exact_match():
+    from backend.core.ouroboros.aegis.budget_state_machine import RejectReason
+    actual = {r.value for r in RejectReason}
+    expected = {
+        "emission_cap_exceeded",
+        "fanout_cap_exceeded",
+        "cost_ceiling_exceeded",
+        "causal_depth_exceeded",
+        "lineage_forgery",
+        "budget_authority_unavailable",
+    }
+    assert actual == expected
+
+
+def test_token_verdict_kind_taxonomy_exact_match():
+    from backend.core.ouroboros.aegis.lease import TokenVerdictKind
+    actual = {v.value for v in TokenVerdictKind}
+    expected = {
+        "valid", "invalid_format", "invalid_signature",
+        "expired", "replayed",
+    }
+    assert actual == expected
+
+
+def test_preflight_outcome_taxonomy_exact_match():
+    from backend.core.ouroboros.aegis.preflight import PreflightOutcome
+    actual = {v.value for v in PreflightOutcome}
+    expected = {
+        "skipped_disabled",
+        "ready",
+        "failed_spawn",
+        "failed_bootstrap_timeout",
+        "failed_credential_scrub",
+    }
+    assert actual == expected

--- a/tests/aegis/test_bootstrap.py
+++ b/tests/aegis/test_bootstrap.py
@@ -1,0 +1,125 @@
+"""Bootstrap payload — atomic 0o600 write, unlink-on-read, entropy."""
+from __future__ import annotations
+
+import stat
+
+import pytest
+
+from backend.core.ouroboros.aegis.bootstrap import (
+    BOOTSTRAP_PAYLOAD_SCHEMA_VERSION,
+    BootstrapPayload,
+    atomic_write_payload,
+    default_expiry,
+    mint_bootstrap_psk,
+    read_and_unlink_payload,
+)
+
+
+def test_psk_entropy_is_high():
+    """PSK should have ≥256 bits of effective entropy (URL-safe base64
+    of 48 raw bytes → ~384 bits; we require at least 64 characters)."""
+    psk = mint_bootstrap_psk()
+    assert isinstance(psk, str)
+    assert len(psk) >= 60  # 48 bytes base64-url-safe ~ 64 chars
+    # Different invocations produce different PSKs.
+    others = {mint_bootstrap_psk() for _ in range(10)}
+    assert psk not in others or len(others) == 10  # ≥10 distinct values likely
+
+
+def test_payload_dict_roundtrip():
+    p = BootstrapPayload(
+        aegis_url="http://127.0.0.1:12345",
+        bootstrap_psk="psk-xxx",
+        daemon_pid=12345,
+        expires_at=99999.0,
+    )
+    d = p.to_dict()
+    recovered = BootstrapPayload.from_dict(d)
+    assert recovered == p
+
+
+def test_atomic_write_creates_file_with_mode_0o600(tmp_path):
+    target = tmp_path / "agentic" / "bootstrap.json"
+    p = BootstrapPayload(
+        aegis_url="http://127.0.0.1:1", bootstrap_psk="psk",
+        daemon_pid=1, expires_at=999.0,
+    )
+    atomic_write_payload(p, target)
+    assert target.exists()
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
+
+
+def test_atomic_write_excl_refuses_overwrite(tmp_path):
+    target = tmp_path / "bootstrap.json"
+    p = BootstrapPayload(
+        aegis_url="http://127.0.0.1:1", bootstrap_psk="psk",
+        daemon_pid=1, expires_at=999.0,
+    )
+    atomic_write_payload(p, target)
+    with pytest.raises(FileExistsError):
+        atomic_write_payload(p, target)
+
+
+def test_read_and_unlink_removes_file(tmp_path):
+    target = tmp_path / "bootstrap.json"
+    p = BootstrapPayload(
+        aegis_url="http://127.0.0.1:99", bootstrap_psk="psk-2",
+        daemon_pid=2, expires_at=42.0,
+    )
+    atomic_write_payload(p, target)
+    assert target.exists()
+    recovered = read_and_unlink_payload(target)
+    assert recovered == p
+    assert not target.exists(), "payload file must be unlinked after read"
+
+
+def test_read_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        read_and_unlink_payload(tmp_path / "absent.json")
+
+
+def test_read_malformed_json_raises_value_error(tmp_path):
+    target = tmp_path / "bootstrap.json"
+    target.write_text("not json at all", encoding="utf-8")
+    with pytest.raises(ValueError):
+        read_and_unlink_payload(target)
+
+
+def test_read_non_object_json_raises_value_error(tmp_path):
+    target = tmp_path / "bootstrap.json"
+    target.write_text('["a", "b"]', encoding="utf-8")
+    with pytest.raises(ValueError):
+        read_and_unlink_payload(target)
+
+
+def test_read_missing_field_raises_value_error(tmp_path):
+    target = tmp_path / "bootstrap.json"
+    target.write_text('{"aegis_url": "http://x", "daemon_pid": 1}', encoding="utf-8")
+    with pytest.raises(ValueError):
+        read_and_unlink_payload(target)
+
+
+def test_default_expiry_is_in_future():
+    now = 1000.0
+    exp = default_expiry(now_s=now)
+    assert exp > now
+
+
+def test_schema_version_constant():
+    assert BOOTSTRAP_PAYLOAD_SCHEMA_VERSION == "aegis_bootstrap.1"
+
+
+def test_atomic_write_parent_chmod_to_0700(tmp_path):
+    """The bootstrap-dir gets tightened to 0o700 to prevent other users
+    from listing the directory and racing on the payload path."""
+    bootstrap_dir = tmp_path / "bootstrap-dir"
+    bootstrap_dir.mkdir(mode=0o755)
+    target = bootstrap_dir / "bp.json"
+    p = BootstrapPayload(
+        aegis_url="http://127.0.0.1:1", bootstrap_psk="x",
+        daemon_pid=1, expires_at=42.0,
+    )
+    atomic_write_payload(p, target)
+    parent_mode = stat.S_IMODE(bootstrap_dir.stat().st_mode)
+    assert parent_mode == 0o700, f"expected parent 0o700, got 0o{parent_mode:o}"

--- a/tests/aegis/test_budget_state_machine.py
+++ b/tests/aegis/test_budget_state_machine.py
@@ -1,0 +1,309 @@
+"""ImmutableBudgetStateMachine — closed taxonomy, caps, monotonic-tightening.
+
+Slice Aegis-1 regression spine, claim #2 (the budget half): per-route +
+session + hourly caps enforce as strictest-wins, and tighten() rejects
+loosening attempts.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.aegis.budget_state_machine import (
+    BudgetCaps,
+    BudgetVerdict,
+    HOURLY_BURN_WINDOW_S,
+    ImmutableBudgetStateMachine,
+    KNOWN_ROUTES,
+    MonotonicTighteningViolationError,
+    RejectReason,
+)
+
+
+# ---------------------------------------------------------------------------
+# Closed-taxonomy pins
+# ---------------------------------------------------------------------------
+
+
+def test_reject_reason_closed_taxonomy_exact_membership():
+    """AST-style pin: the 6 values match §43.6.1 spec, bytes-identical."""
+    expected = {
+        "emission_cap_exceeded",
+        "fanout_cap_exceeded",
+        "cost_ceiling_exceeded",
+        "causal_depth_exceeded",
+        "lineage_forgery",
+        "budget_authority_unavailable",
+    }
+    actual = {r.value for r in RejectReason}
+    assert actual == expected, (
+        f"RejectReason taxonomy drifted. extra={actual - expected}, "
+        f"missing={expected - actual}"
+    )
+
+
+def test_known_routes_exact_membership():
+    expected = ("IMMEDIATE", "STANDARD", "COMPLEX", "BACKGROUND", "SPECULATIVE")
+    assert KNOWN_ROUTES == expected
+
+
+def test_budget_verdict_dict_roundtrip_admitted():
+    v = BudgetVerdict(
+        admitted=True, reason=None,
+        debit_usd=0.05,
+        remaining_session_usd=0.95,
+        remaining_hourly_usd=0.45,
+        remaining_route_usd=0.25,
+    )
+    d = v.to_dict()
+    recovered = BudgetVerdict.from_dict(d)
+    assert recovered == v
+
+
+def test_budget_verdict_dict_roundtrip_denied():
+    v = BudgetVerdict(
+        admitted=False,
+        reason=RejectReason.COST_CEILING_EXCEEDED,
+        debit_usd=0.0,
+        remaining_session_usd=0.0,
+        remaining_hourly_usd=0.0,
+        remaining_route_usd=0.0,
+        detail="session cap exceeded",
+    )
+    d = v.to_dict()
+    recovered = BudgetVerdict.from_dict(d)
+    assert recovered == v
+
+
+# ---------------------------------------------------------------------------
+# Admit + caps
+# ---------------------------------------------------------------------------
+
+
+def _machine(
+    tmp_path: Path,
+    *,
+    session_cap: float = 1.00,
+    hourly_cap: float = 0.50,
+    route_caps: dict | None = None,
+    overrun: float = 1.0,
+) -> ImmutableBudgetStateMachine:
+    caps = BudgetCaps(
+        session_cap_usd=session_cap,
+        hourly_burn_cap_usd=hourly_cap,
+        route_caps_usd=route_caps if route_caps is not None else {
+            "STANDARD": 0.25, "IMMEDIATE": 0.50,
+        },
+        overrun_multiplier=overrun,
+    )
+    return ImmutableBudgetStateMachine(
+        caps=caps, wal_path=tmp_path / "spend.jsonl",
+    )
+
+
+@pytest.mark.asyncio
+async def test_admit_succeeds_within_caps(tmp_path):
+    m = _machine(tmp_path)
+    v = await m.admit(
+        route="STANDARD", estimated_cost_usd=0.10,
+        lease_nonce="n1", op_id="op-1",
+    )
+    assert v.admitted is True
+    assert v.reason is None
+    assert v.debit_usd == pytest.approx(0.10)
+
+
+@pytest.mark.asyncio
+async def test_admit_rejected_when_route_cap_exceeded(tmp_path):
+    m = _machine(tmp_path, route_caps={"STANDARD": 0.05})
+    v = await m.admit(
+        route="STANDARD", estimated_cost_usd=0.10,
+        lease_nonce="n1", op_id="op-1",
+    )
+    assert v.admitted is False
+    assert v.reason is RejectReason.COST_CEILING_EXCEEDED
+    assert "route" in (v.detail or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_admit_rejected_when_session_cap_exceeded(tmp_path):
+    m = _machine(tmp_path, session_cap=0.05, hourly_cap=1.00,
+                 route_caps={"STANDARD": 1.00})
+    v = await m.admit(
+        route="STANDARD", estimated_cost_usd=0.10,
+        lease_nonce="n1", op_id="op-1",
+    )
+    assert v.admitted is False
+    assert v.reason is RejectReason.COST_CEILING_EXCEEDED
+    assert "session" in (v.detail or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_admit_rejected_when_hourly_cap_exceeded(tmp_path):
+    m = _machine(tmp_path, session_cap=10.0, hourly_cap=0.05,
+                 route_caps={"STANDARD": 10.0})
+    v = await m.admit(
+        route="STANDARD", estimated_cost_usd=0.10,
+        lease_nonce="n1", op_id="op-1",
+    )
+    assert v.admitted is False
+    assert v.reason is RejectReason.COST_CEILING_EXCEEDED
+    assert "hourly" in (v.detail or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_strictest_wins_route_blocks_when_others_open(tmp_path):
+    """Route cap is the tightest — that's the failure reason cited."""
+    m = _machine(
+        tmp_path, session_cap=10.0, hourly_cap=10.0,
+        route_caps={"STANDARD": 0.05},
+    )
+    v = await m.admit(
+        route="STANDARD", estimated_cost_usd=0.10,
+        lease_nonce="n1", op_id="op-1",
+    )
+    assert v.admitted is False
+    assert "route" in (v.detail or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_admit_negative_estimate_rejected(tmp_path):
+    m = _machine(tmp_path)
+    v = await m.admit(
+        route="STANDARD", estimated_cost_usd=-0.01,
+        lease_nonce="n1", op_id="op-1",
+    )
+    assert v.admitted is False
+    assert v.reason is RejectReason.COST_CEILING_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_admit_route_without_configured_cap_unbounded(tmp_path):
+    """A route absent from route_caps is treated as unbounded; only
+    session + hourly apply."""
+    m = _machine(tmp_path, route_caps={"STANDARD": 0.05})
+    # COMPLEX has no cap in the map → only session + hourly enforce.
+    v = await m.admit(
+        route="COMPLEX", estimated_cost_usd=0.30,
+        lease_nonce="n1", op_id="op-1",
+    )
+    assert v.admitted is True
+
+
+# ---------------------------------------------------------------------------
+# Reconcile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_refunds_when_actual_below_reserve(tmp_path):
+    m = _machine(tmp_path, session_cap=1.0, hourly_cap=1.0,
+                 route_caps={"STANDARD": 1.0}, overrun=2.0)
+    v_admit = await m.admit(
+        route="STANDARD", estimated_cost_usd=0.10,
+        lease_nonce="n1", op_id="op-1",
+    )
+    assert v_admit.admitted is True
+    assert v_admit.debit_usd == pytest.approx(0.20)  # 0.10 × 2.0
+
+    v_reconcile = await m.reconcile(
+        lease_nonce="n1", op_id="op-1", route="STANDARD",
+        actual_cost_usd=0.08,
+    )
+    assert v_reconcile.admitted is True
+    snap = m.snapshot()
+    # Reserve 0.20 - 0.12 refund == 0.08 actual on session
+    assert snap["session_debit_usd"] == pytest.approx(0.08)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_unknown_lease_returns_budget_authority_unavailable(tmp_path):
+    m = _machine(tmp_path)
+    v = await m.reconcile(
+        lease_nonce="never-admitted", op_id="op-x", route="STANDARD",
+        actual_cost_usd=0.05,
+    )
+    assert v.admitted is False
+    assert v.reason is RejectReason.BUDGET_AUTHORITY_UNAVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Monotonic-tightening
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tighten_session_cap_accepted_when_lower(tmp_path):
+    m = _machine(tmp_path, session_cap=1.00)
+    new_caps = await m.tighten(session_cap_usd=0.50)
+    assert new_caps.session_cap_usd == 0.50
+
+
+@pytest.mark.asyncio
+async def test_tighten_session_cap_rejected_when_equal(tmp_path):
+    m = _machine(tmp_path, session_cap=1.00)
+    with pytest.raises(MonotonicTighteningViolationError):
+        await m.tighten(session_cap_usd=1.00)
+
+
+@pytest.mark.asyncio
+async def test_tighten_session_cap_rejected_when_higher(tmp_path):
+    m = _machine(tmp_path, session_cap=1.00)
+    with pytest.raises(MonotonicTighteningViolationError):
+        await m.tighten(session_cap_usd=2.00)
+
+
+@pytest.mark.asyncio
+async def test_tighten_hourly_cap_rejected_when_higher(tmp_path):
+    m = _machine(tmp_path, hourly_cap=0.50)
+    with pytest.raises(MonotonicTighteningViolationError):
+        await m.tighten(hourly_burn_cap_usd=0.75)
+
+
+@pytest.mark.asyncio
+async def test_tighten_route_cap_rejected_when_higher(tmp_path):
+    m = _machine(tmp_path, route_caps={"STANDARD": 0.10})
+    with pytest.raises(MonotonicTighteningViolationError):
+        await m.tighten(route_caps_usd={"STANDARD": 0.20})
+
+
+@pytest.mark.asyncio
+async def test_tighten_overrun_multiplier_rejected_when_higher(tmp_path):
+    m = _machine(tmp_path, overrun=1.5)
+    with pytest.raises(MonotonicTighteningViolationError):
+        await m.tighten(overrun_multiplier=2.0)
+
+
+@pytest.mark.asyncio
+async def test_tighten_adding_new_route_cap_is_tightening(tmp_path):
+    """Setting a cap on a previously-unbounded route is tightening
+    (unset = unlimited, set = bounded), so it's accepted."""
+    m = _machine(tmp_path, route_caps={"STANDARD": 0.10})
+    new_caps = await m.tighten(route_caps_usd={"BACKGROUND": 0.05})
+    assert new_caps.route_caps_usd["BACKGROUND"] == 0.05
+    assert new_caps.route_caps_usd["STANDARD"] == 0.10  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_snapshot_includes_all_caps(tmp_path):
+    m = _machine(tmp_path)
+    snap = m.snapshot()
+    for key in (
+        "session_cap_usd", "session_debit_usd",
+        "hourly_burn_cap_usd", "hourly_burn_used_usd",
+        "route_caps_usd", "route_debit_usd",
+        "open_reserve_count", "overrun_multiplier",
+        "schema_version",
+    ):
+        assert key in snap
+
+
+def test_hourly_window_constant_matches_spec():
+    """HOURLY_BURN_WINDOW_S must be 3600 (1 hour) per §43.6.1."""
+    assert HOURLY_BURN_WINDOW_S == 3600

--- a/tests/aegis/test_daemon.py
+++ b/tests/aegis/test_daemon.py
@@ -1,0 +1,325 @@
+"""Aegis daemon — endpoint integration tests via aiohttp TestServer.
+
+Slice Aegis-1 regression spine, claim #3: the daemon serves /health,
+/session/establish, /lease/acquire, /lease/redeem — and ZERO /v1/*
+routes (the negative pin proves Slice 1 does NOT forward provider
+traffic).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.aegis.budget_state_machine import (
+    BudgetCaps,
+    ImmutableBudgetStateMachine,
+)
+from backend.core.ouroboros.aegis.daemon import build_app
+
+
+_PSK = "test-psk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+
+def _budget(tmp_path: Path) -> ImmutableBudgetStateMachine:
+    caps = BudgetCaps(
+        session_cap_usd=1.00,
+        hourly_burn_cap_usd=0.50,
+        route_caps_usd={
+            "IMMEDIATE": 0.50, "STANDARD": 0.25, "COMPLEX": 0.30,
+            "BACKGROUND": 0.05, "SPECULATIVE": 0.05,
+        },
+        overrun_multiplier=1.5,
+    )
+    return ImmutableBudgetStateMachine(
+        caps=caps, wal_path=tmp_path / "spend.jsonl",
+    )
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path) -> AsyncGenerator[TestClient, None]:
+    app = build_app(
+        budget=_budget(tmp_path),
+        bootstrap_psk=_PSK,
+        lease_ttl_s=60,
+        session_ttl_s=300,
+    )
+    server = TestServer(app)
+    test_client = TestClient(server)
+    await test_client.start_server()
+    try:
+        yield test_client
+    finally:
+        await test_client.close()
+
+
+# ---------------------------------------------------------------------------
+# /health
+# ---------------------------------------------------------------------------
+
+
+async def test_health_returns_ok(client: TestClient):
+    resp = await client.get("/health")
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["ok"] is True
+    assert "bind_port" in body
+    assert body["psk_consumed"] is False
+    assert body["active_session_count"] == 0
+    assert "budget" in body
+
+
+async def test_health_never_leaks_hmac_or_psk(client: TestClient):
+    """K + PSK must NEVER appear in the /health response body."""
+    resp = await client.get("/health")
+    body_text = await resp.text()
+    assert _PSK not in body_text, "bootstrap PSK leaked in /health!"
+    # K is 32 random bytes — we can't pin a specific value, but we can
+    # check that no key-shaped fields exist.
+    body = await resp.json()
+    for k in body:
+        assert "hmac" not in k.lower(), f"suspicious key in /health: {k}"
+        assert "key" not in k.lower() or k == "schema_version", (
+            f"suspicious key in /health: {k}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# /session/establish — Model B (one-shot PSK → scoped session token)
+# ---------------------------------------------------------------------------
+
+
+async def test_session_establish_with_valid_psk_succeeds(client: TestClient):
+    resp = await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["ok"] is True
+    assert "session_token" in body
+    assert "." in body["session_token"]  # JWT-like format
+    assert "expires_at" in body
+
+
+async def test_session_establish_without_bearer_returns_401(client: TestClient):
+    resp = await client.post("/session/establish")
+    assert resp.status == 401
+
+
+async def test_session_establish_wrong_psk_returns_403(client: TestClient):
+    resp = await client.post(
+        "/session/establish",
+        headers={"Authorization": "Bearer wrong-psk"},
+    )
+    assert resp.status == 403
+
+
+async def test_session_establish_is_one_shot(client: TestClient):
+    first = await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    assert first.status == 200
+
+    # Second call with the SAME PSK is rejected — PSK is consumed.
+    second = await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    assert second.status == 403
+    body = await second.json()
+    assert body["error"] == "psk_already_consumed"
+
+
+async def test_health_reflects_psk_consumed_after_establish(client: TestClient):
+    await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    resp = await client.get("/health")
+    body = await resp.json()
+    assert body["psk_consumed"] is True
+    assert body["active_session_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# /lease/acquire
+# ---------------------------------------------------------------------------
+
+
+async def _establish(client: TestClient) -> str:
+    """Helper: run /session/establish + return the session token."""
+    resp = await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    body = await resp.json()
+    return body["session_token"]
+
+
+async def test_lease_acquire_with_valid_session_succeeds(client: TestClient):
+    session = await _establish(client)
+    resp = await client.post(
+        "/lease/acquire",
+        headers={"Authorization": f"Bearer {session}"},
+        json={
+            "op_id": "op-1",
+            "route": "STANDARD",
+            "estimated_cost_usd": 0.05,
+            "causal_lineage_hash": "stub-for-arc-4",
+        },
+    )
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["ok"] is True
+    assert "lease_token" in body
+    assert body["verdict"]["admitted"] is True
+
+
+async def test_lease_acquire_without_session_returns_401(client: TestClient):
+    resp = await client.post(
+        "/lease/acquire",
+        json={"op_id": "x", "route": "STANDARD", "estimated_cost_usd": 0.01},
+    )
+    assert resp.status == 401
+
+
+async def test_lease_acquire_with_bogus_session_returns_403(client: TestClient):
+    resp = await client.post(
+        "/lease/acquire",
+        headers={"Authorization": "Bearer not.a.real.token"},
+        json={"op_id": "x", "route": "STANDARD", "estimated_cost_usd": 0.01},
+    )
+    assert resp.status == 403
+
+
+async def test_lease_acquire_rejected_when_route_cap_exceeded(client: TestClient):
+    session = await _establish(client)
+    # STANDARD cap is 0.25; overrun_multiplier 1.5 → 0.20 * 1.5 = 0.30 > 0.25
+    resp = await client.post(
+        "/lease/acquire",
+        headers={"Authorization": f"Bearer {session}"},
+        json={"op_id": "op-x", "route": "STANDARD", "estimated_cost_usd": 0.20},
+    )
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["ok"] is False
+    assert body["verdict"]["admitted"] is False
+    assert body["verdict"]["reason"] == "cost_ceiling_exceeded"
+
+
+async def test_lease_acquire_missing_body_field_returns_400(client: TestClient):
+    session = await _establish(client)
+    resp = await client.post(
+        "/lease/acquire",
+        headers={"Authorization": f"Bearer {session}"},
+        json={"op_id": "x"},  # missing route + cost
+    )
+    assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# /lease/redeem
+# ---------------------------------------------------------------------------
+
+
+async def test_full_lease_lifecycle(client: TestClient):
+    """End-to-end: establish → acquire → redeem."""
+    session = await _establish(client)
+
+    acq = await client.post(
+        "/lease/acquire",
+        headers={"Authorization": f"Bearer {session}"},
+        json={
+            "op_id": "op-1", "route": "STANDARD",
+            "estimated_cost_usd": 0.05,
+            "causal_lineage_hash": "stub",
+        },
+    )
+    acq_body = await acq.json()
+    lease_token = acq_body["lease_token"]
+
+    redeem = await client.post(
+        "/lease/redeem",
+        headers={"Authorization": f"Bearer {session}"},
+        json={"lease_token": lease_token, "actual_cost_usd": 0.04},
+    )
+    assert redeem.status == 200
+    body = await redeem.json()
+    assert body["ok"] is True
+    assert body["verdict"]["admitted"] is True
+
+
+async def test_lease_redeem_replay_rejected(client: TestClient):
+    """A lease redeemed once cannot be redeemed again."""
+    session = await _establish(client)
+    acq = await client.post(
+        "/lease/acquire",
+        headers={"Authorization": f"Bearer {session}"},
+        json={
+            "op_id": "op-1", "route": "STANDARD",
+            "estimated_cost_usd": 0.05,
+        },
+    )
+    acq_body = await acq.json()
+    lease_token = acq_body["lease_token"]
+
+    first = await client.post(
+        "/lease/redeem",
+        headers={"Authorization": f"Bearer {session}"},
+        json={"lease_token": lease_token, "actual_cost_usd": 0.04},
+    )
+    assert first.status == 200
+    body = await first.json()
+    assert body["ok"] is True
+
+    second = await client.post(
+        "/lease/redeem",
+        headers={"Authorization": f"Bearer {session}"},
+        json={"lease_token": lease_token, "actual_cost_usd": 0.04},
+    )
+    body = await second.json()
+    assert body["ok"] is False
+    assert "replayed" in body["error"]
+
+
+# ---------------------------------------------------------------------------
+# Negative pin: Slice 1 does NOT forward /v1/* upstream traffic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", [
+    "/v1/messages",
+    "/v1/chat/completions",
+    "/v1/embeddings",
+])
+async def test_v1_routes_return_404_in_slice_1(client: TestClient, path: str):
+    """Slice 1 DARK SUBSTRATE pin: no /v1/* proxy. Slice 2 will add
+    these endpoints. This test must be UPDATED (not deleted) when
+    Slice 2 lands."""
+    resp = await client.post(path, json={})
+    assert resp.status == 404, (
+        f"{path} unexpectedly served — Slice 1 must NOT forward provider traffic"
+    )
+
+
+async def test_app_router_has_only_expected_routes(client: TestClient):
+    """AST-ish pin: enumerate the router and confirm exactly the
+    Slice 1 endpoint surface is exposed. Any new route must be a
+    deliberate addition."""
+    app = client.app
+    assert app is not None
+    paths = sorted({r.resource.canonical for r in app.router.routes()})
+    expected = sorted({
+        "/health",
+        "/session/establish",
+        "/lease/acquire",
+        "/lease/redeem",
+    })
+    assert paths == expected, (
+        f"router surface drift: got {paths}, expected {expected}"
+    )

--- a/tests/aegis/test_env_scrub.py
+++ b/tests/aegis/test_env_scrub.py
@@ -1,0 +1,117 @@
+"""Env scrub — discovers credential names from credential_registry,
+pops them, and proves post-scrub absence.
+
+Per binding correction #6: the negative test "absolutely no upstream
+credentials remain in the JARVIS child env" is mandatory.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.aegis.credential_registry import (
+    upstream_credential_env_vars,
+)
+from backend.core.ouroboros.aegis.env_scrub import (
+    UpstreamCredentialPresentError,
+    assert_no_upstream_credentials,
+    scrub_upstream_credentials,
+)
+
+
+def test_credential_registry_is_frozen():
+    a = upstream_credential_env_vars()
+    b = upstream_credential_env_vars()
+    # Same object identity (frozenset is hashable + immutable).
+    assert a == b
+    with pytest.raises((AttributeError, TypeError)):
+        a.add("anything")  # frozensets reject .add
+
+
+def test_scrub_returns_captured_pairs():
+    env = {
+        "ANTHROPIC_API_KEY": "sk-ant-xxx",
+        "DOUBLEWORD_API_KEY": "dw-yyy",
+        "UNRELATED": "z",
+    }
+    captured = scrub_upstream_credentials(env)
+    assert captured == {
+        "ANTHROPIC_API_KEY": "sk-ant-xxx",
+        "DOUBLEWORD_API_KEY": "dw-yyy",
+    }
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "DOUBLEWORD_API_KEY" not in env
+    assert env["UNRELATED"] == "z"  # unrelated keys untouched
+
+
+def test_scrub_on_empty_env_returns_empty_dict():
+    env: dict = {}
+    captured = scrub_upstream_credentials(env)
+    assert captured == {}
+
+
+def test_scrub_with_extra_names():
+    env = {"FOO_API_KEY": "abc"}
+    captured = scrub_upstream_credentials(env, extra=["FOO_API_KEY"])
+    assert captured == {"FOO_API_KEY": "abc"}
+    assert "FOO_API_KEY" not in env
+
+
+def test_assert_passes_on_clean_env():
+    assert_no_upstream_credentials({})
+
+
+def test_assert_raises_when_anthropic_key_present():
+    with pytest.raises(UpstreamCredentialPresentError) as exc_info:
+        assert_no_upstream_credentials({"ANTHROPIC_API_KEY": "x"})
+    # Message lists the KEY, not the value.
+    msg = str(exc_info.value)
+    assert "ANTHROPIC_API_KEY" in msg
+    assert "x" not in msg or msg.count("x") < 5  # value not embedded
+
+
+def test_assert_raises_when_doubleword_key_present():
+    with pytest.raises(UpstreamCredentialPresentError) as exc_info:
+        assert_no_upstream_credentials({"DOUBLEWORD_API_KEY": "dw-yyy"})
+    assert "DOUBLEWORD_API_KEY" in str(exc_info.value)
+
+
+def test_assert_lists_all_present_keys():
+    env = {
+        "ANTHROPIC_API_KEY": "1",
+        "DOUBLEWORD_API_KEY": "2",
+    }
+    with pytest.raises(UpstreamCredentialPresentError) as exc_info:
+        assert_no_upstream_credentials(env)
+    msg = str(exc_info.value)
+    assert "ANTHROPIC_API_KEY" in msg
+    assert "DOUBLEWORD_API_KEY" in msg
+
+
+def test_scrub_then_assert_zero_credentials_remain():
+    """The mandatory negative test (binding correction #6): after the
+    scrub, the JARVIS child env contains ZERO upstream credentials."""
+    env = {
+        "ANTHROPIC_API_KEY": "sk-ant-xxx",
+        "DOUBLEWORD_API_KEY": "dw-yyy",
+        "HOME": "/home/user",  # unrelated, should survive
+        "PATH": "/usr/bin",
+    }
+    scrub_upstream_credentials(env)
+    # MUST NOT raise:
+    assert_no_upstream_credentials(env)
+    # Unrelated env survives:
+    assert env["HOME"] == "/home/user"
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_scrub_value_never_logged_via_repr():
+    """Captured values shouldn't appear in the exception's repr if used."""
+    env = {"ANTHROPIC_API_KEY": "SUPER_SECRET_TOKEN_VALUE"}
+    try:
+        # The assert should never raise here because we scrubbed first.
+        scrub_upstream_credentials(env)
+        assert_no_upstream_credentials(env)
+    except UpstreamCredentialPresentError as exc:
+        # If it did raise, the value must not appear in str/repr.
+        assert "SUPER_SECRET_TOKEN_VALUE" not in str(exc)
+        assert "SUPER_SECRET_TOKEN_VALUE" not in repr(exc)

--- a/tests/aegis/test_harness_integration.py
+++ b/tests/aegis/test_harness_integration.py
@@ -1,0 +1,153 @@
+"""Harness integration — aegis_preflight() end-to-end.
+
+Spawns a real Aegis subprocess via `python -m`, reads the bootstrap
+payload, scrubs creds, asserts daemon health endpoint reachable.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import time
+
+import aiohttp
+import pytest
+
+from backend.core.ouroboros.aegis.env_scrub import (
+    assert_no_upstream_credentials,
+)
+from backend.core.ouroboros.aegis.flags import ENV_AEGIS_ENABLED
+from backend.core.ouroboros.aegis.preflight import (
+    PreflightOutcome,
+    aegis_preflight,
+)
+
+
+# ---------------------------------------------------------------------------
+# Skipped-when-disabled
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_skipped_when_disabled(monkeypatch, tmp_path):
+    """JARVIS_AEGIS_ENABLED=false → SKIPPED_DISABLED, zero subprocess."""
+    monkeypatch.setenv(ENV_AEGIS_ENABLED, "false")
+    monkeypatch.setenv("JARVIS_AEGIS_BOOTSTRAP_DIR", str(tmp_path))
+    monkeypatch.setenv("JARVIS_AEGIS_WAL_PATH", str(tmp_path / "spend.jsonl"))
+
+    fake_env = {
+        ENV_AEGIS_ENABLED: "false",
+        "ANTHROPIC_API_KEY": "should-survive",
+    }
+    result = await aegis_preflight(env=fake_env)
+    assert result.outcome is PreflightOutcome.SKIPPED_DISABLED
+    # When disabled, creds are NOT scrubbed.
+    assert fake_env.get("ANTHROPIC_API_KEY") == "should-survive"
+
+
+# ---------------------------------------------------------------------------
+# Full ready cycle — spawn + read + scrub + health
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(30)
+async def test_preflight_ready_full_cycle(monkeypatch, tmp_path):
+    """JARVIS_AEGIS_ENABLED=true with caps → daemon spawns, payload
+    landed, creds scrubbed, /health reachable."""
+    monkeypatch.setenv(ENV_AEGIS_ENABLED, "true")
+    monkeypatch.setenv("JARVIS_AEGIS_BOOTSTRAP_DIR", str(tmp_path / "bootstrap"))
+    monkeypatch.setenv("JARVIS_AEGIS_WAL_PATH", str(tmp_path / "spend.jsonl"))
+    # Loosen caps so the daemon can construct without underflow.
+    monkeypatch.setenv("JARVIS_AEGIS_SESSION_CAP_USD", "10.0")
+    monkeypatch.setenv("JARVIS_AEGIS_HOURLY_BURN_CAP_USD", "5.0")
+    for route in ("IMMEDIATE", "STANDARD", "COMPLEX", "BACKGROUND", "SPECULATIVE"):
+        monkeypatch.setenv(f"JARVIS_AEGIS_ROUTE_CAP_{route}_USD", "1.0")
+    monkeypatch.setenv("JARVIS_AEGIS_BOOTSTRAP_TIMEOUT_S", "20")
+
+    # Synthetic env we'll hand to preflight so we don't mutate the real os.environ.
+    fake_env = dict(os.environ)
+    fake_env["ANTHROPIC_API_KEY"] = "test-anthropic-key"
+    fake_env["DOUBLEWORD_API_KEY"] = "test-doubleword-key"
+
+    result = await aegis_preflight(env=fake_env)
+    pid = result.subprocess_pid
+
+    try:
+        assert result.outcome is PreflightOutcome.READY, (
+            f"preflight failed: {result.outcome.value} — {result.detail}"
+        )
+        assert result.aegis_url is not None
+        assert result.bootstrap_psk is not None
+        assert result.aegis_url.startswith("http://127.0.0.1:")
+        # Credentials MUST be absent post-scrub.
+        assert "ANTHROPIC_API_KEY" not in fake_env
+        assert "DOUBLEWORD_API_KEY" not in fake_env
+        assert_no_upstream_credentials(fake_env)
+        # Aegis URL + PSK exposed.
+        assert fake_env.get("JARVIS_AEGIS_URL") == result.aegis_url
+        assert fake_env.get("JARVIS_AEGIS_BOOTSTRAP_PSK") == result.bootstrap_psk
+
+        # /health must be reachable on the bound URL.
+        async with aiohttp.ClientSession() as sess:
+            # Poll briefly — daemon writes payload BEFORE it starts the
+            # server, so there can be a few ms gap.
+            deadline = time.monotonic() + 5.0
+            last_exc = None
+            while time.monotonic() < deadline:
+                try:
+                    async with sess.get(f"{result.aegis_url}/health") as resp:
+                        assert resp.status == 200
+                        body = await resp.json()
+                        assert body["ok"] is True
+                        assert body["psk_consumed"] is False
+                        return
+                except (aiohttp.ClientError, AssertionError) as exc:
+                    last_exc = exc
+                    await asyncio.sleep(0.05)
+            pytest.fail(f"/health not reachable within 5s: {last_exc}")
+    finally:
+        # Clean up the daemon subprocess so the test isolates.
+        if pid is not None:
+            try:
+                os.kill(pid, 15)  # SIGTERM
+            except (ProcessLookupError, PermissionError):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Failure mode — bootstrap timeout
+# ---------------------------------------------------------------------------
+
+
+async def test_preflight_failed_bootstrap_timeout(monkeypatch, tmp_path):
+    """Force a bootstrap timeout by making the timeout absurdly short."""
+    monkeypatch.setenv(ENV_AEGIS_ENABLED, "true")
+    monkeypatch.setenv("JARVIS_AEGIS_BOOTSTRAP_DIR", str(tmp_path))
+    monkeypatch.setenv("JARVIS_AEGIS_WAL_PATH", str(tmp_path / "wal.jsonl"))
+    monkeypatch.setenv("JARVIS_AEGIS_SESSION_CAP_USD", "1.0")
+    monkeypatch.setenv("JARVIS_AEGIS_HOURLY_BURN_CAP_USD", "1.0")
+    monkeypatch.setenv("JARVIS_AEGIS_BOOTSTRAP_TIMEOUT_S", "1")
+
+    # Replace _spawn_daemon with a stub that spawns a process which
+    # NEVER writes the payload (just `sleep 60`).
+    import backend.core.ouroboros.aegis.preflight as preflight_mod
+
+    real_spawn = preflight_mod._spawn_daemon
+
+    def fake_spawn(*, bootstrap_out, credentials, bind_host_override=None):
+        del bootstrap_out, credentials, bind_host_override
+        return subprocess.Popen(
+            ["sleep", "60"], stdin=subprocess.DEVNULL, close_fds=True,
+        )
+
+    monkeypatch.setattr(preflight_mod, "_spawn_daemon", fake_spawn)
+    result = None
+    try:
+        result = await aegis_preflight(env=dict(os.environ))
+        assert result.outcome is PreflightOutcome.FAILED_BOOTSTRAP_TIMEOUT
+    finally:
+        monkeypatch.setattr(preflight_mod, "_spawn_daemon", real_spawn)
+        if result is not None and result.subprocess_pid:
+            try:
+                os.kill(result.subprocess_pid, 9)
+            except (ProcessLookupError, PermissionError):
+                pass

--- a/tests/aegis/test_lease.py
+++ b/tests/aegis/test_lease.py
@@ -1,0 +1,223 @@
+"""Lease + SessionToken HMAC, expiry, replay protection — unit tests.
+
+Slice Aegis-1 regression spine, claim #2: lease HMAC mint/validate
+roundtrips and rejection is deterministic.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from backend.core.ouroboros.aegis.lease import (
+    DEFAULT_LEASE_TTL_S,
+    DEFAULT_SESSION_TOKEN_TTL_S,
+    Lease,
+    NonceLedger,
+    SessionToken,
+    TokenVerdictKind,
+    mint_lease_token,
+    mint_session_token,
+    validate_lease_token,
+    validate_session_token,
+)
+
+
+# ---------------------------------------------------------------------------
+# SessionToken
+# ---------------------------------------------------------------------------
+
+
+def _K() -> bytes:
+    # Deterministic key for tests. Production uses secrets.token_bytes(32).
+    return b"k" * 32
+
+
+def test_session_token_roundtrip_valid():
+    now = time.time()
+    wire, payload = mint_session_token(_K(), now_s=now, ttl_s=60)
+    assert "." in wire
+    verdict = validate_session_token(
+        _K(), wire, now_s=now + 1, active_jti={payload.jti},
+    )
+    assert verdict.kind is TokenVerdictKind.VALID
+
+
+def test_session_token_expired():
+    now = 1000.0
+    wire, payload_st = mint_session_token(_K(), now_s=now, ttl_s=60)
+    verdict = validate_session_token(
+        _K(), wire, now_s=now + 120, active_jti={payload_st.jti},
+    )
+    assert verdict.kind is TokenVerdictKind.EXPIRED
+
+
+def test_session_token_revoked_by_jti_not_active():
+    now = time.time()
+    wire, payload = mint_session_token(_K(), now_s=now)
+    verdict = validate_session_token(
+        _K(), wire, now_s=now + 1, active_jti=set(),  # not in active set
+    )
+    assert verdict.kind is TokenVerdictKind.REPLAYED
+
+
+def test_session_token_invalid_signature_wrong_key():
+    now = time.time()
+    wire, payload = mint_session_token(_K(), now_s=now)
+    verdict = validate_session_token(
+        b"\x01" * 32, wire, now_s=now + 1, active_jti={payload.jti},
+    )
+    assert verdict.kind is TokenVerdictKind.INVALID_SIGNATURE
+
+
+def test_session_token_invalid_format_missing_dot():
+    verdict = validate_session_token(
+        _K(), "thisisnottokenshaped", now_s=time.time(), active_jti=set(),
+    )
+    assert verdict.kind is TokenVerdictKind.INVALID_FORMAT
+
+
+def test_session_token_invalid_format_empty_segment():
+    verdict = validate_session_token(
+        _K(), ".sigonly", now_s=time.time(), active_jti=set(),
+    )
+    assert verdict.kind is TokenVerdictKind.INVALID_FORMAT
+
+
+def test_session_token_tampered_payload_changes_signature():
+    now = time.time()
+    wire, payload = mint_session_token(_K(), now_s=now)
+    # Flip one char in the payload segment.
+    payload_b64, sig_b64 = wire.split(".", 1)
+    flipped = ("A" if payload_b64[0] != "A" else "B") + payload_b64[1:]
+    tampered = f"{flipped}.{sig_b64}"
+    verdict = validate_session_token(
+        _K(), tampered, now_s=now + 1, active_jti={payload.jti},
+    )
+    assert verdict.kind in (
+        TokenVerdictKind.INVALID_SIGNATURE,
+        TokenVerdictKind.INVALID_FORMAT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lease
+# ---------------------------------------------------------------------------
+
+
+def _lease(
+    *,
+    nonce: str = "n1",
+    expires_at: float = 1e12,  # far future
+) -> Lease:
+    return Lease(
+        nonce=nonce,
+        op_id="op-1",
+        route="STANDARD",
+        estimated_cost_usd=0.01,
+        max_cost_usd=0.015,
+        causal_lineage_hash="lineage-hash-placeholder",
+        issued_at=1000.0,
+        expires_at=expires_at,
+    )
+
+
+def test_lease_token_roundtrip_valid():
+    now = 1000.0
+    lease = _lease(expires_at=now + 60)
+    wire = mint_lease_token(_K(), lease)
+    ledger = NonceLedger(capacity=16)
+    verdict = validate_lease_token(_K(), wire, now_s=now + 1, nonce_ledger=ledger)
+    assert verdict.kind is TokenVerdictKind.VALID
+    assert verdict.payload is not None
+    assert verdict.payload["nonce"] == "n1"
+
+
+def test_lease_token_expired():
+    lease = _lease(expires_at=1000.0)
+    wire = mint_lease_token(_K(), lease)
+    ledger = NonceLedger(capacity=16)
+    verdict = validate_lease_token(_K(), wire, now_s=2000.0, nonce_ledger=ledger)
+    assert verdict.kind is TokenVerdictKind.EXPIRED
+
+
+def test_lease_token_replay_rejected_second_validation():
+    now = 1000.0
+    lease = _lease(expires_at=now + 60)
+    wire = mint_lease_token(_K(), lease)
+    ledger = NonceLedger(capacity=16)
+    first = validate_lease_token(_K(), wire, now_s=now + 1, nonce_ledger=ledger)
+    second = validate_lease_token(_K(), wire, now_s=now + 1, nonce_ledger=ledger)
+    assert first.kind is TokenVerdictKind.VALID
+    assert second.kind is TokenVerdictKind.REPLAYED
+
+
+def test_lease_token_wrong_key_rejected():
+    now = 1000.0
+    lease = _lease(expires_at=now + 60)
+    wire = mint_lease_token(_K(), lease)
+    ledger = NonceLedger(capacity=16)
+    verdict = validate_lease_token(
+        b"\x02" * 32, wire, now_s=now + 1, nonce_ledger=ledger,
+    )
+    assert verdict.kind is TokenVerdictKind.INVALID_SIGNATURE
+    # Crucially: a failed-signature lease must NOT register the nonce
+    # (otherwise an attacker spamming bogus signatures could pre-burn
+    # legitimate nonces).
+    assert not ledger.contains(lease.nonce)
+
+
+# ---------------------------------------------------------------------------
+# NonceLedger
+# ---------------------------------------------------------------------------
+
+
+def test_nonce_ledger_first_register_succeeds():
+    ledger = NonceLedger(capacity=8)
+    assert ledger.try_register_sync("n1") is True
+    assert ledger.contains("n1")
+
+
+def test_nonce_ledger_replay_rejected():
+    ledger = NonceLedger(capacity=8)
+    ledger.try_register_sync("n1")
+    assert ledger.try_register_sync("n1") is False
+
+
+def test_nonce_ledger_drop_oldest_when_capacity_exceeded():
+    ledger = NonceLedger(capacity=3)
+    ledger.try_register_sync("a")
+    ledger.try_register_sync("b")
+    ledger.try_register_sync("c")
+    ledger.try_register_sync("d")  # evicts "a"
+    assert not ledger.contains("a")
+    assert ledger.contains("b")
+    assert ledger.contains("c")
+    assert ledger.contains("d")
+    # Re-registering an evicted nonce succeeds (the FIFO does not
+    # retain memory beyond capacity).
+    assert ledger.try_register_sync("a") is True
+
+
+def test_nonce_ledger_capacity_must_be_positive():
+    with pytest.raises(ValueError):
+        NonceLedger(capacity=0)
+
+
+def test_session_token_dataclass_roundtrip_dict():
+    st = SessionToken(jti="abc", issued_at=1.0, expires_at=2.0)
+    d = st.to_dict()
+    recovered = SessionToken.from_dict(d)
+    assert recovered == st
+
+
+def test_lease_dataclass_roundtrip_dict():
+    lease = _lease()
+    d = lease.to_dict()
+    recovered = Lease.from_dict(d)
+    assert recovered == lease
+
+
+def test_defaults_are_sane():
+    assert DEFAULT_LEASE_TTL_S == 300
+    assert DEFAULT_SESSION_TOKEN_TTL_S == 3600

--- a/tests/aegis/test_session_lifecycle.py
+++ b/tests/aegis/test_session_lifecycle.py
@@ -1,0 +1,161 @@
+"""PSK + session-token lifecycle (binding correction #1).
+
+Model B: bootstrap PSK is single-use → mints scoped session token (TTL).
+Tests:
+  - PSK consumes irrevocably on first /session/establish
+  - Session-token TTL honored (expired token rejected)
+  - Re-establishing AFTER PSK consumption fails (PSK is one-shot)
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import AsyncGenerator
+
+import pytest_asyncio
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.aegis.budget_state_machine import (
+    BudgetCaps,
+    ImmutableBudgetStateMachine,
+)
+from backend.core.ouroboros.aegis.daemon import build_app
+from backend.core.ouroboros.aegis.lease import (
+    TokenVerdictKind,
+    validate_session_token,
+)
+
+
+_PSK = "lifecycle-psk-aaaaaaaaaaaaaaaaaaaaaaaa"
+
+
+def _budget(tmp_path: Path) -> ImmutableBudgetStateMachine:
+    caps = BudgetCaps(
+        session_cap_usd=1.0, hourly_burn_cap_usd=0.5,
+        route_caps_usd={"STANDARD": 0.5}, overrun_multiplier=1.5,
+    )
+    return ImmutableBudgetStateMachine(caps=caps, wal_path=tmp_path / "wal.jsonl")
+
+
+@pytest_asyncio.fixture
+async def client_with_short_session(tmp_path) -> AsyncGenerator[TestClient, None]:
+    """Build a client whose session-token TTL is 1 second so we can
+    deterministically test expiry without sleeping forever."""
+    app = build_app(
+        budget=_budget(tmp_path),
+        bootstrap_psk=_PSK,
+        lease_ttl_s=60,
+        session_ttl_s=1,  # short for the expiry test
+    )
+    server = TestServer(app)
+    test_client = TestClient(server)
+    await test_client.start_server()
+    try:
+        yield test_client
+    finally:
+        await test_client.close()
+
+
+# ---------------------------------------------------------------------------
+# PSK consumption discipline
+# ---------------------------------------------------------------------------
+
+
+async def test_psk_consumed_after_single_use(client_with_short_session: TestClient):
+    client = client_with_short_session
+    first = await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    assert first.status == 200
+
+    # /health should reflect consumption.
+    h = await client.get("/health")
+    body = await h.json()
+    assert body["psk_consumed"] is True
+
+    # Second establish with same PSK is rejected.
+    second = await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    assert second.status == 403
+
+
+async def test_wrong_psk_does_not_consume(client_with_short_session: TestClient):
+    """A failed PSK attempt must NOT mark PSK consumed (operator may
+    retry with the correct value). Confirms via subsequent valid use."""
+    client = client_with_short_session
+    bad = await client.post(
+        "/session/establish",
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert bad.status == 403
+
+    good = await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    assert good.status == 200, "valid PSK should still work after bad attempt"
+
+
+# ---------------------------------------------------------------------------
+# Session-token TTL
+# ---------------------------------------------------------------------------
+
+
+async def test_session_token_expires_after_ttl(client_with_short_session: TestClient):
+    """After TTL elapses, calls bearing the expired session token are
+    rejected."""
+    client = client_with_short_session
+    establish = await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    body = await establish.json()
+    token = body["session_token"]
+
+    # Wait > TTL (configured to 1 second in the fixture).
+    time.sleep(1.2)
+
+    resp = await client.post(
+        "/lease/acquire",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"op_id": "x", "route": "STANDARD", "estimated_cost_usd": 0.01},
+    )
+    assert resp.status == 403
+
+
+async def test_session_token_valid_within_ttl(client_with_short_session: TestClient):
+    client = client_with_short_session
+    establish = await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    body = await establish.json()
+    token = body["session_token"]
+
+    # Immediately use it — should be valid.
+    resp = await client.post(
+        "/lease/acquire",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"op_id": "x", "route": "STANDARD", "estimated_cost_usd": 0.01},
+    )
+    assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# Validation function direct unit (no HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_session_token_with_inactive_jti_returns_replayed():
+    """Even a structurally valid + non-expired token is rejected if
+    the daemon revoked it (jti not in active_jti)."""
+    from backend.core.ouroboros.aegis.lease import mint_session_token
+    K = b"x" * 32
+    now = time.time()
+    token = mint_session_token(K, now_s=now, ttl_s=60)[0]
+    # Empty active set — simulates a daemon restart wiping sessions.
+    verdict = validate_session_token(K, token, now_s=now + 1, active_jti=set())
+    assert verdict.kind is TokenVerdictKind.REPLAYED

--- a/tests/aegis/test_spend_wal.py
+++ b/tests/aegis/test_spend_wal.py
@@ -1,0 +1,118 @@
+"""Spend WAL — atomic append, replay, malformed-line tolerance."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.aegis.spend_wal import (
+    SPEND_WAL_SCHEMA_VERSION,
+    SpendEntry,
+    SpendEntryKind,
+    admit_entry,
+    append_entry,
+    append_entry_sync,
+    boot_entry,
+    reconcile_entry,
+    replay_wal,
+)
+
+
+def test_spend_entry_kind_closed():
+    expected = {"boot", "admit", "reconcile"}
+    actual = {k.value for k in SpendEntryKind}
+    assert actual == expected
+
+
+def test_spend_entry_dict_roundtrip_admit():
+    e = admit_entry(
+        ts=1000.0, lease_nonce="n1", op_id="op-1", route="STANDARD",
+        estimated_cost_usd=0.10, reserve_cost_usd=0.15,
+    )
+    d = e.to_dict()
+    recovered = SpendEntry.from_dict(d)
+    assert recovered == e
+
+
+def test_spend_entry_dict_roundtrip_reconcile():
+    e = reconcile_entry(
+        ts=1000.0, lease_nonce="n1", op_id="op-1", route="STANDARD",
+        actual_cost_usd=0.08, reserve_cost_usd=0.15,
+    )
+    d = e.to_dict()
+    recovered = SpendEntry.from_dict(d)
+    assert recovered == e
+
+
+def test_spend_entry_dict_roundtrip_boot():
+    e = boot_entry(ts=1.0, detail="hello")
+    d = e.to_dict()
+    recovered = SpendEntry.from_dict(d)
+    assert recovered == e
+
+
+def test_append_sync_then_replay(tmp_path):
+    wal = tmp_path / "spend.jsonl"
+    e1 = boot_entry(ts=1.0, detail="boot1")
+    e2 = admit_entry(
+        ts=2.0, lease_nonce="n1", op_id="op-1", route="STANDARD",
+        estimated_cost_usd=0.01, reserve_cost_usd=0.02,
+    )
+    e3 = reconcile_entry(
+        ts=3.0, lease_nonce="n1", op_id="op-1", route="STANDARD",
+        actual_cost_usd=0.015, reserve_cost_usd=0.02,
+    )
+    assert append_entry_sync(wal, e1) is True
+    assert append_entry_sync(wal, e2) is True
+    assert append_entry_sync(wal, e3) is True
+
+    recovered = replay_wal(wal)
+    assert len(recovered) == 3
+    assert recovered[0] == e1
+    assert recovered[1] == e2
+    assert recovered[2] == e3
+
+
+@pytest.mark.asyncio
+async def test_append_async_then_replay(tmp_path):
+    wal = tmp_path / "spend.jsonl"
+    e = boot_entry(ts=1.0, detail="async-boot")
+    ok = await append_entry(wal, e)
+    assert ok is True
+    recovered = replay_wal(wal)
+    assert recovered == [e]
+
+
+def test_replay_missing_file_returns_empty(tmp_path):
+    assert replay_wal(tmp_path / "absent.jsonl") == []
+
+
+def test_replay_skips_malformed_lines(tmp_path):
+    wal = tmp_path / "spend.jsonl"
+    good = boot_entry(ts=1.0, detail="good")
+    append_entry_sync(wal, good)
+    # Inject malformed lines.
+    with wal.open("a", encoding="utf-8") as fh:
+        fh.write("this is not json\n")
+        fh.write('{"kind": "unknown_kind", "ts": 2.0}\n')
+        fh.write('[]\n')  # not a dict
+    good2 = boot_entry(ts=2.0, detail="good2")
+    append_entry_sync(wal, good2)
+
+    recovered = replay_wal(wal)
+    # Only the two valid entries survive.
+    assert len(recovered) == 2
+    assert recovered[0].detail == "good"
+    assert recovered[1].detail == "good2"
+
+
+def test_append_writes_compact_json(tmp_path):
+    wal = tmp_path / "spend.jsonl"
+    e = boot_entry(ts=1.0, detail="x")
+    append_entry_sync(wal, e)
+    raw = wal.read_text().strip()
+    # Compact JSON: no spaces after delimiters, sorted keys.
+    parsed = json.loads(raw)
+    assert parsed["kind"] == "boot"
+    assert parsed["ts"] == 1.0
+    assert parsed["schema_version"] == SPEND_WAL_SCHEMA_VERSION


### PR DESCRIPTION
## Summary

§43.7 spine made physical: a separate OS process minted before any autonomous code runs that owns upstream API credentials, the HMAC signing key K, and the authoritative spend ledger. JARVIS can rewrite anything inside its own process — it cannot mint a credential it does not have, and it cannot debit a ledger it cannot reach.

**Slice 1 is DARK SUBSTRATE — \`JARVIS_AEGIS_ENABLED\` default FALSE.** Zero behavior change to live JARVIS. Slice 2 will wire providers + Slice 4 soak graduates the master flag.

## What's in

- \`backend/core/ouroboros/aegis/\` — 10 new modules (~2,400 LOC)
  - \`daemon.py\` — aiohttp loopback ephemeral-port server, 4 endpoints (\`/health\`, \`/session/establish\`, \`/lease/acquire\`, \`/lease/redeem\`). **Zero \`/v1/*\` routes (AST-pinned)** — Slice 1 does not forward provider traffic.
  - \`lease.py\` — lighter-JWT HMAC wire codec, Lease + SessionToken frozen dataclasses, 5-value \`TokenVerdictKind\`, bounded \`NonceLedger\` with drop-oldest eviction
  - \`budget_state_machine.py\` — \`ImmutableBudgetStateMachine\` with 6-value \`RejectReason\` bytes-identical to §43.6.1 spec; strictest-wins (route AND session AND hourly); \`MonotonicTighteningViolationError\` blocks loosening
  - \`spend_wal.py\` — composes \`cross_process_jsonl.flock_append_line\` verbatim; replay-on-boot
  - \`bootstrap.py\` — atomic write-temp-then-rename of 0600 payload carrying \`{aegis_url, bootstrap_psk, daemon_pid, expires_at}\`
  - \`env_scrub.py\` + \`credential_registry.py\` — central frozenset of upstream credential env names; \`assert_no_upstream_credentials\` invariant
  - \`preflight.py\` — async harness preflight, spawns Aegis subprocess via \`python -m\`, polls for bootstrap payload, scrubs creds
  - \`flags.py\` — 16 FlagRegistry seeds, SAFETY-category caps default 0.0 USD (fail-closed)
- \`scripts/ouroboros_battle_test.py\` — gated preflight call (~30 lines) before harness import
- \`tests/aegis/\` — 9 test files, **114 tests**

## PSK lifecycle — Model B (binding correction #1)

1. Aegis mints single-use bootstrap PSK at boot
2. JARVIS calls \`POST /session/establish\` with \`Authorization: Bearer <PSK>\`; Aegis constant-time compares, marks PSK consumed irrevocably, mints scoped session token (HMAC, TTL)
3. JARVIS uses session token for all subsequent \`/lease/*\`
4. \`/lease/redeem\` registers nonce + reconciles actual vs reserve

A failed PSK attempt does NOT consume the PSK (operator retry tolerated).

## Binding directives — coverage

- Dynamic ephemeral port (\`socket.bind((host, 0))\`) — no hardcoded port
- Atomic write-temp-then-rename (closed a read-during-write race when polling)
- HMAC K ephemeral per boot, never serialized/returned/logged (AST-pinned)
- Caller-provided \`estimated_cost_usd\`; no Slice 1 pricing integration (binding correction #4)
- Slice 1 endpoint surface strict; AST pin enforces no \`/v1/*\`
- Caps env-driven, fail-closed (unset = 0.0 USD), strictest-wins
- WAL composes \`cross_process_jsonl.flock_append_line\` verbatim

## Test plan

- [x] All 114 Aegis unit + integration tests green (sandbox-disabled because the daemon binds a listening socket)
- [x] Harness \`--help\` smoke (wire-in import path) — exit 0
- [x] AST pins enforced (no \`/v1/*\` routes, no state-machine setter, K never leaks, no \`anthropic\`/\`openai\` SDK in package, closed taxonomies bytes-identical to spec)
- [x] \`main\` HEAD matches \`origin/main\` byte-identical (Cursor auto-commits cleaned up)
- [x] Single cohesive squashed commit

## What Slice 1 deliberately does NOT do

- No \`/v1/messages\` or \`/v1/chat/completions\` forwarding (Slice 2)
- No \`providers.py\` / \`doubleword_provider.py\` rewire (Slice 2)
- No \`X-JARVIS-Lease\` header injection (Slice 2)
- No mid-stream guillotine (Slice 2)
- No pricing-table integration (Slice 2+ as needed)
- No graduation claim (Slice 4 §44 soak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces Aegis Slice 1 (dark substrate): a separate local daemon that owns upstream credentials and the budget ledger, with session/lease auth and strict caps. Default off via `JARVIS_AEGIS_ENABLED=false`; no provider forwarding; no behavior change unless enabled.

- **New Features**
  - Out-of-process Aegis daemon on loopback with ephemeral port; endpoints: `/health`, `/session/establish`, `/lease/acquire`, `/lease/redeem` (no `/v1/*`).
  - Auth model: single-use bootstrap PSK → HMAC-scoped session token → single-use lease tokens with TTL and replay protection.
  - Budget control: immutable state machine with route/session/hourly caps (strictest-wins), WAL-backed ledger with replay on boot; caps default to 0.0 USD (fail-closed).
  - Preflight: spawns daemon via `python -m`, writes atomic bootstrap payload, scrubs upstream creds from the JARVIS env, exposes `JARVIS_AEGIS_URL` and `JARVIS_AEGIS_BOOTSTRAP_PSK` for future wiring.
  - Safety pins: no provider SDK imports in `aegis`, HMAC key never serialized or logged, central credential registry for env scrub, and 114 tests covering endpoints, tokens, caps, WAL, and invariants.

- **Migration**
  - No action needed by default; feature is gated by `JARVIS_AEGIS_ENABLED` (kept `false`).
  - To try it: set `JARVIS_AEGIS_ENABLED=true` and configure caps via Aegis flag envs (caps default to 0.0 USD, so nothing admits until set).
  - Keep upstream API keys in your shell/env; preflight passes them to the daemon and removes them from the JARVIS process.
  - Provider traffic is unchanged in Slice 1; forwarding and header injection arrive in Slice 2.

<sup>Written for commit 1a447837d7a992d70089c810e07e9aa517759ac9. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/53861?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

