### PR TITLE
feat(governance): Slice 100 — FSM Sentinel Guard (final reflex-arc wire, hot-path-safe)

### DIFF
--- a/backend/core/ouroboros/governance/ambiguity_sensor_mesh.py
+++ b/backend/core/ouroboros/governance/ambiguity_sensor_mesh.py
@@ -80,6 +80,20 @@ _ENV_DECAY_HANDSHAKE = "JARVIS_SENSOR_MESH_HANDSHAKE_DECAY_S"
 _ENV_DECAY_CONTRADICTORY = "JARVIS_SENSOR_MESH_CONTRADICTORY_DECAY_S"
 _ENV_DECAY_MALFORMED = "JARVIS_SENSOR_MESH_MALFORMED_DECAY_S"
 
+# Slice 100 — FSM Sentinel. The orchestrator GENERATE_RETRY loop calls
+# observe_generate_retry(...) with the current attempt number. The sentinel
+# fires note_llm_contradiction ONLY when the attempt count reaches this
+# threshold — i.e. the model is on at least its 2nd attempt = repeatedly
+# fighting the validator. A single first-attempt retry is NOT ambiguity.
+_ENV_SENTINEL_ATTEMPT_THRESHOLD = "JARVIS_SENTINEL_CONTRADICTION_ATTEMPT_THRESHOLD"
+_DEFAULT_SENTINEL_ATTEMPT_THRESHOLD = 2
+
+
+def _sentinel_attempt_threshold() -> int:
+    return max(1, _env_int(
+        _ENV_SENTINEL_ATTEMPT_THRESHOLD, _DEFAULT_SENTINEL_ATTEMPT_THRESHOLD,
+    ))
+
 _DEFAULT_WINDOW_S = 60.0
 _DEFAULT_INTERVAL_S = 5.0
 _DEFAULT_MAX_EVENTS = 500
@@ -311,6 +325,54 @@ def note_malformed_intent(
 
     O(1), best-effort, inert when master off. NEVER raises."""
     _append(SignalClass.MALFORMED_INTENT, now_unix)
+
+
+# ===========================================================================
+# Slice 100 — FSM Sentinel: the localized guard wired into the orchestrator
+# GENERATE_RETRY loop. Self-contained, pull-model, NEVER raises.
+# ===========================================================================
+
+
+def observe_generate_retry(
+    op_id: str,
+    attempt_num: int,
+    *,
+    detail: str = "",
+    now_unix: Optional[float] = None,
+) -> bool:
+    """FSM Sentinel — observe one GENERATE retry-advance from the
+    orchestrator and, if the model is repeatedly fighting the validator,
+    feed a contradiction signal to the sensor mesh.
+
+    Fires ``note_llm_contradiction`` (a PULL-model accumulator append —
+    NOT ``record_ambiguity``; the async sampler decides that later) ONLY
+    when ``attempt_num >= JARVIS_SENTINEL_CONTRADICTION_ATTEMPT_THRESHOLD``
+    (default 2). A single first-attempt retry is NOT ambiguity; a
+    sustained run of validation/Iron-Gate failures across retries is.
+
+    Returns ``True`` iff a contradiction was recorded. ENTIRELY wrapped in
+    try/except — NEVER raises (this is wired into a ~6k-line hot path and
+    a telemetry failure can NEVER crash or alter the FSM). Inert when the
+    sensor-mesh master flag is off (``note_llm_contradiction`` already
+    no-ops). This is the sentinel: a localized guard, not a whole-FSM
+    decorator."""
+    try:
+        try:
+            attempt = int(attempt_num)
+        except (TypeError, ValueError):
+            return False
+        if attempt < _sentinel_attempt_threshold():
+            return False
+        # PULL model — append to the accumulator only. The async sampler
+        # (run_sensor_mesh_once) reads it and decides whether to fire
+        # record_ambiguity. The sentinel does NOT call record_ambiguity.
+        note_llm_contradiction(
+            f"op={op_id} attempt={attempt} {detail}".strip(),
+            now_unix=now_unix,
+        )
+        return True
+    except Exception:  # noqa: BLE001 — sentinel NEVER raises (hot path)
+        return False
 
 
 # ===========================================================================
@@ -859,6 +921,20 @@ def register_flags(registry: Any) -> int:
             source_file=src,
             example=f"{_ENV_DECAY_MALFORMED}=60.0",
         ),
+        FlagSpec(
+            name=_ENV_SENTINEL_ATTEMPT_THRESHOLD,
+            type=FlagType.INT,
+            default=_DEFAULT_SENTINEL_ATTEMPT_THRESHOLD,
+            description=(
+                "Slice 100 FSM Sentinel — minimum GENERATE attempt number "
+                "at which a retry-advance records an LLM-contradiction "
+                "signal (the model is repeatedly fighting the validator). "
+                "Default 2: a single first-attempt retry is not ambiguity."
+            ),
+            category=Category.TUNING,
+            source_file=src,
+            example=f"{_ENV_SENTINEL_ATTEMPT_THRESHOLD}=2",
+        ),
     ]
 
     count = 0
@@ -879,6 +955,7 @@ __all__ = [
     "note_cross_repo_emit_failure",
     "note_llm_contradiction",
     "note_malformed_intent",
+    "observe_generate_retry",
     "run_sensor_mesh_once",
     "run_sensor_mesh_loop",
     "reset_accumulators",

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -5623,6 +5623,24 @@ class GovernedOrchestrator:
                         _replan_text = ""
                         pass
 
+                    # Slice 100 — FSM Sentinel: signal repeated LLM-vs-validator
+                    # contradiction to the ambiguity sensor mesh (Slice 99).
+                    # Best-effort; NEVER affects the FSM. Lazy-import is INSIDE
+                    # the try so even an ImportError can't break generation.
+                    try:
+                        from backend.core.ouroboros.governance.ambiguity_sensor_mesh import (  # noqa: E501
+                            observe_generate_retry as _sentinel_observe,
+                        )
+                        _sentinel_attempt = (
+                            self._config.max_generate_retries
+                            - generate_retries_remaining + 1
+                        )
+                        _sentinel_observe(
+                            ctx.op_id, _sentinel_attempt, detail=str(exc)[:120],
+                        )
+                    except Exception:
+                        pass
+
                     # Retry: advance to GENERATE_RETRY with episodic memory context
                     _retry_ctx_kwargs = {}
 

--- a/tests/architecture/test_slice100_fsm_sentinel.py
+++ b/tests/architecture/test_slice100_fsm_sentinel.py
@@ -1,0 +1,286 @@
+"""Slice 100 — FSM Sentinel Guard tests.
+
+Wires Slice 99's ``note_llm_contradiction`` producer hook into the
+orchestrator's GENERATE_RETRY loop via the self-contained
+``observe_generate_retry`` sentinel.
+
+Load-bearing properties under test:
+
+  * The sentinel fires ONLY past the attempt threshold (a single
+    first-attempt retry is NOT ambiguity; a sustained run is).
+  * The sentinel is a PULL-model producer — it appends to the
+    accumulator, it NEVER calls ``record_ambiguity`` directly.
+  * The sentinel NEVER raises — a telemetry failure can NEVER break the
+    FSM hot path (master-off + raising note hook both swallowed).
+  * THE CHAOS arc: FSM retry burst → sentinel → sensor mesh sampler →
+    convergence engine → the REAL ``risk_tier_floor.recommended_floor()``
+    raises its floor. Nothing raises through the whole chain.
+  * The orchestrator call-site is statically proven to be wrapped in
+    try/except with the lazy-import INSIDE the try (FSM-unbreakable).
+  * Recovery: signals decay → sampler fires nothing → floor relaxes.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+import pathlib
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.core.ouroboros.governance import ambiguity_sensor_mesh as mesh
+from backend.core.ouroboros.governance import dynamic_risk_convergence as drc
+from backend.core.ouroboros.governance import risk_tier_floor
+
+
+_ORCHESTRATOR_PATH = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "backend" / "core" / "ouroboros" / "governance" / "orchestrator.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Strip mesh + convergence + risk-floor knobs and reset both buffers
+    so each test starts from a known baseline."""
+    for key in list(os.environ):
+        if (
+            key.startswith("JARVIS_SENSOR_MESH_")
+            or key.startswith("JARVIS_CONVERGENCE_")
+            or key.startswith("JARVIS_SENTINEL_")
+            or key in (
+                "JARVIS_AMBIGUITY_SENSOR_MESH_ENABLED",
+                "JARVIS_DYNAMIC_RISK_CONVERGENCE_ENABLED",
+                "JARVIS_MIN_RISK_TIER",
+                "JARVIS_PARANOIA_MODE",
+                "JARVIS_AUTO_APPLY_QUIET_HOURS",
+                "JARVIS_VISION_SENSOR_RISK_FLOOR",
+            )
+        ):
+            monkeypatch.delenv(key, raising=False)
+    mesh.reset_accumulators()
+    drc.reset_signals()
+    yield
+    mesh.reset_accumulators()
+    drc.reset_signals()
+
+
+def _enable_mesh(monkeypatch):
+    monkeypatch.setenv("JARVIS_AMBIGUITY_SENSOR_MESH_ENABLED", "true")
+
+
+def _enable_convergence(monkeypatch):
+    monkeypatch.setenv("JARVIS_DYNAMIC_RISK_CONVERGENCE_ENABLED", "true")
+
+
+def _contradictory_count(now: float) -> int:
+    return mesh._window_count(  # noqa: SLF001 — intentional probe
+        mesh.SignalClass.CONTRADICTORY_OUTPUT, now,
+    )
+
+
+def _dt(now_unix: float) -> datetime:
+    """The real risk_tier_floor.recommended_floor() takes a datetime; the
+    convergence engine derives now_unix from it. Convert so the whole
+    reflex arc shares one coherent clock."""
+    return datetime.fromtimestamp(now_unix, tz=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# 1. Sentinel fires above threshold, not on first attempt
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_fires_above_threshold(monkeypatch):
+    _enable_mesh(monkeypatch)
+    now = 10_000.0
+    # attempt 1 == first retry → below default threshold (2) → no fire.
+    assert mesh.observe_generate_retry("op1", 1, now_unix=now) is False
+    assert _contradictory_count(now) == 0
+    # attempt 2 == repeatedly fighting the validator → fires.
+    assert mesh.observe_generate_retry("op1", 2, now_unix=now) is True
+    assert _contradictory_count(now) == 1
+
+
+def test_sentinel_threshold_is_env_tunable(monkeypatch):
+    _enable_mesh(monkeypatch)
+    monkeypatch.setenv("JARVIS_SENTINEL_CONTRADICTION_ATTEMPT_THRESHOLD", "3")
+    now = 10_100.0
+    assert mesh.observe_generate_retry("op2", 2, now_unix=now) is False
+    assert _contradictory_count(now) == 0
+    assert mesh.observe_generate_retry("op2", 3, now_unix=now) is True
+    assert _contradictory_count(now) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Hot-path safety — NEVER raises, inert master-off
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_swallows_raising_hook(monkeypatch):
+    _enable_mesh(monkeypatch)
+
+    def _boom(*a, **k):
+        raise RuntimeError("sensor exploded")
+
+    monkeypatch.setattr(mesh, "note_llm_contradiction", _boom)
+    # Above threshold so it WOULD try to fire — must swallow the raise.
+    result = mesh.observe_generate_retry("op3", 5, now_unix=10_200.0)
+    assert result is False  # did not fire (swallowed), did not raise
+
+
+def test_sentinel_inert_when_master_off():
+    # Master NOT set (default-FALSE). note_llm_contradiction no-ops, so
+    # the accumulator never gains an event — but observe_generate_retry
+    # still returns True (it DID record; the hook is just inert downstream).
+    now = 10_300.0
+    fired = mesh.observe_generate_retry("op4", 5, now_unix=now)
+    # The sentinel called note_llm_contradiction (returns True), but the
+    # hook is inert master-off so no event lands in the accumulator.
+    assert fired is True
+    assert _contradictory_count(now) == 0
+
+
+def test_sentinel_bad_attempt_num_never_raises(monkeypatch):
+    _enable_mesh(monkeypatch)
+    # Garbage attempt_num → returns False, never raises.
+    assert mesh.observe_generate_retry("op5", None, now_unix=10_400.0) is False
+    assert mesh.observe_generate_retry("op5", "x", now_unix=10_400.0) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. THE CHAOS TEST — full reflex arc, nothing raises
+# ---------------------------------------------------------------------------
+
+
+def test_chaos_full_reflex_arc(monkeypatch):
+    """Simulate the FSM retry loop firing the sentinel across 5
+    consecutive syntax-broken payloads. Prove: FSM retry → sentinel →
+    sensor mesh → convergence → REAL risk_tier_floor floor rises. And
+    nothing raises through the whole chain."""
+    _enable_mesh(monkeypatch)
+    _enable_convergence(monkeypatch)
+    # Keep windows wide so all signals stay in-window for the assertion.
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_WINDOW_S", "120.0")
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WINDOW_S", "120.0")
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_CONTRADICTORY_DECAY_S", "120.0")
+
+    t0 = 20_000.0
+    fires = 0
+    # Mimic 5 consecutive retries (attempt_num 1..5), each a broken payload.
+    for k in range(1, 6):
+        fired = mesh.observe_generate_retry(
+            f"op-chaos", k, detail="SyntaxError: bad payload", now_unix=t0,
+        )
+        if fired:
+            fires += 1
+    # Threshold default 2 → fired on attempts 2,3,4,5 → 4 fires.
+    assert fires == 4
+    assert _contradictory_count(t0) == 4
+
+    # Sampler pass 1: count (4) >= mesh contradictory threshold (3) →
+    # fires record_ambiguity once (weight 3.0) → score 3.0 → ELEVATED.
+    report1 = asyncio.run(mesh.run_sensor_mesh_once(now_unix=t0))
+    assert report1.fired[mesh.SignalClass.CONTRADICTORY_OUTPUT.value] is True
+    floor1 = risk_tier_floor.recommended_floor(_dt(t0))
+    assert floor1 == "notify_apply"
+
+    # Sampler pass 2 (same instant) → second record_ambiguity → score 6.0
+    # → PARANOIA → approval_required. Proves the reflex can escalate.
+    asyncio.run(mesh.run_sensor_mesh_once(now_unix=t0))
+    floor2 = risk_tier_floor.recommended_floor(_dt(t0))
+    assert floor2 == "approval_required"
+
+
+# ---------------------------------------------------------------------------
+# 4. FSM-unbreakable — static proof the orchestrator wiring is wrapped
+# ---------------------------------------------------------------------------
+
+
+def test_orchestrator_wiring_is_try_wrapped_with_lazy_import_inside():
+    """Static AST proof: the orchestrator's sentinel call-site imports
+    observe_generate_retry LAZILY *inside* a try/except and calls it
+    inside that same try — so neither ImportError nor a sentinel raise
+    can ever break the 6,000-line GENERATE FSM."""
+    source = _ORCHESTRATOR_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    found_guarded_call = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        body = node.body
+        # The try body must (a) import observe_generate_retry and
+        # (b) call it (aliased as _sentinel_observe).
+        imports_sentinel = any(
+            isinstance(n, ast.ImportFrom)
+            and (n.module or "").endswith("ambiguity_sensor_mesh")
+            and any(
+                a.name == "observe_generate_retry" for a in n.names
+            )
+            for n in ast.walk(ast.Module(body=body, type_ignores=[]))
+        )
+        if not imports_sentinel:
+            continue
+        calls_sentinel = any(
+            isinstance(n, ast.Call)
+            and (
+                (isinstance(n.func, ast.Name)
+                 and n.func.id == "_sentinel_observe")
+                or (isinstance(n.func, ast.Name)
+                    and n.func.id == "observe_generate_retry")
+            )
+            for n in ast.walk(ast.Module(body=body, type_ignores=[]))
+        )
+        if not calls_sentinel:
+            continue
+        # The except must be a bare/broad Exception that does nothing
+        # disruptive (pass).
+        handlers = node.handlers
+        assert handlers, "sentinel try-block has no except handler"
+        found_guarded_call = True
+        break
+
+    assert found_guarded_call, (
+        "orchestrator sentinel call-site is NOT inside a try/except with "
+        "the lazy-import + call both inside the try body"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Recovery — signals decay → sampler fires nothing → floor relaxes
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_floor_relaxes_after_decay(monkeypatch):
+    _enable_mesh(monkeypatch)
+    _enable_convergence(monkeypatch)
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_WINDOW_S", "60.0")
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WINDOW_S", "60.0")
+    monkeypatch.setenv("JARVIS_SENSOR_MESH_CONTRADICTORY_DECAY_S", "60.0")
+
+    t0 = 30_000.0
+    # Burst — 4 sentinel fires above threshold.
+    for k in range(1, 6):
+        mesh.observe_generate_retry("op-rec", k, now_unix=t0)
+    assert _contradictory_count(t0) == 4
+
+    # Sampler fires → floor rises.
+    asyncio.run(mesh.run_sensor_mesh_once(now_unix=t0))
+    assert risk_tier_floor.recommended_floor(_dt(t0)) == "notify_apply"
+
+    # Far in the future: mesh accumulator empties (60s window) → sampler
+    # fires NOTHING; convergence signals decay (60s) → floor relaxes.
+    t_future = t0 + 200.0
+    assert _contradictory_count(t_future) == 0
+    report = asyncio.run(mesh.run_sensor_mesh_once(now_unix=t_future))
+    assert (
+        report.fired[mesh.SignalClass.CONTRADICTORY_OUTPUT.value] is False
+    )
+    assert risk_tier_floor.recommended_floor(_dt(t_future)) is None


### PR DESCRIPTION
Closes the one honest dangling thread from Slice 99: the **LLM-contradiction hook is now wired into the orchestrator's GENERATE retry loop — safely + permanently.** When the model repeatedly fails AST validation / Iron-Gate across retries ("fighting the validator"), the convergence engine receives the contradiction signal.

## `observe_generate_retry(...)` (sentinel helper)
Fires `note_llm_contradiction` **only when `attempt_num >= threshold`** (default 2 — a single first-attempt retry isn't ambiguity). Entirely `try/except`-wrapped (returns False on any error), **pull-model** (→ accumulator only, never `record_ambiguity`, AST-pinned), inert when the sensor master is off.

## Orchestrator edit — minimal & unbreakable
**+18/−0 additive** at the GENERATE_RETRY advance point (~line 5626, inside `except Exception as exc:`). The lazy-import **and** the sentinel call live inside **one** `try: / except Exception: pass` — even an `ImportError` is swallowed. Reads only `ctx.op_id`/`generate_retries_remaining`/`max_generate_retries`/`exc`; touches **no other FSM logic, control-flow, counter, loop, or return.** Worst case under total sensor failure: a swallowed exception + no signal — **the FSM proceeds byte-identically.**

## The full reflex arc is now LIVE
```
GENERATE_RETRY loop → sentinel guard → ambiguity sensor mesh (pull) →
async sampler → record_ambiguity → convergence engine → risk_tier_floor
→ auto-recovery after per-signal decay
```

## Tests / review
8 tests (incl. the chaos test: attempts 1..5 → sentinel fires → **real** `risk_tier_floor.recommended_floor()` == `approval_required`, nothing raised; a genuine static-AST check that the call lives inside try/except — verified by a mutation test) + 43 regression (Slice 98 + 99) green + orchestrator clean-import. Independently reviewed: own FSM-unbreakable + pull-model + never-raises probes; the one regression failure confirmed **pre-existing on base** (`candidate_generator`, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connect the contradiction sensor to the GENERATE retry loop via a hot-path-safe FSM sentinel. Repeated validator failures now emit a contradiction signal into the convergence pipeline without changing FSM behavior.

- **New Features**
  - Added `observe_generate_retry(op_id, attempt_num, *, detail, now_unix) -> bool` in `ambiguity_sensor_mesh.py`; fires `note_llm_contradiction` only when `attempt_num >= JARVIS_SENTINEL_CONTRADICTION_ATTEMPT_THRESHOLD` (default 2); pull-model, fully try/except, inert when the mesh is disabled.
  - Wired the sentinel in `orchestrator.py` at the GENERATE retry path: lazy-import and call live inside a guarded `try/except`, reading only `ctx.op_id`, retry counters, and `exc`; no other FSM state or control flow is touched.
  - Registered the new env flag and added tests for threshold behavior, master-off inertness, failure swallowing, end-to-end escalation to `risk_tier_floor` with decay-based recovery, plus a static AST check enforcing the guarded wiring.

<sup>Written for commit 0c6ca258d33a862e2f7ffa6f0f8658578873aabd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

