### PR TITLE
Slice 135 — Mid-Cycle Cognitive Synapse Matrix (routing memory + coalesce guard)

### DIFF
--- a/backend/core/ouroboros/governance/episodic_core.py
+++ b/backend/core/ouroboros/governance/episodic_core.py
@@ -68,6 +68,7 @@ class Episode:
     op_id: str
     summary: str
     context: dict = dataclasses.field(default_factory=dict)
+    coalesce_key: str = ""  # Slice 135 — non-empty groups mid-cycle spam (e.g. routing)
 
     def render(self) -> str:
         return f"- [{self.kind}] op={self.op_id}: {self.summary}"
@@ -151,15 +152,33 @@ class EpisodicLedger:
     # ── record / recall ─────────────────────────────────────────────────────
     async def record(
         self, *, kind: str, op_id: str, summary: str,
-        context: Optional[dict] = None,
+        context: Optional[dict] = None, coalesce_key: str = "",
     ) -> Optional[Episode]:
         """Append an episode: durable hash-chained receipt + short-term window;
         the episode evicted from the window is embedded into long-term recall.
-        Fail-soft — returns the Episode (or None on hard failure), never raises."""
+
+        **Slice 135 spam-guard:** when ``coalesce_key`` is non-empty and an
+        episode with the same key is already in the window, that episode is
+        UPDATED IN PLACE (latest summary + merged context + ``coalesced_count``)
+        instead of appending a new one — so a flurry of mid-cycle micro-routing
+        decisions collapses to one high-signal episode and cannot flush the
+        terminal episodes out of the window (no append → no eviction → no extra
+        durable I/O). Fail-soft — never raises."""
         try:
             with self._lock:
+                if coalesce_key:
+                    for existing in self._window:
+                        if existing.coalesce_key == coalesce_key:
+                            existing.summary = str(summary or "")
+                            existing.ts = time.time()
+                            existing.context.update(dict(context or {}))
+                            existing.context["coalesced_count"] = (
+                                existing.context.get("coalesced_count", 1) + 1
+                            )
+                            return existing  # coalesced — no append, no eviction
                 ep = Episode(self._seq, time.time(), str(kind), str(op_id),
-                             str(summary or ""), dict(context or {}))
+                             str(summary or ""), dict(context or {}),
+                             str(coalesce_key or ""))
                 self._seq += 1
                 evicted: Optional[Episode] = None
                 if len(self._window) == self._window.maxlen:
@@ -261,30 +280,30 @@ async def record_transition(
     )
 
 
+async def record_route(
+    *, op_id: str, router: str, summary: str = "", context: Optional[dict] = None,
+) -> Optional[Episode]:
+    """Record a routing decision (kind=route), COALESCED per op so mid-cycle
+    micro-decisions collapse to one high-signal episode. Gated + fail-soft."""
+    if not episodic_core_enabled():
+        return None
+    ctx = dict(context or {})
+    ctx["router"] = str(router)
+    return await get_episodic_ledger().record(
+        kind="route", op_id=str(op_id),
+        summary=summary or f"{router} routing decision",
+        context=ctx, coalesce_key=f"route:{op_id}",
+    )
+
+
 _pending_tasks: set = set()
 
 
-def note_transition_nowait(
-    *, op_id: str, phase_from: str, phase_to: str,
-    summary: str = "", context: Optional[dict] = None,
-) -> None:
-    """FIRE-AND-FORGET, NON-BLOCKING FSM synapse for the hot orchestrator path.
-
-    Schedules ``record_transition`` as a background task on the running event loop
-    and returns IMMEDIATELY — it never awaits, so it cannot block or starve the
-    main loop. Gated (no-op when disabled) and fully fail-soft (never raises). In
-    a sync context with no running loop (tests/CLI) it best-effort runs the record
-    inline. The strong task reference is held until completion to prevent GC."""
-    if not episodic_core_enabled():
-        return
+def _fire_nowait(coro) -> None:
+    """Schedule ``coro`` fire-and-forget on the running loop (or run inline in a
+    sync context). Non-blocking, fail-soft; holds a strong task ref (no GC)."""
+    import asyncio
     try:
-        import asyncio
-        coro = record_transition(
-            op_id=str(op_id) if op_id is not None else "",
-            phase_from=str(phase_from) if phase_from is not None else "",
-            phase_to=str(phase_to) if phase_to is not None else "",
-            summary=summary, context=context,
-        )
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -294,9 +313,42 @@ def note_transition_nowait(
             _pending_tasks.add(task)
             task.add_done_callback(_pending_tasks.discard)
         else:
-            asyncio.run(coro)  # sync context (tests) — bounded, append-only
+            asyncio.run(coro)  # sync context (tests/CLI) — bounded
     except Exception:  # noqa: BLE001 — a synapse must never perturb the FSM
-        pass
+        try:
+            coro.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def note_transition_nowait(
+    *, op_id: str, phase_from: str, phase_to: str,
+    summary: str = "", context: Optional[dict] = None,
+) -> None:
+    """FIRE-AND-FORGET, NON-BLOCKING FSM synapse for the hot orchestrator path —
+    schedules ``record_transition`` and returns immediately. Gated + fail-soft."""
+    if not episodic_core_enabled():
+        return
+    _fire_nowait(record_transition(
+        op_id=str(op_id) if op_id is not None else "",
+        phase_from=str(phase_from) if phase_from is not None else "",
+        phase_to=str(phase_to) if phase_to is not None else "",
+        summary=summary, context=context,
+    ))
+
+
+def note_route_nowait(
+    *, op_id: str, router: str, summary: str = "", context: Optional[dict] = None,
+) -> None:
+    """FIRE-AND-FORGET, NON-BLOCKING mid-cycle ROUTING synapse — schedules
+    ``record_route`` (coalesced per op) and returns immediately. Gated +
+    fail-soft. Safe to call from the hot routing path."""
+    if not episodic_core_enabled():
+        return
+    _fire_nowait(record_route(
+        op_id=str(op_id) if op_id is not None else "",
+        router=str(router), summary=summary, context=context,
+    ))
 
 
 def render_episodic_context(n: int = 0) -> str:
@@ -317,6 +369,8 @@ __all__ = [
     "get_episodic_ledger",
     "reset_episodic_ledger",
     "record_transition",
+    "record_route",
     "note_transition_nowait",
+    "note_route_nowait",
     "render_episodic_context",
 ]

--- a/backend/core/ouroboros/governance/route_decision_service.py
+++ b/backend/core/ouroboros/governance/route_decision_service.py
@@ -145,6 +145,27 @@ class RouteDecisionService:
                     decision.tier, decision.model or "-",
                     decision.escalated, decision.reason,
                 )
+                # Slice 135 — mid-cycle cognitive synapse: record the CAI routing
+                # decision as a coalesced episode (fire-and-forget, gated,
+                # non-blocking, fail-soft). Captures tier/difficulty/confidence so
+                # the organism remembers HOW it routed, not just the outcome.
+                try:
+                    from backend.core.ouroboros.governance.episodic_core import (
+                        note_route_nowait as _note_route,
+                    )
+                    _note_route(
+                        op_id=str(getattr(self, "_last_op_id", "") or "cai"),
+                        router="cai",
+                        summary=f"CAI → {decision.tier} (diff={decision.difficulty})",
+                        context={
+                            "tier": decision.tier,
+                            "difficulty": decision.difficulty,
+                            "confidence": decision.confidence,
+                            "escalated": decision.escalated,
+                        },
+                    )
+                except Exception:  # noqa: BLE001 — synapse never perturbs routing
+                    pass
             return decision
         except Exception as exc:  # noqa: BLE001 — fail-closed
             logger.debug("[CAIRouter] shadow consult skipped: %s", exc)

--- a/tests/architecture/test_slice135_routing_synapses.py
+++ b/tests/architecture/test_slice135_routing_synapses.py
@@ -1,0 +1,139 @@
+"""Slice 135 — Mid-Cycle Cognitive Synapse Matrix (routing decisions).
+
+Wires routing decisions (CAI tier cascade, economic failover, brain selection)
+into the episodic ledger as ``kind=route`` episodes — with a structural
+COALESCING spam-guard so a flurry of mid-cycle micro-routing decisions cannot
+flush the high-signal terminal episodes out of the short-term window.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+
+from backend.core.ouroboros.governance import episodic_core as EC
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestCoalesceGuard(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "1"
+        EC.reset_episodic_ledger()
+
+    def tearDown(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        EC.reset_episodic_ledger()
+
+    def _led(self, window=8):
+        return EC.EpisodicLedger(window=window, embedder=_NoEmb())
+
+    def test_same_key_coalesces_into_one_episode(self):
+        led = self._led()
+        for i in range(5):
+            _run(led.record(kind="route", op_id="X", summary=f"tier decision {i}",
+                            context={"tier": "doubleword", "i": i}, coalesce_key="route:X"))
+        eps = led.recent(10)
+        route_eps = [e for e in eps if e.kind == "route"]
+        self.assertEqual(len(route_eps), 1)                       # 5 → 1
+        self.assertEqual(route_eps[0].summary, "tier decision 4") # latest wins
+        self.assertEqual(route_eps[0].context.get("coalesced_count"), 5)
+
+    def test_coalesce_preserves_high_signal_terminals(self):
+        # window=3. Without coalescing, 5 route appends between two terminals
+        # would flush terminal A. With the guard, A survives.
+        led = self._led(window=3)
+        _run(led.record(kind="transition", op_id="A", summary="A COMPLETE"))
+        for i in range(5):
+            _run(led.record(kind="route", op_id="X", summary=f"r{i}",
+                            coalesce_key="route:X"))
+        _run(led.record(kind="transition", op_id="B", summary="B COMPLETE"))
+        summaries = [e.summary for e in led.recent(10)]
+        self.assertIn("A COMPLETE", summaries)   # high-signal terminal preserved
+        self.assertIn("B COMPLETE", summaries)
+        self.assertEqual(len([e for e in led.recent(10) if e.kind == "route"]), 1)
+
+    def test_different_keys_stay_separate(self):
+        led = self._led()
+        _run(led.record(kind="route", op_id="X", summary="rx", coalesce_key="route:X"))
+        _run(led.record(kind="route", op_id="Y", summary="ry", coalesce_key="route:Y"))
+        self.assertEqual(len([e for e in led.recent(10) if e.kind == "route"]), 2)
+
+    def test_no_key_appends_normally(self):
+        led = self._led()
+        _run(led.record(kind="route", op_id="X", summary="a"))
+        _run(led.record(kind="route", op_id="X", summary="b"))
+        self.assertEqual(len(led.recent(10)), 2)  # no coalesce_key → 2 episodes
+
+
+class _NoEmb:
+    def embed(self, texts):
+        return [[1.0, 0.0, 0.0] for _ in texts]
+
+
+class TestRouteSynapse(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "1"
+        EC.reset_episodic_ledger()
+
+    def tearDown(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        EC.reset_episodic_ledger()
+
+    def test_record_route_gated(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        self.assertIsNone(_run(EC.record_route(
+            op_id="o", router="cai", summary="x")))
+
+    def test_record_route_coalesces_by_op(self):
+        for i in range(3):
+            _run(EC.record_route(op_id="o9", router="cai",
+                                 summary=f"cascade {i}", context={"tier": "claude_heavy"}))
+        eps = EC.get_episodic_ledger().recent(10)
+        route_eps = [e for e in eps if e.kind == "route"]
+        self.assertEqual(len(route_eps), 1)
+        self.assertEqual(route_eps[0].context.get("router"), "cai")
+        self.assertEqual(route_eps[0].context.get("coalesced_count"), 3)
+
+    def test_note_route_nowait_nonblocking(self):
+        async def go():
+            EC.note_route_nowait(op_id="oN", router="economic",
+                                 summary="failover→haiku", context={"tier": "claude_low_cost"})
+            self.assertEqual(EC.get_episodic_ledger().recent(10), [])  # not yet run
+            await asyncio.sleep(0.05)
+            eps = EC.get_episodic_ledger().recent(10)
+            self.assertTrue(eps)
+            self.assertEqual(eps[-1].kind, "route")
+            self.assertEqual(eps[-1].context.get("router"), "economic")
+        _run(go())
+
+
+class TestRouteDecisionWiring(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "1"
+        os.environ["JARVIS_CAI_ROUTER_ENABLED"] = "1"
+        EC.reset_episodic_ledger()
+
+    def tearDown(self):
+        for k in ("JARVIS_EPISODIC_CORE_ENABLED", "JARVIS_CAI_ROUTER_ENABLED"):
+            os.environ.pop(k, None)
+        EC.reset_episodic_ledger()
+
+    def test_cai_tier_advisory_records_route_episode(self):
+        from backend.core.ouroboros.governance.route_decision_service import (
+            RouteDecisionService,
+        )
+        from backend.core.ouroboros.governance.brain_selector import BrainSelector
+        svc = RouteDecisionService(BrainSelector())
+        _run(svc.cai_tier_advisory("refactor the module", "heavy_code"))
+        eps = EC.get_episodic_ledger().recent(10)
+        route_eps = [e for e in eps if e.kind == "route"]
+        self.assertTrue(route_eps)
+        self.assertEqual(route_eps[-1].context.get("router"), "cai")
+        self.assertIn("tier", route_eps[-1].context)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The organism remembered its terminal destinations (S134) but forgot HOW it routed. This wires mid-cycle routing decisions into the episodic ledger with a structural spam-guard.

### `episodic_core.py`
- **COALESCING spam-guard** — `EpisodicLedger.record(coalesce_key=)`: when an episode with the same key is already in the window, it's **updated in place** (latest summary + merged context + `coalesced_count`) instead of appended. A flurry of mid-cycle micro-routing decisions collapses to **one** high-signal episode and **cannot flush the terminal episodes** out of the window (no append → no eviction → no extra durable I/O).
- `record_route(op_id, router, ...)` → `kind=route`, coalesced per op (`key=route:<op>`).
- `note_route_nowait(...)` → fire-and-forget non-blocking route synapse (shared `_fire_nowait` scheduler; closes the coro if scheduling fails — no "never awaited").

### `route_decision_service.py`
`cai_tier_advisory` fires `note_route_nowait` after the CAI decision — captures **tier / difficulty / confidence / escalated** as a coalesced route episode (gated + non-blocking + fail-soft). The organism now remembers *how* it routed.

### Tests — 8
coalesce 5→1 · **high-signal terminal preservation under route spam** · distinct keys · no-key normal append · record_route gated/coalesced · note_route_nowait non-blocking · cai_tier_advisory records route episode. 39 green across episodic + synapse + CAI suites. Master `JARVIS_EPISODIC_CORE_ENABLED` default-FALSE → OFF byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds mid-cycle routing memory to the episodic ledger with a coalescing spam-guard, merging routing micro-decisions into a single high-signal `route` episode per op and preventing window churn. Gated behind `JARVIS_EPISODIC_CORE_ENABLED` (default off).

- **New Features**
  - `EpisodicLedger.record(coalesce_key=)`: updates in place for matching keys, merges context, tracks `coalesced_count`, and avoids eviction/extra I/O.
  - `record_route(op_id, router, ...)` and `note_route_nowait(...)`: emit `kind=route` episodes; non-blocking via shared `_fire_nowait`; fail-soft.
  - `cai_tier_advisory`: emits a coalesced route episode capturing tier, difficulty, confidence, and escalated. 
  - Tests cover coalescing (5→1), terminal preservation, non-blocking behavior, and CAI wiring.

<sup>Written for commit 42e1d18c61bdef3696c30f8aab1297303ad61227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

