### PR TITLE
feat(cross-repo): Slice 97 Stage 1 — signed cross-repo ripple emitter + portable verification contract

### DIFF
--- a/backend/core/ouroboros/cross_repo_mesh/__init__.py
+++ b/backend/core/ouroboros/cross_repo_mesh/__init__.py
@@ -1,0 +1,18 @@
+"""Cross-repo distributed event mesh (Slice 97).
+
+PREDICTIONS, NOT REQUESTS: JARVIS asynchronously EMITS a cryptographically
+signed NOTIFICATION ("ripple") when its state changes. A consumer repo
+INDEPENDENTLY VERIFIES the signature + replay + freshness, then DECIDES
+what to do — it NEVER executes JARVIS-dictated remote code.
+
+Two layers:
+
+  * ``ripple_contract`` — PORTABLE, stdlib-only verification contract.
+    Vendored verbatim into jarvis-prime + reactor-core (which cannot
+    import ``backend.core.ouroboros.*``).  Implements the identical
+    HMAC-SHA256 wire format used by ``aegis.lease``.
+
+  * ``ripple_emitter`` — JARVIS-side signer that composes the existing
+    crypto substrate and publishes durable, signed receipts.
+"""
+from __future__ import annotations

--- a/backend/core/ouroboros/cross_repo_mesh/ripple_contract.py
+++ b/backend/core/ouroboros/cross_repo_mesh/ripple_contract.py
@@ -1,0 +1,347 @@
+"""Portable cross-repo ripple verification contract (Slice 97 Stage 1).
+
+PREDICTIONS, NOT REQUESTS
+=========================
+
+A "ripple" is a cryptographically-signed NOTIFICATION that one repo's
+state changed (a contract rule merged, a capability graduated, a
+constitutional rule landed).  A consumer repo INDEPENDENTLY VERIFIES the
+signature, replay, origin and freshness, then DECIDES what to do.  It
+NEVER executes anything the ripple says.  ``verify_ripple`` returns a
+*verdict + decoded notification* — nothing more.  A forged or replayed
+ripple can never trigger remote code: there is no exec path here.
+
+PORTABILITY (load-bearing)
+==========================
+
+jarvis-prime and reactor-core are SEPARATE repos that CANNOT import
+``backend.core.ouroboros.*``.  The "independent verification" security
+model REQUIRES each repo to verify on its own.  So this file is
+STDLIB-ONLY (``hmac``/``hashlib``/``json``/``base64``/``time``/``secrets``/
+``enum``/``dataclasses``/``typing``) and is COPYABLE verbatim into a
+non-JARVIS repo.  There are NO ``backend.*`` imports.
+
+This is NOT "rewriting the crypto library."  It is a ~stdlib HMAC-verify
+contract that 3 repos share by VENDORING (copying).  The wire format is
+byte-identical to ``backend/core/ouroboros/aegis/lease.py``:
+
+    <b64url(compact-json-payload)>.<b64url(HMAC-SHA256(K, payload_b64))>
+
+  * compact JSON: ``json.dumps(d, separators=(",", ":"), sort_keys=True)``
+  * the HMAC signs the *encoded* payload bytes (defends against any future
+    JSON canonicalization drift between sign and verify)
+  * constant-time signature compare (``hmac.compare_digest``)
+
+A cross-compat test proves a payload signed by JARVIS (via
+``ripple_emitter`` / ``aegis.lease._encode_token``) verifies VERIFIED
+under this portable ``verify_ripple``.
+
+NO EXEC PATH: this module contains no ``eval``/``exec``/``subprocess``/
+dynamic import.  ``ripple_kind`` and ``intent`` are plain STRINGS that
+describe WHAT changed; they are never invoked.
+"""
+from __future__ import annotations
+
+import base64
+import enum
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, Sequence, Set, Tuple
+
+
+RIPPLE_SCHEMA_VERSION: str = "cross_repo_ripple.1"
+
+
+# ---------------------------------------------------------------------------
+# Ripple kind — closed taxonomy. STRINGS describing WHAT changed (never code).
+# ---------------------------------------------------------------------------
+
+
+class RippleKind(str, enum.Enum):
+    """Closed taxonomy of cross-repo state-change notifications.
+
+    Each value is a plain description of WHAT changed in the source repo.
+    A consumer reads the kind to DECIDE what to do; it is never executed.
+    """
+
+    CONTRACT_CHANGED = "contract_changed"
+    CAPABILITY_GRADUATED = "capability_graduated"
+    CONSTITUTIONAL_RULE_MERGED = "constitutional_rule_merged"
+
+
+# ---------------------------------------------------------------------------
+# Verify verdict — closed taxonomy. Failures are SILENT DROPS (never raise).
+# ---------------------------------------------------------------------------
+
+
+class VerifyVerdict(str, enum.Enum):
+    """Closed verdict set for ripple verification.
+
+    Anything other than ``VERIFIED`` is a SILENT DROP — the consumer takes
+    no action and does not raise.  This is the whole security model: a
+    compromised/forged/replayed ripple yields a drop verdict, never code
+    execution.
+    """
+
+    VERIFIED = "verified"
+    DROPPED_BAD_SIGNATURE = "dropped_bad_signature"
+    DROPPED_MALFORMED = "dropped_malformed"
+    DROPPED_REPLAY = "dropped_replay"
+    DROPPED_EXPIRED = "dropped_expired"
+    DROPPED_WRONG_ORIGIN = "dropped_wrong_origin"
+    DISABLED = "disabled"
+
+
+# ---------------------------------------------------------------------------
+# Ripple payload — the signed NOTIFICATION.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RipplePayload:
+    """Immutable signed-notification payload.
+
+    Fields are descriptive strings/numbers only — never code/commands.
+
+      * ``ripple_kind`` / ``intent`` — STRINGS describing WHAT changed.
+      * ``payload_sha256`` — hex digest of the canonical underlying object
+        (so a consumer can correlate without trusting the ripple).
+      * ``nonce`` — replay-protection token.
+      * ``issued_at_unix`` / ``ttl_s`` — freshness window.
+    """
+
+    schema_version: str
+    ripple_kind: str
+    source_repo: str
+    intent: str
+    payload_sha256: str
+    nonce: str
+    issued_at_unix: float
+    ttl_s: float
+
+    def to_canonical_dict(self) -> Dict[str, Any]:
+        """Deterministic dict (sorted keys via the codec) for signing."""
+        return {
+            "schema_version": self.schema_version,
+            "ripple_kind": self.ripple_kind,
+            "source_repo": self.source_repo,
+            "intent": self.intent,
+            "payload_sha256": self.payload_sha256,
+            "nonce": self.nonce,
+            "issued_at_unix": self.issued_at_unix,
+            "ttl_s": self.ttl_s,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "RipplePayload":
+        """Lossless reconstruction. Raises on a malformed dict — callers in
+        ``verify_ripple`` wrap this so verification never raises."""
+        return cls(
+            schema_version=str(d["schema_version"]),
+            ripple_kind=str(d["ripple_kind"]),
+            source_repo=str(d["source_repo"]),
+            intent=str(d["intent"]),
+            payload_sha256=str(d["payload_sha256"]),
+            nonce=str(d["nonce"]),
+            issued_at_unix=float(d["issued_at_unix"]),
+            ttl_s=float(d["ttl_s"]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wire codec — IDENTICAL to aegis.lease (vendored, stdlib-only).
+# ---------------------------------------------------------------------------
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    pad = (-len(s)) % 4
+    return base64.urlsafe_b64decode(s + ("=" * pad))
+
+
+def _canonical_json(payload: Dict[str, Any]) -> bytes:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _sign(psk: bytes, payload_b64: str) -> str:
+    mac = hmac.new(psk, payload_b64.encode("ascii"), hashlib.sha256).digest()
+    return _b64url_encode(mac)
+
+
+def sign_ripple(payload: RipplePayload, psk: bytes) -> str:
+    """Build the wire token: ``b64url(canonical-json).b64url(HMAC-SHA256)``.
+
+    Pure stdlib HMAC — identical wire format to ``aegis.lease._encode_token``.
+    ``psk`` is ``bytes`` (the cross-repo pre-shared key); never module-level.
+    """
+    payload_b64 = _b64url_encode(_canonical_json(payload.to_canonical_dict()))
+    sig_b64 = _sign(psk, payload_b64)
+    return f"{payload_b64}.{sig_b64}"
+
+
+# ---------------------------------------------------------------------------
+# Bounded replay-protection helper (optional — caller may inject a set).
+# ---------------------------------------------------------------------------
+
+
+class NonceSeen:
+    """Tiny bounded set of seen nonces (drop-oldest). Stdlib-only.
+
+    Mirrors ``aegis.lease.NonceLedger`` semantics in a vendorable form.
+    ``register`` returns True if the nonce was newly seen, False if it was
+    already present (replay).
+    """
+
+    def __init__(self, *, capacity: int = 8192) -> None:
+        if capacity < 1:
+            raise ValueError("NonceSeen capacity must be >= 1")
+        self._capacity = int(capacity)
+        self._set: Set[str] = set()
+        self._order: list = []
+
+    def __contains__(self, nonce: object) -> bool:
+        return nonce in self._set
+
+    def add(self, nonce: str) -> None:
+        # Set-like surface so an injected ``set`` is interchangeable.
+        self.register(nonce)
+
+    def register(self, nonce: str) -> bool:
+        if nonce in self._set:
+            return False
+        self._set.add(nonce)
+        self._order.append(nonce)
+        while len(self._order) > self._capacity:
+            evicted = self._order.pop(0)
+            self._set.discard(evicted)
+        return True
+
+    def __len__(self) -> int:
+        return len(self._order)
+
+
+def _mark_seen(seen: Any, nonce: str) -> bool:
+    """Register ``nonce`` into a seen-collection. Returns True if newly
+    seen (accept), False if already present (replay).
+
+    Accepts either a plain ``set`` (or set-like) or a ``NonceSeen``.
+    """
+    if seen is None:
+        return True
+    register = getattr(seen, "register", None)
+    if callable(register):
+        return bool(register(nonce))
+    # Plain set / set-like.
+    if nonce in seen:
+        return False
+    try:
+        seen.add(nonce)
+    except Exception:
+        # Unwritable seen-collection: treat as not-replayed for this call
+        # rather than raising (verify_ripple never raises). The caller's
+        # own ledger is the durable authority.
+        return True
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Verification — verdict + decoded NOTIFICATION only. NEVER raises, NEVER execs.
+# ---------------------------------------------------------------------------
+
+
+def verify_ripple(
+    token: str,
+    psk: bytes,
+    *,
+    now_unix: float,
+    seen_nonces: Optional[Any] = None,
+    expected_origins: Optional[Sequence[str]] = None,
+) -> Tuple[VerifyVerdict, Optional[RipplePayload]]:
+    """Independently verify a ripple token.
+
+    Order of checks (first failure wins):
+
+      1. parse token (``<b64>.<b64>``)            → DROPPED_MALFORMED
+      2. HMAC constant-time compare with ``psk``  → DROPPED_BAD_SIGNATURE
+      3. origin in ``expected_origins`` (if given)→ DROPPED_WRONG_ORIGIN
+      4. ``now_unix`` within [issued_at, issued_at+ttl] → DROPPED_EXPIRED
+      5. nonce not already in ``seen_nonces``     → DROPPED_REPLAY
+      else                                        → (VERIFIED, payload)
+
+    NEVER raises (any internal error → DROPPED_MALFORMED).  NEVER executes
+    anything: returns a verdict + the decoded NOTIFICATION only.  The
+    payload's ``intent`` is a plain string that is never invoked.
+
+    ``seen_nonces`` may be a plain ``set``, a set-like object, or a
+    ``NonceSeen``.  On VERIFIED the nonce is registered (so a second verify
+    of the same token returns DROPPED_REPLAY).  Registration happens LAST,
+    only after every other check passes — a malformed/forged/expired/wrong-
+    origin ripple never pollutes the replay ledger.
+    """
+    try:
+        # (1) Structural parse.
+        if not isinstance(token, str) or token.count(".") != 1:
+            return VerifyVerdict.DROPPED_MALFORMED, None
+        payload_b64, sig_b64 = token.split(".", 1)
+        if not payload_b64 or not sig_b64:
+            return VerifyVerdict.DROPPED_MALFORMED, None
+
+        # (2) Signature (constant-time) BEFORE decoding the payload — we
+        # never parse fields out of an unauthenticated payload.
+        if not isinstance(psk, (bytes, bytearray)):
+            return VerifyVerdict.DROPPED_MALFORMED, None
+        expected_sig = _sign(bytes(psk), payload_b64)
+        if not hmac.compare_digest(expected_sig, sig_b64):
+            return VerifyVerdict.DROPPED_BAD_SIGNATURE, None
+
+        # Decode the (now-authenticated) payload.
+        try:
+            raw = _b64url_decode(payload_b64)
+            obj = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return VerifyVerdict.DROPPED_MALFORMED, None
+        if not isinstance(obj, dict):
+            return VerifyVerdict.DROPPED_MALFORMED, None
+        try:
+            payload = RipplePayload.from_dict(obj)
+        except (KeyError, ValueError, TypeError):
+            return VerifyVerdict.DROPPED_MALFORMED, None
+
+        # (3) Origin.
+        if expected_origins is not None:
+            allowed: Iterable[str] = expected_origins
+            if payload.source_repo not in set(allowed):
+                return VerifyVerdict.DROPPED_WRONG_ORIGIN, None
+
+        # (4) Freshness window [issued_at, issued_at + ttl].
+        issued = payload.issued_at_unix
+        expires = issued + payload.ttl_s
+        if now_unix < issued or now_unix > expires:
+            return VerifyVerdict.DROPPED_EXPIRED, None
+
+        # (5) Replay — registered LAST, only on otherwise-valid ripples.
+        if not _mark_seen(seen_nonces, payload.nonce):
+            return VerifyVerdict.DROPPED_REPLAY, None
+
+        # Verified NOTIFICATION. No execution — verdict + payload only.
+        return VerifyVerdict.VERIFIED, payload
+    except Exception:
+        # Absolute never-raise guarantee: any unexpected internal error is
+        # a silent drop, never a raise and never an execution.
+        return VerifyVerdict.DROPPED_MALFORMED, None
+
+
+__all__ = [
+    "RIPPLE_SCHEMA_VERSION",
+    "RippleKind",
+    "VerifyVerdict",
+    "RipplePayload",
+    "NonceSeen",
+    "sign_ripple",
+    "verify_ripple",
+]

--- a/backend/core/ouroboros/cross_repo_mesh/ripple_emitter.py
+++ b/backend/core/ouroboros/cross_repo_mesh/ripple_emitter.py
@@ -1,0 +1,392 @@
+"""JARVIS-side signed cross-repo ripple emitter (Slice 97 Stage 1).
+
+Composes the EXISTING crypto substrate; does not rewrite it.
+
+  * Signs via the portable contract's ``sign_ripple`` (which is the
+    byte-identical HMAC-SHA256 wire format of ``aegis.lease._encode_token``;
+    a cross-compat test proves emitter output verifies under the portable
+    ``verify_ripple`` AND that ``aegis.lease._encode_token`` of the same
+    canonical dict produces the same token).
+  * Resolves the cross-repo PSK from env (``JARVIS_CROSS_REPO_EMIT_PSK``) —
+    never module-level.
+  * Publishes a durable, immutable receipt to ``.jarvis/cross_repo_ripples.jsonl``
+    and best-effort onto the existing ``CrossRepoEventBus``.
+
+PREDICTIONS, NOT REQUESTS: the emitted ripple is a NOTIFICATION carrying
+STRINGS (kind/intent/hash), never code.  Consumers verify + decide; they
+never execute.
+
+§33.1: master flag ``JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED`` default-FALSE.
+When off, ``emit_ripple`` is inert (returns a DISABLED EmitResult, writes
+nothing).
+
+Authority-asymmetry: this module imports stdlib + the portable contract +
+(lazy) ``aegis.lease`` / ``cross_repo``.  It NEVER imports orchestrator /
+iron_gate / policy / change_engine / auto_committer.  Async, never-raises,
+best-effort.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import secrets
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from backend.core.ouroboros.cross_repo_mesh.ripple_contract import (
+    RIPPLE_SCHEMA_VERSION,
+    RipplePayload,
+    VerifyVerdict,
+    sign_ripple,
+)
+
+logger = logging.getLogger("Ouroboros.CrossRepoMesh.Emitter")
+
+
+# §33.1 master flag — default FALSE.
+_MASTER_FLAG = "JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED"
+_PSK_ENV = "JARVIS_CROSS_REPO_EMIT_PSK"
+_DEFAULT_TTL_S = 3600.0
+_DEFAULT_LEDGER = ".jarvis/cross_repo_ripples.jsonl"
+
+
+def _emit_enabled() -> bool:
+    return os.getenv(_MASTER_FLAG, "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _resolve_psk() -> Optional[bytes]:
+    """Resolve the cross-repo PSK from env. ``bytes`` — never module-level.
+
+    Returns ``None`` if unset/empty (emitter then no-ops rather than signing
+    with a degenerate key).
+    """
+    raw = os.getenv(_PSK_ENV, "")
+    if not raw:
+        return None
+    return raw.encode("utf-8")
+
+
+def _ledger_path() -> Path:
+    return Path(os.getenv("JARVIS_CROSS_REPO_RIPPLE_LEDGER", _DEFAULT_LEDGER))
+
+
+# ---------------------------------------------------------------------------
+# Result type.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EmitResult:
+    """Outcome of an emit attempt. Best-effort; carries provenance only."""
+
+    verdict: VerifyVerdict
+    token: Optional[str] = None
+    nonce: Optional[str] = None
+    ripple_kind: Optional[str] = None
+    ledger_written: bool = False
+    bus_published: bool = False
+    detail: Optional[str] = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Builder — deterministic given now_unix; fresh nonce per ripple.
+# ---------------------------------------------------------------------------
+
+
+def _canonical_payload_sha256(payload_obj: Any) -> str:
+    """SHA-256 over the canonical JSON of the underlying changed object.
+
+    Deterministic (sorted keys, compact separators). Non-JSON-able objects
+    fall back to ``repr`` so the builder never raises.
+    """
+    try:
+        raw = json.dumps(
+            payload_obj, separators=(",", ":"), sort_keys=True, default=str
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        raw = repr(payload_obj).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def build_ripple(
+    kind: Any,
+    intent: str,
+    payload_obj: Any,
+    *,
+    now_unix: float,
+    source_repo: str = "jarvis",
+    ttl_s: float = _DEFAULT_TTL_S,
+) -> RipplePayload:
+    """Build a ``RipplePayload`` notification.
+
+    Computes ``payload_sha256`` over the canonical underlying object and a
+    fresh ``nonce`` (``secrets.token_hex``).  ``now_unix`` is injected (no
+    hidden ``time.time()`` nondeterminism, so tests can pin freshness).
+
+    ``kind`` accepts a ``RippleKind`` enum or a plain string — both are
+    normalized to the string value (the ripple carries a STRING, never code).
+    """
+    kind_str = getattr(kind, "value", kind)
+    return RipplePayload(
+        schema_version=RIPPLE_SCHEMA_VERSION,
+        ripple_kind=str(kind_str),
+        source_repo=str(source_repo),
+        intent=str(intent),
+        payload_sha256=_canonical_payload_sha256(payload_obj),
+        nonce=secrets.token_hex(16),
+        issued_at_unix=float(now_unix),
+        ttl_s=float(ttl_s),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Durable immutable receipt (append-only JSONL).
+# ---------------------------------------------------------------------------
+
+
+def _write_receipt(token: str, payload: RipplePayload) -> bool:
+    """Append an immutable receipt line. Best-effort; never raises."""
+    try:
+        path = _ledger_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        receipt = {
+            "token": token,
+            "ripple_kind": payload.ripple_kind,
+            "source_repo": payload.source_repo,
+            "nonce": payload.nonce,
+            "issued_at_unix": payload.issued_at_unix,
+            "ttl_s": payload.ttl_s,
+            "payload_sha256": payload.payload_sha256,
+            "schema_version": payload.schema_version,
+            "recorded_at_unix": time.time(),
+        }
+        line = json.dumps(receipt, separators=(",", ":"), sort_keys=True)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+        return True
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("ripple receipt write failed: %s", exc)
+        return False
+
+
+async def _publish_bus(token: str, payload: RipplePayload) -> bool:
+    """Best-effort publish onto the existing CrossRepoEventBus. Never raises.
+
+    Lazy import — keeps the emitter's import graph free of the file-bus at
+    module load and preserves authority asymmetry.
+    """
+    try:
+        from backend.core.ouroboros.cross_repo import (
+            CrossRepoEvent,
+            CrossRepoEventBus,
+            EventType,
+            RepoType,
+        )
+
+        bus = CrossRepoEventBus()
+        event = CrossRepoEvent(
+            id=f"ripple_{payload.nonce[:12]}",
+            type=EventType.CROSS_REPO_CORRELATION,
+            source_repo=RepoType.JARVIS,
+            target_repo=None,
+            payload={
+                "ripple_token": token,
+                "ripple_kind": payload.ripple_kind,
+                "schema_version": payload.schema_version,
+            },
+        )
+        await bus.emit(event)
+        return True
+    except Exception as exc:
+        logger.debug("ripple bus publish skipped/failed: %s", exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Emit — async, never-raises, best-effort.
+# ---------------------------------------------------------------------------
+
+
+async def emit_ripple(
+    payload: RipplePayload, *, publish_bus: bool = False
+) -> EmitResult:
+    """Sign + persist a ripple NOTIFICATION. Best-effort; never raises.
+
+    §33.1: inert when ``JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED`` is off —
+    returns a DISABLED result and writes nothing.
+
+    Signs via the portable ``sign_ripple`` (byte-identical to
+    ``aegis.lease._encode_token``).  The output verifies under the portable
+    ``verify_ripple`` — proven in the cross-compat test.
+    """
+    if not _emit_enabled():
+        return EmitResult(verdict=VerifyVerdict.DISABLED, detail="master_off")
+
+    psk = _resolve_psk()
+    if psk is None:
+        # No key → cannot sign. Treat as disabled (never raise, never emit
+        # an unsigned ripple).
+        return EmitResult(
+            verdict=VerifyVerdict.DISABLED, detail="psk_unset"
+        )
+
+    try:
+        token = sign_ripple(payload, psk)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("ripple sign failed: %s", exc)
+        return EmitResult(verdict=VerifyVerdict.DISABLED, detail=f"sign_error:{exc}")
+
+    ledger_written = _write_receipt(token, payload)
+
+    bus_published = False
+    if publish_bus:
+        bus_published = await _publish_bus(token, payload)
+
+    return EmitResult(
+        verdict=VerifyVerdict.VERIFIED,
+        token=token,
+        nonce=payload.nonce,
+        ripple_kind=payload.ripple_kind,
+        ledger_written=ledger_written,
+        bus_published=bus_published,
+        detail="emitted",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shipped-code invariants (mirrors the repo convention; never raises).
+# ---------------------------------------------------------------------------
+
+
+def register_shipped_invariants() -> list:
+    """AST pins for Slice 97 Stage 1. NEVER raises (returns [] on failure).
+
+    Pins:
+      1. ``ripple_contract_stdlib_only`` — the portable contract imports no
+         ``backend.*`` (so siblings can vendor it verbatim).
+      2. ``ripple_contract_no_exec`` — no eval/exec/subprocess/__import__ in
+         the portable contract (predictions, not requests).
+      3. ``emitter_authority_asymmetry`` — the emitter never imports
+         orchestrator/iron_gate/policy/change_engine/auto_committer.
+    """
+    try:
+        from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+            ShippedCodeInvariant,
+        )
+    except Exception:
+        return []
+
+    import ast as _ast
+
+    contract_target = (
+        "backend/core/ouroboros/cross_repo_mesh/ripple_contract.py"
+    )
+    emitter_target = (
+        "backend/core/ouroboros/cross_repo_mesh/ripple_emitter.py"
+    )
+
+    _BANNED_EMITTER_IMPORTS = (
+        "orchestrator",
+        "iron_gate",
+        "policy",
+        "change_engine",
+        "auto_committer",
+    )
+    _BANNED_EXEC_NAMES = {"eval", "exec", "compile", "__import__"}
+
+    def _validate_contract_stdlib_only(tree: _ast.AST, source: str) -> tuple:
+        del source
+        for node in _ast.walk(tree):
+            mod = None
+            if isinstance(node, _ast.ImportFrom):
+                mod = node.module or ""
+            elif isinstance(node, _ast.Import):
+                for alias in node.names:
+                    if alias.name.startswith("backend"):
+                        return (f"contract imports backend.*: {alias.name}",)
+                continue
+            if mod and mod.startswith("backend"):
+                return (f"contract imports backend.*: {mod}",)
+        return ()
+
+    def _validate_contract_no_exec(tree: _ast.AST, source: str) -> tuple:
+        del source
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.Call):
+                fn = node.func
+                if isinstance(fn, _ast.Name) and fn.id in _BANNED_EXEC_NAMES:
+                    return (f"contract has exec-family call: {fn.id}",)
+                if (
+                    isinstance(fn, _ast.Attribute)
+                    and isinstance(fn.value, _ast.Name)
+                    and fn.value.id == "subprocess"
+                ):
+                    return ("contract has subprocess call",)
+            if isinstance(node, (_ast.Import, _ast.ImportFrom)):
+                names = []
+                if isinstance(node, _ast.Import):
+                    names = [a.name for a in node.names]
+                else:
+                    names = [node.module or ""]
+                for n in names:
+                    if n.split(".")[0] == "subprocess":
+                        return ("contract imports subprocess",)
+        return ()
+
+    def _validate_emitter_authority(tree: _ast.AST, source: str) -> tuple:
+        del source
+        for node in _ast.walk(tree):
+            mods = []
+            if isinstance(node, _ast.ImportFrom):
+                mods = [node.module or ""]
+            elif isinstance(node, _ast.Import):
+                mods = [a.name for a in node.names]
+            for mod in mods:
+                for banned in _BANNED_EMITTER_IMPORTS:
+                    if mod.endswith(banned) or f".{banned}" in mod or mod == banned:
+                        return (f"emitter imports banned authority: {mod}",)
+        return ()
+
+    return [
+        ShippedCodeInvariant(
+            invariant_name="ripple_contract_stdlib_only",
+            target_file=contract_target,
+            description=(
+                "Portable ripple contract imports no backend.* (vendorable)."
+            ),
+            validate=_validate_contract_stdlib_only,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="ripple_contract_no_exec",
+            target_file=contract_target,
+            description=(
+                "Portable ripple contract has no exec/eval/subprocess path "
+                "(predictions, not requests)."
+            ),
+            validate=_validate_contract_no_exec,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="emitter_authority_asymmetry",
+            target_file=emitter_target,
+            description=(
+                "Emitter never imports orchestrator/iron_gate/policy/"
+                "change_engine/auto_committer."
+            ),
+            validate=_validate_emitter_authority,
+        ),
+    ]
+
+
+__all__ = [
+    "EmitResult",
+    "build_ripple",
+    "emit_ripple",
+    "register_shipped_invariants",
+]

--- a/tests/architecture/test_slice97_ripple_mesh.py
+++ b/tests/architecture/test_slice97_ripple_mesh.py
@@ -1,0 +1,476 @@
+"""Slice 97 Stage 1 — signed cross-repo ripple mesh.
+
+REAL crypto throughout (no mock HMAC). The "100% certainty the handshake
+holds, malformed/replayed/unauthorized DROPPED, zero false-positives"
+matrix:
+
+  1. valid handshake round-trips
+  2. tampered payload → DROPPED_BAD_SIGNATURE
+  3. wrong PSK → DROPPED_BAD_SIGNATURE
+  4. replay → DROPPED_REPLAY
+  5. expired / fresh
+  6. malformed → DROPPED_MALFORMED (never raises)
+  7. wrong origin → DROPPED_WRONG_ORIGIN
+  8. cross-compat (emitter + aegis.lease) + no-remote-exec
+  9. emitter master-off → DISABLED, writes nothing
+ 10. emitter on → immutable receipt, re-verify → VERIFIED
+ 11. never-raises on broken env / unwritable ledger
+
+Run:
+  JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED=true PYTHONPATH=. \
+    python3 -m pytest tests/architecture/test_slice97_ripple_mesh.py -v
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.cross_repo_mesh.ripple_contract import (
+    RIPPLE_SCHEMA_VERSION,
+    NonceSeen,
+    RippleKind,
+    RipplePayload,
+    VerifyVerdict,
+    sign_ripple,
+    verify_ripple,
+)
+from backend.core.ouroboros.cross_repo_mesh import ripple_emitter as emitter
+from backend.core.ouroboros.cross_repo_mesh.ripple_emitter import (
+    EmitResult,
+    build_ripple,
+    emit_ripple,
+)
+
+
+PSK_A = b"shared-secret-A-32-bytes-padding!"
+PSK_B = b"shared-secret-B-32-bytes-padding!"
+NOW = 1_000_000.0
+
+
+def _mk_payload(*, nonce: str = "nonce-1", source_repo: str = "jarvis",
+                issued_at: float = NOW, ttl_s: float = 3600.0) -> RipplePayload:
+    return RipplePayload(
+        schema_version=RIPPLE_SCHEMA_VERSION,
+        ripple_kind=RippleKind.CONTRACT_CHANGED.value,
+        source_repo=source_repo,
+        intent="contract rule R-17 merged; consumers may re-pin",
+        payload_sha256="a" * 64,
+        nonce=nonce,
+        issued_at_unix=issued_at,
+        ttl_s=ttl_s,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Valid handshake — round-trip integrity.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_handshake_round_trips():
+    payload = build_ripple(
+        RippleKind.CAPABILITY_GRADUATED,
+        "DirectionInferrer graduated to default-true",
+        {"flag": "JARVIS_DIRECTION_INFERRER_ENABLED", "value": True},
+        now_unix=NOW,
+    )
+    token = sign_ripple(payload, PSK_A)
+    verdict, got = verify_ripple(token, PSK_A, now_unix=NOW + 10)
+
+    assert verdict is VerifyVerdict.VERIFIED
+    assert got is not None
+    assert got.ripple_kind == RippleKind.CAPABILITY_GRADUATED.value
+    assert got.intent == "DirectionInferrer graduated to default-true"
+    assert got.payload_sha256 == payload.payload_sha256
+    assert got.nonce == payload.nonce
+    assert got.source_repo == "jarvis"
+
+
+# ---------------------------------------------------------------------------
+# 2. Tampered payload byte → DROPPED_BAD_SIGNATURE.
+# ---------------------------------------------------------------------------
+
+
+def test_tampered_payload_dropped_bad_signature():
+    payload = _mk_payload()
+    token = sign_ripple(payload, PSK_A)
+    payload_b64, sig_b64 = token.split(".", 1)
+    # Flip a character in the payload segment.
+    flipped = ("A" if payload_b64[5] != "A" else "B")
+    tampered = payload_b64[:5] + flipped + payload_b64[6:]
+    bad_token = f"{tampered}.{sig_b64}"
+
+    verdict, got = verify_ripple(bad_token, PSK_A, now_unix=NOW)
+    assert verdict is VerifyVerdict.DROPPED_BAD_SIGNATURE
+    assert got is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Wrong PSK → DROPPED_BAD_SIGNATURE.
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_psk_dropped_bad_signature():
+    token = sign_ripple(_mk_payload(), PSK_A)
+    verdict, got = verify_ripple(token, PSK_B, now_unix=NOW)
+    assert verdict is VerifyVerdict.DROPPED_BAD_SIGNATURE
+    assert got is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Replay → 2nd is DROPPED_REPLAY (shared seen-set).
+# ---------------------------------------------------------------------------
+
+
+def test_replay_dropped_second_time_plain_set():
+    token = sign_ripple(_mk_payload(nonce="replay-nonce"), PSK_A)
+    seen = set()
+    v1, p1 = verify_ripple(token, PSK_A, now_unix=NOW, seen_nonces=seen)
+    v2, p2 = verify_ripple(token, PSK_A, now_unix=NOW, seen_nonces=seen)
+    assert v1 is VerifyVerdict.VERIFIED and p1 is not None
+    assert v2 is VerifyVerdict.DROPPED_REPLAY and p2 is None
+
+
+def test_replay_dropped_second_time_nonceseen():
+    token = sign_ripple(_mk_payload(nonce="replay-nonce-2"), PSK_A)
+    seen = NonceSeen(capacity=16)
+    v1, _ = verify_ripple(token, PSK_A, now_unix=NOW, seen_nonces=seen)
+    v2, _ = verify_ripple(token, PSK_A, now_unix=NOW, seen_nonces=seen)
+    assert v1 is VerifyVerdict.VERIFIED
+    assert v2 is VerifyVerdict.DROPPED_REPLAY
+
+
+def test_failed_verify_does_not_pollute_replay_ledger():
+    # A bad-signature / wrong-origin / expired ripple must NOT register its
+    # nonce — otherwise an attacker could pre-burn a legitimate nonce.
+    good = _mk_payload(nonce="precious-nonce")
+    token = sign_ripple(good, PSK_A)
+    seen = set()
+    # Wrong PSK → bad sig; nonce never even decoded.
+    verify_ripple(token, PSK_B, now_unix=NOW, seen_nonces=seen)
+    # The legit verify still succeeds.
+    v, p = verify_ripple(token, PSK_A, now_unix=NOW, seen_nonces=seen)
+    assert v is VerifyVerdict.VERIFIED and p is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. Expired / fresh / not-yet.
+# ---------------------------------------------------------------------------
+
+
+def test_expired_dropped():
+    token = sign_ripple(_mk_payload(issued_at=NOW, ttl_s=100.0), PSK_A)
+    verdict, got = verify_ripple(token, PSK_A, now_unix=NOW + 101)
+    assert verdict is VerifyVerdict.DROPPED_EXPIRED
+    assert got is None
+
+
+def test_fresh_within_window_verified():
+    token = sign_ripple(_mk_payload(issued_at=NOW, ttl_s=100.0), PSK_A)
+    verdict, got = verify_ripple(token, PSK_A, now_unix=NOW + 50)
+    assert verdict is VerifyVerdict.VERIFIED
+    assert got is not None
+
+
+def test_not_yet_issued_dropped_expired():
+    token = sign_ripple(_mk_payload(issued_at=NOW, ttl_s=100.0), PSK_A)
+    verdict, got = verify_ripple(token, PSK_A, now_unix=NOW - 5)
+    assert verdict is VerifyVerdict.DROPPED_EXPIRED
+    assert got is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Malformed → DROPPED_MALFORMED, never raises.
+# ---------------------------------------------------------------------------
+
+
+# Structurally-malformed (not <b64>.<b64>): zero/2+ dots or empty segment →
+# DROPPED_MALFORMED before any crypto.
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "no-dot-at-all",
+        "too.many.dots",
+        ".",
+        "a.",
+        ".b",
+    ],
+)
+def test_malformed_dropped_never_raises(bad):
+    verdict, got = verify_ripple(bad, PSK_A, now_unix=NOW)
+    assert verdict is VerifyVerdict.DROPPED_MALFORMED
+    assert got is None
+
+
+# Single-dot junk that is structurally token-shaped but whose signature can
+# never match → DROPPED_BAD_SIGNATURE. Still a SILENT DROP (no raise, no
+# exec) — indistinguishable from a forged token, which is the point.
+@pytest.mark.parametrize("bad", ["@@@.@@@", "not-base64!.also-not!"])
+def test_token_shaped_junk_dropped_bad_signature(bad):
+    verdict, got = verify_ripple(bad, PSK_A, now_unix=NOW)
+    assert verdict is VerifyVerdict.DROPPED_BAD_SIGNATURE
+    assert got is None
+
+
+def test_all_garbage_inputs_are_silent_drops_never_raise():
+    # Whatever the bucket, every garbage input is a DROP verdict (never
+    # VERIFIED, never an exception).
+    for bad in ["", ".", "a.b.c", "@@@.@@@", "\x00\x01", "1234567890"]:
+        verdict, got = verify_ripple(bad, PSK_A, now_unix=NOW)
+        assert verdict is not VerifyVerdict.VERIFIED
+        assert got is None
+
+
+def test_malformed_non_string_token():
+    verdict, got = verify_ripple(None, PSK_A, now_unix=NOW)  # type: ignore[arg-type]
+    assert verdict is VerifyVerdict.DROPPED_MALFORMED
+    assert got is None
+
+
+def test_malformed_valid_sig_but_payload_not_ripple_shape():
+    # A correctly-signed token whose payload is missing ripple fields →
+    # DROPPED_MALFORMED (not bad-sig). Signed with PSK_A so sig passes.
+    from backend.core.ouroboros.cross_repo_mesh.ripple_contract import (
+        _b64url_encode,
+        _canonical_json,
+        _sign,
+    )
+
+    junk = {"hello": "world"}
+    pb = _b64url_encode(_canonical_json(junk))
+    token = f"{pb}.{_sign(PSK_A, pb)}"
+    verdict, got = verify_ripple(token, PSK_A, now_unix=NOW)
+    assert verdict is VerifyVerdict.DROPPED_MALFORMED
+    assert got is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Wrong origin → DROPPED_WRONG_ORIGIN.
+# ---------------------------------------------------------------------------
+
+
+def test_wrong_origin_dropped():
+    token = sign_ripple(_mk_payload(source_repo="evil"), PSK_A)
+    verdict, got = verify_ripple(
+        token, PSK_A, now_unix=NOW, expected_origins=("jarvis",)
+    )
+    assert verdict is VerifyVerdict.DROPPED_WRONG_ORIGIN
+    assert got is None
+
+
+def test_expected_origin_match_verified():
+    token = sign_ripple(_mk_payload(source_repo="jarvis"), PSK_A)
+    verdict, got = verify_ripple(
+        token, PSK_A, now_unix=NOW, expected_origins=("jarvis", "prime")
+    )
+    assert verdict is VerifyVerdict.VERIFIED
+    assert got is not None
+
+
+# ---------------------------------------------------------------------------
+# 8. Cross-compat / no-remote-exec.
+# ---------------------------------------------------------------------------
+
+
+def test_cross_compat_aegis_lease_encode_matches_portable_sign():
+    # The portable sign_ripple and aegis.lease._encode_token produce the
+    # IDENTICAL wire token for the same canonical dict + key.
+    from backend.core.ouroboros.aegis import lease
+
+    payload = _mk_payload(nonce="xcompat-nonce")
+    portable_token = sign_ripple(payload, PSK_A)
+    lease_token = lease._encode_token(PSK_A, payload.to_canonical_dict())
+    assert portable_token == lease_token
+
+    # And the aegis-lease-signed token verifies VERIFIED under the portable
+    # verifier (a sibling repo vendoring only ripple_contract can trust it).
+    verdict, got = verify_ripple(lease_token, PSK_A, now_unix=NOW)
+    assert verdict is VerifyVerdict.VERIFIED
+    assert got is not None and got.nonce == "xcompat-nonce"
+
+
+def test_verify_ripple_has_no_exec_side_effect():
+    # The payload's intent is a plain string; verify_ripple returns a
+    # verdict+payload only and never invokes intent. We prove "no callable
+    # side effect" by embedding a string that WOULD be dangerous if exec'd
+    # and asserting it is returned verbatim, untouched.
+    danger = "__import__('os').system('echo PWNED')"
+    payload = RipplePayload(
+        schema_version=RIPPLE_SCHEMA_VERSION,
+        ripple_kind=RippleKind.CONSTITUTIONAL_RULE_MERGED.value,
+        source_repo="jarvis",
+        intent=danger,
+        payload_sha256="b" * 64,
+        nonce="exec-probe",
+        issued_at_unix=NOW,
+        ttl_s=3600.0,
+    )
+    token = sign_ripple(payload, PSK_A)
+    verdict, got = verify_ripple(token, PSK_A, now_unix=NOW)
+    assert verdict is VerifyVerdict.VERIFIED
+    assert got is not None
+    # Returned verbatim — a STRING, never invoked.
+    assert got.intent == danger
+    assert isinstance(got.intent, str)
+    # verify_ripple returns exactly a 2-tuple (verdict, payload), nothing
+    # callable.
+    assert not callable(got)
+
+
+def test_portable_contract_is_stdlib_only_source():
+    import backend.core.ouroboros.cross_repo_mesh.ripple_contract as mod
+
+    src = Path(mod.__file__).read_text()
+    assert "from backend" not in src
+    assert "import backend" not in src
+    # No actual exec/dynamic-import CALLS or subprocess usage. (The docstring
+    # legitimately uses the prose word "subprocess" to state the guarantee, so
+    # we match call/usage shapes, not the bare word.)
+    for banned in ("eval(", "exec(", "subprocess.", "import subprocess",
+                   "os.system", "__import__("):
+        assert banned not in src, f"portable contract must not contain {banned!r}"
+
+
+# ---------------------------------------------------------------------------
+# 9. Emitter master-off → DISABLED, writes nothing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_master_off_disabled_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.delenv("JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED", raising=False)
+    ledger = tmp_path / "ripples.jsonl"
+    monkeypatch.setenv("JARVIS_CROSS_REPO_RIPPLE_LEDGER", str(ledger))
+    monkeypatch.setenv("JARVIS_CROSS_REPO_EMIT_PSK", PSK_A.decode())
+
+    payload = build_ripple(
+        RippleKind.CONTRACT_CHANGED, "x", {"a": 1}, now_unix=NOW
+    )
+    result = await emit_ripple(payload)
+    assert isinstance(result, EmitResult)
+    assert result.verdict is VerifyVerdict.DISABLED
+    assert result.token is None
+    assert not ledger.exists()
+
+
+@pytest.mark.asyncio
+async def test_emit_on_but_psk_unset_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CROSS_REPO_EMIT_PSK", raising=False)
+    ledger = tmp_path / "ripples.jsonl"
+    monkeypatch.setenv("JARVIS_CROSS_REPO_RIPPLE_LEDGER", str(ledger))
+
+    payload = build_ripple(
+        RippleKind.CONTRACT_CHANGED, "x", {"a": 1}, now_unix=NOW
+    )
+    result = await emit_ripple(payload)
+    assert result.verdict is VerifyVerdict.DISABLED
+    assert result.detail == "psk_unset"
+    assert not ledger.exists()
+
+
+# ---------------------------------------------------------------------------
+# 10. Emitter on → immutable receipt; read back + verify → VERIFIED.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_on_writes_immutable_receipt_and_reverifies(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CROSS_REPO_EMIT_PSK", PSK_A.decode())
+    ledger = tmp_path / "ripples.jsonl"
+    monkeypatch.setenv("JARVIS_CROSS_REPO_RIPPLE_LEDGER", str(ledger))
+
+    payload = build_ripple(
+        RippleKind.CONSTITUTIONAL_RULE_MERGED,
+        "rule C-9 merged",
+        {"rule": "C-9"},
+        now_unix=NOW,
+    )
+    result = await emit_ripple(payload)
+    assert result.verdict is VerifyVerdict.VERIFIED
+    assert result.token is not None
+    assert result.ledger_written is True
+    assert ledger.exists()
+
+    # Read the receipt back and re-verify the persisted token.
+    lines = ledger.read_text().strip().splitlines()
+    assert len(lines) == 1
+    receipt = json.loads(lines[0])
+    assert receipt["ripple_kind"] == RippleKind.CONSTITUTIONAL_RULE_MERGED.value
+    assert receipt["nonce"] == payload.nonce
+
+    verdict, got = verify_ripple(receipt["token"], PSK_A, now_unix=NOW + 1)
+    assert verdict is VerifyVerdict.VERIFIED
+    assert got is not None and got.intent == "rule C-9 merged"
+
+    # A second emit appends a second immutable line (append-only ledger).
+    payload2 = build_ripple(
+        RippleKind.CONTRACT_CHANGED, "another", {"k": 2}, now_unix=NOW
+    )
+    await emit_ripple(payload2)
+    assert len(ledger.read_text().strip().splitlines()) == 2
+
+
+# ---------------------------------------------------------------------------
+# 11. Never-raises on broken env / unwritable ledger.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_never_raises_on_unwritable_ledger(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CROSS_REPO_EMIT_PSK", PSK_A.decode())
+    # Point the ledger at a path whose parent is a file → mkdir/open fails.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("i am a file")
+    monkeypatch.setenv(
+        "JARVIS_CROSS_REPO_RIPPLE_LEDGER", str(blocker / "nested" / "x.jsonl")
+    )
+
+    payload = build_ripple(
+        RippleKind.CONTRACT_CHANGED, "x", {"a": 1}, now_unix=NOW
+    )
+    # Must not raise; signs fine, ledger write fails best-effort.
+    result = await emit_ripple(payload)
+    assert result.verdict is VerifyVerdict.VERIFIED
+    assert result.token is not None
+    assert result.ledger_written is False
+
+
+def test_build_ripple_fresh_nonce_each_call():
+    p1 = build_ripple(RippleKind.CONTRACT_CHANGED, "x", {"a": 1}, now_unix=NOW)
+    p2 = build_ripple(RippleKind.CONTRACT_CHANGED, "x", {"a": 1}, now_unix=NOW)
+    assert p1.nonce != p2.nonce
+    # Same canonical object → same sha256 (deterministic content hash).
+    assert p1.payload_sha256 == p2.payload_sha256
+
+
+def test_build_ripple_accepts_string_kind():
+    p = build_ripple("contract_changed", "x", {"a": 1}, now_unix=NOW)
+    assert p.ripple_kind == "contract_changed"
+
+
+def test_register_shipped_invariants_never_raises():
+    invs = emitter.register_shipped_invariants()
+    assert isinstance(invs, list)
+    # When the meta module is importable, the three pins are present and
+    # they HOLD on the actual shipped source.
+    if invs:
+        names = {i.invariant_name for i in invs}
+        assert {
+            "ripple_contract_stdlib_only",
+            "ripple_contract_no_exec",
+            "emitter_authority_asymmetry",
+        } <= names
+        import ast as _ast
+
+        # Derive repo root from this test file (tests/architecture/...).
+        repo_root = Path(__file__).resolve().parents[2]
+        for inv in invs:
+            src = (repo_root / inv.target_file).read_text()
+            violations = inv.validate(_ast.parse(src), src)
+            assert violations == (), f"{inv.invariant_name}: {violations}"


### PR DESCRIPTION
**§40 #20 distributed neural mesh — JARVIS half.** Asynchronously EMITS a cryptographically-signed **notification** ("ripple") on state change; consumers **independently verify + decide** — they never execute JARVIS-dictated remote code (**"predictions, not requests"**). Composes the existing Aegis HMAC-SHA256 codec — no crypto rewrite.

## `cross_repo_mesh/ripple_contract.py` — portable (stdlib-only, vendorable)
The siblings (`jarvis-prime`, `reactor-core`) can't import `backend.*`, and *independent* verification is the security model — so this is a self-contained verifier they copy verbatim.
- `RipplePayload` (frozen; `ripple_kind`/`intent` are **strings** describing *what* changed, never code) + canonical JSON; closed `RippleKind` + `VerifyVerdict` enums.
- `sign_ripple(payload, psk)` — **byte-identical wire format to `aegis.lease`** (`b64url(json).b64url(HMAC-SHA256)`), constant-time compare.
- `verify_ripple(...) -> (verdict, payload)` — first-failure-wins drop matrix (`DROPPED_MALFORMED/_BAD_SIGNATURE/_WRONG_ORIGIN/_EXPIRED/_REPLAY`, else `VERIFIED`). **Never raises, never executes intent.** Nonce registered **last** (only on otherwise-valid ripples) → a forged/expired payload can't pre-burn a legit nonce.

## `cross_repo_mesh/ripple_emitter.py` — JARVIS-side
`build_ripple` (sha256 over canonical payload + `secrets` nonce) + async `emit_ripple` — §33.1 master `JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED` **default-FALSE** (inert no-op); PSK from env (`bytes`, never module-level); signs + appends an immutable receipt; best-effort lazy `CrossRepoEventBus` publish. **An unsigned ripple is never emitted.**

## Cross-compat proven
`sign_ripple(p,K) == aegis.lease._encode_token(K, p.to_canonical_dict())` (exact string equality) and a lease-signed token verifies `VERIFIED` under the portable verifier — a sibling vendoring only `ripple_contract.py` trusts JARVIS ripples with **zero backend deps**.

## Tests
32 + 61 regression green. Independently reviewed (adversarial crypto: forgery / sig-strip / alg-confusion / replay / nonce-burn / clock-skew / 50-string malformed fuzz / a `__import__('os').system(...)` intent that round-tripped untouched — **all dropped or safe**; constant-time confirmed; no exec path; portable stdlib-only; emit inert without flag+PSK).

Stage 2 (sibling listeners) + Stage 3 (live in-process E2E handshake) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a signed cross-repo “ripple” emitter and a portable verifier so repos can verify JARVIS state-change notifications with HMAC and decide locally without executing remote code.

- **New Features**
  - Portable verifier `backend/core/ouroboros/cross_repo_mesh/ripple_contract.py` (stdlib-only): `RipplePayload`, `sign_ripple`, and `verify_ripple` with drop verdicts (malformed, bad signature, wrong origin, expired, replay). Constant‑time compare; replay is recorded last. Wire format matches `aegis.lease`.
  - JARVIS emitter `backend/core/ouroboros/cross_repo_mesh/ripple_emitter.py`: `build_ripple` (SHA-256 of canonical payload + nonce) and async `emit_ripple`. Gated by a master flag (default off). Writes an append-only JSONL ledger and can optionally publish via `CrossRepoEventBus`. Returns `EmitResult`. Unsigned ripples are never emitted.
  - Cross-compat: `sign_ripple(...)` is byte-identical to `aegis.lease._encode_token(...)`, and tokens verify under the portable contract.
  - Shipped invariants: contract is stdlib-only and has no exec path; emitter avoids high‑authority imports.

- **Migration**
  - Emission: set `JARVIS_CROSS_REPO_EMIT_PSK`, enable `JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED`, and optionally set `JARVIS_CROSS_REPO_RIPPLE_LEDGER`.
  - Consumers: vendor `ripple_contract.py` and call `verify_ripple(token, psk, now_unix, expected_origins, seen_nonces)`. Only act on `VERIFIED`.
  - Optional: subscribe to `CrossRepoEventBus` to react to ripples. Default TTL is 1 hour.

<sup>Written for commit adaeefd902342b5e1535761837e9a56040fb566d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

