### PR TITLE
Slice 43 — async batch timeout alignment (stop severing the batch poll at the 30s RT reflex cap)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4137,8 +4137,20 @@ class CandidateGenerator:
             # deterministically when the sentinel walker passes a heavy
             # model_id. Empty model_id from legacy callers → legacy 30s
             # cap path (byte-identical to pre-Slice-28).
+            # Slice 43 — if this op will force-batch (Slice 36/41), compute a
+            # batch-appropriate budget so the outer wait_for doesn't sever the
+            # async batch poll at the 30s RT reflex cap. The force-batch
+            # decision is owned by the provider; we consult the same pure
+            # predicate. NEVER raises → legacy budget on any failure.
+            try:
+                from backend.core.ouroboros.governance.doubleword_provider import (
+                    _slice36_should_force_batch,
+                )
+                _force_batch = _slice36_should_force_batch(context)
+            except Exception:  # noqa: BLE001 — defensive, legacy budget
+                _force_batch = False
             primary_budget = self._compute_primary_budget(
-                remaining, model_id=model_id,
+                remaining, model_id=model_id, force_batch=_force_batch,
             )
             # Slice 34 Phase 2 — dispatch profiler (default OFF; zero
             # overhead when disabled). Records the sem-wait + budget
@@ -5578,6 +5590,7 @@ class CandidateGenerator:
         total_s: float,
         *,
         model_id: str = "",
+        force_batch: bool = False,
     ) -> float:
         """Deterministic Tier 1 primary budget with fallback reserve + Tier 3 cap.
 
@@ -5617,6 +5630,22 @@ class CandidateGenerator:
         """
         if total_s <= 0:
             return 0.0
+
+        # Slice 43 — Async Batch Timeout Alignment.
+        # When the op will be dispatched through the BATCH lane (Slice 36/41
+        # FORCE_BATCH), the provider's internal poll_and_retrieve legitimately
+        # runs for minutes — the batch_future_registry waits up to
+        # _DW_MAX_WAIT_S (3600s). Wrapping that in the 30s RT reflex cap
+        # (_PRIMARY_MAX_TIMEOUT_S) severs the async batch mid-flight (v37
+        # bt-2026-05-28-235234: batch 7b7a7b52 submitted then abandoned at
+        # 30s). Give batch ops a batch-appropriate budget instead, capped by
+        # remaining session time. force_batch implies Claude is disabled
+        # (Slice 36 precondition) → no fallback to reserve for, so the batch
+        # gets the full remaining runway up to the batch cap.
+        if force_batch:
+            batch_cap = _envf_or_default("JARVIS_DW_BATCH_TIMEOUT_S", 300.0)
+            return max(min(total_s, batch_cap), 0.0)
+
         fb_reserve = min(_FALLBACK_MIN_RESERVE_S, total_s * 0.35)
 
         # Slice 28 Phase 2 — adaptive Tier 3 cap for heavy models

--- a/tests/governance/test_slice43_batch_timeout.py
+++ b/tests/governance/test_slice43_batch_timeout.py
@@ -1,0 +1,88 @@
+"""Slice 43 — Async batch timeout alignment.
+
+FORCE_BATCH ops must NOT be severed by the 30s RT reflex cap
+(_PRIMARY_MAX_TIMEOUT_S): the provider's internal poll_and_retrieve runs for
+minutes (the registry waits up to _DW_MAX_WAIT_S=3600). _compute_primary_budget
+gains a force_batch branch returning a batch-appropriate budget. RT path is
+byte-identical. Phase 2 (terminal-state failover) is already implemented in
+_adaptive_poll_batch — pinned here so it can't regress.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+from backend.core.ouroboros.governance.candidate_generator import (
+    CandidateGenerator,
+)
+
+_budget = CandidateGenerator._compute_primary_budget
+_LIGHT = "Qwen/Qwen3.5-35B-A3B-FP8"
+
+
+def test_force_batch_uses_remaining_under_cap(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_BATCH_TIMEOUT_S", raising=False)
+    # remaining (250) < default batch cap (300) → use remaining.
+    assert _budget(250.0, model_id=_LIGHT, force_batch=True) == 250.0
+
+
+def test_force_batch_caps_at_batch_timeout(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_BATCH_TIMEOUT_S", raising=False)
+    # remaining (500) > default batch cap (300) → cap at 300.
+    assert _budget(500.0, model_id=_LIGHT, force_batch=True) == 300.0
+
+
+def test_force_batch_env_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_BATCH_TIMEOUT_S", "120")
+    assert _budget(500.0, force_batch=True) == 120.0
+
+
+def test_force_batch_far_exceeds_30s_reflex_cap(monkeypatch):
+    # The whole point: a 35B (non-heavy) batch op gets >> 30s now.
+    monkeypatch.delenv("JARVIS_DW_BATCH_TIMEOUT_S", raising=False)
+    assert _budget(300.0, model_id=_LIGHT, force_batch=True) >= 200.0
+
+
+def test_rt_path_unchanged_light_model(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_BATCH_TIMEOUT_S", raising=False)
+    # force_batch=False → legacy 30s reflex cap (byte-identical pre-Slice-43).
+    assert _budget(250.0, model_id=_LIGHT, force_batch=False) == 30.0
+
+
+def test_rt_path_default_is_not_force_batch(monkeypatch):
+    # Default (no force_batch kwarg) must remain the RT reflex path.
+    monkeypatch.delenv("JARVIS_DW_BATCH_TIMEOUT_S", raising=False)
+    assert _budget(250.0, model_id=_LIGHT) == 30.0
+
+
+def test_force_batch_zero_remaining():
+    assert _budget(0.0, force_batch=True) == 0.0
+
+
+def test_phase2_pin_adaptive_poll_terminal_returns_none():
+    """Phase 2 already-satisfied pin: _adaptive_poll_batch breaks on
+    failed/expired/cancelled and returns None (clean failover, no hang)."""
+    src = pathlib.Path(
+        "backend/core/ouroboros/governance/doubleword_provider.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    fn = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "_adaptive_poll_batch"
+    )
+    dump = ast.dump(fn)
+    # The terminal-state comparison must be present...
+    assert "failed" in dump and "expired" in dump and "cancelled" in dump, (
+        "_adaptive_poll_batch must handle terminal batch states"
+    )
+    # ...and the terminal branch must contain a `return None` (failover).
+    terminal_ifs = [
+        node for node in ast.walk(fn)
+        if isinstance(node, ast.If) and "expired" in ast.dump(node.test)
+    ]
+    assert terminal_ifs, "terminal-state branch not found"
+    assert any(
+        isinstance(s, ast.Return)
+        and (s.value is None or (isinstance(s.value, ast.Constant) and s.value.value is None))
+        for blk in terminal_ifs for s in ast.walk(blk)
+    ), "terminal-state branch must return None for clean failover"


### PR DESCRIPTION
## Summary
v37 proved Slice 42 worked (18 KB/33 KB uploads cleared Aegis, batch `7b7a7b52` created+submitted async) — but the op **severed at the 30 s `_PRIMARY_MAX_TIMEOUT_S` RT reflex cap** while `batch_future_registry` waits up to `_DW_MAX_WAIT_S=3600 s`, abandoning the in-flight batch.

- **Phase 1 (fix):** `_compute_primary_budget` gains a `force_batch` branch → `min(remaining, JARVIS_DW_BATCH_TIMEOUT_S=300)`, bypassing the 30 s reflex cap **and** the fallback reserve (force-batch requires `JARVIS_PROVIDER_CLAUDE_DISABLED=true` → no fallback to reserve for). Wired at the GENERATE call site via the **same** `_slice36_should_force_batch(context)` the provider uses internally (lazy import, fail-safe → legacy budget). **RT path byte-identical** (Slice 28 tests green).
- **Phase 2 (already satisfied):** `_adaptive_poll_batch` already breaks on `failed`/`expired`/`cancelled` → `return None` (clean failover) — pinned with an AST regression test rather than duplicated.

### Reviewed (Opus)
- **Alignment sound:** cg + provider call the same pure predicate on the same `context` → budget matches the transport actually taken.
- **Fallback bypass safe:** Claude-disabled precondition ⟹ no fallback exists.
- **Benign residual (follow-up, not a blocker):** the PLAN primary path also severs batch at 30 s, but PLAN failures degrade gracefully (advisory, not the candidate-producing path); v37's wedge was GENERATE.

## Test Plan
- [x] 8 Slice 43 tests + 77 cross-arc regression (incl. Slice 28 adaptive-budget = RT byte-identical)
- [ ] v38 capability run (post-merge): confirm the 33 KB batch is awaited to completion → **first retrieved patch / APPLY**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns async batch timeouts with provider behavior so batch polls aren’t cut off by the 30s RT cap. Adds a batch-aware budget path and wires it to the provider’s force-batch decision while keeping the RT path unchanged.

- **Bug Fixes**
  - Added `force_batch` to `_compute_primary_budget`; when true, use `min(remaining, JARVIS_DW_BATCH_TIMEOUT_S=300)` and skip the fallback reserve.
  - At the primary call site, consult the provider’s `_slice36_should_force_batch(context)` (lazy import; falls back to legacy budget on failure).
  - RT behavior remains byte-identical to prior releases.
  - Tests: added Slice 43 cases for budget cap/override and an AST pin to ensure `_adaptive_poll_batch` returns `None` on `failed/expired/cancelled`.

<sup>Written for commit f0231081b4670ae2bb10150a7cac6c01957e92cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/63983?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

