### PR TITLE
Slice 101 Phase 6 — the Synthetic Soul (async sleep-consolidation cascade)

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1988,6 +1988,33 @@ class GovernedLoopService:
             )
             self._cognitive_bus_subscription_ids = []
 
+        # Slice 101 Phase 6 — Sleep Consolidation Daemon. Background async task
+        # that runs the cross-session memory cascade (belief + postmortem-fusion
+        # → consolidation → meta-prior calibration) OFF the hot path on an idle-
+        # gated cadence. Inert (no task spawned) unless JARVIS_SLEEP_DAEMON_
+        # ENABLED (§33.1 default-FALSE). Stored on self for graceful cancel.
+        self._sleep_daemon_task = None
+        try:
+            from backend.core.ouroboros.governance.sleep_daemon import (
+                run_sleep_daemon_loop,
+                sleep_daemon_enabled,
+            )
+            if sleep_daemon_enabled():
+                self._sleep_daemon_task = asyncio.create_task(
+                    run_sleep_daemon_loop()
+                )
+                _incr_observer_boot("sleep_daemon")
+                logger.info(
+                    "[GovernedLoop] Sleep Consolidation Daemon started "
+                    "(Slice 101 Phase 6)",
+                )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[GovernedLoop] Sleep daemon startup failed (non-fatal)",
+                exc_info=True,
+            )
+            self._sleep_daemon_task = None
+
     async def _stop_governance_observers(self) -> None:
         """Stop the Tier 0.5 (batches 1+2) observers gracefully.
 
@@ -1995,6 +2022,21 @@ class GovernedLoopService:
         independently — one observer's stop failure does NOT prevent
         the others from stopping. NEVER raises.
         """
+        # Slice 101 Phase 6 — cancel the Sleep Consolidation Daemon first so its
+        # background cycle doesn't race the drain. Idempotent; NEVER raises.
+        _sleep_task = getattr(self, "_sleep_daemon_task", None)
+        if _sleep_task is not None and not _sleep_task.done():
+            _sleep_task.cancel()
+            try:
+                await _sleep_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[GovernedLoop] sleep daemon stop failed (non-fatal)",
+                    exc_info=True,
+                )
+
         for attr_name in (
             "_invariant_drift_observer",
             "_coherence_observer",

--- a/backend/core/ouroboros/governance/sleep_daemon.py
+++ b/backend/core/ouroboros/governance/sleep_daemon.py
@@ -1,0 +1,213 @@
+"""Sleep Consolidation Daemon — Slice 101 Phase 6 (the Synthetic Soul).
+
+A background async daemon that runs the cross-session memory consolidation
+cascade OFF the hot path, so the organism's long-horizon "deep learning" never
+blocks the FSM. Each cycle composes the EXISTING (previously dormant) substrates
+— it adds orchestration + cadence, not new memory logic:
+
+    belief_revision_ledger (FALSIFIED beliefs)  ─┐
+    postmortem_fusion (root-cause clusters)      ─┤→ sleep_consolidation_pass
+                                                    (stable patterns, persisted)
+                                                  → meta_prior_learning
+                                                    (prior calibration, persisted)
+
+VERIFY-FIRST (2026-06-06): the cascade is ~95% self-composing already —
+``run_consolidation_pass`` internally pulls belief + fusion; ``fuse_recent_
+postmortems`` already extracts ROOT CAUSES (``root_cause_class`` /
+``representative_root_cause`` / ``suggested_next_action``), not symptoms. The
+daemon's job is to RUN the passes on an idle-gated cadence and surface a unified
+report. Both passes persist to JSONL, so the consolidated memory **survives
+reboots**; it is retrieved at GENERATE by
+``strategic_direction._render_consolidated_memory_section``.
+
+HONEST SCOPE NOTE: ``meta_prior_learning`` is prior-STRATEGY calibration (win
+rates from the Schelling consensus stream), a *complementary* signal — NOT the
+failed-paradigm store. The persistent "avoid-this-paradigm" engram is the belief
++ postmortem-fusion ledger. The daemon refreshes both; the GENERATE retrieval
+reads the failure root-causes.
+
+Master ``JARVIS_SLEEP_DAEMON_ENABLED`` — §33.1 default-FALSE. The daemon NEVER
+raises into the loop; every substrate call is independently guarded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger("ouroboros.sleep_daemon")
+
+_ENV_ENABLED = "JARVIS_SLEEP_DAEMON_ENABLED"
+_ENV_INTERVAL_S = "JARVIS_SLEEP_DAEMON_INTERVAL_S"
+_TRUTHY = ("1", "true", "yes", "on")
+
+# Default cadence — 30 min, matching sleep_consolidation's idle threshold so a
+# cycle's idle_seconds proxy clears the pass's own idle gate.
+_DEFAULT_INTERVAL_S = 1800.0
+_MIN_INTERVAL_S = 5.0
+
+SLEEP_CYCLE_SCHEMA_VERSION = "sleep_cycle.1"
+
+
+def sleep_daemon_enabled() -> bool:
+    """§33.1 master — default FALSE. Never raises."""
+    try:
+        raw = os.environ.get(_ENV_ENABLED)
+        if raw is None:
+            return False
+        return raw.strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def daemon_interval_s() -> float:
+    """Idle-gated cadence for the background loop. Clamped to a sane floor."""
+    try:
+        raw = float(os.environ.get(_ENV_INTERVAL_S, str(_DEFAULT_INTERVAL_S)))
+        return max(_MIN_INTERVAL_S, raw)
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_INTERVAL_S
+
+
+@dataclass(frozen=True)
+class SleepCycleReport:
+    """Unified telemetry for one consolidation cycle. Frozen artifact."""
+
+    master_enabled: bool
+    consolidation_verdict: str
+    consolidation_candidates: int
+    fused_cluster_count: int
+    meta_dominant_count: int
+    meta_declining_count: int
+    diagnostic: str
+    elapsed_s: float
+    schema_version: str = SLEEP_CYCLE_SCHEMA_VERSION
+
+
+def _disabled_report(started: float) -> SleepCycleReport:
+    return SleepCycleReport(
+        master_enabled=False,
+        consolidation_verdict="disabled",
+        consolidation_candidates=0,
+        fused_cluster_count=0,
+        meta_dominant_count=0,
+        meta_declining_count=0,
+        diagnostic=f"sleep daemon disabled via {_ENV_ENABLED}=false",
+        elapsed_s=0.0,
+    )
+
+
+def run_sleep_cycle_once(
+    *,
+    idle_seconds: Optional[float] = None,
+    now_unix: Optional[float] = None,
+) -> SleepCycleReport:
+    """Run ONE consolidation cycle synchronously. Composes the existing passes;
+    NEVER raises. Returns a DISABLED report when the master flag is off.
+
+    This is the unit the async loop drives; it is also the deterministic seam
+    the cross-session test exercises directly.
+    """
+    started = time.time() if now_unix is None else float(now_unix)
+    if not sleep_daemon_enabled():
+        return _disabled_report(started)
+
+    idle = daemon_interval_s() if idle_seconds is None else float(idle_seconds)
+
+    # 1) Sleep-consolidation pass — auto-composes belief (FALSIFIED) + fusion.
+    consolidation_verdict = "skipped"
+    consolidation_candidates = 0
+    try:
+        from backend.core.ouroboros.governance.sleep_consolidation_pass import (
+            run_consolidation_pass,
+        )
+        report = run_consolidation_pass(idle)
+        consolidation_verdict = str(getattr(report.verdict, "value", report.verdict))
+        consolidation_candidates = len(getattr(report, "candidates", ()) or ())
+    except Exception as exc:  # noqa: BLE001 — one pass failing never aborts the cycle
+        logger.debug("[SleepDaemon] consolidation pass failed: %s", exc)
+
+    # 2) Root-cause fusion count (for telemetry; the pass already consumed it).
+    fused_cluster_count = 0
+    try:
+        from backend.core.ouroboros.governance.postmortem_fusion import (
+            fuse_recent_postmortems,
+        )
+        fusion = fuse_recent_postmortems(now_unix=started)
+        fused_cluster_count = len(getattr(fusion, "meta_postmortems", ()) or ())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[SleepDaemon] fusion count failed: %s", exc)
+
+    # 3) Meta-prior calibration refresh — complementary stream, also persists.
+    meta_dominant = 0
+    meta_declining = 0
+    try:
+        from backend.core.ouroboros.governance.meta_prior_learning import (
+            compute_meta_distribution,
+        )
+        meta = compute_meta_distribution(now_unix=started)
+        meta_dominant = int(getattr(meta, "dominant_count", 0) or 0)
+        meta_declining = int(getattr(meta, "declining_count", 0) or 0)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[SleepDaemon] meta-prior refresh failed: %s", exc)
+
+    elapsed = max(0.0, time.time() - started)
+    diagnostic = (
+        f"consolidation={consolidation_verdict} "
+        f"candidates={consolidation_candidates} "
+        f"fused={fused_cluster_count} "
+        f"meta_dom={meta_dominant} meta_decl={meta_declining}"
+    )
+    if (
+        consolidation_verdict in ("consolidated", "dreaming")
+        or fused_cluster_count > 0
+    ):
+        logger.info("[SleepDaemon] cycle complete — %s", diagnostic)
+    return SleepCycleReport(
+        master_enabled=True,
+        consolidation_verdict=consolidation_verdict,
+        consolidation_candidates=consolidation_candidates,
+        fused_cluster_count=fused_cluster_count,
+        meta_dominant_count=meta_dominant,
+        meta_declining_count=meta_declining,
+        diagnostic=diagnostic,
+        elapsed_s=elapsed,
+    )
+
+
+async def run_sleep_daemon_loop(
+    *,
+    interval_s: Optional[float] = None,
+    max_cycles: Optional[int] = None,
+    sleep_fn: Any = None,
+) -> int:
+    """Background loop: run a consolidation cycle every ``interval_s`` (idle-gated
+    cadence). Returns the number of cycles run. Bounded by ``max_cycles`` (None =
+    until cancelled). Inert (returns 0 immediately) when the master flag is off.
+    NEVER raises except ``asyncio.CancelledError`` (propagated for clean stop).
+
+    ``sleep_fn`` defaults to ``asyncio.sleep`` (injectable for tests).
+    """
+    if not sleep_daemon_enabled():
+        return 0
+    _sleep = sleep_fn if sleep_fn is not None else asyncio.sleep
+    _interval = daemon_interval_s() if interval_s is None else max(_MIN_INTERVAL_S, float(interval_s))
+    cycles = 0
+    try:
+        while max_cycles is None or cycles < max_cycles:
+            try:
+                run_sleep_cycle_once(idle_seconds=_interval)
+            except Exception as exc:  # noqa: BLE001 — a bad cycle never kills the daemon
+                logger.debug("[SleepDaemon] cycle swallowed: %s", exc)
+            cycles += 1
+            if max_cycles is not None and cycles >= max_cycles:
+                break
+            await _sleep(_interval)
+    except asyncio.CancelledError:
+        logger.debug("[SleepDaemon] loop cancelled after %d cycle(s)", cycles)
+        raise
+    return cycles

--- a/backend/core/ouroboros/governance/strategic_direction.py
+++ b/backend/core/ouroboros/governance/strategic_direction.py
@@ -269,6 +269,13 @@ class StrategicDirectionService:
         avoidance_block = self._render_avoidance_section()
         if avoidance_block:
             body = f"{body}\n\n{avoidance_block}"
+        # Slice 101 Phase 6 — Consolidated Strategic Priors (the Synthetic Soul
+        # retrieval). Cross-session meta-prior calibration distilled by the
+        # sleep-consolidation cascade; persistent across reboots. Authority-free,
+        # empty when the meta-prior substrate is dormant.
+        consolidated_block = self._render_consolidated_memory_section()
+        if consolidated_block:
+            body = f"{body}\n\n{consolidated_block}"
         # §31 U2 Slice 2 — Causal-lineage injection. Mirrors the
         # failure-modes / action-outcomes discipline: ImportError-
         # safe, master-flag-checked inside the substrate, empty
@@ -303,6 +310,62 @@ class StrategicDirectionService:
                 recent_avoidance_digest,
             )
             return recent_avoidance_digest() or ""
+        except Exception:  # noqa: BLE001 — advisory injection is best-effort
+            return ""
+
+    def _render_consolidated_memory_section(self) -> str:
+        """Compose the optional ``## Consolidated Strategic Priors`` block
+        (Slice 101 Phase 6 — the Synthetic Soul retrieval surface).
+
+        This is how a FRESH boot "knows" what worked / failed across prior
+        sessions: it reads the consolidated meta-prior calibration that the
+        Sleep Daemon refreshes (``meta_prior_learning.compute_meta_distribution``,
+        backed by a persistent JSONL ledger that survives reboots) and surfaces
+        DECLINING priors (strategic paradigms losing favor across sessions →
+        avoid) and DOMINANT priors (consistently winning → prefer). Authority-
+        free advice; the substrate self-gates (returns empty ``per_prior`` when
+        ``JARVIS_META_PRIOR_LEARNING_ENABLED`` is off) so this is byte-identical
+        to legacy when dormant. ImportError-safe; NEVER raises.
+        """
+        try:
+            from backend.core.ouroboros.governance.meta_prior_learning import (
+                MetaPriorVerdict,
+                compute_meta_distribution,
+            )
+            report = compute_meta_distribution()
+            declining = [
+                p for p in getattr(report, "per_prior", ())
+                if getattr(p, "verdict", None) is MetaPriorVerdict.DECLINING
+            ]
+            dominant = [
+                p for p in getattr(report, "per_prior", ())
+                if getattr(p, "verdict", None) is MetaPriorVerdict.DOMINANT
+            ]
+            if not declining and not dominant:
+                return ""
+            lines = [
+                "## Consolidated Strategic Priors (cross-session memory)",
+                "",
+                "Distilled from prior sessions by the sleep-consolidation pass. "
+                "Let this bias your approach; it is advisory, not a hard rule.",
+                "",
+            ]
+            if declining:
+                lines.append("**Declining (recently losing favor — avoid unless justified):**")
+                for p in declining[:6]:
+                    lines.append(
+                        f"- `{p.prior_kind}` "
+                        f"(recent win-rate {p.win_rate_recent:.0%}, trend {p.trend:+.2f})"
+                    )
+                lines.append("")
+            if dominant:
+                lines.append("**Dominant (consistently working — prefer):**")
+                for p in dominant[:6]:
+                    lines.append(
+                        f"- `{p.prior_kind}` "
+                        f"(recent win-rate {p.win_rate_recent:.0%})"
+                    )
+            return "\n".join(lines).rstrip()
         except Exception:  # noqa: BLE001 — advisory injection is best-effort
             return ""
 

--- a/tests/architecture/test_slice101_synthetic_soul.py
+++ b/tests/architecture/test_slice101_synthetic_soul.py
@@ -1,0 +1,186 @@
+"""Slice 101 Phase 6 — the Synthetic Soul: cross-session deep-memory verification.
+
+Simulates three independent failing coding sessions, triggers the asynchronous
+sleep-consolidation cascade, then simulates a fresh rebooted session and asserts
+the organism inherently retrieves the consolidated memory and avoids the
+previously-failing paradigm — with zero false positives on clean paths.
+
+The persistent engram is the on-disk JSONL ledger set (belief-revision +
+schelling/meta-prior); a "reboot" is a fresh read of those files (no in-memory
+carry-over), which is exactly what the substrates do on next boot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import sleep_daemon as SD
+from backend.core.ouroboros.governance.belief_revision_ledger import (
+    EvidenceKind,
+    record_claim,
+    record_evidence,
+)
+from backend.core.ouroboros.governance.cognitive_subscribers import (
+    recent_avoidance_digest,
+)
+
+_FAILING_PARADIGM = "backend/core/ouroboros/governance/meta/ast_dynamic_imports.py"
+_CLEAN_FILE = "backend/core/ouroboros/governance/serpent_animation.py"
+
+
+@pytest.fixture(autouse=True)
+def _soul_env(monkeypatch, tmp_path):
+    """All masters ON; every ledger redirected to a tmp file so the test is
+    hermetic and the 'reboot' is a real on-disk re-read."""
+    monkeypatch.setenv("JARVIS_COGNITIVE_BUS_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_BELIEF_REVISION_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_BELIEF_REVISION_PERSIST_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_BELIEF_REVISION_LEDGER_PATH", str(tmp_path / "belief.jsonl"),
+    )
+    monkeypatch.setenv("JARVIS_POSTMORTEM_FUSION_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_SLEEP_CONSOLIDATION_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_SLEEP_CONSOLIDATION_LEDGER_PATH",
+        str(tmp_path / "consolidation.jsonl"),
+    )
+    monkeypatch.setenv("JARVIS_META_PRIOR_LEARNING_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_META_PRIOR_LEARNING_LEDGER_PATH", str(tmp_path / "meta.jsonl"),
+    )
+    monkeypatch.setenv("JARVIS_SCHELLING_PRIOR_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_SCHELLING_PRIOR_PERSIST_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_SCHELLING_PRIOR_LEDGER_PATH", str(tmp_path / "schelling.jsonl"),
+    )
+    monkeypatch.setenv("JARVIS_SLEEP_DAEMON_ENABLED", "1")
+    yield
+
+
+def _record_failing_session(session_idx: int) -> None:
+    """One failing session: a falsified belief about the failing paradigm file
+    (two falsifying records exceed the default falsify_threshold=2 → FALSIFIED)."""
+    claim = record_claim(
+        f"generation in [{_FAILING_PARADIGM}] succeeds",
+        "generation/failure",
+        target_files=[_FAILING_PARADIGM],
+    )
+    assert claim is not None
+    for _ in range(2):
+        record_evidence(
+            claim.claim_id,
+            EvidenceKind.FALSIFYING,
+            source_op_id=f"op-s{session_idx}",
+            source_session_id=f"session-{session_idx}",
+        )
+
+
+# === THE MARQUEE: 3 failing sessions → consolidate → reboot → retrieve ======
+
+def test_three_failing_sessions_retrieved_after_reboot_zero_fp(tmp_path):
+    # --- three independent failing sessions ---
+    for s in range(3):
+        _record_failing_session(s)
+
+    # --- trigger the asynchronous sleep consolidation pass ---
+    report = SD.run_sleep_cycle_once(idle_seconds=99999.0)
+    assert report.master_enabled is True
+    assert report.consolidation_verdict != "disabled"
+
+    # --- persistence: the engram is on disk, surviving any reboot ---
+    belief_ledger = tmp_path / "belief.jsonl"
+    assert belief_ledger.exists()
+    assert belief_ledger.stat().st_size > 0
+
+    # --- simulate a fresh rebooted session: a brand-new read of the ledgers ---
+    digest = recent_avoidance_digest()
+
+    # The fresh session inherently KNOWS the failing paradigm.
+    assert _FAILING_PARADIGM in digest
+    # ...and actively avoids it (the block instructs caution / diagnosis).
+    assert "Recently-Failing Areas" in digest
+    # ZERO false positives: a clean, never-failed path is NOT flagged.
+    assert _CLEAN_FILE not in digest
+
+
+# === The sleep daemon: cascade + async off-hot-path behaviour ===============
+
+def test_sleep_cycle_runs_cascade_without_raising():
+    report = SD.run_sleep_cycle_once(idle_seconds=99999.0)
+    assert report.master_enabled is True
+    # The cascade executed (consolidation produced a real verdict, not disabled).
+    assert report.consolidation_verdict in ("awake", "dreaming", "consolidated")
+
+
+def test_sleep_cycle_inert_when_master_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_SLEEP_DAEMON_ENABLED", raising=False)
+    report = SD.run_sleep_cycle_once()
+    assert report.master_enabled is False
+    assert report.consolidation_verdict == "disabled"
+
+
+def test_sleep_daemon_loop_is_bounded_and_non_blocking():
+    # The daemon runs off the hot path: a fake sleep proves we yield between
+    # cycles (never a blocking compute), and max_cycles bounds it for the test.
+    slept = []
+
+    async def _fake_sleep(s):
+        slept.append(s)
+
+    cycles = asyncio.run(
+        SD.run_sleep_daemon_loop(interval_s=10.0, max_cycles=3, sleep_fn=_fake_sleep)
+    )
+    assert cycles == 3
+    # Yielded between cycles (2 inter-cycle sleeps for 3 cycles).
+    assert len(slept) == 2
+
+
+def test_sleep_daemon_loop_inert_when_master_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_SLEEP_DAEMON_ENABLED", raising=False)
+    cycles = asyncio.run(SD.run_sleep_daemon_loop(max_cycles=5))
+    assert cycles == 0
+
+
+# === Consolidated meta-prior: retrieved at GENERATE across reboot ===========
+
+def test_consolidated_meta_prior_retrieved_after_reboot():
+    from backend.core.ouroboros.governance.schelling_consensus_prior import (
+        record_prior_outcome,
+    )
+    from backend.core.ouroboros.governance.meta_prior_learning import (
+        MetaPriorVerdict,
+        compute_meta_distribution,
+    )
+    from backend.core.ouroboros.governance.strategic_direction import (
+        StrategicDirectionService,
+    )
+
+    # Seed a consistently-winning strategic prior across many observations.
+    for i in range(25):
+        record_prior_outcome("factory_pattern_refactor", f"op-{i}", "sig-x", True)
+
+    # The consolidated meta-distribution recognises it as DOMINANT.
+    report = compute_meta_distribution()
+    kinds_dominant = {
+        p.prior_kind for p in report.per_prior
+        if p.verdict is MetaPriorVerdict.DOMINANT
+    }
+    assert "factory_pattern_refactor" in kinds_dominant
+
+    # Fresh rebooted session: the GENERATE injection surfaces it (reads the
+    # persisted schelling/meta ledgers — survives reboot).
+    svc = object.__new__(StrategicDirectionService)
+    block = svc._render_consolidated_memory_section()
+    assert "factory_pattern_refactor" in block
+    assert "Consolidated Strategic Priors" in block
+
+
+def test_consolidated_memory_inert_when_meta_off(monkeypatch):
+    from backend.core.ouroboros.governance.strategic_direction import (
+        StrategicDirectionService,
+    )
+    monkeypatch.delenv("JARVIS_META_PRIOR_LEARNING_ENABLED", raising=False)
+    svc = object.__new__(StrategicDirectionService)
+    assert svc._render_consolidated_memory_section() == ""


### PR DESCRIPTION
## Slice 101 Phase 6 — the Synthetic Soul

Wires the **cross-session deep-memory cascade off the hot path**, turning per-failure short-term memory (Phase 3) into consolidated long-horizon learning that survives reboots.

### Verify-first finding (reshaped the runbook)
The cascade was **~95% already self-composing**: `run_consolidation_pass()` internally pulls belief-revision (FALSIFIED) + postmortem-fusion, and `fuse_recent_postmortems()` already extracts **root-cause clusters** (`root_cause_class` / `representative_root_cause` / `suggested_next_action`), not symptoms. The genuine gaps were: nothing *ran* the cascade off the hot path, and nothing *retrieved* it at boot.

### What landed
- **`sleep_daemon.py`** — a background async daemon (`run_sleep_daemon_loop`: idle-gated cadence, injectable `sleep_fn`, bounded by `max_cycles`, cleanly cancellable) running `run_sleep_cycle_once` → composes the consolidation pass + refreshes meta-prior calibration. Never blocks the FSM; never raises (except `CancelledError`).
- **GLS boot/stop** — launches the daemon task in `_start_governance_observers`; cancels it **first** in `_stop_governance_observers` (no drain race).
- **`strategic_direction._render_consolidated_memory_section`** — the GENERATE-time **retrieval**: a fresh boot reads the persistent meta-prior calibration and surfaces **DECLINING** priors (avoid) + **DOMINANT** priors (prefer), authority-free.

### Honest scope note
`meta_prior_learning` is prior-**strategy** calibration (win-rates from the schelling consensus stream), a *complementary* signal — **not** itself the failed-paradigm store. The persistent "avoid-this-paradigm" engram is the on-disk belief + postmortem-fusion ledger; the GENERATE injection + the Phase-3 avoidance digest retrieve it. The daemon refreshes both streams.

### Safety
- Masters **§33.1 default-FALSE** (`JARVIS_SLEEP_DAEMON_ENABLED` + the substrate masters) → no task spawned / empty injection when off → byte-identical legacy.
- Every substrate call independently `try/except`-guarded.

### TDD — `tests/architecture/test_slice101_synthetic_soul.py` (7 tests)
The marquee: **3 independent failing sessions → trigger the sleep cascade → simulate a fresh reboot (real on-disk re-read) → assert the fresh session retrieves the failing paradigm and avoids it, with ZERO false positives** on clean paths. Plus: cascade-runs-without-raising, master-off inertness, async-loop boundedness + non-blocking (fake `sleep_fn`), and cross-reboot meta-prior retrieval.
- **296 regression green** (sleep_consolidation + postmortem_fusion + meta_prior + schelling + strategic_direction + cognitive bus/subscribers + the new suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an async Sleep Consolidation Daemon that runs cross-session memory consolidation off the hot path and persists results across reboots. On boot, we now surface consolidated strategic priors during generation to avoid declining paradigms and prefer dominant ones.

- **New Features**
  - Added `sleep_daemon.py` with `run_sleep_daemon_loop` and `run_sleep_cycle_once` to compose consolidation, root-cause fusion, and meta-prior calibration on an idle-gated cadence; cancellable, injectable `sleep_fn`, and `max_cycles` for tests; never raises into the loop.
  - `GovernedLoopService` starts the daemon when enabled and cancels it first on shutdown to avoid drain races; inert if disabled.
  - `strategic_direction._render_consolidated_memory_section` injects “Consolidated Strategic Priors” (DECLINING to avoid, DOMINANT to prefer) at generate time from persisted ledgers.
  - Added architecture tests covering cross-reboot retrieval, zero false positives, daemon boundedness/non-blocking, and master-flag inertness.

- **Migration**
  - No change by default. To enable: set `JARVIS_SLEEP_DAEMON_ENABLED=1` (optional `JARVIS_SLEEP_DAEMON_INTERVAL_S` to tune cadence).

<sup>Written for commit 8fa04cdf821a4bdb481ac05e2cd3a32997cc00fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

