### PR TITLE
fix(soak): IdleWatchdog timeout_s<=0 must disable, not fire immediately

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -128,7 +128,9 @@ class HarnessConfig:
     cost_cap_usd:
         Maximum API spend for the session.
     idle_timeout_s:
-        Seconds of inactivity before the session is stopped.
+        Seconds of inactivity before the session is stopped. ``<=0`` disables
+        the idle stop entirely (the --production-soak profile uses 0 for an
+        unattended long-term run; liveness then rests on cost_cap + wall cap).
     max_wall_seconds_s:
         Hard wall-clock ceiling on total session duration. ``None`` or
         ``<=0`` disables the cap (legacy behavior — only ``idle_timeout_s``

--- a/backend/core/ouroboros/battle_test/idle_watchdog.py
+++ b/backend/core/ouroboros/battle_test/idle_watchdog.py
@@ -182,6 +182,15 @@ class IdleWatchdog:
     async def _watch(self) -> None:
         """Internal loop: check elapsed time, sleep, fire event when idle."""
         try:
+            # timeout_s <= 0 means DISABLED — never fire (matches the production
+            # intent that `--idle-timeout 0` removes the idle stop, same as
+            # max_wall_seconds <=0). Without this guard, timeout_s=0 makes
+            # `remaining = 0 - elapsed` immediately negative → the watchdog fires
+            # idle on its first tick and a long unattended soak dies the moment
+            # it goes quiet. Honored here so the --production-soak profile's
+            # idle=0 is robust across the soak's inevitable restarts.
+            if self._timeout_s <= 0:
+                return
             while True:
                 # HIBERNATION_MODE: while frozen the clock does not advance.
                 # Poll at 100ms so unfreeze() is observed within a tick — the

--- a/tests/architecture/test_idle_watchdog_zero_disable.py
+++ b/tests/architecture/test_idle_watchdog_zero_disable.py
@@ -1,0 +1,56 @@
+"""IdleWatchdog: timeout_s <= 0 must DISABLE the watchdog (never fire).
+
+The --production-soak profile sets --idle-timeout 0 to mean "no idle stop". Before
+this fix, timeout_s=0 made `remaining = 0 - elapsed` immediately negative → the
+watchdog fired idle on its first tick, which would kill a 12-month unattended soak
+the moment it went quiet. These tests pin the disabled semantics + that a normal
+positive timeout still fires.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.battle_test.idle_watchdog import IdleWatchdog
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_never_fires():
+    wd = IdleWatchdog(timeout_s=0)
+    await wd.start()
+    # Give the watch loop ample chances to (wrongly) fire.
+    await asyncio.sleep(0.3)
+    assert wd.idle_event.is_set() is False, "timeout_s=0 must DISABLE the watchdog"
+    wd.stop()
+
+
+@pytest.mark.asyncio
+async def test_negative_timeout_never_fires():
+    wd = IdleWatchdog(timeout_s=-1)
+    await wd.start()
+    await asyncio.sleep(0.3)
+    assert wd.idle_event.is_set() is False
+    wd.stop()
+
+
+@pytest.mark.asyncio
+async def test_positive_timeout_still_fires():
+    wd = IdleWatchdog(timeout_s=0.1)
+    await wd.start()
+    await asyncio.sleep(0.5)  # well past the 0.1s window with no poke
+    assert wd.idle_event.is_set() is True, "a positive timeout must still fire on idle"
+    assert wd.diagnostics is not None and wd.diagnostics.reason == "genuine_idle"
+    wd.stop()
+
+
+@pytest.mark.asyncio
+async def test_positive_timeout_poke_prevents_fire():
+    wd = IdleWatchdog(timeout_s=0.3)
+    await wd.start()
+    for _ in range(5):
+        await asyncio.sleep(0.1)
+        wd.poke()
+    assert wd.idle_event.is_set() is False  # constant pokes keep it alive
+    wd.stop()


### PR DESCRIPTION
Found while monitoring the first correctly-configured production soak. The `--production-soak` profile sets `--idle-timeout 0` to mean *no idle stop*, but `IdleWatchdog` had no zero-guard: `timeout_s=0` → `remaining = 0 - elapsed` is immediately negative → it fires idle on the first tick. A 12-month unattended soak would die the instant it went quiet.

Fix: `_watch()` returns immediately when `timeout_s <= 0` (disabled), matching the documented/production intent and robust across restarts. 4 tests (zero/negative disable, positive still fires, poke keeps alive).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `IdleWatchdog` so `timeout_s <= 0` disables the watchdog instead of firing immediately. This prevents unintended shutdowns in `--production-soak` runs with `--idle-timeout 0`.

- **Bug Fixes**
  - `_watch()` now returns immediately when `timeout_s <= 0` (disabled).
  - Positive timeouts keep existing behavior and still fire on idle.
  - Updated `HarnessConfig.idle_timeout_s` docstring to document the disable semantics.

- **Tests**
  - Added `tests/architecture/test_idle_watchdog_zero_disable.py` covering zero/negative disable, positive firing, and poke keeps alive.

<sup>Written for commit 217a5cb37d30b226e1c29da256fd4b39d1016e5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

