### PR TITLE
Slice 144 — Bridge taps get_default_broker (live-feed fix)

### DIFF
--- a/backend/core/ouroboros/governance/discord_observability_bridge.py
+++ b/backend/core/ouroboros/governance/discord_observability_bridge.py
@@ -259,9 +259,9 @@ async def run_bridge_against_broker(*, stop: Any = None) -> None:
         return
     try:
         from backend.core.ouroboros.governance.ide_observability_stream import (
-            get_stream_broker,
+            get_default_broker,
         )
-        broker = get_stream_broker()
+        broker = get_default_broker()
         sub = broker.subscribe()
         if sub is None:
             logger.warning("[DiscordBridge] broker subscriber cap reached — not bridging")


### PR DESCRIPTION
Soak boot logged `[DiscordBridge] broker tap unavailable: cannot import name get_stream_broker`. The real broker singleton accessor is `get_default_broker()` (what the ~40 producers use). One-line import fix in `run_bridge_against_broker`; fail-soft already kept the soak unaffected. Broker contract verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Discord observability bridge to use `get_default_broker()` instead of `get_stream_broker`, restoring the live feed and removing the startup import error. Addresses Slice 144.

- **Bug Fixes**
  - Replace incorrect `get_stream_broker` import/call with `get_default_broker()` in `run_bridge_against_broker`.
  - Verified `subscribe()`/`unsubscribe()` behavior; fail-soft path prevented soak impact.

<sup>Written for commit ffab5718bdd27c55ba42267ae3a211412f5c3154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

