### PR TITLE
fix(infra): Slice 14 — SessionWAL async-safe checkpoint via asyncio.to_thread (eliminates LoopDeadman tombstone)

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -6771,7 +6771,16 @@ class BattleTestHarness:
                 state = self._slice12g3_build_checkpoint_state(
                     reason="periodic",
                 )
-                self._session_wal.checkpoint(state, "periodic")
+                # Slice 14 — async-safe checkpoint (offloads file I/O
+                # via asyncio.to_thread so the main asyncio loop tick
+                # continues during the ~5-50ms write sequence. Eliminates
+                # the LoopDeadman tombstone observed in bt-2026-05-25-230029
+                # v10 soak where the sync checkpoint() blocked the loop
+                # during periodic firing). Sync .checkpoint() retained on
+                # the shutdown_cancel branch above + force_checkpoint
+                # signal-handler paths because those run when the loop may
+                # already be cancelled and to_thread is unsafe there.
+                await self._session_wal.acheckpoint(state, "periodic")
             except Exception:  # noqa: BLE001 — defensive
                 # Continuous WAL is best-effort; a single failed
                 # checkpoint must not break the periodic cadence.

--- a/backend/core/ouroboros/governance/session_wal.py
+++ b/backend/core/ouroboros/governance/session_wal.py
@@ -166,7 +166,19 @@ class SessionWAL:
     ) -> bool:
         """Write ``state`` atomically to ``summary.json``,
         debounced by ``wal_min_interval_s``. Returns True on
-        successful write, False on skip/error. NEVER raises."""
+        successful write, False on skip/error. NEVER raises.
+
+        ⚠️ SYNCHRONOUS — performs blocking disk I/O (json.dumps +
+        write + fsync + os.replace) while holding ``self._lock``.
+        Callers running on the asyncio main thread should prefer
+        :meth:`acheckpoint` (Slice 14) which routes through
+        ``asyncio.to_thread`` so the loop tick continues during the
+        file write. This sync entry point is RETAINED for:
+          * signal handlers (SIGTERM/SIGINT) where the loop may
+            already be cancelled and `to_thread` is unsafe;
+          * atexit fallback paths (interpreter shutdown);
+          * synchronous test harnesses.
+        """
         if not wal_enabled():
             return False
         try:
@@ -186,6 +198,51 @@ class SessionWAL:
         except Exception:  # noqa: BLE001 — defensive
             logger.debug(
                 "[SessionWAL] checkpoint swallowed exc",
+                exc_info=True,
+            )
+            return False
+
+    async def acheckpoint(
+        self,
+        state: Dict[str, Any],
+        reason: str = "",
+    ) -> bool:
+        """Slice 14 — async-safe variant of :meth:`checkpoint`.
+
+        Routes the blocking file I/O through ``asyncio.to_thread``
+        so the asyncio main loop continues ticking during the
+        ~5-50ms json.dumps + write + fsync + os.replace sequence.
+        Eliminates the LoopDeadman tombstone observed in soak
+        bt-2026-05-25-230029 (v10), where the periodic checkpoint
+        loop (harness.py:6774) called the sync ``checkpoint`` from
+        the asyncio loop and contended with other lock holders
+        until LoopDeadman fired at T+51m.
+
+        Behavior contract identical to sync :meth:`checkpoint` —
+        same return shape, same debounce, same defensive
+        exception-swallow. ONLY difference is that the disk I/O
+        runs on the default thread pool executor instead of
+        blocking the caller's event loop.
+
+        ``threading.Lock`` (not ``asyncio.Lock``) intentionally
+        preserved on ``self._lock`` — signal handlers and atexit
+        fallback paths still call the sync entry point and need
+        to coordinate with this method's worker-thread write.
+
+        NEVER raises. ``asyncio.CancelledError`` propagates per
+        cooperative-cancel contract."""
+        if not wal_enabled():
+            return False
+        try:
+            import asyncio as _asyncio
+            return await _asyncio.to_thread(
+                self.checkpoint, state, reason,
+            )
+        except _asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "[SessionWAL] acheckpoint swallowed exc",
                 exc_info=True,
             )
             return False

--- a/tests/governance/test_slice14_wal_async_safety.py
+++ b/tests/governance/test_slice14_wal_async_safety.py
@@ -1,0 +1,268 @@
+"""Slice 14 — SessionWAL async-safe checkpoint via asyncio.to_thread.
+
+Closes the LoopDeadman tombstone observed in soak bt-2026-05-25-230029:
+
+  2026-05-25T16:51:55 [Ouroboros.LoopDeadman] CRITICAL
+    [LoopDeadman.TOMBSTONE] thread_id=8781099264
+    File "harness.py:6752" in _slice12g3_periodic_checkpoint_loop
+      await asyncio.sleep(interval_s)
+    File "session_wal.py:174" in checkpoint
+      with self._lock:
+    File "session_wal.py:254" in _atomic_write
+
+The periodic checkpoint loop called the SYNC ``checkpoint()`` from the
+asyncio main thread. Inside ``checkpoint()``: `with self._lock`
+(threading.Lock) → `_atomic_write()` (synchronous json.dumps + open +
+write + fsync + os.replace). The ~5-50ms file I/O blocked the asyncio
+loop tick. Cumulative + lock contention with other holders eventually
+triggered LoopDeadman. Result: $0.00 burn in 51min — engine deadlocked
+itself before reaching any provider call.
+
+# Fix mechanism
+
+Add ``async def acheckpoint(self, state, reason)`` on SessionWAL that
+wraps the sync path via ``asyncio.to_thread``. The blocking file I/O
+runs on the default thread pool executor; the asyncio main loop tick
+continues during the write. Migrate harness.py:6774 to await
+``acheckpoint`` instead of calling sync ``checkpoint``.
+
+# Discipline
+
+* Sync ``checkpoint()`` + ``force_checkpoint()`` RETAINED for shutdown
+  / signal handler / atexit paths where the loop may already be
+  cancelled and ``to_thread`` is unsafe.
+* ``threading.Lock`` preserved (NOT asyncio.Lock) — both the sync and
+  the async path coordinate through the same lock, so signal handlers
+  + atexit fallbacks still safely interleave with the worker-thread
+  writes.
+* Behavior contract on ``acheckpoint`` identical to ``checkpoint`` —
+  same return shape, same debounce, same defensive exception-swallow.
+* ``asyncio.CancelledError`` propagates per cooperative-cancel contract.
+
+# Test surface (2 AST pins + 5 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WAL_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "session_wal.py"
+)
+HARNESS_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "battle_test"
+    / "harness.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_acheckpoint_method_present_and_uses_to_thread() -> None:
+    """``SessionWAL`` MUST expose an async ``acheckpoint`` method that
+    routes the sync ``checkpoint`` through ``asyncio.to_thread``.
+    Without this, the periodic checkpoint loop will block the main
+    asyncio thread and re-introduce the LoopDeadman tombstone."""
+    src = WAL_FILE.read_text()
+    assert "async def acheckpoint" in src, (
+        "SessionWAL.acheckpoint method missing — Slice 14 reverted"
+    )
+    assert "asyncio.to_thread" in src, (
+        "acheckpoint does NOT use asyncio.to_thread — blocking IO "
+        "is still on the asyncio main loop"
+    )
+    # The to_thread call must wrap self.checkpoint (NOT some other call)
+    assert "self.checkpoint, state, reason" in src, (
+        "asyncio.to_thread doesn't wrap self.checkpoint — wrong routing"
+    )
+    # Slice 14 attribution + bt soak link
+    assert "Slice 14" in src
+    assert "bt-2026-05-25-230029" in src, (
+        "Missing soak attribution — future readers can't trace the "
+        "LoopDeadman forensic that surfaced this"
+    )
+
+
+def test_ast_pin_harness_periodic_loop_uses_acheckpoint() -> None:
+    """The harness periodic checkpoint loop MUST await ``acheckpoint``
+    instead of calling sync ``checkpoint``. Without this, the new
+    async-safe method is dead code."""
+    src = HARNESS_FILE.read_text()
+    # The periodic loop must use the async variant
+    assert "await self._session_wal.acheckpoint(state, \"periodic\")" in src, (
+        "harness periodic checkpoint loop does NOT use acheckpoint — "
+        "Slice 14 wiring is dead code"
+    )
+    # The Slice 14 comment must be present (audit trail)
+    assert "Slice 14" in src, (
+        "harness.py missing Slice 14 attribution comment"
+    )
+    # The sync checkpoint() call on the periodic path must be REMOVED
+    # — only the shutdown_cancel branch may still use force_checkpoint
+    # (which is a separate method). AST-walk the relevant function.
+    tree = ast.parse(src, filename=str(HARNESS_FILE))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_slice12g3_periodic_checkpoint_loop"
+        ):
+            body_src = ast.unparse(node)
+            # The periodic-firing branch (after the await asyncio.sleep)
+            # must NOT contain a plain ``self._session_wal.checkpoint(``
+            # call — only the shutdown_cancel branch may call
+            # force_checkpoint. Heuristic: the substring
+            # ``self._session_wal.checkpoint(state, "periodic")`` is the
+            # exact line we replaced; it must be gone.
+            assert (
+                'self._session_wal.checkpoint(state, "periodic")'
+                not in body_src
+            ), (
+                "harness periodic loop STILL contains sync checkpoint(state, "
+                "\"periodic\") — Slice 14 migration incomplete"
+            )
+            break
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 5 (functional)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spine_acheckpoint_writes_summary_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """acheckpoint() must successfully write summary.json with the
+    provided state. Same effect as sync checkpoint, just async-safely."""
+    from backend.core.ouroboros.governance.session_wal import SessionWAL
+    monkeypatch.setenv("JARVIS_SESSION_WAL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_SESSION_WAL_MIN_INTERVAL_S", "0.0")
+    wal = SessionWAL(session_dir=tmp_path)
+    state = {"foo": "bar", "n": 42}
+    ok = await wal.acheckpoint(state, "test")
+    assert ok is True, "acheckpoint returned False on a clean write"
+    summary = tmp_path / "summary.json"
+    assert summary.exists(), "summary.json was not written"
+    parsed = json.loads(summary.read_text())
+    assert parsed["foo"] == "bar"
+    assert parsed["n"] == 42
+
+
+@pytest.mark.asyncio
+async def test_spine_acheckpoint_does_not_block_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """While acheckpoint is in flight, the event loop MUST continue
+    processing other tasks. Spawn a concurrent task that polls the
+    loop's clock — if it gets ≥ N polls during the checkpoint, the
+    loop wasn't blocked. This is the regression guard against the
+    LoopDeadman tombstone from bt-2026-05-25-230029."""
+    from backend.core.ouroboros.governance.session_wal import SessionWAL
+    monkeypatch.setenv("JARVIS_SESSION_WAL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_SESSION_WAL_MIN_INTERVAL_S", "0.0")
+    wal = SessionWAL(session_dir=tmp_path)
+
+    # Build a large state to make the write take measurable time
+    # (without being slow enough to slow down CI). 50k-row dict.
+    state = {f"k{i}": f"v{i}" * 8 for i in range(50_000)}
+
+    poll_count = 0
+    async def _poll_loop_tick() -> None:
+        nonlocal poll_count
+        # Sleep 1ms repeatedly — each yield checks the loop is alive
+        for _ in range(40):
+            await asyncio.sleep(0.001)
+            poll_count += 1
+
+    # Race: checkpoint + poll concurrently. If checkpoint blocks the
+    # loop, poll_count will be near 0; if it's properly off-loop, the
+    # poller will get most/all of its 40 yields.
+    await asyncio.gather(
+        wal.acheckpoint(state, "concurrency_test"),
+        _poll_loop_tick(),
+    )
+    # Tolerance: at least half the polls fired (allow CI noise)
+    assert poll_count >= 20, (
+        f"Event loop appears blocked during acheckpoint — only "
+        f"{poll_count}/40 polls fired (regression on Slice 14)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spine_acheckpoint_returns_false_on_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When wal_enabled() is False, acheckpoint must return False
+    WITHOUT scheduling the worker thread. Symmetric to sync checkpoint
+    behavior — no surprise side effects when disabled."""
+    from backend.core.ouroboros.governance.session_wal import SessionWAL
+    monkeypatch.setenv("JARVIS_SESSION_WAL_ENABLED", "false")
+    wal = SessionWAL(session_dir=tmp_path)
+    ok = await wal.acheckpoint({"x": 1}, "disabled_test")
+    assert ok is False
+    assert not (tmp_path / "summary.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_spine_acheckpoint_swallows_inner_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the wrapped sync checkpoint raises, acheckpoint MUST swallow
+    the exception and return False (same defensive contract as the
+    sync entry point). Monkey-patch `checkpoint` to raise."""
+    from backend.core.ouroboros.governance.session_wal import SessionWAL
+    monkeypatch.setenv("JARVIS_SESSION_WAL_ENABLED", "true")
+    wal = SessionWAL(session_dir=tmp_path)
+    # Force the sync checkpoint to raise — verifies acheckpoint's
+    # defensive try/except handles inner failures rather than propagating.
+    # SessionWAL uses __slots__ so patch the class-level method
+    # (instance binding is the same name lookup at call time).
+    def _boom(self, state, reason=""):
+        raise RuntimeError("simulated write failure")
+    monkeypatch.setattr(SessionWAL, "checkpoint", _boom)
+    # Must not raise
+    ok = await wal.acheckpoint({"x": 1}, "fail_test")
+    assert ok is False, (
+        "acheckpoint propagated an exception from wrapped sync call — "
+        "defensive contract violated"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spine_acheckpoint_respects_debounce(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple rapid acheckpoint calls must respect the debounce
+    interval — same as sync checkpoint. Second call within
+    min_interval_s returns False without writing."""
+    from backend.core.ouroboros.governance.session_wal import SessionWAL
+    monkeypatch.setenv("JARVIS_SESSION_WAL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_SESSION_WAL_MIN_INTERVAL_S", "10.0")
+    wal = SessionWAL(session_dir=tmp_path)
+    first = await wal.acheckpoint({"v": 1}, "first")
+    assert first is True
+    # Immediate second call is within debounce window
+    second = await wal.acheckpoint({"v": 2}, "second")
+    assert second is False, (
+        "Second checkpoint within debounce window returned True — "
+        "debounce broken on async path"
+    )
+    # The file still contains the FIRST write (debounce skipped the second)
+    parsed = json.loads((tmp_path / "summary.json").read_text())
+    assert parsed["v"] == 1


### PR DESCRIPTION
fix(infra): Slice 14 — SessionWAL async-safe checkpoint via asyncio.to_thread (eliminates LoopDeadman tombstone)

Closes the deadlock surfaced by soak bt-2026-05-25-230029 (v10 DW-PRIMARY
detonation). Despite Slice 10A/10B firing correctly (trusted-seed logged,
SWE-Bench-Pro op injected, DW catalog loaded), the soak achieved
$0.00 cost in 51 min because the asyncio main loop deadlocked.

## Empirical chain from bt-2026-05-25-230029

  16:00:50  [PromotionLedger] Slice 10B: seeded 1 trusted model(s) ✓
  16:00:50  [ModalityLedger] loaded 22 record(s) (chat=14 unknown=8)
  16:02:18  [SWEBenchPro.HarnessInject] verdict=injected
            (Ansible instance, op-019e615f-f40b)
  16:02:49  Background op submitted: bgop-5b7468da5b87
  16:51:55  [LoopDeadman] CRITICAL [LoopDeadman.TOMBSTONE]
            File "harness.py:6752" in _slice12g3_periodic_checkpoint_loop
              await asyncio.sleep(interval_s)
            File "session_wal.py:174" in checkpoint
              with self._lock:
            File "session_wal.py:254" in _atomic_write

Result: stop_reason=idle_timeout, cost_total=0.0, cost_breakdown={}.
The engine deadlocked itself before reaching any provider call.

## Root cause

`session_wal.py` uses `threading.Lock` (synchronous lock).
`SessionWAL.checkpoint()` acquires the lock and calls
`_atomic_write()` which does synchronous file I/O: json.dumps +
open + write + flush + os.fsync + os.replace. That ~5-50ms blocking
call ran on the asyncio main thread when the harness periodic
checkpoint loop at harness.py:6774 invoked the sync method directly:

  state = self._slice12g3_build_checkpoint_state(reason="periodic")
  self._session_wal.checkpoint(state, "periodic")  # ← blocks loop

Cumulative checkpoint blocking + lock contention with other holders
(signal-handler force_checkpoint paths, etc.) eventually starved the
asyncio loop tick beyond LoopDeadman's threshold.

## Fix mechanism — async-safe acheckpoint via asyncio.to_thread

**1. New `SessionWAL.acheckpoint(state, reason)` async method:**

  async def acheckpoint(self, state, reason=""):
      if not wal_enabled():
          return False
      try:
          return await asyncio.to_thread(
              self.checkpoint, state, reason,
          )
      except asyncio.CancelledError:
          raise
      except Exception:
          logger.debug("[SessionWAL] acheckpoint swallowed exc", exc_info=True)
          return False

The blocking file I/O runs on the default thread pool executor;
the asyncio main loop tick continues during the write.

**2. Harness migration at harness.py:6774:**

  - self._session_wal.checkpoint(state, "periodic")     # blocks loop
  + await self._session_wal.acheckpoint(state, "periodic")  # off-loop

## Operator bindings honored

* **threading.Lock PRESERVED (NOT migrated to asyncio.Lock)** —
  signal handlers (SIGTERM/SIGINT) and atexit fallback paths still
  call the sync entry point during shutdown. Both sync and async
  paths coordinate through the same threading.Lock so they safely
  interleave with worker-thread writes. Per-instance lock state is
  thread-safe by construction.
* **Sync checkpoint() + force_checkpoint() RETAINED verbatim** for:
  (1) signal handlers — loop may already be cancelled, to_thread unsafe;
  (2) atexit fallback — interpreter shutdown, executor pool gone;
  (3) shutdown_cancel branch in the harness periodic loop (already
      sync, kept as-is — runs in the CancelledError handler where
      to_thread can't be guaranteed to complete).
* **Behavior contract on acheckpoint identical to checkpoint** —
  same return shape (True on write, False on skip/error), same
  debounce (`wal_min_interval_s`), same defensive
  exception-swallow. asyncio.CancelledError propagates per
  cooperative-cancel contract.
* **AST-pinned regression guards** — the harness must use
  `await self._session_wal.acheckpoint(state, "periodic")` and
  must NOT contain the sync call shape anywhere in the periodic
  loop body. Walks the AsyncFunctionDef AST to enforce.
* **Functional regression guard** — concurrent-poll test proves
  the event loop stays alive during checkpoint (≥20/40 polls
  fire during a 50k-key state write).

## Test surface (2 AST pins + 5 spine, 7/7 green; +206 arc tests)

AST pins (2):
  1. SessionWAL has `async def acheckpoint` + uses `asyncio.to_thread`
     + wraps `self.checkpoint, state, reason` + Slice 14 attribution
     + bt-2026-05-25-230029 soak link
  2. Harness periodic loop uses `await self._session_wal.acheckpoint(state, "periodic")`
     AND the AsyncFunctionDef body no longer contains
     `self._session_wal.checkpoint(state, "periodic")` (sync removed)

Spine (5):
  - acheckpoint() writes summary.json with expected content (same
    contract as sync checkpoint)
  - Concurrent-poll regression guard — during a 50k-key state write,
    a separate `asyncio.sleep(0.001)` task gets ≥20/40 polls. Direct
    regression on the LoopDeadman tombstone — if the loop blocked
    on the write, the poller would get ~0 polls.
  - Disabled mode (`JARVIS_SESSION_WAL_ENABLED=false`) returns False
    without scheduling worker thread
  - Inner exception (mock raises RuntimeError) swallowed → returns
    False, doesn't propagate (defensive contract preserved)
  - Debounce respected on async path (second call within
    `min_interval_s` returns False without writing)

## Distance to RESOLVED — what this actually unlocks

Pre-Slice-14 (bt-2026-05-25-230029):
  Boot → 10A+10B fire ✓ → SWE-Bench injected ✓ → op submitted ✓ →
  periodic checkpoint loop blocks main thread → LoopDeadman fires
  → idle_timeout → $0.00 burn, op never dispatched

Post-Slice-14:
  Boot → 10A+10B fire ✓ → SWE-Bench injected ✓ → op submitted ✓ →
  periodic checkpoint off-loop ✓ → op dispatches → DW serves via
  Slice 10A/10B routing ✓ → L2 cascade via Slice 6/9 ✓ →
  APPLY → VERIFY → **first RESOLVED verdict**

The engine can finally breathe.

2 files changed (session_wal.py, harness.py), ~75 insertions(+), ~1 deletion(-)
+ 1 file added (test_slice14_wal_async_safety.py), ~270 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SessionWAL checkpoints async-safe by adding `acheckpoint` that offloads blocking I/O via `asyncio.to_thread`, and update the harness to use it. This removes the event-loop deadlock (LoopDeadman tombstone) seen in soak bt-2026-05-25-230029.

- **Bug Fixes**
  - Add `SessionWAL.acheckpoint(state, reason)` that runs sync `checkpoint` in `asyncio.to_thread`; keeps `threading.Lock`, debounce, return shape, and error handling.
  - Update harness periodic loop to `await self._session_wal.acheckpoint(state, "periodic")`; keep sync paths for shutdown and signal handlers.
  - Add tests: AST pins for `acheckpoint` and harness wiring, plus functional checks for write, non-blocking loop, disabled mode, inner errors, and debounce.

<sup>Written for commit d315e41f9c94726c68bce2f2b32ee0aadfc40694. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/58280?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

