### PR TITLE
Slice 79 — graduate adaptive (payload-geometry) GENERATE budget

### DIFF
--- a/backend/core/ouroboros/governance/adaptive_gen_budget.py
+++ b/backend/core/ouroboros/governance/adaptive_gen_budget.py
@@ -89,11 +89,15 @@ def _env_float(name: str, default: float, *, minimum: float) -> float:
 
 
 def adaptive_gen_budget_enabled() -> bool:
-    """Master switch — §33.1 default-FALSE.  NEVER raises."""
+    """Master switch — GRADUATED to default-TRUE (Slice 79). The Floor
+    invariant guarantees zero regression (trivial payload → multiplier 1.0 →
+    byte-identical), so only heavy multi-file payloads (e.g. the ansible /
+    NodeBB SWE-bench instances) gain runway. Set the env to a falsey value to
+    restore the pre-graduation byte-identical path. NEVER raises."""
     raw = os.environ.get(
-        ADAPTIVE_GEN_BUDGET_ENABLED_ENV_VAR, "",
+        ADAPTIVE_GEN_BUDGET_ENABLED_ENV_VAR, "true",
     ).strip().lower()
-    return raw in ("true", "1", "yes", "on")
+    return raw not in ("0", "false", "no", "off")
 
 
 # ===========================================================================
@@ -280,20 +284,21 @@ def register_flags(registry: Any) -> int:
         FlagSpec(
             name=ADAPTIVE_GEN_BUDGET_ENABLED_ENV_VAR,
             type=FlagType.BOOL,
-            default=False,
+            default=True,
             description=(
                 "Payload-adaptive GENERATE budget master switch "
-                "(§33.1 default-FALSE). When ON, the route-base "
+                "(GRADUATED default-TRUE, Slice 79). The route-base "
                 "_gen_timeout is scaled by deterministic payload "
                 "geometry (text tokens + file count) at the "
-                "orchestrator deadline seam — floor=route base "
-                "(zero regression), ceiling=session wall cap. "
-                "Byte-identical when OFF."
+                "generate_runner deadline seam — floor=route base "
+                "(zero regression on trivial ops), ceiling=session "
+                "wall cap. Set falsey to restore the pre-graduation "
+                "byte-identical path."
             ),
             category=Category.SAFETY,
             source_file=src,
-            example="false",
-            since="v3.7 Stage 2 Slice 2 adaptive gen budget (2026-05-16)",
+            example="true",
+            since="v3.7 Stage 2 Slice 2 (2026-05-16); graduated Slice 79 (2026-06-03)",
         ),
         FlagSpec(
             name=_MAX_MULTIPLIER_ENV_VAR,

--- a/tests/governance/test_adaptive_gen_budget.py
+++ b/tests/governance/test_adaptive_gen_budget.py
@@ -63,9 +63,26 @@ def _clean(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_flag_off_is_byte_identical():
-    # flag unset → exactly base (the float-cast of it)
+def test_flag_off_is_byte_identical(monkeypatch):
+    # Slice 79 graduated the master to default-TRUE, so the OFF path must be
+    # set explicitly. With the flag OFF, scaling is byte-identical (== base).
+    monkeypatch.setenv("JARVIS_ADAPTIVE_GEN_BUDGET_ENABLED", "false")
     assert agb.scale_gen_timeout(_BASE, _Ctx("x" * 99999, files=range(50))) == _BASE
+
+
+def test_graduated_default_on_scales_heavy_payload(monkeypatch):
+    # Slice 79 — flag UNSET now defaults ON, so a heavy multi-file swe_bench-
+    # shaped payload gets a scaled (larger) budget without any env opt-in.
+    monkeypatch.delenv("JARVIS_ADAPTIVE_GEN_BUDGET_ENABLED", raising=False)
+    assert agb.adaptive_gen_budget_enabled() is True
+    heavy = _Ctx("x" * 80000, files=range(11))  # big problem statement, 11 files
+    assert agb.scale_gen_timeout(_BASE, heavy) > _BASE
+
+
+def test_graduated_default_on_trivial_still_unchanged(monkeypatch):
+    # the Floor invariant still holds at default-on: a trivial op is unchanged.
+    monkeypatch.delenv("JARVIS_ADAPTIVE_GEN_BUDGET_ENABLED", raising=False)
+    assert agb.scale_gen_timeout(_BASE, _Ctx()) == pytest.approx(_BASE)
 
 
 def test_floor_never_below_base_even_with_huge_payload(monkeypatch):
@@ -231,7 +248,7 @@ def test_orchestrator_composes_scale_gen_timeout_single_seam():
 # ---------------------------------------------------------------------------
 
 
-def test_flag_registry_master_default_false():
+def test_flag_registry_master_default_true():
     captured = []
 
     class _Reg:
@@ -244,5 +261,6 @@ def test_flag_registry_master_default_false():
         s for s in captured
         if s.name == "JARVIS_ADAPTIVE_GEN_BUDGET_ENABLED"
     )
-    assert master.default is False
+    # Slice 79 — graduated default-FALSE → default-TRUE.
+    assert master.default is True
     assert "adaptive_gen_budget.py" in master.source_file


### PR DESCRIPTION
## Verify-first: the engine already existed
Slice 79's "complexity-adaptive temporal envelope" was **already built** (`adaptive_gen_budget.py`, 2026-05-16) for this exact failure — its docstring cites the multi-file ansible known-hard being killed by the outer Iron-Gate `wait_for` before it could be scored. It:
- Computes a deterministic `PayloadWeight` from **ctx geometry** (text tokens + file_count) — more discriminating than the coarse complexity enum for localized-vs-multi-file.
- Scales the route-base `_gen_timeout` by `1 + score` (bounded), wired at the **single highest-enforcement seam** (`generate_runner.py:695`) so deadline + outer `wait_for` + downstream tool-loop `BudgetPlan` all inherit it coherently.

It was just **never graduated** (master flag default-FALSE). So this is a graduation — no new analyzer in `per_problem_harness` (would duplicate), no per-layer timeout edits.

## Change
`adaptive_gen_budget_enabled()` + FlagSpec default flip **FALSE → TRUE**.

## Safe by construction (spine-pinned invariants)
- **Floor = route base** → trivial ops → multiplier 1.0 → **byte-identical** (zero regression).
- **Ceiling = wall-cap fraction** → an op can claim runway but never escape `--max-wall-seconds`.
- Only **heavy multi-file payloads** (ansible/NodeBB) gain budget → directly fixes the tool-loop `remaining < 45s` starvation + the ~174s Claude execution cap.

## Verification
- 17 adaptive tests + **125 budget-flow regression** (generate_runner, timeout-coherence, swe_bench harness) green.
- Revert by setting `JARVIS_ADAPTIVE_GEN_BUDGET_ENABLED` falsey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduated the payload-geometry adaptive GENERATE budget to default ON so heavy multi-file contexts get a larger `_gen_timeout` and avoid early cancellation, while trivial ops stay byte-identical and session caps still apply.

- **New Features**
  - Default ON in `adaptive_gen_budget_enabled()` and `FlagSpec` for `JARVIS_ADAPTIVE_GEN_BUDGET_ENABLED`.
  - Scaling applied at the `generate_runner` deadline seam; floor = route base, ceiling = session wall cap.
  - Tests updated for explicit OFF path, default-ON heavy payload scaling, and trivial unchanged behavior.

- **Migration**
  - To disable, set `JARVIS_ADAPTIVE_GEN_BUDGET_ENABLED` to a falsey value.

<sup>Written for commit 8072adec360ccc884da72369d8bf218b8e3d98f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

