### PR TITLE
feat(governance): harden SWE-bench closed-loop benchmark execution

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"017a5aad-1b23-4260-8044-2c6fdbf5e2fd","pid":81896,"procStart":"Mon May  4 17:29:28 2026","acquiredAt":1778207564508}
+{"sessionId":"8fab2207-fd44-49f5-b707-388b32870c34","pid":3582,"procStart":"Tue Jun  2 23:01:28 2026","acquiredAt":1780442737764}

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -819,6 +819,37 @@ def apply_force_batch_deadline_floor(
     return max(gen_timeout_s, force_batch_gen_timeout_floor_s())
 
 
+def structural_fast_cascade_enabled() -> bool:
+    """Slice 73 master flag — default TRUE. When off, the dispatch loop tries
+    every ranked DW model before cascading (byte-identical legacy behavior)."""
+    raw = os.environ.get(
+        "JARVIS_DW_STRUCTURAL_FAST_CASCADE_ENABLED", "true",
+    ).strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def should_sever_dw_lane(failure_source: Any) -> bool:
+    """Slice 73 — True iff this failure is a STRUCTURAL transport break.
+
+    A ``LIVE_TRANSPORT`` failure (socket/connection break, ``live_transport:
+    RuntimeError``) means the transport to the DW endpoint is down — every
+    ranked sibling model shares that dead transport, so trying the next one
+    just burns another ~30s before the inevitable cascade. Sever the lane and
+    hand Claude the full remaining budget.
+
+    Model-SPECIFIC failures (429 rate-limit, 5xx, parse) are NOT severed — a
+    sibling model may be healthy, so the loop still rotates to it. Pure;
+    never raises (unknown source → don't sever).
+    """
+    try:
+        from backend.core.ouroboros.governance.topology_sentinel import (
+            FailureSource,
+        )
+        return failure_source is FailureSource.LIVE_TRANSPORT
+    except Exception:  # noqa: BLE001 — never block dispatch
+        return False
+
+
 def _note_dw_total_outage(diagnostic: str) -> None:
     """Slice 53 — record one GENERATE op that exhausted ALL DW models with no
     candidate from streaming OR batch (the total-vendor-blackout signature).
@@ -3167,6 +3198,26 @@ class CandidateGenerator:
                         type(exc).__name__, op_id_short,
                     )
                 attempts[-1] = f"{model_id}:failed:{failure_source.value}"
+                # Slice 73 — structural transport short-circuit. A LIVE_TRANSPORT
+                # break affects the whole DW endpoint, so trying the next ranked
+                # model just burns another ~30s on the same dead transport
+                # before the inevitable cascade — starving the Claude fallback
+                # (the bt-2026-06-03 deadline_exhausted_pre_fallback failure).
+                # Sever the lane NOW and fall through to cascade with the full
+                # remaining budget. Model-specific failures still rotate.
+                if (
+                    structural_fast_cascade_enabled()
+                    and should_sever_dw_lane(failure_source)
+                ):
+                    _severed = len(ranked_models) - len(attempts)
+                    logger.warning(
+                        "[CandidateGenerator] Slice 73 structural fast-cascade: "
+                        "model=%s LIVE_TRANSPORT — severing DW lane, cascading to "
+                        "fallback with full budget (op=%s, skipped %d sibling "
+                        "model(s))",
+                        model_id, op_id_short, max(0, _severed),
+                    )
+                    break
                 continue
         # All DW models exhausted (either OPEN or failed). The
         # per-attempt ContextVar was already reset by each loop

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -45,6 +45,14 @@ from backend.core.ouroboros.governance.ascii_strict_gate import (
     AsciiStrictGate,
     build_retry_feedback as _ascii_gate_retry_feedback,
 )
+from backend.core.ouroboros.governance.target_existence_guard import (
+    guard_enabled as _target_guard_enabled,
+    find_missing_targets as _find_missing_targets,
+    build_retry_feedback as _target_missing_retry_feedback,
+    missing_target_error_message as _target_missing_error_message,
+    should_insulate_prompt as _should_insulate_prompt,
+    TARGET_MISSING_PREFIX as _TARGET_MISSING_PREFIX,
+)
 from backend.core.ouroboros.governance.test_runner import BlockedPathError
 from backend.core.ouroboros.governance.context_expander import ContextExpander
 from backend.core.ouroboros.governance.approval_provider import (
@@ -2323,10 +2331,17 @@ class GovernedOrchestrator:
                     logger.debug("[Orchestrator] Goal memory injection failed", exc_info=True)
 
             # ---- Strategic Direction injection (Manifesto + architecture docs) ----
+            # Slice 72 Phase 3 — withhold host-framework strategic context from
+            # benchmark ops (it biased the model toward host paths like
+            # backend/core/...). INERT for every non-swe_bench op.
             _strategic_svc = None
             if _gls_for_gmb is not None:
                 _strategic_svc = getattr(_gls_for_gmb, "_strategic_direction", None)
-            if _strategic_svc is not None and getattr(_strategic_svc, "is_loaded", False):
+            if (
+                _strategic_svc is not None
+                and getattr(_strategic_svc, "is_loaded", False)
+                and not _should_insulate_prompt(getattr(ctx, "signal_source", ""))
+            ):
                 try:
                     _strat_prompt = _strategic_svc.format_for_prompt(
                         op_id=getattr(ctx, "op_id", None),
@@ -2667,7 +2682,9 @@ class GovernedOrchestrator:
                     target_files=list(ctx.target_files),
                     description=ctx.description or "",
                 )
-                if _goal_prompt:
+                if _goal_prompt and not _should_insulate_prompt(
+                    getattr(ctx, "signal_source", "")
+                ):
                     _existing = getattr(ctx, "strategic_memory_prompt", "") or ""
                     ctx = ctx.with_strategic_memory_context(
                         strategic_intent_id=ctx.strategic_intent_id or "goals-v1",
@@ -4977,6 +4994,36 @@ class GovernedOrchestrator:
                                 _ascii_exc._ascii_rejected_content = _rejected_content  # type: ignore[attr-defined]
                                 raise _ascii_exc
 
+                    # Gate 4 — Target existence (Slice 72). For a benchmark op
+                    # the candidate MUST target a file that already exists in the
+                    # prepared worktree. Catches the bt-2026-06-03 generation-
+                    # steering failure where the Claude fallback, after a rushed
+                    # single exploration round, emitted a HOST path
+                    # (backend/core/process_manager.py) for a qutebrowser repo →
+                    # APPLY ENOENT. Routes the miss back to GENERATE_RETRY with
+                    # self-correcting feedback instead of crashing APPLY. INERT
+                    # for every non-swe_bench op (host self-dev legitimately
+                    # creates new files) and when write_root can't be resolved.
+                    if (
+                        getattr(ctx, "signal_source", "") == "swe_bench_pro"
+                        and _target_guard_enabled()
+                    ):
+                        _tg_write_root = self._swe_bench_write_root(ctx)
+                        _tg_missing = _find_missing_targets(
+                            generation.candidates, _tg_write_root,
+                        )
+                        if _tg_missing:
+                            logger.warning(
+                                "[Orchestrator] Iron Gate — target_file_missing: "
+                                "%s not in worktree %s op=%s (attempt=%d)",
+                                ",".join(_tg_missing), _tg_write_root,
+                                ctx.op_id[:12], attempt + 1,
+                            )
+                            generation = None
+                            raise RuntimeError(
+                                _target_missing_error_message(_tg_missing)
+                            )
+
                     # Gate 3 — Dependency file integrity. Catches hallucinated
                     # package-name renames/truncations in requirements.txt (and
                     # future: package.json, Cargo.toml, etc.). Engineered in
@@ -5684,6 +5731,16 @@ class GovernedOrchestrator:
                                 "pre-Slice-12P feedback shape",
                                 exc_info=True,
                             )
+                    elif _err_str.startswith(_TARGET_MISSING_PREFIX):
+                        # Slice 72 — target file doesn't exist in the worktree.
+                        # Surface the host-vs-worktree steering correction so the
+                        # model re-explores and targets a real repo file.
+                        _tg_paths = [
+                            p.strip()
+                            for p in _err_str[len(_TARGET_MISSING_PREFIX):].split(",")
+                            if p.strip()
+                        ]
+                        _error_feedback = _target_missing_retry_feedback(_tg_paths)
                     elif _err_str.startswith("ascii_corruption"):
                         # Extract the specific offending lines from the rejected
                         # candidate so the model sees its own bad code in context
@@ -5914,6 +5971,8 @@ class GovernedOrchestrator:
                         _gen_failure_class = "content"
                         if "exploration_insufficient" in _err_str:
                             _gen_failure_class = "exploration"
+                        elif _err_str.startswith(_TARGET_MISSING_PREFIX):
+                            _gen_failure_class = "target_missing"
                         elif "ascii_corruption" in _err_str:
                             _gen_failure_class = "ascii"
                         elif _err_str.startswith("multi_file_coverage_insufficient"):

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -5375,6 +5375,63 @@ def _remaining_utc_budget_s(
     return max(float(floor_s), rem)
 
 
+# ---------------------------------------------------------------------------
+# Slice 71 — Envelope Inheritance Invariant (fallback synthesis floor)
+# ---------------------------------------------------------------------------
+# Root cause (bt-2026-06-02-232715): the Claude tool loop derives its per-round
+# / stream budget from the GENERATE-phase ``deadline``. A *continuation* round
+# (``is_tool_round = round_index > 0``) runs after earlier rounds CONSUMED that
+# phase window, so ``_remaining_utc_budget_s(deadline)`` collapses to its 1.0s
+# floor → Claude gets ``budget=1.0s`` → ``first_token=NEVER`` → fallback_failed
+# → no candidate → no score, even though the op's wall envelope still had 313s.
+#
+# Fix: tool-loop synthesis inherits the MORE generous of the phase deadline and
+# the op's wall envelope (``OperationContext.pipeline_deadline``, stamped once
+# at submit()). Inheritance only RAISES the inner budget; the outer
+# ``_call_fallback`` ``_race_or_wait_for(timeout=_attempt_remaining)`` + the
+# wall-clock watchdog remain the absolute ceilings, so a continuation round can
+# never run past the op's true wall envelope.
+_SYNTHESIS_ENVELOPE_ENABLED_ENV = "JARVIS_FALLBACK_SYNTHESIS_ENVELOPE_ENABLED"
+
+
+def _synthesis_envelope_enabled() -> bool:
+    """Slice 71 master flag (default TRUE — graduates on for the scored soak).
+
+    Single-knob hot-revert: setting the env to a falsey value restores the
+    byte-identical pre-Slice-71 phase-deadline behavior.
+    """
+    raw = os.environ.get(_SYNTHESIS_ENVELOPE_ENABLED_ENV, "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def _synthesis_envelope_deadline(
+    context: Any, phase_deadline: Optional[datetime],
+) -> Optional[datetime]:
+    """Return the deadline tool-loop synthesis should inherit.
+
+    The MORE generous (later) of ``phase_deadline`` and the op's wall envelope
+    ``context.pipeline_deadline``. NEVER shrinks the budget (``max`` semantics),
+    NEVER raises (a tz naive/aware mismatch or a context without the attribute
+    falls back to ``phase_deadline``), and is a byte-identical passthrough when
+    the master flag is off or no wall envelope is present.
+    """
+    if not _synthesis_envelope_enabled():
+        return phase_deadline
+    try:
+        wall = getattr(context, "pipeline_deadline", None)
+    except Exception:  # noqa: BLE001 — defensive; never perturb generation
+        return phase_deadline
+    if wall is None:
+        return phase_deadline
+    if phase_deadline is None:
+        return wall
+    try:
+        return wall if wall > phase_deadline else phase_deadline
+    except (TypeError, ValueError):
+        # tz naive/aware mismatch (or non-comparable) — fail safe to phase.
+        return phase_deadline
+
+
 # Exponential backoff retry — 2s, 4s, 8s between attempts.
 _CLAUDE_RETRY_MAX_ATTEMPTS = int(
     os.environ.get("JARVIS_CLAUDE_RETRY_MAX_ATTEMPTS", "3")
@@ -7902,7 +7959,13 @@ class ClaudeProvider:
 
         async def _generate_raw(p: str) -> str:
             nonlocal total_cost
-            _r0 = _remaining_utc_budget_s(deadline, floor_s=1.0)
+            # Slice 71 — inherit the op's wall envelope so a continuation round
+            # whose phase deadline was consumed by earlier rounds isn't starved
+            # to the 1.0s floor (first_token=NEVER). max() semantics never shrink
+            # round 0's budget; the outer wait_for stays the ceiling.
+            _r0 = _remaining_utc_budget_s(
+                _synthesis_envelope_deadline(context, deadline), floor_s=1.0,
+            )
             timeout_s = float(_r0 if _r0 is not None else 1.0)
 
             # Multi-modal path. Two sources of image content merge here:
@@ -8729,9 +8792,31 @@ class ClaudeProvider:
         tool_records: tuple = ()
         venom_edits: Tuple[Dict[str, Any], ...] = ()
         if self._tool_loop is not None and not _skip_tools:
+            # Slice 71 — the ToolLoopCoordinator's total budget (and thus its
+            # per-round BudgetPlan) inherits the op's wall envelope, so a
+            # consumed phase deadline can't collapse continuation rounds to the
+            # 1.0s floor. Bounded by the outer wait_for + wall watchdog.
+            _synth_deadline = _synthesis_envelope_deadline(context, deadline)
+            # Slice 71 — instrument the inheritance so the scored soak is
+            # diagnostic regardless of outcome: phase-remaining vs wall-remaining
+            # vs the inherited synthesis budget the tool loop will plan against.
+            try:
+                _phase_rem = _remaining_utc_budget_s(deadline, floor_s=0.0)
+                _synth_rem = _remaining_utc_budget_s(_synth_deadline, floor_s=0.0)
+                if _synth_rem is not None and _phase_rem is not None and _synth_rem > _phase_rem + 1.0:
+                    logger.info(
+                        "[ClaudeProvider] Slice71 synthesis envelope inherited: "
+                        "phase_remaining=%.1fs → synthesis_remaining=%.1fs "
+                        "(wall envelope, op=%s route=%s)",
+                        _phase_rem, _synth_rem,
+                        str(getattr(context, "op_id", "?"))[:16],
+                        getattr(context, "provider_route", "?"),
+                    )
+            except Exception:  # noqa: BLE001 — instrumentation never perturbs
+                pass
             deadline_mono = (
                 time.monotonic()
-                + max(0.0, (deadline - datetime.now(tz=timezone.utc)).total_seconds())
+                + max(0.0, (_synth_deadline - datetime.now(tz=timezone.utc)).total_seconds())
             )
             # ── Slice 3G — envelope-override for per-op worktrees ──
             # Closes bt-2026-05-25-060538 NOOP wiring gap: SWE-Bench-Pro
@@ -8782,7 +8867,11 @@ class ClaudeProvider:
             # Legacy inline loop (backward-compat with tools_enabled=True)
             raw = None
             while True:
-                _r_loop = _remaining_utc_budget_s(deadline, floor_s=1.0)
+                # Slice 71 — legacy inline tool loop inherits the wall envelope
+                # too (parity with the coordinator path above).
+                _r_loop = _remaining_utc_budget_s(
+                    _synthesis_envelope_deadline(context, deadline), floor_s=1.0,
+                )
                 timeout_s = float(_r_loop if _r_loop is not None else 1.0)
                 if timeout_s <= 5.0:
                     logger.warning(

--- a/backend/core/ouroboros/governance/swe_bench_pro/per_problem_harness.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/per_problem_harness.py
@@ -73,7 +73,7 @@ import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from backend.core.ouroboros.governance.swe_bench_pro.evaluator_trace_observer import (  # noqa: E501
     EvaluatorPhase,
@@ -517,6 +517,70 @@ def _extract_target_paths_from_patch(test_patch: str) -> Tuple[str, ...]:
     return tuple(paths)
 
 
+def _strip_test_patch_sections(
+    diff_text: str, test_paths: Iterable[str],
+) -> str:
+    """Drop the diff sections that touch any path in the test-patch manifest.
+
+    Slice 69 — the clean-delta invariant. ``prepare_problem`` applies the
+    held-out ``test_patch`` into the worktree BEFORE the model runs, so the
+    working-tree capture (``git add -A && git diff --cached base_commit``) also
+    sees those test files. The container scorer runs
+    ``git apply <test_patch> && git apply <model_patch>`` — and step 2 has NO
+    ``|| true`` guard, so a model patch carrying the already-applied test hunks
+    HARD-FAILS (``scoring_error``). Stripping the test footprint here leaves
+    100% pure model source changes in the captured patch.
+
+    Splits the unified diff on ``diff --git`` section boundaries and removes any
+    section whose paths (parsed from the ``diff --git`` header AND the
+    ``--- a/`` / ``+++ b/`` lines — same convention as
+    ``_extract_target_paths_from_patch``) intersect the manifest. Path matching
+    is EXACT on the repo-relative path (never basename), so a source file that
+    merely shares a basename with a test survives. Pure; NEVER raises — on any
+    error it returns the input unfiltered (capture is fail-safe, not fail-shut).
+    """
+    test_set = {p.strip() for p in test_paths if p and p.strip()}
+    if not test_set or not diff_text:
+        return diff_text
+    try:
+        sections: List[Tuple[set, List[str]]] = []
+        cur_lines: List[str] = []
+        cur_paths: set = set()
+
+        def _flush() -> None:
+            if cur_lines:
+                sections.append((set(cur_paths), list(cur_lines)))
+
+        for line in diff_text.splitlines(keepends=True):
+            if line.startswith("diff --git "):
+                _flush()
+                cur_lines = [line]
+                cur_paths = set()
+                # "diff --git a/<p1> b/<p2>" — parse both (renames differ).
+                rest = line[len("diff --git "):].rstrip("\r\n")
+                if " b/" in rest:
+                    a_part, b_part = rest.split(" b/", 1)
+                    if a_part.startswith("a/"):
+                        cur_paths.add(a_part[2:].strip())
+                    cur_paths.add(b_part.strip())
+            else:
+                cur_lines.append(line)
+                if line.startswith("+++ b/"):
+                    cur_paths.add(line[len("+++ b/"):].rstrip("\r\n").strip())
+                elif line.startswith("--- a/"):
+                    cur_paths.add(line[len("--- a/"):].rstrip("\r\n").strip())
+        _flush()
+
+        kept: List[str] = []
+        for paths, sec_lines in sections:
+            if paths & test_set:
+                continue  # contaminating test-patch section — drop it
+            kept.extend(sec_lines)
+        return "".join(kept)
+    except Exception:  # noqa: BLE001 — capture is fail-safe, never fail-shut
+        return diff_text
+
+
 # ===========================================================================
 # Public API — prepare_problem
 # ===========================================================================
@@ -595,11 +659,31 @@ async def prepare_problem(
 async def capture_produced_patch(
     prepared: PreparedProblem,
 ) -> Tuple[Optional[str], DiffCaptureOutcome]:
-    """Compute the diff from base_commit to the current worktree
-    HEAD (the patch the model produced)."""
+    """Capture the patch the model produced — the full diff vs ``base_commit``
+    of the worktree's CURRENT state, with the harness's pre-applied
+    ``test_patch`` footprint stripped.
+
+    Slice 68 substrate — APPLY writes the candidate into the worktree's WORKING
+    TREE (uncommitted; any commit goes to the separate AutoCommitter workspace),
+    so the previous ``git diff base_commit HEAD`` (committed-only) returned
+    ``no_changes`` even when the patch was applied. Stage everything (incl. new
+    files) then diff the index vs ``base_commit`` — the canonical SWE-bench
+    ``git add -A && git diff`` capture — which recovers the patch whether it was
+    left in the working tree OR committed, and includes added files. Staging is
+    safe: the worktree is ephemeral (``cleanup_prepared`` removes it).
+
+    Slice 69 clean-delta invariant — that capture ALSO sees the held-out
+    ``test_patch`` (applied at prepare time). Filter it out via
+    ``prepared.target_paths`` so the scorer's
+    ``git apply <test_patch> && git apply <model_patch>`` doesn't double-apply
+    the test hunks (step 2 has no ``|| true`` guard → ``scoring_error``)."""
     try:
+        # Stage all changes (modified + added + deleted) so the diff vs
+        # base_commit also sees untracked files. Best-effort: a non-zero rc
+        # here is non-fatal — the diff below is authoritative.
+        await _run_git(["add", "-A"], cwd=prepared.worktree_path)
         rc, stdout, stderr = await _run_git(
-            ["diff", prepared.base_commit, "HEAD"],
+            ["diff", "--cached", prepared.base_commit],
             cwd=prepared.worktree_path,
         )
         if rc != 0:
@@ -608,9 +692,13 @@ async def capture_produced_patch(
                 prepared.problem_instance_id, rc, stderr.strip()[:200],
             )
             return None, DiffCaptureOutcome.CAPTURE_FAILED
-        if not stdout.strip():
+        # Strip the pre-applied test_patch footprint (clean-delta invariant).
+        cleaned = _strip_test_patch_sections(stdout, prepared.target_paths)
+        if not cleaned.strip():
+            # Either no change at all, or the ONLY change was the test_patch
+            # (the model produced nothing) — both are NO_CHANGES.
             return None, DiffCaptureOutcome.NO_CHANGES
-        return stdout, DiffCaptureOutcome.CAPTURED
+        return cleaned, DiffCaptureOutcome.CAPTURED
     except asyncio.CancelledError:
         raise
     except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/target_existence_guard.py
+++ b/backend/core/ouroboros/governance/target_existence_guard.py
@@ -1,0 +1,165 @@
+"""Slice 72 — Generative Target-Existence Guard.
+
+Root cause (verify-first, bt-2026-06-03-035359 debug.log): for a SWE-Bench-Pro
+op the tool loop WAS correctly confined to the prepared worktree (Slice 3G
+override fired, chroot + allowlist all working), and the model DID explore it —
+but after the DW primary timed out (148s), the Claude fallback did a single
+rushed exploration round and emitted a target path in the HOST framework's
+namespace (``backend/core/process_manager.py``) instead of the benchmark
+repo's (``qutebrowser/utils/guiprocess.py``). APPLY rebased that JARVIS path
+onto the worktree → hard ``ENOENT`` → postmortem, no patch, no container score.
+
+This module is the deterministic gate: for a benchmark op, every candidate's
+target file MUST already exist inside the write root (the worktree) — the
+benchmark fixes EXISTING code, never creates host-framework files. A miss is a
+generation-steering error, surfaced back to the model as self-correcting
+GENERATE_RETRY feedback rather than crashing APPLY.
+
+Pure functions; NEVER raise. Gated by the orchestrator on
+``signal_source == "swe_bench_pro"`` so host self-development (which legitimately
+creates new files) is completely untouched.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, List, Mapping, Optional, Sequence, Tuple
+
+
+_ENABLED_ENV = "JARVIS_SWE_BENCH_TARGET_EXISTENCE_GUARD_ENABLED"
+
+
+def guard_enabled() -> bool:
+    """Master flag — default TRUE (graduates on for the scored soak).
+
+    Single-knob hot-revert: a falsey value restores the pre-Slice-72 behavior
+    (the candidate flows straight to APPLY and ENOENTs as before).
+    """
+    raw = os.environ.get(_ENABLED_ENV, "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def _candidate_target_paths(candidate: Any) -> Tuple[str, ...]:
+    """Extract every repo-relative target path a candidate would write.
+
+    Handles both the legacy single ``file_path`` shape and the multi-file
+    ``files: [{file_path, ...}]`` shape. Pure; never raises; returns () for
+    anything unparseable (a non-dict candidate, missing keys, etc.).
+    """
+    if not isinstance(candidate, Mapping):
+        return ()
+    out: List[str] = []
+    seen: set = set()
+
+    def _add(p: Any) -> None:
+        if isinstance(p, str) and p.strip():
+            s = p.strip()
+            if s not in seen:
+                seen.add(s)
+                out.append(s)
+
+    files = candidate.get("files")
+    if isinstance(files, Sequence) and not isinstance(files, (str, bytes)):
+        for entry in files:
+            if isinstance(entry, Mapping):
+                _add(entry.get("file_path"))
+    _add(candidate.get("file_path"))
+    return tuple(out)
+
+
+def _resolves_inside_and_exists(rel_path: str, write_root: Path) -> bool:
+    """True iff ``rel_path`` resolves INSIDE ``write_root`` AND exists on disk.
+
+    A path that escapes the write root (``../`` climb, absolute host path) is
+    treated as missing — the existing ChangeEngine chroot would reject it too;
+    here we surface it as a retry-able steering error instead. Never raises.
+    """
+    try:
+        root = write_root.resolve()
+        candidate = (root / rel_path).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return False  # escaped the worktree
+    try:
+        return candidate.is_file()
+    except OSError:
+        return False
+
+
+def find_missing_targets(
+    candidates: Sequence[Any], write_root: Optional[Path],
+) -> List[str]:
+    """Return the sorted unique target paths that don't exist under write_root.
+
+    ``write_root`` is the benchmark worktree (from ``_swe_bench_write_root``).
+    When it is ``None`` (no per-op write root resolved) the guard is INERT —
+    we cannot know the repo layout, so we never block. Pure; never raises.
+    """
+    if write_root is None:
+        return []
+    missing: set = set()
+    for cand in candidates or ():
+        for rel in _candidate_target_paths(cand):
+            if not _resolves_inside_and_exists(rel, write_root):
+                missing.add(rel)
+    return sorted(missing)
+
+
+def build_retry_feedback(missing: Sequence[str]) -> str:
+    """The self-correcting GENERATE_RETRY payload shown back to the model."""
+    paths = ", ".join(f"'{p}'" for p in missing) or "'<unknown>'"
+    return (
+        "## PREVIOUS GENERATION REJECTED — TARGET FILE DOES NOT EXIST\n\n"
+        f"The proposed target file(s) {paths} do not exist within the current "
+        "isolated problem repository. You are working on a THIRD-PARTY project, "
+        "NOT the host framework — paths like 'backend/core/...' belong to the "
+        "host system and are out of bounds.\n\n"
+        "INSTRUCTIONS FOR RETRY:\n"
+        "- Your modifications MUST target files that already exist in THIS repo.\n"
+        "- Call search_code / glob_files / list_dir to locate the real file that\n"
+        "  implements the behavior described in the problem statement BEFORE\n"
+        "  emitting any patch.\n"
+        "- Emit the patch against the exact repo-relative path you confirmed\n"
+        "  exists via exploration — do not guess a host-framework path.\n"
+    )
+
+
+# Sentinel prefix the orchestrator's retry-feedback dispatcher keys on (mirrors
+# the ``ascii_gate_failed:`` convention).
+TARGET_MISSING_PREFIX = "target_file_missing:"
+
+
+def missing_target_error_message(missing: Sequence[str]) -> str:
+    """Compose the RuntimeError message the generation-loop gate raises."""
+    return f"{TARGET_MISSING_PREFIX} {', '.join(missing)}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Contextual Prompt Insulation
+# ---------------------------------------------------------------------------
+# The generation-steering root cause was amplified by the GENERATE prompt being
+# saturated with HOST-framework context (the JARVIS Manifesto, architecture
+# docs, recent-commit momentum, active goals) — which biased the model toward
+# host paths like ``backend/core/...``. For a benchmark op that host context is
+# pure noise: the model must focus entirely on the third-party problem repo.
+# This flag strips those host-specific strategic injections for swe_bench ops.
+_PROMPT_INSULATION_ENV = "JARVIS_BENCHMARK_PROMPT_INSULATION_ENABLED"
+
+
+def prompt_insulation_enabled() -> bool:
+    """Master flag — default TRUE. Falsey restores host-context injection."""
+    raw = os.environ.get(_PROMPT_INSULATION_ENV, "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def should_insulate_prompt(signal_source: Optional[str]) -> bool:
+    """True iff host-framework strategic context should be withheld from the
+    GENERATE prompt — i.e. this is a benchmark op AND insulation is enabled.
+
+    Pure; never raises. Non-benchmark ops are always False (host self-dev keeps
+    its full strategic context).
+    """
+    return prompt_insulation_enabled() and (signal_source or "") == "swe_bench_pro"

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -4587,6 +4587,16 @@ _BUDGET_TELEMETRY_ENABLED = os.environ.get(
     "JARVIS_TOOL_LOOP_BUDGET_TELEMETRY", "true"
 ).lower() in ("1", "true", "yes", "on")
 
+
+def _adaptive_turn_gate_enabled() -> bool:
+    """Slice 73 master flag — default TRUE. When off, the viability gate keeps
+    its legacy fair-share semantics (``per_round_timeout`` divided across all
+    hypothetical rounds_left), preserving byte-identical rollback."""
+    raw = os.environ.get(
+        "JARVIS_TOOL_LOOP_ADAPTIVE_TURN_GATE_ENABLED", "true",
+    ).strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
 # Sentinel parked on ``ToolLoopCoordinator._karen_voice`` when the lazy
 # import of KarenPreambleVoice fails — headless envs, missing audio stack,
 # import errors. Using a sentinel (not ``None``) prevents the import
@@ -4798,8 +4808,15 @@ class BudgetPlan:
         (or the legacy ``min_per_round`` reason) and force the model
         to produce its final answer with the remaining budget.
         """
-        # Condition 1 — legacy min_per_round floor
-        if self.unclamped_fair_share_s(remaining_s, remaining_rounds) < self.min_per_round_s:
+        # Condition 1 — min_per_round floor
+        if _adaptive_turn_gate_enabled():
+            # Slice 73 — immediate-turn semantics (mirrors Condition 2): the
+            # round receives the full remaining budget, so bail only when even
+            # one min_per_round-sized turn won't fit, not when the fair-share
+            # across all hypothetical rounds_left dips below the floor.
+            if remaining_s < self.min_per_round_s:
+                return False
+        elif self.unclamped_fair_share_s(remaining_s, remaining_rounds) < self.min_per_round_s:
             return False
         # Condition 2 — Slice 3B + 3B.1 self-tuning TTFT floor.
         #
@@ -4823,8 +4840,21 @@ class BudgetPlan:
         # stream rupture.
         if self.min_ttft_floor_s > 0.0:
             effective_floor = min(self.min_ttft_floor_s, self.max_per_round_s)
-            if self.per_round_timeout(remaining_s, remaining_rounds) < effective_floor:
-                return False
+            if _adaptive_turn_gate_enabled():
+                # Slice 73 — assess the IMMEDIATE turn against the ACTUAL
+                # remaining budget, not the fair-share across all hypothetical
+                # rounds_left. Post-Slice-71 the round receives the full
+                # remaining deadline (generate_fn's own timeout), NOT
+                # per_round_timeout — so dividing by rounds_left is a false-
+                # positive bail that truncated a healthy 148s runway to tiny
+                # responses (16 bails in bt-2026-06-03-053511). Bail ONLY when
+                # the budget can't fit even one floor-sized turn.
+                if remaining_s < effective_floor:
+                    return False
+            else:
+                # Legacy fair-share gate (flag off → byte-identical rollback).
+                if self.per_round_timeout(remaining_s, remaining_rounds) < effective_floor:
+                    return False
         return True
 
     def describe(self) -> str:

--- a/tests/governance/test_slice69_diff_isolation.py
+++ b/tests/governance/test_slice69_diff_isolation.py
@@ -1,0 +1,248 @@
+"""Slice 69 — Sovereign Worktree Alignment & Manifest Diff Isolation.
+
+Two invariants, one cohesive slice (folds the held Slice 68 working-tree
+capture in as substrate):
+
+  Phase 1 (regression pin) — Slice 64's benchmark write-root routing is LIVE
+  and must stay live. A ``ChangeRequest`` carrying a benchmark-sourced
+  ``write_root`` (the prepared per-problem worktree) rebases its mutations
+  INTO that worktree, never the JARVIS auto-commit workspace. We pin the
+  existing behavior; we do NOT add swe_bench source-channel knowledge into the
+  generic ``_redirect_target`` layer.
+
+  Phase 2 (clean-delta invariant) — ``capture_produced_patch`` captures the
+  WORKING-TREE diff vs ``base_commit`` (Slice 68 substrate: APPLY writes the
+  candidate uncommitted), then STRIPS the harness's pre-applied ``test_patch``
+  footprint (``prepared.target_paths``). The container scorer runs
+  ``git apply <test_patch> && git apply <model_patch>`` — if the captured model
+  patch still carries the test hunks, step 2 double-applies them and HARD-FAILS
+  (no ``|| true`` guard), poisoning the score with ``scoring_error``. The final
+  ``captured_patch`` must therefore contain 100% pure model source changes.
+"""
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+from backend.core.ouroboros.governance.change_engine import ChangeEngine
+from backend.core.ouroboros.governance.swe_bench_pro.per_problem_harness import (
+    PreparedProblem,
+    capture_produced_patch,
+    DiffCaptureOutcome,
+    _strip_test_patch_sections,
+)
+
+
+# ===========================================================================
+# Phase 1 — Slice 64 benchmark write-root regression pin
+# ===========================================================================
+
+
+def test_benchmark_write_root_routes_mutation_into_prepared_worktree(tmp_path):
+    """A benchmark-sourced write_root (prepared worktree) rebases the APPLY
+    target INTO that worktree — the operator's main tree is never touched.
+
+    Pins Slice 64 behavior WITHOUT touching _redirect_target: the generic
+    layer takes a clean per-request write_root; the orchestrator owns the
+    swe_bench_pro -> worktree mapping (no source-channel sniffing here)."""
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    worktree = tmp_path / "prepared_worktree"
+    worktree.mkdir()
+    # _redirect_target / _effective_write_root only read self._project_root +
+    # the request write_root; ledger is unused on this path.
+    eng = ChangeEngine(project_root=project_root, ledger=object())  # type: ignore[arg-type]
+
+    target = project_root / "qutebrowser" / "browser" / "commands.py"
+    redirected = eng._redirect_target(target, worktree)
+
+    assert redirected == worktree / "qutebrowser" / "browser" / "commands.py"
+    # Must NOT land in the project (operator) tree.
+    assert project_root not in redirected.parents
+
+
+def test_no_benchmark_write_root_preserves_legacy_target(tmp_path, monkeypatch):
+    """write_root=None (every non-swe_bench op) is byte-identical legacy:
+    no env override -> target unchanged."""
+    monkeypatch.delenv("JARVIS_AUTO_COMMIT_WORKSPACE", raising=False)
+    eng = ChangeEngine(project_root=tmp_path, ledger=object())  # type: ignore[arg-type]
+    target = tmp_path / "src" / "foo.py"
+    assert eng._redirect_target(target, None) == target
+
+
+# ===========================================================================
+# Phase 2a — _strip_test_patch_sections (pure function)
+# ===========================================================================
+
+_SRC_SECTION = (
+    "diff --git a/src/app.py b/src/app.py\n"
+    "index 1111111..2222222 100644\n"
+    "--- a/src/app.py\n"
+    "+++ b/src/app.py\n"
+    "@@ -1,3 +1,3 @@\n"
+    " def f():\n"
+    "-    return 1\n"
+    "+    return 2\n"
+)
+
+_TEST_SECTION = (
+    "diff --git a/tests/test_app.py b/tests/test_app.py\n"
+    "index 0000000..3333333 100644\n"
+    "--- a/tests/test_app.py\n"
+    "+++ b/tests/test_app.py\n"
+    "@@ -0,0 +1,2 @@\n"
+    "+def test_f():\n"
+    "+    assert f() == 2\n"
+)
+
+
+def test_strips_section_matching_test_path():
+    diff = _SRC_SECTION + _TEST_SECTION
+    cleaned = _strip_test_patch_sections(diff, ("tests/test_app.py",))
+    assert "src/app.py" in cleaned
+    assert "return 2" in cleaned
+    assert "tests/test_app.py" not in cleaned
+    assert "def test_f" not in cleaned
+
+
+def test_empty_manifest_leaves_diff_untouched():
+    diff = _SRC_SECTION + _TEST_SECTION
+    assert _strip_test_patch_sections(diff, ()) == diff
+
+
+def test_all_test_sections_strip_to_empty():
+    cleaned = _strip_test_patch_sections(_TEST_SECTION, ("tests/test_app.py",))
+    assert cleaned.strip() == ""
+
+
+def test_path_match_is_exact_not_basename():
+    """A source file sharing a basename with a test path must survive —
+    we filter on the exact repo-relative path, not the basename."""
+    src = (
+        "diff --git a/pkg/test_app.py b/pkg/test_app.py\n"
+        "--- a/pkg/test_app.py\n"
+        "+++ b/pkg/test_app.py\n"
+        "@@ -1 +1 @@\n"
+        "-x = 1\n"
+        "+x = 2\n"
+    )
+    cleaned = _strip_test_patch_sections(src, ("tests/test_app.py",))
+    assert cleaned == src  # different path -> kept
+
+
+def test_strips_new_test_file_added_from_dev_null():
+    """A newly-added test file (--- /dev/null) is still matched via its
+    +++ b/<path> header and stripped."""
+    new_test = (
+        "diff --git a/tests/new_test.py b/tests/new_test.py\n"
+        "new file mode 100644\n"
+        "index 0000000..abcdef0\n"
+        "--- /dev/null\n"
+        "+++ b/tests/new_test.py\n"
+        "@@ -0,0 +1 @@\n"
+        "+assert True\n"
+    )
+    cleaned = _strip_test_patch_sections(_SRC_SECTION + new_test, ("tests/new_test.py",))
+    assert "src/app.py" in cleaned
+    assert "tests/new_test.py" not in cleaned
+
+
+def test_never_raises_on_garbage_returns_input():
+    junk = "not a diff at all\nrandom text\n"
+    assert _strip_test_patch_sections(junk, ("tests/x.py",)) == junk
+
+
+# ===========================================================================
+# Phase 2b — capture_produced_patch end-to-end (real git worktree)
+# ===========================================================================
+
+
+def _git(args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True,
+                   capture_output=True, text=True)
+
+
+def _init_repo(tmp: Path) -> str:
+    _git(["init", "-q"], tmp)
+    _git(["config", "user.email", "t@t.t"], tmp)
+    _git(["config", "user.name", "t"], tmp)
+    (tmp / "src").mkdir()
+    (tmp / "src" / "app.py").write_text("def f():\n    return 1\n")
+    _git(["add", "-A"], tmp)
+    _git(["commit", "-q", "-m", "base"], tmp)
+    return subprocess.run(["git", "rev-parse", "HEAD"], cwd=tmp,
+                          capture_output=True, text=True).stdout.strip()
+
+
+def _prepared(tmp: Path, base: str, target_paths=()) -> PreparedProblem:
+    return PreparedProblem(
+        problem_instance_id="t__inst-1", worktree_path=tmp,
+        base_commit=base, repo_url="x/y", branch_name="swebp/t",
+        target_paths=tuple(target_paths),
+    )
+
+
+def test_capture_strips_pre_applied_test_patch_footprint(tmp_path):
+    """Mirrors the live flow: prepare applied a test_patch (tests/) into the
+    worktree, then the model edited source. The captured patch must contain
+    ONLY the source change — the test footprint is stripped so the scorer's
+    `git apply <test_patch> && git apply <model_patch>` doesn't double-apply."""
+    base = _init_repo(tmp_path)
+    # Harness pre-applied test_patch: a NEW test file in the working tree.
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_app.py").write_text("def test_f():\n    assert True\n")
+    # Model's source edit (uncommitted working tree — Slice 68 substrate).
+    (tmp_path / "src" / "app.py").write_text("def f():\n    return 2  # patched\n")
+
+    prepared = _prepared(tmp_path, base, target_paths=("tests/test_app.py",))
+    patch, outcome = asyncio.run(capture_produced_patch(prepared))
+
+    assert outcome == DiffCaptureOutcome.CAPTURED, outcome
+    assert patch is not None
+    assert "src/app.py" in patch
+    assert "return 2" in patch
+    # The pre-applied test footprint must be GONE.
+    assert "tests/test_app.py" not in patch
+    assert "def test_f" not in patch
+
+
+def test_capture_test_only_change_yields_no_changes(tmp_path):
+    """If the ONLY working-tree change is the pre-applied test_patch (the model
+    produced nothing), filtering strips it to empty -> NO_CHANGES (no false
+    CAPTURED of a test-only patch)."""
+    base = _init_repo(tmp_path)
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_app.py").write_text("def test_f():\n    assert True\n")
+
+    prepared = _prepared(tmp_path, base, target_paths=("tests/test_app.py",))
+    patch, outcome = asyncio.run(capture_produced_patch(prepared))
+
+    assert outcome == DiffCaptureOutcome.NO_CHANGES, outcome
+    assert patch is None
+
+
+def test_capture_source_only_no_manifest_is_unfiltered(tmp_path):
+    """Source-only change with an empty manifest: full working-tree capture
+    (Slice 68 substrate), nothing stripped."""
+    base = _init_repo(tmp_path)
+    (tmp_path / "src" / "app.py").write_text("def f():\n    return 3\n")
+
+    prepared = _prepared(tmp_path, base, target_paths=())
+    patch, outcome = asyncio.run(capture_produced_patch(prepared))
+
+    assert outcome == DiffCaptureOutcome.CAPTURED, outcome
+    assert patch is not None and "return 3" in patch
+
+
+def test_capture_uncommitted_new_source_file(tmp_path):
+    """Slice 68 substrate pin: an ADDED (untracked) source file is captured
+    via `git add -A && git diff --cached`."""
+    base = _init_repo(tmp_path)
+    (tmp_path / "src" / "new_mod.py").write_text("X = 1\n")
+
+    prepared = _prepared(tmp_path, base, target_paths=())
+    patch, outcome = asyncio.run(capture_produced_patch(prepared))
+
+    assert outcome == DiffCaptureOutcome.CAPTURED, outcome
+    assert patch is not None and "new_mod.py" in patch

--- a/tests/governance/test_slice71_synthesis_floor.py
+++ b/tests/governance/test_slice71_synthesis_floor.py
@@ -1,0 +1,101 @@
+"""Slice 71 — Dynamic Temporal Inheritance & Adaptive Synthesis Floor Gating.
+
+Root cause (verify-first, bt-2026-06-02-232715): the Claude fallback's Venom
+tool loop derives its per-round / stream budget from the GENERATE-phase
+``deadline`` (providers.py:7905 ``_generate_raw`` + 8732 ``deadline_mono``).
+A *continuation* round (``is_tool_round = round_index > 0``) runs after earlier
+rounds have CONSUMED that phase window, so ``_remaining_utc_budget_s(deadline)``
+collapses to its 1.0s floor → Claude is handed ``budget=1.0s`` → ``first_token=
+NEVER`` → ``fallback_failed`` → no candidate → no score.
+
+The op's TRUE wall envelope (``OperationContext.pipeline_deadline``, stamped
+once at submit) still had runway (313s in the soak). The Envelope Inheritance
+Invariant: tool-loop synthesis inherits the MORE generous of the phase deadline
+and the wall envelope, so a consumed phase window can't starve the fallback.
+The outer ``_call_fallback`` ``_race_or_wait_for`` + wall watchdog remain the
+absolute ceilings — inheritance only RAISES the inner budget, never beyond the
+op's wall envelope.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from backend.core.ouroboros.governance.providers import (
+    _synthesis_envelope_deadline,
+    _synthesis_envelope_enabled,
+)
+
+
+class _Ctx:
+    """Minimal OperationContext stand-in carrying a pipeline_deadline."""
+
+    def __init__(self, pipeline_deadline):
+        self.pipeline_deadline = pipeline_deadline
+
+
+def _utc(seconds_from_now: float) -> datetime:
+    return datetime.now(tz=timezone.utc) + timedelta(seconds=seconds_from_now)
+
+
+def test_inherits_wall_envelope_when_more_generous(monkeypatch):
+    """Consumed phase deadline (≈now) + healthy wall envelope (≈now+300s):
+    the synthesis deadline inherits the wall envelope."""
+    monkeypatch.setenv("JARVIS_FALLBACK_SYNTHESIS_ENVELOPE_ENABLED", "true")
+    phase = _utc(0.5)          # consumed phase window
+    wall = _utc(300.0)         # healthy pipeline_deadline
+    eff = _synthesis_envelope_deadline(_Ctx(wall), phase)
+    assert eff == wall
+
+
+def test_keeps_phase_when_phase_more_generous(monkeypatch):
+    """If the phase deadline is somehow later than the wall envelope, keep it
+    (max semantics — never SHRINK the budget)."""
+    monkeypatch.setenv("JARVIS_FALLBACK_SYNTHESIS_ENVELOPE_ENABLED", "true")
+    phase = _utc(400.0)
+    wall = _utc(120.0)
+    eff = _synthesis_envelope_deadline(_Ctx(wall), phase)
+    assert eff == phase
+
+
+def test_disabled_flag_is_byte_identical_passthrough(monkeypatch):
+    """Flag off → returns the phase deadline unchanged (legacy behavior)."""
+    monkeypatch.setenv("JARVIS_FALLBACK_SYNTHESIS_ENVELOPE_ENABLED", "false")
+    phase = _utc(1.0)
+    wall = _utc(300.0)
+    assert _synthesis_envelope_deadline(_Ctx(wall), phase) == phase
+
+
+def test_absent_pipeline_deadline_passthrough(monkeypatch):
+    """No wall envelope on the context → phase deadline unchanged."""
+    monkeypatch.setenv("JARVIS_FALLBACK_SYNTHESIS_ENVELOPE_ENABLED", "true")
+    phase = _utc(10.0)
+    assert _synthesis_envelope_deadline(_Ctx(None), phase) == phase
+
+
+def test_none_phase_with_wall_returns_wall(monkeypatch):
+    """Phase deadline None but wall envelope present → inherit the wall."""
+    monkeypatch.setenv("JARVIS_FALLBACK_SYNTHESIS_ENVELOPE_ENABLED", "true")
+    wall = _utc(200.0)
+    assert _synthesis_envelope_deadline(_Ctx(wall), None) == wall
+
+
+def test_never_raises_on_bad_context(monkeypatch):
+    """A context without pipeline_deadline attr → safe passthrough, no raise."""
+    monkeypatch.setenv("JARVIS_FALLBACK_SYNTHESIS_ENVELOPE_ENABLED", "true")
+    phase = _utc(5.0)
+    assert _synthesis_envelope_deadline(object(), phase) == phase
+
+
+def test_naive_aware_mismatch_falls_back_to_phase(monkeypatch):
+    """A tz-naive wall vs tz-aware phase would raise on compare → keep phase
+    (fail-safe; never crash the generation path)."""
+    monkeypatch.setenv("JARVIS_FALLBACK_SYNTHESIS_ENVELOPE_ENABLED", "true")
+    phase = _utc(5.0)
+    naive_wall = datetime.now() + timedelta(seconds=300)  # naive on purpose
+    assert _synthesis_envelope_deadline(_Ctx(naive_wall), phase) == phase
+
+
+def test_default_enabled(monkeypatch):
+    """Slice 71 graduates default-on (operator wants it for the scored soak)."""
+    monkeypatch.delenv("JARVIS_FALLBACK_SYNTHESIS_ENVELOPE_ENABLED", raising=False)
+    assert _synthesis_envelope_enabled() is True

--- a/tests/governance/test_slice72_target_guard.py
+++ b/tests/governance/test_slice72_target_guard.py
@@ -1,0 +1,155 @@
+"""Slice 72 — Generative Target-Existence Guard & Contextual Prompt Insulation.
+
+The deterministic gate: for a benchmark op, every candidate target file MUST
+already exist inside the prepared worktree. A miss (e.g. the model emitting a
+host-framework path like ``backend/core/process_manager.py`` for a qutebrowser
+problem) is surfaced as self-correcting GENERATE_RETRY feedback instead of
+crashing APPLY with ENOENT. Host self-development (which legitimately creates
+new files) is untouched — the orchestrator only invokes this for
+``signal_source == "swe_bench_pro"``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.core.ouroboros.governance.target_existence_guard import (
+    find_missing_targets,
+    build_retry_feedback,
+    guard_enabled,
+    missing_target_error_message,
+    TARGET_MISSING_PREFIX,
+)
+
+
+def _worktree(tmp: Path) -> Path:
+    (tmp / "qutebrowser" / "utils").mkdir(parents=True)
+    (tmp / "qutebrowser" / "utils" / "guiprocess.py").write_text("x = 1\n")
+    return tmp
+
+
+def test_existing_target_is_not_missing(tmp_path):
+    wt = _worktree(tmp_path)
+    cands = [{"file_path": "qutebrowser/utils/guiprocess.py", "full_content": "x = 2\n"}]
+    assert find_missing_targets(cands, wt) == []
+
+
+def test_host_namespace_path_is_flagged_missing(tmp_path):
+    """The exact bt-2026-06-03 failure: a JARVIS path for a qutebrowser repo."""
+    wt = _worktree(tmp_path)
+    cands = [{"file_path": "backend/core/process_manager.py", "full_content": "..."}]
+    assert find_missing_targets(cands, wt) == ["backend/core/process_manager.py"]
+
+
+def test_multi_file_candidate_each_target_checked(tmp_path):
+    wt = _worktree(tmp_path)
+    cands = [{
+        "files": [
+            {"file_path": "qutebrowser/utils/guiprocess.py", "full_content": "a"},
+            {"file_path": "backend/core/nope.py", "full_content": "b"},
+        ]
+    }]
+    assert find_missing_targets(cands, wt) == ["backend/core/nope.py"]
+
+
+def test_path_escaping_worktree_is_missing(tmp_path):
+    """A ../ climb or absolute host path escapes the worktree → flagged."""
+    wt = _worktree(tmp_path)
+    cands = [{"file_path": "../../../etc/passwd"}]
+    assert find_missing_targets(cands, wt) == ["../../../etc/passwd"]
+
+
+def test_none_write_root_is_inert(tmp_path):
+    """No per-op write root resolved (non-benchmark / unresolved) → never block."""
+    cands = [{"file_path": "anything/at/all.py"}]
+    assert find_missing_targets(cands, None) == []
+
+
+def test_directory_target_is_not_a_file(tmp_path):
+    wt = _worktree(tmp_path)
+    cands = [{"file_path": "qutebrowser/utils"}]  # a dir, not a file
+    assert find_missing_targets(cands, wt) == ["qutebrowser/utils"]
+
+
+def test_non_dict_and_empty_candidates_safe(tmp_path):
+    wt = _worktree(tmp_path)
+    assert find_missing_targets([], wt) == []
+    assert find_missing_targets([None, "junk", 42], wt) == []
+
+
+def test_dedupes_missing_across_candidates(tmp_path):
+    wt = _worktree(tmp_path)
+    cands = [
+        {"file_path": "backend/core/x.py"},
+        {"file_path": "backend/core/x.py"},
+    ]
+    assert find_missing_targets(cands, wt) == ["backend/core/x.py"]
+
+
+def test_retry_feedback_is_actionable():
+    fb = build_retry_feedback(["backend/core/process_manager.py"])
+    assert "do not exist" in fb
+    assert "backend/core/process_manager.py" in fb
+    assert "search_code" in fb and "glob_files" in fb
+
+
+def test_error_message_carries_sentinel_prefix():
+    msg = missing_target_error_message(["a.py", "b.py"])
+    assert msg.startswith(TARGET_MISSING_PREFIX)
+    assert "a.py" in msg and "b.py" in msg
+
+
+def test_guard_default_enabled(monkeypatch):
+    monkeypatch.delenv("JARVIS_SWE_BENCH_TARGET_EXISTENCE_GUARD_ENABLED", raising=False)
+    assert guard_enabled() is True
+    monkeypatch.setenv("JARVIS_SWE_BENCH_TARGET_EXISTENCE_GUARD_ENABLED", "false")
+    assert guard_enabled() is False
+
+
+# --- AST-pins: the guard is wired into the live orchestrator generation loop ---
+
+def _orch_src() -> str:
+    p = Path(__file__).resolve().parents[2] / (
+        "backend/core/ouroboros/governance/orchestrator.py"
+    )
+    return p.read_text(encoding="utf-8")
+
+
+def test_orchestrator_invokes_target_guard_gated_on_swe_bench():
+    src = _orch_src()
+    assert "_find_missing_targets(" in src, "gate must call the guard helper"
+    assert "_target_guard_enabled()" in src, "gate must honor the master flag"
+    # Gated on the swe_bench source so host self-dev (new files) is untouched.
+    assert 'signal_source", "") == "swe_bench_pro"' in src
+    # Routed through the GENERATE_RETRY error path (raises, sets generation=None).
+    assert "_target_missing_error_message(" in src
+
+
+def test_orchestrator_has_target_missing_retry_feedback_branch():
+    src = _orch_src()
+    assert "_err_str.startswith(_TARGET_MISSING_PREFIX)" in src
+    assert "_target_missing_retry_feedback(" in src
+
+
+# --- Phase 3: contextual prompt insulation for benchmark ops ---
+
+def test_should_insulate_only_for_benchmark(monkeypatch):
+    from backend.core.ouroboros.governance.target_existence_guard import (
+        should_insulate_prompt, prompt_insulation_enabled,
+    )
+    monkeypatch.delenv("JARVIS_BENCHMARK_PROMPT_INSULATION_ENABLED", raising=False)
+    assert prompt_insulation_enabled() is True
+    assert should_insulate_prompt("swe_bench_pro") is True
+    assert should_insulate_prompt("voice_command") is False
+    assert should_insulate_prompt("") is False
+    assert should_insulate_prompt(None) is False
+    # Master flag off → never insulate (host context restored).
+    monkeypatch.setenv("JARVIS_BENCHMARK_PROMPT_INSULATION_ENABLED", "false")
+    assert should_insulate_prompt("swe_bench_pro") is False
+
+
+def test_orchestrator_gates_strategic_and_goal_injection_on_insulation():
+    src = _orch_src()
+    # Both host-context injections must consult the insulation gate.
+    assert src.count("_should_insulate_prompt(") >= 2, (
+        "both Strategic Direction and Goal injections must be insulation-gated"
+    )

--- a/tests/governance/test_slice73_cascade_and_gates.py
+++ b/tests/governance/test_slice73_cascade_and_gates.py
@@ -1,0 +1,102 @@
+"""Slice 73 — Structural Transport Short-Circuit + Adaptive Turn Allocation.
+
+Empirical harvest (bt-2026-06-03-053511 debug.log) drove the re-scope:
+  * DW Qwen generation = 100% ``live_transport:RuntimeError`` (transport DOWN,
+    zero TTFT samples) — so a TTFT-σ cold-start predictor would be inert. The
+    real waste is the route trying BOTH dead DW models (~30s each) before
+    cascading, starving the Claude fallback (``deadline_exhausted_pre_fallback``).
+  * 16 × ``tool_loop_starved_below_min_ttft_floor`` bails with a HEALTHY 148s
+    budget — the viability gate divided remaining by ALL rounds_left
+    (148/8≈18.5s < 45s floor) and bailed, truncating the model to tiny
+    non-patch responses.
+
+Phase 1 — sever the DW lane on a STRUCTURAL transport break (affects the whole
+endpoint; sibling models share the dead transport) and cascade immediately.
+Phase 2 — the viability gate assesses the IMMEDIATE turn against the actual
+remaining budget (the round receives the full deadline post-Slice-71, NOT
+per_round_timeout), not a fair-share across hypothetical future rounds.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.core.ouroboros.governance.topology_sentinel import FailureSource
+from backend.core.ouroboros.governance.candidate_generator import (
+    should_sever_dw_lane,
+    structural_fast_cascade_enabled,
+)
+from backend.core.ouroboros.governance.tool_executor import BudgetPlan
+
+
+# --- Phase 1: structural transport short-circuit predicate ---
+
+def test_severs_dw_lane_on_live_transport():
+    """A transport/socket break affects the whole DW endpoint → sever, don't
+    waste ~30s trying a sibling model on the same dead transport."""
+    assert should_sever_dw_lane(FailureSource.LIVE_TRANSPORT) is True
+
+
+def test_does_not_sever_on_model_specific_failures():
+    """429 (rate limit) / 5xx / parse are model-specific — still rotate to the
+    next ranked model (a sibling may be healthy)."""
+    assert should_sever_dw_lane(FailureSource.LIVE_HTTP_429) is False
+    assert should_sever_dw_lane(FailureSource.LIVE_HTTP_5XX) is False
+    assert should_sever_dw_lane(FailureSource.LIVE_PARSE_ERROR) is False
+
+
+def test_structural_fast_cascade_default_enabled(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_STRUCTURAL_FAST_CASCADE_ENABLED", raising=False)
+    assert structural_fast_cascade_enabled() is True
+    monkeypatch.setenv("JARVIS_DW_STRUCTURAL_FAST_CASCADE_ENABLED", "false")
+    assert structural_fast_cascade_enabled() is False
+
+
+# --- Phase 2: adaptive turn allocation gate ---
+
+def _plan() -> BudgetPlan:
+    # Mirrors the soak: floor 45s, ceiling 30s, up to 10 rounds.
+    return BudgetPlan.build(
+        total_budget_s=160.0, hard_max_rounds=10, max_per_round_s=30.0,
+        min_ttft_floor_s=45.0,
+    )
+
+
+def test_healthy_budget_with_many_rounds_is_viable(monkeypatch):
+    """The exact false-positive: 148s remaining, 8 rounds_left. Old gate bailed
+    (148/8=18.5 < floor); the immediate turn easily fits → must be viable."""
+    monkeypatch.delenv("JARVIS_TOOL_LOOP_ADAPTIVE_TURN_GATE_ENABLED", raising=False)
+    assert _plan().is_next_round_viable(remaining_s=148.0, remaining_rounds=8) is True
+
+
+def test_genuinely_starved_budget_still_bails():
+    """When the WHOLE remaining budget can't fit one floor-sized turn, bail."""
+    # effective_floor = min(45, max_per_round=30) = 30. remaining 20 < 30.
+    assert _plan().is_next_round_viable(remaining_s=20.0, remaining_rounds=2) is False
+
+
+def test_budget_exactly_at_floor_is_viable():
+    # remaining == effective_floor (30) → the immediate turn fits.
+    assert _plan().is_next_round_viable(remaining_s=30.0, remaining_rounds=9) is True
+
+
+def test_flag_off_restores_legacy_fairshare_gate(monkeypatch):
+    """Master flag off → byte-identical legacy behavior (fair-share bail)."""
+    monkeypatch.setenv("JARVIS_TOOL_LOOP_ADAPTIVE_TURN_GATE_ENABLED", "false")
+    # Legacy: per_round_timeout(148,8)=min(30,18.5)=18.5 < floor 30 → bail.
+    assert _plan().is_next_round_viable(remaining_s=148.0, remaining_rounds=8) is False
+
+
+# --- AST-pins: both fixes wired into the live paths ---
+
+def test_candidate_generator_severs_on_structural_failure():
+    src = (Path(__file__).resolve().parents[2]
+           / "backend/core/ouroboros/governance/candidate_generator.py").read_text()
+    assert "should_sever_dw_lane(" in src, "dispatch loop must consult the sever predicate"
+    # The break must be present in the dispatch loop (not just continue).
+    assert "structural_fast_cascade_enabled()" in src
+
+
+def test_tool_executor_uses_adaptive_turn_gate():
+    src = (Path(__file__).resolve().parents[2]
+           / "backend/core/ouroboros/governance/tool_executor.py").read_text()
+    assert "_adaptive_turn_gate_enabled" in src


### PR DESCRIPTION
## Summary
- Aligns SWE-Bench-Pro worktree/diff isolation so benchmark patches are captured from the sovereign prepared tree.
- Adds provider/orchestrator hardening for wall-aware fallback synthesis, target-existence guarding, benchmark prompt insulation, and transport fast-cascade behavior.
- Adds focused regression coverage for Slice 69, 71, 72, and 73 behavior.

## Notes
- Created because direct push to protected `main` was refused; this PR uses the required feature-branch flow.
- Branch also includes a scheduled task lock update in `.claude/scheduled_tasks.lock` from the current session.

## Test Plan
- Not rerun in this handoff.
- Included tests: `tests/governance/test_slice69_diff_isolation.py`, `tests/governance/test_slice71_synthesis_floor.py`, `tests/governance/test_slice72_target_guard.py`, `tests/governance/test_slice73_cascade_and_gates.py`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens SWE-Bench-Pro runs by capturing clean, worktree-only patches and preventing ENOENTs and double-apply scoring failures. Improves fallback and cascade behavior to use the full wall budget and skip dead transports.

- **Bug Fixes**
  - Clean patch capture: stage and diff the index vs `base_commit`, then strip `test_patch` sections so only model changes remain.
  - Benchmark guard: for `swe_bench_pro`, reject candidates targeting files not present in the prepared worktree and return actionable GENERATE_RETRY feedback; also insulate prompts by withholding host Strategic Direction/Goals for benchmark ops.
  - Fallback budget: tool-loop synthesis inherits the op wall envelope to avoid the 1s floor on continuation rounds.
  - Fast cascade: on DW `LIVE_TRANSPORT` failures, sever the DW lane and cascade immediately instead of trying sibling models on a dead transport.
  - Adaptive tool-loop gate: decide viability using the immediate remaining budget (not fair-share across rounds), preventing false bails; all new controls are flag-gated (default on): `JARVIS_FALLBACK_SYNTHESIS_ENVELOPE_ENABLED`, `JARVIS_SWE_BENCH_TARGET_EXISTENCE_GUARD_ENABLED`, `JARVIS_BENCHMARK_PROMPT_INSULATION_ENABLED`, `JARVIS_DW_STRUCTURAL_FAST_CASCADE_ENABLED`, `JARVIS_TOOL_LOOP_ADAPTIVE_TURN_GATE_ENABLED`.

<sup>Written for commit 27c78daf58c7c9471687349052955761289c527d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

