### PR TITLE
feat(governance): Slice 56 — cross-worktree commit alignment (APPLY → owned worktree)

### DIFF
--- a/backend/core/ouroboros/governance/change_engine.py
+++ b/backend/core/ouroboros/governance/change_engine.py
@@ -404,6 +404,46 @@ class ChangeEngine:
         self._risk_engine = risk_engine or RiskEngine()
         self._tool_hook_registry: Optional[ToolCallHookRegistry] = tool_hook_registry
 
+    # ------------------------------------------------------------------
+    # Slice 56 — cross-worktree write alignment (Option A)
+    # ------------------------------------------------------------------
+
+    def _effective_write_root(self) -> Path:
+        """Resolve the root that APPLY writes into.
+
+        When ``JARVIS_AUTO_COMMIT_WORKSPACE`` is set (harness ledger-sovereignty
+        owned worktree), writes are redirected there so they land in the SAME
+        tree AutoCommitter commits from (``AutoCommitter._effective_repo_root``)
+        — coherent by construction — and the operator's main tree is never
+        touched. Unset → ``self._project_root`` (byte-identical legacy path).
+        """
+        override = os.environ.get("JARVIS_AUTO_COMMIT_WORKSPACE")
+        if override:
+            return Path(override)
+        return self._project_root
+
+    def _redirect_target(self, target: Path) -> Path:
+        """Rebase a write target onto :meth:`_effective_write_root`.
+
+        No-op when the env override is unset (root == project_root). Absolute
+        paths are rebased by their path relative to ``project_root``; relative
+        paths are joined to the write root. A target NOT under ``project_root``
+        is left unchanged (defensive — never silently cross-write elsewhere).
+        NEVER raises — falls back to the original target on any resolution error.
+        """
+        root = self._effective_write_root()
+        try:
+            if root.resolve() == self._project_root.resolve():
+                return target
+            if target.is_absolute():
+                rel = target.resolve().relative_to(self._project_root.resolve())
+            else:
+                rel = target
+            return root / rel
+        except (ValueError, OSError):
+            # Not under project_root (or unresolvable) — leave as-is.
+            return target
+
     async def execute(self, request: ChangeRequest) -> ChangeResult:
         """Execute the 8-phase transactional change pipeline.
 
@@ -569,7 +609,12 @@ class ChangeEngine:
                 op_id=op_id, phase="apply", progress_pct=70.0
             )
 
-            target = Path(request.target_file)
+            # Slice 56 — redirect the write into the owned auto-commit worktree
+            # when active, so the patch lands in the SAME tree AutoCommitter
+            # commits from (and never the operator's main tree). No-op when
+            # JARVIS_AUTO_COMMIT_WORKSPACE is unset. Rollback snapshot + lock +
+            # signature all follow the redirected target (Phase 2 coherence).
+            target = self._redirect_target(Path(request.target_file))
             rollback = RollbackArtifact.capture(target)
 
             await self._ledger.append(

--- a/tests/governance/test_slice56_worktree_alignment.py
+++ b/tests/governance/test_slice56_worktree_alignment.py
@@ -1,0 +1,90 @@
+"""Slice 56 — cross-worktree commit alignment (Option A).
+
+Confirmed divergence (v47, bt-2026-06-01-220823): ChangeEngine APPLY writes to
+the MAIN repo (`self._project_root`), but AutoCommitter checks/commits in the
+owned worktree (`JARVIS_AUTO_COMMIT_WORKSPACE`, stamped by harness
+ledger-sovereignty so commits never touch the operator's main branch). Result:
+the patch lands in main, the committer sees a clean worktree → "No changes
+detected" → never commits. AND the autonomous patch leaks into the operator's
+real working tree.
+
+Fix (A1): redirect ChangeEngine's write target into the owned worktree when
+`JARVIS_AUTO_COMMIT_WORKSPACE` is set — mirroring AutoCommitter's
+`_effective_repo_root` env logic so the two are coherent by construction. The
+patch then lands in the worktree, AutoCommitter commits it on the
+`ouroboros/auto/*` branch, and the operator's main tree is never touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.change_engine import ChangeEngine
+
+
+def _engine(root: Path) -> ChangeEngine:
+    return ChangeEngine(project_root=Path(root), ledger=MagicMock())
+
+
+def test_no_redirect_without_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("JARVIS_AUTO_COMMIT_WORKSPACE", raising=False)
+    e = _engine(tmp_path)
+    t = tmp_path / "tests" / "foo.py"
+    # Byte-identical legacy behavior — writes stay in project_root.
+    assert e._redirect_target(t) == t
+    assert e._effective_write_root() == tmp_path
+
+
+def test_effective_write_root_follows_env(tmp_path, monkeypatch):
+    ws = tmp_path / ".worktrees" / "owned"
+    monkeypatch.setenv("JARVIS_AUTO_COMMIT_WORKSPACE", str(ws))
+    assert _engine(tmp_path)._effective_write_root() == ws
+
+
+def test_redirect_absolute_target_under_project_root(tmp_path, monkeypatch):
+    ws = tmp_path / ".worktrees" / "owned"
+    monkeypatch.setenv("JARVIS_AUTO_COMMIT_WORKSPACE", str(ws))
+    e = _engine(tmp_path)
+    t = tmp_path / "tests" / "foo.py"
+    assert e._redirect_target(t) == ws / "tests" / "foo.py"
+
+
+def test_redirect_relative_target(tmp_path, monkeypatch):
+    ws = tmp_path / "owned"
+    monkeypatch.setenv("JARVIS_AUTO_COMMIT_WORKSPACE", str(ws))
+    e = _engine(tmp_path)
+    assert e._redirect_target(Path("tests/foo.py")) == ws / "tests" / "foo.py"
+
+
+def test_target_outside_project_root_is_left_unchanged(tmp_path, monkeypatch):
+    # Defensive: a path not under project_root is not rebased (no silent
+    # cross-tree write to an unexpected location).
+    ws = tmp_path / "owned"
+    monkeypatch.setenv("JARVIS_AUTO_COMMIT_WORKSPACE", str(ws))
+    e = _engine(tmp_path)
+    outside = Path("/tmp/some_other_root/foo.py")
+    assert e._redirect_target(outside) == outside
+
+
+def test_coherent_with_autocommitter_root(tmp_path, monkeypatch):
+    """ChangeEngine write root and AutoCommitter commit root must resolve to
+    the SAME tree under the env — that coherence is the whole fix."""
+    ws = tmp_path / ".worktrees" / "owned"
+    monkeypatch.setenv("JARVIS_AUTO_COMMIT_WORKSPACE", str(ws))
+    from backend.core.ouroboros.governance.auto_committer import AutoCommitter
+
+    ac = AutoCommitter(repo_root=tmp_path)
+    assert _engine(tmp_path)._effective_write_root() == ac._effective_repo_root()
+
+
+# Wiring pin (Slice 45 lesson): execute() must actually use the redirect.
+def test_execute_uses_redirect_target():
+    import inspect
+
+    from backend.core.ouroboros.governance import change_engine as ce
+
+    src = inspect.getsource(ce.ChangeEngine.execute)
+    assert "_redirect_target" in src, "execute() must redirect the write target"


### PR DESCRIPTION
## Summary
Closes the last blocker to an autonomous committed RESOLVED — **and a sovereignty leak.**

## The confirmed divergence (v47)
- **ChangeEngine APPLY** wrote to the **main repo** (`self._project_root`).
- **AutoCommitter** checks/commits in the **owned worktree** (`JARVIS_AUTO_COMMIT_WORKSPACE`, stamped by `harness_sovereignty_pin` *so commits never touch the operator's main branch*).
- → patch in main, committer sees clean worktree → "No changes detected" → no commit. (The v47 8-second "no changes" was this — **not** an FS-flush race, which is why the runbook's flush idea was declined.)
- → autonomous patches were **leaking into the operator's real main working tree** (reverted manually after each soak).

## Fix — Option A (operator-authorized): redirect APPLY into the owned worktree
- `ChangeEngine._effective_write_root()` — `JARVIS_AUTO_COMMIT_WORKSPACE` when set, else `project_root`. **Mirrors `AutoCommitter._effective_repo_root`** so write-root and commit-root resolve to the *same tree by construction.*
- `ChangeEngine._redirect_target(target)` — rebases the APPLY target onto the write root (absolute via `relative_to(project_root)`; relative joined; outside-root left unchanged; never raises). **No-op when the env is unset** (byte-identical legacy path).
- Wired at the single APPLY seam (`execute`), so the **rollback snapshot, file lock, and signature all follow the redirected target** — Phase 2 cross-worktree rollback coherence falls out for free (snapshot captures/restores the worktree file).

Result: patch lands in the owned worktree → AutoCommitter commits it on `ouroboros/auto/*` → **operator's main tree never touched.** Fixes the no-commit blocker *and* the leak.

**Clean-base note:** the candidate is `full_content` generated against the current main file; the owned-worktree branch is cut from boot HEAD, so for a clean main (battle-test invariant) the worktree base == the generation base.

## Tests
7 new (env root / redirect absolute+relative / outside-root defensive / no-op without env / **coherence with AutoCommitter root** / execute wiring pin). 101 change_engine + multi-file + sovereignty regression green; 3 pre-existing `test_ledger_sovereignty_wiring` "master_off" failures verified present with this change stashed (test-isolation issue, unrelated).

## Next
Phase 4: a tight 7-min DW-only pre-flight to witness the first un-leaked APPLY→commit on the isolated branch, then the full hybrid sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirected `ChangeEngine` APPLY writes into the owned worktree when `JARVIS_AUTO_COMMIT_WORKSPACE` is set, so `AutoCommitter` detects and commits the changes. Fixes the no-commit bug and stops patches from touching the operator’s main working tree.

- **Bug Fixes**
  - Added `_effective_write_root()` to resolve the write root to `JARVIS_AUTO_COMMIT_WORKSPACE` or project root.
  - Added `_redirect_target()` to rebase targets onto the write root; no-op without the env; leaves paths outside the project root unchanged.
  - Wired the redirect in `execute()` so rollback snapshot, file lock, and signature follow the redirected path.
  - Added tests for env resolution, absolute/relative paths, outside-root behavior, coherence with `AutoCommitter`, and an `execute()` wiring pin.

<sup>Written for commit 8525d4dcd31d04cee37957115d341d24c24306fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/65642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

