### PR TITLE
fix(governance): Slice 4A — L2-local hard-stop subtype narrowing

### DIFF
--- a/backend/core/ouroboros/governance/repair_engine.py
+++ b/backend/core/ouroboros/governance/repair_engine.py
@@ -875,7 +875,30 @@ class RepairEngine:
             # CLASSIFY FAILURE
             # ----------------------------------------------------------------
             classification = self._classifier.classify(svr)
-            if classification.is_non_retryable:
+            # ── Slice 4A — L2-local hard-stop subtype narrowing ──
+            # Closes the bt-2026-05-25-091657 L2-after-1-iter trap:
+            # the failure_classifier flags ``missing_dependency`` and
+            # ``interpreter_mismatch`` as non_retryable for ALL
+            # consumers — sensible for general callers (the operator's
+            # environment IS broken, no LLM can pip-install). But in
+            # L2 repair context the model just edited imports/code in
+            # the worktree, so ``ModuleNotFoundError`` is almost
+            # always a CODE issue the next iteration can fix. The
+            # global classifier semantic is preserved (other consumers
+            # still see is_non_retryable=True); L2 narrows its OWN
+            # hard-stop set to subtypes that no patch could resolve:
+            # ``permission_denied`` and ``port_conflict`` (truly
+            # environmental — wrong umask, OS-level binding, etc.).
+            # ``missing_dependency`` and ``interpreter_mismatch`` fall
+            # through to the normal per-class retry path so L2 uses
+            # its iteration budget to fight through them.
+            _L2_HARD_STOP_ENV_SUBTYPES = frozenset({
+                "permission_denied", "port_conflict",
+            })
+            if (
+                classification.is_non_retryable
+                and classification.env_subtype in _L2_HARD_STOP_ENV_SUBTYPES
+            ):
                 return _stopped(f"non_retryable_env:{classification.env_subtype}")
 
             fail_class = classification.failure_class.value

--- a/tests/governance/test_slice4a_l2_hardening.py
+++ b/tests/governance/test_slice4a_l2_hardening.py
@@ -1,0 +1,190 @@
+"""Slice 4A — L2-local hard-stop subtype narrowing.
+
+Closes the L2-after-1-iter trap surfaced by capability soak
+bt-2026-05-25-091657. With all of Slice 3G/3H/3H.1/3H.2/3H.3 live,
+the InteractiveRepair micro-fix loop now runs productively against
+real Ansible code with parseable pytest errors. The model wrote a
+patch that broke an import (visible in the log:
+``InteractiveRepair Iter 0: fixed ModuleNotFoundError at L122-131``).
+But when L2 dispatched as the deeper repair layer, it bailed after
+ONE iteration with ``stop_reason=non_retryable_env:missing_dependency``
+— the failure_classifier treated ``ModuleNotFoundError`` as a
+non-retryable environment issue.
+
+# Root cause
+
+``failure_classifier.NON_RETRYABLE_ENV_SUBTYPES`` is a global set
+that includes ``missing_dependency``. The semantic is correct for
+operator-facing tools: if your environment is missing torch, no LLM
+can pip-install it. But in L2 repair CONTEXT, the model just edited
+the file's imports / code in the worktree, so ``ModuleNotFoundError``
+is almost always a CODE issue the next iteration can fix.
+
+# Fix mechanism
+
+L2 narrows its OWN hard-stop subtypes to the ones no patch can
+plausibly resolve. The classifier's global semantic is preserved.
+
+  _L2_HARD_STOP_ENV_SUBTYPES = frozenset({
+      "permission_denied", "port_conflict",
+  })
+  if (
+      classification.is_non_retryable
+      and classification.env_subtype in _L2_HARD_STOP_ENV_SUBTYPES
+  ):
+      return _stopped(f"non_retryable_env:{classification.env_subtype}")
+
+``missing_dependency`` and ``interpreter_mismatch`` fall through to
+the existing per-class retry cap (``budget.max_class_retries.get(
+fail_class, 1)``) so L2 uses its iteration budget to fight through.
+
+# Test surface (1 AST pin + 4 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPAIR_ENGINE_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "repair_engine.py"
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PIN — 1
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_l2_hard_stop_subtypes_narrowed() -> None:
+    """L2's bail condition must reference its OWN narrower frozenset,
+    NOT the global ``is_non_retryable`` flag alone. Otherwise
+    ``missing_dependency`` triggers a one-iteration bail and L2's
+    repair budget is wasted."""
+    src = REPAIR_ENGINE_FILE.read_text()
+    # The new local frozenset must be present
+    assert "_L2_HARD_STOP_ENV_SUBTYPES" in src, (
+        "Slice 4A L2-local hard-stop frozenset missing — "
+        "bt-2026-05-25-091657 trap is open."
+    )
+    # Both truly-environmental subtypes must be in the narrowed set
+    assert '"permission_denied"' in src, (
+        "permission_denied missing from L2 hard-stop set"
+    )
+    assert '"port_conflict"' in src, (
+        "port_conflict missing from L2 hard-stop set"
+    )
+    # The bail predicate must AND the narrower set with is_non_retryable
+    assert (
+        "classification.env_subtype in _L2_HARD_STOP_ENV_SUBTYPES" in src
+    ), (
+        "Slice 4A bail predicate does not consult the narrowed set — "
+        "missing_dependency will still trigger early bail."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 4 (each retryable + each hard-stop)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_missing_dependency_no_longer_hard_stops_l2() -> None:
+    """``missing_dependency`` (``ModuleNotFoundError``) must NOT
+    trigger the L2 hard-stop after Slice 4A. The classifier still
+    reports is_non_retryable=True (global semantic preserved), but L2
+    falls through to the per-class retry cap."""
+    from backend.core.ouroboros.governance.failure_classifier import (
+        FailureClassifier,
+        NON_RETRYABLE_ENV_SUBTYPES,
+    )
+
+    class _Stub:
+        stdout = "ModuleNotFoundError: No module named 'foo'"
+        stderr = ""
+        passed = False
+        returncode = 1
+
+    cls = FailureClassifier().classify(_Stub())
+    # Global semantic: is_non_retryable IS True (classifier unchanged)
+    assert cls.env_subtype == "missing_dependency"
+    assert cls.is_non_retryable is True
+    assert "missing_dependency" in NON_RETRYABLE_ENV_SUBTYPES
+
+    # L2-local semantic: missing_dependency NOT in the hard-stop set
+    _L2_HARD_STOP_ENV_SUBTYPES = frozenset({
+        "permission_denied", "port_conflict",
+    })
+    assert cls.env_subtype not in _L2_HARD_STOP_ENV_SUBTYPES, (
+        "missing_dependency in L2 hard-stop set — Slice 4A semantic broken"
+    )
+
+
+def test_spine_permission_denied_still_hard_stops_l2() -> None:
+    """``permission_denied`` IS a truly environmental issue (umask,
+    container constraints, etc.) — no LLM patch can fix it. Slice 4A
+    preserves the hard-stop for this subtype."""
+    _L2_HARD_STOP_ENV_SUBTYPES = frozenset({
+        "permission_denied", "port_conflict",
+    })
+    # Mock the classification result for the L2 predicate
+    is_non_retryable = True
+    env_subtype = "permission_denied"
+    should_bail = (
+        is_non_retryable and env_subtype in _L2_HARD_STOP_ENV_SUBTYPES
+    )
+    assert should_bail, (
+        "permission_denied does NOT hard-stop L2 — operator-environment "
+        "issues should not consume L2 iteration budget"
+    )
+
+
+def test_spine_port_conflict_still_hard_stops_l2() -> None:
+    """``port_conflict`` (e.g., address already in use) is
+    environmental — preserved hard-stop."""
+    _L2_HARD_STOP_ENV_SUBTYPES = frozenset({
+        "permission_denied", "port_conflict",
+    })
+    is_non_retryable = True
+    env_subtype = "port_conflict"
+    should_bail = (
+        is_non_retryable and env_subtype in _L2_HARD_STOP_ENV_SUBTYPES
+    )
+    assert should_bail
+
+
+def test_spine_test_failure_falls_through_to_progress_check() -> None:
+    """Normal ``TEST`` failures (not env-classified) have
+    is_non_retryable=False so the bail predicate is False on the
+    first check (short-circuit) — L2 proceeds to its progress /
+    oscillation / per-class retry checks. Slice 4A doesn't change
+    this path; regression pin."""
+    from backend.core.ouroboros.governance.failure_classifier import (
+        FailureClassifier,
+    )
+
+    class _Stub:
+        stdout = "FAILED tests/test_foo.py::test_bar - AssertionError"
+        stderr = ""
+        passed = False
+        returncode = 1
+
+    cls = FailureClassifier().classify(_Stub())
+    assert cls.is_non_retryable is False, (
+        f"TEST classifier marked is_non_retryable={cls.is_non_retryable} "
+        f"— Slice 4A regression"
+    )
+    # The L2 predicate is False (short-circuit on is_non_retryable=False)
+    _L2_HARD_STOP_ENV_SUBTYPES = frozenset({
+        "permission_denied", "port_conflict",
+    })
+    should_bail = (
+        cls.is_non_retryable
+        and cls.env_subtype in _L2_HARD_STOP_ENV_SUBTYPES
+    )
+    assert should_bail is False


### PR DESCRIPTION
fix(governance): Slice 4A — L2-local hard-stop subtype narrowing (don't bail on missing_dependency)

Closes the L2-after-1-iter trap surfaced by capability soak
bt-2026-05-25-091657. With Slice 3G/3H/3H.1/3H.2/3H.3 all live, the
InteractiveRepair micro-fix loop runs productively against real
Ansible code with parseable pytest errors. The model wrote a patch
that broke an import (the log captured
``InteractiveRepair Iter 0: fixed ModuleNotFoundError at L122-131``).
But when L2 dispatched as the deeper repair layer, it bailed after
ONE iteration with ``stop_reason=non_retryable_env:missing_dependency``
— the failure_classifier treated ``ModuleNotFoundError`` as a
non-retryable environment issue.

## Root cause

``failure_classifier.NON_RETRYABLE_ENV_SUBTYPES`` is a global
frozenset that includes ``missing_dependency``. The semantic is
correct for operator-facing tools: if the user's environment is
missing torch, no LLM can pip-install it. But in L2 REPAIR CONTEXT,
the model just edited the file's imports / code in the worktree, so
``ModuleNotFoundError`` is almost always a CODE issue the next
iteration can fix.

## Fix mechanism — L2-local narrower frozenset

L2 narrows its OWN hard-stop subtypes to the ones no patch can
plausibly resolve. The classifier's global semantic is preserved
(other consumers still see ``is_non_retryable=True``).

  _L2_HARD_STOP_ENV_SUBTYPES = frozenset({
      "permission_denied",  # umask / container constraints
      "port_conflict",      # OS-level binding
  })
  if (
      classification.is_non_retryable
      and classification.env_subtype in _L2_HARD_STOP_ENV_SUBTYPES
  ):
      return _stopped(f"non_retryable_env:{classification.env_subtype}")

``missing_dependency`` (ModuleNotFoundError, No module named ...) and
``interpreter_mismatch`` fall through to the existing per-class
retry cap (``budget.max_class_retries.get(fail_class, 1)``) so L2
uses its iteration budget to fight through them.

## Operator bindings honored

* **No global semantic change** — ``NON_RETRYABLE_ENV_SUBTYPES``
  frozenset and ``ClassificationResult.is_non_retryable`` unchanged.
  Other consumers (sensors, advisor, etc.) still see the original
  classifier output.
* **L2-local override** — the narrower set is defined INSIDE L2's
  ``run()`` method body so its scope is exactly the call boundary
  where the override makes sense.
* **No new env var** — the narrowing is a structural decision
  derived from the L2 invocation context (the model just edited the
  file being tested). No operator tuning needed.
* **AST-pinned** — single comprehensive pin verifies the narrower
  frozenset is present + both env subtypes are explicit + the
  predicate consults the narrowed set.

## Test surface (1 AST pin + 4 spine, all green; +97 prior 3-arc tests)

AST pin: ``_L2_HARD_STOP_ENV_SUBTYPES`` frozenset present with both
truly-environmental subtypes; bail predicate consults the narrowed
set.

Spine:
  * ``missing_dependency`` classifier output: is_non_retryable=True
    (global preserved) BUT not in L2 hard-stop set
  * ``permission_denied`` still hard-stops L2 (regression pin)
  * ``port_conflict`` still hard-stops L2 (regression pin)
  * TEST failures (is_non_retryable=False) short-circuit before the
    subtype check — Slice 4A doesn't affect this path

## Next test — Slice 4B (FAIL_TO_PASS pytest scoping)

Slice 4A removes the L2 bail-on-missing-dep trap. Slice 4B (next PR)
plumbs the ``fail_to_pass`` test list from envelope.evidence into
InteractiveRepair's ``_test_argv`` so pytest targets ONLY the
relevant tests — eliminating noise from the full Ansible suite.
Together: clean signal + iterative L2 → first RESOLVED verdict.

1 file changed (repair_engine.py), ~27 insertions(+), ~2 deletions(-)
+ 1 file added (test_slice4a_l2_hardening.py), ~190 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents L2 from hard-stopping on import-related errors by narrowing its hard-stop env subtypes to truly environmental cases. L2 now keeps iterating on `ModuleNotFoundError` and interpreter mismatches while global classifier semantics stay the same.

- **Bug Fixes**
  - Added an L2-local `_L2_HARD_STOP_ENV_SUBTYPES = {"permission_denied", "port_conflict"}` and bail only when subtype is in this set and `is_non_retryable=True`.
  - `missing_dependency` and `interpreter_mismatch` now go through the normal retry budget; global `NON_RETRYABLE_ENV_SUBTYPES` remains unchanged for other consumers.

- **Tests**
  - Added `tests/governance/test_slice4a_l2_hardening.py` with an AST pin for the narrowed set and predicate.
  - Spine checks: `missing_dependency` no longer hard-stops; `permission_denied` and `port_conflict` still hard-stop; regular test failures are unaffected.

<sup>Written for commit 46287323227ea6422300f110c094d81b4cbe54e1. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57448?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

