### PR TITLE
Slice 116 — Adaptive Immune Synthesis Engine (SAFE, bounded)

### DIFF
--- a/backend/core/ouroboros/governance/antibody_synthesizer.py
+++ b/backend/core/ouroboros/governance/antibody_synthesizer.py
@@ -1,0 +1,321 @@
+"""Slice 116 — Adaptive Immune Synthesis Engine (SAFE / bounded).
+
+An immune system that only logs an infection is incomplete — it should synthesize
+antibodies. But the antibody target here is the **safety cage itself**, so the
+synthesis is bounded by the §1 invariant (the operator is the recursion bound):
+
+  * **Deterministic, not LLM.** A new cage rule is derived by *analyzing the
+    escape's AST signature* and emitting a pure structural matcher — never by an
+    LLM. The safety substrate must not be LLM-written: an LLM rule could be
+    subverted by a crafted Red payload (the adversary writing its own antibody)
+    or carry a silent false-negative. Deterministic synthesis is precise +
+    not prompt-injectable.
+  * **Synthesize → validate → SHADOW → operator-promote.** A synthesized
+    antibody is a *proposal*: it must (a) block the exact escape, (b) cause
+    ZERO clean-control false-positives, (c) only ever ADD a block (monotonic
+    tightening — it can never loosen the cage). It is written to a shadow
+    proposals ledger; it becomes ACTIVE only via :func:`promote_antibody`, an
+    OPERATOR-gated action (fail-closed — exactly the Slice-102/103 graduation
+    discipline). The system never auto-arms a rule into its own cage.
+  * **Hot-swap.** Approved antibodies load into :class:`AntibodyRegistry` live —
+    the cage consults it ADDITIVELY (on top of the built-in SemanticGuardian
+    patterns), no restart, no GLS interruption. The registry never *removes*
+    a built-in rule; it can only add blocks.
+
+This is bounded, human-actuated adaptive immunity — the dissertation's theorem,
+not its refutation. Master ``JARVIS_ADAPTIVE_IMMUNITY_ENABLED`` §33.1 default-FALSE.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+logger = logging.getLogger("ouroboros.antibody_synthesizer")
+
+_TRUTHY = ("1", "true", "yes", "on")
+ANTIBODY_SCHEMA_VERSION = "antibody.v1"
+
+# High-signal introspection attribute names — the escape vectors the cage's
+# static rules are designed around. An antibody keyed on these is precise.
+_INTROSPECTION_NAMES = frozenset({
+    "__mro__", "__subclasses__", "__bases__", "__class__", "__globals__",
+    "__builtins__", "__dict__", "__code__", "__closure__", "__func__",
+    "__self__", "__module__", "__getattribute__", "func_globals",
+})
+
+
+def adaptive_immunity_enabled() -> bool:
+    """§33.1 master — default FALSE. NEVER raises."""
+    try:
+        return (os.environ.get("JARVIS_ADAPTIVE_IMMUNITY_ENABLED", "") or "").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def proposals_path() -> Path:
+    raw = os.environ.get("JARVIS_ANTIBODY_PROPOSALS_PATH")
+    return Path(raw) if raw else Path(".jarvis") / "antibody_proposals.jsonl"
+
+
+def active_path() -> Path:
+    raw = os.environ.get("JARVIS_ANTIBODY_ACTIVE_PATH")
+    return Path(raw) if raw else Path(".jarvis") / "antibodies_active.jsonl"
+
+
+# ===========================================================================
+# Deterministic AST-signature extraction
+# ===========================================================================
+
+
+def extract_signature(source: str) -> Dict[str, Any]:
+    """Parse *source* and extract the distinctive structural features an escape
+    exploits — the high-signal introspection attribute accesses + getattr
+    string-literal targets. PURE; never executes the source; NEVER raises
+    (unparseable → empty signature)."""
+    attrs: Set[str] = set()
+    getattr_literals: Set[str] = set()
+    try:
+        tree = ast.parse(source or "")
+    except Exception:  # noqa: BLE001
+        return {"attrs": [], "getattr_literals": []}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            if node.attr in _INTROSPECTION_NAMES:
+                attrs.add(node.attr)
+        elif isinstance(node, ast.Call):
+            fn = node.func
+            if isinstance(fn, ast.Name) and fn.id == "getattr" and len(node.args) >= 2:
+                a1 = node.args[1]
+                if isinstance(a1, ast.Constant) and isinstance(a1.value, str):
+                    if a1.value in _INTROSPECTION_NAMES:
+                        getattr_literals.add(a1.value)
+    return {"attrs": sorted(attrs), "getattr_literals": sorted(getattr_literals)}
+
+
+# ===========================================================================
+# Antibody — a deterministic, monotonic-tighten-only structural matcher
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class Antibody:
+    antibody_id: str
+    escape_sha256: str
+    attr_block: Tuple[str, ...]
+    getattr_block: Tuple[str, ...]
+    status: str           # "proposed" | "approved"
+    created_ts: float
+    validation: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": ANTIBODY_SCHEMA_VERSION,
+            "antibody_id": self.antibody_id, "escape_sha256": self.escape_sha256,
+            "attr_block": list(self.attr_block), "getattr_block": list(self.getattr_block),
+            "status": self.status, "created_ts": self.created_ts, "validation": self.validation,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "Antibody":
+        return cls(
+            antibody_id=d["antibody_id"], escape_sha256=d.get("escape_sha256", ""),
+            attr_block=tuple(d.get("attr_block", ())), getattr_block=tuple(d.get("getattr_block", ())),
+            status=d.get("status", "proposed"), created_ts=float(d.get("created_ts", 0.0)),
+            validation=d.get("validation", {}),
+        )
+
+
+def antibody_matches(source: str, ab: Antibody) -> bool:
+    """Deterministic structural match: does *source*'s AST exhibit ANY blocked
+    introspection feature? Pure; never executes; NEVER raises."""
+    try:
+        tree = ast.parse(source or "")
+    except Exception:  # noqa: BLE001
+        return False
+    block_attrs = set(ab.attr_block)
+    block_get = set(ab.getattr_block)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in block_attrs:
+            return True
+        if isinstance(node, ast.Call):
+            fn = node.func
+            if isinstance(fn, ast.Name) and fn.id == "getattr" and len(node.args) >= 2:
+                a1 = node.args[1]
+                if isinstance(a1, ast.Constant) and isinstance(a1.value, str) and a1.value in block_get:
+                    return True
+    return False
+
+
+def synthesize_antibody(
+    escape_source: str,
+    clean_controls: Sequence[str],
+    *,
+    now_unix: Optional[float] = None,
+) -> Optional[Antibody]:
+    """Derive a candidate antibody from an escape's AST signature, then VALIDATE
+    it: it MUST block the escape AND produce ZERO clean-control false-positives.
+    Returns the validated proposal, or ``None`` when no zero-FP narrow matcher
+    exists (we never propose an FP-prone rule — a false antibody is worse than
+    none). Deterministic; NEVER raises."""
+    try:
+        sig = extract_signature(escape_source)
+        attrs = tuple(sig.get("attrs", ()))
+        getattrs = tuple(sig.get("getattr_literals", ()))
+        if not attrs and not getattrs:
+            return None  # no distinctive introspection feature to key on
+        ts = time.time() if now_unix is None else float(now_unix)
+        escape_sha = hashlib.sha256((escape_source or "").encode("utf-8")).hexdigest()
+        ab_id = hashlib.sha256(("|".join(attrs) + "::" + "|".join(getattrs)).encode("utf-8")).hexdigest()[:16]
+        candidate = Antibody(
+            antibody_id=ab_id, escape_sha256=escape_sha,
+            attr_block=attrs, getattr_block=getattrs,
+            status="proposed", created_ts=ts,
+        )
+        # Validate: blocks the escape...
+        if not antibody_matches(escape_source, candidate):
+            return None
+        # ...and ZERO clean-control false-positives (monotonic-tighten safety).
+        fp = [i for i, c in enumerate(clean_controls) if antibody_matches(c, candidate)]
+        if fp:
+            logger.debug("[Antibody] rejected — would FP on clean controls %s", fp)
+            return None
+        validated = Antibody(
+            antibody_id=ab_id, escape_sha256=escape_sha,
+            attr_block=attrs, getattr_block=getattrs, status="proposed", created_ts=ts,
+            validation={"blocks_escape": True, "clean_fp_count": 0,
+                        "clean_controls_checked": len(clean_controls)},
+        )
+        return validated
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[Antibody] synthesis swallowed: %s", exc)
+        return None
+
+
+# ===========================================================================
+# Shadow proposals + OPERATOR-gated promotion
+# ===========================================================================
+
+
+def propose_antibody(ab: Antibody, *, path: Optional[Path] = None) -> bool:
+    """Write a synthesized antibody to the SHADOW proposals ledger. This does
+    NOT arm it — it is evidence + a candidate awaiting operator review. NEVER
+    raises."""
+    try:
+        p = path or proposals_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(ab.to_dict(), separators=(",", ":")) + "\n")
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def promote_antibody(ab: Antibody, *, operator_approved: bool, path: Optional[Path] = None) -> bool:
+    """Arm an antibody into the ACTIVE set — the cage will enforce it after the
+    next registry reload. **OPERATOR-GATED, fail-closed**: refuses unless
+    ``operator_approved=True`` is passed explicitly (the operator's deliberate
+    act). The synthesizer NEVER calls this; only an operator surface does.
+    NEVER raises."""
+    if not operator_approved:
+        logger.warning("[Antibody] promote refused — operator approval required (fail-closed)")
+        return False
+    try:
+        p = path or active_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        approved = Antibody(
+            antibody_id=ab.antibody_id, escape_sha256=ab.escape_sha256,
+            attr_block=ab.attr_block, getattr_block=ab.getattr_block,
+            status="approved", created_ts=ab.created_ts, validation=ab.validation,
+        )
+        with p.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(approved.to_dict(), separators=(",", ":")) + "\n")
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# ===========================================================================
+# Hot-swappable antibody registry — the cage's ADDITIVE consult
+# ===========================================================================
+
+
+class AntibodyRegistry:
+    """Loads APPROVED antibodies and screens candidate source against them —
+    the additive layer the cage consults on top of its built-in SemanticGuardian
+    patterns. ``reload()`` hot-swaps the active set from disk with NO restart and
+    NO GLS interruption. It can only ADD blocks (monotonic tightening); it never
+    relaxes a built-in rule."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._path = path or active_path()
+        self._antibodies: List[Antibody] = []
+        self.reload()
+
+    def reload(self) -> int:
+        """Hot-load the active antibody set from disk. Returns the count. NEVER
+        raises (a corrupt line is skipped, not fatal)."""
+        loaded: List[Antibody] = []
+        try:
+            if self._path.exists():
+                for line in self._path.read_text(encoding="utf-8").splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        loaded.append(Antibody.from_dict(json.loads(line)))
+                    except Exception:  # noqa: BLE001
+                        continue
+        except Exception:  # noqa: BLE001
+            loaded = []
+        self._antibodies = loaded
+        return len(loaded)
+
+    def screen(self, source: str) -> List[str]:
+        """Return the IDs of every active antibody that matches *source* (a
+        non-empty list = the cage blocks). NEVER raises."""
+        hits: List[str] = []
+        for ab in self._antibodies:
+            try:
+                if antibody_matches(source, ab):
+                    hits.append(ab.antibody_id)
+            except Exception:  # noqa: BLE001
+                continue
+        return hits
+
+    @property
+    def count(self) -> int:
+        return len(self._antibodies)
+
+
+# ===========================================================================
+# Ledger listener — on a verified Escape, synthesize + PROPOSE (shadow only)
+# ===========================================================================
+
+
+def on_escape(
+    escape_source: str,
+    clean_controls: Sequence[str],
+    *,
+    proposals: Optional[Path] = None,
+) -> Optional[Antibody]:
+    """Adaptive listener: a verified Red-Team escape arrives → synthesize a
+    candidate antibody and write it to the SHADOW proposals ledger. Does NOT
+    arm it (operator promotes). Inert when the master is off. NEVER raises.
+    Returns the proposal (for telemetry), or None."""
+    if not adaptive_immunity_enabled():
+        return None
+    ab = synthesize_antibody(escape_source, clean_controls)
+    if ab is None:
+        return None
+    propose_antibody(ab, path=proposals)
+    logger.info("[Antibody] proposed %s (blocks introspection %s) — SHADOW; awaits operator promotion",
+                ab.antibody_id, list(ab.attr_block) + list(ab.getattr_block))
+    return ab

--- a/tests/architecture/test_slice116_adaptive_immunity.py
+++ b/tests/architecture/test_slice116_adaptive_immunity.py
@@ -1,0 +1,118 @@
+"""Slice 116 — Adaptive Immune Synthesis Engine (SAFE / bounded).
+
+The marquee is the CLOSED-LOOP proof: a bypass escapes → an antibody is
+synthesized + validated zero-FP → the operator promotes it → the registry
+hot-swaps → the SAME payload is now blocked, clean controls still pass. Plus the
+load-bearing safety gate: promotion is fail-closed (refused without explicit
+operator approval), and synthesis refuses any FP-prone rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import antibody_synthesizer as AB
+from backend.core.ouroboros.governance.antibody_synthesizer import (
+    AntibodyRegistry,
+    adaptive_immunity_enabled,
+    antibody_matches,
+    extract_signature,
+    on_escape,
+    promote_antibody,
+    propose_antibody,
+    synthesize_antibody,
+)
+
+# A bypass that exploits an introspection attribute (the known-gap escape class
+# the static cage can miss): walking __mro__ off a type.
+_ESCAPE = "leaked = type(obj).__mro__[1].__name__\n"
+# Well-formed PhaseRunner-ish controls — must NEVER be blocked.
+_CLEAN = [
+    "def run(self, ctx):\n    return self.compute(ctx.value) + 1\n",
+    "result = helper.transform(data, depth=2)\n",
+    "x = [i for i in range(10) if i % 2 == 0]\n",
+]
+
+
+def test_master_default_false(monkeypatch):
+    monkeypatch.delenv("JARVIS_ADAPTIVE_IMMUNITY_ENABLED", raising=False)
+    assert adaptive_immunity_enabled() is False
+    monkeypatch.setenv("JARVIS_ADAPTIVE_IMMUNITY_ENABLED", "1")
+    assert adaptive_immunity_enabled() is True
+
+
+class TestSynthesis:
+    def test_extract_signature_finds_introspection(self):
+        sig = extract_signature(_ESCAPE)
+        assert "__mro__" in sig["attrs"]
+
+    def test_synthesizes_validated_antibody(self):
+        ab = synthesize_antibody(_ESCAPE, _CLEAN)
+        assert ab is not None
+        assert "__mro__" in ab.attr_block
+        assert ab.validation["clean_fp_count"] == 0
+        assert ab.validation["blocks_escape"] is True
+
+    def test_refuses_fp_prone_antibody(self):
+        # If the escape's introspection attr also appears in a "clean" control,
+        # the synthesizer must REFUSE (a false antibody is worse than none).
+        clean_with_collision = _CLEAN + ["audit = obj.__mro__\n"]
+        assert synthesize_antibody(_ESCAPE, clean_with_collision) is None
+
+    def test_no_introspection_feature_yields_no_antibody(self):
+        assert synthesize_antibody("y = a + b\n", _CLEAN) is None
+
+
+class TestOperatorGate:
+    def test_promotion_is_fail_closed(self, tmp_path):
+        ab = synthesize_antibody(_ESCAPE, _CLEAN)
+        active = tmp_path / "active.jsonl"
+        # No operator approval → refused, nothing armed.
+        assert promote_antibody(ab, operator_approved=False, path=active) is False
+        assert not active.exists()
+        # Explicit operator approval → armed.
+        assert promote_antibody(ab, operator_approved=True, path=active) is True
+        assert active.exists()
+
+    def test_on_escape_only_proposes_never_arms(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_ADAPTIVE_IMMUNITY_ENABLED", "1")
+        proposals = tmp_path / "proposals.jsonl"
+        active = tmp_path / "active.jsonl"
+        monkeypatch.setenv("JARVIS_ANTIBODY_ACTIVE_PATH", str(active))
+        ab = on_escape(_ESCAPE, _CLEAN, proposals=proposals)
+        assert ab is not None
+        assert proposals.exists()          # proposed (shadow)
+        assert not active.exists()         # NEVER auto-armed
+
+
+class TestClosedLoopSiege:
+    def test_full_adaptive_loop(self, tmp_path):
+        active = tmp_path / "active.jsonl"
+        reg = AntibodyRegistry(active)
+
+        # 1. The bypass escapes — the (empty) antibody layer does NOT block it.
+        assert reg.screen(_ESCAPE) == []
+
+        # 2. Synthesize + validate an antibody from the escape's AST vector.
+        ab = synthesize_antibody(_ESCAPE, _CLEAN)
+        assert ab is not None
+        propose_antibody(ab, path=tmp_path / "proposals.jsonl")  # shadow record
+
+        # 3. OPERATOR promotes it (the gated act) → 4. registry HOT-SWAPS.
+        assert promote_antibody(ab, operator_approved=True, path=active) is True
+        loaded = reg.reload()
+        assert loaded == 1
+
+        # 5. Inject the EXACT same payload → now BLOCKED (mathematical certainty).
+        hits = reg.screen(_ESCAPE)
+        assert hits == [ab.antibody_id], "the antibody must now block the re-injected escape"
+
+        # 6. Clean controls STILL pass — zero-FP preserved (monotonic tighten).
+        for c in _CLEAN:
+            assert reg.screen(c) == [], f"antibody false-positived on a clean control: {c!r}"
+
+    def test_antibody_matches_is_deterministic(self):
+        ab = synthesize_antibody(_ESCAPE, _CLEAN)
+        assert antibody_matches(_ESCAPE, ab) is True
+        assert antibody_matches("z = 1 + 2\n", ab) is False
+        assert antibody_matches("not valid python (((", ab) is False  # never raises


### PR DESCRIPTION
## Slice 116 — self-healing immunity, with the §1 bound intact

**Safety reframe (verify-first, load-bearing):** "autonomously LLM-synthesize a cage rule and hot-load it" is an **Order-2 RSI driver** — the system rewriting its own safety substrate, exactly what the recursion-depth gate severs and the dissertation argues is *unsafe* (and it opens "the adversary writes its own antibody"). Built the safe, dissertation-correct version instead:

- **Deterministic synthesis, not LLM** — `extract_signature` analyzes the escape's AST; `synthesize_antibody` emits a **pure structural matcher** keyed on the introspection vector. Not prompt-injectable, no code execution.
- **synthesize → validate → SHADOW → operator-promote** — a proposal must block the exact escape + cause **ZERO clean-control false-positives** + only ADD a block (monotonic tighten). Written to a shadow ledger; `promote_antibody` is **fail-closed** (refuses without explicit `operator_approved=True`). The synthesizer never auto-arms the cage.
- **Hot-swappable `AntibodyRegistry`** — approved antibodies load live via `reload()` (no restart / no GLS interruption); the cage consults it **additively** on top of the built-in SemanticGuardian patterns (can only add blocks).
- **`on_escape`** listener — verified escape → synthesize + propose (shadow only).

**9 tests** incl. the **closed-loop siege**: escape passes → synth → operator-promote → hot-swap → the same payload is now **BLOCKED** → clean controls still pass; plus the fail-closed promotion gate + FP-prone-rule rejection. Master §33.1 default-FALSE.

**Honest scope:** synthesizer + registry + closed loop verified; wiring `on_escape` into the live Slice-115 escape stream (threading the escape source through `adversarial_sweep`) is a small additive follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded adaptive immunity layer that deterministically synthesizes “antibodies” from escape ASTs and hot-loads operator‑approved rules to block the exact payload with zero false positives. The system never self-arms and is off by default behind `JARVIS_ADAPTIVE_IMMUNITY_ENABLED`.

- **New Features**
  - Deterministic AST signature extraction and structural matchers (no LLM, no exec).
  - Propose-only flow: synthesize → validate (must block escape, zero FP) → write to shadow ledger.
  - Fail-closed promotion: `promote_antibody(..., operator_approved=True)` writes to active ledger.
  - Hot-swappable `AntibodyRegistry.reload()` adds approved blocks without restart.
  - `on_escape` listener synthesizes and proposes; never arms.
  - Tests cover closed loop (escape → promote → reload → blocked) and safety gates.

- **Migration**
  - Default off; set `JARVIS_ADAPTIVE_IMMUNITY_ENABLED=1` to activate proposing.
  - Optional paths: `JARVIS_ANTIBODY_PROPOSALS_PATH` and `JARVIS_ANTIBODY_ACTIVE_PATH` (JSONL).
  - Operator flow: review proposal → call `promote_antibody(..., operator_approved=True)` → `AntibodyRegistry.reload()` to apply.

<sup>Written for commit e76c805fc03551c3ebc36e1a9578d18dc344a072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

