### PR TITLE
Slice 136 — Cognitive Graduation Matrix (final synapse + autonomous episodic ignition)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3598,6 +3598,29 @@ class CandidateGenerator:
                             "queued for cheap provider (op=%s)",
                             _econ.reason, op_id_short,
                         )
+                    # Slice 136 — economic-router cognitive synapse. Fired from
+                    # OUTSIDE the pure decide() (the AST-pinned classifier has no
+                    # side effects), so the organism remembers its economic
+                    # failover decisions. Coalesced per op; gated + non-blocking +
+                    # fail-soft.
+                    try:
+                        from backend.core.ouroboros.governance.episodic_core import (
+                            note_route_nowait as _note_route,
+                        )
+                        _note_route(
+                            op_id=str(op_id_short or ""),
+                            router="economic",
+                            summary=(f"economic {_econ.action.value} → "
+                                     f"{_econ.model or 'cheap-default'}"),
+                            context={
+                                "action": _econ.action.value,
+                                "tier": _econ.model or "cheap_default",
+                                "route": str(provider_route),
+                                "reason": _econ.reason,
+                            },
+                        )
+                    except Exception:  # noqa: BLE001 — synapse never perturbs routing
+                        pass
             except Exception:  # noqa: BLE001 - economic routing is best-effort
                 logger.debug("[CandidateGenerator] EconomicRouter consult skipped", exc_info=True)
             if _can_cascade:

--- a/backend/core/ouroboros/governance/graduation_orchestrator.py
+++ b/backend/core/ouroboros/governance/graduation_orchestrator.py
@@ -36,8 +36,9 @@ logger = logging.getLogger(__name__)
 
 _ENV_MASTER = "JARVIS_GRADUATION_ORCHESTRATOR_ENABLED"
 
-# The ONLY flags this harness may autonomously flip — the Slice-131 cost tiers
-# (all ROUTING/TUNING class, never SAFETY). Everything else is fail-closed.
+# The ONLY flags this harness may autonomously flip — explicitly-vetted
+# non-SAFETY substrates (Slice-131 cost tiers, all ROUTING/TUNING class, plus the
+# Slice-133 episodic memory core). Everything else is fail-closed (refused).
 _COST_CANDIDATES = frozenset({
     "JARVIS_SEMANTIC_CACHE_ENABLED",
     "JARVIS_CAI_ROUTER_ENABLED",
@@ -45,6 +46,7 @@ _COST_CANDIDATES = frozenset({
     "JARVIS_PROMPT_PREFIX_CACHE_ENABLED",
     "JARVIS_PROVIDER_RESPONSE_CACHE_ENABLED",
     "JARVIS_ECONOMIC_ROUTER_ENABLED",
+    "JARVIS_EPISODIC_CORE_ENABLED",   # Slice 136 — the central nervous system
 })
 
 # Substrings that mark a key as credential-shaped — NEVER persisted by this harness.
@@ -153,6 +155,45 @@ async def _default_assertion(flag: str) -> AssertionResult:
             await c.store("q", object(), None, repo_digest="R")
             hit = await c.lookup("q", None, repo_digest="R")
             return AssertionResult(flag, hit is not None, "semantic write-through+near-match")
+        if flag == "JARVIS_EPISODIC_CORE_ENABLED":
+            import asyncio as _aio
+            from backend.core.ouroboros.governance import episodic_core as _EC
+            os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "1"
+            _EC.reset_episodic_ledger()
+            _probe = "episodic-graduation-probe-7f3a"
+            # Write an episode through the async nowait synapse, then wait for it
+            # to clear (proves the non-blocking write-through path).
+            _EC.note_transition_nowait(
+                op_id="grad-probe", phase_from="START", phase_to="COMPLETE",
+                summary=_probe,
+            )
+            await _aio.sleep(0.1)
+            # Assert it renders into the VOLATILE prompt tail. Primary: the exact
+            # content the builder appends (render_episodic_context); bonus: the
+            # full _build_lean_codegen_prompt path when a ctx can be constructed.
+            rendered = _EC.render_episodic_context()
+            in_render = _probe in rendered
+            in_builder = False
+            try:
+                import types as _types
+                from backend.core.ouroboros.governance.providers import (
+                    _build_lean_codegen_prompt as _blcp,
+                )
+                _ctx = _types.SimpleNamespace(
+                    op_id="grad-probe", description="probe", target_files=(),
+                    human_instructions="", implementation_plan="",
+                    session_lessons="", dependency_summary="", provider_route="",
+                )
+                _prompt = _blcp(_ctx)
+                in_builder = _probe in _prompt
+            except Exception:  # noqa: BLE001 — builder ctx best-effort
+                in_builder = False
+            passed = in_render or in_builder
+            return AssertionResult(
+                flag, passed,
+                f"episode rendered into volatile tail (render={in_render}, "
+                f"builder={in_builder})",
+            )
         if flag == "JARVIS_CAI_ROUTER_ENABLED":
             from backend.core.ouroboros.governance import cai_router as CR
             os.environ["JARVIS_CAI_ROUTER_ENABLED"] = "1"

--- a/tests/architecture/test_slice136_cognitive_ignition.py
+++ b/tests/architecture/test_slice136_cognitive_ignition.py
@@ -1,0 +1,94 @@
+"""Slice 136 — The Cognitive Graduation Matrix (final synapse + episodic ignition).
+
+The economic-router synapse is wired at the candidate_generator call site (outside
+the pure decide()) — its mechanism is exercised by the Slice-135 route synapse
+tests (router="economic"). This suite proves the headline: the graduation harness
+can run a LIVE episodic integration assertion (write an episode → wait for the
+async nowait → assert it renders into the volatile prompt tail) and, on pass,
+AUTONOMOUSLY flip + persist JARVIS_EPISODIC_CORE_ENABLED — within the recursion
+bound (episodic is an explicitly-vetted non-SAFETY substrate).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import tempfile
+import unittest
+
+from backend.core.ouroboros.governance import graduation_orchestrator as GO
+from backend.core.ouroboros.governance import episodic_core as EC
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestEpisodicGraduation(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_GRADUATION_ORCHESTRATOR_ENABLED"] = "1"
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        EC.reset_episodic_ledger()
+
+    def tearDown(self):
+        for k in ("JARVIS_GRADUATION_ORCHESTRATOR_ENABLED",
+                  "JARVIS_EPISODIC_CORE_ENABLED"):
+            os.environ.pop(k, None)
+        EC.reset_episodic_ledger()
+
+    def test_episodic_is_vetted_not_safety(self):
+        self.assertIn("JARVIS_EPISODIC_CORE_ENABLED", GO._COST_CANDIDATES)
+        self.assertFalse(GO.is_safety_flag("JARVIS_EPISODIC_CORE_ENABLED"))
+
+    def test_live_episodic_assertion_passes(self):
+        res = _run(GO._default_assertion("JARVIS_EPISODIC_CORE_ENABLED"))
+        self.assertTrue(res.passed, res.detail)
+        self.assertIn("render=True", res.detail)
+
+    def test_autonomous_ignition_flips_and_persists(self):
+        with tempfile.TemporaryDirectory() as d:
+            env = pathlib.Path(d) / ".env"
+            env.write_text("ANTHROPIC_API_KEY=sk-ant-SECRET\nUNRELATED=keep\n")
+            os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+            out = _run(GO.graduate(
+                "JARVIS_EPISODIC_CORE_ENABLED", persist=True, env_path=env))
+            self.assertEqual(out.action, GO.GraduationAction.GRADUATED)
+            self.assertTrue(out.flipped)
+            self.assertEqual(os.environ.get("JARVIS_EPISODIC_CORE_ENABLED"), "1")
+            text = env.read_text()
+            self.assertIn("JARVIS_EPISODIC_CORE_ENABLED=1", text)   # ignited in .env
+            self.assertIn("ANTHROPIC_API_KEY=sk-ant-SECRET", text)  # credential untouched
+            self.assertIn("UNRELATED=keep", text)
+
+    def test_operator_disable_still_honored(self):
+        # Even with a passing assertion, an explicit =0 is never overridden.
+        os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "0"
+        out = _run(GO.graduate("JARVIS_EPISODIC_CORE_ENABLED"))
+        self.assertEqual(out.action, GO.GraduationAction.HELD_OPERATOR_PRECEDENCE)
+
+
+class TestEconomicSynapseMechanism(unittest.TestCase):
+    """The economic synapse uses the same route-synapse path (router=economic);
+    here we confirm the coalesced economic episode shape the call-site emits."""
+
+    def setUp(self):
+        os.environ["JARVIS_EPISODIC_CORE_ENABLED"] = "1"
+        EC.reset_episodic_ledger()
+
+    def tearDown(self):
+        os.environ.pop("JARVIS_EPISODIC_CORE_ENABLED", None)
+        EC.reset_episodic_ledger()
+
+    def test_economic_route_episode_shape(self):
+        _run(EC.record_route(
+            op_id="opE", router="economic",
+            summary="economic cascade_cheap → claude-haiku-4-5",
+            context={"action": "cascade_cheap", "tier": "claude-haiku-4-5"}))
+        eps = [e for e in EC.get_episodic_ledger().recent(10) if e.kind == "route"]
+        self.assertTrue(eps)
+        self.assertEqual(eps[-1].context.get("router"), "economic")
+        self.assertEqual(eps[-1].context.get("action"), "cascade_cheap")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the dangling economic synapse and turns on the central nervous system autonomously.

### P1 — economic synapse (`candidate_generator`)
Fires `note_route_nowait` from the economic_router **call site** (after `_ER.decide()`), capturing action / tier / route / reason as a coalesced route episode. Fired from **outside** the pure `decide()` — the AST-pinned PURE-DATA classifier keeps zero side effects (discipline preserved). Gated + non-blocking + fail-soft.

### P2/P3 — episodic graduation + autonomous ignition (`graduation_orchestrator`)
- `JARVIS_EPISODIC_CORE_ENABLED` added to the vetted non-SAFETY graduatable allowlist (still fail-closed for everything else — **recursion bound intact**).
- **Live episodic assertion:** enables episodic → writes an episode via the async `note_transition_nowait` synapse → waits for it to clear → asserts it rendered into the **volatile prompt tail** (`render_episodic_context` — the exact content the builder appends — plus a best-effort full-builder check). On pass → `graduate()` flips + persists the flag in `.env` via the bounded credential-safe writer.

### Live telemetry (Phase 4)
```
JARVIS_EPISODIC_CORE_ENABLED   graduated  flipped=True  (render=True)
JARVIS_SEMANTIC_CACHE_ENABLED  graduated  flipped=True
JARVIS_CAI_ROUTER_ENABLED      graduated  flipped=True
.env → all three =1; ANTHROPIC_API_KEY untouched
episode → volatile tail: confirmed online
```

### Tests — 6
episodic vetted-not-safety · live assertion passes · autonomous ignition flips+persists+credential-safe · operator-disable (=0) honored · economic episode shape. 27 green across economic + routing-synapse suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the economic routing synapse and adds autonomous episodic ignition. A live write→render check confirms episodic is working, then flips and persists `JARVIS_EPISODIC_CORE_ENABLED`.

- **New Features**
  - Economic synapse: from `candidate_generator` after `_ER.decide()` fire `note_route_nowait` to record action/tier/route/reason. Runs outside the pure classifier, gated, non-blocking, and fail-soft.
  - Graduation: `graduation_orchestrator` now allows `JARVIS_EPISODIC_CORE_ENABLED`. Writes an episode via `note_transition_nowait`, waits, verifies in `render_episodic_context` (plus `_build_lean_codegen_prompt` best-effort). On pass, flips env and persists to `.env` with the credential-safe writer. Operator `=0` is honored.
  - Tests: add `tests/architecture/test_slice136_cognitive_ignition.py` covering vetting, live assertion pass, autonomous flip+persistence, operator precedence, and economic route episode shape.

<sup>Written for commit dbd11761d3c569c2af6faa18e4e3b64c00ad91ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

