### PR TITLE
feat(governance): Slice 86 — benchmark-isolation event-loop hygiene (Oracle full-scan gate)

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -303,6 +303,29 @@ _COMPUTE_RANK: dict[str, int] = {
 }
 
 
+def _oracle_full_scan_suppressed_by_benchmark() -> bool:
+    """Slice 86 — True when the periodic full-repo Oracle scan must be skipped
+    because a benchmark run is in flight.
+
+    Composes the canonical ``benchmark_isolation_mode()`` (Slice 63) with a
+    dedicated kill-switch ``JARVIS_BENCHMARK_SUPPRESS_ORACLE_FULL_SCAN`` (default
+    ON) so an operator can re-enable the scan inside isolation if ever needed.
+    Pure + defensive: any import/parse error returns ``False`` (preserve legacy —
+    never silently stop indexing on an unrelated fault)."""
+    try:
+        from backend.core.ouroboros.governance.intake.intake_layer_service import (
+            benchmark_isolation_mode,
+        )
+        if not benchmark_isolation_mode():
+            return False
+        raw = os.environ.get(
+            "JARVIS_BENCHMARK_SUPPRESS_ORACLE_FULL_SCAN", "true",
+        ).strip().lower()
+        return raw not in ("0", "false", "no", "off")
+    except Exception:  # noqa: BLE001 — never block the index loop
+        return False
+
+
 class ComputeClassMismatch(RuntimeError):
     """Raised when VM compute_class is below the brain's min_compute_class."""
 
@@ -5555,6 +5578,22 @@ class GovernedLoopService:
         while True:
             try:
                 await asyncio.sleep(self._config.oracle_incremental_poll_interval_s)
+                # ── Slice 86 — benchmark-isolation event-loop hygiene ──
+                # The periodic poll below calls ``incremental_update([])``; an
+                # EMPTY list is falsy, so it falls to the else-branch FULL scan
+                # of every repo — 48-72s of CPU-bound work that FREEZES the
+                # event loop. During a benchmark run that freeze starves the DW
+                # stream-reading coroutines mid-generation (bt-2026-06-04-041943:
+                # first_token_ms=-1 / 175-242s "stalls" were ControlPlaneStarvation
+                # lag up to 10s, NOT upstream delay — DW streams content in <=35s).
+                # The consciousness Oracle index is not needed for a benchmark op
+                # (search_code uses ripgrep, not the semantic graph; the targeted
+                # post-APPLY reindex still runs via the orchestrator with the
+                # actual applied_files), so skip ONLY the periodic full scan. The
+                # loop stays alive so it resumes the moment isolation clears
+                # (hot-flip), matching the master-flag short-circuit pattern.
+                if _oracle_full_scan_suppressed_by_benchmark():
+                    continue
                 # Cooperative yield decision — Task #88f.  Read the
                 # advisor busy count via the official public surface
                 # (NOT executor._work_queue.qsize() which is private +

--- a/tests/governance/test_slice86_benchmark_oracle_isolation.py
+++ b/tests/governance/test_slice86_benchmark_oracle_isolation.py
@@ -1,0 +1,83 @@
+"""Slice 86 — benchmark-isolation event-loop hygiene for the Oracle index loop.
+
+Root cause of the multi-instance sweep "stalls" (bt-2026-06-04-041943): NOT
+upstream delay and NOT transport timeout. Direct probes proved DW streams
+content in <=35s even on a 21k-token prompt; the sweep log showed
+``ControlPlaneStarvation lag_ms`` up to 10,000ms in the exact stall window. The
+event loop was FROZEN, so the DW stream-reading coroutines could not consume the
+bytes DW had already sent (first_token_ms=-1).
+
+The freeze source: the GovernedLoop periodic Oracle index loop calls
+``incremental_update([])`` — an EMPTY list is falsy, so it falls to the
+else-branch FULL repo scan (48-72s of CPU-bound work on the loop). During a
+benchmark run the consciousness Oracle index is not needed (search_code uses
+ripgrep, not the semantic graph; the targeted post-APPLY reindex still runs via
+the orchestrator with the real applied_files). So Slice 86 skips ONLY the
+periodic full scan while ``JARVIS_BENCHMARK_ISOLATION_MODE`` is active, leaving
+the loop alive for hot-flip.
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance import governed_loop_service as gls
+
+
+def test_not_suppressed_when_isolation_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_BENCHMARK_ISOLATION_MODE", raising=False)
+    monkeypatch.delenv("JARVIS_BENCHMARK_SUPPRESS_ORACLE_FULL_SCAN", raising=False)
+    assert gls._oracle_full_scan_suppressed_by_benchmark() is False
+
+
+def test_suppressed_by_default_under_isolation(monkeypatch):
+    monkeypatch.setenv("JARVIS_BENCHMARK_ISOLATION_MODE", "true")
+    monkeypatch.delenv("JARVIS_BENCHMARK_SUPPRESS_ORACLE_FULL_SCAN", raising=False)
+    assert gls._oracle_full_scan_suppressed_by_benchmark() is True
+
+
+def test_operator_can_reenable_scan_inside_isolation(monkeypatch):
+    monkeypatch.setenv("JARVIS_BENCHMARK_ISOLATION_MODE", "true")
+    monkeypatch.setenv("JARVIS_BENCHMARK_SUPPRESS_ORACLE_FULL_SCAN", "false")
+    assert gls._oracle_full_scan_suppressed_by_benchmark() is False
+
+
+def test_suppress_flag_inert_when_isolation_off(monkeypatch):
+    # the suppress flag must do nothing unless isolation is actually on
+    monkeypatch.delenv("JARVIS_BENCHMARK_ISOLATION_MODE", raising=False)
+    monkeypatch.setenv("JARVIS_BENCHMARK_SUPPRESS_ORACLE_FULL_SCAN", "true")
+    assert gls._oracle_full_scan_suppressed_by_benchmark() is False
+
+
+def test_helper_returns_bool_for_weird_values(monkeypatch):
+    # an unrecognized value must degrade to a boolean (truthy → suppress),
+    # never raise into the index loop
+    monkeypatch.setenv("JARVIS_BENCHMARK_ISOLATION_MODE", "true")
+    monkeypatch.setenv("JARVIS_BENCHMARK_SUPPRESS_ORACLE_FULL_SCAN", "weird-value")
+    assert gls._oracle_full_scan_suppressed_by_benchmark() is True
+
+
+# --- wiring pin: the index loop actually consults the gate + skips ---
+
+def test_index_loop_consults_gate_and_continues():
+    src = inspect.getsource(gls.GovernedLoopService._oracle_index_loop)
+    assert "_oracle_full_scan_suppressed_by_benchmark()" in src, (
+        "the periodic Oracle loop must consult the benchmark-isolation gate"
+    )
+    # the gate must short-circuit the heavy scan (continue), not run it
+    gate_idx = src.index("if _oracle_full_scan_suppressed_by_benchmark()")
+    after = src[gate_idx: gate_idx + 120]
+    assert "continue" in after, "gate must `continue` (skip the full scan)"
+    # and it must sit BEFORE the actual full-scan CALL (not just a comment)
+    call_idx = src.index("await self._oracle.incremental_update([])")
+    assert call_idx > gate_idx, "gate must precede the full-scan call"
+
+
+def test_targeted_post_apply_reindex_is_not_gated():
+    # The orchestrator's post-APPLY reindex passes the real applied_files and is
+    # a SEPARATE caller — Slice 86 must not touch it (the benchmark op's own
+    # change still needs to be indexed). Pin that this loop is the only gated site.
+    src = inspect.getsource(gls.GovernedLoopService._oracle_index_loop)
+    # this loop calls the empty-list full scan...
+    assert "incremental_update([])" in src
+    # ...and the gate is the empty-list path's guard, not a global oracle off
+    assert "benchmark" in src.lower()


### PR DESCRIPTION
## The real cause of the multi-instance "stalls" — JARVIS froze its own event loop

NOT upstream delay, NOT transport timeout, NOT concurrency. Direct probes proved DW streams content in **≤35s** even on a 21k-token prompt; the sweep log (bt-2026-06-04-041943) showed **`ControlPlaneStarvation lag_ms` up to 10,000ms** in the exact stall window. The event loop was frozen, so the DW stream-reading coroutines couldn't consume the bytes DW had already sent (`first_token_ms=-1` / 175–242s).

**Freeze source:** `GovernedLoopService._oracle_index_loop` polls and calls `incremental_update([])` — an **empty list is falsy**, so it hits the else-branch **full repo scan** (48–72s of CPU-bound work on the loop). During a benchmark run the consciousness Oracle index isn't needed: `search_code` uses ripgrep (not the semantic graph), and the targeted post-APPLY reindex still runs via the orchestrator with the real `applied_files`. So skip **only** the periodic full scan while `JARVIS_BENCHMARK_ISOLATION_MODE` is active.

New `_oracle_full_scan_suppressed_by_benchmark()` composes the canonical Slice 63 `benchmark_isolation_mode()` with a kill-switch `JARVIS_BENCHMARK_SUPPRESS_ORACLE_FULL_SCAN` (default ON); pure + defensive (any fault → `False` → legacy indexing preserved). The loop `continue`s past the heavy scan but stays alive for hot-flip.

### Runbook correction (verify-first)
Declined the runbook's geometry-paced **timeout** scaling: the limiter was never the transport read timeout (the 240s primary-budget cap was), and giving DW more time does nothing when JARVIS's own loop is frozen and can't read the stream. The probe also disproved "300s prompt-compilation delay" — DW's first content token lands in ≤35s even at `medium` on a big prompt.

## Tests
7 new (`test_slice86_benchmark_oracle_isolation.py`), all green. Surgical change (1 defensive helper + 1 loop gate); module imports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents event-loop stalls during benchmark runs by skipping the Oracle periodic full-repo scan when isolation mode is on. Keeps streaming responsive while the loop stays ready to resume.

- **Bug Fixes**
  - Added a gate in `GovernedLoopService._oracle_index_loop` that checks `_oracle_full_scan_suppressed_by_benchmark()` and `continue`s to skip the empty-list full scan under isolation.
  - The helper composes `benchmark_isolation_mode()` with `JARVIS_BENCHMARK_SUPPRESS_ORACLE_FULL_SCAN` (default on); any failure returns `False` to preserve legacy indexing.
  - Targeted post-APPLY reindex remains unaffected, and ripgrep-based `search_code` continues to work during benchmarks. Added tests in `test_slice86_benchmark_oracle_isolation.py`.

<sup>Written for commit 6d4ba99f710b2c276e45d59938848f7c0c7cb6a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

