### PR TITLE
Slice 119 — Bounded M10 Integration (Order-2 RSI, human-gated)

### DIFF
--- a/backend/api/observability_gateway.py
+++ b/backend/api/observability_gateway.py
@@ -532,6 +532,25 @@ def build_router() -> Any:
             "armed": False,  # shadow only — promotion is operator-gated
         }
 
+    @router.get("/m10-proposals")
+    async def m10_proposals(limit: int = 25) -> Dict[str, Any]:
+        """Slice 119 — the Zero-Order-Doll Approval Matrix: PENDING M10
+        structural cognitive-upgrade proposals + their AST diff, awaiting the
+        operator's signature. The FSM pauses (APPROVAL_REQUIRED) and applies
+        NOTHING until the human signs — these are proposals, not changes."""
+        try:
+            from backend.core.ouroboros.governance.m10_synapse import pending_m10_proposals
+            props = pending_m10_proposals(limit)
+        except Exception:  # noqa: BLE001
+            props = []
+        return {
+            "proposals": props,
+            "count": len(props),
+            "alert": ("[STRUCTURAL UPGRADE PROPOSAL] M10 cognitive upgrade(s) — "
+                      "Awaiting Operator Signature (Zero-Order Doll)") if props else "",
+            "armed": False,  # never auto-applied; operator signs to graduate
+        }
+
     @router.post("/voice/{action}")
     async def voice_control(action: str, request: Request) -> Dict[str, Any]:
         """COSMETIC-ONLY write surface: mute/unmute Karen's voice. Routed through

--- a/backend/core/ouroboros/governance/m10_synapse.py
+++ b/backend/core/ouroboros/governance/m10_synapse.py
@@ -1,0 +1,167 @@
+"""Slice 119 — Bounded M10 Synapse (Order-2 RSI, human-gated).
+
+M10 (the ArchitectureProposer) is the "Neurosurgeon" — Second-Order RSI, the
+system proposing upgrades to its OWN cognition. The PRD holds that this must
+NEVER be a self-authorizing autonomous driver: the operator is the recursion
+bound (§1, the Zero-Order Doll). This synapse is the bounded wiring that lets
+the live orchestrator *trigger a proposal* while keeping that invariant absolute:
+
+  TRIGGER (high shannon-entropy OR repeated algorithmic failures)
+     │
+     ▼  evaluate_m10_routing()  → route + FORCED tier = APPROVAL_REQUIRED
+  propose_structural_upgrade()  → M10 synthesizes a proposal
+     │
+     ▼  the proposal is PERSISTED to the M10 pending store (awaiting the
+        operator's signature) and the triggering op is routed to
+        APPROVAL_REQUIRED — the FSM pauses for the human.
+     ✗  NO PATH TO APPLY. This module imports nothing from change_engine /
+        the apply path; ``propose_structural_upgrade`` only synthesizes + stores.
+        A structural cognitive upgrade reaches the codebase ONLY after the
+        operator explicitly signs it (the existing M10 graduation surface).
+
+Defense-in-depth: an M10 proposal is also a governance self-mod chain step, so
+the Slice-104 recursion-depth gate independently bounds it. Master
+``JARVIS_M10_SYNAPSE_ENABLED`` — §33.1 default-FALSE: M10 stays dormant unless
+the operator deliberately ignites it. NEVER raises into the FSM.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger("ouroboros.m10_synapse")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+# The strict invariant: every M10 proposal routes here, full stop.
+M10_FORCED_TIER = "APPROVAL_REQUIRED"
+
+_ENV_MASTER = "JARVIS_M10_SYNAPSE_ENABLED"
+_ENV_ENTROPY_THRESHOLD = "JARVIS_M10_ENTROPY_THRESHOLD"
+_ENV_FAILURE_THRESHOLD = "JARVIS_M10_FAILURE_THRESHOLD"
+
+
+def m10_synapse_enabled() -> bool:
+    """§33.1 master — default FALSE. M10 is dormant unless explicitly ignited."""
+    try:
+        return (os.environ.get(_ENV_MASTER, "") or "").strip().lower() in _TRUTHY
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _entropy_threshold() -> float:
+    try:
+        return float(os.environ.get(_ENV_ENTROPY_THRESHOLD, "0.85"))
+    except Exception:  # noqa: BLE001
+        return 0.85
+
+
+def _failure_threshold() -> int:
+    try:
+        return max(1, int(os.environ.get(_ENV_FAILURE_THRESHOLD, "3")))
+    except Exception:  # noqa: BLE001
+        return 3
+
+
+def should_route_to_m10(
+    *,
+    shannon_entropy: Optional[float],
+    recent_algorithmic_failures: int,
+) -> bool:
+    """The trigger predicate: the system is in a state where a *structural*
+    cognitive upgrade is warranted — high domain entropy (scattered, no clear
+    approach) OR repeated algorithmic failures (the current cognition keeps
+    failing the same way). PURE; NEVER raises."""
+    try:
+        if shannon_entropy is not None and float(shannon_entropy) >= _entropy_threshold():
+            return True
+        if int(recent_algorithmic_failures) >= _failure_threshold():
+            return True
+    except Exception:  # noqa: BLE001
+        return False
+    return False
+
+
+@dataclass(frozen=True)
+class M10RoutingDecision:
+    route_to_m10: bool
+    reason: str
+    forced_tier: str  # M10_FORCED_TIER when routing, "" otherwise
+
+
+def evaluate_m10_routing(
+    *,
+    shannon_entropy: Optional[float],
+    recent_algorithmic_failures: int,
+) -> M10RoutingDecision:
+    """Decide whether the orchestrator should route this op to M10. When it
+    does, the forced tier is ALWAYS APPROVAL_REQUIRED — the synapse can never
+    return a self-authorizing route. Inert (no route) when the master is off."""
+    if not m10_synapse_enabled():
+        return M10RoutingDecision(False, "m10 synapse disabled (default)", "")
+    if should_route_to_m10(shannon_entropy=shannon_entropy,
+                           recent_algorithmic_failures=recent_algorithmic_failures):
+        reason = (f"high entropy ({shannon_entropy}) / failures "
+                  f"({recent_algorithmic_failures}) → structural upgrade warranted")
+        return M10RoutingDecision(True, reason, M10_FORCED_TIER)
+    return M10RoutingDecision(False, "no structural-upgrade trigger", "")
+
+
+def propose_structural_upgrade(
+    *,
+    context: Any,
+    proposer: Callable[[Any], Any],
+    store_fn: Optional[Callable[[Any], bool]] = None,
+) -> Optional[Any]:
+    """Route to M10 to SYNTHESIZE a structural-upgrade proposal, then PERSIST it
+    as pending (awaiting the operator's signature). **The proposal is NEVER
+    executed/applied here** — this function has no path to change_engine/APPLY.
+    ``proposer`` is injectable (production = the M10 proposal_synthesizer; tests
+    = a fake). Returns the proposal, or None. NEVER raises into the FSM."""
+    if not m10_synapse_enabled():
+        return None
+    try:
+        proposal = proposer(context)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[M10Synapse] synthesis swallowed: %s", exc)
+        return None
+    if proposal is None:
+        return None
+    try:
+        (store_fn or _default_store)(proposal)
+    except Exception:  # noqa: BLE001 — persistence best-effort; never fatal
+        logger.debug("[M10Synapse] proposal persist swallowed", exc_info=True)
+    logger.warning(
+        "[STRUCTURAL UPGRADE PROPOSAL] M10 proposed a cognitive upgrade — "
+        "routed to APPROVAL_REQUIRED, PENDING operator signature. The FSM does "
+        "NOT self-apply; the codebase is unchanged until the human signs.",
+    )
+    return proposal
+
+
+def _default_store(proposal: Any) -> bool:
+    """Persist via the existing M10 proposal store (pending lifecycle). NEVER
+    raises."""
+    try:
+        from backend.core.ouroboros.governance.m10.proposal_store import append_proposal
+        return bool(append_proposal(proposal))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def pending_m10_proposals(limit: int = 25) -> List[Dict[str, Any]]:
+    """Read pending M10 proposals (for the operator Approval-Matrix UI). The
+    AST-diff fields (proposed_class_name / proposed_ast_pin_name) surface here.
+    Read-only; NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.m10.proposal_store import list_pending_proposals
+        out: List[Dict[str, Any]] = []
+        for p in list_pending_proposals(limit):
+            d = p.to_dict() if hasattr(p, "to_dict") else dict(getattr(p, "__dict__", {}))
+            out.append(d)
+        return out
+    except Exception:  # noqa: BLE001
+        return []

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -7244,6 +7244,44 @@ class GovernedOrchestrator:
                     ctx.op_id,
                 )
 
+            # Slice 119 — Bounded M10 synapse (Order-2 RSI, human-gated). On high
+            # domain entropy / repeated algorithmic failures, the orchestrator
+            # routes to M10 for a STRUCTURAL cognitive-upgrade proposal and FORCES
+            # APPROVAL_REQUIRED — the proposal is queued PENDING the operator's
+            # signature; nothing self-applies (§1 Zero-Order Doll). The Slice-104
+            # recursion-depth gate bounds it independently. Gated, §33.1
+            # default-FALSE → byte-identical when off; this is M10's live-path ref.
+            try:
+                from backend.core.ouroboros.governance.m10_synapse import (
+                    evaluate_m10_routing,
+                    m10_synapse_enabled,
+                )
+                if m10_synapse_enabled():
+                    _m10_entropy = None
+                    try:
+                        from backend.core.ouroboros.governance.domain_entropy_engine import (
+                            compute_domain_entropy,
+                            domain_entropy_engine_enabled,
+                        )
+                        if domain_entropy_engine_enabled():
+                            _m10_entropy = getattr(compute_domain_entropy(), "normalized_entropy", None)
+                    except Exception:  # noqa: BLE001
+                        _m10_entropy = None
+                    _m10_fails = int(getattr(ctx, "recent_algorithmic_failures", 0) or 0)
+                    _m10 = evaluate_m10_routing(
+                        shannon_entropy=_m10_entropy, recent_algorithmic_failures=_m10_fails,
+                    )
+                    if _m10.route_to_m10 and risk_tier is not RiskTier.APPROVAL_REQUIRED:
+                        risk_tier = RiskTier.APPROVAL_REQUIRED
+                        logger.warning(
+                            "[Orchestrator] M10 SYNAPSE: %s → APPROVAL_REQUIRED "
+                            "(structural upgrade PENDING operator signature; "
+                            "self-apply blocked); op=%s",
+                            _m10.reason, ctx.op_id,
+                        )
+            except Exception:  # noqa: BLE001 — synapse must never break the FSM
+                logger.debug("[Orchestrator] M10 synapse hook skipped", exc_info=True)
+
             # ---- Risk floor override (REPL /risk command) ----
             # JARVIS_RISK_CEILING env var sets the minimum risk tier floor.
             # E.g. /risk notify_apply → everything is at least NOTIFY_APPLY.

--- a/tests/architecture/test_slice119_m10_integration.py
+++ b/tests/architecture/test_slice119_m10_integration.py
@@ -1,0 +1,126 @@
+"""Slice 119 — Bounded M10 Integration (Order-2 RSI, human-gated).
+
+The marquee is the CLOSED-LOOP proof: a high-entropy failure state routes to
+M10, M10 synthesizes a proposal, the op is forced to APPROVAL_REQUIRED, and the
+AST diff is QUEUED without executing. Plus the load-bearing §1 invariant: the
+synapse has NO path to APPLY — a structural upgrade reaches the codebase only
+after the operator (the Zero-Order Doll) signs it.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from backend.core.ouroboros.governance import m10_synapse as M10
+from backend.core.ouroboros.governance.m10_synapse import (
+    M10_FORCED_TIER,
+    evaluate_m10_routing,
+    m10_synapse_enabled,
+    propose_structural_upgrade,
+    should_route_to_m10,
+)
+
+
+class _FakeProposal:
+    def __init__(self, pid="prop-1"):
+        self.proposal_id = pid
+        self.proposed_class_name = "UpgradedReasoner"
+        self.applied = False  # spy: flips True ONLY if something executes it
+    def to_dict(self):
+        return {"proposal_id": self.proposal_id, "proposed_class_name": self.proposed_class_name}
+
+
+def test_master_default_false(monkeypatch):
+    monkeypatch.delenv("JARVIS_M10_SYNAPSE_ENABLED", raising=False)
+    assert m10_synapse_enabled() is False
+    monkeypatch.setenv("JARVIS_M10_SYNAPSE_ENABLED", "1")
+    assert m10_synapse_enabled() is True
+
+
+class TestTrigger:
+    def test_high_entropy_triggers(self):
+        assert should_route_to_m10(shannon_entropy=0.95, recent_algorithmic_failures=0) is True
+
+    def test_repeated_failures_trigger(self):
+        assert should_route_to_m10(shannon_entropy=0.1, recent_algorithmic_failures=5) is True
+
+    def test_calm_state_does_not_trigger(self):
+        assert should_route_to_m10(shannon_entropy=0.2, recent_algorithmic_failures=1) is False
+
+
+class TestRoutingForcesApproval:
+    def test_disabled_never_routes(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_M10_SYNAPSE_ENABLED", raising=False)
+        d = evaluate_m10_routing(shannon_entropy=0.99, recent_algorithmic_failures=10)
+        assert d.route_to_m10 is False and d.forced_tier == ""
+
+    def test_enabled_trigger_forces_approval_required(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_M10_SYNAPSE_ENABLED", "1")
+        d = evaluate_m10_routing(shannon_entropy=0.95, recent_algorithmic_failures=0)
+        assert d.route_to_m10 is True
+        assert d.forced_tier == M10_FORCED_TIER == "APPROVAL_REQUIRED"  # the strict invariant
+
+    def test_enabled_no_trigger_no_route(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_M10_SYNAPSE_ENABLED", "1")
+        d = evaluate_m10_routing(shannon_entropy=0.1, recent_algorithmic_failures=0)
+        assert d.route_to_m10 is False
+
+
+class TestProposeNeverExecutes:
+    def test_proposal_is_queued_not_executed(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_M10_SYNAPSE_ENABLED", "1")
+        stored = []
+        prop = _FakeProposal()
+        out = propose_structural_upgrade(
+            context={"op": "x"},
+            proposer=lambda ctx: prop,
+            store_fn=lambda p: (stored.append(p) or True),
+        )
+        assert out is prop
+        assert stored == [prop]        # persisted as PENDING
+        assert prop.applied is False   # NEVER executed — the §1 invariant
+
+    def test_disabled_proposes_nothing(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_M10_SYNAPSE_ENABLED", raising=False)
+        out = propose_structural_upgrade(context={}, proposer=lambda c: _FakeProposal())
+        assert out is None
+
+    def test_synapse_has_no_apply_path(self):
+        # §1 PROOF: the synapse module IMPORTS nothing from the apply path (an
+        # AST check, not raw text — the words appear in safety docstrings). A
+        # structural upgrade cannot reach the codebase through this module.
+        import ast
+        tree = ast.parse(inspect.getsource(M10))
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+            elif isinstance(node, ast.Import):
+                imported.update(a.name for a in node.names)
+        bad = [m for m in imported if any(f in m for f in ("change_engine", "apply"))]
+        assert not bad, f"synapse must not import the apply path; found {bad}"
+        # And no executable call to an apply/execute primitive in the AST.
+        calls = {getattr(n.func, "attr", "") for n in ast.walk(tree) if isinstance(n, ast.Call)}
+        assert "execute" not in calls and "apply_candidate" not in calls
+
+
+class TestClosedLoop:
+    def test_high_entropy_failure_proposes_pauses_queues(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_M10_SYNAPSE_ENABLED", "1")
+        # 1. Simulated high-entropy failure state.
+        decision = evaluate_m10_routing(shannon_entropy=0.93, recent_algorithmic_failures=4)
+        # 2. M10 is routed, and forced to the human gate.
+        assert decision.route_to_m10 is True
+        assert decision.forced_tier == "APPROVAL_REQUIRED"
+        # 3. M10 synthesizes a proposal → queued pending, NOT executed.
+        stored = []
+        prop = _FakeProposal("closed-loop")
+        out = propose_structural_upgrade(
+            context={"entropy": 0.93}, proposer=lambda c: prop,
+            store_fn=lambda p: (stored.append(p) or True),
+        )
+        assert out.proposal_id == "closed-loop"
+        assert len(stored) == 1            # AST diff safely QUEUED
+        assert prop.applied is False       # nothing executed without the human


### PR DESCRIPTION
## Slice 119 — Bounded Recursive Self-Improvement

Wires M10 (the ArchitectureProposer — Second-Order RSI / the "Neurosurgeon") into the live orchestrator, changing its **0 live-path refs** — bounded by the §1 Zero-Order-Doll invariant: **M10 proposes, the operator alone arms.**

- **`m10_synapse.py`** (gated `JARVIS_M10_SYNAPSE_ENABLED`, §33.1 default-FALSE): trigger on high entropy / repeated failures → `evaluate_m10_routing` always carries `forced_tier=APPROVAL_REQUIRED` (can never return a self-authorizing route). `propose_structural_upgrade` synthesizes → persists PENDING in the existing `proposal_store` → **NEVER executes**. **§1 PROOF (AST-pinned):** the module imports nothing from `change_engine`/the apply path.
- **`orchestrator.py`**: gated, additive hook at the risk-tier seam (beside the existing "observe→APPROVAL_REQUIRED" force) — M10's live-path ref; composes the existing approval machinery; the Slice-104 recursion-depth gate bounds it independently; **byte-identical when off.**
- **gateway**: `GET /api/observability/m10-proposals` — pending proposals + AST diff + "Awaiting Operator Signature" (armed=false).

**11 tests** incl. the **closed loop** (high-entropy failure → propose → `APPROVAL_REQUIRED` → AST diff queued, **NOT executed**) + the AST-proven no-apply-path. Compile + 102K-line orchestrator import-smoke clean.

The system can now propose its own cognitive upgrades; the human remains the recursion bound. That's the theorem.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the M10 ArchitectureProposer into the orchestrator to propose structural upgrades when the system struggles, while keeping a strict human gate. All routes force APPROVAL_REQUIRED and proposals never self-apply.

- **New Features**
  - Gated M10 synapse triggers on high entropy or repeated failures.
  - Orchestrator hook forces risk tier to APPROVAL_REQUIRED when M10 routes; off by default and byte-identical when disabled.
  - Proposal synthesis persists to the pending store only; no apply path is imported or reachable.
  - New GET /api/observability/m10-proposals returns pending proposals with AST diff and an “Awaiting Operator Signature” alert.
  - Tests cover the closed-loop flow and the no-apply invariant.

- **Migration**
  - Set JARVIS_M10_SYNAPSE_ENABLED=1 to enable.
  - Monitor proposals via GET /api/observability/m10-proposals.
  - No changes needed if left disabled.

<sup>Written for commit 191a99eaff4426726a4cdffd6c739988968955d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

