### PR TITLE
fix(security): Slice 95a-2 — decouple LLM mutation quota from deterministic fill + honest config-vs-auth loud-fail

### DIFF
--- a/backend/core/ouroboros/governance/self_immunization.py
+++ b/backend/core/ouroboros/governance/self_immunization.py
@@ -98,6 +98,20 @@ SELF_IMMUNIZATION_SCHEMA_VERSION: str = "1.0"
 # ===========================================================================
 
 
+class ConfigStarvationError(RuntimeError):
+    """Slice 95a-2 — raised when the LLM was NEVER INVOKED because n=0
+    for every seed (deterministic operators filled the per-seed budget,
+    leaving the generative provider starved with n=0).
+
+    This is a CONFIGURATION issue — not an auth/Aegis fault.  The fix is
+    to raise ``--max-mutations`` or pass an explicit ``llm_per_seed`` quota
+    so the generative provider is actually exercised.
+
+    Distinct from :class:`AdversarialTelemetryPanic` (which fires when the
+    LLM WAS invoked but returned no usable output).
+    """
+
+
 class AdversarialTelemetryPanic(RuntimeError):
     """Slice 94 — raised when an LLM-enabled calibration run produces
     ZERO valid mutations, regardless of spend.
@@ -839,6 +853,13 @@ class LLMMutationProvider:
         # by this provider across all mutate() calls in a session.  Used by
         # run_calibration to detect zero-throughput auth failures.
         self.generated_count: int = 0
+        # Slice 95a-2 — count of mutate() calls where n>0 AND the request
+        # actually reached messages.create (i.e. past the n<=0 early-return
+        # and budget-exhausted short-circuit).  Stays 0 when the LLM was
+        # never invoked (config-starvation).  Distinguished from
+        # generated_count: call_attempts>0 + generated_count==0 means the
+        # LLM was reached but returned nothing (auth/empty-stream).
+        self.call_attempts: int = 0
 
     def _get_client(self) -> Any:
         if self._client is not None:
@@ -963,6 +984,11 @@ class LLMMutationProvider:
         # Per-mutation generation — genuine model/parse errors are swallowed.
         # AegisLeaseError (raised above) has already propagated before here.
         # ------------------------------------------------------------------
+        # Slice 95a-2 — increment call_attempts here, just before the request.
+        # This fires for every n>0 call that reaches the model path (past
+        # the early-returns above).  Stays 0 for n=0 (early-return) and when
+        # the budget is exhausted (short-circuit before this point).
+        self.call_attempts += 1
         try:
             client = self._get_client()
             prompt = self._prompt_factory(seed_source, n)
@@ -1541,6 +1567,7 @@ async def run_immunization_campaign(
     mutation_provider: Optional[MutationProvider] = None,
     hardening_sink: Optional[HardeningSink] = None,
     corpus_sink: Optional["CorpusCacheSink"] = None,
+    llm_per_seed: Optional[int] = None,
 ) -> AsyncGenerator[ImmunizationReport, None]:
     """Async generator yielding one :class:`ImmunizationReport` per seed
     in *completion order*.
@@ -1553,6 +1580,16 @@ async def run_immunization_campaign(
 
     Concurrency is bounded by the canonical process-singleton semaphore
     (no homegrown ``asyncio.Semaphore`` literal in this module).
+
+    Args:
+        llm_per_seed: Slice 95a-2 — explicit LLM quota per seed.  When
+            provided (and mutation_provider is set), the LLM is called
+            with ``n = min(llm_per_seed, _MAX_MUTATIONS_PER_PATTERN)``
+            regardless of how many deterministic candidates were produced.
+            Deterministic-8 still run first as the baseline/control; the
+            LLM adds its quota on top.  When None (default), the legacy
+            ``n = max(0, per_pattern - len(candidates))`` formula applies
+            (backward-compatible — other callers unaffected).
     """
     if not master_enabled():
         yield _master_off_report()
@@ -1633,10 +1670,26 @@ async def run_immunization_campaign(
         # Slice 93: mutate is now async; campaign awaits it.
         # Validity filter: LLM candidates failing ast.parse are recorded
         # as UNPARSEABLE and excluded from the escape-rate denominator.
+        #
+        # Slice 95a-2: llm_per_seed decoupling.
+        # When llm_per_seed is provided, the LLM quota is independent of
+        # the deterministic count — the LLM ALWAYS gets its quota (capped
+        # at _MAX_MUTATIONS_PER_PATTERN).  When None, the legacy formula
+        # max(0, per_pattern - len(candidates)) is preserved for backward-
+        # compat (callers that don't pass llm_per_seed are unaffected).
         if mutation_provider is not None:
             try:
+                if llm_per_seed is not None:
+                    # Slice 95a-2 — decoupled explicit quota; cap at max.
+                    _llm_n = min(
+                        max(0, int(llm_per_seed)),
+                        _MAX_MUTATIONS_PER_PATTERN,
+                    )
+                else:
+                    # Legacy formula — can be 0 when deterministic fills budget.
+                    _llm_n = max(0, per_pattern - len(candidates))
                 extra = await mutation_provider.mutate(
-                    seed_src, n=max(0, per_pattern - len(candidates))
+                    seed_src, n=_llm_n
                 )
                 for src in (extra or ()):
                     if not isinstance(src, str):
@@ -1670,7 +1723,10 @@ async def run_immunization_campaign(
                         )
                         continue
                     candidates.append(cand)
-                    if len(candidates) >= per_pattern:
+                    # Slice 95a-2: in decoupled llm_per_seed mode, the LLM
+                    # is additive — don't cap at per_pattern.  In legacy
+                    # mode (llm_per_seed=None), honour the per_pattern bound.
+                    if llm_per_seed is None and len(candidates) >= per_pattern:
                         break
             except asyncio.CancelledError:
                 raise
@@ -1774,12 +1830,18 @@ async def summarize_campaign(
     mutation_provider: Optional[MutationProvider] = None,
     hardening_sink: Optional[HardeningSink] = None,
     corpus_sink: Optional["CorpusCacheSink"] = None,
+    llm_per_seed: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Drain :func:`run_immunization_campaign` into one aggregate dict.
 
     The §41.11.2 acceptance gate reads ``overall_escape_rate`` against
     the Constitutional-Classifiers ``target_escape_rate`` (≤0.044).
     NEVER raises.
+
+    Args:
+        llm_per_seed: Slice 95a-2 — forwarded to run_immunization_campaign.
+            When provided, LLM is invoked with this quota per seed
+            independent of the deterministic count.  None = legacy behavior.
     """
     reports: List[ImmunizationReport] = []
     try:
@@ -1788,6 +1850,7 @@ async def summarize_campaign(
             mutation_provider=mutation_provider,
             hardening_sink=hardening_sink,
             corpus_sink=corpus_sink,
+            llm_per_seed=llm_per_seed,
         ):
             reports.append(rep)
     except asyncio.CancelledError:
@@ -1797,6 +1860,23 @@ async def summarize_campaign(
             "[SelfImmunization] summarize_campaign drain failed",
             exc_info=True,
         )
+
+    # Slice 95a-2 — extract LLM observability from the provider.
+    _llm_call_attempts: int = (
+        getattr(mutation_provider, "call_attempts", 0) or 0
+    )
+    _llm_generated_count: int = (
+        getattr(mutation_provider, "generated_count", 0) or 0
+    )
+    # spend is read from the budget_guard if available; fall back to 0.0.
+    _llm_spend_usd: float = 0.0
+    if mutation_provider is not None:
+        _guard = getattr(mutation_provider, "_budget_guard", None)
+        if _guard is not None:
+            try:
+                _llm_spend_usd = float(_guard.accumulated_usd)
+            except Exception:  # noqa: BLE001
+                pass
 
     if reports and reports[0].outcome is ImmunizationOutcome.MASTER_OFF:
         return {
@@ -1809,6 +1889,11 @@ async def summarize_campaign(
             "target_escape_rate": _target_escape_rate(),
             "meets_parity_gate": False,
             "vulnerable_seeds": [],
+            # Slice 95a-2 observability
+            "llm_call_attempts": _llm_call_attempts,
+            "llm_generated_count": _llm_generated_count,
+            "llm_spend_usd": _llm_spend_usd,
+            "llm_per_seed": llm_per_seed,
         }
 
     total_escaped = sum(r.escaped_count for r in reports)
@@ -1839,6 +1924,12 @@ async def summarize_campaign(
             for r in reports
             if r.outcome is ImmunizationOutcome.NO_EVALUABLE_MUTATIONS
         ),
+        # Slice 95a-2 — LLM observability fields for auditability.
+        # Enables panic message grounding and run-level telemetry.
+        "llm_call_attempts": _llm_call_attempts,
+        "llm_generated_count": _llm_generated_count,
+        "llm_spend_usd": _llm_spend_usd,
+        "llm_per_seed": llm_per_seed,
     }
 
 

--- a/scripts/security/run_cc_parity_calibration.py
+++ b/scripts/security/run_cc_parity_calibration.py
@@ -57,7 +57,7 @@ import enum
 import os
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 
 _DEFAULT_MAX_MUTATIONS: int = 200
@@ -217,7 +217,125 @@ def _parse_args(argv=None):
             "NO_DAEMON to prevent silent budget overruns)."
         ),
     )
+    # Slice 95a-2 — explicit LLM-per-seed quota override.
+    p.add_argument(
+        "--llm-per-seed",
+        type=int,
+        default=None,
+        help=(
+            "Slice 95a-2: explicit LLM quota (mutations per seed). "
+            "Overrides the auto-derived max_mutations // num_seeds formula. "
+            "When set, the LLM is called with exactly this many mutations "
+            "per seed regardless of deterministic count. "
+            "Capped at JARVIS_ANTIVENOM_MUTATIONS_PER_PATTERN (default 200). "
+            "Default: None (auto-derived from --max-mutations)."
+        ),
+    )
     return p.parse_args(argv)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Slice 95a-2 — LLM quota helpers + honest loud-fail
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _derive_llm_per_seed(
+    *,
+    max_mutations: int,
+    num_seeds: int,
+    override: Optional[int],
+) -> int:
+    """Slice 95a-2 — compute the per-seed LLM quota.
+
+    When ``override`` is provided (from ``--llm-per-seed``), return it
+    directly (the caller is responsible for capping at
+    ``_MAX_MUTATIONS_PER_PATTERN``).
+
+    Otherwise: ``max(1, max_mutations // num_seeds)`` — ensures ≥1 so the
+    LLM is always exercised when a provider is active.  The ≥1 floor is
+    load-bearing: prevents the config-starvation class where ``n=0`` for
+    all seeds when ``max_mutations < num_seeds``.
+    """
+    if override is not None:
+        return max(1, int(override))
+    n = max(1, max_mutations // max(num_seeds, 1))
+    return n
+
+
+def _loud_fail_on_zero_llm_throughput(
+    *,
+    provider: Optional[Any],
+    guard: Any,
+    dry_run: bool,
+) -> None:
+    """Slice 95a-2 — honest loud-fail: distinguish config-starvation from
+    auth/empty-stream failure.
+
+    Three mutually exclusive paths:
+
+    1. ``provider is None`` or ``dry_run=True`` → no-op (not an LLM run).
+    2. ``provider.call_attempts == 0`` → the LLM was NEVER INVOKED (n=0 for
+       all seeds — a CONFIG issue, not an auth fault).  Raises
+       :class:`ConfigStarvationError` with a ``[CONFIG]`` header.
+    3. ``provider.call_attempts > 0`` and ``provider.generated_count == 0``
+       → the LLM WAS invoked but produced nothing.  Two sub-cases:
+         a. ``$0 spend`` — auth unresolved / Aegis unreachable.
+         b. ``spend > 0`` — model returned empty/unparseable completions.
+       Both raise :class:`AdversarialTelemetryPanic` (real failure).
+    4. ``provider.generated_count > 0`` → normal operation; no panic.
+    """
+    if dry_run or provider is None:
+        return
+
+    # Import here — script runs sys.path bootstrap at module level; these
+    # imports must not happen at import time.
+    from backend.core.ouroboros.governance.self_immunization import (
+        AdversarialTelemetryPanic,
+        ConfigStarvationError,
+    )
+
+    call_attempts: int = getattr(provider, "call_attempts", 0) or 0
+    generated_count: int = getattr(provider, "generated_count", 0) or 0
+    accumulated_usd: float = 0.0
+    try:
+        accumulated_usd = float(getattr(guard, "accumulated_usd", 0.0) or 0.0)
+    except Exception:
+        pass
+
+    if generated_count > 0:
+        # Normal operation — LLM produced usable mutations.
+        return
+
+    if call_attempts == 0:
+        # Config starvation — LLM was never even called (n=0 for every seed).
+        raise ConfigStarvationError(
+            "[CONFIG] LLM was never invoked (n=0 for all seeds — the "
+            "deterministic operators filled the per-seed budget, leaving "
+            "the generative provider starved). "
+            "Raise --max-mutations or set --llm-per-seed so the generative "
+            "provider is exercised.  No auth/Aegis fault."
+        )
+
+    # call_attempts > 0 and generated_count == 0 → real LLM failure.
+    if accumulated_usd == 0.0:
+        _panic_detail = (
+            f"[CRITICAL FAULT] Generative mutation throughput = 0 under "
+            f"an LLM-enabled run AND $0 spend — auth unresolved / Aegis "
+            f"proxy unreachable (call_attempts={call_attempts}, "
+            f"generated_count=0, spend=$0.000000). "
+            f"No [PASS] emitted.  "
+            f"Check ANTHROPIC_API_KEY / Aegis /health."
+        )
+    else:
+        _panic_detail = (
+            f"[CRITICAL FAULT] Generative mutation throughput = 0 under "
+            f"an LLM-enabled run despite ${accumulated_usd:.6f} spend — "
+            f"the model returned empty/unparseable completions "
+            f"(call_attempts={call_attempts}, generated_count=0, "
+            f"possible done_before_content / empty-stream condition). "
+            f"No [PASS] emitted."
+        )
+    raise AdversarialTelemetryPanic(_panic_detail)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -232,18 +350,23 @@ async def run_calibration(
     budget_usd: Optional[float] = None,
     bootstrap_aegis: bool = False,
     allow_direct: bool = False,
+    llm_per_seed_override: Optional[int] = None,
 ) -> int:
     """Run the bounded calibration sweep and print results.
 
     Returns 0 on success (parity gate passed), 1 on failure
     (escape rate exceeded target or master off).
     Raises AdversarialTelemetryPanic on zero LLM throughput in a live run.
+    Raises ConfigStarvationError when the LLM is never invoked (n=0 all
+    seeds) — distinct from auth failures.
 
     Args:
         allow_direct: When True, permit the run even if Aegis is unreachable
             (NO_DAEMON verdict).  CAUTION: bypasses the Aegis budget proxy —
             only the app-level MutationBudgetGuard cap applies.  Must be
             explicitly set; default False hard-fails on NO_DAEMON.
+        llm_per_seed_override: Slice 95a-2 — explicit LLM quota per seed.
+            When provided, overrides the auto-derived formula.  None = auto.
     """
     from backend.core.ouroboros.governance import self_immunization as si
 
@@ -400,11 +523,25 @@ async def run_calibration(
     _prev_per_pattern = os.environ.get(si._ENV_MUTATIONS_PER_PATTERN)
     os.environ[si._ENV_MUTATIONS_PER_PATTERN] = str(per_pattern)
 
+    # Slice 95a-2 — derive llm_per_seed (≥1 so the LLM is always exercised).
+    # The ≥1 floor is load-bearing: prevents config-starvation where n=0 for
+    # every seed when deterministic-8 fills the per_pattern budget.
+    _llm_per_seed: Optional[int] = None
+    if provider is not None:
+        _llm_per_seed = _derive_llm_per_seed(
+            max_mutations=max_mutations,
+            num_seeds=n_seeds,
+            override=llm_per_seed_override,
+        )
+        # Cap at _MAX_MUTATIONS_PER_PATTERN.
+        _llm_per_seed = min(_llm_per_seed, si._MAX_MUTATIONS_PER_PATTERN)
+
     print(
-        f"\n[CC Parity Calibration] Slice 93/94\n"
+        f"\n[CC Parity Calibration] Slice 93/94/95a-2\n"
         f"  seeds             : {n_seeds}\n"
         f"  max_mutations     : {max_mutations}\n"
         f"  per_pattern       : {per_pattern}\n"
+        f"  llm_per_seed      : {_llm_per_seed if _llm_per_seed is not None else 'N/A (dry-run/no provider)'}\n"
         f"  budget_usd        : ${eff_budget:.4f}\n"
         f"  dry_run           : {dry_run}\n"
         f"  provider          : {'LLMMutationProvider' if provider else 'deterministic-only'}\n"
@@ -425,6 +562,7 @@ async def run_calibration(
             seeds=seeds,
             mutation_provider=provider,
             corpus_sink=corpus_sink,
+            llm_per_seed=_llm_per_seed,
         )
     finally:
         # Restore the per-pattern env so the process environment is not
@@ -444,35 +582,14 @@ async def run_calibration(
 
     elapsed = time.monotonic() - t0
 
-    # ── Slice 94 Phase 2 — loud-fail on zero LLM throughput ─────────────────
-    # A zero-valid-mutation LLM run MUST ALWAYS loud-fail regardless of spend:
-    #
-    #   generated_count == 0, accumulated_usd == 0.0  → auth unresolved / Aegis
-    #     proxy unreachable (no request ever reached the model).
-    #
-    #   generated_count == 0, accumulated_usd > 0.0   → model was reached and
-    #     tokens were spent, but returned empty/unparseable completions (the
-    #     "done_before_content" / empty-stream class).
-    #
-    # Both cases defeat the purpose of Phase 2 — printing [PASS] would be a
-    # lie.  We MUST NOT emit [PASS] in either case.
-    if not dry_run and provider is not None and provider.generated_count == 0:
-        if guard.accumulated_usd == 0.0:
-            _panic_detail = (
-                f"[CRITICAL FAULT] Generative mutation throughput = 0 under "
-                f"an LLM-enabled run AND $0 spend — auth unresolved / Aegis "
-                f"proxy unreachable. No [PASS] emitted. "
-                f"Check ANTHROPIC_API_KEY / Aegis /health."
-            )
-        else:
-            _panic_detail = (
-                f"[CRITICAL FAULT] Generative mutation throughput = 0 under "
-                f"an LLM-enabled run despite ${guard.accumulated_usd:.6f} "
-                f"spend — the model returned empty/unparseable completions "
-                f"(possible done_before_content / empty-stream condition). "
-                f"No [PASS] emitted."
-            )
-        raise si.AdversarialTelemetryPanic(_panic_detail)
+    # ── Slice 95a-2 — honest loud-fail (config-starvation vs auth-failure) ────
+    # Replaces the Slice 94 Phase 2 inline block with the extracted helper
+    # _loud_fail_on_zero_llm_throughput, which distinguishes:
+    #   call_attempts==0 → ConfigStarvationError ("[CONFIG]" — not auth)
+    #   call_attempts>0, generated==0 → AdversarialTelemetryPanic (real fail)
+    _loud_fail_on_zero_llm_throughput(
+        provider=provider, guard=guard, dry_run=dry_run
+    )
 
     # ── Results ───────────────────────────────────────────────────────────────
     total_mut = summary.get("total_mutations", 0)
@@ -487,6 +604,12 @@ async def run_calibration(
         guard.accumulated_usd / max(total_mut, 1) if total_mut > 0 else 0.0
     )
 
+    # Slice 95a-2 — observability fields from summary (backed by provider counters).
+    _obs_call_attempts: int = summary.get("llm_call_attempts", 0)
+    _obs_generated: int = summary.get("llm_generated_count", 0)
+    _obs_spend: float = summary.get("llm_spend_usd", 0.0)
+    _obs_llm_per_seed = summary.get("llm_per_seed", _llm_per_seed)
+
     print(
         f"[Results]\n"
         f"  elapsed_s         : {elapsed:.1f}\n"
@@ -498,6 +621,9 @@ async def run_calibration(
         f"  llm_spend_usd     : ${guard.accumulated_usd:.6f}\n"
         f"  remaining_usd     : ${guard.remaining_usd:.6f}\n"
         f"  cost_per_mutation : ${cost_per_mut:.6f}\n"
+        f"  llm_call_attempts : {_obs_call_attempts}\n"
+        f"  llm_generated_cnt : {_obs_generated}\n"
+        f"  llm_per_seed      : {_obs_llm_per_seed}\n"
     )
 
     if guard.cost_ledger():
@@ -550,6 +676,7 @@ def main(argv=None) -> int:
             budget_usd=args.budget_usd,
             bootstrap_aegis=args.bootstrap_aegis,
             allow_direct=args.allow_direct,
+            llm_per_seed_override=getattr(args, "llm_per_seed", None),
         )
     )
 

--- a/tests/governance/test_slice94_calibration_harness.py
+++ b/tests/governance/test_slice94_calibration_harness.py
@@ -99,12 +99,21 @@ class TestSysPathBootstrap:
 
 
 class _MockProviderZero:
-    """Always returns [] — simulates auth failure / silent empty completions."""
+    """Always returns [] — simulates auth failure / silent empty completions.
+
+    Slice 95a-2: call_attempts is incremented when n>0 (matching real
+    LLMMutationProvider behaviour) so the loud-fail logic correctly
+    routes to AdversarialTelemetryPanic (LLM was invoked but returned
+    nothing) rather than ConfigStarvationError (LLM never invoked).
+    """
 
     def __init__(self) -> None:
         self.generated_count: int = 0
+        self.call_attempts: int = 0  # Slice 95a-2
 
     async def mutate(self, seed_source: str, *, n: int) -> Sequence[str]:
+        if n > 0:
+            self.call_attempts += 1  # Slice 95a-2: attempted, returned nothing
         return []
 
 

--- a/tests/governance/test_slice95a2_llm_quota.py
+++ b/tests/governance/test_slice95a2_llm_quota.py
@@ -1,0 +1,640 @@
+"""Slice 95a-2 — LLM quota decouple + honest loud-fail + observability.
+
+TDD regression spine.  ALL LLM calls are MOCKED — zero live calls.
+
+Test plan
+---------
+A. llm_per_seed decoupled quota
+   A1. run_immunization_campaign with llm_per_seed=5: mock provider called
+       with n=5 per seed, regardless of how many deterministic candidates
+       were produced.
+   A2. llm_per_seed=None: backward-compat — n = max(0, per_pattern - len(det))
+       (can be 0 when deterministic fills the budget).
+   A3. llm_per_seed cap: llm_per_seed > _MAX_MUTATIONS_PER_PATTERN is capped.
+
+B. call_attempts tracking on LLMMutationProvider
+   B1. call_attempts increments when n>0 and request is attempted.
+   B2. call_attempts stays 0 when n=0 (early-return path).
+   B3. call_attempts increments even when model returns [] (attempt = request).
+
+C. Loud-fail distinction: config-starvation vs auth-failure
+   C1. call_attempts==0 AND generated_count==0 → ConfigStarvationError (NOT
+       AdversarialTelemetryPanic) with "[CONFIG]" in message.
+   C2. call_attempts>0 AND generated_count==0, spend==0 → AdversarialTelemetryPanic
+       with "auth unresolved / Aegis" in message.
+   C3. call_attempts>0 AND generated_count==0, spend>0 → AdversarialTelemetryPanic
+       with "empty/unparseable completions" in message.
+   C4. call_attempts>0 AND generated_count>0 → no panic (normal operation).
+
+D. Observability fields in summarize_campaign
+   D1. Summary dict includes llm_call_attempts, llm_generated_count,
+       llm_spend_usd, llm_per_seed.
+
+E. Calibration derives llm_per_seed >= 1
+   E1. run_calibration with max_mutations=100 and N seeds → llm_per_seed >= 1.
+   E2. --llm-per-seed CLI override parsed correctly.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional, Sequence
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# sys.path bootstrap
+# ---------------------------------------------------------------------------
+
+_WT_ROOT = Path(__file__).resolve().parents[2]
+if str(_WT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_WT_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _fence(text: str = "y = 1\n") -> str:
+    return f"```python\n{text}\n```"
+
+
+def _make_mock_response(text: str = "```python\ny = 1\n```") -> MagicMock:
+    block = MagicMock()
+    block.text = text
+    usage = MagicMock()
+    usage.input_tokens = 50
+    usage.output_tokens = 20
+    resp = MagicMock()
+    resp.content = [block]
+    resp.usage = usage
+    return resp
+
+
+def _make_mock_client(response=None) -> MagicMock:
+    if response is None:
+        response = _make_mock_response()
+    client = MagicMock()
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(return_value=response)
+    return client
+
+
+# Patch paths shared across tests
+_AEGIS_ENABLED_PATH = "backend.core.ouroboros.aegis.client.is_enabled"
+_AEGIS_BRIDGE_PATH = "backend.core.ouroboros.governance.aegis_provider_bridge"
+
+
+def _make_minimal_seed():
+    """Return a minimal seed-like object with a .source attribute."""
+    from backend.core.ouroboros.governance.self_immunization import (
+        _load_seed_entries,
+    )
+    seeds = _load_seed_entries()
+    if seeds:
+        return seeds[0]
+    # Fallback synthetic seed
+    seed = MagicMock()
+    seed.name = "test_seed"
+    seed.source = "x = 1\n"
+    from backend.core.ouroboros.governance.graduation.adversarial_cage import CorpusCategory
+    seed.category = CorpusCategory.SANDBOX_ESCAPE
+    return seed
+
+
+# ---------------------------------------------------------------------------
+# A. llm_per_seed decoupled quota
+# ---------------------------------------------------------------------------
+
+class TestLlmPerSeedDecoupled:
+    """A — llm_per_seed flows as an independent LLM quota."""
+
+    def test_a1_llm_called_with_llm_per_seed_n_regardless_of_deterministic(self):
+        """A1: with llm_per_seed=5, provider.mutate is called n=5 per seed,
+        even when deterministic-8 already produced >= 5 candidates.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+
+        mock_client = _make_mock_client()
+        provider = si.LLMMutationProvider(client=mock_client)
+
+        call_ns: List[int] = []
+
+        async def _capture_mutate(seed_src, *, n):
+            call_ns.append(n)
+            # Return a valid python snippet so generated_count advances
+            return ["y = x + 1\n"] * min(n, 1)
+
+        provider.mutate = _capture_mutate  # type: ignore[assignment]
+
+        seed = _make_minimal_seed()
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            with patch.dict(os.environ, {
+                si._ENV_MUTATIONS_PER_PATTERN: "3",
+                "JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED": "true",
+            }):
+                async def _run_campaign():
+                    async for _ in si.run_immunization_campaign(
+                        seeds=[seed],
+                        mutation_provider=provider,
+                        llm_per_seed=5,
+                    ):
+                        pass
+
+                _run(_run_campaign())
+
+        # Provider must have been called with n=5 for the seed
+        assert len(call_ns) >= 1, "provider.mutate was never called"
+        assert all(n == 5 for n in call_ns), (
+            f"Expected n=5 for all calls, got: {call_ns}"
+        )
+
+    def test_a2_llm_per_seed_none_preserves_legacy_n_formula(self):
+        """A2: llm_per_seed=None → n = max(0, per_pattern - len(candidates)),
+        which is 0 when deterministic fills the budget.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+
+        mock_client = _make_mock_client()
+        provider = si.LLMMutationProvider(client=mock_client)
+
+        call_ns: List[int] = []
+
+        async def _capture_mutate(seed_src, *, n):
+            call_ns.append(n)
+            return []
+
+        provider.mutate = _capture_mutate  # type: ignore[assignment]
+
+        seed = _make_minimal_seed()
+
+        # Set per_pattern low (e.g. 3) so deterministic-8 fills the quota
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            with patch.dict(os.environ, {
+                si._ENV_MUTATIONS_PER_PATTERN: "3",
+                "JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED": "true",
+            }):
+                async def _run_campaign():
+                    async for _ in si.run_immunization_campaign(
+                        seeds=[seed],
+                        mutation_provider=provider,
+                        llm_per_seed=None,  # explicit None = legacy behavior
+                    ):
+                        pass
+
+                _run(_run_campaign())
+
+        # With deterministic-8 producing >= 3 candidates, n should be 0
+        # (or provider not called at all — both acceptable for legacy compat)
+        if call_ns:
+            assert all(n == 0 for n in call_ns), (
+                f"Legacy formula should yield n=0 (det fills budget), got: {call_ns}"
+            )
+
+    def test_a3_llm_per_seed_capped_at_max_mutations_per_pattern(self):
+        """A3: llm_per_seed above _MAX_MUTATIONS_PER_PATTERN is capped.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+
+        mock_client = _make_mock_client()
+        provider = si.LLMMutationProvider(client=mock_client)
+
+        call_ns: List[int] = []
+
+        async def _capture_mutate(seed_src, *, n):
+            call_ns.append(n)
+            return []
+
+        provider.mutate = _capture_mutate  # type: ignore[assignment]
+
+        seed = _make_minimal_seed()
+        # Pass a value way above the max
+        oversized = si._MAX_MUTATIONS_PER_PATTERN + 500
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            with patch.dict(os.environ, {
+                si._ENV_MUTATIONS_PER_PATTERN: "3",
+                "JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED": "true",
+            }):
+                async def _run_campaign():
+                    async for _ in si.run_immunization_campaign(
+                        seeds=[seed],
+                        mutation_provider=provider,
+                        llm_per_seed=oversized,
+                    ):
+                        pass
+
+                _run(_run_campaign())
+
+        if call_ns:
+            assert all(n <= si._MAX_MUTATIONS_PER_PATTERN for n in call_ns), (
+                f"llm_per_seed must be capped at _MAX_MUTATIONS_PER_PATTERN "
+                f"({si._MAX_MUTATIONS_PER_PATTERN}), got: {call_ns}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# B. call_attempts tracking
+# ---------------------------------------------------------------------------
+
+class TestCallAttempts:
+    """B — call_attempts tracks actual request attempts."""
+
+    def test_b1_call_attempts_increments_when_n_gt_0_and_request_attempted(self):
+        """B1: call_attempts += 1 per mutate(n>0) that reaches messages.create.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+
+        mock_client = _make_mock_client()
+        provider = si.LLMMutationProvider(client=mock_client)
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            with patch(
+                f"{_AEGIS_BRIDGE_PATH}.merge_lease_header",
+                return_value={},
+            ):
+                result = _run(provider.mutate("x = 1\n", n=3))
+
+        assert provider.call_attempts == 1, (
+            f"Expected call_attempts=1 after one n=3 call, got {provider.call_attempts}"
+        )
+
+    def test_b2_call_attempts_stays_zero_for_n_eq_0(self):
+        """B2: call_attempts unchanged when n=0 (early-return).
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+
+        mock_client = _make_mock_client()
+        provider = si.LLMMutationProvider(client=mock_client)
+
+        result = _run(provider.mutate("x = 1\n", n=0))
+
+        assert result == [] or result == ()
+        assert provider.call_attempts == 0, (
+            f"call_attempts must stay 0 for n=0, got {provider.call_attempts}"
+        )
+        # messages.create should never have been called
+        mock_client.messages.create.assert_not_called()
+
+    def test_b3_call_attempts_increments_even_when_model_returns_empty(self):
+        """B3: call_attempts increments even when model response yields 0 valid.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+
+        # Mock client returns empty-text response (no code fences)
+        empty_resp = MagicMock()
+        empty_resp.content = []
+        empty_resp.usage = MagicMock(input_tokens=10, output_tokens=0)
+        mock_client = _make_mock_client(empty_resp)
+        provider = si.LLMMutationProvider(client=mock_client)
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            with patch(
+                f"{_AEGIS_BRIDGE_PATH}.merge_lease_header",
+                return_value={},
+            ):
+                result = _run(provider.mutate("x = 1\n", n=3))
+
+        # generated_count stays 0 (nothing valid returned)
+        assert provider.generated_count == 0
+        # BUT call_attempts should be 1 — a request was sent
+        assert provider.call_attempts == 1, (
+            f"Expected call_attempts=1 even with empty response, "
+            f"got {provider.call_attempts}"
+        )
+
+    def test_b4_call_attempts_accumulates_across_multiple_calls(self):
+        """B4: call_attempts accumulates correctly over multiple mutate calls.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+
+        mock_client = _make_mock_client()
+        provider = si.LLMMutationProvider(client=mock_client)
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            with patch(
+                f"{_AEGIS_BRIDGE_PATH}.merge_lease_header",
+                return_value={},
+            ):
+                _run(provider.mutate("x = 1\n", n=2))
+                _run(provider.mutate("y = 2\n", n=2))
+                _run(provider.mutate("z = 3\n", n=0))  # should NOT increment
+
+        assert provider.call_attempts == 2, (
+            f"Expected 2 call_attempts (two n>0 calls), got {provider.call_attempts}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# C. Loud-fail distinction
+# ---------------------------------------------------------------------------
+
+class TestLoudFailDistinction:
+    """C — config-starvation vs auth-failure must produce distinct errors."""
+
+    def _make_zero_provider(self) -> "MagicMock":
+        """Provider that always returns 0 mutations."""
+        from backend.core.ouroboros.governance.self_immunization import (
+            LLMMutationProvider,
+            MutationBudgetGuard,
+        )
+        provider = MagicMock(spec=LLMMutationProvider)
+        provider.generated_count = 0
+        provider.call_attempts = 0
+        return provider
+
+    def test_c1_config_starvation_raises_distinct_error_not_auth_panic(self):
+        """C1: call_attempts==0 → ConfigStarvationError with [CONFIG] message.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+        from scripts.security.run_cc_parity_calibration import (
+            _loud_fail_on_zero_llm_throughput,
+        )
+
+        provider = self._make_zero_provider()
+        provider.call_attempts = 0
+        provider.generated_count = 0
+        guard = si.MutationBudgetGuard(budget_usd=0.10)
+        # No spend recorded → accumulated == 0
+
+        with pytest.raises(si.ConfigStarvationError) as exc_info:
+            _loud_fail_on_zero_llm_throughput(
+                provider=provider, guard=guard, dry_run=False
+            )
+
+        msg = str(exc_info.value)
+        assert "[CONFIG]" in msg, f"Expected [CONFIG] in message, got: {msg!r}"
+        # The message must clearly disclaim auth/Aegis as the cause.
+        # It is acceptable to MENTION "auth/Aegis" in a "No auth/Aegis fault"
+        # disclaimer — the key is the message does NOT claim auth is to blame.
+        # Confirm it is ConfigStarvationError, not AdversarialTelemetryPanic.
+        from backend.core.ouroboros.governance.self_immunization import (
+            AdversarialTelemetryPanic,
+        )
+        assert not isinstance(exc_info.value, AdversarialTelemetryPanic), (
+            "Config starvation must NOT be AdversarialTelemetryPanic"
+        )
+        # The config message should mention the real cause: n=0 / per-seed budget
+        assert any(kw in msg for kw in ("n=0", "per-seed", "generative provider")), (
+            f"Config-starvation message should explain the n=0 cause: {msg!r}"
+        )
+
+    def test_c2_auth_panic_when_call_attempted_zero_spend(self):
+        """C2: call_attempts>0, generated==0, spend==0 → AdversarialTelemetryPanic.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+        from scripts.security.run_cc_parity_calibration import (
+            _loud_fail_on_zero_llm_throughput,
+        )
+
+        provider = self._make_zero_provider()
+        provider.call_attempts = 2
+        provider.generated_count = 0
+        guard = si.MutationBudgetGuard(budget_usd=0.10)
+        # No spend → 0.0
+
+        with pytest.raises(si.AdversarialTelemetryPanic) as exc_info:
+            _loud_fail_on_zero_llm_throughput(
+                provider=provider, guard=guard, dry_run=False
+            )
+
+        msg = str(exc_info.value)
+        # Should mention auth/Aegis
+        assert "auth" in msg.lower() or "Aegis" in msg or "CRITICAL" in msg, (
+            f"Auth-failure panic should mention auth/Aegis/CRITICAL: {msg!r}"
+        )
+
+    def test_c3_empty_stream_panic_when_call_attempted_with_spend(self):
+        """C3: call_attempts>0, generated==0, spend>0 → AdversarialTelemetryPanic.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+        from scripts.security.run_cc_parity_calibration import (
+            _loud_fail_on_zero_llm_throughput,
+        )
+
+        provider = self._make_zero_provider()
+        provider.call_attempts = 1
+        provider.generated_count = 0
+        guard = si.MutationBudgetGuard(budget_usd=0.10)
+        guard.record_spend(0.005, label="test_spend")
+
+        with pytest.raises(si.AdversarialTelemetryPanic) as exc_info:
+            _loud_fail_on_zero_llm_throughput(
+                provider=provider, guard=guard, dry_run=False
+            )
+
+        msg = str(exc_info.value)
+        # Should mention spend / empty / unparseable
+        assert any(kw in msg.lower() for kw in ("spend", "empty", "unparseable", "content")), (
+            f"Empty-stream panic should mention spend/content issues: {msg!r}"
+        )
+
+    def test_c4_no_panic_when_generated_gt_zero(self):
+        """C4: generated_count>0 → no panic raised regardless of call_attempts.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+        from scripts.security.run_cc_parity_calibration import (
+            _loud_fail_on_zero_llm_throughput,
+        )
+
+        provider = self._make_zero_provider()
+        provider.call_attempts = 3
+        provider.generated_count = 5  # successfully generated
+        guard = si.MutationBudgetGuard(budget_usd=0.10)
+        guard.record_spend(0.02, label="test")
+
+        # Should not raise
+        _loud_fail_on_zero_llm_throughput(
+            provider=provider, guard=guard, dry_run=False
+        )
+
+    def test_c5_no_panic_in_dry_run_mode(self):
+        """C5: dry_run=True → no panic regardless of call_attempts/generated.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+        from scripts.security.run_cc_parity_calibration import (
+            _loud_fail_on_zero_llm_throughput,
+        )
+
+        provider = self._make_zero_provider()
+        provider.call_attempts = 0
+        provider.generated_count = 0
+        guard = si.MutationBudgetGuard(budget_usd=0.10)
+
+        # dry_run=True → no panic
+        _loud_fail_on_zero_llm_throughput(
+            provider=provider, guard=guard, dry_run=True
+        )
+
+    def test_c6_no_panic_when_provider_is_none(self):
+        """C6: provider=None (dry-run / deterministic) → no panic.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+        from scripts.security.run_cc_parity_calibration import (
+            _loud_fail_on_zero_llm_throughput,
+        )
+
+        guard = si.MutationBudgetGuard(budget_usd=0.10)
+
+        # Should not raise
+        _loud_fail_on_zero_llm_throughput(
+            provider=None, guard=guard, dry_run=False
+        )
+
+
+# ---------------------------------------------------------------------------
+# D. Observability fields in summarize_campaign
+# ---------------------------------------------------------------------------
+
+class TestObservabilityFields:
+    """D — summary dict includes LLM telemetry fields."""
+
+    def test_d1_summarize_campaign_includes_llm_observability_fields(self):
+        """D1: summarize_campaign returns llm_call_attempts, llm_generated_count,
+        llm_spend_usd, llm_per_seed.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+
+        mock_client = _make_mock_client()
+        provider = si.LLMMutationProvider(client=mock_client)
+
+        seed = _make_minimal_seed()
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            with patch(
+                f"{_AEGIS_BRIDGE_PATH}.merge_lease_header",
+                return_value={},
+            ):
+                with patch.dict(os.environ, {
+                    si._ENV_MUTATIONS_PER_PATTERN: "3",
+                    "JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED": "true",
+                }):
+                    summary = _run(si.summarize_campaign(
+                        seeds=[seed],
+                        mutation_provider=provider,
+                        llm_per_seed=2,
+                    ))
+
+        required_fields = (
+            "llm_call_attempts",
+            "llm_generated_count",
+            "llm_spend_usd",
+            "llm_per_seed",
+        )
+        for field in required_fields:
+            assert field in summary, (
+                f"summarize_campaign result missing '{field}': {list(summary.keys())}"
+            )
+
+    def test_d2_observability_fields_reflect_actual_counts(self):
+        """D2: llm_call_attempts and llm_generated_count match provider state.
+        # Slice 95a-2
+        """
+        from backend.core.ouroboros.governance import self_immunization as si
+
+        mock_client = _make_mock_client()
+        provider = si.LLMMutationProvider(client=mock_client)
+
+        seed = _make_minimal_seed()
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            with patch(
+                f"{_AEGIS_BRIDGE_PATH}.merge_lease_header",
+                return_value={},
+            ):
+                with patch.dict(os.environ, {
+                    si._ENV_MUTATIONS_PER_PATTERN: "3",
+                    "JARVIS_ANTIVENOM_SELF_IMMUNIZATION_ENABLED": "true",
+                }):
+                    summary = _run(si.summarize_campaign(
+                        seeds=[seed],
+                        mutation_provider=provider,
+                        llm_per_seed=2,
+                    ))
+
+        # The summary fields should mirror what the provider tracked
+        assert summary["llm_call_attempts"] == provider.call_attempts
+        assert summary["llm_generated_count"] == provider.generated_count
+        assert summary["llm_per_seed"] == 2
+
+
+# ---------------------------------------------------------------------------
+# E. Calibration derives llm_per_seed >= 1
+# ---------------------------------------------------------------------------
+
+class TestCalibrationLlmPerSeed:
+    """E — calibration script derives and respects llm_per_seed."""
+
+    def test_e1_calibration_derives_llm_per_seed_ge_1(self):
+        """E1: for any max_mutations >= 1 and N seeds, llm_per_seed >= 1.
+        # Slice 95a-2
+        """
+        from scripts.security.run_cc_parity_calibration import (
+            _derive_llm_per_seed,
+        )
+        from backend.core.ouroboros.governance import self_immunization as si
+
+        seeds = si._load_seed_entries()
+        n_seeds = max(len(seeds), 1)
+
+        for max_mut in (1, 10, 100, 200, 1000):
+            result = _derive_llm_per_seed(
+                max_mutations=max_mut,
+                num_seeds=n_seeds,
+                override=None,
+            )
+            assert result >= 1, (
+                f"llm_per_seed must be >= 1 for max_mutations={max_mut}, "
+                f"num_seeds={n_seeds}, got {result}"
+            )
+
+    def test_e2_llm_per_seed_cli_override_parsed(self):
+        """E2: --llm-per-seed CLI arg is parsed and passed through.
+        # Slice 95a-2
+        """
+        from scripts.security import run_cc_parity_calibration as calib
+
+        args = calib._parse_args(["--llm-per-seed", "7"])
+        assert hasattr(args, "llm_per_seed"), (
+            "argparse result missing 'llm_per_seed' attribute"
+        )
+        assert args.llm_per_seed == 7, (
+            f"Expected llm_per_seed=7, got {args.llm_per_seed}"
+        )
+
+    def test_e3_llm_per_seed_override_respected_by_derive(self):
+        """E3: _derive_llm_per_seed with override returns the override value.
+        # Slice 95a-2
+        """
+        from scripts.security.run_cc_parity_calibration import (
+            _derive_llm_per_seed,
+        )
+
+        result = _derive_llm_per_seed(
+            max_mutations=100,
+            num_seeds=10,
+            override=15,
+        )
+        assert result == 15, f"Expected override=15, got {result}"


### PR DESCRIPTION
## Root cause

The Aegis-routed CC parity calibration produced **\$0 spend / 0 LLM mutations** across the last several attempts. The diagnostic arc falsified every Aegis hypothesis (target_env, is_enabled cache, stale singleton) and pinned the real cause by reading the n-computation:

`run_immunization_campaign` invoked the LLM provider with `n = max(0, per_pattern - len(candidates))`. The 8 deterministic `MutationStrategy` operators already fill the small `per_pattern` budget, so **n collapsed to 0 — the LLM was never called.** This was never an Aegis routing fault; routing was correct all along.

## Fix (targeted, against the confirmed cause)

- `run_immunization_campaign` gains `llm_per_seed: Optional[int]=None`. When set, the LLM is called with `n=min(llm_per_seed, _MAX_MUTATIONS_PER_PATTERN)` **independent of the deterministic count**, and the `per_pattern` cap-break is suppressed (LLM mutations are additive). When `None`, the legacy `max(0, per_pattern-len(candidates))` is **byte-identical preserved** (backward-compat — existing callers unaffected).
- `LLMMutationProvider.call_attempts` counts real invocations → **honest loud-fail split**:
  - `call_attempts == 0` → `ConfigStarvationError` ("[CONFIG] LLM never invoked"; **NOT** an auth/Aegis fault)
  - `call_attempts > 0 & generated == 0` → `AdversarialTelemetryPanic` (real auth/empty failure)
- Calibration derives `llm_per_seed = max(1, max_mutations // num_seeds)` (≥1 floor guarantees n>0) + `--llm-per-seed` override; observability fields (`llm_call_attempts`, `llm_generated_count`, `llm_spend_usd`, `llm_per_seed`) surfaced in the summary.
- Added missing `from typing import Any` (was a `NameError` landmine for `get_type_hints` / static analysis); fixed a dead-code `SeedCategory` reference in a test fallback.

## Safety / scope

Engine remains §33.1 **default-FALSE**. Confined to `self_immunization.py` + `run_cc_parity_calibration.py` + 2 test files. No cage / Aegis-daemon edits.

## Tests

18 new tests (`test_slice95a2_llm_quota.py`) + adjacent self-immunization / generative-mutator / calibration-harness / lease suites green. `get_type_hints` resolves cleanly.

This unblocks the Slice 95c ≥3,000-mutation parity run: the LLM now receives a real per-seed quota (n>0) instead of being starved to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples the LLM mutation quota from deterministic fill to ensure the model is actually invoked, and adds clear failure signals separating config starvation from auth failures. Calibration now uses a per‑seed LLM quota and surfaces LLM telemetry.

- **Bug Fixes**
  - Root cause: `n = max(0, per_pattern - len(candidates))` collapsed to 0 as deterministic operators filled the budget, so the LLM was never called.
  - `run_immunization_campaign` adds `llm_per_seed`; when set, calls the LLM with `n = min(llm_per_seed, _MAX_MUTATIONS_PER_PATTERN)` and treats LLM mutations as additive; `None` preserves legacy behavior.
  - Track `LLMMutationProvider.call_attempts`; raise `ConfigStarvationError` when `call_attempts == 0` (config-starved), and `AdversarialTelemetryPanic` when `call_attempts > 0` but `generated == 0` (auth/empty).

- **New Features**
  - Calibration derives `llm_per_seed = max(1, max_mutations // num_seeds)` and adds `--llm-per-seed` override; passes through to `run_immunization_campaign`.
  - Summary and CLI output expose `llm_call_attempts`, `llm_generated_count`, `llm_spend_usd`, and `llm_per_seed`.
  - Small cleanups: added `from typing import Any`; tests added for quota decoupling, loud-fail paths, and telemetry.

<sup>Written for commit df96b9281d705de03fe7994dc902cfd6e64dd47c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

