### PR TITLE
fix(swe_bench_pro): harness_inject resolves explicit LOCAL_DATASET_PATH fixture (phase1 triage)

### DIFF
--- a/backend/core/ouroboros/governance/swe_bench_pro/harness_inject.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/harness_inject.py
@@ -176,6 +176,40 @@ def autoscore_enabled() -> bool:
 # ===========================================================================
 
 
+def _local_dataset_instance_ids() -> List[str]:
+    """instance_ids from an EXPLICITLY-set ``LOCAL_DATASET_PATH`` fixture.
+
+    Phase-1 triage (soak bt-2026-06-01-235707): the wiring dry-run sets
+    ``LOCAL_DATASET_PATH`` to the checked-in fixture, but
+    :func:`_resolve_instance_ids` Tier-3 read ``list_cached_problems()`` (the
+    persistent cache) and injected a stale-cached real problem
+    (``django__django-16255``) instead of the fixture's
+    ``jarvis__harness-smoke-001``. This resolves the fixture's OWN ids.
+
+    Returns ``[]`` when the env var is unset/blank — so real HF-source runs
+    (which unset ``LOCAL_DATASET_PATH`` per the runbook) are completely
+    unaffected. Composes ``dataset_loader._iter_local_jsonl_records`` (the
+    single source of truth for local-JSONL scanning). NEVER raises.
+    """
+    from backend.core.ouroboros.governance.swe_bench_pro.dataset_loader import (
+        LOCAL_DATASET_PATH_ENV_VAR,
+    )
+    if not os.environ.get(LOCAL_DATASET_PATH_ENV_VAR, "").strip():
+        return []
+    try:
+        from backend.core.ouroboros.governance.swe_bench_pro.dataset_loader import (
+            _iter_local_jsonl_records,
+        )
+        ids: List[str] = []
+        for record in _iter_local_jsonl_records():
+            iid = record.get("instance_id")
+            if isinstance(iid, str) and iid:
+                ids.append(iid)
+        return ids
+    except Exception:  # noqa: BLE001 — fail-open to legacy tiers
+        return []
+
+
 def _resolve_instance_ids() -> List[str]:
     """Three-tier resolution (strict precedence; NEVER raises):
 
@@ -194,6 +228,17 @@ def _resolve_instance_ids() -> List[str]:
     explicit = inject_instance_ids()
     if explicit:
         return explicit
+
+    # Tier 1.5 — explicit LOCAL_DATASET_PATH fixture (wiring/dry-run
+    # determinism). When the operator pins a local dataset (the phase-1
+    # dry-run contract), resolve from THAT fixture's own records rather than
+    # the persistent cache, so the dry-run runs the intended fixture
+    # (e.g. jarvis__harness-smoke-001) instead of a stale-cached real problem
+    # (the phase1 bt-2026-06-01 django__django-16255 mis-injection). Inert
+    # when LOCAL_DATASET_PATH is unset (real HF runs) — falls through below.
+    local_ids = _local_dataset_instance_ids()
+    if local_ids:
+        return local_ids[: inject_count()]
 
     # Tier 2 — geometric self-curation (opt-in). Compose the
     # sampler; never let an import/scan failure break the legacy

--- a/tests/governance/test_harness_inject_local_dataset_resolution.py
+++ b/tests/governance/test_harness_inject_local_dataset_resolution.py
@@ -1,0 +1,77 @@
+"""Phase 1 triage fix — harness_inject must resolve from an explicitly-set
+LOCAL_DATASET_PATH fixture, not the persistent cache.
+
+Soak evidence (phase1, bt-2026-06-01-235707): the wiring dry-run set
+JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH to the checked-in fixture (whose only
+problem is the trivial `jarvis__harness-smoke-001`) + INJECT_COUNT=1, but the
+harness injected `django__django-16255` — a real, hard problem. Root cause:
+`_resolve_instance_ids` Tier-3 reads `list_cached_problems()` (the persistent
+cache), which contained a stale prepared problem, and ignored the explicitly-set
+LOCAL_DATASET_PATH fixture. So the dry-run ran a hard problem (which didn't
+converge before the wall cap) instead of the trivial wiring fixture.
+
+Fix: when LOCAL_DATASET_PATH is EXPLICITLY set, resolve the fixture's own
+instance_ids (composing dataset_loader._iter_local_jsonl_records — single source
+of truth) ahead of the cache. Inert for real HF-source runs (which unset
+LOCAL_DATASET_PATH per the runbook), so real-run resolution is unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.governance.swe_bench_pro import harness_inject as hi
+
+
+def _write_fixture(tmp_path, ids):
+    p = tmp_path / "fixture.jsonl"
+    with p.open("w") as fh:
+        for iid in ids:
+            fh.write(json.dumps({"instance_id": iid, "repo": "x/y",
+                                 "problem_statement": "p"}) + "\n")
+    return p
+
+
+def test_local_ids_empty_when_env_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH", raising=False)
+    assert hi._local_dataset_instance_ids() == []
+
+
+def test_local_ids_from_explicit_fixture(tmp_path, monkeypatch):
+    fx = _write_fixture(tmp_path, ["jarvis__harness-smoke-001", "x__y-2"])
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH", str(fx))
+    assert hi._local_dataset_instance_ids() == ["jarvis__harness-smoke-001", "x__y-2"]
+
+
+def test_resolve_prefers_fixture_over_cache(tmp_path, monkeypatch):
+    # The exact phase1 bug: cache has a stale real problem; the fixture has the
+    # smoke test. With LOCAL_DATASET_PATH set, resolution must pick the fixture.
+    fx = _write_fixture(tmp_path, ["jarvis__harness-smoke-001"])
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH", str(fx))
+    monkeypatch.delenv("JARVIS_SWE_BENCH_PRO_INJECT_INSTANCE_IDS", raising=False)
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_INJECT_COUNT", "1")
+    monkeypatch.setattr(hi, "list_cached_problems",
+                        lambda: ["django__django-16255"], raising=True)
+    assert hi._resolve_instance_ids() == ["jarvis__harness-smoke-001"]
+
+
+def test_resolve_explicit_ids_still_win(tmp_path, monkeypatch):
+    # Tier-1 explicit precedence must be preserved (highest).
+    fx = _write_fixture(tmp_path, ["fixture-id"])
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH", str(fx))
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_INJECT_INSTANCE_IDS", "explicit-1,explicit-2")
+    assert hi._resolve_instance_ids() == ["explicit-1", "explicit-2"]
+
+
+def test_resolve_unset_env_falls_to_cache(tmp_path, monkeypatch):
+    # Real-run behavior preserved: LOCAL_DATASET_PATH unset -> local tier inert,
+    # resolution falls through to the cache (sampler off by default).
+    monkeypatch.delenv("JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH", raising=False)
+    monkeypatch.delenv("JARVIS_SWE_BENCH_PRO_INJECT_INSTANCE_IDS", raising=False)
+    monkeypatch.delenv("JARVIS_SWE_BENCH_PRO_GEOMETRIC_SAMPLER_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_INJECT_COUNT", "1")
+    monkeypatch.setattr(hi, "list_cached_problems",
+                        lambda: ["cached-real-problem"], raising=True)
+    assert hi._resolve_instance_ids() == ["cached-real-problem"]


### PR DESCRIPTION
## Summary
Phase-1 wiring dry-run triage (a soak-surfaced bug, **not** a rebuild). The Slice 60 "fleet supervisor" was confirmed redundant (`parallel_evaluate` + `result_store` + `swe_bench_pro_soak.sh` already exist), so per the operator directive I ran the existing `phase1` dry-run — which surfaced this real bug.

## What phase1 showed
`bash scripts/swe_bench_pro_soak.sh phase1` set `LOCAL_DATASET_PATH=<fixture>` (only problem: the trivially-passing `jarvis__harness-smoke-001`) + `INJECT_COUNT=1`, but the harness injected **`django__django-16255`** — a real, hard problem. It ran Claude extended thinking, didn't converge (`VerifyPostmortem insuff=3`), and was wall-capped with **no scored `results.jsonl` row**. (Wiring itself — injection→envelope→complexity-floor→routing→dispatch — was confirmed in the debug.log; the issue was *which problem* got resolved.)

## Root cause (code-confirmed)
`_resolve_instance_ids` Tier-3 reads `list_cached_problems()` (the persistent cache dir), which held a stale prepared `django__django-16255`, and **ignored the explicitly-set `LOCAL_DATASET_PATH` fixture**. The geometric sampler (Tier-2) defaults OFF, so resolution fell straight to the cache. Clearing the cache wouldn't help — Tier-3 reads the cache, not the fixture, so it'd resolve to `[]`.

## Fix (root cause, no workaround/duplication)
New **Tier-1.5** in `_resolve_instance_ids`: when `LOCAL_DATASET_PATH` is **explicitly set**, resolve the fixture's own `instance_id`s via a new `_local_dataset_instance_ids()` that **composes `dataset_loader._iter_local_jsonl_records`** (single source of truth — no reinvention, no hardcoded ids), first-N by `inject_count`.
- Explicit `INJECT_INSTANCE_IDS` (Tier-1) still wins; sampler + cache remain below.
- **Inert when `LOCAL_DATASET_PATH` is unset** → real HF-source runs (which unset it per runbook checklist #4) are byte-identical.
- Never raises (fail-open to legacy tiers).

## Tests
5 new (env-unset→`[]`; explicit-fixture enumeration; **resolve-prefers-fixture-over-cache** = the exact phase1 bug; explicit-ids-still-win; unset-env-falls-to-cache = real-run preserved). `dataset_loader` + `parallel_eval` regression green. 8 pre-existing `test_swe_bench_pro_harness_inject` failures (master-flag/test-isolation, `phase_a_disabled`) verified present with this change stashed — unrelated.

## Next
Re-run `phase1` — it should now resolve `jarvis__harness-smoke-001` and produce a clean scored `results.jsonl` row (the wiring proof). Then Phase 2 (operator-selected `SWEBP_INSTANCE_IDS` via `geometric_sampler`) and Phase 3 (real spend) per the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `swe_bench_pro` dry-run determinism by making `harness_inject` respect an explicit `LOCAL_DATASET_PATH`, resolving instance IDs from the local fixture instead of the cache. Real runs remain unchanged when the env var is unset.

- **Bug Fixes**
  - Added Tier 1.5 in `_resolve_instance_ids` that returns IDs from `_local_dataset_instance_ids()` when `LOCAL_DATASET_PATH` is set.
  - `_local_dataset_instance_ids()` composes `dataset_loader._iter_local_jsonl_records`; never raises; trims to `inject_count`.
  - Precedence preserved: `INJECT_INSTANCE_IDS` > local fixture > sampler > cache. Inert when `LOCAL_DATASET_PATH` is unset.

- **Tests**
  - Env unset → `[]`; reads fixture IDs; prefers fixture over cache; explicit IDs still win; unset env falls back to cache.

<sup>Written for commit 17d4f211def85fb4e9a8f907dd4f33de3deba24d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/65644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

