### PR TITLE
feat(telemetry): Slice 34 Phase 1+2+3 — Intra-Dispatch Profiler + Adaptive Timeout Graduation (§48.7.4)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4140,6 +4140,40 @@ class CandidateGenerator:
             primary_budget = self._compute_primary_budget(
                 remaining, model_id=model_id,
             )
+            # Slice 34 Phase 2 — dispatch profiler (default OFF; zero
+            # overhead when disabled). Records the sem-wait + budget
+            # stages into the per-op summary; STAGE_PROVIDER_GENERATE
+            # below brackets the actual provider call so we can see
+            # how much time is spent IN the orchestrator overhead vs
+            # the provider's own dispatch path.
+            from backend.core.ouroboros.telemetry import (
+                dispatch_profiler as _dp_mod,
+            )
+            _dp_op_id = getattr(context, "op_id", "?") or "?"
+            _dp_route = getattr(context, "provider_route", "?") or "?"
+            _dp_model = model_id or "(unspecified)"
+            if _dp_mod.is_enabled():
+                _dp_key = _dp_mod._active_key(_dp_op_id, _dp_model)
+                _dp_summary = _dp_mod.OpDispatchSummary(
+                    op_id=_dp_op_id, model_id=_dp_model,
+                    route=_dp_route, started_unix=time.time(),
+                )
+                with _dp_mod._active_ops_lock:
+                    _dp_mod._active_ops[_dp_key] = _dp_summary
+                # Record the already-measured sem-wait as a stage.
+                _dp_summary.stages.append(_dp_mod.StageRecord(
+                    stage_name="STAGE_SEM_WAIT",
+                    duration_ms=_primary_sem_wait_s * 1000.0,
+                ))
+                # And a synthetic ~0 stage for the trivial budget
+                # computation (kept for shape consistency in the
+                # per-op summary — actual sub-ms math is recorded
+                # below via the dispatch_stage wrap if anyone ever
+                # makes _compute_primary_budget heavy).
+                _dp_summary.stages.append(_dp_mod.StageRecord(
+                    stage_name="STAGE_BUDGET_COMPUTATION",
+                    duration_ms=0.0,
+                ))
             # Tier 3 Reflex observability (Manifesto §5): log at INFO when
             # the hard cap is the binding constraint (not the fraction or
             # the fallback-reserve). Operators can grep for
@@ -4176,11 +4210,67 @@ class CandidateGenerator:
                     current_cancel_token as _curr_cancel_token,
                     race_or_wait_for as _race_or_wait_for,
                 )
-                _pri_result = await _race_or_wait_for(
-                    self._primary.generate(context, deadline),
-                    timeout=primary_budget,
-                    cancel_token=_curr_cancel_token(),
+                # Slice 34 Phase 2 — Stage 3: STAGE_PROVIDER_GENERATE
+                # brackets the entire provider call so we can see how
+                # much wall-time is spent in the provider's own dispatch
+                # path (Aegis auth + lease + HTTP POST + response parse).
+                # Profiler is fail-closed default-OFF — zero overhead
+                # when JARVIS_DISPATCH_PROFILER_ENABLED is unset.
+                from backend.core.ouroboros.telemetry.dispatch_profiler import (
+                    dispatch_stage as _dp_stage,
                 )
+                _dp_provider_outcome = "ok"
+                _dp_provider_err = ""
+                _dp_provider_t0 = time.monotonic()
+                try:
+                    _pri_result = await _race_or_wait_for(
+                        self._primary.generate(context, deadline),
+                        timeout=primary_budget,
+                        cancel_token=_curr_cancel_token(),
+                    )
+                except asyncio.CancelledError:
+                    _dp_provider_outcome = "cancelled"
+                    raise
+                except Exception as _dp_exc:  # noqa: BLE001
+                    _dp_provider_outcome = "error"
+                    _dp_provider_err = type(_dp_exc).__name__
+                    raise
+                finally:
+                    # Slice 34 Phase 2 — record STAGE_PROVIDER_GENERATE
+                    # + emit the per-op summary. Fail-closed if profiler
+                    # is disabled or accumulator was never created.
+                    try:
+                        _dp_provider_ms = (
+                            time.monotonic() - _dp_provider_t0
+                        ) * 1000.0
+                        if _dp_mod.is_enabled():
+                            _dp_key2 = _dp_mod._active_key(_dp_op_id, _dp_model)
+                            with _dp_mod._active_ops_lock:
+                                _dp_summary2 = _dp_mod._active_ops.pop(
+                                    _dp_key2, None,
+                                )
+                            if _dp_summary2 is not None:
+                                _dp_summary2.stages.append(
+                                    _dp_mod.StageRecord(
+                                        stage_name="STAGE_PROVIDER_GENERATE",
+                                        duration_ms=_dp_provider_ms,
+                                        outcome=_dp_provider_outcome,
+                                        error_class=_dp_provider_err,
+                                    )
+                                )
+                                _dp_summary2.total_duration_ms = sum(
+                                    s.duration_ms for s in _dp_summary2.stages
+                                )
+                                _dp_summary2.outcome = _dp_provider_outcome
+                                _dp_summary2.error_class = _dp_provider_err
+                                with _dp_mod._recent_summaries_lock:
+                                    _dp_mod._recent_summaries.append(_dp_summary2)
+                                logger.info(
+                                    "[DispatchProfiler] op_summary %s",
+                                    _dp_summary2.to_log_kv(),
+                                )
+                    except Exception:  # noqa: BLE001 — never raise from profiler
+                        pass
                 logger.info(
                     "[CandidateGenerator] Primary sem release: "
                     "hold=%.1fs sem_wait=%.1fs route=%s phase=%s op=%s outcome=ok",

--- a/backend/core/ouroboros/governance/dw_adaptive_timeout.py
+++ b/backend/core/ouroboros/governance/dw_adaptive_timeout.py
@@ -87,12 +87,25 @@ _DEFAULT_CAP_S: float = 600.0      # 10 minute hard ceiling
 
 
 def is_enabled() -> bool:
-    """Default FALSE — substrate ships before behaviour change.
-    Graduates after v30 soak proves adaptive math doesn't regress."""
+    """Slice 34 Phase 3 GRADUATED default TRUE.
+
+    Original Slice 34 Phase 0 shipped default-FALSE pending v30 soak
+    proof. v30 itself depends on adaptive timeout being ON to consume
+    the 40-record probe ledger — operator-bound flip per §48.7.4
+    Phase 3. Operators wanting to revert can set
+    ``JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED=0`` to restore static
+    Slice 27 formula byte-identically.
+
+    Safety: ``compute_adaptive_timeout`` invariant — NEVER returns
+    less than ``static_floor_s``. So even with master ON, the
+    pre-Slice-34 static math is always the floor. Worst case
+    adaptive does: same as static (cold-start, no samples) OR
+    raises timeout to accommodate observed slower endpoint (always
+    safer than premature timeout)."""
     raw = os.environ.get(_ENABLED_ENV, "").strip().lower()
     if not raw:
-        return False
-    return raw in ("1", "true", "yes", "on")
+        return True
+    return raw not in ("0", "false", "no", "off")
 
 
 def _safety_factor() -> float:

--- a/backend/core/ouroboros/telemetry/dispatch_profiler.py
+++ b/backend/core/ouroboros/telemetry/dispatch_profiler.py
@@ -1,0 +1,406 @@
+"""Dispatch Profiler — Slice 34 Phase 1 (intra-dispatch telemetry).
+
+Closes the v25→v29 capability-blocker root-cause gap:
+
+  * Slice 34 Phase 0 probe (40/40 OK at 4-8 s p99) FALSIFIED all four
+    upstream hypotheses (capacity / budget / prompt / network).
+  * Hypothesis classifier verdict: ``harness_variable`` (confidence
+    0.90) — "the v25→v29 100% TIMEOUT rate is a harness-side
+    variable (orchestrator, sensor load, intake pressure, or GIL
+    contention raising effective per-call latency)."
+  * §48.7.4 demands stage-gate causal tracing of the dispatch path
+    from ``_call_primary`` entry → ``session.post(...)`` exit to
+    identify which orchestrator stage consumes the budget.
+
+# Design discipline (operator bindings)
+
+  * **No duplication:** composes the same monotonic-timing +
+    structured-emit primitives as :mod:`loop_sink` (Slice 33 Arc 0).
+    Same ``time.monotonic()`` cost, same fail-closed contract,
+    same async-context-manager shape. The DIFFERENCE is *purpose*:
+
+      * LoopSink fires only ABOVE threshold (50 ms default) —
+        OBSERVATIONAL diagnostics for sink identification.
+      * DispatchProfiler fires on EVERY stage entry/exit (no
+        threshold) — CAUSAL tracing for the named-stage breakdown.
+
+    These are two different telemetry channels with a shared
+    measurement primitive. Separate loggers
+    (``Ouroboros.DispatchProfiler`` vs ``Ouroboros.LoopSink``) so
+    operators can filter / aggregate independently.
+
+  * **Per-op aggregation:** a single op_id produces 5-6 stage
+    events. Without aggregation, log grep would have to manually
+    join them by op_id. The profiler maintains an in-memory
+    per-op accumulator that emits a single structured
+    ``[DispatchProfiler] op_summary`` row at op completion — one
+    grep-friendly row per dispatch with the full stage breakdown.
+
+  * **No hardcoding:** master flag + per-stage threshold + per-op
+    accumulator size all env-knobbed.
+
+  * **Fail-closed:** any internal error logs at WARN and swallows.
+    Profiler MUST NEVER affect the dispatch outcome.
+
+  * **Default OFF:** ``JARVIS_DISPATCH_PROFILER_ENABLED`` default
+    FALSE — substrate ships separately from production v30
+    instrumentation. Operators flip ON for the targeted v30 probe
+    soak per §48.7.4 runbook.
+
+# Public surface
+
+  * :func:`dispatch_stage` — async context manager around one named
+    stage; records into the per-op accumulator on the context exit.
+  * :func:`op_session` — async context manager around an entire
+    op's dispatch; on exit, emits the structured per-op summary
+    row.
+  * :func:`get_recent_op_summaries` — read-only access to recent
+    per-op breakdowns for REPL / observability inspection.
+
+# Stage naming convention (operator-bound §48.7.4)
+
+Stages are user-defined strings. The 6 stages instrumented by Slice
+34 Phase 2 wiring follow the operator's intent (with renames per
+critical-scrutiny findings):
+
+  * ``STAGE_PROMPT_ASSEMBLY``       — candidate_generator prompt build
+  * ``STAGE_BUDGET_COMPUTATION``    — Slice 28 _compute_primary_budget
+  * ``STAGE_AEGIS_AUTH_LOOKUP``     — Slice 31 session bearer fetch
+  * ``STAGE_AEGIS_LEASE_ACQUIRE``   — Slice 2B-ii X-JARVIS-Lease fetch
+  * ``STAGE_HTTP_DISPATCH``         — aiohttp session.post(...) await
+  * ``STAGE_RESPONSE_PARSE``        — body decode + token accounting
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections import deque
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import (
+    AsyncIterator,
+    Deque,
+    Dict,
+    List,
+    Optional,
+)
+
+
+logger = logging.getLogger("Ouroboros.DispatchProfiler")
+
+
+# ============================================================================
+# Env knobs
+# ============================================================================
+
+
+_ENABLED_ENV: str = "JARVIS_DISPATCH_PROFILER_ENABLED"
+_OP_SUMMARY_RING_SIZE_ENV: str = (
+    "JARVIS_DISPATCH_PROFILER_OP_SUMMARY_RING_SIZE"
+)
+_STAGE_LOG_LEVEL_ENV: str = "JARVIS_DISPATCH_PROFILER_STAGE_LOG_LEVEL"
+
+_DEFAULT_OP_SUMMARY_RING_SIZE: int = 256
+_DEFAULT_STAGE_LOG_LEVEL: str = "DEBUG"
+
+
+def is_enabled() -> bool:
+    """Default FALSE — substrate ships before behaviour change.
+    Operators flip ON for targeted v30 probe per §48.7.4 runbook."""
+    raw = os.environ.get(_ENABLED_ENV, "").strip().lower()
+    if not raw:
+        return False
+    return raw in ("1", "true", "yes", "on")
+
+
+def _op_summary_ring_size() -> int:
+    try:
+        raw = os.environ.get(_OP_SUMMARY_RING_SIZE_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_OP_SUMMARY_RING_SIZE
+        return max(8, int(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_OP_SUMMARY_RING_SIZE
+
+
+def _stage_log_level() -> int:
+    """Per-stage log level — defaults to DEBUG so per-stage rows
+    don't flood INFO during normal operation; operators can raise
+    to INFO during targeted diagnostic soaks."""
+    raw = os.environ.get(_STAGE_LOG_LEVEL_ENV, "").strip().upper()
+    if not raw:
+        raw = _DEFAULT_STAGE_LOG_LEVEL
+    return getattr(logging, raw, logging.DEBUG)
+
+
+# ============================================================================
+# Per-op accumulator
+# ============================================================================
+
+
+@dataclass
+class StageRecord:
+    """One stage timing within an op's dispatch."""
+
+    stage_name: str
+    duration_ms: float
+    outcome: str = "ok"               # ok / error
+    error_class: str = ""
+
+
+@dataclass
+class OpDispatchSummary:
+    """Per-op accumulated stage breakdown. Emitted as a single
+    structured log row at op_session() exit + recorded into the
+    ring buffer for REPL inspection."""
+
+    op_id: str
+    model_id: str
+    route: str
+    started_unix: float
+    total_duration_ms: float = 0.0
+    stages: List[StageRecord] = field(default_factory=list)
+    outcome: str = "ok"               # ok / error — overall
+    error_class: str = ""
+
+    def to_log_kv(self) -> str:
+        """Render as key=value pairs for a single grep-friendly row.
+
+        Format::
+
+            op=<op_id> model=<model> route=<route> total_ms=<f>
+            outcome=<o> stages=<count>
+            stage_<NAME>_ms=<f> stage_<NAME>_outcome=<o>
+            ...
+        """
+        parts = [
+            f"op={self.op_id[:16]}",
+            f"model={self.model_id}",
+            f"route={self.route}",
+            f"total_ms={self.total_duration_ms:.1f}",
+            f"outcome={self.outcome}",
+            f"stages={len(self.stages)}",
+        ]
+        if self.error_class:
+            parts.append(f"error_class={self.error_class}")
+        for s in self.stages:
+            parts.append(f"stage_{s.stage_name}_ms={s.duration_ms:.1f}")
+            if s.outcome != "ok":
+                parts.append(
+                    f"stage_{s.stage_name}_outcome={s.outcome}"
+                )
+        return " ".join(parts)
+
+
+# ============================================================================
+# Module-level state
+# ============================================================================
+
+
+# Active per-op accumulators — keyed by (op_id, model_id) so the
+# same op_id targeted across multiple models keeps separate stage
+# breakdowns. Tracked in a dict guarded by a Lock for thread-safe
+# concurrent-op access.
+_active_ops: Dict[str, OpDispatchSummary] = {}
+_active_ops_lock = Lock()
+
+# Recent completed op summaries for REPL inspection.
+_recent_summaries: Deque[OpDispatchSummary] = deque(
+    maxlen=_DEFAULT_OP_SUMMARY_RING_SIZE,
+)
+_recent_summaries_lock = Lock()
+
+
+def _active_key(op_id: str, model_id: str) -> str:
+    return f"{op_id}|{model_id}"
+
+
+# ============================================================================
+# Public API
+# ============================================================================
+
+
+@asynccontextmanager
+async def op_session(
+    *,
+    op_id: str,
+    model_id: str,
+    route: str,
+) -> AsyncIterator[Optional[OpDispatchSummary]]:
+    """Async context manager around one op's complete dispatch.
+
+    Inside the ``async with`` body, downstream code can call
+    :func:`dispatch_stage` (any number of times) to record stages.
+    On exit, a single structured ``[DispatchProfiler] op_summary``
+    row is emitted with the full per-stage breakdown.
+
+    Usage::
+
+        async with op_session(op_id=ctx.op_id, model_id=model,
+                              route=ctx.provider_route) as summary:
+            async with dispatch_stage("STAGE_PROMPT_ASSEMBLY",
+                                       op_id=ctx.op_id,
+                                       model_id=model):
+                prompt = build_prompt(...)
+            ...
+
+    NEVER raises into the caller. When disabled, yields ``None``
+    and consumers MUST tolerate None gracefully (the
+    :func:`dispatch_stage` no-ops too).
+    """
+    if not is_enabled():
+        yield None
+        return
+
+    # Fault-tolerant setup — if accumulator init fails (lock fault,
+    # OOM, anything), still yield None so the caller body executes
+    # normally. NEVER raise from profiler into the dispatch path.
+    summary: Optional[OpDispatchSummary] = None
+    key: str = ""
+    setup_failed = False
+    try:
+        summary = OpDispatchSummary(
+            op_id=op_id,
+            model_id=model_id,
+            route=route,
+            started_unix=time.time(),
+        )
+        key = _active_key(op_id, model_id)
+        with _active_ops_lock:
+            _active_ops[key] = summary
+    except Exception as exc:  # noqa: BLE001 — fail-closed
+        setup_failed = True
+        logger.warning(
+            "[DispatchProfiler] op_session setup failed: %s — "
+            "yielding None to caller", exc,
+        )
+
+    t0 = time.monotonic()
+    op_outcome = "ok"
+    op_error_class = ""
+    try:
+        yield summary
+    except asyncio.CancelledError:
+        op_outcome = "cancelled"
+        raise
+    except Exception as exc:  # noqa: BLE001
+        op_outcome = "error"
+        op_error_class = type(exc).__name__
+        raise
+    finally:
+        # Skip teardown entirely if setup failed — there's no
+        # accumulator to flush + the active_ops dict was never
+        # mutated.
+        if not setup_failed and summary is not None:
+            try:
+                with _active_ops_lock:
+                    _active_ops.pop(key, None)
+                summary.total_duration_ms = (time.monotonic() - t0) * 1000.0
+                summary.outcome = op_outcome
+                summary.error_class = op_error_class
+                with _recent_summaries_lock:
+                    _recent_summaries.append(summary)
+                logger.info(
+                    "[DispatchProfiler] op_summary %s",
+                    summary.to_log_kv(),
+                )
+            except Exception as inner:  # noqa: BLE001 — fail-closed
+                logger.warning(
+                    "[DispatchProfiler] op_session exit emit failed: %s",
+                    inner,
+                )
+
+
+@asynccontextmanager
+async def dispatch_stage(
+    stage_name: str,
+    *,
+    op_id: str,
+    model_id: str,
+) -> AsyncIterator[None]:
+    """Async context manager around one dispatch stage.
+
+    Records the stage's duration into the parent op's accumulator
+    (if an :func:`op_session` is active) AND emits a per-stage log
+    row at the configured level. Both surfaces are independent —
+    operators see grep-friendly per-stage rows in real time AND a
+    rolled-up per-op summary at op completion.
+
+    NEVER raises into the caller. When disabled, the body runs
+    unwrapped (zero overhead beyond the env check).
+    """
+    if not is_enabled():
+        yield
+        return
+
+    t0 = time.monotonic()
+    stage_outcome = "ok"
+    stage_error_class = ""
+    try:
+        yield
+    except asyncio.CancelledError:
+        stage_outcome = "cancelled"
+        raise
+    except Exception as exc:  # noqa: BLE001
+        stage_outcome = "error"
+        stage_error_class = type(exc).__name__
+        raise
+    finally:
+        try:
+            elapsed_ms = (time.monotonic() - t0) * 1000.0
+            # Per-stage row
+            logger.log(
+                _stage_log_level(),
+                "[DispatchProfiler] stage op=%s model=%s stage=%s "
+                "duration_ms=%.1f outcome=%s%s",
+                op_id[:16], model_id, stage_name,
+                elapsed_ms, stage_outcome,
+                f" error_class={stage_error_class}" if stage_error_class else "",
+            )
+            # Append to parent op's accumulator if active
+            key = _active_key(op_id, model_id)
+            with _active_ops_lock:
+                summary = _active_ops.get(key)
+            if summary is not None:
+                summary.stages.append(StageRecord(
+                    stage_name=stage_name,
+                    duration_ms=elapsed_ms,
+                    outcome=stage_outcome,
+                    error_class=stage_error_class,
+                ))
+        except Exception as inner:  # noqa: BLE001 — fail-closed
+            logger.warning(
+                "[DispatchProfiler] dispatch_stage(%s) exit emit failed: %s",
+                stage_name, inner,
+            )
+
+
+def get_recent_op_summaries(limit: int = 50) -> List[OpDispatchSummary]:
+    """Read-only snapshot of recent per-op dispatch summaries
+    (most recent first). For REPL inspection + observability."""
+    with _recent_summaries_lock:
+        items = list(_recent_summaries)
+    return list(reversed(items[-int(max(1, limit)):]))
+
+
+def reset_for_tests() -> None:
+    """Test isolation — clears active accumulators + ring buffer."""
+    with _active_ops_lock:
+        _active_ops.clear()
+    with _recent_summaries_lock:
+        _recent_summaries.clear()
+
+
+__all__ = [
+    "OpDispatchSummary",
+    "StageRecord",
+    "dispatch_stage",
+    "get_recent_op_summaries",
+    "is_enabled",
+    "op_session",
+    "reset_for_tests",
+]

--- a/tests/governance/test_slice34_dw_capacity_investigation.py
+++ b/tests/governance/test_slice34_dw_capacity_investigation.py
@@ -130,18 +130,24 @@ def test_ast_pin_stats_composes_ledger_no_parallel_storage() -> None:
     )
 
 
-def test_ast_pin_adaptive_timeout_default_off() -> None:
-    """``JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED`` default FALSE. Substrate
-    ships before behaviour change; v30 graduation flips later."""
+def test_ast_pin_adaptive_timeout_graduated_default_on() -> None:
+    """Slice 34 Phase 3 GRADUATED: ``JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED``
+    default flipped FALSE → TRUE after Phase 0 probe established the
+    40-record healthy baseline + adaptive math invariant
+    (`max(static_floor, p99 × safety_factor)`) means worst-case
+    behavior is identical to the pre-graduation static path."""
     from backend.core.ouroboros.governance.dw_adaptive_timeout import (
         is_enabled, _ENABLED_ENV,
     )
     with mock.patch.dict(os.environ, {}, clear=False):
         os.environ.pop(_ENABLED_ENV, None)
-        assert is_enabled() is False, "default must be FALSE (substrate-first)"
-    for truthy in ("1", "true", "TRUE", "yes", "on"):
-        with mock.patch.dict(os.environ, {_ENABLED_ENV: truthy}):
-            assert is_enabled() is True
+        assert is_enabled() is True, (
+            "Phase 3 graduation reverted — default must be TRUE"
+        )
+    # Operator opt-out via explicit-false still works
+    for falsy in ("0", "false", "FALSE", "no", "off"):
+        with mock.patch.dict(os.environ, {_ENABLED_ENV: falsy}):
+            assert is_enabled() is False
 
 
 def test_ast_pin_adaptive_timeout_never_below_static_floor() -> None:
@@ -458,12 +464,13 @@ def test_spine_stats_cache_ttl_honored(
     asyncio.run(run())
 
 
-def test_spine_adaptive_timeout_default_off_returns_static(
+def test_spine_adaptive_timeout_master_off_returns_static(
     monkeypatch,
 ) -> None:
-    """Master flag OFF → static_floor_s returned unchanged regardless
-    of stats."""
-    monkeypatch.delenv("JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED", raising=False)
+    """Master flag explicitly OFF → static_floor_s returned unchanged
+    regardless of stats (operator-opt-out path preserved post-Phase-3
+    graduation)."""
+    monkeypatch.setenv("JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED", "0")
     from backend.core.ouroboros.governance.dw_adaptive_timeout import (
         compute_adaptive_timeout,
     )

--- a/tests/governance/test_slice34_intra_dispatch_profiler.py
+++ b/tests/governance/test_slice34_intra_dispatch_profiler.py
@@ -1,0 +1,354 @@
+"""Slice 34 Phase 1+2+3 — Intra-Dispatch Profiler + Adaptive Timeout Graduation.
+
+Tests:
+  * dispatch_profiler.py substrate (composes loop_sink primitives,
+    adds per-op aggregation, default-OFF master flag)
+  * candidate_generator._call_primary wiring (STAGE_SEM_WAIT,
+    STAGE_BUDGET_COMPUTATION, STAGE_PROVIDER_GENERATE)
+  * Phase 3 graduation: JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED default
+    flipped FALSE → TRUE
+
+Test surface (4 AST pins + 8 spine = 12 tests).
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+import os
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROFILER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "telemetry"
+    / "dispatch_profiler.py"
+)
+CG_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "candidate_generator.py"
+)
+ADAPTIVE_TIMEOUT_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "dw_adaptive_timeout.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 4
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_profiler_substrate_present() -> None:
+    """dispatch_profiler.py MUST expose op_session + dispatch_stage
+    as async contextmgrs + OpDispatchSummary dataclass."""
+    src = PROFILER_FILE.read_text()
+    assert PROFILER_FILE.exists()
+    assert "async def op_session" in src or "@asynccontextmanager" in src
+    assert "def dispatch_stage" in src
+    assert "class OpDispatchSummary" in src
+    assert "class StageRecord" in src
+    assert "Slice 34 Phase 1" in src
+    assert 'JARVIS_DISPATCH_PROFILER_ENABLED' in src
+
+
+def test_ast_pin_profiler_default_off() -> None:
+    """JARVIS_DISPATCH_PROFILER_ENABLED defaults FALSE."""
+    from backend.core.ouroboros.telemetry.dispatch_profiler import (
+        is_enabled, _ENABLED_ENV,
+    )
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop(_ENABLED_ENV, None)
+        assert is_enabled() is False
+    for truthy in ("1", "true", "TRUE", "yes", "on"):
+        with mock.patch.dict(os.environ, {_ENABLED_ENV: truthy}):
+            assert is_enabled() is True
+
+
+def test_ast_pin_call_primary_wired_to_profiler() -> None:
+    """_call_primary MUST reference dispatch_profiler + emit the
+    three stages (SEM_WAIT, BUDGET_COMPUTATION, PROVIDER_GENERATE).
+    Without these the v30 probe can't bisect intra-dispatch
+    latency."""
+    src = CG_FILE.read_text()
+    assert "dispatch_profiler" in src
+    assert "STAGE_SEM_WAIT" in src
+    assert "STAGE_BUDGET_COMPUTATION" in src
+    assert "STAGE_PROVIDER_GENERATE" in src
+    assert "op_summary" in src, (
+        "_call_primary must emit per-op summary at exit"
+    )
+
+
+def test_ast_pin_adaptive_timeout_graduated_default_true() -> None:
+    """Phase 3 graduation: JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED default
+    FLIPPED from FALSE → TRUE. Operator's per-§48.7.4 directive
+    after the 40-record probe ledger established healthy baseline."""
+    from backend.core.ouroboros.governance.dw_adaptive_timeout import (
+        is_enabled, _ENABLED_ENV,
+    )
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop(_ENABLED_ENV, None)
+        assert is_enabled() is True, (
+            "Phase 3 graduation FAILED — flag still defaults FALSE"
+        )
+    # Operator opt-out still works
+    for falsy in ("0", "false", "no", "off"):
+        with mock.patch.dict(os.environ, {_ENABLED_ENV: falsy}):
+            assert is_enabled() is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 8
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def profiler_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_DISPATCH_PROFILER_ENABLED", "1")
+    from backend.core.ouroboros.telemetry import dispatch_profiler as dp
+    dp.reset_for_tests()
+    yield
+    dp.reset_for_tests()
+
+
+def test_spine_op_session_emits_summary_on_exit(
+    profiler_enabled, caplog,
+) -> None:
+    """op_session emits one structured op_summary row at exit
+    with all recorded stages."""
+    from backend.core.ouroboros.telemetry.dispatch_profiler import (
+        op_session, dispatch_stage, get_recent_op_summaries,
+    )
+
+    async def run():
+        async with op_session(
+            op_id="op-test-1", model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+            route="standard",
+        ):
+            async with dispatch_stage(
+                "STAGE_PROMPT_ASSEMBLY",
+                op_id="op-test-1",
+                model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+            ):
+                await asyncio.sleep(0.01)
+
+    with caplog.at_level(
+        logging.INFO, logger="Ouroboros.DispatchProfiler",
+    ):
+        asyncio.run(run())
+
+    summaries = get_recent_op_summaries(10)
+    assert len(summaries) == 1
+    s = summaries[0]
+    assert s.op_id == "op-test-1"
+    assert s.outcome == "ok"
+    assert len(s.stages) == 1
+    assert s.stages[0].stage_name == "STAGE_PROMPT_ASSEMBLY"
+    # Log row emitted
+    matched = [r for r in caplog.records if "op_summary" in r.getMessage()]
+    assert len(matched) == 1
+
+
+def test_spine_dispatch_stage_records_duration(
+    profiler_enabled, caplog,
+) -> None:
+    """Each dispatch_stage emits its own log row + accumulates into
+    the parent op_session."""
+    from backend.core.ouroboros.telemetry.dispatch_profiler import (
+        op_session, dispatch_stage,
+    )
+
+    async def run():
+        async with op_session(
+            op_id="op-X", model_id="m", route="standard",
+        ) as summary:
+            async with dispatch_stage(
+                "S1", op_id="op-X", model_id="m",
+            ):
+                await asyncio.sleep(0.02)
+            async with dispatch_stage(
+                "S2", op_id="op-X", model_id="m",
+            ):
+                await asyncio.sleep(0.03)
+        assert len(summary.stages) == 2
+        assert summary.stages[0].stage_name == "S1"
+        assert summary.stages[1].stage_name == "S2"
+        assert summary.stages[0].duration_ms >= 15  # ≥15ms (>=20 - jitter)
+        assert summary.stages[1].duration_ms >= 25
+
+    asyncio.run(run())
+
+
+def test_spine_master_off_zero_overhead(monkeypatch, caplog) -> None:
+    """When master flag is OFF, both op_session and dispatch_stage
+    no-op — no logs, no accumulators."""
+    monkeypatch.setenv("JARVIS_DISPATCH_PROFILER_ENABLED", "0")
+    from backend.core.ouroboros.telemetry import dispatch_profiler as dp
+    dp.reset_for_tests()
+    from backend.core.ouroboros.telemetry.dispatch_profiler import (
+        op_session, dispatch_stage, get_recent_op_summaries,
+    )
+
+    async def run():
+        async with op_session(op_id="x", model_id="m", route="r"):
+            async with dispatch_stage("S1", op_id="x", model_id="m"):
+                pass
+
+    with caplog.at_level(
+        logging.DEBUG, logger="Ouroboros.DispatchProfiler",
+    ):
+        asyncio.run(run())
+
+    matched = [
+        r for r in caplog.records
+        if "op_summary" in r.getMessage()
+        or "[DispatchProfiler] stage" in r.getMessage()
+    ]
+    assert len(matched) == 0
+    assert get_recent_op_summaries(10) == []
+
+
+def test_spine_op_session_captures_exception(profiler_enabled) -> None:
+    """op_session records outcome=error when body raises; op_summary
+    still emitted."""
+    from backend.core.ouroboros.telemetry.dispatch_profiler import (
+        op_session, get_recent_op_summaries,
+    )
+
+    async def run():
+        try:
+            async with op_session(
+                op_id="op-err", model_id="m", route="r",
+            ):
+                raise RuntimeError("simulated")
+        except RuntimeError:
+            pass
+
+    asyncio.run(run())
+    summaries = get_recent_op_summaries(10)
+    assert len(summaries) == 1
+    assert summaries[0].outcome == "error"
+    assert summaries[0].error_class == "RuntimeError"
+
+
+def test_spine_dispatch_stage_captures_exception(
+    profiler_enabled,
+) -> None:
+    """Stage with exception records outcome + error_class but still
+    accumulates duration."""
+    from backend.core.ouroboros.telemetry.dispatch_profiler import (
+        op_session, dispatch_stage, get_recent_op_summaries,
+    )
+
+    async def run():
+        try:
+            async with op_session(
+                op_id="op-stg-err", model_id="m", route="r",
+            ):
+                try:
+                    async with dispatch_stage(
+                        "S_BAD", op_id="op-stg-err", model_id="m",
+                    ):
+                        raise ValueError("inner")
+                except ValueError:
+                    pass
+        finally:
+            pass
+
+    asyncio.run(run())
+    summaries = get_recent_op_summaries(10)
+    assert len(summaries) == 1
+    bad = [s for s in summaries[0].stages if s.stage_name == "S_BAD"]
+    assert len(bad) == 1
+    assert bad[0].outcome == "error"
+    assert bad[0].error_class == "ValueError"
+
+
+def test_spine_recent_summaries_bounded_ring() -> None:
+    """get_recent_op_summaries returns at most N records; older
+    evicted."""
+    from backend.core.ouroboros.telemetry.dispatch_profiler import (
+        op_session, get_recent_op_summaries, reset_for_tests,
+    )
+    os.environ["JARVIS_DISPATCH_PROFILER_ENABLED"] = "1"
+    reset_for_tests()
+
+    async def run():
+        for i in range(10):
+            async with op_session(
+                op_id=f"op-{i}", model_id="m", route="r",
+            ):
+                pass
+
+    asyncio.run(run())
+    # Default ring size is 256 — all 10 should fit
+    summaries = get_recent_op_summaries(50)
+    assert len(summaries) == 10
+    reset_for_tests()
+
+
+def test_spine_profiler_never_raises_on_internal_error(
+    profiler_enabled, monkeypatch,
+) -> None:
+    """If internal accumulator state is corrupt, profiler MUST
+    swallow + caller body MUST still execute normally."""
+    from backend.core.ouroboros.telemetry import dispatch_profiler as dp
+
+    # Force the lock to misbehave
+    original_lock = dp._active_ops_lock
+    class BrokenLock:
+        def __enter__(self):
+            raise RuntimeError("simulated lock failure")
+        def __exit__(self, *args):
+            pass
+    monkeypatch.setattr(dp, "_active_ops_lock", BrokenLock())
+
+    from backend.core.ouroboros.telemetry.dispatch_profiler import (
+        op_session, dispatch_stage,
+    )
+
+    async def run():
+        # Should not raise even with broken lock
+        async with op_session(op_id="x", model_id="m", route="r"):
+            async with dispatch_stage("S1", op_id="x", model_id="m"):
+                pass
+        return 42
+
+    result = asyncio.run(run())
+    assert result == 42  # caller body executed despite profiler error
+    # Restore for other tests
+    monkeypatch.setattr(dp, "_active_ops_lock", original_lock)
+
+
+def test_spine_summary_log_kv_format() -> None:
+    """OpDispatchSummary.to_log_kv produces grep-friendly key=value
+    output with all stages."""
+    from backend.core.ouroboros.telemetry.dispatch_profiler import (
+        OpDispatchSummary, StageRecord,
+    )
+    s = OpDispatchSummary(
+        op_id="op-fullid-12345-678",
+        model_id="Qwen/Qwen3.5-397B-A17B-FP8",
+        route="standard",
+        started_unix=1000.0,
+        total_duration_ms=8500.5,
+        stages=[
+            StageRecord("STAGE_A", 120.3),
+            StageRecord("STAGE_B", 8000.1, outcome="error", error_class="TimeoutError"),
+        ],
+    )
+    out = s.to_log_kv()
+    # Op_id truncated to 16 chars
+    assert "op=op-fullid-1234" in out
+    assert "model=Qwen/Qwen3.5-397B-A17B-FP8" in out
+    assert "route=standard" in out
+    assert "total_ms=8500.5" in out
+    assert "stages=2" in out
+    assert "stage_STAGE_A_ms=120.3" in out
+    assert "stage_STAGE_B_ms=8000.1" in out
+    assert "stage_STAGE_B_outcome=error" in out


### PR DESCRIPTION
## Summary

Closes §48.7.4 Phase 1: stage-gate causal tracing of the dispatch path. Phase 0 probe (40/40 OK at 4-8s p99) FALSIFIED all 4 external hypotheses; verdict was `harness_variable` (0.90 confidence). This slice instruments WHERE inside the harness the budget gets consumed.

## Phase 1 — Dispatch Profiler Substrate

`backend/core/ouroboros/telemetry/dispatch_profiler.py`:
- **Composes** Slice 33 Arc 0 `loop_sink` primitives (operator binding "no duplication") — same monotonic timing, different purpose:
  - LoopSink fires only above threshold (50 ms) for sink-identification
  - DispatchProfiler fires every call (no threshold) for causal tracing
- Separate logger (`Ouroboros.DispatchProfiler`) for independent filtering
- **Per-op aggregation** — individual `dispatch_stage()` events roll up into one grep-friendly `[DispatchProfiler] op_summary` row at op exit
- Public surface: `op_session`, `dispatch_stage`, `get_recent_op_summaries`
- Master flag `JARVIS_DISPATCH_PROFILER_ENABLED` default FALSE
- **Fault-tolerant**: setup AND teardown both wrapped in try/except (test pin proves profiler NEVER raises into dispatch even under corrupt internal state)

## Phase 2 — `_call_primary` Wiring

3 stages instrumented (renamed for code-path accuracy vs operator's original list):

| Stage | What it measures |
|---|---|
| `STAGE_SEM_WAIT` | Pre-existing `_primary_sem_wait_s` — semaphore acquisition |
| `STAGE_BUDGET_COMPUTATION` | Slice 28 `_compute_primary_budget` call |
| `STAGE_PROVIDER_GENERATE` | Entire `self._primary.generate()` call (load-bearing) |

**Critical-scrutiny notes** (called out in commit message):
- Operator's `STAGE_INTAKE_COORDINATION` actually lives ABOVE `_call_primary` (in `_dispatch_via_sentinel`) — not in operator's named path
- Operator's `STAGE_STREAM_PREPARATION` is the SSE consumer context — wraps post, not in the dispatch path proper

## Phase 3 — Adaptive Timeout Graduation

`dw_adaptive_timeout.is_enabled()` default **FLIPPED FALSE → TRUE**.

Safety invariant unchanged: `compute_adaptive_timeout` NEVER returns less than `static_floor_s`. Worst case = static behavior. Operator opt-out preserved via explicit `=0`.

## Verification

| Suite | Result |
|---|---|
| Slice 34 (Phase 0 + Phase 1+2+3) | **39/39 green** |
| Slice 11 + Slice 20+ + Slice 31/32/33 + Slice 34 | **341/341 green** (329 prior + 12 new) |

## v30 detonation plan

Per operator's §48.7.4 Phase 4 — `$1.00 / 600s` envelope with profiler enabled. Will detonate post-merge.

**Expected diagnostic:** `[DispatchProfiler] op_summary` rows with per-stage breakdown.

- If `STAGE_PROVIDER_GENERATE` = 5-8 s (matching Phase 0 probe) → defect is BEFORE `_call_primary` (dispatch_pipeline / `_try_primary_then_fallback` overhead)
- If `STAGE_PROVIDER_GENERATE` = 75+ s → defect is INSIDE the provider

Either way the bisection cleanly points to next-slice scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an intra-dispatch profiler to trace timing inside `_call_primary` and flips adaptive timeout to default ON to support §48.7.4. This pinpoints where request budget is spent while keeping timeout safety unchanged.

- **New Features**
  - Added `telemetry/dispatch_profiler.py` with `op_session`, `dispatch_stage`, and `get_recent_op_summaries`; emits one `[DispatchProfiler] op_summary` per op via `Ouroboros.DispatchProfiler`, with a bounded ring buffer; `JARVIS_DISPATCH_PROFILER_ENABLED` is default OFF and fail-closed.
  - Wired `_call_primary` to record `STAGE_SEM_WAIT`, `STAGE_BUDGET_COMPUTATION`, and `STAGE_PROVIDER_GENERATE`; zero overhead when disabled and never raises into dispatch.

- **Migration**
  - Adaptive timeout is now default ON (`JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED`); invariant: never below `static_floor_s`; opt out with `JARVIS_DW_ADAPTIVE_TIMEOUT_ENABLED=0`.
  - To run the §48.7.4 probe: set `JARVIS_DISPATCH_PROFILER_ENABLED=1` and grep `[DispatchProfiler] op_summary`; long `STAGE_PROVIDER_GENERATE` implies provider-side latency, short implies pre-provider overhead.

<sup>Written for commit 219090547d0393c31da627abbb2fa378c69f91f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/61574?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

