### PR TITLE
fix(governance): Slice 10B-iii — trusted-seed overrides ambiguous_metadata quarantine (state hierarchy fix)

### DIFF
--- a/backend/core/ouroboros/governance/dw_promotion_ledger.py
+++ b/backend/core/ouroboros/governance/dw_promotion_ledger.py
@@ -356,19 +356,49 @@ class PromotionLedger:
         ``has_ambiguous_metadata`` and pinned to SPECULATIVE-only.
         Trusted models bypass that gate from boot 0.
 
-        Discipline:
-          * Disk records ALWAYS take precedence. If a model already
-            has a record (promoted, demoted, or quarantined), the env
-            seed is silently skipped for that model. Operator must
-            clear the disk record to re-seed.
-          * Empty/unset env → no-op. Existing behavior byte-equivalent
-            to pre-Slice-10B.
-          * NEVER raises — env parse failures degrade to empty list.
-          * Caller responsibility: ``JARVIS_DW_TRUSTED_MODELS=...``
-            is an operator attestation; if the listed model_ids
-            don't exist on the DW endpoint, the classifier will
-            simply find no card for them and the seed is harmless
-            (no provider call ever lands on a phantom model).
+        # Slice 10B-iii state-hierarchy refinement (2026-05-26)
+
+        bt-2026-05-26-062945 (v12 soak) surfaced a design flaw in the
+        original Slice 10B discipline: "disk records always take
+        precedence" conflated TWO distinct kinds of disk state:
+
+          1. **Operator decisions** — `operator_demoted` or
+             `demoted_from_bg` origins. The operator (or operator-driven
+             post-promotion failure) explicitly demoted the model. The
+             env trusted seed MUST NOT override these — that would
+             silently revert an operator action.
+
+          2. **Automatic classifier quarantine** — `ambiguous_metadata`
+             origin. This is an AUTO safety pin assigned by
+             `dw_catalog_classifier.classify()` when the discovered
+             ModelCard has both `parameter_count_b` AND
+             `pricing_out_per_m_usd` as None. It is NOT an operator
+             decision — it is the absence of one. The operator's
+             explicit attestation via JARVIS_DW_TRUSTED_MODELS supplies
+             the warrant the auto-classifier lacks. The env seed
+             SHOULD override this.
+
+        v12 had 18 models on disk from prior discovery, all quarantined
+        with origin=ambiguous_metadata. The pre-10B-iii seed logic
+        skipped 3 of 4 trusted-env models (already on disk) and only
+        promoted the 1 model NOT yet on disk (Qwen3.5-4B). Result:
+        the fleet expansion was silently inert; only 397B (from prior
+        soak's seed under the legacy alias `doubleword-397b`) + the new
+        4B were promoted; 35B + Kimi stayed quarantined.
+
+        Slice 10B-iii state hierarchy:
+          * No disk record         → seed (create promoted=True record)
+          * origin=ambiguous_metadata → OVERRIDE: promote + flip origin
+                                       to trusted_seed (auto-quarantine
+                                       loses to operator attestation)
+          * origin=trusted_seed    → already promoted (idempotent — no-op)
+          * origin=operator_demoted → SKIP (operator decision wins)
+          * origin=demoted_from_bg → SKIP (post-promotion failure wins —
+                                     it's empirical, not auto-classified)
+          * Other origins → SKIP (defensive: unknown disk state wins)
+
+        Empty/unset env → no-op (byte-equivalent to pre-Slice-10B-iii).
+        NEVER raises.
         """
         raw = os.environ.get("JARVIS_DW_TRUSTED_MODELS", "").strip()
         if not raw:
@@ -379,30 +409,66 @@ class PromotionLedger:
         ]
         if not candidates:
             return
-        seeded = 0
+        # ── Slice 10B-iii — state hierarchy override ──
+        # Origins for which env trusted seed OVERRIDES the disk record:
+        _OVERRIDABLE_ORIGINS = frozenset({
+            QUARANTINE_AMBIGUOUS_METADATA,
+        })
+        seeded_new = 0
+        promoted_override = 0
+        skipped_operator = 0
         for mid in candidates:
-            if mid in self._records:
-                # Disk record wins — silently skip the env seed.
+            existing = self._records.get(mid)
+            if existing is None:
+                # No disk record — create fresh promoted entry
+                self._records[mid] = PromotionRecord(
+                    model_id=mid,
+                    quarantine_origin=QUARANTINE_TRUSTED_SEED,
+                    success_latencies_ms=[],
+                    failure_count=0,
+                    promoted=True,
+                    promoted_at_unix=time.time(),
+                    last_event_unix=time.time(),
+                )
+                seeded_new += 1
                 continue
-            rec = PromotionRecord(
-                model_id=mid,
-                quarantine_origin=QUARANTINE_TRUSTED_SEED,
-                success_latencies_ms=[],
-                failure_count=0,
-                promoted=True,  # bypass 10-success requirement
-                promoted_at_unix=time.time(),
-                last_event_unix=time.time(),
-            )
-            self._records[mid] = rec
-            seeded += 1
-        if seeded > 0:
+            if existing.promoted:
+                # Already promoted (likely a prior trusted_seed run);
+                # idempotent — leave as-is.
+                continue
+            if existing.quarantine_origin in _OVERRIDABLE_ORIGINS:
+                # Slice 10B-iii — auto-quarantine LOSES to operator
+                # attestation. Override the disk record: flip to
+                # promoted=True + origin=trusted_seed. Clear any stale
+                # latency history (the prior auto-quarantine never
+                # actually ran the model, so historic latencies don't
+                # apply to the trusted-seed promotion path).
+                existing.promoted = True
+                existing.quarantine_origin = QUARANTINE_TRUSTED_SEED
+                existing.success_latencies_ms.clear()
+                existing.failure_count = 0
+                existing.promoted_at_unix = time.time()
+                existing.last_event_unix = time.time()
+                promoted_override += 1
+                continue
+            # operator_demoted, demoted_from_bg, or unknown origin →
+            # operator decision wins; silently skip.
+            skipped_operator += 1
+        total_promoted = seeded_new + promoted_override
+        if total_promoted > 0 or skipped_operator > 0:
             logger.info(
-                "[PromotionLedger] Slice 10B: seeded %d trusted model(s) "
-                "from JARVIS_DW_TRUSTED_MODELS — these bypass the "
-                "10-success prove-it requirement (origin=trusted_seed)",
-                seeded,
+                "[PromotionLedger] Slice 10B-iii: trusted-seed "
+                "outcome — seeded_new=%d promoted_override=%d "
+                "skipped_operator_decision=%d "
+                "(env=JARVIS_DW_TRUSTED_MODELS; auto-quarantine "
+                "yields to operator attestation; operator demotions "
+                "preserved)",
+                seeded_new,
+                promoted_override,
+                skipped_operator,
             )
-            self._maybe_autosave()
+            if total_promoted > 0:
+                self._maybe_autosave()
 
     def save(self) -> None:
         """Write current state to disk atomically. NEVER raises;

--- a/tests/governance/test_slice10b_iii_ledger_override.py
+++ b/tests/governance/test_slice10b_iii_ledger_override.py
@@ -1,0 +1,372 @@
+"""Slice 10B-iii — Trusted-seed overrides ambiguous_metadata quarantine (state hierarchy fix).
+
+Closes the design flaw surfaced by soak bt-2026-05-26-062945 (FLEET v12).
+Pre-Slice-10B-iii ``_seed_trusted_models_from_env`` had a single
+"disk wins on conflict" rule, conflating TWO distinct kinds of
+disk state:
+
+  1. **Operator decisions** (origin=operator_demoted, demoted_from_bg)
+     — env trusted seed MUST NOT override (would silently revert)
+  2. **Automatic classifier quarantine** (origin=ambiguous_metadata)
+     — AUTO safety pin from `dw_catalog_classifier`; absence of an
+     operator decision, NOT one. Env attestation SHOULD override.
+
+# Empirical proof from bt-2026-05-26-062945
+
+  v12 disk had 18 models from prior discovery, all quarantined with
+  origin=ambiguous_metadata. Operator set JARVIS_DW_TRUSTED_MODELS=
+  "Qwen3.5-397B,Qwen3.5-35B,Qwen3.5-4B,Kimi-K2.6". Pre-Slice-10B-iii:
+
+    seeded 1 trusted model(s) from JARVIS_DW_TRUSTED_MODELS
+
+  Only 1 (the 4B not yet on disk) seeded. The other 3 (already on
+  disk as ambiguous_metadata) silently skipped → fleet expansion
+  inert → topology bridge couldn't promote them → only 397B (from
+  prior soak's legacy `doubleword-397b` alias) actually dispatched.
+
+# Fix mechanism — state hierarchy override
+
+  No disk record         → seed (create promoted=True)
+  origin=ambiguous_metadata → OVERRIDE: promote + flip to trusted_seed
+  origin=trusted_seed    → idempotent (already promoted)
+  origin=operator_demoted → SKIP (operator decision wins)
+  origin=demoted_from_bg → SKIP (post-promotion failure wins)
+  Other origins → SKIP (defensive)
+
+The override clears stale latency history (the prior auto-quarantine
+never ran the model; historical latencies don't apply to the new
+trusted-seed promotion path).
+
+# Test surface (2 AST pins + 6 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEDGER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "dw_promotion_ledger.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_overridable_origins_frozenset_present() -> None:
+    """The ``_OVERRIDABLE_ORIGINS`` frozenset MUST contain
+    ``QUARANTINE_AMBIGUOUS_METADATA`` and MUST NOT contain
+    ``QUARANTINE_OPERATOR_DEMOTED`` or ``QUARANTINE_DEMOTED_FROM_BG``
+    (those are operator decisions and must be preserved)."""
+    src = LEDGER_FILE.read_text()
+    assert "_OVERRIDABLE_ORIGINS" in src, (
+        "Missing _OVERRIDABLE_ORIGINS frozenset — Slice 10B-iii reverted"
+    )
+    # AST walk to find the assignment and verify membership
+    tree = ast.parse(src, filename=str(LEDGER_FILE))
+    found_with_ambiguous = False
+    operator_decisions_excluded = True
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "_OVERRIDABLE_ORIGINS"
+                for t in node.targets
+            )
+        ):
+            members_src = ast.unparse(node.value)
+            if "QUARANTINE_AMBIGUOUS_METADATA" in members_src:
+                found_with_ambiguous = True
+            if (
+                "QUARANTINE_OPERATOR_DEMOTED" in members_src
+                or "QUARANTINE_DEMOTED_FROM_BG" in members_src
+            ):
+                operator_decisions_excluded = False
+    assert found_with_ambiguous, (
+        "_OVERRIDABLE_ORIGINS does not include QUARANTINE_AMBIGUOUS_METADATA "
+        "— auto-quarantine will NOT yield to operator attestation"
+    )
+    assert operator_decisions_excluded, (
+        "_OVERRIDABLE_ORIGINS INCLUDES an operator-decision origin — "
+        "Slice 10B-iii violates operator-decision-wins discipline"
+    )
+
+
+def test_ast_pin_seed_method_has_override_path() -> None:
+    """``_seed_trusted_models_from_env`` MUST have a branch that
+    handles the OVERRIDE path (existing record + overridable origin).
+    Without it, the seed only handles new-record creation and
+    pre-Slice-10B-iii behavior persists."""
+    src = LEDGER_FILE.read_text()
+    tree = ast.parse(src, filename=str(LEDGER_FILE))
+    found_override = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "_seed_trusted_models_from_env"
+        ):
+            body_src = ast.unparse(node)
+            # The body must reference both _OVERRIDABLE_ORIGINS AND
+            # set existing.promoted = True (the override mutation)
+            if (
+                "_OVERRIDABLE_ORIGINS" in body_src
+                and "existing.promoted = True" in body_src
+            ):
+                found_override = True
+                break
+    assert found_override, (
+        "_seed_trusted_models_from_env does not implement the override "
+        "path — Slice 10B-iii bridge is inert"
+    )
+    # Slice 10B-iii attribution
+    assert "Slice 10B-iii" in src
+    assert "bt-2026-05-26-062945" in src, (
+        "Missing soak attribution — future readers can't trace which "
+        "FLEET v12 forensic exposed this"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 6 (functional)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _write_disk_record(
+    ledger_path: Path,
+    model_id: str,
+    origin: str,
+    *,
+    promoted: bool = False,
+) -> None:
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        LEDGER_SCHEMA_VERSION,
+    )
+    ledger_path.write_text(json.dumps({
+        "schema_version": LEDGER_SCHEMA_VERSION,
+        "records": [{
+            "model_id": model_id,
+            "quarantine_origin": origin,
+            "success_latencies_ms": [],
+            "failure_count": 0,
+            "promoted": promoted,
+            "promoted_at_unix": None,
+            "last_event_unix": 0.0,
+        }],
+    }))
+
+
+def test_spine_ambiguous_metadata_overridden_by_env_seed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The EXACT v12 bug scenario: model exists on disk as
+    ambiguous_metadata + env names it as trusted → promote + flip
+    origin to trusted_seed."""
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger, QUARANTINE_AMBIGUOUS_METADATA,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "ledger.json"
+        _write_disk_record(p, "Qwen/Qwen3.5-397B-A17B-FP8",
+                           QUARANTINE_AMBIGUOUS_METADATA)
+        monkeypatch.setenv(
+            "JARVIS_DW_TRUSTED_MODELS", "Qwen/Qwen3.5-397B-A17B-FP8",
+        )
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH", str(p),
+        )
+        ledger = PromotionLedger(path=p, autosave=False)
+        ledger.load()
+        assert ledger.is_promoted("Qwen/Qwen3.5-397B-A17B-FP8") is True, (
+            "Slice 10B-iii failed to override ambiguous_metadata quarantine"
+        )
+
+
+def test_spine_operator_demoted_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator demotion MUST win over env seed. The operator's
+    explicit decision is the authoritative record."""
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger, QUARANTINE_OPERATOR_DEMOTED,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "ledger.json"
+        _write_disk_record(p, "banned-model", QUARANTINE_OPERATOR_DEMOTED)
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "banned-model")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH", str(p),
+        )
+        ledger = PromotionLedger(path=p, autosave=False)
+        ledger.load()
+        assert ledger.is_promoted("banned-model") is False, (
+            "Slice 10B-iii incorrectly overrode operator_demoted decision — "
+            "operator's persistent choice was silently discarded"
+        )
+
+
+def test_spine_demoted_from_bg_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Post-promotion failure (demoted_from_bg) MUST win over env seed.
+    It's empirically-evidenced demotion, not auto-classification."""
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger, QUARANTINE_DEMOTED_FROM_BG,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "ledger.json"
+        _write_disk_record(p, "flaky-model", QUARANTINE_DEMOTED_FROM_BG)
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "flaky-model")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH", str(p),
+        )
+        ledger = PromotionLedger(path=p, autosave=False)
+        ledger.load()
+        assert ledger.is_promoted("flaky-model") is False, (
+            "Slice 10B-iii overrode demoted_from_bg — empirical "
+            "post-promotion failure record was silently discarded"
+        )
+
+
+def test_spine_existing_trusted_seed_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a model already exists with origin=trusted_seed + promoted=True,
+    re-running the seed is idempotent (no error, no state change)."""
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger, QUARANTINE_TRUSTED_SEED,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "ledger.json"
+        _write_disk_record(p, "already-trusted", QUARANTINE_TRUSTED_SEED,
+                           promoted=True)
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "already-trusted")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH", str(p),
+        )
+        ledger = PromotionLedger(path=p, autosave=False)
+        ledger.load()
+        assert ledger.is_promoted("already-trusted") is True
+        # Idempotent — no exception, no state change
+
+
+def test_spine_v12_full_fleet_scenario_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The EXACT v12 scenario reproduced end-to-end:
+      - 3 models on disk as ambiguous_metadata (Qwen 397B, 35B, Kimi)
+      - Env names all 4 fleet models PLUS 1 operator-demoted model
+    Post-10B-iii expected: all 4 fleet models promoted; banned skipped."""
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger, LEDGER_SCHEMA_VERSION,
+        QUARANTINE_AMBIGUOUS_METADATA, QUARANTINE_OPERATOR_DEMOTED,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "ledger.json"
+        # Simulate the actual v12 disk state
+        p.write_text(json.dumps({
+            "schema_version": LEDGER_SCHEMA_VERSION,
+            "records": [
+                {"model_id": "Qwen/Qwen3.5-397B-A17B-FP8",
+                 "quarantine_origin": QUARANTINE_AMBIGUOUS_METADATA,
+                 "success_latencies_ms": [], "failure_count": 0,
+                 "promoted": False, "promoted_at_unix": None,
+                 "last_event_unix": 0.0},
+                {"model_id": "Qwen/Qwen3.5-35B-A3B-FP8",
+                 "quarantine_origin": QUARANTINE_AMBIGUOUS_METADATA,
+                 "success_latencies_ms": [], "failure_count": 0,
+                 "promoted": False, "promoted_at_unix": None,
+                 "last_event_unix": 0.0},
+                {"model_id": "moonshotai/Kimi-K2.6",
+                 "quarantine_origin": QUARANTINE_AMBIGUOUS_METADATA,
+                 "success_latencies_ms": [], "failure_count": 0,
+                 "promoted": False, "promoted_at_unix": None,
+                 "last_event_unix": 0.0},
+                {"model_id": "operator-banned",
+                 "quarantine_origin": QUARANTINE_OPERATOR_DEMOTED,
+                 "success_latencies_ms": [], "failure_count": 0,
+                 "promoted": False, "promoted_at_unix": None,
+                 "last_event_unix": 0.0},
+            ],
+        }))
+        # Env: all 4 fleet PLUS the banned one (test that banned still loses)
+        monkeypatch.setenv(
+            "JARVIS_DW_TRUSTED_MODELS",
+            "Qwen/Qwen3.5-397B-A17B-FP8,"
+            "Qwen/Qwen3.5-35B-A3B-FP8,"
+            "Qwen/Qwen3.5-4B,"
+            "moonshotai/Kimi-K2.6,"
+            "operator-banned"
+        )
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH", str(p),
+        )
+        ledger = PromotionLedger(path=p, autosave=False)
+        ledger.load()
+        promoted = set(ledger.promoted_models())
+        # All 4 fleet models should be promoted
+        for fleet_model in (
+            "Qwen/Qwen3.5-397B-A17B-FP8",
+            "Qwen/Qwen3.5-35B-A3B-FP8",
+            "Qwen/Qwen3.5-4B",
+            "moonshotai/Kimi-K2.6",
+        ):
+            assert fleet_model in promoted, (
+                f"v12 scenario: {fleet_model} NOT promoted — fleet "
+                f"expansion broken; promoted set = {promoted}"
+            )
+        # Operator decision preserved
+        assert "operator-banned" not in promoted, (
+            "Operator demotion was overridden — discipline broken"
+        )
+
+
+def test_spine_override_clears_stale_latency_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When overriding an ambiguous_metadata quarantine, the prior
+    auto-quarantine never ran the model so historical latencies are
+    inapplicable. The override path must clear them."""
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger, LEDGER_SCHEMA_VERSION,
+        QUARANTINE_AMBIGUOUS_METADATA,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "ledger.json"
+        # Plant a quarantined record with stale latencies
+        p.write_text(json.dumps({
+            "schema_version": LEDGER_SCHEMA_VERSION,
+            "records": [{
+                "model_id": "test-model",
+                "quarantine_origin": QUARANTINE_AMBIGUOUS_METADATA,
+                "success_latencies_ms": [500, 600, 700],  # stale
+                "failure_count": 99,  # stale
+                "promoted": False,
+                "promoted_at_unix": None,
+                "last_event_unix": 0.0,
+            }],
+        }))
+        monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "test-model")
+        monkeypatch.setenv(
+            "JARVIS_DW_PROMOTION_LEDGER_PATH", str(p),
+        )
+        ledger = PromotionLedger(path=p, autosave=False)
+        ledger.load()
+        # Inspect the in-memory record post-override
+        rec = ledger._records["test-model"]
+        assert rec.promoted is True
+        assert rec.quarantine_origin == "trusted_seed"
+        assert rec.success_latencies_ms == [], (
+            "Stale latency history NOT cleared on override — "
+            "promotion gate may behave incorrectly with phantom data"
+        )
+        assert rec.failure_count == 0, (
+            "Stale failure_count NOT cleared on override"
+        )


### PR DESCRIPTION
fix(governance): Slice 10B-iii — trusted-seed overrides ambiguous_metadata quarantine (state hierarchy fix)

Closes the v12 FLEET soak bug surfaced by bt-2026-05-26-062945:
PromotionLedger seeded only 1 of 4 env-attested trusted models because
the other 3 already existed on disk as `ambiguous_metadata` quarantine
records from prior discovery runs.

## The bug — state-hierarchy conflation in Slice 10B

Original Slice 10B (PR #58165) `_seed_trusted_models_from_env` had a
single "disk wins on conflict" rule, conflating TWO distinct kinds of
disk state:

  1. **Operator decisions** — origin=operator_demoted or demoted_from_bg.
     The operator (or operator-driven post-promotion failure) explicitly
     demoted the model. Env trusted seed MUST NOT override (would
     silently revert an operator action).

  2. **Automatic classifier quarantine** — origin=ambiguous_metadata.
     This is an AUTO safety pin assigned by `dw_catalog_classifier`
     when a discovered ModelCard has both parameter_count_b AND
     pricing_out_per_m_usd as None. It is NOT an operator decision —
     it is the ABSENCE of one. The operator's explicit attestation via
     JARVIS_DW_TRUSTED_MODELS supplies the warrant the auto-classifier
     lacks. The env seed SHOULD override this.

## Empirical proof from bt-2026-05-26-062945

  v12 disk had 18 models from prior discovery, all quarantined with
  origin=ambiguous_metadata. Operator set:

    JARVIS_DW_TRUSTED_MODELS="Qwen/Qwen3.5-397B-A17B-FP8,
                              Qwen/Qwen3.5-35B-A3B-FP8,
                              Qwen/Qwen3.5-4B,
                              moonshotai/Kimi-K2.6"

  Pre-Slice-10B-iii result:

    [PromotionLedger] Slice 10B: seeded 1 trusted model(s)
                                        ^^^^

  Only the 4B (not yet on disk) seeded. The 397B + 35B + Kimi (already
  on disk as ambiguous_metadata) silently skipped → fleet expansion
  inert → only the 4B + the legacy `doubleword-397b` alias from a
  prior soak actually promoted.

## Fix mechanism — state hierarchy override

New `_OVERRIDABLE_ORIGINS` frozenset contains ONLY
`QUARANTINE_AMBIGUOUS_METADATA`. Override path in
`_seed_trusted_models_from_env`:

  No disk record         → seed (create promoted=True record)
  origin=ambiguous_metadata → OVERRIDE: promote + flip to trusted_seed
  origin=trusted_seed    → idempotent (already promoted)
  origin=operator_demoted → SKIP (operator decision wins)
  origin=demoted_from_bg → SKIP (post-promotion failure wins)
  Other origins → SKIP (defensive: unknown disk state wins)

The override CLEARS stale latency history (the prior auto-quarantine
never actually ran the model; historical latencies don't apply to the
new trusted-seed promotion path).

## Operator bindings honored — "no shortcuts, leverage existing files"

* **Composes existing PromotionLedger schema** — no new fields, no
  schema_version bump. Reuses QUARANTINE_TRUSTED_SEED origin from
  Slice 10B. PromotionRecord.from_json_dict round-trips identically
  for the new override-path records.
* **Operator-decision discipline preserved verbatim** — Slice 10B's
  backward-compat test `test_spine_disk_record_wins_over_env_seed`
  (operator_demoted scenario) STILL PASSES under Slice 10B-iii.
  Only the auto-classifier quarantine path changes behavior.
* **Defensive on unknown origins** — if PromotionLedger evolves to
  add new origin classes (e.g., a future ML-driven quarantine), they
  default to "skip the env override" — fail-safe posture.
* **AST-pinned state hierarchy** — 2 pins:
  (1) _OVERRIDABLE_ORIGINS contains AMBIGUOUS_METADATA AND does NOT
      contain OPERATOR_DEMOTED or DEMOTED_FROM_BG (operator-decision
      discipline regression guard via AST walk + ast.unparse)
  (2) _seed_trusted_models_from_env body references _OVERRIDABLE_ORIGINS
      AND mutates existing.promoted = True (override path active)
* **Structured telemetry** — new log line distinguishes the 3 outcomes:
    [PromotionLedger] Slice 10B-iii: trusted-seed outcome —
      seeded_new=1 promoted_override=3 skipped_operator_decision=0
  so operators can audit per-model what happened.

## Test surface (2 AST pins + 6 spine, 8/8 green; +7 Slice 10B backward-compat tests still green)

AST pins (2):
  1. _OVERRIDABLE_ORIGINS membership verified via AST walk
     (AMBIGUOUS_METADATA in; OPERATOR_DEMOTED + DEMOTED_FROM_BG out)
  2. _seed_trusted_models_from_env contains both _OVERRIDABLE_ORIGINS
     reference AND `existing.promoted = True` mutation

Spine (6):
  - ambiguous_metadata → OVERRIDDEN by env seed (the exact v12 bug)
  - operator_demoted → PRESERVED (operator decision wins)
  - demoted_from_bg → PRESERVED (post-promotion failure wins)
  - existing trusted_seed → idempotent (no error, no state change)
  - End-to-end v12 scenario: 3 ambiguous + 1 operator_demoted + env
    names all 4 fleet models + the banned one → 4 fleet promoted,
    banned skipped (full v12 reproduction in isolation)
  - Override path clears stale latency history + failure_count (the
    auto-quarantine record's data doesn't apply to the new promotion)

## Distance to RESOLVED — what this actually unlocks

v12 (pre-10B-iii): seeded 1 of 4 trusted models → only Qwen3.5-4B
  promoted via env + legacy doubleword-397b from prior soak. 35B +
  Kimi stayed quarantined → 10B-ii topology bridge couldn't promote
  them either → fleet expansion inert despite operator's correct env.

v13 (post-10B-iii): all 4 trusted models promoted at boot (overriding
  the disk ambiguous_metadata records). Slice 10B-ii topology bridge
  admits all 4 to STANDARD/COMPLEX/BG/SPEC per their gate eligibility.
  candidate_generator selects the appropriate fleet model per op shape.
  DW serves majority of generation. RESOLVED verdict path open.

## Operator follow-up after merge

Stale state on disk from the v12 era must be cleared before v13
detonation:

  rm .jarvis/dw_promotion_ledger.json

(The fix prevents NEW soaks from getting stuck this way, but the
existing dirty disk file still has 16 ambiguous_metadata records that
would silently skip when env doesn't name them — clean slate is the
correct posture before the v13 capability validation soak.)

1 file changed (dw_promotion_ledger.py), ~110 insertions(+), ~25 deletions(-)
+ 1 file added (test_slice10b_iii_ledger_override.py), ~320 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PromotionLedger seeding so env-trusted models override `ambiguous_metadata` quarantine but never operator demotions. This promotes all env-attested models at boot and adds clear audit logs.

- **Bug Fixes**
  - State hierarchy: no record → seed; `ambiguous_metadata` → promote and set origin `trusted_seed`; already `trusted_seed` → no-op; `operator_demoted`/`demoted_from_bg`/unknown → skip.
  - On override, clear `success_latencies_ms` and `failure_count`, and update timestamps.
  - Introduces `_OVERRIDABLE_ORIGINS` and updates `_seed_trusted_models_from_env`; adds structured log with `seeded_new`, `promoted_override`, and `skipped_operator_decision`.
  - No schema changes; adds AST guards and functional tests for the override behavior.

- **Migration**
  - If upgrading from v12 soak state, delete stale ledger: `rm .jarvis/dw_promotion_ledger.json`.

<sup>Written for commit 168e47318e1c27882f2669fff6725bc0f8380bd1. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/58826?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

