### PR TITLE
fix(orchestrator): Slice 67b — wire VERIFY advisory into the LIVE slice4b_runner

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -917,6 +917,22 @@ class Slice4bRunner(PhaseRunner):
         if _verify_error is None and not _verify_test_passed:
             _verify_error = f"scoped verify: {_verify_test_failures}/{_verify_test_total} tests failing"
 
+        # Slice 67 — swe_bench_pro VERIFY regression gate is advisory (LIVE
+        # extracted-runner path; mirrors the inline orchestrator block). The
+        # repo tests can't run without the container env; the held-out
+        # container scoring (Slice 65) is authoritative. Clearing the error
+        # keeps the patch applied (no rollback) so the autoscore layer captures
+        # it. Lazy import avoids a runner↔orchestrator module cycle.
+        try:
+            from backend.core.ouroboros.governance.orchestrator import (
+                _swe_bench_verify_advisory,
+            )
+            _verify_error = _swe_bench_verify_advisory(
+                getattr(ctx, "signal_source", "") or "", _verify_error, ctx.op_id,
+            )
+        except Exception:  # noqa: BLE001 — advisory must never break VERIFY
+            pass
+
         if _verify_error is not None:
             logger.warning(
                 "[Orchestrator] VERIFY regression gate fired: %s [%s]",

--- a/tests/governance/test_slice67_verify_advisory.py
+++ b/tests/governance/test_slice67_verify_advisory.py
@@ -35,3 +35,16 @@ def test_empty_source_keeps_error():
 def test_no_error_passthrough():
     assert _swe_bench_verify_advisory("swe_bench_pro", None, "op1") is None
     assert _swe_bench_verify_advisory("opportunity_miner", None, "op1") is None
+
+
+def test_advisory_wired_in_BOTH_verify_paths():
+    # Dead-code guard: the soak proved the LIVE VERIFY is the extracted
+    # slice4b_runner, NOT the inline orchestrator block. Pin BOTH so the gate
+    # is covered whichever path is active (the Slice-45 trap must not recur,
+    # and the live-runner wiring must not get dropped from a commit again).
+    import pathlib
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    runner = (repo / "backend/core/ouroboros/governance/phase_runners/slice4b_runner.py").read_text()
+    inline = (repo / "backend/core/ouroboros/governance/orchestrator.py").read_text()
+    assert "_swe_bench_verify_advisory" in runner, "LIVE VERIFYRunner must call the advisory"
+    assert "_swe_bench_verify_advisory" in inline, "inline VERIFY block must call the advisory"


### PR DESCRIPTION
## Summary

Slice 67 (#67934) merged the **inline-orchestrator** VERIFY advisory, but the **live-runner** edit + the both-paths wiring pin were dropped by a `git commit --amend` and then wiped by `reset --hard`. The soak that achieved `eval=resolved` ran them from the working tree — so the *merged* code is the **dead inline-only path** (the live VERIFY is the extracted `slice4b_runner.VERIFYRunner`). Without this, the live VERIFY regression gate still fails swe_bench ops (`eval=unresolved` returns).

## Fix
Re-applies `_swe_bench_verify_advisory(...)` into `slice4b_runner.py` — the path **proven live in the soak** (`"Slice 67 ... ADVISORY"` was logged from `VERIFYRunner`) — and restores `test_advisory_wired_in_BOTH_verify_paths`, which asserts **both** the live runner and the inline block call the advisory, so this drop can't recur.

5 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the VERIFY advisory into the live `slice4b_runner` path so `VERIFYRunner` mirrors the inline orchestrator and doesn’t block `swe_bench_pro` runs. Restores a guard test to keep the advisory wired in both live and inline paths.

- **Bug Fixes**
  - Call `_swe_bench_verify_advisory(...)` in `slice4b_runner.VERIFYRunner` with a safe try/except so VERIFY stays non-blocking.
  - Restore `test_advisory_wired_in_BOTH_verify_paths` to assert the advisory exists in both `slice4b_runner.py` and `orchestrator.py`.

<sup>Written for commit 9544be6d4698f396b9a757159943071acdec4343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/67937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

