### PR TITLE
feat(dw): Slice 83 — capability-priority dispatch + granular transport isolation

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -850,6 +850,28 @@ def should_sever_dw_lane(failure_source: Any) -> bool:
         return False
 
 
+def _live_transport_sever_threshold() -> int:
+    """Slice 83 Phase 2 — consecutive LIVE_TRANSPORT failures required before
+    the whole DW lane is severed (Slice 73 behavior).
+
+    Slice 73 severed the lane on the FIRST ``live_transport`` failure on the
+    theory that all ranked siblings share one dead transport. But Slice 82/83
+    made the ranked stack HETEROGENEOUS — DeepSeek-V4-Pro, Kimi-K2.6, GLM-5.1,
+    Qwen397B, Qwen35B are distinct served endpoints. One model being briefly
+    unavailable (deploy bounce, per-model 5xx surfacing as a transport break)
+    is NOT a lane outage: the next coder may be perfectly healthy. So we now
+    ROTATE to the next model on a single failure and only sever once
+    ``threshold`` consecutive models have all failed with LIVE_TRANSPORT — the
+    signature of a genuine endpoint-wide blackout. A success (or a non-transport
+    failure on a reachable model) resets the streak. Default 3; floored at 1 so
+    ``=1`` reproduces exact Slice 73 first-failure sever. Env-tunable."""
+    try:
+        raw = os.environ.get("JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD", "3")
+        return max(1, int(str(raw).strip()))
+    except Exception:  # noqa: BLE001 — bad value → safe default
+        return 3
+
+
 def _note_dw_total_outage(diagnostic: str) -> None:
     """Slice 53 — record one GENERATE op that exhausted ALL DW models with no
     candidate from streaming OR batch (the total-vendor-blackout signature).
@@ -3036,6 +3058,12 @@ class CandidateGenerator:
         # Walk the ranked list. For each model not OPEN, attempt DW.
         attempts: List[str] = []
         last_failure: Optional[str] = None
+        # Slice 83 Phase 2 — consecutive LIVE_TRANSPORT streak across the
+        # heterogeneous coder stack. A single model's transport break rotates
+        # to the next coder; only a `threshold`-long streak (genuine lane-wide
+        # blackout) severs. Reset by any success / non-transport failure.
+        _consecutive_lt: int = 0
+        _lt_sever_threshold: int = _live_transport_sever_threshold()
         for model_id in ranked_models:
             state = sentinel.get_state(model_id)
             # Phase 12 Slice H — TERMINAL_OPEN bypasses dispatch
@@ -3316,26 +3344,51 @@ class CandidateGenerator:
                     _note_dw_live_transport_degraded(
                         f"{model_id}:{type(exc).__name__}",
                     )
-                # Slice 73 — structural transport short-circuit. A LIVE_TRANSPORT
-                # break affects the whole DW endpoint, so trying the next ranked
-                # model just burns another ~30s on the same dead transport
-                # before the inevitable cascade — starving the Claude fallback
-                # (the bt-2026-06-03 deadline_exhausted_pre_fallback failure).
-                # Sever the lane NOW and fall through to cascade with the full
-                # remaining budget. Model-specific failures still rotate.
+                    _consecutive_lt += 1
+                else:
+                    # Slice 83 Phase 2 — a non-transport failure (429/5xx/parse)
+                    # proves THIS model's transport is reachable, so the prior
+                    # transport breaks were per-model, not lane-wide. Reset the
+                    # streak: a genuine blackout is N transport breaks in a row.
+                    _consecutive_lt = 0
+                # Slice 73 + Slice 83 Phase 2 — structural transport short-circuit,
+                # now streak-gated. A LIVE_TRANSPORT break MIGHT mean the whole DW
+                # endpoint is down — but with the Slice 82/83 heterogeneous coder
+                # stack (DeepSeek-V4-Pro / Kimi / GLM / Qwen are distinct served
+                # endpoints) a single break may just be one model bouncing. So we
+                # ROTATE to the next coder on the first break and only sever once
+                # `threshold` consecutive models have ALL failed transport — the
+                # signature of a real lane-wide blackout. Severing too early
+                # starves the Claude fallback (bt-2026-06-03
+                # deadline_exhausted_pre_fallback); rotating too long burns budget
+                # on a dead lane. The streak threshold balances both. `=1`
+                # reproduces exact Slice 73 first-failure sever.
                 if (
                     structural_fast_cascade_enabled()
                     and should_sever_dw_lane(failure_source)
+                    and _consecutive_lt >= _lt_sever_threshold
                 ):
                     _severed = len(ranked_models) - len(attempts)
                     logger.warning(
-                        "[CandidateGenerator] Slice 73 structural fast-cascade: "
-                        "model=%s LIVE_TRANSPORT — severing DW lane, cascading to "
-                        "fallback with full budget (op=%s, skipped %d sibling "
-                        "model(s))",
-                        model_id, op_id_short, max(0, _severed),
+                        "[CandidateGenerator] Slice 73/83 structural fast-cascade: "
+                        "model=%s LIVE_TRANSPORT streak=%d>=%d — severing DW lane, "
+                        "cascading to fallback with full budget (op=%s, skipped %d "
+                        "sibling model(s))",
+                        model_id, _consecutive_lt, _lt_sever_threshold,
+                        op_id_short, max(0, _severed),
                     )
                     break
+                if (
+                    failure_source is FailureSource.LIVE_TRANSPORT
+                    and structural_fast_cascade_enabled()
+                ):
+                    logger.info(
+                        "[CandidateGenerator] Slice 83 granular isolation: "
+                        "model=%s LIVE_TRANSPORT streak=%d<%d — rotating to next "
+                        "coder, DW lane stays open (op=%s)",
+                        model_id, _consecutive_lt, _lt_sever_threshold,
+                        op_id_short,
+                    )
                 continue
         # All DW models exhausted (either OPEN or failed). The
         # per-attempt ContextVar was already reset by each loop

--- a/backend/core/ouroboros/governance/provider_topology.py
+++ b/backend/core/ouroboros/governance/provider_topology.py
@@ -1159,6 +1159,47 @@ def _trusted_seed_dw_models_for_route(route: str) -> Tuple[str, ...]:
                 admitted.append(mid_str)
         except Exception:  # noqa: BLE001 — per-model defensive
             continue
+    # Slice 83 — capability-priority sort. Previously this returned the
+    # promoted models in INSERTION order, which buried the strong agentic
+    # coders (GLM-5.1 754B, Kimi-K2.6 / DeepSeek-V4-Pro 1000B) behind the
+    # baseline Qwen (35/397B): the dispatch tried Qwen first, it hit
+    # live_transport, and Slice 73 severed the lane before the coders were
+    # ever reached (the Sweep-#6 mis-dispatch). Reuse the classifier's existing
+    # `_score` (params-weighted +1 for COMPLEX/STANDARD, pricing-weighted for
+    # BG/SPEC) so the highest-CAPABILITY model leads — metadata-driven, not a
+    # hardcoded order. Fail-soft: any scoring error → original insertion order.
+    try:
+        from backend.core.ouroboros.governance.dw_catalog_classifier import (  # noqa: E501
+            _score as _cap_score_fn,
+            _ranking_weights,
+            _family_preference,
+        )
+        from backend.core.ouroboros.governance.pricing_oracle import (
+            resolve_pricing,
+        )
+        _weights = _ranking_weights()
+        _fam = _family_preference()
+        _prefer_cheap = route_lc in ("background", "speculative")
+
+        def _capability_score(mid: str) -> float:
+            try:
+                _pr = resolve_pricing(mid) or (None, None)
+                _card = ModelCard(
+                    model_id=mid, family=parse_family(mid),
+                    parameter_count_b=parse_parameter_count(mid),
+                    context_window=None, pricing_in_per_m_usd=_pr[0],
+                    pricing_out_per_m_usd=_pr[1], supports_streaming=True,
+                    raw_metadata_json="{}",
+                )
+                return float(_cap_score_fn(
+                    _card, _weights, _fam, prefer_cheap=_prefer_cheap,
+                ))
+            except Exception:  # noqa: BLE001
+                return 0.0
+
+        admitted.sort(key=lambda _m: (-_capability_score(_m), _m))
+    except Exception:  # noqa: BLE001 — never break dispatch on ranking error
+        pass
     return tuple(admitted)
 
 

--- a/tests/governance/test_slice83_priority_dispatch.py
+++ b/tests/governance/test_slice83_priority_dispatch.py
@@ -1,0 +1,178 @@
+"""Slice 83 — Capability-Based Priority Dispatch & Granular Transport Isolation.
+
+Two coupled fixes to the DW dispatch stack, both surfaced by the abandoned
+cost-cascade sweep #6 (Claude disabled → dispatch led with Qwen35B → a single
+``live_transport:RuntimeError`` severed the WHOLE lane via Slice 73 → the strong
+coders were never reached → exhausted at ~$0):
+
+Phase 1 — Tiered capability-priority sorting. ``_trusted_seed_dw_models_for_route``
+previously returned admitted models in INSERTION order, so a small/old model
+could lead the COMPLEX dispatch stack. It now sorts by the catalog classifier's
+capability ``_score`` (params + cost-aware), so the strong agentic coders
+(DeepSeek-V4-Pro, Kimi-K2.6, GLM-5.1 — params 754-1000B) lead and Qwen35B sinks.
+
+Phase 2 — Granular per-model circuit breaking. Slice 73 severed the lane on the
+FIRST ``LIVE_TRANSPORT`` failure. With the now-HETEROGENEOUS coder stack (distinct
+served endpoints) one model bouncing is not a lane outage. The loop now ROTATES to
+the next coder on a single break and only severs once ``threshold`` consecutive
+models have all failed transport (``JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD``,
+default 3; ``=1`` reproduces exact Slice 73 behavior). A non-transport failure
+(proves a model reachable) resets the streak.
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance.topology_sentinel import FailureSource
+from backend.core.ouroboros.governance import candidate_generator as cg
+from backend.core.ouroboros.governance.candidate_generator import (
+    _live_transport_sever_threshold,
+    should_sever_dw_lane,
+    structural_fast_cascade_enabled,
+)
+from backend.core.ouroboros.governance.provider_topology import (
+    _trusted_seed_dw_models_for_route,
+)
+
+
+# --- Phase 1: capability-priority ranking ---
+
+_TRUSTED = (
+    "Qwen/Qwen3.5-35B-A3B-FP8,Qwen/Qwen3.5-397B-A17B-FP8,"
+    "deepseek-ai/DeepSeek-V4-Flash,deepseek-ai/DeepSeek-V4-Pro,"
+    "moonshotai/Kimi-K2.6,zai-org/GLM-5.1-FP8"
+)
+
+
+def test_strong_coders_lead_complex_stack(monkeypatch):
+    # The strong agentic coders must rank ABOVE the small Qwen35B even though
+    # Qwen35B is listed FIRST in the trusted seed (insertion order is the bug).
+    monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", _TRUSTED)
+    ranked = list(_trusted_seed_dw_models_for_route("complex"))
+    assert ranked, "COMPLEX route must admit at least one trusted coder"
+    coders = {
+        "deepseek-ai/DeepSeek-V4-Pro",
+        "moonshotai/Kimi-K2.6",
+        "zai-org/GLM-5.1-FP8",
+    }
+    # every strong coder present must out-rank the small Qwen35B
+    if "Qwen/Qwen3.5-35B-A3B-FP8" in ranked:
+        small_idx = ranked.index("Qwen/Qwen3.5-35B-A3B-FP8")
+        for c in coders:
+            if c in ranked:
+                assert ranked.index(c) < small_idx, (
+                    f"{c} must rank above Qwen35B (got {ranked})"
+                )
+
+
+def test_ranking_is_deterministic(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", _TRUSTED)
+    a = _trusted_seed_dw_models_for_route("complex")
+    b = _trusted_seed_dw_models_for_route("complex")
+    assert a == b, "capability sort must be a stable total order (ties → id)"
+
+
+def test_ranking_sort_failure_is_non_fatal(monkeypatch):
+    # If the classifier import/scoring ever raises, the seed must still return
+    # the admitted set (insertion order) rather than blowing up dispatch.
+    monkeypatch.setenv("JARVIS_DW_TRUSTED_MODELS", _TRUSTED)
+    monkeypatch.setenv("JARVIS_DW_KNOWN_MODEL_PARAMS", "")  # no perturbation
+    ranked = _trusted_seed_dw_models_for_route("complex")
+    assert isinstance(ranked, tuple) and len(ranked) >= 1
+
+
+# --- Phase 2: granular sever threshold ---
+
+def test_threshold_default_is_three(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD", raising=False)
+    assert _live_transport_sever_threshold() == 3
+
+
+def test_threshold_env_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD", "5")
+    assert _live_transport_sever_threshold() == 5
+
+
+def test_threshold_floored_at_one(monkeypatch):
+    # =1 must reproduce exact Slice 73 first-failure sever; 0/negative floor up.
+    monkeypatch.setenv("JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD", "1")
+    assert _live_transport_sever_threshold() == 1
+    monkeypatch.setenv("JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD", "0")
+    assert _live_transport_sever_threshold() == 1
+    monkeypatch.setenv("JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD", "-4")
+    assert _live_transport_sever_threshold() == 1
+
+
+def test_threshold_garbage_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD", "not-a-number")
+    assert _live_transport_sever_threshold() == 3
+
+
+def test_sever_decision_below_threshold_rotates(monkeypatch):
+    # The real composite decision the dispatch loop makes. Below the streak
+    # threshold a LIVE_TRANSPORT failure must NOT sever (rotate to next coder).
+    monkeypatch.setenv("JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD", "3")
+    threshold = _live_transport_sever_threshold()
+    fs = FailureSource.LIVE_TRANSPORT
+    for streak in (1, 2):
+        should = (
+            structural_fast_cascade_enabled()
+            and should_sever_dw_lane(fs)
+            and streak >= threshold
+        )
+        assert should is False, f"streak={streak} must rotate, not sever"
+
+
+def test_sever_decision_at_threshold_severs(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD", "3")
+    threshold = _live_transport_sever_threshold()
+    should = (
+        structural_fast_cascade_enabled()
+        and should_sever_dw_lane(FailureSource.LIVE_TRANSPORT)
+        and 3 >= threshold
+    )
+    assert should is True, "a full consecutive-transport streak must sever"
+
+
+def test_non_transport_failure_never_severs(monkeypatch):
+    # 429/5xx/parse prove a model reachable → they must not sever regardless of
+    # streak length (and in the loop they RESET the streak).
+    monkeypatch.setenv("JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD", "1")
+    threshold = _live_transport_sever_threshold()
+    for fs in (
+        FailureSource.LIVE_HTTP_429,
+        FailureSource.LIVE_HTTP_5XX,
+        FailureSource.LIVE_PARSE_ERROR,
+    ):
+        should = (
+            structural_fast_cascade_enabled()
+            and should_sever_dw_lane(fs)
+            and 99 >= threshold
+        )
+        assert should is False, f"{fs} must never sever the lane"
+
+
+# --- wiring pins: the inline dispatch loop actually consumes the above ---
+
+def test_dispatch_loop_wires_streak_counter():
+    src = inspect.getsource(cg)
+    # the consecutive-transport streak counter exists and gates the sever
+    assert "_consecutive_lt" in src, "loop must track a consecutive LT streak"
+    assert "_lt_sever_threshold" in src, "loop must bind the sever threshold"
+    assert "_live_transport_sever_threshold(" in src
+    # the sever is now streak-gated, not first-failure
+    assert "_consecutive_lt >= _lt_sever_threshold" in src
+
+
+def test_dispatch_loop_resets_streak_on_non_transport():
+    src = inspect.getsource(cg)
+    # there must be a reset path (non-transport failure resets the streak)
+    assert "_consecutive_lt = 0" in src, "non-transport failure must reset streak"
+    assert "_consecutive_lt += 1" in src, "transport failure must grow the streak"
+
+
+def test_dispatch_loop_still_consults_slice73_predicates():
+    # Slice 83 composes WITH Slice 73, never replaces it.
+    src = inspect.getsource(cg)
+    assert "should_sever_dw_lane(" in src
+    assert "structural_fast_cascade_enabled()" in src


### PR DESCRIPTION
## Summary

Two coupled fixes to the DW dispatch stack, both surfaced by the abandoned **cost-cascade sweep #6** (Claude disabled → dispatch led with Qwen35B → a single `live_transport:RuntimeError` severed the **whole** lane via Slice 73 → the strong coders were never reached → exhausted at ~$0).

### Phase 1 — Tiered capability-priority sorting (`provider_topology.py`)
`_trusted_seed_dw_models_for_route` now sorts admitted models by the catalog classifier's existing capability `_score` (params-weighted for COMPLEX/STANDARD, cost-aware for BG/SPEC) instead of insertion order. The strong agentic coders (**DeepSeek-V4-Pro / Kimi-K2.6 / GLM-5.1**, 754–1000B) now lead the COMPLEX stack; Qwen35B sinks. Metadata-driven, **not** a hardcoded order. Fail-soft to insertion order on any scoring error.

Verified COMPLEX ranking: `DeepSeek-V4-Pro → Kimi-K2.6 → GLM-5.1 → Qwen397B → DeepSeek-V4-Flash → Qwen35B`.

### Phase 2 — Granular per-model circuit breaking (`candidate_generator.py`)
Slice 73 severed the lane on the **first** `live_transport` failure. With the now-heterogeneous coder stack (distinct served endpoints) one model bouncing is not a lane outage. The dispatch loop now **rotates** to the next coder on a single break and only severs once `threshold` consecutive models have all failed transport (`JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD`, default **3**; `=1` reproduces exact Slice 73 first-failure behavior). A non-transport failure (429/5xx/parse — proves a model reachable) **resets** the streak. Composes **with** Slice 73, never replaces it.

## Tests
- 13 new tests in `tests/governance/test_slice83_priority_dispatch.py` — all green.
- Adjacent suites regression-clean.
- The 6+3 `test_topology_sentinel_dispatch` / `test_provider_topology_v2` failures are **pre-existing local-only** `.jarvis/dw_promotion_ledger.json` runtime contamination — verified identical on clean main via `git stash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritizes higher-capability DW models in dispatch and adds per-model transport isolation. Strong coders lead, and a single transport failure no longer severs the whole lane.

- New Features
  - Capability-priority sorting in `_trusted_seed_dw_models_for_route`: rank by catalog capability score (cost-aware for BG/SPEC); strong coders lead; falls back to insertion order on error.
  - Granular transport isolation in the dispatch loop: rotate on first LIVE_TRANSPORT failure; sever only after N consecutive transport failures (env `JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD`, default 3; set 1 to match old behavior); non-transport failures reset the streak; composes with Slice 73.

- Migration
  - Optional: tune `JARVIS_DW_LIVE_TRANSPORT_SEVER_THRESHOLD` (default 3).

<sup>Written for commit e9f04936a509ee80e9f1881244a197693b4ab2d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

