### PR TITLE
feat(governance): Slice 3F — Async Engine Hardening (kill the rglob loop wedge)

### DIFF
--- a/backend/core/ouroboros/roadmap/source_crawlers.py
+++ b/backend/core/ouroboros/roadmap/source_crawlers.py
@@ -43,6 +43,92 @@ def _extract_title(content: str, path: Path) -> str:
     return path.stem
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Slice 3F — Async Engine Hardening
+# ──────────────────────────────────────────────────────────────────────
+#
+# Closes bt-2026-05-25-050449 wedge: ``crawl_rust_subsystems`` used
+# ``Path.rglob("Cargo.toml")`` which walks the ENTIRE directory tree
+# (recurses INTO ``target/``, ``node_modules/``, ``.git/`` then filters
+# them out AFTER walking). On this repo: ~50,664 dirs to walk vs 4,068
+# if pruned — the rglob took ~914s and wedged the asyncio event loop
+# until LoopDeadman fired ``os._exit(75)``.
+#
+# Slice 3B's ``_chunk_timeout`` watchdog DID NOT fire because
+# ``asyncio.wait_for`` schedules its timer on the event loop — when the
+# loop itself is wedged in synchronous I/O, the timer callback never
+# runs. Time-based defenses are unconditionally defeated by event-loop
+# wedges; the structural cure is to never block the loop in the first
+# place.
+#
+# This helper replaces the offending ``rglob`` with ``os.walk()`` plus
+# in-place ``dirnames[:]`` pruning so skip dirs are NEVER descended
+# into. Adds a bounded ``max_walk_s`` deadline as defense-in-depth
+# (returns partial results gracefully on overrun — better a truncated
+# crate map than a 914s wedge). Pure-sync function with deterministic
+# behavior; safe to call from sync code (its on-thread cost is now
+# bounded).
+
+_DEFAULT_CRAWL_MAX_WALK_S = 10.0
+
+
+def _crawl_max_walk_s() -> float:
+    """``JARVIS_STRATEGIC_CRAWL_MAX_WALK_S`` — per-walk deadline.
+
+    Default 10s. The walk should complete in well under 1s on any
+    healthy repo (pruning skip dirs makes the work proportional to
+    first-party source dirs only). The 10s budget is a generous
+    safety net for misconfigured / pathological repos.
+    """
+    raw = os.environ.get(
+        "JARVIS_STRATEGIC_CRAWL_MAX_WALK_S",
+        str(_DEFAULT_CRAWL_MAX_WALK_S),
+    )
+    try:
+        return max(0.5, float(raw))  # floor at 0.5s — never accept 0
+    except (TypeError, ValueError):
+        return _DEFAULT_CRAWL_MAX_WALK_S
+
+
+def _walk_for_filename(
+    search_root: Path,
+    filename: str,
+    skip_dirnames: frozenset[str],
+    max_walk_s: float,
+) -> List[Path]:
+    """Walk ``search_root`` collecting paths to files named ``filename``.
+
+    Prunes ``skip_dirnames`` IN-PLACE via the ``os.walk`` dirnames
+    list — descent into those subtrees is structurally prevented, not
+    filtered post-hoc (the bt-2026-05-25-050449 bug pattern).
+
+    Bounded by ``max_walk_s`` — returns whatever was collected so far
+    on deadline overrun. Operators can tune the deadline via
+    ``JARVIS_STRATEGIC_CRAWL_MAX_WALK_S``; the helper itself never
+    raises on overrun (a truncated crate map is a graceful degradation).
+    """
+    import logging as _logging
+    _logger = _logging.getLogger("Ouroboros.SourceCrawlers")
+    matches: List[Path] = []
+    deadline = time.monotonic() + max_walk_s
+    overrun = False
+    for dirpath, dirnames, filenames in os.walk(search_root):
+        if time.monotonic() > deadline:
+            overrun = True
+            break
+        # In-place prune — os.walk() honors this for descent control.
+        dirnames[:] = [d for d in dirnames if d not in skip_dirnames]
+        if filename in filenames:
+            matches.append(Path(dirpath) / filename)
+    if overrun:
+        _logger.warning(
+            "[source_crawlers] walk for %r exceeded max_walk_s=%.1fs "
+            "(collected %d so far) — returning partial results",
+            filename, max_walk_s, len(matches),
+        )
+    return sorted(matches)
+
+
 def _extract_summary(content: str, max_len: int = 500) -> str:
     """Return the first *max_len* characters of *content* (stripped)."""
     return content.strip()[:max_len]
@@ -277,16 +363,25 @@ def crawl_rust_subsystems(repo_root: Path) -> List[SnapshotFragment]:
     if not search_root.is_dir():
         return []
 
-    _SKIP = (
-        "/target/", "/.git/", "/worktrees/", "/.worktrees/",
-        "/node_modules/",
-    )
+    # Slice 3F — Async Engine Hardening. The pre-Slice-3F implementation
+    # used ``sorted(search_root.rglob("Cargo.toml"))`` which descends
+    # into EVERY directory and filters via ``_SKIP`` substring match
+    # AFTER the walk. On a JARVIS repo with 5 Rust ``target/`` dirs
+    # (~270MB each) + ``node_modules/`` (deeply nested), the walk took
+    # ~914s and wedged the asyncio event loop (bt-2026-05-25-050449).
+    #
+    # _walk_for_filename uses ``os.walk()`` with in-place ``dirnames[:]``
+    # pruning so the skip dirs are NEVER descended into — and adds a
+    # bounded ``max_walk_s`` deadline (env: JARVIS_STRATEGIC_CRAWL_MAX_WALK_S,
+    # default 10s) as defense-in-depth.
+    _SKIP_DIRNAMES = frozenset({
+        "target", ".git", "worktrees", ".worktrees", "node_modules",
+    })
     fragments: List[SnapshotFragment] = []
     seen_names: set[str] = set()
-    for cargo in sorted(search_root.rglob("Cargo.toml")):
-        cargo_str = str(cargo)
-        if any(s in cargo_str for s in _SKIP):
-            continue
+    for cargo in _walk_for_filename(
+        search_root, "Cargo.toml", _SKIP_DIRNAMES, _crawl_max_walk_s(),
+    ):
         try:
             cargo_text = cargo.read_text(encoding="utf-8", errors="replace")
         except OSError:

--- a/tests/governance/test_slice3f_async_engine_hardening.py
+++ b/tests/governance/test_slice3f_async_engine_hardening.py
@@ -1,0 +1,306 @@
+"""Slice 3F — Async Engine Hardening: kill the rglob loop wedge.
+
+Closes bt-2026-05-25-050449: ``crawl_rust_subsystems`` in
+``source_crawlers.py:286`` used ``Path.rglob("Cargo.toml")`` which
+recursively walks the ENTIRE directory tree (descends INTO
+``target/``, ``node_modules/``, ``.git/``, filters them out AFTER the
+walk). On a JARVIS repo (~50,664 dirs total, only ~4,068 first-party),
+the walk took ~914 seconds and wedged the asyncio event loop until
+``LoopDeadman`` fired ``os._exit(75)``.
+
+# Why Slice 3B's defenses didn't save us
+
+Slice 3B's ``_chunk_timeout`` uses ``asyncio.wait_for`` which
+schedules its timeout callback ON the event loop. When the loop is
+wedged in synchronous I/O, the timer callback never fires. **Time-
+based defenses are structurally defeated by event-loop wedges.** The
+cure is to never block the loop in the first place — or in this case,
+to make the blocking work fast enough that "blocking on the loop" is
+indistinguishable from "non-blocking".
+
+# Fix mechanism — three-part structural defense
+
+## Part 1 — In-place dir pruning (the load-bearing fix)
+
+Replace ``sorted(search_root.rglob("Cargo.toml"))`` with
+``_walk_for_filename(search_root, "Cargo.toml", _SKIP_DIRNAMES, deadline)``
+which uses ``os.walk()`` and prunes skip dirs IN-PLACE via
+``dirnames[:] = [d for d in dirnames if d not in skip_dirnames]``.
+``os.walk`` honors this for descent control — pruned dirs are NEVER
+entered.
+
+Empirical impact: ~860× speedup on this repo (1061ms vs 914000ms).
+
+## Part 2 — Bounded walk deadline (defense-in-depth)
+
+The ``_walk_for_filename`` helper accepts ``max_walk_s`` and checks
+``time.monotonic() > deadline`` at every dirpath. On overrun, returns
+whatever was collected so far + emits a WARNING log. Better a
+truncated crate map than a multi-minute wedge.
+
+Env: ``JARVIS_STRATEGIC_CRAWL_MAX_WALK_S`` (default 10s, floor 0.5s).
+
+## Part 3 — Skip dirs as DIRNAMES not SUBSTRINGS
+
+Pre-Slice-3F skip filter used ``"/target/", "/.git/"`` substrings
+applied AFTER the walk. Post-Slice-3F uses bare dirnames in a
+``frozenset`` matched against ``os.walk``'s ``dirnames`` list. This
+is structurally pre-walk (descent prevented) instead of post-walk
+(traversal complete but result discarded).
+
+# Test surface (3 AST pins + 6 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CRAWLER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "roadmap" / "source_crawlers.py"
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_crawl_rust_subsystems_does_not_use_rglob() -> None:
+    """``crawl_rust_subsystems`` body must NOT contain the
+    ``rglob("Cargo.toml")`` invocation — that was the
+    bt-2026-05-25-050449 wedge. The function body should compose
+    ``_walk_for_filename`` instead."""
+    tree = _parse(CRAWLER_FILE)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if node.name != "crawl_rust_subsystems":
+            continue
+        body_src = ast.unparse(node)
+        # The actual offending CALL was rglob("Cargo.toml").
+        # Comments mentioning rglob (rationale docs) are OK.
+        assert "rglob(\"Cargo.toml\")" not in body_src, (
+            "crawl_rust_subsystems still calls rglob('Cargo.toml') — "
+            "the bt-2026-05-25-050449 event-loop wedge trap is open."
+        )
+        assert "_walk_for_filename" in body_src, (
+            "crawl_rust_subsystems does not compose _walk_for_filename "
+            "— Slice 3F load-bearing helper not wired."
+        )
+        return
+    raise AssertionError(
+        "crawl_rust_subsystems function not found in source_crawlers.py"
+    )
+
+
+def test_ast_pin_walk_for_filename_uses_in_place_prune() -> None:
+    """``_walk_for_filename`` body MUST contain the in-place dirnames
+    slice assignment (``dirnames[:] = ...``). Without this, ``os.walk``
+    still descends into skip dirs — the fix is structurally inert."""
+    tree = _parse(CRAWLER_FILE)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if node.name != "_walk_for_filename":
+            continue
+        body_src = ast.unparse(node)
+        # The in-place slice pattern is the ONLY way to control os.walk
+        # descent. Anything else (filter-after-walk, return-list-from-fn)
+        # silently fails to prune.
+        assert "dirnames[:]" in body_src, (
+            "_walk_for_filename does not use in-place dirnames[:] "
+            "assignment — os.walk will still descend into skip dirs."
+        )
+        assert "os.walk" in body_src, (
+            "_walk_for_filename does not use os.walk — the fix shape "
+            "drifted from spec."
+        )
+        return
+    raise AssertionError(
+        "_walk_for_filename helper not found in source_crawlers.py"
+    )
+
+
+def test_ast_pin_walk_deadline_check_present() -> None:
+    """``_walk_for_filename`` must check ``time.monotonic() > deadline``
+    inside the walk loop. Without the deadline, a pathological repo
+    can still wedge for arbitrarily long even with pruning."""
+    src = CRAWLER_FILE.read_text()
+    assert "time.monotonic() > deadline" in src, (
+        "Deadline check missing from _walk_for_filename — Part 3 "
+        "defense-in-depth not wired."
+    )
+    assert "max_walk_s" in src, "max_walk_s parameter missing"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 6 (pure-data tests using a temp dir)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_walk_prunes_skip_dirnames() -> None:
+    """Build a temp tree with a Cargo.toml inside ``node_modules`` and
+    one outside. The walker must skip the in-node_modules one entirely."""
+    from backend.core.ouroboros.roadmap.source_crawlers import (
+        _walk_for_filename,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # First-party crate
+        (root / "real_crate").mkdir()
+        (root / "real_crate" / "Cargo.toml").write_text(
+            "[package]\nname = \"real\"\n"
+        )
+        # Vendored crate inside node_modules — must NOT be returned
+        (root / "node_modules" / "vendor").mkdir(parents=True)
+        (root / "node_modules" / "vendor" / "Cargo.toml").write_text(
+            "[package]\nname = \"vendor\"\n"
+        )
+        # Build artifact inside target — must NOT be returned
+        (root / "target" / "debug").mkdir(parents=True)
+        (root / "target" / "debug" / "Cargo.toml").write_text(
+            "[package]\nname = \"build_artifact\"\n"
+        )
+        found = _walk_for_filename(
+            root, "Cargo.toml",
+            frozenset({"node_modules", "target"}),
+            max_walk_s=10.0,
+        )
+        assert len(found) == 1, (
+            f"Expected 1 first-party Cargo.toml, got {len(found)}: {found}"
+        )
+        assert found[0].parent.name == "real_crate"
+
+
+def test_spine_walk_respects_deadline_returns_partial() -> None:
+    """When the walk exceeds ``max_walk_s``, returns whatever was
+    collected so far — never raises."""
+    from backend.core.ouroboros.roadmap.source_crawlers import (
+        _walk_for_filename,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # Create one Cargo.toml so there's something to find
+        (root / "Cargo.toml").write_text("[package]\nname = \"x\"\n")
+        # Deadline of 0.001s — should overrun almost immediately
+        # (or find the one Cargo.toml in the first dir; both outcomes
+        # are valid). The contract is: NO EXCEPTION on overrun.
+        found = _walk_for_filename(
+            root, "Cargo.toml", frozenset(), max_walk_s=0.001,
+        )
+        # Either 0 (overrun before yield) or 1 (lucky catch on first
+        # iteration). Both are valid — assertion is "no exception".
+        assert len(found) <= 1
+
+
+def test_spine_walk_finds_all_non_skipped_matches() -> None:
+    """Multiple Cargo.toml in non-skipped subdirs are all returned,
+    sorted by path."""
+    from backend.core.ouroboros.roadmap.source_crawlers import (
+        _walk_for_filename,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for name in ["alpha", "beta", "gamma"]:
+            d = root / name
+            d.mkdir()
+            (d / "Cargo.toml").write_text(f"[package]\nname = \"{name}\"\n")
+        found = _walk_for_filename(
+            root, "Cargo.toml", frozenset({"node_modules"}),
+            max_walk_s=10.0,
+        )
+        assert len(found) == 3
+        # Sorted order
+        assert [p.parent.name for p in found] == ["alpha", "beta", "gamma"]
+
+
+def test_spine_walk_max_walk_s_env_default_is_10s() -> None:
+    """``_crawl_max_walk_s`` default is 10s, env-overridable, floored
+    at 0.5s to prevent operator-induced micro-deadlines."""
+    from backend.core.ouroboros.roadmap.source_crawlers import (
+        _crawl_max_walk_s,
+        _DEFAULT_CRAWL_MAX_WALK_S,
+    )
+    assert _DEFAULT_CRAWL_MAX_WALK_S == 10.0
+    # Default when env unset
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("JARVIS_STRATEGIC_CRAWL_MAX_WALK_S", None)
+        assert _crawl_max_walk_s() == 10.0
+    # Env override honored
+    with patch.dict(os.environ, {"JARVIS_STRATEGIC_CRAWL_MAX_WALK_S": "3.5"}):
+        assert _crawl_max_walk_s() == 3.5
+    # Floor at 0.5s — protects against operator typos
+    with patch.dict(os.environ, {"JARVIS_STRATEGIC_CRAWL_MAX_WALK_S": "0.001"}):
+        assert _crawl_max_walk_s() == 0.5
+    # Malformed → fall back to default
+    with patch.dict(os.environ, {"JARVIS_STRATEGIC_CRAWL_MAX_WALK_S": "garbage"}):
+        assert _crawl_max_walk_s() == 10.0
+
+
+def test_spine_crawl_rust_subsystems_end_to_end_fast() -> None:
+    """End-to-end smoke: the real ``crawl_rust_subsystems`` against the
+    JARVIS repo completes in under 5s (typically <2s). This is the
+    regression test for the bt-2026-05-25-050449 wedge — that soak
+    took 914s for the same function call."""
+    from backend.core.ouroboros.roadmap.source_crawlers import (
+        crawl_rust_subsystems,
+    )
+    t0 = time.monotonic()
+    fragments = crawl_rust_subsystems(REPO_ROOT)
+    elapsed = time.monotonic() - t0
+    assert elapsed < 5.0, (
+        f"crawl_rust_subsystems took {elapsed:.2f}s — would risk "
+        f"wedging the asyncio loop again. The pre-Slice-3F rglob "
+        f"version took ~914s for this same call."
+    )
+    # Must still find SOME crates (this repo has multiple)
+    assert len(fragments) > 0, (
+        "crawl_rust_subsystems returned empty — the fix may have "
+        "accidentally pruned away legitimate first-party crates."
+    )
+
+
+def test_spine_walk_skip_set_matches_by_dirname_not_substring() -> None:
+    """Pre-Slice-3F skip used SUBSTRINGS like ``"/target/"`` which
+    could false-match weird paths. Slice 3F uses bare dirnames in a
+    frozenset matched against ``os.walk``'s dirnames list — exact
+    match, no substring footguns. Verify a dir named ``my_target``
+    (legitimate, not a build dir) is NOT skipped."""
+    from backend.core.ouroboros.roadmap.source_crawlers import (
+        _walk_for_filename,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        # Dir name contains "target" as substring but is NOT a build dir
+        (root / "my_target_aware_crate").mkdir()
+        (root / "my_target_aware_crate" / "Cargo.toml").write_text(
+            "[package]\nname = \"my_target_aware\"\n"
+        )
+        # Actual target dir — must be skipped
+        (root / "target").mkdir()
+        (root / "target" / "Cargo.toml").write_text(
+            "[package]\nname = \"build_artifact\"\n"
+        )
+        found = _walk_for_filename(
+            root, "Cargo.toml",
+            frozenset({"target"}),
+            max_walk_s=10.0,
+        )
+        names = {p.parent.name for p in found}
+        assert "my_target_aware_crate" in names, (
+            "Substring-style skip falsely matched 'my_target_aware_crate' "
+            "— Slice 3F's exact-dirname matching is broken."
+        )
+        assert "target" not in names, (
+            "Actual 'target' dir was NOT skipped — Slice 3F prune broken."
+        )


### PR DESCRIPTION
feat(governance): Slice 3F — Async Engine Hardening (kill the rglob loop wedge)

Closes the asyncio event-loop wedge surfaced by capability soak
bt-2026-05-25-050449: the harness ran for ~15s of normal activity
then went silent for 914 seconds until LoopDeadman fired os._exit(75).

The forensic faulthandler tombstone pinned the wedge to the main
asyncio thread's stack frame at source_crawlers.py:286 inside
``crawl_rust_subsystems``, called from strategic_direction.py:423
which is itself called from a SYNC ``format_for_prompt`` method on
the asyncio loop. The blocking call:

  for cargo in sorted(search_root.rglob("Cargo.toml")):
      cargo_str = str(cargo)
      if any(s in cargo_str for s in _SKIP):
          continue

``Path.rglob`` walks the FULL recursive tree before yielding any
result; the ``_SKIP`` substring filter applies AFTER the walk has
already descended into every target/, .git/, node_modules/, and
worktrees/ subtree. On this JARVIS repo:

  * Total dirs to walk via rglob:    50,664
  * Dirs if skip-pruned BEFORE walk:  4,068  (~12× reduction)
  * Time observed:                    914 seconds  (entire wedge)
  * Time post-fix:                    1.06 seconds (~860× speedup)

## Why Slice 3B's defenses didn't save us

``_chunk_timeout = asyncio.wait_for(..., timeout=...)`` schedules
its timeout callback ON the asyncio event loop. When the loop itself
is wedged in synchronous I/O, the timer callback never fires. **Time-
based defenses are structurally defeated by event-loop wedges.**
``LoopDeadman``'s daemon-thread-based polling is the only reason we
recovered at all — but that's a "kill the process" safety net, not
a "keep the system running" defense.

The cure is to never block the loop in the first place — or in this
case, to make the blocking work fast enough that "blocking on the
loop" is indistinguishable from "non-blocking".

## Fix mechanism — three-part structural defense

### Part 1 — In-place dir pruning (the load-bearing fix)

Replace ``sorted(search_root.rglob("Cargo.toml"))`` with a new helper
``_walk_for_filename(search_root, filename, skip_dirnames, max_walk_s)``
which uses ``os.walk()`` and prunes skip dirs IN-PLACE via:

  for dirpath, dirnames, filenames in os.walk(search_root):
      dirnames[:] = [d for d in dirnames if d not in skip_dirnames]
      if filename in filenames:
          matches.append(Path(dirpath) / filename)

``os.walk`` honors in-place ``dirnames[:]`` modification for descent
control — pruned dirs are NEVER entered. This is the canonical
Pythonic pattern for "walk but skip these subtrees".

### Part 2 — Bounded walk deadline (defense-in-depth)

``_walk_for_filename`` checks ``time.monotonic() > deadline`` at every
dirpath iteration. On overrun, returns whatever was collected so far
+ emits a WARNING log. Better a truncated crate map than a multi-minute
wedge on a pathological repo (e.g. one with a million submodules).

Env: ``JARVIS_STRATEGIC_CRAWL_MAX_WALK_S`` (default 10s, floor 0.5s
to protect against operator typos).

### Part 3 — Skip dirs as DIRNAMES not SUBSTRINGS

Pre-Slice-3F skip used substrings like ``"/target/", "/.git/"``
which could false-match weird paths (e.g. ``/my_target_aware/``).
Post-Slice-3F uses bare dirnames in a ``frozenset`` matched against
``os.walk``'s dirnames list — exact match, no substring footguns:

  _SKIP_DIRNAMES = frozenset({
      "target", ".git", "worktrees", ".worktrees", "node_modules",
  })

## Why I did NOT also wrap the caller in asyncio.to_thread

The natural defense-in-depth would be to make ``format_for_prompt``
async and wrap the crawler calls in ``asyncio.to_thread``. I chose
NOT to because:

  * The caller chain (``format_for_prompt`` → ``_render_*_section``)
    is currently SYNC across many call sites. Threading async through
    requires touching dozens of sites in orchestrator.py, all
    phase_runners, etc. — high blast radius for a defense-in-depth
    add when Parts 2+3 already bound the worst case to 10s.
  * The walk is now <2s in the worst observed real-world case. Even
    on a 10× worse repo (50k+ dirs in `backend/` somehow), the
    deadline caps it at 10s — well within any reasonable
    per-operation budget.
  * If a future arc needs the to_thread wrap, the existing crawler
    API is unchanged — ``asyncio.to_thread(crawl_rust_subsystems, root)``
    works as-is. Slice 3F doesn't preclude that.

## Operator bindings honored

* **Structural fix, no shortcuts/brute force/workarounds** — the
  rglob bug is replaced with the canonical Pythonic walk pattern.
  Not a try/except wrapper, not a thread pool dispatch, not an
  external process — the right algorithm in the right place.
* **No hardcoding** — skip dirs come from the existing _SKIP set
  (cleaned up from substring → dirname form); deadline is
  env-tunable; the walk respects whatever filename you pass.
* **Asynchronous-friendly** — the walk is fast enough that on-loop
  execution doesn't matter; the deadline guarantees an upper bound
  regardless of repo pathology.
* **Build cleanly on existing** — composes the existing
  ``crawl_rust_subsystems`` API verbatim (same signature, same
  return type); only the INTERNAL traversal is replaced. Existing
  callers untouched.
* **No silent fallback** — overrun emits a WARNING log naming the
  filename + deadline + partial count; the warning surfaces in
  debug.log for operator forensics.
* **AST-pinned** — 3 pins prove (1) ``crawl_rust_subsystems`` no
  longer calls ``rglob("Cargo.toml")``, (2) ``_walk_for_filename``
  uses in-place ``dirnames[:]`` slice assignment, (3) the deadline
  check ``time.monotonic() > deadline`` is present.

## What this slice does NOT do

* No changes to ``crawl_memory`` — it uses ``memory_dir.glob("*.md")``
  which is NON-recursive (single dir, no descent). Verified at
  2.4ms execution.
* No changes to ``crawl_specs`` / ``crawl_plans`` / ``crawl_backlog``
  / ``crawl_claude_md`` / ``crawl_git_log`` — same single-dir glob
  pattern, not affected.
* No changes to ``format_for_prompt`` or the strategic_direction
  call chain — the crawler's API contract is preserved.
* No changes to the asyncio event loop's structure — the cure is
  upstream of the loop's machinery.

## Test surface (3 AST pins + 6 spine, all green; +53 prior 3B/3B.1/3C/3D/3E/teardown)

AST pins (3):
  1. ``crawl_rust_subsystems`` body does NOT call ``rglob("Cargo.toml")``
     AND DOES compose ``_walk_for_filename`` — proves the load-bearing
     fix is wired
  2. ``_walk_for_filename`` body uses ``dirnames[:]`` in-place slice +
     ``os.walk`` — proves the canonical descent-control pattern is used
  3. ``_walk_for_filename`` body checks ``time.monotonic() > deadline``
     — proves defense-in-depth deadline is wired

Spine (6):
  * Walk prunes skip dirs (Cargo.toml in node_modules/target NOT
    returned)
  * Walk respects deadline on overrun (returns partial, no exception)
  * Walk finds all non-skipped matches in sorted order
  * Env default 10s, override honored, 0.5s floor, malformed fallback
  * End-to-end smoke: ``crawl_rust_subsystems`` against this repo
    completes in <5s — THE bt-2026-05-25-050449 regression test
  * Substring vs dirname matching: ``my_target_aware`` dir NOT
    skipped, real ``target`` dir IS skipped — Slice 3F's exact-match
    discipline is structural

## Next empirical test

Re-launch the EXACT same $5/3600s capability soak. Predicted outcome:

  * No more 914s asyncio loop wedge
  * Strategic Direction prompt builds in <2s (vs 914s)
  * Tool loop progresses normally
  * Slice 3E final-write nudge fires on round 9 → grace round 10
  * Model emits patch JSON
  * Iron Gate sees cumulative tool records (Slice 3C/3D)
  * APPLY+VERIFY produces RESOLVED/UNRESOLVED.

2 files changed, ~370 insertions(+), ~5 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the event-loop wedge in `crawl_rust_subsystems` by replacing `Path.rglob` with an in-place pruned `os.walk` and adding a bounded deadline. Addresses Linear bt-2026-05-25-050449; strategic crawl drops from 914s to ~1s, with worst cases capped.

- **Bug Fixes**
  - Replaced recursive `rglob` with `_walk_for_filename(..., skip_dirnames, max_walk_s)` using `os.walk` and in-place `dirnames[:]` pruning to never enter skipped subtrees.
  - Switched skip filtering to exact dirnames: `{"target", ".git", "worktrees", ".worktrees", "node_modules"}`.
  - Added deadline via `JARVIS_STRATEGIC_CRAWL_MAX_WALK_S` (default 10s, floor 0.5s); logs a warning and returns partial results on overrun.
  - Preserved `crawl_rust_subsystems` API; no caller changes. Added tests (3 AST pins + 6 spine); end-to-end run completes in <5s.

<sup>Written for commit 64c42b067b9cb067961b716e11256417854af775. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57147?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

