### PR TITLE
feat(governance): Slice 4B — FAIL_TO_PASS pytest scoping for InteractiveRepair

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/validate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/validate_runner.py
@@ -613,7 +613,42 @@ class VALIDATERunner(PhaseRunner):
                     _repair_abs = _repair_root / _repair_target
                     if _repair_abs.is_file():
                         _repair_content = _repair_abs.read_text(errors="replace")
+                        # ── Slice 4B — FAIL_TO_PASS pytest scoping ──
+                        # Without scoping, ``pytest -x -q`` runs every
+                        # test in the worktree cwd. For SWE-Bench-Pro
+                        # ops on Ansible (1000s of tests) that produces
+                        # noise unrelated to the model's patch and
+                        # causes the L2 classifier to bail on
+                        # spurious env-flagged failures. The envelope's
+                        # ``fail_to_pass`` evidence (Slice 4B
+                        # envelope_builder addition) is exactly the
+                        # set of tests SWE-Bench-Pro expects to flip
+                        # FAIL→PASS after the fix. Scope pytest to
+                        # those specific tests for a clean signal.
+                        # Empty list → legacy unscoped behavior.
+                        _fail_to_pass: list = []
+                        try:
+                            import json as _json
+                            _evidence = _json.loads(
+                                getattr(ctx, "intake_evidence_json", "") or "{}"
+                            )
+                            if isinstance(_evidence, dict):
+                                _raw = _evidence.get("fail_to_pass") or []
+                                if isinstance(_raw, list):
+                                    _fail_to_pass = [
+                                        str(t) for t in _raw
+                                        if isinstance(t, str) and t
+                                    ]
+                        except (ValueError, TypeError):
+                            _fail_to_pass = []
                         _test_argv = ["python3", "-m", "pytest", "-x", "-q"]
+                        if _fail_to_pass:
+                            _test_argv.extend(_fail_to_pass)
+                            _fsm_log(
+                                "micro_fix_pytest_scoped",
+                                f"n_tests={len(_fail_to_pass)} "
+                                f"first={_fail_to_pass[0]!r}",
+                            )
                         _repair_result = await asyncio.wait_for(
                             _repair.repair(
                                 file_path=str(_repair_target),

--- a/backend/core/ouroboros/governance/swe_bench_pro/envelope_builder.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/envelope_builder.py
@@ -226,6 +226,43 @@ def _build_evidence(
     _fixture_purpose = _meta.get("purpose")
     if not isinstance(_fixture_purpose, str):
         _fixture_purpose = ""
+    # ── Slice 4B — FAIL_TO_PASS test scoping signal ──
+    # Closes the validate-with-noise trap surfaced by capability soak
+    # bt-2026-05-25-091657: with pytest running the FULL Ansible test
+    # suite (no scope), L2's classifier saw unrelated failures and bailed
+    # on missing_dependency (Slice 4A relaxed that, but the root noise
+    # remained). The FAIL_TO_PASS list in ``problem.metadata`` IS the
+    # set of tests SWE-Bench-Pro expects to flip from FAIL→PASS after
+    # the fix — exactly the right scope for InteractiveRepair's pytest
+    # invocation.
+    #
+    # Defensive extraction: ProblemSpec.metadata is forward-compat (any
+    # non-canonical field is preserved verbatim — see dataset_loader.py
+    # line 294-298). Schema variations: ``FAIL_TO_PASS`` (upstream
+    # SWE-Bench convention), ``fail_to_pass`` (Scale AI), occasionally
+    # JSON-encoded strings. The extraction handles all three shapes
+    # and returns an empty list on any failure — downstream consumers
+    # (validate_runner / InteractiveRepair) treat empty list as
+    # "no scoping" (legacy behavior: run all tests in cwd).
+    _f2p_raw = _meta.get("FAIL_TO_PASS") or _meta.get("fail_to_pass")
+    _fail_to_pass: list = []
+    if isinstance(_f2p_raw, (list, tuple)):
+        _fail_to_pass = [str(t) for t in _f2p_raw if isinstance(t, str) and t]
+    elif isinstance(_f2p_raw, str) and _f2p_raw.strip():
+        # Some datasets carry FAIL_TO_PASS as a JSON-encoded string
+        try:
+            import json as _json
+            _parsed = _json.loads(_f2p_raw)
+            if isinstance(_parsed, list):
+                _fail_to_pass = [
+                    str(t) for t in _parsed if isinstance(t, str) and t
+                ]
+        except (ValueError, TypeError):
+            # Plain comma/newline-separated string fallback
+            _fail_to_pass = [
+                t.strip() for t in _f2p_raw.replace(",", "\n").split("\n")
+                if t.strip()
+            ]
     return {
         EVIDENCE_REPO_ROOT_KEY: str(prepared.worktree_path),
         "problem_instance_id": _safe_str(problem.instance_id),
@@ -238,6 +275,9 @@ def _build_evidence(
         "gold_patch_empty": (_gold_patch == ""),
         "real_benchmark": _is_real_benchmark,
         "fixture_purpose": _fixture_purpose,
+        # Slice 4B — test scoping for InteractiveRepair / L2 (empty
+        # list when source dataset omits the field — legacy behavior).
+        "fail_to_pass": _fail_to_pass,
     }
 
 

--- a/tests/governance/test_slice4b_targeted_pytest.py
+++ b/tests/governance/test_slice4b_targeted_pytest.py
@@ -1,0 +1,228 @@
+"""Slice 4B — FAIL_TO_PASS pytest scoping for InteractiveRepair.
+
+Closes the validate-with-noise trap surfaced by capability soak
+bt-2026-05-25-091657. Even with Slice 4A relaxing L2's hard-stop on
+``missing_dependency``, the root noise persists: ``pytest -x -q``
+runs every test in the worktree cwd. For SWE-Bench-Pro ops on Ansible
+(1000s of tests) that produces failures unrelated to the model's
+patch and overwhelms the L2 classifier's signal extraction.
+
+The envelope's ``fail_to_pass`` evidence (this slice) is exactly the
+set of tests SWE-Bench-Pro expects to flip FAIL→PASS after the fix.
+Scope pytest to those tests for a clean signal.
+
+# Plumbing chain
+
+  ProblemSpec.metadata["fail_to_pass"]  (Scale AI extension)
+       ↓
+  envelope_builder._build_evidence(...)
+       ↓
+  envelope.evidence["fail_to_pass"]
+       ↓
+  ctx.intake_evidence_json (JSON-encoded)
+       ↓
+  validate_runner.py reads ctx.intake_evidence_json
+       ↓
+  _test_argv = [..., "pytest", "-x", "-q", *fail_to_pass]
+       ↓
+  InteractiveRepair.run subprocess
+
+# Defensive schema handling
+
+Upstream SWE-Bench-Pro datasets vary on the field name:
+  - ``FAIL_TO_PASS`` (classic SWE-Bench convention, uppercase)
+  - ``fail_to_pass`` (Scale AI snake_case)
+  - JSON-encoded strings (some datasets)
+  - Comma/newline-separated strings (legacy)
+
+envelope_builder normalizes all four to a List[str]. Empty list →
+no scoping → legacy unscoped behavior (byte-identical).
+
+# Test surface (2 AST pins + 5 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENVELOPE_BUILDER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "swe_bench_pro" / "envelope_builder.py"
+)
+VALIDATE_RUNNER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "phase_runners" / "validate_runner.py"
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_envelope_builder_emits_fail_to_pass() -> None:
+    """``_build_evidence`` must add a ``fail_to_pass`` key to the
+    evidence dict. Without it the downstream consumer (validate_runner)
+    sees nothing and falls back to unscoped pytest."""
+    src = ENVELOPE_BUILDER_FILE.read_text()
+    assert '"fail_to_pass":' in src, (
+        "envelope_builder._build_evidence does NOT emit fail_to_pass — "
+        "Slice 4B plumbing chain broken at source."
+    )
+    # Both upstream key shapes (FAIL_TO_PASS + fail_to_pass) must be
+    # consulted from problem.metadata
+    assert 'FAIL_TO_PASS' in src and 'fail_to_pass' in src.lower(), (
+        "envelope_builder doesn't consult both upstream field names"
+    )
+
+
+def test_ast_pin_validate_runner_scopes_pytest_to_fail_to_pass() -> None:
+    """validate_runner.py must extract fail_to_pass from
+    ctx.intake_evidence_json and extend _test_argv with the test list.
+    Without this, the model still sees the full noise of an unscoped
+    pytest run."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    assert "_fail_to_pass" in src, (
+        "validate_runner is missing the _fail_to_pass extraction — "
+        "Slice 4B plumbing chain broken at consumer."
+    )
+    assert "_test_argv.extend(_fail_to_pass)" in src, (
+        "validate_runner does NOT extend _test_argv with fail_to_pass "
+        "list — pytest still runs unscoped."
+    )
+    assert '"micro_fix_pytest_scoped"' in src, (
+        "Missing FSM telemetry tag micro_fix_pytest_scoped"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 5
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_envelope_builder_extracts_fail_to_pass_list() -> None:
+    """When ProblemSpec.metadata has ``fail_to_pass`` as a list,
+    envelope evidence carries it verbatim."""
+    from backend.core.ouroboros.governance.swe_bench_pro.envelope_builder import (
+        _build_evidence,
+    )
+    # Minimal stubs — _build_evidence only needs getattr access
+    class _Problem:
+        instance_id = "test-instance"
+        base_commit = "abc123"
+        repo_url = "https://github.com/x/y.git"
+        gold_patch = "some patch"
+        metadata = {
+            "fail_to_pass": [
+                "tests/test_foo.py::test_one",
+                "tests/test_bar.py::test_two",
+            ],
+        }
+
+    class _Prepared:
+        worktree_path = Path("/tmp/wt/x")
+        branch_name = "swebp/x"
+
+    evidence = _build_evidence(_Problem(), _Prepared())
+    assert evidence["fail_to_pass"] == [
+        "tests/test_foo.py::test_one",
+        "tests/test_bar.py::test_two",
+    ]
+
+
+def test_spine_envelope_builder_extracts_uppercase_field() -> None:
+    """Upstream SWE-Bench datasets use ``FAIL_TO_PASS`` (uppercase).
+    envelope_builder normalizes either case."""
+    from backend.core.ouroboros.governance.swe_bench_pro.envelope_builder import (
+        _build_evidence,
+    )
+
+    class _Problem:
+        instance_id = "test-instance"
+        base_commit = "abc123"
+        repo_url = ""
+        gold_patch = ""
+        metadata = {"FAIL_TO_PASS": ["tests/test_foo.py::test_one"]}
+
+    class _Prepared:
+        worktree_path = Path("/tmp/wt/x")
+        branch_name = "swebp/x"
+
+    evidence = _build_evidence(_Problem(), _Prepared())
+    assert evidence["fail_to_pass"] == ["tests/test_foo.py::test_one"]
+
+
+def test_spine_envelope_builder_handles_json_string() -> None:
+    """Some datasets store fail_to_pass as JSON-encoded string."""
+    from backend.core.ouroboros.governance.swe_bench_pro.envelope_builder import (
+        _build_evidence,
+    )
+
+    class _Problem:
+        instance_id = "x"
+        base_commit = ""
+        repo_url = ""
+        gold_patch = ""
+        metadata = {
+            "fail_to_pass": '["tests/a.py::t1", "tests/b.py::t2"]',
+        }
+
+    class _Prepared:
+        worktree_path = Path("/tmp/wt/x")
+        branch_name = "swebp/x"
+
+    evidence = _build_evidence(_Problem(), _Prepared())
+    assert evidence["fail_to_pass"] == ["tests/a.py::t1", "tests/b.py::t2"]
+
+
+def test_spine_envelope_builder_handles_missing_field() -> None:
+    """Legacy ProblemSpecs (no fail_to_pass key at all) yield an
+    empty list — legacy unscoped pytest behavior preserved."""
+    from backend.core.ouroboros.governance.swe_bench_pro.envelope_builder import (
+        _build_evidence,
+    )
+
+    class _Problem:
+        instance_id = "x"
+        base_commit = ""
+        repo_url = ""
+        gold_patch = ""
+        metadata = {}  # no fail_to_pass
+
+    class _Prepared:
+        worktree_path = Path("/tmp/wt/x")
+        branch_name = "swebp/x"
+
+    evidence = _build_evidence(_Problem(), _Prepared())
+    assert evidence["fail_to_pass"] == []
+
+
+def test_spine_pytest_argv_extension_pure_logic() -> None:
+    """Pure-logic test of the _test_argv extension pattern from
+    validate_runner. Empty list → unchanged argv; non-empty → extended."""
+    # Empty case
+    fail_to_pass: list = []
+    test_argv = ["python3", "-m", "pytest", "-x", "-q"]
+    if fail_to_pass:
+        test_argv.extend(fail_to_pass)
+    assert test_argv == ["python3", "-m", "pytest", "-x", "-q"]
+
+    # Populated case
+    fail_to_pass = [
+        "tests/test_a.py::test_one",
+        "tests/test_b.py::test_two",
+    ]
+    test_argv = ["python3", "-m", "pytest", "-x", "-q"]
+    if fail_to_pass:
+        test_argv.extend(fail_to_pass)
+    assert test_argv == [
+        "python3", "-m", "pytest", "-x", "-q",
+        "tests/test_a.py::test_one",
+        "tests/test_b.py::test_two",
+    ]


### PR DESCRIPTION
feat(governance): Slice 4B — FAIL_TO_PASS pytest scoping for InteractiveRepair

Closes the validate-with-noise trap that survived Slice 4A. Even
with L2's hard-stop on missing_dependency relaxed, the root noise
persists: ``pytest -x -q`` runs every test in the worktree cwd. For
SWE-Bench-Pro ops on Ansible (1000s of tests), most failures are
unrelated to the model's patch — the L2 classifier extracts a random
non-related failure and the repair loop fights the wrong thing.

The envelope's ``fail_to_pass`` evidence (this slice) is exactly the
set of tests SWE-Bench-Pro expects to flip FAIL→PASS after the fix.
Scope pytest to those specific tests for a clean signal.

## Plumbing chain

  ProblemSpec.metadata["fail_to_pass"]   (Scale AI extension)
       ↓
  envelope_builder._build_evidence(...)
       ↓
  envelope.evidence["fail_to_pass"]
       ↓
  ctx.intake_evidence_json (JSON-encoded by intake)
       ↓
  validate_runner.py reads ctx.intake_evidence_json
       ↓
  _test_argv = [..., "pytest", "-x", "-q", *fail_to_pass]
       ↓
  InteractiveRepair subprocess

## Defensive schema handling

Upstream SWE-Bench-Pro datasets vary on the field name and shape.
envelope_builder normalizes ALL four:

  1. ``FAIL_TO_PASS`` — classic SWE-Bench convention (uppercase)
  2. ``fail_to_pass`` — Scale AI snake_case
  3. JSON-encoded strings — some datasets carry it that way
  4. Comma/newline-separated strings — legacy ingest paths

All four collapse to ``List[str]``. Empty list → no scoping →
legacy unscoped pytest (byte-identical pre-Slice-4B behavior).

## Operator bindings honored

* **No new envelope contract** — composes existing
  ``ProblemSpec.metadata`` (forward-compat extension preserved
  verbatim by dataset_loader.py:294-298) + existing
  ``OperationContext.intake_evidence_json`` (Slice 3G plumbing).
  Just one new evidence key.
* **No hardcoding** — defensive multi-shape extraction at the
  envelope-builder layer; consumer just reads the normalized List.
* **Backward compatible** — non-SWE-Bench-Pro envelopes don't have
  ``fail_to_pass`` in evidence → validate_runner's extraction
  returns empty → unscoped pytest fallback (legacy).
* **No silent fallback** — when scoping fires, FSM logs:
  ``micro_fix_pytest_scoped n_tests=N first='tests/...'`` so
  operators can grep debug.log to confirm Slice 4B fired.
* **AST-pinned** — 2 pins: (1) envelope_builder emits the
  ``fail_to_pass`` evidence key; (2) validate_runner extracts +
  extends _test_argv with the list.

## Test surface (2 AST pins + 5 spine, all green; +103 prior tests)

AST pins (2):
  1. envelope_builder._build_evidence emits ``"fail_to_pass":`` key
     AND consults both upstream field names (``FAIL_TO_PASS`` /
     ``fail_to_pass``)
  2. validate_runner extracts ``_fail_to_pass`` AND extends
     ``_test_argv`` AND emits ``micro_fix_pytest_scoped`` FSM tag

Spine (5):
  * envelope_builder extracts list field verbatim
  * envelope_builder normalizes uppercase ``FAIL_TO_PASS``
  * envelope_builder parses JSON-encoded string variants
  * envelope_builder returns empty list when field missing
    (legacy compatibility)
  * Pure-logic test of _test_argv extension pattern

## Next test — combined Slice 4A + 4B detonation

  1. 3G/3H/3H.1/3H.2/3H.3 — model writes patch, micro-fix runs,
     pytest in worktree cwd, parser extracts real errors
  2. **Slice 4B NEW** — pytest scoped to FAIL_TO_PASS tests only →
     clean signal, no Ansible-suite noise
  3. **Slice 4A** — L2 doesn't bail on missing_dependency →
     iterates productively with full budget
  4. Combined: repair loop converges on real fix → APPLY → VERIFY →
     **first true RESOLVED capability verdict**

2 files changed (envelope_builder + validate_runner), ~85 insertions(+), ~1 deletion(-)
+ 1 file added (test_slice4b_targeted_pytest.py), ~210 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes InteractiveRepair’s pytest run to only the tests expected to flip from FAIL→PASS, cutting noise from unrelated failures in large suites. If no tests are provided, behavior stays the same (unscoped pytest).

- **New Features**
  - `envelope_builder.py`: Normalizes `FAIL_TO_PASS`/`fail_to_pass` (list, JSON string, or comma/newline string) into `evidence["fail_to_pass"]` as a `List[str]`.
  - `validate_runner.py`: Reads `ctx.intake_evidence_json`, extracts `fail_to_pass`, and extends the pytest argv with those tests; falls back to legacy unscoped run when empty.
  - Adds FSM log `micro_fix_pytest_scoped` when scoping is applied.
  - Tests added to pin evidence emission and pytest argv scoping and to cover parsing paths.

<sup>Written for commit 93da1134c8e834d0823e0617774cd90b3f67385f. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57449?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

