### PR TITLE
fix(governance): Slice 7 — surface swallowed TypeError traceback in L2 _generate_repair_candidate

### DIFF
--- a/backend/core/ouroboros/governance/repair_engine.py
+++ b/backend/core/ouroboros/governance/repair_engine.py
@@ -1178,6 +1178,41 @@ class RepairEngine:
                 stop_reason=f"provider_iter_timeout:{_effective_timeout_s:.1f}s",
             )
         except Exception as exc:  # noqa: BLE001 — Protocol contract
+            # ──────────────────────────────────────────────────────────
+            # Slice 7 — total observability for L2 generation failures
+            # (bt-2026-05-25-203830 root: Slice 6.1 proved both L2
+            # dispatches threw IDENTICAL `generate_error:TypeError` on
+            # iter 2's _prime.generate call. The exception class was
+            # logged but the actual TypeError message, file, line, and
+            # stack frames were swallowed silently by this handler —
+            # operators had no way to see WHAT was actually broken in
+            # the provider chain. Manifesto §8 violation.)
+            #
+            # Fix: log full traceback at ERROR level BEFORE returning
+            # the quarantined CandidateGenerationResult. ``logger.
+            # exception`` captures exc_info automatically; we include
+            # the op_id (when available on ctx) plus the exception
+            # CLASS + MESSAGE in the structured message so grep can
+            # attribute the failure to a specific op.
+            #
+            # The contract is preserved verbatim: still returns
+            # CandidateGenerationResult(candidate=None,
+            # stop_reason=f"generate_error:{TypeName}"). Slice 5A's
+            # provider_iter_timeout path stays intact. Slice 6/6.1's
+            # l2_retry classification still consumes the stop_reason
+            # identically. Pure diagnostic addition — zero behavior
+            # change to the FSM.
+            # ──────────────────────────────────────────────────────────
+            _op_id_for_log = getattr(ctx, "op_id", "<unknown>")
+            _logger.error(
+                "[L2 Repair] _generate_repair_candidate raised %s: %s "
+                "(op=%s) — quarantining as generate_error stop_reason; "
+                "full traceback follows",
+                type(exc).__name__,
+                str(exc) or "(no message)",
+                _op_id_for_log,
+                exc_info=True,
+            )
             return CandidateGenerationResult(
                 candidate=None,
                 model_id=None,

--- a/tests/governance/test_slice7_traceback_observability.py
+++ b/tests/governance/test_slice7_traceback_observability.py
@@ -1,0 +1,257 @@
+"""Slice 7 — traceback observability for L2 _generate_repair_candidate failures.
+
+Closes the silent-exception gap exposed by soak bt-2026-05-25-203830.
+Slice 6.1 proved that both L2 dispatches threw IDENTICAL
+``generate_error:TypeError`` on iter 2 (logged via ``l2_soft_retries_
+exhausted attempts=2 history=['generate_error:TypeError',
+'generate_error:TypeError']``) but the underlying exception's
+message, file, line, and stack frames were silently swallowed by
+the broad ``except Exception`` at repair_engine.py:1180.
+
+Manifesto §8 (Absolute Observability) violation: operators saw the
+class name but had no way to fix what they couldn't see.
+
+# Fix mechanism — log full traceback at ERROR before quarantine
+
+  except Exception as exc:
+      _logger.error(
+          "[L2 Repair] _generate_repair_candidate raised %s: %s "
+          "(op=%s) — quarantining as generate_error stop_reason; "
+          "full traceback follows",
+          type(exc).__name__, str(exc) or "(no message)",
+          getattr(ctx, "op_id", "<unknown>"),
+          exc_info=True,  # ← attaches full traceback to log record
+      )
+      return CandidateGenerationResult(
+          candidate=None, model_id=None, provider_name=None,
+          stop_reason=f"generate_error:{type(exc).__name__}",
+      )
+
+# Discipline
+
+* Pure diagnostic addition. Return shape unchanged. Stop_reason
+  format unchanged. FSM consumers (Slice 6/6.1 l2_retry handler
+  in orchestrator.py + validate_runner.py) see identical behavior.
+* Slice 5A's provider_iter_timeout path is intact — it returns
+  early BEFORE the generic exception handler.
+* ``exc_info=True`` works on both ``logger.error`` and
+  ``logger.exception`` — we use ``logger.error(..., exc_info=True)``
+  to retain explicit control of the message format.
+
+# Test surface (2 AST pins + 3 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPAIR_ENGINE_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "repair_engine.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_generate_exception_handler_logs_traceback() -> None:
+    """The ``except Exception`` block in ``_generate_repair_candidate``
+    MUST call ``_logger.error(..., exc_info=True)`` (or equivalent)
+    BEFORE returning the quarantined CandidateGenerationResult.
+
+    Without this, TypeErrors and other provider-side exceptions are
+    classified by class name only — operators lose the file, line,
+    and message needed to fix the bug."""
+    src = REPAIR_ENGINE_FILE.read_text()
+    # The Slice 7 attribution + actual logger call + exc_info=True
+    # must all be present in the file
+    assert "Slice 7" in src, (
+        "Slice 7 attribution comment missing — diagnostic context lost"
+    )
+    assert "_generate_repair_candidate raised" in src, (
+        "Slice 7 log message stem missing — handler lacks traceback log"
+    )
+    assert "exc_info=True" in src, (
+        "exc_info=True NOT in repair_engine — traceback is still "
+        "swallowed by the broad except (Manifesto §8 violation)"
+    )
+
+
+def test_ast_pin_handler_log_precedes_return() -> None:
+    """The logger.error call must come BEFORE the return statement
+    inside the except block — logging AFTER return is unreachable."""
+    tree = ast.parse(REPAIR_ENGINE_FILE.read_text(), filename=str(REPAIR_ENGINE_FILE))
+
+    found_handler = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ExceptHandler):
+            continue
+        if node.type is None or not isinstance(node.type, ast.Name):
+            continue
+        if node.type.id != "Exception":
+            continue
+        # Find the body — look for a call to _logger.error and a
+        # subsequent return with CandidateGenerationResult
+        has_log = False
+        has_return = False
+        for stmt in node.body:
+            # logger.error or _logger.error call
+            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+                call = stmt.value
+                if (
+                    isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "error"
+                    and any(
+                        isinstance(kw, ast.keyword) and kw.arg == "exc_info"
+                        for kw in call.keywords
+                    )
+                ):
+                    has_log = True
+            elif isinstance(stmt, ast.Return):
+                # Return must come AFTER the log to be observable
+                if has_log:
+                    has_return = True
+        if has_log and has_return:
+            found_handler = True
+            break
+
+    assert found_handler, (
+        "No ExceptionHandler with logger.error(exc_info=True) preceding "
+        "a Return statement found — Slice 7 wiring inert"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spine_typeerror_traceback_actually_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Functional test — force a TypeError in the provider's generate
+    call and verify the full traceback lands in caplog at ERROR level.
+    This is the exact scenario from bt-2026-05-25-203830."""
+    from backend.core.ouroboros.governance.repair_engine import (
+        RepairBudget, RepairEngine,
+    )
+
+    class _TypeErrorProvider:
+        async def generate(self, ctx, deadline, repair_context=None):
+            # Simulate the exact failure mode from bt-2026-05-25-203830
+            raise TypeError(
+                "unsupported operand type(s) for +: 'NoneType' and 'str'"
+            )
+
+    engine = RepairEngine(
+        budget=RepairBudget(per_iter_provider_timeout_s=10.0),
+        prime_provider=_TypeErrorProvider(),
+        repo_root="/tmp",
+        sandbox_factory=lambda *a, **k: None,
+    )
+
+    class _Ctx:
+        op_id = "test-op-slice7"
+
+    caplog.set_level(logging.ERROR)
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+    outcome = await engine._generate_repair_candidate(
+        _Ctx(), deadline, repair_context={},
+    )
+
+    # Verify the contract is preserved (Slice 6 still sees the
+    # generate_error stop_reason and classifies as SOFT)
+    assert outcome.candidate is None
+    assert outcome.stop_reason == "generate_error:TypeError"
+
+    # Verify the traceback was logged (Slice 7 deliverable)
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records, "No ERROR log emitted on TypeError — Slice 7 inert"
+
+    # The log record must carry exc_info (traceback)
+    record_with_traceback = [r for r in error_records if r.exc_info]
+    assert record_with_traceback, (
+        "No ERROR record has exc_info attached — traceback still hidden"
+    )
+
+    # The specific TypeError message must appear in the log
+    message_text = "\n".join(r.getMessage() for r in error_records)
+    assert "TypeError" in message_text, (
+        "TypeError class name not in log message"
+    )
+    # op_id attribution
+    assert "test-op-slice7" in message_text, (
+        "op_id not in log message — operators can't attribute failures"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spine_provider_iter_timeout_path_does_not_log_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Slice 5A's provider_iter_timeout path (asyncio.TimeoutError) must
+    NOT trigger the Slice 7 error log — it has its own warning-level
+    handler with structured detail. Slice 7 must not pollute timeouts
+    with extra ERROR-level noise."""
+    from backend.core.ouroboros.governance.repair_engine import (
+        RepairBudget, RepairEngine,
+    )
+
+    class _SlowProvider:
+        async def generate(self, ctx, deadline, repair_context=None):
+            await asyncio.sleep(10)  # exceeds 1s bound
+
+    engine = RepairEngine(
+        budget=RepairBudget(per_iter_provider_timeout_s=1.0),
+        prime_provider=_SlowProvider(),
+        repo_root="/tmp",
+        sandbox_factory=lambda *a, **k: None,
+    )
+
+    class _Ctx:
+        op_id = "test-op-slice7-timeout"
+
+    caplog.set_level(logging.ERROR)
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+    outcome = await engine._generate_repair_candidate(
+        _Ctx(), deadline, repair_context={},
+    )
+
+    assert outcome.candidate is None
+    assert outcome.stop_reason is not None
+    assert outcome.stop_reason.startswith("provider_iter_timeout:")
+
+    # No ERROR-level traceback for the timeout path
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    # Slice 5A uses logger.warning (not error) for this path
+    assert not error_records, (
+        f"Slice 7 incorrectly logged ERROR on timeout path: {error_records}"
+    )
+
+
+def test_spine_contract_preserved_byte_equivalent() -> None:
+    """Verify the public contract: CandidateGenerationResult shape
+    on exception is UNCHANGED (Slice 6/6.1 consumers still see the
+    same stop_reason format). Pure diagnostic — zero behavior change."""
+    src = REPAIR_ENGINE_FILE.read_text()
+    # The exact stop_reason format that Slice 6/6.1's classification
+    # depends on must still be present
+    assert 'stop_reason=f"generate_error:{type(exc).__name__}"' in src, (
+        "Slice 7 broke the stop_reason format — Slice 6.1 SOFT/HARD "
+        "classifier will see unexpected shape"
+    )
+    # The CandidateGenerationResult shape (4 named args) must still
+    # be the return shape on exception
+    assert "candidate=None" in src
+    assert "model_id=None" in src
+    assert "provider_name=None" in src


### PR DESCRIPTION
fix(governance): Slice 7 — surface swallowed TypeError traceback in L2 _generate_repair_candidate

Closes the silent-exception gap exposed by soak bt-2026-05-25-203830.
Slice 6.1 proved the L2 dispatch loop fires perfectly (both attempts
ran, fresh budget honored, full audit cascade with l2_redispatch +
l2_soft_retries_exhausted events), but both dispatches threw IDENTICAL
``generate_error:TypeError`` on iter 2's ``_prime.generate`` call and
the underlying exception was silently swallowed by the broad
``except Exception`` at repair_engine.py:1180.

## Manifesto §8 violation surfaced

Operators saw:

  l2_soft_retries_exhausted ... history=['generate_error:TypeError',
                                          'generate_error:TypeError']

But couldn't see:

  - WHAT the TypeError message was
  - WHICH file/line raised it
  - WHICH variable/operation caused it
  - HOW to fix it

Pre-Slice-7 handler:

  except Exception as exc:  # noqa: BLE001 — Protocol contract
      return CandidateGenerationResult(
          candidate=None, model_id=None, provider_name=None,
          stop_reason=f"generate_error:{type(exc).__name__}",
      )

Class name only. Total observability principle violated.

## Fix mechanism — log full traceback at ERROR before quarantine

  except Exception as exc:  # noqa: BLE001 — Protocol contract
      _op_id_for_log = getattr(ctx, "op_id", "<unknown>")
      _logger.error(
          "[L2 Repair] _generate_repair_candidate raised %s: %s "
          "(op=%s) — quarantining as generate_error stop_reason; "
          "full traceback follows",
          type(exc).__name__, str(exc) or "(no message)",
          _op_id_for_log,
          exc_info=True,  # ← attaches full stack frames to record
      )
      return CandidateGenerationResult(
          candidate=None, model_id=None, provider_name=None,
          stop_reason=f"generate_error:{type(exc).__name__}",
      )

## Operator bindings honored

* **Pure diagnostic — zero behavior change** — Return shape
  unchanged. ``stop_reason=f"generate_error:{type(exc).__name__}"``
  format unchanged. Slice 6/6.1's l2_retry classifier sees identical
  bytes. Slice 5A's provider_iter_timeout path is intact (returns
  early before this handler — spine-tested).
* **Manifesto §8 (Absolute Observability)** — Every L2 generation
  failure now produces a structured ERROR-level log record with
  full traceback attached via ``exc_info=True``. Operators get
  file, line, and variable in the exact frame that threw.
* **Op attribution** — Log message carries ``op=<op_id>`` so grep
  can pin a specific failure to a specific operation across the
  session.
* **No exception swallowing in OTHER hot paths** — Slice 7 scope
  is strictly the one handler proven to swallow real exceptions
  in production. Other ``except Exception`` blocks in repair_engine
  remain as they were (most are fail-open infrastructure paths,
  documented as such — premature noise would violate restraint).
* **AST-pinned** — 2 pins enforce the discipline:
  (1) ``exc_info=True`` + Slice 7 attribution + log stem present
  (2) AST walk confirms the logger.error call is in an
      ExceptionHandler matching ``except Exception`` AND precedes
      a Return statement (logging-after-return = unreachable)

## Test surface (2 AST pins + 3 spine, 5/5 green; +134 arc tests)

AST pins (2):
  1. ``Slice 7`` attribution + ``_generate_repair_candidate raised``
     log stem + ``exc_info=True`` kwarg all present in source
  2. AST walks for ExceptionHandler with logger.error(exc_info=True)
     that PRECEDES a Return statement — regression guard against
     accidental reorder making the log unreachable

Spine (3):
  - Functional: force TypeError in provider, verify caplog catches
    ERROR record with exc_info attached AND TypeError class name +
    op_id in the formatted message (reproduces bt-2026-05-25-203830)
  - Negative: provider_iter_timeout (Slice 5A path) does NOT trigger
    the Slice 7 ERROR log — that path has its own warning-level
    handler with structured detail. No double-log noise.
  - Contract: stop_reason format byte-equivalent + return shape
    preserved — Slice 6/6.1 consumers see identical signal

## Next — bt-2026-05-26 detonation

Re-launch $5/3600s ansible soak. On the next Ansible op iter 2 the
ERROR log will reveal the exact frame throwing TypeError. With that
in hand, Slice 8 fixes the underlying provider-chain bug. We are
no longer guessing.

1 file changed (repair_engine.py), ~36 insertions(+), ~1 deletion(-)
+ 1 file added (test_slice7_traceback_observability.py), ~245 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces full tracebacks for L2 generation failures by logging at ERROR with `exc_info=True` in `_generate_repair_candidate`, fixing the silent TypeError seen in soak `bt-2026-05-25-203830`. No behavior change; `stop_reason` and return shape are unchanged.

- Bug Fixes
  - Log full traceback via `_logger.error(..., exc_info=True)` before returning `generate_error:<TypeName>`.
  - Include `op_id` in the message to attribute failures to specific operations.
  - Preserve timeout path behavior (no extra ERROR logs) and add AST + spine tests to guard logging and contract.

<sup>Written for commit 1da14852afbebbce761f5dcafdd83d1b4d9fe1b4. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/58034?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

