### PR TITLE
Slice 127 P2.1 — fallback-skip gate (IMMEDIATE → DW failover)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1071,6 +1071,50 @@ def dw_transport_degraded_preflight() -> bool:
     except Exception:  # noqa: BLE001 — never block dispatch on a gate error
         return False
 
+
+# ---------------------------------------------------------------------------
+# Slice 127 P2.1 — fallback-skip gate (IMMEDIATE reroute to DW)
+# ---------------------------------------------------------------------------
+#
+# The live soak proved P1+P2 (no terminal_config brick; economic reclassify +
+# ECONOMIC TRIP). But `_generate_immediate` does "Claude direct, skip DW", so an
+# IMMEDIATE op keeps grinding against a depleted Claude lane and exhausts instead
+# of failing over to the funded DW lane — the existing should_allow_request gate
+# only covers Claude-as-PRIMARY. This gate makes the Claude-direct path consult
+# the Claude lane breaker first and reroute to the DW primary when it's OPEN.
+
+
+def fallback_skip_gate_enabled() -> bool:
+    """Slice 127 P2.1 master. Default **FALSE** per §33.1 — when OFF, the
+    IMMEDIATE path stays byte-identical Claude-direct. NEVER raises."""
+    try:
+        return os.environ.get(
+            "JARVIS_FALLBACK_SKIP_GATE_ENABLED", "false",
+        ).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def immediate_reroute_to_dw(
+    *,
+    dw_is_primary: bool,
+    gate_enabled: bool,
+    claude_breaker_enabled: bool,
+    claude_allows_request: bool,
+) -> bool:
+    """Pure decision: should an IMMEDIATE op reroute from Claude-direct to the
+    DW primary? True iff DW is the primary lane, the gate is on, the Claude lane
+    breaker is enabled, and the breaker is NOT allowing requests (OPEN within
+    its window). When the breaker allows (CLOSED, or a HALF_OPEN probe), we keep
+    Claude-direct so the lane self-heals. Pure — no I/O, no side effects."""
+    return bool(
+        dw_is_primary
+        and gate_enabled
+        and claude_breaker_enabled
+        and not claude_allows_request
+    )
+
+
 # ---------------------------------------------------------------------------
 # Content failure classification
 # ---------------------------------------------------------------------------
@@ -3631,6 +3675,36 @@ class CandidateGenerator:
         # If DW IS the primary, go straight to Claude (the fallback).
         _dw_is_primary = (self._tier0 is not None and self._primary is self._tier0)
         if _dw_is_primary:
+            # Slice 127 P2.1 — fallback-skip gate. Claude-direct would just
+            # grind an IMMEDIATE op against a depleted Claude lane (the live
+            # soak: terminal_quota x N, no completion). When the Claude lane
+            # breaker is OPEN (economic/transport), reroute to the funded DW
+            # primary instead. should_allow_request() returns True for a
+            # HALF_OPEN probe → we keep Claude-direct that one time so the lane
+            # self-heals. Gated default-FALSE → OFF is unchanged Claude-direct.
+            if fallback_skip_gate_enabled():
+                try:
+                    from backend.core.ouroboros.governance.claude_circuit_breaker import (  # noqa: E501
+                        get_claude_circuit_breaker as _p21_ccb,
+                        is_enabled as _p21_ccb_enabled,
+                    )
+                    _p21_allows = _p21_ccb().should_allow_request()
+                    if immediate_reroute_to_dw(
+                        dw_is_primary=True,
+                        gate_enabled=True,
+                        claude_breaker_enabled=_p21_ccb_enabled(),
+                        claude_allows_request=_p21_allows,
+                    ):
+                        logger.warning(
+                            "[CandidateGenerator] IMMEDIATE reroute → DW: "
+                            "Claude lane breaker OPEN (economic/transport) — "
+                            "bypassing depleted Claude, routing to funded DW "
+                            "primary (op=%s)",
+                            getattr(context, "op_id", "?"),
+                        )
+                        return await self._call_primary(context, deadline)
+                except Exception:  # noqa: BLE001 — never block dispatch
+                    pass
             return await self._call_fallback(context, deadline)
 
         # Otherwise try primary (Claude/J-Prime), then fallback.

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -12007,7 +12007,9 @@ Two further design corrections, also confident: **(1) read-only siege, not 50 li
 
 ### §51.11.27 — Slice 127 BUILT (Economic Sovereign Matrix) — the verify-first correction of §51.11.D
 
-**Status: P1 + P2 + P3 BUILT, tested, committed. Only P4 (the operator-funded ignition soak) remains.**
+**Status: P1 + P2 + P3 + P2.1 BUILT, tested, committed. The first bounded ignition soak (bt-2026-06-07) PROVED P1+P2 live (0 `terminal_config` bricks; Claude credit-400 → recoverable `terminal_quota`; `ECONOMIC TRIP` isolated the Claude lane + self-heals) and surfaced P2.1. Only P4 (a re-run soak on a lane that actually completes) remains.**
+
+**P2.1 — fallback-skip gate (IMMEDIATE → DW failover).** The live soak exposed a routing blind spot: `_generate_immediate` does "Claude direct, skip DW", and the existing `should_allow_request` gate only covers Claude-as-*primary* — so IMMEDIATE ops kept grinding against the depleted Claude lane (`terminal_quota` ×N, no completion) instead of failing over to the funded DW lane. Fix: the Claude-direct path now consults the Claude lane breaker via a pure decision helper (`immediate_reroute_to_dw`); when the breaker is OPEN (economic/transport) it reroutes the op to the DW primary (`_call_primary`), while a HALF_OPEN probe still keeps Claude-direct so the lane self-heals. Master `JARVIS_FALLBACK_SKIP_GATE_ENABLED` (default-FALSE §33.1). 8 tests + wiring pin; 170 green.
 
 **The blueprint was misdiagnosed (verify-first, ground truth from `bt-2026-06-07-040933` `debug.log`).** §51.11.D claimed a `/v1/models` **401** health-probe trips a **GLOBAL** breaker sticky `OPEN_TERMINAL`, bricking all lanes. The canonical log (line 1592) proves otherwise:
 

--- a/tests/governance/test_fallback_skip_gate.py
+++ b/tests/governance/test_fallback_skip_gate.py
@@ -1,0 +1,98 @@
+"""Slice 127 P2.1 — fallback-skip gate: IMMEDIATE ops reroute to DW when the
+Claude economic lane breaker is OPEN.
+
+The live soak (bt-2026-06-06 23:07) proved P1+P2 (0 `terminal_config` bricks; the
+Claude credit-400 reclassifies to recoverable `terminal_quota`; `ECONOMIC TRIP`
+isolates the Claude lane + self-heals). But it exposed a routing blind spot:
+`_generate_immediate` does "Claude direct, skip DW" — so an IMMEDIATE op keeps
+grinding against the depleted Claude lane and exhausts instead of failing over to
+the funded DW lane, because the existing `should_allow_request` gate only covers
+Claude-as-*primary*.
+
+This gate makes the IMMEDIATE/Claude-direct path consult the Claude lane breaker
+first; when it's OPEN (economic/transport), the op reroutes to the DW primary.
+Pure decision helper (testable) + gated `JARVIS_FALLBACK_SKIP_GATE_ENABLED`
+(default-FALSE → OFF = unchanged Claude-direct).
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+from backend.core.ouroboros.governance.candidate_generator import (
+    fallback_skip_gate_enabled,
+    immediate_reroute_to_dw,
+)
+
+
+class TestFallbackSkipGateMaster(unittest.TestCase):
+    def test_default_false(self) -> None:
+        os.environ.pop("JARVIS_FALLBACK_SKIP_GATE_ENABLED", None)
+        self.assertFalse(fallback_skip_gate_enabled())
+
+    def test_enabled_truthy(self) -> None:
+        for v in ("1", "true", "yes", "on"):
+            os.environ["JARVIS_FALLBACK_SKIP_GATE_ENABLED"] = v
+            self.assertTrue(fallback_skip_gate_enabled())
+        os.environ.pop("JARVIS_FALLBACK_SKIP_GATE_ENABLED", None)
+
+
+class TestImmediateRerouteDecision(unittest.TestCase):
+    def test_reroutes_when_dw_primary_gate_on_breaker_open(self) -> None:
+        # The whole point: DW is primary, gate on, Claude lane breaker enabled
+        # and NOT allowing requests (OPEN) → reroute the IMMEDIATE op to DW.
+        self.assertTrue(immediate_reroute_to_dw(
+            dw_is_primary=True, gate_enabled=True,
+            claude_breaker_enabled=True, claude_allows_request=False,
+        ))
+
+    def test_no_reroute_when_claude_allows(self) -> None:
+        # CLOSED or a HALF_OPEN probe (should_allow_request True) → keep
+        # Claude-direct so the lane can self-heal.
+        self.assertFalse(immediate_reroute_to_dw(
+            dw_is_primary=True, gate_enabled=True,
+            claude_breaker_enabled=True, claude_allows_request=True,
+        ))
+
+    def test_no_reroute_when_gate_off(self) -> None:
+        self.assertFalse(immediate_reroute_to_dw(
+            dw_is_primary=True, gate_enabled=False,
+            claude_breaker_enabled=True, claude_allows_request=False,
+        ))
+
+    def test_no_reroute_when_breaker_disabled(self) -> None:
+        self.assertFalse(immediate_reroute_to_dw(
+            dw_is_primary=True, gate_enabled=True,
+            claude_breaker_enabled=False, claude_allows_request=False,
+        ))
+
+    def test_no_reroute_when_claude_is_primary(self) -> None:
+        # When Claude IS primary, the existing primary-side gate handles it —
+        # this IMMEDIATE/DW-primary reroute does not apply.
+        self.assertFalse(immediate_reroute_to_dw(
+            dw_is_primary=False, gate_enabled=True,
+            claude_breaker_enabled=True, claude_allows_request=False,
+        ))
+
+
+class TestWiringPin(unittest.TestCase):
+    """Bytes-pin the _generate_immediate integration (the async dispatch method
+    is too coupled to unit-test directly — project convention)."""
+
+    def test_immediate_consults_breaker_before_claude_direct(self) -> None:
+        import pathlib
+        src = pathlib.Path(
+            "backend/core/ouroboros/governance/candidate_generator.py"
+        ).read_text()
+        # The reroute decision must be wired into _generate_immediate, before
+        # the Claude-direct _call_fallback, and route to the DW primary.
+        idx_fn = src.find("async def _generate_immediate(")
+        idx_next = src.find("async def _try_jprime_primacy(", idx_fn)
+        body = src[idx_fn:idx_next]
+        self.assertIn("immediate_reroute_to_dw", body)
+        self.assertIn("should_allow_request", body)
+        self.assertIn("_call_primary", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
The fix the **live ignition soak** revealed. The bounded soak (bt-2026-06-07) **proved P1+P2 in production** — **0** `terminal_config` bricks (the old 16-trip sticky failure is gone), the Claude credit-400 reclassified to recoverable `terminal_quota`, and `ECONOMIC TRIP (CLOSED→OPEN) … route to the other lane … self-heals` fired — but exposed a routing blind spot.

## Blind spot
`_generate_immediate` does **"Claude direct, skip DW"**, and the existing `should_allow_request` gate only covers **Claude-as-primary** — so IMMEDIATE ops kept grinding against the depleted Claude lane (`terminal_quota` ×N, no completion) instead of failing over to the funded DW lane.

## Fix
The Claude-direct path now consults the Claude lane breaker via a **pure decision helper** `immediate_reroute_to_dw(...)`; when the breaker is **OPEN** (economic/transport) the op reroutes to the **DW primary** (`_call_primary`). A **HALF_OPEN probe** still keeps Claude-direct so the lane self-heals.

- Master `JARVIS_FALLBACK_SKIP_GATE_ENABLED` (default-FALSE, §33.1) → OFF byte-identical.
- 8 tests (pure truth-table + `_generate_immediate` wiring pin); **170 green**.

Continues #69333 (P1+P2) and #69334 (P3). PRD §51.11.27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a routing blind spot: IMMEDIATE requests now fail over to DW when the Claude circuit breaker is open, instead of grinding on the depleted Claude lane. Improves completion reliability; behavior is gated and defaults to off.

- **Bug Fixes**
  - In `*_generate_immediate*`, consult the Claude circuit breaker and reroute to DW primary when it’s open; keep Claude-direct on HALF_OPEN probes.
  - Added pure decision helper `immediate_reroute_to_dw(...)` and master flag `JARVIS_FALLBACK_SKIP_GATE_ENABLED` (default false) to keep OFF behavior byte-identical.
  - Tests cover the decision truth table and wiring; updated PRD docs.

<sup>Written for commit 767837f7284137bd829318a0e0cc9c3af9fb9278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

