### PR TITLE
Slice 77 — Dynamic transport telemetry: live failures feed surface-health (makes P2 reactive)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -880,6 +880,37 @@ def _note_dw_candidate_success() -> None:
         pass
 
 
+def _note_dw_live_transport_degraded(diagnostic: str = "") -> None:
+    """Slice 77 — the millisecond a LIVE dispatch hits a transport break
+    (``live_transport:RuntimeError`` / socket drop), stamp the
+    ``dw_surface_health`` ledger ``DIRECT_STREAMING → TRANSPORT_DEGRADED`` so
+    the NEXT op's Slice 76 P2 pre-flight gate (:func:`dw_transport_degraded_preflight`)
+    fires and cascades straight to Claude with the full budget — instead of
+    burning the next op's allowance on the same dead transport (the EVAL-2
+    Phase-4 ``deadline_exhausted_pre_fallback`` failure, PRD §50.11).
+
+    This converts the ledger from a one-shot BOOT probe into a live,
+    event-driven status map. Recovery is automatic: once live generations stop
+    failing, no further degraded records are written and the gate's freshness
+    window lapses the stale verdict, re-enabling the DW lane. A fresh ledger
+    instance per call reads-latest-then-saves, so this never clobbers a
+    concurrent probe's record for another surface. NEVER raises (best-effort
+    observability must not perturb the dispatch error path it sits on)."""
+    try:
+        from backend.core.ouroboros.governance.dw_surface_health import (
+            SurfaceHealthLedger,
+            SurfaceKind,
+            SurfaceVerdict,
+        )
+        SurfaceHealthLedger(autosave=True).record(
+            SurfaceKind.DIRECT_STREAMING,
+            SurfaceVerdict.TRANSPORT_DEGRADED,
+            diagnostic=(diagnostic or "live_transport")[:120],
+        )
+    except Exception:  # noqa: BLE001 — never perturb the dispatch error path
+        pass
+
+
 def dw_preflight_gate_enabled() -> bool:
     """Slice 76 Phase 2 master flag — default TRUE. When off, dispatch is
     byte-identical to the pre-Slice-76 path (no pre-flight short-circuit)."""
@@ -3274,6 +3305,17 @@ class CandidateGenerator:
                         type(exc).__name__, op_id_short,
                     )
                 attempts[-1] = f"{model_id}:failed:{failure_source.value}"
+                # Slice 77 — dynamic transport telemetry. The moment a LIVE
+                # generation confirms a transport break, feed it into the
+                # dw_surface_health ledger so the NEXT op's Slice 76 P2
+                # pre-flight gate fires and skips the dead DW lane (closes the
+                # stale-boot-probe gap found in the EVAL-2 Phase-4 re-run,
+                # §50.11). Only LIVE_TRANSPORT — 429/5xx/parse are model- or
+                # request-specific, not a transport-wide break.
+                if failure_source is FailureSource.LIVE_TRANSPORT:
+                    _note_dw_live_transport_degraded(
+                        f"{model_id}:{type(exc).__name__}",
+                    )
                 # Slice 73 — structural transport short-circuit. A LIVE_TRANSPORT
                 # break affects the whole DW endpoint, so trying the next ranked
                 # model just burns another ~30s on the same dead transport

--- a/tests/governance/test_slice77_dynamic_telemetry.py
+++ b/tests/governance/test_slice77_dynamic_telemetry.py
@@ -1,0 +1,99 @@
+"""Slice 77 — Dynamic transport telemetry: live failures feed the surface ledger.
+
+Gap found during the EVAL-2 Phase-4 re-run (PRD §50.11): the Slice 76 P2 pre-flight
+gate reads `dw_surface_health`, but that ledger was only written by ONE-SHOT BOOT
+probes — it stayed `healthy` while every live GENERATE failed with
+`live_transport:RuntimeError`, so the gate never fired and ops kept burning their
+budget on the dead DW lane before Claude could pick up.
+
+Slice 77 closes it: the millisecond a live dispatch hits a LIVE_TRANSPORT break,
+record `DIRECT_STREAMING → TRANSPORT_DEGRADED` into the SAME ledger the P2 gate
+reads. The ledger becomes a live, event-driven status map; the NEXT op's gate
+fires and cascades straight to Claude. Recovery is automatic via the gate's
+existing freshness window (a degraded verdict older than the window is ignored).
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from backend.core.ouroboros.governance import candidate_generator
+from backend.core.ouroboros.governance.candidate_generator import (
+    _note_dw_live_transport_degraded,
+    dw_transport_degraded_preflight,
+)
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger,
+    SurfaceKind,
+    SurfaceVerdict,
+)
+
+
+@pytest.fixture
+def _ledger_path(monkeypatch, tmp_path):
+    path = tmp_path / "dw_surface_health.json"
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH", str(path))
+    monkeypatch.setenv("JARVIS_DW_PREFLIGHT_GATE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_PREFLIGHT_FRESHNESS_S", "120")
+    return path
+
+
+def test_helper_records_transport_degraded(_ledger_path):
+    _note_dw_live_transport_degraded("live_transport:RuntimeError")
+    rec = SurfaceHealthLedger(path=_ledger_path).verdict_for(
+        SurfaceKind.DIRECT_STREAMING,
+    )
+    assert rec is not None
+    assert rec.verdict is SurfaceVerdict.TRANSPORT_DEGRADED
+
+
+def test_live_failure_makes_preflight_gate_fire(_ledger_path):
+    # Before any live failure, the gate is inert (no degraded evidence).
+    assert dw_transport_degraded_preflight() is False
+    # A single live transport break flips the ledger...
+    _note_dw_live_transport_degraded("live_transport:RuntimeError")
+    # ...and the very next op's pre-flight gate now fires.
+    assert dw_transport_degraded_preflight() is True
+
+
+def test_recording_merges_with_existing_surfaces(_ledger_path):
+    # a prior boot probe marked batch_storage healthy
+    led = SurfaceHealthLedger(path=_ledger_path, autosave=True)
+    led.record(SurfaceKind.BATCH_STORAGE, SurfaceVerdict.HEALTHY)
+    # the live-failure recording must NOT clobber the other surface
+    _note_dw_live_transport_degraded("live_transport")
+    snap = SurfaceHealthLedger(path=_ledger_path).snapshot()
+    assert snap[SurfaceKind.BATCH_STORAGE].verdict is SurfaceVerdict.HEALTHY
+    assert snap[SurfaceKind.DIRECT_STREAMING].verdict is SurfaceVerdict.TRANSPORT_DEGRADED
+
+
+def test_helper_never_raises_on_unwritable_path(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_SURFACE_HEALTH_PATH",
+                       "/proc/nonexistent/cannot/write.json")
+    # best-effort observability — a ledger error must NEVER perturb dispatch
+    _note_dw_live_transport_degraded("live_transport")  # must not raise
+
+
+def test_consecutive_failures_accumulate(_ledger_path):
+    _note_dw_live_transport_degraded("t1")
+    _note_dw_live_transport_degraded("t2")
+    rec = SurfaceHealthLedger(path=_ledger_path).verdict_for(
+        SurfaceKind.DIRECT_STREAMING,
+    )
+    assert rec.consecutive_failures >= 2
+
+
+# --- wiring pin: the dispatch loop records on LIVE_TRANSPORT ---
+
+def test_dispatch_records_live_transport_into_ledger():
+    src = inspect.getsource(
+        candidate_generator.CandidateGenerator._dispatch_via_sentinel
+    )
+    assert "_note_dw_live_transport_degraded" in src, (
+        "_dispatch_via_sentinel must feed live LIVE_TRANSPORT failures into the "
+        "surface-health ledger (Slice 77)"
+    )
+    # the record call must reference LIVE_TRANSPORT so it only fires on a true
+    # transport break (not on 429 / 5xx / parse failures)
+    assert "FailureSource.LIVE_TRANSPORT" in src


### PR DESCRIPTION
## What
Closes the gap found in the EVAL-2 Phase-4 re-run (PRD §50.11): **Slice 76 P2's pre-flight gate was blind to live failures**. Its `dw_surface_health` ledger was written only by **one-shot boot probes** — during the re-run it stayed `direct_streaming=healthy` (stamped at boot) while every live GENERATE failed `live_transport:RuntimeError`, so P2 never fired and ops kept burning budget on the dead DW lane → `deadline_exhausted_pre_fallback` (Claude starved).

## Fix (leverage-existing, no new exception wrapper)
The dispatch loop **already** classifies `failure_source = FailureSource.LIVE_TRANSPORT`. At that exact choke point, new `_note_dw_live_transport_degraded()` records `DIRECT_STREAMING → TRANSPORT_DEGRADED` into the **same ledger P2 reads** — only on `LIVE_TRANSPORT` (429/5xx/parse are request-specific). The ledger becomes a live, event-driven status map → the **next** op's gate fires and cascades to Claude with full budget.

## Self-healing
Once live generations stop failing, no further degraded records are written and P2's existing freshness window (`JARVIS_DW_PREFLIGHT_FRESHNESS_S`, 120s) lapses the stale verdict → DW lane re-enabled automatically. Fresh ledger instance per call reads-latest-then-saves (never clobbers a concurrent probe's other-surface record). Never raises.

## Verification
- **6 new TDD tests** incl. the integration assertion (live failure → P2 gate now fires) + cross-surface no-clobber + fail-open.
- **386 blast-radius tests pass**; 12 pre-existing `phase_a_disabled` taxonomy failures verified identical on clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Slice 76 P2 pre-flight gate reactive to live transport failures by writing `DIRECT_STREAMING → TRANSPORT_DEGRADED` to `dw_surface_health` when a live dispatch breaks, so the next op skips the dead DW lane and preserves budget. This closes the boot-probe-only blind spot that caused timeouts and wasted retries.

- **Bug Fixes**
  - Added `_note_dw_live_transport_degraded()` to record a degraded verdict on `FailureSource.LIVE_TRANSPORT`; safe (never raises) and merges with other surfaces.
  - Wired the helper into `_dispatch_via_sentinel` only for `LIVE_TRANSPORT` (not 429/5xx/parse).
  - Self-heals via `JARVIS_DW_PREFLIGHT_FRESHNESS_S` TTL; DW re-enables once failures stop.
  - Added 6 tests covering gate firing after a live failure, cross-surface merge, fail-open, and wiring pin.

<sup>Written for commit 8dffa53e5caeb92ed37cda398966310c91875b50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

