### PR TITLE
fix(governance): Slice 9 — L2 single-shot fast path bypasses Venom tool loop for _generate_repair_candidate

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -1658,6 +1658,21 @@ class DoublewordProvider:
             _complexity in ("trivial", "simple")
             or should_skip_venom_for_route(str(_route))
         )
+        # ──────────────────────────────────────────────────────────────
+        # Slice 9 — L2 single-shot fast path (DW mirror)
+        # See PrimeProvider providers.py:4710 for full rationale.
+        # bt-2026-05-25-211028 deterministic tool_loop_starved bail
+        # also affects DW when L2 routes to it. ``repair_context``
+        # presence signals L2's _generate_repair_candidate is the
+        # caller (Slice 8 made the kwarg accepted; Slice 9 routes
+        # L2 around the tool loop entirely).
+        # ──────────────────────────────────────────────────────────────
+        if repair_context is not None and not _will_skip_tools:
+            logger.info(
+                "[DoublewordProvider] L2 repair_context detected — Slice 9 "
+                "single-shot fast path: skipping Venom tool loop"
+            )
+            _will_skip_tools = True
         _tools_available = self._tool_loop is not None and not _will_skip_tools
         _preloaded_files: List[str] = []
         if prompt_override:

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -4718,6 +4718,35 @@ class PrimeProvider:
                 "loop kept active (mutation tools refused by policy Rule 0d)",
                 _route,
             )
+        # ──────────────────────────────────────────────────────────────
+        # Slice 9 — L2 single-shot fast path
+        # (bt-2026-05-25-211028 root: L2's _generate_repair_candidate
+        # was deterministically bailing inside the tool loop with
+        # ``tool_loop_starved_below_min_ttft_floor:projected=9.69s
+        # min_ttft_floor=45s`` because the L2 op budget (97s remaining
+        # with 1 round_left) clamped per_round_timeout to max_per_round_s
+        # which sat just below the effective floor (9.69 < 10).
+        # Both Slice 6.1 re-dispatches hit the same wall.)
+        #
+        # L2 has all context it needs in the prompt (target file,
+        # failing test output, prior critique) — it needs SYNTHESIS,
+        # not multi-turn EXPLORATION. Spinning up Venom for a micro-fix
+        # is a category error: the model would never call a tool.
+        #
+        # Hook: when ``repair_context is not None``, the caller is L2's
+        # _generate_repair_candidate (the only call site that passes
+        # this parameter — verified by repo-wide grep). Force-skip the
+        # tool loop unconditionally on this path. The model receives
+        # the full L2 prompt and produces a patch in a single turn,
+        # completely bypassing the BudgetPlan.is_next_round_viable gate.
+        # ──────────────────────────────────────────────────────────────
+        if repair_context is not None and not _skip_tools:
+            logger.info(
+                "[PrimeProvider] L2 repair_context detected — Slice 9 "
+                "single-shot fast path: skipping Venom tool loop "
+                "(L2 synthesizes from prompt, no tool exploration needed)"
+            )
+            _skip_tools = True
 
         tool_records: tuple = ()
         venom_edits: Tuple[Dict[str, Any], ...] = ()
@@ -8499,6 +8528,20 @@ class ClaudeProvider:
                 "loop kept active (mutation tools refused by policy Rule 0d)",
                 _route,
             )
+        # ──────────────────────────────────────────────────────────────
+        # Slice 9 — L2 single-shot fast path (ClaudeProvider mirror)
+        # See PrimeProvider block at providers.py:4710 for full
+        # rationale. When repair_context is not None the caller is
+        # L2's _generate_repair_candidate; skip Venom unconditionally
+        # so the model produces the patch in a single turn (no tool
+        # rounds = no tool_loop_starved_below_min_ttft_floor bail).
+        # ──────────────────────────────────────────────────────────────
+        if repair_context is not None and not _skip_tools:
+            logger.info(
+                "[ClaudeProvider] L2 repair_context detected — Slice 9 "
+                "single-shot fast path: skipping Venom tool loop"
+            )
+            _skip_tools = True
 
         # Zero-Waste S1 (D2) cache gate. Eligible only when the
         # provider-response cache is enabled AND no tool loop will

--- a/tests/governance/test_slice9_l2_single_shot.py
+++ b/tests/governance/test_slice9_l2_single_shot.py
@@ -1,0 +1,215 @@
+"""Slice 9 — L2 single-shot fast path bypasses Venom tool loop.
+
+Closes the deterministic tool-loop bail surfaced by soak
+bt-2026-05-25-211028 after Slice 8 unblocked DW's signature:
+
+  ERROR [L2 Repair] _generate_repair_candidate raised RuntimeError:
+  tool_loop_starved_below_min_ttft_floor:round=1,remaining=97.25s,
+  projected_per_round=9.69s,min_ttft_floor=45.00s
+
+The BudgetPlan.is_next_round_viable gate fires when
+``per_round_timeout < min(min_ttft_floor_s, max_per_round_s)``.
+For L2 contexts, fair_share clamps to max_per_round_s (~10s)
+which sits BELOW min_ttft_floor (45s) → effective_floor = 10s
+→ per_round_timeout=9.69 < 10 → bail.
+
+Both Slice 6.1 re-dispatches hit the SAME wall:
+``history=['generate_error:RuntimeError', 'generate_error:RuntimeError']``
+
+# Architectural insight
+
+L2 has all context it needs to synthesize a fix:
+  - target file path
+  - original code
+  - prior patch attempt
+  - pytest failure output / critique
+
+It does NOT need to EXPLORE via tools. Spinning up Venom for a
+micro-fix is a category error — the model would never call a tool
+in this context. Yet the tool-loop bail check still fires.
+
+# Fix mechanism — repair_context as the single-shot signal
+
+L2's ``_generate_repair_candidate`` is the ONLY call site that
+passes ``repair_context=`` (verified by repo-wide grep:
+repair_engine.py:727 and :1161). So presence of repair_context is
+a reliable signal that we're on the L2 path.
+
+In both PrimeProvider.generate and ClaudeProvider.generate, when
+``repair_context is not None``, force ``_skip_tools = True``. The
+existing gate ``if self._tool_loop is not None and not _skip_tools:``
+already protects the tool-loop entry — set _skip_tools=True and
+the model takes the non-tool single-shot path naturally.
+
+# Discipline
+
+* Hook key: ``repair_context is not None`` — no new parameter,
+  no new env knob, no new state. The Protocol shape already
+  carries the signal Slice 8 made uniform.
+* Mirrored in BOTH providers (Prime + Claude). AST-pinned to
+  catch drift.
+* DoublewordProvider doesn't run a Venom tool loop in its
+  generate path — its batch API is structurally single-shot
+  already, so no edit needed there. (Slice 8 just gave it the
+  kwarg.)
+* Pre-existing route-based skips (background / speculative /
+  wiring_validation) are preserved verbatim — Slice 9 only adds
+  one more reason to skip, never disables an existing skip.
+
+# Test surface (2 AST pins + 3 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROVIDERS_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "providers.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_both_providers_skip_tools_on_repair_context() -> None:
+    """BOTH PrimeProvider.generate AND ClaudeProvider.generate must
+    carry the Slice 9 guard ``if repair_context is not None and not
+    _skip_tools: _skip_tools = True``. Without both, a provider chain
+    routed to the un-patched provider deterministically bails inside
+    the tool loop on the L2 path."""
+    src = PROVIDERS_FILE.read_text()
+    # The exact guard expression — both occurrences must be present
+    guard_count = src.count("repair_context is not None and not _skip_tools")
+    assert guard_count >= 2, (
+        f"Expected ≥2 Slice 9 guards (Prime + Claude); found {guard_count}. "
+        "If only one provider skips, the L2 path could still deterministically "
+        "bail when route cascade picks the un-patched provider."
+    )
+    # The skip assignment must follow each guard
+    skip_assignments = src.count("_skip_tools = True")
+    assert skip_assignments >= 2, (
+        f"Expected ≥2 _skip_tools = True assignments in Slice 9 blocks; "
+        f"found {skip_assignments}"
+    )
+    # Slice 9 attribution + bt soak link present
+    assert "Slice 9" in src
+    assert "bt-2026-05-25-211028" in src, (
+        "Missing soak attribution — future readers can't trace which "
+        "diagnostic exposed this gap"
+    )
+
+
+def test_ast_pin_no_new_kwarg_added_to_provider_signatures() -> None:
+    """Slice 9 explicitly uses repair_context as the signal (no new
+    ``single_shot=True`` kwarg). This pin guards against future drift
+    where someone adds a redundant parameter — keeping the Protocol
+    shape Slice 8 fixed AS the single-shot signal."""
+    tree = ast.parse(PROVIDERS_FILE.read_text(), filename=str(PROVIDERS_FILE))
+    generates = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "generate"
+    ]
+    # Each generate() arg list must NOT have a single_shot parameter
+    for fn in generates:
+        all_args = (
+            [a.arg for a in fn.args.args]
+            + [a.arg for a in fn.args.kwonlyargs]
+        )
+        assert "single_shot" not in all_args, (
+            f"Slice 9 anti-pattern: ``generate`` at line {fn.lineno} "
+            "added a single_shot kwarg. The design uses repair_context "
+            "presence as the signal (avoid redundant Protocol surface)."
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_guard_immediately_precedes_existing_tool_loop_gate() -> None:
+    """The Slice 9 guard must come BEFORE the
+    ``if self._tool_loop is not None and not _skip_tools:`` line
+    so that flipping _skip_tools=True actually short-circuits the
+    tool loop entry. AST-walk by source-line ordering."""
+    src = PROVIDERS_FILE.read_text()
+    lines = src.split("\n")
+
+    # Find line numbers (1-indexed) of each Slice 9 guard
+    guard_lines = [
+        idx + 1 for idx, line in enumerate(lines)
+        if "repair_context is not None and not _skip_tools" in line
+    ]
+    # Find line numbers of the tool_loop entry gates
+    tool_loop_lines = [
+        idx + 1 for idx, line in enumerate(lines)
+        if "self._tool_loop is not None and not _skip_tools" in line
+    ]
+
+    assert len(guard_lines) >= 2, "Need ≥2 Slice 9 guards"
+    assert len(tool_loop_lines) >= 2, "Need ≥2 tool_loop entry gates"
+
+    # Each guard must precede a tool_loop gate (within a reasonable
+    # window — same function body, typically <100 lines apart)
+    for guard in guard_lines:
+        nearest_gate = min(
+            (gate for gate in tool_loop_lines if gate > guard),
+            default=None,
+        )
+        assert nearest_gate is not None, (
+            f"Slice 9 guard at line {guard} has no subsequent tool_loop "
+            "gate — guard is dead code"
+        )
+        assert nearest_gate - guard < 100, (
+            f"Slice 9 guard at line {guard} too far from tool_loop gate "
+            f"at line {nearest_gate} (gap={nearest_gate - guard}) — "
+            "likely in different function bodies"
+        )
+
+
+def test_spine_route_based_skip_preserved_verbatim() -> None:
+    """Slice 9 must NOT alter the pre-existing route-based skip
+    (background / speculative / wiring_validation). The new guard
+    ADDS a skip reason; never removes an existing one. Regression
+    guard: should_skip_venom_for_route still imported + called."""
+    src = PROVIDERS_FILE.read_text()
+    assert "should_skip_venom_for_route" in src, (
+        "should_skip_venom_for_route reference lost — route-based "
+        "skip broken by Slice 9 restructure"
+    )
+    # The pre-existing _skip_tools computation must still exist
+    # (BEFORE the Slice 9 guard adds to it)
+    assert "should_skip_venom_for_route(_route) and not _is_read_only" in src, (
+        "Pre-existing route-based _skip_tools logic removed — "
+        "regression"
+    )
+
+
+def test_spine_dw_carries_slice9_guard_too() -> None:
+    """DoublewordProvider DOES run a Venom tool loop in its
+    _generate_realtime path. Slice 9 must apply there too so L2's
+    DW-routed dispatches don't deterministically bail in DW's tool
+    loop the way they did pre-Slice-9 in Prime/Claude.
+
+    AST/text check: DW source must include the repair_context guard
+    that flips its tool-skip flag to True."""
+    dw_file = (
+        REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+        / "doubleword_provider.py"
+    )
+    dw_src = dw_file.read_text()
+    # DW uses _will_skip_tools (slightly different name vs Prime/Claude
+    # which use _skip_tools). The Slice 9 guard must flip it.
+    assert "repair_context is not None and not _will_skip_tools" in dw_src, (
+        "DW missing Slice 9 guard — L2 dispatch via DW will still "
+        "bail in DW's _generate_realtime tool loop"
+    )
+    # Slice 9 attribution comment present in DW too
+    assert "Slice 9" in dw_src, (
+        "DW missing Slice 9 attribution — future readers can't trace"
+    )


### PR DESCRIPTION
fix(governance): Slice 9 — L2 single-shot fast path bypasses Venom tool loop for _generate_repair_candidate

Closes the deterministic tool-loop bail surfaced by soak
bt-2026-05-25-211028 after Slice 8 unblocked DW's Protocol signature.

## Empirical chain

  iter 1 (L1 candidate, tests fail) →
  iter 2 generate via tool-loop-enabled provider →
  BudgetPlan.is_next_round_viable check:
    fair_share = (remaining - reserve) / rounds_left = ~97s
    clamped to max_per_round_s = 10s → projected_per_round = 9.69s
    effective_floor = min(min_ttft_floor=45s, max_per_round_s=10s) = 10s
    9.69 < 10 → bail
  RuntimeError: tool_loop_starved_below_min_ttft_floor:round=1,
    remaining=97.25s, projected_per_round=9.69s, min_ttft_floor=45.00s

Both Slice 6.1 re-dispatches hit the SAME wall:
  history=['generate_error:RuntimeError', 'generate_error:RuntimeError']

## Architectural insight (operator framing)

L2 repair has ALL context it needs to synthesize a fix:
  - target file path (from prior critique)
  - original code (read into prompt at L1 stage)
  - prior patch attempt (in prior validation candidate)
  - pytest failure output / structured critique

L2 needs SYNTHESIS, not EXPLORATION via tools. Spinning up the
multi-turn Venom tool loop for a micro-fix is a category error —
the model would never call a tool in this context. Yet the
tool-loop budget gate still fires.

## Fix mechanism — repair_context as the single-shot signal

L2's ``_generate_repair_candidate`` is the ONLY call site that
passes ``repair_context=`` (verified by repo-wide grep:
repair_engine.py:727 and :1161 — both L2 paths). So presence of
repair_context is a reliable, already-uniform (post-Slice-8)
signal that we're on the L2 path.

In all three providers (Prime + Claude + DW), at the existing
``_skip_tools`` / ``_will_skip_tools`` computation site:

  if repair_context is not None and not _skip_tools:
      logger.info("[Provider] L2 repair_context detected — Slice 9 "
                  "single-shot fast path: skipping Venom tool loop")
      _skip_tools = True

The existing tool-loop entry gate
``if self._tool_loop is not None and not _skip_tools:`` then
short-circuits naturally. Model receives the full L2 prompt and
produces a patch in a single turn, completely bypassing the
BudgetPlan.is_next_round_viable check.

## Operator bindings honored

* **No new parameter** — Slice 8 made repair_context the uniform
  Protocol signal across Claude/Prime/DW. Slice 9 reuses it as
  the single-shot trigger. AST-pinned against drift: a future
  PR that adds a redundant ``single_shot=True`` kwarg trips the
  test (`test_ast_pin_no_new_kwarg_added_to_provider_signatures`).
* **Mirrored across all three providers** — Prime/Claude use
  `_skip_tools`; DW uses `_will_skip_tools` (pre-existing naming
  variance). Both flips guarded by the same `repair_context is not
  None` predicate.
* **Pre-existing route-based skips preserved verbatim** —
  background/speculative/wiring_validation route logic via
  `should_skip_venom_for_route` untouched. Slice 9 ADDS one more
  reason to skip; never removes an existing one (spine-tested).
* **L1 path unchanged byte-equivalent** — every L1 call to
  generate() passes `repair_context=None` (the default); the new
  branch's predicate is False; existing behavior preserved exactly.

## Test surface (2 AST pins + 3 spine, 5/5 green; +163 arc tests)

AST pins (2):
  1. Both PrimeProvider AND ClaudeProvider carry
     ``repair_context is not None and not _skip_tools`` guard
     followed by ``_skip_tools = True`` (≥2 occurrences each).
     Slice 9 attribution + bt-2026-05-25-211028 link present.
  2. No new ``single_shot`` parameter added to any generate()
     signature — the design uses repair_context presence as the
     signal (avoid Protocol surface bloat).

Spine (3):
  - Guard position: each Slice 9 guard precedes a tool_loop entry
    gate within 100 lines (same function body — guard not stranded
    in a different scope).
  - Route-based skip preserved: `should_skip_venom_for_route` still
    imported + called; pre-Slice-9 _skip_tools logic intact.
  - DW carries the same guard (using `_will_skip_tools` per its
    naming convention): L2 dispatches via DW also bypass DW's
    _generate_realtime tool loop.

## Distance to RESOLVED — what this actually unlocks

Pre-Slice-9 Ansible cascade:
  iter 1 → iter 2 generate via Venom → BudgetPlan bail →
  generate_error:RuntimeError → l2_retry → SAME bail → exhausted

Post-Slice-9 Ansible cascade:
  iter 1 → iter 2 generate single-shot → model produces patch →
  iter 2 tests run → maybe pass → APPLY → VERIFY → **RESOLVED**

If iter 2's single-shot patch is good: first RESOLVED verdict.
If it's bad: tests fail, iter 3 generates single-shot too,
real progress on the actual repair signal.

3 files changed (providers.py, doubleword_provider.py), ~50 insertions(+), ~0 deletions(-)
+ 1 file added (test_slice9_l2_single_shot.py), ~210 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass the Venom tool loop on the L2 `_generate_repair_candidate` path by using `repair_context` as a single-shot signal. This prevents the deterministic `tool_loop_starved_below_min_ttft_floor` bail and lets the model synthesize a patch in one turn, unblocking L2 repairs.

- **Bug Fixes**
  - When `repair_context` is present, force-skip tools (`_skip_tools`/`_will_skip_tools`) in `PrimeProvider`, `ClaudeProvider`, and `DoublewordProvider` realtime, avoiding the BudgetPlan gate and producing a single-shot patch.
  - Keep existing route-based skips (`should_skip_venom_for_route`) intact; no new params added; L1 behavior unchanged.
  - Add AST pins and spine tests to verify guards exist and precede the tool-loop gate, DW parity, route-skip preservation, and that no `single_shot` kwarg was introduced.

<sup>Written for commit 13ec77181d5505b66653b12cf1ed62bce1614c6b. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/58083?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

