### PR TITLE
fix(oracle): Teardown-coherence — bound Oracle.shutdown so BoundedShutdownWatchdog can fire

### DIFF
--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -1615,6 +1615,45 @@ class OracleSemanticIndex:
 
 
 # =============================================================================
+# Teardown-coherence — Oracle shutdown deadline knob
+# =============================================================================
+#
+# bt-2026-05-25-020602 wedged in ``Shutting down The Oracle...`` because a
+# 1.1GB ``codebase_graph.pkl`` serialization held the Python GIL + the
+# process I/O slot in uninterruptible kernel state past the
+# ``BoundedShutdownWatchdog`` 30s window. With every Python thread starved
+# (incl. the watchdog daemon thread), ``os._exit(75)`` could not be
+# scheduled — the only OS-level escape from uninterruptible I/O is the I/O
+# completing or kernel timeout. Preventive fix: bound the cache save.
+#
+# Defaults to 5s — enough for graphs up to ~50K nodes on local SSD with
+# room for jitter; abandon on bigger payloads (cache rebuilds on next
+# boot from index; abandoned save is slower start, NOT correctness loss).
+
+_ORACLE_SHUTDOWN_DEADLINE_ENV = "JARVIS_ORACLE_SHUTDOWN_DEADLINE_S"
+_ORACLE_SHUTDOWN_DEADLINE_DEFAULT_S = 5.0
+
+
+def _oracle_shutdown_deadline_s() -> float:
+    """``JARVIS_ORACLE_SHUTDOWN_DEADLINE_S`` — bound on shutdown cache save.
+
+    Default 5s. Set to ``0`` to skip ``_save_cache`` entirely on shutdown.
+    Set higher than 5s only if the graph genuinely needs more time AND
+    the deployment can tolerate longer teardown — the
+    ``BoundedShutdownWatchdog`` default deadline is 30s, so values above
+    ~25s leave little margin for other teardown steps.
+    """
+    raw = os.environ.get(
+        _ORACLE_SHUTDOWN_DEADLINE_ENV,
+        str(_ORACLE_SHUTDOWN_DEADLINE_DEFAULT_S),
+    )
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return _ORACLE_SHUTDOWN_DEADLINE_DEFAULT_S
+
+
+# =============================================================================
 # THE ORACLE - MAIN INDEXER
 # =============================================================================
 
@@ -1808,9 +1847,48 @@ class TheOracle:
         return True
 
     async def shutdown(self) -> None:
-        """Shutdown the Oracle, saving cache."""
+        """Shutdown the Oracle, saving cache (bounded).
+
+        Teardown-coherence (2026-05-24) — closes bt-2026-05-25-020602
+        wedge: a 1.1GB ``codebase_graph.pkl`` synchronous serialization
+        held the Python GIL + the process's I/O slot in uninterruptible
+        kernel state past the ``BoundedShutdownWatchdog`` 30s window,
+        so ``os._exit(75)`` could not be scheduled. Two-layer defense:
+
+        * Layer 1 (``_save_cache`` lifted to ``asyncio.to_thread``)
+          releases the event loop + lets the watchdog daemon thread run.
+        * Layer 2 (this ``asyncio.wait_for``) bounds the cache-save
+          regardless — if the traversal still holds the GIL past
+          the deadline, the asyncio side abandons and returns control
+          so the harness teardown chain completes within the
+          ``BoundedShutdownWatchdog`` budget.
+
+        The graph cache is rebuildable on next boot from index. An
+        abandoned save means slower cold start, NOT correctness loss.
+        Master knob: ``JARVIS_ORACLE_SHUTDOWN_DEADLINE_S`` (default 5s).
+        Set to ``0`` to skip ``_save_cache`` entirely on shutdown.
+        """
         logger.info("Shutting down The Oracle...")
-        await self._save_cache()
+        deadline_s = _oracle_shutdown_deadline_s()
+        if deadline_s <= 0.0:
+            logger.info(
+                "[Oracle.shutdown] cache-save SKIPPED — "
+                "JARVIS_ORACLE_SHUTDOWN_DEADLINE_S=%.2f", deadline_s,
+            )
+        else:
+            try:
+                await asyncio.wait_for(
+                    self._save_cache(), timeout=deadline_s,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[Oracle.shutdown] _save_cache exceeded %.2fs "
+                    "deadline — abandoning save (cache rebuilds on "
+                    "next boot). Set JARVIS_ORACLE_SHUTDOWN_DEADLINE_S "
+                    "higher if your graph genuinely needs more time, "
+                    "or =0 to skip saves on shutdown entirely.",
+                    deadline_s,
+                )
         self._running = False
         logger.info("The Oracle shutdown complete")
 
@@ -2220,62 +2298,94 @@ class TheOracle:
         return False
 
     async def _save_cache(self) -> None:
-        """Save graph to cache on disk.
+        """Save graph to cache on disk (event-loop-safe).
 
-        Serializes synchronously to avoid concurrent heap allocation
-        with C extensions (same rationale as _load_cache).
+        Builds the data dict on the asyncio thread (cheap reference
+        copies), then dispatches the heavy work — pickle serialization +
+        ``write_bytes`` + ``os.replace`` — to ``asyncio.to_thread``.
+
+        Why ``to_thread`` matters for teardown coherence
+        (bt-2026-05-25-020602): doing the serialization on the asyncio
+        thread held the Python GIL + the process I/O slot in
+        uninterruptible kernel state for the full duration of a 1.1GB
+        cache write. Every other Python thread — including the
+        ``BoundedShutdownWatchdog`` daemon thread — was starved. The
+        watchdog's ``os._exit(75)`` could not be scheduled because the
+        kernel can't deliver a syscall to a thread that isn't running.
+
+        Lifting to ``to_thread`` lets the asyncio thread + watchdog
+        thread make progress while the worker thread does the I/O.
+        Combined with the ``asyncio.wait_for`` bound in ``shutdown``,
+        even a worker thread that stays in kernel I/O past the deadline
+        cannot block the harness exit chain.
+
         Uses highest available protocol for better ARM64 alignment.
 
-        Note: pickle is used here for internal cache only — the graph
-        contains only our own dataclasses, not untrusted data.
+        Note: ``pickle`` is used here for internal cache only — the
+        graph contains only our own dataclasses, not untrusted data.
 
-        Iron Gate compliance: writes to ``~/.jarvis/oracle/`` may be blocked
-        by the sandbox; ``sandbox_fallback`` routes to
-        ``.ouroboros/state/sandbox_fallback/oracle/`` without lowering shields.
+        Iron Gate compliance: writes to ``~/.jarvis/oracle/`` may be
+        blocked by the sandbox; ``sandbox_fallback`` routes to
+        ``.ouroboros/state/sandbox_fallback/oracle/`` without lowering
+        shields.
         """
-        _tmp_name: Optional[str] = None
+        # Snapshot the data dict on the asyncio thread. These are cheap
+        # reference copies — heavy work is the serialization below.
+        data = {
+            "graph": self._graph._graph,
+            "node_index": self._graph._node_index,
+            "file_index": dict(self._graph._file_index),
+            "repo_index": dict(self._graph._repo_index),
+            "type_index": dict(self._graph._type_index),
+            "metrics": self._graph._metrics,
+            "file_hashes": self._file_hashes,
+        }
+        _final_cache_path = self._resolved_graph_cache_path()
         try:
-            data = {
-                "graph": self._graph._graph,
-                "node_index": self._graph._node_index,
-                "file_index": dict(self._graph._file_index),
-                "repo_index": dict(self._graph._repo_index),
-                "type_index": dict(self._graph._type_index),
-                "metrics": self._graph._metrics,
-                "file_hashes": self._file_hashes,
-            }
-
-            _final_cache_path = self._resolved_graph_cache_path()
-            _final_cache_path.parent.mkdir(parents=True, exist_ok=True)
-            # Arc B.1 — atomic durability. Serialize into a temp file in
-            # the SAME directory, then os.replace (POSIX-atomic rename)
-            # so a crash / SIGKILL / ProcessMemoryWatchdog os._exit
-            # mid-write can NEVER leave a torn cache (the
-            # bt-2026-05-18-062703 'invalid load key \\x00' that
-            # defeated checkpoint durability + blocked graduation #6).
-            # Mirrors dw_heavy_probe._atomic_write / dataset_loader.
-            import tempfile as _tempfile
-            _tmp_fd, _tmp_name = _tempfile.mkstemp(
-                prefix=_final_cache_path.name + ".",
-                suffix=".tmp",
-                dir=str(_final_cache_path.parent),
+            await asyncio.to_thread(
+                self._write_cache_blocking, data, _final_cache_path,
             )
-            os.close(_tmp_fd)
+        except Exception as e:  # noqa: BLE001 — never raise from save
+            logger.error(f"Error saving cache: {e}")
+
+    @staticmethod
+    def _write_cache_blocking(
+        data: Dict[str, Any], _final_cache_path: Path,
+    ) -> None:
+        """Synchronous serialization + atomic write — runs in a worker
+        thread so the asyncio event loop + the
+        ``BoundedShutdownWatchdog`` daemon thread can make progress.
+
+        Arc B.1 — atomic durability. Serialize into a temp file in the
+        SAME directory, then ``os.replace`` (POSIX-atomic rename) so a
+        crash / SIGKILL / ProcessMemoryWatchdog ``os._exit`` mid-write
+        can NEVER leave a torn cache (the bt-2026-05-18-062703
+        'invalid load key \\x00' that defeated checkpoint durability +
+        blocked graduation #6). Mirrors
+        ``dw_heavy_probe._atomic_write`` / ``dataset_loader``.
+        """
+        _final_cache_path.parent.mkdir(parents=True, exist_ok=True)
+        import tempfile as _tempfile
+        _tmp_fd, _tmp_name = _tempfile.mkstemp(
+            prefix=_final_cache_path.name + ".",
+            suffix=".tmp",
+            dir=str(_final_cache_path.parent),
+        )
+        os.close(_tmp_fd)
+        try:
             cache_path = Path(_tmp_name)
             cache_path.write_bytes(
                 pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL),  # noqa: S301
             )
-
             os.replace(_tmp_name, str(_final_cache_path))
             _tmp_name = None  # promoted — nothing left to clean up
             logger.info(f"Saved cache to {_final_cache_path}")
-        except Exception as e:
+        finally:
             if _tmp_name is not None:
                 try:
                     os.unlink(_tmp_name)
                 except OSError:
                     pass
-            logger.error(f"Error saving cache: {e}")
 
     # =========================================================================
     # QUERY INTERFACE

--- a/tests/governance/test_oracle_shutdown_teardown_coherence.py
+++ b/tests/governance/test_oracle_shutdown_teardown_coherence.py
@@ -1,0 +1,246 @@
+"""Oracle shutdown teardown-coherence — bounded ``_save_cache``.
+
+Closes bt-2026-05-25-020602: a 1.1GB ``codebase_graph.pkl`` synchronous
+serialization in ``Oracle._save_cache`` held the Python GIL + the
+process I/O slot in uninterruptible kernel state past the
+``BoundedShutdownWatchdog`` 30s window, so ``os._exit(75)`` could not
+be scheduled. Two-layer preventive defense:
+
+* Layer 1 — ``_save_cache`` lifts the heavy work to ``asyncio.to_thread``
+  so the asyncio event loop AND the watchdog daemon thread can keep
+  running while a worker thread does the I/O.
+* Layer 2 — ``shutdown()`` wraps ``self._save_cache()`` in
+  ``asyncio.wait_for(timeout=JARVIS_ORACLE_SHUTDOWN_DEADLINE_S)`` so
+  even if the worker thread stays in kernel I/O past the deadline, the
+  asyncio side abandons and returns control to the harness teardown
+  chain within the watchdog's budget.
+
+Why preventive defense is the right shape (not just a bigger watchdog
+deadline): on uninterruptible kernel I/O macOS does not deliver any
+syscall to the waiting thread — including ``os._exit``. The ONLY ways
+out are I/O completion or kernel timeout. So the structural fix MUST
+prevent shutdown from entering long uninterruptible I/O in the first
+place.
+
+The graph cache is rebuildable on next boot from index. An abandoned
+save means slower cold start, NOT correctness loss.
+
+Test surface: 3 AST pins + 6 spine tests.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ORACLE_FILE = REPO_ROOT / "backend" / "core" / "ouroboros" / "oracle.py"
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_shutdown_wraps_save_cache_in_wait_for() -> None:
+    """``TheOracle.shutdown`` body must reference ``asyncio.wait_for``
+    AND ``_save_cache`` — proves Layer 2 bound is composed."""
+    tree = _parse(ORACLE_FILE)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != "TheOracle":
+            continue
+        for sub in node.body:
+            if not isinstance(sub, ast.AsyncFunctionDef):
+                continue
+            if sub.name != "shutdown":
+                continue
+            body_src = ast.unparse(sub)
+            assert "asyncio.wait_for" in body_src, (
+                "TheOracle.shutdown body does not call asyncio.wait_for "
+                "— Layer 2 bound missing. The bt-2026-05-25-020602 wedge "
+                "trap is open again."
+            )
+            assert "_save_cache" in body_src, (
+                "TheOracle.shutdown body does not reference _save_cache "
+                "— Layer 2 bound not wrapping the right call."
+            )
+            assert "_oracle_shutdown_deadline_s" in body_src, (
+                "TheOracle.shutdown does not consume the env-tunable "
+                "deadline helper — hardcoded timeouts forbidden."
+            )
+            return
+    pytest.fail("TheOracle.shutdown not found")
+
+
+def test_ast_pin_save_cache_uses_to_thread() -> None:
+    """``TheOracle._save_cache`` body must reference ``asyncio.to_thread``
+    AND ``_write_cache_blocking`` — proves Layer 1 (lift to worker
+    thread) is composed."""
+    tree = _parse(ORACLE_FILE)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != "TheOracle":
+            continue
+        for sub in node.body:
+            if not isinstance(sub, ast.AsyncFunctionDef):
+                continue
+            if sub.name != "_save_cache":
+                continue
+            body_src = ast.unparse(sub)
+            assert "asyncio.to_thread" in body_src, (
+                "TheOracle._save_cache body does not dispatch via "
+                "asyncio.to_thread — Layer 1 lift missing. The GIL + "
+                "I/O slot will starve the BoundedShutdownWatchdog."
+            )
+            assert "_write_cache_blocking" in body_src, (
+                "TheOracle._save_cache does not call "
+                "_write_cache_blocking — Layer 1 worker entry-point "
+                "is the contract."
+            )
+            return
+    pytest.fail("TheOracle._save_cache not found")
+
+
+def test_ast_pin_write_cache_blocking_preserves_atomic_durability() -> None:
+    """``TheOracle._write_cache_blocking`` body must still use a temp
+    file + ``os.replace`` — the Arc B.1 atomic-durability invariant
+    survives the to_thread lift. Mirrors original bt-2026-05-18-062703
+    'invalid load key' regression protection."""
+    tree = _parse(ORACLE_FILE)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != "TheOracle":
+            continue
+        for sub in node.body:
+            if not isinstance(sub, ast.FunctionDef):
+                continue
+            if sub.name != "_write_cache_blocking":
+                continue
+            body_src = ast.unparse(sub)
+            assert "mkstemp" in body_src, (
+                "_write_cache_blocking must serialize into a temp file "
+                "(Arc B.1 atomic durability)."
+            )
+            assert "os.replace" in body_src, (
+                "_write_cache_blocking must promote via os.replace "
+                "(POSIX-atomic rename) — direct write_bytes to final "
+                "path can leave a torn cache on crash."
+            )
+            return
+    pytest.fail("TheOracle._write_cache_blocking not found")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 6
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_default_deadline_is_five_seconds() -> None:
+    """Default deadline is 5s — sized for graphs up to ~50K nodes on
+    local SSD with room for jitter."""
+    from backend.core.ouroboros.oracle import (
+        _oracle_shutdown_deadline_s,
+        _ORACLE_SHUTDOWN_DEADLINE_DEFAULT_S,
+    )
+    # Clear env to default
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("JARVIS_ORACLE_SHUTDOWN_DEADLINE_S", None)
+        assert _oracle_shutdown_deadline_s() == 5.0
+    assert _ORACLE_SHUTDOWN_DEADLINE_DEFAULT_S == 5.0
+
+
+def test_spine_env_override_honored() -> None:
+    """Operator can tune the deadline via env."""
+    from backend.core.ouroboros.oracle import _oracle_shutdown_deadline_s
+    with patch.dict(
+        os.environ,
+        {"JARVIS_ORACLE_SHUTDOWN_DEADLINE_S": "12.5"},
+    ):
+        assert _oracle_shutdown_deadline_s() == 12.5
+
+
+def test_spine_env_zero_skips_save() -> None:
+    """``=0`` is the explicit-skip configuration. Returns 0.0 from the
+    helper; ``shutdown`` reads that and skips ``_save_cache`` entirely."""
+    from backend.core.ouroboros.oracle import _oracle_shutdown_deadline_s
+    with patch.dict(
+        os.environ,
+        {"JARVIS_ORACLE_SHUTDOWN_DEADLINE_S": "0"},
+    ):
+        assert _oracle_shutdown_deadline_s() == 0.0
+
+
+def test_spine_env_bad_value_falls_back_to_default() -> None:
+    """Malformed env value falls back to the 5s default (no crash)."""
+    from backend.core.ouroboros.oracle import _oracle_shutdown_deadline_s
+    with patch.dict(
+        os.environ,
+        {"JARVIS_ORACLE_SHUTDOWN_DEADLINE_S": "not-a-number"},
+    ):
+        assert _oracle_shutdown_deadline_s() == 5.0
+
+
+def test_spine_shutdown_timeout_abandons_save_gracefully() -> None:
+    """If ``_save_cache`` exceeds the deadline, shutdown logs + returns
+    cleanly — the harness teardown chain MUST move on within the
+    BoundedShutdownWatchdog budget. This is THE regression test for
+    bt-2026-05-25-020602."""
+    from backend.core.ouroboros import oracle as oracle_mod
+
+    class _FakeOracle:
+        """Minimal stand-in — calls the real ``shutdown`` method but
+        with a ``_save_cache`` that never returns."""
+        _running = True
+
+        async def _save_cache(self) -> None:
+            await asyncio.sleep(60.0)  # vastly exceeds 0.05s deadline
+
+        shutdown = oracle_mod.TheOracle.shutdown
+
+    fake = _FakeOracle()
+    with patch.dict(
+        os.environ,
+        {"JARVIS_ORACLE_SHUTDOWN_DEADLINE_S": "0.05"},
+    ):
+        # Should NOT raise, should NOT hang
+        asyncio.run(
+            asyncio.wait_for(fake.shutdown(), timeout=2.0),
+        )
+    # _running must be cleared regardless of save outcome
+    assert fake._running is False
+
+
+def test_spine_shutdown_zero_deadline_skips_save_entirely() -> None:
+    """``JARVIS_ORACLE_SHUTDOWN_DEADLINE_S=0`` is the explicit-skip
+    configuration — ``_save_cache`` is NOT called. Use this in
+    deployments where shutdown speed dominates cache-warm trade-off."""
+    from backend.core.ouroboros import oracle as oracle_mod
+
+    save_calls: list[int] = []
+
+    class _FakeOracle:
+        _running = True
+
+        async def _save_cache(self) -> None:
+            save_calls.append(1)
+
+        shutdown = oracle_mod.TheOracle.shutdown
+
+    fake = _FakeOracle()
+    with patch.dict(
+        os.environ,
+        {"JARVIS_ORACLE_SHUTDOWN_DEADLINE_S": "0"},
+    ):
+        asyncio.run(fake.shutdown())
+    assert save_calls == [], (
+        "_save_cache was called despite deadline=0 — skip configuration "
+        "broken."
+    )
+    assert fake._running is False


### PR DESCRIPTION
fix(oracle): Teardown-coherence — bound Oracle.shutdown so the BoundedShutdownWatchdog can fire

Closes bt-2026-05-25-020602 wedge: a 1.1GB ``codebase_graph.pkl``
synchronous serialization in ``Oracle._save_cache`` held the Python
GIL + the process I/O slot in uninterruptible kernel state past the
``BoundedShutdownWatchdog`` 30s window. With every Python thread
starved (including the watchdog daemon thread), ``os._exit(75)``
could not be scheduled — the only OS-level escape from uninterruptible
kernel I/O is the I/O completing or a kernel timeout.

The watchdog cannot fix this in isolation. It is a daemon thread that
calls ``os._exit`` after sleeping ``deadline_s``. If the OS cannot
schedule that thread (because every CPU slot is held by GIL-holding
work or the process is in STAT=U disk I/O), the ``os._exit`` call
sits queued behind syscalls the kernel will not preempt. The
structural fix MUST prevent ``Oracle.shutdown`` from entering long
uninterruptible I/O in the first place.

## Two-layer preventive defense

### Layer 1 — ``_save_cache`` lifted to ``asyncio.to_thread``

The synchronous serialization + ``write_bytes`` + ``os.replace`` chain
is moved into a new ``_write_cache_blocking`` static helper invoked via
``asyncio.to_thread``. This releases the asyncio event loop AND lets
the ``BoundedShutdownWatchdog`` daemon thread make progress while a
worker thread does the I/O.

Arc B.1 atomic-durability invariant preserved verbatim: temp-file
serialization + ``os.replace`` POSIX-atomic rename. Cleanup of the
temp file on exception remains in a ``finally`` block (the
bt-2026-05-18-062703 'invalid load key' regression protection holds).

### Layer 2 — ``shutdown`` wraps ``_save_cache`` in ``asyncio.wait_for``

New helper ``_oracle_shutdown_deadline_s()`` reads
``JARVIS_ORACLE_SHUTDOWN_DEADLINE_S`` (default 5s). ``shutdown()``
wraps ``self._save_cache()`` in ``asyncio.wait_for(timeout=deadline)``.

If the worker thread stays in kernel I/O past the deadline, the
asyncio side abandons and returns control to the harness teardown
chain within the ``BoundedShutdownWatchdog`` budget. The worker
thread is still alive doing I/O, but it is no longer blocking the
exit path.

``=0`` is the explicit-skip configuration — ``_save_cache`` is not
called at all on shutdown. Useful in deployments where shutdown
speed dominates the cache-warm trade-off.

## Operator bindings honored

* **No hardcoding** — deadline is env-tunable
  (``JARVIS_ORACLE_SHUTDOWN_DEADLINE_S=5.0``).
* **Build on existing** — composes the existing
  ``BoundedShutdownWatchdog`` 30s deadline (5s < 30s gives ~25s
  margin for downstream teardown). No new watchdog substrate, no
  new shutdown surface, no new env knob for the lift itself.
* **Defense-in-depth** — Layers 1 and 2 are INDEPENDENT. If Layer 1
  is bypassed by a future refactor that re-inlines the I/O, Layer 2
  still bounds the await. If Layer 2 is disabled by operator
  (``=0``), Layer 1 still releases the GIL during the I/O.
* **No silent failure** — Layer 2 timeout logs at WARNING with the
  deadline value, the skip configuration, and the rationale
  (cache rebuilds on next boot). Operator forensics can correlate
  to the exact teardown step that abandoned.
* **No correctness loss** — the graph cache is rebuildable on next
  boot from index. An abandoned save means a slower cold start,
  NOT incorrect state.
* **AST-pinned** — three pins prove (1) ``shutdown`` body composes
  ``asyncio.wait_for`` + ``_save_cache`` + the env helper,
  (2) ``_save_cache`` body composes ``asyncio.to_thread`` +
  ``_write_cache_blocking``, (3) ``_write_cache_blocking`` body
  preserves the Arc B.1 atomic-durability invariant (mkstemp +
  os.replace).

## What this fix does NOT do

* No changes to ``BoundedShutdownWatchdog`` itself — its semantics
  are correct; the problem was downstream code denying it CPU.
* No changes to ``_load_cache`` — boot-time cache load runs before
  the harness arms its deadline; long boots are a different concern
  and have their own watchdog (``OracleReadiness`` / startup gate).
* No changes to engine.py teardown wrapper — Layer 2 inside
  ``shutdown`` is sufficient; an additional ``wait_for`` at the
  engine layer would be defense-in-depth-of-defense-in-depth without
  a concrete failure mode to defend against.

## Test surface (3 AST pins + 6 spine, all green)

AST pins (3):
  1. ``TheOracle.shutdown`` body references ``asyncio.wait_for`` +
     ``_save_cache`` + ``_oracle_shutdown_deadline_s``
  2. ``TheOracle._save_cache`` body references ``asyncio.to_thread`` +
     ``_write_cache_blocking``
  3. ``TheOracle._write_cache_blocking`` body preserves ``mkstemp`` +
     ``os.replace`` (Arc B.1 atomicity)

Spine (6):
  * Default deadline is 5.0s
  * Env override honored (12.5s)
  * ``=0`` returns 0.0 (explicit skip)
  * Malformed value falls back to 5.0s
  * Long-running ``_save_cache`` (60s) abandoned in 0.05s deadline,
    ``shutdown`` returns cleanly, ``_running`` cleared — THE
    bt-2026-05-25-020602 regression test
  * ``=0`` skip path does NOT call ``_save_cache`` at all

Surrounding regression: 28 tests (9 new + 19 in Slice 3B + 3B.1
suites) green. Two pre-existing failures in adjacent Oracle test
files are unrelated to this fix (reproduced on main pre-edit).

2 files changed, ~190 insertions(+), ~25 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound `TheOracle.shutdown` to prevent teardown stalls during large cache saves. Fixes bt-2026-05-25-020602 so `BoundedShutdownWatchdog` can exit cleanly.

- **Bug Fixes**
  - Moved cache serialization and atomic write to `asyncio.to_thread` via `_write_cache_blocking` (keeps the event loop and `BoundedShutdownWatchdog` schedulable).
  - Wrapped `_save_cache()` in `asyncio.wait_for` with `JARVIS_ORACLE_SHUTDOWN_DEADLINE_S` (default 5s); `0` skips saving on shutdown.
  - Preserved atomic durability: temp file + `os.replace`; cache format unchanged.
  - Added tests for AST pins and timeout behavior, including the bt-2026-05-25-020602 regression.

- **Migration**
  - No action required. Optionally tune `JARVIS_ORACLE_SHUTDOWN_DEADLINE_S` if your cache needs more than 5s, or set `0` to skip saves on shutdown.

<sup>Written for commit 450aaf52aa32ef192db21dfee57ebbadd8fa14a0. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/56884?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

