### PR TITLE
Slice 145 — Arm Discord bridge unconditionally at boot

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -731,6 +731,27 @@ class BattleTestHarness:
         self._shutdown_event = asyncio.Event()
         self._cost_tracker.budget_event = asyncio.Event()
         self._idle_watchdog.idle_event = asyncio.Event()
+
+        # ── Slice 142/143/145 — Discord Observability Bridge (unconditional) ──
+        # Start the live Discord feed as an early background task — gated +
+        # fail-soft. Placed here (not in the CommandCenter region, which the
+        # production soak skips) so it ALWAYS arms when JARVIS_DISCORD_BRIDGE_ENABLED.
+        # The broker is a lazy singleton; subscribing early just waits on its queue.
+        try:
+            from backend.core.ouroboros.governance.discord_observability_bridge import (
+                discord_bridge_enabled,
+                run_bridge_against_broker,
+            )
+            if discord_bridge_enabled():
+                self._discord_bridge_task = asyncio.create_task(
+                    run_bridge_against_broker(stop=self._shutdown_event)
+                )
+                logger.info(
+                    "[DiscordBridge] live organism feed armed (Slice 142/143/145) — "
+                    "streaming broker events to Discord"
+                )
+        except Exception as exc:  # noqa: BLE001 — never fatal to the soak
+            logger.debug("[DiscordBridge] bridge boot skipped: %s", exc)
         # Ticket A Guard 2: wall-clock ceiling. Event fires when total session
         # wall time exceeds config.max_wall_seconds_s. Prevents provider retry
         # storms from hijacking both --idle-timeout (reset by retry activity)
@@ -2182,27 +2203,6 @@ class BattleTestHarness:
                     )
             except Exception as exc:  # noqa: BLE001 — never fatal to the soak
                 logger.debug("[CommandCenter] gateway boot skipped: %s", exc)
-
-            # ── Slice 142/143 — Discord Observability Bridge ──
-            # If armed, subscribe to the StreamEventBroker in-process and stream
-            # batched events to the operator's Discord channels (#ops/#subagents/
-            # #cost-safety/#commits/#heartbeat/#routing). Off-hot-path, gated
-            # default-FALSE, fully fail-soft — a dead webhook never perturbs the soak.
-            try:
-                from backend.core.ouroboros.governance.discord_observability_bridge import (
-                    discord_bridge_enabled,
-                    run_bridge_against_broker,
-                )
-                if discord_bridge_enabled():
-                    self._discord_bridge_task = asyncio.create_task(
-                        run_bridge_against_broker(stop=self._shutdown_event)
-                    )
-                    logger.info(
-                        "[DiscordBridge] live organism feed armed (Slice 142/143) — "
-                        "streaming broker events to Discord"
-                    )
-            except Exception as exc:  # noqa: BLE001 — never fatal to the soak
-                logger.debug("[DiscordBridge] bridge boot skipped: %s", exc)
 
             # ── Slice 115 — Blue/Red Adversarial Falsification Matrix ──
             # GLS (the cage) is up. In --siege-mode, fire the Red surfaces at the


### PR DESCRIPTION
The Slice 143 bridge-start sat inside the CommandCenter gateway region, which `--production-soak` skips → bridge never armed (verified live: zero `[CommandCenter]` lines despite the flag set in-container). Relocated the gated, fail-soft `create_task` to the early unconditional boot point (right after the loop events); removed the dead block. The broker is a lazy singleton, so subscribing early just waits on its queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Arms the Discord observability bridge at boot so it always starts, including during `--production-soak` runs that skip CommandCenter (Slice 145). Moves bridge subscription to early boot and removes the old CommandCenter block.

- **Bug Fixes**
  - Start bridge via `asyncio.create_task` immediately after loop events; safe with the lazy broker.
  - Keep fail-soft gating with `discord_bridge_enabled()`; log on arm, debug on skip/exception.
  - Remove CommandCenter-start block to prevent double subscription when the gateway is enabled.

<sup>Written for commit 7ca7486cc78369a1359be5cda6a0838c92450dc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

