### PR TITLE
feat(swe_bench_pro): Slice 75 — derived resolved field + tolerant multi-instance parsing

### DIFF
--- a/backend/core/ouroboros/governance/swe_bench_pro/harness_inject.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/harness_inject.py
@@ -44,6 +44,7 @@ import asyncio
 import enum
 import logging
 import os
+import re
 from typing import Any, List, Optional
 
 from backend.core.ouroboros.governance.swe_bench_pro.dataset_loader import (
@@ -155,7 +156,18 @@ def inject_instance_ids() -> List[str]:
     raw = os.environ.get(INJECT_INSTANCE_IDS_ENV_VAR, "").strip()
     if not raw:
         return []
-    return [s.strip() for s in raw.split(",") if s.strip()]
+    # Slice 75 — tolerant multi-instance delimiter. Accept comma- AND/OR
+    # whitespace-separated lists (operators paste either form;
+    # ``"a,b"`` / ``"a b"`` / ``"a, b"`` all parse identically). Order-
+    # preserving dedup so a repeated id is evaluated once, not N times.
+    seen: set = set()
+    out: List[str] = []
+    for s in re.split(r"[,\s]+", raw):
+        s = s.strip()
+        if s and s not in seen:
+            seen.add(s)
+            out.append(s)
+    return out
 
 
 def autoscore_enabled() -> bool:

--- a/backend/core/ouroboros/governance/swe_bench_pro/result_store.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/result_store.py
@@ -131,10 +131,30 @@ class EvaluationRecord:
             self.evaluation.op_id,
         )
 
+    @property
+    def resolved(self) -> bool:
+        """Canonical SWE-bench ``resolved`` — the held-out container suite
+        PASSED. Derived (not stored) from the authoritative outcomes:
+        True iff the eval reached scoring AND the score outcome is ``pass``.
+        ``partial``/``fail``/``scoring_error``/``skipped`` ⇒ False. Pure;
+        NEVER raises (a malformed outcome resolves to False, not None)."""
+        try:
+            return (
+                getattr(self.evaluation.outcome, "value", "") == "resolved"
+                and getattr(self.scoring.outcome, "value", "") == "pass"
+            )
+        except Exception:  # noqa: BLE001
+            return False
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "schema_version": self.schema_version,
             "recorded_at_iso": self.recorded_at_iso,
+            # Slice 75 — top-level derived `resolved` boolean so the durable
+            # ledger is directly queryable for pass-rate / report-card %
+            # without re-deriving from the nested eval+score outcomes. Always a
+            # concrete bool (never None) for clean aggregation.
+            "resolved": self.resolved,
             "evaluation": self.evaluation.to_dict(),
             "scoring": self.scoring.to_dict(),
         }

--- a/tests/governance/test_slice75_batch_serialization.py
+++ b/tests/governance/test_slice75_batch_serialization.py
@@ -1,0 +1,98 @@
+"""Slice 75 — Schema serialization parity + multi-instance batch parsing.
+
+Two additive, verify-first-corrected pieces (the runbook premises were off):
+  * The durable record had NO `resolved` field at all (the earlier `resolved:
+    None` was a parse artifact, not a bug). We ADD a derived top-level
+    `resolved: bool` so the ledger is directly queryable for pass-rate %.
+  * Multi-instance was already CSV-supported; we widen the parser to accept
+    comma AND/OR whitespace delimiters (order-preserving dedup).
+"""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.swe_bench_pro.evaluator import (
+    EvaluationResult,
+    EvaluationOutcome,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.scorer import (
+    ScoringResult,
+    ScoreOutcome,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.result_store import (
+    EvaluationRecord,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.harness_inject import (
+    inject_instance_ids,
+    INJECT_INSTANCE_IDS_ENV_VAR,
+)
+
+
+def _record(eval_outcome: EvaluationOutcome, score_outcome: ScoreOutcome) -> EvaluationRecord:
+    return EvaluationRecord(
+        evaluation=EvaluationResult(
+            outcome=eval_outcome, problem_instance_id="inst-x", op_id="op-1",
+        ),
+        scoring=ScoringResult(outcome=score_outcome, problem_instance_id="inst-x"),
+        recorded_at_iso="2026-06-03T00:00:00+00:00",
+    )
+
+
+# --- Phase 1: derived `resolved` boolean parity ---
+
+def test_resolved_true_only_on_eval_resolved_and_score_pass():
+    rec = _record(EvaluationOutcome.RESOLVED, ScoreOutcome.PASS)
+    assert rec.resolved is True
+    assert rec.to_dict()["resolved"] is True
+
+
+def test_resolved_false_on_non_pass_scores():
+    for sc in (ScoreOutcome.FAIL, ScoreOutcome.PARTIAL,
+               ScoreOutcome.SKIPPED, ScoreOutcome.SCORING_ERROR):
+        rec = _record(EvaluationOutcome.RESOLVED, sc)
+        assert rec.resolved is False, sc
+        assert rec.to_dict()["resolved"] is False, sc
+
+
+def test_resolved_false_when_eval_unresolved():
+    # Defensive: a 'pass' with an 'unresolved' eval should never count resolved.
+    rec = _record(EvaluationOutcome.UNRESOLVED, ScoreOutcome.PASS)
+    assert rec.resolved is False
+
+
+def test_resolved_is_always_concrete_bool_never_none():
+    rec = _record(EvaluationOutcome.UNRESOLVED, ScoreOutcome.SKIPPED)
+    val = rec.to_dict()["resolved"]
+    assert val is False and isinstance(val, bool)
+
+
+# --- Phase 2: tolerant multi-instance delimiter parsing ---
+
+def test_comma_delimited(monkeypatch):
+    monkeypatch.setenv(INJECT_INSTANCE_IDS_ENV_VAR, "a,b,c")
+    assert inject_instance_ids() == ["a", "b", "c"]
+
+
+def test_space_delimited(monkeypatch):
+    monkeypatch.setenv(INJECT_INSTANCE_IDS_ENV_VAR, "a b c")
+    assert inject_instance_ids() == ["a", "b", "c"]
+
+
+def test_mixed_comma_and_space(monkeypatch):
+    monkeypatch.setenv(INJECT_INSTANCE_IDS_ENV_VAR, "a, b,  c   d")
+    assert inject_instance_ids() == ["a", "b", "c", "d"]
+
+
+def test_order_preserving_dedup(monkeypatch):
+    monkeypatch.setenv(INJECT_INSTANCE_IDS_ENV_VAR, "a,b,a,c,b")
+    assert inject_instance_ids() == ["a", "b", "c"]
+
+
+def test_empty_and_whitespace_only(monkeypatch):
+    monkeypatch.setenv(INJECT_INSTANCE_IDS_ENV_VAR, "   ")
+    assert inject_instance_ids() == []
+    monkeypatch.delenv(INJECT_INSTANCE_IDS_ENV_VAR, raising=False)
+    assert inject_instance_ids() == []
+
+
+def test_single_instance_unchanged(monkeypatch):
+    monkeypatch.setenv(INJECT_INSTANCE_IDS_ENV_VAR, "instance_qutebrowser__foo")
+    assert inject_instance_ids() == ["instance_qutebrowser__foo"]


### PR DESCRIPTION
Verify-first: the prior 'resolved: None' was a parse artifact (no such field existed) — added a derived top-level resolved:bool (eval==resolved && score==pass) for queryable pass-rate. Multi-instance was already CSV; widened to comma AND/OR whitespace with order-preserving dedup. Also confirmed the runbook's 2nd instance (…b3c172) is fabricated — only …b3c171 is cached. 10 tests; 8 adjacent harness_inject fails pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a derived top-level `resolved` boolean to SWE Bench Pro results and makes multi-instance batch parsing accept commas and/or whitespace with order-preserving dedup. This simplifies pass-rate queries and makes operator input more tolerant.

- **New Features**
  - `EvaluationRecord.resolved`: True only when `evaluation.outcome == "resolved"` and `scoring.outcome == "pass"`; included in `to_dict` and always a concrete bool.
  - `inject_instance_ids()`: Splits `INJECT_INSTANCE_IDS_ENV_VAR` on commas or whitespace, preserves order, and dedups repeated IDs.

<sup>Written for commit abefdc061897adb32b0a60a60405d940b18f009f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

