### PR TITLE
Slice 134 — Autonomous FSM Synapse Integration (episodic write-side)

### DIFF
--- a/backend/core/ouroboros/governance/episodic_core.py
+++ b/backend/core/ouroboros/governance/episodic_core.py
@@ -261,6 +261,44 @@ async def record_transition(
     )
 
 
+_pending_tasks: set = set()
+
+
+def note_transition_nowait(
+    *, op_id: str, phase_from: str, phase_to: str,
+    summary: str = "", context: Optional[dict] = None,
+) -> None:
+    """FIRE-AND-FORGET, NON-BLOCKING FSM synapse for the hot orchestrator path.
+
+    Schedules ``record_transition`` as a background task on the running event loop
+    and returns IMMEDIATELY — it never awaits, so it cannot block or starve the
+    main loop. Gated (no-op when disabled) and fully fail-soft (never raises). In
+    a sync context with no running loop (tests/CLI) it best-effort runs the record
+    inline. The strong task reference is held until completion to prevent GC."""
+    if not episodic_core_enabled():
+        return
+    try:
+        import asyncio
+        coro = record_transition(
+            op_id=str(op_id) if op_id is not None else "",
+            phase_from=str(phase_from) if phase_from is not None else "",
+            phase_to=str(phase_to) if phase_to is not None else "",
+            summary=summary, context=context,
+        )
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is not None:
+            task = loop.create_task(coro)
+            _pending_tasks.add(task)
+            task.add_done_callback(_pending_tasks.discard)
+        else:
+            asyncio.run(coro)  # sync context (tests) — bounded, append-only
+    except Exception:  # noqa: BLE001 — a synapse must never perturb the FSM
+        pass
+
+
 def render_episodic_context(n: int = 0) -> str:
     """Gated render of the recent window for passive prompt injection. "" when
     disabled/empty. NEVER raises."""
@@ -279,5 +317,6 @@ __all__ = [
     "get_episodic_ledger",
     "reset_episodic_ledger",
     "record_transition",
+    "note_transition_nowait",
     "render_episodic_context",
 ]

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -150,6 +150,40 @@ def _slice12q_record_terminal(
     extracts the smallest correct payload from ctx + state + data,
     delegates idempotency + classification to SessionRecorder.
     NEVER raises."""
+    # Slice 134 — FSM synapse (write-side). Fire-and-forget episodic record of
+    # this terminal transition (START -> <terminal state>) with a context
+    # snapshot — captures COMPLETE / BLOCKED / failed (incl. IRON_GATE +
+    # REFUSED_SAFETY via reason_code) + the route the op took. Self-contained +
+    # recorder-INDEPENDENT (episodic memory must work in production without a
+    # battle-test SessionRecorder). Gated JARVIS_EPISODIC_CORE_ENABLED,
+    # non-blocking (scheduled, never awaited), fail-soft.
+    try:
+        from backend.core.ouroboros.governance.episodic_core import (
+            note_transition_nowait as _note_episode,
+        )
+        _state_value = getattr(state, "value", str(state)) or ""
+        _reason = (
+            getattr(ctx, "terminal_reason_code", "")
+            or (isinstance(data, dict) and (data.get("reason", "") or data.get("error", "")))
+            or ""
+        )
+        _op_id = str(getattr(ctx, "op_id", "") or "")
+        if _op_id:
+            _route = (
+                getattr(ctx, "provider_route", "")
+                or (isinstance(data, dict) and data.get("route", "")) or ""
+            )
+            _note_episode(
+                op_id=_op_id, phase_from="START", phase_to=str(_state_value),
+                summary=("op terminal " + str(_state_value)
+                         + (f" [{_reason}]" if _reason else "")),
+                context={
+                    "terminal_reason_code": str(_reason),
+                    "route": str(_route),
+                },
+            )
+    except Exception:  # noqa: BLE001 — synapse never perturbs the FSM
+        pass
     try:
         from backend.core.ouroboros.battle_test.session_recorder import (
             get_active_recorder,

--- a/tests/architecture/test_slice134_fsm_synapses.py
+++ b/tests/architecture/test_slice134_fsm_synapses.py
@@ -1,0 +1,104 @@
+"""Slice 134 — Autonomous FSM Synapse Integration (the write-side).
+
+The orchestrator's terminal hook fires ``note_transition_nowait`` — a
+fire-and-forget, NON-BLOCKING scheduler that records an episode (with a context
+snapshot) into the episodic ledger without awaiting on the hot path or starving
+the event loop. Gated by JARVIS_EPISODIC_CORE_ENABLED; fail-soft.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+
+from backend.core.ouroboros.governance import episodic_core as EC
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestNoteTransitionNowait(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "1"
+        EC.reset_episodic_ledger()
+
+    def tearDown(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        EC.reset_episodic_ledger()
+
+    def test_disabled_noop(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        EC.note_transition_nowait(op_id="o", phase_from="A", phase_to="B")
+        self.assertEqual(EC.get_episodic_ledger().recent(10), [])
+
+    def test_schedules_on_running_loop_nonblocking(self):
+        async def go():
+            # Returns immediately (no await) — the record runs as a scheduled task.
+            EC.note_transition_nowait(
+                op_id="o1", phase_from="START", phase_to="COMPLETE",
+                summary="cycle done", context={"reason": "ok", "route": "background"},
+            )
+            await asyncio.sleep(0.05)  # let the scheduled task run
+            eps = EC.get_episodic_ledger().recent(10)
+            self.assertTrue(eps)
+            self.assertEqual(eps[-1].op_id, "o1")
+            self.assertEqual(eps[-1].context.get("reason"), "ok")
+            self.assertEqual(eps[-1].context.get("phase_to"), "COMPLETE")
+        _run(go())
+
+    def test_nonblocking_returns_before_task_completes(self):
+        async def go():
+            EC.note_transition_nowait(op_id="o2", phase_from="GENERATE", phase_to="VALIDATE")
+            # Immediately after the call, the task has NOT yet run (we never awaited).
+            self.assertEqual(EC.get_episodic_ledger().recent(10), [])
+            await asyncio.sleep(0.05)
+            self.assertTrue(EC.get_episodic_ledger().recent(10))
+        _run(go())
+
+    def test_fail_soft_never_raises(self):
+        # Bizarre inputs in a sync context must not raise.
+        EC.note_transition_nowait(op_id=None, phase_from=None, phase_to=None)
+
+
+class TestOrchestratorSynapse(unittest.TestCase):
+    """The orchestrator terminal hook fires the synapse — recorder-INDEPENDENT,
+    capturing the context snapshot (reason code + route)."""
+
+    def setUp(self):
+        os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "1"
+        EC.reset_episodic_ledger()
+
+    def tearDown(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        EC.reset_episodic_ledger()
+
+    def test_terminal_records_episode_without_recorder(self):
+        import types
+        from backend.core.ouroboros.governance import orchestrator as ORC
+        ctx = types.SimpleNamespace(
+            op_id="op-T", terminal_reason_code="IRON_GATE_BLOCKED",
+            provider_route="immediate",
+        )
+        state = types.SimpleNamespace(value="BLOCKED")
+        # No active SessionRecorder in this test → proves the synapse is
+        # independent of the battle-test recorder.
+        ORC._slice12q_record_terminal(ctx, state, {"route": "immediate"})
+        eps = EC.get_episodic_ledger().recent(10)
+        self.assertTrue(eps)
+        self.assertEqual(eps[-1].op_id, "op-T")
+        self.assertEqual(eps[-1].kind, "transition")
+        self.assertEqual(eps[-1].context.get("terminal_reason_code"), "IRON_GATE_BLOCKED")
+        self.assertEqual(eps[-1].context.get("phase_to"), "BLOCKED")
+
+    def test_terminal_noop_when_disabled(self):
+        import types
+        from backend.core.ouroboros.governance import orchestrator as ORC
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        ctx = types.SimpleNamespace(op_id="op-D", terminal_reason_code="", provider_route="")
+        ORC._slice12q_record_terminal(ctx, types.SimpleNamespace(value="COMPLETE"), {})
+        self.assertEqual(EC.get_episodic_ledger().recent(10), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Wires the orchestrator's live event loop into the Slice-133 episodic ledger so the hippocampus is actively fed — no manual state logging.

### `episodic_core.py`
`note_transition_nowait()` — **fire-and-forget, NON-BLOCKING** FSM synapse. Schedules `record_transition` as a background task on the running loop and returns immediately (never awaits → can't block/starve the main loop); sync contexts run it inline. Holds a strong task ref (no GC). Gated `JARVIS_EPISODIC_CORE_ENABLED`, fail-soft.

### `orchestrator.py` (`_slice12q_record_terminal`)
Fires the synapse at the terminal FSM junction — captures every **START→terminal** transition (COMPLETE / BLOCKED / failed, incl. **IRON_GATE** + **REFUSED_SAFETY** via `terminal_reason_code`) with a **context snapshot** (reason code + route). Placed at the **top** of the function, **recorder-independent** (episodic memory must work in prod without a battle-test SessionRecorder, which the legacy body early-returns on). Gated + non-blocking + fail-soft → **OFF byte-identical** (session-recorder/terminal regression 37 green).

### Tests — 16
disabled no-op · schedules-on-running-loop · non-blocking-returns-before-task · fail-soft · **orchestrator terminal records episode WITHOUT a recorder + context snapshot** · disabled no-op at the hook.

> Follow-on (optional): add synapses at the CAI/economic routing decision points (`kind=route`) for richer mid-cycle episodes; the highest-value terminal junction (outcomes + blocks + route) is wired here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a non-blocking FSM synapse to record terminal transitions into the episodic ledger and wires it into the orchestrator’s terminal hook. Episodes are recorded asynchronously with context (reason + route), gated by `JARVIS_EPISODIC_CORE_ENABLED`, and safe without a SessionRecorder.

- **New Features**
  - `episodic_core.note_transition_nowait`: schedules `record_transition` on the running event loop and returns immediately; holds a strong task ref; falls back to inline run in sync contexts; fail-soft.
  - Orchestrator `_slice12q_record_terminal`: fires the synapse for every `START -> <terminal>` transition, including `terminal_reason_code` and `provider_route` in the context; non-blocking, recorder-independent, and no behavior change when disabled.

<sup>Written for commit 83b8eb91853fe715d48abf38e185926f69ccbade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

