### PR TITLE
feat(security): Slice 95d — async multi-call batching engine + AST-hash dedup + escaped-source capture

### DIFF
--- a/backend/core/ouroboros/governance/self_immunization.py
+++ b/backend/core/ouroboros/governance/self_immunization.py
@@ -66,6 +66,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import enum
+import hashlib
 import json
 import logging
 import os
@@ -195,6 +196,14 @@ _ENV_CONCURRENCY: str = "JARVIS_ANTIVENOM_IMMUNIZATION_CONCURRENCY"
 _ENV_MUTATION_BUDGET_USD: str = "JARVIS_ANTIVENOM_MUTATION_BUDGET_USD"
 _ENV_CORPUS_CACHE_PATH: str = "JARVIS_ANTIVENOM_CORPUS_CACHE_PATH"
 
+# Slice 95d — per-seed multi-call batching engine + AST-hash dedup +
+# escaped-source capture.  All three sub-flags default-FALSE so the
+# legacy single-call path stays byte-identical for existing tests.
+_ENV_BATCHING: str = "JARVIS_ANTIVENOM_BATCHING_ENABLED"
+_ENV_MAX_CALLS_PER_SEED: str = "JARVIS_ANTIVENOM_MAX_CALLS_PER_SEED"
+_ENV_ESCAPE_CAPTURE: str = "JARVIS_ANTIVENOM_ESCAPE_CAPTURE_ENABLED"
+_ENV_ESCAPE_CAPTURE_PATH: str = "JARVIS_ANTIVENOM_ESCAPE_CAPTURE_PATH"
+
 _TRUTHY = ("true", "1", "yes", "on")
 
 # Constitutional Classifiers (arXiv:2501.18837): the post-deployment
@@ -214,6 +223,10 @@ _MAX_MUTATED_SOURCE_BYTES: int = 64 * 1024
 # Slice 93 — LLM provider defaults
 _DEFAULT_MUTATION_BUDGET_USD: float = 0.10
 _DEFAULT_CORPUS_CACHE_PATH: str = ".jarvis/antivenom_corpus_cache.jsonl"
+
+# Slice 95d — batching / escape-capture defaults
+_DEFAULT_MAX_CALLS_PER_SEED: int = 12
+_DEFAULT_ESCAPE_CAPTURE_PATH: str = ".jarvis/antivenom_escapes.jsonl"
 # Claude Sonnet-class pricing (per-million tokens).  Used for cost estimation.
 # NOTE: these constants match claude-sonnet-4-5 (the default model).  If the
 # ``model`` param of LLMMutationProvider is overridden to Opus or Haiku these
@@ -710,6 +723,63 @@ def _corpus_cache_path() -> Path:
 
 
 # ===========================================================================
+# Slice 95d — batching engine / dedup / escape-capture env readers + helpers
+# ===========================================================================
+
+
+def _batching_enabled() -> bool:
+    """Slice 95d — per-seed multi-call batching loop. Default-FALSE so the
+    legacy single-call LLM path stays byte-identical for existing tests."""
+    raw = os.environ.get(_ENV_BATCHING, "").strip().lower()
+    return raw in _TRUTHY
+
+
+def _max_calls_per_seed() -> int:
+    """Slice 95d — hard per-seed call cap (min 1) preventing an infinite
+    pagination loop when the model keeps returning duplicates/empties."""
+    raw = os.environ.get(_ENV_MAX_CALLS_PER_SEED, "")
+    try:
+        v = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_CALLS_PER_SEED
+    if v < 1:
+        return 1
+    return v
+
+
+def _escape_capture_enabled() -> bool:
+    """Slice 95d — escaped-source instrumentation sink. Default-FALSE."""
+    raw = os.environ.get(_ENV_ESCAPE_CAPTURE, "").strip().lower()
+    return raw in _TRUTHY
+
+
+def _escape_capture_path() -> Path:
+    raw = os.environ.get(_ENV_ESCAPE_CAPTURE_PATH, "").strip()
+    return Path(raw) if raw else Path(_DEFAULT_ESCAPE_CAPTURE_PATH)
+
+
+def _ast_structural_hash(source: str) -> Optional[str]:
+    """Slice 95d — O(1) structural fingerprint of a Python source string.
+
+    Parses ``source`` then hashes a normalized ``ast.dump`` that drops
+    field names and node positions — so two sources differing ONLY in
+    whitespace / comments / formatting collapse to the SAME hash, while
+    structurally-different sources hash differently.
+
+    Returns ``None`` on :class:`SyntaxError` (caller treats None as
+    "can't hash" → does not dedup, falls through to the UNPARSEABLE path).
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    dumped = ast.dump(
+        tree, annotate_fields=False, include_attributes=False
+    )
+    return hashlib.sha256(dumped.encode("utf-8", "replace")).hexdigest()
+
+
+# ===========================================================================
 # Slice 93 — MutationBudgetGuard
 # ===========================================================================
 
@@ -1125,6 +1195,70 @@ class CorpusCacheSink:
         except Exception:  # noqa: BLE001
             logger.debug(
                 "[CorpusCacheSink] record_candidate failed", exc_info=True
+            )
+            return False
+
+
+class EscapeCaptureSink:
+    """Slice 95d — captures the FULL source of every ESCAPED mutation.
+
+    The corpus cache (``CorpusCacheSink``) deliberately stores only
+    ``mutated_source_bytes`` (a byte count, not the source) for every
+    candidate.  That is fine for reproducibility metadata but useless for
+    *analyzing a bypass*: when a mutation escapes the cage we need the
+    exact source that defeated it.  This sink writes that full source
+    (plus forensic context) to a dedicated escapes JSONL, gated behind
+    ``JARVIS_ANTIVENOM_ESCAPE_CAPTURE_ENABLED`` (default-FALSE).
+
+    Mirrors :class:`CorpusCacheSink` — composes the canonical
+    ``cross_process_jsonl.flock_append_line`` primitive and NEVER raises
+    (best-effort instrumentation, swallow + debug-log on any failure).
+
+    Env: ``JARVIS_ANTIVENOM_ESCAPE_CAPTURE_PATH``
+    (default ``.jarvis/antivenom_escapes.jsonl``).
+    """
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._path = path or _escape_capture_path()
+
+    async def record_escape(self, result: "MutationResult") -> bool:
+        """Append one ESCAPED ``MutationResult`` (with its FULL source) to
+        the escapes JSONL.  MUST NOT raise.  Returns True on success."""
+        try:
+            from backend.core.ouroboros.governance.cross_process_jsonl import (  # noqa: E501
+                flock_append_line,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[EscapeCaptureSink] flock primitive import failed",
+                exc_info=True,
+            )
+            return False
+        try:
+            cand = result.candidate
+            payload = {
+                "schema_version": SELF_IMMUNIZATION_SCHEMA_VERSION,
+                "kind": "escaped_variant",
+                "seed_entry_name": cand.seed_entry_name,
+                "seed_category": cand.seed_category,
+                "strategy": cand.strategy.value,
+                "cage_verdict": result.cage_verdict,
+                "semguard_findings": list(result.semguard_findings),
+                # The whole point of this sink: the full escaping source.
+                "mutated_source": cand.mutated_source,
+                "wrote_at_unix": time.time(),
+            }
+            line = json.dumps(payload, sort_keys=True, default=str)
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                None, flock_append_line, self._path, line
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[EscapeCaptureSink] record_escape failed", exc_info=True
             )
             return False
 
@@ -1638,6 +1772,19 @@ async def run_immunization_campaign(
     except Exception:  # noqa: BLE001 — degrade to serial, never abort
         sem = None
 
+    # Slice 95d — batching engine run-level state (only meaningful when
+    # _batching_enabled()).  The dedup set is shared across ALL seeds =
+    # global structural dedup; the call-cap bounds per-seed pagination.
+    _batching: bool = _batching_enabled()
+    _max_calls: int = _max_calls_per_seed()
+    _seen_hashes: set[str] = set()
+
+    # Slice 95d — escaped-source capture sink (constructed once per run,
+    # only when enabled).  Best-effort instrumentation; never authoritative.
+    _escape_sink: Optional["EscapeCaptureSink"] = (
+        EscapeCaptureSink() if _escape_capture_enabled() else None
+    )
+
     async def _run_one_seed(seed: Any) -> ImmunizationReport:
         seed_name = str(getattr(seed, "name", "?"))
         seed_cat = str(
@@ -1673,6 +1820,15 @@ async def run_immunization_campaign(
                 )
             )
 
+        # Slice 95d — when batching, seed the global dedup set with the
+        # deterministic operators' structural hashes so an LLM variant that
+        # is structurally identical to a deterministic mutation is filtered.
+        if _batching:
+            for _det in candidates:
+                _dh = _ast_structural_hash(_det.mutated_source)
+                if _dh is not None:
+                    _seen_hashes.add(_dh)
+
         # Optional LLM augmentation — appended, never replacing the
         # deterministic operators. Failures == zero augmentation.
         # Slice 93: mutate is now async; campaign awaits it.
@@ -1687,55 +1843,144 @@ async def run_immunization_campaign(
         # compat (callers that don't pass llm_per_seed are unaffected).
         if mutation_provider is not None:
             try:
-                if llm_per_seed is not None:
-                    # Slice 95a-2 — decoupled explicit quota; cap at max.
-                    _llm_n = min(
+                if _batching and llm_per_seed is not None:
+                    # ----------------------------------------------------------
+                    # Slice 95d — per-seed multi-call batching loop.
+                    #
+                    # A single max_tokens=2048 response holds only ~14 variants,
+                    # so one mutate() call cannot reach a large quota.  Paginate:
+                    # accumulate UNIQUE valid mutations across multiple calls
+                    # until the target is met, the call-cap is hit, the model
+                    # returns empty (exhausted), or the budget is exhausted.
+                    #
+                    # Per-variant filtering is IDENTICAL to the legacy path
+                    # (non-str skip / oversize skip / ast.parse → UNPARSEABLE
+                    # else accept) PLUS O(1) structural dedup against the
+                    # run-global _seen_hashes set.  AegisLeaseError still
+                    # propagates (the loop is inside this try whose
+                    # ``except AegisLeaseError: raise`` is preserved below).
+                    # ----------------------------------------------------------
+                    _target = min(
                         max(0, int(llm_per_seed)),
                         _MAX_MUTATIONS_PER_PATTERN,
                     )
-                else:
-                    # Legacy formula — can be 0 when deterministic fills budget.
-                    _llm_n = max(0, per_pattern - len(candidates))
-                extra = await mutation_provider.mutate(
-                    seed_src, n=_llm_n
-                )
-                for src in (extra or ()):
-                    if not isinstance(src, str):
-                        continue
-                    if len(src.encode("utf-8", "replace")) > (
-                        _MAX_MUTATED_SOURCE_BYTES
+                    _accepted_llm = 0
+                    _calls = 0
+                    while (
+                        _accepted_llm < _target
+                        and _calls < _max_calls
                     ):
-                        continue
-                    # Slice 93 validity filter — ast.parse gate.
-                    try:
-                        ast.parse(src)
-                        _src_valid = True
-                    except SyntaxError:
-                        _src_valid = False
-                    cand = MutationCandidate(
-                        seed_entry_name=seed_name,
-                        seed_category=seed_cat,
-                        strategy=MutationStrategy.IDENTITY,
-                        mutated_source=src,
-                    )
-                    if not _src_valid:
-                        # Record UNPARSEABLE directly — skip cage evaluation.
-                        inapplicable_results.append(
-                            MutationResult(
-                                candidate=cand,
-                                verdict=ImmunizationVerdict.UNPARSEABLE,
-                                cage_verdict="",
-                                semguard_findings=(),
-                                detail="llm_output_unparseable",
-                            )
+                        _batch_ask = min(
+                            _target - _accepted_llm,
+                            _MAX_MUTATIONS_PER_PATTERN,
                         )
-                        continue
-                    candidates.append(cand)
-                    # Slice 95a-2: in decoupled llm_per_seed mode, the LLM
-                    # is additive — don't cap at per_pattern.  In legacy
-                    # mode (llm_per_seed=None), honour the per_pattern bound.
-                    if llm_per_seed is None and len(candidates) >= per_pattern:
-                        break
+                        if _batch_ask <= 0:
+                            break
+                        extra = await mutation_provider.mutate(
+                            seed_src, n=_batch_ask
+                        )
+                        _calls += 1
+                        if not extra:
+                            # Empty return → model exhausted or budget guard
+                            # short-circuited.  Stop (don't burn the call-cap).
+                            break
+                        for src in extra:
+                            if not isinstance(src, str):
+                                continue
+                            if len(src.encode("utf-8", "replace")) > (
+                                _MAX_MUTATED_SOURCE_BYTES
+                            ):
+                                continue
+                            _h = _ast_structural_hash(src)
+                            if _h is None:
+                                # Unparseable — record UNPARSEABLE, don't dedup.
+                                inapplicable_results.append(
+                                    MutationResult(
+                                        candidate=MutationCandidate(
+                                            seed_entry_name=seed_name,
+                                            seed_category=seed_cat,
+                                            strategy=MutationStrategy.IDENTITY,
+                                            mutated_source=src,
+                                        ),
+                                        verdict=ImmunizationVerdict.UNPARSEABLE,
+                                        cage_verdict="",
+                                        semguard_findings=(),
+                                        detail="llm_output_unparseable",
+                                    )
+                                )
+                                continue
+                            if _h in _seen_hashes:
+                                # Duplicate — does NOT count toward target,
+                                # not recorded.  Keeps the loop O(1) per check.
+                                continue
+                            _seen_hashes.add(_h)
+                            candidates.append(
+                                MutationCandidate(
+                                    seed_entry_name=seed_name,
+                                    seed_category=seed_cat,
+                                    strategy=MutationStrategy.IDENTITY,
+                                    mutated_source=src,
+                                )
+                            )
+                            _accepted_llm += 1
+                            if _accepted_llm >= _target:
+                                break
+                else:
+                    # ----------------------------------------------------------
+                    # Legacy single-call path — byte-identical to pre-Slice95d.
+                    # ----------------------------------------------------------
+                    if llm_per_seed is not None:
+                        # Slice 95a-2 — decoupled explicit quota; cap at max.
+                        _llm_n = min(
+                            max(0, int(llm_per_seed)),
+                            _MAX_MUTATIONS_PER_PATTERN,
+                        )
+                    else:
+                        # Legacy formula — 0 when deterministic fills budget.
+                        _llm_n = max(0, per_pattern - len(candidates))
+                    extra = await mutation_provider.mutate(
+                        seed_src, n=_llm_n
+                    )
+                    for src in (extra or ()):
+                        if not isinstance(src, str):
+                            continue
+                        if len(src.encode("utf-8", "replace")) > (
+                            _MAX_MUTATED_SOURCE_BYTES
+                        ):
+                            continue
+                        # Slice 93 validity filter — ast.parse gate.
+                        try:
+                            ast.parse(src)
+                            _src_valid = True
+                        except SyntaxError:
+                            _src_valid = False
+                        cand = MutationCandidate(
+                            seed_entry_name=seed_name,
+                            seed_category=seed_cat,
+                            strategy=MutationStrategy.IDENTITY,
+                            mutated_source=src,
+                        )
+                        if not _src_valid:
+                            # Record UNPARSEABLE directly — skip cage eval.
+                            inapplicable_results.append(
+                                MutationResult(
+                                    candidate=cand,
+                                    verdict=ImmunizationVerdict.UNPARSEABLE,
+                                    cage_verdict="",
+                                    semguard_findings=(),
+                                    detail="llm_output_unparseable",
+                                )
+                            )
+                            continue
+                        candidates.append(cand)
+                        # Slice 95a-2: in decoupled llm_per_seed mode, the LLM
+                        # is additive — don't cap at per_pattern.  In legacy
+                        # mode (llm_per_seed=None), honour the per_pattern bound.
+                        if (
+                            llm_per_seed is None
+                            and len(candidates) >= per_pattern
+                        ):
+                            break
             except asyncio.CancelledError:
                 raise
             except AegisLeaseError:
@@ -1811,6 +2056,18 @@ async def run_immunization_campaign(
                         "[SelfImmunization] hardening sink raised",
                         exc_info=True,
                     )
+                # Slice 95d — capture the FULL escaping source for analysis.
+                # Best-effort instrumentation; the sink itself never raises.
+                if _escape_sink is not None:
+                    try:
+                        await _escape_sink.record_escape(res)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:  # noqa: BLE001
+                        logger.debug(
+                            "[SelfImmunization] escape capture sink raised",
+                            exc_info=True,
+                        )
 
         return _build_report(seed_name, seed_cat, results, target)
 
@@ -2298,6 +2555,70 @@ def register_flags(registry: Any) -> int:
             source_file=src,
             example=".jarvis/antivenom_corpus_cache.jsonl",
             since="v2.0",
+        ),
+        # Slice 95d — async multi-call batching engine + escape capture
+        FlagSpec(
+            name=_ENV_BATCHING,
+            type=FlagType.BOOL,
+            default=False,
+            description=(
+                "Slice 95d: when true (and llm_per_seed is set), the "
+                "campaign paginates multiple mutate() calls per seed, "
+                "deduping by AST-structural hash, until the per-seed "
+                "quota is met (breaks the single-call max_tokens ceiling "
+                "that capped a 3000-request run to ~418 mutations). "
+                "Default FALSE — the legacy single-call path is "
+                "byte-identical when off."
+            ),
+            category=Category.CAPACITY,
+            source_file=src,
+            example="true",
+            since="v2.1",
+        ),
+        FlagSpec(
+            name=_ENV_MAX_CALLS_PER_SEED,
+            type=FlagType.INT,
+            default=_DEFAULT_MAX_CALLS_PER_SEED,
+            description=(
+                "Slice 95d: hard cap on mutate() calls per seed in "
+                "batching mode — bounds cost and prevents an unbounded "
+                "loop when the model keeps returning duplicates/empties. "
+                "Floored at 1."
+            ),
+            category=Category.CAPACITY,
+            source_file=src,
+            example="12",
+            since="v2.1",
+        ),
+        FlagSpec(
+            name=_ENV_ESCAPE_CAPTURE,
+            type=FlagType.BOOL,
+            default=False,
+            description=(
+                "Slice 95d: when true, the full source of every ESCAPED "
+                "mutation is persisted (via EscapeCaptureSink) so the "
+                "bypass surface forms can be analyzed for cage hardening "
+                "(the corpus cache stores only metadata, not the source). "
+                "Default FALSE."
+            ),
+            category=Category.OBSERVABILITY,
+            source_file=src,
+            example="true",
+            since="v2.1",
+        ),
+        FlagSpec(
+            name=_ENV_ESCAPE_CAPTURE_PATH,
+            type=FlagType.STR,
+            default=_DEFAULT_ESCAPE_CAPTURE_PATH,
+            description=(
+                "Slice 95d: JSONL path for captured escaped-mutation "
+                "source (EscapeCaptureSink). Written via the canonical "
+                "cross-process flock primitive."
+            ),
+            category=Category.OBSERVABILITY,
+            source_file=src,
+            example=".jarvis/antivenom_escapes.jsonl",
+            since="v2.1",
         ),
     ]
     n = 0

--- a/tests/governance/test_self_immunization.py
+++ b/tests/governance/test_self_immunization.py
@@ -648,14 +648,15 @@ class TestAstPinsSyntheticRegression:
 
 class TestFlagSeeds:
     def test_register_flags_seeds_all_five(self):
-        # Slice 93 added 2 new flags (mutation budget + corpus cache path):
-        # the count is now 7. Updated from 5 → 7.
+        # Slice 93 added 2 (mutation budget + corpus cache path): 5 → 7.
+        # Slice 95d added 4 (batching enabled + max-calls-per-seed +
+        # escape-capture enabled + escape-capture path): 7 → 11.
         from backend.core.ouroboros.governance.flag_registry import (
             FlagRegistry,
         )
 
         reg = FlagRegistry()
-        assert si.register_flags(reg) == 7
+        assert si.register_flags(reg) == 11
 
     def test_master_flag_seeded_default_false(self):
         from backend.core.ouroboros.governance.flag_registry import (

--- a/tests/governance/test_slice95d_batching_engine.py
+++ b/tests/governance/test_slice95d_batching_engine.py
@@ -1,0 +1,493 @@
+"""Slice 95d — async multi-call mutation batching + AST-hash dedup +
+escaped-source capture.
+
+TDD regression spine.  ALL LLM calls are MOCKED — zero live calls.
+
+Test plan
+---------
+1. _ast_structural_hash: whitespace/comment-only differences collapse to
+   the SAME hash; structurally-different sources differ; unparseable → None.
+2. Batching reaches target across multiple calls (provider.call_count > 1).
+3. Dedup filters duplicate sources → only 1 unique LLM candidate, loop
+   terminates at max_calls_per_seed (not infinite).
+4. max_calls_per_seed cap honoured (empty / all-dupes provider).
+5. Backward-compat: batching default-OFF → exactly ONE mutate() call per
+   seed (legacy path); llm_per_seed=None path unchanged.
+6. AegisLeaseError propagates through the batching loop.
+7. EscapeCaptureSink: writes the FULL mutated_source; default-OFF = no file.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List, Sequence
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# sys.path bootstrap
+# ---------------------------------------------------------------------------
+
+_WT_ROOT = Path(__file__).resolve().parents[2]
+if str(_WT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_WT_ROOT))
+
+from backend.core.ouroboros.governance import self_immunization as si  # noqa: E402
+
+
+_AEGIS_ENABLED_PATH = "backend.core.ouroboros.aegis.client.is_enabled"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _make_minimal_seed():
+    """Minimal seed-like object with name/category/source."""
+    from backend.core.ouroboros.governance.graduation.adversarial_cage import (
+        CorpusCategory,
+    )
+
+    class _Seed:
+        name = "slice95d_seed"
+        category = CorpusCategory.SANDBOX_ESCAPE
+        source = "x = 1\n"
+
+    return _Seed()
+
+
+class _CountingProvider:
+    """Fake async MutationProvider returning distinct valid sources.
+
+    Each mutate(n=k) call returns up to k DISTINCT, structurally-unique,
+    valid Python sources (a fresh assignment per variant).  Tracks the
+    number of calls + the n requested each call.
+    """
+
+    def __init__(self, per_call_cap: int = 1000) -> None:
+        self.call_count = 0
+        self.requested_ns: List[int] = []
+        self._counter = 0
+        self._per_call_cap = per_call_cap
+
+    async def mutate(self, seed_source: str, *, n: int) -> Sequence[str]:
+        self.call_count += 1
+        self.requested_ns.append(n)
+        out: List[str] = []
+        give = min(n, self._per_call_cap)
+        for _ in range(max(0, give)):
+            # Distinct variable name → structurally distinct AST.
+            out.append(f"v{self._counter} = {self._counter}\n")
+            self._counter += 1
+        return out
+
+
+class _SameSourceProvider:
+    """Always returns the SAME single valid source (dedup target)."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def mutate(self, seed_source: str, *, n: int) -> Sequence[str]:
+        self.call_count += 1
+        return ["dup = 1\n"]
+
+
+class _EmptyProvider:
+    """Always returns []."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def mutate(self, seed_source: str, *, n: int) -> Sequence[str]:
+        self.call_count += 1
+        return []
+
+
+class _LeaseRaisingProvider:
+    """Raises AegisLeaseError on the first call."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def mutate(self, seed_source: str, *, n: int) -> Sequence[str]:
+        self.call_count += 1
+        raise si.AegisLeaseError("[CRITICAL] test lease denial")
+
+
+async def _drive_campaign(**kwargs) -> None:
+    async for _ in si.run_immunization_campaign(**kwargs):
+        pass
+
+
+def _count_llm_candidates_via_corpus(corpus_path: Path, seed_src: str) -> int:
+    """Count accepted LLM (IDENTITY) candidates by reading the corpus cache
+    JSONL — every evaluated candidate is recorded there.
+
+    The deterministic ``_mut_identity`` operator ALSO emits exactly one
+    IDENTITY candidate whose source == the seed; exclude it by skipping the
+    single IDENTITY row whose ``mutated_source_bytes`` equals the seed's
+    byte length (the deterministic identity)."""
+    if not corpus_path.exists():
+        return 0
+    seed_bytes = len(seed_src.encode("utf-8", "replace"))
+    count = 0
+    skipped_det_identity = False
+    for line in corpus_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        rec = json.loads(line)
+        cand = rec.get("candidate") or {}
+        if cand.get("strategy") != "identity":
+            continue
+        if rec.get("verdict") not in ("escaped", "still_caged", "harness_error"):
+            continue
+        if (
+            not skipped_det_identity
+            and cand.get("mutated_source_bytes") == seed_bytes
+        ):
+            # The lone deterministic identity (source == seed). Exclude once.
+            skipped_det_identity = True
+            continue
+        count += 1
+    return count
+
+
+# ===========================================================================
+# 1. _ast_structural_hash
+# ===========================================================================
+
+class TestAstStructuralHash:
+    def test_whitespace_and_comment_differences_collapse(self):
+        a = "def f(x):\n    return x + 1\n"
+        b = "def f(x):  # a comment\n\n    return x + 1\n\n"
+        c = "def f(x):\n        return x + 1\n"  # different indent only
+        ha = si._ast_structural_hash(a)
+        hb = si._ast_structural_hash(b)
+        hc = si._ast_structural_hash(c)
+        assert ha is not None
+        assert ha == hb, "comment/blank-line difference must not change hash"
+        assert ha == hc, "indentation difference must not change hash"
+
+    def test_structurally_different_sources_differ(self):
+        a = si._ast_structural_hash("x = 1\n")
+        b = si._ast_structural_hash("x = 2\n")
+        c = si._ast_structural_hash("y = 1\n")
+        assert a is not None and b is not None and c is not None
+        assert a != b, "different literal value → different structure"
+        assert a != c, "different target name → different structure"
+
+    def test_unparseable_returns_none(self):
+        assert si._ast_structural_hash("def (:\n") is None
+        assert si._ast_structural_hash("this is not python ===") is None
+
+
+# ===========================================================================
+# 2. Batching reaches target across multiple calls
+# ===========================================================================
+
+class TestBatchingReachesTarget:
+    def test_multiple_calls_accumulate_unique_target(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(si._ENV_MASTER, "true")
+        monkeypatch.setenv(si._ENV_BATCHING, "true")
+        corpus_path = tmp_path / "corpus.jsonl"
+        provider = _CountingProvider(per_call_cap=5)  # ~5 per call
+        seed = _make_minimal_seed()
+        sink = si.CorpusCacheSink(path=corpus_path)
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            _run(
+                _drive_campaign(
+                    seeds=[seed],
+                    mutation_provider=provider,
+                    corpus_sink=sink,
+                    llm_per_seed=25,
+                )
+            )
+
+        assert provider.call_count > 1, (
+            f"expected pagination (>1 call), got {provider.call_count}"
+        )
+        n_llm = _count_llm_candidates_via_corpus(corpus_path, seed.source)
+        assert n_llm == 25, (
+            f"expected 25 accumulated unique LLM candidates, got {n_llm}"
+        )
+
+
+# ===========================================================================
+# 3. Dedup filters duplicates + loop terminates at cap
+# ===========================================================================
+
+class TestDedupFiltersDuplicates:
+    def test_same_source_yields_one_unique_and_stops_at_cap(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv(si._ENV_MASTER, "true")
+        monkeypatch.setenv(si._ENV_BATCHING, "true")
+        monkeypatch.setenv(si._ENV_MAX_CALLS_PER_SEED, "4")
+        corpus_path = tmp_path / "corpus.jsonl"
+        provider = _SameSourceProvider()
+        seed = _make_minimal_seed()
+        sink = si.CorpusCacheSink(path=corpus_path)
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            _run(
+                _drive_campaign(
+                    seeds=[seed],
+                    mutation_provider=provider,
+                    corpus_sink=sink,
+                    llm_per_seed=25,
+                )
+            )
+
+        n_llm = _count_llm_candidates_via_corpus(corpus_path, seed.source)
+        assert n_llm == 1, f"dedup must keep exactly 1 unique, got {n_llm}"
+        # Same-source never advances target → loop runs to the call-cap.
+        assert provider.call_count == 4, (
+            f"expected loop to hit cap=4, got {provider.call_count}"
+        )
+
+
+# ===========================================================================
+# 4. max_calls_per_seed cap
+# ===========================================================================
+
+class TestMaxCallsCap:
+    def test_empty_provider_stops_immediately(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(si._ENV_MASTER, "true")
+        monkeypatch.setenv(si._ENV_BATCHING, "true")
+        monkeypatch.setenv(si._ENV_MAX_CALLS_PER_SEED, "6")
+        provider = _EmptyProvider()
+        seed = _make_minimal_seed()
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            _run(
+                _drive_campaign(
+                    seeds=[seed],
+                    mutation_provider=provider,
+                    llm_per_seed=25,
+                )
+            )
+        # Empty return terminates the loop after a single call (model
+        # exhausted) — must NOT burn the whole cap.
+        assert provider.call_count == 1, (
+            f"empty provider must stop after 1 call, got {provider.call_count}"
+        )
+
+    def test_all_dupes_respect_cap(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(si._ENV_MASTER, "true")
+        monkeypatch.setenv(si._ENV_BATCHING, "true")
+        monkeypatch.setenv(si._ENV_MAX_CALLS_PER_SEED, "3")
+        provider = _SameSourceProvider()
+        seed = _make_minimal_seed()
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            _run(
+                _drive_campaign(
+                    seeds=[seed],
+                    mutation_provider=provider,
+                    llm_per_seed=25,
+                )
+            )
+        # Persistent dupes never reach the target and never return empty, so
+        # the loop runs to EXACTLY the call cap (not merely <=).
+        assert provider.call_count == 3, (
+            f"provider.call_count must hit cap=3 exactly, got {provider.call_count}"
+        )
+
+
+# ===========================================================================
+# 5. Backward-compat (default-OFF)
+# ===========================================================================
+
+class TestBackwardCompatDefaultOff:
+    def test_batching_unset_single_call_per_seed(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(si._ENV_MASTER, "true")
+        monkeypatch.delenv(si._ENV_BATCHING, raising=False)
+        provider = _CountingProvider(per_call_cap=2)
+        seed = _make_minimal_seed()
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            _run(
+                _drive_campaign(
+                    seeds=[seed],
+                    mutation_provider=provider,
+                    llm_per_seed=25,
+                )
+            )
+        assert provider.call_count == 1, (
+            "default-OFF must use legacy single-call path "
+            f"(exactly 1 call), got {provider.call_count}"
+        )
+
+    def test_llm_per_seed_none_unchanged_with_batching_on(
+        self, tmp_path, monkeypatch
+    ):
+        # Even with batching ON, llm_per_seed=None must stay on the legacy
+        # single-call path (batching only engages when a quota is given).
+        monkeypatch.setenv(si._ENV_MASTER, "true")
+        monkeypatch.setenv(si._ENV_BATCHING, "true")
+        provider = _CountingProvider(per_call_cap=2)
+        seed = _make_minimal_seed()
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            _run(
+                _drive_campaign(
+                    seeds=[seed],
+                    mutation_provider=provider,
+                    llm_per_seed=None,
+                )
+            )
+        assert provider.call_count == 1, (
+            "llm_per_seed=None must stay single-call even with batching ON, "
+            f"got {provider.call_count}"
+        )
+
+
+# ===========================================================================
+# 6. AegisLeaseError propagates through the batching loop
+# ===========================================================================
+
+class TestAegisLeasePropagates:
+    def test_lease_error_propagates(self, monkeypatch):
+        monkeypatch.setenv(si._ENV_MASTER, "true")
+        monkeypatch.setenv(si._ENV_BATCHING, "true")
+        provider = _LeaseRaisingProvider()
+        seed = _make_minimal_seed()
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            with pytest.raises(si.AegisLeaseError):
+                _run(
+                    _drive_campaign(
+                        seeds=[seed],
+                        mutation_provider=provider,
+                        llm_per_seed=25,
+                    )
+                )
+        assert provider.call_count == 1, "lease error on first call"
+
+
+# ===========================================================================
+# 7. EscapeCaptureSink
+# ===========================================================================
+
+def _make_escaped_result() -> "si.MutationResult":
+    cand = si.MutationCandidate(
+        seed_entry_name="escape_seed",
+        seed_category="sandbox_escape",
+        strategy=si.MutationStrategy.IDENTITY,
+        mutated_source="import os\nos.system('id')\n",
+    )
+    return si.MutationResult(
+        candidate=cand,
+        verdict=si.ImmunizationVerdict.ESCAPED,
+        cage_verdict="passed_through",
+        semguard_findings=("permission_loosened",),
+        detail="escaped the cage",
+    )
+
+
+class TestEscapeCaptureSink:
+    def test_record_escape_writes_full_source(self, tmp_path):
+        path = tmp_path / "escapes.jsonl"
+        sink = si.EscapeCaptureSink(path=path)
+        res = _make_escaped_result()
+
+        ok = _run(sink.record_escape(res))
+        assert ok is True
+        assert path.exists()
+
+        lines = [l for l in path.read_text().splitlines() if l.strip()]
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["kind"] == "escaped_variant"
+        assert rec["seed_entry_name"] == "escape_seed"
+        assert rec["seed_category"] == "sandbox_escape"
+        assert rec["strategy"] == "identity"
+        assert rec["cage_verdict"] == "passed_through"
+        assert rec["semguard_findings"] == ["permission_loosened"]
+        # The whole point: the FULL source, not a byte count.
+        assert rec["mutated_source"] == "import os\nos.system('id')\n"
+        assert "mutated_source_bytes" not in rec
+        assert "schema_version" in rec
+        assert "wrote_at_unix" in rec
+
+    def test_record_escape_never_raises_on_bad_path(self, tmp_path):
+        # A path whose parent cannot be created → swallow + return False.
+        bad = tmp_path / "afile"
+        bad.write_text("not a dir")
+        path = bad / "nested" / "escapes.jsonl"
+        sink = si.EscapeCaptureSink(path=path)
+        res = _make_escaped_result()
+        ok = _run(sink.record_escape(res))
+        assert ok is False  # best-effort, never raised
+
+    def test_default_off_no_file_written(self, tmp_path, monkeypatch):
+        # With escape-capture disabled, the campaign must NOT construct the
+        # sink nor write any escapes file.
+        monkeypatch.setenv(si._ENV_MASTER, "true")
+        monkeypatch.delenv(si._ENV_ESCAPE_CAPTURE, raising=False)
+        capture_path = tmp_path / "escapes.jsonl"
+        monkeypatch.setenv(si._ENV_ESCAPE_CAPTURE_PATH, str(capture_path))
+        seed = _make_minimal_seed()
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            _run(_drive_campaign(seeds=[seed]))
+        assert not capture_path.exists(), (
+            "no escape file may be written when capture is disabled"
+        )
+
+    def test_enabled_campaign_captures_escape(self, tmp_path, monkeypatch):
+        # Wire a provider that returns a source which escapes the cage, then
+        # assert the escapes file is written with the full source.  We force
+        # an escape by stubbing _evaluate_candidate to return ESCAPED for the
+        # LLM IDENTITY candidate.
+        monkeypatch.setenv(si._ENV_MASTER, "true")
+        monkeypatch.setenv(si._ENV_ESCAPE_CAPTURE, "true")
+        capture_path = tmp_path / "escapes.jsonl"
+        monkeypatch.setenv(si._ENV_ESCAPE_CAPTURE_PATH, str(capture_path))
+        seed = _make_minimal_seed()
+
+        escaping_source = "import os\nos.system('whoami')\n"
+
+        class _EscapeProvider:
+            async def mutate(self, seed_source, *, n):
+                return [escaping_source]
+
+        real_eval = si._evaluate_candidate
+
+        def _fake_eval(cand):
+            if cand.mutated_source == escaping_source:
+                return si.MutationResult(
+                    candidate=cand,
+                    verdict=si.ImmunizationVerdict.ESCAPED,
+                    cage_verdict="passed_through",
+                    semguard_findings=(),
+                    detail="forced escape",
+                )
+            return real_eval(cand)
+
+        with patch(_AEGIS_ENABLED_PATH, return_value=False):
+            with patch.object(si, "_evaluate_candidate", _fake_eval):
+                _run(
+                    _drive_campaign(
+                        seeds=[seed],
+                        mutation_provider=_EscapeProvider(),
+                        llm_per_seed=1,
+                    )
+                )
+
+        assert capture_path.exists(), "escape capture file must be written"
+        lines = [l for l in capture_path.read_text().splitlines() if l.strip()]
+        assert any(
+            json.loads(l).get("mutated_source") == escaping_source
+            for l in lines
+        ), "captured record must contain the full escaping source"


### PR DESCRIPTION
Breaks the single-call `max_tokens` ceiling that capped a 3,000-request parity run to ~418 mutations (Slice 95c), and instruments the data the rigorous dual-metric split + cage hardening need. **All gated, default-FALSE — the legacy single-call path is byte-identical when off.**

## What it adds (`self_immunization.py`)
- **Per-seed batching loop** (`JARVIS_ANTIVENOM_BATCHING_ENABLED` default FALSE; `JARVIS_ANTIVENOM_MAX_CALLS_PER_SEED` default 12): when on **and** `llm_per_seed` is set, the campaign paginates `mutate()` calls per seed, accumulating **unique** valid mutations until quota met / call-cap hit / empty return / budget exhausted. **Four independent loop-exit guards — no hang risk.** `AegisLeaseError` still propagates (ZERO-LEAK preserved).
- **O(1) AST-hash dedup** (`_ast_structural_hash`: `ast.dump(annotate_fields=False, include_attributes=False)` → sha256; `None` on `SyntaxError`). Per-run shared set = **global cross-seed dedup**; deterministic candidates pre-seed it so an LLM variant identical to a mechanical mutation is filtered.
- **`EscapeCaptureSink`** (`JARVIS_ANTIVENOM_ESCAPE_CAPTURE_ENABLED` default FALSE; `..._PATH` default `.jarvis/antivenom_escapes.jsonl`): persists the **full source** of every ESCAPED mutation (the corpus cache stores only metadata) so the bypass surface forms can be analyzed for hardening. Never raises.
- 4 new flags registered in `register_flags()` (7 → 11).

## Tests
14 new (`test_slice95d_batching_engine.py`) + 173 adjacent green. Independently reviewed (spec + quality): backward-compat byte-identical, loop-termination guards confirmed, `AegisLeaseError` propagation confirmed, dedup global + deterministic-seeded, escape-sink full-source + never-raises.

## Next
Slice 95e — true-scale ≥3,000 run with batching + escape-capture on → `production_parity_ledger_v2.json` with the rigorous static-vs-runtime split derived from the captured escaped source.

Engine remains §33.1 default-FALSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an async multi-call batching engine for LLM mutations with O(1) AST-structural dedup and an escaped-source capture sink, all behind default-off flags. This removes the single-call max_tokens ceiling and keeps the legacy path byte-identical when disabled.

- New Features
  - Per-seed async batching (default off): paginates multiple `mutate()` calls when `llm_per_seed` is set; stops on quota met, call cap, empty return, or budget exhaustion. `AegisLeaseError` still propagates.
  - O(1) AST-structural dedup: per-run global set filters duplicates across seeds; deterministic variants pre-seed the set; unparseable sources skip dedup.
  - Escaped-source capture (default off): writes full source of escaped mutations to `.jarvis/antivenom_escapes.jsonl`; best-effort sink, never raises.
  - New flags: `JARVIS_ANTIVENOM_BATCHING_ENABLED`, `JARVIS_ANTIVENOM_MAX_CALLS_PER_SEED` (default 12), `JARVIS_ANTIVENOM_ESCAPE_CAPTURE_ENABLED`, `JARVIS_ANTIVENOM_ESCAPE_CAPTURE_PATH`. Total flags: 11.
  - Tests: 14 new cases cover batching pagination, dedup behavior, loop guards, lease error propagation, and escape capture; legacy single-call path remains unchanged.

<sup>Written for commit b09a19de42600fb1f9887b606dfb37e7246e48de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

