### PR TITLE
Slice 112 — process-isolated Oracle IPC + graph hygiene

### DIFF
--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -860,6 +860,43 @@ class CodebaseKnowledgeGraph:
         if _is_new_node:
             self._metrics["total_nodes"] += 1
 
+    def prune_isolated_nodes(self) -> int:
+        """Slice 112 graph hygiene — drop degree-0 (isolated) nodes: symbols
+        with NO callers and NO callees. They are pure serialization bloat —
+        ``shortest_path`` / ``simple_cycles`` traverse *edges*, so a node with
+        zero edges can never appear in any path or cycle. Removing them shrinks
+        the cache to the minimum required for graph traversal without changing
+        a single traversal result. Keeps every index + the node/edge metrics
+        consistent. Returns the count pruned. NEVER raises."""
+        try:
+            import networkx as nx
+            isolated = list(nx.isolates(self._graph))
+            if not isolated:
+                return 0
+            for node_key in isolated:
+                try:
+                    self._graph.remove_node(node_key)
+                except Exception:  # noqa: BLE001
+                    continue
+                nid = self._node_index.pop(node_key, None)
+                if nid is not None:
+                    self._file_index.get(nid.file_path, set()).discard(node_key)
+                    self._repo_index.get(nid.repo, set()).discard(node_key)
+                    self._type_index.get(nid.node_type, set()).discard(node_key)
+            # Drop now-empty index buckets so they don't re-bloat the pickle.
+            for idx in (self._file_index, self._repo_index, self._type_index):
+                for k in [k for k, v in idx.items() if not v]:
+                    idx.pop(k, None)
+            # Recompute authoritative counts from the live graph.
+            self._metrics["total_nodes"] = self._graph.number_of_nodes()
+            self._metrics["total_edges"] = self._graph.number_of_edges()
+            logger.info("[GraphHygiene] pruned %d isolated node(s) → %d nodes / %d edges",
+                        len(isolated), self._metrics["total_nodes"], self._metrics["total_edges"])
+            return len(isolated)
+        except Exception as exc:  # noqa: BLE001 — hygiene must never break save
+            logger.warning("[GraphHygiene] prune_isolated_nodes failed (non-fatal): %s", exc)
+            return 0
+
     def add_edge(
         self,
         source: NodeID,
@@ -2722,6 +2759,18 @@ class TheOracle:
         ``.ouroboros/state/sandbox_fallback/oracle/`` without lowering
         shields.
         """
+        # Slice 112 graph hygiene (gated, default-OFF): crush serialization
+        # bloat by pruning isolated (degree-0) nodes BEFORE the snapshot. Pure
+        # bloat removal — traversal results (shortest_path / simple_cycles) are
+        # invariant under it. Cheap (O(nodes)); never raises.
+        try:
+            if os.environ.get(
+                "JARVIS_ORACLE_GRAPH_PRUNE_ENABLED", "",
+            ).strip().lower() in ("1", "true", "yes", "on"):
+                self._graph.prune_isolated_nodes()
+        except Exception:  # noqa: BLE001 — hygiene must never break save
+            pass
+
         # Snapshot the data dict on the asyncio thread. These are cheap
         # reference copies — heavy work is the serialization below.
         data = {

--- a/backend/core/ouroboros/oracle_ipc.py
+++ b/backend/core/ouroboros/oracle_ipc.py
@@ -1,0 +1,402 @@
+"""Slice 112 — Process-Isolated Oracle: fault-tolerant async IPC.
+
+The Oracle's graph cache is a ~1.1 GB / 2.5 M-node ``networkx.DiGraph`` whose
+``pickle.loads`` is **GIL-bound** (~166 s). In-process — even via
+``asyncio.to_thread`` — that deserialize freezes the engine's single event loop
+(empirically: 165 s of total loop silence), starving the FSM *and* the co-booted
+God-Tier gateway. ``to_thread`` cannot help (the worker thread holds the GIL).
+
+The structural fix is **process isolation**: the Oracle runs in its OWN OS
+process (its OWN GIL), so the heavy deserialize + the in-RAM networkx graph
+(which `shortest_path`/`simple_cycles` require) never touch the engine loop. The
+engine talks to it through :class:`AsyncOracleProxy` — a small async IPC client
+covering the ~5 methods the engine actually calls (``initialize``,
+``incremental_update``, ``get_metrics``, ``get_context_for_improvement``,
+``shutdown``).
+
+Resilience invariant (operator-bound): if the Oracle subprocess dies (OOM kill,
+segfault, anything), the proxy catches the severed connection, narrates a
+high-severity ``OracleCrash`` event, fails in-flight calls cleanly, and
+autonomously respawns the process (bounded backoff) — **without ever crashing
+the GovernedLoopService**. While the Oracle is hydrating (or crashed/respawning)
+the proxy returns a structured :class:`OracleNotReady` so the engine + UI keep
+running and degrade gracefully (compose :class:`OracleReadiness` semantics).
+
+Master ``JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED`` — §33.1 default-FALSE. When
+off, the engine uses the in-process Oracle exactly as before (byte-identical).
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Tuple
+
+# asyncio imported lazily inside coroutines so the module imports cleanly in any
+# context (the child worker creates its own loop).
+import asyncio
+
+logger = logging.getLogger("ouroboros.oracle_ipc")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+_ENV_MASTER = "JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED"
+_ENV_MAX_RESPAWNS = "JARVIS_ORACLE_MAX_RESPAWNS"
+_ENV_RESPAWN_BACKOFF_S = "JARVIS_ORACLE_RESPAWN_BACKOFF_S"
+
+# The exact, audited engine-facing surface (verify-first: these are the only
+# Oracle methods orchestrator/GLS call). Anything else is rejected by the worker.
+_ALLOWED_METHODS = frozenset({
+    "incremental_update",
+    "get_metrics",
+    "get_context_for_improvement",
+})
+
+
+def process_isolation_enabled() -> bool:
+    """§33.1 master — default FALSE. NEVER raises."""
+    try:
+        raw = os.environ.get(_ENV_MASTER)
+        return bool(raw) and raw.strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except Exception:  # noqa: BLE001
+        return default
+
+
+# ===========================================================================
+# Structured states
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class OracleNotReady:
+    """Structured sentinel returned by the proxy when the isolated Oracle cannot
+    serve a query yet: hydrating its graph, init-failed, or crashed/respawning.
+    Callers test ``isinstance(result, OracleNotReady)`` and degrade gracefully
+    (run context-free tasks) instead of blocking or crashing."""
+
+    reason: str = "hydrating"      # hydrating | init_failed | respawning | exhausted
+    elapsed_s: float = 0.0
+    respawns: int = 0
+
+
+class OracleRemoteError(RuntimeError):
+    """Raised in the engine when the isolated Oracle handled a call but the
+    method itself raised. The remote traceback string is preserved."""
+
+
+class OracleCrash:
+    """High-severity marker for a severed Oracle subprocess (narrated)."""
+
+    KIND = "oracle.crash"
+
+
+# ===========================================================================
+# Child worker — runs INSIDE the isolated process (own GIL)
+# ===========================================================================
+
+
+def _oracle_worker_main(conn: Any) -> None:
+    """Top-level (spawn-picklable) child entrypoint. Builds + initializes a
+    TheOracle in THIS process (the 1.1 GB load happens here, never on the engine
+    loop), signals readiness, then serves requests until shutdown/EOF. NEVER
+    lets an exception escape uncaught — a dying worker closes the pipe, which the
+    parent proxy detects as a crash."""
+    try:
+        asyncio.run(_oracle_worker_async(conn))
+    except Exception as exc:  # noqa: BLE001 — last-resort; pipe close signals parent
+        try:
+            conn.send({"control": "init_failed", "error": repr(exc)})
+        except Exception:  # noqa: BLE001
+            pass
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+async def _oracle_worker_async(conn: Any) -> None:
+    from backend.core.ouroboros.oracle import TheOracle
+
+    oracle = TheOracle()
+    loop = asyncio.get_running_loop()
+    try:
+        await oracle.initialize()
+    except Exception as exc:  # noqa: BLE001
+        conn.send({"control": "init_failed", "error": repr(exc)})
+        return
+    conn.send({"control": "ready"})
+
+    while True:
+        try:
+            msg = await loop.run_in_executor(None, conn.recv)
+        except (EOFError, OSError):
+            break  # parent closed the pipe → exit
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("control") == "shutdown":
+            try:
+                await oracle.shutdown()
+            except Exception:  # noqa: BLE001
+                pass
+            break
+        rid = msg.get("id")
+        method = str(msg.get("method", ""))
+        if method not in _ALLOWED_METHODS:
+            conn.send({"id": rid, "ok": False, "error": f"method not allowed: {method}"})
+            continue
+        try:
+            fn = getattr(oracle, method)
+            res = fn(*msg.get("args", []), **msg.get("kwargs", {}))
+            if asyncio.iscoroutine(res):
+                res = await res
+            conn.send({"id": rid, "ok": True, "result": res})
+        except Exception as exc:  # noqa: BLE001 — per-call failure, not fatal
+            conn.send({"id": rid, "ok": False, "error": repr(exc)})
+
+
+# ===========================================================================
+# Default spawn (real subprocess) — injectable for tests
+# ===========================================================================
+
+
+def _default_spawn() -> Tuple[Any, Any]:
+    """Spawn the Oracle worker in a fresh process (spawn context — safe on macOS
+    + clean GIL). Returns (parent_conn, process). NEVER raises into the caller's
+    happy path beyond what Process.start would."""
+    ctx = multiprocessing.get_context("spawn")
+    parent_conn, child_conn = ctx.Pipe(duplex=True)
+    proc = ctx.Process(target=_oracle_worker_main, args=(child_conn,), daemon=True)
+    proc.start()
+    # The parent holds its own copy of the child end open until start(); close it
+    # now so an EOF propagates correctly when the child dies.
+    try:
+        child_conn.close()
+    except Exception:  # noqa: BLE001
+        pass
+    return parent_conn, proc
+
+
+# ===========================================================================
+# AsyncOracleProxy — engine-side client (fault-tolerant)
+# ===========================================================================
+
+
+class AsyncOracleProxy:
+    """Async, crash-tolerant proxy to the process-isolated Oracle.
+
+    ``spawn_fn`` returns ``(connection, process)`` — injected in tests with a
+    controllable fake so crash/respawn paths are deterministic without a real
+    1.1 GB subprocess. ``narrator`` (optional) receives ``OracleCrash`` events
+    (e.g. a DaemonNarrator) — best-effort, never fatal."""
+
+    def __init__(
+        self,
+        *,
+        spawn_fn: Optional[Callable[[], Tuple[Any, Any]]] = None,
+        narrator: Any = None,
+        max_respawns: Optional[int] = None,
+        respawn_backoff_s: Optional[float] = None,
+    ) -> None:
+        self._spawn_fn = spawn_fn or _default_spawn
+        self._narrator = narrator
+        self._max_respawns = max_respawns if max_respawns is not None else _env_int(_ENV_MAX_RESPAWNS, 3)
+        self._backoff = respawn_backoff_s if respawn_backoff_s is not None else _env_float(_ENV_RESPAWN_BACKOFF_S, 2.0)
+
+        self._conn: Any = None
+        self._proc: Any = None
+        self._reader_task: Optional["asyncio.Task"] = None
+        self._pending: Dict[int, "asyncio.Future"] = {}
+        self._next_id = 0
+        self._ready = False
+        self._init_failed = False
+        self._started_at = 0.0
+        self._respawns = 0
+        self._closing = False
+
+    # -- lifecycle ----------------------------------------------------------
+
+    async def start(self) -> None:
+        """Spawn the Oracle process + begin reading. Returns immediately — the
+        Oracle hydrates in the background; queries return OracleNotReady until
+        the worker signals ready."""
+        self._closing = False
+        await self._spawn()
+
+    async def _spawn(self) -> None:
+        self._ready = False
+        self._init_failed = False
+        self._started_at = time.time()
+        self._conn, self._proc = self._spawn_fn()
+        self._reader_task = asyncio.ensure_future(self._reader())
+
+    async def shutdown(self) -> None:
+        self._closing = True
+        try:
+            if self._conn is not None:
+                self._conn.send({"control": "shutdown"})
+        except Exception:  # noqa: BLE001
+            pass
+        # Close the connection BEFORE awaiting the reader: the reader is blocked
+        # in ``conn.recv()`` inside a default-executor thread, and cancelling the
+        # task does NOT interrupt that C-level blocking call. Closing the fd
+        # makes the recv raise (EOF/OSError) so the thread returns — otherwise
+        # the event loop cannot shut its default executor down (teardown hangs).
+        try:
+            if self._conn is not None:
+                self._conn.close()
+        except Exception:  # noqa: BLE001
+            pass
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        self._terminate_proc()
+
+    def _terminate_proc(self) -> None:
+        try:
+            if self._proc is not None and self._proc.is_alive():
+                self._proc.terminate()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- readiness ----------------------------------------------------------
+
+    @property
+    def is_ready(self) -> bool:
+        return self._ready
+
+    def _not_ready(self, reason: Optional[str] = None) -> OracleNotReady:
+        r = reason or ("init_failed" if self._init_failed else "hydrating")
+        return OracleNotReady(reason=r, elapsed_s=time.time() - self._started_at, respawns=self._respawns)
+
+    # -- request/response ---------------------------------------------------
+
+    async def call(self, method: str, *args: Any, **kwargs: Any) -> Any:
+        """Invoke an Oracle method across IPC. Returns the result, or an
+        :class:`OracleNotReady` if the Oracle can't serve yet, or raises
+        :class:`OracleRemoteError` if the remote method itself failed. NEVER
+        raises a connection/transport error into the caller — those degrade to
+        OracleNotReady + trigger a respawn."""
+        if not self._ready:
+            return self._not_ready()
+        loop = asyncio.get_running_loop()
+        rid = self._next_id
+        self._next_id += 1
+        fut: "asyncio.Future" = loop.create_future()
+        self._pending[rid] = fut
+        try:
+            self._conn.send({"id": rid, "method": method, "args": list(args), "kwargs": dict(kwargs)})
+        except (BrokenPipeError, OSError, EOFError):
+            self._pending.pop(rid, None)
+            await self._handle_crash("send failed (pipe severed)")
+            return self._not_ready("respawning")
+        return await fut
+
+    # Convenience wrappers for the audited surface ------------------------
+    async def incremental_update(self, changed_files: Any = None) -> Any:
+        return await self.call("incremental_update", changed_files)
+
+    async def get_metrics(self) -> Any:
+        return await self.call("get_metrics")
+
+    async def get_context_for_improvement(self, *args: Any, **kwargs: Any) -> Any:
+        return await self.call("get_context_for_improvement", *args, **kwargs)
+
+    # -- reader + crash handling -------------------------------------------
+
+    async def _reader(self) -> None:
+        loop = asyncio.get_running_loop()
+        while not self._closing:
+            try:
+                msg = await loop.run_in_executor(None, self._conn.recv)
+            except (EOFError, OSError):
+                if not self._closing:
+                    await self._handle_crash("connection severed (worker died)")
+                return
+            except asyncio.CancelledError:
+                return
+            if not isinstance(msg, dict):
+                continue
+            ctrl = msg.get("control")
+            if ctrl == "ready":
+                self._ready = True
+                logger.info("[OracleIPC] isolated Oracle ready (hydrated in %.1fs)", time.time() - self._started_at)
+                continue
+            if ctrl == "init_failed":
+                self._init_failed = True
+                self._fail_all(f"oracle init failed: {msg.get('error')}")
+                continue
+            rid = msg.get("id")
+            fut = self._pending.pop(rid, None)
+            if fut is not None and not fut.done():
+                if msg.get("ok"):
+                    fut.set_result(msg.get("result"))
+                else:
+                    fut.set_exception(OracleRemoteError(str(msg.get("error"))))
+
+    def _fail_all(self, reason: str) -> None:
+        for fut in list(self._pending.values()):
+            if not fut.done():
+                fut.set_exception(OracleRemoteError(reason))
+        self._pending.clear()
+
+    async def _handle_crash(self, reason: str) -> None:
+        """Catch a severed Oracle, narrate, fail pending calls, and respawn with
+        bounded backoff. NEVER raises — a crash must not propagate into GLS."""
+        self._ready = False
+        self._fail_all(f"oracle crash: {reason}")
+        self._terminate_proc()
+        await self._narrate_crash(reason)
+        if self._closing:
+            return
+        if self._respawns >= self._max_respawns:
+            logger.error("[OracleIPC] respawn budget exhausted (%d) — Oracle stays DEGRADED; "
+                         "engine continues context-free", self._max_respawns)
+            return
+        self._respawns += 1
+        delay = self._backoff * self._respawns
+        logger.warning("[OracleIPC] respawning isolated Oracle (#%d) after %.1fs: %s",
+                       self._respawns, delay, reason)
+        try:
+            await asyncio.sleep(delay)
+            if not self._closing:
+                await self._spawn()
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[OracleIPC] respawn failed: %s", exc)
+
+    async def _narrate_crash(self, reason: str) -> None:
+        """Best-effort high-severity OracleCrash narration. NEVER raises."""
+        if self._narrator is None:
+            return
+        payload = {"op_id": "oracle", "reason": f"Oracle subprocess crashed: {reason}",
+                   "respawns": self._respawns}
+        try:
+            on_event = getattr(self._narrator, "on_event", None)
+            if on_event is not None:
+                res = on_event(OracleCrash.KIND, payload)
+                if asyncio.iscoroutine(res):
+                    await res
+        except Exception:  # noqa: BLE001
+            logger.debug("[OracleIPC] crash narration swallowed", exc_info=True)

--- a/tests/architecture/test_slice112_graph_hygiene.py
+++ b/tests/architecture/test_slice112_graph_hygiene.py
@@ -1,0 +1,68 @@
+"""Slice 112 Phase 3 — graph hygiene: isolated-node pruning.
+
+Proves the prune removes pure-bloat (degree-0) nodes while leaving every
+connected node + every traversal result (shortest_path) invariant, and keeps
+the indices + metrics consistent.
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from backend.core.ouroboros.oracle import (
+    CodebaseKnowledgeGraph,
+    NodeData,
+    NodeID,
+    NodeType,
+)
+
+
+def _node(name: str) -> NodeID:
+    return NodeID(repo="jarvis", file_path=f"backend/{name}.py", name=name,
+                  node_type=NodeType.FUNCTION)
+
+
+def _build_graph_with_isolate():
+    g = CodebaseKnowledgeGraph()
+    a, b, iso = _node("a"), _node("b"), _node("orphan")
+    for nid in (a, b, iso):
+        g.add_node(NodeData(node_id=nid))
+    # Connect a → b; leave `orphan` isolated (degree 0).
+    g._graph.add_edge(str(a), str(b))
+    return g, a, b, iso
+
+
+class TestGraphHygiene:
+    def test_prune_removes_only_isolated_nodes(self):
+        g, a, b, iso = _build_graph_with_isolate()
+        assert g._graph.number_of_nodes() == 3
+        pruned = g.prune_isolated_nodes()
+        assert pruned == 1
+        assert str(iso) not in g._graph
+        assert str(a) in g._graph and str(b) in g._graph
+
+    def test_traversal_results_invariant_after_prune(self):
+        g, a, b, iso = _build_graph_with_isolate()
+        path_before = nx.shortest_path(g._graph, str(a), str(b))
+        g.prune_isolated_nodes()
+        path_after = nx.shortest_path(g._graph, str(a), str(b))
+        assert path_before == path_after  # pruning isolated nodes never changes a path
+
+    def test_indices_and_metrics_consistent_after_prune(self):
+        g, a, b, iso = _build_graph_with_isolate()
+        g.prune_isolated_nodes()
+        # node_index no longer references the orphan.
+        assert str(iso) not in g._node_index
+        assert str(a) in g._node_index
+        # file_index bucket for the orphan's file is dropped (now empty).
+        assert iso.file_path not in g._file_index
+        # metrics recomputed from the live graph.
+        assert g._metrics["total_nodes"] == g._graph.number_of_nodes() == 2
+
+    def test_prune_is_idempotent_and_safe_on_empty(self):
+        g, a, b, iso = _build_graph_with_isolate()
+        assert g.prune_isolated_nodes() == 1
+        assert g.prune_isolated_nodes() == 0  # nothing left to prune
+        empty = CodebaseKnowledgeGraph()
+        assert empty.prune_isolated_nodes() == 0  # never raises on empty

--- a/tests/architecture/test_slice112_oracle_ipc.py
+++ b/tests/architecture/test_slice112_oracle_ipc.py
@@ -1,0 +1,219 @@
+"""Slice 112 — Process-Isolated Oracle IPC: fault-tolerance matrix.
+
+Deterministic, no real 1.1 GB subprocess: we inject a ``spawn_fn`` that returns
+a real ``multiprocessing`` Pipe whose CHILD end the test drives directly to
+simulate the worker — sending ``ready``, answering requests, and simulating a
+crash by closing the pipe. This proves the AsyncOracleProxy's protocol +
+graceful degradation + crash→respawn logic with zero heavyweight dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import multiprocessing
+
+import pytest
+
+from backend.core.ouroboros import oracle_ipc as OIPC
+from backend.core.ouroboros.oracle_ipc import (
+    AsyncOracleProxy,
+    OracleNotReady,
+    OracleRemoteError,
+    OracleCrash,
+    process_isolation_enabled,
+)
+
+
+class _FakeProc:
+    def __init__(self):
+        self._alive = True
+    def is_alive(self):
+        return self._alive
+    def terminate(self):
+        self._alive = False
+    def join(self, timeout=None):
+        pass
+
+
+class _PipeFactory:
+    """Hands out real spawn-context duplex pipes; keeps the CHILD ends so the
+    test can drive the 'worker' side. Tracks spawn count for respawn assertions."""
+
+    def __init__(self):
+        self.ctx = multiprocessing.get_context("spawn")
+        self.children = []
+        self.procs = []
+        self.spawn_count = 0
+
+    def spawn(self):
+        self.spawn_count += 1
+        parent, child = self.ctx.Pipe(duplex=True)
+        self.children.append(child)
+        proc = _FakeProc()
+        self.procs.append(proc)
+        return parent, proc
+
+    @property
+    def child(self):
+        return self.children[-1]
+
+
+async def _wait_until(pred, timeout=3.0):
+    loop = asyncio.get_running_loop()
+    end = loop.time() + timeout
+    while loop.time() < end:
+        if pred():
+            return True
+        await asyncio.sleep(0.02)
+    return False
+
+
+async def _recv_child(child, timeout=3.0):
+    """Read one message from the child end (off the loop so we don't block)."""
+    return await asyncio.wait_for(asyncio.to_thread(child.recv), timeout=timeout)
+
+
+# ===========================================================================
+# Master flag
+# ===========================================================================
+
+
+def test_master_default_false(monkeypatch):
+    monkeypatch.delenv("JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED", raising=False)
+    assert process_isolation_enabled() is False
+    monkeypatch.setenv("JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED", "1")
+    assert process_isolation_enabled() is True
+
+
+# ===========================================================================
+# Graceful degradation — OracleNotReady while hydrating / init-failed
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_not_ready_returns_structured_sentinel_while_hydrating():
+    f = _PipeFactory()
+    proxy = AsyncOracleProxy(spawn_fn=f.spawn)
+    await proxy.start()
+    try:
+        # Worker has NOT signaled ready → every call degrades gracefully.
+        out = await proxy.get_metrics()
+        assert isinstance(out, OracleNotReady)
+        assert out.reason == "hydrating"
+    finally:
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_init_failed_surfaces_as_not_ready():
+    f = _PipeFactory()
+    proxy = AsyncOracleProxy(spawn_fn=f.spawn)
+    await proxy.start()
+    try:
+        f.child.send({"control": "init_failed", "error": "boom"})
+        assert await _wait_until(lambda: proxy._init_failed)
+        out = await proxy.get_metrics()
+        assert isinstance(out, OracleNotReady) and out.reason == "init_failed"
+    finally:
+        await proxy.shutdown()
+
+
+# ===========================================================================
+# Happy path — ready → request/response roundtrip
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_ready_then_call_roundtrip():
+    f = _PipeFactory()
+    proxy = AsyncOracleProxy(spawn_fn=f.spawn)
+    await proxy.start()
+    try:
+        f.child.send({"control": "ready"})
+        assert await _wait_until(lambda: proxy.is_ready)
+
+        call = asyncio.ensure_future(proxy.get_metrics())
+        req = await _recv_child(f.child)
+        assert req["method"] == "get_metrics"
+        f.child.send({"id": req["id"], "ok": True, "result": {"total_nodes": 42}})
+        result = await asyncio.wait_for(call, timeout=3)
+        assert result == {"total_nodes": 42}
+    finally:
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_remote_method_error_raises_oracleremoteerror():
+    f = _PipeFactory()
+    proxy = AsyncOracleProxy(spawn_fn=f.spawn)
+    await proxy.start()
+    try:
+        f.child.send({"control": "ready"})
+        assert await _wait_until(lambda: proxy.is_ready)
+        call = asyncio.ensure_future(proxy.get_context_for_improvement("x"))
+        req = await _recv_child(f.child)
+        f.child.send({"id": req["id"], "ok": False, "error": "KeyError('x')"})
+        with pytest.raises(OracleRemoteError):
+            await asyncio.wait_for(call, timeout=3)
+    finally:
+        await proxy.shutdown()
+
+
+# ===========================================================================
+# Resilience — crash detection → narrate → respawn (the marquee invariant)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_crash_is_detected_narrated_and_respawned():
+    narrated = []
+
+    class _Narrator:
+        async def on_event(self, kind, payload):
+            narrated.append((kind, payload))
+
+    f = _PipeFactory()
+    proxy = AsyncOracleProxy(spawn_fn=f.spawn, narrator=_Narrator(),
+                             max_respawns=2, respawn_backoff_s=0.0)
+    await proxy.start()
+    try:
+        f.child.send({"control": "ready"})
+        assert await _wait_until(lambda: proxy.is_ready)
+        assert f.spawn_count == 1
+
+        # Simulate an OOM kill: the worker process dies → its pipe end closes.
+        f.children[0].close()
+
+        # Proxy must: detect crash → narrate OracleCrash → respawn (spawn #2).
+        assert await _wait_until(lambda: f.spawn_count == 2, timeout=4), "no respawn"
+        assert any(k == OracleCrash.KIND for k, _ in narrated), "crash not narrated"
+        # After respawn, not-ready again until the NEW worker signals ready.
+        assert proxy.is_ready is False
+        out = await proxy.get_metrics()
+        assert isinstance(out, OracleNotReady)
+        # New worker hydrates → ready again.
+        f.children[1].send({"control": "ready"})
+        assert await _wait_until(lambda: proxy.is_ready)
+    finally:
+        await proxy.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_respawn_budget_exhausts_to_degraded_not_crash():
+    f = _PipeFactory()
+    proxy = AsyncOracleProxy(spawn_fn=f.spawn, max_respawns=1, respawn_backoff_s=0.0)
+    await proxy.start()
+    try:
+        f.child.send({"control": "ready"})
+        assert await _wait_until(lambda: proxy.is_ready)
+        # Crash #1 → respawn (budget=1 used).
+        f.children[0].close()
+        assert await _wait_until(lambda: f.spawn_count == 2, timeout=4)
+        # Crash #2 → budget exhausted → stays DEGRADED (no spawn #3), no raise.
+        f.children[1].close()
+        await asyncio.sleep(0.3)
+        assert f.spawn_count == 2  # no further respawn
+        out = await proxy.get_metrics()
+        assert isinstance(out, OracleNotReady)  # engine still runs, degraded
+    finally:
+        await proxy.shutdown()


### PR DESCRIPTION
## Slice 112 — structural GIL-freeze fix (process isolation) + bloat hygiene

**Verify-first reshaped this** (reported in full): `to_thread` can't fix a GIL-bound `pickle.loads`; slice-32's pool is per-file AST offload (wrong scaffolding); lazy-sqlite conflicts with networkx whole-graph algorithms. So: **process isolation** (separate GIL) + **isolated-node hygiene**. Rust/Assembly evaluated + rejected (cost is Python object reconstruction, not byte-parsing).

### Phase 1+2 — `oracle_ipc.py` (gated `JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED`, default-FALSE)
- **Worker** hosts `TheOracle` in its OWN process/GIL → the 1.1 GB / 166 s load + the in-RAM networkx graph never touch the engine loop. Audited 3-method surface over a spawn-context Pipe + method allowlist.
- **`AsyncOracleProxy`**: graceful degradation (structured `OracleNotReady` while hydrating/init-failed/respawning → engine + UI keep running); **resilience** — severed pipe → fail in-flight → narrate high-severity `OracleCrash` → bounded-backoff respawn → budget-exhaust to DEGRADED, **never crashing GLS**. Composes `OracleReadiness` + `daemon_narrator`. (Shutdown closes the conn to unblock the executor recv — fixed a real teardown-hang found in testing.)

### Phase 3 — graph hygiene (`oracle.py`)
`prune_isolated_nodes()` drops degree-0 nodes (pure bloat — `shortest_path`/`simple_cycles` traverse edges, so traversal results are **invariant**). Indices + metrics consistent. Wired into `_save_cache` gated by `JARVIS_ORACLE_GRAPH_PRUNE_ENABLED` (default-FALSE).

### Tests — 11, all green
7 IPC (incl. **crash→narrate→respawn** + **budget-exhaust→degraded-not-crash** + graceful `OracleNotReady`) + 4 hygiene (incl. **traversal-invariance** + idempotent/empty-safe).

**Honest scope:** the mechanism is complete + gated-off (default path byte-identical). The live call-site wiring (engine `await`s the proxy + handles `OracleNotReady`) + the real 1.1 GB-subprocess soak are the next step — they need a 3-min-boot soak I can't meaningfully run in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates the Oracle in a separate process with a fault‑tolerant async IPC proxy to prevent GIL freezes during graph load, and adds graph hygiene to prune isolated nodes without changing traversal results. Both features are disabled by default and gated by env flags.

- **New Features**
  - Added `oracle_ipc.py`: worker hosts `TheOracle` in its own process; `AsyncOracleProxy` communicates via a Pipe. Gate with `JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED` (default off).
  - Proxy degrades gracefully with `OracleNotReady`, narrates `OracleCrash`, and respawns with bounded backoff; shutdown closes the connection to avoid teardown hangs.
  - Allowed method surface only: `incremental_update`, `get_metrics`, `get_context_for_improvement`.
  - Added `prune_isolated_nodes()` to drop degree‑0 nodes; wired into `_save_cache` behind `JARVIS_ORACLE_GRAPH_PRUNE_ENABLED` (default off). Traversal results stay the same; indices and metrics remain consistent.

<sup>Written for commit efbbabc870829e2dd7a89515d31c2fd6fe305aff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

