### PR TITLE
Slice 133 — The Sovereign Episodic Memory Core (the hippocampus)

### DIFF
--- a/backend/core/ouroboros/governance/episodic_core.py
+++ b/backend/core/ouroboros/governance/episodic_core.py
@@ -1,0 +1,283 @@
+"""Slice 133 — The Sovereign Episodic Memory Core.
+
+A continuously-aware organism must passively recall its immediate past — what it
+just routed, generated, or failed at — without firing a manual MEMORY_SEARCH
+tool. This is the hippocampus: a continuous, append-only episodic ledger plus
+passive injection of the recent window into the generation prompt.
+
+**Pure composition — nothing reinvented:**
+  * **Durable tamper-evidence** — each episode appends a hash-chained receipt via
+    the existing ``BlueEvidenceLedger`` (red_blue_matrix), on a DEDICATED path
+    (``.jarvis/episodic_memory.jsonl``) so the dissertation evidence chain stays
+    pure. (The blue ledger stores ``payload_sha256`` — tamper-evidence — so the
+    full episode content lives in the in-memory window + the semantic index.)
+  * **Long-term recall** — as episodes fall out of the short-term window they are
+    embedded via the ``SemanticIndex`` embedder (``_embedder_factory``) and kept
+    for cosine recall. No new vectorizer.
+
+**Two memory tiers:**
+  * **Short-term window** — a bounded deque (``JARVIS_EPISODIC_WINDOW``, default 8)
+    of full episodes; this is what gets passively injected into the prompt.
+  * **Long-term** — evicted episodes, embedded, recalled by similarity.
+
+**P2a-safe injection:** ``render_episodic_context`` returns a block that the
+caller appends to the VOLATILE user-prompt tail only — episodes change every loop
+and must NEVER enter the cached system prefix. Gated ``JARVIS_EPISODIC_CORE_ENABLED``
+default-FALSE. All paths fail-soft (memory never blocks generation).
+"""
+from __future__ import annotations
+
+import dataclasses
+import os
+import threading
+import time
+from collections import deque
+from typing import Any, Deque, List, Optional, Sequence, Tuple
+
+_ENV_MASTER = "JARVIS_EPISODIC_CORE_ENABLED"
+_ENV_WINDOW = "JARVIS_EPISODIC_WINDOW"
+_ENV_LONGTERM_MAX = "JARVIS_EPISODIC_LONGTERM_MAX"
+_DEFAULT_WINDOW = 8
+_DEFAULT_LONGTERM_MAX = 512
+
+
+def episodic_core_enabled() -> bool:
+    """Master gate, default-FALSE per §33.1. NEVER raises."""
+    return os.getenv(_ENV_MASTER, "false").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _window_size() -> int:
+    try:
+        return max(1, int(os.getenv(_ENV_WINDOW, _DEFAULT_WINDOW)))
+    except (TypeError, ValueError):
+        return _DEFAULT_WINDOW
+
+
+def _longterm_max() -> int:
+    try:
+        return max(1, int(os.getenv(_ENV_LONGTERM_MAX, _DEFAULT_LONGTERM_MAX)))
+    except (TypeError, ValueError):
+        return _DEFAULT_LONGTERM_MAX
+
+
+@dataclasses.dataclass
+class Episode:
+    seq: int
+    ts: float
+    kind: str            # transition | route | error | complete | ...
+    op_id: str
+    summary: str
+    context: dict = dataclasses.field(default_factory=dict)
+
+    def render(self) -> str:
+        return f"- [{self.kind}] op={self.op_id}: {self.summary}"
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    try:
+        from backend.core.ouroboros.governance.semantic_index import _cosine as _si
+        return float(_si(a, b))
+    except Exception:  # noqa: BLE001
+        try:
+            num = sum(x * y for x, y in zip(a, b))
+            na = sum(x * x for x in a) ** 0.5
+            nb = sum(y * y for y in b) ** 0.5
+            return num / (na * nb) if na and nb else -1.0
+        except Exception:  # noqa: BLE001
+            return -1.0
+
+
+class EpisodicLedger:
+    """Append-only episodic memory: bounded short-term window + tamper-evident
+    durable receipts + long-term embedded recall. All async paths fail-soft."""
+
+    def __init__(
+        self,
+        *,
+        window: Optional[int] = None,
+        blue_ledger: Any = None,
+        embedder: Any = None,
+        longterm_max: Optional[int] = None,
+    ) -> None:
+        self._window: Deque[Episode] = deque(maxlen=window or _window_size())
+        self._longterm: Deque[Tuple[List[float], Episode]] = deque(
+            maxlen=longterm_max or _longterm_max()
+        )
+        self._blue = blue_ledger          # None → lazy default (dedicated path)
+        self._blue_resolved = blue_ledger is not None
+        self._embedder = embedder         # None → lazy SemanticIndex factory
+        self._seq = 0
+        self._lock = threading.Lock()
+
+    # ── substrate composition (lazy, fail-soft) ─────────────────────────────
+    def _blue_ledger(self) -> Any:
+        if not self._blue_resolved:
+            self._blue_resolved = True
+            try:
+                from pathlib import Path
+                from backend.core.ouroboros.governance.red_blue_matrix import (
+                    BlueEvidenceLedger,
+                )
+                self._blue = BlueEvidenceLedger(
+                    path=Path(".jarvis") / "episodic_memory.jsonl"
+                )
+            except Exception:  # noqa: BLE001
+                self._blue = None
+        return self._blue
+
+    def _get_embedder(self) -> Any:
+        if self._embedder is None:
+            try:
+                from backend.core.ouroboros.governance.semantic_index import (
+                    _embedder_factory,
+                )
+                self._embedder = _embedder_factory()
+            except Exception:  # noqa: BLE001
+                self._embedder = None
+        return self._embedder
+
+    def _embed(self, text: str) -> Optional[List[float]]:
+        try:
+            emb = self._get_embedder()
+            if emb is None:
+                return None
+            vecs = emb.embed([text or ""])
+            if not vecs or not vecs[0]:
+                return None
+            return [float(x) for x in vecs[0]]
+        except Exception:  # noqa: BLE001
+            return None
+
+    # ── record / recall ─────────────────────────────────────────────────────
+    async def record(
+        self, *, kind: str, op_id: str, summary: str,
+        context: Optional[dict] = None,
+    ) -> Optional[Episode]:
+        """Append an episode: durable hash-chained receipt + short-term window;
+        the episode evicted from the window is embedded into long-term recall.
+        Fail-soft — returns the Episode (or None on hard failure), never raises."""
+        try:
+            with self._lock:
+                ep = Episode(self._seq, time.time(), str(kind), str(op_id),
+                             str(summary or ""), dict(context or {}))
+                self._seq += 1
+                evicted: Optional[Episode] = None
+                if len(self._window) == self._window.maxlen:
+                    evicted = self._window[0]  # about to be dropped by append
+                self._window.append(ep)
+            # Durable tamper-evident receipt (best-effort).
+            try:
+                bl = self._blue_ledger()
+                if bl is not None:
+                    bl.record(attack_class=str(kind), payload=str(summary or ""),
+                              verdict="recorded", blocked=False)
+            except Exception:  # noqa: BLE001
+                pass
+            # Write-through the evicted episode → long-term semantic recall.
+            if evicted is not None:
+                self._writethrough(evicted)
+            return ep
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _writethrough(self, ep: Episode) -> None:
+        """Embed an aged-out episode for long-term recall. Fail-soft."""
+        vec = self._embed(ep.summary)
+        if vec is None:
+            return
+        with self._lock:
+            self._longterm.append((vec, ep))
+
+    def recent(self, n: int) -> List[Episode]:
+        """The immediate short-term window (most recent last). NEVER raises."""
+        try:
+            with self._lock:
+                items = list(self._window)
+            return items[-max(0, int(n)):] if n else items
+        except Exception:  # noqa: BLE001
+            return []
+
+    async def recall(self, query: str, k: int = 3) -> List[Episode]:
+        """Cosine recall over long-term (aged-out) episodes. Fail-soft → []."""
+        try:
+            qv = self._embed(query)
+            if qv is None:
+                return []
+            with self._lock:
+                snapshot = list(self._longterm)
+            scored = sorted(
+                ((_cosine(qv, v), ep) for v, ep in snapshot),
+                key=lambda t: t[0], reverse=True,
+            )
+            return [ep for _, ep in scored[: max(1, int(k))]]
+        except Exception:  # noqa: BLE001
+            return []
+
+    def render_recent(self, n: int) -> str:
+        """Render the recent window as a prompt block (VOLATILE — caller appends
+        to the user prompt tail, never the cached prefix). "" when empty."""
+        eps = self.recent(n)
+        if not eps:
+            return ""
+        body = "\n".join(ep.render() for ep in eps)
+        return (
+            "## Recent Episodes (your short-term memory — what you just did)\n\n"
+            + body
+        )
+
+
+# ── singleton + module helpers ──────────────────────────────────────────────
+_singleton: Optional[EpisodicLedger] = None
+_singleton_lock = threading.Lock()
+
+
+def get_episodic_ledger() -> EpisodicLedger:
+    global _singleton
+    if _singleton is None:
+        with _singleton_lock:
+            if _singleton is None:
+                _singleton = EpisodicLedger()
+    return _singleton
+
+
+def reset_episodic_ledger() -> None:
+    global _singleton
+    with _singleton_lock:
+        _singleton = None
+
+
+async def record_transition(
+    *, op_id: str, phase_from: str, phase_to: str,
+    summary: str = "", context: Optional[dict] = None,
+) -> Optional[Episode]:
+    """Convenience: record an FSM state transition. Gated + fail-soft."""
+    if not episodic_core_enabled():
+        return None
+    txt = summary or f"{phase_from} -> {phase_to}"
+    ctx = dict(context or {})
+    ctx.update({"phase_from": phase_from, "phase_to": phase_to})
+    return await get_episodic_ledger().record(
+        kind="transition", op_id=op_id, summary=txt, context=ctx,
+    )
+
+
+def render_episodic_context(n: int = 0) -> str:
+    """Gated render of the recent window for passive prompt injection. "" when
+    disabled/empty. NEVER raises."""
+    if not episodic_core_enabled():
+        return ""
+    try:
+        return get_episodic_ledger().render_recent(n or _window_size())
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+__all__ = [
+    "episodic_core_enabled",
+    "Episode",
+    "EpisodicLedger",
+    "get_episodic_ledger",
+    "reset_episodic_ledger",
+    "record_transition",
+    "render_episodic_context",
+]

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -2308,6 +2308,20 @@ def _build_lean_codegen_prompt(
             "## Session Lessons\n\n" + _session_lessons.strip()
         )
 
+    # ── 5a. Episodic memory (Slice 133) — passive recall of the immediate
+    # past. Appended to `parts` (the VOLATILE user-prompt tail) ONLY — episodes
+    # change every loop, so they must NEVER enter the P2a cached system prefix
+    # (`stable_prefix_out`). Gated JARVIS_EPISODIC_CORE_ENABLED; "" when off.
+    try:
+        from backend.core.ouroboros.governance.episodic_core import (
+            render_episodic_context as _render_episodes,
+        )
+        _episodes_block = _render_episodes()
+        if _episodes_block:
+            parts.append(_episodes_block)
+    except Exception:  # noqa: BLE001 — memory never blocks generation
+        pass
+
     # ── 5b. Dependency impact from Oracle graph ─────────────────────────
     _dep_summary = getattr(ctx, "dependency_summary", "")
     if isinstance(_dep_summary, str) and _dep_summary.strip():

--- a/tests/architecture/test_slice133_episodic_core.py
+++ b/tests/architecture/test_slice133_episodic_core.py
@@ -1,0 +1,143 @@
+"""Slice 133 — The Sovereign Episodic Memory Core.
+
+A continuously-aware organism must passively recall its immediate past without a
+manual MEMORY_SEARCH. This builds an append-only ``EpisodicLedger`` composing the
+existing tamper-evident ``BlueEvidenceLedger`` (hash-chain receipt per episode) +
+``SemanticIndex`` (long-term embedding as episodes age out of the short-term
+window), plus passive injection of the recent window into the generation prompt's
+VOLATILE tail (never the P2a cached prefix).
+
+Gated ``JARVIS_EPISODIC_CORE_ENABLED`` default-FALSE; embedder + ledger injectable
+→ unit-tested without fastembed / disk.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+
+from backend.core.ouroboros.governance import episodic_core as EC
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class _Emb:
+    """Deterministic fake embedder: summary→distinct unit vector by first char."""
+    def embed(self, texts):
+        out = []
+        for t in texts:
+            c = (t or "x")[0].lower()
+            out.append([1.0, 0.0, 0.0] if c in "ar" else [0.0, 1.0, 0.0])
+        return out
+
+
+class _BlueSpy:
+    def __init__(self):
+        self.records = []
+    def record(self, *, attack_class, payload, verdict, blocked, blocked_by=""):
+        self.records.append((attack_class, payload, verdict))
+        return object()
+
+
+class TestGate(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+
+    def test_default_false(self):
+        self.assertFalse(EC.episodic_core_enabled())
+
+
+class TestLedger(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "1"
+
+    def tearDown(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+
+    def _led(self, window=8, blue=None, emb=None):
+        return EC.EpisodicLedger(window=window, blue_ledger=blue, embedder=emb or _Emb())
+
+    def test_record_and_recent(self):
+        led = self._led()
+        for i in range(3):
+            _run(led.record(kind="transition", op_id=f"op{i}", summary=f"did thing {i}"))
+        recent = led.recent(2)
+        self.assertEqual(len(recent), 2)
+        self.assertEqual(recent[-1].summary, "did thing 2")
+
+    def test_window_evicts_oldest(self):
+        led = self._led(window=2)
+        for i in range(3):
+            _run(led.record(kind="transition", op_id=f"op{i}", summary=f"s{i}"))
+        recent = led.recent(10)
+        self.assertEqual(len(recent), 2)
+        self.assertEqual(recent[0].summary, "s1")  # s0 evicted
+
+    def test_durable_receipt_per_episode(self):
+        blue = _BlueSpy()
+        led = self._led(blue=blue)
+        _run(led.record(kind="error", op_id="opE", summary="boom"))
+        self.assertEqual(len(blue.records), 1)
+        self.assertEqual(blue.records[0][0], "error")      # attack_class = kind
+        self.assertEqual(blue.records[0][2], "recorded")   # verdict
+
+    def test_writethrough_on_eviction_enables_recall(self):
+        led = self._led(window=1)
+        _run(led.record(kind="route", op_id="o1", summary="apple routing decision"))
+        _run(led.record(kind="route", op_id="o2", summary="banana something else"))
+        # o1 ('apple' → [1,0,0]) evicted → embedded → recallable
+        hits = _run(led.recall("avocado query", k=1))  # 'a' → [1,0,0] matches apple
+        self.assertTrue(hits)
+        self.assertEqual(hits[0].op_id, "o1")
+
+    def test_writethrough_fail_soft(self):
+        class _Boom:
+            def embed(self, texts):
+                raise RuntimeError("embedder down")
+        led = self._led(window=1, emb=_Boom())
+        _run(led.record(kind="t", op_id="a", summary="x"))
+        _run(led.record(kind="t", op_id="b", summary="y"))  # eviction embed fails soft
+        self.assertEqual(led.recent(10)[-1].op_id, "b")  # ledger still works
+
+    def test_render_recent_block(self):
+        led = self._led()
+        _run(led.record(kind="complete", op_id="opX", summary="finished the refactor"))
+        block = led.render_recent(5)
+        self.assertIn("finished the refactor", block)
+        self.assertIn("opX", block)
+
+
+class TestRenderHelperGate(unittest.TestCase):
+    def tearDown(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        EC.reset_episodic_ledger()
+
+    def test_render_empty_when_disabled(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        self.assertEqual(EC.render_episodic_context(5), "")
+
+    def test_render_reflects_singleton_when_enabled(self):
+        os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "1"
+        EC.reset_episodic_ledger()
+        _run(EC.get_episodic_ledger().record(
+            kind="route", op_id="opR", summary="chose DW cheap tier"))
+        block = EC.render_episodic_context()
+        self.assertIn("chose DW cheap tier", block)
+        self.assertIn("opR", block)
+
+    def test_record_transition_convenience_gated(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        self.assertIsNone(_run(EC.record_transition(
+            op_id="o", phase_from="GENERATE", phase_to="VALIDATE")))
+        os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "1"
+        EC.reset_episodic_ledger()
+        ep = _run(EC.record_transition(
+            op_id="o", phase_from="GENERATE", phase_to="VALIDATE"))
+        self.assertIsNotNone(ep)
+        self.assertEqual(ep.context["phase_to"], "VALIDATE")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A continuously-aware organism must passively recall its immediate past without a manual MEMORY_SEARCH. **Pure composition** — no new ledger, no new vectorizer.

### `episodic_core.py` (NEW)
- **EpisodicLedger** — bounded short-term window (deque, `JARVIS_EPISODIC_WINDOW` default 8) of full Episodes + **tamper-evident durable receipts** via the existing `BlueEvidenceLedger` on a **dedicated path** (`.jarvis/episodic_memory.jsonl` — dissertation evidence chain stays pure) + **long-term recall**: episodes evicted from the window are embedded via `SemanticIndex._embedder_factory` and recalled by cosine. `record()/recall()/recent()/render_recent()` async-safe + **fail-soft** (memory never blocks generation). `record_transition()` for FSM hooks.
- **Passive injection (the hippocampus):** `render_episodic_context()` (gated) renders the recent window; `_build_lean_codegen_prompt` appends it to `parts` — the **VOLATILE user-prompt tail only**, never the P2a cached system prefix. Episodes change every loop, so the injection helper *only ever writes to `parts`* → **P2a-safe by construction**.

### Gating + safety
Master `JARVIS_EPISODIC_CORE_ENABLED` **default-FALSE** → OFF byte-identical (render returns `''` → nothing appended; verified `tool_use_interface` stays at its 9-failure pre-existing baseline).

### Tests — 10
window-evict · durable receipt (kind→attack_class) · write-through→recall · fail-soft embedder · render block · gated render · `record_transition` · recent ordering.

> Follow-on: wire `record_transition` at the orchestrator FSM transition points (gated) so the write-side captures every START→COMPLETE / route / error live; the read-side passive injection is wired here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an episodic memory core that passively recalls the immediate past and appends it to the volatile prompt tail, enabling short‑term awareness without manual searches. Default OFF behind `JARVIS_EPISODIC_CORE_ENABLED`, so behavior is unchanged unless enabled.

- New Features
  - `episodic_core.py`: `EpisodicLedger` with a bounded short‑term window (env `JARVIS_EPISODIC_WINDOW`, default 8) and long‑term recall by embedding evicted episodes via `SemanticIndex._embedder_factory` and cosine.
  - Durable, tamper‑evident receipts written via `BlueEvidenceLedger` to `.jarvis/episodic_memory.jsonl` (best‑effort, fail‑soft).
  - Passive prompt injection: `_build_lean_codegen_prompt` appends `render_episodic_context()` to `parts` only (never the P2a cached prefix).
  - Convenience hook: `record_transition(op_id, phase_from, phase_to, ...)`.
  - All paths fail‑soft; memory never blocks generation. `JARVIS_EPISODIC_LONGTERM_MAX` caps long‑term store.

- Tests
  - 10 tests covering window eviction, durable receipt shape, write‑through recall, fail‑soft embedder, gated rendering, ordering, and `record_transition`.

<sup>Written for commit a50cb2511b4b3f652b555414325fedb28ac25e08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

