### PR TITLE
feat(toolloop): Slice 85 — cumulative convergence gate + Aegis concurrency diagnostic

### DIFF
--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -4540,6 +4540,51 @@ _COMPACT_THRESHOLD_CHARS = int(
 )  # Trigger compaction at 75% of max to avoid hard crash
 
 
+# ── Slice 85 Phase 3 — cumulative convergence axis ──
+# The existing convergence nudges miss a model that EXPLORES forever by varying
+# its tools: the exploration-budget nudge only counts rounds where EVERY tool is
+# in the narrow {read_file, search_code, get_callers} set, so a round that mixes
+# in glob_files / list_dir / git_log slips past it (the 114k-token / 25-call
+# wander, sweep bt-2026-06-04-041943). This superset is the EVASION-PROOF set of
+# read-only NAVIGATION tools — any of them is "still just looking, not changing
+# anything", so all of them feed the cumulative convergence counter. Mutating /
+# progress tools (edit_file, write_file, bash, run_tests) are deliberately
+# excluded: a round that touches one is making progress, not wandering.
+_READONLY_EXPLORATION_TOOLS: frozenset = frozenset({
+    "read_file", "search_code", "get_callers", "glob_files", "list_dir",
+    "list_symbols", "git_log", "git_diff", "git_blame",
+})
+
+
+def _convergence_explore_call_threshold() -> int:
+    """Slice 85 — cumulative read-only-call count that forces convergence.
+
+    Once this many read-only navigation calls have accrued across ALL rounds,
+    the loop fires the existing Slice 3E final-write nudge ("stop exploring,
+    emit the patch"). Tool-agnostic + cumulative, so mixed-tool wandering can't
+    evade it. Default 14 (the wander hit 25; 14 catches it at ~round 4-5 while
+    leaving room for genuine multi-file localization). ``0`` opts out entirely
+    (legacy behavior). Invalid / negative → default. Env-tunable; never raises."""
+    raw = os.environ.get("JARVIS_TOOL_LOOP_CONVERGENCE_EXPLORE_CALLS", "").strip()
+    if not raw:
+        return 14
+    try:
+        v = int(raw)
+        return v if v >= 0 else 14
+    except ValueError:
+        return 14
+
+
+def _should_force_convergence(
+    *, cumulative_explore_calls: int, threshold: int,
+) -> bool:
+    """Pure trigger decision for the cumulative convergence axis. ``threshold``
+    of ``0`` disables the axis (never fires). Pure; never raises."""
+    if threshold <= 0:
+        return False
+    return cumulative_explore_calls >= threshold
+
+
 # ---------------------------------------------------------------------------
 # BudgetPlan — structural per-round timeout derivation
 # ---------------------------------------------------------------------------
@@ -5378,6 +5423,10 @@ class ToolLoopCoordinator:
         # generation deadline.
         round_index = -1
         _explore_only_rounds = 0
+        # Slice 85 Phase 3 — cumulative read-only-call counter (evasion-proof
+        # convergence axis; mixed-tool wandering still accrues here).
+        _cumulative_explore_calls = 0
+        _convergence_call_threshold = _convergence_explore_call_threshold()
         _soft_overflow_warned = False
         # ── Slice 3E — convergence-force final-write nudge ──
         # ``_final_nudge_issued`` flips True when the final-write nudge
@@ -5593,9 +5642,26 @@ class ToolLoopCoordinator:
                 not _final_nudge_issued
                 and _rounds_left_in_loop <= 1
             )
-            if (_trigger_time or _trigger_rounds) and not _final_nudge_issued:
+            # Slice 85 Phase 3 — cumulative read-only-call axis. Fires EARLY
+            # (not just at the time/round end) when the model has accrued
+            # enough read-only navigation across all rounds — the evasion-proof
+            # signal the per-round exploration-budget counter missed on the
+            # 114k wander. Reuses the same nudge + grace-round machinery.
+            _trigger_context = (
+                not _final_nudge_issued
+                and _should_force_convergence(
+                    cumulative_explore_calls=_cumulative_explore_calls,
+                    threshold=_convergence_call_threshold,
+                )
+            )
+            if (
+                (_trigger_time or _trigger_rounds or _trigger_context)
+                and not _final_nudge_issued
+            ):
                 _trigger_kind = (
-                    "time_reserve" if _trigger_time else "round_cap"
+                    "time_reserve" if _trigger_time
+                    else "round_cap" if _trigger_rounds
+                    else "context_horizon"
                 )
                 current_prompt += (
                     "\n\n[SYSTEM] FINAL ROUND — exploration budget exhausted. "
@@ -5933,6 +5999,17 @@ class ToolLoopCoordinator:
             # Count rounds where ONLY exploration tools were called.
             # When the cap is reached, inject a nudge to produce the final answer.
             _round_tool_names = {tc.name for tc, *_ in exec_results} if exec_results else set()
+            # Slice 85 Phase 3 — accrue EVERY read-only navigation call this
+            # round onto the cumulative axis (evaluated at the top of the next
+            # iteration's nudge gate). This is the evasion-proof signal: a round
+            # that mixes glob_files/list_dir/git_log into search_code is NOT
+            # "exploration-only" below, so it slips the per-round counter — but
+            # those calls are still pure looking-around, so they accrue here.
+            if exec_results:
+                _cumulative_explore_calls += sum(
+                    1 for tc, *_ in exec_results
+                    if tc.name in _READONLY_EXPLORATION_TOOLS
+                )
             if _round_tool_names and _round_tool_names <= self._EXPLORATION_TOOLS:
                 _explore_only_rounds += 1
                 if _explore_only_rounds >= self._max_exploration_rounds:

--- a/tests/aegis/test_slice85_concurrent_forwarding.py
+++ b/tests/aegis/test_slice85_concurrent_forwarding.py
@@ -1,0 +1,180 @@
+"""Slice 85 Phase 1 — Aegis concurrent-forwarding diagnostic.
+
+Verify-first gate for the runbook: the sweep's no-first-token stalls
+(first_token_ms=-1 over 175-242s on the harder problems) could be the Aegis
+proxy stalling some streams under concurrent SSE forwarding — OR an upstream
+prompt-compilation delay. A direct (Aegis-bypassing) probe already proved DW's
+endpoint handles 6 concurrent streams cleanly, so this test isolates the Aegis
+hop: it fires N concurrent PACED OpenAI-compat streams through the real Aegis
+forwarding code (`aegis/forwarding.py`, `iter_any()` chunk pass-through) and
+asserts every one demultiplexes to a complete, byte-faithful body with no stall,
+truncation, or cross-stream interference.
+
+If this stays green, Aegis forwarding is NOT the concurrency bottleneck and the
+no-first-token stalls are upstream/prompt-driven — i.e. a context/budget problem
+(Phase 3's domain), not a proxy problem. If it ever goes red, it localizes the
+stall to the proxy's transport loop. Either way it is a permanent regression pin.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.aegis.daemon import build_app
+from backend.core.ouroboros.aegis.upstream_registry import (
+    ENV_AEGIS_UPSTREAM_ANTHROPIC_URL,
+    ENV_AEGIS_UPSTREAM_DOUBLEWORD_URL,
+)
+
+from tests.aegis.test_forwarding import (
+    _budget, _PSK, _STUB_ANTHROPIC_KEY, _STUB_DW_KEY,
+)
+
+_N_CONCURRENT = 6
+_FRAMES_PER_STREAM = 12  # multi-chunk so a stall mid-stream would truncate
+
+
+def _paced_openai_sse() -> bytes:
+    frames = [
+        'data: ' + json.dumps({
+            "id": "x", "object": "chat.completion.chunk",
+            "choices": [{"delta": {"content": f"tok{i} "}, "index": 0}],
+        }) + "\n\n"
+        for i in range(_FRAMES_PER_STREAM)
+    ]
+    frames.append('data: ' + json.dumps({
+        "id": "x", "object": "chat.completion.chunk",
+        "choices": [{"delta": {}, "finish_reason": "stop", "index": 0}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": _FRAMES_PER_STREAM},
+    }) + "\n\n")
+    frames.append("data: [DONE]\n\n")
+    return "".join(frames).encode("utf-8")
+
+
+@pytest_asyncio.fixture
+async def paced_stack(tmp_path: Path, monkeypatch):
+    """Aegis + a PACED OpenAI-compat upstream (each SSE frame is a separate
+    drained write with a small sleep — forces true chunk-by-chunk forwarding)."""
+    body = _paced_openai_sse()
+
+    async def openai_handler(request: web.Request) -> web.StreamResponse:
+        await request.read()
+        resp = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "text/event-stream",
+                     "Cache-Control": "no-cache"},
+        )
+        await resp.prepare(request)
+        for event in body.split(b"\n\n"):
+            if not event:
+                continue
+            await resp.write(event + b"\n\n")
+            await resp.drain()
+            await asyncio.sleep(0.01)  # pace: simulate slow token stream
+        await resp.write_eof()
+        return resp
+
+    stub = web.Application()
+    stub.router.add_post("/v1/chat/completions", openai_handler)
+    stub_server = TestServer(stub)
+    await stub_server.start_server()
+    stub_url = f"http://{stub_server.host}:{stub_server.port}"
+
+    monkeypatch.setenv(ENV_AEGIS_UPSTREAM_ANTHROPIC_URL, stub_url)
+    monkeypatch.setenv(ENV_AEGIS_UPSTREAM_DOUBLEWORD_URL, stub_url)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", _STUB_ANTHROPIC_KEY)
+    monkeypatch.setenv("DOUBLEWORD_API_KEY", _STUB_DW_KEY)
+
+    aegis_app = build_app(
+        budget=_budget(tmp_path, session_cap=50.0, hourly_cap=50.0,
+                       route_caps={"STANDARD": 50.0, "IMMEDIATE": 50.0}),
+        bootstrap_psk=_PSK, lease_ttl_s=300, session_ttl_s=300,
+        forwarding_enabled=True,
+    )
+    aegis_server = TestServer(aegis_app)
+    client = TestClient(aegis_server)
+    await client.start_server()
+    try:
+        yield client
+    finally:
+        await client.close()
+        await stub_server.close()
+
+
+async def _establish_session(client: TestClient) -> str:
+    est = await client.post(
+        "/session/establish", headers={"Authorization": f"Bearer {_PSK}"},
+    )
+    body = await est.json()
+    return body["session_token"]
+
+
+async def _acquire_lease(client: TestClient, session_token: str, idx: int) -> str:
+    acq = await client.post(
+        "/lease/acquire",
+        headers={"Authorization": f"Bearer {session_token}"},
+        json={"op_id": f"op-conc-{idx}", "route": "STANDARD",
+              "estimated_cost_usd": 0.10, "causal_lineage_hash": "stub"},
+    )
+    acq_body = await acq.json()
+    assert acq_body["ok"] is True, f"lease {idx} denied: {acq_body}"
+    return acq_body["lease_token"]
+
+
+async def _stream_with_lease(client: TestClient, lease: str, idx: int) -> str:
+    resp = await client.post(
+        "/v1/chat/completions",
+        headers={"X-JARVIS-Lease": lease},
+        json={"model": "deepseek-ai/DeepSeek-V4-Pro", "stream": True,
+              "messages": [{"role": "user", "content": "fix it"}]},
+    )
+    assert resp.status == 200, f"stream {idx} status={resp.status}"
+    return (await resp.read()).decode("utf-8", "replace")
+
+
+async def _setup_leases(client: TestClient) -> list:
+    # One session (PSK is single-use), N leases acquired off it.
+    session = await _establish_session(client)
+    return [await _acquire_lease(client, session, i)
+            for i in range(_N_CONCURRENT)]
+
+
+@pytest.mark.asyncio
+async def test_six_concurrent_paced_streams_all_complete(paced_stack):
+    leases = await _setup_leases(paced_stack)
+    # Fire all N streams AT ONCE; every one must return complete and intact.
+    results = await asyncio.gather(
+        *[_stream_with_lease(paced_stack, leases[i], i)
+          for i in range(_N_CONCURRENT)],
+        return_exceptions=True,
+    )
+    failures = [r for r in results if isinstance(r, BaseException)]
+    assert not failures, f"concurrent forwarding raised: {failures}"
+
+    for i, bodytext in enumerate(results):
+        assert isinstance(bodytext, str)
+        assert "tok0 " in bodytext, f"stream {i} lost its first token (stall?)"
+        assert f"tok{_FRAMES_PER_STREAM - 1} " in bodytext, (
+            f"stream {i} truncated before the last token (mid-stream stall)"
+        )
+        assert "[DONE]" in bodytext, f"stream {i} missing terminator"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_streams_do_not_interleave_bodies(paced_stack):
+    leases = await _setup_leases(paced_stack)
+    results = await asyncio.gather(
+        *[_stream_with_lease(paced_stack, leases[i], i)
+          for i in range(_N_CONCURRENT)]
+    )
+    for i, bodytext in enumerate(results):
+        # exactly one terminator per stream — interleaving would dupe/split it
+        assert bodytext.count("[DONE]") == 1, (
+            f"stream {i} has {bodytext.count('[DONE]')} terminators — cross-stream bleed"
+        )

--- a/tests/governance/test_slice85_context_convergence.py
+++ b/tests/governance/test_slice85_context_convergence.py
@@ -1,0 +1,108 @@
+"""Slice 85 Phase 3 — cumulative convergence gate for the Venom tool loop.
+
+Confirmed failure (sweep bt-2026-06-04-041943): a DW op explored **25 tool calls
+across 8+ rounds / 486s / 114,800 input tokens and emitted 0 patches** — the
+"114k wander". The tool loop already HAS convergence nudges, but both axes missed
+this:
+
+- Slice 3E final-write nudge: triggers on time-reserve or rounds_left<=1 — both
+  fire only at the very END, after the wander already happened.
+- Exploration-budget nudge (`_explore_only_rounds >= _max_exploration_rounds=5`):
+  only counts rounds where EVERY tool is in the narrow
+  ``_EXPLORATION_TOOLS = {read_file, search_code, get_callers}``. The wander's
+  rounds mixed in ``glob_files`` / ``list_dir`` / ``git_log`` (all read-only
+  exploration, just not in that set), so those rounds were NOT "exploration-only",
+  the counter never reached 5, and the nudge NEVER fired (verified: 0 nudge events
+  in the wander's log).
+
+Fix: a CUMULATIVE, tool-agnostic axis. Count every read-only navigation call
+across ALL rounds (a superset that mixed-tool wandering can't evade); once the
+cumulative count crosses a threshold, fire the EXISTING Slice 3E nudge (reusing
+its grace-round machinery — no new gate). Env-tunable, no hardcoded per-tool
+limits.
+
+NOT a new compaction utility: ``context_compaction.py`` (Gap #8) already bounds
+single-round prompt size at 75% of the ceiling. The wander was a CONVERGENCE
+problem (model kept choosing to explore), not a context-size problem — compaction
+kept each round bounded while the cumulative exploration still ran away.
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance import tool_executor as te
+
+
+# --- the read-only exploration superset (evasion-proof) ---
+
+def test_readonly_exploration_superset_covers_wander_tools():
+    s = te._READONLY_EXPLORATION_TOOLS
+    # the narrow Iron-Gate set must be included...
+    for t in ("read_file", "search_code", "get_callers"):
+        assert t in s
+    # ...PLUS the navigation tools the wander used to EVADE the old counter
+    for t in ("glob_files", "list_dir", "git_log"):
+        assert t in s, f"{t} must count toward convergence (the wander evaded via it)"
+
+
+def test_mutating_tools_are_not_exploration():
+    # tools that make progress must NOT count as exploration
+    for t in ("edit_file", "write_file", "bash", "run_tests"):
+        assert t not in te._READONLY_EXPLORATION_TOOLS
+
+
+# --- the cumulative convergence threshold ---
+
+def test_convergence_threshold_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_TOOL_LOOP_CONVERGENCE_EXPLORE_CALLS", raising=False)
+    n = te._convergence_explore_call_threshold()
+    assert isinstance(n, int) and n > 0
+    # must trip well below the 25-call wander
+    assert n < 25, "default threshold must catch the 25-call wander"
+
+
+def test_convergence_threshold_env_tunable(monkeypatch):
+    monkeypatch.setenv("JARVIS_TOOL_LOOP_CONVERGENCE_EXPLORE_CALLS", "9")
+    assert te._convergence_explore_call_threshold() == 9
+
+
+def test_convergence_threshold_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("JARVIS_TOOL_LOOP_CONVERGENCE_EXPLORE_CALLS", "garbage")
+    assert te._convergence_explore_call_threshold() > 0
+
+
+def test_convergence_threshold_zero_disables(monkeypatch):
+    # 0 = opt-out (legacy behavior, never force-converge on cumulative axis)
+    monkeypatch.setenv("JARVIS_TOOL_LOOP_CONVERGENCE_EXPLORE_CALLS", "0")
+    assert te._convergence_explore_call_threshold() == 0
+
+
+# --- the pure trigger decision ---
+
+def test_cumulative_trigger_fires_at_threshold():
+    # below threshold → keep exploring; at/above → force convergence
+    assert te._should_force_convergence(cumulative_explore_calls=8, threshold=12) is False
+    assert te._should_force_convergence(cumulative_explore_calls=12, threshold=12) is True
+    assert te._should_force_convergence(cumulative_explore_calls=25, threshold=12) is True
+
+
+def test_cumulative_trigger_disabled_when_threshold_zero():
+    # threshold 0 must never fire (opt-out), even at a huge call count
+    assert te._should_force_convergence(cumulative_explore_calls=999, threshold=0) is False
+
+
+def test_wander_would_have_converged():
+    # the actual wander: 25 cumulative read-only calls vs the default threshold
+    thr = te._convergence_explore_call_threshold()
+    assert te._should_force_convergence(cumulative_explore_calls=25, threshold=thr) is True
+
+
+# --- wiring pins: the run() loop actually consumes the cumulative axis ---
+
+def test_run_loop_tracks_cumulative_and_feeds_existing_nudge():
+    src = inspect.getsource(te.ToolLoopCoordinator.run)
+    assert "_cumulative_explore_calls" in src, "loop must track cumulative read-only calls"
+    assert "_should_force_convergence(" in src, "loop must consult the cumulative trigger"
+    # composes WITH the existing Slice 3E nudge (does not replace it)
+    assert "_final_nudge_issued" in src
+    assert "_trigger_context" in src or "context" in src.lower()


### PR DESCRIPTION
Targets the **"114k wander"** (sweep bt-2026-06-04-041943): a DW op explored **25 tool calls / 8+ rounds / 486s / 114,800 input tokens and emitted 0 patches**.

### Phase 1 — Aegis concurrent-forwarding diagnostic (verify-first gate)
The no-first-token stalls (`first_token_ms=-1` over 175–242s) could be the Aegis proxy stalling streams under concurrent SSE forwarding — or upstream prompt delay. A direct probe already cleared the **DW endpoint** (6 concurrent streams → 0 ruptures). `tests/aegis/test_slice85_concurrent_forwarding.py` now fires **6 concurrent PACED streams through the real Aegis forwarding code** and asserts each demultiplexes to a complete, intact body (no stall / truncation / cross-bleed) — **GREEN**. So per the runbook's own gate, proxy + endpoint are both concurrency-clean → the stalls are **upstream prompt-compilation delay** on the hard problems (a context/budget problem, Phase 3's domain), not a proxy problem.

### Phase 2 — deliberately NOT built (would duplicate)
`context_compaction.py` (Gap #8) already bounds single-round prompt size at 75% of the ceiling. The wander was a **convergence** problem (the model kept *choosing* to explore), not a per-round size problem — compaction kept each round bounded while *cumulative* exploration ran away. No new compaction utility.

### Phase 3 — cumulative convergence axis
**Root cause:** the existing exploration-budget nudge only counts rounds where *every* tool is in the narrow `{read_file, search_code, get_callers}` set, so a round that mixed in `glob_files`/`list_dir`/`git_log` slipped past it and **the nudge never fired** (verified: 0 nudge events in the wander). **Fix:** a cumulative, tool-agnostic counter over the read-only *navigation* superset (evasion-proof — mixed-tool rounds still accrue); once it crosses `JARVIS_TOOL_LOOP_CONVERGENCE_EXPLORE_CALLS` (default 14, `0`=opt-out) it fires the **existing** Slice 3E final-write nudge via a new `_trigger_context` axis — reusing the nudge + grace-round machinery, not a new gate. The 25-call wander now converges at ~round 4–5.

## Tests
12 new (10 convergence + 2 concurrent-forwarding), all green. The 8 adjacent `tool_executor` source-pin failures are **pre-existing on clean main** (verified via stash — line-brittle pins unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops long exploratory runs in the tool loop by adding a cumulative convergence gate, and verifies Aegis concurrent SSE forwarding is clean. The 25-call wander now converges around rounds 4–5 instead of drifting.

- **New Features**
  - Cumulative counter for read-only navigation calls across rounds; triggers the existing final-write nudge when `JARVIS_TOOL_LOOP_CONVERGENCE_EXPLORE_CALLS` is reached (default 14, `0` disables).
  - Read-only superset includes `read_file`, `search_code`, `get_callers`, plus `glob_files`, `list_dir`, `git_log`, etc.; mutating tools are excluded.
  - Aegis diagnostic sends 6 paced concurrent streams through real forwarding and asserts complete, non-interleaved bodies to rule out proxy-side stalls.

<sup>Written for commit 49c044f6ac53ca2a862c4b31c3831c78533e96fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

