### PR TITLE
feat(governance): Slice 33 Arc 2 — Multi-Engine Async I/O Offloading (v28 top-3 sinks fix)

### DIFF
--- a/backend/core/ouroboros/governance/git_momentum.py
+++ b/backend/core/ouroboros/governance/git_momentum.py
@@ -106,6 +106,117 @@ class MomentumSnapshot:
         return self.commit_count == 0
 
 
+async def compute_recent_momentum_async(
+    project_root: Path,
+    max_commits: int = _DEFAULT_MAX_COMMITS,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+) -> Optional[MomentumSnapshot]:
+    """Slice 33 Arc 2 Phase 1 — async-native git momentum.
+
+    Same return shape as :func:`compute_recent_momentum` but uses
+    ``asyncio.create_subprocess_exec`` so no thread-pool slot is
+    consumed during the git log scan. NEVER raises — every failure
+    path returns ``None``.
+    """
+    import asyncio as _asyncio_gm
+    n = max(1, int(max_commits))
+    try:
+        proc = await _asyncio_gm.create_subprocess_exec(
+            "git", "log", f"-{n}", "--pretty=format:%H|%ct|%s",
+            cwd=str(project_root),
+            stdout=_asyncio_gm.subprocess.PIPE,
+            stderr=_asyncio_gm.subprocess.DEVNULL,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        stdout_bytes, _ = await _asyncio_gm.wait_for(
+            proc.communicate(), timeout=float(timeout_s),
+        )
+    except _asyncio_gm.TimeoutError:
+        try:
+            proc.kill()
+            await proc.wait()
+        except Exception:  # noqa: BLE001
+            pass
+        return None
+    except _asyncio_gm.CancelledError:
+        try:
+            proc.kill()
+        except Exception:  # noqa: BLE001
+            pass
+        raise
+    except Exception:  # noqa: BLE001
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        text = stdout_bytes.decode("utf-8", errors="replace")
+    except Exception:  # noqa: BLE001
+        return None
+    return _parse_git_log_output(text)  # noqa: F821 — defined below
+
+
+def _parse_git_log_output(text: str) -> Optional[MomentumSnapshot]:
+    """Pure parse — shared by sync + async entries. NEVER raises.
+    Extracted from the legacy ``compute_recent_momentum`` body so
+    the async variant doesn't duplicate parsing logic."""
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return None
+    scope_counts: Dict[str, int] = {}
+    type_counts: Dict[str, int] = {}
+    latest_subjects: List[str] = []
+    non_conventional = 0
+    timestamps: List[int] = []
+    parsed = 0
+
+    for raw in lines:
+        parts = raw.split("|", 2)
+        if len(parts) != 3:
+            continue
+        _hash, ts_str, subject = parts
+        subject = subject.strip()
+        if not subject:
+            continue
+        parsed += 1
+        try:
+            timestamps.append(int(ts_str))
+        except ValueError:
+            pass
+
+        m = _CONVENTIONAL_COMMIT_RE.match(subject)
+        if not m:
+            non_conventional += 1
+            latest_subjects.append(subject[:_SUBJECT_TRUNCATION])
+            continue
+        t = (m.group("type") or "").lower()
+        s = (m.group("scope") or "").lower()
+        sub = (m.group("subject") or "").strip()
+        if t:
+            type_counts[t] = type_counts.get(t, 0) + 1
+        if s:
+            scope_counts[s] = scope_counts.get(s, 0) + 1
+        if sub:
+            latest_subjects.append(sub[:_SUBJECT_TRUNCATION])
+
+    if parsed == 0:
+        return None
+
+    span = 0.0
+    if len(timestamps) >= 2:
+        span = float(max(timestamps) - min(timestamps))
+
+    return MomentumSnapshot(
+        commit_count=parsed,
+        scope_counts=scope_counts,
+        type_counts=type_counts,
+        latest_subjects=tuple(latest_subjects),
+        non_conventional_count=non_conventional,
+        wall_seconds_span=span,
+    )
+
+
 def compute_recent_momentum(
     project_root: Path,
     max_commits: int = _DEFAULT_MAX_COMMITS,
@@ -153,64 +264,9 @@ def compute_recent_momentum(
 
     if result.returncode != 0:
         return None
-
-    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
-    if not lines:
-        return None
-
-    scope_counts: Dict[str, int] = {}
-    type_counts: Dict[str, int] = {}
-    latest_subjects: List[str] = []
-    non_conventional = 0
-    timestamps: List[int] = []
-    parsed = 0
-
-    for raw in lines:
-        # Split on the first two pipes only. Subjects may contain pipes.
-        parts = raw.split("|", 2)
-        if len(parts) != 3:
-            # Malformed line — skip but do not abort the whole snapshot.
-            continue
-        _hash, ts_str, subject = parts
-        subject = subject.strip()
-        if not subject:
-            continue
-        parsed += 1
-        try:
-            timestamps.append(int(ts_str))
-        except ValueError:
-            pass
-
-        m = _CONVENTIONAL_COMMIT_RE.match(subject)
-        if not m:
-            non_conventional += 1
-            latest_subjects.append(subject[:_SUBJECT_TRUNCATION])
-            continue
-        t = (m.group("type") or "").lower()
-        s = (m.group("scope") or "").lower()
-        sub = (m.group("subject") or "").strip()
-        if t:
-            type_counts[t] = type_counts.get(t, 0) + 1
-        if s:
-            scope_counts[s] = scope_counts.get(s, 0) + 1
-        if sub:
-            latest_subjects.append(sub[:_SUBJECT_TRUNCATION])
-
-    if parsed == 0:
-        return None
-
-    span = 0.0
-    if len(timestamps) >= 2:
-        span = float(max(timestamps) - min(timestamps))
-
-    return MomentumSnapshot(
-        commit_count=parsed,
-        scope_counts=scope_counts,
-        type_counts=type_counts,
-        latest_subjects=tuple(latest_subjects),
-        non_conventional_count=non_conventional,
-        wall_seconds_span=span,
-    )
+    # Slice 33 Arc 2 Phase 1 — shared parser keeps sync + async byte-
+    # identical. Extracted from the legacy inline parse loop.
+    return _parse_git_log_output(result.stdout)
 
 
 def format_themes(snapshot: Optional[MomentumSnapshot]) -> List[str]:

--- a/backend/core/ouroboros/governance/posture_observer.py
+++ b/backend/core/ouroboros/governance/posture_observer.py
@@ -141,6 +141,84 @@ _CONV_COMMIT_RE = re.compile(
 )
 
 
+# ---------------------------------------------------------------------------
+# Slice 33 Arc 2 Phase 2 — dedicated filesystem signal executor
+# ---------------------------------------------------------------------------
+#
+# Closes the v28 (bt-2026-05-27-235042) LoopSink-confirmed sink:
+#   posture.signal.postmortem_failure_rate blocked_ms=5322.57
+#
+# Root cause: 4 of the 9 signal collectors (postmortem_failure_rate,
+# iron_gate_reject_rate, l2_repair_rate, session_lessons_infra_ratio)
+# all iterate .ouroboros/sessions/*/summary.json synchronously. Under
+# Arc 1, each runs in the DEFAULT ThreadPoolExecutor via asyncio.
+# to_thread — contending with every other to_thread caller in the
+# process (oracle file reads, oracle parse-result dispatches, etc.).
+#
+# Phase 2 routes these 4 specifically to a DEDICATED 2-worker
+# ThreadPoolExecutor reserved for filesystem signal collection.
+# Bounded (operators with more cores can raise via env). Lazy
+# singleton (no startup cost when posture observer isn't active).
+
+import threading as _threading_fs  # noqa: E402
+from concurrent.futures import (  # noqa: E402
+    ThreadPoolExecutor as _ThreadPoolExecutor_fs,
+)
+
+_FS_SIGNAL_EXECUTOR_MAX_WORKERS_ENV: str = (
+    "JARVIS_POSTURE_FS_SIGNAL_EXECUTOR_MAX_WORKERS"
+)
+_DEFAULT_FS_SIGNAL_EXECUTOR_MAX_WORKERS: int = 2
+_fs_signal_executor: Optional[_ThreadPoolExecutor_fs] = None
+_fs_signal_executor_lock = _threading_fs.Lock()
+
+
+def _fs_signal_executor_max_workers() -> int:
+    try:
+        raw = os.environ.get(_FS_SIGNAL_EXECUTOR_MAX_WORKERS_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_FS_SIGNAL_EXECUTOR_MAX_WORKERS
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_FS_SIGNAL_EXECUTOR_MAX_WORKERS
+
+
+def _get_fs_signal_executor() -> _ThreadPoolExecutor_fs:
+    """Slice 33 Arc 2 Phase 2 — lazy singleton dedicated to filesystem
+    signal collection (recent_summaries-backed signals). Separate from
+    asyncio's default ThreadPoolExecutor so heavy session-dir scans
+    don't contend with oracle file reads / parse dispatches."""
+    global _fs_signal_executor
+    if _fs_signal_executor is not None:
+        return _fs_signal_executor
+    with _fs_signal_executor_lock:
+        if _fs_signal_executor is None:
+            _fs_signal_executor = _ThreadPoolExecutor_fs(
+                max_workers=_fs_signal_executor_max_workers(),
+                thread_name_prefix="posture-fs-signal",
+            )
+            logger.info(
+                "[PostureObserver] fs_signal_executor initialised "
+                "max_workers=%d",
+                _fs_signal_executor_max_workers(),
+            )
+    return _fs_signal_executor
+
+
+def shutdown_fs_signal_executor() -> None:
+    """Slice 33 Arc 2 Phase 2 — clean shutdown. NEVER raises."""
+    global _fs_signal_executor
+    with _fs_signal_executor_lock:
+        if _fs_signal_executor is None:
+            return
+        try:
+            _fs_signal_executor.shutdown(wait=False, cancel_futures=True)
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            _fs_signal_executor = None
+
+
 # Callable the wiring layer can inject to surface in-flight op count.
 OpenOpsProvider = Callable[[], int]
 
@@ -164,6 +242,9 @@ class SignalCollector:
         self._open_ops_provider = open_ops_provider
 
     def _git_subjects(self, n: int) -> List[str]:
+        """Legacy sync entry — retained for backwards compat with the
+        sync ``commit_ratios`` / ``build_bundle`` path. Production
+        chunked-async cycle uses :meth:`_git_subjects_async`."""
         try:
             result = subprocess.run(
                 ["git", "log", f"-{n}", "--pretty=format:%s"],
@@ -175,6 +256,83 @@ class SignalCollector:
         if result.returncode != 0:
             return []
         return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+
+    async def _git_subjects_async(self, n: int) -> List[str]:
+        """Slice 33 Arc 2 Phase 1 — async git subprocess.
+
+        Replaces ``subprocess.run`` (which ties up a ThreadPool worker
+        for the full duration even via ``asyncio.to_thread``) with
+        ``asyncio.create_subprocess_exec`` which is genuinely
+        non-blocking from asyncio's perspective. The cold-cache 18 s
+        git log on a 29k-file repo no longer holds a thread-pool
+        slot, freeing default-executor capacity for sibling work.
+
+        Bounded by ``asyncio.wait_for(timeout=5.0)`` — on timeout the
+        subprocess is killed cleanly. NEVER raises — returns ``[]``
+        on any failure (timeout / git missing / nonzero exit /
+        decode error).
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "git", "log", f"-{n}", "--pretty=format:%s",
+                cwd=str(self._root),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except (FileNotFoundError, OSError):
+            return []
+        try:
+            stdout_bytes, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=5.0,
+            )
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
+            return []
+        except asyncio.CancelledError:
+            try:
+                proc.kill()
+            except Exception:  # noqa: BLE001
+                pass
+            raise
+        except Exception:  # noqa: BLE001 — defensive
+            return []
+        if proc.returncode != 0:
+            return []
+        try:
+            text = stdout_bytes.decode("utf-8", errors="replace")
+        except Exception:  # noqa: BLE001
+            return []
+        return [ln.strip() for ln in text.splitlines() if ln.strip()]
+
+    async def commit_ratios_async(self) -> Dict[str, float]:
+        """Slice 33 Arc 2 Phase 1 — async-native commit ratios.
+
+        Same semantics as sync :meth:`commit_ratios`, but the git log
+        runs via ``create_subprocess_exec`` — no thread-pool slot
+        consumed even during cold-cache 18 s scans.
+        """
+        subjects = await self._git_subjects_async(commit_window())
+        if not subjects:
+            return {"feat": 0.0, "fix": 0.0, "refactor": 0.0, "test_docs": 0.0}
+        counts = {"feat": 0, "fix": 0, "refactor": 0, "test": 0, "docs": 0}
+        for subj in subjects:
+            m = _CONV_COMMIT_RE.match(subj)
+            if not m:
+                continue
+            ctype = m.group("type").lower()
+            if ctype in counts:
+                counts[ctype] += 1
+        total = len(subjects)
+        return {
+            "feat": counts["feat"] / total,
+            "fix": counts["fix"] / total,
+            "refactor": counts["refactor"] / total,
+            "test_docs": (counts["test"] + counts["docs"]) / total,
+        }
 
     def commit_ratios(self) -> Dict[str, float]:
         """feat / fix / refactor / test+docs ratios over last N commits."""
@@ -421,29 +579,40 @@ class SignalCollector:
 
         # Literal callsite labels (not f-strings) so AST pins +
         # production log greps see the exact string at the call site.
+        # Slice 33 Arc 2 Phase 1 — commit_ratios uses async-native
+        # subprocess (create_subprocess_exec) instead of to_thread
+        # wrapping subprocess.run; no thread-pool slot consumed even
+        # during cold-cache 18 s scans.
         async with _ls_sink_async("posture.signal.commit_ratios"):
-            ratios = await _asyncio_ls.to_thread(self.commit_ratios)
+            ratios = await self.commit_ratios_async()
         await _asyncio_ls.sleep(0)
 
-        # The rest of the signals are typically sub-second, so we don't need individual 
-        # sinks for them — one sink wrapping the whole batch is sufficient to surface 
-        # them in the same cycle without overwhelming LoopSink with 12 separate events. 
-        # But we do want to yield between them to avoid blocking the loop, so we interleave 
-        # explicit sleeps.
+        # Slice 33 Arc 2 Phase 2 — 4 filesystem-bound signals
+        # (postmortem/iron_gate/l2_repair/session_lessons all call
+        # recent_summaries which iterates .ouroboros/sessions/*/
+        # summary.json) route through a DEDICATED 2-worker
+        # ThreadPoolExecutor so heavy session-dir scans don't contend
+        # with the default executor's other consumers (oracle file
+        # reads / parse dispatches / etc.).
+        _loop_fs = _asyncio_ls.get_running_loop()
+        _fs_exec = _get_fs_signal_executor()
+
         async with _ls_sink_async("posture.signal.postmortem_failure_rate"):
-            # This is the heaviest collector (parsing + iterating over multiple 
-            # summary.json files) so it gets its own sink and label.
-            pm = await _asyncio_ls.to_thread(self.postmortem_failure_rate)
-        # Yield to the event loop before starting the next collector to ensure we don't 
-        # block it for too long.
+            pm = await _loop_fs.run_in_executor(
+                _fs_exec, self.postmortem_failure_rate,
+            )
         await _asyncio_ls.sleep(0)
 
         async with _ls_sink_async("posture.signal.iron_gate_reject_rate"):
-            ig = await _asyncio_ls.to_thread(self.iron_gate_reject_rate)
+            ig = await _loop_fs.run_in_executor(
+                _fs_exec, self.iron_gate_reject_rate,
+            )
         await _asyncio_ls.sleep(0)
 
         async with _ls_sink_async("posture.signal.l2_repair_rate"):
-            l2 = await _asyncio_ls.to_thread(self.l2_repair_rate)
+            l2 = await _loop_fs.run_in_executor(
+                _fs_exec, self.l2_repair_rate,
+            )
         await _asyncio_ls.sleep(0)
 
         async with _ls_sink_async("posture.signal.open_ops_normalized"):
@@ -451,7 +620,9 @@ class SignalCollector:
         await _asyncio_ls.sleep(0)
 
         async with _ls_sink_async("posture.signal.session_lessons_infra_ratio"):
-            sl = await _asyncio_ls.to_thread(self.session_lessons_infra_ratio)
+            sl = await _loop_fs.run_in_executor(
+                _fs_exec, self.session_lessons_infra_ratio,
+            )
         await _asyncio_ls.sleep(0)
 
         async with _ls_sink_async("posture.signal.time_since_last_graduation_inv"):

--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -207,6 +207,48 @@ def _is_oracle_legacy_thread_mode() -> bool:
     return raw in ("1", "true", "yes", "on")
 
 
+# Slice 33 Arc 2 Phase 3 — async graph-write queue master switch.
+# Default TRUE — closes the v28 LoopSink-confirmed sink:
+#   oracle._index_file.graph_write_bulk 76 occurrences peak 3,580 ms
+# Setting JARVIS_ORACLE_GRAPH_QUEUE_ENABLED=0 restores the pre-
+# Slice-33-Arc-2-P3 inline-write path byte-identically (escape hatch).
+
+_ORACLE_GRAPH_QUEUE_ENABLED_ENV: str = "JARVIS_ORACLE_GRAPH_QUEUE_ENABLED"
+_ORACLE_GRAPH_QUEUE_MAX_SIZE_ENV: str = "JARVIS_ORACLE_GRAPH_QUEUE_MAX_SIZE"
+_ORACLE_GRAPH_QUEUE_BATCH_SIZE_ENV: str = "JARVIS_ORACLE_GRAPH_QUEUE_BATCH_SIZE"
+_DEFAULT_GRAPH_QUEUE_MAX_SIZE: int = 1000
+_DEFAULT_GRAPH_QUEUE_BATCH_SIZE: int = 50
+
+
+def _is_oracle_graph_queue_enabled() -> bool:
+    """Slice 33 Arc 2 Phase 3 — default TRUE. Explicit falsy values
+    restore inline-write path (escape hatch only)."""
+    raw = os.environ.get(_ORACLE_GRAPH_QUEUE_ENABLED_ENV, "").strip().lower()
+    if not raw:
+        return True
+    return raw not in ("0", "false", "no", "off")
+
+
+def _oracle_graph_queue_max_size() -> int:
+    try:
+        raw = os.environ.get(_ORACLE_GRAPH_QUEUE_MAX_SIZE_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_GRAPH_QUEUE_MAX_SIZE
+        return max(10, int(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_GRAPH_QUEUE_MAX_SIZE
+
+
+def _oracle_graph_queue_batch_size() -> int:
+    try:
+        raw = os.environ.get(_ORACLE_GRAPH_QUEUE_BATCH_SIZE_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_GRAPH_QUEUE_BATCH_SIZE
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_GRAPH_QUEUE_BATCH_SIZE
+
+
 # =============================================================================
 # ENUMS AND TYPES
 # =============================================================================
@@ -1729,6 +1771,22 @@ class TheOracle:
         from backend.core.ouroboros.oracle_readiness import OracleReadiness
         self._readiness = OracleReadiness()
 
+        # Slice 33 Arc 2 Phase 3 — async graph-write queue substrate.
+        # When the master flag JARVIS_ORACLE_GRAPH_QUEUE_ENABLED is
+        # enabled (default TRUE), _index_file enqueues
+        # (nodes, edges, cache_key, content_hash) batches and the
+        # consumer task drains+applies them via asyncio.to_thread —
+        # the NetworkX bulk mutations happen on a worker thread
+        # instead of the asyncio main loop. Closes v28 LoopSink
+        # graph_write_bulk pressure (76 occurrences, peak 3,580 ms).
+        self._graph_write_queue: Optional[asyncio.Queue] = None
+        self._graph_write_consumer_task: Optional[asyncio.Task] = None
+        self._graph_write_consumer_started: bool = False
+        self._graph_write_consumer_stop_event: Optional[asyncio.Event] = None
+        self._graph_writes_enqueued: int = 0
+        self._graph_writes_applied: int = 0
+        self._graph_writes_dropped: int = 0
+
         logger.info("The Oracle initialized")
 
     # ------------------------------------------------------------------
@@ -2230,16 +2288,52 @@ class TheOracle:
         # Use the hash the worker computed — defensive consistency
         # check against the main-thread hash (they MUST match, but if
         # they don't we trust the worker's view of what it parsed).
-        self._file_hashes[cache_key] = result.content_hash or content_hash
-        # Graph mutations on the event loop — same as legacy.
-        # Slice 33 Arc 0 — wrap the bulk write loop. v26 postmortem's
-        # leading hypothesis: 11,999 dispatches × N nodes/edges per
-        # file = millions of dict mutations here. If this site
-        # dominates the v27 leaderboard, Slice 33 Arc A (graph-write
-        # queue) gets scoped against the named target.
+        _effective_hash = result.content_hash or content_hash
+        # Slice 33 Arc 2 Phase 3 — async graph-write queue (default
+        # TRUE per JARVIS_ORACLE_GRAPH_QUEUE_ENABLED). When enabled,
+        # enqueue the write batch and return; the consumer task
+        # drains and applies via asyncio.to_thread off-loop. Closes
+        # the v28 LoopSink 76-occurrence graph_write_bulk pressure
+        # (peak 3,580 ms on large files).
+        if _is_oracle_graph_queue_enabled():
+            await self._ensure_graph_write_consumer()
+            assert self._graph_write_queue is not None
+            try:
+                # put_nowait if there's room, otherwise await to
+                # apply backpressure. Backpressure here means
+                # _index_file slows to match consumer drain rate —
+                # which is appropriate; otherwise we'd OOM on a 29k-
+                # file index burst.
+                self._graph_write_queue.put_nowait(
+                    (result.nodes, result.edges,
+                     cache_key, _effective_hash),
+                )
+                self._graph_writes_enqueued += 1
+            except asyncio.QueueFull:
+                # Backpressure path: await the put. The asyncio loop
+                # still ticks because we're awaiting.
+                try:
+                    await self._graph_write_queue.put(
+                        (result.nodes, result.edges,
+                         cache_key, _effective_hash),
+                    )
+                    self._graph_writes_enqueued += 1
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        f"Failed to enqueue graph write for "
+                        f"{file_path}: {exc}"
+                    )
+                    self._graph_writes_dropped += 1
+            return
+
+        # Legacy inline-write path (escape hatch
+        # JARVIS_ORACLE_GRAPH_QUEUE_ENABLED=0). Slice 33 Arc 0
+        # LoopSink instrumentation retained for parity with the
+        # async-queue path's telemetry.
         from backend.core.ouroboros.telemetry.loop_sink import (  # noqa: WPS433
             sink_sync as _ls_sink_sync,
         )
+        self._file_hashes[cache_key] = _effective_hash
         with _ls_sink_sync(
             "oracle._index_file.graph_write_bulk",
         ):
@@ -2374,6 +2468,139 @@ class TheOracle:
                     await self._index_file(repo_name, repo_path, file_path)
             except Exception as e:
                 logger.warning(f"Error scanning {file_path}: {e}")
+
+    # ------------------------------------------------------------------
+    # Slice 33 Arc 2 Phase 3 — async graph-write queue
+    # ------------------------------------------------------------------
+
+    async def _ensure_graph_write_consumer(self) -> None:
+        """Lazy-start the graph-write consumer task on first enqueue.
+        Idempotent — safe to call concurrently."""
+        if self._graph_write_consumer_started:
+            return
+        # Lock-free initialization is fine here: _index_file is the
+        # only enqueue caller, runs in a single asyncio loop, so
+        # concurrent first-calls don't happen in practice. We use
+        # the flag check + immediate assignment for forward safety.
+        self._graph_write_consumer_started = True
+        max_size = _oracle_graph_queue_max_size()
+        self._graph_write_queue = asyncio.Queue(maxsize=max_size)
+        self._graph_write_consumer_stop_event = asyncio.Event()
+        self._graph_write_consumer_task = asyncio.create_task(
+            self._graph_write_consumer_loop(),
+            name="oracle.graph_write_consumer",
+        )
+        logger.info(
+            "[Oracle] graph_write_consumer started max_size=%d batch_size=%d",
+            max_size, _oracle_graph_queue_batch_size(),
+        )
+
+    async def _graph_write_consumer_loop(self) -> None:
+        """Drain the graph-write queue and apply batches off-loop.
+
+        Uses ``asyncio.to_thread`` to run the actual NetworkX bulk
+        mutations in a worker thread — the asyncio main loop is free
+        to schedule other coroutines during the apply window. Each
+        batch is up to ``JARVIS_ORACLE_GRAPH_QUEUE_BATCH_SIZE``
+        (default 50) records to amortize the per-call scheduling
+        overhead.
+        """
+        assert self._graph_write_queue is not None
+        assert self._graph_write_consumer_stop_event is not None
+        batch_size = _oracle_graph_queue_batch_size()
+        stop_event = self._graph_write_consumer_stop_event
+        queue = self._graph_write_queue
+        while True:
+            try:
+                # Wait for the first item OR a stop signal — whichever
+                # comes first. asyncio.wait drops the loser.
+                get_task = asyncio.create_task(queue.get())
+                stop_task = asyncio.create_task(stop_event.wait())
+                done, pending = await asyncio.wait(
+                    {get_task, stop_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for p in pending:
+                    p.cancel()
+                if stop_task in done and get_task not in done:
+                    # Stop signal received with no pending item — exit
+                    break
+                if get_task not in done:
+                    continue
+                first = get_task.result()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[Oracle] graph_write_consumer wait error: %s", exc,
+                )
+                continue
+            # Coalesce additional ready items into the batch
+            batch: List[Any] = [first]
+            while len(batch) < batch_size:
+                try:
+                    batch.append(queue.get_nowait())
+                except asyncio.QueueEmpty:
+                    break
+            # Apply batch off-loop. Worker thread holds GIL during
+            # mutations but asyncio loop ticks during the await.
+            try:
+                await asyncio.to_thread(self._apply_graph_batch_sync, batch)
+                self._graph_writes_applied += len(batch)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[Oracle] graph_write_consumer apply error: %s "
+                    "batch_size=%d", exc, len(batch),
+                )
+            finally:
+                for _ in batch:
+                    try:
+                        queue.task_done()
+                    except ValueError:
+                        # task_done() called more times than get() —
+                        # defensive; shouldn't happen but keep going.
+                        pass
+
+    def _apply_graph_batch_sync(self, batch: List[Any]) -> None:
+        """Sync NetworkX mutation worker — runs in asyncio.to_thread.
+
+        Each batch item is the tuple ``(nodes, edges, cache_key,
+        content_hash)`` produced by ``_index_file``. We apply the
+        cache hash + nodes + edges atomically per item, then move
+        to the next item. NEVER raises — per-item failures are
+        logged and the batch continues.
+        """
+        for item in batch:
+            try:
+                nodes, edges, cache_key, content_hash = item
+                self._file_hashes[cache_key] = content_hash
+                for node_data in nodes:
+                    self._graph.add_node(node_data)
+                for source, target, edge_data in edges:
+                    self._graph.add_edge(source, target, edge_data)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[Oracle] graph batch item apply failed: %s", exc,
+                )
+
+    async def stop_graph_write_consumer(self) -> None:
+        """Signal the consumer to stop + drain remaining queue.
+        NEVER raises. Idempotent."""
+        if not self._graph_write_consumer_started:
+            return
+        if self._graph_write_consumer_stop_event is not None:
+            self._graph_write_consumer_stop_event.set()
+        if self._graph_write_consumer_task is not None:
+            try:
+                await asyncio.wait_for(
+                    self._graph_write_consumer_task, timeout=5.0,
+                )
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._graph_write_consumer_task.cancel()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[Oracle] graph_write_consumer stop error: %s", exc,
+                )
 
     @staticmethod
     def _resolved_graph_cache_path() -> Path:

--- a/tests/governance/test_slice33_arc2_multi_engine_async_io.py
+++ b/tests/governance/test_slice33_arc2_multi_engine_async_io.py
@@ -1,0 +1,480 @@
+"""Slice 33 Arc 2 — Multi-Engine Asynchronous I/O Offloading Layer.
+
+Closes the v28 (``bt-2026-05-27-235042``) LoopSink-confirmed top
+sinks across 3 orthogonal axes:
+
+  Phase 1: posture.signal.commit_ratios 18,140 ms cold-cache git
+           (sync subprocess.run holds a ThreadPool slot for the
+           full duration).
+  Phase 2: posture.signal.postmortem_failure_rate 5,322 ms
+           session-dir iteration (4 signals contend with oracle
+           file reads in the DEFAULT ThreadPool).
+  Phase 3: oracle._index_file.graph_write_bulk 3,580 ms peak
+           (76 occurrences total — NetworkX bulk mutations inline
+           on the asyncio loop).
+
+# Phase 1 — async-native git subprocess
+
+``SignalCollector._git_subjects_async()`` + ``commit_ratios_async()``
+use ``asyncio.create_subprocess_exec`` — no ThreadPool slot consumed
+even during cold-cache 18 s scans. Sibling: ``git_momentum.
+compute_recent_momentum_async`` mirrors for non-posture callers.
+``build_bundle_async`` calls ``commit_ratios_async`` directly (no
+``to_thread`` hop).
+
+# Phase 2 — dedicated filesystem executor
+
+Module-level lazy singleton ``_fs_signal_executor`` (2 workers,
+``JARVIS_POSTURE_FS_SIGNAL_EXECUTOR_MAX_WORKERS`` configurable).
+``build_bundle_async`` routes 4 filesystem-bound signals
+(postmortem/iron_gate/l2_repair/session_lessons) through
+``loop.run_in_executor(_fs_exec, fn)`` so heavy session-dir scans
+don't contend with the default executor's other consumers.
+
+# Phase 3 — async graph-write queue + bg consumer
+
+``TheOracle._graph_write_queue: asyncio.Queue`` (bounded, default
+1000) + ``_graph_write_consumer_task`` drains in batches (default
+50) and applies via ``asyncio.to_thread`` — NetworkX bulk mutations
+move off the asyncio loop. Backpressure via ``put`` await when
+queue fills. Master flag ``JARVIS_ORACLE_GRAPH_QUEUE_ENABLED``
+default TRUE; explicit-false restores inline writes.
+
+# Test surface (5 AST + 11 spine = 16 tests)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import os
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POSTURE_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "posture_observer.py"
+)
+GIT_MOMENTUM_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "git_momentum.py"
+)
+ORACLE_FILE = REPO_ROOT / "backend" / "core" / "ouroboros" / "oracle.py"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 5
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_phase1_git_subjects_async_present() -> None:
+    """SignalCollector MUST have ``_git_subjects_async`` + ``commit_ratios_async``
+    as async methods using ``asyncio.create_subprocess_exec`` (no
+    ``subprocess.run`` inside)."""
+    src = POSTURE_FILE.read_text()
+    tree = ast.parse(src, filename=str(POSTURE_FILE))
+    git_subjects_async_found = False
+    commit_ratios_async_found = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef):
+            if node.name == "_git_subjects_async":
+                body = ast.unparse(node)
+                assert "create_subprocess_exec" in body, (
+                    "_git_subjects_async must use create_subprocess_exec"
+                )
+                # Strip docstring before checking for forbidden tokens
+                # — the docstring legitimately mentions subprocess.run
+                # for context. AST-walk Call nodes specifically.
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute):
+                        if (
+                            isinstance(sub.func.value, ast.Name)
+                            and sub.func.value.id == "subprocess"
+                            and sub.func.attr == "run"
+                        ):
+                            pytest.fail(
+                                "_git_subjects_async makes a sync "
+                                "subprocess.run call — must use "
+                                "create_subprocess_exec only"
+                            )
+                git_subjects_async_found = True
+            if node.name == "commit_ratios_async":
+                body = ast.unparse(node)
+                assert "_git_subjects_async" in body, (
+                    "commit_ratios_async must call _git_subjects_async"
+                )
+                commit_ratios_async_found = True
+    assert git_subjects_async_found, "_git_subjects_async missing"
+    assert commit_ratios_async_found, "commit_ratios_async missing"
+
+
+def test_ast_pin_phase1_git_momentum_async_present() -> None:
+    """``git_momentum.compute_recent_momentum_async`` MUST exist and
+    use ``create_subprocess_exec`` + the shared parser."""
+    src = GIT_MOMENTUM_FILE.read_text()
+    tree = ast.parse(src, filename=str(GIT_MOMENTUM_FILE))
+    found = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "compute_recent_momentum_async"
+        ):
+            body = ast.unparse(node)
+            assert "create_subprocess_exec" in body
+            assert "_parse_git_log_output" in body
+            found = True
+            break
+    assert found, "compute_recent_momentum_async missing"
+    # Shared parser must exist
+    assert "_parse_git_log_output" in src
+
+
+def test_ast_pin_phase2_fs_signal_executor_substrate() -> None:
+    """Phase 2 dedicated filesystem executor MUST be present with
+    lazy singleton + shutdown helpers, AND build_bundle_async MUST
+    route the 4 filesystem-bound signals through it."""
+    src = POSTURE_FILE.read_text()
+    assert "_get_fs_signal_executor" in src
+    assert "shutdown_fs_signal_executor" in src
+    assert "JARVIS_POSTURE_FS_SIGNAL_EXECUTOR_MAX_WORKERS" in src
+    tree = ast.parse(src, filename=str(POSTURE_FILE))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "build_bundle_async"
+        ):
+            body = ast.unparse(node)
+            assert "_get_fs_signal_executor" in body, (
+                "build_bundle_async must call _get_fs_signal_executor"
+            )
+            # The 4 named filesystem signals must use run_in_executor
+            # (not to_thread). Count the run_in_executor calls — should
+            # be 4 (postmortem, iron_gate, l2_repair, session_lessons).
+            n_exec = body.count("run_in_executor")
+            assert n_exec >= 4, (
+                f"build_bundle_async expected ≥4 run_in_executor calls "
+                f"(one per filesystem signal), found {n_exec}"
+            )
+            return
+    pytest.fail("build_bundle_async not located")
+
+
+def test_ast_pin_phase3_oracle_graph_queue_substrate() -> None:
+    """TheOracle MUST have queue + consumer + apply method names
+    present, AND _index_file MUST dispatch through queue when
+    master flag enabled."""
+    src = ORACLE_FILE.read_text()
+    # Master flag + helpers
+    assert "_is_oracle_graph_queue_enabled" in src
+    assert "JARVIS_ORACLE_GRAPH_QUEUE_ENABLED" in src
+    # Methods
+    for name in (
+        "_ensure_graph_write_consumer",
+        "_graph_write_consumer_loop",
+        "_apply_graph_batch_sync",
+        "stop_graph_write_consumer",
+    ):
+        assert name in src, f"TheOracle missing method {name}"
+    # _index_file dispatches through queue
+    tree = ast.parse(src, filename=str(ORACLE_FILE))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_index_file"
+        ):
+            body = ast.unparse(node)
+            assert "_is_oracle_graph_queue_enabled" in body, (
+                "_index_file must consult the queue master flag"
+            )
+            assert "_graph_write_queue" in body, (
+                "_index_file must enqueue to _graph_write_queue"
+            )
+            assert "_ensure_graph_write_consumer" in body, (
+                "_index_file must ensure consumer is started"
+            )
+            return
+    pytest.fail("_index_file not located")
+
+
+def test_ast_pin_phase3_master_flag_default_true() -> None:
+    """``JARVIS_ORACLE_GRAPH_QUEUE_ENABLED`` defaults TRUE."""
+    from backend.core.ouroboros.oracle import (
+        _is_oracle_graph_queue_enabled,
+        _ORACLE_GRAPH_QUEUE_ENABLED_ENV,
+    )
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop(_ORACLE_GRAPH_QUEUE_ENABLED_ENV, None)
+        assert _is_oracle_graph_queue_enabled() is True
+    for falsy in ("0", "false", "FALSE", "no", "off"):
+        with mock.patch.dict(
+            os.environ, {_ORACLE_GRAPH_QUEUE_ENABLED_ENV: falsy},
+        ):
+            assert _is_oracle_graph_queue_enabled() is False, (
+                f"{falsy!r} should disable"
+            )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 11
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_phase1_commit_ratios_async_parity() -> None:
+    """Sync ``commit_ratios()`` and async ``commit_ratios_async()``
+    MUST return the same dict for the same input commits."""
+    from backend.core.ouroboros.governance.posture_observer import (
+        SignalCollector,
+    )
+    c = SignalCollector(Path.cwd())
+    sync_result = c.commit_ratios()
+    async_result = asyncio.run(c.commit_ratios_async())
+    assert sync_result == async_result, (
+        f"sync↔async commit_ratios diverged: "
+        f"sync={sync_result} async={async_result}"
+    )
+
+
+def test_spine_phase1_async_subprocess_loop_stays_responsive() -> None:
+    """While ``commit_ratios_async`` is running, sibling coroutine
+    heartbeat MUST tick (proves create_subprocess_exec genuinely
+    yields to the loop)."""
+    from backend.core.ouroboros.governance.posture_observer import (
+        SignalCollector,
+    )
+
+    async def run() -> int:
+        ticks = 0
+
+        async def heartbeat() -> None:
+            nonlocal ticks
+            while True:
+                ticks += 1
+                await asyncio.sleep(0.005)
+
+        hb = asyncio.create_task(heartbeat())
+        try:
+            c = SignalCollector(Path.cwd())
+            await c.commit_ratios_async()
+        finally:
+            hb.cancel()
+            try:
+                await hb
+            except asyncio.CancelledError:
+                pass
+        return ticks
+
+    ticks = asyncio.run(run())
+    assert ticks >= 2, (
+        f"loop wedged during commit_ratios_async — only {ticks} ticks"
+    )
+
+
+def test_spine_phase1_git_momentum_async_parity() -> None:
+    """Sync + async ``compute_recent_momentum`` MUST produce
+    equal MomentumSnapshot for the same repo."""
+    from backend.core.ouroboros.governance.git_momentum import (
+        compute_recent_momentum, compute_recent_momentum_async,
+    )
+    sync_snap = compute_recent_momentum(Path.cwd(), max_commits=10)
+    async_snap = asyncio.run(
+        compute_recent_momentum_async(Path.cwd(), max_commits=10),
+    )
+    assert sync_snap == async_snap, (
+        f"compute_recent_momentum sync↔async diverged"
+    )
+
+
+def test_spine_phase2_fs_executor_lazy_singleton() -> None:
+    """``_get_fs_signal_executor`` returns the same instance across
+    calls, with the configured max_workers."""
+    from backend.core.ouroboros.governance.posture_observer import (
+        _get_fs_signal_executor, shutdown_fs_signal_executor,
+    )
+    try:
+        e1 = _get_fs_signal_executor()
+        e2 = _get_fs_signal_executor()
+        assert e1 is e2, "fs_executor must be a singleton"
+        assert e1._max_workers == 2, (
+            f"default max_workers should be 2, got {e1._max_workers}"
+        )
+    finally:
+        shutdown_fs_signal_executor()
+
+
+def test_spine_phase2_fs_executor_max_workers_env_override() -> None:
+    """``JARVIS_POSTURE_FS_SIGNAL_EXECUTOR_MAX_WORKERS`` env knob
+    overrides the default."""
+    from backend.core.ouroboros.governance.posture_observer import (
+        _get_fs_signal_executor, shutdown_fs_signal_executor,
+    )
+    shutdown_fs_signal_executor()  # reset for env override
+    with mock.patch.dict(
+        os.environ,
+        {"JARVIS_POSTURE_FS_SIGNAL_EXECUTOR_MAX_WORKERS": "4"},
+    ):
+        try:
+            e = _get_fs_signal_executor()
+            assert e._max_workers == 4
+        finally:
+            shutdown_fs_signal_executor()
+
+
+def test_spine_phase2_build_bundle_async_uses_fs_executor() -> None:
+    """``build_bundle_async`` MUST submit the 4 named filesystem
+    signals to the dedicated executor — verified by patching
+    ``_get_fs_signal_executor`` to return a mock and checking
+    submit count."""
+    from backend.core.ouroboros.governance import posture_observer
+    fake_exec = mock.MagicMock()
+    fake_exec._max_workers = 2
+
+    # Make run_in_executor return Futures that resolve to whatever
+    # the wrapped fn returns
+    async def run() -> int:
+        with mock.patch.object(
+            posture_observer, "_get_fs_signal_executor",
+            return_value=fake_exec,
+        ):
+            c = posture_observer.SignalCollector(Path.cwd())
+            # Patch loop.run_in_executor to call the fn directly
+            # (avoid actually using fake_exec for execution)
+            real_loop = asyncio.get_running_loop()
+            orig_rie = real_loop.run_in_executor
+
+            calls = []
+
+            def patched_rie(executor, fn, *args):
+                if executor is fake_exec:
+                    calls.append(fn.__name__)
+                return orig_rie(executor if executor is not fake_exec else None, fn, *args)
+
+            real_loop.run_in_executor = patched_rie  # type: ignore[method-assign]
+            try:
+                await c.build_bundle_async()
+            finally:
+                real_loop.run_in_executor = orig_rie  # type: ignore[method-assign]
+            return len(calls)
+
+    n_calls = asyncio.run(run())
+    assert n_calls == 4, (
+        f"expected 4 fs_executor dispatches "
+        f"(postmortem/iron_gate/l2_repair/session_lessons), got {n_calls}"
+    )
+
+
+def test_spine_phase3_graph_queue_consumer_lazy_start() -> None:
+    """``_ensure_graph_write_consumer`` is idempotent + starts a task."""
+    from backend.core.ouroboros.oracle import TheOracle
+
+    async def run():
+        o = TheOracle()
+        assert o._graph_write_consumer_started is False
+        await o._ensure_graph_write_consumer()
+        assert o._graph_write_consumer_started is True
+        assert o._graph_write_queue is not None
+        assert o._graph_write_consumer_task is not None
+        # Second call is idempotent
+        await o._ensure_graph_write_consumer()
+        # Clean shutdown
+        await o.stop_graph_write_consumer()
+
+    asyncio.run(run())
+
+
+def test_spine_phase3_graph_queue_drains_batch() -> None:
+    """End-to-end: enqueue items, consumer drains via apply, graph
+    state updates."""
+    from backend.core.ouroboros.oracle import (
+        TheOracle, NodeData, NodeID, NodeType, EdgeData, EdgeType,
+    )
+
+    async def run():
+        o = TheOracle()
+        await o._ensure_graph_write_consumer()
+
+        nid = NodeID(
+            repo="testrepo", file_path="t.py",
+            name="foo", node_type=NodeType.FUNCTION,
+        )
+        nd = NodeData(node_id=nid)
+        # Enqueue a single-item batch (no edges)
+        assert o._graph_write_queue is not None
+        await o._graph_write_queue.put(([nd], [], "testrepo:t.py", "abc"))
+        # Wait briefly for consumer to drain
+        await asyncio.sleep(0.2)
+        # Graph should now contain the node — verified via the
+        # CodebaseKnowledgeGraph wrapper's get_node accessor (the
+        # _graph attribute is the wrapper, not the bare DiGraph)
+        assert o._graph.get_node(nid) is not None, (
+            "consumer didn't drain + apply within 200ms"
+        )
+        assert o._graph_writes_applied >= 1
+        await o.stop_graph_write_consumer()
+
+    asyncio.run(run())
+
+
+def test_spine_phase3_apply_batch_sync_never_raises() -> None:
+    """``_apply_graph_batch_sync`` MUST swallow per-item errors
+    and continue processing the rest of the batch."""
+    from backend.core.ouroboros.oracle import TheOracle
+    o = TheOracle()
+    # Mix of bad (will fail unpack) and good items
+    bad_batch = [
+        "not_a_tuple",  # will fail unpack
+        ([], [], "key1", "hash1"),  # empty but valid
+    ]
+    # Must not raise
+    try:
+        o._apply_graph_batch_sync(bad_batch)
+    except Exception as exc:
+        pytest.fail(
+            f"_apply_graph_batch_sync propagated error: {exc}"
+        )
+    # The good item should have applied its hash
+    assert o._file_hashes.get("key1") == "hash1"
+
+
+def test_spine_phase3_master_flag_disable_restores_inline_path() -> None:
+    """When ``JARVIS_ORACLE_GRAPH_QUEUE_ENABLED=0``, ``_index_file``
+    MUST take the legacy inline-write path (no queue dispatch).
+    AST-walk verifies the legacy branch is reachable."""
+    src = ORACLE_FILE.read_text()
+    tree = ast.parse(src, filename=str(ORACLE_FILE))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_index_file"
+        ):
+            body = ast.unparse(node)
+            # Legacy branch must contain inline add_node/add_edge
+            assert "self._graph.add_node" in body, (
+                "_index_file legacy path missing inline add_node call"
+            )
+            assert "self._graph.add_edge" in body, (
+                "_index_file legacy path missing inline add_edge call"
+            )
+            return
+    pytest.fail("_index_file not located")
+
+
+def test_spine_phase3_consumer_stop_idempotent() -> None:
+    """``stop_graph_write_consumer`` is safe to call repeatedly + on
+    a never-started consumer."""
+    from backend.core.ouroboros.oracle import TheOracle
+
+    async def run():
+        o = TheOracle()
+        # Stop before start — must not raise
+        await o.stop_graph_write_consumer()
+        await o._ensure_graph_write_consumer()
+        # Stop twice — must not raise
+        await o.stop_graph_write_consumer()
+        await o.stop_graph_write_consumer()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

Closes the v28 LoopSink-confirmed top sinks across 3 orthogonal axes — each fix targets a named callsite from empirical v28 data, **not speculation**.

## v28 evidence → Arc 2 targets

| v28 callsite | Magnitude | Phase | Fix |
|---|---|---|---|
| `posture.signal.commit_ratios` | 18,140 ms (cold) | Phase 1 | `asyncio.create_subprocess_exec` |
| `posture.signal.postmortem_failure_rate` | 5,322 ms | Phase 2 | dedicated 2-worker `ThreadPoolExecutor` |
| `oracle._index_file.graph_write_bulk` | 3,580 ms peak (76 events) | Phase 3 | `asyncio.Queue` + bg consumer |

## Phase 1 — async git subprocess

`SignalCollector._git_subjects_async()` + `commit_ratios_async()` use `create_subprocess_exec` — no ThreadPool slot consumed even during cold-cache 18s scans. Sibling `git_momentum.compute_recent_momentum_async`. Shared `_parse_git_log_output` parser keeps sync ↔ async byte-identical.

## Phase 2 — dedicated filesystem executor

Module-level lazy singleton `_fs_signal_executor` (2 workers, `JARVIS_POSTURE_FS_SIGNAL_EXECUTOR_MAX_WORKERS` configurable). 4 filesystem-bound signals (postmortem/iron_gate/l2_repair/session_lessons) route through `loop.run_in_executor(_fs_exec, fn)` — isolated from oracle file reads in the default ThreadPool.

## Phase 3 — async graph-write queue

`TheOracle._graph_write_queue: asyncio.Queue` + `_graph_write_consumer_task` drains in batches (default 50) and applies via `asyncio.to_thread` — NetworkX bulk mutations move off the asyncio main thread. Backpressure via `put` await. Master flag `JARVIS_ORACLE_GRAPH_QUEUE_ENABLED` default-TRUE; escape hatch `=0`.

| Knob | Default |
|---|---|
| `JARVIS_ORACLE_GRAPH_QUEUE_ENABLED` | TRUE |
| `JARVIS_ORACLE_GRAPH_QUEUE_MAX_SIZE` | 1000 |
| `JARVIS_ORACLE_GRAPH_QUEUE_BATCH_SIZE` | 50 |

Eventual-consistency tradeoff: graph queries immediately after `_index_file` returns may see stale state until consumer drains. Acceptable for Oracle's use case (queries follow indexing by seconds).

## Verification

| Suite | Result |
|---|---|
| Slice 33 Arc 2 (5 AST + 11 spine) | **16/16 green** |
| Slice 11 + Slice 20+ + Slice 31/32/33 Arc 0+1 baseline | **302/302 green** (286 prior + 16 new) |

## v29 expectation

If v29 still doesn't reach APPLY after all 3 phases land, the remaining blocker is DW capacity (Slice 28 budget), not loop health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the top v28 I/O sinks off the event loop by using async subprocesses, a dedicated FS executor, and a background graph-write queue. This keeps posture collection and indexing responsive while preserving sync behavior and results.

- New Features
  - Phase 1: `commit_ratios_async` and `compute_recent_momentum_async` use `asyncio.create_subprocess_exec`; `build_bundle_async` calls the async path; shared `_parse_git_log_output` keeps sync/async results identical.
  - Phase 2: Dedicated 2‑worker `ThreadPoolExecutor` for FS-bound signals in posture (`postmortem`, `iron_gate`, `l2_repair`, `session_lessons`); size set by `JARVIS_POSTURE_FS_SIGNAL_EXECUTOR_MAX_WORKERS`.
  - Phase 3: Bounded `asyncio.Queue` with a background consumer moves NetworkX graph mutations off-loop; batched via `asyncio.to_thread`. Controlled by `JARVIS_ORACLE_GRAPH_QUEUE_ENABLED` (default true), with `JARVIS_ORACLE_GRAPH_QUEUE_MAX_SIZE` and `JARVIS_ORACLE_GRAPH_QUEUE_BATCH_SIZE` knobs. Legacy inline writes are used when disabled. Tests added to cover async parity, executor routing, queue behavior, and flags.

<sup>Written for commit 86291822d7a3e30903b3de747910ab769cb37c06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/60171?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

