### PR TITLE
Slice 110 hotfix — mount observability gateway at module level

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5973,6 +5973,22 @@ except ImportError as e:
 except Exception as e:
     logger.warning(f"⚠️  Failed to mount Trinity Health API: {e}")
 
+# ═══════════════════════════════════════════════════════════════
+# Slice 110 — Native Command Center: Observability API Gateway
+# Mounted at MODULE LEVEL (not inside mount_routers()) so the gateway is live
+# under BOTH the standalone `python3 backend/main.py` boot AND the full
+# supervisor boot — mount_routers() is not invoked on the standalone path, so
+# the gateway (and the bus→WS bridge it feeds) must register at import like the
+# Trinity/Voice-Unlock module-level routers above. Read-only over the web for
+# everything authority-bearing (§1 sovereignty, fail-closed).
+# ═══════════════════════════════════════════════════════════════
+try:
+    from api.observability_gateway import build_router as _build_obs_router
+    app.include_router(_build_obs_router())
+    logger.info("✅ Observability Command-Center gateway mounted at /api/observability")
+except Exception as e:  # noqa: BLE001
+    logger.warning(f"⚠️  Observability gateway not available: {e}")
+
 
 # =============================================================================
 # Lightweight Health Check Endpoints (Non-blocking)
@@ -8161,17 +8177,10 @@ def mount_routers():
     except ImportError as e:
         logger.warning(f"⚠️ Broadcast API not available: {e}")
 
-    # Slice 110 — Native Command Center: Observability API Gateway. Composing
-    # bridge (NOT a parallel server) that exposes the internal TrinityEventBus /
-    # Slice-109 Why-Snapshots over typed WebSockets + REST for the React command
-    # center. Read-only over the web for everything authority-bearing; the bus→WS
-    # bridge self-subscribes at GLS boot. Mounts onto THIS app.
-    try:
-        from api.observability_gateway import build_router as _build_obs_router
-        app.include_router(_build_obs_router())
-        logger.info("✅ Observability Command-Center gateway mounted at /api/observability")
-    except Exception as e:  # noqa: BLE001
-        logger.warning(f"⚠️ Observability gateway not available: {e}")
+    # NOTE (Slice 110): the Observability Command-Center gateway is mounted at
+    # MODULE LEVEL (near the Trinity Health mount), NOT here — mount_routers()
+    # is not invoked on the standalone `python3 backend/main.py` boot, so a
+    # module-level mount guarantees the gateway is live under every entrypoint.
 
     # Context Intelligence API (router already has /context prefix)
     context = components.get("context", {})


### PR DESCRIPTION
Live ignition bound :8000/:3000 but /api/observability/* (and the pre-existing /api/broadcast/*) returned 404 — mount_routers() is not invoked under the standalone `python3 backend/main.py` boot. Fix: mount the gateway at module level (beside Trinity Health), drop the redundant mount_routers() include. No gateway-logic / authority-invariant change. 18 tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the Observability Command-Center gateway at module level so /api/observability works under both the standalone `python3 backend/main.py` boot and the supervisor boot. Resolves the Slice 110 requirement that the gateway is always available.

- **Bug Fixes**
  - Register `api.observability_gateway` at module import so routes are live for all entrypoints.
  - Remove the gateway include from `mount_routers()` to avoid double-mounts; no logic or authority model changes.

<sup>Written for commit 1cbbf9470e77d12838a7c0421935ddc94f5ea4a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

