### PR TITLE
feat(dw): Slice 84 — DW coder-fleet end-to-end unblock (transport realignment)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -287,14 +287,54 @@ def _envi_or_default(name: str, default: int) -> int:
     except ValueError: # If the raw value cannot be parsed as an integer, return the default. This ensures that invalid env var values don't cause crashes and instead fall back to safe defaults.
         return default # Return the default value if parsing fails due to invalid format.
 
-# Model ID substring matchers for heavy models. Case-insensitive, CSV-extensible via env var. Used to apply the heavy-model scalar in the adaptive formula.
+# Slice 84 — param-aware heavy threshold. The marker fast-path ("397B","Kimi")
+# only covered two models; Slice 83 then ranked DeepSeek-V4-Pro (1000B) and
+# GLM-5.1 (754B) FIRST, but they carried NO marker → got the bare 30s TTFT cap →
+# killed at elapsed=30.01s before first token (the v44-v64 "DW down" mirage).
+# Any model at/above this parameter count is treated as heavy (deserves the
+# longer TTFT runway), so the whole frontier-coder fleet — present AND future —
+# qualifies WITHOUT a per-model marker. 100B cleanly separates the 397B+/754B+
+# workhorses (+ DeepSeek-V4-Flash 100B) from the cheap Qwen-35B fast-path model.
+_HEAVY_MODEL_MIN_PARAMS_B_DEFAULT: float = 100.0
+
+
+def _heavy_model_min_params_b() -> float:
+    """Env-tunable parameter-count floor for param-aware heavy detection."""
+    return _envf_or_default(
+        "JARVIS_HEAVY_MODEL_MIN_PARAMS_B", _HEAVY_MODEL_MIN_PARAMS_B_DEFAULT,
+    )
+
+
+# Model ID matchers for heavy models. Two paths: (1) the curated/CSV marker
+# fast-path, (2) Slice 84 param-aware fallback. Used to apply the heavy-model
+# TTFT scalar in the adaptive primary-budget formula.
 def _is_heavy_model(model_id: str) -> bool:
-    """Case-insensitive substring match against the heavy-model marker
-    list. Used to apply the 1.5× scalar in the adaptive formula."""
-    if not model_id: # Defensive: empty model_id is not heavy, avoids unnecessary env lookup.
-        return False # If model_id is empty or None, return False immediately without checking markers.
-    mid_lower = model_id.lower() # Lowercase once for efficiency since we check multiple markers.
-    return any(m.lower() in mid_lower for m in _heavy_model_markers()) # Check if any heavy model marker is a substring of the model_id (case-insensitive). Returns True if a match is found, False otherwise.
+    """True iff ``model_id`` warrants the heavy-model TTFT runway.
+
+    A model qualifies if EITHER it matches a curated/CSV marker
+    (``397B``/``Kimi``, operator-extensible) OR — Slice 84 — its resolved
+    parameter count is at/above ``JARVIS_HEAVY_MODEL_MIN_PARAMS_B`` (default
+    100B). The param path reuses Slice 82's catalog resolver (curated map +
+    ``\\d+B`` regex), so the strong DW coders (DeepSeek-V4-Pro 1000B, GLM-5.1
+    754B, …) auto-qualify with no per-model hardcoding. Fail-soft: an
+    unresolvable param count + no marker → not heavy. Pure; never raises."""
+    if not model_id:  # Defensive: empty model_id is not heavy.
+        return False
+    mid_lower = model_id.lower()  # Lowercase once for efficiency.
+    # (1) curated / CSV marker fast-path
+    if any(m.lower() in mid_lower for m in _heavy_model_markers()):
+        return True
+    # (2) Slice 84 — param-aware fallback
+    try:
+        from backend.core.ouroboros.governance.dw_catalog_client import (
+            parse_parameter_count,
+        )
+        pb = parse_parameter_count(model_id)
+        if pb is not None and pb >= _heavy_model_min_params_b():
+            return True
+    except Exception:  # noqa: BLE001 — never block dispatch on a catalog hiccup
+        pass
+    return False
 
 # Pure function for the adaptive Tier 0 timeout formula. Called by the route-aware cap selector (:func:`_tier0_rt_cap_for_route`) when the caller
 def _compute_adaptive_tier0_timeout_s(

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -117,17 +117,51 @@ _COMPLEXITY_REASONING_EFFORT = {
 }
 
 
+# Slice 84 — ordered effort scale + serveability clamp. Direct boundary probes
+# (2026-06-03) proved DW streams effort=none/low/medium cleanly (ttfb 1.4-6.3s,
+# real content) but RUPTURES the chunked stream at effort=high
+# (ClientPayloadError: TransferEncodingError) — which the dispatch then mislabels
+# live_transport. So a complexity that derives "high" (heavy_code/architectural)
+# must be clamped to a serveable ceiling before it reaches the wire. Default cap
+# "medium" (verified serveable, keeps a real CoT buffer); env-tunable up/down.
+# The explicit JARVIS_DW_REASONING_EFFORT override is NOT clamped — operator
+# intent wins (e.g. a future DW build that serves "high" cleanly).
+_EFFORT_ORDER: Tuple[str, ...] = ("none", "low", "medium", "high")
+_DW_MAX_EFFORT_DEFAULT: str = "medium"
+
+
+def _dw_max_reasoning_effort() -> str:
+    """Env-tunable serveability ceiling for DW reasoning_effort. Invalid →
+    default ``medium``. NEVER raises."""
+    raw = os.environ.get("JARVIS_DW_MAX_REASONING_EFFORT", "").strip().lower()
+    return raw if raw in _EFFORT_ORDER else _DW_MAX_EFFORT_DEFAULT
+
+
+def _clamp_reasoning_effort(eff: str) -> str:
+    """Clamp ``eff`` down to the serveable ceiling (never exceed it). An
+    unknown effort string is returned unchanged (fail-open). Pure."""
+    cap = _dw_max_reasoning_effort()
+    try:
+        if _EFFORT_ORDER.index(eff) > _EFFORT_ORDER.index(cap):
+            return cap
+    except ValueError:
+        pass
+    return eff
+
+
 def _reasoning_effort_for(complexity: str = "") -> str:
-    """Slice 55 — resolve reasoning_effort. Explicit
-    ``JARVIS_DW_REASONING_EFFORT`` wins (operator override / kill-switch);
-    otherwise derive from the op's ``task_complexity`` (unknown → ``none``,
-    preserving Slice 54's default)."""
+    """Slice 55/84 — resolve reasoning_effort. Explicit
+    ``JARVIS_DW_REASONING_EFFORT`` wins (operator override / kill-switch,
+    UNCLAMPED); otherwise derive from the op's ``task_complexity`` (unknown →
+    ``none``) and clamp to the DW-serveable ceiling (Slice 84 — ``high``
+    ruptures DW's chunked stream)."""
     env = os.environ.get("JARVIS_DW_REASONING_EFFORT", "").strip().lower()
     if env:
         return env
-    return _COMPLEXITY_REASONING_EFFORT.get(
+    derived = _COMPLEXITY_REASONING_EFFORT.get(
         (complexity or "").strip().lower(), "none",
     )
+    return _clamp_reasoning_effort(derived)
 
 
 def _reasoning_request_params(effort: str = "", *, complexity: str = "") -> dict:
@@ -2949,6 +2983,14 @@ class DoublewordProvider:
             len(result.candidates), elapsed, total_cost, len(tool_records),
             _token_usage["input"], _token_usage["output"],
         )
+
+        # Slice 84 — attach the Venom tool-loop execution records so the Iron
+        # Gate exploration gate can count this op's read_file/search_code calls
+        # (mirrors ClaudeProvider, providers.py ~5048). Without this the records
+        # were dropped and the gate saw 0/2 → rejected every DW candidate as
+        # exploration_insufficient even after a full 7-tool-call loop.
+        if tool_records:
+            result = result.with_tool_records(tool_records)
 
         # Attach Venom mutation audit (empty when no mutating tools fired).
         if venom_edits:

--- a/tests/governance/test_slice27_unified_auth_adaptive_timeout.py
+++ b/tests/governance/test_slice27_unified_auth_adaptive_timeout.py
@@ -394,8 +394,14 @@ def test_spine_phase3_heavy_marker_env_csv_override(monkeypatch) -> None:
     assert _heavy_model_markers() == ("MyCustomModel", "512B")
     assert _is_heavy_model("vendor/MyCustomModel-XL") is True
     assert _is_heavy_model("Qwen/Qwen3.5-512B-MoE") is True
-    # 397B no longer in marker list → not heavy under this config
-    assert _is_heavy_model("Qwen/Qwen3.5-397B-A17B-FP8") is False
+    # Slice 84 — markers are now ADDITIVE to a param-aware path: a 397B model
+    # stays heavy even when it is absent from the custom marker list, because
+    # 397B >= the 100B param floor (the v44-v64 regression was exactly a large
+    # coder NOT matching a marker and getting the bare 30s TTFT cap). To fully
+    # exclude a large model an operator raises JARVIS_HEAVY_MODEL_MIN_PARAMS_B.
+    assert _is_heavy_model("Qwen/Qwen3.5-397B-A17B-FP8") is True
+    monkeypatch.setenv("JARVIS_HEAVY_MODEL_MIN_PARAMS_B", "500")
+    assert _is_heavy_model("Qwen/Qwen3.5-397B-A17B-FP8") is False  # 397 < 500
 
 
 def test_spine_phase3_legacy_route_only_returns_static_90s(monkeypatch) -> None:

--- a/tests/governance/test_slice55_dynamic_effort.py
+++ b/tests/governance/test_slice55_dynamic_effort.py
@@ -23,7 +23,11 @@ def test_complexity_maps_to_effort(monkeypatch):
     assert _reasoning_effort_for("simple") == "none"
     assert _reasoning_effort_for("moderate") == "low"
     assert _reasoning_effort_for("complex") == "medium"
-    assert _reasoning_effort_for("heavy_code") == "high"
+    # Slice 84 — heavy_code/architectural map to "high" in the table, but
+    # _reasoning_effort_for now clamps to the DW-serveable ceiling (default
+    # "medium"): effort=high ruptures DW's chunked stream (ClientPayloadError:
+    # TransferEncodingError, verified by direct probe 2026-06-03).
+    assert _reasoning_effort_for("heavy_code") == "medium"
 
 
 def test_unknown_complexity_defaults_none(monkeypatch):

--- a/tests/governance/test_slice84_dw_fleet_unblock.py
+++ b/tests/governance/test_slice84_dw_fleet_unblock.py
@@ -1,0 +1,154 @@
+"""Slice 84 — DW coder-fleet end-to-end unblock (transport realignment).
+
+Root cause of the v44-v64 "DW down" blocker, found by direct boundary probes
+2026-06-03/04: it was NEVER DW being down. Three compounding JARVIS-side defects
+starved the strong DW coders the moment Slice 83 ranked them first:
+
+1. **TTFT cap blindness** (`candidate_generator._is_heavy_model`). The adaptive
+   primary-timeout widening (2.5× → 75-150s TTFT runway) only matched the
+   markers ``("397B", "Kimi")``. DeepSeek-V4-Pro (1000B) and GLM-5.1 (754B) —
+   the top-ranked coders — were NOT matched, so they got the bare 30s
+   ``_PRIMARY_MAX_TIMEOUT_S`` cap and were killed at elapsed=30.01s before first
+   token on a complex SWE-bench prompt+tool-loop. Direct probe: bare-model TTFT
+   1.4s; through JARVIS prompt+Venom loop > 30s. Confirmed live: extending the
+   markers gave DeepSeek-V4-Pro a 150s cap → it streamed + ran the full tool
+   loop + produced a candidate for $0.0031.
+
+2. **reasoning_effort=high stream rupture** (`doubleword_provider`). Direct
+   probe: DeepSeek-V4-Pro streaming at effort=none/low/medium = clean; at
+   effort=high = ``ClientPayloadError: TransferEncodingError`` (DW serving
+   ruptures the chunked stream). ``heavy_code``/``architectural`` ops map to
+   "high" → rupture → mislabeled live_transport. Clamp the max effort sent to
+   DW so it never sends the unserveable "high".
+
+3. **RT tool records not attached** (`doubleword_provider._generate_realtime`).
+   ClaudeProvider returns ``result.with_tool_records(tool_records)``; the DW RT
+   path ran the loop (search_code/read_file) but never attached the records, so
+   ``GenerationResult.tool_execution_records`` stayed empty → the Iron Gate
+   exploration gate saw 0/2 and rejected every DW candidate.
+
+The fix is principled + no-hardcoding: param-aware "heavy" (reuse Slice 82's
+catalog param resolver), an ordered effort clamp, and the one-line records
+attach. NOT the runbook's "non-blocking Aegis streaming" — `aegis/forwarding.py`
+already streams chunk-by-chunk via ``iter_any()``; the 30s was JARVIS's own TTFT
+cap, not an Aegis socket limit (verified by raising the Aegis sock_read 12× with
+no effect).
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance import candidate_generator as cg
+from backend.core.ouroboros.governance import doubleword_provider as dw
+
+
+# --- Phase 1: param-aware heavy-model detection ---
+
+def test_strong_coders_are_heavy_via_param_count(monkeypatch):
+    # No marker env — must qualify purely on parameter count (Slice 82 catalog).
+    monkeypatch.delenv("JARVIS_ADAPTIVE_HEAVY_MODEL_MARKERS", raising=False)
+    monkeypatch.delenv("JARVIS_HEAVY_MODEL_MIN_PARAMS_B", raising=False)
+    assert cg._is_heavy_model("deepseek-ai/DeepSeek-V4-Pro") is True
+    assert cg._is_heavy_model("zai-org/GLM-5.1-FP8") is True
+    assert cg._is_heavy_model("moonshotai/Kimi-K2.6") is True
+
+
+def test_small_fast_model_is_not_heavy(monkeypatch):
+    # Qwen35B is the cheap fast-path model — must NOT get the heavy runway.
+    monkeypatch.delenv("JARVIS_ADAPTIVE_HEAVY_MODEL_MARKERS", raising=False)
+    monkeypatch.delenv("JARVIS_HEAVY_MODEL_MIN_PARAMS_B", raising=False)
+    assert cg._is_heavy_model("Qwen/Qwen3.5-35B-A3B-FP8") is False
+
+
+def test_legacy_markers_still_match(monkeypatch):
+    # The curated marker fast-path must remain (397B / Kimi).
+    monkeypatch.delenv("JARVIS_ADAPTIVE_HEAVY_MODEL_MARKERS", raising=False)
+    assert cg._is_heavy_model("Qwen/Qwen3.5-397B-A17B-FP8") is True
+
+
+def test_heavy_param_threshold_env_tunable(monkeypatch):
+    monkeypatch.delenv("JARVIS_ADAPTIVE_HEAVY_MODEL_MARKERS", raising=False)
+    # raise threshold above GLM's 754B → GLM no longer heavy via params
+    monkeypatch.setenv("JARVIS_HEAVY_MODEL_MIN_PARAMS_B", "800")
+    assert cg._is_heavy_model("zai-org/GLM-5.1-FP8") is False
+    # DeepSeek-V4-Pro (1000B) still clears 800
+    assert cg._is_heavy_model("deepseek-ai/DeepSeek-V4-Pro") is True
+
+
+def test_unresolvable_model_is_not_heavy_by_param_path(monkeypatch):
+    monkeypatch.delenv("JARVIS_ADAPTIVE_HEAVY_MODEL_MARKERS", raising=False)
+    # no param, no marker → not heavy (fail-soft)
+    assert cg._is_heavy_model("acme/MysteryModel-v1") is False
+
+
+def test_heavy_model_gets_widened_primary_timeout(monkeypatch):
+    # End-to-end: the strong coder must receive MORE than the bare 30s cap.
+    monkeypatch.delenv("JARVIS_ADAPTIVE_HEAVY_MODEL_MARKERS", raising=False)
+    monkeypatch.delenv("JARVIS_HEAVY_MODEL_MIN_PARAMS_B", raising=False)
+    fn = cg.CandidateGenerator._compute_primary_budget
+    base = fn(total_s=600.0, model_id="Qwen/Qwen3.5-35B-A3B-FP8")
+    heavy = fn(total_s=600.0, model_id="deepseek-ai/DeepSeek-V4-Pro")
+    assert heavy > base, "DeepSeek-V4-Pro must get a wider TTFT runway than the 35B"
+    assert heavy > cg._PRIMARY_MAX_TIMEOUT_S
+
+
+# --- Phase 2: reasoning_effort clamp (never send the unserveable "high") ---
+
+def test_high_effort_is_clamped_to_serveable(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_REASONING_EFFORT", raising=False)
+    monkeypatch.delenv("JARVIS_DW_MAX_REASONING_EFFORT", raising=False)
+    # heavy_code/architectural map to "high" — must be clamped (high ruptures DW)
+    assert dw._reasoning_effort_for("heavy_code") != "high"
+    assert dw._reasoning_effort_for("architectural") != "high"
+
+
+def test_clamp_does_not_raise_low_efforts(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_REASONING_EFFORT", raising=False)
+    monkeypatch.delenv("JARVIS_DW_MAX_REASONING_EFFORT", raising=False)
+    # trivial/simple stay "none"; complex stays "medium" (all serveable)
+    assert dw._reasoning_effort_for("trivial") == "none"
+    assert dw._reasoning_effort_for("complex") == "medium"
+
+
+def test_clamp_env_tunable(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_REASONING_EFFORT", raising=False)
+    monkeypatch.setenv("JARVIS_DW_MAX_REASONING_EFFORT", "low")
+    assert dw._reasoning_effort_for("complex") == "low"   # medium clamped to low
+    assert dw._reasoning_effort_for("heavy_code") == "low"
+
+
+def test_explicit_override_still_wins(monkeypatch):
+    # JARVIS_DW_REASONING_EFFORT is the operator kill-switch — wins over clamp.
+    monkeypatch.setenv("JARVIS_DW_REASONING_EFFORT", "none")
+    assert dw._reasoning_effort_for("heavy_code") == "none"
+
+
+# --- Phase 3: DW RT path attaches tool records (Iron Gate exploration count) ---
+
+def test_rt_path_attaches_tool_records():
+    src = inspect.getsource(dw.DoublewordProvider._generate_realtime)
+    assert "with_tool_records(" in src, (
+        "RT path must attach tool_records so the Iron Gate exploration gate "
+        "counts read_file/search_code calls (mirrors ClaudeProvider)"
+    )
+
+
+def test_generation_result_with_tool_records_roundtrips():
+    from backend.core.ouroboros.governance.op_context import GenerationResult
+
+    class _Rec:
+        def __init__(self, name):
+            self.tool_name = name
+
+    r = GenerationResult(
+        candidates=(), provider_name="doubleword", generation_duration_s=0.0,
+    )
+    recs = (_Rec("search_code"), _Rec("read_file"))
+    r2 = r.with_tool_records(recs)
+    assert r2.tool_execution_records == recs
+    # exploration count would now see 2 read_file/search_code records
+    explore = sum(
+        1 for rec in r2.tool_execution_records
+        if rec.tool_name in {"read_file", "search_code", "get_callers"}
+    )
+    assert explore == 2


### PR DESCRIPTION
## Summary — the v44–v64 "DW down" blocker was never DW being down

Direct out-of-band boundary probes proved DW serves all coders cleanly. Three compounding **JARVIS-side** defects starved the strong coders the moment Slice 83 ranked them first. **Confirmed live**: DeepSeek-V4-Pro streamed, ran the full Venom tool loop (7 calls), produced a candidate for **$0.0031** vs Claude's $0.24 on the same problem (~77× cheaper).

### Phase 1 — param-aware heavy-model TTFT (`_is_heavy_model`)
The TTFT widening (2.5×→75-150s) only matched markers `("397B","Kimi")`. DeepSeek-V4-Pro (1000B) / GLM-5.1 (754B) carried no marker → bare **30s** cap → killed at `elapsed=30.01s` before first token. Now any model **≥100B params** (Slice 82 catalog) is heavy. Env `JARVIS_HEAVY_MODEL_MIN_PARAMS_B`.

### Phase 2 — reasoning_effort serveability clamp (`_reasoning_effort_for`)
Direct probe: `none`/`low`/`medium` stream clean; **`high` ruptures** (`TransferEncodingError`). `heavy_code`/`architectural`→`high`→rupture. Now clamped to default `medium`. Env `JARVIS_DW_MAX_REASONING_EFFORT`.

### Phase 3 — DW RT attaches tool records (`_generate_realtime`)
The RT path dropped its Venom tool records → Iron Gate exploration gate saw 0/2 → rejected every DW candidate. Now `result.with_tool_records(...)` (mirrors ClaudeProvider).

### Runbook correction (verify-first)
NOT "non-blocking Aegis streaming": `aegis/forwarding.py` already streams via `iter_any()`. The 30s was JARVIS's own TTFT cap — verified by raising the Aegis `sock_read` 12× with no effect.

## Tests
12 new + 2 updated (intended behavior changes), 330 adjacent green. The 1 `section39` route-set failure is pre-existing on clean main (verified via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the DW coder fleet by fixing heavy-model TTFT detection, clamping `reasoning_effort` to serveable levels, and attaching realtime tool records. Restores clean streaming and correct exploration scoring for top DW models.

- **Bug Fixes**
  - Param-aware heavy-model detection in `candidate_generator._is_heavy_model`: models with ≥ `JARVIS_HEAVY_MODEL_MIN_PARAMS_B` (default 100B) now get the widened TTFT runway. Uses the Slice 82 catalog resolver; markers remain additive.
  - Serveability clamp in `doubleword_provider._reasoning_effort_for`: derived efforts are clamped to `JARVIS_DW_MAX_REASONING_EFFORT` (default `medium`) to avoid `high` stream ruptures. Explicit `JARVIS_DW_REASONING_EFFORT` stays unclamped.
  - Realtime tool records in `DoublewordProvider._generate_realtime`: attaches `result.with_tool_records(...)` so Iron Gate counts exploration calls.

- **Migration**
  - Optional tuning only:
    - `JARVIS_HEAVY_MODEL_MIN_PARAMS_B` to adjust the heavy threshold.
    - `JARVIS_DW_MAX_REASONING_EFFORT` to set the serveable ceiling.

<sup>Written for commit b8ff4471ab7b91511e500f7bb9caab095c97c45a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

