### PR TITLE
Slice 76 — Resilient Ingress: clone-race fix + DW pre-flight gate + dual-metric analytics + PR janitor

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -879,6 +879,62 @@ def _note_dw_candidate_success() -> None:
     except Exception:  # noqa: BLE001
         pass
 
+
+def dw_preflight_gate_enabled() -> bool:
+    """Slice 76 Phase 2 master flag — default TRUE. When off, dispatch is
+    byte-identical to the pre-Slice-76 path (no pre-flight short-circuit)."""
+    raw = os.environ.get(
+        "JARVIS_DW_PREFLIGHT_GATE_ENABLED", "true",
+    ).strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def _dw_preflight_freshness_s() -> float:
+    """Max age (seconds) of a TRANSPORT_DEGRADED surface verdict for the
+    pre-flight gate to act on it. Stale evidence is ignored so the gate never
+    starves DW on an old reading. Env-tunable; non-positive / invalid → 120s."""
+    raw = os.environ.get("JARVIS_DW_PREFLIGHT_FRESHNESS_S", "120").strip()
+    try:
+        val = float(raw)
+        return val if val > 0 else 120.0
+    except (ValueError, TypeError):
+        return 120.0
+
+
+def dw_transport_degraded_preflight() -> bool:
+    """Slice 76 Phase 2 — pre-flight DW transport health gate.
+
+    Consults the EXISTING ``dw_surface_health`` ledger (kept fresh by the
+    surface probes — NO new probe is issued here): returns True iff the
+    ``DIRECT_STREAMING`` surface carries a FRESH ``TRANSPORT_DEGRADED`` verdict.
+    That means the socket/TLS to the DW endpoint is down RIGHT NOW — every
+    ranked sibling model shares that dead transport (cf.
+    :func:`should_sever_dw_lane`), so the op should cascade to Claude with its
+    full budget BEFORE the ``_primary_sem`` wait + per-model timeout cascade
+    burns it (the EVAL-2 ``terminal_timeout``, PRD §50.11).
+
+    Conservative by construction: unknown / stale / HEALTHY / UPSTREAM_DEGRADED
+    (server responded — transport is up) all return False, so the DW lane
+    proceeds normally and we never starve DW on thin evidence. NEVER raises
+    (fail-open: a gate error must not block DW dispatch)."""
+    if not dw_preflight_gate_enabled():
+        return False
+    try:
+        from backend.core.ouroboros.governance.dw_surface_health import (
+            SurfaceHealthLedger,
+            SurfaceKind,
+            SurfaceVerdict,
+        )
+        rec = SurfaceHealthLedger(autosave=False).verdict_for(
+            SurfaceKind.DIRECT_STREAMING,
+        )
+        if rec is None or rec.verdict is not SurfaceVerdict.TRANSPORT_DEGRADED:
+            return False
+        age_s = time.time() - float(rec.last_probe_unix or 0.0)
+        return 0.0 <= age_s <= _dw_preflight_freshness_s()
+    except Exception:  # noqa: BLE001 — never block dispatch on a gate error
+        return False
+
 # ---------------------------------------------------------------------------
 # Content failure classification
 # ---------------------------------------------------------------------------
@@ -2913,6 +2969,26 @@ class CandidateGenerator:
                 provider_route,
             )
             return None
+
+        # Slice 76 Phase 2 — pre-flight DW transport gate. If the existing
+        # dw_surface_health ledger shows the DIRECT_STREAMING surface FRESHLY
+        # TRANSPORT_DEGRADED, the whole ranked list shares that dead transport
+        # (cf. should_sever_dw_lane). Cascade to Claude with the FULL untouched
+        # budget NOW — before the _primary_sem wait + per-model timeout cascade
+        # burns it (the EVAL-2 terminal_timeout, PRD §50.11). Only when the
+        # route already cascades to Claude (a "queue"-tolerance route keeps its
+        # contract). Gated + fail-open; default-on.
+        if (
+            fallback_tolerance == "cascade_to_claude"
+            and dw_transport_degraded_preflight()
+        ):
+            logger.info(
+                "[CandidateGenerator] Slice 76 pre-flight: DW DIRECT_STREAMING "
+                "TRANSPORT_DEGRADED (fresh) — severing DW lane pre-budget, "
+                "cascading to Claude with full budget (op=%s route=%s)",
+                getattr(context, "op_id", "?"), provider_route,
+            )
+            return await self._call_fallback(context, deadline)
 
         sentinel = get_default_sentinel()
         # Register every model in the ranked list (idempotent). The

--- a/backend/core/ouroboros/governance/swe_bench_pro/per_problem_harness.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/per_problem_harness.py
@@ -100,11 +100,16 @@ REPO_CACHE_PATH_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_REPO_CACHE_PATH"
 WORKTREE_BASE_PATH_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_WORKTREE_BASE_PATH"
 GIT_CLONE_TIMEOUT_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_GIT_CLONE_TIMEOUT_S"
 GIT_OP_TIMEOUT_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_GIT_OP_TIMEOUT_S"
+# Slice 76 (Resilient Ingress) — bounded purge-and-retry around the cold clone.
+CLONE_MAX_ATTEMPTS_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_CLONE_MAX_ATTEMPTS"
+CLONE_RETRY_BACKOFF_MS_ENV_VAR: str = "JARVIS_SWE_BENCH_PRO_CLONE_RETRY_BACKOFF_MS"
 
 _DEFAULT_REPO_CACHE_PATH: str = ".jarvis/swe_bench_pro/repo_cache"
 _DEFAULT_WORKTREE_BASE_PATH: str = ".jarvis/swe_bench_pro/worktrees"
 _DEFAULT_GIT_CLONE_TIMEOUT_S: int = 600  # 10 min
 _DEFAULT_GIT_OP_TIMEOUT_S: int = 60      # 1 min
+_DEFAULT_CLONE_MAX_ATTEMPTS: int = 3     # cold-clone attempts before fail-closed
+_DEFAULT_CLONE_RETRY_BACKOFF_MS: int = 500  # linear backoff base between attempts
 
 # Branch prefix for per-problem worktrees — distinct from L3
 # unit-* + L2 exercise ouroboros/l2-exercise/* branches.
@@ -224,6 +229,17 @@ def git_op_timeout_s() -> int:
     return _env_int(GIT_OP_TIMEOUT_ENV_VAR, _DEFAULT_GIT_OP_TIMEOUT_S)
 
 
+def clone_max_attempts() -> int:
+    return _env_int(CLONE_MAX_ATTEMPTS_ENV_VAR, _DEFAULT_CLONE_MAX_ATTEMPTS)
+
+
+def clone_retry_backoff_ms() -> int:
+    # minimum=0 so an operator (and the test suite) can disable backoff entirely.
+    return _env_int(
+        CLONE_RETRY_BACKOFF_MS_ENV_VAR, _DEFAULT_CLONE_RETRY_BACKOFF_MS, minimum=0,
+    )
+
+
 # ===========================================================================
 # Path sanitization
 # ===========================================================================
@@ -316,55 +332,105 @@ def _cached_repo_path_for(repo_url: str) -> Path:
     return repo_cache_path() / _sanitize_for_filename(cleaned)
 
 
+# Slice 76 (Resilient Ingress) — per-repo-path clone lock registry. Concurrent
+# same-repo cold clones (e.g. two ansible instances at different commits, EVAL-2
+# PRD §50.11) would otherwise race into the SAME cache path and the second
+# aborts with ``rc=128 destination already exists and is not empty``. Keying the
+# lock per target path serializes ONLY same-repo clones — distinct repos still
+# clone concurrently. Locks live on the single asyncio loop, so plain-dict
+# lazy creation is race-free (no await between membership check and insert).
+_repo_clone_locks: Dict[str, "asyncio.Lock"] = {}
+
+
+def _clone_lock_for(target: Path) -> "asyncio.Lock":
+    key = str(target)
+    lock = _repo_clone_locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _repo_clone_locks[key] = lock
+    return lock
+
+
 async def _ensure_repo_cached(repo_url: str) -> Optional[Path]:
     """Ensure the upstream repo is cloned into the cache.  Returns
-    the cache path on success, None on failure.  Idempotent."""
+    the cache path on success, None on failure.  Idempotent.
+
+    Slice 76 (Resilient Ingress): the clone critical section is guarded by a
+    per-repo-path :class:`asyncio.Lock` so concurrent same-repo cold clones
+    SERIALIZE — the second caller waits and then takes the now-valid cache-hit
+    instead of racing into the same directory (the EVAL-2 ``rc=128`` race, PRD
+    §50.11). Within the lock a bounded purge-and-retry recovers from a stale /
+    partial cache dir left by a crashed prior run (or a genuine transient
+    upstream blip), fail-closing to ``None`` only after the attempt budget.
+    """
     if not repo_url.strip():
         logger.warning("[SWEBenchPro] empty repo_url — cannot cache")
         return None
     target = _cached_repo_path_for(repo_url)
-    try:
-        if target.is_dir() and (target / ".git").is_dir():
-            return target
-        target.parent.mkdir(parents=True, exist_ok=True)
-        if target.is_dir():
-            shutil.rmtree(str(target), ignore_errors=True)
-        # ``--template=`` (empty string) disables template-hook copying
-        # from git's global templates directory. SWE-Bench-Pro clones
-        # don't need or want pre-commit / commit-msg / etc. hooks —
-        # they're benchmark eval substrates, not contributor checkouts.
-        # As a side effect this also unblocks restricted environments
-        # where git's global templates dir is non-writable (a real
-        # failure mode observed in stage-1 wiring soak 2026-05-12:
-        # ``fatal: cannot copy '/opt/homebrew/opt/git/share/git-core/
-        # templates/hooks/commit-msg.sample' to ...``). The flag is
-        # AST-pinned by the spine to prevent drift.
-        rc, _stdout, stderr = await _run_git(
-            [
-                "clone",
-                "--filter=blob:none",
-                "--template=",  # AST-pinned: benchmark cleanliness
-                repo_url,
-                str(target),
-            ],
-            timeout_s=git_clone_timeout_s(),
-        )
-        if rc != 0:
-            logger.warning(
-                "[SWEBenchPro] git clone %r failed rc=%d: %s",
-                repo_url, rc, stderr.strip()[:200],
-            )
-            shutil.rmtree(str(target), ignore_errors=True)
-            return None
+    # Fast-path OUTSIDE the lock: an already-valid cache never contends.
+    if target.is_dir() and (target / ".git").is_dir():
         return target
-    except asyncio.CancelledError:
-        raise
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "[SWEBenchPro] _ensure_repo_cached raised for %r",
-            repo_url, exc_info=True,
-        )
-        return None
+    async with _clone_lock_for(target):
+        try:
+            # Double-checked under the lock: a sibling caller may have populated
+            # the cache while we waited — take the cache-hit, skip the clone.
+            if target.is_dir() and (target / ".git").is_dir():
+                return target
+            target.parent.mkdir(parents=True, exist_ok=True)
+            max_attempts = clone_max_attempts()
+            backoff_ms = clone_retry_backoff_ms()
+            last_stderr = ""
+            for attempt in range(1, max_attempts + 1):
+                # Purge any stale / partial dir before EACH attempt — a crashed
+                # prior clone, or this loop's own prior failed attempt, leaves a
+                # non-empty non-``.git`` directory that git refuses to clone into.
+                if target.exists():
+                    shutil.rmtree(str(target), ignore_errors=True)
+                # ``--template=`` (empty string) disables template-hook copying
+                # from git's global templates directory. SWE-Bench-Pro clones
+                # don't need or want pre-commit / commit-msg / etc. hooks —
+                # they're benchmark eval substrates, not contributor checkouts.
+                # As a side effect this also unblocks restricted environments
+                # where git's global templates dir is non-writable (a real
+                # failure mode observed in stage-1 wiring soak 2026-05-12:
+                # ``fatal: cannot copy '/opt/homebrew/opt/git/share/git-core/
+                # templates/hooks/commit-msg.sample' to ...``). The flag is
+                # AST-pinned by the spine to prevent drift.
+                rc, _stdout, stderr = await _run_git(
+                    [
+                        "clone",
+                        "--filter=blob:none",
+                        "--template=",  # AST-pinned: benchmark cleanliness
+                        repo_url,
+                        str(target),
+                    ],
+                    timeout_s=git_clone_timeout_s(),
+                )
+                if rc == 0:
+                    return target
+                last_stderr = stderr.strip()[:200]
+                logger.warning(
+                    "[SWEBenchPro] git clone %r attempt %d/%d failed rc=%d: %s",
+                    repo_url, attempt, max_attempts, rc, last_stderr,
+                )
+                if attempt < max_attempts and backoff_ms > 0:
+                    # Linear backoff — let a transient upstream blip clear
+                    # before the next purge-and-retry.
+                    await asyncio.sleep((backoff_ms / 1000.0) * attempt)
+            shutil.rmtree(str(target), ignore_errors=True)
+            logger.warning(
+                "[SWEBenchPro] git clone %r exhausted %d attempt(s): %s",
+                repo_url, max_attempts, last_stderr,
+            )
+            return None
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[SWEBenchPro] _ensure_repo_cached raised for %r",
+                repo_url, exc_info=True,
+            )
+            return None
 
 
 # ===========================================================================

--- a/backend/core/ouroboros/governance/swe_bench_pro/result_store.py
+++ b/backend/core/ouroboros/governance/swe_bench_pro/result_store.py
@@ -56,6 +56,7 @@ empty tuple on internal failure.
 from __future__ import annotations
 
 import asyncio
+import enum
 import json
 import logging
 import os
@@ -63,7 +64,7 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from backend.core.ouroboros.governance.cross_process_jsonl import (
     flock_append_line,
@@ -107,6 +108,26 @@ _DEFAULT_RESULT_PATH: str = ".jarvis/swe_bench_pro/results.jsonl"
 # ===========================================================================
 
 
+class EvaluationCategory(str, enum.Enum):
+    """Slice 76 Phase 3 — the dual-metric analytics category derived from the
+    authoritative (eval, score) outcomes (PRD §50.11). Closed taxonomy.
+
+    Separates a *capability* verdict from an *infrastructure* exclusion so the
+    strict and operational (fairly-attempted) pass rates are computed natively,
+    never by manual recalculation.
+    """
+
+    #: eval=resolved AND score=pass — held-out container suite passed.
+    RESOLVED = "resolved"
+    #: the model got a fair shot and did not pass (eval=resolved fail/partial,
+    #: or eval=unresolved — failed to produce a working fix). NEVER excluded.
+    CAPABILITY_MISS = "capability_miss"
+    #: the op never got a fair attempt (prepare_failed / terminal_timeout) or
+    #: the patch existed but scoring infra broke (scoring_error). Excluded from
+    #: the OPERATIONAL denominator — not a capability failure.
+    INFRASTRUCTURE_EXCLUSION = "infrastructure_exclusion"
+
+
 @dataclass(frozen=True)
 class EvaluationRecord:
     """One (evaluation, scoring) pair persisted to the result store.
@@ -146,6 +167,29 @@ class EvaluationRecord:
         except Exception:  # noqa: BLE001
             return False
 
+    @property
+    def category(self) -> EvaluationCategory:
+        """Slice 76 Phase 3 — derived dual-metric category (PRD §50.11). Pure;
+        NEVER raises. Ordering is load-bearing: the never-fairly-attempted infra
+        cases are caught first so they are excluded from capability, while a
+        model that got a fair shot and failed (incl. eval=unresolved) is a
+        CAPABILITY_MISS — the derivation never flatters the model."""
+        try:
+            eval_v = getattr(self.evaluation.outcome, "value", "")
+            score_v = getattr(self.scoring.outcome, "value", "")
+            if eval_v == "resolved" and score_v == "pass":
+                return EvaluationCategory.RESOLVED
+            # never got a fair attempt (preparation / provider) → excluded
+            if eval_v in ("prepare_failed", "terminal_timeout"):
+                return EvaluationCategory.INFRASTRUCTURE_EXCLUSION
+            # the patch was produced but scoring infra broke → excluded
+            if eval_v == "resolved" and score_v == "scoring_error":
+                return EvaluationCategory.INFRASTRUCTURE_EXCLUSION
+            # the model got a fair shot and did not pass → capability failure
+            return EvaluationCategory.CAPABILITY_MISS
+        except Exception:  # noqa: BLE001
+            return EvaluationCategory.INFRASTRUCTURE_EXCLUSION
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "schema_version": self.schema_version,
@@ -155,6 +199,10 @@ class EvaluationRecord:
             # without re-deriving from the nested eval+score outcomes. Always a
             # concrete bool (never None) for clean aggregation.
             "resolved": self.resolved,
+            # Slice 76 Phase 3 — derived dual-metric category (RESOLVED /
+            # CAPABILITY_MISS / INFRASTRUCTURE_EXCLUSION) for native strict-vs-
+            # operational rate aggregation without re-deriving from outcomes.
+            "category": self.category.value,
             "evaluation": self.evaluation.to_dict(),
             "scoring": self.scoring.to_dict(),
         }
@@ -171,6 +219,41 @@ class EvaluationRecord:
             evaluation=evaluation,
             scoring=scoring,
         )
+
+
+def dual_metric_rates(records: Iterable["EvaluationRecord"]) -> Dict[str, Any]:
+    """Slice 76 Phase 3 — native strict-vs-operational aggregation (PRD §50.11).
+
+    Buckets records by :class:`EvaluationCategory` and returns both honest
+    rates with zero manual recalculation:
+
+      * ``strict_rate``      = resolved / total (every row counted).
+      * ``operational_rate`` = resolved / fairly_attempted, where
+        ``fairly_attempted = total − infrastructure_exclusion`` (the cases that
+        never got a fair shot are excluded — NOT the capability misses).
+
+    Pure; never raises. Empty input → all-zero rates (no division by zero).
+    """
+    counts = {c.value: 0 for c in EvaluationCategory}
+    total = 0
+    for rec in records:
+        total += 1
+        try:
+            counts[rec.category.value] += 1
+        except Exception:  # noqa: BLE001 — a malformed row counts as infra
+            counts[EvaluationCategory.INFRASTRUCTURE_EXCLUSION.value] += 1
+    resolved = counts[EvaluationCategory.RESOLVED.value]
+    excluded = counts[EvaluationCategory.INFRASTRUCTURE_EXCLUSION.value]
+    fairly = total - excluded
+    return {
+        "resolved": resolved,
+        "capability_miss": counts[EvaluationCategory.CAPABILITY_MISS.value],
+        "infrastructure_exclusion": excluded,
+        "total": total,
+        "fairly_attempted": fairly,
+        "strict_rate": (resolved / total) if total else 0.0,
+        "operational_rate": (resolved / fairly) if fairly else 0.0,
+    }
 
 
 # ===========================================================================

--- a/scripts/swe_bench_pro_report.py
+++ b/scripts/swe_bench_pro_report.py
@@ -63,36 +63,75 @@ def build(target_ids):
     return rows, None
 
 
+_CATEGORY_MARK = {
+    "resolved": "✅ resolved",
+    "capability_miss": "❌ capability_miss",
+    "infrastructure_exclusion": "⚠️ infra_exclusion",
+}
+
+
+def _category(row) -> str:
+    """Slice 76 Phase 3 — read the persisted `category` if present, else derive
+    it from the (eval, score) outcomes (back-compat for pre-Slice-76 rows).
+    Mirrors result_store.EvaluationRecord.category exactly."""
+    cat = row.get("category")
+    if cat in _CATEGORY_MARK:
+        return cat
+    ev = ((row.get("evaluation") or {}).get("outcome")) or ""
+    sc = ((row.get("scoring") or {}).get("outcome")) or ""
+    if ev == "resolved" and sc == "pass":
+        return "resolved"
+    if ev in ("prepare_failed", "terminal_timeout"):
+        return "infrastructure_exclusion"
+    if ev == "resolved" and sc == "scoring_error":
+        return "infrastructure_exclusion"
+    return "capability_miss"
+
+
 def render(rows) -> str:
     items = sorted(rows.items())
-    scored = [(k, v) for k, v in items if v is not None]
+    cats = {iid: (_category(v) if v is not None else None) for iid, v in items}
     total = len(items)
-    resolved = sum(1 for _, v in scored if v.get("resolved") is True)
-    rate = (resolved / total * 100.0) if total else 0.0
+    # a requested instance that produced NO row at all never got a fair attempt
+    resolved = sum(1 for c in cats.values() if c == "resolved")
+    excluded = sum(1 for c in cats.values()
+                   if c == "infrastructure_exclusion" or c is None)
+    cap_miss = sum(1 for c in cats.values() if c == "capability_miss")
+    fairly = total - excluded
+    strict = (resolved / total * 100.0) if total else 0.0
+    operational = (resolved / fairly * 100.0) if fairly else 0.0
     out = []
     out.append("# O+V — SWE-Bench-Pro Report Card")
     out.append("")
-    out.append(f"## Resolved: **{resolved} / {total} = {rate:.1f}%**")
+    out.append(f"## Strict: **{resolved} / {total} = {strict:.1f}%**  ·  "
+               f"Operational (fairly-attempted): **{resolved} / {fairly} = "
+               f"{operational:.1f}%**")
     out.append("")
-    out.append("| Repo | Instance | eval_outcome | score_outcome | resolved |")
+    out.append(f"- ✅ resolved: **{resolved}**  ·  ❌ capability_miss: "
+               f"**{cap_miss}**  ·  ⚠️ infrastructure_exclusion: **{excluded}**")
+    out.append("")
+    out.append("| Repo | Instance | eval_outcome | score_outcome | category |")
     out.append("|---|---|---|---|:---:|")
     for iid, r in items:
         if r is None:
-            out.append(f"| {_repo(iid)} | {_short(iid)} | _(no row)_ | _(no row)_ | — |")
+            out.append(f"| {_repo(iid)} | {_short(iid)} | _(no row)_ | "
+                       f"_(no row)_ | ⚠️ infra_exclusion |")
             continue
         ev = r.get("evaluation") or {}
         sc = r.get("scoring") or {}
-        mark = "✅" if r.get("resolved") is True else "❌"
         out.append(
             f"| {_repo(iid)} | {_short(iid)} | {ev.get('outcome')} | "
-            f"{sc.get('outcome')} | {mark} |"
+            f"{sc.get('outcome')} | {_CATEGORY_MARK.get(cats[iid] or '', cats[iid] or '?')} |"
         )
     out.append("")
     out.append(
         "_Methodology: each instance is the latest durable verdict in "
-        "results.jsonl; `resolved` = held-out container suite passed "
-        "(eval=resolved AND score=pass). Provider: Claude. Platform: "
-        "linux/amd64 via Apple-Silicon emulation._"
+        "results.jsonl. **Strict** counts every row; **Operational** excludes "
+        "`infrastructure_exclusion` rows (prepare_failed / terminal_timeout / "
+        "scoring_error — never a fair attempt), NOT the capability misses. "
+        "`resolved` = held-out container suite passed (eval=resolved AND "
+        "score=pass). Provider: Claude. Platform: linux/amd64 via Apple-Silicon "
+        "emulation._"
     )
     return "\n".join(out)
 

--- a/scripts/utils/async_pr_janitor.py
+++ b/scripts/utils/async_pr_janitor.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Async token-bucket PR janitor — drains the runaway ``app/github-actions``
+"🚨 Fix CI/CD" bot-PR backlog at a GitHub-safe pace, never touching a human PR.
+
+Context (Slice 76 Phase 5, PRD §50.11 follow-on): a misconfigured
+``failed-ci-auto-pr.yml`` (``workflows: ["*"]`` + no loop-guard) opened **67,744**
+``app/github-actions`` "Fix CI/CD" pull requests against ``drussell23/JARVIS``.
+The workflow is disabled (backlog cannot grow); this drains the standing debt.
+
+Safety — a closed PR is irreversible, so the close gate is *defense-in-depth*:
+a PR is closed ONLY IF **all** hold (``should_close``):
+  1. its number is NOT in the immutable :data:`PROTECTED_PR_IDS` backstop;
+  2. the author is positively a bot (``author.type == "Bot"``) ...
+  3. ... whose login is a known CI-bot login; and
+  4. the title is the exact runaway pattern (``🚨 Fix CI/CD``).
+A human PR fails gate 2/3/4 even if (1) were ever stale. The author/title filters
+are the *dynamic primary* gate; the hardcoded ID set is the explicit backstop.
+
+Rate discipline (GitHub secondary limits punish concurrent mutations): closes run
+SERIALLY through a token bucket (default ~1 close/s) and parse ``Retry-After`` +
+``x-ratelimit-remaining``/``-reset`` headers, applying adaptive exponential backoff
+on 403/429. A JSONL checkpoint makes the multi-hour drain resumable + auditable.
+
+Usage:
+  python3 scripts/utils/async_pr_janitor.py            # drain (live)
+  python3 scripts/utils/async_pr_janitor.py --dry-run  # log gate decisions only
+  RATE_PER_S=0.5 python3 scripts/utils/async_pr_janitor.py
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+REPO = os.environ.get("PR_JANITOR_REPO", "drussell23/JARVIS")
+API = "https://api.github.com"
+
+# Immutable backstop — the verified human PRs that must NEVER be closed.
+PROTECTED_PR_IDS = frozenset(
+    {36818, 35182, 31230, 29868, 21835, 21154, 19664, 253, 181, 158, 134, 113, 106}
+)
+# Known CI-bot author logins (search API renders "app/github-actions"; the REST
+# pulls API renders "github-actions[bot]" — accept both).
+BOT_LOGINS = frozenset({"app/github-actions", "github-actions[bot]"})
+BOT_TITLE_PREFIX = "🚨 Fix CI/CD"
+
+CHECKPOINT = Path(os.environ.get(
+    "PR_JANITOR_CHECKPOINT", ".jarvis/pr_janitor_checkpoint.jsonl"
+))
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [PRJanitor] %(message)s",
+)
+logger = logging.getLogger("pr_janitor")
+
+
+# ---------------------------------------------------------------------------
+# Pure, unit-testable core
+# ---------------------------------------------------------------------------
+
+def should_close(pr: Dict[str, Any], *, protected=PROTECTED_PR_IDS) -> bool:
+    """Defense-in-depth close gate. Returns True ONLY for a runaway bot PR.
+
+    Pure function — every closure decision flows through here so the
+    "never close a human PR" invariant is one testable predicate.
+    """
+    number = pr.get("number")
+    if not isinstance(number, int) or number in protected:
+        return False
+    user = pr.get("user") or {}
+    if user.get("type") != "Bot":
+        return False
+    if user.get("login") not in BOT_LOGINS:
+        return False
+    title = pr.get("title") or ""
+    return title.startswith(BOT_TITLE_PREFIX)
+
+
+def compute_backoff(attempt: int, retry_after: Optional[float], *, base: float = 2.0,
+                    cap: float = 300.0) -> float:
+    """Adaptive backoff: honor an explicit Retry-After, else exponential
+    (base^attempt) clamped to ``cap``. Never negative."""
+    if retry_after is not None and retry_after > 0:
+        return min(float(retry_after), cap)
+    return min(base ** max(0, attempt), cap)
+
+
+def _load_done(checkpoint: Path) -> set[int]:
+    done: set[int] = set()
+    if not checkpoint.exists():
+        return done
+    for line in checkpoint.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+            n = row.get("number")
+            if isinstance(n, int):
+                done.add(n)
+        except (ValueError, TypeError):
+            continue
+    return done
+
+
+# ---------------------------------------------------------------------------
+# GitHub I/O (async)
+# ---------------------------------------------------------------------------
+
+def _auth_token() -> str:
+    tok = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if tok:
+        return tok.strip()
+    env = {**os.environ, "PATH": "/opt/homebrew/bin:" + os.environ.get("PATH", "")}
+    out = subprocess.run(
+        ["gh", "auth", "token"], capture_output=True, text=True, env=env, check=False,
+    )
+    return out.stdout.strip()
+
+
+def _headers(token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def _retry_after_from(headers: Dict[str, str]) -> Optional[float]:
+    ra = headers.get("Retry-After") or headers.get("retry-after")
+    if ra:
+        try:
+            return float(ra)
+        except (ValueError, TypeError):
+            return None
+    # secondary-limit signal: remaining == 0 → wait until reset
+    rem = headers.get("X-RateLimit-Remaining") or headers.get("x-ratelimit-remaining")
+    reset = headers.get("X-RateLimit-Reset") or headers.get("x-ratelimit-reset")
+    if rem == "0" and reset:
+        try:
+            return max(0.0, float(reset) - time.time())
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+async def _fetch_open_page(session, token: str, per_page: int) -> List[Dict[str, Any]]:
+    """Fetch the newest page of open PRs (we close as we go, so re-fetching
+    the first page each round walks the shrinking set without cursor drift)."""
+    url = f"{API}/repos/{REPO}/pulls?state=open&per_page={per_page}&sort=created&direction=desc"
+    async with session.get(url, headers=_headers(token)) as resp:
+        if resp.status != 200:
+            ra = _retry_after_from(dict(resp.headers))
+            return [{"__error__": resp.status, "__retry_after__": ra}]
+        return await resp.json()
+
+
+async def _close_pr(session, token: str, number: int) -> Tuple[bool, Optional[float]]:
+    url = f"{API}/repos/{REPO}/pulls/{number}"
+    async with session.patch(url, headers=_headers(token),
+                             json={"state": "closed"}) as resp:
+        if resp.status == 200:
+            return True, None
+        ra = _retry_after_from(dict(resp.headers))
+        return False, ra if ra is not None else 0.0
+
+
+async def run(rate_per_s: float, dry_run: bool, max_closes: Optional[int]) -> int:
+    import aiohttp  # local import so unit tests of the pure core need no dep
+
+    token = _auth_token()
+    if not token:
+        logger.error("no GitHub token (GH_TOKEN / gh auth token) — aborting")
+        return 0
+    CHECKPOINT.parent.mkdir(parents=True, exist_ok=True)
+    done = _load_done(CHECKPOINT)
+    min_interval = 1.0 / rate_per_s if rate_per_s > 0 else 1.0
+    closed = 0
+    attempt = 0
+    logger.info("janitor start repo=%s protected=%d already_done=%d dry_run=%s",
+                REPO, len(PROTECTED_PR_IDS), len(done), dry_run)
+    async with aiohttp.ClientSession() as session:
+        while True:
+            if max_closes is not None and closed >= max_closes:
+                logger.info("reached --max-closes=%d — stopping", max_closes)
+                break
+            page = await _fetch_open_page(session, token, 100)
+            if page and page[0].get("__error__"):
+                wait = compute_backoff(attempt, page[0].get("__retry_after__"))
+                attempt += 1
+                logger.warning("list rate-limited (status=%s) backoff %.1fs",
+                               page[0].get("__error__"), wait)
+                await asyncio.sleep(wait)
+                continue
+            attempt = 0
+            closable = [p for p in page if should_close(p) and p["number"] not in done]
+            if not closable:
+                # page is all human/protected/already-done → backlog drained
+                remaining_bot = [p for p in page if should_close(p)]
+                if not remaining_bot:
+                    logger.info("no closable bot PRs on newest page — DRAINED. "
+                                "total closed this run=%d", closed)
+                    break
+                # everything closable is already in `done` (resumed) — skip ahead
+                for p in remaining_bot:
+                    done.discard(p["number"])  # force re-close (idempotent)
+            for p in closable:
+                n = p["number"]
+                if dry_run:
+                    logger.info("[dry-run] would close #%d %s", n, p.get("title", "")[:50])
+                    done.add(n)
+                    closed += 1
+                    continue
+                ok, ra = await _close_pr(session, token, n)
+                if ok:
+                    closed += 1
+                    done.add(n)
+                    with CHECKPOINT.open("a", encoding="utf-8") as fh:
+                        fh.write(json.dumps({"number": n, "ts": time.time()}) + "\n")
+                    if closed % 50 == 0:
+                        logger.info("closed=%d (latest #%d)", closed, n)
+                    await asyncio.sleep(min_interval)
+                else:
+                    wait = compute_backoff(attempt, ra)
+                    attempt += 1
+                    logger.warning("close #%d throttled — backoff %.1fs", n, wait)
+                    await asyncio.sleep(wait)
+                if max_closes is not None and closed >= max_closes:
+                    break
+    logger.info("janitor done — closed=%d", closed)
+    return closed
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Async bot-PR janitor")
+    ap.add_argument("--dry-run", action="store_true", help="log gate decisions, close nothing")
+    ap.add_argument("--rate-per-s", type=float,
+                    default=float(os.environ.get("RATE_PER_S", "1.0")),
+                    help="sustained close throughput (default 1/s — GitHub-safe)")
+    ap.add_argument("--max-closes", type=int, default=None,
+                    help="stop after N closes (for a bounded first batch)")
+    args = ap.parse_args()
+    asyncio.run(run(args.rate_per_s, args.dry_run, args.max_closes))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/governance/test_slice76_dual_metric.py
+++ b/tests/governance/test_slice76_dual_metric.py
@@ -1,0 +1,119 @@
+"""Slice 76 Phase 3 — programmatic dual-metric categorization.
+
+Adds a derived ``EvaluationCategory`` (RESOLVED / CAPABILITY_MISS /
+INFRASTRUCTURE_EXCLUSION) to the durable ledger so the strict vs.
+fairly-attempted rates (PRD §50.11) are computed natively, never by manual text.
+
+Honesty contract (the load-bearing distinction):
+  * RESOLVED               — eval=resolved AND score=pass.
+  * INFRASTRUCTURE_EXCLUSION — the op never got a fair attempt: eval
+    prepare_failed / terminal_timeout, or eval=resolved but scoring_error.
+    These are excluded from the OPERATIONAL denominator (not capability).
+  * CAPABILITY_MISS        — the model got a fair shot and did not pass:
+    eval=resolved with fail/partial, OR eval=unresolved (failed to produce a
+    working fix). Counts against capability — NEVER flatters the model.
+"""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.swe_bench_pro.evaluator import (
+    EvaluationResult,
+    EvaluationOutcome,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.scorer import (
+    ScoringResult,
+    ScoreOutcome,
+)
+from backend.core.ouroboros.governance.swe_bench_pro.result_store import (
+    EvaluationRecord,
+    EvaluationCategory,
+)
+
+
+def _rec(eo: EvaluationOutcome, so: ScoreOutcome) -> EvaluationRecord:
+    return EvaluationRecord(
+        evaluation=EvaluationResult(outcome=eo, problem_instance_id="i", op_id="o"),
+        scoring=ScoringResult(outcome=so, problem_instance_id="i"),
+        recorded_at_iso="2026-06-03T00:00:00+00:00",
+    )
+
+
+# --- the three categories, mapped to the exact EVAL-2 rows (§50.11) ---
+
+def test_resolved_category():
+    rec = _rec(EvaluationOutcome.RESOLVED, ScoreOutcome.PASS)  # qutebrowser
+    assert rec.category is EvaluationCategory.RESOLVED
+    assert rec.to_dict()["category"] == "resolved"
+
+
+def test_capability_miss_on_resolved_fail():
+    rec = _rec(EvaluationOutcome.RESOLVED, ScoreOutcome.FAIL)  # element-web, NodeBB-76c6
+    assert rec.category is EvaluationCategory.CAPABILITY_MISS
+    assert rec.to_dict()["category"] == "capability_miss"
+
+
+def test_capability_miss_on_resolved_partial():
+    assert _rec(EvaluationOutcome.RESOLVED, ScoreOutcome.PARTIAL).category \
+        is EvaluationCategory.CAPABILITY_MISS
+
+
+def test_capability_miss_on_unresolved_never_flatters_model():
+    # model failed to produce a working fix — a capability failure, NOT excluded
+    assert _rec(EvaluationOutcome.UNRESOLVED, ScoreOutcome.SKIPPED).category \
+        is EvaluationCategory.CAPABILITY_MISS
+
+
+def test_infra_exclusion_on_prepare_failed():
+    rec = _rec(EvaluationOutcome.PREPARE_FAILED, ScoreOutcome.SKIPPED)  # ansible×2
+    assert rec.category is EvaluationCategory.INFRASTRUCTURE_EXCLUSION
+    assert rec.to_dict()["category"] == "infrastructure_exclusion"
+
+
+def test_infra_exclusion_on_terminal_timeout():
+    rec = _rec(EvaluationOutcome.TERMINAL_TIMEOUT, ScoreOutcome.SKIPPED)  # NodeBB-04998908
+    assert rec.category is EvaluationCategory.INFRASTRUCTURE_EXCLUSION
+
+
+def test_infra_exclusion_on_scoring_error_despite_resolved():
+    # the patch existed but scoring infra broke — not a capability verdict
+    assert _rec(EvaluationOutcome.RESOLVED, ScoreOutcome.SCORING_ERROR).category \
+        is EvaluationCategory.INFRASTRUCTURE_EXCLUSION
+
+
+def test_category_is_consistent_with_resolved_bool():
+    # category==RESOLVED iff the Slice 75 resolved bool is True
+    for eo in EvaluationOutcome:
+        for so in ScoreOutcome:
+            rec = _rec(eo, so)
+            assert (rec.category is EvaluationCategory.RESOLVED) == rec.resolved, (eo, so)
+
+
+# --- dual-metric aggregation helper (strict vs operational) ---
+
+def test_dual_metric_rates_match_eval2():
+    rows = [
+        _rec(EvaluationOutcome.RESOLVED, ScoreOutcome.PASS),          # resolved
+        _rec(EvaluationOutcome.RESOLVED, ScoreOutcome.FAIL),          # cap miss
+        _rec(EvaluationOutcome.RESOLVED, ScoreOutcome.FAIL),          # cap miss
+        _rec(EvaluationOutcome.TERMINAL_TIMEOUT, ScoreOutcome.SKIPPED),  # infra
+        _rec(EvaluationOutcome.PREPARE_FAILED, ScoreOutcome.SKIPPED),    # infra
+        _rec(EvaluationOutcome.PREPARE_FAILED, ScoreOutcome.SKIPPED),    # infra
+    ]
+    from backend.core.ouroboros.governance.swe_bench_pro.result_store import (
+        dual_metric_rates,
+    )
+    m = dual_metric_rates(rows)
+    assert m["resolved"] == 1
+    assert m["capability_miss"] == 2
+    assert m["infrastructure_exclusion"] == 3
+    assert m["total"] == 6
+    assert m["fairly_attempted"] == 3
+    assert abs(m["strict_rate"] - (1 / 6)) < 1e-9
+    assert abs(m["operational_rate"] - (1 / 3)) < 1e-9
+
+
+def test_dual_metric_handles_empty():
+    from backend.core.ouroboros.governance.swe_bench_pro.result_store import (
+        dual_metric_rates,
+    )
+    m = dual_metric_rates([])
+    assert m["total"] == 0 and m["strict_rate"] == 0.0 and m["operational_rate"] == 0.0

--- a/tests/governance/test_slice76_ingress_resilience.py
+++ b/tests/governance/test_slice76_ingress_resilience.py
@@ -1,0 +1,187 @@
+"""Slice 76 — Resilient Ingress: concurrent same-repo clone serialization + retry.
+
+Root cause (EVAL-2, session bt-2026-06-03-094511, PRD §50.11): the two ansible
+instances are the same upstream repo (`ansible/ansible`) at different commits. With
+a cold cache and 3 background workers, their two `_ensure_repo_cached` calls raced
+into the *same* cache path concurrently — both fell through the cache-hit fast-path
+(no valid `.git` yet), and the second's `git clone` aborted with
+``rc=128: destination path '…' already exists and is not an empty directory``. The
+NodeBB pair did NOT race only because its cache already existed (cache-hit → no
+fresh clone). Verify-first against the live error proved this is a *concurrency race
+on a shared cache path*, NOT the runbook's hypothesised rate-limiting / socket drop.
+
+The structural fix (verified here before implementation):
+  1. A per-repo-path ``asyncio.Lock`` SERIALIZES same-repo clones — the second
+     caller waits, then takes the now-valid cache-hit (exactly one real clone).
+  2. Bounded purge-and-retry is defense-in-depth for a genuinely stale / partial
+     cache dir (a crashed prior run leaving a non-empty non-``.git`` directory):
+     intercept ``rc=128``, purge the dir, jittered backoff, re-clone.
+  3. The lock is keyed PER REPO PATH, so *different* repos still clone concurrently
+     (no global serialization stall).
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+from backend.core.ouroboros.governance.swe_bench_pro import per_problem_harness
+from backend.core.ouroboros.governance.swe_bench_pro.per_problem_harness import (
+    _ensure_repo_cached,
+    REPO_CACHE_PATH_ENV_VAR,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv(REPO_CACHE_PATH_ENV_VAR, str(tmp_path / "cache"))
+    # zero backoff so retry tests run instantly; clear any per-process lock state
+    monkeypatch.setenv("JARVIS_SWE_BENCH_PRO_CLONE_RETRY_BACKOFF_MS", "0")
+    registry = getattr(per_problem_harness, "_repo_clone_locks", None)
+    if isinstance(registry, dict):
+        registry.clear()
+    yield
+
+
+def _install_fake_git(monkeypatch, *, clone_calls, fail_first_n=0, sleep_s=0.02):
+    """Patch ``_run_git`` with a fake that mimics git-clone semantics.
+
+    * Records every clone target in ``clone_calls``.
+    * The first ``fail_first_n`` clone attempts simulate the production
+      ``rc=128 destination not empty`` (leaving the dir partially populated,
+      exactly as a real aborted clone would).
+    * Otherwise yields the event loop (``sleep_s``) to widen the race window,
+      then materializes a valid ``.git`` checkout.
+    """
+    state = {"attempt": 0}
+
+    async def fake_run_git(args, **_kwargs):
+        if not args or args[0] != "clone":
+            return (0, "", "")
+        from pathlib import Path
+
+        target = Path(args[-1])
+        clone_calls.append(str(target))
+        state["attempt"] += 1
+        if state["attempt"] <= fail_first_n:
+            # simulate a half-written aborted clone: dir exists, non-empty, no .git
+            target.mkdir(parents=True, exist_ok=True)
+            (target / ".partial").write_text("x", encoding="utf-8")
+            return (
+                128,
+                "",
+                "fatal: destination path '%s' already exists and is "
+                "not an empty directory." % target,
+            )
+        await asyncio.sleep(sleep_s)
+        (target / ".git").mkdir(parents=True, exist_ok=True)
+        (target / "README").write_text("ok", encoding="utf-8")
+        return (0, "", "")
+
+    monkeypatch.setattr(per_problem_harness, "_run_git", fake_run_git)
+
+
+# --- Phase 1: per-repo serialization (the EVAL-2 race) ---
+
+def test_concurrent_same_repo_clones_serialize_to_one(monkeypatch):
+    """Two concurrent calls for the SAME repo must produce exactly ONE clone
+    (the second takes the cache-hit), and both must return the same valid path."""
+    clone_calls: list[str] = []
+    _install_fake_git(monkeypatch, clone_calls=clone_calls)
+
+    async def _run():
+        url = "https://github.com/ansible/ansible.git"
+        return await asyncio.gather(
+            _ensure_repo_cached(url),
+            _ensure_repo_cached(url),
+        )
+
+    a, b = asyncio.run(_run())
+    assert a is not None and b is not None, "both callers must resolve a cache path"
+    assert a == b, "both callers must converge on the same cache path"
+    assert len(clone_calls) == 1, (
+        "same-repo clones must serialize to exactly one real clone; "
+        f"got {len(clone_calls)} (the EVAL-2 race)"
+    )
+
+
+# --- Phase 2: bounded purge-and-retry over a stale / partial dir ---
+
+def test_rc128_stale_dir_is_purged_and_retried(monkeypatch):
+    """A single clone hitting rc=128 (stale non-.git dir) must be purged and
+    retried within the attempt budget, ultimately succeeding."""
+    clone_calls: list[str] = []
+    _install_fake_git(monkeypatch, clone_calls=clone_calls, fail_first_n=1)
+
+    result = asyncio.run(
+        _ensure_repo_cached("https://github.com/ansible/ansible.git")
+    )
+    assert result is not None, "purge-and-retry must recover from a stale dir"
+    assert (result / ".git").is_dir(), "the retried clone must be valid"
+    assert len(clone_calls) == 2, "must retry exactly once after the rc=128"
+
+
+def test_retry_budget_is_bounded(monkeypatch):
+    """If every attempt fails rc=128, the harness gives up (returns None) within
+    the bounded attempt budget — never an unbounded loop."""
+    clone_calls: list[str] = []
+    _install_fake_git(monkeypatch, clone_calls=clone_calls, fail_first_n=999)
+
+    result = asyncio.run(
+        _ensure_repo_cached("https://github.com/ansible/ansible.git")
+    )
+    assert result is None, "exhausted retries must fail closed (None)"
+    # default budget is 3 attempts — bounded, not infinite
+    assert 1 < len(clone_calls) <= 5, f"retries must be bounded; got {len(clone_calls)}"
+
+
+# --- Phase 3: per-repo locking does NOT over-serialize distinct repos ---
+
+def test_different_repos_clone_concurrently(monkeypatch):
+    """The lock is keyed per repo path: two DIFFERENT repos must both clone
+    (no global serialization stall)."""
+    clone_calls: list[str] = []
+    _install_fake_git(monkeypatch, clone_calls=clone_calls)
+
+    async def _run():
+        return await asyncio.gather(
+            _ensure_repo_cached("https://github.com/ansible/ansible.git"),
+            _ensure_repo_cached("https://github.com/qutebrowser/qutebrowser.git"),
+        )
+
+    a, b = asyncio.run(_run())
+    assert a is not None and b is not None
+    assert a != b, "different repos must resolve to different cache paths"
+    assert len(clone_calls) == 2, "both distinct repos must clone"
+
+
+def test_warm_cache_hit_skips_clone_entirely(monkeypatch):
+    """Once cached, a subsequent call takes the fast-path with zero clones —
+    the lock must not perturb the existing idempotent cache-hit behavior."""
+    clone_calls: list[str] = []
+    _install_fake_git(monkeypatch, clone_calls=clone_calls)
+    url = "https://github.com/ansible/ansible.git"
+
+    first = asyncio.run(_ensure_repo_cached(url))
+    assert first is not None and len(clone_calls) == 1
+    second = asyncio.run(_ensure_repo_cached(url))
+    assert second == first, "warm cache must return the same path"
+    assert len(clone_calls) == 1, "warm cache-hit must not re-clone"
+
+
+# --- Wiring pins: the structural fix exists in the module ---
+
+def test_per_repo_lock_registry_exists():
+    assert hasattr(per_problem_harness, "_repo_clone_locks"), (
+        "Slice 76 requires a per-repo asyncio.Lock registry"
+    )
+    assert isinstance(per_problem_harness._repo_clone_locks, dict)
+
+
+def test_ensure_repo_cached_uses_lock_and_retry():
+    src = inspect.getsource(per_problem_harness._ensure_repo_cached)
+    assert "_repo_clone_locks" in src or "_clone_lock_for" in src, (
+        "_ensure_repo_cached must acquire the per-repo clone lock"
+    )
+    assert "async with" in src, "the critical section must be lock-guarded"

--- a/tests/governance/test_slice76_preflight_gate.py
+++ b/tests/governance/test_slice76_preflight_gate.py
@@ -1,0 +1,116 @@
+"""Slice 76 Phase 2 — pre-flight DW transport gate.
+
+Root cause (EVAL-2, PRD §50.11): when DoubleWord transport is down, an op still
+pays the `_primary_sem` wait + per-model timeout cascade (`sem_wait_total_s=360`)
+BEFORE Slice 73's mid-flight sever cascades to Claude — so Claude arrives with
+`remaining_s=0.0` (`deadline_exhausted_pre_fallback`) and the op times out.
+
+Fix (verify-first, leverage-existing — NO new probe): consult the EXISTING
+`dw_surface_health` ledger (kept fresh by the surface probes). If the
+`DIRECT_STREAMING` surface shows a FRESH `TRANSPORT_DEGRADED` verdict, sever the
+DW lane in `_dispatch_via_sentinel` BEFORE the semaphore/budget burn and cascade
+to Claude with the full untouched budget. Conservative by construction: stale /
+unknown / healthy / upstream-degraded evidence leaves the gate inert.
+"""
+from __future__ import annotations
+
+import inspect
+import time
+
+import pytest
+
+from backend.core.ouroboros.governance import candidate_generator
+from backend.core.ouroboros.governance.candidate_generator import (
+    dw_transport_degraded_preflight,
+    dw_preflight_gate_enabled,
+)
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger,
+    SurfaceKind,
+    SurfaceVerdict,
+)
+
+
+@pytest.fixture
+def _ledger(monkeypatch, tmp_path):
+    """Point both the writer and the gate's reader at a temp ledger file."""
+    path = tmp_path / "dw_surface_health.json"
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(path))
+    monkeypatch.setenv("JARVIS_DW_PREFLIGHT_GATE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_PREFLIGHT_FRESHNESS_S", "120")
+
+    def _write(verdict: SurfaceVerdict, age_s: float = 0.0):
+        led = SurfaceHealthLedger(path=path, autosave=True)
+        led.record(SurfaceKind.DIRECT_STREAMING, verdict,
+                   now_unix=time.time() - age_s)
+    return _write
+
+
+def test_fresh_transport_degraded_trips_gate(_ledger):
+    _ledger(SurfaceVerdict.TRANSPORT_DEGRADED, age_s=5.0)
+    assert dw_transport_degraded_preflight() is True
+
+
+def test_stale_transport_degraded_is_ignored(_ledger):
+    _ledger(SurfaceVerdict.TRANSPORT_DEGRADED, age_s=600.0)  # > 120s freshness
+    assert dw_transport_degraded_preflight() is False
+
+
+def test_healthy_surface_does_not_trip(_ledger):
+    _ledger(SurfaceVerdict.HEALTHY, age_s=1.0)
+    assert dw_transport_degraded_preflight() is False
+
+
+def test_upstream_degraded_is_not_transport_degraded(_ledger):
+    # UPSTREAM_DEGRADED = server responded badly (5xx) — DW transport is UP,
+    # so the lane should NOT be severed pre-flight.
+    _ledger(SurfaceVerdict.UPSTREAM_DEGRADED, age_s=1.0)
+    assert dw_transport_degraded_preflight() is False
+
+
+def test_no_record_does_not_trip(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH",
+                       str(tmp_path / "absent.json"))
+    monkeypatch.setenv("JARVIS_DW_PREFLIGHT_GATE_ENABLED", "true")
+    assert dw_transport_degraded_preflight() is False
+
+
+def test_disabled_flag_makes_gate_inert(_ledger, monkeypatch):
+    _ledger(SurfaceVerdict.TRANSPORT_DEGRADED, age_s=1.0)
+    monkeypatch.setenv("JARVIS_DW_PREFLIGHT_GATE_ENABLED", "false")
+    assert dw_preflight_gate_enabled() is False
+    assert dw_transport_degraded_preflight() is False
+
+
+def test_gate_never_raises_on_corrupt_ledger(monkeypatch, tmp_path):
+    bad = tmp_path / "corrupt.json"
+    bad.write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(bad))
+    monkeypatch.setenv("JARVIS_DW_PREFLIGHT_GATE_ENABLED", "true")
+    # fail-open: a gate error must never block DW dispatch
+    assert dw_transport_degraded_preflight() is False
+
+
+def test_freshness_window_is_env_tunable(_ledger, monkeypatch):
+    _ledger(SurfaceVerdict.TRANSPORT_DEGRADED, age_s=200.0)
+    assert dw_transport_degraded_preflight() is False  # default 120s window
+    monkeypatch.setenv("JARVIS_DW_PREFLIGHT_FRESHNESS_S", "300")
+    assert dw_transport_degraded_preflight() is True   # widened window
+
+
+# --- wiring pin: the gate is consulted in the dispatch path pre-budget ---
+
+def test_dispatch_consults_preflight_gate_before_fallback():
+    src = inspect.getsource(candidate_generator.CandidateGenerator._dispatch_via_sentinel)
+    assert "dw_transport_degraded_preflight" in src, (
+        "_dispatch_via_sentinel must consult the pre-flight gate"
+    )
+    assert "_call_fallback" in src, "the gate must cascade to the Claude fallback"
+    # the gate must be consulted BEFORE the sentinel dispatch assignment +
+    # the model-registration loop (i.e. before any DW semaphore is touched).
+    gate_pos = src.index("dw_transport_degraded_preflight")
+    dispatch_pos = src.index("sentinel = get_default_sentinel()")
+    register_pos = src.index("sentinel.register_endpoint")
+    assert 0 <= gate_pos < dispatch_pos < register_pos, (
+        "pre-flight gate must fire BEFORE sentinel/semaphore dispatch"
+    )

--- a/tests/utils/test_async_pr_janitor.py
+++ b/tests/utils/test_async_pr_janitor.py
@@ -1,0 +1,109 @@
+"""Slice 76 Phase 5 — async PR janitor safety-gate + backoff tests.
+
+The load-bearing invariant: ``should_close`` NEVER returns True for a human PR.
+A closed PR is irreversible at 67k scale, so this predicate is the single
+chokepoint every closure flows through — it gets the most adversarial tests.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# load the script module by path (scripts/ is not an importable package)
+_SPEC = importlib.util.spec_from_file_location(
+    "async_pr_janitor",
+    Path(__file__).resolve().parents[2] / "scripts" / "utils" / "async_pr_janitor.py",
+)
+janitor = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(janitor)  # type: ignore[union-attr]
+
+
+def _bot_pr(number=99999, title="🚨 Fix CI/CD: PR Automation & Validation (Run #1)"):
+    return {"number": number, "title": title,
+            "user": {"login": "github-actions[bot]", "type": "Bot"}}
+
+
+def _human_pr(number=36818, title="fix(governance): R1 timeout coherence"):
+    return {"number": number, "title": title,
+            "user": {"login": "drussell23", "type": "User"}}
+
+
+# --- the safety invariant: never close a human PR ---
+
+def test_closes_a_clean_bot_pr():
+    assert janitor.should_close(_bot_pr()) is True
+
+
+def test_accepts_search_api_bot_login_too():
+    pr = _bot_pr()
+    pr["user"]["login"] = "app/github-actions"
+    assert janitor.should_close(pr) is True
+
+
+def test_never_closes_a_human_pr():
+    assert janitor.should_close(_human_pr()) is False
+
+
+def test_never_closes_a_protected_id_even_if_bot_shaped():
+    # belt-and-suspenders: a protected number with a bot-looking author/title
+    pr = _bot_pr(number=106)
+    assert janitor.should_close(pr) is False
+
+
+def test_every_protected_id_is_refused():
+    for n in janitor.PROTECTED_PR_IDS:
+        assert janitor.should_close(_bot_pr(number=n)) is False, n
+
+
+def test_human_login_with_bot_type_is_refused():
+    # author.type gate alone isn't enough — login must also match a known bot
+    pr = _bot_pr()
+    pr["user"]["login"] = "drussell23"
+    assert janitor.should_close(pr) is False
+
+
+def test_bot_author_but_wrong_title_is_refused():
+    # title gate guards against a non-runaway bot PR (e.g. dependabot-shaped)
+    assert janitor.should_close(_bot_pr(title="chore(deps): bump foo")) is False
+
+
+def test_user_type_is_refused_even_with_bot_login():
+    pr = _bot_pr()
+    pr["user"]["type"] = "User"
+    assert janitor.should_close(pr) is False
+
+
+def test_missing_or_malformed_fields_fail_closed():
+    assert janitor.should_close({}) is False
+    assert janitor.should_close({"number": "x", "user": {"type": "Bot"}}) is False
+    assert janitor.should_close({"number": 5, "user": None}) is False
+
+
+# --- adaptive backoff ---
+
+def test_backoff_honors_retry_after():
+    assert janitor.compute_backoff(0, 42.0) == 42.0
+
+
+def test_backoff_is_exponential_without_retry_after():
+    assert janitor.compute_backoff(0, None) == 1.0
+    assert janitor.compute_backoff(1, None) == 2.0
+    assert janitor.compute_backoff(3, None) == 8.0
+
+
+def test_backoff_is_capped():
+    assert janitor.compute_backoff(50, None) == 300.0
+    assert janitor.compute_backoff(0, 99999.0) == 300.0
+
+
+# --- checkpoint resume ---
+
+def test_load_done_parses_checkpoint(tmp_path):
+    cp = tmp_path / "cp.jsonl"
+    cp.write_text('{"number": 1, "ts": 0}\n{"number": 2}\nbad line\n{"number": 3}\n',
+                  encoding="utf-8")
+    assert janitor._load_done(cp) == {1, 2, 3}
+
+
+def test_load_done_absent_is_empty(tmp_path):
+    assert janitor._load_done(tmp_path / "nope.jsonl") == set()


### PR DESCRIPTION
Closes the infrastructure boundaries surfaced by **EVAL-2** (PRD §50.11), so the next macro sweep produces an un-poisoned denominator. Four phases, all verify-first + TDD.

## Phase 1 — Resilient git-clone ingress (`per_problem_harness.py`)
The 2 ansible `prepare_failed (rc=128)` rows were a **concurrent same-repo cold-clone race** on the shared cache path (verify-first corrected the runbook's "rate-limiting" hypothesis). Fix: per-repo-path `asyncio.Lock` serializes same-repo clones (second takes the cache-hit) + bounded purge-and-retry. Distinct repos still clone concurrently. **7 tests.**

## Phase 2 — Pre-flight DW transport gate (`candidate_generator.py`)
The NodeBB `terminal_timeout` was the DW semaphore-wait burning the budget before Slice 73's mid-flight sever could cascade. Fix: consult the **existing** `dw_surface_health` ledger (zero new probe, zero added latency — improves on the runbook's literal 5s socket probe) for a fresh `DIRECT_STREAMING TRANSPORT_DEGRADED` verdict and cascade to Claude with full budget *before* the semaphore. Conservative (stale/healthy/unknown → inert), fail-open, default-on. **9 tests.**

## Phase 3 — Programmatic dual-metric analytics (`result_store.py` + report)
New `EvaluationCategory` enum (`RESOLVED` / `CAPABILITY_MISS` / `INFRASTRUCTURE_EXCLUSION`) derived natively on the durable ledger + `dual_metric_rates()`. Report card now renders **Strict vs. Operational** with zero manual recalc. Derivation never flatters the model (eval=unresolved → capability_miss, not exclusion). Verified live on EVAL-2: `Strict 1/6=16.7% · Operational 1/3=33.3%`. **10 tests.**

## Phase 5 — Async token-bucket PR janitor (`scripts/utils/async_pr_janitor.py`)
Drains the **67,744** runaway `app/github-actions` "Fix CI/CD" bot PRs (not ~400 — verify-first found the true scale) at a GitHub-safe ~1/s with adaptive backoff + checkpoint resume. Defense-in-depth close gate: bot-author + bot-title + immutable protected-ID backstop → **never closes a human PR** (your 13 are guarded). Running in the background now. **14 tests.**

## Verification
- **355 blast-radius tests pass** (swe_bench_pro + candidate_generator + dual_lane + janitor + Slices 73–76).
- 12 pre-existing `phase_a_disabled` taxonomy failures **verified identical on clean main** (not introduced here).
- All new behavior behind default-on flags with byte-identical legacy rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens SWE-Bench-Pro ingress and DW dispatch to prevent clone races and budget burn, adds native strict vs operational analytics, and ships a safe PR janitor to clear the runaway bot backlog.

- **Bug Fixes**
  - Serialized same-repo cold clones with per-path `asyncio.Lock` and bounded purge-and-retry; tunables `JARVIS_SWE_BENCH_PRO_CLONE_MAX_ATTEMPTS` and `JARVIS_SWE_BENCH_PRO_CLONE_RETRY_BACKOFF_MS`.
  - Pre-flight DW transport gate: consults `dw_surface_health` for fresh `DIRECT_STREAMING` `TRANSPORT_DEGRADED` and cascades to Claude before the semaphore; gated by `JARVIS_DW_PREFLIGHT_GATE_ENABLED` (default true) and `JARVIS_DW_PREFLIGHT_FRESHNESS_S`.

- **New Features**
  - Dual-metric analytics: `EvaluationCategory` and `dual_metric_rates()` power Strict vs Operational pass rates; report shows both rates and a category column (back-compat for old rows).
  - Async token-bucket PR janitor (`scripts/utils/async_pr_janitor.py`): drains `app/github-actions` “🚨 Fix CI/CD” PRs at ~1/s with adaptive backoff, checkpoint resume, and a defense-in-depth close gate that never touches human PRs.

<sup>Written for commit 243a814050bbc4f48bd0ecc85cfe15497bd6f9ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

