### PR TITLE
Slice 143 — Wire Discord bridge into the soak boot + #routing channel

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -2183,6 +2183,27 @@ class BattleTestHarness:
             except Exception as exc:  # noqa: BLE001 — never fatal to the soak
                 logger.debug("[CommandCenter] gateway boot skipped: %s", exc)
 
+            # ── Slice 142/143 — Discord Observability Bridge ──
+            # If armed, subscribe to the StreamEventBroker in-process and stream
+            # batched events to the operator's Discord channels (#ops/#subagents/
+            # #cost-safety/#commits/#heartbeat/#routing). Off-hot-path, gated
+            # default-FALSE, fully fail-soft — a dead webhook never perturbs the soak.
+            try:
+                from backend.core.ouroboros.governance.discord_observability_bridge import (
+                    discord_bridge_enabled,
+                    run_bridge_against_broker,
+                )
+                if discord_bridge_enabled():
+                    self._discord_bridge_task = asyncio.create_task(
+                        run_bridge_against_broker(stop=self._shutdown_event)
+                    )
+                    logger.info(
+                        "[DiscordBridge] live organism feed armed (Slice 142/143) — "
+                        "streaming broker events to Discord"
+                    )
+            except Exception as exc:  # noqa: BLE001 — never fatal to the soak
+                logger.debug("[DiscordBridge] bridge boot skipped: %s", exc)
+
             # ── Slice 115 — Blue/Red Adversarial Falsification Matrix ──
             # GLS (the cage) is up. In --siege-mode, fire the Red surfaces at the
             # cage + recursion-depth bound as a fire-and-forget background task,

--- a/backend/core/ouroboros/governance/discord_observability_bridge.py
+++ b/backend/core/ouroboros/governance/discord_observability_bridge.py
@@ -48,6 +48,11 @@ _CHANNEL_MAP: Dict[str, str] = {
     "governor_emergency_brake": "cost_safety", "circuit_breaker_tripped": "cost_safety",
     "circuit_breaker_state_change": "cost_safety", "circuit_breaker_approaching": "cost_safety",
     "provider_failure_classified": "cost_safety", "intervention_banner_raised": "cost_safety",
+    # ── #routing — which provider/model/tier, and confidence (Slice 143) ──
+    "route_proposal": "routing",
+    "model_confidence_drop": "routing",
+    "model_confidence_approaching": "routing",
+    "model_sustained_low_confidence": "routing",
     # ── #commits ──
     "commit_authority_decision_recorded": "commits",
     # ── #heartbeat — the organism pulse ──
@@ -93,7 +98,7 @@ class BridgeEvent:
 
 _EMOJI = {
     "ops": "⚙️", "subagents": "🕸️", "cost_safety": "💰",
-    "commits": "📝", "heartbeat": "💓",
+    "commits": "📝", "heartbeat": "💓", "routing": "🧭",
 }
 
 

--- a/tests/architecture/test_slice142_discord_bridge.py
+++ b/tests/architecture/test_slice142_discord_bridge.py
@@ -42,6 +42,8 @@ class TestRouting(unittest.TestCase):
         self.assertEqual(DB.channel_for("circuit_breaker_tripped"), "cost_safety")
         self.assertEqual(DB.channel_for("commit_authority_decision_recorded"), "commits")
         self.assertEqual(DB.channel_for("posture_changed"), "heartbeat")
+        self.assertEqual(DB.channel_for("route_proposal"), "routing")  # Slice 143
+        self.assertEqual(DB.channel_for("model_confidence_drop"), "routing")
 
     def test_channel_for_unknown_is_none(self):
         self.assertIsNone(DB.channel_for("dashboard_rendered"))  # noise → dropped


### PR DESCRIPTION
Makes the Discord feed **live from the running soak** (Slice 142 was the module + a manual smoke test) and lights up routing.

- **harness.py** — gated, fail-soft bridge start alongside the other background tasks: `asyncio.create_task(run_bridge_against_broker(stop=self._shutdown_event))` when `JARVIS_DISCORD_BRIDGE_ENABLED`. Off-hot-path; never fatal.
- **bridge** — routing was dark because route decisions fire to the episodic ledger (`note_route_nowait`), not the broker. But the broker **does** emit `route_proposal` (`confidence_observability.publish_route_proposal_event`) + `model_confidence_{drop,approaching,sustained_low}`. Mapped all four → new **#routing** channel (`JARVIS_DISCORD_WEBHOOK_ROUTING`).

11 tests; harness imports clean with the wiring. Needs a `#routing` webhook to post there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Discord observability feed live in soak and adds a new `#routing` channel that streams route and model-confidence events from the broker. Bridge start is gated and fail-soft so it never impacts the soak.

- **New Features**
  - Start the Discord bridge in `harness.py` with `asyncio.create_task(run_bridge_against_broker(stop=self._shutdown_event))` when `JARVIS_DISCORD_BRIDGE_ENABLED` is set (off by default; never fatal).
  - Route broker events `route_proposal` and `model_confidence_{drop,approaching,sustained_low}` to `#routing` via `JARVIS_DISCORD_WEBHOOK_ROUTING` (🧭).
  - Tests updated to cover routing channel mapping.

- **Migration**
  - Create a Discord webhook for `#routing` and set `JARVIS_DISCORD_WEBHOOK_ROUTING`.
  - Enable the bridge with `JARVIS_DISCORD_BRIDGE_ENABLED=true` when ready.

<sup>Written for commit 4e8936ac1a658d3cae3af811e67542dfa7972613. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

