### PR TITLE
fix(governance): Slice 18c — route-aware Tier 0 RT budget cap (eliminates premature-timeout cascade)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -146,6 +146,53 @@ _FALLBACK_MIN_RESERVE_S = float(os.environ.get("OUROBOROS_FALLBACK_MIN_RESERVE_S
 _TIER3_REFLEX_HARD_CAP_S = float(
     os.environ.get("OUROBOROS_TIER3_REFLEX_HARD_CAP_S", "30")
 )
+
+# ──────────────────────────────────────────────────────────────────────
+# Slice 18c (2026-05-26) — route-aware Tier 0 RT budget cap
+#
+# Closes the cascade-to-Claude-on-premature-timeout pattern surfaced by
+# soak bt-2026-05-26-070049 (FLEET v13): Slice 10A correctly routed
+# SWE-Bench-Pro to STANDARD; Slice 10B-iii promoted Qwen 397B; Slice
+# 10B-ii bridge unblocked the topology; candidate_generator dispatched
+# DW Tier 0 RT — but the 30s default cap (above) clamped the budget
+# below the 397B's actual TTFT envelope. Result: 8 EXHAUSTION events,
+# each cascading to Claude which then refused on credit-balance.
+#
+# The 30s default was designed for IMMEDIATE-equivalent "reflex"
+# semantics (per Manifesto §5 — speed permanently supersedes cost).
+# Applying it to STANDARD + COMPLEX routes — which are explicitly
+# cost-optimized (DW primary) and have no reflex-time SLA — is a
+# category error.
+#
+# Fix: route-aware cap selector. STANDARD + COMPLEX use the new
+# JARVIS_DW_TIER0_RT_BUDGET_S (default 90s — matches Qwen 397B + Kimi
+# K2.6 TTFT envelope per §46.2). BG/SPEC + everything else keeps the
+# 30s reflex cap (those are either cost-floored or DW-only routes
+# where 30s is the right ceiling).
+#
+# Operator override per route via the env knob; future Slice 13B
+# bandit (§45.7.2) can replace this static cap with per-shape
+# empirical p95 envelope. Until then, 90s is the empirical floor
+# observed on 397B cold-start cold-cache runs.
+# ──────────────────────────────────────────────────────────────────────
+_TIER0_RT_BUDGET_STANDARD_COMPLEX_S = float(
+    os.environ.get("JARVIS_DW_TIER0_RT_BUDGET_S", "90"),
+)
+
+
+def _tier0_rt_cap_for_route(provider_route: str) -> float:
+    """Slice 18c — return the absolute Tier 0 RT cap for *route*.
+
+    STANDARD + COMPLEX: 90s default (matches 397B/Kimi TTFT envelope).
+    Everything else: 30s reflex cap (preserved for IMMEDIATE/BG/SPEC
+    cost-optimization semantics + pre-Slice-18c byte-equivalence).
+    """
+    r = (provider_route or "").strip().lower()
+    if r in ("standard", "complex"):
+        return _TIER0_RT_BUDGET_STANDARD_COMPLEX_S
+    return _TIER3_REFLEX_HARD_CAP_S
+
+
 # Legacy alias retained for downstream imports + existing test surface.
 # Do not change to a different default without updating the test pins.
 # Reads OUROBOROS_PRIMARY_MAX_TIMEOUT_S as a per-primary override — when
@@ -4809,16 +4856,24 @@ class CandidateGenerator:
         tier1_reserve = min(min_reserve, total_s * (1.0 - effective_fraction))
         # Tier 3 Reflex (Manifesto §5): absolute hard cap on DW calls.
         # Strictest of four constraints wins (fraction, route max_wait,
-        # tier1 reserve, Tier 3 cap). Added 2026-04-24 after F1 Slice 4 S4
+        # tier1 reserve, Tier 0 RT cap). Added 2026-04-24 after F1 Slice 4 S4
         # (bt-2026-04-24-213248) proved the previous patch (inside
         # _call_primary) was inert for the DW-is-Tier0-AND-Primary
         # configuration — this code path is where DW actually gets its
         # 90s max_wait in that configuration.
+        #
+        # Slice 18c (2026-05-26) — the 4th constraint is now route-aware.
+        # STANDARD + COMPLEX get the new JARVIS_DW_TIER0_RT_BUDGET_S
+        # (default 90s — matches 397B/Kimi TTFT envelope) instead of the
+        # 30s reflex cap. Eliminates the FLEET-v13-soak premature-timeout
+        # cascade pattern (8 EXHAUSTION events, each on a DW dispatch
+        # that needed >30s to complete). IMMEDIATE/BG/SPEC preserved at
+        # 30s for cost-optimization semantics.
         budget = min(
             total_s * effective_fraction,
             max_wait,
             total_s - tier1_reserve,
-            _TIER3_REFLEX_HARD_CAP_S,
+            _tier0_rt_cap_for_route(provider_route),
         )
         return max(budget, 0.0)
 

--- a/tests/governance/test_slice18c_tier0_rt_budget.py
+++ b/tests/governance/test_slice18c_tier0_rt_budget.py
@@ -1,0 +1,186 @@
+"""Slice 18c — Route-aware Tier 0 RT budget cap (eliminates premature-timeout cascade-to-Claude).
+
+Closes the cascade pattern surfaced by soak bt-2026-05-26-070049 (FLEET v13):
+DW Tier 0 RT dispatched correctly on Qwen 397B via Slice 10B-iii promotion +
+Slice 10B-ii topology bridge, but the 30s default cap clamped budgets BELOW
+the 397B's actual TTFT envelope. Result: 8 EXHAUSTION events, each cascading
+to Claude which then refused on credit-balance.
+
+# Root cause
+
+`_TIER3_REFLEX_HARD_CAP_S = 30s` (designed for IMMEDIATE-equivalent reflex
+semantics per Manifesto §5) was being applied as the absolute Tier 0 RT cap
+on STANDARD + COMPLEX routes. Those routes are explicitly cost-optimized
+(DW primary) with no reflex-time SLA. The 30s cap was a category error.
+
+# Fix mechanism — route-aware cap selector
+
+  _tier0_rt_cap_for_route(route) -> float:
+    if route in ("standard", "complex"):
+      return _TIER0_RT_BUDGET_STANDARD_COMPLEX_S  (default 90s)
+    return _TIER3_REFLEX_HARD_CAP_S                (default 30s)
+
+Operator override via `JARVIS_DW_TIER0_RT_BUDGET_S` env. Future Slice 13B
+bandit (§45.7.2) can replace this static cap with per-shape p95 envelope.
+
+# Operator bindings honored
+
+* IMMEDIATE / BG / SPEC preserved at 30s (byte-equivalent to pre-Slice-18c
+  for cost-optimization semantics).
+* STANDARD + COMPLEX get 90s default — matches the empirical 397B + Kimi
+  TTFT envelope documented in §46.2.
+* No new logic in the budget formula — just the 4th constraint in the
+  min() switches from a global constant to a route-aware function call.
+* AST-pinned: the route-aware function MUST appear in the constraint
+  selector or pre-Slice-18c behavior persists.
+
+# Test surface (2 AST pins + 5 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CG_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "candidate_generator.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_route_aware_cap_function_present() -> None:
+    """``_tier0_rt_cap_for_route`` MUST be a module-level function that
+    routes STANDARD+COMPLEX to a different (larger) cap than the
+    legacy reflex 30s. Without it, all routes inherit the 30s cap and
+    the cascade pattern from FLEET v13 reproduces."""
+    src = CG_FILE.read_text()
+    assert "def _tier0_rt_cap_for_route(" in src, (
+        "Slice 18c selector function missing — cap routing dead"
+    )
+    assert "_TIER0_RT_BUDGET_STANDARD_COMPLEX_S" in src, (
+        "Missing _TIER0_RT_BUDGET_STANDARD_COMPLEX_S constant"
+    )
+    assert "JARVIS_DW_TIER0_RT_BUDGET_S" in src, (
+        "Missing JARVIS_DW_TIER0_RT_BUDGET_S env knob"
+    )
+    # Slice 18c attribution + bt soak link
+    assert "Slice 18c" in src
+    assert "bt-2026-05-26-070049" in src, (
+        "Missing soak attribution — future readers can't trace which "
+        "FLEET v13 forensic surfaced this cascade pattern"
+    )
+
+
+def test_ast_pin_compute_tier0_budget_uses_route_aware_cap() -> None:
+    """``_compute_tier0_budget`` MUST call ``_tier0_rt_cap_for_route``
+    in its min() constraint switch. Without this call site swap, the
+    function body still uses ``_TIER3_REFLEX_HARD_CAP_S`` directly
+    and the cap routing is dead code."""
+    src = CG_FILE.read_text()
+    tree = ast.parse(src, filename=str(CG_FILE))
+    found_use = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "_compute_tier0_budget"
+        ):
+            body_src = ast.unparse(node)
+            if "_tier0_rt_cap_for_route" in body_src:
+                found_use = True
+                break
+    assert found_use, (
+        "_compute_tier0_budget does NOT call _tier0_rt_cap_for_route — "
+        "Slice 18c switch is inert; pre-Slice-18c 30s cap still applies"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 5
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_standard_and_complex_get_90s_default() -> None:
+    """STANDARD + COMPLEX routes admit the new 90s default cap.
+    This is the empirical floor for Qwen 397B + Kimi K2.6 TTFT
+    envelope per §46.2."""
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _tier0_rt_cap_for_route,
+    )
+    assert _tier0_rt_cap_for_route("standard") == 90.0
+    assert _tier0_rt_cap_for_route("complex") == 90.0
+
+
+def test_spine_bg_spec_immediate_keep_30s_reflex_cap() -> None:
+    """IMMEDIATE / BACKGROUND / SPECULATIVE preserve the 30s reflex
+    cap (byte-equivalent to pre-Slice-18c). Cost-optimization +
+    fast-reflex semantics intact."""
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _tier0_rt_cap_for_route,
+    )
+    assert _tier0_rt_cap_for_route("immediate") == 30.0
+    assert _tier0_rt_cap_for_route("background") == 30.0
+    assert _tier0_rt_cap_for_route("speculative") == 30.0
+
+
+def test_spine_unknown_route_falls_through_to_reflex_cap() -> None:
+    """Unknown / empty / None routes fall through to the 30s reflex
+    cap (defensive — never grant the larger budget to an unmapped
+    route)."""
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _tier0_rt_cap_for_route,
+    )
+    assert _tier0_rt_cap_for_route("") == 30.0
+    assert _tier0_rt_cap_for_route("totally_made_up") == 30.0
+
+
+def test_spine_compute_tier0_budget_honors_90s_on_standard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The budget formula must return a Tier 0 budget ≥ 60s for STANDARD
+    when the parent budget is generous, proving the 90s cap is the
+    effective constraint (NOT the legacy 30s cap)."""
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+    # Static method — invoke with a 200s parent budget; complexity=complex
+    # to use the multiplier-friendly path. We expect budget to land
+    # between 60-90s (constrained by 90s cap, not 30s reflex).
+    budget = CandidateGenerator._compute_tier0_budget(
+        total_s=200.0,
+        complexity="complex",
+        provider_route="standard",
+    )
+    assert budget > 30.0, (
+        f"STANDARD route still capped at 30s reflex cap; got {budget}s "
+        f"— Slice 18c not taking effect"
+    )
+    assert budget <= 90.0, (
+        f"STANDARD route budget exceeded the new 90s cap; got {budget}s "
+        f"— constraint formula bug"
+    )
+
+
+def test_spine_compute_tier0_budget_unchanged_on_immediate() -> None:
+    """IMMEDIATE route returns 0 (DW skipped per Manifesto §5).
+    Spine guard — Slice 18c must not accidentally enable DW on
+    IMMEDIATE."""
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+    budget = CandidateGenerator._compute_tier0_budget(
+        total_s=200.0,
+        complexity="complex",
+        provider_route="immediate",
+    )
+    assert budget == 0.0, (
+        f"IMMEDIATE route returned non-zero Tier 0 budget {budget} — "
+        f"Slice 18c violated Manifesto §5 (Claude-direct for IMMEDIATE)"
+    )


### PR DESCRIPTION
fix(governance): Slice 18c — route-aware Tier 0 RT budget cap (eliminates premature-timeout cascade)

Closes the cascade-to-Claude-on-premature-timeout pattern surfaced by
soak bt-2026-05-26-070049 (FLEET v13). After Slice 10A/10B/10B-ii/10B-iii
unlocked DW dispatch architecturally + the operator's expanded
JARVIS_DW_TRUSTED_MODELS env activated the 4-model fleet, DW Tier 0 RT
DID fire on Qwen 397B — but the dispatch was capped at 30s and got
clamped below the 397B's actual TTFT envelope.

## Empirical chain from bt-2026-05-26-070049

  00:02:10  [PromotionLedger] Slice 10B-iii seeded_new=4 ✓
  00:05:42  🛤️  Route: standard (swe_bench_pro_envelope) ✓
  00:05:44  Tier 0 RT: budget=30.0s of 360.0s ... 
            model=Qwen/Qwen3.5-397B-A17B-FP8 ← clamped at 30s!
  00:06:46  EXHAUSTION event_n=2 cause=circuit_breaker_tripped:terminal_config
            fallback_failure_mode=TIMEOUT
            (DW timed out → cascade to Claude → credit refused)
  (×8 EXHAUSTION events over 52 min)

DW DID record cost (cost_breakdown.doubleword=$0.012636 — first non-zero
DW spend in the entire arc) but every COMPLEX/STANDARD op cascaded to
Claude after the 30s timeout.

## Root cause

`_TIER3_REFLEX_HARD_CAP_S` (default 30s, env OUROBOROS_TIER3_REFLEX_HARD_CAP_S)
was designed for IMMEDIATE-equivalent reflex semantics per Manifesto §5
("speed permanently supersedes cost"). It was applied as the absolute
4th constraint in `_compute_tier0_budget`'s min() switch for ALL routes
including STANDARD + COMPLEX.

STANDARD + COMPLEX routes are explicitly cost-optimized (DW primary)
with no reflex-time SLA. The 30s cap was a category error — clamping
DW's legitimate per-op budget below what a 397B-parameter model needs
to first-token + generate a meaningful response.

## Fix mechanism — route-aware cap selector

  _TIER0_RT_BUDGET_STANDARD_COMPLEX_S = float(
      os.environ.get("JARVIS_DW_TIER0_RT_BUDGET_S", "90"),
  )

  def _tier0_rt_cap_for_route(provider_route: str) -> float:
      r = (provider_route or "").strip().lower()
      if r in ("standard", "complex"):
          return _TIER0_RT_BUDGET_STANDARD_COMPLEX_S  # 90s default
      return _TIER3_REFLEX_HARD_CAP_S                 # 30s default

Single call-site change in `_compute_tier0_budget`'s 4-constraint min():

  - _TIER3_REFLEX_HARD_CAP_S,
  + _tier0_rt_cap_for_route(provider_route),

Behavioral effect:
  - STANDARD: cap raises from 30s → 90s (DW has headroom)
  - COMPLEX:  cap raises from 30s → 90s (DW has headroom)
  - IMMEDIATE: stays 30s (reflex cap preserved per §5)
  - BACKGROUND: stays 30s (cost-floor cap preserved)
  - SPECULATIVE: stays 30s (cost-floor cap preserved)
  - Unknown routes: stays 30s (fail-safe; never grant larger budget to
    unmapped route)

The new 90s default is the empirical TTFT envelope observed on Qwen 397B
+ Kimi K2.6 cold-cache cold-start runs per §46.2 (DW Fleet Inventory).

## Operator bindings honored

* **No new logic in the formula** — just the 4th constraint in the
  existing min() switches from a global constant to a route-aware
  function call. All other constraint paths (fraction, route max_wait,
  tier1 reserve) preserved verbatim.
* **Pre-Slice-18c byte-equivalence on non-targeted routes** —
  IMMEDIATE/BG/SPEC/unknown all return the legacy `_TIER3_REFLEX_HARD_CAP_S`.
  Only STANDARD + COMPLEX behavior changes.
* **No new logic in the call sites** — `_compute_tier0_budget_dynamic`
  (the tracker-aware variant) automatically inherits the new ceiling
  because it calls `_compute_tier0_budget` first as its static base.
* **Operator-tunable** — JARVIS_DW_TIER0_RT_BUDGET_S env knob allows
  raising/lowering the STANDARD/COMPLEX cap without touching code.
  Future Slice 13B bandit (per §45.7.2) replaces this static cap with
  per-shape empirical p95 envelope.
* **AST-pinned** — 2 pins:
  (1) `_tier0_rt_cap_for_route` function + `_TIER0_RT_BUDGET_STANDARD_COMPLEX_S`
      constant + `JARVIS_DW_TIER0_RT_BUDGET_S` env knob + Slice 18c
      attribution + bt-2026-05-26-070049 soak link all present
  (2) `_compute_tier0_budget` AST body references `_tier0_rt_cap_for_route`
      (call-site swap regression guard against accidental revert to
      raw `_TIER3_REFLEX_HARD_CAP_S` constant)

## Test surface (2 AST pins + 5 spine, 7/7 green)

AST pins (2): selector function presence + call-site integration

Spine (5):
  - STANDARD route admits 90s default
  - COMPLEX route admits 90s default
  - IMMEDIATE / BG / SPECULATIVE preserved at 30s reflex cap
  - Unknown / empty / made-up route falls through to 30s (defensive)
  - End-to-end: _compute_tier0_budget("standard", complex, 200s parent
    budget) returns >30s and ≤90s (proves new cap is effective constraint)
  - IMMEDIATE still returns 0 (Manifesto §5 spine guard)

## Distance to RESOLVED — what this actually unlocks

v13 (pre-18c) cascade pattern:
  Slice 10A routes STANDARD → Slice 10B-ii admits DW → Slice 10B-iii
  promotes fleet → Tier 0 RT dispatches Qwen 397B at 30s cap →
  TTFT exceeds 30s → cascade to Claude → credit refused → EXHAUSTION

v14 (post-18c) expected cascade:
  Same chain → Tier 0 RT dispatches Qwen 397B at 90s cap →
  TTFT in envelope → DW returns candidate → APPLY → VERIFY → RESOLVED

The operator handles Anthropic billing separately; this PR addresses
the architectural 30s cap that caused the cascade in the first place.
Even with Claude credit refilled, Slice 18c is the correct fix —
DW should serve STANDARD/COMPLEX natively, not flake to Claude on
premature timeouts.

1 file changed (candidate_generator.py), ~55 insertions(+), ~6 deletions(-)
+ 1 file added (test_slice18c_tier0_rt_budget.py), ~180 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Tier 0 runtime budget cap route-aware to prevent premature DW timeouts and cascade-to-Claude on STANDARD/COMPLEX routes. STANDARD and COMPLEX now default to a 90s cap; IMMEDIATE/BACKGROUND/SPECULATIVE remain at 30s.

- **Bug Fixes**
  - Swapped the hard 30s cap for `_tier0_rt_cap_for_route(provider_route)` in `_compute_tier0_budget`.
  - Added `JARVIS_DW_TIER0_RT_BUDGET_S` to tune the STANDARD/COMPLEX cap (default 90s); `_TIER3_REFLEX_HARD_CAP_S` still caps other routes at 30s.
  - Behavior: STANDARD/COMPLEX gain headroom; IMMEDIATE/BACKGROUND/SPEC/unknown stay at 30s.
  - Tests: new coverage pins the selector function and call-site, and verifies budgets for each route end-to-end.

<sup>Written for commit 264aba9d50070d8d42ab1ca9030ccb997929d31d. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/59069?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

