### PR TITLE
Slice 101 Phase 7 — adversarial autobiography (O+V audits its own commits)

### DIFF
--- a/backend/core/ouroboros/governance/auto_committer.py
+++ b/backend/core/ouroboros/governance/auto_committer.py
@@ -113,6 +113,52 @@ def ov_signature_substring() -> str:
     return _OV_SIGNATURE
 
 
+def _run_post_commit_self_audit(op_id: str, commit_hash: str) -> None:
+    """Runs in a thread executor — the sync, git-heavy adversarial-autobiography
+    self-audit. NEVER raises. The audit self-publishes SSE + a JSONL ledger; a
+    CORPUS_ESCAPE (a shipped autonomous commit smuggled a cage-bypass pattern)
+    is logged loud for operator review. We do NOT auto-remediate."""
+    try:
+        from backend.core.ouroboros.governance.adversarial_autobiography import (
+            audit_autobiography,
+        )
+        report = audit_autobiography(force_refresh=True)
+        finding = str(getattr(report.finding, "value", report.finding))
+        if finding == "corpus_escape":
+            logger.warning(
+                "[AutoCommitter] SELF-AUDIT CAGE ESCAPE after commit %s "
+                "(op=%s): %d adversarial-corpus pattern(s) in O+V history — "
+                "operator review required.",
+                (commit_hash or "")[:8], op_id,
+                int(getattr(report, "escape_count", 0) or 0),
+            )
+    except Exception:  # noqa: BLE001 — self-audit must never affect anything
+        pass
+
+
+def _schedule_post_commit_self_audit(op_id: str, commit_hash: str) -> None:
+    """Slice 101 Phase 7 — after an O+V commit lands, schedule a NON-BLOCKING
+    adversarial-autobiography self-audit so a cage-bypass that shipped is caught
+    promptly (not only on the 30-min sleep cadence). The audit is sync + git-
+    heavy, so it runs in a thread executor (Zero-Block Invariant) — fire-and-
+    forget; the commit path NEVER waits on it. Self-gates on the autobiography
+    master so nothing is spawned when off. NEVER raises into the commit path.
+    """
+    try:
+        from backend.core.ouroboros.governance.adversarial_autobiography import (
+            master_enabled as _autobiography_enabled,
+        )
+        if not _autobiography_enabled():
+            return
+        loop = asyncio.get_running_loop()
+        # Fire-and-forget: do NOT await. _run_post_commit_self_audit never raises.
+        loop.run_in_executor(
+            None, _run_post_commit_self_audit, op_id, commit_hash,
+        )
+    except Exception:  # noqa: BLE001 — scheduling must never touch the commit
+        pass
+
+
 def ov_coauthor_line() -> str:
     """Canonical ``Co-Authored-By:`` trailer line for O+V commits."""
     return _OV_COAUTHOR
@@ -598,6 +644,10 @@ class AutoCommitter:
 
             # §24.6.2 — Store intent token in git notes post-commit.
             await self._store_intent_token(intent_token, commit_hash)
+
+            # Slice 101 Phase 7 — fire-and-forget self-audit (non-blocking,
+            # master-gated, never touches the commit path).
+            _schedule_post_commit_self_audit(op_id, commit_hash)
 
             result = CommitResult(
                 committed=True,

--- a/backend/core/ouroboros/governance/sleep_daemon.py
+++ b/backend/core/ouroboros/governance/sleep_daemon.py
@@ -83,6 +83,8 @@ class SleepCycleReport:
     fused_cluster_count: int
     meta_dominant_count: int
     meta_declining_count: int
+    autobiography_finding: str
+    autobiography_escape_count: int
     diagnostic: str
     elapsed_s: float
     schema_version: str = SLEEP_CYCLE_SCHEMA_VERSION
@@ -96,6 +98,8 @@ def _disabled_report(started: float) -> SleepCycleReport:
         fused_cluster_count=0,
         meta_dominant_count=0,
         meta_declining_count=0,
+        autobiography_finding="corpus_disabled",
+        autobiography_escape_count=0,
         diagnostic=f"sleep daemon disabled via {_ENV_ENABLED}=false",
         elapsed_s=0.0,
     )
@@ -142,6 +146,38 @@ def run_sleep_cycle_once(
     except Exception as exc:  # noqa: BLE001
         logger.debug("[SleepDaemon] fusion count failed: %s", exc)
 
+    # 2b) Adversarial autobiography self-audit — Slice 101 Phase 7. The organism
+    # reads its OWN recent commit history (git log + git show, scoped to O+V-
+    # signed commits) and probes each diff against the canonical adversarial
+    # corpus: did a shipped autonomous commit smuggle a cage-bypass pattern? This
+    # is the right home for an expensive git self-audit — off the hot path, on
+    # the idle sleep cadence. The audit self-publishes SSE + ledger. A
+    # CORPUS_ESCAPE is a loud SAFETY alarm (we surface it, we do NOT auto-
+    # remediate — un-gameable observability is the correct posture for a self-
+    # integrity detector). Self-gates on JARVIS_ADVERSARIAL_AUTOBIOGRAPHY_ENABLED
+    # (returns CORPUS_DISABLED cheaply, before any git, when off).
+    autobiography_finding = "corpus_disabled"
+    autobiography_escape_count = 0
+    try:
+        from backend.core.ouroboros.governance.adversarial_autobiography import (
+            audit_autobiography,
+        )
+        audit = audit_autobiography(force_refresh=True)
+        autobiography_finding = str(
+            getattr(audit.finding, "value", audit.finding)
+        )
+        autobiography_escape_count = int(getattr(audit, "escape_count", 0) or 0)
+        if autobiography_finding == "corpus_escape":
+            logger.warning(
+                "[SleepDaemon] SELF-AUDIT CAGE ESCAPE — %d O+V commit(s) "
+                "shipped an adversarial-corpus pattern (cage_health=%.3f). "
+                "Operator review required.",
+                autobiography_escape_count,
+                float(getattr(audit, "cage_health_ratio", 0.0) or 0.0),
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[SleepDaemon] autobiography audit failed: %s", exc)
+
     # 3) Meta-prior calibration refresh — complementary stream, also persists.
     meta_dominant = 0
     meta_declining = 0
@@ -160,11 +196,13 @@ def run_sleep_cycle_once(
         f"consolidation={consolidation_verdict} "
         f"candidates={consolidation_candidates} "
         f"fused={fused_cluster_count} "
-        f"meta_dom={meta_dominant} meta_decl={meta_declining}"
+        f"meta_dom={meta_dominant} meta_decl={meta_declining} "
+        f"autobiography={autobiography_finding}"
     )
     if (
         consolidation_verdict in ("consolidated", "dreaming")
         or fused_cluster_count > 0
+        or autobiography_escape_count > 0
     ):
         logger.info("[SleepDaemon] cycle complete — %s", diagnostic)
     return SleepCycleReport(
@@ -174,6 +212,8 @@ def run_sleep_cycle_once(
         fused_cluster_count=fused_cluster_count,
         meta_dominant_count=meta_dominant,
         meta_declining_count=meta_declining,
+        autobiography_finding=autobiography_finding,
+        autobiography_escape_count=autobiography_escape_count,
         diagnostic=diagnostic,
         elapsed_s=elapsed,
     )

--- a/tests/governance/test_slice101_phase7_autobiography.py
+++ b/tests/governance/test_slice101_phase7_autobiography.py
@@ -1,0 +1,151 @@
+"""Slice 101 Phase 7 — adversarial autobiography: O+V audits its OWN commits.
+
+Proves the organism's self-integrity detector: scoped to O+V-signed commits, it
+probes each diff against the canonical adversarial corpus and flags a shipped
+cage-bypass (CORPUS_ESCAPE). Driven hermetically via the injectable git runners.
+Also covers the Sleep-Daemon self-audit step and the non-blocking post-commit
+trigger — both master-gated, both never-raise.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from backend.core.ouroboros.governance.adversarial_autobiography import (
+    AutobiographyFinding,
+    audit_autobiography,
+)
+from backend.core.ouroboros.governance.auto_committer import (
+    ov_signature_substring,
+    _schedule_post_commit_self_audit,
+)
+from backend.core.ouroboros.governance.p9_4_adversarial_corpus import (
+    CORPUS,
+    materialize_pattern,
+)
+
+_OV_SIG = ov_signature_substring()
+
+
+def _runner_returning(stdout: str):
+    def _runner(args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=stdout)
+    return _runner
+
+
+def _ov_commit_log(commit_hash: str = "abc123def") -> str:
+    body = "feat(governance): something\n\n" + _OV_SIG
+    return f"{commit_hash}\n1700000000\n{body}__END_HEADER__\n__OV_AUTOBIO__\n"
+
+
+def _non_ov_commit_log(commit_hash: str = "deadbeef") -> str:
+    body = "feat: a human commit\n\nCo-Authored-By: Someone"
+    return f"{commit_hash}\n1700000000\n{body}__END_HEADER__\n__OV_AUTOBIO__\n"
+
+
+def _first_materializable_pattern() -> str:
+    for entry in CORPUS:
+        p = materialize_pattern(entry)
+        if isinstance(p, str) and p and not (p.startswith("<") and p.endswith(">")):
+            return p
+    raise AssertionError("no materializable corpus entry found")
+
+
+def _diff_embedding(pattern: str) -> str:
+    added = "\n".join("+" + line for line in pattern.splitlines())
+    return "+++ b/backend/x.py\n" + added + "\n"
+
+
+def _enable(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_ADVERSARIAL_AUTOBIOGRAPHY_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_AUTOBIOGRAPHY_LEDGER_PATH", str(tmp_path / "autobio.jsonl"),
+    )
+
+
+# === THE SAFETY CORE: O+V detects a cage-bypass in its OWN commit ===========
+
+def test_self_audit_detects_corpus_escape_in_own_commit(monkeypatch, tmp_path):
+    _enable(monkeypatch, tmp_path)
+    pattern = _first_materializable_pattern()
+    report = audit_autobiography(
+        force_refresh=True,
+        git_log_runner=_runner_returning(_ov_commit_log()),
+        git_show_runner=_runner_returning(_diff_embedding(pattern)),
+    )
+    assert report.finding is AutobiographyFinding.CORPUS_ESCAPE
+    assert report.escape_count >= 1
+    assert report.commits_audited == 1
+
+
+def test_self_audit_clean_when_own_commit_has_no_pattern(monkeypatch, tmp_path):
+    _enable(monkeypatch, tmp_path)
+    report = audit_autobiography(
+        force_refresh=True,
+        git_log_runner=_runner_returning(_ov_commit_log()),
+        git_show_runner=_runner_returning("+++ b/x.py\n+print('hello world')\n"),
+    )
+    assert report.finding is AutobiographyFinding.CORPUS_CLEAN
+    assert report.escape_count == 0
+
+
+def test_self_audit_ignores_non_ov_commits(monkeypatch, tmp_path):
+    _enable(monkeypatch, tmp_path)
+    pattern = _first_materializable_pattern()
+    # Even a human commit carrying the pattern is NOT audited (only O+V's own).
+    report = audit_autobiography(
+        force_refresh=True,
+        git_log_runner=_runner_returning(_non_ov_commit_log()),
+        git_show_runner=_runner_returning(_diff_embedding(pattern)),
+    )
+    assert report.finding is AutobiographyFinding.CORPUS_NO_COMMITS
+    assert report.commits_audited == 0
+
+
+def test_self_audit_disabled_when_master_off(monkeypatch, tmp_path):
+    monkeypatch.delenv("JARVIS_ADVERSARIAL_AUTOBIOGRAPHY_ENABLED", raising=False)
+    report = audit_autobiography(
+        force_refresh=True,
+        git_log_runner=_runner_returning(_ov_commit_log()),
+        git_show_runner=_runner_returning("+anything\n"),
+    )
+    assert report.finding is AutobiographyFinding.CORPUS_DISABLED
+
+
+# === Sleep-Daemon self-audit step ==========================================
+
+def test_sleep_cycle_includes_autobiography_finding(monkeypatch, tmp_path):
+    from backend.core.ouroboros.governance import sleep_daemon as SD
+    monkeypatch.setenv("JARVIS_SLEEP_DAEMON_ENABLED", "1")
+    # autobiography master OFF → the step self-gates to corpus_disabled (no git).
+    monkeypatch.delenv("JARVIS_ADVERSARIAL_AUTOBIOGRAPHY_ENABLED", raising=False)
+    report = SD.run_sleep_cycle_once(idle_seconds=99999.0)
+    assert report.master_enabled is True
+    assert report.autobiography_finding == "corpus_disabled"
+    assert report.autobiography_escape_count == 0
+
+
+def test_sleep_cycle_runs_real_autobiography_when_enabled(monkeypatch, tmp_path):
+    from backend.core.ouroboros.governance import sleep_daemon as SD
+    monkeypatch.setenv("JARVIS_SLEEP_DAEMON_ENABLED", "1")
+    _enable(monkeypatch, tmp_path)
+    report = SD.run_sleep_cycle_once(idle_seconds=99999.0)
+    # Real git over this worktree (no O+V-signed commits) → a valid finding,
+    # never a raise. Robust to environment.
+    assert report.autobiography_finding in (
+        "corpus_clean", "corpus_escape", "corpus_no_commits", "corpus_disabled",
+    )
+
+
+# === Non-blocking post-commit trigger ======================================
+
+def test_post_commit_schedule_inert_when_master_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_ADVERSARIAL_AUTOBIOGRAPHY_ENABLED", raising=False)
+    # No running loop + master off → returns immediately, never raises.
+    _schedule_post_commit_self_audit("op-1", "abc123")
+
+
+def test_post_commit_schedule_never_raises_without_loop(monkeypatch):
+    monkeypatch.setenv("JARVIS_ADVERSARIAL_AUTOBIOGRAPHY_ENABLED", "1")
+    # Master on but no running loop → get_running_loop raises → swallowed.
+    _schedule_post_commit_self_audit("op-2", "def456")


### PR DESCRIPTION
## Slice 101 Phase 7 — the self-integrity detector

Wires the safety substrate that matters most as autonomy grows: **O+V audits its OWN commit history for cage-bypass**. It reads its own recent commits (`git log` + `git show`, scoped to O+V-signed commits via `auto_committer.ov_signature_substring`) and probes each diff against the canonical adversarial corpus — *did a shipped autonomous commit smuggle a cage-bypass pattern?* Composes the existing `audit_autobiography()`; adds orchestration, not detection logic.

### Two surfaces — both master-gated, both off the hot path
- **Sleep-Daemon self-audit step** (`run_sleep_cycle_once`, after fusion / before meta-prior) — periodic self-reflection on the idle cadence, the right home for an expensive git audit. `SleepCycleReport` gains `autobiography_finding` + `autobiography_escape_count`.
- **Non-blocking post-commit trigger** (AutoCommitter) — after a commit lands, `loop.run_in_executor(...)` runs the sync git audit in a **thread, fire-and-forget** (Zero-Block Invariant); the commit path never waits. Catches a cage-bypass that just shipped *promptly*, not only on the 30-min cadence.

### Safety posture (deliberate)
A `CORPUS_ESCAPE` is a **loud, persistent alarm** — the substrate self-publishes SSE (`autobiography_audit_completed`) + a JSONL ledger; we log `WARNING`. We **do NOT auto-remediate**: un-gameable observability is the correct response for a self-integrity detector — an organism that auto-reacts to its own escape-detection is exploitable.

### Verify-first
Per-op risk-floor composition was **rejected** — `audit_autobiography` runs `git log`/`git show` (500ms–2s), far too heavy for the per-op GATE. The sleep daemon + non-blocking post-commit trigger are the correct homes. The detector exposes injectable `git_log_runner`/`git_show_runner` test seams.

### Tests — 8 new (hermetic via injected git runners)
- **The safety core:** a real materialized corpus pattern in an O+V-signed commit → `CORPUS_ESCAPE` (escape_count ≥ 1).
- Ignores non-O+V commits (`CORPUS_NO_COMMITS`); clean on benign diffs (`CORPUS_CLEAN`); master-off → `CORPUS_DISABLED`.
- Sleep-step finding surfaced; post-commit trigger inert/never-raises.

**Regression-clean:** 10 pre-existing `auto_committer` gitignore/SSE/sovereignty failures verified **identical on base** (via stash) — not caused by this change (the trigger is a no-op when the autobiography master is off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self-audit that scans recent O+V-signed commits for adversarial-corpus patterns and flags any cage-bypass. Runs on the sleep cadence and as a non-blocking post-commit check; surfaces findings via logs/SSE/ledger without auto-remediation.

- **New Features**
  - `sleep_daemon.run_sleep_cycle_once`: adds a self-audit step; extends `SleepCycleReport` with `autobiography_finding` and `autobiography_escape_count`; logs a WARNING on `corpus_escape`. Master-gated by `JARVIS_ADVERSARIAL_AUTOBIOGRAPHY_ENABLED`.
  - `auto_committer`: schedules a fire-and-forget self-audit after each commit using a thread executor; never blocks or raises; also master-gated.
  - Safety signaling: publishes `autobiography_audit_completed` SSE and writes a JSONL ledger; no auto-remediation by design.
  - Tests: 8 new cases cover escape detection, clean paths, gating, and non-blocking scheduling.

<sup>Written for commit a1fd5b2a7c1abb8aab9a392e7abb2a74c60bf68c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

