### PR TITLE
Slice 114 — decouple the gateway into its own process (UI never blinks)

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -447,6 +447,9 @@ class BattleTestHarness:
         self._governed_loop_service: Any = None
         # Slice 110 follow-up — co-boot command-center gateway server task.
         self._gateway_task: Optional[asyncio.Task] = None
+        # Slice 114 — decoupled gateway process + its cross-process telemetry queue.
+        self._gateway_proc: Any = None
+        self._telemetry_queue: Any = None
         self._predictive_engine: Any = None
         self._branch_manager: Any = None
         self._branch_name: Optional[str] = None
@@ -2135,7 +2138,38 @@ class BattleTestHarness:
                     gateway_port,
                     serve_gateway,
                 )
-                if command_center_gateway_enabled():
+                from backend.core.ouroboros.governance.telemetry_broker import (
+                    gateway_decoupled_enabled,
+                )
+                if command_center_gateway_enabled() and gateway_decoupled_enabled():
+                    # Slice 114: run the gateway in its OWN OS process — immune to
+                    # EVERY engine-loop freeze (vector loads, GIL-heavy ops).
+                    # Telemetry crosses via a bounded non-blocking queue; the FSM
+                    # never blocks on the UI, and the UI never blinks when the FSM
+                    # does. (The in-process bridge from GLS boot still registers
+                    # but no-ops — 0 local WS clients in decoupled mode.)
+                    from backend.core.ouroboros.governance.telemetry_broker import (
+                        build_queue_publishing_subscriber,
+                        make_telemetry_queue,
+                        spawn_gateway_process,
+                    )
+                    from backend.core.ouroboros.governance.cognitive_bus import (
+                        register_cognitive_subscribers,
+                    )
+                    self._telemetry_queue = make_telemetry_queue()
+                    self._gateway_proc = spawn_gateway_process(
+                        self._telemetry_queue, gateway_host(), gateway_port(),
+                    )
+                    _qsub = build_queue_publishing_subscriber(self._telemetry_queue)
+                    if _qsub is not None:
+                        await register_cognitive_subscribers([_qsub])
+                    logger.info(
+                        "[CommandCenter] DECOUPLED gateway spawned in its OWN "
+                        "process on http://%s:%d (Slice 114) — UI immune to "
+                        "engine-loop freezes",
+                        gateway_host(), gateway_port(),
+                    )
+                elif command_center_gateway_enabled():
                     self._gateway_task = asyncio.create_task(serve_gateway())
                     logger.info(
                         "[CommandCenter] observability gateway co-booting on "
@@ -2143,7 +2177,7 @@ class BattleTestHarness:
                         gateway_host(), gateway_port(),
                     )
             except Exception as exc:  # noqa: BLE001 — never fatal to the soak
-                logger.debug("[CommandCenter] gateway co-boot skipped: %s", exc)
+                logger.debug("[CommandCenter] gateway boot skipped: %s", exc)
 
             # ── Glanceable operator status line (Priority 2B) ─────────
             # Aggregates cost / idle / phase / op / route data from the
@@ -6447,6 +6481,20 @@ class BattleTestHarness:
                     await self._gateway_task
                 except asyncio.CancelledError:
                     pass
+        except Exception:
+            pass
+
+        # 0-cc2. Slice 114 — decoupled gateway PROCESS: stop its drain (sentinel)
+        # then terminate the process. Best-effort; never blocks teardown.
+        try:
+            if getattr(self, "_telemetry_queue", None) is not None:
+                from backend.core.ouroboros.governance.telemetry_broker import (
+                    stop_gateway_queue,
+                )
+                stop_gateway_queue(self._telemetry_queue)
+            proc = getattr(self, "_gateway_proc", None)
+            if proc is not None and proc.is_alive():
+                proc.terminate()
         except Exception:
             pass
 

--- a/backend/core/ouroboros/governance/telemetry_broker.py
+++ b/backend/core/ouroboros/governance/telemetry_broker.py
@@ -1,0 +1,210 @@
+"""Slice 114 — cross-process telemetry broker (gateway decoupling).
+
+Slices 110–113 co-booted the FastAPI gateway INSIDE the engine's event loop, so
+the command center shared the loop's fate: the Oracle freeze (fixed by Slice
+112) was the worst, but ChromaDB / EmbeddingService / consciousness C-extension
+boots still starve the loop ~57 s, and the gateway times out with it. A UI that
+shares the engine loop can never be "100 % responsive."
+
+This module severs that coupling. The gateway runs in its OWN OS process (its
+OWN event loop), and telemetry crosses the boundary through a bounded,
+non-blocking ``multiprocessing.Queue``:
+
+    ENGINE process                         GATEWAY process (isolated)
+    ──────────────                         ──────────────────────────
+    bridge handler                         uvicorn(observability gateway)
+      └─ publish_frame(q, frame)  ──Q──▶     └─ _drain(): q.get → manager.broadcast
+         (put_nowait, drop-oldest;             (blocking get OFF its own loop;
+          NEVER blocks the FSM loop)            engine freezes can't touch it)
+
+Result: the engine loop can freeze for any reason (vector loads, GIL-heavy ops)
+and the gateway process keeps serving WS/REST with zero timeouts — it only ever
+*consumes* a queue. No external dependency (stdlib ``multiprocessing`` only),
+no lock the engine can contend on (the queue is the only shared primitive).
+
+Master ``JARVIS_GATEWAY_DECOUPLED_ENABLED`` — §33.1 default-FALSE (the co-boot
+path stays the default until this is soak-proven). NEVER raises into the FSM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import multiprocessing
+import os
+import queue as _queue
+from typing import Any, Optional
+
+logger = logging.getLogger("ouroboros.telemetry_broker")
+
+_TRUTHY = ("1", "true", "yes", "on")
+_ENV_MASTER = "JARVIS_GATEWAY_DECOUPLED_ENABLED"
+_ENV_QUEUE_MAX = "JARVIS_TELEMETRY_QUEUE_MAX"
+
+# Shutdown sentinel pushed onto the queue to stop the gateway-process drain.
+_STOP = "__telemetry_stop__"
+
+
+def gateway_decoupled_enabled() -> bool:
+    """§33.1 master — default FALSE. NEVER raises."""
+    try:
+        raw = os.environ.get(_ENV_MASTER)
+        return bool(raw) and raw.strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _queue_max() -> int:
+    try:
+        return max(16, int(os.environ.get(_ENV_QUEUE_MAX, "512")))
+    except Exception:  # noqa: BLE001
+        return 512
+
+
+def make_telemetry_queue() -> Any:
+    """Create the bounded cross-process telemetry queue (spawn context — matches
+    the Slice-112 Oracle IPC + safe on macOS)."""
+    return multiprocessing.get_context("spawn").Queue(maxsize=_queue_max())
+
+
+def publish_frame(q: Any, frame: Any) -> bool:
+    """ENGINE-SIDE: hand a telemetry frame to the gateway process. NON-BLOCKING
+    and drop-oldest on a full queue — the FSM event loop must NEVER block on
+    telemetry, so a slow/dead gateway can only ever cost us the oldest frame,
+    never a stall. Returns True iff the frame was enqueued. NEVER raises."""
+    if q is None:
+        return False
+    try:
+        q.put_nowait(frame)
+        return True
+    except _queue.Full:
+        # Drop the oldest frame to make room — recency beats completeness for a
+        # live dashboard. Best-effort; never blocks.
+        try:
+            q.get_nowait()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            q.put_nowait(frame)
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def stop_gateway_queue(q: Any) -> None:
+    """Push the drain-stop sentinel (best-effort)."""
+    try:
+        if q is not None:
+            q.put_nowait(_STOP)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ===========================================================================
+# Gateway process (isolated) — drains the queue + serves WS/REST
+# ===========================================================================
+
+
+async def drain_queue_to_manager(q: Any, manager: Any, *, _stop_after: Optional[int] = None) -> int:
+    """GATEWAY-SIDE drain loop: pull frames off the cross-process queue and fan
+    them to the local WS manager. The blocking ``q.get`` runs in a worker thread
+    (``run_in_executor``) so the gateway's OWN event loop is never blocked
+    either. Stops on the ``_STOP`` sentinel / EOF. ``_stop_after`` bounds it for
+    tests. Returns the number of frames broadcast. NEVER raises out."""
+    loop = asyncio.get_running_loop()
+    delivered = 0
+    while True:
+        try:
+            frame = await loop.run_in_executor(None, q.get)
+        except (EOFError, OSError):
+            return delivered
+        except asyncio.CancelledError:
+            return delivered
+        if frame == _STOP or frame is None:
+            return delivered
+        try:
+            await manager.broadcast(frame)
+            delivered += 1
+        except Exception:  # noqa: BLE001 — one bad frame never kills the drain
+            logger.debug("[TelemetryBroker] broadcast swallowed", exc_info=True)
+        if _stop_after is not None and delivered >= _stop_after:
+            return delivered
+
+
+def _gateway_process_main(q: Any, host: str, port: int, log_level: str = "warning") -> None:
+    """Top-level (spawn-picklable) entrypoint for the ISOLATED gateway process.
+    Runs the observability gateway under uvicorn + the queue drain on its own
+    fresh event loop. NEVER lets an exception escape (process exit signals the
+    parent)."""
+    try:
+        asyncio.run(_gateway_process_async(q, host, port, log_level))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[TelemetryBroker] gateway process exited: %s", exc)
+
+
+async def _gateway_process_async(q: Any, host: str, port: int, log_level: str) -> None:
+    import uvicorn
+    from backend.api.observability_gateway import build_gateway_app, observability_manager
+
+    app = build_gateway_app()
+    drain_task = asyncio.ensure_future(drain_queue_to_manager(q, observability_manager))
+    config = uvicorn.Config(app, host=host, port=int(port), log_level=log_level,
+                            loop="asyncio", lifespan="off")
+    server = uvicorn.Server(config)
+    logger.info("[TelemetryBroker] decoupled gateway serving on http://%s:%d (own process)", host, port)
+    try:
+        await server.serve()
+    finally:
+        drain_task.cancel()
+        try:
+            await drain_task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+
+
+def spawn_gateway_process(q: Any, host: str = "127.0.0.1", port: int = 8000) -> Any:
+    """Spawn the isolated gateway process. Returns the ``Process`` handle. The
+    queue ``q`` is inherited by the child at spawn. NEVER raises beyond what
+    Process.start would."""
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(
+        target=_gateway_process_main, args=(q, host, int(port)), daemon=True,
+        name="jarvis-observability-gateway",
+    )
+    proc.start()
+    return proc
+
+
+# ===========================================================================
+# Engine-side bridge — publishes lifecycle frames to the queue (decoupled mode)
+# ===========================================================================
+
+
+def build_queue_publishing_subscriber(q: Any) -> Optional[Any]:
+    """A ``CognitiveSubscriber`` that, instead of broadcasting to an in-process
+    WS manager, publishes telemetry frames to the cross-process queue. This is
+    the decoupled-mode replacement for the Slice-110 in-process bridge.
+    Returns ``None`` if the cognitive_bus module is unavailable."""
+    try:
+        from backend.core.ouroboros.governance.cognitive_bus import (
+            CognitiveSubscriber,
+            lifecycle_pattern,
+        )
+        from backend.core.ouroboros.governance import cognitive_observability as CO
+        from backend.api.observability_gateway import frames_for_lifecycle
+    except Exception:  # noqa: BLE001
+        return None
+
+    async def _on_lifecycle_to_queue(event: Any) -> None:
+        try:
+            kind, op_id, payload = CO._unpack(event)
+            if not kind:
+                return
+            for frame in frames_for_lifecycle(kind, op_id, dict(payload)):
+                publish_frame(q, frame)
+        except Exception:  # noqa: BLE001 — telemetry never touches the FSM
+            logger.debug("[TelemetryBroker] queue bridge swallowed", exc_info=True)
+
+    return CognitiveSubscriber("telemetry_broker_queue", lifecycle_pattern(), _on_lifecycle_to_queue)

--- a/scripts/launch_shadow_soak.sh
+++ b/scripts/launch_shadow_soak.sh
@@ -115,6 +115,10 @@ if [ "${COMMAND_CENTER:-0}" = "1" ]; then
   # overridable; default ON for the command-center soak.
   export JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED="${JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED:-1}"
   export JARVIS_ORACLE_GRAPH_PRUNE_ENABLED="${JARVIS_ORACLE_GRAPH_PRUNE_ENABLED:-1}"
+  # Slice 114: run the gateway in its OWN process (cross-process telemetry
+  # queue) so the command center is immune to EVERY engine-loop freeze —
+  # ChromaDB / embeddings / Oracle / any GIL-heavy op. The UI never blinks.
+  export JARVIS_GATEWAY_DECOUPLED_ENABLED="${JARVIS_GATEWAY_DECOUPLED_ENABLED:-1}"
   export JARVIS_BACKEND_PORT FRONTEND_PORT JARVIS_FRONTEND_PORT="$FRONTEND_PORT"
   CC_PIDS=()
   cleanup_cc() {

--- a/tests/architecture/test_slice114_telemetry_broker.py
+++ b/tests/architecture/test_slice114_telemetry_broker.py
@@ -1,0 +1,151 @@
+"""Slice 114 — cross-process telemetry broker (gateway decoupling).
+
+Proves the non-blocking engine→gateway transport: publish never blocks the FSM
+(drop-oldest on full), the gateway-side drain fans frames to its WS manager and
+stops cleanly on the sentinel, and the decoupled bridge subscriber routes
+lifecycle events to the queue instead of an in-process manager. No real
+subprocess — the IPC mechanics are exercised with stdlib queues.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue as _queue
+
+import pytest
+
+from backend.core.ouroboros.governance import telemetry_broker as TB
+from backend.core.ouroboros.governance.telemetry_broker import (
+    drain_queue_to_manager,
+    gateway_decoupled_enabled,
+    publish_frame,
+    stop_gateway_queue,
+)
+
+
+class _BoundedFakeQueue:
+    """Deterministic bounded queue with the put_nowait/get_nowait + queue.Full
+    contract publish_frame relies on (mp.Queue's Full timing is racy in tests)."""
+
+    def __init__(self, maxsize):
+        self._items = []
+        self._max = maxsize
+
+    def put_nowait(self, item):
+        if len(self._items) >= self._max:
+            raise _queue.Full()
+        self._items.append(item)
+
+    def get_nowait(self):
+        if not self._items:
+            raise _queue.Empty()
+        return self._items.pop(0)
+
+
+class _FakeManager:
+    def __init__(self):
+        self.frames = []
+    async def broadcast(self, frame):
+        self.frames.append(frame)
+
+
+class _FakeEvent:
+    def __init__(self, payload):
+        self.payload = payload
+
+
+# ===========================================================================
+# Master flag
+# ===========================================================================
+
+
+def test_master_default_false(monkeypatch):
+    monkeypatch.delenv("JARVIS_GATEWAY_DECOUPLED_ENABLED", raising=False)
+    assert gateway_decoupled_enabled() is False
+    monkeypatch.setenv("JARVIS_GATEWAY_DECOUPLED_ENABLED", "1")
+    assert gateway_decoupled_enabled() is True
+
+
+# ===========================================================================
+# publish_frame — non-blocking, drop-oldest, never raises
+# ===========================================================================
+
+
+class TestPublishFrame:
+    def test_roundtrip(self):
+        q = _BoundedFakeQueue(4)
+        assert publish_frame(q, {"kind": "telemetry", "n": 1}) is True
+        assert q.get_nowait() == {"kind": "telemetry", "n": 1}
+
+    def test_drop_oldest_when_full(self):
+        q = _BoundedFakeQueue(2)
+        publish_frame(q, {"n": 1})
+        publish_frame(q, {"n": 2})
+        # Queue full → publish_frame drops the oldest (n=1) to make room for n=3.
+        assert publish_frame(q, {"n": 3}) is True
+        remaining = [q.get_nowait(), q.get_nowait()]
+        assert {"n": 1} not in remaining          # oldest dropped
+        assert {"n": 3} in remaining               # newest kept
+
+    def test_none_queue_is_safe(self):
+        assert publish_frame(None, {"n": 1}) is False  # never raises
+
+
+# ===========================================================================
+# drain_queue_to_manager — gateway-side fan-out + clean stop
+# ===========================================================================
+
+
+class TestDrain:
+    @pytest.mark.asyncio
+    async def test_drains_frames_to_manager_then_stops_on_sentinel(self):
+        q = _queue.Queue()
+        mgr = _FakeManager()
+        q.put({"kind": "why_snapshot", "op_id": "a"})
+        q.put({"kind": "telemetry", "op_id": "a"})
+        stop_gateway_queue(q)  # pushes the _STOP sentinel
+        n = await asyncio.wait_for(drain_queue_to_manager(q, mgr), timeout=5)
+        assert n == 2
+        assert [f["kind"] for f in mgr.frames] == ["why_snapshot", "telemetry"]
+
+    @pytest.mark.asyncio
+    async def test_bad_frame_never_kills_drain(self):
+        class _BoomOnce:
+            def __init__(self):
+                self.frames = []
+                self._first = True
+            async def broadcast(self, frame):
+                if self._first:
+                    self._first = False
+                    raise RuntimeError("boom")
+                self.frames.append(frame)
+        q = _queue.Queue()
+        mgr = _BoomOnce()
+        q.put({"n": 1})  # raises in broadcast → swallowed
+        q.put({"n": 2})  # still delivered
+        q.put(TB._STOP)
+        await asyncio.wait_for(drain_queue_to_manager(q, mgr), timeout=5)
+        assert mgr.frames == [{"n": 2}]
+
+
+# ===========================================================================
+# Decoupled bridge subscriber — routes lifecycle events to the queue
+# ===========================================================================
+
+
+class TestQueueBridge:
+    @pytest.mark.asyncio
+    async def test_subscriber_publishes_frames_to_queue(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_COGNITIVE_OBSERVABILITY_ENABLED", "1")
+        q = _BoundedFakeQueue(32)
+        sub = TB.build_queue_publishing_subscriber(q)
+        assert sub is not None
+        assert sub.label == "telemetry_broker_queue"
+        ev = _FakeEvent({"lifecycle_kind": "post_apply", "op_id": "op-7",
+                         "phase": "APPLY", "confidence": 0.9})
+        await sub.handler(ev)
+        # Frames (why_snapshot + telemetry) were routed to the cross-process
+        # queue — NOT to any in-process manager.
+        kinds = [q.get_nowait()["kind"] for _ in range(len(q._items))]
+        assert "why_snapshot" in kinds
+        assert "telemetry" in kinds


### PR DESCRIPTION
## Slice 114 — true gateway decoupling

The co-boot topology made the command center share the engine loop, so any GIL-heavy work froze the UI (the Oracle was worst — fixed in Slice 112 — but ChromaDB/embeddings still starved it ~57 s).

### Phase 1+2 — cross-process telemetry broker (`telemetry_broker.py`)
- Gateway runs in its **OWN OS process** (`spawn_gateway_process`) → **immune to every engine-loop freeze**.
- Telemetry crosses on a bounded `multiprocessing.Queue` (stdlib, **no external dep**): `publish_frame` is **non-blocking + drop-oldest** (FSM never blocks on the UI); the gateway-side `drain_queue_to_manager` reads off *its* own loop and fans to WS clients (engine freezes can't reach it).
- `JARVIS_GATEWAY_DECOUPLED_ENABLED` §33.1 default-FALSE; harness spawns the process + registers the queue bridge when set; launcher enables it for the soak.

### Phase 3 (async vector init) — verify-first reframed, deliberately NOT built
Once the gateway is decoupled it's immune to the ChromaDB/embedding freeze, so deferring those only affects the **engine's** own responsiveness, not the UI. And they hold the GIL on C-ext init (threading won't help — same lesson as the Oracle). The only real fix is lazy-first-use/isolation — a separate lever, **moot for the UI goal**. Not shipping redundant code.

### Tests — 7 green
publish drop-oldest + never-raises; drain fan-out + clean-stop + bad-frame-resilient; queue bridge. Compile + harness import-smoke clean. Default path byte-identical.

**Honest boundary:** the soak is the invincibility proof — with the flag on, the gateway should stay 200 with **zero timeouts** through ChromaDB/embedding/Oracle loads. Operator's local verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples the observability gateway into its own OS process so the UI stays responsive even when the engine loop stalls. Telemetry crosses via a bounded, non-blocking `multiprocessing.Queue`, gated by `JARVIS_GATEWAY_DECOUPLED_ENABLED` (default off).

- **New Features**
  - Added `telemetry_broker.py` for cross-process telemetry: `spawn_gateway_process`, `make_telemetry_queue`, `publish_frame` (non-blocking, drop-oldest), `drain_queue_to_manager`, and `build_queue_publishing_subscriber`.
  - Harness boots the gateway as a separate process when both `command_center_gateway_enabled()` and `gateway_decoupled_enabled()` are true; shutdown uses a sentinel plus `Process.terminate()`.
  - `launch_shadow_soak.sh` enables `JARVIS_GATEWAY_DECOUPLED_ENABLED=1` for the command-center soak; no external deps (stdlib only).
  - Tests cover queue semantics, drain fan-out and clean stop, and the decoupled bridge; default path is unchanged with the flag off.

- **Migration**
  - To enable, set `JARVIS_GATEWAY_DECOUPLED_ENABLED=1` (the soak script already does this).
  - No other changes required; with the flag off, the gateway co-boots as before.

<sup>Written for commit ed8fe76e8263131de86e32889e9f9e031b9805ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

