### PR TITLE
feat(governance): Slice 53 — dual-lane total-outage circuit breaker (Option A, gated)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -818,6 +818,36 @@ def apply_force_batch_deadline_floor(
         return gen_timeout_s
     return max(gen_timeout_s, force_batch_gen_timeout_floor_s())
 
+
+def _note_dw_total_outage(diagnostic: str) -> None:
+    """Slice 53 — record one GENERATE op that exhausted ALL DW models with no
+    candidate from streaming OR batch (the total-vendor-blackout signature).
+
+    Routed through the dual-lane breaker singleton. NEVER raises (defensive
+    lazy import) — recording is best-effort observability + breaker state, it
+    must not perturb the generation error path it sits on.
+    """
+    try:
+        from backend.core.ouroboros.governance.dual_lane_breaker import (
+            get_dual_lane_breaker,
+        )
+        get_dual_lane_breaker().record_total_outage(diagnostic or "all_models_open")
+    except Exception:  # noqa: BLE001 — never perturb the error path
+        pass
+
+
+def _note_dw_candidate_success() -> None:
+    """Slice 53 — record that some DW lane (or fallback) yielded a candidate,
+    resetting the breaker's consecutive-outage counter. Preserves Slice 41
+    single-lane resilience. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.dual_lane_breaker import (
+            get_dual_lane_breaker,
+        )
+        get_dual_lane_breaker().record_success()
+    except Exception:  # noqa: BLE001
+        pass
+
 # ---------------------------------------------------------------------------
 # Content failure classification
 # ---------------------------------------------------------------------------
@@ -2255,6 +2285,7 @@ class CandidateGenerator:
                 context, deadline, _provider_route,
             )
             if _result is not None:
+                _note_dw_candidate_success()  # Slice 53 — a lane yielded a candidate
                 return _result
             # _dispatch_via_sentinel returns None to signal "fall
             # through to legacy path" (e.g. the route has empty
@@ -3202,10 +3233,12 @@ class CandidateGenerator:
             # Same exception shape the orchestrator's existing
             # accept-failure branch already handles for BG/SPEC.
             if provider_route == "speculative":
+                _note_dw_total_outage(last_failure or "")  # Slice 53
                 raise RuntimeError(
                     f"speculative_deferred:dw_severed_queued:"
                     f"{(last_failure or 'all_models_open')[:120]}"
                 )
+            _note_dw_total_outage(last_failure or "")  # Slice 53
             raise RuntimeError(
                 f"background_dw_blocked_by_topology:"
                 f"dw_severed_queued:"
@@ -3213,6 +3246,7 @@ class CandidateGenerator:
             )
         # cascade_to_claude — Claude is the explicit cost contract.
         if self._fallback is None:
+            _note_dw_total_outage(last_failure or "")  # Slice 53
             raise RuntimeError(
                 f"sentinel_dispatch_no_fallback:"
                 f"{(last_failure or 'all_models_open')[:120]}"

--- a/backend/core/ouroboros/governance/dual_lane_breaker.py
+++ b/backend/core/ouroboros/governance/dual_lane_breaker.py
@@ -1,0 +1,142 @@
+"""Slice 53 — dual-lane total-outage circuit breaker.
+
+Closes the DW-only blackout gap surfaced by v45/v46 + the Slice 51 vendor
+repro: when DoubleWord returns empty token streams under HTTP 200 on BOTH the
+streaming preflight AND the batch generation, every GENERATE op exhausts all DW
+models and burns retry tokens indefinitely. The existing
+``ProviderExhaustionWatcher`` does not catch this because DW-only exhaustions
+raise ``fallback_skipped:no_fallback_configured`` which is deliberately NOT
+counted toward its hibernation threshold (so single-fallback-less ops don't
+hibernate the loop).
+
+Option A — gated dual-lane isolation. A single GENERATE op only fails to yield
+a candidate from EITHER lane when BOTH lanes are empty (streaming degraded AND
+batch generation empty). So:
+
+  * ``record_total_outage()`` — call when an op exhausts all DW models with no
+    candidate from streaming or batch. Increments a consecutive counter.
+  * ``record_success()`` — call when any lane yields a candidate. Resets the
+    counter. This is what preserves Slice 41's ACTIVE_BATCH_ONLY posture:
+    single-lane streaming degradation still produces a batch candidate, so the
+    counter never climbs to the threshold.
+  * Trips when ``JARVIS_TOTAL_OUTAGE_THRESHOLD`` (default 3) CONSECUTIVE total
+    outages accumulate — a verified total vendor blackout, not a transient.
+
+A tripped breaker is terminal for the session: the orchestrator requests a
+graceful, exit-code-0 pause (state already serialized to summary.json) rather
+than exhausting retry tokens. A late candidate does not silently un-trip it.
+
+Pure, thread-safe, env-driven. NEVER raises.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass
+
+_DEFAULT_THRESHOLD = 3
+_ENABLED_ENV = "JARVIS_DUAL_LANE_BREAKER_ENABLED"
+_THRESHOLD_ENV = "JARVIS_TOTAL_OUTAGE_THRESHOLD"
+
+
+def _enabled() -> bool:
+    """Master switch (default ON). ``=0/false/no/off`` disables — the breaker
+    then records nothing and never trips (byte-identical to pre-Slice-53)."""
+    return (
+        os.environ.get(_ENABLED_ENV, "true").strip().lower()
+        not in ("0", "false", "no", "off")
+    )
+
+
+def _threshold() -> int:
+    """Consecutive total-outage count required to trip (default 3, floor 1)."""
+    try:
+        v = int(os.environ.get(_THRESHOLD_ENV, "").strip())
+        return max(1, v)
+    except (TypeError, ValueError):
+        return _DEFAULT_THRESHOLD
+
+
+@dataclass(frozen=True)
+class BreakerState:
+    """Immutable snapshot for observability surfaces."""
+
+    consecutive_total_outages: int
+    tripped: bool
+    last_diagnostic: str
+    threshold: int
+    enabled: bool
+
+
+class DualLaneOutageBreaker:
+    """Thread-safe consecutive-total-outage counter with a terminal trip."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._consecutive = 0
+        self._tripped = False
+        self._last_diag = ""
+
+    def record_total_outage(self, diagnostic: str = "") -> bool:
+        """Record one op that exhausted BOTH lanes with no candidate.
+
+        Returns ``True`` exactly once — on the call that trips the breaker —
+        so the caller can fire the graceful-pause request a single time.
+        Returns ``False`` while disabled, below threshold, or already tripped.
+        """
+        if not _enabled():
+            return False
+        with self._lock:
+            if self._tripped:
+                return False
+            self._consecutive += 1
+            if diagnostic:
+                self._last_diag = diagnostic[:200]
+            if self._consecutive >= _threshold():
+                self._tripped = True
+                return True
+            return False
+
+    def record_success(self) -> None:
+        """Record that some lane yielded a candidate — resets the consecutive
+        counter (preserves Slice 41 single-lane resilience). Does NOT un-trip a
+        breaker that has already verified a total blackout."""
+        with self._lock:
+            self._consecutive = 0
+
+    def is_tripped(self) -> bool:
+        with self._lock:
+            return self._tripped
+
+    def reset(self) -> None:
+        """Full reset (new session / tests)."""
+        with self._lock:
+            self._consecutive = 0
+            self._tripped = False
+            self._last_diag = ""
+
+    def snapshot(self) -> BreakerState:
+        with self._lock:
+            return BreakerState(
+                consecutive_total_outages=self._consecutive,
+                tripped=self._tripped,
+                last_diagnostic=self._last_diag,
+                threshold=_threshold(),
+                enabled=_enabled(),
+            )
+
+
+# Process-wide singleton — candidate_generator records outcomes, the loop
+# service polls is_tripped(). Lazy so import is side-effect-free.
+_DEFAULT_BREAKER: "DualLaneOutageBreaker | None" = None
+_DEFAULT_LOCK = threading.Lock()
+
+
+def get_dual_lane_breaker() -> DualLaneOutageBreaker:
+    global _DEFAULT_BREAKER
+    if _DEFAULT_BREAKER is None:
+        with _DEFAULT_LOCK:
+            if _DEFAULT_BREAKER is None:
+                _DEFAULT_BREAKER = DualLaneOutageBreaker()
+    return _DEFAULT_BREAKER

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1989,6 +1989,40 @@ class GovernedLoopService:
         """
         start_time = time.monotonic()
 
+        # Gate: Slice 53 dual-lane total-outage breaker. When a verified total
+        # vendor blackout has tripped the breaker (JARVIS_TOTAL_OUTAGE_THRESHOLD
+        # consecutive ops exhausted BOTH the streaming and batch lanes with no
+        # candidate), pause target allocations — refuse new ops so the loop
+        # idles into a clean idle_timeout exit-0 rather than burning retry
+        # tokens against a confirmed-dead provider. Single-lane degradation
+        # never trips it (a working batch lane yields candidates that reset the
+        # counter), so Slice 41 ACTIVE_BATCH_ONLY is preserved.
+        try:
+            from backend.core.ouroboros.governance.dual_lane_breaker import (
+                get_dual_lane_breaker,
+            )
+            _dlb = get_dual_lane_breaker()
+        except Exception:  # noqa: BLE001 — defensive; never block submit on import
+            _dlb = None
+        if _dlb is not None and _dlb.is_tripped():
+            if not getattr(self, "_dual_lane_pause_logged", False):
+                logger.error(
+                    "[GovernedLoop] Dual-lane outage breaker TRIPPED (diag=%s) "
+                    "— pausing target allocations; loop will idle to a clean "
+                    "exit. Disable via JARVIS_DUAL_LANE_BREAKER_ENABLED=false.",
+                    _dlb.snapshot().last_diagnostic,
+                )
+                self._dual_lane_pause_logged = True
+            result = OperationResult(
+                op_id=ctx.op_id,
+                terminal_phase=OperationPhase.CANCELLED,
+                reason_code="dual_lane_outage_paused",
+                trigger_source=trigger_source,
+                terminal_class="DEGRADED",
+            )
+            await self._emit_terminal_events(ctx=ctx, result=result)
+            return result
+
         # Gate: service must be active
         if self._state not in (ServiceState.ACTIVE, ServiceState.DEGRADED):
             result = OperationResult(

--- a/tests/governance/test_slice53_circuit_breaker.py
+++ b/tests/governance/test_slice53_circuit_breaker.py
@@ -1,0 +1,157 @@
+"""Slice 53 — dual-lane total-outage circuit breaker.
+
+Forensic basis (v45/v46 + Slice 51 vendor repro): under DW-only (Claude
+disabled) a verified TOTAL vendor blackout (both the streaming preflight AND
+the batch generation return empty / live_transport RuntimeError) caused every
+GENERATE op to exhaust all DW models and burn retry tokens indefinitely —
+``fallback_skipped:no_fallback_configured`` is deliberately NOT counted toward
+the existing ProviderExhaustionWatcher, so nothing paused the loop.
+
+Option A (gated dual-lane isolation): trip a global breaker only when
+``JARVIS_TOTAL_OUTAGE_THRESHOLD`` (default 3) CONSECUTIVE ops exhaust BOTH
+lanes. A working batch lane (single-lane streaming degradation, Slice 41
+ACTIVE_BATCH_ONLY) still returns a candidate -> ``record_success`` resets the
+counter -> the breaker never trips. So Slice 41's keep-eligible posture is
+preserved for single-lane drops; only a genuine both-lanes-empty blackout trips.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.dual_lane_breaker import (
+    DualLaneOutageBreaker,
+)
+
+
+def _fresh() -> DualLaneOutageBreaker:
+    b = DualLaneOutageBreaker()
+    b.reset()
+    return b
+
+
+def test_trips_after_threshold_consecutive_total_outages(monkeypatch):
+    monkeypatch.setenv("JARVIS_TOTAL_OUTAGE_THRESHOLD", "3")
+    b = _fresh()
+    assert b.record_total_outage("qwen:live_transport") is False  # 1
+    assert b.is_tripped() is False
+    assert b.record_total_outage("qwen:live_transport") is False  # 2
+    assert b.is_tripped() is False
+    tripped_now = b.record_total_outage("qwen:live_transport")     # 3 -> trip
+    assert tripped_now is True
+    assert b.is_tripped() is True
+
+
+def test_record_total_outage_returns_true_only_on_the_tripping_call(monkeypatch):
+    monkeypatch.setenv("JARVIS_TOTAL_OUTAGE_THRESHOLD", "2")
+    b = _fresh()
+    assert b.record_total_outage("x") is False   # 1
+    assert b.record_total_outage("x") is True    # 2 -> trips (edge fires once)
+    assert b.record_total_outage("x") is False   # already tripped — no re-fire
+
+
+def test_single_lane_resilience_success_resets_counter(monkeypatch):
+    """Slice 41 preserved: if the batch lane keeps yielding candidates, the
+    consecutive counter never reaches the threshold."""
+    monkeypatch.setenv("JARVIS_TOTAL_OUTAGE_THRESHOLD", "3")
+    b = _fresh()
+    b.record_total_outage("stream down, batch tried")   # 1
+    b.record_total_outage("stream down, batch tried")   # 2
+    b.record_success()                                   # batch returned a candidate -> reset
+    b.record_total_outage("stream down again")           # 1 (post-reset)
+    b.record_total_outage("stream down again")           # 2
+    assert b.is_tripped() is False, "single-lane drops must never trip the breaker"
+
+
+def test_three_consecutive_after_a_reset_does_trip(monkeypatch):
+    monkeypatch.setenv("JARVIS_TOTAL_OUTAGE_THRESHOLD", "3")
+    b = _fresh()
+    b.record_total_outage("x")
+    b.record_success()  # reset
+    b.record_total_outage("y")
+    b.record_total_outage("y")
+    assert b.is_tripped() is False
+    b.record_total_outage("y")  # 3rd consecutive -> trip
+    assert b.is_tripped() is True
+
+
+def test_threshold_env_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_TOTAL_OUTAGE_THRESHOLD", "1")
+    b = _fresh()
+    assert b.record_total_outage("immediate") is True
+    assert b.is_tripped() is True
+
+
+def test_master_flag_disabled_never_trips(monkeypatch):
+    monkeypatch.setenv("JARVIS_DUAL_LANE_BREAKER_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_TOTAL_OUTAGE_THRESHOLD", "1")
+    b = _fresh()
+    for _ in range(10):
+        assert b.record_total_outage("x") is False
+    assert b.is_tripped() is False
+
+
+def test_tripped_breaker_stays_tripped_through_late_success(monkeypatch):
+    """Once a total blackout is verified and pause requested, a late
+    candidate does not silently un-trip mid-shutdown."""
+    monkeypatch.setenv("JARVIS_TOTAL_OUTAGE_THRESHOLD", "1")
+    b = _fresh()
+    b.record_total_outage("x")
+    assert b.is_tripped() is True
+    b.record_success()
+    assert b.is_tripped() is True
+
+
+def test_snapshot_exposes_state(monkeypatch):
+    monkeypatch.setenv("JARVIS_TOTAL_OUTAGE_THRESHOLD", "3")
+    b = _fresh()
+    b.record_total_outage("qwen397:live_transport:RuntimeError")
+    snap = b.snapshot()
+    assert snap.consecutive_total_outages == 1
+    assert snap.tripped is False
+    assert "qwen397" in snap.last_diagnostic
+
+
+# ---------------------------------------------------------------------------
+# Wiring pins — Slice 45 dead-code lesson: the breaker must be wired into the
+# real generation error path (candidate_generator) AND the dispatch chokepoint
+# (governed_loop_service.submit), or it records/pauses nothing in production.
+# ---------------------------------------------------------------------------
+
+
+def test_recording_wired_in_candidate_generator():
+    import inspect
+
+    import backend.core.ouroboros.governance.candidate_generator as cg
+
+    src = inspect.getsource(cg)
+    # Outage recorded at the DW-exhaustion raises; success resets on candidate.
+    assert "_note_dw_total_outage" in src, "outage recording helper missing"
+    assert "_note_dw_candidate_success" in src, "success-reset helper missing"
+    assert src.count("_note_dw_total_outage(") >= 4, (
+        "expected the helper definition + 3 raise-site calls"
+    )
+    # Reset must sit on the sentinel success return.
+    assert "_note_dw_candidate_success()  # Slice 53" in src
+
+
+def test_pause_gate_wired_in_governed_loop_submit():
+    import inspect
+
+    import backend.core.ouroboros.governance.governed_loop_service as gls
+
+    src = inspect.getsource(gls.GovernedLoopService.submit)
+    assert "get_dual_lane_breaker" in src, "submit() does not consult the breaker"
+    assert "is_tripped()" in src, "submit() does not check is_tripped()"
+    assert "dual_lane_outage_paused" in src, "submit() missing the pause reason_code"
+
+
+def test_candidate_generator_helpers_never_raise(monkeypatch):
+    """Recording sits on the generation error path — it must be inert on any
+    internal failure, never perturbing the raise it precedes."""
+    import backend.core.ouroboros.governance.candidate_generator as cg
+
+    # Even with a hostile threshold value, the helpers swallow everything.
+    monkeypatch.setenv("JARVIS_TOTAL_OUTAGE_THRESHOLD", "not-an-int")
+    cg._note_dw_total_outage("x")      # must not raise
+    cg._note_dw_candidate_success()    # must not raise


### PR DESCRIPTION
## Summary

Arms O+V against a **verified total DoubleWord blackout** without breaking single-lane resilience. Implements the gated **Option A** I recommended when deferring Slice 52 Phase 3.

## The gap
Per v45/v46 + the Slice 51 vendor repro: when DW returns empty token streams under HTTP 200 on **both** the streaming preflight and batch generation, every GENERATE op exhausts all DW models and burns retry tokens forever. The existing `ProviderExhaustionWatcher` doesn't catch it — DW-only exhaustions raise `fallback_skipped:no_fallback_configured`, **deliberately not counted** toward its threshold.

## Option A — gated dual-lane isolation
A single op only fails to yield a candidate from *either* lane when **both** lanes are empty. So the breaker trips only on a verified **total** blackout, and **never** on single-lane streaming degradation — a working batch lane yields candidates that reset the counter. **Slice 41 `ACTIVE_BATCH_ONLY` is preserved by construction.**

### `dual_lane_breaker.py` (new, pure, thread-safe)
- `record_total_outage(diag)` — increments a consecutive counter; returns `True` exactly once (on the tripping call).
- `record_success()` — resets the counter (Slice 41 preservation); does **not** un-trip a verified blackout.
- Trips at `JARVIS_TOTAL_OUTAGE_THRESHOLD` consecutive total outages (default **3**).
- Master switch `JARVIS_DUAL_LANE_BREAKER_ENABLED` (default on; `=false` → records nothing, byte-identical to pre-Slice-53).

### Wiring — `candidate_generator`
`_note_dw_total_outage` at the **three** DW-exhaustion raises in `_dispatch_via_sentinel` (`sentinel_dispatch_no_fallback` / `background_dw_blocked_by_topology` / `speculative_deferred`); `_note_dw_candidate_success` on the sentinel success return. Both best-effort (lazy import, never raise) since they sit on the generation error path.

### Wiring — `governed_loop_service.submit` (the single dispatch chokepoint)
A new first gate refuses ops with `reason_code=dual_lane_outage_paused` when tripped — **pausing target allocations** so the loop idles into a clean `idle_timeout` exit-0 rather than burning retries against a confirmed-dead provider. The gate is `is_tripped()`-guarded → normal path byte-identical when untripped.

**Deliberately NOT** wired to a forced `os._exit`: pausing allocations + the existing `idle_timeout` achieves the graceful exit-0 without touching session-shutdown plumbing (`UserSignalBus.request_stop` is a per-op cancel, not a session stop — verified, not assumed).

## Tests
- **11** — 8 state-machine (trip-at-threshold / **single-lane-preserved** / reset-on-success / 3-after-reset-trips / threshold env / master-flag-off / terminal-trip-through-late-success / snapshot) + **3 wiring pins** (recording wired in candidate_generator, pause gate wired in submit, helpers never raise — per the Slice 45 dead-code lesson).
- **80 transport/candidate regression tests green** (slice43/41/50 + dw_heavy_probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a gated dual-lane circuit breaker that pauses operations on a confirmed total DW outage (both streaming and batch return no candidates) while preserving single-lane resilience. When tripped, new ops are refused and the loop exits cleanly via idle timeout instead of burning retries.

- **New Features**
  - New `dual_lane_breaker.py`: thread-safe breaker with `record_total_outage` and `record_success`; trips after `JARVIS_TOTAL_OUTAGE_THRESHOLD` consecutive total outages (default 3); master switch `JARVIS_DUAL_LANE_BREAKER_ENABLED` (default on).
  - `candidate_generator`: records DW total-outage at three exhaustion raises; records success on candidate return; helpers are lazy-imported and never raise.
  - `governed_loop_service.submit`: first gate checks breaker; when tripped, returns `reason_code=dual_lane_outage_paused` so the loop idles to an exit-0.

- **Migration**
  - No action required. To disable, set `JARVIS_DUAL_LANE_BREAKER_ENABLED=false`. To tune sensitivity, set `JARVIS_TOTAL_OUTAGE_THRESHOLD` (min 1; default 3).

<sup>Written for commit 08fce9c59edf85728ee3dc9e61aef35e23398e87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/65639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

