### PR TITLE
Slice 131 P2b — The Asynchronous Claude Batch Engine (50% on non-urgent ops)

### DIFF
--- a/backend/core/ouroboros/governance/batch_engine.py
+++ b/backend/core/ouroboros/governance/batch_engine.py
@@ -1,0 +1,225 @@
+"""Slice 131 Phase 2b — The Asynchronous Claude Batch Engine.
+
+BACKGROUND / SPECULATIVE ops are non-urgent — they do not need a real-time
+response, so they should ride the Anthropic **Message Batches** endpoint
+(``/v1/messages/batches``) for a flat **50% discount** instead of the standard
+completions path.
+
+This engine owns the full async lifecycle:
+
+    pack → dispatch → AWAITING_BATCH (poll) → retrieve → inject as real-time
+
+with a hard **FALLBACK invariant**: if the Batch API is disabled, the route is
+ineligible, the create call 4xx/5xx's, the poll times out, or a result errors,
+the engine **seamlessly falls back to the supplied real-time ``fallback``** so the
+op is never starved. Gated ``JARVIS_BATCH_ROUTING_ENABLED`` default-FALSE → OFF
+never touches the batch path.
+
+The Anthropic batch client (sync ``client.messages.batches.create/retrieve/
+results``) is **injectable**; the engine drives its blocking calls via
+``asyncio.to_thread`` so the event loop is never blocked, and is tested with a
+fake client (no network). NO model string is hardcoded here — the caller passes
+the model (resolved upstream from ``brain_selection_policy.yaml``).
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import enum
+import logging
+import os
+import time
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV_MASTER = "JARVIS_BATCH_ROUTING_ENABLED"
+_ENV_POLL_INTERVAL = "JARVIS_BATCH_POLL_INTERVAL_S"
+_ENV_MAX_WAIT = "JARVIS_BATCH_MAX_WAIT_S"
+
+_DEFAULT_POLL_INTERVAL = 30.0   # Anthropic batches typically complete <1h
+_DEFAULT_MAX_WAIT = 3600.0      # 1h; hard ceiling below the API's 24h max
+
+# Non-urgent routes eligible for batch delegation.
+_ELIGIBLE_ROUTES = frozenset({"background", "speculative"})
+
+
+def batch_routing_enabled() -> bool:
+    """Master gate, default-FALSE per §33.1. Re-read each call → hot-revert.
+    NEVER raises."""
+    return os.getenv(_ENV_MASTER, "false").strip().lower() in ("1", "true", "yes", "on")
+
+
+def is_batch_eligible(route: Any) -> bool:
+    """True only for non-urgent routes (BACKGROUND / SPECULATIVE)."""
+    return str(route or "").strip().lower() in _ELIGIBLE_ROUTES
+
+
+def _poll_interval_s() -> float:
+    try:
+        return max(0.001, float(os.getenv(_ENV_POLL_INTERVAL, _DEFAULT_POLL_INTERVAL)))
+    except (TypeError, ValueError):
+        return _DEFAULT_POLL_INTERVAL
+
+
+def _max_wait_s() -> float:
+    try:
+        return max(0.01, float(os.getenv(_ENV_MAX_WAIT, _DEFAULT_MAX_WAIT)))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_WAIT
+
+
+def pack_batch_request(
+    custom_id: str, prompt: str, model: str, *,
+    max_tokens: int = 16000, system: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Package one op into a Message Batches request (the ``.jsonl`` row shape:
+    ``{custom_id, params}``). ``params`` is a non-streaming Messages payload."""
+    params: Dict[str, Any] = {
+        "model": str(model),
+        "max_tokens": int(max_tokens),
+        "messages": [{"role": "user", "content": str(prompt or "")}],
+    }
+    if system:
+        params["system"] = system
+    return {"custom_id": str(custom_id), "params": params}
+
+
+class BatchState(str, enum.Enum):
+    """Closed lifecycle taxonomy."""
+
+    COMPLETED = "completed"                    # batched result returned
+    FELL_BACK_DISABLED = "fell_back_disabled"  # master off
+    FELL_BACK_INELIGIBLE = "fell_back_ineligible"
+    FELL_BACK_FAULT = "fell_back_fault"        # create/transport 4xx/5xx/error
+    FELL_BACK_TIMEOUT = "fell_back_timeout"    # poll exceeded max_wait
+    FELL_BACK_ERROR = "fell_back_error"        # batch result errored/missing
+
+
+@dataclasses.dataclass
+class BatchOutcome:
+    result: Any
+    state: BatchState
+    batch_id: Optional[str] = None
+
+
+_Fallback = Callable[[], Awaitable[Any]]
+
+
+class ClaudeBatchEngine:
+    """Async batch dispatch + reconciliation with a hard real-time fallback."""
+
+    def __init__(self, *, client: Any = None) -> None:
+        self._client = client  # sync Anthropic-like client; None → lazy default
+
+    def _batches(self) -> Optional[Any]:
+        c = self._client
+        if c is None:
+            return None
+        try:
+            return c.messages.batches
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def _dispatch(self, requests: List[Dict[str, Any]]) -> Optional[str]:
+        batches = self._batches()
+        if batches is None:
+            return None
+        batch = await asyncio.to_thread(batches.create, requests=requests)
+        return getattr(batch, "id", None)
+
+    async def poll_until_complete(self, batch_id: str) -> bool:
+        """Poll batch status until ``ended`` or ``max_wait``. AWAITING_BATCH.
+        Returns True iff it ended in time. NEVER raises (caller falls back)."""
+        batches = self._batches()
+        if batches is None:
+            return False
+        deadline = time.monotonic() + _max_wait_s()
+        interval = _poll_interval_s()
+        while time.monotonic() < deadline:
+            b = await asyncio.to_thread(batches.retrieve, batch_id)
+            if str(getattr(b, "processing_status", "")) == "ended":
+                return True
+            await asyncio.sleep(interval)
+        return False
+
+    async def _retrieve(self, batch_id: str, custom_id: str) -> Optional[Any]:
+        """Pull the result for ``custom_id``. Returns the message on success,
+        None on errored/missing (caller falls back)."""
+        batches = self._batches()
+        if batches is None:
+            return None
+        rows = await asyncio.to_thread(lambda: list(batches.results(batch_id)))
+        for row in rows:
+            if getattr(row, "custom_id", None) != custom_id:
+                continue
+            res = getattr(row, "result", None)
+            if res is not None and getattr(res, "type", "") == "succeeded":
+                return getattr(res, "message", None)
+            return None  # errored / canceled / expired
+        return None
+
+    async def generate_or_fallback(
+        self,
+        *,
+        prompt: str,
+        model: str,
+        route: Any,
+        fallback: _Fallback,
+        custom_id: str = "op",
+        max_tokens: int = 16000,
+        system: Optional[str] = None,
+    ) -> BatchOutcome:
+        """Route a non-urgent op through the Batch API for 50% off, else fall
+        back to ``fallback`` (the real-time generation path). The FALLBACK
+        invariant holds for every failure mode. NEVER raises."""
+        if not batch_routing_enabled():
+            return BatchOutcome(await fallback(), BatchState.FELL_BACK_DISABLED)
+        if not is_batch_eligible(route):
+            return BatchOutcome(await fallback(), BatchState.FELL_BACK_INELIGIBLE)
+
+        batch_id: Optional[str] = None
+        try:
+            req = pack_batch_request(
+                custom_id, prompt, model, max_tokens=max_tokens, system=system,
+            )
+            batch_id = await self._dispatch([req])
+            if not batch_id:
+                logger.debug("[BatchEngine] dispatch returned no id → fallback")
+                return BatchOutcome(await fallback(), BatchState.FELL_BACK_FAULT, batch_id)
+        except Exception as exc:  # noqa: BLE001 — 4xx/5xx/transport → fallback
+            logger.info("[BatchEngine] dispatch fault (%s) → real-time fallback", exc)
+            return BatchOutcome(await fallback(), BatchState.FELL_BACK_FAULT, batch_id)
+
+        # AWAITING_BATCH — poll to completion (bounded).
+        try:
+            ended = await self.poll_until_complete(batch_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.info("[BatchEngine] poll fault (%s) → fallback", exc)
+            return BatchOutcome(await fallback(), BatchState.FELL_BACK_FAULT, batch_id)
+        if not ended:
+            logger.info("[BatchEngine] batch %s exceeded max_wait → fallback", batch_id)
+            return BatchOutcome(await fallback(), BatchState.FELL_BACK_TIMEOUT, batch_id)
+
+        # Retrieve + inject as if real-time.
+        try:
+            message = await self._retrieve(batch_id, custom_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.info("[BatchEngine] retrieve fault (%s) → fallback", exc)
+            return BatchOutcome(await fallback(), BatchState.FELL_BACK_FAULT, batch_id)
+        if message is None:
+            logger.info("[BatchEngine] batch %s result errored/missing → fallback", batch_id)
+            return BatchOutcome(await fallback(), BatchState.FELL_BACK_ERROR, batch_id)
+
+        logger.info("[BatchEngine] BATCH_HIT %s — 50%% discount (route=%s)", batch_id, route)
+        return BatchOutcome(message, BatchState.COMPLETED, batch_id)
+
+
+__all__ = [
+    "batch_routing_enabled",
+    "is_batch_eligible",
+    "pack_batch_request",
+    "BatchState",
+    "BatchOutcome",
+    "ClaudeBatchEngine",
+]

--- a/tests/architecture/test_slice131_batch_engine.py
+++ b/tests/architecture/test_slice131_batch_engine.py
@@ -1,0 +1,191 @@
+"""Slice 131 Phase 2b — the Asynchronous Claude Batch Engine.
+
+Non-urgent (BACKGROUND / SPECULATIVE) ops don't need a real-time response, so
+they should ride the Anthropic Message Batches endpoint (flat 50% discount)
+instead of the standard completions path. This engine packages the prompt into
+the batch request, dispatches it, polls to completion (AWAITING_BATCH), retrieves
+the result, and returns it as if real-time — with a hard FALLBACK invariant:
+any 4xx/5xx/unavailable/timeout → seamlessly fall back to the real-time path so
+the op is never starved.
+
+Gated ``JARVIS_BATCH_ROUTING_ENABLED`` default-FALSE; the (sync) Anthropic batch
+client is injectable so the engine is tested without network.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import unittest
+
+from backend.core.ouroboros.governance import batch_engine as BE
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ── fake Anthropic batch client (sync, matches messages.batches.*) ──────────
+class _Res:
+    def __init__(self, custom_id, type_, message=None, error=None):
+        self.custom_id = custom_id
+        self.result = type("R", (), {"type": type_, "message": message, "error": error})()
+
+
+class _Batch:
+    def __init__(self, id_, status):
+        self.id = id_
+        self.processing_status = status
+
+
+class _FakeBatches:
+    def __init__(self, *, ended_after=1, fail_create=False, results=None):
+        self.ended_after = ended_after
+        self.fail_create = fail_create
+        self._results = results or []
+        self.polls = 0
+        self.created_requests = None
+
+    def create(self, requests=None):
+        if self.fail_create:
+            raise RuntimeError("HTTP 429 batch unavailable")
+        self.created_requests = requests
+        return _Batch("batch_xyz", "in_progress")
+
+    def retrieve(self, batch_id):
+        self.polls += 1
+        return _Batch(batch_id, "ended" if self.polls >= self.ended_after else "in_progress")
+
+    def results(self, batch_id):
+        return iter(self._results)
+
+
+def _client(batches):
+    return type("C", (), {"messages": type("M", (), {"batches": batches})()})()
+
+
+async def _fallback_factory(flag):
+    async def _fb():
+        flag["called"] = True
+        return "REALTIME_RESULT"
+    return _fb
+
+
+class TestGateAndEligibility(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JARVIS_BATCH_ROUTING_ENABLED", None)
+
+    def test_default_false(self):
+        self.assertFalse(BE.batch_routing_enabled())
+
+    def test_eligibility(self):
+        self.assertTrue(BE.is_batch_eligible("background"))
+        self.assertTrue(BE.is_batch_eligible("speculative"))
+        self.assertFalse(BE.is_batch_eligible("immediate"))
+        self.assertFalse(BE.is_batch_eligible("standard"))
+        self.assertFalse(BE.is_batch_eligible(""))
+
+    def test_pack_request_shape(self):
+        req = BE.pack_batch_request("op-1", "do the thing", "claude-x", max_tokens=2048,
+                                    system="be terse")
+        self.assertEqual(req["custom_id"], "op-1")
+        self.assertEqual(req["params"]["model"], "claude-x")
+        self.assertEqual(req["params"]["max_tokens"], 2048)
+        self.assertEqual(req["params"]["system"], "be terse")
+        self.assertEqual(req["params"]["messages"][0]["role"], "user")
+        self.assertIn("do the thing", req["params"]["messages"][0]["content"])
+
+
+class TestLifecycle(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_BATCH_ROUTING_ENABLED"] = "1"
+        os.environ["JARVIS_BATCH_POLL_INTERVAL_S"] = "0.01"
+        os.environ["JARVIS_BATCH_MAX_WAIT_S"] = "2"
+
+    def tearDown(self):
+        for k in ("JARVIS_BATCH_ROUTING_ENABLED", "JARVIS_BATCH_POLL_INTERVAL_S",
+                  "JARVIS_BATCH_MAX_WAIT_S"):
+            os.environ.pop(k, None)
+
+    def _engine(self, batches):
+        return BE.ClaudeBatchEngine(client=_client(batches))
+
+    def test_happy_path_returns_batched_result(self):
+        results = [_Res("op-1", "succeeded", message="BATCHED_MSG")]
+        eng = self._engine(_FakeBatches(ended_after=2, results=results))
+        flag = {"called": False}
+        out = _run(eng.generate_or_fallback(
+            prompt="p", model="m", route="background", custom_id="op-1",
+            fallback=_run(_fallback_factory(flag)),
+        ))
+        self.assertEqual(out.result, "BATCHED_MSG")
+        self.assertEqual(out.state, BE.BatchState.COMPLETED)
+        self.assertFalse(flag["called"])  # real-time NOT hit → 50% saved
+
+    def test_disabled_falls_back(self):
+        os.environ["JARVIS_BATCH_ROUTING_ENABLED"] = "0"
+        eng = self._engine(_FakeBatches())
+        flag = {"called": False}
+        out = _run(eng.generate_or_fallback(
+            prompt="p", model="m", route="background",
+            fallback=_run(_fallback_factory(flag)),
+        ))
+        self.assertEqual(out.result, "REALTIME_RESULT")
+        self.assertTrue(flag["called"])
+        self.assertEqual(out.state, BE.BatchState.FELL_BACK_DISABLED)
+
+    def test_ineligible_route_falls_back(self):
+        eng = self._engine(_FakeBatches())
+        flag = {"called": False}
+        out = _run(eng.generate_or_fallback(
+            prompt="p", model="m", route="immediate",
+            fallback=_run(_fallback_factory(flag)),
+        ))
+        self.assertTrue(flag["called"])
+        self.assertEqual(out.state, BE.BatchState.FELL_BACK_INELIGIBLE)
+
+    def test_create_4xx_5xx_falls_back(self):
+        eng = self._engine(_FakeBatches(fail_create=True))
+        flag = {"called": False}
+        out = _run(eng.generate_or_fallback(
+            prompt="p", model="m", route="speculative",
+            fallback=_run(_fallback_factory(flag)),
+        ))
+        self.assertEqual(out.result, "REALTIME_RESULT")
+        self.assertTrue(flag["called"])
+        self.assertEqual(out.state, BE.BatchState.FELL_BACK_FAULT)
+
+    def test_poll_timeout_falls_back(self):
+        os.environ["JARVIS_BATCH_MAX_WAIT_S"] = "0.05"
+        eng = self._engine(_FakeBatches(ended_after=9999))  # never ends in time
+        flag = {"called": False}
+        out = _run(eng.generate_or_fallback(
+            prompt="p", model="m", route="background",
+            fallback=_run(_fallback_factory(flag)),
+        ))
+        self.assertTrue(flag["called"])
+        self.assertEqual(out.state, BE.BatchState.FELL_BACK_TIMEOUT)
+
+    def test_errored_result_falls_back(self):
+        results = [_Res("op-1", "errored", error="server_error")]
+        eng = self._engine(_FakeBatches(ended_after=1, results=results))
+        flag = {"called": False}
+        out = _run(eng.generate_or_fallback(
+            prompt="p", model="m", route="background", custom_id="op-1",
+            fallback=_run(_fallback_factory(flag)),
+        ))
+        self.assertTrue(flag["called"])
+        self.assertEqual(out.state, BE.BatchState.FELL_BACK_ERROR)
+
+
+class TestNoHardcode(unittest.TestCase):
+    def test_no_hardcoded_model(self):
+        src = pathlib.Path(
+            "backend/core/ouroboros/governance/batch_engine.py"
+        ).read_text()
+        for banned in ("claude-haiku", "claude-sonnet", "claude-opus", "claude-3"):
+            self.assertNotIn(banned, src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Non-urgent BACKGROUND/SPECULATIVE ops ride the Anthropic Message Batches endpoint for a flat **50% discount** instead of the real-time completions path.

### `batch_engine.py` (NEW)
Full async lifecycle: **pack → dispatch → AWAITING_BATCH (poll) → retrieve → inject as real-time**.
- `batch_routing_enabled()` — master `JARVIS_BATCH_ROUTING_ENABLED` **default-FALSE**.
- `is_batch_eligible(route)` — only BACKGROUND/SPECULATIVE.
- `pack_batch_request` → the `{custom_id, params}` jsonl row. **No hardcoded model** (caller passes it; pinned).
- `ClaudeBatchEngine.generate_or_fallback()` — dispatch via an **injectable** sync Anthropic client driven through `asyncio.to_thread` (event loop never blocks); `poll_until_complete` bounded by `JARVIS_BATCH_MAX_WAIT_S` (default 1h) at `JARVIS_BATCH_POLL_INTERVAL_S` (default 30s); retrieve the succeeded message.
- **THE FALLBACK INVARIANT:** disabled / ineligible / create 4xx-5xx / poll-timeout / errored-result → seamlessly `await` the supplied real-time fallback so the op is never starved. Closed `BatchState` taxonomy records the path.

### Tests — 10
gate · eligibility · pack shape · happy path (real-time NOT hit → 50% saved) · the five fallback modes (disabled, ineligible, create-fault, poll-timeout, errored) · no-hardcode pin. Injectable fake client → no network.

> **Integration boundary (documented):** this PR ships the decoupled reconciliation engine + its drop-in fallback API. The GovernedLoopService op-FSM AWAITING_BATCH suspend/resume wiring (so a worker isn't blocked across the batch window) is the follow-on — gated, so OFF is byte-identical until wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an async batch engine that routes non-urgent BACKGROUND/SPECULATIVE ops to Anthropic Message Batches for ~50% cost, with a guaranteed real-time fallback. The feature is off by default behind `JARVIS_BATCH_ROUTING_ENABLED`.

- New Features
  - `backend/core/ouroboros/governance/batch_engine.py`: async pack → dispatch → poll → retrieve pipeline via `ClaudeBatchEngine.generate_or_fallback(...)`.
  - Eligibility limited to background/speculative via `is_batch_eligible`; master gate via `batch_routing_enabled`.
  - `pack_batch_request` builds `{custom_id, params}` jsonl row; no hardcoded model (caller provides).
  - Polling bounded by `JARVIS_BATCH_POLL_INTERVAL_S` and `JARVIS_BATCH_MAX_WAIT_S` (defaults 30s / 1h). Drives the sync client via `asyncio.to_thread` to avoid blocking; client is injectable.
  - Closed `BatchState` records outcomes; handles disabled/ineligible/create-fault/timeout/errored paths.
  - Tests: 10 unit tests cover gate, eligibility, pack shape, happy path, and all fallback modes using a fake client (no network).

- Migration
  - Enable by setting `JARVIS_BATCH_ROUTING_ENABLED=1` and calling `ClaudeBatchEngine.generate_or_fallback` with your real-time fallback. Optional tuning via `JARVIS_BATCH_POLL_INTERVAL_S` and `JARVIS_BATCH_MAX_WAIT_S`.

<sup>Written for commit f3000d64ecf2b3ce03d128afe68f20973f8a861a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

