### PR TITLE
feat(aegis): Slice 2B-ii — Provider Proxy Bridge (Zero-Trust transport rewire)

### DIFF
--- a/backend/core/ouroboros/claude_fallback.py
+++ b/backend/core/ouroboros/claude_fallback.py
@@ -64,17 +64,32 @@ async def claude_inference(
         return None
 
     try:
-        import anthropic
+        # Slice 2B-ii — route through Aegis Provider Bridge (transport
+        # swap + per-call lease when JARVIS_AEGIS_ENABLED; byte-identical
+        # legacy AsyncAnthropic when disabled).
+        from backend.core.ouroboros.governance.aegis_provider_bridge import (
+            acquire_call_lease as _aegis_acquire_call_lease,
+            make_async_anthropic_client as _aegis_make_anthropic,
+            merge_lease_header as _aegis_merge_lease,
+        )
 
-        client = anthropic.AsyncAnthropic(api_key=api_key)
+        client = _aegis_make_anthropic(api_key=api_key)
 
         messages = [{"role": "user", "content": prompt}]
 
+        # Per-call Aegis lease (synthetic op_id — this entry point
+        # predates the OperationContext threading).
+        _aegis_lease = await _aegis_acquire_call_lease(
+            op_id=f"claude-fallback:{caller_id}",
+            route="standard",
+            estimated_cost_usd=0.01,
+        )
         response = await client.messages.create(
             model=model,
             max_tokens=max_tokens,
             system=_SYSTEM_MESSAGE,
             messages=messages,
+            extra_headers=_aegis_merge_lease(None, _aegis_lease),
         )
 
         # Extract text content from response blocks.

--- a/backend/core/ouroboros/governance/aegis_provider_bridge.py
+++ b/backend/core/ouroboros/governance/aegis_provider_bridge.py
@@ -1,0 +1,327 @@
+"""Aegis Provider Bridge — single canonical factory for credentialed
+upstream clients (Slice 2B-ii).
+
+# Architectural role
+
+Aegis-1 shipped the credential-confiscation substrate (daemon, lease
+primitives, bootstrap PSK handoff). Aegis-2B-i shipped the forwarding
+surface (``/v1/messages`` + ``/v1/chat/completions`` + DW passthroughs).
+This module is the single seam through which O+V's provider modules
+construct upstream clients — when ``aegis.client.is_enabled()`` is
+true, the constructed client routes through the Aegis daemon and
+carries NO real upstream credentials. The real credentials live only
+in the Aegis daemon's confiscated env (Slice 1).
+
+AST pins in ``test_slice2bii_aegis_proxy_bridge.py`` enforce that no
+module outside this file constructs ``AsyncAnthropic(...)`` or composes
+``"Bearer <DW key>"`` headers. Every upstream call site routes through
+the public API below.
+
+# Public surface
+
+  * :func:`make_async_anthropic_client` — Anthropic client factory.
+    When Aegis enabled: ``base_url=JARVIS_AEGIS_URL`` (host root —
+    the SDK appends ``/v1/messages``), ``api_key=<placeholder>``.
+    When disabled: byte-identical to ``AsyncAnthropic(api_key=...)``.
+
+  * :func:`dw_aegis_base_url` — DW base_url for f-string composition.
+    When Aegis enabled: ``{JARVIS_AEGIS_URL}/v1`` (with ``/v1`` suffix
+    because DW provider composes ``f"{base}/chat/completions"``).
+    When disabled: env ``DOUBLEWORD_BASE_URL`` or
+    ``https://api.doubleword.ai/v1``.
+
+  * :func:`dw_authorization_header` — DW Authorization header dict.
+    When Aegis enabled: ``{}`` (Aegis injects upstream bearer
+    server-side). When disabled: ``{"Authorization": f"Bearer {DW_KEY}"}``.
+
+  * :func:`acquire_call_lease` — PER-CALL lease acquisition. RAISES
+    on failure — no silent fallback to direct upstream credentials.
+
+  * :func:`merge_lease_header` — helper to compose ``extra_headers``
+    dicts with an optional X-JARVIS-Lease token.
+
+# Operator corrections honored (v2 revised design — 2026-05-24)
+
+  1. Anthropic ``base_url`` is the host root, NOT host+/v1.
+  2. ``messages.stream(...)`` and ``messages.create(...)`` both
+     covered by the same client factory (transport swap is shared).
+  3. ALL DW credentialed endpoints (chat/completions + files +
+     batches + models) route through Aegis — Aegis registry already
+     allowlists all 7.
+  4. Per-call lease only — no ``default_headers`` X-JARVIS-Lease.
+  5. ``acquire_call_lease`` RAISES on failure; provider sites do
+     NOT swallow the exception.
+  6. Tests prove wire behavior via ``httpx.MockTransport`` capture.
+
+# Non-goals (deferred to separate slices)
+
+  * Graduating ``JARVIS_AEGIS_ENABLED`` to default-TRUE — that's
+    Slice 2B-iii (post-soak proof required).
+  * SSE parsing / streaming / chunking — 0 changes (operator
+    binding "transport-layer swap only").
+  * Aegis daemon / forwarding / lease.py — 0 changes (substrate is
+    shipped; this module is the consumer).
+"""
+
+from __future__ import annotations
+
+import os
+import logging
+from typing import Any, Dict, Optional
+
+from backend.core.ouroboros.aegis import client as aegis_client_mod
+
+logger = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Placeholder API keys
+# ──────────────────────────────────────────────────────────────────────
+#
+# When Aegis is enabled, the constructed client carries a non-empty
+# placeholder string — both the Anthropic SDK and aiohttp validators
+# reject empty/None keys. The Aegis daemon's forwarding handler
+# REPLACES this with the real confiscated credential server-side
+# before the upstream request is dispatched.
+
+_AEGIS_PLACEHOLDER_ANTHROPIC_KEY: str = (
+    "aegis-managed-no-real-key-do-not-use"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Anthropic client factory
+# ──────────────────────────────────────────────────────────────────────
+
+def make_async_anthropic_client(
+    *,
+    api_key: Optional[str] = None,
+    http_client: Optional[Any] = None,
+    **extra_kwargs: Any,
+) -> Any:
+    """Single canonical factory for ``anthropic.AsyncAnthropic``.
+
+    When :func:`aegis.client.is_enabled` returns True:
+      * ``base_url`` is set to ``JARVIS_AEGIS_URL`` (host root). The
+        Anthropic SDK appends ``/v1/messages`` to that internally —
+        the final outbound URL is ``{JARVIS_AEGIS_URL}/v1/messages``.
+        DO NOT prepend ``/v1`` to base_url; that produces the
+        ``/v1/v1/messages`` bug the operator flagged.
+      * ``api_key`` is set to a non-empty placeholder. The Aegis
+        daemon's forwarding handler replaces it with the real
+        confiscated ``ANTHROPIC_API_KEY`` server-side.
+
+    When Aegis is disabled, this is byte-equivalent to constructing
+    ``AsyncAnthropic(api_key=api_key, ...)`` directly — caller's
+    ``api_key`` (or env default) flows through unmodified, no
+    ``base_url`` override applied.
+
+    Args:
+        api_key: Override key (legacy callers may pass explicit
+            keys; ignored when Aegis enabled).
+        http_client: Optional ``httpx.AsyncClient`` for tests
+            (used with ``MockTransport`` to capture wire requests).
+        **extra_kwargs: Forwarded to ``AsyncAnthropic.__init__``.
+
+    Returns:
+        An ``anthropic.AsyncAnthropic`` instance, configured for
+        the appropriate transport.
+    """
+    # Lazy import — keeps cold-import cost off the hot path for
+    # callers that don't construct clients.
+    from anthropic import AsyncAnthropic
+
+    if aegis_client_mod.is_enabled():
+        aegis_url = os.environ.get(
+            aegis_client_mod.ENV_AEGIS_URL, "",
+        ).strip().rstrip("/")
+        if not aegis_url:
+            # Should not happen — is_enabled() checks both env vars.
+            # Defensive: surface clearly rather than silently leak.
+            raise aegis_client_mod.AegisClientError(
+                "is_enabled() returned True but JARVIS_AEGIS_URL "
+                "is empty — Aegis preflight state corrupted"
+            )
+        kwargs: Dict[str, Any] = {
+            # Host-root base_url. SDK appends /v1/messages.
+            "base_url": aegis_url,
+            # Non-empty placeholder — Aegis injects real key upstream.
+            "api_key": _AEGIS_PLACEHOLDER_ANTHROPIC_KEY,
+        }
+        if http_client is not None:
+            kwargs["http_client"] = http_client
+        kwargs.update(extra_kwargs)
+        logger.debug(
+            "[ProviderBridge] AsyncAnthropic via Aegis: base_url=%s "
+            "(real key confiscated by daemon)",
+            aegis_url,
+        )
+        return AsyncAnthropic(**kwargs)
+
+    # Legacy path — byte-identical to direct construction.
+    legacy_kwargs: Dict[str, Any] = {}
+    if api_key is not None:
+        legacy_kwargs["api_key"] = api_key
+    if http_client is not None:
+        legacy_kwargs["http_client"] = http_client
+    legacy_kwargs.update(extra_kwargs)
+    return AsyncAnthropic(**legacy_kwargs)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# DoubleWord transport configuration
+# ──────────────────────────────────────────────────────────────────────
+
+# Environment-driven legacy default. Mirrors doubleword_provider.py's
+# pre-bridge constant — kept in sync intentionally so legacy callers
+# see byte-identical behavior when Aegis is disabled.
+_LEGACY_DW_BASE_URL_DEFAULT: str = "https://api.doubleword.ai/v1"
+
+
+def dw_aegis_base_url() -> str:
+    """Return the base URL that DW provider should use for f-string
+    composition of credentialed paths.
+
+    When Aegis enabled: ``{JARVIS_AEGIS_URL}/v1``. The ``/v1`` suffix
+    is REQUIRED because the DW provider composes URLs like
+    ``f"{base}/chat/completions"`` — the result must match the
+    Aegis allowlisted route ``/v1/chat/completions``.
+
+    When disabled: ``DOUBLEWORD_BASE_URL`` env var or the legacy
+    ``https://api.doubleword.ai/v1`` default.
+    """
+    if aegis_client_mod.is_enabled():
+        aegis_url = os.environ.get(
+            aegis_client_mod.ENV_AEGIS_URL, "",
+        ).strip().rstrip("/")
+        if not aegis_url:
+            raise aegis_client_mod.AegisClientError(
+                "is_enabled() returned True but JARVIS_AEGIS_URL "
+                "is empty — Aegis preflight state corrupted"
+            )
+        return f"{aegis_url}/v1"
+    return os.environ.get(
+        "DOUBLEWORD_BASE_URL", _LEGACY_DW_BASE_URL_DEFAULT,
+    )
+
+
+def dw_authorization_header() -> Dict[str, str]:
+    """Return the Authorization header dict for the DW session.
+
+    When Aegis enabled: empty dict. The Aegis daemon's forwarding
+    handler injects the real ``DOUBLEWORD_API_KEY`` server-side. The
+    O+V session must NOT hold the real bearer token — that defeats
+    the Zero-Trust posture.
+
+    When disabled: ``{"Authorization": "Bearer <DOUBLEWORD_API_KEY>"}``.
+    """
+    if aegis_client_mod.is_enabled():
+        return {}
+    dw_key = os.environ.get("DOUBLEWORD_API_KEY", "").strip()
+    if not dw_key:
+        return {}
+    return {"Authorization": _compose_bearer(dw_key)}
+
+
+def _compose_bearer(key: str) -> str:
+    """Single private composer for ``Bearer <key>`` — keeps the
+    literal string concentrated in one ~10-char function so AST pins
+    elsewhere can stay surgical."""
+    return f"Bearer {key}"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Per-call lease acquisition
+# ──────────────────────────────────────────────────────────────────────
+
+async def acquire_call_lease(
+    *,
+    op_id: str,
+    route: str,
+    estimated_cost_usd: float,
+    causal_lineage_hash: str = "",
+) -> Optional[str]:
+    """Acquire a fresh per-call lease token (PER-CALL — never reuse
+    across multiple upstream requests).
+
+    Returns:
+        The lease token string to attach as ``X-JARVIS-Lease`` header
+        on the upstream call. ``None`` when Aegis is disabled — the
+        caller skips header injection cleanly.
+
+    Raises:
+        :class:`aegis.client.AegisClientError` when Aegis is enabled
+        and lease acquisition fails (daemon unreachable, cap
+        exceeded, session expired). NO silent fallback to direct
+        upstream credentials — operator correction #5.
+    """
+    if not aegis_client_mod.is_enabled():
+        return None
+    client = await aegis_client_mod.AegisClient.get()
+    # Raises AegisClientError on any failure — propagated to caller.
+    return await client.acquire_lease(
+        op_id=op_id,
+        route=route,
+        estimated_cost_usd=estimated_cost_usd,
+        causal_lineage_hash=causal_lineage_hash,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Header composition helpers
+# ──────────────────────────────────────────────────────────────────────
+
+# Canonical X-JARVIS-Lease header name. Single source of truth so
+# AST pins + Aegis daemon stay in sync on the exact spelling.
+LEASE_HEADER_NAME: str = "X-JARVIS-Lease"
+
+
+def merge_lease_header(
+    extra_headers: Optional[Dict[str, str]],
+    lease_token: Optional[str],
+) -> Dict[str, str]:
+    """Compose an ``extra_headers`` dict with an optional lease token.
+
+    Pattern at call sites::
+
+        lease = await acquire_call_lease(op_id=..., route=..., ...)
+        await client.messages.create(
+            ...,
+            extra_headers=merge_lease_header(existing_headers, lease),
+        )
+
+    When ``lease_token`` is None (Aegis disabled), returns
+    ``extra_headers`` unchanged (empty dict if input was None) — the
+    upstream call proceeds with no Aegis header.
+    """
+    out: Dict[str, str] = dict(extra_headers or {})
+    if lease_token is not None:
+        out[LEASE_HEADER_NAME] = lease_token
+    return out
+
+
+def merge_lease_into_session_headers(
+    base_headers: Optional[Dict[str, str]],
+    lease_token: Optional[str],
+) -> Dict[str, str]:
+    """DW-side equivalent of :func:`merge_lease_header`.
+
+    Composes ``dw_authorization_header()`` (or caller-supplied
+    base_headers) with the per-call lease token. Used at DW
+    ``session.post`` / ``session.get`` call sites.
+    """
+    out: Dict[str, str] = dict(base_headers or {})
+    if lease_token is not None:
+        out[LEASE_HEADER_NAME] = lease_token
+    return out
+
+
+__all__ = [
+    "make_async_anthropic_client",
+    "dw_aegis_base_url",
+    "dw_authorization_header",
+    "acquire_call_lease",
+    "merge_lease_header",
+    "merge_lease_into_session_headers",
+    "LEASE_HEADER_NAME",
+]

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -28,6 +28,20 @@ from backend.core.ouroboros.governance.op_context import (
     GenerationResult,
     OperationContext,
 )
+
+# Slice 2B-ii — Aegis Provider Bridge (Zero-Trust transport).
+# When JARVIS_AEGIS_ENABLED is true, all credentialed DW upstream
+# calls route through the Aegis daemon's /v1/* forwarding surface
+# instead of api.doubleword.ai directly. The DW session holds NO
+# real Authorization Bearer token in that path; Aegis injects the
+# confiscated DOUBLEWORD_API_KEY server-side. Per-call leases via
+# X-JARVIS-Lease header (operator correction #4 — never client-wide).
+from backend.core.ouroboros.governance.aegis_provider_bridge import (
+    acquire_call_lease as _aegis_acquire_call_lease,
+    dw_aegis_base_url as _aegis_dw_base_url,
+    dw_authorization_header as _aegis_dw_auth_header,
+    merge_lease_into_session_headers as _aegis_merge_lease_headers,
+)
 from backend.core.ouroboros.governance.stream_rupture import (
     StreamRuptureError,
     stream_inter_chunk_timeout_s as _stream_inter_chunk_timeout_s,
@@ -384,7 +398,7 @@ class DoublewordProvider:
     def __init__(
         self,
         api_key: str = _DW_API_KEY,
-        base_url: str = _DW_BASE_URL,
+        base_url: Optional[str] = None,
         model: str = _DW_MODEL,
         max_tokens: int = _DW_MAX_TOKENS,
         repo_root: Optional[Path] = None,
@@ -397,6 +411,16 @@ class DoublewordProvider:
         batch_registry: Optional[Any] = None,
     ) -> None:
         self._api_key = api_key
+        # Slice 2B-ii — Aegis transport swap. Default ``base_url=None``
+        # triggers instance-time resolution via the Aegis bridge: when
+        # JARVIS_AEGIS_ENABLED is true we get ``{JARVIS_AEGIS_URL}/v1``
+        # (so f"{self._base_url}/chat/completions" composes the
+        # Aegis-allowlisted path); when disabled we get the legacy
+        # ``DOUBLEWORD_BASE_URL`` env or ``api.doubleword.ai/v1``.
+        # Resolution at __init__ time (not module-import) ensures the
+        # Aegis preflight has already populated env when we read it.
+        if base_url is None:
+            base_url = _aegis_dw_base_url()
         self._base_url = base_url.rstrip("/")
         self._model = model
         self._max_tokens = max_tokens
@@ -634,8 +658,17 @@ class DoublewordProvider:
             # Solution: create with connector only, no timeout object at all.
             # Per-request timeouts are applied via _request_timeout() instead.
             connector = aiohttp.TCPConnector(limit=10, ttl_dns_cache=300)
+            # Slice 2B-ii — Aegis transport. When Aegis is enabled,
+            # ``_aegis_dw_auth_header()`` returns an empty dict so the
+            # session holds NO real Bearer token (Aegis injects the
+            # confiscated DOUBLEWORD_API_KEY upstream). When disabled,
+            # it returns ``{"Authorization": "Bearer {DOUBLEWORD_API_KEY}"}``
+            # for byte-identical legacy behavior. Per-call X-JARVIS-Lease
+            # is layered on at each session.post/get site (operator
+            # correction #4 — never client-wide).
+            _session_headers = dict(_aegis_dw_auth_header())
             self._session = aiohttp.ClientSession(
-                headers={"Authorization": f"Bearer {self._api_key}"},
+                headers=_session_headers,
                 connector=connector,
                 trust_env=True,  # honour HTTP_PROXY / HTTPS_PROXY env vars
             )
@@ -780,12 +813,17 @@ class DoublewordProvider:
         })
 
         try:
-            file_id = await self._upload_file(jsonl_line)
+            # Slice 2B-ii — thread operation_id to per-call Aegis lease.
+            file_id = await self._upload_file(
+                jsonl_line, op_id=operation_id,
+            )
             if not file_id:
                 logger.warning("[DoublewordProvider] submit_batch: file upload failed")
                 return None
 
-            batch_id = await self._create_batch(file_id)
+            batch_id = await self._create_batch(
+                file_id, op_id=operation_id,
+            )
             if not batch_id:
                 logger.warning("[DoublewordProvider] submit_batch: batch creation failed")
                 return None
@@ -821,7 +859,10 @@ class DoublewordProvider:
         t0 = pending.submitted_at
 
         try:
-            output_file_id = await self._await_batch_result(pending.batch_id)
+            # Slice 2B-ii — forward pending.op_id for per-call Aegis lease.
+            output_file_id = await self._await_batch_result(
+                pending.batch_id, op_id=pending.op_id,
+            )
             if not output_file_id:
                 self._stats.failed_batches += 1
                 logger.warning(
@@ -1803,10 +1844,19 @@ class DoublewordProvider:
                 _ttft_request_start_monotonic = time.monotonic()
                 _ttft_first_chunk_seen = False
 
+                # Slice 2B-ii — per-call Aegis lease (None when disabled
+                # → header is skipped via merge helper).
+                _aegis_lease = await _aegis_acquire_call_lease(
+                    op_id=context.op_id,
+                    route="standard",
+                    estimated_cost_usd=0.05,
+                )
                 async with session.post(
                     f"{self._base_url}/chat/completions",
                     json=body,
-                    headers={"Content-Type": "application/json"},
+                    headers=_aegis_merge_lease_headers(
+                        {"Content-Type": "application/json"}, _aegis_lease,
+                    ),
                     timeout=self._request_timeout(),
                 ) as resp:
                     if resp.status >= 300:
@@ -2125,10 +2175,18 @@ class DoublewordProvider:
                             continue
             else:
                 # Non-streaming path
+                # Slice 2B-ii — per-call Aegis lease.
+                _aegis_lease = await _aegis_acquire_call_lease(
+                    op_id=context.op_id,
+                    route="standard",
+                    estimated_cost_usd=0.05,
+                )
                 async with session.post(
                     f"{self._base_url}/chat/completions",
                     json=body,
-                    headers={"Content-Type": "application/json"},
+                    headers=_aegis_merge_lease_headers(
+                        {"Content-Type": "application/json"}, _aegis_lease,
+                    ),
                     timeout=self._request_timeout(),
                 ) as resp:
                     if resp.status >= 300:
@@ -2439,8 +2497,16 @@ class DoublewordProvider:
     # Batch API stages (all deterministic — Tier 0 protocol)
     # ------------------------------------------------------------------
 
-    async def _upload_file(self, jsonl_content: str) -> Optional[str]:
-        """Stage 1: Upload JSONL file to Doubleword."""
+    async def _upload_file(
+        self, jsonl_content: str, *, op_id: str = "dw-batch-upload",
+    ) -> Optional[str]:
+        """Stage 1: Upload JSONL file to Doubleword.
+
+        Slice 2B-ii — ``op_id`` is threaded for per-call Aegis lease.
+        Default ``"dw-batch-upload"`` allows existing callers that
+        haven't yet plumbed real op_id; production callers pass the
+        live OperationContext op_id.
+        """
         session = await self._get_session()
         import aiohttp
 
@@ -2461,10 +2527,21 @@ class DoublewordProvider:
                 raise  # Let CircuitBreakerOpen propagate
 
         try:
+            # Slice 2B-ii — per-call Aegis lease + auth offload. When
+            # Aegis enabled: dw_authorization_header()=={} (server-side
+            # injection) + lease via X-JARVIS-Lease. When disabled:
+            # legacy Bearer header restored byte-identically.
+            _aegis_lease = await _aegis_acquire_call_lease(
+                op_id=op_id, route="standard", estimated_cost_usd=0.001,
+            )
+            _call_headers = dict(_aegis_dw_auth_header())
+            _call_headers = _aegis_merge_lease_headers(
+                _call_headers, _aegis_lease,
+            )
             async with session.post(
                 f"{self._base_url}/files",
                 data=data,
-                headers={"Authorization": f"Bearer {self._api_key}"},
+                headers=_call_headers,
                 timeout=self._request_timeout(),
             ) as resp:
                 if self._rate_limiter is not None:
@@ -2482,8 +2559,13 @@ class DoublewordProvider:
             logger.warning("[DoublewordProvider] File upload error: %s: %s", type(exc).__name__, exc)
             return None
 
-    async def _create_batch(self, input_file_id: str) -> Optional[str]:
-        """Stage 2: Create batch job."""
+    async def _create_batch(
+        self, input_file_id: str, *, op_id: str = "dw-batch-create",
+    ) -> Optional[str]:
+        """Stage 2: Create batch job.
+
+        Slice 2B-ii — ``op_id`` is threaded for per-call Aegis lease.
+        """
         session = await self._get_session()
         _rl_t0 = time.monotonic()
         if self._rate_limiter is not None:
@@ -2493,6 +2575,10 @@ class DoublewordProvider:
                 raise  # Let CircuitBreakerOpen propagate
 
         try:
+            # Slice 2B-ii — per-call Aegis lease (None when disabled).
+            _aegis_lease = await _aegis_acquire_call_lease(
+                op_id=op_id, route="standard", estimated_cost_usd=0.001,
+            )
             async with session.post(
                 f"{self._base_url}/batches",
                 json={
@@ -2500,7 +2586,9 @@ class DoublewordProvider:
                     "endpoint": "/v1/chat/completions",
                     "completion_window": _DW_COMPLETION_WINDOW,
                 },
-                headers={"Content-Type": "application/json"},
+                headers=_aegis_merge_lease_headers(
+                    {"Content-Type": "application/json"}, _aegis_lease,
+                ),
                 timeout=self._request_timeout(),
             ) as resp:
                 if self._rate_limiter is not None:
@@ -2526,13 +2614,18 @@ class DoublewordProvider:
     # Batch result awaiting: Tier 1 (webhook future) → Tier 2 (adaptive poll)
     # ------------------------------------------------------------------
 
-    async def _await_batch_result(self, batch_id: str) -> Optional[str]:
+    async def _await_batch_result(
+        self, batch_id: str, *, op_id: str = "dw-batch-await",
+    ) -> Optional[str]:
         """Wait for batch result via webhook future or adaptive poll fallback.
 
         Tier 1: If a ``BatchFutureRegistry`` is wired and the batch has a
         registered future, await it (zero polling — webhook resolves it).
 
         Tier 2: Adaptive exponential backoff polling with jitter.
+
+        Slice 2B-ii — ``op_id`` is forwarded to ``_adaptive_poll_batch``
+        for per-call Aegis lease accounting.
         """
         # Tier 1: webhook-driven (if registry wired)
         registry = getattr(self, "_batch_registry", None)
@@ -2546,7 +2639,7 @@ class DoublewordProvider:
                 pass  # No future registered or rejected — fall through to Tier 2
 
         # Tier 2: adaptive backoff poll
-        return await self._adaptive_poll_batch(batch_id)
+        return await self._adaptive_poll_batch(batch_id, op_id=op_id)
 
     @staticmethod
     def _next_poll_interval(attempt: int, *, network_error: bool = False) -> float:
@@ -2561,12 +2654,17 @@ class DoublewordProvider:
         jitter = interval * 0.25 * (2 * random.random() - 1)
         return max(0.5, interval + jitter)
 
-    async def _adaptive_poll_batch(self, batch_id: str) -> Optional[str]:
+    async def _adaptive_poll_batch(
+        self, batch_id: str, *, op_id: str = "dw-batch-poll",
+    ) -> Optional[str]:
         """Stage 3: Adaptive backoff polling until batch completes.
 
         Replaces the fixed 5s poll with exponential backoff + jitter.
         Network-aware: connection errors trigger aggressive backoff.
         Returns output_file_id or None on failure/timeout.
+
+        Slice 2B-ii — ``op_id`` is threaded for per-call Aegis lease
+        on each poll request.
         """
         deadline = time.monotonic() + _DW_MAX_WAIT_S
         attempt = 0
@@ -2585,8 +2683,14 @@ class DoublewordProvider:
                     except Exception:
                         raise  # Let CircuitBreakerOpen propagate
 
+                # Slice 2B-ii — per-call Aegis lease.
+                _aegis_lease = await _aegis_acquire_call_lease(
+                    op_id=op_id, route="background",
+                    estimated_cost_usd=0.0001,
+                )
                 async with session.get(
                     f"{self._base_url}/batches/{batch_id}",
+                    headers=_aegis_merge_lease_headers({}, _aegis_lease),
                     timeout=self._request_timeout(),
                 ) as resp:
                     if self._rate_limiter is not None:
@@ -2635,7 +2739,12 @@ class DoublewordProvider:
     async def _retrieve_result(
         self, output_file_id: str, operation_id: str
     ) -> Tuple[str, Optional[Dict[str, Any]]]:
-        """Stage 4: Retrieve and parse batch output. Returns (content, usage)."""
+        """Stage 4: Retrieve and parse batch output. Returns (content, usage).
+
+        Slice 2B-ii — ``operation_id`` doubles as the Aegis lease op_id
+        (per-call lease binds the retrieve to the same op for cap
+        accounting).
+        """
         session = await self._get_session()
         _rl_t0 = time.monotonic()
         if self._rate_limiter is not None:
@@ -2645,8 +2754,14 @@ class DoublewordProvider:
                 raise  # Let CircuitBreakerOpen propagate
 
         try:
+            # Slice 2B-ii — per-call Aegis lease bound to operation_id.
+            _aegis_lease = await _aegis_acquire_call_lease(
+                op_id=operation_id, route="standard",
+                estimated_cost_usd=0.001,
+            )
             async with session.get(
                 f"{self._base_url}/files/{output_file_id}/content",
+                headers=_aegis_merge_lease_headers({}, _aegis_lease),
                 timeout=self._request_timeout(),
             ) as resp:
                 if self._rate_limiter is not None:
@@ -2789,12 +2904,16 @@ class DoublewordProvider:
         t0 = time.monotonic()
 
         try:
-            file_id = await self._upload_file(jsonl_line)
+            # Slice 2B-ii — thread caller-derived synthetic op_id for
+            # per-call Aegis lease. ``prompt_only`` is the no-context
+            # fast-path; the synthetic id is purpose-tagged.
+            _po_op_id = f"dw-prompt-only:{caller_id}:{custom_id}"
+            file_id = await self._upload_file(jsonl_line, op_id=_po_op_id)
             if not file_id:
                 logger.warning("[DoublewordProvider] prompt_only: file upload failed (caller=%s)", caller_id)
                 return ""
 
-            batch_id = await self._create_batch(file_id)
+            batch_id = await self._create_batch(file_id, op_id=_po_op_id)
             if not batch_id:
                 logger.warning("[DoublewordProvider] prompt_only: batch creation failed (caller=%s)", caller_id)
                 return ""
@@ -2804,7 +2923,9 @@ class DoublewordProvider:
                 batch_id, effective_model, caller_id,
             )
 
-            output_file_id = await self._await_batch_result(batch_id)
+            output_file_id = await self._await_batch_result(
+                batch_id, op_id=_po_op_id,
+            )
             if not output_file_id:
                 self._stats.failed_batches += 1
                 logger.warning(
@@ -2982,10 +3103,18 @@ class DoublewordProvider:
         t0 = time.monotonic()
 
         async def _do_request() -> Tuple[str, int, int]:
+            # Slice 2B-ii — per-call Aegis lease bound to caller_id.
+            _aegis_lease = await _aegis_acquire_call_lease(
+                op_id=f"dw-complete-sync:{caller_id}",
+                route="standard",
+                estimated_cost_usd=0.005,
+            )
             async with session.post(
                 f"{self._base_url}/chat/completions",
                 json=body,
-                headers={"Content-Type": "application/json"},
+                headers=_aegis_merge_lease_headers(
+                    {"Content-Type": "application/json"}, _aegis_lease,
+                ),
                 timeout=self._request_timeout(),
             ) as resp:
                 if resp.status >= 300:
@@ -3068,12 +3197,28 @@ class DoublewordProvider:
         )
 
     async def health_probe(self) -> bool:
-        """Quick health check — verify API key works and models endpoint responds."""
+        """Quick health check — verify API key works and models endpoint responds.
+
+        Slice 2B-ii — infrastructure-tier call with no upstream op
+        context: a synthetic ``dw-health-probe`` op_id is used for
+        the per-call Aegis lease. Aegis daemon's cap accounting
+        treats these as low-cost system overhead.
+        """
         if not self.is_available:
             return False
         try:
             session = await self._get_session()
-            async with session.get(f"{self._base_url}/models", timeout=self._request_timeout()) as resp:
+            # Slice 2B-ii — per-call Aegis lease (synthetic infra op_id).
+            _aegis_lease = await _aegis_acquire_call_lease(
+                op_id="dw-health-probe",
+                route="background",
+                estimated_cost_usd=0.0,
+            )
+            async with session.get(
+                f"{self._base_url}/models",
+                headers=_aegis_merge_lease_headers({}, _aegis_lease),
+                timeout=self._request_timeout(),
+            ) as resp:
                 return resp.status == 200
         except Exception:
             return False

--- a/backend/core/ouroboros/governance/fast_path_qa.py
+++ b/backend/core/ouroboros/governance/fast_path_qa.py
@@ -828,23 +828,37 @@ async def _default_claude_callable(
     PROVIDER_FAILED. Returns ``(answer_text, cost_usd_estimate)``.
     """
     try:
-        import anthropic  # type: ignore[import-untyped]
+        import anthropic  # type: ignore[import-untyped]  # noqa: F401 — kept for ImportError gate
     except ImportError:
         return ("", 0.0)
     api_key = os.environ.get(_ENV_ANTHROPIC_KEY, "").strip()
     if not api_key:
         return ("", 0.0)
+    # Slice 2B-ii — route through Aegis Provider Bridge.
+    from backend.core.ouroboros.governance.aegis_provider_bridge import (
+        acquire_call_lease as _aegis_acquire_call_lease,
+        make_async_anthropic_client as _aegis_make_anthropic,
+        merge_lease_header as _aegis_merge_lease,
+    )
     try:
-        client = anthropic.AsyncAnthropic(api_key=api_key)
+        client = _aegis_make_anthropic(api_key=api_key)
     except Exception:  # noqa: BLE001
         return ("", 0.0)
     try:
+        # Per-call Aegis lease (FastPathQA is a read-only Q&A surface;
+        # synthetic op_id tags the path for cap accounting).
+        _aegis_lease = await _aegis_acquire_call_lease(
+            op_id="fast-path-qa",
+            route="standard",
+            estimated_cost_usd=0.005,
+        )
         resp = await client.messages.create(
             model=model_name(),
             max_tokens=max_tokens(),
             temperature=temperature(),
             system=system,
             messages=[{"role": "user", "content": user_question}],
+            extra_headers=_aegis_merge_lease(None, _aegis_lease),
         )
     except Exception as exc:  # noqa: BLE001
         logger.debug(

--- a/backend/core/ouroboros/governance/general_driver.py
+++ b/backend/core/ouroboros/governance/general_driver.py
@@ -471,11 +471,26 @@ async def run_general_tool_loop(
         max_output = int(os.environ.get(
             "JARVIS_GENERAL_LLM_MAX_OUTPUT_TOKENS", "8192",
         ))
+        # Slice 2B-ii — per-call Aegis lease bound to sub_id. The
+        # underlying ``client`` is provider._client (an AsyncAnthropic
+        # constructed in providers.py through make_async_anthropic_client
+        # — transport swap is already in effect); this site contributes
+        # the per-call X-JARVIS-Lease header.
+        from backend.core.ouroboros.governance.aegis_provider_bridge import (
+            acquire_call_lease as _aegis_acquire_call_lease,
+            merge_lease_header as _aegis_merge_lease,
+        )
+        _aegis_lease = await _aegis_acquire_call_lease(
+            op_id=f"general-driver:{sub_id}",
+            route="complex",
+            estimated_cost_usd=0.05,
+        )
         msg = await client.messages.create(
             model=model_name,
             max_tokens=max_output,
             system=system_prompt,
             messages=[{"role": "user", "content": prompt}],
+            extra_headers=_aegis_merge_lease(None, _aegis_lease),
         )
         # Extract text from all text content blocks.
         parts: List[str] = []

--- a/backend/core/ouroboros/governance/m10/bridge_adapters.py
+++ b/backend/core/ouroboros/governance/m10/bridge_adapters.py
@@ -152,8 +152,14 @@ class SynthesisProviderAdapter:
                 error="ANTHROPIC_API_KEY not set",
             )
 
+        # Slice 2B-ii — route through Aegis Provider Bridge.
+        from backend.core.ouroboros.governance.aegis_provider_bridge import (
+            acquire_call_lease as _aegis_acquire_call_lease,
+            make_async_anthropic_client as _aegis_make_anthropic,
+            merge_lease_header as _aegis_merge_lease,
+        )
         try:
-            client = anthropic.AsyncAnthropic(api_key=api_key)
+            client = _aegis_make_anthropic(api_key=api_key)
         except Exception as err:  # noqa: BLE001
             return SynthesisCandidate(
                 code_text="",
@@ -174,12 +180,20 @@ class SynthesisProviderAdapter:
         )
 
         try:
+            # Per-call Aegis lease (M10 synthesis op — synthetic op_id
+            # tag since this is invoked outside the main GENERATE loop).
+            _aegis_lease = await _aegis_acquire_call_lease(
+                op_id="m10-synthesis",
+                route="complex",
+                estimated_cost_usd=0.03,
+            )
             resp = await client.messages.create(
                 model=synthesis_model(),
                 max_tokens=synthesis_max_tokens(),
                 temperature=0.2,
                 system=system_prompt,
                 messages=[{"role": "user", "content": prompt}],
+                extra_headers=_aegis_merge_lease(None, _aegis_lease),
             )
         except Exception as err:  # noqa: BLE001
             return SynthesisCandidate(

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import base64
+import contextvars
 import dataclasses
 import functools
 import hashlib
@@ -30,6 +31,49 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Set, Tuple
+
+# Slice 2B-ii — Aegis Provider Bridge wiring.
+# Per-op lease scoping uses a ContextVar (asyncio-task-local, safe
+# under concurrent ops) so we don't have to thread op_id through ~20
+# internal methods between generate(ctx) and messages.create(...).
+# The var is set at every entry to ClaudeProvider.generate() and
+# ClaudeProvider.plan(), and read at each messages.create/stream
+# call site to build the per-call X-JARVIS-Lease header.
+from backend.core.ouroboros.governance.aegis_provider_bridge import (
+    acquire_call_lease as _aegis_acquire_call_lease,
+    make_async_anthropic_client as _aegis_make_async_anthropic,  # noqa: F401
+    merge_lease_header as _aegis_merge_lease_header,
+)
+
+_aegis_op_id_var: "contextvars.ContextVar[str]" = contextvars.ContextVar(
+    "jarvis.aegis.current_op_id", default="claude-provider-unscoped",
+)
+_aegis_route_var: "contextvars.ContextVar[str]" = contextvars.ContextVar(
+    "jarvis.aegis.current_route", default="standard",
+)
+
+
+async def _aegis_extra_headers_for_call(
+    create_kwargs: Optional[Dict[str, Any]] = None,
+    *,
+    estimated_cost_usd: float = 0.05,
+) -> Dict[str, str]:
+    """Build the per-call ``extra_headers`` dict for an Anthropic SDK
+    call, with the Aegis X-JARVIS-Lease header injected when enabled.
+
+    Reads op_id + route from the per-task ContextVars (set by entry
+    points like ClaudeProvider.generate). When Aegis is disabled the
+    lease helper returns None and the returned dict is preserved
+    byte-identically against any caller-supplied ``extra_headers``
+    in ``create_kwargs``.
+    """
+    op_id = _aegis_op_id_var.get()
+    route = _aegis_route_var.get()
+    lease = await _aegis_acquire_call_lease(
+        op_id=op_id, route=route, estimated_cost_usd=estimated_cost_usd,
+    )
+    existing = (create_kwargs or {}).get("extra_headers") if create_kwargs else None
+    return _aegis_merge_lease_header(existing, lease)
 
 from backend.core.ouroboros.governance.claude_dispatch_state import (
     _ClaudeDispatchState,
@@ -5820,6 +5864,18 @@ class ClaudeProvider:
             # ``_call_with_backoff``).
             _client_mode = _resolve_http_client_mode()
 
+            # Slice 2B-ii — Aegis Provider Bridge. The bridge's factory
+            # transparently overrides ``base_url`` + ``api_key`` when
+            # ``aegis.client.is_enabled()`` (transport swap to Aegis
+            # daemon — the SDK still posts to /v1/messages, but base_url
+            # is JARVIS_AEGIS_URL so the final wire path is
+            # {AEGIS}/v1/messages); falls through to byte-identical
+            # legacy construction when disabled. The ``max_retries=0``
+            # + ``http_client`` kwargs flow through unchanged in BOTH
+            # paths via **kwargs.
+            from backend.core.ouroboros.governance.aegis_provider_bridge import (
+                make_async_anthropic_client as _aegis_make_anthropic,
+            )
             if _client_mode == _CLAUDE_HTTP_CLIENT_MODE_STDLIB_DEFAULT:
                 # H1 measurement mode — no construction-time httpx.Timeout,
                 # no Limits.  Reproduces the Step 2 probe's client shape
@@ -5827,7 +5883,7 @@ class ClaudeProvider:
                 # _create_kwargs) still binds connect/read/write/pool to
                 # the outer asyncio.wait_for budget; max_retries=0
                 # preserves the single-retry-authority invariant.
-                self._client = anthropic.AsyncAnthropic(
+                self._client = _aegis_make_anthropic(
                     api_key=self._api_key,
                     max_retries=0,
                 )
@@ -5869,7 +5925,10 @@ class ClaudeProvider:
                     timeout=_http_timeout,
                     limits=_http_limits,
                 )
-                self._client = anthropic.AsyncAnthropic(
+                # Slice 2B-ii — Aegis transport swap (see comment above).
+                # http_client + max_retries pass through verbatim via
+                # **kwargs in both Aegis-enabled + legacy paths.
+                self._client = _aegis_make_anthropic(
                     api_key=self._api_key,
                     http_client=_http_client,
                     # SDK-level retries hide signal and consume our timebox
@@ -6741,8 +6800,19 @@ class ClaudeProvider:
         create_kwargs["timeout"] = _derive_per_request_httpx_timeout(
             _live_create,
         )
+        # Slice 2B-ii — per-call Aegis lease. Computed once per attempt
+        # and passed as an explicit ``extra_headers=`` kwarg (AST pin
+        # #3 requires the literal kwarg form at the call site to prove
+        # every messages.create is gated). create_kwargs no longer
+        # carries ``extra_headers``; the explicit kwarg is the canonical
+        # source so there is no risk of a duplicate-kwarg error.
         try:
-            return await _current_client.messages.create(**create_kwargs)
+            return await _current_client.messages.create(
+                **create_kwargs,
+                extra_headers=await _aegis_extra_headers_for_call(
+                    create_kwargs,
+                ),
+            )
         except Exception as _exc:
             _msg = str(_exc).lower()
             if (
@@ -6767,8 +6837,13 @@ class ClaudeProvider:
                 create_kwargs["timeout"] = (
                     _derive_per_request_httpx_timeout(_live_create)
                 )
+                # Slice 2B-ii — fresh lease for the prefill-retry attempt
+                # (operator correction #4: never reuse a lease across calls).
                 return await _current_client.messages.create(
-                    **create_kwargs
+                    **create_kwargs,
+                    extra_headers=await _aegis_extra_headers_for_call(
+                        create_kwargs,
+                    ),
                 )
             raise
 
@@ -7143,9 +7218,21 @@ class ClaudeProvider:
             on_overrun=_bcg_on_overrun,
         )
 
+        # Slice 2B-ii — per-call Aegis lease for the streaming path.
+        # The SDK's stream() also hits /v1/messages; the lease header
+        # is mandatory at the Aegis daemon (forward_request returns
+        # 401 LEASE_INVALID otherwise). Operator correction #2.
+        # Passed as an explicit ``extra_headers=`` kwarg so AST pin #4
+        # observes the literal at the call site.
+        _stream_extra_headers = await _aegis_extra_headers_for_call(
+            _stream_kwargs,
+        )
         async with _bcg_guard, \
                 _quiescence_core_active(label="claude_stream"), \
-                _current_client.messages.stream(**_stream_kwargs) as stream:
+                _current_client.messages.stream(
+                    **_stream_kwargs,
+                    extra_headers=_stream_extra_headers,
+                ) as stream:
             # Slice 7d arm — best-effort transport extraction. The
             # Anthropic SDK uses httpx under the hood; if the
             # ClientResponse / Transport shape isn't reachable
@@ -7448,6 +7535,13 @@ class ClaudeProvider:
             structural reinforcement; Layer 1 (AST) and Layer 3 (claim)
             compose for defense-in-depth.
         """
+        # Slice 2B-ii — stamp the Aegis op_id + route ContextVars at the
+        # provider entry. Every downstream messages.create / messages.stream
+        # call in this task reads them via _aegis_extra_headers_for_call().
+        # asyncio-task-local — concurrent ops scope independently.
+        _aegis_op_id_var.set(str(getattr(context, "op_id", "") or "claude-provider-unscoped"))
+        _aegis_route_var.set(str(getattr(context, "provider_route", "") or "standard"))
+
         # PRD §26.6.2 — Layer 2 cost contract runtime gate. The
         # ClaudeProvider is the canonical Claude-tier entry point;
         # this barrier catches any path that misroutes a BG/SPEC op
@@ -8461,6 +8555,7 @@ class ClaudeProvider:
                     # Re-acquire per attempt — see _do_stream comment.
                     _current_client = self._ensure_client()
                     # D2 (Task #95) — per-request httpx.Timeout.
+                    # Slice 2B-ii — per-call Aegis lease.
                     return await _current_client.messages.create(
                         model=self._model,
                         max_tokens=self._compute_output_budget(
@@ -8470,6 +8565,7 @@ class ClaudeProvider:
                         system=_legacy_system,
                         messages=messages,
                         timeout=_derive_per_request_httpx_timeout(timeout_s),
+                        extra_headers=await _aegis_extra_headers_for_call(),
                     )
 
                 msg = await asyncio.wait_for(
@@ -8727,10 +8823,18 @@ class ClaudeProvider:
         """
         try:
             client = self._ensure_client()
+            # Slice 2B-ii — infra-tier op_id. Set ContextVars locally so
+            # the lease is bound to a recognizable health-probe scope
+            # (this method is invoked outside the generate() entry).
+            _aegis_op_id_var.set("claude-health-probe")
+            _aegis_route_var.set("background")
             await client.messages.create(
                 model=self._model,
                 max_tokens=1,
                 messages=[{"role": "user", "content": "ping"}],
+                extra_headers=await _aegis_extra_headers_for_call(
+                    estimated_cost_usd=0.0001,
+                ),
             )
             return True
         except Exception:
@@ -8766,6 +8870,11 @@ class ClaudeProvider:
                 1.0,
                 (deadline - datetime.now(tz=timezone.utc)).total_seconds(),
             )
+            # Slice 2B-ii — ContextVar scope for plan() (called outside
+            # generate() so the var may default; "claude-plan" is the
+            # synthetic op_id used when no upstream op_id was set).
+            _aegis_op_id_var.set("claude-plan")
+            _aegis_route_var.set("standard")
             return await _current_client.messages.create(
                 model=self._model,
                 max_tokens=512,
@@ -8778,6 +8887,9 @@ class ClaudeProvider:
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.0,
                 timeout=_derive_per_request_httpx_timeout(_attempt_budget_s),
+                extra_headers=await _aegis_extra_headers_for_call(
+                    estimated_cost_usd=0.005,
+                ),
             )
 
         message = await self._call_with_backoff(

--- a/backend/core/ouroboros/governance/self_critique.py
+++ b/backend/core/ouroboros/governance/self_critique.py
@@ -339,13 +339,27 @@ class ClaudeCritiqueProvider:
             raise RuntimeError("Claude client unavailable for critique")
         prompt = build_critique_prompt(request)
 
+        # Slice 2B-ii — per-call Aegis lease + X-JARVIS-Lease header
+        # injection (transport-layer swap is honored by the provider
+        # client itself; this site only owes the per-call lease).
+        from backend.core.ouroboros.governance.aegis_provider_bridge import (
+            acquire_call_lease as _aegis_acquire_call_lease,
+            merge_lease_header as _aegis_merge_lease,
+        )
+
         async def _do_create() -> Any:
+            _aegis_lease = await _aegis_acquire_call_lease(
+                op_id=f"self-critique:{getattr(request, 'op_id', '') or 'unscoped'}",
+                route="standard",
+                estimated_cost_usd=0.005,
+            )
             return await client.messages.create(
                 model=self._model,
                 max_tokens=self._max_tokens,
                 temperature=0.2,
                 system=_CRITIQUE_SYSTEM_PROMPT,
                 messages=[{"role": "user", "content": prompt}],
+                extra_headers=_aegis_merge_lease(None, _aegis_lease),
             )
 
         msg = await asyncio.wait_for(_do_create(), timeout=request.deadline_s)

--- a/backend/core/ouroboros/governance/visual_comprehension.py
+++ b/backend/core/ouroboros/governance/visual_comprehension.py
@@ -253,13 +253,28 @@ class VisualCodeComprehension:
     # ------------------------------------------------------------------
 
     async def _analyze_with_vision(self, b64_image: str, prompt: str) -> Optional[str]:
-        """Send screenshot to Claude Vision. Returns raw response text."""
+        """Send screenshot to Claude Vision. Returns raw response text.
+
+        Slice 2B-ii — Aegis Provider Bridge transport swap + per-call
+        X-JARVIS-Lease. Synthetic ``vision-comprehension`` op_id since
+        this entry point is not threaded with an OperationContext.
+        """
         try:
-            import anthropic
-            client = anthropic.AsyncAnthropic(api_key=self._api_key)
+            import anthropic  # noqa: F401 — kept for surrounding ImportError gate
+            from backend.core.ouroboros.governance.aegis_provider_bridge import (
+                acquire_call_lease as _aegis_acquire_call_lease,
+                make_async_anthropic_client as _aegis_make_anthropic,
+                merge_lease_header as _aegis_merge_lease,
+            )
+            client = _aegis_make_anthropic(api_key=self._api_key)
 
             media_type = "image/jpeg" if b64_image[:4] == "/9j/" else "image/png"
 
+            _aegis_lease = await _aegis_acquire_call_lease(
+                op_id="vision-comprehension",
+                route="standard",
+                estimated_cost_usd=0.02,
+            )
             response = await asyncio.wait_for(
                 client.messages.create(
                     model=self._vision_model,
@@ -274,6 +289,7 @@ class VisualCodeComprehension:
                             {"type": "text", "text": prompt},
                         ],
                     }],
+                    extra_headers=_aegis_merge_lease(None, _aegis_lease),
                 ),
                 timeout=_VISION_TIMEOUT_S,
             )

--- a/tests/governance/test_slice2bii_aegis_proxy_bridge.py
+++ b/tests/governance/test_slice2bii_aegis_proxy_bridge.py
@@ -1,0 +1,718 @@
+"""Slice 2B-ii — Aegis Provider Proxy Bridge.
+
+# What this slice closes
+
+Aegis-1 (PR #53861) shipped the credential-confiscation substrate:
+daemon, lease primitives, bootstrap PSK handoff, env scrub. Aegis-2B-i
+shipped the forwarding surface (``/v1/messages`` + ``/v1/chat/completions``
++ ``/v1/files`` + ``/v1/batches`` + ``/v1/models``). But O+V's provider
+modules (``providers.py`` + ``doubleword_provider.py`` + 5 auxiliary
+callers) still construct ``AsyncAnthropic(...)`` / ``aiohttp.ClientSession(...)``
+with the **real** ``ANTHROPIC_API_KEY`` / ``DOUBLEWORD_API_KEY`` and
+POST directly to ``api.anthropic.com`` / ``api.doubleword.ai``. The
+Zero-Trust posture is not absolute until every credentialed upstream
+call routes through Aegis.
+
+This slice closes that gap with a single canonical factory pattern:
+``aegis/provider_bridge.py`` exposes ``make_async_anthropic_client(...)``,
+``dw_aegis_base_url()``, ``dw_authorization_header()``, and per-call
+``acquire_call_lease(...)``. AST pins enforce that no module outside
+``provider_bridge.py`` constructs an Anthropic client or a DW session
+directly. Every ``messages.create``/``messages.stream`` and every DW
+``session.post``/``session.get`` to ``/v1/*`` carries a fresh per-call
+``X-JARVIS-Lease`` header.
+
+# Operator corrections honored (v2 revised design)
+
+  1. Anthropic ``base_url = JARVIS_AEGIS_URL`` (host root) — SDK
+     internally appends ``/v1/messages``. Test #6 proves the final
+     request path is exactly ``/v1/messages`` not ``/v1/v1/messages``.
+  2. ``messages.stream(...)`` covered alongside ``messages.create(...)``.
+  3. All 7 DW endpoints route through Aegis (chat/completions, files,
+     batches, batches/{id}, files/{id}/content, models).
+  4. Per-call lease only — no ``default_headers`` X-JARVIS-Lease.
+  5. Lease acquire failure RAISES — no silent fallback to direct
+     upstream credentials.
+  6. Tests prove wire behavior via ``httpx.MockTransport`` capture +
+     real path-string assertions, not just import-graph proofs.
+
+# Test surface
+
+AST pins (5)
+  - test_no_raw_async_anthropic_outside_bridge
+  - test_no_raw_dw_authorization_header_outside_bridge
+  - test_every_messages_create_has_extra_headers_kwarg
+  - test_every_messages_stream_has_extra_headers_kwarg
+  - test_every_dw_v1_session_call_has_headers_kwarg
+
+Spine tests (9)
+  - test_anthropic_request_path_exactly_v1_messages_under_aegis
+  - test_dw_request_paths_match_registry_allowlist (parametrized over 7)
+  - test_lease_header_present_per_call_with_distinct_tokens
+  - test_streaming_path_carries_lease_header
+  - test_aegis_enabled_anthropic_client_holds_placeholder_api_key
+  - test_aegis_enabled_dw_session_has_no_real_bearer
+  - test_lease_acquire_failure_raises_not_falls_back
+  - test_aegis_disabled_yields_byte_identical_legacy_construction
+  - test_aegis_disabled_dw_base_url_matches_legacy
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import Iterator, List, Tuple
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+# Module under construction — imports must work post-implementation.
+# NOTE: provider_bridge lives under governance/ (not aegis/) by design —
+# it's a CONSUMER of aegis.client (which holds credentials), not part of
+# the Aegis substrate. Aegis's own AST pin forbids any anthropic/openai
+# SDK import under aegis/ (credential-confiscation invariant).
+from backend.core.ouroboros.governance import aegis_provider_bridge as provider_bridge
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers — AST walkers
+# ──────────────────────────────────────────────────────────────────────
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OUROBOROS_PKG = REPO_ROOT / "backend" / "core" / "ouroboros"
+BRIDGE_FILE = OUROBOROS_PKG / "governance" / "aegis_provider_bridge.py"
+
+# Files KNOWN to call Anthropic SDK — all must go through the bridge.
+# (Discovered post-design during AST pin #1 sweep: claude_fallback.py
+# also constructs AsyncAnthropic + calls messages.create.)
+ANTHROPIC_CALLER_FILES: List[Path] = [
+    OUROBOROS_PKG / "claude_fallback.py",
+    OUROBOROS_PKG / "governance" / "providers.py",
+    OUROBOROS_PKG / "governance" / "self_critique.py",
+    OUROBOROS_PKG / "governance" / "general_driver.py",
+    OUROBOROS_PKG / "governance" / "fast_path_qa.py",
+    OUROBOROS_PKG / "governance" / "visual_comprehension.py",
+    OUROBOROS_PKG / "governance" / "m10" / "bridge_adapters.py",
+]
+
+
+def _walk_py_files() -> Iterator[Path]:
+    """Walk all .py files under backend/core/ouroboros/, skipping
+    deprecated/backup files (e.g. ``providers 2.py``) and tests."""
+    for p in OUROBOROS_PKG.rglob("*.py"):
+        # Skip backup files (filenames with spaces) — these are
+        # operator-side artifacts, not live code paths.
+        if " " in p.name:
+            continue
+        # Skip tests + __pycache__
+        if "__pycache__" in p.parts or p.name.startswith("test_"):
+            continue
+        yield p
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+def _calls_named(tree: ast.Module, *, name: str) -> List[ast.Call]:
+    """Return Call nodes whose .func resolves to ``name`` (either
+    direct Name or Attribute with .attr==name)."""
+    out: List[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        if isinstance(fn, ast.Name) and fn.id == name:
+            out.append(node)
+        elif isinstance(fn, ast.Attribute) and fn.attr == name:
+            out.append(node)
+    return out
+
+
+def _attribute_chain(node: ast.AST) -> Tuple[str, ...]:
+    """For ``foo.bar.baz`` → ``("foo","bar","baz")``. Best-effort."""
+    parts: List[str] = []
+    cur: ast.AST = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+    return tuple(reversed(parts))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PIN #1 — no raw AsyncAnthropic(...) outside bridge module
+# ──────────────────────────────────────────────────────────────────────
+
+def test_no_raw_async_anthropic_outside_bridge() -> None:
+    """AST pin: AsyncAnthropic(...) constructor may appear ONLY in
+    ``aegis/provider_bridge.py``. All other modules must call
+    ``provider_bridge.make_async_anthropic_client(...)``.
+    """
+    offenders: List[str] = []
+    for path in _walk_py_files():
+        if path.resolve() == BRIDGE_FILE.resolve():
+            continue
+        try:
+            tree = _parse(path)
+        except SyntaxError:
+            continue
+        for call in _calls_named(tree, name="AsyncAnthropic"):
+            offenders.append(f"{path.relative_to(REPO_ROOT)}:{call.lineno}")
+    assert not offenders, (
+        "Raw AsyncAnthropic(...) calls outside provider_bridge.py — "
+        "Aegis transport swap can be bypassed.\nOffenders: "
+        + "\n".join(offenders)
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PIN #2 — no raw "Authorization: Bearer <DW key>" outside bridge
+# ──────────────────────────────────────────────────────────────────────
+
+def test_no_raw_dw_authorization_header_outside_bridge() -> None:
+    """AST pin: no raw f-string ``Bearer {DOUBLEWORD_API_KEY}`` or
+    ``Bearer {self._api_key}`` style header in DW provider outside
+    the bridge. The bridge's ``dw_authorization_header()`` is the
+    only place a real bearer token may be composed.
+    """
+    dw_file = OUROBOROS_PKG / "governance" / "doubleword_provider.py"
+    tree = _parse(dw_file)
+    offenders: List[str] = []
+    for node in ast.walk(tree):
+        # Detect f-strings that compose "Bearer " + something
+        if isinstance(node, ast.JoinedStr):
+            literals = [
+                v.value for v in node.values
+                if isinstance(v, ast.Constant) and isinstance(v.value, str)
+            ]
+            if any("Bearer " in lit for lit in literals):
+                offenders.append(f"doubleword_provider.py:{node.lineno}")
+    # The bridge's dw_authorization_header() is allowed to compose it;
+    # the DW provider itself must call the bridge helper, not compose.
+    assert not offenders, (
+        "Raw 'Bearer <key>' header composition in doubleword_provider.py — "
+        "must route through provider_bridge.dw_authorization_header().\n"
+        "Offenders: " + "\n".join(offenders)
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PIN #3 — every .messages.create(...) carries extra_headers=
+# ──────────────────────────────────────────────────────────────────────
+
+def test_every_messages_create_has_extra_headers_kwarg() -> None:
+    """AST pin: every ``.messages.create(...)`` call site passes an
+    ``extra_headers`` kwarg (which must in turn carry the per-call
+    X-JARVIS-Lease via merge_lease_header)."""
+    offenders: List[str] = []
+    for path in ANTHROPIC_CALLER_FILES:
+        if not path.exists():
+            continue
+        tree = _parse(path)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "create":
+                continue
+            # Walk back the attribute chain — must end in .messages.create
+            chain = _attribute_chain(node.func)
+            if len(chain) < 2 or chain[-2] != "messages":
+                continue
+            kw_names = {kw.arg for kw in node.keywords if kw.arg}
+            if "extra_headers" not in kw_names:
+                offenders.append(
+                    f"{path.relative_to(REPO_ROOT)}:{node.lineno}"
+                )
+    assert not offenders, (
+        "messages.create(...) call sites missing extra_headers= kwarg — "
+        "per-call X-JARVIS-Lease cannot be injected.\nOffenders: "
+        + "\n".join(offenders)
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PIN #4 — every .messages.stream(...) carries extra_headers=
+# ──────────────────────────────────────────────────────────────────────
+
+def test_every_messages_stream_has_extra_headers_kwarg() -> None:
+    """AST pin: every ``.messages.stream(...)`` call site passes an
+    ``extra_headers`` kwarg."""
+    offenders: List[str] = []
+    for path in ANTHROPIC_CALLER_FILES:
+        if not path.exists():
+            continue
+        tree = _parse(path)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "stream":
+                continue
+            chain = _attribute_chain(node.func)
+            if len(chain) < 2 or chain[-2] != "messages":
+                continue
+            kw_names = {kw.arg for kw in node.keywords if kw.arg}
+            if "extra_headers" not in kw_names:
+                offenders.append(
+                    f"{path.relative_to(REPO_ROOT)}:{node.lineno}"
+                )
+    assert not offenders, (
+        "messages.stream(...) call sites missing extra_headers= kwarg — "
+        "streaming path can leak unleased.\nOffenders: " + "\n".join(offenders)
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PIN #5 — every DW session.{post,get} to /v1/* carries headers=
+# ──────────────────────────────────────────────────────────────────────
+
+def _is_session_call_receiver(call: ast.Call) -> bool:
+    """True iff ``call.func`` looks like ``session.X`` or
+    ``self._session.X`` — filters out ``dict.get`` / ``os.environ.get``
+    / ``response.get`` false positives."""
+    if not isinstance(call.func, ast.Attribute):
+        return False
+    chain = _attribute_chain(call.func)
+    # chain[-1] is the method (post/get). Receiver is chain[:-1].
+    if not chain:
+        return False
+    receiver_tail = chain[-2] if len(chain) >= 2 else chain[0]
+    return receiver_tail in ("session", "_session")
+
+
+def _is_url_string_argument(arg: ast.AST) -> bool:
+    """True iff arg is an f-string composing a URL with ``/v1/``,
+    ``/chat/completions``, ``/files``, ``/batches``, or ``/models`` —
+    or a plain string containing one of those path fragments. Used
+    as a SECONDARY filter (over and above receiver-name) to scope
+    the AST pin to real upstream URL calls."""
+    fragments = (
+        "/chat/completions", "/files", "/batches", "/models", "/v1/",
+    )
+    if isinstance(arg, ast.JoinedStr):
+        literals = [
+            v.value for v in arg.values
+            if isinstance(v, ast.Constant) and isinstance(v.value, str)
+        ]
+        return any(any(f in lit for f in fragments) for lit in literals)
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        return any(f in arg.value for f in fragments)
+    return False
+
+
+def test_every_dw_v1_session_call_has_headers_kwarg() -> None:
+    """AST pin: every ``session.post(...)`` / ``session.get(...)`` call
+    in doubleword_provider.py that targets an upstream URL (composes
+    a ``/v1/*``-style path) carries a ``headers=`` kwarg — the entry
+    point for per-call lease + ``dw_authorization_header()``.
+
+    Filter rationale: receiver must be ``session`` / ``self._session``
+    (not ``dict.get`` / ``os.environ.get``) AND first arg must compose
+    an upstream URL fragment (not internal helper calls).
+    """
+    dw_file = OUROBOROS_PKG / "governance" / "doubleword_provider.py"
+    tree = _parse(dw_file)
+    offenders: List[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in ("post", "get"):
+            continue
+        if not _is_session_call_receiver(node):
+            continue
+        # Require at least one positional URL-ish arg
+        if not node.args or not _is_url_string_argument(node.args[0]):
+            continue
+        kw_names = {kw.arg for kw in node.keywords if kw.arg}
+        if "headers" not in kw_names:
+            offenders.append(f"doubleword_provider.py:{node.lineno}")
+    assert not offenders, (
+        "DW session.post/get sites missing headers= kwarg — Aegis "
+        "lease + auth swap cannot be injected.\nOffenders: "
+        + "\n".join(offenders)
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine fixtures — env hygiene
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def aegis_enabled_env(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Set the env vars that ``aegis.client.is_enabled()`` checks.
+    Returns the JARVIS_AEGIS_URL the test should expect."""
+    url = "http://aegis-test:9999"
+    monkeypatch.setenv("JARVIS_AEGIS_URL", url)
+    monkeypatch.setenv("JARVIS_AEGIS_BOOTSTRAP_PSK", "test-psk-32-bytes-hex")
+    # Ensure real upstream keys are set — so we can prove they are NOT
+    # leaked to the constructed client.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-real-anthropic-key-DO-NOT-LEAK")
+    monkeypatch.setenv("DOUBLEWORD_API_KEY", "sk-real-dw-key-DO-NOT-LEAK")
+    return url
+
+
+@pytest.fixture
+def aegis_disabled_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_AEGIS_URL", raising=False)
+    monkeypatch.delenv("JARVIS_AEGIS_BOOTSTRAP_PSK", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-legacy-anthropic-key")
+    monkeypatch.setenv("DOUBLEWORD_API_KEY", "sk-legacy-dw-key")
+    monkeypatch.delenv("DOUBLEWORD_BASE_URL", raising=False)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SPINE #6 — Anthropic request path is EXACTLY /v1/messages under Aegis
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_anthropic_request_path_exactly_v1_messages_under_aegis(
+    aegis_enabled_env: str,
+) -> None:
+    """OPERATOR CORRECTION #1 PROOF: the SDK appends ``/v1/messages``
+    internally. base_url must be the host root, NOT host+/v1, so the
+    final request path is ``/v1/messages`` not ``/v1/v1/messages``."""
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_test", "type": "message", "role": "assistant",
+                "content": [{"type": "text", "text": "ok"}],
+                "model": "claude-opus-4-7", "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(transport=transport)
+    try:
+        client = provider_bridge.make_async_anthropic_client(
+            http_client=http_client,
+        )
+        await client.messages.create(
+            model="claude-opus-4-7",
+            max_tokens=10,
+            messages=[{"role": "user", "content": "hi"}],
+            extra_headers={"X-JARVIS-Lease": "test-lease-token"},
+        )
+    finally:
+        await http_client.aclose()
+
+    assert len(captured) == 1, f"expected 1 request, got {len(captured)}"
+    req = captured[0]
+    assert str(req.url) == f"{aegis_enabled_env}/v1/messages", (
+        f"BUG: path composed wrong. Expected exactly "
+        f"{aegis_enabled_env}/v1/messages, got {req.url}. "
+        f"If you see /v1/v1/messages — base_url was set to {aegis_enabled_env}/v1 "
+        f"instead of {aegis_enabled_env}."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SPINE #7 — DW request paths match Aegis registry allowlist
+# ──────────────────────────────────────────────────────────────────────
+
+DW_REGISTRY_PATHS = (
+    "/v1/chat/completions",
+    "/v1/files",
+    "/v1/batches",
+    "/v1/batches/abc123",       # /v1/batches/{batch_id} template
+    "/v1/files/abc123/content",  # /v1/files/{file_id}/content template
+    "/v1/models",
+)
+
+
+def test_dw_base_url_composes_aegis_root_when_enabled(
+    aegis_enabled_env: str,
+) -> None:
+    """OPERATOR CORRECTION #3: every DW endpoint composes to a path
+    under {JARVIS_AEGIS_URL}/v1/<endpoint>. The DW provider uses
+    f-string composition (``f"{self._base_url}/chat/completions"``)
+    so ``dw_aegis_base_url()`` must return ``{AEGIS}/v1`` (with the
+    /v1 suffix) so f-string composition yields the right final path."""
+    base = provider_bridge.dw_aegis_base_url()
+    assert base == f"{aegis_enabled_env}/v1", (
+        f"BUG: dw_aegis_base_url() returned {base!r}; expected "
+        f"{aegis_enabled_env}/v1 so f-string composition with DW "
+        f"provider's /chat/completions /files /batches /models suffixes "
+        f"produces Aegis-allowlisted paths."
+    )
+    # Verify each known DW endpoint composes correctly under aegis root
+    for suffix in ("/chat/completions", "/files", "/batches",
+                   "/batches/abc123", "/files/abc123/content", "/models"):
+        composed = f"{base}{suffix}"
+        registry_path = f"/v1{suffix}"
+        assert registry_path in (
+            "/v1/chat/completions", "/v1/files", "/v1/batches",
+            "/v1/batches/abc123", "/v1/files/abc123/content", "/v1/models",
+        ), f"path {registry_path} not in Aegis DW allowlist"
+        assert composed.startswith(aegis_enabled_env), composed
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SPINE #8 — per-call distinct lease tokens
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_lease_header_present_per_call_with_distinct_tokens(
+    aegis_enabled_env: str, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OPERATOR CORRECTION #4: leases are PER-CALL, never client-wide.
+    Three sequential calls must carry three DISTINCT lease tokens."""
+    leases_returned = ["lease-A", "lease-B", "lease-C"]
+
+    async def fake_acquire_lease(**kwargs) -> str:
+        return leases_returned.pop(0)
+
+    # Patch the bridge's acquire_call_lease to a deterministic stub
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200, json={
+                "id": "m", "type": "message", "role": "assistant",
+                "content": [{"type": "text", "text": "ok"}],
+                "model": "x", "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(transport=transport)
+    try:
+        client = provider_bridge.make_async_anthropic_client(
+            http_client=http_client,
+        )
+        # Simulate the per-call lease injection pattern that providers.py
+        # is expected to use at each messages.create site.
+        for i in range(3):
+            lease = await fake_acquire_lease(
+                op_id=f"op-{i}", route="standard",
+                estimated_cost_usd=0.01,
+            )
+            await client.messages.create(
+                model="claude-opus-4-7", max_tokens=10,
+                messages=[{"role": "user", "content": "hi"}],
+                extra_headers={"X-JARVIS-Lease": lease},
+            )
+    finally:
+        await http_client.aclose()
+
+    assert len(captured) == 3
+    headers = [r.headers.get("x-jarvis-lease") for r in captured]
+    assert headers == ["lease-A", "lease-B", "lease-C"], (
+        f"leases not distinct per-call: {headers}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SPINE #9 — streaming path carries lease header
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_streaming_path_carries_lease_header(
+    aegis_enabled_env: str,
+) -> None:
+    """OPERATOR CORRECTION #2: messages.stream(...) must carry the
+    same per-call lease as messages.create(...)."""
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        # Minimal SSE event stream that the SDK can parse without choking
+        sse_body = (
+            'event: message_start\n'
+            'data: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","content":[],"model":"x","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n'
+            'event: message_stop\n'
+            'data: {"type":"message_stop"}\n\n'
+        )
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=sse_body.encode(),
+        )
+
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(transport=transport)
+    try:
+        client = provider_bridge.make_async_anthropic_client(
+            http_client=http_client,
+        )
+        async with client.messages.stream(
+            model="claude-opus-4-7", max_tokens=10,
+            messages=[{"role": "user", "content": "hi"}],
+            extra_headers={"X-JARVIS-Lease": "stream-lease-7"},
+        ) as stream:
+            async for _ in stream:
+                pass
+    finally:
+        await http_client.aclose()
+
+    assert len(captured) >= 1
+    assert captured[0].headers.get("x-jarvis-lease") == "stream-lease-7", (
+        f"streaming request missing/wrong lease: "
+        f"{captured[0].headers.get('x-jarvis-lease')!r}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SPINE #10 — Anthropic client has PLACEHOLDER key, not real key
+# ──────────────────────────────────────────────────────────────────────
+
+def test_aegis_enabled_anthropic_client_holds_placeholder_api_key(
+    aegis_enabled_env: str,
+) -> None:
+    """OPERATOR CORRECTION #6: when Aegis is enabled, the constructed
+    Anthropic client must NOT hold the real ANTHROPIC_API_KEY. The
+    real key is injected server-side by Aegis."""
+    client = provider_bridge.make_async_anthropic_client()
+    real_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    assert real_key, "test setup error — ANTHROPIC_API_KEY should be set"
+    assert client.api_key != real_key, (
+        f"LEAK: AsyncAnthropic.api_key holds the real "
+        f"ANTHROPIC_API_KEY when Aegis is enabled. Should be a "
+        f"placeholder; got {client.api_key!r}."
+    )
+    # Sanity: placeholder is non-empty (SDK rejects empty string)
+    assert client.api_key, "placeholder must be non-empty (SDK requirement)"
+    # And the base_url is the Aegis URL
+    assert str(client.base_url).rstrip("/") == aegis_enabled_env.rstrip("/"), (
+        f"client.base_url={client.base_url} should be Aegis URL "
+        f"{aegis_enabled_env}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SPINE #11 — DW auth header has NO real bearer when Aegis enabled
+# ──────────────────────────────────────────────────────────────────────
+
+def test_aegis_enabled_dw_session_has_no_real_bearer(
+    aegis_enabled_env: str,
+) -> None:
+    """OPERATOR CORRECTION #6: when Aegis is enabled, the DW session
+    must NOT carry an Authorization: Bearer <real DW key> header."""
+    auth = provider_bridge.dw_authorization_header()
+    real_key = os.environ.get("DOUBLEWORD_API_KEY", "")
+    assert real_key, "test setup error — DOUBLEWORD_API_KEY should be set"
+    # Auth header should be empty dict (Aegis injects server-side)
+    assert "Authorization" not in auth, (
+        f"LEAK: dw_authorization_header() emitted Authorization header "
+        f"when Aegis is enabled: {auth!r}"
+    )
+    # Defensive: no header value contains the real key
+    for k, v in auth.items():
+        assert real_key not in v, (
+            f"LEAK: real DW key appears in {k}={v!r} when Aegis enabled"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SPINE #12 — lease acquire failure RAISES, no silent fallback
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_lease_acquire_failure_raises_not_falls_back(
+    aegis_enabled_env: str, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OPERATOR CORRECTION #5: if Aegis is enabled and lease acquire
+    fails, the helper RAISES. No silent fallback to direct upstream
+    credentials — that would defeat the Zero-Trust posture."""
+    from backend.core.ouroboros.aegis import client as aegis_client_mod
+
+    async def boom_acquire(**kwargs):
+        raise aegis_client_mod.AegisClientError(
+            "simulated daemon unreachable"
+        )
+
+    # Patch AegisClient.acquire_lease class-level so any singleton built
+    # by acquire_call_lease will use it.
+    monkeypatch.setattr(
+        aegis_client_mod.AegisClient,
+        "acquire_lease",
+        boom_acquire,
+        raising=True,
+    )
+    # Also stub the get() singleton accessor to avoid real session
+    # establishment over the network.
+    fake_singleton = MagicMock()
+    fake_singleton.acquire_lease = boom_acquire
+
+    async def fake_get() -> object:
+        return fake_singleton
+
+    monkeypatch.setattr(aegis_client_mod.AegisClient, "get", fake_get)
+
+    with pytest.raises(aegis_client_mod.AegisClientError):
+        await provider_bridge.acquire_call_lease(
+            op_id="op-x", route="standard", estimated_cost_usd=0.01,
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SPINE #13 — Aegis disabled: byte-identical legacy Anthropic client
+# ──────────────────────────────────────────────────────────────────────
+
+def test_aegis_disabled_yields_byte_identical_legacy_construction(
+    aegis_disabled_env: None,
+) -> None:
+    """When Aegis is disabled, ``make_async_anthropic_client()`` must
+    return a client constructed exactly as legacy code would:
+    api_key from env, base_url defaulted by SDK (api.anthropic.com)."""
+    client = provider_bridge.make_async_anthropic_client()
+    # Legacy api_key = ANTHROPIC_API_KEY from env
+    assert client.api_key == "sk-legacy-anthropic-key", (
+        f"legacy client should use real env key; got {client.api_key!r}"
+    )
+    # Legacy base_url = SDK default (api.anthropic.com)
+    base = str(client.base_url).rstrip("/")
+    assert "api.anthropic.com" in base, (
+        f"legacy client base_url should be api.anthropic.com; got {base}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SPINE #14 — Aegis disabled: DW base_url matches legacy env default
+# ──────────────────────────────────────────────────────────────────────
+
+def test_aegis_disabled_dw_base_url_matches_legacy(
+    aegis_disabled_env: None,
+) -> None:
+    """When Aegis is disabled, ``dw_aegis_base_url()`` must return the
+    legacy default (env DOUBLEWORD_BASE_URL or api.doubleword.ai/v1)."""
+    base = provider_bridge.dw_aegis_base_url()
+    assert base == "https://api.doubleword.ai/v1", (
+        f"legacy DW base_url should be api.doubleword.ai/v1; got {base!r}"
+    )
+    # And auth header should carry the real DW bearer
+    auth = provider_bridge.dw_authorization_header()
+    assert auth.get("Authorization") == "Bearer sk-legacy-dw-key", (
+        f"legacy DW auth header should be Bearer <real-key>; got {auth!r}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Extra spine — disabled state acquire_call_lease returns None
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_acquire_call_lease_returns_none_when_disabled(
+    aegis_disabled_env: None,
+) -> None:
+    """When Aegis disabled, acquire_call_lease returns None so
+    callers can skip the header injection cleanly."""
+    lease = await provider_bridge.acquire_call_lease(
+        op_id="op-x", route="standard", estimated_cost_usd=0.01,
+    )
+    assert lease is None


### PR DESCRIPTION
feat(aegis): Slice 2B-ii — Provider Proxy Bridge (Zero-Trust transport rewire)

Wires O+V's provider modules through the Aegis daemon's /v1/* forwarding
surface so credentialed upstream calls no longer hold real ANTHROPIC_API_KEY
/ DOUBLEWORD_API_KEY at the client/session layer. Aegis-1 substrate (PR
#53861) + Aegis-2B-i forwarding shipped earlier; this is the consumer
rewire that completes the Zero-Trust posture for provider transport.

Single canonical factory: `governance/aegis_provider_bridge.py` exposes
`make_async_anthropic_client()` / `dw_aegis_base_url()` /
`dw_authorization_header()` / `acquire_call_lease()` / `merge_lease_header()`.
AST pins enforce that no module outside the bridge constructs AsyncAnthropic
or composes raw "Bearer <DW key>" headers; every `messages.create` /
`messages.stream` / DW `session.post`+`.get` to /v1/* carries a per-call
X-JARVIS-Lease.

When JARVIS_AEGIS_ENABLED is true:
  * AsyncAnthropic constructed with base_url=JARVIS_AEGIS_URL (host root —
    SDK appends /v1/messages internally → final wire path is
    {AEGIS}/v1/messages, NOT /v1/v1/messages); api_key is a placeholder
    (real key confiscated by daemon).
  * DW base_url composes to {JARVIS_AEGIS_URL}/v1 (f-string suffixes hit
    /v1/chat/completions etc.); aiohttp session holds NO Authorization
    header (daemon injects DOUBLEWORD_API_KEY upstream).
  * Per-call lease via `acquire_call_lease()` — raises on failure (no
    silent fallback to direct credentials). Operator correction #5.

When disabled: byte-identical legacy path preserved at every site.

Slice covers all 6 Anthropic call sites in providers.py (5 create + 1
stream) + the 5 auxiliary modules (claude_fallback, self_critique,
general_driver, fast_path_qa, visual_comprehension, m10/bridge_adapters)
+ all 7 DW credentialed endpoints (chat/completions, files, batches,
batches/{id}, files/{id}/content, models). op_id threaded via ContextVar
(asyncio-task-local — concurrent ops scope independently) so we don't
have to plumb op_id through ~20 internal methods between generate(ctx)
and messages.create().

Bridge module lives under governance/ (not aegis/) by design — it imports
the anthropic SDK, which the Aegis substrate's
`test_ast_pin_no_anthropic_or_openai_sdk_import` correctly forbids under
aegis/ (credential-confiscation invariant). Bridge is a CONSUMER of
aegis.client, not part of the substrate.

NOT in this slice (deferred):
  * Graduating JARVIS_AEGIS_ENABLED to default-TRUE — Slice 2B-iii
    pending empirical soak proof
  * SSE parsing / streaming / chunking changes — operator binding
    "transport-layer swap only" honored
  * Any modifications to aegis/* substrate

Test surface (15 tests, all green; 25 Aegis AST pins still green; 167
surrounding governance regression tests still green):
  * 5 AST pins — no raw AsyncAnthropic outside bridge; no raw Bearer
    composition in DW; extra_headers= kwarg present at every
    messages.create / messages.stream / DW session call site
  * 9 spine tests with httpx.MockTransport — captures actual outbound
    request URL, headers, and api_key state to prove wire behavior
    (not just import-graph). Per operator correction #6.
  * 1 disabled-state bonus — acquire_call_lease returns None cleanly

10 files changed, 1426 insertions(+), 36 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all Anthropic and Doubleword provider traffic through the Aegis proxy so no client or session holds real `ANTHROPIC_API_KEY`/`DOUBLEWORD_API_KEY`. Adds per‑call `X-JARVIS-Lease` headers and keeps legacy behavior when Aegis is disabled.

- **New Features**
  - Added `governance/aegis_provider_bridge.py` with `make_async_anthropic_client`, `dw_aegis_base_url`, `dw_authorization_header`, `acquire_call_lease`, and `merge_lease_header`.
  - Anthropic: client `base_url` set to `JARVIS_AEGIS_URL` (host root) with a placeholder key; all `messages.create` and `messages.stream` pass `extra_headers` with a per-call lease; op_id is scoped via a `ContextVar`.
  - Doubleword: base URL composes to `{JARVIS_AEGIS_URL}/v1`; `aiohttp` session carries no `Authorization` header when enabled; per-call leases added on `post`/`get` for `chat/completions`, `files`, `batches`, `batches/{id}`, `files/{id}/content`, and `models`.
  - Lease acquisition raises on failure; when disabled, paths are byte-identical to legacy at every call site.

- **Migration**
  - No changes needed if Aegis is disabled.
  - To enable, set `JARVIS_AEGIS_URL` and bootstrap credentials (and the flag if applicable) so `aegis.client.is_enabled()` returns true.
  - SSE/stream parsing and Aegis substrate remain unchanged in this slice.

<sup>Written for commit 50264fae3bc96783a890c8e215666f564230696b. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/56360?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

