### PR TITLE
feat(intake): Slice 63 — benchmark-isolation sensor gate (+ overridable soak cap)

### DIFF
--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -16,7 +16,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from backend.core.ouroboros.governance.multi_repo.registry import RepoRegistry
@@ -34,6 +34,33 @@ def _sensor_disabled(env_name: str) -> bool:
     """
     raw = os.environ.get(f"JARVIS_{env_name}_ENABLED", "true").strip().lower()
     return raw in {"0", "false", "no", "off"}
+
+
+def benchmark_isolation_mode() -> bool:
+    """Slice 63 — True when ``JARVIS_BENCHMARK_ISOLATION_MODE`` is set truthy.
+
+    In isolation mode every autonomous sensor is suppressed so an injected
+    curated benchmark (e.g. ``swe_bench_pro``) owns 100% of the execution +
+    token budget. The benchmark ops are delivered by the harness boot hook
+    (``maybe_inject_swe_bench_at_boot`` -> intake), which is sensor-INDEPENDENT,
+    so isolation never blocks the benchmark itself — it only removes the
+    cross-task budget dilution that starved the bt-2026-06-02-074655 soak
+    (OpportunityMiner 'torch' + GitHubIssue '#65637' ops ate the Claude budget
+    before either benchmark instance could GENERATE). Default-FALSE."""
+    return os.environ.get(
+        "JARVIS_BENCHMARK_ISOLATION_MODE", "false",
+    ).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def apply_benchmark_isolation(sensors: List[Any]) -> Tuple[List[Any], int]:
+    """Return ``([], n_suppressed)`` under benchmark isolation, else
+    ``(sensors, 0)`` unchanged. Pure — the single decision seam the intake
+    layer composes after building ``self._sensors`` (covers BOTH the poll-loop
+    ``start()`` and the FS-event-bridge subscription, which both iterate
+    ``self._sensors``)."""
+    if benchmark_isolation_mode():
+        return [], len(sensors)
+    return sensors, 0
 
 
 # ---------------------------------------------------------------------------
@@ -859,6 +886,23 @@ class IntakeLayerService:
             logger.debug(
                 "[IntakeLayer] VisionSensor registered enabled=false "
                 "(set JARVIS_VISION_SENSOR_ENABLED=1 to opt in)",
+            )
+
+        # ---- Slice 63: benchmark-isolation gate (single seam) ----
+        # When JARVIS_BENCHMARK_ISOLATION_MODE is set, suppress ALL autonomous
+        # sensors so an injected curated benchmark owns 100% of the budget.
+        # Placed AFTER the full sensor list is built and BEFORE the FS event
+        # bridge subscription below — both the start() poll loop and the bridge
+        # iterate self._sensors, so clearing it here covers both activation
+        # paths. The harness-injected benchmark ops are sensor-independent and
+        # are unaffected.
+        self._sensors, _n_suppressed = apply_benchmark_isolation(self._sensors)
+        if _n_suppressed:
+            logger.info(
+                "[IntakeLayer] BENCHMARK ISOLATION MODE — suppressed %d "
+                "autonomous sensor(s); only injected benchmark ops will flow "
+                "(JARVIS_BENCHMARK_ISOLATION_MODE=true)",
+                _n_suppressed,
             )
 
         # ---- ReactorEventConsumer (P3) ----

--- a/scripts/swe_bench_pro_soak.sh
+++ b/scripts/swe_bench_pro_soak.sh
@@ -25,7 +25,10 @@ REPO="$(git rev-parse --show-toplevel)"
 cd "$REPO"
 
 # ---- Phase 0 rails (MANDATORY; composed via battle-test flags) -------------
-COST_CAP="2.00"          # operator-bound USD ceiling
+# Slice 63 — COST_CAP is operator-overridable: DW-down forces the costly
+# Claude-only lane (~$0.50/op), so a 106-file instance needs more headroom than
+# the $2 default (e.g. COST_CAP=8 bash scripts/swe_bench_pro_soak.sh phase3 ...).
+COST_CAP="${COST_CAP:-2.00}"   # operator-bound USD ceiling (env-overridable)
 MAX_WALL="2400"          # hard wall-clock seconds (retry-storm-proof)
 IDLE_TIMEOUT="1800"      # per-op liveness seconds
 # Restricted-env: sandbox blocks .git/config under the repo root, so the
@@ -56,6 +59,14 @@ export JARVIS_OP_LIFECYCLE_SSE_ENABLED=true
 # AND real phase3 benchmark) is lost on process exit — no verdict artifact.
 # This is the durable-row gate the report_card reads.
 export JARVIS_SWE_BENCH_PRO_RESULT_PERSISTENCE_ENABLED=true
+# Slice 63 — benchmark isolation: suppress ALL autonomous sensors so the
+# injected benchmark instances own 100% of the execution + token budget.
+# The bt-2026-06-02-074655 soak burned its budget on OpportunityMiner ('torch')
+# + GitHubIssue ('#65637') noise ops before either swe_bench instance could
+# GENERATE. Injected ops are sensor-independent, so this never blocks the
+# benchmark. (Budget Safe-Halt already exists — candidate_generator's
+# SessionBudgetPreflightRefused — so isolation + an adequate COST_CAP is the fix.)
+export JARVIS_BENCHMARK_ISOLATION_MODE=true
 
 _battle() {
   # Single composition point. The harness owns the caps.

--- a/tests/governance/test_slice63_isolation_governor.py
+++ b/tests/governance/test_slice63_isolation_governor.py
@@ -1,0 +1,79 @@
+"""Slice 63 — benchmark-isolation sensor gate.
+
+Phase 3 soak (bt-2026-06-02-074655): autonomous sensors (OpportunityMiner
+'torch is 7 versions behind', GitHubIssue '#65637') fired ops that competed with
+the 2 injected swe_bench instances for the shared Claude budget while DW's
+circuit was tripped, draining the $2 cap to $0 before either benchmark instance
+could GENERATE — 0 scored rows.
+
+Fix: a single benchmark-isolation gate. When ``JARVIS_BENCHMARK_ISOLATION_MODE``
+is set, the intake layer suppresses ALL autonomous sensors so an injected
+benchmark (swe_bench_pro is delivered by the harness boot hook — sensor-
+INDEPENDENT) owns 100% of the execution + token budget. Composes the existing
+``self._sensors`` collection (started via one loop + subscribed by the FS event
+bridge from the same list) — no parallel governance manager.
+
+Runbook Phase 2 (provider-aware budget Safe-Halt) is intentionally NOT built in
+code: it ALREADY exists as the candidate_generator ``SessionBudgetPreflightRefused``
+gate (verified live this run — it refused the over-budget Claude call rather than
+burning through), and auto-RAISING a spend cap is a footgun. The soak script's
+cap is made operator-overridable instead.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+from backend.core.ouroboros.governance.intake import intake_layer_service as ils
+
+
+def test_isolation_mode_default_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_BENCHMARK_ISOLATION_MODE", raising=False)
+    assert ils.benchmark_isolation_mode() is False
+
+
+def test_isolation_mode_truthy(monkeypatch):
+    for v in ("true", "1", "yes", "on", "TRUE", "On"):
+        monkeypatch.setenv("JARVIS_BENCHMARK_ISOLATION_MODE", v)
+        assert ils.benchmark_isolation_mode() is True, v
+
+
+def test_isolation_mode_falsy(monkeypatch):
+    for v in ("false", "0", "no", "off", ""):
+        monkeypatch.setenv("JARVIS_BENCHMARK_ISOLATION_MODE", v)
+        assert ils.benchmark_isolation_mode() is False, v
+
+
+def test_apply_isolation_suppresses_all_when_on(monkeypatch):
+    monkeypatch.setenv("JARVIS_BENCHMARK_ISOLATION_MODE", "true")
+    sensors = ["miner", "github", "testfail"]
+    kept, n = ils.apply_benchmark_isolation(sensors)
+    assert kept == [] and n == 3
+
+
+def test_apply_isolation_noop_when_off(monkeypatch):
+    # Default (no benchmark) — every sensor stays registered, byte-identical
+    # to pre-Slice-63 behaviour.
+    monkeypatch.delenv("JARVIS_BENCHMARK_ISOLATION_MODE", raising=False)
+    sensors = ["miner", "github", "testfail"]
+    kept, n = ils.apply_benchmark_isolation(sensors)
+    assert kept == sensors and n == 0
+
+
+def test_apply_isolation_empty_list_when_on(monkeypatch):
+    monkeypatch.setenv("JARVIS_BENCHMARK_ISOLATION_MODE", "true")
+    kept, n = ils.apply_benchmark_isolation([])
+    assert kept == [] and n == 0
+
+
+def test_soak_script_sets_isolation_and_overridable_cap():
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    src = (repo / "scripts/swe_bench_pro_soak.sh").read_text()
+    assert re.search(r"export\s+JARVIS_BENCHMARK_ISOLATION_MODE=true", src), (
+        "soak script must enable benchmark isolation so sensor noise can't "
+        "dilute the benchmark budget"
+    )
+    assert re.search(r'COST_CAP="\$\{COST_CAP:-', src), (
+        "COST_CAP must be operator-overridable (DW-down -> Claude-only is "
+        "expensive; $2 is too thin for a 106-file instance)"
+    )


### PR DESCRIPTION
## Summary

The first real Phase 3 soak (`bt-2026-06-02-074655`) burned its `$2` budget to `$0` before either injected swe_bench instance could GENERATE — the full organism's autonomous sensors fired competing ops (**OpportunityMiner** `torch is 7 versions behind`, **GitHubIssue** `#65637`) that ate the shared Claude budget while **DW's circuit was tripped** (`terminal_structural`). Result: 0 scored rows. Main tree stayed **pristine** (L3 worktree isolation held). This is budget dilution — a config issue, not a code bug.

## Verify-first scoping (composes existing surfaces; no parallel machinery)

| Runbook phase | Action |
|---|---|
| **1 — sensor isolation** | **Built as a single gate**, not a new governance manager. `benchmark_isolation_mode()` + `apply_benchmark_isolation()` clear `self._sensors` at the `_build_components` registration seam. Both activation paths iterate `self._sensors` (the `start()` poll loop **and** the FS-event-bridge subscription), so one clear covers both. swe_bench ops are injected by the harness boot hook (**sensor-independent**), so isolation never blocks the benchmark. Default-FALSE. |
| **2 — budget Safe-Halt** | **Not built — already exists.** `candidate_generator`'s `SessionBudgetPreflightRefused` is exactly "halt the over-budget op rather than burn through" (verified live this run). Auto-**raising** a spend cap is a footgun; instead `COST_CAP` is made operator-overridable. |

## Changes
- `intake_layer_service.py`: `benchmark_isolation_mode()` + `apply_benchmark_isolation()` + the one-line gate.
- `swe_bench_pro_soak.sh`: `phase1`+`phase3` set `JARVIS_BENCHMARK_ISOLATION_MODE=true`; `COST_CAP="${COST_CAP:-2.00}"` (overridable, e.g. `COST_CAP=8 …`).

## Tests
7 tests (helpers + soak-script pins). intake + sensor_governor suites regression-clean — **184 passed**; the 1 failure (`test_intake_lock` pgrep pattern) is **pre-existing on main**, verified via stash, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a benchmark-isolation gate that suppresses all autonomous sensors during runs, so injected `swe_bench_pro` tasks get the full execution and token budget. Also makes the soak script `COST_CAP` overridable to avoid early budget exhaustion.

- **New Features**
  - Intake: `benchmark_isolation_mode()` and `apply_benchmark_isolation()` clear `self._sensors` when `JARVIS_BENCHMARK_ISOLATION_MODE` is truthy; covers both the poll loop and FS-event bridge; default off.
  - Soak script: sets `JARVIS_BENCHMARK_ISOLATION_MODE=true` for `phase1` and `phase3`; `COST_CAP` is now `${COST_CAP:-2.00}`.
  - Tests: added `tests/governance/test_slice63_isolation_governor.py` to verify gating behavior and script pins.

- **Migration**
  - No changes required by default.
  - To isolate benchmarks: set `JARVIS_BENCHMARK_ISOLATION_MODE=true`.
  - Optionally raise `COST_CAP` (e.g., `COST_CAP=8`) for larger or provider-limited runs.

<sup>Written for commit e5721f3d31b3f93065b0464ffbd080781f9aa414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/66711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

