### PR TITLE
feat(governance): Slice 34 Phase 0 — DW Capacity Investigation Substrate (§48.7)

### DIFF
--- a/backend/core/ouroboros/governance/dw_adaptive_timeout.py
+++ b/backend/core/ouroboros/governance/dw_adaptive_timeout.py
@@ -1,0 +1,193 @@
+"""DW Adaptive Timeout — Slice 34 substrate (Phase 0).
+
+Observation-driven timeout for DW primary calls. **Extends** Slice 27
+Phase 3's static ``_compute_adaptive_tier0_timeout_s`` rather than
+replacing it — the static formula is the cold-start prior, observed
+rolling p99 is the refinement once sufficient samples accrue.
+
+# Composition
+
+  * Reads from :class:`DWPerShapeStats` (which reads from
+    :class:`DWCapacityLedger`).
+  * Falls through to ``candidate_generator._compute_adaptive_tier0_timeout_s``
+    (Slice 27 Phase 3 — already prompt-size + heavy-model aware)
+    when stats are absent or sample count is below threshold.
+  * NEVER returns less than the static formula (safety floor) —
+    observation-driven adjustments only *raise* the timeout, never
+    lower it below what Slice 27's calibrated math would compute.
+
+# Formula
+
+```
+static_floor    = _compute_adaptive_tier0_timeout_s(...)   # Slice 27
+stats           = per_shape.stats_for_shape(...)
+if stats is None or stats.sample_count < min_samples:
+    return static_floor                                     # cold start
+observed_budget = stats.p99_ms / 1000 × safety_factor       # default ×1.5
+final           = clamp(max(static_floor, observed_budget), static_floor, cap)
+```
+
+# Why p99 not p95
+
+The dispatch decision is "how long should we wait before giving up
+on THIS call." A p95 budget kills 5% of legitimate calls that would
+have succeeded — wasted dispatch. p99 with safety_factor 1.5 gives
+~99.5% tail coverage while staying bounded.
+
+# Why max(static, observed)
+
+If observed is FASTER than static (DW endpoint is healthy), we still
+honor the static prior because the dispatcher's static math was
+calibrated for the worst case it could reason about analytically.
+Lowering below static risks cutting off cold-MoE-warmup calls that
+LATER succeed.
+
+# Master flag
+
+``JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED`` (default **FALSE** —
+substrate ships first, behavior change graduates after v30 soak
+proves adaptive math doesn't regress static performance).
+
+# What this module does NOT do
+
+  * Does NOT decide WHICH model to dispatch (that's
+    :mod:`dw_adaptive_rotator` future arc).
+  * Does NOT learn parameters (no gradient descent, no ML training).
+    Per §48.10's caveat — non-stationary DW behavior makes any
+    "learned" model unstable. This is *adaptive heuristic*, not ML.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+from backend.core.ouroboros.governance.dw_per_shape_stats import (
+    DWPerShapeStats,
+    ShapeStats,
+    get_default_stats,
+)
+
+
+logger = logging.getLogger("Ouroboros.DWAdaptiveTimeout")
+
+
+# ============================================================================
+# Env knobs
+# ============================================================================
+
+
+_ENABLED_ENV: str = "JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED"
+_SAFETY_FACTOR_ENV: str = "JARVIS_DW_ADAPTIVE_TIMEOUT_SAFETY_FACTOR"
+_CAP_S_ENV: str = "JARVIS_DW_ADAPTIVE_TIMEOUT_CAP_S"
+
+_DEFAULT_SAFETY_FACTOR: float = 1.5
+_DEFAULT_CAP_S: float = 600.0      # 10 minute hard ceiling
+
+
+def is_enabled() -> bool:
+    """Default FALSE — substrate ships before behaviour change.
+    Graduates after v30 soak proves adaptive math doesn't regress."""
+    raw = os.environ.get(_ENABLED_ENV, "").strip().lower()
+    if not raw:
+        return False
+    return raw in ("1", "true", "yes", "on")
+
+
+def _safety_factor() -> float:
+    try:
+        raw = os.environ.get(_SAFETY_FACTOR_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_SAFETY_FACTOR
+        return max(1.0, float(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_SAFETY_FACTOR
+
+
+def _cap_s() -> float:
+    try:
+        raw = os.environ.get(_CAP_S_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_CAP_S
+        return max(1.0, float(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_CAP_S
+
+
+# ============================================================================
+# Core function
+# ============================================================================
+
+
+def compute_adaptive_timeout(
+    *,
+    model_id: str,
+    route: str,
+    prompt_chars: int,
+    static_floor_s: float,
+    stats: Optional[DWPerShapeStats] = None,
+) -> float:
+    """Observation-driven timeout. NEVER returns less than ``static_floor_s``.
+
+    Args:
+      model_id: DW model identifier.
+      route: ``immediate`` / ``standard`` / ``complex`` / ``background``
+        / ``speculative``.
+      prompt_chars: input prompt size for shape-bucketing.
+      static_floor_s: the timeout Slice 27 Phase 3's static formula
+        would compute for this call. ALWAYS the floor — observation
+        only raises above it.
+      stats: optional per-shape stats instance (defaults to module
+        singleton). Tests pass a custom instance.
+
+    Returns:
+      Timeout in seconds, clamped to ``[static_floor_s, _cap_s()]``.
+
+    Behavior matrix:
+      master_flag=False → returns static_floor_s (no behavior change)
+      master_flag=True + no stats → returns static_floor_s
+      master_flag=True + stats present → returns max(static_floor,
+                                                     p99 × safety_factor)
+                                         clamped to cap.
+    """
+    if not is_enabled():
+        return static_floor_s
+
+    s = stats or get_default_stats()
+    try:
+        shape_stats = s.stats_for_shape(
+            model_id=model_id,
+            route=route,
+            prompt_chars=prompt_chars,
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-closed to static
+        logger.warning(
+            "[DWAdaptiveTimeout] stats_for_shape failed: %s — using static floor",
+            exc,
+        )
+        return static_floor_s
+
+    if shape_stats is None:
+        # Insufficient samples — Slice 27 static prior wins
+        return static_floor_s
+
+    safety = _safety_factor()
+    observed_budget_s = (shape_stats.p99_ms / 1000.0) * safety
+    final = max(static_floor_s, observed_budget_s)
+    final = min(final, _cap_s())
+    logger.debug(
+        "[DWAdaptiveTimeout] model=%s route=%s prompt_chars=%d "
+        "static_floor=%.2fs observed_p99=%.0fms × %.2f = %.2fs "
+        "(samples=%d) → final=%.2fs",
+        model_id, route, prompt_chars,
+        static_floor_s, shape_stats.p99_ms, safety,
+        observed_budget_s, shape_stats.sample_count, final,
+    )
+    return final
+
+
+__all__ = [
+    "compute_adaptive_timeout",
+    "is_enabled",
+]

--- a/backend/core/ouroboros/governance/dw_capacity_ledger.py
+++ b/backend/core/ouroboros/governance/dw_capacity_ledger.py
@@ -1,0 +1,370 @@
+"""DW Capacity Ledger — Slice 34 substrate (Phase 0).
+
+Closes the v25→v29 diagnostic gap: 5 capability soaks produced
+zero successful DW 397B candidates with no per-(model, shape)
+observation data to attribute the failure. This ledger records
+EVERY outbound DW call's full envelope as one JSONL row, building
+the empirical dataset that §48.7's 4 hypotheses (a-d) need to
+resolve which is true.
+
+# Design discipline (per operator binding)
+
+  * **No shortcuts:** every DW call records — passive observation,
+    no sampling. False negatives (missing records) would invalidate
+    the diagnostic.
+  * **No hardcoding:** every threshold env-knobbed.
+  * **Compose existing:** writes go through
+    :func:`cross_process_jsonl.flock_append_line` (Slice 33 Arc 2
+    Phase 2 instrumented) — no parallel write path.
+  * **Async-native:** :meth:`record_call` dispatches the file write
+    via ``asyncio.to_thread`` so the asyncio loop keeps ticking
+    during file I/O.
+  * **Fail-closed:** any internal error logs at WARN and swallows.
+    Recording failure MUST NEVER affect the provider call's outcome.
+  * **Default ON (passive):** ``JARVIS_DW_CAPACITY_LEDGER_ENABLED``
+    default TRUE — observation has no behavior side-effects.
+
+# Schema (v1)
+
+Each row is one JSON object. Fields:
+
+  schema_version       : "dw_capacity.1"
+  timestamp_unix       : float (record time)
+  model_id             : str (e.g. "Qwen/Qwen3.5-397B-A17B-FP8")
+  route                : str (immediate/standard/complex/background/speculative)
+  prompt_chars         : int (input prompt size)
+  outcome              : str (ok/timeout/infra_error/syntax_error/...)
+  ttft_ms              : float | null (time to first token; streaming only)
+  total_elapsed_ms     : float (wall-clock total)
+  response_tokens      : int | null (output token count if available)
+  response_chars       : int | null (output char count if available)
+  cost_usd             : float (per-call cost)
+  error_class          : str (exception type if outcome != ok; e.g. TimeoutError)
+  error_detail         : str (truncated to 256 chars)
+  caller               : str (op_id or "probe" / "health_probe" / etc.)
+
+# What this module does NOT do
+
+  * Does NOT decide routing (that's :mod:`dw_adaptive_timeout`
+    + :mod:`dw_per_shape_stats`).
+  * Does NOT bound the ledger file size (operators rotate via
+    standard log-rotation tools; future arc may add internal
+    rotation).
+  * Does NOT replace ``PromotionLedger`` (which holds *small
+    persistent state*; this holds *append-only event stream*).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, asdict, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+logger = logging.getLogger("Ouroboros.DWCapacityLedger")
+
+
+# ============================================================================
+# Env knobs (re-read at call time so tests + operators can flip)
+# ============================================================================
+
+
+_LEDGER_ENABLED_ENV: str = "JARVIS_DW_CAPACITY_LEDGER_ENABLED"
+_LEDGER_PATH_ENV: str = "JARVIS_DW_CAPACITY_LEDGER_PATH"
+_DEFAULT_LEDGER_PATH: str = ".jarvis/dw_capacity_ledger.jsonl"
+_ERROR_DETAIL_MAX_CHARS: int = 256
+
+
+def is_enabled() -> bool:
+    """Default TRUE — passive observation has no behaviour effect."""
+    raw = os.environ.get(_LEDGER_ENABLED_ENV, "").strip().lower()
+    if not raw:
+        return True
+    return raw not in ("0", "false", "no", "off")
+
+
+def ledger_path() -> Path:
+    raw = os.environ.get(_LEDGER_PATH_ENV, "").strip()
+    if not raw:
+        raw = _DEFAULT_LEDGER_PATH
+    return Path(raw)
+
+
+# ============================================================================
+# Schema
+# ============================================================================
+
+
+LEDGER_SCHEMA_VERSION = "dw_capacity.1"
+
+
+@dataclass(frozen=True)
+class DWCallRecord:
+    """Frozen envelope of one DW call. All fields IPC-safe primitives."""
+
+    schema_version: str = LEDGER_SCHEMA_VERSION
+    timestamp_unix: float = 0.0
+    model_id: str = ""
+    route: str = ""
+    prompt_chars: int = 0
+    outcome: str = ""
+    ttft_ms: Optional[float] = None
+    total_elapsed_ms: float = 0.0
+    response_tokens: Optional[int] = None
+    response_chars: Optional[int] = None
+    cost_usd: float = 0.0
+    error_class: str = ""
+    error_detail: str = ""
+    caller: str = ""
+
+    def to_jsonl_line(self) -> str:
+        """Render as single JSONL line (trailing newline added by writer)."""
+        d = asdict(self)
+        return json.dumps(d, sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "DWCallRecord":
+        """Parse from dict. Defensive — unknown fields ignored,
+        missing fields take defaults. NEVER raises on malformed input
+        (returns a record with default fields if parse fails)."""
+        try:
+            return cls(
+                schema_version=str(d.get("schema_version", LEDGER_SCHEMA_VERSION)),
+                timestamp_unix=float(d.get("timestamp_unix", 0.0)),
+                model_id=str(d.get("model_id", "")),
+                route=str(d.get("route", "")),
+                prompt_chars=int(d.get("prompt_chars", 0)),
+                outcome=str(d.get("outcome", "")),
+                ttft_ms=(
+                    float(d["ttft_ms"]) if d.get("ttft_ms") is not None
+                    else None
+                ),
+                total_elapsed_ms=float(d.get("total_elapsed_ms", 0.0)),
+                response_tokens=(
+                    int(d["response_tokens"]) if d.get("response_tokens") is not None
+                    else None
+                ),
+                response_chars=(
+                    int(d["response_chars"]) if d.get("response_chars") is not None
+                    else None
+                ),
+                cost_usd=float(d.get("cost_usd", 0.0)),
+                error_class=str(d.get("error_class", "")),
+                error_detail=str(d.get("error_detail", "")),
+                caller=str(d.get("caller", "")),
+            )
+        except Exception:  # noqa: BLE001 — defensive
+            return cls()
+
+
+# ============================================================================
+# Ledger writer
+# ============================================================================
+
+
+class DWCapacityLedger:
+    """Append-only per-call record sink. Composes ``flock_append_line``
+    (Slice 33 Arc 2 Phase 2) for cross-process-safe writes.
+
+    Public API:
+      * :meth:`record_call` — async write of one record
+      * :meth:`read_recent` — sync read of last N records (for stats
+        + REPL inspection)
+      * :meth:`aggregate_by_model_shape` — group + summarize
+    """
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._path = path or ledger_path()
+        # Lazy-create parent dir
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    async def record_call(
+        self,
+        record: DWCallRecord,
+        *,
+        sanitize_error_detail: bool = True,
+    ) -> bool:
+        """Append one record to the ledger.
+
+        Returns True on success, False on any failure. NEVER raises.
+
+        Truncates ``error_detail`` to ``_ERROR_DETAIL_MAX_CHARS`` if
+        ``sanitize_error_detail=True`` (default — prevents accidentally
+        logging a 1 MB stack trace per failed call).
+        """
+        if not is_enabled():
+            return False
+        try:
+            # Sanitize error_detail length to avoid pathological writes
+            rec = record
+            if sanitize_error_detail and len(record.error_detail) > _ERROR_DETAIL_MAX_CHARS:
+                truncated = record.error_detail[:_ERROR_DETAIL_MAX_CHARS] + "...[truncated]"
+                rec = DWCallRecord(
+                    **{**asdict(record), "error_detail": truncated},
+                )
+            line = rec.to_jsonl_line()
+            # Lazy import — avoid module-init cycle.
+            from backend.core.ouroboros.governance.cross_process_jsonl import (
+                flock_append_line,
+            )
+            # Off-loop write — keeps asyncio main thread responsive
+            # even when ledger growth triggers FS sync.
+            ok = await asyncio.to_thread(
+                flock_append_line, self._path, line,
+            )
+            return bool(ok)
+        except Exception as exc:  # noqa: BLE001 — fail-closed
+            logger.warning(
+                "[DWCapacityLedger] record_call failed: %s "
+                "(model=%s outcome=%s)", exc, record.model_id, record.outcome,
+            )
+            return False
+
+    def read_recent(self, limit: int = 1000) -> List[DWCallRecord]:
+        """Read the last N records from the ledger. NEVER raises.
+
+        Returns the records in file order (oldest first within the
+        window). Malformed lines are silently skipped.
+
+        For large ledgers (>10K rows) this reads the entire file —
+        future arc could add tail-only fast path.
+        """
+        if not self._path.exists():
+            return []
+        try:
+            with self._path.open("r", encoding="utf-8") as f:
+                all_lines = f.readlines()
+        except OSError:
+            return []
+        # Take last `limit` lines + parse
+        recent_lines = all_lines[-int(max(1, limit)):]
+        records: List[DWCallRecord] = []
+        for line in recent_lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+                if not isinstance(d, dict):
+                    continue
+                records.append(DWCallRecord.from_dict(d))
+            except (json.JSONDecodeError, ValueError):
+                continue
+        return records
+
+    def aggregate_by_model_shape(
+        self,
+        *,
+        window: int = 1000,
+        prompt_chars_bucket: int = 5000,
+    ) -> Dict[str, Dict[str, Any]]:
+        """Group recent records by ``(model_id, route,
+        prompt_chars // prompt_chars_bucket)`` and produce per-shape
+        summary stats.
+
+        Returns ``{shape_key: {"count": N, "success_rate": R,
+        "p50_ms": ..., "p95_ms": ..., "p99_ms": ...}, ...}`` where
+        shape_key is ``"<model>::<route>::<bucket>"``.
+
+        Pure-function on the file snapshot — no DB, no in-memory state.
+        Suitable for REPL inspection + Phase 2 hypothesis-resolution
+        report generation. NEVER raises.
+        """
+        recs = self.read_recent(limit=window)
+        if not recs:
+            return {}
+        buckets: Dict[str, List[DWCallRecord]] = {}
+        bucket_size = max(1, int(prompt_chars_bucket))
+        for r in recs:
+            key = f"{r.model_id}::{r.route}::{(r.prompt_chars // bucket_size) * bucket_size}"
+            buckets.setdefault(key, []).append(r)
+        out: Dict[str, Dict[str, Any]] = {}
+        for key, group in buckets.items():
+            n = len(group)
+            successes = sum(1 for g in group if g.outcome == "ok")
+            latencies = sorted(g.total_elapsed_ms for g in group)
+            out[key] = {
+                "count": n,
+                "success_rate": (successes / n) if n else 0.0,
+                "p50_ms": _percentile(latencies, 0.50),
+                "p95_ms": _percentile(latencies, 0.95),
+                "p99_ms": _percentile(latencies, 0.99),
+                "ttft_p50_ms": _percentile(
+                    sorted(
+                        g.ttft_ms for g in group if g.ttft_ms is not None
+                    ),
+                    0.50,
+                ),
+                "outcomes": _outcome_histogram(group),
+            }
+        return out
+
+
+def _percentile(sorted_samples: List[float], q: float) -> float:
+    """Nearest-rank percentile. Returns 0.0 on empty input."""
+    n = len(sorted_samples)
+    if n == 0:
+        return 0.0
+    idx = max(0, min(n - 1, int(round(q * n)) - 1))
+    return float(sorted_samples[idx])
+
+
+def _outcome_histogram(records: List[DWCallRecord]) -> Dict[str, int]:
+    """Per-outcome count for one bucket."""
+    hist: Dict[str, int] = {}
+    for r in records:
+        key = r.outcome or "unknown"
+        hist[key] = hist.get(key, 0) + 1
+    return hist
+
+
+# ============================================================================
+# Module-level singleton accessor
+# ============================================================================
+
+
+_default_ledger: Optional[DWCapacityLedger] = None
+
+
+def get_default_ledger() -> DWCapacityLedger:
+    """Lazy module-level singleton. Per-process; tests can replace
+    via ``reset_for_tests``."""
+    global _default_ledger
+    if _default_ledger is None:
+        _default_ledger = DWCapacityLedger()
+    return _default_ledger
+
+
+def reset_for_tests() -> None:
+    """Test isolation — clears singleton so next call gets a fresh
+    ledger pointing at the (possibly-overridden) env path."""
+    global _default_ledger
+    _default_ledger = None
+
+
+# ============================================================================
+# Public surface
+# ============================================================================
+
+
+__all__ = [
+    "DWCallRecord",
+    "DWCapacityLedger",
+    "LEDGER_SCHEMA_VERSION",
+    "get_default_ledger",
+    "is_enabled",
+    "ledger_path",
+    "reset_for_tests",
+]

--- a/backend/core/ouroboros/governance/dw_capacity_probe.py
+++ b/backend/core/ouroboros/governance/dw_capacity_probe.py
@@ -1,0 +1,566 @@
+"""DW Capacity Probe — Slice 34 substrate (Phase 0).
+
+Out-of-band diagnostic probe. Runs N=10 trials at each of 4 prompt
+sizes against a target DW model, records every call into
+:class:`DWCapacityLedger`, and produces a per-size summary.
+
+# Why "out-of-band"
+
+The probe MUST be invokable independently of the full O+V harness +
+sensor + intake + Aegis daemon — operator binding §48.7.2: *"Isolate
+the variable — is it the harness or the endpoint?"* This module
+takes only a provider instance + ledger; zero coupling to
+orchestrator, sensors, or governance.
+
+# Composition
+
+  * **Provider:** uses ``DoublewordProvider.prompt_only()`` —
+    the lowest-level surface that exercises the same HTTP transport
+    + Aegis bearer + per-call lease + Slice 28 timeout math that
+    production dispatch uses.
+  * **Ledger:** records every trial into the same
+    :class:`DWCapacityLedger` production reads. Probe data + soak
+    data accumulate in the same place so :class:`DWPerShapeStats`
+    sees both.
+  * **No retry loop, no Venom, no orchestrator:** isolation is the
+    point. If the probe succeeds where the harness fails, the
+    delta is the harness — not the endpoint.
+
+# Hypotheses the probe disambiguates (§48.7.3)
+
+  (a) **Account capacity:** probe times out across all prompt sizes
+      with relatively uniform latency → endpoint serving capacity
+      hit — operator-side fix needed.
+  (b) **Slice 28 budget math:** probe succeeds at high latency (e.g.
+      30-60 s) within manually-elevated timeout → static formula was
+      under-budgeting — tune ``JARVIS_ADAPTIVE_TIER0_HEAVY_SCALAR``.
+  (c) **Prompt complexity:** probe succeeds at small sizes but
+      timeouts at large → DW's effective input-size ceiling; refactor
+      prompts or compose §48.9.5 prefix trie.
+  (d) **Network/regional latency:** baseline RTT > ½ of typical
+      response time → physical-path issue; operator switches VPN /
+      region.
+
+# Public surface
+
+  * :class:`ProbeResult` — frozen per-size summary
+  * :class:`DWCapacityProbe.probe` — async entry point
+  * :func:`build_capacity_probe_from_default_provider` — convenience
+    factory used by the operator-runnable script
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from backend.core.ouroboros.governance.dw_capacity_ledger import (
+    DWCallRecord,
+    DWCapacityLedger,
+    get_default_ledger,
+)
+
+
+logger = logging.getLogger("Ouroboros.DWCapacityProbe")
+
+
+# ============================================================================
+# Probe configuration
+# ============================================================================
+
+
+_DEFAULT_PROMPT_SIZES: List[int] = [1024, 5120, 20480, 51200]
+_DEFAULT_TRIALS_PER_SIZE: int = 10
+_DEFAULT_TIMEOUT_PER_CALL_S: float = 60.0
+_DEFAULT_PROBE_CALLER: str = "dw_capacity_probe"
+
+# Templated probe prompt — deterministic, repeatable, exercises code-gen
+# instinct without depending on any external data.
+_PROBE_TEMPLATE = (
+    "You are a helpful assistant. Produce a single Python function "
+    "called `compute_sum` that takes a list of integers and returns "
+    "the sum. Include a one-sentence docstring. Output only the "
+    "function definition. "
+    "Padding for size testing follows; please ignore it: "
+)
+
+
+def _build_probe_prompt(target_chars: int) -> str:
+    """Construct a prompt of approximately ``target_chars`` size.
+
+    Uses ``_PROBE_TEMPLATE`` as the load-bearing instruction + ASCII
+    padding ('x') to hit the target size. Deterministic — same input
+    size produces same prompt across runs."""
+    if target_chars <= len(_PROBE_TEMPLATE):
+        return _PROBE_TEMPLATE
+    padding_chars = target_chars - len(_PROBE_TEMPLATE)
+    return _PROBE_TEMPLATE + ("x" * padding_chars)
+
+
+# ============================================================================
+# Result types
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class ProbeTrial:
+    """One probe trial's empirical outcome."""
+
+    target_size: int
+    outcome: str               # ok / timeout / error
+    total_elapsed_ms: float
+    response_chars: int = 0
+    error_class: str = ""
+    error_detail: str = ""
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Per-size aggregate. Captures enough data to disambiguate the
+    4 hypotheses from §48.7.1."""
+
+    model_id: str
+    target_size: int
+    trials_run: int
+    successes: int
+    timeouts: int
+    other_failures: int
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    max_ms: float
+    min_ms: float
+    avg_response_chars: float
+    trials: List[ProbeTrial] = field(default_factory=list)
+
+    @property
+    def success_rate(self) -> float:
+        return (self.successes / self.trials_run) if self.trials_run else 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "target_size": self.target_size,
+            "trials_run": self.trials_run,
+            "successes": self.successes,
+            "timeouts": self.timeouts,
+            "other_failures": self.other_failures,
+            "success_rate": self.success_rate,
+            "p50_ms": self.p50_ms,
+            "p95_ms": self.p95_ms,
+            "p99_ms": self.p99_ms,
+            "max_ms": self.max_ms,
+            "min_ms": self.min_ms,
+            "avg_response_chars": self.avg_response_chars,
+        }
+
+
+# ============================================================================
+# Probe
+# ============================================================================
+
+
+class DWCapacityProbe:
+    """Out-of-band capacity diagnostic.
+
+    Composes any object that exposes ``async prompt_only(prompt: str,
+    *, model_id: str = ..., timeout_s: float = ...) -> str`` — the
+    canonical DW provider surface. Tests inject fakes; production
+    code uses ``build_capacity_probe_from_default_provider()``.
+
+    NEVER raises into the caller. Per-trial errors are captured as
+    ``ProbeTrial(outcome=...)`` entries; aggregate ``ProbeResult``
+    is always populated.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: Any,
+        ledger: Optional[DWCapacityLedger] = None,
+        prompt_builder: Optional[Callable[[int], str]] = None,
+    ) -> None:
+        self._provider = provider
+        self._ledger = ledger or get_default_ledger()
+        self._prompt_builder = prompt_builder or _build_probe_prompt
+
+    async def probe(
+        self,
+        *,
+        model_id: str,
+        prompt_sizes: Optional[List[int]] = None,
+        trials_per_size: int = _DEFAULT_TRIALS_PER_SIZE,
+        timeout_per_call_s: float = _DEFAULT_TIMEOUT_PER_CALL_S,
+        caller: str = _DEFAULT_PROBE_CALLER,
+    ) -> List[ProbeResult]:
+        """Run the full probe matrix. Returns one
+        :class:`ProbeResult` per ``prompt_sizes`` entry.
+
+        Args:
+          model_id: DW model to target.
+          prompt_sizes: input sizes to test. Defaults to
+            ``[1024, 5120, 20480, 51200]`` (1KB, 5KB, 20KB, 50KB).
+          trials_per_size: N trials per size (default 10).
+          timeout_per_call_s: per-call timeout. Set generously
+            (default 60s) — probe wants to MEASURE actual response
+            time, not exit at the production Slice 28 budget.
+          caller: ledger ``caller`` field for filtering probe data
+            from production data in later analysis.
+
+        Returns:
+          List of ProbeResult, one per prompt size, in input order.
+        """
+        sizes = list(prompt_sizes or _DEFAULT_PROMPT_SIZES)
+        results: List[ProbeResult] = []
+        for size in sizes:
+            trials: List[ProbeTrial] = []
+            for trial_idx in range(int(max(1, trials_per_size))):
+                trial = await self._run_one_trial(
+                    model_id=model_id,
+                    size=size,
+                    timeout_s=timeout_per_call_s,
+                    caller=caller,
+                )
+                trials.append(trial)
+                logger.info(
+                    "[DWCapacityProbe] model=%s size=%d trial=%d/%d "
+                    "outcome=%s elapsed_ms=%.1f response_chars=%d",
+                    model_id, size, trial_idx + 1,
+                    max(1, trials_per_size),
+                    trial.outcome, trial.total_elapsed_ms,
+                    trial.response_chars,
+                )
+            results.append(_aggregate_trials(model_id, size, trials))
+        return results
+
+    async def _run_one_trial(
+        self,
+        *,
+        model_id: str,
+        size: int,
+        timeout_s: float,
+        caller: str,
+    ) -> ProbeTrial:
+        """Single probe trial. Records into ledger; never raises."""
+        prompt = self._prompt_builder(size)
+        actual_prompt_chars = len(prompt)
+        t0 = time.monotonic()
+        outcome = "error"
+        response_text = ""
+        error_class = ""
+        error_detail = ""
+        try:
+            response_text = await asyncio.wait_for(
+                self._call_provider(prompt, model_id=model_id),
+                timeout=timeout_s,
+            )
+            outcome = "ok"
+        except asyncio.TimeoutError:
+            outcome = "timeout"
+            error_class = "TimeoutError"
+            error_detail = f"probe timeout after {timeout_s:.1f}s"
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            outcome = "error"
+            error_class = type(exc).__name__
+            error_detail = str(exc)
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+        response_chars = len(response_text or "")
+        # Record into ledger (await — but if it fails, trial still
+        # captured)
+        try:
+            await self._ledger.record_call(DWCallRecord(
+                timestamp_unix=time.time(),
+                model_id=model_id,
+                route="probe",
+                prompt_chars=actual_prompt_chars,
+                outcome=outcome,
+                ttft_ms=None,  # prompt_only doesn't expose TTFT
+                total_elapsed_ms=elapsed_ms,
+                response_tokens=None,
+                response_chars=response_chars,
+                cost_usd=0.0,  # probe doesn't track cost — diagnostic only
+                error_class=error_class,
+                error_detail=error_detail,
+                caller=caller,
+            ))
+        except Exception:  # noqa: BLE001 — never raise from probe
+            pass
+        return ProbeTrial(
+            target_size=size,
+            outcome=outcome,
+            total_elapsed_ms=elapsed_ms,
+            response_chars=response_chars,
+            error_class=error_class,
+            error_detail=error_detail,
+        )
+
+    async def _call_provider(
+        self,
+        prompt: str,
+        *,
+        model_id: str,
+    ) -> str:
+        """Wrapped provider call. Accepts any provider-shaped object
+        with ``async prompt_only(prompt, model_id=...) -> str``.
+
+        Falls back to plain ``prompt_only(prompt)`` for older providers
+        that don't accept ``model_id`` kwarg — minimal surface, max
+        compatibility."""
+        # Try the modern signature first
+        try:
+            return await self._provider.prompt_only(
+                prompt, model_id=model_id,
+            )
+        except TypeError:
+            # Legacy provider — drop the kwarg
+            return await self._provider.prompt_only(prompt)
+
+
+def _aggregate_trials(
+    model_id: str,
+    size: int,
+    trials: List[ProbeTrial],
+) -> ProbeResult:
+    """Pure-function aggregation. Never raises."""
+    n = len(trials)
+    if n == 0:
+        return ProbeResult(
+            model_id=model_id,
+            target_size=size,
+            trials_run=0,
+            successes=0,
+            timeouts=0,
+            other_failures=0,
+            p50_ms=0.0, p95_ms=0.0, p99_ms=0.0,
+            max_ms=0.0, min_ms=0.0,
+            avg_response_chars=0.0,
+            trials=[],
+        )
+    successes = sum(1 for t in trials if t.outcome == "ok")
+    timeouts = sum(1 for t in trials if t.outcome == "timeout")
+    other = n - successes - timeouts
+    latencies = sorted(t.total_elapsed_ms for t in trials)
+    response_chars = [t.response_chars for t in trials if t.outcome == "ok"]
+    avg_response = (
+        sum(response_chars) / len(response_chars) if response_chars else 0.0
+    )
+    return ProbeResult(
+        model_id=model_id,
+        target_size=size,
+        trials_run=n,
+        successes=successes,
+        timeouts=timeouts,
+        other_failures=other,
+        p50_ms=_percentile(latencies, 0.50),
+        p95_ms=_percentile(latencies, 0.95),
+        p99_ms=_percentile(latencies, 0.99),
+        max_ms=max(latencies),
+        min_ms=min(latencies),
+        avg_response_chars=avg_response,
+        trials=list(trials),
+    )
+
+
+def _percentile(sorted_samples: List[float], q: float) -> float:
+    n = len(sorted_samples)
+    if n == 0:
+        return 0.0
+    idx = max(0, min(n - 1, int(round(q * n)) - 1))
+    return float(sorted_samples[idx])
+
+
+# ============================================================================
+# Convenience factory for the operator-runnable script
+# ============================================================================
+
+
+def build_capacity_probe_from_default_provider() -> DWCapacityProbe:
+    """Build a probe pointing at the default DW provider + default
+    ledger. Used by ``scripts/dw_capacity_probe.py``.
+
+    Lazy import — avoids coupling this module's import path to the
+    full provider stack when only the substrate is needed (tests
+    import this module without instantiating a real provider).
+    """
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordProvider,
+    )
+    provider = DoublewordProvider()
+    return DWCapacityProbe(provider=provider)
+
+
+# ============================================================================
+# Hypothesis classifier (Phase 0 → Phase 1 bridge)
+# ============================================================================
+
+
+def classify_probe_results(
+    results: List[ProbeResult],
+) -> Dict[str, Any]:
+    """Apply §48.7.1's 4-hypothesis decision matrix to the probe
+    output. Returns a structured verdict for operators + downstream
+    Phase 1 tooling.
+
+    Verdict keys:
+      hypothesis            : str — "a"|"b"|"c"|"d"|"mixed"|"undetermined"
+      confidence            : float (0-1)
+      reasoning             : str (human-readable)
+      recommended_action    : str (next operator step)
+      per_size_summary      : list of dicts
+
+    This is heuristic — operator binding "intelligent" not "ML-trained."
+    Single-pass deterministic over the probe data. Pure function.
+    """
+    if not results:
+        return {
+            "hypothesis": "undetermined",
+            "confidence": 0.0,
+            "reasoning": "no probe results provided",
+            "recommended_action": "re-run probe",
+            "per_size_summary": [],
+        }
+
+    summaries = [r.to_dict() for r in results]
+    # Sort by target_size ascending
+    by_size = sorted(results, key=lambda r: r.target_size)
+
+    # Heuristic decisions
+    all_failed = all(r.success_rate == 0.0 for r in by_size)
+    all_succeeded = all(r.success_rate >= 0.8 for r in by_size)
+    size_correlated_failure = (
+        by_size[0].success_rate >= 0.5
+        and by_size[-1].success_rate <= 0.2
+    )
+    high_latency_succeeded = any(
+        r.success_rate >= 0.5 and r.p95_ms >= 30_000.0 for r in by_size
+    )
+
+    if all_failed:
+        # Hypothesis (a) or (d) — endpoint unreachable or fundamentally over budget
+        smallest = by_size[0]
+        if smallest.p95_ms < 5_000.0:
+            # Failed FAST → network/auth, not capacity
+            return {
+                "hypothesis": "d",
+                "confidence": 0.7,
+                "reasoning": (
+                    f"All sizes failed with p95<5s on smallest "
+                    f"({smallest.p95_ms:.0f}ms). Suggests network/auth "
+                    f"path issue, not capacity exhaustion."
+                ),
+                "recommended_action": (
+                    "Measure raw TCP RTT to DW endpoint; verify Aegis "
+                    "bearer; check for HTTP 4xx in ledger error_class "
+                    "field."
+                ),
+                "per_size_summary": summaries,
+            }
+        return {
+            "hypothesis": "a",
+            "confidence": 0.65,
+            "reasoning": (
+                f"All sizes failed with elevated latency (smallest "
+                f"p95={smallest.p95_ms:.0f}ms). Suggests DW endpoint "
+                f"capacity exhaustion on this account."
+            ),
+            "recommended_action": (
+                "Contact DW for capacity diagnosis; consider Slice 22 "
+                "tier-decay with raised JARVIS_CLAUDE_SESSION_CAP_USD "
+                "(§48.11) as temporary fallback."
+            ),
+            "per_size_summary": summaries,
+        }
+
+    if size_correlated_failure:
+        # Hypothesis (c) — prompt complexity is the variable
+        return {
+            "hypothesis": "c",
+            "confidence": 0.85,
+            "reasoning": (
+                f"Smallest size ({by_size[0].target_size}B) succeeds "
+                f"({by_size[0].success_rate:.0%}); largest "
+                f"({by_size[-1].target_size}B) fails "
+                f"({by_size[-1].success_rate:.0%}). Endpoint capacity "
+                f"is sufficient for small inputs but breaks down at "
+                f"scale."
+            ),
+            "recommended_action": (
+                "Refactor O+V prompts to stay below the empirical "
+                "ceiling (likely between "
+                f"{by_size[0].target_size}B and "
+                f"{by_size[-1].target_size}B); §48.9.5 prefix-trie "
+                "candidate."
+            ),
+            "per_size_summary": summaries,
+        }
+
+    if high_latency_succeeded:
+        # Hypothesis (b) — DW works but slowly; static budget under-sized
+        max_p95 = max(r.p95_ms for r in by_size if r.success_rate >= 0.5)
+        return {
+            "hypothesis": "b",
+            "confidence": 0.8,
+            "reasoning": (
+                f"DW succeeds with elevated latency (max successful "
+                f"p95={max_p95:.0f}ms). Slice 28 static budget "
+                f"(default 75s heavy-model) may under-budget actual "
+                f"response times."
+            ),
+            "recommended_action": (
+                f"Raise JARVIS_ADAPTIVE_TIER0_CAP_S above "
+                f"{(max_p95/1000)*1.5:.0f}s OR enable "
+                f"JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED=1 (Slice 34's "
+                f"adaptive-timeout substrate)."
+            ),
+            "per_size_summary": summaries,
+        }
+
+    if all_succeeded:
+        # No defect detected in probe — issue is harness-side
+        return {
+            "hypothesis": "harness_variable",
+            "confidence": 0.9,
+            "reasoning": (
+                "All probe sizes succeeded with healthy success rates. "
+                "DW endpoint + auth + network are functional. The "
+                "v25→v29 100% TIMEOUT rate is a harness-side variable "
+                "(orchestrator, sensor load, intake pressure, or "
+                "GIL contention raising effective per-call latency)."
+            ),
+            "recommended_action": (
+                "Re-run v30 soak with LoopSink enabled; compare per-call "
+                "latency in production ledger vs probe ledger; identify "
+                "harness-side dispatch overhead."
+            ),
+            "per_size_summary": summaries,
+        }
+
+    return {
+        "hypothesis": "mixed",
+        "confidence": 0.4,
+        "reasoning": (
+            "Probe results don't cleanly match any single hypothesis. "
+            "Suggests multi-factor interaction — re-run with more "
+            "trials per size for statistical power."
+        ),
+        "recommended_action": (
+            "Increase trials_per_size to 30; inspect per_size_summary "
+            "manually."
+        ),
+        "per_size_summary": summaries,
+    }
+
+
+__all__ = [
+    "DWCapacityProbe",
+    "ProbeResult",
+    "ProbeTrial",
+    "build_capacity_probe_from_default_provider",
+    "classify_probe_results",
+]

--- a/backend/core/ouroboros/governance/dw_per_shape_stats.py
+++ b/backend/core/ouroboros/governance/dw_per_shape_stats.py
@@ -1,0 +1,263 @@
+"""DW Per-Shape Statistics — Slice 34 substrate (Phase 0).
+
+Rolling p50/p95/p99 + success-rate aggregator over the
+:class:`DWCapacityLedger` event stream. Operates per
+``(model_id, route, prompt_size_bucket)`` shape so a 397B on a
+20 KB STANDARD op gets its own stats from a 35B on the same shape
+or a 397B on a 5 KB IMMEDIATE op.
+
+# Design discipline
+
+  * **Composes existing:** reads via :meth:`DWCapacityLedger.read_recent`
+    — no parallel storage. Cached for ``_CACHE_TTL_S`` (default 30s)
+    to avoid re-parsing the file on every dispatch.
+  * **No hardcoding:** window size, prompt bucket size, cache TTL,
+    minimum-samples-for-confidence all env-knobbed.
+  * **Fail-closed:** :meth:`stats_for_shape` returns ``None`` when
+    insufficient samples — caller must fall through to static formula.
+  * **Pure-function inference:** stats are derived from the snapshot;
+    no in-memory mutation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from backend.core.ouroboros.governance.dw_capacity_ledger import (
+    DWCallRecord,
+    DWCapacityLedger,
+    get_default_ledger,
+)
+
+
+logger = logging.getLogger("Ouroboros.DWPerShapeStats")
+
+
+# ============================================================================
+# Env knobs
+# ============================================================================
+
+
+_WINDOW_SIZE_ENV: str = "JARVIS_DW_PER_SHAPE_WINDOW"
+_BUCKET_SIZE_ENV: str = "JARVIS_DW_PER_SHAPE_PROMPT_BUCKET_CHARS"
+_CACHE_TTL_ENV: str = "JARVIS_DW_PER_SHAPE_CACHE_TTL_S"
+_MIN_SAMPLES_ENV: str = "JARVIS_DW_PER_SHAPE_MIN_SAMPLES"
+
+_DEFAULT_WINDOW_SIZE: int = 500
+_DEFAULT_BUCKET_SIZE: int = 5000     # 5 KB buckets
+_DEFAULT_CACHE_TTL_S: float = 30.0
+_DEFAULT_MIN_SAMPLES: int = 10
+
+
+def _window_size() -> int:
+    try:
+        raw = os.environ.get(_WINDOW_SIZE_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_WINDOW_SIZE
+        return max(10, int(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_WINDOW_SIZE
+
+
+def _bucket_size() -> int:
+    try:
+        raw = os.environ.get(_BUCKET_SIZE_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_BUCKET_SIZE
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_BUCKET_SIZE
+
+
+def _cache_ttl_s() -> float:
+    try:
+        raw = os.environ.get(_CACHE_TTL_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_CACHE_TTL_S
+        return max(1.0, float(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_CACHE_TTL_S
+
+
+def _min_samples() -> int:
+    try:
+        raw = os.environ.get(_MIN_SAMPLES_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_MIN_SAMPLES
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_MIN_SAMPLES
+
+
+# ============================================================================
+# Result type
+# ============================================================================
+
+
+@dataclass(frozen=True)
+class ShapeStats:
+    """Aggregated per-shape latency + success stats from a recent
+    sliding window of the ledger. Frozen — recompute via
+    :meth:`DWPerShapeStats.stats_for_shape` if you need fresher data.
+    """
+
+    model_id: str
+    route: str
+    prompt_bucket: int          # prompt_chars rounded down to bucket
+    sample_count: int
+    success_rate: float          # 0.0 - 1.0
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    ttft_p50_ms: float           # 0.0 when no TTFT records
+    last_observed_unix: float
+
+
+# ============================================================================
+# Aggregator
+# ============================================================================
+
+
+class DWPerShapeStats:
+    """Per-shape rolling aggregator backed by ``DWCapacityLedger``.
+
+    Caches the ledger snapshot for ``_CACHE_TTL_S`` to amortize
+    file-read cost across many dispatch decisions. Cache is
+    per-instance — the module-level singleton reads it.
+
+    NEVER raises into the caller. On any internal error (ledger
+    read failure, malformed data), returns ``None`` from
+    :meth:`stats_for_shape` and the caller falls through to the
+    static formula in :mod:`dw_adaptive_timeout`.
+    """
+
+    def __init__(
+        self,
+        ledger: Optional[DWCapacityLedger] = None,
+    ) -> None:
+        self._ledger = ledger or get_default_ledger()
+        self._cache: Dict[Tuple[str, str, int], ShapeStats] = {}
+        self._cache_built_at: float = 0.0
+        self._cache_lock_held: bool = False
+
+    def _maybe_rebuild_cache(self) -> None:
+        """Rebuild cache if older than TTL. Single-threaded by
+        design (asyncio loop is the only caller path)."""
+        now = time.monotonic()
+        if (now - self._cache_built_at) < _cache_ttl_s():
+            return
+        try:
+            recs = self._ledger.read_recent(limit=_window_size())
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[DWPerShapeStats] ledger read failed: %s", exc,
+            )
+            return
+        new_cache: Dict[Tuple[str, str, int], List[DWCallRecord]] = {}
+        bucket = _bucket_size()
+        for r in recs:
+            key = (
+                r.model_id,
+                r.route,
+                (r.prompt_chars // bucket) * bucket,
+            )
+            new_cache.setdefault(key, []).append(r)
+        # Build ShapeStats for each non-empty bucket
+        self._cache.clear()
+        for key, group in new_cache.items():
+            n = len(group)
+            if n == 0:
+                continue
+            successes = sum(1 for g in group if g.outcome == "ok")
+            latencies = sorted(g.total_elapsed_ms for g in group)
+            ttfts = sorted(
+                g.ttft_ms for g in group if g.ttft_ms is not None
+            )
+            last_ts = max(g.timestamp_unix for g in group)
+            self._cache[key] = ShapeStats(
+                model_id=key[0],
+                route=key[1],
+                prompt_bucket=key[2],
+                sample_count=n,
+                success_rate=successes / n,
+                p50_ms=_percentile(latencies, 0.50),
+                p95_ms=_percentile(latencies, 0.95),
+                p99_ms=_percentile(latencies, 0.99),
+                ttft_p50_ms=_percentile(ttfts, 0.50),
+                last_observed_unix=last_ts,
+            )
+        self._cache_built_at = now
+
+    def stats_for_shape(
+        self,
+        *,
+        model_id: str,
+        route: str,
+        prompt_chars: int,
+    ) -> Optional[ShapeStats]:
+        """Return rolling stats for the given shape, or ``None`` if
+        insufficient samples (< ``_min_samples()``). Caller MUST
+        treat ``None`` as "no evidence — use static formula."
+        """
+        self._maybe_rebuild_cache()
+        bucket = _bucket_size()
+        key = (
+            model_id,
+            (route or "").strip().lower(),
+            (max(0, int(prompt_chars)) // bucket) * bucket,
+        )
+        stats = self._cache.get(key)
+        if stats is None or stats.sample_count < _min_samples():
+            return None
+        return stats
+
+    def snapshot(self) -> Dict[Tuple[str, str, int], ShapeStats]:
+        """Read-only copy of the full cache. For REPL inspection +
+        Phase 2 hypothesis-resolution reports."""
+        self._maybe_rebuild_cache()
+        return dict(self._cache)
+
+    def invalidate(self) -> None:
+        """Force cache rebuild on next read. Used by tests."""
+        self._cache_built_at = 0.0
+
+
+def _percentile(sorted_samples: List[float], q: float) -> float:
+    n = len(sorted_samples)
+    if n == 0:
+        return 0.0
+    idx = max(0, min(n - 1, int(round(q * n)) - 1))
+    return float(sorted_samples[idx])
+
+
+# ============================================================================
+# Module-level singleton
+# ============================================================================
+
+
+_default_stats: Optional[DWPerShapeStats] = None
+
+
+def get_default_stats() -> DWPerShapeStats:
+    """Lazy module singleton — composes the default ledger."""
+    global _default_stats
+    if _default_stats is None:
+        _default_stats = DWPerShapeStats()
+    return _default_stats
+
+
+def reset_for_tests() -> None:
+    global _default_stats
+    _default_stats = None
+
+
+__all__ = [
+    "DWPerShapeStats",
+    "ShapeStats",
+    "get_default_stats",
+    "reset_for_tests",
+]

--- a/scripts/dw_capacity_probe.py
+++ b/scripts/dw_capacity_probe.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Slice 34 Phase 0 — DW capacity probe runner.
+
+Operator-runnable diagnostic. Loads the configured DW provider,
+runs the standard probe matrix (4 prompt sizes × N trials), records
+into the DW capacity ledger, prints summary + hypothesis verdict.
+
+Usage:
+
+    # Default (probes 397B with 1/5/20/50KB × 10 trials, 60s timeout)
+    python3 scripts/dw_capacity_probe.py
+
+    # Custom model
+    python3 scripts/dw_capacity_probe.py --model Qwen/Qwen3.5-35B-A3B-FP8
+
+    # Tighter or wider trial count
+    python3 scripts/dw_capacity_probe.py --trials 30
+
+    # Custom prompt sizes (comma-sep KB values)
+    python3 scripts/dw_capacity_probe.py --sizes 1,5,20,50,100
+
+    # Custom per-call timeout (default 60s — set higher to MEASURE
+    # actual response time vs production Slice 28 budget)
+    python3 scripts/dw_capacity_probe.py --timeout 120
+
+The script writes structured probe events to the standard DW
+capacity ledger (``.jarvis/dw_capacity_ledger.jsonl`` by default,
+override via ``JARVIS_DW_CAPACITY_LEDGER_PATH``) AND prints a
+human-readable summary table + Phase 0 → Phase 1 hypothesis verdict
+to stdout. Exit code: 0 on probe completion (regardless of DW
+outcome); 1 only on script-level errors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+
+# Add project root to sys.path so we can import backend.* from any cwd
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _setup_logging(verbose: bool) -> None:
+    """Lightweight log setup — probe shouldn't pull in the heavyweight
+    harness logging config."""
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    # Suppress noisy aiohttp at INFO unless verbose
+    if not verbose:
+        logging.getLogger("aiohttp").setLevel(logging.WARNING)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="DW capacity probe — Slice 34 Phase 0",
+    )
+    p.add_argument(
+        "--model",
+        default="Qwen/Qwen3.5-397B-A17B-FP8",
+        help="DW model_id to probe (default: %(default)s)",
+    )
+    p.add_argument(
+        "--sizes",
+        default="1,5,20,50",
+        help="Comma-separated prompt sizes in KB (default: %(default)s)",
+    )
+    p.add_argument(
+        "--trials",
+        type=int,
+        default=10,
+        help="Trials per prompt size (default: %(default)s)",
+    )
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=60.0,
+        help=(
+            "Per-call timeout in seconds (default: %(default)s — "
+            "set higher to measure actual response time)"
+        ),
+    )
+    p.add_argument(
+        "--caller",
+        default="dw_capacity_probe.cli",
+        help="Ledger 'caller' field for filtering (default: %(default)s)",
+    )
+    p.add_argument(
+        "-v", "--verbose", action="store_true",
+        help="Enable DEBUG logging",
+    )
+    return p.parse_args(argv)
+
+
+def _print_summary_table(results: list) -> None:
+    """Human-readable summary table for stdout."""
+    print()
+    print("=" * 88)
+    print(
+        f"{'size (chars)':<14} {'trials':>8} {'ok':>4} "
+        f"{'timeout':>8} {'other':>6} {'p50ms':>8} "
+        f"{'p95ms':>8} {'p99ms':>8} {'max ms':>8} {'resp chars':>10}"
+    )
+    print("-" * 88)
+    for r in results:
+        print(
+            f"{r.target_size:<14d} {r.trials_run:>8d} "
+            f"{r.successes:>4d} {r.timeouts:>8d} "
+            f"{r.other_failures:>6d} {r.p50_ms:>8.0f} "
+            f"{r.p95_ms:>8.0f} {r.p99_ms:>8.0f} "
+            f"{r.max_ms:>8.0f} {r.avg_response_chars:>10.0f}"
+        )
+    print("=" * 88)
+
+
+def _print_verdict(verdict: dict) -> None:
+    """Print the Phase 0 → Phase 1 hypothesis verdict."""
+    print()
+    print("=" * 88)
+    print("§48.7 PHASE 0 → PHASE 1 HYPOTHESIS VERDICT")
+    print("=" * 88)
+    print(f"hypothesis         : {verdict['hypothesis']}")
+    print(f"confidence         : {verdict['confidence']:.2f}")
+    print()
+    print(f"reasoning          :")
+    for line in verdict["reasoning"].split(". "):
+        if line.strip():
+            print(f"  {line.strip()}")
+    print()
+    print(f"recommended_action :")
+    for line in verdict["recommended_action"].split(". "):
+        if line.strip():
+            print(f"  {line.strip()}")
+    print("=" * 88)
+
+
+async def _amain(argv: list[str]) -> int:
+    args = _parse_args(argv)
+    _setup_logging(args.verbose)
+
+    # Lazy imports — avoid pulling the full backend stack during arg parse
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        get_default_ledger,
+        ledger_path,
+        is_enabled as ledger_is_enabled,
+    )
+    from backend.core.ouroboros.governance.dw_capacity_probe import (
+        build_capacity_probe_from_default_provider,
+        classify_probe_results,
+    )
+
+    if not ledger_is_enabled():
+        print(
+            "WARNING: JARVIS_DW_CAPACITY_LEDGER_ENABLED=false — "
+            "probe will run but no records will be persisted.",
+            file=sys.stderr,
+        )
+
+    # Parse prompt sizes (KB → chars)
+    try:
+        sizes_kb = [int(s.strip()) for s in args.sizes.split(",") if s.strip()]
+    except ValueError as exc:
+        print(f"ERROR: invalid --sizes value: {exc}", file=sys.stderr)
+        return 1
+    if not sizes_kb:
+        print("ERROR: --sizes must list at least one value", file=sys.stderr)
+        return 1
+    sizes_chars = [kb * 1024 for kb in sizes_kb]
+
+    ledger = get_default_ledger()
+    print(f"Ledger path        : {ledger.path}")
+    print(f"Model              : {args.model}")
+    print(f"Prompt sizes (KB)  : {sizes_kb}")
+    print(f"Trials per size    : {args.trials}")
+    print(f"Per-call timeout   : {args.timeout}s")
+    print(f"Caller             : {args.caller}")
+    print()
+
+    try:
+        probe = build_capacity_probe_from_default_provider()
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"ERROR: failed to build probe — {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Running {len(sizes_chars) * args.trials} probe trials...")
+    try:
+        results = await probe.probe(
+            model_id=args.model,
+            prompt_sizes=sizes_chars,
+            trials_per_size=args.trials,
+            timeout_per_call_s=args.timeout,
+            caller=args.caller,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"ERROR: probe execution failed — {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    _print_summary_table(results)
+    verdict = classify_probe_results(results)
+    _print_verdict(verdict)
+
+    # Also emit a machine-readable summary JSON line on stderr so
+    # automation can capture it
+    summary = {
+        "schema": "dw_probe_summary.1",
+        "model_id": args.model,
+        "verdict": verdict,
+        "results": [r.to_dict() for r in results],
+    }
+    print("\n--- machine-readable summary (stderr) ---", file=sys.stderr)
+    print(json.dumps(summary, sort_keys=True), file=sys.stderr)
+    return 0
+
+
+def main() -> None:
+    sys.exit(asyncio.run(_amain(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/governance/test_slice34_dw_capacity_investigation.py
+++ b/tests/governance/test_slice34_dw_capacity_investigation.py
@@ -1,0 +1,753 @@
+"""Slice 34 — DW Capacity Investigation Substrate.
+
+Tests the 4 substrate modules + probe + adaptive timeout composition
+that resolve the v25→v29 capability blocker (DW 397B 100% TIMEOUT).
+
+Substrate (per §48.7):
+  * ``dw_capacity_ledger.py`` — per-call JSONL ledger
+  * ``dw_per_shape_stats.py`` — rolling p50/p95/p99 aggregator
+  * ``dw_adaptive_timeout.py`` — observation-driven timeout
+  * ``dw_capacity_probe.py`` — out-of-band probe + hypothesis
+    classifier
+
+Test surface (6 AST pins + 20 spine = 26 tests).
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import List
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEDGER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "dw_capacity_ledger.py"
+)
+STATS_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "dw_per_shape_stats.py"
+)
+TIMEOUT_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "dw_adaptive_timeout.py"
+)
+PROBE_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "dw_capacity_probe.py"
+)
+SCRIPT_FILE = REPO_ROOT / "scripts" / "dw_capacity_probe.py"
+
+
+@pytest.fixture
+def tmp_ledger_env(monkeypatch, tmp_path):
+    """Isolated ledger per test."""
+    p = tmp_path / "ledger.jsonl"
+    monkeypatch.setenv("JARVIS_DW_CAPACITY_LEDGER_PATH", str(p))
+    monkeypatch.setenv("JARVIS_DW_CAPACITY_LEDGER_ENABLED", "1")
+    # Reset module singletons that cache the path
+    from backend.core.ouroboros.governance import dw_capacity_ledger as L
+    from backend.core.ouroboros.governance import dw_per_shape_stats as S
+    L.reset_for_tests()
+    S.reset_for_tests()
+    yield p
+    L.reset_for_tests()
+    S.reset_for_tests()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 6
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_ledger_substrate_present() -> None:
+    """``DWCapacityLedger`` + ``DWCallRecord`` + ``record_call`` async +
+    schema versioned. Without these no observation."""
+    src = LEDGER_FILE.read_text()
+    tree = ast.parse(src, filename=str(LEDGER_FILE))
+    found_class = False
+    found_record = False
+    found_async = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            if node.name == "DWCapacityLedger":
+                found_class = True
+                for sub in node.body:
+                    if (
+                        isinstance(sub, ast.AsyncFunctionDef)
+                        and sub.name == "record_call"
+                    ):
+                        found_async = True
+            if node.name == "DWCallRecord":
+                found_record = True
+    assert found_class, "DWCapacityLedger class missing"
+    assert found_record, "DWCallRecord dataclass missing"
+    assert found_async, "DWCapacityLedger.record_call must be async"
+    assert 'LEDGER_SCHEMA_VERSION = "dw_capacity.1"' in src, (
+        "schema version constant missing or wrong value"
+    )
+
+
+def test_ast_pin_ledger_composes_existing_flock_writer() -> None:
+    """Ledger MUST write via ``cross_process_jsonl.flock_append_line``
+    (Slice 33 Arc 2 Phase 2 instrumented surface). NO parallel
+    write path — operator binding 'compose existing.'"""
+    src = LEDGER_FILE.read_text()
+    assert "flock_append_line" in src, (
+        "ledger doesn't compose cross_process_jsonl.flock_append_line — "
+        "duplicates the write path"
+    )
+    # AND it must dispatch off-loop
+    tree = ast.parse(src, filename=str(LEDGER_FILE))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "record_call"
+        ):
+            body = ast.unparse(node)
+            assert "to_thread" in body or "run_in_executor" in body, (
+                "record_call must dispatch off-loop (to_thread/run_in_executor)"
+            )
+            return
+    pytest.fail("record_call not found")
+
+
+def test_ast_pin_stats_composes_ledger_no_parallel_storage() -> None:
+    """``DWPerShapeStats`` MUST read from ``DWCapacityLedger``. NO
+    parallel storage."""
+    src = STATS_FILE.read_text()
+    assert "DWCapacityLedger" in src
+    assert "read_recent" in src, (
+        "stats must read via DWCapacityLedger.read_recent (no parallel DB)"
+    )
+
+
+def test_ast_pin_adaptive_timeout_default_off() -> None:
+    """``JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED`` default FALSE. Substrate
+    ships before behaviour change; v30 graduation flips later."""
+    from backend.core.ouroboros.governance.dw_adaptive_timeout import (
+        is_enabled, _ENABLED_ENV,
+    )
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop(_ENABLED_ENV, None)
+        assert is_enabled() is False, "default must be FALSE (substrate-first)"
+    for truthy in ("1", "true", "TRUE", "yes", "on"):
+        with mock.patch.dict(os.environ, {_ENABLED_ENV: truthy}):
+            assert is_enabled() is True
+
+
+def test_ast_pin_adaptive_timeout_never_below_static_floor() -> None:
+    """Adaptive timeout MUST never return less than ``static_floor_s``
+    even when master flag is on and observed p99 is lower. This is
+    the safety invariant — Slice 27's calibrated math is the floor."""
+    src = TIMEOUT_FILE.read_text()
+    tree = ast.parse(src, filename=str(TIMEOUT_FILE))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "compute_adaptive_timeout"
+        ):
+            body = ast.unparse(node)
+            assert "max(static_floor_s" in body or "max(static_floor" in body, (
+                "compute_adaptive_timeout must use max(static_floor, ...) — "
+                "safety floor invariant"
+            )
+            return
+    pytest.fail("compute_adaptive_timeout not located")
+
+
+def test_ast_pin_probe_no_orchestrator_coupling() -> None:
+    """Probe MUST NOT import orchestrator / sensor / intake modules —
+    operator binding §48.7.2: 'isolate the variable.'"""
+    src = PROBE_FILE.read_text()
+    tree = ast.parse(src, filename=str(PROBE_FILE))
+    forbidden_prefixes = (
+        "backend.core.ouroboros.governance.orchestrator",
+        "backend.core.ouroboros.governance.candidate_generator",
+        "backend.core.ouroboros.governance.intake",
+        "backend.core.ouroboros.governance.tool_executor",
+        "backend.core.ouroboros.battle_test",
+    )
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module and any(
+                node.module.startswith(p) for p in forbidden_prefixes
+            ):
+                pytest.fail(
+                    f"probe imports forbidden coupling: {node.module}"
+                )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 20
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_ledger_record_call_writes_jsonl(tmp_ledger_env) -> None:
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCallRecord, DWCapacityLedger,
+    )
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        ok = await ledger.record_call(DWCallRecord(
+            timestamp_unix=time.time(),
+            model_id="test/foo",
+            route="standard",
+            prompt_chars=100,
+            outcome="ok",
+            total_elapsed_ms=42.0,
+            cost_usd=0.001,
+        ))
+        assert ok is True
+        # File should exist with one line
+        assert tmp_ledger_env.exists()
+        lines = tmp_ledger_env.read_text().strip().split("\n")
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["model_id"] == "test/foo"
+        assert parsed["outcome"] == "ok"
+        assert parsed["schema_version"] == "dw_capacity.1"
+
+    asyncio.run(run())
+
+
+def test_spine_ledger_disabled_master_skips_write(monkeypatch, tmp_path) -> None:
+    """Master flag OFF → record_call returns False without touching disk."""
+    p = tmp_path / "ledger.jsonl"
+    monkeypatch.setenv("JARVIS_DW_CAPACITY_LEDGER_PATH", str(p))
+    monkeypatch.setenv("JARVIS_DW_CAPACITY_LEDGER_ENABLED", "0")
+    from backend.core.ouroboros.governance import dw_capacity_ledger as L
+    L.reset_for_tests()
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCallRecord, DWCapacityLedger,
+    )
+
+    async def run():
+        ledger = DWCapacityLedger(path=p)
+        ok = await ledger.record_call(DWCallRecord(model_id="x"))
+        assert ok is False
+        assert not p.exists()
+
+    asyncio.run(run())
+
+
+def test_spine_ledger_read_recent_returns_records(tmp_ledger_env) -> None:
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCallRecord, DWCapacityLedger,
+    )
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        for i in range(5):
+            await ledger.record_call(DWCallRecord(
+                timestamp_unix=time.time() + i,
+                model_id=f"test/m{i}",
+                route="standard",
+                prompt_chars=100,
+                outcome="ok",
+                total_elapsed_ms=float(i * 10),
+            ))
+        recs = ledger.read_recent(limit=10)
+        assert len(recs) == 5
+        # Order preserved (oldest first)
+        assert recs[0].model_id == "test/m0"
+        assert recs[-1].model_id == "test/m4"
+
+    asyncio.run(run())
+
+
+def test_spine_ledger_read_recent_skips_malformed_lines(tmp_ledger_env) -> None:
+    """Garbage lines mixed with valid JSONL — read_recent must skip
+    malformed without raising."""
+    # Write garbage + valid mix
+    tmp_ledger_env.write_text(
+        '{"model_id":"valid","outcome":"ok","total_elapsed_ms":1.0}\n'
+        'not-json-at-all\n'
+        '{"truncated": "json\n'
+        '{"model_id":"v2","outcome":"timeout","total_elapsed_ms":2.0}\n'
+    )
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCapacityLedger,
+    )
+    ledger = DWCapacityLedger(path=tmp_ledger_env)
+    recs = ledger.read_recent(limit=100)
+    assert len(recs) == 2
+    assert {r.model_id for r in recs} == {"valid", "v2"}
+
+
+def test_spine_ledger_record_call_never_raises_on_internal_error(
+    tmp_ledger_env, monkeypatch,
+) -> None:
+    """Force flock_append_line to raise; record_call must swallow."""
+    from backend.core.ouroboros.governance import cross_process_jsonl
+    monkeypatch.setattr(
+        cross_process_jsonl, "flock_append_line",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("simulated")),
+    )
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCallRecord, DWCapacityLedger,
+    )
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        ok = await ledger.record_call(DWCallRecord(model_id="x"))
+        assert ok is False  # but no raise
+
+    asyncio.run(run())
+
+
+def test_spine_ledger_aggregate_by_model_shape(tmp_ledger_env) -> None:
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCallRecord, DWCapacityLedger,
+    )
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        # 10 records: 8 timeouts + 2 success on 397B/standard/20K
+        for i in range(10):
+            await ledger.record_call(DWCallRecord(
+                timestamp_unix=time.time(),
+                model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+                route="standard",
+                prompt_chars=20480,
+                outcome="ok" if i < 2 else "timeout",
+                total_elapsed_ms=1000.0 if i < 2 else 75000.0,
+            ))
+        agg = ledger.aggregate_by_model_shape(window=100, prompt_chars_bucket=5000)
+        assert len(agg) == 1
+        key = list(agg.keys())[0]
+        assert "Qwen/Qwen3.5-397B-A17B-FP8" in key
+        assert agg[key]["count"] == 10
+        assert agg[key]["success_rate"] == 0.2
+
+    asyncio.run(run())
+
+
+def test_spine_ledger_error_detail_truncated(tmp_ledger_env) -> None:
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCallRecord, DWCapacityLedger,
+    )
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        long_detail = "x" * 10_000
+        await ledger.record_call(DWCallRecord(
+            model_id="x", outcome="error",
+            error_detail=long_detail,
+        ))
+        recs = ledger.read_recent(1)
+        assert len(recs) == 1
+        # Truncated to 256 chars + "...[truncated]" suffix
+        assert len(recs[0].error_detail) <= 300
+        assert recs[0].error_detail.endswith("[truncated]")
+
+    asyncio.run(run())
+
+
+def test_spine_stats_returns_none_below_min_samples(
+    tmp_ledger_env, monkeypatch,
+) -> None:
+    """Insufficient samples → None (caller falls through to static)."""
+    monkeypatch.setenv("JARVIS_DW_PER_SHAPE_MIN_SAMPLES", "20")
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCallRecord, DWCapacityLedger,
+    )
+    from backend.core.ouroboros.governance.dw_per_shape_stats import (
+        DWPerShapeStats,
+    )
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        # Only 5 records — below min_samples=20
+        for i in range(5):
+            await ledger.record_call(DWCallRecord(
+                model_id="x", route="standard", prompt_chars=100,
+                outcome="ok", total_elapsed_ms=10.0,
+            ))
+        stats = DWPerShapeStats(ledger=ledger)
+        result = stats.stats_for_shape(
+            model_id="x", route="standard", prompt_chars=100,
+        )
+        assert result is None  # insufficient samples
+
+    asyncio.run(run())
+
+
+def test_spine_stats_computes_correct_percentiles(tmp_ledger_env) -> None:
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCallRecord, DWCapacityLedger,
+    )
+    from backend.core.ouroboros.governance.dw_per_shape_stats import (
+        DWPerShapeStats,
+    )
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        # 100 records, latency = 0..9900 in 100ms steps
+        for i in range(100):
+            await ledger.record_call(DWCallRecord(
+                model_id="x", route="standard", prompt_chars=100,
+                outcome="ok", total_elapsed_ms=float(i * 100),
+            ))
+        stats = DWPerShapeStats(ledger=ledger)
+        result = stats.stats_for_shape(
+            model_id="x", route="standard", prompt_chars=100,
+        )
+        assert result is not None
+        assert result.sample_count == 100
+        assert result.success_rate == 1.0
+        # Nearest-rank: p50 idx ≈ 49, p95 idx ≈ 94, p99 idx ≈ 98
+        assert 4500 <= result.p50_ms <= 5500
+        assert 9000 <= result.p95_ms <= 9500
+        assert 9700 <= result.p99_ms <= 9900
+
+    asyncio.run(run())
+
+
+def test_spine_stats_cache_ttl_honored(
+    tmp_ledger_env, monkeypatch,
+) -> None:
+    """Cache rebuild only every TTL — verify second call within TTL
+    sees same data even if file changes."""
+    monkeypatch.setenv("JARVIS_DW_PER_SHAPE_MIN_SAMPLES", "1")
+    monkeypatch.setenv("JARVIS_DW_PER_SHAPE_CACHE_TTL_S", "60")
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCallRecord, DWCapacityLedger,
+    )
+    from backend.core.ouroboros.governance.dw_per_shape_stats import (
+        DWPerShapeStats,
+    )
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        await ledger.record_call(DWCallRecord(
+            model_id="x", route="standard", prompt_chars=100,
+            outcome="ok", total_elapsed_ms=100.0,
+        ))
+        stats = DWPerShapeStats(ledger=ledger)
+        r1 = stats.stats_for_shape(
+            model_id="x", route="standard", prompt_chars=100,
+        )
+        # Add more — cache should NOT see them yet (TTL=60s)
+        for _ in range(10):
+            await ledger.record_call(DWCallRecord(
+                model_id="x", route="standard", prompt_chars=100,
+                outcome="ok", total_elapsed_ms=5000.0,
+            ))
+        r2 = stats.stats_for_shape(
+            model_id="x", route="standard", prompt_chars=100,
+        )
+        # Cached — same as r1
+        assert r2.sample_count == r1.sample_count
+        # invalidate → fresh read
+        stats.invalidate()
+        r3 = stats.stats_for_shape(
+            model_id="x", route="standard", prompt_chars=100,
+        )
+        assert r3.sample_count == 11
+
+    asyncio.run(run())
+
+
+def test_spine_adaptive_timeout_default_off_returns_static(
+    monkeypatch,
+) -> None:
+    """Master flag OFF → static_floor_s returned unchanged regardless
+    of stats."""
+    monkeypatch.delenv("JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.dw_adaptive_timeout import (
+        compute_adaptive_timeout,
+    )
+
+    class FakeStats:
+        def stats_for_shape(self, **kw):
+            from backend.core.ouroboros.governance.dw_per_shape_stats import (
+                ShapeStats,
+            )
+            return ShapeStats(
+                model_id="x", route="standard", prompt_bucket=0,
+                sample_count=100, success_rate=0.5,
+                p50_ms=1000, p95_ms=5000, p99_ms=10000,
+                ttft_p50_ms=500, last_observed_unix=time.time(),
+            )
+
+    t = compute_adaptive_timeout(
+        model_id="x", route="standard", prompt_chars=100,
+        static_floor_s=42.0, stats=FakeStats(),
+    )
+    assert t == 42.0  # static returned, no adaptive math
+
+
+def test_spine_adaptive_timeout_master_on_raises_to_p99_safety(
+    monkeypatch,
+) -> None:
+    """Master ON + stats present → max(static, p99×safety_factor)."""
+    monkeypatch.setenv("JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_DW_ADAPTIVE_TIMEOUT_SAFETY_FACTOR", "1.5")
+    from backend.core.ouroboros.governance.dw_adaptive_timeout import (
+        compute_adaptive_timeout,
+    )
+    from backend.core.ouroboros.governance.dw_per_shape_stats import (
+        ShapeStats,
+    )
+
+    class FakeStats:
+        def stats_for_shape(self, **kw):
+            return ShapeStats(
+                model_id="x", route="standard", prompt_bucket=0,
+                sample_count=100, success_rate=0.5,
+                p50_ms=1000, p95_ms=50000, p99_ms=80000,  # 80s p99
+                ttft_p50_ms=500, last_observed_unix=time.time(),
+            )
+
+    # static=75s, p99=80s × 1.5 = 120s → max = 120s
+    t = compute_adaptive_timeout(
+        model_id="x", route="standard", prompt_chars=100,
+        static_floor_s=75.0, stats=FakeStats(),
+    )
+    assert abs(t - 120.0) < 0.01
+
+
+def test_spine_adaptive_timeout_never_below_static_safety(monkeypatch) -> None:
+    """Even when observed p99 is LOW, static_floor is the floor."""
+    monkeypatch.setenv("JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED", "1")
+    from backend.core.ouroboros.governance.dw_adaptive_timeout import (
+        compute_adaptive_timeout,
+    )
+    from backend.core.ouroboros.governance.dw_per_shape_stats import (
+        ShapeStats,
+    )
+
+    class FakeStats:
+        def stats_for_shape(self, **kw):
+            return ShapeStats(
+                model_id="x", route="standard", prompt_bucket=0,
+                sample_count=100, success_rate=1.0,
+                p50_ms=10, p95_ms=20, p99_ms=30,  # super fast
+                ttft_p50_ms=5, last_observed_unix=time.time(),
+            )
+
+    t = compute_adaptive_timeout(
+        model_id="x", route="standard", prompt_chars=100,
+        static_floor_s=75.0, stats=FakeStats(),
+    )
+    assert t == 75.0  # static is the floor
+
+
+def test_spine_adaptive_timeout_capped(monkeypatch) -> None:
+    """Adaptive timeout MUST be bounded by JARVIS_DW_ADAPTIVE_TIMEOUT_CAP_S."""
+    monkeypatch.setenv("JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_DW_ADAPTIVE_TIMEOUT_CAP_S", "300")
+    from backend.core.ouroboros.governance.dw_adaptive_timeout import (
+        compute_adaptive_timeout,
+    )
+    from backend.core.ouroboros.governance.dw_per_shape_stats import (
+        ShapeStats,
+    )
+
+    class FakeStats:
+        def stats_for_shape(self, **kw):
+            return ShapeStats(
+                model_id="x", route="standard", prompt_bucket=0,
+                sample_count=100, success_rate=0.0,
+                p50_ms=300000, p95_ms=500000, p99_ms=900000,  # 900s p99
+                ttft_p50_ms=0, last_observed_unix=time.time(),
+            )
+
+    t = compute_adaptive_timeout(
+        model_id="x", route="standard", prompt_chars=100,
+        static_floor_s=75.0, stats=FakeStats(),
+    )
+    assert t == 300.0  # capped
+
+
+def test_spine_adaptive_timeout_fails_closed_on_stats_error(monkeypatch) -> None:
+    """Stats raises → adaptive returns static_floor (never raises)."""
+    monkeypatch.setenv("JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED", "1")
+    from backend.core.ouroboros.governance.dw_adaptive_timeout import (
+        compute_adaptive_timeout,
+    )
+
+    class RaisingStats:
+        def stats_for_shape(self, **kw):
+            raise RuntimeError("simulated")
+
+    t = compute_adaptive_timeout(
+        model_id="x", route="standard", prompt_chars=100,
+        static_floor_s=42.0, stats=RaisingStats(),
+    )
+    assert t == 42.0
+
+
+def test_spine_probe_runs_trials_against_fake_provider(tmp_ledger_env) -> None:
+    """End-to-end probe with a fake provider — verify trials run +
+    ledger records the trials."""
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCapacityLedger,
+    )
+    from backend.core.ouroboros.governance.dw_capacity_probe import (
+        DWCapacityProbe,
+    )
+
+    class FakeProvider:
+        def __init__(self):
+            self.calls: List[str] = []
+
+        async def prompt_only(self, prompt: str, *, model_id: str = "") -> str:
+            self.calls.append(prompt[:20])
+            await asyncio.sleep(0.001)
+            return "def compute_sum(): return 0"
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        provider = FakeProvider()
+        probe = DWCapacityProbe(provider=provider, ledger=ledger)
+        results = await probe.probe(
+            model_id="fake/m",
+            prompt_sizes=[1000, 5000],
+            trials_per_size=3,
+        )
+        assert len(results) == 2
+        assert results[0].trials_run == 3
+        assert results[0].successes == 3
+        assert results[0].timeouts == 0
+        # Ledger should have 6 records (2 sizes × 3 trials)
+        recs = ledger.read_recent(20)
+        assert len(recs) == 6
+        for r in recs:
+            assert r.route == "probe"
+            assert r.outcome == "ok"
+
+    asyncio.run(run())
+
+
+def test_spine_probe_captures_timeouts(tmp_ledger_env) -> None:
+    """Timeout outcomes correctly classified."""
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCapacityLedger,
+    )
+    from backend.core.ouroboros.governance.dw_capacity_probe import (
+        DWCapacityProbe,
+    )
+
+    class SlowProvider:
+        async def prompt_only(self, prompt: str, *, model_id: str = "") -> str:
+            await asyncio.sleep(2.0)  # > timeout_per_call_s
+            return "x"
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        provider = SlowProvider()
+        probe = DWCapacityProbe(provider=provider, ledger=ledger)
+        results = await probe.probe(
+            model_id="fake/slow",
+            prompt_sizes=[1000],
+            trials_per_size=2,
+            timeout_per_call_s=0.1,
+        )
+        assert results[0].timeouts == 2
+        assert results[0].successes == 0
+        recs = ledger.read_recent(10)
+        for r in recs:
+            assert r.outcome == "timeout"
+            assert r.error_class == "TimeoutError"
+
+    asyncio.run(run())
+
+
+def test_spine_probe_never_raises_on_provider_error(tmp_ledger_env) -> None:
+    """Provider raises → trial captures error, probe continues."""
+    from backend.core.ouroboros.governance.dw_capacity_ledger import (
+        DWCapacityLedger,
+    )
+    from backend.core.ouroboros.governance.dw_capacity_probe import (
+        DWCapacityProbe,
+    )
+
+    class BrokenProvider:
+        async def prompt_only(self, prompt: str, *, model_id: str = "") -> str:
+            raise ValueError("provider exploded")
+
+    async def run():
+        ledger = DWCapacityLedger(path=tmp_ledger_env)
+        provider = BrokenProvider()
+        probe = DWCapacityProbe(provider=provider, ledger=ledger)
+        results = await probe.probe(
+            model_id="x", prompt_sizes=[1000], trials_per_size=2,
+        )
+        assert results[0].other_failures == 2
+        recs = ledger.read_recent(10)
+        assert all(r.error_class == "ValueError" for r in recs)
+
+    asyncio.run(run())
+
+
+def test_spine_hypothesis_classifier_size_correlated_failure() -> None:
+    """Small succeeds + large fails → hypothesis (c) prompt complexity."""
+    from backend.core.ouroboros.governance.dw_capacity_probe import (
+        ProbeResult, classify_probe_results,
+    )
+    results = [
+        ProbeResult(
+            model_id="x", target_size=1024, trials_run=10,
+            successes=10, timeouts=0, other_failures=0,
+            p50_ms=300, p95_ms=500, p99_ms=600,
+            max_ms=700, min_ms=200, avg_response_chars=400,
+        ),
+        ProbeResult(
+            model_id="x", target_size=51200, trials_run=10,
+            successes=0, timeouts=10, other_failures=0,
+            p50_ms=60000, p95_ms=60000, p99_ms=60000,
+            max_ms=60000, min_ms=60000, avg_response_chars=0,
+        ),
+    ]
+    v = classify_probe_results(results)
+    assert v["hypothesis"] == "c"
+    assert v["confidence"] >= 0.7
+    assert "prompt" in v["reasoning"].lower() or "size" in v["reasoning"].lower()
+
+
+def test_spine_hypothesis_classifier_all_succeed_flags_harness() -> None:
+    """All sizes succeed → not an endpoint issue; harness is variable."""
+    from backend.core.ouroboros.governance.dw_capacity_probe import (
+        ProbeResult, classify_probe_results,
+    )
+    results = [
+        ProbeResult(
+            model_id="x", target_size=s, trials_run=10,
+            successes=10, timeouts=0, other_failures=0,
+            p50_ms=500, p95_ms=800, p99_ms=1000,
+            max_ms=1100, min_ms=300, avg_response_chars=400,
+        )
+        for s in (1024, 5120, 20480, 51200)
+    ]
+    v = classify_probe_results(results)
+    assert v["hypothesis"] == "harness_variable"
+    assert v["confidence"] >= 0.7
+
+
+def test_spine_hypothesis_classifier_all_fail_fast_flags_network() -> None:
+    """All sizes fail with sub-5s latency → hypothesis (d) network/auth."""
+    from backend.core.ouroboros.governance.dw_capacity_probe import (
+        ProbeResult, classify_probe_results,
+    )
+    results = [
+        ProbeResult(
+            model_id="x", target_size=s, trials_run=10,
+            successes=0, timeouts=0, other_failures=10,
+            p50_ms=2000, p95_ms=4000, p99_ms=4500,
+            max_ms=4800, min_ms=1000, avg_response_chars=0,
+        )
+        for s in (1024, 5120)
+    ]
+    v = classify_probe_results(results)
+    assert v["hypothesis"] == "d"


### PR DESCRIPTION
## Summary

Closes the upstream-blocker diagnostic gap from v25→v29 (0 APPLY across 5 soaks, 0 per-(model, shape) observation data). Ships **4 composable substrate modules + operator-runnable probe + hypothesis classifier** — per §48.7's Phase 0 design.

Per operator binding: *"solve the root problem directly — without workarounds, brute force, or shortcut solutions ... fully leverage the existing files and architecture ... no duplication."*

## Substrate

| Module | Purpose | Composes |
|---|---|---|
| `dw_capacity_ledger.py` | Per-call JSONL ledger (schema v1) | `cross_process_jsonl.flock_append_line` (Slice 33 A2 P2) |
| `dw_per_shape_stats.py` | Rolling p50/p95/p99 aggregator | `dw_capacity_ledger.read_recent` (no parallel storage) |
| `dw_adaptive_timeout.py` | Observation-driven timeout | Slice 27 `_compute_adaptive_tier0_timeout_s` (extends, not replaces) |
| `dw_capacity_probe.py` | Out-of-band probe + hypothesis classifier | Any obj with async `prompt_only` (AST-pin: no orchestrator coupling) |
| `scripts/dw_capacity_probe.py` | Operator CLI | All of the above |

## Discipline checkpoints

- **No workarounds**: adaptive timeout extends Slice 27 (cold-start prior), NEVER returns below `static_floor_s` — safety invariant AST-pinned
- **No hardcoding**: 8 new env knobs (window, bucket, TTL, min-samples, safety-factor, cap, master flags)
- **No duplication**: writes via existing `flock_append_line`; stats reads existing ledger; timeout extends existing formula
- **Async-native**: ledger writes via `to_thread`; probe is pure-async; classifier is pure-function
- **Fail-closed**: every module's public surface NEVER raises into caller; ledger swallows write errors → False; stats returns None on insufficient samples; adaptive timeout returns static_floor on stats error
- **No orchestrator coupling**: probe AST-pin enforces zero imports from orchestrator/candidate_generator/intake/tool_executor/battle_test

## Master flags (substrate-first ship)

- `JARVIS_DW_CAPACITY_LEDGER_ENABLED` (default **TRUE** — pure observation)
- `JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED` (default **FALSE** — until v30 soak validates)

## Hypothesis classifier (§48.7.1 → §48.7.3 bridge)

Pure-function over probe results → structured verdict:
- `hypothesis ∈ {a, b, c, d, mixed, harness_variable, undetermined}`
- `confidence` float
- `reasoning` (human-readable)
- `recommended_action` (next operator step)

## Verification

| Suite | Result |
|---|---|
| Slice 34 (6 AST + 21 spine) | **27/27 green** |
| Slice 11 + Slice 20+ + Slice 31/32/33 baseline | **329/329 green** (302 prior + 27 new) |
| End-to-end smoke (synthetic 100% TIMEOUT → p99 75000ms → adaptive 112.5s) | verified |

## Operator's Phase 0 runbook

```bash
python3 scripts/dw_capacity_probe.py \
  --model "Qwen/Qwen3.5-397B-A17B-FP8" \
  --sizes 1,5,20,50 \
  --trials 10 \
  --timeout 120
```

Reads results from `.jarvis/dw_capacity_ledger.jsonl`, prints hypothesis verdict. Phase 1 (hypothesis-specific fix) authorized only after Phase 0 evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DW capacity investigation substrate: a per-call ledger, per-shape stats, an observation-driven timeout, and an operator probe + classifier to diagnose and act on 397B timeout issues. This closes the diagnostic gap by capturing real DW behavior and giving a clear hypothesis-driven verdict.

- **New Features**
  - `dw_capacity_ledger.py`: append-only JSONL for every DW call; writes via `cross_process_jsonl.flock_append_line`.
  - `dw_per_shape_stats.py`: rolling p50/p95/p99 and success rate per (model, route, prompt-size bucket).
  - `dw_adaptive_timeout.py`: computes timeout from observed p99 × safety factor; clamps to a cap; never below the static floor.
  - `dw_capacity_probe.py`: out-of-band probe + heuristic classifier; composes any provider with `prompt_only`.
  - `scripts/dw_capacity_probe.py`: CLI to run 4 sizes × N trials, record to the ledger, and print a verdict.

- **Migration**
  - Behavior: ledger is enabled by default; adaptive timeout is guarded by `JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED` (default false).
  - Run the probe: `python3 scripts/dw_capacity_probe.py --model "Qwen/Qwen3.5-397B-A17B-FP8" --sizes 1,5,20,50 --trials 10 --timeout 120`.
  - Key env knobs (optional): `JARVIS_DW_CAPACITY_LEDGER_PATH`, `JARVIS_DW_PER_SHAPE_*`, `JARVIS_DW_ADAPTIVE_TIMEOUT_*`.

<sup>Written for commit bf57b2dcd6e1635318029e963a368069d45a27ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/61115?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

