### PR TITLE
feat(orchestrator): Slice 74 — decouple terminal SSE broadcast from ledger dedup + permanent rendezvous telemetry

### DIFF
--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -2271,6 +2271,19 @@ def publish_operation_terminal(ctx: Any, state: Any) -> Optional[str]:
             "phase_entered_at": phase_entered_iso,
             "timestamp": _iso_now(),
         }
+        # Slice 74 rendezvous telemetry — broker IDENTITY + live subscriber
+        # count at the publish seam. Compared against the eval's SUBSCRIBE
+        # probe: same broker_id + subs>0 ⇒ rendezvous should fire; different
+        # broker_id ⇒ singleton mismatch; subs=0 ⇒ no listener registered for
+        # this op_id. Zero-risk INFO probe; remove after diagnosis.
+        try:
+            _s74_b = get_default_broker()
+            logger.info(
+                "[Slice74Probe] PUBLISH_TERMINAL op_id=%s broker_id=0x%x subs=%d",
+                op_id, id(_s74_b), len(getattr(_s74_b, "_subscribers", {})),
+            )
+        except Exception:  # noqa: BLE001 — probe never perturbs publish
+            pass
         return publish_task_event(
             EVENT_TYPE_OPERATION_TERMINAL, op_id, payload,
         )

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -2128,6 +2128,36 @@ _default_broker: Optional[StreamEventBroker] = None
 _default_broker_lock = threading.Lock()
 
 
+# Slice 74 — notification-layer terminal idempotency. Decoupling the terminal
+# SSE broadcast from the ledger's physical-write dedup (orchestrator) means the
+# broadcast can now be invoked even on a deduped storage write — so exactly-once
+# semantics must live HERE (the notification layer), not ride on storage state.
+# Bounded FIFO set of (op_id, state) already published; thread-safe; fail-open
+# (a possible duplicate event beats a dropped terminal wake).
+_TERMINAL_PUBLISHED_MAX = 4096
+_terminal_published_set: set = set()
+_terminal_published_order: deque = deque()
+_terminal_published_lock = threading.Lock()
+
+
+def _terminal_publish_once(op_id: str, state_value: str) -> bool:
+    """Return True iff this ``(op_id, state)`` terminal event has not been
+    broadcast before (and records it). Bounded; thread-safe; NEVER raises —
+    on any internal error it returns True (fail-open toward delivery)."""
+    key = (op_id, state_value)
+    try:
+        with _terminal_published_lock:
+            if key in _terminal_published_set:
+                return False
+            _terminal_published_set.add(key)
+            _terminal_published_order.append(key)
+            while len(_terminal_published_order) > _TERMINAL_PUBLISHED_MAX:
+                _terminal_published_set.discard(_terminal_published_order.popleft())
+            return True
+    except Exception:  # noqa: BLE001
+        return True
+
+
 def get_default_broker() -> StreamEventBroker:
     global _default_broker
     with _default_broker_lock:
@@ -2249,6 +2279,13 @@ def publish_operation_terminal(ctx: Any, state: Any) -> Optional[str]:
             return None
         op_id = getattr(ctx, "op_id", None)
         if not isinstance(op_id, str) or not op_id:
+            return None
+        # Slice 74 — exactly-once at the notification layer. The orchestrator no
+        # longer gates this call on the ledger's `written` dedup, so idempotency
+        # for (op_id, terminal state) lives here. Returns None on a repeat so a
+        # deduped storage write still fires the FIRST terminal broadcast but
+        # never double-fires.
+        if not _terminal_publish_once(op_id, state_value):
             return None
         phase_obj = getattr(ctx, "phase", None)
         phase_value = getattr(phase_obj, "name", None)

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -11192,6 +11192,19 @@ class GovernedOrchestrator:
         # already documents NEVER-raise, but this defensive wrapper
         # honors the operator binding verbatim ("never raise into
         # _record_ledger — swallow + DEBUG").
+        # Slice 74 probe — did the TERMINAL ledger write land (written=True →
+        # publish fires) or get DEDUPED (written=False → publish skipped → the
+        # eval never wakes, falls back to the 25-min ledger scan)? Captures the
+        # `written` boolean for terminal states. Zero-risk; remove after diag.
+        try:
+            _s74_sv = str(getattr(state, "value", state)).upper()
+            if _s74_sv in ("COMPLETED", "FAILED", "BLOCKED", "COMPLETE", "ROLLED_BACK"):
+                logger.info(
+                    "[Slice74Probe] LEDGER_TERMINAL op_id=%s state=%s written=%s",
+                    getattr(ctx, "op_id", "?"), _s74_sv, written,
+                )
+        except Exception:  # noqa: BLE001
+            pass
         if written:
             try:
                 from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: E501

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -11197,21 +11197,38 @@ class GovernedOrchestrator:
         # eval never wakes, falls back to the 25-min ledger scan)? Captures the
         # `written` boolean for terminal states. Zero-risk; remove after diag.
         try:
-            _s74_sv = str(getattr(state, "value", state)).upper()
-            if _s74_sv in ("COMPLETED", "FAILED", "BLOCKED", "COMPLETE", "ROLLED_BACK"):
+            # Canonical terminal set is lowercase {applied, rolled_back, failed,
+            # blocked} — 'applied' is the SUCCESS terminal (there is no
+            # 'completed'). Match the real set so the success path is observed.
+            _s74_sv = str(getattr(state, "value", state)).lower()
+            if _s74_sv in ("applied", "rolled_back", "failed", "blocked"):
                 logger.info(
                     "[Slice74Probe] LEDGER_TERMINAL op_id=%s state=%s written=%s",
                     getattr(ctx, "op_id", "?"), _s74_sv, written,
                 )
         except Exception:  # noqa: BLE001
             pass
+        # Slice 74 — Immutable Lifecycle Boundary: the terminal SSE broadcast is
+        # DECOUPLED from the ledger's physical-write dedup. A definitive terminal
+        # state MUST notify the system (the autoscore eval rendezvous + IDE
+        # consumers) even when the ledger deduped the row (written=False) —
+        # otherwise a deduped COMPLETED/FAILED write silently drops the wake
+        # (the bt-2026-06-03-063919 25-min-lag class). publish_operation_terminal
+        # is internally a no-op for non-terminal states and carries its own
+        # (op_id, state) idempotency guard, so this is exactly-once regardless of
+        # how many times _record_ledger fires for the state. NEVER raises here.
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: E501
+                publish_operation_terminal as _s74_publish_terminal,
+            )
+            _s74_publish_terminal(ctx, state)
+        except Exception:  # noqa: BLE001 — never raise into _record_ledger
+            pass
         if written:
             try:
                 from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: E501
                     TERMINAL_OPERATION_STATES,
-                    publish_operation_terminal,
                 )
-                publish_operation_terminal(ctx, state)
                 # Fail-Fast counter prune — single terminal chokepoint.
                 # Composes the SAME canonical terminal set the SSE
                 # publisher uses (no duplicated state list). Pruning

--- a/backend/core/ouroboros/governance/swe_bench_pro/evaluator.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/evaluator.py
@@ -581,6 +581,15 @@ async def evaluate_problem(
             # ---- Phase B.2.0.5: subscribe BEFORE ingest (race-free) ----
             # AST-pinned by the B.2.3 spine — source-order invariant.
             subscriber = resolved_broker.subscribe(op_id_filter=op_id)
+            # Slice 74 rendezvous telemetry — capture the broker IDENTITY +
+            # target op_id at the subscribe seam so we can prove whether the
+            # publish-side broker is the SAME singleton instance the eval
+            # awaits on. Zero-risk INFO probe; remove after diagnosis.
+            logger.info(
+                "[Slice74Probe] SUBSCRIBE op_id=%s broker_id=0x%x subscriber=%s",
+                op_id, id(resolved_broker),
+                "ok" if subscriber is not None else "None",
+            )
             if subscriber is None:
                 # Broker capacity exhausted. Don't ingest — there's no
                 # observer to rendezvous with, and a polling-only fallback

--- a/backend/core/ouroboros/governance/swe_bench_pro/result_store.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/result_store.py
@@ -285,10 +285,30 @@ class EvaluationResultStore:
                 with self._lock:
                     self._records[record.dedup_key] = record
 
-                if not self.is_persistence_enabled():
+                # Slice 74 persistence probe — was record() reached with the
+                # real verdict, and is durable persistence even enabled? If the
+                # durable results.jsonl row was None, either record() was never
+                # called with the RESOLVED verdict (data-mapping / wiring) or
+                # persistence was off / the append failed (cache-line). This
+                # disambiguates. Zero-risk; remove after diagnosis.
+                _s74_persist = self.is_persistence_enabled()
+                logger.info(
+                    "[Slice74Probe] RECORD instance=%s eval=%s score=%s persist_enabled=%s",
+                    _instance_id,
+                    getattr(getattr(evaluation, "outcome", None), "value", "?"),
+                    getattr(getattr(scoring, "outcome", None), "value", "?"),
+                    _s74_persist,
+                )
+
+                if not _s74_persist:
                     return True
 
-                return await self._append_jsonl(record)
+                _s74_appended = await self._append_jsonl(record)
+                logger.info(
+                    "[Slice74Probe] RECORD_PERSIST instance=%s appended=%s path=%s",
+                    _instance_id, _s74_appended, self._persistence_path,
+                )
+                return _s74_appended
             except asyncio.CancelledError:
                 raise
             except Exception:  # noqa: BLE001 - public surface is fail-closed

--- a/tests/governance/test_slice74_lifecycle_invariant.py
+++ b/tests/governance/test_slice74_lifecycle_invariant.py
@@ -1,0 +1,122 @@
+"""Slice 74 — Immutable Lifecycle Boundary Invariant.
+
+Telemetry (bt-2026-06-03-081821 Slice74Probe) proved the broker rendezvous works
+(same singleton, subs=1, ~1s wake) — so the prior 25-min lag was a transient on
+the COMPLETED/terminal write path, the prime suspect being a deduped ledger write
+(`written=False`) that skipped the SSE broadcast at `orchestrator._record_ledger`.
+
+The fix decouples the terminal SSE broadcast from the ledger's physical-write
+dedup: a definitive terminal state MUST notify the system even when the ledger
+deduped the row. Idempotency moves from the ledger gate to the notification
+layer (`_terminal_publish_once`) so it broadcasts exactly once, never zero, never
+twice — regardless of how many times `_record_ledger` fires for that state.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    publish_operation_terminal,
+    _terminal_publish_once,
+    _terminal_published_set,
+    _terminal_published_order,
+    reset_default_broker,
+    TERMINAL_OPERATION_STATES,
+)
+
+
+class _State:
+    def __init__(self, value: str):
+        self.value = value
+
+
+class _Ctx:
+    def __init__(self, op_id: str):
+        self.op_id = op_id
+        self.phase = None
+        self.phase_entered_at = None
+        self.terminal_reason_code = ""
+
+
+def _clear_idempotency():
+    _terminal_published_set.clear()
+    _terminal_published_order.clear()
+
+
+def _enable(monkeypatch):
+    monkeypatch.setenv("JARVIS_OP_LIFECYCLE_SSE_ENABLED", "true")
+    reset_default_broker()
+    _clear_idempotency()
+
+
+# --- The core invariant: terminal broadcast fires regardless of ledger dedup ---
+
+def test_terminal_broadcast_fires_for_terminal_state(monkeypatch):
+    """A terminal state ('applied' = success) broadcasts — the publish no longer
+    rides on the ledger's `written` flag (the orchestrator calls it
+    unconditionally; this verifies the publisher itself always fires)."""
+    _enable(monkeypatch)
+    ev = publish_operation_terminal(_Ctx("op-s74-applied"), _State("applied"))
+    assert ev is not None, "terminal broadcast must fire for 'applied'"
+
+
+def test_terminal_broadcast_fires_for_failed(monkeypatch):
+    _enable(monkeypatch)
+    ev = publish_operation_terminal(_Ctx("op-s74-failed"), _State("failed"))
+    assert ev is not None
+
+
+def test_exactly_once_idempotency(monkeypatch):
+    """Decoupled from `written`, the publisher must still fire EXACTLY once per
+    (op_id, state) — a deduped storage write gets the first broadcast, a repeat
+    invocation does NOT double-fire."""
+    _enable(monkeypatch)
+    ev1 = publish_operation_terminal(_Ctx("op-s74-once"), _State("applied"))
+    ev2 = publish_operation_terminal(_Ctx("op-s74-once"), _State("applied"))
+    assert ev1 is not None, "first terminal broadcast must fire"
+    assert ev2 is None, "repeat (op_id, state) must be deduped at the notify layer"
+
+
+def test_distinct_states_each_fire(monkeypatch):
+    _enable(monkeypatch)
+    a = publish_operation_terminal(_Ctx("op-s74-multi"), _State("applied"))
+    f = publish_operation_terminal(_Ctx("op-s74-multi"), _State("failed"))
+    assert a is not None and f is not None, "distinct terminal states each fire"
+
+
+def test_non_terminal_state_is_noop(monkeypatch):
+    _enable(monkeypatch)
+    ev = publish_operation_terminal(_Ctx("op-s74-mid"), _State("generating"))
+    assert ev is None, "non-terminal state must be a no-op"
+
+
+def test_publish_once_helper_semantics():
+    _clear_idempotency()
+    assert _terminal_publish_once("op-x", "applied") is True
+    assert _terminal_publish_once("op-x", "applied") is False  # repeat
+    assert _terminal_publish_once("op-x", "failed") is True    # different state
+    assert _terminal_publish_once("op-y", "applied") is True   # different op
+
+
+def test_terminal_states_are_lowercase_canonical():
+    # Guards the probe/test against the 'COMPLETED' mismatch that would have
+    # silently missed the success terminal ('applied').
+    assert "applied" in TERMINAL_OPERATION_STATES
+    assert "completed" not in TERMINAL_OPERATION_STATES
+
+
+# --- AST-pin: the orchestrator broadcast is decoupled from `written` ---
+
+def test_orchestrator_publishes_terminal_outside_written_gate():
+    src = (Path(__file__).resolve().parents[2]
+           / "backend/core/ouroboros/governance/orchestrator.py").read_text()
+    # The decoupled call must exist...
+    assert "_s74_publish_terminal(ctx, state)" in src
+    # ...and appear BEFORE the `if written:` block that follows the probe (i.e.
+    # not gated by the ledger write result).
+    pub_idx = src.index("_s74_publish_terminal(ctx, state)")
+    # The next `if written:` after the LEDGER_TERMINAL probe must come AFTER the
+    # decoupled publish.
+    probe_idx = src.index("[Slice74Probe] LEDGER_TERMINAL")
+    written_idx = src.index("if written:", probe_idx)
+    assert pub_idx < written_idx, "terminal publish must be decoupled from `if written`"


### PR DESCRIPTION
Instrument-first localized the ~25-min eval-wake lag: telemetry (Slice74Probe) proved the broker rendezvous works (same singleton, subs=1, ~1s wake, durable row appended), so the lag was a transient on the terminal write path — prime suspect a deduped ledger write skipping the SSE broadcast.

Root fix (not the falsified instance_id workaround): publish_operation_terminal is called UNCONDITIONALLY on _record_ledger (no-op for non-terminal states), decoupled from the `written` dedup; idempotency moved to the notification layer (_terminal_publish_once, exactly-once). 5 rendezvous probes retained as permanent observability. Probe fix: match the lowercase canonical terminal set ({applied,rolled_back,failed,blocked}; 'applied'=success).

Tests: test_slice74_lifecycle_invariant.py (8). 210 passed regression; 4 adjacent autoscore_wiring fails pre-existing (identical on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure terminal SSE broadcasts always fire on terminal states, even when the ledger write is deduped, removing missed eval wake-ups and the long-delay fallback. Idempotency now lives in the notification layer, so terminal events deliver exactly once.

- **Bug Fixes**
  - Decoupled terminal publish from the ledger `written` flag in `_record_ledger`.
  - Fixed terminal-state match to the lowercase canonical set: {applied, rolled_back, failed, blocked}.

- **New Features**
  - Added `_terminal_publish_once` (bounded, thread-safe) to enforce exactly-once delivery per (op_id, state).
  - Added lightweight Slice74 probes at subscribe, publish, ledger, and persistence seams for rendezvous telemetry.
  - Added tests to lock the lifecycle invariant and the decoupled publish behavior.

<sup>Written for commit 711c56e4463dcbb272559a9376282597f6126734. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

