### PR TITLE
feat(change_engine): Slice 64 — context-aware APPLY write-root for swe_bench ops

### DIFF
--- a/backend/core/ouroboros/governance/change_engine.py
+++ b/backend/core/ouroboros/governance/change_engine.py
@@ -328,6 +328,12 @@ class ChangeRequest:
     verify_fn: Optional[Any] = None
     break_glass_op_id: Optional[str] = None
     op_id: Optional[str] = None
+    # Slice 64 — per-request APPLY write root. When set (e.g. a swe_bench_pro
+    # op's prepared per-problem worktree, carried in the envelope repo_root),
+    # it takes precedence over JARVIS_AUTO_COMMIT_WORKSPACE so the patch lands
+    # in the correct tree (the cloned benchmark repo), not the JARVIS auto-
+    # commit workspace. None = byte-identical legacy resolution.
+    write_root: Optional[Path] = None
 
 
 @dataclass
@@ -408,30 +414,39 @@ class ChangeEngine:
     # Slice 56 — cross-worktree write alignment (Option A)
     # ------------------------------------------------------------------
 
-    def _effective_write_root(self) -> Path:
+    def _effective_write_root(self, request_write_root: Optional[Path] = None) -> Path:
         """Resolve the root that APPLY writes into.
 
-        When ``JARVIS_AUTO_COMMIT_WORKSPACE`` is set (harness ledger-sovereignty
-        owned worktree), writes are redirected there so they land in the SAME
-        tree AutoCommitter commits from (``AutoCommitter._effective_repo_root``)
-        — coherent by construction — and the operator's main tree is never
-        touched. Unset → ``self._project_root`` (byte-identical legacy path).
+        Precedence (Slice 64):
+          1. ``request_write_root`` — a per-op root (e.g. a swe_bench_pro
+             prepared per-problem worktree from the envelope repo_root). Wins
+             so the patch lands in the correct cloned-repo tree, not the JARVIS
+             auto-commit workspace (the bt-2026-06-02-081453 mis-route).
+          2. ``JARVIS_AUTO_COMMIT_WORKSPACE`` (harness ledger-sovereignty owned
+             worktree) — writes land in the SAME tree AutoCommitter commits from
+             (coherent by construction); the operator's main tree is untouched.
+          3. ``self._project_root`` (byte-identical legacy path).
         """
+        if request_write_root is not None:
+            return Path(request_write_root)
         override = os.environ.get("JARVIS_AUTO_COMMIT_WORKSPACE")
         if override:
             return Path(override)
         return self._project_root
 
-    def _redirect_target(self, target: Path) -> Path:
+    def _redirect_target(
+        self, target: Path, request_write_root: Optional[Path] = None,
+    ) -> Path:
         """Rebase a write target onto :meth:`_effective_write_root`.
 
-        No-op when the env override is unset (root == project_root). Absolute
-        paths are rebased by their path relative to ``project_root``; relative
-        paths are joined to the write root. A target NOT under ``project_root``
-        is left unchanged (defensive — never silently cross-write elsewhere).
-        NEVER raises — falls back to the original target on any resolution error.
+        No-op when the effective root equals ``project_root`` (no per-request
+        root and no env override). Absolute paths are rebased by their path
+        relative to ``project_root``; relative paths are joined to the write
+        root. A target NOT under ``project_root`` is left unchanged (defensive —
+        never silently cross-write elsewhere). NEVER raises — falls back to the
+        original target on any resolution error.
         """
-        root = self._effective_write_root()
+        root = self._effective_write_root(request_write_root)
         try:
             if root.resolve() == self._project_root.resolve():
                 return target
@@ -614,7 +629,12 @@ class ChangeEngine:
             # commits from (and never the operator's main tree). No-op when
             # JARVIS_AUTO_COMMIT_WORKSPACE is unset. Rollback snapshot + lock +
             # signature all follow the redirected target (Phase 2 coherence).
-            target = self._redirect_target(Path(request.target_file))
+            # Slice 64 — a per-request write_root (e.g. a swe_bench_pro prepared
+            # worktree) takes precedence over the auto-commit workspace so the
+            # patch lands in the correct cloned-repo tree.
+            target = self._redirect_target(
+                Path(request.target_file), request.write_root,
+            )
             rollback = RollbackArtifact.capture(target)
 
             await self._ledger.append(

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -10525,6 +10525,35 @@ class GovernedOrchestrator:
             adapter_names_run=adapter_names,
         )
 
+    def _swe_bench_write_root(self, ctx: OperationContext) -> Optional[Path]:
+        """Slice 64 — the APPLY write root for a swe_bench_pro op.
+
+        Returns the VALIDATED envelope ``repo_root`` (the prepared per-problem
+        worktree — a cloned benchmark repo) so APPLY writes there instead of the
+        JARVIS ``JARVIS_AUTO_COMMIT_WORKSPACE`` (the bt-2026-06-02-081453 mis-
+        route where ``src/Markdown.ts`` was rebased onto a JARVIS worktree and
+        APPLY failed). Composes the SAME ``guard_envelope_repo_root`` anchor-
+        validator the Advisor uses (operation_advisor) — no raw-evidence trust.
+        Returns ``None`` for every non-swe_bench op (legacy write resolution
+        unchanged) and on any error (never breaks APPLY)."""
+        try:
+            if getattr(ctx, "signal_source", "") != "swe_bench_pro":
+                return None
+            from backend.core.ouroboros.governance.operation_advisor import (
+                guard_envelope_repo_root,
+            )
+            return guard_envelope_repo_root(
+                ctx.intake_evidence_json,
+                project_root=self._config.project_root,
+            )
+        except Exception:  # noqa: BLE001 — APPLY must never break on this
+            logger.debug(
+                "[Orchestrator] _swe_bench_write_root resolution raised "
+                "for op=%s — falling back to legacy write root",
+                getattr(ctx, "op_id", "?"), exc_info=True,
+            )
+            return None
+
     def _build_change_request(
         self, ctx: OperationContext, candidate: Dict[str, Any]
     ) -> ChangeRequest:
@@ -10550,6 +10579,7 @@ class GovernedOrchestrator:
             proposed_content=proposed_content,
             profile=profile,
             op_id=ctx.op_id,
+            write_root=self._swe_bench_write_root(ctx),
         )
 
     def _discover_tests_for_gate(self, sut_path: Path) -> List[Path]:
@@ -10628,6 +10658,7 @@ class GovernedOrchestrator:
                 proposed_content=fc,
                 profile=profile,
                 op_id=f"{ctx.op_id}::{idx:02d}",
+                write_root=self._swe_bench_write_root(ctx),  # Slice 64
             )
 
             try:

--- a/tests/governance/test_slice64_routing_pacing.py
+++ b/tests/governance/test_slice64_routing_pacing.py
@@ -1,0 +1,84 @@
+"""Slice 64 — context-aware APPLY write-root routing.
+
+Guarded soak (bt-2026-06-02-081453): Claude solved the element-web bug and
+proposed a patch for ``src/Markdown.ts``, but APPLY failed with
+``No such file or directory: .worktrees/ouroboros__auto__bt-<session>/src/Markdown.ts``.
+
+Root cause: the harness sets ``JARVIS_AUTO_COMMIT_WORKSPACE`` to a JARVIS-repo
+worktree (harness.py:2637), and Slice 56's ``ChangeEngine._redirect_target``
+blindly rebased EVERY write there. A swe_bench op's target belongs in its
+prepared per-problem worktree (an element-web clone, carried in the envelope as
+``EVIDENCE_REPO_ROOT_KEY``), not the JARVIS auto-commit workspace — so the
+rebased path didn't exist, APPLY failed, the op never reached a clean terminal,
+the operation_terminal SSE never fired, and the closed-loop evaluator hung
+(0 scored rows).
+
+Fix (additive + gated): ``ChangeRequest`` gains an optional ``write_root``;
+``_effective_write_root`` prefers it over ``JARVIS_AUTO_COMMIT_WORKSPACE``; the
+orchestrator populates it from the validated envelope repo_root ONLY for
+swe_bench_pro ops. ``write_root=None`` is byte-identical for every other op
+(contained blast radius).
+
+(Runbook Phase 2 — indexer asyncio.sleep pacing — was NOT built: Oracle indexing
+is ``execution_mode=process`` (process-isolated, off the main loop), so the
+"indexer locks the GIL" premise is falsified.)
+"""
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+
+from backend.core.ouroboros.governance.change_engine import ChangeEngine, ChangeRequest
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _engine(root):
+    # _effective_write_root / _redirect_target only touch self._project_root +
+    # env + the arg, so a stub ledger is fine.
+    return ChangeEngine(project_root=root, ledger=object())  # type: ignore[arg-type]
+
+
+def test_change_request_has_write_root_field():
+    names = {f.name for f in dataclasses.fields(ChangeRequest)}
+    assert "write_root" in names
+
+
+def test_request_write_root_wins_over_auto_commit_env(tmp_path, monkeypatch):
+    eng = _engine(tmp_path)
+    monkeypatch.setenv("JARVIS_AUTO_COMMIT_WORKSPACE", str(tmp_path / "autocommit"))
+    wt = tmp_path / "swebp_wt" / "element-web"
+    assert eng._effective_write_root(wt) == wt
+
+
+def test_no_request_root_falls_back_to_env_then_project(tmp_path, monkeypatch):
+    eng = _engine(tmp_path)
+    monkeypatch.delenv("JARVIS_AUTO_COMMIT_WORKSPACE", raising=False)
+    assert eng._effective_write_root(None) == tmp_path           # project_root
+    ac = tmp_path / "ac"
+    monkeypatch.setenv("JARVIS_AUTO_COMMIT_WORKSPACE", str(ac))
+    assert eng._effective_write_root(None) == ac                 # env override
+
+
+def test_redirect_rebases_onto_request_write_root(tmp_path, monkeypatch):
+    eng = _engine(tmp_path)
+    # auto-commit env present but MUST be ignored when a request write_root is given
+    monkeypatch.setenv("JARVIS_AUTO_COMMIT_WORKSPACE", str(tmp_path / "autocommit"))
+    wt = tmp_path / "swebp_wt" / "element-web"
+    target = tmp_path / "src" / "Markdown.ts"   # absolute under project_root
+    assert eng._redirect_target(target, wt) == wt / "src" / "Markdown.ts"
+
+
+def test_redirect_none_preserves_legacy(tmp_path, monkeypatch):
+    eng = _engine(tmp_path)
+    monkeypatch.delenv("JARVIS_AUTO_COMMIT_WORKSPACE", raising=False)
+    target = tmp_path / "src" / "x.py"
+    assert eng._redirect_target(target, None) == target   # no override -> unchanged
+
+
+def test_orchestrator_gates_write_root_on_swe_bench_source():
+    src = (_REPO / "backend/core/ouroboros/governance/orchestrator.py").read_text()
+    assert "write_root=" in src, "orchestrator must set ChangeRequest.write_root"
+    assert "guard_envelope_repo_root" in src, (
+        "write_root must come from the validated envelope repo_root, not raw evidence"
+    )


### PR DESCRIPTION
## Summary

Guarded soak (`bt-2026-06-02-081453`): Claude **solved the element-web bug** and proposed a patch for `src/Markdown.ts` ($0.23), but APPLY failed —
`No such file or directory: .worktrees/ouroboros__auto__bt-<session>/src/Markdown.ts` — so the op never reached a clean terminal, the `operation_terminal` SSE never fired, the closed-loop evaluator hung, and **0 scored rows** landed. Main tree stayed pristine.

**Root cause:** the harness sets `JARVIS_AUTO_COMMIT_WORKSPACE` to a **JARVIS-repo** worktree (harness.py:2637), and Slice 56's `ChangeEngine._redirect_target` rebased *every* write there. A swe_bench op's target belongs in its prepared **per-problem worktree** (a cloned benchmark repo, carried in the envelope as `EVIDENCE_REPO_ROOT_KEY`), so the JARVIS-worktree rebase pointed at a nonexistent path.

## Fix (additive + gated — Phase 1 only)
- `ChangeRequest` gains optional `write_root: Optional[Path] = None`.
- `_effective_write_root` / `_redirect_target` take a per-request `write_root` with precedence **`request.write_root` > `JARVIS_AUTO_COMMIT_WORKSPACE` > `project_root`**. `None` = byte-identical legacy.
- `orchestrator._swe_bench_write_root(ctx)`: for `signal_source=="swe_bench_pro"` **only**, resolves the **validated** envelope `repo_root` via the same `guard_envelope_repo_root` anchor-validator the Advisor uses (no raw-evidence trust); wired into both `ChangeRequest` build sites. Every non-swe_bench op keeps legacy resolution — **contained blast radius**.

## Runbook deviations (verify-first)
- **Phase 2 (indexer `asyncio.sleep` pacing) — NOT built.** Oracle indexing is `execution_mode=process` (process-isolated, off the main loop; 5/5 confirmed in the soak). The "indexer locks the GIL" premise is falsified — same class as the Slice 51 core-reservation governor I refused.
- **Phase 3 qutebrowser ID was malformed** (carried the NodeBB version hash). The verified ID will be used for the re-soak.

## Tests
6 tests (ChangeEngine precedence + rebase-onto-worktree + `ChangeRequest` field + orchestrator wiring pin). change_engine / Slice 56 / sovereignty suites regression-clean — **51 passed**; the 3 `ledger_sovereignty` `master_off` failures are **pre-existing on main** (verified via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes APPLY path routing for `swe_bench_pro` by writing to the prepared per-problem worktree instead of the JARVIS auto-commit workspace, preventing file-not-found errors and allowing ops to complete. Adds a per-request write root with safe precedence; legacy behavior remains for all other ops.

- **Bug Fixes**
  - Added `write_root` to `ChangeRequest`.
  - Updated `ChangeEngine` to resolve write roots with precedence: `request.write_root` > `JARVIS_AUTO_COMMIT_WORKSPACE` > project root.
  - Orchestrator now sets `write_root` only for `swe_bench_pro` via validated envelope `repo_root` using `guard_envelope_repo_root` (single and multi-file).
  - Added tests for precedence, rebasing, and orchestrator wiring.

<sup>Written for commit 528153ea6f88a4fd09191470842c9b0b66d0a071. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/67731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

