### PR TITLE
feat(swe_bench_pro): EVAL-2 — macro report-card reporter + §50.10 first multi-instance sample (1/2=50%)

### DIFF
--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -11513,6 +11513,25 @@ The goal the operator named: evaluate O+V the way frontier AI labs evaluate agen
 
 **Anti-goals (per the operator binding):** never a parallel eval framework (extend `parallel_evaluate`); never hardcode instance IDs or sample membership (drive from `geometric_sampler` + env); never report a percentage without a methodology footnote + durable ledger backing it; never let a fast happy-path number hide the §50.4 caveats (provider, N, arch). Honest framing per `feedback_no_preresult_euphoria.md`: §50.9 is a *roadmap*, EVAL-1/EVAL-2 are the immediate next work, and the first published percentage is earned only after EVAL-2 runs clean.
 
+### §50.10 — First multi-instance sample (N=2): EVAL-1 closed, EVAL-2 seeded *(2026-06-03, session bt-2026-06-03-090724)*
+
+After **Slice 74** (instant terminal wake + durable persistence) and **Slice 75** (derived `resolved:bool` + tolerant multi-instance parsing), O+V ran its **first concurrent multi-instance batch** — the seed of the percentage program (§50.9 EVAL-2). Two SWE-Bench-Pro instances were parsed from a single comma-delimited token, prepared into **isolated per-problem `$TMPDIR` worktrees**, dispatched as **two distinct solve ops**, and each independently container-scored.
+
+**The result — O+V SWE-Bench-Pro, N=2 sample: 1/2 resolved = 50%:**
+
+| Instance | Repo | Held-out outcome | `resolved` |
+|---|---|---|---|
+| `instance_qutebrowser__…b3c171` | qutebrowser (Python) | `eval=resolved score=pass` — held-out suite (21 tests) PASSED | **True** |
+| `instance_element-hq__element-web-…vnan` | element-web (TypeScript) | `eval=resolved score=fail` — O+V produced a patch (`src/Markdown.ts` domain), container ran the 7 `Markdown-test.ts` held-out tests, patch did NOT pass | **False** |
+
+Both rows are durable in `.jarvis/swe_bench_pro/results.jsonl` with the Slice 75 `resolved` boolean populated correctly (`True` / `False`, no `None`). This simultaneously **closed EVAL-1** (durable, schemaful, queryable result ledger) and produced the first sample data point.
+
+**What this proves (and what it doesn't):**
+- ✅ The full pipeline scales from 1 → N: native stream parse, sandbox isolation, concurrent dispatch, per-instance container scoring, durable `resolved`-stamped rows.
+- ✅ O+V autonomously produced a coherent patch for BOTH unseen problems — including a **cross-language** result (a TypeScript repo it had never seen), even though that patch did not pass the held-out tests.
+- ⚠️ **N=2 is a seed, not a benchmark percentage.** 50% on two cherry-adjacent instances (one known-good Python, one known-good-but-harder TypeScript) is a methodology proof, not a citable rate. The honest, resume-grade statement remains: *"O+V resolved 1 of 2 SWE-Bench-Pro instances it attempted; one cross-language attempt produced a patch that failed the held-out suite."*
+- The defensible **rate** comes from EVAL-2 (the 6-instance cached sweep: qutebrowser + element-web known-good poles vs ansible×2 + NodeBB×2 known-hard poles) → `report_card.render_markdown(build_report_card(replay_from_disk(results.jsonl)))` → `resolved/6 = Y%` with a methodology footnote (N, Claude-served, Apple-Silicon arch caveat). That sweep is the immediate next work; this §50.10 row is appended with the N=6 result when it lands.
+
 ---
 
 ## Appendix D — Document History

--- a/scripts/swe_bench_pro_report.py
+++ b/scripts/swe_bench_pro_report.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""EVAL-2 — macro report card from the durable SWE-Bench-Pro result ledger.
+
+Reads ``.jarvis/swe_bench_pro/results.jsonl`` (the Slice 74/75 durable ledger),
+takes the LATEST verdict per ``instance_id`` (the ledger accumulates a row per
+solve-op across runs; for a sample percentage we want one verdict per problem),
+and renders a Markdown report with the headline ``resolved / N = Y%`` over the
+canonical Slice 75 ``resolved`` boolean.
+
+Leverages the canonical EvaluationRecord schema (``evaluation``/``scoring``/
+``resolved`` fields) — no new aggregation logic, no hardcoded instance ids. Scope
+to a sample with a comma/space-separated id list as argv[1]; omit to report every
+instance in the ledger.
+
+Usage:
+  python3 scripts/swe_bench_pro_report.py "id1,id2,..."   # scope to a sample
+  python3 scripts/swe_bench_pro_report.py                  # all instances
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+LEDGER = Path(".jarvis/swe_bench_pro/results.jsonl")
+
+
+def _short(instance_id: str) -> str:
+    # "instance_qutebrowser__qutebrowser-…b3c171" -> "qutebrowser…b3c171"
+    base = instance_id.split("__", 1)[1] if "__" in instance_id else instance_id
+    return base[:46]
+
+
+def _repo(instance_id: str) -> str:
+    m = re.match(r"instance_([^_]+(?:-[^_]+)*)__", instance_id)
+    return m.group(1) if m else instance_id.split("__", 1)[0]
+
+
+def build(target_ids):
+    if not LEDGER.exists():
+        return None, "no results.jsonl ledger found"
+    latest = {}  # instance_id -> row (file order is chronological; last wins)
+    for line in LEDGER.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        ev = r.get("evaluation") or {}
+        iid = ev.get("problem_instance_id") or ""
+        if iid:
+            latest[iid] = r
+    if target_ids:
+        rows = {k: v for k, v in latest.items() if k in target_ids}
+        # surface any requested instance that produced no row at all
+        for tid in target_ids:
+            rows.setdefault(tid, None)
+    else:
+        rows = latest
+    return rows, None
+
+
+def render(rows) -> str:
+    items = sorted(rows.items())
+    scored = [(k, v) for k, v in items if v is not None]
+    total = len(items)
+    resolved = sum(1 for _, v in scored if v.get("resolved") is True)
+    rate = (resolved / total * 100.0) if total else 0.0
+    out = []
+    out.append("# O+V — SWE-Bench-Pro Report Card")
+    out.append("")
+    out.append(f"## Resolved: **{resolved} / {total} = {rate:.1f}%**")
+    out.append("")
+    out.append("| Repo | Instance | eval_outcome | score_outcome | resolved |")
+    out.append("|---|---|---|---|:---:|")
+    for iid, r in items:
+        if r is None:
+            out.append(f"| {_repo(iid)} | {_short(iid)} | _(no row)_ | _(no row)_ | — |")
+            continue
+        ev = r.get("evaluation") or {}
+        sc = r.get("scoring") or {}
+        mark = "✅" if r.get("resolved") is True else "❌"
+        out.append(
+            f"| {_repo(iid)} | {_short(iid)} | {ev.get('outcome')} | "
+            f"{sc.get('outcome')} | {mark} |"
+        )
+    out.append("")
+    out.append(
+        "_Methodology: each instance is the latest durable verdict in "
+        "results.jsonl; `resolved` = held-out container suite passed "
+        "(eval=resolved AND score=pass). Provider: Claude. Platform: "
+        "linux/amd64 via Apple-Silicon emulation._"
+    )
+    return "\n".join(out)
+
+
+def main():
+    raw = sys.argv[1] if len(sys.argv) > 1 else ""
+    target_ids = [s for s in re.split(r"[,\s]+", raw.strip()) if s] or None
+    rows, err = build(target_ids)
+    if err:
+        print(err)
+        sys.exit(1)
+    print(render(rows))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds scripts/swe_bench_pro_report.py (durable-ledger → per-instance-latest → resolved/N=Y% Markdown report, leveraging the canonical schema + Slice 75 resolved field) and PRD §50.10 documenting the first multi-instance sample (qutebrowser RESOLVED, element-web patch failed held-out tests; 1/2=50%). Reporter verified on the live ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a macro report-card tool that reads the durable SWE-Bench-Pro ledger and outputs resolved/N, and documents the first multi-instance run (N=2) with 1/2 resolved (50%) to close EVAL-1 and seed EVAL-2.

- **New Features**
  - Added `scripts/swe_bench_pro_report.py`: reads `.jarvis/swe_bench_pro/results.jsonl`, takes the latest verdict per `instance_id`, and renders a Markdown report with `resolved / N = Y%`.
  - Uses the canonical `evaluation`/`scoring` schema and the Slice 75 `resolved` boolean; no hardcoded instance IDs. Optional scoping via comma/space-separated IDs.
  - Documented §50.10: first multi-instance sample — qutebrowser resolved (21 tests passed), element-web produced a patch but failed 7 held-out tests; reporter shows 1/2 = 50.0%. EVAL-1 is complete; EVAL-2 (6-instance sweep) follows.

<sup>Written for commit 59ea0ac377c593b9bb5a9676486f69d9bcceb8da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

