### PR TITLE
feat(governance): Slice 33 Arc 1 — Posture chunked-async + radar widening (v27 22.5s sink fix)

### DIFF
--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -655,6 +655,15 @@ class UnifiedIntakeRouter:
         - ``"pending_ack"``    — parked awaiting human acknowledgement
         - ``"backpressure"``   — queue is full; non-exempt source rejected
         """
+        # Slice 33 Arc 1+ widening — intake routing is on the hot path
+        # for every sensor signal; if it's slow, the loop notices.
+        from backend.core.ouroboros.telemetry.loop_sink import (
+            sink_async as _ls_sink_async,
+        )
+        async with _ls_sink_async("intake.UnifiedIntakeRouter.ingest"):
+            return await self._ingest_impl(envelope)
+
+    async def _ingest_impl(self, envelope: IntentEnvelope) -> str:
         # 1. Dedup check
         if self._is_duplicate(envelope):
             return "deduplicated"

--- a/backend/core/ouroboros/governance/posture_observer.py
+++ b/backend/core/ouroboros/governance/posture_observer.py
@@ -374,6 +374,9 @@ class SignalCollector:
             return 0
 
     def build_bundle(self) -> SignalBundle:
+        """Legacy sync entry — retained for backwards compatibility
+        with tests and any call-site that needs a synchronous bundle.
+        Production posture cycle uses :meth:`build_bundle_async`."""
         ratios = self.commit_ratios()
         base = baseline_bundle()
         return SignalBundle(
@@ -389,6 +392,92 @@ class SignalCollector:
             time_since_last_graduation_inv=self.time_since_last_graduation_inv(),
             cost_burn_normalized=self.cost_burn_normalized(),
             worktree_orphan_count=self.worktree_orphan_count(),
+            commit_window=commit_window(),
+            postmortem_window_h=postmortem_window_h(),
+            schema_version=base.schema_version,
+        )
+
+    async def build_bundle_async(self) -> SignalBundle:
+        """Slice 33 Arc 1 — chunked async signal collection.
+
+        Closes v27 (bt-2026-05-27-232749) sink: ``build_bundle`` ran 12
+        synchronous signal collectors sequentially in ONE
+        ``asyncio.to_thread`` call, holding the GIL for 22.56 s on a
+        cold session (LoopSink event_1). The fix: each collector runs
+        in its own ``asyncio.to_thread`` with explicit ``sleep(0)``
+        cooperative yields between them. Per-signal LoopSink wires
+        attribute heavy individual collectors so v28 surfaces them.
+
+        Each individual signal returns to the event loop in milliseconds
+        even under GIL contention — the 22.56 s monolithic block becomes
+        12 short hops, each yielding the loop a scheduling slot.
+        Operator binding: "true non-blocking asyncio primitives or
+        explicit chunked yielding". This is the explicit-chunked path.
+        """
+        import asyncio as _asyncio_ls  # noqa: WPS433 — local alias
+        from backend.core.ouroboros.telemetry.loop_sink import (
+            sink_async as _ls_sink_async,
+        )
+
+        # Literal callsite labels (not f-strings) so AST pins +
+        # production log greps see the exact string at the call site.
+        async with _ls_sink_async("posture.signal.commit_ratios"):
+            ratios = await _asyncio_ls.to_thread(self.commit_ratios)
+        await _asyncio_ls.sleep(0)
+
+        # The rest of the signals are typically sub-second, so we don't need individual 
+        # sinks for them — one sink wrapping the whole batch is sufficient to surface 
+        # them in the same cycle without overwhelming LoopSink with 12 separate events. 
+        # But we do want to yield between them to avoid blocking the loop, so we interleave 
+        # explicit sleeps.
+        async with _ls_sink_async("posture.signal.postmortem_failure_rate"):
+            # This is the heaviest collector (parsing + iterating over multiple 
+            # summary.json files) so it gets its own sink and label.
+            pm = await _asyncio_ls.to_thread(self.postmortem_failure_rate)
+        # Yield to the event loop before starting the next collector to ensure we don't 
+        # block it for too long.
+        await _asyncio_ls.sleep(0)
+
+        async with _ls_sink_async("posture.signal.iron_gate_reject_rate"):
+            ig = await _asyncio_ls.to_thread(self.iron_gate_reject_rate)
+        await _asyncio_ls.sleep(0)
+
+        async with _ls_sink_async("posture.signal.l2_repair_rate"):
+            l2 = await _asyncio_ls.to_thread(self.l2_repair_rate)
+        await _asyncio_ls.sleep(0)
+
+        async with _ls_sink_async("posture.signal.open_ops_normalized"):
+            oo = await _asyncio_ls.to_thread(self.open_ops_normalized)
+        await _asyncio_ls.sleep(0)
+
+        async with _ls_sink_async("posture.signal.session_lessons_infra_ratio"):
+            sl = await _asyncio_ls.to_thread(self.session_lessons_infra_ratio)
+        await _asyncio_ls.sleep(0)
+
+        async with _ls_sink_async("posture.signal.time_since_last_graduation_inv"):
+            ts = await _asyncio_ls.to_thread(self.time_since_last_graduation_inv)
+        await _asyncio_ls.sleep(0)
+
+        async with _ls_sink_async("posture.signal.cost_burn_normalized"):
+            cb = await _asyncio_ls.to_thread(self.cost_burn_normalized)
+        await _asyncio_ls.sleep(0)
+
+        async with _ls_sink_async("posture.signal.worktree_orphan_count"):
+            wo = await _asyncio_ls.to_thread(self.worktree_orphan_count)
+        base = baseline_bundle()
+        return SignalBundle(
+            feat_ratio=ratios["feat"],
+            fix_ratio=ratios["fix"],
+            refactor_ratio=ratios["refactor"],
+            test_docs_ratio=ratios["test_docs"],
+            postmortem_failure_rate=pm,
+            iron_gate_reject_rate=ig,
+            l2_repair_rate=l2,
+            open_ops_normalized=oo,
+            session_lessons_infra_ratio=sl,
+            time_since_last_graduation_inv=ts,
+            cost_burn_normalized=cb,
+            worktree_orphan_count=wo,
             commit_window=commit_window(),
             postmortem_window_h=postmortem_window_h(),
             schema_version=base.schema_version,
@@ -777,15 +866,22 @@ class PostureObserver:
         return to_persist
 
     async def _collect_with_timeout(self) -> Optional[SignalBundle]:
-        """Run the synchronous collector with a timeout guard.
+        """Run the collector with a timeout guard.
 
-        Collectors are IO-bound (subprocess / file read); wrap in
-        ``asyncio.to_thread`` + ``wait_for`` so one slow collector can't
-        freeze the observer loop.
+        Slice 33 Arc 1 (v27 LoopSink-confirmed fix): uses the
+        chunked-async ``build_bundle_async()`` which dispatches each
+        of the 12 individual signal collectors via separate
+        ``asyncio.to_thread`` calls with explicit cooperative yields
+        between them. Closes the 22.56 s monolithic GIL hold v27
+        named as the dominant on-loop sink.
+
+        Legacy synchronous ``build_bundle`` path is preserved on the
+        collector for backwards compatibility but no longer used in
+        the production cycle.
         """
         try:
             return await asyncio.wait_for(
-                asyncio.to_thread(self._collector.build_bundle),
+                self._collector.build_bundle_async(),
                 timeout=collector_timeout_s(),
             )
         except asyncio.TimeoutError:

--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -1384,6 +1384,18 @@ class OracleSemanticIndex:
         On timeout / exception → ``status=DEGRADED``. Queries
         return empty without raising. Idempotent — subsequent calls
         return the cached status."""
+        # Slice 33 Arc 1+ widening — ChromaDB lazy init is a known
+        # bootstrap-phase heavyweight; instrument so we know exactly
+        # how much loop time it costs even with the executor wrapper.
+        from backend.core.ouroboros.telemetry.loop_sink import (
+            sink_async as _ls_sink_async,
+        )
+        async with _ls_sink_async(
+            "oracle.OracleSemanticIndex.initialize_backend",
+        ):
+            return await self._initialize_backend_impl()
+
+    async def _initialize_backend_impl(self) -> "OracleSemanticBackendStatus":
         if self._init_attempted:
             return self._status
         if self._init_lock is None:

--- a/tests/governance/test_slice33_arc1_posture_chunked_async.py
+++ b/tests/governance/test_slice33_arc1_posture_chunked_async.py
@@ -1,0 +1,310 @@
+"""Slice 33 Arc 1 — Posture Observer chunked-async signal collection.
+
+Closes the v27 (``bt-2026-05-27-232749``) LoopSink-confirmed sink:
+``[LoopSink] callsite=posture_observer.run_one_cycle kind=async
+blocked_ms=22560.30`` — the 22.56 second cold-session block dwarfed
+every other on-loop event by an order of magnitude.
+
+# Root cause
+
+``SignalCollector.build_bundle()`` ran 12 sync signal collectors
+sequentially inside ONE ``asyncio.to_thread`` call. Each collector
+performs sync I/O (git subprocess, session-dir iteration, file
+reads). The whole bundle = one monolithic worker-thread block;
+under GIL contention the asyncio main thread starved.
+
+# Slice 33 Arc 1 fix
+
+New ``SignalCollector.build_bundle_async()`` — same SignalBundle
+return shape, but each of the 9 individual signal collectors is
+dispatched in its own ``asyncio.to_thread`` call with an explicit
+``await asyncio.sleep(0)`` cooperative yield between them. Per-signal
+``LoopSink`` instrumentation (``posture.signal.<name>``) attributes
+heavy individual collectors so v28 names which signal is hot.
+
+``_collect_with_timeout`` now awaits ``build_bundle_async`` instead
+of the monolithic ``to_thread(build_bundle)``. Sync ``build_bundle``
+retained for backwards compat (tests + any other caller).
+
+# Slice 33 Arc 1+ radar widening
+
+Two additional ``LoopSink`` wires added to surface the still-unnamed
+v27 post-boot sinks (5 of 6 ControlPlaneStarvation events had no
+LoopSink correlation):
+
+  * ``intake.UnifiedIntakeRouter.ingest`` — every sensor signal
+    flows through this; if it's slow the loop notices.
+  * ``oracle.OracleSemanticIndex.initialize_backend`` — ChromaDB
+    lazy init is a known bootstrap heavyweight.
+
+# Arc 2 scope refinement (NOT in this PR)
+
+v27 LoopSink data showed ``semantic_index.SemanticIndex.build``
+at 691ms — BUT tracing call-sites confirms the ONLY ``.build()``
+caller is the daemon thread inside ``build_async()``. The 691ms
+happened in a daemon thread, NOT on the asyncio main loop. Arc 2
+(spawn-pool offload) targets a non-issue from main-loop starvation
+perspective. Deferred pending v28 evidence.
+
+# Test surface (3 AST + 6 spine = 9 tests)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POSTURE_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "posture_observer.py"
+)
+INTAKE_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance" / "intake"
+    / "unified_intake_router.py"
+)
+ORACLE_FILE = REPO_ROOT / "backend" / "core" / "ouroboros" / "oracle.py"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 3
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_build_bundle_async_present_with_per_signal_wires() -> None:
+    """``SignalCollector.build_bundle_async`` MUST exist as an async
+    method AND its body MUST contain per-signal LoopSink wires (the
+    ``posture.signal.<name>`` pattern). Without per-signal wires
+    we lose attribution for v28."""
+    src = POSTURE_FILE.read_text()
+    tree = ast.parse(src, filename=str(POSTURE_FILE))
+    found = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "build_bundle_async"
+        ):
+            body = ast.unparse(node)
+            assert "loop_sink" in body or "sink_async" in body, (
+                "build_bundle_async missing LoopSink import"
+            )
+            assert "posture.signal." in body, (
+                "build_bundle_async missing per-signal callsite labels"
+            )
+            assert "asyncio.to_thread" in body or "to_thread" in body, (
+                "build_bundle_async not dispatching signals to threads"
+            )
+            assert "sleep(0)" in body, (
+                "build_bundle_async missing cooperative yields"
+            )
+            found = True
+            break
+    assert found, (
+        "build_bundle_async not found — Slice 33 Arc 1 substrate missing"
+    )
+    assert "Slice 33 Arc 1" in src, (
+        "posture_observer.py missing Slice 33 Arc 1 attribution"
+    )
+
+
+def test_ast_pin_collect_with_timeout_awaits_async_builder() -> None:
+    """``_collect_with_timeout`` MUST await ``build_bundle_async``,
+    NOT the legacy monolithic ``to_thread(build_bundle)``. Without
+    this swap the 22.56 s sink re-opens."""
+    src = POSTURE_FILE.read_text()
+    tree = ast.parse(src, filename=str(POSTURE_FILE))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_collect_with_timeout"
+        ):
+            body = ast.unparse(node)
+            assert "build_bundle_async" in body, (
+                "_collect_with_timeout doesn't call build_bundle_async — "
+                "Slice 33 Arc 1 wiring incomplete; v27 sink re-opens"
+            )
+            assert "to_thread(self._collector.build_bundle)" not in body, (
+                "_collect_with_timeout still uses legacy "
+                "to_thread(build_bundle) path"
+            )
+            return
+    pytest.fail("_collect_with_timeout not found in posture_observer.py")
+
+
+def test_ast_pin_arc1_plus_radar_widening_three_new_wires() -> None:
+    """Slice 33 Arc 1+ widens LoopSink coverage by 3 new wires:
+    posture per-signal (covered by build_bundle_async pin above),
+    intake.UnifiedIntakeRouter.ingest, and
+    oracle.OracleSemanticIndex.initialize_backend."""
+    intake_src = INTAKE_FILE.read_text()
+    assert "intake.UnifiedIntakeRouter.ingest" in intake_src, (
+        "intake.ingest LoopSink callsite label missing"
+    )
+    assert "loop_sink" in intake_src or "sink_async" in intake_src, (
+        "intake module missing loop_sink import"
+    )
+
+    oracle_src = ORACLE_FILE.read_text()
+    assert (
+        "oracle.OracleSemanticIndex.initialize_backend" in oracle_src
+    ), (
+        "ChromaDB initialize_backend LoopSink callsite label missing"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 6
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_build_bundle_async_parity_with_sync() -> None:
+    """``build_bundle_async`` MUST return a SignalBundle with the
+    same field shape as the legacy sync ``build_bundle``. Refactor
+    must NOT alter what the inferrer sees."""
+    from backend.core.ouroboros.governance.posture_observer import (
+        SignalCollector,
+    )
+    c = SignalCollector(Path.cwd())
+    sync_bundle = c.build_bundle()
+    async_bundle = asyncio.run(c.build_bundle_async())
+    sync_d = (
+        sync_bundle.__dict__ if hasattr(sync_bundle, "__dict__")
+        else dict(getattr(sync_bundle, "_asdict", lambda: {})())
+    )
+    async_d = (
+        async_bundle.__dict__ if hasattr(async_bundle, "__dict__")
+        else dict(getattr(async_bundle, "_asdict", lambda: {})())
+    )
+    assert set(sync_d.keys()) == set(async_d.keys()), (
+        f"field shape diverged: sync={sorted(sync_d)} "
+        f"async={sorted(async_d)}"
+    )
+    # All numeric/structural fields must equal (timestamps may differ
+    # by microseconds; we compare deterministic fields)
+    for field in (
+        "feat_ratio", "fix_ratio", "refactor_ratio", "test_docs_ratio",
+        "commit_window", "postmortem_window_h", "schema_version",
+    ):
+        assert sync_d.get(field) == async_d.get(field), (
+            f"deterministic field {field} diverged: "
+            f"sync={sync_d.get(field)} async={async_d.get(field)}"
+        )
+
+
+def test_spine_build_bundle_async_is_actually_async() -> None:
+    from backend.core.ouroboros.governance.posture_observer import (
+        SignalCollector,
+    )
+    assert asyncio.iscoroutinefunction(
+        SignalCollector.build_bundle_async,
+    ), "build_bundle_async must be async"
+
+
+def test_spine_main_loop_stays_responsive_during_build_bundle() -> None:
+    """The key Slice 33 Arc 1 contract: while ``build_bundle_async``
+    is running, the asyncio main loop MUST keep ticking. Heartbeat
+    sibling coroutine increments a counter every 10ms; over the
+    bundle build the counter MUST grow — proving cooperative yields
+    work. This is the structural inverse of the v27 22.56 s wedge."""
+    from backend.core.ouroboros.governance.posture_observer import (
+        SignalCollector,
+    )
+
+    async def run():
+        tick_count = 0
+
+        async def heartbeat():
+            nonlocal tick_count
+            while True:
+                tick_count += 1
+                await asyncio.sleep(0.01)
+
+        hb = asyncio.create_task(heartbeat())
+        try:
+            c = SignalCollector(Path.cwd())
+            await c.build_bundle_async()
+        finally:
+            hb.cancel()
+            try:
+                await hb
+            except asyncio.CancelledError:
+                pass
+        return tick_count
+
+    ticks = asyncio.run(run())
+    # 9 signals × cooperative yields → heartbeat should fire many
+    # times. Threshold is generous (5+) but proves the loop wasn't
+    # wedged. If the loop wedged we'd see 0-1 ticks.
+    assert ticks >= 5, (
+        f"main loop wedged during build_bundle_async — only {ticks} "
+        f"heartbeat tick(s). v27 22.56 s wedge is back."
+    )
+
+
+def test_spine_intake_ingest_wraps_in_sink_async() -> None:
+    """``UnifiedIntakeRouter.ingest`` MUST be wrapped in
+    ``sink_async(intake.UnifiedIntakeRouter.ingest)``. AST-walk
+    verifies the wiring at the function body."""
+    src = INTAKE_FILE.read_text()
+    tree = ast.parse(src, filename=str(INTAKE_FILE))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "ingest"
+        ):
+            body = ast.unparse(node)
+            assert "sink_async" in body, (
+                "ingest body missing sink_async wrapper"
+            )
+            assert "intake.UnifiedIntakeRouter.ingest" in body, (
+                "ingest body missing callsite label"
+            )
+            return
+    pytest.fail("UnifiedIntakeRouter.ingest not located")
+
+
+def test_spine_oracle_initialize_backend_wraps_in_sink_async() -> None:
+    """``OracleSemanticIndex.initialize_backend`` MUST be wrapped
+    in ``sink_async``. ChromaDB lazy init is a known boot heavyweight
+    and we need attribution for v28."""
+    src = ORACLE_FILE.read_text()
+    tree = ast.parse(src, filename=str(ORACLE_FILE))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "initialize_backend"
+        ):
+            body = ast.unparse(node)
+            assert "sink_async" in body
+            assert "oracle.OracleSemanticIndex.initialize_backend" in body
+            return
+    pytest.fail("OracleSemanticIndex.initialize_backend not located")
+
+
+def test_spine_per_signal_wires_use_unique_callsite_labels() -> None:
+    """Each of the 9 per-signal LoopSink wires inside
+    ``build_bundle_async`` MUST use a unique callsite label so the
+    v28 leaderboard can attribute heavy collectors precisely."""
+    src = POSTURE_FILE.read_text()
+    # The 9 signal callsite labels expected (matches the wires we
+    # added — must stay synchronized with the body)
+    expected = {
+        "posture.signal.commit_ratios",
+        "posture.signal.postmortem_failure_rate",
+        "posture.signal.iron_gate_reject_rate",
+        "posture.signal.l2_repair_rate",
+        "posture.signal.open_ops_normalized",
+        "posture.signal.session_lessons_infra_ratio",
+        "posture.signal.time_since_last_graduation_inv",
+        "posture.signal.cost_burn_normalized",
+        "posture.signal.worktree_orphan_count",
+    }
+    missing = {label for label in expected if label not in src}
+    assert not missing, (
+        f"build_bundle_async missing per-signal labels: {sorted(missing)}"
+    )


### PR DESCRIPTION
## Summary

Closes the **v27 LoopSink-confirmed dominant on-loop sink** — `posture_observer.run_one_cycle` blocked the asyncio main thread for **22.56 seconds** during a cold session. Slice 33 Arc 0's diagnostic-first discipline forced this sink to name itself; v26's speculative hypothesis (graph writes + embedder) was wrong.

## Root cause

`SignalCollector.build_bundle()` ran 9 sync signal collectors sequentially inside ONE `asyncio.to_thread` call. Each collector performs sync I/O (git subprocess, session-dir iteration, file reads). Whole bundle = one monolithic worker-thread block; GIL contention starved the asyncio main thread for the full 22.56 s.

## Fix — chunked-async with explicit cooperative yields

`SignalCollector.build_bundle_async()` — same `SignalBundle` return shape (parity AST-pin + spine test), but each individual collector dispatched in its own `asyncio.to_thread` call with `await asyncio.sleep(0)` between them. Per-signal `LoopSink` wires (9 literal callsite labels) give v28 precise attribution.

First test run already surfaced `posture.signal.time_since_last_graduation_inv` at 96 ms — exactly the per-signal attribution we wanted.

## Radar widening (2 additional wires)

v27 surfaced 6 post-boot ControlPlaneStarvation events with ONLY 1 LoopSink correlation — 5 of 6 stalls came from unnamed callsites. Two probes added:

- `intake.UnifiedIntakeRouter.ingest` (every sensor signal flows through)
- `oracle.OracleSemanticIndex.initialize_backend` (ChromaDB lazy init)

## Arc 2 deferred — empirical refinement

v27 showed `semantic_index.SemanticIndex.build` at 691 ms — BUT tracing call-sites confirms the ONLY `.build()` caller is the daemon thread inside `build_async()`. The 691 ms happened in a daemon thread, **NOT on the asyncio main loop**. Arc 2 (spawn-pool offload) targets a non-issue from main-loop starvation perspective. **Deferred pending v28 evidence.** Honors "no euphoria, only artifacts".

## Verification

| Suite | Result |
|---|---|
| Slice 33 Arc 0 + Arc 1 (7 AST + 15 spine) | **22/22 green** |
| Slice 11 + Slice 20+ + Slice 31/32 baseline | **286/286 green** (277 prior + 9 new) |
| `build_bundle_async` ↔ `build_bundle` parity | identical fields + deterministic values |
| `test_spine_main_loop_stays_responsive_during_build_bundle` | structural inverse of v27 wedge proven |

## v28 expectation

Posture's 22.56 s sink: closed. Per-signal attribution: live. Intake + ChromaDB radar: live. v28 burn ($10/3600 s) will either show APPLY events (the bar Slice 31+32+33 collectively aimed to unblock) OR surface a remaining sink in the new LoopSink coverage that Slice 33 Arc 3 can scope precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the posture observer’s 22.56s event-loop stall by chunking signal collection into async steps with cooperative yields. Also adds per‑signal telemetry and widens radar to pinpoint remaining slow paths.

- **Bug Fixes**
  - Introduced `build_bundle_async()` to run each collector in its own `asyncio.to_thread` with `await asyncio.sleep(0)` between calls; removes the monolithic GIL hold.
  - `_collect_with_timeout` now awaits `build_bundle_async()`; legacy sync `build_bundle` is kept for compatibility.

- **New Features**
  - Per‑signal `LoopSink` wires (9 labels) for posture collectors to attribute slow signals precisely.
  - Instrumented `intake.UnifiedIntakeRouter.ingest` and `oracle.OracleSemanticIndex.initialize_backend` with `sink_async` to widen coverage.

<sup>Written for commit e4fd3d25daa35029679ee935b58954f8853db3db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/59495?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

