### PR TITLE
feat(governance): Slice 96 — autonomous telemetry-driven graduation engine (tiered, fail-closed)

### DIFF
--- a/backend/core/ouroboros/governance/autonomous_graduation_engine.py
+++ b/backend/core/ouroboros/governance/autonomous_graduation_engine.py
@@ -1,0 +1,1009 @@
+"""Slice 96 — Autonomous Telemetry-Driven Graduation Engine (TIERED).
+
+Autonomously evaluates whether built-but-dormant §33.1 subsystems have
+EARNED graduation (master flag FALSE→TRUE) and, for NON-safety
+features, flips them — without ever bypassing the security cage.
+
+## TIERED autonomy (the §1 zero-order-doll invariant)
+
+Auto-activating a SAFETY / governance capability (a kill-switch or a
+gate) is itself a governance self-modification. So the engine routes
+SAFETY-tier graduations to an OPERATOR ADVISORY, not an auto-flip.
+NON-safety (STANDARD-tier) features auto-flip. The TIER is DATA-DRIVEN
+off the FlagRegistry category:
+
+    FlagSpec.category is Category.SAFETY  → SAFETY tier (advisory)
+    else                                  → STANDARD tier (auto-flip)
+
+with the governance_boundary_gate composed as a belt-and-suspenders
+corroboration signal (a source_file that boundary-crosses into the
+cage is also treated as SAFETY).
+
+## No source mutation — the delivery channel
+
+The engine NEVER edits ``flag_registry`` / ``*_seed.py`` source
+defaults — that would land inside ``governance/`` and trip the
+boundary gate + hash-cap. Instead, an AUTO_FLIP is delivered as an
+immutable receipt appended to the durable env-override ledger
+(:mod:`graduation_override_ledger`); a boot-time applier injects the
+authorized flags into ``os.environ`` (OS-level, external to the cage).
+
+## The mathematically-absolute decision matrix
+
+For each candidate (= a flag in the GraduationLedger's
+``eligible_flags()``), ALL gates must pass for READY; ANY failure
+holds with a precise ``delta`` naming the failing gate:
+
+  * Gate A (regression/telemetry): flag in ``eligible_flags()`` — the
+    entry condition (zero runner/regression failures, clean-session
+    cadence met). Composed, not reimplemented.
+  * Gate B (AST stability): ``shipped_code_invariants.validate_all()``
+    has ZERO ``InvariantViolation`` whose ``target_file`` matches the
+    flag's ``FlagSpec.source_file``. Any AST drift → HOLD AST_DRIFT.
+  * Gate C (contract, if any): if a graduation contract in the
+    unified dashboard maps to this flag, its verdict must be
+    READY-equivalent; if no contract maps, Gate C is vacuously
+    satisfied.
+
+If all gates pass → READY. Tier from category; disposition is
+STANDARD→AUTO_FLIP, SAFETY→APPROVAL_ADVISORY. Master OFF → DISABLED.
+
+## Authority posture (§33.1)
+
+* Master ``JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED`` default-FALSE.
+* Pure / never-raises everywhere.
+* Authority-asymmetry: stdlib-only at module load; lazy-imports the
+  composed substrates; FORBIDS orchestrator / iron_gate / policy /
+  providers / candidate_generator / urgency_router / change_engine /
+  semantic_guardian / auto_committer / risk_tier_floor.
+"""
+from __future__ import annotations
+
+import enum
+import hashlib
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+AUTONOMOUS_GRADUATION_ENGINE_SCHEMA_VERSION: str = "graduation_engine.1"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+# ---------------------------------------------------------------------------
+# Master flag
+# ---------------------------------------------------------------------------
+
+
+def autonomous_graduation_engine_enabled() -> bool:
+    """``JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED`` (default
+    FALSE)."""
+    raw = os.environ.get(
+        "JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED", "",
+    ).strip().lower()
+    return raw in _TRUTHY
+
+
+def advisory_ledger_path() -> str:
+    raw = os.environ.get("JARVIS_GRADUATION_ADVISORY_LEDGER_PATH")
+    if raw:
+        return raw
+    return ".jarvis/graduation_advisories.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Closed enums
+# ---------------------------------------------------------------------------
+
+
+class GraduationTier(str, enum.Enum):
+    """Closed 2-value taxonomy. The TIER decides autonomy:
+    STANDARD auto-flips; SAFETY routes to operator approval."""
+
+    STANDARD = "standard"
+    SAFETY = "safety"
+
+
+class GraduationDisposition(str, enum.Enum):
+    """Closed 4-value taxonomy — the engine's verdict per candidate."""
+
+    AUTO_FLIP = "auto_flip"
+    APPROVAL_ADVISORY = "approval_advisory"
+    HOLD = "hold"
+    DISABLED = "disabled"
+
+
+class HoldReason(str, enum.Enum):
+    """Closed taxonomy of why a candidate was held."""
+
+    NOT_ELIGIBLE = "not_eligible"
+    AST_DRIFT = "ast_drift"
+    CONTRACT_NOT_READY = "contract_not_ready"
+    MASTER_OFF = "master_off"
+    UNKNOWN_SPEC = "unknown_spec"
+    EVALUATION_ERROR = "evaluation_error"
+
+
+# ---------------------------------------------------------------------------
+# Frozen artifacts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GraduationDecision:
+    """One candidate's decision. Frozen — §33.5 versioned artifact."""
+
+    flag_name: str
+    tier: GraduationTier
+    disposition: GraduationDisposition
+    evidence: Dict[str, Any]
+    delta: str
+    evidence_sha256: str
+    schema_version: str = AUTONOMOUS_GRADUATION_ENGINE_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "flag_name": self.flag_name,
+            "tier": self.tier.value,
+            "disposition": self.disposition.value,
+            "evidence": self.evidence,
+            "delta": self.delta,
+            "evidence_sha256": self.evidence_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class GraduationEngineReport:
+    """Aggregate report. Frozen — §33.5 versioned artifact."""
+
+    schema_version: str
+    evaluated_at_unix: float
+    decisions: Tuple[GraduationDecision, ...]
+    auto_flipped: Tuple[str, ...]
+    advisories: Tuple[str, ...]
+    held: Tuple[str, ...]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "evaluated_at_unix": float(self.evaluated_at_unix),
+            "decisions": [d.to_dict() for d in self.decisions],
+            "auto_flipped": list(self.auto_flipped),
+            "advisories": list(self.advisories),
+            "held": list(self.held),
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    """Outcome of executing a report — receipts + advisories emitted."""
+
+    recorded_overrides: Tuple[str, ...] = field(default_factory=tuple)
+    advisories_emitted: Tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "recorded_overrides": list(self.recorded_overrides),
+            "advisories_emitted": list(self.advisories_emitted),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Evidence hashing
+# ---------------------------------------------------------------------------
+
+
+def _evidence_sha256(evidence: Dict[str, Any]) -> str:
+    try:
+        blob = json.dumps(evidence, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        blob = repr(evidence)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Substrate composition (lazy — keeps module-load stdlib-only)
+# ---------------------------------------------------------------------------
+
+
+def _default_ledger() -> Any:
+    from backend.core.ouroboros.governance.adaptation.graduation_ledger import (  # noqa: E501
+        get_default_ledger,
+    )
+    return get_default_ledger()
+
+
+def _default_registry() -> Any:
+    from backend.core.ouroboros.governance.flag_registry import (
+        ensure_seeded,
+    )
+    return ensure_seeded()
+
+
+def _default_validate_all() -> Tuple[Any, ...]:
+    """Lazy bridge to shipped_code_invariants.validate_all().
+
+    Slice 96 review fix — does NOT swallow failures to ``()``. An empty
+    tuple means "validator ran, found no violations" (Gate B clean); a
+    FAILURE must be distinguishable so Gate B can fail CLOSED. The
+    exception propagates to ``_drifted_source_files``, which converts it
+    to the ``None`` (unavailable) sentinel that HOLDs every candidate.
+    """
+    from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+        validate_all,
+    )
+    return tuple(validate_all())
+
+
+def _safety_category_names() -> Tuple[str, ...]:
+    """The category values that signal a SAFETY tier. Lazy-resolves the
+    canonical ``flag_registry.Category.SAFETY`` enum so the tier signal
+    is DATA-DRIVEN off the registry, not a hardcoded string."""
+    try:
+        from backend.core.ouroboros.governance.flag_registry import Category
+        return (Category.SAFETY.value,)
+    except Exception:  # noqa: BLE001
+        return ("safety",)
+
+
+def _known_category_names() -> Tuple[str, ...]:
+    """Every recognized ``flag_registry.Category`` value. STANDARD (the
+    auto-flippable tier) requires POSITIVE recognition: a category that is
+    NOT in this set (None / "" / a forged/garbage value) is treated as
+    SAFETY (fail-CLOSED) so a malformed or partially-registered spec can
+    never silently auto-activate. Slice 96 review fix."""
+    try:
+        from backend.core.ouroboros.governance.flag_registry import Category
+        return tuple(c.value for c in Category)
+    except Exception:  # noqa: BLE001
+        # Lazy-import failure → empty set → every flag reads as "unknown
+        # category" → SAFETY tier. Fail-closed by construction.
+        return ()
+
+
+def _boundary_crosses(source_file: str) -> bool:
+    """Belt-and-suspenders SAFETY corroboration: a source_file that
+    boundary-crosses into the governance cage is treated as SAFETY-tier
+    even if its category somehow isn't SAFETY. Composes the canonical
+    governance_boundary_gate predicate. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.governance_boundary_gate import (  # noqa: E501
+            evaluate_target_files,
+        )
+        report = evaluate_target_files([source_file])
+        return getattr(report.verdict, "value", "") == "boundary_crossed"
+    except Exception:  # noqa: BLE001 — defensive
+        return False
+
+
+def _contract_verdict_for_flag(flag_name: str) -> Optional[bool]:
+    """Gate C: if a graduation contract in the unified dashboard maps to
+    this flag, return whether its verdict is READY-equivalent. Returns
+    None when NO contract maps (Gate C vacuously satisfied). Composes
+    ``unified_graduation_dashboard.aggregate_dashboard``. NEVER
+    raises."""
+    try:
+        from backend.core.ouroboros.governance.unified_graduation_dashboard import (  # noqa: E501
+            aggregate_dashboard,
+        )
+        snapshot = aggregate_dashboard()
+        for row in snapshot.rows:
+            # Contract rows are keyed by contract name, not flag name.
+            # A contract maps to a flag only if its name matches the
+            # flag (today none do — Gate C is vacuous). Conservative:
+            # exact-match only; no fuzzy mapping.
+            if getattr(row, "source", "") != "contract":
+                continue
+            if getattr(row, "name", "") != flag_name:
+                continue
+            return getattr(row.verdict, "value", "") == "ready"
+    except Exception:  # noqa: BLE001 — defensive
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# evaluate_graduations — the decision matrix
+# ---------------------------------------------------------------------------
+
+
+def evaluate_graduations(
+    *,
+    now_unix: Optional[float] = None,
+    ledger: Optional[Any] = None,
+    registry: Optional[Any] = None,
+    validate_all_fn: Optional[Callable[[], Tuple[Any, ...]]] = None,
+) -> GraduationEngineReport:
+    """Evaluate every eligible candidate against the absolute decision
+    matrix. Pure read; NEVER raises.
+
+    ``ledger`` / ``registry`` / ``validate_all_fn`` are injectable for
+    hermetic testing; production callers omit them to compose the
+    canonical singletons."""
+    ts = float(now_unix) if now_unix is not None else time.time()
+
+    if not autonomous_graduation_engine_enabled():
+        # Master off — emit a DISABLED report. Still enumerate
+        # candidates so the report is shaped, but disposition=DISABLED.
+        return _disabled_report(ts, ledger, registry)
+
+    try:
+        live_ledger = ledger if ledger is not None else _default_ledger()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[GraduationEngine] ledger init failed: %s", exc)
+        return GraduationEngineReport(
+            schema_version=AUTONOMOUS_GRADUATION_ENGINE_SCHEMA_VERSION,
+            evaluated_at_unix=ts,
+            decisions=(), auto_flipped=(), advisories=(), held=(),
+        )
+    try:
+        live_registry = (
+            registry if registry is not None else _default_registry()
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[GraduationEngine] registry init failed: %s", exc)
+        live_registry = None
+
+    validate_fn = validate_all_fn or _default_validate_all
+
+    # Gate A entry condition — the eligible candidate set.
+    try:
+        candidates = list(live_ledger.eligible_flags())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[GraduationEngine] eligible_flags failed: %s", exc)
+        candidates = []
+
+    # Gate B input — AST violations grouped by target_file (one call).
+    drifted_files = _drifted_source_files(validate_fn)
+
+    safety_names = _safety_category_names()
+
+    decisions: List[GraduationDecision] = []
+    for flag in candidates:
+        decisions.append(
+            _evaluate_one(
+                flag,
+                registry=live_registry,
+                ledger=live_ledger,
+                drifted_files=drifted_files,
+                safety_names=safety_names,
+            )
+        )
+
+    auto = tuple(
+        d.flag_name for d in decisions
+        if d.disposition is GraduationDisposition.AUTO_FLIP
+    )
+    adv = tuple(
+        d.flag_name for d in decisions
+        if d.disposition is GraduationDisposition.APPROVAL_ADVISORY
+    )
+    held = tuple(
+        d.flag_name for d in decisions
+        if d.disposition is GraduationDisposition.HOLD
+    )
+    return GraduationEngineReport(
+        schema_version=AUTONOMOUS_GRADUATION_ENGINE_SCHEMA_VERSION,
+        evaluated_at_unix=ts,
+        decisions=tuple(decisions),
+        auto_flipped=auto,
+        advisories=adv,
+        held=held,
+    )
+
+
+def _drifted_source_files(
+    validate_fn: Callable[[], Tuple[Any, ...]],
+) -> Optional[frozenset]:
+    """Run the AST validator and project to the set of target_files
+    carrying at least one violation. NEVER raises.
+
+    Slice 96 review fix — returns ``None`` (the UNAVAILABLE sentinel) if
+    the validator itself raises/errors, distinct from an empty frozenset
+    ("ran clean, no drift"). Gate B treats ``None`` as fail-CLOSED: it
+    cannot PROVE AST stability, so every candidate HOLDs. Swallowing the
+    failure to an empty set (the prior behavior) would let a broken
+    validator wave every flag through — a fail-OPEN safety hole."""
+    try:
+        violations = validate_fn()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "[GraduationEngine] validate_fn raised — Gate B fail-CLOSED "
+            "(holding all candidates): %s", exc,
+        )
+        return None
+    files: set = set()
+    for v in violations or ():
+        tf = getattr(v, "target_file", None)
+        if isinstance(tf, str) and tf:
+            files.add(_normalize(tf))
+    return frozenset(files)
+
+
+def _normalize(path: str) -> str:
+    return path.replace("\\", "/").lstrip("./").strip()
+
+
+def _evaluate_one(
+    flag: str,
+    *,
+    registry: Optional[Any],
+    ledger: Any,
+    drifted_files: Optional[frozenset],
+    safety_names: Tuple[str, ...],
+) -> GraduationDecision:
+    """Compute the absolute decision for a single eligible flag.
+    NEVER raises."""
+    try:
+        spec = registry.get_spec(flag) if registry is not None else None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[GraduationEngine] get_spec(%s) failed: %s", flag, exc)
+        spec = None
+
+    # progress snapshot (composed telemetry evidence).
+    try:
+        progress = ledger.progress(flag)
+    except Exception:  # noqa: BLE001
+        progress = {}
+
+    if spec is None:
+        # Unknown to the registry — cannot determine tier/source_file.
+        return _hold(
+            flag, GraduationTier.STANDARD, HoldReason.UNKNOWN_SPEC,
+            delta=(
+                f"Gate-registry: flag {flag} not in FlagRegistry — "
+                f"cannot resolve source_file / category"
+            ),
+            evidence={"progress": progress, "registry": "missing"},
+        )
+
+    source_file = _normalize(getattr(spec, "source_file", "") or "")
+    category_val = getattr(getattr(spec, "category", None), "value", "")
+
+    # ---- Tier determination (DATA-DRIVEN, category-primary) ----
+    # The PRIMARY signal is the FlagRegistry category: SAFETY ("kill
+    # switches, gates") → SAFETY tier. The governance_boundary_gate is
+    # composed as a corroborating SECOND signal — but a boundary-cross
+    # alone does NOT flip a non-SAFETY-category flag, because virtually
+    # every §33.1 flag's source_file lives inside governance/ (so an
+    # unconditional OR would neuter the STANDARD tier entirely). The
+    # boundary verdict is recorded as evidence; it only *escalates*
+    # (never de-escalates) and is honored as a tier flip only when the
+    # category is ALREADY ambiguous (EXPERIMENTAL — the "not yet
+    # categorized" slot). This keeps the boundary gate a true
+    # belt-and-suspenders without making every cage-resident flag SAFETY.
+    category_is_safety = category_val in safety_names
+    # Slice 96 review fix — FAIL-CLOSED tier default: STANDARD (the
+    # auto-flippable tier) requires POSITIVE recognition as a known,
+    # non-SAFETY category. None / "" / a forged or unregistered category
+    # value is NOT in the known set → treated as SAFETY → routes to
+    # APPROVAL_ADVISORY, never auto-flip. A malformed/partial spec can no
+    # longer silently auto-activate a (possibly safety-relevant) capability.
+    category_known = category_val in _known_category_names()
+    boundary_crossed = _boundary_crosses(source_file)
+    is_safety = (
+        category_is_safety
+        or (not category_known)
+        or (boundary_crossed and category_val == "experimental")
+    )
+    tier = GraduationTier.SAFETY if is_safety else GraduationTier.STANDARD
+
+    evidence: Dict[str, Any] = {
+        "flag_name": flag,
+        "source_file": source_file,
+        "category": category_val,
+        "category_known": category_known,
+        "tier": tier.value,
+        "tier_signal": (
+            "category_safety" if category_is_safety
+            else (
+                "unknown_category_failclosed" if not category_known
+                else (
+                    "boundary_experimental" if is_safety
+                    else "category_standard"
+                )
+            )
+        ),
+        "boundary_crossed": boundary_crossed,
+        "progress": progress,
+        "gate_a_eligible": True,
+    }
+
+    # ---- Gate B (AST stability) ----
+    # Slice 96 review fix — fail-CLOSED on validator UNAVAILABLE.
+    # drifted_files is None when shipped_code_invariants.validate_all()
+    # itself raised: we cannot PROVE the subsystem's AST is stable, so we
+    # refuse graduation rather than wave it through (the prior empty-set
+    # swallow was a fail-OPEN hole).
+    if drifted_files is None:
+        evidence["hold_reason"] = HoldReason.AST_DRIFT.value
+        evidence["gate_b_ast_clean"] = False
+        evidence["gate_b_validator_unavailable"] = True
+        return _decision(
+            flag, tier, GraduationDisposition.HOLD,
+            delta=(
+                "Gate-B AST_DRIFT (fail-closed): "
+                "shipped_code_invariants.validate_all() was UNAVAILABLE "
+                "(raised) — cannot prove AST stability; refusing graduation"
+            ),
+            evidence=evidence,
+        )
+    if source_file and source_file in drifted_files:
+        evidence["hold_reason"] = HoldReason.AST_DRIFT.value
+        evidence["gate_b_ast_clean"] = False
+        return _decision(
+            flag, tier, GraduationDisposition.HOLD,
+            delta=(
+                f"Gate-B AST_DRIFT: shipped_code_invariants.validate_all() "
+                f"reports a violation on {source_file} — subsystem AST "
+                f"unstable; refusing graduation"
+            ),
+            evidence=evidence,
+        )
+    evidence["gate_b_ast_clean"] = True
+
+    # ---- Gate C (contract, if any) ----
+    contract = _contract_verdict_for_flag(flag)
+    if contract is None:
+        evidence["gate_c_contract"] = "vacuous"
+    elif contract is False:
+        evidence["gate_c_contract"] = "not_ready"
+        evidence["hold_reason"] = HoldReason.CONTRACT_NOT_READY.value
+        return _decision(
+            flag, tier, GraduationDisposition.HOLD,
+            delta=(
+                f"Gate-C CONTRACT_NOT_READY: a graduation contract maps "
+                f"to {flag} and its verdict is not READY — refusing "
+                f"graduation"
+            ),
+            evidence=evidence,
+        )
+    else:
+        evidence["gate_c_contract"] = "ready"
+
+    # ---- All gates passed → READY ----
+    if tier is GraduationTier.SAFETY:
+        evidence["disposition_reason"] = (
+            "SAFETY-tier (§1 zero-order-doll): auto-activating a "
+            "governance/kill-switch capability is a governance self-"
+            "modification — routes to operator approval, not auto-flip"
+        )
+        return _decision(
+            flag, tier, GraduationDisposition.APPROVAL_ADVISORY,
+            delta=(
+                f"READY → APPROVAL_ADVISORY: {flag} met all gates but is "
+                f"SAFETY-tier ({category_val}); operator must approve the "
+                f"flip"
+            ),
+            evidence=evidence,
+        )
+    return _decision(
+        flag, tier, GraduationDisposition.AUTO_FLIP,
+        delta=(
+            f"READY → AUTO_FLIP: {flag} met Gate-A (telemetry) + Gate-B "
+            f"(AST) + Gate-C (contract) and is STANDARD-tier — autonomous "
+            f"env-override authorized"
+        ),
+        evidence=evidence,
+    )
+
+
+def _decision(
+    flag: str,
+    tier: GraduationTier,
+    disposition: GraduationDisposition,
+    *,
+    delta: str,
+    evidence: Dict[str, Any],
+) -> GraduationDecision:
+    return GraduationDecision(
+        flag_name=flag,
+        tier=tier,
+        disposition=disposition,
+        evidence=evidence,
+        delta=delta,
+        evidence_sha256=_evidence_sha256(evidence),
+    )
+
+
+def _hold(
+    flag: str,
+    tier: GraduationTier,
+    reason: HoldReason,
+    *,
+    delta: str,
+    evidence: Dict[str, Any],
+) -> GraduationDecision:
+    ev = dict(evidence)
+    ev["hold_reason"] = reason.value
+    return _decision(flag, tier, GraduationDisposition.HOLD, delta=delta,
+                     evidence=ev)
+
+
+def _disabled_report(
+    ts: float,
+    ledger: Optional[Any],
+    registry: Optional[Any],
+) -> GraduationEngineReport:
+    """Master-off shape: enumerate candidates but mark them DISABLED."""
+    decisions: List[GraduationDecision] = []
+    try:
+        live = ledger if ledger is not None else _default_ledger()
+        for flag in live.eligible_flags():
+            ev = {"hold_reason": HoldReason.MASTER_OFF.value}
+            decisions.append(GraduationDecision(
+                flag_name=flag,
+                tier=GraduationTier.STANDARD,
+                disposition=GraduationDisposition.DISABLED,
+                evidence=ev,
+                delta="master_off: JARVIS_AUTONOMOUS_GRADUATION_ENGINE_"
+                      "ENABLED is FALSE",
+                evidence_sha256=_evidence_sha256(ev),
+            ))
+    except Exception:  # noqa: BLE001 — defensive
+        pass
+    return GraduationEngineReport(
+        schema_version=AUTONOMOUS_GRADUATION_ENGINE_SCHEMA_VERSION,
+        evaluated_at_unix=ts,
+        decisions=tuple(decisions),
+        auto_flipped=(), advisories=(), held=(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# execute_graduations — deliver receipts + advisories
+# ---------------------------------------------------------------------------
+
+
+def execute_graduations(
+    report: GraduationEngineReport,
+    *,
+    now_unix: Optional[float] = None,
+) -> ExecutionResult:
+    """Deliver the report. AUTO_FLIP → immutable override receipt
+    (the override ledger structurally refuses non-STANDARD tiers).
+    APPROVAL_ADVISORY → a receipt-backed advisory JSONL. NEVER writes
+    source; NEVER auto-flips a SAFETY flag. NEVER raises."""
+    recorded: List[str] = []
+    advised: List[str] = []
+    try:
+        from backend.core.ouroboros.governance import (
+            graduation_override_ledger as override_ledger,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[GraduationEngine] override ledger unavailable: %s", exc)
+        override_ledger = None  # type: ignore
+
+    for decision in report.decisions:
+        try:
+            if decision.disposition is GraduationDisposition.AUTO_FLIP:
+                if override_ledger is None:
+                    continue
+                # The override ledger STRUCTURALLY refuses any non-
+                # STANDARD tier — a SAFETY flag can never be recorded
+                # even if a bug mislabeled its disposition.
+                if override_ledger.record_graduation(
+                    decision, now_unix=now_unix,
+                ):
+                    recorded.append(decision.flag_name)
+            elif (
+                decision.disposition
+                is GraduationDisposition.APPROVAL_ADVISORY
+            ):
+                if _emit_advisory(decision, now_unix=now_unix):
+                    advised.append(decision.flag_name)
+        except Exception as exc:  # noqa: BLE001 — best-effort per decision
+            logger.debug(
+                "[GraduationEngine] execute %s failed: %s",
+                decision.flag_name, exc,
+            )
+            continue
+    return ExecutionResult(
+        recorded_overrides=tuple(recorded),
+        advisories_emitted=tuple(advised),
+    )
+
+
+def _emit_advisory(
+    decision: GraduationDecision,
+    *,
+    now_unix: Optional[float] = None,
+) -> bool:
+    """Append a receipt-backed advisory for a SAFETY-tier graduation.
+    Dedicated advisory JSONL (lowest coupling). NEVER raises."""
+    try:
+        from pathlib import Path
+
+        ts = float(now_unix) if now_unix is not None else time.time()
+        record = {
+            "schema_version": AUTONOMOUS_GRADUATION_ENGINE_SCHEMA_VERSION,
+            "flag_name": decision.flag_name,
+            "tier": decision.tier.value,
+            "disposition": decision.disposition.value,
+            "requires_operator_approval": True,
+            "evidence": decision.evidence,
+            "evidence_sha256": decision.evidence_sha256,
+            "delta": decision.delta,
+            "advised_at_unix": ts,
+            "authorized_by": "autonomous_graduation_engine",
+        }
+        try:
+            line = json.dumps(record, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return False
+        path = Path(advisory_ledger_path())
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return False
+        try:
+            from backend.core.ouroboros.governance.cross_process_jsonl import (  # noqa: E501
+                flock_append_line,
+            )
+            return bool(flock_append_line(path, line))
+        except ImportError:
+            with path.open("a", encoding="utf-8") as f:
+                f.write(line)
+                f.write("\n")
+            return True
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.debug("[GraduationEngine] advisory emit failed: %s", exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Auto-discovered §33.1 registrars
+# ---------------------------------------------------------------------------
+
+
+def register_flags(registry: Any) -> int:  # noqa: ANN001
+    """Register this engine's env knobs with the FlagRegistry.
+    Auto-discovered via ``flag_registry_seed`` module-discovery."""
+    if registry is None:
+        return 0
+    from backend.core.ouroboros.governance.flag_registry import (
+        Category,
+        FlagSpec,
+        FlagType,
+    )
+
+    src = (
+        "backend/core/ouroboros/governance/"
+        "autonomous_graduation_engine.py"
+    )
+    seeds = [
+        FlagSpec(
+            name="JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED",
+            type=FlagType.BOOL,
+            default=False,
+            description=(
+                "Master switch for the Autonomous Telemetry-Driven "
+                "Graduation Engine (§40 / Slice 96). Default-FALSE per "
+                "§33.1. When on, the engine evaluates eligible §33.1 "
+                "flags and auto-flips STANDARD-tier ones via the durable "
+                "env-override ledger; SAFETY-tier flags route to operator "
+                "advisory only."
+            ),
+            category=Category.SAFETY,
+            source_file=src,
+            example="true",
+        ),
+        FlagSpec(
+            name="JARVIS_GRADUATION_OVERRIDE_APPLY_ENABLED",
+            type=FlagType.BOOL,
+            default=False,
+            description=(
+                "Boot-time applier sub-gate. When on (or the engine "
+                "master is on), apply_overrides_to_environ injects "
+                "previously-authorized STANDARD-tier graduations into "
+                "os.environ — honoring operator env-precedence. "
+                "Default-FALSE: dormant-by-default."
+            ),
+            category=Category.SAFETY,
+            source_file=(
+                "backend/core/ouroboros/governance/"
+                "graduation_override_ledger.py"
+            ),
+            example="true",
+        ),
+    ]
+    n = 0
+    for spec in seeds:
+        try:
+            registry.register(spec)
+            n += 1
+        except Exception:  # noqa: BLE001 — fail-open per §33.1
+            continue
+    return n
+
+
+def register_shipped_invariants() -> list:
+    """Auto-discovered AST pins for this module. NEVER raises.
+
+    Pins:
+      1. tier + disposition enums closed (no smuggled members).
+      2. authority-asymmetry — no orchestrator/iron_gate/policy/
+         providers/candidate_generator/urgency_router/change_engine/
+         semantic_guardian/auto_committer/risk_tier imports.
+      3. master default-FALSE (no unconditional `return True`).
+      4. composes-canonical — references graduation_ledger +
+         flag_registry + shipped_code_invariants +
+         unified_graduation_dashboard.
+    """
+    import ast
+
+    try:
+        from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+            ShippedCodeInvariant,
+        )
+    except ImportError:
+        return []
+
+    target = (
+        "backend/core/ouroboros/governance/"
+        "autonomous_graduation_engine.py"
+    )
+
+    def _validate_enums_closed(tree, source):  # noqa: ANN001
+        violations: list = []
+        expected = {
+            "GraduationTier": {"STANDARD", "SAFETY"},
+            "GraduationDisposition": {
+                "AUTO_FLIP", "APPROVAL_ADVISORY", "HOLD", "DISABLED",
+            },
+        }
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            if node.name not in expected:
+                continue
+            seen: set = set()
+            for stmt in node.body:
+                if isinstance(stmt, ast.Assign):
+                    for tgt in stmt.targets:
+                        if isinstance(tgt, ast.Name):
+                            seen.add(tgt.id)
+            req = expected[node.name]
+            missing = req - seen
+            extras = seen - req
+            if missing:
+                violations.append(
+                    f"{node.name} missing members: {sorted(missing)}"
+                )
+            if extras:
+                violations.append(
+                    f"{node.name} has extra members (closed-taxonomy "
+                    f"violation): {sorted(extras)}"
+                )
+        return tuple(violations)
+
+    def _validate_authority_asymmetry(tree, source):  # noqa: ANN001
+        forbidden = (
+            "orchestrator", "iron_gate", "policy", "providers",
+            "candidate_generator", "urgency_router", "change_engine",
+            "semantic_guardian", "auto_committer", "risk_tier_floor",
+        )
+        violations: list = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                for f in forbidden:
+                    if f in module:
+                        violations.append(
+                            f"forbidden authority import: {module}"
+                        )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    for f in forbidden:
+                        if f in alias.name:
+                            violations.append(
+                                f"forbidden authority import: {alias.name}"
+                            )
+        return tuple(violations)
+
+    def _validate_master_default_false(tree, source):  # noqa: ANN001
+        violations: list = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.FunctionDef)
+                and node.name == "autonomous_graduation_engine_enabled"
+            ):
+                func_src = ast.unparse(node)
+                if "return True" in func_src:
+                    violations.append(
+                        "autonomous_graduation_engine_enabled MUST NOT "
+                        "unconditionally return True (master default-FALSE "
+                        "per §33.1)"
+                    )
+                key = "JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED"
+                if key not in func_src:
+                    violations.append(
+                        f"master gate MUST read {key!r}"
+                    )
+        return tuple(violations)
+
+    def _validate_composes_canonical(tree, source):  # noqa: ANN001
+        required = (
+            "graduation_ledger",
+            "flag_registry",
+            "shipped_code_invariants",
+            "unified_graduation_dashboard",
+        )
+        violations: list = []
+        for token in required:
+            if token not in source:
+                violations.append(
+                    f"engine MUST compose canonical substrate {token!r} "
+                    f"(no reimplemented verdict/eligibility/AST logic)"
+                )
+        return tuple(violations)
+
+    return [
+        ShippedCodeInvariant(
+            invariant_name="autonomous_graduation_engine_enums_closed",
+            target_file=target,
+            description=(
+                "GraduationTier (STANDARD/SAFETY) + GraduationDisposition "
+                "(AUTO_FLIP/APPROVAL_ADVISORY/HOLD/DISABLED) are closed "
+                "taxonomies — no smuggled member can widen the tiered "
+                "autonomy boundary."
+            ),
+            validate=_validate_enums_closed,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="autonomous_graduation_engine_authority_asymmetry",
+            target_file=target,
+            description=(
+                "Engine MUST stay pure substrate composing graduation "
+                "ledger + registry + shipped invariants + dashboard. NEVER "
+                "imports orchestrator / iron_gate / policy / providers / "
+                "candidate_generator / urgency_router / change_engine / "
+                "semantic_guardian / auto_committer / risk_tier_floor."
+            ),
+            validate=_validate_authority_asymmetry,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="autonomous_graduation_engine_master_default_false",
+            target_file=target,
+            description=(
+                "Master flag JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED "
+                "stays default-FALSE per §33.1."
+            ),
+            validate=_validate_master_default_false,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="autonomous_graduation_engine_composes_canonical",
+            target_file=target,
+            description=(
+                "Engine composes the canonical graduation_ledger + "
+                "flag_registry + shipped_code_invariants + "
+                "unified_graduation_dashboard substrates — no parallel "
+                "eligibility / AST / verdict reasoning."
+            ),
+            validate=_validate_composes_canonical,
+        ),
+    ]
+
+
+__all__ = [
+    "AUTONOMOUS_GRADUATION_ENGINE_SCHEMA_VERSION",
+    "ExecutionResult",
+    "GraduationDecision",
+    "GraduationDisposition",
+    "GraduationEngineReport",
+    "GraduationTier",
+    "HoldReason",
+    "autonomous_graduation_engine_enabled",
+    "advisory_ledger_path",
+    "evaluate_graduations",
+    "execute_graduations",
+    "register_flags",
+    "register_shipped_invariants",
+]

--- a/backend/core/ouroboros/governance/graduation_override_ledger.py
+++ b/backend/core/ouroboros/governance/graduation_override_ledger.py
@@ -1,0 +1,379 @@
+"""Slice 96 — durable env-override ledger + boot-time applier.
+
+The sanctioned, cage-respecting delivery channel for an autonomous
+graduation. The :class:`AutonomousGraduationEngine` (Module 1) decides
+that a built-but-dormant §33.1 subsystem has EARNED its master-flag
+flip (FALSE→TRUE). It MUST NOT edit source defaults — editing
+``flag_registry`` / ``*_seed.py`` source lands inside
+``backend/core/ouroboros/governance/`` and trips the governance
+boundary gate + AST hash-cap (→ APPROVAL_REQUIRED). Instead, the flip
+is delivered as an **immutable receipt** appended to a durable JSONL,
+and a **boot-time applier** injects the authorized flags into
+``os.environ`` — env vars are OS-level, external to the cage, and
+honor the hash-cap signatures perfectly (they don't mutate any
+hashed source byte).
+
+## The tiered-boundary invariant (LOAD-BEARING)
+
+ONLY ``STANDARD``-tier graduations are ever written here. ``SAFETY``-
+tier graduations (auto-activating a kill-switch / gate is itself a
+governance self-modification — the §1 zero-order-doll invariant) are
+routed to an operator advisory, NEVER an override. This is enforced
+STRUCTURALLY: :func:`record_graduation` REFUSES any decision whose
+``tier`` is not ``STANDARD``. Therefore a SAFETY flag can never reach
+the override ledger, and the boot applier (which reads ONLY this
+ledger) structurally cannot auto-activate a safety capability.
+
+## Authority posture (§33.1)
+
+* Default-off: the applier is gated by ``JARVIS_GRADUATION_OVERRIDE_-
+  APPLY_ENABLED`` OR ``JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED``
+  (both default-FALSE) — dormant by default.
+* Append-only, immutable receipts. Never edits or deletes a row.
+* Best-effort: every public function NEVER raises.
+* Authority-asymmetry: imports stdlib only at module load; the
+  canonical ``cross_process_jsonl`` substrate is lazy-imported. NO
+  orchestrator / iron_gate / policy / providers / candidate_generator
+  / urgency_router / change_engine / semantic_guardian /
+  auto_committer / risk_tier_floor imports anywhere.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+GRADUATION_OVERRIDE_LEDGER_SCHEMA_VERSION: str = "graduation_override.1"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+# The ONLY tier permitted to reach this ledger. SAFETY-tier flips are
+# structurally excluded (they route to operator advisories).
+_PERMITTED_TIER: str = "standard"
+
+# Defensive caps.
+MAX_LEDGER_FILE_BYTES: int = 4 * 1024 * 1024
+MAX_RECORDS_LOADED: int = 50_000
+
+
+# ---------------------------------------------------------------------------
+# Master / sub gates
+# ---------------------------------------------------------------------------
+
+
+def _env_truthy(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in _TRUTHY
+
+
+def engine_master_enabled() -> bool:
+    """``JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED`` (default
+    FALSE)."""
+    return _env_truthy("JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED")
+
+
+def apply_enabled() -> bool:
+    """The boot applier is dormant unless EITHER the engine master OR
+    its own apply sub-gate is on. Both default FALSE."""
+    return (
+        engine_master_enabled()
+        or _env_truthy("JARVIS_GRADUATION_OVERRIDE_APPLY_ENABLED")
+    )
+
+
+def ledger_path() -> Path:
+    """Append-only override-ledger path. Env-overridable via
+    ``JARVIS_GRADUATION_OVERRIDE_LEDGER_PATH``; defaults to
+    ``.jarvis/graduation_overrides.jsonl`` under cwd."""
+    raw = os.environ.get("JARVIS_GRADUATION_OVERRIDE_LEDGER_PATH")
+    if raw:
+        return Path(raw)
+    return Path(".jarvis") / "graduation_overrides.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Receipt record
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OverrideRecord:
+    """One immutable graduation receipt. Frozen — append-only."""
+
+    flag_name: str
+    authorized_true: bool
+    tier: str
+    receipt_id: str
+    evidence: Dict[str, Any]
+    evidence_sha256: str
+    decided_at_unix: float
+    decided_at_iso: str
+    authorized_by: str = "autonomous_graduation_engine"
+    schema_version: str = GRADUATION_OVERRIDE_LEDGER_SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "flag_name": self.flag_name,
+            "authorized_true": bool(self.authorized_true),
+            "tier": self.tier,
+            "receipt_id": self.receipt_id,
+            "evidence": self.evidence,
+            "evidence_sha256": self.evidence_sha256,
+            "decided_at_unix": float(self.decided_at_unix),
+            "decided_at_iso": self.decided_at_iso,
+            "authorized_by": self.authorized_by,
+        }
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Write — record_graduation
+# ---------------------------------------------------------------------------
+
+
+def record_graduation(decision: Any, *, now_unix: Optional[float] = None) -> bool:
+    """Append an immutable receipt for an AUTO_FLIP decision.
+
+    STRUCTURAL TIER GATE (load-bearing): refuses any decision whose
+    ``tier`` is not STANDARD, regardless of disposition. A SAFETY flag
+    can therefore NEVER reach this ledger — even a forged decision with
+    a SAFETY tier + an AUTO_FLIP disposition is rejected here.
+
+    Also refuses non-AUTO_FLIP dispositions (advisories / holds /
+    disabled never produce an override).
+
+    Returns True on a successful append, False otherwise. NEVER
+    raises."""
+    try:
+        flag_name = getattr(decision, "flag_name", None)
+        tier = getattr(decision, "tier", None)
+        disposition = getattr(decision, "disposition", None)
+        if not isinstance(flag_name, str) or not flag_name.strip():
+            return False
+        tier_val = getattr(tier, "value", tier)
+        disp_val = getattr(disposition, "value", disposition)
+        # STRUCTURAL TIER GATE — the load-bearing safety boundary.
+        if tier_val != _PERMITTED_TIER:
+            logger.info(
+                "[GraduationOverride] refusing non-STANDARD tier=%s "
+                "flag=%s (safety/governance flips route to advisory)",
+                tier_val, flag_name,
+            )
+            return False
+        # Only AUTO_FLIP decisions yield overrides.
+        if disp_val != "auto_flip":
+            return False
+        evidence = getattr(decision, "evidence", {}) or {}
+        if not isinstance(evidence, dict):
+            evidence = {"_raw": str(evidence)}
+        evidence_sha = getattr(decision, "evidence_sha256", "") or ""
+        ts = float(now_unix) if now_unix is not None else time.time()
+        record = OverrideRecord(
+            flag_name=flag_name.strip(),
+            authorized_true=True,
+            tier=_PERMITTED_TIER,
+            receipt_id=uuid.uuid4().hex,
+            evidence=evidence,
+            evidence_sha256=str(evidence_sha),
+            decided_at_unix=ts,
+            decided_at_iso=_utc_now_iso(),
+            authorized_by="autonomous_graduation_engine",
+        )
+        return _append_record(record)
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.debug("[GraduationOverride] record failed: %s", exc)
+        return False
+
+
+def _append_record(record: OverrideRecord) -> bool:
+    try:
+        line = json.dumps(record.to_dict(), separators=(",", ":"))
+    except (TypeError, ValueError) as exc:
+        logger.debug("[GraduationOverride] serialize failed: %s", exc)
+        return False
+    path = ledger_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.debug("[GraduationOverride] mkdir failed: %s", exc)
+        return False
+    try:
+        from backend.core.ouroboros.governance.cross_process_jsonl import (
+            flock_append_line,
+        )
+    except ImportError:
+        # Stdlib fallback — never raises.
+        try:
+            with path.open("a", encoding="utf-8") as f:
+                f.write(line)
+                f.write("\n")
+            return True
+        except OSError as exc:
+            logger.debug("[GraduationOverride] append failed: %s", exc)
+            return False
+    ok = bool(flock_append_line(path, line))
+    if ok:
+        logger.info(
+            "[GraduationOverride] recorded flag=%s tier=%s receipt=%s",
+            record.flag_name, record.tier, record.receipt_id,
+        )
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Read — all_overrides
+# ---------------------------------------------------------------------------
+
+
+def all_overrides() -> Tuple[OverrideRecord, ...]:
+    """Read every receipt. Bounded + fail-open — NEVER raises."""
+    path = ledger_path()
+    if not path.exists():
+        return ()
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return ()
+    if size > MAX_LEDGER_FILE_BYTES:
+        logger.warning(
+            "[GraduationOverride] %s exceeds cap (%d bytes) — refusing",
+            path, size,
+        )
+        return ()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ()
+    out: list = []
+    for raw_line in text.splitlines():
+        if len(out) >= MAX_RECORDS_LOADED:
+            break
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        flag = obj.get("flag_name")
+        if not isinstance(flag, str) or not flag:
+            continue
+        # Defensive read-side tier filter — a row that somehow carries
+        # a non-STANDARD tier is dropped on read too (defense in depth).
+        tier = str(obj.get("tier") or "")
+        if tier != _PERMITTED_TIER:
+            continue
+        ev = obj.get("evidence")
+        if not isinstance(ev, dict):
+            ev = {}
+        try:
+            out.append(OverrideRecord(
+                flag_name=flag,
+                authorized_true=bool(obj.get("authorized_true", False)),
+                tier=tier,
+                receipt_id=str(obj.get("receipt_id") or ""),
+                evidence=ev,
+                evidence_sha256=str(obj.get("evidence_sha256") or ""),
+                decided_at_unix=float(obj.get("decided_at_unix") or 0.0),
+                decided_at_iso=str(obj.get("decided_at_iso") or ""),
+                authorized_by=str(
+                    obj.get("authorized_by")
+                    or "autonomous_graduation_engine"
+                ),
+                schema_version=str(
+                    obj.get("schema_version")
+                    or GRADUATION_OVERRIDE_LEDGER_SCHEMA_VERSION
+                ),
+            ))
+        except (TypeError, ValueError):
+            continue
+    return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# Boot applier — apply_overrides_to_environ
+# ---------------------------------------------------------------------------
+
+
+def apply_overrides_to_environ(
+    environ: Optional[Any] = None,
+) -> Tuple[str, ...]:
+    """The BOOT applier. Reads the override ledger and, for each
+    authorized STANDARD-tier flag, sets ``environ[flag] = "true"`` —
+    but ONLY if the flag is not already present in ``environ`` (operator
+    env-precedence wins — an explicit operator setting is NEVER
+    overridden).
+
+    Returns the tuple of flag names actually applied this call.
+
+    SAFETY-tier flags are STRUCTURALLY absent from the ledger (they go
+    to advisories), so this applier cannot auto-activate any safety
+    capability — there is no code path here that reads a SAFETY flag.
+
+    Gated by :func:`apply_enabled` (default-FALSE). Pure except the
+    environ writes. NEVER raises."""
+    target = environ if environ is not None else os.environ
+    try:
+        if not apply_enabled():
+            return ()
+        applied: list = []
+        seen: set = set()
+        for rec in all_overrides():
+            if not rec.authorized_true:
+                continue
+            if rec.tier != _PERMITTED_TIER:  # defense in depth
+                continue
+            flag = rec.flag_name
+            if flag in seen:
+                continue
+            seen.add(flag)
+            # Env-precedence: never overwrite an operator-set value.
+            try:
+                already_present = flag in target
+            except TypeError:
+                already_present = False
+            if already_present:
+                continue
+            try:
+                target[flag] = "true"
+            except Exception:  # noqa: BLE001 — defensive
+                continue
+            applied.append(flag)
+        if applied:
+            logger.info(
+                "[GraduationOverride] boot applier injected %d flag(s): %s",
+                len(applied), ", ".join(applied),
+            )
+        return tuple(applied)
+    except Exception as exc:  # noqa: BLE001 — best-effort boot path
+        logger.debug("[GraduationOverride] applier failed: %s", exc)
+        return ()
+
+
+__all__ = [
+    "GRADUATION_OVERRIDE_LEDGER_SCHEMA_VERSION",
+    "OverrideRecord",
+    "all_overrides",
+    "apply_enabled",
+    "apply_overrides_to_environ",
+    "engine_master_enabled",
+    "ledger_path",
+    "record_graduation",
+]

--- a/tests/governance/test_autonomous_graduation_engine.py
+++ b/tests/governance/test_autonomous_graduation_engine.py
@@ -1,0 +1,582 @@
+"""Slice 96 — Autonomous Telemetry-Driven Graduation Engine (TIERED).
+
+The tiered-boundary proof: a STANDARD-tier flag that is telemetry-
+eligible + AST-clean AUTO-FLIPS (via a durable env-override ledger +
+a boot applier that injects into os.environ); a SAFETY-tier flag that
+is identically ready is held to an APPROVAL_ADVISORY and STRUCTURALLY
+cannot reach the override ledger or the boot applier.
+
+All unit assertions use synthetic ledger + registry stubs — hermetic,
+no dependence on live state. A final LIVE readout (Phase 4) runs the
+engine against the REAL GraduationLedger + populated registry and
+reports honestly which dormant flags graduated / advised / held.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomous_graduation_engine import (
+    GraduationDisposition,
+    GraduationEngineReport,
+    GraduationTier,
+    HoldReason,
+    autonomous_graduation_engine_enabled,
+    evaluate_graduations,
+    execute_graduations,
+    register_flags,
+    register_shipped_invariants,
+)
+from backend.core.ouroboros.governance import (
+    graduation_override_ledger as gol,
+)
+from backend.core.ouroboros.governance.flag_registry import (
+    Category,
+    FlagRegistry,
+    FlagSpec,
+    FlagType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic stubs — hermetic, no live state
+# ---------------------------------------------------------------------------
+
+
+class _StubLedger:
+    """Mimics GraduationLedger.eligible_flags()/progress()."""
+
+    def __init__(self, eligible, progress_map=None):
+        self._eligible = list(eligible)
+        self._progress = progress_map or {}
+
+    def eligible_flags(self):
+        return list(self._eligible)
+
+    def progress(self, flag_name):
+        return self._progress.get(
+            flag_name,
+            {
+                "clean": 5, "infra": 0, "runner": 0, "migration": 0,
+                "unique_sessions": 5, "required": 3,
+            },
+        )
+
+
+_STD_FLAG = "JARVIS_STUB_STANDARD_FLAG"
+_SAFETY_FLAG = "JARVIS_STUB_SAFETY_FLAG"
+_STD_SRC = "backend/core/ouroboros/governance/stub_standard.py"
+_SAFETY_SRC = "backend/core/ouroboros/governance/stub_safety.py"
+
+
+def _stub_registry():
+    reg = FlagRegistry()
+    reg.register(FlagSpec(
+        name=_STD_FLAG, type=FlagType.BOOL, default=False,
+        description="stub standard", category=Category.TUNING,
+        source_file=_STD_SRC,
+    ))
+    reg.register(FlagSpec(
+        name=_SAFETY_FLAG, type=FlagType.BOOL, default=False,
+        description="stub safety", category=Category.SAFETY,
+        source_file=_SAFETY_SRC,
+    ))
+    return reg
+
+
+def _no_ast_drift(*_a, **_k):
+    return ()
+
+
+def _drift_on(source_file):
+    from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+        InvariantViolation,
+    )
+
+    def _validate():
+        return (
+            InvariantViolation(
+                invariant_name="stub_drift",
+                target_file=source_file,
+                detail="synthetic drift",
+            ),
+        )
+
+    return _validate
+
+
+@pytest.fixture(autouse=True)
+def _engine_on(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_GRADUATION_OVERRIDE_APPLY_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_GRADUATION_OVERRIDE_LEDGER_PATH",
+        str(tmp_path / "graduation_overrides.jsonl"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_GRADUATION_ADVISORY_LEDGER_PATH",
+        str(tmp_path / "graduation_advisories.jsonl"),
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — STANDARD ready → AUTO_FLIP → receipt → environ injection
+# ---------------------------------------------------------------------------
+
+
+def test_standard_ready_auto_flips_and_applies(tmp_path):
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_no_ast_drift,
+    )
+    assert isinstance(report, GraduationEngineReport)
+    dec = {d.flag_name: d for d in report.decisions}[_STD_FLAG]
+    assert dec.tier is GraduationTier.STANDARD
+    assert dec.disposition is GraduationDisposition.AUTO_FLIP
+    assert _STD_FLAG in report.auto_flipped
+    assert dec.evidence_sha256
+
+    result = execute_graduations(report)
+    assert _STD_FLAG in result.recorded_overrides
+
+    # Receipt landed in the override ledger.
+    overrides = gol.all_overrides()
+    assert any(o.flag_name == _STD_FLAG for o in overrides)
+
+    # Boot applier injects into a fresh environ.
+    env: dict = {}
+    applied = gol.apply_overrides_to_environ(env)
+    assert _STD_FLAG in applied
+    assert env[_STD_FLAG] == "true"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — SAFETY ready → APPROVAL_ADVISORY (the core safety test)
+# ---------------------------------------------------------------------------
+
+
+def test_safety_ready_routes_to_advisory_never_override(tmp_path):
+    report = evaluate_graduations(
+        ledger=_StubLedger([_SAFETY_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_no_ast_drift,
+    )
+    dec = {d.flag_name: d for d in report.decisions}[_SAFETY_FLAG]
+    assert dec.tier is GraduationTier.SAFETY
+    assert dec.disposition is GraduationDisposition.APPROVAL_ADVISORY
+    assert _SAFETY_FLAG in report.advisories
+    assert _SAFETY_FLAG not in report.auto_flipped
+
+    result = execute_graduations(report)
+    # Safety flag NEVER recorded as an override.
+    assert _SAFETY_FLAG not in result.recorded_overrides
+    assert _SAFETY_FLAG in result.advisories_emitted
+
+    # Structurally absent from the override ledger.
+    overrides = gol.all_overrides()
+    assert all(o.flag_name != _SAFETY_FLAG for o in overrides)
+
+    # Boot applier cannot set it.
+    env: dict = {}
+    applied = gol.apply_overrides_to_environ(env)
+    assert _SAFETY_FLAG not in applied
+    assert _SAFETY_FLAG not in env
+
+
+def test_safety_flag_structurally_cannot_be_recorded():
+    """record_graduation MUST refuse a SAFETY-tier decision even if
+    a caller hands it one directly — structural, not convention."""
+    from backend.core.ouroboros.governance.autonomous_graduation_engine import (  # noqa: E501
+        GraduationDecision,
+    )
+    forged = GraduationDecision(
+        flag_name=_SAFETY_FLAG,
+        tier=GraduationTier.SAFETY,
+        disposition=GraduationDisposition.AUTO_FLIP,  # forged disposition
+        evidence={"forged": True},
+        delta="ready",
+        evidence_sha256="deadbeef",
+    )
+    ok = gol.record_graduation(forged)
+    assert ok is False
+    assert all(o.flag_name != _SAFETY_FLAG for o in gol.all_overrides())
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Hard-lock denials (mathematically absolute)
+# ---------------------------------------------------------------------------
+
+
+def test_not_eligible_holds_with_reason():
+    # _STD_FLAG NOT in eligible set → HOLD NOT_ELIGIBLE.
+    report = evaluate_graduations(
+        ledger=_StubLedger([]),  # nothing eligible
+        registry=_stub_registry(),
+        validate_all_fn=_no_ast_drift,
+    )
+    # No candidates → no decisions for the stub flag at all.
+    assert _STD_FLAG not in {d.flag_name for d in report.decisions}
+    assert report.auto_flipped == ()
+
+
+def test_eligible_but_ast_drift_holds_ast_drift():
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_drift_on(_STD_SRC),
+    )
+    dec = {d.flag_name: d for d in report.decisions}[_STD_FLAG]
+    assert dec.disposition is GraduationDisposition.HOLD
+    assert dec.evidence.get("hold_reason") == HoldReason.AST_DRIFT.value
+    # delta names the exact failing gate.
+    assert "AST" in dec.delta or "ast" in dec.delta
+    assert _STD_FLAG in report.held
+    assert _STD_FLAG not in report.auto_flipped
+
+
+def test_ast_drift_on_other_file_does_not_block():
+    # Drift on a DIFFERENT source_file must not hold this flag.
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_drift_on("some/unrelated/file.py"),
+    )
+    dec = {d.flag_name: d for d in report.decisions}[_STD_FLAG]
+    assert dec.disposition is GraduationDisposition.AUTO_FLIP
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Boot applier: env-precedence + idempotent + STANDARD-only
+# ---------------------------------------------------------------------------
+
+
+def test_applier_respects_env_precedence():
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_no_ast_drift,
+    )
+    execute_graduations(report)
+
+    # Operator explicitly set it false — applier must NOT overwrite.
+    env = {_STD_FLAG: "false"}
+    applied = gol.apply_overrides_to_environ(env)
+    assert _STD_FLAG not in applied
+    assert env[_STD_FLAG] == "false"
+
+
+def test_applier_idempotent():
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_no_ast_drift,
+    )
+    execute_graduations(report)
+    env: dict = {}
+    first = gol.apply_overrides_to_environ(env)
+    second = gol.apply_overrides_to_environ(env)
+    assert _STD_FLAG in first
+    # Second pass: already present → not re-applied.
+    assert _STD_FLAG not in second
+    assert env[_STD_FLAG] == "true"
+
+
+def test_applier_gated_off_is_inert(monkeypatch):
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_no_ast_drift,
+    )
+    execute_graduations(report)
+    monkeypatch.setenv("JARVIS_GRADUATION_OVERRIDE_APPLY_ENABLED", "false")
+    monkeypatch.setenv(
+        "JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED", "false",
+    )
+    env: dict = {}
+    applied = gol.apply_overrides_to_environ(env)
+    assert applied == ()
+    assert env == {}
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Receipts: immutable JSONL round-trip with sha + authorized_by
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_round_trips_with_evidence_and_sha():
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_no_ast_drift,
+    )
+    execute_graduations(report)
+    overrides = gol.all_overrides()
+    rec = [o for o in overrides if o.flag_name == _STD_FLAG][0]
+    assert rec.authorized_true is True
+    assert rec.authorized_by == "autonomous_graduation_engine"
+    assert rec.evidence_sha256
+    assert isinstance(rec.evidence, dict)
+    assert rec.tier == GraduationTier.STANDARD.value
+
+    # On-disk row is valid JSON with the receipt fields.
+    path = Path(os.environ["JARVIS_GRADUATION_OVERRIDE_LEDGER_PATH"])
+    rows = [
+        json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()
+    ]
+    row = [r for r in rows if r["flag_name"] == _STD_FLAG][0]
+    assert row["authorized_true"] is True
+    assert row["evidence_sha256"]
+    assert row["authorized_by"] == "autonomous_graduation_engine"
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — never-raises / master-off / pins
+# ---------------------------------------------------------------------------
+
+
+def test_master_off_returns_disabled_report(monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED", "false",
+    )
+    assert autonomous_graduation_engine_enabled() is False
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_no_ast_drift,
+    )
+    assert report.auto_flipped == ()
+    assert report.advisories == ()
+    for d in report.decisions:
+        assert d.disposition is GraduationDisposition.DISABLED
+
+
+def test_broken_ledger_never_raises():
+    class _Boom:
+        def eligible_flags(self):
+            raise RuntimeError("boom")
+
+        def progress(self, _):
+            raise RuntimeError("boom")
+
+    report = evaluate_graduations(
+        ledger=_Boom(),
+        registry=_stub_registry(),
+        validate_all_fn=_no_ast_drift,
+    )
+    assert isinstance(report, GraduationEngineReport)
+    assert report.auto_flipped == ()
+
+
+def test_broken_registry_never_raises():
+    class _BoomReg:
+        def get_spec(self, _):
+            raise RuntimeError("boom")
+
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_BoomReg(),
+        validate_all_fn=_no_ast_drift,
+    )
+    assert isinstance(report, GraduationEngineReport)
+    # Unknown spec → held, never auto-flipped.
+    assert _STD_FLAG not in report.auto_flipped
+
+
+def test_record_graduation_never_raises_on_garbage():
+    assert gol.record_graduation(None) is False
+    assert gol.record_graduation("not a decision") is False
+
+
+def test_report_to_dict_is_serializable():
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_no_ast_drift,
+    )
+    d = report.to_dict()
+    json.dumps(d)  # must not raise
+    assert d["schema_version"]
+
+
+# ---------------------------------------------------------------------------
+# Slice 96 review fixes — FAIL-CLOSED regression pins
+# ---------------------------------------------------------------------------
+
+
+class _SpecReg:
+    """Registry stub returning ONE spec with a chosen category (incl.
+    None / a garbage non-Category value) — for the fail-closed tier test."""
+
+    def __init__(self, flag, category, source_file):
+        self._flag = flag
+        self._spec = SimpleNamespace(
+            name=flag, type=FlagType.BOOL, default=False,
+            description="stub", category=category, source_file=source_file,
+        )
+
+    def get_spec(self, name):
+        return self._spec if name == self._flag else None
+
+
+@pytest.mark.parametrize("bad_category", [None, "garbage_not_a_category",
+                                          SimpleNamespace(value="totally_unknown")])
+def test_unknown_category_fails_closed_to_safety(bad_category):
+    """An eligible, AST-clean flag whose category is None / a forged /
+    unregistered value MUST NOT auto-flip. Fail-CLOSED: unknown category
+    → SAFETY tier → APPROVAL_ADVISORY, never the override ledger."""
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_SpecReg(_STD_FLAG, bad_category, _STD_SRC),
+        validate_all_fn=_no_ast_drift,
+    )
+    dec = {d.flag_name: d for d in report.decisions}[_STD_FLAG]
+    assert dec.tier is GraduationTier.SAFETY, dec.evidence
+    assert dec.disposition is GraduationDisposition.APPROVAL_ADVISORY
+    assert _STD_FLAG not in report.auto_flipped
+    # And it can never reach the override ledger.
+    execute_graduations(report)
+    assert all(o.flag_name != _STD_FLAG for o in gol.all_overrides())
+
+
+def test_ast_validator_unavailable_holds_all_failclosed():
+    """If shipped_code_invariants.validate_all() itself RAISES, Gate B
+    cannot prove AST stability → every candidate HOLDs (fail-CLOSED).
+    The prior empty-set swallow waved every flag through (fail-OPEN)."""
+    def _boom_validate():
+        raise RuntimeError("validator exploded")
+
+    report = evaluate_graduations(
+        ledger=_StubLedger([_STD_FLAG]),
+        registry=_stub_registry(),
+        validate_all_fn=_boom_validate,
+    )
+    dec = {d.flag_name: d for d in report.decisions}[_STD_FLAG]
+    assert dec.disposition is GraduationDisposition.HOLD
+    assert dec.evidence.get("hold_reason") == HoldReason.AST_DRIFT.value
+    assert dec.evidence.get("gate_b_validator_unavailable") is True
+    assert _STD_FLAG not in report.auto_flipped
+
+
+# ---------------------------------------------------------------------------
+# AST pins — canonical pass + synthetic regression per pin
+# ---------------------------------------------------------------------------
+
+
+def _engine_source():
+    import backend.core.ouroboros.governance.autonomous_graduation_engine as m
+    return Path(m.__file__).read_text(encoding="utf-8")
+
+
+def _run_pins():
+    pins = register_shipped_invariants()
+    src = _engine_source()
+    tree = ast.parse(src)
+    out = {}
+    for p in pins:
+        out[p.invariant_name] = p.validate(tree, src)
+    return out
+
+
+def test_ast_pins_canonical_pass():
+    results = _run_pins()
+    assert results, "engine must register at least one shipped invariant"
+    for name, violations in results.items():
+        assert violations == (), f"{name} should pass on canonical: {violations}"
+
+
+def test_pin_authority_asymmetry_regresses():
+    pins = {p.invariant_name: p for p in register_shipped_invariants()}
+    pin = [p for n, p in pins.items() if "authority" in n][0]
+    bad = (
+        "from backend.core.ouroboros.governance.orchestrator import X\n"
+    )
+    assert pin.validate(ast.parse(bad), bad) != ()
+
+
+def test_pin_master_default_false_regresses():
+    pins = {p.invariant_name: p for p in register_shipped_invariants()}
+    pin = [p for n, p in pins.items() if "master" in n][0]
+    bad = (
+        "def autonomous_graduation_engine_enabled():\n"
+        "    return True\n"
+    )
+    assert pin.validate(ast.parse(bad), bad) != ()
+
+
+def test_pin_tier_enum_closed_regresses():
+    pins = {p.invariant_name: p for p in register_shipped_invariants()}
+    pin = [p for n, p in pins.items() if "tier" in n or "enum" in n][0]
+    bad = (
+        "class GraduationTier:\n"
+        "    STANDARD = 'standard'\n"
+        "    SAFETY = 'safety'\n"
+        "    BACKDOOR = 'backdoor'\n"
+    )
+    assert pin.validate(ast.parse(bad), bad) != ()
+
+
+def test_pin_composes_canonical_regresses():
+    pins = {p.invariant_name: p for p in register_shipped_invariants()}
+    pin = [p for n, p in pins.items() if "composes" in n][0]
+    bad = "x = 1\n"  # references none of the canonical substrates
+    assert pin.validate(ast.parse(bad), bad) != ()
+
+
+# ---------------------------------------------------------------------------
+# FlagRegistry seed integration
+# ---------------------------------------------------------------------------
+
+
+def test_register_flags_installs_master_and_apply_flags():
+    reg = FlagRegistry()
+    n = register_flags(reg)
+    assert n >= 2
+    assert reg.get_spec("JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED")
+    assert reg.get_spec("JARVIS_GRADUATION_OVERRIDE_APPLY_ENABLED")
+    # Master defaults FALSE per §33.1.
+    spec = reg.get_spec("JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED")
+    assert spec.default is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — LIVE readout (first automated readout; honest, no auto-fix)
+# ---------------------------------------------------------------------------
+
+
+def test_live_readout(capsys):
+    """Run the engine against the REAL ledger + populated registry and
+    PRINT the decisions. This is the first automated graduation readout
+    — reported honestly. Always passes (it's a readout, not a gate)."""
+    from backend.core.ouroboros.governance.adaptation.graduation_ledger import (  # noqa: E501
+        GraduationLedger,
+    )
+    from backend.core.ouroboros.governance.flag_registry import ensure_seeded
+
+    live_ledger = GraduationLedger()
+    live_registry = ensure_seeded()
+    report = evaluate_graduations(
+        ledger=live_ledger,
+        registry=live_registry,
+    )
+    lines = ["", "=== Slice 96 LIVE GRADUATION READOUT ==="]
+    lines.append(f"eligible candidates: {len(report.decisions)}")
+    lines.append(f"auto_flipped (STANDARD): {list(report.auto_flipped)}")
+    lines.append(f"advisories (SAFETY):     {list(report.advisories)}")
+    for d in report.decisions:
+        lines.append(
+            f"  {d.flag_name} tier={d.tier.value} "
+            f"disp={d.disposition.value} delta={d.delta!r}"
+        )
+    print("\n".join(lines))
+    captured = capsys.readouterr()
+    assert "LIVE GRADUATION READOUT" in captured.out
+    # Structural sanity: every decision is a valid disposition.
+    for d in report.decisions:
+        assert d.disposition in set(GraduationDisposition)


### PR DESCRIPTION
Automates §33.1 master-flag graduation **evaluation** while STRUCTURALLY respecting the §1 zero-order-doll invariant: a safety/governance capability is **never auto-activated without operator approval**. Composes the existing graduation substrate (8 contracts + `unified_graduation_dashboard` + `GraduationLedger` + `shipped_code_invariants.validate_all` + `governance_boundary_gate`) — no reimplemented logic, **no source mutation**.

## How it works
- **`evaluate_graduations()`** — candidate set = `GraduationLedger.eligible_flags()`. Mathematically-absolute, AND-composed decision matrix; ANY gate fail → HOLD with a precise delta:
  - **Gate A** telemetry: in `eligible_flags()` (clean-session/zero-regression, already computed)
  - **Gate B** AST: `validate_all()` has zero `InvariantViolation` on the flag's `source_file`
  - **Gate C** contract: matching dashboard contract verdict READY (vacuous if none)
- **Tier (data-driven, no hardcoded list)**: `FlagSpec.category is Category.SAFETY` → **SAFETY → APPROVAL_ADVISORY**; else **STANDARD → AUTO_FLIP**.
- **`execute_graduations()`**: AUTO_FLIP → immutable override receipt; APPROVAL_ADVISORY → receipt-backed advisory. Never writes source, never auto-flips SAFETY.
- **`graduation_override_ledger.py`**: durable `.jarvis/graduation_overrides.jsonl` (sha256-evidenced receipts) + `apply_overrides_to_environ()` boot applier — injects authorized STANDARD flags into `os.environ` only when not already operator-set (**env-precedence**), the sanctioned opt-in channel that **honors the hash-cap with zero source edits**. SAFETY flags structurally cannot reach this ledger (3 independent barriers).

## Review caught two fail-OPEN holes → flipped to fail-CLOSED (the §1-forbidden shortcut class)
- **Unknown/None/forged `FlagSpec.category`** previously → STANDARD → auto-flip. Now STANDARD requires **positive recognition** as a known non-SAFETY `Category`; anything else → SAFETY → advisory.
- **`validate_all()` RAISING** previously swallowed to `()` (looked clean) → auto-flip. Now → `None` UNAVAILABLE sentinel → **Gate B HOLDs every candidate** (cannot prove stability → refuse).

## Safety + tests
§33.1 master + apply gate both **default-FALSE**; authority-asymmetry AST-pinned; never-raises. **26 tests** (incl. 4 fail-closed regression pins + the forged-SAFETY-decision refusal) + **177 adjacent regression** green. Independently reviewed (3 SAFETY barriers + unknown-category + AST-unavailable + env-precedence probes).

**First LIVE readout: 0 candidates** — the graduation ledger is dormant (no clean-session evidence yet), so nothing flipped. The engine is wired and waiting for real telemetry, exactly as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a telemetry-driven graduation engine that auto-flips STANDARD flags and routes SAFETY flags to operator advisory. Uses durable receipts and an env-based delivery path, never editing source defaults.

- **New Features**
  - `evaluate_graduations()` uses `GraduationLedger.eligible_flags()` with three gates: telemetry, `shipped_code_invariants.validate_all` (AST), and `unified_graduation_dashboard` contracts.
  - Tiering: `Category.SAFETY` → advisory; non-safety → auto-flip. `governance_boundary_gate` corroborates safety.
  - Delivery: writes STANDARD overrides to `.jarvis/graduation_overrides.jsonl` via `graduation_override_ledger`; boot applier injects into `os.environ` and honors operator env precedence.
  - Defaults off; enable with `JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED`. Optional applier gate `JARVIS_GRADUATION_OVERRIDE_APPLY_ENABLED`.

- **Bug Fixes**
  - Unknown or forged `FlagSpec.category` now fails closed to SAFETY; STANDARD requires positive recognition as a known non-safety category.
  - If `shipped_code_invariants.validate_all()` raises, Gate B holds all candidates (fail-closed) instead of treating the run as clean.

<sup>Written for commit f5437c92868d1aa107fbbbe9460095620b1e7f9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

