### PR TITLE
feat(security): Slice 95h — banned-constant propagation hardening of the live cage (zero-FP)

### DIFF
--- a/backend/core/ouroboros/governance/meta/ast_phase_runner_validator.py
+++ b/backend/core/ouroboros/governance/meta/ast_phase_runner_validator.py
@@ -341,6 +341,16 @@ _TAINT_EXEC_SINKS_ATTR: FrozenSet[str] = frozenset((
     "import_module",  # importlib.import_module(<tainted>)
 ))
 _GETATTR_NAME: str = "get" + "attr"
+# Slice 95h — the attr-resolution sinks whose KEY argument (position 1) is an
+# attribute name. ``getattr``/``setattr``/``delattr`` all take ``(obj, name,
+# ...)``; a banned reflection attr name in that key position is unambiguous
+# reflection-escape intent regardless of whether the result is called. Built
+# via concatenation so the validator never trips its own banned-name scan.
+_SETATTR_NAME: str = "set" + "attr"
+_DELATTR_NAME: str = "del" + "attr"
+_ATTR_KEY_SINKS: FrozenSet[str] = frozenset((
+    _GETATTR_NAME, _SETATTR_NAME, _DELATTR_NAME,
+))
 
 
 def _is_string_assembly_expr(node: ast.AST, tainted: FrozenSet[str]) -> bool:
@@ -399,6 +409,70 @@ def _collect_tainted_names(tree: ast.AST) -> FrozenSet[str]:
     return frozenset(tainted)
 
 
+def _collect_banned_const_names(tree: ast.AST) -> FrozenSet[str]:
+    """Slice 95h. Fixpoint collecting names bound to a PLAIN string ``Constant``
+    whose VALUE is a banned reflection attr name (``_BANNED_INTROSPECTION_ATTRS``),
+    propagating through plain aliases (``b = a``). Mirrors ``_collect_tainted_names``'
+    shape and bound.
+
+    Conservative by construction:
+      * ONLY ``ast.Constant`` strings whose value is in the banned reflection
+        attr set are seeded (a benign ``x = "hello"`` / ``s = "__main__"`` is
+        NEVER collected — ``__main__``/``__doc__``/``__name__`` are not banned
+        reflection attrs).
+      * String-ASSEMBLY exprs are intentionally NOT collected here (those remain
+        Rule 11's existing taint domain) — only literal constants.
+
+    Never raises (caller wraps, but this is also independently defensive)."""
+    banned: set = set()
+    for _ in range(6):  # converges fast; bound guards pathological inputs
+        changed = False
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            value = node.value
+            if value is None:
+                continue
+            # seed: plain string Constant whose value is a banned reflection attr
+            if (isinstance(value, ast.Constant)
+                    and isinstance(value.value, str)
+                    and value.value in _BANNED_INTROSPECTION_ATTRS):
+                _value_is_banned_const = True
+            # propagate: plain alias of an already-banned-const symbol
+            elif isinstance(value, ast.Name) and value.id in banned:
+                _value_is_banned_const = True
+            else:
+                _value_is_banned_const = False
+            if _value_is_banned_const:
+                targets = (
+                    node.targets if isinstance(node, ast.Assign)
+                    else [node.target]
+                )
+                for tgt in targets:
+                    if isinstance(tgt, ast.Name) and tgt.id not in banned:
+                        banned.add(tgt.id)
+                        changed = True
+        if not changed:
+            break
+    return frozenset(banned)
+
+
+def _attr_key_is_banned_const(
+    node: ast.AST, banned_consts: FrozenSet[str],
+) -> bool:
+    """Slice 95h. True iff ``node`` (the KEY/attr-name argument of a
+    getattr/setattr/delattr call) is a banned reflection attr name —
+    EITHER as a plain inline string ``Constant`` whose value is banned, OR a
+    ``Name`` proven to hold such a constant (``banned_consts``)."""
+    if (isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value in _BANNED_INTROSPECTION_ATTRS):
+        return True
+    if isinstance(node, ast.Name) and node.id in banned_consts:
+        return True
+    return False
+
+
 def _arg_is_tainted(node: ast.AST, tainted: FrozenSet[str]) -> bool:
     if isinstance(node, ast.Name) and node.id in tainted:
         return True
@@ -415,10 +489,26 @@ def _check_taint_flow(tree: ast.AST) -> Optional[str]:
         # tainted symbol yet is still an exploit; the per-arg check below catches
         # both the inline and the via-variable forms.
         tainted = _collect_tainted_names(tree)
+        # Slice 95h — names proven to hold a PLAIN string literal that IS a
+        # banned reflection attr name. Drives the additive (c) check below.
+        banned_consts = _collect_banned_const_names(tree)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
+            # (c) Slice 95h: getattr/setattr/delattr(obj, <banned-attr-name>, ...)
+            #     where the KEY arg is a banned reflection attr name held in a
+            #     plain-literal local (banned-const propagation) OR an inline
+            #     banned string Constant. A banned reflection attr name in the
+            #     key position is unambiguous reflection-escape intent — flagged
+            #     WHETHER OR NOT the result is immediately called (unlike (b),
+            #     which only caught the immediately-called assembled form). This
+            #     is additive; (a)/(b) below remain intact.
+            if (isinstance(func, ast.Name)
+                    and func.id in _ATTR_KEY_SINKS
+                    and len(node.args) >= 2
+                    and _attr_key_is_banned_const(node.args[1], banned_consts)):
+                return f"sink={func.id}:banned_attr_const_propagated"
             # (a) eval/exec/compile/__import__/importlib.import_module(<tainted>)
             sink = None
             if isinstance(func, ast.Name) and func.id in _TAINT_EXEC_SINKS_BARE:

--- a/tests/governance/test_slice95h_const_propagation.py
+++ b/tests/governance/test_slice95h_const_propagation.py
@@ -1,0 +1,340 @@
+"""Slice 95h — banned-constant propagation hardening of the LIVE adversarial cage.
+
+The converged ~8.8% adversarial benchmark's taxonomy captured a
+"constant-in-variable" technique that defeats literal-string matching: a banned
+reflection attr NAME is held in a PLAIN string-literal local, then used to
+resolve the attr dynamically via ``getattr``/``setattr``::
+
+    lookup = "__subclasses__"
+    getattr(obj, lookup)()           # banned attr name via a plain-literal var
+
+The existing Rule 11 (``_check_taint_flow`` + ``_collect_tainted_names``) taints
+only string-ASSEMBLY exprs (``'o'+'s'``, ``"".join(...)``, ``.format``). A PLAIN
+literal (``lookup = "__subclasses__"``) is NOT assembled → not tainted → the
+``getattr(obj, lookup)`` escapes. Slice 95h closes this by ALSO tracking plain
+string-literal bindings whose VALUE is a banned reflection attr name, and
+flagging their flow into ``getattr``/``setattr``/``delattr`` attr-sinks —
+whether or not the result is immediately called.
+
+ZERO clean-control false positives is a HARD, non-negotiable invariant: a false
+positive in this LIVE cage BLOCKS legitimate autonomous code-apply. The
+clean-control matrix below is the gating deliverable.
+
+All detections stay under the existing ``TAINT_EXPLOIT`` reason + the existing
+kill-switch ``JARVIS_AST_VALIDATOR_BLOCK_TAINT_EXPLOIT`` (default TRUE) — same
+rule (Rule 11), no new ValidationFailureReason, no new flag.
+"""
+from __future__ import annotations
+
+import textwrap
+from typing import Iterator
+
+import pytest
+
+from backend.core.ouroboros.governance.meta.ast_phase_runner_validator import (  # noqa: E501
+    ValidationFailureReason,
+    ValidationStatus,
+    _BANNED_INTROSPECTION_ATTRS,
+    _collect_banned_const_names,
+    validate_ast,
+)
+import ast as _ast
+
+
+_VALIDATOR_FLAG = "JARVIS_PHASE_RUNNER_AST_VALIDATOR_ENABLED"
+_TAINT_FLAG = "JARVIS_AST_VALIDATOR_BLOCK_TAINT_EXPLOIT"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Master flag + the taint-exploit kill-switch default-TRUE
+    (security-on); clear any stray env so the defaults take effect."""
+    for flag in (_VALIDATOR_FLAG, _TAINT_FLAG):
+        monkeypatch.delenv(flag, raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Source builder — mirrors tests/governance/test_slice95g_indirection_taint.py
+# ---------------------------------------------------------------------------
+
+
+def _runner_body(body: str) -> str:
+    """Wrap a function-body fragment in a valid PhaseRunner stub so Rules 1-6
+    (incl. the Rule-6 import allowlist) don't short-circuit."""
+    return textwrap.dedent(f"""
+        from backend.core.ouroboros.governance.phase_runner import (
+            PhaseRunner,
+        )
+        from backend.core.ouroboros.governance.op_context import (
+            OperationContext,
+        )
+        from backend.core.ouroboros.governance.phase_runner import (
+            PhaseResult,
+        )
+
+        class TestPR(PhaseRunner):
+            phase = "TEST"
+            async def run(self, ctx: OperationContext) -> PhaseResult:
+                try:
+{textwrap.indent(textwrap.dedent(body), '                    ')}
+                except Exception:
+                    return None
+    """).strip()
+
+
+# ===========================================================================
+# 1. ADVERSARIAL INTERCEPTION
+#
+# Two sub-groups, because the LIVE cage is defense-in-depth and ORDER matters:
+#
+#  (1a) Cases the NEW Slice-95h Rule-11 check is the *first* (and in some cases
+#       only) rule to catch → MUST block with reason == TAINT_EXPLOIT. These
+#       are the genuine gaps 95h closes: setattr/delattr with a banned-const
+#       attr key (Rule 7's getattr-only matcher never sees them), and getattr
+#       via an ALIAS-PROPAGATED banned-const (`a=X; b=a; getattr(self,b)` —
+#       Rule 7's constant-fold name-map does not chase `b=a` aliases).
+#
+#  (1b) The plain getattr-with-banned-literal / single-binding forms. These are
+#       ALSO caught by the pre-existing Rule 7 (INTROSPECTION_ESCAPE), which
+#       runs BEFORE Rule 11 in validate_ast — so they block under
+#       INTROSPECTION_ESCAPE, NOT TAINT_EXPLOIT. What the security invariant
+#       requires is that they BLOCK (they do, doubly so). We assert BLOCKED and
+#       that the new Rule-11 check ALSO independently catches them (proven via
+#       _check_taint_flow directly) so 95h's coverage is complete even if Rule
+#       7 were ever disabled.
+# ===========================================================================
+
+
+# (1a) — NEW coverage; the 95h check is the gating rule → reason TAINT_EXPLOIT.
+@pytest.mark.parametrize(
+    "body",
+    [
+        # alias propagation b = a → getattr (Rule 7's fold map misses `b=a`)
+        'a = "__class__"\nb = a\ngetattr(self, b)',
+        # setattr with banned attr literal (Rule 7 is getattr-only)
+        'setattr(obj, "__class__", x)',
+        # setattr via banned-const variable
+        'k = "__getattribute__"\nsetattr(obj, k, x)',
+        # delattr with banned attr literal
+        'delattr(obj, "__class__")',
+        # delattr via banned-const variable
+        'g = "__getattr__"\ndelattr(obj, g)',
+    ],
+)
+def test_const_propagation_new_coverage_taint_exploit(body):
+    src = _runner_body(body)
+    result = validate_ast(src)
+    assert result.status is ValidationStatus.FAILED, (
+        f"escape not blocked: {body!r} → {result.status} {result.detail!r}"
+    )
+    assert result.reason is ValidationFailureReason.TAINT_EXPLOIT, (
+        f"{body!r} blocked for {result.reason}, expected TAINT_EXPLOIT "
+        f"(detail={result.detail!r})"
+    )
+
+
+# (1b) — defense-in-depth getattr forms: MUST block (Rule 7 wins the race).
+@pytest.mark.parametrize(
+    "body",
+    [
+        'lookup = "__subclasses__"\ngetattr(obj, lookup)()',
+        'lookup = "__subclasses__"\ngetattr(obj, lookup)',
+        'getattr(obj, "__bases__")',
+        'getattr(type(obj), "__mro__")',
+        'd = "__dict__"\ngetattr(obj, d)',
+    ],
+)
+def test_const_propagation_getattr_blocked_defense_in_depth(body):
+    src = _runner_body(body)
+    result = validate_ast(src)
+    assert result.status is ValidationStatus.FAILED, (
+        f"escape not blocked: {body!r} → {result.status} {result.detail!r}"
+    )
+    # Blocked by whichever rule fires first — Rule 7 (INTROSPECTION_ESCAPE)
+    # precedes Rule 11 in validate_ast. Security requires only that it BLOCK.
+    assert result.reason in (
+        ValidationFailureReason.INTROSPECTION_ESCAPE,
+        ValidationFailureReason.TAINT_EXPLOIT,
+    ), (
+        f"{body!r} blocked for unexpected reason {result.reason} "
+        f"(detail={result.detail!r})"
+    )
+
+
+# Prove the NEW Rule-11 check ALSO catches the (1b) getattr forms on its own —
+# i.e. 95h's coverage is complete even if Rule 7 were disabled. We call
+# _check_taint_flow directly (the unit under test) on the parsed tree.
+@pytest.mark.parametrize(
+    "body, expected_sink_prefix",
+    [
+        ('lookup = "__subclasses__"\ngetattr(obj, lookup)()', "sink=getattr:"),
+        ('lookup = "__subclasses__"\ngetattr(obj, lookup)', "sink=getattr:"),
+        ('getattr(obj, "__bases__")', "sink=getattr:"),
+        ('getattr(type(obj), "__mro__")', "sink=getattr:"),
+        ('d = "__dict__"\ngetattr(obj, d)', "sink=getattr:"),
+    ],
+)
+def test_new_check_independently_catches_getattr(body, expected_sink_prefix):
+    from backend.core.ouroboros.governance.meta.ast_phase_runner_validator import (  # noqa: E501
+        _check_taint_flow,
+    )
+    tree = _ast.parse(textwrap.dedent(body))
+    diag = _check_taint_flow(tree)
+    assert diag is not None and diag.startswith(expected_sink_prefix), (
+        f"new check did not catch {body!r}: {diag!r}"
+    )
+    assert diag.endswith("banned_attr_const_propagated"), diag
+
+
+# Direct unit test of the new collector — proves it ONLY collects names bound
+# to a plain Constant string whose value is a banned reflection attr.
+@pytest.mark.parametrize(
+    "src, expected",
+    [
+        ('lookup = "__subclasses__"', {"lookup"}),
+        ('a = "__class__"\nb = a', {"a", "b"}),
+        # benign string consts are NEVER collected
+        ('x = "hello"', set()),
+        ('s = "__main__"', set()),       # __main__ is NOT a banned reflection attr
+        ('mode = "__doc__"', set()),     # __doc__ is benign — must not collect
+        ('name = "items"', set()),
+        # assembled (not plain) string is Rule-11-taint, not banned-const
+        ("p = 'o' + 's'", set()),
+        # multiple
+        ('a = "__bases__"\nx = "ok"\nc = a', {"a", "c"}),
+    ],
+)
+def test_collect_banned_const_names(src, expected):
+    tree = _ast.parse(textwrap.dedent(src))
+    assert _collect_banned_const_names(tree) == frozenset(expected)
+
+
+def test_banned_set_excludes_benign_dunders():
+    """Sanity: the rule is driven off _BANNED_INTROSPECTION_ATTRS, and the
+    benign dunders that legitimately appear in getattr keys are NOT in it."""
+    for benign in ("__doc__", "__name__", "__module__", "__main__", "__init__"):
+        assert benign not in _BANNED_INTROSPECTION_ATTRS, (
+            f"{benign} unexpectedly banned — would cause a false positive"
+        )
+    # high-signal reflection attrs ARE banned (drive the new check)
+    for banned in ("__subclasses__", "__bases__", "__class__"):
+        assert banned in _BANNED_INTROSPECTION_ATTRS
+
+
+# ===========================================================================
+# 2. CLEAN-CONTROL MATRIX — must PASS, zero false positives. THE GATE.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        # --- getattr with benign string literals ---------------------------
+        'getattr(obj, "value")',
+        'getattr(self, "_cache", None)',
+        'getattr(ctx, "data", None)',
+        'getattr(obj, "items")',
+        # --- getattr with an UNKNOWN var (function param / runtime value) --
+        # `name` is the run() body's free var here; its value is unknown so it
+        # must NOT be flagged — only proven banned-const names flow.
+        "getattr(obj, name)",
+        "getattr(obj, name, None)",
+        # --- getattr with a benign string CONST in a var -------------------
+        'attr = "items"\ngetattr(obj, attr)',
+        'fld = "_value"\ngetattr(self, fld, None)',
+        # --- benign dunder string consts (NOT banned reflection attrs) -----
+        's = "__main__"\nif __name__ == s:\n    return None',
+        'mode = "__doc__"\nreturn getattr(obj, mode)',
+        'n = "__name__"\nreturn getattr(obj, n)',
+        'fmt = "{}"\nreturn fmt.format(x)',
+        # --- setattr / delattr benign -------------------------------------
+        'setattr(self, "_x", 1)',
+        "setattr(obj, key, v)",          # key is an unknown var/param
+        'attr = "_priv"\nsetattr(self, attr, 1)',
+        "delattr(obj, key)",             # unknown var
+        'delattr(obj, "_scratch")',
+        # --- benign string locals that happen to be near getattr ----------
+        'lookup = "value"\nreturn getattr(obj, lookup, None)',
+    ],
+)
+def test_clean_control_not_flagged(body):
+    src = _runner_body(body)
+    result = validate_ast(src)
+    assert result.status is ValidationStatus.PASSED, (
+        f"FALSE POSITIVE: clean control flagged: {body!r} → "
+        f"{result.status} reason={result.reason} detail={result.detail!r}"
+    )
+
+
+# A realistic ~25-line benign PhaseRunner — the strongest FP probe.
+_REALISTIC_BENIGN = textwrap.dedent('''
+    from backend.core.ouroboros.governance.phase_runner import PhaseRunner
+    from backend.core.ouroboros.governance.op_context import OperationContext
+    from backend.core.ouroboros.governance.phase_runner import PhaseResult
+
+
+    class RealisticPR(PhaseRunner):
+        phase = "VALIDATE"
+
+        async def run(self, ctx: OperationContext) -> PhaseResult:
+            try:
+                data = getattr(ctx, "data", None)
+                if data is None:
+                    return None
+                mode = "summary"
+                results = []
+                for key in ("alpha", "beta", "gamma"):
+                    value = getattr(data, key, None)
+                    if value is not None:
+                        results.append((key, value))
+                doc_field = "__doc__"
+                label = getattr(self, doc_field, "")
+                cache = {k: v for k, v in results if v}
+                names = [n for n in cache if not n.startswith("_")]
+                setattr(self, "_last_mode", mode)
+                return PhaseResult(ok=True, detail=f"{label}:{len(names)}")
+            except Exception:
+                return None
+''').strip()
+
+
+def test_realistic_benign_runner_validates_clean():
+    result = validate_ast(_REALISTIC_BENIGN)
+    assert result.status is ValidationStatus.PASSED, (
+        f"FALSE POSITIVE on realistic benign runner: "
+        f"{result.status} reason={result.reason} detail={result.detail!r}"
+    )
+
+
+# ===========================================================================
+# 3. KILL-SWITCH — disabling JARVIS_AST_VALIDATOR_BLOCK_TAINT_EXPLOIT
+#    disables the new check (and the rest of Rule 11).
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        # NEW-coverage cases: ONLY Rule 11 catches these (Rule 7 is getattr-only
+        # and does not chase `b=a` aliases) — so with Rule 11 disabled they must
+        # PASS. (getattr-with-banned-literal is intentionally NOT used here: it
+        # is also caught by Rule 7, whose own kill-switch is separate.)
+        'a = "__class__"\nb = a\ngetattr(self, b)',
+        'setattr(obj, "__class__", x)',
+        'k = "__getattribute__"\nsetattr(obj, k, x)',
+        'delattr(obj, "__class__")',
+    ],
+)
+def test_kill_switch_disables_new_check(body, monkeypatch):
+    monkeypatch.setenv(_TAINT_FLAG, "false")
+    src = _runner_body(body)
+    result = validate_ast(src)
+    assert result.reason is not ValidationFailureReason.TAINT_EXPLOIT, (
+        f"kill-switch failed: {body!r} still TAINT_EXPLOIT "
+        f"(status={result.status} detail={result.detail!r})"
+    )
+    assert result.status is ValidationStatus.PASSED, (
+        f"kill-switch off but still failed for another reason: {body!r} → "
+        f"{result.status} reason={result.reason} detail={result.detail!r}"
+    )


### PR DESCRIPTION
Third + final hardening pass against the converged **~8.8%** baseline. Closes the **constant-in-variable** evasion technique by EXTENDING Rule 11 taint (no new module/reason/flag — stays under `TAINT_EXPLOIT` + `JARVIS_AST_VALIDATOR_BLOCK_TAINT_EXPLOIT` default-TRUE). Driven entirely off `_BANNED_INTROSPECTION_ATTRS`; no hardcoded payloads.

## Changes (`ast_phase_runner_validator.py`)
- **`_collect_banned_const_names(tree)`**: collects a name ONLY when assigned a plain `ast.Constant` string whose value is a banned reflection attr name, + plain `b=a` alias propagation (6-iteration fixpoint, mirrors `_collect_tainted_names`). Assembled strings / non-string constants / benign strings NEVER collected.
- **`_check_taint_flow` check (c)** [additive]: a Call to a bare-Name in `_ATTR_KEY_SINKS` {`getattr`,`setattr`,`delattr`} whose **`args[1]` (key position only)** is a banned-const (literal or propagated var) → `TAINT_EXPLOIT`, whether or not immediately called. Existing (a)/(b) untouched.

## Honest rule-ordering
Rule 7 (`INTROSPECTION_ESCAPE`) runs first and already catches inline-literal + single-binding `getattr`. 95h's **genuine new coverage** is `setattr`/`delattr`-with-banned-const + **alias-propagated** `getattr` (`a="__class__"; b=a; getattr(self,b)`). Tests split accordingly — did NOT weaken the pre-existing cage to claim credit.

## Tests
47 + 276 adjacent regression green. Reviewer's **19 own FP probes all clean** — including the value-position trap `setattr(obj,"_safe","__class__")` (arg2 value, NOT key → correctly not flagged), benign-param `getattr(obj, name)`, benign dunders `__doc__`/`__name__`/`__module__`. `args[1]`-only scoping confirmed.

## Completes the hardening trilogy
95f synonym-constructs + 95g indirection/aliasing + 95h constant-propagation — **all 3 static-fixable evasion classes from the v2/v3 taxonomy closed with zero clean-control FP.** The remaining residual (eval/deserialize of runtime-constructed values) is the §43 Arc 5 OS-containment boundary, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the AST validator to stop constant-in-variable evasion. Calls to `getattr`/`setattr`/`delattr` now fail when the attr key is a banned reflection name, even if passed via a plain string variable.

- **New Features**
  - Added `_collect_banned_const_names` to track names bound to plain string constants in `_BANNED_INTROSPECTION_ATTRS`, with simple `b = a` alias propagation.
  - Extended Rule 11 to flag `getattr`/`setattr`/`delattr` when `args[1]` (key) is a banned constant or a variable proven to hold one; returns `TAINT_EXPLOIT`.
  - Key-position only; value-position remains allowed. Benign dunders (e.g., `__doc__`, `__name__`) are not flagged.
  - No new reasons or flags; controlled by `JARVIS_AST_VALIDATOR_BLOCK_TAINT_EXPLOIT` (default true). Preserves Rule 7 precedence; adds coverage for alias-propagated `getattr` and `setattr`/`delattr`.

<sup>Written for commit 5781b820994fb467fe20e147468674686d1ced66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

