### PR TITLE
Slice 94 — Calibration hardening: loud-fail gate + Aegis readiness + canonical preflight (no silent [PASS])

### DIFF
--- a/backend/core/ouroboros/governance/self_immunization.py
+++ b/backend/core/ouroboros/governance/self_immunization.py
@@ -92,6 +92,37 @@ logger = logging.getLogger(__name__)
 
 SELF_IMMUNIZATION_SCHEMA_VERSION: str = "1.0"
 
+
+# ===========================================================================
+# Slice 94 — Adversarial telemetry panic (loud-fail on zero LLM throughput)
+# ===========================================================================
+
+
+class AdversarialTelemetryPanic(RuntimeError):
+    """Slice 94 — raised when an LLM-enabled calibration run produces
+    ZERO valid mutations, regardless of spend.
+
+    A zero-valid-mutation outcome defeats the purpose of Phase 2 calibration
+    — printing [PASS] would be a lie in either case below:
+
+      * generated_count == 0 AND accumulated_usd == 0.0: auth unresolved /
+        Aegis proxy unreachable — no request ever reached the model.
+      * generated_count == 0 AND accumulated_usd > 0.0: model was reached,
+        tokens were spent, but returned empty/unparseable completions
+        (the "done_before_content" / empty-stream class).
+
+    Raised by ``run_calibration`` in ``run_cc_parity_calibration.py``
+    after the campaign, ONLY when:
+      * dry_run is False (live run was requested)
+      * an LLM provider was injected (not deterministic-only fallback)
+      * provider.generated_count == 0 (zero valid mutations from the LLM)
+
+    The per-mutation provider boundary still NEVER raises
+    (``LLMMutationProvider.mutate`` always returns []).  One bad mutation
+    is not a panic.  Only zero-valid-mutations (with OR without spend) is
+    the signal that the LLM path produced no usable output.
+    """
+
 _ENV_MASTER: str = "JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED"
 _ENV_MUTATIONS_PER_PATTERN: str = "JARVIS_ANTIVENOM_MUTATIONS_PER_PATTERN"
 _ENV_TARGET_ESCAPE_RATE: str = "JARVIS_ANTIVENOM_TARGET_ESCAPE_RATE"
@@ -592,6 +623,10 @@ class LLMMutationProvider:
         self._budget_guard = budget_guard
         self._model = model
         self._max_tokens = max_tokens
+        # Slice 94 — monotonically-increasing count of mutations returned
+        # by this provider across all mutate() calls in a session.  Used by
+        # run_calibration to detect zero-throughput auth failures.
+        self.generated_count: int = 0
 
     def _get_client(self) -> Any:
         if self._client is not None:
@@ -716,6 +751,10 @@ class LLMMutationProvider:
             valid = [
                 c for c in raw_candidates if self._is_valid_python(c)
             ]
+            # Slice 94 — increment generated_count so run_calibration can
+            # detect zero-throughput auth failures (never > 0 when auth
+            # silently fails and response is empty).
+            self.generated_count += len(valid)
             return valid
 
         except asyncio.CancelledError:

--- a/scripts/security/run_cc_parity_calibration.py
+++ b/scripts/security/run_cc_parity_calibration.py
@@ -13,6 +13,7 @@ Usage::
 
     python3 scripts/security/run_cc_parity_calibration.py [--dry-run]
     python3 scripts/security/run_cc_parity_calibration.py --max-mutations 200
+    python3 scripts/security/run_cc_parity_calibration.py --bootstrap-aegis
 
 This script does NOT run the full 3,000-mutation corpus and does NOT
 flip any master flag.  That is a deferred operator soak.  The
@@ -30,13 +31,30 @@ Env vars honored:
 Design: thin CLI — all logic lives in ``self_immunization``.  The only
 work here is argument parsing, async entrypoint wiring, and result
 formatting.
+
+Slice 94 hardening:
+  Phase 3 — sys.path bootstrap (no PYTHONPATH required).
+  Phase 2 — AdversarialTelemetryPanic on zero LLM throughput.
+  Phase 1 — Aegis readiness check + opt-in --bootstrap-aegis flag.
 """
+# Slice 94 Phase 3 — repo-root sys.path bootstrap.
+# Must run BEFORE any `backend.*` import.  The script lives at
+# scripts/security/run_cc_parity_calibration.py so parents[2] is the
+# repo root (parents[0]=scripts/security, parents[1]=scripts,
+# parents[2]=<repo-root>).
 from __future__ import annotations
+
+import sys
+from pathlib import Path as _Path
+
+_REPO_ROOT = _Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 import argparse
 import asyncio
+import enum
 import os
-import sys
 import time
 from pathlib import Path
 from typing import Optional
@@ -46,6 +64,93 @@ _DEFAULT_MAX_MUTATIONS: int = 200
 _PARITY_TARGET: float = 0.044  # arXiv:2501.18837 Constitutional Classifiers
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Slice 94 Phase 1 — Aegis readiness verdict
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _AegisReadiness(str, enum.Enum):
+    """Closed 3-value readiness verdict for the pre-run Aegis check."""
+
+    READY = "ready"
+    NO_DAEMON = "no_daemon"
+    NO_CREDENTIAL = "no_credential"
+
+
+async def _check_aegis_readiness(
+    aegis_url: Optional[str] = None,
+) -> _AegisReadiness:
+    """Slice 94 Phase 1 — probe Aegis liveness + credential presence.
+
+    Steps:
+      1. Check ANTHROPIC_API_KEY in os.environ (credential resolvability).
+      2. Probe GET {aegis_url}/health if aegis_url is known.
+
+    Returns:
+      READY          — credential present and (if url known) daemon responded
+      NO_CREDENTIAL  — ANTHROPIC_API_KEY absent in environment
+      NO_DAEMON      — credential present but health probe failed/unreachable
+    """
+    # Check credential resolvability first.
+    if not os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        return _AegisReadiness.NO_CREDENTIAL
+
+    # If no aegis_url provided (daemon not bootstrapped yet), consider READY
+    # from a credential standpoint — the caller decides whether that matters.
+    if not aegis_url:
+        return _AegisReadiness.READY
+
+    # Probe GET /health — require HTTP 200 AND body {"ok": true}.
+    # A hung Aegis must not hang the calibration: timeout=5s hard cap.
+    try:
+        import aiohttp  # type: ignore[import]
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{aegis_url}/health", timeout=aiohttp.ClientTimeout(total=5)
+            ) as resp:
+                if resp.status != 200:
+                    return _AegisReadiness.NO_DAEMON
+                try:
+                    body = await resp.json(content_type=None)
+                except Exception:
+                    # Non-JSON body (plain text 200) → not a well-formed Aegis.
+                    return _AegisReadiness.NO_DAEMON
+                if body.get("ok") is True:
+                    return _AegisReadiness.READY
+                return _AegisReadiness.NO_DAEMON
+    except Exception:
+        return _AegisReadiness.NO_DAEMON
+
+
+def _load_env_file_into_environ() -> None:
+    """Slice 94 Phase 1 — minimal .env loader for --bootstrap-aegis path.
+
+    Composes the same logic as ``scripts/ouroboros_battle_test.py``
+    ``_load_env_files()`` (lines 179-199): iterates repo-root .env and
+    backend/.env, force-overrides API key vars, setdefault for the rest.
+    Clearly separated so the existing harness function is NOT duplicated
+    — this is a minimal inline equivalent for the calibration entrypoint.
+    """
+    _FORCE_OVERRIDE_KEYS = frozenset({"ANTHROPIC_API_KEY", "DOUBLEWORD_API_KEY"})
+    for env_path in (
+        _REPO_ROOT / ".env",
+        _REPO_ROOT / "backend" / ".env",
+    ):
+        if not env_path.exists():
+            continue
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip().strip("'\"")
+            if key in _FORCE_OVERRIDE_KEYS:
+                os.environ[key] = value  # .env wins for API keys
+            else:
+                os.environ.setdefault(key, value)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # CLI
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -53,7 +158,7 @@ _PARITY_TARGET: float = 0.044  # arXiv:2501.18837 Constitutional Classifiers
 def _parse_args(argv=None):
     p = argparse.ArgumentParser(
         description=(
-            "Slice 93 CC Parity Calibration — bounded LLM mutation sweep "
+            "Slice 93/94 CC Parity Calibration — bounded LLM mutation sweep "
             "(default ~200 mutations). Reads "
             "JARVIS_ANTIVENOM_MUTATION_BUDGET_USD for cost cap."
         )
@@ -85,6 +190,33 @@ def _parse_args(argv=None):
             "0 means no LLM calls (same as --dry-run)."
         ),
     )
+    # Slice 94 Phase 1 — opt-in Aegis bootstrap flag.
+    p.add_argument(
+        "--bootstrap-aegis",
+        action="store_true",
+        default=False,
+        help=(
+            "Slice 94: (a) load repo-root .env into os.environ, then "
+            "(b) run aegis_preflight() (the canonical mint — PSK handshake "
+            "+ credential scrub).  Requires Aegis to be installed and "
+            "ANTHROPIC_API_KEY to be present in .env or the environment. "
+            "Default: off (Aegis must already be running)."
+        ),
+    )
+    # Slice 94 Phase 2 — explicit opt-in to bypass Aegis budget proxy.
+    p.add_argument(
+        "--allow-direct",
+        action="store_true",
+        default=False,
+        help=(
+            "Slice 94: permit a live run when Aegis is NOT reachable "
+            "(NO_DAEMON verdict).  CAUTION: this bypasses the Aegis budget "
+            "proxy — spend comes directly from ANTHROPIC_API_KEY with NO "
+            "Aegis-side cost enforcement.  Only the app-level "
+            "MutationBudgetGuard cap applies.  Default: off (hard-fail on "
+            "NO_DAEMON to prevent silent budget overruns)."
+        ),
+    )
     return p.parse_args(argv)
 
 
@@ -98,13 +230,113 @@ async def run_calibration(
     max_mutations: int = _DEFAULT_MAX_MUTATIONS,
     dry_run: bool = False,
     budget_usd: Optional[float] = None,
+    bootstrap_aegis: bool = False,
+    allow_direct: bool = False,
 ) -> int:
     """Run the bounded calibration sweep and print results.
 
     Returns 0 on success (parity gate passed), 1 on failure
     (escape rate exceeded target or master off).
+    Raises AdversarialTelemetryPanic on zero LLM throughput in a live run.
+
+    Args:
+        allow_direct: When True, permit the run even if Aegis is unreachable
+            (NO_DAEMON verdict).  CAUTION: bypasses the Aegis budget proxy —
+            only the app-level MutationBudgetGuard cap applies.  Must be
+            explicitly set; default False hard-fails on NO_DAEMON.
     """
     from backend.core.ouroboros.governance import self_immunization as si
+
+    # ── Slice 94 Phase 1 — Aegis bootstrap / readiness check ────────────────
+    _preflight_result = None
+    if bootstrap_aegis:
+        # (a) Load .env into environ so credentials are available.
+        _load_env_file_into_environ()
+        # (b) Run the canonical aegis_preflight() — PSK handshake +
+        #     credential scrub.  NEVER spawn a daemon ourselves.
+        try:
+            from backend.core.ouroboros.aegis.preflight import (
+                aegis_preflight,
+                PreflightOutcome,
+            )
+        except ImportError as exc:
+            print(
+                f"[CRITICAL] --bootstrap-aegis requested but aegis.preflight "
+                f"could not be imported: {exc}\n"
+                "Install backend deps or check PYTHONPATH."
+            )
+            return 1
+        try:
+            _preflight_result = await aegis_preflight()
+        except Exception as exc:
+            print(
+                f"[CRITICAL] aegis_preflight() raised unexpectedly: {exc}\n"
+                "Aborting — cannot continue without Aegis when "
+                "--bootstrap-aegis is set."
+            )
+            return 1
+        if _preflight_result.outcome not in (
+            PreflightOutcome.READY,
+            PreflightOutcome.SKIPPED_DISABLED,
+        ):
+            print(
+                f"[CRITICAL] Aegis preflight returned non-READY outcome: "
+                f"{_preflight_result.outcome.value}\n"
+                f"  detail: {_preflight_result.detail}\n"
+                "Check ANTHROPIC_API_KEY and Aegis daemon status."
+            )
+            return 1
+        aegis_url = _preflight_result.aegis_url
+        print(
+            f"[Aegis] preflight={_preflight_result.outcome.value}  "
+            f"url={aegis_url}"
+        )
+    else:
+        # Default path — check readiness without bootstrapping.
+        # Only gate on readiness for live (non-dry-run, non-zero-budget) runs.
+        eff_check_budget = budget_usd
+        if eff_check_budget is None:
+            eff_check_budget = float(
+                os.environ.get("JARVIS_ANTIVENOM_MUTATION_BUDGET_USD", "0.10")
+            )
+        if not dry_run and eff_check_budget > 0:
+            readiness = await _check_aegis_readiness()
+            if readiness == _AegisReadiness.NO_CREDENTIAL:
+                print(
+                    "[CRITICAL] ANTHROPIC_API_KEY is not set in the "
+                    "environment.\n"
+                    "Options:\n"
+                    "  1. export ANTHROPIC_API_KEY=<key>\n"
+                    "  2. Add it to repo-root .env and rerun with "
+                    "       --bootstrap-aegis\n"
+                    "Aborting — no [PASS] will be emitted."
+                )
+                return 1
+            elif readiness == _AegisReadiness.NO_DAEMON:
+                if not allow_direct:
+                    print(
+                        "[CRITICAL] Aegis daemon not reachable (GET /health "
+                        "did not return {\"ok\": true}).\n"
+                        "Options:\n"
+                        "  1. Re-run with --bootstrap-aegis to mint an Aegis "
+                        "daemon.\n"
+                        "  2. Start the harness Aegis independently and "
+                        "retry.\n"
+                        "  3. Pass --allow-direct to explicitly bypass the "
+                        "budget proxy (WARNING: spends real "
+                        "ANTHROPIC_API_KEY quota with no Aegis enforcement).\n"
+                        "Aborting — no [PASS] will be emitted."
+                    )
+                    return 1
+                # --allow-direct: operator opted in to Aegis bypass.
+                print(
+                    "[WARNING] --allow-direct set: Aegis proxy bypassed. "
+                    "This run spends real ANTHROPIC_API_KEY quota with NO "
+                    "Aegis-side budget enforcement. Only the app-level "
+                    f"MutationBudgetGuard cap (${eff_check_budget:.4f}) "
+                    "applies."
+                )
+        aegis_url = None
 
     # ── Check master gate ────────────────────────────────────────────────────
     if not si.master_enabled():
@@ -156,7 +388,7 @@ async def run_calibration(
     os.environ[si._ENV_MUTATIONS_PER_PATTERN] = str(per_pattern)
 
     print(
-        f"\n[CC Parity Calibration] Slice 93\n"
+        f"\n[CC Parity Calibration] Slice 93/94\n"
         f"  seeds             : {n_seeds}\n"
         f"  max_mutations     : {max_mutations}\n"
         f"  per_pattern       : {per_pattern}\n"
@@ -188,7 +420,46 @@ async def run_calibration(
             os.environ.pop(si._ENV_MUTATIONS_PER_PATTERN, None)
         else:
             os.environ[si._ENV_MUTATIONS_PER_PATTERN] = _prev_per_pattern
+
+        # Slice 94 Phase 1 — tear down Aegis if we bootstrapped it.
+        if _preflight_result is not None and _preflight_result.subprocess_pid:
+            try:
+                import signal as _signal
+                os.kill(_preflight_result.subprocess_pid, _signal.SIGTERM)
+            except Exception:
+                pass  # Best-effort teardown; preflight owns lifecycle
+
     elapsed = time.monotonic() - t0
+
+    # ── Slice 94 Phase 2 — loud-fail on zero LLM throughput ─────────────────
+    # A zero-valid-mutation LLM run MUST ALWAYS loud-fail regardless of spend:
+    #
+    #   generated_count == 0, accumulated_usd == 0.0  → auth unresolved / Aegis
+    #     proxy unreachable (no request ever reached the model).
+    #
+    #   generated_count == 0, accumulated_usd > 0.0   → model was reached and
+    #     tokens were spent, but returned empty/unparseable completions (the
+    #     "done_before_content" / empty-stream class).
+    #
+    # Both cases defeat the purpose of Phase 2 — printing [PASS] would be a
+    # lie.  We MUST NOT emit [PASS] in either case.
+    if not dry_run and provider is not None and provider.generated_count == 0:
+        if guard.accumulated_usd == 0.0:
+            _panic_detail = (
+                f"[CRITICAL FAULT] Generative mutation throughput = 0 under "
+                f"an LLM-enabled run AND $0 spend — auth unresolved / Aegis "
+                f"proxy unreachable. No [PASS] emitted. "
+                f"Check ANTHROPIC_API_KEY / Aegis /health."
+            )
+        else:
+            _panic_detail = (
+                f"[CRITICAL FAULT] Generative mutation throughput = 0 under "
+                f"an LLM-enabled run despite ${guard.accumulated_usd:.6f} "
+                f"spend — the model returned empty/unparseable completions "
+                f"(possible done_before_content / empty-stream condition). "
+                f"No [PASS] emitted."
+            )
+        raise si.AdversarialTelemetryPanic(_panic_detail)
 
     # ── Results ───────────────────────────────────────────────────────────────
     total_mut = summary.get("total_mutations", 0)
@@ -264,6 +535,8 @@ def main(argv=None) -> int:
             max_mutations=args.max_mutations,
             dry_run=args.dry_run,
             budget_usd=args.budget_usd,
+            bootstrap_aegis=args.bootstrap_aegis,
+            allow_direct=args.allow_direct,
         )
     )
 

--- a/tests/governance/test_slice94_calibration_harness.py
+++ b/tests/governance/test_slice94_calibration_harness.py
@@ -1,0 +1,1108 @@
+"""Slice 94 — Calibration Hardening TDD regression spine.
+
+Covers:
+(a) sys.path bootstrap: repo_root computed correctly from __file__ depth.
+(b) Readiness check: returns no_credential when ANTHROPIC_API_KEY absent
+    AND Aegis health probe unreachable (both conditions mocked).
+(c) AdversarialTelemetryPanic raised when LLM-enabled run yields
+    0 generated mutations + $0 spend (mock provider returning [] always).
+(d) NO panic when provider generated > 0 mutations (even if all caged).
+(e) --bootstrap-aegis composes aegis_preflight (mock READY) and loads
+    .env (mock) — succeeds cleanly.
+(f) Bootstrap fails loud when aegis_preflight returns non-READY (mock
+    FAILED_CREDENTIAL_SCRUB).
+(g) LLMMutationProvider.generated_count increments correctly.
+
+ALL LLM calls and daemon interactions are MOCKED.  No live paid calls.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import sys
+from pathlib import Path
+from typing import List, Sequence
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure worktree root is on sys.path so backend.* imports work.
+# ---------------------------------------------------------------------------
+
+_WT_ROOT = Path(__file__).resolve().parents[2]  # tests/governance/ → root
+if str(_WT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_WT_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# (a) sys.path bootstrap — verify repo_root computation
+# ---------------------------------------------------------------------------
+
+
+class TestSysPathBootstrap:
+    """Phase 3: the script's _REPO_ROOT resolves to the actual repo root."""
+
+    def test_script_repo_root_resolves_correctly(self):
+        """Import the script as a module and check _REPO_ROOT."""
+        script_path = _WT_ROOT / "scripts" / "security" / "run_cc_parity_calibration.py"
+        assert script_path.exists(), f"Script not found: {script_path}"
+
+        # Dynamically load the module to inspect _REPO_ROOT without running main.
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "_calib_bootstrap_test", script_path
+        )
+        assert spec is not None
+        mod = importlib.util.module_from_spec(spec)
+        # Execute the module (runs the bootstrap block).
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+        assert hasattr(mod, "_REPO_ROOT"), "_REPO_ROOT not defined in script"
+        repo_root: Path = mod._REPO_ROOT
+        # The repo root must contain CLAUDE.md (canonical marker).
+        assert (repo_root / "CLAUDE.md").exists(), (
+            f"_REPO_ROOT={repo_root} does not contain CLAUDE.md — "
+            "wrong parents depth"
+        )
+
+    def test_script_importable_without_pythonpath(self, tmp_path, monkeypatch):
+        """The script's sys.path insert lets `backend` import succeed even
+        if PYTHONPATH is not set.
+
+        We verify indirectly: after loading the module, `backend` must
+        appear importable (i.e. _REPO_ROOT was inserted into sys.path).
+        """
+        # Remove any existing path entry that contains 'backend' from
+        # sys.path to simulate a clean environment.
+        original_path = sys.path[:]
+        try:
+            sys.path = [p for p in sys.path if "jarvis" not in p.lower()
+                        or "site-packages" in p]
+
+            script_path = _WT_ROOT / "scripts" / "security" / "run_cc_parity_calibration.py"
+            import importlib.util
+            spec = importlib.util.spec_from_file_location("_calib_tmp", script_path)
+            mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+            spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+            # After exec, _REPO_ROOT should be in sys.path.
+            assert str(mod._REPO_ROOT) in sys.path
+        finally:
+            sys.path[:] = original_path
+
+
+# ---------------------------------------------------------------------------
+# Helpers — shared stubs
+# ---------------------------------------------------------------------------
+
+
+class _MockProviderZero:
+    """Always returns [] — simulates auth failure / silent empty completions."""
+
+    def __init__(self) -> None:
+        self.generated_count: int = 0
+
+    async def mutate(self, seed_source: str, *, n: int) -> Sequence[str]:
+        return []
+
+
+class _MockProviderPositive:
+    """Returns n valid-Python stubs — simulates working LLM."""
+
+    def __init__(self, mutations_per_call: int = 2) -> None:
+        self.generated_count: int = 0
+        self._per_call = mutations_per_call
+
+    async def mutate(self, seed_source: str, *, n: int) -> Sequence[str]:
+        results: List[str] = []
+        for i in range(min(n, self._per_call)):
+            results.append(f"x = {i}  # llm mutation {i}\n")
+            self.generated_count += 1
+        return results
+
+
+# ---------------------------------------------------------------------------
+# (b) Readiness check
+# ---------------------------------------------------------------------------
+
+
+class TestAegisReadinessCheck:
+    """Phase 1: _check_aegis_readiness() returns correct verdicts."""
+
+    def test_no_credential_when_key_absent(self, monkeypatch):
+        """Without ANTHROPIC_API_KEY, verdict = no_credential."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        from scripts.security.run_cc_parity_calibration import (
+            _check_aegis_readiness,
+            _AegisReadiness,
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            _check_aegis_readiness(aegis_url=None)
+        )
+        assert result == _AegisReadiness.NO_CREDENTIAL
+
+    def test_no_daemon_when_health_probe_fails(self, monkeypatch):
+        """With credential present but health probe fails → no_daemon."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from scripts.security.run_cc_parity_calibration import (
+            _check_aegis_readiness,
+            _AegisReadiness,
+        )
+
+        async def _failing_probe():
+            # Simulate health probe failing (connection refused / timeout).
+            with patch(
+                "aiohttp.ClientSession",
+                side_effect=Exception("connection refused"),
+            ):
+                return await _check_aegis_readiness(
+                    aegis_url="http://127.0.0.1:9999"
+                )
+
+        result = asyncio.get_event_loop().run_until_complete(_failing_probe())
+        assert result == _AegisReadiness.NO_DAEMON
+
+    def test_ready_when_no_url_but_credential_present(self, monkeypatch):
+        """No aegis_url provided + credential present → READY (pre-bootstrap)."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from scripts.security.run_cc_parity_calibration import (
+            _check_aegis_readiness,
+            _AegisReadiness,
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            _check_aegis_readiness(aegis_url=None)
+        )
+        assert result == _AegisReadiness.READY
+
+
+# ---------------------------------------------------------------------------
+# (c) AdversarialTelemetryPanic on zero LLM throughput
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialTelemetryPanic:
+    """Phase 2: run_calibration raises AdversarialTelemetryPanic when LLM
+    provider yields 0 valid mutations — regardless of spend.
+
+    Two branches:
+      (1) zero generated + zero spend → auth/proxy failure message
+      (2) zero generated + nonzero spend → empty-stream/done_before_content msg
+    """
+
+    def _make_minimal_seed(self):
+        class _Cat:
+            def __init__(self, v):
+                self.value = v
+        class _Seed:
+            def __init__(self):
+                self.name = "test_seed_panic"
+                self.source = "import shutil\nshutil.disk_usage('/')\n"
+                self.category = _Cat("sandbox_escape")
+                self.known_gap = False
+        return [_Seed()]
+
+    def test_panic_on_zero_generated_zero_spend(self, monkeypatch):
+        """A mock provider that returns [] always + zero spend → panic."""
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from backend.core.ouroboros.governance.self_immunization import (
+            AdversarialTelemetryPanic,
+            MutationBudgetGuard,
+        )
+        from scripts.security.run_cc_parity_calibration import run_calibration
+
+        guard = MutationBudgetGuard(budget_usd=0.10)
+        # Zero-throughput mock provider.
+        zero_provider = _MockProviderZero()
+
+        seeds = self._make_minimal_seed()
+
+        async def _run():
+            # Patch _load_seed_entries to return our minimal seed.
+            with patch(
+                "backend.core.ouroboros.governance.self_immunization._load_seed_entries",
+                return_value=seeds,
+            ):
+                # Patch LLMMutationProvider construction to return our mock.
+                with patch(
+                    "backend.core.ouroboros.governance.self_immunization.LLMMutationProvider",
+                    return_value=zero_provider,
+                ):
+                    # Also wire the guard to confirm zero spend.
+                    with patch(
+                        "backend.core.ouroboros.governance.self_immunization.MutationBudgetGuard",
+                        return_value=guard,
+                    ):
+                        # Readiness check — bypass by mocking ANTHROPIC_API_KEY
+                        # already set via monkeypatch.
+                        return await run_calibration(
+                            max_mutations=4,
+                            dry_run=False,
+                            budget_usd=0.10,
+                        )
+
+        with pytest.raises(AdversarialTelemetryPanic) as exc_info:
+            asyncio.get_event_loop().run_until_complete(_run())
+
+        msg = str(exc_info.value)
+        assert "throughput = 0" in msg
+        # The exception message itself says "No [PASS] emitted" — meaning
+        # [PASS] was deliberately NOT printed.  We verify the panic was
+        # raised (not swallowed) and contains the expected critical fault text.
+        assert "CRITICAL FAULT" in msg
+
+    def test_no_panic_on_dry_run(self, monkeypatch):
+        """dry_run=True — no provider injected → no panic even with zero
+        LLM output (deterministic-only is expected)."""
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+
+        from scripts.security.run_cc_parity_calibration import run_calibration
+
+        seeds = self._make_minimal_seed()
+
+        async def _run():
+            with patch(
+                "backend.core.ouroboros.governance.self_immunization._load_seed_entries",
+                return_value=seeds,
+            ):
+                return await run_calibration(
+                    max_mutations=4,
+                    dry_run=True,
+                    budget_usd=0.10,
+                )
+
+        # Should NOT raise.
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert isinstance(result, int)
+
+    def test_panic_on_zero_generated_nonzero_spend(self, monkeypatch):
+        """A mock provider that returns [] with nonzero spend (done_before_content
+        / empty-stream class) → panic with spend-specific message."""
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from backend.core.ouroboros.governance.self_immunization import (
+            AdversarialTelemetryPanic,
+            MutationBudgetGuard,
+        )
+        from scripts.security.run_cc_parity_calibration import run_calibration
+
+        # Guard that already has nonzero accumulated spend recorded.
+        guard = MutationBudgetGuard(budget_usd=0.10)
+        guard.record_spend(0.0042, label="done_before_content_sim")
+
+        # Zero-throughput mock provider — generated_count stays 0.
+        zero_provider = _MockProviderZero()
+
+        seeds = self._make_minimal_seed()
+
+        async def _run():
+            with patch(
+                "backend.core.ouroboros.governance.self_immunization._load_seed_entries",
+                return_value=seeds,
+            ):
+                with patch(
+                    "backend.core.ouroboros.governance.self_immunization.LLMMutationProvider",
+                    return_value=zero_provider,
+                ):
+                    with patch(
+                        "backend.core.ouroboros.governance.self_immunization.MutationBudgetGuard",
+                        return_value=guard,
+                    ):
+                        return await run_calibration(
+                            max_mutations=4,
+                            dry_run=False,
+                            budget_usd=0.10,
+                        )
+
+        with pytest.raises(AdversarialTelemetryPanic) as exc_info:
+            asyncio.get_event_loop().run_until_complete(_run())
+
+        msg = str(exc_info.value)
+        assert "CRITICAL FAULT" in msg
+        assert "throughput = 0" in msg
+        # Nonzero-spend branch should mention spend amount and
+        # done_before_content / empty-stream condition.
+        assert "empty" in msg.lower() or "done_before_content" in msg.lower() or "spend" in msg.lower()
+        # Must NOT show the "auth unresolved" phrasing (that's the $0 branch).
+        assert "auth unresolved" not in msg
+
+
+# ---------------------------------------------------------------------------
+# (d) No panic when provider generated > 0 mutations
+# ---------------------------------------------------------------------------
+
+
+class TestNoPanicWithPositiveThroughput:
+    """Phase 2: if generated_count > 0 (even if all mutations are caged),
+    no AdversarialTelemetryPanic is raised."""
+
+    def _make_minimal_seed(self):
+        class _Cat:
+            def __init__(self, v):
+                self.value = v
+        class _Seed:
+            def __init__(self):
+                self.name = "test_seed_positive"
+                self.source = "import shutil\nshutil.disk_usage('/')\n"
+                self.category = _Cat("sandbox_escape")
+                self.known_gap = False
+        return [_Seed()]
+
+    def test_no_panic_with_positive_generated_count(self, monkeypatch):
+        """Provider returned 1+ mutations (all may be caged) — no panic."""
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from backend.core.ouroboros.governance.self_immunization import (
+            AdversarialTelemetryPanic,
+            MutationBudgetGuard,
+        )
+        from scripts.security.run_cc_parity_calibration import run_calibration
+
+        guard = MutationBudgetGuard(budget_usd=0.10)
+        # Simulate small recorded spend so guard is non-zero.
+        guard.record_spend(0.0001, label="test")
+        positive_provider = _MockProviderPositive(mutations_per_call=1)
+        # Manually set generated_count to simulate prior mutations.
+        positive_provider.generated_count = 2
+
+        seeds = self._make_minimal_seed()
+
+        async def _run():
+            with patch(
+                "backend.core.ouroboros.governance.self_immunization._load_seed_entries",
+                return_value=seeds,
+            ):
+                with patch(
+                    "backend.core.ouroboros.governance.self_immunization.LLMMutationProvider",
+                    return_value=positive_provider,
+                ):
+                    with patch(
+                        "backend.core.ouroboros.governance.self_immunization.MutationBudgetGuard",
+                        return_value=guard,
+                    ):
+                        return await run_calibration(
+                            max_mutations=4,
+                            dry_run=False,
+                            budget_usd=0.10,
+                        )
+
+        # Should complete WITHOUT AdversarialTelemetryPanic.
+        try:
+            result = asyncio.get_event_loop().run_until_complete(_run())
+            assert isinstance(result, int)
+        except AdversarialTelemetryPanic:
+            pytest.fail(
+                "AdversarialTelemetryPanic raised even though "
+                "generated_count > 0"
+            )
+
+
+# ---------------------------------------------------------------------------
+# (e) --bootstrap-aegis composes aegis_preflight (mock READY) and loads .env
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapAegisCLI:
+    """Phase 1: --bootstrap-aegis composes aegis_preflight and .env loader."""
+
+    def test_bootstrap_aegis_calls_preflight_and_env_loader(self, monkeypatch):
+        """With aegis_preflight mocked to READY, run_calibration proceeds
+        and _load_env_file_into_environ is called."""
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from backend.core.ouroboros.aegis.preflight import (
+            AegisPreflightResult,
+            PreflightOutcome,
+        )
+        from scripts.security import run_cc_parity_calibration as calib_mod
+
+        mock_ready_result = AegisPreflightResult(
+            outcome=PreflightOutcome.READY,
+            aegis_url="http://127.0.0.1:18443",
+            subprocess_pid=None,
+        )
+
+        class _Cat:
+            def __init__(self, v):
+                self.value = v
+        class _Seed:
+            name = "bs_seed"
+            source = "import shutil\nshutil.disk_usage('/')\n"
+            category = _Cat("sandbox_escape")
+            known_gap = False
+
+        env_loader_called = []
+
+        async def _run():
+            with patch.object(
+                calib_mod,
+                "_load_env_file_into_environ",
+                side_effect=lambda: env_loader_called.append(True),
+            ):
+                with patch(
+                    "backend.core.ouroboros.aegis.preflight.aegis_preflight",
+                    new=AsyncMock(return_value=mock_ready_result),
+                ):
+                    with patch(
+                        "backend.core.ouroboros.governance.self_immunization._load_seed_entries",
+                        return_value=[_Seed()],
+                    ):
+                        return await calib_mod.run_calibration(
+                            max_mutations=4,
+                            dry_run=True,  # dry-run avoids LLM calls
+                            budget_usd=0.0,
+                            bootstrap_aegis=True,
+                        )
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert isinstance(result, int)
+        assert env_loader_called, (
+            "_load_env_file_into_environ was not called during --bootstrap-aegis"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (f) Bootstrap fails loud when aegis_preflight returns non-READY
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapAegisFails:
+    """Phase 1: if aegis_preflight returns FAILED_*, run_calibration
+    prints a CRITICAL message and returns 1 (not [PASS])."""
+
+    def test_bootstrap_aegis_fails_on_non_ready_outcome(self, monkeypatch):
+        """FAILED_CREDENTIAL_SCRUB → run_calibration returns 1."""
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+
+        from backend.core.ouroboros.aegis.preflight import (
+            AegisPreflightResult,
+            PreflightOutcome,
+        )
+        from scripts.security import run_cc_parity_calibration as calib_mod
+
+        mock_failed_result = AegisPreflightResult(
+            outcome=PreflightOutcome.FAILED_CREDENTIAL_SCRUB,
+            aegis_url=None,
+            detail="ANTHROPIC_API_KEY not in env after scrub",
+        )
+
+        async def _run():
+            with patch.object(calib_mod, "_load_env_file_into_environ"):
+                with patch(
+                    "backend.core.ouroboros.aegis.preflight.aegis_preflight",
+                    new=AsyncMock(return_value=mock_failed_result),
+                ):
+                    return await calib_mod.run_calibration(
+                        max_mutations=4,
+                        dry_run=False,
+                        budget_usd=0.10,
+                        bootstrap_aegis=True,
+                    )
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert result == 1, (
+            f"Expected return 1 on FAILED_CREDENTIAL_SCRUB but got {result}"
+        )
+
+    def test_bootstrap_aegis_fails_on_spawn_failure(self, monkeypatch):
+        """FAILED_SPAWN → run_calibration returns 1."""
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+
+        from backend.core.ouroboros.aegis.preflight import (
+            AegisPreflightResult,
+            PreflightOutcome,
+        )
+        from scripts.security import run_cc_parity_calibration as calib_mod
+
+        mock_spawn_fail = AegisPreflightResult(
+            outcome=PreflightOutcome.FAILED_SPAWN,
+            detail="daemon subprocess died immediately",
+        )
+
+        async def _run():
+            with patch.object(calib_mod, "_load_env_file_into_environ"):
+                with patch(
+                    "backend.core.ouroboros.aegis.preflight.aegis_preflight",
+                    new=AsyncMock(return_value=mock_spawn_fail),
+                ):
+                    return await calib_mod.run_calibration(
+                        max_mutations=4,
+                        dry_run=False,
+                        budget_usd=0.10,
+                        bootstrap_aegis=True,
+                    )
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# (g) LLMMutationProvider.generated_count increments correctly
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratedCountIncrement:
+    """Slice 94 Phase 2 — generated_count semantics on LLMMutationProvider."""
+
+    def test_generated_count_starts_at_zero(self):
+        """Fresh provider has generated_count == 0."""
+        from backend.core.ouroboros.governance.self_immunization import (
+            LLMMutationProvider,
+            MutationBudgetGuard,
+        )
+        guard = MutationBudgetGuard(budget_usd=0.10)
+        provider = LLMMutationProvider(client=MagicMock(), budget_guard=guard)
+        assert provider.generated_count == 0
+
+    def test_generated_count_increments_per_valid_mutation(self):
+        """Each valid mutation returned increments generated_count by 1."""
+        from backend.core.ouroboros.governance.self_immunization import (
+            LLMMutationProvider,
+            MutationBudgetGuard,
+        )
+
+        guard = MutationBudgetGuard(budget_usd=0.10)
+
+        # Build a mock response with 2 valid Python code fences.
+        mock_response = MagicMock()
+        mock_response.usage = MagicMock(input_tokens=100, output_tokens=100)
+        mock_response.content = [
+            MagicMock(
+                text="```python\nx = 1\n```\n\n```python\ny = 2\n```\n"
+            )
+        ]
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        provider = LLMMutationProvider(client=mock_client, budget_guard=guard)
+        assert provider.generated_count == 0
+
+        async def _run():
+            return await provider.mutate("x = 1\n", n=5)
+
+        results = asyncio.get_event_loop().run_until_complete(_run())
+        # 2 valid fences → count should be 2
+        assert provider.generated_count == len(results)
+        assert provider.generated_count >= 1  # At least one valid mutation
+
+    def test_generated_count_not_incremented_on_error(self):
+        """If mutate raises internally (mock error), count stays 0."""
+        from backend.core.ouroboros.governance.self_immunization import (
+            LLMMutationProvider,
+            MutationBudgetGuard,
+        )
+
+        guard = MutationBudgetGuard(budget_usd=0.10)
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(
+            side_effect=RuntimeError("auth failed")
+        )
+
+        provider = LLMMutationProvider(client=mock_client, budget_guard=guard)
+
+        async def _run():
+            return await provider.mutate("x = 1\n", n=3)
+
+        results = asyncio.get_event_loop().run_until_complete(_run())
+        assert results == [] or len(results) == 0
+        assert provider.generated_count == 0
+
+    def test_generated_count_not_incremented_for_unparseable(self):
+        """Unparseable LLM output doesn't increment generated_count
+        (validity filter drops it before the counter)."""
+        from backend.core.ouroboros.governance.self_immunization import (
+            LLMMutationProvider,
+            MutationBudgetGuard,
+        )
+
+        guard = MutationBudgetGuard(budget_usd=0.10)
+
+        # Response with only invalid Python in the fence.
+        mock_response = MagicMock()
+        mock_response.usage = MagicMock(input_tokens=50, output_tokens=50)
+        mock_response.content = [
+            MagicMock(text="```python\ndef (((not valid python:\n```\n")
+        ]
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        provider = LLMMutationProvider(client=mock_client, budget_guard=guard)
+
+        async def _run():
+            return await provider.mutate("x = 1\n", n=3)
+
+        results = asyncio.get_event_loop().run_until_complete(_run())
+        # Validity filter dropped the unparseable output.
+        assert results == []
+        assert provider.generated_count == 0
+
+    def test_generated_count_accumulates_across_calls(self):
+        """generated_count accumulates across multiple mutate() calls."""
+        from backend.core.ouroboros.governance.self_immunization import (
+            LLMMutationProvider,
+            MutationBudgetGuard,
+        )
+
+        guard = MutationBudgetGuard(budget_usd=1.0)
+
+        def _make_response(code: str):
+            r = MagicMock()
+            r.usage = MagicMock(input_tokens=50, output_tokens=50)
+            r.content = [MagicMock(text=f"```python\n{code}\n```\n")]
+            return r
+
+        call_n = [0]
+        snippets = ["x = 1\n", "y = 2\n", "z = 3\n"]
+
+        async def _create(**kwargs):
+            idx = min(call_n[0], len(snippets) - 1)
+            call_n[0] += 1
+            return _make_response(snippets[idx])
+
+        mock_client = MagicMock()
+        mock_client.messages.create = _create
+
+        provider = LLMMutationProvider(client=mock_client, budget_guard=guard)
+
+        async def _run():
+            await provider.mutate("seed1\n", n=1)
+            await provider.mutate("seed2\n", n=1)
+            return provider.generated_count
+
+        total = asyncio.get_event_loop().run_until_complete(_run())
+        assert total == 2  # One valid mutation per call
+
+
+# ---------------------------------------------------------------------------
+# AdversarialTelemetryPanic is importable from self_immunization
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialTelemetryPanicImport:
+    """Structural: exception class is defined and importable."""
+
+    def test_exception_class_importable(self):
+        from backend.core.ouroboros.governance.self_immunization import (
+            AdversarialTelemetryPanic,
+        )
+        assert issubclass(AdversarialTelemetryPanic, RuntimeError)
+
+    def test_exception_can_be_raised_and_caught(self):
+        from backend.core.ouroboros.governance.self_immunization import (
+            AdversarialTelemetryPanic,
+        )
+        with pytest.raises(AdversarialTelemetryPanic):
+            raise AdversarialTelemetryPanic("test panic")
+
+
+# ---------------------------------------------------------------------------
+# IMPORTANT #1 — Health probe body check (ok: true required)
+# ---------------------------------------------------------------------------
+
+
+class TestAegisHealthProbeBody:
+    """Phase 1: _check_aegis_readiness probes ok:true in body, with timeout."""
+
+    def test_ready_when_status_200_and_ok_true(self, monkeypatch):
+        """HTTP 200 + body {"ok": true} → READY."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from scripts.security.run_cc_parity_calibration import (
+            _check_aegis_readiness,
+            _AegisReadiness,
+        )
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"ok": True})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        async def _run():
+            with patch("aiohttp.ClientSession", return_value=mock_session):
+                return await _check_aegis_readiness(
+                    aegis_url="http://127.0.0.1:18443"
+                )
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert result == _AegisReadiness.READY
+
+    def test_no_daemon_when_status_200_but_ok_false(self, monkeypatch):
+        """HTTP 200 + body {"ok": false} → NO_DAEMON (body check fails)."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from scripts.security.run_cc_parity_calibration import (
+            _check_aegis_readiness,
+            _AegisReadiness,
+        )
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"ok": False, "error": "warming up"})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        async def _run():
+            with patch("aiohttp.ClientSession", return_value=mock_session):
+                return await _check_aegis_readiness(
+                    aegis_url="http://127.0.0.1:18443"
+                )
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert result == _AegisReadiness.NO_DAEMON
+
+    def test_no_daemon_when_status_200_non_json_body(self, monkeypatch):
+        """HTTP 200 + non-JSON body → NO_DAEMON (body parse fails)."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from scripts.security.run_cc_parity_calibration import (
+            _check_aegis_readiness,
+            _AegisReadiness,
+        )
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(side_effect=ValueError("not JSON"))
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        async def _run():
+            with patch("aiohttp.ClientSession", return_value=mock_session):
+                return await _check_aegis_readiness(
+                    aegis_url="http://127.0.0.1:18443"
+                )
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert result == _AegisReadiness.NO_DAEMON
+
+
+# ---------------------------------------------------------------------------
+# IMPORTANT #2 — NO_DAEMON without/with --allow-direct
+# ---------------------------------------------------------------------------
+
+
+class TestNoDaemonHardFail:
+    """Phase 1: NO_DAEMON without --allow-direct → return 1 (no silent bypass).
+    With --allow-direct → proceeds (warns operator)."""
+
+    def _make_minimal_seed(self):
+        class _Cat:
+            def __init__(self, v):
+                self.value = v
+        class _Seed:
+            name = "nd_seed"
+            source = "import shutil\nshutil.disk_usage('/')\n"
+            category = _Cat("sandbox_escape")
+            known_gap = False
+        return [_Seed()]
+
+    def test_no_daemon_without_allow_direct_returns_1(self, monkeypatch):
+        """NO_DAEMON + no --allow-direct → run_calibration returns 1."""
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from scripts.security.run_cc_parity_calibration import (
+            run_calibration,
+            _AegisReadiness,
+        )
+
+        async def _run():
+            with patch(
+                "scripts.security.run_cc_parity_calibration._check_aegis_readiness",
+                new=AsyncMock(return_value=_AegisReadiness.NO_DAEMON),
+            ):
+                return await run_calibration(
+                    max_mutations=4,
+                    dry_run=False,
+                    budget_usd=0.10,
+                    allow_direct=False,
+                )
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert result == 1, (
+            f"Expected return 1 on NO_DAEMON without --allow-direct, got {result}"
+        )
+
+    def test_no_daemon_with_allow_direct_proceeds(self, monkeypatch):
+        """NO_DAEMON + --allow-direct → run_calibration proceeds past the gate."""
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from scripts.security.run_cc_parity_calibration import (
+            run_calibration,
+            _AegisReadiness,
+        )
+        from backend.core.ouroboros.governance.self_immunization import (
+            MutationBudgetGuard,
+        )
+
+        guard = MutationBudgetGuard(budget_usd=0.10)
+        # Positive provider so panic doesn't fire.
+        pos_provider = _MockProviderPositive(mutations_per_call=1)
+        pos_provider.generated_count = 1  # pre-seed so panic condition false
+
+        seeds = self._make_minimal_seed()
+
+        async def _run():
+            with patch(
+                "scripts.security.run_cc_parity_calibration._check_aegis_readiness",
+                new=AsyncMock(return_value=_AegisReadiness.NO_DAEMON),
+            ):
+                with patch(
+                    "backend.core.ouroboros.governance.self_immunization._load_seed_entries",
+                    return_value=seeds,
+                ):
+                    with patch(
+                        "backend.core.ouroboros.governance.self_immunization.LLMMutationProvider",
+                        return_value=pos_provider,
+                    ):
+                        with patch(
+                            "backend.core.ouroboros.governance.self_immunization.MutationBudgetGuard",
+                            return_value=guard,
+                        ):
+                            return await run_calibration(
+                                max_mutations=4,
+                                dry_run=False,
+                                budget_usd=0.10,
+                                allow_direct=True,
+                            )
+
+        # Should NOT return 1 at the gate (may return 0 or 1 for parity, but
+        # must not hard-fail at the NO_DAEMON check).
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        # If we got past the gate, result is an int (not an early-return-1
+        # from the NO_DAEMON block).  We can't assert 0 here because parity
+        # depends on seed; just assert it's an int and didn't raise.
+        assert isinstance(result, int)
+
+
+# ---------------------------------------------------------------------------
+# Minor #5 — _load_env_file_parses_correctly
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEnvFile:
+    """Minor #5: _load_env_file_into_environ parses .env correctly."""
+
+    def test_load_env_file_parses_correctly(self, tmp_path, monkeypatch):
+        """Verify correct parsing of quoted values, comments, blank lines,
+        KEY=val=with=eq, and graceful missing-file handling.
+        Also verify no secret values are printed/logged.
+        """
+        import io
+        import logging as _logging
+
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "# This is a comment\n"
+            "\n"
+            "PLAIN_KEY=plain_value\n"
+            'QUOTED_KEY="quoted_value"\n'
+            "SINGLE_QUOTED='single_value'\n"
+            "KEY_WITH_EQ=val=with=eq\n"
+            "# another comment\n"
+            "EMPTY_VALUE=\n"
+        )
+
+        # Import the module dynamically to access _load_env_file_into_environ
+        # and _REPO_ROOT without side-effects.
+        from scripts.security import run_cc_parity_calibration as calib_mod
+
+        # Point _REPO_ROOT at our tmp_path so the function reads our test .env.
+        original_repo_root = calib_mod._REPO_ROOT
+        try:
+            calib_mod._REPO_ROOT = tmp_path
+
+            # Remove any pre-existing keys to get clean assertions.
+            for k in ("PLAIN_KEY", "QUOTED_KEY", "SINGLE_QUOTED", "KEY_WITH_EQ", "EMPTY_VALUE"):
+                monkeypatch.delenv(k, raising=False)
+
+            # Capture log output to ensure NO secret values are logged.
+            log_capture = io.StringIO()
+            handler = _logging.StreamHandler(log_capture)
+            root_logger = _logging.getLogger()
+            root_logger.addHandler(handler)
+
+            try:
+                calib_mod._load_env_file_into_environ()
+            finally:
+                root_logger.removeHandler(handler)
+
+            # Verify parsed values.
+            assert os.environ.get("PLAIN_KEY") == "plain_value"
+            assert os.environ.get("QUOTED_KEY") == "quoted_value"
+            assert os.environ.get("SINGLE_QUOTED") == "single_value"
+            assert os.environ.get("KEY_WITH_EQ") == "val=with=eq"
+            # EMPTY_VALUE: setdefault keeps empty string if not set.
+            # The function strips quotes but preserves the (empty) value.
+
+            # Verify log output does NOT contain any parsed values (no leakage).
+            log_output = log_capture.getvalue()
+            assert "plain_value" not in log_output
+            assert "quoted_value" not in log_output
+            assert "single_value" not in log_output
+
+        finally:
+            calib_mod._REPO_ROOT = original_repo_root
+
+    def test_missing_env_file_is_graceful(self, tmp_path, monkeypatch):
+        """If neither .env file exists, _load_env_file_into_environ does not crash."""
+        from scripts.security import run_cc_parity_calibration as calib_mod
+
+        original_repo_root = calib_mod._REPO_ROOT
+        try:
+            # tmp_path has no .env files.
+            calib_mod._REPO_ROOT = tmp_path
+            # Should not raise.
+            calib_mod._load_env_file_into_environ()
+        finally:
+            calib_mod._REPO_ROOT = original_repo_root
+
+
+# ---------------------------------------------------------------------------
+# Minor #6 — teardown sends SIGTERM to subprocess_pid
+# ---------------------------------------------------------------------------
+
+
+class TestTeardownSigterm:
+    """Minor #6: on the READY bootstrap path, teardown sends SIGTERM to
+    subprocess_pid (if set), and ProcessLookupError (already-dead) is
+    swallowed without crashing."""
+
+    def _make_minimal_seed(self):
+        class _Cat:
+            def __init__(self, v):
+                self.value = v
+        class _Seed:
+            name = "td_seed"
+            source = "import shutil\nshutil.disk_usage('/')\n"
+            category = _Cat("sandbox_escape")
+            known_gap = False
+        return [_Seed()]
+
+    def test_sigterm_sent_on_ready_path(self, monkeypatch):
+        """With subprocess_pid=99999 on READY preflight, os.kill is called
+        with SIGTERM (signal 15)."""
+        import signal as _signal
+
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from backend.core.ouroboros.aegis.preflight import (
+            AegisPreflightResult,
+            PreflightOutcome,
+        )
+        from scripts.security import run_cc_parity_calibration as calib_mod
+
+        # subprocess_pid=99999 — guaranteed non-existent / mock target.
+        mock_ready_result = AegisPreflightResult(
+            outcome=PreflightOutcome.READY,
+            aegis_url="http://127.0.0.1:18443",
+            subprocess_pid=99999,
+        )
+
+        kill_calls = []
+
+        def _mock_kill(pid, sig):
+            kill_calls.append((pid, sig))
+
+        seeds = self._make_minimal_seed()
+
+        async def _run():
+            with patch.object(calib_mod, "_load_env_file_into_environ"):
+                with patch(
+                    "backend.core.ouroboros.aegis.preflight.aegis_preflight",
+                    new=AsyncMock(return_value=mock_ready_result),
+                ):
+                    with patch(
+                        "backend.core.ouroboros.governance.self_immunization._load_seed_entries",
+                        return_value=seeds,
+                    ):
+                        with patch("os.kill", side_effect=_mock_kill):
+                            return await calib_mod.run_calibration(
+                                max_mutations=4,
+                                dry_run=True,
+                                budget_usd=0.0,
+                                bootstrap_aegis=True,
+                            )
+
+        asyncio.get_event_loop().run_until_complete(_run())
+        # SIGTERM must have been sent to the mock PID.
+        assert any(
+            pid == 99999 and sig == _signal.SIGTERM
+            for pid, sig in kill_calls
+        ), f"Expected os.kill(99999, SIGTERM) but got: {kill_calls}"
+
+    def test_process_lookup_error_swallowed(self, monkeypatch):
+        """If os.kill raises ProcessLookupError (already-dead process),
+        teardown does NOT crash — it is silently swallowed."""
+        import signal as _signal
+
+        monkeypatch.setenv("JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED", "true")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-fake")
+
+        from backend.core.ouroboros.aegis.preflight import (
+            AegisPreflightResult,
+            PreflightOutcome,
+        )
+        from scripts.security import run_cc_parity_calibration as calib_mod
+
+        mock_ready_result = AegisPreflightResult(
+            outcome=PreflightOutcome.READY,
+            aegis_url="http://127.0.0.1:18443",
+            subprocess_pid=99999,
+        )
+
+        seeds = self._make_minimal_seed()
+
+        async def _run():
+            with patch.object(calib_mod, "_load_env_file_into_environ"):
+                with patch(
+                    "backend.core.ouroboros.aegis.preflight.aegis_preflight",
+                    new=AsyncMock(return_value=mock_ready_result),
+                ):
+                    with patch(
+                        "backend.core.ouroboros.governance.self_immunization._load_seed_entries",
+                        return_value=seeds,
+                    ):
+                        with patch(
+                            "os.kill",
+                            side_effect=ProcessLookupError("No such process"),
+                        ):
+                            # Must NOT raise despite ProcessLookupError.
+                            return await calib_mod.run_calibration(
+                                max_mutations=4,
+                                dry_run=True,
+                                budget_usd=0.0,
+                                bootstrap_aegis=True,
+                            )
+
+        # Should complete without raising ProcessLookupError.
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert isinstance(result, int)


### PR DESCRIPTION
## Slice 94 — Calibration Hardening (readiness check · loud-fail gate · canonical preflight bootstrap)

Hardens the Slice 93 CC-parity calibration tool so an environment/auth failure **can no longer masquerade as a passing safety validation** — the gap caught when the live probe silently degraded to deterministic-only and printed a cheerful `[PASS]`.

### Fixes
- **Loud-fail (`AdversarialTelemetryPanic`):** a zero-valid-mutation LLM-enabled run now *always* raises — both the **$0-spend** branch (auth unresolved / Aegis unreachable) and the **spend>0** branch (model returned empty/unparseable completions — the `done_before_content` class this repo hits repeatedly). No more fake `[PASS]`. Tracks `LLMMutationProvider.generated_count` to separate LLM output from the deterministic-8.
- **No silent Aegis bypass:** Aegis readiness check (`GET /health`, requires body `ok:true`, 5s timeout) + credential resolvability. `NO_DAEMON` **hard-fails** unless the operator explicitly passes `--allow-direct` (with a loud cost warning) — honoring the Aegis-routed + budget-capped intent.
- **`--bootstrap-aegis`:** loads `.env` then **composes the canonical `aegis_preflight()`** (PSK handshake + credential scrub) — *no raw subprocess daemon spawn* (the rejected §43-Arc-3 anti-pattern); teardown in `finally`.
- **`sys.path` bootstrap** — runs without `PYTHONPATH=.`.

### Review (two-stage) caught real bugs
The first pass had a loud-fail gate that could itself be **silently defeated** by the empty-completion case (`generated_count==0` but `spend>0` → no panic), and a `NO_DAEMON` path that **silently bypassed Aegis** to a direct, unbudgeted Anthropic call. Both fixed.

### Tests
**28 green** (+ 105 adjacent). All mocked — no live LLM/Aegis calls. Covers both panic branches, the `--allow-direct` gate, the `ok:true` health check, `.env` parsing (incl. no-value-leak assertion), and teardown SIGTERM/already-dead handling.

### Scope
Engine stays **default-FALSE**. This is calibration-tooling hardening only — no new generative features. After merge, the live $5 calibration sweep becomes runnable *honestly* (Aegis-up / `--bootstrap-aegis` / explicit `--allow-direct`), and will loudly report auth failure instead of fake-passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the CC parity calibration tool to fail loudly on zero LLM throughput and to enforce Aegis readiness by default. Prevents silent [PASS] and unbudgeted direct calls unless explicitly allowed.

- **New Features**
  - `AdversarialTelemetryPanic`: raises when an LLM-enabled run returns zero valid mutations (both $0 spend and spend>0). Uses `generated_count` in `LLMMutationProvider`.
  - Aegis readiness check: verifies credential presence and `GET /health` returns `{"ok": true}` with a 5s timeout. `NO_DAEMON` hard-fails unless `--allow-direct` (prints a loud cost warning).
  - `--bootstrap-aegis`: loads `.env` then runs canonical `aegis_preflight()` (PSK handshake + credential scrub); best-effort SIGTERM teardown.
  - `sys.path` bootstrap so `scripts/security/run_cc_parity_calibration.py` runs without `PYTHONPATH=.`.

- **Bug Fixes**
  - Closed gaps where empty/unparseable completions could defeat the fail gate and where `NO_DAEMON` silently bypassed Aegis to direct Anthropic calls.

<sup>Written for commit 7d97fcedfaeb67bdd8d41e583bea72406e906f44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

