### PR TITLE
feat(governance): Slice 12Z — Invariant Drift Cooperative Refactor

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -682,15 +682,22 @@ class DoublewordProvider:
             from backend.core.ouroboros.governance.session_budget_authority import (  # noqa: E501
                 check_preflight as _sba_check_preflight,
             )
-            # Slice 12Y Part 1 — pass signal_source so the SBA
-            # can apply the background-spend ceiling for sensor
-            # ops. No-op when source is None or non-background-tier.
+            # Slice 12Y Part 1 — Slice 12Z bug fix:
+            # _check_budget(self) has no `context` parameter (DW
+            # provider's structure differs from Claude's
+            # generate(self, context)). Passing signal_source=None
+            # preserves the pre-Slice-12Y behavior for DW —
+            # background-spend ceiling does NOT apply at the DW
+            # call site. This is intentional: DW per-call cost is
+            # ~$0.002 (3 orders of magnitude smaller than Claude's
+            # $0.50 estimate), so the background-ceiling primary
+            # use case (foreground fixture starvation prevention)
+            # is fully covered by the Claude provider path which
+            # DOES carry context.
             _sba_check_preflight(
                 provider_name="doubleword",
                 estimated_cost_usd=float(self._max_cost_per_op or 0.0),
-                signal_source=(
-                    getattr(context, "signal_source", None)
-                ),
+                signal_source=None,
             )
         except ImportError:
             # Module absent on this build — graceful fall-through to

--- a/backend/core/ouroboros/governance/meta/cross_kingdom_boundary.py
+++ b/backend/core/ouroboros/governance/meta/cross_kingdom_boundary.py
@@ -203,6 +203,171 @@ def _scan_one_file(
 # ---------------------------------------------------------------------------
 
 
+async def scan_governance_tree_async(
+    *,
+    governance_root_override: "Path | None" = None,
+    forbidden_prefix: str = _FORBIDDEN_IMPORT_PREFIX,
+) -> Tuple[str, ...]:
+    """Slice 12Z — async-cooperative sibling of
+    :func:`scan_governance_tree`.
+
+    bt-2026-05-23-221029 (Slice 12Y validation soak) tombstone
+    captured this module's sync ``rglob`` + ``read_text`` loop
+    running directly on the asyncio MainThread when
+    :func:`shipped_code_invariants.validate_all_async` took its
+    PermissionError sync-fallback path. ``LoopDeadman`` fired at
+    301.8s. SidecarProfiler captured 4 in-progress STUCK_FRAME
+    emissions all pointing at ``pathlib.read_text``.
+
+    Slice 12Z composes the canonical Slice 12U
+    :mod:`cooperative_fs_io` substrate — dedicated
+    ``advisor-blast`` executor for per-file reads +
+    ``cooperative_yield_every_n_async`` between batches — so the
+    same scan that wedged on the loop now yields control every
+    N files and dispatches I/O off-thread. Returns the same
+    violation tuple shape as the sync sibling; deterministic
+    result parity is pinned by ``test_result_parity_with_sync``.
+
+    Each violation string format unchanged:
+      ``<relative-path>:<lineno> forbidden import of <module>``
+
+    NEVER raises into the caller — iteration errors terminate
+    the scan cleanly with whatever violations are accumulated.
+    """
+    # Lazy import — keeps cooperative_fs_io off the sync-only
+    # module-load path for callers that only need
+    # :func:`scan_governance_tree`.
+    try:
+        from backend.core.ouroboros.governance.cooperative_fs_io import (  # noqa: E501
+            iter_files_cooperative,
+            read_text_offloaded,
+        )
+        from backend.core.ouroboros.governance.event_loop_governance import (  # noqa: E501
+            offload_blocking,
+        )
+    except Exception:  # noqa: BLE001 — fall back to sync
+        return scan_governance_tree(
+            governance_root_override=governance_root_override,
+            forbidden_prefix=forbidden_prefix,
+        )
+
+    root = (
+        governance_root_override
+        if governance_root_override is not None
+        else _governance_root()
+    )
+
+    violations: List[str] = []
+    try:
+        # Cooperative file iteration — yields control every N
+        # items (default 64 via JARVIS_EVENT_LOOP_YIELD_EVERY_N)
+        # so the heartbeat coroutine + Claude SDK stream
+        # consumer get scheduling slots throughout the scan.
+        async for path_str in iter_files_cooperative(
+            root, pattern="*.py",
+        ):
+            try:
+                # __pycache__ filter matches the sync
+                # implementation byte-for-byte.
+                if "__pycache__" in Path(path_str).parts:
+                    continue
+            except Exception:  # noqa: BLE001
+                continue
+
+            try:
+                rel = (
+                    Path(path_str).relative_to(root).as_posix()
+                )
+            except ValueError:
+                rel = str(path_str)
+            if rel in _BOUNDARY_EXEMPTIONS:
+                continue
+
+            # Per-file read offloaded to the dedicated
+            # advisor-blast executor (Slice 12T Part 3 +
+            # Slice 12U cooperative_fs_io). The AST parse +
+            # forbidden-import walk also runs off-loop via
+            # ``offload_blocking`` so the substring scan doesn't
+            # hold the GIL on the loop thread.
+            try:
+                source = await read_text_offloaded(
+                    Path(path_str),
+                )
+                if source is None:
+                    continue
+            except Exception:  # noqa: BLE001
+                continue
+
+            try:
+                # _scan_one_file is fast pure-Python AST work
+                # — offload to the dedicated pool so the
+                # cumulative cost (one parse + one walk per
+                # .py file in governance/, hundreds of files)
+                # doesn't accumulate on the loop thread.
+                file_violations = await offload_blocking(
+                    _scan_one_file_from_source,
+                    source, forbidden_prefix,
+                    label="cross_kingdom.scan_one_file",
+                )
+            except Exception:  # noqa: BLE001
+                continue
+
+            for line, module in file_violations:
+                violations.append(
+                    f"{rel}:{line} forbidden import of "
+                    f"{module!r}"
+                )
+    except Exception:  # noqa: BLE001 — defensive
+        # Swallow iteration faults — return what we collected.
+        pass
+
+    return tuple(violations)
+
+
+def _scan_one_file_from_source(
+    source: str,
+    forbidden_prefix: str,
+) -> Tuple[Tuple[int, str], ...]:
+    """Slice 12Z module-level helper — same AST-walk as
+    :func:`_scan_one_file` but operates on a pre-read ``source``
+    string. Lifted to module level so the
+    :func:`cooperative_fs_io.offload_blocking` worker doesn't
+    capture caller-local state. NEVER raises."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return ()
+    violations: List[Tuple[int, str]] = []
+    try:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if (
+                    module == forbidden_prefix
+                    or module.startswith(
+                        forbidden_prefix + ".",
+                    )
+                ):
+                    violations.append(
+                        (int(node.lineno), str(module)),
+                    )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    name = alias.name or ""
+                    if (
+                        name == forbidden_prefix
+                        or name.startswith(
+                            forbidden_prefix + ".",
+                        )
+                    ):
+                        violations.append(
+                            (int(node.lineno), str(name)),
+                        )
+    except Exception:  # noqa: BLE001 — defensive
+        return ()
+    return tuple(violations)
+
+
 def scan_governance_tree(
     *,
     governance_root_override: "Path | None" = None,
@@ -215,6 +380,12 @@ def scan_governance_tree(
 
     Each violation string is formatted:
       ``<relative-path>:<lineno> forbidden import of <module>``
+
+    Slice 12Z note: prefer :func:`scan_governance_tree_async`
+    from any asyncio context — this sync entry point blocks
+    the calling thread for the full scan duration. The async
+    sibling composes :mod:`cooperative_fs_io` for non-blocking
+    iteration on the event loop.
     """
     root = (
         governance_root_override
@@ -324,7 +495,9 @@ def register_flags(registry: Any) -> None:
 
 __all__ = [
     "CROSS_KINGDOM_BOUNDARY_SCHEMA_VERSION",
+    "_scan_one_file_from_source",
     "register_flags",
     "register_shipped_invariants",
     "scan_governance_tree",
+    "scan_governance_tree_async",
 ]

--- a/backend/core/ouroboros/governance/meta/shipped_code_invariants.py
+++ b/backend/core/ouroboros/governance/meta/shipped_code_invariants.py
@@ -2644,14 +2644,53 @@ async def validate_all_async() -> Tuple[InvariantViolation, ...]:
             timeout_s, elapsed_ms,
         )
         return ()
-    except Exception as exc:  # noqa: BLE001 — degrade to sync
+    except Exception as exc:  # noqa: BLE001 — degrade to off-loop
         elapsed_ms = (_time.monotonic() - t0) * 1000.0
         logger.warning(
             "[ShippedCodeInvariants] async pool unavailable "
-            "(%s); degrading to sync. parent_await_ms=%.1f",
+            "(%s); degrading to thread-pool off-loop fallback. "
+            "parent_await_ms=%.1f",
             type(exc).__name__, elapsed_ms,
         )
-        return validate_invariants_grouped()
+        # ── Slice 12Z — sync-fallback off-loop dispatch ──
+        #
+        # bt-2026-05-23-221029 tombstone proved the
+        # "return validate_invariants_grouped()" call here ran
+        # SYNC on the asyncio main loop. validate_invariants_grouped
+        # invokes the cross_kingdom_boundary._validate_cross_kingdom_boundary
+        # validator which calls scan_governance_tree (sync rglob +
+        # read_text over the whole governance/ tree). That stack
+        # held the GIL for 300+ seconds and triggered LoopDeadman.
+        #
+        # Slice 12Z dispatches the entire sync grouped-validation
+        # path through ``offload_blocking`` (Task #102 canonical
+        # offload primitive) — the heavy AST work + file reads
+        # all run on a worker thread, the asyncio loop continues
+        # ticking, and LoopDeadman never trips on this path again.
+        # The async-pool path remains the primary; this is the
+        # second-best degraded path that no longer wedges.
+        try:
+            from backend.core.ouroboros.governance.event_loop_governance import (  # noqa: E501
+                offload_blocking as _offload_blocking,
+            )
+            return await _offload_blocking(
+                validate_invariants_grouped,
+                label="shipped_invariants_sync_fallback",
+            )
+        except Exception as _fallback_exc:  # noqa: BLE001
+            # If even the offload path fails (e.g.,
+            # event_loop_governance not importable in some
+            # degraded build), fall back to direct sync as the
+            # absolute last resort — observability is
+            # non-authoritative so a missing pin is preferable
+            # to a hard crash.
+            logger.debug(
+                "[ShippedCodeInvariants] offload_blocking "
+                "fallback raised (%s) — final sync attempt "
+                "(may wedge loop on large trees)",
+                type(_fallback_exc).__name__,
+            )
+            return validate_invariants_grouped()
 
     elapsed_ms = (_time.monotonic() - t0) * 1000.0
     logger.info(

--- a/tests/governance/test_slice12z_invariant_cooperative.py
+++ b/tests/governance/test_slice12z_invariant_cooperative.py
@@ -1,0 +1,481 @@
+"""Slice 12Z — Invariant Drift Cooperative Refactor.
+
+bt-2026-05-23-221029 (Slice 12Y validation soak) LoopDeadman
+tombstone captured the exact wedge stack:
+
+    File ".../pathlib.py:1059 in read_text"
+    File ".../meta/cross_kingdom_boundary.py:163 in _scan_one_file"
+    File ".../meta/cross_kingdom_boundary.py:243 in scan_governance_tree"
+    File ".../meta/cross_kingdom_boundary.py:291 in _validate_cross_kingdom_boundary"
+    File ".../meta/shipped_code_invariants.py:2526 in validate_invariants_grouped"
+    File ".../meta/shipped_code_invariants.py:2654 in validate_all_async"
+    File ".../invariant_drift_auditor.py:639 in _capture_shipped_invariants_async"
+    File ".../invariant_drift_auditor.py:671 in capture_snapshot_async"
+
+The async-pool path in :func:`validate_all_async` worked correctly, but
+its **sync fallback** (line 2654: ``return validate_invariants_grouped()``)
+ran on the main asyncio loop when the process pool was unavailable
+(PermissionError observed in production). That fallback called
+:func:`scan_governance_tree` — sync ``rglob`` + ``read_text`` over the
+entire governance/ tree — holding the GIL for 301.8s until LoopDeadman
+fired. SidecarProfiler caught 4 in-progress STUCK_FRAME emissions all
+pointing at ``pathlib.read_text`` / ``pathlib.stat`` / ``pathlib.open``.
+
+Slice 12Z closes the wedge via TWO composable disciplines:
+
+# Discipline 1 — Async-cooperative ``scan_governance_tree_async``
+
+NEW async sibling in ``cross_kingdom_boundary.py``. Composes the
+Slice 12U :mod:`cooperative_fs_io` substrate:
+
+  * :func:`iter_files_cooperative` — async iteration with
+    ``asyncio.sleep(0)`` yields every N items (default 64 via
+    ``JARVIS_EVENT_LOOP_YIELD_EVERY_N``) so the heartbeat coroutine
+    + SDK stream consumer get scheduling slots throughout the scan
+  * :func:`read_text_offloaded` — per-file read dispatches to the
+    dedicated ``advisor-blast`` ThreadPoolExecutor (Slice 12T Part 3
+    isolation contract)
+  * :func:`offload_blocking` — per-file AST parse + walk via the
+    Slice 12U canonical primitive (cumulative substring scan +
+    AST work offloaded together so the GIL releases between
+    files)
+
+Result parity with sync sibling pinned by
+:meth:`TestScanResultParity.test_async_matches_sync`. Same
+violation-string format. NEW helper
+:func:`_scan_one_file_from_source` lifted to module level so the
+offload worker doesn't capture caller-local state.
+
+# Discipline 2 — ``validate_all_async`` sync-fallback offload
+
+Slice 12Z modifies ``validate_all_async`` so its
+exception-fallback path (when the process pool fails) dispatches
+``validate_invariants_grouped`` via
+:func:`event_loop_governance.offload_blocking` instead of calling
+sync on the loop. This is the architectural fix that closes the
+proven wedge: even when the pool is unavailable, the sync
+grouped-validation runs on a worker thread; the loop continues
+ticking; LoopDeadman never trips on this path again.
+
+A double-fallback guard remains: if even ``offload_blocking``
+fails (e.g., ``event_loop_governance`` not importable in some
+degraded build), the absolute-last-resort sync call still runs —
+preserves the observability-non-authoritative contract that says
+"missing pin > hard crash".
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance.meta import cross_kingdom_boundary
+from backend.core.ouroboros.governance.meta.cross_kingdom_boundary import (
+    _scan_one_file_from_source,
+    scan_governance_tree,
+    scan_governance_tree_async,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Shared fixtures
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_governance_tree(tmp_path: Path) -> Path:
+    """Build a small governance/-like tree with mixed clean +
+    forbidden imports. Mirrors the real tree's structure
+    (subdirs + .py files) without being so large that test
+    runtime explodes."""
+    # Clean files.
+    (tmp_path / "clean_a.py").write_text(
+        "import json\nimport os\n",
+    )
+    (tmp_path / "clean_b.py").write_text(
+        "from backend.core.ouroboros import oracle\n",
+    )
+    # Subdir with one forbidden import.
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "violator_top.py").write_text(
+        "from backend.core.coding_council import foo\n",
+    )
+    # Lazy nested forbidden import.
+    (sub / "violator_nested.py").write_text(
+        "def f():\n"
+        "    import backend.core.coding_council.bar\n",
+    )
+    # __pycache__ — must be skipped.
+    pyc = tmp_path / "__pycache__"
+    pyc.mkdir()
+    (pyc / "ignored.py").write_text(
+        "from backend.core.coding_council import IGNORED\n",
+    )
+    # A few extra clean files to give the iterator some bulk
+    # for the heartbeat-yield test.
+    for i in range(15):
+        (tmp_path / f"extra_{i:02d}.py").write_text(
+            f"# extra clean file {i}\nprint('hi')\n",
+        )
+    return tmp_path
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Discipline 1 — scan_governance_tree_async basic correctness
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestScanAsyncShape:
+    def test_is_coroutine_function(self):
+        assert asyncio.iscoroutinefunction(
+            scan_governance_tree_async,
+        ), (
+            "scan_governance_tree_async no longer async — "
+            "Slice 12Z core regression"
+        )
+
+    def test_helper_is_module_level(self):
+        """The offload worker MUST be module-level (not a
+        closure) so the executor doesn't capture caller state."""
+        assert callable(_scan_one_file_from_source)
+        import inspect
+        sig = inspect.signature(_scan_one_file_from_source)
+        params = list(sig.parameters.keys())
+        assert params == ["source", "forbidden_prefix"], (
+            f"_scan_one_file_from_source signature drifted: {params}"
+        )
+
+    def test_exports_present(self):
+        for name in (
+            "scan_governance_tree_async",
+            "_scan_one_file_from_source",
+        ):
+            assert hasattr(cross_kingdom_boundary, name)
+            assert name in cross_kingdom_boundary.__all__
+
+
+class TestScanResultParity:
+    """The async path MUST return the same violations as the
+    sync path for the same input tree. This is the load-bearing
+    correctness claim — if it drifts, the refactor regressed
+    invariant accuracy."""
+
+    @pytest.mark.asyncio
+    async def test_async_matches_sync(self, fake_governance_tree):
+        sync_result = scan_governance_tree(
+            governance_root_override=fake_governance_tree,
+        )
+        async_result = await scan_governance_tree_async(
+            governance_root_override=fake_governance_tree,
+        )
+        assert set(sync_result) == set(async_result), (
+            f"Async scan returned different violations:\n"
+            f"  sync : {sync_result}\n"
+            f"  async: {async_result}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pycache_skipped_in_async(
+        self, fake_governance_tree,
+    ):
+        """__pycache__/ MUST be skipped in async path too —
+        same exemption discipline as sync."""
+        result = await scan_governance_tree_async(
+            governance_root_override=fake_governance_tree,
+        )
+        for v in result:
+            assert "__pycache__" not in v, (
+                f"async scan reported __pycache__ violation: {v}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_detects_top_level_forbidden_import(
+        self, fake_governance_tree,
+    ):
+        result = await scan_governance_tree_async(
+            governance_root_override=fake_governance_tree,
+        )
+        # violator_top.py:1 should be flagged.
+        assert any(
+            "violator_top.py:1" in v and "coding_council" in v
+            for v in result
+        ), f"top-level forbidden import not detected: {result}"
+
+    @pytest.mark.asyncio
+    async def test_detects_lazy_nested_forbidden_import(
+        self, fake_governance_tree,
+    ):
+        result = await scan_governance_tree_async(
+            governance_root_override=fake_governance_tree,
+        )
+        # violator_nested.py:2 (nested inside def f()) flagged.
+        assert any(
+            "violator_nested.py:2" in v and "coding_council" in v
+            for v in result
+        ), f"nested forbidden import not detected: {result}"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Discipline 1 — Non-blocking proof (THE load-bearing claim)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestScanAsyncNonBlocking:
+    """The whole point of Slice 12Z: a concurrent heartbeat
+    coroutine MUST accumulate ticks during the scan. Pre-Slice-12Z
+    the sync fallback wedged for 301.8s on the same code path."""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_ticks_during_scan(
+        self, fake_governance_tree, monkeypatch,
+    ):
+        # Aggressive yield cadence so the small fake tree
+        # (~20 .py files) still triggers cooperative yields.
+        monkeypatch.setenv(
+            "JARVIS_EVENT_LOOP_YIELD_EVERY_N", "2",
+        )
+        ticks = 0
+        scan_running = True
+
+        async def heartbeat():
+            nonlocal ticks
+            while scan_running:
+                ticks += 1
+                await asyncio.sleep(0.001)
+
+        hb_task = asyncio.create_task(heartbeat())
+        await asyncio.sleep(0.01)
+        ticks_before = ticks
+
+        await scan_governance_tree_async(
+            governance_root_override=fake_governance_tree,
+        )
+
+        scan_running = False
+        await asyncio.sleep(0.01)
+        hb_task.cancel()
+        try:
+            await hb_task
+        except asyncio.CancelledError:
+            pass
+        ticks_during = ticks - ticks_before
+        assert ticks_during >= 1, (
+            f"Heartbeat starved during scan_governance_tree_async: "
+            f"ticks={ticks_during} — Slice 12Z exorcism failed; "
+            "scan still wedges the loop"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Discipline 1 — AST drift-prevention
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestScanAsyncASTPins:
+    def _read(self) -> str:
+        return Path(
+            "backend/core/ouroboros/governance/meta/"
+            "cross_kingdom_boundary.py"
+        ).read_text()
+
+    def test_async_uses_cooperative_fs_io(self):
+        src = self._read()
+        tree = ast.parse(src)
+        target = None
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.AsyncFunctionDef)
+                and node.name == "scan_governance_tree_async"
+            ):
+                target = node
+                break
+        assert target is not None
+        body = ast.unparse(target)
+        assert "iter_files_cooperative" in body, (
+            "scan_governance_tree_async no longer uses "
+            "iter_files_cooperative — Slice 12Z exorcism broken"
+        )
+        assert "read_text_offloaded" in body, (
+            "scan_governance_tree_async no longer uses "
+            "read_text_offloaded — per-file reads back on loop"
+        )
+
+    def test_async_does_not_call_rglob_directly(self):
+        """The async path MUST go through the substrate. A
+        direct ``root.rglob(...)`` call would bypass the
+        cooperative yields and re-introduce the wedge."""
+        src = self._read()
+        tree = ast.parse(src)
+        target = None
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.AsyncFunctionDef)
+                and node.name == "scan_governance_tree_async"
+            ):
+                target = node
+                break
+        assert target is not None
+        for inner in ast.walk(target):
+            if isinstance(inner, ast.Call):
+                fn = inner.func
+                if (
+                    isinstance(fn, ast.Attribute)
+                    and fn.attr == "rglob"
+                ):
+                    pytest.fail(
+                        "scan_governance_tree_async calls "
+                        ".rglob() directly — bypasses Slice 12Z "
+                        "cooperative substrate; loop will wedge"
+                    )
+
+    def test_async_does_not_call_path_read_text(self):
+        """Per-file reads MUST go via ``read_text_offloaded``
+        (dedicated executor). Direct ``Path.read_text()`` is the
+        wedge pattern."""
+        src = self._read()
+        tree = ast.parse(src)
+        target = None
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.AsyncFunctionDef)
+                and node.name == "scan_governance_tree_async"
+            ):
+                target = node
+                break
+        assert target is not None
+        for inner in ast.walk(target):
+            if isinstance(inner, ast.Call):
+                fn = inner.func
+                # Direct call like `path.read_text(...)`.
+                if (
+                    isinstance(fn, ast.Attribute)
+                    and fn.attr == "read_text"
+                ):
+                    pytest.fail(
+                        "scan_governance_tree_async calls "
+                        ".read_text() directly — bypasses "
+                        "Slice 12Z offload; per-file reads "
+                        "wedge the loop"
+                    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Discipline 2 — validate_all_async sync-fallback offload
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestValidateAllAsyncFallbackOffload:
+    """The bt-2026-05-23-221029 fix point: when the process
+    pool fails, the sync fallback MUST run via offload_blocking
+    (thread pool) instead of sync on the loop."""
+
+    def _read(self) -> str:
+        return Path(
+            "backend/core/ouroboros/governance/meta/"
+            "shipped_code_invariants.py"
+        ).read_text()
+
+    def test_fallback_uses_offload_blocking(self):
+        """AST pin: the validate_all_async exception fallback
+        MUST reference ``offload_blocking``. Without this, a
+        pool failure re-introduces the wedge."""
+        src = self._read()
+        # Find validate_all_async function via AST.
+        tree = ast.parse(src)
+        target = None
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.AsyncFunctionDef)
+                and node.name == "validate_all_async"
+            ):
+                target = node
+                break
+        assert target is not None, (
+            "validate_all_async missing — Slice 12Z fix has "
+            "no home"
+        )
+        body = ast.unparse(target)
+        assert "offload_blocking" in body, (
+            "validate_all_async fallback no longer references "
+            "offload_blocking — Slice 12Z wedge fix regressed; "
+            "pool-failure path will wedge the loop again"
+        )
+
+    def test_slice12z_marker_present(self):
+        src = self._read()
+        assert "Slice 12Z" in src, (
+            "Slice 12Z marker comment removed from "
+            "shipped_code_invariants.py — refactor lost"
+        )
+
+    def test_double_fallback_preserves_last_resort_sync(self):
+        """When even offload_blocking fails (degraded build
+        without event_loop_governance), the absolute last
+        resort is still a direct sync call — observability
+        non-authoritative contract."""
+        src = self._read()
+        # The two-stage fallback: offload_blocking inside an
+        # outer try; sync inside its inner except.
+        # AST inspection of the fallback structure.
+        tree = ast.parse(src)
+        target = None
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.AsyncFunctionDef)
+                and node.name == "validate_all_async"
+            ):
+                target = node
+                break
+        assert target is not None
+        body_text = ast.unparse(target)
+        # Both paths must reference the sync helper —
+        # `validate_invariants_grouped` appears in the
+        # offload arg AND in the absolute-last-resort branch.
+        assert body_text.count(
+            "validate_invariants_grouped"
+        ) >= 2, (
+            "validate_all_async fallback chain incomplete — "
+            "expected offload_blocking(validate_invariants_grouped) "
+            "+ absolute-last-resort sync fallback (2 references)"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Cross-discipline sanity
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestSyncSiblingUnchanged:
+    """The sync ``scan_governance_tree`` is still called by tests
+    + other sync callers. Slice 12Z MUST NOT break it."""
+
+    def test_sync_still_callable(self, fake_governance_tree):
+        result = scan_governance_tree(
+            governance_root_override=fake_governance_tree,
+        )
+        assert isinstance(result, tuple)
+        # 2 forbidden imports in the fake tree (top + nested).
+        assert len(result) == 2
+
+
+class TestRegisterShippedInvariantsUnchanged:
+    """The validator registration is the prod-facing API."""
+
+    def test_register_returns_one_invariant(self):
+        invs = cross_kingdom_boundary.register_shipped_invariants()
+        # Single invariant registered:
+        # governance_no_coding_council_imports.
+        assert len(invs) == 1
+        assert (
+            invs[0].invariant_name
+            == "governance_no_coding_council_imports"
+        )


### PR DESCRIPTION
## Summary

Closes the `pathlib.read_text` wedge captured by Slice 12Y's tombstone in `bt-2026-05-23-221029`:

```
File ".../pathlib.py:1059 in read_text"
File ".../cross_kingdom_boundary.py:163 in _scan_one_file"
File ".../cross_kingdom_boundary.py:243 in scan_governance_tree"
File ".../cross_kingdom_boundary.py:291 in _validate_cross_kingdom_boundary"
File ".../shipped_code_invariants.py:2526 in validate_invariants_grouped"
File ".../shipped_code_invariants.py:2654 in validate_all_async"
```

The async-pool path worked; its **sync fallback** (when process pool unavailable) ran on the asyncio loop, held the GIL 301.8s, tripped LoopDeadman.

## Discipline 1 — `scan_governance_tree_async`

NEW async sibling in `cross_kingdom_boundary.py` composing the Slice 12U `cooperative_fs_io` substrate:
- `iter_files_cooperative` for non-blocking walk
- `read_text_offloaded` for per-file reads (dedicated `advisor-blast` executor)
- `offload_blocking` for AST parse + walk

Sync sibling preserved unchanged. NEW module-level helper `_scan_one_file_from_source` so the offload worker doesn't capture caller-local state.

## Discipline 2 — `validate_all_async` fallback offload

Surgical fix at `shipped_code_invariants.py:2654`: sync-fallback now dispatches via `event_loop_governance.offload_blocking` instead of calling sync on the loop. Double-fallback preserved (offload → absolute-last-resort sync) for the observability-non-authoritative contract.

## Bonus Slice 12Y bug fix (caught by Pyright)

`doubleword_provider.py:692` referenced `context` in Slice 12Y's `_check_budget` kwarg, but `_check_budget(self)` has no `context` param — would NameError at runtime. Fixed to `signal_source=None` with documented rationale: DW per-call ($0.002) is 3 orders smaller than Claude's $0.50, so the background-spend ceiling's primary use case is fully covered by the Claude path.

## Test verdict

- **16/16** Slice 12Z green (5.1s)
- **210/210** cross-arc 12U + 12W + 12X + 12Y + 12Z + advisor + Task 102 green (15.99s)
- Rebased onto main HEAD with Slice Aegis-1 merged in parallel — no conflicts

## Test coverage (16 tests, 5 areas)

| Area | Count | Notes |
|---|---|---|
| Shape | 3 | async coroutine type, helper signature, exports |
| Result parity | 4 | async ↔ sync same violations; __pycache__ skipped; top-level + nested detection |
| **Non-blocking** | **1 LOAD-BEARING** | heartbeat ticks during scan |
| AST pins | 3 | uses cooperative_fs_io; NO direct .rglob(); NO direct .read_text() |
| `validate_all_async` | 3 | fallback offload via AST walk; marker present; double-fallback preserved |
| Compatibility | 2 | sync sibling still callable; register_shipped_invariants unchanged |

## Post-merge

Path A with $1.00 cap. Expected: invariant_drift's sync fallback now runs OFF the loop via `offload_blocking` → no LoopDeadman fire. Fixture op gets clean shot at COMPLETE with Slice 12Y's reserved $0.50 runway intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes invariant scanning cooperative and moves the sync fallback off the event loop to prevent LoopDeadman stalls. Adds an async scanner and offloads heavy work so the loop stays responsive while keeping the same results.

- **New Features**
  - Added `scan_governance_tree_async` in `cross_kingdom_boundary.py` using `cooperative_fs_io` (`iter_files_cooperative`, `read_text_offloaded`) and `offload_blocking`; new helper `_scan_one_file_from_source` for offloaded AST work.
  - Updated `validate_all_async` to offload the sync fallback by calling `offload_blocking(validate_invariants_grouped)` with a last‑resort direct sync fallback if offload is unavailable.

- **Bug Fixes**
  - Fixed `doubleword_provider._check_budget` to pass `signal_source=None` and remove the invalid `context` reference.

<sup>Written for commit 235c1dd127128df643199bb6285224b52e301713. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/53907?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

