### PR TITLE
Slice 44 — reap auto-soak worktrees (base-independent) + exclude .worktrees from Oracle indexing

### DIFF
--- a/backend/core/ouroboros/governance/worktree_manager.py
+++ b/backend/core/ouroboros/governance/worktree_manager.py
@@ -106,6 +106,41 @@ def _parse_worktree_porcelain(text: str) -> "list[dict[str, str]]":
     return entries
 
 
+# Slice 44 — campaign-debris worktree prefixes reaped at boot, in addition to
+# the L3 isolation ``unit-`` prefix. ``ouroboros__auto__bt-*`` are auto-soak
+# worktrees (full repo checkouts) that the original reaper (``unit-`` only)
+# never swept, so they accumulated to 492k files / 13GB and starved the loop.
+# Env-tunable (comma-separated) so the set stays dynamic with no hardcoding.
+# NOTE the slash form ``ouroboros/auto/bt-`` is FIRST and load-bearing: the
+# auto-soak worktree's git BRANCH is ``ouroboros/auto/bt-<session>`` (slashes),
+# while its on-disk DIR is ``ouroboros__auto__bt-<session>`` (slashes→``__``).
+# ``git worktree list --porcelain`` is repo-global, so matching the branch form
+# reaps the debris via ``branch_matches`` regardless of which ``worktree_base``
+# the boot WorktreeManager was constructed with (the prod base differs from the
+# repo-root ``.worktrees`` where the debris actually lives). The ``__`` dir form
+# + ``soak-`` cover the unregistered-on-disk-dir path under this manager's base.
+_DEFAULT_REAP_EXTRA_PREFIXES = (
+    "ouroboros/auto/bt-", "ouroboros__auto__bt-", "soak-",
+)
+
+
+def _resolve_reap_prefixes(primary: str) -> "tuple[str, ...]":
+    """Return the deduped, order-preserving prefix array the boot reaper
+    matches against: the caller's ``primary`` prefix first, then the
+    campaign-debris extras (``JARVIS_WORKTREE_REAP_PREFIXES`` override, else
+    the defaults). Empty / whitespace entries are dropped. NEVER raises."""
+    raw = os.environ.get("JARVIS_WORKTREE_REAP_PREFIXES", "").strip()
+    if raw:
+        extras = tuple(p.strip() for p in raw.split(",") if p.strip())
+    else:
+        extras = _DEFAULT_REAP_EXTRA_PREFIXES
+    out: list = []
+    for p in (primary, *extras):
+        if p and p not in out:
+            out.append(p)
+    return tuple(out)
+
+
 class WorktreeManager:
     """Manages git worktree creation and cleanup for subagent isolation.
 
@@ -341,6 +376,16 @@ class WorktreeManager:
         a second call on the same clean repo returns 0.
         """
         reaped: Set[str] = set()
+        # Slice 44 — match against a multi-prefix array (legacy "unit-" PLUS
+        # campaign-debris prefixes ouroboros__auto__bt- / soak-, env-tunable).
+        # These auto-soak worktrees (full repo checkouts) were never reaped
+        # before — 62 of them accumulated to 492k files / 13GB, which Oracle's
+        # _find_python_files indexer recursively walked (its EXCLUDE_PATTERNS
+        # lacked .worktrees), holding the GIL and starving the asyncio loop
+        # (v38/v39 SidecarProfiler: oracle scan_dir + 51s thread.join wedge).
+        # (The file-watch guard already excluded .worktrees at the scheduling
+        # layer — Oracle was the scanner.)
+        prefixes = _resolve_reap_prefixes(branch_prefix)
 
         porcelain = await self._run_git_capture(["worktree", "list", "--porcelain"])
         for entry in _parse_worktree_porcelain(porcelain):
@@ -359,8 +404,8 @@ class WorktreeManager:
                 lives_under_base = wt_path.parent.resolve() == base_resolved
             except OSError:
                 lives_under_base = False
-            name_matches = wt_path.name.startswith(branch_prefix)
-            branch_matches = branch_short.startswith(branch_prefix)
+            name_matches = any(wt_path.name.startswith(p) for p in prefixes)
+            branch_matches = any(branch_short.startswith(p) for p in prefixes)
             if not (branch_matches or (lives_under_base and name_matches)):
                 continue
 
@@ -383,7 +428,7 @@ class WorktreeManager:
             for child in self._worktree_base.iterdir():
                 if not child.is_dir():
                     continue
-                if not child.name.startswith(branch_prefix):
+                if not any(child.name.startswith(p) for p in prefixes):
                     continue
                 if str(child) in reaped:
                     continue
@@ -400,13 +445,14 @@ class WorktreeManager:
                         child, exc,
                     )
 
-        branches = await self._run_git_capture(
-            ["for-each-ref", "--format=%(refname:short)", f"refs/heads/{branch_prefix}*"]
-        )
-        for name in branches.splitlines():
-            name = name.strip()
-            if name.startswith(branch_prefix):
-                await self._git_delete_branch(name)
+        for _p in prefixes:
+            branches = await self._run_git_capture(
+                ["for-each-ref", "--format=%(refname:short)", f"refs/heads/{_p}*"]
+            )
+            for name in branches.splitlines():
+                name = name.strip()
+                if name.startswith(_p):
+                    await self._git_delete_branch(name)
 
         await self._run_git_capture(["worktree", "prune"])
 

--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -175,6 +175,12 @@ class OracleConfig:
         "*.egg-info",
         "build",
         "dist",
+        # Slice 44 — never index worktree checkouts (each is a full repo
+        # copy → 62 of them = 492k duplicate .py files; the recursive
+        # scan_dir walk held the GIL and starved the asyncio loop) or the
+        # session/telemetry tree.
+        ".worktrees",
+        ".ouroboros",
     ]
 
     # File types to index

--- a/tests/governance/test_slice44_worktree_reaper.py
+++ b/tests/governance/test_slice44_worktree_reaper.py
@@ -1,0 +1,151 @@
+"""Slice 44 — watchdog/index exclusion + dynamic reaper coverage.
+
+Root cause (v38/v39 SidecarProfiler): 62 orphaned ouroboros__auto__bt-* worktrees
+(492k files / 13GB full-repo checkouts) were never reaped (reaper only swept
+unit-*) and Oracle's _find_python_files indexed them (EXCLUDE_PATTERNS lacked
+.worktrees) → recursive scan_dir held the GIL → asyncio loop starvation +
+51s shutdown join. Fixes: (1) reaper matches a multi-prefix array; (2) Oracle
+excludes .worktrees + .ouroboros.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from backend.core.ouroboros.governance.worktree_manager import (
+    WorktreeManager,
+    _resolve_reap_prefixes,
+    _DEFAULT_REAP_EXTRA_PREFIXES,
+)
+from backend.core.ouroboros.oracle import OracleConfig
+
+
+async def _init_git_repo(path: Path) -> None:
+    for cmd in (
+        ["git", "-C", str(path), "init"],
+        ["git", "-C", str(path), "config", "user.email", "t@t.com"],
+        ["git", "-C", str(path), "config", "user.name", "T"],
+        ["git", "-C", str(path), "commit", "--allow-empty", "-m", "init"],
+    ):
+        p = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        await p.wait()
+
+
+async def _git_worktree_add(repo: Path, branch: str, wt_dir: Path) -> None:
+    p = await asyncio.create_subprocess_exec(
+        "git", "-C", str(repo), "worktree", "add", "-b", branch, str(wt_dir),
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+    await p.wait()
+
+
+# --- reaper prefix resolution ---------------------------------------------
+
+
+def test_default_includes_primary_and_campaign_extras(monkeypatch):
+    monkeypatch.delenv("JARVIS_WORKTREE_REAP_PREFIXES", raising=False)
+    out = _resolve_reap_prefixes("unit-")
+    assert out[0] == "unit-"  # primary first
+    # BOTH forms: branch (slash) — load-bearing for base-independent reaping —
+    # and the on-disk dir (__) form.
+    assert "ouroboros/auto/bt-" in out
+    assert "ouroboros__auto__bt-" in out
+    assert "soak-" in out
+
+
+def test_env_override_replaces_extras(monkeypatch):
+    monkeypatch.setenv("JARVIS_WORKTREE_REAP_PREFIXES", "foo-, bar- ,")
+    out = _resolve_reap_prefixes("unit-")
+    assert out == ("unit-", "foo-", "bar-")  # whitespace/empty dropped
+
+
+def test_primary_not_duplicated(monkeypatch):
+    monkeypatch.setenv("JARVIS_WORKTREE_REAP_PREFIXES", "unit-,ouroboros__auto__bt-")
+    out = _resolve_reap_prefixes("unit-")
+    assert out.count("unit-") == 1
+
+
+def test_never_raises_on_blank_primary(monkeypatch):
+    monkeypatch.delenv("JARVIS_WORKTREE_REAP_PREFIXES", raising=False)
+    out = _resolve_reap_prefixes("")  # blank primary dropped, extras remain
+    assert "ouroboros__auto__bt-" in out and "" not in out
+
+
+def test_default_extras_constant_shape():
+    assert "ouroboros__auto__bt-" in _DEFAULT_REAP_EXTRA_PREFIXES
+
+
+# --- reaper prefix MATCHING (the dir-name logic the reaper applies) --------
+
+
+def _matches(name: str, prefixes) -> bool:
+    return any(name.startswith(p) for p in prefixes)
+
+
+def test_auto_soak_worktree_dir_now_matches(monkeypatch):
+    monkeypatch.delenv("JARVIS_WORKTREE_REAP_PREFIXES", raising=False)
+    pfx = _resolve_reap_prefixes("unit-")
+    assert _matches("ouroboros__auto__bt-2026-05-24-053214", pfx) is True
+    assert _matches("unit-abc123", pfx) is True  # legacy still works
+    # real feature worktrees are NOT reaped
+    assert _matches("feat-ouroboros-gap-fixes-tier3", pfx) is False
+
+
+# --- Oracle indexing exclusion --------------------------------------------
+
+
+def test_oracle_excludes_worktrees_and_ouroboros():
+    assert ".worktrees" in OracleConfig.EXCLUDE_PATTERNS
+    assert ".ouroboros" in OracleConfig.EXCLUDE_PATTERNS
+
+
+def _oracle_should_exclude(path_str: str) -> bool:
+    # Mirrors oracle._find_python_files.should_exclude (substring match).
+    return any(p in path_str for p in OracleConfig.EXCLUDE_PATTERNS)
+
+
+def test_oracle_skips_worktree_paths_keeps_source():
+    assert _oracle_should_exclude("/repo/.worktrees/ouroboros__auto__bt-x/backend/a.py") is True
+    assert _oracle_should_exclude("/repo/.ouroboros/sessions/bt-x/y.py") is True
+    # genuine source still indexed
+    assert _oracle_should_exclude("/repo/backend/core/ouroboros/oracle.py") is False
+
+
+# --- END-TO-END reap (the Critical-bug regression: slash branch / base) ----
+
+
+async def test_reap_orphans_removes_auto_soak_slash_branch_worktree(tmp_path, monkeypatch):
+    """The real debris shape: branch ``ouroboros/auto/bt-*`` (slashes), dir
+    ``ouroboros__auto__bt-*`` under .worktrees. Must be reaped via the
+    repo-global porcelain branch_matches — independent of worktree_base."""
+    monkeypatch.delenv("JARVIS_WORKTREE_REAP_PREFIXES", raising=False)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    await _init_git_repo(repo)
+    base = repo / ".worktrees"
+    base.mkdir()
+    wt_dir = base / "ouroboros__auto__bt-2026-05-24-053214"
+    await _git_worktree_add(repo, "ouroboros/auto/bt-2026-05-24-053214", wt_dir)
+    assert wt_dir.exists(), "setup: worktree should exist"
+
+    mgr = WorktreeManager(repo_root=repo, worktree_base=base)
+    reaped = await mgr.reap_orphans()  # default prefixes incl. ouroboros/auto/bt-
+    assert reaped >= 1, "auto-soak worktree must be reaped"
+    assert not wt_dir.exists(), "worktree dir must be removed"
+
+
+async def test_reap_orphans_preserves_real_feature_worktree(tmp_path, monkeypatch):
+    """A genuine feature worktree (branch feat/...) must NEVER be reaped."""
+    monkeypatch.delenv("JARVIS_WORKTREE_REAP_PREFIXES", raising=False)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    await _init_git_repo(repo)
+    base = repo / ".worktrees"
+    base.mkdir()
+    real = base / "feat-real-work"
+    await _git_worktree_add(repo, "feat/real-work", real)
+    assert real.exists()
+
+    mgr = WorktreeManager(repo_root=repo, worktree_base=base)
+    await mgr.reap_orphans()
+    assert real.exists(), "real feature worktree must be preserved"


### PR DESCRIPTION
## Summary
The v38/v39 loop-starvation kill, root-caused via the SidecarProfiler stuck-frame stack (`oracle.py scan_dir` + 51 s `thread.join`). Eliminated 4 wrong suspects first: `commit_ratios` (already async), branch count (cleanup didn't fix it), the batch wait (freeze is at boot), and `fs_event_bridge` (its `FileWatchGuard` already excludes `.worktrees` at scheduling). **Real cause:** 62 orphaned `ouroboros/auto/bt-*` worktrees (492 k files / 13 GB full-repo checkouts) that the reaper never swept (matched only `unit-`) **and** Oracle indexed (`EXCLUDE_PATTERNS` lacked `.worktrees`) → recursive `_find_python_files` walk held the GIL.

- **Fix 1 — reaper coverage:** `reap_orphans` matches a multi-prefix array (`_resolve_reap_prefixes`, env-tunable `JARVIS_WORKTREE_REAP_PREFIXES`). **Critical detail (caught in review):** the debris's git *branch* is `ouroboros/auto/bt-*` (slashes) while its *dir* is `ouroboros__auto__bt-*` (`__`), and the production boot reaper's `worktree_base` differs from `<repo>/.worktrees`. So the load-bearing prefix is the **slash branch form** `ouroboros/auto/bt-` — it reaps via the repo-global `git worktree list` porcelain `branch_matches`, **base-independent.** Signature byte-compatible; real worktrees (`feat/*`) never match.
- **Fix 2 — Oracle:** added `.worktrees` + `.ouroboros` to `OracleConfig.EXCLUDE_PATTERNS` (the actual scanner in the stack).
- **Not touched:** `fs_event_bridge` (verified already excludes `.worktrees` via `FileWatchGuard` default).

## Test Plan
- [x] 10 Slice 44 tests incl. **e2e**: a `ouroboros/auto/bt-*`-branch worktree IS reaped (base-independent), a `feat/*` worktree is preserved
- [x] 10 worktree-isolation regression (legacy `unit-` reaping intact) + oracle + dw_heavy_probe green
- [ ] v40: boot reaps the 13 GB; LoopSink shows no large file-watch/Oracle latency; batch ops run unhindered → first APPLY

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes event loop starvation in Slice 44 by cleaning up orphaned auto‑soak worktrees at boot and stopping Oracle from scanning them. This removes large duplicate checkouts and keeps real feature worktrees untouched.

- Bug Fixes
  - Reaper: `WorktreeManager.reap_orphans` now matches multiple prefixes (legacy `unit-` plus `ouroboros/auto/bt-`, `ouroboros__auto__bt-`, `soak-`), using branch-based matching for base independence; configurable via `JARVIS_WORKTREE_REAP_PREFIXES`; never matches `feat/*`.
  - Oracle: added `.worktrees` and `.ouroboros` to `OracleConfig.EXCLUDE_PATTERNS` to skip full checkout trees during indexing.

<sup>Written for commit 401b56544f53ae03d5f69d1217c3d70d97fa8840. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/65628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

