### PR TITLE
fix(governance): Slice 3H.2 — pytest cwd via InteractiveRepairLoop construction-order reorder

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/validate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/validate_runner.py
@@ -494,9 +494,49 @@ class VALIDATERunner(PhaseRunner):
                     pass
             try:
                 from backend.core.ouroboros.governance.interactive_repair import InteractiveRepairLoop
+                # ── Slice 3H.2 — resolve repair root BEFORE constructing
+                # the repair loop, so InteractiveRepair's subprocess (which
+                # uses ``cwd=str(self._project_root)``) executes pytest in
+                # the per-instance worktree, not the host JARVIS repo.
+                #
+                # Closes bt-2026-05-25-082441: the prior soak proved every
+                # other wire (Slice 3G repo_root override, Slice 3H Part 1+2,
+                # Slice 3H.1 candidate fallback) was correct, and
+                # ``InteractiveRepair`` actually RAN (no "disabled" log) —
+                # but it bailed every iter at the hard-guard
+                # (``error_type=UnknownError or line_number <= 0``) because
+                # pytest was running in the JARVIS cwd, finding JARVIS tests,
+                # not seeing any failure attributable to the model's patch
+                # on ``lib/ansible/cli/doc.py``. The error parser's regex
+                # for ``File "..." line N`` never matched JARVIS output
+                # against an Ansible code path → UnknownError → break.
+                #
+                # The fix: resolve the envelope-override root FIRST, then
+                # construct the loop with that root. ``self._project_root``
+                # inside InteractiveRepair flows directly to
+                # ``cwd=str(self._project_root)`` at the
+                # ``asyncio.create_subprocess_exec`` call site — no API
+                # change needed; just feed the right value at construction.
+                _repair_root: Path = orch._config.project_root
+                try:
+                    from backend.core.ouroboros.governance.operation_advisor import (
+                        resolve_envelope_repo_root as _slice3h_resolve_root,
+                    )
+                    _wt_override = _slice3h_resolve_root(
+                        getattr(ctx, "intake_evidence_json", "") or "",
+                        project_root=orch._config.project_root,
+                    )
+                    if _wt_override is not None:
+                        _repair_root = _wt_override
+                        _fsm_log(
+                            "micro_fix_root_envelope_override",
+                            f"root={_wt_override}",
+                        )
+                except Exception:  # noqa: BLE001 — never block micro-fix
+                    _repair_root = orch._config.project_root
                 _repair = InteractiveRepairLoop(
                     provider=orch._generator,
-                    project_root=orch._config.project_root,
+                    project_root=_repair_root,
                 )
                 # ── Slice 3H — repair-target derivation + envelope-override ──
                 # Closes the bt-2026-05-25-072558 VALIDATE_RETRY trap:
@@ -562,34 +602,13 @@ class VALIDATERunner(PhaseRunner):
                                 f"file_path={_cand_path!r} "
                                 f"source={_fallback_source}",
                             )
-                # Part 2 — resolve the repair file against the
-                # envelope's worktree (mirrors Slice 3G's tool-loop
-                # override). Without this, the absolute path
-                # ``orch._config.project_root / target`` resolves to
-                # the JARVIS repo even when the model is editing
-                # Ansible code in a SWE-Bench-Pro worktree. Composes
-                # the canonical
-                # ``operation_advisor.resolve_envelope_repo_root``
-                # (env-flag-gated, allowlist-validated, fail-silent);
-                # ``None`` result → use legacy ``project_root`` →
-                # byte-identical pre-Slice-3H behavior.
-                _repair_root: Path = orch._config.project_root
-                try:
-                    from backend.core.ouroboros.governance.operation_advisor import (
-                        resolve_envelope_repo_root as _slice3h_resolve_root,
-                    )
-                    _wt_override = _slice3h_resolve_root(
-                        getattr(ctx, "intake_evidence_json", "") or "",
-                        project_root=orch._config.project_root,
-                    )
-                    if _wt_override is not None:
-                        _repair_root = _wt_override
-                        _fsm_log(
-                            "micro_fix_root_envelope_override",
-                            f"root={_wt_override}",
-                        )
-                except Exception:  # noqa: BLE001 — never block micro-fix
-                    _repair_root = orch._config.project_root
+                # Part 2 (Slice 3H) — note that ``_repair_root`` is now
+                # resolved ABOVE the InteractiveRepairLoop constructor
+                # (Slice 3H.2 reorder) so the loop's subprocess pytest
+                # invocation lands in the worktree. ``_repair_abs`` below
+                # uses the same resolved root for the patched-file lookup
+                # — single source of truth for both the file system path
+                # and the subprocess cwd.
                 if _repair_target:
                     _repair_abs = _repair_root / _repair_target
                     if _repair_abs.is_file():

--- a/tests/governance/test_slice3h2_pytest_cwd.py
+++ b/tests/governance/test_slice3h2_pytest_cwd.py
@@ -1,0 +1,248 @@
+"""Slice 3H.2 — pytest cwd via InteractiveRepairLoop construction order.
+
+Closes the final wiring seam surfaced by capability soak
+bt-2026-05-25-082441. With ``JARVIS_INTERACTIVE_REPAIR_ENABLED=true``,
+the repair loop actually ran (no "disabled" log) — but it bailed every
+iter at the hard-guard:
+
+  if err.error_type in {"UnknownError", "TimeoutError"} or err.line_number <= 0:
+      logger.warning("[InteractiveRepair] Refusing to patch: ...")
+      break
+
+Root cause: ``_run_and_capture`` invokes pytest via
+``asyncio.create_subprocess_exec`` with ``cwd=str(self._project_root)``
+— the right shape. But ``self._project_root`` was set to
+``orch._config.project_root`` (the host JARVIS repo) at constructor
+time, not the per-instance worktree. Pytest ran in the JARVIS cwd,
+discovered JARVIS tests (not the Ansible tests the patch should have
+affected), produced output with no failure attributable to
+``lib/ansible/cli/doc.py`` — the ``Traceback`` regex never matched
+that path → ``UnknownError`` → hard-guard break.
+
+# Fix mechanism — construction-order reorder
+
+Move ``_repair_root`` resolution ABOVE the ``InteractiveRepairLoop``
+constructor and pass it as ``project_root``:
+
+  _repair_root: Path = orch._config.project_root  # default
+  try:
+      from ...operation_advisor import (
+          resolve_envelope_repo_root as _slice3h_resolve_root,
+      )
+      _wt_override = _slice3h_resolve_root(
+          getattr(ctx, "intake_evidence_json", "") or "",
+          project_root=orch._config.project_root,
+      )
+      if _wt_override is not None:
+          _repair_root = _wt_override
+  except Exception:
+      _repair_root = orch._config.project_root
+
+  _repair = InteractiveRepairLoop(
+      provider=orch._generator,
+      project_root=_repair_root,  # was orch._config.project_root
+  )
+
+No InteractiveRepair API change. The existing
+``cwd=str(self._project_root)`` line at
+``interactive_repair.py:165`` now lands in the worktree.
+
+# Test surface (2 AST pins + 4 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATE_RUNNER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "phase_runners" / "validate_runner.py"
+)
+INTERACTIVE_REPAIR_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "interactive_repair.py"
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_interactive_repair_constructed_with_repair_root() -> None:
+    """``InteractiveRepairLoop(...)`` MUST be constructed with
+    ``project_root=_repair_root`` — NOT ``project_root=
+    orch._config.project_root``. Without this Slice 3H.2 reorder,
+    the subprocess pytest runs in the JARVIS cwd and the
+    bt-2026-05-25-082441 hard-guard trap is open again."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    assert "project_root=_repair_root" in src, (
+        "InteractiveRepairLoop is NOT constructed with _repair_root "
+        "— Slice 3H.2 reorder missing; pytest will run in wrong cwd."
+    )
+    # The InteractiveRepairLoop SPECIFICALLY must not be constructed
+    # with the JARVIS project_root. Other callers of
+    # ``project_root=orch._config.project_root`` (e.g. LSPTypeChecker,
+    # resolve_envelope_repo_root's allowlist anchor) are legitimate
+    # and unaffected — they need the host JARVIS root by design.
+    tree = _parse(VALIDATE_RUNNER_FILE)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name) and not (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "InteractiveRepairLoop"
+        ):
+            # Match either bare name InteractiveRepairLoop(...)
+            # or module.InteractiveRepairLoop(...)
+            if not (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "InteractiveRepairLoop"
+            ):
+                continue
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id != "InteractiveRepairLoop"
+        ):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "project_root":
+                kw_src = ast.unparse(kw.value)
+                assert kw_src != "orch._config.project_root", (
+                    f"InteractiveRepairLoop constructed with "
+                    f"project_root=orch._config.project_root — "
+                    f"Slice 3H.2 reorder regressed."
+                )
+
+
+def test_ast_pin_repair_root_resolved_before_constructor() -> None:
+    """The ``_repair_root`` initialization MUST appear textually BEFORE
+    the ``InteractiveRepairLoop(...)`` constructor. Python evaluates
+    statements in order — without this textual ordering, the loop is
+    constructed with the JARVIS root and the override has no effect
+    on the subprocess cwd."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    repair_root_idx = src.find("_repair_root: Path = orch._config.project_root")
+    constructor_idx = src.find("_repair = InteractiveRepairLoop(")
+    assert repair_root_idx >= 0, "_repair_root init missing"
+    assert constructor_idx >= 0, "InteractiveRepairLoop constructor missing"
+    assert repair_root_idx < constructor_idx, (
+        "_repair_root MUST be initialized BEFORE InteractiveRepairLoop "
+        "construction — Slice 3H.2 ordering invariant broken."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 4
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_interactive_repair_subprocess_uses_self_project_root() -> None:
+    """Verify the subprocess invocation in InteractiveRepair flows
+    ``self._project_root`` to ``cwd=``. This is the contract Slice 3H.2
+    depends on — if InteractiveRepair changes its subprocess invocation
+    to ignore self._project_root, Slice 3H.2's reorder becomes
+    decorative and the bt-2026-05-25-082441 trap reopens."""
+    src = INTERACTIVE_REPAIR_FILE.read_text()
+    assert "cwd=str(self._project_root)" in src, (
+        "InteractiveRepair subprocess no longer uses "
+        "cwd=str(self._project_root) — Slice 3H.2's downstream contract "
+        "is broken. The construction-time override is now ignored."
+    )
+
+
+def test_spine_interactive_repair_loop_stores_project_root() -> None:
+    """End-to-end import + construction test — InteractiveRepairLoop
+    stores the passed ``project_root`` as ``self._project_root`` and
+    that's what the subprocess uses."""
+    from backend.core.ouroboros.governance.interactive_repair import (
+        InteractiveRepairLoop,
+    )
+    from pathlib import Path as _P
+
+    class _StubProvider:
+        async def plan(self, prompt, deadline):  # noqa: D401
+            return "no_op"
+
+    test_root = _P("/some/test/worktree/instance_x")
+    loop = InteractiveRepairLoop(
+        provider=_StubProvider(),
+        project_root=test_root,
+    )
+    assert loop._project_root == test_root, (
+        f"InteractiveRepairLoop did not store project_root verbatim: "
+        f"expected {test_root}, got {loop._project_root}"
+    )
+
+
+def test_spine_repair_root_resolution_pure_logic() -> None:
+    """Pure-logic test of the Slice 3H.2 resolution order — the
+    overridden ``_repair_root`` (the worktree) flows to the
+    constructor, NOT the legacy ``project_root``."""
+    import json
+    import tempfile
+    from pathlib import Path as _P
+    from backend.core.ouroboros.governance.operation_advisor import (
+        resolve_envelope_repo_root,
+    )
+
+    with tempfile.TemporaryDirectory() as proj, \
+         tempfile.TemporaryDirectory() as wt_base:
+        worktree = _P(wt_base) / "instance_ansible"
+        worktree.mkdir()
+        evidence_json = json.dumps({"repo_root": str(worktree)})
+
+        # Mirror the Slice 3H.2 reorder
+        _repair_root: _P = _P(proj)  # default
+        _wt_override = resolve_envelope_repo_root(
+            evidence_json,
+            project_root=_P(proj),
+            extra_allowlist=(_P(wt_base).resolve(),),
+        )
+        if _wt_override is not None:
+            _repair_root = _wt_override
+
+        # Constructor argument = _repair_root (not _P(proj))
+        constructor_arg = _repair_root
+        assert constructor_arg == worktree.resolve(), (
+            f"Slice 3H.2 reorder didn't apply: constructor would "
+            f"receive {constructor_arg}, expected {worktree.resolve()}"
+        )
+        assert constructor_arg != _P(proj), (
+            "Constructor would still get JARVIS root — Slice 3H.2 "
+            "reorder broken."
+        )
+
+
+def test_spine_legacy_fallback_when_no_envelope_override() -> None:
+    """When no envelope override is present (non-SWE-Bench-Pro op),
+    the legacy ``orch._config.project_root`` path is preserved —
+    Slice 3H.2 is additive only."""
+    import json
+    import tempfile
+    from pathlib import Path as _P
+    from backend.core.ouroboros.governance.operation_advisor import (
+        resolve_envelope_repo_root,
+    )
+
+    with tempfile.TemporaryDirectory() as proj:
+        # Empty evidence JSON → resolver returns None → fallback path
+        _repair_root: _P = _P(proj)  # default
+        _wt_override = resolve_envelope_repo_root(
+            "",  # empty evidence
+            project_root=_P(proj),
+        )
+        if _wt_override is not None:
+            _repair_root = _wt_override
+
+        # Legacy: constructor gets the project_root from config
+        assert _repair_root == _P(proj), (
+            "Legacy fallback broken — _repair_root should equal "
+            "project_root when no envelope override"
+        )


### PR DESCRIPTION
fix(governance): Slice 3H.2 — pytest cwd via InteractiveRepairLoop construction-order reorder

Closes the final wiring seam surfaced by capability soak
bt-2026-05-25-082441. With ``JARVIS_INTERACTIVE_REPAIR_ENABLED=true``,
the repair loop actually ran (no "disabled" log) — but it bailed
every iteration at the hard-guard with ``error_type=UnknownError``
because pytest was running in the wrong cwd.

## Root cause

``InteractiveRepair._run_and_capture`` already invokes pytest with
``cwd=str(self._project_root)`` (interactive_repair.py:165) — that's
correct. But ``self._project_root`` came from constructor argument
``project_root=orch._config.project_root`` — the host JARVIS root.

So pytest ran in the JARVIS cwd:
  * Discovered JARVIS tests (not Ansible tests)
  * Produced output with no failure attributable to the model's
    patch on ``lib/ansible/cli/doc.py``
  * The ``re.search(r'File "([^"]+)", line (\d+)', tb_text)`` regex
    in ``_extract_error`` never matched the Ansible path
  * Returned ``UnknownError`` with ``line_number=0``
  * The hard-guard
    ``if err.error_type in {"UnknownError"} or err.line_number <= 0``
    fired ``break`` on every iteration
  * Repair returned ``fixed=False iterations=1``

The Slice 3H Part 2 envelope-override was resolving ``_repair_root``
CORRECTLY (proven by the ``micro_fix_root_envelope_override`` log
line firing with the right worktree path) — but the constructor had
already run with the wrong root by then.

## Fix mechanism — construction-order reorder

Move ``_repair_root`` resolution ABOVE the ``InteractiveRepairLoop``
constructor and pass it as ``project_root``. No API change. The
existing ``cwd=str(self._project_root)`` line at
``interactive_repair.py:165`` now lands in the worktree.

  # ── Slice 3H.2 — resolve repair root BEFORE construction ──
  _repair_root: Path = orch._config.project_root  # default
  try:
      from ...operation_advisor import (
          resolve_envelope_repo_root as _slice3h_resolve_root,
      )
      _wt_override = _slice3h_resolve_root(
          getattr(ctx, "intake_evidence_json", "") or "",
          project_root=orch._config.project_root,
      )
      if _wt_override is not None:
          _repair_root = _wt_override
          _fsm_log("micro_fix_root_envelope_override",
                   f"root={_wt_override}")
  except Exception:
      _repair_root = orch._config.project_root
  _repair = InteractiveRepairLoop(
      provider=orch._generator,
      project_root=_repair_root,  # was orch._config.project_root
  )

The duplicate Part 2 block below the constructor (which originally
did the same resolution AFTER construction) is removed; the
``_repair_root`` variable defined above is the single source of
truth for both the subprocess cwd AND the ``_repair_abs = _repair_root
/ _repair_target`` file lookup.

## Operator bindings honored

* **One-line semantic change** — the resolver block didn't move
  (it's structurally the same), only its TEXTUAL POSITION moved
  above the constructor. The duplicate block below is consolidated
  into a single source of truth.
* **No API change** — InteractiveRepairLoop's constructor signature
  is unchanged; ``_run_and_capture``'s subprocess invocation is
  unchanged; the only delta is the value passed at construction.
* **Build cleanly on existing** — uses Slice 3H Part 2's resolver
  call verbatim; no new env var, no new envelope contract.
* **Pure-function preservation** — when ``resolve_envelope_repo_root``
  returns None (non-SWE-Bench-Pro op), ``_repair_root`` stays at
  the legacy ``orch._config.project_root`` default → byte-identical
  pre-Slice-3H.2 behavior.
* **AST-pinned** — 2 pins prove (1) InteractiveRepairLoop is
  constructed with ``project_root=_repair_root`` (NOT
  ``orch._config.project_root``); (2) ``_repair_root`` initialization
  textually precedes the constructor (statement ordering invariant).
* **Cross-module contract preserved** — Slice 3H.2 depends on
  InteractiveRepair's subprocess using ``cwd=str(self._project_root)``.
  AST-pinned at the InteractiveRepair side too.

## Test surface (2 AST pins + 4 spine, all green; +89 prior 3B/3B.1/3C/3D/3E/3F/3G/3H/3H.1/teardown)

AST pins (2):
  1. validate_runner.py constructs InteractiveRepairLoop with
     ``project_root=_repair_root`` — and the AST walker confirms NO
     ``InteractiveRepairLoop`` call site passes
     ``project_root=orch._config.project_root`` (scoped to the
     constructor — does NOT block legitimate other callers like
     LSPTypeChecker or resolve_envelope_repo_root)
  2. ``_repair_root: Path = orch._config.project_root`` (the
     initialization) appears textually BEFORE the
     ``InteractiveRepairLoop(`` constructor — Python statement order
     invariant

Spine (4):
  * InteractiveRepair subprocess STILL uses
    ``cwd=str(self._project_root)`` (cross-module contract regression
    pin — if this drifts, Slice 3H.2's construction-time override
    becomes decorative)
  * InteractiveRepairLoop stores passed ``project_root`` as
    ``self._project_root`` verbatim (end-to-end import + construction)
  * Pure-logic test of the resolution order: envelope override →
    constructor argument is the worktree, NOT the JARVIS root
  * Legacy fallback: no envelope → constructor gets project_root from
    config (backward compatibility)

## Next empirical test

Re-launch the EXACT same $5/3600s capability soak. Predicted final
execution chain (all 9 slices live):

  1. Slice 3G: tool loop on Ansible code
  2. Model emits patch on lib/ansible/cli/doc.py
  3. Episodic critique recorded
  4. Slice 3H.1: micro_fix_target_from_candidate
     source=generation_candidates_first
  5. **Slice 3H.2 NEW**: InteractiveRepair subprocess uses
     ``cwd=/tmp/swebp_wt/instance_ansible__.../``
  6. Pytest runs Ansible tests, captures the model's-patch failure
     with parseable line number
  7. InteractiveRepair model call generates fix targeted at the
     real line
  8. Repair iterates 2-3 rounds until fixed=True
  9. micro_fix_succeeded_break
 10. APPLY phase commits the repaired patch
 11. VERIFY phase runs TestRunner against FAIL_TO_PASS tests
 12. **First true RESOLVED / UNRESOLVED capability signal**

2 files changed, ~280 insertions(+), ~28 deletions(-)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the repair loop running `pytest` in the wrong cwd by resolving the worktree root before constructing `InteractiveRepairLoop`. This makes pytest run in the envelope worktree and enables targeted repairs instead of bailing with UnknownError.

- Bug Fixes
  - Resolve `_repair_root` via `resolve_envelope_repo_root` before creating `InteractiveRepairLoop`, and pass it as `project_root` so subprocesses use the correct `cwd`.
  - Remove the duplicate post-construction resolver; single source of truth drives both subprocess cwd and patched-file lookup.
  - No API changes; when no override is present, fall back to `orch._config.project_root` (unchanged behavior).
  - Add tests: AST pins for construction ordering and args, plus spine checks for subprocess `cwd`, stored `project_root`, override flow, and legacy fallback.

<sup>Written for commit 0ee79712258f29774096a0cab0a401d9cfe4746c. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57435?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

