### PR TITLE
feat(governance): Slice 29 — preflight backoff daemon (Shape A: inside preflight, 30→60→120→240→300s)

### DIFF
--- a/backend/core/ouroboros/governance/preflight_probe.py
+++ b/backend/core/ouroboros/governance/preflight_probe.py
@@ -216,6 +216,17 @@ def _envf(name: str, default: float) -> float:
         return default
 
 
+def _envi(name: str, default: int) -> int:
+    """Slice 29 — stdlib-only int env reader mirroring _envf/_envb shape."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
 def _envs(name: str, default: str) -> str:
     raw = os.environ.get(name, "").strip()
     return raw if raw else default
@@ -832,11 +843,41 @@ async def run_boot_preflight(
         "[Slice25B] preflight starting: probing %d promoted models "
         "(%s)", len(model_ids), ", ".join(model_ids),
     )
-    # run_preflight raises PreflightAllFailedError when halt_on_all_fail
-    # is True (default). The exception propagates up to GLS.start's
-    # outer try/except which transitions state→FAILED with a clean
-    # diagnostic — exactly the "safe exit" the operator directive
-    # specifies for total-blackout.
+    # Slice 29 — Preflight Backoff Daemon Execution
+    # ─────────────────────────────────────────────
+    # v22 forensic (bt-2026-05-27-034646): all 3 trusted DW models
+    # failed preflight at boot with status=0 transport blips. Static
+    # PreflightAllFailedError halted boot — but a transient upstream
+    # blackout is not a terminal condition; an un-killable background
+    # daemon should wait it out with exponential backoff.
+    #
+    # When JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED is on (default
+    # TRUE), the entire preflight gate becomes a polling loop:
+    #
+    #   * Run preflight (halt_on_all_fail=False so we get the report)
+    #   * If active_count >= 1 → recovery; return report (boot
+    #     proceeds normally to bg_pool.start())
+    #   * If active_count == 0 → log heartbeat, sleep backoff,
+    #     double backoff with 300s ceiling, retry
+    #
+    # GLS.start() awaits the entire daemon loop; bg_pool / sensors
+    # are not constructed until preflight succeeds. Functionally
+    # equivalent to "BG pool SUSPENDED" — no dispatches occur during
+    # the wait because nothing exists yet to dispatch.
+    #
+    # Operator opt-out: ``JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED=false``
+    # restores the byte-identical pre-Slice-29 fail-fast behavior.
+    if _is_recovery_daemon_enabled():
+        return await _run_preflight_with_recovery_daemon(
+            model_ids=model_ids,
+            probe_fn=probe_fn,
+            ledger=ledger,
+            sentinel=sentinel,
+        )
+
+    # Legacy path (daemon disabled) — preserves Slice 25B behavior
+    # byte-identically: PreflightAllFailedError raises on total
+    # blackout and propagates up to GLS.start's outer try/except.
     report = await run_preflight(
         model_ids=model_ids,
         probe_fn=probe_fn,
@@ -847,3 +888,117 @@ async def run_boot_preflight(
         "[Slice25B] preflight complete: %s", report.summary_line(),
     )
     return report
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Slice 29 — Preflight Backoff Daemon
+# ──────────────────────────────────────────────────────────────────────
+
+
+_ENV_DAEMON_ENABLED = "JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED"
+_ENV_DAEMON_BASE_S = "JARVIS_PREFLIGHT_DAEMON_BASE_BACKOFF_S"
+_ENV_DAEMON_MULTIPLIER = "JARVIS_PREFLIGHT_DAEMON_BACKOFF_MULTIPLIER"
+_ENV_DAEMON_MAX_BACKOFF_S = "JARVIS_PREFLIGHT_DAEMON_MAX_BACKOFF_S"
+_ENV_DAEMON_MAX_ATTEMPTS = "JARVIS_PREFLIGHT_DAEMON_MAX_ATTEMPTS"
+
+# Operator-specified defaults (Slice 29 directive):
+#   base=30s, multiplier=2.0, max_backoff=300s ceiling.
+# max_attempts=0 (unbounded) — defer to outer harness wall cap
+# (battle_test --max-wall-seconds). This is "un-killable background
+# asset" semantics — the daemon polls forever until either DW
+# recovers or the operator-bound session wall-clock fires.
+_DAEMON_BASE_BACKOFF_S_DEFAULT = 30.0
+_DAEMON_BACKOFF_MULTIPLIER_DEFAULT = 2.0
+_DAEMON_MAX_BACKOFF_S_DEFAULT = 300.0
+_DAEMON_MAX_ATTEMPTS_DEFAULT = 0  # 0 = unbounded
+
+
+def _is_recovery_daemon_enabled() -> bool:
+    """Master flag — default TRUE per Slice 29 operator binding
+    ("un-killable background asset")."""
+    return _envb(_ENV_DAEMON_ENABLED, default=True)
+
+
+async def _run_preflight_with_recovery_daemon(
+    *,
+    model_ids: Tuple[str, ...],
+    probe_fn,
+    ledger,
+    sentinel,
+) -> PreflightReport:
+    """Slice 29 — exponential-backoff polling loop wrapping run_preflight.
+
+    Loops with backoff sequence (default 30s → 60s → 120s → 240s → 300s
+    capped). Breaks the loop on the first iteration where active_count
+    >= 1. Emits a verbatim operator-attested heartbeat on every backoff
+    sleep so operators can grep for daemon activity.
+
+    Returns the recovery PreflightReport when ≥1 model probes ACTIVE.
+
+    Raises PreflightAllFailedError only if max_attempts is reached
+    without recovery (default unbounded — operator wall-clock is the
+    authoritative timeout).
+    """
+    base_s = _envf(_ENV_DAEMON_BASE_S, _DAEMON_BASE_BACKOFF_S_DEFAULT)
+    multiplier = _envf(_ENV_DAEMON_MULTIPLIER, _DAEMON_BACKOFF_MULTIPLIER_DEFAULT)
+    max_backoff_s = _envf(_ENV_DAEMON_MAX_BACKOFF_S, _DAEMON_MAX_BACKOFF_S_DEFAULT)
+    max_attempts = _envi(_ENV_DAEMON_MAX_ATTEMPTS, _DAEMON_MAX_ATTEMPTS_DEFAULT)
+
+    logger.info(
+        "[PreflightDaemon] starting recovery loop: base=%.0fs "
+        "multiplier=%.1fx max_backoff=%.0fs max_attempts=%s",
+        base_s, multiplier, max_backoff_s,
+        max_attempts if max_attempts > 0 else "unbounded",
+    )
+
+    current_backoff = base_s
+    attempt = 0
+    last_report: Optional[PreflightReport] = None
+
+    while True:
+        attempt += 1
+        # Run preflight with halt_on_all_fail=False so we get the
+        # report regardless of all-fail outcome. The recovery
+        # decision is OURS to make here, not the substrate's.
+        report = await run_preflight(
+            model_ids=model_ids,
+            probe_fn=probe_fn,
+            ledger=ledger,
+            sentinel=sentinel,
+            halt_on_all_fail=False,
+        )
+        last_report = report
+
+        if report.active_count >= 1:
+            # Slice 29 — operator-attested recovery message verbatim
+            # (AST-pinned by the regression suite)
+            logger.info(
+                "[PreflightDaemon] Upstream line recovery confirmed. "
+                "Un-pausing agent pool and executing delayed boot-strap "
+                "component initialization. attempt=%d active=%d total=%d",
+                attempt, report.active_count, report.total_probed,
+            )
+            logger.info(
+                "[Slice25B] preflight complete: %s", report.summary_line(),
+            )
+            return report
+
+        # All-fail — decide retry vs give-up
+        if max_attempts > 0 and attempt >= max_attempts:
+            logger.error(
+                "[PreflightDaemon] max_attempts=%d reached without "
+                "recovery; raising PreflightAllFailedError",
+                max_attempts,
+            )
+            raise PreflightAllFailedError(report)
+
+        # Slice 29 — operator-attested heartbeat verbatim
+        # (AST-pinned by the regression suite)
+        logger.warning(
+            "[PreflightDaemon] Active provider fleet empty. "
+            "Entering backoff cycle. Next probe attempt in %.0f seconds.",
+            current_backoff,
+        )
+        await asyncio.sleep(current_backoff)
+        # Exponential growth, capped
+        current_backoff = min(current_backoff * multiplier, max_backoff_s)

--- a/tests/governance/test_slice29_preflight_recovery_daemon.py
+++ b/tests/governance/test_slice29_preflight_recovery_daemon.py
@@ -1,0 +1,462 @@
+"""Slice 29 — Preflight Backoff Daemon (Inside Preflight, Shape A).
+
+Closes the v22 (bt-2026-05-27-034646) fragility: a transient
+status=0 transport blip across all 3 trusted DW models terminated
+boot via PreflightAllFailedError. True background daemon architectures
+wait out transient upstream congestion with exponential backoff.
+
+Per Slice 29 operator directive — Shape A (Daemon Inside Preflight):
+
+  When ``JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED=true`` (default
+  TRUE), ``run_boot_preflight`` wraps ``run_preflight`` in an
+  exponential-backoff polling loop. On every iteration:
+
+    * If ``active_count >= 1`` → break loop, log recovery, return
+    * If ``active_count == 0`` → log heartbeat, sleep backoff,
+      double backoff (capped at 300s)
+
+  Operator opt-out: ``=false`` restores byte-identical pre-Slice-29
+  fail-fast PreflightAllFailedError behavior.
+
+Operator-attested verbatim log messages (AST-pinned):
+  Heartbeat: "[PreflightDaemon] Active provider fleet empty.
+             Entering backoff cycle. Next probe attempt in X seconds."
+  Recovery:  "[PreflightDaemon] Upstream line recovery confirmed.
+             Un-pausing agent pool and executing delayed boot-strap
+             component initialization."
+
+# Test surface (3 AST pins + 9 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PF_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "preflight_probe.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_slice29_substrate_present() -> None:
+    """The Slice 29 substrate (helper + 5 env constants + 4 defaults)
+    MUST be in place."""
+    src = PF_FILE.read_text()
+    assert "Slice 29" in src, (
+        "preflight_probe missing Slice 29 attribution"
+    )
+    for sym in (
+        "_ENV_DAEMON_ENABLED",
+        "_ENV_DAEMON_BASE_S",
+        "_ENV_DAEMON_MULTIPLIER",
+        "_ENV_DAEMON_MAX_BACKOFF_S",
+        "_ENV_DAEMON_MAX_ATTEMPTS",
+        "_DAEMON_BASE_BACKOFF_S_DEFAULT",
+        "_DAEMON_BACKOFF_MULTIPLIER_DEFAULT",
+        "_DAEMON_MAX_BACKOFF_S_DEFAULT",
+        "_DAEMON_MAX_ATTEMPTS_DEFAULT",
+        "_is_recovery_daemon_enabled",
+        "_run_preflight_with_recovery_daemon",
+    ):
+        assert sym in src, f"Slice 29 symbol {sym!r} missing"
+    # Operator-spec defaults
+    assert "_DAEMON_BASE_BACKOFF_S_DEFAULT = 30.0" in src
+    assert "_DAEMON_BACKOFF_MULTIPLIER_DEFAULT = 2.0" in src
+    assert "_DAEMON_MAX_BACKOFF_S_DEFAULT = 300.0" in src
+
+
+def test_ast_pin_verbatim_heartbeat_and_recovery_messages() -> None:
+    """The operator-attested log messages MUST be present verbatim
+    inside ``_run_preflight_with_recovery_daemon`` body (AST-walk
+    string-literal join handles Python's compile-time concat)."""
+    src = PF_FILE.read_text()
+    tree = ast.parse(src, filename=str(PF_FILE))
+    body_src = ""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_run_preflight_with_recovery_daemon"
+        ):
+            body_src = ast.unparse(node)
+            break
+    assert body_src, (
+        "_run_preflight_with_recovery_daemon function not found"
+    )
+    # Operator-attested verbatim clauses — heartbeat
+    heartbeat_required = [
+        "Active provider fleet empty",
+        "Entering backoff cycle",
+        "Next probe attempt in",
+    ]
+    for clause in heartbeat_required:
+        assert clause in body_src, (
+            f"Heartbeat message missing operator clause: {clause!r}"
+        )
+    # Operator-attested verbatim clauses — recovery
+    recovery_required = [
+        "Upstream line recovery confirmed",
+        "Un-pausing agent pool",
+        "executing delayed boot-strap component initialization",
+    ]
+    for clause in recovery_required:
+        assert clause in body_src, (
+            f"Recovery message missing operator clause: {clause!r}"
+        )
+
+
+def test_ast_pin_run_boot_preflight_dispatches_to_daemon() -> None:
+    """``run_boot_preflight`` MUST dispatch to the daemon path when
+    ``_is_recovery_daemon_enabled()`` returns True. Without this
+    wiring, the daemon substrate is dead code."""
+    src = PF_FILE.read_text()
+    tree = ast.parse(src, filename=str(PF_FILE))
+    body_src = ""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "run_boot_preflight"
+        ):
+            body_src = ast.unparse(node)
+            break
+    assert body_src, "run_boot_preflight not found"
+    assert "_is_recovery_daemon_enabled" in body_src
+    assert "_run_preflight_with_recovery_daemon" in body_src
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Master flag spine — 2
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_master_flag_defaults_true(monkeypatch) -> None:
+    """Per operator directive ('un-killable background asset'), the
+    master flag defaults TRUE so v23+ inherits the daemon behavior
+    without needing explicit env setting."""
+    monkeypatch.delenv("JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _is_recovery_daemon_enabled,
+    )
+    assert _is_recovery_daemon_enabled() is True
+
+
+def test_spine_master_flag_explicit_off_disables_daemon(monkeypatch) -> None:
+    """Operator opt-out: ``=false`` restores legacy fail-fast path."""
+    monkeypatch.setenv("JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED", "false")
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _is_recovery_daemon_enabled,
+    )
+    assert _is_recovery_daemon_enabled() is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Backoff + recovery spine — 7
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spine_recovery_on_first_attempt_no_backoff(
+    monkeypatch, caplog,
+) -> None:
+    """When the first probe succeeds, daemon returns immediately
+    without sleeping. Verifies the fast-path (no upstream blip)."""
+    monkeypatch.setenv("JARVIS_PREFLIGHT_DAEMON_BASE_BACKOFF_S", "0.01")
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _run_preflight_with_recovery_daemon, ProbeOutcome,
+    )
+
+    async def stub(mid):
+        return ProbeOutcome(model_id=mid, success=True, status_code=200)
+
+    with caplog.at_level(logging.INFO):
+        report = await _run_preflight_with_recovery_daemon(
+            model_ids=("Qwen-397B",),
+            probe_fn=stub,
+            ledger=None,
+            sentinel=None,
+        )
+
+    assert report.active_count == 1
+    # NO heartbeat should fire (first attempt succeeded)
+    heartbeats = [
+        r for r in caplog.records
+        if "Active provider fleet empty" in r.getMessage()
+    ]
+    assert len(heartbeats) == 0, (
+        f"Heartbeat fired unexpectedly on first-attempt success: "
+        f"{len(heartbeats)}"
+    )
+    # Recovery message MUST fire
+    recoveries = [
+        r for r in caplog.records
+        if "Upstream line recovery confirmed" in r.getMessage()
+    ]
+    assert len(recoveries) == 1
+
+
+@pytest.mark.asyncio
+async def test_spine_recovery_after_two_backoff_cycles(
+    monkeypatch, caplog,
+) -> None:
+    """Operator-spec test: simulate transient blackout that clears
+    after 2 backoff steps. First 2 attempts fail (heartbeats fire);
+    3rd attempt succeeds (recovery fires + returns clean report)."""
+    monkeypatch.setenv("JARVIS_PREFLIGHT_DAEMON_BASE_BACKOFF_S", "0.05")
+    monkeypatch.setenv("JARVIS_PREFLIGHT_DAEMON_MAX_BACKOFF_S", "0.2")
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _run_preflight_with_recovery_daemon, ProbeOutcome,
+    )
+
+    attempt_count = {"n": 0}
+
+    async def stub(mid):
+        # Each call to run_preflight calls stub for each model.
+        # 1 model × 3 attempts: first 2 attempts fail, 3rd succeeds.
+        attempt_count["n"] += 1
+        succeed = attempt_count["n"] >= 3
+        return ProbeOutcome(
+            model_id=mid, success=succeed,
+            status_code=200 if succeed else 503,
+        )
+
+    with caplog.at_level(logging.INFO):
+        report = await _run_preflight_with_recovery_daemon(
+            model_ids=("Qwen-397B",),
+            probe_fn=stub,
+            ledger=None,
+            sentinel=None,
+        )
+
+    assert report.active_count == 1
+    # 2 heartbeats should fire (between attempts 1-2 and 2-3)
+    heartbeats = [
+        r for r in caplog.records
+        if "Active provider fleet empty" in r.getMessage()
+    ]
+    assert len(heartbeats) == 2, (
+        f"Expected 2 heartbeats for 2-cycle recovery, got {len(heartbeats)}"
+    )
+    # Exactly 1 recovery message
+    recoveries = [
+        r for r in caplog.records
+        if "Upstream line recovery confirmed" in r.getMessage()
+    ]
+    assert len(recoveries) == 1
+
+
+@pytest.mark.asyncio
+async def test_spine_exponential_backoff_sleep_progression(
+    monkeypatch,
+) -> None:
+    """Backoff doubles per cycle: 30 → 60 → 120 → 240 → 300 (capped)
+    at default settings. Verify by spying on asyncio.sleep durations."""
+    monkeypatch.delenv("JARVIS_PREFLIGHT_DAEMON_BASE_BACKOFF_S", raising=False)
+    monkeypatch.delenv("JARVIS_PREFLIGHT_DAEMON_MULTIPLIER", raising=False)
+    monkeypatch.delenv("JARVIS_PREFLIGHT_DAEMON_MAX_BACKOFF_S", raising=False)
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _run_preflight_with_recovery_daemon, ProbeOutcome,
+    )
+    # Spy on asyncio.sleep
+    sleep_durations: list = []
+    original_sleep = asyncio.sleep
+
+    async def spy_sleep(s):
+        sleep_durations.append(s)
+        await original_sleep(0)  # don't actually sleep
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.preflight_probe.asyncio.sleep",
+        spy_sleep,
+    )
+
+    attempt_count = {"n": 0}
+
+    async def stub(mid):
+        # Fail for 6 attempts, then succeed → 5 backoff cycles
+        attempt_count["n"] += 1
+        succeed = attempt_count["n"] >= 7
+        return ProbeOutcome(
+            model_id=mid, success=succeed,
+            status_code=200 if succeed else 503,
+        )
+
+    await _run_preflight_with_recovery_daemon(
+        model_ids=("Qwen-397B",),
+        probe_fn=stub,
+        ledger=None,
+        sentinel=None,
+    )
+
+    # Expected backoff sequence (6 sleeps for 6-fail-then-succeed
+    # on attempt 7): each failed attempt is followed by a sleep, so
+    # 6 failures → 6 sleeps; the 7th attempt succeeds without sleep.
+    # Doubling: 30 → 60 → 120 → 240 → 300 (cap) → 300 (still cap)
+    expected = [30.0, 60.0, 120.0, 240.0, 300.0, 300.0]
+    assert sleep_durations == expected, (
+        f"Backoff progression broken: expected {expected}, got {sleep_durations}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spine_backoff_ceiling_enforced(monkeypatch) -> None:
+    """The 300s ceiling MUST clamp — even after 10 doublings,
+    backoff stays at max_backoff_s."""
+    monkeypatch.setenv("JARVIS_PREFLIGHT_DAEMON_BASE_BACKOFF_S", "100")
+    monkeypatch.setenv("JARVIS_PREFLIGHT_DAEMON_MAX_BACKOFF_S", "150")
+    monkeypatch.setenv("JARVIS_PREFLIGHT_DAEMON_BACKOFF_MULTIPLIER", "10.0")
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _run_preflight_with_recovery_daemon, ProbeOutcome,
+    )
+
+    sleep_durations: list = []
+    original_sleep = asyncio.sleep
+
+    async def spy_sleep(s):
+        sleep_durations.append(s)
+        await original_sleep(0)
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.preflight_probe.asyncio.sleep",
+        spy_sleep,
+    )
+
+    attempt_count = {"n": 0}
+
+    async def stub(mid):
+        attempt_count["n"] += 1
+        succeed = attempt_count["n"] >= 5
+        return ProbeOutcome(
+            model_id=mid, success=succeed,
+            status_code=200 if succeed else 503,
+        )
+
+    await _run_preflight_with_recovery_daemon(
+        model_ids=("Qwen-397B",),
+        probe_fn=stub, ledger=None, sentinel=None,
+    )
+    # 4 sleeps; base=100, ×10 → 1000 → cap 150. So:
+    # First sleep: 100 (base). Then min(100×10, 150)=150 for all subsequent.
+    assert sleep_durations == [100.0, 150.0, 150.0, 150.0], (
+        f"Ceiling not enforced: {sleep_durations}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_spine_max_attempts_raises_preflight_all_failed(
+    monkeypatch,
+) -> None:
+    """When max_attempts is reached without recovery,
+    PreflightAllFailedError raises (operator-configured give-up)."""
+    monkeypatch.setenv("JARVIS_PREFLIGHT_DAEMON_BASE_BACKOFF_S", "0.01")
+    monkeypatch.setenv("JARVIS_PREFLIGHT_DAEMON_MAX_BACKOFF_S", "0.01")
+    monkeypatch.setenv("JARVIS_PREFLIGHT_DAEMON_MAX_ATTEMPTS", "3")
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _run_preflight_with_recovery_daemon, ProbeOutcome,
+        PreflightAllFailedError,
+    )
+
+    async def stub(mid):
+        return ProbeOutcome(model_id=mid, success=False, status_code=503)
+
+    with pytest.raises(PreflightAllFailedError) as excinfo:
+        await _run_preflight_with_recovery_daemon(
+            model_ids=("Qwen-397B",),
+            probe_fn=stub, ledger=None, sentinel=None,
+        )
+    # Report should reflect the final (all-fail) probe outcome
+    assert excinfo.value.report.all_failed is True
+
+
+@pytest.mark.asyncio
+async def test_spine_master_flag_off_preserves_legacy_fail_fast(
+    monkeypatch,
+) -> None:
+    """When daemon disabled, ``run_boot_preflight`` invokes
+    ``run_preflight`` with halt_on_all_fail=True, which raises
+    PreflightAllFailedError on all-fail. Byte-identical pre-Slice-29."""
+    monkeypatch.setenv("JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_PREFLIGHT_PROBE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", "Qwen-397B")
+    monkeypatch.setenv(
+        "JARVIS_DW_PROMOTION_LEDGER_PATH",
+        "/tmp/claude/test_slice29_legacy_ledger.json",
+    )
+    # Clean ledger
+    from pathlib import Path
+    Path("/tmp/claude/test_slice29_legacy_ledger.json").unlink(missing_ok=True)
+
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_boot_preflight, PreflightAllFailedError,
+    )
+
+    # Fake DW provider
+    fake_provider = mock.MagicMock()
+    fake_provider._get_session = mock.AsyncMock(return_value=mock.MagicMock())
+    fake_provider._base_url = "https://test.example/v1"
+    fake_provider._api_key = "test-key"
+
+    class _FailingProber:
+        async def probe(self, *, session, model_id, base_url, api_key, **kw):
+            from backend.core.ouroboros.governance.dw_heavy_probe import (
+                HeavyProbeResult,
+            )
+            return HeavyProbeResult(
+                model_id=model_id, success=False,
+                ttft_ms=10000, total_latency_ms=10000, cost_usd=0.0,
+                error="status_503:upstream blackout",
+            )
+
+    with pytest.raises(PreflightAllFailedError):
+        await run_boot_preflight(
+            dw_provider=fake_provider,
+            prober_factory=_FailingProber,
+        )
+
+
+@pytest.mark.asyncio
+async def test_spine_recovery_log_includes_attempt_count(
+    monkeypatch, caplog,
+) -> None:
+    """Recovery log line MUST carry the attempt counter so postmortem
+    can reconstruct how long the upstream blackout persisted."""
+    monkeypatch.setenv("JARVIS_PREFLIGHT_DAEMON_BASE_BACKOFF_S", "0.01")
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _run_preflight_with_recovery_daemon, ProbeOutcome,
+    )
+
+    attempt_count = {"n": 0}
+
+    async def stub(mid):
+        attempt_count["n"] += 1
+        succeed = attempt_count["n"] >= 4  # 3 fails, 4th succeeds
+        return ProbeOutcome(
+            model_id=mid, success=succeed,
+            status_code=200 if succeed else 503,
+        )
+
+    with caplog.at_level(logging.INFO):
+        await _run_preflight_with_recovery_daemon(
+            model_ids=("Qwen-397B",),
+            probe_fn=stub, ledger=None, sentinel=None,
+        )
+
+    recovery_msgs = [
+        r.getMessage() for r in caplog.records
+        if "Upstream line recovery confirmed" in r.getMessage()
+    ]
+    assert len(recovery_msgs) == 1
+    # attempt=4 since 3 failed + 4th succeeded
+    assert "attempt=4" in recovery_msgs[0], (
+        f"Recovery log missing attempt counter: {recovery_msgs[0]!r}"
+    )


### PR DESCRIPTION
## Slice 29 — Preflight Backoff Daemon (Shape A — Inside Preflight)

**Soak attribution**: `bt-2026-05-27-034646` (v22 — terminal halt on transient status=0 blip)
**Builds on**: PR #59084 (Slice 28 → `a79774ffdf`)

### The v22 fragility

v22 preflight hit status=0 transport blips across all 3 trusted DW models. `PreflightAllFailedError` correctly fired — but **a transient upstream blackout is not a terminal condition.** True background daemon architectures wait it out with exponential backoff.

### Architecture — Shape A authorized by operator

Per operator's clarification: *"True architectural clean-room design dictates that the engine's state should remain un-instantiated until environmental prerequisites are satisfied."*

`run_boot_preflight` wraps `run_preflight` in an exponential-backoff polling loop. GLS.start() awaits the entire daemon; BG pool / sensors aren't constructed until preflight succeeds.

```
GLS.start()
  → _build_components()
    → run_boot_preflight()
        ← polls every 30s → 60s → 120s → 240s → 300s (capped)
        ← detects 1 ACTIVE
        → returns report
    → bg_pool.start() (normal flow)
  → state=ACTIVE
```

### Backoff sequence (operator-attested defaults)

| Tunable | Default | Env |
|---|---|---|
| Base | 30s | `JARVIS_PREFLIGHT_DAEMON_BASE_BACKOFF_S` |
| Multiplier | 2.0× | `JARVIS_PREFLIGHT_DAEMON_BACKOFF_MULTIPLIER` |
| Max backoff | 300s (cap) | `JARVIS_PREFLIGHT_DAEMON_MAX_BACKOFF_S` |
| Max attempts | 0 (unbounded) | `JARVIS_PREFLIGHT_DAEMON_MAX_ATTEMPTS` |
| Master | TRUE | `JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED` |

Per "un-killable background asset" — max_attempts defaults to unbounded; the outer harness wall cap (`--max-wall-seconds`) is the authoritative timeout.

### §5 verbatim attestation messages (AST-pinned)

```
[PreflightDaemon] Active provider fleet empty. Entering backoff cycle.
                   Next probe attempt in X seconds.

[PreflightDaemon] Upstream line recovery confirmed. Un-pausing agent pool
                   and executing delayed boot-strap component initialization.
                   attempt=N active=M total=K
```

### Composition discipline

- ✅ No new state — composes existing `run_preflight` (with `halt_on_all_fail=False`)
- ✅ No hardcoding — all 5 thresholds env-tunable
- ✅ Backwards compatible — `JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED=false` restores byte-identical pre-Slice-29 fail-fast
- ✅ AST-pinned: 3 pins (substrate present / verbatim log messages / `run_boot_preflight` dispatches to daemon)
- ✅ Acyclic — daemon helper is module-internal, no new imports

### Verification

**12 new tests** (3 AST + 9 spine):
- AST pins: substrate symbols + env knobs + operator-spec defaults / verbatim log messages / dispatch wiring
- Master flag: defaults true / explicit-off restores legacy
- Recovery on first attempt → no backoff, no heartbeat
- Recovery after 2 backoff cycles (the operator-spec test)
- Exponential progression verified: 30 → 60 → 120 → 240 → 300 → 300 (capped)
- Ceiling enforced even with 10× multiplier
- max_attempts → PreflightAllFailedError raised
- Master-off → legacy fail-fast path
- Recovery log carries attempt counter for postmortem

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a preflight backoff daemon that retries with exponential backoff until at least one model is ACTIVE, so boot no longer halts on transient upstream outages. Enabled by default; legacy fail-fast is still available via a flag.

- **New Features**
  - Wraps `run_preflight` in a polling loop when `JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED=true` (default).
  - Backoff: 30 → 60 → 120 → 240 → 300s (cap). Tunables: `JARVIS_PREFLIGHT_DAEMON_BASE_BACKOFF_S`, `JARVIS_PREFLIGHT_DAEMON_BACKOFF_MULTIPLIER`, `JARVIS_PREFLIGHT_DAEMON_MAX_BACKOFF_S`, `JARVIS_PREFLIGHT_DAEMON_MAX_ATTEMPTS` (default `0` = unbounded).
  - Logs heartbeat on backoff and recovery on success (includes attempt count).
  - Backwards compatible: set `JARVIS_PREFLIGHT_RECOVERY_DAEMON_ENABLED=false` to restore pre-Slice-29 fail-fast.
  - Tests: 12 new cases cover defaults, backoff progression and cap, max-attempts give-up, daemon dispatch, and log messages.

<sup>Written for commit 5115058f1d44f5cd63ffe751df5d6050a1e74b10. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/59085?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

