### PR TITLE
feat(governance): Slice 3G — Envelope-override repo_root for per-op worktrees

### DIFF
--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -4748,6 +4748,25 @@ class PrimeProvider:
                 )
             except Exception:  # noqa: BLE001 — defensive
                 _eb_observer = None
+            # ── Slice 3G — envelope-override for per-op worktrees ──
+            # Mirrors the ClaudeProvider site below. SWE-Bench-Pro ops
+            # carry the per-instance worktree path via
+            # ``envelope.evidence.repo_root``; without this override the
+            # tool loop searches the host JARVIS repo (wrong codebase).
+            # Composes the canonical
+            # ``operation_advisor.resolve_envelope_repo_root`` resolver;
+            # None result → no override → byte-identical legacy behavior.
+            _evidence_override: Optional[Path] = None
+            try:
+                from backend.core.ouroboros.governance.operation_advisor import (
+                    resolve_envelope_repo_root as _resolve_evidence_root,
+                )
+                _evidence_override = _resolve_evidence_root(
+                    getattr(context, "intake_evidence_json", "") or "",
+                    project_root=self._repo_root,
+                )
+            except Exception:  # noqa: BLE001 — never block tool loop
+                _evidence_override = None
             try:
                 raw, tool_records_list = await self._tool_loop.run(
                     prompt=prompt,
@@ -4759,6 +4778,7 @@ class PrimeProvider:
                     risk_tier=getattr(context, "risk_tier", None),
                     is_read_only=_is_read_only,
                     per_round_observer=_eb_observer,
+                    repo_root_override=_evidence_override,
                 )
             finally:
                 # Idempotent close — no-op when master flag off.
@@ -8558,6 +8578,28 @@ class ClaudeProvider:
                 time.monotonic()
                 + max(0.0, (deadline - datetime.now(tz=timezone.utc)).total_seconds())
             )
+            # ── Slice 3G — envelope-override for per-op worktrees ──
+            # Closes bt-2026-05-25-060538 NOOP wiring gap: SWE-Bench-Pro
+            # ops carry their per-instance worktree path via
+            # ``envelope.evidence.repo_root``. Without this override the
+            # tool loop searches the host JARVIS repo (wrong codebase)
+            # and the model correctly emits ``2b.1-noop`` because the
+            # target file genuinely isn't there. Composes the canonical
+            # ``operation_advisor.resolve_envelope_repo_root`` resolver
+            # (env-flag-gated, allowlist-validated, fail-silent); no
+            # parallel path-validation, no shared-state mutation. None
+            # result → no override → byte-identical legacy behavior.
+            _evidence_override: Optional[Path] = None
+            try:
+                from backend.core.ouroboros.governance.operation_advisor import (
+                    resolve_envelope_repo_root as _resolve_evidence_root,
+                )
+                _evidence_override = _resolve_evidence_root(
+                    getattr(context, "intake_evidence_json", "") or "",
+                    project_root=self._repo_root,
+                )
+            except Exception:  # noqa: BLE001 — never block tool loop
+                _evidence_override = None
             raw, tool_records_list = await self._tool_loop.run(
                 prompt=prompt_text,
                 generate_fn=_generate_raw,
@@ -8567,6 +8609,7 @@ class ClaudeProvider:
                 deadline=deadline_mono,
                 risk_tier=getattr(context, "risk_tier", None),
                 is_read_only=bool(getattr(context, "is_read_only", False)),
+                repo_root_override=_evidence_override,
             )
             tool_records = tuple(tool_records_list)
             tool_rounds = len(tool_records_list)

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -5254,6 +5254,22 @@ class ToolLoopCoordinator:
         # :func:`epistemic_budget_provider_bridge.attach_to_provider_run`'s
         # callback. Return value is ignored; exceptions are swallowed (never
         # propagate into the round loop).
+        repo_root_override: Optional[Path] = None,
+        # Slice 3G (2026-05-25) — envelope-override for per-op worktrees.
+        # When set, the tool loop's resolved ``repo_root`` honors this
+        # path instead of falling back to ``policy.repo_root_for(repo)``.
+        # The bt-2026-05-25-060538 NOOP autopsy proved that SWE-Bench-Pro
+        # ops carried the per-instance worktree path via
+        # ``envelope.evidence.repo_root`` but the ToolExecutor still
+        # resolved against the host JARVIS repo — the model's tool calls
+        # searched the wrong codebase and (correctly) emitted
+        # ``2b.1-noop: file not present in this repository``. The
+        # provider extracts the override via the existing canonical
+        # ``operation_advisor.resolve_envelope_repo_root`` helper
+        # (env-flag-gated, allowlist-validated, fail-silent) so this
+        # fix composes the same path-validation contract the Advisor
+        # already uses — no parallel resolver, no shared-state mutation.
+        # Default ``None`` preserves byte-identical legacy behavior.
     ) -> Tuple[str, List[ToolExecutionRecord]]:
         """Multi-turn tool loop with parallel execution support.
 
@@ -5309,6 +5325,21 @@ class ToolLoopCoordinator:
         records: List[ToolExecutionRecord] = []
         current_prompt = prompt
         repo_root = self._policy.repo_root_for(repo)
+        # ── Slice 3G — envelope-override for per-op worktrees ──
+        # When the caller supplies ``repo_root_override`` (provider has
+        # already resolved + path-validated via
+        # ``operation_advisor.resolve_envelope_repo_root``), honor it
+        # over the policy fallback. This closes the bt-2026-05-25-060538
+        # wiring gap: SWE-Bench-Pro ops now resolve tool calls against
+        # the per-instance worktree (where the actual problem code
+        # lives), not the host JARVIS repo (where the model found
+        # nothing and correctly NOOPed).
+        if repo_root_override is not None:
+            repo_root = Path(repo_root_override)
+            logger.info(
+                "[ToolLoop] op=%s repo_root override (Slice 3G): %s",
+                op_id[:12] if op_id else "?", repo_root,
+            )
 
         # Deadline-based loop: iterate until the provider produces a final
         # answer (no tool call) or the deadline expires. effective_max_rounds

--- a/tests/governance/test_slice3g_envelope_repo_root_override.py
+++ b/tests/governance/test_slice3g_envelope_repo_root_override.py
@@ -1,0 +1,310 @@
+"""Slice 3G — envelope-override for per-op worktree repo_root.
+
+Closes bt-2026-05-25-060538 NOOP wiring gap surfaced by the autopsy:
+the SWE-Bench-Pro harness creates per-instance worktrees at
+``/tmp/swebp_wt/instance_*/`` containing the ACTUAL problem code, and
+stamps the worktree path on the envelope as
+``evidence.repo_root``. But ``ToolLoopCoordinator.run()`` was
+unconditionally resolving the tool loop's working directory via
+``policy.repo_root_for(ctx.primary_repo)``, which only knew about the
+host JARVIS repo — so the model's ``read_file`` / ``glob_files`` /
+``list_dir`` searched the wrong codebase.
+
+The model correctly emitted ``2b.1-noop`` with verbatim reason::
+
+  "The target file lib/ansible/cli/doc.py does not exist in this
+  repository. This is the JARVIS Trinity AI Ecosystem codebase,
+  not an Ansible repository."
+
+That is intellectually-honest model behavior identifying our wiring
+bug. The capability infrastructure is fine; the harness wiring needed
+to plumb the envelope's worktree path into the tool executor.
+
+# Fix mechanism — surgical envelope-override path
+
+Two-site change:
+
+* ``tool_executor.py::ToolLoopCoordinator.run()`` accepts a new
+  ``repo_root_override: Optional[Path] = None`` kwarg. When set, the
+  resolved ``repo_root`` honors it INSTEAD of the
+  ``policy.repo_root_for(repo)`` fallback. ``None`` preserves
+  byte-identical legacy behavior.
+
+* ``providers.py`` (ClaudeProvider site + PrimeProvider site)
+  extracts the override from ``ctx.intake_evidence_json`` via the
+  pre-existing canonical resolver
+  ``operation_advisor.resolve_envelope_repo_root`` (env-flag-gated,
+  allowlist-validated, fail-silent). Composes the same path-validation
+  contract the Advisor already uses — no parallel resolver, no
+  shared-state mutation.
+
+The path validation in ``resolve_envelope_repo_root`` is the security
+guarantee: every override must resolve under ``project_root`` or an
+explicitly-allowed prefix; symlink escapes are defeated via
+``Path.resolve(strict=False)``; missing/wrong-type evidence is
+silently treated as "no override". The tool executor itself does NO
+validation — the trust is anchored at the resolver.
+
+# Test surface (3 AST pins + 6 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_EXECUTOR_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance" / "tool_executor.py"
+)
+PROVIDERS_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance" / "providers.py"
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_tool_loop_run_accepts_repo_root_override() -> None:
+    """``ToolLoopCoordinator.run()`` must declare a
+    ``repo_root_override`` parameter. Without it the provider can't
+    pass the envelope's worktree path through, and the
+    bt-2026-05-25-060538 NOOP wiring trap is open."""
+    tree = _parse(TOOL_EXECUTOR_FILE)
+    coordinator = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "ToolLoopCoordinator":
+            coordinator = node
+            break
+    assert coordinator is not None, "ToolLoopCoordinator not found"
+    run_method = None
+    for sub in coordinator.body:
+        if isinstance(sub, ast.AsyncFunctionDef) and sub.name == "run":
+            run_method = sub
+            break
+    assert run_method is not None, "ToolLoopCoordinator.run not found"
+    arg_names = [a.arg for a in run_method.args.args] + [
+        a.arg for a in run_method.args.kwonlyargs
+    ]
+    assert "repo_root_override" in arg_names, (
+        "ToolLoopCoordinator.run signature missing repo_root_override "
+        "kwarg — Slice 3G wiring incomplete."
+    )
+
+
+def test_ast_pin_tool_loop_run_honors_override_in_body() -> None:
+    """The ``run()`` body must reference ``repo_root_override`` AND
+    assign to ``repo_root`` based on it. Without the body wiring the
+    parameter is decorative — the policy.repo_root_for(repo) fallback
+    still wins."""
+    tree = _parse(TOOL_EXECUTOR_FILE)
+    coordinator = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "ToolLoopCoordinator":
+            coordinator = node
+            break
+    assert coordinator is not None
+    run_method = None
+    for sub in coordinator.body:
+        if isinstance(sub, ast.AsyncFunctionDef) and sub.name == "run":
+            run_method = sub
+            break
+    assert run_method is not None
+    body_src = ast.unparse(run_method)
+    assert "repo_root_override" in body_src, (
+        "run() body does not reference repo_root_override"
+    )
+    # The override branch MUST assign to repo_root — otherwise the
+    # parameter exists but doesn't influence behavior.
+    assert "repo_root = Path(repo_root_override)" in body_src, (
+        "run() body does not assign repo_root from override — Slice 3G "
+        "wiring is decorative; legacy fallback still wins."
+    )
+
+
+def test_ast_pin_providers_compose_resolve_envelope_repo_root() -> None:
+    """Both provider call sites (ClaudeProvider + PrimeProvider) must
+    compose ``resolve_envelope_repo_root`` AND pass
+    ``repo_root_override=`` to ``_tool_loop.run()``. Without this the
+    coordinator's new kwarg is never set — Slice 3G is dead."""
+    src = PROVIDERS_FILE.read_text()
+    # Both sites use the same import shape
+    assert (
+        "resolve_envelope_repo_root as _resolve_evidence_root" in src
+    ), (
+        "providers.py is missing the canonical resolver import — "
+        "Slice 3G providers wiring incomplete."
+    )
+    # Both call sites must pass repo_root_override
+    assert (
+        src.count("repo_root_override=_evidence_override") >= 2
+    ), (
+        "providers.py has fewer than 2 sites passing "
+        "repo_root_override — expected exactly 2 (Claude + Prime)."
+    )
+    # Both sites must consume intake_evidence_json
+    assert src.count("intake_evidence_json") >= 2, (
+        "providers.py missing intake_evidence_json consumption at "
+        "both call sites."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 6
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_resolve_envelope_repo_root_handles_swebench_evidence() -> None:
+    """The canonical resolver accepts the SWE-Bench-Pro envelope shape
+    (evidence dict with ``repo_root`` key) and returns the resolved
+    Path when the worktree exists under an allowed prefix."""
+    import json
+    import tempfile
+    from backend.core.ouroboros.governance.operation_advisor import (
+        resolve_envelope_repo_root,
+    )
+    with tempfile.TemporaryDirectory() as tmp_root:
+        # Build the SWE-Bench-Pro envelope shape
+        worktree = Path(tmp_root) / "swebp_wt" / "instance_ansible"
+        worktree.mkdir(parents=True)
+        evidence_json = json.dumps({"repo_root": str(worktree)})
+        # project_root = the host JARVIS repo (or here, the temp root
+        # so the allowlist accepts the worktree)
+        result = resolve_envelope_repo_root(
+            evidence_json,
+            project_root=Path(tmp_root),
+        )
+        assert result is not None, (
+            "Canonical resolver failed to accept a valid worktree "
+            "under the allowlist anchor"
+        )
+        assert result == worktree.resolve()
+
+
+def test_spine_resolve_returns_none_for_empty_evidence() -> None:
+    """Empty / malformed / missing-key evidence returns None gracefully.
+    The Slice 3G code path treats None as 'no override' — preserves
+    byte-identical legacy behavior for non-SWE-Bench-Pro ops."""
+    from backend.core.ouroboros.governance.operation_advisor import (
+        resolve_envelope_repo_root,
+    )
+    # Empty string
+    assert resolve_envelope_repo_root("", project_root=Path(".")) is None
+    # Malformed JSON
+    assert (
+        resolve_envelope_repo_root("not-json", project_root=Path("."))
+        is None
+    )
+    # Wrong type (not a dict)
+    assert (
+        resolve_envelope_repo_root('"a-string"', project_root=Path("."))
+        is None
+    )
+    # Dict without repo_root key
+    assert (
+        resolve_envelope_repo_root('{"other": "x"}', project_root=Path("."))
+        is None
+    )
+
+
+def test_spine_resolve_rejects_path_outside_allowlist() -> None:
+    """The resolver's allowlist contract: paths that don't resolve
+    under ``project_root`` (or env-derived extra prefixes) are
+    rejected. This is the security boundary Slice 3G inherits — no
+    arbitrary-path override attacks."""
+    import json
+    import tempfile
+    import os
+    from backend.core.ouroboros.governance.operation_advisor import (
+        resolve_envelope_repo_root,
+    )
+    with tempfile.TemporaryDirectory() as outside_anchor, \
+         tempfile.TemporaryDirectory() as escape_target:
+        # Clear any env-derived allowlist for this test
+        # (JARVIS_ADVISOR_WORKTREE_AWARE_ALLOWLIST may otherwise let it through)
+        saved = os.environ.pop(
+            "JARVIS_ADVISOR_WORKTREE_AWARE_ALLOWLIST", None,
+        )
+        try:
+            # Anchor is outside_anchor; evidence points elsewhere
+            evidence_json = json.dumps({"repo_root": str(escape_target)})
+            result = resolve_envelope_repo_root(
+                evidence_json,
+                project_root=Path(outside_anchor),
+            )
+            # Should be rejected (escape_target NOT under outside_anchor)
+            assert result is None, (
+                "Resolver accepted a path outside the allowlist — "
+                "security boundary breached."
+            )
+        finally:
+            if saved is not None:
+                os.environ["JARVIS_ADVISOR_WORKTREE_AWARE_ALLOWLIST"] = saved
+
+
+def test_spine_resolve_explicit_allowlist_accepts_worktree() -> None:
+    """When the caller supplies ``extra_allowlist`` explicitly,
+    paths under those prefixes are accepted even if outside
+    project_root. Production providers can use this to whitelist
+    ``JARVIS_SWE_BENCH_PRO_WORKTREE_BASE_PATH`` (= ``/tmp/swebp_wt``)."""
+    import json
+    import tempfile
+    from backend.core.ouroboros.governance.operation_advisor import (
+        resolve_envelope_repo_root,
+    )
+    with tempfile.TemporaryDirectory() as proj, \
+         tempfile.TemporaryDirectory() as wt_base:
+        worktree = Path(wt_base) / "instance_ansible"
+        worktree.mkdir()
+        evidence_json = json.dumps({"repo_root": str(worktree)})
+        result = resolve_envelope_repo_root(
+            evidence_json,
+            project_root=Path(proj),
+            extra_allowlist=(Path(wt_base).resolve(),),
+        )
+        assert result is not None and result == worktree.resolve()
+
+
+def test_spine_resolve_handles_nonexistent_path() -> None:
+    """Paths that don't exist on disk → None. The worktree must
+    actually be there for the override to fire — defends against
+    stale envelope state."""
+    import json
+    from backend.core.ouroboros.governance.operation_advisor import (
+        resolve_envelope_repo_root,
+    )
+    evidence_json = json.dumps(
+        {"repo_root": "/nonexistent/path/to/worktree"}
+    )
+    result = resolve_envelope_repo_root(
+        evidence_json,
+        project_root=Path("/"),
+    )
+    assert result is None
+
+
+def test_spine_tool_loop_signature_keyword_compatible() -> None:
+    """The new ``repo_root_override`` kwarg must be keyword-only or
+    have a default — existing callers (test suites, alternate provider
+    impls) that don't know about it must continue to work
+    byte-identically. Verified via signature inspection."""
+    from backend.core.ouroboros.governance.tool_executor import (
+        ToolLoopCoordinator,
+    )
+    import inspect
+    sig = inspect.signature(ToolLoopCoordinator.run)
+    assert "repo_root_override" in sig.parameters, (
+        "ToolLoopCoordinator.run signature missing the new parameter"
+    )
+    param = sig.parameters["repo_root_override"]
+    assert param.default is None, (
+        f"repo_root_override default is {param.default!r}, expected "
+        f"None to preserve byte-identical legacy behavior for "
+        f"callers that don't pass it."
+    )


### PR DESCRIPTION
feat(governance): Slice 3G — Envelope-override repo_root for per-op worktrees (fix harness wiring)

Closes the harness wiring bug surfaced by the bt-2026-05-25-060538
NOOP autopsy: SWE-Bench-Pro ops carry their per-instance worktree
path via ``envelope.evidence.repo_root`` (e.g. ``/tmp/swebp_wt/
instance_ansible__.../``), but ``ToolLoopCoordinator.run()`` was
unconditionally resolving its working directory via
``self._policy.repo_root_for(repo)`` — which only knew about the host
JARVIS repo. The model's ``read_file`` / ``glob_files`` / ``list_dir``
calls searched the WRONG codebase.

The model's verbatim NOOP reason on that soak (from
``[claude-api] Model returned 2b.1-noop:``):

  "The target file lib/ansible/cli/doc.py does not exist in this
   repository. This is the JARVIS Trinity AI Ecosystem codebase,
   not an Ansible repository. All attempts to locate
   ansible/cli/doc.py via read_file, glob_files, and list_dir
   confirmed the file is absent."

The model was intellectually honest — it refused to hallucinate a
patch for code it couldn't see in its tool environment, and emitted
explicit ``2b.1-noop`` with an accurate diagnostic reason. This is
textbook Iron Gate compliance. **The model correctly diagnosed our
harness wiring bug.** The capability infrastructure is fine; the
plumbing between the SWE-Bench-Pro envelope and the ToolExecutor was
the missing link.

## Fix mechanism — surgical two-site change

### Site 1 — ``tool_executor.py::ToolLoopCoordinator.run()``

Added ``repo_root_override: Optional[Path] = None`` kwarg. When set,
the resolved ``repo_root`` honors it INSTEAD of the
``policy.repo_root_for(repo)`` fallback. Single conditional, three
lines of body:

  if repo_root_override is not None:
      repo_root = Path(repo_root_override)
      logger.info("[ToolLoop] op=%s repo_root override (Slice 3G): %s", ...)

The downstream ``PolicyContext(repo=..., repo_root=...)`` construction
and per-op ``ToolExecutor(repo_root=...)`` cache both read the local
``repo_root`` variable — so the override flows through transparently.
``None`` preserves byte-identical legacy behavior.

### Site 2 — ``providers.py`` (ClaudeProvider + PrimeProvider)

Both ``_tool_loop.run(...)`` call sites now extract the override from
``ctx.intake_evidence_json`` via the pre-existing canonical resolver
``operation_advisor.resolve_envelope_repo_root``:

  _evidence_override = None
  try:
      from backend.core.ouroboros.governance.operation_advisor import (
          resolve_envelope_repo_root as _resolve_evidence_root,
      )
      _evidence_override = _resolve_evidence_root(
          getattr(context, "intake_evidence_json", "") or "",
          project_root=self._repo_root,
      )
  except Exception:
      _evidence_override = None
  raw, tool_records_list = await self._tool_loop.run(
      ..., repo_root_override=_evidence_override,
  )

## Why compose ``resolve_envelope_repo_root`` instead of writing a new resolver

The canonical helper already exists in ``operation_advisor.py``,
graduated to default-TRUE on 2026-05-12 for the Advisor's worktree-
aware path. It provides:

  * Env-flag gating (``JARVIS_ADVISOR_WORKTREE_AWARE_ENABLED``)
  * JSON parsing with fail-silent on malformed input
  * Path existence + is-directory validation
  * Allowlist enforcement (anchored to ``project_root`` + env-derived
    extra prefixes) — defeats symlink escape attacks via
    ``Path.resolve(strict=False)``
  * Returns ``None`` on every failure path — caller treats None as
    "no override" and falls back to legacy behavior

Slice 3G composes this verbatim — zero parallel resolver, zero
shared-state mutation, zero new security boundary. The Advisor and
the ToolExecutor now consult the same trusted resolver for the same
question ("is there a per-op worktree override?").

## Operator bindings honored

* **Structural fix, no shortcuts** — composes the canonical resolver;
  one new kwarg with safe default; no env-var band-aid.
* **No hardcoding** — every path goes through the env-flag-gated +
  allowlist-validated resolver. Operators can disable via
  ``JARVIS_ADVISOR_WORKTREE_AWARE_ENABLED=false`` (slice becomes
  no-op, byte-identical to pre-3G).
* **Build cleanly on existing** — leverages 4 already-shipped pieces:
  ``OperationContext.intake_evidence_json`` (the JSON-encoded evidence
  field that ALREADY existed), ``EVIDENCE_REPO_ROOT_KEY`` constant,
  ``resolve_envelope_repo_root`` resolver, ``swe_bench_pro/
  envelope_builder.py:230`` (already stamps the worktree path).
  Slice 3G is the LAST mile that wires these together.
* **No shared-state mutation** — no registration in ``_repo_roots``,
  no per-op cleanup needed, no risk of cross-op leak. The override
  is a per-call parameter that disappears with the call frame.
* **Pure function path** — when caller passes ``None`` (legacy
  behavior), zero new code paths execute.
* **No silent fallback for bad data** — invalid paths / missing
  evidence / disabled flag → ``None`` from resolver → no override →
  legacy fallback. The override path only activates when the
  evidence is valid AND the path resolves under an allowed prefix.
* **AST-pinned** — 3 pins prove (1) ``run()`` signature carries the
  new kwarg, (2) body assigns from it, (3) both provider sites import
  the canonical resolver AND pass the override (count ≥ 2).

## Backward compatibility

* Pre-Slice-3G callers (test suites, alternate provider impls) that
  don't pass ``repo_root_override`` continue to work byte-identically
  via the ``= None`` default.
* Pre-Slice-3G ops without ``ctx.intake_evidence_json`` (legacy
  intake paths) fall through resolver → ``None`` → no override.
* Pre-Slice-3G ops with non-SWE-Bench-Pro envelopes (no
  ``evidence.repo_root`` key) same fallthrough.
* The ``JARVIS_ADVISOR_WORKTREE_AWARE_ENABLED=false`` master flag is
  the global kill switch — when off, resolver always returns None,
  Slice 3G is a no-op everywhere.

## Test surface (3 AST pins + 6 spine, all green; +62 prior 3B/3B.1/3C/3D/3E/3F/teardown)

AST pins (3):
  1. ``ToolLoopCoordinator.run()`` signature has ``repo_root_override``
  2. ``run()`` body assigns ``repo_root = Path(repo_root_override)``
  3. providers.py imports ``resolve_envelope_repo_root`` AND passes
     ``repo_root_override=_evidence_override`` at BOTH call sites
     (count ≥ 2 — Claude + Prime)

Spine (6):
  * SWE-Bench-Pro envelope shape (evidence dict with repo_root key) →
    resolver returns the resolved Path
  * Empty / malformed / wrong-type / missing-key evidence → None
    (legacy behavior preserved)
  * Path outside allowlist → None (security boundary preserved)
  * ``extra_allowlist`` kwarg honored (production providers can
    whitelist ``JARVIS_SWE_BENCH_PRO_WORKTREE_BASE_PATH``)
  * Nonexistent path → None (stale envelope defended)
  * ``ToolLoopCoordinator.run`` signature has the new kwarg with
    default=None (backward compat regression pin)

## Next empirical test

Re-launch the EXACT same $5/3600s capability soak on the ansible
instance. Predicted outcome:

  * Boot + ROUTE complex (same as bt-2026-05-25-060538)
  * GENERATE start → ClaudeProvider extracts evidence_repo_root →
    passes to tool loop
  * ``[ToolLoop] op=op-... repo_root override (Slice 3G): /tmp/swebp_wt/
    instance_ansible__.../`` log line fires
  * Tool calls execute against the ANSIBLE worktree (lib/ansible/cli/
    doc.py NOW visible to read_file / glob_files)
  * Model emits a real RoleMixin refactoring patch (not NOOP)
  * Iron Gate sees exploration records → passes
  * APPLY phase fires (change_engine applies patch to worktree)
  * VERIFY phase runs TestRunner against the failing tests
  * **First true RESOLVED / UNRESOLVED capability signal**

3 files changed, ~390 insertions(+), ~14 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes tool calls to the correct per-op worktree by honoring `envelope.evidence.repo_root`, fixing the NOOP caused by searching the host repo. This unblocks SWE-Bench-Pro runs and keeps legacy behavior when no override is present.

- Bug Fixes
  - Added `repo_root_override` to `ToolLoopCoordinator.run`; when set, it overrides `policy.repo_root_for(repo)`. Default `None` preserves existing behavior.
  - Updated both provider call sites to derive the override from `context.intake_evidence_json` via the canonical `resolve_envelope_repo_root` (env-flag-gated, allowlist-validated, fail-silent).
  - Tool loop now logs the effective override path and executes against the per-instance worktree; incorrect-repo NOOPs are eliminated.
  - Added tests to pin the new kwarg, body assignment, provider wiring, and resolver behavior (valid path, malformed/missing data, allowlist, nonexistent path).

<sup>Written for commit 704a29b094928925d46b04c4261a0e76ba61a660. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57292?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

