### PR TITLE
Slice 139 — The Sovereign Migration Matrix (autonomous cloud migration)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,40 @@
-# Slice 138 — The Sovereign Infrastructure Matrix
+# Slice 138/139 — The Sovereign Infrastructure & Migration Matrix
 
 Reboot-surviving, self-backing-up deployment for the T5 unattended soak. One
-command arms the crypto gate and launches the organism as systemd services.
+command arms the crypto gate and launches the organism as systemd services — and
+one command migrates the whole organism from your workstation to a cloud host.
+
+## Autonomous cloud migration (Slice 139) — workstation → industrial host
+
+From the **main checkout** (where `.jarvis/` holds the real keys + signed roadmap):
+
+```bash
+# Package, ship, provision, and ignite on a fresh Linux host — one command:
+./scripts/migrate_to_host.sh ops@gcp-jprime /opt/jarvis --launch
+```
+
+It runs three composable pieces (each usable alone):
+- **`scripts/pack_sovereign_release.sh`** → a lean `.tar.gz`: excludes `.venv`,
+  `.git`, caches, and the 600M+ of regenerable `.jarvis` state; **preserves** the
+  Ed25519 pubkey + salt + meta + **signed roadmap** + the tamper-evident evidence
+  chain + episodic memory (allowlist) so the organism wakes up authorized and
+  remembering; **`.env` is NEVER in the artifact**.
+- **`deploy/provision_host.sh`** (IaC bootstrap) → installs Python 3.11+, the
+  build toolchain (numpy/fastembed), git/rsync, makes the venv, `pip install -r
+  requirements.txt`, and import-sanity-checks the deps. apt + dnf.
+- **The handshake** → `scp`s the artifact, ships `.env` **out-of-band** over the
+  same authenticated SSH (never in the tarball), extracts, provisions, and (with
+  `--launch`) runs `arm_and_launch.sh`. Because the signed roadmap travels in the
+  artifact, the host ignition is **non-interactive** (no passphrase prompt;
+  `arm_and_launch.sh` skips re-signing when a signed roadmap is present).
+
+Omit `--launch` to stage + provision only, then verify `.env` and ignite manually.
+
+---
+
+## One-command ignition (Linux + systemd)
+
+```bash
 
 ## One-command ignition (Linux + systemd)
 

--- a/deploy/provision_host.sh
+++ b/deploy/provision_host.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# =============================================================================
+# provision_host.sh — Slice 139: Infrastructure-as-Code bootstrap
+# Provisions a fresh Linux host with the exact dependencies the JARVIS sovereign
+# organism needs, then builds its venv. Idempotent; run ON the target host from
+# inside the extracted artifact directory (migrate_to_host.sh does this for you).
+#
+# Provides: Python 3.11+, build toolchain (numpy / fastembed native deps),
+# z3-solver system prereqs, git + rsync (state vault), systemd (already present
+# on a standard Linux server). Supports apt (Debian/Ubuntu) + dnf (RHEL/Fedora).
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+log() { printf '\033[36m[provision]\033[0m %s\n' "$*"; }
+die() { printf '\033[31m[provision] FATAL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+SUDO=""; [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+
+# ── 1. System dependencies ───────────────────────────────────────────────────
+if command -v apt-get >/dev/null 2>&1; then
+  log "apt: installing system deps…"
+  $SUDO apt-get update -y
+  $SUDO apt-get install -y --no-install-recommends \
+    python3 python3-venv python3-pip python3-dev \
+    build-essential git rsync ca-certificates curl
+elif command -v dnf >/dev/null 2>&1; then
+  log "dnf: installing system deps…"
+  $SUDO dnf install -y python3 python3-pip python3-devel \
+    gcc gcc-c++ make git rsync ca-certificates curl
+else
+  die "no apt-get or dnf — install python3.11+, build tools, git, rsync manually."
+fi
+
+# ── 2. Python version gate (3.11+ ideal; 3.9 hard minimum per CLAUDE.md) ─────
+PYV="$(python3 -c 'import sys;print("%d.%d"%sys.version_info[:2])')"
+log "python3 = $PYV"
+python3 - <<'PY' || die "Python 3.9+ required (3.11+ recommended)."
+import sys
+raise SystemExit(0 if sys.version_info[:2] >= (3, 9) else 1)
+PY
+case "$PYV" in 3.9|3.10) log "WARNING: $PYV works but 3.11+ is recommended for the soak." ;; esac
+
+# ── 3. Virtualenv + Python deps ──────────────────────────────────────────────
+if [ ! -d .venv ]; then log "creating .venv…"; python3 -m venv .venv; fi
+# shellcheck disable=SC1091
+. .venv/bin/activate
+log "installing requirements (this pulls anthropic / aiohttp / cryptography / numpy / fastembed / z3-solver)…"
+pip install --upgrade pip wheel setuptools >/dev/null
+pip install -r requirements.txt
+
+# ── 4. Sanity: the load-bearing imports actually resolve ─────────────────────
+python3 - <<'PY' || die "dependency import sanity check failed."
+import importlib
+for m in ("anthropic", "aiohttp", "cryptography", "numpy", "yaml"):
+    importlib.import_module(m)
+# z3 + fastembed are import-guarded/optional in-app; warn but don't fail.
+for opt in ("z3", "fastembed"):
+    try:
+        importlib.import_module(opt)
+    except Exception:
+        print(f"[provision] note: optional '{opt}' unavailable (app fails-closed/falls back).")
+print("[provision] core imports OK")
+PY
+
+# ── 5. systemd presence + crypto perms ───────────────────────────────────────
+command -v systemctl >/dev/null 2>&1 || log "WARNING: no systemctl — arm_and_launch.sh needs systemd for the reboot-surviving daemon."
+chmod 700 .jarvis 2>/dev/null || true
+chmod 600 .jarvis/layer4_* .jarvis/roadmap.signed.yaml 2>/dev/null || true
+
+log "═══════════════════════════════════════════════════════════════"
+log "HOST PROVISIONED."
+log "  1. Place funded creds: write .env at $REPO_ROOT (DOUBLEWORD_API_KEY / ANTHROPIC_API_KEY)"
+log "  2. Ignite:             ./scripts/arm_and_launch.sh"
+log "═══════════════════════════════════════════════════════════════"

--- a/scripts/arm_and_launch.sh
+++ b/scripts/arm_and_launch.sh
@@ -32,23 +32,31 @@ fi
 
 # ── Phase 1: cryptographic provisioning + roadmap signing ────────────────────
 PUB="$JARVIS_DIR/layer4_operator.pub"
-if [ ! -f "$PUB" ] && [ -z "${JARVIS_LAYER4_OPERATOR_PUBKEY:-}" ]; then
-  log "No operator key found — provisioning (you'll be prompted for a passphrase; it is NEVER stored)."
-  python3 -m backend.core.ouroboros.governance.sovereign_keys provision
-else
-  log "Operator key already provisioned."
-fi
-
 DRAFT="$JARVIS_DIR/roadmap.draft.yaml"
 SIGNED="$JARVIS_DIR/roadmap.signed.yaml"
-if [ ! -f "$DRAFT" ]; then
-  die "No roadmap draft at $DRAFT. Author your SAFE authorized scopes there first \
+
+if [ -f "$SIGNED" ] && [ "${ARM_RESIGN:-0}" != "1" ]; then
+  # Slice 139: a migrated artifact carries the already-signed roadmap → ignite
+  # NON-INTERACTIVELY (no passphrase prompt on the headless cloud host). The
+  # loop still verifies the signature at runtime, fail-closed. Force a re-sign
+  # with ARM_RESIGN=1.
+  log "Signed roadmap present ($SIGNED) — skipping provision+sign (idempotent/migrated). ARM_RESIGN=1 to re-sign."
+else
+  if [ ! -f "$PUB" ] && [ -z "${JARVIS_LAYER4_OPERATOR_PUBKEY:-}" ]; then
+    log "No operator key found — provisioning (you'll be prompted for a passphrase; it is NEVER stored)."
+    python3 -m backend.core.ouroboros.governance.sovereign_keys provision
+  else
+    log "Operator key already provisioned."
+  fi
+  if [ ! -f "$DRAFT" ]; then
+    die "No roadmap draft at $DRAFT. Author your SAFE authorized scopes there first \
 (an unsigned, authority-free draft), then re-run. The un-signable floor still holds: \
 Order-2/M10, recursion, governance, and APPROVAL_REQUIRED/BLOCKED always escalate to you."
+  fi
+  log "Signing roadmap: $DRAFT → $SIGNED (passphrase prompt)."
+  python3 -m backend.core.ouroboros.governance.sovereign_keys sign --draft "$DRAFT" --out "$SIGNED"
+  [ -f "$SIGNED" ] || die "Signing did not produce $SIGNED."
 fi
-log "Signing roadmap: $DRAFT → $SIGNED (passphrase prompt)."
-python3 -m backend.core.ouroboros.governance.sovereign_keys sign --draft "$DRAFT" --out "$SIGNED"
-[ -f "$SIGNED" ] || die "Signing did not produce $SIGNED."
 
 # ── Phase 2: operator parameters (sane defaults) ─────────────────────────────
 COST_CAP="${JARVIS_T5_COST_CAP:-500}"

--- a/scripts/migrate_to_host.sh
+++ b/scripts/migrate_to_host.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# =============================================================================
+# migrate_to_host.sh — Slice 139: The Deployment Handshake
+# Package the organism, fire it to the industrial Linux host, provision the host,
+# and ignite — one command. Run from your workstation (the source checkout).
+#
+#   Usage:  ./scripts/migrate_to_host.sh <user@host> <remote_dir> [--launch]
+#   e.g.    ./scripts/migrate_to_host.sh ops@gcp-jprime /opt/jarvis --launch
+#
+# Steps:
+#   1. pack_sovereign_release.sh → lean artifact (crypto/sig/evidence in; .env + .venv + .git out).
+#   2. scp the artifact to the host.
+#   3. scp .env SEPARATELY (secrets out-of-band over the same authenticated SSH; never in the tarball).
+#   4. ssh: extract → provision_host.sh → (with --launch) arm_and_launch.sh.
+#
+# Without --launch it stops after provisioning and prints the final ignition
+# command (so you can place/verify .env first). The signed roadmap travels in the
+# artifact, so arm_and_launch.sh on the host is non-interactive (no re-sign).
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+log() { printf '\033[36m[migrate]\033[0m %s\n' "$*"; }
+die() { printf '\033[31m[migrate] FATAL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+HOST="${1:-}"; REMOTE_DIR="${2:-}"; LAUNCH="${3:-}"
+[ -n "$HOST" ] && [ -n "$REMOTE_DIR" ] || die "usage: $0 <user@host> <remote_dir> [--launch]"
+command -v ssh >/dev/null 2>&1 && command -v scp >/dev/null 2>&1 || die "ssh + scp required."
+
+# ── 1. Package ───────────────────────────────────────────────────────────────
+SHA="$(git rev-parse --short HEAD 2>/dev/null || echo nogit)"
+ART="$REPO_ROOT/dist/jarvis-sovereign-$SHA.tgz"
+log "Packaging → $ART"
+"$REPO_ROOT/scripts/pack_sovereign_release.sh" "$ART" >/dev/null
+[ -f "$ART" ] || die "packaging failed."
+ART_BASE="$(basename "$ART")"
+log "Artifact: $ART ($(du -h "$ART" | cut -f1))"
+
+# ── 2. Ship the artifact ─────────────────────────────────────────────────────
+log "ssh: preparing $REMOTE_DIR on $HOST"
+ssh "$HOST" "mkdir -p '$REMOTE_DIR'"
+log "scp: artifact → $HOST:$REMOTE_DIR/"
+scp "$ART" "$HOST:$REMOTE_DIR/$ART_BASE"
+
+# ── 3. Ship secrets out-of-band (NOT in the artifact) ────────────────────────
+if [ -f "$REPO_ROOT/.env" ]; then
+  log "scp: .env (funded creds) → $HOST:$REMOTE_DIR/jarvis-sovereign/.env  [out-of-band, over authenticated SSH]"
+  ssh "$HOST" "mkdir -p '$REMOTE_DIR/jarvis-sovereign'"
+  scp "$REPO_ROOT/.env" "$HOST:$REMOTE_DIR/jarvis-sovereign/.env"
+else
+  log "WARNING: no local .env — you must place funded creds on the host before launch."
+fi
+
+# ── 4. Extract + provision (+ optional launch) ───────────────────────────────
+log "ssh: extract + provision on $HOST"
+ssh "$HOST" "set -e; cd '$REMOTE_DIR'; tar xzf '$ART_BASE'; cd jarvis-sovereign; \
+  chmod +x scripts/*.sh deploy/*.sh; bash deploy/provision_host.sh"
+
+if [ "$LAUNCH" = "--launch" ]; then
+  log "ssh: igniting arm_and_launch.sh on $HOST (signed roadmap travels in the artifact → non-interactive)"
+  ssh "$HOST" "cd '$REMOTE_DIR/jarvis-sovereign'; bash scripts/arm_and_launch.sh"
+  log "═══════════════════════════════════════════════════════════════"
+  log "MIGRATION COMPLETE — organism igniting on $HOST."
+  log "  Watch: ssh $HOST 'tail -f $REMOTE_DIR/jarvis-sovereign/.jarvis/t5_soak.out'"
+  log "═══════════════════════════════════════════════════════════════"
+else
+  log "═══════════════════════════════════════════════════════════════"
+  log "MIGRATION STAGED on $HOST (not yet launched)."
+  log "  Verify .env, then ignite:"
+  log "    ssh $HOST 'cd $REMOTE_DIR/jarvis-sovereign && ./scripts/arm_and_launch.sh'"
+  log "═══════════════════════════════════════════════════════════════"
+fi

--- a/scripts/pack_sovereign_release.sh
+++ b/scripts/pack_sovereign_release.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# =============================================================================
+# pack_sovereign_release.sh — Slice 139: The Sovereign Artifact Packager
+# Bundles the JARVIS-AI-Agent repo into a lean, deployable .tar.gz for migration
+# to the industrial Linux host.
+#
+#   EXCLUDES the bulk + the dangerous: .venv, .git, __pycache__, *.pyc,
+#            .pytest_cache, node_modules, .claude/worktrees, AND the 600M+ of
+#            regenerable .jarvis caches/ledgers.
+#   EXCLUDES secrets: .env is NEVER baked into the artifact (transferred
+#            out-of-band by migrate_to_host.sh).
+#   PRESERVES the load-bearing .jarvis crypto + signatures + evidence/memory via
+#            an explicit allowlist (Ed25519 pubkey + salt + meta + signed roadmap
+#            + the tamper-evident evidence chain + episodic memory + warm vector
+#            index) so the organism wakes up authorized and remembering.
+#
+# Usage:  ./scripts/pack_sovereign_release.sh [output.tgz]
+# Output: dist/jarvis-sovereign-<gitsha>.tgz  (default)
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+SHA="$(git rev-parse --short HEAD 2>/dev/null || echo nogit)"
+OUT="${1:-$REPO_ROOT/dist/jarvis-sovereign-$SHA.tgz}"
+mkdir -p "$(dirname "$OUT")"
+
+log() { printf '\033[36m[pack]\033[0m %s\n' "$*"; }
+
+command -v rsync >/dev/null 2>&1 || { echo "[pack] FATAL: rsync required"; exit 1; }
+
+# The ONLY .jarvis entries that travel — crypto, signatures, evidence, memory.
+# Everything else under .jarvis is regenerable local state and is left behind.
+_JARVIS_ALLOWLIST=(
+  layer4_operator.pub
+  layer4_key.salt
+  layer4_key.meta.json
+  roadmap.signed.yaml
+  roadmap.draft.yaml
+  dissertation_evidence.jsonl
+  episodic_memory.jsonl
+  semantic_index.npz
+)
+
+STAGE_PARENT="$(mktemp -d)"
+STAGE="$STAGE_PARENT/jarvis-sovereign"
+trap 'rm -rf "$STAGE_PARENT"' EXIT
+mkdir -p "$STAGE"
+
+log "Staging clean tree (excluding .venv / .git / .env / caches / .jarvis bulk)…"
+rsync -a \
+  --exclude='.venv' \
+  --exclude='.git' \
+  --exclude='.env' \
+  --exclude='.env.*' \
+  --exclude='__pycache__' \
+  --exclude='*.pyc' \
+  --exclude='.pytest_cache' \
+  --exclude='.mypy_cache' \
+  --exclude='node_modules' \
+  --exclude='.claude/worktrees' \
+  --exclude='dist' \
+  --exclude='.jarvis' \
+  ./ "$STAGE/"
+
+log "Preserving load-bearing .jarvis crypto + signatures + evidence (allowlist)…"
+mkdir -p "$STAGE/.jarvis"
+_preserved=0
+for f in "${_JARVIS_ALLOWLIST[@]}"; do
+  if [ -f "$REPO_ROOT/.jarvis/$f" ]; then
+    cp -p "$REPO_ROOT/.jarvis/$f" "$STAGE/.jarvis/$f"
+    log "  + .jarvis/$f"
+    _preserved=$((_preserved + 1))
+  fi
+done
+[ "$_preserved" -gt 0 ] || log "WARNING: no .jarvis crypto/sig files found — provision + sign before packaging."
+
+# Hard guarantee: no secret ever rode along.
+if [ -f "$STAGE/.env" ]; then echo "[pack] FATAL: .env leaked into stage"; exit 2; fi
+
+log "Compressing → $OUT"
+tar czf "$OUT" -C "$STAGE_PARENT" "jarvis-sovereign"
+SIZE="$(du -h "$OUT" | cut -f1)"
+log "═══════════════════════════════════════════════════════════════"
+log "ARTIFACT READY: $OUT ($SIZE, git=$SHA)"
+log "  .jarvis crypto/sig/evidence preserved: $_preserved file(s)"
+log "  .env + .venv + .git + caches: EXCLUDED"
+log "  Next: ./scripts/migrate_to_host.sh user@host:/opt/jarvis $OUT"
+log "═══════════════════════════════════════════════════════════════"


### PR DESCRIPTION
A Tier-D organism packages + deploys itself. Three composable pieces to migrate the whole organism from a macOS workstation to its industrial Linux host — solving the deployment bottleneck (this Mac has no systemd + can't run the soak nested under an agent).

### `scripts/pack_sovereign_release.sh` — the Artifact Packager
rsync-staged lean `.tar.gz`: **excludes** `.venv` / `.git` / `.env` / caches / the 600M+ regenerable `.jarvis` bulk; **preserves** (allowlist) the Ed25519 pubkey + salt + meta + **signed roadmap** + `dissertation_evidence.jsonl` + `episodic_memory.jsonl` + `semantic_index.npz` so the organism wakes up authorized + remembering. Hard guarantee: `.env` can never leak in (staged-tree assertion). **Live-validated: 600M→59M, crypto/sig travel, zero secrets/bulk.**

### `deploy/provision_host.sh` — IaC bootstrap
Idempotent apt/dnf provisioner: Python 3.11+ (3.9 floor), build toolchain (numpy/fastembed native), git/rsync, venv + `pip install -r requirements.txt`, **dependency import-sanity gate**, systemd check, `.jarvis` crypto perms.

### `scripts/migrate_to_host.sh` — the Deployment Handshake
`pack → scp artifact → scp .env OUT-OF-BAND` (over authenticated SSH, never in the tarball) `→ ssh extract + provision + (--launch) arm_and_launch.sh`. **Non-interactive host ignition**: the signed roadmap travels in the artifact, so `arm_and_launch.sh` now skips re-signing when a valid signed roadmap is present (`ARM_RESIGN=1` forces). The loop still verifies the signature at runtime, fail-closed.

```bash
./scripts/migrate_to_host.sh ops@gcp-jprime /opt/jarvis --launch
```

Config/scripts only — no changes to the live loop. All scripts `bash -n` clean; `dist/` gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-command workstation→Linux host migration: package a lean, signed artifact, provision the host, and optionally launch non-interactively. Secrets never ship in the tarball; they move over SSH out-of-band.

- New Features
  - `scripts/pack_sovereign_release.sh` creates a slim `.tgz` that excludes `.venv`, `.git`, `.env`, caches, and `.jarvis` bulk, while preserving only the allowlisted `.jarvis` keys, signed roadmap, evidence, and memory.
  - `deploy/provision_host.sh` provisions via apt/dnf, ensures Python 3.11+ (3.9 min), builds a venv, installs deps, and sanity-checks imports (`anthropic`, `aiohttp`, `cryptography`, `numpy`; optional `fastembed`, `z3-solver`), and sets safe crypto perms.
  - `scripts/migrate_to_host.sh` orchestrates pack → `scp` artifact → `scp` `.env` (separate) → extract → provision → optional `--launch`.
  - `scripts/arm_and_launch.sh` skips re-signing when `roadmap.signed.yaml` is present; set `ARM_RESIGN=1` to force. Runtime signature checks remain.

- Migration
  - Example: ./scripts/migrate_to_host.sh ops@gcp-jprime /opt/jarvis --launch
  - Omit `--launch` to stage and provision only, then start with ./scripts/arm_and_launch.sh

<sup>Written for commit d6c35a1b6ea12d68e1a387d7dcf721ca4fa548be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

