### PR TITLE
Slice 131 P1 — Cost Sovereign: activate dormant caches + no-hardcode failover model

### DIFF
--- a/backend/core/ouroboros/governance/brain_selection_policy.yaml
+++ b/backend/core/ouroboros/governance/brain_selection_policy.yaml
@@ -297,6 +297,17 @@ gates:
     persist_path: "~/.jarvis/ouroboros/cost_state.json"
 
 # ---------------------------------------------------------------------------
+# Cost Optimization (Slice 131 — Cost Sovereign Matrix)
+# Canonical, no-hardcode source for cost-routing model tiers. The economic
+# router's cheap-tier failover (economic_router.economic_failover_model) reads
+# claude_low_cost_model here; JARVIS_ECONOMIC_FAILOVER_MODEL env still overrides.
+# Keep this an ACTIVE model id (per shared model catalog) — claude-3-5-haiku is
+# retired; the current cheapest Anthropic tier is claude-haiku-4-5 ($1/$5 per M).
+# ---------------------------------------------------------------------------
+cost_optimization:
+  claude_low_cost_model: "claude-haiku-4-5"
+
+# ---------------------------------------------------------------------------
 # Provider Topology — Hard-segmented DW model mapping (Manifesto §5)
 # ---------------------------------------------------------------------------
 #

--- a/backend/core/ouroboros/governance/economic_router.py
+++ b/backend/core/ouroboros/governance/economic_router.py
@@ -31,7 +31,8 @@ from __future__ import annotations
 import dataclasses
 import enum
 import os
-from typing import Optional
+import pathlib
+from typing import Any, Optional
 
 _ENV_MASTER = "JARVIS_ECONOMIC_ROUTER_ENABLED"
 _ENV_MICRO_TOKENS = "JARVIS_ECONOMIC_MICRO_OP_TOKENS"
@@ -44,7 +45,31 @@ _CHARS_PER_TOKEN = 4  # standard rough estimate
 
 
 def economic_router_enabled() -> bool:
-    return os.getenv(_ENV_MASTER, "false").strip().lower() in ("1", "true", "yes", "on")
+    """Master gate. **Graduated to default-TRUE (Slice 131)** — the router only
+    acts on the provider-FAILURE path (DW 402/429), so default-on cannot raise
+    spend on the happy path; it only adds a cheap-tier failover instead of a
+    hard stall. Hot-revert: ``=false``."""
+    return os.getenv(_ENV_MASTER, "true").strip().lower() not in ("0", "false", "no", "off")
+
+
+# Canonical no-hardcode source for the cheap-tier failover model.
+_POLICY_PATH = pathlib.Path(__file__).parent / "brain_selection_policy.yaml"
+
+
+def _low_cost_model_from_policy(policy_path: Optional[pathlib.Path] = None) -> str:
+    """Resolve the cheap Claude tier from ``brain_selection_policy.yaml``
+    (``cost_optimization.claude_low_cost_model``). NO hardcoded model string in
+    this module (CLAUDE.md mandate) — the default lives in the YAML config.
+    NEVER raises; returns "" on any read/parse failure."""
+    path = policy_path or _POLICY_PATH
+    try:
+        import yaml  # lazy — keep module import-light + yaml-optional
+        with open(path, "r", encoding="utf-8") as fh:
+            data: Any = yaml.safe_load(fh) or {}
+        val = (data.get("cost_optimization", {}) or {}).get("claude_low_cost_model", "")
+        return str(val or "").strip()
+    except Exception:  # noqa: BLE001 — failure-soft
+        return ""
 
 
 def economic_reclassify_enabled() -> bool:
@@ -64,10 +89,17 @@ def micro_op_token_limit() -> int:
         return _DEFAULT_MICRO_OP_TOKENS
 
 
-def economic_failover_model() -> str:
-    """The cheapest Claude tier for micro-op failover — resolved from env, never
-    hardcoded. Empty when unset (caller uses the default fallback provider)."""
-    return (os.getenv(_ENV_FAILOVER_MODEL, "") or "").strip()
+def economic_failover_model(policy_path: Optional[pathlib.Path] = None) -> str:
+    """The cheapest Claude tier for micro-op failover. Resolution order
+    (CLAUDE.md no-hardcode mandate):
+      1. ``JARVIS_ECONOMIC_FAILOVER_MODEL`` env override (operator wins).
+      2. ``brain_selection_policy.yaml`` → ``cost_optimization.claude_low_cost_model``.
+      3. "" (caller composes the default fallback provider).
+    NEVER raises."""
+    env = (os.getenv(_ENV_FAILOVER_MODEL, "") or "").strip()
+    if env:
+        return env
+    return _low_cost_model_from_policy(policy_path)
 
 
 def _allow_mutating_fallback() -> bool:

--- a/backend/core/ouroboros/governance/provider_response_cache.py
+++ b/backend/core/ouroboros/governance/provider_response_cache.py
@@ -79,10 +79,13 @@ _MAX_REPLAY_LINES = 50_000
 
 
 def response_cache_enabled() -> bool:
-    """Master switch, default-FALSE (PRD §7). Re-read each call so a
-    flip hot-reverts. NEVER raises."""
-    return os.environ.get(_ENV_MASTER, "false").strip().lower() in (
-        "1", "true", "yes", "on",
+    """Master switch. **Graduated to default-TRUE (Slice 131)** — the cache is
+    correctness-fail-closed (any git diff re-keys the entry, so a stale repo
+    state can never serve a wrong response) and availability-fail-open, so
+    default-on only ever ELIMINATES redundant identical-context calls. Re-read
+    each call so a flip hot-reverts. NEVER raises."""
+    return os.environ.get(_ENV_MASTER, "true").strip().lower() not in (
+        "0", "false", "no", "off",
     )
 
 

--- a/tests/architecture/test_slice124_economic_router.py
+++ b/tests/architecture/test_slice124_economic_router.py
@@ -11,11 +11,13 @@ from backend.core.ouroboros.governance import economic_router as ER
 from backend.core.ouroboros.governance.economic_router import EconomicAction as A
 
 
-def test_master_default_false(monkeypatch):
+def test_master_default_true_graduated_slice131(monkeypatch):
+    # Slice 131 graduated this to default-TRUE (router only acts on the
+    # provider-failure path, so default-on cannot raise happy-path spend).
     monkeypatch.delenv("JARVIS_ECONOMIC_ROUTER_ENABLED", raising=False)
-    assert ER.economic_router_enabled() is False
-    monkeypatch.setenv("JARVIS_ECONOMIC_ROUTER_ENABLED", "1")
     assert ER.economic_router_enabled() is True
+    monkeypatch.setenv("JARVIS_ECONOMIC_ROUTER_ENABLED", "false")
+    assert ER.economic_router_enabled() is False
 
 
 class TestErrorClassification:
@@ -71,10 +73,14 @@ class TestTokenEstimate:
 
 class TestNoHardcodedModel:
     def test_cheap_model_resolved_from_env(self, monkeypatch):
-        monkeypatch.delenv("JARVIS_ECONOMIC_FAILOVER_MODEL", raising=False)
-        assert ER.economic_failover_model() == ""  # unset → empty (caller defaults)
         monkeypatch.setenv("JARVIS_ECONOMIC_FAILOVER_MODEL", "claude-haiku-4-5-20251001")
         assert ER.economic_failover_model() == "claude-haiku-4-5-20251001"
+
+    def test_cheap_model_resolves_from_policy_when_env_unset(self, monkeypatch):
+        # Slice 131: env-unset now resolves from brain_selection_policy.yaml
+        # (cost_optimization.claude_low_cost_model), not "" — no hardcode in code.
+        monkeypatch.delenv("JARVIS_ECONOMIC_FAILOVER_MODEL", raising=False)
+        assert ER.economic_failover_model()  # non-empty, from policy config
 
 
 class TestDecision:
@@ -85,7 +91,7 @@ class TestDecision:
         monkeypatch.delenv("JARVIS_BACKGROUND_ALLOW_FALLBACK", raising=False)
 
     def test_disabled_is_noop(self, monkeypatch):
-        monkeypatch.delenv("JARVIS_ECONOMIC_ROUTER_ENABLED", raising=False)
+        monkeypatch.setenv("JARVIS_ECONOMIC_ROUTER_ENABLED", "false")  # Slice 131: default is now TRUE
         d = ER.decide(route="background", error_text="http_402", prompt_chars=400, is_read_only=True)
         assert d.action is A.NO_OP
 
@@ -123,9 +129,11 @@ class TestDecision:
         d = ER.decide(route="standard", error_text="http_402", prompt_chars=400, is_read_only=True)
         assert d.action is A.NO_OP  # STANDARD already cascades by policy
 
-    def test_cheap_model_empty_when_env_unset(self, monkeypatch):
+    def test_cheap_model_from_policy_when_env_unset(self, monkeypatch):
+        # Slice 131: env-unset now resolves the cheap tier from the policy YAML
+        # (non-empty), so the cascade carries a concrete cheap model.
         monkeypatch.setenv("JARVIS_ECONOMIC_ROUTER_ENABLED", "1")
         monkeypatch.delenv("JARVIS_ECONOMIC_FAILOVER_MODEL", raising=False)
         d = ER.decide(route="background", error_text="http_402", prompt_chars=400, is_read_only=True)
         assert d.action is A.CASCADE_CHEAP
-        assert d.model == ""  # caller composes the default fallback provider
+        assert d.model  # resolved from brain_selection_policy.yaml (non-empty)

--- a/tests/architecture/test_slice131_cost_sovereign_p1.py
+++ b/tests/architecture/test_slice131_cost_sovereign_p1.py
@@ -1,0 +1,104 @@
+"""Slice 131 Phase 1 — activate the dormant cost substrate + no-hardcode failover.
+
+The cost audit found two high-ROI features built but switched OFF:
+  * Provider Response Cache (exact-match, repo-state-keyed, fail-closed on git
+    diff) — 100% savings on repeat calls.
+  * Economic Router (cheap-tier failover on DW 402/429) — 70-80% on micro-ops.
+
+Both are graduated to default-TRUE here (response cache is correctness-fail-closed;
+economic router only fires on the provider-failure path), and the economic
+failover model is refactored to resolve from ``brain_selection_policy.yaml``
+(env override wins) instead of requiring a hardcoded/env-only value (CLAUDE.md
+no-hardcoded-models mandate).
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import tempfile
+import unittest
+
+from backend.core.ouroboros.governance import economic_router as ER
+from backend.core.ouroboros.governance import provider_response_cache as PRC
+
+
+class TestGraduatedDefaults(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = {
+            k: os.environ.get(k)
+            for k in ("JARVIS_ECONOMIC_ROUTER_ENABLED",
+                      "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED")
+        }
+        for k in self._saved:
+            os.environ.pop(k, None)
+
+    def tearDown(self) -> None:
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_economic_router_default_true(self) -> None:
+        self.assertTrue(ER.economic_router_enabled())
+
+    def test_provider_response_cache_default_true(self) -> None:
+        self.assertTrue(PRC.response_cache_enabled())
+
+    def test_both_still_hot_revertible(self) -> None:
+        os.environ["JARVIS_ECONOMIC_ROUTER_ENABLED"] = "false"
+        os.environ["JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED"] = "0"
+        self.assertFalse(ER.economic_router_enabled())
+        self.assertFalse(PRC.response_cache_enabled())
+
+
+class TestFailoverModelResolution(unittest.TestCase):
+    def setUp(self) -> None:
+        self._prev = os.environ.get("JARVIS_ECONOMIC_FAILOVER_MODEL")
+        os.environ.pop("JARVIS_ECONOMIC_FAILOVER_MODEL", None)
+
+    def tearDown(self) -> None:
+        if self._prev is None:
+            os.environ.pop("JARVIS_ECONOMIC_FAILOVER_MODEL", None)
+        else:
+            os.environ["JARVIS_ECONOMIC_FAILOVER_MODEL"] = self._prev
+
+    def test_env_override_wins(self) -> None:
+        os.environ["JARVIS_ECONOMIC_FAILOVER_MODEL"] = "claude-opus-4-8"
+        self.assertEqual(ER.economic_failover_model(), "claude-opus-4-8")
+
+    def test_resolves_from_policy_when_env_unset(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            policy = pathlib.Path(d) / "brain_selection_policy.yaml"
+            policy.write_text(
+                "cost_optimization:\n  claude_low_cost_model: claude-haiku-4-5\n"
+            )
+            self.assertEqual(
+                ER.economic_failover_model(policy_path=policy),
+                "claude-haiku-4-5",
+            )
+
+    def test_no_hardcoded_model_string_in_module(self) -> None:
+        # The CLAUDE.md no-hardcode mandate: the .py must not embed a concrete
+        # claude-* model id. The default lives in the YAML config, not code.
+        src = pathlib.Path(
+            "backend/core/ouroboros/governance/economic_router.py"
+        ).read_text()
+        self.assertNotIn("claude-haiku", src)
+        self.assertNotIn("claude-sonnet", src)
+        self.assertNotIn("claude-opus", src)
+        self.assertNotIn("claude-3-5", src)
+
+    def test_missing_policy_is_safe_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            missing = pathlib.Path(d) / "nope.yaml"
+            self.assertEqual(ER.economic_failover_model(policy_path=missing), "")
+
+    def test_live_policy_has_low_cost_model(self) -> None:
+        # The real brain_selection_policy.yaml must define the cheap tier so
+        # env-unset deployments still get a failover model (not empty).
+        self.assertTrue(ER.economic_failover_model())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Slice 131 — The Cost Sovereign Matrix (Phase 1 of 5)

A verify-first cost/token audit (+ 2026 LLM-cost research) found two high-ROI features **built but switched OFF** — the money being burned. Phase 1 activates them and fixes a no-hardcode violation. Phases 2a (tool-block caching), 2b (Claude Batch API 50%), 3 (semantic response cache), 4 (FrugalGPT cascade) follow as their own PRs.

### What this PR does
- **Graduate `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED` → default-TRUE.** Exact-match, repo-state-keyed cache; **correctness-fail-closed** (any git diff re-keys, so a stale repo can never serve a wrong response), availability-fail-open → default-on only eliminates redundant identical-context calls. ~100% savings on repeats.
- **Graduate `JARVIS_ECONOMIC_ROUTER_ENABLED` → default-TRUE.** Only acts on the provider-**failure** path (DW 402/429), so default-on cannot raise happy-path spend — it adds a cheap-tier failover instead of a hard stall. 70-80% on background micro-ops.
- **No-hardcode refactor (CLAUDE.md mandate):** `economic_failover_model()` now resolves the cheap Claude tier from `brain_selection_policy.yaml` (`cost_optimization.claude_low_cost_model = claude-haiku-4-5` — `claude-3-5-haiku` is **retired**), with `JARVIS_ECONOMIC_FAILOVER_MODEL` env override winning. The .py embeds **no** `claude-*` string (pinned by test).

Both flags hot-revertible (`=false`). Verified live: router on, cache on, failover resolves to `claude-haiku-4-5` from policy.

### Tests
36 green — `test_slice131_cost_sovereign_p1.py` (8 new) + `test_slice124_economic_router.py` (updated for graduated defaults + policy resolution) + Slice 127 reclassify regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the provider response cache and economic router by default to cut repeat-call costs and add cheap-tier failover on provider errors. Move the failover model into policy so it’s configurable; env override still works.

- **New Features**
  - Response cache now default true. Exact-match, repo-state-keyed; fail-closed on git diff; availability fail-open. Hot-revert with `JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED=false`.
  - Economic router now default true. Triggers only on 402/429 failure path; adds cheap-tier failover; no change to happy-path spend. Hot-revert with `JARVIS_ECONOMIC_ROUTER_ENABLED=false`.

- **Refactors**
  - `economic_failover_model()` reads from `brain_selection_policy.yaml` at `cost_optimization.claude_low_cost_model` (claude-haiku-4-5). `JARVIS_ECONOMIC_FAILOVER_MODEL` env override wins. No `claude-*` strings in code.

<sup>Written for commit 4067cbe5953da4776d2a2501436985107d77b402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

