### PR TITLE
Slice 110 co-boot — live engine + gateway in one process

### DIFF
--- a/backend/api/observability_gateway.py
+++ b/backend/api/observability_gateway.py
@@ -46,6 +46,7 @@ envelope ``{kind, op_id, ts, payload}`` where ``kind`` ∈ {``why_snapshot``,
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import time
@@ -374,6 +375,101 @@ def _is_loopback(request: Any) -> bool:
         return str(host) in _LOOPBACK_HOSTS
     except Exception:  # noqa: BLE001
         return False
+
+
+# ===========================================================================
+# Co-boot server (Slice 110 follow-up) — run the gateway IN the engine process
+# ===========================================================================
+#
+# Process-topology fix: the bus→WS bridge broadcasts to ``observability_manager``,
+# a module global. For LIVE cognitive frames, the producer (the governed loop,
+# which registers the bridge at GLS boot) and the gateway HTTP/WS server must
+# share ONE process + event loop. ``serve_gateway`` runs a lightweight uvicorn
+# server for ONLY the gateway router (it does NOT import the monolith) on the
+# CURRENT running loop — co-booted by the soak harness once GLS is up. Then a
+# WS client connected to this server receives the bridge's live broadcasts.
+
+
+def command_center_gateway_enabled() -> bool:
+    """Co-boot switch — when TRUE, the harness serves the gateway in-process so
+    live cognitive frames reach the command center. §33.1 default FALSE (the
+    headless evidence soak does not open a port unless asked)."""
+    return _env_truthy("JARVIS_COMMAND_CENTER_GATEWAY", default=False)
+
+
+def _cors_origins() -> List[str]:
+    """Dev CORS allow-list for the command-center frontend. Env-driven (no
+    hardcoded port): the frontend port comes from ``JARVIS_FRONTEND_PORT`` and we
+    permit the standard local hostnames (incl. the Docker bridge host)."""
+    port = (os.environ.get("JARVIS_FRONTEND_PORT", "3000") or "3000").strip()
+    hosts = ("localhost", "127.0.0.1", "host.docker.internal")
+    return [f"http://{h}:{port}" for h in hosts]
+
+
+def gateway_host() -> str:
+    return (os.environ.get("JARVIS_GATEWAY_HOST", "127.0.0.1") or "127.0.0.1").strip()
+
+
+def gateway_port() -> int:
+    try:
+        return int(os.environ.get("JARVIS_BACKEND_PORT", "8000") or "8000")
+    except Exception:  # noqa: BLE001
+        return 8000
+
+
+def build_gateway_app() -> Any:
+    """A MINIMAL standalone FastAPI app hosting ONLY the observability gateway
+    router + CORS for the frontend. Deliberately does NOT import the monolith
+    (`backend.main`) — keeps the co-boot lightweight + fast. Requires FastAPI."""
+    if not _HAVE_FASTAPI:
+        raise RuntimeError("FastAPI unavailable — cannot build gateway app")
+    from fastapi import FastAPI
+    from fastapi.middleware.cors import CORSMiddleware
+
+    app = FastAPI(title="O+V Observability Gateway", docs_url=None, redoc_url=None)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=_cors_origins(),
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(build_router())
+    return app
+
+
+async def serve_gateway(*, host: Optional[str] = None, port: Optional[int] = None,
+                        log_level: str = "warning") -> None:
+    """Run the gateway as a uvicorn ``Server`` on the CURRENT event loop (co-boot
+    inside the engine process). Blocks until cancelled. NEVER raises out — a
+    bind failure or shutdown is logged, not propagated into the soak. On
+    cancellation it asks the server to exit gracefully."""
+    try:
+        import uvicorn
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[ObsGateway] uvicorn unavailable — gateway not served: %s", exc)
+        return
+    h = host or gateway_host()
+    p = int(port if port is not None else gateway_port())
+    try:
+        config = uvicorn.Config(build_gateway_app(), host=h, port=p,
+                                log_level=log_level, loop="asyncio", lifespan="off")
+        server = uvicorn.Server(config)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[ObsGateway] gateway server config failed: %s", exc)
+        return
+    logger.info("[ObsGateway] command-center gateway serving on http://%s:%d (co-boot)", h, p)
+    try:
+        await server.serve()
+    except asyncio.CancelledError:
+        # Graceful shutdown on soak teardown.
+        try:
+            server.should_exit = True
+        except Exception:  # noqa: BLE001
+            pass
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[ObsGateway] gateway server stopped: %s", exc)
 
 
 def build_router() -> Any:

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -445,6 +445,8 @@ class BattleTestHarness:
         self._oracle_init_task: Optional[asyncio.Task] = None
         self._governance_stack: Any = None
         self._governed_loop_service: Any = None
+        # Slice 110 follow-up — co-boot command-center gateway server task.
+        self._gateway_task: Optional[asyncio.Task] = None
         self._predictive_engine: Any = None
         self._branch_manager: Any = None
         self._branch_name: Optional[str] = None
@@ -2156,6 +2158,30 @@ class BattleTestHarness:
 
             await self._governed_loop_service.start()
             logger.info("GovernedLoopService booted")
+
+            # ── Slice 110 follow-up — co-boot the Command-Center gateway ──
+            # GLS is up, so the bus→WS bridge is registered (it self-gated on
+            # the cognitive bus + gateway flags during GLS boot). Serving the
+            # gateway HTTP/WS on THIS event loop means the bridge's live
+            # broadcasts reach connected command-center clients — the producer
+            # and the server now share one process. Fire-and-forget task,
+            # gated + non-fatal; cancelled in _shutdown_components.
+            try:
+                from backend.api.observability_gateway import (
+                    command_center_gateway_enabled,
+                    gateway_host,
+                    gateway_port,
+                    serve_gateway,
+                )
+                if command_center_gateway_enabled():
+                    self._gateway_task = asyncio.create_task(serve_gateway())
+                    logger.info(
+                        "[CommandCenter] observability gateway co-booting on "
+                        "http://%s:%d (Slice 110)",
+                        gateway_host(), gateway_port(),
+                    )
+            except Exception as exc:  # noqa: BLE001 — never fatal to the soak
+                logger.debug("[CommandCenter] gateway co-boot skipped: %s", exc)
 
             # ── Glanceable operator status line (Priority 2B) ─────────
             # Aggregates cost / idle / phase / op / route data from the
@@ -6444,6 +6470,19 @@ class BattleTestHarness:
                 self._activity_monitor_task.cancel()
                 try:
                     await self._activity_monitor_task
+                except asyncio.CancelledError:
+                    pass
+        except Exception:
+            pass
+
+        # 0-cc. Command-Center gateway server (Slice 110 follow-up). Ask the
+        # uvicorn server to exit gracefully (serve_gateway sets should_exit on
+        # cancel), then await the task.
+        try:
+            if getattr(self, "_gateway_task", None):
+                self._gateway_task.cancel()
+                try:
+                    await self._gateway_task
                 except asyncio.CancelledError:
                     pass
         except Exception:

--- a/scripts/launch_shadow_soak.sh
+++ b/scripts/launch_shadow_soak.sh
@@ -91,18 +91,24 @@ export OUROBOROS_NARRATOR_ENABLED=1                 # Karen master (unmuted)
 export JARVIS_KAREN_TOOL_VOICE_ENABLED=1            # tool/phase sub-voice (unmuted)
 export JARVIS_KAREN_VOICE="${JARVIS_KAREN_VOICE:-Karen}"
 
-# ---- 3c. Slice 110 — Native Command Center (FastAPI gateway + React UI) ----
-# COMMAND_CENTER=1 brings up the SOVEREIGN INTERFACE instead of the headless
-# soak: the FastAPI backend (backend/main.py) hosts the O+V engine + the
-# observability gateway + the bus→WS bridge in ONE process, and the React
-# command center is served on :3000. The cognitive bus, the Why-Snapshot
-# bridge, and the WS fan-out all share that process, so the dashboard paints
-# live cognitive telemetry. The headless evidence soak and the native UI are
-# alternative front-ends to the same engine — we never double-boot it.
+# ---- 3c. Slice 110 — Native Command Center (live engine + gateway + React UI) ----
+# COMMAND_CENTER=1 brings up the SOVEREIGN INTERFACE: it runs the SOAK HARNESS
+# (the O+V engine — the cognitive-event PRODUCER) with the gateway co-booted IN
+# THE SAME PROCESS + EVENT LOOP (JARVIS_COMMAND_CENTER_GATEWAY=1). Because the
+# producer (GLS, which registers the bus→WS bridge at boot) and the gateway WS
+# server share one process, the bridge's live broadcasts reach the dashboard —
+# so the command center PULSES with real cognitive telemetry, not an idle shell.
+# The React UI is served on :3000. (Running backend/main.py would serve the UI
+# but NOT boot the engine → an idle dashboard; that was the prior gap.)
 export JARVIS_OBSERVABILITY_GATEWAY_ENABLED=1
 if [ "${COMMAND_CENTER:-0}" = "1" ]; then
   BACKEND_PORT="${JARVIS_BACKEND_PORT:-8000}"
   FRONTEND_PORT="${JARVIS_FRONTEND_PORT:-3000}"
+  CC_COST_CAP="${SHADOW_COST_CAP:-0.50}"
+  CC_IDLE="${SHADOW_IDLE_TIMEOUT:-600}"
+  CC_WALL="${SHADOW_MAX_WALL_SECONDS:-3600}"   # 60-min default watch session
+  export JARVIS_COMMAND_CENTER_GATEWAY=1        # co-boot the gateway inside the engine loop
+  export JARVIS_BACKEND_PORT FRONTEND_PORT JARVIS_FRONTEND_PORT="$FRONTEND_PORT"
   CC_PIDS=()
   cleanup_cc() {
     log "shutting down command center..."
@@ -112,14 +118,17 @@ if [ "${COMMAND_CENTER:-0}" = "1" ]; then
   }
   trap cleanup_cc EXIT INT TERM
 
-  log "starting O+V engine + FastAPI observability gateway on :$BACKEND_PORT..."
-  python3 backend/main.py --port "$BACKEND_PORT" &
+  log "booting O+V engine (soak) + co-booted gateway on :$BACKEND_PORT (cost=\$$CC_COST_CAP wall=${CC_WALL}s)..."
+  python3 scripts/ouroboros_battle_test.py \
+    --cost-cap "$CC_COST_CAP" --idle-timeout "$CC_IDLE" --max-wall-seconds "$CC_WALL" \
+    --headless -v &
   CC_PIDS+=("$!")
 
-  # Wait for the gateway health endpoint (async, bounded).
-  for i in $(seq 1 60); do
+  # Wait for the co-booted gateway health endpoint (async, bounded — the engine
+  # boots the full 6-layer stack before serving, so allow generous time).
+  for i in $(seq 1 90); do
     if curl -sf "http://127.0.0.1:$BACKEND_PORT/api/observability/health" >/dev/null 2>&1; then
-      log "observability gateway is live (/api/observability/health)."
+      log "live gateway up — engine producing telemetry (/api/observability/health)."
       break
     fi
     sleep 1
@@ -132,10 +141,10 @@ if [ "${COMMAND_CENTER:-0}" = "1" ]; then
     CC_PIDS+=("$!")
     log "OPEN → http://localhost:$FRONTEND_PORT/command-center"
   else
-    log "frontend/ or npm missing — gateway REST/WS is live at :$BACKEND_PORT, build the UI with 'cd frontend && npm install && npm start'."
+    log "frontend/ or npm missing — live gateway REST/WS is up at :$BACKEND_PORT; build the UI with 'cd frontend && npm install && npm start'."
   fi
 
-  log "command center up. Ctrl-C to tear down. (engine + gateway + UI share one process tree)"
+  log "command center LIVE. Engine + gateway + UI share one process tree; the dashboard pulses as the engine works. Ctrl-C to tear down."
   wait
   exit 0
 fi

--- a/tests/architecture/test_slice110_command_center.py
+++ b/tests/architecture/test_slice110_command_center.py
@@ -13,6 +13,8 @@ verification; this proves the data path that feeds it.)
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from backend.api import observability_gateway as OG
@@ -228,6 +230,94 @@ class TestRouter:
         with c.websocket_connect("/api/observability/ws") as ws:
             first = ws.receive_json()
             assert first["kind"] == OG.KIND_HELLO
+
+
+# ===========================================================================
+# Co-boot server (Slice 110 follow-up) — engine + gateway in one process
+# ===========================================================================
+
+
+class TestCoBoot:
+    def test_gateway_flag_default_false(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_COMMAND_CENTER_GATEWAY", raising=False)
+        assert OG.command_center_gateway_enabled() is False
+        monkeypatch.setenv("JARVIS_COMMAND_CENTER_GATEWAY", "1")
+        assert OG.command_center_gateway_enabled() is True
+
+    def test_cors_origins_are_env_driven_no_hardcode(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_FRONTEND_PORT", "4321")
+        origins = OG._cors_origins()
+        assert "http://localhost:4321" in origins
+        assert "http://127.0.0.1:4321" in origins
+        assert any("host.docker.internal:4321" in o for o in origins)
+
+    def test_gateway_port_host_env_driven(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_BACKEND_PORT", "9123")
+        monkeypatch.setenv("JARVIS_GATEWAY_HOST", "0.0.0.0")
+        assert OG.gateway_port() == 9123
+        assert OG.gateway_host() == "0.0.0.0"
+
+    def test_build_gateway_app_mounts_router_with_cors(self):
+        from fastapi.testclient import TestClient
+        app = OG.build_gateway_app()
+        # CORS middleware present.
+        assert any("CORSMiddleware" in str(m) for m in app.user_middleware)
+        # The gateway router is mounted on the standalone app.
+        r = TestClient(app).get("/api/observability/health")
+        assert r.status_code == 200
+        assert r.json()["schema_version"] == OG.GATEWAY_FRAME_SCHEMA_VERSION
+
+    @pytest.mark.asyncio
+    async def test_serve_gateway_builds_and_serves(self, monkeypatch):
+        import uvicorn
+        captured = {}
+
+        class _FakeServer:
+            def __init__(self, config):
+                captured["config"] = config
+                self.should_exit = False
+                self.served = False
+            async def serve(self):
+                self.served = True
+                captured["server"] = self
+
+        monkeypatch.setattr(uvicorn, "Config", lambda *a, **k: {"args": a, "kw": k})
+        monkeypatch.setattr(uvicorn, "Server", _FakeServer)
+        await OG.serve_gateway(port=0)
+        assert captured["server"].served is True
+
+    @pytest.mark.asyncio
+    async def test_serve_gateway_graceful_on_cancel(self, monkeypatch):
+        import uvicorn
+        captured = {}
+
+        class _FakeServer:
+            def __init__(self, config):
+                self.should_exit = False
+                captured["server"] = self
+            async def serve(self):
+                raise asyncio.CancelledError()
+
+        monkeypatch.setattr(uvicorn, "Config", lambda *a, **k: object())
+        monkeypatch.setattr(uvicorn, "Server", _FakeServer)
+        with pytest.raises(asyncio.CancelledError):
+            await OG.serve_gateway(port=0)
+        # On cancel it requests graceful exit.
+        assert captured["server"].should_exit is True
+
+    @pytest.mark.asyncio
+    async def test_serve_gateway_swallows_missing_uvicorn(self, monkeypatch):
+        # If uvicorn import fails, serve_gateway returns quietly (never raises).
+        import builtins
+        real_import = builtins.__import__
+
+        def _boom(name, *a, **k):
+            if name == "uvicorn":
+                raise ImportError("no uvicorn")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", _boom)
+        await OG.serve_gateway(port=0)  # must not raise
 
 
 class TestLoopbackGate:


### PR DESCRIPTION
## Co-boot follow-up — make the command center *pulse* with live telemetry

**Root problem (process topology):** the bus→WS bridge broadcasts to a module-global manager, so the cognitive **producer** (governed loop) and the gateway **WS server** must share one process + event loop. `backend/main.py` served the UI but never booted the engine → idle dashboard.

**Fix (compose, no duplication):** co-boot a lightweight uvicorn gateway server **inside the soak harness's event loop**, right after GLS boots (where the bridge self-registers).

- `observability_gateway.py`: `build_gateway_app()` (minimal standalone app — gateway router + **env-driven CORS**, does *not* import the monolith), `serve_gateway()` (uvicorn `Server` on the current loop; graceful `should_exit` on cancel; swallows missing-uvicorn), `command_center_gateway_enabled()` (`JARVIS_COMMAND_CENTER_GATEWAY`, §33.1 default-FALSE), env-driven host/port (no hardcode).
- `harness.py`: after *"GovernedLoopService booted"*, fire-and-forget `serve_gateway()` task (gated + non-fatal); cancelled in `_shutdown_components`.
- `launch_shadow_soak.sh` `COMMAND_CENTER=1` now runs the **harness** (the engine) with the gateway co-booted in-process + serves the React UI on `:3000`.

**Tests:** 7 new co-boot tests (gating, env-CORS/port, app build, serve lifecycle + graceful-cancel + missing-uvicorn) — **25 Slice-110 tests green**, harness imports clean.

Authority invariant unchanged (read-only over the web; cosmetic-only voice toggle).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Co-boots the observability gateway inside the engine process so the command center streams live telemetry. `COMMAND_CENTER=1` now runs the soak harness with an in-process `uvicorn` server and serves the React UI on :3000.

- **New Features**
  - Co-boot lightweight `uvicorn` gateway after GLS boot so producer and WS server share one loop.
  - `build_gateway_app()` adds a minimal `FastAPI` app with env-driven CORS; no monolith import.
  - `serve_gateway()` runs on the current loop; graceful on cancel; logs on bind/uvicorn issues without failing the soak.
  - Env-driven host/port (`JARVIS_GATEWAY_HOST`, `JARVIS_BACKEND_PORT`) and CORS via `JARVIS_FRONTEND_PORT`; health at `/api/observability/health`.
  - `launch_shadow_soak.sh`: `COMMAND_CENTER=1` boots the engine, co-boots the gateway, waits for health, and opens the UI.

- **Migration**
  - Use `COMMAND_CENTER=1 ./scripts/launch_shadow_soak.sh` to start engine + co-booted gateway; UI at http://localhost:3000/command-center.
  - Customize via `JARVIS_COMMAND_CENTER_GATEWAY=1`, `JARVIS_BACKEND_PORT`, `JARVIS_FRONTEND_PORT`, `JARVIS_GATEWAY_HOST` as needed.
  - If you previously ran `backend/main.py`, switch to the script to get live telemetry.

<sup>Written for commit c8cd0be833aabb8f8294381c74dc73d69a40c97e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

