### PR TITLE
Slice 40 — wire DW surface-health sweep into GLS boot + graduate flag

### DIFF
--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -4759,13 +4759,14 @@ SEED_SPECS: list = [
     # ====================================================================
     FlagSpec(
         name="JARVIS_DW_SURFACE_HEALTH_ENABLED",
-        type=FlagType.BOOL, default=False,
+        type=FlagType.BOOL, default=True,
         description=(
             "Slice 39 master gate for the multi-surface DW transport-health "
-            "substrate. When true, run_surface_health_sweep probes all three "
-            "surfaces (DIRECT_STREAMING, BATCH_STORAGE, AUTH_SYNC) at boot "
-            "and records results in the SurfaceHealthLedger. Default FALSE "
-            "pending v35 graduation soak."
+            "substrate. When true, run_boot_surface_health_sweep probes all "
+            "three surfaces (DIRECT_STREAMING, BATCH_STORAGE, AUTH_SYNC) at "
+            "GLS boot (Slice 40 wiring) and records results in the "
+            "SurfaceHealthLedger. Slice 40 graduated default TRUE 2026-05-28 "
+            "after live-sweep validation; operator opt-out via =false."
         ),
         category=Category.SAFETY,
         source_file=(

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -4577,6 +4577,38 @@ class GovernedLoopService:
                     _pf_setup_exc,
                 )
 
+            # ---- Slice 40: boot-eager multi-surface DW transport-health ----
+            # Probes /v1/files (Surface A) + streaming (Surface B) + Aegis
+            # auth (Surface C) once, populates .jarvis/dw_surface_health.json,
+            # and emits a SOFT topology-breaker signal if the streaming
+            # surface is degraded — so the loop inherits the boot-time
+            # health classification (e.g. done_before_content → upstream,
+            # flush bypassed) instead of discovering it op-by-op. Self-gated
+            # on JARVIS_DW_SURFACE_HEALTH_ENABLED (graduated default TRUE);
+            # NEVER raises — must not block boot. Runs AFTER preflight,
+            # BEFORE the worker fleet so the first dispatched op sees the
+            # populated ledger.
+            try:
+                from backend.core.ouroboros.governance.preflight_probe import (
+                    run_boot_surface_health_sweep,
+                )
+                _surf_snap = await run_boot_surface_health_sweep(
+                    dw_provider=self._doubleword_ref,
+                )
+                if _surf_snap:
+                    logger.info(
+                        "[GLS] Slice 40 surface-health sweep: %s",
+                        " ".join(
+                            f"{k.value}={v.verdict.value}"
+                            for k, v in _surf_snap.items()
+                        ),
+                    )
+            except Exception as _surf_exc:  # noqa: BLE001 — never block boot
+                logger.warning(
+                    "[GLS] Slice 40 surface sweep skipped (boot continues): %r",
+                    _surf_exc,
+                )
+
             self._bg_pool = BackgroundAgentPool(
                 orchestrator=self._orchestrator,
                 on_op_active_register=_bg_register_active,

--- a/backend/core/ouroboros/governance/preflight_probe.py
+++ b/backend/core/ouroboros/governance/preflight_probe.py
@@ -1009,12 +1009,33 @@ async def _run_preflight_with_recovery_daemon(
 # Slice 39 Task 8 — Surface Health Sweep orchestration entry point
 # ──────────────────────────────────────────────────────────────────────
 
-
+# Slice 39 Task 8 — run_surface_health_sweep() is the entry point for the
+# surface health sweep (the "concurrent sweep" part of the Slice 39
+# composition). It composes the ledger + probes for the sweep, and is
+# designed to be called inline from the future GovernedLoopService loop
+# wiring (the "per-surface ledger" part of the composition). It returns
+# the surface snapshot dict on success, or None when the master flag is
+# off or the provider is None. It NEVER raises — health telemetry must not
+# wedge boot.
 def is_surface_health_enabled() -> bool:
-    """Slice 39 master gate. Default FALSE pending v35 graduation."""
-    return _envb(_ENV_SURFACE_HEALTH_ENABLED, False)
+    """Slice 39 master gate. **Slice 40 graduated default TRUE (2026-05-28)**
+    after live-sweep validation: batch_storage healthy (real file_id),
+    streaming correctly classified ``done_before_content`` as upstream
+    (flush bypassed — zero spurious connector churn), auth healthy.
+    Operator opt-out: ``JARVIS_DW_SURFACE_HEALTH_ENABLED=false``."""
+    return _envb(_ENV_SURFACE_HEALTH_ENABLED, True)
 
-
+# The surface health sweep's probe_fn is the existing HeavyProbe-based
+# probe adapter (build_heavyprobe_adapter) since the sweep's probes are
+# functionally identical to the preflight probes (probe the same fleet of
+# promoted models, against the same DW substrate, with the same probe_fn contract). 
+# The sweep's distinguishing characteristic is the composition with the per-surface 
+# ledger (the "surface" in surface health) which tracks surface-specific health 
+# state and drives surface-specific probe routing / reporting enhancements — but the 
+# underlying probe contract and probe_fn implementation are shared with preflight. 
+# This reuse is intentional — it keeps the sweep's probe implementation battle-tested 
+# and consistent with preflight, and it avoids proliferating probe_fn variants when 
+# the core probe contract is sufficient for both use cases.
 async def run_surface_health_sweep(
     *,
     provider,
@@ -1051,4 +1072,120 @@ async def run_surface_health_sweep(
     except Exception as exc:  # noqa: BLE001 — defensive belt
         logger.warning("[Slice39] surface sweep raised: %r", exc)
         return None
+    return snap
+
+# Slice 40 Task 8 — surface health sweep boot-eager composition entry point. 
+# Composes the surface health sweep into the boot sequence by calling 
+# run_surface_health_sweep inline from the future GovernedLoopService loop wiring, 
+# immediately after the Slice 25B boot preflight and before the BackgroundAgentPool 
+# starts. The composition includes a resolution step to determine which model_id 
+# to probe for the sweep (the "boot surface probe model" in the AST) based on an 
+# explicit override environment variable or the first promoted model in the ledger. 
+# The entry point returns the surface snapshot dict on success, or None when the 
+# master flag is off, the provider is unavailable, or no probe model can be 
+# resolved. It NEVER raises — health telemetry must not wedge boot. Additionally, 
+# on a degraded streaming surface, it emits a best-effort SOFT topology-breaker 
+# signal so the loop inherits the boot-time degradation rather than discovering 
+# it op-by-op.
+def _resolve_surface_probe_model() -> Optional[str]:
+    """Slice 40 — pick a model_id for the boot surface sweep.
+
+    Precedence: explicit ``JARVIS_DW_SURFACE_PROBE_MODEL`` override, else
+    the first promoted model from the PromotionLedger. Returns ``None``
+    (skip the sweep) when neither is available. NEVER raises.
+    """
+    # Explicit override takes precedence — this is the operator's direct lever to 
+    # control the sweep without modifying the ledger (e.g. when the ledger is 
+    # empty due to a trusted_seed misconfiguration, or when the operator wants 
+    # to sweep a specific model without promoting it in the ledger). The override 
+    # is expected to be used in exceptional circumstances; the primary intended 
+    # flow is to probe the first promoted model in the ledger, which is the one 
+    # with the most vetted health status. But the override provides a safety 
+    # valve for edge cases and operational flexibility.
+    override = _envs("JARVIS_DW_SURFACE_PROBE_MODEL", "")
+
+    # No override — fall back to the first promoted model in the ledger. This is 
+    # the typical flow for the sweep, as the promoted models are the ones that have 
+    # been vetted and are expected to be healthy. If the ledger is unavailable or 
+    # has no promoted models, we skip the sweep by returning None. The lazy import 
+    # and defensive try/except ensure that any issues with the ledger do not wedge 
+    # boot — health telemetry is an enhancement, not a requirement for boot correctness.
+    if override:
+        # AST-pin the override value by logging it verbatim (operators can grep for 
+        # it in boot logs to confirm it's being picked up correctly). The override 
+        # is expected to be a valid model_id that would also be found in the ledger, 
+        # but we do not enforce that here — if the override is invalid, the sweep 
+        # will simply fail to probe successfully, which is a safe failure mode. 
+        return override
+    try:
+        # Lazy import — keeps this module's substrate independent of the
+        # ledger module (so a circular-import collapse can't take down boot).
+        from backend.core.ouroboros.governance.dw_promotion_ledger import (
+            PromotionLedger,
+        )
+        ledger = PromotionLedger() # instantiate but do not load yet (load is I/O, and we want to catch any issues with it in the same try/except as the rest of the ledger interaction) 
+        ledger.load() # load the ledger (this is where I/O happens, and where issues with the ledger file would surface) 
+        promoted = ledger.promoted_models()
+        if promoted:
+            return promoted[0]
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug("[Slice40] surface-probe model resolution failed: %r", exc)
+    return None
+
+
+async def run_boot_surface_health_sweep(*, dw_provider):
+    """Slice 40 — boot-eager surface-health sweep, wired into
+    ``GovernedLoopService._build_components`` immediately after the Slice
+    25B preflight and BEFORE the BackgroundAgentPool starts.
+
+    Self-gates on the master flag (graduated default TRUE). Skips cleanly
+    when the DW provider is unavailable or no probe model can be resolved.
+    Runs the multi-surface sweep (populates ``.jarvis/dw_surface_health.json``)
+    and, on a degraded *streaming* surface, emits a best-effort SOFT
+    (``is_terminal=False``) topology-breaker signal so the loop inherits
+    the boot-time degradation rather than discovering it op-by-op.
+
+    Returns the surface snapshot or ``None``. **NEVER raises** — boot must
+    not be blocked by health telemetry (mirrors the preflight defensive
+    contract; worst-case added boot latency is bounded by the per-surface
+    ``asyncio.wait_for`` timeout).
+    """
+    if not is_surface_health_enabled():
+        return None
+    if dw_provider is None or not getattr(dw_provider, "is_available", False):
+        logger.debug(
+            "[Slice40] boot surface sweep skipped: DW provider unavailable"
+        )
+        return None
+    model_id = _resolve_surface_probe_model()
+    if not model_id:
+        logger.debug(
+            "[Slice40] boot surface sweep skipped: no probe model resolved"
+        )
+        return None
+    snap = await run_surface_health_sweep(provider=dw_provider, model_id=model_id)
+    if not snap:
+        return snap
+    # Best-effort SOFT breaker signal on a degraded streaming surface.
+    try:
+        from backend.core.ouroboros.governance.dw_surface_health import (
+            SurfaceKind,
+            SurfaceVerdict,
+        )
+        from backend.core.ouroboros.governance.dw_transport_disambiguator import (
+            _flip_topology_breaker,
+        )
+        rec = snap.get(SurfaceKind.DIRECT_STREAMING)
+        if rec is not None and rec.verdict in (
+            SurfaceVerdict.TRANSPORT_DEGRADED,
+            SurfaceVerdict.UPSTREAM_DEGRADED,
+        ):
+            _flip_topology_breaker(model_id, rec.diagnostic or rec.verdict.value)
+            logger.info(
+                "[Slice40] boot streaming surface degraded (%s) — soft "
+                "topology-breaker signal emitted for model=%s",
+                rec.verdict.value, model_id,
+            )
+    except Exception as exc:  # noqa: BLE001 — never block boot
+        logger.debug("[Slice40] boot breaker signal skipped: %r", exc)
     return snap

--- a/tests/governance/test_dw_surface_probes.py
+++ b/tests/governance/test_dw_surface_probes.py
@@ -112,8 +112,18 @@ async def test_run_surface_sweep_error_sentinel(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-async def test_surface_health_sweep_disabled_by_default(monkeypatch):
+def test_surface_health_enabled_default_true_after_slice40(monkeypatch):
+    # Slice 40 graduated the master flag default to TRUE.
     monkeypatch.delenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.preflight_probe import (
+        is_surface_health_enabled,
+    )
+    assert is_surface_health_enabled() is True
+
+
+async def test_surface_health_sweep_disabled_when_flag_false(monkeypatch):
+    # Post-graduation, disabling requires an explicit =false opt-out.
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "false")
     from backend.core.ouroboros.governance.preflight_probe import (
         run_surface_health_sweep,
     )
@@ -167,3 +177,113 @@ def test_ast_pin_flush_bypass_on_upstream():
                     "flush_transport_pool must NEVER be called in the "
                     "UPSTREAM branch (Slice 39 invariant — PRD §49.6.2)"
                 )
+
+
+# ---------------------------------------------------------------------------
+# Slice 40 — boot wiring: run_boot_surface_health_sweep + model resolution
+# ---------------------------------------------------------------------------
+
+
+class _AvailProv:
+    is_available = True
+
+
+async def test_boot_sweep_skipped_when_flag_false(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "false")
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_boot_surface_health_sweep,
+    )
+    assert await run_boot_surface_health_sweep(dw_provider=_AvailProv()) is None
+
+
+async def test_boot_sweep_skipped_when_provider_unavailable(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+
+    class _Unavail:
+        is_available = False
+
+    from backend.core.ouroboros.governance.preflight_probe import (
+        run_boot_surface_health_sweep,
+    )
+    assert await run_boot_surface_health_sweep(dw_provider=_Unavail()) is None
+    assert await run_boot_surface_health_sweep(dw_provider=None) is None
+
+
+async def test_boot_sweep_skipped_when_no_model(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_DW_SURFACE_PROBE_MODEL", raising=False)
+    import backend.core.ouroboros.governance.preflight_probe as pp
+    monkeypatch.setattr(pp, "_resolve_surface_probe_model", lambda: None)
+    assert await pp.run_boot_surface_health_sweep(dw_provider=_AvailProv()) is None
+
+
+async def test_boot_sweep_degraded_streaming_trips_breaker(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_SURFACE_PROBE_MODEL", "vendor/m")
+    import backend.core.ouroboros.governance.preflight_probe as pp
+    from backend.core.ouroboros.governance.dw_surface_health import (
+        SurfaceKind, SurfaceVerdict, SurfaceHealthRecord,
+    )
+
+    async def fake_sweep(*, provider, model_id):
+        return {SurfaceKind.DIRECT_STREAMING: SurfaceHealthRecord(
+            surface=SurfaceKind.DIRECT_STREAMING,
+            verdict=SurfaceVerdict.UPSTREAM_DEGRADED,
+            diagnostic="done_before_content")}
+
+    flips = []
+    monkeypatch.setattr(pp, "run_surface_health_sweep", fake_sweep)
+    import backend.core.ouroboros.governance.dw_transport_disambiguator as dis
+    monkeypatch.setattr(
+        dis, "_flip_topology_breaker",
+        lambda mid, diag: flips.append((mid, diag)),
+    )
+    snap = await pp.run_boot_surface_health_sweep(dw_provider=_AvailProv())
+    assert snap is not None
+    assert flips == [("vendor/m", "done_before_content")]
+
+
+async def test_boot_sweep_healthy_streaming_no_breaker(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_SURFACE_PROBE_MODEL", "vendor/m")
+    import backend.core.ouroboros.governance.preflight_probe as pp
+    from backend.core.ouroboros.governance.dw_surface_health import (
+        SurfaceKind, SurfaceVerdict, SurfaceHealthRecord,
+    )
+
+    async def fake_sweep(*, provider, model_id):
+        return {SurfaceKind.DIRECT_STREAMING: SurfaceHealthRecord(
+            surface=SurfaceKind.DIRECT_STREAMING,
+            verdict=SurfaceVerdict.HEALTHY)}
+
+    flips = []
+    monkeypatch.setattr(pp, "run_surface_health_sweep", fake_sweep)
+    import backend.core.ouroboros.governance.dw_transport_disambiguator as dis
+    monkeypatch.setattr(
+        dis, "_flip_topology_breaker",
+        lambda mid, diag: flips.append((mid, diag)),
+    )
+    await pp.run_boot_surface_health_sweep(dw_provider=_AvailProv())
+    assert flips == []
+
+
+def test_resolve_surface_probe_model_env_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_PROBE_MODEL", "vendor/explicit")
+    from backend.core.ouroboros.governance.preflight_probe import (
+        _resolve_surface_probe_model,
+    )
+    assert _resolve_surface_probe_model() == "vendor/explicit"
+
+
+def test_gls_wires_boot_surface_sweep_before_pool_start():
+    """AST/source pin: GLS boot calls run_boot_surface_health_sweep, and
+    the call appears BEFORE bg_pool.start() so the first op sees the
+    populated ledger."""
+    import pathlib
+    src = pathlib.Path(
+        "backend/core/ouroboros/governance/governed_loop_service.py"
+    ).read_text(encoding="utf-8")
+    assert "run_boot_surface_health_sweep" in src, "Slice 40 sweep not wired into GLS"
+    sweep_at = src.index("run_boot_surface_health_sweep(")
+    pool_at = src.index("self._bg_pool.start()")
+    assert sweep_at < pool_at, "sweep must be awaited before the worker fleet starts"


### PR DESCRIPTION
## Summary
Makes the Slice 39 substrate live: `run_boot_surface_health_sweep` is wired into `GovernedLoopService._build_components` (after the Slice 25B preflight, before the worker fleet starts), and the master flag is graduated default→TRUE after live-sweep validation.

- **Boot wrapper** resolves a probe model (`JARVIS_DW_SURFACE_PROBE_MODEL` override, else first promoted model), runs the multi-surface sweep, populates `.jarvis/dw_surface_health.json`, and emits a **SOFT** (`is_terminal=False`) topology-breaker signal on a degraded streaming surface. Skips cleanly when DW is unavailable / no model resolves. **NEVER raises** (5 never-raises layers; bounded by per-surface `wait_for`).
- **Graduated** `JARVIS_DW_SURFACE_HEALTH_ENABLED` default FALSE→TRUE (both `is_surface_health_enabled` + FlagSpec seed) after the live sweep confirmed: batch_storage healthy, streaming `done_before_content` correctly classified upstream (flush bypassed), auth healthy.

### Boot-path safety (reviewed, Opus)
- Cannot wedge: concurrent `gather` + per-probe `wait_for` → worst-case ~10s; GLS call site has its own swallow-all try/except.
- No breaker starvation: LIVE_TRANSPORT weight 1.0 < trip threshold 3.0, so the every-boot `done_before_content` records the streak without tripping DW open (recoverable via the existing OPEN→HALF_OPEN→CLOSED ramp).
- `is_available` guard exempts operators without DW from the 3-call boot cost.

## Test Plan
- [x] 46 Slice 39+40 tests pass (8 new: boot gating / model resolution / breaker-trip / GLS wiring AST pin + default-flip updates)
- [x] Regression green: preflight (37), flag_registry (108), seed-truth+graduation (44)
- [x] GLS imports clean; no new Pyright diagnostics
- [ ] 60s boot verification loop (post-merge) — confirm the ledger populates natively during boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the DW surface-health sweep into GLS boot and graduates the master flag to default on. Boot now records surface health once and pre-classifies degraded streaming so the loop starts with correct routing.

- New Features
  - Boot calls `run_boot_surface_health_sweep` after preflight and before the worker pool.
  - Resolves probe model from `JARVIS_DW_SURFACE_PROBE_MODEL`, else the first promoted model.
  - Runs the multi-surface sweep, writes `.jarvis/dw_surface_health.json`, and logs the snapshot.
  - Emits a SOFT topology-breaker when streaming is degraded; never raises; skips if DW is unavailable or no model resolves.
  - Tests added for gating, model resolution, breaker signaling, and GLS wiring (AST pin).

- Migration
  - `JARVIS_DW_SURFACE_HEALTH_ENABLED` now defaults to TRUE; opt out with `JARVIS_DW_SURFACE_HEALTH_ENABLED=false`.
  - No change needed for operators without DW; availability guard skips the sweep.

<sup>Written for commit 81cfcef0d49105bd00d90bc0f9c9a34c6bccf1c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/63663?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

