### PR TITLE
fix(soak): launch_shadow_soak.sh must honor --production-soak (Slice 123 wrapper gap)

### DIFF
--- a/scripts/launch_shadow_soak.sh
+++ b/scripts/launch_shadow_soak.sh
@@ -36,6 +36,17 @@ for _a in "$@"; do
       # expired roadmap fails CLOSED → per-PR human review (legacy behavior).
       export JARVIS_LAYER4_ROADMAP_ENABLED=1
       ;;
+    --production-soak)
+      # Slice 123 fix: the wrapper (not just the python harness) must honor the
+      # production profile, since this script builds its own python invocation.
+      # Enable the process-isolated Oracle + boot-recovery quarantine here, and
+      # mark PRODUCTION_SOAK so the cap defaults below scale up. Each respects an
+      # existing env value so the operator can still override individually.
+      PRODUCTION_SOAK=1
+      export JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED="${JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED:-1}"
+      export JARVIS_BOOT_RECOVERY_QUARANTINE_ENABLED="${JARVIS_BOOT_RECOVERY_QUARANTINE_ENABLED:-1}"
+      PROD_FLAG="--production-soak"
+      ;;
     *) SIEGE_ARGS+=("$_a") ;;
   esac
 done
@@ -201,6 +212,16 @@ COST_CAP="${SHADOW_COST_CAP:-0.50}"
 IDLE_TIMEOUT="${SHADOW_IDLE_TIMEOUT:-600}"
 MAX_WALL="${SHADOW_MAX_WALL_SECONDS:-0}"
 
+# Slice 123 fix: --production-soak scales the caps up for a real T5 evidence run.
+# Re-resolves against SHADOW_* so an explicit operator override still wins; only
+# the DEFAULT changes (0.50→25.00 budget, 600→0 idle = no idle stop).
+if [ "${PRODUCTION_SOAK:-0}" = "1" ]; then
+  COST_CAP="${SHADOW_COST_CAP:-25.00}"
+  IDLE_TIMEOUT="${SHADOW_IDLE_TIMEOUT:-0}"
+  MAX_WALL="${SHADOW_MAX_WALL_SECONDS:-0}"
+  log "production-soak profile ACTIVE: cost-cap=\$$COST_CAP idle=$IDLE_TIMEOUT wall=$MAX_WALL oracle_isolation=on quarantine=on"
+fi
+
 # SHADOW_INTERACTIVE=1 drops --headless so the operator watches the live Rich
 # TUI (token stream + diff overlays + status line) and the SerpentFlow REPL on
 # a real terminal — the "let Karen narrate the boot" ignition session. The
@@ -215,4 +236,4 @@ fi
 log "launching O+V shadow soak (cost-cap=\$$COST_CAP idle=$IDLE_TIMEOUT wall=$MAX_WALL ${HEADLESS_FLAG})..."
 exec python3 scripts/ouroboros_battle_test.py \
   --cost-cap "$COST_CAP" --idle-timeout "$IDLE_TIMEOUT" --max-wall-seconds "$MAX_WALL" \
-  "$HEADLESS_FLAG" -v
+  ${PROD_FLAG:-} "$HEADLESS_FLAG" -v


### PR DESCRIPTION
The first armed production-soak ran on battle-test defaults (cost-cap 0.50, idle 600, isolation off, quarantine off): the wrapper swallowed `--production-soak` into SIEGE_ARGS and built its own python invocation, never forwarding it. Slice 123 wired the flag into the python harness but the **wrapper is the operator's actual entrypoint**.

Fix: the wrapper's arg loop now handles `--production-soak` — sets the isolation + quarantine env, scales the cap defaults (0.50→25.00, idle 600→0) re-resolved against `SHADOW_*` (explicit override still wins), and forwards the flag to python. Verified: `--production-soak` → cost_cap=25.00/idle=0/wall=0/isolation=1/quarantine=1; `SHADOW_COST_CAP=5` → 5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the soak launcher wrapper honor `--production-soak` so production runs use the right safety toggles and budgets. Prevents production soaks from falling back to battle-test defaults.

- **Bug Fixes**
  - Parse `--production-soak` in the wrapper; set `PRODUCTION_SOAK` and export `JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED` and `JARVIS_BOOT_RECOVERY_QUARANTINE_ENABLED` if unset.
  - Scale defaults when active: cost-cap 0.50→25.00, idle 600→0, wall 0; still respects `SHADOW_*` overrides.
  - Forward `--production-soak` to the Python harness and log the active profile.

<sup>Written for commit d20c97e909ede1096dce93afac2e5123ba789de7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

