### PR TITLE
feat(governance): Slice 36 — Adaptive Transport Dispatcher + Aggregation Bug Fix (v25-v31 capability blocker)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -103,6 +103,80 @@ _DW_TEMPERATURE = float(os.environ.get("DOUBLEWORD_TEMPERATURE", "0.2"))
 _DW_CONNECT_TIMEOUT_S = float(os.environ.get("DOUBLEWORD_CONNECT_TIMEOUT_S", "10"))
 _DW_REQUEST_TIMEOUT_S = float(os.environ.get("DOUBLEWORD_REQUEST_TIMEOUT_S", "120"))
 
+
+# ============================================================================
+# Slice 36 — Adaptive Transport Selector
+# ============================================================================
+#
+# v31 empirical evidence (bt-2026-05-28-065235):
+#
+#   * STAGE_RT_HTTP_POST p50 TTFT     = 66,775 ms (DW /v1/chat/completions)
+#   * STAGE_RT_VENOM_TOOL_LOOP p50    = 66,849 ms (nested with above)
+#   * Phase 0 probe via prompt_only   =  4,000-8,000 ms end-to-end (BATCH)
+#
+# Same DW account, same Qwen3.5-397B model, same prompt sizes (1-50KB).
+# DW's RT streaming endpoint has fundamentally different latency
+# characteristics than its batch API. Production picked RT; v25-v31
+# produced 0 APPLY events across 6 capability soaks.
+#
+# Slice 36 makes the transport selection ADAPTIVE: when Claude is
+# disabled (pure-DW config), STANDARD/COMPLEX routes auto-switch to
+# the empirically-faster BATCH API path. RT path preserved for
+# IMMEDIATE / BG / SPECULATIVE (latency-sensitive low-context paths
+# where Venom adds value).
+#
+# Trade-off acknowledged: BATCH path does NOT support the Venom tool
+# loop (single-shot generation). v31 evidence: 0 successful Venom
+# rounds across all production ops anyway (every RT call timed out).
+# Net delta = positive (some candidates >> zero candidates).
+#
+# Operator escape hatch: ``JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX=0``
+# reverts to legacy RT-only routing for STANDARD/COMPLEX.
+
+_SLICE36_FORCE_BATCH_ENV: str = "JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX"
+
+
+def _slice36_should_force_batch(context: Any) -> bool:
+    """Slice 36 — adaptive transport selector decision.
+
+    Returns True when the BATCH API path should be used in place of
+    the RT streaming path for THIS specific op.
+
+    Decision matrix:
+
+      * ``JARVIS_PROVIDER_CLAUDE_DISABLED != true`` (Claude available
+        as fallback) → False (RT path; Claude catches any RT failure)
+      * Master flag explicitly off → False (operator opt-out)
+      * Route NOT in {standard, complex} → False (preserve RT for
+        IMMEDIATE / BG / SPECULATIVE where Venom adds value AND
+        prompt sizes are small)
+      * All conditions hold → True (force batch)
+
+    NEVER raises — defensive on any attribute lookup or env parse
+    failure (returns False = preserve legacy RT behavior).
+    """
+    try:
+        # Claude must be disabled — Slice 36 is the "pure-DW
+        # production" path optimization. With Claude available, RT
+        # failures cascade to Claude fallback and the empirical
+        # cost-benefit shifts.
+        _claude_disabled = os.environ.get(
+            "JARVIS_PROVIDER_CLAUDE_DISABLED", "",
+        ).strip().lower() in ("1", "true", "yes", "on")
+        if not _claude_disabled:
+            return False
+        # Master opt-out (default ON per operator authorization)
+        _raw = os.environ.get(_SLICE36_FORCE_BATCH_ENV, "1").strip().lower()
+        if _raw in ("0", "false", "no", "off"):
+            return False
+        # Route gate — only STANDARD + COMPLEX get the batch path
+        _route = (
+            getattr(context, "provider_route", "") or ""
+        ).strip().lower()
+        return _route in ("standard", "complex")
+    except Exception:  # noqa: BLE001 — defensive
+        return False
+
 # Pricing (March 2026)
 _DW_INPUT_COST_PER_M = float(os.environ.get("DOUBLEWORD_INPUT_COST_PER_M", "0.10"))
 _DW_OUTPUT_COST_PER_M = float(os.environ.get("DOUBLEWORD_OUTPUT_COST_PER_M", "0.40"))
@@ -1395,10 +1469,25 @@ class DoublewordProvider:
                 _heavy_exc,
             )
 
+        # Slice 36 — adaptive transport selector. v31 proved DW RT
+        # streaming TTFT p50 = 66.8s vs batch end-to-end 4-8s for
+        # the same prompts. STANDARD/COMPLEX routes under pure-DW
+        # config skip RT entirely and go straight to batch.
+        _slice36_force_batch = _slice36_should_force_batch(context)
+        if _slice36_force_batch:
+            logger.info(
+                "[DoublewordProvider] Slice 36 transport selector: "
+                "STANDARD/COMPLEX + Claude-disabled → BATCH path "
+                "(skipping RT; v31 evidence: RT TTFT 66s vs BATCH 4-8s) "
+                "op=%s route=%s",
+                getattr(context, "op_id", "?")[:16],
+                getattr(context, "provider_route", "?"),
+            )
+
         # Real-time mode: /v1/chat/completions with SSE streaming + Venom tool loop
         # On 429/503, fall back to batch within DW (stay cheap) instead of
         # cascading to the 150x more expensive Claude fallback.
-        if self._realtime_enabled:
+        if self._realtime_enabled and not _slice36_force_batch:
             try:
                 # Slice 9.1 — thread repair_context for L2 single-shot
                 return await self._generate_realtime(

--- a/backend/core/ouroboros/telemetry/dispatch_profiler.py
+++ b/backend/core/ouroboros/telemetry/dispatch_profiler.py
@@ -411,9 +411,30 @@ def record_stage(
             duration_ms, outcome,
             f" error_class={error_class}" if error_class else "",
         )
+        # Slice 36 Phase 2 — model_id tolerant lookup. v31 surfaced
+        # the bug: Slice 34's op_session uses (op_id, model_id_kwarg
+        # from sentinel walker, e.g. "Qwen3.5-35B") but Slice 35's
+        # record_stage call sites in DW provider use self._model
+        # (provider default, e.g. "Qwen3.5-397B"). Exact key mismatch
+        # → record_stage finds no active op → stage drops from
+        # summary aggregation (per-stage log row still emitted —
+        # that's how we diagnosed in v31).
+        #
+        # Fix: try exact (op_id, model_id) match first; on miss,
+        # fall back to "any active op for this op_id" (typically
+        # there's at most one concurrent op per op_id). This
+        # preserves model_id when it matches AND tolerates
+        # walker-rotation mismatches.
         key = _active_key(op_id, model_id)
         with _active_ops_lock:
             summary = _active_ops.get(key)
+            if summary is None:
+                # Tolerant fallback — find any active entry for op_id
+                _prefix = f"{op_id}|"
+                for k, s in _active_ops.items():
+                    if k.startswith(_prefix):
+                        summary = s
+                        break
         if summary is not None:
             summary.stages.append(StageRecord(
                 stage_name=stage_name,

--- a/tests/governance/test_slice36_adaptive_transport.py
+++ b/tests/governance/test_slice36_adaptive_transport.py
@@ -1,0 +1,280 @@
+"""Slice 36 — Adaptive Transport Dispatcher + Model-ID-Tolerant Aggregation.
+
+Closes the v25→v31 production capability blocker:
+
+  * v31 empirical evidence: STAGE_RT_HTTP_POST p50 TTFT = 66.8s
+    on DW /v1/chat/completions for the same prompts that the
+    BATCH API (/v1/batches via prompt_only) served in 4-8s.
+  * Production picked RT; 0 APPLY events across 6 soaks.
+  * Slice 36 routes STANDARD/COMPLEX (pure-DW config) through
+    BATCH instead of RT.
+
+Phase 1: ``_slice36_should_force_batch`` decision function +
+``generate()`` wiring.
+
+Phase 2: ``record_stage`` model_id-tolerant lookup — fixes the
+v31 aggregation bug where Slice 34's op_session (model from
+sentinel walker) and Slice 35's record_stage (model from
+provider default) used different keys.
+
+Test surface (4 AST + 7 spine = 11 tests).
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+import time
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DW_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+    / "doubleword_provider.py"
+)
+PROFILER_FILE = (
+    REPO_ROOT / "backend" / "core" / "ouroboros" / "telemetry"
+    / "dispatch_profiler.py"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# AST PINS — 4
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_ast_pin_slice36_decision_function_present() -> None:
+    """``_slice36_should_force_batch`` MUST exist at module level
+    with the 4 documented decision branches."""
+    src = DW_FILE.read_text()
+    tree = ast.parse(src, filename=str(DW_FILE))
+    # The env knob string lives in the module-level constant; the
+    # function body references the constant. Check both.
+    assert "JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX" in src, (
+        "env knob string missing from doubleword_provider"
+    )
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "_slice36_should_force_batch"
+        ):
+            body = ast.unparse(node)
+            assert "JARVIS_PROVIDER_CLAUDE_DISABLED" in body
+            assert (
+                "_SLICE36_FORCE_BATCH_ENV" in body
+                or "JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX" in body
+            )
+            assert "provider_route" in body
+            assert "standard" in body and "complex" in body
+            return
+    pytest.fail("_slice36_should_force_batch not located in doubleword_provider.py")
+
+
+def test_ast_pin_generate_consults_slice36_selector() -> None:
+    """``generate()`` MUST call ``_slice36_should_force_batch``
+    BEFORE its RT-vs-batch routing decision."""
+    src = DW_FILE.read_text()
+    # The decision call appears AND the RT branch is gated on it
+    assert "_slice36_should_force_batch(context)" in src or (
+        "_slice36_should_force_batch" in src
+    )
+    assert "_slice36_force_batch" in src
+    assert "self._realtime_enabled and not _slice36_force_batch" in src, (
+        "RT branch must be gated by both the legacy flag AND the new "
+        "Slice 36 force-batch decision"
+    )
+
+
+def test_ast_pin_record_stage_tolerant_lookup() -> None:
+    """``record_stage`` MUST do exact-match lookup FIRST, then fall
+    back to ``op_id`` prefix-match if exact key misses. This is the
+    Phase 2 aggregation bug fix."""
+    src = PROFILER_FILE.read_text()
+    # The decision call appears AND tolerant fallback exists
+    assert "Slice 36" in src, (
+        "Phase 2 fix attribution missing from dispatch_profiler"
+    )
+    assert "for k, s in _active_ops.items():" in src or (
+        "_prefix" in src and "startswith(_prefix)" in src
+    ), (
+        "tolerant lookup fallback (any-active-for-op_id) missing"
+    )
+
+
+def test_ast_pin_slice36_env_default_on() -> None:
+    """``JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX`` defaults TRUE per
+    operator authorization. Operator opt-out via explicit-false."""
+    # Set Claude-disabled + STANDARD route + leave master unset (default)
+    # Should return True
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        _slice36_should_force_batch,
+    )
+    class FakeCtx:
+        provider_route = "standard"
+    with mock.patch.dict(os.environ, {
+        "JARVIS_PROVIDER_CLAUDE_DISABLED": "true",
+    }, clear=False):
+        os.environ.pop("JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX", None)
+        assert _slice36_should_force_batch(FakeCtx()) is True
+    # Explicit opt-out → False
+    with mock.patch.dict(os.environ, {
+        "JARVIS_PROVIDER_CLAUDE_DISABLED": "true",
+        "JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX": "0",
+    }):
+        assert _slice36_should_force_batch(FakeCtx()) is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Spine — 7
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spine_force_batch_false_when_claude_enabled() -> None:
+    """When Claude is NOT disabled (default), Slice 36 returns False
+    regardless of route — RT path with Claude fallback is the
+    legacy default behavior."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        _slice36_should_force_batch,
+    )
+    class FakeCtx:
+        provider_route = "standard"
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("JARVIS_PROVIDER_CLAUDE_DISABLED", None)
+        assert _slice36_should_force_batch(FakeCtx()) is False
+    with mock.patch.dict(os.environ, {
+        "JARVIS_PROVIDER_CLAUDE_DISABLED": "false",
+    }):
+        assert _slice36_should_force_batch(FakeCtx()) is False
+
+
+def test_spine_force_batch_false_for_non_standard_routes() -> None:
+    """IMMEDIATE / BG / SPECULATIVE preserve RT path (low-context
+    paths where Venom adds value)."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        _slice36_should_force_batch,
+    )
+    class FakeCtx:
+        pass
+    with mock.patch.dict(os.environ, {
+        "JARVIS_PROVIDER_CLAUDE_DISABLED": "true",
+    }):
+        for route in ("immediate", "background", "speculative", "", None):
+            ctx = FakeCtx()
+            ctx.provider_route = route
+            assert _slice36_should_force_batch(ctx) is False, (
+                f"route={route!r} should NOT force batch"
+            )
+
+
+def test_spine_force_batch_true_for_standard_and_complex() -> None:
+    """STANDARD + COMPLEX under pure-DW config → force batch."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        _slice36_should_force_batch,
+    )
+    class FakeCtx:
+        pass
+    with mock.patch.dict(os.environ, {
+        "JARVIS_PROVIDER_CLAUDE_DISABLED": "1",
+    }):
+        for route in ("standard", "complex", "STANDARD", "Complex"):
+            ctx = FakeCtx()
+            ctx.provider_route = route
+            assert _slice36_should_force_batch(ctx) is True, (
+                f"route={route!r} should force batch"
+            )
+
+
+def test_spine_force_batch_never_raises_on_missing_attrs() -> None:
+    """If context has no ``provider_route`` attr or env access
+    fails, Slice 36 MUST return False (preserve legacy behavior)."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        _slice36_should_force_batch,
+    )
+    class BrokenCtx:
+        def __getattr__(self, name):
+            raise RuntimeError(f"broken attr {name}")
+    # Must not raise; must return False (defensive)
+    with mock.patch.dict(os.environ, {
+        "JARVIS_PROVIDER_CLAUDE_DISABLED": "true",
+    }):
+        result = _slice36_should_force_batch(BrokenCtx())
+        assert result is False
+
+
+def test_spine_record_stage_tolerant_on_model_id_mismatch() -> None:
+    """Phase 2 fix: when op_session uses model X but record_stage
+    is called with model Y for the same op_id, the stage MUST still
+    aggregate into the op's summary (tolerant fallback)."""
+    os.environ["JARVIS_DISPATCH_PROFILER_ENABLED"] = "1"
+    from backend.core.ouroboros.telemetry import dispatch_profiler as dp
+    dp.reset_for_tests()
+
+    async def run():
+        # Slice 34 op_session uses model_A
+        async with dp.op_session(
+            op_id="op-test-mismatch",
+            model_id="Qwen/Qwen3.5-35B-A3B-FP8",
+            route="standard",
+        ) as summary:
+            # Slice 35 record_stage uses model_B (provider default)
+            dp.record_stage(
+                "STAGE_RT_PROMPT_BUILD",
+                op_id="op-test-mismatch",
+                model_id="Qwen/Qwen3.5-397B-A17B-FP8",  # MISMATCH
+                duration_ms=100.0,
+            )
+        # PRE-Slice-36 bug: stage would NOT appear in summary.stages
+        # POST-Slice-36: tolerant fallback finds the active op
+        assert len(summary.stages) == 1
+        assert summary.stages[0].stage_name == "STAGE_RT_PROMPT_BUILD"
+        assert summary.stages[0].duration_ms == 100.0
+
+    asyncio.run(run())
+    dp.reset_for_tests()
+
+
+def test_spine_record_stage_exact_match_still_works() -> None:
+    """Tolerant fallback MUST NOT break the exact-match case
+    (model_id matches → exact lookup succeeds → stage records)."""
+    os.environ["JARVIS_DISPATCH_PROFILER_ENABLED"] = "1"
+    from backend.core.ouroboros.telemetry import dispatch_profiler as dp
+    dp.reset_for_tests()
+
+    async def run():
+        async with dp.op_session(
+            op_id="op-exact", model_id="m-same", route="standard",
+        ) as summary:
+            dp.record_stage(
+                "S1", op_id="op-exact", model_id="m-same",
+                duration_ms=50.0,
+            )
+        assert len(summary.stages) == 1
+
+    asyncio.run(run())
+    dp.reset_for_tests()
+
+
+def test_spine_record_stage_no_active_op_still_emits_log() -> None:
+    """When NO active op_session matches (neither exact nor
+    prefix), record_stage MUST still emit the per-stage log row
+    (per Slice 35 contract — log rows are independent of summary
+    aggregation)."""
+    os.environ["JARVIS_DISPATCH_PROFILER_ENABLED"] = "1"
+    from backend.core.ouroboros.telemetry import dispatch_profiler as dp
+    dp.reset_for_tests()
+
+    # No op_session active — record_stage should not raise, should
+    # still emit the per-stage row (verified via lack of exception)
+    try:
+        dp.record_stage(
+            "S_ORPHAN", op_id="op-no-session", model_id="m",
+            duration_ms=42.0,
+        )
+    except Exception as exc:
+        pytest.fail(f"record_stage raised when no active op: {exc}")
+    dp.reset_for_tests()


### PR DESCRIPTION
## Summary

Closes the v25→v31 production capability blocker. v31 per-stage telemetry named DW's RT streaming TTFT (66.8 s p50) as 8× slower than its BATCH API end-to-end (4-8 s). Production picked RT and produced 0 APPLY across 6 capability soaks.

## Phase 1 — Adaptive Transport Selector

`_slice36_should_force_batch(context)` decision matrix:

1. `JARVIS_PROVIDER_CLAUDE_DISABLED=true` (pure-DW config)
2. `JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX=true` (default; operator opt-out via `=0`)
3. Route ∈ {standard, complex}

All 3 → BATCH instead of RT. RT preserved for IMMEDIATE / BG / SPECULATIVE.

**Trade-off**: BATCH path drops Venom tool loop. v31 showed 0 successful Venom rounds across all production ops anyway (every RT call timed out). Net delta = positive.

## Phase 2 — Model-ID-Tolerant Aggregation Bug Fix

v31 bug: Slice 34's `op_session` keys on `(op_id, walker_model_id)`; Slice 35's `record_stage` calls use `(op_id, self._model)`. Mismatch → stages dropped from `op_summary` aggregation (per-stage rows still emitted; we diagnosed v31 via the rows).

Fix in `dispatch_profiler.record_stage`: exact-match first, then prefix-match `{op_id}|` fallback. Preserves model_id when matched; tolerates walker rotation.

## Verification

| Suite | Result |
|---|---|
| Slice 36 (4 AST + 7 spine) | **11/11 green** |
| Slice 11 + Slice 20+ + Slice 31/32/33 + Slice 34 + Slice 36 | **352/352** (341 prior + 11 new) |

## v32 expectation

`$10 / 3600 s` with profiler enabled. Expected:
- Slice 36 INFO log at dispatch confirms BATCH routing
- `STAGE_BATCH_*` aggregate into `op_summary` (Phase 2 fix)
- Dispatch wall-time: v31's 30-66 s timeouts → v32's 4-8 s completions
- **APPLY events should fire for the first time in the v25→v32 arc**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an adaptive transport selector that routes DW STANDARD/COMPLEX ops to the faster Batch API when Claude is disabled, cutting RT TTFT from ~66s to ~4–8s and unblocking the v25→v31 capability gap. Also fixes stage aggregation so Batch stages show in `op_summary` even when model IDs differ.

- **New Features**
  - Added `_slice36_should_force_batch(context)` to force Batch when `JARVIS_PROVIDER_CLAUDE_DISABLED=true`, `JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX` is on (default), and route ∈ {standard, complex}.
  - Keeps RT for IMMEDIATE/BG/SPECULATIVE routes; logs an INFO line when Batch is chosen.
  - Operator opt-out via `JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX=0`.

- **Bug Fixes**
  - In `dispatch_profiler.record_stage`, try exact `(op_id, model_id)` match first, then fall back to any active op for the same `op_id` (prefix match).
  - Prevents stage drops from `op_summary` when the walker’s model ID differs from the provider default; preserves model ID when exactly matched.
  - Added 11 tests (AST + spine) covering the selector and tolerant aggregation.

<sup>Written for commit 3fb302dafaf06a4080cd82d36ced6f7ff70e775d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/62027?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

