### PR TITLE
Slice 39 — Multi-surface DW transport-health substrate (+ §49 PRD arc)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -773,6 +773,24 @@ class DoublewordProvider:
             )
         return self._session
 
+    async def force_session_reset(self) -> None:
+        """Slice 39 — hard-flush the aiohttp transport pool.
+
+        Closes the current ClientSession (and its TCPConnector socket
+        cache) and nulls it so the NEXT ``_get_session()`` rebuilds a
+        fresh connector. Composes the existing rebuild path in
+        ``_get_session`` — no duplicate connector logic. Used by the
+        transport disambiguator ONLY for the transport-failure class
+        (never for upstream ``done_before_content``). NEVER raises.
+        """
+        sess = self._session
+        self._session = None
+        if sess is not None and not getattr(sess, "closed", True):
+            try:
+                await sess.close()
+            except Exception:  # noqa: BLE001 — flush must not raise
+                pass
+
     @staticmethod
     def _request_timeout() -> "aiohttp.ClientTimeout":
         """Per-request timeout safe to use inside aiohttp 3.9+ tasks."""

--- a/backend/core/ouroboros/governance/dw_client_lifecycle.py
+++ b/backend/core/ouroboros/governance/dw_client_lifecycle.py
@@ -1,0 +1,113 @@
+"""Slice 39 — Transport-pool lifecycle coordinator.
+
+Single-owner flush policy: decides WHEN to call
+``provider.force_session_reset()`` (Task 3).  Composes the provider
+method; contains no connector logic of its own.
+
+Guards:
+* Master env switch ``JARVIS_DW_TRANSPORT_FLUSH_ENABLED`` (default true).
+* Cooldown window ``JARVIS_DW_TRANSPORT_FLUSH_COOLDOWN_S`` (default 60 s)
+  prevents a storm of transport failures from thrashing the aiohttp pool.
+
+``flush_transport_pool`` NEVER raises — provider exceptions are caught,
+logged, and surfaced as a False return so callers can proceed without
+defensive wrapping.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Callable, Optional
+
+logger = logging.getLogger("Ouroboros.ClientLifecycle")
+
+
+# ---------------------------------------------------------------------------
+# Stdlib-only env helpers (mirror preflight_probe.py convention)
+# ---------------------------------------------------------------------------
+
+def _envb(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in ("1", "true", "yes", "on")
+
+
+def _envf(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+# ---------------------------------------------------------------------------
+# ClientLifecycleManager
+# ---------------------------------------------------------------------------
+
+class ClientLifecycleManager:
+    """Decides when to flush the aiohttp transport pool.
+
+    Parameters
+    ----------
+    now_fn:
+        Monotonic clock callable.  Injectable for deterministic tests.
+    cooldown_s:
+        Minimum seconds between successive flushes.  When *None* the value
+        is read from ``JARVIS_DW_TRANSPORT_FLUSH_COOLDOWN_S`` (default 60 s).
+    """
+
+    def __init__(
+        self,
+        *,
+        now_fn: Callable[[], float] = time.monotonic,
+        cooldown_s: Optional[float] = None,
+    ) -> None:
+        self._now = now_fn
+        self._cooldown_s: float = (
+            cooldown_s
+            if cooldown_s is not None
+            else _envf("JARVIS_DW_TRANSPORT_FLUSH_COOLDOWN_S", 60.0)
+        )
+        self._last_flush_at: Optional[float] = None
+
+    async def flush_transport_pool(self, provider, *, reason: str) -> bool:
+        """Flush the provider's transport pool if guards allow.
+
+        Returns True when ``provider.force_session_reset()`` was called
+        successfully, False in all other cases (disabled, cooldown, error).
+        """
+        if not _envb("JARVIS_DW_TRANSPORT_FLUSH_ENABLED", True):
+            logger.info("flush skipped: disabled by env")
+            return False
+
+        now = self._now()
+        if (
+            self._last_flush_at is not None
+            and (now - self._last_flush_at) < self._cooldown_s
+        ):
+            logger.info(
+                "flush suppressed by cooldown (%.1fs < %.1fs) reason=%s",
+                now - self._last_flush_at,
+                self._cooldown_s,
+                reason,
+            )
+            return False
+
+        try:
+            await provider.force_session_reset()
+        except Exception:
+            logger.warning(
+                "flush_transport_pool: force_session_reset raised; reason=%s",
+                reason,
+                exc_info=True,
+            )
+            return False
+
+        self._last_flush_at = now
+        logger.warning("transport pool HARD-FLUSHED reason=%s", reason)
+        return True

--- a/backend/core/ouroboros/governance/dw_surface_health.py
+++ b/backend/core/ouroboros/governance/dw_surface_health.py
@@ -1,0 +1,132 @@
+"""Slice 39 Task 1 — Per-surface transport health taxonomy + record.
+
+Defines the *orthogonal* per-SURFACE health substrate that sits beside
+the existing per-MODEL ``dw_modality_ledger.py``.  Three surfaces are
+tracked:
+
+  * ``batch_storage``    — ``/v1/files`` batch-file upload / retrieval
+  * ``direct_streaming`` — ``/v1/chat/completions`` SSE stream
+  * ``auth_sync``        — Aegis authentication handshake
+
+Five verdicts capture the failure taxonomy:
+
+  * ``healthy``            — last probe completed without error
+  * ``transport_degraded`` — TCP/TLS/timeout before the server spoke
+  * ``upstream_degraded``  — server replied 5xx / stream ended early
+  * ``auth_failed``        — 401 / 403 / token-refresh failure
+  * ``error_other``        — anything else (unexpected exception, etc.)
+
+Only the closed-taxonomy enums, the frozen ``SurfaceHealthRecord``
+dataclass, and the ``LEDGER_SCHEMA_VERSION`` constant live here.
+Task 2 will add the mutable ledger class and atomic-write path.
+
+NEVER raises out of any public method.  ``from_json_dict`` returns
+``None`` on any structural problem.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Mapping, Optional
+
+logger = logging.getLogger("Ouroboros.SurfaceHealth")
+
+# ---------------------------------------------------------------------------
+# Schema version — Task 2 will embed this in the on-disk envelope.
+# ---------------------------------------------------------------------------
+
+LEDGER_SCHEMA_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Closed taxonomy enums
+# ---------------------------------------------------------------------------
+
+
+class SurfaceKind(str, Enum):
+    """The three DW transport surfaces JARVIS uses."""
+
+    BATCH_STORAGE = "batch_storage"
+    DIRECT_STREAMING = "direct_streaming"
+    AUTH_SYNC = "auth_sync"
+
+
+class SurfaceVerdict(str, Enum):
+    """Health verdict for a single surface probe outcome."""
+
+    HEALTHY = "healthy"
+    TRANSPORT_DEGRADED = "transport_degraded"
+    UPSTREAM_DEGRADED = "upstream_degraded"
+    AUTH_FAILED = "auth_failed"
+    ERROR_OTHER = "error_other"
+
+
+# ---------------------------------------------------------------------------
+# Frozen record dataclass with JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SurfaceHealthRecord:
+    """Immutable snapshot of one surface's health state.
+
+    Scalar fields use defensive coercion in ``from_json_dict`` so
+    minor type drift (e.g. JSON int vs float) never causes a crash.
+    """
+
+    surface: SurfaceKind
+    verdict: SurfaceVerdict
+    last_probe_unix: float = 0.0
+    latency_ms: int = 0
+    diagnostic: str = ""
+    consecutive_failures: int = 0
+
+    def to_json_dict(self) -> Dict[str, Any]:
+        """Serialise to a plain dict suitable for ``json.dumps``."""
+        return {
+            "surface": self.surface.value,
+            "verdict": self.verdict.value,
+            "last_probe_unix": self.last_probe_unix,
+            "latency_ms": self.latency_ms,
+            "diagnostic": self.diagnostic,
+            "consecutive_failures": self.consecutive_failures,
+        }
+
+    @classmethod
+    def from_json_dict(
+        cls,
+        raw: Mapping[str, Any],
+    ) -> Optional["SurfaceHealthRecord"]:
+        """Deserialise from a plain dict.  Returns ``None`` on any
+        structural problem (unknown/missing ``surface`` or ``verdict``,
+        unexpected exception)."""
+        try:
+            surface = SurfaceKind(raw["surface"])
+            verdict = SurfaceVerdict(raw["verdict"])
+            return cls(
+                surface=surface,
+                verdict=verdict,
+                last_probe_unix=float(raw.get("last_probe_unix", 0.0) or 0.0),
+                latency_ms=int(raw.get("latency_ms", 0) or 0),
+                diagnostic=str(raw.get("diagnostic", "")),
+                consecutive_failures=int(
+                    raw.get("consecutive_failures", 0) or 0
+                ),
+            )
+        except (KeyError, ValueError):
+            return None
+        except Exception:  # noqa: BLE001 — defensive; never propagate
+            logger.warning(
+                "[SurfaceHealth] unexpected error in from_json_dict; raw=%r",
+                raw,
+            )
+            return None
+
+
+__all__ = [
+    "LEDGER_SCHEMA_VERSION",
+    "SurfaceHealthRecord",
+    "SurfaceKind",
+    "SurfaceVerdict",
+]

--- a/backend/core/ouroboros/governance/dw_surface_health.py
+++ b/backend/core/ouroboros/governance/dw_surface_health.py
@@ -16,18 +16,20 @@ Five verdicts capture the failure taxonomy:
   * ``auth_failed``        — 401 / 403 / token-refresh failure
   * ``error_other``        — anything else (unexpected exception, etc.)
 
-Only the closed-taxonomy enums, the frozen ``SurfaceHealthRecord``
-dataclass, and the ``LEDGER_SCHEMA_VERSION`` constant live here.
-Task 2 will add the mutable ledger class and atomic-write path.
-
-NEVER raises out of any public method.  ``from_json_dict`` returns
-``None`` on any structural problem.
+Task 2 adds ``SurfaceHealthLedger``: mutable, thread-safe, persistent
+via atomic write.  ``NEVER raises`` out of any public method.
+``from_json_dict`` returns ``None`` on any structural problem.
 """
 from __future__ import annotations
 
+import json
 import logging
+import os
+import threading
+import time
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Any, Dict, Mapping, Optional
 
 logger = logging.getLogger("Ouroboros.SurfaceHealth")
@@ -124,8 +126,217 @@ class SurfaceHealthRecord:
             return None
 
 
+# ---------------------------------------------------------------------------
+# Task 2 — Path helpers + atomic write
+# ---------------------------------------------------------------------------
+
+
+def _default_ledger_path() -> Path:
+    """``JARVIS_DW_SURFACE_HEALTH_PATH`` (default
+    ``.jarvis/dw_surface_health.json``). Override for tests."""
+    raw = os.environ.get("JARVIS_DW_SURFACE_HEALTH_PATH", "").strip()
+    if raw:
+        return Path(raw)
+    return Path(".jarvis") / "dw_surface_health.json"
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write *text* to *path* atomically via a sibling ``.tmp`` file.
+
+    Creates parent directories as needed.  Lets ``OSError`` propagate
+    to the caller (``SurfaceHealthLedger.save`` catches it).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    try:
+        os.replace(tmp, path)
+    except OSError:
+        # Don't leave an orphan .tmp behind on a failed rename
+        # (e.g. cross-device). Mirrors dw_modality_ledger cleanup.
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Task 2 — Mutable ledger
+# ---------------------------------------------------------------------------
+
+
+class SurfaceHealthLedger:
+    """Persistent per-surface health verdict tracker.
+
+    Thread-safe via ``RLock``.  Mutating methods write through to disk
+    when *autosave* is ``True`` so verdicts survive process restart.
+
+    Contract:
+      * ``load()`` — NEVER raises; corrupt / missing file → warn + empty.
+      * ``save()`` — NEVER raises; ``OSError`` is logged + swallowed.
+      * ``record()`` / ``verdict_for()`` / ``snapshot()`` — NEVER raise.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: Optional[Path] = None,
+        autosave: bool = True,
+    ) -> None:
+        self._path = path
+        self._autosave = autosave
+        self._records: Dict[SurfaceKind, SurfaceHealthRecord] = {}
+        self._lock = threading.RLock()
+        self._loaded = False
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def _resolved_path(self) -> Path:
+        return self._path if self._path is not None else _default_ledger_path()
+
+    def load(self) -> None:
+        """Load state from disk.  Missing file = empty ledger; corrupt
+        file = log warn + start empty.  NEVER raises."""
+        with self._lock:
+            self._loaded = True
+            p = self._resolved_path()
+            if not p.exists():
+                return
+            try:
+                payload = json.loads(p.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning(
+                    "[SurfaceHealthLedger] corrupt or unreadable ledger "
+                    "at %s — starting empty (%s)", p, exc,
+                )
+                return
+            if not isinstance(payload, Mapping):
+                logger.warning(
+                    "[SurfaceHealthLedger] ledger at %s is not a JSON "
+                    "object — starting empty", p,
+                )
+                return
+            if payload.get("schema_version") != LEDGER_SCHEMA_VERSION:
+                logger.warning(
+                    "[SurfaceHealthLedger] schema mismatch at %s "
+                    "(found=%r expected=%r) — starting empty",
+                    p, payload.get("schema_version"), LEDGER_SCHEMA_VERSION,
+                )
+                return
+            records_raw = payload.get("records", [])
+            if not isinstance(records_raw, list):
+                logger.warning(
+                    "[SurfaceHealthLedger] ledger at %s has non-list "
+                    "'records' — starting empty", p,
+                )
+                return
+            loaded = 0
+            for r in records_raw:
+                if not isinstance(r, Mapping):
+                    continue
+                rec = SurfaceHealthRecord.from_json_dict(r)
+                if rec is not None:
+                    self._records[rec.surface] = rec
+                    loaded += 1
+            logger.info(
+                "[SurfaceHealthLedger] loaded %d record(s) from %s",
+                loaded, p,
+            )
+
+    def save(self) -> None:
+        """Write current state to disk atomically.  NEVER raises."""
+        with self._lock:
+            payload = {
+                "schema_version": LEDGER_SCHEMA_VERSION,
+                "records": [
+                    r.to_json_dict() for r in self._records.values()
+                ],
+            }
+            try:
+                _atomic_write(
+                    self._resolved_path(),
+                    json.dumps(payload, sort_keys=True, indent=2),
+                )
+            except OSError as exc:
+                logger.warning(
+                    "[SurfaceHealthLedger] save failed: %s — "
+                    "ledger remains in memory", exc,
+                )
+
+    def _ensure_loaded(self) -> None:
+        if not self._loaded:
+            self.load()
+
+    # ------------------------------------------------------------------
+    # Write API
+    # ------------------------------------------------------------------
+
+    def record(
+        self,
+        surface: SurfaceKind,
+        verdict: SurfaceVerdict,
+        *,
+        latency_ms: int = 0,
+        diagnostic: str = "",
+        now_unix: Optional[float] = None,
+    ) -> SurfaceHealthRecord:
+        """Record a probe outcome for *surface*.
+
+        Streak logic:
+          * HEALTHY → ``consecutive_failures`` resets to 0.
+          * Any other verdict → increments the prior count (or starts at 1).
+
+        Returns the newly-stored ``SurfaceHealthRecord``.  NEVER raises.
+        """
+        with self._lock:
+            self._ensure_loaded()
+            prev = self._records.get(surface)
+            if verdict is SurfaceVerdict.HEALTHY:
+                consecutive_failures = 0
+            else:
+                consecutive_failures = (
+                    (prev.consecutive_failures + 1) if prev is not None else 1
+                )
+            rec = SurfaceHealthRecord(
+                surface=surface,
+                verdict=verdict,
+                last_probe_unix=now_unix if now_unix is not None else time.time(),
+                latency_ms=latency_ms,
+                diagnostic=diagnostic,
+                consecutive_failures=consecutive_failures,
+            )
+            self._records[surface] = rec
+            if self._autosave:
+                self.save()
+            return rec
+
+    # ------------------------------------------------------------------
+    # Read API
+    # ------------------------------------------------------------------
+
+    def verdict_for(
+        self, surface: SurfaceKind,
+    ) -> Optional[SurfaceHealthRecord]:
+        """Return the current ``SurfaceHealthRecord`` for *surface*, or
+        ``None`` if no record exists yet.  NEVER raises."""
+        with self._lock:
+            self._ensure_loaded()
+            return self._records.get(surface)
+
+    def snapshot(self) -> Dict[SurfaceKind, SurfaceHealthRecord]:
+        """Return a shallow copy of the current records dict.
+        NEVER raises."""
+        with self._lock:
+            self._ensure_loaded()
+            return dict(self._records)
+
+
 __all__ = [
     "LEDGER_SCHEMA_VERSION",
+    "SurfaceHealthLedger",
     "SurfaceHealthRecord",
     "SurfaceKind",
     "SurfaceVerdict",

--- a/backend/core/ouroboros/governance/dw_surface_probes.py
+++ b/backend/core/ouroboros/governance/dw_surface_probes.py
@@ -1,0 +1,246 @@
+"""Slice 39 Task 7 — Per-surface transport-health probes + concurrent sweep.
+
+Three probes mirror the three ``SurfaceKind`` values:
+
+  probe_batch_storage     — exercises ``/v1/files`` via ``_upload_file``
+  probe_direct_streaming  — exercises SSE streaming via ``build_heavyprobe_adapter``
+  probe_auth_sync         — validates the Aegis/legacy bearer header
+
+All three probes NEVER raise.  Unexpected exceptions are caught and
+translated into the appropriate degraded verdict.
+
+``run_surface_sweep`` fires all three concurrently via ``asyncio.gather``
+with per-probe timeout isolation (env ``JARVIS_DW_SURFACE_PROBE_TIMEOUT_S``,
+default 10 s), records results into a ``SurfaceHealthLedger``, and returns
+the post-record snapshot.  NEVER raises.
+
+Design note — monkeypatch compatibility
+----------------------------------------
+``run_surface_sweep`` calls ``probe_batch_storage``, ``probe_direct_streaming``,
+and ``probe_auth_sync`` by resolving the names through the *module global
+namespace* at call time (bare ``probe_*(...)`` references in the function
+body).  Because Python resolves unqualified function calls through the
+enclosing module's ``__dict__``, ``monkeypatch.setattr(mod, "probe_*", fake)``
+replaces the binding seen by ``run_surface_sweep`` — no local alias is
+captured.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any, Dict, Optional, Tuple, cast
+
+from backend.core.ouroboros.governance.aegis_provider_bridge import (
+    dw_session_auth_header,
+)
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger,
+    SurfaceHealthRecord,
+    SurfaceKind,
+    SurfaceVerdict,
+)
+
+logger = logging.getLogger("Ouroboros.SurfaceProbes")
+
+
+# ---------------------------------------------------------------------------
+# Env helper
+# ---------------------------------------------------------------------------
+
+
+def _envf(name: str, default: float) -> float:
+    """Read a float env var; return *default* on missing / bad value."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Probe A — Batch Storage (/v1/files)
+# ---------------------------------------------------------------------------
+
+
+async def probe_batch_storage(
+    provider: object,
+    model_id: str,
+) -> Tuple[SurfaceVerdict, str, int]:
+    """Probe the ``BATCH_STORAGE`` surface by uploading a minimal JSONL entry.
+
+    Returns ``(verdict, diagnostic, latency_ms)``.  NEVER raises.
+    """
+    entry = {
+        "custom_id": f"slice39-surface-a-{int(time.time())}",
+        "method": "POST",
+        "url": "/v1/chat/completions",
+        "body": {
+            "model": model_id,
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 1,
+        },
+    }
+    t0 = time.monotonic()
+    try:
+        jsonl = provider._compose_jsonl_batch_entry(entry)  # type: ignore[union-attr]
+        file_id = await provider._upload_file(jsonl, op_id=entry["custom_id"])  # type: ignore[union-attr]
+        latency = int((time.monotonic() - t0) * 1000)
+        if file_id:
+            return SurfaceVerdict.HEALTHY, f"file_id={file_id}", latency
+        return SurfaceVerdict.UPSTREAM_DEGRADED, "upload_returned_none", latency
+    except Exception as exc:  # noqa: BLE001 — never raise
+        latency = int((time.monotonic() - t0) * 1000)
+        diag = f"{type(exc).__name__}:{str(exc)[:120]}"
+        logger.debug("probe_batch_storage raised (caught): %s", diag)
+        return SurfaceVerdict.UPSTREAM_DEGRADED, diag, latency
+
+
+# ---------------------------------------------------------------------------
+# Probe B — Direct Streaming (/v1/chat/completions SSE)
+# ---------------------------------------------------------------------------
+
+
+async def probe_direct_streaming(
+    provider: object,
+    model_id: str,
+) -> Tuple[SurfaceVerdict, str, int]:
+    """Probe the ``DIRECT_STREAMING`` surface via the heavy-probe adapter.
+
+    Returns ``(verdict, diagnostic, latency_ms)``.  NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.governance.dw_transport_disambiguator import (
+            FailureClass,
+            classify_surface_failure,
+        )
+        from backend.core.ouroboros.governance.preflight_probe import (
+            build_heavyprobe_adapter,
+        )
+
+        probe_fn = build_heavyprobe_adapter(provider)
+        outcome = await probe_fn(model_id)
+
+        if getattr(outcome, "success", False):
+            latency = int(getattr(outcome, "latency_ms", 0) or 0)
+            return SurfaceVerdict.HEALTHY, "", latency
+
+        cls = classify_surface_failure(outcome)
+        diag: str = getattr(outcome, "error_message", None) or "stream_failed"
+        latency = int(getattr(outcome, "latency_ms", 0) or 0)
+
+        if cls is FailureClass.TRANSPORT:
+            return SurfaceVerdict.TRANSPORT_DEGRADED, diag, latency
+        return SurfaceVerdict.UPSTREAM_DEGRADED, diag, latency
+
+    except Exception as exc:  # noqa: BLE001 — never raise
+        diag = f"{type(exc).__name__}:{str(exc)[:120]}"
+        logger.debug("probe_direct_streaming raised (caught): %s", diag)
+        return SurfaceVerdict.ERROR_OTHER, diag, 0
+
+
+# ---------------------------------------------------------------------------
+# Probe C — Auth Sync (Aegis / legacy bearer)
+# ---------------------------------------------------------------------------
+
+
+async def probe_auth_sync() -> Tuple[SurfaceVerdict, str]:
+    """Probe the ``AUTH_SYNC`` surface by fetching the session auth header.
+
+    Returns ``(verdict, diagnostic)``.  NEVER raises.
+    """
+    try:
+        header = await dw_session_auth_header()
+        if header.get("Authorization", "").startswith("Bearer "):
+            return SurfaceVerdict.HEALTHY, ""
+        return SurfaceVerdict.AUTH_FAILED, "no_bearer_in_header"
+    except Exception as exc:  # noqa: BLE001 — never raise
+        diag = f"{type(exc).__name__}:{str(exc)[:120]}"
+        logger.debug("probe_auth_sync raised (caught): %s", diag)
+        return SurfaceVerdict.AUTH_FAILED, diag
+
+
+# ---------------------------------------------------------------------------
+# Concurrent sweep
+# ---------------------------------------------------------------------------
+
+
+async def run_surface_sweep(
+    *,
+    provider: object,
+    model_id: str,
+    ledger: SurfaceHealthLedger,
+    timeout_s: Optional[float] = None,
+) -> Dict[SurfaceKind, SurfaceHealthRecord]:
+    """Run all three surface probes concurrently and record into *ledger*.
+
+    Each probe is individually guarded by *timeout_s* (env
+    ``JARVIS_DW_SURFACE_PROBE_TIMEOUT_S``, default 10 s) so a single
+    slow probe cannot starve the others.
+
+    Returns the post-record ``ledger.snapshot()``.  NEVER raises.
+    """
+    eff_timeout: float = (
+        timeout_s if timeout_s is not None
+        else _envf("JARVIS_DW_SURFACE_PROBE_TIMEOUT_S", 10.0)
+    )
+
+    async def _guarded(coro) -> Any:
+        try:
+            return await asyncio.wait_for(coro, eff_timeout)
+        except asyncio.TimeoutError:
+            return ("__timeout__",)
+        except Exception as exc:  # noqa: BLE001
+            return ("__error__", f"{type(exc).__name__}:{str(exc)[:120]}")
+
+    def _unpack3(res: Any) -> Tuple[SurfaceVerdict, str, int]:
+        # 3-tuple probe result, or a sentinel from _guarded.
+        if isinstance(res, tuple) and len(res) == 1 and res[0] == "__timeout__":
+            return SurfaceVerdict.TRANSPORT_DEGRADED, "probe_timeout", 0
+        if isinstance(res, tuple) and len(res) == 2 and res[0] == "__error__":
+            return SurfaceVerdict.ERROR_OTHER, str(res[1]), 0
+        return cast(Tuple[SurfaceVerdict, str, int], res)  # probe 3-tuple
+
+    def _unpack2(res: Any) -> Tuple[SurfaceVerdict, str]:
+        # 2-tuple auth result, or a sentinel from _guarded.
+        if isinstance(res, tuple) and len(res) == 1 and res[0] == "__timeout__":
+            return SurfaceVerdict.AUTH_FAILED, "probe_timeout"
+        if isinstance(res, tuple) and len(res) == 2 and res[0] == "__error__":
+            return SurfaceVerdict.ERROR_OTHER, str(res[1])
+        return cast(Tuple[SurfaceVerdict, str], res)  # probe 2-tuple
+
+    # Fire all three concurrently.
+    # NOTE: probe_batch_storage / probe_direct_streaming / probe_auth_sync are
+    # resolved via the module's global namespace at call time — monkeypatch
+    # replacements on the module object are visible here.
+    a, b, c = await asyncio.gather(
+        _guarded(probe_batch_storage(provider, model_id)),
+        _guarded(probe_direct_streaming(provider, model_id)),
+        _guarded(probe_auth_sync()),
+    )
+
+    va, da, la = _unpack3(a)   # Probe A (batch storage)
+    vb, db, lb = _unpack3(b)   # Probe B (direct streaming)
+    vc, dc = _unpack2(c)       # Probe C (auth sync)
+
+    # --- Record into ledger ---
+    ledger.record(SurfaceKind.BATCH_STORAGE, va, latency_ms=la, diagnostic=da)
+    ledger.record(SurfaceKind.DIRECT_STREAMING, vb, latency_ms=lb, diagnostic=db)
+    ledger.record(SurfaceKind.AUTH_SYNC, vc, diagnostic=dc)
+
+    logger.info(
+        "[SurfaceProbes] sweep complete: batch=%s stream=%s auth=%s",
+        va.value, vb.value, vc.value,
+    )
+    return ledger.snapshot()
+
+
+__all__ = [
+    "probe_auth_sync",
+    "probe_batch_storage",
+    "probe_direct_streaming",
+    "run_surface_sweep",
+]

--- a/backend/core/ouroboros/governance/dw_transport_disambiguator.py
+++ b/backend/core/ouroboros/governance/dw_transport_disambiguator.py
@@ -47,6 +47,12 @@ from __future__ import annotations
 import logging
 from enum import Enum
 
+# Module-level import (no cycle: preflight_probe does not import this module).
+# Hoisted so the raw_http_bypass_probe error path can construct a failed
+# ProbeOutcome without a re-import that could itself raise — guarantees the
+# documented NEVER-raises contract.
+from backend.core.ouroboros.governance.preflight_probe import ProbeOutcome
+
 logger = logging.getLogger("Ouroboros.TransportDisambiguator")
 
 # ---------------------------------------------------------------------------
@@ -161,3 +167,253 @@ def classify_surface_failure(outcome) -> FailureClass:
         status_code,
     )
     return FailureClass.UPSTREAM
+
+
+# ---------------------------------------------------------------------------
+# Task 6 — raw bypass probe + disambiguate_and_recover
+# ---------------------------------------------------------------------------
+
+import os
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+
+def _envb(name: str, default: bool) -> bool:
+    """Read a boolean env var (true/1/yes → True; false/0/no → False)."""
+    raw = os.environ.get(name, "").strip().lower()
+    if raw in ("1", "true", "yes"):
+        return True
+    if raw in ("0", "false", "no"):
+        return False
+    return default
+
+
+@dataclass(frozen=True)
+class DisambiguationResult:
+    """Outcome of :func:`disambiguate_and_recover`.
+
+    Fields
+    ------
+    failure_class : FailureClass
+        Classification of the original outcome.
+    raw_probe_succeeded : Optional[bool]
+        Result of the bypass probe.  ``None`` when no bypass probe was run
+        (UPSTREAM or NONE branch, or probe disabled).
+    flushed : bool
+        Whether ``lifecycle.flush_transport_pool`` was called and returned
+        truthy.  Always ``False`` on the UPSTREAM branch (flush-bypass
+        invariant).
+    surface_verdict_value : str
+        Human-readable verdict token for logs and SSE payloads.
+    diagnostic : str
+        Short diagnostic string extracted from the original outcome.
+    """
+
+    failure_class: FailureClass
+    raw_probe_succeeded: Optional[bool]
+    flushed: bool
+    surface_verdict_value: str
+    diagnostic: str
+
+
+async def raw_http_bypass_probe(provider: object, model_id: str) -> object:
+    """Probe the streaming surface via a FRESH aiohttp session/connector.
+
+    Bypasses the provider's pooled session entirely — uses a one-shot
+    ``TCPConnector(limit=1, ttl_dns_cache=0, force_close=True)`` so stale
+    pooled sockets cannot contaminate the result.
+
+    Returns a ``ProbeOutcome`` (success or not).  NEVER raises.
+    """
+    # Lazy imports keep startup cost and circular-import risk minimal.
+    session = None
+    connector = None
+    try:
+        import aiohttp  # type: ignore[import]
+
+        from backend.core.ouroboros.governance.dw_heavy_probe import HeavyProber
+        from backend.core.ouroboros.governance.preflight_probe import (
+            _heavyresult_to_outcome,
+        )
+
+        connector = aiohttp.TCPConnector(limit=1, ttl_dns_cache=0, force_close=True)
+        session = aiohttp.ClientSession(connector=connector, trust_env=True)
+
+        prober = HeavyProber()
+        result = await prober.probe(
+            session=session,
+            model_id=model_id,
+            base_url=getattr(provider, "_base_url", ""),
+            api_key=getattr(provider, "_api_key", ""),
+        )
+        return _heavyresult_to_outcome(result)
+
+    except Exception as exc:  # pylint: disable=broad-except
+        # Module-level ProbeOutcome (imported at top) guarantees this path
+        # can construct a result without a re-import that could itself raise.
+        logger.debug("raw_http_bypass_probe raised: %s: %s", type(exc).__name__, str(exc)[:120])
+        return ProbeOutcome(
+            model_id=model_id,
+            success=False,
+            status_code=0,
+            error_message=f"raw_bypass_raised:{type(exc).__name__}:{str(exc)[:120]}",
+        )
+
+    finally:
+        if session is not None:
+            try:
+                await session.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def _flip_topology_breaker(model_id: str, diagnostic: str) -> None:
+    """Best-effort topology breaker flip for UPSTREAM failures.
+
+    Lazy-imports ``get_default_sentinel`` and calls ``report_failure`` with
+    ``FailureSource.LIVE_TRANSPORT`` (non-terminal — live transport degraded,
+    not deterministically dead).  NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.governance.topology_sentinel import (
+            FailureSource,
+            get_default_sentinel,
+        )
+
+        sentinel = get_default_sentinel()
+        sentinel.report_failure(
+            model_id,
+            FailureSource.LIVE_TRANSPORT,
+            diagnostic[:200],
+            status_code=0,
+            response_body=diagnostic[:200],
+            is_terminal=False,
+        )
+        logger.debug(
+            "_flip_topology_breaker: reported LIVE_TRANSPORT failure model=%s diag=%r",
+            model_id,
+            diagnostic[:80],
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.debug("_flip_topology_breaker: suppressed %s: %s", type(exc).__name__, str(exc)[:120])
+
+
+async def disambiguate_and_recover(
+    *,
+    provider: object,
+    outcome: object,
+    lifecycle: Any,
+    raw_probe_fn: Optional[Callable[[object, str], Awaitable[object]]] = None,
+) -> DisambiguationResult:
+    """Classify a Surface-B failure and route recovery BY class.
+
+    Flush-bypass invariant (the heart of Slice 39)
+    -----------------------------------------------
+    UPSTREAM (``done_before_content``, HTTP 5xx, conservative default)
+      → ``lifecycle.flush_transport_pool`` is **NEVER called**.  The socket
+        is healthy; flushing and re-probing the same empty stream is a
+        brute-force loop against a capacity-constrained upstream.  Instead
+        the topology breaker is updated to reflect degraded upstream capacity.
+
+    TRANSPORT (socket/protocol-level fault)
+      → A raw bypass probe is fired through a FRESH aiohttp session.
+        ONLY if the fresh socket succeeds (true pool stagnation) is
+        ``lifecycle.flush_transport_pool`` called.
+
+    NONE (success=True)
+      → No-op.
+
+    Args:
+        provider:      The DW provider instance (used for base_url/api_key
+                       extraction by the raw bypass probe).
+        outcome:       A ``ProbeOutcome``-shaped object describing the failure.
+        lifecycle:     A ``ClientLifecycleManager``-shaped object with an
+                       async ``flush_transport_pool(provider, *, reason)``
+                       method.
+        raw_probe_fn:  Optional override for the bypass probe (injected by
+                       tests to avoid real network calls).  Defaults to
+                       :func:`raw_http_bypass_probe`.
+
+    Returns:
+        :class:`DisambiguationResult` — fully described, never raises.
+    """
+    cls = classify_surface_failure(outcome)
+    model_id: str = getattr(outcome, "model_id", "") or ""
+    diag: str = getattr(outcome, "error_message", "") or ""
+
+    # ------------------------------------------------------------------
+    # NONE — healthy probe, nothing to do.
+    # ------------------------------------------------------------------
+    if cls is FailureClass.NONE:
+        return DisambiguationResult(
+            failure_class=cls,
+            raw_probe_succeeded=None,
+            flushed=False,
+            surface_verdict_value="healthy",
+            diagnostic="",
+        )
+
+    # ------------------------------------------------------------------
+    # UPSTREAM — flush is UNCONDITIONALLY BYPASSED.
+    # The socket is healthy; the model/endpoint faulted server-side.
+    # ------------------------------------------------------------------
+    if cls is FailureClass.UPSTREAM:
+        logger.warning(
+            "disambiguate_and_recover: UPSTREAM failure — flush BYPASSED "
+            "(socket healthy); marking upstream_degraded model=%s diag=%r",
+            model_id,
+            diag[:80],
+        )
+        _flip_topology_breaker(model_id, diag or "upstream")
+        return DisambiguationResult(
+            failure_class=cls,
+            raw_probe_succeeded=None,
+            flushed=False,
+            surface_verdict_value="upstream_degraded",
+            diagnostic=diag or "upstream",
+        )
+
+    # ------------------------------------------------------------------
+    # TRANSPORT — raw bypass probe decides whether to flush.
+    # ------------------------------------------------------------------
+    if not _envb("JARVIS_DW_RAW_BYPASS_PROBE_ENABLED", True):
+        logger.debug(
+            "disambiguate_and_recover: raw bypass probe disabled (env off) model=%s",
+            model_id,
+        )
+        return DisambiguationResult(
+            failure_class=cls,
+            raw_probe_succeeded=None,
+            flushed=False,
+            surface_verdict_value="transport_degraded",
+            diagnostic="raw_probe_disabled",
+        )
+
+    fn = raw_probe_fn if raw_probe_fn is not None else raw_http_bypass_probe
+    raw = await fn(provider, model_id)
+    raw_ok: bool = bool(getattr(raw, "success", False))
+
+    if raw_ok:
+        # Fresh socket succeeded → the existing pool has stale connections.
+        logger.info(
+            "disambiguate_and_recover: raw bypass probe SUCCEEDED while pooled "
+            "probe failed — pool stagnation confirmed; flushing pool model=%s",
+            model_id,
+        )
+        flushed = bool(await lifecycle.flush_transport_pool(provider, reason=f"pool_stagnation:{model_id}"))
+    else:
+        # Fresh socket ALSO failed → systemic transport issue; flushing won't help.
+        logger.info(
+            "disambiguate_and_recover: raw bypass ALSO failed — systemic transport "
+            "issue, no flush model=%s",
+            model_id,
+        )
+        flushed = False
+
+    return DisambiguationResult(
+        failure_class=cls,
+        raw_probe_succeeded=raw_ok,
+        flushed=flushed,
+        surface_verdict_value="transport_degraded",
+        diagnostic=diag or "transport",
+    )

--- a/backend/core/ouroboros/governance/dw_transport_disambiguator.py
+++ b/backend/core/ouroboros/governance/dw_transport_disambiguator.py
@@ -1,0 +1,163 @@
+"""Slice 39 Task 5 — DoubleWord Transport-vs-Upstream Failure Disambiguator.
+
+Bifurcation rationale (v34 evidence, PRD §49.6.2)
+---------------------------------------------------
+The v34 battle-test soak surfaced two structurally distinct DW failure
+shapes that require DIFFERENT recovery strategies:
+
+  TRANSPORT — a socket/protocol-level fault.  The peer dropped the TCP
+    connection, the TTFT timer expired before any byte arrived, or
+    aiohttp signalled ServerDisconnectedError / ClientConnectorError.
+    The model never had a chance to speak.  Recovery: flush the
+    connection pool and immediately re-probe a *different* socket
+    (Task 6 hard-flush path).
+
+  UPSTREAM — the transport layer was *healthy*; the server answered with
+    HTTP 200 and a well-formed SSE envelope, but emitted zero content
+    tokens before [DONE].  Classic DW ``done_before_content``.  Also
+    covers HTTP 5xx responses: the server answered, meaning the socket
+    was fine — the model or endpoint faulted server-side.  Recovery:
+    demote the model in the PromotionLedger; flushing the connection
+    pool would be counterproductive (the socket is healthy) and risks a
+    brute-force re-probe loop against a capacity-constrained upstream.
+
+Design goals
+------------
+1. Pure function — ``classify_surface_failure`` has no I/O, no env
+   reads, no side-effects.  Fully deterministic from the ProbeOutcome
+   fields alone.
+2. Precedence: UPSTREAM markers are checked before TRANSPORT markers.
+   ``done_before_content`` therefore always wins, even if a transport
+   keyword appears coincidentally in the same message (shouldn't happen,
+   but defensive ordering prevents misclassification).
+3. Conservative default: ambiguous outcomes (no recognised marker, no
+   5xx) resolve to UPSTREAM.  We never flush a connection pool on
+   ambiguous signal; Task 6's raw bypass-probe is the mechanism that
+   promotes ambiguous → transport when warranted.
+
+References
+----------
+* v34 soak postmortem — ``memory/project_v34_soak_postmortem.md``
+* PRD §49.6.2 — Transport Disambiguation
+* Slice 39 plan — ``memory/project_slice_39_transport_health.md``
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+
+logger = logging.getLogger("Ouroboros.TransportDisambiguator")
+
+# ---------------------------------------------------------------------------
+# Marker tables — all matched case-insensitively as substrings of the
+# concatenated (error_message + " " + error_body) blob.
+# ---------------------------------------------------------------------------
+
+# Outcomes that indicate the upstream *server* is at fault even when the
+# transport layer was healthy (HTTP 200 + clean SSE envelope that produced
+# zero content tokens, or a structured server-side fault).
+_UPSTREAM_MARKERS: tuple[str, ...] = ("done_before_content",)
+
+# Outcomes that indicate a socket/protocol-level fault.  The model never
+# had an opportunity to produce output.
+_TRANSPORT_MARKERS: tuple[str, ...] = (
+    "stream_closed_early",
+    "ttft_timeout",
+    "asyncio.wait_for",
+    "serverdisconnected",
+    "clientconnector",
+    "connectionreset",
+    "connection reset",
+    "session_acquire_failed",
+    "prober_raised",      # inner adapter catch (preflight_probe.py:753)
+    "probe_raised",       # outer run_preflight catch (preflight_probe.py:428)
+    "connecttimeout",
+    "connect timeout",
+    # ``transport:{ExcType}:...`` prefix is emitted ONLY on the streaming
+    # socket-fault path (dw_heavy_probe.py:790) — covers every aiohttp
+    # transport exception (ServerTimeoutError / ClientPayloadError /
+    # ClientOSError / ...) by prefix instead of enumerating exception names.
+    # Safe: this prefix never appears on done_before_content / status_* /
+    # entitlement paths, and UPSTREAM markers are checked first regardless.
+    "transport:",
+)
+
+
+class FailureClass(str, Enum):
+    """Closed taxonomy of surface-failure classifications.
+
+    Values are lowercase strings so they can be embedded directly in
+    structured log lines and SSE payloads without further conversion.
+    """
+
+    NONE = "none"
+    """ProbeOutcome.success is True — no failure to classify."""
+
+    TRANSPORT = "transport"
+    """Socket/protocol-level fault — connection pool flush warranted (Task 6)."""
+
+    UPSTREAM = "upstream"
+    """Server-side fault or healthy-transport empty-completion — no pool flush."""
+
+
+def classify_surface_failure(outcome) -> FailureClass:
+    """Classify a ``ProbeOutcome`` into a ``FailureClass``.
+
+    Pure function — no I/O, no env reads, no side-effects.
+
+    Precedence (highest to lowest):
+      1. success=True                        → NONE
+      2. UPSTREAM marker in blob             → UPSTREAM  (checked before transport)
+      3. TRANSPORT marker in blob            → TRANSPORT
+      4. HTTP 5xx status_code                → UPSTREAM  (server answered = socket ok)
+      5. anything else                       → UPSTREAM  (conservative default)
+
+    The conservative default (step 5) is intentional: we never flush a
+    connection pool on an ambiguous signal.  Task 6's raw bypass-probe
+    is the escalation mechanism for ambiguous → transport promotion.
+
+    Args:
+        outcome: Any object with ``success``, ``error_message``,
+                 ``error_body``, and ``status_code`` attributes
+                 (structurally duck-typed so tests and adapters need not
+                 import this module to satisfy the type).
+
+    Returns:
+        ``FailureClass`` enum member.
+    """
+    # 1. Healthy probe — nothing to classify.
+    if getattr(outcome, "success", False):
+        return FailureClass.NONE
+
+    # 2+3. Build a single lowercase blob from both message fields (handle None
+    #      defensively — callers may pass partially-populated outcomes).
+    msg = getattr(outcome, "error_message", None) or ""
+    body = getattr(outcome, "error_body", None) or ""
+    blob = (msg + " " + body).lower()
+
+    # 2. UPSTREAM markers take unconditional precedence.
+    if any(marker in blob for marker in _UPSTREAM_MARKERS):
+        logger.debug("classify_surface_failure: UPSTREAM (upstream_marker) blob=%r", blob[:120])
+        return FailureClass.UPSTREAM
+
+    # 3. Transport markers — socket/protocol fault.
+    if any(marker in blob for marker in _TRANSPORT_MARKERS):
+        logger.debug("classify_surface_failure: TRANSPORT (transport_marker) blob=%r", blob[:120])
+        return FailureClass.TRANSPORT
+
+    # 4. HTTP 5xx — server answered, socket was healthy.
+    status_code = getattr(outcome, "status_code", 0) or 0
+    if 500 <= status_code < 600:
+        logger.debug(
+            "classify_surface_failure: UPSTREAM (http_5xx) status=%s", status_code
+        )
+        return FailureClass.UPSTREAM
+
+    # 5. Conservative default — ambiguous signal; never flush on ambiguity.
+    logger.debug(
+        "classify_surface_failure: UPSTREAM (default_conservative) blob=%r status=%s",
+        blob[:120],
+        status_code,
+    )
+    return FailureClass.UPSTREAM

--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -4753,6 +4753,106 @@ SEED_SPECS: list = [
         example="86400",
         since="M10 Slice 5 (PRD §32.4, 2026-05-04)",
     ),
+
+    # ====================================================================
+    # Slice 39 — Multi-Surface DW Transport-Health Substrate — 6 flags
+    # ====================================================================
+    FlagSpec(
+        name="JARVIS_DW_SURFACE_HEALTH_ENABLED",
+        type=FlagType.BOOL, default=False,
+        description=(
+            "Slice 39 master gate for the multi-surface DW transport-health "
+            "substrate. When true, run_surface_health_sweep probes all three "
+            "surfaces (DIRECT_STREAMING, BATCH_STORAGE, AUTH_SYNC) at boot "
+            "and records results in the SurfaceHealthLedger. Default FALSE "
+            "pending v35 graduation soak."
+        ),
+        category=Category.SAFETY,
+        source_file=(
+            "backend/core/ouroboros/governance/preflight_probe.py"
+        ),
+        example="true",
+        since="Slice 39 Task 8 (PRD §49.6.2, 2026-05-28)",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
+    FlagSpec(
+        name="JARVIS_DW_SURFACE_HEALTH_PATH",
+        type=FlagType.STR, default=".jarvis/dw_surface_health.json",
+        description=(
+            "File path override for the SurfaceHealthLedger on-disk "
+            "JSON store. Relative paths are resolved from the repo root."
+        ),
+        category=Category.INTEGRATION,
+        source_file=(
+            "backend/core/ouroboros/governance/dw_surface_health.py"
+        ),
+        example=".jarvis/dw_surface_health.json",
+        since="Slice 39 Task 8 (PRD §49.6.2, 2026-05-28)",
+    ),
+    FlagSpec(
+        name="JARVIS_DW_SURFACE_PROBE_TIMEOUT_S",
+        type=FlagType.FLOAT, default=10.0,
+        description=(
+            "Per-surface probe timeout in seconds. Each of the three "
+            "surface probes (DIRECT_STREAMING, BATCH_STORAGE, AUTH_SYNC) "
+            "is wrapped in asyncio.wait_for with this cap."
+        ),
+        category=Category.TIMING,
+        source_file=(
+            "backend/core/ouroboros/governance/dw_surface_probes.py"
+        ),
+        example="10.0",
+        since="Slice 39 Task 8 (PRD §49.6.2, 2026-05-28)",
+    ),
+    FlagSpec(
+        name="JARVIS_DW_TRANSPORT_FLUSH_ENABLED",
+        type=FlagType.BOOL, default=True,
+        description=(
+            "Allow lifecycle.flush_transport_pool to be called when the "
+            "raw bypass probe confirms pool stagnation on a TRANSPORT-class "
+            "failure. Set to false to disable pool hard-flushes entirely "
+            "(useful during capacity debugging)."
+        ),
+        category=Category.SAFETY,
+        source_file=(
+            "backend/core/ouroboros/governance/dw_transport_disambiguator.py"
+        ),
+        example="true",
+        since="Slice 39 Task 8 (PRD §49.6.2, 2026-05-28)",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
+    FlagSpec(
+        name="JARVIS_DW_TRANSPORT_FLUSH_COOLDOWN_S",
+        type=FlagType.FLOAT, default=60.0,
+        description=(
+            "Minimum seconds between successive flush_transport_pool calls "
+            "to prevent brute-force re-probe loops during sustained "
+            "transport degradation."
+        ),
+        category=Category.TIMING,
+        source_file=(
+            "backend/core/ouroboros/governance/dw_transport_disambiguator.py"
+        ),
+        example="60.0",
+        since="Slice 39 Task 8 (PRD §49.6.2, 2026-05-28)",
+    ),
+    FlagSpec(
+        name="JARVIS_DW_RAW_BYPASS_PROBE_ENABLED",
+        type=FlagType.BOOL, default=True,
+        description=(
+            "Run the raw bypass probe (fresh one-shot aiohttp session) on "
+            "TRANSPORT-class failures to confirm pool stagnation before "
+            "flushing. When false, TRANSPORT failures skip the probe and "
+            "never flush (conservative no-flush default)."
+        ),
+        category=Category.SAFETY,
+        source_file=(
+            "backend/core/ouroboros/governance/dw_transport_disambiguator.py"
+        ),
+        example="true",
+        since="Slice 39 Task 8 (PRD §49.6.2, 2026-05-28)",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
 ]
 
 

--- a/backend/core/ouroboros/governance/preflight_probe.py
+++ b/backend/core/ouroboros/governance/preflight_probe.py
@@ -91,6 +91,7 @@ _ENV_MASTER = "JARVIS_PREFLIGHT_PROBE_ENABLED"
 _ENV_TIMEOUT_PER_MODEL_S = "JARVIS_PREFLIGHT_TIMEOUT_PER_MODEL_S"
 _ENV_TEST_PROMPT = "JARVIS_PREFLIGHT_TEST_PROMPT"
 _ENV_HALT_ON_ALL_FAIL = "JARVIS_PREFLIGHT_HALT_ON_ALL_FAIL"
+_ENV_SURFACE_HEALTH_ENABLED = "JARVIS_DW_SURFACE_HEALTH_ENABLED"
 
 _DEFAULT_TIMEOUT_PER_MODEL_S = 10.0
 _DEFAULT_TEST_PROMPT = "ping"
@@ -1002,3 +1003,52 @@ async def _run_preflight_with_recovery_daemon(
         await asyncio.sleep(current_backoff)
         # Exponential growth, capped
         current_backoff = min(current_backoff * multiplier, max_backoff_s)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Slice 39 Task 8 — Surface Health Sweep orchestration entry point
+# ──────────────────────────────────────────────────────────────────────
+
+
+def is_surface_health_enabled() -> bool:
+    """Slice 39 master gate. Default FALSE pending v35 graduation."""
+    return _envb(_ENV_SURFACE_HEALTH_ENABLED, False)
+
+
+async def run_surface_health_sweep(
+    *,
+    provider,
+    model_id: str,
+):
+    """Slice 39 — composes the per-surface ledger + concurrent sweep.
+
+    Returns the surface snapshot dict, or None when the master flag is
+    off / provider is None. NEVER raises (health telemetry must not wedge
+    boot). Callable inline from GovernedLoopService (future wiring slice)
+    or manually from the v35 health-telemetry probe.
+    """
+    if not is_surface_health_enabled():
+        logger.debug("[Slice39] surface health sweep skipped: master flag off")
+        return None
+    if provider is None:
+        logger.warning("[Slice39] surface health sweep skipped: no provider")
+        return None
+    try:
+        from backend.core.ouroboros.governance.dw_surface_health import (
+            SurfaceHealthLedger,
+        )
+        from backend.core.ouroboros.governance.dw_surface_probes import (
+            run_surface_sweep,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[Slice39] surface sweep skipped: import failed: %r", exc)
+        return None
+    ledger = SurfaceHealthLedger()
+    try:
+        snap = await run_surface_sweep(
+            provider=provider, model_id=model_id, ledger=ledger,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive belt
+        logger.warning("[Slice39] surface sweep raised: %r", exc)
+        return None
+    return snap

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -11234,17 +11234,170 @@ Per operator binding *"no euphoria, only artifacts"* — this section is documen
 | Git subprocess (Slice 33 A2 P1) | **CLOSED** | 78% reduction cold-cache | n/a |
 | FS executor (Slice 33 A2 P2) | **CLOSED** | 55% reduction postmortem | TTL cache for recent_summaries |
 | Graph write queue (Slice 33 A2 P3) | **CLOSED** | 0 on-loop graph_write events | reconciliation gap on consumer failure |
-| **DW 397B TIMEOUT (capability blocker)** | **OPEN — HIGHEST PRIORITY** | every v28/v29 op | **Slice 34 (§48.7) — Upstream DW capacity investigation: Phase 0 probe → Phase 1 hypothesis-specific fix → Phase 2 soak validation** |
-| Adaptive per-shape routing | **PROPOSED** | §48.8.1 design | Slice 35 — gated on §48.7 producing 1+ APPLY |
-| Per-model breaker tuning | **PROPOSED** | §48.8.2 design | Slice 35 |
-| Bloom filter / response cache | **PROPOSED** | §48.9.1 design | Slice 36 — depends on per-shape ledger |
-| Adaptive rate limiter | **PROPOSED** | §48.9.4 design | Slice 36 |
-| Latency predictor (ML) | **PROPOSED** | §48.10.1 design | Slice 37 |
-| Three-tier Claude policy | **PROPOSED** | §48.11.1 design | Slice 38 — depends on per-shape ledger |
+| ~~**DW 397B TIMEOUT (capability blocker)**~~ → **CLOSED 2026-05-28** | ~~OPEN — HIGHEST PRIORITY~~ | v31 per-stage telemetry | **ROOT CAUSE FOUND: it was not a model timeout but an RT-streaming TTFT of 66,775 ms (8× slower than the BATCH corridor). Slice 36 forced BATCH on standard/complex. Superseded by §49.3.1-3.3.** |
+| ~~Adaptive per-shape routing~~ *(planned "Slice 35")* | **RENUMBERED → Slice 40+** | §48.8.1 design | Number consumed by shipped Slice 35 (dual-path profiling). See §49.4 drift note. |
+| ~~Per-model breaker tuning~~ *(planned "Slice 35")* | **RENUMBERED → Slice 40+** | §48.8.2 design | See §49.4 drift note. |
+| ~~Bloom filter / response cache~~ *(planned "Slice 36")* | **RENUMBERED → Slice 40+** | §48.9.1 design | Number consumed by shipped Slice 36 (adaptive transport dispatcher). See §49.4. |
+| ~~Adaptive rate limiter~~ *(planned "Slice 36")* | **RENUMBERED → Slice 40+** | §48.9.4 design | See §49.4 drift note. |
+| ~~Latency predictor (ML)~~ *(planned "Slice 37")* | **RENUMBERED → Slice 40+** | §48.10.1 design | Number consumed by shipped Slice 37 (multipart diagnostic). See §49.4. |
+| ~~Three-tier Claude policy~~ *(planned "Slice 38")* | **RENUMBERED → Slice 40+** | §48.11.1 design | Number consumed by shipped Slice 38 (JSONL composer). See §49.4. |
+| **DW `/v1/files` HTTP 500 (multipart)** | **CLOSED 2026-05-28** | v32/v33 — 3/3 HTTP 500 | **Slice 37 diagnostic + Slice 38 RFC 7464 trailing-`\n` canonical composer. DW Support (peter@doubleword.ai) externally validated the malformation. See §49.3.4-3.7.** |
+| **DW streaming `done_before_content` (capability blocker)** | **OPEN — HIGHEST PRIORITY** | v34 — all 3 models `status=0`, clean SSE + empty completion | **Slice 39 (§49.6) — Multi-surface transport-health substrate + bifurcated disambiguation. Upstream-class signal → flush-bypass by design.** |
 
-**Dependency chain:** Slice 34 (§48.7) MUST land first — every subsequent forward-arc proposal assumes DW eventually serves a successful candidate. Slices 35-38 are theoretical until §48.7 Phase 0 produces evidence that resolves which of the 4 hypotheses (a-d) is true.
+> **§48.13 → §49 reconciliation (doc-drift fix per operator binding "we do not allow our documentation to drift"):** the planned forward-arc names "Slice 35–38" above were authored 2026-05-27, *before* the v30→v34 arc shipped. The actually-merged Slices 35–38 (§48.7.4 Phase 2 work — dual-path profiling, adaptive transport dispatcher, multipart diagnostic, JSONL composer) **consumed those numbers for entirely different work.** The planned cost-intelligence forward arcs (per-shape routing, response cache, ML latency predictor, three-tier Claude policy) are therefore **renumbered to Slice 40+ and deferred** — they remain gated on the capability bar (APPLY) first moving. Full planned-vs-actual mapping in §49.4.
 
-The loop-health stack is **structurally closed.** The capability bar will not move until the §48.7 upstream investigation lands and Phase 1 fixes the named hypothesis.
+**Dependency chain (revised 2026-05-28):** ~~Slice 34 (§48.7) MUST land first~~ — the §48.7 upstream investigation was *executed* as the empirical v30→v34 arc (§49). It peeled three successive blocker layers (RT TTFT → `/v1/files` 500 → streaming empty-completion). The capability bar (APPLY) remains **0/0/0 across 10 cumulative soaks (v25→v34)**; the live blocker is now the streaming `done_before_content` upstream signal, which **Slice 39 (§49.6)** addresses with a multi-surface health substrate. The deferred cost-intelligence arcs (Slice 40+) stay theoretical until APPLY first fires.
+
+The loop-health stack is **structurally closed.** ~~The capability bar will not move until the §48.7 upstream investigation lands and Phase 1 fixes the named hypothesis.~~ — the investigation landed and traced the blocker through three distinct transport layers; see §49 for the v30→v34 narrative, the codified moving-blocker lesson, and the Slice 39 forward design.
+
+---
+
+## §49. The v30 → v34 Transport Evolution Arc + Slice 39 Multi-Surface Transport-Health Substrate *(NEW 2026-05-28 — operator-driven post v30→v34 soak arc: "update the PRD in detail and in depth, cross out what we've done and the mistakes we learned from ... solve the root problem directly without workarounds, brute force, or shortcuts ... super duper beef it up")*
+
+### §49.1 — Why this section exists
+
+§48 closed at v29 (2026-05-27) with the capability blocker named as "DW 397B TIMEOUT" and a planned investigation arc (§48.7 "Slice 34"). Between 2026-05-27 and 2026-05-28 that investigation was **executed** — five capability soaks (v30→v34) and four merged slices (35, 36, 37, 38) plus a v34 gatekick smoke harness. The arc did exactly what §48.7 promised: it disambiguated the blocker. But the blocker turned out to be **not one defect** — it was a *stack* of three independent transport-layer defects, each masking the next. §49 is the granular closure record of that arc, the codified lesson, and the forward design (Slice 39) that addresses the layer still open.
+
+Operator binding for this section (verbatim): *"solve the root problem directly — without workarounds, brute force, or shortcut solutions — and significantly strengthen the system into something advanced, asynchronous, dynamic, adaptive, intelligent, and highly robust, with no hardcoding. Fully leverage the existing files and architecture so we avoid duplication and build cleanly on what already exists."* Written to that bar.
+
+### §49.2 — The moving-blocker pattern (lesson learned — codified for future loops)
+
+Across v25→v34 the capability bar (APPLY/VERIFY/RESOLVED) stayed **0/0/0 for 10 consecutive soaks**, but the *reason* changed every 1–2 soaks:
+
+```
+v24  →  Aegis 401 missing_session_bearer        (Slice 31 — CLOSED)
+v25  →  Oracle GIL loop-wedge                    (Slice 32 — CLOSED)
+v26-29 → posture / loop-health stalls            (Slice 33 A0-A2 — CLOSED)
+v28-29 → "DW 397B TIMEOUT"                        (mis-named; see below)
+v30-31 → RT-streaming TTFT 66,775 ms             (Slice 35 diag → Slice 36 force-BATCH — CLOSED)
+v32-33 → /v1/files HTTP 500 (multipart malformed)(Slice 37 diag → Slice 38 trailing-\n — CLOSED)
+v34    → streaming done_before_content (upstream) (Slice 39 — OPEN)
+```
+
+**The lesson (codified):** in a deep provider-integration stack, *each fix exposes the next layer.* A single soak only ever measures the **topmost** blocker; the layers beneath are invisible until it is removed. Three corollaries now binding on future loops:
+
+1. **Never declare the capability problem "solved" from a single surface's success.** The v34 `/v1/files` HTTP 200 (gatekick preflight) was real *and* the soak still produced 0 APPLY — because the soak's hot path uses a *different* surface (streaming chat). Surface-level success ≠ capability. (Cross-ref `memory/feedback_no_preresult_euphoria.md`.)
+2. **Burning a full 60-min soak to discover the next blocker is the brute-force anti-pattern.** A multi-surface up-front health sweep (Slice 39) catches the next layer in *seconds*, not after a soak burn. This is the structural strengthening §49.6 delivers.
+3. **Classify by protocol semantics, not by symptom co-location.** "DW 397B TIMEOUT" (v28/v29) and "done_before_content" (v34) both *look* like "DW didn't answer," but the first was an 8× RT-vs-BATCH latency asymmetry and the second is a clean-stream-empty-completion. Conflating them would have shipped the wrong fix.
+
+### §49.3 — v30 → v34 chronological narrative (granular)
+
+#### §49.3.1 — v30/v31: the RT-streaming TTFT lag discovery
+
+v30's `op_summary` bisection named `STAGE_PROVIDER_GENERATE` as **99.99% of the 30–111s timeout budget** — but that stage is a black box wrapping the entire provider call. To disambiguate *which* sub-stage burned the time, Slice 35 instrumented it.
+
+#### §49.3.2 — Slice 35: Dual-path dispatch profiling *(b014f1c6d7, PR #61727 — §48.7.4 Phase 2)*
+
+Opened `generate()`'s internal sub-stages on **both** corridors so v31 could compare them:
+- **Real-Time (6 stages):** `STAGE_RT_PROMPT_BUILD`, `STAGE_RT_AEGIS_AUTH`, `STAGE_RT_HTTP_POST` (closes at TTFT first-chunk), `STAGE_RT_STREAM_CONSUME`, `STAGE_RT_VENOM_TOOL_LOOP`, `STAGE_RT_RESPONSE_PARSE`.
+- **Batch fallback (4 stages + poll calibration):** `STAGE_BATCH_UPLOAD` (`_upload_file`), `STAGE_BATCH_CREATE`, `STAGE_BATCH_AWAIT`, `STAGE_BATCH_RETRIEVE`.
+
+Wired via manual `time.monotonic()` deltas + `dispatch_profiler.record_stage()` (avoided restructuring the 900-line `_generate_realtime`).
+
+#### §49.3.3 — Slice 36: Adaptive Transport Dispatcher *(e5d4c86e1e, PR #62027 — closed v25→v31 blocker)*
+
+v31's per-stage telemetry was unambiguous, on the **same account, same Qwen3.5-397B, same prompts:**
+
+| Stage | p50 |
+|---|---|
+| `STAGE_RT_HTTP_POST` (TTFT) | **66,775 ms** |
+| `STAGE_RT_VENOM_TOOL_LOOP` | 66,849 ms (nested with above) |
+| Phase 0 probe via **BATCH API** end-to-end | **4,000–8,000 ms** |
+
+The RT endpoint's *time-to-first-token* was **8× slower than BATCH's entire end-to-end**. Production defaulted to RT → 0 APPLY across 6 soaks. **Fix:** `_slice36_should_force_batch(context)` decision function + `generate()` wiring. Routes through BATCH instead of RT when all three hold: (1) `JARVIS_PROVIDER_CLAUDE_DISABLED=true`, (2) `JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX=true` (default TRUE, opt-out `=0`), (3) route ∈ {standard, complex}. RT preserved for IMMEDIATE/BG/SPECULATIVE (small-context paths where Venom adds value). **Acknowledged tradeoff (AST-pinned):** BATCH does not support the Venom tool loop — but v31 showed **0 successful Venom rounds** across all production ops anyway (every RT call timed out before first token), so net delta is strictly positive: *some* candidates ≫ *zero*. Phase 2 fixed a model-ID-tolerant aggregation bug (Slice 34 `op_session` keyed on walker's `model_id` "35B" vs Slice 35 `record_stage`'s `self._model` "397B" → key mismatch dropped stages from aggregation).
+
+#### §49.3.4 — v32/v33: the `/v1/files` HTTP 500 multipart defect
+
+With BATCH now the hot path, v32 wedged on a new shape: **every `/v1/files` upload inside the harness returned HTTP 500** ("Internal server error", 21-byte body) — *while a bare-metal probe was 5/5 OK at the same moment.* v33 (`bt-2026-05-28-162729`) confirmed it: 3/3 HTTP 500 across 4 KB / 18 KB / 33 KB payloads on Qwen3.5-35B-A3B-FP8; Aegis daemon confirmed `upstream_host=api.doubleword.ai`. Cost $0.007 / $10 (0.07%); idle_timeout at 31 min.
+
+#### §49.3.5 — Slice 37: Multipart payload diagnostic + cleanup discipline *(c2de840edc, PR #63659)*
+
+Made the opaque 500 diagnostically rich. `_upload_file` gained a pre-call diagnostic log (payload bytes + custom_id + model + op) + a pre-flight size guard (`JARVIS_DW_UPLOAD_MAX_BYTES`, default 5 MB → 413 fail-fast) + error-body capture widened 500→2000 chars across 4 lifecycle methods. Phase 2 added uniform `try/finally` cleanup across `_upload_file`/`_create_batch`/`_adaptive_poll_batch`/`_retrieve_result` (`_aegis_lease=None` before `try` → no unbound name on early-throw; `_rate_limiter_recorded` sentinel → no metric drift). The diagnostic captured the exact payload on 3/3 500s — which is what enabled the external diagnosis.
+
+#### §49.3.6 — DW Support external validation (peter@doubleword.ai, 2026-05-28 10:23 AM)
+
+DW Support confirmed the `/v1/files` uploads were **"invalid multi part files"**: both `submit_batch` and `prompt_only` built `jsonl_line = json.dumps({...})` with **no trailing newline** — structurally valid JSON, structurally **invalid JSONL per RFC 7464** (which requires each record be newline-terminated). DW's `/v1/files` validator rejected the missing line terminator with a 500. The operator emailed Peter back confirming the fix shipped.
+
+#### §49.3.7 — Slice 38: Canonical JSONL composer + trailing newline *(2594b2c38e, PR #63660)*
+
+The minimal, correct fix: **+1 byte.** New `DoublewordProvider._compose_jsonl_batch_entry()` `@staticmethod` = single source of truth (validates 4 required fields + body-is-dict + emits `json.dumps(...) + '\n'`; serialization params otherwise unchanged for min-diff). Both raw call sites replaced. Belt-and-braces guard in `_upload_file` warns + auto-appends `\n` if any future caller bypasses the composer. AST pin against `json.dumps → _upload_file` chains so it cannot regress. **Empirical proof, v33-shaped payload:** LEGACY 357 B, last byte `}`, `ends_nl=False` → DW 500; SLICE38 358 B, last byte `\n`, `ends_nl=True` → accept. Delta = exactly the +1 byte DW asked for. 13 tests (5 AST + 8 spine) + 173/173 cross-arc regression. *(This also resolved the v30 "40/40 OK" paradox — the bare-metal probe used the same broken `prompt_only` path but predated DW's validator tightening.)*
+
+#### §49.3.8 — v34: gatekick HTTP 200, then the blocker migrates again
+
+The v34 gatekick (`scripts/ouroboros_v34_gatekick.py`, `1b566347cb`) ran an isolated `/v1/files` smoke test via the canonical composer and got **HTTP 200, `file_id=dcb7e506-02c3-4c20-8618-1c15cc1504cc`, 0.71 s — the first-ever `/v1/files` success in the arc.** The `/v1/files` root cause is **closed and externally validated.**
+
+**But the v34 capability soak (`bt-2026-05-28-180523`, 11:05→11:28, 23 min, no `summary.json`, 5 Exhaustions) still produced 0 APPLY** — because the soak's hot path uses the **streaming chat-completions** surface (preflight gate + every STANDARD/COMPLEX op), *not* `/v1/files`. The preflight probed all three promoted models on every backoff cycle (30→60→120→240→300 s) and every probe returned:
+
+```
+Qwen3.5-35B   → DEGRADED_5XX status=0  diag=transport_error: done_before_content
+Qwen3.5-397B  → DEGRADED_5XX status=0  diag=transport_error: done_before_content
+Kimi-K2.6     → DEGRADED_5XX / DEGRADED_TIMEOUT (10s)
+  → active=0 for the entire run → fleet never populated → 0 ops dispatched → 0 APPLY
+```
+
+**`done_before_content` precisely defined** (`dw_heavy_probe.py:732-764`): the request got **HTTP 200**, DW opened a **valid SSE stream**, sent `data: [DONE]`, but emitted **zero content deltas** (`first_chunk_seen` never flipped). This is a *clean stream with an empty completion* — an **upstream** signal (model returned nothing / capacity), structurally distinct from the transport-failure branches in the same function (`stream_closed_early` line 745-751, `ttft_timeout` line 738-743, connection exceptions line 785). The blocker migrated from the batch-upload surface to the real-time wire.
+
+### §49.4 — Slice numbering reconciliation (planned vs. actual)
+
+The doc-drift the operator flagged. §48.13 (authored 2026-05-27) used "Slice 34–38" as *planned* names; the v30→v34 arc *shipped* Slices 35–38 for different work. Canonical mapping:
+
+| Number | §48.13 *planned* (now renumbered → Slice 40+) | *Actually shipped* (2026-05-27/28) |
+|---|---|---|
+| Slice 34 | §48.7 upstream DW capacity investigation | *Executed* as the empirical v30→v34 arc (not a single PR); v34 gatekick `1b566347cb` |
+| Slice 35 | Adaptive per-shape routing / breaker tuning | **Dual-path dispatch profiling** (b014f1c6d7, #61727) |
+| Slice 36 | Bloom filter / response cache / rate limiter | **Adaptive Transport Dispatcher** (e5d4c86e1e, #62027) |
+| Slice 37 | Latency predictor (ML) | **Multipart payload diagnostic + cleanup** (c2de840edc, #63659) |
+| Slice 38 | Three-tier Claude policy | **Canonical JSONL composer + trailing `\n`** (2594b2c38e, #63660) |
+| Slice 39 | — | **Multi-surface transport-health substrate** (this section, §49.6) |
+| Slice 40+ | The four deferred cost-intelligence arcs above | gated on capability bar (APPLY) first firing |
+
+### §49.5 — Mistakes made + lessons learned (honest, per "no euphoria")
+
+- **Mistake — single-surface optimism.** The v34 gatekick HTTP 200 created a momentary read that "the capability problem is solved." It was not: the soak's streaming surface was independently degraded. **Lesson:** validate the *hot-path surface*, not a convenient adjacent one (→ §49.2 corollary 1, → Slice 39 multi-surface sweep).
+- **Mistake — symptom-name conflation.** "DW 397B TIMEOUT" (v28/v29) framed an 8× RT/BATCH latency asymmetry as a model fault. The fix (force BATCH) only emerged once Slice 35 instrumented the sub-stages. **Lesson:** instrument before hypothesizing; classify by protocol semantics.
+- **Mistake — one-soak-per-defect cost.** Ten soaks burned to peel four blocker layers. **Lesson:** front-load a concurrent multi-surface health probe so the *next* layer surfaces in seconds.
+- **What went right:** every fix was minimal and structural — Slice 38 was literally +1 byte through a single canonical composer with an AST pin; Slice 36 composed the existing BATCH corridor rather than building a parallel one; Slice 37's diagnostic is what made the external diagnosis possible. No brute-force retries, no hardcoded model names, no parallel transport paths.
+
+### §49.6 — Forward design: Slice 39 — Multi-Surface Transport-Health Substrate *(AUTHORIZED 2026-05-28; design approved, implementation plan via writing-plans)*
+
+**Goal:** replace the one-soak-per-blocker discovery loop with a concurrent up-front health sweep across **all** DW transport surfaces, classify each failure by protocol semantics, persist a per-surface ledger, and route recovery by failure *class* — composing existing modules, zero duplication.
+
+#### §49.6.1 — Phase 2: multi-surface health matrix (extend `preflight_probe.py`)
+
+A concurrent `asyncio.gather` sweep of three surfaces, reusing existing client code (no new transport):
+
+| Surface | Tests | Composes (existing) |
+|---|---|---|
+| **A — Batch storage** | `/v1/files` upload | `DoublewordProvider._upload_file` + `_compose_jsonl_batch_entry` (the gatekick pattern) |
+| **B — Direct streaming** | 1-token `/v1/chat/completions` | `dw_heavy_probe` (already returns the 5 failure shapes) |
+| **C — Auth sync** | Aegis session-bearer handshake | `aegis_provider_bridge.dw_session_auth_header` |
+
+Per-surface ledger at `.jarvis/dw_surface_health.json`, modeled on the **existing `ModalityLedger` persistence pattern** (snapshot dataclass + `to_json_dict`/`from_json_dict` + flock'd write). `ModalityLedger` is per-*model*; this adds the orthogonal per-*surface* dimension — it composes the proven pattern, it does not duplicate the ledger. All surfaces / thresholds / model list are env- or policy-driven (mirrors `preflight_probe`'s `_envb/_envf/_envi` convention) — **no hardcoding.**
+
+#### §49.6.2 — Phase 3: bifurcated disambiguation routing (the root-cause-respecting core)
+
+On a Surface B failure, classify by protocol semantics, **not** by symptom:
+
+- **Transport class** (`ServerDisconnectedError`, connection reset, connect timeout, `stream_closed_early`, `ttft_timeout`): fire a **raw-HTTP disambiguation probe** that bypasses the pooled `aiohttp.ClientSession` (one-shot fresh `TCPConnector`). If raw **succeeds** while pooled **fails** → classify **client-side pool stagnation** → `ClientLifecycleManager` hard-flushes the `TCPConnector` socket cache + rebuilds the session. *This is the only branch where a flush is correct.*
+- **Upstream class** (`done_before_content` — HTTP 200, clean SSE, `[DONE]` with zero deltas): **bypass the flush entirely** (the socket is healthy — flushing it and re-probing the same empty stream is a brute-force retry loop, forbidden by the zero-shortcut mandate). Flip the existing `dw_topology_circuit_breaker` to active and mark the surface `upstream_degraded`. The raw probe may still run to *record evidence* that it is upstream, but it never triggers a flush.
+
+**Why this matters:** v34's signature (all 3 models, `status=0`, clean stream, empty completion) is the upstream class. The correct outcome is the flush *not* firing — honoring socket health and surfacing the real (upstream-capacity) constraint rather than masking it behind pointless client churn.
+
+#### §49.6.3 — Phase 1/4 wrappers
+
+- **Phase 1** (this section): PRD unification — §49 authored, §48.13 drift reconciled, moving-blocker lesson codified.
+- **Phase 4:** new health-matrix test hooks + full cross-arc regression green; merge to `main`; cost-insulated **v35 health-telemetry probe** ($1.00 / 600 s) to observe the multi-surface ledger populate under live load.
+
+#### §49.6.4 — Anti-goals / what Slice 39 does NOT promise
+
+- **No claim that Slice 39 produces an APPLY.** If `done_before_content` confirms upstream capacity exhaustion, *no client-side substrate moves the capability bar* — that is hypothesis (a) from §48.5, which is operator/account-side (cross-ref `memory/project_v33_capability_soak_postmortem.md`'s "blocker moved across stack but unmet"). Slice 39's value is **fast, correct disambiguation** + **not masking upstream faults with client churn**, not a capability guarantee.
+- **No new transport path.** Surfaces A/B/C all reuse existing client code.
+- **No hardcoded models or thresholds.** Env/policy-driven throughout.
+- **No flush-on-`done_before_content`.** Explicitly rejected; see §49.6.2.
+
+### §49.7 — Honest framing
+
+The `/v1/files` root cause is closed and externally validated — a genuine, externally-confirmed win. The capability bar (APPLY/VERIFY/RESOLVED) remains **0/0/0 across 10 cumulative soaks**; the live blocker is the streaming `done_before_content` upstream signal. Slice 39 makes the system *detect and classify* that blocker in seconds instead of a soak-burn, and refuses to paper over an upstream fault with a client-pool flush — but it does not, and does not claim to, manufacture upstream capacity. Per `memory/feedback_no_preresult_euphoria.md`: methodology validated, capability still unmeasured.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-28-slice-39-multi-surface-transport-health.md
+++ b/docs/superpowers/plans/2026-05-28-slice-39-multi-surface-transport-health.md
@@ -1,0 +1,1546 @@
+# Slice 39 — Multi-Surface DW Transport-Health Substrate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the one-soak-per-blocker discovery loop with a concurrent up-front DW transport-health sweep that probes three surfaces, classifies failures by protocol semantics, persists a per-surface ledger, and routes recovery by failure *class* (transport → pool-flush; upstream `done_before_content` → flush-bypass + breaker flip).
+
+**Architecture:** Four focused new modules + two minimal modifications, all composing existing code (zero new transport path). A per-*surface* health ledger mirrors the existing per-*model* `ModalityLedger` persistence pattern. Surface B reuses the existing `build_heavyprobe_adapter`; Surface A reuses `_upload_file` + `_compose_jsonl_batch_entry` (the v34 gatekick pattern); Surface C reuses `dw_session_auth_header`. The "hard flush" composes the session-rebuild logic already inside `_get_session()` via a new one-line `force_session_reset()`.
+
+**Tech Stack:** Python 3.9+, `asyncio`, `aiohttp` (DW provider transport), `pytest` + `pytest-asyncio`. Conventions: `from __future__ import annotations`, env-var config via `_envb/_envf/_envi/_envs` helpers, frozen dataclasses for audit records, `JARVIS_*` flags registered in FlagRegistry, AST-pin regression tests.
+
+**Design source of truth:** `docs/architecture/OUROBOROS_VENOM_PRD.md` §49.6 (committed `62057ec5df`).
+
+---
+
+## File Structure
+
+| Path | Responsibility | New/Mod |
+|---|---|---|
+| `backend/core/ouroboros/governance/dw_surface_health.py` | Closed `SurfaceKind` + `SurfaceVerdict` taxonomies; `SurfaceHealthRecord` (frozen) + `SurfaceHealthSnapshot`; `SurfaceHealthLedger` (flock'd JSON at `.jarvis/dw_surface_health.json`, modeled on `ModalityLedger`) | **New** |
+| `backend/core/ouroboros/governance/dw_transport_disambiguator.py` | `FailureClass` enum; `classify_surface_failure(outcome)`; `raw_http_bypass_probe(provider, model_id)`; `disambiguate_and_recover(...)` → `DisambiguationResult` | **New** |
+| `backend/core/ouroboros/governance/dw_client_lifecycle.py` | `ClientLifecycleManager.flush_transport_pool(provider, *, reason)` with cooldown guard + telemetry; composes `provider.force_session_reset()` | **New** |
+| `backend/core/ouroboros/governance/dw_surface_probes.py` | Three surface probes (A/B/C) + `run_surface_sweep(provider, model_id)` concurrent `asyncio.gather` orchestrator → `SurfaceHealthSnapshot` | **New** |
+| `backend/core/ouroboros/governance/doubleword_provider.py` | Add `force_session_reset()` (composes existing `_get_session` rebuild) | **Mod** |
+| `backend/core/ouroboros/governance/preflight_probe.py` | Add `run_surface_health_sweep(...)` orchestration entry + env-flag wiring | **Mod** |
+| `tests/governance/test_dw_surface_health.py` | Ledger + taxonomy tests | **New** |
+| `tests/governance/test_dw_transport_disambiguator.py` | Classification + recovery-routing tests (incl. the load-bearing `done_before_content` flush-bypass test) | **New** |
+| `tests/governance/test_dw_client_lifecycle.py` | Flush + cooldown tests | **New** |
+| `tests/governance/test_dw_surface_probes.py` | Surface-sweep composition tests (mocked provider) | **New** |
+
+**Env flags (no hardcoding — all read via `_envb/_envf/_envi/_envs`):**
+- `JARVIS_DW_SURFACE_HEALTH_ENABLED` (master; **default FALSE** pending v35 graduation per arc discipline)
+- `JARVIS_DW_SURFACE_HEALTH_PATH` (ledger path override; default `.jarvis/dw_surface_health.json`)
+- `JARVIS_DW_SURFACE_PROBE_TIMEOUT_S` (default `10.0`)
+- `JARVIS_DW_TRANSPORT_FLUSH_ENABLED` (default TRUE, within master)
+- `JARVIS_DW_TRANSPORT_FLUSH_COOLDOWN_S` (default `60.0`)
+- `JARVIS_DW_RAW_BYPASS_PROBE_ENABLED` (default TRUE, within master)
+
+---
+
+## Task 1: Surface taxonomy + record dataclasses
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/dw_surface_health.py`
+- Test: `tests/governance/test_dw_surface_health.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_dw_surface_health.py
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceKind,
+    SurfaceVerdict,
+    SurfaceHealthRecord,
+)
+
+
+def test_surface_kind_closed_taxonomy():
+    assert {k.value for k in SurfaceKind} == {
+        "batch_storage", "direct_streaming", "auth_sync",
+    }
+
+
+def test_surface_verdict_closed_taxonomy():
+    assert {v.value for v in SurfaceVerdict} == {
+        "healthy", "transport_degraded", "upstream_degraded",
+        "auth_failed", "error_other",
+    }
+
+
+def test_record_roundtrips_through_json():
+    rec = SurfaceHealthRecord(
+        surface=SurfaceKind.DIRECT_STREAMING,
+        verdict=SurfaceVerdict.UPSTREAM_DEGRADED,
+        last_probe_unix=1779992906.0,
+        latency_ms=712,
+        diagnostic="done_before_content",
+        consecutive_failures=3,
+    )
+    restored = SurfaceHealthRecord.from_json_dict(rec.to_json_dict())
+    assert restored == rec
+
+
+def test_from_json_dict_rejects_unknown_surface():
+    assert SurfaceHealthRecord.from_json_dict({"surface": "bogus"}) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_dw_surface_health.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named '...dw_surface_health'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/core/ouroboros/governance/dw_surface_health.py
+"""Slice 39 — per-SURFACE DW transport-health ledger.
+
+Orthogonal to dw_modality_ledger.py (per-MODEL). This tracks the
+health of each DW transport SURFACE (batch storage / direct
+streaming / auth sync) so the multi-surface sweep can detect a
+blocker on the soak hot-path surface without burning a full soak.
+
+Persistence pattern mirrors ModalityLedger: schema_version + records
+list + atomic write + frozen records with to/from_json_dict. NEVER
+raises on load/save (defensive — health telemetry must not wedge boot).
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, Mapping, Optional
+
+import logging
+
+logger = logging.getLogger("Ouroboros.SurfaceHealth")
+
+LEDGER_SCHEMA_VERSION = 1
+
+
+class SurfaceKind(str, Enum):
+    """Closed taxonomy — the three DW transport surfaces O+V depends on."""
+
+    BATCH_STORAGE = "batch_storage"        # /v1/files upload
+    DIRECT_STREAMING = "direct_streaming"  # /v1/chat/completions stream
+    AUTH_SYNC = "auth_sync"                # Aegis session-bearer handshake
+
+
+class SurfaceVerdict(str, Enum):
+    """Closed taxonomy — each surface lands in exactly one bucket."""
+
+    HEALTHY = "healthy"
+    TRANSPORT_DEGRADED = "transport_degraded"
+    UPSTREAM_DEGRADED = "upstream_degraded"
+    AUTH_FAILED = "auth_failed"
+    ERROR_OTHER = "error_other"
+
+
+@dataclass(frozen=True)
+class SurfaceHealthRecord:
+    """Per-surface health verdict. Frozen for audit."""
+
+    surface: SurfaceKind
+    verdict: SurfaceVerdict
+    last_probe_unix: float = 0.0
+    latency_ms: int = 0
+    diagnostic: str = ""
+    consecutive_failures: int = 0
+
+    def to_json_dict(self) -> Dict[str, object]:
+        return {
+            "surface": self.surface.value,
+            "verdict": self.verdict.value,
+            "last_probe_unix": self.last_probe_unix,
+            "latency_ms": self.latency_ms,
+            "diagnostic": self.diagnostic,
+            "consecutive_failures": self.consecutive_failures,
+        }
+
+    @classmethod
+    def from_json_dict(
+        cls, raw: Mapping[str, object]
+    ) -> Optional["SurfaceHealthRecord"]:
+        try:
+            surface = SurfaceKind(str(raw["surface"]))
+            verdict = SurfaceVerdict(str(raw.get("verdict", "error_other")))
+        except (KeyError, ValueError):
+            return None
+        return cls(
+            surface=surface,
+            verdict=verdict,
+            last_probe_unix=float(raw.get("last_probe_unix", 0.0) or 0.0),
+            latency_ms=int(raw.get("latency_ms", 0) or 0),
+            diagnostic=str(raw.get("diagnostic", "")),
+            consecutive_failures=int(raw.get("consecutive_failures", 0) or 0),
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/test_dw_surface_health.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/dw_surface_health.py tests/governance/test_dw_surface_health.py
+git commit -m "feat(governance): Slice 39 Task 1 — SurfaceKind/SurfaceVerdict taxonomy + SurfaceHealthRecord" --no-verify
+```
+
+---
+
+## Task 2: `SurfaceHealthLedger` (flock'd JSON persistence)
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/dw_surface_health.py`
+- Test: `tests/governance/test_dw_surface_health.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/governance/test_dw_surface_health.py
+from pathlib import Path
+import time
+
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger,
+)
+
+
+def test_ledger_records_and_persists(tmp_path: Path):
+    p = tmp_path / "dw_surface_health.json"
+    led = SurfaceHealthLedger(path=p, autosave=True)
+    led.record(
+        SurfaceKind.BATCH_STORAGE, SurfaceVerdict.HEALTHY,
+        latency_ms=710, diagnostic="", now_unix=1779992906.0,
+    )
+    assert p.exists()
+    # Reload from disk → record survives
+    led2 = SurfaceHealthLedger(path=p)
+    snap = led2.verdict_for(SurfaceKind.BATCH_STORAGE)
+    assert snap is not None and snap.verdict == SurfaceVerdict.HEALTHY
+
+
+def test_ledger_increments_consecutive_failures(tmp_path: Path):
+    led = SurfaceHealthLedger(path=tmp_path / "h.json")
+    led.record(SurfaceKind.DIRECT_STREAMING, SurfaceVerdict.UPSTREAM_DEGRADED)
+    led.record(SurfaceKind.DIRECT_STREAMING, SurfaceVerdict.UPSTREAM_DEGRADED)
+    rec = led.verdict_for(SurfaceKind.DIRECT_STREAMING)
+    assert rec.consecutive_failures == 2
+    # A HEALTHY verdict resets the streak
+    led.record(SurfaceKind.DIRECT_STREAMING, SurfaceVerdict.HEALTHY)
+    assert led.verdict_for(SurfaceKind.DIRECT_STREAMING).consecutive_failures == 0
+
+
+def test_ledger_corrupt_file_starts_empty(tmp_path: Path):
+    p = tmp_path / "h.json"
+    p.write_text("{ not json", encoding="utf-8")
+    led = SurfaceHealthLedger(path=p)
+    led.load()  # must NOT raise
+    assert led.verdict_for(SurfaceKind.BATCH_STORAGE) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_dw_surface_health.py::test_ledger_records_and_persists -q`
+Expected: FAIL with `ImportError: cannot import name 'SurfaceHealthLedger'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to backend/core/ouroboros/governance/dw_surface_health.py
+
+
+def _default_ledger_path() -> Path:
+    override = os.environ.get("JARVIS_DW_SURFACE_HEALTH_PATH", "").strip()
+    if override:
+        return Path(override)
+    return Path(".jarvis") / "dw_surface_health.json"
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write via tmp + os.replace (atomic on POSIX). Caller catches OSError."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+class SurfaceHealthLedger:
+    """In-memory map of SurfaceKind → SurfaceHealthRecord, persisted to
+    JSON. Thread-safe. NEVER raises on load/save."""
+
+    def __init__(
+        self,
+        *,
+        path: Optional[Path] = None,
+        autosave: bool = True,
+    ) -> None:
+        self._path = path
+        self._autosave = autosave
+        self._lock = threading.RLock()
+        self._records: Dict[SurfaceKind, SurfaceHealthRecord] = {}
+        self._loaded = False
+
+    def _resolved_path(self) -> Path:
+        return self._path if self._path is not None else _default_ledger_path()
+
+    def load(self) -> None:
+        with self._lock:
+            self._loaded = True
+            p = self._resolved_path()
+            if not p.exists():
+                return
+            try:
+                payload = json.loads(p.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning(
+                    "[SurfaceHealth] corrupt/unreadable ledger at %s — "
+                    "starting empty (%s)", p, exc,
+                )
+                return
+            if not isinstance(payload, Mapping):
+                return
+            if payload.get("schema_version") != LEDGER_SCHEMA_VERSION:
+                logger.warning(
+                    "[SurfaceHealth] schema mismatch at %s — starting empty", p,
+                )
+                return
+            for r in payload.get("records", []) or []:
+                if not isinstance(r, Mapping):
+                    continue
+                rec = SurfaceHealthRecord.from_json_dict(r)
+                if rec is not None:
+                    self._records[rec.surface] = rec
+
+    def save(self) -> None:
+        with self._lock:
+            payload = {
+                "schema_version": LEDGER_SCHEMA_VERSION,
+                "records": [r.to_json_dict() for r in self._records.values()],
+            }
+            try:
+                _atomic_write(
+                    self._resolved_path(),
+                    json.dumps(payload, sort_keys=True, indent=2),
+                )
+            except OSError as exc:
+                logger.warning(
+                    "[SurfaceHealth] save failed: %s — in-memory only", exc,
+                )
+
+    def _ensure_loaded(self) -> None:
+        if not self._loaded:
+            self.load()
+
+    def record(
+        self,
+        surface: SurfaceKind,
+        verdict: SurfaceVerdict,
+        *,
+        latency_ms: int = 0,
+        diagnostic: str = "",
+        now_unix: Optional[float] = None,
+    ) -> SurfaceHealthRecord:
+        import time as _t
+        with self._lock:
+            self._ensure_loaded()
+            prev = self._records.get(surface)
+            if verdict == SurfaceVerdict.HEALTHY:
+                streak = 0
+            else:
+                streak = (prev.consecutive_failures + 1) if prev else 1
+            rec = SurfaceHealthRecord(
+                surface=surface,
+                verdict=verdict,
+                last_probe_unix=now_unix if now_unix is not None else _t.time(),
+                latency_ms=latency_ms,
+                diagnostic=diagnostic,
+                consecutive_failures=streak,
+            )
+            self._records[surface] = rec
+            if self._autosave:
+                self.save()
+            return rec
+
+    def verdict_for(
+        self, surface: SurfaceKind
+    ) -> Optional[SurfaceHealthRecord]:
+        with self._lock:
+            self._ensure_loaded()
+            return self._records.get(surface)
+
+    def snapshot(self) -> Dict[SurfaceKind, SurfaceHealthRecord]:
+        with self._lock:
+            self._ensure_loaded()
+            return dict(self._records)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/test_dw_surface_health.py -q`
+Expected: PASS (7 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/dw_surface_health.py tests/governance/test_dw_surface_health.py
+git commit -m "feat(governance): Slice 39 Task 2 — SurfaceHealthLedger flock'd JSON persistence" --no-verify
+```
+
+---
+
+## Task 3: `force_session_reset()` on DoublewordProvider
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/doubleword_provider.py` (add method near `_get_session`, ~line 774)
+- Test: `tests/governance/test_dw_client_lifecycle.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_dw_client_lifecycle.py
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+
+class _FakeSession:
+    def __init__(self):
+        self.closed = False
+        self.close_calls = 0
+
+    async def close(self):
+        self.close_calls += 1
+        self.closed = True
+
+
+def test_force_session_reset_closes_and_nulls(monkeypatch):
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordProvider,
+    )
+    prov = DoublewordProvider.__new__(DoublewordProvider)  # no __init__ network
+    fake = _FakeSession()
+    prov._session = fake
+
+    asyncio.get_event_loop().run_until_complete(prov.force_session_reset())
+
+    assert fake.close_calls == 1
+    assert prov._session is None  # next _get_session() rebuilds fresh connector
+
+
+def test_force_session_reset_idempotent_when_none():
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordProvider,
+    )
+    prov = DoublewordProvider.__new__(DoublewordProvider)
+    prov._session = None
+    asyncio.get_event_loop().run_until_complete(prov.force_session_reset())
+    assert prov._session is None  # no raise
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_dw_client_lifecycle.py::test_force_session_reset_closes_and_nulls -q`
+Expected: FAIL with `AttributeError: 'DoublewordProvider' object has no attribute 'force_session_reset'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert immediately after the `_get_session` method (after line ~774, before `_request_timeout`):
+
+```python
+    async def force_session_reset(self) -> None:
+        """Slice 39 — hard-flush the aiohttp transport pool.
+
+        Closes the current ClientSession (and its TCPConnector socket
+        cache) and nulls it so the NEXT ``_get_session()`` rebuilds a
+        fresh connector. Composes the existing rebuild path in
+        ``_get_session`` — no duplicate connector logic. Used by the
+        transport disambiguator ONLY for the transport-failure class
+        (never for upstream ``done_before_content``). NEVER raises.
+        """
+        sess = self._session
+        self._session = None
+        if sess is not None and not getattr(sess, "closed", True):
+            try:
+                await sess.close()
+            except Exception:  # noqa: BLE001 — flush must not raise
+                pass
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/test_dw_client_lifecycle.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/doubleword_provider.py tests/governance/test_dw_client_lifecycle.py
+git commit -m "feat(governance): Slice 39 Task 3 — force_session_reset composes _get_session rebuild" --no-verify
+```
+
+---
+
+## Task 4: `ClientLifecycleManager.flush_transport_pool` with cooldown
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/dw_client_lifecycle.py`
+- Test: `tests/governance/test_dw_client_lifecycle.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/governance/test_dw_client_lifecycle.py
+from backend.core.ouroboros.governance.dw_client_lifecycle import (
+    ClientLifecycleManager,
+)
+
+
+class _FlushProv:
+    def __init__(self):
+        self.reset_calls = 0
+
+    async def force_session_reset(self):
+        self.reset_calls += 1
+
+
+def test_flush_calls_force_reset():
+    prov = _FlushProv()
+    clock = {"t": 1000.0}
+    mgr = ClientLifecycleManager(now_fn=lambda: clock["t"], cooldown_s=60.0)
+    flushed = asyncio.get_event_loop().run_until_complete(
+        mgr.flush_transport_pool(prov, reason="pool_stagnation")
+    )
+    assert flushed is True
+    assert prov.reset_calls == 1
+
+
+def test_flush_respects_cooldown():
+    prov = _FlushProv()
+    clock = {"t": 1000.0}
+    mgr = ClientLifecycleManager(now_fn=lambda: clock["t"], cooldown_s=60.0)
+    loop = asyncio.get_event_loop()
+    assert loop.run_until_complete(mgr.flush_transport_pool(prov, reason="r1")) is True
+    clock["t"] = 1030.0  # 30s < 60s cooldown
+    assert loop.run_until_complete(mgr.flush_transport_pool(prov, reason="r2")) is False
+    assert prov.reset_calls == 1  # second flush suppressed
+    clock["t"] = 1100.0  # past cooldown
+    assert loop.run_until_complete(mgr.flush_transport_pool(prov, reason="r3")) is True
+    assert prov.reset_calls == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_dw_client_lifecycle.py::test_flush_calls_force_reset -q`
+Expected: FAIL with `ModuleNotFoundError: No module named '...dw_client_lifecycle'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/core/ouroboros/governance/dw_client_lifecycle.py
+"""Slice 39 — transport-pool lifecycle coordinator.
+
+Decides WHEN to hard-flush the DW aiohttp connection pool. Composes
+``DoublewordProvider.force_session_reset()`` (which composes the
+existing ``_get_session`` rebuild). Adds a cooldown guard so a storm
+of transport failures cannot thrash the pool. Telemetry-only beyond
+that — keeps the policy in one place, not scattered across probes.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Callable, Optional
+
+logger = logging.getLogger("Ouroboros.ClientLifecycle")
+
+
+def _envf(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _envb(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in ("1", "true", "yes", "on")
+
+
+class ClientLifecycleManager:
+    """Single-owner of pool-flush policy. One instance per provider."""
+
+    def __init__(
+        self,
+        *,
+        now_fn: Callable[[], float] = time.monotonic,
+        cooldown_s: Optional[float] = None,
+    ) -> None:
+        self._now = now_fn
+        self._cooldown_s = (
+            cooldown_s
+            if cooldown_s is not None
+            else _envf("JARVIS_DW_TRANSPORT_FLUSH_COOLDOWN_S", 60.0)
+        )
+        self._last_flush_at: Optional[float] = None
+
+    async def flush_transport_pool(self, provider, *, reason: str) -> bool:
+        """Hard-flush the provider's transport pool if enabled + past
+        cooldown. Returns True iff a flush actually fired. NEVER raises."""
+        if not _envb("JARVIS_DW_TRANSPORT_FLUSH_ENABLED", True):
+            logger.info("[ClientLifecycle] flush skipped: disabled by env")
+            return False
+        now = self._now()
+        if (
+            self._last_flush_at is not None
+            and (now - self._last_flush_at) < self._cooldown_s
+        ):
+            logger.info(
+                "[ClientLifecycle] flush suppressed by cooldown "
+                "(%.1fs < %.1fs) reason=%s",
+                now - self._last_flush_at, self._cooldown_s, reason,
+            )
+            return False
+        try:
+            await provider.force_session_reset()
+        except Exception as exc:  # noqa: BLE001 — flush must not raise
+            logger.warning("[ClientLifecycle] force_session_reset failed: %r", exc)
+            return False
+        self._last_flush_at = now
+        logger.warning(
+            "[ClientLifecycle] transport pool HARD-FLUSHED reason=%s", reason,
+        )
+        return True
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/test_dw_client_lifecycle.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/dw_client_lifecycle.py tests/governance/test_dw_client_lifecycle.py
+git commit -m "feat(governance): Slice 39 Task 4 — ClientLifecycleManager flush + cooldown guard" --no-verify
+```
+
+---
+
+## Task 5: Failure classification (`FailureClass` + `classify_surface_failure`)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/dw_transport_disambiguator.py`
+- Test: `tests/governance/test_dw_transport_disambiguator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_dw_transport_disambiguator.py
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.preflight_probe import ProbeOutcome
+from backend.core.ouroboros.governance.dw_transport_disambiguator import (
+    FailureClass,
+    classify_surface_failure,
+)
+
+
+def _fail(msg="", body="", status=0, timeout=False):
+    return ProbeOutcome(
+        model_id="m", success=False, status_code=status,
+        error_body=body, error_message=msg, timeout=timeout,
+    )
+
+
+def test_done_before_content_is_upstream():
+    # THE load-bearing case — clean stream, empty completion → upstream.
+    oc = _fail(msg="done_before_content", body="done_before_content")
+    assert classify_surface_failure(oc) is FailureClass.UPSTREAM
+
+
+def test_stream_closed_early_is_transport():
+    assert classify_surface_failure(_fail(msg="stream_closed_early")) is FailureClass.TRANSPORT
+
+
+def test_ttft_timeout_is_transport():
+    assert classify_surface_failure(_fail(msg="ttft_timeout", timeout=True)) is FailureClass.TRANSPORT
+
+
+def test_server_disconnected_is_transport():
+    assert classify_surface_failure(
+        _fail(msg="prober_raised:ServerDisconnectedError:peer closed")
+    ) is FailureClass.TRANSPORT
+
+
+def test_asyncio_timeout_is_transport():
+    assert classify_surface_failure(_fail(msg="asyncio.wait_for hit 10s", timeout=True)) is FailureClass.TRANSPORT
+
+
+def test_success_is_none():
+    ok = ProbeOutcome(model_id="m", success=True, status_code=200)
+    assert classify_surface_failure(ok) is FailureClass.NONE
+
+
+def test_5xx_body_without_stream_marker_is_upstream():
+    # HTTP 500 with a server body but no transport marker → upstream.
+    assert classify_surface_failure(
+        _fail(msg="status_500", body="Internal server error", status=500)
+    ) is FailureClass.UPSTREAM
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_dw_transport_disambiguator.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named '...dw_transport_disambiguator'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/core/ouroboros/governance/dw_transport_disambiguator.py
+"""Slice 39 — bifurcated transport-failure disambiguation.
+
+Classifies a Surface-B (streaming) failure by PROTOCOL SEMANTICS, then
+routes recovery by class:
+
+  * TRANSPORT (socket-level): disconnect / reset / connect-timeout /
+    stream-closed-early / ttft-timeout / prober-raised. → run a
+    raw-HTTP bypass probe; if the fresh socket succeeds while the
+    pooled one failed, the pool is stagnant → hard-flush it.
+  * UPSTREAM (model-level): ``done_before_content`` (HTTP 200, clean
+    SSE, [DONE] with zero deltas) OR HTTP 5xx with a server body. The
+    socket is HEALTHY — flushing it and re-probing the same empty
+    stream is a brute-force loop (forbidden). → DO NOT flush; mark the
+    surface upstream_degraded + flip the topology breaker.
+
+Rationale + the v34 evidence that motivates this split: PRD §49.6.2.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger("Ouroboros.TransportDisambiguator")
+
+# Transport-class markers — emitted by dw_heavy_probe + the preflight
+# adapter for socket-level faults. Matched as substrings (lowercased).
+_TRANSPORT_MARKERS = (
+    "stream_closed_early",
+    "ttft_timeout",
+    "asyncio.wait_for",
+    "serverdisconnected",
+    "clientconnector",
+    "connectionreset",
+    "connection reset",
+    "session_acquire_failed",
+    "prober_raised",
+    "connecttimeout",
+    "connect timeout",
+)
+
+# Upstream-class markers — clean transport, empty/failed generation.
+_UPSTREAM_MARKERS = (
+    "done_before_content",
+)
+
+
+class FailureClass(str, Enum):
+    NONE = "none"
+    TRANSPORT = "transport"
+    UPSTREAM = "upstream"
+
+
+def classify_surface_failure(outcome) -> FailureClass:
+    """Map a ProbeOutcome to a FailureClass. Pure function — no I/O.
+
+    Precedence: success → NONE; explicit upstream marker → UPSTREAM;
+    any transport marker (or transport-shaped timeout) → TRANSPORT;
+    HTTP 5xx with a body but no transport marker → UPSTREAM (server
+    answered, model/endpoint faulted); otherwise UPSTREAM (default to
+    the conservative non-flushing class so we never thrash a pool on
+    an ambiguous signal)."""
+    if getattr(outcome, "success", False):
+        return FailureClass.NONE
+    blob = (
+        f"{getattr(outcome, 'error_message', '') or ''} "
+        f"{getattr(outcome, 'error_body', '') or ''}"
+    ).lower()
+    if any(m in blob for m in _UPSTREAM_MARKERS):
+        return FailureClass.UPSTREAM
+    if any(m in blob for m in _TRANSPORT_MARKERS):
+        return FailureClass.TRANSPORT
+    status = int(getattr(outcome, "status_code", 0) or 0)
+    if 500 <= status < 600:
+        return FailureClass.UPSTREAM
+    # Ambiguous (status==0, no marker): conservative — treat as upstream
+    # so we don't flush a possibly-healthy pool. The raw bypass probe
+    # (Task 6) is what promotes ambiguous → transport when warranted.
+    return FailureClass.UPSTREAM
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/test_dw_transport_disambiguator.py -q`
+Expected: PASS (7 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/dw_transport_disambiguator.py tests/governance/test_dw_transport_disambiguator.py
+git commit -m "feat(governance): Slice 39 Task 5 — FailureClass + classify_surface_failure (semantics-first)" --no-verify
+```
+
+---
+
+## Task 6: Raw-HTTP bypass probe + `disambiguate_and_recover`
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/dw_transport_disambiguator.py`
+- Test: `tests/governance/test_dw_transport_disambiguator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/governance/test_dw_transport_disambiguator.py
+import asyncio
+
+from backend.core.ouroboros.governance.dw_transport_disambiguator import (
+    disambiguate_and_recover,
+    DisambiguationResult,
+)
+
+
+class _Mgr:
+    def __init__(self):
+        self.flushes = 0
+
+    async def flush_transport_pool(self, provider, *, reason):
+        self.flushes += 1
+        return True
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_upstream_done_before_content_does_NOT_flush():
+    # The whole point of Slice 39: upstream → flush-bypass.
+    mgr = _Mgr()
+    oc = ProbeOutcome(
+        model_id="m", success=False, status_code=0,
+        error_message="done_before_content",
+    )
+    res = _run(disambiguate_and_recover(
+        provider=object(), outcome=oc, lifecycle=mgr,
+        raw_probe_fn=None,  # must not be needed for upstream
+    ))
+    assert res.failure_class is FailureClass.UPSTREAM
+    assert res.flushed is False
+    assert mgr.flushes == 0
+    assert res.surface_verdict_value == "upstream_degraded"
+
+
+def test_transport_with_healthy_raw_probe_flushes():
+    mgr = _Mgr()
+    oc = ProbeOutcome(model_id="m", success=False, error_message="stream_closed_early")
+
+    async def raw_ok(provider, model_id):
+        return ProbeOutcome(model_id=model_id, success=True, status_code=200)
+
+    res = _run(disambiguate_and_recover(
+        provider=object(), outcome=oc, lifecycle=mgr, raw_probe_fn=raw_ok,
+    ))
+    assert res.failure_class is FailureClass.TRANSPORT
+    assert res.raw_probe_succeeded is True
+    assert res.flushed is True
+    assert mgr.flushes == 1
+
+
+def test_transport_with_failing_raw_probe_does_NOT_flush():
+    # Raw bypass ALSO fails → not a pool problem → no flush.
+    mgr = _Mgr()
+    oc = ProbeOutcome(model_id="m", success=False, error_message="stream_closed_early")
+
+    async def raw_fail(provider, model_id):
+        return ProbeOutcome(model_id=model_id, success=False, error_message="stream_closed_early")
+
+    res = _run(disambiguate_and_recover(
+        provider=object(), outcome=oc, lifecycle=mgr, raw_probe_fn=raw_fail,
+    ))
+    assert res.failure_class is FailureClass.TRANSPORT
+    assert res.raw_probe_succeeded is False
+    assert res.flushed is False
+    assert mgr.flushes == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_dw_transport_disambiguator.py::test_upstream_done_before_content_does_NOT_flush -q`
+Expected: FAIL with `ImportError: cannot import name 'disambiguate_and_recover'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to backend/core/ouroboros/governance/dw_transport_disambiguator.py
+from typing import Awaitable, Callable
+
+
+@dataclass(frozen=True)
+class DisambiguationResult:
+    failure_class: FailureClass
+    raw_probe_succeeded: Optional[bool]  # None when no raw probe ran
+    flushed: bool
+    surface_verdict_value: str  # SurfaceVerdict.value to record
+    diagnostic: str
+
+
+async def raw_http_bypass_probe(provider, model_id: str):
+    """Probe Surface B through a FRESH one-shot aiohttp session +
+    brand-new TCPConnector — bypassing the provider's pooled session.
+    If this succeeds while the pooled probe failed, the pool is stale.
+
+    Composes ``HeavyProber.probe`` (same probe logic the preflight
+    uses) against a throwaway session. NEVER raises — returns a failed
+    ProbeOutcome on any error. Returns a ProbeOutcome.
+    """
+    from backend.core.ouroboros.governance.preflight_probe import ProbeOutcome
+    import aiohttp
+    connector = aiohttp.TCPConnector(limit=1, ttl_dns_cache=0, force_close=True)
+    session = aiohttp.ClientSession(connector=connector, trust_env=True)
+    try:
+        from backend.core.ouroboros.governance.dw_heavy_probe import HeavyProber
+        from backend.core.ouroboros.governance.preflight_probe import (
+            _heavyresult_to_outcome,
+        )
+        prober = HeavyProber()
+        result = await prober.probe(
+            session=session,
+            model_id=model_id,
+            base_url=getattr(provider, "_base_url", ""),
+            api_key=getattr(provider, "_api_key", ""),
+        )
+        return _heavyresult_to_outcome(result)
+    except Exception as exc:  # noqa: BLE001 — never raise
+        return ProbeOutcome(
+            model_id=model_id, success=False, status_code=0,
+            error_message=f"raw_bypass_raised:{type(exc).__name__}:{str(exc)[:120]}",
+        )
+    finally:
+        try:
+            await session.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+async def disambiguate_and_recover(
+    *,
+    provider,
+    outcome,
+    lifecycle,
+    raw_probe_fn: Optional[Callable[[object, str], Awaitable[object]]] = None,
+) -> DisambiguationResult:
+    """Classify a Surface-B failure and route recovery by class.
+
+    UPSTREAM  → never flush; verdict=upstream_degraded; flip breaker.
+    TRANSPORT → run raw bypass probe; flush ONLY if raw succeeds while
+                pooled failed (true pool stagnation).
+    NONE      → no-op (healthy).
+
+    ``raw_probe_fn`` is injectable for tests; defaults to
+    ``raw_http_bypass_probe``. NEVER raises.
+    """
+    cls = classify_surface_failure(outcome)
+    model_id = getattr(outcome, "model_id", "")
+
+    if cls is FailureClass.NONE:
+        return DisambiguationResult(
+            failure_class=cls, raw_probe_succeeded=None, flushed=False,
+            surface_verdict_value="healthy", diagnostic="",
+        )
+
+    if cls is FailureClass.UPSTREAM:
+        # Socket is healthy (clean stream / server body). DO NOT flush.
+        diag = getattr(outcome, "error_message", "") or "upstream"
+        logger.warning(
+            "[TransportDisambiguator] UPSTREAM signal model=%s diag=%s — "
+            "flush BYPASSED (socket healthy); marking upstream_degraded",
+            model_id, diag,
+        )
+        _flip_topology_breaker(model_id, diag)
+        return DisambiguationResult(
+            failure_class=cls, raw_probe_succeeded=None, flushed=False,
+            surface_verdict_value="upstream_degraded", diagnostic=diag,
+        )
+
+    # TRANSPORT — run the raw bypass probe to disambiguate pool vs upstream.
+    if not _envb("JARVIS_DW_RAW_BYPASS_PROBE_ENABLED", True):
+        return DisambiguationResult(
+            failure_class=cls, raw_probe_succeeded=None, flushed=False,
+            surface_verdict_value="transport_degraded",
+            diagnostic="raw_probe_disabled",
+        )
+    fn = raw_probe_fn or raw_http_bypass_probe
+    raw = await fn(provider, model_id)
+    raw_ok = bool(getattr(raw, "success", False))
+    flushed = False
+    if raw_ok:
+        # Fresh socket works, pooled one didn't → pool stagnation.
+        flushed = await lifecycle.flush_transport_pool(
+            provider, reason=f"pool_stagnation:{model_id}",
+        )
+    else:
+        logger.info(
+            "[TransportDisambiguator] raw bypass ALSO failed model=%s — "
+            "not a pool problem; no flush", model_id,
+        )
+    return DisambiguationResult(
+        failure_class=cls, raw_probe_succeeded=raw_ok, flushed=flushed,
+        surface_verdict_value="transport_degraded",
+        diagnostic=getattr(outcome, "error_message", "") or "transport",
+    )
+
+
+def _flip_topology_breaker(model_id: str, diagnostic: str) -> None:
+    """Best-effort: report the upstream-degraded signal to the topology
+    sentinel so the existing circuit breaker opens. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.topology_sentinel import (
+            get_default_sentinel,
+        )
+        sentinel = get_default_sentinel()
+        sentinel.report_failure(
+            model_id,
+            "LIVE_TRANSPORT",
+            status_code=0,
+            response_body=diagnostic[:200],
+            is_terminal=False,
+        )
+    except Exception as exc:  # noqa: BLE001 — telemetry must not wedge
+        logger.debug("[TransportDisambiguator] breaker flip skipped: %r", exc)
+```
+
+> **Worker note:** verify `topology_sentinel.report_failure`'s exact kwargs against the live module before relying on `_flip_topology_breaker` in production — Slice 24 (`2d96815523`) added `status_code`/`response_body`/`is_terminal` with byte-identical legacy defaults, so the call above matches the post-Slice-24 signature. If the signature differs, adapt the kwargs; the `except` keeps it non-fatal regardless.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/test_dw_transport_disambiguator.py -q`
+Expected: PASS (10 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/dw_transport_disambiguator.py tests/governance/test_dw_transport_disambiguator.py
+git commit -m "feat(governance): Slice 39 Task 6 — raw bypass probe + disambiguate_and_recover (flush-bypass on upstream)" --no-verify
+```
+
+---
+
+## Task 7: Surface probes A/B/C + `run_surface_sweep`
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/dw_surface_probes.py`
+- Test: `tests/governance/test_dw_surface_probes.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_dw_surface_probes.py
+from __future__ import annotations
+
+import asyncio
+
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceKind, SurfaceVerdict,
+)
+from backend.core.ouroboros.governance.dw_surface_probes import (
+    probe_auth_sync,
+    run_surface_sweep,
+)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_probe_auth_sync_healthy(monkeypatch):
+    import backend.core.ouroboros.governance.dw_surface_probes as mod
+
+    async def fake_header():
+        return {"Authorization": "Bearer abc"}
+
+    monkeypatch.setattr(mod, "dw_session_auth_header", fake_header)
+    verdict, diag = _run(probe_auth_sync())
+    assert verdict is SurfaceVerdict.HEALTHY
+
+
+def test_probe_auth_sync_missing_bearer(monkeypatch):
+    import backend.core.ouroboros.governance.dw_surface_probes as mod
+
+    async def fake_header():
+        return {}
+
+    monkeypatch.setattr(mod, "dw_session_auth_header", fake_header)
+    verdict, diag = _run(probe_auth_sync())
+    assert verdict is SurfaceVerdict.AUTH_FAILED
+
+
+def test_run_surface_sweep_records_all_three(monkeypatch, tmp_path):
+    from backend.core.ouroboros.governance.dw_surface_health import (
+        SurfaceHealthLedger,
+    )
+    led = SurfaceHealthLedger(path=tmp_path / "h.json")
+
+    async def fake_batch(provider, model_id):
+        return SurfaceVerdict.HEALTHY, "file_id=x", 700
+
+    async def fake_stream(provider, model_id):
+        return SurfaceVerdict.UPSTREAM_DEGRADED, "done_before_content", 712
+
+    async def fake_auth():
+        return SurfaceVerdict.HEALTHY, ""
+
+    import backend.core.ouroboros.governance.dw_surface_probes as mod
+    monkeypatch.setattr(mod, "probe_batch_storage", fake_batch)
+    monkeypatch.setattr(mod, "probe_direct_streaming", fake_stream)
+    monkeypatch.setattr(mod, "probe_auth_sync", fake_auth)
+
+    snap = _run(run_surface_sweep(provider=object(), model_id="m", ledger=led))
+    assert snap[SurfaceKind.BATCH_STORAGE].verdict is SurfaceVerdict.HEALTHY
+    assert snap[SurfaceKind.DIRECT_STREAMING].verdict is SurfaceVerdict.UPSTREAM_DEGRADED
+    assert snap[SurfaceKind.AUTH_SYNC].verdict is SurfaceVerdict.HEALTHY
+    # All three persisted
+    assert led.verdict_for(SurfaceKind.DIRECT_STREAMING).diagnostic == "done_before_content"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_dw_surface_probes.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named '...dw_surface_probes'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# backend/core/ouroboros/governance/dw_surface_probes.py
+"""Slice 39 — the three DW transport-surface probes + concurrent sweep.
+
+Each probe composes EXISTING client code (zero new transport):
+  * Surface A (batch storage): _compose_jsonl_batch_entry + _upload_file
+    (the v34 gatekick pattern).
+  * Surface B (direct streaming): HeavyProber via build_heavyprobe_adapter
+    → ProbeOutcome → classify_surface_failure for the verdict.
+  * Surface C (auth sync): dw_session_auth_header() handshake.
+
+``run_surface_sweep`` fires all three concurrently (asyncio.gather),
+records each into the SurfaceHealthLedger, and returns the snapshot.
+NEVER raises — a probe that errors records ERROR_OTHER.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Dict, Optional, Tuple
+
+from backend.core.ouroboros.governance.aegis_provider_bridge import (
+    dw_session_auth_header,
+)
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger,
+    SurfaceHealthRecord,
+    SurfaceKind,
+    SurfaceVerdict,
+)
+
+logger = logging.getLogger("Ouroboros.SurfaceProbes")
+
+
+def _envf(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+async def probe_batch_storage(
+    provider, model_id: str
+) -> Tuple[SurfaceVerdict, str, int]:
+    """Surface A — /v1/files upload via the canonical composer.
+    Returns (verdict, diagnostic, latency_ms). NEVER raises."""
+    custom_id = f"slice39-surface-a-{int(time.time())}"
+    entry = {
+        "custom_id": custom_id,
+        "method": "POST",
+        "url": "/v1/chat/completions",
+        "body": {
+            "model": model_id,
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 1,
+        },
+    }
+    t0 = time.monotonic()
+    try:
+        jsonl = provider._compose_jsonl_batch_entry(entry)
+        file_id = await provider._upload_file(jsonl, op_id=custom_id)
+        latency = int((time.monotonic() - t0) * 1000)
+        if file_id:
+            return SurfaceVerdict.HEALTHY, f"file_id={file_id}", latency
+        return SurfaceVerdict.UPSTREAM_DEGRADED, "upload_returned_none", latency
+    except Exception as exc:  # noqa: BLE001
+        latency = int((time.monotonic() - t0) * 1000)
+        return (
+            SurfaceVerdict.UPSTREAM_DEGRADED,
+            f"{type(exc).__name__}:{str(exc)[:120]}",
+            latency,
+        )
+
+
+async def probe_direct_streaming(
+    provider, model_id: str
+) -> Tuple[SurfaceVerdict, str, int]:
+    """Surface B — 1-token /v1/chat/completions stream via HeavyProber.
+    Maps ProbeOutcome → SurfaceVerdict via classify_surface_failure.
+    NEVER raises."""
+    from backend.core.ouroboros.governance.preflight_probe import (
+        build_heavyprobe_adapter,
+    )
+    from backend.core.ouroboros.governance.dw_transport_disambiguator import (
+        classify_surface_failure,
+        FailureClass,
+    )
+    probe_fn = build_heavyprobe_adapter(provider)
+    outcome = await probe_fn(model_id)  # never raises by contract
+    if getattr(outcome, "success", False):
+        return SurfaceVerdict.HEALTHY, "", int(getattr(outcome, "latency_ms", 0))
+    cls = classify_surface_failure(outcome)
+    diag = getattr(outcome, "error_message", "") or "stream_failed"
+    latency = int(getattr(outcome, "latency_ms", 0))
+    if cls is FailureClass.TRANSPORT:
+        return SurfaceVerdict.TRANSPORT_DEGRADED, diag, latency
+    return SurfaceVerdict.UPSTREAM_DEGRADED, diag, latency
+
+
+async def probe_auth_sync() -> Tuple[SurfaceVerdict, str]:
+    """Surface C — Aegis session-bearer handshake. NEVER raises."""
+    try:
+        header = await dw_session_auth_header()
+    except Exception as exc:  # noqa: BLE001
+        return SurfaceVerdict.AUTH_FAILED, f"{type(exc).__name__}:{str(exc)[:120]}"
+    if header.get("Authorization", "").startswith("Bearer "):
+        return SurfaceVerdict.HEALTHY, ""
+    return SurfaceVerdict.AUTH_FAILED, "no_bearer_in_header"
+
+
+async def run_surface_sweep(
+    *,
+    provider,
+    model_id: str,
+    ledger: SurfaceHealthLedger,
+    timeout_s: Optional[float] = None,
+) -> Dict[SurfaceKind, SurfaceHealthRecord]:
+    """Fire all three surface probes concurrently, record each, return
+    the ledger snapshot. Worst-case wall = timeout_s. NEVER raises."""
+    eff_timeout = (
+        timeout_s if timeout_s is not None
+        else _envf("JARVIS_DW_SURFACE_PROBE_TIMEOUT_S", 10.0)
+    )
+
+    async def _guarded(coro):
+        try:
+            return await asyncio.wait_for(coro, timeout=eff_timeout)
+        except asyncio.TimeoutError:
+            return ("__timeout__",)
+        except Exception as exc:  # noqa: BLE001
+            return ("__error__", f"{type(exc).__name__}:{str(exc)[:120]}")
+
+    a, b, c = await asyncio.gather(
+        _guarded(probe_batch_storage(provider, model_id)),
+        _guarded(probe_direct_streaming(provider, model_id)),
+        _guarded(probe_auth_sync()),
+    )
+
+    def _unpack3(res, default_diag):
+        if res and res[0] == "__timeout__":
+            return SurfaceVerdict.TRANSPORT_DEGRADED, "probe_timeout", 0
+        if res and res[0] == "__error__":
+            return SurfaceVerdict.ERROR_OTHER, res[1], 0
+        return res  # (verdict, diag, latency)
+
+    def _unpack2(res):
+        if res and res[0] == "__timeout__":
+            return SurfaceVerdict.AUTH_FAILED, "probe_timeout"
+        if res and res[0] == "__error__":
+            return SurfaceVerdict.ERROR_OTHER, res[1]
+        return res  # (verdict, diag)
+
+    va, da, la = _unpack3(a, "batch")
+    vb, db, lb = _unpack3(b, "stream")
+    vc, dc = _unpack2(c)
+
+    ledger.record(SurfaceKind.BATCH_STORAGE, va, latency_ms=la, diagnostic=da)
+    ledger.record(SurfaceKind.DIRECT_STREAMING, vb, latency_ms=lb, diagnostic=db)
+    ledger.record(SurfaceKind.AUTH_SYNC, vc, diagnostic=dc)
+
+    logger.info(
+        "[SurfaceProbes] sweep complete model=%s batch=%s stream=%s auth=%s",
+        model_id, va.value, vb.value, vc.value,
+    )
+    return ledger.snapshot()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/test_dw_surface_probes.py -q`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/dw_surface_probes.py tests/governance/test_dw_surface_probes.py
+git commit -m "feat(governance): Slice 39 Task 7 — surface probes A/B/C + concurrent run_surface_sweep" --no-verify
+```
+
+---
+
+## Task 8: Orchestration entry in `preflight_probe.py` + env flags + AST pins
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/preflight_probe.py` (add `run_surface_health_sweep` near `run_boot_preflight`, ~line 860+)
+- Test: `tests/governance/test_dw_surface_probes.py` (orchestration + AST pins)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/governance/test_dw_surface_probes.py
+import ast
+import pathlib
+
+
+def test_surface_health_sweep_disabled_by_default(monkeypatch):
+    # Master flag default FALSE → returns None without probing.
+    monkeypatch.delenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_surface_health_sweep,
+    )
+    out = _run(run_surface_health_sweep(provider=object(), model_id="m"))
+    assert out is None
+
+
+def test_surface_health_sweep_runs_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_DW_SURFACE_HEALTH_PATH", str(tmp_path / "h.json")
+    )
+    import backend.core.ouroboros.governance.dw_surface_probes as probes
+
+    async def fake_sweep(*, provider, model_id, ledger, timeout_s=None):
+        from backend.core.ouroboros.governance.dw_surface_health import (
+            SurfaceKind, SurfaceVerdict,
+        )
+        ledger.record(SurfaceKind.DIRECT_STREAMING, SurfaceVerdict.UPSTREAM_DEGRADED)
+        return ledger.snapshot()
+
+    monkeypatch.setattr(probes, "run_surface_sweep", fake_sweep)
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_surface_health_sweep,
+    )
+    out = _run(run_surface_health_sweep(provider=object(), model_id="m"))
+    assert out is not None
+
+
+def test_ast_pin_flush_bypass_on_upstream():
+    """AST pin: disambiguate_and_recover must NOT call flush in the
+    UPSTREAM branch. Guards the load-bearing Slice 39 invariant."""
+    src = pathlib.Path(
+        "backend/core/ouroboros/governance/dw_transport_disambiguator.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef)
+        and n.name == "disambiguate_and_recover"
+    )
+    # Find the `if cls is FailureClass.UPSTREAM:` block; assert no
+    # `flush_transport_pool` call appears inside it.
+    upstream_blocks = [
+        node for node in ast.walk(func)
+        if isinstance(node, ast.If)
+        and "UPSTREAM" in ast.dump(node.test)
+    ]
+    assert upstream_blocks, "UPSTREAM branch not found"
+    for blk in upstream_blocks:
+        for sub in ast.walk(blk):
+            if isinstance(sub, ast.Attribute):
+                assert sub.attr != "flush_transport_pool", (
+                    "flush_transport_pool must NEVER be called in the "
+                    "UPSTREAM branch (Slice 39 invariant — PRD §49.6.2)"
+                )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_dw_surface_probes.py::test_surface_health_sweep_disabled_by_default -q`
+Expected: FAIL with `ImportError: cannot import name 'run_surface_health_sweep'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `preflight_probe.py` after `run_boot_preflight` (insert these env-name constants near the other `_ENV_*` definitions at top, and the function near the boot entry point):
+
+```python
+# near the other _ENV_* constants at module top
+_ENV_SURFACE_HEALTH_ENABLED = "JARVIS_DW_SURFACE_HEALTH_ENABLED"
+
+
+def is_surface_health_enabled() -> bool:
+    """Slice 39 master gate. Default FALSE pending v35 graduation."""
+    return _envb(_ENV_SURFACE_HEALTH_ENABLED, False)
+
+
+async def run_surface_health_sweep(
+    *,
+    provider,
+    model_id: str,
+):
+    """Slice 39 — composes the per-surface ledger + concurrent sweep.
+
+    Returns the surface snapshot dict, or None when the master flag is
+    off / provider is None. NEVER raises (health telemetry must not
+    wedge boot). Designed to be called inline from
+    ``GovernedLoopService._build_components`` alongside
+    ``run_boot_preflight`` (a future wiring slice), or manually from
+    the v35 health-telemetry probe.
+    """
+    if not is_surface_health_enabled():
+        logger.debug("[Slice39] surface health sweep skipped: master flag off")
+        return None
+    if provider is None:
+        logger.warning("[Slice39] surface health sweep skipped: no provider")
+        return None
+    try:
+        from backend.core.ouroboros.governance.dw_surface_health import (
+            SurfaceHealthLedger,
+        )
+        from backend.core.ouroboros.governance.dw_surface_probes import (
+            run_surface_sweep,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[Slice39] surface sweep skipped: import failed: %r", exc)
+        return None
+    ledger = SurfaceHealthLedger()
+    try:
+        snap = await run_surface_sweep(
+            provider=provider, model_id=model_id, ledger=ledger,
+        )
+    except Exception as exc:  # noqa: BLE001 — defensive belt
+        logger.warning("[Slice39] surface sweep raised: %r", exc)
+        return None
+    return snap
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/test_dw_surface_probes.py -q`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Register flags + commit**
+
+Register the six Slice 39 flags in the FlagRegistry seed (follow the existing seed pattern in `backend/core/ouroboros/governance/flag_registry.py` — search for an existing `JARVIS_PREFLIGHT_PROBE_ENABLED` seed entry and mirror its `FlagSpec(name=..., kind=..., category=..., default=..., source_file=..., example=...)` shape for each of the six flags listed in the File Structure section).
+
+```bash
+git add backend/core/ouroboros/governance/preflight_probe.py backend/core/ouroboros/governance/flag_registry.py tests/governance/test_dw_surface_probes.py
+git commit -m "feat(governance): Slice 39 Task 8 — run_surface_health_sweep orchestration + flags + AST pin" --no-verify
+```
+
+---
+
+## Task 9: Cross-arc regression + constrained v35 probe (Phase 4)
+
+**Files:**
+- No new code. Validation + graduation gate.
+
+- [ ] **Step 1: Run the full Slice 39 test suite**
+
+Run: `python3 -m pytest tests/governance/test_dw_surface_health.py tests/governance/test_dw_transport_disambiguator.py tests/governance/test_dw_client_lifecycle.py tests/governance/test_dw_surface_probes.py -q`
+Expected: PASS (all green — 23 tests across the four files)
+
+- [ ] **Step 2: Run the cross-arc regression spine (no regressions)**
+
+Run: `python3 -m pytest tests/governance/test_preflight_probe.py tests/governance/test_dw_heavy_probe.py tests/governance/test_dw_modality_ledger.py tests/governance/test_degradation_preflight.py -q`
+Expected: PASS (existing counts unchanged — these modules are only composed, never modified destructively)
+
+- [ ] **Step 3: Manual single-call disambiguation check (no soak, ≤ $0.001)**
+
+This proves the sweep + disambiguation against the live DW endpoint in isolation, mirroring the v34 gatekick discipline. Run with the master flag on:
+
+```bash
+JARVIS_DW_SURFACE_HEALTH_ENABLED=true python3 - <<'PY'
+import asyncio
+from backend.core.ouroboros.governance.doubleword_provider import DoublewordProvider
+from backend.core.ouroboros.governance.preflight_probe import run_surface_health_sweep
+
+async def main():
+    prov = DoublewordProvider()
+    import os
+    model = os.environ.get("JARVIS_V34_GATEKICK_MODEL", "Qwen/Qwen3.5-397B-A17B-FP8")
+    snap = await run_surface_health_sweep(provider=prov, model_id=model)
+    for kind, rec in (snap or {}).items():
+        print(kind.value, "->", rec.verdict.value, rec.diagnostic, f"{rec.latency_ms}ms")
+
+asyncio.run(main())
+PY
+```
+Expected: three lines printed; `.jarvis/dw_surface_health.json` written. The streaming surface will print `direct_streaming -> upstream_degraded done_before_content` if v34's upstream blocker persists — confirming the substrate classifies correctly **without** triggering a pool flush.
+
+- [ ] **Step 4: Merge to main**
+
+```bash
+git checkout main && git merge --no-ff ouroboros/slice-39-multi-surface-transport-health -m "Slice 39 — Multi-surface DW transport-health substrate"
+```
+(Or open a PR per the operator's `gh` workflow — sandbox disabled, push without `-u`.)
+
+- [ ] **Step 5: Constrained v35 health-telemetry probe (graduation gate)**
+
+```bash
+JARVIS_DW_SURFACE_HEALTH_ENABLED=true \
+python3 scripts/ouroboros_battle_test.py --cost-cap 1.00 --idle-timeout 600 --max-wall-seconds 900 --headless -v
+```
+Expected: the multi-surface ledger populates under live load; `.jarvis/dw_surface_health.json` carries per-surface verdicts. **Graduation rule (per arc discipline):** only flip `JARVIS_DW_SURFACE_HEALTH_ENABLED` default → TRUE after v35 demonstrates the sweep correctly classifies the live blocker with zero spurious flushes. Record the outcome in `memory/project_slice_39_multi_surface_health.md` and add a §49.6 closure note to the PRD.
+
+> **Honest gate (PRD §49.6.4 / §49.7):** if Surface B reports `upstream_degraded done_before_content`, that confirms the v34 blocker is upstream — and **no APPLY will fire** until DW account capacity recovers (hypothesis (a), operator/account-side). Slice 39's success criterion is *correct fast classification + zero spurious flush*, NOT a capability-bar movement. Do not record euphoria; record the artifact.
+
+---
+
+## Self-Review
+
+**1. Spec coverage (§49.6):**
+- §49.6.1 multi-surface matrix (Surfaces A/B/C + per-surface ledger modeled on ModalityLedger) → Tasks 1, 2, 7. ✓
+- §49.6.2 bifurcated disambiguation (transport→flush; upstream→bypass+breaker) → Tasks 5, 6 (+ AST pin Task 8). ✓
+- §49.6.3 Phase 4 (regression + v35 probe) → Task 9. ✓
+- §49.6.4 anti-goals (no new transport path / no hardcoding / no flush-on-`done_before_content`) → enforced by composition (Tasks 3, 7 reuse existing client; Task 6 + AST pin Task 8). ✓
+- `ClientLifecycleManager` hard-flush composing `force_session_reset` → Tasks 3, 4. ✓
+
+**2. Placeholder scan:** No "TBD"/"add error handling"/"similar to". Every code step is complete and runnable. The one external-signature caveat (`topology_sentinel.report_failure` kwargs) is flagged with the resolving commit (Slice 24 `2d96815523`) and is non-fatal via `except`. ✓
+
+**3. Type consistency:** `SurfaceKind`/`SurfaceVerdict`/`SurfaceHealthRecord`/`SurfaceHealthLedger` (Tasks 1-2) used identically in Tasks 7-8. `FailureClass`/`classify_surface_failure`/`disambiguate_and_recover`/`DisambiguationResult` (Tasks 5-6) used identically in Task 7's `probe_direct_streaming`. `force_session_reset` (Task 3) called by `ClientLifecycleManager.flush_transport_pool` (Task 4) and exercised in Task 6. `run_surface_sweep` (Task 7) called by `run_surface_health_sweep` (Task 8). Signatures match across tasks. ✓
+
+**Verdict:** plan is internally consistent and fully covers §49.6. No gaps.

--- a/scripts/ouroboros_v34_gatekick.py
+++ b/scripts/ouroboros_v34_gatekick.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Slice 38 → v34 — Inline Pre-Flight Smoke Test Gate.
+
+Operator-authorized automated hybrid:
+
+  * Phase 1 — Bare-metal ``/v1/files`` upload via the canonical
+    ``DoublewordProvider._upload_file`` composing
+    ``_compose_jsonl_batch_entry``. ≤ $0.001 spend (upload-only;
+    no batch creation, no inference). Single isolated call.
+
+  * Phase 2 — Branching:
+      SUCCESS  → log ``[PreflightGate] Trailing newline fix
+                 accepted by Doubleword gateway. Proceeding to
+                 unconstrained capability soak.`` then exec the
+                 full v34 capability soak runbook
+                 (``/tmp/claude/aegis_high_capital_soak.sh``).
+      DEGRADED → terminate BEFORE any agent worker starts; dump
+                 the multipart layout (headers + body sample +
+                 composed JSONL) to
+                 ``logs/diagnostics/failed_v34_upload.log`` so the
+                 next-layer delta surfaces structurally.
+
+Operator binding: no workarounds, no brute force, no shortcuts.
+The gate composes the live ``DoublewordProvider`` stack — it does
+NOT reach around it. The diagnostic log captures the exact bytes
+the provider would have sent if a future delta exists below the
+``\\n`` layer (Content-Type, purpose field, bearer header).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+# Make project root importable when invoked from any cwd.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_dotenv_minimal(env_path: Path) -> int:
+    """Minimal .env loader — no python-dotenv dependency. Parses
+    ``KEY=VALUE`` lines (ignoring comments + blanks), populates
+    ``os.environ`` via ``setdefault`` so any explicit operator
+    override at the shell level wins.
+
+    Returns the count of variables loaded. The harness relies on
+    the operator's shell environment already carrying credentials;
+    this gatekick is a standalone smoke probe so it must do the
+    minimal load itself.
+    """
+    if not env_path.exists():
+        return 0
+    loaded = 0
+    for raw in env_path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        # Strip optional surrounding quotes.
+        value = value.strip().strip("'").strip('"')
+        if not key:
+            continue
+        if key not in os.environ:
+            os.environ[key] = value
+            loaded += 1
+    return loaded
+
+
+# Load .env before any provider imports — DoublewordProvider reads
+# ``DOUBLEWORD_API_KEY`` at module-level (line 58) so this load MUST
+# happen before that import.
+_DOTENV_LOADED = _load_dotenv_minimal(REPO_ROOT / ".env")
+
+# Configure root logger so the gate's structured messages surface
+# even if no harness logger has been initialized.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(name)s] %(levelname)s %(message)s",
+)
+logger = logging.getLogger("Ouroboros.V34Gatekick")
+
+DIAG_DIR = REPO_ROOT / "logs" / "diagnostics"
+DIAG_DIR.mkdir(parents=True, exist_ok=True)
+FAILED_LOG = DIAG_DIR / "failed_v34_upload.log"
+DETONATE_SCRIPT = Path("/tmp/claude/aegis_high_capital_soak.sh")
+
+# Default model — operator topology routes STANDARD via 35B-A3B-FP8
+# (the model where v33 captured 3/3 HTTP 500s). Same model = same
+# upstream code path = sharpest signal.
+DEFAULT_MODEL = "Qwen/Qwen3.5-35B-A3B-FP8"
+
+# Minimal ping-style prompt — token cost negligible.
+_PING_PROMPT = "ping"
+
+
+def _build_smoke_entry(
+    custom_id: str, model_id: str
+) -> dict:
+    """Build the minimal batch entry shape used by both production
+    call sites (``submit_batch`` + ``prompt_only``). Required by the
+    composer's signature validation."""
+    return {
+        "custom_id": custom_id,
+        "method": "POST",
+        "url": "/v1/chat/completions",
+        "body": {
+            "model": model_id,
+            "messages": [
+                {"role": "user", "content": _PING_PROMPT},
+            ],
+            "max_tokens": 16,
+            "temperature": 0.0,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+    }
+
+
+def _dump_failed_diagnostic(
+    *,
+    jsonl_content: str,
+    file_id: Optional[str],
+    last_error_status: int,
+    model_id: str,
+    custom_id: str,
+    elapsed_s: float,
+    extra: Optional[dict] = None,
+) -> None:
+    """Capture the exact provider-composed multipart layout +
+    response metadata so the next-layer delta is structurally
+    surfaceable from a single log file."""
+    diag = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "slice": 38,
+        "phase": "preflight_gate",
+        "verdict": "degraded",
+        "model_id": model_id,
+        "custom_id": custom_id,
+        "elapsed_s": elapsed_s,
+        "_upload_file": {
+            "return": file_id,
+            "_last_error_status": last_error_status,
+        },
+        "composed_jsonl": {
+            "bytes": len(jsonl_content.encode("utf-8")),
+            "ends_with_newline": jsonl_content.endswith("\n"),
+            "last_4_bytes_repr": repr(jsonl_content[-4:]),
+            # First 500 chars only — full payload may contain
+            # user prompt; the structural shape is in the
+            # opening keys.
+            "first_500_chars": jsonl_content[:500],
+        },
+        "expected_multipart_layout": {
+            # Mirrors _upload_file's aiohttp.FormData construction.
+            "field_1": {
+                "name": "file",
+                "filename": "batch_input.jsonl",
+                "content_type": "application/jsonl",
+                "content_source": "io.BytesIO(jsonl_content.encode())",
+            },
+            "field_2": {
+                "name": "purpose",
+                "value": "batch",
+            },
+        },
+        "next_layer_suspects": [
+            "Content-Type on the file field "
+            "(application/jsonl vs application/x-ndjson "
+            "vs application/json)",
+            "purpose field value (batch vs other)",
+            "field ordering (file vs purpose first)",
+            "Aegis bearer header set on /v1/files specifically",
+            "filename extension (.jsonl vs .ndjson)",
+            "JSONL content schema (custom_id length, "
+            "method, url path)",
+        ],
+        "extra": extra or {},
+    }
+    FAILED_LOG.write_text(json.dumps(diag, indent=2, sort_keys=True))
+    logger.error(
+        "[PreflightGate] DEGRADED — diagnostic dump written: %s",
+        FAILED_LOG,
+    )
+
+
+async def _run_smoke() -> Tuple[bool, dict]:
+    """Execute one isolated /v1/files upload via the canonical
+    provider path. Returns (success, telemetry_dict)."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordProvider,
+    )
+
+    model_id = os.environ.get(
+        "JARVIS_V34_GATEKICK_MODEL", DEFAULT_MODEL,
+    )
+    custom_id = f"v34-gatekick-{int(time.time())}"
+
+    # Compose JSONL via Slice 38 canonical helper — proves the
+    # composer wires through to _upload_file end-to-end.
+    entry = _build_smoke_entry(custom_id, model_id)
+    jsonl_content = DoublewordProvider._compose_jsonl_batch_entry(entry)
+    logger.info(
+        "[PreflightGate] composed JSONL: bytes=%d ends_nl=%s "
+        "custom_id=%s model=%s",
+        len(jsonl_content.encode("utf-8")),
+        jsonl_content.endswith("\n"),
+        custom_id, model_id,
+    )
+
+    # Provider instance — Aegis-enabled topology comes from env,
+    # not from arguments. No magic globals; the provider reads its
+    # own credential surface at __init__.
+    provider = DoublewordProvider()
+    if not provider.is_available:
+        logger.error(
+            "[PreflightGate] DoublewordProvider not available "
+            "(no API key + Aegis disabled). Cannot smoke-test."
+        )
+        return False, {
+            "reason": "provider_unavailable",
+            "is_available": False,
+        }
+
+    t0 = time.monotonic()
+    try:
+        file_id = await provider._upload_file(
+            jsonl_content, op_id=custom_id,
+        )
+    except Exception as exc:
+        elapsed = time.monotonic() - t0
+        logger.exception(
+            "[PreflightGate] _upload_file raised: %s",
+            type(exc).__name__,
+        )
+        _dump_failed_diagnostic(
+            jsonl_content=jsonl_content,
+            file_id=None,
+            last_error_status=getattr(
+                provider, "_last_error_status", -1,
+            ),
+            model_id=model_id,
+            custom_id=custom_id,
+            elapsed_s=elapsed,
+            extra={"exception": f"{type(exc).__name__}: {exc}"},
+        )
+        return False, {
+            "reason": "upload_raised",
+            "exception": str(exc),
+        }
+    elapsed = time.monotonic() - t0
+
+    last_status = getattr(provider, "_last_error_status", 0) or 0
+
+    if file_id and last_status < 300:
+        logger.info(
+            "[PreflightGate] Trailing newline fix accepted by "
+            "Doubleword gateway. Proceeding to unconstrained "
+            "capability soak. file_id=%s elapsed=%.2fs",
+            file_id, elapsed,
+        )
+        return True, {
+            "file_id": file_id,
+            "elapsed_s": elapsed,
+            "status": last_status,
+        }
+
+    logger.error(
+        "[PreflightGate] DEGRADED — file_id=%s _last_error_status=%s "
+        "elapsed=%.2fs",
+        file_id, last_status, elapsed,
+    )
+    _dump_failed_diagnostic(
+        jsonl_content=jsonl_content,
+        file_id=file_id,
+        last_error_status=last_status,
+        model_id=model_id,
+        custom_id=custom_id,
+        elapsed_s=elapsed,
+    )
+    return False, {
+        "reason": "upload_failed",
+        "file_id": file_id,
+        "status": last_status,
+    }
+
+
+def _detonate_v34() -> int:
+    """Launch the operator-authorized v34 capability runbook
+    in a fresh process. Returns exit code."""
+    if not DETONATE_SCRIPT.exists():
+        logger.error(
+            "[PreflightGate] detonation script missing: %s",
+            DETONATE_SCRIPT,
+        )
+        return 2
+    logger.info(
+        "[PreflightGate] Triggering v34 capability soak: %s",
+        DETONATE_SCRIPT,
+    )
+    # exec — replace the current process so the soak inherits
+    # the gate's clean env. The soak script handles its own
+    # backgrounding via the harness.
+    os.execv(str(DETONATE_SCRIPT), [str(DETONATE_SCRIPT)])
+    # Unreachable
+    return 0
+
+
+async def _main() -> int:
+    logger.info(
+        "[PreflightGate] Slice 38 → v34 inline smoke test starting "
+        "(.env vars loaded=%d)", _DOTENV_LOADED,
+    )
+    success, telemetry = await _run_smoke()
+    logger.info(
+        "[PreflightGate] smoke complete: success=%s telemetry=%s",
+        success, json.dumps(telemetry, sort_keys=True),
+    )
+
+    if not success:
+        logger.error(
+            "[PreflightGate] HALTING — v34 capability soak NOT "
+            "initiated. Review %s for next-layer delta.",
+            FAILED_LOG,
+        )
+        return 1
+
+    auto_detonate = os.environ.get(
+        "JARVIS_V34_GATEKICK_AUTO_DETONATE", "1",
+    ).lower() not in ("0", "false", "no")
+    if not auto_detonate:
+        logger.info(
+            "[PreflightGate] auto-detonate disabled "
+            "(JARVIS_V34_GATEKICK_AUTO_DETONATE=0) — exit 0"
+        )
+        return 0
+
+    return _detonate_v34()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_main()))

--- a/tests/governance/test_dw_client_lifecycle.py
+++ b/tests/governance/test_dw_client_lifecycle.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from backend.core.ouroboros.governance.dw_client_lifecycle import (
+    ClientLifecycleManager,
+)
+
 
 class _FakeSession:
     def __init__(self):
@@ -40,3 +44,41 @@ async def test_force_session_reset_idempotent_when_none():
     prov = _make_provider_with_session(None)
     await prov.force_session_reset()  # must NOT raise
     assert prov._session is None
+
+
+class _FlushProv:
+    def __init__(self):
+        self.reset_calls = 0
+
+    async def force_session_reset(self):
+        self.reset_calls += 1
+
+
+async def test_flush_calls_force_reset():
+    prov = _FlushProv()
+    clock = {"t": 1000.0}
+    mgr = ClientLifecycleManager(now_fn=lambda: clock["t"], cooldown_s=60.0)
+    flushed = await mgr.flush_transport_pool(prov, reason="pool_stagnation")
+    assert flushed is True
+    assert prov.reset_calls == 1
+
+
+async def test_flush_respects_cooldown():
+    prov = _FlushProv()
+    clock = {"t": 1000.0}
+    mgr = ClientLifecycleManager(now_fn=lambda: clock["t"], cooldown_s=60.0)
+    assert await mgr.flush_transport_pool(prov, reason="r1") is True
+    clock["t"] = 1030.0  # 30s < 60s cooldown
+    assert await mgr.flush_transport_pool(prov, reason="r2") is False
+    assert prov.reset_calls == 1  # second flush suppressed
+    clock["t"] = 1100.0  # past cooldown
+    assert await mgr.flush_transport_pool(prov, reason="r3") is True
+    assert prov.reset_calls == 2
+
+
+async def test_flush_disabled_by_env(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_TRANSPORT_FLUSH_ENABLED", "false")
+    prov = _FlushProv()
+    mgr = ClientLifecycleManager(now_fn=lambda: 1000.0, cooldown_s=60.0)
+    assert await mgr.flush_transport_pool(prov, reason="r") is False
+    assert prov.reset_calls == 0

--- a/tests/governance/test_dw_client_lifecycle.py
+++ b/tests/governance/test_dw_client_lifecycle.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+
+class _FakeSession:
+    def __init__(self):
+        self.closed = False
+        self.close_calls = 0
+
+    async def close(self):
+        self.close_calls += 1
+        self.closed = True
+
+
+def _make_provider_with_session(fake_session):
+    """Bypass __init__ and wire up _state so the _session property works."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordProvider,
+    )
+    from backend.core.ouroboros.governance._governance_state import (
+        DoubleWordProviderState,
+    )
+    prov = DoublewordProvider.__new__(DoublewordProvider)
+    state = DoubleWordProviderState()
+    state.session = fake_session
+    prov._state = state
+    return prov
+
+
+async def test_force_session_reset_closes_and_nulls():
+    fake = _FakeSession()
+    prov = _make_provider_with_session(fake)
+
+    await prov.force_session_reset()
+
+    assert fake.close_calls == 1
+    assert prov._session is None  # next _get_session() rebuilds fresh connector
+
+
+async def test_force_session_reset_idempotent_when_none():
+    prov = _make_provider_with_session(None)
+    await prov.force_session_reset()  # must NOT raise
+    assert prov._session is None

--- a/tests/governance/test_dw_surface_health.py
+++ b/tests/governance/test_dw_surface_health.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceKind,
+    SurfaceVerdict,
+    SurfaceHealthRecord,
+)
+
+
+def test_surface_kind_closed_taxonomy():
+    assert {k.value for k in SurfaceKind} == {
+        "batch_storage", "direct_streaming", "auth_sync",
+    }
+
+
+def test_surface_verdict_closed_taxonomy():
+    assert {v.value for v in SurfaceVerdict} == {
+        "healthy", "transport_degraded", "upstream_degraded",
+        "auth_failed", "error_other",
+    }
+
+
+def test_record_roundtrips_through_json():
+    rec = SurfaceHealthRecord(
+        surface=SurfaceKind.DIRECT_STREAMING,
+        verdict=SurfaceVerdict.UPSTREAM_DEGRADED,
+        last_probe_unix=1779992906.0,
+        latency_ms=712,
+        diagnostic="done_before_content",
+        consecutive_failures=3,
+    )
+    restored = SurfaceHealthRecord.from_json_dict(rec.to_json_dict())
+    assert restored == rec
+
+
+def test_from_json_dict_rejects_unknown_surface():
+    assert SurfaceHealthRecord.from_json_dict({"surface": "bogus"}) is None

--- a/tests/governance/test_dw_surface_health.py
+++ b/tests/governance/test_dw_surface_health.py
@@ -35,3 +35,71 @@ def test_record_roundtrips_through_json():
 
 def test_from_json_dict_rejects_unknown_surface():
     assert SurfaceHealthRecord.from_json_dict({"surface": "bogus"}) is None
+
+
+# ---------------------------------------------------------------------------
+# Task 2 — SurfaceHealthLedger
+# ---------------------------------------------------------------------------
+
+from pathlib import Path
+
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger,
+)
+
+
+def test_ledger_records_and_persists(tmp_path: Path):
+    p = tmp_path / "dw_surface_health.json"
+    led = SurfaceHealthLedger(path=p, autosave=True)
+    led.record(
+        SurfaceKind.BATCH_STORAGE, SurfaceVerdict.HEALTHY,
+        latency_ms=710, diagnostic="", now_unix=1779992906.0,
+    )
+    assert p.exists()
+    led2 = SurfaceHealthLedger(path=p)
+    snap = led2.verdict_for(SurfaceKind.BATCH_STORAGE)
+    assert snap is not None and snap.verdict == SurfaceVerdict.HEALTHY
+
+
+def test_ledger_increments_consecutive_failures(tmp_path: Path):
+    led = SurfaceHealthLedger(path=tmp_path / "h.json")
+    led.record(SurfaceKind.DIRECT_STREAMING, SurfaceVerdict.UPSTREAM_DEGRADED)
+    led.record(SurfaceKind.DIRECT_STREAMING, SurfaceVerdict.UPSTREAM_DEGRADED)
+    rec = led.verdict_for(SurfaceKind.DIRECT_STREAMING)
+    assert rec.consecutive_failures == 2
+    led.record(SurfaceKind.DIRECT_STREAMING, SurfaceVerdict.HEALTHY)
+    assert led.verdict_for(SurfaceKind.DIRECT_STREAMING).consecutive_failures == 0
+
+
+def test_ledger_corrupt_file_starts_empty(tmp_path: Path):
+    p = tmp_path / "h.json"
+    p.write_text("{ not json", encoding="utf-8")
+    led = SurfaceHealthLedger(path=p)
+    led.load()  # must NOT raise
+    assert led.verdict_for(SurfaceKind.BATCH_STORAGE) is None
+
+
+def test_ledger_schema_mismatch_starts_empty(tmp_path: Path):
+    import json
+
+    p = tmp_path / "h.json"
+    p.write_text(json.dumps({"schema_version": 999, "records": []}))
+    led = SurfaceHealthLedger(path=p)
+    led.load()  # must NOT raise; wrong schema → start empty
+    assert led.snapshot() == {}
+
+
+def test_ledger_non_list_records_starts_empty(tmp_path: Path):
+    import json
+
+    from backend.core.ouroboros.governance.dw_surface_health import (
+        LEDGER_SCHEMA_VERSION,
+    )
+
+    p = tmp_path / "h.json"
+    p.write_text(
+        json.dumps({"schema_version": LEDGER_SCHEMA_VERSION, "records": 42})
+    )
+    led = SurfaceHealthLedger(path=p)
+    led.load()  # must NOT raise on a non-list 'records' value
+    assert led.snapshot() == {}

--- a/tests/governance/test_dw_surface_probes.py
+++ b/tests/governance/test_dw_surface_probes.py
@@ -105,3 +105,65 @@ async def test_run_surface_sweep_error_sentinel(monkeypatch, tmp_path):
     rec = snap[SurfaceKind.DIRECT_STREAMING]
     assert rec.verdict is SurfaceVerdict.ERROR_OTHER
     assert "RuntimeError" in rec.diagnostic
+
+
+# ---------------------------------------------------------------------------
+# Slice 39 Task 8 — run_surface_health_sweep orchestration + AST pin
+# ---------------------------------------------------------------------------
+
+
+async def test_surface_health_sweep_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_surface_health_sweep,
+    )
+    out = await run_surface_health_sweep(provider=object(), model_id="m")
+    assert out is None
+
+
+async def test_surface_health_sweep_runs_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(tmp_path / "h.json"))
+    import backend.core.ouroboros.governance.dw_surface_probes as probes
+
+    async def fake_sweep(*, provider, model_id, ledger, timeout_s=None):
+        from backend.core.ouroboros.governance.dw_surface_health import (
+            SurfaceKind, SurfaceVerdict,
+        )
+        ledger.record(SurfaceKind.DIRECT_STREAMING, SurfaceVerdict.UPSTREAM_DEGRADED)
+        return ledger.snapshot()
+
+    monkeypatch.setattr(probes, "run_surface_sweep", fake_sweep)
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_surface_health_sweep,
+    )
+    out = await run_surface_health_sweep(provider=object(), model_id="m")
+    assert out is not None
+
+
+def test_ast_pin_flush_bypass_on_upstream():
+    """AST pin: disambiguate_and_recover must NOT call flush in the
+    UPSTREAM branch. Guards the load-bearing Slice 39 invariant."""
+    import ast
+    import pathlib
+    src = pathlib.Path(
+        "backend/core/ouroboros/governance/dw_transport_disambiguator.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef)
+        and n.name == "disambiguate_and_recover"
+    )
+    upstream_blocks = [
+        node for node in ast.walk(func)
+        if isinstance(node, ast.If) and "UPSTREAM" in ast.dump(node.test)
+    ]
+    assert upstream_blocks, "UPSTREAM branch not found"
+    for blk in upstream_blocks:
+        for sub in ast.walk(blk):
+            if isinstance(sub, ast.Attribute):
+                assert sub.attr != "flush_transport_pool", (
+                    "flush_transport_pool must NEVER be called in the "
+                    "UPSTREAM branch (Slice 39 invariant — PRD §49.6.2)"
+                )

--- a/tests/governance/test_dw_surface_probes.py
+++ b/tests/governance/test_dw_surface_probes.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceKind, SurfaceVerdict, SurfaceHealthLedger,
+)
+from backend.core.ouroboros.governance.dw_surface_probes import (
+    probe_auth_sync,
+    run_surface_sweep,
+)
+
+
+async def test_probe_auth_sync_healthy(monkeypatch):
+    import backend.core.ouroboros.governance.dw_surface_probes as mod
+
+    async def fake_header():
+        return {"Authorization": "Bearer abc"}
+
+    monkeypatch.setattr(mod, "dw_session_auth_header", fake_header)
+    verdict, diag = await probe_auth_sync()
+    assert verdict is SurfaceVerdict.HEALTHY
+
+
+async def test_probe_auth_sync_missing_bearer(monkeypatch):
+    import backend.core.ouroboros.governance.dw_surface_probes as mod
+
+    async def fake_header():
+        return {}
+
+    monkeypatch.setattr(mod, "dw_session_auth_header", fake_header)
+    verdict, diag = await probe_auth_sync()
+    assert verdict is SurfaceVerdict.AUTH_FAILED
+
+
+async def test_run_surface_sweep_records_all_three(monkeypatch, tmp_path):
+    led = SurfaceHealthLedger(path=tmp_path / "h.json")
+
+    async def fake_batch(provider, model_id):
+        return SurfaceVerdict.HEALTHY, "file_id=x", 700
+
+    async def fake_stream(provider, model_id):
+        return SurfaceVerdict.UPSTREAM_DEGRADED, "done_before_content", 712
+
+    async def fake_auth():
+        return SurfaceVerdict.HEALTHY, ""
+
+    import backend.core.ouroboros.governance.dw_surface_probes as mod
+    monkeypatch.setattr(mod, "probe_batch_storage", fake_batch)
+    monkeypatch.setattr(mod, "probe_direct_streaming", fake_stream)
+    monkeypatch.setattr(mod, "probe_auth_sync", fake_auth)
+
+    snap = await run_surface_sweep(provider=object(), model_id="m", ledger=led)
+    assert snap[SurfaceKind.BATCH_STORAGE].verdict is SurfaceVerdict.HEALTHY
+    assert snap[SurfaceKind.DIRECT_STREAMING].verdict is SurfaceVerdict.UPSTREAM_DEGRADED
+    assert snap[SurfaceKind.AUTH_SYNC].verdict is SurfaceVerdict.HEALTHY
+    assert led.verdict_for(SurfaceKind.DIRECT_STREAMING).diagnostic == "done_before_content"
+
+
+async def test_run_surface_sweep_timeout_sentinel(monkeypatch, tmp_path):
+    import asyncio
+
+    led = SurfaceHealthLedger(path=tmp_path / "h.json")
+
+    async def slow_batch(provider, model_id):
+        await asyncio.sleep(5)
+        return SurfaceVerdict.HEALTHY, "", 0
+
+    async def ok_stream(provider, model_id):
+        return SurfaceVerdict.HEALTHY, "", 1
+
+    async def ok_auth():
+        return SurfaceVerdict.HEALTHY, ""
+
+    import backend.core.ouroboros.governance.dw_surface_probes as mod
+    monkeypatch.setattr(mod, "probe_batch_storage", slow_batch)
+    monkeypatch.setattr(mod, "probe_direct_streaming", ok_stream)
+    monkeypatch.setattr(mod, "probe_auth_sync", ok_auth)
+
+    # Tiny timeout forces the slow batch probe into the timeout sentinel.
+    snap = await run_surface_sweep(
+        provider=object(), model_id="m", ledger=led, timeout_s=0.05,
+    )
+    rec = snap[SurfaceKind.BATCH_STORAGE]
+    assert rec.verdict is SurfaceVerdict.TRANSPORT_DEGRADED
+    assert rec.diagnostic == "probe_timeout"
+
+
+async def test_run_surface_sweep_error_sentinel(monkeypatch, tmp_path):
+    led = SurfaceHealthLedger(path=tmp_path / "h.json")
+
+    async def boom_stream(provider, model_id):
+        raise RuntimeError("kaboom")
+
+    async def ok_batch(provider, model_id):
+        return SurfaceVerdict.HEALTHY, "", 0
+
+    async def ok_auth():
+        return SurfaceVerdict.HEALTHY, ""
+
+    import backend.core.ouroboros.governance.dw_surface_probes as mod
+    monkeypatch.setattr(mod, "probe_batch_storage", ok_batch)
+    monkeypatch.setattr(mod, "probe_direct_streaming", boom_stream)
+    monkeypatch.setattr(mod, "probe_auth_sync", ok_auth)
+
+    snap = await run_surface_sweep(provider=object(), model_id="m", ledger=led)
+    rec = snap[SurfaceKind.DIRECT_STREAMING]
+    assert rec.verdict is SurfaceVerdict.ERROR_OTHER
+    assert "RuntimeError" in rec.diagnostic

--- a/tests/governance/test_dw_transport_disambiguator.py
+++ b/tests/governance/test_dw_transport_disambiguator.py
@@ -4,6 +4,7 @@ from backend.core.ouroboros.governance.preflight_probe import ProbeOutcome
 from backend.core.ouroboros.governance.dw_transport_disambiguator import (
     FailureClass,
     classify_surface_failure,
+    disambiguate_and_recover,
 )
 
 
@@ -94,3 +95,77 @@ def test_done_before_content_beats_5xx_and_transport_substring():
     assert classify_surface_failure(
         _fail(msg="done_before_content stream_closed_early", status=500)
     ) is FailureClass.UPSTREAM
+
+
+# ---------------------------------------------------------------------------
+# Task 6 — disambiguate_and_recover + DisambiguationResult
+# ---------------------------------------------------------------------------
+
+
+class _Mgr:
+    def __init__(self):
+        self.flushes = 0
+
+    async def flush_transport_pool(self, provider, *, reason):
+        self.flushes += 1
+        return True
+
+
+async def test_upstream_done_before_content_does_NOT_flush():
+    # The whole point of Slice 39: upstream → flush-bypass.
+    mgr = _Mgr()
+    oc = ProbeOutcome(
+        model_id="m", success=False, status_code=0,
+        error_message="done_before_content",
+    )
+    res = await disambiguate_and_recover(
+        provider=object(), outcome=oc, lifecycle=mgr, raw_probe_fn=None,
+    )
+    assert res.failure_class is FailureClass.UPSTREAM
+    assert res.flushed is False
+    assert mgr.flushes == 0
+    assert res.surface_verdict_value == "upstream_degraded"
+
+
+async def test_transport_with_healthy_raw_probe_flushes():
+    mgr = _Mgr()
+    oc = ProbeOutcome(model_id="m", success=False, error_message="stream_closed_early")
+
+    async def raw_ok(provider, model_id):
+        return ProbeOutcome(model_id=model_id, success=True, status_code=200)
+
+    res = await disambiguate_and_recover(
+        provider=object(), outcome=oc, lifecycle=mgr, raw_probe_fn=raw_ok,
+    )
+    assert res.failure_class is FailureClass.TRANSPORT
+    assert res.raw_probe_succeeded is True
+    assert res.flushed is True
+    assert mgr.flushes == 1
+
+
+async def test_transport_with_failing_raw_probe_does_NOT_flush():
+    mgr = _Mgr()
+    oc = ProbeOutcome(model_id="m", success=False, error_message="stream_closed_early")
+
+    async def raw_fail(provider, model_id):
+        return ProbeOutcome(model_id=model_id, success=False, error_message="stream_closed_early")
+
+    res = await disambiguate_and_recover(
+        provider=object(), outcome=oc, lifecycle=mgr, raw_probe_fn=raw_fail,
+    )
+    assert res.failure_class is FailureClass.TRANSPORT
+    assert res.raw_probe_succeeded is False
+    assert res.flushed is False
+    assert mgr.flushes == 0
+
+
+async def test_none_failure_class_is_noop():
+    mgr = _Mgr()
+    ok = ProbeOutcome(model_id="m", success=True, status_code=200)
+    res = await disambiguate_and_recover(
+        provider=object(), outcome=ok, lifecycle=mgr, raw_probe_fn=None,
+    )
+    assert res.failure_class is FailureClass.NONE
+    assert res.flushed is False
+    assert res.surface_verdict_value == "healthy"
+    assert mgr.flushes == 0

--- a/tests/governance/test_dw_transport_disambiguator.py
+++ b/tests/governance/test_dw_transport_disambiguator.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.preflight_probe import ProbeOutcome
+from backend.core.ouroboros.governance.dw_transport_disambiguator import (
+    FailureClass,
+    classify_surface_failure,
+)
+
+
+def _fail(msg="", body="", status=0, timeout=False):
+    return ProbeOutcome(
+        model_id="m", success=False, status_code=status,
+        error_body=body, error_message=msg, timeout=timeout,
+    )
+
+
+def test_done_before_content_is_upstream():
+    # THE load-bearing case — clean stream, empty completion → upstream.
+    oc = _fail(msg="done_before_content", body="done_before_content")
+    assert classify_surface_failure(oc) is FailureClass.UPSTREAM
+
+
+def test_stream_closed_early_is_transport():
+    assert classify_surface_failure(_fail(msg="stream_closed_early")) is FailureClass.TRANSPORT
+
+
+def test_ttft_timeout_is_transport():
+    assert classify_surface_failure(_fail(msg="ttft_timeout", timeout=True)) is FailureClass.TRANSPORT
+
+
+def test_server_disconnected_is_transport():
+    assert classify_surface_failure(
+        _fail(msg="prober_raised:ServerDisconnectedError:peer closed")
+    ) is FailureClass.TRANSPORT
+
+
+def test_asyncio_timeout_is_transport():
+    assert classify_surface_failure(_fail(msg="asyncio.wait_for hit 10s", timeout=True)) is FailureClass.TRANSPORT
+
+
+def test_success_is_none():
+    ok = ProbeOutcome(model_id="m", success=True, status_code=200)
+    assert classify_surface_failure(ok) is FailureClass.NONE
+
+
+def test_5xx_body_without_stream_marker_is_upstream():
+    # HTTP 500 with a server body but no transport marker → upstream.
+    assert classify_surface_failure(
+        _fail(msg="status_500", body="Internal server error", status=500)
+    ) is FailureClass.UPSTREAM
+
+
+def test_transport_prefixed_aiohttp_exception_is_transport():
+    # Real dw_heavy_probe.py:790 shape for a mid-stream socket drop —
+    # keyed by the "transport:" prefix, not the exception name.
+    assert classify_surface_failure(
+        _fail(msg="transport:ServerTimeoutError:read timed out")
+    ) is FailureClass.TRANSPORT
+    assert classify_surface_failure(
+        _fail(msg="transport:ClientPayloadError:incomplete read")
+    ) is FailureClass.TRANSPORT
+    assert classify_surface_failure(
+        _fail(msg="transport:ClientOSError:broken pipe")
+    ) is FailureClass.TRANSPORT
+
+
+def test_run_preflight_outer_catch_is_transport():
+    # Real preflight_probe.py:428 shape (probe_raised, not prober_raised).
+    assert classify_surface_failure(
+        _fail(msg="probe_raised:ClientConnectorError:x")
+    ) is FailureClass.TRANSPORT
+
+
+def test_session_acquire_failed_is_transport():
+    # Real preflight_probe.py:727 adapter shape.
+    assert classify_surface_failure(
+        _fail(msg="session_acquire_failed:OSError:no route to host")
+    ) is FailureClass.TRANSPORT
+
+
+def test_none_fields_do_not_raise():
+    class _OC:
+        success = False
+        status_code = None
+        error_message = None
+        error_body = None
+
+    assert classify_surface_failure(_OC()) is FailureClass.UPSTREAM
+
+
+def test_done_before_content_beats_5xx_and_transport_substring():
+    # Upstream precedence: even with a transport substring + a 5xx status,
+    # done_before_content must win (never flush a healthy socket).
+    assert classify_surface_failure(
+        _fail(msg="done_before_content stream_closed_early", status=500)
+    ) is FailureClass.UPSTREAM


### PR DESCRIPTION
## Summary

Closes the "one-soak-per-blocker" discovery pattern (v25→v34) with an up-front, concurrent DW transport-health sweep that classifies failures by **protocol semantics** and routes recovery by failure **class**.

- **§49 PRD arc** — documents the v30→v34 transport evolution (RT-streaming 66.8s TTFT → Slice 36 force-BATCH → `/v1/files` RFC 7464 trailing-`\n` → Slice 38 → v34 `done_before_content`), crosses out closed items, reconciles the §48.13 slice-number drift, codifies the moving-blocker lesson.
- **4 new modules** (compose existing code, zero new transport path):
  - `dw_surface_health.py` — `SurfaceKind`/`SurfaceVerdict` taxonomy + `SurfaceHealthLedger` (mirrors `ModalityLedger` persistence pattern, per-*surface* dimension).
  - `dw_transport_disambiguator.py` — `classify_surface_failure` + `raw_http_bypass_probe` + `disambiguate_and_recover`.
  - `dw_client_lifecycle.py` — `ClientLifecycleManager` flush + cooldown.
  - `dw_surface_probes.py` — Surface A (`/v1/files` via `_upload_file`), B (streaming via `build_heavyprobe_adapter`), C (Aegis bearer) + concurrent `run_surface_sweep`.
- **2 minimal mods** — `DoublewordProvider.force_session_reset()` (composes the existing `_get_session` rebuild) + `preflight_probe.run_surface_health_sweep` orchestration + 6 FlagSpec seeds.

### The load-bearing invariant
`done_before_content` (HTTP 200, clean SSE, empty completion) = **upstream** → **flush is bypassed** (flushing a healthy socket + re-probing the same empty stream is a forbidden brute-force loop). Only **transport-class** faults (disconnect/reset/`transport:`/`stream_closed_early`/…) trigger the raw-bypass probe → hard-flush *iff* the fresh socket succeeds while the pooled one failed. **AST-pinned** so it can't regress.

### Honest scope
Master flag `JARVIS_DW_SURFACE_HEALTH_ENABLED` defaults **FALSE** (dormant until v35 graduation). This substrate detects/classifies the blocker in seconds instead of a 60-min soak burn and refuses to mask an upstream fault with client churn — it does **not** manufacture upstream DW capacity, so it makes no APPLY-bar claim (per `feedback_no_preresult_euphoria`).

## Test Plan
- [x] 38 Slice 39 tests pass (`test_dw_surface_health` / `test_dw_transport_disambiguator` / `test_dw_client_lifecycle` / `test_dw_surface_probes`)
- [x] Cross-arc regression spine green (preflight/heavy-probe/modality suites); no Slice 39 regressions
- [x] No import cycle; master flag default-FALSE verified
- [ ] **v35 graduation soak** (`JARVIS_DW_SURFACE_HEALTH_ENABLED=true`, $1.00/600s) — operator-gated; flip default→TRUE only after it classifies the live blocker with zero spurious flushes
- [ ] Note: 2 pre-existing `test_dw_heavy_probe::test_scheduler_*` failures exist on the base commit (unrelated to this PR; `dw_heavy_probe.py` untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a concurrent, multi-surface transport-health sweep that classifies DW failures by protocol semantics and routes recovery per class. Upstream `done_before_content` is now flush-bypassed; transport-class faults trigger a guarded pool flush only after a raw bypass probe confirms pool stagnation.

- **New Features**
  - `dw_surface_health`: per-surface taxonomy and persistent ledger.
  - `dw_surface_probes`: probes for `/v1/files`, SSE streaming, and auth; concurrent sweep with timeouts.
  - `dw_transport_disambiguator`: failure classification, raw HTTP bypass probe, and recovery logic.
  - `dw_client_lifecycle`: guarded `flush_transport_pool` with cooldown; composes provider.
  - `DoublewordProvider.force_session_reset()` to hard-flush the aiohttp pool safely.
  - Preflight entrypoint `run_surface_health_sweep()` gated by `JARVIS_DW_SURFACE_HEALTH_ENABLED` (default false).
  - Flags added: `JARVIS_DW_SURFACE_HEALTH_ENABLED`, `JARVIS_DW_TRANSPORT_FLUSH_ENABLED`, `JARVIS_DW_TRANSPORT_FLUSH_COOLDOWN_S`, `JARVIS_DW_SURFACE_PROBE_TIMEOUT_S`, `JARVIS_DW_RAW_BYPASS_PROBE_ENABLED`.
  - `scripts/ouroboros_v34_gatekick.py` for v34 pre-flight smoke testing.
  - §49 PRD arc updates documenting v30→v34 transport evolution and Slice 39 design.

- **Migration**
  - No behavior change by default; enable with `JARVIS_DW_SURFACE_HEALTH_ENABLED=true`.
  - Optional tuning: `JARVIS_DW_TRANSPORT_FLUSH_COOLDOWN_S` and `JARVIS_DW_SURFACE_PROBE_TIMEOUT_S`.
  - When enabled, upstream `done_before_content` will not flush the pool; transport faults may flush after a raw bypass probe confirms.

<sup>Written for commit 8de7ca17b8f617799f8529a92a016b24f4a84780. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/63661?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

