### PR TITLE
fix(governance): Slice 3H.1 — failed-candidate propagation to micro-fix

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/validate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/validate_runner.py
@@ -519,14 +519,49 @@ class VALIDATERunner(PhaseRunner):
                 _repair_target = (
                     list(ctx.target_files)[0] if ctx.target_files else None
                 )
-                if not _repair_target and best_candidate is not None:
-                    _cand_path = best_candidate.get("file_path", "") or ""
-                    if _cand_path:
-                        _repair_target = _cand_path
-                        _fsm_log(
-                            "micro_fix_target_from_candidate",
-                            f"file_path={_cand_path!r}",
+                # ── Slice 3H.1 — failed-candidate propagation ──
+                # The bt-2026-05-25-075811 soak proved Slice 3H Part 1's
+                # original predicate ``best_candidate is not None`` was
+                # DEAD on the failed-validation path: ``best_candidate``
+                # is only assigned at line 295-296 of this file when
+                # ``validation.passed`` is True — but micro-fix runs
+                # precisely when validation FAILED (all candidates rejected
+                # with a critique). The repair module thus saw "no target"
+                # on every iteration even though there WAS a candidate
+                # the model just produced and the validator just critiqued.
+                #
+                # Fallback chain in failure-likelihood order:
+                #   1. ``best_candidate`` (kept first — passed-validation
+                #      pre-existing path; truly was None until Slice 3H.1
+                #      proved insufficient on its own)
+                #   2. ``generation.candidates[0]`` (new — the first
+                #      proposed candidate; in 99% of ops n_cands=1 so this
+                #      IS the candidate that failed validation; for n>1
+                #      the first candidate is also the highest-priority
+                #      one per the candidate ordering contract)
+                #
+                # Both branches feed the same FSM tag with a ``source=``
+                # discriminator so operator grep can attribute correctly.
+                if not _repair_target:
+                    _fallback_cand: Optional[Dict[str, Any]] = None
+                    _fallback_source = ""
+                    if best_candidate is not None:
+                        _fallback_cand = best_candidate
+                        _fallback_source = "best_candidate"
+                    elif generation.candidates:
+                        _fallback_cand = generation.candidates[0]
+                        _fallback_source = "generation_candidates_first"
+                    if _fallback_cand is not None:
+                        _cand_path = (
+                            _fallback_cand.get("file_path", "") or ""
                         )
+                        if _cand_path:
+                            _repair_target = _cand_path
+                            _fsm_log(
+                                "micro_fix_target_from_candidate",
+                                f"file_path={_cand_path!r} "
+                                f"source={_fallback_source}",
+                            )
                 # Part 2 — resolve the repair file against the
                 # envelope's worktree (mirrors Slice 3G's tool-loop
                 # override). Without this, the absolute path

--- a/tests/governance/test_slice3h1_failed_candidate_fallback.py
+++ b/tests/governance/test_slice3h1_failed_candidate_fallback.py
@@ -1,0 +1,225 @@
+"""Slice 3H.1 — failed-candidate propagation to micro-fix.
+
+Closes the dead-code path in Slice 3H Part 1 surfaced by capability
+soak bt-2026-05-25-075811. Soak proved Slice 3H Part 2
+(``micro_fix_root_envelope_override``) fires correctly, but Part 1
+(``micro_fix_target_from_candidate``) was DEAD on the failed-
+validation path that micro-fix actually runs from.
+
+# Root cause
+
+``best_candidate`` is assigned in ``validate_runner.py:295-296`` ONLY
+when ``validation.passed`` is True::
+
+    if validation.passed and best_candidate is None:
+        best_candidate = candidate
+
+But micro-fix runs precisely when validation FAILED (the entire
+purpose of the InteractiveRepairLoop is to fix critique errors). So
+``best_candidate`` is None at the time Slice 3H's predicate
+``if not _repair_target and best_candidate is not None`` evaluates,
+the candidate fallback never fires, ``_repair_target`` stays None,
+and ``micro_fix_skipped_no_target`` logs every iteration.
+
+The candidate the model emitted IS in scope as
+``generation.candidates`` — the validator just ran against it. We
+just need to fall back to ``generation.candidates[0]`` when
+``best_candidate`` is None.
+
+# Fix mechanism — two-step fallback chain
+
+The predicate now walks a documented fallback chain:
+
+  1. ``best_candidate`` (kept first — preserves the passed-validation
+     path that pre-existed)
+  2. ``generation.candidates[0]`` (new — the candidate the validator
+     just critiqued)
+
+Both branches emit the same FSM telemetry tag
+(``micro_fix_target_from_candidate``) with a ``source=`` discriminator
+(``best_candidate`` or ``generation_candidates_first``) so operator
+grep can attribute the path correctly.
+
+# Test surface (2 AST pins + 4 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATE_RUNNER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "phase_runners" / "validate_runner.py"
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_fallback_chain_includes_generation_candidates() -> None:
+    """The micro-fix block must reference ``generation.candidates``
+    in the fallback chain. Without it, the failed-validation path
+    silently re-creates the bt-2026-05-25-075811 dead-code trap."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    assert "elif generation.candidates:" in src, (
+        "validate_runner.py micro-fix is missing the "
+        "generation.candidates fallback branch — Slice 3H.1 trap "
+        "is open."
+    )
+    assert "_fallback_cand = generation.candidates[0]" in src, (
+        "validate_runner.py does not assign generation.candidates[0] "
+        "to the fallback — Slice 3H.1 logic broken."
+    )
+    assert '"generation_candidates_first"' in src, (
+        "Missing source discriminator 'generation_candidates_first' "
+        "in FSM telemetry — operator grep cannot distinguish paths."
+    )
+
+
+def test_ast_pin_best_candidate_first_in_chain() -> None:
+    """``best_candidate`` must be checked FIRST in the fallback chain.
+    This preserves the rare passed-validation path that originally
+    motivated Slice 3H Part 1, and matches the operator's documented
+    fallback order: documented source → known source → discovered
+    source."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    # best_candidate must appear in the same fallback structure
+    # BEFORE the elif generation.candidates branch
+    bc_idx = src.find("if best_candidate is not None:")
+    elif_idx = src.find("elif generation.candidates:")
+    assert bc_idx >= 0, "best_candidate branch missing"
+    assert elif_idx >= 0, "elif generation.candidates branch missing"
+    assert bc_idx < elif_idx, (
+        "best_candidate must be checked BEFORE generation.candidates "
+        "fallback — Slice 3H.1 chain ordering broken."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 4 (pure-logic tests of the fallback chain)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_failed_validation_path_resolves_target() -> None:
+    """THE bt-2026-05-25-075811 regression test. ctx.target_files empty
+    + best_candidate=None (failed validation) + generation.candidates
+    has one entry → repair_target derived from candidates[0]."""
+
+    class _G:
+        candidates = ({"file_path": "lib/ansible/cli/doc.py"},)
+
+    ctx_target_files: tuple[str, ...] = ()
+    best_candidate = None  # validation FAILED — bc is None
+    generation = _G()
+
+    _repair_target = (
+        list(ctx_target_files)[0] if ctx_target_files else None
+    )
+    if not _repair_target:
+        _fallback_cand = None
+        _fallback_source = ""
+        if best_candidate is not None:
+            _fallback_cand = best_candidate
+            _fallback_source = "best_candidate"
+        elif generation.candidates:
+            _fallback_cand = generation.candidates[0]
+            _fallback_source = "generation_candidates_first"
+        if _fallback_cand is not None:
+            _cand_path = _fallback_cand.get("file_path", "") or ""
+            if _cand_path:
+                _repair_target = _cand_path
+
+    assert _repair_target == "lib/ansible/cli/doc.py"
+    assert _fallback_source == "generation_candidates_first"
+
+
+def test_spine_best_candidate_wins_when_present() -> None:
+    """When best_candidate IS set (passed-validation path), it wins
+    over generation.candidates — backward compatibility with Slice 3H
+    pre-3H.1 semantics."""
+
+    class _G:
+        candidates = ({"file_path": "second/choice.py"},)
+
+    ctx_target_files: tuple[str, ...] = ()
+    best_candidate = {"file_path": "first/choice.py"}
+    generation = _G()
+
+    _repair_target = None
+    _fallback_cand = None
+    _fallback_source = ""
+    if best_candidate is not None:
+        _fallback_cand = best_candidate
+        _fallback_source = "best_candidate"
+    elif generation.candidates:
+        _fallback_cand = generation.candidates[0]
+        _fallback_source = "generation_candidates_first"
+    if _fallback_cand is not None:
+        _repair_target = _fallback_cand.get("file_path", "")
+
+    assert _repair_target == "first/choice.py"
+    assert _fallback_source == "best_candidate"
+
+
+def test_spine_empty_candidates_yields_no_target() -> None:
+    """Defense-in-depth: when BOTH best_candidate is None AND
+    generation.candidates is empty (theoretical edge — provider
+    returned zero candidates), repair_target stays None and
+    micro-fix still skips correctly — no null-pointer hazard from
+    the new branch."""
+
+    class _G:
+        candidates = ()
+
+    best_candidate = None
+    generation = _G()
+
+    _fallback_cand = None
+    _fallback_source = ""
+    if best_candidate is not None:
+        _fallback_cand = best_candidate
+        _fallback_source = "best_candidate"
+    elif generation.candidates:
+        _fallback_cand = generation.candidates[0]
+        _fallback_source = "generation_candidates_first"
+
+    assert _fallback_cand is None
+    assert _fallback_source == ""
+
+
+def test_spine_ctx_target_files_short_circuits_fallback() -> None:
+    """When ctx.target_files IS populated (legacy intake path), the
+    fallback chain never executes — the legacy target wins. Backward
+    compatibility regression pin."""
+
+    class _G:
+        candidates = ({"file_path": "fallback/should/not/win.py"},)
+
+    ctx_target_files = ("legacy/explicit/target.py",)
+    best_candidate = None
+    generation = _G()
+
+    _repair_target = (
+        list(ctx_target_files)[0] if ctx_target_files else None
+    )
+    if not _repair_target:
+        # Fallback chain (should NOT execute here)
+        _fallback_cand = None
+        if best_candidate is not None:
+            _fallback_cand = best_candidate
+        elif generation.candidates:
+            _fallback_cand = generation.candidates[0]
+        if _fallback_cand is not None:
+            _cand_path = _fallback_cand.get("file_path", "") or ""
+            if _cand_path:
+                _repair_target = _cand_path
+
+    assert _repair_target == "legacy/explicit/target.py"

--- a/tests/governance/test_slice3h_validate_retry_micro_fix.py
+++ b/tests/governance/test_slice3h_validate_retry_micro_fix.py
@@ -78,19 +78,30 @@ def test_ast_pin_candidate_fallback_target_derivation() -> None:
     ``micro_fix_skipped_no_target`` and the retry FSM degenerates to
     a single attempt at L2 dispatch with no working target."""
     src = VALIDATE_RUNNER_FILE.read_text()
-    # The fallback construct is unique enough to grep for verbatim
-    assert (
-        "if not _repair_target and best_candidate is not None:" in src
-    ), (
+    # Slice 3H's fallback was originally a single ``best_candidate``
+    # check. Slice 3H.1 expanded it to a two-step chain
+    # (``best_candidate`` → ``generation.candidates[0]``) because
+    # best_candidate is only set on PASSED validations and micro-fix
+    # runs on FAILED ones. The outer predicate is now ``if not
+    # _repair_target:`` with a nested fallback chain inside.
+    assert "if not _repair_target:" in src, (
         "validate_runner.py is missing the Slice 3H candidate-derived "
-        "repair-target fallback. SWE-Bench-Pro ops will continue to "
-        "skip micro-fix and exhaust retries on unfixed errors."
+        "repair-target fallback outer predicate. SWE-Bench-Pro ops "
+        "will continue to skip micro-fix and exhaust retries."
+    )
+    # At minimum the fallback chain must consult best_candidate (the
+    # Slice 3H Part 1 contract — strengthened by Slice 3H.1 with an
+    # additional ``generation.candidates`` branch tested in its own
+    # AST pin file).
+    assert "if best_candidate is not None:" in src, (
+        "validate_runner.py does not check best_candidate in fallback "
+        "chain — Slice 3H Part 1 contract broken."
     )
     assert (
-        'best_candidate.get("file_path", "") or ""' in src
+        '_fallback_cand.get("file_path", "") or ""' in src
     ), (
         "validate_runner.py does not extract file_path from "
-        "best_candidate — Slice 3H candidate-contract consumption broken."
+        "_fallback_cand — Slice 3H candidate-contract consumption broken."
     )
     # The FSM tag is the operator's grep handle for diagnosing
     # whether this path fired in a given soak.


### PR DESCRIPTION
fix(governance): Slice 3H.1 — failed-candidate propagation to micro-fix

Closes the dead-code path in Slice 3H Part 1 surfaced by capability
soak bt-2026-05-25-075811. The soak proved Slice 3H Part 2
(``micro_fix_root_envelope_override``) fires correctly — but Part 1
(``micro_fix_target_from_candidate``) was DEAD on the failed-
validation path that micro-fix actually runs from.

## Root cause

``best_candidate`` is assigned in ``validate_runner.py:295-296`` ONLY
when ``validation.passed`` is True:

  if validation.passed and best_candidate is None:
      best_candidate = candidate

But micro-fix runs precisely when validation FAILED (the entire
purpose of the InteractiveRepairLoop is to fix critique errors). So
``best_candidate`` is None at the time Slice 3H's predicate
``if not _repair_target and best_candidate is not None`` evaluates,
the candidate fallback never fires, ``_repair_target`` stays None,
and ``micro_fix_skipped_no_target`` logs every iteration.

The candidate the model emitted IS in scope as
``generation.candidates`` — the validator just ran against it.

## Fix mechanism — two-step fallback chain

The predicate now walks a documented fallback chain:

  if not _repair_target:
      _fallback_cand: Optional[Dict[str, Any]] = None
      _fallback_source = ""
      if best_candidate is not None:
          _fallback_cand = best_candidate
          _fallback_source = "best_candidate"
      elif generation.candidates:
          _fallback_cand = generation.candidates[0]
          _fallback_source = "generation_candidates_first"
      if _fallback_cand is not None:
          _cand_path = _fallback_cand.get("file_path", "") or ""
          if _cand_path:
              _repair_target = _cand_path
              _fsm_log(
                  "micro_fix_target_from_candidate",
                  f"file_path={_cand_path!r} source={_fallback_source}",
              )

## Order rationale

1. ``best_candidate`` (kept first — preserves the passed-validation
   path that Slice 3H originally targeted; rare but real for ops
   where the first validate iter PASSED but a later one FAILED)
2. ``generation.candidates[0]`` (new — the highest-priority candidate
   the model emitted; in 99% of failed-validation ops n_cands=1 so
   this IS the candidate the validator just critiqued)

Both branches emit the same FSM telemetry tag with a ``source=``
discriminator so operator grep can attribute path attribution.

## Operator bindings honored

* **No new substrate** — composes the existing ``generation.candidates``
  tuple (already populated by GENERATE phase before VALIDATE runs).
  No new envelope shape, no new candidate field.
* **No hardcoding** — fallback chain is dynamic; both sources are
  already produced by the orchestrator's existing phase contract.
* **Backward compatible** — when ``best_candidate`` IS set (the
  legacy Slice 3H path), it still wins. The new ``elif`` branch
  only activates on failed-validation ops.
* **Defense-in-depth** — empty ``generation.candidates`` (theoretical
  edge — provider returned zero candidates) still yields None for
  ``_repair_target`` and micro-fix skips correctly via existing
  ``if _repair_target:`` guard.
* **AST-pinned** — 2 pins: (1) ``elif generation.candidates:`` branch
  present + ``_fallback_cand = generation.candidates[0]`` assignment
  + ``generation_candidates_first`` source tag, (2) ``best_candidate``
  branch comes BEFORE ``elif generation.candidates`` (chain ordering
  invariant).

## Test surface (2 AST pins + 4 spine, all green; +83 prior 3B/3B.1/3C/3D/3E/3F/3G/3H/teardown)

AST pins (2):
  1. Fallback chain references ``generation.candidates[0]`` with the
     ``generation_candidates_first`` source discriminator
  2. ``best_candidate`` branch comes BEFORE ``elif generation.candidates``
     in source order (chain priority preserved)

Spine (4):
  * THE bt-2026-05-25-075811 regression test: empty target_files +
    best_candidate=None + generation.candidates has one entry →
    _repair_target derived from candidates[0], source=
    generation_candidates_first
  * When best_candidate IS set, it wins over generation.candidates
    (backward compatibility)
  * When BOTH best_candidate=None AND generation.candidates=()
    (theoretical edge), repair_target stays None safely
  * When ctx.target_files IS populated (legacy path), the fallback
    chain never executes

## Updated Slice 3H AST pin

The pre-3H.1 AST pin asserted the literal string
``if not _repair_target and best_candidate is not None:`` which no
longer exists (Slice 3H.1 split the predicate). Updated the assertion
to check the new structure: ``if not _repair_target:`` outer + inner
``if best_candidate is not None:`` branch + ``_fallback_cand.get(...)``
extraction.

## Next empirical test

Re-launch the EXACT same $5/3600s capability soak on the ansible
instance. Predicted chain (now COMPLETE):

  1. Slice 3G repo_root override → tool loop on Ansible code
  2. Model emits patch on lib/ansible/cli/doc.py
  3. VALIDATE finds 1 critique error → best_candidate stays None
  4. micro_fix_pre → Slice 3H Part 2 fires
     (micro_fix_root_envelope_override)
  5. **NEW: Slice 3H.1 fires** (micro_fix_target_from_candidate
     file_path='lib/ansible/cli/doc.py'
     source=generation_candidates_first)
  6. InteractiveRepairLoop opens the patched file from the worktree
  7. Repair loop iterates with pytest feedback until fixed
  8. micro_fix_returned fixed=True → micro_fix_succeeded_break
  9. APPLY phase commits the repaired patch
 10. VERIFY runs TestRunner against FAIL_TO_PASS tests
 11. **First true RESOLVED / UNRESOLVED capability signal in the arc**

2 files changed, ~140 insertions(+), ~12 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes micro-fix target selection in Slice 3H.1 so the repair loop runs after failed validation. When there’s no explicit target, we now use `best_candidate` or fall back to `generation.candidates[0]`, with FSM telemetry indicating the source.

- **Bug Fixes**
  - Added a two-step fallback chain: `best_candidate` → `generation.candidates[0]`, setting `_repair_target` and logging `micro_fix_target_from_candidate` with `source=best_candidate|generation_candidates_first`.
  - Preserves legacy behavior: `ctx.target_files` still wins; if both sources are missing, micro-fix skips safely (no new substrate or fields).
  - Tests: added two AST pins and four spine tests to cover the new chain and ordering; updated existing AST assertion to the new `if not _repair_target:` structure.

<sup>Written for commit bdf407e8ead71304d88c2b62b5a809a9682c04be. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57361?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

