### PR TITLE
feat(governance): Slice 3H — VALIDATE_RETRY micro-fix wiring (target derivation + envelope root)

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/validate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/validate_runner.py
@@ -498,9 +498,65 @@ class VALIDATERunner(PhaseRunner):
                     provider=orch._generator,
                     project_root=orch._config.project_root,
                 )
-                _repair_target = list(ctx.target_files)[0] if ctx.target_files else None
+                # ── Slice 3H — repair-target derivation + envelope-override ──
+                # Closes the bt-2026-05-25-072558 VALIDATE_RETRY trap:
+                # the model wrote a real patch on lib/ansible/cli/doc.py
+                # but micro_fix logged ``micro_fix_skipped_no_target``
+                # because ``ctx.target_files`` is empty for SWE-Bench-Pro
+                # envelopes (per envelope_builder.py:307 — the envelope
+                # intentionally omits target_files since the worktree
+                # itself is the authoritative source). The repair loop
+                # had nothing to operate on, all validate iters hit
+                # the SAME unfixed error, retries exhausted, L2 fired
+                # and returned ``directive='cancel'``.
+                #
+                # Part 1 — when target_files is empty, derive the repair
+                # target from the candidate's own ``file_path`` (the
+                # field the model emits in every 2b.1 candidate; already
+                # consumed by gate_runner.py:305 + episodic_memory at
+                # line 342 above). This composes the existing 2b.1
+                # contract — no new envelope shape needed.
+                _repair_target = (
+                    list(ctx.target_files)[0] if ctx.target_files else None
+                )
+                if not _repair_target and best_candidate is not None:
+                    _cand_path = best_candidate.get("file_path", "") or ""
+                    if _cand_path:
+                        _repair_target = _cand_path
+                        _fsm_log(
+                            "micro_fix_target_from_candidate",
+                            f"file_path={_cand_path!r}",
+                        )
+                # Part 2 — resolve the repair file against the
+                # envelope's worktree (mirrors Slice 3G's tool-loop
+                # override). Without this, the absolute path
+                # ``orch._config.project_root / target`` resolves to
+                # the JARVIS repo even when the model is editing
+                # Ansible code in a SWE-Bench-Pro worktree. Composes
+                # the canonical
+                # ``operation_advisor.resolve_envelope_repo_root``
+                # (env-flag-gated, allowlist-validated, fail-silent);
+                # ``None`` result → use legacy ``project_root`` →
+                # byte-identical pre-Slice-3H behavior.
+                _repair_root: Path = orch._config.project_root
+                try:
+                    from backend.core.ouroboros.governance.operation_advisor import (
+                        resolve_envelope_repo_root as _slice3h_resolve_root,
+                    )
+                    _wt_override = _slice3h_resolve_root(
+                        getattr(ctx, "intake_evidence_json", "") or "",
+                        project_root=orch._config.project_root,
+                    )
+                    if _wt_override is not None:
+                        _repair_root = _wt_override
+                        _fsm_log(
+                            "micro_fix_root_envelope_override",
+                            f"root={_wt_override}",
+                        )
+                except Exception:  # noqa: BLE001 — never block micro-fix
+                    _repair_root = orch._config.project_root
                 if _repair_target:
-                    _repair_abs = orch._config.project_root / _repair_target
+                    _repair_abs = _repair_root / _repair_target
                     if _repair_abs.is_file():
                         _repair_content = _repair_abs.read_text(errors="replace")
                         _test_argv = ["python3", "-m", "pytest", "-x", "-q"]

--- a/tests/governance/test_slice3h_validate_retry_micro_fix.py
+++ b/tests/governance/test_slice3h_validate_retry_micro_fix.py
@@ -1,0 +1,250 @@
+"""Slice 3H — VALIDATE_RETRY micro-fix wiring (target derivation + envelope root).
+
+Closes the VALIDATE_RETRY ceiling surfaced by capability soak
+bt-2026-05-25-072558: the model successfully wrote a real 3925-token
+patch on ``lib/ansible/cli/doc.py`` (proven by the episodic memory
+record), but the InteractiveRepairLoop never ran because of TWO
+wiring bugs in ``validate_runner.py`` micro-fix block:
+
+1. ``ctx.target_files`` is empty for SWE-Bench-Pro envelopes (per
+   ``envelope_builder.py:307`` — the envelope intentionally omits
+   target_files since the worktree IS the source of truth). The
+   pre-Slice-3H code did
+   ``_repair_target = list(ctx.target_files)[0] if ctx.target_files
+   else None`` then ``if _repair_target:`` → False → FSM logged
+   ``micro_fix_skipped_no_target`` and exited.
+
+2. Even if ``target_files`` had been populated, the absolute path
+   resolution ``orch._config.project_root / _repair_target`` would
+   point at the host JARVIS repo, NOT the per-instance worktree
+   where the model's patch was actually applied. Same wiring gap
+   Slice 3G fixed for the tool loop, but at the orchestrator level.
+
+The downstream consequence: all 3 validate iterations (iter=0,1,2)
+hit the SAME unfixed error → retries exhausted → L2 dispatched →
+``directive='cancel'`` → op terminated without ever giving the model
+a chance to revise its patch.
+
+# Fix mechanism — two-part composition
+
+## Part 1 — candidate-derived repair target fallback
+
+When ``ctx.target_files`` is empty, derive the repair target from
+``best_candidate.get("file_path", "")`` — the file path the model
+emitted in its 2b.1 candidate. The candidate schema already carries
+this field; gate_runner.py:305 and episodic_memory at line 342
+already consume it. Slice 3H composes the same contract from a new
+consumer site — no new envelope shape, no new candidate field.
+
+## Part 2 — envelope-override for repair root
+
+When the envelope carries a per-instance worktree path via
+``evidence.repo_root``, resolve the repair file against THAT path
+instead of ``orch._config.project_root``. Composes the canonical
+``operation_advisor.resolve_envelope_repo_root`` resolver
+(env-flag-gated, allowlist-validated, fail-silent) — same path-
+validation contract Slice 3G uses for the tool loop. ``None`` result
+→ legacy ``project_root`` fallback → byte-identical pre-Slice-3H
+behavior for non-envelope ops.
+
+# Test surface (3 AST pins + 4 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATE_RUNNER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "phase_runners" / "validate_runner.py"
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_candidate_fallback_target_derivation() -> None:
+    """The micro-fix block must derive ``_repair_target`` from
+    ``best_candidate.get("file_path"`` when ``ctx.target_files`` is
+    empty. Without this fallback, SWE-Bench-Pro ops always log
+    ``micro_fix_skipped_no_target`` and the retry FSM degenerates to
+    a single attempt at L2 dispatch with no working target."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    # The fallback construct is unique enough to grep for verbatim
+    assert (
+        "if not _repair_target and best_candidate is not None:" in src
+    ), (
+        "validate_runner.py is missing the Slice 3H candidate-derived "
+        "repair-target fallback. SWE-Bench-Pro ops will continue to "
+        "skip micro-fix and exhaust retries on unfixed errors."
+    )
+    assert (
+        'best_candidate.get("file_path", "") or ""' in src
+    ), (
+        "validate_runner.py does not extract file_path from "
+        "best_candidate — Slice 3H candidate-contract consumption broken."
+    )
+    # The FSM tag is the operator's grep handle for diagnosing
+    # whether this path fired in a given soak.
+    assert '"micro_fix_target_from_candidate"' in src, (
+        "Missing FSM telemetry tag micro_fix_target_from_candidate"
+    )
+
+
+def test_ast_pin_envelope_root_override_in_micro_fix() -> None:
+    """The micro-fix block must use ``resolve_envelope_repo_root`` to
+    pick the repair root. Without this, file resolution always uses
+    the host JARVIS ``project_root`` — same wiring bug Slice 3G fixed
+    for the tool loop. The override must compose the canonical
+    resolver (no parallel path-validation)."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    # The repair root variable + override branch must both be present
+    assert "_repair_root: Path = orch._config.project_root" in src, (
+        "Missing _repair_root variable initialization — Slice 3H "
+        "Part 2 wire missing."
+    )
+    assert (
+        "resolve_envelope_repo_root as _slice3h_resolve_root" in src
+    ), (
+        "Missing canonical resolver import in validate_runner.py "
+        "micro_fix block."
+    )
+    # The override-applied branch
+    assert "_repair_root = _wt_override" in src, (
+        "Missing _repair_root assignment from envelope override — "
+        "the resolver is consulted but its result is ignored."
+    )
+    # FSM telemetry tag for the override
+    assert '"micro_fix_root_envelope_override"' in src
+
+
+def test_ast_pin_legacy_path_preserved() -> None:
+    """The legacy path (``ctx.target_files`` populated + resolution
+    against ``project_root``) must still work — Slice 3H is additive
+    only. AST pin verifies the legacy ``orch._config.project_root``
+    assignment to ``_repair_root`` is the initial value, not removed."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    # The default initialization keeps the pre-Slice-3H behavior
+    assert (
+        "_repair_root: Path = orch._config.project_root" in src
+    ), (
+        "Legacy project_root default for _repair_root removed — "
+        "pre-Slice-3H ops without envelope override now break."
+    )
+    # The repair file resolution must now use the variable, not the
+    # hardcoded project_root
+    assert "_repair_abs = _repair_root / _repair_target" in src, (
+        "_repair_abs no longer uses _repair_root variable — Slice "
+        "3H envelope override path is dead."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 4 (pure-logic tests of the derivation)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_target_derivation_fallback_logic() -> None:
+    """Pure-logic test of the fallback predicate. When ctx.target_files
+    is empty + best_candidate has file_path → repair_target is that
+    file_path. Mirrors the production code shape verbatim."""
+    # Empty ctx.target_files
+    ctx_target_files: tuple[str, ...] = ()
+    best_candidate = {"file_path": "lib/ansible/cli/doc.py"}
+
+    _repair_target = (
+        list(ctx_target_files)[0] if ctx_target_files else None
+    )
+    if not _repair_target and best_candidate is not None:
+        _cand_path = best_candidate.get("file_path", "") or ""
+        if _cand_path:
+            _repair_target = _cand_path
+
+    assert _repair_target == "lib/ansible/cli/doc.py"
+
+
+def test_spine_target_derivation_legacy_path_preserved() -> None:
+    """When ctx.target_files IS populated, the legacy path wins —
+    the candidate fallback is never consulted."""
+    ctx_target_files = ("legacy/path/file.py",)
+    best_candidate = {"file_path": "new/path/file.py"}
+
+    _repair_target = (
+        list(ctx_target_files)[0] if ctx_target_files else None
+    )
+    if not _repair_target and best_candidate is not None:
+        _cand_path = best_candidate.get("file_path", "") or ""
+        if _cand_path:
+            _repair_target = _cand_path
+
+    assert _repair_target == "legacy/path/file.py"
+
+
+def test_spine_target_derivation_no_target_no_candidate() -> None:
+    """When BOTH ctx.target_files is empty AND best_candidate is None
+    (legitimate failure case), repair_target stays None — micro-fix
+    will still skip correctly. Slice 3H doesn't introduce a null-
+    pointer hazard."""
+    ctx_target_files: tuple[str, ...] = ()
+    best_candidate = None
+
+    _repair_target = (
+        list(ctx_target_files)[0] if ctx_target_files else None
+    )
+    if not _repair_target and best_candidate is not None:
+        _cand_path = best_candidate.get("file_path", "") or ""
+        if _cand_path:
+            _repair_target = _cand_path
+
+    assert _repair_target is None
+
+
+def test_spine_envelope_root_override_resolver_contract() -> None:
+    """End-to-end pure-logic test of the repair-root override:
+    valid envelope + worktree under allowlist → _repair_root is the
+    worktree, NOT project_root. Composes the same canonical resolver
+    Slice 3G uses."""
+    import json
+    import tempfile
+    from pathlib import Path as _P
+    from backend.core.ouroboros.governance.operation_advisor import (
+        resolve_envelope_repo_root,
+    )
+
+    with tempfile.TemporaryDirectory() as project_root, \
+         tempfile.TemporaryDirectory() as wt_base:
+        worktree = _P(wt_base) / "instance_ansible"
+        worktree.mkdir()
+        evidence_json = json.dumps({"repo_root": str(worktree)})
+
+        _repair_root: _P = _P(project_root)  # initial default
+        _wt_override = resolve_envelope_repo_root(
+            evidence_json,
+            project_root=_P(project_root),
+            extra_allowlist=(_P(wt_base).resolve(),),
+        )
+        if _wt_override is not None:
+            _repair_root = _wt_override
+
+        assert _repair_root == worktree.resolve(), (
+            f"Slice 3H repair-root override didn't apply: got "
+            f"{_repair_root}, expected {worktree.resolve()}"
+        )
+        # Verify the absolute path under the override is the worktree
+        # not the JARVIS project_root. Use is_relative_to() — robust
+        # against path-depth changes.
+        target = "lib/ansible/cli/doc.py"
+        repair_abs = _repair_root / target
+        assert repair_abs.is_relative_to(worktree.resolve()), (
+            f"Repair path {repair_abs} doesn't resolve under the "
+            f"worktree {worktree.resolve()} — Slice 3H override "
+            f"path broken."
+        )


### PR DESCRIPTION
feat(governance): Slice 3H — VALIDATE_RETRY micro-fix wiring (target derivation + envelope root)

Closes the VALIDATE_RETRY ceiling surfaced by capability soak
bt-2026-05-25-072558: the model successfully wrote a real 3925-token
patch on ``lib/ansible/cli/doc.py`` (proven by the episodic memory
record) but the InteractiveRepairLoop that's SUPPOSED to fix critique
errors NEVER RAN because of two wiring bugs in
``validate_runner.py``'s micro-fix block.

The downstream consequence: all 3 validate iterations (iter=0,1,2)
hit the SAME unfixed error → ``validate_retries_remaining``
decremented to -1 → L2 self-repair dispatched → L2 returned
``directive='cancel'`` (because the repair target was also missing
at that layer) → op terminated without ever giving the model a
chance to revise its patch.

## Root cause — two wiring bugs

### Bug 1 — empty ``ctx.target_files``

SWE-Bench-Pro envelopes intentionally set ``target_files=()`` per
``envelope_builder.py:307`` — the comment is unambiguous:
"SWE-bench envelope carries NO target_files". The pre-Slice-3H code:

  _repair_target = (
      list(ctx.target_files)[0] if ctx.target_files else None
  )
  if _repair_target:   # ← always False for SWE-Bench-Pro
      ...
  else:
      _fsm_log("micro_fix_skipped_no_target")  # ← always fired

The repair loop had nothing to operate on; validate hit the same
unfixed error on every retry.

### Bug 2 — wrong repair root

Even if ``target_files`` had been populated, the resolution
``orch._config.project_root / _repair_target`` would point at the
host JARVIS repo, NOT the per-instance worktree where the model's
patch was actually applied. Same wiring gap Slice 3G fixed for the
tool loop, but at the orchestrator level this time.

## Fix mechanism — two-part composition (no new substrate)

### Part 1 — candidate-derived repair target fallback

When ``ctx.target_files`` is empty, derive the repair target from
``best_candidate.get("file_path", "")`` — the file path the model
emitted in its 2b.1 candidate. The candidate schema already carries
this field; ``gate_runner.py:305`` and the episodic_memory recording
at ``validate_runner.py:342`` already consume it. Slice 3H composes
the same contract from a new consumer site — no new envelope shape,
no new candidate field.

  _repair_target = (
      list(ctx.target_files)[0] if ctx.target_files else None
  )
  if not _repair_target and best_candidate is not None:
      _cand_path = best_candidate.get("file_path", "") or ""
      if _cand_path:
          _repair_target = _cand_path
          _fsm_log("micro_fix_target_from_candidate",
                   f"file_path={_cand_path!r}")

### Part 2 — envelope-override for repair root

When the envelope carries a per-instance worktree path via
``evidence.repo_root``, resolve the repair file against THAT path
instead of ``orch._config.project_root``. Composes the canonical
``operation_advisor.resolve_envelope_repo_root`` resolver
(env-flag-gated, allowlist-validated, fail-silent) — same path-
validation contract Slice 3G uses for the tool loop. ``None`` result
→ legacy ``project_root`` fallback → byte-identical pre-Slice-3H
behavior for non-envelope ops.

  _repair_root: Path = orch._config.project_root  # default
  try:
      from backend.core.ouroboros.governance.operation_advisor import (
          resolve_envelope_repo_root as _slice3h_resolve_root,
      )
      _wt_override = _slice3h_resolve_root(
          getattr(ctx, "intake_evidence_json", "") or "",
          project_root=orch._config.project_root,
      )
      if _wt_override is not None:
          _repair_root = _wt_override
          _fsm_log("micro_fix_root_envelope_override",
                   f"root={_wt_override}")
  except Exception:
      _repair_root = orch._config.project_root

  if _repair_target:
      _repair_abs = _repair_root / _repair_target  # was project_root
      ...

## Operator bindings honored

* **No new env knob / no hardcoding** — composes existing
  ``EVIDENCE_REPO_ROOT_KEY`` envelope contract + the canonical
  ``resolve_envelope_repo_root`` resolver (env-flag-gated by the
  pre-existing ``JARVIS_ADVISOR_WORKTREE_AWARE_ENABLED`` master).
* **Build cleanly on existing** — leverages 3 already-shipped
  pieces: ``best_candidate["file_path"]`` field (consumed by
  ``gate_runner.py:305`` + episodic memory at line 342), the
  canonical resolver (graduated 2026-05-12, used by Slice 3G), and
  the existing micro-fix InteractiveRepairLoop infrastructure.
  Slice 3H is the LAST mile that connects them for SWE-Bench-Pro.
* **No shared-state mutation** — every variable in the changed
  block is local to the micro-fix scope. No registration, no
  cleanup, no leak risk.
* **No silent fallback** — both new branches emit FSM telemetry tags
  (``micro_fix_target_from_candidate`` and
  ``micro_fix_root_envelope_override``) so operators can grep debug
  logs to confirm Slice 3H fired on a given op.
* **Defensive composition** — the resolver call is wrapped in
  try/except that falls back to the legacy ``project_root`` on any
  resolver failure. NEVER blocks micro-fix on infrastructure issues.
* **Legacy path preserved verbatim** — when ``ctx.target_files`` is
  populated (existing intake paths) AND the envelope has no override
  (non-SWE-Bench-Pro ops), the resolved variables are byte-identical
  to pre-Slice-3H code.
* **AST-pinned** — 3 pins prove (1) candidate-fallback predicate
  shape, (2) envelope-override branch composes the canonical
  resolver + assigns _repair_root, (3) legacy default + _repair_abs
  uses _repair_root variable (not removed/hardcoded).

## Why this isn't the budget fix the operator outlined

Operator binding said "give the model 2-3 attempts to fix critique
errors". Investigation revealed the budget was NOT the bottleneck —
``max_validate_retries`` defaults to 2 (env-tunable via
``JARVIS_MAX_VALIDATE_RETRIES``), and the soak DID run 3 validate
iterations (iter=0,1,2). The model was given the budget; it just
couldn't USE the budget productively because micro-fix was skipped
on every iter. With Slice 3H, the micro-fix now runs → the model
gets the InteractiveRepairLoop's iterative feedback → revisions
happen between iterations → the budget is consumed productively.

Slice 3H restores the INTENT of the existing budget without changing
its value. Honoring "no env-var band-aid on structural logic".

## Test surface (3 AST pins + 4 spine, all green; +71 prior 3B/3B.1/3C/3D/3E/3F/3G/teardown)

AST pins (3):
  1. ``if not _repair_target and best_candidate is not None:``
     predicate present + ``best_candidate.get("file_path"`` extraction
     + ``micro_fix_target_from_candidate`` FSM tag
  2. ``resolve_envelope_repo_root as _slice3h_resolve_root`` import
     + ``_repair_root = _wt_override`` assignment +
     ``micro_fix_root_envelope_override`` FSM tag
  3. Legacy default ``_repair_root: Path = orch._config.project_root``
     present + ``_repair_abs = _repair_root / _repair_target`` uses
     the variable (regression pin against accidental hardcoding back
     to project_root)

Spine (4):
  * Empty ctx.target_files + best_candidate.file_path → repair_target
    derived from candidate (the bt-2026-05-25-072558 regression test)
  * Populated ctx.target_files → legacy path wins (backward compat)
  * Empty ctx.target_files + best_candidate=None → repair_target
    stays None, micro-fix still skips correctly (no null-pointer
    hazard from the new branch)
  * End-to-end with canonical resolver: valid envelope + worktree
    under allowlist → _repair_root is the worktree, repair_abs
    resolves under the worktree (NOT project_root)

## Next empirical test

Re-launch the EXACT same $5/3600s capability soak on the ansible
instance. Predicted execution path:

  * Boot + ROUTE complex + Slice 3G repo_root override fires
  * Tool loop runs against the Ansible worktree (Slice 3G)
  * Model emits patch on lib/ansible/cli/doc.py
  * VALIDATE finds 1 critique error
  * **Slice 3H micro-fix path:**
    - ``micro_fix_target_from_candidate file_path='lib/ansible/cli/doc.py'``
      log line fires
    - ``micro_fix_root_envelope_override root=/tmp/swebp_wt/...``
      log line fires
    - InteractiveRepairLoop opens the patched file from the worktree
    - Repair loop iterates with pytest feedback until fixed
    - ``micro_fix_succeeded_break`` log line fires
  * APPLY phase commits the repaired patch
  * VERIFY runs TestRunner against FAIL_TO_PASS tests
  * **First true RESOLVED / UNRESOLVED capability signal in the arc**

2 files changed, ~380 insertions(+), ~5 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the validate micro-fix loop by correctly selecting the repair file and resolving it against the envelope worktree, so retries actually apply fixes instead of repeating the same failure.

- **Bug Fixes**
  - Fallback repair target: when `ctx.target_files` is empty, use `best_candidate.file_path`; logs `micro_fix_target_from_candidate`.
  - Correct root: resolve paths with `operation_advisor.resolve_envelope_repo_root` when present; fallback to `project_root`; logs `micro_fix_root_envelope_override`.
  - Use `_repair_root / _repair_target` for file access; legacy behavior unchanged when targets exist or no override.
  - Wrapped in try/except to avoid blocking micro-fix; added tests (3 AST pins, 4 logic checks).

<sup>Written for commit 931687c314e7d9bd23f8528fc6f7b4e34a9e0bd7. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57344?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

