### PR TITLE
feat(swe_bench_pro): Slice 62 — HF token placeholder sentinel + sampler tier-order fix

### DIFF
--- a/backend/core/ouroboros/governance/swe_bench_pro/dataset_loader.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/dataset_loader.py
@@ -392,6 +392,75 @@ def _local_dataset_path() -> Path:
     return Path(raw) if raw else Path(_DEFAULT_LOCAL_DATASET_PATH)
 
 
+class HFTokenPlaceholderError(ValueError):
+    """Slice 62 — raised when an HF dataset is configured but the ambient
+    Hugging Face token is an un-substituted placeholder.
+
+    A CONFIG error (not transient): the recurring 2026-06-02 misconfig where
+    auth used a literal placeholder (``hf_YOUR_REAL_TOKEN_HERE`` /
+    ``your_actual_token_here`` / ``<paste_your_huggingface_token_here>``),
+    which otherwise 401s deep inside huggingface_hub with a cryptic traceback.
+    Aborts loudly with an actionable message BEFORE the network call.
+    """
+
+
+# Obvious un-substituted-placeholder fingerprints (lower-cased substring
+# match). Closed, additive list — covers the example strings handed out in
+# the runbooks + the generic "<paste …>" / "…token_here" shapes.
+_HF_TOKEN_PLACEHOLDER_MARKERS: tuple = (
+    "paste_your", "your_actual_token", "your_real_token", "your_token",
+    "your_huggingface_token", "yourtoken", "hf_your", "<paste",
+    "real_token_here", "token_here", "your_hf_token",
+)
+
+
+def hf_token_appears_placeholder(token: Optional[str]) -> bool:
+    """True iff a NON-EMPTY ``token`` is an obvious un-substituted placeholder.
+
+    Pure + deterministic. Empty/blank/None returns False — an unset HF_TOKEN
+    is valid (a disk-cached ``hf auth login`` token resolves ambiently), so
+    only a non-empty bogus value is a misconfiguration worth aborting on.
+    """
+    t = (token or "").strip().lower()
+    if not t:
+        return False
+    return any(marker in t for marker in _HF_TOKEN_PLACEHOLDER_MARKERS)
+
+
+def _ambient_hf_token() -> str:
+    """The Hugging Face token huggingface_hub will resolve from the env, in
+    its precedence order. Empty string when none is set in the environment
+    (a disk-cached login token is not visible here — and that's fine, it is
+    never a placeholder)."""
+    for var in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HUGGINGFACE_TOKEN"):
+        val = os.environ.get(var, "").strip()
+        if val:
+            return val
+    return ""
+
+
+def _assert_hf_token_not_placeholder(hf_name: str) -> None:
+    """Slice 62 sentinel — abort with a clear, actionable error when an HF
+    dataset is requested but the ambient token is a placeholder. Logs at
+    ERROR (unmissable even if a fail-open caller later swallows the raise)
+    then raises :class:`HFTokenPlaceholderError`."""
+    tok = _ambient_hf_token()
+    if not hf_token_appears_placeholder(tok):
+        return
+    logger.error(
+        "[SWEBenchPro] HF dataset %r requested but the Hugging Face token "
+        "looks like an un-substituted placeholder (%r). Put your REAL token "
+        "in .env (gitignored + loaded at boot + wins over shell exports): "
+        "HF_TOKEN=hf_xxxxx — and accept the gated license at "
+        "https://huggingface.co/datasets/%s . Aborting before the 401.",
+        hf_name, tok[:16], hf_name,
+    )
+    raise HFTokenPlaceholderError(
+        f"HF_TOKEN is a placeholder ({tok[:16]!r}); set a REAL Hugging Face "
+        f"token in .env to access {hf_name}"
+    )
+
+
 def _hf_dataset_name() -> str:
     """HuggingFace dataset path; empty default = HF fetch disabled."""
     return os.environ.get(HF_DATASET_ENV_VAR, "").strip()
@@ -631,6 +700,11 @@ def _iter_hf_records() -> Iterator[Dict[str, Any]]:
     hf_name = _hf_dataset_name()
     if not hf_name:
         return
+    # Slice 62 — placeholder-token sentinel BEFORE any import/network so a
+    # fake token aborts with a clear message instead of a cryptic 401. Placed
+    # outside the fail-open try below so a CONFIG error propagates (transient
+    # fetch errors below stay fail-open).
+    _assert_hf_token_not_placeholder(hf_name)
     try:
         try:
             import datasets  # type: ignore  # noqa: I001 — lazy import
@@ -677,6 +751,9 @@ def _load_from_huggingface(instance_id: str) -> Optional[ProblemSpec]:
                     return None
         return None
     except asyncio.CancelledError:
+        raise
+    except HFTokenPlaceholderError:
+        # Slice 62 — config error: surface it, don't fail-open to None.
         raise
     except Exception:  # noqa: BLE001 — defensive
         logger.warning(
@@ -732,6 +809,10 @@ def iter_all_dataset_records(
             if emitted >= cap:
                 return
     except asyncio.CancelledError:
+        raise
+    except HFTokenPlaceholderError:
+        # Slice 62 — config error: the sampler must see the misconfig, not a
+        # silently-empty distribution.
         raise
     except Exception:  # noqa: BLE001 — defensive (fail-open scan)
         logger.warning(

--- a/backend/core/ouroboros/governance/swe_bench_pro/harness_inject.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/harness_inject.py
@@ -211,7 +211,7 @@ def _local_dataset_instance_ids() -> List[str]:
 
 
 def _resolve_instance_ids() -> List[str]:
-    """Three-tier resolution (strict precedence; NEVER raises):
+    """Four-tier resolution (strict precedence; NEVER raises):
 
       1. ``INJECT_INSTANCE_IDS`` CSV override — explicit operator
          control always wins.
@@ -222,27 +222,25 @@ def _resolve_instance_ids() -> List[str]:
          own gold-patch geometry — zero hardcoded IDs.  This is the
          Stage-2 rubric path.  If the sampler cannot form a valid
          pair it returns ``None`` and resolution falls through.
-      3. First-N from ``list_cached_problems()`` (legacy default).
+      3. Explicit ``LOCAL_DATASET_PATH`` fixture first-N (wiring/dry-run
+         determinism, sampler OFF).
+      4. First-N from ``list_cached_problems()`` (legacy default).
 
-    Pure function over env + dataset state."""
+    Pure function over env + dataset state.
+
+    Slice 62 ordering fix — the geometric sampler (an explicit opt-in)
+    now precedes the local-dataset first-N. The #65644 Tier-1.5 was
+    mis-placed ahead of the sampler, so enabling the sampler over a
+    local dataset blind-took the first id and never sampled.
+    """
     explicit = inject_instance_ids()
     if explicit:
         return explicit
 
-    # Tier 1.5 — explicit LOCAL_DATASET_PATH fixture (wiring/dry-run
-    # determinism). When the operator pins a local dataset (the phase-1
-    # dry-run contract), resolve from THAT fixture's own records rather than
-    # the persistent cache, so the dry-run runs the intended fixture
-    # (e.g. jarvis__harness-smoke-001) instead of a stale-cached real problem
-    # (the phase1 bt-2026-06-01 django__django-16255 mis-injection). Inert
-    # when LOCAL_DATASET_PATH is unset (real HF runs) — falls through below.
-    local_ids = _local_dataset_instance_ids()
-    if local_ids:
-        return local_ids[: inject_count()]
-
-    # Tier 2 — geometric self-curation (opt-in). Compose the
-    # sampler; never let an import/scan failure break the legacy
-    # fallthrough (fail-open per §7).
+    # Tier 2 — geometric self-curation (opt-in, explicit). When the
+    # operator turns the sampler ON they want a *sampled* discriminator
+    # pair, so it precedes the blind local/cache first-N tiers below.
+    # Fail-open per §7: any import/scan failure falls through.
     try:
         from backend.core.ouroboros.governance.swe_bench_pro.geometric_sampler import (  # noqa: E501
             geometric_sampler_enabled,
@@ -263,15 +261,28 @@ def _resolve_instance_ids() -> List[str]:
             logger.warning(
                 "[SWEBenchPro.HarnessInject] geometric sampler ON "
                 "but yielded no valid pair — falling through to "
-                "cache first-N"
+                "local/cache first-N"
             )
     except Exception:  # noqa: BLE001 — fail-open (legacy path intact)
         logger.warning(
             "[SWEBenchPro.HarnessInject] geometric sampler tier "
-            "raised — falling through to cache first-N",
+            "raised — falling through to local/cache first-N",
             exc_info=True,
         )
 
+    # Tier 3 — explicit LOCAL_DATASET_PATH fixture (wiring/dry-run
+    # determinism, sampler OFF). When the operator pins a local dataset
+    # (the phase-1 dry-run contract) WITHOUT the sampler, resolve from
+    # THAT fixture's own records rather than the persistent cache, so the
+    # dry-run runs the intended fixture (e.g. jarvis__harness-smoke-001)
+    # instead of a stale-cached real problem (the phase1 bt-2026-06-01
+    # django__django-16255 mis-injection). Inert when LOCAL_DATASET_PATH
+    # is unset (real HF runs) — falls through below.
+    local_ids = _local_dataset_instance_ids()
+    if local_ids:
+        return local_ids[: inject_count()]
+
+    # Tier 4 — first-N from list_cached_problems() (legacy default).
     cached = list_cached_problems()
     if not cached:
         return []

--- a/tests/governance/test_slice62_hf_placeholder_sentinel.py
+++ b/tests/governance/test_slice62_hf_placeholder_sentinel.py
@@ -1,0 +1,73 @@
+"""Slice 62 — Hugging Face token placeholder sentinel.
+
+Recurring misconfig (2026-06-02, three times): the operator's HF auth used an
+un-substituted placeholder (`hf_YOUR_REAL_TOKEN_HERE`, `your_actual_token_here`,
+`<paste_your_huggingface_token_here>`), which 401s DEEP inside huggingface_hub —
+a cryptic traceback that doesn't say "your token is fake."
+
+Fix: a pre-flight sentinel in the HF load path. A placeholder token is a CONFIG
+error (not transient), so it aborts loudly with an actionable message BEFORE the
+network call — while genuinely transient errors stay fail-open (the loader's
+existing contract). An unset/empty token is NOT a placeholder (a disk-cached
+`hf auth login` token is valid with HF_TOKEN unset).
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.swe_bench_pro import dataset_loader as dl
+
+
+def test_predicate_detects_placeholders():
+    for p in [
+        "hf_YOUR_REAL_TOKEN_HERE",
+        "your_actual_token_here",
+        "<paste_your_huggingface_token_here>",
+        "paste_your_token",
+        "YOUR_HUGGINGFACE_TOKEN",
+        "your_real_token",
+        "token_here",
+    ]:
+        assert dl.hf_token_appears_placeholder(p) is True, p
+
+
+def test_predicate_accepts_real_and_empty():
+    # A realistic token must pass; empty/unset must NOT trip (disk-cached
+    # `hf auth login` token is valid with HF_TOKEN env unset).
+    assert dl.hf_token_appears_placeholder("hf_AbC123realLooKing789xyz") is False
+    assert dl.hf_token_appears_placeholder("") is False
+    assert dl.hf_token_appears_placeholder("   ") is False
+    assert dl.hf_token_appears_placeholder(None) is False  # defensive
+
+
+def test_iter_hf_records_raises_on_placeholder(monkeypatch):
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_HF_DATASET", "ScaleAI/SWE-bench_Pro")
+    monkeypatch.setenv("HF_TOKEN", "hf_YOUR_REAL_TOKEN_HERE")
+    with pytest.raises(dl.HFTokenPlaceholderError):
+        list(dl._iter_hf_records())
+
+
+def test_iter_hf_records_inert_when_dataset_unset(monkeypatch):
+    # No HF dataset configured -> the HF path is inert, placeholder token in
+    # env is irrelevant (never reaches the sentinel). Byte-identical to legacy.
+    monkeypatch.delenv("JARVIS_SWE_BENCH_PRO_HF_DATASET", raising=False)
+    monkeypatch.setenv("HF_TOKEN", "hf_YOUR_REAL_TOKEN_HERE")
+    assert list(dl._iter_hf_records()) == []
+
+
+def test_iter_all_dataset_records_propagates_placeholder(monkeypatch):
+    # The full-scan path (geometric sampler) must surface the config error,
+    # not silently fail-open to an empty distribution.
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_HF_DATASET", "ScaleAI/SWE-bench_Pro")
+    monkeypatch.setenv("HF_TOKEN", "paste_your_token")
+    monkeypatch.delenv("JARVIS_SWE_BENCH_PRO_LOCAL_DATASET_PATH", raising=False)
+    with pytest.raises(dl.HFTokenPlaceholderError):
+        list(dl.iter_all_dataset_records())
+
+
+def test_load_from_huggingface_propagates_placeholder(monkeypatch):
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_HF_DATASET", "ScaleAI/SWE-bench_Pro")
+    monkeypatch.setenv("HF_TOKEN", "<paste_your_huggingface_token_here>")
+    with pytest.raises(dl.HFTokenPlaceholderError):
+        dl._load_from_huggingface("any__instance-1")


### PR DESCRIPTION
## Summary

Operators repeatedly authenticated with an **un-substituted placeholder token** (`hf_YOUR_REAL_TOKEN_HERE`, `your_actual_token_here`, `<paste_your_huggingface_token_here>`) → `401` deep inside `huggingface_hub` with a cryptic traceback that never says "your token is fake."

## Verify-first scoping of the authorized runbook

| Phase | Finding | Action |
|---|---|---|
| 1 — store token in `.env` | `.env` **already** gitignored (`.gitignore:21`); entrypoint **already** loads it (`ouroboros_battle_test.py:170-197`), `.env` winning over stale shell exports *precisely to avoid silent 401s* | ✅ already works — needs a **real** token (operator action) |
| 2 — subprocess env-inheritance refactor | Entrypoint loads `.env` into `os.environ`; subprocess inherits `os.environ` by default — **no inheritance gap** | ❌ unnecessary churn — declined |
| 3 — placeholder sentinel | The genuine recurring-pain fix | ✅ built |

## The sentinel (`dataset_loader.py`)

- Pure `hf_token_appears_placeholder()` predicate + `_assert_hf_token_not_placeholder()` at the top of `_iter_hf_records` **before any import/network**.
- A placeholder is a **config** error (not transient): logs an actionable `ERROR` and raises `HFTokenPlaceholderError`, which the two fail-open callers (`_load_from_huggingface`, `iter_all_dataset_records`) **selectively re-raise** — transient fetch errors stay fail-open.
- Unset/empty token is **not** a placeholder (a disk-cached `hf auth login` token is valid with `HF_TOKEN` unset).

## Bonus: real #65644 ordering bug fixed

The geometric-sampler tier test (`test_harness_inject_tier_order`) was red on `main` — my own #65644 placed **Tier-1.5 (`LOCAL_DATASET_PATH` first-N) ahead of the geometric sampler**, so enabling the sampler over a local dataset blind-took the first id and never sampled. Reordered to **CSV → sampler (explicit opt-in) → local first-N → cache**. `phase1` (sampler-off + `LOCAL_DATASET_PATH` → fixture) is intact, and the sampler is now actually usable for the live-HF triage.

## Tests

6 sentinel tests + the previously-red `test_harness_inject_tier_order` now green; #65644 local-dataset + `parallel_eval` suites green; swe_bench baseline unchanged (same 12 pre-existing `phase_a_disabled`/taxonomy fails, verified on `main` via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a preflight check that blocks placeholder Hugging Face tokens and surfaces a clear error before any network call. Also fixes the geometric sampler tier order so sampling runs before local first‑N and cache.

- **New Features**
  - Added placeholder-token sentinel in `dataset_loader.py`; raises `HFTokenPlaceholderError` and logs a clear message before touching `huggingface_hub`.
  - Allows empty/unset token; on-disk `hf auth login` remains valid without `HF_TOKEN`.

- **Bug Fixes**
  - Reordered `_resolve_instance_ids` to: CSV → geometric sampler (opt-in) → local first‑N (`LOCAL_DATASET_PATH`) → cache, so the sampler actually samples when a local dataset is set.
  - Added tests for the sentinel and the tier ordering.

<sup>Written for commit 39c87c865b542adfecb5670a80d97e583e53aa80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/66312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

