### PR TITLE
Slice 131 P2a — Tool-Catalog Prefix-Cache Mechanism (gated, OFF byte-identical)

### DIFF
--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -1710,6 +1710,46 @@ def _build_communication_mode_block(ctx: "OperationContext") -> Optional[str]:
     )
 
 
+def _prompt_prefix_cache_enabled() -> bool:
+    """Slice 131 P2a — gate the tool-catalog prefix-cache inversion. Default-FALSE
+    → OFF byte-identical (the stable tool catalog + output schema stay in the
+    volatile per-op user prompt). When ON, they are diverted into the cached
+    SYSTEM prefix so they ride the ~90%-cheaper cache instead of being re-billed
+    every op. NEVER raises."""
+    return os.getenv(
+        "JARVIS_PROMPT_PREFIX_CACHE_ENABLED", "false"
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _route_stable_tail(
+    parts: List[str],
+    stable_out: Optional[List[str]],
+    tool_section: str,
+    schema_section: str,
+    *,
+    enabled: bool,
+) -> None:
+    """ONE source of truth for where the STABLE tool catalog + output schema go.
+
+    OFF (or no sink) → append to the user-prompt ``parts`` (byte-identical
+    legacy: tool section then schema). ON + sink → divert both into
+    ``stable_out`` so the caller folds them into the cached system prefix,
+    eliminating the per-op re-bill. An empty tool section (VENOM_SKIP routes)
+    contributes nothing — only the schema is routed. NEVER raises."""
+    if enabled and stable_out is not None:
+        # ON: divert into the cached system prefix; skip an empty tool section
+        # (VENOM_SKIP routes) — no value in caching whitespace.
+        if tool_section:
+            stable_out.append(tool_section)
+        stable_out.append(schema_section)
+    else:
+        # OFF (or no sink): BYTE-IDENTICAL legacy — append the tool section
+        # (even when "") then the schema, exactly as the two prior parts.append
+        # calls did, so disabled behavior is bit-for-bit unchanged.
+        parts.append(tool_section)
+        parts.append(schema_section)
+
+
 def _build_tool_section(
     mcp_tools: Optional[List[Dict[str, Any]]] = None,
     *,
@@ -2188,8 +2228,15 @@ def _build_lean_codegen_prompt(
     force_full_content: bool = False,
     mcp_tools: Optional[List[Dict[str, Any]]] = None,
     preloaded_out: Optional[List[str]] = None,
+    stable_prefix_out: Optional[List[str]] = None,
 ) -> str:
     """Build a lean, tool-first generation prompt (~3-6K tokens).
+
+    Slice 131 P2a: when ``stable_prefix_out`` is provided AND
+    ``JARVIS_PROMPT_PREFIX_CACHE_ENABLED`` is on, the STABLE tool catalog +
+    output schema are diverted into ``stable_prefix_out`` (for the caller to fold
+    into the cached system prefix) instead of the volatile user prompt. Default
+    (no sink / flag off) is byte-identical legacy behavior.
 
     Unlike ``_build_codegen_prompt`` which front-loads full file contents,
     import context, test context, and expanded context into a single
@@ -2328,12 +2375,12 @@ def _build_lean_codegen_prompt(
     # _should_use_lean_prompt should already return False for those
     # routes, so this path shouldn't be reached for them, but plumb
     # the route anyway in case of caller drift).
-    parts.append(
-        _build_tool_section(
-            mcp_tools=mcp_tools,
-            voice_plain_language=voice_plain_language,
-            provider_route=str(getattr(ctx, "provider_route", "") or ""),
-        )
+    # Slice 131 P2a — compute the stable tool catalog once; routing (volatile
+    # user prompt vs cached system prefix) is decided after the schema is built.
+    _tool_section = _build_tool_section(
+        mcp_tools=mcp_tools,
+        voice_plain_language=voice_plain_language,
+        provider_route=str(getattr(ctx, "provider_route", "") or ""),
     )
 
     # ── 8. Output schema ────────────────────────────────────────────────
@@ -2375,7 +2422,13 @@ Rules:
 - Python files must be syntactically valid (`ast.parse()`-clean).
 - If the change is already implemented, return `{{"schema_version": "2b.1-noop", "reason": "<why>"}}`.
 - NEVER wrap the JSON in ```json ... ``` fences. NEVER emit prose before the opening `{{`. Your first character is `{{`."""
-    parts.append(schema_instruction)
+    # Slice 131 P2a — route the STABLE tool catalog + schema: into the cached
+    # system prefix (sink) when enabled, else the volatile user prompt
+    # (byte-identical legacy: tool section then schema).
+    _route_stable_tail(
+        parts, stable_prefix_out, _tool_section, schema_instruction,
+        enabled=_prompt_prefix_cache_enabled(),
+    )
 
     # ── 8a. Slice 20 Phase 3 — DW zero-candidate prohibition ────────────
     # Addresses v15 soak bt-2026-05-26-184355 "model judgment flaw":

--- a/tests/architecture/test_slice131_prompt_prefix_cache.py
+++ b/tests/architecture/test_slice131_prompt_prefix_cache.py
@@ -1,0 +1,87 @@
+"""Slice 131 Phase 2a — Tool-Catalog Prompt Restructuring (prefix segregation).
+
+The leak: the STABLE tool catalog + output schema are appended to the END of the
+VOLATILE per-op lean prompt (after the task + source snapshot), so they are
+re-billed every op instead of riding the ~90%-cheaper cached prefix. The fix is a
+structural inversion — divert the stable tail into the cached SYSTEM prefix,
+leaving only volatile content in the user message.
+
+This suite pins the GATED MECHANISM (default-FALSE → OFF byte-identical):
+  * ``_prompt_prefix_cache_enabled`` default-FALSE.
+  * ``_route_stable_tail`` (one source of truth): OFF → stable tail stays in the
+    user-prompt ``parts`` (byte-identical legacy); ON → diverted into the stable
+    sink (→ caller folds it into the cached system block); no-sink → fail-safe to
+    parts.
+  * ``_build_cached_system_blocks`` wraps base+stable in ONE ephemeral
+    cache_control breakpoint with the tool catalog inside it.
+
+NOTE (honest): the end-to-end cross-function activation (threading the sink from
+``_build_lean_codegen_prompt`` through ``_generate_raw`` to the system seam) +
+the live "model still uses its tools flawlessly" verification require a funded
+interactive Anthropic soak (the spec's Phase 3) — that is the graduation gate,
+not a unit test. OFF is proven byte-identical here.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+from backend.core.ouroboros.governance import providers as P
+
+
+class TestGate(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JARVIS_PROMPT_PREFIX_CACHE_ENABLED", None)
+
+    def test_default_false(self):
+        self.assertFalse(P._prompt_prefix_cache_enabled())
+
+    def test_explicit_on(self):
+        os.environ["JARVIS_PROMPT_PREFIX_CACHE_ENABLED"] = "1"
+        try:
+            self.assertTrue(P._prompt_prefix_cache_enabled())
+        finally:
+            os.environ.pop("JARVIS_PROMPT_PREFIX_CACHE_ENABLED", None)
+
+
+class TestRouteStableTail(unittest.TestCase):
+    def test_off_keeps_tail_in_user_parts_byte_identical(self):
+        parts, stable = [], []
+        P._route_stable_tail(parts, stable, "TOOLS", "SCHEMA", enabled=False)
+        self.assertEqual(parts, ["TOOLS", "SCHEMA"])  # legacy: in the user prompt
+        self.assertEqual(stable, [])
+
+    def test_on_diverts_tail_into_stable_prefix(self):
+        parts, stable = [], []
+        P._route_stable_tail(parts, stable, "TOOLS", "SCHEMA", enabled=True)
+        self.assertEqual(stable, ["TOOLS", "SCHEMA"])  # → cached system prefix
+        self.assertEqual(parts, [])                     # user prompt stays volatile
+
+    def test_on_without_sink_falls_back_to_parts(self):
+        parts = []
+        P._route_stable_tail(parts, None, "TOOLS", "SCHEMA", enabled=True)
+        self.assertEqual(parts, ["TOOLS", "SCHEMA"])  # fail-safe: never lose tools
+
+    def test_empty_tool_section_only_schema_routed(self):
+        # VENOM_SKIP routes emit an empty tool section → only the schema rides.
+        parts, stable = [], []
+        P._route_stable_tail(parts, stable, "", "SCHEMA", enabled=True)
+        self.assertEqual(stable, ["SCHEMA"])
+        self.assertEqual(parts, [])
+
+
+class TestCachedSystemCarriesTools(unittest.TestCase):
+    def test_stable_prefix_folds_into_one_cached_block(self):
+        prov = P.ClaudeProvider("test-key")
+        prov._prompt_cache_enabled = True
+        prov._prompt_cache_min_chars = 0
+        base = P._CODEGEN_SYSTEM_PROMPT
+        stable = "\n\n".join(["**Available Tools** read_file ...", "## Output Schema ..."])
+        blocks = prov._build_cached_system_blocks(base + "\n\n" + stable)
+        self.assertIsInstance(blocks, list)
+        self.assertEqual(blocks[-1]["cache_control"], {"type": "ephemeral"})
+        self.assertIn("Available Tools", blocks[-1]["text"])  # tools now cached
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the final hot-path leak: the stable tool catalog + output schema are appended to the END of the volatile per-op lean prompt, so they're re-billed every op instead of riding the ~90%-cheaper cached prefix.

### What this lands — the gated mechanism (default-FALSE, OFF byte-identical)
- `_prompt_prefix_cache_enabled()` — master `JARVIS_PROMPT_PREFIX_CACHE_ENABLED`, **default-FALSE**.
- `_route_stable_tail(parts, stable_out, tool, schema, enabled)` — **one source of truth**. OFF (or no sink) appends tool-section (even `""`) then schema to the user-prompt `parts` **bit-for-bit** as the two prior `parts.append` calls; ON+sink diverts both into the stable sink (skipping an empty VENOM_SKIP tool section) for the caller to fold into the cached system prefix.
- `_build_lean_codegen_prompt` gains a `stable_prefix_out` param; computes the tool section once and routes tool+schema via the helper.

### Safety
No caller threads `stable_prefix_out` yet → the helper **always** takes the legacy `parts` branch in production, so this is **inert + bit-identical in prod even with the flag on**. Verified: OFF leaves the pre-existing `tool_use_interface` baseline unchanged (9 failures on clean HEAD == 9 with this change). 7 prefix-cache tests green.

### Activation (graduation gate — NOT in this PR)
Thread `stable_prefix_out` from the prompt build through the `_generate_raw` closures into the system composition at the **4 sites** (`generate`@4833/`_generate_raw`@4935; `generate`@7915 @8221/8635/8990; `_claude_do_stream`@7467), then a **live funded Anthropic soak** to verify the model still recognizes + uses its tools flawlessly once they move from the user message into the system prefix — the spec's Phase 3, a live-API behavior that cannot be unit-tested in this environment. Shipping the tested, safe mechanism now; activation + soak is the focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a gated path to move the stable tool catalog and output schema from the per-op user prompt to the cached system prefix to reduce token spend. Default is off, so behavior is byte-identical.

- **New Features**
  - Added `_prompt_prefix_cache_enabled()` behind `JARVIS_PROMPT_PREFIX_CACHE_ENABLED` (default false).
  - Added `_route_stable_tail(parts, stable_out, tool_section, schema_section, enabled)` to centralize routing; off/no sink → append to user prompt; on+sink → divert to system prefix; skips empty tool sections.
  - `_build_lean_codegen_prompt` now accepts `stable_prefix_out`; computes the tool section once and routes tool + schema via the helper.
  - Added tests for the gate, routing behavior, and cached-system integration; no caller threads `stable_prefix_out` yet, keeping runtime output unchanged.

<sup>Written for commit 7972fdf43a39574320607806f822b948074b3695. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

