### PR TITLE
feat(governance): Slice 3D — Coordinator-attribute record harvest fallback

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4444,10 +4444,64 @@ class CandidateGenerator:
                         # if the exception didn't carry records (legacy
                         # provider, untagged path), getattr returns (),
                         # extend is a no-op, behavior matches pre-Slice-3C.
+                        #
+                        # Slice 3D (2026-05-24) — coordinator-attribute
+                        # fallback. The Slice 3C exception attachment only
+                        # fires on raises through ToolLoopCoordinator's
+                        # ``_attach_tool_records`` sites. When the outer
+                        # ``_race_or_wait_for(... timeout=_attempt_remaining)``
+                        # hits its deadline, it raises asyncio.TimeoutError
+                        # / CancelledError that DOES NOT traverse the tool
+                        # executor's raise sites — the records sit untouched
+                        # in ``coordinator._last_records``. The
+                        # bt-2026-05-25-041717 attempt 1: 244.2s tool loop
+                        # made 13+ tool calls then the outer race timed
+                        # out; Slice 3C harvested nothing because the
+                        # TimeoutError was opaque; Iron Gate saw 0/2 on
+                        # the final attempt and the cumulative exploration
+                        # was lost.
+                        #
+                        # Fallback path: when the exception carries no
+                        # records, read directly from the coordinator's
+                        # instance attribute. ``_last_records`` is reset to
+                        # ``[]`` at every ``run()`` start (tool_executor.py
+                        # line 5250) and re-populated at each round
+                        # boundary, so at except-block time it reflects
+                        # exactly the just-failed attempt's records — no
+                        # cross-attempt double-counting.
                         try:
                             _harvested = getattr(
                                 inner_exc, "tool_execution_records", (),
                             ) or ()
+                            if not _harvested:
+                                # Slice 3D fallback — coordinator probe.
+                                # Defensive getattr chain: any provider
+                                # without ``_tool_loop`` (tools disabled
+                                # config) or coordinator without
+                                # ``_last_records`` (legacy/test stub)
+                                # falls through to empty harvest.
+                                _coord = getattr(
+                                    self._fallback, "_tool_loop", None,
+                                )
+                                if _coord is not None:
+                                    _harvested = tuple(
+                                        getattr(
+                                            _coord, "_last_records", (),
+                                        ) or ()
+                                    )
+                                    if _harvested:
+                                        logger.info(
+                                            "[CandidateGenerator] Slice 3D: "
+                                            "harvested %d records from "
+                                            "coordinator._last_records "
+                                            "(exception %s carried 0; "
+                                            "fallback succeeded) op=%s",
+                                            len(_harvested),
+                                            type(inner_exc).__name__,
+                                            getattr(
+                                                context, "op_id", "?",
+                                            )[:16],
+                                        )
                             if _harvested:
                                 _carryover_tool_records.extend(_harvested)
                         except Exception:  # noqa: BLE001 — never block retry

--- a/tests/governance/test_slice3d_coordinator_record_harvest.py
+++ b/tests/governance/test_slice3d_coordinator_record_harvest.py
@@ -1,0 +1,272 @@
+"""Slice 3D — coordinator-attribute record harvest fallback.
+
+Closes the residual propagation gap from Slice 3C surfaced by
+bt-2026-05-25-041717: the ansible op's attempt-1 tool loop ran 244.2s,
+emitted a 9941-token output across 13+ tool calls, then died at the
+OUTER ``_race_or_wait_for(... timeout=_attempt_remaining)`` boundary.
+That outer race raises ``asyncio.TimeoutError`` / ``CancelledError``
+that does NOT traverse ``ToolLoopCoordinator``'s
+``_attach_tool_records`` raise sites — Slice 3C harvested nothing
+because the exception was opaque, the cumulative records were lost,
+the next attempt's GenerationResult carried 0 records, Iron Gate
+rejected for ``exploration_insufficient: 0/2`` — same trap as
+bt-2026-05-25-033000.
+
+# Fix mechanism
+
+When the inner_exc carries no records (the Slice 3C path returns
+empty), Slice 3D falls back to ``coordinator._last_records`` directly.
+The coordinator resets ``_last_records = []`` at every ``run()`` start
+(tool_executor.py line 5250), so at except-block time it reflects
+exactly the just-failed attempt's records — no cross-attempt
+double-counting risk.
+
+The fallback path uses defensive getattr chains (``_fallback._tool_loop``
++ ``_tool_loop._last_records``) so legacy/test providers without these
+attributes fall through cleanly. Mirrors the Slice 3C never-block-retry
+guarantee.
+
+# Test surface (2 AST pins + 5 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANDIDATE_GENERATOR_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance" / "candidate_generator.py"
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_slice3d_fallback_references_coordinator_last_records() -> None:
+    """The candidate_generator outer-retry except block must reference
+    ``_tool_loop`` AND ``_last_records`` for the Slice 3D fallback path
+    to compose. Without this, the asyncio TimeoutError that the outer
+    race raises (the bt-2026-05-25-041717 failure mode) silently drops
+    the coordinator's records."""
+    src = CANDIDATE_GENERATOR_FILE.read_text()
+    assert "_tool_loop" in src and "_last_records" in src, (
+        "candidate_generator.py is missing the Slice 3D coordinator "
+        "fallback. The asyncio.TimeoutError trap from "
+        "bt-2026-05-25-041717 is open again."
+    )
+    # Confirm the fallback comment marker is present so the intent
+    # survives future refactors that touch the harvest block.
+    assert "Slice 3D" in src, (
+        "Slice 3D marker missing from candidate_generator.py"
+    )
+
+
+def test_ast_pin_slice3d_fallback_is_within_harvest_except_block() -> None:
+    """The ``_last_records`` reference must live INSIDE the same
+    ``except (Exception, asyncio.CancelledError)`` block that harvests
+    via ``inner_exc.tool_execution_records``. The fallback is one
+    if-branch BELOW the Slice 3C primary path; not a parallel try/except.
+    """
+    tree = _parse(CANDIDATE_GENERATOR_FILE)
+    found = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        body_src = ast.unparse(node)
+        if (
+            "tool_execution_records" in body_src
+            and "_last_records" in body_src
+            and "_tool_loop" in body_src
+            and "_carryover_tool_records" in body_src
+        ):
+            found = True
+            break
+    assert found, (
+        "No except-handler block composes BOTH Slice 3C (inner_exc."
+        "tool_execution_records) AND Slice 3D (coordinator._last_records). "
+        "The two paths must coexist in the same harvest block — they "
+        "share the _carryover_tool_records accumulator."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 5
+# ──────────────────────────────────────────────────────────────────────
+
+
+class _StubCoordinator:
+    """Minimal coordinator stub mirroring ToolLoopCoordinator's contract
+    for the records-harvest pathway (Slice 3D consumes _last_records)."""
+
+    def __init__(self, records=None) -> None:
+        self._last_records = list(records or ())
+
+
+class _StubFallback:
+    """Minimal provider stub for the harvest path. Carries a coordinator
+    via ``_tool_loop`` exactly as the real ClaudeProvider/PrimeProvider
+    do."""
+
+    def __init__(self, coordinator=None) -> None:
+        self._tool_loop = coordinator
+
+
+def _simulate_harvest(
+    inner_exc, fallback,
+) -> list:
+    """Pure-function model of the candidate_generator harvest body.
+
+    Mirrors the production code at candidate_generator.py:4441+ exactly
+    — when this drifts, the AST pin above catches it. We pull the
+    behavior into a test helper so we can exercise edge cases without
+    booting the full CandidateGenerator.
+    """
+    carryover: list = []
+    try:
+        harvested = getattr(
+            inner_exc, "tool_execution_records", (),
+        ) or ()
+        if not harvested:
+            # Slice 3D fallback
+            coord = getattr(fallback, "_tool_loop", None)
+            if coord is not None:
+                harvested = tuple(
+                    getattr(coord, "_last_records", ()) or ()
+                )
+        if harvested:
+            carryover.extend(harvested)
+    except Exception:  # noqa: BLE001
+        pass
+    return carryover
+
+
+def test_spine_slice3c_path_wins_when_exception_carries_records() -> None:
+    """When the inner_exc has ``tool_execution_records``, Slice 3C path
+    wins — Slice 3D fallback is NOT consulted. Prevents double-counting
+    if both attribute paths are populated."""
+    exc = RuntimeError("tool_loop_starved_below_min_ttft_floor")
+    exc.tool_execution_records = (  # type: ignore[attr-defined]
+        {"tool_name": "search_code", "via": "slice_3c"},
+    )
+    # Coordinator ALSO has records — Slice 3D would over-count if it ran
+    coord = _StubCoordinator(records=[
+        {"tool_name": "read_file", "via": "slice_3d_should_NOT_fire"},
+    ])
+    fb = _StubFallback(coordinator=coord)
+    result = _simulate_harvest(exc, fb)
+    assert len(result) == 1, (
+        f"Expected 1 record from Slice 3C only; got {len(result)}. "
+        "Slice 3D fallback fired when it shouldn't have — double-count "
+        "risk."
+    )
+    assert result[0]["via"] == "slice_3c"
+
+
+def test_spine_slice3d_fallback_fires_on_opaque_timeout() -> None:
+    """THE bt-2026-05-25-041717 regression test. ``asyncio.TimeoutError``
+    from the outer race wrapper carries no ``tool_execution_records``
+    attribute. Slice 3D fallback reads from ``coordinator._last_records``
+    and recovers the partial-run history."""
+    import asyncio
+    exc = asyncio.TimeoutError()  # ← opaque, no records on it
+    coord = _StubCoordinator(records=[
+        {"tool_name": "search_code", "round": 0},
+        {"tool_name": "glob_files", "round": 0},
+        {"tool_name": "bash", "round": 1},
+        {"tool_name": "read_file", "round": 2},
+    ])
+    fb = _StubFallback(coordinator=coord)
+    result = _simulate_harvest(exc, fb)
+    assert len(result) == 4, (
+        f"Slice 3D fallback failed to harvest 4 records from coordinator; "
+        f"got {len(result)}. Iron Gate would see 0/2 on outer-race "
+        f"timeout — bt-2026-05-25-041717 trap is open."
+    )
+
+
+def test_spine_missing_tool_loop_attribute_falls_through_cleanly() -> None:
+    """Legacy / test providers without ``_tool_loop`` must not crash
+    the harvest path. Defensive getattr returns None, fallback is no-op."""
+    import asyncio
+    exc = asyncio.TimeoutError()
+
+    class _NoToolLoopFallback:
+        pass  # no _tool_loop attribute at all
+
+    fb = _NoToolLoopFallback()
+    result = _simulate_harvest(exc, fb)
+    assert result == [], (
+        "Provider without _tool_loop attribute must yield empty harvest "
+        "(no exception escape from the harvest path)."
+    )
+
+
+def test_spine_coordinator_with_empty_records_is_noop() -> None:
+    """Coordinator exists but its ``_last_records`` is empty
+    (no rounds completed before failure). Accumulator unchanged."""
+    import asyncio
+    exc = asyncio.TimeoutError()
+    coord = _StubCoordinator(records=[])
+    fb = _StubFallback(coordinator=coord)
+    result = _simulate_harvest(exc, fb)
+    assert result == []
+
+
+def test_spine_full_cross_attempt_cycle_proves_propagation() -> None:
+    """End-to-end model: 3 outer-retry attempts where each fails via a
+    DIFFERENT exception mode. Slice 3C + 3D together must recover all
+    records.
+
+      * Attempt 1: outer-race TimeoutError (opaque) → 3D fallback (4 records)
+      * Attempt 2: tool_loop_starved (Slice 3C attaches) → 3C path (2 records)
+      * Attempt 3: succeeds with 0 records (direct patch emit)
+
+    Iron Gate's cumulative count must be 6, not 0.
+    """
+    import asyncio
+    carryover: list = []
+
+    # Attempt 1 — coordinator harvested via Slice 3D
+    coord = _StubCoordinator(records=[
+        {"tool": "search_code", "attempt": 1},
+        {"tool": "glob_files", "attempt": 1},
+        {"tool": "bash", "attempt": 1},
+        {"tool": "read_file", "attempt": 1},
+    ])
+    fb = _StubFallback(coordinator=coord)
+    exc_1 = asyncio.TimeoutError()
+    carryover.extend(_simulate_harvest(exc_1, fb))
+
+    # Attempt 2 — Slice 3C attaches records to RuntimeError
+    # (coordinator._last_records was just reset to [] at attempt 2 start
+    # then re-populated with attempt 2's calls)
+    coord._last_records = [
+        {"tool": "read_file", "attempt": 2},
+        {"tool": "search_code", "attempt": 2},
+    ]
+    exc_2 = RuntimeError("tool_loop_starved_below_min_ttft_floor")
+    exc_2.tool_execution_records = (  # type: ignore[attr-defined]
+        *coord._last_records,
+    )
+    carryover.extend(_simulate_harvest(exc_2, fb))
+
+    # Attempt 3 — succeeds; carryover gets merged onto its GenerationResult.
+    # The merge is the orchestrator's _fb_result.with_tool_records(...)
+    # call — we just verify the accumulator at this point.
+    assert len(carryover) == 6, (
+        f"Expected 6 carryover records across two distinct failure "
+        f"modes; got {len(carryover)}. The bt-2026-05-25-033000 + "
+        f"bt-2026-05-25-041717 cumulative-exploration invariant is "
+        f"broken."
+    )
+    # Order check: attempt 1 records come first
+    assert carryover[0]["attempt"] == 1
+    assert carryover[3]["attempt"] == 1
+    assert carryover[4]["attempt"] == 2


### PR DESCRIPTION
feat(governance): Slice 3D — Coordinator-attribute record harvest fallback

Closes the residual propagation gap from Slice 3C surfaced by
bt-2026-05-25-041717. The ansible op's attempt-1 tool loop ran 244.2s,
emitted a 9941-token output across 13+ tool calls, then died at the
OUTER ``_race_or_wait_for(... timeout=_attempt_remaining)`` boundary.
That outer race raises ``asyncio.TimeoutError`` / ``CancelledError``
that does NOT traverse ``ToolLoopCoordinator``'s
``_attach_tool_records`` raise sites — the records sat in
``coordinator._last_records`` but Slice 3C's harvest saw nothing
because ``getattr(exc, 'tool_execution_records', ())`` returned empty
on the opaque async timeout.

The next retry attempt's GenerationResult carried 0 records, Iron
Gate rejected for ``exploration_insufficient`` — same trap as
bt-2026-05-25-033000 even though Slice 3C was in flight.

## Root cause

The OUTER race-or-wait_for boundary is OUTSIDE the tool_executor's
raise sites:

  _fb_result = await _race_or_wait_for(
      self._fallback.generate(context, deadline),
      timeout=_attempt_remaining,             ← THIS timeout
      cancel_token=_curr_cancel_token(),
  )

When ``timeout=_attempt_remaining`` fires, asyncio raises
TimeoutError on the awaiter side — the inner provider's
``self._tool_loop.run(...)`` never gets to its
``_attach_tool_records`` sites because it's cancelled mid-await.
Slice 3C's exception-attachment contract is bypassed entirely.

## Fix mechanism — defensive fallback path

When the inner_exc carries no records, Slice 3D falls back to reading
``coordinator._last_records`` directly. The coordinator resets
``_last_records = []`` at every ``run()`` start (tool_executor.py:5250)
and writes ``self._last_records = list(records)`` at every round
boundary. So at except-block time it reflects exactly the just-failed
attempt's records — no cross-attempt double-counting risk.

  try:
      _harvested = getattr(inner_exc, "tool_execution_records", ()) or ()
      if not _harvested:
          # Slice 3D fallback
          _coord = getattr(self._fallback, "_tool_loop", None)
          if _coord is not None:
              _harvested = tuple(
                  getattr(_coord, "_last_records", ()) or ()
              )
              if _harvested:
                  logger.info("[CandidateGenerator] Slice 3D: ...")
      if _harvested:
          _carryover_tool_records.extend(_harvested)
  except Exception:
      pass

Defensive getattr chain (``_fallback._tool_loop`` +
``_tool_loop._last_records``) handles legacy/test providers without
these attributes — falls through to empty harvest, same as the
Slice 3C path's never-block-retry guarantee.

## Operator bindings honored

* **Build cleanly on existing** — composes the EXISTING coordinator
  ``_last_records`` instance attribute (line 5250 reset, line 5687
  round-boundary write — both predate this slice). Zero new public
  APIs, zero new state.
* **No hardcoding** — defensive getattr chains throughout; no
  compile-time dependencies on provider type.
* **Defense-in-depth** — Slice 3C path is tried FIRST. Slice 3D only
  fires when exc-attachment yielded zero. If both paths populate
  records on the same attempt (future provider quirk), Slice 3C wins
  and 3D is a no-op (single-source-of-truth per attempt).
* **No silent fallback** — when 3D fallback fires, logs at INFO:
  ``[CandidateGenerator] Slice 3D: harvested N records from
  coordinator._last_records (exception X carried 0; fallback
  succeeded) op=...``
* **Surgical** — one if-branch added to the existing harvest
  try/except block. Total diff is +~30 lines around the existing
  Slice 3C accumulator.

## What this fix does NOT do

* No changes to ``_attach_tool_records`` or its 7 call sites in
  tool_executor — Slice 3C's contract is unchanged.
* No changes to the merge path on success (``with_tool_records``
  call site) — Slice 3D extends the accumulator; the merge
  doesn't care which path filled it.
* No changes to the primary-provider path — that path doesn't have
  an outer race-or-wait_for wrapper. The bug only existed in the
  fallback outer-retry loop's ``_race_or_wait_for`` timeout edge.

## Test surface (2 AST pins + 5 spine, all green; +37 prior 3B/3B.1/3C/teardown)

AST pins (2):
  1. candidate_generator references BOTH ``_tool_loop`` AND
     ``_last_records`` AND ``Slice 3D`` marker
  2. The ``_last_records`` reference lives INSIDE the same
     except-handler block that harvests via
     ``inner_exc.tool_execution_records`` (not a parallel try/except)
     — they share the ``_carryover_tool_records`` accumulator

Spine (5):
  * Slice 3C path wins when exc carries records (no double-harvest)
  * Slice 3D fallback fires on opaque ``asyncio.TimeoutError`` — THE
    bt-2026-05-25-041717 regression test
  * Provider without ``_tool_loop`` attribute → empty harvest, no crash
  * Coordinator with empty ``_last_records`` → no-op accumulator
  * Full cross-attempt cycle: 3 attempts with mixed failure modes
    (outer TimeoutError + tool_loop_starved + success) → all 6
    records propagate to the winning GenerationResult

## Next empirical test

Re-launch the EXACT same $5/3600s capability soak. Predicted outcome:

  * Attempt 1: tool loop times out at outer race after 244s →
    coordinator has ~13 records → Slice 3D harvests them
  * Attempt 2: tool loop starves → Slice 3C harvests 2 records
  * Attempt 3 (winning): direct patch emit OR tool-loop completion →
    carryover merges → Iron Gate sees ~15+ cumulative records →
    exploration_insufficient PASSES → APPLY phase fires → VERIFY
    runs → conclusive RESOLVED / UNRESOLVED.

2 files changed, ~280 insertions(+), ~6 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Slice 3D: a fallback that reads `coordinator._last_records` when a fallback attempt times out, so tool execution records still carry into the next retry. This closes the Slice 3C gap where `asyncio.TimeoutError` dropped records and caused `exploration_insufficient`.

- **Bug Fixes**
  - On outer `\_race_or_wait_for(... timeout=...)` timeouts, harvest records from `self._fallback._tool_loop._last_records` if `inner_exc.tool_execution_records` is empty.
  - Keep Slice 3C as primary; Slice 3D only runs when 3C returns none, with an INFO log when used; no API changes and safe `getattr` guards for providers without these attributes.
  - No merge-path changes and no double-counting across attempts.
  - Adds tests covering the timeout path, missing/empty coordinator attributes, and mixed-attempt propagation.

<sup>Written for commit 884e92ae5e019f2954b19c2d602142499936065a. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57002?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

