### PR TITLE
feat(governance): Slice 20A — eliminate self-fallback when Claude disabled (PURE-DW v15 fix)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1307,7 +1307,7 @@ class CandidateGenerator:
     def __init__(
         self,
         primary: CandidateProvider,
-        fallback: CandidateProvider,
+        fallback: Optional[CandidateProvider] = None,
         primary_concurrency: int = 4,
         fallback_concurrency: int = 2,
         tier0: Optional[Any] = None,  # DoublewordProvider (batch, async)

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -3571,11 +3571,44 @@ class GovernedLoopService:
             logger.info("[GovernedLoop] Promoting DoublewordProvider to PRIMARY (J-Prime unhealthy)")
 
         if primary is not None or fallback is not None:
-            # If only one provider, use it as both (FSM still works)
+            # If only one provider, use it as both (FSM still works).
+            #
+            # Slice 20A (2026-05-26) — self-fallback elimination
+            #
+            # Pre-Slice-20A: `effective_fallback = fallback or primary` blindly
+            # promoted primary (e.g., DW) to fallback when no real Tier 1
+            # provider existed. This violated Slice 19a's "Claude disabled
+            # → no fallback" contract: the FSM ended up with primary=DW
+            # AND fallback=DW (same object), and Slice 19b's `fallback is
+            # None` guard never fired. Empirically observed in
+            # bt-2026-05-26-184355 (v15 soak): cascade fired
+            # `fallback_failed` with `fallback_name=doubleword-397b ==
+            # primary_name` — DW was called twice for the same op and
+            # collided on its own scheduler.
+            #
+            # Fix: when JARVIS_PROVIDER_CLAUDE_DISABLED=true AND no
+            # separate physical secondary provider is supplied, keep
+            # effective_fallback strictly None. Slice 19b's `fallback is
+            # None` guard fires correctly. The FSM gracefully emits
+            # `fallback_skipped:no_fallback_configured`; ExhaustionWatcher
+            # filters it; hibernation is reserved for genuine distress.
+            _claude_disabled = os.environ.get(
+                "JARVIS_PROVIDER_CLAUDE_DISABLED", "",
+            ).strip().lower() in ("true", "1", "yes", "on")
             effective_primary = primary or fallback
-            effective_fallback = fallback or primary
+            if _claude_disabled and fallback is None:
+                effective_fallback = None
+                logger.info(
+                    "[GovernedLoop] Slice 20A: self-fallback ELIMINATED "
+                    "— Claude disabled AND no Tier 1 provider supplied; "
+                    "effective_fallback=None (Slice 19b's fallback_skipped "
+                    "path will engage on cascade)."
+                )
+            else:
+                effective_fallback = fallback or primary
             assert effective_primary is not None
-            assert effective_fallback is not None
+            # Slice 20A — effective_fallback may legitimately be None now;
+            # the assert was a pre-Slice-19b invariant that no longer holds.
 
             _pool_size = int(os.environ.get("JARVIS_BG_POOL_SIZE", "3"))
             _fallback_concurrency = int(os.environ.get(

--- a/tests/governance/test_slice20a_self_fallback_elimination.py
+++ b/tests/governance/test_slice20a_self_fallback_elimination.py
@@ -1,0 +1,211 @@
+"""Slice 20A — Self-fallback elimination when Claude is intentionally disabled.
+
+Closes the double-binding bug surfaced by soak bt-2026-05-26-184355 (PURE-DW v15).
+Slice 19a correctly disabled ClaudeProvider construction (`self._fallback`
+stays None at the provider level). BUT GovernedLoopService line 3576
+then collapsed it back into primary via:
+
+  effective_fallback = fallback or primary  # ← assigned DW as fallback
+
+When the operator set JARVIS_PROVIDER_CLAUDE_DISABLED=true:
+  fallback=None (from gate), primary=DW
+  → effective_fallback = None or DW = DW
+  → CandidateGenerator(primary=DW, fallback=DW)  # SAME OBJECT!
+
+Result: Slice 19b's `self._fallback is None` guard never fired
+because fallback wasn't None — it was DW. The cascade FSM called
+DW twice (once as primary, once as fallback), DW collided on its
+own scheduler, exhaustion event recorded as fallback_failed instead
+of fallback_skipped, hibernation breaker counted them, soak still
+limped along but the architectural intent was violated.
+
+Empirical evidence from v15 (multiple events):
+
+  EXHAUSTION event_n=1 cause=fallback_failed
+  primary_name=doubleword-397b
+  fallback_name=doubleword-397b   ← SAME PROVIDER
+  fallback_err_msg=doubleword_sche... (DW's own scheduler conflict)
+
+# Fix mechanism
+
+GovernedLoopService line 3573-3578 now checks if Claude was
+intentionally disabled. When YES AND fallback is None, effective_fallback
+STAYS None. CandidateGenerator's `fallback: Optional[CandidateProvider]
+= None` signature accepts this. Slice 19b's existing guard then fires
+correctly on the first cascade attempt.
+
+# Test surface (2 AST pins + 4 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import os
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GLS_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "governed_loop_service.py"
+)
+CG_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "candidate_generator.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_governed_loop_honors_claude_disabled_for_fallback() -> None:
+    """GovernedLoopService MUST check JARVIS_PROVIDER_CLAUDE_DISABLED
+    when deriving effective_fallback. Without this, the legacy
+    `fallback or primary` self-binding silently activates."""
+    src = GLS_FILE.read_text()
+    assert "Slice 20A" in src, (
+        "GovernedLoopService missing Slice 20A attribution — fix reverted"
+    )
+    assert "_claude_disabled" in src, (
+        "Missing _claude_disabled local in effective_fallback derivation — "
+        "self-fallback elimination dead code"
+    )
+    # The structural form: when _claude_disabled is True AND fallback is None,
+    # effective_fallback = None
+    assert "effective_fallback = None" in src, (
+        "Missing `effective_fallback = None` assignment — Slice 19b's "
+        "fallback_skipped guard cannot fire"
+    )
+    # Soak attribution
+    assert "bt-2026-05-26-184355" in src, (
+        "Missing v15 soak attribution"
+    )
+
+
+def test_ast_pin_candidate_generator_accepts_optional_fallback() -> None:
+    """CandidateGenerator.__init__ MUST accept fallback as
+    Optional[CandidateProvider] = None — required for Slice 20A's
+    effective_fallback=None to flow through without a TypeError."""
+    src = CG_FILE.read_text()
+    # The __init__ signature must allow fallback to be None
+    tree = ast.parse(src, filename=str(CG_FILE))
+    found = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "__init__"
+        ):
+            # Find the fallback arg
+            for arg in node.args.args:
+                if arg.arg == "fallback":
+                    # Check if its annotation is Optional[...] OR
+                    # the default is None (defaults align with args
+                    # via the args.defaults list)
+                    annotation_src = (
+                        ast.unparse(arg.annotation) if arg.annotation else ""
+                    )
+                    if "Optional[" in annotation_src or "| None" in annotation_src:
+                        found = True
+                        break
+            if found:
+                break
+    assert found, (
+        "CandidateGenerator.__init__ fallback param NOT Optional — "
+        "Slice 20A's effective_fallback=None will TypeError at construction"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 4
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_candidate_generator_constructs_with_fallback_none() -> None:
+    """CandidateGenerator must construct successfully with fallback=None.
+    Before Slice 20A this would fail because __init__ required a
+    CandidateProvider, not Optional[CandidateProvider]."""
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+
+    class _StubProvider:
+        provider_name = "stub"
+        async def generate(self, *a, **k):
+            return None
+
+    # Must NOT raise
+    cg = CandidateGenerator(
+        primary=_StubProvider(),
+        fallback=None,
+    )
+    assert cg._fallback is None, (
+        "CandidateGenerator._fallback not None after explicit fallback=None"
+    )
+
+
+def test_spine_slice19b_guard_fires_when_fallback_actually_none() -> None:
+    """The whole point of Slice 20A: with fallback=None propagated,
+    Slice 19b's `self._fallback is None` guard fires correctly.
+    Verify _call_fallback raises with fallback_skipped: cause."""
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+    import asyncio
+    from datetime import datetime, timezone, timedelta
+
+    class _StubProvider:
+        provider_name = "stub-primary"
+        async def generate(self, *a, **k):
+            return None
+
+    class _StubCtx:
+        op_id = "test-op-20a"
+        provider_route = "standard"
+
+    cg = CandidateGenerator(
+        primary=_StubProvider(),
+        fallback=None,
+    )
+
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+
+    async def _runner():
+        try:
+            await cg._call_fallback(_StubCtx(), deadline)
+            return None
+        except RuntimeError as exc:
+            return str(exc)
+
+    result = asyncio.run(_runner())
+    assert result is not None, "_call_fallback did not raise"
+    assert "fallback_skipped" in result, (
+        f"_call_fallback raised but cause was not fallback_skipped — got "
+        f"{result!r}; Slice 19b guard didn't fire because fallback wasn't None"
+    )
+
+
+def test_spine_self_fallback_collapse_path_documented() -> None:
+    """The Slice 20A fix must mention the specific empirical pattern
+    it eliminates: `fallback_name == primary_name == doubleword-397b`.
+    Future readers need to trace WHY the branch exists."""
+    src = GLS_FILE.read_text()
+    # Look for the explanatory comment block
+    assert "self-fallback" in src.lower(), (
+        "Missing self-fallback explanation — context lost"
+    )
+
+
+def test_spine_legacy_path_preserved_when_claude_enabled() -> None:
+    """When Claude is NOT disabled (default operator config),
+    effective_fallback STILL falls back to primary if no real
+    fallback exists. Pre-Slice-20A byte-equivalent for non-DW-only
+    soaks."""
+    src = GLS_FILE.read_text()
+    # The legacy `fallback or primary` branch must still exist in the
+    # else clause
+    assert "effective_fallback = fallback or primary" in src, (
+        "Legacy `fallback or primary` branch removed — non-DW-only "
+        "soaks broken; pre-Slice-20A byte-equivalence violated"
+    )


### PR DESCRIPTION
## Slice 20A — Self-Fallback Elimination

**Soak attribution**: `bt-2026-05-26-184355` (PURE-DW v15)
**Builds on**: PR #59070 (Slice 19a) + PR #59071 (Slice 19b)

### What the bug was

Slice 19a correctly disabled `ClaudeProvider` construction when `JARVIS_PROVIDER_CLAUDE_DISABLED=true` (`self._fallback` stayed `None` at the provider level). But `GovernedLoopService` line 3576 collapsed it back into primary via:

```python
effective_fallback = fallback or primary   # ← double-binding DW
```

When the operator set `JARVIS_PROVIDER_CLAUDE_DISABLED=true`:
- `fallback = None` (from Slice 19a gate)
- `primary = DW`
- `effective_fallback = None or DW = DW`
- `CandidateGenerator(primary=DW, fallback=DW)` ← **SAME OBJECT**

Slice 19b's `self._fallback is None` guard never fired because `fallback` wasn't `None` — it was the same DW provider instance. Cascade FSM called DW twice, DW collided on its own scheduler, exhaustion recorded as `fallback_failed` instead of `fallback_skipped`.

### Empirical evidence from v15

```
EXHAUSTION event_n=1 cause=fallback_failed
primary_name=doubleword-397b
fallback_name=doubleword-397b   ← SAME PROVIDER
fallback_err_msg=doubleword_sche... (DW's own scheduler conflict)
```

### Fix mechanism

**`candidate_generator.py:833`** — Signature change:
```python
- fallback: CandidateProvider
+ fallback: Optional[CandidateProvider] = None
```

**`governed_loop_service.py:3573-3590`** — When Claude is disabled AND no real fallback exists, `effective_fallback` stays `None`:
```python
_claude_disabled = os.environ.get(
    "JARVIS_PROVIDER_CLAUDE_DISABLED", "",
).strip().lower() in ("true", "1", "yes", "on")
effective_primary = primary or fallback
if _claude_disabled and fallback is None:
    effective_fallback = None
    logger.info("[GovernedLoop] Slice 20A: self-fallback ELIMINATED...")
else:
    effective_fallback = fallback or primary   # legacy preserved
```

Slice 19b's existing guard then fires correctly on the first cascade attempt → raises with cause prefix `fallback_skipped:` → `ExhaustionWatcher` does NOT advance consecutive counter → no hibernation.

### Verification

**6 new tests** (2 AST pins + 4 spine, all passing):
- AST pin: `governed_loop` honors `JARVIS_PROVIDER_CLAUDE_DISABLED` for fallback
- AST pin: `CandidateGenerator.__init__` accepts `Optional[CandidateProvider]`
- Spine: `CandidateGenerator` constructs successfully with `fallback=None`
- Spine: Slice 19b guard fires when fallback actually `None` (verified `fallback_skipped` cause string raised)
- Spine: self-fallback collapse path documented in source
- Spine: legacy `fallback or primary` branch preserved for non-DW-only soaks

**Regression**: 23/23 green across Slices 18c/19a/19b/20A.

### Discipline

- **No new env knob** — `JARVIS_PROVIDER_CLAUDE_DISABLED` (Slice 19a) is the only operator surface; Slice 20A is the load-bearing repair to make it actually work end-to-end.
- **Legacy `fallback or primary` branch preserved verbatim** in the else clause — byte-identical behavior for default (Claude-enabled) soaks.
- Tests pin both branches: Slice 20A pin proves new path, legacy branch pin proves zero-regression for the default path.

### Next steps (deferred — separate PRs)

- **Slice 20B**: Asynchronous JSON healing with DW-driven Qwen3.5-35B repair
- **Slice 20C**: Fleet schema rotation in `UrgencyRouter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates self-fallback when Claude is disabled, preventing DW from being used as both primary and fallback. Keeps `effective_fallback=None` in that mode, aligns with Slice 19a, and avoids double-call collisions.

- **Bug Fixes**
  - In `GovernedLoopService`, when `JARVIS_PROVIDER_CLAUDE_DISABLED` is set and no real fallback exists, keep `effective_fallback=None` (legacy `fallback or primary` path preserved when Claude is enabled).
  - `CandidateGenerator.__init__` now accepts `fallback: Optional[CandidateProvider] = None`.
  - Slice 19b guard now fires; cascade emits `fallback_skipped` (not `fallback_failed`), preventing unnecessary hibernation.
  - Added 6 tests to cover the new path and pin legacy behavior.

<sup>Written for commit 6eb9924b1fbf6164243084295bd4bca802e387ad. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/59072?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

