### PR TITLE
feat(governance): Slice 99 — asynchronous ambiguity sensor mesh + live producer hooks

### DIFF
--- a/backend/core/ouroboros/cross_repo_mesh/ripple_emitter.py
+++ b/backend/core/ouroboros/cross_repo_mesh/ripple_emitter.py
@@ -76,6 +76,22 @@ def _ledger_path() -> Path:
     return Path(os.getenv("JARVIS_CROSS_REPO_RIPPLE_LEDGER", _DEFAULT_LEDGER))
 
 
+def _note_emit_failure(detail: str) -> None:
+    """Best-effort EMIT-SIDE handshake-failure signal into the Slice-99
+    Ambiguity Sensor Mesh. Fire-and-forget honored — observed from the
+    LOCAL emit failure only (no request/response heartbeat). A sensor
+    failure must NEVER affect the emit result, so this is lazy-imported
+    and fully wrapped. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.ambiguity_sensor_mesh import (
+            note_cross_repo_emit_failure,
+        )
+
+        note_cross_repo_emit_failure(detail)
+    except Exception:  # noqa: BLE001 — sensor is best-effort, hot-path safe
+        return
+
+
 # ---------------------------------------------------------------------------
 # Result type.
 # ---------------------------------------------------------------------------
@@ -241,9 +257,13 @@ async def emit_ripple(
         token = sign_ripple(payload, psk)
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning("ripple sign failed: %s", exc)
+        _note_emit_failure(f"sign_error:{exc}")
         return EmitResult(verdict=VerifyVerdict.DISABLED, detail=f"sign_error:{exc}")
 
     ledger_written = _write_receipt(token, payload)
+    if not ledger_written:
+        # EMIT-SIDE write failure — handshake-health signal (best-effort).
+        _note_emit_failure("ledger_write_failed")
 
     bus_published = False
     if publish_bus:

--- a/backend/core/ouroboros/governance/ambiguity_sensor_mesh.py
+++ b/backend/core/ouroboros/governance/ambiguity_sensor_mesh.py
@@ -1,0 +1,887 @@
+"""Asynchronous Ambiguity Sensor Mesh (Slice 99).
+
+The LIVE nervous system that feeds the Slice-98 Dynamic Risk-State
+Convergence Engine. Slice 98 built the brain (``record_ambiguity`` +
+``convergence_score`` + the strictest-wins floor composition); this is
+the afferent pathway that delivers REAL signals to it.
+
+Design (non-negotiable)
+=======================
+* **NEVER break the hot path.** Every producer hook is BEST-EFFORT,
+  wrapped in try/except, and a sensor failure can NEVER break
+  generation / emit / the orchestrator. A hook is a tiny O(1)
+  increment into a bounded in-process accumulator — nothing more.
+
+* **PULL model, async, non-blocking.** Hooks only APPEND timestamped
+  events to thread-safe bounded accumulators (no network, no LLM, no
+  convergence-engine call on the hot path). A separate async sampler
+  daemon READS those accumulators on a cadence and decides whether to
+  fire ``record_ambiguity``. The sampler uses ``asyncio.sleep`` — no
+  blocking I/O, no event-loop starvation.
+
+* **Fire-and-forget honored.** The cross-repo mesh is "predictions, not
+  requests" (Slice 97). JARVIS-side handshake health is observed ONLY
+  from EMIT-SIDE failures (local ``emit_ripple`` failures) — there is
+  NO outbound ping that expects a reply. Adding a request/response
+  heartbeat would undo Slice 97's safety model, so we do not.
+
+* **§33.1 default-FALSE master** ``JARVIS_AMBIGUITY_SENSOR_MESH_ENABLED``
+  — hooks + sampler are ALL inert when off. Recovery in the convergence
+  engine stays automatic (pure function of the window); the per-signal
+  decay we pass through ``record_ambiguity(decay_s=...)`` preserves that
+  (per-signal age-vs-decay, no latch).
+
+Authority asymmetry (AST-pinned)
+--------------------------------
+Imports only stdlib + (lazily) ``dynamic_risk_convergence`` and the
+observability/flag-registry seam. NEVER imports orchestrator /
+iron_gate / policy / change_engine / candidate_generator /
+auto_committer.
+"""
+from __future__ import annotations
+
+import ast
+import enum
+import logging
+import os
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Deque, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.AmbiguitySensorMesh")
+
+
+SENSOR_MESH_SCHEMA_VERSION: str = "ambiguity_sensor_mesh.1"
+
+
+# ===========================================================================
+# Env knobs
+# ===========================================================================
+
+
+_ENV_MASTER = "JARVIS_AMBIGUITY_SENSOR_MESH_ENABLED"
+_ENV_WINDOW_S = "JARVIS_SENSOR_MESH_WINDOW_S"
+_ENV_INTERVAL_S = "JARVIS_SENSOR_MESH_INTERVAL_S"
+_ENV_MAX_EVENTS = "JARVIS_SENSOR_MESH_MAX_EVENTS"
+
+# Per-class threshold / severity-weight / decay knobs. The "structured
+# tensor": source = signal class, severity = weight, decay = decay_s.
+_ENV_THRESH_HANDSHAKE = "JARVIS_SENSOR_MESH_HANDSHAKE_THRESHOLD"
+_ENV_THRESH_CONTRADICTORY = "JARVIS_SENSOR_MESH_CONTRADICTORY_THRESHOLD"
+_ENV_THRESH_MALFORMED = "JARVIS_SENSOR_MESH_MALFORMED_THRESHOLD"
+
+_ENV_WEIGHT_HANDSHAKE = "JARVIS_SENSOR_MESH_HANDSHAKE_WEIGHT"
+_ENV_WEIGHT_CONTRADICTORY = "JARVIS_SENSOR_MESH_CONTRADICTORY_WEIGHT"
+_ENV_WEIGHT_MALFORMED = "JARVIS_SENSOR_MESH_MALFORMED_WEIGHT"
+
+_ENV_DECAY_HANDSHAKE = "JARVIS_SENSOR_MESH_HANDSHAKE_DECAY_S"
+_ENV_DECAY_CONTRADICTORY = "JARVIS_SENSOR_MESH_CONTRADICTORY_DECAY_S"
+_ENV_DECAY_MALFORMED = "JARVIS_SENSOR_MESH_MALFORMED_DECAY_S"
+
+_DEFAULT_WINDOW_S = 60.0
+_DEFAULT_INTERVAL_S = 5.0
+_DEFAULT_MAX_EVENTS = 500
+
+# Default per-class thresholds (events within window → fire). Chosen so
+# a single failure isn't ambiguity, but a sustained burst is.
+_DEFAULT_THRESH_HANDSHAKE = 3
+_DEFAULT_THRESH_CONTRADICTORY = 3
+_DEFAULT_THRESH_MALFORMED = 3
+
+# Default severity weights — each fire contributes this much weight to
+# the convergence score. Sized so two simultaneous sources reach the
+# paranoia threshold (6.0) → approval_required floor.
+_DEFAULT_WEIGHT_HANDSHAKE = 3.0
+_DEFAULT_WEIGHT_CONTRADICTORY = 3.0
+_DEFAULT_WEIGHT_MALFORMED = 3.0
+
+# Default per-class decay horizons handed to record_ambiguity(decay_s=)
+# so the convergence engine relaxes per-signal automatically.
+_DEFAULT_DECAY_HANDSHAKE = 60.0
+_DEFAULT_DECAY_CONTRADICTORY = 60.0
+_DEFAULT_DECAY_MALFORMED = 60.0
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSY = frozenset({"0", "false", "no", "off"})
+
+
+def _flag(name: str, *, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    if raw in _FALSY:
+        return False
+    return raw in _TRUTHY or default
+
+
+def master_enabled() -> bool:
+    """§33.1 master — default-**FALSE**. Re-read at call time so
+    monkeypatch + live operator flips work. When off, hooks are no-ops
+    and the sampler is inert."""
+    return _flag(_ENV_MASTER, default=False)
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _window_s() -> float:
+    return _env_float(_ENV_WINDOW_S, _DEFAULT_WINDOW_S)
+
+
+def _interval_s() -> float:
+    return max(0.0, _env_float(_ENV_INTERVAL_S, _DEFAULT_INTERVAL_S))
+
+
+def _max_events() -> int:
+    return max(1, _env_int(_ENV_MAX_EVENTS, _DEFAULT_MAX_EVENTS))
+
+
+# ===========================================================================
+# Closed taxonomy — mirrors the convergence engine's AmbiguitySignal
+# ===========================================================================
+
+
+class SignalClass(str, enum.Enum):
+    """Closed 3-value producer-hook taxonomy. Each maps 1:1 onto a
+    ``dynamic_risk_convergence.AmbiguitySignal``. Bytes-pinned via AST."""
+
+    CROSS_REPO_HANDSHAKE = "cross_repo_handshake"
+    CONTRADICTORY_OUTPUT = "contradictory_output"
+    MALFORMED_INTENT = "malformed_intent"
+
+
+# Per-class (threshold_env, default_threshold, weight_env,
+# default_weight, decay_env, default_decay) tensor descriptor.
+_CLASS_CONFIG: Dict[SignalClass, Tuple[str, int, str, float, str, float]] = {
+    SignalClass.CROSS_REPO_HANDSHAKE: (
+        _ENV_THRESH_HANDSHAKE, _DEFAULT_THRESH_HANDSHAKE,
+        _ENV_WEIGHT_HANDSHAKE, _DEFAULT_WEIGHT_HANDSHAKE,
+        _ENV_DECAY_HANDSHAKE, _DEFAULT_DECAY_HANDSHAKE,
+    ),
+    SignalClass.CONTRADICTORY_OUTPUT: (
+        _ENV_THRESH_CONTRADICTORY, _DEFAULT_THRESH_CONTRADICTORY,
+        _ENV_WEIGHT_CONTRADICTORY, _DEFAULT_WEIGHT_CONTRADICTORY,
+        _ENV_DECAY_CONTRADICTORY, _DEFAULT_DECAY_CONTRADICTORY,
+    ),
+    SignalClass.MALFORMED_INTENT: (
+        _ENV_THRESH_MALFORMED, _DEFAULT_THRESH_MALFORMED,
+        _ENV_WEIGHT_MALFORMED, _DEFAULT_WEIGHT_MALFORMED,
+        _ENV_DECAY_MALFORMED, _DEFAULT_DECAY_MALFORMED,
+    ),
+}
+
+
+def _threshold_for(cls: SignalClass) -> int:
+    env, default, *_ = _CLASS_CONFIG[cls]
+    return max(1, _env_int(env, default))
+
+
+def _weight_for(cls: SignalClass) -> float:
+    _, _, env, default, _, _ = _CLASS_CONFIG[cls]
+    return _env_float(env, default)
+
+
+def _decay_for(cls: SignalClass) -> float:
+    *_, env, default = _CLASS_CONFIG[cls]
+    return _env_float(env, default)
+
+
+# ===========================================================================
+# Thread-safe in-process accumulators (per signal class)
+# ===========================================================================
+
+
+# One bounded deque of event timestamps per signal class. The ONLY
+# mutable state. Drop-oldest on overflow (deque maxlen). Never grows
+# unbounded.
+_ACCUMULATORS: Dict[SignalClass, Deque[float]] = {
+    cls: deque(maxlen=_DEFAULT_MAX_EVENTS) for cls in SignalClass
+}
+_LOCK = threading.Lock()
+
+
+def _ensure_capacity() -> None:
+    """Re-size accumulators if the env cap changed since module load.
+    Defensive — never raises."""
+    cap = _max_events()
+    for cls, buf in list(_ACCUMULATORS.items()):
+        if buf.maxlen != cap:
+            _ACCUMULATORS[cls] = deque(buf, maxlen=cap)
+
+
+def _append(cls: SignalClass, now_unix: Optional[float]) -> None:
+    """Append a timestamped event into a class accumulator. O(1).
+    Inert when master off. NEVER raises (hot-path safety)."""
+    try:
+        if not master_enabled():
+            return
+        try:
+            ts = float(now_unix) if now_unix is not None else time.time()
+        except (TypeError, ValueError):
+            ts = time.time()
+        with _LOCK:
+            _ensure_capacity()
+            _ACCUMULATORS[cls].append(ts)
+    except Exception:  # noqa: BLE001 — producer hooks NEVER raise
+        return
+
+
+def _window_count(cls: SignalClass, now_unix: float) -> int:
+    """In-window event count for a class. PURE w.r.t. the accumulator +
+    now. NEVER raises."""
+    try:
+        window = _window_s()
+        with _LOCK:
+            snapshot = list(_ACCUMULATORS.get(cls, ()))
+        count = 0
+        for ts in snapshot:
+            try:
+                age = now_unix - float(ts)
+            except (TypeError, ValueError):
+                continue
+            if age < 0:
+                age = 0.0
+            if age < window:
+                count += 1
+        return count
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def reset_accumulators() -> None:
+    """Test helper — clear all class accumulators. Production NEVER needs
+    this (the sliding window self-decays). NEVER raises."""
+    with _LOCK:
+        for buf in _ACCUMULATORS.values():
+            buf.clear()
+
+
+# ===========================================================================
+# Producer hooks — the LIVE nervous system. Tiny, best-effort, never raise.
+# ===========================================================================
+
+
+def note_cross_repo_emit_failure(
+    detail: str = "", *, now_unix: Optional[float] = None,
+) -> None:
+    """Record an EMIT-SIDE cross-repo handshake failure.
+
+    Call site: ``ripple_emitter.emit_ripple`` failure paths (sign error /
+    write failure). Fire-and-forget honored — this is observed from
+    LOCAL emit failures only, never a request/response heartbeat.
+    O(1), best-effort, inert when master off. NEVER raises."""
+    _append(SignalClass.CROSS_REPO_HANDSHAKE, now_unix)
+
+
+def note_llm_contradiction(
+    detail: str = "", *, now_unix: Optional[float] = None,
+) -> None:
+    """Record an LLM-fighting-the-validator signal — repeated GENERATE
+    retries / Iron-Gate rejections / contradictory generative output.
+
+    Call site (when wired): the orchestrator's GENERATE_RETRY /
+    exploration-gate rejection point, ONLY past a small retry count.
+    O(1), best-effort, inert when master off. NEVER raises."""
+    _append(SignalClass.CONTRADICTORY_OUTPUT, now_unix)
+
+
+def note_malformed_intent(
+    detail: str = "", *, now_unix: Optional[float] = None,
+) -> None:
+    """Record a malformed-intent signal (intent-parse failure).
+
+    O(1), best-effort, inert when master off. NEVER raises."""
+    _append(SignalClass.MALFORMED_INTENT, now_unix)
+
+
+# ===========================================================================
+# §33.5 frozen versioned report artifact
+# ===========================================================================
+
+
+# Map each SignalClass → the convergence engine's AmbiguitySignal value
+# string (resolved lazily to AmbiguitySignal at fire time — keeps the
+# import lazy for authority-asymmetry).
+_CLASS_TO_CONVERGENCE_SIGNAL = {
+    SignalClass.CROSS_REPO_HANDSHAKE: "CROSS_REPO_HANDSHAKE_FAILURE",
+    SignalClass.CONTRADICTORY_OUTPUT: "CONTRADICTORY_OUTPUT",
+    SignalClass.MALFORMED_INTENT: "MALFORMED_INTENT",
+}
+
+
+@dataclass(frozen=True)
+class SensorMeshReport:
+    """Frozen one-pass evaluation snapshot — §33.5 versioned artifact.
+
+    * ``window_counts`` — per-class in-window event count.
+    * ``fired`` — per-class bool: did this pass fire ``record_ambiguity``.
+    * ``weights`` / ``decays`` — per-class severity weight + decay used.
+    * ``thresholds`` — per-class threshold evaluated against.
+    * ``evaluated_at_unix`` — when the pass ran.
+    """
+
+    schema_version: str
+    window_counts: Dict[str, int]
+    fired: Dict[str, bool]
+    weights: Dict[str, float]
+    decays: Dict[str, float]
+    thresholds: Dict[str, int]
+    evaluated_at_unix: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "window_counts": dict(self.window_counts),
+            "fired": dict(self.fired),
+            "weights": dict(self.weights),
+            "decays": dict(self.decays),
+            "thresholds": dict(self.thresholds),
+            "evaluated_at_unix": float(self.evaluated_at_unix),
+        }
+
+    @property
+    def any_fired(self) -> bool:
+        return any(self.fired.values())
+
+
+# ===========================================================================
+# Async sampler — PULL model. Reads accumulators, fires record_ambiguity.
+# ===========================================================================
+
+
+def _fire_record_ambiguity(
+    cls: SignalClass,
+    *,
+    now_unix: float,
+    weight: float,
+    decay_s: float,
+) -> bool:
+    """Lazy-import the convergence engine and fire one structured
+    ``record_ambiguity`` for this class. Best-effort; NEVER raises.
+    Returns True iff the call was made."""
+    try:
+        from backend.core.ouroboros.governance import (
+            dynamic_risk_convergence as drc,
+        )
+
+        signal = getattr(
+            drc.AmbiguitySignal,
+            _CLASS_TO_CONVERGENCE_SIGNAL[cls],
+            None,
+        )
+        if signal is None:
+            return False
+        drc.record_ambiguity(
+            signal,
+            now_unix=now_unix,
+            weight=weight,
+            decay_s=decay_s,
+        )
+        return True
+    except Exception:  # noqa: BLE001 — sampler NEVER raises
+        logger.debug(
+            "[SensorMesh] record_ambiguity fire failed for %s",
+            getattr(cls, "value", cls),
+            exc_info=True,
+        )
+        return False
+
+
+async def run_sensor_mesh_once(
+    now_unix: Optional[float] = None,
+) -> SensorMeshReport:
+    """One evaluation pass. For each signal class, compute the in-window
+    event count; if it breaches the class threshold, fire a structured
+    ``record_ambiguity(signal, weight=severity, decay_s=per-class)``.
+
+    Master OFF → an all-zero / nothing-fired report (inert). Async +
+    bounded; does NOT sleep. NEVER raises."""
+    try:
+        now = float(now_unix) if now_unix is not None else time.time()
+    except (TypeError, ValueError):
+        now = time.time()
+
+    window_counts: Dict[str, int] = {}
+    fired: Dict[str, bool] = {}
+    weights: Dict[str, float] = {}
+    decays: Dict[str, float] = {}
+    thresholds: Dict[str, int] = {}
+
+    enabled = False
+    try:
+        enabled = master_enabled()
+    except Exception:  # noqa: BLE001
+        enabled = False
+
+    for cls in SignalClass:
+        key = cls.value
+        weight = _weight_for(cls)
+        decay = _decay_for(cls)
+        threshold = _threshold_for(cls)
+        weights[key] = weight
+        decays[key] = decay
+        thresholds[key] = threshold
+        if not enabled:
+            window_counts[key] = 0
+            fired[key] = False
+            continue
+        count = _window_count(cls, now)
+        window_counts[key] = count
+        did_fire = False
+        if count >= threshold:
+            did_fire = _fire_record_ambiguity(
+                cls, now_unix=now, weight=weight, decay_s=decay,
+            )
+        fired[key] = did_fire
+
+    return SensorMeshReport(
+        schema_version=SENSOR_MESH_SCHEMA_VERSION,
+        window_counts=window_counts,
+        fired=fired,
+        weights=weights,
+        decays=decays,
+        thresholds=thresholds,
+        evaluated_at_unix=now,
+    )
+
+
+async def run_sensor_mesh_loop(
+    *,
+    interval_s: Optional[float] = None,
+    iterations: Optional[int] = None,
+) -> int:
+    """Async cadence loop. Runs ``run_sensor_mesh_once`` every
+    ``interval_s`` seconds (env ``JARVIS_SENSOR_MESH_INTERVAL_S`` when
+    unset). ``iterations`` bounds the loop for tests so it terminates;
+    when ``None`` the loop runs until cancelled.
+
+    PULL model — non-blocking ``asyncio.sleep`` between passes, no
+    event-loop starvation. NEVER raises (a pass failure is swallowed and
+    the loop continues). Returns the number of passes executed."""
+    import asyncio
+
+    sleep_s = _interval_s() if interval_s is None else max(0.0, float(
+        interval_s if interval_s is not None else _interval_s()
+    ))
+
+    passes = 0
+    try:
+        while True:
+            try:
+                await run_sensor_mesh_once()
+            except Exception:  # noqa: BLE001 — sampler NEVER raises
+                logger.debug("[SensorMesh] pass failed", exc_info=True)
+            passes += 1
+            if iterations is not None and passes >= int(iterations):
+                break
+            if sleep_s > 0:
+                try:
+                    await asyncio.sleep(sleep_s)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    pass
+    except asyncio.CancelledError:
+        # Cooperative cancellation — clean exit, not an error.
+        return passes
+    except Exception:  # noqa: BLE001 — loop NEVER raises out
+        logger.debug("[SensorMesh] loop aborted", exc_info=True)
+    return passes
+
+
+# ===========================================================================
+# AST pins via shipped_code_invariants
+# ===========================================================================
+
+
+def register_shipped_invariants() -> list:
+    """Return AST invariant pins. Auto-discovered via §33.3. NEVER
+    raises."""
+    try:
+        from backend.core.ouroboros.governance.meta.shipped_code_invariants import (  # noqa: E501
+            ShippedCodeInvariant,
+        )
+    except ImportError:
+        return []
+
+    target = (
+        "backend/core/ouroboros/governance/ambiguity_sensor_mesh.py"
+    )
+
+    _EXPECTED_CLASSES = {
+        "cross_repo_handshake",
+        "contradictory_output",
+        "malformed_intent",
+    }
+
+    def _enum_members(tree: ast.AST, class_name: str) -> set:
+        found: set = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                for sub in node.body:
+                    if (
+                        isinstance(sub, ast.Assign)
+                        and len(sub.targets) == 1
+                        and isinstance(sub.targets[0], ast.Name)
+                        and isinstance(sub.value, ast.Constant)
+                        and isinstance(sub.value.value, str)
+                    ):
+                        found.add(sub.value.value)
+        return found
+
+    def _validate_signal_class_taxonomy(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        found = _enum_members(tree, "SignalClass")
+        if not found:
+            return ("SignalClass class not found",)
+        missing = _EXPECTED_CLASSES - found
+        extra = found - _EXPECTED_CLASSES
+        if missing:
+            return (f"SignalClass missing: {sorted(missing)}",)
+        if extra:
+            return (f"SignalClass drift: {sorted(extra)}",)
+        return ()
+
+    def _validate_authority_asymmetry(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        forbidden = (
+            "backend.core.ouroboros.governance.orchestrator",
+            "backend.core.ouroboros.governance.iron_gate",
+            "backend.core.ouroboros.governance.policy",
+            "backend.core.ouroboros.governance.change_engine",
+            "backend.core.ouroboros.governance.candidate_generator",
+            "backend.core.ouroboros.governance.auto_committer",
+        )
+        violations: List[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                if any(mod == f for f in forbidden):
+                    violations.append(f"forbidden authority import: {mod}")
+        return tuple(violations)
+
+    def _validate_master_default_false(
+        tree: ast.AST, source: str,  # noqa: ARG001
+    ) -> tuple:
+        """§33.1 — master_enabled MUST default to False (hooks + sampler
+        inert by default)."""
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.FunctionDef)
+                and node.name == "master_enabled"
+            ):
+                for sub in ast.walk(node):
+                    if (
+                        isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Name)
+                        and sub.func.id == "_flag"
+                    ):
+                        for kw in sub.keywords:
+                            if (
+                                kw.arg == "default"
+                                and isinstance(kw.value, ast.Constant)
+                                and kw.value.value is False
+                            ):
+                                return ()
+                return (
+                    "master_enabled() must call _flag(...) with "
+                    "default=False (§33.1 default-FALSE)",
+                )
+        return ("master_enabled() not found",)
+
+    def _validate_hooks_never_push_directly(
+        tree: ast.AST, source: str,
+    ) -> tuple:
+        """PULL model — the producer hooks must NOT call
+        record_ambiguity directly (that would push from the hot path).
+        Only the sampler (_fire_record_ambiguity) may. We assert the
+        three note_* hook bodies contain no 'record_ambiguity' call."""
+        hook_names = {
+            "note_cross_repo_emit_failure",
+            "note_llm_contradiction",
+            "note_malformed_intent",
+        }
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.FunctionDef)
+                and node.name in hook_names
+            ):
+                for sub in ast.walk(node):
+                    if (
+                        isinstance(sub, ast.Attribute)
+                        and sub.attr == "record_ambiguity"
+                    ):
+                        return (
+                            f"{node.name} calls record_ambiguity directly "
+                            "— violates PULL model (hooks only append)",
+                        )
+        return ()
+
+    return [
+        ShippedCodeInvariant(
+            invariant_name="sensor_mesh_class_taxonomy_closed",
+            target_file=target,
+            description=(
+                "SignalClass 3-value taxonomy bytes-pinned, 1:1 with "
+                "the convergence engine's AmbiguitySignal."
+            ),
+            validate=_validate_signal_class_taxonomy,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="sensor_mesh_authority_asymmetry",
+            target_file=target,
+            description=(
+                "Sensor mesh imports only stdlib + (lazy) "
+                "dynamic_risk_convergence / observability. MUST NOT "
+                "import orchestrator / iron_gate / policy / "
+                "change_engine / candidate_generator / auto_committer."
+            ),
+            validate=_validate_authority_asymmetry,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="sensor_mesh_master_default_false",
+            target_file=target,
+            description=(
+                "§33.1 — master default-FALSE so all hooks + the "
+                "sampler are inert by default."
+            ),
+            validate=_validate_master_default_false,
+        ),
+        ShippedCodeInvariant(
+            invariant_name="sensor_mesh_hooks_pull_model",
+            target_file=target,
+            description=(
+                "PULL model — producer hooks (note_*) only append to "
+                "accumulators; they NEVER call record_ambiguity from "
+                "the hot path. Only the async sampler fires it."
+            ),
+            validate=_validate_hooks_never_push_directly,
+        ),
+    ]
+
+
+# ===========================================================================
+# FlagRegistry seeds (auto-discovered via §33.3 naming-cage)
+# ===========================================================================
+
+
+def register_flags(registry: Any) -> int:
+    """Register this mesh's env knobs. Auto-discovered. NEVER raises
+    fatally (fail-open per seed)."""
+    try:
+        from backend.core.ouroboros.governance.flag_registry import (
+            Category,
+            FlagSpec,
+            FlagType,
+        )
+    except Exception:  # noqa: BLE001
+        return 0
+
+    src = "backend/core/ouroboros/governance/ambiguity_sensor_mesh.py"
+    seeds = [
+        FlagSpec(
+            name=_ENV_MASTER,
+            type=FlagType.BOOL,
+            default=False,
+            description=(
+                "Asynchronous Ambiguity Sensor Mesh master switch. "
+                "§33.1 default-FALSE — when off, all producer hooks + "
+                "the async sampler are inert (no signals reach the "
+                "convergence engine)."
+            ),
+            category=Category.SAFETY,
+            source_file=src,
+            example=f"{_ENV_MASTER}=true",
+        ),
+        FlagSpec(
+            name=_ENV_WINDOW_S,
+            type=FlagType.FLOAT,
+            default=_DEFAULT_WINDOW_S,
+            description=(
+                "Sliding window (seconds) over which the sampler counts "
+                "accumulated producer-hook events per signal class."
+            ),
+            category=Category.TIMING,
+            source_file=src,
+            example=f"{_ENV_WINDOW_S}=60.0",
+        ),
+        FlagSpec(
+            name=_ENV_INTERVAL_S,
+            type=FlagType.FLOAT,
+            default=_DEFAULT_INTERVAL_S,
+            description=(
+                "Async sampler cadence (seconds) between evaluation "
+                "passes."
+            ),
+            category=Category.TIMING,
+            source_file=src,
+            example=f"{_ENV_INTERVAL_S}=5.0",
+        ),
+        FlagSpec(
+            name=_ENV_MAX_EVENTS,
+            type=FlagType.INT,
+            default=_DEFAULT_MAX_EVENTS,
+            description=(
+                "Bounded per-class accumulator capacity (oldest "
+                "dropped on overflow)."
+            ),
+            category=Category.CAPACITY,
+            source_file=src,
+            example=f"{_ENV_MAX_EVENTS}=500",
+        ),
+        FlagSpec(
+            name=_ENV_THRESH_HANDSHAKE,
+            type=FlagType.INT,
+            default=_DEFAULT_THRESH_HANDSHAKE,
+            description=(
+                "Cross-repo handshake-failure events within the window "
+                "→ fire CROSS_REPO_HANDSHAKE_FAILURE ambiguity."
+            ),
+            category=Category.TUNING,
+            source_file=src,
+            example=f"{_ENV_THRESH_HANDSHAKE}=3",
+        ),
+        FlagSpec(
+            name=_ENV_THRESH_CONTRADICTORY,
+            type=FlagType.INT,
+            default=_DEFAULT_THRESH_CONTRADICTORY,
+            description=(
+                "LLM-contradiction events within the window → fire "
+                "CONTRADICTORY_OUTPUT ambiguity."
+            ),
+            category=Category.TUNING,
+            source_file=src,
+            example=f"{_ENV_THRESH_CONTRADICTORY}=3",
+        ),
+        FlagSpec(
+            name=_ENV_THRESH_MALFORMED,
+            type=FlagType.INT,
+            default=_DEFAULT_THRESH_MALFORMED,
+            description=(
+                "Malformed-intent events within the window → fire "
+                "MALFORMED_INTENT ambiguity."
+            ),
+            category=Category.TUNING,
+            source_file=src,
+            example=f"{_ENV_THRESH_MALFORMED}=3",
+        ),
+        FlagSpec(
+            name=_ENV_WEIGHT_HANDSHAKE,
+            type=FlagType.FLOAT,
+            default=_DEFAULT_WEIGHT_HANDSHAKE,
+            description=(
+                "Severity weight contributed to the convergence score "
+                "when the handshake class fires."
+            ),
+            category=Category.TUNING,
+            source_file=src,
+            example=f"{_ENV_WEIGHT_HANDSHAKE}=3.0",
+        ),
+        FlagSpec(
+            name=_ENV_WEIGHT_CONTRADICTORY,
+            type=FlagType.FLOAT,
+            default=_DEFAULT_WEIGHT_CONTRADICTORY,
+            description=(
+                "Severity weight contributed when the contradictory "
+                "class fires."
+            ),
+            category=Category.TUNING,
+            source_file=src,
+            example=f"{_ENV_WEIGHT_CONTRADICTORY}=3.0",
+        ),
+        FlagSpec(
+            name=_ENV_WEIGHT_MALFORMED,
+            type=FlagType.FLOAT,
+            default=_DEFAULT_WEIGHT_MALFORMED,
+            description=(
+                "Severity weight contributed when the malformed-intent "
+                "class fires."
+            ),
+            category=Category.TUNING,
+            source_file=src,
+            example=f"{_ENV_WEIGHT_MALFORMED}=3.0",
+        ),
+        FlagSpec(
+            name=_ENV_DECAY_HANDSHAKE,
+            type=FlagType.FLOAT,
+            default=_DEFAULT_DECAY_HANDSHAKE,
+            description=(
+                "Per-signal decay horizon (seconds) handed to "
+                "record_ambiguity(decay_s=) for handshake fires — the "
+                "convergence engine relaxes per-signal automatically."
+            ),
+            category=Category.TIMING,
+            source_file=src,
+            example=f"{_ENV_DECAY_HANDSHAKE}=60.0",
+        ),
+        FlagSpec(
+            name=_ENV_DECAY_CONTRADICTORY,
+            type=FlagType.FLOAT,
+            default=_DEFAULT_DECAY_CONTRADICTORY,
+            description=(
+                "Per-signal decay horizon (seconds) for contradictory "
+                "fires."
+            ),
+            category=Category.TIMING,
+            source_file=src,
+            example=f"{_ENV_DECAY_CONTRADICTORY}=60.0",
+        ),
+        FlagSpec(
+            name=_ENV_DECAY_MALFORMED,
+            type=FlagType.FLOAT,
+            default=_DEFAULT_DECAY_MALFORMED,
+            description=(
+                "Per-signal decay horizon (seconds) for malformed-intent "
+                "fires."
+            ),
+            category=Category.TIMING,
+            source_file=src,
+            example=f"{_ENV_DECAY_MALFORMED}=60.0",
+        ),
+    ]
+
+    count = 0
+    for spec in seeds:
+        try:
+            registry.register(spec)
+            count += 1
+        except Exception:  # noqa: BLE001 — fail-open per §33.1
+            continue
+    return count
+
+
+__all__ = [
+    "SENSOR_MESH_SCHEMA_VERSION",
+    "SignalClass",
+    "SensorMeshReport",
+    "master_enabled",
+    "note_cross_repo_emit_failure",
+    "note_llm_contradiction",
+    "note_malformed_intent",
+    "run_sensor_mesh_once",
+    "run_sensor_mesh_loop",
+    "reset_accumulators",
+    "register_shipped_invariants",
+    "register_flags",
+]

--- a/backend/core/ouroboros/governance/dynamic_risk_convergence.py
+++ b/backend/core/ouroboros/governance/dynamic_risk_convergence.py
@@ -192,10 +192,13 @@ def _weight_for(signal: Any) -> float:
 # ===========================================================================
 
 
-# Module-level bounded deque of (signal, timestamp_unix, weight). The
-# ONLY mutable authoritative state — and it only ever decays in relevance
-# as time advances (pure-function-of-window recovery).
-_SIGNALS: Deque[Tuple[Any, float, float]] = deque(
+# Module-level bounded deque of (signal, timestamp_unix, weight,
+# decay_s). The ONLY mutable authoritative state — and it only ever
+# decays in relevance as time advances (pure-function-of-window
+# recovery). ``decay_s`` is the signal's OWN decay horizon (``None`` →
+# fall back to the global window); per-signal age-vs-decay still has NO
+# latch, so the recovery invariant is preserved.
+_SIGNALS: Deque[Tuple[Any, float, float, Optional[float]]] = deque(
     maxlen=_DEFAULT_MAX_SIGNALS,
 )
 _LOCK = threading.Lock()
@@ -225,12 +228,21 @@ def record_ambiguity(
     *,
     now_unix: Optional[float] = None,
     weight: float = 1.0,
+    decay_s: Optional[float] = None,
 ) -> None:
     """Append an ambiguity signal stamped with the current time.
 
     Bounded (deque maxlen). NEVER raises — garbage inputs are stored
     as-is and simply contribute the default weight at scoring time
     (or are skipped if they can't be timestamped).
+
+    ``decay_s`` (Phase 3 "structured signal + decay-timer") is an
+    OPTIONAL per-signal decay horizon (seconds). When set, this signal
+    counts toward the score iff its age ``< decay_s`` — INDEPENDENTLY of
+    the global ``JARVIS_CONVERGENCE_WINDOW_S``. When ``None`` (the
+    legacy default), the signal falls back to the global window, so
+    existing callers behave byte-identically. Per-signal age-vs-decay
+    has NO latch — recovery stays a pure function of the window.
     """
     try:
         ts = float(now_unix) if now_unix is not None else time.time()
@@ -240,9 +252,19 @@ def record_ambiguity(
         w = float(weight)
     except (TypeError, ValueError):
         w = 1.0
+    d: Optional[float]
+    if decay_s is None:
+        d = None
+    else:
+        try:
+            d = float(decay_s)
+            if d <= 0:
+                d = None
+        except (TypeError, ValueError):
+            d = None
     with _LOCK:
         _ensure_capacity()
-        _SIGNALS.append((signal, ts, w))
+        _SIGNALS.append((signal, ts, w, d))
 
 
 def reset_signals() -> None:
@@ -279,7 +301,7 @@ def convergence_score(now_unix: Optional[float] = None) -> float:
     total = 0.0
     with _LOCK:
         snapshot = list(_SIGNALS)
-    for signal, ts, stored_weight in snapshot:
+    for signal, ts, stored_weight, decay_s in snapshot:
         try:
             age = now - float(ts)
         except (TypeError, ValueError):
@@ -287,7 +309,12 @@ def convergence_score(now_unix: Optional[float] = None) -> float:
         if age < 0:
             # Future-stamped signal — count it (clock skew tolerance).
             age = 0.0
-        if age < window:
+        # Per-signal decay (Phase 3): a signal with its OWN decay_s
+        # counts iff age < decay_s; else fall back to the global window.
+        # Still a pure function of age — NO latch — so recovery is
+        # preserved per-signal.
+        effective_window = decay_s if decay_s is not None else window
+        if age < effective_window:
             try:
                 total += _weight_for(signal) * float(stored_weight)
             except (TypeError, ValueError):
@@ -305,14 +332,15 @@ def _signal_counts(now_unix: Optional[float] = None) -> Dict[str, int]:
     counts: Dict[str, int] = {s.value: 0 for s in AmbiguitySignal}
     with _LOCK:
         snapshot = list(_SIGNALS)
-    for signal, ts, _w in snapshot:
+    for signal, ts, _w, decay_s in snapshot:
         try:
             age = now - float(ts)
         except (TypeError, ValueError):
             continue
         if age < 0:
             age = 0.0
-        if age < window and isinstance(signal, AmbiguitySignal):
+        effective_window = decay_s if decay_s is not None else window
+        if age < effective_window and isinstance(signal, AmbiguitySignal):
             counts[signal.value] = counts.get(signal.value, 0) + 1
     return counts
 

--- a/tests/architecture/test_slice99_sensor_mesh.py
+++ b/tests/architecture/test_slice99_sensor_mesh.py
@@ -1,0 +1,483 @@
+"""Slice 99 — Asynchronous Ambiguity Sensor Mesh tests (live chaos matrix).
+
+The load-bearing properties under test:
+
+  * Producer hooks are tiny, best-effort, and NEVER break the hot path.
+  * The async sampler is a PULL observer — it reads accumulators and
+    fires ``record_ambiguity`` on a DYNAMIC threshold breach.
+  * The convergence engine's per-signal decay preserves the
+    pure-function-of-window recovery (no latch).
+  * Two simultaneous live sources (LLM parse-loop + forced partition)
+    both fire → the REAL ``risk_tier_floor.recommended_floor()`` reaches
+    ``approval_required`` (paranoia) with zero missed signals.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+
+import pytest
+
+from backend.core.ouroboros.governance import ambiguity_sensor_mesh as mesh
+from backend.core.ouroboros.governance import dynamic_risk_convergence as drc
+from backend.core.ouroboros.governance import risk_tier_floor
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Strip mesh + convergence + risk-floor knobs and reset both buffers
+    so each test starts from a known baseline."""
+    for key in list(os.environ):
+        if (
+            key.startswith("JARVIS_SENSOR_MESH_")
+            or key.startswith("JARVIS_CONVERGENCE_")
+            or key in (
+                "JARVIS_AMBIGUITY_SENSOR_MESH_ENABLED",
+                "JARVIS_DYNAMIC_RISK_CONVERGENCE_ENABLED",
+                "JARVIS_MIN_RISK_TIER",
+                "JARVIS_PARANOIA_MODE",
+                "JARVIS_AUTO_APPLY_QUIET_HOURS",
+                "JARVIS_VISION_SENSOR_RISK_FLOOR",
+            )
+        ):
+            monkeypatch.delenv(key, raising=False)
+    mesh.reset_accumulators()
+    drc.reset_signals()
+    yield
+    mesh.reset_accumulators()
+    drc.reset_signals()
+
+
+def _enable_mesh(monkeypatch):
+    monkeypatch.setenv("JARVIS_AMBIGUITY_SENSOR_MESH_ENABLED", "true")
+
+
+def _enable_convergence(monkeypatch):
+    monkeypatch.setenv("JARVIS_DYNAMIC_RISK_CONVERGENCE_ENABLED", "true")
+
+
+# ---------------------------------------------------------------------------
+# 1. Per-signal decay in the convergence engine
+# ---------------------------------------------------------------------------
+
+
+def test_per_signal_decay_counts_then_drops(monkeypatch):
+    _enable_convergence(monkeypatch)
+    # Global window is 60s; this signal has its OWN 10s decay.
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WINDOW_S", "60.0")
+    t0 = 1000.0
+    drc.record_ambiguity(
+        drc.AmbiguitySignal.CONTRADICTORY_OUTPUT,
+        now_unix=t0,
+        weight=1.0,
+        decay_s=10.0,
+    )
+    # At t+5 (< 10s decay) it counts.
+    assert drc.convergence_score(now_unix=t0 + 5) == pytest.approx(1.0)
+    # At t+15 (> its OWN 10s decay, even though global window is 60s) it
+    # drops — per-signal age vs per-signal decay, no latch.
+    assert drc.convergence_score(now_unix=t0 + 15) == pytest.approx(0.0)
+
+
+def test_decay_none_falls_back_to_global_window(monkeypatch):
+    _enable_convergence(monkeypatch)
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WINDOW_S", "60.0")
+    t0 = 2000.0
+    # No decay_s → legacy global-window behavior, byte-identical.
+    drc.record_ambiguity(
+        drc.AmbiguitySignal.CONTRADICTORY_OUTPUT, now_unix=t0,
+    )
+    assert drc.convergence_score(now_unix=t0 + 15) == pytest.approx(1.0)
+    assert drc.convergence_score(now_unix=t0 + 61) == pytest.approx(0.0)
+
+
+def test_decay_nonpositive_falls_back(monkeypatch):
+    _enable_convergence(monkeypatch)
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WINDOW_S", "60.0")
+    t0 = 2500.0
+    drc.record_ambiguity(
+        drc.AmbiguitySignal.MALFORMED_INTENT, now_unix=t0, decay_s=0.0,
+    )
+    drc.record_ambiguity(
+        drc.AmbiguitySignal.MALFORMED_INTENT, now_unix=t0, decay_s=-5.0,
+    )
+    # decay_s<=0 → treated as None → global window.
+    assert drc.convergence_score(now_unix=t0 + 30) == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. Producer hook → accumulator
+# ---------------------------------------------------------------------------
+
+
+def test_hook_appends_to_accumulator(monkeypatch):
+    _enable_mesh(monkeypatch)
+    now = 3000.0
+    for _ in range(5):
+        mesh.note_cross_repo_emit_failure("partition", now_unix=now)
+    count = mesh._window_count(  # noqa: SLF001 — intentional probe
+        mesh.SignalClass.CROSS_REPO_HANDSHAKE, now,
+    )
+    assert count == 5
+
+
+def test_hook_inert_when_master_off():
+    # Master NOT set (default-FALSE).
+    now = 3100.0
+    for _ in range(5):
+        mesh.note_llm_contradiction("x", now_unix=now)
+    count = mesh._window_count(  # noqa: SLF001
+        mesh.SignalClass.CONTRADICTORY_OUTPUT, now,
+    )
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Sampler fires record_ambiguity on threshold breach
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sampler_fires_on_threshold_breach(monkeypatch):
+    _enable_mesh(monkeypatch)
+    _enable_convergence(monkeypatch)
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_CONTRADICTORY_THRESHOLD", "3")
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_CONTRADICTORY_WEIGHT", "6.0")
+    now = 4000.0
+    for _ in range(4):  # 4 >= 3 threshold
+        mesh.note_llm_contradiction("retry-loop", now_unix=now)
+
+    report = await mesh.run_sensor_mesh_once(now_unix=now)
+    assert report.fired["contradictory_output"] is True
+    # The convergence engine actually received the signal → floor rises.
+    assert drc.convergence_score(now_unix=now) >= 6.0
+    assert (
+        drc.recommended_convergence_floor(now_unix=now)
+        == "approval_required"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sampler_does_not_fire_below_threshold(monkeypatch):
+    _enable_mesh(monkeypatch)
+    _enable_convergence(monkeypatch)
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_CONTRADICTORY_THRESHOLD", "5")
+    now = 4200.0
+    for _ in range(2):  # 2 < 5 threshold
+        mesh.note_llm_contradiction("x", now_unix=now)
+    report = await mesh.run_sensor_mesh_once(now_unix=now)
+    assert report.fired["contradictory_output"] is False
+    assert drc.convergence_score(now_unix=now) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# 4. THE CHAOS TEST — two live sources fire simultaneously → paranoia
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chaos_dual_source_reaches_paranoia(monkeypatch):
+    _enable_mesh(monkeypatch)
+    _enable_convergence(monkeypatch)
+    # Each class fires with weight 3.0 → two sources = 6.0 = paranoia.
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_CONTRADICTORY_THRESHOLD", "3")
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_HANDSHAKE_THRESHOLD", "3")
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_CONTRADICTORY_WEIGHT", "3.0")
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_HANDSHAKE_WEIGHT", "3.0")
+    now = 5000.0
+
+    # Simulate a LIVE LLM parsing loop (contradiction burst) AND a forced
+    # partition (emit-failure burst) SIMULTANEOUSLY.
+    for _ in range(5):
+        mesh.note_llm_contradiction("parse-loop", now_unix=now)
+    for _ in range(5):
+        mesh.note_cross_repo_emit_failure("partition", now_unix=now)
+
+    report = await mesh.run_sensor_mesh_once(now_unix=now)
+
+    # BOTH sources fired — zero missed signals.
+    assert report.fired["contradictory_output"] is True
+    assert report.fired["cross_repo_handshake"] is True
+    assert report.window_counts["contradictory_output"] == 5
+    assert report.window_counts["cross_repo_handshake"] == 5
+
+    # The REAL risk_tier_floor reaches approval_required (paranoia).
+    monkeypatch.setattr(drc.time, "time", lambda: now)
+    assert risk_tier_floor.recommended_floor() == "approval_required"
+
+
+# ---------------------------------------------------------------------------
+# 5. Recovery — after bursts stop + decay elapses, floor relaxes to None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recovery_is_automatic_after_decay(monkeypatch):
+    _enable_mesh(monkeypatch)
+    _enable_convergence(monkeypatch)
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_CONTRADICTORY_THRESHOLD", "3")
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_HANDSHAKE_THRESHOLD", "3")
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_CONTRADICTORY_WEIGHT", "3.0")
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_HANDSHAKE_WEIGHT", "3.0")
+    # Per-class convergence decay 10s.
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_CONTRADICTORY_DECAY_S", "10.0")
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_HANDSHAKE_DECAY_S", "10.0")
+    # Mesh sliding window short so accumulators self-clear too.
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_WINDOW_S", "10.0")
+    now = 6000.0
+
+    for _ in range(5):
+        mesh.note_llm_contradiction("x", now_unix=now)
+    for _ in range(5):
+        mesh.note_cross_repo_emit_failure("x", now_unix=now)
+    await mesh.run_sensor_mesh_once(now_unix=now)
+    monkeypatch.setattr(drc.time, "time", lambda: now)
+    assert risk_tier_floor.recommended_floor() == "approval_required"
+
+    # Bursts STOP. Advance past both the mesh window AND the per-signal
+    # convergence decay (10s each). NO reset call anywhere.
+    later = now + 20.0
+    report = await mesh.run_sensor_mesh_once(now_unix=later)
+    # Accumulators aged out → nothing new fires.
+    assert report.fired["contradictory_output"] is False
+    assert report.fired["cross_repo_handshake"] is False
+    # Convergence floor relaxes to None automatically (per-signal decay).
+    assert drc.recommended_convergence_floor(now_unix=later) is None
+    monkeypatch.setattr(drc.time, "time", lambda: later)
+    assert risk_tier_floor.recommended_floor() is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Hot-path safety — hooks swallow everything; emit unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_hook_swallows_accumulator_raise(monkeypatch):
+    _enable_mesh(monkeypatch)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("accumulator exploded")
+
+    # Force a layer INSIDE _append (the never-raises boundary) to blow
+    # up; the public hooks must still swallow it and NEVER propagate.
+    monkeypatch.setattr(mesh, "_ensure_capacity", _boom)
+    mesh.note_cross_repo_emit_failure("x")
+    mesh.note_llm_contradiction("x")
+    mesh.note_malformed_intent("x")  # none of these may raise
+
+
+@pytest.mark.asyncio
+async def test_sampler_swallows_record_ambiguity_raise(monkeypatch):
+    _enable_mesh(monkeypatch)
+    _enable_convergence(monkeypatch)
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_MALFORMED_THRESHOLD", "1")
+    now = 7000.0
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("convergence exploded")
+
+    monkeypatch.setattr(drc, "record_ambiguity", _boom)
+    mesh.note_malformed_intent("x", now_unix=now)
+    # The sampler fire path must swallow the convergence raise.
+    report = await mesh.run_sensor_mesh_once(now_unix=now)
+    # Count breached but the fire failed silently → fired False, no raise.
+    assert report.fired["malformed_intent"] is False
+
+
+def test_emit_ripple_unaffected_by_sensor_raise(monkeypatch):
+    """emit_ripple must return its normal result even if the sensor hook
+    raises — best-effort hook, hot-path safe."""
+    import backend.core.ouroboros.cross_repo_mesh.ripple_emitter as re_mod
+    from backend.core.ouroboros.governance import ambiguity_sensor_mesh
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("sensor exploded")
+
+    # Patch the LAZY-IMPORTED hook target so the emitter's
+    # _note_emit_failure try/except is the boundary under test (the real
+    # hot-path-safety guarantee). emit_ripple must still return normally.
+    monkeypatch.setattr(
+        ambiguity_sensor_mesh, "note_cross_repo_emit_failure", _boom,
+    )
+    monkeypatch.setenv("JARVIS_AMBIGUITY_SENSOR_MESH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CROSS_REPO_EMIT_PSK", "test-psk")
+
+    def _bad_sign(*_a, **_k):
+        raise ValueError("sign boom")
+
+    monkeypatch.setattr(re_mod, "sign_ripple", _bad_sign)
+    payload = re_mod.build_ripple(
+        "test", "intent", {"a": 1}, now_unix=1.0,
+    )
+    result = asyncio.run(re_mod.emit_ripple(payload))
+    assert result.verdict == re_mod.VerifyVerdict.DISABLED
+    assert "sign_error" in (result.detail or "")
+
+
+# ---------------------------------------------------------------------------
+# 7. Loop bound + master-off no-op + garbage tolerance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_terminates_on_iterations(monkeypatch):
+    _enable_mesh(monkeypatch)
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_INTERVAL_S", "0")
+    passes = await asyncio.wait_for(
+        mesh.run_sensor_mesh_loop(iterations=3, interval_s=0.0),
+        timeout=5.0,
+    )
+    assert passes == 3
+
+
+@pytest.mark.asyncio
+async def test_loop_master_off_is_noop(monkeypatch):
+    # Master off → passes run but nothing fires.
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_INTERVAL_S", "0")
+    now = 8000.0
+    for _ in range(10):
+        mesh.note_llm_contradiction("x", now_unix=now)
+    passes = await mesh.run_sensor_mesh_loop(iterations=2, interval_s=0.0)
+    assert passes == 2
+    report = await mesh.run_sensor_mesh_once(now_unix=now)
+    assert report.any_fired is False
+
+
+@pytest.mark.asyncio
+async def test_run_once_never_raises_on_garbage(monkeypatch):
+    _enable_mesh(monkeypatch)
+    # Garbage now_unix → tolerated.
+    report = await mesh.run_sensor_mesh_once(now_unix="not-a-number")  # type: ignore[arg-type]
+    assert isinstance(report, mesh.SensorMeshReport)
+
+
+def test_report_to_dict_roundtrip(monkeypatch):
+    _enable_mesh(monkeypatch)
+    now = 8500.0
+    report = asyncio.run(mesh.run_sensor_mesh_once(now_unix=now))
+    d = report.to_dict()
+    assert d["schema_version"] == mesh.SENSOR_MESH_SCHEMA_VERSION
+    assert set(d["window_counts"]) == {c.value for c in mesh.SignalClass}
+    assert "fired" in d and "weights" in d and "decays" in d
+    assert "thresholds" in d and "evaluated_at_unix" in d
+
+
+# ---------------------------------------------------------------------------
+# 8. AST pins + FlagRegistry seeds
+# ---------------------------------------------------------------------------
+
+
+def test_ast_pins_canonical_pass():
+    pins = mesh.register_shipped_invariants()
+    assert len(pins) >= 4
+    with open(mesh.__file__, "r", encoding="utf-8") as fh:
+        source = fh.read()
+    tree = ast.parse(source)
+    for pin in pins:
+        result = pin.validate(tree, source)
+        assert result == (), f"{pin.invariant_name} failed: {result}"
+
+
+def test_ast_pin_class_taxonomy_regression():
+    pins = {p.invariant_name: p for p in mesh.register_shipped_invariants()}
+    pin = pins["sensor_mesh_class_taxonomy_closed"]
+    bad = (
+        "import enum\n"
+        "class SignalClass(str, enum.Enum):\n"
+        "    CROSS_REPO_HANDSHAKE = 'cross_repo_handshake'\n"
+        "    CONTRADICTORY_OUTPUT = 'contradictory_output'\n"  # malformed removed
+    )
+    tree = ast.parse(bad)
+    assert pin.validate(tree, bad) != ()
+
+
+def test_ast_pin_authority_regression():
+    pins = {p.invariant_name: p for p in mesh.register_shipped_invariants()}
+    name = next(n for n in pins if "authority" in n)
+    pin = pins[name]
+    bad = (
+        "from backend.core.ouroboros.governance.orchestrator import foo\n"
+    )
+    tree = ast.parse(bad)
+    assert pin.validate(tree, bad) != ()
+
+
+def test_ast_pin_master_default_false_regression():
+    pins = {p.invariant_name: p for p in mesh.register_shipped_invariants()}
+    name = next(n for n in pins if "master" in n)
+    pin = pins[name]
+    bad = (
+        "def master_enabled():\n"
+        "    return _flag('X', default=True)\n"
+    )
+    tree = ast.parse(bad)
+    assert pin.validate(tree, bad) != ()
+
+
+def test_ast_pin_pull_model_regression():
+    """If a producer hook calls record_ambiguity directly (push from the
+    hot path) the PULL-model pin must trip."""
+    pins = {p.invariant_name: p for p in mesh.register_shipped_invariants()}
+    pin = pins["sensor_mesh_hooks_pull_model"]
+    bad = (
+        "def note_llm_contradiction(detail=''):\n"
+        "    drc.record_ambiguity(SIG)\n"
+    )
+    tree = ast.parse(bad)
+    assert pin.validate(tree, bad) != ()
+
+
+def test_flag_registry_seed_count():
+    class _Reg:
+        def __init__(self):
+            self.registered = []
+
+        def register(self, spec):
+            self.registered.append(spec)
+
+    reg = _Reg()
+    count = mesh.register_flags(reg)
+    assert count == len(reg.registered)
+    assert count >= 1
+    names = {s.name for s in reg.registered}
+    assert "JARVIS_AMBIGUITY_SENSOR_MESH_ENABLED" in names
+
+
+# ---------------------------------------------------------------------------
+# 9. Live emit-side wiring — emit failure feeds the accumulator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_failure_feeds_handshake_accumulator(monkeypatch):
+    """End-to-end: a real emit_ripple sign failure increments the
+    handshake accumulator via the wired hook."""
+    _enable_mesh(monkeypatch)
+    import backend.core.ouroboros.cross_repo_mesh.ripple_emitter as re_mod
+
+    monkeypatch.setenv("JARVIS_CROSS_REPO_RIPPLE_EMIT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CROSS_REPO_EMIT_PSK", "test-psk")
+    now = 9000.0
+
+    def _bad_sign(*_a, **_k):
+        raise ValueError("sign boom")
+
+    monkeypatch.setattr(re_mod, "sign_ripple", _bad_sign)
+    payload = re_mod.build_ripple("test", "intent", {"a": 1}, now_unix=now)
+
+    before = mesh._window_count(  # noqa: SLF001
+        mesh.SignalClass.CROSS_REPO_HANDSHAKE, now,
+    )
+    result = await re_mod.emit_ripple(payload)
+    assert result.verdict == re_mod.VerifyVerdict.DISABLED
+    after = mesh._window_count(  # noqa: SLF001
+        mesh.SignalClass.CROSS_REPO_HANDSHAKE, now,
+    )
+    assert after == before + 1


### PR DESCRIPTION
Wires LIVE producer hooks into `record_ambiguity` (the Slice-98 convergence-engine seam) — real ambiguity signals now reach the engine that raises the risk-tier floor + auto-relaxes. **Best-effort, async/non-blocking, pull-model, §33.1 default-FALSE.** The brain (Slice 98) now has a nervous system.

## Per-signal decay (`dynamic_risk_convergence.py`)
`record_ambiguity` gains `decay_s`; `convergence_score` uses each signal's **own** effective window. **Preserves pure-function recovery** (per-signal age vs per-signal decay — no latch; the reviewer re-queried an old timestamp and it still recomputed). Backward-compat: `decay_s=None` == prior behavior; all 20 Slice-98 tests unchanged.

## `ambiguity_sensor_mesh.py` (new)
- **3 producer hooks** — `note_cross_repo_emit_failure` / `note_llm_contradiction` / `note_malformed_intent`. Tiny O(1) appends, best-effort, **never raise**, inert master-off. **Pull model**: hooks only append to bounded deques; they **never** call `record_ambiguity` (AST-pinned).
- **Async sampler** — `run_sensor_mesh_once` reads each class's sliding-window count; on threshold breach fires `record_ambiguity(signal, weight, decay_s)`. `run_sensor_mesh_loop` is the `asyncio.sleep` cadence loop (iterations-bounded, never-raises).

## Wiring (fire-and-forget honored)
- **Emit-side cross-repo failure: WIRED** in `ripple_emitter.py` (lazy-import + try/except at `sign_error` + `write_failed` — emit-side only, **no ACK**; a sensor raise can **never** alter the `EmitResult`, test-proven).
- **LLM-contradiction + malformed-intent: exposed + tested**; orchestrator GENERATE_RETRY wiring **deferred** (1-line follow-up — did not touch the 6,000-line hot-path FSM; safety > completeness).

## Chaos test (Phase 4)
Simultaneous LLM-parse-loop burst + forced-partition burst → **both fire** → the **real** `risk_tier_floor.recommended_floor()` == `approval_required` (paranoia), zero missed; recovery relaxes to `None` after per-signal decay, no reset.

## Tests / review
23 tests + 95 regression green. Independently reviewed with own probes: emit unbreakable by a raising sensor, no latch, pull-model AST-enforced, inert-by-default, orchestrator honestly 0-line-diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Slice 99 asynchronous ambiguity sensor mesh with live producer hooks that feed Slice 98’s convergence engine, and adds per‑signal decay to `record_ambiguity` for automatic relaxation. Emit-side cross-repo failure is now wired; the mesh is off by default and does nothing until enabled.

- **New Features**
  - Producer hooks: `note_cross_repo_emit_failure`, `note_llm_contradiction`, `note_malformed_intent` append to bounded deques (O(1), never raise, inert when `JARVIS_AMBIGUITY_SENSOR_MESH_ENABLED` is off).
  - Async sampler: `run_sensor_mesh_once` reads sliding-window counts and fires `record_ambiguity(signal, weight, decay_s)` on threshold breach; `run_sensor_mesh_loop` provides a cadence loop; includes a `SensorMeshReport`.
  - Per-signal decay: `record_ambiguity(decay_s)` lets each signal relax on its own horizon; `convergence_score` uses the signal’s effective window; backward-compatible when `decay_s=None`.
  - Wiring: `ripple_emitter` lazily calls the hook on sign/write failures (try/except; never affects `EmitResult`); orchestrator wiring for `note_llm_contradiction`/`note_malformed_intent` is exposed but deferred.

- **Migration**
  - Enable the mesh with `JARVIS_AMBIGUITY_SENSOR_MESH_ENABLED=true` and run `run_sensor_mesh_loop()` in a background task.
  - Tune behavior via `JARVIS_SENSOR_MESH_*` (window, interval, thresholds, weights, decays).
  - Optionally wire orchestrator GENERATE_RETRY to `note_llm_contradiction` in a follow-up.

<sup>Written for commit 91527be68e8c7166063958149d48292716360ecd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

