### PR TITLE
Slice 141 — The Sovereign Telemetry Failsafe (autonomous anomaly radar)

### DIFF
--- a/backend/core/ouroboros/governance/telemetry_sentinel.py
+++ b/backend/core/ouroboros/governance/telemetry_sentinel.py
@@ -1,0 +1,265 @@
+"""Slice 141 — The Sovereign Telemetry Failsafe (anomaly radar).
+
+A detached 12-month soak must not be a black box. This sentinel watches three
+CATASTROPHIC signals and fires a webhook only on those — never on routine events:
+
+  1. **COST_CAP_90** — cumulative spend crosses 90% of the cost cap.
+  2. **CONSECUTIVE_5XX** — provider 5xx streak beyond the backoff retry budget.
+  3. **REFUSED_SAFETY** — a safety refusal / rogue-FSM block in the live loop.
+
+Design (mirrors the episodic synapses): SYNC detector methods that update state +
+return a ``SentinelAlert`` (or None), an ASYNC fail-soft webhook ``dispatch``, and
+fire-and-forget ``note_*_nowait`` hooks for the hot path. Per-kind cooldown stops
+alert spam. Gated ``JARVIS_TELEMETRY_SENTINEL_ENABLED`` default-FALSE. The webhook
+poster is injectable; the default uses stdlib ``urllib`` (no new dependency).
+"""
+from __future__ import annotations
+
+import dataclasses
+import enum
+import json
+import logging
+import os
+import time
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV_MASTER = "JARVIS_TELEMETRY_SENTINEL_ENABLED"
+_ENV_WEBHOOK = "JARVIS_SENTINEL_WEBHOOK_URL"
+_ENV_COST_FRAC = "JARVIS_SENTINEL_COST_FRAC"
+_ENV_5XX = "JARVIS_SENTINEL_5XX_THRESHOLD"
+_ENV_COOLDOWN = "JARVIS_SENTINEL_COOLDOWN_S"
+
+_DEFAULT_COST_FRAC = 0.9
+_DEFAULT_5XX = 5
+_DEFAULT_COOLDOWN = 3600.0
+
+
+def telemetry_sentinel_enabled() -> bool:
+    """Master gate, default-FALSE per §33.1. NEVER raises."""
+    return os.getenv(_ENV_MASTER, "false").strip().lower() in ("1", "true", "yes", "on")
+
+
+class AnomalyKind(str, enum.Enum):
+    COST_CAP_90 = "cost_cap_90"
+    CONSECUTIVE_5XX = "consecutive_5xx"
+    REFUSED_SAFETY = "refused_safety"
+
+
+@dataclasses.dataclass(frozen=True)
+class SentinelAlert:
+    kind: AnomalyKind
+    detail: str
+    ts: float
+
+
+# poster(url, payload) -> status_code
+_Poster = Callable[[str, Dict[str, Any]], Awaitable[int]]
+
+
+class TelemetrySentinel:
+    """Async, fail-soft anomaly detector + webhook dispatcher."""
+
+    def __init__(
+        self,
+        *,
+        cost_frac: Optional[float] = None,
+        max_consec_5xx: Optional[int] = None,
+        cooldown_s: Optional[float] = None,
+        webhook_url: Optional[str] = None,
+    ) -> None:
+        self._cost_frac = cost_frac if cost_frac is not None else _env_float(_ENV_COST_FRAC, _DEFAULT_COST_FRAC)
+        self._max_5xx = max_consec_5xx if max_consec_5xx is not None else _env_int(_ENV_5XX, _DEFAULT_5XX)
+        self._cooldown = cooldown_s if cooldown_s is not None else _env_float(_ENV_COOLDOWN, _DEFAULT_COOLDOWN)
+        self._webhook = webhook_url if webhook_url is not None else (os.getenv(_ENV_WEBHOOK, "") or "")
+        self._consec_5xx = 0
+        self._last_alert: Dict[AnomalyKind, float] = {}
+
+    # ── cooldown ─────────────────────────────────────────────────────────────
+    def _cooldown_ok(self, kind: AnomalyKind, now: float) -> bool:
+        last = self._last_alert.get(kind)
+        if last is not None and (now - last) < self._cooldown:
+            return False
+        self._last_alert[kind] = now
+        return True
+
+    def _alert(self, kind: AnomalyKind, detail: str) -> Optional[SentinelAlert]:
+        now = time.monotonic()
+        if not self._cooldown_ok(kind, now):
+            return None
+        return SentinelAlert(kind=kind, detail=detail, ts=time.time())
+
+    # ── detectors (sync, return an alert or None) ────────────────────────────
+    def note_cost(self, *, spent: float, cap: float) -> Optional[SentinelAlert]:
+        try:
+            if cap <= 0:
+                return None
+            if float(spent) >= self._cost_frac * float(cap):
+                pct = 100.0 * float(spent) / float(cap)
+                return self._alert(
+                    AnomalyKind.COST_CAP_90,
+                    f"spend ${float(spent):.2f} / ${float(cap):.2f} ({pct:.0f}% of cap)",
+                )
+        except Exception:  # noqa: BLE001
+            return None
+        return None
+
+    def note_provider_result(self, status_code: int) -> Optional[SentinelAlert]:
+        try:
+            code = int(status_code)
+            if 500 <= code <= 599:
+                self._consec_5xx += 1
+                if self._consec_5xx >= self._max_5xx:
+                    return self._alert(
+                        AnomalyKind.CONSECUTIVE_5XX,
+                        f"{self._consec_5xx} consecutive provider 5xx (last={code}) "
+                        f"beyond backoff budget",
+                    )
+            else:
+                self._consec_5xx = 0  # any non-5xx resets the streak
+        except Exception:  # noqa: BLE001
+            return None
+        return None
+
+    def note_safety_refusal(self, detail: str) -> Optional[SentinelAlert]:
+        return self._alert(AnomalyKind.REFUSED_SAFETY, str(detail or "safety refusal"))
+
+    # ── dispatch (async, fail-soft) ──────────────────────────────────────────
+    async def dispatch(self, alert: Optional[SentinelAlert], *, poster: Optional[_Poster] = None) -> bool:
+        if alert is None:
+            return False
+        url = self._webhook
+        if not url:
+            logger.debug("[Sentinel] no webhook url — alert %s not dispatched", alert.kind.value)
+            return False
+        msg = f"[JARVIS SENTINEL] {alert.kind.value.upper()}: {alert.detail}"
+        payload: Dict[str, Any] = {
+            "text": msg, "content": msg,         # Slack + Discord compatible
+            "kind": alert.kind.value, "ts": alert.ts,
+        }
+        try:
+            send = poster or _default_poster
+            rc = await send(url, payload)
+            ok = 200 <= int(rc) < 300
+            (logger.warning if not ok else logger.info)(
+                "[Sentinel] %s dispatched rc=%s", alert.kind.value, rc)
+            return ok
+        except Exception as exc:  # noqa: BLE001 — a dead webhook never crashes the soak
+            logger.warning("[Sentinel] dispatch swallowed (%s): %s", alert.kind.value, exc)
+            return False
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return max(1, int(os.getenv(name, default)))
+    except (TypeError, ValueError):
+        return default
+
+
+async def _default_poster(url: str, payload: Dict[str, Any]) -> int:
+    """Stdlib urllib POST off the event loop, hard-timeout. Returns the HTTP
+    status (0 on transport error). NEVER raises."""
+    import asyncio
+
+    def _post() -> int:
+        import urllib.request
+        try:
+            req = urllib.request.Request(
+                url, data=json.dumps(payload).encode("utf-8"),
+                headers={"Content-Type": "application/json"}, method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return int(getattr(resp, "status", 200) or 200)
+        except Exception:  # noqa: BLE001
+            return 0
+    return await asyncio.to_thread(_post)
+
+
+# ── singleton + fire-and-forget hot-path hooks ──────────────────────────────
+_singleton: Optional[TelemetrySentinel] = None
+
+
+def get_sentinel() -> TelemetrySentinel:
+    global _singleton
+    if _singleton is None:
+        _singleton = TelemetrySentinel()
+    return _singleton
+
+
+def reset_sentinel() -> None:
+    global _singleton
+    _singleton = None
+
+
+_pending: set = set()
+
+
+def _fire(coro) -> None:
+    import asyncio
+    try:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is not None:
+            t = loop.create_task(coro)
+            _pending.add(t)
+            t.add_done_callback(_pending.discard)
+        else:
+            asyncio.run(coro)
+    except Exception:  # noqa: BLE001
+        try:
+            coro.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def note_cost_nowait(*, spent: float, cap: float, poster: Optional[_Poster] = None) -> None:
+    """Fire-and-forget cost check — alerts at ≥90% of cap. Gated + non-blocking."""
+    if not telemetry_sentinel_enabled():
+        return
+    s = get_sentinel()
+    alert = s.note_cost(spent=spent, cap=cap)
+    if alert is not None:
+        _fire(s.dispatch(alert, poster=poster))
+
+
+def note_provider_result_nowait(status_code: int, *, poster: Optional[_Poster] = None) -> None:
+    """Fire-and-forget provider-status check — alerts on a 5xx streak. Gated."""
+    if not telemetry_sentinel_enabled():
+        return
+    s = get_sentinel()
+    alert = s.note_provider_result(status_code)
+    if alert is not None:
+        _fire(s.dispatch(alert, poster=poster))
+
+
+def note_safety_refusal_nowait(detail: str, *, poster: Optional[_Poster] = None) -> None:
+    """Fire-and-forget safety-refusal alert (rogue FSM state). Gated."""
+    if not telemetry_sentinel_enabled():
+        return
+    s = get_sentinel()
+    alert = s.note_safety_refusal(detail)
+    if alert is not None:
+        _fire(s.dispatch(alert, poster=poster))
+
+
+__all__ = [
+    "telemetry_sentinel_enabled",
+    "AnomalyKind",
+    "SentinelAlert",
+    "TelemetrySentinel",
+    "get_sentinel",
+    "reset_sentinel",
+    "note_cost_nowait",
+    "note_provider_result_nowait",
+    "note_safety_refusal_nowait",
+]

--- a/tests/architecture/test_slice141_telemetry_sentinel.py
+++ b/tests/architecture/test_slice141_telemetry_sentinel.py
@@ -1,0 +1,139 @@
+"""Slice 141 — The Sovereign Telemetry Failsafe (anomaly radar).
+
+An async sentinel that fires a webhook ONLY on catastrophic anomalies — so a
+12-month container is not a black box requiring manual `docker logs` polling:
+  * cost spend crosses 90% of the cap,
+  * consecutive provider 5xx beyond the backoff limit,
+  * a REFUSED_SAFETY violation (rogue FSM state).
+
+Gated JARVIS_TELEMETRY_SENTINEL_ENABLED default-FALSE; dispatch is async +
+fail-soft (a dead webhook never perturbs the soak); per-kind cooldown prevents
+alert spam. The webhook poster is injectable → tested without network.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+
+from backend.core.ouroboros.governance import telemetry_sentinel as TS
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestGate(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JARVIS_TELEMETRY_SENTINEL_ENABLED", None)
+
+    def test_default_false(self):
+        self.assertFalse(TS.telemetry_sentinel_enabled())
+
+
+class TestDetectors(unittest.TestCase):
+    def _s(self, **kw):
+        return TS.TelemetrySentinel(cooldown_s=10_000, **kw)
+
+    def test_cost_below_threshold_no_alert(self):
+        s = self._s()
+        self.assertIsNone(s.note_cost(spent=400.0, cap=500.0))  # 80% < 90%
+
+    def test_cost_at_threshold_alerts(self):
+        s = self._s()
+        a = s.note_cost(spent=450.0, cap=500.0)  # 90%
+        self.assertIsNotNone(a)
+        self.assertEqual(a.kind, TS.AnomalyKind.COST_CAP_90)
+
+    def test_cost_cooldown_suppresses_repeat(self):
+        s = self._s()
+        self.assertIsNotNone(s.note_cost(spent=460.0, cap=500.0))
+        self.assertIsNone(s.note_cost(spent=470.0, cap=500.0))  # within cooldown
+
+    def test_consecutive_5xx_threshold(self):
+        s = self._s(max_consec_5xx=3)
+        self.assertIsNone(s.note_provider_result(500))
+        self.assertIsNone(s.note_provider_result(503))
+        a = s.note_provider_result(502)  # 3rd consecutive → trips
+        self.assertIsNotNone(a)
+        self.assertEqual(a.kind, TS.AnomalyKind.CONSECUTIVE_5XX)
+
+    def test_success_resets_5xx_counter(self):
+        s = self._s(max_consec_5xx=3)
+        s.note_provider_result(500)
+        s.note_provider_result(500)
+        self.assertIsNone(s.note_provider_result(200))   # reset
+        self.assertIsNone(s.note_provider_result(500))   # count restarts
+        self.assertIsNone(s.note_provider_result(500))
+
+    def test_4xx_does_not_trip_5xx(self):
+        s = self._s(max_consec_5xx=2)
+        self.assertIsNone(s.note_provider_result(429))
+        self.assertIsNone(s.note_provider_result(400))
+
+    def test_safety_refusal_alerts(self):
+        s = self._s()
+        a = s.note_safety_refusal("rogue FSM tried to flip a kill-switch")
+        self.assertIsNotNone(a)
+        self.assertEqual(a.kind, TS.AnomalyKind.REFUSED_SAFETY)
+
+
+class TestDispatch(unittest.TestCase):
+    def test_dispatch_posts_payload(self):
+        calls = []
+        async def _poster(url, payload):
+            calls.append((url, payload))
+            return 204
+        s = TS.TelemetrySentinel(cooldown_s=0, webhook_url="https://hook.example/x")
+        alert = s.note_safety_refusal("boom")
+        ok = _run(s.dispatch(alert, poster=_poster))
+        self.assertTrue(ok)
+        self.assertEqual(calls[0][0], "https://hook.example/x")
+        # Slack ("text") + Discord ("content") compatible payload.
+        self.assertIn("boom", calls[0][1].get("text", ""))
+        self.assertIn("boom", calls[0][1].get("content", ""))
+
+    def test_dispatch_failsoft(self):
+        async def _boom(url, payload):
+            raise RuntimeError("webhook unreachable")
+        s = TS.TelemetrySentinel(cooldown_s=0, webhook_url="https://hook.example/x")
+        ok = _run(s.dispatch(s.note_safety_refusal("x"), poster=_boom))
+        self.assertFalse(ok)  # swallowed → soak never crashes
+
+    def test_dispatch_noop_without_url(self):
+        s = TS.TelemetrySentinel(cooldown_s=0)  # no webhook_url
+        ok = _run(s.dispatch(s.note_safety_refusal("x"), poster=None))
+        self.assertFalse(ok)
+
+
+class TestNowaitHooks(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_TELEMETRY_SENTINEL_ENABLED"] = "1"
+        os.environ["JARVIS_SENTINEL_WEBHOOK_URL"] = "https://hook.example/x"
+        TS.reset_sentinel()
+
+    def tearDown(self):
+        for k in ("JARVIS_TELEMETRY_SENTINEL_ENABLED", "JARVIS_SENTINEL_WEBHOOK_URL"):
+            os.environ.pop(k, None)
+        TS.reset_sentinel()
+
+    def test_nowait_gated(self):
+        os.environ.pop("JARVIS_TELEMETRY_SENTINEL_ENABLED", None)
+        # disabled → returns immediately, no raise
+        TS.note_safety_refusal_nowait("x")
+
+    def test_nowait_schedules_dispatch(self):
+        sent = []
+        async def go():
+            async def _poster(url, payload):
+                sent.append(payload)
+                return 204
+            TS.note_safety_refusal_nowait("rogue", poster=_poster)
+            await asyncio.sleep(0.05)
+            self.assertTrue(sent)
+            self.assertIn("rogue", sent[0].get("content", ""))
+        _run(go())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A detached 12-month soak must not be a black box requiring manual `docker logs` polling. `telemetry_sentinel.py` fires a webhook **only on catastrophic anomalies**:
- **COST_CAP_90** — cumulative spend crosses 90% of the cap.
- **CONSECUTIVE_5XX** — provider 5xx streak beyond the backoff budget (resets on any non-5xx).
- **REFUSED_SAFETY** — a safety refusal / rogue-FSM block in the live loop.

Architecture mirrors the episodic synapses: **sync detectors** (return a `SentinelAlert` or None) + **async fail-soft `dispatch`** (a dead webhook never perturbs the soak) + **fire-and-forget `note_*_nowait`** hot-path hooks (non-blocking). Per-kind **cooldown** stops alert spam. Slack+Discord-compatible payload (`{text,content}`); default poster is stdlib `urllib` (no new dependency). Master `JARVIS_TELEMETRY_SENTINEL_ENABLED` **default-FALSE**; `JARVIS_SENTINEL_WEBHOOK_URL` + env-tunable thresholds.

**13 tests** (cost threshold + cooldown · 5xx streak + reset + 4xx-ignored · safety alert · dispatch payload/fail-soft/no-url · nowait gated + schedules). Injectable poster → no network in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a telemetry sentinel that posts a webhook only on catastrophic anomalies to make long-running soaks observable without log polling. It’s async, fail-soft, uses per-kind cooldowns, and is disabled by default.

- **New Features**
  - Sync detectors for COST_CAP_90 (≥90% of cap), CONSECUTIVE_5XX (resets on non-5xx), and REFUSED_SAFETY.
  - Async dispatcher with injectable poster; Slack/Discord payload; default stdlib `urllib` (no new deps).
  - Per-kind cooldown and non-blocking `note_*_nowait` hooks behind a master gate.
  - 13 tests covering thresholds, cooldowns, 5xx reset, payload, and fail-soft behavior.

- **Migration**
  - Set `JARVIS_TELEMETRY_SENTINEL_ENABLED=true`.
  - Set `JARVIS_SENTINEL_WEBHOOK_URL=https://...`.
  - Optional: tune `JARVIS_SENTINEL_COST_FRAC`, `JARVIS_SENTINEL_5XX_THRESHOLD`, `JARVIS_SENTINEL_COOLDOWN_S`.

<sup>Written for commit 44f25d657e4dbdd3e3743b63c73997b69f44c760. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

