### PR TITLE
fix(governance): Slice 10B — JARVIS_DW_TRUSTED_MODELS seeds PromotionLedger from boot (eliminates ambiguous-metadata SPECULATIVE-pin)

### DIFF
--- a/backend/core/ouroboros/governance/dw_promotion_ledger.py
+++ b/backend/core/ouroboros/governance/dw_promotion_ledger.py
@@ -113,10 +113,20 @@ LEDGER_SCHEMA_VERSION = "dw_promotion.1"
 QUARANTINE_AMBIGUOUS_METADATA = "ambiguous_metadata"
 QUARANTINE_OPERATOR_DEMOTED = "operator_demoted"
 QUARANTINE_DEMOTED_FROM_BG = "demoted_from_bg"   # post-promotion failure
+# Slice 10B — operator-attested trusted promotion (bypasses the
+# prove-it ledger's 10-success requirement). When a model is seeded
+# via ``JARVIS_DW_TRUSTED_MODELS``, the ledger creates a record
+# with origin=``trusted_seed`` and ``promoted=True`` so the
+# classifier's ``is_promoted`` check passes from boot 0. This is
+# the operator's attestation that the model is known-good — used
+# to bootstrap DW catalog when the dw_catalog_classifier's
+# automatic discovery returns only ambiguous-metadata models.
+QUARANTINE_TRUSTED_SEED = "trusted_seed"
 _VALID_QUARANTINE_ORIGINS = frozenset({
     QUARANTINE_AMBIGUOUS_METADATA,
     QUARANTINE_OPERATOR_DEMOTED,
     QUARANTINE_DEMOTED_FROM_BG,
+    QUARANTINE_TRUSTED_SEED,
 })
 
 
@@ -279,43 +289,120 @@ class PromotionLedger:
     def load(self) -> None:
         """Load from disk. Missing file = empty ledger; corrupt =
         log + start empty (caller might want to know but lifecycle
-        continues). NEVER raises."""
+        continues). NEVER raises.
+
+        Slice 10B — after loading persisted records, seed any
+        operator-attested trusted models from
+        ``JARVIS_DW_TRUSTED_MODELS`` (comma-separated). Trusted seeds
+        are force-promoted (bypassing the 10-success ledger gate)
+        with origin=``trusted_seed`` so the classifier's
+        ``is_promoted`` check passes from boot 0. Disk records
+        always take precedence over the env seed — if a model is
+        already on disk as demoted/quarantined, the env seed does
+        NOT override it (operator must clear the disk record first
+        to re-seed). Use case: bootstrap DW catalog when the
+        ``dw_catalog_classifier`` returns only ambiguous-metadata
+        models (typical of fresh installs / sparse provider metadata).
+        """
         with self._lock:
             self._loaded = True
             p = self._resolved_path()
-            if not p.exists():
-                return
-            try:
-                payload = json.loads(p.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError) as exc:
-                logger.warning(
-                    "[PromotionLedger] corrupt or unreadable ledger at %s — "
-                    "starting empty (%s)", p, exc,
-                )
-                return
-            if not isinstance(payload, Mapping):
-                return
-            if payload.get("schema_version") != LEDGER_SCHEMA_VERSION:
-                logger.warning(
-                    "[PromotionLedger] schema mismatch at %s "
-                    "(found=%r expected=%r) — starting empty",
-                    p, payload.get("schema_version"), LEDGER_SCHEMA_VERSION,
-                )
-                return
-            records_raw = payload.get("records", [])
-            if not isinstance(records_raw, list):
-                return
-            loaded = 0
-            for r in records_raw:
-                if not isinstance(r, Mapping):
-                    continue
-                rec = PromotionRecord.from_json_dict(r)
-                if rec is not None:
-                    self._records[rec.model_id] = rec
-                    loaded += 1
-            logger.info(
-                "[PromotionLedger] loaded %d record(s) from %s", loaded, p,
+            if p.exists():
+                try:
+                    payload = json.loads(p.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError) as exc:
+                    logger.warning(
+                        "[PromotionLedger] corrupt or unreadable ledger at %s — "
+                        "starting empty (%s)", p, exc,
+                    )
+                    payload = None
+                if payload is None or not isinstance(payload, Mapping):
+                    pass
+                elif payload.get("schema_version") != LEDGER_SCHEMA_VERSION:
+                    logger.warning(
+                        "[PromotionLedger] schema mismatch at %s "
+                        "(found=%r expected=%r) — starting empty",
+                        p, payload.get("schema_version"), LEDGER_SCHEMA_VERSION,
+                    )
+                else:
+                    records_raw = payload.get("records", [])
+                    if isinstance(records_raw, list):
+                        loaded = 0
+                        for r in records_raw:
+                            if not isinstance(r, Mapping):
+                                continue
+                            rec = PromotionRecord.from_json_dict(r)
+                            if rec is not None:
+                                self._records[rec.model_id] = rec
+                                loaded += 1
+                        logger.info(
+                            "[PromotionLedger] loaded %d record(s) from %s",
+                            loaded, p,
+                        )
+            # Slice 10B — seed operator-attested trusted models
+            # (after disk load so persisted records win on conflict).
+            self._seed_trusted_models_from_env()
+
+    def _seed_trusted_models_from_env(self) -> None:
+        """Slice 10B — seed PromotionRecord entries for trusted models
+        listed in ``JARVIS_DW_TRUSTED_MODELS`` (comma-separated). Each
+        new entry is force-promoted with origin=``trusted_seed``.
+
+        Operator binding: bootstrap DW catalog when discovery returns
+        sparse metadata (the bt-2026-05-25-215404 cost catastrophe
+        root). The 7 DW→Claude fallback events in that soak were
+        caused by ``background_dw_blocked_by_topology: catalog
+        purged`` — every discovered model failed
+        ``has_ambiguous_metadata`` and pinned to SPECULATIVE-only.
+        Trusted models bypass that gate from boot 0.
+
+        Discipline:
+          * Disk records ALWAYS take precedence. If a model already
+            has a record (promoted, demoted, or quarantined), the env
+            seed is silently skipped for that model. Operator must
+            clear the disk record to re-seed.
+          * Empty/unset env → no-op. Existing behavior byte-equivalent
+            to pre-Slice-10B.
+          * NEVER raises — env parse failures degrade to empty list.
+          * Caller responsibility: ``JARVIS_DW_TRUSTED_MODELS=...``
+            is an operator attestation; if the listed model_ids
+            don't exist on the DW endpoint, the classifier will
+            simply find no card for them and the seed is harmless
+            (no provider call ever lands on a phantom model).
+        """
+        raw = os.environ.get("JARVIS_DW_TRUSTED_MODELS", "").strip()
+        if not raw:
+            return
+        # Comma-separated; tolerate whitespace + empty tokens
+        candidates = [
+            tok.strip() for tok in raw.split(",") if tok.strip()
+        ]
+        if not candidates:
+            return
+        seeded = 0
+        for mid in candidates:
+            if mid in self._records:
+                # Disk record wins — silently skip the env seed.
+                continue
+            rec = PromotionRecord(
+                model_id=mid,
+                quarantine_origin=QUARANTINE_TRUSTED_SEED,
+                success_latencies_ms=[],
+                failure_count=0,
+                promoted=True,  # bypass 10-success requirement
+                promoted_at_unix=time.time(),
+                last_event_unix=time.time(),
             )
+            self._records[mid] = rec
+            seeded += 1
+        if seeded > 0:
+            logger.info(
+                "[PromotionLedger] Slice 10B: seeded %d trusted model(s) "
+                "from JARVIS_DW_TRUSTED_MODELS — these bypass the "
+                "10-success prove-it requirement (origin=trusted_seed)",
+                seeded,
+            )
+            self._maybe_autosave()
 
     def save(self) -> None:
         """Write current state to disk atomically. NEVER raises;

--- a/tests/governance/test_slice10b_dw_trusted_seed.py
+++ b/tests/governance/test_slice10b_dw_trusted_seed.py
@@ -1,0 +1,268 @@
+"""Slice 10B — JARVIS_DW_TRUSTED_MODELS seeds PromotionLedger at boot.
+
+Closes the orthogonal half of the bt-2026-05-25-215404 cost
+catastrophe. Slice 10A fixed the ROUTING layer (SWE-bench ops now
+target STANDARD not IMMEDIATE), but the underlying TOPOLOGY still
+rejected DW even on STANDARD because:
+
+  [DiscoveryRunner] boot complete: ok=False models=23
+                                   routes_assigned=['speculative']
+  [CandidateGenerator] BACKGROUND route: DW failed
+    (background_dw_blocked_by_topology:Catalog-driven (Phase 12).
+     Static list purged; ranking authority is dw_catalog_classifier)
+
+Even though DW discovered 23 models, ALL 23 failed
+``has_ambiguous_metadata()`` (parameter_count_b is None AND
+pricing_out_per_m_usd is None per Zero-Trust §3.6) and pinned
+SPECULATIVE-only. Standard / Background / Complex routes saw zero
+models → topology block → Claude fallback → cost explosion.
+
+# Fix mechanism — operator-attested trusted seed
+
+Add ``JARVIS_DW_TRUSTED_MODELS=model1,model2,...`` env knob. At
+``PromotionLedger.load()``, after disk records are read, any
+trusted models not already on disk are force-promoted with
+origin=``trusted_seed``. The classifier's ``is_promoted`` check
+passes from boot 0, bypassing the prove-it ledger's
+10-success requirement.
+
+# Discipline
+
+* Disk records ALWAYS win on conflict — if a model already has
+  a persisted state (promoted / quarantined / demoted), the env
+  seed is silently skipped. Operator must clear the disk record
+  to re-seed.
+* Empty/unset env → no-op. Byte-equivalent to pre-Slice-10B.
+* Trusted seeds are ATTESTATIONS — the operator vouches the
+  model_id corresponds to a real DW endpoint model. If the
+  endpoint doesn't have that model, the classifier finds no
+  card; the seed is harmless (no provider call ever lands).
+* QUARANTINE_TRUSTED_SEED added to canonical origin enum —
+  AST-pinned to ensure future origin additions preserve the
+  taxonomy.
+
+# Test surface (2 AST pins + 5 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEDGER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "dw_promotion_ledger.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_trusted_seed_constant_in_canonical_origins() -> None:
+    """``QUARANTINE_TRUSTED_SEED`` MUST be added to the canonical
+    ``_VALID_QUARANTINE_ORIGINS`` frozenset. Otherwise PromotionRecord
+    serialization would silently downgrade ``trusted_seed`` origin
+    to ``ambiguous_metadata`` on round-trip via from_json_dict()."""
+    src = LEDGER_FILE.read_text()
+    assert "QUARANTINE_TRUSTED_SEED" in src, (
+        "Missing QUARANTINE_TRUSTED_SEED constant — Slice 10B reverted"
+    )
+    assert "QUARANTINE_TRUSTED_SEED = \"trusted_seed\"" in src, (
+        "QUARANTINE_TRUSTED_SEED value drifted — round-trip serialization breaks"
+    )
+    # Must appear in the _VALID_QUARANTINE_ORIGINS frozenset
+    tree = ast.parse(src, filename=str(LEDGER_FILE))
+    found_in_valid = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "_VALID_QUARANTINE_ORIGINS"
+                for t in node.targets
+            )
+        ):
+            members = ast.unparse(node.value)
+            if "QUARANTINE_TRUSTED_SEED" in members:
+                found_in_valid = True
+    assert found_in_valid, (
+        "QUARANTINE_TRUSTED_SEED defined but NOT in _VALID_QUARANTINE_ORIGINS "
+        "— round-trip will downgrade to ambiguous_metadata"
+    )
+
+
+def test_ast_pin_seed_method_called_from_load() -> None:
+    """``PromotionLedger.load()`` MUST call ``_seed_trusted_models_from_env()``
+    so the trusted seed fires automatically on the standard ledger init
+    path. Without this hook, the env knob is decorative."""
+    src = LEDGER_FILE.read_text()
+    assert "_seed_trusted_models_from_env" in src, (
+        "Missing _seed_trusted_models_from_env method"
+    )
+    assert "JARVIS_DW_TRUSTED_MODELS" in src, (
+        "Missing JARVIS_DW_TRUSTED_MODELS env reference"
+    )
+    # The seed method must be invoked from load()
+    tree = ast.parse(src, filename=str(LEDGER_FILE))
+    load_calls_seed = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "load":
+            body_src = ast.unparse(node)
+            if "_seed_trusted_models_from_env" in body_src:
+                load_calls_seed = True
+    assert load_calls_seed, (
+        "load() does not call _seed_trusted_models_from_env — "
+        "env seed never fires"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 5 (functional)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_trusted_seed_promotes_unknown_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A model_id listed in JARVIS_DW_TRUSTED_MODELS, when no disk
+    record exists, must end up in the ledger as promoted=True with
+    origin=trusted_seed. The classifier's is_promoted(model_id)
+    must return True for it."""
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger, QUARANTINE_TRUSTED_SEED,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        ledger_path = Path(tmp) / "ledger.json"
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "doubleword-397b")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH", str(ledger_path),
+        )
+        ledger = PromotionLedger(path=ledger_path, autosave=False)
+        ledger.load()
+        # Trusted model is now promoted
+        assert ledger.is_promoted("doubleword-397b") is True, (
+            "Trusted seed model NOT promoted after load — Slice 10B inert"
+        )
+        # Record has the canonical origin tag
+        promoted_set = set(ledger.promoted_models())
+        assert "doubleword-397b" in promoted_set
+
+
+def test_spine_multiple_trusted_models_csv_parsed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CSV with multiple model_ids + extra whitespace + empty tokens
+    is parsed correctly. All listed models end up promoted."""
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        ledger_path = Path(tmp) / "ledger.json"
+        monkeypatch.setenv(
+            "JARVIS_DW_TRUSTED_MODELS",
+            "doubleword-397b, ,deepseek-r1, qwen3-235b ,, ",
+        )
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH", str(ledger_path),
+        )
+        ledger = PromotionLedger(path=ledger_path, autosave=False)
+        ledger.load()
+        for mid in ("doubleword-397b", "deepseek-r1", "qwen3-235b"):
+            assert ledger.is_promoted(mid) is True, (
+                f"Trusted model {mid} not promoted — CSV parser broken"
+            )
+
+
+def test_spine_disk_record_wins_over_env_seed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a model already has a disk record (e.g., demoted), the
+    env seed MUST be silently skipped. Operator-driven state on
+    disk wins over the env attestation — env is bootstrap-only,
+    not a live override."""
+    import json
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger, LEDGER_SCHEMA_VERSION,
+        QUARANTINE_OPERATOR_DEMOTED,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        ledger_path = Path(tmp) / "ledger.json"
+        # Seed disk with a DEMOTED record for the same model_id
+        # that the env attempts to trust-seed
+        ledger_path.write_text(json.dumps({
+            "schema_version": LEDGER_SCHEMA_VERSION,
+            "records": [{
+                "model_id": "doubleword-397b",
+                "quarantine_origin": QUARANTINE_OPERATOR_DEMOTED,
+                "success_latencies_ms": [],
+                "failure_count": 0,
+                "promoted": False,
+                "promoted_at_unix": None,
+                "last_event_unix": 0.0,
+            }],
+        }))
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "doubleword-397b")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH", str(ledger_path),
+        )
+        ledger = PromotionLedger(path=ledger_path, autosave=False)
+        ledger.load()
+        # Disk record (demoted) MUST win — env seed silently skipped
+        assert ledger.is_promoted("doubleword-397b") is False, (
+            "Env seed overrode disk demotion — operator's persistent "
+            "decision was discarded (data integrity violation)"
+        )
+        assert ledger.is_quarantined("doubleword-397b") is True
+
+
+def test_spine_empty_env_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset / empty / whitespace-only env → no-op. Ledger state
+    byte-equivalent to pre-Slice-10B."""
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        ledger_path = Path(tmp) / "ledger.json"
+        # Test each empty-shape variant
+        for env_val in ("", "   ", " , , ", ",,,"):
+            monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", env_val)
+            monkeypatch.setenv(
+                "JARVIS_DW_PROMOTION_LEDGER_PATH", str(ledger_path),
+            )
+            ledger = PromotionLedger(path=ledger_path, autosave=False)
+            ledger.load()
+            assert len(ledger.promoted_models()) == 0, (
+                f"Empty env value {env_val!r} produced phantom seeds"
+            )
+
+
+def test_spine_trusted_seed_origin_round_trips_through_persistence() -> None:
+    """A PromotionRecord with origin=trusted_seed must round-trip
+    through to_json_dict / from_json_dict without origin downgrade.
+    Without QUARANTINE_TRUSTED_SEED in _VALID_QUARANTINE_ORIGINS, the
+    from_json_dict path silently coerces to ambiguous_metadata."""
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionRecord, QUARANTINE_TRUSTED_SEED,
+    )
+    rec = PromotionRecord(
+        model_id="doubleword-397b",
+        quarantine_origin=QUARANTINE_TRUSTED_SEED,
+        promoted=True,
+    )
+    payload = rec.to_json_dict()
+    assert payload["quarantine_origin"] == "trusted_seed"
+    restored = PromotionRecord.from_json_dict(payload)
+    assert restored is not None
+    assert restored.quarantine_origin == QUARANTINE_TRUSTED_SEED, (
+        f"Round-trip downgraded origin from trusted_seed to "
+        f"{restored.quarantine_origin} — Slice 10B persistence broken"
+    )
+    assert restored.promoted is True


### PR DESCRIPTION
fix(governance): Slice 10B — JARVIS_DW_TRUSTED_MODELS seeds PromotionLedger from boot (eliminates ambiguous-metadata SPECULATIVE-pin)

Closes the orthogonal half of bt-2026-05-25-215404's cost catastrophe.
Slice 10A (PR #58161) fixed the ROUTING layer — SWE-Bench-Pro ops
now target STANDARD instead of IMMEDIATE. But the underlying
TOPOLOGY still rejected DW on STANDARD because:

  [DiscoveryRunner] boot complete: ok=False models=23
                                   routes_assigned=['speculative']
  [CandidateGenerator] BACKGROUND route: DW failed
    (background_dw_blocked_by_topology:Catalog-driven (Phase 12).
     Static list purged; ranking authority is dw_catalog_classifier)

Even with DW discovery succeeding (23 models found), ALL 23 fell
into ``has_ambiguous_metadata()`` because the DW endpoint returned
model cards without ``parameter_count_b`` AND without
``pricing_out_per_m_usd``. Zero-Trust §3.6 then pinned every one
of them to SPECULATIVE-only — leaving STANDARD / BACKGROUND /
COMPLEX with zero eligible models → topology block → 7 DW→Claude
fallback events in the soak.

## Architectural insight

The PromotionLedger has an existing "prove-it" gate: a model
graduates from SPECULATIVE to BACKGROUND/STANDARD after 10
sub-200ms successful ops. Chicken-and-egg failure mode: if every
discovered model is SPECULATIVE-pinned at boot, ops never route to
DW STANDARD → no successful ops at STANDARD priority → no
promotions → the catalog stays empty for STANDARD forever.

The operator's intent ("DoubleWord 397B is my preferred primary
model") needs a bootstrap path that doesn't require running 10
successful ops first.

## Fix mechanism — operator-attested trusted seed

  JARVIS_DW_TRUSTED_MODELS=doubleword-397b,deepseek-r1,...

When ``PromotionLedger.load()`` runs, after disk records are
read, any model_ids in this env are force-promoted with
origin=``trusted_seed`` IF they don't already have a disk record.
This bypasses the 10-success prove-it requirement; the
classifier's ``is_promoted`` check passes from boot 0.

The catalog classifier then admits these models into STANDARD /
BACKGROUND / COMPLEX (subject to the existing per-route param /
price gates — but the promoted flag lets them past the
ambiguous-metadata SPECULATIVE-pin first).

## Operator bindings honored

* **Composes existing infrastructure** — extends PromotionLedger
  with new constant ``QUARANTINE_TRUSTED_SEED`` and one private
  method ``_seed_trusted_models_from_env``. NO new module, no
  new state structure, no parallel persistence path. Trusted
  seeds write through the same json schema (LEDGER_SCHEMA_VERSION
  unchanged; existing on-disk ledgers load identically).
* **Disk records ALWAYS win** — if the operator demoted a model
  via REPL/observability and it persisted to disk, the env seed
  is silently skipped. Persistence is authoritative for ANY
  state that already exists. Spine-tested.
* **Operator-attestation discipline** — trusted_seed is the
  operator vouching that this model_id exists on the DW
  endpoint AND is operationally sound. If the endpoint doesn't
  have the model, the classifier finds no card and the seed is
  harmless (no provider call ever lands on a phantom model).
  The env knob is documentation that the operator owns this
  attestation; no internal hardcoded list.
* **No env knob redundancy** — JARVIS_DW_TRUSTED_MODELS is the
  ONLY new env. The existing ``JARVIS_DW_PROMOTION_*`` knobs for
  prove-it thresholds + ``JARVIS_DW_CLASSIFIER_*_MIN_PARAMS_B``
  per-route gates remain authoritative; trusted seed only
  bypasses the boot-0 ambiguous-metadata pin, not these gates.
  If a trusted model fails its per-route gate, it still won't
  be assigned to that route — discipline preserved.
* **AST-pinned canonical-origin frozenset** — QUARANTINE_TRUSTED_SEED
  must be added to ``_VALID_QUARANTINE_ORIGINS`` or the
  ``from_json_dict()`` round-trip would silently downgrade
  ``trusted_seed`` to ``ambiguous_metadata`` (the default).
  Spine-tested for round-trip integrity.
* **Defensive failure modes** — empty/unset env → no-op, no
  phantom records. CSV with whitespace + empty tokens parses
  correctly. Spine-tested with each empty-shape variant.

## Test surface (2 AST pins + 5 spine, 7/7 green; +199 arc tests)

AST pins (2):
  1. ``QUARANTINE_TRUSTED_SEED`` constant present + added to
     ``_VALID_QUARANTINE_ORIGINS`` (AST walks the assignment to
     verify membership — regression guard against the silent
     downgrade trap)
  2. ``load()`` body contains a call to
     ``_seed_trusted_models_from_env`` (AST walks the load FunctionDef)
     — without this hook the env knob is dead code

Spine (5):
  - Trusted model promoted from boot 0 when no disk record exists
    (the bt-2026-05-25-215404 root case)
  - CSV with whitespace + empty tokens + multiple model_ids parsed
    correctly — all listed models promoted
  - Disk record (demoted) WINS over env seed — operator-persistent
    decisions never overridden by env attestation
  - Empty/whitespace/comma-only env values → no-op, no phantom
    seed records
  - PromotionRecord(origin=trusted_seed) round-trips through
    to_json_dict / from_json_dict without origin downgrade
    (proves QUARANTINE_TRUSTED_SEED is in the canonical frozenset)

## Distance to RESOLVED + cost economics

With Slice 10A + 10B both live, the operator runbook for cost-
optimal soaks becomes:

  export JARVIS_DW_TRUSTED_MODELS=doubleword-397b
  /tmp/claude/aegis_high_capital_soak.sh

The cascade:
  Slice 10A: SWE-bench op → STANDARD route (not IMMEDIATE)
  Slice 10B: doubleword-397b promoted from boot 0
  Result: STANDARD dispatches go to DW primary, Claude fallback only on DW failure

Expected cost compression vs bt-2026-05-25-215404 (the pre-fix soak):
  - 99.83% Claude cost → estimated <30% Claude cost (DW serves the
    bulk of generation, Claude only on genuine fallback)
  - DW realtime calls: 3 → estimated 20+
  - DW→Claude fallback events: 7 → estimated 0-2 (DW endpoint health
    dependent, not topology-rejected)

1 file changed (dw_promotion_ledger.py), ~95 insertions(+), ~30 deletions(-)
+ 1 file added (test_slice10b_dw_trusted_seed.py), ~270 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Boot-time seeding of PromotionLedger from `JARVIS_DW_TRUSTED_MODELS` promotes operator‑trusted DW models immediately. This removes the ambiguous‑metadata SPECULATIVE pin, lets DW serve STANDARD/BACKGROUND routes, and cuts Claude fallbacks.

- **New Features**
  - Seeds trusted models during `PromotionLedger.load()` from `JARVIS_DW_TRUSTED_MODELS` (CSV). Sets `promoted=True` with origin `trusted_seed`.
  - Adds `QUARANTINE_TRUSTED_SEED` to `_VALID_QUARANTINE_ORIGINS`; uses the same JSON schema; autosaves on seed.
  - Disk records always win; unset/empty env is a no‑op; CSV tolerates spaces and empty tokens.
  - Only bypasses the 10‑success “prove‑it” gate; per‑route param/price gates and `JARVIS_DW_PROMOTION_*` knobs still apply.

- **Migration**
  - Optional: set `JARVIS_DW_TRUSTED_MODELS=doubleword-397b,deepseek-r1` to bootstrap DW as the primary model. No changes needed if unset.

<sup>Written for commit 4452366c2a3d79fbe5b5e9412e23849856ce66c6. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/58165?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

