### PR TITLE
feat(governance): Slice 45 — DW terminal-worker tool advertisement (v40b exploration-gate deadlock fix)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -1373,6 +1373,16 @@ class DoublewordProvider:
                     _zw_complexity = getattr(
                         context, "task_complexity", "",
                     )
+                    # Slice 45 note: this dormant response-cache path uses
+                    # the legacy complexity-only skip test, NOT the
+                    # terminal-worker policy. Harmless today — the cache is
+                    # default-OFF and ``_zw_eligible`` below gates this path
+                    # to loop-less / trivial-simple ops, so a moderate/heavy
+                    # terminal-worker background op never assembles its
+                    # prompt here (it falls through to the main path). If
+                    # JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED is ever turned
+                    # on, mirror background_is_terminal_worker here to keep
+                    # the assembled prompt coherent with the main path.
                     _zw_will_skip = _zw_complexity in (
                         "trivial", "simple",
                     )
@@ -1877,12 +1887,29 @@ class DoublewordProvider:
         from backend.core.ouroboros.governance.route_predicates import (
             should_skip_venom_for_route,
         )
+        from backend.core.ouroboros.governance.dw_terminal_worker_policy import (
+            background_is_terminal_worker,
+        )
         _complexity = getattr(context, "task_complexity", "")
         _route = getattr(context, "provider_route", "") or ""
-        _will_skip_tools = (
-            _complexity in ("trivial", "simple")
-            or should_skip_venom_for_route(str(_route))
-        )
+        # Slice 45 — keep the prompt-layer tool advertisement coherent with
+        # the exec-layer tool-loop run condition. When DW is the terminal
+        # worker (Claude disabled), a BACKGROUND op runs the Venom loop
+        # whenever it is non-trivial (line ~2632 ``_skip_tools =
+        # complexity == "trivial"``) and therefore MUST be told the tools
+        # exist. We mirror that exec gate EXACTLY here (skip only trivial)
+        # so the prompt's tool advertisement matches whether the loop
+        # actually runs — for simple AND moderate/heavy background alike
+        # (the simple-background half of the v40b deadlock would otherwise
+        # remain: loop runs, tools suppressed). Env-gated + BACKGROUND-only
+        # -> byte-identical legacy when Claude is enabled / flag off.
+        if background_is_terminal_worker(str(_route)):
+            _will_skip_tools = (_complexity == "trivial")
+        else:
+            _will_skip_tools = (
+                _complexity in ("trivial", "simple")
+                or should_skip_venom_for_route(str(_route))
+            )
         # ──────────────────────────────────────────────────────────────
         # Slice 9 — L2 single-shot fast path (DW mirror)
         # See PrimeProvider providers.py:4710 for full rationale.

--- a/backend/core/ouroboros/governance/dw_terminal_worker_policy.py
+++ b/backend/core/ouroboros/governance/dw_terminal_worker_policy.py
@@ -1,0 +1,101 @@
+"""Slice 45 — DW terminal-worker tool policy (env-aware leaf).
+
+Why this exists
+---------------
+v40b (bt-2026-05-29-200702) produced the arc's first DW candidate, but the
+Iron Gate rejected it: ``exploration_insufficient: 0/1`` — the model made
+**0 tool calls**. Root cause is a *predicate mismatch* between two layers
+(NOT a parse bug, NOT model incapacity — Phase 1 trace
+``scripts/trace_qwen_tool_syntax.py`` proved Qwen-397B emits a flawless
+``2b.2-tool`` envelope the instant the tool section is advertised):
+
+  * PROMPT layer (``providers._build_tool_section``):
+        ``should_skip_venom_for_route("background")`` -> returns ""  ->
+        the model is NEVER shown the tool list or the 2b.2-tool schema.
+  * EXEC layer (``doubleword_provider`` ``_skip_tools = complexity ==
+        "trivial"``): a non-trivial BACKGROUND op still RUNS the Venom
+        tool loop -> ``parse_fn`` is called on output the model was never
+        instructed to shape -> ``None`` every round -> 0 tool calls ->
+        Iron Gate 0/1 -> deadlock.
+
+The historical suppression (Slice 12AF) assumed BACKGROUND never runs the
+loop because "Claude is invoked later, so tools are moot." That assumption
+is **false when Claude is disabled** (``JARVIS_PROVIDER_CLAUDE_DISABLED``):
+DW is then the *terminal worker* for the op and must be allowed to explore
+to clear the Iron Gate.
+
+What this module does
+---------------------
+Provides the single env-aware predicate that both ``providers.py``
+(``_build_tool_section``) and ``doubleword_provider.py``
+(``_will_skip_tools``) consult to decide whether a VENOM-skip route should
+nonetheless be advertised + run the tool loop. It is a deliberate **leaf**
+(env reads only, no governance imports) so both callers can import it with
+zero circular-import risk. ``route_predicates.py`` stays env-free by
+design; the env-aware policy belongs here.
+
+Discipline
+----------
+* Scope is **BACKGROUND only**. SPECULATIVE stays fire-and-forget (no time
+  budget for tool rounds); WIRING_VALIDATION's no-op patch is correct by
+  contract. Both remain suppressed.
+* Gated by ``JARVIS_DW_BACKGROUND_VENOM_ENABLED`` (default ``true``) AND
+  ``claude_is_disabled()``. When Claude is enabled OR the master flag is
+  off, the predicate returns ``False`` everywhere -> byte-identical legacy.
+* NEVER raises — accepts any string, returns bool.
+
+Manifesto compliance: §5 intelligence-driven routing (policy over a closed
+signal, not regex/LLM); §7 observability (named, greppable, env-tunable).
+"""
+from __future__ import annotations
+
+import os
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+# The single route this policy widens. Kept as a module constant so an
+# AST-pin can assert scope did not silently expand to speculative /
+# wiring_validation.
+TERMINAL_WORKER_ROUTE = "background"
+
+# Master flag name (exported for FlagRegistry seeding + tests).
+MASTER_FLAG = "JARVIS_DW_BACKGROUND_VENOM_ENABLED"
+
+__all__ = [
+    "TERMINAL_WORKER_ROUTE",
+    "MASTER_FLAG",
+    "claude_is_disabled",
+    "background_is_terminal_worker",
+]
+
+
+def _truthy(name: str, default: str) -> bool:
+    return os.environ.get(name, default).strip().lower() in _TRUTHY
+
+
+def claude_is_disabled() -> bool:
+    """True iff the Claude (Anthropic) provider is disabled for this run.
+
+    Mirrors the ``JARVIS_PROVIDER_CLAUDE_DISABLED`` posture already
+    consumed by Slices 19a / 20A / 22 / 23. Pure env read; NEVER raises.
+    """
+    return _truthy("JARVIS_PROVIDER_CLAUDE_DISABLED", "")
+
+
+def background_is_terminal_worker(route: str) -> bool:
+    """True iff ``route`` is the BACKGROUND route AND DW is acting as the
+    terminal worker (Claude disabled) AND the master flag is on.
+
+    When True, callers MUST advertise the tool section + let the Venom
+    loop run so the model can explore and clear the Iron Gate — even
+    though ``route`` is a member of ``VENOM_SKIP_ROUTES``.
+
+    Scope is intentionally narrow (BACKGROUND only). Returns ``False`` for
+    every other route, for a Claude-enabled run, and when the master flag
+    is off — preserving byte-identical legacy behavior. NEVER raises.
+    """
+    if route != TERMINAL_WORKER_ROUTE:
+        return False
+    if not _truthy(MASTER_FLAG, "true"):
+        return False
+    return claude_is_disabled()

--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -4854,6 +4854,25 @@ SEED_SPECS: list = [
         since="Slice 39 Task 8 (PRD §49.6.2, 2026-05-28)",
         posture_relevance=_HARDEN_CRITICAL,
     ),
+    FlagSpec(
+        name="JARVIS_DW_BACKGROUND_VENOM_ENABLED",
+        type=FlagType.BOOL, default=True,
+        description=(
+            "Slice 45 — when DW is the terminal worker (Claude disabled), "
+            "advertise the Venom tool section + run the tool loop for the "
+            "BACKGROUND route so the model can explore and clear the Iron "
+            "Gate. Only takes effect when JARVIS_PROVIDER_CLAUDE_DISABLED "
+            "is set; BACKGROUND-only (speculative/wiring_validation stay "
+            "suppressed). False restores the legacy suppression."
+        ),
+        category=Category.ROUTING,
+        source_file=(
+            "backend/core/ouroboros/governance/dw_terminal_worker_policy.py"
+        ),
+        example="true",
+        since="Slice 45 (v40b deadlock fix, 2026-05-29)",
+        posture_relevance=_EXPLORE_CRITICAL,
+    ),
 ]
 
 

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -1738,17 +1738,41 @@ def _build_tool_section(
         legacy behavior for any caller that hasn't yet plumbed the
         route through (defense for partial adoption).
     """
+    _route_str = str(provider_route or "")
+    _route_skips_venom = False
     try:
         from backend.core.ouroboros.governance.route_predicates import (
             should_skip_venom_for_route,
         )
-        if should_skip_venom_for_route(str(provider_route or "")):
-            return ""
+        _route_skips_venom = should_skip_venom_for_route(_route_str)
     except Exception:  # noqa: BLE001 — defensive
-        # Defense: never let an import failure suppress the full
-        # tool section for legacy routes. Falls through to emit
-        # the normal block.
-        pass
+        # route_predicates import failed: fall through to emit the normal
+        # block (legacy behavior for non-skip routes; never suppress).
+        _route_skips_venom = False
+    if _route_skips_venom:
+        # Slice 45 — terminal-worker exception. When DW is the terminal
+        # worker (Claude disabled), the BACKGROUND route must STILL see the
+        # tool advertisements: the Venom loop already runs for non-trivial
+        # background ops (doubleword_provider ``_skip_tools = complexity ==
+        # "trivial"``), so suppressing the tool section here left the model
+        # with a running loop and no instructions -> 0 tool calls -> Iron
+        # Gate 0/1 deadlock (v40b bt-2026-05-29-200702). Phase 1 trace
+        # proved Qwen emits a clean 2b.2-tool envelope the instant tools
+        # are advertised. Env-gated + BACKGROUND-only -> byte-identical
+        # legacy when Claude is enabled or the master flag is off.
+        _terminal_worker = False
+        try:
+            from backend.core.ouroboros.governance.dw_terminal_worker_policy import (
+                background_is_terminal_worker,
+            )
+            _terminal_worker = background_is_terminal_worker(_route_str)
+        except Exception:  # noqa: BLE001 — defensive
+            # Policy import failed: SUPPRESS (safe default — preserves the
+            # Slice 12AF suppression for VENOM_SKIP_ROUTES rather than
+            # leaking tool advertisements to a loop-less route).
+            _terminal_worker = False
+        if not _terminal_worker:
+            return ""
     voice_block = ""
     if voice_plain_language:
         voice_block = (
@@ -2427,9 +2451,24 @@ def _should_use_lean_prompt(
     )
     _route = getattr(ctx, "provider_route", "")
     if should_skip_venom_for_route(_route):
-        if os.environ.get(
+        # Slice 45 — terminal-worker exception. When DW is the terminal
+        # worker (Claude disabled), the BACKGROUND route MUST use the lean
+        # tool-first prompt: the Venom loop runs (exec layer), so the model
+        # needs the advertised tools, AND the lean builder's preloaded
+        # target files grant Iron Gate exploration credit. Without this,
+        # background fell through to the full prompt whose ``if
+        # tools_enabled:`` gate (and the DW call site's defaulted
+        # tools_enabled=False) left the model with a running loop and no
+        # tool instructions -> 0 tool calls -> exploration_insufficient
+        # (v40b bt-2026-05-29-200702). Env-gated + BACKGROUND-only ->
+        # byte-identical legacy when Claude is enabled / flag off.
+        from backend.core.ouroboros.governance.dw_terminal_worker_policy import (
+            background_is_terminal_worker,
+        )
+        _legacy_lean_override = os.environ.get(
             "JARVIS_BG_CASCADE_LEAN_PROMPT_ENABLED", "false",
-        ).lower() not in ("1", "true", "yes", "on"):
+        ).lower() in ("1", "true", "yes", "on")
+        if not background_is_terminal_worker(_route) and not _legacy_lean_override:
             return False
     if getattr(ctx, "cross_repo", False):
         return False

--- a/scripts/trace_qwen_tool_syntax.py
+++ b/scripts/trace_qwen_tool_syntax.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Slice 45 Phase 1 — out-of-band Qwen tool-syntax bisection diagnostic.
+
+WHY THIS EXISTS
+---------------
+v40b (bt-2026-05-29-200702) produced the arc's first DW candidate but the
+Iron Gate rejected it: ``exploration_insufficient: 0/1`` — the model made
+**0 tool calls**. Code reading found the root cause is a *predicate
+mismatch*, not a parse bug:
+
+  * PROMPT layer  (providers._build_tool_section, providers.py:1745):
+        ``should_skip_venom_for_route("background")`` -> returns ""  ->
+        the model is NEVER shown the 2b.2-tool schema or the tool list.
+  * EXEC  layer  (doubleword_provider.py:2632):
+        ``_skip_tools = _complexity == "trivial"``  ->  non-trivial
+        background still RUNS the Venom tool loop -> parse_fn is called
+        on output the model was never instructed to shape -> None every
+        round -> 0 tool calls -> Iron Gate 0/1 -> deadlock.
+
+This script settles the FIX SHAPE empirically before any production edit.
+The pipeline never sends a native OpenAI ``tools=[]`` array (the protocol
+is *prompt-embedded*), so the model can only signal tool intent **in its
+content text** — inspecting ``choices[0].message.content`` is sufficient
+and correct to bisect Branch A vs B.
+
+It sends a real codegen-style prompt through the Doubleword **Batch API**
+lane (``prompt_only`` -> upload -> create -> poll -> retrieve) under two
+conditions:
+
+  COND_A  "tools_advertised"  — prompt INCLUDES the 2b.2-tool section
+          (what we would send if we align the background predicate).
+  COND_B  "tools_suppressed"  — prompt OMITS the tool section (exactly
+          what the background route sends TODAY; the control).
+
+VERDICTS
+--------
+  PREDICATE_FIX_SUFFICIENT  Qwen emits a parseable 2b.2-tool envelope when
+                            advertised -> aligning the predicate is enough.
+  NEEDS_PARSE_ADAPTER       Qwen emits tool intent in a NON-2b.2 shape
+                            (markdown-wrapped / native tool_calls / alt
+                            JSON / <tool_call> tags) -> ALSO build a
+                            translation adapter (runbook Branch A).
+  BEHAVIORAL_SKIP           Qwen emits a patch with no tool intent even
+                            when advertised -> exploration-enforcement
+                            prompt modifier needed (runbook Branch B).
+
+This is a READ-ONLY diagnostic. It imports production helpers but mutates
+no production code paths and writes only under a trace output directory.
+
+Usage:
+    python3 scripts/trace_qwen_tool_syntax.py [--cond both|a|b] [--model SLUG]
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_dotenv(path: Path) -> None:
+    """Minimal .env loader (no dependency). Does not override existing env."""
+    if not path.exists():
+        return
+    for raw in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = val
+
+
+# ── tool-intent modality classifiers ───────────────────────────────────
+# Each returns the matched snippet (truncated) or "" if no match.
+
+def _find_2b2_envelope(text: str) -> str:
+    m = re.search(r'\{\s*"schema_version"\s*:\s*"2b\.2-tool".*?"tool_call', text, re.DOTALL)
+    return text[m.start():m.start() + 160] if m else ""
+
+
+def _find_markdown_tool_json(text: str) -> str:
+    # ```json ... {"tool_call"/"tool_calls"/"name"+"arguments"} ... ```
+    for m in re.finditer(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL):
+        blk = m.group(1)
+        if re.search(r'"tool_calls?"\s*:', blk) or (
+            '"name"' in blk and '"arguments"' in blk
+        ):
+            return blk[:200]
+    return ""
+
+
+def _find_native_toolcalls(text: str) -> str:
+    # OpenAI-native object leaked into content, or a bare tool_calls array.
+    m = re.search(r'"tool_calls"\s*:\s*\[', text)
+    if m:
+        return text[m.start():m.start() + 160]
+    m = re.search(r'"function"\s*:\s*\{\s*"name"', text)
+    return text[m.start():m.start() + 160] if m else ""
+
+
+def _find_xml_toolcall(text: str) -> str:
+    # Qwen/Hermes-style <tool_call>...</tool_call> or <function=...>
+    m = re.search(r"<tool_call>.*?</tool_call>", text, re.DOTALL)
+    if m:
+        return m.group(0)[:200]
+    m = re.search(r"<function[ =].*?>", text)
+    return m.group(0)[:160] if m else ""
+
+
+def _find_alt_json_toolish(text: str) -> str:
+    # Any JSON object carrying name+arguments but NOT our schema_version.
+    for m in re.finditer(r"\{[^{}]*\"name\"[^{}]*\"arguments\"[^{}]*\}", text, re.DOTALL):
+        blk = m.group(0)
+        if "2b.2-tool" not in blk:
+            return blk[:200]
+    return ""
+
+
+def _looks_like_patch(text: str) -> bool:
+    return bool(
+        re.search(r"^\s*(diff --git|--- a/|\+\+\+ b/|@@ )", text, re.MULTILINE)
+        or re.search(r"```(?:diff|python|py)\b", text)
+        or '"file_path"' in text
+        or '"full_content"' in text
+    )
+
+
+def classify(content: str, parser_caught: bool) -> Dict[str, Any]:
+    """Classify the model's tool-call modality from raw content."""
+    hits = {
+        "envelope_2b2": _find_2b2_envelope(content),
+        "markdown_tool_json": _find_markdown_tool_json(content),
+        "native_tool_calls": _find_native_toolcalls(content),
+        "xml_tool_call": _find_xml_toolcall(content),
+        "alt_json_toolish": _find_alt_json_toolish(content),
+    }
+    any_alt_intent = any(
+        hits[k] for k in ("markdown_tool_json", "native_tool_calls", "xml_tool_call", "alt_json_toolish")
+    )
+    if parser_caught and hits["envelope_2b2"]:
+        verdict = "PREDICATE_FIX_SUFFICIENT"
+    elif hits["envelope_2b2"] and not parser_caught:
+        # Envelope present but parser missed it (e.g. nested/markdown-wrapped).
+        verdict = "NEEDS_PARSE_ADAPTER"
+    elif any_alt_intent:
+        verdict = "NEEDS_PARSE_ADAPTER"
+    elif _looks_like_patch(content):
+        verdict = "BEHAVIORAL_SKIP"
+    else:
+        verdict = "INCONCLUSIVE"
+    return {
+        "verdict": verdict,
+        "parser_caught": parser_caught,
+        "hits": {k: (v[:200] if v else "") for k, v in hits.items()},
+        "any_alt_intent": any_alt_intent,
+        "looks_like_patch": _looks_like_patch(content),
+    }
+
+
+async def run_condition(
+    label: str,
+    prompt: str,
+    model: Optional[str],
+) -> Dict[str, Any]:
+    from backend.core.ouroboros.governance.doubleword_provider import DoublewordProvider
+
+    provider = DoublewordProvider()
+    # _parse_tool_call_response is defined inline inside generate(); replicate
+    # its EXACT regex+brace-scan here so the diagnostic mirrors production.
+    def _parse_tool_call_response(raw: str) -> bool:
+        m = re.search(r'\{\s*"schema_version"\s*:\s*"2b\.2-tool".*?"tool_call', raw, re.DOTALL)
+        if not m:
+            return False
+        brace = 0
+        start = m.start()
+        for i in range(start, len(raw)):
+            if raw[i] == "{":
+                brace += 1
+            elif raw[i] == "}":
+                brace -= 1
+                if brace == 0:
+                    try:
+                        obj = json.loads(raw[start:i + 1])
+                    except json.JSONDecodeError:
+                        return False
+                    if isinstance(obj.get("tool_calls"), list) and obj["tool_calls"]:
+                        return True
+                    return bool(obj.get("tool_call", {}).get("name"))
+        return False
+
+    print(f"\n{'='*70}\n[{label}] sending batch completion ({len(prompt)} chars, model={model or 'default'})...", flush=True)
+    t0 = time.monotonic()
+    err = ""
+    content = ""
+    try:
+        content = await provider.prompt_only(
+            prompt,
+            model=model,
+            caller_id=f"slice45_trace_{label}",
+            max_tokens=2048,
+        )
+    except Exception as exc:  # noqa: BLE001 — diagnostic must never crash silently
+        err = f"{type(exc).__name__}: {exc}"
+    dt = time.monotonic() - t0
+    parser_caught = _parse_tool_call_response(content) if content else False
+    result = {
+        "label": label,
+        "elapsed_s": round(dt, 1),
+        "error": err,
+        "content_len": len(content),
+        "content": content,
+        "classification": classify(content, parser_caught) if content else {
+            "verdict": "NO_RESPONSE", "parser_caught": False, "hits": {},
+        },
+    }
+    v = result["classification"]["verdict"]
+    print(f"[{label}] {dt:.1f}s  len={len(content)}  verdict={v}  err={err or '-'}", flush=True)
+    if content:
+        head = content[:600].replace("\n", "\n  ")
+        print(f"[{label}] content head:\n  {head}\n  ...", flush=True)
+    return result
+
+
+def build_prompts() -> Tuple[str, str]:
+    """Return (tools_advertised_prompt, tools_suppressed_prompt)."""
+    from backend.core.ouroboros.governance.providers import _build_tool_section
+
+    # A real, small, exploration-warranting task against our own codebase.
+    task = (
+        "TASK: Add a `__repr__` method to the `SurfaceHealthRecord` dataclass "
+        "in `backend/core/ouroboros/governance/dw_surface_health.py` that returns "
+        "a compact one-line summary of its fields.\n\n"
+        "You do NOT have the file contents. Before proposing any patch you must "
+        "investigate the codebase to read the dataclass definition.\n"
+    )
+    # COND_A: full tool section as a NON-skip route would advertise it.
+    tool_section = _build_tool_section(mcp_tools=None, provider_route="standard")
+    cond_a = task + "\n" + tool_section
+    # COND_B: exactly what background route sends today (tool section == "").
+    suppressed = _build_tool_section(mcp_tools=None, provider_route="background")
+    cond_b = task + "\n" + suppressed
+    return cond_a, cond_b
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cond", choices=["both", "a", "b"], default="both")
+    ap.add_argument("--model", default=None, help="override DW model slug")
+    ap.add_argument("--aegis", choices=["on", "off"], default="off",
+                    help="off = direct to api.doubleword.ai using DOUBLEWORD_API_KEY")
+    args = ap.parse_args()
+
+    _load_dotenv(REPO_ROOT / ".env")
+    # Direct path by default — out-of-band, no daemon dependency.
+    if args.aegis == "off":
+        os.environ["JARVIS_AEGIS_ENABLED"] = "false"
+
+    cond_a, cond_b = build_prompts()
+    print(f"COND_A tools_advertised prompt: {len(cond_a)} chars "
+          f"(tool_section present={'## Available Tools' in cond_a})")
+    print(f"COND_B tools_suppressed prompt: {len(cond_b)} chars "
+          f"(tool_section present={'## Available Tools' in cond_b})")
+
+    results: List[Dict[str, Any]] = []
+    if args.cond in ("both", "a"):
+        results.append(await run_condition("tools_advertised", cond_a, args.model))
+    if args.cond in ("both", "b"):
+        results.append(await run_condition("tools_suppressed", cond_b, args.model))
+
+    out_dir = REPO_ROOT / ".ouroboros" / "slice45_trace"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = str(int(time.time()))
+    report = {
+        "stamp": stamp,
+        "model": args.model or os.environ.get("DOUBLEWORD_MODEL", "Qwen/Qwen3.5-397B-A17B-FP8"),
+        "results": results,
+    }
+    report_path = out_dir / f"trace_{stamp}.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    print(f"\n{'='*70}\nSUMMARY")
+    for r in results:
+        print(f"  {r['label']:18s} verdict={r['classification']['verdict']:24s} "
+              f"parser_caught={r['classification'].get('parser_caught')} "
+              f"len={r['content_len']} err={r['error'] or '-'}")
+    print(f"\nFull report (incl. raw content): {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/governance/test_slice45_terminal_worker_tools.py
+++ b/tests/governance/test_slice45_terminal_worker_tools.py
@@ -1,0 +1,240 @@
+"""Slice 45 — DW terminal-worker tool advertisement.
+
+Root cause closed (v40b bt-2026-05-29-200702): a predicate mismatch between
+the prompt layer (``providers._build_tool_section`` suppressed tools for
+``should_skip_venom_for_route`` routes) and the exec layer
+(``doubleword_provider`` ran the Venom loop for any non-trivial op). A
+non-trivial BACKGROUND op therefore ran the tool loop against a prompt that
+hid the tool advertisements -> 0 tool calls -> Iron Gate
+``exploration_insufficient: 0/1`` -> deadlock.
+
+Phase 1 trace (scripts/trace_qwen_tool_syntax.py) proved Qwen-397B emits a
+flawless ``2b.2-tool`` envelope the instant tools are advertised, so the fix
+is purely to stop suppressing tools for the terminal-worker BACKGROUND route
+(Claude disabled). Env-gated + BACKGROUND-only -> byte-identical legacy when
+Claude is enabled or the master flag is off; SPECULATIVE / WIRING_VALIDATION
+stay suppressed.
+
+These tests pin:
+  1. the policy predicate behavior matrix;
+  2. ``_build_tool_section`` advertises iff terminal-worker;
+  3. the Slice 12AF legacy suppression is preserved by default;
+  4. AST pins: scope did not expand; both call sites consult the policy.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_terminal_worker_policy import (
+    MASTER_FLAG,
+    TERMINAL_WORKER_ROUTE,
+    background_is_terminal_worker,
+    claude_is_disabled,
+)
+from backend.core.ouroboros.governance.providers import (
+    _build_lean_codegen_prompt,
+    _build_tool_section,
+    _should_use_lean_prompt,
+)
+
+
+def _mk_ctx(route: str, complexity: str = "moderate"):
+    """Duck-typed minimal OperationContext (matches test_slice12af pattern)."""
+    c = MagicMock()
+    c.provider_route = route
+    c.task_complexity = complexity
+    c.cross_repo = False
+    c.target_files = ()
+    c.repair_context = None
+    return c
+
+_REPO = Path(__file__).resolve().parents[2]
+_PROVIDERS = _REPO / "backend/core/ouroboros/governance/providers.py"
+_DW = _REPO / "backend/core/ouroboros/governance/doubleword_provider.py"
+_POLICY = _REPO / "backend/core/ouroboros/governance/dw_terminal_worker_policy.py"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Each test controls the two flags explicitly; start from a clean slate."""
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)
+    monkeypatch.delenv(MASTER_FLAG, raising=False)
+    yield
+
+
+# ── 1. policy predicate matrix ──────────────────────────────────────────
+
+
+def test_claude_is_disabled_reads_env(monkeypatch):
+    assert claude_is_disabled() is False
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    assert claude_is_disabled() is True
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "0")
+    assert claude_is_disabled() is False
+
+
+def test_legacy_background_not_terminal_worker():
+    # No CLAUDE_DISABLED -> Claude active -> background is the cheap pre-pass.
+    assert background_is_terminal_worker("background") is False
+
+
+def test_claude_disabled_background_is_terminal_worker(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    assert background_is_terminal_worker("background") is True
+
+
+def test_master_flag_off_disables_even_when_claude_disabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    monkeypatch.setenv(MASTER_FLAG, "false")
+    assert background_is_terminal_worker("background") is False
+
+
+def test_scope_is_background_only(monkeypatch):
+    # Even with DW terminal, SPECULATIVE / WIRING_VALIDATION / others stay out.
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    for route in ("speculative", "wiring_validation", "standard", "immediate", "complex", ""):
+        assert background_is_terminal_worker(route) is False, route
+
+
+def test_predicate_never_raises_on_odd_input(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    assert background_is_terminal_worker("BACKGROUND") is False  # case-sensitive by design
+    assert background_is_terminal_worker(" background ") is False
+
+
+# ── 2. _build_tool_section advertises iff terminal-worker ────────────────
+
+
+def test_tool_section_advertises_for_terminal_worker_background(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    section = _build_tool_section(provider_route="background")
+    assert "## Available Tools" in section
+    assert "2b.2-tool" in section
+    # The exploration tools the Iron Gate counts must be present.
+    assert "read_file" in section and "search_code" in section
+
+
+def test_tool_section_speculative_still_suppressed_when_terminal(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    assert _build_tool_section(provider_route="speculative") == ""
+    assert _build_tool_section(provider_route="wiring_validation") == ""
+
+
+# ── 3. Slice 12AF legacy suppression preserved by default ───────────────
+
+
+def test_legacy_background_section_empty_without_claude_disabled():
+    # The exact Slice 12AF invariant — unchanged when Claude is enabled.
+    assert _build_tool_section(provider_route="background") == ""
+    assert _build_tool_section(provider_route="speculative") == ""
+
+
+def test_master_off_restores_legacy_suppression(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    monkeypatch.setenv(MASTER_FLAG, "false")
+    assert _build_tool_section(provider_route="background") == ""
+
+
+def test_standard_route_always_advertises():
+    # Regression: non-skip routes are unaffected by this slice.
+    section = _build_tool_section(provider_route="standard")
+    assert "## Available Tools" in section and "2b.2-tool" in section
+
+
+# ── 4. AST / structural pins ────────────────────────────────────────────
+
+
+def test_terminal_worker_route_constant_is_background():
+    # Scope guard: an accidental widening to speculative/wiring would
+    # change product behavior silently.
+    assert TERMINAL_WORKER_ROUTE == "background"
+
+
+def test_build_tool_section_consults_policy():
+    src = _PROVIDERS.read_text(encoding="utf-8")
+    assert "background_is_terminal_worker" in src, (
+        "_build_tool_section must consult the terminal-worker policy"
+    )
+
+
+def test_doubleword_provider_consults_policy():
+    src = _DW.read_text(encoding="utf-8")
+    assert "background_is_terminal_worker" in src, (
+        "doubleword_provider _will_skip_tools must consult the policy"
+    )
+
+
+# ── 5. END-TO-END production prompt-assembly (the path v40b actually took) ─
+#
+# The component tests above prove _build_tool_section advertises, but the
+# v40b deadlock lived in the PROMPT-SELECTION wiring: _should_use_lean_prompt
+# returned False for background -> full prompt -> ``if tools_enabled:`` gate
+# (DW call site defaults tools_enabled=False) -> _build_tool_section never
+# called. These tests drive the real selection + assembly path so a future
+# regression of that wiring is caught.
+
+
+def test_lean_selected_for_terminal_worker_background(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    monkeypatch.delenv("JARVIS_LEAN_PROMPT", raising=False)
+    monkeypatch.delenv("JARVIS_BG_CASCADE_LEAN_PROMPT_ENABLED", raising=False)
+    for comp in ("simple", "moderate", "heavy"):
+        assert _should_use_lean_prompt(
+            _mk_ctx("background", comp), tools_enabled=True
+        ) is True, comp
+
+
+def test_lean_not_selected_for_background_when_claude_enabled(monkeypatch):
+    # Legacy invariant: Claude active -> background still skips the lean
+    # tool-first prompt (byte-identical pre-Slice-45).
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)
+    monkeypatch.delenv("JARVIS_BG_CASCADE_LEAN_PROMPT_ENABLED", raising=False)
+    assert _should_use_lean_prompt(
+        _mk_ctx("background", "moderate"), tools_enabled=True
+    ) is False
+
+
+def test_lean_not_selected_for_speculative_terminal(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    assert _should_use_lean_prompt(
+        _mk_ctx("speculative", "moderate"), tools_enabled=True
+    ) is False
+
+
+def test_assembled_lean_prompt_advertises_tools_for_terminal_background(monkeypatch):
+    """THE end-to-end pin: the real assembled prompt the model receives for a
+    Claude-disabled background op must contain the tool advertisements."""
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    monkeypatch.delenv("JARVIS_LEAN_PROMPT", raising=False)
+    prompt = _build_lean_codegen_prompt(_mk_ctx("background", "moderate"), preloaded_out=[])
+    assert "## Available Tools" in prompt
+    assert "2b.2-tool" in prompt
+    assert "read_file" in prompt and "search_code" in prompt
+
+
+def test_assembled_lean_prompt_no_tools_for_background_legacy(monkeypatch):
+    """Legacy: Claude enabled -> even if the lean builder is reached
+    directly, the tool section stays suppressed for background."""
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)
+    prompt = _build_lean_codegen_prompt(_mk_ctx("background", "moderate"), preloaded_out=[])
+    assert "## Available Tools" not in prompt
+
+
+def test_policy_module_is_a_leaf_no_governance_imports():
+    """The policy must stay a dependency-free leaf (env reads only) so both
+    providers.py and doubleword_provider.py import it without circular risk."""
+    tree = ast.parse(_POLICY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            mod = (
+                node.module
+                if isinstance(node, ast.ImportFrom)
+                else node.names[0].name
+            )
+            assert mod is None or "ouroboros.governance" not in str(mod), (
+                f"leaf policy must not import governance modules; found {mod}"
+            )


### PR DESCRIPTION
## Summary

Closes the **v40b** (`bt-2026-05-29-200702`) capability blocker. v40b produced the arc's **first DW candidate ever**, but the Iron Gate rejected it with `exploration_insufficient: 0/1` — the model made **0 tool calls**. Root cause is a **predicate mismatch** (not a parse bug, not model incapacity):

- **PROMPT layer** (`providers._build_tool_section`) suppressed the tool section for `VENOM_SKIP_ROUTES` (background/speculative/wiring_validation).
- **EXEC layer** (`doubleword_provider`) ran the Venom loop for any non-trivial op (`_skip_tools = complexity == "trivial"`).

A non-trivial **background** op therefore ran the loop against a prompt that hid the tools → `parse_fn` returned `None` every round → 0 tool calls → deadlock. The Slice 12AF suppression assumed background never runs the loop ("Claude does the real work later") — **false when Claude is disabled and DW is the terminal worker.**

## Phase 1 diagnostic (verify-first)

`scripts/trace_qwen_tool_syntax.py` ran two live DW **batch-lane** completions:

| Condition | Result | Verdict |
|---|---|---|
| tools advertised | Qwen-397B emitted a flawless `2b.2-tool` envelope (parallel `tool_calls`, `read_file`+`search_code`) in 5.8s, parser caught it | **PREDICATE_FIX_SUFFICIENT** |
| tools suppressed (today's background) | narrated "I cannot see the file… I would need to read it" — wanted to explore, no means | structural skip |

→ No parse adapter (Branch A) and no exploration-enforcement prompt (Branch B) were needed. The fix is purely to advertise tools to the terminal-worker background route.

## Fix (env-gated, BACKGROUND-only, byte-identical legacy when Claude enabled / flag off)

- New leaf policy `dw_terminal_worker_policy.background_is_terminal_worker()` = `route=="background"` AND `JARVIS_DW_BACKGROUND_VENOM_ENABLED` (default true) AND `claude_is_disabled()`.
- `_should_use_lean_prompt`: terminal-worker background uses the **lean** prompt (advertises tools **and** preloads target files for Iron Gate credit).
- `_will_skip_tools` (DW): for terminal-worker, mirrors the exec gate exactly (skip only trivial) — closes the residual simple-background half too.
- `_build_tool_section`: restructured so route-skip suppression is the **safe default**; the terminal-worker exception relaxes it only when the policy is True; import failures default to SUPPRESS.
- Seeded `JARVIS_DW_BACKGROUND_VENOM_ENABLED` in FlagRegistry (ROUTING).

## Review

Two Opus reviews. The **first caught the fix as dead code** in the prod path (`_should_use_lean_prompt` returned False for background → full prompt → the `if tools_enabled:` gate skipped `_build_tool_section`). The corrected v2 routes through lean and was **re-reviewed READY TO MERGE** — all 5 findings resolved, cross_repo doubly-mitigated, no orphan-`2b.2-tool` path, speculative/wiring untouched, Claude-enabled byte-identical.

## Test Plan

- [x] 20 Slice 45 tests: policy matrix + `_build_tool_section` integration + **end-to-end assembled-prompt pins** (the wiring the first review flagged) + AST/leaf pins
- [x] 227 cross-arc regression green (12AF/12AD/12AH/9/skill-injection/dw-heavy-probe/dw-surface-health/flag-registry)
- [x] The one red (`test_slice12af…test_bare_assert_replaced_with_structured_raise`) is **pre-existing on the base commit** `547ee80873` (generate_runner refactor drift), unrelated — verified by stashing the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock where DW background ran the Venom loop without advertised tools when Claude was disabled. Background ops now get tool ads and the lean prompt when DW is the terminal worker, allowing exploration to clear the Iron Gate.

- **Bug Fixes**
  - Added `background_is_terminal_worker(route)` policy (route=`background` AND `JARVIS_DW_BACKGROUND_VENOM_ENABLED`=true AND Claude disabled) to gate behavior.
  - `providers._build_tool_section`: advertise tools for terminal-worker background; otherwise keep VENOM-skip suppression. Import failures default to suppress.
  - `providers._should_use_lean_prompt`: use the lean, tool-first prompt for terminal-worker background; legacy behavior otherwise.
  - `doubleword_provider`: align prompt-layer gate with exec-layer loop; skip tools only for trivial when terminal-worker, else legacy rules.
  - Seeded `JARVIS_DW_BACKGROUND_VENOM_ENABLED` (default true) in Flag Registry. SPECULATIVE and WIRING_VALIDATION remain suppressed.
  - Added `scripts/trace_qwen_tool_syntax.py` diagnostic and new tests pinning policy, prompt assembly, and AST guards.

<sup>Written for commit d34f5693981c244403f89daaf0d19935370164ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/65629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

