### PR TITLE
feat(governance): Slice 31 — Aegis session-bearer lifecycle synchronization (v24 401 fix)

### DIFF
--- a/backend/core/ouroboros/governance/aegis_provider_bridge.py
+++ b/backend/core/ouroboros/governance/aegis_provider_bridge.py
@@ -205,6 +205,64 @@ def dw_aegis_base_url() -> str:
     )
 
 
+async def dw_session_auth_header() -> Dict[str, str]:
+    """Slice 31 — Aegis-aware Authorization header builder for DW HTTP calls.
+
+    Returns the ``Authorization`` header dict that must accompany
+    every outbound HTTP call to the DW endpoint (when routed through
+    Aegis). This is the **session bearer** the Aegis passthrough
+    endpoint requires (``passthrough.py:_bearer_session`` extracts
+    the token from ``Authorization: Bearer <token>``); it is NOT the
+    DW API key and NOT a per-call lease token.
+
+    Behavior matrix:
+
+    * **Aegis enabled** → ``{"Authorization": "Bearer <session_token>"}``
+      where ``session_token`` is fetched from ``AegisClient`` via the
+      cached session state (single ``/session/establish`` per process;
+      subsequent calls return the cached value with no daemon
+      round-trip). On Aegis client error: returns ``{}`` rather than
+      raising — defensive, lets the caller surface the real 401 from
+      the daemon if cred path is broken.
+    * **Aegis disabled** → ``{"Authorization": "Bearer <DOUBLEWORD_API_KEY>"}``
+      (byte-identical to legacy ``dw_authorization_header()`` non-Aegis
+      branch).
+
+    Why this is separate from ``dw_authorization_header()``: the
+    legacy sync helper returns ``{}`` for Aegis-enabled because
+    pre-Slice-31 the assumption was Aegis injects the bearer
+    SERVER-SIDE. v24 forensic (``bt-2026-05-27-183704``) showed the
+    daemon actually requires ``Authorization: Bearer <session_token>``
+    from the CLIENT at the passthrough layer (``missing_session_bearer``
+    401). Slice 31 closes the gap by fetching the session token via
+    this new async helper and including it in every outbound header.
+
+    Composition pattern at call sites::
+
+        auth_headers = await dw_session_auth_header()
+        lease = await acquire_call_lease(op_id=..., route=..., ...)
+        headers = merge_lease_into_session_headers(auth_headers, lease)
+        async with session.post(..., headers=headers) as resp:
+            ...
+    """
+    if aegis_client_mod.is_enabled():
+        try:
+            client = await aegis_client_mod.AegisClient.get()
+            token = await client._ensure_session_token()
+            return {"Authorization": _compose_bearer(token)}
+        except Exception:  # noqa: BLE001 — defensive
+            # Fallback to no Auth header — daemon will return its own
+            # structured 401 which the caller's existing error path
+            # surfaces. This is preferable to raising into the upload
+            # call site which would short-circuit observability.
+            return {}
+    # Aegis disabled — legacy path: real DW API key as Bearer
+    dw_key = os.environ.get("DOUBLEWORD_API_KEY", "").strip()
+    if not dw_key:
+        return {}
+    return {"Authorization": _compose_bearer(dw_key)}
+
+
 def dw_authorization_header() -> Dict[str, str]:
     """Return the Authorization header dict for the DW session.
 
@@ -214,6 +272,15 @@ def dw_authorization_header() -> Dict[str, str]:
     the Zero-Trust posture.
 
     When disabled: ``{"Authorization": "Bearer <DOUBLEWORD_API_KEY>"}``.
+
+    .. note::
+       Slice 31 — for Aegis-routed calls, this legacy sync helper
+       returns ``{}`` which is correct for the *DW Authorization*
+       header (Aegis daemon injects DW key server-side) but is
+       INSUFFICIENT for the *Aegis session bearer* the daemon
+       requires from the client. New code must use
+       :func:`dw_session_auth_header` (async) which returns the
+       session bearer when Aegis is enabled.
     """
     if aegis_client_mod.is_enabled():
         return {}

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -40,6 +40,7 @@ from backend.core.ouroboros.governance.aegis_provider_bridge import (
     acquire_call_lease as _aegis_acquire_call_lease,
     dw_aegis_base_url as _aegis_dw_base_url,
     dw_authorization_header as _aegis_dw_auth_header,
+    dw_session_auth_header as _aegis_dw_session_auth_header,
     merge_lease_into_session_headers as _aegis_merge_lease_headers,
 )
 from backend.core.ouroboros.governance.stream_rupture import (
@@ -681,6 +682,15 @@ class DoublewordProvider:
             # for byte-identical legacy behavior. Per-call X-JARVIS-Lease
             # is layered on at each session.post/get site (operator
             # correction #4 — never client-wide).
+            #
+            # Slice 31 — the Aegis SESSION BEARER (Authorization: Bearer
+            # <session_token>) is injected per-call via
+            # ``_aegis_dw_session_auth_header()`` at every outbound site,
+            # NOT at session creation. Rationale: session-bearer tokens
+            # have TTL + may rotate; per-call fetch reads cached state
+            # (no daemon round-trip in steady state) and avoids a stale
+            # baked-in token surviving across reconnects. Per-call
+            # headers override session headers in aiohttp.
             _session_headers = dict(_aegis_dw_auth_header())
             self._session = aiohttp.ClientSession(
                 headers=_session_headers,
@@ -1920,6 +1930,10 @@ class DoublewordProvider:
                 _ttft_request_start_monotonic = time.monotonic()
                 _ttft_first_chunk_seen = False
 
+                # Slice 31 — Aegis session bearer (closes v24
+                # missing_session_bearer 401 wedge on RT streaming).
+                _call_auth = await _aegis_dw_session_auth_header()
+                _call_auth["Content-Type"] = "application/json"
                 # Slice 2B-ii — per-call Aegis lease (None when disabled
                 # → header is skipped via merge helper).
                 _aegis_lease = await _aegis_acquire_call_lease(
@@ -1931,7 +1945,7 @@ class DoublewordProvider:
                     f"{self._base_url}/chat/completions",
                     json=body,
                     headers=_aegis_merge_lease_headers(
-                        {"Content-Type": "application/json"}, _aegis_lease,
+                        _call_auth, _aegis_lease,
                     ),
                     timeout=self._request_timeout(),
                 ) as resp:
@@ -2251,6 +2265,10 @@ class DoublewordProvider:
                             continue
             else:
                 # Non-streaming path
+                # Slice 31 — Aegis session bearer (closes v24
+                # missing_session_bearer 401 wedge).
+                _call_auth = await _aegis_dw_session_auth_header()
+                _call_auth["Content-Type"] = "application/json"
                 # Slice 2B-ii — per-call Aegis lease.
                 _aegis_lease = await _aegis_acquire_call_lease(
                     op_id=context.op_id,
@@ -2261,7 +2279,7 @@ class DoublewordProvider:
                     f"{self._base_url}/chat/completions",
                     json=body,
                     headers=_aegis_merge_lease_headers(
-                        {"Content-Type": "application/json"}, _aegis_lease,
+                        _call_auth, _aegis_lease,
                     ),
                     timeout=self._request_timeout(),
                 ) as resp:
@@ -2605,14 +2623,18 @@ class DoublewordProvider:
                 raise  # Let CircuitBreakerOpen propagate
 
         try:
-            # Slice 2B-ii — per-call Aegis lease + auth offload. When
-            # Aegis enabled: dw_authorization_header()=={} (server-side
-            # injection) + lease via X-JARVIS-Lease. When disabled:
-            # legacy Bearer header restored byte-identically.
+            # Slice 31 — Aegis-aware Authorization session bearer
+            # injection (closes v24 missing_session_bearer 401 wedge).
+            # When Aegis enabled: dw_session_auth_header() returns
+            # {"Authorization": "Bearer <session_token>"} — the bearer
+            # the Aegis passthrough endpoint requires for /files.
+            # When disabled: returns legacy DW API key Bearer header.
+            # Slice 2B-ii — per-call Aegis lease layered on top via
+            # _aegis_merge_lease_headers (X-JARVIS-Lease).
+            _call_headers = await _aegis_dw_session_auth_header()
             _aegis_lease = await _aegis_acquire_call_lease(
                 op_id=op_id, route="standard", estimated_cost_usd=0.001,
             )
-            _call_headers = dict(_aegis_dw_auth_header())
             _call_headers = _aegis_merge_lease_headers(
                 _call_headers, _aegis_lease,
             )
@@ -2653,6 +2675,9 @@ class DoublewordProvider:
                 raise  # Let CircuitBreakerOpen propagate
 
         try:
+            # Slice 31 — Aegis session bearer for /batches POST.
+            _call_auth = await _aegis_dw_session_auth_header()
+            _call_auth["Content-Type"] = "application/json"
             # Slice 2B-ii — per-call Aegis lease (None when disabled).
             _aegis_lease = await _aegis_acquire_call_lease(
                 op_id=op_id, route="standard", estimated_cost_usd=0.001,
@@ -2665,7 +2690,7 @@ class DoublewordProvider:
                     "completion_window": _DW_COMPLETION_WINDOW,
                 },
                 headers=_aegis_merge_lease_headers(
-                    {"Content-Type": "application/json"}, _aegis_lease,
+                    _call_auth, _aegis_lease,
                 ),
                 timeout=self._request_timeout(),
             ) as resp:
@@ -2761,6 +2786,8 @@ class DoublewordProvider:
                     except Exception:
                         raise  # Let CircuitBreakerOpen propagate
 
+                # Slice 31 — Aegis session bearer for /batches GET poll.
+                _call_auth = await _aegis_dw_session_auth_header()
                 # Slice 2B-ii — per-call Aegis lease.
                 _aegis_lease = await _aegis_acquire_call_lease(
                     op_id=op_id, route="background",
@@ -2768,7 +2795,7 @@ class DoublewordProvider:
                 )
                 async with session.get(
                     f"{self._base_url}/batches/{batch_id}",
-                    headers=_aegis_merge_lease_headers({}, _aegis_lease),
+                    headers=_aegis_merge_lease_headers(_call_auth, _aegis_lease),
                     timeout=self._request_timeout(),
                 ) as resp:
                     if self._rate_limiter is not None:
@@ -2832,6 +2859,8 @@ class DoublewordProvider:
                 raise  # Let CircuitBreakerOpen propagate
 
         try:
+            # Slice 31 — Aegis session bearer for /files retrieve.
+            _call_auth = await _aegis_dw_session_auth_header()
             # Slice 2B-ii — per-call Aegis lease bound to operation_id.
             _aegis_lease = await _aegis_acquire_call_lease(
                 op_id=operation_id, route="standard",
@@ -2839,7 +2868,7 @@ class DoublewordProvider:
             )
             async with session.get(
                 f"{self._base_url}/files/{output_file_id}/content",
-                headers=_aegis_merge_lease_headers({}, _aegis_lease),
+                headers=_aegis_merge_lease_headers(_call_auth, _aegis_lease),
                 timeout=self._request_timeout(),
             ) as resp:
                 if self._rate_limiter is not None:
@@ -3207,6 +3236,9 @@ class DoublewordProvider:
         t0 = time.monotonic()
 
         async def _do_request() -> Tuple[str, int, int]:
+            # Slice 31 — Aegis session bearer for sync complete().
+            _call_auth = await _aegis_dw_session_auth_header()
+            _call_auth["Content-Type"] = "application/json"
             # Slice 2B-ii — per-call Aegis lease bound to caller_id.
             _aegis_lease = await _aegis_acquire_call_lease(
                 op_id=f"dw-complete-sync:{caller_id}",
@@ -3217,7 +3249,7 @@ class DoublewordProvider:
                 f"{self._base_url}/chat/completions",
                 json=body,
                 headers=_aegis_merge_lease_headers(
-                    {"Content-Type": "application/json"}, _aegis_lease,
+                    _call_auth, _aegis_lease,
                 ),
                 timeout=self._request_timeout(),
             ) as resp:
@@ -3312,6 +3344,8 @@ class DoublewordProvider:
             return False
         try:
             session = await self._get_session()
+            # Slice 31 — Aegis session bearer for /models probe.
+            _call_auth = await _aegis_dw_session_auth_header()
             # Slice 2B-ii — per-call Aegis lease (synthetic infra op_id).
             _aegis_lease = await _aegis_acquire_call_lease(
                 op_id="dw-health-probe",
@@ -3320,7 +3354,7 @@ class DoublewordProvider:
             )
             async with session.get(
                 f"{self._base_url}/models",
-                headers=_aegis_merge_lease_headers({}, _aegis_lease),
+                headers=_aegis_merge_lease_headers(_call_auth, _aegis_lease),
                 timeout=self._request_timeout(),
             ) as resp:
                 return resp.status == 200

--- a/tests/governance/test_slice31_aegis_session_bearer.py
+++ b/tests/governance/test_slice31_aegis_session_bearer.py
@@ -1,0 +1,350 @@
+"""Slice 31 — Aegis Session-Bearer Lifecycle Synchronization.
+
+Closes the v24 (``bt-2026-05-27-183704``) upstream coordination
+roadblock surfaced by forensic audit: every outbound DW HTTP call
+through the Aegis passthrough returned ``401 missing_session_bearer``.
+
+# Root cause
+
+``aegis_provider_bridge.dw_authorization_header()`` (legacy sync) was
+returning ``{}`` whenever Aegis was enabled, on the now-falsified
+assumption that the Aegis daemon would inject the bearer
+server-side. The actual passthrough endpoint
+(``aegis/passthrough.py:_bearer_session``) extracts
+``Authorization: Bearer <session_token>`` from the *client* request;
+absent that header it returns 401 with
+``error="missing_session_bearer"``. Result: every /files upload,
+/batches POST, batches GET poll, /files retrieve, /chat/completions
+(streaming AND non-streaming), /models probe — all died at the gate
+without ever reaching DW.
+
+Per operator binding: "We do not compromise our security posture."
+The fix is bidirectional: the client MUST present a valid session
+bearer; the daemon MUST keep validating it.
+
+# Slice 31 substrate
+
+New async helper ``dw_session_auth_header()`` in
+``aegis_provider_bridge.py``:
+
+  * **Aegis enabled** → ``{"Authorization": "Bearer <session_token>"}``
+    where ``session_token`` comes from
+    ``AegisClient._ensure_session_token()`` (cached after first call).
+  * **Aegis disabled** → byte-identical to the legacy non-Aegis
+    branch: ``{"Authorization": "Bearer <DOUBLEWORD_API_KEY>"}``.
+  * On any Aegis client error → ``{}`` (defensive — caller's existing
+    401 path surfaces the real error rather than the helper raising
+    inside a critical transport path).
+
+# Slice 31 wiring (8 sites)
+
+Every outbound DW HTTP call site in ``doubleword_provider.py``
+composes the new helper BEFORE acquiring a per-call lease:
+
+  1. ``_streaming chat completions`` (RT path, ~line 1935)
+  2. ``_non-streaming chat completions`` (~line 2270)
+  3. ``_upload_file`` (multi-part /files POST, ~line 2634)
+  4. ``_create_batch`` (/batches POST, ~line 2679)
+  5. ``_await_batch_result`` (/batches GET poll, ~line 2790)
+  6. ``_retrieve_result`` (/files content GET, ~line 2863)
+  7. ``complete()`` sync chat completions (~line 3240)
+  8. ``health_probe`` (/models GET, ~line 3348)
+
+The per-call Aegis lease (``X-JARVIS-Lease``, Slice 2B-ii) layers
+on top via ``merge_lease_into_session_headers``. Per-call headers
+override session headers in aiohttp — session-level
+``_aegis_dw_auth_header()`` returning ``{}`` is fine; the per-call
+bearer takes precedence.
+
+# Test surface (4 AST pins + 7 spine)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BRIDGE_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "aegis_provider_bridge.py"
+)
+DW_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "doubleword_provider.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 4
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_dw_session_auth_header_helper_present() -> None:
+    """``dw_session_auth_header`` MUST be an async function defined
+    in ``aegis_provider_bridge.py``. Without it, none of the wiring
+    sites compile, and the v24 401 wedge re-opens."""
+    src = BRIDGE_FILE.read_text()
+    tree = ast.parse(src, filename=str(BRIDGE_FILE))
+    found = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "dw_session_auth_header"
+        ):
+            found = True
+            # Must accept zero positional args (helper signature)
+            assert len(node.args.args) == 0, (
+                "dw_session_auth_header must take no positional args"
+            )
+            break
+    assert found, (
+        "dw_session_auth_header missing from aegis_provider_bridge.py — "
+        "Slice 31 helper reverted; v24 401 wedge re-opens"
+    )
+    # Slice 31 attribution in raw source
+    assert "Slice 31" in src, (
+        "aegis_provider_bridge.py missing Slice 31 attribution"
+    )
+
+
+def test_ast_pin_doubleword_imports_session_auth_helper() -> None:
+    """``doubleword_provider`` MUST import the new helper via the
+    canonical alias ``_aegis_dw_session_auth_header``. Without the
+    import, no call site can compose it."""
+    src = DW_FILE.read_text()
+    tree = ast.parse(src, filename=str(DW_FILE))
+    imported = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module and "aegis_provider_bridge" in node.module:
+                for alias in node.names:
+                    if alias.name == "dw_session_auth_header":
+                        assert alias.asname == "_aegis_dw_session_auth_header", (
+                            "dw_session_auth_header must be imported as "
+                            "_aegis_dw_session_auth_header (canonical alias)"
+                        )
+                        imported = True
+                        break
+    assert imported, (
+        "doubleword_provider doesn't import dw_session_auth_header — "
+        "Slice 31 wiring incomplete; the 8 outbound sites can't compose it"
+    )
+
+
+def test_ast_pin_all_eight_outbound_sites_compose_session_bearer() -> None:
+    """Every async function in ``doubleword_provider`` that acquires
+    a per-call Aegis lease (``_aegis_acquire_call_lease``) MUST also
+    await ``_aegis_dw_session_auth_header()`` within the SAME
+    function body. The lease without the session bearer reproduces
+    the v24 401 wedge exactly."""
+    src = DW_FILE.read_text()
+    tree = ast.parse(src, filename=str(DW_FILE))
+    lease_funcs: list[str] = []
+    bearer_funcs: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef):
+            body = ast.unparse(node)
+            if "_aegis_acquire_call_lease" in body:
+                lease_funcs.append(node.name)
+            if "_aegis_dw_session_auth_header" in body:
+                bearer_funcs.append(node.name)
+    missing = set(lease_funcs) - set(bearer_funcs)
+    assert not missing, (
+        f"Slice 31 wiring incomplete — functions acquire a lease but "
+        f"never compose the session bearer: {sorted(missing)}. Each "
+        f"such function reproduces the v24 401 missing_session_bearer "
+        f"wedge on every call."
+    )
+    # Sanity: at least 5 such functions exist (we wired 8 sites across
+    # multiple top-level methods; lower bound generous against
+    # refactors).
+    assert len(lease_funcs) >= 5, (
+        f"Expected ≥5 lease-acquiring functions in doubleword_provider, "
+        f"found {len(lease_funcs)} — refactor may have collapsed sites; "
+        f"re-audit wiring."
+    )
+
+
+def test_ast_pin_legacy_helper_still_present_for_session_creation() -> None:
+    """Legacy ``dw_authorization_header`` (sync) MUST remain importable
+    in ``doubleword_provider`` — it's still used by ``_get_session``
+    for the aiohttp session-level header (returning ``{}`` under
+    Aegis is correct; per-call headers override). Removing it would
+    break legacy session construction."""
+    src = DW_FILE.read_text()
+    tree = ast.parse(src, filename=str(DW_FILE))
+    imported = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module and "aegis_provider_bridge" in node.module:
+                for alias in node.names:
+                    if alias.name == "dw_authorization_header":
+                        imported = True
+                        break
+    assert imported, (
+        "Legacy dw_authorization_header import dropped — _get_session "
+        "session-construction path broken"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 7
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_session_helper_returns_legacy_bearer_when_aegis_disabled() -> None:
+    """When Aegis is disabled (the legacy path), the helper MUST
+    return the DW API key as a Bearer — byte-identical to
+    ``dw_authorization_header()``'s non-Aegis branch. No regression
+    for operators who never enable Aegis."""
+    from backend.core.ouroboros.governance import aegis_provider_bridge
+
+    with mock.patch.object(
+        aegis_provider_bridge.aegis_client_mod,
+        "is_enabled",
+        return_value=False,
+    ), mock.patch.dict(
+        os.environ, {"DOUBLEWORD_API_KEY": "sk-test-legacy-key"},
+    ):
+        headers = asyncio.run(aegis_provider_bridge.dw_session_auth_header())
+        assert headers == {"Authorization": "Bearer sk-test-legacy-key"}
+
+
+def test_spine_session_helper_returns_empty_when_aegis_disabled_no_key() -> None:
+    """Aegis disabled + no DOUBLEWORD_API_KEY → empty dict. The
+    caller's existing transport path surfaces the credential error;
+    the helper does not raise into the upload site."""
+    from backend.core.ouroboros.governance import aegis_provider_bridge
+
+    with mock.patch.object(
+        aegis_provider_bridge.aegis_client_mod,
+        "is_enabled",
+        return_value=False,
+    ), mock.patch.dict(os.environ, {"DOUBLEWORD_API_KEY": ""}, clear=False):
+        # Clear the key explicitly (mock.patch.dict with empty string)
+        os.environ.pop("DOUBLEWORD_API_KEY", None)
+        try:
+            headers = asyncio.run(
+                aegis_provider_bridge.dw_session_auth_header()
+            )
+            assert headers == {}
+        finally:
+            os.environ["DOUBLEWORD_API_KEY"] = ""  # restore for other tests
+
+
+def test_spine_session_helper_fetches_session_token_when_aegis_enabled() -> None:
+    """Aegis enabled → helper MUST fetch the session token via
+    ``AegisClient._ensure_session_token()`` and return it as a
+    Bearer header. This is the v24 wedge fix."""
+    from backend.core.ouroboros.governance import aegis_provider_bridge
+
+    fake_client = mock.MagicMock()
+    fake_client._ensure_session_token = mock.AsyncMock(
+        return_value="session-token-abc123",
+    )
+
+    with mock.patch.object(
+        aegis_provider_bridge.aegis_client_mod,
+        "is_enabled",
+        return_value=True,
+    ), mock.patch.object(
+        aegis_provider_bridge.aegis_client_mod.AegisClient,
+        "get",
+        new=mock.AsyncMock(return_value=fake_client),
+    ):
+        headers = asyncio.run(aegis_provider_bridge.dw_session_auth_header())
+        assert headers == {"Authorization": "Bearer session-token-abc123"}
+        fake_client._ensure_session_token.assert_awaited_once()
+
+
+def test_spine_session_helper_returns_empty_when_aegis_client_raises() -> None:
+    """If the Aegis client raises (daemon down, network blip,
+    credential rotation in flight), the helper MUST swallow and
+    return ``{}``. Rationale: the existing 401 error path is the
+    operator-visible surface; raising inside the helper would
+    short-circuit observability."""
+    from backend.core.ouroboros.governance import aegis_provider_bridge
+
+    with mock.patch.object(
+        aegis_provider_bridge.aegis_client_mod,
+        "is_enabled",
+        return_value=True,
+    ), mock.patch.object(
+        aegis_provider_bridge.aegis_client_mod.AegisClient,
+        "get",
+        new=mock.AsyncMock(side_effect=RuntimeError("daemon down")),
+    ):
+        headers = asyncio.run(aegis_provider_bridge.dw_session_auth_header())
+        assert headers == {}
+
+
+def test_spine_legacy_dw_authorization_header_unchanged() -> None:
+    """The legacy sync helper ``dw_authorization_header`` retains
+    its byte-identical behavior — returns ``{}`` under Aegis (which
+    is correct for session-level headers, since per-call now
+    provides the bearer), returns Bearer-key without Aegis."""
+    from backend.core.ouroboros.governance import aegis_provider_bridge
+
+    with mock.patch.object(
+        aegis_provider_bridge.aegis_client_mod,
+        "is_enabled",
+        return_value=True,
+    ):
+        assert aegis_provider_bridge.dw_authorization_header() == {}
+
+    with mock.patch.object(
+        aegis_provider_bridge.aegis_client_mod,
+        "is_enabled",
+        return_value=False,
+    ), mock.patch.dict(
+        os.environ, {"DOUBLEWORD_API_KEY": "sk-legacy"},
+    ):
+        assert aegis_provider_bridge.dw_authorization_header() == {
+            "Authorization": "Bearer sk-legacy",
+        }
+
+
+def test_spine_helper_is_async() -> None:
+    """``dw_session_auth_header`` MUST be an async coroutine (the
+    AegisClient session-token fetch is async; a sync helper couldn't
+    await it). The legacy ``dw_authorization_header`` stays sync —
+    they are deliberately split."""
+    from backend.core.ouroboros.governance import aegis_provider_bridge
+
+    assert asyncio.iscoroutinefunction(
+        aegis_provider_bridge.dw_session_auth_header,
+    ), "dw_session_auth_header must be async — it fetches via AegisClient"
+    assert not asyncio.iscoroutinefunction(
+        aegis_provider_bridge.dw_authorization_header,
+    ), "legacy dw_authorization_header must remain sync (no breaking change)"
+
+
+def test_spine_compose_bearer_uses_canonical_helper() -> None:
+    """The helper MUST compose the bearer via ``_compose_bearer`` (the
+    same canonical helper the legacy path uses), guaranteeing
+    identical token formatting. Without this, the daemon's bearer
+    parser could fail on a malformed header."""
+    src = BRIDGE_FILE.read_text()
+    tree = ast.parse(src, filename=str(BRIDGE_FILE))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "dw_session_auth_header"
+        ):
+            body_src = ast.unparse(node)
+            # Two _compose_bearer calls expected (Aegis-enabled +
+            # legacy-fallback paths)
+            count = body_src.count("_compose_bearer")
+            assert count >= 2, (
+                f"dw_session_auth_header should use _compose_bearer in "
+                f"both paths (Aegis + legacy), found {count} call(s)"
+            )
+            return
+    pytest.fail("dw_session_auth_header not found in AST walk")


### PR DESCRIPTION
## Summary

Closes the v24 (`bt-2026-05-27-183704`) upstream coordination roadblock: every outbound DW HTTP call through the Aegis passthrough returned `401 missing_session_bearer`, blocking 397B/Kimi/every Slice 28+ adaptive-budget primary call before they could stream a single token.

## Root cause

`aegis_provider_bridge.dw_authorization_header()` (legacy sync) returned `{}` whenever Aegis was enabled, on the now-falsified assumption that the Aegis daemon would inject the bearer server-side. The passthrough endpoint (`aegis/passthrough.py:_bearer_session`) actually extracts `Authorization: Bearer <session_token>` from the *client* — absent that header it returns 401.

## Slice 31 substrate

New async helper `dw_session_auth_header()`:

  * **Aegis enabled** → `{"Authorization": "Bearer <session_token>"}` via cached `AegisClient._ensure_session_token()` (no daemon round-trip in steady state)
  * **Aegis disabled** → byte-identical legacy DW API key Bearer
  * **Aegis client error** → `{}` (defensive — the existing 401 path surfaces the real error)

## Slice 31 wiring (8 outbound sites)

Every lease-acquiring async function in `doubleword_provider.py` now composes the new helper BEFORE acquiring its per-call lease:

| # | Site | Endpoint |
|---|------|----------|
| 1 | RT streaming | `/chat/completions` |
| 2 | Non-streaming | `/chat/completions` |
| 3 | `_upload_file` | `/files` (multipart POST — **v24 401 site**) |
| 4 | `_create_batch` | `/batches` POST |
| 5 | `_await_batch_result` | `/batches/{id}` GET |
| 6 | `_retrieve_result` | `/files/{id}/content` GET |
| 7 | `complete()` sync | `/chat/completions` |
| 8 | `health_probe` | `/models` GET |

Per-call lease (X-JARVIS-Lease) layers on top via `merge_lease_into_session_headers`. Per-call headers override session headers in aiohttp.

## Why not session-level

Session bearer has TTL + may rotate. Per-call fetch reads cached state (zero round-trip steady-state) and avoids a stale token surviving across reconnects.

## Verification

| Suite | Result |
|-------|--------|
| Slice 31 (4 AST + 7 spine) | **11/11 green** |
| Slice 20+ + Aegis bridge baseline | **193/193 green** |
| Behaviour for Aegis-disabled operators | **byte-identical** |

## Composes

Slice 27 (auth bridge into `prompt_only`), Slice 28 (adaptive heavy-model TTFT), Slice 30 (explicit `model_id` threading). Without Slice 31, all three were structurally unreachable in production through the Aegis passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 401 missing_session_bearer for all Aegis-routed DW calls by sending the session bearer on every request. Adds an Aegis-aware auth helper and wires it into all outbound sites; behavior is unchanged when Aegis is off.

- **Bug Fixes**
  - Added async `dw_session_auth_header()` to return `Authorization: Bearer <session_token>` when Aegis is enabled, or the legacy DW API key when disabled; returns `{}` on Aegis client errors.
  - Injected this header per call across streaming and non‑streaming `/chat/completions`, `/files` upload/retrieve, `/batches` POST/GET, and `/models` probe; merged with per-call `X-JARVIS-Lease` via `merge_lease_into_session_headers`.
  - Kept session-level `dw_authorization_header()` behavior unchanged; bearer is not set at session creation to avoid stale tokens.
  - Added tests (AST pins + behavior) to enforce the new helper, verify all call sites are wired, and ensure Aegis-disabled behavior remains byte-identical.

<sup>Written for commit a5574ff36c989e35d80ed7f7f2e67ab3a7291bef. Summary will update on new commits. <a href="https://cubic.dev/pr/drussell23/JARVIS/pull/59096?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

