### PR TITLE
feat(telemetry): Slice 35 — Dual-path RT + Batch dispatch profiling + tightened poll calibration

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -837,17 +837,38 @@ class DoublewordProvider:
             },
         })
 
+        # Slice 35 Phase 2 — batch path stage profiler (composes
+        # Slice 34 dispatch_profiler). Default OFF; records stages
+        # only when JARVIS_DISPATCH_PROFILER_ENABLED=1.
+        from backend.core.ouroboros.telemetry import (
+            dispatch_profiler as _s35b_dp,
+        )
+        _s35b_model = self._model or "(unspecified)"
         try:
             # Slice 2B-ii — thread operation_id to per-call Aegis lease.
+            _s35b_t_upload = time.monotonic()
             file_id = await self._upload_file(
                 jsonl_line, op_id=operation_id,
+            )
+            _s35b_dp.record_stage(
+                "STAGE_BATCH_UPLOAD",
+                op_id=operation_id, model_id=_s35b_model,
+                duration_ms=(time.monotonic() - _s35b_t_upload) * 1000.0,
+                outcome="ok" if file_id else "error",
             )
             if not file_id:
                 logger.warning("[DoublewordProvider] submit_batch: file upload failed")
                 return None
 
+            _s35b_t_create = time.monotonic()
             batch_id = await self._create_batch(
                 file_id, op_id=operation_id,
+            )
+            _s35b_dp.record_stage(
+                "STAGE_BATCH_CREATE",
+                op_id=operation_id, model_id=_s35b_model,
+                duration_ms=(time.monotonic() - _s35b_t_create) * 1000.0,
+                outcome="ok" if batch_id else "error",
             )
             if not batch_id:
                 logger.warning("[DoublewordProvider] submit_batch: batch creation failed")
@@ -883,10 +904,22 @@ class DoublewordProvider:
         """
         t0 = pending.submitted_at
 
+        # Slice 35 Phase 2 — batch path stage profiler.
+        from backend.core.ouroboros.telemetry import (
+            dispatch_profiler as _s35p_dp,
+        )
+        _s35p_model = self._model or "(unspecified)"
         try:
             # Slice 2B-ii — forward pending.op_id for per-call Aegis lease.
+            _s35p_t_await = time.monotonic()
             output_file_id = await self._await_batch_result(
                 pending.batch_id, op_id=pending.op_id,
+            )
+            _s35p_dp.record_stage(
+                "STAGE_BATCH_AWAIT",
+                op_id=pending.op_id, model_id=_s35p_model,
+                duration_ms=(time.monotonic() - _s35p_t_await) * 1000.0,
+                outcome="ok" if output_file_id else "error",
             )
             if not output_file_id:
                 self._stats.failed_batches += 1
@@ -896,8 +929,15 @@ class DoublewordProvider:
                 )
                 return None
 
+            _s35p_t_retrieve = time.monotonic()
             content, usage = await self._retrieve_result(
                 output_file_id, pending.op_id,
+            )
+            _s35p_dp.record_stage(
+                "STAGE_BATCH_RETRIEVE",
+                op_id=pending.op_id, model_id=_s35p_model,
+                duration_ms=(time.monotonic() - _s35p_t_retrieve) * 1000.0,
+                outcome="ok" if content else "error",
             )
 
             elapsed = time.monotonic() - t0
@@ -1655,6 +1695,18 @@ class DoublewordProvider:
         total_cost = 0.0
         self._last_chunk_at = 0.0  # reset — prevents stale timestamps from prior generation
 
+        # Slice 35 Phase 1 — RT stage profiler. Composes Slice 34's
+        # dispatch_profiler (no parallel telemetry surface). Default
+        # OFF via JARVIS_DISPATCH_PROFILER_ENABLED so production stays
+        # byte-identical until operator opts into the v31 telemetry
+        # probe. record_stage() never raises into the caller.
+        from backend.core.ouroboros.telemetry import (
+            dispatch_profiler as _s35_dp,
+        )
+        _s35_op_id = getattr(context, "op_id", "?") or "?"
+        _s35_model = self._model or "(unspecified)"
+        _s35_stage_t0 = time.monotonic()
+
         # Gap #7: discover MCP tools for prompt injection
         _mcp_tools = None
         if self._mcp_client is not None:
@@ -1732,6 +1784,14 @@ class DoublewordProvider:
                 len(prompt), len(prompt) // 4,
                 getattr(context, "provider_route", "") or "unknown",
             )
+
+        # Slice 35 Phase 1 — record STAGE_RT_PROMPT_BUILD: prompt
+        # assembly + MCP discovery + lean detection ended here.
+        _s35_dp.record_stage(
+            "STAGE_RT_PROMPT_BUILD",
+            op_id=_s35_op_id, model_id=_s35_model,
+            duration_ms=(time.monotonic() - _s35_stage_t0) * 1000.0,
+        )
 
         _SYSTEM_PROMPT = (
             "You are a code generation assistant for the JARVIS Trinity AI Ecosystem. "
@@ -1930,6 +1990,8 @@ class DoublewordProvider:
                 _ttft_request_start_monotonic = time.monotonic()
                 _ttft_first_chunk_seen = False
 
+                # Slice 35 Phase 1 — STAGE_RT_AEGIS_AUTH timer.
+                _s35_auth_t0 = time.monotonic()
                 # Slice 31 — Aegis session bearer (closes v24
                 # missing_session_bearer 401 wedge on RT streaming).
                 _call_auth = await _aegis_dw_session_auth_header()
@@ -1941,6 +2003,18 @@ class DoublewordProvider:
                     route="standard",
                     estimated_cost_usd=0.05,
                 )
+                _s35_dp.record_stage(
+                    "STAGE_RT_AEGIS_AUTH",
+                    op_id=_s35_op_id, model_id=_s35_model,
+                    duration_ms=(time.monotonic() - _s35_auth_t0) * 1000.0,
+                )
+                # Slice 35 Phase 1 — STAGE_RT_HTTP_POST + STAGE_RT_STREAM_CONSUME
+                # timers. The post() context manager handle is the
+                # HTTP handshake; the chunk loop INSIDE the `async
+                # with` is the stream consumption. We capture the
+                # handshake-only time by measuring up to the first
+                # chunk arrival via _ttft_first_chunk_seen.
+                _s35_post_t0 = time.monotonic()
                 async with session.post(
                     f"{self._base_url}/chat/completions",
                     json=body,
@@ -2250,6 +2324,19 @@ class DoublewordProvider:
                                                 context, "op_id", "",
                                             ) or "",
                                         )
+                                        # Slice 35 Phase 1 — record
+                                        # STAGE_RT_HTTP_POST at first-chunk
+                                        # arrival (TTFT closes the HTTP
+                                        # handshake stage).
+                                        _s35_dp.record_stage(
+                                            "STAGE_RT_HTTP_POST",
+                                            op_id=_s35_op_id,
+                                            model_id=_s35_model,
+                                            duration_ms=float(_ttft_ms),
+                                        )
+                                        # Reset stream-consume timer
+                                        # to start AT first chunk.
+                                        _s35_stream_t0 = time.monotonic()
                                     except Exception:  # noqa: BLE001
                                         pass
                                 try:
@@ -2420,6 +2507,24 @@ class DoublewordProvider:
         venom_edits: Tuple[Dict[str, Any], ...] = ()
         raw: str = ""
 
+        # Slice 35 Phase 1 — STAGE_RT_STREAM_CONSUME: record the time
+        # from first-chunk arrival to here (Venom loop entry / parse).
+        # When tools are skipped, the stream consume window covered the
+        # entire chat completion. _s35_stream_t0 was set at first chunk.
+        try:
+            _s35_dp.record_stage(
+                "STAGE_RT_STREAM_CONSUME",
+                op_id=_s35_op_id, model_id=_s35_model,
+                duration_ms=(
+                    (time.monotonic() - _s35_stream_t0) * 1000.0
+                ) if "_s35_stream_t0" in dir() else 0.0,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        # Slice 35 Phase 1 — STAGE_RT_VENOM_TOOL_LOOP timer. Strongest
+        # suspect for the v25-v29 30-111s inflation: tool_loop rounds
+        # against DW often spin multiple times per op.
+        _s35_venom_t0 = time.monotonic()
         if self._tool_loop is not None and not _skip_tools:
             deadline_mono = time.monotonic() + max(
                 0.0,
@@ -2520,6 +2625,20 @@ class DoublewordProvider:
             )
             raise DoublewordInfraError("Non-JSON response from real-time API", status_code=0)
 
+        # Slice 35 Phase 1 — record STAGE_RT_VENOM_TOOL_LOOP (covers
+        # the entire Venom block whether or not the loop ran; when
+        # _skip_tools is true this records the streaming-only-time as
+        # a near-zero Venom stage). Then begin STAGE_RT_RESPONSE_PARSE.
+        try:
+            _s35_dp.record_stage(
+                "STAGE_RT_VENOM_TOOL_LOOP",
+                op_id=_s35_op_id, model_id=_s35_model,
+                duration_ms=(time.monotonic() - _s35_venom_t0) * 1000.0,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        _s35_parse_t0 = time.monotonic()
+
         # Slice 20B — _parse_with_heal wraps _parse_generation_response
         # with an LLM-heal retry on json_parse_error (RT path).
         result = await self._parse_with_heal(
@@ -2532,6 +2651,15 @@ class DoublewordProvider:
             repo_roots=self._repo_roots or None,
             repo_root=self._repo_root,
         )
+        # Slice 35 Phase 1 — record STAGE_RT_RESPONSE_PARSE.
+        try:
+            _s35_dp.record_stage(
+                "STAGE_RT_RESPONSE_PARSE",
+                op_id=_s35_op_id, model_id=_s35_model,
+                duration_ms=(time.monotonic() - _s35_parse_t0) * 1000.0,
+            )
+        except Exception:  # noqa: BLE001
+            pass
         if _preloaded_files:
             result = dataclasses.replace(
                 result, prompt_preloaded_files=tuple(_preloaded_files),
@@ -2748,13 +2876,42 @@ class DoublewordProvider:
     def _next_poll_interval(attempt: int, *, network_error: bool = False) -> float:
         """Compute next poll interval with exponential backoff + jitter.
 
-        Starting interval: 2s (normal) or 15s (network error).
-        Multiplier: 1.5x per attempt. Cap: 30s. Jitter: +/-25%.
+        Slice 35 Phase 2 — operator-tightened calibration based on
+        Phase 0 probe empirical p99 of 4-8s. The pre-Slice-35 defaults
+        (base 2s, cap 30s) were sized for a much slower baseline; the
+        operator's calibration reflects the actual measured DW endpoint
+        responsiveness:
+
+          * Normal start: 1.5s (was 2.0s) — aggressive first 3 cycles
+            (1.5s, 2.25s, 3.4s) match the 4-8s probe p99
+          * Network error start: 8.0s (was 15.0s) — still defensive
+            but proportional
+          * Multiplier: 1.5x per attempt (unchanged)
+          * Cap: 10s (was 30s) — caps at empirical p99 × ~1.5 safety
+            factor instead of the prior 30s which exceeded the
+            measured ceiling by 3-7x
+          * Jitter: +/-25% (unchanged)
+          * Floor: 0.5s (unchanged)
+
+        Env knobs (operator-tunable without code change):
+          JARVIS_DW_POLL_BASE_S         (default 1.5)
+          JARVIS_DW_POLL_NETWORK_BASE_S (default 8.0)
+          JARVIS_DW_POLL_MULTIPLIER     (default 1.5)
+          JARVIS_DW_POLL_CAP_S          (default 10.0)
+          JARVIS_DW_POLL_JITTER_FRACTION (default 0.25)
         """
-        import random
-        base = 15.0 if network_error else 2.0
-        interval = min(base * (1.5 ** attempt), 30.0)
-        jitter = interval * 0.25 * (2 * random.random() - 1)
+        import os as _os, random
+        try:
+            _base_normal = float(_os.environ.get("JARVIS_DW_POLL_BASE_S", "1.5"))
+            _base_network = float(_os.environ.get("JARVIS_DW_POLL_NETWORK_BASE_S", "8.0"))
+            _mult = float(_os.environ.get("JARVIS_DW_POLL_MULTIPLIER", "1.5"))
+            _cap = float(_os.environ.get("JARVIS_DW_POLL_CAP_S", "10.0"))
+            _jit_frac = float(_os.environ.get("JARVIS_DW_POLL_JITTER_FRACTION", "0.25"))
+        except (TypeError, ValueError):
+            _base_normal, _base_network, _mult, _cap, _jit_frac = 1.5, 8.0, 1.5, 10.0, 0.25
+        base = _base_network if network_error else _base_normal
+        interval = min(base * (_mult ** attempt), _cap)
+        jitter = interval * _jit_frac * (2 * random.random() - 1)
         return max(0.5, interval + jitter)
 
     async def _adaptive_poll_batch(

--- a/backend/core/ouroboros/telemetry/dispatch_profiler.py
+++ b/backend/core/ouroboros/telemetry/dispatch_profiler.py
@@ -379,6 +379,55 @@ async def dispatch_stage(
             )
 
 
+def record_stage(
+    stage_name: str,
+    *,
+    op_id: str,
+    model_id: str,
+    duration_ms: float,
+    outcome: str = "ok",
+    error_class: str = "",
+) -> None:
+    """Slice 35 — manual stage record helper for the dual-path
+    profiler wiring.
+
+    Use when async-context-manager wrapping would require dangerous
+    indent restructuring (e.g., inside large branchy async functions
+    like ``DoublewordProvider._generate_realtime``). Caller measures
+    ``duration_ms`` themselves via ``time.monotonic()`` deltas.
+
+    Records into the active op accumulator (if an :func:`op_session`
+    is active for this op_id + model_id) AND emits a per-stage log
+    row. NEVER raises into the caller — internal errors swallowed.
+    """
+    if not is_enabled():
+        return
+    try:
+        logger.log(
+            _stage_log_level(),
+            "[DispatchProfiler] stage op=%s model=%s stage=%s "
+            "duration_ms=%.1f outcome=%s%s",
+            op_id[:16], model_id, stage_name,
+            duration_ms, outcome,
+            f" error_class={error_class}" if error_class else "",
+        )
+        key = _active_key(op_id, model_id)
+        with _active_ops_lock:
+            summary = _active_ops.get(key)
+        if summary is not None:
+            summary.stages.append(StageRecord(
+                stage_name=stage_name,
+                duration_ms=duration_ms,
+                outcome=outcome,
+                error_class=error_class,
+            ))
+    except Exception as inner:  # noqa: BLE001 — fail-closed
+        logger.warning(
+            "[DispatchProfiler] record_stage(%s) failed: %s",
+            stage_name, inner,
+        )
+
+
 def get_recent_op_summaries(limit: int = 50) -> List[OpDispatchSummary]:
     """Read-only snapshot of recent per-op dispatch summaries
     (most recent first). For REPL inspection + observability."""


### PR DESCRIPTION
## Summary

v30 op_summary bisection named `STAGE_PROVIDER_GENERATE` as 99.99% of the 30-111s timeout budget. Slice 35 opens up `generate()`'s internal sub-stages on **BOTH the RT (production hot path) AND batch (fallback / probe) corridors** so v31 can disambiguate WHICH sub-stage consumes the time.

## Phase 1 — RT path stages (6)

Wired in `_generate_realtime` via `dispatch_profiler.record_stage()` (avoids indent restructuring in the 900-line function):

| Stage | Where it ends |
|---|---|
| `STAGE_RT_PROMPT_BUILD` | After `_build_codegen_prompt` |
| `STAGE_RT_AEGIS_AUTH` | After `_aegis_acquire_call_lease` |
| `STAGE_RT_HTTP_POST` | At TTFT first-chunk arrival |
| `STAGE_RT_STREAM_CONSUME` | At Venom loop entry / parse |
| `STAGE_RT_VENOM_TOOL_LOOP` | After Venom block (strongest v25-v29 suspect) |
| `STAGE_RT_RESPONSE_PARSE` | After `_parse_with_heal` |

## Phase 2 — Batch path stages (4) + poll calibration

In `submit_batch` + `poll_and_retrieve`:

| Stage | Wraps |
|---|---|
| `STAGE_BATCH_UPLOAD` | `_upload_file` |
| `STAGE_BATCH_CREATE` | `_create_batch` |
| `STAGE_BATCH_AWAIT` | `_await_batch_result` (poll loop) |
| `STAGE_BATCH_RETRIEVE` | `_retrieve_result` |

(Operator's `STAGE_BATCH_PROMPT_BUILD` omitted — `submit_batch()` receives a pre-built jsonl_line, so prompt assembly is in the caller, not here.)

**Poll calibration:** `_next_poll_interval` defaults tightened to operator's spec + Phase 0 empirical baseline:

| Knob | Old | New |
|---|---|---|
| `JARVIS_DW_POLL_BASE_S` | 2.0 | **1.5** |
| `JARVIS_DW_POLL_NETWORK_BASE_S` | 15.0 | **8.0** |
| `JARVIS_DW_POLL_CAP_S` | 30.0 | **10.0** |
| multiplier / jitter / floor | 1.5 / 0.25 / 0.5 | unchanged |

All 5 knobs env-tunable.

## Phase 3 — Unified output

Both paths emit via `dispatch_profiler.record_stage()` → `[DispatchProfiler] stage` rows + per-op rollup in `[DispatchProfiler] op_summary` row at op exit (handled by Slice 34's `_call_primary` wiring).

## Verification

| Suite | Result |
|---|---|
| Slice 34 + 35 | **39/39 green** |
| Slice 11 + Slice 20+ + Slice 31/32/33 + Slice 34/35 | **341/341 broader regression** |

## v31 bisection contract

The dominant stage names the next-slice scope:

- `STAGE_RT_VENOM_TOOL_LOOP` >> others → tool loop is sink → Slice 36 = round-level diagnostic
- `STAGE_RT_STREAM_CONSUME` >> others → DW streaming pacing → Slice 36 = chunk-level diagnostic
- `STAGE_RT_HTTP_POST` >> others → Aegis daemon / network → Slice 36 = transport diagnostic
- `STAGE_RT_PROMPT_BUILD` >> others → prompt assembly → Slice 36 = prompt construction profiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dual-path stage profiling for real-time and batch generation to pinpoint latency hot spots, and tightens batch poll backoff defaults for faster result retrieval.

- New Features
  - Real-time path: stage timers added for STAGE_RT_PROMPT_BUILD, STAGE_RT_AEGIS_AUTH, STAGE_RT_HTTP_POST, STAGE_RT_STREAM_CONSUME, STAGE_RT_VENOM_TOOL_LOOP, STAGE_RT_RESPONSE_PARSE.
  - Batch path: stage timers added for STAGE_BATCH_UPLOAD, STAGE_BATCH_CREATE, STAGE_BATCH_AWAIT, STAGE_BATCH_RETRIEVE.
  - New `record_stage()` in `backend/core/ouroboros/telemetry/dispatch_profiler.py` for manual timing; emits per-stage logs and feeds per-op rollups. Gated by `JARVIS_DISPATCH_PROFILER_ENABLED` (off by default).
  - Poll calibration: defaults tightened to base=1.5s, network base=8s, cap=10s (multiplier=1.5x, jitter=0.25 unchanged). Override via `JARVIS_DW_POLL_*` envs.

- Migration
  - Enable profiling by setting `JARVIS_DISPATCH_PROFILER_ENABLED=1`.
  - Optional tuning: `JARVIS_DW_POLL_BASE_S`, `JARVIS_DW_POLL_NETWORK_BASE_S`, `JARVIS_DW_POLL_MULTIPLIER`, `JARVIS_DW_POLL_CAP_S`, `JARVIS_DW_POLL_JITTER_FRACTION`.

<sup>Written for commit d78d30ceb548afde8a970cdf526421f924d90e64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/61727?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

