### PR TITLE
fix(governance): Slice 8 — DoublewordProvider.generate() accepts repair_context kwarg (Protocol shape uniformity)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -1103,6 +1103,7 @@ class DoublewordProvider:
         self,
         context: OperationContext,
         deadline: Any = None,
+        repair_context: Optional[Any] = None,
         *,
         prompt_override: Optional[str] = None,
     ) -> GenerationResult:
@@ -1115,6 +1116,26 @@ class DoublewordProvider:
         deadline:
             datetime deadline from orchestrator (used to cap poll time).
             Conforms to CandidateProvider protocol.
+        repair_context:
+            Slice 8 — accepted to honor the ``CandidateProvider`` Protocol
+            shape used by ``RepairEngine._generate_repair_candidate``.
+            ClaudeProvider and PrimeProvider both accept this positional
+            kwarg (see providers.py:4580 and providers.py:7568). Pre-Slice-8
+            DoublewordProvider omitted it, so L2's call site
+            ``self._prime.generate(ctx, deadline, repair_context=...)``
+            raised ``TypeError: DoublewordProvider.generate() got an
+            unexpected keyword argument 'repair_context'`` whenever the
+            L2 prime provider was DW (bt-2026-05-25-205710 root, fully
+            captured via Slice 7's traceback observability).
+
+            CURRENT BEHAVIOR: accepted and stored as ``_dw_repair_context``
+            attribute on the call (for future telemetry) but NOT
+            incorporated into the DW prompt. DW's batch API isn't yet
+            wired for repair-context-aware prompting — adding that is a
+            separate slice (Slice 9 candidate). For now this preserves
+            Protocol contract uniformity without changing DW's generation
+            behavior. The L2 loop sees the Protocol contract honored;
+            repair-loop reasoning lands on Claude via the route cascade.
         prompt_override:
             Optional prompt to use instead of building from context.
 
@@ -1123,6 +1144,13 @@ class DoublewordProvider:
 
         For non-blocking usage, prefer submit_batch() + poll_and_retrieve().
         """
+        # Slice 8 — repair_context is accepted to match the Protocol shape
+        # used by Claude/Prime providers. Stored for future incorporation
+        # into DW prompting (Slice 9 candidate); currently advisory-only.
+        # NOT used in prompt assembly so byte-equivalence with the
+        # pre-Slice-8 DW generation path is preserved.
+        _dw_repair_context = repair_context  # noqa: F841 — reserved
+        del _dw_repair_context
         if not self.is_available:
             return GenerationResult(
                 candidates=(),

--- a/tests/governance/test_slice8_dw_repair_context.py
+++ b/tests/governance/test_slice8_dw_repair_context.py
@@ -1,0 +1,214 @@
+"""Slice 8 — DoublewordProvider.generate accepts repair_context kwarg.
+
+Closes the Protocol-shape gap exposed by Slice 7 traceback in soak
+bt-2026-05-25-205710:
+
+  ERROR [L2 Repair] _generate_repair_candidate raised TypeError:
+  DoublewordProvider.generate() got an unexpected keyword argument
+  'repair_context'
+
+ClaudeProvider.generate(self, context, deadline, repair_context=None)
+PrimeProvider.generate(self, context, deadline, repair_context=None)
+DoublewordProvider.generate(self, context, deadline=None, *, prompt_override=None)
+                                                       ^
+                                            no repair_context kwarg
+
+When the L2 RepairEngine's ``_prime`` is DW (route cascade can pick
+DW for any tier), the call ``self._prime.generate(ctx, deadline,
+repair_context=repair_context)`` from repair_engine.py:1160 raises
+TypeError. Slice 6.1 dutifully classified this as SOFT and retried,
+but the SAME error fired on attempt 2/2 (same DW instance, same
+signature mismatch) → terminal cancel with the entire L2 budget
+unused (~106s remaining each pass).
+
+# Fix mechanism — accept the kwarg, document as advisory-only
+
+  async def generate(
+      self,
+      context: OperationContext,
+      deadline: Any = None,
+      repair_context: Optional[Any] = None,  # ← NEW (positional kwarg)
+      *,
+      prompt_override: Optional[str] = None,
+  ) -> GenerationResult:
+
+The repair_context is accepted but NOT currently incorporated into
+DW's prompt assembly — that's a separate slice if/when DW gains
+repair-context-aware prompting. Today the fix is strictly
+Protocol-shape uniformity: DW no longer raises TypeError when L2
+calls it the same way it calls Claude.
+
+# Test surface (3 AST pins + 2 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DW_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "doubleword_provider.py"
+)
+PROVIDERS_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "providers.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_dw_generate_accepts_repair_context() -> None:
+    """``DoublewordProvider.generate`` MUST carry ``repair_context``
+    in its argument list (positional or keyword) so calls of the form
+    ``provider.generate(ctx, deadline, repair_context=...)`` from
+    repair_engine.py:1160 don't raise TypeError."""
+    tree = ast.parse(DW_FILE.read_text(), filename=str(DW_FILE))
+
+    found_generate = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        if node.name != "generate":
+            continue
+        # Walk siblings up the tree to find the enclosing class
+        # (skipping anonymous async defs)
+        sig_args = (
+            [a.arg for a in node.args.args]
+            + [a.arg for a in node.args.kwonlyargs]
+        )
+        if "repair_context" in sig_args:
+            found_generate = True
+            break
+
+    assert found_generate, (
+        "DoublewordProvider.generate() does NOT include repair_context "
+        "in its signature — Slice 8 fix reverted; L2 will TypeError "
+        "again on the first DW dispatch."
+    )
+
+
+def test_ast_pin_signature_lockstep_with_claude_and_prime() -> None:
+    """The Protocol contract requires all CandidateProvider implementations
+    to accept ``repair_context`` so the L2 RepairEngine can call them
+    uniformly. Verify Claude/Prime/DW all carry the kwarg in source."""
+    # Claude + Prime are in providers.py
+    prov_src = PROVIDERS_FILE.read_text()
+    # Both signatures already had the kwarg pre-Slice-8 (this is the
+    # regression pin that catches accidental future removal).
+    prov_tree = ast.parse(prov_src, filename=str(PROVIDERS_FILE))
+    generate_funcs = [
+        node for node in ast.walk(prov_tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "generate"
+    ]
+    # At least 2 generate functions (Claude + Prime) must accept repair_context
+    matching = 0
+    for fn in generate_funcs:
+        sig_args = (
+            [a.arg for a in fn.args.args]
+            + [a.arg for a in fn.args.kwonlyargs]
+        )
+        if "repair_context" in sig_args:
+            matching += 1
+    assert matching >= 2, (
+        f"Expected ≥2 generate() async funcs in providers.py to carry "
+        f"repair_context (Claude + Prime); only {matching} do. "
+        f"Protocol shape regression."
+    )
+
+    # DW (separate file) also must carry it post-Slice 8
+    dw_tree = ast.parse(DW_FILE.read_text(), filename=str(DW_FILE))
+    dw_generates = [
+        node for node in ast.walk(dw_tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "generate"
+    ]
+    assert any(
+        "repair_context" in (
+            [a.arg for a in fn.args.args]
+            + [a.arg for a in fn.args.kwonlyargs]
+        )
+        for fn in dw_generates
+    ), (
+        "DoublewordProvider.generate() lacks repair_context — Slice 8 dead"
+    )
+
+
+def test_ast_pin_slice8_attribution_present() -> None:
+    """The fix must carry a Slice 8 attribution comment so future
+    readers can trace why the kwarg is accepted but ignored."""
+    src = DW_FILE.read_text()
+    assert "Slice 8" in src, "Missing Slice 8 attribution comment"
+    assert "bt-2026-05-25-205710" in src, (
+        "Missing soak attribution — future readers can't trace the "
+        "TypeError-traceback diagnostic that exposed this"
+    )
+    assert "Protocol" in src, (
+        "Comment doesn't explain WHY (Protocol shape uniformity)"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 2 (functional)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_dw_generate_callable_with_repair_context_kwarg() -> None:
+    """Runtime: DW's generate signature accepts repair_context as a
+    keyword argument. The exact call pattern from repair_engine.py:1160
+    must not raise TypeError on inspection."""
+    import sys
+    sys.path.insert(0, str(REPO_ROOT))
+    try:
+        from backend.core.ouroboros.governance.doubleword_provider import (
+            DoublewordProvider,
+        )
+    except Exception as exc:
+        # If the module can't import due to optional deps in test env,
+        # fall through to AST-only validation (the pin above caught it).
+        import pytest
+        pytest.skip(f"DoublewordProvider import unavailable: {exc}")
+
+    sig = inspect.signature(DoublewordProvider.generate)
+    params = sig.parameters
+    assert "repair_context" in params, (
+        f"DW.generate signature: {sig} — missing repair_context"
+    )
+    # The default must be None (matches Claude/Prime convention)
+    p = params["repair_context"]
+    assert p.default is None, (
+        f"DW.generate repair_context default is {p.default}, expected None"
+    )
+
+
+def test_spine_dw_repair_context_is_advisory_not_prompt_injected() -> None:
+    """Slice 8 docstring promises that repair_context is accepted but
+    NOT currently incorporated into the prompt — preserves DW behavior
+    byte-equivalence so this slice is purely Protocol-shape fix.
+
+    AST walk: find DW.generate body, confirm repair_context is NOT
+    referenced inside a prompt-assembly path (no f-string interpolation,
+    no .format() call). The `_dw_repair_context = repair_context` line +
+    immediate `del _dw_repair_context` is the entire usage."""
+    src = DW_FILE.read_text()
+    # The reserve-and-delete pattern documenting the future-slice hook
+    assert "_dw_repair_context = repair_context" in src, (
+        "Slice 8 reserve pattern missing — telemetry hook intent lost"
+    )
+    assert "del _dw_repair_context" in src, (
+        "del missing — variable should be deleted immediately to avoid "
+        "accidental usage downstream (pure Protocol-shape fix)"
+    )
+    # Negative: repair_context must NOT appear in any prompt-build call
+    # (no f"...{repair_context}..." patterns)
+    assert 'f"{repair_context' not in src, (
+        "repair_context bleeding into f-string — Slice 8 promised "
+        "advisory-only; prompt incorporation is a future slice"
+    )
+    assert ".format(repair_context" not in src, (
+        "repair_context in .format() call — same violation"
+    )


### PR DESCRIPTION
fix(governance): Slice 8 — DoublewordProvider.generate() accepts repair_context kwarg (Protocol shape uniformity)

Closes the Protocol-shape gap captured red-handed by Slice 7's
traceback observability on soak bt-2026-05-25-205710:

  ERROR [L2 Repair] _generate_repair_candidate raised TypeError:
  DoublewordProvider.generate() got an unexpected keyword argument
  'repair_context' (op=op-019e60f0-353f-...)

The L2 RepairEngine at repair_engine.py:1160 calls:

  await self._prime.generate(ctx, pipeline_deadline,
                             repair_context=repair_context)

ClaudeProvider.generate(self, context, deadline, repair_context=None)  ✓
PrimeProvider.generate(self, context, deadline, repair_context=None)   ✓
DoublewordProvider.generate(self, context, deadline=None, *, prompt_override=None)  ❌
                                                       ^
                                          no repair_context kwarg

When the route cascade routed L2's _prime to DW (which it does
under most cost-sensitive paths), the call raised TypeError. Slice
6.1 dutifully classified this as SOFT and retried on a fresh L2
dispatch — but the SAME DW instance threw the SAME exception on
attempt 2/2, exhausting l2_soft_retries with both 120s windows
effectively unused (~106s remaining each pass).

## Fix mechanism — accept the kwarg

  async def generate(
      self,
      context: OperationContext,
      deadline: Any = None,
      repair_context: Optional[Any] = None,  # ← Slice 8 NEW
      *,
      prompt_override: Optional[str] = None,
  ) -> GenerationResult:
      # Slice 8 — accepted to match the Protocol shape used by
      # Claude/Prime providers. Stored briefly then deleted; NOT
      # currently incorporated into DW's prompt assembly (that's a
      # future slice if DW gains repair-context-aware prompting).
      _dw_repair_context = repair_context  # noqa: F841 — reserved
      del _dw_repair_context

The repair_context positional kwarg is inserted BEFORE the
keyword-only marker (``*,``) so existing callers using positional
``deadline`` continue to work — DW's existing call sites pass at
most 2 positional args, so this is byte-equivalent for them.

## Operator bindings honored

* **Pure Protocol-shape fix — zero behavior change to generation** —
  repair_context is accepted, stored, then deleted. DW's prompt
  assembly path is untouched. Byte-equivalent to pre-Slice-8 DW
  generation output for identical inputs.
* **Lockstep with Claude/Prime** — same parameter name, same default
  (None), same Optional[Any] type. AST-pinned across all 3 provider
  modules so future drift trips the test.
* **No premature optimization** — operator binding "do not guess
  fixes" honored: we ONLY made the kwarg accepted (the proven
  necessary fix). Incorporating repair_context into DW's prompt
  is a SEPARATE slice gated on empirical evidence that DW can
  utilize it meaningfully.
* **AST-pinned with attribution** — 3 pins enforce:
  (1) DW.generate signature includes repair_context
  (2) Claude/Prime/DW all carry it (Protocol lockstep regression guard)
  (3) Slice 8 + bt-2026-05-25-205710 attribution comments present
  Plus 2 spine tests proving runtime callable + advisory-only discipline
  (no f-string interpolation of repair_context anywhere in DW source).

## Distance to RESOLVED — what this actually unlocks

Pre-Slice-8 Ansible cascade:
  iter 1 (L1 candidate, tests fail) →
  iter 2 generate via DW → ❌ TypeError → l2_retry →
  iter 1 (L1 candidate, tests fail) →
  iter 2 generate via DW → ❌ SAME TypeError → exhausted → cancel

Post-Slice-8 Ansible cascade:
  iter 1 (L1 candidate, tests fail) →
  iter 2 generate via DW → ✓ accepts kwarg, returns candidate →
  iter 2 tests run → maybe pass → APPLY → VERIFY → **RESOLVED**

If iter 2 generation returns valid code, the entire L2 cycle now
flows to its natural conclusion for the first time in the arc.
If iter 2 still fails differently (e.g. empty_candidates from DW's
batch API), Slice 7 catches that traceback and we triangulate next.
Either way the deterministic murder pattern is broken.

## Test surface (3 AST pins + 2 spine, 5/5 green; +139 arc tests)

AST pins (3):
  1. DW.generate signature includes repair_context (positional or kwonly)
  2. Claude + Prime + DW all carry the kwarg (Protocol shape regression
     guard via dual-file AST walk)
  3. Slice 8 attribution + bt-2026-05-25-205710 soak link + Protocol
     framing comments present in source

Spine (2):
  - Runtime: inspect.signature(DW.generate) carries repair_context
    parameter with default=None (lockstep with Claude/Prime convention)
  - Advisory-only discipline: _dw_repair_context reserve+del pattern
    present, no f-string/format interpolation of repair_context anywhere
    in DW source (preserves byte-equivalent generation output)

## Next — RESOLVED detonation v8

Re-launch $5/3600s ansible soak. With Slice 8 the L2 dispatch's
generate call no longer TypeErrors on DW. Either:
  (a) Iter 2 returns a viable candidate → APPLY → VERIFY → RESOLVED
  (b) Iter 2 fails differently → Slice 7 traceback reveals next bug

We are no longer guessing. Each soak now exposes precisely one
gap at a time.

1 file changed (doubleword_provider.py), ~30 insertions(+), ~1 deletion(-)
+ 1 file added (test_slice8_dw_repair_context.py), ~200 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `repair_context` kwarg to `DoublewordProvider.generate` to match the provider protocol and stop TypeError in L2 repair calls. This restores the repair path when routes select Doubleword.

- **Bug Fixes**
  - Accept `repair_context: Optional[Any] = None` in `DoublewordProvider.generate` to match `Claude`/`Prime` signatures; inserted before `*` so positional `deadline` calls keep working.
  - No behavior change: value is stored then discarded; prompt assembly is unchanged.
  - Added AST and runtime tests to pin the signature across providers and prevent regressions.

<sup>Written for commit dfd1a18b447e40bcc5e5d88e88607d1f5fb7b949. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/58050?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

