### PR TITLE
Slice 101 Phase 8 — Dynamic Entropy Engine (compositional curiosity)

### DIFF
--- a/backend/core/ouroboros/governance/domain_entropy_engine.py
+++ b/backend/core/ouroboros/governance/domain_entropy_engine.py
@@ -1,0 +1,378 @@
+"""Dynamic Entropy Engine — Slice 101 Phase 8 (Compositional Curiosity).
+
+The PROACTIVE counterpart to the defensive substrates: instead of waiting for a
+signal, O+V mathematically scans its own semantic map to find the architectural
+zones it knows LEAST about, and proactively schedules governed exploration there.
+
+ROOT-PROBLEM-FIRST (verify-first, 2026-06-06): we do NOT build a random-walk or
+an 'explore' flag, and we do NOT duplicate the existing curiosity substrates
+(``curiosity_gradient`` already computes per-generation logprob/prophecy entropy;
+``compositional_curiosity`` computes maturity-novelty pairs). The one genuinely
+missing signal is **knowledge sparsity over codebase domains**: a Shannon-entropy
+read of the ``semantic_index`` cluster distribution. Sparse clusters (few samples)
+are the zones O+V has explored least → the highest-value curiosity targets.
+
+    H(X) = -Σ P(x) log2 P(x)      P(cluster_i) = size_i / Σ size
+
+CAGE INVARIANT (load-bearing): curiosity chooses WHERE to look; it NEVER runs a
+probe directly. Each identified zone becomes a GOVERNED ``IntentEnvelope``
+(source=exploration, urgency=low) routed through ``unified_intake_router.ingest``
+— so every proactive probe passes the full First-Order cage (Iron Gate,
+SemanticGuardian, rehearsal floor, worktree isolation, risk tiers) exactly like
+any other op. Bypassing the cage for curiosity would unravel Phases 1-7.
+
+BUDGET (recoverable throttle): the number of zones emitted per scan is a PURE
+function of the current ``cognitive_load_shedding`` verdict — NORMAL → full,
+ELEVATED → halved, OVERLOADED → zero. No latch: when load recovers, curiosity
+recovers automatically (the Slice 98 recovery invariant). The intake's own
+cognitive-shed gate (Phase 4) is a second backstop on these low-urgency ops.
+
+CLOSED LOOP (no new wiring): a governed exploration op completes → publishes
+post_apply/post_failure → the Phase-3 belief subscriber records it → the Phase-6
+sleep daemon consolidates it into the Synthetic Soul. Mapping new territory
+permanently updates deep memory, for free.
+
+Master ``JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED`` — §33.1 default-FALSE. NEVER raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from dataclasses import dataclass
+from typing import Any, List, Mapping, Optional, Sequence, Tuple
+
+logger = logging.getLogger("ouroboros.domain_entropy_engine")
+
+_ENV_ENABLED = "JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED"
+_ENV_BASE_BUDGET = "JARVIS_DOMAIN_ENTROPY_BASE_BUDGET"
+_ENV_MAX_ZONES = "JARVIS_DOMAIN_ENTROPY_MAX_ZONES"
+_TRUTHY = ("1", "true", "yes", "on")
+
+_DEFAULT_BASE_BUDGET = 3
+_DEFAULT_MAX_ZONES = 8
+
+DOMAIN_ENTROPY_SCHEMA_VERSION = "domain_entropy.1"
+
+# Exploration ops are the lowest-urgency (deferrable) tier so the Phase-4
+# cognitive-shed gate can throttle them under load. Mirrors the existing
+# ProactiveExplorationSensor curiosity emission.
+_EXPLORATION_SOURCE = "exploration"
+_EXPLORATION_URGENCY = "low"
+
+
+def domain_entropy_engine_enabled() -> bool:
+    """§33.1 master — default FALSE. Never raises."""
+    try:
+        raw = os.environ.get(_ENV_ENABLED)
+        if raw is None:
+            return False
+        return raw.strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _base_budget() -> int:
+    try:
+        return max(0, int(os.environ.get(_ENV_BASE_BUDGET, str(_DEFAULT_BASE_BUDGET))))
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_BASE_BUDGET
+
+
+def _max_zones() -> int:
+    try:
+        return max(1, int(os.environ.get(_ENV_MAX_ZONES, str(_DEFAULT_MAX_ZONES))))
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_MAX_ZONES
+
+
+@dataclass(frozen=True)
+class SparseZone:
+    """One under-explored domain — a curiosity target."""
+
+    cluster_id: str
+    kind: str
+    size: int
+    probability: float       # P(cluster) = size / total
+    sparsity_score: float    # 1 - normalized density, in [0, 1] (higher = sparser)
+    representative_paths: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class DomainEntropyReport:
+    """Shannon-entropy read of the semantic-index domain distribution."""
+
+    master_enabled: bool
+    cluster_count: int
+    total_samples: int
+    total_entropy_bits: float        # H(X)
+    max_entropy_bits: float          # log2(n) — uniform reference
+    normalized_entropy: float        # H / max, in [0, 1] (1 = maximally spread)
+    sparse_zones: Tuple[SparseZone, ...]
+    diagnostic: str
+    schema_version: str = DOMAIN_ENTROPY_SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class CuriosityScanReport:
+    """Outcome of one proactive scan + governed-emission cycle."""
+
+    master_enabled: bool
+    normalized_entropy: float
+    zones_identified: int
+    budget: int
+    emitted: int
+    ingest_results: Tuple[str, ...]
+    diagnostic: str
+    schema_version: str = DOMAIN_ENTROPY_SCHEMA_VERSION
+
+
+def _disabled_entropy_report() -> DomainEntropyReport:
+    return DomainEntropyReport(
+        master_enabled=False,
+        cluster_count=0,
+        total_samples=0,
+        total_entropy_bits=0.0,
+        max_entropy_bits=0.0,
+        normalized_entropy=0.0,
+        sparse_zones=(),
+        diagnostic=f"disabled via {_ENV_ENABLED}=false",
+    )
+
+
+def _load_clusters() -> Sequence[Mapping[str, Any]]:
+    """Read the live semantic-index cluster distribution. NEVER raises;
+    returns () when the index is unavailable."""
+    try:
+        from backend.core.ouroboros.governance.semantic_index import (
+            get_default_index,
+        )
+        stats = get_default_index().stats()
+        clusters = getattr(stats, "clusters", None) or []
+        return [c for c in clusters if isinstance(c, Mapping)]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[DomainEntropy] cluster load failed: %s", exc)
+        return ()
+
+
+def compute_domain_entropy(
+    *,
+    clusters: Optional[Sequence[Mapping[str, Any]]] = None,
+    now_unix: Optional[float] = None,
+) -> DomainEntropyReport:
+    """Compute the Shannon entropy of the domain (cluster) distribution and rank
+    the sparsest zones. Pure + NEVER raises. ``clusters`` is an injectable seam
+    (each item a mapping with at least ``size``; optional ``kind`` /
+    ``cluster_id`` / ``representative_paths``); defaults to the live index.
+    Returns a DISABLED report when the master flag is off.
+    """
+    if not domain_entropy_engine_enabled():
+        return _disabled_entropy_report()
+    rows = clusters if clusters is not None else _load_clusters()
+
+    sized: List[Tuple[str, str, int, Tuple[str, ...]]] = []
+    for i, c in enumerate(rows):
+        try:
+            size = int(c.get("size", 0) or 0)
+            if size <= 0:
+                continue
+            cid = str(c.get("cluster_id", c.get("id", i)))
+            kind = str(c.get("kind", "mixed"))
+            reps = tuple(str(p) for p in (c.get("representative_paths", ()) or ()))[:8]
+            sized.append((cid, kind, size, reps))
+        except Exception:  # noqa: BLE001 — skip a malformed cluster, never abort
+            continue
+
+    total = sum(s[2] for s in sized)
+    if total <= 0 or not sized:
+        return DomainEntropyReport(
+            master_enabled=True,
+            cluster_count=0,
+            total_samples=0,
+            total_entropy_bits=0.0,
+            max_entropy_bits=0.0,
+            normalized_entropy=0.0,
+            sparse_zones=(),
+            diagnostic="no clusters with samples — index empty or unbuilt",
+        )
+
+    n = len(sized)
+    max_size = max(s[2] for s in sized)
+    entropy = 0.0
+    for _cid, _kind, size, _reps in sized:
+        p = size / total
+        if p > 0.0:
+            entropy -= p * math.log2(p)
+    max_entropy = math.log2(n) if n > 1 else 0.0
+    normalized = (entropy / max_entropy) if max_entropy > 0.0 else 0.0
+
+    # Sparse zones: ascending size — the fewest-sample domains are least-explored.
+    zones: List[SparseZone] = []
+    for cid, kind, size, reps in sorted(sized, key=lambda s: (s[2], s[0])):
+        p = size / total
+        sparsity = 1.0 - (size / max_size) if max_size > 0 else 0.0
+        zones.append(SparseZone(
+            cluster_id=cid,
+            kind=kind,
+            size=size,
+            probability=p,
+            sparsity_score=max(0.0, min(1.0, sparsity)),
+            representative_paths=reps,
+        ))
+
+    return DomainEntropyReport(
+        master_enabled=True,
+        cluster_count=n,
+        total_samples=total,
+        total_entropy_bits=entropy,
+        max_entropy_bits=max_entropy,
+        normalized_entropy=max(0.0, min(1.0, normalized)),
+        sparse_zones=tuple(zones[: _max_zones()]),
+        diagnostic=(
+            f"H={entropy:.4f}b / max={max_entropy:.4f}b "
+            f"(norm={normalized:.3f}) over {n} domains, {total} samples"
+        ),
+    )
+
+
+def exploration_budget(
+    *,
+    load_report: Optional[Any] = None,
+    base_budget: Optional[int] = None,
+) -> int:
+    """Recoverable curiosity budget = PURE function of the current cognitive-load
+    verdict. NORMAL/DISABLED → full base; ELEVATED → halved; OVERLOADED → zero.
+    No latch: budget recovers automatically when load recovers. NEVER raises.
+    ``load_report`` is injectable (defaults to a live evaluate_cognitive_load).
+    """
+    base = _base_budget() if base_budget is None else max(0, int(base_budget))
+    try:
+        report = load_report
+        if report is None:
+            from backend.core.ouroboros.governance.cognitive_load_shedding import (
+                evaluate_cognitive_load,
+            )
+            report = evaluate_cognitive_load()
+        verdict = str(getattr(getattr(report, "verdict", None), "value", "") or "")
+        if verdict == "overloaded":
+            return 0
+        if verdict == "elevated":
+            return base // 2
+        # normal / disabled (load substrate off → no throttle signal) → full budget
+        return base
+    except Exception:  # noqa: BLE001 — never let the budget calc break the scan
+        return base
+
+
+def build_exploration_envelopes(
+    report: DomainEntropyReport,
+    budget: int,
+    *,
+    repo: str = ".",
+    make_envelope_fn: Any = None,
+) -> List[Any]:
+    """Map the top-``budget`` sparsest zones to GOVERNED exploration envelopes.
+    Pure (no emission). Each envelope is source=exploration, urgency=low (so the
+    cognitive-shed gate can throttle it) — a request for the cage-protected loop
+    to explore, NOT a probe to run directly. NEVER raises; returns [] on any
+    failure or empty budget.
+    """
+    if budget <= 0 or not report.sparse_zones:
+        return []
+    try:
+        if make_envelope_fn is None:
+            from backend.core.ouroboros.governance.intake.intent_envelope import (
+                make_envelope,
+            )
+            make_envelope_fn = make_envelope
+    except Exception:  # noqa: BLE001
+        return []
+
+    envelopes: List[Any] = []
+    for zone in report.sparse_zones[: max(0, int(budget))]:
+        try:
+            tf = zone.representative_paths if zone.representative_paths else (".",)
+            env = make_envelope_fn(
+                source=_EXPLORATION_SOURCE,
+                description=(
+                    f"Entropy-driven exploration: domain '{zone.cluster_id}' "
+                    f"(kind={zone.kind}) is sparsely mapped — only {zone.size} "
+                    f"sample(s), P={zone.probability:.3f}, sparsity="
+                    f"{zone.sparsity_score:.2f}. The organism has explored this "
+                    f"architectural zone least; map it (read + characterize, "
+                    f"propose a test or minimal safe improvement)."
+                ),
+                target_files=tuple(tf),
+                repo=repo,
+                confidence=round(min(1.0, max(0.0, zone.sparsity_score)), 4),
+                urgency=_EXPLORATION_URGENCY,
+                evidence={
+                    "category": "entropy_driven_curiosity",
+                    "cluster_id": zone.cluster_id,
+                    "kind": zone.kind,
+                    "size": zone.size,
+                    "probability": zone.probability,
+                    "sparsity_score": zone.sparsity_score,
+                    "normalized_entropy": report.normalized_entropy,
+                    "sensor": "DomainEntropyEngine",
+                },
+                requires_human_ack=False,
+            )
+            envelopes.append(env)
+        except Exception as exc:  # noqa: BLE001 — skip a bad zone, never abort
+            logger.debug("[DomainEntropy] envelope build failed: %s", exc)
+            continue
+    return envelopes
+
+
+async def run_curiosity_scan_once(
+    *,
+    router: Any,
+    clusters: Optional[Sequence[Mapping[str, Any]]] = None,
+    load_report: Optional[Any] = None,
+    repo: str = ".",
+    now_unix: Optional[float] = None,
+) -> CuriosityScanReport:
+    """Run ONE proactive scan + GOVERNED emission cycle. Computes domain entropy,
+    allocates a recoverable budget, and emits the sparsest zones as governed
+    exploration ops via ``router.ingest`` — every probe passes the full cage.
+    NEVER raises; inert (emits nothing) when the master flag is off, the budget
+    is zero (overloaded — recoverable), or the router is missing.
+    """
+    if not domain_entropy_engine_enabled():
+        return CuriosityScanReport(
+            master_enabled=False, normalized_entropy=0.0, zones_identified=0,
+            budget=0, emitted=0, ingest_results=(),
+            diagnostic="domain entropy engine disabled",
+        )
+    report = compute_domain_entropy(clusters=clusters, now_unix=now_unix)
+    budget = exploration_budget(load_report=load_report)
+    envelopes = build_exploration_envelopes(report, budget, repo=repo)
+    results: List[str] = []
+    emitted = 0
+    if router is not None:
+        for env in envelopes:
+            try:
+                res = await router.ingest(env)
+                results.append(str(res))
+                if str(res) in ("enqueued", "pending_ack"):
+                    emitted += 1
+            except Exception as exc:  # noqa: BLE001 — one bad ingest never aborts the scan
+                logger.debug("[DomainEntropy] ingest failed: %s", exc)
+                results.append("error")
+    diag = (
+        f"entropy_norm={report.normalized_entropy:.3f} "
+        f"zones={len(report.sparse_zones)} budget={budget} emitted={emitted}"
+    )
+    if emitted > 0:
+        logger.info("[DomainEntropy] proactive scan — %s", diag)
+    return CuriosityScanReport(
+        master_enabled=True,
+        normalized_entropy=report.normalized_entropy,
+        zones_identified=len(report.sparse_zones),
+        budget=budget,
+        emitted=emitted,
+        ingest_results=tuple(results),
+        diagnostic=diag,
+    )

--- a/backend/core/ouroboros/governance/intake/sensors/proactive_exploration_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/proactive_exploration_sensor.py
@@ -240,7 +240,41 @@ class ProactiveExplorationSensor:
         curiosity_explored = await self._emit_curiosity_signals()
         explored.extend(curiosity_explored)
 
+        # Slice 101 Phase 8 — entropy-driven proactive exploration. Fourth
+        # independent signal source: the Dynamic Entropy Engine computes Shannon
+        # entropy over the SemanticIndex domain distribution and schedules
+        # governed exploration of the SPARSEST (least-mapped) zones. The budget
+        # is a recoverable function of cognitive load. Master-gated (default-
+        # FALSE); emits governed low-urgency ops through the SAME router.ingest
+        # cage path — never runs a probe directly. NEVER raises.
+        entropy_explored = await self._emit_entropy_signals()
+        explored.extend(entropy_explored)
+
         return explored
+
+    async def _emit_entropy_signals(self) -> List[str]:
+        """Compose the Dynamic Entropy Engine (Slice 101 Phase 8). Schedules
+        governed exploration of the sparsest semantic domains via the shared
+        ``self._router.ingest`` path — cage-protected, never a direct probe.
+        Inert (returns []) when ``JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED`` is off.
+        NEVER raises.
+        """
+        try:
+            from backend.core.ouroboros.governance.domain_entropy_engine import (
+                domain_entropy_engine_enabled,
+                run_curiosity_scan_once,
+            )
+            if not domain_entropy_engine_enabled():
+                return []
+            report = await run_curiosity_scan_once(
+                router=self._router, repo=self._repo,
+            )
+            return list(report.ingest_results)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[ExplorationSensor] entropy scan error", exc_info=True,
+            )
+            return []
 
     async def _emit_cluster_coverage_signals(self) -> List[str]:
         """Emit IntentEnvelopes for under-touched semantic clusters.

--- a/tests/architecture/test_slice101_curiosity_engine.py
+++ b/tests/architecture/test_slice101_curiosity_engine.py
@@ -1,0 +1,156 @@
+"""Slice 101 Phase 8 — the Dynamic Entropy Engine (compositional curiosity).
+
+Proves the proactive loop: the engine computes Shannon entropy over the semantic-
+index domain distribution, identifies the sparsest (least-explored) zone, allocates
+a recoverable compute budget that shrinks under load, and emits the zone as a
+GOVERNED low-urgency exploration op — never executing a probe directly, so the
+Antivenom cage is preserved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from backend.core.ouroboros.governance import domain_entropy_engine as DEE
+
+
+def _load(verdict: str):
+    return SimpleNamespace(verdict=SimpleNamespace(value=verdict))
+
+
+class _FakeRouter:
+    """Records every governed envelope handed to ingest(). This is the ONLY
+    side-effect channel the engine has — proving it never runs a probe itself."""
+
+    def __init__(self):
+        self.ingested = []
+
+    async def ingest(self, envelope):
+        self.ingested.append(envelope)
+        return "enqueued"
+
+
+# === Mathematical certainty: Shannon entropy over the domain distribution ===
+
+def test_shannon_entropy_is_mathematically_exact(monkeypatch):
+    monkeypatch.setenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", "1")
+    # sizes [2, 50, 48] → P=[0.02, 0.50, 0.48]
+    # H = -(0.02·log2 0.02 + 0.50·log2 0.50 + 0.48·log2 0.48) = 1.121146 bits
+    clusters = [
+        {"cluster_id": "auth", "kind": "goal", "size": 2},
+        {"cluster_id": "core", "kind": "git_commit", "size": 50},
+        {"cluster_id": "vision", "kind": "conversation", "size": 48},
+    ]
+    report = DEE.compute_domain_entropy(clusters=clusters)
+    assert report.cluster_count == 3
+    assert report.total_samples == 100
+    assert abs(report.total_entropy_bits - 1.121146) < 1e-4
+    # max = log2(3) = 1.584962 → normalized = 0.707366
+    assert abs(report.normalized_entropy - 0.707366) < 1e-4
+
+
+# === The knowledge gap: the sparsest domain is identified first =============
+
+def test_sparse_domain_identified(monkeypatch):
+    monkeypatch.setenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", "1")
+    clusters = [
+        {"cluster_id": "well_known", "kind": "git_commit", "size": 80},
+        {"cluster_id": "uncharted", "kind": "goal", "size": 1},   # the gap
+        {"cluster_id": "moderate", "kind": "conversation", "size": 19},
+    ]
+    report = DEE.compute_domain_entropy(clusters=clusters)
+    # Sparsest (fewest samples) ranked first.
+    assert report.sparse_zones[0].cluster_id == "uncharted"
+    assert report.sparse_zones[0].size == 1
+    # Highest sparsity score (1 - 1/80 ≈ 0.9875).
+    assert report.sparse_zones[0].sparsity_score > 0.95
+
+
+def test_engine_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", raising=False)
+    report = DEE.compute_domain_entropy(clusters=[{"cluster_id": "x", "size": 5}])
+    assert report.master_enabled is False
+    assert report.sparse_zones == ()
+
+
+def test_empty_index_is_safe(monkeypatch):
+    monkeypatch.setenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", "1")
+    report = DEE.compute_domain_entropy(clusters=[])
+    assert report.total_samples == 0
+    assert report.sparse_zones == ()
+
+
+# === Recoverable budget: shrinks under load, recovers automatically =========
+
+def test_budget_is_recoverable_function_of_load(monkeypatch):
+    monkeypatch.setenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", "1")
+    monkeypatch.delenv("JARVIS_DOMAIN_ENTROPY_BASE_BUDGET", raising=False)  # default 3
+    assert DEE.exploration_budget(load_report=_load("normal")) == 3
+    assert DEE.exploration_budget(load_report=_load("elevated")) == 1   # 3 // 2
+    assert DEE.exploration_budget(load_report=_load("overloaded")) == 0
+    # Recovery is automatic (pure function of CURRENT load — no latch):
+    assert DEE.exploration_budget(load_report=_load("normal")) == 3
+
+
+# === The cage invariant: probes are GOVERNED ops, never direct execution ====
+
+def test_scan_emits_only_governed_envelopes(monkeypatch):
+    monkeypatch.setenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", "1")
+    clusters = [
+        {"cluster_id": "big", "kind": "git_commit", "size": 90},
+        {"cluster_id": "gap_a", "kind": "goal", "size": 2},
+        {"cluster_id": "gap_b", "kind": "conversation", "size": 8},
+    ]
+    router = _FakeRouter()
+    report = asyncio.run(DEE.run_curiosity_scan_once(
+        router=router, clusters=clusters, load_report=_load("normal"),
+    ))
+    assert report.emitted >= 1
+    # Every emission is a GOVERNED, cage-eligible envelope — NOT a direct probe.
+    for env in router.ingested:
+        assert env.source == "exploration"
+        assert env.urgency == "low"          # sheddable → cognitive-shed can throttle
+        assert env.requires_human_ack is False
+    # The sparsest zone was scheduled for exploration.
+    descs = " ".join(e.description for e in router.ingested)
+    assert "gap_a" in descs
+
+
+def test_overload_throttles_to_zero_emission(monkeypatch):
+    monkeypatch.setenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", "1")
+    clusters = [
+        {"cluster_id": "big", "kind": "git_commit", "size": 90},
+        {"cluster_id": "gap", "kind": "goal", "size": 2},
+    ]
+    router = _FakeRouter()
+    report = asyncio.run(DEE.run_curiosity_scan_once(
+        router=router, clusters=clusters, load_report=_load("overloaded"),
+    ))
+    assert report.budget == 0
+    assert report.emitted == 0
+    assert router.ingested == []   # recoverably throttled — nothing scheduled
+
+
+def test_scan_inert_when_master_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", raising=False)
+    router = _FakeRouter()
+    report = asyncio.run(DEE.run_curiosity_scan_once(
+        router=router, clusters=[{"cluster_id": "x", "size": 5}],
+        load_report=_load("normal"),
+    ))
+    assert report.master_enabled is False
+    assert report.emitted == 0
+    assert router.ingested == []
+
+
+def test_build_envelopes_pure_no_router_needed(monkeypatch):
+    monkeypatch.setenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", "1")
+    report = DEE.compute_domain_entropy(clusters=[
+        {"cluster_id": "a", "kind": "goal", "size": 3},
+        {"cluster_id": "b", "kind": "git_commit", "size": 60},
+    ])
+    envs = DEE.build_exploration_envelopes(report, budget=1)
+    assert len(envs) == 1
+    assert envs[0].source == "exploration"
+    assert envs[0].urgency == "low"


### PR DESCRIPTION
## Slice 101 Phase 8 — the proactive intelligence

The defensive substrates are locked; this awakens the **proactive** side. O+V mathematically scans its own semantic map for the architectural zones it knows *least* about and proactively schedules **governed** exploration there.

### The math (no random-walk, no 'explore' flag)
`domain_entropy_engine.compute_domain_entropy` computes Shannon entropy `H(X) = -Σ P(x) log2 P(x)` over the `semantic_index` cluster size-distribution (`P = size / Σsize`). **Sparse clusters (few samples) = least-explored zones = highest-value curiosity targets.** Ranked ascending by size.

### The cage invariant (load-bearing)
Curiosity chooses **where** to look; it **never runs a probe directly**. Each identified zone becomes a **governed `IntentEnvelope`** (`source=exploration`, `urgency=low`) routed through `router.ingest` — so every proactive probe passes the full First-Order cage (Iron Gate, SemanticGuardian, rehearsal floor, worktree isolation, risk tiers), exactly like any other op. Bypassing the cage for curiosity would unravel Phases 1–7. *(The TDD proves this: the scan's only side-effect channel is a fake router; it never executes anything.)*

### Recoverable budget + automatic close-loop (zero new wiring)
- `exploration_budget()` is a **pure, recoverable** function of the `cognitive_load_shedding` verdict — NORMAL→full, ELEVATED→halved, OVERLOADED→**0**. No latch: when load recovers, curiosity recovers (the Slice-98 invariant). The intake's Phase-4 cognitive-shed gate is a second backstop (these ops are `urgency=low` = sheddable).
- A governed exploration op completes → `post_apply`/`post_failure` → Phase-3 belief subscriber → Phase-6 sleep consolidation. Mapping new territory **permanently updates the Synthetic Soul, for free.**

### Wiring
Added as a 4th signal source on `ProactiveExplorationSensor` (`_emit_entropy_signals`), composing the existing `self._router.ingest` path — no parallel sensor.

### Verify-first (no duplication)
- `curiosity_gradient` → per-generation logprob/prophecy/recurrence entropy (different).
- `curiosity_engine.shannon_entropy_bits` → text-token entropy (different input).
- `compositional_curiosity` → maturity-novelty pairs (different signal).
- Domain entropy is a distinct counts-distribution over codebase domains. Master `JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED` §33.1 default-FALSE.

### TDD — `tests/architecture/test_slice101_curiosity_engine.py` (9 tests)
- **Mathematical certainty:** hand-computed `H = 1.121146 b` for sizes `[2,50,48]`, normalized `0.707366`.
- Sparsest domain identified first; recoverable budget (NORMAL→3, ELEVATED→1, OVERLOADED→0, recovers); **cage proof** (only governed envelopes, never direct execution); overload→zero emission; master-off inert.
- **77 regression green** (compositional_curiosity + proactive sensor + the new suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Dynamic Entropy Engine that finds the least-known semantic domains using Shannon entropy and schedules governed exploration via the existing intake path. Integrates with the proactive sensor and uses a load-aware, recoverable budget so curiosity backs off under load and auto-recovers.

- **New Features**
  - New `domain_entropy_engine.py`: computes domain entropy, ranks sparse zones, and builds low-urgency `IntentEnvelope`s (`source=exploration`) for `router.ingest`.
  - Budget via `exploration_budget()`: NORMAL → base, ELEVATED → base/2, OVERLOADED → 0; tunables `JARVIS_DOMAIN_ENTROPY_BASE_BUDGET` and `JARVIS_DOMAIN_ENTROPY_MAX_ZONES`.
  - Master gate `JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED` (default false); inert when off.
  - Integrated as `_emit_entropy_signals` in `ProactiveExplorationSensor`; never runs probes directly.

- **Migration**
  - Off by default. Set `JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED=1` to enable.
  - Optional tuning: `JARVIS_DOMAIN_ENTROPY_BASE_BUDGET`, `JARVIS_DOMAIN_ENTROPY_MAX_ZONES`.

<sup>Written for commit 3940d854207cf1b2fe340b53bd19817d20c2fe1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

