### PR TITLE
feat(governance): Slice 25B — pre-flight eager boot integration + autonomous graduation (v18 wedge closure)

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -4466,6 +4466,74 @@ class GovernedLoopService:
                     op_id,
                 )
 
+            # ────────────────────────────────────────────────────────
+            # Slice 25B Phase 2 — boot-eager preflight safety gate
+            # ────────────────────────────────────────────────────────
+            # Probe every trusted DW model in the PromotionLedger BEFORE
+            # the BackgroundAgentPool unblocks worker allocations. This
+            # is the operator-mandated fail-fast boundary: a network
+            # blackout or fleet-wide entitlement failure halts boot
+            # cleanly here rather than churning 30+ min of wall-clock
+            # via the dispatcher's exhaustion loops (v18 forensic:
+            # bt-2026-05-26-233010).
+            #
+            # Composition:
+            #   * Slice 25B Phase 4 auto-activates when
+            #     JARVIS_PROVIDER_CLAUDE_DISABLED=true (DW-only posture
+            #     makes preflight a hard architectural requirement).
+            #   * 403 entitlement → ledger.demote with origin=
+            #     account_not_entitled (persisted; future boots inherit
+            #     pre-filtered fleet).
+            #   * 5xx / timeout → sentinel.report_failure (breaker trips
+            #     toward OPEN).
+            #   * All-fail → PreflightAllFailedError propagates to
+            #     start()'s outer try/except → state=FAILED with
+            #     structured diagnostic (clean safe-exit per directive).
+            #
+            # The probe runs concurrently via asyncio.gather with per-
+            # probe asyncio.wait_for(10s) — worst-case wall is 10s
+            # regardless of fleet size.
+            try:
+                from backend.core.ouroboros.governance.preflight_probe import (
+                    run_boot_preflight,
+                    PreflightAllFailedError as _PreflightAllFailedError,
+                )
+                _preflight_report = await run_boot_preflight(
+                    dw_provider=self._doubleword_ref,
+                )
+                if _preflight_report is not None:
+                    logger.info(
+                        "[GLS] Slice 25B preflight: %s",
+                        _preflight_report.summary_line(),
+                    )
+            except _PreflightAllFailedError as _pf_exc:
+                # Output structured diagnostic to console (operator
+                # directive: "output the structured network diagnostic
+                # payload to the console") + re-raise for clean halt
+                # via the outer try/except → state=FAILED transition.
+                logger.error(
+                    "[GLS] Slice 25B preflight FAIL-FAST — halting boot. "
+                    "report=%s | per-model verdicts: %s",
+                    _pf_exc.report.summary_line(),
+                    ", ".join(
+                        f"{r.model_id}={r.verdict.value}"
+                        f"(status={r.status_code})"
+                        for r in _pf_exc.report.results
+                    ),
+                )
+                raise
+            except Exception as _pf_setup_exc:  # noqa: BLE001
+                # Defensive — preflight substrate failure must not
+                # block boot. Only PreflightAllFailedError above is
+                # the fail-fast contract; any OTHER exception (import
+                # error, missing ledger, etc.) gets swallowed with a
+                # warning so boot proceeds via legacy path.
+                logger.warning(
+                    "[GLS] Slice 25B preflight setup failure (boot continues "
+                    "via legacy path): %r",
+                    _pf_setup_exc,
+                )
+
             self._bg_pool = BackgroundAgentPool(
                 orchestrator=self._orchestrator,
                 on_op_active_register=_bg_register_active,

--- a/backend/core/ouroboros/governance/preflight_probe.py
+++ b/backend/core/ouroboros/governance/preflight_probe.py
@@ -222,8 +222,35 @@ def _envs(name: str, default: str) -> str:
 
 
 def is_preflight_enabled() -> bool:
-    """Master flag — read at every call so toggles take effect immediately."""
-    return _envb(_ENV_MASTER, default=False)
+    """Master flag — read at every call so toggles take effect immediately.
+
+    Slice 25B Phase 4 — autonomous activation via Slice 23 pattern:
+    when ``JARVIS_PROVIDER_CLAUDE_DISABLED=true`` is active (the DW-only
+    posture), preflight health-tracking is a hard architectural
+    requirement — not an optional feature. Operator-explicit values
+    still win (``=false`` rolls back even with Claude disabled, mirroring
+    Slice 23's branch-2 precedence).
+
+    Decision matrix (first-match-wins, mirrors Slice 23's structure):
+
+      1. ``JARVIS_PREFLIGHT_PROBE_ENABLED=true``  → True (explicit on)
+      2. ``JARVIS_PREFLIGHT_PROBE_ENABLED=false`` → False (explicit off)
+      3. ``JARVIS_PROVIDER_CLAUDE_DISABLED=true`` → True (Slice 19a posture)
+      4. default                                  → False
+    """
+    raw = os.environ.get(_ENV_MASTER, "").strip().lower()
+    if raw in ("1", "true", "yes", "on"):
+        return True
+    if raw in ("0", "false", "no", "off"):
+        return False
+    # Slice 25B Phase 4 — Slice 19a composition: DW-only posture requires
+    # pre-flight health tracking
+    claude_raw = os.environ.get(
+        "JARVIS_PROVIDER_CLAUDE_DISABLED", "",
+    ).strip().lower()
+    if claude_raw in ("1", "true", "yes", "on"):
+        return True
+    return False
 
 
 def _classify_outcome(outcome: ProbeOutcome) -> Tuple[
@@ -556,3 +583,267 @@ def _report_to_sentinel(
             "[Preflight] sentinel report_failure failed for %s: %r",
             outcome.model_id, exc,
         )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Slice 25B Phase 1 — HeavyProbe → ProbeOutcome adapter
+# ──────────────────────────────────────────────────────────────────────
+#
+# The substrate's ``probe_fn`` parameter is a Callable[[str],
+# Awaitable[ProbeOutcome]]. Production binds it to ``HeavyProber.probe``
+# via the adapter built here. The adapter:
+#
+#   1. Resolves the aiohttp session + base_url + api_key from the
+#      DoublewordProvider instance (no parallel session pool —
+#      reuses the provider's connection lifecycle).
+#   2. Invokes HeavyProber.probe(...) which returns HeavyProbeResult.
+#   3. Parses HeavyProbeResult.error string into structured
+#      ProbeOutcome fields (status_code / error_body / timeout) so
+#      ``_classify_outcome`` can route via the existing 5-branch
+#      verdict matrix without re-parsing.
+#
+# Error-string format reference (from dw_heavy_probe.py:_do_probe):
+#   * ``entitlement_blocked:<marker>:status_<N>`` — Task #86 structured
+#   * ``status_<N>:<body_text>`` — generic 4xx/5xx
+#   * ``ttft_timeout`` — first-token wait exceeded probe timeout
+#   * ``unhandled:<ExcType>:<msg>`` — unexpected; treat as transport
+#   * Other freeform tokens (``stream_closed_early`` etc.) — transport
+#
+# AST-pin invariant: the adapter MUST NOT re-implement entitlement
+# marker matching — when the structured ``entitlement_blocked:`` prefix
+# is present, the error_body carries the marker into ProbeOutcome
+# verbatim so dw_entitlement_classifier (composed in _classify_outcome)
+# does the marker matching on its own.
+
+
+def _parse_heavyprobe_error(
+    error_str: str,
+) -> Tuple[int, str, bool, str]:
+    """Pure-function parser for HeavyProbeResult.error string.
+
+    Returns ``(status_code, error_body, timeout, error_message)``.
+    ``status_code=0`` when the error format doesn't carry an HTTP status
+    (transport / unhandled). ``timeout=True`` for ttft_timeout.
+    ``error_body`` carries the response body excerpt OR the synthesized
+    entitlement marker (so dw_entitlement_classifier can re-detect on
+    the receiving side without re-parsing).
+    """
+    if not error_str:
+        return 0, "", False, ""
+    if error_str == "ttft_timeout":
+        return 0, "", True, "ttft_timeout"
+    if error_str.startswith("entitlement_blocked:"):
+        # entitlement_blocked:<marker>:status_<N>
+        # Body = marker (synthesized — preserves marker-based detection
+        # at the classifier without coupling to HeavyProbe's internal
+        # structured error format).
+        parts = error_str.split(":", 2)
+        marker = parts[1] if len(parts) >= 2 else ""
+        # status suffix
+        status = 0
+        if len(parts) >= 3 and parts[2].startswith("status_"):
+            try:
+                status = int(parts[2][7:])
+            except ValueError:
+                pass
+        return status, marker, False, error_str
+    if error_str.startswith("status_"):
+        # status_<N>:<body>
+        head, sep, body = error_str.partition(":")
+        try:
+            status = int(head[7:])
+        except ValueError:
+            status = 0
+        return status, body, False, error_str
+    # Transport / unhandled / unknown — status_code=0, no body
+    return 0, "", False, error_str
+
+
+def _heavyresult_to_outcome(result) -> ProbeOutcome:
+    """Adapter: HeavyProbeResult → ProbeOutcome (frozen, structured).
+
+    Used by ``build_heavyprobe_adapter`` to close over the per-probe
+    contract. Pure-function — testable independently of aiohttp.
+    """
+    if result.success:
+        return ProbeOutcome(
+            model_id=result.model_id,
+            success=True,
+            status_code=200,
+            latency_ms=int(result.ttft_ms or 0),
+        )
+    status_code, error_body, timeout, msg = _parse_heavyprobe_error(
+        result.error or "",
+    )
+    return ProbeOutcome(
+        model_id=result.model_id,
+        success=False,
+        status_code=status_code,
+        error_body=error_body,
+        latency_ms=int(result.total_latency_ms or 0),
+        timeout=timeout,
+        error_message=msg[:200],
+    )
+
+
+def build_heavyprobe_adapter(
+    dw_provider,
+    *,
+    prober_factory=None,
+) -> "Callable[[str], Awaitable[ProbeOutcome]]":
+    """Build a probe_fn closure suitable for ``run_preflight``.
+
+    Closes over the DoublewordProvider's session/base_url/api_key.
+    Tests can pass a custom ``prober_factory`` (zero-arg callable
+    returning a HeavyProber-compatible instance) to inject mock
+    probers without aiohttp.
+
+    The returned async function takes a model_id and returns a
+    ProbeOutcome. Never raises — HeavyProber.probe is documented
+    as never-raises; the adapter additionally catches at the
+    session-access layer (provider._get_session()) since that's
+    the one site that could surface a transport-level failure.
+    """
+    async def _probe(model_id: str) -> ProbeOutcome:
+        try:
+            session = await dw_provider._get_session()
+        except Exception as exc:  # noqa: BLE001 — defensive
+            return ProbeOutcome(
+                model_id=model_id,
+                success=False,
+                status_code=0,
+                error_message=(
+                    f"session_acquire_failed:{type(exc).__name__}:"
+                    f"{str(exc)[:120]}"
+                ),
+            )
+        # Lazy import — keeps preflight_probe substrate independent of
+        # dw_heavy_probe at module-import time.
+        if prober_factory is not None:
+            prober = prober_factory()
+        else:
+            from backend.core.ouroboros.governance.dw_heavy_probe import (
+                HeavyProber,
+            )
+            prober = HeavyProber()
+        try:
+            result = await prober.probe(
+                session=session,
+                model_id=model_id,
+                base_url=getattr(dw_provider, "_base_url", ""),
+                api_key=getattr(dw_provider, "_api_key", ""),
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive belt
+            return ProbeOutcome(
+                model_id=model_id,
+                success=False,
+                status_code=0,
+                error_message=(
+                    f"prober_raised:{type(exc).__name__}:{str(exc)[:120]}"
+                ),
+            )
+        return _heavyresult_to_outcome(result)
+
+    return _probe
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Slice 25B Phase 2 — boot-eager entry point
+# ──────────────────────────────────────────────────────────────────────
+
+
+async def run_boot_preflight(
+    *,
+    dw_provider,
+    prober_factory=None,
+) -> Optional[PreflightReport]:
+    """One-shot boot-eager preflight: composes the adapter + ledger +
+    sentinel + run_preflight. Designed to be called inline from
+    ``GovernedLoopService._build_components`` BEFORE BackgroundAgentPool
+    workers unblock.
+
+    Returns the PreflightReport on completion (whether all-pass or
+    partial-pass). Raises ``PreflightAllFailedError`` (propagated from
+    ``run_preflight``) when every probed model fails — caller's outer
+    ``try/except`` in ``GovernedLoopService.start`` handles the clean
+    halt via the existing FAILED-state transition.
+
+    Returns ``None`` (no exception) when:
+      * master flag is off → preflight skipped
+      * no trusted models promoted in the ledger → nothing to probe
+      * dw_provider is None → no DW substrate to probe against
+
+    Composes:
+      * ``is_preflight_enabled()`` — Slice 25B Phase 4 autonomous gate
+      * ``PromotionLedger.promoted_models()`` — what to probe
+      * ``build_heavyprobe_adapter(dw_provider)`` — probe_fn for run_preflight
+      * ``get_default_sentinel()`` — sentinel for DEGRADED side-effects
+      * ``run_preflight()`` — orchestrator (Slice 25 substrate)
+    """
+    if not is_preflight_enabled():
+        logger.debug(
+            "[Slice25B] preflight skipped: master flag off "
+            "(JARVIS_PREFLIGHT_PROBE_ENABLED + JARVIS_PROVIDER_CLAUDE_DISABLED both unset)"
+        )
+        return None
+    if dw_provider is None:
+        logger.warning(
+            "[Slice25B] preflight skipped: no DW provider in component stack"
+        )
+        return None
+
+    # Lazy imports — keeps preflight_probe acyclic
+    try:
+        from backend.core.ouroboros.governance.dw_promotion_ledger import (
+            PromotionLedger,
+        )
+        from backend.core.ouroboros.governance.topology_sentinel import (
+            get_default_sentinel,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.warning(
+            "[Slice25B] preflight skipped: substrate import failed: %r", exc,
+        )
+        return None
+
+    ledger = PromotionLedger()
+    try:
+        ledger.load()
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.warning(
+            "[Slice25B] preflight skipped: ledger.load() failed: %r", exc,
+        )
+        return None
+
+    model_ids = ledger.promoted_models()
+    if not model_ids:
+        logger.info(
+            "[Slice25B] preflight skipped: no promoted models in ledger "
+            "(trusted_seed not configured or all quarantined)"
+        )
+        return None
+
+    sentinel = get_default_sentinel()
+    probe_fn = build_heavyprobe_adapter(
+        dw_provider, prober_factory=prober_factory,
+    )
+
+    logger.info(
+        "[Slice25B] preflight starting: probing %d promoted models "
+        "(%s)", len(model_ids), ", ".join(model_ids),
+    )
+    # run_preflight raises PreflightAllFailedError when halt_on_all_fail
+    # is True (default). The exception propagates up to GLS.start's
+    # outer try/except which transitions state→FAILED with a clean
+    # diagnostic — exactly the "safe exit" the operator directive
+    # specifies for total-blackout.
+    report = await run_preflight(
+        model_ids=model_ids,
+        probe_fn=probe_fn,
+        ledger=ledger,
+        sentinel=sentinel,
+    )
+    logger.info(
+        "[Slice25B] preflight complete: %s", report.summary_line(),
+    )
+    return report

--- a/tests/governance/test_slice25b_preflight_boot_wiring.py
+++ b/tests/governance/test_slice25b_preflight_boot_wiring.py
@@ -1,0 +1,341 @@
+"""Slice 25B — Pre-Flight Eager Boot Integration & Graduation.
+
+Wires the Slice 25 substrate into GovernedLoopService boot via 4 phases:
+
+  Phase 1: HeavyProbeResult → ProbeOutcome adapter (build_heavyprobe_adapter
+           + _heavyresult_to_outcome + _parse_heavyprobe_error)
+  Phase 2: run_boot_preflight one-shot entry point + boot gate insertion
+           in _build_components BEFORE BackgroundAgentPool.start
+  Phase 3: 403 → ledger.demote + 5xx/timeout → sentinel.report_failure
+           + all-fail → PreflightAllFailedError clean halt
+  Phase 4: Autonomous activation — is_preflight_enabled returns True when
+           JARVIS_PROVIDER_CLAUDE_DISABLED=true (Slice 19a posture
+           composition, mirrors Slice 23's branch-3 pattern)
+
+# Test surface (3 AST pins + 10 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PF_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "preflight_probe.py"
+)
+GLS_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "governed_loop_service.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_phase4_autonomous_activation_via_slice19a() -> None:
+    """is_preflight_enabled MUST consult JARVIS_PROVIDER_CLAUDE_DISABLED
+    as an autonomous activation branch (Slice 19a composition).
+    Without this, the operator's "DW-only posture is hard architectural
+    requirement" contract is just env-flag hope."""
+    src = PF_FILE.read_text()
+    assert "Slice 25B Phase 4" in src, (
+        "preflight_probe missing Slice 25B Phase 4 attribution"
+    )
+    # The Slice 19a env var MUST appear inside is_preflight_enabled
+    tree = ast.parse(src, filename=str(PF_FILE))
+    is_enabled_body = ""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "is_preflight_enabled"
+        ):
+            is_enabled_body = ast.unparse(node)
+            break
+    assert is_enabled_body, "is_preflight_enabled not found"
+    assert "JARVIS_PROVIDER_CLAUDE_DISABLED" in is_enabled_body, (
+        "is_preflight_enabled missing Slice 19a autonomous activation — "
+        "DW-only sessions will silently skip preflight"
+    )
+
+
+def test_ast_pin_boot_gate_inserted_before_bg_pool_start() -> None:
+    """The Slice 25B boot gate MUST fire in _build_components BEFORE
+    BackgroundAgentPool.start. Without this ordering, workers unblock
+    against an unprobed fleet and the entire safety-gate guarantee
+    is moot."""
+    src = GLS_FILE.read_text()
+    assert "Slice 25B Phase 2" in src, (
+        "governed_loop_service missing Slice 25B Phase 2 attribution"
+    )
+    assert "run_boot_preflight" in src, (
+        "governed_loop_service missing run_boot_preflight call — wiring "
+        "incomplete"
+    )
+    # Ordering check: the preflight call site must come BEFORE
+    # `await self._bg_pool.start()`. We find both positions and
+    # assert preflight < bg_pool_start in source order.
+    pf_pos = src.find("run_boot_preflight(")
+    bg_pos = src.find("await self._bg_pool.start()")
+    assert pf_pos > 0 and bg_pos > 0, (
+        "could not locate both Slice 25B preflight and bg_pool.start"
+    )
+    assert pf_pos < bg_pos, (
+        "Slice 25B preflight gate is AFTER bg_pool.start — workers "
+        "unblock against unprobed fleet; gate is non-functional"
+    )
+
+
+def test_ast_pin_adapter_no_parallel_classifier_reimplementation() -> None:
+    """The HeavyProbe adapter MUST NOT re-implement entitlement marker
+    matching. The structured ``entitlement_blocked:`` prefix is parsed
+    out, and the marker is forwarded as ``error_body`` so the EXISTING
+    dw_entitlement_classifier (composed in _classify_outcome) does
+    the marker-match on the receiving side. Source-grep ban on the
+    classifier's marker strings in the adapter code."""
+    src = PF_FILE.read_text()
+    # The adapter section starts at "Slice 25B Phase 1"
+    phase1_marker = src.find("Slice 25B Phase 1 — HeavyProbe → ProbeOutcome")
+    assert phase1_marker > 0, "Phase 1 attribution header missing"
+    phase1_block = src[phase1_marker:phase1_marker + 6000]
+    # Banned: re-implementing classifier marker logic
+    banned = [
+        "contact your administrator",  # marker is classifier's job
+        "request access",
+        "from .dw_entitlement_classifier",  # adapter must not import
+    ]
+    for pat in banned:
+        assert pat not in phase1_block, (
+            f"Slice 25B adapter contains banned pattern {pat!r} — "
+            "duplicates classifier responsibility"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Phase 4 spine — 4
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_phase4_default_off(monkeypatch) -> None:
+    monkeypatch.delenv("JARVIS_PREFLIGHT_PROBE_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)
+    from backend.core.ouroboros.governance.preflight_probe import (
+        is_preflight_enabled,
+    )
+    assert is_preflight_enabled() is False
+
+
+def test_spine_phase4_claude_disabled_auto_activates(monkeypatch) -> None:
+    monkeypatch.delenv("JARVIS_PREFLIGHT_PROBE_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    from backend.core.ouroboros.governance.preflight_probe import (
+        is_preflight_enabled,
+    )
+    assert is_preflight_enabled() is True
+
+
+def test_spine_phase4_explicit_off_beats_claude_disabled(monkeypatch) -> None:
+    """Operator rollback wins — explicit off blocks even when Claude
+    is disabled. Mirrors Slice 23's branch-2 precedence."""
+    monkeypatch.setenv("JARVIS_PREFLIGHT_PROBE_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    from backend.core.ouroboros.governance.preflight_probe import (
+        is_preflight_enabled,
+    )
+    assert is_preflight_enabled() is False
+
+
+def test_spine_phase4_explicit_on_independent_of_claude(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_PREFLIGHT_PROBE_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)
+    from backend.core.ouroboros.governance.preflight_probe import (
+        is_preflight_enabled,
+    )
+    assert is_preflight_enabled() is True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Adapter spine — 4
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_parser_entitlement_blocked() -> None:
+    """The Task #86 structured prefix MUST parse status + carry the
+    marker into error_body so classifier re-detects it."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _parse_heavyprobe_error,
+    )
+    sc, body, timeout, msg = _parse_heavyprobe_error(
+        "entitlement_blocked:blocked by a routing rule:status_403"
+    )
+    assert sc == 403
+    assert "blocked by a routing rule" in body
+    assert timeout is False
+
+
+def test_spine_parser_status_4xx_5xx() -> None:
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _parse_heavyprobe_error,
+    )
+    assert _parse_heavyprobe_error("status_503:upstream timeout") == (
+        503, "upstream timeout", False, "status_503:upstream timeout",
+    )
+    assert _parse_heavyprobe_error("status_404:not found")[0] == 404
+
+
+def test_spine_parser_ttft_timeout() -> None:
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _parse_heavyprobe_error,
+    )
+    sc, body, timeout, msg = _parse_heavyprobe_error("ttft_timeout")
+    assert sc == 0
+    assert timeout is True
+
+
+def test_spine_heavyresult_to_outcome_success_path() -> None:
+    """HeavyProbeResult.success=True → ProbeOutcome.success=True
+    with status_code=200 + ttft_ms forwarded as latency_ms."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _heavyresult_to_outcome, ProbeOutcome,
+    )
+
+    @dataclass
+    class _FakeHeavyResult:
+        model_id: str = "Qwen-397B"
+        success: bool = True
+        ttft_ms: int = 420
+        total_latency_ms: int = 580
+        cost_usd: float = 0.00002
+        error: str = ""
+
+    outcome = _heavyresult_to_outcome(_FakeHeavyResult())
+    assert isinstance(outcome, ProbeOutcome)
+    assert outcome.success is True
+    assert outcome.status_code == 200
+    assert outcome.latency_ms == 420
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Boot-eager entry spine — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spine_boot_preflight_skips_when_master_off(monkeypatch) -> None:
+    """When master flag is off (default), run_boot_preflight returns
+    None without invoking any substrate."""
+    monkeypatch.delenv("JARVIS_PREFLIGHT_PROBE_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_boot_preflight,
+    )
+    # Pass a stub dw_provider — should never be touched
+    fake_provider = mock.MagicMock()
+    fake_provider._get_session = mock.AsyncMock(
+        side_effect=AssertionError("session should not be acquired"),
+    )
+    result = await run_boot_preflight(dw_provider=fake_provider)
+    assert result is None
+    assert not fake_provider._get_session.called
+
+
+@pytest.mark.asyncio
+async def test_spine_boot_preflight_composes_substrate_end_to_end(
+    monkeypatch, tmp_path,
+) -> None:
+    """End-to-end boot probe with injected prober_factory: master flag
+    on, fake DW provider, fake prober that returns mixed outcomes
+    (1 active, 1 entitlement, 1 5xx). Verifies the report shape +
+    side-effects route correctly."""
+    monkeypatch.setenv("JARVIS_PREFLIGHT_PROBE_ENABLED", "true")
+    # Use a tmpdir ledger so we don't touch real .jarvis state
+    monkeypatch.setenv("JARVIS_DW_PROMOTION_LEDGER_PATH", str(tmp_path / "ledger.json"))
+    # Seed via the canonical trusted-models env path (Slice 10B substrate)
+    monkeypatch.setenv(
+        "JARVIS_DW_TRUSTED_MODELS",
+        "Qwen-397B,Qwen-4B,Qwen-35B",
+    )
+    # Reset the default sentinel so we get fresh state
+    from backend.core.ouroboros.governance import topology_sentinel as ts_mod
+    monkeypatch.setattr(ts_mod, "_default_sentinel", None)
+
+    # Sanity-check: the trusted-seed path actually promoted these models
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger,
+    )
+    seed_ledger = PromotionLedger()
+    seed_ledger.load()
+    promoted = seed_ledger.promoted_models()
+    assert set(promoted) == {"Qwen-397B", "Qwen-4B", "Qwen-35B"}, (
+        f"Trusted-seed didn't promote expected set: got {promoted!r}"
+    )
+
+    # Fake DW provider with a session
+    fake_provider = mock.MagicMock()
+    fake_provider._get_session = mock.AsyncMock(return_value=mock.MagicMock())
+    fake_provider._base_url = "https://test.example/v1"
+    fake_provider._api_key = "test-key"
+
+    # Fake prober that returns different outcomes per model
+    class _FakeProber:
+        async def probe(self, *, session, model_id, base_url, api_key, **kw):
+            from backend.core.ouroboros.governance.dw_heavy_probe import (
+                HeavyProbeResult,
+            )
+            if model_id == "Qwen-397B":
+                return HeavyProbeResult(
+                    model_id=model_id, success=True,
+                    ttft_ms=300, total_latency_ms=500, cost_usd=0.00002,
+                )
+            if model_id == "Qwen-4B":
+                return HeavyProbeResult(
+                    model_id=model_id, success=False,
+                    ttft_ms=10000, total_latency_ms=200, cost_usd=0.0,
+                    error=(
+                        "entitlement_blocked:blocked by a routing rule:"
+                        "status_403"
+                    ),
+                )
+            if model_id == "Qwen-35B":
+                return HeavyProbeResult(
+                    model_id=model_id, success=False,
+                    ttft_ms=10000, total_latency_ms=800, cost_usd=0.00002,
+                    error="status_503:upstream",
+                )
+
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_boot_preflight,
+    )
+    report = await run_boot_preflight(
+        dw_provider=fake_provider,
+        prober_factory=_FakeProber,
+    )
+    assert report is not None
+    assert report.active_count == 1
+    assert report.demoted_entitlement_count == 1
+    assert report.degraded_5xx_count == 1
+    assert report.all_failed is False
+
+    # Verify the ledger now reflects the entitlement demotion (read fresh)
+    from backend.core.ouroboros.governance.dw_promotion_ledger import (
+        PromotionLedger, QUARANTINE_ACCOUNT_NOT_ENTITLED,
+    )
+    check = PromotionLedger()
+    check.load()
+    assert "Qwen-4B" not in check.promoted_models(), (
+        "Qwen-4B should be demoted after entitlement block — "
+        "side-effect persistence broken"
+    )
+    snap = check.snapshot("Qwen-4B")
+    assert snap is not None
+    assert snap.quarantine_origin == QUARANTINE_ACCOUNT_NOT_ENTITLED, (
+        f"Expected origin=account_not_entitled, got {snap.quarantine_origin!r}"
+    )


### PR DESCRIPTION
## Slice 25B — Pre-Flight Eager Boot Integration + Autonomous Graduation

**Soak attribution**: `bt-2026-05-26-233010` (v18 — the 33-min DW blackout)
**Builds on**: PR #59080 (Slice 25 preflight substrate → `83999fb207`)

Wires the Slice 25 substrate into `GovernedLoopService.start()` via 4 phases per operator directive. Closes the v18 observability gap end-to-end: a network blackout or fleet-wide entitlement failure now halts boot cleanly with a structured diagnostic INSTEAD of burning 33 minutes against doomed cascades.

### Phase 1 — HeavyProbe → ProbeOutcome adapter

Three new pure-function pieces in `preflight_probe.py`:
- `_parse_heavyprobe_error(error_str)` — parses 4 known `HeavyProbeResult.error` shapes
- `_heavyresult_to_outcome(result)` — frozen-record adapter
- `build_heavyprobe_adapter(dw_provider, *, prober_factory=None)` — async closure binding session/base_url/api_key. Tests inject `prober_factory` to swap mock probers without aiohttp.

**AST-pinned discipline**: adapter MUST NOT re-implement entitlement marker matching. The classifier (existing) does the marker work; adapter just forwards the marker as `error_body`.

### Phase 2 — boot-eager safety gate

New `async def run_boot_preflight(*, dw_provider, prober_factory=None)` orchestrator. Integration site: `governed_loop_service._build_components` INLINE BEFORE `BackgroundAgentPool.start`.

**AST pin** verifies source-order: preflight call site MUST appear before `bg_pool.start` in file order.

Try/except shape:
- `PreflightAllFailedError` → structured per-model diagnostic logged + re-raised (propagates to outer `try/except` → `ServiceState.FAILED` clean exit)
- Any OTHER exception → swallowed with warning (boot proceeds via legacy path — preflight failure must NOT block boot)

### Phase 3 — dynamic eviction & failure handling

Composes Slice 25 substrate side-effects:
- **403 entitlement** → `ledger.demote(model_id, origin=QUARANTINE_ACCOUNT_NOT_ENTITLED)` — persisted to disk; future boots inherit pre-filtered fleet. End-to-end test verifies persistence.
- **5xx / timeout** → `sentinel.report_failure(...)` with Slice 24's structural fields.
- **All-fail** → `PreflightAllFailedError` → "structured network diagnostic payload to the console" (operator directive).

### Phase 4 — autonomous activation (graduation)

`is_preflight_enabled()` now consults `JARVIS_PROVIDER_CLAUDE_DISABLED` as a structural autonomous trigger, mirroring Slice 23's decision-matrix pattern:

| # | Condition | Verdict |
|---|---|---|
| 1 | `JARVIS_PREFLIGHT_PROBE_ENABLED=true` | True (explicit on) |
| 2 | `JARVIS_PREFLIGHT_PROBE_ENABLED=false` | False (explicit off; rollback wins) |
| 3 | `JARVIS_PROVIDER_CLAUDE_DISABLED=true` | True (Slice 19a posture) |
| 4 | default | False |

Per operator directive: *"in a pure-DW world, pre-flight health tracking is a hard architectural requirement, not an optional feature."*

### What v19 will show

```
Boot post-Slice-25B with Claude disabled:
  1. _build_components() reaches DW provider construction (line 3443)
  2. PromotionLedger seeded with 4 trusted models (Slice 10B)
  3. Slice 25B boot gate fires (Phase 4 auto-on via claude_disabled branch)
  4. HeavyProber probes all 4 in parallel (max 10s wall)
     - 403 entitlement → ledger.demote (persisted) → future fleet pre-filtered
     - 5xx/timeout → sentinel.report_failure (breakers trip toward OPEN)
     - All-fail → PreflightAllFailedError → clean halt
  5. ONLY IF preflight passed (≥1 ACTIVE): bg_pool.start()
  6. Workers unblock against pre-filtered, health-verified fleet
```

v18 wedge sequence (33 min / $0.0084 / 0 candidates) becomes:
- **Best case**: preflight clears in 1s → soak proceeds with clean fleet
- **Worst case**: preflight all-fail in 10s → clean halt with structured diagnostic showing per-model verdicts → operator sees the upstream issue in 10s instead of 33 min

### Verification

**13 new tests** (3 AST pins + 10 spine), all passing.

**Surrounding regression**: **245/245 green** across:
- Slice 18c → 25B arc (115 tests)
- Entire existing `test_topology_sentinel.py` (60, untouched)
- Phase 10 graduation contract (32, preserved)
- Entire existing `test_dw_promotion_ledger.py` (38 — `QUARANTINE_ACCOUNT_NOT_ENTITLED` integrated without breaking suite)

**Operator's "232 spine compliance" target exceeded (245 ≥ 232).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a boot-time preflight gate in `GovernedLoopService` that probes trusted DW models before workers start. This fails fast on blackouts or entitlement blocks and prints a clear report instead of burning time on retries.

- **New Features**
  - Runs `run_boot_preflight(...)` before `BackgroundAgentPool.start()` to probe promoted models.
  - Adds a HeavyProber → `ProbeOutcome` adapter with error parsing (no entitlement-marker reimplementation).
  - Failure handling: 403 → demote via `PromotionLedger` with `QUARANTINE_ACCOUNT_NOT_ENTITLED` (persisted); 5xx/timeout → `topology_sentinel.report_failure`; all-fail → `PreflightAllFailedError` to cleanly halt; other exceptions warn and boot continues.
  - Autonomous activation: preflight auto-enables when `JARVIS_PROVIDER_CLAUDE_DISABLED=true`; `JARVIS_PREFLIGHT_PROBE_ENABLED` still overrides (true/false).

- **Migration**
  - In DW-only posture (`JARVIS_PROVIDER_CLAUDE_DISABLED=true`), preflight is on by default.
  - To disable, set `JARVIS_PREFLIGHT_PROBE_ENABLED=false`. No other changes required.

<sup>Written for commit 84cba36f79b7d3b361ce1a0dd34c3900b3bbd1b5. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/59081?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

