### PR TITLE
Slice 101 Phase 5 — pre-APPLY proof gate (counterfactual rehearsal + proof carrier)

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -7561,6 +7561,42 @@ class GovernedOrchestrator:
                     exc_info=True,
                 )
 
+            # ── Slice 101 Phase 5: Proof Carrier (pre-APPLY proof artifact) ──
+            # Aggregates the available pre-APPLY signals (counterfactual
+            # rehearsal, cross-session coherence, MCP/credential scan) into ONE
+            # per-candidate proof-of-correctness artifact and self-publishes it
+            # to the IDE SSE stream (proof_carrier_built) for operator
+            # visibility. This is the observability aggregator over signals
+            # already individually gated — rehearsal via the risk-tier floor
+            # just above, credentials via the tool-emit scanner (Phase 4),
+            # boundary via the governance gate — so it raises visibility, not a
+            # redundant second gate. Master JARVIS_PROOF_CARRIER_ENABLED §33.1
+            # default-FALSE → DISABLED (zero cost) when off. NEVER raises.
+            try:
+                from backend.core.ouroboros.governance.proof_carrier_transport import (  # noqa: E501
+                    ProofVerdict as _ProofVerdict,
+                    build_proof_carrier as _build_proof_carrier,
+                )
+                _proof = _build_proof_carrier(
+                    getattr(ctx, "op_id", "") or "",
+                    list(getattr(ctx, "target_files", ()) or ()),
+                )
+                if _proof.verdict not in (
+                    _ProofVerdict.CLEAN, _ProofVerdict.DISABLED,
+                ):
+                    logger.info(
+                        "[Orchestrator] GATE proof_carrier op=%s verdict=%s "
+                        "source=%s mcp=%d rehearsal=%d drift=%s",
+                        getattr(ctx, "op_id", "?"),
+                        _proof.verdict.value,
+                        _proof.dominant_source.value,
+                        _proof.mcp_finding_count,
+                        _proof.rehearsal_concern_count,
+                        _proof.coherence_drift_level,
+                    )
+            except Exception:  # noqa: BLE001 — proof artifact must never touch GATE
+                pass
+
             # ---- Phase 5a-green: SAFE_AUTO diff preview (Green — when human is watching) ----
             # Mythos §7.4 UX: when a human is watching (TTY or explicit flag),
             # show a brief diff preview even for Green ops so the operator can

--- a/backend/core/ouroboros/governance/risk_tier_floor.py
+++ b/backend/core/ouroboros/governance/risk_tier_floor.py
@@ -437,6 +437,42 @@ def _convergence_floor(
         return None
 
 
+def _rehearsal_floor(
+    target_files: Optional[Sequence[Any]],
+) -> Optional[str]:
+    """Slice 101 Phase 5 — compose the Counterfactual Rehearsal pre-APPLY
+    verdict into the strictest-wins floor.
+
+    A candidate whose target files overlap a recent postmortem failure zone
+    raises friction (``notify_apply``); a cage-boundary crossing escalates
+    (``approval_required``). This is the "structural failure-memory checked
+    before a patch lands" gate — it composes EXACTLY like the convergence and
+    boundary floors above, so the orchestrator GATE seam needs no change (it
+    already passes ``target_files``). Master-gated inside the substrate
+    (``JARVIS_COUNTERFACTUAL_REHEARSAL_ENABLED``, §33.1 default-FALSE → DISABLED
+    verdict → None → byte-identical legacy). NEVER raises — the floor must stay
+    robust regardless of the rehearsal substrate's health.
+    """
+    if not target_files:
+        return None
+    try:
+        from backend.core.ouroboros.governance.counterfactual_rehearsal_mode import (  # noqa: E501
+            RehearsalVerdict,
+            evaluate_rehearsal,
+        )
+        report = evaluate_rehearsal(target_files)
+        if report.verdict is RehearsalVerdict.ESCALATE:
+            return "approval_required"
+        if report.verdict is RehearsalVerdict.CONCERN_RAISED:
+            return "notify_apply"
+    except Exception:  # noqa: BLE001 — floor must stay robust
+        logger.debug(
+            "[RiskFloor] rehearsal floor lookup failed", exc_info=True,
+        )
+        return None
+    return None
+
+
 def recommended_floor(
     now: Optional[datetime] = None,
     *,
@@ -495,6 +531,12 @@ def recommended_floor(
     convergence = _convergence_floor(now)
     if convergence is not None:
         candidates.append(convergence)
+    # Slice 101 Phase 5 — Counterfactual Rehearsal pre-APPLY gate. Overlap with
+    # a recent postmortem failure zone → notify_apply; cage-boundary cross →
+    # approval_required. Master-gated (default-FALSE) → None when off.
+    rehearsal = _rehearsal_floor(target_files)
+    if rehearsal is not None:
+        candidates.append(rehearsal)
     if not candidates:
         return None
     # Pick the strictest — highest ordinal wins.

--- a/tests/governance/test_slice101_phase5_proof_gate.py
+++ b/tests/governance/test_slice101_phase5_proof_gate.py
@@ -1,0 +1,155 @@
+"""Slice 101 Phase 5 — pre-APPLY proof gate.
+
+counterfactual_rehearsal composes into the strictest-wins risk-tier floor
+(the "structural failure-memory checked before a patch lands" gate);
+proof_carrier_transport aggregates the pre-APPLY signals into one artifact.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from backend.core.ouroboros.governance import risk_tier_floor as RTF
+from backend.core.ouroboros.governance import counterfactual_rehearsal_mode as CRM
+from backend.core.ouroboros.governance.counterfactual_rehearsal_mode import (
+    RehearsalVerdict,
+)
+
+
+def _fake_report(verdict):
+    return SimpleNamespace(verdict=verdict)
+
+
+# === Part A: rehearsal → risk-tier floor mapping ============================
+
+def test_concern_maps_to_notify_apply(monkeypatch):
+    monkeypatch.setattr(
+        CRM, "evaluate_rehearsal",
+        lambda tf, **k: _fake_report(RehearsalVerdict.CONCERN_RAISED),
+    )
+    assert RTF._rehearsal_floor(["foo.py"]) == "notify_apply"
+
+
+def test_escalate_maps_to_approval_required(monkeypatch):
+    monkeypatch.setattr(
+        CRM, "evaluate_rehearsal",
+        lambda tf, **k: _fake_report(RehearsalVerdict.ESCALATE),
+    )
+    assert RTF._rehearsal_floor(["foo.py"]) == "approval_required"
+
+
+def test_clean_and_disabled_map_to_no_floor(monkeypatch):
+    for v in (RehearsalVerdict.CLEAN, RehearsalVerdict.DISABLED):
+        monkeypatch.setattr(
+            CRM, "evaluate_rehearsal", lambda tf, **k: _fake_report(v),
+        )
+        assert RTF._rehearsal_floor(["foo.py"]) is None
+
+
+def test_empty_target_files_is_no_floor():
+    assert RTF._rehearsal_floor([]) is None
+    assert RTF._rehearsal_floor(None) is None
+
+
+def test_rehearsal_floor_never_raises(monkeypatch):
+    def _boom(tf, **k):
+        raise RuntimeError("rehearsal exploded")
+    monkeypatch.setattr(CRM, "evaluate_rehearsal", _boom)
+    # The floor must stay robust even if the substrate throws.
+    assert RTF._rehearsal_floor(["foo.py"]) is None
+
+
+# === Part A: master-OFF byte-identical inertness ===========================
+
+def test_master_off_floor_is_inert(monkeypatch):
+    # Real substrate, master off → DISABLED verdict → no floor → legacy.
+    monkeypatch.delenv("JARVIS_COUNTERFACTUAL_REHEARSAL_ENABLED", raising=False)
+    assert RTF._rehearsal_floor(["foo.py"]) is None
+
+
+# === Part A: composition into the strictest-wins ladder =====================
+
+def test_rehearsal_composes_into_recommended_floor(monkeypatch):
+    # Clear other floor sources so rehearsal is the only candidate.
+    for env in (
+        "JARVIS_MIN_RISK_TIER", "JARVIS_PARANOIA_MODE",
+        "JARVIS_AUTO_APPLY_QUIET_HOURS",
+    ):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setattr(
+        CRM, "evaluate_rehearsal",
+        lambda tf, **k: _fake_report(RehearsalVerdict.CONCERN_RAISED),
+    )
+    floor = RTF.recommended_floor(target_files=["foo.py"])
+    assert floor == "notify_apply"
+
+
+def test_strictest_wins_when_rehearsal_and_paranoia(monkeypatch):
+    # paranoia → notify_apply, rehearsal ESCALATE → approval_required; strictest wins.
+    monkeypatch.setenv("JARVIS_PARANOIA_MODE", "1")
+    monkeypatch.setattr(
+        CRM, "evaluate_rehearsal",
+        lambda tf, **k: _fake_report(RehearsalVerdict.ESCALATE),
+    )
+    floor = RTF.recommended_floor(target_files=["foo.py"])
+    assert floor == "approval_required"
+
+
+# === Part B: proof_carrier_transport aggregation ============================
+
+def test_proof_carrier_inert_when_master_off(monkeypatch):
+    from backend.core.ouroboros.governance.proof_carrier_transport import (
+        ProofVerdict,
+        build_proof_carrier,
+    )
+    monkeypatch.delenv("JARVIS_PROOF_CARRIER_ENABLED", raising=False)
+    carrier = build_proof_carrier("op-1", ["foo.py"])
+    assert carrier.verdict == ProofVerdict.DISABLED
+
+
+def test_proof_carrier_blocks_on_rehearsal_escalate(monkeypatch):
+    from backend.core.ouroboros.governance.proof_carrier_transport import (
+        ProofVerdict,
+        build_proof_carrier,
+    )
+    monkeypatch.setenv("JARVIS_PROOF_CARRIER_ENABLED", "1")
+    carrier = build_proof_carrier(
+        "op-2", ["foo.py"],
+        mcp_count_override=0, mcp_kinds_override=[],
+        coherence_drift_override="none",
+        rehearsal_count_override=3,
+        rehearsal_verdict_override="escalate",
+    )
+    assert carrier.verdict == ProofVerdict.BLOCK
+
+
+def test_proof_carrier_warns_on_rehearsal_concern(monkeypatch):
+    from backend.core.ouroboros.governance.proof_carrier_transport import (
+        ProofVerdict,
+        build_proof_carrier,
+    )
+    monkeypatch.setenv("JARVIS_PROOF_CARRIER_ENABLED", "1")
+    carrier = build_proof_carrier(
+        "op-3", ["foo.py"],
+        mcp_count_override=0, mcp_kinds_override=[],
+        coherence_drift_override="none",
+        rehearsal_count_override=2,
+        rehearsal_verdict_override="concern_raised",
+    )
+    assert carrier.verdict == ProofVerdict.WARN
+
+
+def test_proof_carrier_clean_when_no_signals(monkeypatch):
+    from backend.core.ouroboros.governance.proof_carrier_transport import (
+        ProofVerdict,
+        build_proof_carrier,
+    )
+    monkeypatch.setenv("JARVIS_PROOF_CARRIER_ENABLED", "1")
+    carrier = build_proof_carrier(
+        "op-4", ["foo.py"],
+        mcp_count_override=0, mcp_kinds_override=[],
+        coherence_drift_override="none",
+        rehearsal_count_override=0,
+        rehearsal_verdict_override="clean",
+    )
+    assert carrier.verdict == ProofVerdict.CLEAN


### PR DESCRIPTION
## Slice 101 Phase 5 — the pre-APPLY proof gate

Wires structural failure-memory into the APPLY decision by **composing the existing strictest-wins risk-tier-floor stack** — zero duplication, and **zero orchestrator GATE surgery for the gate itself**.

### 1. `counterfactual_rehearsal` → risk-tier floor (`risk_tier_floor._rehearsal_floor`)
A candidate whose target files overlap a recent **postmortem failure zone** raises friction (`notify_apply`); a cage-boundary cross escalates (`approval_required`). Composed into `recommended_floor()` right beside `_convergence_floor` + `_governance_boundary_floor`. Because the orchestrator GATE already passes `target_files` into `apply_floor_to_name(...)`, the gate goes **live with no orchestrator change**. This is the literal "structural failure-memory checked before a patch lands."

### 2. `proof_carrier_transport` @ orchestrator GATE seam
Aggregates the pre-APPLY signals (rehearsal + cross-session coherence + MCP/credential scan) into **one per-candidate proof-of-correctness artifact** and self-publishes `proof_carrier_built` to the IDE SSE stream. Observability aggregator over already-gated signals — raises visibility, **not a redundant second gate** (rehearsal is gated via the floor above, credentials via the Phase-4 tool-emit scanner, boundary via the governance gate).

### Why this design (root cause, no duplication)
The codebase already had the exact pattern: `dynamic_risk_convergence` and `governance_boundary_gate` compose into `recommended_floor()` as strictest-wins candidates. Rehearsal is just another candidate — so it inherits all the existing wiring (the GATE seam, `apply_floor_to_name`, the tier ordering) for free.

### Safety
- Masters **§33.1 default-FALSE** (`JARVIS_COUNTERFACTUAL_REHEARSAL_ENABLED` + `JARVIS_PROOF_CARRIER_ENABLED`) → DISABLED verdict → `None` floor / zero cost → byte-identical legacy when off.
- `_rehearsal_floor` **never raises** (the floor must stay robust even if the substrate throws — explicitly tested).
- Raises friction, doesn't replace proof (the SemanticGuardian principle).

### Tests
- 12 new (`test_slice101_phase5_proof_gate.py`) — verdict→floor mapping (concern→notify_apply, escalate→approval_required, clean/disabled→none), empty-target no-floor, never-raises, master-off inertness, strictest-wins composition, proof-carrier BLOCK/WARN/CLEAN aggregation.
- **186 regression green** (risk_tier_floor + risk_tier_floor_vision + proof_carrier_transport + counterfactual_rehearsal_mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pre-APPLY proof gate by composing counterfactual rehearsal into the strictest-wins risk tier floor and emitting a per-candidate proof-of-correctness artifact at the GATE seam. Both features are off by default and never raise; when enabled, risky targets prompt notify or require approval, and the proof carrier improves visibility only.

- **New Features**
  - Counterfactual rehearsal floor in `risk_tier_floor`: maps overlap to `notify_apply` and cage-boundary to `approval_required`; composed into `recommended_floor()` using `target_files`; guarded by `JARVIS_COUNTERFACTUAL_REHEARSAL_ENABLED` (default off).
  - Proof carrier in orchestrator: aggregates rehearsal, coherence, and MCP/credential scan into a single artifact and publishes `proof_carrier_built` to the IDE SSE stream; guarded by `JARVIS_PROOF_CARRIER_ENABLED` (default off) and never gates decisions.

<sup>Written for commit f261acc635d207437b68b524601d99a2ec6f172a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

