### PR TITLE
Slice 42 — Aegis full-body capped read (fix multi-segment multipart truncation; preserve DoS cap)

### DIFF
--- a/backend/core/ouroboros/aegis/forwarding.py
+++ b/backend/core/ouroboros/aegis/forwarding.py
@@ -60,6 +60,10 @@ from backend.core.ouroboros.aegis.pricing import (
     TokenPrice,
     cost_per_token_usd,
 )
+from backend.core.ouroboros.aegis.request_body import (
+    BodyTooLarge,
+    read_body_capped,
+)
 from backend.core.ouroboros.aegis.upstream_registry import (
     AuthScheme,
     UpstreamEndpoint,
@@ -267,7 +271,7 @@ import enum  # noqa: E402 — local to the module bottom is fine
 
 
 class ForwardOutcome(str, enum.Enum):
-    """Closed 6-value taxonomy of how a forwarding attempt resolved."""
+    """Closed 7-value taxonomy of how a forwarding attempt resolved."""
 
     SUCCESS = "success"
     LEASE_INVALID = "lease_invalid"
@@ -275,6 +279,8 @@ class ForwardOutcome(str, enum.Enum):
     UPSTREAM_ERROR_STATUS = "upstream_error_status"
     BUDGET_GUILLOTINE = "budget_guillotine"
     CLIENT_DISCONNECTED = "client_disconnected"
+    # Slice 42 — inbound body exceeded the DoS cap; rejected with HTTP 413.
+    REQUEST_TOO_LARGE = "request_too_large"
 
 
 @dataclass(frozen=True)
@@ -394,9 +400,25 @@ async def forward_request(
             detail=str(exc),
         )
 
-    # 2. Request body --------------------------------------------------------
+    # 2. Request body (FULL read, cap-enforced) ------------------------------
+    # Slice 42 — read the ENTIRE body via read_body_capped. The prior single
+    # ``request.content.read(cap)`` truncated multi-TCP-segment bodies (the
+    # same StreamReader.read(n) bug as passthrough). For JSON requests a
+    # truncated body then failed json.loads → body_parse_failed; for any
+    # large legitimate request body it silently corrupted the upstream call.
+    # DoS cap preserved: over-cap → HTTP 413, no unbounded buffering.
     try:
-        body_bytes = await request.content.read(_max_request_body_bytes())
+        body_bytes = await read_body_capped(request, _max_request_body_bytes())
+    except BodyTooLarge as exc:
+        resp = web.json_response({
+            "ok": False, "error": "request_body_too_large", "detail": str(exc),
+        }, status=413)
+        return resp, ForwardResult(
+            outcome=ForwardOutcome.REQUEST_TOO_LARGE,
+            usage_input_tokens=0, usage_output_tokens=0,
+            actual_cost_usd=0.0, upstream_status=None,
+            detail=str(exc),
+        )
     except (asyncio.CancelledError, aiohttp.ClientError):
         raise
     except Exception as exc:  # noqa: BLE001

--- a/backend/core/ouroboros/aegis/passthrough.py
+++ b/backend/core/ouroboros/aegis/passthrough.py
@@ -56,6 +56,10 @@ from backend.core.ouroboros.aegis.lease import (
     TokenVerdictKind,
     validate_session_token,
 )
+from backend.core.ouroboros.aegis.request_body import (
+    BodyTooLarge,
+    read_body_capped,
+)
 from backend.core.ouroboros.aegis.upstream_registry import (
     AuthScheme,
     EndpointKind,
@@ -86,13 +90,16 @@ _INBOUND_HEADERS_TO_STRIP: Tuple[str, ...] = (
 
 
 class PassthroughOutcome(str, enum.Enum):
-    """Closed 5-value taxonomy of passthrough outcomes."""
+    """Closed 6-value taxonomy of passthrough outcomes."""
 
     SUCCESS = "success"
     AUTH_MISSING = "auth_missing"
     AUTH_INVALID = "auth_invalid"
     UPSTREAM_UNREACHABLE = "upstream_unreachable"
     CLIENT_DISCONNECTED = "client_disconnected"
+    # Slice 42 — inbound body exceeded the DoS cap; rejected with HTTP 413
+    # (distinct from CLIENT_DISCONNECTED: we refuse it, the client didn't drop).
+    REQUEST_TOO_LARGE = "request_too_large"
 
 
 @dataclass(frozen=True)
@@ -227,9 +234,27 @@ async def forward_passthrough(
             ),
         )
 
-    # --- 3. Request body (cap-enforced; passthrough never parses) ----------
+    # --- 3. Request body (FULL read, cap-enforced; passthrough never parses) -
+    # Slice 42 — read the ENTIRE body via read_body_capped (chunk-accumulation
+    # loop). The prior single ``request.content.read(cap)`` truncated bodies
+    # that arrived across multiple TCP segments (e.g. an 18 KB multipart batch
+    # upload), forwarding a broken multipart upstream → DW HTTP 400. The DoS
+    # cap is preserved: over-cap → HTTP 413, no unbounded buffering.
     try:
-        body_bytes = await request.content.read(_max_request_body_bytes())
+        body_bytes = await read_body_capped(request, _max_request_body_bytes())
+    except BodyTooLarge as exc:
+        return (
+            web.json_response(
+                {"ok": False, "error": "request_body_too_large",
+                 "detail": str(exc)}, status=413,
+            ),
+            PassthroughResult(
+                outcome=PassthroughOutcome.REQUEST_TOO_LARGE,
+                upstream_status=None,
+                response_bytes=0,
+                detail=str(exc),
+            ),
+        )
     except (asyncio.CancelledError, aiohttp.ClientError):
         raise
     except Exception as exc:  # noqa: BLE001

--- a/backend/core/ouroboros/aegis/request_body.py
+++ b/backend/core/ouroboros/aegis/request_body.py
@@ -1,0 +1,62 @@
+"""Aegis-side full-body reader with DoS cap (Slice 42).
+
+Fixes a latent multi-segment truncation bug at the two proxy body-read sites
+(``passthrough.py`` + ``forwarding.py``). Both used::
+
+    body_bytes = await request.content.read(cap)
+
+``aiohttp.StreamReader.read(n)`` returns *at most* ``n`` bytes "but at least
+one byte" — for a body that arrives across multiple TCP segments (e.g. an
+18 KB multipart/form-data batch upload) the single call returns ONLY the first
+buffered segment and the rest is silently dropped. The proxy then forwarded a
+truncated multipart body upstream, which DW's parser rejected with HTTP 400
+("Multipart parsing failed"). Small bodies (one segment) slipped through,
+masking the bug.
+
+``read_body_capped`` reads the FULL body via a chunk-accumulation loop and
+preserves the DoS protection: if the accumulated length exceeds ``cap`` it
+raises :class:`BodyTooLarge` (caller → HTTP 413) WITHOUT buffering past the
+cap. It never silently truncates.
+"""
+from __future__ import annotations
+
+# Per-iteration read unit. Large enough to drain quickly, bounded so a single
+# read() can't be coerced into an unbounded allocation. The cap is enforced
+# across the accumulation, independent of this unit.
+_READ_CHUNK_BYTES = 64 * 1024
+
+
+class BodyTooLarge(Exception):
+    """Raised when the accumulated request body exceeds the DoS cap.
+
+    Carries ``cap`` so the caller can emit a precise HTTP 413 detail.
+    """
+
+    def __init__(self, cap: int) -> None:
+        self.cap = cap
+        super().__init__(f"request body exceeds cap of {cap} bytes")
+
+
+async def read_body_capped(request, cap: int) -> bytes:
+    """Read the ENTIRE request body, enforcing ``cap``.
+
+    Loops ``request.content.read(_READ_CHUNK_BYTES)`` until EOF (empty read),
+    accumulating chunks. Raises :class:`BodyTooLarge` the moment the running
+    total exceeds ``cap`` — bounding buffered memory to ``cap + one chunk``
+    so an exhaustion attack cannot force unbounded allocation. Returns the
+    full body bytes on success.
+
+    Does NOT swallow transport errors — ``asyncio.CancelledError`` /
+    ``aiohttp.ClientError`` propagate to the caller's existing handler.
+    """
+    chunks = []
+    total = 0
+    while True:
+        chunk = await request.content.read(_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > cap:
+            raise BodyTooLarge(cap)
+        chunks.append(chunk)
+    return b"".join(chunks)

--- a/tests/aegis/test_passthrough.py
+++ b/tests/aegis/test_passthrough.py
@@ -20,6 +20,7 @@ Verify:
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
 from pathlib import Path
@@ -79,6 +80,10 @@ def _make_dw_passthrough_stub(recorder: _Recorder) -> web.Application:
             ),
             "body_len": len(body),
             "body_preview": body[:64],  # for byte-identity checks
+            # Slice 42 — full-body hash so large multi-segment uploads can be
+            # asserted byte-identical (catches mid-body truncation, not just
+            # length/front).
+            "body_sha256": __import__("hashlib").sha256(body).hexdigest(),
         }
 
     async def files_handler(request: web.Request) -> web.Response:
@@ -201,6 +206,52 @@ async def test_files_multipart_credential_injected(stack):
     assert rec["body_len"] == len(multipart_body)
     assert rec["body_preview"] == multipart_body[:64]
     assert "multipart/form-data" in rec["content_type"]
+
+
+def _large_multipart(total_bytes: int) -> bytes:
+    """Build a valid multipart/form-data body of ~total_bytes (field 'file'
+    padded + 'purpose'), large enough to span multiple loopback TCP segments."""
+    head = (
+        b"--BOUNDARY\r\n"
+        b'Content-Disposition: form-data; name="file"; filename="batch.jsonl"\r\n'
+        b"Content-Type: application/jsonl\r\n\r\n"
+    )
+    tail = (
+        b"\n\r\n--BOUNDARY\r\n"
+        b'Content-Disposition: form-data; name="purpose"\r\n\r\n'
+        b"batch\r\n--BOUNDARY--\r\n"
+    )
+    pad = total_bytes - len(head) - len(tail)
+    file_line = b'{"custom_id":"req1","content":"' + (b"X" * max(pad - 40, 0)) + b'"}'
+    return head + file_line + tail
+
+
+@pytest.mark.parametrize("size", [18 * 1024, 64 * 1024])
+async def test_files_large_multipart_forwarded_byte_identical(stack, size):
+    # Slice 42 regression: an 18 KB / 64 KB multipart upload arrives over the
+    # loopback socket in MULTIPLE TCP segments. Pre-fix, Aegis' single
+    # request.content.read(cap) returned only the first segment → the upstream
+    # stub received a TRUNCATED body (body_len < len) → DW 400 in production.
+    # Post-fix, read_body_capped reads the full body → byte-identical forward.
+    client, recorder, _ = stack
+    session = await _session_token(client)
+    body = _large_multipart(size)
+    resp = await client.post(
+        "/v1/files",
+        headers={
+            "Authorization": f"Bearer {session}",
+            "Content-Type": "multipart/form-data; boundary=BOUNDARY",
+        },
+        data=body,
+    )
+    assert resp.status == 200
+    assert len(recorder.received) == 1
+    rec = recorder.received[0]
+    # FULL byte-identity at the upstream — proves no multi-segment truncation.
+    assert rec["body_len"] == len(body), (
+        f"truncated forward: upstream saw {rec['body_len']} of {len(body)} bytes"
+    )
+    assert rec["body_sha256"] == hashlib.sha256(body).hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/aegis/test_request_body.py
+++ b/tests/aegis/test_request_body.py
@@ -1,0 +1,85 @@
+"""Slice 42 — Aegis full-body capped reader (multi-segment truncation fix)."""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.aegis.request_body import (
+    BodyTooLarge,
+    read_body_capped,
+)
+
+
+class _FragmentedContent:
+    """Simulates aiohttp StreamReader delivering a body across multiple TCP
+    segments — read(n) returns only the NEXT fragment (≤ n), not the whole
+    body, which is exactly the semantics that truncated the old single-read."""
+
+    def __init__(self, body: bytes, fragment_size: int):
+        self._body = body
+        self._frag = fragment_size
+        self._pos = 0
+
+    async def read(self, n: int) -> bytes:
+        if self._pos >= len(self._body):
+            return b""
+        end = min(self._pos + min(self._frag, n), len(self._body))
+        chunk = self._body[self._pos:end]
+        self._pos = end
+        return chunk
+
+
+class _FakeReq:
+    def __init__(self, content):
+        self.content = content
+
+
+async def test_reads_full_body_across_fragments():
+    # 18 KB body delivered in 4 KB segments — the bug's exact shape.
+    body = b"A" * 18432
+    req = _FakeReq(_FragmentedContent(body, fragment_size=4096))
+    out = await read_body_capped(req, cap=4 * 1024 * 1024)
+    assert out == body  # byte-identical, FULL body (not just the first 4 KB)
+    assert len(out) == 18432
+
+
+async def test_old_single_read_would_truncate():
+    # Documents the bug: a single read(huge) returns only the first segment.
+    body = b"A" * 18432
+    content = _FragmentedContent(body, fragment_size=4096)
+    first = await content.read(4 * 1024 * 1024)
+    assert len(first) == 4096 and first != body  # truncated → broken multipart
+
+
+async def test_64kb_multi_fragment_byte_identical():
+    body = bytes((i % 256) for i in range(65536))  # varied bytes, not just 'A'
+    req = _FakeReq(_FragmentedContent(body, fragment_size=1500))  # ~MTU-sized
+    out = await read_body_capped(req, cap=4 * 1024 * 1024)
+    assert out == body
+
+
+async def test_small_single_segment_body():
+    body = b'{"x": 1}\n'
+    req = _FakeReq(_FragmentedContent(body, fragment_size=64 * 1024))
+    assert await read_body_capped(req, cap=4 * 1024 * 1024) == body
+
+
+async def test_empty_body():
+    req = _FakeReq(_FragmentedContent(b"", fragment_size=4096))
+    assert await read_body_capped(req, cap=4 * 1024 * 1024) == b""
+
+
+async def test_raises_too_large_over_cap():
+    cap = 8192
+    body = b"A" * (cap + 1)
+    req = _FakeReq(_FragmentedContent(body, fragment_size=4096))
+    with pytest.raises(BodyTooLarge) as ei:
+        await read_body_capped(req, cap=cap)
+    assert ei.value.cap == cap
+
+
+async def test_exactly_at_cap_succeeds():
+    cap = 8192
+    body = b"A" * cap
+    req = _FakeReq(_FragmentedContent(body, fragment_size=4096))
+    out = await read_body_capped(req, cap=cap)
+    assert len(out) == cap


### PR DESCRIPTION
## Summary
Root-cause fix for the v36 blocker — **in the Aegis zero-trust daemon, not `doubleword_provider`** (a live A/B probe proved direct uploads are 201 at every size; the runbook's original `_upload_file` target was falsified).

Both Aegis proxy body-read sites used `await request.content.read(cap)`. aiohttp `StreamReader.read(n)` returns at most the **first buffered TCP segment**, so a multi-segment body (18 KB multipart batch upload) was **silently truncated** → Aegis forwarded a broken multipart upstream → DW HTTP 400 "Multipart parsing failed." Small bodies (one segment) passed, masking it.

- **`aegis/request_body.py`** (new): `read_body_capped()` — chunk-accumulation loop reads the **full** body; enforces the 4 MB DoS cap by raising `BodyTooLarge` → **HTTP 413**, rejecting after one over-cap chunk (bounded memory; the old `read(cap)` silently truncated instead of 413-ing).
- Wired at `passthrough.py:232` (multipart `/v1/files` — the one that bit us) + `forwarding.py:399` (JSON path — same latent bug). New `REQUEST_TOO_LARGE` outcome on both enums.

### Security (Opus-reviewed)
- **DoS cap bounded-memory verified**: a 1 GB stream with an 8 KB cap is rejected after one 64 KB chunk — cannot OOM the daemon.
- **Behavior isolation**: only request-body reading changed — auth, credential injection, header stripping, response streaming untouched.

## Test Plan
- [x] 7 socket-free unit tests (fragmented multi-chunk reader, byte-identity, 413 over-cap, exactly-at-cap)
- [x] Extended passthrough byte-identity matrix to **18 KB + 64 KB** with full `body_sha256` (old code truncates these)
- [x] Full `tests/aegis/` suite 242 passed; no taxonomy-pin breaks; no new Pyright diagnostics
- [ ] v37 capability run (post-merge): confirm the 18 KB real-op upload clears Aegis → batch generates → first APPLY

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slice 42: Fix Aegis truncating multi-segment request bodies by reading the full body with a cap. Keeps the 4 MB DoS limit and returns HTTP 413 when exceeded.

- **Bug Fixes**
  - Add `aegis/request_body.read_body_capped()` (chunked read with `BodyTooLarge` on overflow).
  - Replace `request.content.read(cap)` with `read_body_capped` in `passthrough.py` and `forwarding.py`.
  - Add `REQUEST_TOO_LARGE` to `PassthroughOutcome` and `ForwardOutcome`; return 413 JSON on over-cap.
  - Tests cover multi-segment uploads (18 KB, 64 KB) for byte-identity and 413/at-cap cases.

<sup>Written for commit 5cd9d60a740c286107e3dba1ac87ced9334b677a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/63863?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

