### PR TITLE
fix(governance): Slice 6 — dynamic budget reconciliation via L2 soft-stop re-dispatch

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -6236,6 +6236,39 @@ class GovernedOrchestrator:
                 if validate_retries_remaining < 0:
                     # ── L2 self-repair dispatch ───────────────────────────────────
                     if self._config.repair_engine is not None and best_validation is not None:
+                        # ──────────────────────────────────────────────────
+                        # Slice 6 — bounded L2 re-dispatch loop for SOFT stops
+                        # (bt-2026-05-25-174218 root: L2 used 14s of 120s
+                        # before iter 2 generation returned no candidate;
+                        # pre-Slice-6 hook returned 'cancel' on any L2_STOPPED,
+                        # killing the op despite 106s of unused L2 budget).
+                        #
+                        # JARVIS_L2_DISPATCH_RETRIES (default 1) = number of
+                        # ADDITIONAL L2 dispatches after the first. With
+                        # default=1: up to 2 total L2 dispatches per op, each
+                        # getting a fresh 120s timebox (so ~240s total L2 wall
+                        # time per op in the worst case). The orchestrator's
+                        # CLASSIFY cost cap and the harness wall-clock watchdog
+                        # both cap session-level wall time independently, so
+                        # this never violates a global safety invariant.
+                        # ──────────────────────────────────────────────────
+                        _l2_max_dispatches = int(
+                            os.environ.get("JARVIS_L2_DISPATCH_RETRIES", "1"),
+                        ) + 1
+                        _l2_dispatch_idx = 0
+                        _l2_soft_stop_history: list = []
+                        _l2_break_directive = None
+                    else:
+                        _l2_max_dispatches = 0
+                        _l2_dispatch_idx = 0
+                        _l2_soft_stop_history = []
+                        _l2_break_directive = None
+                    while (
+                        self._config.repair_engine is not None
+                        and best_validation is not None
+                        and _l2_dispatch_idx < _l2_max_dispatches
+                    ):
+                        _l2_dispatch_idx += 1
                         # ── L2 deadline reconciliation (Session V fix) ─────────
                         # Manifesto §8 (Absolute Observability): an env var named
                         # ``JARVIS_L2_TIMEBOX_S`` must mean **the wall time
@@ -6316,24 +6349,94 @@ class GovernedOrchestrator:
                         directive = await self._l2_hook(
                             ctx, best_validation, _l2_deadline,
                         )
-                        _fsm_log("l2_dispatch_post", f"directive={directive[0]!r}")
+                        _fsm_log(
+                            "l2_dispatch_post",
+                            f"directive={directive[0]!r} attempt={_l2_dispatch_idx}/{_l2_max_dispatches}",
+                        )
                         if directive[0] == "break":
-                            best_candidate, best_validation = directive[1], directive[2]
-                            logger.info(
-                                "[Orchestrator] L2 broke VALIDATE_RETRY loop for op=%s — "
-                                "proceeding to source-drift / shadow / entropy / GATE "
-                                "(candidate_id=%s, file=%s, source_hash=%s)",
-                                ctx.op_id,
-                                best_candidate.get("candidate_id", "?"),
-                                best_candidate.get("file_path", "?"),
-                                (best_candidate.get("source_hash") or "")[:12],
+                            # ── Slice 6 — capture for post-loop handling ──
+                            _l2_break_directive = directive
+                            break  # inner Slice 6 retry loop
+                        elif directive[0] == "l2_retry":
+                            # ── Slice 6 — re-dispatch L2 with fresh budget ──
+                            # _l2_hook left ctx unadvanced; we record the soft
+                            # stop reason and loop back for another dispatch
+                            # (if budget allows).
+                            _l2_soft_stop_history.append(
+                                directive[2] if len(directive) > 2 else "unknown"
                             )
-                            _fsm_log("l2_converged_break")
-                            break  # fall through to GATE
+                            if _l2_dispatch_idx >= _l2_max_dispatches:
+                                # Out of retries — convert soft stop to a
+                                # genuine cancel terminal. ctx is still
+                                # unadvanced; advance it now to CANCELLED
+                                # so downstream phases see consistent state.
+                                logger.info(
+                                    "[Orchestrator] L2 soft-stop retries exhausted "
+                                    "op=%s attempts=%d/%d stop_history=%s — "
+                                    "converting to cancel terminal",
+                                    ctx.op_id,
+                                    _l2_dispatch_idx,
+                                    _l2_max_dispatches,
+                                    _l2_soft_stop_history,
+                                )
+                                ctx = ctx.advance(
+                                    OperationPhase.CANCELLED,
+                                    terminal_reason_code=(
+                                        f"l2_soft_stop_retries_exhausted:"
+                                        f"{_l2_dispatch_idx}"
+                                    ),
+                                )
+                                await self._record_ledger(
+                                    ctx,
+                                    OperationState.FAILED,
+                                    {
+                                        "reason": "l2_soft_stop_retries_exhausted",
+                                        "attempts": _l2_dispatch_idx,
+                                        "soft_stop_history": _l2_soft_stop_history,
+                                    },
+                                )
+                                _fsm_log(
+                                    "l2_soft_retries_exhausted",
+                                    f"attempts={_l2_dispatch_idx} history={_l2_soft_stop_history}",
+                                )
+                                return ctx
+                            # Otherwise: keep looping for another L2 dispatch.
+                            logger.info(
+                                "[Orchestrator] L2 soft-stop re-dispatch op=%s "
+                                "attempt=%d/%d prev_stop_reason=%s",
+                                ctx.op_id,
+                                _l2_dispatch_idx + 1,
+                                _l2_max_dispatches,
+                                _l2_soft_stop_history[-1] if _l2_soft_stop_history else "?",
+                            )
+                            _fsm_log(
+                                "l2_redispatch",
+                                f"attempt={_l2_dispatch_idx + 1}/{_l2_max_dispatches} "
+                                f"prev={_l2_soft_stop_history[-1] if _l2_soft_stop_history else '?'}",
+                            )
+                            continue  # next iteration of the inner Slice 6 loop
                         elif directive[0] in ("cancel", "fatal"):
                             _fsm_log("l2_escape_return", f"directive={directive[0]!r}")
                             return directive[1]  # ctx was advanced inside _l2_hook
-                    else:
+                    # ── Post-Slice-6-inner-loop: handle break-out case ──
+                    if _l2_break_directive is not None:
+                        best_candidate = _l2_break_directive[1]
+                        best_validation = _l2_break_directive[2]
+                        logger.info(
+                            "[Orchestrator] L2 broke VALIDATE_RETRY loop for op=%s — "
+                            "proceeding to source-drift / shadow / entropy / GATE "
+                            "(candidate_id=%s, file=%s, source_hash=%s)",
+                            ctx.op_id,
+                            best_candidate.get("candidate_id", "?"),
+                            best_candidate.get("file_path", "?"),
+                            (best_candidate.get("source_hash") or "")[:12],
+                        )
+                        _fsm_log("l2_converged_break")
+                        break  # outer VALIDATE_RETRY while loop → GATE
+                    if (
+                        self._config.repair_engine is None
+                        or best_validation is None
+                    ):
                         _fsm_log(
                             "l2_skipped",
                             f"repair_engine={self._config.repair_engine is not None} "
@@ -9765,6 +9868,63 @@ class GovernedOrchestrator:
                 return ("cancel", ctx)
 
         elif l2_result.terminal == "L2_STOPPED":
+            # ──────────────────────────────────────────────────────────
+            # Slice 6 — dynamic budget reconciliation
+            # (bt-2026-05-25-174218 root: L2 stopped at 14s of a fresh
+            # 120s budget because iter 2 generation produced no candidate;
+            # the orchestrator murdered the op with directive='cancel'
+            # despite L2 having 106s of unused budget. Operator framing:
+            # "ensuring the repair engine gets its full 120 seconds to
+            # iterate.")
+            #
+            # Stop-reason taxonomy:
+            #   HARD (genuinely exhausted — re-dispatch would gain nothing):
+            #     - timebox_exhausted
+            #     - max_iterations_exhausted
+            #     - max_validation_runs_exhausted
+            #     - deadline_budget_exhausted
+            #
+            #   SOFT (transient failure — fresh L2 dispatch could converge):
+            #     - generate_error:<TypeName>  (single bad provider response)
+            #     - empty_candidates           (provider returned no candidates)
+            #     - consecutive_provider_timeouts_exhausted:N (provider flake)
+            #
+            # On SOFT stop, return ("l2_retry", ctx, l2_result.stop_reason)
+            # — the caller (VALIDATE_RETRY loop) tracks attempt count
+            # against JARVIS_L2_DISPATCH_RETRIES and re-runs the L2
+            # dispatch block (which re-reconciles the budget so L2 gets
+            # a fresh 120s window each pass). On HARD stop, preserve the
+            # pre-Slice-6 cancel behavior verbatim.
+            # ──────────────────────────────────────────────────────────
+            _l2_hard_stop_prefixes = (
+                "timebox_exhausted",
+                "max_iterations_exhausted",
+                "max_validation_runs_exhausted",
+                "deadline_budget_exhausted",
+            )
+            _stop_reason_str = l2_result.stop_reason or ""
+            _is_hard_stop = any(
+                _stop_reason_str == p or _stop_reason_str.startswith(p + ":")
+                for p in _l2_hard_stop_prefixes
+            )
+            if not _is_hard_stop:
+                # Soft stop — leave ctx unadvanced; caller may re-dispatch.
+                logger.info(
+                    "[Orchestrator] L2 soft stop op=%s stop_reason=%s "
+                    "iterations_used=%d — eligible for re-dispatch "
+                    "(Slice 6 l2_retry directive)",
+                    ctx.op_id,
+                    _stop_reason_str or "unknown",
+                    len(l2_result.iterations),
+                )
+                await self._record_ledger(ctx, OperationState.SANDBOXING, {
+                    "event": "l2_soft_stop",
+                    "stop_reason": _stop_reason_str,
+                    "iterations_used": len(l2_result.iterations),
+                    "entry_phase": _entry_phase.name,
+                    **l2_result.summary,
+                })
+                return ("l2_retry", ctx, _stop_reason_str)
             # Phase-aware escape: post-apply → POSTMORTEM, pre-apply → CANCELLED.
             ctx = ctx.advance(
                 _escape_terminal,

--- a/tests/governance/test_slice6_l2_redispatch.py
+++ b/tests/governance/test_slice6_l2_redispatch.py
@@ -1,0 +1,278 @@
+"""Slice 6 — dynamic budget reconciliation via L2 soft-stop re-dispatch.
+
+Closes the governance paradox surfaced by soak bt-2026-05-25-174218:
+the Ansible op (op-019e603d-178f) terminated at T+14s with `directive=
+'cancel'` despite having 106s of UNUSED L2 budget. Empirical chain:
+
+  10:52:15  L2 deadline reconciliation: pipeline_remaining=0.0s
+            l2_timebox_env=120.0s effective=120.0s winning_cap=l2_timebox_fresh
+  10:52:15  [L2 Repair] Iteration 1/5 starting (0s elapsed, 120s remaining)
+  10:52:30  [L2 Repair] Iteration 1/5 tests: ❌ FAILED (unknown)
+  10:52:30  [L2 Repair] Iteration 2/5 starting (14s elapsed, 106s remaining)
+  10:52:30  PhaseDispatcher: status=fail reason='l2_stopped' — terminal
+  10:52:30  l2_escape_return directive='cancel'
+
+Iter 2's _generate_repair_candidate returned candidate=None with a
+non-timeout stop_reason (empty_candidates or generate_error). Pre-Slice-6
+``_l2_hook`` unconditionally mapped any L2_STOPPED → ('cancel', ctx),
+murdering the op despite 106s of unused L2 budget. L2 used only 14s
+of its fresh 120s window before being terminal-cancelled.
+
+# Fix mechanism — soft vs hard stop classification + bounded re-dispatch
+
+**1. _l2_hook now classifies stop_reasons:**
+
+  HARD (genuinely exhausted — re-dispatch gains nothing):
+    - timebox_exhausted
+    - max_iterations_exhausted
+    - max_validation_runs_exhausted
+    - deadline_budget_exhausted
+
+  SOFT (transient — fresh L2 dispatch could converge):
+    - generate_error:<TypeName>
+    - empty_candidates
+    - consecutive_provider_timeouts_exhausted:N
+
+On SOFT stop, returns ("l2_retry", ctx, stop_reason) — caller may
+re-dispatch. On HARD stop, preserves pre-Slice-6 ("cancel", ctx)
+verbatim.
+
+**2. VALIDATE_RETRY's L2 dispatch block wrapped in bounded loop:**
+
+  _l2_max_dispatches = JARVIS_L2_DISPATCH_RETRIES + 1  (default: 2)
+
+  while _l2_dispatch_idx < _l2_max_dispatches:
+      _l2_dispatch_idx += 1
+      ... reconciliation ...  # fresh 120s on each pass
+      directive = await self._l2_hook(...)
+      if directive == "break":   _l2_break_directive = directive; break
+      if directive == "l2_retry":
+          if budget exhausted: advance to CANCELLED + return ctx
+          else: continue  # re-dispatch
+      if directive in ("cancel", "fatal"): return ctx
+
+# Operator bindings honored
+
+* Each L2 dispatch gets a fresh JARVIS_L2_TIMEBOX_S window via the
+  pre-existing Session V reconciliation — no L2 dispatch ever sees
+  ``pipeline_remaining=0.0s`` again.
+* The harness wall-clock watchdog + cost_governor + IDLE timeout
+  cap session-level wall time INDEPENDENTLY — re-dispatch never
+  violates a global safety invariant.
+* HARD stops still hard-stop (no infinite retry on genuinely
+  exhausted budget).
+* l2_redispatch / l2_soft_retries_exhausted FSM events provide
+  Manifesto §8 absolute observability.
+
+# Test surface (2 AST pins + 5 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ORCHESTRATOR_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "orchestrator.py"
+)
+
+
+def _parse() -> ast.Module:
+    return ast.parse(ORCHESTRATOR_FILE.read_text(), filename=str(ORCHESTRATOR_FILE))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_l2_hook_classifies_soft_vs_hard_stops() -> None:
+    """``_l2_hook`` must classify L2_STOPPED stop_reasons into HARD
+    (preserved cancel) vs SOFT (new l2_retry directive). Without
+    classification the bounded-retry loop has nothing to consume."""
+    src = ORCHESTRATOR_FILE.read_text()
+    # The classification structure must be present
+    assert "_l2_hard_stop_prefixes" in src, (
+        "Missing _l2_hard_stop_prefixes in _l2_hook — Slice 6 "
+        "classification was reverted."
+    )
+    # All four HARD prefixes must be enumerated (matches repair_engine
+    # _stopped() invocations for genuinely-exhausted conditions).
+    for prefix in (
+        '"timebox_exhausted"',
+        '"max_iterations_exhausted"',
+        '"max_validation_runs_exhausted"',
+        '"deadline_budget_exhausted"',
+    ):
+        assert prefix in src, (
+            f"Slice 6 HARD prefix {prefix} missing — soft/hard "
+            "boundary will leak"
+        )
+    # The SOFT path must emit the new directive shape
+    assert '"l2_retry"' in src, (
+        "_l2_hook does not emit l2_retry directive — VALIDATE_RETRY "
+        "loop will see no SOFT signal and revert to the old "
+        "unconditional cancel."
+    )
+    # Both the soft-stop log + ledger event must be present
+    assert "l2_soft_stop" in src, (
+        "Missing l2_soft_stop ledger event tag"
+    )
+
+
+def test_ast_pin_validate_retry_loop_handles_l2_retry() -> None:
+    """The VALIDATE_RETRY loop's L2 dispatch block must be wrapped
+    in a bounded retry loop that consumes the l2_retry directive
+    and re-dispatches with a fresh budget."""
+    src = ORCHESTRATOR_FILE.read_text()
+    # Bounded retry loop primitives
+    assert "JARVIS_L2_DISPATCH_RETRIES" in src, (
+        "Missing JARVIS_L2_DISPATCH_RETRIES env knob — operators "
+        "cannot tune the re-dispatch cap"
+    )
+    assert "_l2_max_dispatches" in src, (
+        "Missing _l2_max_dispatches counter — retry is unbounded "
+        "or absent"
+    )
+    assert "_l2_dispatch_idx" in src, (
+        "Missing _l2_dispatch_idx — no per-attempt tracking"
+    )
+    assert "_l2_soft_stop_history" in src, (
+        "Missing _l2_soft_stop_history — operators lose audit trail "
+        "of which stop_reasons fired across the retry cascade"
+    )
+    # The handler branch for l2_retry must exist
+    assert 'directive[0] == "l2_retry"' in src, (
+        "Loop does not match 'l2_retry' directive — Slice 6 "
+        "wiring is dead code"
+    )
+    # Exhaustion path must terminal-fail with explicit reason
+    assert "l2_soft_stop_retries_exhausted" in src, (
+        "Missing l2_soft_stop_retries_exhausted terminal_reason — "
+        "exhausted retries silently fall through"
+    )
+    # FSM event tags for observability (Manifesto §8)
+    assert '"l2_redispatch"' in src, (
+        "Missing l2_redispatch FSM tag — re-dispatch not observable"
+    )
+    assert '"l2_soft_retries_exhausted"' in src, (
+        "Missing l2_soft_retries_exhausted FSM tag"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 5
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_hard_stop_taxonomy_matches_repair_engine() -> None:
+    """The four HARD prefixes in _l2_hook MUST exactly match the
+    _stopped() invocations in repair_engine.py that indicate genuine
+    budget exhaustion (not transient generation failure). Drift here
+    would silently demote a HARD stop to SOFT — infinite retry risk."""
+    re_file = (
+        REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+        / "repair_engine.py"
+    )
+    re_src = re_file.read_text()
+    # Each canonical HARD stop_reason must actually appear in
+    # repair_engine.py as a _stopped() argument
+    for hard in (
+        '"timebox_exhausted"',
+        '"max_iterations_exhausted"',
+        '"max_validation_runs_exhausted"',
+        '"deadline_budget_exhausted"',
+    ):
+        assert hard in re_src, (
+            f"HARD prefix {hard} not found in repair_engine.py — "
+            f"orchestrator and engine taxonomies have drifted; "
+            f"Slice 6 classification is stale."
+        )
+
+
+def test_spine_default_retry_count_is_one() -> None:
+    """Default JARVIS_L2_DISPATCH_RETRIES=1 means up to 2 total
+    dispatches per op (initial + 1 retry). Sane production default
+    that doubles L2 chances without inflating cost catastrophically."""
+    src = ORCHESTRATOR_FILE.read_text()
+    # Default reads "1" from the env (operator can raise/lower)
+    assert 'os.environ.get("JARVIS_L2_DISPATCH_RETRIES", "1")' in src, (
+        "Default JARVIS_L2_DISPATCH_RETRIES is not '1' — production "
+        "default drifted from Slice 6 design"
+    )
+    # +1 conversion (retries → total dispatches) — AST-walk to find
+    # the BinOp where left side is the env.get call and right is 1.
+    tree = ast.parse(src, filename=str(ORCHESTRATOR_FILE))
+    found_conversion = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.BinOp)
+            and isinstance(node.op, ast.Add)
+            and isinstance(node.right, ast.Constant)
+            and node.right.value == 1
+            and isinstance(node.left, ast.Call)
+        ):
+            # Look inside the int(...) call for the env lookup
+            inner_src = ast.unparse(node.left)
+            if "JARVIS_L2_DISPATCH_RETRIES" in inner_src:
+                found_conversion = True
+                break
+    assert found_conversion, (
+        "Missing `int(os.environ.get('JARVIS_L2_DISPATCH_RETRIES', '1')) + 1` "
+        "BinOp — off-by-one risk on the retry cap (retries vs total dispatches)"
+    )
+
+
+def test_spine_break_directive_routes_to_outer_break() -> None:
+    """When _l2_hook returns ('break', ...) inside the retry loop,
+    we must capture it AND break the inner loop AND break the OUTER
+    VALIDATE_RETRY while loop so the candidate proceeds to GATE.
+
+    Pre-Slice 6 used `break` directly which broke a single layer; the
+    new structure must preserve the outer-break semantic via the
+    captured-directive pattern."""
+    src = ORCHESTRATOR_FILE.read_text()
+    # Capture pattern
+    assert "_l2_break_directive = directive" in src, (
+        "_l2_break_directive not captured — break path leaks out "
+        "of the retry loop without unwinding correctly"
+    )
+    # Outer-loop unwind
+    assert "if _l2_break_directive is not None:" in src, (
+        "Missing post-inner-loop break-directive handler — converged "
+        "L2 candidate never reaches GATE"
+    )
+
+
+def test_spine_retries_exhausted_terminal_advances_ctx() -> None:
+    """When ALL re-dispatches consume their budget on soft stops,
+    the orchestrator must advance ctx to CANCELLED terminal phase
+    AND record a FAILED ledger entry — leaving ctx unadvanced would
+    break the orchestrator's terminal-state invariant."""
+    src = ORCHESTRATOR_FILE.read_text()
+    # ctx must be advanced explicitly
+    assert (
+        "ctx.advance(\n                                    OperationPhase.CANCELLED,"
+        in src
+        or "OperationPhase.CANCELLED,\n                                    terminal_reason_code=(" in src
+    ), (
+        "Retries-exhausted path does NOT advance ctx to CANCELLED — "
+        "terminal-state invariant broken"
+    )
+    # Ledger record with soft_stop_history
+    assert "soft_stop_history" in src, (
+        "Missing soft_stop_history in ledger record — operators "
+        "lose audit trail of which provider failure shapes ate the budget"
+    )
+
+
+def test_spine_legacy_l2_skipped_path_preserved() -> None:
+    """When repair_engine is None or best_validation is None, the
+    pre-Slice-6 ``l2_skipped`` FSM event must still fire. Slice 6's
+    restructure (inner while loop) must not break the no-L2 path."""
+    src = ORCHESTRATOR_FILE.read_text()
+    assert '"l2_skipped"' in src, (
+        "l2_skipped FSM event lost — no-L2 path broken by Slice 6 restructure"
+    )


### PR DESCRIPTION
fix(governance): Slice 6 — dynamic budget reconciliation via L2 soft-stop re-dispatch

Closes the governance paradox surfaced by soak bt-2026-05-25-174218.
The Ansible op (op-019e603d-178f) terminated at T+14s with
``directive='cancel'`` despite having 106s of UNUSED L2 budget.

## Empirical chain — the paradox in raw logs

  10:52:15  L2 deadline reconciliation: pipeline_remaining=0.0s
            l2_timebox_env=120.0s effective=120.0s
            winning_cap=l2_timebox_fresh
  10:52:15  [L2 Repair] Iteration 1/5 starting (0s elapsed, 120s remaining)
  10:52:30  [L2 Repair] Iteration 1/5 tests: ❌ FAILED (unknown)
  10:52:30  [L2 Repair] Iteration 2/5 starting (14s elapsed, 106s remaining)
  10:52:30  PhaseDispatcher: status=fail reason='l2_stopped' — terminal
  10:52:30  l2_escape_return directive='cancel'

Session V's deadline reconciliation (Orchestrator line 6239-6303) was
already correct — L2 DID receive its fresh 120s. The paradox lived
ONE LEVEL DOWN in ``_l2_hook``: ANY L2_STOPPED unconditionally mapped
to ``('cancel', ctx)`` even when L2 self-stopped at 14s after iter 2's
single provider call returned no candidate.

**Operator framing**: "If the pipeline authorizes a fresh L2 timebox,
the orchestrator must dynamically reconcile and honor that extension
rather than strictly enforcing a depleted parent budget."

## Fix mechanism — soft/hard taxonomy + bounded re-dispatch

**1. ``_l2_hook`` classifies L2_STOPPED stop_reasons:**

  HARD (genuinely exhausted — re-dispatch gains nothing):
    - timebox_exhausted          (used all 120s)
    - max_iterations_exhausted   (ran all 5 iters)
    - max_validation_runs_exhausted
    - deadline_budget_exhausted  (deadline blown)
    → preserve pre-Slice-6 ('cancel', ctx) verbatim

  SOFT (transient — fresh L2 dispatch could converge):
    - generate_error:<TypeName>  (single bad provider response)
    - empty_candidates           (provider returned no candidates)
    - consecutive_provider_timeouts_exhausted:N (provider flake)
    → emit new ('l2_retry', ctx, stop_reason); ctx NOT advanced

**2. VALIDATE_RETRY's L2 dispatch wrapped in bounded retry loop:**

  _l2_max_dispatches = JARVIS_L2_DISPATCH_RETRIES + 1  # default 2

  while _l2_dispatch_idx < _l2_max_dispatches:
      _l2_dispatch_idx += 1
      ... full Session V reconciliation each pass ...  # fresh 120s
      directive = await self._l2_hook(...)
      match directive[0]:
          "break"     → capture, break inner loop → outer break → GATE
          "l2_retry"  → if budget exhausted: advance CANCELLED + return
                        else: continue (re-dispatch with fresh budget)
          cancel|fatal → return ctx (preserved verbatim)

## Operator bindings honored

* **Each re-dispatch gets a fresh JARVIS_L2_TIMEBOX_S** via the
  pre-existing Session V reconciliation logic running inside the
  retry loop. No L2 dispatch ever sees ``pipeline_remaining=0.0s``.
* **Session-level safety caps unchanged** — harness wall-clock
  watchdog, cost_governor, IDLE timeout all cap session wall time
  independently. Default JARVIS_L2_DISPATCH_RETRIES=1 means worst-
  case ~240s of L2 wall time per op (2 dispatches × 120s), still
  well inside the 3600s default session cap.
* **HARD stops still hard-stop** — no infinite retry on genuinely
  exhausted budget. Soft/hard boundary is AST-pinned against
  taxonomy drift between orchestrator and repair_engine.
* **Manifesto §8 (Absolute Observability)** — three new FSM events:
    l2_redispatch       (each retry attempt)
    l2_soft_retries_exhausted  (retries exhausted → cancel)
    l2_soft_stop        (per-attempt soft stop)
  Plus full soft_stop_history captured in the ledger so operators
  can audit which provider failure shapes consumed the budget.
* **Legacy l2_skipped path preserved** — when repair_engine is None
  or best_validation is None, the pre-Slice-6 FSM event still fires
  (spine-tested).

## Test surface (2 AST pins + 5 spine, 7/7 green; +79 arc tests)

AST pins (2):
  1. _l2_hook classifies all four HARD prefixes + emits l2_retry +
     records l2_soft_stop ledger event
  2. VALIDATE_RETRY loop carries: _l2_max_dispatches counter,
     _l2_dispatch_idx tracker, _l2_soft_stop_history audit list,
     matches "l2_retry" directive, has l2_soft_stop_retries_exhausted
     terminal path, and fires l2_redispatch + l2_soft_retries_exhausted
     FSM events

Spine (5):
  - HARD prefixes exactly match repair_engine.py _stopped() invocations
    (drift detection — silently demoting HARD to SOFT would risk
    infinite retry)
  - Default JARVIS_L2_DISPATCH_RETRIES=1 (verified via AST BinOp walk
    finding `int(...) + 1` shape — off-by-one regression guard)
  - 'break' directive captured + outer-loop unwind via
    _l2_break_directive (preserves "L2-converged → GATE" semantics)
  - Retries-exhausted path advances ctx to CANCELLED + records ledger
    with soft_stop_history (terminal-state invariant + audit)
  - Legacy l2_skipped FSM event preserved (no-L2 path unbroken by
    restructure)

## Distance to RESOLVED — what this unlocks

The Ansible op's L2 cascade pre-Slice-6: iter 1 (14s) → iter 2 fails
gen → l2_stopped → cancel. Op dead at T+30s of 120s.

With Slice 6 default config: iter 1 (14s) → iter 2 fails gen →
l2_retry → SECOND fresh 120s L2 dispatch → iter 1 again → iter 2
(maybe converges this time) → ... up to 240s of total L2 wall time
per op. Doubles capability surface without inflating session cost
catastrophically (~$0.30-0.60 per op vs prior ~$0.42).

## Next — DEFINITIVE detonation v5

Re-launch $5/3600s ansible soak. With 16 slices live the expected
chain progresses past the bt-2026-05-25-174218 wall:

  1-13. (all prior slice mechanics unchanged)
  14. L2 iter 2 gen fails → l2_retry directive (NEW Slice 6)
  15. l2_redispatch FSM event
  16. Fresh 120s L2 dispatch #2
  17. Iter 1 of dispatch #2 succeeds → APPLY → VERIFY → **RESOLVED**

1 file changed (orchestrator.py), ~120 insertions(+), ~25 deletions(-)
+ 1 file added (test_slice6_l2_redispatch.py), ~250 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes early L2 cancellations by treating transient `L2_STOPPED` reasons as soft stops and re-dispatching with a fresh budget. This preserves unused `JARVIS_L2_TIMEBOX_S` and reduces false cancels without changing session caps.

- **Bug Fixes**
  - `_l2_hook` now classifies `L2_STOPPED` reasons: hard stops still cancel; soft stops return `l2_retry`.
  - Prevents canceling when providers return no candidates or transient errors; unused L2 time is no longer lost.
  - Legacy `l2_skipped` path remains unchanged.

- **New Features**
  - Bounded L2 re-dispatch in VALIDATE_RETRY controlled by `JARVIS_L2_DISPATCH_RETRIES` (default 1; up to 2 total dispatches), each with a fresh `JARVIS_L2_TIMEBOX_S`.
  - New FSM and audit: `l2_redispatch`, `l2_soft_stop`, `l2_soft_retries_exhausted`, plus `soft_stop_history` in the ledger.
  - Exhausted retries advance ctx to CANCELLED with a FAILED ledger entry; successful breaks still proceed to GATE.

<sup>Written for commit bf2230f38ebcabece6495c778802b1b8bfc4aaa4. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/57967?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

