### PR TITLE
feat(governance): §40 #14 closure — CLAUDE.md spec-drift validator (mirror-self tests itself against its docs)

### DIFF
--- a/backend/core/ouroboros/governance/invariant_drift_auditor.py
+++ b/backend/core/ouroboros/governance/invariant_drift_auditor.py
@@ -172,6 +172,14 @@ class DriftKind(str, enum.Enum):
     # compare_snapshots() primitive (which remains a pure binary
     # comparison between two snapshots).
     GRADIENT_DRIFT_DETECTED = "gradient_drift_detected"
+    # §40 #14 Mirror-Self spec-drift (added 2026-06-05): CLAUDE.md
+    # CLAIMS an env-flag default that the FlagRegistry ACTUALLY
+    # registers differently — the system testing itself against its
+    # own documentation. Emitted by ``mirror_self_spec_drift`` (a
+    # pure read-only validator), NOT by the compare_snapshots()
+    # primitive. Flows into the existing auto_action bridge so spec
+    # drift files an advisory repair op like any other drift kind.
+    SPEC_DRIFT = "spec_drift"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/mirror_self_spec_drift.py
+++ b/backend/core/ouroboros/governance/mirror_self_spec_drift.py
@@ -1,0 +1,850 @@
+"""
+Mirror-Self Spec-Drift Validator
+=================================
+
+Closes the spec-drift half of §40 #14 — the "Mirror-Self Test".
+The metacognition-calibration half (prediction × actual) already
+ships in :mod:`mirror_self_test`. The PRD §40 #14 binding also
+requires:
+
+  "the system reproduces its own canonical behavior from the
+   CLAUDE.md spec; if implementation drifts from spec, file
+   repair ops."
+
+This substrate is a **pure read-only validator** that compares
+what CLAUDE.md *CLAIMS* an env-flag default is against what the
+:class:`flag_registry.FlagRegistry` *ACTUALLY* registers. A
+mismatch is **spec drift** — the system testing itself against
+its own documentation. Detection only — it NEVER mutates
+CLAUDE.md or any flag; it files an *advisory* repair op through
+the existing invariant-drift pipeline.
+
+The machine-checkable claim surface
+-----------------------------------
+
+CLAUDE.md documents env-flag defaults in a handful of consistent,
+parseable phrasings:
+
+  * ``\`JARVIS_FOO_ENABLED\` default-TRUE``
+  * ``\`JARVIS_FOO_ENABLED\` default-FALSE``
+  * ``\`JARVIS_FOO_ENABLED\` (default \`true\`)``
+  * ``\`JARVIS_FOO_ENABLED\` default \`false\```
+
+:func:`_parse_claimed_flag_defaults` regex-extracts ONLY these
+unambiguous boolean claims. A flag claimed with *conflicting*
+defaults in different places is marked ambiguous and EXCLUDED
+(fail-open — never emit a false-positive drift on a doc the
+parser can't read unambiguously).
+
+Composition — no parallel machinery
+-----------------------------------
+
+* :class:`flag_registry.FlagRegistry` — the canonical
+  ``ensure_seeded()`` registry is the authority on ACTUAL
+  defaults. We never duplicate flag metadata.
+* :mod:`invariant_drift_auditor` — spec-drift records convert to
+  :class:`InvariantDriftRecord` (with the new ``DriftKind.SPEC_DRIFT``
+  member) so they flow through the **existing**
+  :class:`invariant_drift_auto_action_bridge.InvariantDriftAutoActionBridge`.
+  No new observer, no new auto-action bridge, no duplicated drift
+  machinery — :func:`to_invariant_drift_records` +
+  :func:`to_bridge_snapshot` are the only adapter surface.
+* :mod:`second_order_doll_metric` (#15) — composes
+  ``aggregate_doll_completion().completion_ratio`` as a *severity
+  gate*: spec drift is WARNING by default and only escalates to
+  CRITICAL once the organism has empirical governance-stability
+  evidence (completion ratio ≥ the gate ratio). This avoids
+  early-autonomy thrashing where every spec edit trips a CRITICAL.
+
+NEVER raises. Unreadable CLAUDE.md / missing registry / disabled
+master / doll metric unavailable all degrade to an empty or
+conservative report — never an exception.
+
+Closed 4-value :class:`SpecDriftVerdict`:
+
+  ALIGNED            claims parsed; zero drift records
+  DRIFTED            ≥1 claimed default ≠ registry actual default
+  INSUFFICIENT_DATA  no parseable boolean claims found
+  DISABLED           master flag off (§33.1)
+
+§33.1 cognitive substrate ``JARVIS_MIRROR_SELF_SPEC_DRIFT_ENABLED``
+default-**FALSE** — operator-paced opt-in. Sub-knob
+``JARVIS_MIRROR_SELF_SPEC_DRIFT_DOLL_GATE_RATIO`` (float, default
+0.75) is the completion-ratio escalation threshold.
+
+Authority asymmetry (AST-pinned): imports stdlib only at
+module-load. ``flag_registry`` / ``invariant_drift_auditor`` /
+``second_order_doll_metric`` are all lazy-imported behind composer
+helpers. Does NOT import orchestrator / iron_gate / policy /
+providers / candidate_generator / urgency_router / change_engine /
+semantic_guardian / auto_committer / risk_tier_floor.
+"""
+from __future__ import annotations
+
+import ast
+import enum
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+)
+
+MIRROR_SELF_SPEC_DRIFT_SCHEMA_VERSION: str = "mirror_self_spec_drift.1"
+
+
+# ===========================================================================
+# Env knobs
+# ===========================================================================
+
+
+_ENV_MASTER = "JARVIS_MIRROR_SELF_SPEC_DRIFT_ENABLED"
+_ENV_DOLL_GATE_RATIO = "JARVIS_MIRROR_SELF_SPEC_DRIFT_DOLL_GATE_RATIO"
+
+_DEFAULT_DOLL_GATE_RATIO = 0.75
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _flag(name: str, *, default: bool = False) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in _TRUTHY
+
+
+def master_enabled() -> bool:
+    """§33.1 cognitive substrate — default-FALSE.
+
+    Operator-paced opt-in. When off, :func:`detect_spec_drift`
+    returns a DISABLED report with zero records.
+    """
+    return _flag(_ENV_MASTER, default=False)
+
+
+def doll_gate_ratio() -> float:
+    """Completion-ratio threshold at/above which spec drift escalates
+    from WARNING to CRITICAL. Defaults to 0.75. Clamped to [0.0, 1.0].
+    NEVER raises."""
+    raw = os.environ.get(_ENV_DOLL_GATE_RATIO, "").strip()
+    if not raw:
+        return _DEFAULT_DOLL_GATE_RATIO
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_DOLL_GATE_RATIO
+    return max(0.0, min(1.0, val))
+
+
+# ===========================================================================
+# Closed taxonomy
+# ===========================================================================
+
+
+class SpecDriftVerdict(str, enum.Enum):
+    """Closed 4-value verdict — bytes-pinned via AST."""
+
+    ALIGNED = "aligned"
+    DRIFTED = "drifted"
+    INSUFFICIENT_DATA = "insufficient_data"
+    DISABLED = "disabled"
+
+
+# ===========================================================================
+# §33.5 frozen versioned artifacts
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class SpecDriftRecord:
+    """One CLAUDE.md claim that contradicts the registry's actual
+    default for the same flag."""
+
+    flag: str
+    claimed_default: bool
+    actual_default: bool
+    source_file: str
+    severity: Any  # invariant_drift_auditor.DriftSeverity (lazy enum)
+    schema_version: str = MIRROR_SELF_SPEC_DRIFT_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "flag": self.flag,
+            "claimed_default": bool(self.claimed_default),
+            "actual_default": bool(self.actual_default),
+            "source_file": self.source_file,
+            "severity": getattr(
+                self.severity, "value", str(self.severity),
+            ),
+            "schema_version": self.schema_version,
+        }
+
+
+@dataclass(frozen=True)
+class SpecDriftReport:
+    """Aggregate of one spec-vs-registry validation pass."""
+
+    evaluated_at_unix: float
+    master_enabled: bool
+    verdict: SpecDriftVerdict
+    records: Tuple[SpecDriftRecord, ...]
+    claims_evaluated: int
+    unregistered_count: int
+    completion_ratio: Optional[float]
+    diagnostic: str
+    schema_version: str = MIRROR_SELF_SPEC_DRIFT_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "evaluated_at_unix": self.evaluated_at_unix,
+            "master_enabled": self.master_enabled,
+            "verdict": self.verdict.value,
+            "records": [r.to_dict() for r in self.records],
+            "claims_evaluated": int(self.claims_evaluated),
+            "unregistered_count": int(self.unregistered_count),
+            "completion_ratio": self.completion_ratio,
+            "diagnostic": self.diagnostic[:512],
+            "schema_version": self.schema_version,
+        }
+
+
+# ===========================================================================
+# Parser — the machine-checkable claim surface
+# ===========================================================================
+
+
+# A flag token: JARVIS_ followed by uppercase/digit/underscore. We only
+# ever treat JARVIS_-prefixed identifiers as flags to avoid matching
+# prose. The flag may be backtick-wrapped in the doc.
+_FLAG_RE = r"JARVIS_[A-Z0-9_]+"
+
+# Form 1+2: ``FLAG`` default-TRUE / default-FALSE  (case-insensitive)
+_DASH_RE = re.compile(
+    r"`?(" + _FLAG_RE + r")`?\s+default-(true|false)\b",
+    re.IGNORECASE,
+)
+
+# Form 3+4: ``FLAG`` (default `true`)  /  ``FLAG`` default `false`
+# Allows an optional "(" and requires the value in backticks.
+_BACKTICK_RE = re.compile(
+    r"`?(" + _FLAG_RE + r")`?\s+\(?default\s+`(true|false)`",
+    re.IGNORECASE,
+)
+
+
+def _parse_claimed_flag_defaults(spec_text: Any) -> Mapping[str, bool]:
+    """Regex-extract ``(JARVIS_FLAG -> claimed_bool)`` from CLAUDE.md's
+    consistent default phrasings.
+
+    Only unambiguous boolean claims are returned. A flag claimed with
+    *conflicting* defaults anywhere in the text is dropped (fail-open).
+    Pure. NEVER raises.
+    """
+    try:
+        text = spec_text if isinstance(spec_text, str) else ""
+    except Exception:  # noqa: BLE001
+        return {}
+    if not text:
+        return {}
+
+    # flag -> set of claimed bools seen (so we can detect conflict)
+    seen: Dict[str, set] = {}
+    try:
+        for rx in (_DASH_RE, _BACKTICK_RE):
+            for m in rx.finditer(text):
+                flag = m.group(1)
+                claimed = m.group(2).strip().lower() == "true"
+                seen.setdefault(flag, set()).add(claimed)
+    except Exception:  # noqa: BLE001 — defensive
+        return {}
+
+    out: Dict[str, bool] = {}
+    for flag, vals in seen.items():
+        if len(vals) == 1:  # unambiguous
+            out[flag] = next(iter(vals))
+        # len > 1 → conflicting claims → ambiguous → exclude
+    return out
+
+
+# ===========================================================================
+# Composers — canonical surfaces (all lazy-imported)
+# ===========================================================================
+
+
+def _read_default_spec_text() -> str:
+    """Read the repo-root CLAUDE.md. Resolves the repo root
+    structurally (this module lives at
+    ``backend/core/ouroboros/governance/`` → repo root is
+    ``parents[4]``). Returns "" if unreadable. NEVER raises."""
+    try:
+        repo_root = Path(__file__).resolve().parents[4]
+        target = repo_root / "CLAUDE.md"
+        if not target.exists():
+            return ""
+        return target.read_text(encoding="utf-8", errors="replace")
+    except Exception:  # noqa: BLE001 — defensive
+        return ""
+
+
+def _resolve_registry(registry: Optional[Any]) -> Optional[Any]:
+    """Resolve the canonically-populated FlagRegistry when the caller
+    passes None. Composes ``flag_registry.ensure_seeded()`` — the same
+    surface the unified /help + observability surfaces use. NEVER
+    raises."""
+    if registry is not None:
+        return registry
+    try:
+        from backend.core.ouroboros.governance.flag_registry import (
+            ensure_seeded,
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+    try:
+        return ensure_seeded()
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+
+
+def _doll_completion_ratio() -> Optional[float]:
+    """Compose #15 ``second_order_doll_metric.aggregate_doll_completion``
+    to read the governance-stability completion ratio. Returns None when
+    the doll metric is disabled / unavailable (caller stays at the
+    conservative WARNING severity). Pure read. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.second_order_doll_metric import (  # noqa: E501
+            aggregate_doll_completion,
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+    try:
+        snap = aggregate_doll_completion()
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+    if snap is None or not getattr(snap, "master_enabled", False):
+        return None
+    try:
+        return float(getattr(snap, "completion_ratio", 0.0))
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+
+
+def _severity_for(completion_ratio: Optional[float]) -> Any:
+    """Doll-gated severity. WARNING by default, escalates to CRITICAL
+    only when the empirical completion ratio ≥ the gate ratio. Lazy
+    import of the canonical DriftSeverity. NEVER raises."""
+    from backend.core.ouroboros.governance.invariant_drift_auditor import (
+        DriftSeverity,
+    )
+    if completion_ratio is None:
+        return DriftSeverity.WARNING
+    try:
+        if completion_ratio >= doll_gate_ratio():
+            return DriftSeverity.CRITICAL
+    except Exception:  # noqa: BLE001 — defensive
+        return DriftSeverity.WARNING
+    return DriftSeverity.WARNING
+
+
+def _lookup_spec(registry: Any, flag: str) -> Optional[Any]:
+    """Best-effort FlagSpec lookup. NEVER raises."""
+    try:
+        getter = getattr(registry, "get_spec", None)
+        if getter is None:
+            return None
+        return getter(flag)
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+
+
+def _spec_is_bool(spec: Any) -> bool:
+    """True iff the FlagSpec's type is BOOL. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.flag_registry import (
+            FlagType,
+        )
+        return getattr(spec, "type", None) is FlagType.BOOL
+    except Exception:  # noqa: BLE001 — defensive
+        return False
+
+
+# ===========================================================================
+# Detection
+# ===========================================================================
+
+
+def detect_spec_drift(
+    spec_text: Optional[str] = None,
+    registry: Optional[Any] = None,
+    *,
+    now_unix: Optional[float] = None,
+) -> SpecDriftReport:
+    """Validate CLAUDE.md's claimed env-flag defaults against the
+    FlagRegistry's actual registered defaults.
+
+    A drift record is emitted ONLY when the flag IS registered AND its
+    type is BOOL AND ``actual_default != claimed_default``. Absent /
+    non-bool / ambiguous claims are SKIPPED (no false positive).
+
+    Detection only — never mutates CLAUDE.md or any flag. NEVER raises.
+    """
+    now = time.time() if now_unix is None else float(now_unix)
+
+    if not master_enabled():
+        return SpecDriftReport(
+            evaluated_at_unix=now,
+            master_enabled=False,
+            verdict=SpecDriftVerdict.DISABLED,
+            records=(),
+            claims_evaluated=0,
+            unregistered_count=0,
+            completion_ratio=None,
+            diagnostic=f"gate disabled via {_ENV_MASTER}=false",
+        )
+
+    text = spec_text if spec_text is not None else _read_default_spec_text()
+    claims = _parse_claimed_flag_defaults(text)
+    reg = _resolve_registry(registry)
+
+    if not claims:
+        return SpecDriftReport(
+            evaluated_at_unix=now,
+            master_enabled=True,
+            verdict=SpecDriftVerdict.INSUFFICIENT_DATA,
+            records=(),
+            claims_evaluated=0,
+            unregistered_count=0,
+            completion_ratio=None,
+            diagnostic="no parseable boolean flag-default claims found",
+        )
+
+    # Read the doll-metric completion ratio ONCE per pass for the
+    # severity gate (cheap, cached inside the doll metric).
+    completion_ratio = _doll_completion_ratio()
+    severity = _severity_for(completion_ratio)
+
+    records: List[SpecDriftRecord] = []
+    unregistered = 0
+    evaluated = 0
+
+    for flag, claimed_default in sorted(claims.items()):
+        if reg is None:
+            unregistered += 1
+            continue
+        spec = _lookup_spec(reg, flag)
+        if spec is None:
+            # Doc-only / unregistered flag — separate concern, NOT
+            # drift. Count it but emit no record (no FP).
+            unregistered += 1
+            continue
+        if not _spec_is_bool(spec):
+            # Non-bool flag claimed as a boolean default — skip.
+            continue
+        evaluated += 1
+        try:
+            actual_default = bool(getattr(spec, "default", None))
+        except Exception:  # noqa: BLE001 — defensive
+            continue
+        if actual_default != bool(claimed_default):
+            records.append(
+                SpecDriftRecord(
+                    flag=flag,
+                    claimed_default=bool(claimed_default),
+                    actual_default=actual_default,
+                    source_file=str(getattr(spec, "source_file", "")),
+                    severity=severity,
+                )
+            )
+
+    verdict = (
+        SpecDriftVerdict.DRIFTED if records
+        else SpecDriftVerdict.ALIGNED
+    )
+    diagnostic = (
+        f"{len(records)} drift(s) across {evaluated} bool claim(s); "
+        f"unregistered={unregistered}; "
+        f"completion_ratio={completion_ratio}; "
+        f"severity={getattr(severity, 'value', severity)} → "
+        f"{verdict.value}"
+    )
+
+    return SpecDriftReport(
+        evaluated_at_unix=now,
+        master_enabled=True,
+        verdict=verdict,
+        records=tuple(records),
+        claims_evaluated=evaluated,
+        unregistered_count=unregistered,
+        completion_ratio=completion_ratio,
+        diagnostic=diagnostic,
+    )
+
+
+# ===========================================================================
+# Adapter — feed the EXISTING invariant-drift pipeline (no duplication)
+# ===========================================================================
+
+
+def to_invariant_drift_records(
+    report: Optional[SpecDriftReport],
+) -> Tuple[Any, ...]:
+    """Convert spec-drift records into canonical
+    :class:`invariant_drift_auditor.InvariantDriftRecord` instances —
+    tagged ``DriftKind.SPEC_DRIFT`` — so they flow through the EXISTING
+    :class:`invariant_drift_auto_action_bridge` (severity → advisory
+    action) with zero parallel machinery. NEVER raises."""
+    if report is None:
+        return ()
+    try:
+        from backend.core.ouroboros.governance.invariant_drift_auditor import (  # noqa: E501
+            DriftKind,
+            InvariantDriftRecord,
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        return ()
+    out: List[Any] = []
+    try:
+        for rec in report.records:
+            out.append(
+                InvariantDriftRecord(
+                    drift_kind=DriftKind.SPEC_DRIFT,
+                    severity=rec.severity,
+                    detail=(
+                        f"CLAUDE.md claims {rec.flag} default="
+                        f"{rec.claimed_default} but FlagRegistry "
+                        f"registers default={rec.actual_default} "
+                        f"(source={rec.source_file})"
+                    ),
+                    affected_keys=(rec.flag,),
+                )
+            )
+    except Exception:  # noqa: BLE001 — defensive
+        return tuple(out)
+    return tuple(out)
+
+
+def to_bridge_snapshot(report: Optional[SpecDriftReport]) -> Any:
+    """Build a minimal :class:`InvariantSnapshot` carrier so a DRIFTED
+    report can flow straight into the existing bridge's ``emit(snapshot,
+    records)`` signature. The bridge reads only ``snapshot_id`` +
+    ``posture_value`` from it, so we populate a stable, empty-but-valid
+    snapshot. NEVER raises — returns a best-effort object even on
+    garbage input."""
+    try:
+        from backend.core.ouroboros.governance.invariant_drift_auditor import (  # noqa: E501
+            InvariantSnapshot,
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+    try:
+        ts = (
+            float(getattr(report, "evaluated_at_unix", 0.0))
+            if report is not None else 0.0
+        )
+        sid = "spec-drift"
+        if report is not None:
+            sid = f"spec-drift-{int(ts)}"
+        return InvariantSnapshot(
+            snapshot_id=sid,
+            captured_at_utc=ts,
+            shipped_invariant_names=(),
+            shipped_violation_signature="",
+            shipped_violation_count=0,
+            flag_registry_hash="",
+            flag_count=0,
+            exploration_floor_pins=(),
+            posture_value=None,
+            posture_confidence=None,
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+
+
+# ===========================================================================
+# Renderer
+# ===========================================================================
+
+
+def format_spec_drift_panel(
+    report: Optional[SpecDriftReport] = None,
+) -> str:
+    """Operator-facing spec-drift summary. NEVER raises."""
+    if report is None:
+        if not master_enabled():
+            return f"spec-drift: disabled ({_ENV_MASTER}=false)"
+        return "spec-drift: no report"
+    if report.verdict is SpecDriftVerdict.DISABLED:
+        return f"spec-drift: disabled ({_ENV_MASTER}=false)"
+    lines = [
+        f"🪞 Mirror-Self Spec-Drift — {report.verdict.value}",
+        f"  claims={report.claims_evaluated} "
+        f"drift={len(report.records)} "
+        f"unregistered={report.unregistered_count} "
+        f"completion_ratio={report.completion_ratio}",
+    ]
+    for r in report.records:
+        sev = getattr(r.severity, "value", str(r.severity))
+        lines.append(
+            f"  [{sev}] {r.flag}: CLAUDE.md={r.claimed_default} "
+            f"registry={r.actual_default} ({r.source_file})"
+        )
+    return "\n".join(lines)
+
+
+# ===========================================================================
+# AST pins
+# ===========================================================================
+
+
+def register_shipped_invariants() -> list:
+    try:
+        from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+            ShippedCodeInvariant,
+        )
+    except ImportError:
+        return []
+
+    target = (
+        "backend/core/ouroboros/governance/mirror_self_spec_drift.py"
+    )
+
+    _EXPECTED_VERDICTS = {
+        "aligned", "drifted", "insufficient_data", "disabled",
+    }
+
+    def _validate_verdict_taxonomy(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ClassDef)
+                and node.name == "SpecDriftVerdict"
+            ):
+                found = set()
+                for sub in node.body:
+                    if (
+                        isinstance(sub, ast.Assign)
+                        and len(sub.targets) == 1
+                        and isinstance(sub.targets[0], ast.Name)
+                        and isinstance(sub.value, ast.Constant)
+                        and isinstance(sub.value.value, str)
+                    ):
+                        found.add(sub.value.value)
+                missing = _EXPECTED_VERDICTS - found
+                extra = found - _EXPECTED_VERDICTS
+                if missing:
+                    return (
+                        f"SpecDriftVerdict missing: {sorted(missing)}",
+                    )
+                if extra:
+                    return (
+                        f"SpecDriftVerdict drift: {sorted(extra)}",
+                    )
+                return ()
+        return ("SpecDriftVerdict class not found",)
+
+    def _validate_authority_asymmetry(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        forbidden = (
+            "backend.core.ouroboros.governance.orchestrator",
+            "backend.core.ouroboros.governance.iron_gate",
+            "backend.core.ouroboros.governance.policy",
+            "backend.core.ouroboros.governance.providers",
+            "backend.core.ouroboros.governance.candidate_generator",
+            "backend.core.ouroboros.governance.urgency_router",
+            "backend.core.ouroboros.governance.change_engine",
+            "backend.core.ouroboros.governance.semantic_guardian",
+            "backend.core.ouroboros.governance.auto_committer",
+            "backend.core.ouroboros.governance.risk_tier_floor",
+        )
+        violations: List[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                if any(mod == f for f in forbidden):
+                    violations.append(
+                        f"forbidden authority import: {mod}",
+                    )
+        return tuple(violations)
+
+    def _validate_master_default_false(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.FunctionDef)
+                and node.name == "master_enabled"
+            ):
+                for sub in ast.walk(node):
+                    if (
+                        isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Name)
+                        and sub.func.id == "_flag"
+                    ):
+                        for kw in sub.keywords:
+                            if (
+                                kw.arg == "default"
+                                and isinstance(kw.value, ast.Constant)
+                                and kw.value.value is False
+                            ):
+                                return ()
+                return (
+                    "master_enabled() must call _flag(...) with "
+                    "default=False per §33.1",
+                )
+        return ("master_enabled() not found",)
+
+    def _validate_composes_canonical(
+        tree: ast.AST, source: str,
+    ) -> tuple:
+        violations: List[str] = []
+        if "flag_registry" not in source:
+            violations.append(
+                "must compose canonical flag_registry (FlagRegistry "
+                "is the authority on actual flag defaults)",
+            )
+        if "invariant_drift_auditor" not in source:
+            violations.append(
+                "must compose invariant_drift_auditor (spec-drift "
+                "records flow through the EXISTING drift pipeline "
+                "— no parallel observer/bridge)",
+            )
+        if "second_order_doll_metric" not in source:
+            violations.append(
+                "must compose #15 second_order_doll_metric "
+                "(completion_ratio severity gate)",
+            )
+        return tuple(violations)
+
+    return [
+        ShippedCodeInvariant(
+            invariant_name="spec_drift_verdict_taxonomy_closed",
+            target_file=target,
+            description=(
+                "SpecDriftVerdict 4-value taxonomy bytes-pinned "
+                "(ALIGNED / DRIFTED / INSUFFICIENT_DATA / DISABLED)."
+            ),
+            validate=_validate_verdict_taxonomy,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="spec_drift_authority_asymmetry",
+            target_file=target,
+            description=(
+                "Read-only validator — MUST NOT import orchestrator "
+                "/ iron_gate / policy / providers / "
+                "candidate_generator / urgency_router / "
+                "change_engine / semantic_guardian / auto_committer "
+                "/ risk_tier_floor. Detection + advisory only."
+            ),
+            validate=_validate_authority_asymmetry,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="spec_drift_master_default_false",
+            target_file=target,
+            description=(
+                "§33.1 cognitive substrate default-FALSE."
+            ),
+            validate=_validate_master_default_false,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="spec_drift_composes_canonical",
+            target_file=target,
+            description=(
+                "Composes canonical flag_registry (actual defaults) "
+                "+ invariant_drift_auditor (existing drift pipeline) "
+                "+ #15 second_order_doll_metric (severity gate) — "
+                "no parallel implementations."
+            ),
+            validate=_validate_composes_canonical,
+        ),
+    ]
+
+
+# ===========================================================================
+# FlagRegistry seeds
+# ===========================================================================
+
+
+def register_flags(registry: Any) -> int:
+    from backend.core.ouroboros.governance.flag_registry import (
+        Category,
+        FlagSpec,
+        FlagType,
+    )
+
+    src = (
+        "backend/core/ouroboros/governance/mirror_self_spec_drift.py"
+    )
+
+    seeds = [
+        FlagSpec(
+            name=_ENV_MASTER,
+            type=FlagType.BOOL,
+            default=False,
+            description=(
+                "Mirror-Self spec-drift validator master switch. "
+                "§33.1 cognitive substrate default-FALSE. When on, "
+                "detect_spec_drift compares CLAUDE.md's claimed "
+                "env-flag defaults (parseable default-TRUE / "
+                "default-FALSE / (default `true`) phrasings) against "
+                "the FlagRegistry's ACTUAL registered defaults; a "
+                "mismatch is spec drift that flows through the "
+                "existing invariant_drift auto-action bridge as an "
+                "advisory repair op. Detection only — never mutates "
+                "CLAUDE.md or any flag. Closes the spec-drift half "
+                "of §40 #14."
+            ),
+            category=Category.SAFETY,
+            source_file=src,
+            example=f"{_ENV_MASTER}=true",
+        ),
+        FlagSpec(
+            name=_ENV_DOLL_GATE_RATIO,
+            type=FlagType.FLOAT,
+            default=_DEFAULT_DOLL_GATE_RATIO,
+            description=(
+                "#15 doll-metric completion-ratio threshold at/above "
+                "which spec drift escalates from WARNING to CRITICAL. "
+                "Below it (or when the doll metric is disabled/"
+                "unavailable) spec drift stays WARNING — avoids "
+                "early-autonomy thrashing before the organism has "
+                "empirical governance-stability evidence. Defaults "
+                "to 0.75. Clamped to [0.0, 1.0]."
+            ),
+            category=Category.TUNING,
+            source_file=src,
+            example=f"{_ENV_DOLL_GATE_RATIO}=0.9",
+        ),
+    ]
+
+    count = 0
+    for spec in seeds:
+        try:
+            registry.register(spec)
+            count += 1
+        except Exception:  # noqa: BLE001
+            continue
+    return count
+
+
+__all__ = [
+    "MIRROR_SELF_SPEC_DRIFT_SCHEMA_VERSION",
+    "SpecDriftVerdict",
+    "SpecDriftRecord",
+    "SpecDriftReport",
+    "master_enabled",
+    "doll_gate_ratio",
+    "detect_spec_drift",
+    "to_invariant_drift_records",
+    "to_bridge_snapshot",
+    "format_spec_drift_panel",
+    "register_shipped_invariants",
+    "register_flags",
+]

--- a/tests/governance/test_invariant_drift_auditor.py
+++ b/tests/governance/test_invariant_drift_auditor.py
@@ -846,6 +846,9 @@ class TestAuthorityInvariants:
             # auto_action_router edge-case race-condition fix
             # (a0782f7d5f); pre-existing addition CIGW will surface
             # via Slice 4 advisory bridge.
+            "spec_drift",  # added 2026-06-05 by §40 #14 Mirror-Self
+            # spec-drift validator (mirror_self_spec_drift) —
+            # CLAUDE.md claimed flag-default ≠ FlagRegistry actual.
         }
         assert {k.value for k in DriftKind} == expected
 

--- a/tests/governance/test_mirror_self_spec_drift.py
+++ b/tests/governance/test_mirror_self_spec_drift.py
@@ -1,0 +1,512 @@
+"""§40 #14 Mirror-Self spec-drift validator — regression spine.
+
+Coverage tracks the validator's contracts:
+
+  * Parse contract — ``_parse_claimed_flag_defaults`` extracts ONLY
+    unambiguous boolean default claims from CLAUDE.md's consistent
+    phrasings (``default-TRUE`` / ``default-FALSE`` /
+    ``(default `true`)`` / ``default `false```); conflicting claims
+    for the same flag → ambiguous → excluded (fail-open).
+  * Detect contract — ``detect_spec_drift`` emits a SpecDriftRecord
+    ONLY when the flag IS registered AND its type is BOOL AND the
+    registered default ≠ the claimed default. Absent / non-bool /
+    ambiguous → SKIP (no false positive).
+  * Severity contract — doll-metric-gated escalation: WARNING by
+    default, CRITICAL only when completion_ratio ≥ gate ratio.
+  * Composition contract — DRIFTED report → InvariantDriftRecords
+    consumable by the existing invariant_drift_auto_action_bridge
+    (no parallel bridge); §33.1 master default-FALSE;
+    authority-asymmetry + AST pins.
+  * Live contract — run against the REAL CLAUDE.md + populated
+    registry and surface any genuine drift.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    mirror_self_spec_drift as msd,
+)
+from backend.core.ouroboros.governance.flag_registry import (
+    Category,
+    FlagRegistry,
+    FlagSpec,
+    FlagType,
+)
+from backend.core.ouroboros.governance.invariant_drift_auditor import (
+    DriftKind,
+    DriftSeverity,
+    InvariantDriftRecord,
+)
+
+
+_MASTER = "JARVIS_MIRROR_SELF_SPEC_DRIFT_ENABLED"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _bool_spec(name: str, default: bool) -> FlagSpec:
+    return FlagSpec(
+        name=name,
+        type=FlagType.BOOL,
+        default=default,
+        description="synthetic",
+        category=Category.SAFETY,
+        source_file="synthetic/test.py",
+    )
+
+
+def _int_spec(name: str, default: int = 5) -> FlagSpec:
+    return FlagSpec(
+        name=name,
+        type=FlagType.INT,
+        default=default,
+        description="synthetic int",
+        category=Category.TUNING,
+        source_file="synthetic/test.py",
+    )
+
+
+@pytest.fixture()
+def master_on():
+    with patch.dict("os.environ", {_MASTER: "true"}, clear=False):
+        yield
+
+
+@pytest.fixture()
+def master_off():
+    with patch.dict("os.environ", {_MASTER: "false"}, clear=False):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# 1. _parse_claimed_flag_defaults
+# ---------------------------------------------------------------------------
+
+
+class TestParse:
+    def test_default_true_dash_form(self):
+        claims = msd._parse_claimed_flag_defaults(
+            "Master `JARVIS_TOOL_RENDER_REGISTRY_ENABLED` default-TRUE."
+        )
+        assert claims.get("JARVIS_TOOL_RENDER_REGISTRY_ENABLED") is True
+
+    def test_default_false_dash_form(self):
+        claims = msd._parse_claimed_flag_defaults(
+            "`JARVIS_FOO_ENABLED` default-FALSE per §33.1."
+        )
+        assert claims.get("JARVIS_FOO_ENABLED") is False
+
+    def test_default_paren_true_form(self):
+        claims = msd._parse_claimed_flag_defaults(
+            "`JARVIS_MULTI_FILE_GEN_ENABLED` (default `true`)"
+        )
+        assert claims.get("JARVIS_MULTI_FILE_GEN_ENABLED") is True
+
+    def test_default_backtick_false_form(self):
+        claims = msd._parse_claimed_flag_defaults(
+            "`JARVIS_BAR_ENABLED` default `false` — opt-in."
+        )
+        assert claims.get("JARVIS_BAR_ENABLED") is False
+
+    def test_default_backtick_true_form(self):
+        claims = msd._parse_claimed_flag_defaults(
+            "`JARVIS_DIRECTION_INFERRER_ENABLED` default `true`"
+        )
+        assert claims.get("JARVIS_DIRECTION_INFERRER_ENABLED") is True
+
+    def test_case_insensitive_dash(self):
+        claims = msd._parse_claimed_flag_defaults(
+            "`JARVIS_X_ENABLED` default-true and "
+            "`JARVIS_Y_ENABLED` Default-False"
+        )
+        assert claims.get("JARVIS_X_ENABLED") is True
+        assert claims.get("JARVIS_Y_ENABLED") is False
+
+    def test_ambiguous_conflicting_claims_excluded(self):
+        # Same flag claimed BOTH true AND false → fail-open exclude.
+        claims = msd._parse_claimed_flag_defaults(
+            "`JARVIS_AMBIG_ENABLED` default-TRUE ... later "
+            "`JARVIS_AMBIG_ENABLED` (default `false`)"
+        )
+        assert "JARVIS_AMBIG_ENABLED" not in claims
+
+    def test_consistent_repeated_claims_kept(self):
+        # Same flag, same value twice → still unambiguous, kept.
+        claims = msd._parse_claimed_flag_defaults(
+            "`JARVIS_REPEAT_ENABLED` default-TRUE ... "
+            "`JARVIS_REPEAT_ENABLED` default `true`"
+        )
+        assert claims.get("JARVIS_REPEAT_ENABLED") is True
+
+    def test_non_flag_text_ignored(self):
+        claims = msd._parse_claimed_flag_defaults(
+            "The system is enabled by default and true to its nature."
+        )
+        assert claims == {}
+
+    def test_non_jarvis_prefixed_name_ignored(self):
+        claims = msd._parse_claimed_flag_defaults(
+            "`SOME_OTHER_ENABLED` default-TRUE"
+        )
+        assert claims == {}
+
+    def test_empty_and_garbage_never_raise(self):
+        assert msd._parse_claimed_flag_defaults("") == {}
+        assert msd._parse_claimed_flag_defaults(None) == {}  # type: ignore[arg-type]
+        assert msd._parse_claimed_flag_defaults(12345) == {}  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 2. detect_spec_drift
+# ---------------------------------------------------------------------------
+
+
+class TestDetect:
+    def test_aligned_true_true(self, master_on):
+        reg = FlagRegistry()
+        reg.register(_bool_spec("JARVIS_A_ENABLED", True))
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_A_ENABLED` default-TRUE",
+            registry=reg,
+        )
+        assert report.verdict is msd.SpecDriftVerdict.ALIGNED
+        assert report.records == ()
+
+    def test_drifted_true_claim_false_actual(self, master_on):
+        reg = FlagRegistry()
+        reg.register(_bool_spec("JARVIS_A_ENABLED", False))
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_A_ENABLED` default-TRUE",
+            registry=reg,
+        )
+        assert report.verdict is msd.SpecDriftVerdict.DRIFTED
+        assert len(report.records) == 1
+        rec = report.records[0]
+        assert rec.flag == "JARVIS_A_ENABLED"
+        assert rec.claimed_default is True
+        assert rec.actual_default is False
+        assert rec.source_file == "synthetic/test.py"
+
+    def test_drifted_false_claim_true_actual(self, master_on):
+        reg = FlagRegistry()
+        reg.register(_bool_spec("JARVIS_B_ENABLED", True))
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_B_ENABLED` default `false`",
+            registry=reg,
+        )
+        assert report.verdict is msd.SpecDriftVerdict.DRIFTED
+        assert report.records[0].claimed_default is False
+        assert report.records[0].actual_default is True
+
+    def test_flag_not_in_registry_no_drift(self, master_on):
+        reg = FlagRegistry()  # empty
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_MISSING_ENABLED` default-TRUE",
+            registry=reg,
+        )
+        # No FP — absent flag is a separate concern, not drift.
+        assert report.records == ()
+        assert report.verdict is msd.SpecDriftVerdict.ALIGNED
+        # ... but it may be counted as unregistered.
+        assert report.unregistered_count >= 1
+
+    def test_non_bool_flag_skipped(self, master_on):
+        reg = FlagRegistry()
+        reg.register(_int_spec("JARVIS_C_ENABLED", 5))
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_C_ENABLED` default-TRUE",
+            registry=reg,
+        )
+        # Non-bool → skipped, no record, no FP.
+        assert report.records == ()
+        assert report.verdict is msd.SpecDriftVerdict.ALIGNED
+
+    def test_ambiguous_claim_skipped(self, master_on):
+        reg = FlagRegistry()
+        reg.register(_bool_spec("JARVIS_AMBIG_ENABLED", True))
+        report = msd.detect_spec_drift(
+            spec_text=(
+                "`JARVIS_AMBIG_ENABLED` default-TRUE ... "
+                "`JARVIS_AMBIG_ENABLED` (default `false`)"
+            ),
+            registry=reg,
+        )
+        # Ambiguous claim excluded by parser → no drift evaluation.
+        assert report.records == ()
+
+    def test_insufficient_data_when_no_claims(self, master_on):
+        reg = FlagRegistry()
+        reg.register(_bool_spec("JARVIS_A_ENABLED", True))
+        report = msd.detect_spec_drift(
+            spec_text="no parseable flag claims here at all",
+            registry=reg,
+        )
+        assert report.verdict is msd.SpecDriftVerdict.INSUFFICIENT_DATA
+        assert report.records == ()
+
+    def test_master_off_disabled_report(self, master_off):
+        reg = FlagRegistry()
+        reg.register(_bool_spec("JARVIS_A_ENABLED", False))
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_A_ENABLED` default-TRUE",
+            registry=reg,
+        )
+        assert report.verdict is msd.SpecDriftVerdict.DISABLED
+        assert report.records == ()
+
+    def test_unreadable_spec_path_never_raises(self, master_on):
+        # spec_text None + a registry; if CLAUDE.md unreadable the
+        # module falls back to empty — but we force the read to fail.
+        with patch.object(msd, "_read_default_spec_text", return_value=""):
+            report = msd.detect_spec_drift(registry=FlagRegistry())
+        assert report.verdict in (
+            msd.SpecDriftVerdict.INSUFFICIENT_DATA,
+            msd.SpecDriftVerdict.ALIGNED,
+        )
+        assert report.records == ()
+
+    def test_missing_registry_does_not_raise(self, master_on):
+        # registry=None resolves the populated one; must not raise.
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_A_ENABLED` default-TRUE",
+            registry=None,
+        )
+        assert isinstance(report, msd.SpecDriftReport)
+
+
+# ---------------------------------------------------------------------------
+# 3. Doll-metric severity gate (#15)
+# ---------------------------------------------------------------------------
+
+
+class TestDollSeverityGate:
+    def _drifted_report(self, master_on_env):
+        reg = FlagRegistry()
+        reg.register(_bool_spec("JARVIS_A_ENABLED", False))
+        return msd.detect_spec_drift(
+            spec_text="`JARVIS_A_ENABLED` default-TRUE",
+            registry=reg,
+        )
+
+    def test_below_threshold_warning(self, master_on):
+        # completion_ratio below gate → stays WARNING (conservative).
+        with patch.object(
+            msd, "_doll_completion_ratio", return_value=0.10,
+        ):
+            report = self._drifted_report(master_on)
+        assert report.records[0].severity is DriftSeverity.WARNING
+
+    def test_at_or_above_threshold_critical(self, master_on):
+        with patch.object(
+            msd, "_doll_completion_ratio", return_value=0.99,
+        ):
+            report = self._drifted_report(master_on)
+        assert report.records[0].severity is DriftSeverity.CRITICAL
+
+    def test_doll_unavailable_stays_warning(self, master_on):
+        # None ratio (disabled / unavailable) → conservative WARNING.
+        with patch.object(
+            msd, "_doll_completion_ratio", return_value=None,
+        ):
+            report = self._drifted_report(master_on)
+        assert report.records[0].severity is DriftSeverity.WARNING
+
+
+# ---------------------------------------------------------------------------
+# 4. Converter feeds the existing bridge
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeConverter:
+    def test_converter_yields_invariant_drift_records(self, master_on):
+        reg = FlagRegistry()
+        reg.register(_bool_spec("JARVIS_A_ENABLED", False))
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_A_ENABLED` default-TRUE",
+            registry=reg,
+        )
+        records = msd.to_invariant_drift_records(report)
+        assert len(records) == 1
+        rec = records[0]
+        assert isinstance(rec, InvariantDriftRecord)
+        assert rec.drift_kind is DriftKind.SPEC_DRIFT
+        assert rec.severity is report.records[0].severity
+        assert "JARVIS_A_ENABLED" in rec.affected_keys
+
+    def test_aligned_report_yields_no_records(self, master_on):
+        reg = FlagRegistry()
+        reg.register(_bool_spec("JARVIS_A_ENABLED", True))
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_A_ENABLED` default-TRUE",
+            registry=reg,
+        )
+        assert msd.to_invariant_drift_records(report) == ()
+
+    def test_records_accepted_by_existing_bridge(self, master_on):
+        from backend.core.ouroboros.governance.auto_action_router import (
+            AdvisoryActionType,
+            AutoActionProposalLedger,
+        )
+        from backend.core.ouroboros.governance import (
+            invariant_drift_auto_action_bridge as bridge_mod,
+        )
+
+        reg = FlagRegistry()
+        reg.register(_bool_spec("JARVIS_A_ENABLED", False))
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_A_ENABLED` default-TRUE",
+            registry=reg,
+        )
+        records = msd.to_invariant_drift_records(report)
+
+        # The bridge's pure drift→action mapping must accept our
+        # records (it reads only .severity / .drift_kind).
+        action_type = bridge_mod.drift_to_action_type(records)
+        assert action_type is not AdvisoryActionType.NO_ACTION
+
+        # And the full emit() path must accept them without error,
+        # filing an advisory action into an in-memory ledger.
+        ledger = AutoActionProposalLedger()
+        bridge = bridge_mod.InvariantDriftAutoActionBridge(ledger=ledger)
+        snapshot = msd.to_bridge_snapshot(report)
+        with patch.object(bridge_mod, "bridge_enabled", return_value=True):
+            bridge.emit(snapshot, records)
+        stats = bridge.stats()
+        assert stats["emit_count_total"] == 1
+        assert stats["emit_count_appended"] >= 1
+        assert stats["emit_count_failed_construction"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. never-raises
+# ---------------------------------------------------------------------------
+
+
+class TestNeverRaises:
+    def test_detect_with_broken_registry_never_raises(self, master_on):
+        class Broken:
+            def get_spec(self, name):
+                raise RuntimeError("boom")
+
+        report = msd.detect_spec_drift(
+            spec_text="`JARVIS_A_ENABLED` default-TRUE",
+            registry=Broken(),
+        )
+        assert isinstance(report, msd.SpecDriftReport)
+        assert report.records == ()
+
+    def test_converter_on_garbage_never_raises(self):
+        assert msd.to_invariant_drift_records(None) == ()  # type: ignore[arg-type]
+
+    def test_bridge_snapshot_on_garbage_never_raises(self):
+        snap = msd.to_bridge_snapshot(None)  # type: ignore[arg-type]
+        assert snap is not None
+
+
+# ---------------------------------------------------------------------------
+# 6. AST pins
+# ---------------------------------------------------------------------------
+
+
+class TestShippedInvariants:
+    def _pins(self):
+        return msd.register_shipped_invariants()
+
+    def _run(self, name, source):
+        tree = ast.parse(source)
+        for inv in self._pins():
+            if inv.invariant_name == name:
+                return inv.validate(tree, source)
+        raise AssertionError(f"invariant {name} not registered")
+
+    def test_canonical_source_all_pass(self):
+        src = Path(
+            "backend/core/ouroboros/governance/mirror_self_spec_drift.py"
+        ).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        for inv in self._pins():
+            assert inv.validate(tree, src) == (), inv.invariant_name
+
+    def test_verdict_taxonomy_regression(self):
+        bad = (
+            "import enum\n"
+            "class SpecDriftVerdict(str, enum.Enum):\n"
+            "    ALIGNED = 'aligned'\n"
+            "    DRIFTED = 'drifted'\n"
+            "    EXTRA = 'extra'\n"
+        )
+        assert self._run("spec_drift_verdict_taxonomy_closed", bad)
+
+    def test_authority_asymmetry_regression(self):
+        bad = (
+            "from backend.core.ouroboros.governance.orchestrator "
+            "import Orchestrator\n"
+        )
+        assert self._run("spec_drift_authority_asymmetry", bad)
+
+    def test_master_default_false_regression(self):
+        bad = (
+            "def master_enabled():\n"
+            "    return _flag('X', default=True)\n"
+        )
+        assert self._run("spec_drift_master_default_false", bad)
+
+    def test_composes_canonical_regression(self):
+        bad = "x = 1  # references nothing canonical\n"
+        assert self._run("spec_drift_composes_canonical", bad)
+
+
+# ---------------------------------------------------------------------------
+# 7. FlagRegistry seed
+# ---------------------------------------------------------------------------
+
+
+class TestFlagSeed:
+    def test_register_flags_count(self):
+        reg = FlagRegistry()
+        count = msd.register_flags(reg)
+        assert count >= 1
+        spec = reg.get_spec(_MASTER)
+        assert spec is not None
+        assert spec.type is FlagType.BOOL
+        assert spec.default is False
+
+
+# ---------------------------------------------------------------------------
+# 8. LIVE — real CLAUDE.md × real populated registry
+# ---------------------------------------------------------------------------
+
+
+class TestLive:
+    def test_against_real_claude_md_and_registry(self, master_on):
+        from backend.core.ouroboros.governance.flag_registry import (
+            ensure_seeded,
+        )
+
+        registry = ensure_seeded()
+        report = msd.detect_spec_drift(registry=registry)
+        # Must not raise; verdict is a valid enum member.
+        assert isinstance(report.verdict, msd.SpecDriftVerdict)
+        # Surface what it found for the operator-facing report.
+        print(
+            f"\n[LIVE spec-drift] verdict={report.verdict.value} "
+            f"claims={report.claims_evaluated} "
+            f"drift_records={len(report.records)} "
+            f"unregistered={report.unregistered_count}"
+        )
+        for rec in report.records:
+            print(
+                f"  DRIFT {rec.flag}: CLAUDE.md claims "
+                f"{rec.claimed_default} but registry has "
+                f"{rec.actual_default} (source={rec.source_file}, "
+                f"severity={rec.severity.value})"
+            )


### PR DESCRIPTION
Closes the **one genuine code gap** among the four "open" §40 items. **Verify-first found #2/#4/#6 were already built** (#2 hash-cap fully wired into AutoCommitter; #4 M10 graduation contract built + wired into `unified_graduation_dashboard.py`; #6 coherence rig built + AST-pinned) — saving ~3,000 LOC of duplication. The mirror-self ledger already shipped (prediction/actual calibration); this adds the missing **"reproduce canonical behavior from spec, drift → repair op"** half — the system testing itself against its own documentation.

## `mirror_self_spec_drift.py` (NEW) — pure, read-only, never-raises
- **Parser**: regex-extracts `(JARVIS_FLAG, claimed_bool)` from CLAUDE.md's two consistent default phrasings (`default-TRUE/FALSE`, `` (default `true/false`)``). Hard-anchored to `JARVIS_` tokens so prose can't mis-parse; conflicting claims → ambiguous → excluded (fail-open).
- **Detect**: looks up each claimed flag's ACTUAL default in the populated FlagRegistry; emits a `SpecDriftRecord` **only when** (registered AND `FlagType.BOOL` AND `actual != claimed`). Absent → unregistered (no drift); non-bool → skipped. Verdict: `ALIGNED/DRIFTED/INSUFFICIENT_DATA/DISABLED`.
- **Doll-metric (#15) gated severity**: WARNING by default, escalated to CRITICAL only at `completion_ratio ≥ 0.75` — avoids early-autonomy thrashing.
- **Composes the EXISTING invariant-drift pipeline** (no duplication): new `DriftKind.SPEC_DRIFT` + `to_invariant_drift_records()` so the existing `invariant_drift_auto_action_bridge` files advisory repair ops via its `drift_to_action_type` path. **Detection + advisory only — never mutates CLAUDE.md / flags / code.**
- §33.1 master `JARVIS_MIRROR_SELF_SPEC_DRIFT_ENABLED` default-FALSE; authority-asymmetry AST-pinned; 4 shipped-invariant pins + FlagRegistry seeds auto-discovered.

## Live result
Against the real CLAUDE.md + populated registry: **ALIGNED** — 13 boolean claims parsed, all match the registry, 0 drift, 2 doc-only flags correctly counted unregistered. No spec-vs-code drift today (the healthy result).

## Tests
37 new + 333 adjacent regression green. Independently reviewed: own parser FP-probes clean, live spot-checked vs source, bridge maps without crash, byte-identical no-mutation verified, `DriftKind` taxonomy-closed test updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mirror-self spec-drift validator that checks CLAUDE.md’s claimed `JARVIS_*` boolean defaults against the registered defaults and files advisory repair ops via the existing drift pipeline. Closes §40 #14 and keeps the system aligned with its own docs.

- **New Features**
  - Add `mirror_self_spec_drift.py`: parses CLAUDE.md for unambiguous `JARVIS_*` boolean default claims; compares to `FlagRegistry`; emits a record only when the flag is registered, type `BOOL`, and the defaults differ.
  - Integrate with existing drift pipeline: new `DriftKind.SPEC_DRIFT` in `invariant_drift_auditor`; converters to `InvariantDriftRecord` consumed by `invariant_drift_auto_action_bridge`. Pure detection; no mutations; never raises.
  - Severity gating via `second_order_doll_metric` completion ratio: WARNING by default, CRITICAL when ratio ≥ `JARVIS_MIRROR_SELF_SPEC_DRIFT_DOLL_GATE_RATIO` (default 0.75).
  - Operator controls and pins: `JARVIS_MIRROR_SELF_SPEC_DRIFT_ENABLED` (default false) + registry seeds and AST-pinned invariants to enforce authority asymmetry and taxonomy closure.
  - Live result today: aligned (13 claims parsed, 0 drift, 2 unregistered counted but not flagged).

<sup>Written for commit f7374c32e3c8a2fa1bbc35e4e593c924611a79d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

