### PR TITLE
Slice 131 P3 — The Asynchronous Semantic Response Cache

### DIFF
--- a/backend/core/ouroboros/governance/provider_response_cache.py
+++ b/backend/core/ouroboros/governance/provider_response_cache.py
@@ -136,11 +136,12 @@ def _cache_path() -> Path:
 
 
 class CacheLookupOutcome(str, enum.Enum):
-    """Closed taxonomy. ``SEMANTIC_HIT`` is RESERVED for the S1.x
-    semantic tier and is never produced in v1 (exact-only)."""
+    """Closed taxonomy. ``SEMANTIC_HIT`` is produced by the Slice 131 Phase 3
+    semantic tier (``semantic_cache``) — a strict-cosine near-match served on
+    exact-key MISS, gated by ``JARVIS_SEMANTIC_CACHE_ENABLED`` (default-FALSE)."""
 
     EXACT_HIT = "exact_hit"
-    SEMANTIC_HIT = "semantic_hit"            # reserved (S1.x)
+    SEMANTIC_HIT = "semantic_hit"            # Slice 131 P3 — near-match tier
     MISS = "miss"
     DISABLED = "disabled"
     INVALIDATED_REPO_CHANGE = "invalidated_repo_change"
@@ -583,6 +584,32 @@ async def cached_or_generate(
     except Exception as exc:  # noqa: BLE001 — fail-open
         logger.debug("[PRC] gate fault (fail-open): %s", exc)
         return await produce(), CacheLookupOutcome.FAULT_FAIL_OPEN
+
+    # Slice 131 P3 — semantic near-match interception (composes this substrate).
+    # On exact-key MISS, a strict-cosine near-match returns the cached response
+    # BEFORE paying for generation. Gated (JARVIS_SEMANTIC_CACHE_ENABLED,
+    # default-FALSE) + fail-closed (any fault → fall through to produce()).
+    # Skipped under exact-cache shadow mode (passthrough integrity) and on
+    # SHADOW_HIT_PASSTHROUGH (entry already exists at the exact key).
+    if not shadow and outcome is not CacheLookupOutcome.SHADOW_HIT_PASSTHROUGH:
+        try:
+            from backend.core.ouroboros.governance.semantic_cache import (
+                semantic_cache_enabled as _sem_enabled,
+                semantic_cache_lookup as _sem_lookup,
+            )
+            if _sem_enabled():
+                _sem_traj = await _sem_lookup(str(prompt), repo_root)
+                if _sem_traj is not None:
+                    _sem_gr = reconstruct_generation_result(_sem_traj)
+                    if _sem_gr is not None:
+                        logger.info(
+                            "[PRC] SEMANTIC_HIT — provider skipped, $0.00 "
+                            "(model=%s route=%s)", model, route,
+                        )
+                        return _sem_gr, CacheLookupOutcome.SEMANTIC_HIT
+        except Exception as exc:  # noqa: BLE001 — fail-closed → produce()
+            logger.debug("[PRC] semantic gate fault (fail-open): %s", exc)
+
     # Miss / invalidated / reconstruction-failed / SHADOW_HIT_PASSTHROUGH
     # → real generation, then best-effort store (store-omission is
     # fail-safe). On SHADOW_HIT_PASSTHROUGH the entry already exists at
@@ -598,6 +625,18 @@ async def cached_or_generate(
         ):
             t = _trajectory_from_generation_result(full, pref, gr)
             get_default_cache().store(t)
+            # Slice 131 P3 — write-through into the semantic cache so the next
+            # cycle can near-match this novel generation. Gated + fail-soft
+            # (store-omission never blocks the return).
+            try:
+                from backend.core.ouroboros.governance.semantic_cache import (
+                    semantic_cache_enabled as _sem_enabled2,
+                    semantic_cache_store as _sem_store,
+                )
+                if t is not None and _sem_enabled2():
+                    await _sem_store(str(prompt), t, repo_root)
+            except Exception as exc:  # noqa: BLE001 — write-through never blocks
+                logger.debug("[PRC] semantic write-through skipped: %s", exc)
     except Exception as exc:  # noqa: BLE001 — store never blocks
         logger.debug("[PRC] post-store skipped: %s", exc)
     return gr, outcome

--- a/backend/core/ouroboros/governance/semantic_cache.py
+++ b/backend/core/ouroboros/governance/semantic_cache.py
@@ -1,0 +1,270 @@
+"""Slice 131 Phase 3 — The Asynchronous Semantic Response Cache.
+
+Closes the near-match gap the exact-match ``provider_response_cache`` (Phase 1)
+cannot: two prompts expressing the *same intent* in different words hash to
+different keys and miss. This layer vectorizes the prompt and serves a cached
+response when a recent entry crosses a strict cosine threshold.
+
+**Pure composition — nothing reinvented:**
+  * Vectorization: ``semantic_index._embedder_factory`` (the dormant fastembed
+    embedder + stdlib-hashing fallback) + ``semantic_index._cosine``. The
+    concrete embedding model lives in SemanticIndex; this module embeds NO model
+    name (CLAUDE.md no-hardcode mandate — pinned by test).
+  * Storage payload + fail-closed git guard: ``provider_response_cache``'s
+    ``CachedTrajectory`` (the serializable response) + ``repo_state_digest``
+    (any git diff → a different digest → never served).
+
+**Invariants:**
+  * Gated ``JARVIS_SEMANTIC_CACHE_ENABLED`` default-FALSE → OFF byte-identical
+    (no embedder import, no work).
+  * Fully ASYNC + FAIL-CLOSED: the (sync, CPU-bound) embedder runs in an
+    executor under ``asyncio.wait_for``; any hang/error/timeout → drop the cache
+    attempt → return ``None`` → caller takes the standard generation path.
+  * Repo-state fail-closed EVEN on a semantic match: each entry stores the
+    ``repo_state_digest`` at write time; a near-match whose digest has drifted is
+    skipped (no stale code served).
+  * Write-through: a completed novel generation is embedded + pushed immediately
+    so the very next cycle can hit it.
+  * Bounded LRU (``deque(maxlen=...)``).
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import os
+import threading
+from collections import deque
+from typing import Any, Deque, List, Optional, Sequence
+
+_ENV_MASTER = "JARVIS_SEMANTIC_CACHE_ENABLED"
+_ENV_THRESHOLD = "JARVIS_SEMANTIC_CACHE_THRESHOLD"
+_ENV_MAX = "JARVIS_SEMANTIC_CACHE_MAX_ENTRIES"
+_ENV_TIMEOUT = "JARVIS_SEMANTIC_CACHE_EMBED_TIMEOUT_S"
+
+_DEFAULT_THRESHOLD = 0.95
+_DEFAULT_MAX = 256
+_DEFAULT_TIMEOUT = 2.0
+
+# An embedder exposes ``embed(texts) -> Optional[List[List[float]]]`` (the
+# SemanticIndex contract). Injectable for tests / the hot path.
+EmbedderLike = Any
+
+
+def semantic_cache_enabled() -> bool:
+    """Master gate, default-FALSE per §33.1. Re-read each call → hot-revert.
+    NEVER raises."""
+    return os.getenv(_ENV_MASTER, "false").strip().lower() in ("1", "true", "yes", "on")
+
+
+def semantic_threshold() -> float:
+    """Strict cosine threshold for a near-match (default 0.95). Clamped [0,1]."""
+    try:
+        v = float(os.getenv(_ENV_THRESHOLD, _DEFAULT_THRESHOLD))
+    except (TypeError, ValueError):
+        v = _DEFAULT_THRESHOLD
+    return max(0.0, min(1.0, v))
+
+
+def _max_entries() -> int:
+    try:
+        return max(1, int(os.getenv(_ENV_MAX, _DEFAULT_MAX)))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX
+
+
+def _embed_timeout_s() -> float:
+    try:
+        return max(0.01, float(os.getenv(_ENV_TIMEOUT, _DEFAULT_TIMEOUT)))
+    except (TypeError, ValueError):
+        return _DEFAULT_TIMEOUT
+
+
+def _safe_repo_digest(repo_root: Any) -> str:
+    """Compose Phase-1 ``repo_state_digest`` (fail-closed git guard). NEVER raises."""
+    if repo_root is None:
+        return ""
+    try:
+        from backend.core.ouroboros.governance.provider_response_cache import (
+            repo_state_digest,
+        )
+        return repo_state_digest(repo_root)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    """Compose SemanticIndex's cosine; fall back to a local computation if the
+    import is unavailable. NEVER raises (returns -1.0 on failure → never a hit)."""
+    try:
+        from backend.core.ouroboros.governance.semantic_index import _cosine as _si_cos
+        return float(_si_cos(a, b))
+    except Exception:  # noqa: BLE001
+        try:
+            num = sum(x * y for x, y in zip(a, b))
+            na = sum(x * x for x in a) ** 0.5
+            nb = sum(y * y for y in b) ** 0.5
+            if na == 0.0 or nb == 0.0:
+                return -1.0
+            return num / (na * nb)
+        except Exception:  # noqa: BLE001
+            return -1.0
+
+
+@dataclasses.dataclass
+class _Entry:
+    vector: List[float]
+    trajectory: Any           # CachedTrajectory
+    repo_digest: str
+
+
+class SemanticResponseCache:
+    """Bounded, async, fail-closed near-match cache over CachedTrajectory."""
+
+    def __init__(
+        self,
+        *,
+        embedder: Optional[EmbedderLike] = None,
+        max_entries: Optional[int] = None,
+        threshold: Optional[float] = None,
+    ) -> None:
+        self._embedder = embedder  # None → lazy factory on first use
+        self._threshold = threshold
+        self._entries: Deque[_Entry] = deque(maxlen=max_entries or _max_entries())
+        self._lock = threading.Lock()
+
+    # ── embedder (lazy, composed from SemanticIndex) ────────────────────────
+    def _get_embedder(self) -> Optional[EmbedderLike]:
+        if self._embedder is None:
+            try:
+                from backend.core.ouroboros.governance.semantic_index import (
+                    _embedder_factory,
+                )
+                self._embedder = _embedder_factory()
+            except Exception:  # noqa: BLE001
+                self._embedder = None
+        return self._embedder
+
+    async def _embed_one(self, text: str) -> Optional[List[float]]:
+        """Vectorize ``text`` in an executor under a hard timeout. FAIL-CLOSED:
+        any error/timeout → None (caller falls back to generation)."""
+        try:
+            emb = self._get_embedder()
+            if emb is None:
+                return None
+            loop = asyncio.get_event_loop()
+            vecs = await asyncio.wait_for(
+                loop.run_in_executor(None, emb.embed, [text or ""]),
+                timeout=_embed_timeout_s(),
+            )
+            if not vecs or not vecs[0]:
+                return None
+            return [float(x) for x in vecs[0]]
+        except Exception:  # noqa: BLE001 — incl. asyncio.TimeoutError
+            return None
+
+    # ── lookup / store ──────────────────────────────────────────────────────
+    async def lookup(
+        self, prompt: str, repo_root: Any, *, repo_digest: Optional[str] = None,
+    ) -> Optional[Any]:
+        """Return a cached ``CachedTrajectory`` for a near-match, or None. Gated +
+        fail-closed + repo-state-validated. NEVER raises."""
+        if not semantic_cache_enabled():
+            return None
+        try:
+            vec = await self._embed_one(prompt)
+            if vec is None:
+                return None
+            cur_digest = repo_digest if repo_digest is not None else _safe_repo_digest(repo_root)
+            thr = self._threshold if self._threshold is not None else semantic_threshold()
+            with self._lock:
+                snapshot = list(self._entries)
+            best: Optional[_Entry] = None
+            best_sim = -1.0
+            for e in snapshot:
+                if e.repo_digest != cur_digest:
+                    continue  # fail-closed: repo drifted → never serve stale
+                sim = _cosine(vec, e.vector)
+                if sim > best_sim:
+                    best_sim, best = sim, e
+            if best is not None and best_sim >= thr:
+                return best.trajectory
+            return None
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def store(
+        self, prompt: str, trajectory: Any, repo_root: Any,
+        *, repo_digest: Optional[str] = None,
+    ) -> bool:
+        """Write-through: embed ``prompt`` and push ``(vector, trajectory,
+        repo_digest)``. Gated + fail-soft (errors → False, never raise)."""
+        if not semantic_cache_enabled():
+            return False
+        try:
+            vec = await self._embed_one(prompt)
+            if vec is None:
+                return False
+            cur_digest = repo_digest if repo_digest is not None else _safe_repo_digest(repo_root)
+            with self._lock:
+                self._entries.append(_Entry(vector=vec, trajectory=trajectory, repo_digest=cur_digest))
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+
+# ── singleton + module-level convenience API (the integration seam) ─────────
+_singleton: Optional[SemanticResponseCache] = None
+_singleton_lock = threading.Lock()
+
+
+def get_semantic_cache() -> SemanticResponseCache:
+    global _singleton
+    if _singleton is None:
+        with _singleton_lock:
+            if _singleton is None:
+                _singleton = SemanticResponseCache()
+    return _singleton
+
+
+def reset_semantic_cache() -> None:
+    """Tests / clean boot."""
+    global _singleton
+    with _singleton_lock:
+        _singleton = None
+
+
+async def semantic_cache_lookup(prompt: str, repo_root: Any) -> Optional[Any]:
+    """Process-wide near-match lookup (the seam the provider calls on exact-miss).
+    Gated + fail-closed. NEVER raises."""
+    try:
+        return await get_semantic_cache().lookup(prompt, repo_root)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def semantic_cache_store(prompt: str, trajectory: Any, repo_root: Any) -> bool:
+    """Process-wide write-through (the provider calls this after a novel
+    generation completes). Gated + fail-soft. NEVER raises."""
+    try:
+        return await get_semantic_cache().store(prompt, trajectory, repo_root)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+__all__ = [
+    "semantic_cache_enabled",
+    "semantic_threshold",
+    "SemanticResponseCache",
+    "get_semantic_cache",
+    "reset_semantic_cache",
+    "semantic_cache_lookup",
+    "semantic_cache_store",
+]

--- a/tests/architecture/test_slice131_semantic_cache.py
+++ b/tests/architecture/test_slice131_semantic_cache.py
@@ -1,0 +1,220 @@
+"""Slice 131 Phase 3 — the Asynchronous Semantic Response Cache.
+
+Exact-match caching (Phase 1) never hits on semantic *variations* of the same
+intent. This layer closes the near-match gap by composing the dormant
+``SemanticIndex`` bge-small embedder + ``_cosine`` with the Phase-1
+``provider_response_cache`` (``CachedTrajectory`` + the ``repo_state_digest``
+fail-closed git-diff guard) — it builds NO new vectorizer and NO new store.
+
+Invariants under test:
+  * gated ``JARVIS_SEMANTIC_CACHE_ENABLED`` default-FALSE (OFF byte-identical).
+  * near-match (cosine ≥ strict threshold) → serve the cached trajectory.
+  * fully async + FAIL-CLOSED: embedder error OR timeout → drop the cache
+    attempt → return None → caller falls back to standard generation.
+  * repo-state fail-closed EVEN on a semantic match: a near-match whose repo
+    state has drifted is never served (no stale code).
+  * write-through: a completed generation is embedded + pushed immediately.
+  * bounded (LRU eviction); no hardcoded embedder/model string (delegates).
+"""
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+import pathlib
+import time
+import unittest
+
+from backend.core.ouroboros.governance import semantic_cache as SC
+from backend.core.ouroboros.governance.provider_response_cache import CachedTrajectory
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _traj(key: str = "k1") -> CachedTrajectory:
+    return CachedTrajectory(
+        full_key=key, prefix_key="p", candidates=({"file_path": "x.py"},),
+        provider_name="doubleword", model_id="m", is_noop=False,
+        prompt_preloaded_files=(), total_input_tokens=10,
+        total_output_tokens=20, n_bytes=100,
+    )
+
+
+class _FakeEmbedder:
+    """Maps text→vector; unknown text → orthogonal default. Synchronous, like
+    SemanticIndex's _Embedder.embed."""
+
+    def __init__(self, mapping):
+        self._m = mapping
+
+    def embed(self, texts):
+        return [self._m.get(t, [0.0, 0.0, 1.0]) for t in texts]
+
+
+class _BoomEmbedder:
+    def embed(self, texts):
+        raise RuntimeError("vectorizer exploded")
+
+
+class _SlowEmbedder:
+    def embed(self, texts):
+        time.sleep(0.5)
+        return [[1.0, 0.0, 0.0] for _ in texts]
+
+
+class TestGate(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JARVIS_SEMANTIC_CACHE_ENABLED", None)
+
+    def test_default_false(self):
+        self.assertFalse(SC.semantic_cache_enabled())
+
+    def test_lookup_none_when_disabled(self):
+        c = SC.SemanticResponseCache(embedder=_FakeEmbedder({"a": [1, 0, 0]}))
+        _run(c.store("a", _traj(), repo_root=None, repo_digest="R"))  # store no-ops when off
+        out = _run(c.lookup("a", repo_root=None, repo_digest="R"))
+        self.assertIsNone(out)
+
+
+class TestSemanticHitMiss(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_SEMANTIC_CACHE_ENABLED"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JARVIS_SEMANTIC_CACHE_ENABLED", None)
+        os.environ.pop("JARVIS_SEMANTIC_CACHE_EMBED_TIMEOUT_S", None)
+
+    def test_near_match_hits(self):
+        emb = _FakeEmbedder({"add a foo function": [1, 0, 0],
+                             "please add a foo function": [1, 0, 0]})
+        c = SC.SemanticResponseCache(embedder=emb)
+        _run(c.store("add a foo function", _traj("hit"), None, repo_digest="R"))
+        out = _run(c.lookup("please add a foo function", None, repo_digest="R"))
+        self.assertIsNotNone(out)
+        self.assertEqual(out.full_key, "hit")
+
+    def test_distant_prompt_misses(self):
+        emb = _FakeEmbedder({"add a foo function": [1, 0, 0],
+                             "delete the database": [0, 1, 0]})
+        c = SC.SemanticResponseCache(embedder=emb)
+        _run(c.store("add a foo function", _traj(), None, repo_digest="R"))
+        out = _run(c.lookup("delete the database", None, repo_digest="R"))
+        self.assertIsNone(out)  # orthogonal → cosine 0 < threshold
+
+    def test_boundary_threshold(self):
+        # cosine([1,0,0],[0.97,x,0]) ≈ 0.97 ≥ 0.95 → hit.
+        v = [0.97, math.sqrt(max(0.0, 1 - 0.97 ** 2)), 0.0]
+        emb = _FakeEmbedder({"orig": [1, 0, 0], "variant": v})
+        c = SC.SemanticResponseCache(embedder=emb)
+        _run(c.store("orig", _traj("b"), None, repo_digest="R"))
+        self.assertIsNotNone(_run(c.lookup("variant", None, repo_digest="R")))
+
+    def test_repo_state_fail_closed_even_on_match(self):
+        # Identical vector, but repo drifted → must NOT serve stale code.
+        emb = _FakeEmbedder({"x": [1, 0, 0]})
+        c = SC.SemanticResponseCache(embedder=emb)
+        _run(c.store("x", _traj(), None, repo_digest="R_old"))
+        out = _run(c.lookup("x", None, repo_digest="R_new"))
+        self.assertIsNone(out)
+
+    def test_fail_closed_on_embedder_error(self):
+        c = SC.SemanticResponseCache(embedder=_BoomEmbedder())
+        # store fails soft, lookup returns None — caller falls back to API.
+        self.assertFalse(_run(c.store("x", _traj(), None, repo_digest="R")))
+        self.assertIsNone(_run(c.lookup("x", None, repo_digest="R")))
+
+    def test_fail_closed_on_embedder_timeout(self):
+        os.environ["JARVIS_SEMANTIC_CACHE_EMBED_TIMEOUT_S"] = "0.05"
+        c = SC.SemanticResponseCache(embedder=_SlowEmbedder())
+        self.assertIsNone(_run(c.lookup("x", None, repo_digest="R")))
+
+    def test_write_through_then_hit(self):
+        emb = _FakeEmbedder({"q": [1, 0, 0]})
+        c = SC.SemanticResponseCache(embedder=emb)
+        self.assertTrue(_run(c.store("q", _traj("wt"), None, repo_digest="R")))
+        out = _run(c.lookup("q", None, repo_digest="R"))
+        self.assertEqual(out.full_key, "wt")
+
+    def test_bounded_eviction(self):
+        emb = _FakeEmbedder({"a": [1, 0, 0], "b": [0, 1, 0], "c": [0, 0, 1]})
+        c = SC.SemanticResponseCache(embedder=emb, max_entries=2)
+        _run(c.store("a", _traj("a"), None, repo_digest="R"))
+        _run(c.store("b", _traj("b"), None, repo_digest="R"))
+        _run(c.store("c", _traj("c"), None, repo_digest="R"))  # evicts "a"
+        self.assertEqual(len(c), 2)
+        self.assertIsNone(_run(c.lookup("a", None, repo_digest="R")))  # evicted
+        self.assertIsNotNone(_run(c.lookup("c", None, repo_digest="R")))
+
+
+class TestCachedOrGenerateWiring(unittest.TestCase):
+    """The semantic tier fused into cached_or_generate: on exact MISS a
+    near-match returns SEMANTIC_HIT and the provider (produce) is skipped."""
+
+    def setUp(self):
+        os.environ["JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED"] = "1"
+        os.environ["JARVIS_SEMANTIC_CACHE_ENABLED"] = "1"
+        from backend.core.ouroboros.governance import provider_response_cache as PRC
+        self.PRC = PRC
+        self._saved = {
+            "gdc": PRC.get_default_cache,
+            "cck": PRC.compute_cache_key,
+            "rgr": PRC.reconstruct_generation_result,
+        }
+
+        class _StubCache:
+            def lookup(self, full, pref):
+                return (PRC.CacheLookupOutcome.MISS, None)  # force exact MISS
+
+            def store(self, t):
+                pass
+
+        PRC.get_default_cache = lambda: _StubCache()
+        PRC.compute_cache_key = lambda *a, **k: ("full", "pref")  # avoid git
+
+    def tearDown(self):
+        self.PRC.get_default_cache = self._saved["gdc"]
+        self.PRC.compute_cache_key = self._saved["cck"]
+        self.PRC.reconstruct_generation_result = self._saved["rgr"]
+        os.environ.pop("JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED", None)
+        os.environ.pop("JARVIS_SEMANTIC_CACHE_ENABLED", None)
+
+    def test_semantic_hit_intercepts_before_produce(self):
+        PRC = self.PRC
+        sentinel_gr = object()
+        PRC.reconstruct_generation_result = lambda t: sentinel_gr
+
+        saved_lookup = SC.semantic_cache_lookup
+        async def _fake_lookup(prompt, repo_root):
+            return _traj("sem")  # near-match found
+        SC.semantic_cache_lookup = _fake_lookup
+
+        called = {"produce": False}
+        async def _produce():
+            called["produce"] = True
+            return object()
+
+        try:
+            gr, outcome = _run(PRC.cached_or_generate(
+                prompt="x", model="m", route="r",
+                repo_root=pathlib.Path("."), produce=_produce,
+            ))
+        finally:
+            SC.semantic_cache_lookup = saved_lookup
+
+        self.assertIs(gr, sentinel_gr)
+        self.assertEqual(outcome, PRC.CacheLookupOutcome.SEMANTIC_HIT)
+        self.assertFalse(called["produce"])  # provider skipped → $0.00
+
+
+class TestNoHardcode(unittest.TestCase):
+    def test_no_hardcoded_embedder_model_string(self):
+        src = pathlib.Path(
+            "backend/core/ouroboros/governance/semantic_cache.py"
+        ).read_text()
+        self.assertNotIn("bge", src.lower())  # delegates to SemanticIndex factory
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/governance/test_provider_response_cache.py
+++ b/tests/governance/test_provider_response_cache.py
@@ -49,10 +49,15 @@ def _gr(content="print(1)", noop=False):
 # -- flags / knobs ---------------------------------------------------------
 
 
+# Slice 131 P1 GRADUATED this master to default-TRUE (the cache is
+# correctness-fail-closed: any git diff re-keys, so default-on can only
+# eliminate redundant identical-context calls). Only explicit off-values
+# disable; unset/empty/garbage now resolve TRUE.
 @pytest.mark.parametrize("raw,exp", [
-    (None, False), ("", False), ("1", True), ("true", True),
-    ("YES", True), ("0", False), ("garbage", False)])
-def test_master_default_false_asymmetric(monkeypatch, raw, exp):
+    (None, True), ("", True), ("1", True), ("true", True),
+    ("YES", True), ("0", False), ("false", False), ("off", False),
+    ("garbage", True)])
+def test_master_default_true_asymmetric_slice131(monkeypatch, raw, exp):
     if raw is None:
         monkeypatch.delenv(
             "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED", raising=False)


### PR DESCRIPTION
Closes the near-match gap exact-match caching can't: the same intent phrased differently misses. This tier vectorizes the prompt and serves a cached response on a strict-cosine near-match. **Pure composition** — nothing reinvented.

### `semantic_cache.py` (NEW)
- **Vectorization** composes `semantic_index._embedder_factory` (dormant fastembed/bge-small + stdlib fallback) + `_cosine`. **No hardcoded model** (test-pinned).
- **Payload + fail-closed git guard** composes `provider_response_cache.CachedTrajectory` + `repo_state_digest`.
- **Fully async + FAIL-CLOSED:** embedder runs in an executor under `asyncio.wait_for`; any error/timeout → None → caller takes the standard generation path.
- **Repo-state fail-closed even on a near-match:** each entry stores its digest; a drifted repo is never served (no stale code).
- **Write-through** ingestion; **bounded LRU**. Master `JARVIS_SEMANTIC_CACHE_ENABLED` **default-FALSE**; strict threshold `JARVIS_SEMANTIC_CACHE_THRESHOLD` default **0.95**.

### Fusion (`cached_or_generate`)
Activated the reserved `SEMANTIC_HIT` outcome and fused the tier into the substrate: on exact-key **MISS** a near-match returns the cached response **before paying for generation** (skipped under shadow/passthrough); **write-through** after a novel store. Both gated + fail-closed → **OFF byte-identical**.

### Tests — 13 new + regression
gate · near-match hit · distant miss · boundary threshold · repo-state fail-closed · embedder error + timeout fail-closed · write-through · bounded eviction · no-hardcode pin · `cached_or_generate` SEMANTIC_HIT wiring (skips `produce`). Also fixed `test_provider_response_cache` master-default test to the P1 graduated default-TRUE (missed in P1's regression). **76 green** across PRC + semantic + P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an asynchronous semantic response cache (Slice 131 P3) that serves near-match cached responses on strict cosine similarity to reduce redundant generations. Integrated into `cached_or_generate`: on exact miss, a semantic near-match returns `SEMANTIC_HIT` and skips provider work; write-through after a novel generation.

- **New Features**
  - New `semantic_cache.py`: composes `semantic_index._embedder_factory` and `_cosine`; async embedding with timeout; no model string hardcoded.
  - Repo-state safety: stores `repo_state_digest`; mismatched digests never serve a hit.
  - Gated by `JARVIS_SEMANTIC_CACHE_ENABLED` (default false); strict `JARVIS_SEMANTIC_CACHE_THRESHOLD` default 0.95; bounded LRU; process-wide `semantic_cache_lookup`/`semantic_cache_store`.
  - PRC integration: produces `SEMANTIC_HIT` only on exact-key miss; respects shadow mode; write-through on successful generation.

- **Migration**
  - No action required (disabled by default). To enable, set `JARVIS_SEMANTIC_CACHE_ENABLED=1`. Optional: tune `JARVIS_SEMANTIC_CACHE_THRESHOLD` and `JARVIS_SEMANTIC_CACHE_MAX_ENTRIES`.

<sup>Written for commit fcbd306ce7f254ad2c03570199e03a4fb74b6325. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

