### PR TITLE
fix(governance): Slice 4C-A — InteractiveRepair subprocess PYTHONPATH injection

### DIFF
--- a/backend/core/ouroboros/governance/interactive_repair.py
+++ b/backend/core/ouroboros/governance/interactive_repair.py
@@ -157,13 +157,64 @@ class InteractiveRepairLoop:
     async def _run_and_capture(
         self, file_path: str, content: str, test_argv: List[str],
     ) -> Optional[ExtractedError]:
-        """Run test argv and extract specific error. Argv-based, no shell."""
+        """Run test argv and extract specific error. Argv-based, no shell.
+
+        Slice 4C-A (2026-05-25) — PYTHONPATH injection. The subprocess
+        inherits the JARVIS Python environment by default, which does
+        NOT have the target project's package installed (no ``pip
+        install -e .`` is run during SWE-Bench-Pro prepare_problem).
+        For Ansible-shape projects (src-layout: package code under
+        ``lib/<pkg>/``), the test file's ``from ansible.cli.doc
+        import ...`` fails with ``ModuleNotFoundError: No module
+        named 'ansible'`` — proven by raw pytest replication from
+        soak bt-2026-05-25-094217.
+
+        Surgical fix: build a per-subprocess env dict that inherits
+        ``os.environ`` and PREPENDS the worktree's canonical Python
+        source roots to ``PYTHONPATH``:
+
+          * ``<repo_root>/lib`` — Ansible / Django / Flask / Pandas
+            convention (separate ``lib/`` source dir)
+          * ``<repo_root>/src`` — modern Python packaging convention
+          * ``<repo_root>`` itself — flat-layout projects (single
+            top-level package dir at repo root)
+
+        All three are prepended (PATHSEP-joined) so pytest finds the
+        package regardless of layout convention. Existing PYTHONPATH
+        (if any) is preserved AFTER the new prepends — operator
+        overrides take precedence on conflicting names but the
+        worktree paths win on absent ones.
+
+        The injection is per-subprocess via ``env=`` kwarg — the
+        parent process's ``os.environ`` is NEVER mutated. Stateless,
+        bleeds zero into other code paths.
+        """
+        # Slice 4C-A — build per-subprocess env with PYTHONPATH override
+        _proj_root = str(self._project_root)
+        _existing_pp = os.environ.get("PYTHONPATH", "")
+        _candidates = [
+            os.path.join(_proj_root, "lib"),
+            os.path.join(_proj_root, "src"),
+            _proj_root,
+        ]
+        # Only include candidate paths that actually exist on disk —
+        # avoids polluting PYTHONPATH with non-existent dirs that would
+        # otherwise become noise in import-error tracebacks.
+        _real = [p for p in _candidates if os.path.isdir(p)]
+        _pythonpath_parts = _real + (
+            [_existing_pp] if _existing_pp else []
+        )
+        _subprocess_env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(_pythonpath_parts),
+        }
         try:
             proc = await asyncio.create_subprocess_exec(
                 *test_argv,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=str(self._project_root),
+                env=_subprocess_env,
             )
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=_MICRO_TIMEOUT_S)
             if proc.returncode == 0:

--- a/tests/governance/test_slice4c_pythonpath_injection.py
+++ b/tests/governance/test_slice4c_pythonpath_injection.py
@@ -1,0 +1,221 @@
+"""Slice 4C-A — PYTHONPATH subprocess injection for InteractiveRepair.
+
+Closes the final environment gap surfaced by raw pytest diagnostic
+from soak bt-2026-05-25-094217. With Slice 3G/3H/3H.1/3H.2/3H.3/4A/4B
+all live and pytest correctly scoped to FAIL_TO_PASS tests, the
+subprocess STILL produced ``ModuleNotFoundError: No module named
+'ansible'`` because the InteractiveRepair subprocess inherited the
+JARVIS Python environment (which doesn't have the target project's
+package installed). For Ansible-shape projects (src-layout: package
+code under ``lib/<pkg>/``), the test file's
+``from ansible.cli.doc import ...`` cannot resolve.
+
+# Fix mechanism — per-subprocess env dict
+
+Build a per-subprocess env dict that inherits ``os.environ`` and
+PREPENDS the worktree's canonical Python source roots to
+``PYTHONPATH``:
+
+  * ``<repo_root>/lib`` — Ansible / Django / Flask / Pandas
+  * ``<repo_root>/src`` — modern Python packaging
+  * ``<repo_root>`` — flat-layout (single top-level package dir)
+
+Only paths that exist on disk are included (avoids noise in tracebacks).
+Pass via ``env=`` kwarg to ``asyncio.create_subprocess_exec`` — the
+parent process's ``os.environ`` is NEVER mutated.
+
+# Empirical proof
+
+Local replication on the bt-2026-05-25-094217 worktree:
+
+  Before: ``ModuleNotFoundError: No module named 'ansible'`` (collection error)
+  After:  ``__________________________ test_rolemixin__build_doc __________________________``
+          (real AssertionError that Slice 3H.3 cascade #4 can parse)
+
+# Test surface (2 AST pins + 5 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INTERACTIVE_REPAIR_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "interactive_repair.py"
+)
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_subprocess_invocation_uses_env_kwarg() -> None:
+    """``asyncio.create_subprocess_exec`` MUST be called with the
+    ``env=`` kwarg pointing to the per-subprocess dict. Without this,
+    the subprocess inherits ``os.environ`` as-is and the PYTHONPATH
+    override is decorative."""
+    src = INTERACTIVE_REPAIR_FILE.read_text()
+    assert "env=_subprocess_env" in src, (
+        "create_subprocess_exec is NOT called with env=_subprocess_env "
+        "— Slice 4C-A injection is dead-coded."
+    )
+    # The subprocess env must compose os.environ as the base layer
+    # (otherwise we'd nuke PATH / HOME / TMPDIR / etc.)
+    assert "**os.environ," in src or "**os.environ\n" in src, (
+        "_subprocess_env does not inherit os.environ — risks "
+        "missing PATH / HOME / TMPDIR for the subprocess."
+    )
+
+
+def test_ast_pin_pythonpath_composes_canonical_layouts() -> None:
+    """The injected PYTHONPATH must include the three canonical Python
+    src layouts: ``lib/`` (Ansible-style), ``src/`` (modern packaging),
+    and the repo root itself (flat layout). Without all three, some
+    project layouts will still fail to import."""
+    src = INTERACTIVE_REPAIR_FILE.read_text()
+    # All three candidate paths must appear in the assembly
+    assert '"lib"' in src, (
+        "PYTHONPATH candidates missing 'lib' — Ansible/Django/Pandas "
+        "src-layout projects won't import"
+    )
+    assert '"src"' in src, (
+        "PYTHONPATH candidates missing 'src' — modern packaging "
+        "layouts won't import"
+    )
+    # Only-existing-paths filter is critical (don't pollute PYTHONPATH
+    # with non-existent dirs)
+    assert "os.path.isdir" in src, (
+        "PYTHONPATH composition does not filter to existing dirs — "
+        "noisy import-error tracebacks under non-conforming repos"
+    )
+    # PATHSEP-joined assembly (so the OS understands the list)
+    assert "os.pathsep.join" in src, (
+        "PYTHONPATH not assembled via os.pathsep.join — invalid format"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 5 (pure-function tests of the assembly)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_pythonpath_assembly_with_all_three_layouts() -> None:
+    """When all three canonical layout dirs exist, all three appear
+    in PYTHONPATH in priority order (lib > src > root)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "lib").mkdir()
+        (root / "src").mkdir()
+
+        # Mirror the production assembly
+        proj_root = str(root)
+        existing_pp = "/some/other/pp"
+        candidates = [
+            os.path.join(proj_root, "lib"),
+            os.path.join(proj_root, "src"),
+            proj_root,
+        ]
+        real = [p for p in candidates if os.path.isdir(p)]
+        parts = real + ([existing_pp] if existing_pp else [])
+        pythonpath = os.pathsep.join(parts)
+
+        assert f"{tmp}/lib" in pythonpath
+        assert f"{tmp}/src" in pythonpath
+        assert tmp in pythonpath
+        assert "/some/other/pp" in pythonpath
+        # Order: lib, src, root, existing
+        idx_lib = pythonpath.find("lib")
+        idx_src = pythonpath.find("src")
+        idx_existing = pythonpath.find("/some/other/pp")
+        assert idx_lib < idx_src < idx_existing
+
+
+def test_spine_pythonpath_skips_nonexistent_dirs() -> None:
+    """Non-existent ``lib/`` and ``src/`` are filtered out — only the
+    repo root itself is in PYTHONPATH for flat-layout projects."""
+    with tempfile.TemporaryDirectory() as tmp:
+        # NO lib/ or src/ created — flat layout
+        proj_root = str(tmp)
+        candidates = [
+            os.path.join(proj_root, "lib"),
+            os.path.join(proj_root, "src"),
+            proj_root,
+        ]
+        real = [p for p in candidates if os.path.isdir(p)]
+        # Only the root exists
+        assert real == [proj_root]
+
+
+def test_spine_pythonpath_preserves_existing() -> None:
+    """Existing ``PYTHONPATH`` (operator-set) is preserved AFTER
+    the new prepends — operator overrides take precedence on
+    conflicting names but worktree paths win on absent ones."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "lib").mkdir()
+        proj_root = str(root)
+        existing_pp = "/operator/custom/path"
+        candidates = [
+            os.path.join(proj_root, "lib"),
+            os.path.join(proj_root, "src"),
+            proj_root,
+        ]
+        real = [p for p in candidates if os.path.isdir(p)]
+        parts = real + ([existing_pp] if existing_pp else [])
+        pythonpath = os.pathsep.join(parts)
+
+        # Existing is preserved at the end
+        assert pythonpath.endswith(existing_pp)
+        # But worktree lib is prepended
+        assert pythonpath.startswith(f"{tmp}/lib")
+
+
+def test_spine_pythonpath_empty_existing_is_ok() -> None:
+    """No PYTHONPATH in parent env → just the worktree candidates."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "lib").mkdir()
+        proj_root = str(root)
+        existing_pp = ""  # parent env didn't set PYTHONPATH
+        candidates = [
+            os.path.join(proj_root, "lib"),
+            os.path.join(proj_root, "src"),
+            proj_root,
+        ]
+        real = [p for p in candidates if os.path.isdir(p)]
+        parts = real + ([existing_pp] if existing_pp else [])
+        pythonpath = os.pathsep.join(parts)
+
+        # No trailing empty entry
+        assert not pythonpath.endswith(os.pathsep)
+        # Worktree lib is in there
+        assert f"{tmp}/lib" in pythonpath
+
+
+def test_spine_subprocess_env_inherits_os_environ() -> None:
+    """The subprocess env dict MUST inherit ``os.environ`` so the
+    subprocess has PATH / HOME / TMPDIR / etc. Without inheritance
+    the subprocess can't find ``python3`` or any system command."""
+    # Mirror the production env-dict construction
+    subprocess_env = {
+        **os.environ,
+        "PYTHONPATH": "/tmp/test",
+    }
+    # Key system vars must be present
+    assert "PATH" in subprocess_env
+    # PYTHONPATH override is the one we set
+    assert subprocess_env["PYTHONPATH"] == "/tmp/test"
+    # Parent os.environ is NOT mutated by dict construction
+    assert os.environ.get("PYTHONPATH", "") != "/tmp/test", (
+        "Parent os.environ was mutated by dict construction — "
+        "the spread+override pattern is broken"
+    )


### PR DESCRIPTION
fix(governance): Slice 4C-A — InteractiveRepair subprocess PYTHONPATH injection

Closes the final environment gap surfaced by raw pytest diagnostic
from soak bt-2026-05-25-094217. With all of 3G/3H/3H.1/3H.2/3H.3/4A/4B
live and pytest correctly scoped to FAIL_TO_PASS tests, the
subprocess STILL failed at collection with
``ModuleNotFoundError: No module named 'ansible'`` because the
InteractiveRepair subprocess inherited the JARVIS Python environment
(which doesn't have the target project's package installed).

Empirical proof — local replication on the same worktree:

  Before:  ModuleNotFoundError: No module named 'ansible'
           (collection error, line_number=0, parser bails)

  After:   __________________________ test_rolemixin__build_doc ____________________
           (real AssertionError that Slice 3H.3 cascade #4 parses cleanly)

## Fix mechanism — per-subprocess env dict

Build a per-subprocess env dict that inherits ``os.environ`` and
PREPENDS the worktree's canonical Python source roots to PYTHONPATH:

  * ``<repo_root>/lib`` — Ansible / Django / Flask / Pandas convention
  * ``<repo_root>/src`` — modern Python packaging convention
  * ``<repo_root>`` itself — flat-layout projects

Only paths that exist on disk are included (avoids polluting PYTHONPATH
with non-existent dirs that become noise in import-error tracebacks).
All three layouts are tried because we have no a-priori way to know
which convention the target repo uses.

  _proj_root = str(self._project_root)
  _existing_pp = os.environ.get("PYTHONPATH", "")
  _candidates = [
      os.path.join(_proj_root, "lib"),
      os.path.join(_proj_root, "src"),
      _proj_root,
  ]
  _real = [p for p in _candidates if os.path.isdir(p)]
  _pythonpath_parts = _real + ([_existing_pp] if _existing_pp else [])
  _subprocess_env = {
      **os.environ,
      "PYTHONPATH": os.pathsep.join(_pythonpath_parts),
  }
  proc = await asyncio.create_subprocess_exec(
      *test_argv,
      stdout=asyncio.subprocess.PIPE,
      stderr=asyncio.subprocess.PIPE,
      cwd=str(self._project_root),
      env=_subprocess_env,  # ← NEW
  )

## Operator bindings honored

* **Stateless** — the env dict is local to the subprocess call.
  The parent process's ``os.environ`` is NEVER mutated. No risk
  of bleeding into the JARVIS test runner or other code paths.
* **No new env knob** — PYTHONPATH composition is derived from
  the worktree path that already flows in via Slice 3H.2's
  reorder. Zero operator configuration.
* **No hardcoding** — three canonical layouts tried in priority
  order; existing-dir filter handles arbitrary project layouts.
* **No pollution** — non-existent ``lib/`` / ``src/`` candidates
  are filtered out via ``os.path.isdir`` so tracebacks stay clean.
* **Existing PYTHONPATH preserved** — operator-set PYTHONPATH is
  appended AFTER the worktree prepends (worktree wins on absent
  packages, operator wins on explicit overrides).
* **AST-pinned** — 2 pins: (1) ``env=_subprocess_env`` kwarg
  present on the ``create_subprocess_exec`` call; (2) all three
  canonical layouts (``lib`` / ``src`` / root) composed via
  ``os.pathsep.join`` with ``os.path.isdir`` filter.

## Empirical evidence

Local replication on the bt-2026-05-25-094217 worktree:

  $ cd /tmp/swebp_wt/instance_ansible__.../
  $ PYTHONPATH="$PWD/lib:$PYTHONPATH" python3 -m pytest -x -q \
        test/units/cli/test_doc.py::test_rolemixin__build_doc

Yields real test execution with a parseable AssertionError. The
Slice 3H.3 cascade #4 (``<path>:<line>: in <fn>`` + ``E   ...``)
matches this output.

## Test surface (2 AST pins + 5 spine, all green; +110 prior arc tests)

AST pins (2):
  1. ``create_subprocess_exec`` call uses ``env=_subprocess_env``
     AND the env dict inherits ``os.environ`` (``**os.environ``)
  2. PYTHONPATH composition includes all three layouts (``lib``,
     ``src``, root) AND filters via ``os.path.isdir`` AND assembles
     via ``os.pathsep.join``

Spine (5):
  * All three layouts present → PYTHONPATH carries lib + src + root
    + existing (in priority order)
  * Non-existent ``lib/`` / ``src/`` → only root in PYTHONPATH (flat
    layout)
  * Existing PYTHONPATH preserved at end of new path
  * Empty existing PYTHONPATH yields no trailing PATHSEP
  * Subprocess env inherits os.environ (PATH preserved) AND parent
    os.environ is NOT mutated by dict construction

## Next test — ULTIMATE detonation v3

Re-launch $5/3600s ansible soak. With Slice 4C-A live the full
expected chain:

  1. 3G repo_root → tool loop on Ansible
  2. Model writes patch on lib/ansible/cli/doc.py
  3. 3H.1 target_from_candidate
  4. 3H Part 2 root_envelope_override
  5. 4B pytest_scoped to FAIL_TO_PASS tests
  6. **NEW 4C-A**: PYTHONPATH includes worktree/lib → ansible IMPORTS
  7. Pytest runs test_rolemixin__build_doc → AssertionError with
     parseable line number
  8. 3H.3 cascade #4 extracts file:line:ErrorClass
  9. InteractiveRepair model call with real feedback
 10. Repair iterates → fix converges
 11. APPLY → VERIFY → **first RESOLVED capability verdict**

1 file changed (interactive_repair.py), ~65 insertions(+), ~2 deletions(-)
+ 1 file added (test_slice4c_pythonpath_injection.py), ~225 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `InteractiveRepair` subprocess import errors by injecting a per-subprocess `PYTHONPATH` that prepends the repo’s `lib/`, `src/`, and root paths when present. This lets `pytest` import the target project (e.g., `ansible`) and return real test failures instead of `ModuleNotFoundError`.

- **Bug Fixes**
  - Build a subprocess env from `**os.environ` and pass it via `env` to `asyncio.create_subprocess_exec`.
  - Prepend existing repo paths to `PYTHONPATH`; keep the original `PYTHONPATH` at the end; skip non-existent dirs.
  - Added AST and functional tests to pin the env injection and path composition.

<sup>Written for commit 112f4828e430d841ca1d949e4cc4ef0988bc8c2e. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57450?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

