### PR TITLE
Slice 41 — batch-aware fleet eligibility + ledger-driven routing (root-cause: unblock dispatch)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -165,16 +165,51 @@ def _slice36_should_force_batch(context: Any) -> bool:
         ).strip().lower() in ("1", "true", "yes", "on")
         if not _claude_disabled:
             return False
-        # Master opt-out (default ON per operator authorization)
-        _raw = os.environ.get(_SLICE36_FORCE_BATCH_ENV, "1").strip().lower()
-        if _raw in ("0", "false", "no", "off"):
-            return False
         # Route gate — only STANDARD + COMPLEX get the batch path
         _route = (
             getattr(context, "provider_route", "") or ""
         ).strip().lower()
-        return _route in ("standard", "complex")
+        if _route not in ("standard", "complex"):
+            return False
+        # Slice 36 static opt-out (default ON per operator authorization).
+        _raw = os.environ.get(_SLICE36_FORCE_BATCH_ENV, "1").strip().lower()
+        _static_on = _raw not in ("0", "false", "no", "off")
+        # Slice 41 — ledger-driven failover. Even if the static opt-in is OFF,
+        # force batch when the surface-health ledger shows the streaming wire
+        # degraded but the batch lane healthy (don't fail closed / halt loops).
+        return _static_on or _slice41_ledger_force_batch()
     except Exception:  # noqa: BLE001 — defensive
+        return False
+
+
+def _slice41_ledger_force_batch() -> bool:
+    """Slice 41 — True iff the Slice 39/40 surface-health ledger shows the
+    DIRECT_STREAMING surface degraded AND BATCH_STORAGE healthy (gated on the
+    surface-health master flag). This is the autonomous, ledger-driven failover
+    trigger: when the real-time wire is dropping content upstream but batch
+    generation works, route standard/complex ops through the batch lane.
+    NEVER raises — returns False (legacy RT) on any error / flag-off."""
+    try:
+        from backend.core.ouroboros.governance.preflight_probe import (
+            is_surface_health_enabled,
+        )
+        if not is_surface_health_enabled():
+            return False
+        from backend.core.ouroboros.governance.dw_surface_health import (
+            SurfaceHealthLedger,
+            SurfaceKind,
+            SurfaceVerdict,
+        )
+        led = SurfaceHealthLedger()
+        stream = led.verdict_for(SurfaceKind.DIRECT_STREAMING)
+        batch = led.verdict_for(SurfaceKind.BATCH_STORAGE)
+        streaming_degraded = stream is not None and stream.verdict in (
+            SurfaceVerdict.TRANSPORT_DEGRADED,
+            SurfaceVerdict.UPSTREAM_DEGRADED,
+        )
+        batch_healthy = batch is not None and batch.verdict == SurfaceVerdict.HEALTHY
+        return streaming_degraded and batch_healthy
+    except Exception:  # noqa: BLE001 — defensive, fail to legacy RT
         return False
 
 # Pricing (March 2026)

--- a/backend/core/ouroboros/governance/preflight_probe.py
+++ b/backend/core/ouroboros/governance/preflight_probe.py
@@ -102,6 +102,11 @@ class PreflightVerdict(str, Enum):
     """Closed taxonomy — each probed model lands in exactly one bucket."""
 
     ACTIVE = "active"
+    # Slice 41 — streaming track degraded (done_before_content) BUT the
+    # batch_storage surface is healthy: the model is still usable via the
+    # batch lane, so it stays ELIGIBLE (counted as active) with a
+    # FORCE_BATCH routing modifier instead of being dropped from the fleet.
+    ACTIVE_BATCH_ONLY = "active_batch_only"
     DEMOTED_ENTITLEMENT = "demoted_entitlement"
     DEGRADED_5XX = "degraded_5xx"
     DEGRADED_TIMEOUT = "degraded_timeout"
@@ -159,9 +164,16 @@ class PreflightReport:
     degraded_5xx_count: int
     degraded_timeout_count: int
     error_other_count: int
+    # Slice 41 — subset of active_count that is ACTIVE_BATCH_ONLY (streaming
+    # degraded, kept eligible via the batch lane). Observability only;
+    # active_count already includes these so every fleet-empty / halt
+    # consumer treats them as eligible without further changes.
+    active_batch_only_count: int = 0
 
     @property
     def all_failed(self) -> bool:
+        # active_count includes ACTIVE_BATCH_ONLY, so a fleet with only
+        # batch-routable models is NOT "all failed".
         return self.active_count == 0 and len(self.results) > 0
 
     @property
@@ -171,6 +183,7 @@ class PreflightReport:
     def summary_line(self) -> str:
         return (
             f"active={self.active_count} "
+            f"active_batch_only={self.active_batch_only_count} "
             f"demoted_entitlement={self.demoted_entitlement_count} "
             f"degraded_5xx={self.degraded_5xx_count} "
             f"degraded_timeout={self.degraded_timeout_count} "
@@ -339,6 +352,73 @@ def _classify_outcome(outcome: ProbeOutcome) -> Tuple[
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Slice 41 — batch-aware fleet eligibility helpers
+# ──────────────────────────────────────────────────────────────────────
+
+# Slice 41 adds a nuance to the classification + routing: when the batch surface is healthy, 
+# a streaming-only degradation pattern (``done_before_content``) is recoverable via the 
+# batch lane, so we keep the model eligible with a FORCE_BATCH routing modifier instead of 
+# demoting it from the fleet. These helpers implement that logic without muddying the core 
+# classification or the main orchestration flow. 
+def _is_streaming_only_degradation(outcome: "ProbeOutcome") -> bool:
+    """Pure — True iff this probe failure is the streaming-transport-specific
+    empty-completion (``done_before_content``) that the BATCH lane bypasses.
+
+    This is the ONLY failure shape eligible for batch-failover: it means the
+    request reached DW, the model executed, but the RT-streaming wire emitted
+    zero content tokens before ``[DONE]``. Batch execution of the same request
+    completes with real content (empirically confirmed). Timeouts / 5xx /
+    entitlement / connection faults are NOT streaming-only — they are not
+    upgraded (a 5xx or auth fault would break batch too)."""
+    # Defensive: the presence of "done_before_content" in either the error_message or 
+    # error_body is the heuristic for this classification, so we check both fields just 
+    # in case the probe substrate shifts where it puts this info in the future. We also 
+    # guard against missing fields and non-string types just in case of unexpected probe 
+    # outcomes, since this logic is purely an eligibility enhancement and should fail 
+    # closed (not upgrade) if we can't confidently identify the streaming-only pattern.
+    if getattr(outcome, "success", False):
+        # Success outcomes are not degradations at all, so they can't be streaming-only 
+        # degradations. This is a quick check to avoid false positives in the string 
+        # matching below if the probe substrate returns an unexpected success outcome 
+        # with empty fields.
+        return False
+    # The "done_before_content" pattern has been observed in the error_message field, 
+    # but we check both fields to be safe. We also convert to lowercase to make the 
+    # check case-insensitive, just in case of future changes in the probe substrate's 
+    # formatting.
+    blob = (
+        f"{getattr(outcome, 'error_message', '') or ''} "
+        f"{getattr(outcome, 'error_body', '') or ''}"
+    ).lower()
+    # The presence of "done_before_content" is the heuristic for identifying this specific 
+    # degradation pattern. If we see it, we consider this a streaming-only degradation that 
+    # is eligible for batch failover. If we don't see it, we treat this as a regular 
+    # degradation that is not eligible for batch failover. This logic is based on empirical 
+    # observations of the probe outcomes and the known behavior of the DW surfaces.
+    return "done_before_content" in blob
+
+
+def _batch_surface_healthy() -> bool:
+    """Read the Slice 39/40 surface-health ledger; True iff batch_storage is
+    HEALTHY. Gated on the master flag. Reads ``.jarvis/dw_surface_health.json``
+    (or the env-overridden path). NEVER raises — returns False on any error so
+    a missing/unreadable ledger fails CLOSED (no spurious batch-failover)."""
+    if not is_surface_health_enabled():
+        return False
+    try:
+        from backend.core.ouroboros.governance.dw_surface_health import (
+            SurfaceHealthLedger,
+            SurfaceKind,
+            SurfaceVerdict,
+        )
+        rec = SurfaceHealthLedger().verdict_for(SurfaceKind.BATCH_STORAGE)
+        return rec is not None and rec.verdict == SurfaceVerdict.HEALTHY
+    except Exception as exc:  # noqa: BLE001 — fail closed
+        logger.debug("[Slice41] batch surface health read failed: %r", exc)
+        return False
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Public entry point
 # ──────────────────────────────────────────────────────────────────────
 
@@ -437,13 +517,31 @@ async def run_preflight(
     # Classify + route side-effects
     results: List[ModelPreflightResult] = []
     active = 0
+    active_batch_only = 0
     dem_ent = 0
     deg_5xx = 0
     deg_timeout = 0
     err_other = 0
 
+    # Slice 41 — read the batch-surface health ONCE per cycle (not per model).
+    # When batch_storage is healthy, a streaming-only degradation
+    # (done_before_content) is recoverable via the batch lane → keep the
+    # model eligible instead of emptying the fleet.
+    batch_failover_ok = _batch_surface_healthy()
+
     for outcome in outcomes:
         verdict, marker, diag = _classify_outcome(outcome)
+
+        # Slice 41 — batch-aware fleet eligibility upgrade.
+        if (
+            verdict is PreflightVerdict.DEGRADED_5XX
+            and batch_failover_ok
+            and _is_streaming_only_degradation(outcome)
+        ):
+            verdict = PreflightVerdict.ACTIVE_BATCH_ONLY
+            marker = "FORCE_BATCH"
+            diag = f"streaming_degraded_batch_healthy: {diag}"
+
         results.append(ModelPreflightResult(
             model_id=outcome.model_id,
             verdict=verdict,
@@ -458,6 +556,19 @@ async def run_preflight(
             logger.info(
                 "[Preflight] model=%s ACTIVE latency=%dms",
                 outcome.model_id, outcome.latency_ms,
+            )
+            continue
+
+        if verdict is PreflightVerdict.ACTIVE_BATCH_ONLY:
+            # Counts as active (fleet not empty) — usable via the batch lane.
+            # NO sentinel failure report: the model is healthy enough to serve.
+            active += 1
+            active_batch_only += 1
+            logger.info(
+                "[Preflight] model=%s ACTIVE_BATCH_ONLY — streaming degraded "
+                "(done_before_content) but batch_storage healthy; kept "
+                "eligible with FORCE_BATCH routing modifier",
+                outcome.model_id,
             )
             continue
 
@@ -514,6 +625,7 @@ async def run_preflight(
         degraded_5xx_count=deg_5xx,
         degraded_timeout_count=deg_timeout,
         error_other_count=err_other,
+        active_batch_only_count=active_batch_only,
     )
 
     logger.info("[Preflight] complete: %s", report.summary_line())

--- a/tests/governance/test_dw_heavy_probe.py
+++ b/tests/governance/test_dw_heavy_probe.py
@@ -681,7 +681,7 @@ class _StubProber:
         self.probed_ids: List[str] = []
 
     async def probe(self, *, session, model_id, base_url, api_key,
-                    observer=None):
+                    observer=None, parameter_count_b=None, **_kw):
         self.probed_ids.append(model_id)
         return HeavyProbeResult(
             model_id=model_id,

--- a/tests/governance/test_slice25_preflight_probe.py
+++ b/tests/governance/test_slice25_preflight_probe.py
@@ -51,10 +51,12 @@ LEDGER_FILE = (
 # ──────────────────────────────────────────────────────────────────────
 
 
-def test_ast_pin_preflight_verdict_taxonomy_closed_at_5() -> None:
-    """PreflightVerdict MUST be exactly the 5 documented values.
-    Adding a 6th drift kind requires updating this pin + the
-    classifier + side-effect router — that friction is intentional."""
+def test_ast_pin_preflight_verdict_taxonomy_closed_at_6() -> None:
+    """PreflightVerdict MUST be exactly the 6 documented values.
+    Slice 41 added ACTIVE_BATCH_ONLY (streaming degraded + batch healthy →
+    keep eligible, route via batch). Adding a 7th drift kind requires
+    updating this pin + the classifier + side-effect router — that friction
+    is intentional."""
     src = PF_FILE.read_text()
     tree = ast.parse(src, filename=str(PF_FILE))
     found = []
@@ -67,6 +69,7 @@ def test_ast_pin_preflight_verdict_taxonomy_closed_at_5() -> None:
                             found.append(target.id)
     expected = {
         "ACTIVE",
+        "ACTIVE_BATCH_ONLY",
         "DEMOTED_ENTITLEMENT",
         "DEGRADED_5XX",
         "DEGRADED_TIMEOUT",

--- a/tests/governance/test_slice41_batch_aware_fleet.py
+++ b/tests/governance/test_slice41_batch_aware_fleet.py
@@ -1,0 +1,236 @@
+"""Slice 41 — batch-aware fleet eligibility + ledger-driven routing.
+
+A model whose STREAMING probe returns ``done_before_content`` (transport-
+specific empty generation) must stay ELIGIBLE — verdict ACTIVE_BATCH_ONLY,
+counted as active, FORCE_BATCH marker, NOT reported as a sentinel failure —
+*when the surface ledger shows batch_storage healthy* (batch generation was
+empirically confirmed working while streaming is degraded). This prevents the
+streaming-based preflight from emptying the fleet and halting dispatch.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.core.ouroboros.governance.preflight_probe import (
+    ProbeOutcome,
+    PreflightVerdict,
+    _is_streaming_only_degradation,
+    _batch_surface_healthy,
+    run_preflight,
+)
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger,
+    SurfaceKind,
+    SurfaceVerdict,
+)
+
+
+def _done_before_content(model_id="vendor/m"):
+    # Mirrors the real adapter shape for a streaming empty-completion.
+    return ProbeOutcome(
+        model_id=model_id, success=False, status_code=0,
+        error_message="done_before_content",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_streaming_only_degradation (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_done_before_content_is_streaming_only():
+    assert _is_streaming_only_degradation(_done_before_content()) is True
+
+
+def test_timeout_is_not_streaming_only():
+    assert _is_streaming_only_degradation(
+        ProbeOutcome(model_id="m", success=False, timeout=True,
+                     error_message="ttft_timeout")
+    ) is False
+
+
+def test_5xx_is_not_streaming_only():
+    assert _is_streaming_only_degradation(
+        ProbeOutcome(model_id="m", success=False, status_code=503,
+                     error_message="status_503", error_body="Service Unavailable")
+    ) is False
+
+
+def test_success_is_not_streaming_only():
+    assert _is_streaming_only_degradation(
+        ProbeOutcome(model_id="m", success=True, status_code=200)
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# _batch_surface_healthy (ledger read; gated; never raises)
+# ---------------------------------------------------------------------------
+
+
+def test_batch_surface_healthy_true(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    p = tmp_path / "h.json"
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(p))
+    SurfaceHealthLedger(path=p).record(
+        SurfaceKind.BATCH_STORAGE, SurfaceVerdict.HEALTHY,
+    )
+    assert _batch_surface_healthy() is True
+
+
+def test_batch_surface_unhealthy_false(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    p = tmp_path / "h.json"
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(p))
+    SurfaceHealthLedger(path=p).record(
+        SurfaceKind.BATCH_STORAGE, SurfaceVerdict.UPSTREAM_DEGRADED,
+    )
+    assert _batch_surface_healthy() is False
+
+
+def test_batch_surface_missing_ledger_false(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(tmp_path / "none.json"))
+    assert _batch_surface_healthy() is False
+
+
+# ---------------------------------------------------------------------------
+# run_preflight batch-aware upgrade
+# ---------------------------------------------------------------------------
+
+
+class _SentinelSpy:
+    def __init__(self):
+        self.failures = []
+
+    def report_failure(self, model_id, source, detail="", *,
+                       status_code=None, response_body="", is_terminal=False):
+        self.failures.append(model_id)
+
+
+async def _probe_done(model_id):
+    return _done_before_content(model_id)
+
+
+async def test_done_before_content_upgrades_to_active_batch_only(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    p = tmp_path / "h.json"
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(p))
+    SurfaceHealthLedger(path=p).record(
+        SurfaceKind.BATCH_STORAGE, SurfaceVerdict.HEALTHY,
+    )
+    spy = _SentinelSpy()
+    report = await run_preflight(
+        model_ids=("vendor/m",), probe_fn=_probe_done,
+        sentinel=spy, halt_on_all_fail=False,
+    )
+    res = report.results[0]
+    assert res.verdict is PreflightVerdict.ACTIVE_BATCH_ONLY
+    assert res.entitlement_marker == "FORCE_BATCH"
+    # Counts as active → fleet NOT empty → no halt.
+    assert report.active_count == 1
+    assert report.active_batch_only_count == 1
+    assert report.all_failed is False
+    # NOT reported as a failure — the model is usable via batch.
+    assert spy.failures == []
+
+
+async def test_done_before_content_stays_degraded_when_batch_unhealthy(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    p = tmp_path / "h.json"
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(p))
+    SurfaceHealthLedger(path=p).record(
+        SurfaceKind.BATCH_STORAGE, SurfaceVerdict.UPSTREAM_DEGRADED,
+    )
+    spy = _SentinelSpy()
+    report = await run_preflight(
+        model_ids=("vendor/m",), probe_fn=_probe_done,
+        sentinel=spy, halt_on_all_fail=False,
+    )
+    assert report.results[0].verdict is PreflightVerdict.DEGRADED_5XX
+    assert report.active_count == 0
+    assert report.all_failed is True
+    assert spy.failures == ["vendor/m"]
+
+
+async def test_done_before_content_stays_degraded_when_flag_off(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "false")
+    p = tmp_path / "h.json"
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(p))
+    SurfaceHealthLedger(path=p).record(
+        SurfaceKind.BATCH_STORAGE, SurfaceVerdict.HEALTHY,
+    )
+    report = await run_preflight(
+        model_ids=("vendor/m",), probe_fn=_probe_done,
+        sentinel=_SentinelSpy(), halt_on_all_fail=False,
+    )
+    assert report.results[0].verdict is PreflightVerdict.DEGRADED_5XX
+    assert report.all_failed is True
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — ledger-driven batch routing (_slice36_should_force_batch)
+# ---------------------------------------------------------------------------
+
+from backend.core.ouroboros.governance.doubleword_provider import (  # noqa: E402
+    _slice36_should_force_batch,
+    _slice41_ledger_force_batch,
+)
+
+
+class _Ctx:
+    def __init__(self, route):
+        self.provider_route = route
+
+
+def _seed_ledger(monkeypatch, tmp_path, *, stream, batch):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "true")
+    p = tmp_path / "h.json"
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(p))
+    led = SurfaceHealthLedger(path=p)
+    led.record(SurfaceKind.DIRECT_STREAMING, stream)
+    led.record(SurfaceKind.BATCH_STORAGE, batch)
+
+
+def test_ledger_force_batch_true_on_degraded_stream_healthy_batch(monkeypatch, tmp_path):
+    _seed_ledger(monkeypatch, tmp_path,
+                 stream=SurfaceVerdict.UPSTREAM_DEGRADED, batch=SurfaceVerdict.HEALTHY)
+    assert _slice41_ledger_force_batch() is True
+
+
+def test_ledger_force_batch_false_when_batch_unhealthy(monkeypatch, tmp_path):
+    _seed_ledger(monkeypatch, tmp_path,
+                 stream=SurfaceVerdict.UPSTREAM_DEGRADED, batch=SurfaceVerdict.UPSTREAM_DEGRADED)
+    assert _slice41_ledger_force_batch() is False
+
+
+def test_ledger_force_batch_false_when_stream_healthy(monkeypatch, tmp_path):
+    _seed_ledger(monkeypatch, tmp_path,
+                 stream=SurfaceVerdict.HEALTHY, batch=SurfaceVerdict.HEALTHY)
+    assert _slice41_ledger_force_batch() is False
+
+
+def test_ledger_force_batch_false_when_flag_off(monkeypatch, tmp_path):
+    _seed_ledger(monkeypatch, tmp_path,
+                 stream=SurfaceVerdict.UPSTREAM_DEGRADED, batch=SurfaceVerdict.HEALTHY)
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_ENABLED", "false")
+    assert _slice41_ledger_force_batch() is False
+
+
+def test_force_batch_ledger_overrides_static_optout(monkeypatch, tmp_path):
+    # Static Slice 36 opt-out OFF, but the ledger shows streaming degraded +
+    # batch healthy → Slice 41 still forces batch (don't fail closed).
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX", "0")
+    _seed_ledger(monkeypatch, tmp_path,
+                 stream=SurfaceVerdict.UPSTREAM_DEGRADED, batch=SurfaceVerdict.HEALTHY)
+    assert _slice36_should_force_batch(_Ctx("standard")) is True
+    assert _slice36_should_force_batch(_Ctx("complex")) is True
+    # Non-standard/complex route never forces batch.
+    assert _slice36_should_force_batch(_Ctx("immediate")) is False
+
+
+def test_force_batch_requires_claude_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "false")
+    _seed_ledger(monkeypatch, tmp_path,
+                 stream=SurfaceVerdict.UPSTREAM_DEGRADED, batch=SurfaceVerdict.HEALTHY)
+    assert _slice36_should_force_batch(_Ctx("standard")) is False


### PR DESCRIPTION
## Summary
Root-cause fix for the v25→v34 0-APPLY wedge. An end-to-end probe confirmed **batch generation works** (16 tokens, 18s) on the same model whose streaming probe returns `done_before_content` (0 tokens) — so the degradation is transport-specific, and the streaming-based preflight was emptying the fleet before the working batch lane was ever tried.

- **Phase 1 — batch-aware preflight eligibility:** new `PreflightVerdict.ACTIVE_BATCH_ONLY`. A `done_before_content` streaming result, when the surface ledger shows `batch_storage` healthy, keeps the model **eligible** (counts into `active_count` → fleet not empty → no halt) with a `FORCE_BATCH` marker, and is **not** reported as a sentinel failure. `_classify_outcome` stays pure; ledger read once/cycle; `_batch_surface_healthy` fails closed.
- **Phase 2 — ledger-driven routing:** `_slice36_should_force_batch` gains `_slice41_ledger_force_batch` — forces batch on standard/complex (Claude-disabled) when streaming degraded + batch healthy, even if the static opt-in is off (don't fail closed).
- **Phase 3 — scheduler test isolation:** the 2 pre-existing `test_scheduler_*` failures were a stub signature drift (`_StubProber.probe` missing `parameter_count_b`); fixed in-test only. **100% green.**

### Reviewed (Opus)
- Masking risk bounded: the preflight verdict/marker does NOT drive dispatch selection — its only effect is preventing the all-failed halt; routing re-derives from the live ledger. A genuinely-dead model fails downstream via normal cascade/demotion, no black hole.
- Self-correcting (live ledger reads), no import cycle, consistent with Slice 40 (which writes the ledger; Slice 41 reads it).

## Test Plan
- [x] 16 Slice 41 tests + 142 cross-arc regression green; verdict-taxonomy AST pin updated 5→6
- [x] `test_dw_heavy_probe.py` now 37/37 (was 35/37 — the 2 legacy flakes fixed)
- [ ] v36 capability run (post-merge): confirm fleet stays open, ops dispatch, generations route through batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents fleet halts from streaming-only failures by keeping models eligible and auto-routing them through batch when the ledger says batch is healthy. This unblocks dispatch by avoiding fleet-empty preflight results while streaming is degraded.

- New Features
  - Added `PreflightVerdict.ACTIVE_BATCH_ONLY`: counts as active, sets `FORCE_BATCH`, not reported as a failure.
  - Upgrades `done_before_content` to `ACTIVE_BATCH_ONLY` when the surface-health ledger reports `batch_storage` healthy; ledger read once per cycle via `_batch_surface_healthy` and `_is_streaming_only_degradation`.
  - Ledger-driven routing: `_slice36_should_force_batch` now consults `_slice41_ledger_force_batch` to force batch on `standard`/`complex` when streaming is degraded and batch is healthy, even if the static opt-in is off (gated by the surface-health flag).

- Bug Fixes
  - Fixed scheduler test stub signature drift to isolate tests from real fleet state; all tests green and verdict taxonomy pin updated 5→6.

<sup>Written for commit 5176100530e6175e76ebf8a9d5aecaf3bc5cdfae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/63747?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

