### PR TITLE
feat(dw): Slice 87 — cognitive-stall interceptor → early cascade to Tier-1 fallback

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -44,7 +44,9 @@ from backend.core.ouroboros.governance.aegis_provider_bridge import (
     merge_lease_into_session_headers as _aegis_merge_lease_headers,
 )
 from backend.core.ouroboros.governance.stream_rupture import (
+    CognitiveStallError,
     StreamRuptureError,
+    cognitive_stall_timeout_s as _cognitive_stall_timeout_s,
     stream_inter_chunk_timeout_s as _stream_inter_chunk_timeout_s,
     stream_rupture_timeout_s as _stream_rupture_timeout_s,
 )
@@ -2344,6 +2346,16 @@ class DoublewordProvider:
                     # DW stream stays observably fresh (Move 2 v4).
                     _stream_op_id = str(getattr(context, "op_id", "") or "")
                     _stream_chunk_count = 0
+                    # Slice 87 — cognitive-stall watchdog state. The inter-chunk
+                    # rupture watchdog above sees reasoning deltas and stays
+                    # alive, so a model stuck reasoning with no content runs the
+                    # FULL primary budget (the 240s/0-content capability stalls).
+                    # Track elapsed-since-first-progress while content is empty;
+                    # cascade to Tier 1 once it crosses the stall threshold.
+                    _reasoning_seen = False
+                    _content_seen = False
+                    _first_progress_at = 0.0
+                    _cognitive_stall_s = _cognitive_stall_timeout_s()
                     # Parse SSE stream with per-chunk timeout to detect stalled streams
                     while True:
                         try:
@@ -2390,7 +2402,42 @@ class DoublewordProvider:
                             # candidate still comes from `content`.
                             _reasoning_delta = delta.get("reasoning", "") or ""
                             if _reasoning_delta and not token:
-                                _reasoning_seen = True  # noqa: F841 — liveness marker
+                                _reasoning_seen = True  # liveness marker
+                            # Slice 87 — cognitive-stall watchdog. Mark first
+                            # progress (any reasoning OR content byte), flip
+                            # content_seen on the first real content token, and
+                            # cascade if content stays empty past the threshold
+                            # while the stream is otherwise alive.
+                            if (_reasoning_delta or token) and _first_progress_at == 0.0:
+                                _first_progress_at = time.monotonic()
+                            if token:
+                                _content_seen = True
+                            if (
+                                _cognitive_stall_s > 0
+                                and not _content_seen
+                                and _reasoning_seen
+                                and _first_progress_at > 0.0
+                                and (time.monotonic() - _first_progress_at)
+                                > _cognitive_stall_s
+                            ):
+                                _stall_elapsed = (
+                                    time.monotonic()
+                                    - _ttft_request_start_monotonic
+                                )
+                                logger.warning(
+                                    "[DoublewordProvider] COGNITIVE STALL: "
+                                    "model=%s reasoned %.0fs with 0 content — "
+                                    "cascading to Tier-1 fallback (op=%s)",
+                                    _effective_model, _stall_elapsed,
+                                    _stream_op_id[:24],
+                                )
+                                raise CognitiveStallError(
+                                    provider="doubleword",
+                                    elapsed_s=_stall_elapsed,
+                                    bytes_received=len(content),
+                                    stall_timeout_s=_cognitive_stall_s,
+                                    reasoning_seen=_reasoning_seen,
+                                )
                             # Priority 1 Slice 1 + Slice 2 — capture +
                             # monitor. Reads chunk's logprobs structure;
                             # feeds capturer (always when capture enabled)

--- a/backend/core/ouroboros/governance/stream_rupture.py
+++ b/backend/core/ouroboros/governance/stream_rupture.py
@@ -92,6 +92,30 @@ def stream_inter_chunk_timeout_s() -> float:
     )
 
 
+def cognitive_stall_timeout_s() -> float:
+    """Slice 87 — max seconds a DW reasoning model may stream REASONING with
+    ZERO functional content before the cognitive-stall watchdog fires and
+    cascades to the Tier-1 fallback.
+
+    Distinct from the inter-chunk watchdog (which sees reasoning bytes and stays
+    alive): this measures elapsed-since-first-progress while ``content`` is still
+    empty. Default 90s — comfortably above the legitimate reasoning-then-content
+    band (direct probes: DW emits content at 21-34s at ``medium`` on a 21k-token
+    prompt) yet far below the 240s budget the capability-stalled ops burned. So
+    a model that WILL emit content is never killed mid-think, while a model stuck
+    in a reasoning loop it can't exit cascades ~150s sooner. ``0`` disables the
+    watchdog (legacy: wait the full primary budget). Invalid → default. Never
+    raises."""
+    raw = os.environ.get("JARVIS_DW_COGNITIVE_STALL_S", "").strip()
+    if not raw:
+        return 90.0
+    try:
+        v = float(raw)
+        return v if v >= 0 else 90.0
+    except ValueError:
+        return 90.0
+
+
 # ---------------------------------------------------------------------------
 # Slice 12F-B — Budget-aware dispatch floor
 # ---------------------------------------------------------------------------
@@ -168,6 +192,48 @@ class StreamRuptureError(RuntimeError):
             f"elapsed={elapsed_s:.1f}s:"
             f"bytes={bytes_received}:"
             f"timeout={rupture_timeout_s:.0f}s"
+        )
+
+
+class CognitiveStallError(StreamRuptureError):
+    """Slice 87 — the stream is ALIVE (reasoning deltas flowing) but the model
+    has emitted ZERO functional content for longer than the cognitive-stall
+    watchdog. Distinct from a byte-level rupture: bytes ARE arriving, the model
+    is just stuck in a reasoning loop it can't exit (the 240s/0-content stalls
+    on capability-hard problems, sweep bt-2026-06-04-061913).
+
+    Subclasses :class:`StreamRuptureError` so the FSM classifier's existing
+    ``isinstance`` check routes it to TRANSIENT_TRANSPORT → an IMMEDIATE cascade
+    to the Tier-1 fallback (Claude), instead of burning the rest of the DW
+    primary budget. ``phase`` is fixed to ``"cognitive_stall"`` and the message
+    carries a distinct ``cognitive_stall:`` prefix so postmortems can tell a
+    reasoning-stall apart from a network rupture."""
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        elapsed_s: float,
+        bytes_received: int,
+        stall_timeout_s: float,
+        reasoning_seen: bool = True,
+    ) -> None:
+        self.reasoning_seen = reasoning_seen
+        self.stall_timeout_s = stall_timeout_s
+        super().__init__(
+            provider=provider,
+            elapsed_s=elapsed_s,
+            bytes_received=bytes_received,
+            rupture_timeout_s=stall_timeout_s,
+            phase="cognitive_stall",
+        )
+        # Override the message with a distinct, greppable prefix.
+        self.args = (
+            f"cognitive_stall:{provider}:"
+            f"elapsed={elapsed_s:.1f}s:"
+            f"reasoning_seen={reasoning_seen}:"
+            f"content_bytes={bytes_received}:"
+            f"stall_timeout={stall_timeout_s:.0f}s",
         )
 
 

--- a/tests/governance/test_slice87_cognitive_fallback.py
+++ b/tests/governance/test_slice87_cognitive_fallback.py
@@ -1,0 +1,118 @@
+"""Slice 87 — cognitive-stall interceptor → early cascade to the Tier-1 fallback.
+
+The 240s/0-content stalls (sweep bt-2026-06-04-061913) were a DW reasoning model
+stuck in a reasoning loop it couldn't exit: reasoning deltas kept flowing (so the
+inter-chunk rupture watchdog stayed alive) while ``content`` stayed empty until
+the full 240s primary budget expired. With Claude DISABLED there was no rescue;
+with Claude enabled the existing cascade fired only AFTER burning all 240s.
+
+Slice 87 adds an early cognitive-stall watchdog: once the stream has streamed
+reasoning for longer than ``JARVIS_DW_COGNITIVE_STALL_S`` (default 90s) with zero
+functional content, raise ``CognitiveStallError`` — a ``StreamRuptureError``
+subclass, so the FSM classifier's existing ``isinstance`` check routes it to
+TRANSIENT_TRANSPORT → an IMMEDIATE cascade to Tier-1 (Claude), ~150s sooner.
+
+NOTE the honest scope: this converts CLAUDE-SOLVABLE hard problems to victories
+via the cheapest path (DW first, Claude rescue). It does NOT manufacture
+capability — element-web / NodeBB were misses even WITH Claude, so escalating
+them still misses (it just fails faster + spends Claude $). The cascade is a
+cost-optimization, not a capability lift.
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance.stream_rupture import (
+    CognitiveStallError,
+    StreamRuptureError,
+    cognitive_stall_timeout_s,
+)
+from backend.core.ouroboros.governance import doubleword_provider as dw
+
+
+# --- the threshold helper ---
+
+def test_default_threshold_clears_legitimate_reasoning_band(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_COGNITIVE_STALL_S", raising=False)
+    t = cognitive_stall_timeout_s()
+    # must be ABOVE the legitimate content-after-reasoning band (~21-34s probe)
+    assert t >= 60.0
+    # ...and BELOW the 240s budget the capability stalls burned
+    assert t < 240.0
+
+
+def test_threshold_env_tunable(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_COGNITIVE_STALL_S", "120")
+    assert cognitive_stall_timeout_s() == 120.0
+
+
+def test_threshold_zero_disables(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_COGNITIVE_STALL_S", "0")
+    assert cognitive_stall_timeout_s() == 0.0
+
+
+def test_threshold_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_COGNITIVE_STALL_S", "garbage")
+    assert cognitive_stall_timeout_s() == 90.0
+
+
+# --- the exception routes to cascade (via subclass) ---
+
+def test_cognitive_stall_is_rupture_subclass_so_it_cascades():
+    # The FSM classifier (candidate_generator ~1723) routes any
+    # isinstance(StreamRuptureError) → TRANSIENT_TRANSPORT → immediate Tier-1
+    # cascade. The subclass relationship IS the cascade wiring.
+    err = CognitiveStallError(
+        provider="doubleword", elapsed_s=92.0, bytes_received=0,
+        stall_timeout_s=90.0, reasoning_seen=True,
+    )
+    assert isinstance(err, StreamRuptureError)
+    assert isinstance(err, RuntimeError)
+
+
+def test_cognitive_stall_carries_distinct_telemetry():
+    err = CognitiveStallError(
+        provider="doubleword", elapsed_s=92.0, bytes_received=0,
+        stall_timeout_s=90.0, reasoning_seen=True,
+    )
+    msg = str(err)
+    assert msg.startswith("cognitive_stall:"), msg
+    assert "reasoning_seen=True" in msg
+    assert err.phase == "cognitive_stall"
+    assert err.reasoning_seen is True
+
+
+def test_classifier_routes_cognitive_stall_to_transient_transport():
+    # End-to-end: feed the real classifier a CognitiveStallError and assert the
+    # cascade-eligible mode, if the classifier is reachable as a pure function.
+    from backend.core.ouroboros.governance import candidate_generator as cg
+    fn = getattr(cg, "_classify_failure_mode", None) or getattr(
+        cg, "classify_failure_mode", None,
+    )
+    if fn is None:
+        # classifier is a method, not a module fn — the subclass test above
+        # already pins the isinstance contract it relies on.
+        return
+    err = CognitiveStallError(
+        provider="doubleword", elapsed_s=92.0, bytes_received=0,
+        stall_timeout_s=90.0,
+    )
+    mode = fn(err)
+    assert "TRANSIENT_TRANSPORT" in str(mode)
+
+
+# --- wiring pin: the DW RT stream raises the stall + watchdog is gateable ---
+
+def test_rt_stream_raises_cognitive_stall_on_content_silence():
+    src = inspect.getsource(dw.DoublewordProvider._generate_realtime)
+    assert "CognitiveStallError(" in src, "RT stream must raise the stall error"
+    assert "_cognitive_stall_timeout_s()" in src, "RT stream must read the threshold"
+    # the gate must require content-silence + active reasoning (not a byte rupture)
+    assert "_content_seen" in src
+    assert "_first_progress_at" in src
+
+
+def test_watchdog_disabled_when_threshold_zero():
+    # the loop must guard on `_cognitive_stall_s > 0` so 0 fully opts out
+    src = inspect.getsource(dw.DoublewordProvider._generate_realtime)
+    assert "_cognitive_stall_s > 0" in src


### PR DESCRIPTION
## The 240s/0-content stalls were a reasoning model stuck in a loop it couldn't exit

(sweep bt-2026-06-04-061913) Reasoning deltas kept flowing — so the inter-chunk rupture watchdog stayed alive — while `content` stayed empty until the full 240s primary budget expired. With Claude disabled there was no rescue; with Claude enabled the existing cascade fired only **after** burning all 240s.

### Phase 1 — cognitive-stall watchdog (`doubleword_provider` RT stream)
Tracks elapsed-since-first-progress while content is empty; once it crosses `JARVIS_DW_COGNITIVE_STALL_S` (default **90s** — above the legitimate 21–34s reasoning→content band probed on a 21k-token prompt, below the 240s budget) with active reasoning + zero content, raises `CognitiveStallError`. `0` opts out.

### Phase 2 — reuses the **existing** cascade
`CognitiveStallError` subclasses `StreamRuptureError`, so the FSM classifier's existing `isinstance` check (candidate_generator ~1723) routes it to `TRANSIENT_TRANSPORT` → an **immediate cascade to Tier-1 (Claude)**, ~150s sooner. No new router/dispatch code — the multi-provider cost cascade already exists; this just trips it early.

### Honest scope (verify-first)
This converts **Claude-solvable** hard problems to victories via the cheapest path (DW first, Claude rescue). It does **not** manufacture capability — element-web/NodeBB were misses *even with Claude* in the macro sweep, so escalating them still misses (fails faster + spends Claude $). The cascade is a cost-optimization, not a capability lift. Declined the runbook's 25%-of-budget abort (60s would kill legitimate long-thinkers); 90s clears the probed reasoning band.

## Tests
9 new + 44 adjacent stream-rupture/reasoning green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a cognitive-stall watchdog to the `DoublewordProvider` stream that triggers an early cascade to Tier‑1 when a model keeps reasoning without emitting content. This avoids burning the full 240s budget and typically cascades ~150s sooner.

- **New Features**
  - Raise `CognitiveStallError` when reasoning flows without content past a threshold; tracked since first progress in the RT stream.
  - `CognitiveStallError` extends `StreamRuptureError`, so the existing FSM immediately cascades to Tier‑1 (Claude).
  - Config via `JARVIS_DW_COGNITIVE_STALL_S` (default 90s); `0` disables; helper `cognitive_stall_timeout_s()` added.
  - Distinct telemetry prefix (`cognitive_stall:`) and warning logs for easier postmortems.
  - Adds focused tests for threshold parsing, subclass routing, and DW wiring.

<sup>Written for commit 8fa47a3ace913c0250f9f24e4693304064d0a630. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

