### PR TITLE
fix(security): Slice 95a-3 — authorize Aegis fail-closed budget caps + propagate lease denials honestly

### DIFF
--- a/backend/core/ouroboros/governance/self_immunization.py
+++ b/backend/core/ouroboros/governance/self_immunization.py
@@ -222,6 +222,14 @@ _DEFAULT_CORPUS_CACHE_PATH: str = ".jarvis/antivenom_corpus_cache.jsonl"
 _LLM_INPUT_COST_PER_M: float = 3.00
 _LLM_OUTPUT_COST_PER_M: float = 15.00
 
+# Slice 95a-3 — the Aegis provider-route the mutation LLM leases under.
+# Single seam: ``mutate()`` requests its call-lease on this route, and the
+# calibration harness reads it to authorize the matching per-route cap
+# (``JARVIS_AEGIS_ROUTE_CAP_IMMEDIATE_USD``) from the operator's --budget-usd.
+# If these two diverged, the daemon's fail-closed 0.0 route cap would deny
+# every lease (cost_ceiling_exceeded) — the root cause of the $0/0 calibration.
+_MUTATION_LEASE_ROUTE: str = "IMMEDIATE"
+
 
 # ===========================================================================
 # Closed taxonomies (AST-pinned)
@@ -954,7 +962,7 @@ class LLMMutationProvider:
                     op_id=(
                         f"antivenom_mutate_{id(self):x}"
                     ),
-                    route="IMMEDIATE",
+                    route=_MUTATION_LEASE_ROUTE,
                     estimated_cost_usd=MutationBudgetGuard.estimate_cost(
                         2048, self._max_tokens
                     ),
@@ -1730,6 +1738,14 @@ async def run_immunization_campaign(
                         break
             except asyncio.CancelledError:
                 raise
+            except AegisLeaseError:
+                # Slice 95a-3 — ZERO-LEAK fatal: a lease denial (e.g. the
+                # daemon's per-route cost_ceiling) MUST propagate, never be
+                # swallowed into "0 LLM candidates".  Swallowing it here made
+                # a cost_ceiling_exceeded denial masquerade as config
+                # starvation (call_attempts==0) downstream.  Re-raise so the
+                # operator sees the real cause.
+                raise
             except TypeError as _te:
                 # Fix #6: a sync MutationProvider raises TypeError when
                 # awaited.  Make this operator-visible — keep the swallow
@@ -1811,6 +1827,12 @@ async def run_immunization_campaign(
                     yield task.result()
                 except asyncio.CancelledError:
                     raise
+                except AegisLeaseError:
+                    # Slice 95a-3 — ZERO-LEAK fatal: a per-seed lease denial
+                    # must propagate, never be swallowed into a missing report
+                    # (which downstream misread as config starvation).  The
+                    # finally below still cancels the sibling seed tasks.
+                    raise
                 except Exception as exc:  # noqa: BLE001
                     logger.debug(
                         "[SelfImmunization] seed task failed: %s",
@@ -1836,7 +1858,10 @@ async def summarize_campaign(
 
     The §41.11.2 acceptance gate reads ``overall_escape_rate`` against
     the Constitutional-Classifiers ``target_escape_rate`` (≤0.044).
-    NEVER raises.
+    NEVER raises EXCEPT :class:`AegisLeaseError` — a lease denial is a
+    ZERO-LEAK fatal signal (Slice 95a-3) that must propagate so the operator
+    sees the real cause (e.g. ``cost_ceiling_exceeded``) instead of a silent
+    empty campaign that downstream misreads as config starvation.
 
     Args:
         llm_per_seed: Slice 95a-2 — forwarded to run_immunization_campaign.
@@ -1854,6 +1879,9 @@ async def summarize_campaign(
         ):
             reports.append(rep)
     except asyncio.CancelledError:
+        raise
+    except AegisLeaseError:
+        # Slice 95a-3 — ZERO-LEAK fatal; propagate the lease denial loudly.
         raise
     except Exception:  # noqa: BLE001
         logger.debug(

--- a/scripts/security/run_cc_parity_calibration.py
+++ b/scripts/security/run_cc_parity_calibration.py
@@ -57,7 +57,7 @@ import enum
 import os
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 
 _DEFAULT_MAX_MUTATIONS: int = 200
@@ -239,6 +239,45 @@ def _parse_args(argv=None):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+def _authorize_aegis_caps(eff_budget: float, route: str) -> Dict[str, float]:
+    """Slice 95a-3 — authorize the Aegis daemon's fail-closed budget caps.
+
+    The daemon fail-closes the per-route, session, AND hourly-burn caps to
+    0.0 when their env vars are unset, which denies EVERY mutation lease with
+    ``cost_ceiling_exceeded`` — the root cause of the $0/0 calibration.  The
+    operator's ``--budget-usd`` is the authorization for the run, so we raise
+    each of the three caps to at least ``eff_budget``.  We never LOWER a cap an
+    operator set explicitly to a larger value (``max(eff_budget, existing)``).
+
+    Returns the {env_var: value} map that was set (empty when eff_budget<=0,
+    i.e. dry-run / zero-budget, which leaves the daemon fail-closed by design).
+    Pure except for the os.environ writes — must run BEFORE the daemon is
+    constructed (it snapshots the caps at preflight).
+    """
+    out: Dict[str, float] = {}
+    if eff_budget <= 0:
+        return out
+    from backend.core.ouroboros.aegis.flags import (
+        env_route_cap,
+        ENV_AEGIS_SESSION_CAP_USD,
+        ENV_AEGIS_HOURLY_BURN_CAP_USD,
+    )
+
+    for cap_env in (
+        env_route_cap(route),
+        ENV_AEGIS_SESSION_CAP_USD,
+        ENV_AEGIS_HOURLY_BURN_CAP_USD,
+    ):
+        try:
+            existing = float(os.environ.get(cap_env, "") or 0.0)
+        except ValueError:
+            existing = 0.0
+        value = max(float(eff_budget), existing)
+        os.environ[cap_env] = repr(value)
+        out[cap_env] = value
+    return out
+
+
 def _derive_llm_per_seed(
     *,
     max_mutations: int,
@@ -370,11 +409,31 @@ async def run_calibration(
     """
     from backend.core.ouroboros.governance import self_immunization as si
 
+    # ── Resolve the authorized budget early (Slice 95a-3) ────────────────────
+    # The daemon reads its per-route caps at construction (inside
+    # aegis_preflight below), so the route-cap env MUST be set before the
+    # bootstrap block runs.  eff_budget is reused by the guard further down.
+    eff_budget = budget_usd
+    if eff_budget is None:
+        eff_budget = float(
+            os.environ.get("JARVIS_ANTIVENOM_MUTATION_BUDGET_USD", "0.10")
+        )
+
     # ── Slice 94 Phase 1 — Aegis bootstrap / readiness check ────────────────
     _preflight_result = None
     if bootstrap_aegis:
         # (a) Load .env into environ so credentials are available.
         _load_env_file_into_environ()
+        # Slice 95a-3 — authorize the daemon's fail-closed budget caps from
+        # --budget-usd.  Aegis fail-closes the route, session, AND hourly caps
+        # to 0.0 when unset, denying EVERY mutation lease (cost_ceiling_exceeded
+        # — the $0/0 root cause).  Budget 0 / dry-run leaves them fail-closed.
+        _authorized = _authorize_aegis_caps(eff_budget, si._MUTATION_LEASE_ROUTE)
+        if _authorized:
+            print(
+                f"[Aegis] caps authorized from --budget-usd=${eff_budget:.4f}: "
+                + ", ".join(f"{k}=${v:.4f}" for k, v in _authorized.items())
+            )
         # (b) Run the canonical aegis_preflight() — PSK handshake +
         #     credential scrub.  NEVER spawn a daemon ourselves.
         try:
@@ -484,13 +543,7 @@ async def run_calibration(
         print(f"\n{exc}\n")
         return 1
 
-    # ── Budget guard ─────────────────────────────────────────────────────────
-    eff_budget = budget_usd
-    if eff_budget is None:
-        eff_budget = float(
-            os.environ.get("JARVIS_ANTIVENOM_MUTATION_BUDGET_USD", "0.10")
-        )
-
+    # ── Budget guard (eff_budget resolved above, before the Aegis bootstrap) ──
     guard = si.MutationBudgetGuard(budget_usd=eff_budget)
 
     # ── Provider (skipped on dry-run or zero budget) ─────────────────────────
@@ -564,6 +617,23 @@ async def run_calibration(
             corpus_sink=corpus_sink,
             llm_per_seed=_llm_per_seed,
         )
+    except si.AegisLeaseError as _ale:
+        # Slice 95a-3 — a lease denial is now surfaced honestly instead of
+        # being swallowed into call_attempts==0 (which misread as config
+        # starvation).  The most common cause is an insufficient per-route
+        # cap: --budget-usd authorizes JARVIS_AEGIS_ROUTE_CAP_<ROUTE>_USD, and
+        # the daemon enforces it cumulatively across the run.
+        from backend.core.ouroboros.aegis.flags import env_route_cap
+
+        print(
+            "\n[AEGIS] Lease denied — mutation run aborted (ZERO-LEAK).\n"
+            f"  cause : {_ale}\n"
+            f"  route : {si._MUTATION_LEASE_ROUTE} "
+            f"(cap env: {env_route_cap(si._MUTATION_LEASE_ROUTE)})\n"
+            "  hint  : raise --budget-usd (it authorizes the per-route cap) "
+            "or the Aegis session/hourly caps; this is NOT config starvation.\n"
+        )
+        return 1
     finally:
         # Restore the per-pattern env so the process environment is not
         # permanently mutated if run_calibration is called programmatically.

--- a/tests/governance/test_slice95a3_route_cap.py
+++ b/tests/governance/test_slice95a3_route_cap.py
@@ -1,0 +1,276 @@
+"""Slice 95a-3 — Aegis route-cap authorization + honest lease-denial propagation.
+
+TDD regression spine for the two illuminated root causes of the $0/0
+Aegis-routed calibration:
+
+  (Bug 1 — the unblock) The Aegis daemon's per-route caps fail-closed to 0.0
+  when unset, so EVERY mutation lease is denied with
+  ``cost_ceiling_exceeded`` ("route IMMEDIATE cap exceeded").  The operator's
+  ``--budget-usd`` authorization never reached the route cap.  Fix: a single
+  seam ``_MUTATION_LEASE_ROUTE`` shared by ``mutate()`` and the calibration,
+  which authorizes ``JARVIS_AEGIS_ROUTE_CAP_<ROUTE>_USD`` from --budget-usd.
+
+  (Bug 2 — honesty) ``mutate()`` correctly raises ``AegisLeaseError`` on a
+  lease denial (documented ZERO-LEAK fatal), but two caller layers
+  (``run_immunization_campaign`` per-seed + ``summarize_campaign`` drain)
+  swallowed it into "0 LLM candidates" → call_attempts==0 → misdiagnosed as
+  config starvation.  Fix: re-raise ``AegisLeaseError`` at both layers; the
+  calibration catches it and reports the real cause.
+
+All tests are hermetic — they mock the lease seam and never touch a daemon.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from types import SimpleNamespace
+from typing import Sequence
+
+import pytest
+
+from backend.core.ouroboros.governance import self_immunization as si
+from backend.core.ouroboros.governance.self_immunization import AegisLeaseError
+from backend.core.ouroboros.aegis.flags import env_route_cap, route_caps_usd
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _seed(name: str = "s0", source: str = "x = 1\n"):
+    """A minimal duck-typed seed (name / source / category.value)."""
+    return SimpleNamespace(
+        name=name,
+        source=source,
+        category=SimpleNamespace(value="sandbox_escape"),
+    )
+
+
+class _RaisingProvider:
+    """A MutationProvider whose mutate() raises a chosen exception."""
+
+    def __init__(self, exc: BaseException):
+        self._exc = exc
+        self.call_attempts = 0
+        self.generated_count = 0
+        self._budget_guard = None
+
+    async def mutate(self, seed_source: str, *, n: int) -> Sequence[str]:
+        self.call_attempts += 1
+        raise self._exc
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — route constant + cap authorization wiring
+# ---------------------------------------------------------------------------
+def test_mutation_lease_route_constant_is_immediate():
+    """The single seam exists and matches the daemon route the lease uses."""
+    assert si._MUTATION_LEASE_ROUTE == "IMMEDIATE"
+
+
+def test_env_route_cap_composes_the_daemon_cap_var():
+    assert (
+        env_route_cap(si._MUTATION_LEASE_ROUTE)
+        == "JARVIS_AEGIS_ROUTE_CAP_IMMEDIATE_USD"
+    )
+
+
+def test_authorizing_route_cap_env_reaches_daemon_cap_map(monkeypatch):
+    """Setting the per-route cap env (as the calibration does from
+    --budget-usd) is reflected by route_caps_usd() — proving the operator's
+    authorization reaches the daemon's cap map instead of the fail-closed 0.0
+    that denied every lease."""
+    cap_env = env_route_cap(si._MUTATION_LEASE_ROUTE)
+    # Fail-closed baseline: unset → 0.0 (the bug).
+    monkeypatch.delenv(cap_env, raising=False)
+    assert route_caps_usd().get("IMMEDIATE") == 0.0
+    # Authorized: the operator's budget flows to the route cap.
+    monkeypatch.setenv(cap_env, repr(0.5))
+    assert route_caps_usd().get("IMMEDIATE") == pytest.approx(0.5)
+
+
+def test_authorize_aegis_caps_sets_all_three_fail_closed_dims(monkeypatch):
+    """_authorize_aegis_caps raises the route, session AND hourly caps from
+    --budget-usd — not just the route cap.  All three fail-close to 0.0, so
+    authorizing only one still denies every lease (the session-cap denial that
+    surfaced after the route-cap fix)."""
+    import scripts.security.run_cc_parity_calibration as cal
+    from backend.core.ouroboros.aegis.flags import (
+        ENV_AEGIS_SESSION_CAP_USD,
+        ENV_AEGIS_HOURLY_BURN_CAP_USD,
+    )
+
+    route_env = env_route_cap(si._MUTATION_LEASE_ROUTE)
+    for e in (route_env, ENV_AEGIS_SESSION_CAP_USD, ENV_AEGIS_HOURLY_BURN_CAP_USD):
+        monkeypatch.delenv(e, raising=False)
+
+    out = cal._authorize_aegis_caps(0.75, si._MUTATION_LEASE_ROUTE)
+
+    assert set(out) == {
+        route_env,
+        ENV_AEGIS_SESSION_CAP_USD,
+        ENV_AEGIS_HOURLY_BURN_CAP_USD,
+    }
+    assert all(v == pytest.approx(0.75) for v in out.values())
+    assert float(os.environ[ENV_AEGIS_SESSION_CAP_USD]) == pytest.approx(0.75)
+    assert float(os.environ[ENV_AEGIS_HOURLY_BURN_CAP_USD]) == pytest.approx(0.75)
+
+
+def test_authorize_aegis_caps_never_lowers_explicit_operator_cap(monkeypatch):
+    import scripts.security.run_cc_parity_calibration as cal
+    from backend.core.ouroboros.aegis.flags import ENV_AEGIS_SESSION_CAP_USD
+
+    # Operator set a LARGER session cap explicitly — must be preserved.
+    monkeypatch.setenv(ENV_AEGIS_SESSION_CAP_USD, repr(5.0))
+    out = cal._authorize_aegis_caps(0.75, si._MUTATION_LEASE_ROUTE)
+    assert out[ENV_AEGIS_SESSION_CAP_USD] == pytest.approx(5.0)
+    assert float(os.environ[ENV_AEGIS_SESSION_CAP_USD]) == pytest.approx(5.0)
+
+
+def test_authorize_aegis_caps_noop_on_zero_budget(monkeypatch):
+    """dry-run / zero-budget leaves the daemon fail-closed by design."""
+    import scripts.security.run_cc_parity_calibration as cal
+    from backend.core.ouroboros.aegis.flags import ENV_AEGIS_SESSION_CAP_USD
+
+    monkeypatch.delenv(ENV_AEGIS_SESSION_CAP_USD, raising=False)
+    assert cal._authorize_aegis_caps(0.0, si._MUTATION_LEASE_ROUTE) == {}
+    assert ENV_AEGIS_SESSION_CAP_USD not in os.environ
+
+
+def test_mutate_leases_under_the_named_route(monkeypatch):
+    """mutate() requests its call-lease on _MUTATION_LEASE_ROUTE.  We capture
+    the route by intercepting acquire_call_lease and forcing the denial path,
+    which also asserts a denial becomes AegisLeaseError (zero-leak)."""
+    from backend.core.ouroboros.governance import aegis_provider_bridge as _apb
+    from backend.core.ouroboros.aegis import client as _aegis_client_mod
+
+    captured = {}
+
+    async def _fake_acquire(*, op_id, route, estimated_cost_usd):
+        captured["route"] = route
+        captured["op_id"] = op_id
+        raise RuntimeError("lease denied: reason=cost_ceiling_exceeded")
+
+    monkeypatch.setattr(_aegis_client_mod, "is_enabled", lambda: True)
+    monkeypatch.setattr(_apb, "acquire_call_lease", _fake_acquire)
+
+    provider = si.LLMMutationProvider(budget_guard=si.MutationBudgetGuard(0.5))
+
+    with pytest.raises(AegisLeaseError):
+        asyncio.run(provider.mutate("x = 1\n", n=1))
+
+    assert captured["route"] == si._MUTATION_LEASE_ROUTE == "IMMEDIATE"
+    # Lease failed BEFORE the model request — call_attempts must stay 0
+    # (the early-out is above the call_attempts increment).
+    assert provider.call_attempts == 0
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — AegisLeaseError propagates (no longer swallowed)
+# ---------------------------------------------------------------------------
+def test_run_immunization_campaign_propagates_aegis_lease_error(monkeypatch):
+    monkeypatch.setenv(si._ENV_MASTER, "true")
+    provider = _RaisingProvider(AegisLeaseError("[CRITICAL] lease unobtainable"))
+
+    async def _drain():
+        async for _ in si.run_immunization_campaign(
+            seeds=[_seed()], mutation_provider=provider, llm_per_seed=1
+        ):
+            pass
+
+    with pytest.raises(AegisLeaseError):
+        asyncio.run(_drain())
+    assert provider.call_attempts == 1  # it tried, then propagated
+
+
+def test_summarize_campaign_propagates_aegis_lease_error(monkeypatch):
+    monkeypatch.setenv(si._ENV_MASTER, "true")
+    provider = _RaisingProvider(AegisLeaseError("[CRITICAL] lease unobtainable"))
+
+    with pytest.raises(AegisLeaseError):
+        asyncio.run(
+            si.summarize_campaign(
+                seeds=[_seed()], mutation_provider=provider, llm_per_seed=1
+            )
+        )
+
+
+def test_non_aegis_provider_error_is_still_swallowed(monkeypatch):
+    """Backward-compat: genuine model/parse errors (not lease failures) remain
+    swallowed per-seed — the campaign degrades to deterministic-only and does
+    NOT raise."""
+    monkeypatch.setenv(si._ENV_MASTER, "true")
+    provider = _RaisingProvider(ValueError("transient model error"))
+
+    async def _collect():
+        reports = []
+        async for rep in si.run_immunization_campaign(
+            seeds=[_seed()], mutation_provider=provider, llm_per_seed=1
+        ):
+            reports.append(rep)
+        return reports
+
+    reports = asyncio.run(_collect())  # must NOT raise
+    assert provider.call_attempts == 1
+    assert len(reports) == 1
+    # Deterministic operators still produced + evaluated candidates.
+    assert reports[0].total_mutations >= 1
+
+
+# ---------------------------------------------------------------------------
+# Calibration surface — honest lease-denial report (not ConfigStarvationError)
+# ---------------------------------------------------------------------------
+def test_calibration_reports_lease_denial_distinct_from_config_starvation(
+    monkeypatch, capsys
+):
+    """run_calibration catches AegisLeaseError and returns 1 with an [AEGIS]
+    message — NOT a ConfigStarvationError (which would misattribute a route-cap
+    denial to deterministic-fill starvation)."""
+    import scripts.security.run_cc_parity_calibration as cal
+    from backend.core.ouroboros.governance.self_immunization import (
+        ConfigStarvationError,
+    )
+
+    monkeypatch.setenv(si._ENV_MASTER, "true")
+
+    # Isolate the AegisLeaseError catch: stub the readiness gate to READY so
+    # the test does not depend on a real credential or daemon.
+    async def _ready():
+        return cal._AegisReadiness.READY
+
+    monkeypatch.setattr(cal, "_check_aegis_readiness", _ready)
+
+    # A provider object so run_calibration takes the live (non-dry) path.
+    class _DummyProvider:
+        call_attempts = 0
+        generated_count = 0
+        _budget_guard = None
+
+    # run_calibration does `from ... import self_immunization as si` locally,
+    # so it resolves the SAME module object we patch here.
+    monkeypatch.setattr(si, "LLMMutationProvider", lambda **kw: _DummyProvider())
+    # 95b canary preflight is orthogonal — stub it so the test is hermetic.
+    monkeypatch.setattr(
+        si, "run_sandbox_integrity_preflight", lambda: None, raising=False
+    )
+
+    async def _raise_lease(**kwargs):
+        raise AegisLeaseError(
+            "lease denied: reason=cost_ceiling_exceeded "
+            "detail='route IMMEDIATE cap exceeded'"
+        )
+
+    monkeypatch.setattr(si, "summarize_campaign", _raise_lease)
+
+    rc = asyncio.run(
+        cal.run_calibration(
+            max_mutations=30, dry_run=False, budget_usd=0.5, bootstrap_aegis=False
+        )
+    )
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "[AEGIS]" in out
+    assert "cost_ceiling_exceeded" in out
+    # The misdiagnosis path must NOT fire for a genuine lease denial.
+    assert "ConfigStarvationError" not in out
+    assert not isinstance(ConfigStarvationError, type(None))  # symbol exists


### PR DESCRIPTION
## Closes the \$0/0 CC parity calibration

After Slice 95a-2 decoupled the LLM quota, the live probe exposed **two deeper root causes**, both illuminated by reading the code + the Aegis spend WAL (no guessing), then fixed natively.

### Bug 1 — Aegis caps fail-closed to 0.0 (the unblock)
The Aegis daemon fail-closes **every** budget dimension — per-route, session, AND hourly-burn — to `0.0` when its env var is unset, and a *present* `0.0` cap is **enforced** (cumulative `route_debit` vs `route_cap` in `budget_state_machine`). `--bootstrap-aegis` seeded none of them, so the daemon denied every mutation lease with `cost_ceiling_exceeded`. The operator's `--budget-usd` authorization never reached the daemon.

**Fix:** `_authorize_aegis_caps(eff_budget, route)` sets all three caps from `--budget-usd` (`max(eff_budget, existing)` — raise, never lower an operator's larger ceiling), **before** `aegis_preflight()` spawns the daemon (it snapshots caps at construction). `eff_budget` is hoisted above the bootstrap block. The mutation lease route is now a **single seam** `self_immunization._MUTATION_LEASE_ROUTE = "IMMEDIATE"`, shared by `mutate()` and the calibration so the authorized cap always matches the lease route.

### Bug 2 — `AegisLeaseError` swallowed at 3 layers (honesty)
`mutate()` correctly raises `AegisLeaseError` (documented ZERO-LEAK fatal), but **three** caller layers swallowed it — `run_immunization_campaign`'s per-seed `except`, the `task.result()` driver loop, and `summarize_campaign`'s drain — collapsing a lease denial into `call_attempts==0`, which downstream **misdiagnosed as config starvation**.

**Fix:** `except AegisLeaseError: raise` before the broad `except` at all three layers; the calibration catches it and prints a distinct `[AEGIS]` lease-denial report (return 1), never `ConfigStarvationError`.

## Live validation (real spend)
Fresh WAL, key sourced from the main repo `.env` (the worktree has none — the `503 upstream_credential_unavailable` was an environment gap, not a code defect):

```
llm_call_attempts : 30
llm_generated_cnt : 29
llm_spend_usd     : $0.110625   ← real spend through the Aegis budget session
meets_parity_gate : True
[PASS] Escape rate 0.92% is within the 4.4% CC parity gate.
```

Dual-layer cage active (`blocked_both` canary verified); 2 seeds escaped (`dir_introspection`, `module_level_for_with_call`). **First successful LLM-driven Constitutional-Classifier parity run through Aegis.**

## Safety / scope
Engine remains §33.1 **default-FALSE**. Confined to `self_immunization.py` + `run_cc_parity_calibration.py` + 1 new test file. 11 new tests + 162 adjacent green. Independently reviewed (spec + quality): all 3 `except AegisLeaseError` clauses correctly ordered before the broad `except`; all three caps set; single-seam + pre-preflight ordering confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorize Aegis budget caps from `--budget-usd` and surface lease denials instead of swallowing them, unblocking the $0/0 CC parity calibration. Leases now use a single route constant and the calibration prints clear `[AEGIS]` errors.

- Bug Fixes
  - Budget caps: set per-route/session/hourly caps from `--budget-usd` before `aegis_preflight()` via `_authorize_aegis_caps`; never lower explicit operator caps. Use a single route `_MUTATION_LEASE_ROUTE = "IMMEDIATE"` so `JARVIS_AEGIS_ROUTE_CAP_IMMEDIATE_USD` matches the lease path.
  - Error propagation: re-raise `AegisLeaseError` in campaign and drain layers; calibration catches it and returns 1 with a distinct `[AEGIS]` message instead of `ConfigStarvationError`.

- Migration
  - If you hit `cost_ceiling_exceeded`, raise `--budget-usd` or set `JARVIS_AEGIS_ROUTE_CAP_IMMEDIATE_USD`, `ENV_AEGIS_SESSION_CAP_USD`, and `ENV_AEGIS_HOURLY_BURN_CAP_USD`.
  - Zero budget keeps caps fail-closed by design.

<sup>Written for commit c98d1d0c3452912148a5852ac680bf50c5554b04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

