### PR TITLE
Slice 140 — The Sovereign Container Matrix (detached Docker soak, no GCP needed)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -62,7 +62,8 @@ pytest.ini
 
 # Config files not needed in container
 terraform/
-scripts/
+# NOTE (Slice 140): scripts/ is NOT excluded — the soak container ENTRYPOINT is
+# scripts/launch_shadow_soak.sh, so scripts/ must stay in the build context.
 .claude/
 *.tfvars
 *.tfstate*

--- a/.dockerignore
+++ b/.dockerignore
@@ -94,3 +94,11 @@ credentials/
 # Cache directories
 .cache/
 .huggingface/
+
+# ── Slice 140: secrets + crypto must NEVER be baked into an image layer ──
+# They mount at RUNTIME (docker-compose.soak.yml: env_file .env + ./.jarvis volume).
+.env
+.env.*
+\!.env.example
+.jarvis/
+.claude/worktrees/

--- a/docker-compose.soak.yml
+++ b/docker-compose.soak.yml
@@ -1,0 +1,52 @@
+# JARVIS Sovereign Organism — T5 Unattended Soak (Slice 140)
+# =============================================================================
+# Detached, reboot-surviving soak via Docker — the container IS the supervisor.
+#
+#   ./scripts/launch_docker_soak.sh         # build + up -d + tail logs
+#   docker compose -f docker-compose.soak.yml logs -f jarvis-soak
+#   docker compose -f docker-compose.soak.yml down
+#
+# restart: always  → survives crashes AND host reboot (if dockerd starts on boot:
+#                    `sudo systemctl enable docker`). This replaces systemd's
+#                    Restart=always for the containerized path.
+# ./.jarvis volume → the Ed25519 keys + signed roadmap are READ from the host,
+#                    and the evidence chain + episodic memory are WRITTEN back to
+#                    the host disk → survive container death (the persistence vault).
+# env_file .env    → funded DOUBLEWORD/ANTHROPIC creds injected at runtime only.
+# =============================================================================
+services:
+  jarvis-soak:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.soak
+    image: jarvis-sovereign-soak:latest
+    container_name: jarvis-sovereign-soak
+    working_dir: /app
+    restart: always
+    stop_grace_period: 30s
+    # Funded provider creds — loaded at runtime, never in the image. Marked
+    # non-required so `compose config` validates anywhere; launch_docker_soak.sh's
+    # preflight hard-fails if .env is actually missing at ignition.
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      JARVIS_SOVEREIGN_KEYS_ENABLED: "1"
+      JARVIS_LAYER4_ROADMAP_ENABLED: "1"
+      JARVIS_EPISODIC_CORE_ENABLED: "1"
+      JARVIS_SEMANTIC_CACHE_ENABLED: "1"
+      JARVIS_CAI_ROUTER_ENABLED: "1"
+      # Inert until its activation seam lands — keep OFF.
+      JARVIS_PROMPT_PREFIX_CACHE_ENABLED: "0"
+      JARVIS_KAREN_VOICE_ENABLED: "0"
+      # The container is the supervisor; the Oracle runs in-process-isolated already.
+      JARVIS_ORACLE_PROCESS_ISOLATION_ENABLED: "1"
+    volumes:
+      # Crypto + signed roadmap (read) + evidence/memory (write) persist on host.
+      - ./.jarvis:/app/.jarvis
+    # Decouple the soak's CPU from the host so nothing starves it (tune to host).
+    deploy:
+      resources:
+        limits:
+          cpus: "4.0"
+          memory: 8g

--- a/docker/Dockerfile.soak
+++ b/docker/Dockerfile.soak
@@ -30,8 +30,14 @@ WORKDIR /app
 
 # Dependency layer first (cached across code changes).
 COPY requirements.txt /app/requirements.txt
-RUN pip install --upgrade pip wheel setuptools && \
-    pip install -r requirements.txt
+# The governance soak does NOT need the torch/ML training stack — fastembed
+# (semantic + episodic memory) runs on onnxruntime, and no governance/harness
+# module imports torch. Those pins (torch==2.12.0 / torchaudio==2.12.0) also do
+# not exist on PyPI for linux (max 2.11.0; the Mac has them via a private index).
+# Filter the torch family out for a lean, buildable, soak-only image.
+RUN grep -ivE '^torch(audio|vision)?==' requirements.txt > /tmp/requirements-soak.txt && \
+    pip install --upgrade pip wheel setuptools && \
+    pip install -r /tmp/requirements-soak.txt
 
 # Application code (.dockerignore keeps .venv / .git / .env / .jarvis out).
 COPY . /app

--- a/docker/Dockerfile.soak
+++ b/docker/Dockerfile.soak
@@ -1,0 +1,43 @@
+# JARVIS Sovereign Organism — T5 Unattended Soak (Slice 140)
+# =============================================================================
+# A self-contained soak container. Run detached under dockerd (`up -d`) → it
+# survives this session ending AND host reboot (compose restart: always), and
+# runs in its OWN process namespace — decoupled from any agent event loop, so the
+# S123/S127 control-plane starvation (nested-under-agent) cannot occur.
+#
+# SECURITY: secrets + crypto are NEVER baked into the image. The funded .env and
+# the .jarvis/ (Ed25519 keys + signed roadmap + persistent evidence/memory) mount
+# at RUNTIME via docker-compose.soak.yml. .dockerignore excludes both from the
+# build context.
+#
+#   docker build -f docker/Dockerfile.soak -t jarvis-sovereign-soak:latest .
+# =============================================================================
+FROM python:3.11-slim-bookworm
+
+LABEL org.opencontainers.image.title="jarvis-sovereign-soak"
+LABEL org.opencontainers.image.description="JARVIS T5 unattended soak organism"
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+# Native build deps for numpy / fastembed (onnxruntime) + state-vault transports.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential git rsync curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Dependency layer first (cached across code changes).
+COPY requirements.txt /app/requirements.txt
+RUN pip install --upgrade pip wheel setuptools && \
+    pip install -r requirements.txt
+
+# Application code (.dockerignore keeps .venv / .git / .env / .jarvis out).
+COPY . /app
+
+# .env (funded creds) + .jarvis (crypto + signed roadmap + persistence) are
+# supplied at runtime by compose — not present in the image.
+ENTRYPOINT ["bash", "scripts/launch_shadow_soak.sh"]
+CMD ["--production-soak", "--layer4-autonomous", "--headless", \
+     "--cost-cap", "500", "--idle-timeout", "0", "--max-wall-seconds", "0"]

--- a/docker/Dockerfile.soak
+++ b/docker/Dockerfile.soak
@@ -28,16 +28,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Dependency layer first (cached across code changes).
-COPY requirements.txt /app/requirements.txt
-# The governance soak does NOT need the torch/ML training stack — fastembed
-# (semantic + episodic memory) runs on onnxruntime, and no governance/harness
-# module imports torch. Those pins (torch==2.12.0 / torchaudio==2.12.0) also do
-# not exist on PyPI for linux (max 2.11.0; the Mac has them via a private index).
-# Filter the torch family out for a lean, buildable, soak-only image.
-RUN grep -ivE '^torch(audio|vision)?==' requirements.txt > /tmp/requirements-soak.txt && \
-    pip install --upgrade pip wheel setuptools && \
-    pip install -r /tmp/requirements-soak.txt
+# Dependency layer first (cached across code changes). The soak installs a CURATED
+# requirements set — NOT the full monorepo requirements.txt, which carries the
+# vision/voice/training stack (torch / transformers / faster-whisper / speechbrain)
+# that (a) the governance loop never imports and (b) does not resolve in a clean
+# Linux container (torch==2.12.0 is private-index-only; transformers vs pinned
+# huggingface-hub is ResolutionImpossible). See docker/requirements-soak.txt.
+COPY docker/requirements-soak.txt /app/requirements-soak.txt
+RUN pip install --upgrade pip wheel setuptools && \
+    pip install -r /app/requirements-soak.txt
 
 # Application code (.dockerignore keeps .venv / .git / .env / .jarvis out).
 COPY . /app

--- a/docker/requirements-soak.txt
+++ b/docker/requirements-soak.txt
@@ -41,5 +41,8 @@ uuid6
 # Unpinned so pip resolves a self-consistent onnxruntime / huggingface-hub / tokenizers.
 fastembed
 
-# Formal-proof engine (optional; import-guarded + fail-closed when absent)
-z3-solver>=4.16.0
+# NOTE: z3-solver is intentionally OMITTED. It has no prebuilt wheel for
+# linux/arm64 → pip builds it from source and fails in the slim container, and
+# the SMT prover (smt_invariant_prover) is import-guarded + fail-closed +
+# default-FALSE, so its absence is a clean no-op for the soak. To run formal
+# proofs on an x86_64 host (where a manylinux wheel exists), add:  z3-solver>=4.16.0

--- a/docker/requirements-soak.txt
+++ b/docker/requirements-soak.txt
@@ -1,0 +1,45 @@
+# JARVIS Sovereign Soak — curated runtime dependencies (Slice 140)
+# =============================================================================
+# The FULL requirements.txt is the whole monorepo (vision/voice/training: torch,
+# transformers, faster-whisper, speechbrain, ...) — it does not resolve in a clean
+# Linux container (torch==2.12.0 is private-index-only; transformers vs pinned
+# huggingface-hub is ResolutionImpossible) AND the governance soak imports none
+# of it. This is the minimal, conflict-free set the Ouroboros governance loop +
+# battle-test harness actually need.
+#
+# Hard top-level imports (verified across backend/core/ouroboros): aiohttp,
+# cryptography, psutil, rich, uuid6. Lazy/fail-soft runtime imports: anthropic,
+# PyYAML, numpy, httpx, fastembed (semantic + episodic memory; pulls onnxruntime
+# / huggingface-hub / tokenizers compatibly), z3-solver (optional, import-guarded).
+# =============================================================================
+
+# Providers + async transport
+anthropic==0.75.0
+aiohttp==3.13.2
+aiohttp_cors==0.8.1
+httpx==0.28.1
+
+# Layer-4 Ed25519 sovereign keys
+cryptography>=42.0.0
+
+# Semantic index numerics
+numpy>=1.26.4,<2.5
+
+# Config / roadmap / policy / env
+PyYAML==6.0.3
+python-dotenv>=1.0.0
+
+# Resource + memory pressure
+psutil==7.1.3
+
+# Boot-surface + REPL (imported even under --headless)
+rich
+prompt_toolkit
+uuid6
+
+# Semantic cache + episodic memory (onnxruntime backend, NOT torch).
+# Unpinned so pip resolves a self-consistent onnxruntime / huggingface-hub / tokenizers.
+fastembed
+
+# Formal-proof engine (optional; import-guarded + fail-closed when absent)
+z3-solver>=4.16.0

--- a/scripts/launch_docker_soak.sh
+++ b/scripts/launch_docker_soak.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# =============================================================================
+# launch_docker_soak.sh — Slice 140: one-command containerized T5 soak
+# Build the soak image, launch it DETACHED under dockerd (survives this session +
+# host reboot, decoupled from any agent event loop), and tail its logs.
+#
+#   ./scripts/launch_docker_soak.sh           # build + up -d + follow logs
+#   ./scripts/launch_docker_soak.sh --no-logs # build + up -d, then return
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+COMPOSE="docker-compose.soak.yml"
+log() { printf '\033[36m[docker-soak]\033[0m %s\n' "$*"; }
+die() { printf '\033[31m[docker-soak] FATAL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+docker info >/dev/null 2>&1 || die "docker daemon not reachable."
+
+# Preflight: the runtime-mounted secrets + crypto must exist on the host.
+[ -f "$REPO_ROOT/.env" ] || die "no .env at repo root (funded DOUBLEWORD_API_KEY / ANTHROPIC_API_KEY required)."
+[ -f "$REPO_ROOT/.jarvis/roadmap.signed.yaml" ] || die "no .jarvis/roadmap.signed.yaml — provision + sign first (sovereign_keys), the Layer-4 gate is fail-closed."
+
+DC=(docker compose)
+docker compose version >/dev/null 2>&1 || DC=(docker-compose)
+
+log "Building the soak image (heavy deps — first build takes a few minutes)…"
+"${DC[@]}" -f "$COMPOSE" build
+
+log "Igniting detached (restart=always → survives reboot; decoupled from this session)…"
+"${DC[@]}" -f "$COMPOSE" up -d
+
+log "═══════════════════════════════════════════════════════════════"
+log "T5 SOAK CONTAINER RUNNING (detached, dockerd-supervised)."
+log "  Status: ${DC[*]} -f $COMPOSE ps"
+log "  Logs:   ${DC[*]} -f $COMPOSE logs -f jarvis-soak"
+log "  Stop:   ${DC[*]} -f $COMPOSE down"
+log "  Reboot-survival: sudo systemctl enable docker   (so dockerd starts on boot)"
+log "═══════════════════════════════════════════════════════════════"
+
+if [ "${1:-}" != "--no-logs" ]; then
+  log "Tailing logs (Ctrl-C detaches; the container keeps running)…"
+  "${DC[@]}" -f "$COMPOSE" logs -f jarvis-soak
+fi


### PR DESCRIPTION
Runs the T5 soak as a detached Docker container — solving **both** blockers that made a local launch impossible: a dockerd-supervised container **survives this session ending AND host reboot**, and runs in its **own process namespace** (decoupled from the agent event loop → the S123/S127 nested-under-agent starvation cannot occur). No GCP, no systemd required.

### `docker/Dockerfile.soak`
`python:3.11-slim-bookworm` + build toolchain (numpy/fastembed native) + git/rsync → `pip install -r requirements.txt` (cached layer) → `ENTRYPOINT launch_shadow_soak.sh --production-soak --layer4-autonomous --headless`. Secrets + crypto **never** baked in.

### `docker-compose.soak.yml`
- `restart: always` → crash + reboot survival (**the container is the supervisor**, replacing systemd).
- `./.jarvis` bind-mount → Ed25519 keys + signed roadmap **read** from host; evidence chain + episodic memory **written back** → host-disk persistence (the vault).
- `env_file .env` (`required:false` so `config` validates anywhere) → funded creds at runtime only.
- CPU/mem limits decouple the soak so nothing starves it.

### 🔒 Security catch
The existing `.dockerignore`'s `.env/` (directory rule) did **not** exclude the `.env` **file**, and `.jarvis/` was unlisted — a `COPY .` would have **baked funded secrets + crypto into image layers**. Added explicit `.env`, `.env.*`, `.jarvis/`, `.claude/worktrees/` exclusions (+ `!.env.example`). Verified.

### `scripts/launch_docker_soak.sh`
One command: preflight (.env + signed roadmap present) → build → `up -d` → tail logs. Ctrl-C detaches; the container runs on.

Validated: `bash -n` clean; `docker compose config` resolves (restart:always, .jarvis volume source→target, flags, cpu limits). Image build validating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the T5 soak as a detached Docker container that survives crashes and reboots and runs in its own process namespace. Removes the need for GCP/systemd and prevents agent-loop starvation.

- **New Features**
  - Added `docker-compose.soak.yml` with restart: always, optional runtime `.env`, `./.jarvis` bind mount, and CPU/mem limits.
  - Added `docker/Dockerfile.soak` using python:3.11-slim; installs from curated `docker/requirements-soak.txt`; no secrets baked; entrypoint runs `launch_shadow_soak.sh` with soak flags.
  - Added `scripts/launch_docker_soak.sh` for build + up -d + optional log tail; preflight checks for `.env` and `.jarvis/roadmap.signed.yaml`.

- **Bug Fixes**
  - Updated `.dockerignore` to exclude `.env`, `.env.*`, `.jarvis/`, and `.claude/worktrees/` (keeping `!.env.example`) and keep `scripts/` in the build context so `scripts/launch_shadow_soak.sh` ships; prevents secret bake-in and fixes container start.
  - Replaced monorepo deps with curated `docker/requirements-soak.txt` to avoid `torch` and `transformers`/`huggingface-hub` conflicts; image builds cleanly with `fastembed` and minimal deps.
  - Omitted `z3-solver` from the soak image to avoid linux/arm64 build failures; it’s optional and can be added on x86_64 if needed.

<sup>Written for commit 999aa6e3ba458b1c6658d1c51fa94daa18c3711b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

