### PR TITLE
feat(aegis): Slice 2B-i — non-streaming reconcile + DW passthrough endpoints (Aegis-side only)

### DIFF
--- a/backend/core/ouroboros/aegis/daemon.py
+++ b/backend/core/ouroboros/aegis/daemon.py
@@ -162,16 +162,58 @@ def build_app(
         # so the handler can look up wire family / auth scheme /
         # credential env var without re-reading env on the hot path.
         from backend.core.ouroboros.aegis.upstream_registry import (
+            EndpointKind,
             snapshot as _upstream_snapshot,
         )
         upstream_map = _upstream_snapshot()
         app[_K_UPSTREAM_MAP] = upstream_map
-        for path in upstream_map.keys():
-            # Single shared handler — dispatches on request.path so
-            # adding upstream paths to the registry is a one-line edit.
-            app.router.add_post(path, _handle_forward)
+
+        # Register one handler per (path, method) pair. Two kinds:
+        #   - LLM_COMPLETION → _handle_forward (lease-gated, reconciled)
+        #   - PASSTHROUGH    → _handle_passthrough (session-gated, transparent)
+        # Closure binds the endpoint descriptor so the handler can dispatch
+        # without re-walking the registry on the hot path.
+        for path, endpoint in upstream_map.items():
+            if endpoint.kind is EndpointKind.LLM_COMPLETION:
+                handler = _make_llm_handler(endpoint)
+            elif endpoint.kind is EndpointKind.PASSTHROUGH:
+                handler = _make_passthrough_handler(endpoint)
+            else:  # pragma: no cover — closed enum
+                continue
+            for method in endpoint.http_methods:
+                add = getattr(app.router, f"add_{method.lower()}")
+                add(path, handler)
 
     return app
+
+
+def _make_llm_handler(endpoint):
+    """Build a closure-bound handler for an LLM_COMPLETION endpoint."""
+    async def _handler(request: web.Request) -> web.StreamResponse:
+        from backend.core.ouroboros.aegis.forwarding import forward_request
+        response, _ = await forward_request(
+            request=request,
+            endpoint=endpoint,
+            K=request.app[_K_HMAC_KEY],
+            nonce_ledger=request.app[_K_NONCE_LEDGER],
+            budget=request.app[_K_BUDGET],
+        )
+        return response
+    return _handler
+
+
+def _make_passthrough_handler(endpoint):
+    """Build a closure-bound handler for a PASSTHROUGH endpoint."""
+    async def _handler(request: web.Request) -> web.StreamResponse:
+        from backend.core.ouroboros.aegis.passthrough import forward_passthrough
+        response, _ = await forward_passthrough(
+            request=request,
+            endpoint=endpoint,
+            K=request.app[_K_HMAC_KEY],
+            active_jti=set(request.app[_K_ACTIVE_SESSIONS].keys()),
+        )
+        return response
+    return _handler
 
 
 # ---------------------------------------------------------------------------
@@ -457,52 +499,6 @@ async def _handle_lease_redeem(request: web.Request) -> web.Response:
         "verdict": reconcile_verdict.to_dict(),
         "lease": lease.to_dict(),
     })
-
-
-# ---------------------------------------------------------------------------
-# Slice 2 — upstream forwarding handler
-# ---------------------------------------------------------------------------
-
-
-async def _handle_forward(request: web.Request) -> web.StreamResponse:
-    """Slice 2 forwarding entry point.
-
-    Dispatches on ``request.path`` against the upstream registry
-    captured at ``build_app`` time (so env overrides apply at boot,
-    not per-request). Delegates everything else to
-    :func:`forwarding.forward_request`.
-
-    The HMAC key K is read once from app state and passed to the
-    forwarder; never exposed in any response body or log line.
-    """
-    app = request.app
-    upstream_map = app.get(_K_UPSTREAM_MAP)
-    if upstream_map is None:
-        # Defensive: should never happen because the route is only
-        # registered when forwarding is enabled. If it does, fail
-        # closed.
-        return web.json_response(
-            {"ok": False, "error": "forwarding_disabled"}, status=503,
-        )
-
-    endpoint = upstream_map.get(request.path)
-    if endpoint is None:
-        return web.json_response(
-            {"ok": False, "error": "upstream_path_unregistered"}, status=404,
-        )
-
-    # Lazy-import forwarding so the daemon's substrate can be imported
-    # by tests without paying the aiohttp.ClientSession startup cost.
-    from backend.core.ouroboros.aegis.forwarding import forward_request
-
-    response, _result = await forward_request(
-        request=request,
-        endpoint=endpoint,
-        K=app[_K_HMAC_KEY],
-        nonce_ledger=app[_K_NONCE_LEDGER],
-        budget=app[_K_BUDGET],
-    )
-    return response
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/ouroboros/aegis/flags.py
+++ b/backend/core/ouroboros/aegis/flags.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 ENV_AEGIS_ENABLED: str = "JARVIS_AEGIS_ENABLED"
 ENV_AEGIS_FORWARDING_ENABLED: str = "JARVIS_AEGIS_FORWARDING_ENABLED"
 ENV_AEGIS_MAX_REQUEST_BODY_BYTES: str = "JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES"
+ENV_AEGIS_MAX_RESPONSE_BUFFER_BYTES: str = "JARVIS_AEGIS_MAX_RESPONSE_BUFFER_BYTES"
 ENV_AEGIS_BOOTSTRAP_DIR: str = "JARVIS_AEGIS_BOOTSTRAP_DIR"
 ENV_AEGIS_BOOTSTRAP_TIMEOUT_S: str = "JARVIS_AEGIS_BOOTSTRAP_TIMEOUT_S"
 ENV_AEGIS_DAEMON_BIND_HOST: str = "JARVIS_AEGIS_DAEMON_BIND_HOST"
@@ -225,6 +226,24 @@ def _seeds() -> List[FlagSpec]:
             example=f"{ENV_AEGIS_MAX_REQUEST_BODY_BYTES}=8388608",
         ),
         FlagSpec(
+            name=ENV_AEGIS_MAX_RESPONSE_BUFFER_BYTES,
+            type=FlagType.INT,
+            default=4 * 1024 * 1024,
+            description=(
+                "Slice 2B-i: maximum bytes Aegis will BUFFER from a "
+                "non-streaming upstream response to parse the usage "
+                "field for authoritative reconciliation. Bytes are "
+                "still passed through to JARVIS byte-identically; "
+                "this cap only limits how much Aegis retains for "
+                "parsing. Responses larger than this fall back to the "
+                "pre-flight reserve (warning logged); 4 MiB comfortably "
+                "fits any Anthropic / DW non-streaming JSON response."
+            ),
+            category=Category.CAPACITY,
+            source_file=_SRC_AEGIS,
+            example=f"{ENV_AEGIS_MAX_RESPONSE_BUFFER_BYTES}=8388608",
+        ),
+        FlagSpec(
             name=ENV_AEGIS_BOOTSTRAP_DIR,
             type=FlagType.STR,
             default="",
@@ -410,6 +429,7 @@ __all__ = [
     "ENV_AEGIS_ENABLED",
     "ENV_AEGIS_FORWARDING_ENABLED",
     "ENV_AEGIS_MAX_REQUEST_BODY_BYTES",
+    "ENV_AEGIS_MAX_RESPONSE_BUFFER_BYTES",
     "ENV_AEGIS_HOURLY_BURN_CAP_USD",
     "ENV_AEGIS_LEASE_EXPIRY_S",
     "ENV_AEGIS_LEASE_OVERRUN_MULTIPLIER",

--- a/backend/core/ouroboros/aegis/forwarding.py
+++ b/backend/core/ouroboros/aegis/forwarding.py
@@ -191,6 +191,74 @@ def _update_usage(family: WireFamily, usage: UsageAccumulator, event: Dict[str, 
 
 
 # ---------------------------------------------------------------------------
+# Non-streaming response body parser — Slice 2B-i authoritative reconcile
+# ---------------------------------------------------------------------------
+
+
+def _parse_nonstreaming_usage(
+    family: WireFamily, body_bytes: bytes,
+) -> Optional[tuple[int, int]]:
+    """Parse the upstream non-streaming JSON body for usage.
+
+    Returns ``(input_tokens, output_tokens)`` on success, ``None`` on any
+    failure (malformed JSON, missing usage field, schema drift). Caller
+    treats None as "fall back to pre-flight reserve" — Aegis remains the
+    authoritative ledger even when parsing fails (over-account beats
+    under-account).
+
+    Anthropic non-streaming shape:
+        {"id": "...", "type": "message", ..., "usage": {
+            "input_tokens": N, "output_tokens": M,
+            "cache_creation_input_tokens": ..., "cache_read_input_tokens": ...
+        }}
+
+    OpenAI-compat non-streaming shape:
+        {"id": "...", "choices": [...], "usage": {
+            "prompt_tokens": N, "completion_tokens": M, "total_tokens": ...
+        }}
+    """
+    if not body_bytes:
+        return None
+    try:
+        obj = json.loads(body_bytes.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    usage_obj = obj.get("usage")
+    if not isinstance(usage_obj, dict):
+        return None
+
+    if family is WireFamily.ANTHROPIC:
+        in_t = usage_obj.get("input_tokens")
+        out_t = usage_obj.get("output_tokens")
+    elif family is WireFamily.OPENAI_COMPAT:
+        in_t = usage_obj.get("input_tokens", usage_obj.get("prompt_tokens"))
+        out_t = usage_obj.get("output_tokens", usage_obj.get("completion_tokens"))
+    else:
+        return None
+
+    if not isinstance(in_t, int) or not isinstance(out_t, int):
+        return None
+    if in_t < 0 or out_t < 0:
+        return None
+    return in_t, out_t
+
+
+def _max_response_buffer_bytes() -> int:
+    """Cap on bytes Aegis buffers from a non-streaming response for
+    usage parsing. Bytes still pass through to JARVIS byte-identically;
+    this only limits how much Aegis retains in memory for parsing."""
+    raw = os.environ.get("JARVIS_AEGIS_MAX_RESPONSE_BUFFER_BYTES", "").strip()
+    if not raw:
+        return 4 * 1024 * 1024
+    try:
+        return max(1024, int(raw))
+    except (TypeError, ValueError):
+        return 4 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
 # Outcome enum
 # ---------------------------------------------------------------------------
 
@@ -392,7 +460,9 @@ async def forward_request(
     elif endpoint.auth_scheme is AuthScheme.HEADER_BEARER:
         outbound_headers[endpoint.auth_header] = f"Bearer {upstream_credential}"
 
-    upstream_url = endpoint.upstream_url()
+    upstream_url = endpoint.upstream_url_for(
+        request_path=request.path, query_string=request.query_string,
+    )
     timeout = aiohttp.ClientTimeout(
         connect=_DEFAULT_CONNECT_TIMEOUT_S,
         sock_read=_DEFAULT_SOCK_READ_TIMEOUT_S,
@@ -447,6 +517,15 @@ async def forward_request(
 
         guillotine_fired = False
         client_disconnected = False
+        # Slice 2B-i: for non-streaming responses, buffer the body
+        # (capped) so we can parse `usage` for authoritative reconcile.
+        # Bytes are STILL written to the client byte-identically as they
+        # arrive — the buffer is a tee for parsing only.
+        nonstreaming_buffer: Optional[bytearray] = None
+        nonstreaming_cap: int = 0
+        if not is_streaming:
+            nonstreaming_buffer = bytearray()
+            nonstreaming_cap = _max_response_buffer_bytes()
         try:
             async for chunk in upstream_resp.content.iter_any():
                 if not chunk:
@@ -486,26 +565,83 @@ async def forward_request(
                         # the underlying connection from the session pool.
                         upstream_resp.release()
                         break
-
-            # Non-streaming responses include usage directly in the
-            # final JSON body. Re-parse the last 16KB of the response
-            # we already wrote out for the usage field.
-            if not is_streaming and not client_disconnected and not guillotine_fired:
-                # Drain anything remaining (rare with iter_chunked).
-                trailing = await upstream_resp.content.read()
-                if trailing:
-                    try:
-                        await client_resp.write(trailing)
-                    except (ConnectionResetError, aiohttp.ClientConnectionError):
-                        client_disconnected = True
-                # Best-effort: aiohttp doesn't let us "tee" the body
-                # we already wrote, so for non-streaming we rely on
-                # the Content-Length + a separate accounting call.
-                # For Slice 2 we accept caller-supplied actual cost
-                # via /lease/redeem; non-streaming usage tracking is
-                # a Slice 3 refinement.
+                else:
+                    # Non-streaming: tee into the parse buffer up to cap.
+                    # If response exceeds cap, the buffer truncates and
+                    # the parse will likely fail → we fall back to the
+                    # pre-flight reserve (operator-friendly: over-account).
+                    assert nonstreaming_buffer is not None
+                    remaining = nonstreaming_cap - len(nonstreaming_buffer)
+                    if remaining > 0:
+                        nonstreaming_buffer.extend(chunk[:remaining])
 
         finally:
+            # IMPORTANT ordering: parse non-streaming body + reconcile
+            # budget BEFORE write_eof. Once write_eof flushes EOF to
+            # the client, the consumer (e.g. aiohttp TestClient's
+            # ``await resp.read()``) returns and may immediately
+            # snapshot the budget. Reconcile must be observable by then.
+            _nonstreaming_parse_succeeded = False
+            if (
+                not is_streaming
+                and not client_disconnected
+                and final_status is not None
+                and 200 <= final_status < 300
+                and nonstreaming_buffer is not None
+                and len(nonstreaming_buffer) > 0
+            ):
+                parsed = _parse_nonstreaming_usage(
+                    endpoint.wire_family, bytes(nonstreaming_buffer),
+                )
+                if parsed is not None:
+                    in_t, out_t = parsed
+                    usage.input_tokens = in_t
+                    usage.output_tokens = out_t
+                    _nonstreaming_parse_succeeded = True
+                else:
+                    logger.warning(
+                        "[AegisForward] non-streaming usage parse failed "
+                        "(body bytes=%d, family=%s, lease=%s); reserve stands",
+                        len(nonstreaming_buffer),
+                        endpoint.wire_family.value,
+                        lease.nonce,
+                    )
+
+            # Pre-flush reconcile / reserve-stands decision. Three cases:
+            #
+            #   1. Non-streaming + parse SUCCEEDED → reconcile with the
+            #      parsed actual cost. Must happen BEFORE write_eof so
+            #      the budget snapshot is consistent when the client
+            #      unblocks on EOF (race-free).
+            #
+            #   2. Non-streaming + parse FAILED → DO NOT reconcile.
+            #      The pre-flight reserve stands until lease expiry.
+            #      "Over-account, never silently zero" invariant.
+            #
+            #   3. Streaming → fall through; the SSE-parser-driven
+            #      reconcile happens at function tail (its usage
+            #      accumulator is updated per chunk, and the client
+            #      unblock on EOF is gradual — no race).
+            _reconcile_handled = False
+            if not is_streaming and not client_disconnected:
+                if _nonstreaming_parse_succeeded:
+                    _actual_cost_preflush = usage.cost_usd(price)
+                    try:
+                        await budget.reconcile(
+                            lease_nonce=lease.nonce,
+                            op_id=lease.op_id,
+                            route=lease.route,
+                            actual_cost_usd=_actual_cost_preflush,
+                        )
+                    except Exception as exc:  # noqa: BLE001 — never fail-loud
+                        logger.warning(
+                            "[AegisForward] pre-flush reconcile raised: %s", exc,
+                        )
+                    _reconcile_handled = True
+                else:
+                    # Parse failed → reserve stands (deliberate).
+                    _reconcile_handled = True
+
             try:
                 await client_resp.write_eof()
             except (ConnectionResetError, aiohttp.ClientConnectionError):
@@ -529,13 +665,16 @@ async def forward_request(
         outcome = ForwardOutcome.SUCCESS
         detail = None
 
-    # Reconcile budget — this is the authoritative actual-cost record.
-    await budget.reconcile(
-        lease_nonce=lease.nonce,
-        op_id=lease.op_id,
-        route=lease.route,
-        actual_cost_usd=actual_cost,
-    )
+    # Reconcile budget — streaming path lands here (non-streaming was
+    # already handled pre-flush above, either via reconcile-with-parsed
+    # or reserve-stands-on-parse-failure).
+    if not _reconcile_handled:
+        await budget.reconcile(
+            lease_nonce=lease.nonce,
+            op_id=lease.op_id,
+            route=lease.route,
+            actual_cost_usd=actual_cost,
+        )
 
     return client_resp, ForwardResult(
         outcome=outcome,

--- a/backend/core/ouroboros/aegis/passthrough.py
+++ b/backend/core/ouroboros/aegis/passthrough.py
@@ -1,0 +1,376 @@
+"""Aegis credential-injecting passthrough — closed allowlist.
+
+For upstream API endpoints that JARVIS needs to reach but that do NOT
+burn LLM tokens (file uploads, batch management, model listing). The
+passthrough:
+
+  1. Validates the inbound session token (NOT a lease — passthrough
+     has no cost, so no lease accounting applies).
+  2. Reads the inbound body byte-for-byte (multipart, JSON, or empty
+     — Aegis doesn't parse, doesn't re-encode).
+  3. Strips ALL JARVIS-side auth + lease + internal headers.
+  4. Injects the real upstream credential from env.
+  5. Forwards the request (preserving method, query string, Content-Type).
+  6. Streams the response back to the client byte-identically.
+  7. Records a non-credential audit line for observability.
+
+Binding constraints (Slice 2B-i):
+
+  * **NOT an open proxy.** Only the explicit (method, path) pairs
+    declared in :mod:`upstream_registry` with ``kind=PASSTHROUGH``
+    are reachable. The daemon registers ONE route per (method, path)
+    pair at boot; no dynamic dispatch.
+  * **No credential logging.** Outbound auth header value never
+    appears in any log line, exception, or response body.
+  * **No multipart body logging.** Request body bytes (potentially
+    PII / proprietary data) are forwarded but never logged.
+  * **Strip-then-inject ordering.** Strip the inbound auth/lease
+    BEFORE composing outbound headers — guarantees a no-op header
+    set in the gap window between strip and inject.
+  * **No token-cost reconciliation.** Passthrough endpoints by
+    design do NOT touch the budget state machine; the spend WAL
+    is unaffected.
+  * **Standard request-body cap** (``JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES``)
+    applies — same ceiling as LLM forwarding.
+
+The audit line emitted per passthrough request contains:
+``method``, ``aegis_path`` (template), ``request_path`` (concrete),
+``upstream_status``, ``upstream_url`` (host+path only — no auth/query),
+``content_length`` (response). Operator can grep
+``[AegisPassthrough]`` in logs for the full audit trail.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional, Set, Tuple
+
+import aiohttp
+from aiohttp import web
+
+from backend.core.ouroboros.aegis.lease import (
+    TokenVerdictKind,
+    validate_session_token,
+)
+from backend.core.ouroboros.aegis.upstream_registry import (
+    AuthScheme,
+    EndpointKind,
+    UpstreamEndpoint,
+)
+
+logger = logging.getLogger(__name__)
+
+
+PASSTHROUGH_SCHEMA_VERSION: str = "aegis_passthrough.1"
+
+# Read-size for streaming response pass-through. Matches forwarding.py
+# iter_any() shape — preserves TCP chunk boundaries.
+_DEFAULT_CONNECT_TIMEOUT_S: float = 10.0
+_DEFAULT_SOCK_READ_TIMEOUT_S: float = 30.0
+_DEFAULT_OUTBOUND_TOTAL_TIMEOUT_S: float = 600.0  # batch retrieval can be slow
+
+# Headers we ALWAYS strip from inbound before composing outbound.
+# Anything carrying JARVIS-side identity or auth must not leak upstream.
+_INBOUND_HEADERS_TO_STRIP: Tuple[str, ...] = (
+    "authorization",
+    "x-jarvis-lease",
+    "x-jarvis-session",
+    "x-jarvis-causal-lineage",
+    "host",
+    "content-length",  # aiohttp recomputes on outbound
+)
+
+
+class PassthroughOutcome(str, enum.Enum):
+    """Closed 5-value taxonomy of passthrough outcomes."""
+
+    SUCCESS = "success"
+    AUTH_MISSING = "auth_missing"
+    AUTH_INVALID = "auth_invalid"
+    UPSTREAM_UNREACHABLE = "upstream_unreachable"
+    CLIENT_DISCONNECTED = "client_disconnected"
+
+
+@dataclass(frozen=True)
+class PassthroughResult:
+    outcome: PassthroughOutcome
+    upstream_status: Optional[int]
+    response_bytes: int
+    detail: Optional[str] = None
+    schema_version: str = PASSTHROUGH_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Auth — session token (passthrough does NOT consume leases)
+# ---------------------------------------------------------------------------
+
+
+def _bearer_session(request: web.Request) -> Optional[str]:
+    """Extract session token from ``Authorization: Bearer <token>``.
+
+    Passthrough deliberately uses session-token auth (the JARVIS process
+    is already proven legitimate via /session/establish). A lease would
+    be appropriate if there were cost accounting; passthrough has none.
+    """
+    raw = request.headers.get("Authorization", "").strip()
+    if not raw or not raw.lower().startswith("bearer "):
+        return None
+    return raw[7:].strip() or None
+
+
+# ---------------------------------------------------------------------------
+# Header composition
+# ---------------------------------------------------------------------------
+
+
+def _max_request_body_bytes() -> int:
+    raw = os.environ.get("JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES", "").strip()
+    if not raw:
+        return 4 * 1024 * 1024
+    try:
+        return max(1024, int(raw))
+    except (TypeError, ValueError):
+        return 4 * 1024 * 1024
+
+
+def _strip_inbound_headers(request: web.Request) -> Dict[str, str]:
+    """Build outbound header set: copy inbound, strip JARVIS auth/lease
+    plus host/content-length. Returns a fresh dict; never mutates
+    request.headers. Credential VALUE is never read here — that lands
+    via the upstream_credential injection step that follows."""
+    out: Dict[str, str] = {}
+    for name, value in request.headers.items():
+        if name.lower() in _INBOUND_HEADERS_TO_STRIP:
+            continue
+        out[name] = value
+    return out
+
+
+def _inject_upstream_credential(
+    headers: Dict[str, str], endpoint: UpstreamEndpoint, credential: str,
+) -> None:
+    """Add the upstream auth header per scheme. Mutates ``headers``."""
+    if endpoint.auth_scheme is AuthScheme.HEADER_RAW:
+        headers[endpoint.auth_header] = credential
+    elif endpoint.auth_scheme is AuthScheme.HEADER_BEARER:
+        headers[endpoint.auth_header] = f"Bearer {credential}"
+    # Closed enum — no else branch needed.
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+async def forward_passthrough(
+    *,
+    request: web.Request,
+    endpoint: UpstreamEndpoint,
+    K: bytes,
+    active_jti: Set[str],
+) -> Tuple[web.StreamResponse, PassthroughResult]:
+    """Validate session + forward to allowlisted upstream + stream back.
+
+    Returns ``(response, result)``. NEVER raises — error paths build
+    a json_response with closed-taxonomy outcome and return.
+    """
+    now = time.time()
+
+    # --- 1. Endpoint kind invariant (defensive — daemon should never
+    # route LLM endpoints here, but fail closed if misconfigured) -----
+    if endpoint.kind is not EndpointKind.PASSTHROUGH:
+        return (
+            web.json_response(
+                {"ok": False, "error": "endpoint_kind_mismatch"},
+                status=500,
+            ),
+            PassthroughResult(
+                outcome=PassthroughOutcome.UPSTREAM_UNREACHABLE,
+                upstream_status=None,
+                response_bytes=0,
+                detail=f"endpoint {endpoint.aegis_path} is not PASSTHROUGH",
+            ),
+        )
+
+    # --- 2. Session auth ----------------------------------------------------
+    presented = _bearer_session(request)
+    if presented is None:
+        return (
+            web.json_response(
+                {"ok": False, "error": "missing_session_bearer"}, status=401,
+            ),
+            PassthroughResult(
+                outcome=PassthroughOutcome.AUTH_MISSING,
+                upstream_status=None,
+                response_bytes=0,
+            ),
+        )
+
+    session_verdict = validate_session_token(
+        K, presented, now_s=now, active_jti=active_jti,
+    )
+    if session_verdict.kind is not TokenVerdictKind.VALID:
+        return (
+            web.json_response(
+                {"ok": False, "error": f"session_{session_verdict.kind.value}"},
+                status=403,
+            ),
+            PassthroughResult(
+                outcome=PassthroughOutcome.AUTH_INVALID,
+                upstream_status=None,
+                response_bytes=0,
+                detail=session_verdict.detail,
+            ),
+        )
+
+    # --- 3. Request body (cap-enforced; passthrough never parses) ----------
+    try:
+        body_bytes = await request.content.read(_max_request_body_bytes())
+    except (asyncio.CancelledError, aiohttp.ClientError):
+        raise
+    except Exception as exc:  # noqa: BLE001
+        return (
+            web.json_response(
+                {"ok": False, "error": "request_body_read_failed"}, status=400,
+            ),
+            PassthroughResult(
+                outcome=PassthroughOutcome.CLIENT_DISCONNECTED,
+                upstream_status=None,
+                response_bytes=0,
+                detail=str(exc),
+            ),
+        )
+
+    # --- 4. Credential injection (never logged) -----------------------------
+    upstream_credential = os.environ.get(endpoint.credential_env_var, "").strip()
+    if not upstream_credential:
+        return (
+            web.json_response({
+                "ok": False,
+                "error": "upstream_credential_unavailable",
+                "detail": (
+                    f"env var {endpoint.credential_env_var} is empty in "
+                    "aegis daemon"
+                ),
+            }, status=503),
+            PassthroughResult(
+                outcome=PassthroughOutcome.UPSTREAM_UNREACHABLE,
+                upstream_status=None,
+                response_bytes=0,
+                detail=f"missing {endpoint.credential_env_var}",
+            ),
+        )
+
+    outbound_headers = _strip_inbound_headers(request)
+    _inject_upstream_credential(outbound_headers, endpoint, upstream_credential)
+
+    # --- 5. Compose outbound URL preserving path + query string ------------
+    # request.path is the concrete path (template substituted by aiohttp);
+    # query_string preserved so e.g. ?limit=10 on /v1/batches survives.
+    upstream_url = endpoint.upstream_url_for(
+        request_path=request.path,
+        query_string=request.query_string,
+    )
+
+    timeout = aiohttp.ClientTimeout(
+        connect=_DEFAULT_CONNECT_TIMEOUT_S,
+        sock_read=_DEFAULT_SOCK_READ_TIMEOUT_S,
+        total=_DEFAULT_OUTBOUND_TOTAL_TIMEOUT_S,
+    )
+
+    # --- 6. Open upstream + stream response back ---------------------------
+    final_status: Optional[int] = None
+    bytes_passed: int = 0
+    client_disconnected = False
+
+    async with aiohttp.ClientSession(
+        timeout=timeout, headers=outbound_headers,
+    ) as session:
+        try:
+            upstream_resp = await session.request(
+                method=request.method,
+                url=upstream_url,
+                data=body_bytes if body_bytes else None,
+            )
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            return (
+                web.json_response({
+                    "ok": False,
+                    "error": "upstream_unreachable",
+                    "detail": str(exc),
+                }, status=502),
+                PassthroughResult(
+                    outcome=PassthroughOutcome.UPSTREAM_UNREACHABLE,
+                    upstream_status=None,
+                    response_bytes=0,
+                    detail=str(exc),
+                ),
+            )
+
+        final_status = upstream_resp.status
+
+        # Mirror upstream content-type + cache-control. Don't propagate
+        # transport-encoding headers (aiohttp manages those outbound).
+        passthrough_response_headers: Dict[str, str] = {}
+        for hdr in ("Content-Type", "Cache-Control"):
+            v = upstream_resp.headers.get(hdr)
+            if v:
+                passthrough_response_headers[hdr] = v
+
+        client_resp = web.StreamResponse(
+            status=final_status,
+            headers=passthrough_response_headers,
+        )
+        client_resp.enable_chunked_encoding()
+        await client_resp.prepare(request)
+
+        try:
+            async for chunk in upstream_resp.content.iter_any():
+                if not chunk:
+                    continue
+                try:
+                    await client_resp.write(chunk)
+                    bytes_passed += len(chunk)
+                except (ConnectionResetError, aiohttp.ClientConnectionError):
+                    client_disconnected = True
+                    break
+        finally:
+            try:
+                await client_resp.write_eof()
+            except (ConnectionResetError, aiohttp.ClientConnectionError):
+                client_disconnected = True
+
+    # --- 7. Audit log (no credentials, no body bytes) ----------------------
+    # We log: method, path template + concrete, upstream status, bytes,
+    # and the host portion of the upstream URL (no query string, no
+    # auth) so operator can see "which DW endpoint was hit".
+    upstream_host = endpoint.upstream_base_url
+    logger.info(
+        "[AegisPassthrough] method=%s template=%s concrete=%s "
+        "upstream_host=%s upstream_status=%s bytes=%d disconnected=%s",
+        request.method, endpoint.aegis_path, request.path,
+        upstream_host, final_status, bytes_passed, client_disconnected,
+    )
+
+    outcome = (
+        PassthroughOutcome.CLIENT_DISCONNECTED if client_disconnected
+        else PassthroughOutcome.SUCCESS
+    )
+    return client_resp, PassthroughResult(
+        outcome=outcome,
+        upstream_status=final_status,
+        response_bytes=bytes_passed,
+        detail=None,
+    )
+
+
+__all__ = [
+    "PASSTHROUGH_SCHEMA_VERSION",
+    "PassthroughOutcome",
+    "PassthroughResult",
+    "forward_passthrough",
+]

--- a/backend/core/ouroboros/aegis/upstream_registry.py
+++ b/backend/core/ouroboros/aegis/upstream_registry.py
@@ -1,26 +1,32 @@
 """Upstream endpoint registry — single source of truth for forwarding.
 
-Maps each Aegis-side path Aegis serves (``/v1/messages``,
-``/v1/chat/completions``) to:
+Maps each Aegis-side method+path Aegis serves to its upstream descriptor.
 
-  1. The upstream base URL (where Aegis sends the forwarded request).
-  2. The auth header name expected by the upstream (e.g. ``x-api-key``
-     for Anthropic, ``Authorization: Bearer`` for OpenAI-compat).
-  3. The credential env var name (so Aegis knows which env var holds
-     the real API key the forwarded request needs).
-  4. The wire family (``anthropic`` or ``openai_compat``) so the
-     forwarder knows which streaming-usage parser to apply.
+Two endpoint **kinds** (closed taxonomy, AST-pinned):
 
-The registry is built at module import from existing JARVIS env
-conventions (``DOUBLEWORD_BASE_URL`` is composed; Anthropic's URL is
-sourced from env with the well-known default). NO hardcoded constants
-beyond the upstream domain names — and even those are env-overridable.
+  * ``LLM_COMPLETION`` — Lease-required; body parsed for usage; budget
+    reconciled authoritatively by Aegis on stream end / response body.
+    Examples: ``POST /v1/messages``, ``POST /v1/chat/completions``.
 
-This is a CLOSED registry. Adding a new upstream provider requires:
-  1. Adding an :class:`UpstreamEndpoint` to ``_REGISTRY``
-  2. Adding the credential env var to
+  * ``PASSTHROUGH`` — Session-token authenticated; transparent body
+    pass-through; NO usage parsing, NO budget reconcile. Used for
+    non-LLM API operations where JARVIS still needs to talk to the
+    upstream but the call doesn't burn tokens (file uploads, batch
+    management, model listing).
+
+Per binding directives (Slice 2B-i):
+  * Closed allowlist — Aegis is NOT an open proxy.
+  * Only the explicit (method, path) pairs in :func:`_build_registry`
+    are served; unknown ``/v1/*`` returns 404.
+  * Aegis injects the real upstream credential; JARVIS-side auth
+    (lease/session/internal) is stripped before forwarding.
+  * Multipart bodies (``POST /v1/files``) pass through byte-identically.
+
+Adding a new upstream surface requires:
+  1. Adding an :class:`UpstreamEndpoint` to ``_build_registry``
+  2. Adding its ``credential_env_var`` to
      :mod:`backend.core.ouroboros.aegis.credential_registry`
-  3. Adding the wire-family handler in
+  3. (LLM_COMPLETION only) Wire-family usage parser in
      :mod:`backend.core.ouroboros.aegis.forwarding`
 """
 from __future__ import annotations
@@ -35,15 +41,11 @@ from backend.core.ouroboros.aegis.credential_registry import (
 )
 
 
-UPSTREAM_REGISTRY_SCHEMA_VERSION: str = "aegis_upstream_registry.1"
+UPSTREAM_REGISTRY_SCHEMA_VERSION: str = "aegis_upstream_registry.2"
 
 
 class WireFamily(str, enum.Enum):
-    """Closed 2-value taxonomy of upstream wire shapes Aegis forwards.
-
-    Each family has a corresponding streaming-usage parser in
-    :mod:`backend.core.ouroboros.aegis.forwarding`.
-    """
+    """Closed 2-value taxonomy of upstream wire shapes for LLM completion."""
 
     ANTHROPIC = "anthropic"          # /v1/messages, SSE with `usage` in message_start + message_delta
     OPENAI_COMPAT = "openai_compat"  # /v1/chat/completions, SSE with `usage` in final delta
@@ -56,6 +58,17 @@ class AuthScheme(str, enum.Enum):
     HEADER_BEARER = "header_bearer"       # Header value is `Bearer <key>`
 
 
+class EndpointKind(str, enum.Enum):
+    """Closed 2-value taxonomy of how Aegis treats the endpoint.
+
+    - LLM_COMPLETION: lease-gated, usage-parsed, budget-reconciled
+    - PASSTHROUGH:    session-gated, transparent, no budget impact
+    """
+
+    LLM_COMPLETION = "llm_completion"
+    PASSTHROUGH = "passthrough"
+
+
 # ---------------------------------------------------------------------------
 # Env knobs (single seam)
 # ---------------------------------------------------------------------------
@@ -64,15 +77,10 @@ ENV_AEGIS_UPSTREAM_ANTHROPIC_URL: str = "JARVIS_AEGIS_UPSTREAM_ANTHROPIC_URL"
 ENV_AEGIS_UPSTREAM_DOUBLEWORD_URL: str = "JARVIS_AEGIS_UPSTREAM_DOUBLEWORD_URL"
 
 _ANTHROPIC_DEFAULT_BASE_URL: str = "https://api.anthropic.com"
-# DOUBLEWORD_BASE_URL convention from doubleword_provider.py:44 includes
-# the /v1 suffix. Aegis aligns: the upstream BASE URL we use for outbound
-# already includes /v1, and the path Aegis serves is /v1/chat/completions.
-# We compose by reading the existing env, falling back to the same default.
 _DOUBLEWORD_DEFAULT_BASE_URL: str = "https://api.doubleword.ai"
 
 
 def _resolve_anthropic_base_url() -> str:
-    # Operator override first, then bare default.
     return (
         os.environ.get(ENV_AEGIS_UPSTREAM_ANTHROPIC_URL, "").strip()
         or _ANTHROPIC_DEFAULT_BASE_URL
@@ -92,7 +100,6 @@ def _resolve_doubleword_base_url() -> str:
         return override.rstrip("/")
     existing = os.environ.get("DOUBLEWORD_BASE_URL", "").strip()
     if existing:
-        # Strip trailing /v1 if present so we can append the path served.
         stripped = existing.rstrip("/")
         if stripped.endswith("/v1"):
             stripped = stripped[: -len("/v1")]
@@ -109,25 +116,62 @@ def _resolve_doubleword_base_url() -> str:
 class UpstreamEndpoint:
     """Frozen descriptor of one upstream Aegis can forward to.
 
-    ``aegis_path`` is what Aegis registers as its own route. The
-    forwarder appends this path to ``upstream_base_url`` to compose
-    the outbound URL — preserves byte-identity between what JARVIS
-    requests and what upstream receives.
+    ``aegis_path`` can be a literal path (``/v1/messages``) or an aiohttp
+    route template with placeholders (``/v1/batches/{batch_id}``). For
+    template paths, the path parameter is substituted from
+    ``request.match_info`` into ``request.path`` at forward time — no
+    template engine here; the path Aegis serves is the path Aegis forwards.
+
+    For LLM_COMPLETION endpoints, ``wire_family`` MUST be set (the
+    forwarder dispatches its usage parser by family). For PASSTHROUGH
+    endpoints, ``wire_family`` MUST be None.
     """
 
     aegis_path: str
     upstream_base_url: str
-    wire_family: WireFamily
     auth_header: str
     auth_scheme: AuthScheme
     credential_env_var: str
-    # Default route hint — used only if the lease doesn't specify a route.
-    # Aegis pricing lookup is keyed on (route, model); the lease already
-    # carries route, so this is just a defensive fallback.
-    default_route_hint: str
+    kind: EndpointKind
+    http_methods: Tuple[str, ...]
+    # LLM_COMPLETION-only fields:
+    wire_family: Optional[WireFamily] = None
+    default_route_hint: str = "STANDARD"
 
-    def upstream_url(self) -> str:
-        return f"{self.upstream_base_url.rstrip('/')}{self.aegis_path}"
+    def __post_init__(self) -> None:
+        # Frozen-dataclass-compatible validation — fail loud at construction.
+        if self.kind is EndpointKind.LLM_COMPLETION and self.wire_family is None:
+            raise ValueError(
+                f"LLM_COMPLETION endpoint {self.aegis_path} must declare a "
+                f"wire_family (got None)"
+            )
+        if self.kind is EndpointKind.PASSTHROUGH and self.wire_family is not None:
+            raise ValueError(
+                f"PASSTHROUGH endpoint {self.aegis_path} must NOT declare a "
+                f"wire_family (got {self.wire_family}). Passthrough endpoints "
+                f"don't parse usage."
+            )
+        if not self.http_methods:
+            raise ValueError(
+                f"endpoint {self.aegis_path} must declare at least one HTTP method"
+            )
+        for m in self.http_methods:
+            if m != m.upper() or not m.isascii():
+                raise ValueError(
+                    f"endpoint {self.aegis_path} method {m!r} must be uppercase ASCII"
+                )
+
+    def upstream_url_for(self, request_path: str, query_string: str = "") -> str:
+        """Compose the outbound URL for a given inbound request path
+        (and optional query string). For templated paths
+        (``/v1/batches/{batch_id}``), ``request_path`` is the concrete
+        path the client requested (``/v1/batches/abc123``) — aiohttp
+        already matched the template; we just forward the concrete
+        path byte-identically."""
+        url = f"{self.upstream_base_url.rstrip('/')}{request_path}"
+        if query_string:
+            url = f"{url}?{query_string}"
+        return url
 
 
 # ---------------------------------------------------------------------------
@@ -136,24 +180,82 @@ class UpstreamEndpoint:
 
 
 def _build_registry() -> Mapping[str, UpstreamEndpoint]:
+    anthropic_base = _resolve_anthropic_base_url()
+    dw_base = _resolve_doubleword_base_url()
     return {
+        # ---- LLM_COMPLETION ----
         "/v1/messages": UpstreamEndpoint(
             aegis_path="/v1/messages",
-            upstream_base_url=_resolve_anthropic_base_url(),
+            upstream_base_url=anthropic_base,
             wire_family=WireFamily.ANTHROPIC,
             auth_header="x-api-key",
             auth_scheme=AuthScheme.HEADER_RAW,
             credential_env_var="ANTHROPIC_API_KEY",
             default_route_hint="IMMEDIATE",
+            kind=EndpointKind.LLM_COMPLETION,
+            http_methods=("POST",),
         ),
         "/v1/chat/completions": UpstreamEndpoint(
             aegis_path="/v1/chat/completions",
-            upstream_base_url=_resolve_doubleword_base_url(),
+            upstream_base_url=dw_base,
             wire_family=WireFamily.OPENAI_COMPAT,
             auth_header="Authorization",
             auth_scheme=AuthScheme.HEADER_BEARER,
             credential_env_var="DOUBLEWORD_API_KEY",
             default_route_hint="STANDARD",
+            kind=EndpointKind.LLM_COMPLETION,
+            http_methods=("POST",),
+        ),
+        # ---- PASSTHROUGH (DW non-LLM operations, allowlisted) ----
+        # POST /v1/files — multipart upload of batch input JSONL
+        "/v1/files": UpstreamEndpoint(
+            aegis_path="/v1/files",
+            upstream_base_url=dw_base,
+            auth_header="Authorization",
+            auth_scheme=AuthScheme.HEADER_BEARER,
+            credential_env_var="DOUBLEWORD_API_KEY",
+            kind=EndpointKind.PASSTHROUGH,
+            http_methods=("POST",),
+        ),
+        # POST /v1/batches — create batch job
+        "/v1/batches": UpstreamEndpoint(
+            aegis_path="/v1/batches",
+            upstream_base_url=dw_base,
+            auth_header="Authorization",
+            auth_scheme=AuthScheme.HEADER_BEARER,
+            credential_env_var="DOUBLEWORD_API_KEY",
+            kind=EndpointKind.PASSTHROUGH,
+            http_methods=("POST",),
+        ),
+        # GET /v1/batches/{batch_id} — poll batch status
+        "/v1/batches/{batch_id}": UpstreamEndpoint(
+            aegis_path="/v1/batches/{batch_id}",
+            upstream_base_url=dw_base,
+            auth_header="Authorization",
+            auth_scheme=AuthScheme.HEADER_BEARER,
+            credential_env_var="DOUBLEWORD_API_KEY",
+            kind=EndpointKind.PASSTHROUGH,
+            http_methods=("GET",),
+        ),
+        # GET /v1/files/{file_id}/content — retrieve batch output JSONL
+        "/v1/files/{file_id}/content": UpstreamEndpoint(
+            aegis_path="/v1/files/{file_id}/content",
+            upstream_base_url=dw_base,
+            auth_header="Authorization",
+            auth_scheme=AuthScheme.HEADER_BEARER,
+            credential_env_var="DOUBLEWORD_API_KEY",
+            kind=EndpointKind.PASSTHROUGH,
+            http_methods=("GET",),
+        ),
+        # GET /v1/models — list available models (DW health probe)
+        "/v1/models": UpstreamEndpoint(
+            aegis_path="/v1/models",
+            upstream_base_url=dw_base,
+            auth_header="Authorization",
+            auth_scheme=AuthScheme.HEADER_BEARER,
+            credential_env_var="DOUBLEWORD_API_KEY",
+            kind=EndpointKind.PASSTHROUGH,
+            http_methods=("GET",),
         ),
     }
 
@@ -174,11 +276,7 @@ def _validate_credential_registry_alignment(
 ) -> None:
     """Defense: every upstream endpoint's credential_env_var MUST appear
     in :mod:`credential_registry`'s frozen set — otherwise env_scrub
-    would miss it. Raises at boot rather than silently degrading.
-
-    This is the structural seam that keeps the two registries from
-    drifting. Adding a new provider requires both edits.
-    """
+    would miss it. Raises at boot rather than silently degrading."""
     known = upstream_credential_env_vars()
     missing = sorted(
         ep.credential_env_var for ep in registry.values()
@@ -194,24 +292,44 @@ def _validate_credential_registry_alignment(
 
 
 def known_aegis_paths() -> Tuple[str, ...]:
-    """Stable tuple of the Aegis-side paths this registry serves.
-    Used by AST pins to enumerate the allowed /v1/* surface."""
+    """Stable tuple of Aegis-side paths (templates included). Used by
+    AST pins to enumerate the allowed /v1/* surface."""
     return tuple(sorted(_build_registry().keys()))
 
 
 def endpoint_for_path(path: str) -> Optional[UpstreamEndpoint]:
-    """Lookup helper. Returns None if the path is not registered."""
+    """Lookup by aegis_path (template or literal). Returns None if
+    not registered."""
     return _build_registry().get(path)
+
+
+def llm_completion_endpoints() -> Mapping[str, UpstreamEndpoint]:
+    """Sub-snapshot of LLM completion endpoints only."""
+    return {
+        path: ep for path, ep in _build_registry().items()
+        if ep.kind is EndpointKind.LLM_COMPLETION
+    }
+
+
+def passthrough_endpoints() -> Mapping[str, UpstreamEndpoint]:
+    """Sub-snapshot of passthrough endpoints only."""
+    return {
+        path: ep for path, ep in _build_registry().items()
+        if ep.kind is EndpointKind.PASSTHROUGH
+    }
 
 
 __all__ = [
     "AuthScheme",
     "ENV_AEGIS_UPSTREAM_ANTHROPIC_URL",
     "ENV_AEGIS_UPSTREAM_DOUBLEWORD_URL",
+    "EndpointKind",
     "UPSTREAM_REGISTRY_SCHEMA_VERSION",
     "UpstreamEndpoint",
     "WireFamily",
     "endpoint_for_path",
     "known_aegis_paths",
+    "llm_completion_endpoints",
+    "passthrough_endpoints",
     "snapshot",
 ]

--- a/tests/aegis/integration/__init__.py
+++ b/tests/aegis/integration/__init__.py
@@ -1,0 +1,15 @@
+"""Aegis integration test suite — gated by ``@pytest.mark.aegis_integration``.
+
+Tests in this directory exercise the full credential-confiscation
+spine in production-shape code: real preflight, real subprocess, real
+provider modules (Slice 2B-ii+), real Aegis daemon, stub upstream.
+
+Run locally:
+    pytest -m aegis_integration tests/aegis/integration/
+
+Default ``pytest tests/aegis/`` SKIPS this directory so iteration stays
+fast. CI runs the integration suite as a separate stage.
+
+Slice 2B-i ships the directory + marker registration. Provider-rewire
+integration tests land in Slice 2B-ii.
+"""

--- a/tests/aegis/test_ast_pins.py
+++ b/tests/aegis/test_ast_pins.py
@@ -92,6 +92,48 @@ def test_ast_pin_v1_paths_known_only_via_upstream_registry():
     snapshot()
 
 
+def test_ast_pin_llm_endpoints_have_wire_family_and_passthrough_do_not():
+    """Slice 2B-i invariant: LLM_COMPLETION endpoints declare a
+    wire_family (the forwarder dispatches its usage parser by family);
+    PASSTHROUGH endpoints do NOT declare one (they don't parse usage).
+    Both directions enforced at UpstreamEndpoint.__post_init__ — pinned
+    here as a separate AST/contract verification."""
+    from backend.core.ouroboros.aegis.upstream_registry import (
+        EndpointKind, snapshot,
+    )
+    for path, ep in snapshot().items():
+        if ep.kind is EndpointKind.LLM_COMPLETION:
+            assert ep.wire_family is not None, (
+                f"{path}: LLM_COMPLETION endpoint must declare wire_family"
+            )
+        elif ep.kind is EndpointKind.PASSTHROUGH:
+            assert ep.wire_family is None, (
+                f"{path}: PASSTHROUGH endpoint must NOT declare wire_family"
+            )
+
+
+def test_ast_pin_passthrough_endpoints_audited_set():
+    """The PASSTHROUGH allowlist is operator-bound (Slice 2B-i). New
+    additions must be a deliberate edit + this pin update — prevents
+    a future change from silently expanding the proxy surface."""
+    from backend.core.ouroboros.aegis.upstream_registry import (
+        passthrough_endpoints,
+    )
+    audited = {
+        "/v1/files",                       # POST multipart batch upload
+        "/v1/batches",                     # POST create batch
+        "/v1/batches/{batch_id}",          # GET poll batch
+        "/v1/files/{file_id}/content",     # GET retrieve batch output
+        "/v1/models",                      # GET list models (DW health)
+    }
+    actual = set(passthrough_endpoints().keys())
+    assert actual == audited, (
+        f"passthrough endpoint set drifted from operator-audited allowlist. "
+        f"added={actual - audited}, removed={audited - actual}. "
+        f"Adding a new passthrough requires explicit operator approval."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Pin 2: ImmutableBudgetStateMachine has no setter beyond tighten()
 # ---------------------------------------------------------------------------

--- a/tests/aegis/test_forwarding.py
+++ b/tests/aegis/test_forwarding.py
@@ -273,6 +273,9 @@ async def _establish_and_acquire(
 
 
 async def test_router_includes_v1_routes_when_forwarding_enabled(full_stack):
+    """Slice 1 substrate (4 endpoints) + Slice 2A LLM completion
+    forwarding (2 endpoints) + Slice 2B-i passthrough (5 endpoints).
+    Total: 11 distinct route paths (some templated)."""
     client, _ = full_stack
     app = client.app
     assert app is not None
@@ -284,6 +287,11 @@ async def test_router_includes_v1_routes_when_forwarding_enabled(full_stack):
         "/lease/redeem",
         "/v1/messages",
         "/v1/chat/completions",
+        "/v1/files",
+        "/v1/batches",
+        "/v1/batches/{batch_id}",
+        "/v1/files/{file_id}/content",
+        "/v1/models",
     })
     assert paths == expected
 

--- a/tests/aegis/test_forwarding_nonstreaming_reconcile.py
+++ b/tests/aegis/test_forwarding_nonstreaming_reconcile.py
@@ -1,0 +1,409 @@
+"""Slice 2B-i: Aegis is the authoritative reconciler for non-streaming
+LLM responses.
+
+These tests prove:
+  1. Aegis parses ``usage`` from the non-streaming upstream JSON body.
+  2. ``budget.reconcile()`` is called with the parsed actual cost
+     (not the reserve, not the JARVIS-supplied estimate).
+  3. The response body is forwarded to JARVIS byte-identically (the
+     parse is a tee, not a rewrite).
+  4. Malformed / missing-usage responses fall back to the pre-flight
+     reserve (over-account, never silently zero).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import AsyncGenerator, List, Tuple
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.aegis.budget_state_machine import (
+    BudgetCaps,
+    ImmutableBudgetStateMachine,
+)
+from backend.core.ouroboros.aegis.daemon import build_app
+from backend.core.ouroboros.aegis.upstream_registry import (
+    ENV_AEGIS_UPSTREAM_ANTHROPIC_URL,
+    ENV_AEGIS_UPSTREAM_DOUBLEWORD_URL,
+)
+
+
+_PSK = "nonstream-test-psk-aaaaaaaaaaaaaaaaaaaaaa"
+_STUB_ANTHROPIC_KEY = "stub-anthropic"
+_STUB_DW_KEY = "stub-dw"
+
+
+def _budget(tmp_path: Path) -> ImmutableBudgetStateMachine:
+    caps = BudgetCaps(
+        session_cap_usd=10.0, hourly_burn_cap_usd=10.0,
+        route_caps_usd={"STANDARD": 5.0, "IMMEDIATE": 5.0},
+        overrun_multiplier=2.0,  # generous reserve so reconcile shows refund
+    )
+    return ImmutableBudgetStateMachine(
+        caps=caps, wal_path=tmp_path / "wal.jsonl",
+    )
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.received: List[dict] = []
+
+
+def _anthropic_nonstreaming_body(
+    *, input_tokens: int = 100, output_tokens: int = 200,
+) -> bytes:
+    return json.dumps({
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-20250514",
+        "content": [{"type": "text", "text": "hello"}],
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        },
+        "stop_reason": "end_turn",
+    }).encode("utf-8")
+
+
+def _openai_nonstreaming_body(
+    *, prompt_tokens: int = 100, completion_tokens: int = 200,
+) -> bytes:
+    return json.dumps({
+        "id": "chatcmpl_test",
+        "object": "chat.completion",
+        "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "hello"},
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }).encode("utf-8")
+
+
+def _make_nonstreaming_stub_app(
+    recorder: _Recorder,
+    *,
+    anthropic_body: bytes,
+    openai_body: bytes,
+) -> web.Application:
+    app = web.Application()
+
+    async def anthropic_handler(request: web.Request) -> web.Response:
+        body = await request.read()
+        recorder.received.append({"path": request.path, "body": body})
+        return web.Response(
+            status=200, body=anthropic_body,
+            content_type="application/json",
+        )
+
+    async def openai_handler(request: web.Request) -> web.Response:
+        body = await request.read()
+        recorder.received.append({"path": request.path, "body": body})
+        return web.Response(
+            status=200, body=openai_body,
+            content_type="application/json",
+        )
+
+    app.router.add_post("/v1/messages", anthropic_handler)
+    app.router.add_post("/v1/chat/completions", openai_handler)
+    return app
+
+
+@pytest_asyncio.fixture
+async def stack_anthropic(
+    tmp_path, monkeypatch,
+) -> AsyncGenerator[Tuple[TestClient, _Recorder, ImmutableBudgetStateMachine], None]:
+    recorder = _Recorder()
+    stub = _make_nonstreaming_stub_app(
+        recorder,
+        anthropic_body=_anthropic_nonstreaming_body(
+            input_tokens=500, output_tokens=1000,
+        ),
+        openai_body=_openai_nonstreaming_body(),
+    )
+    stub_server = TestServer(stub)
+    await stub_server.start_server()
+    stub_url = f"http://{stub_server.host}:{stub_server.port}"
+    monkeypatch.setenv(ENV_AEGIS_UPSTREAM_ANTHROPIC_URL, stub_url)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", _STUB_ANTHROPIC_KEY)
+    budget = _budget(tmp_path)
+    app = build_app(
+        budget=budget, bootstrap_psk=_PSK,
+        lease_ttl_s=300, session_ttl_s=300, forwarding_enabled=True,
+    )
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    try:
+        yield client, recorder, budget
+    finally:
+        await client.close()
+        await stub_server.close()
+
+
+@pytest_asyncio.fixture
+async def stack_openai(
+    tmp_path, monkeypatch,
+) -> AsyncGenerator[Tuple[TestClient, _Recorder, ImmutableBudgetStateMachine], None]:
+    recorder = _Recorder()
+    stub = _make_nonstreaming_stub_app(
+        recorder,
+        anthropic_body=_anthropic_nonstreaming_body(),
+        openai_body=_openai_nonstreaming_body(
+            prompt_tokens=2000, completion_tokens=400,
+        ),
+    )
+    stub_server = TestServer(stub)
+    await stub_server.start_server()
+    stub_url = f"http://{stub_server.host}:{stub_server.port}"
+    monkeypatch.setenv(ENV_AEGIS_UPSTREAM_DOUBLEWORD_URL, stub_url)
+    monkeypatch.setenv("DOUBLEWORD_API_KEY", _STUB_DW_KEY)
+    budget = _budget(tmp_path)
+    app = build_app(
+        budget=budget, bootstrap_psk=_PSK,
+        lease_ttl_s=300, session_ttl_s=300, forwarding_enabled=True,
+    )
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    try:
+        yield client, recorder, budget
+    finally:
+        await client.close()
+        await stub_server.close()
+
+
+async def _establish_and_acquire(
+    client: TestClient, *, route: str = "STANDARD", estimated: float = 0.10,
+) -> str:
+    est = await client.post(
+        "/session/establish",
+        headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    body = await est.json()
+    session_token = body["session_token"]
+    acq = await client.post(
+        "/lease/acquire",
+        headers={"Authorization": f"Bearer {session_token}"},
+        json={
+            "op_id": "op-nonstream", "route": route,
+            "estimated_cost_usd": estimated,
+            "causal_lineage_hash": "stub",
+        },
+    )
+    body = await acq.json()
+    assert body["ok"] is True, f"lease denied: {body}"
+    return body["lease_token"]
+
+
+# ---------------------------------------------------------------------------
+# Anthropic non-streaming
+# ---------------------------------------------------------------------------
+
+
+async def test_anthropic_nonstreaming_byte_identity(stack_anthropic):
+    """The buffered tee for parsing must not alter the bytes JARVIS sees."""
+    client, _, _ = stack_anthropic
+    lease = await _establish_and_acquire(client, route="IMMEDIATE")
+    resp = await client.post(
+        "/v1/messages",
+        headers={"X-JARVIS-Lease": lease},
+        json={"model": "claude-sonnet-4-20250514", "stream": False,
+              "messages": [{"role": "user", "content": "hi"}]},
+    )
+    body = await resp.read()
+    expected = _anthropic_nonstreaming_body(
+        input_tokens=500, output_tokens=1000,
+    )
+    assert body == expected, (
+        f"non-streaming body altered by Aegis tee: got {len(body)}B vs "
+        f"expected {len(expected)}B"
+    )
+
+
+async def test_anthropic_nonstreaming_reconciles_authoritatively(stack_anthropic):
+    """budget.reconcile() must be called with the parsed actual cost,
+    not the reserve."""
+    client, _, budget = stack_anthropic
+
+    # Reserve: estimated=0.10 × overrun=2.0 = 0.20
+    # Actual cost (parsed from body): 500 input × $3/M + 1000 output × $15/M
+    #   = 0.0015 + 0.015 = 0.0165
+    snap_before = budget.snapshot()
+    assert snap_before["session_debit_usd"] == 0.0
+
+    lease = await _establish_and_acquire(client, route="IMMEDIATE", estimated=0.10)
+    snap_after_admit = budget.snapshot()
+    assert snap_after_admit["session_debit_usd"] == pytest.approx(0.20)
+
+    resp = await client.post(
+        "/v1/messages",
+        headers={"X-JARVIS-Lease": lease},
+        json={"model": "claude-sonnet-4-20250514", "stream": False,
+              "messages": [{"role": "user", "content": "hi"}]},
+    )
+    await resp.read()
+    assert resp.status == 200
+
+    snap_after_reconcile = budget.snapshot()
+    # Reconcile must have happened: debit drops from 0.20 (reserve)
+    # to 0.0165 (parsed actual).
+    assert snap_after_reconcile["session_debit_usd"] == pytest.approx(
+        0.0165, rel=0.01,
+    ), (
+        f"reconcile did not happen with parsed cost — debit is "
+        f"{snap_after_reconcile['session_debit_usd']} (expected ~0.0165)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compat non-streaming (DW)
+# ---------------------------------------------------------------------------
+
+
+async def test_openai_nonstreaming_byte_identity(stack_openai):
+    client, _, _ = stack_openai
+    lease = await _establish_and_acquire(client, route="STANDARD")
+    resp = await client.post(
+        "/v1/chat/completions",
+        headers={"X-JARVIS-Lease": lease},
+        json={"model": "Qwen/Qwen3.5-397B-A17B-FP8", "stream": False,
+              "messages": [{"role": "user", "content": "hi"}]},
+    )
+    body = await resp.read()
+    expected = _openai_nonstreaming_body(
+        prompt_tokens=2000, completion_tokens=400,
+    )
+    assert body == expected
+
+
+async def test_openai_nonstreaming_reconciles_prompt_completion_aliases(stack_openai):
+    """OpenAI-compat usage uses prompt_tokens/completion_tokens (not
+    input_tokens/output_tokens) — the parser handles the aliases."""
+    client, _, budget = stack_openai
+    lease = await _establish_and_acquire(client, route="STANDARD", estimated=0.10)
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        headers={"X-JARVIS-Lease": lease},
+        json={"model": "Qwen/Qwen3.5-397B-A17B-FP8", "stream": False,
+              "messages": [{"role": "user", "content": "hi"}]},
+    )
+    await resp.read()
+    assert resp.status == 200
+
+    snap = budget.snapshot()
+    # 2000 prompt × $0.10/M + 400 completion × $0.40/M = 0.0002 + 0.00016 = 0.00036
+    # (Qwen pricing from env fallback when no policy yaml configured for stub)
+    # The exact value depends on which pricing source is found. Just verify
+    # reconcile happened (debit is NOT the reserve 0.20).
+    assert snap["session_debit_usd"] < 0.10, (
+        f"reconcile did not happen — debit {snap['session_debit_usd']} "
+        f"still shows reserve, not actual"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fallback to reserve when usage missing / malformed
+# ---------------------------------------------------------------------------
+
+
+async def test_anthropic_malformed_body_falls_back_to_reserve(
+    tmp_path, monkeypatch,
+):
+    """If the upstream body is malformed (no usage field), Aegis
+    keeps the reserve — never silently treats the op as $0."""
+    recorder = _Recorder()
+    # Body with NO usage field — parse must return None.
+    bad_body = json.dumps({"id": "msg_x", "content": []}).encode("utf-8")
+    stub = _make_nonstreaming_stub_app(
+        recorder, anthropic_body=bad_body,
+        openai_body=_openai_nonstreaming_body(),
+    )
+    stub_server = TestServer(stub)
+    await stub_server.start_server()
+    try:
+        monkeypatch.setenv(
+            ENV_AEGIS_UPSTREAM_ANTHROPIC_URL,
+            f"http://{stub_server.host}:{stub_server.port}",
+        )
+        monkeypatch.setenv("ANTHROPIC_API_KEY", _STUB_ANTHROPIC_KEY)
+        budget = _budget(tmp_path)
+        app = build_app(
+            budget=budget, bootstrap_psk=_PSK,
+            lease_ttl_s=300, session_ttl_s=300, forwarding_enabled=True,
+        )
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        try:
+            lease = await _establish_and_acquire(
+                client, route="IMMEDIATE", estimated=0.10,
+            )
+            resp = await client.post(
+                "/v1/messages",
+                headers={"X-JARVIS-Lease": lease},
+                json={"model": "claude-sonnet-4-20250514", "stream": False,
+                      "messages": [{"role": "user", "content": "hi"}]},
+            )
+            await resp.read()
+            assert resp.status == 200
+            snap = budget.snapshot()
+            # Reserve 0.20 stands — reconcile saw no usage to parse so
+            # the in-memory debit was unchanged (actual stays at reserve).
+            assert snap["session_debit_usd"] == pytest.approx(0.20)
+        finally:
+            await client.close()
+    finally:
+        await stub_server.close()
+
+
+# ---------------------------------------------------------------------------
+# Direct parser unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_anthropic_usage_well_formed():
+    from backend.core.ouroboros.aegis.forwarding import _parse_nonstreaming_usage
+    from backend.core.ouroboros.aegis.upstream_registry import WireFamily
+    body = _anthropic_nonstreaming_body(input_tokens=42, output_tokens=99)
+    result = _parse_nonstreaming_usage(WireFamily.ANTHROPIC, body)
+    assert result == (42, 99)
+
+
+def test_parse_openai_compat_usage_well_formed():
+    from backend.core.ouroboros.aegis.forwarding import _parse_nonstreaming_usage
+    from backend.core.ouroboros.aegis.upstream_registry import WireFamily
+    body = _openai_nonstreaming_body(prompt_tokens=42, completion_tokens=99)
+    result = _parse_nonstreaming_usage(WireFamily.OPENAI_COMPAT, body)
+    assert result == (42, 99)
+
+
+def test_parse_malformed_returns_none():
+    from backend.core.ouroboros.aegis.forwarding import _parse_nonstreaming_usage
+    from backend.core.ouroboros.aegis.upstream_registry import WireFamily
+    assert _parse_nonstreaming_usage(WireFamily.ANTHROPIC, b"not json") is None
+    assert _parse_nonstreaming_usage(WireFamily.ANTHROPIC, b"") is None
+    assert _parse_nonstreaming_usage(WireFamily.ANTHROPIC, b"[]") is None
+    assert _parse_nonstreaming_usage(WireFamily.ANTHROPIC, b'{"no_usage": true}') is None
+
+
+def test_parse_rejects_negative_tokens():
+    from backend.core.ouroboros.aegis.forwarding import _parse_nonstreaming_usage
+    from backend.core.ouroboros.aegis.upstream_registry import WireFamily
+    bad = json.dumps({"usage": {"input_tokens": -1, "output_tokens": 10}}).encode()
+    assert _parse_nonstreaming_usage(WireFamily.ANTHROPIC, bad) is None
+
+
+def test_parse_rejects_non_int_tokens():
+    from backend.core.ouroboros.aegis.forwarding import _parse_nonstreaming_usage
+    from backend.core.ouroboros.aegis.upstream_registry import WireFamily
+    bad = json.dumps({"usage": {"input_tokens": "abc", "output_tokens": 10}}).encode()
+    assert _parse_nonstreaming_usage(WireFamily.ANTHROPIC, bad) is None

--- a/tests/aegis/test_upstream_registry.py
+++ b/tests/aegis/test_upstream_registry.py
@@ -1,6 +1,8 @@
 """Upstream registry — env composition + credential alignment."""
 from __future__ import annotations
 
+import pytest
+
 from backend.core.ouroboros.aegis.credential_registry import (
     upstream_credential_env_vars,
 )
@@ -16,34 +18,59 @@ from backend.core.ouroboros.aegis.upstream_registry import (
 
 
 def test_known_paths_are_v1():
+    """All registered Aegis paths follow the /v1/ convention.
+    Slice 2B-i added 5 PASSTHROUGH endpoints + the 2 LLM_COMPLETION
+    endpoints from Slice 2A — total 7."""
     paths = known_aegis_paths()
-    assert paths == ("/v1/chat/completions", "/v1/messages")
+    assert paths == (
+        "/v1/batches",
+        "/v1/batches/{batch_id}",
+        "/v1/chat/completions",
+        "/v1/files",
+        "/v1/files/{file_id}/content",
+        "/v1/messages",
+        "/v1/models",
+    )
 
 
-def test_snapshot_returns_both_endpoints():
+def test_snapshot_returns_all_endpoints():
     reg = snapshot()
-    assert set(reg.keys()) == {"/v1/messages", "/v1/chat/completions"}
+    assert set(reg.keys()) == {
+        "/v1/messages",
+        "/v1/chat/completions",
+        "/v1/files",
+        "/v1/batches",
+        "/v1/batches/{batch_id}",
+        "/v1/files/{file_id}/content",
+        "/v1/models",
+    }
 
 
 def test_anthropic_endpoint_descriptor_defaults():
     reg = snapshot()
     ep = reg["/v1/messages"]
+    from backend.core.ouroboros.aegis.upstream_registry import EndpointKind
     assert ep.wire_family is WireFamily.ANTHROPIC
     assert ep.auth_scheme is AuthScheme.HEADER_RAW
     assert ep.auth_header == "x-api-key"
     assert ep.credential_env_var == "ANTHROPIC_API_KEY"
     assert ep.upstream_base_url.endswith("api.anthropic.com")
-    assert ep.upstream_url().endswith("/v1/messages")
+    assert ep.kind is EndpointKind.LLM_COMPLETION
+    assert ep.http_methods == ("POST",)
+    assert ep.upstream_url_for("/v1/messages").endswith("/v1/messages")
 
 
 def test_doubleword_endpoint_descriptor_defaults():
     reg = snapshot()
     ep = reg["/v1/chat/completions"]
+    from backend.core.ouroboros.aegis.upstream_registry import EndpointKind
     assert ep.wire_family is WireFamily.OPENAI_COMPAT
     assert ep.auth_scheme is AuthScheme.HEADER_BEARER
     assert ep.auth_header == "Authorization"
     assert ep.credential_env_var == "DOUBLEWORD_API_KEY"
-    assert ep.upstream_url().endswith("/v1/chat/completions")
+    assert ep.kind is EndpointKind.LLM_COMPLETION
+    assert ep.http_methods == ("POST",)
+    assert ep.upstream_url_for("/v1/chat/completions").endswith("/v1/chat/completions")
 
 
 def test_anthropic_url_env_override(monkeypatch):
@@ -51,7 +78,7 @@ def test_anthropic_url_env_override(monkeypatch):
     reg = snapshot()
     ep = reg["/v1/messages"]
     assert ep.upstream_base_url == "https://my-proxy.example.com"
-    assert ep.upstream_url() == "https://my-proxy.example.com/v1/messages"
+    assert ep.upstream_url_for("/v1/messages") == "https://my-proxy.example.com/v1/messages"
 
 
 def test_doubleword_url_env_override_strips_trailing_v1(monkeypatch):
@@ -61,7 +88,147 @@ def test_doubleword_url_env_override_strips_trailing_v1(monkeypatch):
     reg = snapshot()
     ep = reg["/v1/chat/completions"]
     assert ep.upstream_base_url == "https://my-dw.example.com"
-    assert ep.upstream_url() == "https://my-dw.example.com/v1/chat/completions"
+    assert ep.upstream_url_for("/v1/chat/completions") == "https://my-dw.example.com/v1/chat/completions"
+
+
+# ---------------------------------------------------------------------------
+# Slice 2B-i: passthrough endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_passthrough_endpoints_all_present():
+    from backend.core.ouroboros.aegis.upstream_registry import (
+        EndpointKind, passthrough_endpoints,
+    )
+    pts = passthrough_endpoints()
+    assert set(pts.keys()) == {
+        "/v1/files",
+        "/v1/batches",
+        "/v1/batches/{batch_id}",
+        "/v1/files/{file_id}/content",
+        "/v1/models",
+    }
+    for ep in pts.values():
+        assert ep.kind is EndpointKind.PASSTHROUGH
+        assert ep.wire_family is None
+        assert ep.credential_env_var == "DOUBLEWORD_API_KEY"
+        assert ep.auth_scheme is AuthScheme.HEADER_BEARER
+
+
+def test_files_endpoint_is_post():
+    reg = snapshot()
+    assert reg["/v1/files"].http_methods == ("POST",)
+
+
+def test_batches_create_is_post():
+    reg = snapshot()
+    assert reg["/v1/batches"].http_methods == ("POST",)
+
+
+def test_batches_poll_is_get():
+    reg = snapshot()
+    assert reg["/v1/batches/{batch_id}"].http_methods == ("GET",)
+
+
+def test_files_content_is_get():
+    reg = snapshot()
+    assert reg["/v1/files/{file_id}/content"].http_methods == ("GET",)
+
+
+def test_models_is_get():
+    reg = snapshot()
+    assert reg["/v1/models"].http_methods == ("GET",)
+
+
+def test_upstream_url_for_substitutes_concrete_path():
+    """Templated path → concrete request path forwarded byte-identically."""
+    reg = snapshot()
+    ep = reg["/v1/batches/{batch_id}"]
+    out = ep.upstream_url_for("/v1/batches/abc-123-xyz")
+    assert out.endswith("/v1/batches/abc-123-xyz")
+
+
+def test_upstream_url_for_preserves_query_string():
+    reg = snapshot()
+    ep = reg["/v1/models"]
+    out = ep.upstream_url_for("/v1/models", query_string="limit=10&offset=0")
+    assert out.endswith("/v1/models?limit=10&offset=0")
+
+
+# ---------------------------------------------------------------------------
+# Endpoint kind invariants
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_kind_closed_taxonomy():
+    from backend.core.ouroboros.aegis.upstream_registry import EndpointKind
+    assert {k.value for k in EndpointKind} == {"llm_completion", "passthrough"}
+
+
+def test_llm_endpoint_construction_without_wire_family_raises():
+    from backend.core.ouroboros.aegis.upstream_registry import (
+        EndpointKind, UpstreamEndpoint,
+    )
+    with pytest.raises(ValueError, match="wire_family"):
+        UpstreamEndpoint(
+            aegis_path="/v1/test",
+            upstream_base_url="https://x",
+            auth_header="x-api-key",
+            auth_scheme=AuthScheme.HEADER_RAW,
+            credential_env_var="ANTHROPIC_API_KEY",
+            kind=EndpointKind.LLM_COMPLETION,
+            http_methods=("POST",),
+            wire_family=None,  # missing → must raise
+        )
+
+
+def test_passthrough_endpoint_construction_with_wire_family_raises():
+    from backend.core.ouroboros.aegis.upstream_registry import (
+        EndpointKind, UpstreamEndpoint,
+    )
+    with pytest.raises(ValueError, match="must NOT declare a wire_family"):
+        UpstreamEndpoint(
+            aegis_path="/v1/test",
+            upstream_base_url="https://x",
+            auth_header="Authorization",
+            auth_scheme=AuthScheme.HEADER_BEARER,
+            credential_env_var="DOUBLEWORD_API_KEY",
+            kind=EndpointKind.PASSTHROUGH,
+            http_methods=("GET",),
+            wire_family=WireFamily.OPENAI_COMPAT,  # passthrough must not set
+        )
+
+
+def test_endpoint_construction_requires_at_least_one_method():
+    from backend.core.ouroboros.aegis.upstream_registry import (
+        EndpointKind, UpstreamEndpoint,
+    )
+    with pytest.raises(ValueError, match="at least one HTTP method"):
+        UpstreamEndpoint(
+            aegis_path="/v1/test",
+            upstream_base_url="https://x",
+            auth_header="Authorization",
+            auth_scheme=AuthScheme.HEADER_BEARER,
+            credential_env_var="DOUBLEWORD_API_KEY",
+            kind=EndpointKind.PASSTHROUGH,
+            http_methods=(),
+        )
+
+
+def test_endpoint_methods_must_be_uppercase():
+    from backend.core.ouroboros.aegis.upstream_registry import (
+        EndpointKind, UpstreamEndpoint,
+    )
+    with pytest.raises(ValueError, match="uppercase"):
+        UpstreamEndpoint(
+            aegis_path="/v1/test",
+            upstream_base_url="https://x",
+            auth_header="Authorization",
+            auth_scheme=AuthScheme.HEADER_BEARER,
+            credential_env_var="DOUBLEWORD_API_KEY",
+            kind=EndpointKind.PASSTHROUGH,
+            http_methods=("get",),  # lowercase → must raise
+        )
 
 
 def test_aegis_specific_doubleword_override_wins(monkeypatch):


### PR DESCRIPTION
## Aegis Slice 2B-i — non-streaming reconcile + DW passthrough endpoints (Aegis-side only)

Aegis-side Slice 2B-i landing. **Aegis-only surface — NO provider rewire in this slice** (provider-side integration deferred to Slice 2B-ii per `tests/aegis/integration/__init__.py` docstring contract).

### Reconciliation provenance

This branch is a clean reconstruction from `origin/main` (`1e6110256`) following a session where three divergent sources held different fragments of the intended 2B-i scope:

| Source | Verdict | Why |
|---|---|---|
| **A** — `origin/ouroboros/aegis/slice-2b-i-aegis-side @ bda25bcf88` | ❌ SKIPPED | Forked pre-Slice-12AA-fix; phantom-reverts 12AA-fix + 12AC + PDF + touched **forbidden** `providers.py` / `orchestrator.py` / `session_budget_authority.py` / `cost_governor.py` |
| **B** — battle-test branch @ `423cd0b916` (parallel-session autocommit) | 🥇 PRIMARY (9 of 10 files) | Newest Aegis files; but captured a **half-refactored state**: `upstream_registry.py` updated to `upstream_url_for(path, query_string)` (new API) while `forwarding.py` still called the old `upstream_url()` method. Caught by 9 forwarding test failures during verification. |
| **C** — `stash@{0}` (`aegis-wip-preserved-for-slice-12aa-fix-2026-05-23`) | 🥈 SUPPLEMENT (2 of 10 files) | Used for `forwarding.py` (API-consistent with the new upstream_registry method) + `tests/aegis/integration/__init__.py` (Slice-2B-i scope per its own docstring; absent from B) |

### Audit refs preserved on origin (no work lost)

```
aegis-audit/2026-05-23-aegis-2b-i-reconcile/local-aegis-pre-reconcile        → 869dcbc21
aegis-audit/2026-05-23-aegis-2b-i-reconcile/remote-aegis-pre-reconcile       → bda25bcf88 (original of THIS branch)
aegis-audit/2026-05-23-aegis-2b-i-reconcile/battle-test-parallel-autocommit  → 423cd0b91687
```

Plus local `stash@{0}` (`4770ee9b72`) and `stash@{1}` (`9b43ac5018`) intact in the operator's repo.

### Scope

| File | Status | Lines | Purpose |
|---|---|---|---|
| `backend/core/ouroboros/aegis/daemon.py` | M | +96 | 2B-i dispatch wiring |
| `backend/core/ouroboros/aegis/flags.py` | M | +20 | Slice 2B-i flag adds |
| `backend/core/ouroboros/aegis/forwarding.py` | M | +189/-25 | non-streaming reconcile spine; uses `endpoint.upstream_url_for(path, query_string)` |
| `backend/core/ouroboros/aegis/passthrough.py` | **A NEW** | +376 | allowlisted DW passthrough endpoints (`/v1/files`, `/v1/batches/*`, `/v1/models`, …) with credential-injection + zero-log discipline |
| `backend/core/ouroboros/aegis/upstream_registry.py` | M | +226 | endpoint catalog + `UpstreamEndpoint.upstream_url_for()` canonical URL composer |
| `tests/aegis/integration/__init__.py` | **A NEW** | +15 | pytest collection scaffolding + `aegis_integration` marker registration; provider-rewire integration tests land in Slice 2B-ii per docstring contract |
| `tests/aegis/test_ast_pins.py` | M | +42 | AST pins for new Aegis surfaces |
| `tests/aegis/test_forwarding.py` | M | +8 | extended for 2B-i |
| `tests/aegis/test_forwarding_nonstreaming_reconcile.py` | **A NEW** | +409 | non-streaming reconcile spine tests |
| `tests/aegis/test_upstream_registry.py` | M | +181 | extended for 2B-i |

**Totals: 10 files changed, +1426 / −136**

### Forbidden-file scan (all 0 lines vs `origin/main`)

- ✅ `backend/core/ouroboros/governance/providers.py`
- ✅ `backend/core/ouroboros/governance/orchestrator.py`
- ✅ `backend/core/ouroboros/governance/session_budget_authority.py`
- ✅ `backend/core/ouroboros/governance/cost_governor.py`
- ✅ `backend/core/ouroboros/governance/operation_advisor.py`
- ✅ `docs/architecture/OV_RESEARCH_PAPER_2026-04-16.pdf`

Slice 12AA-fix, Slice 12AA per-op-reservation, Slice 12AC tests — all preserved (not deleted by this slice).

**No Aegis source file imports `providers.py`, `orchestrator.py`, or `session_budget_authority.py`** (grep-verified).

### Tests

**196/196 Aegis tests pass** (`--ignore=tests/aegis/integration`; the integration suite is operator-gated per docstring marker contract).

### Operator bindings honored

- ✅ Preservation-first: 3 audit refs + 2 stashes + 2 TMPDIR diff snapshots before any mutation
- ✅ No provider rewire
- ✅ No forbidden file mutations
- ✅ No Path A / no Path B / no provider spend
- ✅ Audit refs + stashes NOT deleted
- ✅ Main checkout untouched
- ✅ Sovereignty marker stamped via canonical `ledger_sovereignty.mark_owned()` on the isolated rebuild worktree only (operator-authorized)
- ✅ Force-push used `--force-with-lease=bda25bcf88` to protect against concurrent remote update

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds authoritative non‑streaming reconciliation for LLM requests and a closed allowlist of Doubleword passthrough endpoints, Aegis-side only (no provider rewire). This improves budget accuracy and enables DW file/batch/model ops without exposing credentials or touching spend.

- New Features
  - Non‑streaming reconcile for `/v1/messages` and `/v1/chat/completions`: tee + parse usage from JSON, reconcile pre‑EOF, fall back to reserve on parse failure; buffer cap via JARVIS_AEGIS_MAX_RESPONSE_BUFFER_BYTES.
  - DW passthrough (session auth, credential injection, zero‑log, no budget impact): POST `/v1/files`, POST `/v1/batches`, GET `/v1/batches/{batch_id}`, GET `/v1/files/{file_id}/content`, GET `/v1/models`.

- Refactors
  - Upstream registry v2: adds `EndpointKind` (LLM_COMPLETION | PASSTHROUGH) and `UpstreamEndpoint.upstream_url_for(request_path, query_string)`.
  - Daemon registers per‑method handlers: LLM → forwarding; PASSTHROUGH → new passthrough handler.
  - New flag: JARVIS_AEGIS_MAX_RESPONSE_BUFFER_BYTES.
  - Tests: non‑streaming reconcile suite, AST pins for closed allowlist and invariants; 196/196 Aegis tests pass; integration suite scaffolded and gated.

<sup>Written for commit eefd69a1451b8495b36f018253eedc71ca97b41a. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/54651?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

