### PR TITLE
Slice 131 P4 — The CAI Autonomous Router (FrugalGPT cascade for O+V)

### DIFF
--- a/backend/core/ouroboros/governance/brain_selection_policy.yaml
+++ b/backend/core/ouroboros/governance/brain_selection_policy.yaml
@@ -306,6 +306,11 @@ gates:
 # ---------------------------------------------------------------------------
 cost_optimization:
   claude_low_cost_model: "claude-haiku-4-5"
+  # Slice 131 Phase 4 — the CAI Autonomous Router cheapest->heaviest provider
+  # ladder. Tier NAMES are structural identifiers (cai_router resolves each:
+  # doubleword->DW topology, claude_low_cost->claude_low_cost_model above,
+  # claude_heavy->provider default). Reorder/extend here, never in code.
+  cascade_tiers: ["doubleword", "claude_low_cost", "claude_heavy"]
 
 # ---------------------------------------------------------------------------
 # Provider Topology — Hard-segmented DW model mapping (Manifesto §5)

--- a/backend/core/ouroboros/governance/cai_router.py
+++ b/backend/core/ouroboros/governance/cai_router.py
@@ -1,0 +1,297 @@
+"""Slice 131 Phase 4 — The CAI Autonomous Router (FrugalGPT cascade for O+V).
+
+The "Cursor-auto" for O+V: autonomously pick the cheapest CAPABLE provider tier
+per op, escalating to heavyweights only when the model signals high difficulty or
+low confidence — with situational awareness acting as a cost-guard.
+
+This module is **pure composition** of substrate that already exists — it builds
+nothing the codebase already has:
+
+  * **CAI** (Contextual Awareness Intelligence) — ``ContextAwarenessIntelligence
+    .predict_intent`` is a cheap, synchronous, deterministic intent+confidence
+    scorer (no LLM call). It supplies the per-op **confidence** signal.
+  * **SAI** (Self-Aware Intelligence) — ``SelfAwareIntelligence.get_cognitive_state``
+    supplies a **situational pressure** signal. Under high pressure the router
+    suppresses confidence-driven escalation (cost-guard): only genuine *difficulty*
+    is allowed to climb the ladder, so a strained system never burns extra money
+    chasing low-confidence escalations.
+  * **tiers** — the cheapest→heaviest provider ladder is resolved from
+    ``brain_selection_policy.yaml`` (``cost_optimization.cascade_tiers``); the
+    cheap Claude tier's model reuses Phase-1 ``economic_router`` policy resolution.
+    **No model string is hardcoded in this module** (CLAUDE.md mandate).
+  * **failover** — when the chosen cheap tier 402/429s, the existing
+    ``economic_router`` matrix (Phase 1, default-on) owns the recovery. This
+    module decides the *first* tier; economic_router decides the *fallback*.
+
+**Decoupled + injectable.** ``decide`` accepts an injected ``classifier`` and
+``sai_probe`` (sync or async) so the hot path / tests never depend on the heavy
+CAI/SAI init. **Fail-closed:** any error → ``None`` → the caller keeps the
+existing ``UrgencyRouter`` path. **Gated** ``JARVIS_CAI_ROUTER_ENABLED``
+default-FALSE → OFF is byte-identical. **Adaptive:** ``record_outcome`` tunes the
+confidence threshold from observed escalation need (self-tuning).
+"""
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import os
+import pathlib
+from typing import Any, Awaitable, Callable, List, Optional, Union
+
+# ── env knobs ───────────────────────────────────────────────────────────────
+_ENV_MASTER = "JARVIS_CAI_ROUTER_ENABLED"
+_ENV_THRESHOLD = "JARVIS_CAI_CONFIDENCE_THRESHOLD"
+_DEFAULT_THRESHOLD = 0.5
+_THRESHOLD_FLOOR = 0.10
+_THRESHOLD_CEIL = 0.95
+_ADAPT_STEP = 0.01  # per-outcome EWMA nudge
+
+# Default cheapest→heaviest tier ladder (NAMES are structural identifiers, not
+# model strings — the concrete models resolve from the policy / providers).
+_DEFAULT_LADDER = ["doubleword", "claude_low_cost", "claude_heavy"]
+_POLICY_PATH = pathlib.Path(__file__).parent / "brain_selection_policy.yaml"
+
+# Adaptive state (module-level, fail-soft). reset_adaptive_state() for tests.
+_adaptive_offset = 0.0
+
+
+def cai_router_enabled() -> bool:
+    """Master gate, default-FALSE per §33.1. Re-read each call so a flip
+    hot-reverts. NEVER raises."""
+    return os.getenv(_ENV_MASTER, "false").strip().lower() in ("1", "true", "yes", "on")
+
+
+# ── signals ─────────────────────────────────────────────────────────────────
+@dataclasses.dataclass(frozen=True)
+class CAIClassification:
+    """The CAI difficulty + confidence signal for one op.
+
+    ``difficulty`` ∈ {low, medium, high}; ``confidence`` ∈ [0, 1]."""
+
+    difficulty: str = "medium"
+    confidence: float = 0.5
+
+
+@dataclasses.dataclass(frozen=True)
+class SituationalSignal:
+    """The SAI situational signal. ``pressure`` ∈ {nominal, elevated, high}."""
+
+    pressure: str = "nominal"
+
+
+@dataclasses.dataclass(frozen=True)
+class CAIRoutingDecision:
+    """The autonomous routing decision. ``tier`` is a ladder name; ``model`` is
+    the resolved concrete model for tiers that need one ("" → provider default)."""
+
+    tier: str
+    model: str
+    difficulty: str
+    confidence: float
+    escalated: bool          # final tier is above the cheapest rung
+    reason: str
+    situational_pressure: str
+
+
+# ── threshold (adaptive) ────────────────────────────────────────────────────
+def confidence_threshold() -> float:
+    """Confidence below which the router escalates one extra rung. Base from env,
+    nudged by ``record_outcome`` (self-tuning). Clamped. NEVER raises."""
+    try:
+        base = float(os.getenv(_ENV_THRESHOLD, _DEFAULT_THRESHOLD))
+    except (TypeError, ValueError):
+        base = _DEFAULT_THRESHOLD
+    return max(_THRESHOLD_FLOOR, min(_THRESHOLD_CEIL, base + _adaptive_offset))
+
+
+def record_outcome(escalation_was_needed: bool) -> None:
+    """Feed back whether an escalation turned out warranted. If escalations are
+    frequently needed, raise the threshold so the router escalates more readily
+    next time (and vice-versa). EWMA-style, bounded. NEVER raises."""
+    global _adaptive_offset
+    try:
+        delta = _ADAPT_STEP if escalation_was_needed else -_ADAPT_STEP
+        _adaptive_offset = max(-0.4, min(0.4, _adaptive_offset + delta))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def reset_adaptive_state() -> None:
+    """Reset the adaptive offset (tests / clean boot)."""
+    global _adaptive_offset
+    _adaptive_offset = 0.0
+
+
+# ── tier ladder + model resolution (policy-driven, no hardcode) ──────────────
+def cascade_tiers(policy_path: Optional[pathlib.Path] = None) -> List[str]:
+    """Cheapest→heaviest provider ladder from
+    ``brain_selection_policy.yaml`` (``cost_optimization.cascade_tiers``).
+    Falls back to the default ladder. NEVER raises."""
+    path = policy_path or _POLICY_PATH
+    try:
+        import yaml
+        with open(path, "r", encoding="utf-8") as fh:
+            data: Any = yaml.safe_load(fh) or {}
+        tiers = (data.get("cost_optimization", {}) or {}).get("cascade_tiers")
+        if isinstance(tiers, list) and tiers:
+            return [str(t) for t in tiers]
+    except Exception:  # noqa: BLE001
+        pass
+    return list(_DEFAULT_LADDER)
+
+
+def tier_model(tier: str, policy_path: Optional[pathlib.Path] = None) -> str:
+    """Resolve the concrete model for a tier. The cheap Claude tier composes the
+    Phase-1 ``economic_router`` policy resolution (env override → policy →
+    ""). DW / heavy-Claude return "" (the provider picks its own model). NO model
+    string is hardcoded here. NEVER raises."""
+    try:
+        if tier == "claude_low_cost":
+            from backend.core.ouroboros.governance.economic_router import (
+                economic_failover_model,
+            )
+            return economic_failover_model(policy_path)
+    except Exception:  # noqa: BLE001
+        return ""
+    return ""
+
+
+# ── default adapters (compose the real CAI / SAI, fail-soft) ─────────────────
+_DIFFICULTY_FROM_COMPLEXITY = {
+    "trivial": "low", "simple": "low", "light": "low",
+    "moderate": "medium", "medium": "medium",
+    "heavy_code": "high", "complex": "high", "architectural": "high",
+}
+
+
+def classify_default(prompt: str, context: Any) -> CAIClassification:
+    """Default classifier: difficulty from the op's existing ``task_complexity``
+    (O+V already computes it), confidence from CAI ``predict_intent``. Fail-soft
+    to medium/0.5 so a missing CAI never blocks routing."""
+    difficulty = "medium"
+    raw = str(getattr(context, "task_complexity", "") or "").strip().lower()
+    if raw in _DIFFICULTY_FROM_COMPLEXITY:
+        difficulty = _DIFFICULTY_FROM_COMPLEXITY[raw]
+    confidence = 0.5
+    try:
+        from backend.intelligence.context_awareness_intelligence import (
+            ContextAwarenessIntelligence,
+        )
+        cai = ContextAwarenessIntelligence()
+        pred = cai.predict_intent(prompt or "")
+        confidence = float(pred.get("confidence", 0.5))
+    except Exception:  # noqa: BLE001
+        pass
+    return CAIClassification(difficulty=difficulty, confidence=confidence)
+
+
+def probe_situational_default() -> SituationalSignal:
+    """Default SAI probe: derive situational pressure from
+    ``SelfAwareIntelligence.get_cognitive_state``. Fail-soft to nominal."""
+    try:
+        from backend.intelligence.self_aware_intelligence import (
+            SelfAwareIntelligence,
+        )
+        sai = SelfAwareIntelligence()
+        state = sai.get_cognitive_state() or {}
+        raw = str(
+            state.get("pressure")
+            or state.get("memory_pressure")
+            or state.get("situational_pressure")
+            or "nominal"
+        ).strip().lower()
+        if raw in ("high", "critical", "severe"):
+            return SituationalSignal("high")
+        if raw in ("elevated", "warning", "moderate"):
+            return SituationalSignal("elevated")
+    except Exception:  # noqa: BLE001
+        pass
+    return SituationalSignal("nominal")
+
+
+# ── the cascade decision ─────────────────────────────────────────────────────
+_DIFFICULTY_RUNG = {"low": 0, "medium": 1, "high": 2}
+
+_Classifier = Callable[[str, Any], Union[CAIClassification, Awaitable[CAIClassification]]]
+_SaiProbe = Callable[[], Union[SituationalSignal, Awaitable[SituationalSignal]]]
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def decide(
+    prompt: str,
+    context: Any,
+    *,
+    classifier: Optional[_Classifier] = None,
+    sai_probe: Optional[_SaiProbe] = None,
+    policy_path: Optional[pathlib.Path] = None,
+) -> Optional[CAIRoutingDecision]:
+    """Autonomously choose the first provider tier for an op (FrugalGPT cascade).
+
+    Returns ``None`` when disabled OR on ANY error (fail-closed → the caller
+    keeps the existing route). When enabled: difficulty (CAI) sets the base rung;
+    low confidence (CAI, vs the adaptive threshold) bumps one rung UP — but only
+    when SAI situational pressure is not ``high`` (cost-guard). The chosen tier's
+    concrete model is resolved from policy. ``economic_router`` owns failover.
+    """
+    if not cai_router_enabled():
+        return None
+    try:
+        cls = await _maybe_await((classifier or classify_default)(prompt, context))
+        sai = await _maybe_await((sai_probe or probe_situational_default)())
+        if not isinstance(cls, CAIClassification):
+            return None
+        if not isinstance(sai, SituationalSignal):
+            sai = SituationalSignal("nominal")
+
+        tiers = cascade_tiers(policy_path)
+        if not tiers:
+            return None
+        top = len(tiers) - 1
+
+        base = min(_DIFFICULTY_RUNG.get(cls.difficulty, 1), top)
+        rung = base
+        cost_guard = sai.pressure == "high"
+        confidence_bump = cls.confidence < confidence_threshold()
+        if confidence_bump and not cost_guard:
+            rung = min(rung + 1, top)
+
+        tier = tiers[rung]
+        model = tier_model(tier, policy_path)
+        reason = (
+            f"difficulty={cls.difficulty} confidence={cls.confidence:.2f} "
+            f"thr={confidence_threshold():.2f} sai={sai.pressure} "
+            f"rung={rung}/{top} -> {tier}"
+            + (" [cost-guard suppressed bump]" if (confidence_bump and cost_guard) else "")
+        )
+        return CAIRoutingDecision(
+            tier=tier,
+            model=model,
+            difficulty=cls.difficulty,
+            confidence=cls.confidence,
+            escalated=rung > 0,
+            reason=reason,
+            situational_pressure=sai.pressure,
+        )
+    except Exception:  # noqa: BLE001 — fail-closed
+        return None
+
+
+__all__ = [
+    "cai_router_enabled",
+    "CAIClassification",
+    "SituationalSignal",
+    "CAIRoutingDecision",
+    "confidence_threshold",
+    "record_outcome",
+    "reset_adaptive_state",
+    "cascade_tiers",
+    "tier_model",
+    "classify_default",
+    "probe_situational_default",
+    "decide",
+]

--- a/backend/core/ouroboros/governance/route_decision_service.py
+++ b/backend/core/ouroboros/governance/route_decision_service.py
@@ -71,6 +71,7 @@ class RouteDecisionService:
         self._brain_selector = brain_selector or BrainSelector()
         self._selector: Optional[Any] = None  # lazy-init IntelligentModelSelector
         self._sai: Optional[Any] = None       # lazy-init SelfAwareIntelligence
+        self._last_cai_tier: Optional[Any] = None  # Slice 131 P4 — last CAI tier (observability)
 
     def _get_selector(self) -> Optional[Any]:
         """Lazy-init IntelligentModelSelector to avoid circular imports at module load."""
@@ -117,6 +118,38 @@ class RouteDecisionService:
             logger.debug("[RouteDecision] SAI health check skipped: %s", exc)
         return False
 
+    async def cai_tier_advisory(
+        self, description: str, complexity_hint: str = "",
+    ) -> Optional[Any]:
+        """Slice 131 Phase 4 — gated SHADOW consult of the CAI Autonomous Router.
+
+        Composes the cheapest-capable provider-tier cascade (CAI difficulty +
+        confidence, SAI situational cost-guard, policy-driven tier ladder, with
+        economic_router owning failover downstream). **Advisory only** — it does
+        NOT override brain selection yet; enforce is the documented follow-on
+        once shadow telemetry validates the tier choices. Stored on
+        ``self._last_cai_tier`` for observability. Gated
+        ``JARVIS_CAI_ROUTER_ENABLED`` default-FALSE → OFF is byte-identical (not
+        even invoked). Fail-closed: any error → ``None``. NEVER raises."""
+        self._last_cai_tier = None
+        try:
+            from backend.core.ouroboros.governance import cai_router
+            if not cai_router.cai_router_enabled():
+                return None
+            ctx = type("_CAICtx", (), {"task_complexity": str(complexity_hint or "")})()
+            decision = await cai_router.decide(description or "", ctx)
+            self._last_cai_tier = decision
+            if decision is not None:
+                logger.info(
+                    "[CAIRouter] shadow tier=%s model=%s escalated=%s | %s",
+                    decision.tier, decision.model or "-",
+                    decision.escalated, decision.reason,
+                )
+            return decision
+        except Exception as exc:  # noqa: BLE001 — fail-closed
+            logger.debug("[CAIRouter] shadow consult skipped: %s", exc)
+            return None
+
     async def select(
         self,
         description: str,
@@ -136,6 +169,13 @@ class RouteDecisionService:
         logger.debug(
             "[RouteDecision] intent=%s complexity=%s brain_override=%s",
             intent, complexity.value if complexity else None, brain_override,
+        )
+
+        # Slice 131 P4 — gated SHADOW consult of the CAI Autonomous Router.
+        # Advisory/observable only (does not alter the selection below); OFF
+        # (default) is byte-identical — the method early-returns before any work.
+        await self.cai_tier_advisory(
+            description, complexity.value if complexity else "",
         )
 
         # If intent classified successfully, override Layer-1 result

--- a/tests/architecture/test_slice131_cai_router.py
+++ b/tests/architecture/test_slice131_cai_router.py
@@ -1,0 +1,178 @@
+"""Slice 131 Phase 4 — the CAI Autonomous Router (FrugalGPT cascade for O+V).
+
+"Cursor-auto for O+V": pick the cheapest CAPABLE provider tier per op, escalating
+to heavyweights only when CAI signals high difficulty / low confidence — with SAI
+acting as a situational cost-guard (under high system pressure, suppress
+confidence-driven escalation to conserve spend).
+
+Composition (verify-first — do NOT rebuild):
+  * CAI  — ContextAwarenessIntelligence.predict_intent (cheap, sync, deterministic
+           intent+confidence scorer) → the difficulty/confidence signal.
+  * SAI  — SelfAwareIntelligence.get_cognitive_state → situational pressure.
+  * tiers — resolved from brain_selection_policy.yaml (no hardcoded models);
+            the cheap Claude tier reuses Phase-1 economic_failover_model.
+  * failover — the existing economic_router (downstream, on 402/429).
+
+Gated JARVIS_CAI_ROUTER_ENABLED default-FALSE; fail-closed (any error → None →
+caller keeps the existing UrgencyRouter path). OFF must be byte-identical.
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import os
+import pathlib
+import unittest
+
+from backend.core.ouroboros.governance import cai_router as CR
+
+
+@dataclasses.dataclass
+class _Ctx:
+    task_complexity: str = ""
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestGate(unittest.TestCase):
+    def setUp(self) -> None:
+        self._prev = os.environ.get("JARVIS_CAI_ROUTER_ENABLED")
+        os.environ.pop("JARVIS_CAI_ROUTER_ENABLED", None)
+
+    def tearDown(self) -> None:
+        if self._prev is None:
+            os.environ.pop("JARVIS_CAI_ROUTER_ENABLED", None)
+        else:
+            os.environ["JARVIS_CAI_ROUTER_ENABLED"] = self._prev
+
+    def test_default_false(self) -> None:
+        self.assertFalse(CR.cai_router_enabled())
+
+    def test_disabled_decide_returns_none(self) -> None:
+        # OFF byte-identical: caller falls back to the existing route path.
+        out = _run(CR.decide("add a function", _Ctx(),
+                             classifier=lambda p, c: CR.CAIClassification("high", 0.1)))
+        self.assertIsNone(out)
+
+
+class TestCascade(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["JARVIS_CAI_ROUTER_ENABLED"] = "1"
+        CR.reset_adaptive_state()
+
+    def tearDown(self) -> None:
+        os.environ.pop("JARVIS_CAI_ROUTER_ENABLED", None)
+        CR.reset_adaptive_state()
+
+    def _decide(self, difficulty, confidence, pressure="nominal"):
+        return _run(CR.decide(
+            "do a thing", _Ctx(),
+            classifier=lambda p, c: CR.CAIClassification(difficulty, confidence),
+            sai_probe=lambda: CR.SituationalSignal(pressure),
+        ))
+
+    def test_low_difficulty_high_confidence_uses_cheapest(self) -> None:
+        d = self._decide("low", 0.95)
+        self.assertEqual(d.tier, "doubleword")     # cheapest rung
+        self.assertFalse(d.escalated)
+
+    def test_high_difficulty_escalates_to_heavy(self) -> None:
+        d = self._decide("high", 0.95)
+        self.assertEqual(d.tier, "claude_heavy")   # top rung
+        self.assertTrue(d.escalated)
+
+    def test_low_confidence_bumps_one_rung(self) -> None:
+        # low difficulty but the model is unsure → escalate one rung up.
+        d = self._decide("low", 0.05)
+        self.assertEqual(d.tier, "claude_low_cost")
+        self.assertTrue(d.escalated)
+
+    def test_sai_high_pressure_suppresses_confidence_bump(self) -> None:
+        # Same low-confidence op, but the system is under high situational
+        # pressure → cost-guard keeps it on the cheapest tier.
+        d = self._decide("low", 0.05, pressure="high")
+        self.assertEqual(d.tier, "doubleword")
+        self.assertFalse(d.escalated)
+
+    def test_difficulty_escalation_survives_cost_guard(self) -> None:
+        # The cost-guard only suppresses CONFIDENCE bumps, not genuine
+        # difficulty — a hard op still gets the capable tier under pressure.
+        d = self._decide("high", 0.95, pressure="high")
+        self.assertEqual(d.tier, "claude_heavy")
+
+    def test_claude_low_cost_model_resolves_from_policy(self) -> None:
+        d = self._decide("medium", 0.95)
+        self.assertEqual(d.tier, "claude_low_cost")
+        self.assertTrue(d.model)  # resolved from brain_selection_policy.yaml
+
+    def test_fail_closed_on_classifier_error(self) -> None:
+        def _boom(p, c):
+            raise RuntimeError("classifier exploded")
+        out = _run(CR.decide("x", _Ctx(), classifier=_boom))
+        self.assertIsNone(out)  # fail-closed → caller keeps existing path
+
+    def test_async_classifier_and_probe_awaited(self) -> None:
+        async def _acls(p, c):
+            return CR.CAIClassification("high", 0.9)
+        async def _asai():
+            return CR.SituationalSignal("nominal")
+        d = _run(CR.decide("x", _Ctx(), classifier=_acls, sai_probe=_asai))
+        self.assertEqual(d.tier, "claude_heavy")
+
+    def test_record_outcome_tunes_threshold(self) -> None:
+        base = CR.confidence_threshold()
+        for _ in range(20):
+            CR.record_outcome(escalation_was_needed=True)
+        self.assertGreater(CR.confidence_threshold(), base)  # escalate more readily
+
+
+class TestRouteDecisionFusion(unittest.TestCase):
+    """The gated SHADOW consult fused into RouteDecisionService.select() — it
+    surfaces the CAI tier decision (advisory/observable), byte-identical when
+    OFF, never overriding brain selection (enforce = documented follow-on)."""
+
+    def setUp(self) -> None:
+        from backend.core.ouroboros.governance.route_decision_service import (
+            RouteDecisionService,
+        )
+        from backend.core.ouroboros.governance.brain_selector import BrainSelector
+        self.svc = RouteDecisionService(BrainSelector())
+        CR.reset_adaptive_state()
+
+    def tearDown(self) -> None:
+        os.environ.pop("JARVIS_CAI_ROUTER_ENABLED", None)
+        CR.reset_adaptive_state()
+
+    def test_advisory_none_when_disabled(self) -> None:
+        os.environ.pop("JARVIS_CAI_ROUTER_ENABLED", None)
+        out = _run(self.svc.cai_tier_advisory("refactor the module", "heavy_code"))
+        self.assertIsNone(out)
+        self.assertIsNone(self.svc._last_cai_tier)
+
+    def test_advisory_decides_and_stores_when_enabled(self) -> None:
+        os.environ["JARVIS_CAI_ROUTER_ENABLED"] = "1"
+        out = _run(self.svc.cai_tier_advisory("refactor the module", "heavy_code"))
+        self.assertIsNotNone(out)
+        self.assertEqual(out.tier, "claude_heavy")        # high difficulty
+        self.assertIs(self.svc._last_cai_tier, out)        # observable
+
+    def test_advisory_fail_closed(self) -> None:
+        os.environ["JARVIS_CAI_ROUTER_ENABLED"] = "1"
+        # A None description must not raise — fail-soft to a decision or None.
+        out = _run(self.svc.cai_tier_advisory(None, ""))
+        self.assertTrue(out is None or isinstance(out, CR.CAIRoutingDecision))
+
+
+class TestNoHardcode(unittest.TestCase):
+    def test_no_claude_model_string_in_module(self) -> None:
+        src = pathlib.Path(
+            "backend/core/ouroboros/governance/cai_router.py"
+        ).read_text()
+        for banned in ("claude-haiku", "claude-sonnet", "claude-opus", "claude-3-5"):
+            self.assertNotIn(banned, src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Clean Phase-4-only branch off current main (`2f24591f93`). Supersedes #69342.

The 'Cursor-auto' for O+V: autonomously picks the cheapest **capable** provider tier per op, escalating to heavyweights only on CAI high-difficulty / low-confidence. **Pure composition** — nothing rebuilt.

- **`cai_router.py` (NEW):** CAI (`predict_intent` intent+confidence) + SAI (`get_cognitive_state` situational **cost-guard** — high pressure suppresses confidence escalation) + policy-driven cheapest→heaviest tier ladder (`cost_optimization.cascade_tiers`; cheap-Claude reuses Phase-1 `economic_failover_model`) + `economic_router` failover downstream. `decide()` async/injectable/fail-closed/adaptive. Master `JARVIS_CAI_ROUTER_ENABLED` **default-FALSE**. No hardcoded model (pinned).
- **Fusion:** gated SHADOW consult (`cai_tier_advisory`) in `RouteDecisionService.select()` — observable, byte-identical OFF, enforce = follow-on after shadow validation.
- **15 new tests green.**

> Pre-existing (out of scope): 6 `test_route_decision_service` `_INTENT_TO_BRAIN` failures fail identically on clean HEAD — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the CAI Autonomous Router to pick the cheapest capable provider tier per operation using CAI difficulty/confidence and a SAI cost-guard. Runs in shadow mode by default with no behavior change; enforcement will follow.

- **New Features**
  - Added `cai_router.py`: async `decide()` composes CAI + SAI, reads `cost_optimization.cascade_tiers` from policy, resolves `claude_low_cost` via `economic_router`, fail-closed, adaptive confidence threshold, and no hardcoded model strings.
  - `RouteDecisionService.select()` now performs a gated shadow consult via `cai_tier_advisory`, logs tier + reason, and stores `self._last_cai_tier` (advisory only).
  - Policy update: added `cost_optimization.cascade_tiers: ["doubleword", "claude_low_cost", "claude_heavy"]`; 15 tests cover ladder, cost-guard, async adapters, and adaptivity.

- **Migration**
  - To enable shadow mode: set `JARVIS_CAI_ROUTER_ENABLED=1` (default is off).
  - To change the ladder: edit `brain_selection_policy.yaml` `cost_optimization.cascade_tiers` (no code changes required).

<sup>Written for commit 103c0cfc4d7be98212ca7c677ee9fe408bd8152e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

