### PR TITLE
feat(swe_bench_pro): add containerized scoring backend

### DIFF
--- a/.ouroboros/slice45_trace/trace_1780088359.json
+++ b/.ouroboros/slice45_trace/trace_1780088359.json
@@ -1,0 +1,46 @@
+{
+  "stamp": "1780088359",
+  "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+  "results": [
+    {
+      "label": "tools_advertised",
+      "elapsed_s": 5.8,
+      "error": "",
+      "content_len": 501,
+      "content": "{\n  \"schema_version\": \"2b.2-tool\",\n  \"preamble\": \"Reading the SurfaceHealthRecord dataclass to see its current fields and structure.\",\n  \"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"backend/core/ouroboros/governance/dw_surface_health.py\"\n      }\n    },\n    {\n      \"name\": \"search_code\",\n      \"arguments\": {\n        \"pattern\": \"from.*dw_surface_health.*import.*SurfaceHealthRecord|import.*SurfaceHealthRecord\",\n        \"file_glob\": \"*.py\"\n      }\n    }\n  ]\n}",
+      "classification": {
+        "verdict": "PREDICATE_FIX_SUFFICIENT",
+        "parser_caught": true,
+        "hits": {
+          "envelope_2b2": "{\n  \"schema_version\": \"2b.2-tool\",\n  \"preamble\": \"Reading the SurfaceHealthRecord dataclass to see its current fields and structure.\",\n  \"tool_calls\": [\n    {\n ",
+          "markdown_tool_json": "",
+          "native_tool_calls": "\"tool_calls\": [\n    {\n      \"name\": \"read_file\",\n      \"arguments\": {\n        \"path\": \"backend/core/ouroboros/governance/dw_surface_health.py\"\n      }\n    },\n  ",
+          "xml_tool_call": "",
+          "alt_json_toolish": ""
+        },
+        "any_alt_intent": true,
+        "looks_like_patch": false
+      }
+    },
+    {
+      "label": "tools_suppressed",
+      "elapsed_s": 13.0,
+      "error": "",
+      "content_len": 2594,
+      "content": "### Step 1: Investigation Plan\nSince I do not have direct access to the file system or the specific contents of `backend/core/ouroboros/governance/dw_surface_health.py`, I cannot immediately see the field definitions of the `SurfaceHealthRecord` dataclass.\n\nTo proceed correctly and avoid hallucinating field names, the following steps are required in a real-world execution environment:\n1.  **Locate the File**: Navigate to `backend/core/ouroboros/governance/dw_surface_health.py`.\n2.  **Read the Class Definition**: Identify the `@dataclass` decorator and list all fields defined within `SurfaceHealthRecord` (e.g., `surface_id`, `timestamp`, `health_score`, `anomaly_flags`, etc.).\n3.  **Analyze Field Types**: Determine which fields are critical for a \"compact one-line summary\" (usually IDs, status enums, and key metrics) versus those that might be too verbose (like large arrays or full trace logs).\n\n### Step 2: Assumption & Strategy (Simulated)\n*Assuming* a standard health record structure based on the class name `SurfaceHealthRecord` and the context of \"governance\" and \"ouroboros\" (often implying cyclic or self-healing systems), the dataclass likely contains:\n-   `surface_id`: Identifier for the surface.\n-   `timestamp`: When the record was created.\n-   `status` or `health_score`: Current health state.\n-   `issues` or `errors`: Optional list of detected problems.\n\n**Strategy for `__repr__`**:\n-   Use an f-string.\n-   Include the class name.\n-   Include key identifying fields (`surface_id`).\n-   Include the primary state (`status` or `health_score`).\n-   Truncate or summarize list fields if they exist to maintain the \"compact one-line\" requirement.\n\n### Step 3: Proposed Implementation Pattern\nOnce the actual fields are known, the implementation will follow this pattern:\n\n```python\ndef __repr__(self) -> str:\n    # Example pattern - fields must be replaced with actual definition\n    return f\"{self.__class__.__name__}(id={self.surface_id}, status={self.status}, score={self.health_score})\"\n```\n\n### Step 4: Request for File Content\nTo provide the **exact** code patch you need, please provide the content of `backend/core/ouroboros/governance/dw_surface_health.py` or at least the definition of the `SurfaceHealthRecord` dataclass.\n\n**Example of what I need:**\n```python\n@dataclass\nclass SurfaceHealthRecord:\n    surface_id: str\n    timestamp: datetime\n    health_score: float\n    is_healthy: bool\n    error_details: Optional[List[str]] = None\n```\n\n**Once you provide the file content, I will generate the precise `__repr__` method tailored to those specific fields.**",
+      "classification": {
+        "verdict": "BEHAVIORAL_SKIP",
+        "parser_caught": false,
+        "hits": {
+          "envelope_2b2": "",
+          "markdown_tool_json": "",
+          "native_tool_calls": "",
+          "xml_tool_call": "",
+          "alt_json_toolish": ""
+        },
+        "any_alt_intent": false,
+        "looks_like_patch": true
+      }
+    }
+  ]
+}

--- a/backend/core/ouroboros/governance/swe_bench_pro/container_engine.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/container_engine.py
@@ -42,7 +42,7 @@ import platform
 import re
 import shlex
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, List, Optional, Sequence, Tuple
 

--- a/backend/core/ouroboros/governance/swe_bench_pro/container_engine.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/container_engine.py
@@ -1,0 +1,450 @@
+"""Containerized test-execution backend for SWE-Bench-Pro scoring (Slice 65).
+
+The barrier that blocked every prior soak: local scoring runs ``pytest`` in the
+bare host Python env, which lacks each benchmark repo's dependencies (qutebrowser
+needs PyQt, NodeBB needs Node, etc.), so the gold/model tests can't even import
+→ ``unresolved``/``scoring_error``. SWE-Bench-Pro ships a prepared Docker image
+per problem (``dockerhub_tag``) with the FULL environment for exactly this.
+
+This module is an ALTERNATIVE execution backend for the scorer's apply+run step
+— NOT a new scorer. It is gated (``JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED``,
+default-OFF → the existing local :func:`scorer.score_evaluation` path is byte-
+identical), composes the same ``asyncio.create_subprocess_exec`` shape the scorer
+already uses for ``git apply`` (no new hard dependency on the docker SDK), and
+hardcodes NOTHING:
+
+  * image namespace is env-overridable (``JARVIS_SWE_BENCH_PRO_IMAGE_NAMESPACE``,
+    default ``jefzda/sweap-images`` per the official scaleapi/SWE-bench_Pro-os
+    harness); the per-image tag comes from the problem's ``dockerhub_tag``;
+  * the ``--platform`` emulation flag is DERIVED from the host architecture
+    (Apple-Silicon/aarch64 → ``linux/amd64``; native x86 → none), so the same
+    code runs un-emulated on an x86 CI box;
+  * the test ids come from the problem's ``fail_to_pass`` + ``pass_to_pass``;
+  * the repo root + entrypoint match the verified image contract (``/app``,
+    ``--entrypoint bash``), both env-overridable for future image families.
+
+Verified flow (bt-2026-06-02, qutebrowser, gold patch → ``test_error`` PASSED):
+``cd /app && git apply <test_patch> && git apply <model_patch> &&
+python -m pytest <fail_to_pass ∪ pass_to_pass> -rA``.
+
+The docker invocation is driven through an injectable async runner so the
+orchestration is unit-testable without a daemon. NEVER raises into the scorer —
+any infra/daemon error surfaces as a populated :class:`ContainerScoreResult`
+with ``error`` set (the scorer maps that to ``SCORING_ERROR``, never a crash).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import platform
+import re
+import shlex
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.SWEBenchPro.ContainerEngine")
+
+# --- env knobs (all default-safe; nothing hardcoded at a call site) ---------
+CONTAINER_EVAL_ENABLED_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED"
+IMAGE_NAMESPACE_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_IMAGE_NAMESPACE"
+REPO_ROOT_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_CONTAINER_REPO_ROOT"
+ENTRYPOINT_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_CONTAINER_ENTRYPOINT"
+DOCKER_BIN_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_DOCKER_BIN"
+
+_DEFAULT_IMAGE_NAMESPACE: str = "jefzda/sweap-images"   # scaleapi/SWE-bench_Pro-os
+_DEFAULT_REPO_ROOT: str = "/app"                        # verified image WorkingDir + git root
+_DEFAULT_ENTRYPOINT: str = "bash"                       # images set ENTRYPOINT=[/bin/bash]
+_DEFAULT_DOCKER_BIN: str = "docker"
+
+# Host architectures that cannot natively run the linux/amd64 benchmark images
+# and therefore require emulation (QEMU/Rosetta via Docker Desktop).
+_EMULATION_ARCHES: frozenset = frozenset({"arm64", "aarch64"})
+
+_TRUTHY: frozenset = frozenset({"1", "true", "yes", "on"})
+
+# A pytest -rA result line: "PASSED nodeid" / "FAILED nodeid" / "ERROR nodeid".
+_RESULT_LINE = re.compile(r"^(PASSED|FAILED|ERROR)\s+(\S+)", re.MULTILINE)
+# Sentinels emitted by the in-container script for non-test failures.
+_APPLY_FAIL_SENTINEL = "JARVIS_APPLY_FAIL"
+_SETUP_FAIL_SENTINEL = "JARVIS_SETUP_FAIL"
+
+
+# ---------------------------------------------------------------------------
+# Config predicates (pure)
+# ---------------------------------------------------------------------------
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def container_eval_enabled() -> bool:
+    """Master switch (§33.1 default-FALSE). OFF → scorer uses its local path."""
+    return _env_truthy(CONTAINER_EVAL_ENABLED_ENV_VAR)
+
+
+def image_namespace() -> str:
+    raw = os.environ.get(IMAGE_NAMESPACE_ENV_VAR, "").strip()
+    return raw or _DEFAULT_IMAGE_NAMESPACE
+
+
+def container_repo_root() -> str:
+    raw = os.environ.get(REPO_ROOT_ENV_VAR, "").strip()
+    return raw or _DEFAULT_REPO_ROOT
+
+
+def container_entrypoint() -> str:
+    raw = os.environ.get(ENTRYPOINT_ENV_VAR, "").strip()
+    return raw or _DEFAULT_ENTRYPOINT
+
+
+def docker_bin() -> str:
+    raw = os.environ.get(DOCKER_BIN_ENV_VAR, "").strip()
+    return raw or _DEFAULT_DOCKER_BIN
+
+
+def resolve_image(dockerhub_tag: str) -> str:
+    """``<namespace>:<dockerhub_tag>`` — the full pullable reference."""
+    return f"{image_namespace()}:{dockerhub_tag}"
+
+
+def host_platform_flag() -> Optional[str]:
+    """``"linux/amd64"`` when the host arch can't natively run the amd64 images
+    (Apple Silicon), else ``None`` (native x86 — no emulation flag needed).
+    Derived from the host, never hardcoded — same code path on x86 CI."""
+    try:
+        machine = (platform.machine() or "").strip().lower()
+    except Exception:  # noqa: BLE001 — platform probe must never break scoring
+        return None
+    return "linux/amd64" if machine in _EMULATION_ARCHES else None
+
+
+# ---------------------------------------------------------------------------
+# Problem field access (the dataset folds these into ProblemSpec.metadata)
+# ---------------------------------------------------------------------------
+
+def problem_image_tag(problem: Any) -> Optional[str]:
+    """The problem's ``dockerhub_tag`` (lives in ``ProblemSpec.metadata``)."""
+    meta = getattr(problem, "metadata", None) or {}
+    tag = meta.get("dockerhub_tag")
+    return tag if isinstance(tag, str) and tag.strip() else None
+
+
+def should_use_container(problem: Any) -> bool:
+    """True iff container eval is enabled AND the problem carries an image tag.
+    Pure gate — the scorer falls back to its local path when False."""
+    return container_eval_enabled() and problem_image_tag(problem) is not None
+
+
+def _coerce_id_list(value: Any) -> List[str]:
+    """Accept a real list, a JSON-string, OR a Python-repr string; return clean
+    ids. The SWE-bench-Pro dataset is INCONSISTENT — ``pass_to_pass`` is JSON
+    (double-quoted) but ``fail_to_pass`` is a Python ``repr`` (single-quoted),
+    which ``json.loads`` rejects. So try JSON first, then ``ast.literal_eval``
+    (literals only — safe), before treating the raw string as a single id."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return []
+        parsed: Any = None
+        try:
+            parsed = json.loads(value)
+        except (ValueError, TypeError):
+            try:
+                import ast
+                parsed = ast.literal_eval(value)
+            except (ValueError, SyntaxError, TypeError):
+                return [value]
+        value = parsed
+    if isinstance(value, (list, tuple)):
+        return [str(x).strip() for x in value if str(x).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def target_test_ids(problem: Any) -> List[str]:
+    """Deduped union of ``fail_to_pass`` + ``pass_to_pass`` test node-ids
+    (order-preserving). These are the tests the patch must satisfy."""
+    meta = getattr(problem, "metadata", None) or {}
+    ids: List[str] = []
+    seen: set = set()
+    for key in ("fail_to_pass", "pass_to_pass"):
+        for tid in _coerce_id_list(meta.get(key)):
+            if tid not in seen:
+                seen.add(tid)
+                ids.append(tid)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Result model + parsing (pure)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ContainerScoreResult:
+    """Scorer-compatible shape (mirrors TestRunner.run's total/failed/
+    failed_tests) plus an ``error`` channel for infra failures."""
+    passed: int = 0
+    failed: int = 0
+    total: int = 0
+    failed_tests: Tuple[str, ...] = ()
+    error: Optional[str] = None
+    raw_tail: str = ""
+
+    # TestRunner-compatible aliases (so the scorer's getattr() reads work
+    # whether it sees a TestRunner result or this one).
+    @property
+    def tests_total(self) -> int:
+        return self.total
+
+
+def parse_pytest_text(stdout: str, expected_ids: Sequence[str]) -> ContainerScoreResult:
+    """Parse ``pytest -rA`` text into pass/fail counts scoped to ``expected_ids``.
+
+    Pure + deterministic. Recognises the in-container failure sentinels first
+    (apply/setup), then maps each expected test id to PASSED/FAILED/ERROR from
+    the ``-rA`` summary. A required test with no result line counts as failed
+    (conservative — a test that never ran is not a pass)."""
+    text = stdout or ""
+    if _APPLY_FAIL_SENTINEL in text:
+        return ContainerScoreResult(error="model_patch_apply_failed", raw_tail=text[-400:])
+    if _SETUP_FAIL_SENTINEL in text:
+        return ContainerScoreResult(error="container_setup_failed", raw_tail=text[-400:])
+
+    status_by_id: dict = {}
+    for m in _RESULT_LINE.finditer(text):
+        status_by_id[m.group(2)] = m.group(1)
+
+    expected = [e for e in expected_ids if e]
+    if not expected:
+        # No explicit ids — fall back to the summary counts.
+        passed = len(re.findall(r"^PASSED ", text, re.MULTILINE))
+        failed = len(re.findall(r"^(FAILED|ERROR) ", text, re.MULTILINE))
+        total = passed + failed
+        return ContainerScoreResult(passed=passed, failed=failed, total=total,
+                                    raw_tail=text[-400:])
+
+    failed_tests: List[str] = []
+    passed = 0
+    for tid in expected:
+        status = status_by_id.get(tid)
+        if status == "PASSED":
+            passed += 1
+        else:
+            failed_tests.append(tid)
+    failed = len(failed_tests)
+    return ContainerScoreResult(
+        passed=passed, failed=failed, total=len(expected),
+        failed_tests=tuple(failed_tests), raw_tail=text[-400:],
+    )
+
+
+# ---------------------------------------------------------------------------
+# In-container eval script (pure builder, grounded in the verified flow)
+# ---------------------------------------------------------------------------
+
+def build_eval_script(
+    *, repo_root: str, fail_to_pass: Sequence[str], pass_to_pass: Sequence[str],
+    test_patch_path: str = "/jarvis/test.patch",
+    model_patch_path: str = "/jarvis/model.patch",
+) -> str:
+    """Bash script run inside the container (entrypoint=bash, via ``-lc``).
+
+    Order matters and matches the verified flow:
+      1. cd to the repo root + resolve the actual git toplevel (adaptive — the
+         image's WorkingDir is the git root, but we re-derive it so a different
+         image family still works).
+      2. ``git apply`` the dataset's ``test_patch`` to MATERIALISE the new tests
+         (idempotent — ``|| true`` because some images pre-bake them).
+      3. ``git apply`` the candidate model patch; a hard failure emits the
+         apply sentinel (so the parser scores it SCORING_ERROR, not a silent 0).
+      4. ``pytest`` the explicit fail_to_pass ∪ pass_to_pass node-ids with
+         ``-rA`` so every result is a parseable line.
+    All test ids are shell-quoted; nothing is interpolated unquoted."""
+    union: List[str] = []
+    seen: set = set()
+    for tid in list(fail_to_pass) + list(pass_to_pass):
+        t = (tid or "").strip()
+        if t and t not in seen:
+            seen.add(t)
+            union.append(t)
+    quoted_ids = " ".join(shlex.quote(t) for t in union)
+    root_q = shlex.quote(repo_root)
+    tp_q = shlex.quote(test_patch_path)
+    mp_q = shlex.quote(model_patch_path)
+    return (
+        "set -o pipefail; "
+        f"cd {root_q} 2>/dev/null || true; "
+        "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd); cd \"$ROOT\" || "
+        f"{{ echo {_SETUP_FAIL_SENTINEL}; exit 4; }}; "
+        f"git apply {tp_q} 2>/dev/null || true; "
+        f"git apply {mp_q} || {{ echo {_APPLY_FAIL_SENTINEL}; exit 3; }}; "
+        f"python -m pytest {quoted_ids} -rA --tb=no -q 2>&1 || true"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Docker invocation (injectable async runner; real = `docker` CLI subprocess)
+# ---------------------------------------------------------------------------
+
+# (return_code, stdout, stderr)
+DockerRun = Callable[[Sequence[str], float], Awaitable[Tuple[int, str, str]]]
+
+
+async def _real_docker_run(argv: Sequence[str], timeout_s: float) -> Tuple[int, str, str]:
+    """Run ``docker ...`` via asyncio subprocess (same shape as
+    scorer._git_apply_patch). Bounded by ``timeout_s``; kills + drains on
+    timeout. NEVER leaves a zombie — ``--rm`` on the run + proc kill here."""
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        await proc.wait()
+        return 124, "", f"docker run exceeded {timeout_s}s"
+    return (
+        proc.returncode if proc.returncode is not None else -1,
+        (out or b"").decode("utf-8", "replace"),
+        (err or b"").decode("utf-8", "replace"),
+    )
+
+
+def build_docker_argv(image: str, script: str, patch_dir: str) -> List[str]:
+    """The ``docker run`` argv (adaptive --platform, ephemeral --rm, bash
+    entrypoint, patches bind-mounted read-only)."""
+    argv: List[str] = [docker_bin(), "run", "--rm"]
+    plat = host_platform_flag()
+    if plat:
+        argv += ["--platform", plat]
+    argv += [
+        "--entrypoint", container_entrypoint(),
+        "-v", f"{patch_dir}:/jarvis:ro",
+        image,
+        "-lc", script,
+    ]
+    return argv
+
+
+async def run_container_scoring(
+    problem: Any,
+    model_patch: str,
+    *,
+    timeout_s: float,
+    _docker_run: Optional[DockerRun] = None,
+) -> ContainerScoreResult:
+    """Score ``model_patch`` for ``problem`` inside its prepared image.
+
+    Returns a :class:`ContainerScoreResult`. NEVER raises (except
+    ``CancelledError``): infra/daemon failures come back with ``error`` set so
+    the scorer maps them to ``SCORING_ERROR`` rather than crashing the loop."""
+    runner = _docker_run or _real_docker_run
+    tag = problem_image_tag(problem)
+    if not tag:
+        return ContainerScoreResult(error="no_dockerhub_tag")
+    image = resolve_image(tag)
+    expected = target_test_ids(problem)
+    if not expected:
+        return ContainerScoreResult(error="no_target_test_ids")
+
+    test_patch = getattr(problem, "test_patch", "") or ""
+    meta = getattr(problem, "metadata", None) or {}
+    f2p = _coerce_id_list(meta.get("fail_to_pass"))
+    p2p = _coerce_id_list(meta.get("pass_to_pass"))
+
+    tmp = tempfile.mkdtemp(prefix="jarvis-swebp-")
+    try:
+        Path(tmp, "test.patch").write_text(test_patch, encoding="utf-8")
+        Path(tmp, "model.patch").write_text(model_patch or "", encoding="utf-8")
+        script = build_eval_script(
+            repo_root=container_repo_root(), fail_to_pass=f2p, pass_to_pass=p2p,
+        )
+        argv = build_docker_argv(image, script, tmp)
+        logger.info(
+            "[ContainerEngine] scoring instance=%s image=%s platform=%s tests=%d",
+            getattr(problem, "instance_id", "?"), image,
+            host_platform_flag() or "native", len(expected),
+        )
+        try:
+            rc, stdout, stderr = await runner(argv, timeout_s)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — infra failure, never crash
+            logger.warning(
+                "[ContainerEngine] docker run raised for instance=%s: %s",
+                getattr(problem, "instance_id", "?"), exc, exc_info=True,
+            )
+            return ContainerScoreResult(error=f"docker_run_raised:{type(exc).__name__}")
+
+        if rc == 124:
+            return ContainerScoreResult(error="container_timeout", raw_tail=stderr[-400:])
+        result = parse_pytest_text(stdout, expected)
+        if result.error is None and result.total == 0 and rc != 0:
+            # pytest never produced parseable lines AND docker failed → infra.
+            result.error = f"container_no_results:rc={rc}:{(stderr or stdout)[-200:]}"
+        return result
+    finally:
+        try:
+            import shutil
+            shutil.rmtree(tmp, ignore_errors=True)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+# ---------------------------------------------------------------------------
+# FlagRegistry self-registration (auto-discovered by §33.3 walker)
+# ---------------------------------------------------------------------------
+
+def register_flags(registry: Any) -> int:
+    """Register this module's env flags. Returns count registered. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.flag_registry import (
+            Category, FlagSpec, FlagType,
+        )
+    except ImportError:
+        return 0
+    specs = [
+        FlagSpec(
+            name=CONTAINER_EVAL_ENABLED_ENV_VAR, type=FlagType.BOOL,
+            category=Category.EXPERIMENTAL, default=False,
+            source_file="swe_bench_pro/container_engine.py",
+            example="JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED=true",
+            description="Score SWE-bench-Pro patches inside the per-problem "
+                        "Docker image (full repo env) instead of the local "
+                        "python env. Default OFF → local scoring path.",
+        ),
+        FlagSpec(
+            name=IMAGE_NAMESPACE_ENV_VAR, type=FlagType.STR,
+            category=Category.INTEGRATION, default=_DEFAULT_IMAGE_NAMESPACE,
+            source_file="swe_bench_pro/container_engine.py",
+            example=f"{IMAGE_NAMESPACE_ENV_VAR}={_DEFAULT_IMAGE_NAMESPACE}",
+            description="Docker image namespace; <namespace>:<dockerhub_tag>.",
+        ),
+    ]
+    n = 0
+    for spec in specs:
+        try:
+            registry.register(spec)
+            n += 1
+        except Exception:  # noqa: BLE001
+            pass
+    return n
+
+
+__all__ = [
+    "container_eval_enabled", "image_namespace", "resolve_image",
+    "host_platform_flag", "problem_image_tag", "should_use_container",
+    "target_test_ids", "parse_pytest_text", "build_eval_script",
+    "build_docker_argv", "run_container_scoring", "ContainerScoreResult",
+    "register_flags",
+]

--- a/backend/core/ouroboros/governance/swe_bench_pro/scorer.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/scorer.py
@@ -296,6 +296,40 @@ def _classify_test_outcome(
     return ScoreOutcome.PARTIAL
 
 
+def _finalize_score(
+    test_result: Any, instance_id: str, started_at: float,
+) -> "ScoringResult":
+    """Shared classify + ScoringResult build from a test-result object.
+
+    Slice 65 — extracted so BOTH execution backends compose it: the local
+    TestRunner path and the containerized backend (container_engine
+    ``ContainerScoreResult``). Both expose ``total`` / ``failed`` /
+    ``failed_tests``, so this reads them via getattr — byte-identical to the
+    pre-Slice-65 inline block for the local path. Pure; NEVER raises."""
+    total = max(0, int(getattr(test_result, "total", 0) or 0))
+    failed = max(0, int(getattr(test_result, "failed", 0) or 0))
+    passed = max(0, total - failed)
+    pass_rate = (passed / total) if total > 0 else 0.0
+    outcome = _classify_test_outcome(passed, failed, total)
+
+    diagnostic = ""
+    if outcome != ScoreOutcome.PASS and total > 0:
+        failed_tests = getattr(test_result, "failed_tests", ()) or ()
+        if failed_tests:
+            diagnostic = f"failed_tests={','.join(failed_tests[:5])}"
+
+    return ScoringResult(
+        outcome=outcome,
+        problem_instance_id=instance_id,
+        tests_passed=passed,
+        tests_failed=failed,
+        tests_total=total,
+        pass_rate=round(pass_rate, 4),
+        diagnostic=diagnostic,
+        elapsed_s=time.monotonic() - started_at,
+    )
+
+
 # ===========================================================================
 # Canonical safe git-apply subprocess (mirrors B.1 shape)
 # ===========================================================================
@@ -464,6 +498,31 @@ async def score_evaluation(
     # ...)`` wrapper — it temporarily takes over the name during that
     # nested call and restores ``score_evaluation:<id>`` on return.
     async with task_phase(EvaluatorPhase.SCORE_EVALUATION, instance_id):
+        # Slice 65 — containerized execution backend (gated, default-OFF).
+        # When enabled AND the problem carries a Docker image tag, run
+        # apply+test inside the prepared per-problem image (full repo env —
+        # PyQt/Node/etc. the bare local env lacks) instead of the local
+        # worktree path below. Composes the SAME _finalize_score classify.
+        # NEVER raises into here — infra failures come back as result.error
+        # and map to SCORING_ERROR (the local path stays byte-identical when
+        # the flag is off). No prepare/cleanup: the container is ephemeral.
+        from backend.core.ouroboros.governance.swe_bench_pro import (
+            container_engine as _container,
+        )
+        if _container.should_use_container(problem):
+            c_result = await _container.run_container_scoring(
+                problem, captured_patch,
+                timeout_s=_resolve_test_timeout_s(test_timeout_s),
+            )
+            if c_result.error:
+                return ScoringResult(
+                    outcome=ScoreOutcome.SCORING_ERROR,
+                    problem_instance_id=instance_id,
+                    diagnostic=f"container:{c_result.error}",
+                    elapsed_s=time.monotonic() - started_at,
+                )
+            return _finalize_score(c_result, instance_id, started_at)
+
         prepared, harness_outcome = await prepare_problem(problem)
         if prepared is None or harness_outcome != HarnessOutcome.READY:
             return ScoringResult(
@@ -514,30 +573,7 @@ async def score_evaluation(
                     elapsed_s=time.monotonic() - started_at,
                 )
 
-            total = max(0, int(getattr(test_result, "total", 0) or 0))
-            failed = max(0, int(getattr(test_result, "failed", 0) or 0))
-            passed = max(0, total - failed)
-            pass_rate = (passed / total) if total > 0 else 0.0
-            outcome = _classify_test_outcome(passed, failed, total)
-
-            diagnostic = ""
-            if outcome != ScoreOutcome.PASS and total > 0:
-                failed_tests = getattr(test_result, "failed_tests", ()) or ()
-                if failed_tests:
-                    diagnostic = (
-                        f"failed_tests={','.join(failed_tests[:5])}"
-                    )
-
-            return ScoringResult(
-                outcome=outcome,
-                problem_instance_id=instance_id,
-                tests_passed=passed,
-                tests_failed=failed,
-                tests_total=total,
-                pass_rate=round(pass_rate, 4),
-                diagnostic=diagnostic,
-                elapsed_s=time.monotonic() - started_at,
-            )
+            return _finalize_score(test_result, instance_id, started_at)
 
         except asyncio.CancelledError:
             logger.info(

--- a/scripts/swe_bench_pro_soak.sh
+++ b/scripts/swe_bench_pro_soak.sh
@@ -116,8 +116,16 @@ case "$PHASE" in
     fi
     export JARVIS_SWE_BENCH_PRO_ENABLED=true                    # Phase A master (session-only)
     export JARVIS_SWE_BENCH_PRO_HARNESS_INJECT_ENABLED=true     # Path B: full autonomous loop
+    export JARVIS_SWE_BENCH_PRO_AUTOSCORE_ENABLED=true          # closed loop (score + record)
     export JARVIS_SWE_BENCH_PRO_INJECT_INSTANCE_IDS="$SWEBP_INSTANCE_IDS"  # operator-chosen
     export JARVIS_SWE_BENCH_PRO_SCORE_REJECT_TEST_MODS=true     # cheat-detection ON (rubric integrity)
+    # Slice 65 — score inside each problem's prepared Docker image (full repo
+    # env). REQUIRES a running Docker daemon + the image pullable
+    # (jefzda/sweap-images:<dockerhub_tag>); on Apple Silicon the engine injects
+    # --platform linux/amd64 automatically. Without this, scoring runs in the
+    # bare local python env and real repos (PyQt/Node/etc.) can't execute their
+    # tests → unresolved. Opt-out: SWEBP_CONTAINER_EVAL=off.
+    export JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED="${SWEBP_CONTAINER_EVAL:-true}"
     # Path A (cheaper, rubric-only) opt-in; Path B is default.
     if [ "${SWEBP_PATH:-B}" = "A" ]; then
       export JARVIS_SWE_BENCH_PRO_HARNESS_INJECT_ENABLED=false

--- a/tests/governance/test_slice65_container_engine.py
+++ b/tests/governance/test_slice65_container_engine.py
@@ -1,0 +1,168 @@
+"""Slice 65 — containerized test-execution backend for SWE-bench-Pro scoring.
+
+Verified (bt-2026-06-02): local scoring can't run per-repo tests (qutebrowser
+needs PyQt etc.), but the problem's Docker image (jefzda/sweap-images:<tag>) has
+the full env — `cd /app && git apply test_patch && git apply model_patch &&
+pytest <fail_to_pass+pass_to_pass>` made the gold patch's fail_to_pass test PASS.
+
+container_engine is an ALTERNATIVE execution backend for the scorer's apply+run
+step (gated, default-OFF → existing local path byte-identical). Adaptive: detects
+host arch for --platform emulation; reads the image tag + test ids from the
+problem; no hardcoded image/registry/test ids. Docker is driven via an injectable
+async runner (real = `docker` CLI subprocess, mirroring scorer._git_apply_patch),
+so the orchestration is unit-testable without a daemon.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.swe_bench_pro import container_engine as ce
+from backend.core.ouroboros.governance.swe_bench_pro.dataset_loader import ProblemSpec
+
+
+def _problem(**meta):
+    base = dict(instance_id="instance_x", repo="x/y", base_commit="abc",
+                problem_statement="p", test_patch="--- a/t\n+++ b/t\n", gold_patch="g")
+    return ProblemSpec(metadata=meta, **base)
+
+
+# ── pure: image resolution + platform ──────────────────────────────────────
+
+def test_resolve_image_default_namespace(monkeypatch):
+    monkeypatch.delenv("JARVIS_SWE_BENCH_PRO_IMAGE_NAMESPACE", raising=False)
+    assert ce.resolve_image("qutebrowser.foo-bar") == "jefzda/sweap-images:qutebrowser.foo-bar"
+
+
+def test_resolve_image_namespace_overridable(monkeypatch):
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_IMAGE_NAMESPACE", "myorg/imgs")
+    assert ce.resolve_image("t") == "myorg/imgs:t"
+
+
+def test_host_platform_flag_arm_needs_amd64(monkeypatch):
+    monkeypatch.setattr(ce.platform, "machine", lambda: "arm64")
+    assert ce.host_platform_flag() == "linux/amd64"
+    monkeypatch.setattr(ce.platform, "machine", lambda: "aarch64")
+    assert ce.host_platform_flag() == "linux/amd64"
+
+
+def test_host_platform_flag_x86_none(monkeypatch):
+    monkeypatch.setattr(ce.platform, "machine", lambda: "x86_64")
+    assert ce.host_platform_flag() is None
+
+
+def test_problem_image_tag_from_metadata():
+    p = _problem(dockerhub_tag="qutebrowser.foo")
+    assert ce.problem_image_tag(p) == "qutebrowser.foo"
+    assert ce.problem_image_tag(_problem()) is None
+
+
+# ── pure: gating ────────────────────────────────────────────────────────────
+
+def test_should_use_container_gated(monkeypatch):
+    p = _problem(dockerhub_tag="t")
+    monkeypatch.delenv("JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED", raising=False)
+    assert ce.should_use_container(p) is False              # default off
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED", "true")
+    assert ce.should_use_container(p) is True               # on + has tag
+    assert ce.should_use_container(_problem()) is False     # on but no tag
+
+
+# ── pure: test id extraction (JSON-string OR list in metadata) ──────────────
+
+def test_target_test_ids_union_dedup():
+    p = _problem(fail_to_pass='["t::a"]', pass_to_pass='["t::b", "t::a"]')
+    ids = ce.target_test_ids(p)
+    assert "t::a" in ids and "t::b" in ids and len(ids) == 2  # union, deduped
+
+
+def test_target_test_ids_mixed_json_and_python_repr():
+    # The real dataset shape: fail_to_pass is a Python repr (single quotes),
+    # pass_to_pass is JSON (double quotes). Both must parse to clean ids.
+    p = _problem(fail_to_pass="['t::error']", pass_to_pass='["t::ok1", "t::ok2"]')
+    ids = ce.target_test_ids(p)
+    assert ids == ["t::error", "t::ok1", "t::ok2"], ids
+    assert "['t::error']" not in ids  # NOT the unparsed literal
+
+
+# ── pure: pytest -rA result parsing ─────────────────────────────────────────
+
+def test_parse_pytest_text_pass_and_fail():
+    out = (
+        "==== test session ====\n"
+        "PASSED tests/t.py::test_a\n"
+        "FAILED tests/t.py::test_b\n"
+        "PASSED tests/t.py::test_c\n"
+        "==== 2 passed, 1 failed ====\n"
+    )
+    r = ce.parse_pytest_text(out, ["tests/t.py::test_a", "tests/t.py::test_b", "tests/t.py::test_c"])
+    assert r.passed == 2 and r.failed == 1 and r.total == 3
+    assert "tests/t.py::test_b" in r.failed_tests
+
+
+def test_parse_pytest_text_apply_fail_sentinel():
+    r = ce.parse_pytest_text("JARVIS_APPLY_FAIL\n", ["t::a"])
+    assert r.error and "apply" in r.error.lower()
+
+
+# ── pure: eval-script builder grounded in the verified flow ─────────────────
+
+def test_build_eval_script_has_verified_steps():
+    s = ce.build_eval_script(repo_root="/app",
+                             fail_to_pass=["tests/t.py::test_error"],
+                             pass_to_pass=["tests/t.py::test_ok"])
+    assert "cd /app" in s or "/app" in s
+    assert "git apply" in s
+    assert "pytest" in s
+    assert "tests/t.py::test_error" in s and "tests/t.py::test_ok" in s
+
+
+# ── orchestration: injectable docker runner (no daemon needed) ──────────────
+
+def test_run_container_scoring_pass(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED", "true")
+    monkeypatch.setattr(ce.platform, "machine", lambda: "arm64")
+    p = _problem(dockerhub_tag="qb.tag", fail_to_pass='["tests/t.py::test_error"]',
+                 pass_to_pass='["tests/t.py::test_ok"]')
+
+    captured = {}
+
+    async def _fake_docker_run(argv, timeout_s):
+        captured["argv"] = argv
+        return 0, ("PASSED tests/t.py::test_error\nPASSED tests/t.py::test_ok\n"
+                   "==== 2 passed ====\n"), ""
+
+    res = asyncio.run(ce.run_container_scoring(
+        p, "--- a/x\n+++ b/x\n", timeout_s=30, _docker_run=_fake_docker_run))
+    assert res.error is None
+    assert res.total == 2 and res.failed == 0 and res.passed == 2
+    # adaptive platform flag + resolved image + entrypoint bash in the argv
+    flat = " ".join(captured["argv"])
+    assert "--platform" in flat and "linux/amd64" in flat
+    assert "jefzda/sweap-images:qb.tag" in flat
+    assert "--entrypoint" in flat and "bash" in flat
+
+
+def test_run_container_scoring_fail(monkeypatch):
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED", "true")
+    p = _problem(dockerhub_tag="qb.tag", fail_to_pass='["tests/t.py::test_error"]',
+                 pass_to_pass='[]')
+
+    async def _fake(argv, timeout_s):
+        return 1, "FAILED tests/t.py::test_error\n==== 1 failed ====\n", ""
+
+    res = asyncio.run(ce.run_container_scoring(
+        p, "patch", timeout_s=30, _docker_run=_fake))
+    assert res.error is None and res.failed == 1 and res.passed == 0
+
+
+def test_run_container_scoring_docker_error_is_scoring_error(monkeypatch):
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED", "true")
+    p = _problem(dockerhub_tag="qb.tag", fail_to_pass='["t::a"]', pass_to_pass='[]')
+
+    async def _boom(argv, timeout_s):
+        raise RuntimeError("docker daemon not running")
+
+    res = asyncio.run(ce.run_container_scoring(p, "patch", timeout_s=30, _docker_run=_boom))
+    assert res.error is not None  # surfaced as a scoring error, never raises

--- a/tests/governance/test_slice65_container_engine.py
+++ b/tests/governance/test_slice65_container_engine.py
@@ -15,8 +15,27 @@ so the orchestration is unit-testable without a daemon.
 from __future__ import annotations
 
 import asyncio
+import pathlib
+import re
 
 import pytest
+
+_REPO = pathlib.Path(__file__).resolve().parents[2]
+
+
+def test_soak_phase3_enables_container_eval():
+    src = (_REPO / "scripts/swe_bench_pro_soak.sh").read_text()
+    assert re.search(
+        r"JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED=", src,
+    ), "phase3 must enable the container scoring backend"
+
+
+def test_scorer_routes_to_container_when_enabled():
+    # Wiring pin: scorer composes container_engine.should_use_container +
+    # run_container_scoring (not a duplicated scoring path).
+    src = (_REPO / "backend/core/ouroboros/governance/swe_bench_pro/scorer.py").read_text()
+    assert "should_use_container" in src and "run_container_scoring" in src
+    assert "_finalize_score" in src  # shared classify, no duplication
 
 from backend.core.ouroboros.governance.swe_bench_pro import container_engine as ce
 from backend.core.ouroboros.governance.swe_bench_pro.dataset_loader import ProblemSpec


### PR DESCRIPTION
## Summary
- Adds a Docker-backed SWE-Bench-Pro container execution backend for scoring in prepared repository environments.
- Wires `score_evaluation` to use the container path when enabled while sharing final score classification via `_finalize_score`.
- Adds regression coverage for image resolution, platform detection, and scoring outcomes.

## Notes
- Created from existing commit `aa929996b3` after direct push to protected `main` was refused.
- Local working tree still has uncommitted follow-up changes that are not included in this PR.

## Test Plan
- Not run in this handoff; commit includes `tests/governance/test_slice65_container_engine.py` coverage.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a containerized scoring backend for SWE-Bench-Pro that runs tests inside each problem’s Docker image to resolve missing dependency issues and make scoring reliable. The scorer auto-routes to containers when enabled; the default local path is unchanged.

- **New Features**
  - New `backend/core/ouroboros/governance/swe_bench_pro/container_engine.py` to run `git apply` + `pytest` via the `docker` CLI, with `--platform linux/amd64` auto-applied on ARM hosts.
  - `score_evaluation` integrates the backend and uses a shared `_finalize_score`; infra errors return `SCORING_ERROR` without crashing.
  - Robust test ID parsing for mixed JSON and Python-repr fields; includes unit tests for image resolution, platform detection, script/argv build, and scoring via an injectable runner.
  - `scripts/swe_bench_pro_soak.sh` enables container eval in Phase 3 (opt-out with `SWEBP_CONTAINER_EVAL=off`).

- **Migration**
  - Ensure a running Docker daemon and pullable images (`jefzda/sweap-images:<dockerhub_tag>`). Override namespace with `JARVIS_SWE_BENCH_PRO_IMAGE_NAMESPACE` if needed.
  - Enable with `JARVIS_SWE_BENCH_PRO_CONTAINER_EVAL_ENABLED=true`. No other changes required.
  - Apple Silicon requires no manual config; the backend derives `--platform linux/amd64` automatically.

<sup>Written for commit f8cdb8686e03ee89941449090a1e5c0490462cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/67733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

