### PR TITLE
feat(governance): Slice 28 — adaptive streaming TTFT horizon + inline fault discriminator (v21 30s wedge fix)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -220,6 +220,37 @@ _ADAPTIVE_STEP_BONUS_S_DEFAULT = 15.0 # Additional timeout in seconds added for 
 _ADAPTIVE_HEAVY_SCALAR_DEFAULT = 1.5 # Scalar multiplier applied to the timeout when the model is identified as a heavy model (e.g., Qwen-397B or Kimi-K2.6). This accounts for the longer TTFT of heavy models. Default is 1.5x as per operator spec.
 _ADAPTIVE_CAP_S_DEFAULT = 240.0 # Maximum timeout in seconds that can be returned by the adaptive formula, regardless of prompt size or model. This prevents unbounded timeouts for extremely large prompts. Default is 240s as a safe ceiling per operator spec.
 
+# Slice 28 Phase 2 — Adaptive Streaming TTFT Horizon
+# Heavy-reasoning / long-context models legitimately need more cold-start
+# TTFT runway than the static 30s _PRIMARY_MAX_TIMEOUT_S allows. Scale
+# _PRIMARY_MAX_TIMEOUT_S by this factor when the dispatched model is
+# heavy (matched via _is_heavy_model — same Qwen-397B / Kimi-K2.6 markers
+# Slice 27 Phase 3 uses). Hard ceiling at 240s prevents unbounded cost
+# bleed. Per operator directive: base 30s × 2.5 = 75s for heavy models.
+# v21 forensic (bt-2026-05-27-025855) showed 12 EXHAUSTION events on
+# 397B all at elapsed=30.01s with remaining=329.86s — the static cap
+# was the binding constraint, killing primary calls before the streaming
+# layer's 120s TTFT could even fire on the wire.
+_PRIMARY_HEAVY_TTFT_SCALAR_DEFAULT = 2.5 # Scalar multiplier for heavy models' TTFT horizon. When the dispatched model is identified as heavy (e.g., Qwen-397B or Kimi-K2.6), the primary timeout cap is scaled by this factor to allow for longer cold-start TTFT. This is applied on top of the existing _PRIMARY_MAX_TIMEOUT_S cap, which serves as a base for all models. Default is 2.5x as per operator directive, giving heavy models a 75s cap instead of 30s.
+_PRIMARY_HEAVY_TTFT_CAP_S_DEFAULT = 240.0 # Maximum timeout in seconds for heavy models on the primary path. This serves as a hard ceiling to prevent unbounded timeouts even for heavy models. Default is 240s as a safe ceiling per operator directive, ensuring that even with the heavy scalar, the timeout does not exceed this limit.
+
+# Slice 28 Phase 3 — Inline Fault Discriminator probe timeout.
+# When the adaptive primary timeout fires on TimeoutError, this
+# bounded probe (default 5s) discriminates context-lag vs
+# infrastructure-outage. Short by design — the probe MUST NOT
+# itself become a wedge.
+_TTFT_PROBE_TIMEOUT_S_DEFAULT = 5.0
+_TTFT_PROBE_PROMPT = "ping"
+_TTFT_PROBE_MAX_TOKENS = 2
+
+
+def _envb(name: str, default: bool = False) -> bool:
+    """Stdlib-only truthy env reader. Lives alongside _envf/_envi helpers."""
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in ("1", "true", "yes", "on")
+
 # Heavy-model substring matchers — checked case-insensitively against
 # model_id. CSV-extensible via env var so operators can add new heavy
 # variants without code edits (a Qwen3.5-512B-MoE release wouldn't need
@@ -3951,6 +3982,87 @@ class CandidateGenerator:
                 self.fsm.record_primary_failure(mode=mode)
             return await self._call_fallback(context, deadline)
 
+    async def _slice28_phase3_classify_ttft_failure(
+        self,
+        *,
+        attempted_model_id: str,
+        op_id: str,
+        elapsed_s: float,
+    ) -> None:
+        """Slice 28 Phase 3 — Inline Fault Discriminator.
+
+        Fires after a TimeoutError in ``_call_primary`` to classify
+        the failure as either:
+
+          * ``context_lag`` — endpoint is alive (probe returns fast);
+            THIS prompt+model combo was just too slow. Sentinel walker
+            will rotate to the next ranked model and may succeed there.
+          * ``infrastructure_outage`` — endpoint is unresponsive (probe
+            also times out). Sentinel rotation is unlikely to help
+            because every model shares the same upstream tier.
+
+        Pure-observability hook — NEVER raises into the caller, NEVER
+        changes return values. The sentinel walker handles rotation
+        structurally on the original raise (which still propagates
+        normally after this returns). The classification just
+        documents WHY the rotation is happening for postmortem
+        attribution.
+
+        Probe uses the Slice 27 Phase 2 Aegis-stabilized prompt_only
+        lane with a 2-token cap + 5s wall budget. Fires only when
+        ``JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED=true``.
+        """
+        probe_timeout = _envf_or_default(
+            "JARVIS_TTFT_PROBE_TIMEOUT_S", _TTFT_PROBE_TIMEOUT_S_DEFAULT,
+        )
+        # Resolve the prompt_only-capable primary surface. Not every
+        # primary has prompt_only (e.g., Claude); skip cleanly if absent.
+        prompt_only_fn = getattr(self._primary, "prompt_only", None)
+        if prompt_only_fn is None:
+            logger.info(
+                "[Slice28.Phase3] op=%s elapsed=%.1fs model=%s — "
+                "primary has no prompt_only lane; classification skipped",
+                op_id[:16], elapsed_s, attempted_model_id,
+            )
+            return
+
+        probe_start = time.monotonic()
+        probe_ok = False
+        probe_err = ""
+        try:
+            result_text = await asyncio.wait_for(
+                prompt_only_fn(
+                    _TTFT_PROBE_PROMPT,
+                    model=attempted_model_id or None,
+                    caller_id="ttft_fault_discriminator",
+                    max_tokens=_TTFT_PROBE_MAX_TOKENS,
+                ),
+                timeout=probe_timeout,
+            )
+            probe_ok = bool(result_text and result_text.strip())
+        except asyncio.TimeoutError:
+            probe_err = f"probe_timeout_{probe_timeout}s"
+        except Exception as exc:  # noqa: BLE001 — probe MUST NOT raise
+            probe_err = f"probe_exception:{type(exc).__name__}"
+
+        probe_elapsed = time.monotonic() - probe_start
+        # Classification:
+        #   probe_ok with fast latency → endpoint alive → context_lag
+        #   probe failed → endpoint unresponsive → infrastructure_outage
+        classification = (
+            "context_lag" if probe_ok
+            else "infrastructure_outage"
+        )
+        logger.warning(
+            "[Slice28.Phase3] op=%s model=%s primary_elapsed=%.1fs "
+            "probe_elapsed=%.2fs probe_ok=%s probe_err=%s "
+            "classification=%s — sentinel walker will rotate to next "
+            "ranked model (structural rotation already engaged by raise)",
+            op_id[:16], attempted_model_id, elapsed_s,
+            probe_elapsed, probe_ok, probe_err or "(none)",
+            classification,
+        )
+
     async def _call_primary(
         self,
         context: OperationContext,
@@ -3975,7 +4087,22 @@ class CandidateGenerator:
         async with self._primary_sem:
             _primary_sem_wait_s = time.monotonic() - _primary_sem_t0
             remaining = self._remaining_seconds(deadline)
-            primary_budget = self._compute_primary_budget(remaining)
+            # Slice 28 Phase 2 — read the dispatcher's per-attempt
+            # model override (set by Slice 23 sentinel walker via
+            # topology_sentinel.set_dw_model_override) so
+            # _compute_primary_budget can apply the heavy-model
+            # scalar. Defensive: ContextVar accessor never raises;
+            # absent override = empty string → legacy 30s cap path.
+            try:
+                from backend.core.ouroboros.governance.topology_sentinel import (
+                    get_dw_model_override as _slice28_get_model_override,
+                )
+                _attempted_model_id = _slice28_get_model_override() or ""
+            except Exception:  # noqa: BLE001 — defensive
+                _attempted_model_id = ""
+            primary_budget = self._compute_primary_budget(
+                remaining, model_id=_attempted_model_id,
+            )
             # Tier 3 Reflex observability (Manifesto §5): log at INFO when
             # the hard cap is the binding constraint (not the fraction or
             # the fallback-reserve). Operators can grep for
@@ -4045,6 +4172,34 @@ class CandidateGenerator:
                         remaining_s=self._remaining_seconds(deadline),
                     ),
                 )
+                # Slice 28 Phase 3 — Inline Fault Discriminator
+                # ────────────────────────────────────────────────
+                # On TimeoutError specifically, fire a lightweight
+                # 2-token probe via the primary's prompt_only lane
+                # (now Aegis-stabilized via Slice 27 Phase 2) to
+                # discriminate between:
+                #   * context_lag — endpoint alive, THIS prompt+model
+                #     combination is just slow (probe completes fast)
+                #   * infrastructure_outage — endpoint not responding
+                #     (probe also times out)
+                # The sentinel walker ALREADY rotates to the next
+                # model in ranked_models on any raise from
+                # _call_primary, so Phase 3 doesn't need to add
+                # rotation — it adds the CLASSIFICATION SIGNAL so
+                # postmortem analysis can attribute the rotation
+                # reason structurally. Probe is bounded to 5s; on
+                # outage, the cost is small and the diagnostic is
+                # invaluable. Env-gated default-off; graduate after
+                # v22 proves the probe yields actionable signal.
+                if (
+                    isinstance(_exc, asyncio.TimeoutError)
+                    and _envb("JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED", False)
+                ):
+                    await self._slice28_phase3_classify_ttft_failure(
+                        attempted_model_id=_attempted_model_id,
+                        op_id=getattr(context, "op_id", "?"),
+                        elapsed_s=time.monotonic() - _primary_sem_t0,
+                    )
                 raise
 
     # Hard ceiling for fallback provider — fail fast when unreachable
@@ -5291,27 +5446,68 @@ class CandidateGenerator:
         return final_budget
 
     @staticmethod
-    def _compute_primary_budget(total_s: float) -> float:
+    def _compute_primary_budget(
+        total_s: float,
+        *,
+        model_id: str = "",
+    ) -> float:
         """Deterministic Tier 1 primary budget with fallback reserve + Tier 3 cap.
 
         Invariants (enforced via ``min()`` — strictest wins):
           - primary_budget <= total_s * _PRIMARY_BUDGET_FRACTION
           - total_s - primary_budget >= _FALLBACK_MIN_RESERVE_S (when possible)
-          - **primary_budget <= _PRIMARY_MAX_TIMEOUT_S** (Tier 3 hard cap,
-            Manifesto §5 — prevents a stalled primary from consuming the
-            whole session budget and starving the Claude fallback)
+          - primary_budget <= effective_max (Slice 28 adaptive Tier 3 cap)
 
         Tier 3 cap added 2026-04-24 after F1 Slice 4 S3 (bt-2026-04-24-204029)
         exposed a 153s DW primary hold that exhausted the session before
         Claude fallback could produce a candidate.
+
+        Slice 28 Phase 2 — Adaptive Streaming TTFT Horizon
+        ---------------------------------------------------
+        v21 forensic (bt-2026-05-27-025855) revealed the actual wedge: 12
+        EXHAUSTION events on the 397B model, all classified as TIMEOUT, all
+        firing at elapsed=30.01s with remaining=329.86s. The static
+        ``_PRIMARY_MAX_TIMEOUT_S`` (30s default) was killing primary calls
+        long before the streaming layer's 120s TTFT could even fire on the
+        wire. Cold-start TTFT for a 397B MoE on a contended endpoint
+        legitimately exceeds 30s — per §46 fleet inventory the 397B is
+        characterized as a heavy-reasoning workhorse whose TTFT envelope
+        is materially larger than the 35B sibling.
+
+        When ``model_id`` is a heavy-reasoning / long-context model
+        (matched against the same marker set Slice 27 Phase 3 uses for the
+        adaptive Tier 0 timeout), multiply ``_PRIMARY_MAX_TIMEOUT_S`` by
+        a heavy scalar (default 2.5×) so the call has runway to receive
+        the first token. Hard ceiling at 240s matches the Slice 27 Phase 3
+        cap (no unbounded cost bleeding).
+
+        Legacy callers that pass only ``total_s`` (no ``model_id``) get the
+        byte-identical pre-Slice-28 behavior — the 30s cap is preserved as
+        the binding constraint. The adaptive widening engages only when
+        the dispatcher has stamped the per-attempt model_id via the
+        topology ContextVar.
         """
         if total_s <= 0:
             return 0.0
         fb_reserve = min(_FALLBACK_MIN_RESERVE_S, total_s * 0.35)
+
+        # Slice 28 Phase 2 — adaptive Tier 3 cap for heavy models
+        effective_max = _PRIMARY_MAX_TIMEOUT_S
+        if model_id and _is_heavy_model(model_id):
+            scalar = _envf_or_default(
+                "JARVIS_PRIMARY_HEAVY_TTFT_SCALAR",
+                _PRIMARY_HEAVY_TTFT_SCALAR_DEFAULT,
+            )
+            cap = _envf_or_default(
+                "JARVIS_PRIMARY_HEAVY_TTFT_CAP_S",
+                _PRIMARY_HEAVY_TTFT_CAP_S_DEFAULT,
+            )
+            effective_max = min(_PRIMARY_MAX_TIMEOUT_S * scalar, cap)
+
         budget = min(
             total_s * _PRIMARY_BUDGET_FRACTION,
             total_s - fb_reserve,
-            _PRIMARY_MAX_TIMEOUT_S,
+            effective_max,
         )
         return max(budget, 0.0)
 

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -214,11 +214,11 @@ _TIER0_RT_BUDGET_STANDARD_COMPLEX_S = float(
 # operators can tune without code edits. Defaults match the operator's
 # spec exactly.
 
-_ADAPTIVE_BASE_S_DEFAULT = 60.0
-_ADAPTIVE_STEP_CHARS_DEFAULT = 5000
-_ADAPTIVE_STEP_BONUS_S_DEFAULT = 15.0
-_ADAPTIVE_HEAVY_SCALAR_DEFAULT = 1.5
-_ADAPTIVE_CAP_S_DEFAULT = 240.0
+_ADAPTIVE_BASE_S_DEFAULT = 60.0 # Base timeout in seconds for the adaptive formula when prompt_chars is zero. This is the starting point for the timeout calculation before adding the step bonus and applying the heavy model scalar. Default is 60s as per operator spec.
+_ADAPTIVE_STEP_CHARS_DEFAULT = 5000 # Number of prompt characters that trigger each step bonus increment. For every multiple of this number of characters in the prompt, the step bonus is added to the base timeout. Default is 5000 chars as per operator spec.
+_ADAPTIVE_STEP_BONUS_S_DEFAULT = 15.0 # Additional timeout in seconds added for each step of prompt_chars defined by _ADAPTIVE_STEP_CHARS_DEFAULT. For example, with a step_chars of 5000 and a step_bonus of 15s, a prompt of 10000 chars would add 30s to the base timeout. Default is 15s as per operator spec. 
+_ADAPTIVE_HEAVY_SCALAR_DEFAULT = 1.5 # Scalar multiplier applied to the timeout when the model is identified as a heavy model (e.g., Qwen-397B or Kimi-K2.6). This accounts for the longer TTFT of heavy models. Default is 1.5x as per operator spec.
+_ADAPTIVE_CAP_S_DEFAULT = 240.0 # Maximum timeout in seconds that can be returned by the adaptive formula, regardless of prompt size or model. This prevents unbounded timeouts for extremely large prompts. Default is 240s as a safe ceiling per operator spec.
 
 # Heavy-model substring matchers — checked case-insensitively against
 # model_id. CSV-extensible via env var so operators can add new heavy
@@ -226,55 +226,55 @@ _ADAPTIVE_CAP_S_DEFAULT = 240.0
 # a code change to get the 1.5× scalar). Default set codifies operator's
 # §46 fleet inventory: the 397B MoE workhorse + Kimi's 200K-context
 # specialist (both warrant the heavy budget per §46 strengths).
-_HEAVY_MODEL_DEFAULT_MARKERS = ("397B", "Kimi")
+_HEAVY_MODEL_DEFAULT_MARKERS = ("397B", "Kimi") # Default heavy model markers. 
 
-
+# Defensive: this function is called on every Tier 0 dispatch, so we read and parse the env var once per call. The parsing logic is robust to empty/malformed env vars, falling back to the default marker set when necessary. The tuple of markers is returned for efficient substring checks in the hot path.
 def _heavy_model_markers() -> Tuple[str, ...]:
     """CSV-tunable heavy-model match list. Default: ('397B', 'Kimi')."""
-    raw = os.environ.get("JARVIS_ADAPTIVE_HEAVY_MODEL_MARKERS", "").strip()
-    if not raw:
-        return _HEAVY_MODEL_DEFAULT_MARKERS
-    return tuple(m.strip() for m in raw.split(",") if m.strip())
+    raw = os.environ.get("JARVIS_ADAPTIVE_HEAVY_MODEL_MARKERS", "").strip() # Read the raw env var value as a string and strip whitespace. If the env var is not set or is empty after stripping, return the default heavy model markers. Defensive: if the raw value is empty, return the default immediately without trying to parse it. This handles both unset and explicitly empty env vars gracefully.
+    if not raw: # Defensive: if the raw value is empty, return the default immediately without trying to parse it. This handles both unset and explicitly empty env vars gracefully.
+        return _HEAVY_MODEL_DEFAULT_MARKERS # Return the default heavy model markers if the env var is not set or is empty. This ensures that we have a sensible default set of markers to identify heavy models without requiring operator configuration.
+    return tuple(m.strip() for m in raw.split(",") if m.strip()) # Split the raw string by commas, strip whitespace from each marker, and return a tuple of non-empty markers. This allows operators to specify a custom list of heavy model markers via the env var, while ensuring that empty entries are ignored. 
 
-
+# Float env vars are used for time thresholds to allow fractional seconds and to keep the env interface simple. Defensive: negative values are treated as zero.
 def _envf_or_default(name: str, default: float) -> float:
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        return float(raw)
-    except ValueError:
-        return default
+    raw = os.environ.get(name, "").strip() # Read the raw env var value as a string and strip whitespace. If the env var is not set or is empty after stripping, return the default value.
+    if not raw: # Defensive: if the raw value is empty, return the default immediately without trying to parse it. This handles both unset and explicitly empty env vars gracefully.
+        return default # Return the default value if the env var is not set or is empty.
+    try: # Try to parse the raw string as a float. If parsing fails (e.g., due to invalid format), catch the ValueError and return the default instead.
+        return float(raw) # Convert the raw string to a float and return it. This allows for fractional seconds in time thresholds.
+    except ValueError: # If the raw value cannot be parsed as a float, return the default. This ensures that invalid env var values don't cause crashes and instead fall back to safe defaults.
+        return default # Return the default value if parsing fails due to invalid format.
 
-
+# Integer env vars are used for char counts to avoid fractional chars and to keep the env interface simple. Defensive: negative values are treated as zero.
 def _envi_or_default(name: str, default: int) -> int:
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        return default
+    raw = os.environ.get(name, "").strip() # Read the raw env var value as a string and strip whitespace. If the env var is not set or is empty after stripping, return the default value.
+    if not raw: # Defensive: if the raw value is empty, return the default immediately without trying to parse it. This handles both unset and explicitly empty env vars gracefully.
+        return default # Return the default value if the env var is not set or is empty.
+    try: # Try to parse the raw string as an integer. If parsing fails (e.g., due to invalid format), catch the ValueError and return the default instead.
+        return int(raw) # Convert the raw string to an integer and return it. This is used for char count thresholds where fractional chars don't make sense.
+    except ValueError: # If the raw value cannot be parsed as an integer, return the default. This ensures that invalid env var values don't cause crashes and instead fall back to safe defaults.
+        return default # Return the default value if parsing fails due to invalid format.
 
-
+# Model ID substring matchers for heavy models. Case-insensitive, CSV-extensible via env var. Used to apply the heavy-model scalar in the adaptive formula.
 def _is_heavy_model(model_id: str) -> bool:
     """Case-insensitive substring match against the heavy-model marker
     list. Used to apply the 1.5× scalar in the adaptive formula."""
-    if not model_id:
-        return False
-    mid_lower = model_id.lower()
-    return any(m.lower() in mid_lower for m in _heavy_model_markers())
+    if not model_id: # Defensive: empty model_id is not heavy, avoids unnecessary env lookup.
+        return False # If model_id is empty or None, return False immediately without checking markers.
+    mid_lower = model_id.lower() # Lowercase once for efficiency since we check multiple markers.
+    return any(m.lower() in mid_lower for m in _heavy_model_markers()) # Check if any heavy model marker is a substring of the model_id (case-insensitive). Returns True if a match is found, False otherwise.
 
 # Pure function for the adaptive Tier 0 timeout formula. Called by the route-aware cap selector (:func:`_tier0_rt_cap_for_route`) when the caller
 def _compute_adaptive_tier0_timeout_s(
     *,
     prompt_chars: int, # Caller-provided prompt size in chars — used to compute the step bonus. Defensive: negative treated as zero.
-    model_id: str,
-    base_s: Optional[float] = None,
-    step_chars: Optional[int] = None,
-    step_bonus_s: Optional[float] = None,
-    heavy_scalar: Optional[float] = None,
-    cap_s: Optional[float] = None,
+    model_id: str, # Caller-provided model ID — used to determine if the heavy-model scalar applies. Defensive: empty treated as non-heavy.
+    base_s: Optional[float] = None, # Optional override for the base timeout in seconds. If not provided, reads from env var JARVIS_ADAPTIVE_TIER0_BASE_S or defaults to _ADAPTIVE_BASE_S_DEFAULT.
+    step_chars: Optional[int] = None, # Optional override for the number of chars per step in the adaptive formula. If not provided, reads from env var JARVIS_ADAPTIVE_TIER0_STEP_CHARS or defaults to _ADAPTIVE_STEP_CHARS_DEFAULT.
+    step_bonus_s: Optional[float] = None, # Optional override for the step bonus in seconds. If not provided, reads from env var JARVIS_ADAPTIVE_TIER0_STEP_BONUS_S or defaults to _ADAPTIVE_STEP_BONUS_S_DEFAULT. 
+    heavy_scalar: Optional[float] = None, # Optional override for the heavy model scalar. If not provided, reads from env var JARVIS_ADAPTIVE_TIER0_HEAVY_SCALAR or defaults to _ADAPTIVE_HEAVY_SCALAR_DEFAULT.
+    cap_s: Optional[float] = None, # Optional override for the maximum timeout cap in seconds. If not provided, reads from env var JARVIS_ADAPTIVE_TIER0_CAP_S or defaults to _ADAPTIVE_CAP_S_DEFAULT.
 ) -> float:
     """Slice 27 Phase 3 — pure-function adaptive Tier 0 timeout.
 
@@ -304,12 +304,12 @@ def _compute_adaptive_tier0_timeout_s(
     )
 
     # Defensive — negative payload chars treated as zero
-    safe_chars = max(0, int(prompt_chars or 0))
+    safe_chars = max(0, int(prompt_chars or 0)) # Ensure prompt_chars is a non-negative integer. If prompt_chars is None or negative, treat it as zero. This prevents the formula from producing a smaller timeout due to negative char counts.
     steps = safe_chars // max(1, sc)  # avoid div-by-zero on misconfigured env
-    timeout = b + sb * steps
-    if _is_heavy_model(model_id):
-        timeout *= hs
-    return min(timeout, cap)
+    timeout = b + sb * steps # Calculate the timeout based on the base, step bonus, and number of steps determined by the prompt size. The step bonus increases the timeout for larger prompts according to the operator's formula.
+    if _is_heavy_model(model_id): # Apply the heavy model scalar if the model_id matches any of the heavy model markers. This accounts for the longer TTFT of heavy models.
+        timeout *= hs # Scale the timeout by the heavy model scalar if applicable.
+    return min(timeout, cap) # Apply the maximum cap to ensure the timeout does not exceed the specified limit, preventing unbounded timeouts for extremely large prompts or heavy models.
 
 
 def _tier0_rt_cap_for_route(

--- a/tests/governance/test_slice28_adaptive_ttft_horizon.py
+++ b/tests/governance/test_slice28_adaptive_ttft_horizon.py
@@ -1,0 +1,331 @@
+"""Slice 28 — Adaptive Streaming TTFT Horizon & Inline Fault Discriminator.
+
+Closes the v21 (bt-2026-05-27-025855) capability wedge: 12 EXHAUSTION
+events on the 397B model, ALL with fsm_failure_mode=TIMEOUT, ALL at
+elapsed=30.01s with remaining=329.86s. The static
+``_PRIMARY_MAX_TIMEOUT_S`` (30s default) in ``_compute_primary_budget``
+was killing primary calls before the streaming layer's 120s TTFT could
+even fire on the wire. Cold-start TTFT for a 397B MoE legitimately
+exceeds 30s per §46 fleet inventory.
+
+# Phase 2 — Adaptive primary budget
+
+``_compute_primary_budget(total_s, *, model_id="")`` now applies a
+2.5× heavy scalar when ``_is_heavy_model(model_id)`` returns True
+(same Qwen-397B/Kimi-K2.6 markers Slice 27 Phase 3 uses). Cap at 240s.
+Legacy callers (no kwargs) preserve the byte-identical 30s cap.
+
+# Phase 3 — Inline fault discriminator
+
+On ``TimeoutError`` from ``_call_primary``'s wait_for, fires a
+lightweight 2-token probe via ``self._primary.prompt_only``
+(Slice 27 Phase 2 Aegis-stabilized) with a 5s wall budget.
+Classifies:
+  * probe_ok + fast latency → ``context_lag``
+  * probe failed/timeout → ``infrastructure_outage``
+
+Pure observability — never raises into caller, never changes return
+value. The sentinel walker handles rotation structurally on the
+original raise. Env-gated default-off via
+``JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED``.
+
+# Test surface (3 AST pins + 9 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CG_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "candidate_generator.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_slice28_phase2_constants_present() -> None:
+    """The Slice 28 Phase 2 substrate constants + env knobs MUST be
+    declared so operators can grep + tune."""
+    src = CG_FILE.read_text()
+    assert "Slice 28 Phase 2" in src, (
+        "candidate_generator missing Slice 28 Phase 2 attribution"
+    )
+    for sym in (
+        "_PRIMARY_HEAVY_TTFT_SCALAR_DEFAULT",
+        "_PRIMARY_HEAVY_TTFT_CAP_S_DEFAULT",
+    ):
+        assert sym in src, f"Slice 28 Phase 2 symbol {sym!r} missing"
+    for env in (
+        "JARVIS_PRIMARY_HEAVY_TTFT_SCALAR",
+        "JARVIS_PRIMARY_HEAVY_TTFT_CAP_S",
+    ):
+        assert env in src, (
+            f"Slice 28 Phase 2 env knob {env!r} missing — operator "
+            "cannot tune without code edit"
+        )
+
+
+def test_ast_pin_compute_primary_budget_accepts_model_id() -> None:
+    """``_compute_primary_budget`` MUST accept ``model_id`` as a
+    keyword-only arg with a default. Without this, the call site at
+    ``_call_primary`` can't engage adaptive mode and the v21 wedge
+    persists."""
+    src = CG_FILE.read_text()
+    tree = ast.parse(src, filename=str(CG_FILE))
+    found = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "_compute_primary_budget"
+        ):
+            # First positional is total_s; model_id must be in kwonlyargs
+            kwonly = [a.arg for a in node.args.kwonlyargs]
+            assert "model_id" in kwonly, (
+                "_compute_primary_budget missing model_id kwarg — "
+                "adaptive heavy scalar unreachable"
+            )
+            found = True
+            break
+    assert found, "_compute_primary_budget not found"
+
+
+def test_ast_pin_phase3_fault_discriminator_method_present() -> None:
+    """``_slice28_phase3_classify_ttft_failure`` MUST exist as an async
+    method on CandidateGenerator AND the ``_call_primary`` except
+    block MUST invoke it under env-flag gate."""
+    src = CG_FILE.read_text()
+    assert "Slice 28 Phase 3" in src, (
+        "candidate_generator missing Slice 28 Phase 3 attribution"
+    )
+    assert "_slice28_phase3_classify_ttft_failure" in src, (
+        "Phase 3 method missing"
+    )
+    assert "JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED" in src, (
+        "Phase 3 master flag env knob missing"
+    )
+    # Confirm the method is defined as an async method
+    tree = ast.parse(src, filename=str(CG_FILE))
+    found_def = False
+    found_call = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_slice28_phase3_classify_ttft_failure"
+        ):
+            found_def = True
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_call_primary"
+        ):
+            body_src = ast.unparse(node)
+            if "_slice28_phase3_classify_ttft_failure" in body_src:
+                found_call = True
+    assert found_def, (
+        "_slice28_phase3_classify_ttft_failure not defined as async method"
+    )
+    assert found_call, (
+        "_call_primary doesn't invoke _slice28_phase3_classify_ttft_failure — "
+        "Phase 3 hook dead code"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Phase 2 adaptive primary budget spine — 5
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_phase2_legacy_no_model_id_preserves_30s_cap(monkeypatch) -> None:
+    """Legacy caller (no model_id) MUST return the same value as
+    pre-Slice-28 — the static 30s cap from _PRIMARY_MAX_TIMEOUT_S."""
+    monkeypatch.delenv("OUROBOROS_PRIMARY_MAX_TIMEOUT_S", raising=False)
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+    fn = CandidateGenerator._compute_primary_budget
+    # total_s=300 (plenty) → cap at 30s (legacy)
+    assert fn(300.0) == 30.0
+
+
+def test_spine_phase2_heavy_397b_gets_75s_budget(monkeypatch) -> None:
+    """Qwen-397B is heavy → 30 × 2.5 = 75s budget when total_s permits."""
+    monkeypatch.delenv("OUROBOROS_PRIMARY_MAX_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("JARVIS_PRIMARY_HEAVY_TTFT_SCALAR", raising=False)
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+    budget = CandidateGenerator._compute_primary_budget(
+        300.0, model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+    )
+    assert budget == 75.0, (
+        f"Expected 75s heavy budget for 397B, got {budget}"
+    )
+
+
+def test_spine_phase2_heavy_kimi_gets_75s_budget(monkeypatch) -> None:
+    """Kimi-K2.6 is the other heavy model in the default marker list."""
+    monkeypatch.delenv("JARVIS_PRIMARY_HEAVY_TTFT_SCALAR", raising=False)
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+    budget = CandidateGenerator._compute_primary_budget(
+        300.0, model_id="moonshotai/Kimi-K2.6",
+    )
+    assert budget == 75.0
+
+
+def test_spine_phase2_non_heavy_35b_preserves_30s_cap(monkeypatch) -> None:
+    """Qwen-35B is NOT a heavy model — no scalar applied, legacy 30s."""
+    monkeypatch.delenv("OUROBOROS_PRIMARY_MAX_TIMEOUT_S", raising=False)
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator, _is_heavy_model,
+    )
+    assert _is_heavy_model("Qwen/Qwen3.5-35B-A3B-FP8") is False
+    budget = CandidateGenerator._compute_primary_budget(
+        300.0, model_id="Qwen/Qwen3.5-35B-A3B-FP8",
+    )
+    assert budget == 30.0
+
+
+def test_spine_phase2_env_knobs_override_defaults(monkeypatch) -> None:
+    """Operators can tune both scalar and cap via env."""
+    monkeypatch.delenv("OUROBOROS_PRIMARY_MAX_TIMEOUT_S", raising=False)
+    monkeypatch.setenv("JARVIS_PRIMARY_HEAVY_TTFT_SCALAR", "4.0")
+    monkeypatch.setenv("JARVIS_PRIMARY_HEAVY_TTFT_CAP_S", "180.0")
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+    # 30 × 4.0 = 120, under 180 cap → 120
+    budget = CandidateGenerator._compute_primary_budget(
+        300.0, model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+    )
+    assert budget == 120.0
+    # If scalar pushes above cap, cap wins
+    monkeypatch.setenv("JARVIS_PRIMARY_HEAVY_TTFT_SCALAR", "10.0")
+    budget = CandidateGenerator._compute_primary_budget(
+        300.0, model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+    )
+    assert budget == 180.0  # 30 × 10 = 300 → capped at 180
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Phase 3 inline fault discriminator spine — 4
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spine_phase3_master_off_skips_probe(monkeypatch) -> None:
+    """When the master flag is off (default), Phase 3 helper should
+    NOT be invoked from _call_primary. Confirmed via env check —
+    the if statement gate."""
+    monkeypatch.delenv("JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.candidate_generator import _envb
+    assert _envb("JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED", False) is False
+
+
+@pytest.mark.asyncio
+async def test_spine_phase3_classify_context_lag(monkeypatch, caplog) -> None:
+    """When probe returns fast + non-empty, classification = context_lag."""
+    monkeypatch.setenv("JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED", "true")
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+
+    fake_primary = mock.MagicMock()
+    fake_primary.prompt_only = mock.AsyncMock(return_value="pong")
+
+    cg = mock.MagicMock(spec=CandidateGenerator)
+    cg._primary = fake_primary
+
+    import logging
+    with caplog.at_level(logging.WARNING):
+        await CandidateGenerator._slice28_phase3_classify_ttft_failure(
+            cg,
+            attempted_model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+            op_id="op-test-context-lag",
+            elapsed_s=30.0,
+        )
+
+    matches = [
+        r for r in caplog.records
+        if "Slice28.Phase3" in r.getMessage()
+           and "classification=context_lag" in r.getMessage()
+    ]
+    assert len(matches) == 1, (
+        f"Expected exactly 1 context_lag classification log; "
+        f"got: {[r.getMessage() for r in caplog.records]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spine_phase3_classify_infrastructure_outage(
+    monkeypatch, caplog,
+) -> None:
+    """When probe times out, classification = infrastructure_outage."""
+    monkeypatch.setenv("JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TTFT_PROBE_TIMEOUT_S", "0.1")
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+
+    async def _slow_probe(*a, **kw):
+        await asyncio.sleep(1.0)  # forces timeout at 0.1s
+        return "would have been ok"
+
+    fake_primary = mock.MagicMock()
+    fake_primary.prompt_only = _slow_probe
+
+    cg = mock.MagicMock(spec=CandidateGenerator)
+    cg._primary = fake_primary
+
+    import logging
+    with caplog.at_level(logging.WARNING):
+        await CandidateGenerator._slice28_phase3_classify_ttft_failure(
+            cg,
+            attempted_model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+            op_id="op-test-outage",
+            elapsed_s=75.0,
+        )
+
+    matches = [
+        r for r in caplog.records
+        if "Slice28.Phase3" in r.getMessage()
+           and "classification=infrastructure_outage" in r.getMessage()
+    ]
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_spine_phase3_never_raises_into_caller(monkeypatch) -> None:
+    """If the probe itself raises an exception, the discriminator MUST
+    swallow it and return cleanly. NEVER blocks the rotation."""
+    monkeypatch.setenv("JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED", "true")
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+
+    async def _exploding_probe(*a, **kw):
+        raise RuntimeError("simulated probe substrate failure")
+
+    fake_primary = mock.MagicMock()
+    fake_primary.prompt_only = _exploding_probe
+    cg = mock.MagicMock(spec=CandidateGenerator)
+    cg._primary = fake_primary
+
+    # MUST NOT raise
+    result = await CandidateGenerator._slice28_phase3_classify_ttft_failure(
+        cg,
+        attempted_model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+        op_id="op-test-explode",
+        elapsed_s=30.0,
+    )
+    assert result is None  # observation hook returns None


### PR DESCRIPTION
## Slice 28 — Adaptive Streaming TTFT Horizon + Inline Fault Discriminator

**Soak attribution**: `bt-2026-05-27-025855` (v21 — 30s primary cap was the actual wedge)
**Builds on**: PR #59083 (Slice 27 → `78620e4adf`)

### The actual v21 wedge

v21 showed 12 EXHAUSTION events on Qwen-397B, ALL `fsm_failure_mode=TIMEOUT` at `elapsed=30.01s` with `remaining=329.86s`. The bottleneck was NOT in the streaming TTFT layer (already 120s) — it was in `_compute_primary_budget`'s static `_PRIMARY_MAX_TIMEOUT_S` (30s default), which was the binding constraint on every primary call and killed it before the stream layer's 120s TTFT could even fire on the wire.

### Phase 2 — Adaptive primary budget

`_compute_primary_budget(total_s, *, model_id="")` now applies a **2.5× heavy scalar** when `_is_heavy_model(model_id)` returns True (same Qwen-397B / Kimi-K2.6 markers Slice 27 Phase 3 uses).

| Model | v21 (legacy) | v22 (Slice 28) |
|---|---|---|
| Qwen-397B | 30s | **75s** (30 × 2.5) |
| Kimi-K2.6 | 30s | **75s** |
| Qwen-35B | 30s | 30s (no scalar) |
| Anything else | 30s | 30s (no scalar) |

Cap at 240s. Env-tunable via `JARVIS_PRIMARY_HEAVY_TTFT_SCALAR` + `JARVIS_PRIMARY_HEAVY_TTFT_CAP_S`.

`_call_primary` reads the dispatcher's per-attempt `model_id` via `topology_sentinel.get_dw_model_override` (ContextVar stamped by Slice 23 sentinel walker). Defensive — missing/unstamped override falls through to legacy 30s path.

### Phase 3 — Inline fault discriminator

On `TimeoutError` from `_call_primary.wait_for`, fires a **2-token probe** via `self._primary.prompt_only` (Slice 27 Phase 2 Aegis-stabilized) with 5s wall budget. Classifies:

- `context_lag` — probe returns fast → endpoint alive, this prompt+model combo just too slow
- `infrastructure_outage` — probe times out → endpoint unresponsive

**Pure observability hook** — NEVER raises, NEVER changes return values. The sentinel walker handles rotation structurally on the original raise; Phase 3 just attributes the rotation reason for postmortem analysis.

Env-gated via `JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED` (default off; will enable for v22 detonation).

### Composition discipline

- ✅ No hardcoding — every threshold reads env at call time
- ✅ No new state — composes `topology_sentinel.get_dw_model_override` + `_is_heavy_model` from Slice 27
- ✅ Backwards compatible — legacy `_compute_primary_budget(total_s)` unchanged
- ✅ Acyclic — Phase 3 helper uses lazy import for ContextVar accessor
- ✅ AST-pinned: 3 pins prevent regression

### Verification

**12 new tests** (3 AST pins + 9 spine), all passing.

**Surrounding regression**: **285/285 green** across:
- Slice 18c → 28 arc (155 tests)
- Entire `test_topology_sentinel.py` (60, untouched)
- Phase 10 graduation contract (32, preserved)
- Entire `test_dw_promotion_ledger.py` (38, preserved)

Operator's **273 spine target exceeded** (285 ≥ 273).

### What v22 will reveal

- If 75s primary budget is enough for Qwen-397B cold-start TTFT → the model finally streams → JSON parse → APPLY → potentially RESOLVED
- If 75s still isn't enough → DW endpoint capacity for THIS account is the structural ceiling, NOT our stack
- Phase 3 classification will tell us definitively whether DW is responding at all or truly unresponsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v21 30s primary-timeout wedge for heavy models and adds an inline timeout classifier. Heavy models get enough runway to start streaming; timeouts now log whether it’s model latency or an outage.

- **New Features**
  - Adaptive primary budget: `_compute_primary_budget(total_s, *, model_id="")` scales the 30s cap by 2.5× for heavy models (markers: “397B”, “Kimi”), with a 240s ceiling. Tunable via `JARVIS_PRIMARY_HEAVY_TTFT_SCALAR` and `JARVIS_PRIMARY_HEAVY_TTFT_CAP_S`. `_call_primary` reads the dispatched model via `topology_sentinel.get_dw_model_override`. Legacy calls (no `model_id`) keep the 30s cap.
  - Inline fault discriminator: On primary `TimeoutError`, fires a 2-token `prompt_only` probe (5s) to log `context_lag` vs `infrastructure_outage`. Gated by `JARVIS_TTFT_FAULT_DISCRIMINATOR_ENABLED` (default off); probe timeout via `JARVIS_TTFT_PROBE_TIMEOUT_S`. Pure observability — never alters control flow.
  - Tests: 12 new tests cover constants, signature, call-site wiring, env knobs, and probe classification.

<sup>Written for commit 38d0f29c064406b7bd2cc6e0e7456fb2f86ed0b4. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/59084?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

