### PR TITLE
feat(governance): Slice 3B.1 — Self-tuning TTFT floor constraint

### DIFF
--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -4750,11 +4750,29 @@ class BudgetPlan:
         # Condition 1 — legacy min_per_round floor
         if self.unclamped_fair_share_s(remaining_s, remaining_rounds) < self.min_per_round_s:
             return False
-        # Condition 2 — Slice 3B min TTFT floor
-        # Skip this check when floor is 0 (operator opt-out) for
-        # backward-compat with tests that don't set min_ttft_floor_s.
+        # Condition 2 — Slice 3B + 3B.1 self-tuning TTFT floor.
+        #
+        # The EFFECTIVE floor is the smaller of:
+        #   (a) min_ttft_floor_s — empirical Claude completion floor
+        #   (b) max_per_round_s  — operator's per-round ceiling
+        #
+        # Rationale (Slice 3B.1, post bt-2026-05-25-015301): the
+        # global min_ttft_floor (default 45s) sits ABOVE the legacy
+        # default max_per_round_s (30s). Without self-tuning, the
+        # gate would fire on EVERY round under ample budget because
+        # per_round_timeout clamps to max_per_round_s=30s < floor=45s.
+        # That's a false positive — when max_per_round_s is the
+        # dominant clamp, the operator has tuned the ceiling
+        # intentionally; respect it as the effective per-round
+        # budget AND the effective floor.
+        #
+        # Gate fires ONLY when fair-share squeeze pushes
+        # per_round_timeout below this effective floor — genuine
+        # starvation that would have produced the soak-#2-style
+        # stream rupture.
         if self.min_ttft_floor_s > 0.0:
-            if self.per_round_timeout(remaining_s, remaining_rounds) < self.min_ttft_floor_s:
+            effective_floor = min(self.min_ttft_floor_s, self.max_per_round_s)
+            if self.per_round_timeout(remaining_s, remaining_rounds) < effective_floor:
                 return False
         return True
 

--- a/tests/governance/test_slice3b1_self_tuning_floor.py
+++ b/tests/governance/test_slice3b1_self_tuning_floor.py
@@ -1,0 +1,189 @@
+"""Slice 3B.1 — Self-tuning TTFT floor constraint.
+
+Slice 3B's soak bt-2026-05-25-015301 proved the Layer 1 gate works
+(no more stream rupture mid-flight) but revealed the gate OVER-FIRES
+under plentiful budget:
+
+  remaining=328.59s rounds_left=9 projected_per_round=30.00s
+    min_ttft_floor=45.00s — bailing pre-call
+
+With 328s of wall budget remaining (ample!), fair_share = 36.5s
+which CLAMPS to ``max_per_round_s = 30s``. The 30s ceiling is BELOW
+the 45s floor → gate fires every time, regardless of budget health.
+
+# Root cause
+
+``is_next_round_viable`` checked ``per_round_timeout < floor``. But
+``per_round_timeout`` returns ``min(max_per_round_s, fair_share)`` —
+when ``max_per_round_s`` is the dominant clamp (ample budget), the
+check fires even though the squeeze isn't real.
+
+# Fix — self-tuning floor
+
+The floor must be capped at ``max_per_round_s``. If the operator has
+configured ``max_per_round_s = 30s``, that IS the effective ceiling
+on per-round duration — the floor only matters when fair_share
+squeezes BELOW that ceiling.
+
+Effective floor: ``min(min_ttft_floor_s, max_per_round_s)``.
+
+Equivalent gate predicate: gate fires iff
+``per_round_timeout < min(min_ttft_floor_s, max_per_round_s)``.
+
+  * Ample budget at ceiling (per_round = max = 30s,
+    floor = 45s):  effective_floor = min(45, 30) = 30; 30 >= 30 → OK
+  * Tight budget below ceiling (per_round = fair_share = 5s,
+    floor = 45s, max = 30s): effective_floor = 30; 5 < 30 → gate fires
+  * Tight budget above ceiling (per_round = max = 30s,
+    fair_share = 200s, floor = 45s): same as ample budget — OK
+  * Operator-bumped ceiling (max = 60s, fair_share = 200s,
+    floor = 45s): effective_floor = min(45, 60) = 45; 60 >= 45 → OK
+
+Self-tuning: no env knob, no hardcoding. Adapts to operator's
+``max_per_round_s`` (env: ``JARVIS_GOVERNED_TOOL_TIMEOUT_S``).
+
+# Test surface (1 AST pin + 5 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_EXECUTOR_FILE = REPO_ROOT / "backend" / "core" / "ouroboros" / "governance" / "tool_executor.py"
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PIN — is_next_round_viable references max_per_round_s
+# ──────────────────────────────────────────────────────────────────────
+
+def test_ast_pin_is_next_round_viable_caps_floor_at_max_per_round() -> None:
+    """``BudgetPlan.is_next_round_viable`` body must reference BOTH
+    ``min_ttft_floor_s`` AND ``max_per_round_s`` — the self-tuning
+    invariant requires the floor to be capped at the operator's
+    configured max. Without this, the gate over-fires when the
+    operator's max_per_round_s is below the global floor."""
+    tree = _parse(TOOL_EXECUTOR_FILE)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != "BudgetPlan":
+            continue
+        for sub in node.body:
+            if not isinstance(sub, ast.FunctionDef):
+                continue
+            if sub.name != "is_next_round_viable":
+                continue
+            body_src = ast.unparse(sub)
+            assert "min_ttft_floor_s" in body_src, (
+                "is_next_round_viable does not reference min_ttft_floor_s"
+            )
+            assert "max_per_round_s" in body_src, (
+                "is_next_round_viable does not reference max_per_round_s — "
+                "Slice 3B.1's self-tuning invariant requires capping the "
+                "floor at max_per_round_s. Without this, the gate fires "
+                "under ample budget at the ceiling (the trap surfaced "
+                "by soak bt-2026-05-25-015301)."
+            )
+            return
+    pytest.fail("BudgetPlan.is_next_round_viable not found")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — the soak's failure mode is now PASSING
+# ──────────────────────────────────────────────────────────────────────
+
+def test_spine_ample_budget_at_max_per_round_ceiling_is_viable() -> None:
+    """The EXACT soak condition: budget=328s, rounds_left=9,
+    max_per_round_s=30s (default), min_ttft_floor=45s.
+
+    fair_share = 328/9 = 36.4s; clamps to max=30s.
+    Effective floor = min(45, 30) = 30s.
+    30 >= 30 → viable=True.
+
+    This is the regression test for the over-fire trap."""
+    from backend.core.ouroboros.governance.tool_executor import BudgetPlan
+    plan = BudgetPlan.build(
+        total_budget_s=358.0,
+        hard_max_rounds=10,
+        max_per_round_s=30.0,  # legacy default
+        min_per_round_s=3.0,
+        final_write_reserve_s=10.0,
+    )
+    # Pre-Slice-3B.1: this returned False (the soak's failure)
+    # Post-Slice-3B.1: returns True (operator's max ceiling is honored)
+    assert plan.is_next_round_viable(remaining_s=328.0, remaining_rounds=9) is True
+
+
+def test_spine_tight_budget_below_ceiling_still_starves() -> None:
+    """Genuine starvation: budget=30s, rounds_left=10, max=30s,
+    floor=45s. fair_share = 2s; clamps to min=3s. 3 < 30 → gate fires.
+
+    This is the original Slice 3B target — preserved post-3B.1."""
+    from backend.core.ouroboros.governance.tool_executor import BudgetPlan
+    plan = BudgetPlan.build(
+        total_budget_s=300.0,
+        hard_max_rounds=10,
+        max_per_round_s=30.0,
+        min_per_round_s=3.0,
+        final_write_reserve_s=10.0,
+    )
+    # fair_share = 20/10 = 2s, clamps to 3s
+    # effective_floor = min(45, 30) = 30
+    # 3 < 30 → starved
+    assert plan.is_next_round_viable(remaining_s=30.0, remaining_rounds=10) is False
+
+
+def test_spine_operator_bumped_ceiling_above_floor() -> None:
+    """Operator sets max=60s (above floor=45). With ample budget,
+    per_round = max = 60s. effective_floor = min(45, 60) = 45.
+    60 >= 45 → viable."""
+    from backend.core.ouroboros.governance.tool_executor import BudgetPlan
+    plan = BudgetPlan.build(
+        total_budget_s=600.0,
+        hard_max_rounds=10,
+        max_per_round_s=60.0,  # operator-bumped
+        min_per_round_s=3.0,
+        final_write_reserve_s=10.0,
+    )
+    assert plan.is_next_round_viable(remaining_s=600.0, remaining_rounds=10) is True
+
+
+def test_spine_soak_starvation_at_5s_still_caught() -> None:
+    """The ORIGINAL Slice 3B soak's failure mode (bt-2026-05-25-012206):
+    budget=61.6s, rounds_left=10. fair_share=5.16s, max=30s, floor=45s.
+    effective_floor = min(45, 30) = 30. 5.16 < 30 → starved.
+
+    Slice 3B.1 doesn't regress Slice 3B's win — genuine sub-floor
+    starvation still gates correctly."""
+    from backend.core.ouroboros.governance.tool_executor import BudgetPlan
+    plan = BudgetPlan.build(
+        total_budget_s=358.0,
+        hard_max_rounds=10,
+        max_per_round_s=30.0,
+        min_per_round_s=3.0,
+        final_write_reserve_s=10.0,
+    )
+    assert plan.is_next_round_viable(remaining_s=61.6, remaining_rounds=10) is False
+
+
+def test_spine_legacy_min_per_round_gate_preserved() -> None:
+    """The legacy unclamped-fair-share < min_per_round_s gate (Condition 1
+    of is_next_round_viable) must STILL work — Slice 3B.1 only refines
+    Condition 2 (the TTFT floor)."""
+    from backend.core.ouroboros.governance.tool_executor import BudgetPlan
+    plan = BudgetPlan.build(
+        total_budget_s=100.0,
+        hard_max_rounds=10,
+        max_per_round_s=30.0,
+        min_per_round_s=10.0,  # high min — easy to starve
+        final_write_reserve_s=10.0,
+    )
+    # remaining=20, rounds=10: unclamped_fair_share = 10/10 = 1s.
+    # 1 < min_per_round_s=10 → legacy condition 1 starves.
+    assert plan.is_next_round_viable(remaining_s=20.0, remaining_rounds=10) is False

--- a/tests/governance/test_slice3b_adaptive_stream_resilience.py
+++ b/tests/governance/test_slice3b_adaptive_stream_resilience.py
@@ -214,21 +214,23 @@ def test_spine_is_next_round_viable_true_with_ample_budget(
     plan_with_default_floor,
 ) -> None:
     """With 600s remaining and 10 rounds left, the per_round_timeout
-    clamps to max_per_round_s=30s — which is below min_ttft_floor=45s.
+    clamps to max_per_round_s=30s.
 
-    EXPECTED: False (round not viable — coordinator should stop and
-    force final-write before starting another doomed round).
+    Post-Slice-3B.1 (self-tuning): the effective floor is
+    ``min(min_ttft_floor=45, max_per_round=30) = 30``. The clamped
+    per_round_timeout (30s) satisfies the effective floor (30s).
+    Round is viable.
 
-    This is the LOAD-BEARING insight: the default max_per_round_s=30s
-    is BELOW the empirical min_ttft_floor=45s, so the coordinator
-    will be more conservative about starting new rounds. This is the
-    INTENDED behavior — the alternative (start a 30s round and have
-    it murdered) is what Slice 3B is fixing.
+    Pre-Slice-3B.1 over-fire behavior is now structurally fixed —
+    when the operator's max_per_round_s is the dominant clamp, the
+    gate defers to it as the effective floor rather than firing on
+    the global min_ttft_floor that exceeds the operator's ceiling.
     """
     plan = plan_with_default_floor
     # per_round_timeout = clamp((600 - 10) / 10, 3, 30) = 30s
-    # is_next_round_viable: 30s >= 45s? False
-    assert plan.is_next_round_viable(remaining_s=600.0, remaining_rounds=10) is False
+    # effective_floor = min(45, 30) = 30s
+    # 30s >= 30s → viable
+    assert plan.is_next_round_viable(remaining_s=600.0, remaining_rounds=10) is True
 
 
 def test_spine_is_next_round_viable_true_with_few_rounds_left(


### PR DESCRIPTION
feat(governance): Slice 3B.1 — Self-tuning TTFT floor constraint

Closes the over-fire regression surfaced by Slice 3B soak
bt-2026-05-25-015301: the Layer 1 gate worked (no more stream
rupture) but fired on every round under ample budget because the
default ``max_per_round_s=30s`` is structurally below the global
``min_ttft_floor=45s``. With 328s of wall budget remaining, the
coordinator bailed after round 0 with
``tool_loop_starved_below_min_ttft_floor projected_per_round=30.00s
min_ttft_floor=45.00s`` — false-positive starvation that prevented
all real work.

## Root cause

``BudgetPlan.is_next_round_viable()`` checked
``per_round_timeout < min_ttft_floor_s``. But ``per_round_timeout``
returns ``min(max_per_round_s, fair_share)`` — when the operator's
configured ceiling (``max_per_round_s=30s``) is the dominant clamp,
the check fires regardless of how much budget remains. The 45s
global floor + the 30s legacy ceiling are mutually exclusive
configurations; the gate had no way to distinguish "ample budget
at ceiling" from "tight budget below floor".

## Fix — self-tuning effective floor

One-expression refinement to ``is_next_round_viable``:

  effective_floor = min(self.min_ttft_floor_s, self.max_per_round_s)
  if self.per_round_timeout(remaining, rounds) < effective_floor:
      return False

The floor is now capped at ``max_per_round_s``. If the operator's
ceiling is the dominant clamp, that ceiling IS the effective floor —
the global min_ttft_floor only matters when fair-share squeeze
pushes per_round_timeout below the operator's intentional ceiling.

## Behavior matrix (proven by spine tests)

  | Scenario              | budget | rounds | max | floor | gate fires? |
  |-----------------------|--------|--------|-----|-------|-------------|
  | Ample @ legacy max    |  328s  |   9    | 30  |  45   | NO (3B.1)   |
  | Ample @ bumped max    |  600s  |  10    | 60  |  45   | NO          |
  | Tight @ legacy max    |   30s  |  10    | 30  |  45   | YES         |
  | Original 3B soak cond | 61.6s  |  10    | 30  |  45   | YES         |
  | Legacy min_per_round  |   20s  |  10    | 30  |  45*  | YES (cond1) |

## Operator binding honored

  * **No hardcoding** — both min_ttft_floor_s + max_per_round_s
    remain env-tunable; the gate auto-adapts to whatever combination
    the operator sets.
  * **Self-tuning** — no new env var, no compile-time constant; the
    effective floor is derived per-plan from the operator's
    configuration.
  * **Defense-in-depth preserved** — Layer 2 (stream consumer clamp)
    still references the raw min_ttft_floor (not the effective
    floor) so the stream-side defense is unchanged. Layer 1's
    adaptive behavior + Layer 2's static safety net compose
    cleanly.
  * **Single-line invariant change** — entire fix is one expression
    + one extra constant lookup. Zero new state.
  * **No regression of Slice 3B win** — genuine starvation
    (fair_share < effective_floor) still gates correctly. Proven
    by ``test_spine_soak_starvation_at_5s_still_caught``.

## Test surface (1 AST pin + 5 spine, all green; +1 prior 3B test refit)

AST pin: ``is_next_round_viable`` body references BOTH
``min_ttft_floor_s`` AND ``max_per_round_s`` (proves the
self-tuning expression is composed).

Spine:
  * Ample budget at legacy max=30 ceiling → viable (the regression
    fix — was False pre-3B.1, now True)
  * Tight budget below ceiling → still starves (3B win preserved)
  * Operator-bumped ceiling above floor → viable
  * Original soak's 5s/round condition → still starves
  * Legacy min_per_round condition 1 → still gates

Refit: one prior Slice 3B spine test (``test_spine_is_next_round_viable_true_with_ample_budget``)
was asserting the pre-3B.1 over-fire behavior was "correct";
updated to assert the post-3B.1 self-tuning behavior with comment
explaining the regression-fix.

Surrounding regression: 86 tests across slice 3A + 3B + 2B-ii.x +
Aegis AST pins, all green.

2 files changed, ~190 insertions(+), 10 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the TTFT floor self-tuning to the operator’s ceiling so the round-viability gate stops over-firing under ample budget. Prevents the Slice 3B soak regression while keeping genuine starvation checks intact.

- **Bug Fixes**
  - In `BudgetPlan.is_next_round_viable`, compare `per_round_timeout` against `effective_floor = min(min_ttft_floor_s, max_per_round_s)` to avoid false starvation when `max_per_round_s < min_ttft_floor_s`.
  - No new config: operator settings are honored; Layer 2 continues to use the raw `min_ttft_floor_s`.
  - Tests: added AST pin to ensure both vars are used, five spine tests covering ample/tight budget scenarios, and updated one prior test to the new expected behavior.

<sup>Written for commit 9519f1eb8290255424c1aa72c74eef11944c206e. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/56761?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

