### PR TITLE
feat(orchestrator): Slice 66 — swe_bench_pro advisory VALIDATE test-gate

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -460,6 +460,57 @@ def _phase_runner_validate_extracted() -> bool:
     )
 
 
+def _swe_bench_test_advisory(
+    signal_source: str,
+    op_id: str,
+    candidate: "Dict[str, Any]",
+    result: "ValidationResult",
+) -> "ValidationResult":
+    """Slice 66 — for swe_bench_pro ops, a VALIDATE ``test`` failure is ADVISORY.
+
+    The benchmark repo's test env lives ONLY in the per-problem Docker image
+    (the bare local env can't import qutebrowser/PyQt etc.), AND running the
+    held-out ``fail_to_pass`` tests inside VALIDATE would LEAK them into the L2
+    repair loop — the model would iterate against the evaluation oracle and game
+    the score. So a ``test``-class failure is promoted to passed: the candidate
+    proceeds to APPLY (captured), and the ONE-SHOT container scoring (Slice 65,
+    in the autoscore layer that holds the ProblemSpec) is the authoritative
+    held-out judge — exactly once, no leakage.
+
+    This is NOT a bypass: syntax / build / infra failures STILL block (those are
+    valid LOCAL checks — a patch must be well-formed). Pure + gated; non-
+    swe_bench ops, non-``test`` failures, and already-passed results are returned
+    unchanged (byte-identical). NEVER raises."""
+    try:
+        if result.passed:
+            return result
+        if result.failure_class != "test":
+            return result
+        if (signal_source or "") != "swe_bench_pro":
+            return result
+        from dataclasses import replace
+        logger.info(
+            "[Orchestrator] Slice 66 — swe_bench_pro 'test' failure is ADVISORY "
+            "for op=%s (local env can't run repo tests; running held-out tests "
+            "here would leak them). Promoting candidate to APPLY; the one-shot "
+            "container scoring is the authoritative held-out judge.",
+            op_id,
+        )
+        return replace(
+            result,
+            passed=True,
+            best_candidate=candidate,
+            error=None,
+            failure_class=None,
+            short_summary=(
+                "swe_bench_pro: local test-gate advisory; container scoring "
+                "is authoritative (Slice 66)"
+            ),
+        )
+    except Exception:  # noqa: BLE001 — advisory must never break validation
+        return result
+
+
 def _phase_runner_slice3_fully_extracted() -> bool:
     """All three Slice 3 flags set — routes ROUTE+CTX+PLAN through runners.
 
@@ -10156,6 +10207,26 @@ class GovernedOrchestrator:
         return None
 
     async def _run_validation(
+        self,
+        ctx: OperationContext,
+        candidate: Dict[str, Any],
+        remaining_s: float,
+    ) -> ValidationResult:
+        """Validation seam — runs the core pipeline, then applies the Slice 66
+        swe_bench_pro advisory test-gate. A ``test`` failure for a benchmark op
+        is promoted to passed (the held-out container scoring is authoritative;
+        running the held-out tests here would leak them); non-swe_bench ops and
+        non-``test`` failures are byte-identical. Wrapping HERE covers all three
+        callers — the inline VALIDATE block, the extracted VALIDATERunner, and
+        L2 re-validation — so the advisory holds on every validation path."""
+        result = await self._run_validation_core(ctx, candidate, remaining_s)
+        return _swe_bench_test_advisory(
+            getattr(ctx, "signal_source", "") or "",
+            getattr(ctx, "op_id", "") or "",
+            candidate, result,
+        )
+
+    async def _run_validation_core(
         self,
         ctx: OperationContext,
         candidate: Dict[str, Any],

--- a/tests/governance/test_slice66_delegated_validation.py
+++ b/tests/governance/test_slice66_delegated_validation.py
@@ -1,0 +1,67 @@
+"""Slice 66 — swe_bench_pro advisory test-gate in VALIDATE.
+
+Culminating soak (bt-2026-06-02-193445): DW generated a candidate cheaply, but
+the op's VALIDATE failed `best_fc='test'` — the candidate's tests ran in the bare
+LOCAL env (no qutebrowser/PyQt) → fail → L2 exhausted → op terminal=fail →
+eval=unresolved → scorer's RESOLVED-guard skipped → the Slice 65 container engine
+was NEVER invoked (0 log lines).
+
+Fix (benchmark-VALID, gated): for swe_bench_pro ops, a `test` failure-class in
+VALIDATE is ADVISORY — the local repo env can't run the tests AND running the
+held-out fail_to_pass tests in VALIDATE would LEAK them into the L2 repair loop
+(gaming the score). So a test-only failure is promoted to passed → the candidate
+reaches APPLY (captured) → the ONE-SHOT container scoring (Slice 65, autoscore
+layer) is the authoritative held-out judge. Syntax/build/infra failures STILL
+block (valid local checks). Non-swe_bench ops + non-test failures are byte-
+identical.
+
+This is NOT a bypass: the local test-run is meaningless without the env, and the
+authoritative test (the held-out container scoring) is preserved exactly once.
+"""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.orchestrator import _swe_bench_test_advisory
+from backend.core.ouroboros.governance.op_context import ValidationResult
+
+
+def _vr(passed: bool, fc, cand=None) -> ValidationResult:
+    return ValidationResult(
+        passed=passed, best_candidate=cand, validation_duration_s=0.1,
+        error=None if passed else "boom", failure_class=fc,
+    )
+
+
+def test_swe_bench_test_failure_promoted_to_passed():
+    cand = {"full_content": "patch", "file_path": "qutebrowser/misc/guiprocess.py"}
+    r = _swe_bench_test_advisory("swe_bench_pro", "op1", cand, _vr(False, "test"))
+    assert r.passed is True
+    assert r.best_candidate is cand          # candidate carried forward to APPLY
+    assert r.failure_class is None           # promoted (advisory)
+    assert r.error is None
+
+
+def test_swe_bench_build_failure_still_blocks():
+    # Valid LOCAL check — a malformed patch must still fail VALIDATE.
+    r = _swe_bench_test_advisory("swe_bench_pro", "op1", {}, _vr(False, "build"))
+    assert r.passed is False and r.failure_class == "build"
+
+
+def test_swe_bench_infra_failure_still_blocks():
+    r = _swe_bench_test_advisory("swe_bench_pro", "op1", {}, _vr(False, "infra"))
+    assert r.passed is False and r.failure_class == "infra"
+
+
+def test_non_swe_bench_test_failure_unchanged():
+    # Organic self-dev ops keep the strict local test-gate (byte-identical).
+    r = _swe_bench_test_advisory("opportunity_miner", "op1", {}, _vr(False, "test"))
+    assert r.passed is False and r.failure_class == "test"
+
+
+def test_already_passed_unchanged():
+    r = _swe_bench_test_advisory("swe_bench_pro", "op1", {}, _vr(True, None))
+    assert r.passed is True
+
+
+def test_empty_source_unchanged():
+    r = _swe_bench_test_advisory("", "op1", {}, _vr(False, "test"))
+    assert r.passed is False and r.failure_class == "test"


### PR DESCRIPTION
## Summary

Culminating soak (`bt-2026-06-02-193445`): DW generated a candidate cheaply, but the op's VALIDATE failed `best_fc='test'` — the candidate's tests ran in the **bare local env** (no qutebrowser/PyQt) → L2 retries exhausted → op terminal=fail → `eval=unresolved` → the scorer's RESOLVED-guard skipped → the **Slice 65 container engine was never invoked**. The blocker sits one phase *above* scoring: the local VALIDATE test-gate, which a benchmark repo can't satisfy without its containerized env.

## Verify-first correction of the runbook (benchmark validity)

The runbook's Phase 2 — *"feed container test results into the L2 repair loop so it self-heals until convergence"* — would **leak the held-out `fail_to_pass` oracle** into the repair loop (the model iterates against the evaluation tests = a gamed score). **Rejected.** It's also infeasible as specified: the VALIDATE `ctx` carries only `repo_root` + `fail_to_pass` in evidence — not `dockerhub_tag`/`test_patch`/`pass_to_pass`.

## Fix (benchmark-valid, gated, minimal spine touch)

`_swe_bench_test_advisory()`: for `signal_source=='swe_bench_pro'`, a `test`-class VALIDATE failure is **advisory** — promoted to passed, candidate carried to APPLY. The local repo tests are meaningless without the env *and* running the held-out tests here would leak them, so the candidate reaches APPLY (captured) and the **one-shot container scoring** (Slice 65, autoscore layer with the ProblemSpec) is the authoritative held-out judge — exactly once, no leakage.

- **Syntax/build/infra failures STILL block** (valid local checks — a patch must be well-formed).
- Wrapped at `_run_validation` (body → `_run_validation_core`) so the advisory holds on **all three callers** — inline VALIDATE, extracted `VALIDATERunner`, and L2 re-validation.
- Pure + gated → **non-swe_bench ops byte-identical**; never raises.

## Tests
6 tests (promote test-fail / build+infra still block / non-swe_bench unchanged / passed unchanged / empty source). Regression-clean — **160 passed** across validation/swe_bench/self_dev; the 4 `self_dev` `candidate_ledger`/`candidate_parser` failures are **pre-existing on main** (verified via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make VALIDATE test failures advisory for `swe_bench_pro` so candidates reach APPLY and Slice 65 container scoring runs once, avoiding local env false negatives and held-out test leakage.

- **Bug Fixes**
  - Added `_swe_bench_test_advisory()` to promote `failure_class='test'` to passed for `signal_source='swe_bench_pro'`, carrying the candidate to APPLY; other failure classes unchanged.
  - Kept syntax/build/infra failures blocking; non-`swe_bench` ops remain unchanged.
  - Wrapped advisory at `_run_validation` and extracted `_run_validation_core` to cover all validation entry points.
  - Added tests in `tests/governance/test_slice66_delegated_validation.py`.

<sup>Written for commit 6f5f35089caa4282f772d761d2572a8da7850f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/67779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

