### PR TITLE
feat(governance): Slice 3C — Tool-record propagation across outer-retry attempts

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4324,6 +4324,21 @@ class CandidateGenerator:
                 else:
                     _outer_max = _FALLBACK_OUTER_RETRY_MAX
                 _last_inner_exc: Optional[BaseException] = None
+                # ── Slice 3C — outer-retry tool-record carryover ──
+                # Iron Gate (post-GENERATE) inspects
+                # ``GenerationResult.tool_execution_records`` to verify the
+                # model met the exploration floor. Each provider attempt
+                # carries only its OWN tool calls (the coordinator resets
+                # ``_last_records`` at run start). If attempt N raises after
+                # genuine exploration but attempt N+1 succeeds with NO tool
+                # calls (the bt-2026-05-25-033000 cascade — direct patch
+                # emit after retries), Iron Gate sees 0 records and rejects
+                # even though the model explored the codebase across
+                # attempts. Accumulator harvests records from each failed
+                # attempt's exception (Slice-3C-stamped via
+                # ``_attach_tool_records`` in tool_executor) and merges
+                # into the winning attempt's GenerationResult below.
+                _carryover_tool_records: List[Any] = []
                 while True:
                     _outer_attempt += 1
                     _attempt_t0 = time.monotonic()
@@ -4370,12 +4385,73 @@ class CandidateGenerator:
                             _phase_hint,
                             getattr(context, "op_id", "?")[:16],
                         )
+                        # Slice 3C — merge carryover records into the
+                        # winning attempt's GenerationResult so Iron Gate
+                        # sees the cumulative exploration across attempts.
+                        # No-op when carryover is empty (single-attempt
+                        # success path) — byte-identical legacy behavior.
+                        if _carryover_tool_records:
+                            try:
+                                _winning_records = tuple(
+                                    getattr(
+                                        _fb_result,
+                                        "tool_execution_records",
+                                        (),
+                                    ) or ()
+                                )
+                                _merged = (
+                                    tuple(_carryover_tool_records)
+                                    + _winning_records
+                                )
+                                _with_tool_records = getattr(
+                                    _fb_result, "with_tool_records", None,
+                                )
+                                if callable(_with_tool_records):
+                                    _fb_result = _with_tool_records(_merged)
+                                    logger.info(
+                                        "[CandidateGenerator] Slice 3C: "
+                                        "merged %d carryover tool records "
+                                        "from %d failed attempt(s) into "
+                                        "winning GenerationResult "
+                                        "(winning=%d, total=%d) op=%s",
+                                        len(_carryover_tool_records),
+                                        _outer_attempt - 1,
+                                        len(_winning_records),
+                                        len(_merged),
+                                        getattr(
+                                            context, "op_id", "?",
+                                        )[:16],
+                                    )
+                            except Exception:  # noqa: BLE001 — defensive
+                                # Carryover merge must NEVER break a
+                                # successful generate. Log + fall through
+                                # with the unmerged result.
+                                logger.exception(
+                                    "[CandidateGenerator] Slice 3C "
+                                    "carryover merge degraded — returning "
+                                    "winning-attempt GenerationResult "
+                                    "unmodified for op=%s",
+                                    getattr(context, "op_id", "?")[:16],
+                                )
                         return _fb_result
                     except _OperationCancelledError:
                         # W3(7) cooperative cancel — operator/watchdog/signal.
                         # NEVER retry; honor the cancel immediately.
                         raise
                     except (Exception, asyncio.CancelledError) as inner_exc:
+                        # Slice 3C — harvest tool-records from the failed
+                        # attempt BEFORE any other handling. Best-effort:
+                        # if the exception didn't carry records (legacy
+                        # provider, untagged path), getattr returns (),
+                        # extend is a no-op, behavior matches pre-Slice-3C.
+                        try:
+                            _harvested = getattr(
+                                inner_exc, "tool_execution_records", (),
+                            ) or ()
+                            if _harvested:
+                                _carryover_tool_records.extend(_harvested)
+                        except Exception:  # noqa: BLE001 — never block retry
+                            pass
                         # Pre-instrumented (e.g. fallback_budget_starved
                         # from a different code path) → propagate as-is.
                         if hasattr(inner_exc, "exhaustion_report"):

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -194,6 +194,57 @@ def _compute_args_hash(arguments: Dict[str, Any]) -> str:
     return hashlib.sha256(normalized.encode()).hexdigest()
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Slice 3C — tool-record propagation via exception attachment
+# ──────────────────────────────────────────────────────────────────────
+#
+# Closes bt-2026-05-25-033000: Iron Gate counter saw 0 tool calls despite
+# ToolLoopCoordinator accumulating 19 records across 10 rounds. Root: the
+# provider's outer-retry mechanism (candidate_generator) runs the tool
+# loop 1..N times per orchestrator generation. Each FAILED attempt's
+# records (held in ``coordinator._last_records``) were silently dropped
+# because the exception that propagated up didn't carry them — and the
+# next attempt resets ``_last_records`` at run start. The successful
+# attempt's records were the only ones reaching ``GenerationResult``;
+# when the successful attempt skipped tools (e.g. emitted a direct patch),
+# Iron Gate saw 0/2 even though earlier attempts had explored exhaustively.
+#
+# Fix mechanism: every failure-path ``raise`` inside ``ToolLoopCoordinator.
+# run()`` stamps the current ``records`` list onto the exception via
+# ``_attach_tool_records``. The orchestrator already harvests this
+# attribute (orchestrator.py:5135, predates this slice); the candidate
+# generator's outer-retry loop is updated in the same slice to accumulate
+# across attempts so the final ``GenerationResult`` carries every tool
+# call the model made for the op, not just the records from the winning
+# attempt.
+#
+# Why exception attachment vs context-field accumulator: exceptions are
+# the data flow path that was ALREADY in use for failure propagation; a
+# parallel ``ctx.cumulative_tool_records`` field would duplicate the
+# transport. Operator binding "pass data cleanly via context/results" —
+# the exception IS the result on failure paths.
+
+
+def _attach_tool_records(
+    exc: BaseException, records: Any,
+) -> BaseException:
+    """Stamp ``tool_execution_records`` onto an exception so outer-retry
+    callers can harvest the partial-run records. Returns the same exception
+    so the call composes inline with ``raise``.
+
+    Never raises — attribute assignment to built-in exception subclasses
+    is well-defined on Python 3.9+, but the try/except guard keeps the
+    contract that this helper is safe on the re-raise path under any
+    custom exception subclass.
+    """
+    try:
+        # Use tuple — immutable + matches the GenerationResult field type.
+        exc.tool_execution_records = tuple(records)  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 — never break a re-raise
+        pass
+    return exc
+
+
 # ---------------------------------------------------------------------------
 # L1 Tool-Use: Protocols (B-ready seams)
 # ---------------------------------------------------------------------------
@@ -5231,7 +5282,11 @@ class ToolLoopCoordinator:
         returning a stale tool-call JSON as the "final answer".
         """
         if time.monotonic() >= deadline:
-            raise RuntimeError("tool_loop_deadline_exceeded")
+            # Pre-loop deadline check — no records to attach yet, but stamp
+            # an empty tuple to honor the Slice 3C contract uniformly.
+            raise _attach_tool_records(
+                RuntimeError("tool_loop_deadline_exceeded"), (),
+            )
 
         # ── Structural budget plan ──
         # Built once per run() so all timing decisions are derived from
@@ -5286,7 +5341,10 @@ class ToolLoopCoordinator:
                 )
                 self._last_records = list(records)
                 self._finalize_run(op_id)
-                raise RuntimeError("tool_loop_max_rounds_exceeded")
+                # Slice 3C — propagate accumulated records to outer-retry.
+                raise _attach_tool_records(
+                    RuntimeError("tool_loop_max_rounds_exceeded"), records,
+                )
 
             # ── Pre-round hard-floor viability gate (Manifesto §3) ──
             # Round 0 always runs — the caller's refreshed fallback budget
@@ -5308,7 +5366,10 @@ class ToolLoopCoordinator:
                 if _remaining_pre <= 0:
                     self._last_records = list(records)
                     self._finalize_run(op_id)
-                    raise RuntimeError("tool_loop_deadline_exceeded")
+                    # Slice 3C — propagate accumulated records to outer-retry.
+                    raise _attach_tool_records(
+                        RuntimeError("tool_loop_deadline_exceeded"), records,
+                    )
                 if _remaining_pre < plan.min_per_round_s:
                     logger.warning(
                         "[ToolLoop] op=%s round=%d budget_starved "
@@ -5320,11 +5381,15 @@ class ToolLoopCoordinator:
                     )
                     self._last_records = list(records)
                     self._finalize_run(op_id)
-                    raise RuntimeError(
-                        "tool_loop_round_budget_starved:"
-                        f"round={round_index},"
-                        f"remaining={_remaining_pre:.2f}s,"
-                        f"min_per_round={plan.min_per_round_s:.2f}s"
+                    # Slice 3C — propagate accumulated records to outer-retry.
+                    raise _attach_tool_records(
+                        RuntimeError(
+                            "tool_loop_round_budget_starved:"
+                            f"round={round_index},"
+                            f"remaining={_remaining_pre:.2f}s,"
+                            f"min_per_round={plan.min_per_round_s:.2f}s"
+                        ),
+                        records,
                     )
                 # ── Slice 3B Layer 1 — MIN_TTFT_FLOOR viability gate ──
                 # Refuse to START a round whose per_round_timeout would
@@ -5361,12 +5426,18 @@ class ToolLoopCoordinator:
                     )
                     self._last_records = list(records)
                     self._finalize_run(op_id)
-                    raise RuntimeError(
-                        "tool_loop_starved_below_min_ttft_floor:"
-                        f"round={round_index},"
-                        f"remaining={_remaining_pre:.2f}s,"
-                        f"projected_per_round={_projected:.2f}s,"
-                        f"min_ttft_floor={plan.min_ttft_floor_s:.2f}s"
+                    # Slice 3C — propagate accumulated records to outer-retry
+                    # so Iron Gate sees every tool call across attempts, not
+                    # just the winning attempt (bt-2026-05-25-033000 root).
+                    raise _attach_tool_records(
+                        RuntimeError(
+                            "tool_loop_starved_below_min_ttft_floor:"
+                            f"round={round_index},"
+                            f"remaining={_remaining_pre:.2f}s,"
+                            f"projected_per_round={_projected:.2f}s,"
+                            f"min_ttft_floor={plan.min_ttft_floor_s:.2f}s"
+                        ),
+                        records,
                     )
 
             # Signal to provider: use lower max_tokens for tool rounds
@@ -5379,8 +5450,12 @@ class ToolLoopCoordinator:
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                self._last_records = list(records)
                 self._finalize_run(op_id)
-                raise RuntimeError("tool_loop_deadline_exceeded")
+                # Slice 3C — propagate accumulated records to outer-retry.
+                raise _attach_tool_records(
+                    RuntimeError("tool_loop_deadline_exceeded"), records,
+                )
 
             # ── Final-write reserve enforcement ──
             # If remaining budget is at or below the reserve, stop issuing
@@ -5544,7 +5619,7 @@ class ToolLoopCoordinator:
                     started_ns = time.time_ns()
                     try:
                         tool_result = await self._backend.execute_async(tc, p_ctx, per_tool_deadline)
-                    except asyncio.CancelledError:
+                    except asyncio.CancelledError as _cancel_exc:
                         ended_ns = time.time_ns()
                         records.append(ToolExecutionRecord(
                             schema_version="tool.exec.v1",
@@ -5569,6 +5644,9 @@ class ToolLoopCoordinator:
                         )
                         self._last_records = list(records)
                         self._finalize_run(op_id)
+                        # Slice 3C — preserve records on the cancellation
+                        # exception so outer-retry callers can harvest.
+                        _attach_tool_records(_cancel_exc, records)
                         raise
                     ended_ns = time.time_ns()
                     exec_results = [(tc, tool_result, c_id, t_ver, started_ns, ended_ns)]
@@ -5784,8 +5862,17 @@ class ToolLoopCoordinator:
                         len(prompt) + _keep + _overflow, len(current_prompt),
                     )
                 else:
+                    self._last_records = list(records)
                     self._finalize_run(op_id)
-                    raise RuntimeError(f"tool_loop_context_overflow:{len(current_prompt)}")
+                    # Slice 3C — propagate accumulated records to outer-retry
+                    # so context-overflow doesn't drop the model's prior
+                    # exploration history.
+                    raise _attach_tool_records(
+                        RuntimeError(
+                            f"tool_loop_context_overflow:{len(current_prompt)}"
+                        ),
+                        records,
+                    )
 
             # ── Upgrade 1 (PRD §31.2) per-round budget observer ──
             # Fires AFTER round body + compaction + force-truncate guard,

--- a/tests/governance/test_slice3c_tool_record_propagation.py
+++ b/tests/governance/test_slice3c_tool_record_propagation.py
@@ -1,0 +1,288 @@
+"""Slice 3C — tool-record propagation across outer-retry attempts.
+
+Closes bt-2026-05-25-033000: Iron Gate counter saw 0 tool calls despite
+``ToolLoopCoordinator`` accumulating 19 records across 10 rounds. Root:
+the candidate_generator outer-retry mechanism ran the tool loop multiple
+times per orchestrator generation. Each FAILED attempt's records were
+silently dropped because the exception that propagated up didn't carry
+them. The successful attempt's records (often zero — direct patch emit)
+were the only ones reaching ``GenerationResult.tool_execution_records``.
+
+# Fix mechanism (two-layer, composes existing protocol)
+
+* Layer 1 (``tool_executor.py::_attach_tool_records``): every failure-
+  path ``raise`` inside ``ToolLoopCoordinator.run()`` stamps the current
+  ``records`` list onto the exception via the helper. Mirrors the
+  pre-existing protocol consumed by orchestrator.py:5135.
+
+* Layer 2 (``candidate_generator.py`` outer-retry loop): accumulator
+  ``_carryover_tool_records`` harvests records from each failed
+  attempt's exception. On the winning attempt, merges accumulator +
+  winning records via ``GenerationResult.with_tool_records`` so Iron
+  Gate sees cumulative exploration across attempts.
+
+# Why exception-attachment vs ctx-field
+
+Exceptions were ALREADY the failure-path data transport (orchestrator.py
+already reads ``getattr(exc, 'tool_execution_records', ())``). A
+parallel ``ctx.cumulative_tool_records`` field would duplicate the
+transport. Operator binding "pass data cleanly via context/results" —
+the exception IS the result on failure paths.
+
+# Test surface (3 AST pins + 6 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_EXECUTOR_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance" / "tool_executor.py"
+)
+CANDIDATE_GENERATOR_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance" / "candidate_generator.py"
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_attach_tool_records_helper_exists() -> None:
+    """``_attach_tool_records`` must be a module-level function in
+    tool_executor — it's the contract surface every failure-path raise
+    composes through, and the symbol orchestrator.py + candidate_generator.py
+    coordinate on by name."""
+    tree = _parse(TOOL_EXECUTOR_FILE)
+    found = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_attach_tool_records":
+            found = True
+            # Must accept (exc, records) and return exc
+            args = [a.arg for a in node.args.args]
+            assert "exc" in args and "records" in args, (
+                f"_attach_tool_records signature must accept (exc, records); "
+                f"got {args}"
+            )
+            break
+    assert found, (
+        "_attach_tool_records helper missing from tool_executor.py — "
+        "Slice 3C contract broken. The bt-2026-05-25-033000 trap is open."
+    )
+
+
+def test_ast_pin_tool_loop_failure_raises_attach_records() -> None:
+    """Every ``raise RuntimeError(\"tool_loop_*\")`` inside
+    ``ToolLoopCoordinator.run()`` must compose ``_attach_tool_records``
+    so outer-retry callers can harvest the partial-run records.
+
+    Walks the AST of the ``run`` method, finds all ``raise`` statements
+    whose argument is a RuntimeError with a ``tool_loop_`` reason, and
+    requires each one to be wrapped in a call to ``_attach_tool_records``
+    (or for the RuntimeError construction itself to have records
+    stamped via a sibling assignment — both shapes are accepted).
+    """
+    tree = _parse(TOOL_EXECUTOR_FILE)
+    coordinator = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "ToolLoopCoordinator":
+            coordinator = node
+            break
+    assert coordinator is not None, "ToolLoopCoordinator class missing"
+
+    run_method = None
+    for sub in coordinator.body:
+        if isinstance(sub, ast.AsyncFunctionDef) and sub.name == "run":
+            run_method = sub
+            break
+    assert run_method is not None, "ToolLoopCoordinator.run method missing"
+
+    naked_raise_sites: list[str] = []
+    for raise_node in ast.walk(run_method):
+        if not isinstance(raise_node, ast.Raise):
+            continue
+        if raise_node.exc is None:
+            # bare ``raise`` — re-raises current exception; checked
+            # separately in the cancellation test below.
+            continue
+        # Look for tool_loop_* RuntimeError patterns
+        unparsed = ast.unparse(raise_node)
+        if "tool_loop_" not in unparsed:
+            continue
+        if "_attach_tool_records" not in unparsed:
+            naked_raise_sites.append(unparsed[:120])
+
+    assert not naked_raise_sites, (
+        "Found tool_loop_* raise sites in ToolLoopCoordinator.run that do "
+        f"NOT compose _attach_tool_records: {naked_raise_sites}. "
+        "Slice 3C contract requires every failure-path raise to carry "
+        "records so outer-retry can accumulate."
+    )
+
+
+def test_ast_pin_candidate_generator_outer_retry_accumulator() -> None:
+    """The ``candidate_generator.py`` outer-retry loop must declare a
+    ``_carryover_tool_records`` accumulator AND harvest from the
+    inner_exc via ``tool_execution_records``. Spine for the cumulative-
+    exploration invariant."""
+    src = CANDIDATE_GENERATOR_FILE.read_text()
+    assert "_carryover_tool_records" in src, (
+        "candidate_generator.py missing the Slice 3C accumulator — "
+        "outer-retry attempts will continue dropping records."
+    )
+    assert "tool_execution_records" in src, (
+        "candidate_generator.py missing tool_execution_records reference"
+    )
+    # Confirm the merge path uses with_tool_records (the public API on
+    # GenerationResult, byte-identical to dataclasses.replace).
+    assert "with_tool_records" in src, (
+        "candidate_generator.py must merge carryover via "
+        "GenerationResult.with_tool_records — Slice 3C contract."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 6
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_attach_tool_records_stamps_attribute() -> None:
+    """Helper writes ``tool_execution_records`` attribute on the
+    exception and returns the same exception for inline composition."""
+    from backend.core.ouroboros.governance.tool_executor import (
+        _attach_tool_records,
+    )
+    exc = RuntimeError("test")
+    records = [{"tool_name": "search_code"}, {"tool_name": "read_file"}]
+    returned = _attach_tool_records(exc, records)
+    assert returned is exc, "Helper must return same exc for inline raise"
+    assert hasattr(exc, "tool_execution_records")
+    assert exc.tool_execution_records == tuple(records)
+
+
+def test_spine_attach_tool_records_empty_iterable_ok() -> None:
+    """Empty records is valid — stamps an empty tuple."""
+    from backend.core.ouroboros.governance.tool_executor import (
+        _attach_tool_records,
+    )
+    exc = RuntimeError("test")
+    _attach_tool_records(exc, ())
+    assert exc.tool_execution_records == ()
+
+
+def test_spine_attach_tool_records_never_raises_on_weird_input() -> None:
+    """Even if records is a generator that raises on iteration, the
+    helper swallows and returns. NEVER block a re-raise."""
+    from backend.core.ouroboros.governance.tool_executor import (
+        _attach_tool_records,
+    )
+
+    def _bad_gen():
+        raise ValueError("intentional")
+        yield  # unreachable
+
+    exc = RuntimeError("test")
+    # Should not propagate the ValueError
+    result = _attach_tool_records(exc, _bad_gen())
+    assert result is exc
+
+
+def test_spine_harvest_pattern_matches_orchestrator_convention() -> None:
+    """Validate that the orchestrator's existing harvest pattern
+    (orchestrator.py:5135) works on Slice-3C-stamped exceptions.
+    Cross-module contract — if this drifts, Slice 3C silently breaks."""
+    from backend.core.ouroboros.governance.tool_executor import (
+        _attach_tool_records,
+    )
+    exc = RuntimeError("tool_loop_starved_below_min_ttft_floor")
+    records = [{"tool_name": "search_code"}]
+    _attach_tool_records(exc, records)
+    # Mirror orchestrator.py:5135's getattr-default-empty-tuple pattern
+    harvested = getattr(exc, "tool_execution_records", ()) or ()
+    assert tuple(harvested) == tuple(records), (
+        "Slice 3C exception attachment must be readable via the "
+        "getattr(exc, 'tool_execution_records', ()) convention that "
+        "orchestrator.py:5135 already uses."
+    )
+
+
+def test_spine_carryover_accumulator_pattern() -> None:
+    """Simulate the candidate_generator outer-retry pattern: failed
+    attempts stamp records onto exceptions, the accumulator extends from
+    each, the final result merges accumulator + winning records.
+
+    This is a pure-data test of the propagation math — proves the merge
+    order (carryover BEFORE winning) preserves chronological exploration
+    history."""
+    from backend.core.ouroboros.governance.tool_executor import (
+        _attach_tool_records,
+    )
+
+    # Simulate 2 failed attempts then 1 winning attempt
+    attempt_1_exc = RuntimeError("tool_loop_starved")
+    _attach_tool_records(
+        attempt_1_exc,
+        [{"tool_name": "search_code", "attempt": 1}],
+    )
+
+    attempt_2_exc = RuntimeError("tool_loop_deadline")
+    _attach_tool_records(
+        attempt_2_exc,
+        [
+            {"tool_name": "read_file", "attempt": 2},
+            {"tool_name": "glob_files", "attempt": 2},
+        ],
+    )
+
+    # Winning attempt — model emitted patch with no further tool calls
+    winning_records = ()  # The bt-2026-05-25-033000 scenario
+
+    # Apply Slice 3C harvest pattern from candidate_generator
+    _carryover = []
+    for _failed_exc in (attempt_1_exc, attempt_2_exc):
+        _carryover.extend(
+            getattr(_failed_exc, "tool_execution_records", ()) or ()
+        )
+
+    merged = tuple(_carryover) + winning_records
+    assert len(merged) == 3, (
+        f"Carryover merge dropped records: expected 3, got {len(merged)}"
+    )
+    # Order check: carryover first (chronological exploration history)
+    assert merged[0]["tool_name"] == "search_code"
+    assert merged[0]["attempt"] == 1
+    assert merged[2]["tool_name"] == "glob_files"
+    assert merged[2]["attempt"] == 2
+
+
+def test_spine_generation_result_with_tool_records_round_trip() -> None:
+    """``GenerationResult.with_tool_records`` is the merge contract that
+    Slice 3C uses to stamp the cumulative records onto the winning
+    attempt. Round-trip test proves the contract holds."""
+    from backend.core.ouroboros.governance.op_context import GenerationResult
+
+    base = GenerationResult(
+        candidates=(),
+        provider_name="claude-api",
+        generation_duration_s=12.5,
+        tool_execution_records=(),
+    )
+    cumulative = (
+        {"tool_name": "search_code"},
+        {"tool_name": "read_file"},
+        {"tool_name": "glob_files"},
+    )
+    merged = base.with_tool_records(cumulative)
+    assert merged.tool_execution_records == cumulative
+    # Must be a NEW immutable result (frozen dataclass) — base unchanged
+    assert base.tool_execution_records == ()
+    # All other fields must round-trip
+    assert merged.provider_name == "claude-api"
+    assert merged.generation_duration_s == 12.5


### PR DESCRIPTION
feat(governance): Slice 3C — Tool-record propagation across outer-retry attempts

Closes bt-2026-05-25-033000: the $5/3600s high-capital capability soak
proved Venom CAN emit a 5118-token patch when capital is not the
constraint. But Iron Gate rejected the patch with
``exploration_insufficient: 0/2`` despite the ToolLoop having
accumulated 19 records across 10 rounds of search_code / glob_files /
read_file / bash / list_dir calls. The model had explored
exhaustively, then emitted a direct patch — Iron Gate saw zero.

## Root cause

The candidate_generator outer-retry mechanism runs the provider's
generate() 1..N times per orchestrator generation
(``_FALLBACK_OUTER_RETRY_MAX=3``). Each attempt invokes the same
``ToolLoopCoordinator`` instance, which RESETS ``self._last_records =
[]`` at run start (tool_executor.py line 5250). When attempt N raises,
its records were silently dropped because the exception that
propagated didn't carry them. The next attempt started fresh. When the
final WINNING attempt happened to skip the tool loop (e.g., direct
patch emit after retries primed the prompt), the GenerationResult
carried zero records — even though earlier attempts had explored
deeply.

Iron Gate post-GENERATE inspects ONLY
``generation.tool_execution_records`` (orchestrator.py:4611). The
multi-attempt history was invisible to it.

## Fix mechanism — two-layer, composes existing protocol

### Layer 1 — ``tool_executor.py::_attach_tool_records``

Module-level helper stamps ``tool_execution_records`` onto an exception
and returns the exception for inline ``raise`` composition. Every
failure-path raise inside ``ToolLoopCoordinator.run()`` now composes
through it:

  raise _attach_tool_records(
      RuntimeError("tool_loop_starved_below_min_ttft_floor:..."),
      records,
  )

Mirrors the pre-existing protocol consumed by orchestrator.py:5135
(``getattr(exc, 'tool_execution_records', ())``). The orchestrator's
shadow-logging path already read this attribute — Slice 3C just makes
EVERY failure-path raise honor the contract, not just the shadow path.

### Layer 2 — candidate_generator outer-retry accumulator

The outer-retry ``while True`` loop now maintains
``_carryover_tool_records: List[Any] = []`` and harvests from each
failed attempt's exception via the same getattr-default-empty pattern
the orchestrator uses. On the WINNING attempt, the accumulator merges
into the GenerationResult via the public
``GenerationResult.with_tool_records`` API:

  _merged = tuple(_carryover_tool_records) + _winning_records
  _fb_result = _fb_result.with_tool_records(_merged)

Iron Gate now sees cumulative exploration across attempts, not just
the records from whichever attempt happened to succeed.

## Why exception attachment vs new ctx-field

Operator binding: "no messy global state, pass the data cleanly via
context/results." Exceptions WERE already the failure-path data
transport (orchestrator.py:5135 predates this slice). A parallel
``ctx.cumulative_tool_records`` field would duplicate the transport.
The exception IS the result on failure paths — Slice 3C just makes
that contract explicit at every raise site.

## Operator bindings honored

* **Build cleanly on existing** — composes the existing
  ``with_tool_records`` API + the existing
  ``getattr(exc, 'tool_execution_records', ())`` orchestrator
  convention. Zero new public APIs.
* **No hardcoding** — accumulator is dynamic; merge order
  (carryover first → winning second) preserves chronological
  exploration history without any compile-time constants.
* **Defense-in-depth** — merge is wrapped in try/except that NEVER
  raises out (a degraded merge falls back to the unmerged winning
  result; legacy behavior preserved). Harvest is wrapped in
  try/except that NEVER blocks retry (a getattr failure on a weird
  exception type is silently swallowed).
* **No silent fallback** — when merge succeeds, an INFO log line
  reports the merge:
  ``[CandidateGenerator] Slice 3C: merged N carryover tool records
  from M failed attempt(s) into winning GenerationResult
  (winning=X, total=Y) op=...``
* **AST-pinned** — 3 pins prove (1) ``_attach_tool_records`` helper
  exists with the right signature, (2) EVERY tool_loop_* raise site
  in ``ToolLoopCoordinator.run`` composes the helper (caught a 7th
  raise site — ``tool_loop_context_overflow`` — that would have
  silently leaked records without the AST sweep), (3)
  candidate_generator declares the accumulator and uses
  ``with_tool_records`` for the merge.

## What this fix does NOT do

* No changes to ``ToolLoopCoordinator.run()`` happy-path return —
  the ``return raw, records`` at line 5378 still carries records
  cleanly when the model emits a final non-tool response on a single
  attempt. Slice 3C only matters when the OUTER-retry mechanism
  fires.
* No changes to the primary-provider path (``_call_primary``) — that
  path doesn't iterate through multiple attempts inside a single
  generate() call. The bug only existed in the fallback outer-retry
  loop.
* No changes to Iron Gate's exploration math (``_explore_count`` /
  ``_min_explore`` / ``_EXPLORATION_TOOLS``). Slice 3C just makes
  sure Iron Gate sees the records that already exist; the gate's
  semantics are untouched.

## Test surface (3 AST pins + 6 spine, all green; +28 prior 3B/3B.1/teardown)

AST pins (3):
  1. ``_attach_tool_records`` helper exists with (exc, records) signature
  2. EVERY ``raise RuntimeError("tool_loop_*")`` inside
     ToolLoopCoordinator.run composes ``_attach_tool_records``
     (sweeps all 7 raise sites including context_overflow)
  3. candidate_generator declares ``_carryover_tool_records`` AND
     references ``tool_execution_records`` AND uses ``with_tool_records``

Spine (6):
  * Helper stamps attribute + returns same exc for inline composition
  * Empty iterable is valid (stamps empty tuple)
  * Helper NEVER raises on weird input (generator that raises mid-iter)
  * Stamped attribute matches orchestrator's
    ``getattr(exc, 'tool_execution_records', ())`` convention
    (cross-module contract regression pin)
  * Carryover accumulator pattern: 2 failed attempts (1 + 2 records)
    + 1 winning attempt (0 records) merges to 3 records in
    chronological order — THE bt-2026-05-25-033000 regression test
  * ``GenerationResult.with_tool_records`` round-trip preserves
    frozen-dataclass immutability + all other fields

## Next empirical test

Re-launch the EXACT same $5/3600s capability soak on the same ansible
instance. Predicted outcome:

  * Attempt 1: same as before — tool loop runs 10 rounds, model emits
    5118-token patch, attempt times out (RuntimeError carries records
    now)
  * Attempt 2: starts with accumulator already populated
  * Attempt 3 (winning): emits direct patch → carryover merges →
    Iron Gate sees ~20 cumulative records → ``exploration_insufficient``
    PASSES → APPLY phase fires → VERIFY runs → conclusive
    RESOLVED / UNRESOLVED verdict.

5 files changed, ~340 insertions(+), ~12 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates tool execution records across fallback outer-retry attempts so Iron Gate sees cumulative exploration and no longer rejects valid patches. Addresses bt-2026-05-25-033000 by ensuring earlier attempts’ tool calls are preserved and merged into the final result.

- **Bug Fixes**
  - Added `_attach_tool_records(exc, records)` in `tool_executor.py`; every failure-path raise in `ToolLoopCoordinator.run()` now stamps `tool_execution_records` and re-raises.
  - In `candidate_generator.py`, added `_carryover_tool_records` to harvest from failed attempts and merge into the winning `GenerationResult` via `with_tool_records`, preserving chronological order.
  - Defensive merge (never breaks success path) with info logging when records are merged; no changes to single-attempt happy path.
  - New tests in `tests/governance/test_slice3c_tool_record_propagation.py` (AST pins + spine) to enforce helper presence, raise-site coverage, accumulator/merge behavior, and `GenerationResult` round-trip.

<sup>Written for commit bc2bceb8975685dba8b2363778e9a1b3a2447bdb. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/56983?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

