### PR TITLE
fix(governance): Slice 10B-ii — Dynamic topology sync (provider_topology consults PromotionLedger for trusted-seed bypass)

### DIFF
--- a/backend/core/ouroboros/governance/provider_topology.py
+++ b/backend/core/ouroboros/governance/provider_topology.py
@@ -268,11 +268,32 @@ class ProviderTopology:
         the legacy DW cascade keeps working when the yaml is absent. The
         whole point of the hard-block is that it is **explicit** — new
         routes are opt-in to the cortex, not opt-out by accident.
+
+        Slice 10B-ii (2026-05-26) — when the YAML returns ``dw_allowed=
+        false`` for a non-IMMEDIATE route, consult
+        :func:`_trusted_seed_dw_models_for_route` for operator-attested
+        models from PromotionLedger that pass the route's per-route
+        eligibility gates. If non-empty, the runtime bypass returns
+        True so the candidate_generator topology block doesn't fire
+        and DW dispatch can proceed via the trusted seeds. IMMEDIATE
+        is excluded from the bypass per Manifesto §5 (Claude-direct
+        by design — speed permanently supersedes cost optimization).
+
+        The YAML ``dw_allowed: false`` stays the SAFETY CONTRACT; the
+        ledger bypass is the RUNTIME AUTHORITY when the operator has
+        explicitly attested specific models via JARVIS_DW_TRUSTED_MODELS.
         """
         if not self.enabled:
             return True
         entry = self.routes.get((route or "").strip().lower())
         if entry is None:
+            return True
+        if entry.dw_allowed:
+            return True
+        # ── Slice 10B-ii — trusted-seed runtime bypass ──
+        # YAML says DW blocked for this route; check whether
+        # operator-attested PromotionLedger seeds qualify.
+        if _trusted_seed_dw_models_for_route(route):
             return True
         return entry.dw_allowed
 
@@ -399,7 +420,17 @@ class ProviderTopology:
         entry = self.routes.get((route or "").strip().lower())
         if entry is None:
             return ()
-        return entry.effective_dw_models
+        effective = entry.effective_dw_models
+        if effective:
+            return effective
+        # ── Slice 10B-ii — trusted-seed runtime bypass ──
+        # YAML + dynamic catalog both returned empty; consult
+        # PromotionLedger for operator-attested trusted seeds that
+        # pass the route's per-route eligibility gates. See
+        # :func:`_trusted_seed_dw_models_for_route` for the gate
+        # composition (re-uses dw_catalog_classifier.gate_for_route
+        # so the same param/price thresholds apply).
+        return _trusted_seed_dw_models_for_route(route)
 
     def fallback_tolerance_for_route(self, route: str) -> str:
         """Return the v2 ``fallback_tolerance`` for *route*.
@@ -990,6 +1021,145 @@ def clear_dynamic_catalog() -> None:
     global _DYNAMIC_CATALOG
     with _DYNAMIC_CATALOG_LOCK:
         _DYNAMIC_CATALOG = None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Slice 10B-ii (2026-05-26) — PromotionLedger trusted-seed bypass
+#
+# Closes the two-registry disconnect surfaced by bt-2026-05-26-000630
+# (v11 DW-PRIMARY soak). Slice 10B seeded ``JARVIS_DW_TRUSTED_MODELS``
+# into PromotionLedger as ``promoted=True`` with origin=trusted_seed,
+# but the topology check (``dw_allowed_for_route`` / ``dw_models_for_
+# route``) never consulted PromotionLedger — it only read
+# ``brain_selection_policy.yaml`` (where ``dw_allowed: false`` +
+# ``dw_models: []`` for STANDARD/COMPLEX/BG/SPEC remained the
+# Phase-12 frozen contract awaiting catalog discovery). Result:
+# operator-attested DW models were structurally invisible to the
+# topology gate; every STANDARD-routed op cascaded to Claude despite
+# the trusted seed.
+#
+# This module is the cooperative bridge between the YAML safety
+# contract (immutable, encodes cost-policy) and the operator-attested
+# runtime authority (mutable, encodes "this model is known-good").
+# Compose discipline: re-use ``dw_promotion_ledger.PromotionLedger``
+# + ``dw_catalog_classifier.gate_for_route`` (same per-route param /
+# price thresholds that the classifier applies during normal discovery).
+# No parallel state, no new env knob; ``JARVIS_DW_TRUSTED_MODELS``
+# stays the single operator-facing surface.
+# ──────────────────────────────────────────────────────────────────────
+
+
+# Routes that MUST NEVER receive a trusted-seed bypass even when seeds
+# exist. Manifesto §5: IMMEDIATE is Claude-direct by design — "survival
+# and execution speed permanently supersede cost optimization." The
+# operator's stated preference for cheap DW does NOT override §5's
+# human-reflex-routing contract.
+_TRUSTED_SEED_BYPASS_FORBIDDEN_ROUTES = frozenset({"immediate"})
+
+
+def _trusted_seed_dw_models_for_route(route: str) -> Tuple[str, ...]:
+    """Slice 10B-ii — return PromotionLedger trusted-seed model_ids
+    that pass the route's per-route eligibility gates, in stable
+    insertion order. Returns empty tuple when:
+
+      * route is IMMEDIATE (Manifesto §5 — bypass forbidden);
+      * PromotionLedger import / read raises (defensive fail-empty);
+      * no promoted models exist in the ledger;
+      * promoted models exist but none have ModelCard metadata
+        that passes the route's ``EligibilityGate`` (per-route
+        min_params_b + max_out_price_per_m thresholds);
+      * any ledger / catalog interaction surfaces an exception
+        (NEVER raises — topology must not crash on bridge errors).
+
+    Composes ``dw_promotion_ledger.PromotionLedger`` (already-existing
+    Slice 10B substrate) + ``dw_catalog_classifier.gate_for_route``
+    (already-existing per-route gate definitions). No parallel state.
+
+    Trusted seeds without catalog ModelCard metadata (the common case
+    — operator attestation is "this model_id is good" without metadata)
+    PASS the gate by construction: per-route gates skip checks when the
+    relevant field is None (see EligibilityGate.admits — checks fire
+    ONLY when both threshold AND card field are non-None). This is
+    intentional — the OPERATOR'S attestation is the warrant, not
+    metadata. Future enhancement: cross-check against
+    dw_catalog_client snapshot if available.
+    """
+    route_lc = (route or "").strip().lower()
+    if not route_lc or route_lc in _TRUSTED_SEED_BYPASS_FORBIDDEN_ROUTES:
+        return ()
+    try:
+        # Lazy imports — keep provider_topology bootable without
+        # forcing the entire promotion-ledger / classifier graph
+        # to load when topology is consulted standalone (e.g., test).
+        from backend.core.ouroboros.governance.dw_promotion_ledger import (  # noqa: E501
+            PromotionLedger,
+        )
+        from backend.core.ouroboros.governance.dw_catalog_classifier import (  # noqa: E501
+            gate_for_route,
+        )
+    except Exception:  # noqa: BLE001 — defensive (fail-closed → empty)
+        return ()
+    try:
+        ledger = PromotionLedger()
+        ledger.load()
+        promoted = ledger.promoted_models()
+    except Exception:  # noqa: BLE001 — defensive
+        return ()
+    if not promoted:
+        return ()
+    try:
+        gate = gate_for_route(route_lc)
+    except Exception:  # noqa: BLE001 — defensive
+        return ()
+    # When we lack ModelCard metadata for a promoted model, the
+    # EligibilityGate.admits() check on a synthetic minimal card
+    # passes by construction (every gate check skips when the
+    # relevant field is None). Build a minimal synthetic ModelCard
+    # for each promoted model_id and let the gate decide.
+    try:
+        from backend.core.ouroboros.governance.dw_catalog_client import (  # noqa: E501
+            ModelCard,
+            parse_parameter_count,
+            parse_family,
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        # If ModelCard unavailable, fall back to returning ALL
+        # promoted seeds (defense-in-depth: operator attested them).
+        return tuple(promoted)
+    admitted: list = []
+    for model_id in promoted:
+        try:
+            mid_str = str(model_id)
+            # Parse parameter count from the model_id (e.g.,
+            # "doubleword-397b" → 397.0). The existing
+            # parse_parameter_count helper handles "-NNNb",
+            # "-NN.Mb", and "_NNNb" suffixes; returns None when
+            # no recognizable size token is present.
+            #
+            # When parsing fails (no size in model_id), we set
+            # the field to None — the per-route EligibilityGate
+            # will reject if min_params_b > 0 (STANDARD=14B,
+            # COMPLEX=30B). This is the CORRECT behavior: a
+            # model_id without a parseable size hasn't proven it
+            # meets the per-route cost-shape contract. BG/SPEC
+            # routes (no min_params_b) admit the model regardless.
+            parsed_params = parse_parameter_count(mid_str)
+            parsed_family = parse_family(mid_str)
+            synthetic = ModelCard(
+                model_id=mid_str,
+                family=parsed_family or "unknown",
+                parameter_count_b=parsed_params,
+                context_window=None,
+                pricing_in_per_m_usd=None,
+                pricing_out_per_m_usd=None,
+                supports_streaming=True,
+                raw_metadata_json="{}",
+            )
+            if gate.admits(synthetic):
+                admitted.append(mid_str)
+        except Exception:  # noqa: BLE001 — per-model defensive
+            continue
+    return tuple(admitted)
 
 
 @dataclass(frozen=True)

--- a/tests/governance/test_slice10b_ii_topology_sync.py
+++ b/tests/governance/test_slice10b_ii_topology_sync.py
@@ -1,0 +1,295 @@
+"""Slice 10B-ii — Dynamic topology sync: provider_topology consults PromotionLedger for trusted-seed bypass.
+
+Closes the two-registry disconnect surfaced by soak bt-2026-05-26-000630
+(v11 DW-PRIMARY soak). Slice 10B (PR #58165) seeded
+``JARVIS_DW_TRUSTED_MODELS`` into PromotionLedger, but the topology
+check (``dw_allowed_for_route`` / ``dw_models_for_route``) never
+consulted PromotionLedger — it only read brain_selection_policy.yaml
+where ``dw_allowed: false`` + ``dw_models: []`` for STANDARD/COMPLEX/
+BG/SPEC remained the Phase-12 frozen contract awaiting catalog
+discovery. Result: trusted seeds were structurally invisible to the
+topology gate; every STANDARD op cascaded to Claude.
+
+# Empirical proof from bt-2026-05-26-000630
+
+  17:00  [PromotionLedger] Slice 10B: seeded 1 trusted model(s) ✓
+  17:09  Route: standard (swe_bench_pro_envelope:not_human_blocking) ✓
+  17:09  [CandidateGenerator] Topology block: route=standard
+         reason=Static list purged; ranking authority is dw_catalog_classifier
+         — routing direct to Claude  ← THE BUG
+  17:09  → Claude (BadRequestError: credit balance too low)
+  17:57  LoopDeadman tombstone — engine dead, $0.00 burn
+
+# Fix mechanism
+
+Add ``_trusted_seed_dw_models_for_route(route)`` helper that:
+  1. Returns empty tuple for IMMEDIATE (Manifesto §5 exclusion)
+  2. Loads PromotionLedger.promoted_models()
+  3. For each promoted model_id, builds a synthetic ModelCard with
+     parameter_count_b parsed from the model_id via the existing
+     parse_parameter_count helper (e.g., "doubleword-397b" → 397.0)
+  4. Filters via dw_catalog_classifier.gate_for_route (same per-route
+     param/price thresholds as the normal discovery classifier)
+  5. Returns the admitted model_ids
+
+Two integration points in ProviderTopology:
+  - dw_allowed_for_route: returns True when bypass returns non-empty
+  - dw_models_for_route: returns bypass list when YAML+catalog empty
+
+YAML stays the SAFETY CONTRACT (immutable cost-policy); PromotionLedger
+becomes the RUNTIME AUTHORITY when operator attests specific models.
+
+# Test surface (3 AST pins + 6 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOPOLOGY_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "provider_topology.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_trusted_seed_helper_present() -> None:
+    """``_trusted_seed_dw_models_for_route`` MUST exist as a
+    module-level function. Slice 10B-ii's bridge depends on it."""
+    src = TOPOLOGY_FILE.read_text()
+    assert "def _trusted_seed_dw_models_for_route(" in src, (
+        "Slice 10B-ii helper function missing — bypass dead"
+    )
+    # Slice 10B-ii attribution + bt soak link
+    assert "Slice 10B-ii" in src
+    assert "bt-2026-05-26-000630" in src, (
+        "Missing soak attribution — future readers can't trace which "
+        "forensic surfaced the two-registry disconnect"
+    )
+    # IMMEDIATE exclusion (Manifesto §5)
+    assert "_TRUSTED_SEED_BYPASS_FORBIDDEN_ROUTES" in src
+    assert '"immediate"' in src, (
+        "IMMEDIATE not in forbidden-routes frozenset — bypass leaks "
+        "and violates Manifesto §5 (Claude-direct for human-reflex)"
+    )
+
+
+def test_ast_pin_dw_allowed_for_route_consults_bypass() -> None:
+    """``dw_allowed_for_route`` MUST call
+    ``_trusted_seed_dw_models_for_route`` when the YAML returns
+    ``dw_allowed=False``. Without this hook, the candidate_generator's
+    v1 topology-block path never sees the bypass."""
+    src = TOPOLOGY_FILE.read_text()
+    tree = ast.parse(src, filename=str(TOPOLOGY_FILE))
+    found_call = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "dw_allowed_for_route"
+        ):
+            body_src = ast.unparse(node)
+            if "_trusted_seed_dw_models_for_route" in body_src:
+                found_call = True
+                break
+    assert found_call, (
+        "dw_allowed_for_route does not call "
+        "_trusted_seed_dw_models_for_route — Slice 10B-ii bridge "
+        "inert on the v1 topology-check path"
+    )
+
+
+def test_ast_pin_dw_models_for_route_consults_bypass() -> None:
+    """``dw_models_for_route`` MUST consult
+    ``_trusted_seed_dw_models_for_route`` as a fallback after
+    catalog + YAML both return empty. Without this hook, the v2
+    sentinel-mode topology check (and candidate_generator's
+    sentinel-on path) miss the bypass."""
+    src = TOPOLOGY_FILE.read_text()
+    tree = ast.parse(src, filename=str(TOPOLOGY_FILE))
+    found_call = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "dw_models_for_route"
+        ):
+            body_src = ast.unparse(node)
+            if "_trusted_seed_dw_models_for_route" in body_src:
+                found_call = True
+                break
+    assert found_call, (
+        "dw_models_for_route does not call "
+        "_trusted_seed_dw_models_for_route — bridge inert on v2 path"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 6 (functional)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_trusted_seed_admits_non_immediate_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With JARVIS_DW_TRUSTED_MODELS=doubleword-397b set, the helper
+    must admit the model into STANDARD, COMPLEX, BACKGROUND, and
+    SPECULATIVE routes (per-route gates pass)."""
+    from backend.core.ouroboros.governance.provider_topology import (
+        _trusted_seed_dw_models_for_route,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "doubleword-397b")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH",
+            str(Path(tmp) / "ledger.json"),
+        )
+        for route in ("standard", "complex", "background", "speculative"):
+            seeds = _trusted_seed_dw_models_for_route(route)
+            assert "doubleword-397b" in seeds, (
+                f"Trusted seed NOT admitted into {route} route — "
+                f"Slice 10B-ii bridge broken on {route}; got {seeds}"
+            )
+
+
+def test_spine_immediate_route_excluded_from_bypass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Manifesto §5: IMMEDIATE is Claude-direct by design. Even with
+    trusted seeds present, IMMEDIATE must return empty tuple. The
+    operator's cost preference does NOT override §5 human-reflex
+    routing."""
+    from backend.core.ouroboros.governance.provider_topology import (
+        _trusted_seed_dw_models_for_route,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "doubleword-397b")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH",
+            str(Path(tmp) / "ledger.json"),
+        )
+        seeds = _trusted_seed_dw_models_for_route("immediate")
+        assert seeds == (), (
+            f"IMMEDIATE bypass LEAKED — violates Manifesto §5 "
+            f"(Claude-direct, speed supersedes cost); got {seeds}"
+        )
+
+
+def test_spine_no_trusted_seeds_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no trusted seeds are configured, helper returns empty
+    tuple for all routes (byte-equivalent to pre-Slice-10B-ii)."""
+    from backend.core.ouroboros.governance.provider_topology import (
+        _trusted_seed_dw_models_for_route,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        monkeypatch.delenv("JARVIS_DW_TRUSTED_MODELS", raising=False)
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH",
+            str(Path(tmp) / "ledger.json"),
+        )
+        for route in ("standard", "complex", "background", "speculative"):
+            seeds = _trusted_seed_dw_models_for_route(route)
+            assert seeds == (), (
+                f"Empty trusted-seed env produced phantom seeds on {route}: {seeds}"
+            )
+
+
+def test_spine_model_id_with_no_parseable_size_filtered_by_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A trusted model_id without a parseable parameter size
+    (e.g., 'mystery-model') must FAIL the STANDARD/COMPLEX gates
+    (min_params_b=14B/30B) because parameter_count_b parses to None,
+    AND the gate rejects when min > 0 AND card.parameter_count_b is None.
+    The model SHOULD pass BACKGROUND/SPECULATIVE which don't gate on params."""
+    from backend.core.ouroboros.governance.provider_topology import (
+        _trusted_seed_dw_models_for_route,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "mystery-model")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH",
+            str(Path(tmp) / "ledger.json"),
+        )
+        assert _trusted_seed_dw_models_for_route("standard") == ()
+        assert _trusted_seed_dw_models_for_route("complex") == ()
+        # BACKGROUND + SPECULATIVE have no min_params_b → admit
+        assert "mystery-model" in _trusted_seed_dw_models_for_route("background")
+        assert "mystery-model" in _trusted_seed_dw_models_for_route("speculative")
+
+
+def test_spine_dw_allowed_for_route_bypass_integration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: when YAML returns dw_allowed=False for STANDARD
+    (the production state) AND a trusted seed exists, the public
+    dw_allowed_for_route method must return True. This is the
+    contract the candidate_generator's topology-block check reads
+    on the v1 path."""
+    from backend.core.ouroboros.governance.provider_topology import (
+        get_topology,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "doubleword-397b")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH",
+            str(Path(tmp) / "ledger.json"),
+        )
+        topology = get_topology()
+        # If topology is fully disabled, the test is moot (always returns
+        # True). Skip in that case.
+        if not topology.enabled:
+            pytest.skip("Topology disabled in this environment")
+        allowed_standard = topology.dw_allowed_for_route("standard")
+        allowed_immediate = topology.dw_allowed_for_route("immediate")
+        assert allowed_standard is True, (
+            "Slice 10B-ii: STANDARD route should be DW-allowed with "
+            "trusted seed present (bridge failed)"
+        )
+        # IMMEDIATE: production yaml has dw_allowed=False AND bypass
+        # excludes IMMEDIATE per §5 → stays False
+        assert allowed_immediate is False, (
+            "IMMEDIATE bypass LEAKED end-to-end — §5 violated"
+        )
+
+
+def test_spine_dw_models_for_route_bypass_integration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: dw_models_for_route must return the trusted seed
+    list when YAML+catalog are both empty for STANDARD. This is the
+    contract sentinel-mode topology checks read on the v2 path."""
+    from backend.core.ouroboros.governance.provider_topology import (
+        get_topology,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "doubleword-397b")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH",
+            str(Path(tmp) / "ledger.json"),
+        )
+        topology = get_topology()
+        if not topology.enabled:
+            pytest.skip("Topology disabled in this environment")
+        models_standard = topology.dw_models_for_route("standard")
+        models_immediate = topology.dw_models_for_route("immediate")
+        assert "doubleword-397b" in models_standard, (
+            f"Slice 10B-ii: dw_models_for_route('standard') missing "
+            f"trusted seed; got {models_standard}"
+        )
+        # IMMEDIATE excluded — even if YAML had a model, the bypass
+        # for IMMEDIATE returns empty; here YAML is also empty for IMMEDIATE
+        # so the assertion is that doubleword-397b is NOT in the result.
+        assert "doubleword-397b" not in models_immediate, (
+            "IMMEDIATE bypass LEAKED into dw_models_for_route"
+        )


### PR DESCRIPTION
fix(governance): Slice 10B-ii — Dynamic topology sync (provider_topology consults PromotionLedger for trusted-seed bypass)

Closes the two-registry disconnect surfaced by soak bt-2026-05-26-000630
(v11 DW-PRIMARY soak — 0 DW calls, $0.00 cost, LoopDeadman at T+51m).

## The bug — two parallel registries that never talk

Slice 10B (PR #58165) seeded ``JARVIS_DW_TRUSTED_MODELS`` into
``PromotionLedger`` as ``promoted=True`` with origin=trusted_seed.
But the topology check at ``candidate_generator.py:1992`` consults
``provider_topology.{dw_allowed_for_route, dw_models_for_route}``
which only read ``brain_selection_policy.yaml`` (Phase 12 frozen
contract: ``dw_allowed: false`` + ``dw_models: []`` for STANDARD/
COMPLEX/BG/SPEC awaiting catalog discovery).

PromotionLedger and provider_topology were two separate registries
that never talked. Trusted seeds were structurally invisible to the
topology gate. Every STANDARD-routed op cascaded to Claude.

## Empirical chain from bt-2026-05-26-000630

  17:00:50 [PromotionLedger] Slice 10B: seeded 1 trusted model(s) ✓
  17:09:53 Route: standard
           (swe_bench_pro_envelope:not_human_blocking) ✓ [Slice 10A]
  17:09:54 [CandidateGenerator] Topology block: route=standard
           reason=Catalog-driven (Phase 12). Static list purged;
           ranking authority is dw_catalog_classifier ...
           — routing direct to Claude  ← THE BUG
  17:09:55 [ClaudeProvider] BadRequestError: credit balance too low
  17:57:42 [LoopDeadman] WEDGE DETECTED — os._exit(75)
  $0.00 burn, 0 DW calls, 0 RESOLVED verdicts

## Fix mechanism — bridge module-private helper

  _trusted_seed_dw_models_for_route(route) -> Tuple[str, ...]

Returns the operator-attested PromotionLedger model_ids that pass
the route's per-route ``dw_catalog_classifier.gate_for_route``
thresholds. Per-model evaluation:

  1. IMMEDIATE excluded via _TRUSTED_SEED_BYPASS_FORBIDDEN_ROUTES
     frozenset (Manifesto §5 — Claude-direct by design)
  2. PromotionLedger.promoted_models() → list of model_ids
  3. For each model_id, parse_parameter_count(model_id) extracts
     the size token (e.g. "doubleword-397b" → 397.0)
  4. Synthetic ModelCard with parsed params + None for absent
     fields → EligibilityGate.admits() decides
  5. Admitted ids returned in insertion order

Two integration points in ProviderTopology:

  - dw_allowed_for_route: returns True when bypass non-empty
    (v1 topology-check path — current production)
  - dw_models_for_route: returns bypass list when YAML+catalog
    both empty (v2 sentinel path — Phase 10 Slice 5a forward)

## Operator bindings honored — "no shortcuts, leverage existing files"

* **Composes existing infrastructure** —
  - PromotionLedger (Slice 10B substrate; same instance + .load())
  - dw_catalog_classifier.gate_for_route (canonical per-route gates)
  - dw_catalog_client.parse_parameter_count + parse_family + ModelCard
  - No new env knob, no parallel state, no YAML edit
* **YAML stays the SAFETY CONTRACT** — dw_allowed: false +
  dw_models: [] remain the immutable cost-policy gate. The trusted-seed
  bypass is the RUNTIME AUTHORITY ONLY when the operator has
  explicitly attested specific models via JARVIS_DW_TRUSTED_MODELS.
  The two layers are cooperative, not contradictory.
* **IMMEDIATE strictly excluded** — Manifesto §5 contract preserved.
  Operator's cost preference does NOT override the human-reflex-routing
  speed contract. AST-pinned + spine-tested.
* **Per-route gates respected** — trusted seeds STILL must pass
  STANDARD min_params_b=14B / COMPLEX min_params_b=30B / price caps.
  A trusted seed model_id without a parseable size (e.g. "mystery-model")
  is REJECTED from STANDARD/COMPLEX (params=None + min>0 → admits=False)
  but ADMITTED to BACKGROUND/SPECULATIVE (no min_params_b). Operator
  attestation is the warrant; per-route economics still apply.
* **Defensive fail-empty** — every external call (ledger.load,
  ledger.promoted_models, gate_for_route, ModelCard construction)
  wrapped in try/except. Topology check NEVER raises on bridge errors.
* **AST-pinned** — 3 pins:
  (1) helper function present + _TRUSTED_SEED_BYPASS_FORBIDDEN_ROUTES
      frozenset contains "immediate" + Slice 10B-ii + bt soak attribution
  (2) dw_allowed_for_route body calls _trusted_seed_dw_models_for_route
      (AST walk via FunctionDef → ast.unparse contains substring)
  (3) dw_models_for_route body calls _trusted_seed_dw_models_for_route

## Test surface (3 AST pins + 6 spine, 9/9 green; +213 arc tests)

AST pins (3): helper presence + dw_allowed integration + dw_models integration

Spine (6):
  - Trusted seed admitted into all 4 non-IMMEDIATE routes
    (STANDARD, COMPLEX, BACKGROUND, SPECULATIVE)
  - IMMEDIATE bypass strictly empty (Manifesto §5 verified)
  - Empty/unset JARVIS_DW_TRUSTED_MODELS → empty on all routes
    (byte-equivalent to pre-Slice-10B-ii)
  - model_id without parseable size correctly filtered from
    STANDARD/COMPLEX (params=None vs min>0 → reject) but admitted
    to BG/SPEC (no min_params_b)
  - End-to-end: dw_allowed_for_route('standard') returns True with
    trusted seed AND False for IMMEDIATE (production YAML state)
  - End-to-end: dw_models_for_route('standard') includes
    'doubleword-397b'; 'immediate' excludes it

## Distance to RESOLVED — what this actually unlocks

Pre-Slice-10B-ii (v11 soak):
  Boot → Slice 10B seed ✓ → Slice 10A STANDARD route ✓ →
  topology block fires anyway → cascade to Claude →
  Anthropic credit BadRequestError → circuit breaker OPEN →
  no provider attempts → LoopDeadman → $0.00 burn

Post-Slice-10B-ii (v12 expected):
  Boot → Slice 10B seed ✓ → Slice 10A STANDARD route ✓ →
  topology consults trusted seed ✓ → dw_allowed=True ✓ →
  candidate_generator dispatches to DW ✓ →
  DW serves generation ($0.005 per op) → APPLY → VERIFY → RESOLVED

(With operator-refilled Anthropic credit as the secondary fallback —
this PR addresses the architectural fix only, not the billing issue.)

1 file changed (provider_topology.py), ~160 insertions(+), ~3 deletions(-)
+ 1 file added (test_slice10b_ii_topology_sync.py), ~290 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a routing bug where trusted DW seeds in `PromotionLedger` were ignored by `provider_topology`, causing DW to never dispatch. Now topology checks consult the ledger to allow DW on non-IMMEDIATE routes when attested models pass per-route gates, while keeping the YAML safety contract intact.

- **Bug Fixes**
  - Added `_trusted_seed_dw_models_for_route(route)` to read operator-attested models from `PromotionLedger` and filter them with `dw_catalog_classifier.gate_for_route`.
  - Updated `dw_allowed_for_route` to return True when the trusted-seed bypass is non-empty; updated `dw_models_for_route` to return the bypass list when YAML and catalog are empty.
  - Excludes IMMEDIATE from the bypass; fails empty on errors; no new env knobs; reuses `JARVIS_DW_TRUSTED_MODELS` and existing catalog helpers.

<sup>Written for commit 898c62a6dd312f2f22adfcd199db32ecb7c6dd51. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/58434?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

