### PR TITLE
Slice 78 — Iron Gate test-only patch guard + Aegis transport robustness (verify-first scoped)

### DIFF
--- a/backend/core/ouroboros/aegis/forwarding.py
+++ b/backend/core/ouroboros/aegis/forwarding.py
@@ -98,6 +98,31 @@ _MAX_REQUEST_BODY_BYTES_DEFAULT: int = 4 * 1024 * 1024
 #   - Sock-read: same 30s — single source of truth
 _DEFAULT_CONNECT_TIMEOUT_S: float = 10.0
 _DEFAULT_SOCK_READ_TIMEOUT_S: float = 30.0
+# Slice 78 Track 2 — make the upstream sock-read window operator-tunable. The
+# 30s default matches the DW inter-chunk SSE stall threshold (§44.6), but the
+# SAME window also governs the time-to-FIRST-token: a reasoning model in
+# thinking-mode can stay silent past 30s before its first byte, and the DW
+# provider itself tolerates a far longer TTFT rupture window (120s / 360s). When
+# that happens this proxy would cut the upstream read BEFORE the client it serves
+# would — so an operator can raise it via JARVIS_AEGIS_UPSTREAM_SOCK_READ_S
+# (e.g. 120/360) to stop the proxy pre-empting the provider's own rupture logic.
+# Default UNCHANGED (30s) — verify-first: not raised blindly without confirmed
+# TTFT>30s evidence (direct probes showed ~1-2s TTFT on the bare models).
+_AEGIS_SOCK_READ_ENV_VAR: str = "JARVIS_AEGIS_UPSTREAM_SOCK_READ_S"
+
+
+def _upstream_sock_read_timeout_s() -> float:
+    """Env-tunable upstream per-chunk read timeout. Invalid / non-positive →
+    the 30s default. NEVER raises."""
+    raw = os.environ.get(_AEGIS_SOCK_READ_ENV_VAR, "").strip()
+    if raw:
+        try:
+            val = float(raw)
+            if val > 0:
+                return val
+        except (ValueError, TypeError):
+            pass
+    return _DEFAULT_SOCK_READ_TIMEOUT_S
 
 
 # ---------------------------------------------------------------------------
@@ -501,7 +526,7 @@ async def forward_request(
     )
     timeout = aiohttp.ClientTimeout(
         connect=_DEFAULT_CONNECT_TIMEOUT_S,
-        sock_read=_DEFAULT_SOCK_READ_TIMEOUT_S,
+        sock_read=_upstream_sock_read_timeout_s(),
     )
 
     # 4. Open upstream + stream pass-through ---------------------------------
@@ -553,6 +578,7 @@ async def forward_request(
 
         guillotine_fired = False
         client_disconnected = False
+        upstream_read_failed = False  # Slice 78 — upstream read timeout/error
         # Slice 2B-i: for non-streaming responses, buffer the body
         # (capped) so we can parse `usage` for authoritative reconcile.
         # Bytes are STILL written to the client byte-identically as they
@@ -611,6 +637,22 @@ async def forward_request(
                     if remaining > 0:
                         nonstreaming_buffer.extend(chunk[:remaining])
 
+        except (asyncio.TimeoutError, aiohttp.ServerTimeoutError,
+                aiohttp.ClientError) as _read_exc:
+            # Slice 78 Track 2 — the upstream read (iter_any) raised: a sock_read
+            # timeout (proxy cut before the provider's own rupture window) or a
+            # mid-stream connection break. Previously this ESCAPED forward_request
+            # (which documents "NEVER raises") and EOF'd the client with zero SSE
+            # bytes — the DW provider then saw an empty stream → StreamRuptureError
+            # → exhaustion → misclassified `live_transport:RuntimeError`. Catch it
+            # here, mark the clean UPSTREAM_UNREACHABLE outcome, and let the
+            # `finally` flush a graceful EOF.
+            upstream_read_failed = True
+            logger.warning(
+                "[AegisForward] upstream read failed mid-stream "
+                "(%s: %s) lease=%s — UPSTREAM_UNREACHABLE",
+                type(_read_exc).__name__, str(_read_exc)[:120], lease.nonce,
+            )
         finally:
             # IMPORTANT ordering: parse non-streaming body + reconcile
             # budget BEFORE write_eof. Once write_eof flushes EOF to
@@ -691,6 +733,9 @@ async def forward_request(
             f"actual {actual_cost:.6f} exceeded lease.max_cost_usd "
             f"{lease.max_cost_usd:.6f}"
         )
+    elif upstream_read_failed:
+        outcome = ForwardOutcome.UPSTREAM_UNREACHABLE
+        detail = "upstream read failed mid-stream (timeout / connection break)"
     elif client_disconnected:
         outcome = ForwardOutcome.CLIENT_DISCONNECTED
         detail = "client closed connection mid-stream"

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -5024,6 +5024,56 @@ class GovernedOrchestrator:
                                 _target_missing_error_message(_tg_missing)
                             )
 
+                    # Gate 4.5 — Source-domain purity (Slice 78). For a swe_bench
+                    # op, a candidate that modifies ONLY test files is the "cheat
+                    # the held-out suite" failure mode. SCORE_REJECT_TEST_MODS
+                    # rejects it post-hoc — but only AFTER the op burned its full
+                    # GENERATE + APPLY + scoring budget. Catch it HERE and route
+                    # to GENERATE_RETRY telling the model to fix the SOURCE defect
+                    # instead. INERT for non-swe_bench ops (host self-dev
+                    # legitimately authors tests) and when the guard is disabled.
+                    # Naming-heuristic only (no ctx.target_files) so a source file
+                    # is never misclassified as a test.
+                    if getattr(ctx, "signal_source", "") == "swe_bench_pro":
+                        try:
+                            from backend.core.ouroboros.governance.patch_domain_guard import (  # noqa: E501
+                                PatchDomainGuard as _PatchDomainGuard,
+                            )
+                        except ImportError:
+                            _PatchDomainGuard = None  # type: ignore[assignment]
+                        if _PatchDomainGuard is not None:
+                            _domain_guard = _PatchDomainGuard()
+                            if _domain_guard.enabled:
+                                for _cand in generation.candidates:
+                                    _mod_paths: List[str] = []
+                                    if isinstance(_cand, dict):
+                                        if _cand.get("file_path"):
+                                            _mod_paths.append(str(_cand["file_path"]))
+                                        for _entry in (_cand.get("files") or []):
+                                            if (
+                                                isinstance(_entry, dict)
+                                                and _entry.get("file_path")
+                                            ):
+                                                _mod_paths.append(
+                                                    str(_entry["file_path"])
+                                                )
+                                    _dg_ok, _dg_reason, _dg_verdict = (
+                                        _domain_guard.check(_mod_paths, None)
+                                    )
+                                    if not _dg_ok:
+                                        logger.warning(
+                                            "[Orchestrator] Iron Gate — "
+                                            "patch_domain_test_only: candidate "
+                                            "modifies only tests [%s] op=%s "
+                                            "(attempt=%d)",
+                                            ", ".join(_dg_verdict.test_files),
+                                            ctx.op_id[:12], attempt + 1,
+                                        )
+                                        generation = None
+                                        raise RuntimeError(
+                                            _dg_reason or "patch_domain_test_only"
+                                        )
+
                     # Gate 3 — Dependency file integrity. Catches hallucinated
                     # package-name renames/truncations in requirements.txt (and
                     # future: package.json, Cargo.toml, etc.). Engineered in

--- a/backend/core/ouroboros/governance/patch_domain_guard.py
+++ b/backend/core/ouroboros/governance/patch_domain_guard.py
@@ -1,0 +1,196 @@
+"""Slice 78 Track 1 — Iron Gate source-domain purity guard.
+
+A SWE-bench-class failure mode: the model "resolves" a bug by editing the TEST
+files (the held-out fail_to_pass / pass_to_pass suite) instead of the actual
+source defect. ``SCORE_REJECT_TEST_MODS`` already rejects this — but only at
+SCORING time, after the op has burned its full generation + APPLY budget. This
+guard catches it EARLY (post-GENERATE, pre-APPLY), mirroring the exploration /
+ASCII Iron Gates: a test-only candidate is short-circuited back to
+GENERATE_RETRY with corrective feedback telling the model to fix the source.
+
+Design (verify-first): swe_bench candidates carry ``full_content`` per file, not
+diffs, so the authoritative pre-apply signal is the candidate's MODIFIED FILE
+PATHS. ``extract_modified_paths`` additionally parses unified-diff ``+++`` headers
+for diff-shaped inputs (e.g. a produced patch). The Slice 69 ``target_paths``
+(the test_patch footprint) are treated as authoritative test files even when they
+don't match a naming convention.
+
+Authority discipline: this module is a pure deterministic classifier. It imports
+NO orchestrator / policy / change_engine substrates — it only inspects strings.
+Every public surface NEVER raises (fail-open: a guard error must not block the
+pipeline). Master flag ``JARVIS_PATCH_DOMAIN_GUARD_ENABLED`` (default TRUE).
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+PATCH_DOMAIN_GUARD_ENABLED_ENV_VAR: str = "JARVIS_PATCH_DOMAIN_GUARD_ENABLED"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+# Test-path heuristics — conventional across Python / JS / TS / Go / Ruby / etc.
+# A path is a test file if ANY of these match (case-insensitive on the basename
+# segments). Deliberately conservative: only well-established test conventions,
+# so a source file is never misclassified as a test.
+_TEST_PATTERNS: Tuple[re.Pattern, ...] = (
+    re.compile(r"(^|/)tests?/"),          # tests/  or  test/
+    re.compile(r"(^|/)__tests__/"),       # JS __tests__/
+    re.compile(r"(^|/)spec/"),            # ruby/js spec/
+    re.compile(r"(^|/)test_[^/]+$"),      # test_foo.py
+    re.compile(r"_test\.[a-z0-9]+$"),     # foo_test.go / foo_test.py
+    re.compile(r"\.test\.[a-z0-9]+$"),    # foo.test.ts / foo.test.js
+    re.compile(r"-test\.[a-z0-9]+$"),     # Markdown-test.ts
+    re.compile(r"_spec\.[a-z0-9]+$"),     # foo_spec.rb
+    re.compile(r"\.spec\.[a-z0-9]+$"),    # foo.spec.ts
+    re.compile(r"(^|/)conftest\.py$"),    # pytest conftest
+)
+
+
+def is_test_path(path: str) -> bool:
+    """True iff *path* is a test file by established naming convention. Pure;
+    NEVER raises (a non-string / empty path → False)."""
+    try:
+        p = str(path).strip().replace("\\", "/")
+        if not p:
+            return False
+        low = p.lower()
+        return any(pat.search(low) for pat in _TEST_PATTERNS)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def extract_modified_paths(patch_str: str) -> List[str]:
+    """Extract modified file paths from a unified diff. Reads ``+++ b/<path>``
+    headers (falling back to ``--- a/<path>`` for deletions), strips the a//b/
+    prefixes, and skips ``/dev/null``. Order-preserving dedup. NEVER raises."""
+    out: List[str] = []
+    seen = set()
+    try:
+        for line in str(patch_str).splitlines():
+            # Read both the new-path (+++ b/…) and old-path (--- a/…) headers;
+            # order-preserving dedup collapses the pair for a normal hunk and
+            # /dev/null is skipped, so a new file resolves to its +++ path and a
+            # deletion to its --- path. Either way we capture every touched file.
+            if line.startswith("+++ ") or line.startswith("--- "):
+                tgt: Optional[str] = line[4:].strip()
+            else:
+                continue
+            # strip trailing tab-timestamp some diffs carry
+            tgt = tgt.split("\t", 1)[0].strip()
+            if tgt in ("/dev/null", ""):
+                continue
+            for prefix in ("a/", "b/"):
+                if tgt.startswith(prefix):
+                    tgt = tgt[len(prefix):]
+                    break
+            if tgt and tgt not in seen:
+                seen.add(tgt)
+                out.append(tgt)
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+@dataclass(frozen=True)
+class PurityVerdict:
+    """Result of the source-domain purity check."""
+
+    modified_files: Tuple[str, ...] = ()
+    test_files: Tuple[str, ...] = ()
+    source_files: Tuple[str, ...] = ()
+
+    @property
+    def test_only(self) -> bool:
+        """True iff the candidate modifies at least one file AND every modified
+        file is a test file (the cheat-the-suite signature)."""
+        return bool(self.modified_files) and not self.source_files
+
+    @property
+    def is_pure(self) -> bool:
+        """True iff the candidate touches at least one source file (or is
+        empty — an empty patch is judged by other gates, not this one)."""
+        return not self.test_only
+
+
+def verify_patch_domain_purity(
+    modified_paths: Sequence[str],
+    test_target_paths: Optional[Sequence[str]] = None,
+) -> PurityVerdict:
+    """Classify *modified_paths* into test vs source. A path is a test file if it
+    matches a test naming convention OR is in *test_target_paths* (the Slice 69
+    test_patch footprint — authoritative). Pure; NEVER raises."""
+    try:
+        targets = {str(p).replace("\\", "/") for p in (test_target_paths or [])}
+        mods = [str(p).replace("\\", "/") for p in (modified_paths or []) if str(p).strip()]
+        tests: List[str] = []
+        sources: List[str] = []
+        for p in mods:
+            if p in targets or is_test_path(p):
+                tests.append(p)
+            else:
+                sources.append(p)
+        return PurityVerdict(
+            modified_files=tuple(mods),
+            test_files=tuple(tests),
+            source_files=tuple(sources),
+        )
+    except Exception:  # noqa: BLE001 — fail-open to an empty (pure) verdict
+        return PurityVerdict()
+
+
+def build_retry_feedback(verdict: PurityVerdict) -> str:
+    """The corrective GENERATE_RETRY message for a test-only candidate."""
+    files = ", ".join(verdict.test_files) or "the test suite"
+    return (
+        "Validation Failure: Proposed patch modifies test files exclusively "
+        f"({files}). You must isolate and resolve the core logic defect inside "
+        "the SOURCE domain code, not the testing suite infrastructure. Do NOT "
+        "edit the held-out tests — explore the source tree and fix the bug at "
+        "its origin."
+    )
+
+
+class PatchDomainGuard:
+    """Iron-Gate wrapper mirroring ``AsciiStrictGate`` — a thin, env-gated
+    façade over the pure :func:`verify_patch_domain_purity` classifier."""
+
+    def __init__(self) -> None:
+        self._enabled = (
+            os.environ.get(PATCH_DOMAIN_GUARD_ENABLED_ENV_VAR, "true")
+            .strip().lower() in _TRUTHY
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def check(
+        self,
+        modified_paths: Sequence[str],
+        test_target_paths: Optional[Sequence[str]] = None,
+    ) -> Tuple[bool, str, PurityVerdict]:
+        """Returns ``(ok, reason, verdict)``. ``ok=False`` ONLY for an enabled
+        guard on a test-only candidate. NEVER raises (fail-open → ``ok=True``)."""
+        try:
+            if not self._enabled:
+                return True, "", PurityVerdict()
+            verdict = verify_patch_domain_purity(modified_paths, test_target_paths)
+            if verdict.test_only:
+                return False, build_retry_feedback(verdict), verdict
+            return True, "", verdict
+        except Exception:  # noqa: BLE001 — never block the pipeline
+            return True, "", PurityVerdict()
+
+
+__all__ = [
+    "PATCH_DOMAIN_GUARD_ENABLED_ENV_VAR",
+    "is_test_path",
+    "extract_modified_paths",
+    "PurityVerdict",
+    "verify_patch_domain_purity",
+    "build_retry_feedback",
+    "PatchDomainGuard",
+]

--- a/tests/aegis/test_slice78_aegis_realignment.py
+++ b/tests/aegis/test_slice78_aegis_realignment.py
@@ -1,0 +1,67 @@
+"""Slice 78 Track 2 — Aegis upstream transport robustness (env-tunable sock_read
++ caught upstream-read timeout).
+
+Verify-first scope: the runbook's premises (strip `-dottxt`, fix a flush/buffer
+drop) were DISPROVEN — no `-dottxt` transform exists in the code and the SSE
+forward loop is byte-faithful. What IS real (proven by the diagnostic agent):
+  1. The upstream `sock_read` was a hardcoded 30s that ALSO governs TTFT; a
+     reasoning model's first token can exceed it, so the proxy would cut before
+     the DW provider's own 120s/360s rupture window. Now env-tunable (default
+     UNCHANGED at 30s — not raised blindly without confirmed TTFT>30s evidence).
+  2. The `iter_any()` upstream-read loop had NO `except` — a sock_read timeout
+     ESCAPED `forward_request` (which documents "never raises") and EOF'd the
+     client with 0 SSE bytes → the DW provider saw an empty stream → exhaustion
+     → misclassified `live_transport:RuntimeError`. Now caught → clean
+     `UPSTREAM_UNREACHABLE`.
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.aegis import forwarding
+
+
+def test_sock_read_default_is_unchanged_30s(monkeypatch):
+    monkeypatch.delenv("JARVIS_AEGIS_UPSTREAM_SOCK_READ_S", raising=False)
+    assert forwarding._upstream_sock_read_timeout_s() == 30.0
+
+
+def test_sock_read_is_env_overridable(monkeypatch):
+    monkeypatch.setenv("JARVIS_AEGIS_UPSTREAM_SOCK_READ_S", "120")
+    assert forwarding._upstream_sock_read_timeout_s() == 120.0
+    monkeypatch.setenv("JARVIS_AEGIS_UPSTREAM_SOCK_READ_S", "360.5")
+    assert forwarding._upstream_sock_read_timeout_s() == 360.5
+
+
+def test_sock_read_invalid_falls_back_to_default(monkeypatch):
+    for bad in ("bad", "-5", "0", "", "   "):
+        monkeypatch.setenv("JARVIS_AEGIS_UPSTREAM_SOCK_READ_S", bad)
+        assert forwarding._upstream_sock_read_timeout_s() == 30.0, bad
+
+
+def test_timeout_construction_uses_the_resolver():
+    src = inspect.getsource(forwarding.forward_request)
+    assert "_upstream_sock_read_timeout_s()" in src, (
+        "the ClientTimeout must use the env-tunable resolver, not the constant"
+    )
+
+
+# --- the contract fix: upstream-read failures are CAUGHT, not escaped ---
+
+def test_forward_loop_catches_upstream_read_timeout():
+    src = inspect.getsource(forwarding.forward_request)
+    # the iter_any loop's try must now catch the upstream read exceptions
+    assert "asyncio.TimeoutError" in src
+    assert "aiohttp.ServerTimeoutError" in src
+    assert "upstream_read_failed" in src
+
+
+def test_upstream_read_failure_maps_to_unreachable_outcome():
+    src = inspect.getsource(forwarding.forward_request)
+    # the new flag must drive the clean UPSTREAM_UNREACHABLE outcome
+    assert "upstream_read_failed" in src
+    assert "ForwardOutcome.UPSTREAM_UNREACHABLE" in src
+    # ordering: the flag is set in the except, consumed in the outcome ladder
+    assert src.index("upstream_read_failed = True") < src.rindex(
+        "ForwardOutcome.UPSTREAM_UNREACHABLE"
+    )

--- a/tests/governance/test_slice78_iron_gate_deflection.py
+++ b/tests/governance/test_slice78_iron_gate_deflection.py
@@ -1,0 +1,140 @@
+"""Slice 78 Track 1 — Iron Gate test-only patch guard (source-domain purity).
+
+A SWE-bench failure mode: the model "resolves" a bug by editing the TEST files
+(the held-out fail_to_pass / pass_to_pass suite) instead of the source defect.
+`SCORE_REJECT_TEST_MODS` already catches this — but only at SCORING time, after
+the op burned its full budget. This guard catches it EARLY (post-GENERATE,
+pre-APPLY, Iron-Gate style) and short-circuits to GENERATE_RETRY with corrective
+feedback, so the model is told to fix the source instead of the tests.
+
+Verify-first: swe_bench candidates carry `full_content` per file, not diffs — so
+the guard inspects the candidate's MODIFIED FILE PATHS (the pre-apply signal),
+with unified-diff header parsing as a fallback for diff-shaped inputs.
+"""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.patch_domain_guard import (
+    is_test_path,
+    extract_modified_paths,
+    verify_patch_domain_purity,
+    build_retry_feedback,
+    PatchDomainGuard,
+)
+
+
+# --- test-path classification ---
+
+def test_recognizes_common_test_paths():
+    for p in ("tests/test_foo.py", "foo/tests/bar.py", "test_thing.py",
+              "src/Markdown-test.ts", "pkg/foo_test.go", "a/b/conftest.py",
+              "spec/models_spec.rb", "src/__tests__/x.js"):
+        assert is_test_path(p) is True, p
+
+
+def test_source_paths_are_not_test_paths():
+    for p in ("qutebrowser/misc/guiprocess.py", "lib/ansible/cli/doc.py",
+              "src/Markdown.ts", "backend/api/server.py", "contest.py"):
+        assert is_test_path(p) is False, p
+
+
+# --- the core purity verdict ---
+
+def test_test_only_patch_is_impure():
+    v = verify_patch_domain_purity(["tests/test_a.py", "tests/test_b.py"], [])
+    assert v.is_pure is False
+    assert v.test_only is True
+    assert set(v.test_files) == {"tests/test_a.py", "tests/test_b.py"}
+
+
+def test_patch_touching_source_is_pure():
+    v = verify_patch_domain_purity(["src/core.py", "tests/test_core.py"], [])
+    assert v.is_pure is True
+    assert v.test_only is False
+    assert list(v.source_files) == ["src/core.py"]
+
+
+def test_target_paths_count_as_test_files():
+    # the SWE-bench test_patch footprint (Slice 69 target_paths) is authoritative:
+    # a non-conventionally-named file that IS the held-out test counts as a test.
+    v = verify_patch_domain_purity(["weird/holdout_suite.py"],
+                                   ["weird/holdout_suite.py"])
+    assert v.is_pure is False and v.test_only is True
+
+
+def test_empty_patch_is_not_flagged():
+    # no modified paths → cannot judge → not test-only (let other gates handle)
+    v = verify_patch_domain_purity([], [])
+    assert v.test_only is False
+    assert v.is_pure is True
+
+
+def test_single_source_file_is_pure():
+    v = verify_patch_domain_purity(["qutebrowser/misc/guiprocess.py"], [])
+    assert v.is_pure is True and v.test_only is False
+
+
+# --- diff header extraction (fallback path) ---
+
+def test_extract_paths_from_unified_diff():
+    diff = (
+        "diff --git a/src/core.py b/src/core.py\n"
+        "--- a/src/core.py\n+++ b/src/core.py\n@@ -1 +1 @@\n-x\n+y\n"
+        "diff --git a/tests/test_core.py b/tests/test_core.py\n"
+        "--- a/tests/test_core.py\n+++ b/tests/test_core.py\n@@ -1 +1 @@\n-a\n+b\n"
+    )
+    paths = extract_modified_paths(diff)
+    assert "src/core.py" in paths and "tests/test_core.py" in paths
+
+
+def test_extract_handles_dev_null_new_file():
+    diff = "--- /dev/null\n+++ b/src/new.py\n@@ -0,0 +1 @@\n+x\n"
+    assert extract_modified_paths(diff) == ["src/new.py"]
+
+
+def test_diff_only_touching_tests_is_impure():
+    diff = "--- a/tests/t.py\n+++ b/tests/t.py\n@@ -1 +1 @@\n-a\n+b\n"
+    v = verify_patch_domain_purity(extract_modified_paths(diff), [])
+    assert v.test_only is True
+
+
+# --- corrective feedback ---
+
+def test_retry_feedback_names_the_test_files_and_demands_source():
+    v = verify_patch_domain_purity(["tests/test_a.py"], [])
+    fb = build_retry_feedback(v)
+    assert "test" in fb.lower()
+    assert "source" in fb.lower()
+    assert "tests/test_a.py" in fb
+
+
+# --- the gate wrapper (mirrors AsciiStrictGate) ---
+
+def test_guard_disabled_is_inert(monkeypatch):
+    monkeypatch.setenv("JARVIS_PATCH_DOMAIN_GUARD_ENABLED", "false")
+    g = PatchDomainGuard()
+    assert g.enabled is False
+    ok, reason, verdict = g.check(["tests/test_a.py"], [])
+    assert ok is True  # inert when disabled
+
+
+def test_guard_blocks_test_only_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_PATCH_DOMAIN_GUARD_ENABLED", "true")
+    g = PatchDomainGuard()
+    assert g.enabled is True
+    ok, reason, verdict = g.check(["tests/test_a.py"], [])
+    assert ok is False
+    assert "test" in reason.lower()
+
+
+def test_guard_passes_source_patch_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_PATCH_DOMAIN_GUARD_ENABLED", "true")
+    g = PatchDomainGuard()
+    ok, reason, verdict = g.check(["src/core.py"], [])
+    assert ok is True
+
+
+def test_guard_never_raises_on_garbage(monkeypatch):
+    monkeypatch.setenv("JARVIS_PATCH_DOMAIN_GUARD_ENABLED", "true")
+    g = PatchDomainGuard()
+    ok, _r, _v = g.check(None, None)  # type: ignore[arg-type]
+    assert ok is True  # fail-open: never block the pipeline on a guard error


### PR DESCRIPTION
Two tracks, both held to verify-first — which **disproved several runbook premises** and rescoped the work to what the code/evidence actually support.

## Track 1 — Iron Gate source-domain purity guard ✅ (real, high-value)
A SWE-bench failure mode: the model "resolves" a bug by editing the held-out **test** suite instead of the source. `SCORE_REJECT_TEST_MODS` catches this only at *scoring* time (after the full budget is burned). New `patch_domain_guard.py` catches it **early** (post-GENERATE, pre-APPLY, Iron-Gate Gate 4.5) → GENERATE_RETRY with corrective feedback to fix the source.
- Verify-first: runbook's `autonomy/iron_gate.py` doesn't exist (gates live in the orchestrator); candidates are `full_content` not diffs (guard inspects modified **paths**, naming-heuristic-only so source is never misclassified); swe_bench-gated (inert for host self-dev).
- **15 TDD tests.**

## Track 2 — Aegis upstream transport robustness ⚠️ (rescoped — premises disproven)
The runbook's two prescriptions were **both disproven by investigation**:
- ❌ "strip `-dottxt`" — **no `-dottxt` transform exists anywhere** in the code; JARVIS already uses bare model names.
- ❌ "fix the flush/buffer drop" — the SSE forward loop is **byte-faithful**; no flush bug.

What's actually real (and shipped):
1. Upstream `sock_read` made **env-tunable** (`JARVIS_AEGIS_UPSTREAM_SOCK_READ_S`); the 30s default also governs TTFT but the DW provider tolerates 120s/360s. **Default unchanged at 30s** (verify-first: direct probes showed ~1–2s TTFT, so 30s isn't the confirmed cause).
2. The `iter_any()` upstream-read loop had **no `except`** — a read timeout escaped `forward_request` (documented "never raises") and EOF'd the client with 0 bytes → empty stream → exhaustion → **misclassified** `live_transport:RuntimeError`. Now caught → clean `UPSTREAM_UNREACHABLE`.
- **6 TDD tests.**

**Honest bottom line:** the live soak evidence shows the binding re-run blocker is **budget starvation** (tool-loop 45s floor + Claude ~174s cap on complex instances), and `live_transport` is a misclassified exhaustion — **not** a transport break. Track 2 hardens the proxy + makes failures classify cleanly, but is **not** a confirmed unblock. DW itself is healthy (direct probes return content).

## Verification
- **70 blast-radius tests pass** (both tracks + per_problem_harness + 43 Aegis forwarding); 12 pre-existing `phase_a_disabled` failures verified identical on clean main.
- All new behavior behind default-safe flags; Aegis default behavior byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guard that rejects test‑only patches in SWE‑bench runs and improves Aegis transport handling by making upstream read timeouts configurable and properly classified. This cuts wasted runs and yields clearer failure signals without changing defaults.

- **New Features**
  - Iron Gate source‑domain guard: blocks candidates that modify only tests in SWE‑bench, sends corrective feedback, and retries generation. Enabled by `JARVIS_PATCH_DOMAIN_GUARD_ENABLED` (on by default).
  - Aegis upstream `sock_read` is env‑tunable via `JARVIS_AEGIS_UPSTREAM_SOCK_READ_S` (default stays 30s).

- **Bug Fixes**
  - Aegis now catches upstream read timeouts/errors during stream forwarding and maps them to `UPSTREAM_UNREACHABLE` instead of leaking and misclassifying failures.

<sup>Written for commit bf9043ae6fc82af2165959021a17cad11812a018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

