### PR TITLE
Slice 111 — Core Optimization & Tech-Debt Eradication

### DIFF
--- a/backend/core/ouroboros/governance/flag_registry.py
+++ b/backend/core/ouroboros/governance/flag_registry.py
@@ -266,16 +266,31 @@ class FlagRegistry:
 
     def register(
         self,
-        spec: FlagSpec,
+        spec: Optional[FlagSpec] = None,
         *,
         override: bool = True,
+        **legacy: Any,
     ) -> None:
         """Install a FlagSpec. ``override=True`` silently replaces an
         existing entry (with a DEBUG log) so seed files can be re-run
-        during tests. ``override=False`` raises if name already exists."""
+        during tests. ``override=False`` raises if name already exists.
+
+        Backward-compatible call conventions (Slice 111): the canonical
+        form is ``register(FlagSpec(...))``. The legacy seed convention —
+        used by 1000+ ``register_flags()`` sites across 150+ modules —
+        passes flat kwargs ``register(name=, type_=, default=,
+        description=, category=, source_file=, example=,
+        posture_relevance=)``. When ``spec`` is omitted and kwargs are
+        present, we normalize them into a proper ``FlagSpec`` via
+        :meth:`_spec_from_legacy` (string→enum mapping, never raising).
+        This single API-boundary adapter reconciles both conventions —
+        no per-caller migration, no latent debt, zero boot tracebacks."""
+        if spec is None and legacy:
+            spec = self._spec_from_legacy(legacy)
         if not isinstance(spec, FlagSpec):
             raise TypeError(
-                f"register expects FlagSpec, got {type(spec).__name__}"
+                f"register expects FlagSpec (or legacy kwargs), got "
+                f"{type(spec).__name__}"
             )
         with self._lock:
             if spec.name in self._specs and not override:
@@ -289,6 +304,51 @@ class FlagRegistry:
                     spec.name,
                 )
             self._specs[spec.name] = spec
+
+    @staticmethod
+    def _spec_from_legacy(kw: Mapping[str, Any]) -> "FlagSpec":
+        """Normalize a legacy ``register(name=, type_=, ...)`` kwargs dict into
+        a canonical :class:`FlagSpec`. Tolerant by construction — unknown
+        type/category strings degrade to safe defaults rather than raising, so
+        a malformed seed can never abort boot. String→enum mapping:
+
+        * ``type_`` / ``type`` (``"bool"``/``"int"``/...) → :class:`FlagType`
+        * ``category`` (``"Observability"`` etc., case-insensitive) → :class:`Category`
+        * ``posture_relevance`` — legacy passed a bare string (e.g. ``"RELEVANT"``)
+          which does NOT map to the new ``Mapping[str, Relevance]`` shape, so it
+          is dropped unless a real mapping is supplied (advisory field only)."""
+        name = str(kw.get("name", "") or "").strip()
+
+        raw_type = str(kw.get("type_") or kw.get("type") or "str").strip().lower()
+        try:
+            ftype = FlagType(raw_type)
+        except Exception:  # noqa: BLE001
+            ftype = FlagType.STR
+
+        raw_cat = str(kw.get("category") or "experimental").strip().lower()
+        try:
+            cat = Category(raw_cat)
+        except Exception:  # noqa: BLE001
+            cat = Category.EXPERIMENTAL
+
+        pr = kw.get("posture_relevance")
+        posture: Mapping[str, Relevance] = pr if isinstance(pr, Mapping) else {}
+
+        aliases = kw.get("aliases")
+        aliases_t = tuple(aliases) if isinstance(aliases, (list, tuple)) else ()
+
+        return FlagSpec(
+            name=name,
+            type=ftype,
+            default=kw.get("default"),
+            description=str(kw.get("description", "") or ""),
+            category=cat,
+            source_file=str(kw.get("source_file", "") or ""),
+            example=kw.get("example"),
+            since=str(kw.get("since", "v1.0") or "v1.0"),
+            posture_relevance=posture,
+            aliases=aliases_t,
+        )
 
     def bulk_register(self, specs: List[FlagSpec], *, override: bool = True) -> None:
         for s in specs:

--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -69,6 +69,33 @@ from typing import (
     Union,
 )
 
+_ORACLE_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _oracle_threaded_cache_load() -> bool:
+    """Slice 111 — should the (≈1.1 GB) graph-cache ``pickle.loads`` run OFF the
+    event loop (``asyncio.to_thread``)?  The load is synchronous-on-loop by
+    legacy design to avoid concurrent C-extension heap allocation with
+    ChromaDB/torch/numpy → libmalloc corruption on **macOS ARM64** (a hard-won
+    crash fix). But on the loop it blocks boot for the full deserialize (~158 s
+    observed), defeating the deferred-init path. Resolution:
+
+    * Explicit ``JARVIS_ORACLE_CACHE_THREADED_LOAD`` wins (``1``/``0``).
+    * Default **TRUE on non-Darwin** (Linux/GCP — the 12–18 mo deployment
+      target, where the ARM64 libmalloc hazard does not apply) so the engine +
+      gateway boot concurrently while the graph hydrates in a worker thread.
+    * Default **FALSE on Darwin** (the dev box) — keep the safe synchronous
+      path; opt in explicitly to test the threaded load locally.
+
+    NEVER raises."""
+    try:
+        raw = os.environ.get("JARVIS_ORACLE_CACHE_THREADED_LOAD")
+        if raw is not None:
+            return raw.strip().lower() in _ORACLE_TRUTHY
+        return sys.platform != "darwin"
+    except Exception:  # noqa: BLE001
+        return False
+
 try:
     import networkx as nx
     NETWORKX_AVAILABLE = True
@@ -1907,6 +1934,15 @@ class TheOracle:
             # the still-pending semantic index.
             self._readiness.mark_graph_ready()
 
+            # libmalloc-safe ordering invariant (macOS ARM64): the ChromaDB /
+            # torch / embedder backend is initialized ONLY AFTER graph loading
+            # has completed (and its readiness signaled above). Loading the
+            # graph cache and spinning up ChromaDB's C-extension heap
+            # concurrently triggered libmalloc corruption on macOS ARM64 — so
+            # graph load and semantic-backend init must never overlap. Slice 111
+            # preserves this: the threaded graph-cache load stays OFF by default
+            # on Darwin (see _oracle_threaded_cache_load), and semantic init is
+            # still gated behind mark_graph_ready() here.
             # Phase 3 — Slice 10: Construct the OracleSemanticIndex
             # WITHOUT loading ChromaDB. The constructor is now
             # lightweight (config stash only); the actual ChromaDB
@@ -2640,13 +2676,30 @@ class TheOracle:
 
         return sandbox_fallback(OracleConfig.GRAPH_CACHE_FILE)
 
+    @staticmethod
+    def _read_and_unpickle_cache(cache_path: Path) -> Dict[str, Any]:
+        """Read + deserialize the graph cache. Pure blocking work — safe to run
+        either on the loop (Darwin default) or in a worker thread (non-Darwin
+        default, Slice 111) per :func:`_oracle_threaded_cache_load`.
+
+        ``pickle`` is used for the INTERNAL cache only (never untrusted data) —
+        the file is written by this same process in ``_write_cache_blocking``.
+        """
+        raw = cache_path.read_bytes()
+        return pickle.loads(raw)  # noqa: S301 — trusted internal cache
+
     async def _load_cache(self) -> bool:
         """Load cached graph from disk.
 
-        Loads synchronously (not asyncio.to_thread) to prevent concurrent
-        C-extension heap allocation with ChromaDB/torch/numpy.  At boot
-        time nothing else needs the event loop — blocking for 2-5s is
-        acceptable to avoid libmalloc memory corruption on macOS ARM64.
+        The ≈1.1 GB ``pickle.loads`` is the dominant boot cost (~158 s observed).
+        Slice 111: when :func:`_oracle_threaded_cache_load` is true (default on
+        non-Darwin / production Linux) the deserialize runs in a worker thread
+        via ``asyncio.to_thread`` so it does NOT block the event loop — the
+        engine + co-booted gateway boot concurrently while the graph hydrates,
+        finally honoring the deferred-init path. On macOS ARM64 the default
+        stays synchronous-on-loop to avoid concurrent C-extension heap
+        allocation with ChromaDB/torch/numpy (libmalloc corruption — a hard-won
+        crash fix); opt in with JARVIS_ORACLE_CACHE_THREADED_LOAD=1 to test.
 
         Note: pickle is used here for internal cache only (never untrusted
         data) — the cache file is written by this same process.
@@ -2654,9 +2707,12 @@ class TheOracle:
         try:
             cache_path = self._resolved_graph_cache_path()
             if cache_path.exists():
-                _raw = cache_path.read_bytes()
-                data = pickle.loads(_raw)  # noqa: S301 — trusted internal cache
-                del _raw  # free the raw bytes immediately
+                if _oracle_threaded_cache_load():
+                    data = await asyncio.to_thread(
+                        self._read_and_unpickle_cache, cache_path,
+                    )
+                else:
+                    data = self._read_and_unpickle_cache(cache_path)
 
                 self._graph._graph = data["graph"]
                 self._graph._node_index = data["node_index"]

--- a/scripts/launch_shadow_soak.sh
+++ b/scripts/launch_shadow_soak.sh
@@ -106,7 +106,7 @@ if [ "${COMMAND_CENTER:-0}" = "1" ]; then
   FRONTEND_PORT="${JARVIS_FRONTEND_PORT:-3000}"
   CC_COST_CAP="${SHADOW_COST_CAP:-0.50}"
   CC_IDLE="${SHADOW_IDLE_TIMEOUT:-600}"
-  CC_WALL="${SHADOW_MAX_WALL_SECONDS:-3600}"   # 60-min default watch session
+  CC_WALL="${SHADOW_MAX_WALL_SECONDS:-0}"      # 0 = INFINITE (12–18 mo deployment); set SHADOW_MAX_WALL_SECONDS for a bounded watch
   export JARVIS_COMMAND_CENTER_GATEWAY=1        # co-boot the gateway inside the engine loop
   export JARVIS_BACKEND_PORT FRONTEND_PORT JARVIS_FRONTEND_PORT="$FRONTEND_PORT"
   CC_PIDS=()
@@ -150,9 +150,14 @@ if [ "${COMMAND_CENTER:-0}" = "1" ]; then
 fi
 
 # ---- 4. Launch the soak (headless evidence-accrual mode) ----
+# Slice 111: the wall cap defaults to 0 = INFINITE for the true 12–18 month
+# evidence-accrual deployment (the harness treats 0/unset as "no wall cap" —
+# liveness then rests on --idle-timeout + the cost budget). NOTE: this removes
+# the OOM/hang safety ceiling the watchdog provides; set SHADOW_MAX_WALL_SECONDS
+# (e.g. 2400) to restore a bounded soak for graduation runs or CI.
 COST_CAP="${SHADOW_COST_CAP:-0.50}"
 IDLE_TIMEOUT="${SHADOW_IDLE_TIMEOUT:-600}"
-MAX_WALL="${SHADOW_MAX_WALL_SECONDS:-2400}"
+MAX_WALL="${SHADOW_MAX_WALL_SECONDS:-0}"
 
 # SHADOW_INTERACTIVE=1 drops --headless so the operator watches the live Rich
 # TUI (token stream + diff overlays + status line) and the SerpentFlow REPL on

--- a/tests/architecture/test_slice111_core_optimization.py
+++ b/tests/architecture/test_slice111_core_optimization.py
@@ -1,0 +1,135 @@
+"""Slice 111 — Core Optimization & Tech-Debt Eradication.
+
+Two units under test:
+
+1. ``FlagRegistry.register`` backward-compat adapter — the single API-boundary
+   fix that lets the 1000+ legacy ``register(name=, type_=, ...)`` seed sites
+   resolve into proper ``FlagSpec`` objects (string→enum mapping), eliminating
+   the boot tracebacks WITHOUT touching every caller. Canonical
+   ``register(FlagSpec(...))`` must still work; malformed type/category must
+   degrade to safe defaults rather than abort boot.
+
+2. ``oracle._oracle_threaded_cache_load`` gate + ``_read_and_unpickle_cache`` —
+   the platform-aware switch that moves the ~1.1 GB graph ``pickle.loads`` off
+   the event loop (default ON on Linux/prod, OFF on macOS ARM64 for the
+   documented libmalloc-safety reason), so boot no longer blocks ~158 s.
+"""
+
+from __future__ import annotations
+
+import pickle
+import sys
+
+import pytest
+
+from backend.core.ouroboros.governance.flag_registry import (
+    Category,
+    FlagRegistry,
+    FlagSpec,
+    FlagType,
+    Relevance,
+)
+
+
+# ===========================================================================
+# Phase 1 — FlagRegistry legacy adapter
+# ===========================================================================
+
+
+class TestFlagRegistryLegacyAdapter:
+    def test_legacy_kwargs_resolve_to_flagspec(self):
+        r = FlagRegistry()
+        r.register(
+            name="JARVIS_X", type_="bool", default="false", description="d",
+            category="Observability", posture_relevance="RELEVANT",
+            source_file="x.py", example="JARVIS_X=true",
+        )
+        s = r.get_spec("JARVIS_X")
+        assert isinstance(s, FlagSpec)
+        assert s.type is FlagType.BOOL
+        assert s.category is Category.OBSERVABILITY
+        assert s.source_file == "x.py"
+
+    def test_bare_posture_string_is_dropped(self):
+        # Legacy passed a bare "RELEVANT"; the new field is Mapping[str,Relevance].
+        r = FlagRegistry()
+        r.register(name="JARVIS_Y", type_="int", default=1, description="d",
+                   category="timing", posture_relevance="RELEVANT", source_file="y.py")
+        assert dict(r.get_spec("JARVIS_Y").posture_relevance) == {}
+
+    def test_real_mapping_posture_is_kept(self):
+        r = FlagRegistry()
+        r.register(name="JARVIS_Z", type_="bool", default="false", description="d",
+                   category="safety", source_file="z.py",
+                   posture_relevance={"HARDEN": Relevance.CRITICAL})
+        assert r.get_spec("JARVIS_Z").posture_relevance["HARDEN"] is Relevance.CRITICAL
+
+    def test_canonical_flagspec_still_works(self):
+        r = FlagRegistry()
+        r.register(FlagSpec(name="JARVIS_C", type=FlagType.FLOAT, default=1.5,
+                            description="d", category=Category.TUNING, source_file="c.py"))
+        assert r.get_spec("JARVIS_C").type is FlagType.FLOAT
+
+    def test_unknown_type_degrades_to_str(self):
+        r = FlagRegistry()
+        r.register(name="JARVIS_BADT", type_="frobnicate", default="x",
+                   description="d", category="tuning", source_file="b.py")
+        assert r.get_spec("JARVIS_BADT").type is FlagType.STR
+
+    def test_unknown_category_degrades_to_experimental(self):
+        r = FlagRegistry()
+        r.register(name="JARVIS_BADC", type_="bool", default="false",
+                   description="d", category="not_a_category", source_file="b.py")
+        assert r.get_spec("JARVIS_BADC").category is Category.EXPERIMENTAL
+
+    def test_no_args_still_raises(self):
+        r = FlagRegistry()
+        with pytest.raises(TypeError):
+            r.register()
+
+    def test_real_legacy_caller_runs_clean(self):
+        # A real ~10-flag seed module that previously threw on every call.
+        from backend.core.ouroboros.governance import autonomy_command_bus_bridge as B
+        r = FlagRegistry()
+        B.register_flags(r)  # must not raise / must not log a traceback
+        assert r.get_spec("JARVIS_COMMAND_BUS_BRIDGE_ENABLED") is not None
+
+
+# ===========================================================================
+# Phase 2 — Oracle threaded-load gate + cache (de)serialization
+# ===========================================================================
+
+
+class TestOracleThreadedLoadGate:
+    def _gate(self):
+        from backend.core.ouroboros import oracle as O
+        return O._oracle_threaded_cache_load
+
+    def test_explicit_true_wins(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ORACLE_CACHE_THREADED_LOAD", "1")
+        assert self._gate()() is True
+
+    def test_explicit_false_wins_even_on_linux(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ORACLE_CACHE_THREADED_LOAD", "0")
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert self._gate()() is False
+
+    def test_default_threaded_on_linux(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_ORACLE_CACHE_THREADED_LOAD", raising=False)
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert self._gate()() is True
+
+    def test_default_synchronous_on_darwin(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_ORACLE_CACHE_THREADED_LOAD", raising=False)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        assert self._gate()() is False
+
+    def test_read_and_unpickle_roundtrip(self, tmp_path):
+        from backend.core.ouroboros.oracle import TheOracle
+        payload = {"graph": {"n": 1}, "node_index": {}, "file_index": {},
+                   "repo_index": {}, "type_index": {}, "metrics": {"total_nodes": 1}}
+        p = tmp_path / "cache.pkl"
+        p.write_bytes(pickle.dumps(payload))
+        out = TheOracle._read_and_unpickle_cache(p)
+        assert out["graph"] == {"n": 1}
+        assert out["metrics"]["total_nodes"] == 1


### PR DESCRIPTION
## Slice 111 — eradicate FlagRegistry debt + crush Oracle boot latency

**Verify-first overturned both premises:**
- **Phase 1** was not "~10 callers" — **1000+ `register(name=...)` sites across 150+ modules** use the legacy kwarg convention; `register(FlagSpec)` silently broke all of them (the 30 boot tracebacks were the visible subset).
- **Phase 2** was not gather-able — `_load_cache` is a **single ~1.1 GB `pickle.loads`**, synchronous-on-loop *by design* (macOS-ARM64 libmalloc-corruption fix), which defeats the existing deferred-init by blocking the loop ~158 s.

### Phase 1 — one API-boundary adapter (not 1000 edits)
`FlagRegistry.register()` now accepts legacy kwargs and normalizes them into a `FlagSpec` via `_spec_from_legacy` (string→enum for `type_`/`category`, bare posture string dropped, unknown values degrade to safe defaults, never raises). Fixes **all** callers + **every traceback** with one change; canonical `register(FlagSpec)` unchanged.

### Phase 2 — platform-gated threaded cache load
`_oracle_threaded_cache_load()` moves the `pickle.loads` to `asyncio.to_thread` so it no longer blocks the loop — **default ON on non-Darwin** (Linux/GCP deployment target → engine + gateway boot concurrently while the graph hydrates), **default OFF on macOS ARM64** (preserves the libmalloc-safety invariant; opt-in `JARVIS_ORACLE_CACHE_THREADED_LOAD=1`). Restored the pinned `"AFTER graph loading"` ordering comment.

### Phase 3 — infinite soak
`launch_shadow_soak.sh` wall cap default `2400/3600 → 0` (INFINITE) for the 12–18 mo deployment; env-overridable to restore a bounded cap.

### Tests
13 new Slice-111 + 64 `flag_registry` + oracle readiness/cache/deferred suites **green**. Pre-existing (stash-confirmed) `test_ast_pin_save_cache_is_atomic` left untouched — orthogonal SAVE-path stale pin, not Phase-2 scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores compatibility for legacy `FlagRegistry.register(name=...)` calls and cuts Oracle boot time by moving graph cache deserialization off the event loop on non-Darwin. Also sets the soak harness wall cap to 0 (infinite) by default.

- **Bug Fixes**
  - `FlagRegistry.register()` now accepts legacy kwargs and normalizes them into a `FlagSpec` (string→enum, safe defaults), fixing all legacy seed callers without edits.
  - Oracle cache load can run in a worker thread when `_oracle_threaded_cache_load()` is true (default ON on non-Darwin, OFF on macOS ARM64), avoiding event-loop stalls while preserving the macOS libmalloc safety invariant.

- **Migration**
  - No call-site changes needed; override threading via `JARVIS_ORACLE_CACHE_THREADED_LOAD=1|0`.
  - Soak harness: `SHADOW_MAX_WALL_SECONDS` now defaults to `0` (infinite); set a value to restore a bounded cap.

<sup>Written for commit 848c02207d78c4fc870356421d8800aa86c40b5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

