### PR TITLE
fix(governance): Slice 5A — L2 per-iter provider isolation + graceful continue on TimeoutError

### DIFF
--- a/backend/core/ouroboros/governance/repair_engine.py
+++ b/backend/core/ouroboros/governance/repair_engine.py
@@ -94,6 +94,15 @@ class RepairBudget:
     max_files_changed: int = 3
     max_total_validation_runs: int = 8
     no_progress_streak_kill: int = 2
+    # Slice 5A — L2 provider isolation: bound each iteration's provider
+    # generate call so a single 118s Claude stream cannot eat the whole
+    # pipeline budget and starve all remaining iters. Default 45s gives
+    # the provider enough headroom for a reasoned patch while leaving
+    # budget for 2-3 more iters under a 120s timebox.
+    per_iter_provider_timeout_s: float = 45.0
+    # Stop the engine if N consecutive iters timeout on the provider
+    # (avoids burning the full timebox on a wedged provider chain).
+    max_consecutive_provider_timeouts: int = 2
     max_class_retries: Dict[str, int] = dataclasses.field(
         default_factory=lambda: {"syntax": 2, "test": 3, "flake": 2, "env": 1}
     )
@@ -130,6 +139,13 @@ class RepairBudget:
         timebox_s = float(os.environ.get("JARVIS_L2_TIMEBOX_S", "120.0"))
         min_deadline_remaining_s = float(os.environ.get("JARVIS_L2_MIN_DEADLINE_S", "10.0"))
         per_iteration_test_timeout_s = float(os.environ.get("JARVIS_L2_ITER_TEST_TIMEOUT_S", "60.0"))
+        # Slice 5A — L2 provider isolation knobs
+        per_iter_provider_timeout_s = float(
+            os.environ.get("JARVIS_L2_PER_ITER_PROVIDER_TIMEOUT_S", "45.0"),
+        )
+        max_consecutive_provider_timeouts = int(
+            os.environ.get("JARVIS_L2_MAX_CONSECUTIVE_PROVIDER_TIMEOUTS", "2"),
+        )
 
         # JSON parsing with fallback to default
         max_class_retries_json = os.environ.get("JARVIS_L2_CLASS_RETRIES_JSON")
@@ -157,6 +173,8 @@ class RepairBudget:
             no_progress_streak_kill=no_progress_streak_kill,
             max_class_retries=max_class_retries,
             flake_confirm_reruns=flake_confirm_reruns,
+            per_iter_provider_timeout_s=per_iter_provider_timeout_s,
+            max_consecutive_provider_timeouts=max_consecutive_provider_timeouts,
         )
 
 
@@ -643,6 +661,10 @@ class RepairEngine:
         prev_failing_count: Optional[int] = None
         prev_failure_class: Optional[str] = None
         total_validation_runs = 0
+        # Slice 5A — track consecutive provider iter timeouts so a wedged
+        # provider chain hard-stops only after N back-to-back timeouts
+        # (default 2) instead of starving the whole timebox on iter 1.
+        consecutive_provider_timeouts = 0
         t_start = time.monotonic()
         records: list = []
         model_id: str = getattr(ctx.generation, "model_id", "")
@@ -706,10 +728,53 @@ class RepairEngine:
                     hypothesis_seed=None,  # LINEAR FSM does not seed
                 )
                 if gen_outcome.candidate is None:
+                    # ──────────────────────────────────────────────────
+                    # Slice 5A — graceful continue on provider iter
+                    # timeout. The pre-5A behavior hard-stopped the
+                    # engine on ANY generate_error stop_reason; the
+                    # bt-2026-05-25-095834 cascade proved that a single
+                    # provider timeout (Claude stream cap) terminated
+                    # the entire L2 loop and chained into the orchestrator
+                    # ForegroundCooldown. Now: if the stop_reason was
+                    # specifically a provider iter timeout (the only
+                    # source of `provider_iter_timeout:` stop_reason
+                    # under Slice 5A), CONTINUE to next iter until N
+                    # consecutive timeouts (max_consecutive_provider_
+                    # timeouts, default 2). All other generate_error
+                    # shapes preserve byte-equivalent hard-stop behavior.
+                    # ──────────────────────────────────────────────────
+                    _is_provider_timeout = (
+                        gen_outcome.stop_reason is not None
+                        and gen_outcome.stop_reason.startswith(
+                            "provider_iter_timeout:",
+                        )
+                    )
+                    if _is_provider_timeout:
+                        consecutive_provider_timeouts += 1
+                        if (
+                            consecutive_provider_timeouts
+                            >= budget.max_consecutive_provider_timeouts
+                        ):
+                            _logger.warning(
+                                "[L2 Repair] hard-stop: %d consecutive "
+                                "provider iter timeouts >= cap %d",
+                                consecutive_provider_timeouts,
+                                budget.max_consecutive_provider_timeouts,
+                            )
+                            return _stopped(
+                                "consecutive_provider_timeouts_exhausted:"
+                                f"{consecutive_provider_timeouts}",
+                            )
+                        # Soft-skip this iter; the next loop entry will
+                        # re-check kill conditions (remaining_s, timebox,
+                        # etc.) before retrying GENERATE.
+                        continue
                     return _stopped(
                         gen_outcome.stop_reason
                         or "generate_error:unknown",
                     )
+                # Reset the counter on any successful provider call.
+                consecutive_provider_timeouts = 0
                 current_candidate = gen_outcome.candidate
                 # Preserve byte-equivalent getattr-with-fallback semantic
                 # — None (sentinel) means "provider response lacked the
@@ -1056,12 +1121,62 @@ class RepairEngine:
         # composes the same _generate_repair_candidate signature.
         del hypothesis_seed  # Phase A: explicitly unused; Phase C owns
 
+        # ──────────────────────────────────────────────────────────────
+        # Slice 5A — L2 provider isolation (bt-2026-05-25-095834 root)
+        #
+        # The naked ``await self._prime.generate(...)`` saw the FULL
+        # pipeline_deadline (e.g. 118s for Claude streaming) and any
+        # single iter could exhaust the entire L2 timebox. The cascade
+        # from bt-2026-05-25-095834: L2 iter 1 timeout → iter 2 generate
+        # eats remaining budget → engine bails → orchestrator
+        # ForegroundCooldown → 16 ops piled up cancelled.
+        #
+        # Fix: wrap with asyncio.wait_for bounded by the L2-local
+        # per_iter_provider_timeout_s (default 45s). The deadline arg
+        # passed to provider stays unchanged so server-side cap still
+        # honors pipeline_deadline as upper bound; the wait_for is a
+        # CLIENT-side narrower bound. Effective bound is the smaller of
+        # (per_iter_provider_timeout_s, remaining_pipeline_seconds) so
+        # the deadline contract is never violated.
+        #
+        # On asyncio.TimeoutError we emit a structured stop_reason
+        # ("provider_iter_timeout:<s>") which the L2 loop classifies
+        # as a SOFT iter failure (continues to next iter via the new
+        # _consecutive_provider_timeouts counter) instead of the
+        # pre-Slice-5A behavior where any generate_error hard-stopped
+        # the engine. Stops only after N consecutive timeouts (budget
+        # field max_consecutive_provider_timeouts, default 2).
+        # ──────────────────────────────────────────────────────────────
+        _per_iter_bound = self._budget.per_iter_provider_timeout_s
+        _now = datetime.now(timezone.utc)
+        _remaining_pipeline_s = (pipeline_deadline - _now).total_seconds()
+        # Honor pipeline_deadline as hard upper bound — never wait_for
+        # longer than the operation's overall remaining budget.
+        _effective_timeout_s = max(
+            1.0, min(_per_iter_bound, _remaining_pipeline_s),
+        )
         try:
-            gen_result = await self._prime.generate(
-                ctx, pipeline_deadline, repair_context=repair_context,
+            gen_result = await asyncio.wait_for(
+                self._prime.generate(
+                    ctx, pipeline_deadline, repair_context=repair_context,
+                ),
+                timeout=_effective_timeout_s,
             )
         except asyncio.CancelledError:
             raise
+        except asyncio.TimeoutError:
+            _logger.warning(
+                "[L2 Repair] provider iter timeout: effective=%.1fs "
+                "per_iter_bound=%.1fs remaining_pipeline=%.1fs — "
+                "continuing to next iter (Slice 5A graceful continue)",
+                _effective_timeout_s, _per_iter_bound, _remaining_pipeline_s,
+            )
+            return CandidateGenerationResult(
+                candidate=None,
+                model_id=None,
+                provider_name=None,
+                stop_reason=f"provider_iter_timeout:{_effective_timeout_s:.1f}s",
+            )
         except Exception as exc:  # noqa: BLE001 — Protocol contract
             return CandidateGenerationResult(
                 candidate=None,

--- a/tests/governance/test_slice5a_l2_provider_isolation.py
+++ b/tests/governance/test_slice5a_l2_provider_isolation.py
@@ -1,0 +1,255 @@
+"""Slice 5A — L2 per-iter provider isolation.
+
+Closes the cascade surfaced by bt-2026-05-25-095834. L2 iter 1's
+provider call (Claude streaming) consumed 118s of the pipeline budget;
+any generate_error stop_reason then hard-stopped the engine; the
+orchestrator cooldown chained 16 orphan ops into cancelled-on-shutdown.
+
+# Fix
+
+  1. Wrap ``self._prime.generate(...)`` in ``asyncio.wait_for`` bounded
+     by ``per_iter_provider_timeout_s`` (default 45s, env-overridable).
+  2. On ``asyncio.TimeoutError``: emit stop_reason
+     ``provider_iter_timeout:<s>`` (does NOT hard-stop the engine).
+  3. Loop classifies ``provider_iter_timeout:`` as a SOFT iter failure —
+     ``continue`` to next iter until N consecutive timeouts.
+  4. After ``max_consecutive_provider_timeouts`` (default 2) consecutive
+     timeouts, hard-stop with ``consecutive_provider_timeouts_exhausted``.
+  5. Any successful provider call resets the consecutive counter.
+
+# Discipline
+
+  * pipeline_deadline still passed through to provider unchanged
+    (server-side cap honors it; wait_for is a narrower CLIENT-side bound)
+  * Effective timeout = ``min(per_iter_provider_timeout_s,
+    remaining_pipeline_seconds)`` — never violates the operation's
+    deadline contract.
+  * All non-timeout exceptions preserve pre-5A hard-stop behavior
+    (byte-equivalent for generate_error:<TypeName>).
+
+# Test surface (2 AST pins + 6 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPAIR_ENGINE_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "repair_engine.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_provider_call_wrapped_in_wait_for() -> None:
+    """The ``self._prime.generate(...)`` call MUST be inside an
+    ``asyncio.wait_for`` with a ``timeout=`` kwarg. Without this, a
+    single provider stream can consume the whole pipeline_deadline
+    and starve all remaining L2 iters."""
+    src = REPAIR_ENGINE_FILE.read_text()
+    # asyncio.wait_for must wrap a self._prime.generate call
+    assert "asyncio.wait_for(" in src, (
+        "_generate_repair_candidate does not use asyncio.wait_for — "
+        "provider call is unbounded; Slice 5A reverted."
+    )
+    # The wait_for must carry a timeout kwarg
+    assert "timeout=_effective_timeout_s" in src, (
+        "asyncio.wait_for missing timeout=_effective_timeout_s — "
+        "Slice 5A bound is decorative."
+    )
+    # The effective timeout must honor pipeline_deadline as upper bound
+    assert "_remaining_pipeline_s" in src, (
+        "Slice 5A does not compute remaining_pipeline_s — risks "
+        "exceeding the operation's deadline contract."
+    )
+    # On TimeoutError, structured stop_reason must be emitted
+    assert 'provider_iter_timeout:' in src, (
+        "TimeoutError handler does not emit provider_iter_timeout: "
+        "stop_reason — loop cannot classify as soft failure."
+    )
+
+
+def test_ast_pin_loop_classifies_provider_timeout_as_soft() -> None:
+    """The L2 loop must check for ``provider_iter_timeout:`` prefix and
+    ``continue`` (not hard-stop) until ``max_consecutive_provider_timeouts``
+    is reached. Without this the soft-timeout discipline is dead."""
+    src = REPAIR_ENGINE_FILE.read_text()
+    assert "consecutive_provider_timeouts" in src, (
+        "L2 loop missing consecutive_provider_timeouts counter — "
+        "Slice 5A graceful-continue path inert."
+    )
+    assert "provider_iter_timeout:" in src, (
+        "Loop does not match provider_iter_timeout: stop_reason"
+    )
+    # The loop must call continue on soft-timeout
+    assert (
+        "continue" in src
+        and "max_consecutive_provider_timeouts" in src
+    ), (
+        "Loop missing continue + max_consecutive cap — single timeout "
+        "still hard-stops the engine."
+    )
+    # Successful call must reset the counter
+    assert "consecutive_provider_timeouts = 0" in src, (
+        "Counter never resets on success — eventual false hard-stop"
+    )
+    # Hard-stop reason when cap exhausted
+    assert "consecutive_provider_timeouts_exhausted" in src, (
+        "Hard-stop reason missing — cap exhaustion has no telemetry tag"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 6
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_budget_fields_default_to_5a_values() -> None:
+    """RepairBudget defaults must compose the 5A fields."""
+    from backend.core.ouroboros.governance.repair_engine import RepairBudget
+
+    b = RepairBudget()
+    assert b.per_iter_provider_timeout_s == 45.0
+    assert b.max_consecutive_provider_timeouts == 2
+
+
+def test_spine_budget_from_env_reads_5a_knobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """from_env() reads both 5A env knobs."""
+    from backend.core.ouroboros.governance.repair_engine import RepairBudget
+
+    monkeypatch.setenv("JARVIS_L2_PER_ITER_PROVIDER_TIMEOUT_S", "30")
+    monkeypatch.setenv("JARVIS_L2_MAX_CONSECUTIVE_PROVIDER_TIMEOUTS", "3")
+    b = RepairBudget.from_env()
+    assert b.per_iter_provider_timeout_s == 30.0
+    assert b.max_consecutive_provider_timeouts == 3
+
+
+def test_spine_effective_timeout_min_of_two_bounds() -> None:
+    """The effective wait_for timeout is min(per_iter_bound,
+    remaining_pipeline_seconds) — never exceeds operation deadline."""
+    # Case 1: per_iter < remaining → per_iter wins
+    per_iter = 45.0
+    remaining = 100.0
+    eff = max(1.0, min(per_iter, remaining))
+    assert eff == 45.0
+
+    # Case 2: remaining < per_iter → remaining wins (honors deadline)
+    per_iter = 45.0
+    remaining = 20.0
+    eff = max(1.0, min(per_iter, remaining))
+    assert eff == 20.0
+
+    # Case 3: both negative/zero (deadline blown) → floor at 1.0
+    per_iter = 45.0
+    remaining = -5.0
+    eff = max(1.0, min(per_iter, remaining))
+    assert eff == 1.0
+
+
+@pytest.mark.asyncio
+async def test_spine_provider_timeout_returns_soft_stop_reason() -> None:
+    """A provider call that exceeds per_iter_provider_timeout_s
+    returns CandidateGenerationResult(candidate=None,
+    stop_reason='provider_iter_timeout:<s>') — does NOT raise."""
+    from backend.core.ouroboros.governance.repair_engine import (
+        RepairBudget, RepairEngine,
+    )
+
+    class _SlowProvider:
+        async def generate(self, ctx, deadline, repair_context=None):
+            await asyncio.sleep(10)  # exceeds 1s bound
+            raise AssertionError("should have been cancelled by wait_for")
+
+    budget = RepairBudget(per_iter_provider_timeout_s=1.0)
+    engine = RepairEngine(
+        budget=budget,
+        prime_provider=_SlowProvider(),
+        repo_root="/tmp",
+        sandbox_factory=lambda *a, **k: None,
+    )
+
+    class _Ctx:
+        op_id = "test-op"
+
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+    outcome = await engine._generate_repair_candidate(
+        _Ctx(), deadline, repair_context={},
+    )
+    assert outcome.candidate is None
+    assert outcome.stop_reason is not None
+    assert outcome.stop_reason.startswith("provider_iter_timeout:")
+
+
+@pytest.mark.asyncio
+async def test_spine_non_timeout_exception_preserves_hard_stop() -> None:
+    """Byte-equivalence: non-TimeoutError exceptions still produce
+    ``generate_error:<TypeName>`` (no behavior change vs. pre-5A)."""
+    from backend.core.ouroboros.governance.repair_engine import (
+        RepairBudget, RepairEngine,
+    )
+
+    class _BoomProvider:
+        async def generate(self, ctx, deadline, repair_context=None):
+            raise RuntimeError("simulated provider explosion")
+
+    budget = RepairBudget(per_iter_provider_timeout_s=30.0)
+    engine = RepairEngine(
+        budget=budget,
+        prime_provider=_BoomProvider(),
+        repo_root="/tmp",
+        sandbox_factory=lambda *a, **k: None,
+    )
+
+    class _Ctx:
+        op_id = "test-op"
+
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+    outcome = await engine._generate_repair_candidate(
+        _Ctx(), deadline, repair_context={},
+    )
+    assert outcome.candidate is None
+    assert outcome.stop_reason == "generate_error:RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_spine_cancelled_error_propagates() -> None:
+    """CancelledError must propagate — wait_for's cancellation
+    semantics are part of the asyncio cooperative-cancel contract."""
+    from backend.core.ouroboros.governance.repair_engine import (
+        RepairBudget, RepairEngine,
+    )
+
+    class _CancelProvider:
+        async def generate(self, ctx, deadline, repair_context=None):
+            raise asyncio.CancelledError()
+
+    budget = RepairBudget(per_iter_provider_timeout_s=30.0)
+    engine = RepairEngine(
+        budget=budget,
+        prime_provider=_CancelProvider(),
+        repo_root="/tmp",
+        sandbox_factory=lambda *a, **k: None,
+    )
+
+    class _Ctx:
+        op_id = "test-op"
+
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+    with pytest.raises(asyncio.CancelledError):
+        await engine._generate_repair_candidate(
+            _Ctx(), deadline, repair_context={},
+        )


### PR DESCRIPTION
fix(governance): Slice 5A — L2 per-iter provider isolation + graceful continue on TimeoutError

Closes the orchestrator-cascade root cause surfaced by soak
bt-2026-05-25-095834. Empirical chain that motivated the fix:

  03:02:13  op-019e5e95-362b INTENT (Ansible repair op)
  03:03:43  micro_fix_root_envelope_override (Slice 3H.2 ✓)
  03:03:43  micro_fix_pytest_scoped n_tests=2 (Slice 4B ✓)
  03:03:51  🔧 [L2 Repair] Iteration 1/5 starting
  03:04:01  🔧 [L2 Repair] Iteration 2/5 starting (Slice 4A ✓)
  03:04:28  ClaudeProvider stream terminated via CancelledError:
            elapsed=118.3s budget=118.2s ← L2 iter 2 ate full budget
  03:04:28  EXHAUSTION cause=fallback_failed fallback_failure_mode=TIMEOUT
  03:04:28  ForegroundCooldown attempt=2/3 backoff_s=120
  03:35:47  session killed; 16 ops cancelled_during_shutdown

A single L2 iter's ``self._prime.generate(...)`` saw the FULL
pipeline_deadline (e.g. 118s for Claude streaming) and consumed all
of it. The L2 loop's pre-5A behavior then hard-stopped on ANY
``generate_error:*`` stop_reason — so one provider timeout terminated
the engine and chained into orchestrator cooldown.

## Fix mechanism — bounded per-iter timeout + graceful continue

**1. RepairBudget gains two new fields** (both env-overridable):

  per_iter_provider_timeout_s: float = 45.0
    # env: JARVIS_L2_PER_ITER_PROVIDER_TIMEOUT_S
    # Bounds each iter's provider call; default 45s leaves budget
    # for 2-3 iters under a 120s timebox.

  max_consecutive_provider_timeouts: int = 2
    # env: JARVIS_L2_MAX_CONSECUTIVE_PROVIDER_TIMEOUTS
    # Hard-stop only after N back-to-back provider timeouts.

**2. ``_generate_repair_candidate`` wraps the provider call** with
``asyncio.wait_for`` bounded by the SMALLER of:

  - per_iter_provider_timeout_s (operator knob, default 45s)
  - remaining_pipeline_seconds (honors operation deadline contract)

On ``asyncio.TimeoutError``: emits structured stop_reason
``provider_iter_timeout:<s>`` — does NOT raise.

The ``pipeline_deadline`` arg passed to the provider stays unchanged
so server-side cap still honors the operation's overall deadline as
upper bound. ``wait_for`` is a narrower CLIENT-side bound.

**3. L2 loop classifies the new stop_reason as a SOFT failure**:

  if gen_outcome.stop_reason.startswith("provider_iter_timeout:"):
      consecutive_provider_timeouts += 1
      if consecutive_provider_timeouts >= cap:
          return _stopped("consecutive_provider_timeouts_exhausted:N")
      continue  # next iter (after re-checking kill conditions)

Any successful provider call resets the counter (so non-consecutive
timeouts don't accumulate forever).

## Operator bindings honored

* **Byte-equivalent for non-timeout exceptions** — every other
  ``except Exception`` shape preserves the original
  ``generate_error:<TypeName>`` stop_reason; only TimeoutError takes
  the new path. Pre-5A callers see identical behavior on
  RuntimeError / ValueError / etc.
* **CancelledError still propagates** — the cooperative-cancel
  contract stays intact (wait_for's cancellation semantics are
  part of the asyncio Protocol contract).
* **Honors pipeline_deadline as upper bound** — _effective_timeout_s
  = min(per_iter_bound, remaining_pipeline_s). Never waits longer
  than the operation has left.
* **AST-pinned** — 2 pins enforce the discipline:
  (1) ``asyncio.wait_for(self._prime.generate..., timeout=_effective_timeout_s)``
      is the only allowed call shape
  (2) loop matches ``provider_iter_timeout:`` prefix + counter +
      cap check + counter reset on success

## Test surface (2 AST pins + 6 spine, 8/8 green; +66 arc tests)

AST pins (2):
  1. asyncio.wait_for wraps self._prime.generate with timeout kwarg,
     _remaining_pipeline_s honored, provider_iter_timeout: emitted
  2. Loop carries consecutive_provider_timeouts counter, matches
     provider_iter_timeout: prefix, continues, resets on success,
     hard-stops at consecutive_provider_timeouts_exhausted

Spine (6):
  - Budget defaults to 45.0 + 2
  - from_env() reads both 5A env knobs
  - Effective timeout = min(per_iter_bound, remaining_pipeline_s)
    with 1.0 floor for blown-deadline edge case
  - Slow provider triggers provider_iter_timeout:<s> stop_reason
    (does NOT raise; candidate=None)
  - RuntimeError still produces generate_error:RuntimeError
    (byte-equivalent for non-timeout exceptions)
  - CancelledError still propagates (cooperative-cancel preserved)

## Next slice — repointed 5B

The original Slice 5B target (shipped_code_invariants) was
already off-loop — log triangulation revealed parent_await_ms=33220
was worker process execution time, not main-loop blocking. The
repointed 5B will analyze ControlPlaneSnapshot stack traces from
bt-2026-05-25-095834 (94 starvation events, peak lag_ms=88719) to
find the actual sync I/O blocker and refactor THAT.

1 file changed (repair_engine.py), ~85 insertions(+), ~5 deletions(-)
+ 1 file added (test_slice5a_l2_provider_isolation.py), ~245 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a single slow provider call from consuming the entire L2 timebox by adding a per-iteration timeout and continuing on timeout, improving resilience and avoiding orchestrator cooldown cascades. Keeps multiple iterations within the overall `pipeline_deadline`.

- **Bug Fixes**
  - Bound each provider call with `asyncio.wait_for` using timeout = min(`per_iter_provider_timeout_s`, remaining pipeline seconds); default 45s.
  - On `asyncio.TimeoutError`, return `provider_iter_timeout:<s>` and continue; reset the counter on success; hard-stop only after N consecutive timeouts (default 2) with `consecutive_provider_timeouts_exhausted`.
  - Behavior unchanged for other exceptions; `CancelledError` still propagates; overall deadline still honored. New env knobs: `JARVIS_L2_PER_ITER_PROVIDER_TIMEOUT_S`, `JARVIS_L2_MAX_CONSECUTIVE_PROVIDER_TIMEOUTS`.

<sup>Written for commit fa5335a72e8d26921f547285dcda5a4bc4389bb7. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57746?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

