### PR TITLE
Slice 138 — The Sovereign Infrastructure Matrix (indestructible deployment)

### DIFF
--- a/backend/core/ouroboros/governance/state_persistence_daemon.py
+++ b/backend/core/ouroboros/governance/state_persistence_daemon.py
@@ -1,0 +1,192 @@
+"""Slice 138 — Autonomous State Persistence Daemon (the Evidence Vault).
+
+Continuously backs up the ``.jarvis/`` directory — the organism's episodic memory
+(``episodic_memory.jsonl``), tamper-evident evidence chain
+(``dissertation_evidence.jsonl``), and signed roadmap — to a remote target so the
+12-month T5 evidence + memory survive host-death. No manual backups.
+
+**Pluggable backend** (``JARVIS_BACKUP_BACKEND`` = ``rsync`` | ``s3`` | ``git``)
+to a ``JARVIS_BACKUP_TARGET``. **Gated** ``JARVIS_STATE_BACKUP_ENABLED``
+default-FALSE. **Async + fail-soft**: a backup failure (network down, bad target,
+non-zero exit) is logged and swallowed — it must NEVER crash the soak. The shell
+runner is injectable so the command-building + loop logic is fully unit-tested
+without touching the network or disk.
+
+Run as its own process / systemd unit:
+    python3 -m backend.core.ouroboros.governance.state_persistence_daemon
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import subprocess
+import time
+from typing import Awaitable, Callable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV_MASTER = "JARVIS_STATE_BACKUP_ENABLED"
+_ENV_BACKEND = "JARVIS_BACKUP_BACKEND"
+_ENV_TARGET = "JARVIS_BACKUP_TARGET"
+_ENV_SRC = "JARVIS_BACKUP_SRC"
+_ENV_INTERVAL = "JARVIS_BACKUP_INTERVAL_S"
+_ENV_CMD_TIMEOUT = "JARVIS_BACKUP_CMD_TIMEOUT_S"
+
+_DEFAULT_SRC = ".jarvis"
+_DEFAULT_INTERVAL = 900.0   # 15 min
+_DEFAULT_CMD_TIMEOUT = 300.0
+
+
+def state_backup_enabled() -> bool:
+    """Master gate, default-FALSE per §33.1. NEVER raises."""
+    return os.getenv(_ENV_MASTER, "false").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _backend() -> str:
+    return (os.getenv(_ENV_BACKEND, "rsync") or "rsync").strip().lower()
+
+
+def _target() -> str:
+    return (os.getenv(_ENV_TARGET, "") or "").strip()
+
+
+def _src() -> str:
+    return (os.getenv(_ENV_SRC, _DEFAULT_SRC) or _DEFAULT_SRC).strip()
+
+
+def _interval_s() -> float:
+    try:
+        return max(1.0, float(os.getenv(_ENV_INTERVAL, _DEFAULT_INTERVAL)))
+    except (TypeError, ValueError):
+        return _DEFAULT_INTERVAL
+
+
+def _cmd_timeout_s() -> float:
+    try:
+        return max(1.0, float(os.getenv(_ENV_CMD_TIMEOUT, _DEFAULT_CMD_TIMEOUT)))
+    except (TypeError, ValueError):
+        return _DEFAULT_CMD_TIMEOUT
+
+
+def _redact(target: str) -> str:
+    """Never log a target that may embed a credential (e.g. https://tok@host)."""
+    if "@" in target:
+        return target.split("@", 1)[-1]  # drop anything before '@'
+    return target
+
+
+def build_backup_commands(backend: str, src: str, target: str) -> List[List[str]]:
+    """Pure: map (backend, src, target) → an ordered list of argv command lists.
+    rsync/s3 are one command; git is add → commit → push. Unknown → [] (no-op).
+    NEVER raises."""
+    b = (backend or "").strip().lower()
+    if not src or not target:
+        return []
+    if b == "rsync":
+        # Mirror the dir (trailing slash → contents), prune deletions remotely.
+        return [["rsync", "-az", "--delete", f"{src.rstrip('/')}/", target]]
+    if b == "s3":
+        return [["aws", "s3", "sync", src, target, "--delete"]]
+    if b == "git":
+        # A self-contained git repo INSIDE src pushing to a private remote.
+        msg = f"state-vault snapshot {int(time.time())}"
+        return [
+            ["git", "-C", src, "add", "-A"],
+            ["git", "-C", src, "commit", "-m", msg, "--allow-empty"],
+            ["git", "-C", src, "push", target, "HEAD"],
+        ]
+    return []
+
+
+async def _default_runner(cmd: List[str]) -> int:
+    """Run ``cmd`` off the event loop with a hard timeout. Returns the exit code
+    (non-zero on failure / timeout). NEVER raises out."""
+    def _call() -> int:
+        try:
+            proc = subprocess.run(
+                cmd, capture_output=True, timeout=_cmd_timeout_s(),
+            )
+            return int(proc.returncode)
+        except Exception:  # noqa: BLE001
+            return 1
+    return await asyncio.to_thread(_call)
+
+
+_Runner = Callable[[List[str]], Awaitable[int]]
+
+
+async def run_once(*, runner: Optional[_Runner] = None) -> bool:
+    """Back up once. Gated + fail-soft. Returns True iff every command in the
+    backend sequence exited 0. NEVER raises."""
+    if not state_backup_enabled():
+        return False
+    try:
+        backend, src, target = _backend(), _src(), _target()
+        cmds = build_backup_commands(backend, src, target)
+        if not cmds:
+            logger.debug("[StateVault] no-op (backend=%s target set=%s)",
+                         backend, bool(target))
+            return False
+        run = runner or _default_runner
+        for cmd in cmds:
+            rc = await run(cmd)
+            if rc != 0:
+                logger.warning("[StateVault] backup step failed rc=%s backend=%s → %s",
+                               rc, backend, _redact(target))
+                return False
+        logger.info("[StateVault] backed up %s → %s (%s)", src, _redact(target), backend)
+        return True
+    except Exception as exc:  # noqa: BLE001 — backup must never crash the soak
+        logger.warning("[StateVault] backup swallowed: %s", exc)
+        return False
+
+
+async def run_forever(
+    *, interval_s: Optional[float] = None,
+    runner: Optional[_Runner] = None,
+    stop: Optional[asyncio.Event] = None,
+) -> None:
+    """Continuous backup loop. Backs up every ``interval_s`` until ``stop`` is
+    set. Each iteration is fail-soft. NEVER raises out."""
+    interval = interval_s if interval_s is not None else _interval_s()
+    logger.info("[StateVault] daemon started (interval=%.0fs, backend=%s)",
+                interval, _backend())
+    while True:
+        await run_once(runner=runner)
+        if stop is not None and stop.is_set():
+            return
+        try:
+            if stop is not None:
+                try:
+                    await asyncio.wait_for(stop.wait(), timeout=interval)
+                    return  # stop fired during the wait
+                except asyncio.TimeoutError:
+                    pass
+            else:
+                await asyncio.sleep(interval)
+        except Exception:  # noqa: BLE001
+            await asyncio.sleep(interval)
+
+
+def _main() -> None:  # pragma: no cover — process entrypoint
+    logging.basicConfig(level=logging.INFO)
+    if not state_backup_enabled():
+        logger.warning("[StateVault] JARVIS_STATE_BACKUP_ENABLED not set — exiting")
+        return
+    try:
+        asyncio.run(run_forever())
+    except KeyboardInterrupt:
+        pass
+
+
+__all__ = [
+    "state_backup_enabled",
+    "build_backup_commands",
+    "run_once",
+    "run_forever",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _main()

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,58 @@
+# Slice 138 — The Sovereign Infrastructure Matrix
+
+Reboot-surviving, self-backing-up deployment for the T5 unattended soak. One
+command arms the crypto gate and launches the organism as systemd services.
+
+## One-command ignition (Linux + systemd)
+
+```bash
+./scripts/arm_and_launch.sh
+```
+
+It will: provision the Ed25519 operator key (if needed, passphrase-prompted —
+never stored) → sign `.jarvis/roadmap.draft.yaml` → `.jarvis/roadmap.signed.yaml`
+→ render + install two **user** systemd units → `enable --now` both →
+`enable-linger` so they survive logout **and** reboot.
+
+### Prerequisites (you provide)
+- `.env` at repo root with funded `DOUBLEWORD_API_KEY` / `ANTHROPIC_API_KEY`
+  (loaded by `launch_shadow_soak.sh`'s Slice-125 credential bootstrap; never
+  parsed by systemd).
+- `.jarvis/roadmap.draft.yaml` — your authority-free draft of the SAFE authorized
+  scopes. The **un-signable floor still holds absolutely**: Order-2/M10, recursion
+  breach, governance touches, and `APPROVAL_REQUIRED`/`BLOCKED` always escalate to
+  a live operator regardless of signature.
+- (Optional but recommended) a backup target so `.jarvis/` survives host-death.
+
+## The two services
+| Unit | What |
+|---|---|
+| `jarvis-agent.service` | The soak: `launch_shadow_soak.sh --production-soak --layer4-autonomous --headless`. `Restart=always`, 10s→5min exponential backoff (systemd ≥254), logs → `.jarvis/t5_soak.out`. Prefix-cache stays OFF (inert until its seam lands). |
+| `jarvis-state-vault.service` | The evidence vault: `state_persistence_daemon` continuously mirrors `.jarvis/` (episodic memory + tamper-evident evidence chain + signed roadmap) to your remote target. Gated, fail-soft. |
+
+### State-vault backends (`JARVIS_BACKUP_BACKEND` + `JARVIS_BACKUP_TARGET`)
+- `rsync` → `user@host:/vault` (needs ssh-agent / key)
+- `s3` → `s3://bucket/jarvis` (needs `AWS_*` in `.env`)
+- `git` → a private remote (a self-contained repo inside `.jarvis/`)
+
+## Monitor / stop
+```bash
+systemctl --user status jarvis-agent.service
+tail -f .jarvis/t5_soak.out
+systemctl --user stop jarvis-agent.service jarvis-state-vault.service
+```
+
+## Non-systemd hosts
+- **macOS** dev hosts have no systemd — run the soak on a dedicated **Linux**
+  server. (A `launchd` plist is the macOS equivalent; not shipped here.)
+- Quick/ephemeral fallback (dies on reboot — not for a real 12-month run):
+  ```bash
+  nohup env JARVIS_SOVEREIGN_KEYS_ENABLED=1 JARVIS_EPISODIC_CORE_ENABLED=1 \
+    JARVIS_SEMANTIC_CACHE_ENABLED=1 JARVIS_CAI_ROUTER_ENABLED=1 JARVIS_KAREN_VOICE_ENABLED=0 \
+    ./scripts/launch_shadow_soak.sh --production-soak --layer4-autonomous --headless \
+    --cost-cap 500 --idle-timeout 0 --max-wall-seconds 0 > .jarvis/t5_soak.out 2>&1 &
+  ```
+
+> Run on a **dedicated host**, never nested under another agent/event loop
+> (Slices 123 & 127: nesting causes control-plane starvation — environmental,
+> not a code defect).

--- a/deploy/jarvis-agent.service.template
+++ b/deploy/jarvis-agent.service.template
@@ -1,0 +1,45 @@
+# JARVIS Sovereign Organism — T5 Unattended Soak (Slice 137/138)
+# Rendered by scripts/arm_and_launch.sh (@PLACEHOLDERS@ are substituted with the
+# absolute repo path + chosen cost cap). Installed as a systemd unit so the soak
+# survives reboots and crashes — Restart=always with exponential backoff.
+#
+# Linux only (systemd). A macOS dev host has no systemd — run the soak on a
+# dedicated Linux server (see deploy/README.md for the launchd/nohup fallback).
+
+[Unit]
+Description=JARVIS Sovereign Organism — T5 Unattended Soak
+After=network-online.target
+Wants=network-online.target
+# Never stop trying to restart over a 12-month run (disable the start-rate limit).
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+WorkingDirectory=@REPO_ROOT@
+# Funded provider creds (DOUBLEWORD_API_KEY / ANTHROPIC_API_KEY / HF_TOKEN) live
+# in @REPO_ROOT@/.env and are loaded by launch_shadow_soak.sh's Slice-125
+# credential bootstrap — NOT via systemd EnvironmentFile (which mis-parses
+# quoted/secret values). Only feature flags are set here.
+Environment=JARVIS_SOVEREIGN_KEYS_ENABLED=1
+Environment=JARVIS_LAYER4_ROADMAP_ENABLED=1
+Environment=JARVIS_EPISODIC_CORE_ENABLED=1
+Environment=JARVIS_SEMANTIC_CACHE_ENABLED=1
+Environment=JARVIS_CAI_ROUTER_ENABLED=1
+# Prefix-cache stays OFF: its activation seam isn't wired (inert until then).
+Environment=JARVIS_PROMPT_PREFIX_CACHE_ENABLED=0
+Environment=JARVIS_KAREN_VOICE_ENABLED=0
+ExecStart=/usr/bin/env bash @REPO_ROOT@/scripts/launch_shadow_soak.sh --production-soak --layer4-autonomous --headless --cost-cap @COST_CAP@ --idle-timeout 0 --max-wall-seconds 0
+# Resilience: always restart; 10s base, exponential to 5 min (systemd >= 254).
+# On older systemd, RestartSteps/RestartMaxDelaySec are ignored → fixed 10s.
+Restart=always
+RestartSec=10
+RestartSteps=5
+RestartMaxDelaySec=300
+# Persistent, append-only logs in the evidence dir (backed up by the state vault).
+StandardOutput=append:@REPO_ROOT@/.jarvis/t5_soak.out
+StandardError=append:@REPO_ROOT@/.jarvis/t5_soak.out
+TimeoutStopSec=30
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=default.target

--- a/deploy/jarvis-state-vault.service.template
+++ b/deploy/jarvis-state-vault.service.template
@@ -1,0 +1,30 @@
+# JARVIS State Vault — autonomous .jarvis/ backup daemon (Slice 138)
+# Rendered by scripts/arm_and_launch.sh. Continuously mirrors the organism's
+# memory + tamper-evident evidence chain to a remote target so they survive
+# host-death. Fail-soft (a backup failure never affects the soak).
+
+[Unit]
+Description=JARVIS State Vault — autonomous evidence/memory backup
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+WorkingDirectory=@REPO_ROOT@
+# Backend creds (e.g. AWS_* for s3, or ssh-agent for rsync) come from @REPO_ROOT@/.env.
+EnvironmentFile=-@REPO_ROOT@/.env
+Environment=JARVIS_STATE_BACKUP_ENABLED=1
+Environment=JARVIS_BACKUP_BACKEND=@BACKUP_BACKEND@
+Environment=JARVIS_BACKUP_TARGET=@BACKUP_TARGET@
+Environment=JARVIS_BACKUP_INTERVAL_S=@BACKUP_INTERVAL_S@
+ExecStart=/usr/bin/env python3 -m backend.core.ouroboros.governance.state_persistence_daemon
+Restart=always
+RestartSec=10
+RestartSteps=5
+RestartMaxDelaySec=300
+StandardOutput=append:@REPO_ROOT@/.jarvis/state_vault.out
+StandardError=append:@REPO_ROOT@/.jarvis/state_vault.out
+
+[Install]
+WantedBy=default.target

--- a/scripts/arm_and_launch.sh
+++ b/scripts/arm_and_launch.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# =============================================================================
+# arm_and_launch.sh — Slice 138: The Indestructible Deployment
+# One foolproof command to arm the cryptographic gate and launch the T5 Sovereign
+# Organism as reboot-surviving systemd services (the soak + the state vault).
+#
+#   1. Provision the Ed25519 operator key (if needed) + sign the roadmap.
+#   2. Render + install the systemd units (agent + state vault) as USER services.
+#   3. enable --now both + enable-linger so they survive logout AND reboot.
+#
+# Linux + systemd only. Run from anywhere inside the repo. Re-runnable (idempotent).
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+JARVIS_DIR="$REPO_ROOT/.jarvis"
+DEPLOY="$REPO_ROOT/deploy"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+mkdir -p "$JARVIS_DIR" "$UNIT_DIR"
+
+log() { printf '\033[36m[arm]\033[0m %s\n' "$*"; }
+die() { printf '\033[31m[arm] FATAL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v systemctl >/dev/null 2>&1 || die "systemctl not found — this host has no systemd. \
+Run the soak on a dedicated Linux server (see deploy/README.md for the launchd/nohup fallback)."
+
+# ── Preflight: funded creds present? (loaded by launch_shadow_soak.sh) ────────
+if [ ! -f "$REPO_ROOT/.env" ]; then
+  log "WARNING: no .env at repo root — DOUBLEWORD_API_KEY / ANTHROPIC_API_KEY must be present for a real soak."
+fi
+
+# ── Phase 1: cryptographic provisioning + roadmap signing ────────────────────
+PUB="$JARVIS_DIR/layer4_operator.pub"
+if [ ! -f "$PUB" ] && [ -z "${JARVIS_LAYER4_OPERATOR_PUBKEY:-}" ]; then
+  log "No operator key found — provisioning (you'll be prompted for a passphrase; it is NEVER stored)."
+  python3 -m backend.core.ouroboros.governance.sovereign_keys provision
+else
+  log "Operator key already provisioned."
+fi
+
+DRAFT="$JARVIS_DIR/roadmap.draft.yaml"
+SIGNED="$JARVIS_DIR/roadmap.signed.yaml"
+if [ ! -f "$DRAFT" ]; then
+  die "No roadmap draft at $DRAFT. Author your SAFE authorized scopes there first \
+(an unsigned, authority-free draft), then re-run. The un-signable floor still holds: \
+Order-2/M10, recursion, governance, and APPROVAL_REQUIRED/BLOCKED always escalate to you."
+fi
+log "Signing roadmap: $DRAFT → $SIGNED (passphrase prompt)."
+python3 -m backend.core.ouroboros.governance.sovereign_keys sign --draft "$DRAFT" --out "$SIGNED"
+[ -f "$SIGNED" ] || die "Signing did not produce $SIGNED."
+
+# ── Phase 2: operator parameters (sane defaults) ─────────────────────────────
+COST_CAP="${JARVIS_T5_COST_CAP:-500}"
+BACKUP_BACKEND="${JARVIS_BACKUP_BACKEND:-}"
+BACKUP_TARGET="${JARVIS_BACKUP_TARGET:-}"
+BACKUP_INTERVAL_S="${JARVIS_BACKUP_INTERVAL_S:-900}"
+if [ -z "$BACKUP_TARGET" ]; then
+  read -r -p "[arm] State-vault backend (rsync/s3/git) [skip]: " BACKUP_BACKEND || true
+  if [ -n "${BACKUP_BACKEND:-}" ]; then
+    read -r -p "[arm] State-vault target (e.g. user@host:/vault | s3://bucket/jarvis | git-remote): " BACKUP_TARGET || true
+  fi
+fi
+
+# ── Phase 3: render + install the systemd units ──────────────────────────────
+render() { # render <template> <dest>
+  sed -e "s|@REPO_ROOT@|$REPO_ROOT|g" \
+      -e "s|@COST_CAP@|$COST_CAP|g" \
+      -e "s|@BACKUP_BACKEND@|${BACKUP_BACKEND:-rsync}|g" \
+      -e "s|@BACKUP_TARGET@|${BACKUP_TARGET:-}|g" \
+      -e "s|@BACKUP_INTERVAL_S@|$BACKUP_INTERVAL_S|g" \
+      "$1" > "$2"
+}
+render "$DEPLOY/jarvis-agent.service.template" "$UNIT_DIR/jarvis-agent.service"
+log "Installed $UNIT_DIR/jarvis-agent.service (cost-cap=\$$COST_CAP)."
+
+systemctl --user daemon-reload
+
+# Survive logout AND reboot without an interactive session.
+loginctl enable-linger "$USER" 2>/dev/null || log "enable-linger skipped (may need: sudo loginctl enable-linger $USER)."
+
+if [ -n "${BACKUP_TARGET:-}" ]; then
+  render "$DEPLOY/jarvis-state-vault.service.template" "$UNIT_DIR/jarvis-state-vault.service"
+  systemctl --user daemon-reload
+  systemctl --user enable --now jarvis-state-vault.service
+  log "State Vault ARMED → ${BACKUP_TARGET} (every ${BACKUP_INTERVAL_S}s)."
+else
+  log "WARNING: no backup target — .jarvis/ is NOT protected against host-death. Re-run with a target to arm the vault."
+fi
+
+systemctl --user enable --now jarvis-agent.service
+
+# ── Status ───────────────────────────────────────────────────────────────────
+log "═══════════════════════════════════════════════════════════════"
+log "T5 SOVEREIGN ORGANISM IGNITED."
+log "  Soak:        systemctl --user status jarvis-agent.service"
+log "  State Vault: systemctl --user status jarvis-state-vault.service"
+log "  Live logs:   tail -f $JARVIS_DIR/t5_soak.out"
+log "  Stop:        systemctl --user stop jarvis-agent.service jarvis-state-vault.service"
+log "═══════════════════════════════════════════════════════════════"

--- a/tests/architecture/test_slice138_state_persistence.py
+++ b/tests/architecture/test_slice138_state_persistence.py
@@ -1,0 +1,131 @@
+"""Slice 138 — Autonomous State Persistence (the Evidence Vault).
+
+Continuously backs up the ``.jarvis/`` directory (dissertation_evidence.jsonl +
+episodic_memory.jsonl + signed roadmap) to a remote target so the organism's
+memory + evidence chain survive host-death — no manual backups.
+
+Pluggable backend (rsync / s3 / git), gated default-FALSE, async + fail-soft
+(a backup failure must never crash the soak). The shell runner is injectable so
+the command-building + loop logic is tested without touching the network/disk.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+
+from backend.core.ouroboros.governance import state_persistence_daemon as SP
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestGate(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JARVIS_STATE_BACKUP_ENABLED", None)
+
+    def test_default_false(self):
+        self.assertFalse(SP.state_backup_enabled())
+
+
+class TestBuildCommand(unittest.TestCase):
+    def test_rsync(self):
+        cmds = SP.build_backup_commands("rsync", ".jarvis", "user@host:/vault")
+        self.assertEqual(len(cmds), 1)
+        self.assertEqual(cmds[0][0], "rsync")
+        self.assertIn("--delete", cmds[0])
+        self.assertIn("user@host:/vault", cmds[0])
+
+    def test_s3(self):
+        cmds = SP.build_backup_commands("s3", ".jarvis", "s3://my-vault/jarvis")
+        self.assertEqual(cmds[0][:3], ["aws", "s3", "sync"])
+        self.assertIn("s3://my-vault/jarvis", cmds[0])
+
+    def test_git_is_three_step(self):
+        cmds = SP.build_backup_commands("git", ".jarvis", "origin")
+        self.assertEqual(len(cmds), 3)            # add → commit → push
+        self.assertEqual(cmds[0][:2], ["git", "-C"])
+        self.assertIn("add", cmds[0])
+        self.assertIn("commit", cmds[1])
+        self.assertIn("push", cmds[2])
+
+    def test_unknown_backend_is_noop(self):
+        self.assertEqual(SP.build_backup_commands("ftp", ".jarvis", "x"), [])
+
+
+class TestRunOnce(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_STATE_BACKUP_ENABLED"] = "1"
+        os.environ["JARVIS_BACKUP_BACKEND"] = "rsync"
+        os.environ["JARVIS_BACKUP_TARGET"] = "user@host:/vault"
+
+    def tearDown(self):
+        for k in ("JARVIS_STATE_BACKUP_ENABLED", "JARVIS_BACKUP_BACKEND",
+                  "JARVIS_BACKUP_TARGET"):
+            os.environ.pop(k, None)
+
+    def test_disabled_is_noop(self):
+        os.environ.pop("JARVIS_STATE_BACKUP_ENABLED", None)
+        calls = []
+        ok = _run(SP.run_once(runner=lambda cmd: calls.append(cmd) or 0))
+        self.assertFalse(ok)
+        self.assertEqual(calls, [])
+
+    def test_runs_the_backend_command(self):
+        calls = []
+        async def _runner(cmd):
+            calls.append(cmd)
+            return 0  # exit code 0 = success
+        ok = _run(SP.run_once(runner=_runner))
+        self.assertTrue(ok)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "rsync")
+
+    def test_nonzero_exit_is_failsoft(self):
+        async def _runner(cmd):
+            return 1  # failure
+        ok = _run(SP.run_once(runner=_runner))
+        self.assertFalse(ok)  # reported, not raised
+
+    def test_runner_exception_is_failsoft(self):
+        async def _runner(cmd):
+            raise RuntimeError("network down")
+        ok = _run(SP.run_once(runner=_runner))
+        self.assertFalse(ok)  # swallowed → soak never crashes
+
+    def test_no_target_is_noop(self):
+        os.environ.pop("JARVIS_BACKUP_TARGET", None)
+        ok = _run(SP.run_once(runner=lambda cmd: 0))
+        self.assertFalse(ok)
+
+
+class TestRunForever(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_STATE_BACKUP_ENABLED"] = "1"
+        os.environ["JARVIS_BACKUP_BACKEND"] = "rsync"
+        os.environ["JARVIS_BACKUP_TARGET"] = "user@host:/vault"
+
+    def tearDown(self):
+        for k in ("JARVIS_STATE_BACKUP_ENABLED", "JARVIS_BACKUP_BACKEND",
+                  "JARVIS_BACKUP_TARGET"):
+            os.environ.pop(k, None)
+
+    def test_loops_until_stopped(self):
+        calls = []
+        async def _runner(cmd):
+            calls.append(cmd)
+            return 0
+        async def go():
+            stop = asyncio.Event()
+            task = asyncio.ensure_future(
+                SP.run_forever(interval_s=0.01, runner=_runner, stop=stop))
+            await asyncio.sleep(0.05)
+            stop.set()
+            await task
+        _run(go())
+        self.assertGreaterEqual(len(calls), 2)  # backed up repeatedly
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reboot-surviving, self-backing-up deployment for the T5 soak. No manual daemon files, no manual backups.

### `state_persistence_daemon.py` (the Evidence Vault)
Continuously mirrors `.jarvis/` (episodic memory + tamper-evident evidence chain + signed roadmap) to a remote target so the organism's memory survives host-death. Pluggable backend (**rsync / s3 / git** via `JARVIS_BACKUP_BACKEND`+`TARGET`), gated `JARVIS_STATE_BACKUP_ENABLED` default-FALSE, async + **fail-soft** (a backup failure logs + is swallowed — never crashes the soak), hard per-command timeout, credential-redacted logging. **11 tests** (injectable runner → no network/disk).

### `deploy/jarvis-agent.service.template` + `jarvis-state-vault.service.template`
systemd units — `Restart=always` + 10s→5min exponential backoff (systemd ≥254), `StartLimitIntervalSec=0` (never give up over 12 months), logs append to `.jarvis/t5_soak.out`, runs the exact verified launch command (prefix-cache OFF).

### `scripts/arm_and_launch.sh`
One foolproof command: provisions the Ed25519 key (passphrase-prompted, never stored) → signs the roadmap → prompts for the backup target → renders+installs both **user** systemd units → `enable-linger` (survive logout+reboot) → `enable --now`. Refuses on non-systemd hosts with the launchd/nohup pointer. `bash -n` clean; idempotent.

### `deploy/README.md`
Deployment guide + non-systemd fallback + the dedicated-host caveat (never nest under another event loop — Slices 123/127).

> Config/infra only — no changes to the live loop. Backup daemon gated default-FALSE; systemd units are operator-installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reboot‑surviving deployment for the T5 soak with a fail‑soft state vault that continuously backs up `.jarvis/`. One command now provisions keys, signs the roadmap, installs user systemd services, and keeps the soak running across reboots.

- **New Features**
  - `state_persistence_daemon.py`: async, fail‑soft backup of `.jarvis/` to a remote target. Backends `rsync`/`s3`/`git` via `JARVIS_BACKUP_BACKEND` + `JARVIS_BACKUP_TARGET`, gated by `JARVIS_STATE_BACKUP_ENABLED` (default false), with hard timeouts and redacted logging.
  - `deploy/jarvis-agent.service.template` and `deploy/jarvis-state-vault.service.template`: user systemd units with `Restart=always`, exponential backoff, and append‑only logs under `.jarvis/`.
  - `scripts/arm_and_launch.sh`: provisions the Ed25519 operator key, signs the roadmap, prompts for a backup target, installs and enables both services, and sets `enable-linger`. Refuses non‑systemd hosts.
  - `deploy/README.md`: deployment guide and non‑systemd fallback.

- **Migration**
  - Ensure `.env` has funded API keys and `.jarvis/roadmap.draft.yaml` exists.
  - Run `./scripts/arm_and_launch.sh`, pick `rsync`/`s3`/`git` and set the backup target when prompted.
  - Check status: `systemctl --user status jarvis-agent.service jarvis-state-vault.service`. If no target was set, the vault service is skipped and backups remain off.

<sup>Written for commit ccd52b6a69f67780603f450f4e3d05c6ebc7117f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

