### PR TITLE
Slice 101 — Cognitive Integration Bus & the belief-revision learning loop

### DIFF
--- a/backend/core/ouroboros/governance/cognitive_bus.py
+++ b/backend/core/ouroboros/governance/cognitive_bus.py
@@ -1,0 +1,227 @@
+"""Cognitive Integration Bus — Slice 101 (Asynchronous Cognitive Awakening).
+
+A *thin* adapter that lets dormant "cognitive" substrates (belief revision,
+counterfactual rehearsal, predictive postmortem, autonomous graduation,
+cognitive load shedding, MCP output scanning) react to Orchestrator/GLS
+lifecycle transitions WITHOUT bolting blocking synchronous calls into the FSM
+hot path.
+
+DESIGN (verify-first, 2026-06-05):
+  * We do NOT build a new pub/sub. We COMPOSE the production-hardened
+    ``backend.core.trinity_event_bus.TrinityEventBus`` — async delivery via
+    priority queues + per-handler ``asyncio.wait_for`` fault isolation, so a
+    slow/broken cognitive subscriber can never stall the FSM. ``SkillObserver``
+    already subscribes to this bus; we follow that precedent.
+  * The orchestrator hot path only ever calls :func:`publish_lifecycle_event`,
+    which is **sync-safe, fire-and-forget, and NEVER raises**: it schedules a
+    publish coroutine on the running loop and returns immediately. If the master
+    flag is off, the bus was never created, or there is no running loop, it is a
+    silent no-op (legacy byte-identical).
+  * Subscribers are **observational** — they record/forecast and feed back only
+    through existing advisory channels (prompt-injected priors, risk-floor).
+    They hold NO authority over the FSM (Manifesto §1 invariant preserved).
+
+Master flag ``JARVIS_COGNITIVE_BUS_ENABLED`` — §33.1 default-FALSE. When off,
+publish is a no-op and no subscribers register, so the system is identical to
+pre-Slice-101 behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional
+
+logger = logging.getLogger("ouroboros.cognitive_bus")
+
+_ENV_ENABLED = "JARVIS_COGNITIVE_BUS_ENABLED"
+_TRUTHY = ("1", "true", "yes", "on")
+
+# --- Lifecycle vocabulary (closed) -----------------------------------------
+# Namespaced under a dedicated topic root so cognitive subscribers can match a
+# single wildcard pattern and never collide with the existing Trinity topics.
+_TOPIC_PREFIX = "ouroboros.lifecycle"
+
+LIFECYCLE_PRE_APPLY = "pre_apply"
+LIFECYCLE_POST_APPLY = "post_apply"
+LIFECYCLE_POST_FAILURE = "post_failure"
+LIFECYCLE_SESSION_END = "session_end"
+LIFECYCLE_INTAKE_ACCEPT = "intake_accept"
+LIFECYCLE_TOOL_EMIT = "tool_emit"
+
+_LIFECYCLE_KINDS = frozenset(
+    {
+        LIFECYCLE_PRE_APPLY,
+        LIFECYCLE_POST_APPLY,
+        LIFECYCLE_POST_FAILURE,
+        LIFECYCLE_SESSION_END,
+        LIFECYCLE_INTAKE_ACCEPT,
+        LIFECYCLE_TOOL_EMIT,
+    }
+)
+
+
+def cognitive_bus_enabled() -> bool:
+    """§33.1 master — default FALSE. Never raises."""
+    try:
+        raw = os.environ.get(_ENV_ENABLED)
+        if raw is None:
+            return False
+        return raw.strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001 — env access must never break the hot path
+        return False
+
+
+def lifecycle_topic(kind: str) -> str:
+    """Full topic string for a lifecycle kind, e.g. ``ouroboros.lifecycle.pre_apply``."""
+    return f"{_TOPIC_PREFIX}.{kind}"
+
+
+def lifecycle_pattern() -> str:
+    """Wildcard pattern matching every lifecycle topic (for subscribers)."""
+    return f"{_TOPIC_PREFIX}.*"
+
+
+def is_lifecycle_kind(kind: str) -> bool:
+    return kind in _LIFECYCLE_KINDS
+
+
+async def _safe_publish(
+    bus: Any,
+    topic: str,
+    data: Dict[str, Any],
+    priority: Any,
+    correlation_id: Optional[str],
+) -> None:
+    """Await the bus publish, swallowing ALL errors so the scheduled task can
+    never surface an unretrieved exception (e.g. RuntimeError 'not running')."""
+    try:
+        from backend.core.trinity_event_bus import RepoType
+
+        await bus.publish_raw(
+            topic,
+            data,
+            priority=priority,
+            target=RepoType.JARVIS,  # local-only: no cross-repo lifecycle noise
+            persist=False,           # high-volume telemetry; never hits the WAL
+            correlation_id=correlation_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — fire-and-forget; never propagate
+        logger.debug("[CognitiveBus] publish swallowed: %s", exc)
+
+
+def publish_lifecycle_event(
+    kind: str,
+    payload: Optional[Dict[str, Any]] = None,
+    *,
+    priority: Any = None,
+    correlation_id: Optional[str] = None,
+) -> bool:
+    """Fire-and-forget publish of an FSM lifecycle transition. SYNC-SAFE and
+    NEVER raises — safe to drop into any orchestrator/GLS seam.
+
+    Returns True iff a publish task was actually scheduled (master on + bus
+    running + running loop present + known kind); False on any inert path. The
+    boolean is for tests/telemetry only — callers ignore it.
+    """
+    try:
+        if not cognitive_bus_enabled():
+            return False
+        if kind not in _LIFECYCLE_KINDS:
+            return False
+
+        from backend.core.trinity_event_bus import (
+            EventPriority,
+            get_event_bus_if_exists,
+            is_event_bus_running,
+        )
+
+        if not is_event_bus_running():
+            # Do NOT create a bus from the hot path; if nobody booted it, skip.
+            return False
+        bus = get_event_bus_if_exists()
+        if bus is None:
+            return False
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop (sync context with no event loop) — best-effort skip.
+            return False
+
+        prio = priority if priority is not None else EventPriority.NORMAL
+        data = dict(payload or {})
+        data.setdefault("lifecycle_kind", kind)
+        loop.create_task(
+            _safe_publish(bus, lifecycle_topic(kind), data, prio, correlation_id)
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — the hot path must never see us raise
+        logger.debug("[CognitiveBus] publish_lifecycle_event swallowed: %s", exc)
+        return False
+
+
+# --- Subscriber registry ----------------------------------------------------
+# A cognitive subscriber is just (pattern, async handler). We wrap each handler
+# so a buggy subscriber can never propagate (belt-and-suspenders on top of the
+# bus's own per-handler fault isolation).
+
+CognitiveHandler = Callable[[Any], Awaitable[None]]
+
+
+class CognitiveSubscriber:
+    """A bound (pattern, handler) pair plus a human label for telemetry."""
+
+    __slots__ = ("label", "pattern", "handler")
+
+    def __init__(self, label: str, pattern: str, handler: CognitiveHandler) -> None:
+        self.label = label
+        self.pattern = pattern
+        self.handler = handler
+
+
+def _wrap_handler(sub: CognitiveSubscriber) -> CognitiveHandler:
+    async def _guarded(event: Any) -> None:
+        try:
+            await sub.handler(event)
+        except Exception as exc:  # noqa: BLE001 — one bad subscriber never escapes
+            logger.debug("[CognitiveBus] subscriber %s swallowed: %s", sub.label, exc)
+
+    return _guarded
+
+
+async def register_cognitive_subscribers(
+    subscribers: Iterable[CognitiveSubscriber],
+    *,
+    bus: Any = None,
+) -> List[str]:
+    """Subscribe each cognitive subscriber to the bus. Called ONCE at boot (not
+    the hot path), so here it is fine to get-or-create the bus. Returns the list
+    of subscription IDs. Inert (returns []) when the master flag is off. Never
+    raises; a single failed subscribe is skipped, not fatal.
+    """
+    if not cognitive_bus_enabled():
+        return []
+    sub_ids: List[str] = []
+    try:
+        if bus is None:
+            from backend.core.trinity_event_bus import (
+                RepoType,
+                get_trinity_event_bus,
+            )
+
+            bus = await get_trinity_event_bus(RepoType.JARVIS)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[CognitiveBus] bus acquisition failed: %s", exc)
+        return []
+
+    for sub in subscribers:
+        try:
+            sid = await bus.subscribe(sub.pattern, _wrap_handler(sub))
+            sub_ids.append(sid)
+            logger.debug("[CognitiveBus] registered subscriber %s -> %s", sub.label, sub.pattern)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[CognitiveBus] subscribe failed for %s: %s", sub.label, exc)
+            continue
+    return sub_ids

--- a/backend/core/ouroboros/governance/cognitive_subscribers.py
+++ b/backend/core/ouroboros/governance/cognitive_subscribers.py
@@ -1,0 +1,157 @@
+"""Cognitive subscribers — Slice 101 Phase 3 (Adaptive Intelligence Invariant).
+
+Closes the synthetic learning loop on top of the :mod:`cognitive_bus`:
+
+    GENERATE failure / cage block
+        → orchestrator publishes ``ouroboros.lifecycle.post_failure``
+        → :func:`belief_revision_on_failure` (async subscriber)
+        → ``belief_revision_ledger`` records a FALSIFIED belief about the
+          generation pattern (the files that just failed)
+        → :func:`recent_avoidance_digest` reads recent DRIFTING/FALSIFIED
+          beliefs and is injected, authority-free, into the GENERATE prompt
+          (via ``strategic_direction`` additive block)
+        → the FSM organically biases AWAY from recently-failing areas.
+
+Every surface is observational: the subscriber only *records*, the digest only
+*advises the prompt*. Neither holds FSM authority (Manifesto §1 invariant). Each
+substrate gates itself on its own master flag (``JARVIS_BELIEF_REVISION_ENABLED``
+§33.1 default-FALSE), composed under the cognitive-bus master. NEVER raises.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Mapping, Optional, Sequence
+
+from backend.core.ouroboros.governance.cognitive_bus import (
+    CognitiveSubscriber,
+    LIFECYCLE_POST_FAILURE,
+    lifecycle_pattern,
+)
+
+logger = logging.getLogger("ouroboros.cognitive_subscribers")
+
+# The belief domain under which generation/cage failures are recorded. Keeping
+# it stable lets the read-side digest scope to generation-failure memory.
+_DOMAIN_GENERATION_FAILURE = "generation/failure"
+
+_MAX_DIGEST_FILES = 8
+
+
+def _event_payload(event: Any) -> Mapping[str, Any]:
+    try:
+        payload = getattr(event, "payload", None)
+        if isinstance(payload, Mapping):
+            return payload
+    except Exception:  # noqa: BLE001
+        pass
+    return {}
+
+
+async def belief_revision_on_failure(event: Any) -> None:
+    """Subscriber: on a ``post_failure`` lifecycle event, record the failed
+    generation pattern as a FALSIFYING belief so future GENERATE prompts can
+    steer away from it. NEVER raises (the bus wrapper double-guards too)."""
+    payload = _event_payload(event)
+    if payload.get("lifecycle_kind") != LIFECYCLE_POST_FAILURE:
+        return
+    try:
+        from backend.core.ouroboros.governance.belief_revision_ledger import (
+            EvidenceKind,
+            master_enabled,
+            record_claim,
+            record_evidence,
+        )
+    except Exception as exc:  # noqa: BLE001 — substrate unavailable → inert
+        logger.debug("[CognitiveSub] belief import failed: %s", exc)
+        return
+    if not master_enabled():
+        return
+
+    files: Sequence[Any] = payload.get("target_files") or ()
+    op_id = str(payload.get("op_id") or "")
+    reason = str(payload.get("reason") or payload.get("state") or "failure")[:200]
+    sig = ", ".join(sorted({str(f) for f in files if f})[:6]) or "(no target files)"
+    # The belief we are falsifying: "generation in <files> succeeds". A failure
+    # is direct falsifying evidence against it.
+    text = f"generation in [{sig}] succeeds"
+
+    try:
+        claim = record_claim(
+            text,
+            _DOMAIN_GENERATION_FAILURE,
+            target_files=list(files),
+            confidence=0.5,
+        )
+        if claim is not None:
+            record_evidence(
+                claim.claim_id,
+                EvidenceKind.FALSIFYING,
+                source_op_id=op_id,
+                note=reason,
+            )
+    except Exception as exc:  # noqa: BLE001 — recording is best-effort
+        logger.debug("[CognitiveSub] belief record failed: %s", exc)
+
+
+def recent_avoidance_digest(
+    *,
+    rows: Optional[Sequence[Mapping[str, Any]]] = None,
+    now_unix: Optional[float] = None,
+    max_files: int = _MAX_DIGEST_FILES,
+) -> str:
+    """Read-side of the learning loop. Returns a short, authority-free markdown
+    block naming the files that have recently accrued DRIFTING/FALSIFIED beliefs,
+    ranked by failure recurrence — to be injected into the GENERATE prompt. Empty
+    string when the substrate is off, the ledger is empty, or nothing recurs.
+    NEVER raises. ``rows`` is a testing seam (passed through to the evaluator).
+    """
+    try:
+        from backend.core.ouroboros.governance.belief_revision_ledger import (
+            BeliefVerdict,
+            evaluate_recent_beliefs,
+            master_enabled,
+        )
+    except Exception:  # noqa: BLE001
+        return ""
+    if not master_enabled():
+        return ""
+    try:
+        reports = evaluate_recent_beliefs(rows=rows, now_unix=now_unix)
+    except Exception:  # noqa: BLE001
+        return ""
+
+    file_counts: dict[str, int] = {}
+    for r in reports:
+        verdict = getattr(r, "verdict", None)
+        if verdict not in (BeliefVerdict.DRIFTING, BeliefVerdict.FALSIFIED):
+            continue
+        claim = getattr(r, "claim", None)
+        for f in (getattr(claim, "target_files", ()) or ()):
+            key = str(f)
+            if key:
+                file_counts[key] = file_counts.get(key, 0) + 1
+    if not file_counts:
+        return ""
+
+    ranked = sorted(file_counts.items(), key=lambda kv: (-kv[1], kv[0]))[:max_files]
+    lines = [f"- `{f}` (recent failures: {n})" for f, n in ranked]
+    return (
+        "## Recently-Failing Areas (proceed with extra care)\n\n"
+        "Prior autonomous generations in these areas recently failed validation "
+        "or hit a cage block. Diagnose the root cause before patching here; do "
+        "not blindly retry the same approach.\n\n" + "\n".join(lines)
+    )
+
+
+def build_default_subscribers() -> List[CognitiveSubscriber]:
+    """The default cognitive subscriber set registered at GLS boot. Each handler
+    self-gates on its own substrate master flag, so this list is safe to register
+    whenever the cognitive bus is enabled."""
+    return [
+        CognitiveSubscriber(
+            "belief_revision_failure",
+            lifecycle_pattern(),
+            belief_revision_on_failure,
+        ),
+    ]

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1579,6 +1579,18 @@ class GovernedLoopService:
 
         self._state = ServiceState.STOPPING
 
+        # Slice 101 — publish session_end onto the cognitive bus before the
+        # drain so observational subscribers can react. Fire-and-forget,
+        # NEVER raises, inert unless JARVIS_COGNITIVE_BUS_ENABLED.
+        try:
+            from backend.core.ouroboros.governance.cognitive_bus import (
+                LIFECYCLE_SESSION_END,
+                publish_lifecycle_event as _cb_session_end,
+            )
+            _cb_session_end(LIFECYCLE_SESSION_END, {"service": "GLS"})
+        except Exception:  # noqa: BLE001
+            pass
+
         # P2 Slice 3 — stop the Convergence Reaper first so its
         # background task doesn't race the drain. Master-gated
         # NEVER-raise; idempotent on an already-stopped reaper.
@@ -1915,6 +1927,38 @@ class GovernedLoopService:
                 exc_info=True,
             )
             self._trajectory_auditor_observer = None
+
+        # Slice 101 — Cognitive Integration Bus subscriber registration.
+        # Registers the cognitive subscribers (belief-revision learning loop,
+        # ...) onto the production TrinityEventBus so they react to FSM
+        # lifecycle events published from _record_ledger. Inert (returns [])
+        # unless JARVIS_COGNITIVE_BUS_ENABLED (§33.1 default-FALSE). Each
+        # subscriber self-gates on its own substrate master. NEVER fatal.
+        self._cognitive_bus_subscription_ids = []
+        try:
+            from backend.core.ouroboros.governance.cognitive_bus import (
+                register_cognitive_subscribers,
+            )
+            from backend.core.ouroboros.governance.cognitive_subscribers import (
+                build_default_subscribers,
+            )
+            self._cognitive_bus_subscription_ids = (
+                await register_cognitive_subscribers(build_default_subscribers())
+            )
+            if self._cognitive_bus_subscription_ids:
+                _incr_observer_boot("cognitive_bus")
+                logger.info(
+                    "[GovernedLoop] Cognitive Integration Bus: %d subscriber(s) "
+                    "registered (Slice 101)",
+                    len(self._cognitive_bus_subscription_ids),
+                )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[GovernedLoop] Cognitive bus subscriber registration failed "
+                "(non-fatal)",
+                exc_info=True,
+            )
+            self._cognitive_bus_subscription_ids = []
 
     async def _stop_governance_observers(self) -> None:
         """Stop the Tier 0.5 (batches 1+2) observers gracefully.

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -11292,6 +11292,46 @@ class GovernedOrchestrator:
             _s74_publish_terminal(ctx, state)
         except Exception:  # noqa: BLE001 — never raise into _record_ledger
             pass
+        # ── Slice 101 — Cognitive Integration Bus lifecycle fan-out ──
+        # Mirror the terminal state onto the cognitive bus so dormant
+        # substrates (belief revision, counterfactual rehearsal, ...) can
+        # react in the BACKGROUND via async subscribers. Sync-safe, fire-
+        # and-forget, NEVER raises into _record_ledger; inert unless
+        # JARVIS_COGNITIVE_BUS_ENABLED (§33.1 default-FALSE). Decoupled from
+        # `written` just like the SSE publish above — a deduped terminal row
+        # must still wake the cognitive layer (the publisher is internally a
+        # no-op when the bus isn't running, so this is exactly-once-safe).
+        try:
+            _cb_sv = str(getattr(state, "value", state)).lower()
+            _cb_kind = None
+            if _cb_sv == "applied":
+                _cb_kind = "post_apply"
+            elif _cb_sv in ("failed", "blocked", "rolled_back"):
+                _cb_kind = "post_failure"
+            if _cb_kind is not None:
+                from backend.core.ouroboros.governance.cognitive_bus import (  # noqa: E501
+                    publish_lifecycle_event as _cb_publish,
+                )
+                try:
+                    _cb_tf = [
+                        str(p)
+                        for p in (getattr(ctx, "target_files", None) or [])
+                    ][:32]
+                except Exception:  # noqa: BLE001
+                    _cb_tf = []
+                _cb_publish(
+                    _cb_kind,
+                    {
+                        "op_id": str(getattr(ctx, "op_id", "") or ""),
+                        "state": _cb_sv,
+                        "phase": str(getattr(ctx, "current_phase", "") or ""),
+                        "target_files": _cb_tf,
+                        "reason": str((data or {}).get("reason", "")),
+                    },
+                    correlation_id=str(getattr(ctx, "op_id", "") or "") or None,
+                )
+        except Exception:  # noqa: BLE001 — bus fan-out must never touch the FSM
+            pass
         if written:
             try:
                 from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: E501

--- a/backend/core/ouroboros/governance/strategic_direction.py
+++ b/backend/core/ouroboros/governance/strategic_direction.py
@@ -259,6 +259,16 @@ class StrategicDirectionService:
         rust_map_block = self._render_rust_subsystems_section(op_id=op_id)
         if rust_map_block:
             body = f"{body}\n\n{rust_map_block}"
+        # Slice 101 — Recently-Failing Areas (Adaptive Intelligence
+        # Invariant). Reads recent DRIFTING/FALSIFIED beliefs recorded by
+        # the cognitive-bus belief subscriber on post_failure, biasing
+        # generation away from recently-failing files. Authority-free,
+        # ImportError-safe, master-gated inside the substrate, empty when
+        # no signal. Placed among the additive blocks (before causal
+        # lineage, which stays closest to the generation point).
+        avoidance_block = self._render_avoidance_section()
+        if avoidance_block:
+            body = f"{body}\n\n{avoidance_block}"
         # §31 U2 Slice 2 — Causal-lineage injection. Mirrors the
         # failure-modes / action-outcomes discipline: ImportError-
         # safe, master-flag-checked inside the substrate, empty
@@ -272,6 +282,29 @@ class StrategicDirectionService:
         if causal_lineage_block:
             body = f"{body}\n\n{causal_lineage_block}"
         return body
+
+    def _render_avoidance_section(self) -> str:
+        """Compose the optional ``## Recently-Failing Areas`` block (Slice 101).
+
+        Authority-free read-side of the cognitive learning loop. Composes
+        :func:`cognitive_subscribers.recent_avoidance_digest`, which self-gates
+        on the cognitive-bus + belief-revision masters and returns '' when there
+        is no signal. Gated first on ``cognitive_bus_enabled()`` so the whole
+        path is byte-identical to pre-Slice-101 when the bus is off.
+        ImportError-safe; NEVER raises.
+        """
+        try:
+            from backend.core.ouroboros.governance.cognitive_bus import (
+                cognitive_bus_enabled,
+            )
+            if not cognitive_bus_enabled():
+                return ""
+            from backend.core.ouroboros.governance.cognitive_subscribers import (
+                recent_avoidance_digest,
+            )
+            return recent_avoidance_digest() or ""
+        except Exception:  # noqa: BLE001 — advisory injection is best-effort
+            return ""
 
     def _render_dev_memory_section(
         self, op_id: Optional[str] = None,

--- a/tests/governance/test_cognitive_bus.py
+++ b/tests/governance/test_cognitive_bus.py
@@ -1,0 +1,143 @@
+"""Slice 101 Phase 1 — Cognitive Integration Bus transport adapter.
+
+Proves the thin adapter over the real ``TrinityEventBus``:
+  * inert when the master flag is off (publish no-op, register []),
+  * inert on unknown kind / no running bus (never creates a bus from hot path),
+  * end-to-end delivery of a lifecycle event to a real subscriber,
+  * a raising subscriber is fault-isolated and never propagates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from backend.core.ouroboros.governance import cognitive_bus as CB
+from backend.core.trinity_event_bus import (
+    EventPriority,
+    get_trinity_event_bus,
+    shutdown_trinity_event_bus,
+)
+
+
+async def _poll_until(predicate, *, timeout_s: float = 3.0, step_s: float = 0.02) -> bool:
+    waited = 0.0
+    while waited < timeout_s:
+        if predicate():
+            return True
+        await asyncio.sleep(step_s)
+        waited += step_s
+    return predicate()
+
+
+# --- inert paths ------------------------------------------------------------
+
+def test_master_off_publish_is_noop(monkeypatch):
+    monkeypatch.delenv(CB._ENV_ENABLED, raising=False)
+    assert CB.cognitive_bus_enabled() is False
+    assert CB.publish_lifecycle_event(CB.LIFECYCLE_POST_FAILURE, {"op_id": "x"}) is False
+
+
+def test_master_off_register_is_empty(monkeypatch):
+    monkeypatch.delenv(CB._ENV_ENABLED, raising=False)
+
+    async def _run():
+        sub = CB.CognitiveSubscriber("noop", CB.lifecycle_pattern(), lambda e: asyncio.sleep(0))
+        return await CB.register_cognitive_subscribers([sub])
+
+    assert asyncio.run(_run()) == []
+
+
+def test_unknown_kind_is_rejected(monkeypatch):
+    monkeypatch.setenv(CB._ENV_ENABLED, "1")
+    assert CB.cognitive_bus_enabled() is True
+    # Unknown kind short-circuits before any bus interaction.
+    assert CB.publish_lifecycle_event("not_a_real_kind", {"op_id": "x"}) is False
+
+
+def test_master_on_but_no_bus_is_noop(monkeypatch):
+    monkeypatch.setenv(CB._ENV_ENABLED, "1")
+
+    async def _run():
+        await shutdown_trinity_event_bus()  # ensure no global bus exists
+        # Known kind, master on, running loop present — but no bus booted.
+        return CB.publish_lifecycle_event(CB.LIFECYCLE_PRE_APPLY, {"op_id": "x"})
+
+    assert asyncio.run(_run()) is False
+
+
+# --- end-to-end delivery ----------------------------------------------------
+
+def test_lifecycle_event_delivered_to_subscriber(monkeypatch):
+    monkeypatch.setenv(CB._ENV_ENABLED, "1")
+
+    received = []
+
+    async def _handler(event):
+        received.append(event)
+
+    async def _run():
+        await shutdown_trinity_event_bus()
+        bus = await get_trinity_event_bus()
+        try:
+            sub = CB.CognitiveSubscriber("recorder", CB.lifecycle_pattern(), _handler)
+            ids = await CB.register_cognitive_subscribers([sub], bus=bus)
+            assert len(ids) == 1
+
+            scheduled = CB.publish_lifecycle_event(
+                CB.LIFECYCLE_POST_FAILURE,
+                {"op_id": "op-123", "phase": "GENERATE"},
+                priority=EventPriority.HIGH,
+            )
+            assert scheduled is True
+
+            ok = await _poll_until(lambda: len(received) >= 1)
+            assert ok, "lifecycle event was never delivered"
+            evt = received[0]
+            assert evt.topic == CB.lifecycle_topic(CB.LIFECYCLE_POST_FAILURE)
+            assert evt.payload["op_id"] == "op-123"
+            assert evt.payload["phase"] == "GENERATE"
+            # publisher stamps the kind for subscriber convenience
+            assert evt.payload["lifecycle_kind"] == CB.LIFECYCLE_POST_FAILURE
+        finally:
+            await shutdown_trinity_event_bus()
+
+    asyncio.run(_run())
+
+
+def test_raising_subscriber_is_fault_isolated(monkeypatch):
+    monkeypatch.setenv(CB._ENV_ENABLED, "1")
+
+    good_received = []
+
+    async def _bad_handler(event):
+        raise RuntimeError("subscriber boom")
+
+    async def _good_handler(event):
+        good_received.append(event)
+
+    async def _run():
+        await shutdown_trinity_event_bus()
+        bus = await get_trinity_event_bus()
+        try:
+            subs = [
+                CB.CognitiveSubscriber("bad", CB.lifecycle_pattern(), _bad_handler),
+                CB.CognitiveSubscriber("good", CB.lifecycle_pattern(), _good_handler),
+            ]
+            ids = await CB.register_cognitive_subscribers(subs, bus=bus)
+            assert len(ids) == 2
+
+            # Unique payload avoids the bus dedup window.
+            CB.publish_lifecycle_event(CB.LIFECYCLE_PRE_APPLY, {"op_id": "op-fault-iso"})
+            ok = await _poll_until(lambda: len(good_received) >= 1)
+            assert ok, "good subscriber starved by a raising sibling"
+        finally:
+            await shutdown_trinity_event_bus()
+
+    asyncio.run(_run())
+
+
+def test_topic_helpers_are_consistent():
+    assert CB.lifecycle_topic(CB.LIFECYCLE_TOOL_EMIT) == "ouroboros.lifecycle.tool_emit"
+    assert CB.lifecycle_pattern() == "ouroboros.lifecycle.*"
+    assert CB.is_lifecycle_kind(CB.LIFECYCLE_SESSION_END) is True
+    assert CB.is_lifecycle_kind("bogus") is False

--- a/tests/governance/test_cognitive_subscribers.py
+++ b/tests/governance/test_cognitive_subscribers.py
@@ -1,0 +1,134 @@
+"""Slice 101 Phase 3 — cognitive subscribers + the belief-revision learning loop.
+
+Proves the Adaptive Intelligence Invariant end-to-end against a REAL tmp belief
+ledger: a post_failure event records a falsifying belief; the avoidance digest
+surfaces the failing files; and the StrategicDirection injection gate is inert
+unless the cognitive bus is on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from backend.core.ouroboros.governance import cognitive_subscribers as CS
+from backend.core.ouroboros.governance.belief_revision_ledger import (
+    EvidenceKind,
+    record_claim,
+    record_evidence,
+)
+
+
+def _belief_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_BELIEF_REVISION_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_BELIEF_REVISION_PERSIST_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_BELIEF_REVISION_LEDGER_PATH",
+        str(tmp_path / "belief_revision_ledger.jsonl"),
+    )
+
+
+def _post_failure_event(*, files, op_id="op-1", reason="validate_failed"):
+    return SimpleNamespace(
+        payload={
+            "lifecycle_kind": CS.LIFECYCLE_POST_FAILURE,
+            "op_id": op_id,
+            "state": "failed",
+            "reason": reason,
+            "target_files": list(files),
+        }
+    )
+
+
+# --- subscriber records a falsifying belief ---------------------------------
+
+def test_post_failure_records_falsifying_belief(monkeypatch, tmp_path):
+    _belief_env(monkeypatch, tmp_path)
+    asyncio.run(CS.belief_revision_on_failure(_post_failure_event(files=["bar.py"])))
+    digest = CS.recent_avoidance_digest()
+    assert "bar.py" in digest
+    assert "Recently-Failing Areas" in digest
+
+
+def test_non_failure_event_records_nothing(monkeypatch, tmp_path):
+    _belief_env(monkeypatch, tmp_path)
+    evt = SimpleNamespace(
+        payload={"lifecycle_kind": "post_apply",
+                 "op_id": "op-2", "target_files": ["baz.py"]}
+    )
+    asyncio.run(CS.belief_revision_on_failure(evt))
+    assert CS.recent_avoidance_digest() == ""
+
+
+def test_belief_master_off_is_inert(monkeypatch, tmp_path):
+    monkeypatch.delenv("JARVIS_BELIEF_REVISION_ENABLED", raising=False)
+    monkeypatch.setenv(
+        "JARVIS_BELIEF_REVISION_LEDGER_PATH",
+        str(tmp_path / "belief_revision_ledger.jsonl"),
+    )
+    asyncio.run(CS.belief_revision_on_failure(_post_failure_event(files=["x.py"])))
+    # master off → digest is empty regardless
+    assert CS.recent_avoidance_digest() == ""
+
+
+# --- avoidance digest ranks recurrence --------------------------------------
+
+def test_digest_ranks_by_recurrence(monkeypatch, tmp_path):
+    _belief_env(monkeypatch, tmp_path)
+    # hot.py fails twice, cold.py once → hot.py ranked first
+    for _ in range(2):
+        c = record_claim("generation in [hot.py] succeeds", "generation/failure",
+                         target_files=["hot.py"])
+        record_evidence(c.claim_id, EvidenceKind.FALSIFYING)
+    c2 = record_claim("generation in [cold.py] succeeds", "generation/failure",
+                      target_files=["cold.py"])
+    record_evidence(c2.claim_id, EvidenceKind.FALSIFYING)
+
+    digest = CS.recent_avoidance_digest()
+    assert "hot.py" in digest and "cold.py" in digest
+    assert digest.index("hot.py") < digest.index("cold.py")
+
+
+def test_digest_empty_when_no_failures(monkeypatch, tmp_path):
+    _belief_env(monkeypatch, tmp_path)
+    assert CS.recent_avoidance_digest() == ""
+
+
+# --- StrategicDirection injection gate --------------------------------------
+
+def test_strategic_injection_inert_when_bus_off(monkeypatch, tmp_path):
+    from backend.core.ouroboros.governance.strategic_direction import (
+        StrategicDirectionService,
+    )
+    _belief_env(monkeypatch, tmp_path)
+    # Record a real failing belief so the digest WOULD be non-empty...
+    c = record_claim("generation in [z.py] succeeds", "generation/failure",
+                     target_files=["z.py"])
+    record_evidence(c.claim_id, EvidenceKind.FALSIFYING)
+    # ...but with the cognitive bus master OFF, the injection is byte-identical
+    # to legacy (empty), even though the belief substrate itself is on.
+    monkeypatch.delenv("JARVIS_COGNITIVE_BUS_ENABLED", raising=False)
+    svc = object.__new__(StrategicDirectionService)  # bypass heavy __init__
+    assert svc._render_avoidance_section() == ""
+
+
+def test_strategic_injection_fires_when_bus_on(monkeypatch, tmp_path):
+    from backend.core.ouroboros.governance.strategic_direction import (
+        StrategicDirectionService,
+    )
+    _belief_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("JARVIS_COGNITIVE_BUS_ENABLED", "1")
+    c = record_claim("generation in [z.py] succeeds", "generation/failure",
+                     target_files=["z.py"])
+    record_evidence(c.claim_id, EvidenceKind.FALSIFYING)
+    svc = object.__new__(StrategicDirectionService)
+    block = svc._render_avoidance_section()
+    assert "z.py" in block
+    assert "Recently-Failing Areas" in block
+
+
+def test_build_default_subscribers_shape():
+    subs = CS.build_default_subscribers()
+    assert len(subs) >= 1
+    labels = {s.label for s in subs}
+    assert "belief_revision_failure" in labels


### PR DESCRIPTION
## Slice 101 — Asynchronous Cognitive Awakening

Wires the first dormant cognitive substrate into the live loop via an event-driven adapter, closing the **Adaptive Intelligence Invariant**: a generation failure becomes a falsified belief that biases future GENERATE prompts away from recently-failing areas.

### Verify-first corrections (vs. the runbook)
- **Did NOT build a new pub/sub.** Composes the production `TrinityEventBus` (async delivery, per-handler `wait_for` fault isolation — a slow subscriber cannot stall the FSM). `SkillObserver` precedent.
- Pinned the real module APIs (`record_claim`/`record_evidence`/`evaluate_recent_beliefs`, `EvidenceKind.FALSIFYING`) — no phantom calls.

### What landed
- **`cognitive_bus.py`** — thin transport adapter. `publish_lifecycle_event()` is sync-safe / fire-and-forget / never-raises (schedules on the running loop, no-op if bus not running). `register_cognitive_subscribers()` wraps handlers in belt-and-suspenders fault isolation.
- **`orchestrator._record_ledger`** — publishes `post_apply`/`post_failure` at the single exactly-once terminal seam (beside the existing SSE publish), decoupled from the dedup `written` flag.
- **`governed_loop_service`** — registers subscribers at boot; publishes `session_end` on stop.
- **`cognitive_subscribers.py`** — `belief_revision_on_failure` records the FALSIFYING belief; `recent_avoidance_digest()` ranks recurring DRIFTING/FALSIFIED files.
- **`strategic_direction._render_avoidance_section`** — injects the digest authority-free into the GENERATE prompt (same additive-block discipline as the posture/failure-mode blocks).

### Safety
- All surfaces **observational** — record/forecast/advise only; **no FSM authority** (Manifesto §1 preserved).
- Masters `JARVIS_COGNITIVE_BUS_ENABLED` + `JARVIS_BELIEF_REVISION_ENABLED` are **§33.1 default-FALSE** → byte-identical legacy when off.
- Every integration point is `try/except`-guarded and never raises into the hot path.

### Tests
- 15 new (`test_cognitive_bus.py` 7 + `test_cognitive_subscribers.py` 8) — inert paths, real end-to-end bus delivery, fault isolation, the failure→belief→digest loop, injection gate.
- 120 existing strategic_direction + belief_revision regression green.

### Deferred (named follow-ups, same arc)
- Phase 4: `mcp_output_scanner` at the tool-emit path (security) + `cognitive_load_shedding` advisory at the intake gate.
- `autonomous_graduation_engine` on `session_end` (synchronous, not via the fire-and-forget bus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a thin Cognitive Integration Bus to publish FSM lifecycle events asynchronously and wires a belief-revision loop that nudges GENERATE prompts away from recently failing areas. Runs entirely in the background and is off by default, so the hot path and behavior remain unchanged unless enabled.

- New Features
  - Added `cognitive_bus.py`: composes `TrinityEventBus`; `publish_lifecycle_event()` is sync-safe, fire-and-forget, never raises; `register_cognitive_subscribers()` wraps handlers with fault isolation.
  - Orchestrator publishes `post_apply`/`post_failure` at the terminal seam with context; `governed_loop_service` registers subscribers at boot and publishes `session_end` on stop.
  - Added `belief_revision_on_failure` subscriber to record `FALSIFYING` evidence; `recent_avoidance_digest()` ranks recurring failing files; `strategic_direction` injects a “Recently-Failing Areas” block into the GENERATE prompt.
  - Master flags `JARVIS_COGNITIVE_BUS_ENABLED` and `JARVIS_BELIEF_REVISION_ENABLED` default to false; all integration points are try/except-guarded and never affect the FSM when off.

<sup>Written for commit 98b2a198dc3bb749ec1d4f1be3a2d7453f674467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

