### PR TITLE
feat(aegis): Slice 2B-iv — Aegis Zero-Trust Arc GRADUATION (dual flag → default-TRUE)

### DIFF
--- a/backend/core/ouroboros/aegis/flags.py
+++ b/backend/core/ouroboros/aegis/flags.py
@@ -69,13 +69,47 @@ DEFAULT_WAL_PATH_REL: str = ".jarvis/aegis/spend.jsonl"
 
 
 def is_enabled() -> bool:
-    """Master switch. Default **false** (Slice 1 dark)."""
-    return get_default_registry().get_bool(ENV_AEGIS_ENABLED, default=False)
+    """Aegis Zero-Trust master switch. Default **TRUE** post Slice
+    2B-iv graduation (2026-05-25).
+
+    Graduated based on 6 sequential battle-test soaks proving the
+    end-to-end architecture works correctly:
+      * bt-2026-05-24-222008 → Slice 2B-ii.1 (avail-gate Catch-22)
+      * bt-2026-05-24-225714 → Slice 2B-ii.2 + 2B-iii.1
+        (heavy probe + ledger hygiene)
+      * bt-2026-05-24-232345 → Slice 2B-iii.2 (cap defaults)
+      * bt-2026-05-24-233640 → architecture fully proven
+        (real Anthropic request_ids from forwarded calls)
+      * bt-2026-05-24-235428 → Slice 2B-iii.3 (header collision)
+      * bt-2026-05-25-004146 → ULTIMATE — ZERO AuthenticationError,
+        $0.10 real Claude generation through Aegis,
+        stop_reason=end_turn output_tokens=5433; Iron Gate then
+        correctly refused the undisciplined patch — governance
+        working as designed.
+
+    Operator opt-out preserved: setting
+    ``JARVIS_AEGIS_ENABLED=false`` STILL disables the master
+    (env-precedence honored — graduation flips the DEFAULT, not
+    seals the flag). Critical for emergency rollback.
+    """
+    return get_default_registry().get_bool(ENV_AEGIS_ENABLED, default=True)
 
 
 def forwarding_enabled() -> bool:
     """Slice 2 sub-switch — gates /v1/messages + /v1/chat/completions
-    registration. Default **false** through Slice 4 graduation soak.
+    registration. Default **TRUE** post Slice 2B-iv graduation
+    (2026-05-25), in lockstep with ``is_enabled()``.
+
+    Dual-graduation rationale: master without forwarding = daemon
+    spawns + scrubs creds, but no /v1/* routes → providers POST to
+    {AEGIS}/v1/messages → 404 → all generation breaks by default.
+    Empirical evidence: all 6 graduation soaks ran with both flags
+    =true; dual-on is the ONLY tested configuration that operates
+    end-to-end.
+
+    Operator opt-out preserved: setting
+    ``JARVIS_AEGIS_FORWARDING_ENABLED=false`` STILL disables
+    forwarding (env-precedence honored).
 
     Independent of :func:`is_enabled`: an operator can spin up the
     Aegis daemon in lease-only mode (Slice 1 substrate) without
@@ -83,7 +117,7 @@ def forwarding_enabled() -> bool:
     and for the §44 diagnostic harnesses that test the daemon
     without provider traffic."""
     return get_default_registry().get_bool(
-        ENV_AEGIS_FORWARDING_ENABLED, default=False,
+        ENV_AEGIS_FORWARDING_ENABLED, default=True,
     )
 
 
@@ -182,14 +216,18 @@ def _seeds() -> List[FlagSpec]:
         FlagSpec(
             name=ENV_AEGIS_ENABLED,
             type=FlagType.BOOL,
-            default=False,
+            default=True,
             description=(
-                "Arc #1 master switch. **Slice 1 dark by default.** "
-                "When false (default), Aegis daemon is not spawned, no "
-                "credential scrub, no behavior change. When true (post "
-                "Slice 4 graduation), harness spawns Aegis pre-supervisor, "
-                "scrubs upstream credentials from JARVIS env, and routes "
-                "all provider traffic through the localhost proxy."
+                "Arc #1 master switch. **Graduated to default-TRUE 2026-05-25 "
+                "via Slice 2B-iv** after 6 sequential battle-test soaks "
+                "proved end-to-end architecture (real Anthropic request_ids "
+                "from Aegis-forwarded calls; final soak bt-2026-05-25-004146 "
+                "delivered $0.10 real Claude generation via the daemon with "
+                "ZERO AuthenticationError). When true (default), harness "
+                "spawns Aegis pre-supervisor, scrubs upstream credentials "
+                "from JARVIS env, and routes all provider traffic through "
+                "the localhost proxy. Operator opt-out preserved via "
+                "explicit JARVIS_AEGIS_ENABLED=false (env-precedence)."
             ),
             category=Category.SAFETY,
             source_file=_SRC_AEGIS,
@@ -198,14 +236,20 @@ def _seeds() -> List[FlagSpec]:
         FlagSpec(
             name=ENV_AEGIS_FORWARDING_ENABLED,
             type=FlagType.BOOL,
-            default=False,
+            default=True,
             description=(
                 "Slice 2 sub-switch. Gates registration of /v1/messages "
                 "(Anthropic-compat) and /v1/chat/completions (OpenAI-compat / "
-                "DW) forwarding routes on the Aegis daemon. Default-FALSE "
-                "through Slice 4 graduation soak. Independent of "
-                "JARVIS_AEGIS_ENABLED so the daemon can run in lease-only "
-                "mode for the §44 diagnostic harnesses."
+                "DW) forwarding routes on the Aegis daemon. **Graduated to "
+                "default-TRUE 2026-05-25 via Slice 2B-iv** in lockstep with "
+                "the master flag — without it, the master-on path returns "
+                "404 on every /v1/* call (provider traffic routes through "
+                "Aegis but daemon has no forwarding routes registered). "
+                "All 6 graduation soaks used both flags =true; dual-on is "
+                "the ONLY tested production configuration. Independent of "
+                "JARVIS_AEGIS_ENABLED so an operator can run the daemon "
+                "in lease-only mode for the §44 diagnostic harnesses by "
+                "explicit JARVIS_AEGIS_FORWARDING_ENABLED=false."
             ),
             category=Category.SAFETY,
             source_file=_SRC_AEGIS,

--- a/tests/aegis/test_slice2biv_graduation.py
+++ b/tests/aegis/test_slice2biv_graduation.py
@@ -1,0 +1,284 @@
+"""Slice 2B-iv — Aegis Zero-Trust GRADUATION.
+
+Closes the entire Aegis Zero-Trust Arc by graduating both master
+switches to default-TRUE. The architecture has been proven
+end-to-end across 6 sequential soaks:
+
+  bt-2026-05-24-222008 → Slice 2B-ii.1 surfaced (Catch-22)
+  bt-2026-05-24-225714 → Slice 2B-ii.2 + 2B-iii.1 surfaced
+  bt-2026-05-24-232345 → Slice 2B-iii.2 surfaced (caps default $0)
+  bt-2026-05-24-233640 → architecture fully proven (signals 1-4 green;
+                          DW 403 = real upstream entitlement, not Aegis)
+  bt-2026-05-24-235428 → Slice 2B-iii.3 surfaced (header collision 401)
+  bt-2026-05-25-004146 → ULTIMATE: ZERO AuthenticationError, real
+                          $0.10 Claude generation through Aegis with
+                          stop_reason=end_turn output_tokens=5433.
+                          Iron Gate then correctly refused the
+                          undisciplined patch attempt — governance
+                          working as designed.
+
+# What graduates
+
+Both ``JARVIS_AEGIS_ENABLED`` and ``JARVIS_AEGIS_FORWARDING_ENABLED``
+flip from default-FALSE → default-TRUE. The graduation is **dual**
+because the empirical evidence shows the architecture works ONLY when
+both are on:
+
+  * Master on / forwarding off → daemon spawns + scrubs creds, but
+    no /v1/* routes registered → providers POST to {AEGIS}/v1/messages
+    → 404 → all generation breaks by default. Would ship a regression.
+  * Master off / forwarding on → forwarding routes never registered
+    (build_app reads master flag at boot).
+  * Master on / forwarding on → the configuration we tested across
+    all 6 soaks; end-to-end operational. THIS is the default.
+
+# Why this is the right time
+
+  * Architecture proven (request_id from Anthropic in soaks 4, 5, 6
+    — REAL upstream traffic, not mocked).
+  * Strip-fix proven (zero AuthenticationError in 10-min soak after
+    Slice 2B-iii.3 landed, vs 1 within 30s pre-fix).
+  * Governance proven (Iron Gate correctly refused exploration-skipping
+    Claude on the ansible op — fail-closed posture intact).
+  * Soak hygiene proven (Slice 2B-iii.1 ledger rotation + 2B-iii.2
+    structural cap defaults ensure clean per-session state).
+
+# What this slice does NOT do
+
+  * NO modification to `aegis/flags.py` defaults beyond the two
+    booleans flipping — `session_cap_usd`, `hourly_burn_cap_usd`,
+    `route_caps_usd` all STAY at $0.00 fail-closed (operator must
+    explicitly authorize spend per session).
+  * NO modification to operator-facing env-precedence — any operator
+    setting `=false` for either flag preserves opt-out.
+  * NO modification to provider behavior under disabled-Aegis paths
+    — bridge factory still has the legacy direct-upstream branch
+    intact (would fire if operator explicitly opts out).
+
+# Test surface
+
+AST pins (4): both flag defaults locked structurally at the
+``is_enabled()`` / ``forwarding_enabled()`` function-body level
+AND at the ``_seeds()`` FlagSpec registration level (the FlagRegistry
+seed mirrors the function default — both must stay in sync).
+
+Spine tests (4): both helpers return True when env unset; both
+return False when env explicitly =false (operator-opt-out preserved);
+both return True when env explicitly =true (post-graduation explicit
+opt-in is a no-op).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FLAGS_FILE = REPO_ROOT / "backend" / "core" / "ouroboros" / "aegis" / "flags.py"
+
+
+def _parse_flags() -> ast.Module:
+    return ast.parse(FLAGS_FILE.read_text())
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PIN #1 — is_enabled() function body has default=True
+# ──────────────────────────────────────────────────────────────────────
+
+def test_ast_pin_is_enabled_default_true() -> None:
+    """``is_enabled()`` body must call ``get_bool(..., default=True)``.
+
+    This is the load-bearing graduation. Reverting to default=False
+    would silently demote the entire Aegis Zero-Trust posture across
+    every JARVIS deployment on next pull.
+    """
+    tree = _parse_flags()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "is_enabled":
+            continue
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call):
+                continue
+            if not isinstance(sub.func, ast.Attribute):
+                continue
+            if sub.func.attr != "get_bool":
+                continue
+            default_kw = next(
+                (kw for kw in sub.keywords if kw.arg == "default"), None,
+            )
+            assert default_kw is not None, (
+                "is_enabled() get_bool() call missing default= kwarg"
+            )
+            assert isinstance(default_kw.value, ast.Constant), (
+                f"default= must be a literal, got {ast.dump(default_kw.value)}"
+            )
+            assert default_kw.value.value is True, (
+                "is_enabled() default REVERTED from True → False. "
+                "Slice 2B-iv graduated this flag based on 6-soak "
+                "empirical evidence; reverting would silently demote "
+                "the entire Aegis Zero-Trust posture by default."
+            )
+            return
+    pytest.fail("is_enabled() function not found in flags.py")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PIN #2 — forwarding_enabled() function body has default=True
+# ──────────────────────────────────────────────────────────────────────
+
+def test_ast_pin_forwarding_enabled_default_true() -> None:
+    """``forwarding_enabled()`` body must call ``get_bool(..., default=True)``.
+
+    Dual-graduation requirement: master without forwarding = 404 on
+    every /v1/* call = all generation broken by default. The two
+    flags graduate together.
+    """
+    tree = _parse_flags()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "forwarding_enabled":
+            continue
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call):
+                continue
+            if not isinstance(sub.func, ast.Attribute):
+                continue
+            if sub.func.attr != "get_bool":
+                continue
+            default_kw = next(
+                (kw for kw in sub.keywords if kw.arg == "default"), None,
+            )
+            assert default_kw is not None
+            assert isinstance(default_kw.value, ast.Constant)
+            assert default_kw.value.value is True, (
+                "forwarding_enabled() default REVERTED from True → "
+                "False. Slice 2B-iv graduated this with the master; "
+                "demoting it (without also demoting master) would "
+                "break all generation by default — providers route "
+                "through Aegis but daemon would return 404."
+            )
+            return
+    pytest.fail("forwarding_enabled() function not found in flags.py")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PIN #3 — FlagSpec seeds for both flags also default=True
+# ──────────────────────────────────────────────────────────────────────
+
+def _find_flagspec_default(tree: ast.Module, env_var_attr_name: str) -> bool:
+    """Walk for ``FlagSpec(name=ENV_AEGIS_ENABLED, ..., default=...)``
+    and return the literal default. The FlagRegistry seed mirrors the
+    function default — both must stay in sync."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name) or node.func.id != "FlagSpec":
+            continue
+        name_kw = next((kw for kw in node.keywords if kw.arg == "name"), None)
+        if name_kw is None:
+            continue
+        # Match against the ENV constant name
+        if not (
+            isinstance(name_kw.value, ast.Name)
+            and name_kw.value.id == env_var_attr_name
+        ):
+            continue
+        default_kw = next(
+            (kw for kw in node.keywords if kw.arg == "default"), None,
+        )
+        assert default_kw is not None, (
+            f"FlagSpec(name={env_var_attr_name}) missing default= kwarg"
+        )
+        assert isinstance(default_kw.value, ast.Constant)
+        return default_kw.value.value
+    pytest.fail(f"FlagSpec(name={env_var_attr_name}) not found")
+
+
+def test_ast_pin_flagspec_seed_aegis_enabled_default_true() -> None:
+    """The FlagRegistry seed for ENV_AEGIS_ENABLED must also be
+    default=True (mirrors the is_enabled() function default).
+
+    De-sync between function-default + seed-default is a known
+    foot-gun: docs/observability show one value, runtime reads
+    another. This pin enforces parity.
+    """
+    tree = _parse_flags()
+    assert _find_flagspec_default(tree, "ENV_AEGIS_ENABLED") is True, (
+        "FlagSpec seed for ENV_AEGIS_ENABLED is NOT default=True. "
+        "Mismatch between function default (graduated to True) and "
+        "registry seed (still False) would mis-document the "
+        "graduated state in /observability/flags and /help."
+    )
+
+
+def test_ast_pin_flagspec_seed_forwarding_enabled_default_true() -> None:
+    """Same parity check for ENV_AEGIS_FORWARDING_ENABLED."""
+    tree = _parse_flags()
+    assert _find_flagspec_default(tree, "ENV_AEGIS_FORWARDING_ENABLED") is True, (
+        "FlagSpec seed for ENV_AEGIS_FORWARDING_ENABLED is NOT "
+        "default=True. See parallel test for ENV_AEGIS_ENABLED."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — runtime behavior matches the AST pins
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def aegis_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip both Aegis master/forwarding env vars so the helpers
+    fall through to their default. Per-fixture reset; monkeypatch
+    restores after the test."""
+    monkeypatch.delenv("JARVIS_AEGIS_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_AEGIS_FORWARDING_ENABLED", raising=False)
+
+
+def test_spine_is_enabled_true_when_env_unset(aegis_env_unset: None) -> None:
+    """With no env var, ``is_enabled()`` returns True (graduated)."""
+    from backend.core.ouroboros.aegis.flags import is_enabled
+    assert is_enabled() is True
+
+
+def test_spine_forwarding_enabled_true_when_env_unset(
+    aegis_env_unset: None,
+) -> None:
+    """With no env var, ``forwarding_enabled()`` returns True."""
+    from backend.core.ouroboros.aegis.flags import forwarding_enabled
+    assert forwarding_enabled() is True
+
+
+def test_spine_operator_can_still_opt_out_via_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator explicit opt-out (env =false) STILL preserved
+    post-graduation — graduation doesn't seal the flag, just flips
+    the default. Critical for emergency rollback scenarios."""
+    from backend.core.ouroboros.aegis.flags import (
+        is_enabled, forwarding_enabled,
+    )
+    monkeypatch.setenv("JARVIS_AEGIS_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_AEGIS_FORWARDING_ENABLED", "false")
+    assert is_enabled() is False, (
+        "Operator opt-out (JARVIS_AEGIS_ENABLED=false) was overridden "
+        "post-graduation — would prevent emergency rollback. "
+        "Graduation must flip the DEFAULT, not seal the flag."
+    )
+    assert forwarding_enabled() is False, (
+        "Same for forwarding flag."
+    )
+
+
+def test_spine_operator_explicit_true_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operators with existing soak runbooks that set =true explicitly
+    (per the 6 prior soaks) keep working — explicit-true matches the
+    new default; behavior unchanged."""
+    from backend.core.ouroboros.aegis.flags import (
+        is_enabled, forwarding_enabled,
+    )
+    monkeypatch.setenv("JARVIS_AEGIS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_AEGIS_FORWARDING_ENABLED", "true")
+    assert is_enabled() is True
+    assert forwarding_enabled() is True


### PR DESCRIPTION
feat(aegis): Slice 2B-iv — Aegis Zero-Trust Arc GRADUATION

Closes the entire Aegis Zero-Trust Arc by graduating both master
switches to default-TRUE. This is the structural lock-in of 6 prior
slices + 6 sequential battle-test soaks worth of empirical proof.

## What graduates

Two booleans flip default-FALSE → default-TRUE in
`aegis/flags.py`, with matching `FlagSpec` seed updates and AST
pins enforcing both:

  * `JARVIS_AEGIS_ENABLED` — Arc #1 master switch. Operator's
    literal directive.
  * `JARVIS_AEGIS_FORWARDING_ENABLED` — Slice 2 sub-switch
    (necessary co-graduation; without it the master-on path
    returns 404 on every /v1/* call → all generation would break
    by default. All 6 soaks tested dual-on; that's the production
    configuration).

## Empirical evidence chain (6 sequential soaks)

  | Soak                       | What surfaced + closed                |
  |----------------------------|---------------------------------------|
  | bt-2026-05-24-222008       | Catch-22: env scrub disabled providers |
  |   → Slice 2B-ii.1          | Aegis-aware is_available gates        |
  | bt-2026-05-24-225714       | 11th call site + stale WAL            |
  |   → Slice 2B-ii.2 + iii.1  | heavy probe wired + ledger hygiene    |
  | bt-2026-05-24-232345       | $0 fail-closed cap blocks leases      |
  |   → Slice 2B-iii.2         | structural cap defaults helper        |
  | bt-2026-05-24-233640       | architecture FULLY proven —           |
  |                            | real Anthropic request_ids from       |
  |                            | Aegis-forwarded calls                 |
  | bt-2026-05-24-235428       | header case-collision (401 leak)      |
  |   → Slice 2B-iii.3         | strip endpoint.auth_header from       |
  |                            | inbound headers                       |
  | bt-2026-05-25-004146       | ULTIMATE: ZERO AuthenticationError,   |
  |                            | $0.10 real Claude generation via      |
  |                            | Aegis (stop_reason=end_turn,          |
  |                            | output_tokens=5433). Iron Gate then   |
  |                            | correctly refused the undisciplined   |
  |                            | patch attempt — governance working    |
  |                            | exactly as designed.                  |

## Operator binding — opt-out preserved

Graduation flips the DEFAULT, NOT seals the flag. Operators can
still emergency-rollback via explicit env:

  export JARVIS_AEGIS_ENABLED=false
  export JARVIS_AEGIS_FORWARDING_ENABLED=false

Test coverage explicitly verifies this (the new spine test
`test_spine_operator_can_still_opt_out_via_env`).

## Operator binding — strictness preserved

Daemon-side fail-closed defaults UNTOUCHED:

  * `session_cap_usd` stays default $0.00 (operator must
    explicitly authorize spend; `default_battle_test_caps()`
    helper installs battle-test caps structurally without
    changing the daemon default)
  * `hourly_burn_cap_usd` stays $0.00
  * `route_caps_usd` stays default-empty

Per operator's standing binding "Do not simply loosen the
default ... The ceiling should remain strict."

## Test surface (8 new + 200 surrounding regression, all green)

AST pins (4):
  * `is_enabled()` function default=True (literal AST constant
    walk, not substring — survives reformat)
  * `forwarding_enabled()` function default=True
  * `FlagSpec(name=ENV_AEGIS_ENABLED).default=True`
  * `FlagSpec(name=ENV_AEGIS_FORWARDING_ENABLED).default=True`

Spine (4):
  * Both helpers return True when env unset (graduated default)
  * Operator opt-out via explicit `=false` STILL preserved
  * Operator explicit `=true` (matching new default) is no-op
  * (Implicit: nothing breaks under env-precedence inversion)

Regression: 200 tests across the full Aegis-area suite all green
(slice 2B-ii / ii.1 / ii.2 / iii.1 / iii.2 / iii.3 / AST pins / etc).
32 pre-existing PermissionError integration tests are sandbox-blocked
(network sockets), unaffected by this change.

## What this does NOT do (no scope creep)

  * No capability-measurement claim — the ultimate soak's ansible
    op terminated with `generate_runner: generation is None` after
    Iron Gate correctly refused two undisciplined patch attempts.
    That's a model-compliance issue (Claude ignored exploration
    feedback), not an architecture issue. Capability measurement
    is a separate, larger arc.
  * No bridge / provider / daemon code changes — those substrates
    are already proven across the prior 6 PRs.
  * No new env vars / flags / observability surfaces.

## Files

  * `backend/core/ouroboros/aegis/flags.py` — 2 function defaults +
    2 FlagSpec seeds flipped; docstrings updated to reflect
    graduated state with empirical-evidence references.
  * `tests/aegis/test_slice2biv_graduation.py` (NEW) — 8 tests.

2 files changed, ~370 insertions(+), ~25 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduate Aegis Zero-Trust to on-by-default by flipping both master flags to true. Keeps operator opt‑out and strict $0 spend caps; ensures `/v1/*` forwarding works out of the box.

- **New Features**
  - Set `is_enabled()` and `forwarding_enabled()` defaults to true in `backend/core/ouroboros/aegis/flags.py`, with matching `FlagSpec` seeds.
  - Add AST pins and spine tests to lock defaults and verify env precedence (`tests/aegis/test_slice2biv_graduation.py`).
  - No bridge/provider/daemon changes and no new env vars. Strict caps remain $0.

- **Migration**
  - Aegis and forwarding now default to ON. To keep the previous behavior, set:
    - `JARVIS_AEGIS_ENABLED=false`
    - `JARVIS_AEGIS_FORWARDING_ENABLED=false`

<sup>Written for commit 0e5e094c2da1749d6112bc9c157a2adf35366b48. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/56663?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

