### PR TITLE
feat(governance): Slice 59 — complexity-classifier calibration for non-concrete (directory) targets

### DIFF
--- a/backend/core/ouroboros/governance/complexity_classifier.py
+++ b/backend/core/ouroboros/governance/complexity_classifier.py
@@ -101,6 +101,24 @@ _COMPLEX_FLOOR_SOURCES = frozenset({
 })
 
 
+def _is_concrete_file_target(target: str) -> bool:
+    """Slice 59 — True iff ``target`` names a specific file (not a directory).
+
+    Text-only (the classifier is no-FS by contract). A concrete file target is
+    non-empty, does not end with ``/``, and its basename contains a ``.``
+    (an extension or a dotfile like ``.gitignore``). Directory-level targets
+    such as ``backend/core/`` or ``backend/core`` are NOT concrete — an op
+    aimed at a directory has no specific file to full-rewrite, so a fast-path
+    generation only yields a fragment (v57 truncation). Extension-less real
+    files (e.g. ``Makefile``) read as non-concrete here; escalating those is a
+    safe, conservative over-classification (more reasoning, never less).
+    """
+    t = (target or "").strip()
+    if not t or t.endswith("/"):
+        return False
+    return "." in t.rsplit("/", 1)[-1]
+
+
 class OperationComplexityClassifier:
     """Classifies operations by complexity and persistence at CLASSIFY phase.
 
@@ -189,6 +207,19 @@ class OperationComplexityClassifier:
         # a real pre-known edit set and would misclassify a no-target
         # localize-from-issue task as SIMPLE (starving PLAN + budget).
         if source in _COMPLEX_FLOOR_SOURCES:
+            return ComplexityClass.COMPLEX
+
+        # Slice 59 — non-concrete (directory-level) targets must never fast-path.
+        # An op aimed at e.g. ['backend/core/'] has no specific file to
+        # full-rewrite; classified TRIVIAL/SIMPLE it gets reasoning_effort=none
+        # + fast_path and the model emits a fragment (v57 truncation). Escalate
+        # to COMPLEX so it receives full reasoning headroom (or is gated by the
+        # Advisor blast-radius check upstream). Architectural keywords and the
+        # source-floor above still win; empty target_files are untouched
+        # (the no-target SWE-bench path is owned by the source-floor).
+        if target_files and any(
+            not _is_concrete_file_target(t) for t in target_files
+        ):
             return ComplexityClass.COMPLEX
 
         # Check for trivial indicators

--- a/tests/governance/test_slice59_sensor_triage.py
+++ b/tests/governance/test_slice59_sensor_triage.py
@@ -1,0 +1,83 @@
+"""Slice 59 — complexity-classifier calibration for non-concrete targets.
+
+v57 (bt-2026-06-01-231338): a proactive-exploration op with a DIRECTORY target
+(`target_files=['backend/core/']`) and a vague goal was classified trivial/simple
+(file_count=1) → reasoning_effort=none + fast_path → DW emitted a 200-byte
+fragment for a 10,912-byte file (correctly skipped by the providers.py:4507
+completeness guard, so 0 commits). Root cause: the LIVE classifier
+(complexity_classifier.OperationComplexityClassifier, used by classify_runner)
+treats a directory target as a single concrete file.
+
+Fix: a text-only "concrete file target" check. A non-concrete (directory-level)
+target can never be TRIVIAL/SIMPLE — escalate so the op gets full reasoning
+headroom (or is gated upstream by the Advisor blast-radius check, which already
+blocks the high-blast directory ops). Architectural keywords and the
+benchmark source-floor still take precedence; empty target_files (SWE-bench
+no-target ops) are untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.complexity_classifier import (
+    OperationComplexityClassifier,
+    ComplexityClass,
+    _is_concrete_file_target,
+)
+
+_FAST = {ComplexityClass.TRIVIAL, ComplexityClass.SIMPLE}
+
+
+def _clf() -> OperationComplexityClassifier:
+    return OperationComplexityClassifier()
+
+
+def test_is_concrete_file_target():
+    assert _is_concrete_file_target("tests/foo.py") is True
+    assert _is_concrete_file_target("requirements.txt") is True
+    assert _is_concrete_file_target(".gitignore") is True          # dotfile = real file
+    assert _is_concrete_file_target("backend/core/") is False       # trailing slash = dir
+    assert _is_concrete_file_target("backend/core") is False        # no extension = dir-like
+    assert _is_concrete_file_target("") is False
+    assert _is_concrete_file_target("   ") is False
+
+
+def test_directory_target_never_fast_path():
+    r = _clf().classify(description="fix the import error", target_files=["backend/core/"])
+    assert r.complexity not in _FAST, f"directory target classified {r.complexity}"
+
+
+def test_v57_vague_proactive_dir_op_escalated():
+    # The exact v57 op that produced the truncated fragment.
+    r = _clf().classify(
+        description=("Proactive exploration: domain code_gen::.py has persistent "
+                     "uncertainty; address import_error proactively in your solution."),
+        target_files=["backend/core/"],
+        source="exploration",
+    )
+    assert r.complexity not in _FAST
+
+
+def test_concrete_file_can_still_be_fast_path():
+    # A specific file + trivial intent must STILL be allowed to fast-path
+    # (zero regression for the change-producing ops like v48's todo target).
+    r = _clf().classify(
+        description="fix typo in comment",
+        target_files=["tests/test_ouroboros_governance/test_todo_scanner_trigger_tag.py"],
+    )
+    assert r.complexity in (ComplexityClass.TRIVIAL, ComplexityClass.SIMPLE,
+                            ComplexityClass.MODERATE)
+
+
+def test_architectural_keyword_still_wins_over_dir_guard():
+    r = _clf().classify(description="redesign the system architecture",
+                        target_files=["backend/core/"])
+    assert r.complexity == ComplexityClass.ARCHITECTURAL
+
+
+def test_no_target_files_not_escalated_by_dir_guard():
+    # SWE-bench-style no-target op: the dir guard must NOT fire on empty
+    # target_files (the source-floor owns those). file_count=0 -> SIMPLE.
+    r = _clf().classify(description="resolve the failing test", target_files=[])
+    assert r.complexity == ComplexityClass.SIMPLE


### PR DESCRIPTION
## Summary
Fixes the v57 DW-truncation root cause at the **input taxonomy** layer: a directory-level target was classified trivial/simple → `reasoning_effort=none` + fast-path → the model emitted a fragment.

## Root cause (verified)
The op `target_files=['backend/core/']` + vague goal was classified `trivial` (file_count=1). The **live** classifier — `complexity_classifier.OperationComplexityClassifier` via `classify_runner.py:581` (confirmed live; the orchestrator-inline CLASSIFY block and `brain_selector` are both **dead** under the phase dispatcher — Slice 45 lesson) — treats a directory target as a single concrete file. An op aimed at a directory has no specific file to full-rewrite, so a fast-path generation only yields a fragment (which the existing `providers.py:4507` completeness guard correctly skips — hence 0 commits, *not* a regression).

## Fix (Phase 1)
- `_is_concrete_file_target()` — text-only (no-FS, honors the classifier contract): non-empty, not ending in `/`, basename contains `.` (extension or dotfile like `.gitignore`).
- `_classify_complexity` escalates any op with a **non-concrete target** to `COMPLEX` — it can never fast-path. Gets full reasoning headroom, or is gated upstream by the Advisor blast-radius check (which already blocks the high-blast directory ops).
- Architectural keywords + the `swe_bench_pro` source-floor still win; **empty `target_files`** (no-target SWE-bench ops) are untouched. Extension-less real files (e.g. `Makefile`) read non-concrete → conservatively escalated (more reasoning, never less).

## Phase 2 (sensor filter) — deliberately NOT built
Blocking *all* proactive exploration unless it names a concrete file would **neuter a deliberately open-ended capability**. Phase 1 (escalate) + the existing Advisor blast gate already achieve the runbook's "escalate-or-gate" intent without crippling the feature. Flagged as a product decision rather than forced.

## Tests
6 new (helper unit + the exact v57 case + concrete-file-still-fast-path + architectural-wins + no-target-untouched). 52 classifier + `classify_runner` parity regression green.

## Phase 4 (curated dataset) — direction, not code
The pivot to a curated, well-specified task set (the real `swe_bench_pro` harness, where files + expected diffs are explicit, Claude fallback on) is the right next move — those are exactly the change-producing ops the pipeline handles cleanly (cf. v48's committed `abbabc70`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escalates directory-level targets to COMPLEX in the operation complexity classifier to prevent fast-path fragment outputs. Adds a text-only check to detect concrete file targets and includes tests.

- **Bug Fixes**
  - Added `_is_concrete_file_target()` (non-empty, no trailing `/`, basename has `.`) in `backend/core/ouroboros/governance/complexity_classifier.py`.
  - Updated `_classify_complexity` to return COMPLEX when any `target_files` entry is non-concrete; empty `target_files` remain unchanged and architectural/source floors still apply.
  - Added `tests/governance/test_slice59_sensor_triage.py` covering directory targets, the v57 case, concrete-file still fast-path, and no-target behavior.

<sup>Written for commit 3577f22ddb767f0462adaa4a8946e5b3ff34f0f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/65643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

