### PR TITLE
fix(governance): Slice 9.1 — thread repair_context through DW dispatch chain (NameError hotfix)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -1228,9 +1228,12 @@ class DoublewordProvider:
             _zw_eligible = (self._tool_loop is None) or _zw_will_skip
             if _zw_prompt is not None and _zw_eligible:
                 async def _dw_inner():
+                    # Slice 9.1 — thread repair_context (closure-captured
+                    # from the outer generate() scope, where it IS a parameter)
                     return await self._dispatch_internal(
                         context, deadline,
                         prompt_override=_zw_prompt,
+                        repair_context=repair_context,
                     )
 
                 try:
@@ -1285,8 +1288,11 @@ class DoublewordProvider:
         # dispatcher (RT + batch fall-back) verbatim — extracted into
         # _dispatch_internal so the gate's _dw_inner closure can call
         # the same code path without duplication.
+        # Slice 9.1 — thread repair_context for L2 single-shot.
         return await self._dispatch_internal(
-            context, deadline, prompt_override=prompt_override,
+            context, deadline,
+            prompt_override=prompt_override,
+            repair_context=repair_context,
         )
 
     async def _dispatch_internal(
@@ -1295,6 +1301,7 @@ class DoublewordProvider:
         deadline: Any = None,
         *,
         prompt_override: Optional[str] = None,
+        repair_context: Optional[Any] = None,  # Slice 9.1 — thread for L2 single-shot
     ) -> GenerationResult:
         """RT + batch dispatcher. Extracted from :meth:`generate` so
         the Zero-Waste S1 cache gate's ``_dw_inner`` thunk can
@@ -1340,7 +1347,12 @@ class DoublewordProvider:
         # cascading to the 150x more expensive Claude fallback.
         if self._realtime_enabled:
             try:
-                return await self._generate_realtime(context, deadline, prompt_override=prompt_override)
+                # Slice 9.1 — thread repair_context for L2 single-shot
+                return await self._generate_realtime(
+                    context, deadline,
+                    prompt_override=prompt_override,
+                    repair_context=repair_context,
+                )
             except DoublewordInfraError as exc:
                 if exc.status_code in (429, 503):
                     logger.info(
@@ -1603,6 +1615,7 @@ class DoublewordProvider:
         deadline: Any = None,
         *,
         prompt_override: Optional[str] = None,
+        repair_context: Optional[Any] = None,  # Slice 9.1 — L2 single-shot signal
     ) -> GenerationResult:
         """Generate code via DoubleWord real-time chat completions API.
 

--- a/tests/governance/test_slice9_l2_single_shot.py
+++ b/tests/governance/test_slice9_l2_single_shot.py
@@ -190,6 +190,44 @@ def test_spine_route_based_skip_preserved_verbatim() -> None:
     )
 
 
+def test_spine_dw_dispatch_chain_threads_repair_context() -> None:
+    """Slice 9.1 regression — when Slice 9's guard lives in DW's
+    _generate_realtime (line 1670), the kwarg must be THREADED through
+    the entire dispatch chain or it raises NameError at runtime
+    (caught by Slice 7 traceback in bt-2026-05-25-213811).
+
+    All three DW functions in the dispatch chain must carry the
+    repair_context parameter:
+      generate() → _dispatch_internal() → _generate_realtime()
+    """
+    dw_file = (
+        REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+        / "doubleword_provider.py"
+    )
+    tree = ast.parse(dw_file.read_text(), filename=str(dw_file))
+
+    chain_funcs = ("generate", "_dispatch_internal", "_generate_realtime")
+    found = {name: False for name in chain_funcs}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name in chain_funcs
+        ):
+            args = (
+                [a.arg for a in node.args.args]
+                + [a.arg for a in node.args.kwonlyargs]
+            )
+            if "repair_context" in args:
+                found[node.name] = True
+
+    missing = [name for name, ok in found.items() if not ok]
+    assert not missing, (
+        f"Slice 9.1 dispatch-chain threading broken: {missing} "
+        "missing repair_context parameter. NameError will fire "
+        "at runtime when L2 routes to DW."
+    )
+
+
 def test_spine_dw_carries_slice9_guard_too() -> None:
     """DoublewordProvider DOES run a Venom tool loop in its
     _generate_realtime path. Slice 9 must apply there too so L2's


### PR DESCRIPTION
fix(governance): Slice 9.1 — thread repair_context through DW dispatch chain (NameError hotfix)

Hotfix for Slice 9 (PR #58083) — caught red-handed by Slice 7's
traceback observability on soak bt-2026-05-25-213811:

  ERROR [L2 Repair] _generate_repair_candidate raised NameError:
  name 'repair_context' is not defined
  File ".../doubleword_provider.py", line 1670, in _generate_realtime
      if repair_context is not None and not _will_skip_tools:
         ^^^^^^^^^^^^^^
  NameError: name 'repair_context' is not defined

## Root cause

Slice 9's DW patch added the single-shot guard at
``_generate_realtime:1670``, but that function's signature did NOT
include ``repair_context`` — the kwarg is only on the outer
``generate()`` (Slice 8). The dispatch chain:

  generate(self, ctx, deadline, repair_context=None, *, prompt_override=None)
       ↓
  _dispatch_internal(self, ctx, deadline, *, prompt_override=None)  ← no repair_context
       ↓
  _generate_realtime(self, ctx, deadline, *, prompt_override=None)  ← no repair_context
       ↓
  Slice 9 guard: ``if repair_context is not None ...``   ← NameError

Slice 6.1's bounded retry caught the NameError as a SOFT generate_error
and re-dispatched, but the second attempt hit the same NameError
deterministically → l2_soft_retries_exhausted with
``history=['generate_error:NameError', 'generate_error:NameError']``.

## Fix mechanism — thread repair_context through entire chain

  generate(... repair_context=None ...)
       ↓ pass repair_context=repair_context
  _dispatch_internal(... repair_context: Optional[Any] = None ...)
       ↓ pass repair_context=repair_context
  _generate_realtime(... repair_context: Optional[Any] = None ...)
       ↓ now in scope at line 1670
  if repair_context is not None and not _will_skip_tools:
      _will_skip_tools = True   ← Slice 9 fast path actually fires

Changes (3 sites):
  1. ``_dispatch_internal`` signature: add ``repair_context``
     keyword-only parameter with None default
  2. ``_generate_realtime`` signature: add ``repair_context``
     keyword-only parameter with None default
  3. Both ``_dispatch_internal`` call sites in generate():
     - line 1231 (Zero-Waste cache gate inner closure):
       closure-captures repair_context from outer generate scope
     - line 1288 (unguarded fall-through path)
  4. ``_generate_realtime`` call site in _dispatch_internal (line 1350)

## Operator bindings honored

* **Pure threading fix** — no logic change. Slice 9's guard
  semantics unchanged. The NameError was a wiring gap, not a
  design bug.
* **Slice 7's traceback observability paid off immediately** —
  the NameError caught with full stack, file, and line. Without
  Slice 7 we'd be staring at `generate_error:NameError` with no
  hint where to look. Validates Manifesto §8 as load-bearing.
* **Slice 6.1's bounded retry contained the damage** — soft-stop
  classification kept the orchestrator from cascading into a
  fatal cooldown. The op terminal-cancelled cleanly with audit.
* **Default=None preserves L1 byte-equivalence** — any L1 call
  to generate() (without passing repair_context) flows through
  the dispatch chain with repair_context=None at every hop;
  Slice 9 guard's `is not None` predicate is False; existing
  behavior preserved exactly.
* **AST-pinned regression guard added** — new test
  `test_spine_dw_dispatch_chain_threads_repair_context` walks
  all 3 DW function signatures and confirms each carries
  repair_context. Future drift trips the test before it ships.

## Test surface (added 1 spine test; 6/6 green; +163 arc tests)

New spine (1):
  - DW dispatch chain integrity: AST walk confirms generate(),
    _dispatch_internal, _generate_realtime ALL carry repair_context
    parameter. Without ALL three, runtime NameError.

Existing tests (5) all still pass — Slice 9's design pin still
catches the guard presence; Slice 9.1 just makes the guard
actually executable.

## Next — RESOLVED detonation v9.1

Re-launch $5/3600s ansible soak. With Slice 9.1 the L2 dispatch's
DW generate call:
  1. Receives repair_context in generate()
  2. Threads through _dispatch_internal
  3. Threads through _generate_realtime
  4. Hits the Slice 9 guard at line 1670 with repair_context IN SCOPE
  5. Flips _will_skip_tools = True → bypasses Venom → single-shot
  6. Model produces patch → APPLY → VERIFY → **RESOLVED**

1 file changed (doubleword_provider.py), ~14 insertions(+), ~4 deletions(-)
+ 1 file modified (test_slice9_l2_single_shot.py), +40 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a NameError by threading repair_context through the Doubleword dispatch chain so the Slice 9 single-shot guard actually runs. Adds a small regression test to prevent future drift.

- **Bug Fixes**
  - Add repair_context to _dispatch_internal and _generate_realtime; forward it from generate.
  - Update internal call sites so the Slice 9 guard runs without NameError; default None keeps existing behavior unchanged.
  - Add an AST-based test that asserts generate, _dispatch_internal, and _generate_realtime all include repair_context.

<sup>Written for commit b4a1b1f18304276b443a1c652046aab195f146ef. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/58098?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

