### PR TITLE
feat(governance): Slice 25 — autonomous pre-flight health & entitlement sentinel (composes HeavyProbe + entitlement_classifier + ledger + sentinel)

### DIFF
--- a/backend/core/ouroboros/governance/dw_promotion_ledger.py
+++ b/backend/core/ouroboros/governance/dw_promotion_ledger.py
@@ -122,11 +122,21 @@ QUARANTINE_DEMOTED_FROM_BG = "demoted_from_bg"   # post-promotion failure
 # to bootstrap DW catalog when the dw_catalog_classifier's
 # automatic discovery returns only ambiguous-metadata models.
 QUARANTINE_TRUSTED_SEED = "trusted_seed"
+# Slice 25 — Pre-Flight Health Probe outcome. When the boot-time
+# entitlement probe (preflight_probe.py) classifies a model's 4xx
+# response via dw_entitlement_classifier as ``ENTITLEMENT_BLOCKED``
+# ("blocked by a routing rule" marker), the model is demoted with this
+# origin so future dispatches don't waste budget on a model the
+# account isn't entitled to call. Distinct from operator_demoted
+# (manual operator decision) so postmortem can tell apart "operator
+# kicked this out" from "DW account doesn't entitle us to call it".
+QUARANTINE_ACCOUNT_NOT_ENTITLED = "account_not_entitled"
 _VALID_QUARANTINE_ORIGINS = frozenset({
     QUARANTINE_AMBIGUOUS_METADATA,
     QUARANTINE_OPERATOR_DEMOTED,
     QUARANTINE_DEMOTED_FROM_BG,
     QUARANTINE_TRUSTED_SEED,
+    QUARANTINE_ACCOUNT_NOT_ENTITLED,
 })
 
 

--- a/backend/core/ouroboros/governance/preflight_probe.py
+++ b/backend/core/ouroboros/governance/preflight_probe.py
@@ -1,0 +1,558 @@
+"""Slice 25 — Autonomous Pre-Flight Health & Entitlement Sentinel.
+
+Closes the observability gap surfaced by v18 (bt-2026-05-26-233010):
+when the upstream DW tier undergoes a network blackout or per-model
+entitlement failure, the dispatch engine blindly churns wall-clock
+time burning through every model in the fleet before finally
+exhausting. The operator-binding contract: *we do not let external
+dependency failures compromise system predictability*.
+
+# Composition discipline (operator-mandated)
+
+This module ORCHESTRATES existing substrate — it does NOT duplicate
+any probe / classifier / ledger / sentinel logic:
+
+* **HeavyProber** (``dw_heavy_probe.py``) — already-built async probe
+  primitive with budget enforcement + adaptive TTFT + defensive
+  error capture. We invoke ``HeavyProber.probe(model_id, ...)`` per
+  trusted model in parallel (bounded by ``asyncio.gather``).
+* **dw_entitlement_classifier** (``classify_4xx``) — pure-function
+  classifier already distinguishes ``ENTITLEMENT_BLOCKED`` (per-model
+  routing-rule rejection — permanent) from ``AUTH_FAILURE`` (global
+  cred problem — transient) from ``OTHER_4XX``. We pass the probe's
+  error body through this classifier verbatim.
+* **PromotionLedger.demote(origin=QUARANTINE_ACCOUNT_NOT_ENTITLED)** —
+  in-memory + on-disk demotion via the EXISTING demote API. The new
+  origin constant (added in dw_promotion_ledger.py) is the only
+  delta on the ledger side.
+* **TopologySentinel.report_failure** — invoked for 5xx / timeout
+  outcomes via the EXISTING signature; trips CLOSED→OPEN naturally
+  via the weighted-streak threshold. Slice 24's structural fields
+  (status_code / response_body / is_terminal) carry through.
+
+# Injection / testability
+
+The public ``run_preflight()`` takes an injectable ``probe_fn`` so
+tests can mock outcomes WITHOUT requiring aiohttp + DW credentials.
+Production wiring binds ``HeavyProber.probe`` (via the bound-session
+factory at the call site). This decoupling lets the test surface
+exercise every branch deterministically and keeps the module's
+import surface acyclic.
+
+# Closed outcome taxonomy
+
+``PreflightVerdict`` is closed at 5 values:
+* ``ACTIVE`` — probe succeeded with at least one token
+* ``DEMOTED_ENTITLEMENT`` — 4xx + classifier returned ENTITLEMENT_BLOCKED
+* ``DEGRADED_5XX`` — 5xx or transport error; sentinel reported_failure
+* ``DEGRADED_TIMEOUT`` — probe timeout; sentinel reported_failure
+* ``ERROR_OTHER`` — unclassified failure (probe substrate raised
+  unexpectedly); recorded but no eviction (defensive — caller can
+  still attempt the model)
+
+# Fail-fast boundary
+
+If ALL probed models end in non-ACTIVE verdicts AND ``halt_on_all_fail``
+is True (default), ``run_preflight`` raises
+``PreflightAllFailedError`` with a structured diagnostic. The caller
+(harness boot OR candidate_generator first-activation) catches and
+emits a clean shutdown rather than entering a deterministic
+exhaustion loop. When ``halt_on_all_fail=False`` the function
+returns the report for caller-side branching.
+
+# Master flag
+
+``JARVIS_PREFLIGHT_PROBE_ENABLED`` — default-FALSE pending v19
+validation. Once a v19 detonation proves the probe yields actionable
+demotions without false-positives, graduate to default-TRUE per
+Slice 23's structural-condition pattern (auto-on when Claude
+disabled + multi-model fleet present).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Awaitable, Callable, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Constants + closed taxonomy
+# ──────────────────────────────────────────────────────────────────────
+
+
+_ENV_MASTER = "JARVIS_PREFLIGHT_PROBE_ENABLED"
+_ENV_TIMEOUT_PER_MODEL_S = "JARVIS_PREFLIGHT_TIMEOUT_PER_MODEL_S"
+_ENV_TEST_PROMPT = "JARVIS_PREFLIGHT_TEST_PROMPT"
+_ENV_HALT_ON_ALL_FAIL = "JARVIS_PREFLIGHT_HALT_ON_ALL_FAIL"
+
+_DEFAULT_TIMEOUT_PER_MODEL_S = 10.0
+_DEFAULT_TEST_PROMPT = "ping"
+_DEFAULT_HALT_ON_ALL_FAIL = True
+
+
+class PreflightVerdict(str, Enum):
+    """Closed taxonomy — each probed model lands in exactly one bucket."""
+
+    ACTIVE = "active"
+    DEMOTED_ENTITLEMENT = "demoted_entitlement"
+    DEGRADED_5XX = "degraded_5xx"
+    DEGRADED_TIMEOUT = "degraded_timeout"
+    ERROR_OTHER = "error_other"
+
+
+@dataclass(frozen=True)
+class ProbeOutcome:
+    """Test-injectable contract — what ``probe_fn(model_id)`` returns.
+
+    Production binds this to ``HeavyProbeResult`` via a thin adapter
+    that extracts ``success`` / ``status_code`` / ``error_body``
+    / ``latency_ms`` from the heavy-probe result.
+
+    Tests construct directly.
+
+    ``status_code`` semantics (matches DoublewordInfraError convention):
+      * 200 — success (with optional tokens received)
+      * 4xx — body fed to dw_entitlement_classifier for kind verdict
+      * 5xx — degraded; sentinel report_failure(LIVE_HTTP_5XX)
+      * 0   — non-HTTP (timeout/DNS/TLS); degraded_timeout if exception
+              indicates timeout, else degraded_5xx
+    """
+
+    model_id: str
+    success: bool
+    status_code: int = 0
+    error_body: str = ""
+    latency_ms: int = 0
+    timeout: bool = False
+    error_message: str = ""
+
+
+@dataclass(frozen=True)
+class ModelPreflightResult:
+    """Per-model outcome of the preflight probe. Frozen for audit."""
+
+    model_id: str
+    verdict: PreflightVerdict
+    status_code: int = 0
+    latency_ms: int = 0
+    entitlement_marker: str = ""
+    diagnostic: str = ""
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    """Aggregate outcome across the trusted fleet."""
+
+    started_at_unix: float
+    finished_at_unix: float
+    results: Tuple[ModelPreflightResult, ...]
+    active_count: int
+    demoted_entitlement_count: int
+    degraded_5xx_count: int
+    degraded_timeout_count: int
+    error_other_count: int
+
+    @property
+    def all_failed(self) -> bool:
+        return self.active_count == 0 and len(self.results) > 0
+
+    @property
+    def total_probed(self) -> int:
+        return len(self.results)
+
+    def summary_line(self) -> str:
+        return (
+            f"active={self.active_count} "
+            f"demoted_entitlement={self.demoted_entitlement_count} "
+            f"degraded_5xx={self.degraded_5xx_count} "
+            f"degraded_timeout={self.degraded_timeout_count} "
+            f"error_other={self.error_other_count} "
+            f"total={self.total_probed} "
+            f"duration_s={self.finished_at_unix - self.started_at_unix:.2f}"
+        )
+
+
+class PreflightAllFailedError(RuntimeError):
+    """Raised when every probed model failed AND halt_on_all_fail=True.
+
+    Carries the structured report so the caller (harness boot) can
+    dump it before exiting cleanly. NEVER raised when at least one
+    model probed ACTIVE — partial success is acceptable.
+    """
+
+    def __init__(self, report: PreflightReport) -> None:
+        self.report = report
+        super().__init__(
+            f"preflight all models failed — {report.summary_line()}"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _envb(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in ("1", "true", "yes", "on")
+
+
+def _envf(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _envs(name: str, default: str) -> str:
+    raw = os.environ.get(name, "").strip()
+    return raw if raw else default
+
+
+def is_preflight_enabled() -> bool:
+    """Master flag — read at every call so toggles take effect immediately."""
+    return _envb(_ENV_MASTER, default=False)
+
+
+def _classify_outcome(outcome: ProbeOutcome) -> Tuple[
+    PreflightVerdict, str, str,
+]:
+    """Pure-function classifier — maps ProbeOutcome → (verdict, marker, diag).
+
+    Composes ``dw_entitlement_classifier.classify_4xx`` for the 4xx
+    branch. No I/O, no state, deterministic.
+    """
+    if outcome.success:
+        return PreflightVerdict.ACTIVE, "", ""
+
+    if outcome.timeout:
+        return (
+            PreflightVerdict.DEGRADED_TIMEOUT,
+            "",
+            f"timeout after {outcome.latency_ms}ms",
+        )
+
+    # 4xx → run through entitlement classifier
+    if 400 <= outcome.status_code < 500:
+        try:
+            from backend.core.ouroboros.governance.dw_entitlement_classifier import (
+                classify_4xx,
+                KIND_ENTITLEMENT_BLOCKED,
+            )
+            result = classify_4xx(outcome.status_code, outcome.error_body)
+            if result.kind == KIND_ENTITLEMENT_BLOCKED:
+                return (
+                    PreflightVerdict.DEMOTED_ENTITLEMENT,
+                    result.matched_marker,
+                    f"http_{outcome.status_code} entitlement_blocked "
+                    f"marker={result.matched_marker!r}",
+                )
+            # AUTH_FAILURE / OTHER_4XX — treat as degraded (not entitlement)
+            return (
+                PreflightVerdict.DEGRADED_5XX,
+                "",
+                f"http_{outcome.status_code} kind={result.kind}",
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive
+            return (
+                PreflightVerdict.ERROR_OTHER,
+                "",
+                f"classifier_raised:{type(exc).__name__}:{str(exc)[:120]}",
+            )
+
+    # 5xx → degraded
+    if 500 <= outcome.status_code < 600:
+        return (
+            PreflightVerdict.DEGRADED_5XX,
+            "",
+            f"http_{outcome.status_code} {outcome.error_message[:120]}",
+        )
+
+    # 0 status_code with no timeout flag = transport-level non-timeout
+    # (DNS/TLS/connection-refused). Classify as 5xx-style degradation
+    # so the sentinel breaker sees the failure pressure.
+    if outcome.status_code == 0:
+        return (
+            PreflightVerdict.DEGRADED_5XX,
+            "",
+            f"transport_error: {outcome.error_message[:120]}",
+        )
+
+    # Other status codes (1xx/2xx-non-success/3xx) — unexpected
+    return (
+        PreflightVerdict.ERROR_OTHER,
+        "",
+        f"unexpected_status={outcome.status_code} "
+        f"msg={outcome.error_message[:120]}",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Public entry point
+# ──────────────────────────────────────────────────────────────────────
+
+
+async def run_preflight(
+    *,
+    model_ids: Tuple[str, ...],
+    probe_fn: Callable[[str], Awaitable[ProbeOutcome]],
+    ledger: Optional["object"] = None,
+    sentinel: Optional["object"] = None,
+    timeout_per_model_s: Optional[float] = None,
+    halt_on_all_fail: Optional[bool] = None,
+) -> PreflightReport:
+    """Probe each model in ``model_ids`` concurrently; route outcomes.
+
+    For each model:
+
+      * **ACTIVE** → no side effect (model is healthy)
+      * **DEMOTED_ENTITLEMENT** → ``ledger.demote(model_id,
+        origin=QUARANTINE_ACCOUNT_NOT_ENTITLED)`` if ledger provided
+      * **DEGRADED_5XX** / **DEGRADED_TIMEOUT** →
+        ``sentinel.report_failure(model_id, LIVE_HTTP_5XX/LIVE_TRANSPORT,
+        status_code=..., response_body=..., is_terminal=False)`` if
+        sentinel provided
+      * **ERROR_OTHER** → recorded, no eviction (defensive)
+
+    Concurrency: probes fire via ``asyncio.gather`` with per-probe
+    ``asyncio.wait_for`` enforcing ``timeout_per_model_s`` (default 10s).
+    Worst-case wall is ``timeout_per_model_s`` regardless of fleet size.
+
+    Returns PreflightReport. Raises PreflightAllFailedError when every
+    probe failed AND halt_on_all_fail is True (default).
+
+    Callers MUST pass a ``probe_fn`` callable — tests inject a stub,
+    production binds ``HeavyProber.probe`` adapted to ProbeOutcome.
+    """
+    if not model_ids:
+        # Empty fleet — caller should not have called us, but be defensive
+        empty = PreflightReport(
+            started_at_unix=time.time(),
+            finished_at_unix=time.time(),
+            results=(),
+            active_count=0,
+            demoted_entitlement_count=0,
+            degraded_5xx_count=0,
+            degraded_timeout_count=0,
+            error_other_count=0,
+        )
+        return empty
+
+    effective_timeout = (
+        timeout_per_model_s
+        if timeout_per_model_s is not None
+        else _envf(_ENV_TIMEOUT_PER_MODEL_S, _DEFAULT_TIMEOUT_PER_MODEL_S)
+    )
+    effective_halt = (
+        halt_on_all_fail
+        if halt_on_all_fail is not None
+        else _envb(_ENV_HALT_ON_ALL_FAIL, _DEFAULT_HALT_ON_ALL_FAIL)
+    )
+
+    started = time.time()
+    logger.info(
+        "[Preflight] starting probes: models=%d timeout=%.1fs halt_on_all_fail=%s",
+        len(model_ids), effective_timeout, effective_halt,
+    )
+
+    # Bounded per-probe timeout wrapper
+    async def _probe_with_timeout(mid: str) -> ProbeOutcome:
+        try:
+            return await asyncio.wait_for(
+                probe_fn(mid), timeout=effective_timeout,
+            )
+        except asyncio.TimeoutError:
+            return ProbeOutcome(
+                model_id=mid,
+                success=False,
+                status_code=0,
+                latency_ms=int(effective_timeout * 1000),
+                timeout=True,
+                error_message=f"asyncio.wait_for hit {effective_timeout}s",
+            )
+        except Exception as exc:  # noqa: BLE001 — probe MUST NOT raise
+            return ProbeOutcome(
+                model_id=mid,
+                success=False,
+                status_code=0,
+                error_message=f"probe_raised:{type(exc).__name__}:{str(exc)[:120]}",
+            )
+
+    outcomes = await asyncio.gather(
+        *[_probe_with_timeout(m) for m in model_ids],
+        return_exceptions=False,
+    )
+
+    # Classify + route side-effects
+    results: List[ModelPreflightResult] = []
+    active = 0
+    dem_ent = 0
+    deg_5xx = 0
+    deg_timeout = 0
+    err_other = 0
+
+    for outcome in outcomes:
+        verdict, marker, diag = _classify_outcome(outcome)
+        results.append(ModelPreflightResult(
+            model_id=outcome.model_id,
+            verdict=verdict,
+            status_code=outcome.status_code,
+            latency_ms=outcome.latency_ms,
+            entitlement_marker=marker,
+            diagnostic=diag,
+        ))
+
+        if verdict is PreflightVerdict.ACTIVE:
+            active += 1
+            logger.info(
+                "[Preflight] model=%s ACTIVE latency=%dms",
+                outcome.model_id, outcome.latency_ms,
+            )
+            continue
+
+        if verdict is PreflightVerdict.DEMOTED_ENTITLEMENT:
+            dem_ent += 1
+            logger.warning(
+                "[Preflight] model=%s ENTITLEMENT_BLOCKED — evicting from "
+                "PromotionLedger with origin=account_not_entitled "
+                "(marker=%r)",
+                outcome.model_id, marker,
+            )
+            _demote_in_ledger(ledger, outcome.model_id)
+            continue
+
+        if verdict is PreflightVerdict.DEGRADED_5XX:
+            deg_5xx += 1
+            logger.warning(
+                "[Preflight] model=%s DEGRADED_5XX status=%d — sentinel "
+                "report_failure (diag=%s)",
+                outcome.model_id, outcome.status_code, diag,
+            )
+            _report_to_sentinel(
+                sentinel, outcome, source="live_http_5xx", is_terminal=False,
+            )
+            continue
+
+        if verdict is PreflightVerdict.DEGRADED_TIMEOUT:
+            deg_timeout += 1
+            logger.warning(
+                "[Preflight] model=%s DEGRADED_TIMEOUT latency=%dms — "
+                "sentinel report_failure",
+                outcome.model_id, outcome.latency_ms,
+            )
+            _report_to_sentinel(
+                sentinel, outcome, source="live_transport", is_terminal=False,
+            )
+            continue
+
+        # ERROR_OTHER — recorded only, no eviction
+        err_other += 1
+        logger.warning(
+            "[Preflight] model=%s ERROR_OTHER (diag=%s) — "
+            "no eviction (defensive)",
+            outcome.model_id, diag,
+        )
+
+    finished = time.time()
+    report = PreflightReport(
+        started_at_unix=started,
+        finished_at_unix=finished,
+        results=tuple(results),
+        active_count=active,
+        demoted_entitlement_count=dem_ent,
+        degraded_5xx_count=deg_5xx,
+        degraded_timeout_count=deg_timeout,
+        error_other_count=err_other,
+    )
+
+    logger.info("[Preflight] complete: %s", report.summary_line())
+
+    if report.all_failed and effective_halt:
+        logger.error(
+            "[Preflight] FAIL-FAST — every probed model failed; halting "
+            "initialization. report=%s",
+            report.summary_line(),
+        )
+        raise PreflightAllFailedError(report)
+
+    return report
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Side-effect helpers (kept private — never raise into caller)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _demote_in_ledger(ledger: Optional[object], model_id: str) -> None:
+    """Best-effort demote with QUARANTINE_ACCOUNT_NOT_ENTITLED origin.
+
+    Lazy import keeps this module's substrate independent of the
+    ledger module (so a circular-import collapse can't take down
+    preflight). NEVER raises into the caller — eviction is the
+    enhancement; correctness of the report is the primary contract.
+    """
+    if ledger is None:
+        return
+    try:
+        from backend.core.ouroboros.governance.dw_promotion_ledger import (
+            QUARANTINE_ACCOUNT_NOT_ENTITLED,
+        )
+        ledger.demote(model_id, origin=QUARANTINE_ACCOUNT_NOT_ENTITLED)
+        # ledger.demote() already writes to disk via _ensure_loaded /
+        # save semantics; no additional persistence call needed.
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug(
+            "[Preflight] ledger demote failed for %s: %r",
+            model_id, exc,
+        )
+
+
+def _report_to_sentinel(
+    sentinel: Optional[object],
+    outcome: ProbeOutcome,
+    *,
+    source: str,
+    is_terminal: bool,
+) -> None:
+    """Best-effort sentinel report_failure call. Slice 24's structural
+    fields carry through (status_code / response_body / is_terminal).
+    """
+    if sentinel is None:
+        return
+    try:
+        from backend.core.ouroboros.governance.topology_sentinel import (
+            FailureSource,
+        )
+        # Map source string to enum
+        fs = (
+            FailureSource.LIVE_TRANSPORT
+            if source == "live_transport"
+            else FailureSource.LIVE_HTTP_5XX
+        )
+        sentinel.report_failure(
+            outcome.model_id,
+            fs,
+            detail=f"preflight:{outcome.error_message[:200]}",
+            status_code=(
+                outcome.status_code if outcome.status_code > 0 else None
+            ),
+            response_body=outcome.error_body[:512],
+            is_terminal=is_terminal,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug(
+            "[Preflight] sentinel report_failure failed for %s: %r",
+            outcome.model_id, exc,
+        )

--- a/tests/governance/test_slice25_preflight_probe.py
+++ b/tests/governance/test_slice25_preflight_probe.py
@@ -1,0 +1,405 @@
+"""Slice 25 — Autonomous Pre-Flight Health & Entitlement Sentinel.
+
+Closes the observability gap surfaced by v18 (bt-2026-05-26-233010):
+when the upstream DW tier undergoes a network blackout or per-model
+entitlement failure, the dispatch engine blindly churns wall-clock
+time burning through every model in the fleet. Slice 25 adds a
+boot-time orchestrator that composes the existing HeavyProbe +
+dw_entitlement_classifier + PromotionLedger.demote + TopologySentinel
+into a single fail-fast preflight.
+
+# Composition (no duplication)
+
+* HeavyProber (existing) — async probe primitive injected via
+  ``probe_fn`` parameter for testability.
+* dw_entitlement_classifier (existing) — pure-function 4xx classifier.
+* PromotionLedger.demote (existing) — augmented with new origin
+  constant ``QUARANTINE_ACCOUNT_NOT_ENTITLED``.
+* TopologySentinel.report_failure (existing) — Slice 24's structural
+  fields carry through.
+
+# Closed verdict taxonomy (AST-pinned)
+
+PreflightVerdict has exactly 5 values:
+  ACTIVE / DEMOTED_ENTITLEMENT / DEGRADED_5XX / DEGRADED_TIMEOUT / ERROR_OTHER
+
+# Test surface (3 AST pins + 9 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PF_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "preflight_probe.py"
+)
+LEDGER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "dw_promotion_ledger.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_preflight_verdict_taxonomy_closed_at_5() -> None:
+    """PreflightVerdict MUST be exactly the 5 documented values.
+    Adding a 6th drift kind requires updating this pin + the
+    classifier + side-effect router — that friction is intentional."""
+    src = PF_FILE.read_text()
+    tree = ast.parse(src, filename=str(PF_FILE))
+    found = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "PreflightVerdict":
+            for stmt in node.body:
+                if isinstance(stmt, ast.Assign):
+                    for target in stmt.targets:
+                        if isinstance(target, ast.Name):
+                            found.append(target.id)
+    expected = {
+        "ACTIVE",
+        "DEMOTED_ENTITLEMENT",
+        "DEGRADED_5XX",
+        "DEGRADED_TIMEOUT",
+        "ERROR_OTHER",
+    }
+    assert set(found) == expected, (
+        f"PreflightVerdict taxonomy drift: got {found!r}, expected {expected!r}"
+    )
+
+
+def test_ast_pin_ledger_account_not_entitled_origin_registered() -> None:
+    """QUARANTINE_ACCOUNT_NOT_ENTITLED MUST be declared AND included
+    in _VALID_QUARANTINE_ORIGINS. Without the latter, demote()
+    silently falls back to OPERATOR_DEMOTED and the postmortem
+    can't tell entitlement evictions apart from manual demotes."""
+    src = LEDGER_FILE.read_text()
+    assert 'QUARANTINE_ACCOUNT_NOT_ENTITLED = "account_not_entitled"' in src, (
+        "QUARANTINE_ACCOUNT_NOT_ENTITLED constant missing or renamed"
+    )
+    # Walk the AST to confirm it's in the _VALID_QUARANTINE_ORIGINS frozenset
+    tree = ast.parse(src, filename=str(LEDGER_FILE))
+    found_in_valid = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "_VALID_QUARANTINE_ORIGINS"
+        ):
+            body_src = ast.unparse(node)
+            if "QUARANTINE_ACCOUNT_NOT_ENTITLED" in body_src:
+                found_in_valid = True
+                break
+    assert found_in_valid, (
+        "QUARANTINE_ACCOUNT_NOT_ENTITLED not in _VALID_QUARANTINE_ORIGINS "
+        "frozenset — demote() will silently swap to OPERATOR_DEMOTED"
+    )
+
+
+def test_ast_pin_composes_existing_substrate_no_duplication() -> None:
+    """preflight_probe MUST compose existing primitives — not
+    duplicate them. Verify by source-grep that the canonical imports
+    are present (lazy imports inside side-effect helpers count;
+    they're the operator-binding-compliant composition pattern)."""
+    src = PF_FILE.read_text()
+    # Must compose, not duplicate
+    assert "dw_entitlement_classifier" in src, (
+        "preflight_probe must compose dw_entitlement_classifier, "
+        "not reimplement 4xx classification"
+    )
+    assert "QUARANTINE_ACCOUNT_NOT_ENTITLED" in src, (
+        "preflight_probe must import the canonical origin constant"
+    )
+    assert "topology_sentinel" in src, (
+        "preflight_probe must compose TopologySentinel.report_failure"
+    )
+    # Must NOT contain any raw HTTP-classification code (the classifier
+    # is the single seam). Source-grep ban on telltale patterns.
+    banned_patterns = [
+        "blocked by a routing rule",  # marker is the classifier's job
+        "contact your administrator",
+    ]
+    for pat in banned_patterns:
+        assert pat not in src, (
+            f"preflight_probe contains raw classifier marker {pat!r} — "
+            "violates composition: the classifier owns marker matching"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 9
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spine_all_active_returns_clean_report() -> None:
+    """All probes succeed → report.active_count == fleet size,
+    all_failed=False, no exception."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_preflight, ProbeOutcome,
+    )
+
+    async def stub(mid):
+        return ProbeOutcome(model_id=mid, success=True, status_code=200, latency_ms=50)
+
+    report = await run_preflight(
+        model_ids=("Qwen-397B", "Qwen-35B", "Kimi"),
+        probe_fn=stub,
+    )
+    assert report.active_count == 3
+    assert report.demoted_entitlement_count == 0
+    assert report.degraded_5xx_count == 0
+    assert report.all_failed is False
+
+
+@pytest.mark.asyncio
+async def test_spine_403_entitlement_demotes_model() -> None:
+    """403 + entitlement marker → DEMOTED_ENTITLEMENT verdict + ledger.demote
+    called with origin=account_not_entitled."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_preflight, ProbeOutcome, PreflightVerdict,
+    )
+
+    async def stub(mid):
+        if mid == "Qwen-4B":
+            return ProbeOutcome(
+                model_id=mid,
+                success=False,
+                status_code=403,
+                error_body=(
+                    "Real-time access to 'Qwen-4B' is blocked by a "
+                    "routing rule. Please contact your administrator."
+                ),
+            )
+        return ProbeOutcome(model_id=mid, success=True, status_code=200, latency_ms=50)
+
+    mock_ledger = mock.MagicMock()
+    report = await run_preflight(
+        model_ids=("Qwen-397B", "Qwen-4B"),
+        probe_fn=stub,
+        ledger=mock_ledger,
+    )
+    assert report.demoted_entitlement_count == 1
+    assert report.active_count == 1
+    # The model with entitlement block
+    blocked = [r for r in report.results if r.verdict is PreflightVerdict.DEMOTED_ENTITLEMENT]
+    assert len(blocked) == 1
+    assert blocked[0].model_id == "Qwen-4B"
+    assert "blocked by a routing rule" in blocked[0].entitlement_marker
+
+    # ledger.demote called with the right origin
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        QUARANTINE_ACCOUNT_NOT_ENTITLED,
+    )
+    assert mock_ledger.demote.called, "ledger.demote was not invoked"
+    call_args = mock_ledger.demote.call_args
+    assert call_args.args[0] == "Qwen-4B"
+    assert call_args.kwargs.get("origin") == QUARANTINE_ACCOUNT_NOT_ENTITLED
+
+
+@pytest.mark.asyncio
+async def test_spine_5xx_calls_sentinel_report_failure_with_slice24_fields() -> None:
+    """5xx response → DEGRADED_5XX verdict + sentinel.report_failure
+    called with the Slice 24 structural fields (status_code,
+    response_body, is_terminal=False)."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_preflight, ProbeOutcome, PreflightVerdict,
+    )
+
+    async def stub(mid):
+        return ProbeOutcome(
+            model_id=mid, success=False, status_code=503,
+            error_body="upstream unavailable", error_message="provider blackout",
+        )
+
+    mock_sentinel = mock.MagicMock()
+    report = await run_preflight(
+        model_ids=("Qwen-397B",),
+        probe_fn=stub,
+        sentinel=mock_sentinel,
+        halt_on_all_fail=False,
+    )
+    assert report.degraded_5xx_count == 1
+    assert mock_sentinel.report_failure.called
+    call_kwargs = mock_sentinel.report_failure.call_args.kwargs
+    assert call_kwargs.get("status_code") == 503
+    assert call_kwargs.get("response_body") == "upstream unavailable"
+    assert call_kwargs.get("is_terminal") is False
+
+
+@pytest.mark.asyncio
+async def test_spine_timeout_calls_sentinel_report_failure_live_transport() -> None:
+    """Probe timeout → DEGRADED_TIMEOUT + sentinel.report_failure with
+    FailureSource.LIVE_TRANSPORT (not LIVE_HTTP_5XX)."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_preflight, ProbeOutcome,
+    )
+
+    async def stub(mid):
+        # Simulate timeout by sleeping past the per-model timeout
+        await asyncio.sleep(0.5)
+        return ProbeOutcome(model_id=mid, success=False, status_code=0)
+
+    mock_sentinel = mock.MagicMock()
+    report = await run_preflight(
+        model_ids=("Qwen-397B",),
+        probe_fn=stub,
+        sentinel=mock_sentinel,
+        timeout_per_model_s=0.1,
+        halt_on_all_fail=False,
+    )
+    assert report.degraded_timeout_count == 1
+    assert mock_sentinel.report_failure.called
+    # FailureSource.LIVE_TRANSPORT was used (verify via the second positional arg)
+    from backend.core.ouroboros.governance.topology_sentinel import FailureSource
+    call_args = mock_sentinel.report_failure.call_args
+    assert call_args.args[1] is FailureSource.LIVE_TRANSPORT
+
+
+@pytest.mark.asyncio
+async def test_spine_all_fail_halt_on_all_fail_raises() -> None:
+    """When every model fails AND halt_on_all_fail=True (default),
+    PreflightAllFailedError raises with the structured report."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_preflight, ProbeOutcome, PreflightAllFailedError,
+    )
+
+    async def stub(mid):
+        return ProbeOutcome(model_id=mid, success=False, status_code=503)
+
+    with pytest.raises(PreflightAllFailedError) as excinfo:
+        await run_preflight(
+            model_ids=("Qwen-397B", "Qwen-35B"),
+            probe_fn=stub,
+        )
+    assert excinfo.value.report.all_failed is True
+    assert excinfo.value.report.degraded_5xx_count == 2
+
+
+@pytest.mark.asyncio
+async def test_spine_halt_on_all_fail_false_returns_report() -> None:
+    """When halt_on_all_fail=False, all-failure returns the report
+    instead of raising — caller can branch on report.all_failed."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_preflight, ProbeOutcome,
+    )
+
+    async def stub(mid):
+        return ProbeOutcome(model_id=mid, success=False, status_code=503)
+
+    report = await run_preflight(
+        model_ids=("Qwen-397B",),
+        probe_fn=stub,
+        halt_on_all_fail=False,
+    )
+    assert report.all_failed is True
+    # Did NOT raise
+
+
+@pytest.mark.asyncio
+async def test_spine_empty_fleet_returns_empty_report_no_raise() -> None:
+    """Empty model_ids → empty report, NO raise (caller should not have
+    invoked us with empty fleet, but defensive)."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_preflight, ProbeOutcome,
+    )
+
+    async def stub(mid):
+        raise AssertionError("probe_fn should not be called")
+
+    report = await run_preflight(model_ids=(), probe_fn=stub)
+    assert report.total_probed == 0
+    assert report.all_failed is False  # all_failed only True when len > 0
+
+
+@pytest.mark.asyncio
+async def test_spine_probe_exception_classified_as_degraded_no_raise() -> None:
+    """If probe_fn itself raises, the outer wrapper MUST catch and
+    classify as a transport-level failure. The preflight orchestrator
+    MUST NOT propagate exceptions from individual probes — that
+    would defeat the fail-fast boundary's structured halt."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_preflight, ProbeOutcome, PreflightVerdict,
+    )
+
+    async def stub(mid):
+        raise RuntimeError("simulated probe substrate failure")
+
+    report = await run_preflight(
+        model_ids=("Qwen-397B",),
+        probe_fn=stub,
+        halt_on_all_fail=False,
+    )
+    assert report.total_probed == 1
+    # status_code=0 + no timeout flag → DEGRADED_5XX (transport)
+    result = report.results[0]
+    assert result.verdict is PreflightVerdict.DEGRADED_5XX
+    assert "probe_raised" in result.diagnostic
+
+
+@pytest.mark.asyncio
+async def test_spine_mixed_outcomes_route_independently() -> None:
+    """End-to-end: 4 models, each landing in a different verdict bucket.
+    Verifies side-effects route independently (entitlement → ledger,
+    5xx/timeout → sentinel, error_other → no side-effect).
+
+    This is the v18 scenario in microcosm: 397B succeeds, 4B is
+    entitlement-blocked, 35B is 5xx, Kimi times out."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_preflight, ProbeOutcome, PreflightVerdict,
+    )
+
+    async def stub(mid):
+        if mid == "Qwen-397B":
+            return ProbeOutcome(model_id=mid, success=True, status_code=200)
+        if mid == "Qwen-4B":
+            return ProbeOutcome(
+                model_id=mid, success=False, status_code=403,
+                error_body="blocked by a routing rule",
+            )
+        if mid == "Qwen-35B":
+            return ProbeOutcome(
+                model_id=mid, success=False, status_code=502,
+                error_message="bad gateway",
+            )
+        if mid == "Kimi":
+            await asyncio.sleep(0.5)  # forces timeout
+            return ProbeOutcome(model_id=mid, success=False)
+        raise AssertionError(f"unexpected model_id {mid}")
+
+    mock_ledger = mock.MagicMock()
+    mock_sentinel = mock.MagicMock()
+    report = await run_preflight(
+        model_ids=("Qwen-397B", "Qwen-4B", "Qwen-35B", "Kimi"),
+        probe_fn=stub,
+        ledger=mock_ledger,
+        sentinel=mock_sentinel,
+        timeout_per_model_s=0.1,
+        halt_on_all_fail=False,
+    )
+    assert report.active_count == 1
+    assert report.demoted_entitlement_count == 1
+    assert report.degraded_5xx_count == 1
+    assert report.degraded_timeout_count == 1
+    assert report.all_failed is False  # at least one ACTIVE
+
+    # Ledger demote called exactly once for the entitlement-blocked model
+    assert mock_ledger.demote.call_count == 1
+    assert mock_ledger.demote.call_args.args[0] == "Qwen-4B"
+
+    # Sentinel report_failure called for BOTH 5xx and timeout (2 calls)
+    assert mock_sentinel.report_failure.call_count == 2
+    sentinel_model_ids = {
+        c.args[0] for c in mock_sentinel.report_failure.call_args_list
+    }
+    assert sentinel_model_ids == {"Qwen-35B", "Kimi"}


### PR DESCRIPTION
## Slice 25 — Autonomous Pre-Flight Health & Entitlement Sentinel

**Soak attribution**: `bt-2026-05-26-233010` (v18 — the DW upstream blackout that proved the gap)
**Builds on**: PR #59079 (Slice 24 sentinel transition schema → `2d96815523`)

### The observability gap

v18 churned 33 wall-clock minutes against an upstream DW tier where:
- Qwen-4B was 403-blocked ("blocked by a routing rule")
- Qwen-35B / Qwen-397B / Kimi-K2.6 all 5xx-errored or timed out
- Engine produced **0 candidates** despite Slice 23's fleet walker iterating all 4 models correctly

Per operator binding *"we do not let external dependency failures compromise system predictability"*, Slice 25 adds a boot-time orchestrator that probes the trusted fleet, routes outcomes to demotion/sentinel, and fail-fasts when every model is down.

### Composition discipline — 100% leverage of existing substrate

**No probe / classifier / ledger / sentinel logic is duplicated.** Audit found the primitives already shipped:

| Existing primitive | How Slice 25 uses it |
|---|---|
| `HeavyProber` (`dw_heavy_probe.py`) | Injected via `probe_fn` parameter (testable) |
| `dw_entitlement_classifier.classify_4xx` | Composed verbatim for 4xx branch — AST-pinned ban on duplicating marker matching |
| `PromotionLedger.demote` | Used unchanged; only delta is the new `QUARANTINE_ACCOUNT_NOT_ENTITLED` origin constant |
| `TopologySentinel.report_failure` | Slice 24's structural fields carry through |

### Closed verdict taxonomy (AST-pinned at 5)

| Verdict | Side-effect |
|---|---|
| `ACTIVE` | none (healthy) |
| `DEMOTED_ENTITLEMENT` | `ledger.demote(model_id, origin=QUARANTINE_ACCOUNT_NOT_ENTITLED)` (in-memory + on-disk) |
| `DEGRADED_5XX` | `sentinel.report_failure(LIVE_HTTP_5XX, status_code, response_body, is_terminal=False)` |
| `DEGRADED_TIMEOUT` | `sentinel.report_failure(LIVE_TRANSPORT, ...)` |
| `ERROR_OTHER` | recorded only (defensive — no eviction) |

### Concurrency + fail-fast

- `asyncio.gather` + per-probe `asyncio.wait_for(timeout_per_model_s)` (default 10s)
- Worst-case wall = `timeout_per_model_s` regardless of fleet size (parallel probes)
- All-fail + `halt_on_all_fail=True` (default) → `PreflightAllFailedError(report)` raised with structured diagnostic; caller emits clean halt
- All-fail + `halt_on_all_fail=False` → return report; caller branches on `report.all_failed`

### Verification

**12 tests** (3 AST pins + 9 spine), all passing:
- AST pins prevent: taxonomy drift / missing origin in valid set / classifier-marker duplication
- Spine covers every code path including the v18 scenario (4 models, 4 different verdicts) routing side-effects independently

**Surrounding regression**: **232/232 green** across:
- Slice 18c → 25 arc (102 tests)
- Entire existing `test_topology_sentinel.py` (60, untouched)
- Phase 10 graduation contract (32, preserved)
- Entire existing `test_dw_promotion_ledger.py` (38 — new origin integrated without breaking suite)

### What's NEXT (out of scope for Slice 25)

Slice 25 ships the **substrate**. The wiring decision is a follow-up:
1. **Wiring slice** — bind `HeavyProber.probe` → `ProbeOutcome` adapter + integrate into harness boot OR `candidate_generator` first-sentinel-activation. ~50 LOC, clean composition point.
2. **Graduation** — flip `JARVIS_PREFLIGHT_PROBE_ENABLED` default-true after v19 proves the probe yields actionable demotions without false-positives. Optionally extend with Slice 23's autonomous-activation pattern.

The substrate is locked in, AST-pinned, 232-test green. v19 detonation can now wire it whenever the operator authorizes the integration scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an autonomous pre-flight health and entitlement probe to validate the model fleet at boot. It demotes non‑entitled models, reports 5xx/timeout to the sentinel, and fail‑fasts when all models are down.

- **New Features**
  - New `backend/core/ouroboros/governance/preflight_probe.py` with `run_preflight(...)` to probe models concurrently with per-model timeouts (default 10s).
  - Composes `HeavyProber`, `dw_entitlement_classifier.classify_4xx`, `PromotionLedger.demote`, and `TopologySentinel.report_failure` (no duplicated logic).
  - Adds ledger origin `QUARANTINE_ACCOUNT_NOT_ENTITLED`; 403 entitlement-blocked models are demoted via ledger.
  - Raises `PreflightAllFailedError` when every model fails (configurable via `halt_on_all_fail`); otherwise returns a structured report.
  - Controlled by `JARVIS_PREFLIGHT_PROBE_ENABLED` (default false); knobs: `JARVIS_PREFLIGHT_TIMEOUT_PER_MODEL_S`, `JARVIS_PREFLIGHT_HALT_ON_ALL_FAIL`.

<sup>Written for commit 0bc651363177406ad038dcc71b9e8c879a83d92d. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/59080?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

