### PR TITLE
chore(cursor): add .cursorignore to reduce IDE indexer churn

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,42 @@
+# Cursor ignore — keeps the AI indexer + @-mention picker out of noisy paths.
+# Format is .gitignore-compatible. Affects Cursor's AI features only;
+# does NOT affect git.
+
+# iCloud / Finder conflicted-copy duplicates ("foo 2.md", "foo 2.py", etc).
+# There are ~2,286 of these in the tree — pure noise for the indexer.
+**/* 2.*
+**/* 3.*
+**/* [0-9].*
+
+# Large legacy / historical docs that should not be retrieved by AI search.
+docs/LEGACY_SESSION_HISTORY.md
+
+# Generated / runtime state (already in .gitignore, listed here for
+# defense-in-depth so Cursor's indexer skips them even if a stray copy
+# slips outside .gitignore).
+.ouroboros/
+.jarvis/
+.worktrees/
+worktrees/
+venv/
+.venv/
+node_modules/
+
+# Build / cache artifacts.
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.hypothesis/
+.tox/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+
+# Logs and large session artifacts.
+*.log
+debug.log
+.ouroboros/sessions/


### PR DESCRIPTION
## Summary
- Add `.cursorignore` to keep Cursor's AI indexer and `@`-mention picker out of noisy paths.
- Excludes ~2,286 iCloud-conflict `<name> 2.<ext>` duplicate files, the 1.6MB `docs/LEGACY_SESSION_HISTORY.md`, and defense-in-depth re-exclusion of already-gitignored heavy dirs (`.ouroboros/`, `.jarvis/`, `worktrees/`, `venv/`).
- Resolves Cursor chat "Taking longer than expected…" stalls caused by per-request context bloat and indexer churn.

## Test plan
- [x] Confirmed `.cursorignore` is at repo root and uses standard `.gitignore`-compatible glob syntax.
- [ ] After merge, reload Cursor window (`Cmd+Shift+P` → "Developer: Reload Window") so the indexer rebuilds against the new ignore file.
- [ ] Re-run a Cursor chat query that previously hung; verify response latency returns to normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.cursorignore` to keep Cursor’s indexer and @-mention picker out of noisy paths. This cuts index churn and fixes chat stalls from oversized context.

- Excludes conflicted-copy duplicates (e.g., `* 2.*`), the large `docs/LEGACY_SESSION_HISTORY.md`, and generated dirs like `.ouroboros/`, `.jarvis/`, `worktrees/`, `venv/`, and `node_modules/`.

**Migration**
- Reload Cursor to rebuild the index: Cmd+Shift+P → “Developer: Reload Window”.

<sup>Written for commit a1ebae4db317601c123622ab15fc27cd01ae5746. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/58073?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

