### PR TITLE
fix(governance): Slice 6.1 — apply Slice 6 wiring to validate_runner.py (production VALIDATE_RETRY path)

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/validate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/validate_runner.py
@@ -386,7 +386,34 @@ class VALIDATERunner(PhaseRunner):
             validate_retries_remaining -= 1
             if validate_retries_remaining < 0:
                 # ── L2 self-repair dispatch ──
+                # ──────────────────────────────────────────────────
+                # Slice 6 — bounded L2 re-dispatch loop for SOFT stops
+                # (bt-2026-05-25-200829 root: my prior Slice 6 patch
+                # landed in orchestrator.py:6235 but production VALIDATE_RETRY
+                # actually flows through THIS module, not orchestrator.py's
+                # legacy block. _l2_hook DID return 'l2_retry' correctly
+                # but this caller didn't handle that directive — fell
+                # through to no_candidate_valid_return at line 479,
+                # murdering the op the same way pre-Slice-6 did.
+                # JARVIS_L2_DISPATCH_RETRIES (default 1) = number of
+                # ADDITIONAL L2 dispatches after the first.
+                # ──────────────────────────────────────────────────
                 if orch._config.repair_engine is not None and best_validation is not None:
+                    _l2_max_dispatches = int(
+                        os.environ.get("JARVIS_L2_DISPATCH_RETRIES", "1"),
+                    ) + 1
+                else:
+                    _l2_max_dispatches = 0
+                _l2_dispatch_idx = 0
+                _l2_soft_stop_history: list = []
+                _l2_break_directive = None
+                _l2_retries_exhausted_ctx = None
+                while (
+                    orch._config.repair_engine is not None
+                    and best_validation is not None
+                    and _l2_dispatch_idx < _l2_max_dispatches
+                ):
+                    _l2_dispatch_idx += 1
                     # ── L2 deadline reconciliation (Session V fix) ──
                     _l2_timebox_s = float(
                         os.environ.get("JARVIS_L2_TIMEBOX_S", "120.0")
@@ -413,35 +440,86 @@ class VALIDATERunner(PhaseRunner):
                     logger.info(
                         "[Orchestrator] L2 deadline reconciliation: "
                         "pipeline_remaining=%.1fs l2_timebox_env=%.1fs "
-                        "effective=%.1fs winning_cap=%s op=%s",
+                        "effective=%.1fs winning_cap=%s op=%s "
+                        "(Slice 6 attempt=%d/%d)",
                         _orig_remaining_s,
                         _l2_timebox_s,
                         (_l2_deadline - _now_dt).total_seconds(),
                         _winning_cap,
                         ctx.op_id[:16],
+                        _l2_dispatch_idx,
+                        _l2_max_dispatches,
                     )
                     _fsm_log(
                         "l2_dispatch_pre",
                         f"effective_s={(_l2_deadline - _now_dt).total_seconds():.0f} "
-                        f"cap={_winning_cap} l2_timebox_env={_l2_timebox_s:.0f}",
+                        f"cap={_winning_cap} l2_timebox_env={_l2_timebox_s:.0f} "
+                        f"attempt={_l2_dispatch_idx}/{_l2_max_dispatches}",
                     )
                     directive = await orch._l2_hook(
                         ctx, best_validation, _l2_deadline,
                     )
-                    _fsm_log("l2_dispatch_post", f"directive={directive[0]!r}")
+                    _fsm_log(
+                        "l2_dispatch_post",
+                        f"directive={directive[0]!r} attempt={_l2_dispatch_idx}/{_l2_max_dispatches}",
+                    )
                     if directive[0] == "break":
-                        best_candidate, best_validation = directive[1], directive[2]
-                        logger.info(
-                            "[Orchestrator] L2 broke VALIDATE_RETRY loop for op=%s — "
-                            "proceeding to source-drift / shadow / entropy / GATE "
-                            "(candidate_id=%s, file=%s, source_hash=%s)",
-                            ctx.op_id,
-                            best_candidate.get("candidate_id", "?"),
-                            best_candidate.get("file_path", "?"),
-                            (best_candidate.get("source_hash") or "")[:12],
+                        # Slice 6 — capture for post-loop handling
+                        _l2_break_directive = directive
+                        break  # inner Slice 6 retry loop
+                    elif directive[0] == "l2_retry":
+                        # Slice 6 — re-dispatch L2 with fresh budget
+                        _l2_soft_stop_history.append(
+                            directive[2] if len(directive) > 2 else "unknown"
                         )
-                        _fsm_log("l2_converged_break")
-                        break
+                        if _l2_dispatch_idx >= _l2_max_dispatches:
+                            # Out of retries — convert soft stop to cancel.
+                            logger.info(
+                                "[Orchestrator] L2 soft-stop retries exhausted "
+                                "op=%s attempts=%d/%d stop_history=%s — "
+                                "converting to cancel terminal",
+                                ctx.op_id,
+                                _l2_dispatch_idx,
+                                _l2_max_dispatches,
+                                _l2_soft_stop_history,
+                            )
+                            ctx = ctx.advance(
+                                OperationPhase.CANCELLED,
+                                terminal_reason_code=(
+                                    f"l2_soft_stop_retries_exhausted:"
+                                    f"{_l2_dispatch_idx}"
+                                ),
+                            )
+                            await orch._record_ledger(
+                                ctx,
+                                OperationState.FAILED,
+                                {
+                                    "reason": "l2_soft_stop_retries_exhausted",
+                                    "attempts": _l2_dispatch_idx,
+                                    "soft_stop_history": _l2_soft_stop_history,
+                                },
+                            )
+                            _fsm_log(
+                                "l2_soft_retries_exhausted",
+                                f"attempts={_l2_dispatch_idx} history={_l2_soft_stop_history}",
+                            )
+                            _l2_retries_exhausted_ctx = ctx
+                            break  # inner Slice 6 retry loop
+                        # Otherwise: keep looping for another L2 dispatch.
+                        logger.info(
+                            "[Orchestrator] L2 soft-stop re-dispatch op=%s "
+                            "attempt=%d/%d prev_stop_reason=%s",
+                            ctx.op_id,
+                            _l2_dispatch_idx + 1,
+                            _l2_max_dispatches,
+                            _l2_soft_stop_history[-1] if _l2_soft_stop_history else "?",
+                        )
+                        _fsm_log(
+                            "l2_redispatch",
+                            f"attempt={_l2_dispatch_idx + 1}/{_l2_max_dispatches} "
+                            f"prev={_l2_soft_stop_history[-1] if _l2_soft_stop_history else '?'}",
+                        )
+                        continue  # next inner Slice 6 retry-loop iteration
                     elif directive[0] in ("cancel", "fatal"):
                         _fsm_log("l2_escape_return", f"directive={directive[0]!r}")
                         # directive[1] is the advanced ctx (CANCELLED/POSTMORTEM)
@@ -451,7 +529,42 @@ class VALIDATERunner(PhaseRunner):
                             reason=_reason,
                             artifacts={"best_candidate": None, "best_validation": best_validation},
                         )
-                else:
+                # ── Post-Slice-6-inner-loop handlers ──
+                if _l2_break_directive is not None:
+                    best_candidate = _l2_break_directive[1]
+                    best_validation = _l2_break_directive[2]
+                    logger.info(
+                        "[Orchestrator] L2 broke VALIDATE_RETRY loop for op=%s — "
+                        "proceeding to source-drift / shadow / entropy / GATE "
+                        "(candidate_id=%s, file=%s, source_hash=%s)",
+                        ctx.op_id,
+                        best_candidate.get("candidate_id", "?"),
+                        best_candidate.get("file_path", "?"),
+                        (best_candidate.get("source_hash") or "")[:12],
+                    )
+                    _fsm_log("l2_converged_break")
+                    break  # outer VALIDATE_RETRY while loop → GATE
+                if _l2_retries_exhausted_ctx is not None:
+                    # Soft-stop retries exhausted: terminal cancel via the
+                    # explicit phase result (ctx already advanced + ledger
+                    # already written inside the inner loop).
+                    return PhaseResult(
+                        next_ctx=_l2_retries_exhausted_ctx,
+                        next_phase=None,
+                        status="fail",
+                        reason=(
+                            _l2_retries_exhausted_ctx.terminal_reason_code
+                            or "l2_soft_stop_retries_exhausted"
+                        ),
+                        artifacts={
+                            "best_candidate": None,
+                            "best_validation": best_validation,
+                        },
+                    )
+                if (
+                    orch._config.repair_engine is None
+                    or best_validation is None
+                ):
                     _fsm_log(
                         "l2_skipped",
                         f"repair_engine={orch._config.repair_engine is not None} "

--- a/tests/governance/test_slice6_l2_redispatch.py
+++ b/tests/governance/test_slice6_l2_redispatch.py
@@ -77,6 +77,14 @@ ORCHESTRATOR_FILE = (
     REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
     / "orchestrator.py"
 )
+# bt-2026-05-25-200829 revealed the production VALIDATE_RETRY path
+# lives here, NOT in orchestrator.py's legacy block at line 6235.
+# Slice 6 wiring MUST be present in both files for the soft-stop
+# re-dispatch to actually fire in production.
+VALIDATE_RUNNER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "phase_runners" / "validate_runner.py"
+)
 
 
 def _parse() -> ast.Module:
@@ -275,4 +283,111 @@ def test_spine_legacy_l2_skipped_path_preserved() -> None:
     src = ORCHESTRATOR_FILE.read_text()
     assert '"l2_skipped"' in src, (
         "l2_skipped FSM event lost — no-L2 path broken by Slice 6 restructure"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Slice 6 production-path coverage — validate_runner.py
+#
+# The bt-2026-05-25-200829 soak proved that the production VALIDATE_RETRY
+# path runs through ``phase_runners/validate_runner.py``, NOT the legacy
+# block in orchestrator.py. The l2_retry directive was correctly emitted
+# by _l2_hook but validate_runner.py's caller didn't handle it — the
+# op terminal-cancelled despite Slice 6 being live in orchestrator.py.
+#
+# These pins enforce Slice 6 wiring is present in BOTH files so the
+# regression "I patched the wrong module" never repeats.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_validate_runner_handles_l2_retry() -> None:
+    """validate_runner.py is the production VALIDATE_RETRY phase runner.
+    It must carry the same Slice 6 bounded re-dispatch loop + l2_retry
+    handler as orchestrator.py — otherwise the soft-stop directive
+    falls through to no_candidate_valid_return."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    # Required Slice 6 primitives (identical to orchestrator.py)
+    assert "JARVIS_L2_DISPATCH_RETRIES" in src, (
+        "validate_runner missing JARVIS_L2_DISPATCH_RETRIES env knob — "
+        "production VALIDATE_RETRY path bypasses Slice 6 entirely"
+    )
+    assert "_l2_max_dispatches" in src, (
+        "validate_runner missing _l2_max_dispatches — production "
+        "retry cap absent"
+    )
+    assert "_l2_soft_stop_history" in src, (
+        "validate_runner missing _l2_soft_stop_history audit list"
+    )
+    assert "_l2_retries_exhausted_ctx" in src, (
+        "validate_runner missing _l2_retries_exhausted_ctx terminal "
+        "carrier — exhausted-retries path can't return PhaseResult"
+    )
+    # l2_retry directive handler
+    assert 'directive[0] == "l2_retry"' in src, (
+        "validate_runner does NOT match l2_retry directive — Slice 6 "
+        "soft-stop wiring is dead code in production"
+    )
+    # FSM observability tags
+    assert '"l2_redispatch"' in src, (
+        "validate_runner missing l2_redispatch FSM tag"
+    )
+    assert '"l2_soft_retries_exhausted"' in src, (
+        "validate_runner missing l2_soft_retries_exhausted FSM tag"
+    )
+    # Terminal advance + ledger record on exhaustion
+    assert "l2_soft_stop_retries_exhausted" in src, (
+        "validate_runner missing l2_soft_stop_retries_exhausted "
+        "terminal_reason_code"
+    )
+
+
+def test_spine_validate_runner_default_retry_count() -> None:
+    """Same +1 conversion check as orchestrator — keeps the two
+    modules in lockstep on the default retry budget."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    tree = ast.parse(src, filename=str(VALIDATE_RUNNER_FILE))
+    found_conversion = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.BinOp)
+            and isinstance(node.op, ast.Add)
+            and isinstance(node.right, ast.Constant)
+            and node.right.value == 1
+            and isinstance(node.left, ast.Call)
+        ):
+            inner_src = ast.unparse(node.left)
+            if "JARVIS_L2_DISPATCH_RETRIES" in inner_src:
+                found_conversion = True
+                break
+    assert found_conversion, (
+        "validate_runner missing `int(env) + 1` retries→dispatches "
+        "conversion — off-by-one on the production retry cap"
+    )
+
+
+def test_spine_validate_runner_break_directive_routes_correctly() -> None:
+    """Break directive in validate_runner must capture into
+    _l2_break_directive, then unwind the outer VALIDATE_RETRY loop
+    via the captured-directive pattern (same shape as orchestrator)."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    assert "_l2_break_directive = directive" in src, (
+        "validate_runner doesn't capture break directive — outer-loop "
+        "unwind broken"
+    )
+    assert "if _l2_break_directive is not None:" in src, (
+        "Missing post-inner-loop break-directive handler in validate_runner"
+    )
+
+
+def test_spine_validate_runner_returns_phase_result_on_exhaustion() -> None:
+    """When soft-stop retries exhaust in validate_runner, the function
+    must return a PhaseResult(status='fail') — NOT raw ctx like
+    orchestrator.py. Validate_runner's contract requires PhaseResult."""
+    src = VALIDATE_RUNNER_FILE.read_text()
+    # The exhausted-retries path must build a PhaseResult around the
+    # advanced ctx (visible by the next_ctx=_l2_retries_exhausted_ctx
+    # construction pattern).
+    assert "next_ctx=_l2_retries_exhausted_ctx" in src, (
+        "validate_runner doesn't build PhaseResult from exhausted-ctx "
+        "— contract violation (raw ctx returned)"
     )


### PR DESCRIPTION
fix(governance): Slice 6.1 — apply Slice 6 wiring to validate_runner.py (production VALIDATE_RETRY path)

Closes the "I patched the wrong module" forensic miss from soak
bt-2026-05-25-200829. Slice 6 (PR #57967, commit a467e94dd7)
correctly added the bounded L2 re-dispatch loop + l2_retry directive
handler to ``orchestrator.py:6235``, and ``_l2_hook`` correctly
returned ``('l2_retry', ctx, stop_reason)`` on soft stops.

**But the soak proved the production VALIDATE_RETRY path doesn't
run through that block** — it runs through
``phase_runners/validate_runner.py:431`` which had the OLD format
(no Slice 6 handling). When ``_l2_hook`` returned ``'l2_retry'``,
validate_runner's caller had no matching branch — fell through to
``no_candidate_valid_return`` at line 479, murdering the op the
same way pre-Slice-6 did despite Slice 6 being "live."

## Empirical proof from bt-2026-05-25-200829

  13:15:17  L2 soft stop op=... stop_reason=generate_error:TypeError
            iterations_used=2 — eligible for re-dispatch
            (Slice 6 l2_retry directive)         ← _l2_hook fired correctly
  13:15:17  l2_dispatch_post ... directive='l2_retry'
            ← format string MISSING `attempt=N/M` proves wrong module
  13:15:17  no_candidate_valid_return ... phase=CANCELLED
            ← FALL-THROUGH; op died

The missing ``attempt=N/M`` suffix in the FSM log was the smoking
gun — orchestrator.py's Slice 6 edit produced that suffix;
validate_runner.py's pre-Slice-6 format didn't.

## Fix mechanism — Slice 6 wiring transplanted

Apply the identical bounded re-dispatch loop + ``l2_retry`` handler
in validate_runner.py around the existing ``_l2_hook`` call. Returns
``PhaseResult(status='fail', reason='l2_soft_stop_retries_exhausted')``
on exhaustion (validate_runner's contract requires PhaseResult, not
raw ctx like orchestrator.py).

## Operator bindings honored

* **Lockstep with orchestrator.py** — same env knob, same default,
  same FSM event names (l2_redispatch, l2_soft_retries_exhausted,
  l2_soft_stop), same break-directive capture pattern. Both modules
  guarded by AST pins so future divergence trips the test.
* **PhaseResult contract preserved** — exhausted-retries path
  returns ``PhaseResult`` (not raw ctx) per validate_runner's
  interface. Captured into ``_l2_retries_exhausted_ctx`` and wrapped
  for the return at the post-inner-loop handler.
* **Identical Session V reconciliation** — each retry pass reads
  JARVIS_L2_TIMEBOX_S fresh, so L2 always gets its full 120s window.
* **Manifesto §8** — l2_dispatch_pre and l2_dispatch_post now carry
  ``attempt=N/M`` suffix so operators can immediately distinguish
  the first L2 dispatch from soft-stop retries in the FSM log.

## Test surface — 4 new pins (11/11 total Slice 6 tests green)

The original Slice 6 test file already had 7 pins on orchestrator.py.
Slice 6.1 adds 4 production-path pins on validate_runner.py:

  1. AST pin: validate_runner has JARVIS_L2_DISPATCH_RETRIES env knob,
     _l2_max_dispatches counter, _l2_soft_stop_history audit list,
     _l2_retries_exhausted_ctx terminal carrier, l2_retry directive
     handler, and all three FSM observability tags
  2. Spine: same `int(env) + 1` BinOp regression guard for default
     retry count (lockstep with orchestrator)
  3. Spine: break-directive capture + post-loop unwind pattern
     (preserves L2-converged → GATE semantic)
  4. Spine: PhaseResult contract on exhaustion (`next_ctx=
     _l2_retries_exhausted_ctx` shape — NOT raw ctx)

The test file now AST-pins Slice 6 wiring presence in BOTH modules
so "I patched the wrong file" never regresses.

## Distance to RESOLVED — what this actually unlocks

The Ansible op's L2 cascade pre-Slice-6.1:
  iter 1 (14s tests fail) → iter 2 gen TypeError → L2_STOPPED →
  l2_retry → ❌ validate_runner ignored it → no_candidate_valid_return

With Slice 6.1:
  iter 1 (14s tests fail) → iter 2 gen TypeError → L2_STOPPED →
  l2_retry → ✓ validate_runner re-dispatches → fresh 120s L2 #2 →
  iter 1 of dispatch #2 → (maybe converges) → APPLY → VERIFY →
  **RESOLVED**

1 file changed (validate_runner.py), ~120 insertions(+), ~30 deletions(-)
+ 1 file modified (test_slice6_l2_redispatch.py), +130 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the production VALIDATE_RETRY path by adding Slice 6 L2 re-dispatch wiring to `validate_runner.py` so soft stops trigger bounded retries instead of cancelling. Adds attempt-aware logging and returns a proper `PhaseResult` when retries are exhausted.

- **Bug Fixes**
  - Implemented bounded L2 re-dispatch loop with `l2_retry` handling in `validate_runner.py`; honors `JARVIS_L2_DISPATCH_RETRIES` (+1 dispatches) and refreshes `JARVIS_L2_TIMEBOX_S` per attempt.
  - Captures `break` directives and unwinds to GATE; on exhaustion, advances ctx to CANCELLED and returns `PhaseResult(status='fail', reason='l2_soft_stop_retries_exhausted')`.
  - Adds FSM logs with `attempt=N/M` for `l2_dispatch_pre`/`l2_dispatch_post`, plus `l2_redispatch` and `l2_soft_retries_exhausted` events.
  - Adds tests that pin the Slice 6 wiring in both `validate_runner.py` and `orchestrator.py`, verify the `int(env) + 1` conversion, break-directive unwind, and `PhaseResult` shape on exhaustion.

<sup>Written for commit 45021eede6bd297c6617058f6da3be23d86cae89. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/58009?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

