### PR TITLE
feat(governance): Slice 49 — external GIL-immune watchdog + scanner exclusions + universal ingest stratification

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1110,6 +1110,7 @@ class BattleTestHarness:
             self._wall_clock_hard_deadline_stop: Optional[
                 threading.Event
             ] = None
+            self._external_watchdog: Optional[Any] = None  # Slice 49
             _wall_cap = self._config.max_wall_seconds_s
             if _wall_cap is not None and _wall_cap > 0:
                 self._wall_clock_monitor_task = asyncio.ensure_future(
@@ -1140,6 +1141,12 @@ class BattleTestHarness:
                     "terminate with stop_reason=wall_clock_cap if not already stopped.",
                     _wall_cap,
                 )
+                # Slice 49 — external subprocess watchdog: a GIL-immune
+                # backstop for the in-process resource-zero thread, which v44
+                # proved can be starved out (73min > 40min cap, never fired).
+                # Budget = cap + margin so the in-process layers get their full
+                # window first; this fires ONLY if even they were starved.
+                self._arm_external_watchdog(_wall_cap)
 
             # ProcessMemoryWatchdog — adaptive RSS ceiling on the soak
             # process TREE. Protective by default (the 52GB OOM had NO
@@ -5408,6 +5415,71 @@ class BattleTestHarness:
     # Hot-reload Restart Monitor
     # ------------------------------------------------------------------
 
+    def _arm_external_watchdog(self, cap_s: float) -> None:
+        """Slice 49 — spawn the out-of-process GIL-immune kill sentinel.
+
+        Belt-and-braces beyond the in-process resource-zero thread (which v44
+        proved can be GIL-starved). Default ON; opt out via
+        ``JARVIS_EXTERNAL_WATCHDOG_ENABLED=false``. Budget = cap + margin so
+        the in-process graceful + resource-zero layers always get first crack;
+        this only fires if they were starved. NEVER raises into boot.
+        """
+        if os.environ.get(
+            "JARVIS_EXTERNAL_WATCHDOG_ENABLED", "true",
+        ).strip().lower() in ("false", "0", "no", "off"):
+            return
+        try:
+            from backend.core.ouroboros.governance.external_watchdog import (
+                ExternalProcessWatchdog,
+            )
+
+            def _env_f(name: str, default: float) -> float:
+                raw = os.environ.get(name, "").strip()
+                try:
+                    return float(raw) if raw else default
+                except (TypeError, ValueError):
+                    return default
+
+            margin_s = max(30.0, _env_f("JARVIS_EXTERNAL_WATCHDOG_MARGIN_S", 90.0))
+            stale_s = max(30.0, _env_f("JARVIS_EXTERNAL_WATCHDOG_STALE_S", 120.0))
+            hb_path = self._session_dir / "heartbeat.tick"
+            self._external_watchdog = ExternalProcessWatchdog(
+                target_pid=os.getpid(),
+                heartbeat_path=hb_path,
+                budget_s=float(cap_s) + margin_s,
+                stale_window_s=stale_s,
+            )
+            self._external_watchdog.arm()
+            logger.info(
+                "[ExternalWatchdog] armed: budget=%.0fs stale=%.0fs pid=%d "
+                "(out-of-process, GIL-immune backstop)",
+                float(cap_s) + margin_s, stale_s, os.getpid(),
+            )
+        except Exception as exc:  # noqa: BLE001 -- never break boot
+            self._external_watchdog = None
+            logger.warning(
+                "[ExternalWatchdog] arm failed (non-fatal): %s", exc,
+            )
+
+    def _beat_external_watchdog(self) -> None:
+        """Touch the heartbeat so the external sentinel sees liveness."""
+        wd = getattr(self, "_external_watchdog", None)
+        if wd is not None:
+            try:
+                wd.beat()
+            except Exception:  # noqa: BLE001 -- best-effort liveness
+                pass
+
+    def _disarm_external_watchdog(self) -> None:
+        """Terminate the external sentinel on clean shutdown."""
+        wd = getattr(self, "_external_watchdog", None)
+        if wd is not None:
+            try:
+                wd.disarm()
+            except Exception:  # noqa: BLE001
+                pass
+            self._external_watchdog = None
+
     def _start_wall_clock_hard_deadline_thread(
         self, cap_s: float,
     ) -> None:
@@ -5745,6 +5817,10 @@ class BattleTestHarness:
                 )
                 return
             _tick += 1
+            # Slice 49 — refresh the external sentinel's heartbeat each tick.
+            # If THIS loop is wedged, beats stop and the external staleness
+            # window fires; the external budget fires regardless of beats.
+            self._beat_external_watchdog()
             elapsed_monotonic = time.monotonic() - anchor_monotonic
             elapsed_wall = max(0.0, time.time() - anchor_wall)
             # Layer 7 dual-clock cap check — fire on whichever ticks
@@ -6287,6 +6363,12 @@ class BattleTestHarness:
         not prevent the remaining components from being cleaned up.
         """
         logger.info("Shutting down session %s ...", self._session_id)
+
+        # Slice 49 — clean shutdown has begun, so the main loop is no longer
+        # the concern; retire the external sentinel before teardown so it
+        # cannot SIGKILL during a legitimate (BoundedShutdownWatchdog-governed)
+        # cleanup. The in-process ShutdownWatchdog covers shutdown-path hangs.
+        self._disarm_external_watchdog()
 
         # ── Slice 12V Phase 1 — WAL-first shutdown ──
         #

--- a/backend/core/ouroboros/governance/external_watchdog.py
+++ b/backend/core/ouroboros/governance/external_watchdog.py
@@ -1,0 +1,225 @@
+"""Slice 49 — External Subprocess Watchdog (GIL-immune terminal kill path).
+
+v44 (bt-2026-05-31-002950) ran 73 min past a 40-min ``--max-wall-seconds``
+cap because the in-process resource-zero watchdog — a Python thread — never
+fired under FS-scan GIL contention. A watchdog that shares the interpreter
+with the system it guards can be starved out. The fix is a SEPARATE OS
+process: it cannot be GIL-starved by the parent by construction.
+
+Architecture (aligned with the Slice 47 Watchdog Isolation Invariant — this
+sentinel is even MORE isolated than the resource-zero thread, since it shares
+no interpreter, GIL, logging lock, or signal queue with the parent):
+
+  * The parent ``beat()``s a WALL timestamp into a heartbeat file each loop
+    tick. (monotonic clocks are NOT comparable across processes, so the
+    cross-process liveness signal must be wall-clock.)
+  * The child sentinel polls the file with its OWN clocks and decides:
+      - BUDGET kill — wall-authoritative: once total session wall exceeds the
+        budget it SIGKILLs the parent regardless of GIL state. This is the
+        backstop that should have killed v44.
+      - STALENESS kill — suspend-aware: a stale heartbeat means a wedge ONLY
+        if real time elapsed. A host sleep (wall jumps while the child's
+        monotonic barely moves) must NOT be mistaken for a wedge (Slice 46).
+
+This module is STDLIB-ONLY on purpose: the sentinel subprocess must start
+fast and never depend on the (possibly wedged or un-importable) backend
+package. It is both the importable/testable module AND the subprocess entry
+point (``python external_watchdog.py --watch <pid> <hb> <budget> <stale>``).
+"""
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def _suspend_detected(
+    mono_delta: float, wall_delta: float, threshold: float,
+) -> bool:
+    """True if this poll interval looks like a host suspend.
+
+    During suspend the wall clock keeps advancing (or jumps on resume) while
+    the monotonic clock pauses, so ``wall_delta`` greatly exceeds
+    ``mono_delta``. Genuine elapsed time advances both ~equally.
+    """
+    return (wall_delta - mono_delta) > threshold
+
+
+def evaluate_kill(
+    *,
+    now_wall: float,
+    armed_wall: float,
+    last_beat_wall: float,
+    budget_s: float,
+    stale_window_s: float,
+    suspended: bool,
+) -> Tuple[bool, str]:
+    """Pure kill decision for one poll.
+
+    Budget is wall-authoritative (fires across suspend, matching
+    ``--max-wall-seconds`` semantics). Staleness fires only when NOT a suspend
+    interval, so a host sleep never forges a wedge.
+    """
+    if (now_wall - armed_wall) >= budget_s:
+        return True, "wall_budget_exceeded"
+    if not suspended and (now_wall - last_beat_wall) >= stale_window_s:
+        return True, "heartbeat_stale"
+    return False, ""
+
+
+def _read_beat(heartbeat_path: str) -> Optional[float]:
+    """Read the parent's last wall timestamp; None on any error."""
+    try:
+        with open(heartbeat_path, "r") as f:
+            return float(f.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def run_watchdog(
+    target_pid: int,
+    heartbeat_path: str,
+    budget_s: float,
+    stale_window_s: float,
+    poll_s: float = 1.0,
+    suspend_threshold_s: float = 5.0,
+) -> str:
+    """Sentinel loop (runs in the child process). Returns the kill reason.
+
+    SIGKILLs ``target_pid`` when the budget or a real (non-suspend) staleness
+    window is exceeded, then returns. Exits early if the parent already died.
+    """
+    armed_wall = time.time()
+    armed_mono = time.monotonic()
+    prev_wall = armed_wall
+    prev_mono = armed_mono
+    # If the parent never writes a beat, fall back to arm time so the budget
+    # path still governs.
+    while True:
+        time.sleep(poll_s)
+        now_wall = time.time()
+        now_mono = time.monotonic()
+        suspended = _suspend_detected(
+            now_mono - prev_mono, now_wall - prev_wall, suspend_threshold_s,
+        )
+        prev_wall, prev_mono = now_wall, now_mono
+
+        # Parent already gone? nothing to guard.
+        try:
+            os.kill(target_pid, 0)
+        except ProcessLookupError:
+            return "parent_exited"
+        except PermissionError:
+            pass  # alive, different ownership — keep guarding
+
+        last_beat = _read_beat(heartbeat_path)
+        if last_beat is None:
+            last_beat = armed_wall  # no beat yet → budget still applies
+
+        kill, reason = evaluate_kill(
+            now_wall=now_wall, armed_wall=armed_wall, last_beat_wall=last_beat,
+            budget_s=budget_s, stale_window_s=stale_window_s, suspended=suspended,
+        )
+        if kill:
+            try:
+                os.write(
+                    2,
+                    (
+                        "\n[ExternalWatchdog] SIGKILL parent pid=%d "
+                        "reason=%s (out-of-process, GIL-immune)\n"
+                        % (target_pid, reason)
+                    ).encode("ascii", "replace"),
+                )
+            except Exception:
+                pass
+            try:
+                os.kill(target_pid, signal.SIGKILL)
+            except OSError:
+                pass
+            return reason
+
+
+class ExternalProcessWatchdog:
+    """Manager wiring the parent to its out-of-process sentinel.
+
+    Lifecycle: ``arm()`` once at boot, ``beat()`` each main-loop tick,
+    ``disarm()`` on clean shutdown. The sentinel is a detached child process
+    (``start_new_session=True``) so it survives parent thread wedges.
+    """
+
+    def __init__(
+        self,
+        target_pid: int,
+        heartbeat_path: "Path",
+        budget_s: float,
+        stale_window_s: float,
+        poll_s: float = 1.0,
+    ) -> None:
+        self.target_pid = int(target_pid)
+        self.heartbeat_path = Path(heartbeat_path)
+        self.budget_s = float(budget_s)
+        self.stale_window_s = float(stale_window_s)
+        self.poll_s = float(poll_s)
+        self._proc: Optional["object"] = None
+
+    def beat(self) -> None:
+        """Atomically write the current wall timestamp to the heartbeat file."""
+        try:
+            self.heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self.heartbeat_path.with_suffix(
+                self.heartbeat_path.suffix + ".tmp"
+            )
+            tmp.write_text(repr(time.time()))
+            os.replace(tmp, self.heartbeat_path)
+        except OSError:
+            pass  # best-effort — a missed beat just shortens the stale margin
+
+    def arm(self) -> None:
+        """Spawn the detached sentinel subprocess."""
+        import subprocess
+
+        self.beat()  # seed the heartbeat before the child starts polling
+        self._proc = subprocess.Popen(
+            [
+                sys.executable, os.path.abspath(__file__), "--watch",
+                str(self.target_pid), str(self.heartbeat_path),
+                str(self.budget_s), str(self.stale_window_s), str(self.poll_s),
+            ],
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,  # detach — survives parent thread wedges
+        )
+
+    def disarm(self) -> None:
+        """Terminate the sentinel on clean shutdown."""
+        proc = self._proc
+        if proc is None:
+            return
+        try:
+            proc.terminate()  # type: ignore[attr-defined]
+            proc.wait(timeout=3)  # type: ignore[attr-defined]
+        except Exception:
+            try:
+                proc.kill()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+        self._proc = None
+
+
+def _main(argv: list) -> int:
+    # argv: --watch <pid> <heartbeat_path> <budget_s> <stale_window_s> [poll_s]
+    if not argv or argv[0] != "--watch" or len(argv) < 5:
+        return 2
+    pid = int(argv[1])
+    hb = argv[2]
+    budget_s = float(argv[3])
+    stale_window_s = float(argv[4])
+    poll_s = float(argv[5]) if len(argv) >= 6 else 1.0
+    run_watchdog(pid, hb, budget_s, stale_window_s, poll_s=poll_s)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv[1:]))

--- a/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
@@ -259,6 +259,41 @@ def _todo_fixme_count(source: str) -> int:
     return len(re.findall(r"#\s*(?:TODO|FIXME|HACK|XXX)\b", source, re.IGNORECASE))
 
 
+# Slice 49 — directory segments PRUNED during the file walk itself. rglob()
+# cannot prune (it stats every descendant before any filter), so v44 walked
+# the 437MB .jarvis/swe_bench_pro tree at 107% CPU. os.walk with in-place
+# ``dirs[:]`` pruning never descends into these trees → the OS never stats
+# them. Distinct from _NON_PROJECT_SEGMENTS (post-walk production-code
+# classification): this set is about NEVER TRAVERSING heavy/non-source trees.
+_WALK_PRUNE_SEGMENTS: frozenset = frozenset({
+    ".jarvis", ".worktrees", ".ouroboros",
+    ".git", "node_modules", "__pycache__",
+    ".venv", "venv", ".mypy_cache", ".pytest_cache",
+    "build", "dist", ".eggs",
+})
+
+
+def _iter_python_files_pruned(
+    root: "Path",
+    skip_segments: "frozenset",
+) -> "List[Path]":
+    """Walk ``root`` for ``*.py`` files, pruning ``skip_segments`` dirs.
+
+    Uses ``os.walk`` with in-place ``dirs[:]`` mutation so excluded trees are
+    NEVER descended into — the OS never scandir/stats inside them (unlike
+    ``rglob`` which traverses the entire subtree before any filter). This is
+    the Slice 49 fix for the v44 FS-scan wedge.
+    """
+    found: "List[Path]" = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune in place so os.walk does not descend into excluded dirs.
+        dirnames[:] = [d for d in dirnames if d not in skip_segments]
+        for name in filenames:
+            if name.endswith(".py"):
+                found.append(Path(dirpath) / name)
+    return found
+
+
 def _analyze_file(
     file_path: str,
     source: str,
@@ -567,8 +602,13 @@ class OpportunityMinerSensor:
             # loop entirely during the walk. The returned list is
             # then iterable with cooperative yields.
             try:
+                # Slice 49 — pruning walk (never descends into .jarvis/
+                # .worktrees/.ouroboros etc.) replaces rglob, which stat'd
+                # the entire 437MB .jarvis/swe_bench_pro tree in v44.
                 py_files = await offload_blocking(
-                    lambda r=root: list(r.rglob("*.py")),
+                    lambda r=root: _iter_python_files_pruned(
+                        r, _WALK_PRUNE_SEGMENTS,
+                    ),
                     label="opportunity_miner.rglob",
                 )
             except Exception:  # noqa: BLE001 — preserve scan loop

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -259,9 +259,36 @@ def goal_alignment_failure_stats() -> Dict[str, int]:
     return {"failures": _goal_alignment_failures}
 
 
+def _ingest_stratification_enabled() -> bool:
+    """Slice 49 master switch (default ON). Off → byte-identical pre-Slice-49
+    priority (no penalty, no file reads in the hot intake path)."""
+    return os.environ.get(
+        "JARVIS_INGEST_STRATIFICATION_ENABLED", "true",
+    ).strip().lower() not in ("false", "0", "no", "off")
+
+
+def _is_test_generation_intent(envelope: "IntentEnvelope") -> bool:
+    """Slice 49 escape hatch — True when the op's intent is adding test
+    coverage, so the blast-radius penalty is suppressed (lets the organism
+    target and heal its own large uncovered core modules). Conservative:
+    matches explicit coverage/test-generation phrasing or source tags."""
+    src = (getattr(envelope, "source", "") or "").lower()
+    if "coverage" in src or "test_gen" in src or "testgen" in src:
+        return True
+    desc = (getattr(envelope, "description", "") or "").lower()
+    return (
+        "add test" in desc
+        or "test coverage" in desc
+        or "coverage for" in desc
+        or "write tests" in desc
+    )
+
+
 def _compute_priority(
     envelope: "IntentEnvelope",
     dependency_credit: int = 0,
+    *,
+    repo_root: "Optional[Path]" = None,
 ) -> Tuple[int, Optional[Any]]:
     """Compute cost-aware priority score + rich goal alignment for an envelope.
 
@@ -413,10 +440,34 @@ def _compute_priority(
             "[Router] inferred-direction boost skipped: %s", exc,
         )
 
+    # Slice 49 — universal ingestion stratification (SOFT). Add a bounded
+    # penalty for ops targeting large uncovered files so they are processed
+    # last fleet-wide (across -miner AND -cau tracks). This ONLY reorders the
+    # queue; OperationAdvisor.advise() remains the hard blast-radius gate, and
+    # the penalty is fully reachable (no drop) with a test-generation escape.
+    # Authority invariant: priority ordering ONLY — never fed to UrgencyRouter,
+    # Iron Gate, risk tier, policy engine, FORBIDDEN_PATH, or approval gating.
+    stratification_penalty = 0
+    if repo_root is not None and _ingest_stratification_enabled():
+        try:
+            from backend.core.ouroboros.governance.target_stratification import (
+                ingest_priority_penalty,
+            )
+            stratification_penalty = ingest_priority_penalty(
+                envelope.target_files or (),
+                repo_root,
+                suppress=_is_test_generation_intent(envelope),
+            )
+            if stratification_penalty > 0 and isinstance(envelope.evidence, dict):
+                envelope.evidence["stratification_penalty"] = stratification_penalty
+        except Exception as exc:  # noqa: BLE001 -- fail-soft, never break intake
+            logger.debug("[Router] ingest stratification skipped: %s", exc)
+
     priority = (
         base - urgency + cost_penalty - confidence_bonus
         - dep_bonus - goal_boost - semantic_boost
         - inferred_direction_boost
+        + stratification_penalty
     )
     return priority, alignment
 
@@ -749,6 +800,7 @@ class UnifiedIntakeRouter:
                 _dep_credit += len(self._queued_behind.get(_blocking_id, []))
         priority, alignment = _compute_priority(
             envelope, dependency_credit=_dep_credit,
+            repo_root=self._config.project_root,
         )
         # Stash goal-alignment diagnostics on the envelope so downstream
         # phases (orchestrator, SerpentFlow postmortems, dead-letter audit)

--- a/backend/core/ouroboros/governance/target_stratification.py
+++ b/backend/core/ouroboros/governance/target_stratification.py
@@ -28,11 +28,16 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Union
+from typing import Iterable, Union
 
 # Defaults are module constants so tests + callers share one source of truth.
 DEFAULT_PENALTY_ALPHA: float = 0.75
 DEFAULT_PENALTY_MAX_LINES: int = 2000
+# Slice 49 — ingest-priority penalty scale/cap. The worst target file's soft
+# penalty (0..alpha) is projected onto 0..SCALE integer priority points and
+# capped, so it deprioritizes large uncovered ops without ever swamping the
+# base priority scale (sources map to 1..99).
+DEFAULT_INGEST_PENALTY_SCALE: int = 5
 
 
 def _env_float(name: str, default: float) -> float:
@@ -104,3 +109,62 @@ def stratification_penalty_multiplier(
     # Clamp into (1 - alpha, 1.0] defensively (alpha could be mis-set > 1).
     floor = 1.0 - a
     return max(floor, min(1.0, multiplier))
+
+
+def _count_lines(path: Path) -> int:
+    """Cheap line count; 0 on any error (fail-soft, never raises)."""
+    try:
+        with open(path, "rb") as f:
+            return sum(1 for _ in f)
+    except OSError:
+        return 0
+
+
+def ingest_priority_penalty(
+    target_files: Iterable[Union[str, Path]],
+    repo_root: Path,
+    *,
+    suppress: bool = False,
+    alpha: float | None = None,
+    max_lines: int | None = None,
+    scale: int | None = None,
+) -> int:
+    """Integer priority penalty (>= 0) for the central ingest funnel (Slice 49).
+
+    Deprioritizes operations targeting large, uncovered files fleet-wide
+    (added to the priority int, where lower = higher priority). The worst
+    target file dominates; the result is projected onto 0..scale and capped,
+    so it can never swamp the base priority scale. Covered files and the
+    ``suppress`` escape hatch (test-generation intent) yield 0. Fail-soft:
+    any error on a file contributes 0, never raises.
+
+    Stays SOFT by construction — this only reorders the queue. The hard
+    blast-radius gate remains OperationAdvisor.advise().
+    """
+    if suppress:
+        return 0
+    a = DEFAULT_PENALTY_ALPHA if alpha is None else alpha
+    if alpha is None:
+        a = _env_float("JARVIS_STRATIFICATION_PENALTY_ALPHA", a)
+    sc = DEFAULT_INGEST_PENALTY_SCALE if scale is None else scale
+    if scale is None:
+        sc = _env_int("JARVIS_INGEST_STRATIFICATION_SCALE", sc)
+    if sc <= 0:
+        return 0
+
+    worst = 0.0
+    for f in target_files or ():
+        name = Path(f).name
+        if not name.endswith(".py") or "test_" in name:
+            continue
+        if file_has_test_coverage(f, repo_root):
+            continue
+        lines = _count_lines(repo_root / f)
+        if lines <= 0:
+            continue
+        mult = stratification_penalty_multiplier(
+            lines, has_test_coverage=False, alpha=a, max_lines=max_lines,
+        )
+        worst = max(worst, 1.0 - mult)  # 0..alpha
+
+    return min(sc, round(worst * sc))

--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -181,6 +181,13 @@ class OracleConfig:
         # session/telemetry tree.
         ".worktrees",
         ".ouroboros",
+        # Slice 49 — the substring match below (``pattern in path_str``)
+        # means ``.worktrees`` never matched ``.jarvis/swe_bench_pro/
+        # worktrees`` (437MB / 26,839 files), so v44 walked + ast-parsed
+        # that whole tree at 107% CPU. ``.jarvis`` is the repo-local state
+        # dir (swe_bench checkouts, session telemetry, locks) — never source
+        # to index. Substring ``.jarvis`` covers the entire subtree.
+        ".jarvis",
     ]
 
     # File types to index

--- a/tests/governance/test_slice49_external_watchdog.py
+++ b/tests/governance/test_slice49_external_watchdog.py
@@ -1,0 +1,135 @@
+"""Slice 49 Phase 2 — external subprocess watchdog (GIL-immune kill path).
+
+v44 wedged 73min past a 40min cap because the in-process resource-zero
+watchdog (a Python thread) never fired. The fix: an OUT-OF-PROCESS sentinel
+that SIGKILLs the parent from outside the interpreter entirely — it cannot
+be GIL-starved by construction.
+
+Design:
+  * parent `beat()`s a wall timestamp into a heartbeat file each loop tick
+  * the child polls the file with its OWN clocks
+  * BUDGET kill is wall-authoritative (fires at --max-wall-seconds regardless
+    of GIL — this is what should have killed v44)
+  * STALENESS kill is suspend-aware: a host sleep (wall jumps but the child's
+    monotonic barely moves) must NOT be mistaken for a wedge (Slice 46 lesson)
+
+Pins:
+  §1  budget exceeded → kill (wall-authoritative)
+  §2  stale heartbeat (real wedge) → kill
+  §3  suspend interval (wall>>monotonic) → NO staleness kill
+  §4  fresh heartbeat within window → no kill
+  §5  suspend detector: wall-monotonic divergence past threshold
+  §6  beat() writes a parseable wall timestamp atomically
+  §7  END-TO-END: an armed watchdog actually SIGKILLs a stalled victim process
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.external_watchdog import (
+    ExternalProcessWatchdog,
+    _suspend_detected,
+    evaluate_kill,
+)
+
+
+# ── §1 budget (wall-authoritative) ──────────────────────────────────────
+def test_budget_exceeded_kills() -> None:
+    kill, reason = evaluate_kill(
+        now_wall=1000.0, armed_wall=900.0, last_beat_wall=999.0,
+        budget_s=60.0, stale_window_s=30.0, suspended=False,
+    )
+    assert kill and reason == "wall_budget_exceeded"
+
+
+# ── §2 stale heartbeat (real wedge) ─────────────────────────────────────
+def test_stale_heartbeat_kills() -> None:
+    kill, reason = evaluate_kill(
+        now_wall=1000.0, armed_wall=995.0, last_beat_wall=900.0,
+        budget_s=3600.0, stale_window_s=30.0, suspended=False,
+    )
+    assert kill and reason == "heartbeat_stale"
+
+
+# ── §3 suspend must NOT trigger a staleness kill ────────────────────────
+def test_suspend_does_not_kill_on_staleness() -> None:
+    kill, _ = evaluate_kill(
+        now_wall=1000.0, armed_wall=995.0, last_beat_wall=900.0,
+        budget_s=3600.0, stale_window_s=30.0, suspended=True,
+    )
+    assert kill is False
+
+
+# ── §4 fresh heartbeat ──────────────────────────────────────────────────
+def test_fresh_heartbeat_no_kill() -> None:
+    kill, _ = evaluate_kill(
+        now_wall=1000.0, armed_wall=995.0, last_beat_wall=998.0,
+        budget_s=3600.0, stale_window_s=30.0, suspended=False,
+    )
+    assert kill is False
+
+
+# ── §5 suspend detector ─────────────────────────────────────────────────
+def test_suspend_detector() -> None:
+    # wall jumped 300s but monotonic only moved 2s → host slept
+    assert _suspend_detected(mono_delta=2.0, wall_delta=300.0, threshold=5.0)
+    # both advanced ~equally → genuine elapsed time (wedge candidate)
+    assert not _suspend_detected(mono_delta=29.0, wall_delta=30.0, threshold=5.0)
+
+
+# ── §6 beat() writes parseable timestamp ────────────────────────────────
+def test_beat_writes_wall_timestamp(tmp_path: Path) -> None:
+    hb = tmp_path / "heartbeat.tick"
+    wd = ExternalProcessWatchdog(
+        target_pid=99999, heartbeat_path=hb, budget_s=60.0, stale_window_s=30.0,
+    )
+    before = time.time()
+    wd.beat()
+    val = float(hb.read_text().strip())
+    assert before - 1.0 <= val <= time.time() + 1.0
+
+
+# ── §7 END-TO-END: real subprocess kill of a stalled victim ─────────────
+@pytest.mark.timeout(30)
+def test_watchdog_kills_stalled_victim(tmp_path: Path) -> None:
+    victim = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        hb = tmp_path / "heartbeat.tick"
+        wd = ExternalProcessWatchdog(
+            target_pid=victim.pid, heartbeat_path=hb,
+            budget_s=1.5, stale_window_s=1.5, poll_s=0.25,
+        )
+        wd.arm()  # spawns the external sentinel; never beats → budget fires
+        # poll for the victim to die
+        deadline = time.time() + 12.0
+        while time.time() < deadline and victim.poll() is None:
+            time.sleep(0.25)
+        assert victim.poll() is not None, "watchdog did not kill the stalled victim"
+        wd.disarm()
+    finally:
+        if victim.poll() is None:
+            victim.kill()
+            victim.wait(timeout=5)
+
+
+# ── §8 harness wiring pin (arm at boot / beat in monitor / disarm on stop) ─
+def test_harness_wires_external_watchdog() -> None:
+    import backend.core.ouroboros.battle_test.harness as _h
+    src = Path(_h.__file__).read_text()
+    # arm at boot — right after the in-process hard-deadline thread
+    assert "_arm_external_watchdog(_wall_cap)" in src
+    # beat each wall-clock monitor tick
+    assert "self._beat_external_watchdog()" in src
+    # disarm at clean shutdown
+    assert "self._disarm_external_watchdog()" in src
+    # the three methods exist on the harness class
+    for m in (
+        "_arm_external_watchdog", "_beat_external_watchdog",
+        "_disarm_external_watchdog",
+    ):
+        assert hasattr(_h.BattleTestHarness, m), f"missing {m}"

--- a/tests/governance/test_slice49_ingest_stratification.py
+++ b/tests/governance/test_slice49_ingest_stratification.py
@@ -1,0 +1,84 @@
+"""Slice 49 Phase 3 — universal ingestion stratification (soft, at the funnel).
+
+OperationAdvisor.advise() already HARD-gates blast-radius on every op
+(classify_runner.py:396). This adds a SOFT priority penalty at the single
+funnel UnifiedIntakeRouter.ingest -> _compute_priority, so large uncovered
+targets are deprioritized (processed last) fleet-wide across ALL sensor
+tracks — while staying fully reachable (no drop), with a test-gen escape.
+
+Pins:
+  §1  no files / covered file → zero penalty
+  §2  huge uncovered file → positive penalty (deprioritized)
+  §3  suppress (test-gen escape) → zero penalty
+  §4  penalty is bounded (cannot dominate the whole priority scale)
+  §5  _compute_priority: huge-uncovered envelope ranks WORSE than small-covered
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.target_stratification import (
+    ingest_priority_penalty,
+)
+
+
+def _mk(root: Path, rel: str, lines: int, *, covered: bool) -> str:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("x = 1\n" * lines)
+    if covered:
+        (root / "tests").mkdir(exist_ok=True)
+        (root / "tests" / f"test_{Path(rel).stem}.py").write_text("def test(): pass\n")
+    return rel
+
+
+# ── §1 ─────────────────────────────────────────────────────────────────
+def test_no_files_or_covered_is_zero(tmp_path: Path) -> None:
+    assert ingest_priority_penalty([], tmp_path) == 0
+    rel = _mk(tmp_path, "backend/big.py", 5000, covered=True)
+    assert ingest_priority_penalty([rel], tmp_path) == 0
+
+
+# ── §2 ─────────────────────────────────────────────────────────────────
+def test_huge_uncovered_gets_penalty(tmp_path: Path) -> None:
+    rel = _mk(tmp_path, "backend/huge.py", 5000, covered=False)
+    assert ingest_priority_penalty([rel], tmp_path) > 0
+
+
+# ── §3 ─────────────────────────────────────────────────────────────────
+def test_suppress_escape_hatch(tmp_path: Path) -> None:
+    rel = _mk(tmp_path, "backend/huge.py", 5000, covered=False)
+    assert ingest_priority_penalty([rel], tmp_path, suppress=True) == 0
+
+
+# ── §4 ─────────────────────────────────────────────────────────────────
+def test_penalty_is_bounded(tmp_path: Path) -> None:
+    rels = [_mk(tmp_path, f"backend/h{i}.py", 9000, covered=False) for i in range(5)]
+    pen = ingest_priority_penalty(rels, tmp_path)
+    assert 0 < pen <= 5  # bounded — cannot swamp base priorities (1..99)
+
+
+# ── §5 integration with _compute_priority ───────────────────────────────
+def test_compute_priority_deprioritizes_huge_uncovered(tmp_path: Path) -> None:
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (
+        _compute_priority,
+    )
+    from backend.core.ouroboros.governance.intake.intent_envelope import make_envelope
+
+    huge = _mk(tmp_path, "backend/huge.py", 5000, covered=False)
+    small = _mk(tmp_path, "backend/small.py", 40, covered=True)
+
+    common = dict(
+        source="ai_miner", description="improve", repo="jarvis",
+        confidence=0.5, urgency="normal", evidence={}, requires_human_ack=True,
+    )
+    env_huge = make_envelope(target_files=(huge,), **common)
+    env_small = make_envelope(target_files=(small,), **common)
+
+    p_huge, _ = _compute_priority(env_huge, repo_root=tmp_path)
+    p_small, _ = _compute_priority(env_small, repo_root=tmp_path)
+
+    # lower int = higher priority; the huge uncovered op must rank WORSE
+    assert p_huge > p_small

--- a/tests/governance/test_slice49_scanner_exclusions.py
+++ b/tests/governance/test_slice49_scanner_exclusions.py
@@ -1,0 +1,74 @@
+"""Slice 49 Phase 1 — Python-scanner traversal exclusions.
+
+v44 wedged at 107% CPU on os.scandir/os.stat walking + ast-parsing
+`.jarvis/swe_bench_pro/worktrees` (437MB / 26,839 files). FileWatchGuard
+already excluded it — the storm came from the PYTHON scanners:
+  * Oracle EXCLUDE_PATTERNS had .worktrees/.ouroboros (Slice 44) but NOT
+    .jarvis, and its substring match (`pattern in path_str`) means
+    `.worktrees` never matched `.jarvis/swe_bench_pro/worktrees`.
+  * OpportunityMiner did `root.rglob("*.py")` over "." — the walk itself
+    traversed every file; post-walk _is_production_code filtering was too late.
+
+Pins:
+  §1  Oracle EXCLUDE_PATTERNS covers .jarvis (+ Slice 44 .worktrees/.ouroboros)
+  §2  a .jarvis/swe_bench_pro/worktrees path is excluded by the substring rule
+  §3  miner pruning walk never descends into .jarvis/.worktrees/.ouroboros
+  §4  miner pruning walk still returns real source files
+  §5  pruning happens DURING traversal (excluded dirs are never stat'd deep)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.core.ouroboros.oracle import OracleConfig
+from backend.core.ouroboros.governance.intake.sensors.opportunity_miner_sensor import (
+    _WALK_PRUNE_SEGMENTS,
+    _iter_python_files_pruned,
+)
+
+
+# ── §1 Oracle pattern coverage ──────────────────────────────────────────
+def test_oracle_excludes_jarvis_and_worktrees() -> None:
+    pats = set(OracleConfig.EXCLUDE_PATTERNS)
+    assert ".jarvis" in pats
+    assert ".worktrees" in pats
+    assert ".ouroboros" in pats
+
+
+# ── §2 swe_bench path excluded via substring ────────────────────────────
+def test_oracle_substring_excludes_nested_swe_bench() -> None:
+    path = "/repo/.jarvis/swe_bench_pro/worktrees/inst/copy-i18n.py"
+    assert any(p in path for p in OracleConfig.EXCLUDE_PATTERNS)
+
+
+# ── §3/§4/§5 miner pruning walk ─────────────────────────────────────────
+def test_miner_walk_prunes_heavy_trees(tmp_path: Path) -> None:
+    # real source
+    (tmp_path / "backend" / "core").mkdir(parents=True)
+    (tmp_path / "backend" / "core" / "real.py").write_text("x = 1\n")
+    # trees that must NEVER be walked
+    swe = tmp_path / ".jarvis" / "swe_bench_pro" / "worktrees" / "inst"
+    swe.mkdir(parents=True)
+    (swe / "junk.py").write_text("print 'py2'\n")  # would SyntaxError if parsed
+    (tmp_path / ".worktrees" / "wt").mkdir(parents=True)
+    (tmp_path / ".worktrees" / "wt" / "dup.py").write_text("y = 2\n")
+    (tmp_path / ".ouroboros" / "sessions").mkdir(parents=True)
+    (tmp_path / ".ouroboros" / "sessions" / "log.py").write_text("z = 3\n")
+
+    found = _iter_python_files_pruned(tmp_path, _WALK_PRUNE_SEGMENTS)
+    names = {p.name for p in found}
+
+    assert "real.py" in names
+    assert "junk.py" not in names
+    assert "dup.py" not in names
+    assert "log.py" not in names
+    # nothing under an excluded segment leaked through
+    assert all(
+        not any(seg in p.parts for seg in (".jarvis", ".worktrees", ".ouroboros"))
+        for p in found
+    )
+
+
+def test_prune_segments_include_the_heavy_trees() -> None:
+    for seg in (".jarvis", ".worktrees", ".ouroboros"):
+        assert seg in _WALK_PRUNE_SEGMENTS


### PR DESCRIPTION
## Summary
Closes the **v44 wedge** (107% CPU, 73 min > 40 min cap, the in-process watchdog never fired) and generalizes Slice 48 fleet-wide. All three runbook targets were corrected after verifying the real code (FileWatchGuard already excluded the trees; Oracle._save_cache was the wrong Phase-2 target; advise() already gates).

### Phase 1 — Python-scanner traversal exclusions (the real FS-scan culprit)
FileWatchGuard **already** excluded `.jarvis`/`.worktrees`/`swe_bench_pro`. The storm came from the **python scanners** walking + ast-parsing `.jarvis/swe_bench_pro` (437 MB / 26,839 files):
- `oracle.py`: `EXCLUDE_PATTERNS += ".jarvis"` (substring match — `.worktrees` never matched `.jarvis/swe_bench_pro/worktrees`; the Slice 44 gap).
- `opportunity_miner_sensor.py`: replaced unprunable `rglob("*.py")` with `_iter_python_files_pruned` (`os.walk` + in-place `dirs[:]` prune) so excluded trees are **never stat'd**.

### Phase 2 — External Subprocess Watchdog (GIL-immune; the v44 fix)
New stdlib-only `external_watchdog.py`: a **detached child process** SIGKILLs the parent from outside the interpreter — cannot be GIL-starved by construction (more isolated than the resource-zero thread; aligned with the Slice 47 invariant). Parent `beat()`s a **wall** timestamp (monotonic isn't cross-process comparable); the child decides via pure `evaluate_kill`: **budget kill is wall-authoritative** (fires at the cap regardless of GIL — what v44 needed), **staleness kill is suspend-aware** (`wall >> monotonic` ⇒ host sleep ⇒ no false wedge, the Slice 46 lesson). Wired into the harness (arm after the in-process hard-deadline thread with `budget = cap + margin`, beat each monitor tick, disarm at clean shutdown). `JARVIS_EXTERNAL_WATCHDOG_ENABLED` default-on. **An end-to-end test spawns a real victim process and confirms the sentinel SIGKILLs it.**

### Phase 3 — Universal ingest stratification (soft, fleet-wide)
`OperationAdvisor.advise()` already hard-gates every op, so no `TaskAdmissionController`. Applied the Slice 48 soft penalty to `UnifiedIntakeRouter.ingest → _compute_priority` (the funnel all sensor tracks pass through, `-miner` **and** `-cau`): large uncovered targets are **deprioritized** fleet-wide, never dropped, with a test-generation escape hatch. Authority invariant: priority ordering only.

## Tests — 17 new, regression-clean
64 passed across the new specs + the 10 wall-clock harness pins (unchanged) + 37 heavy-probe pins. The 5 adjacent-suite failures were verified **pre-existing on clean main** (intake-router `GLS.submit`, oracle libmalloc comment pin) or **sandbox artifacts** (`slice32` process-pool `PermissionError`; pass 11/11 unsandboxed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GIL‑immune external watchdog to enforce wall‑clock budgets, prunes heavy state directories from Python scanners, and applies soft ingest stratification to deprioritize large uncovered targets. This fixes the v44 overrun and FS‑scan wedge by killing on time and avoiding `.jarvis` traversal.

- **New Features**
  - External subprocess watchdog that SIGKILLs the parent on wall‑budget or real staleness; suspend‑aware, armed/beat/disarmed in the harness; toggled by `JARVIS_EXTERNAL_WATCHDOG_ENABLED` (margin/stale tunables available).
  - Universal ingest stratification: adds a bounded, soft priority penalty for large uncovered files across all tracks; never drops work and ignores test‑generation intents; toggled by `JARVIS_INGEST_STRATIFICATION_ENABLED`.

- **Bug Fixes**
  - Prevent Python scanners from walking repo state trees: add `.jarvis` to Oracle exclusions and replace `rglob("*.py")` with a pruned `os.walk` so `.jarvis/.worktrees/.ouroboros` are never traversed.

<sup>Written for commit 6185ec1332bbf8364e9d8e224df1047646b4edfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/65634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

