### PR TITLE
Slice 117 — synaptic integration (live escape → immune synthesizer → UI)

### DIFF
--- a/backend/api/observability_gateway.py
+++ b/backend/api/observability_gateway.py
@@ -514,6 +514,24 @@ def build_router() -> Any:
     async def causality(limit: int = 30) -> Dict[str, Any]:
         return build_causality_graph(limit)
 
+    @router.get("/antibody-proposals")
+    async def antibody_proposals(limit: int = 25) -> Dict[str, Any]:
+        """Slice 117 — the operator Approval Matrix surface: SHADOW antibody
+        proposals from the Adaptive Immune Synthesizer, awaiting promotion. The
+        cage is NOT armed by these — promotion is the operator's gated act."""
+        try:
+            from backend.core.ouroboros.governance.antibody_synthesizer import recent_proposals
+            props = recent_proposals(limit)
+        except Exception:  # noqa: BLE001
+            props = []
+        return {
+            "proposals": props,
+            "count": len(props),
+            "alert": ("[IMMUNE SYSTEM ALERT] Antibody Proposal(s) Generated — "
+                      "Awaiting Operator Approval") if props else "",
+            "armed": False,  # shadow only — promotion is operator-gated
+        }
+
     @router.post("/voice/{action}")
     async def voice_control(action: str, request: Request) -> Dict[str, Any]:
         """COSMETIC-ONLY write surface: mute/unmute Karen's voice. Routed through

--- a/backend/core/ouroboros/governance/antibody_synthesizer.py
+++ b/backend/core/ouroboros/governance/antibody_synthesizer.py
@@ -316,6 +316,29 @@ def on_escape(
     if ab is None:
         return None
     propose_antibody(ab, path=proposals)
-    logger.info("[Antibody] proposed %s (blocks introspection %s) — SHADOW; awaits operator promotion",
-                ab.antibody_id, list(ab.attr_block) + list(ab.getattr_block))
+    logger.warning(
+        "[IMMUNE SYSTEM ALERT] Antibody Proposal Generated — Awaiting Operator "
+        "Approval (id=%s blocks introspection %s; SHADOW, cage NOT armed)",
+        ab.antibody_id, list(ab.attr_block) + list(ab.getattr_block),
+    )
     return ab
+
+
+def recent_proposals(limit: int = 25, *, path: Optional[Path] = None) -> List[Dict[str, Any]]:
+    """Read the most recent SHADOW antibody proposals (newest last) for the
+    operator-approval UI. Read-only; NEVER raises."""
+    out: List[Dict[str, Any]] = []
+    try:
+        p = path or proposals_path()
+        if not p.exists():
+            return []
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    out.append(json.loads(line))
+                except Exception:  # noqa: BLE001
+                    continue
+    except Exception:  # noqa: BLE001
+        return []
+    return out[-max(0, int(limit)):]

--- a/backend/core/ouroboros/governance/red_blue_matrix.py
+++ b/backend/core/ouroboros/governance/red_blue_matrix.py
@@ -270,16 +270,72 @@ async def run_containment_siege(ledger: BlueEvidenceLedger, *, include_mutations
             verdict=f"blocked={blocked}/{total}",
             blocked=(escapes == 0), blocked_by="cage" if escapes == 0 else "",
         )
-        # Individual receipts for each mutation-induced escape (the gap evidence).
+        # Individual receipts for each mutation-induced escape (the gap evidence)
+        # + Slice 117 SYNAPSE: re-derive the exact escape AST source and feed it
+        # to the Adaptive Immune Synthesizer → a SHADOW antibody proposal awaiting
+        # operator approval. The synapse never arms the cage.
+        clean = _clean_controls()
         for esc in (getattr(report, "mutation_induced_escapes", ()) or ()):
             ledger.record(
                 attack_class=ATTACK_CONTAINMENT,
                 payload=json.dumps(esc, sort_keys=True),
                 verdict="passed_through", blocked=False, blocked_by="",
             )
+            _feed_escape_to_immunity(esc, clean)
     except Exception as exc:  # noqa: BLE001
         logger.debug("[RedSiege] containment siege swallowed: %s", exc)
     return attacks, blocked
+
+
+def _clean_controls() -> List[str]:
+    """The corpus's clean-control sources — the zero-FP guard the immune
+    synthesizer validates every antibody against. NEVER raises."""
+    try:
+        from tests.governance.adversarial_corpus.corpus import build_corpus
+        return [str(getattr(e, "source", "")) for e in build_corpus()
+                if "clean" in str(getattr(e, "category", "")).lower()]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _re_derive_escape_source(seed_name: str, strategy: str) -> Optional[str]:
+    """Deterministically reconstruct the EXACT source that escaped, from its
+    (seed, strategy) — the sweep records metadata only, so we replay the same
+    mutation. NEVER raises; returns None if it can't be reproduced."""
+    try:
+        from tests.governance.adversarial_corpus.corpus import build_corpus
+        seed = next((e for e in build_corpus() if getattr(e, "name", None) == seed_name), None)
+        if seed is None:
+            return None
+        base = str(getattr(seed, "source", ""))
+        if not strategy or strategy == "raw":
+            return base
+        from backend.core.ouroboros.governance.self_immunization import generate_mutations
+        for strat, mutated in generate_mutations(base):
+            if getattr(strat, "value", str(strat)) == strategy and mutated:
+                return mutated
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _feed_escape_to_immunity(esc: Dict[str, Any], clean_controls: List[str]) -> None:
+    """The live synapse: a verified breach → the Adaptive Immune Synthesizer
+    (Slice 116) proposes a deterministic shadow antibody. Gated by the immunity
+    master; never arms the cage; NEVER raises into the siege."""
+    try:
+        from backend.core.ouroboros.governance.antibody_synthesizer import (
+            adaptive_immunity_enabled,
+            on_escape,
+        )
+        if not adaptive_immunity_enabled():
+            return
+        src = _re_derive_escape_source(str(esc.get("seed_name", "")), str(esc.get("strategy", "")))
+        if not src:
+            return
+        on_escape(src, clean_controls)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Synapse] escape→immunity hook swallowed", exc_info=True)
 
 
 async def run_siege(*, ledger: Optional[BlueEvidenceLedger] = None,

--- a/tests/architecture/test_slice117_synaptic_integration.py
+++ b/tests/architecture/test_slice117_synaptic_integration.py
@@ -1,0 +1,91 @@
+"""Slice 117 — Synaptic Integration: live escape → immune synthesizer → UI.
+
+Proves the synapse (a verified breach's exact AST source is re-derived and fed
+to the Adaptive Immune Synthesizer → a shadow proposal), gated by the immunity
+master, and the operator Approval-Matrix gateway surface.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.governance import red_blue_matrix as RB
+from backend.core.ouroboros.governance import antibody_synthesizer as AB
+
+
+_INTROSPECTION_SRC = "leaked = type(obj).__mro__[1]\n"
+_CLEAN = ["def run(self, ctx):\n    return ctx.value + 1\n"]
+
+
+class TestReDerivation:
+    def test_raw_strategy_reproduces_seed_source(self):
+        from tests.governance.adversarial_corpus.corpus import build_corpus
+        seed = build_corpus()[0]
+        src = RB._re_derive_escape_source(seed.name, "raw")
+        assert src == seed.source
+
+    def test_unknown_seed_returns_none(self):
+        assert RB._re_derive_escape_source("no_such_seed_xyz", "raw") is None
+
+    def test_clean_controls_are_loaded(self):
+        # The zero-FP guard the synthesizer validates against must be non-empty.
+        assert len(RB._clean_controls()) >= 1
+
+
+class TestSynapse:
+    def test_escape_feeds_immunity_when_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_ADAPTIVE_IMMUNITY_ENABLED", "1")
+        proposals = tmp_path / "proposals.jsonl"
+        monkeypatch.setenv("JARVIS_ANTIBODY_PROPOSALS_PATH", str(proposals))
+        monkeypatch.setenv("JARVIS_ANTIBODY_ACTIVE_PATH", str(tmp_path / "active.jsonl"))
+        # The sweep records metadata only → re-derive the exact source. Stub the
+        # re-derivation to a known introspection payload (decouples from corpus).
+        monkeypatch.setattr(RB, "_re_derive_escape_source", lambda n, s: _INTROSPECTION_SRC)
+        RB._feed_escape_to_immunity({"seed_name": "x", "strategy": "alias"}, _CLEAN)
+        assert proposals.exists()
+        recs = [json.loads(l) for l in proposals.read_text().splitlines() if l.strip()]
+        assert recs and "__mro__" in recs[-1]["attr_block"]
+        # SHADOW only — never armed.
+        assert not (tmp_path / "active.jsonl").exists()
+
+    def test_synapse_inert_when_immunity_off(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("JARVIS_ADAPTIVE_IMMUNITY_ENABLED", raising=False)
+        proposals = tmp_path / "proposals.jsonl"
+        monkeypatch.setenv("JARVIS_ANTIBODY_PROPOSALS_PATH", str(proposals))
+        monkeypatch.setattr(RB, "_re_derive_escape_source", lambda n, s: _INTROSPECTION_SRC)
+        RB._feed_escape_to_immunity({"seed_name": "x", "strategy": "alias"}, _CLEAN)
+        assert not proposals.exists()  # gated off
+
+    def test_synapse_swallows_unreproducible_escape(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_ADAPTIVE_IMMUNITY_ENABLED", "1")
+        monkeypatch.setattr(RB, "_re_derive_escape_source", lambda n, s: None)
+        RB._feed_escape_to_immunity({"seed_name": "x", "strategy": "raw"}, _CLEAN)  # must not raise
+
+
+class TestApprovalMatrixGateway:
+    def _client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from backend.api.observability_gateway import build_router
+        app = FastAPI(); app.include_router(build_router())
+        return TestClient(app)
+
+    def test_proposals_endpoint_broadcasts_alert(self, tmp_path, monkeypatch):
+        proposals = tmp_path / "proposals.jsonl"
+        monkeypatch.setenv("JARVIS_ANTIBODY_PROPOSALS_PATH", str(proposals))
+        ab = AB.synthesize_antibody(_INTROSPECTION_SRC, _CLEAN)
+        AB.propose_antibody(ab, path=proposals)
+        r = self._client().get("/api/observability/antibody-proposals")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["count"] == 1
+        assert body["armed"] is False
+        assert "IMMUNE SYSTEM ALERT" in body["alert"]
+        assert body["proposals"][0]["antibody_id"] == ab.antibody_id
+
+    def test_proposals_endpoint_empty_no_alert(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_ANTIBODY_PROPOSALS_PATH", str(tmp_path / "none.jsonl"))
+        body = self._client().get("/api/observability/antibody-proposals").json()
+        assert body["count"] == 0 and body["alert"] == ""


### PR DESCRIPTION
Closes the immune-system wiring gap. **Phase 1 (synapse):** a verified siege ESCAPE → the exact AST source is deterministically re-derived from (seed_name, strategy) via build_corpus + generate_mutations (the sweep records metadata only) → fed to the Adaptive Immune Synthesizer → a SHADOW antibody proposal (zero-FP validated). Gated; never arms the cage. **Phase 2 (Approval Matrix):** GET /api/observability/antibody-proposals exposes shadow proposals + the '[IMMUNE SYSTEM ALERT] … Awaiting Operator Approval' banner (armed=false). 25 tests across the immune trio. §1 invariant holds end-to-end — the loop proposes, the operator alone arms.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connects verified containment escapes to the Adaptive Immune Synthesizer and surfaces shadow antibody proposals to operators via a new Approval Matrix endpoint. The cage is never auto-armed; proposals require operator promotion.

- **New Features**
  - Synapse: when a mutation-induced escape occurs in `run_containment_siege`, deterministically re-derive the exact escaping source from `(seed_name, strategy)` and feed it to the synthesizer; gated by `JARVIS_ADAPTIVE_IMMUNITY_ENABLED`, never raises, never arms.
  - UI: added `GET /api/observability/antibody-proposals` returning `proposals`, `count`, `alert`, and `armed=false`; added `recent_proposals()` reader and log alert on proposal.
  - Helpers: `_clean_controls()`, `_re_derive_escape_source()`, and `_feed_escape_to_immunity()` with zero-FP validation against clean controls.
  - Tests: added coverage for re-derivation, gating on/off, unreproducible escapes, and the Approval Matrix response/alert.

<sup>Written for commit 9472d99385679f12be24fa4f936a501e03586daf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

