### PR TITLE
fix(governance): Slice 19a — Pure provider isolation gate (JARVIS_PROVIDER_CLAUDE_DISABLED for DW-only soaks)

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -111,7 +111,11 @@ logger = logging.getLogger("Ouroboros.GovernedLoop")
 # The predicate is read at call-time (not cached) so the test
 # monkeypatch path works and so an operator can enable Aegis after
 # the module has been imported.
-def _provider_construction_gate(*, local_api_key: Optional[str]) -> bool:
+def _provider_construction_gate(
+    *,
+    local_api_key: Optional[str],
+    provider_name: str = "",
+) -> bool:
     """Decide whether a provider (Claude / DoubleWord) should be
     constructed at GovernedLoopService boot.
 
@@ -123,7 +127,46 @@ def _provider_construction_gate(*, local_api_key: Optional[str]) -> bool:
     Pure, side-effect-free, no I/O. Extracted as a callable so the
     AST pin can enforce its composition shape and so unit tests can
     monkeypatch ``aegis.client.is_enabled`` cleanly.
+
+    # Slice 19a (2026-05-26) — pure provider isolation gate
+
+    Operator binding: "i want to run the soak with only using DW's API's
+    because i want to understand how external API works". To run a
+    DW-only soak (no Claude fallback for empirical isolation), the
+    operator sets ``JARVIS_PROVIDER_CLAUDE_DISABLED=true``. When set
+    AND this call is gating ClaudeProvider construction (signalled by
+    ``provider_name="claude"``), the gate short-circuits to False even
+    if the API key is present and Aegis is enabled. The provider is
+    NEVER constructed; ``self._fallback`` stays None; the
+    candidate_generator's cascade naturally degrades to
+    "all_providers_exhausted" on DW failures instead of cascading to a
+    non-existent fallback.
+
+    IMMEDIATE-routed ops (per Manifesto §5) fail VISIBLY in this mode
+    because §5 specifies Claude-direct for human-reflex routing and
+    there is no Claude. Per operator binding: "if an unrelated process
+    tries to call an IMMEDIATE reflex action while Claude is intentionally
+    pulled, it must fail visibly to maintain absolute system observability."
+
+    SWE-Bench-Pro ops are unaffected because Slice 10A (PR #58161)
+    downgrades them to STANDARD route which uses DW primary.
+
+    The disable knob is ONLY honored when ``provider_name="claude"``;
+    other providers (DoubleWord) ignore it. DW disable would need its
+    own Slice (operator-bound; not authorized here).
+
+    Defensive fail-closed: the env value is parsed as a strict
+    truthy-string set (``true``/``1``/``yes``/``on`` case-insensitive);
+    any other value (including empty, missing, mis-typed) preserves
+    pre-Slice-19a behavior.
     """
+    # Slice 19a — Claude-specific isolation gate
+    if provider_name == "claude":
+        _disable_raw = os.environ.get(
+            "JARVIS_PROVIDER_CLAUDE_DISABLED", "",
+        ).strip().lower()
+        if _disable_raw in ("true", "1", "yes", "on"):
+            return False
     from backend.core.ouroboros.aegis.client import is_enabled as _aegis_is_enabled
     return bool(local_api_key) or _aegis_is_enabled()
 
@@ -3300,7 +3343,35 @@ class GovernedLoopService:
         # the Aegis bridge (Slice 2B-ii). The api_key is coerced
         # None → "" so the provider's self._api_key is always a string
         # (downstream code in the bridge handles the empty case).
-        if _provider_construction_gate(local_api_key=self._config.claude_api_key):
+        #
+        # Slice 19a (2026-05-26) — provider_name="claude" lets the gate
+        # honor JARVIS_PROVIDER_CLAUDE_DISABLED for pure DW-only soaks.
+        # When that env is true, ClaudeProvider is NEVER constructed
+        # (self._fallback stays None); IMMEDIATE ops fail visibly per
+        # Manifesto §5 transparency; DW carries all non-IMMEDIATE routes.
+        if not _provider_construction_gate(
+            local_api_key=self._config.claude_api_key,
+            provider_name="claude",
+        ):
+            # Slice 19a — diagnose the skip cause so operators can
+            # distinguish "no API key + no Aegis" (existing case) from
+            # "explicitly disabled via JARVIS_PROVIDER_CLAUDE_DISABLED"
+            # (new Slice 19a case).
+            _claude_disable_env = os.environ.get(
+                "JARVIS_PROVIDER_CLAUDE_DISABLED", "",
+            ).strip().lower()
+            if _claude_disable_env in ("true", "1", "yes", "on"):
+                logger.info(
+                    "[GovernedLoop] Slice 19a: ClaudeProvider construction "
+                    "SKIPPED — JARVIS_PROVIDER_CLAUDE_DISABLED=true. "
+                    "self._fallback stays None; IMMEDIATE-routed ops will "
+                    "fail visibly (Manifesto §5 transparency). SWE-Bench "
+                    "ops unaffected (Slice 10A → STANDARD route → DW)."
+                )
+        if _provider_construction_gate(
+            local_api_key=self._config.claude_api_key,
+            provider_name="claude",
+        ):
             try:
                 from backend.core.ouroboros.governance.providers import (
                     ClaudeProvider,

--- a/tests/governance/test_slice19a_claude_isolation_gate.py
+++ b/tests/governance/test_slice19a_claude_isolation_gate.py
@@ -1,0 +1,259 @@
+"""Slice 19a — Pure provider isolation gate: JARVIS_PROVIDER_CLAUDE_DISABLED.
+
+Operator binding (verbatim 2026-05-26):
+
+  "i want to hold off using Claude's API because we know it'll work and
+   i want to run the soak with only using DW's API's because i want to
+   understand how external API works and etc. does that make sense?
+   because DW is the primary"
+
+# Architectural choice
+
+When ``JARVIS_PROVIDER_CLAUDE_DISABLED=true`` AND
+``_provider_construction_gate`` is called with ``provider_name="claude"``,
+the gate returns False. ClaudeProvider is NEVER constructed.
+``self._fallback`` stays None. ``candidate_generator``'s cascade
+naturally degrades to ``all_providers_exhausted`` on DW failures
+instead of routing to a non-existent fallback.
+
+IMMEDIATE-routed ops (per Manifesto §5: voice_human, IDE test_failure,
+runtime_health) FAIL VISIBLY under DW-only mode because §5 specifies
+Claude-direct routing for human-reflex ops. Per operator binding:
+"if an unrelated process tries to call an IMMEDIATE reflex action
+while Claude is intentionally pulled, it must fail visibly to
+maintain absolute system observability."
+
+SWE-Bench-Pro ops are unaffected because Slice 10A (PR #58161)
+downgrades them to STANDARD route which uses DW primary.
+
+# Slice 19a discipline
+
+* Gate is provider-aware via the new ``provider_name`` kwarg
+* Disable knob ONLY honored for ``provider_name="claude"``
+* DW gating (and any future provider's gating) ignores it
+* Truthy parse uses the canonical frozenset ``{true, 1, yes, on}``
+  (case-insensitive). Any other value falls through to legacy
+  behavior — defensive fail-closed against accidental "no" / "off"
+  being interpreted as disable.
+
+# Test surface (2 AST pins + 6 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GLS_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "governed_loop_service.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_gate_function_carries_provider_name_kwarg() -> None:
+    """``_provider_construction_gate`` MUST carry the ``provider_name``
+    kwarg with default empty string (preserves legacy callers)."""
+    src = GLS_FILE.read_text()
+    tree = ast.parse(src, filename=str(GLS_FILE))
+    found = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "_provider_construction_gate"
+        ):
+            kwonly_names = [a.arg for a in node.args.kwonlyargs]
+            assert "provider_name" in kwonly_names, (
+                "Slice 19a: _provider_construction_gate missing "
+                "provider_name kwarg — Claude-specific disable inert"
+            )
+            # Find the JARVIS_PROVIDER_CLAUDE_DISABLED env read inside
+            body_src = ast.unparse(node)
+            assert "JARVIS_PROVIDER_CLAUDE_DISABLED" in body_src, (
+                "Gate body does NOT consult JARVIS_PROVIDER_CLAUDE_DISABLED "
+                "— Slice 19a disable knob inert"
+            )
+            # ast.unparse normalizes to single quotes; accept either.
+            assert (
+                'provider_name == "claude"' in body_src
+                or "provider_name == 'claude'" in body_src
+            ), (
+                "Gate body lacks Claude-only guard — disable could "
+                "leak to other providers"
+            )
+            found = True
+            break
+    assert found, "_provider_construction_gate not found"
+    # Slice 19a attribution
+    assert "Slice 19a" in src
+    assert "JARVIS_PROVIDER_CLAUDE_DISABLED" in src
+
+
+def test_ast_pin_claude_call_site_passes_provider_name() -> None:
+    """The ClaudeProvider construction call site MUST pass
+    ``provider_name="claude"`` to ``_provider_construction_gate``.
+    Without this, the disable knob never fires (gate doesn't know
+    it's gating Claude)."""
+    src = GLS_FILE.read_text()
+    tree = ast.parse(src, filename=str(GLS_FILE))
+    # Find all calls to _provider_construction_gate
+    found_claude_call = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_provider_construction_gate"
+        ):
+            # Inspect kwargs for provider_name="claude"
+            for kw in node.keywords:
+                if (
+                    kw.arg == "provider_name"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value == "claude"
+                ):
+                    found_claude_call = True
+                    break
+            if found_claude_call:
+                break
+    assert found_claude_call, (
+        "No call to _provider_construction_gate with "
+        "provider_name=\"claude\" — Slice 19a disable knob orphaned"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 6
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def stubbed_aegis(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the aegis client import so gate tests don't depend on
+    heavy daemon boot. The fake module has is_enabled() returning False
+    by default; tests can monkey-patch it per case."""
+    fake_aegis = types.ModuleType("backend.core.ouroboros.aegis.client")
+    fake_aegis.is_enabled = lambda: False
+    fake_aegis_pkg = types.ModuleType("backend.core.ouroboros.aegis")
+    monkeypatch.setitem(sys.modules, "backend.core.ouroboros.aegis", fake_aegis_pkg)
+    monkeypatch.setitem(sys.modules, "backend.core.ouroboros.aegis.client", fake_aegis)
+
+
+def test_spine_claude_with_key_legacy_behavior(
+    stubbed_aegis, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the disable env, Claude with API key gates True
+    (byte-equivalent to pre-Slice-19a)."""
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        _provider_construction_gate,
+    )
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)
+    assert _provider_construction_gate(
+        local_api_key="sk-test", provider_name="claude",
+    ) is True
+
+
+def test_spine_claude_with_disable_env_blocked(
+    stubbed_aegis, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With disable env true, Claude gating returns False even with
+    API key present — Slice 19a's core contract."""
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        _provider_construction_gate,
+    )
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    assert _provider_construction_gate(
+        local_api_key="sk-test", provider_name="claude",
+    ) is False
+
+
+def test_spine_dw_unaffected_by_claude_disable_env(
+    stubbed_aegis, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DW provider's gate call IGNORES the Claude-specific disable
+    env. DW must still construct normally when its API key is set."""
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        _provider_construction_gate,
+    )
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    # provider_name="doubleword" must IGNORE the Claude env
+    assert _provider_construction_gate(
+        local_api_key="dw-key", provider_name="doubleword",
+    ) is True
+    # Even with empty provider_name (legacy callers), Claude env ignored
+    assert _provider_construction_gate(
+        local_api_key="some-key",
+    ) is True
+
+
+def test_spine_truthy_env_variants_all_disable(
+    stubbed_aegis, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All canonical truthy variants disable Claude: true / True / 1 /
+    yes / on / ON. Case-insensitive."""
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        _provider_construction_gate,
+    )
+    for val in ("true", "True", "TRUE", "1", "yes", "Yes", "on", "ON"):
+        monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", val)
+        assert _provider_construction_gate(
+            local_api_key="sk-test", provider_name="claude",
+        ) is False, f"Truthy variant {val!r} failed to disable Claude"
+
+
+def test_spine_falsy_env_variants_preserve_legacy(
+    stubbed_aegis, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Falsy/empty/junk env values preserve legacy behavior (Claude
+    still constructed). Defensive fail-closed posture against
+    accidental 'no'/'off' being interpreted as disable."""
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        _provider_construction_gate,
+    )
+    for val in ("false", "False", "0", "no", "off", "", "junk", "maybe"):
+        monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", val)
+        assert _provider_construction_gate(
+            local_api_key="sk-test", provider_name="claude",
+        ) is True, (
+            f"Falsy/junk variant {val!r} unexpectedly disabled Claude "
+            "(should preserve legacy True)"
+        )
+
+
+def test_spine_disable_env_with_aegis_on_still_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slice 19a disable wins EVEN over Aegis-enabled state. The
+    operator's explicit attestation supersedes the daemon-key-held
+    inference. (This is the v14 detonation contract.)"""
+    # Stub Aegis as enabled (the daemon scenario)
+    fake_aegis = types.ModuleType("backend.core.ouroboros.aegis.client")
+    fake_aegis.is_enabled = lambda: True
+    fake_aegis_pkg = types.ModuleType("backend.core.ouroboros.aegis")
+    monkeypatch.setitem(
+        sys.modules, "backend.core.ouroboros.aegis", fake_aegis_pkg,
+    )
+    monkeypatch.setitem(
+        sys.modules, "backend.core.ouroboros.aegis.client", fake_aegis,
+    )
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        _provider_construction_gate,
+    )
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    # Even with Aegis on (key in daemon) + Claude disable env true:
+    # Slice 19a's explicit operator attestation wins
+    assert _provider_construction_gate(
+        local_api_key="", provider_name="claude",
+    ) is False, (
+        "Slice 19a disable env did NOT override Aegis-on path — "
+        "DW-only soak intent will be violated"
+    )


### PR DESCRIPTION
fix(governance): Slice 19a — Pure provider isolation gate (JARVIS_PROVIDER_CLAUDE_DISABLED for DW-only soaks)

Operator binding (verbatim 2026-05-26):

  "i want to hold off using Claude's API because we know it'll work and
   i want to run the soak with only using DW's API's because i want to
   understand how external API works and etc. does that make sense?
   because DW is the primary"

## Why this is its own slice (not an env-key hack)

The operator's intent is to validate DW's empirical reliability in
isolation, without Claude as a safety net. A naive approach (unset
ANTHROPIC_API_KEY) would fail because Aegis daemon-mode confiscates
the local key intentionally — the existing _provider_construction_gate
returns True when Aegis is enabled regardless of local key presence.
A clean operator-facing knob that respects the architecture is the
right primitive.

## Fix mechanism — provider-aware gate

Extends ``_provider_construction_gate`` with a new ``provider_name``
kwarg (default empty for backward compat). When called with
``provider_name="claude"`` AND ``JARVIS_PROVIDER_CLAUDE_DISABLED=true``,
the gate short-circuits to False BEFORE the key/Aegis check. Result:

  - ClaudeProvider is NEVER constructed
  - self._fallback stays None
  - candidate_generator's cascade naturally degrades to
    all_providers_exhausted on DW failures (no Claude to cascade to)
  - IMMEDIATE-routed ops (Manifesto §5: voice_human, IDE test_failure,
    runtime_health) fail VISIBLY per operator transparency directive

Truthy parse: case-insensitive frozenset {true, 1, yes, on}. All other
values fall through to legacy behavior (defensive fail-closed against
accidental "no" / "off" being interpreted as disable).

## Operator bindings honored — "no shortcuts, no hardcoding"

* **Explicit operator surface** — JARVIS_PROVIDER_CLAUDE_DISABLED is
  the only new env. Composes with existing JARVIS_DW_TRUSTED_MODELS
  (Slice 10B) and JARVIS_DW_TIER0_RT_BUDGET_S (Slice 18c) for a
  cohesive DW-only soak config.
* **Per-provider isolation** — the disable knob ONLY fires for
  provider_name="claude". DW (and future providers) ignore it.
  Slice 19b candidate could add JARVIS_PROVIDER_DW_DISABLED for
  symmetric isolation; not authorized here.
* **Aegis-aware** — disable knob wins EVEN when Aegis is enabled.
  Operator's explicit attestation supersedes the daemon-key-held
  inference. Spine-tested.
* **Backward-compatible** — default empty provider_name preserves
  pre-Slice-19a behavior for any legacy callers. Truthy parse
  defaults to false. Existing soaks unaffected unless operator
  explicitly opts in.
* **Manifesto §5 transparency** — IMMEDIATE-routed ops fail VISIBLY
  in DW-only mode. Per operator: "if an unrelated process tries to
  call an IMMEDIATE reflex action while Claude is intentionally
  pulled, it must fail visibly to maintain absolute system
  observability." NO silent auto-downgrade to STANDARD; the failure
  itself is the diagnostic signal.
* **Slice 10A unaffected** — SWE-Bench-Pro ops continue routing
  STANDARD (per Slice 10A envelope downgrade). Those ops carry the
  capability validation; DW carries them end-to-end.
* **AST-pinned** — 2 pins:
  (1) _provider_construction_gate has provider_name kwarg AND
      body references JARVIS_PROVIDER_CLAUDE_DISABLED AND has
      Claude-only guard (`provider_name == "claude"` substring)
  (2) ClaudeProvider call site passes provider_name="claude"
      (AST-walk for ast.Call with that keyword to prevent
      accidental kwarg-rename regression)

## Test surface (2 AST pins + 6 spine, 8/8 green)

AST pins (2): gate signature + call-site integration

Spine (6):
  - Claude with key + no disable env → True (legacy preserved)
  - Claude with key + disable env true → False (Slice 19a fires)
  - DW with key ignores Claude disable env → True (provider isolation)
  - All canonical truthy variants (true/True/TRUE/1/yes/Yes/on/ON)
    disable Claude
  - All falsy/junk variants (false/0/no/off/empty/junk/maybe)
    preserve legacy True
  - Slice 19a wins EVEN when Aegis is enabled (operator attestation
    > daemon-key inference)

## Operator runbook for v14 DW-only detonation

Update /tmp/claude/aegis_high_capital_soak.sh to add:

  export JARVIS_PROVIDER_CLAUDE_DISABLED=true

Detonate the v14 capability soak. Expected boot log:

  [GovernedLoop] Slice 19a: ClaudeProvider construction SKIPPED —
    JARVIS_PROVIDER_CLAUDE_DISABLED=true. self._fallback stays None;
    IMMEDIATE-routed ops will fail visibly (Manifesto §5 transparency).
    SWE-Bench ops unaffected (Slice 10A → STANDARD route → DW).

Expected empirical signal: DW serves all SWE-Bench-Pro ops; IMMEDIATE
ops (sensors firing on test_failure / runtime_health) fail with
all_providers_exhausted — providing clean isolation telemetry for
operator analysis of DW endpoint reliability.

1 file changed (governed_loop_service.py), ~75 insertions(+), ~5 deletions(-)
+ 1 file added (test_slice19a_claude_isolation_gate.py), ~260 lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider isolation gate to run DW-only soaks by disabling Claude via `JARVIS_PROVIDER_CLAUDE_DISABLED`. Extends `_provider_construction_gate` with a `provider_name` knob and blocks Claude construction even when Aegis is enabled.

- **New Features**
  - `JARVIS_PROVIDER_CLAUDE_DISABLED=true` short-circuits Claude before key/Aegis checks; `self._fallback` stays `None`.
  - Gate is provider-aware via `provider_name="claude"`; DW and others ignore it.
  - IMMEDIATE ops fail visibly when Claude is disabled; STANDARD routes (SWE-Bench) continue on DW.
  - Truthy values accepted: `true`, `1`, `yes`, `on` (case-insensitive); anything else preserves legacy behavior.
  - Clear boot log message when Claude is skipped.

- **Migration**
  - To run a DW-only soak: set `JARVIS_PROVIDER_CLAUDE_DISABLED=true`.
  - No change for existing runs unless this env is set.

<sup>Written for commit f106eabcd6ddc2e5bde7887216f6e045560cdad8. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/59070?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

