### PR TITLE
Slice 113 — unified async Oracle adapter + live wiring

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1723,67 +1723,29 @@ class BattleTestHarness:
         prerequisite to op #1.
         """
         try:
-            from backend.core.ouroboros.oracle import TheOracle
+            from backend.core.ouroboros.oracle_adapter import make_oracle_adapter
 
-            # Construct synchronously — the constructor only touches
-            # filesystem (cache dir mkdir) and Python objects; cheap.
-            # The Oracle reference is now valid for downstream wiring
-            # (GovernanceStack, GLS) even before init completes.
-            self._oracle = TheOracle()
-
-            block_on_boot = (
-                os.environ.get("JARVIS_ORACLE_BLOCK_BOOT", "")
-                .strip().lower() in _TRUTHY
-            )
-
-            if block_on_boot:
-                # Legacy synchronous-await path. Single env flag, no
-                # secret modes — operators who need deterministic boot
-                # ordering opt in explicitly.
-                logger.info(
-                    "Oracle init: synchronous (JARVIS_ORACLE_BLOCK_BOOT=true)",
-                )
-                await self._oracle.initialize()
-                logger.info("Oracle booted (synchronous)")
-                return
-
-            # Deferred path — spawn initialize() as a tracked task and
-            # return immediately so the harness boot continues. The
-            # Oracle object is wired into GLS / governance stack at
-            # the normal sites; consumers awaiting graph or semantic
-            # readiness unblock the moment each phase finishes.
+            # Slice 113: the unified async Oracle adapter. Default path is the
+            # in-process adapter — a TRANSPARENT drop-in over ``TheOracle``
+            # (``__getattr__`` delegates every non-overridden method) that only
+            # changes the 5 engine call sites to ``await``. When
+            # ``JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED`` is set, the factory
+            # returns the process-isolated proxy (Slice 112) so the 1.1 GB /
+            # 166 s graph load runs in the Oracle's OWN process and never
+            # freezes this event loop. ``start()`` encapsulates the
+            # deferred-vs-blocking init (``JARVIS_ORACLE_BLOCK_BOOT``) and, for
+            # isolation, the subprocess spawn — it returns fast; the graph
+            # hydrates in the background and queries degrade to {} until ready.
+            self._oracle = make_oracle_adapter()
+            await self._oracle.start()
+            # Surface the adapter's deferred-init task for the existing shutdown
+            # cancellation path (adapter.shutdown() also cancels it — idempotent).
+            self._oracle_init_task = getattr(self._oracle, "_init_task", None)
             logger.info(
-                "Oracle init: deferred to background task "
-                "(JARVIS_ORACLE_BLOCK_BOOT=false; default)",
+                "Oracle adapter started (process_isolation=%s, block_on_boot=%s)",
+                os.environ.get("JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED", "false"),
+                os.environ.get("JARVIS_ORACLE_BLOCK_BOOT", "false"),
             )
-
-            async def _deferred_init() -> None:
-                try:
-                    await self._oracle.initialize()
-                    logger.info("Oracle booted (deferred)")
-                except asyncio.CancelledError:
-                    # Shutdown cancellation — propagate cleanly.
-                    raise
-                except Exception as inner_exc:  # noqa: BLE001
-                    # Failure already recorded via OracleReadiness
-                    # (initialize()'s except branch); waiters will
-                    # surface OracleInitFailed instead of hanging.
-                    logger.warning(
-                        "Oracle deferred init failed: %s", inner_exc,
-                    )
-
-            self._oracle_init_task = asyncio.ensure_future(_deferred_init())
-            # Defensive: install a done_callback that swallows
-            # CancelledError so the asyncio loop-level handler
-            # doesn't classify shutdown cancellation as a leak.
-            def _swallow(task: asyncio.Task) -> None:
-                try:
-                    if task.cancelled():
-                        return
-                    task.exception()  # consume so it isn't logged as unhandled
-                except Exception:  # noqa: BLE001
-                    pass
-            self._oracle_init_task.add_done_callback(_swallow)
         except Exception as exc:
             logger.warning("Oracle failed to boot: %s", exc)
 

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -5664,7 +5664,7 @@ class GovernedLoopService:
             if self._oracle is not None:
                 logger.info(
                     "[GovernedLoop] Oracle already injected (%s nodes), skipping re-init",
-                    self._oracle.get_metrics().get("total_nodes", "?"),
+                    (await self._oracle.get_metrics()).get("total_nodes", "?"),
                 )
             elif TheOracle is None:
                 raise ImportError("TheOracle not available")
@@ -5696,7 +5696,7 @@ class GovernedLoopService:
                 )
             logger.info(
                 "[GovernedLoop] Oracle indexed %s nodes across all repos",
-                self._oracle.get_metrics().get("total_nodes", "?"),
+                (await self._oracle.get_metrics()).get("total_nodes", "?"),
             )
         except asyncio.CancelledError:
             return

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -9667,7 +9667,13 @@ class GovernedOrchestrator:
 
         for raw_path in target_files[:3]:  # Cap at 3 files to stay within budget
             try:
-                ctx_info = oracle.get_context_for_improvement(raw_path, max_depth=2)
+                # Slice 113: this builder is SYNC, so reach the underlying
+                # in-process Oracle directly via the adapter's ``.raw`` (avoids
+                # an async cascade through every caller). In-process → identical
+                # behavior; under process isolation the graph is in another
+                # process so this sync path simply degrades (caught below).
+                _raw_oracle = getattr(oracle, "raw", oracle)
+                ctx_info = _raw_oracle.get_context_for_improvement(raw_path, max_depth=2)
             except Exception:
                 continue
 

--- a/backend/core/ouroboros/oracle_adapter.py
+++ b/backend/core/ouroboros/oracle_adapter.py
@@ -1,0 +1,212 @@
+"""Slice 113 — Unified async Oracle adapter (the wiring layer).
+
+Slice 112 built the process-isolated Oracle (``AsyncOracleProxy``) + the
+in-process ``TheOracle``, but they don't share a call signature: the in-process
+Oracle's ``get_metrics`` / ``get_context_for_improvement`` are SYNC, the proxy's
+are ASYNC + may return ``OracleNotReady``. This module gives the engine ONE
+``await``-able interface over EITHER backend, selected by
+``JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED`` — so the FSM/GLS call sites are
+identical regardless of topology, and the OFF path stays byte-identical to the
+legacy in-process behavior.
+
+Degradation convention (load-bearing for call-site simplicity): the convenience
+methods return **safe degraded values** rather than the raw ``OracleNotReady``
+sentinel —
+
+  * ``get_metrics()``                  → ``dict`` ({} while hydrating/crashed)
+  * ``get_context_for_improvement()``  → ``dict`` ({} while hydrating/crashed)
+  * ``incremental_update()``           → ``None`` (no-op while not ready)
+
+so a call site just ``await``s and its existing empty-dict handling Just Works.
+``is_ready`` + the structured ``OracleNotReady`` remain available for callers
+that want to branch explicitly.
+
+Composes: ``TheOracle`` (+ its ``OracleReadiness`` for the in-process ready
+gate), ``AsyncOracleProxy`` (Slice 112), ``oracle_ipc.process_isolation_enabled``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger("ouroboros.oracle_adapter")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _env_truthy(name: str) -> bool:
+    try:
+        return (os.environ.get(name, "") or "").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return False
+
+
+class InProcessOracleAdapter:
+    """Wraps the in-process ``TheOracle`` behind the unified async interface.
+    Preserves the existing deferred-init behavior (non-blocking boot; readiness
+    composed from ``OracleReadiness``). Default path — byte-identical effect to
+    legacy, just reached through ``await``."""
+
+    def __init__(self, oracle: Any) -> None:
+        self._oracle = oracle
+        self._init_task: Optional["asyncio.Task"] = None
+
+    async def start(self) -> None:
+        """Kick off initialization. Deferred (non-blocking) by default — the
+        graph hydrates in the background; queries degrade to {} until ready.
+        ``JARVIS_ORACLE_BLOCK_BOOT`` forces the legacy synchronous-await."""
+        if _env_truthy("JARVIS_ORACLE_BLOCK_BOOT"):
+            await self._oracle.initialize()
+            return
+        self._init_task = asyncio.ensure_future(self._safe_init())
+
+    async def _safe_init(self) -> None:
+        try:
+            await self._oracle.initialize()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — readiness records the failure
+            logger.warning("[OracleAdapter] in-process init failed (non-fatal): %s", exc)
+
+    @property
+    def is_ready(self) -> bool:
+        """Graph-scope readiness. Best-effort: if the Oracle exposes no
+        ``OracleReadiness`` primitive, assume ready (legacy oracles were always
+        treated as usable once constructed). NEVER raises."""
+        try:
+            from backend.core.ouroboros.oracle_readiness import OracleReadinessScope
+            readiness = getattr(self._oracle, "_readiness", None)
+            if readiness is None:
+                return True
+            return bool(readiness.is_ready(OracleReadinessScope.GRAPH))
+        except Exception:  # noqa: BLE001
+            return True
+
+    async def get_metrics(self) -> dict:
+        try:
+            return dict(self._oracle.get_metrics()) if self.is_ready else {}
+        except Exception:  # noqa: BLE001
+            return {}
+
+    async def get_context_for_improvement(self, target: Any, max_depth: int = 2) -> dict:
+        try:
+            if not self.is_ready:
+                return {}
+            res = self._oracle.get_context_for_improvement(target, max_depth=max_depth)
+            return res if isinstance(res, dict) else {}
+        except Exception:  # noqa: BLE001
+            return {}
+
+    async def incremental_update(self, changed_files: Any = None) -> None:
+        try:
+            if self.is_ready:
+                await self._oracle.incremental_update(changed_files)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[OracleAdapter] incremental_update swallowed: %s", exc)
+
+    async def shutdown(self) -> None:
+        if self._init_task is not None:
+            self._init_task.cancel()
+            try:
+                await self._init_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        try:
+            await self._oracle.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Escape hatch for callers that need the raw underlying Oracle (e.g.
+    # governance-stack wiring that predates the adapter). Read-only.
+    @property
+    def raw(self) -> Any:
+        return self._oracle
+
+    def __getattr__(self, name: str) -> Any:
+        """Transparent delegation: any method NOT overridden above (e.g.
+        ``find_nodes_in_file``, ``get_callers``, graph traversal) passes
+        straight through to the wrapped in-process Oracle, so the adapter is a
+        drop-in for every existing consumer — only the 5 engine call sites that
+        opt into the async interface change. (Dunder/private names are NOT
+        delegated, so this never shadows ``self._oracle`` lookups.)"""
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return getattr(self._oracle, name)
+
+
+class IsolatedOracleAdapter:
+    """Wraps the Slice-112 ``AsyncOracleProxy`` behind the unified interface,
+    normalizing the structured ``OracleNotReady`` sentinel into the safe
+    degraded values the call sites expect."""
+
+    def __init__(self, proxy: Any) -> None:
+        self._proxy = proxy
+
+    async def start(self) -> None:
+        await self._proxy.start()
+
+    @property
+    def is_ready(self) -> bool:
+        try:
+            return bool(self._proxy.is_ready)
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def get_metrics(self) -> dict:
+        r = await self._proxy.get_metrics()
+        return r if isinstance(r, dict) else {}
+
+    async def get_context_for_improvement(self, target: Any, max_depth: int = 2) -> dict:
+        r = await self._proxy.get_context_for_improvement(target, max_depth=max_depth)
+        return r if isinstance(r, dict) else {}
+
+    async def incremental_update(self, changed_files: Any = None) -> None:
+        # Returns OracleNotReady while hydrating — tolerated (best-effort no-op).
+        await self._proxy.incremental_update(changed_files)
+
+    async def shutdown(self) -> None:
+        await self._proxy.shutdown()
+
+    @property
+    def raw(self) -> Any:
+        return self._proxy
+
+    def __getattr__(self, name: str) -> Any:
+        """Under process isolation the graph lives in another process, so only
+        the IPC'd surface is reachable. A non-IPC method (e.g. in-process graph
+        traversal) cannot be served — raise a CLEAR error rather than silently
+        delegating to a proxy that lacks it. Consumers needing those degrade."""
+        if name.startswith("_"):
+            raise AttributeError(name)
+        raise AttributeError(
+            f"{name!r} is not available on the process-isolated Oracle "
+            f"(only the IPC surface is reachable; consumer should degrade)"
+        )
+
+
+def make_oracle_adapter(
+    *,
+    narrator: Any = None,
+    oracle: Any = None,
+    proxy: Any = None,
+) -> Any:
+    """Factory: return the isolated-process adapter when
+    ``JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED`` is set, else the in-process
+    adapter. ``oracle`` / ``proxy`` injectable for tests. NEVER raises — falls
+    back to in-process on any error."""
+    try:
+        from backend.core.ouroboros.oracle_ipc import (
+            AsyncOracleProxy,
+            process_isolation_enabled,
+        )
+        if process_isolation_enabled():
+            return IsolatedOracleAdapter(proxy or AsyncOracleProxy(narrator=narrator))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[OracleAdapter] isolation path unavailable, using in-process: %s", exc)
+    if oracle is None:
+        from backend.core.ouroboros.oracle import TheOracle
+        oracle = TheOracle()
+    return InProcessOracleAdapter(oracle)

--- a/scripts/launch_shadow_soak.sh
+++ b/scripts/launch_shadow_soak.sh
@@ -108,6 +108,13 @@ if [ "${COMMAND_CENTER:-0}" = "1" ]; then
   CC_IDLE="${SHADOW_IDLE_TIMEOUT:-600}"
   CC_WALL="${SHADOW_MAX_WALL_SECONDS:-0}"      # 0 = INFINITE (12–18 mo deployment); set SHADOW_MAX_WALL_SECONDS for a bounded watch
   export JARVIS_COMMAND_CENTER_GATEWAY=1        # co-boot the gateway inside the engine loop
+  # Slice 112/113: run the Oracle in its OWN process so the 1.1 GB / 166 s graph
+  # load happens on a separate GIL and NEVER freezes the engine loop — this is
+  # what keeps the gateway responsive THROUGH the hydration window (the soak's
+  # proof). Plus isolated-node graph hygiene to shrink the cache. Both
+  # overridable; default ON for the command-center soak.
+  export JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED="${JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED:-1}"
+  export JARVIS_ORACLE_GRAPH_PRUNE_ENABLED="${JARVIS_ORACLE_GRAPH_PRUNE_ENABLED:-1}"
   export JARVIS_BACKEND_PORT FRONTEND_PORT JARVIS_FRONTEND_PORT="$FRONTEND_PORT"
   CC_PIDS=()
   cleanup_cc() {

--- a/tests/architecture/test_slice113_oracle_adapter.py
+++ b/tests/architecture/test_slice113_oracle_adapter.py
@@ -1,0 +1,157 @@
+"""Slice 113 — unified async Oracle adapter.
+
+Proves both backends present ONE await-able interface, the in-process path
+degrades to safe empty values while hydrating, the isolated path normalizes
+OracleNotReady → {}, and the factory selects by the isolation flag.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.oracle_adapter import (
+    InProcessOracleAdapter,
+    IsolatedOracleAdapter,
+    make_oracle_adapter,
+)
+from backend.core.ouroboros.oracle_ipc import OracleNotReady
+
+
+class _FakeReadiness:
+    def __init__(self, ready):
+        self._ready = ready
+    def is_ready(self, scope=None):
+        return self._ready
+
+
+class _FakeOracle:
+    def __init__(self, ready=True):
+        if ready is not None:
+            self._readiness = _FakeReadiness(ready)
+        self.updated = []
+    def get_metrics(self):
+        return {"total_nodes": 5}
+    def get_context_for_improvement(self, target, max_depth=2):
+        return {"ctx": target, "depth": max_depth}
+    async def initialize(self):
+        return True
+    async def incremental_update(self, files=None):
+        self.updated.append(files)
+    async def shutdown(self):
+        pass
+
+
+class _FakeProxy:
+    def __init__(self, ready=True, result=None):
+        self._ready = ready
+        self._result = result
+        self.started = False
+    async def start(self):
+        self.started = True
+    @property
+    def is_ready(self):
+        return self._ready
+    async def get_metrics(self):
+        return self._result if self._ready else OracleNotReady()
+    async def get_context_for_improvement(self, target, max_depth=2):
+        return self._result if self._ready else OracleNotReady()
+    async def incremental_update(self, files=None):
+        return None if self._ready else OracleNotReady()
+    async def shutdown(self):
+        pass
+
+
+# ===========================================================================
+# In-process adapter
+# ===========================================================================
+
+
+class TestInProcessAdapter:
+    @pytest.mark.asyncio
+    async def test_ready_returns_real_values(self):
+        a = InProcessOracleAdapter(_FakeOracle(ready=True))
+        assert (await a.get_metrics()) == {"total_nodes": 5}
+        assert (await a.get_context_for_improvement("foo", max_depth=3)) == {"ctx": "foo", "depth": 3}
+
+    @pytest.mark.asyncio
+    async def test_not_ready_degrades_to_empty(self):
+        a = InProcessOracleAdapter(_FakeOracle(ready=False))
+        assert (await a.get_metrics()) == {}
+        assert (await a.get_context_for_improvement("foo")) == {}
+
+    @pytest.mark.asyncio
+    async def test_no_readiness_primitive_assumes_ready(self):
+        a = InProcessOracleAdapter(_FakeOracle(ready=None))  # no _readiness attr
+        assert (await a.get_metrics()) == {"total_nodes": 5}
+
+    @pytest.mark.asyncio
+    async def test_incremental_update_only_when_ready(self):
+        o = _FakeOracle(ready=True)
+        a = InProcessOracleAdapter(o)
+        await a.incremental_update(["x.py"])
+        assert o.updated == [["x.py"]]
+        o2 = _FakeOracle(ready=False)
+        a2 = InProcessOracleAdapter(o2)
+        await a2.incremental_update(["y.py"])
+        assert o2.updated == []  # skipped while not ready
+
+    @pytest.mark.asyncio
+    async def test_deferred_start_is_nonblocking(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_ORACLE_BLOCK_BOOT", raising=False)
+        a = InProcessOracleAdapter(_FakeOracle(ready=True))
+        await a.start()              # returns immediately (init runs as a task)
+        assert a._init_task is not None
+        await a.shutdown()
+
+
+# ===========================================================================
+# Isolated (proxy) adapter — normalizes OracleNotReady → safe values
+# ===========================================================================
+
+
+class TestIsolatedAdapter:
+    @pytest.mark.asyncio
+    async def test_ready_passthrough(self):
+        a = IsolatedOracleAdapter(_FakeProxy(ready=True, result={"total_nodes": 9}))
+        assert (await a.get_metrics()) == {"total_nodes": 9}
+
+    @pytest.mark.asyncio
+    async def test_not_ready_normalizes_to_empty(self):
+        a = IsolatedOracleAdapter(_FakeProxy(ready=False))
+        assert (await a.get_metrics()) == {}
+        assert (await a.get_context_for_improvement("t")) == {}
+        # incremental_update tolerates the OracleNotReady return (no raise)
+        await a.incremental_update(["z.py"])
+
+
+# ===========================================================================
+# Factory selection by the isolation flag
+# ===========================================================================
+
+
+class TestTransparentDelegation:
+    @pytest.mark.asyncio
+    async def test_in_process_delegates_unknown_methods(self):
+        class _OracleWithExtra(_FakeOracle):
+            def find_nodes_in_file(self, fp):
+                return ["node:" + fp]
+        a = InProcessOracleAdapter(_OracleWithExtra())
+        # Not in the adapter interface → transparently hits the raw Oracle.
+        assert a.find_nodes_in_file("x.py") == ["node:x.py"]
+
+    def test_isolated_raises_clear_on_non_ipc_method(self):
+        a = IsolatedOracleAdapter(_FakeProxy())
+        with pytest.raises(AttributeError):
+            _ = a.find_nodes_in_file
+
+
+class TestFactory:
+    def test_flag_off_selects_in_process(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED", raising=False)
+        a = make_oracle_adapter(oracle=_FakeOracle())
+        assert isinstance(a, InProcessOracleAdapter)
+
+    def test_flag_on_selects_isolated(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED", "1")
+        a = make_oracle_adapter(proxy=_FakeProxy())
+        assert isinstance(a, IsolatedOracleAdapter)


### PR DESCRIPTION
## Slice 113 — wire the process-isolated Oracle into the engine

ONE `await`-able interface over either backend, selected by `JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED`.

- **`InProcessOracleAdapter`** — transparent drop-in over `TheOracle` (`__getattr__` delegates every non-overridden method, so `find_nodes_in_file`/`get_callers`/traversal consumers keep working); only the 3 engine methods become async. Composes `OracleReadiness`; deferred-init in `start()`.
- **`IsolatedOracleAdapter`** — wraps the Slice-112 `AsyncOracleProxy`, normalizes `OracleNotReady` → safe degraded values; non-IPC methods raise a clear error.
- **`make_oracle_adapter()`** — factory; in-process default (byte-identical), isolated when the flag is set.

**Live wiring** (verify-first: exactly 5 consumers; the `" 2.py"`/`" 3.py"` hits were stale backups):
- harness boot → `make_oracle_adapter()` + `start()`; adapter injected into GLS + governance stack.
- GLS `_oracle_index_loop` → `await get_metrics()` (×2).
- orchestrator `_build_dependency_summary` (SYNC — avoided an async cascade) → uses the adapter's `.raw` for direct sync access in-process; degrades under isolation.
- launcher `COMMAND_CENTER` → isolation + graph-prune default-ON for the soak.

**22 tests green** (11 adapter incl. transparent-delegation + 7 IPC + 4 hygiene); compile + import-smoke clean. Default path byte-identical (flag off).

**Honest boundary:** the live soak is the empirical proof — with isolation ON, the 165 s loop-silence window should now be **gone** and the gateway responsive *through* hydration. That's the operator's local verification (3-min boot, can't run in CI).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unified async Oracle adapter adds one awaitable interface for both in‑process and isolated backends, controlled by `JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED`. This keeps the gateway responsive during the 1.1 GB/166 s graph hydration while preserving default behavior when the flag is off.

- **New Features**
  - Added `oracle_adapter.py` with `InProcessOracleAdapter`, `IsolatedOracleAdapter`, and `make_oracle_adapter()`; normalizes readiness and returns safe empty values while hydrating. Under isolation, non‑IPC methods raise clear errors.
  - Harness now uses `make_oracle_adapter()` and `start()`; GLS awaits `get_metrics()`; orchestrator uses `oracle.raw` to keep its sync path in‑process and degrades under isolation.
  - `scripts/launch_shadow_soak.sh`: enable isolation and graph prune by default for command‑center soak.
  - Tests cover both backends, delegation, and factory selection.

- **Migration**
  - No action needed; in‑process remains the default.
  - To enable isolation: set `JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED=1`. Optional: `JARVIS_ORACLE_BLOCK_BOOT=1` to block on init, `JARVIS_ORACLE_GRAPH_PRUNE_ENABLED=1` for cache hygiene.

<sup>Written for commit 46e8ba92c18f84d5b89d53e1c812e59337fbb8c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

