### PR TITLE
Slice 146 — Graduate DW-sovereignty economic masters to default-TRUE

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1085,11 +1085,12 @@ def dw_transport_degraded_preflight() -> bool:
 
 
 def fallback_skip_gate_enabled() -> bool:
-    """Slice 127 P2.1 master. Default **FALSE** per §33.1 — when OFF, the
-    IMMEDIATE path stays byte-identical Claude-direct. NEVER raises."""
+    """Slice 127 P2.1 master. Slice 146: graduated default-TRUE — when the Claude
+    lane breaker is OPEN, IMMEDIATE ops skip the depleted fallback and reroute to
+    funded DW (live-proven). Operator can still force-off with =0. NEVER raises."""
     try:
         return os.environ.get(
-            "JARVIS_FALLBACK_SKIP_GATE_ENABLED", "false",
+            "JARVIS_FALLBACK_SKIP_GATE_ENABLED", "true",
         ).strip().lower() in ("1", "true", "yes", "on")
     except Exception:  # noqa: BLE001
         return False

--- a/backend/core/ouroboros/governance/claude_circuit_breaker.py
+++ b/backend/core/ouroboros/governance/claude_circuit_breaker.py
@@ -111,7 +111,7 @@ def claude_economic_breaker_enabled() -> bool:
     future ops route around it, and the existing recovery-window self-heals it.
     NEVER raises."""
     raw = os.environ.get(
-        "JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED", "",
+        "JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED", "true",  # Slice 146: graduated default-TRUE
     ).strip().lower()
     return raw in ("1", "true", "yes", "on")
 

--- a/backend/core/ouroboros/governance/dw_transport_recovery.py
+++ b/backend/core/ouroboros/governance/dw_transport_recovery.py
@@ -47,9 +47,10 @@ _DEFAULT_CAP_S = 600.0
 
 
 def dw_dynamic_recovery_enabled() -> bool:
-    """Master gate. Default **FALSE** per §33.1. NEVER raises."""
+    """Master gate. Slice 146: graduated default-TRUE (DW transport self-healing
+    on by default — live-proven). NEVER raises."""
     try:
-        return os.getenv(_ENV_MASTER, "false").strip().lower() in (
+        return os.getenv(_ENV_MASTER, "true").strip().lower() in (
             "1", "true", "yes", "on",
         )
     except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/economic_router.py
+++ b/backend/core/ouroboros/governance/economic_router.py
@@ -79,7 +79,7 @@ def economic_reclassify_enabled() -> bool:
     the recoverable ``TERMINAL_QUOTA`` instead of the sticky ``TERMINAL_CONFIG``
     that would otherwise sticky-brick the op. Lives here (next to the canonical
     economic detector) so the PURE-DATA classifier stays env-free. NEVER raises."""
-    return os.getenv(_ENV_RECLASSIFY, "false").strip().lower() in ("1", "true", "yes", "on")
+    return os.getenv(_ENV_RECLASSIFY, "true").strip().lower() in ("1", "true", "yes", "on")
 
 
 def micro_op_token_limit() -> int:

--- a/tests/architecture/test_slice124_economic_router.py
+++ b/tests/architecture/test_slice124_economic_router.py
@@ -50,9 +50,10 @@ class TestErrorClassification:
 
 
 class TestEconomicReclassifyMaster:
-    def test_default_false(self, monkeypatch):
+    def test_default_true_graduated(self, monkeypatch):
+        # Slice 146: graduated default-TRUE — DW-sovereign (live-proven).
         monkeypatch.delenv("JARVIS_ECONOMIC_RECLASSIFY_ENABLED", raising=False)
-        assert ER.economic_reclassify_enabled() is False
+        assert ER.economic_reclassify_enabled() is True
 
     def test_enabled_truthy(self, monkeypatch):
         for v in ("1", "true", "yes", "on", "TRUE"):

--- a/tests/governance/test_claude_circuit_breaker_economic.py
+++ b/tests/governance/test_claude_circuit_breaker_economic.py
@@ -86,9 +86,11 @@ class TestClaudeEconomicBreaker(unittest.TestCase):
         finally:
             os.environ.pop("JARVIS_CLAUDE_ECONOMIC_BREAKER_THRESHOLD", None)
 
-    def test_master_default_false(self) -> None:
+    def test_master_default_true_graduated(self) -> None:
+        # Slice 146: graduated default-TRUE — economic trips quarantine the Claude
+        # lane by default so future ops route to DW (live-proven).
         os.environ.pop("JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED", None)
-        self.assertFalse(claude_economic_breaker_enabled())
+        self.assertTrue(claude_economic_breaker_enabled())
 
 
 class TestEconomicBreakerWiringPin(unittest.TestCase):

--- a/tests/governance/test_dw_transport_recovery.py
+++ b/tests/governance/test_dw_transport_recovery.py
@@ -38,9 +38,10 @@ class _ZeroRng:
 
 
 class TestMaster(unittest.TestCase):
-    def test_default_false(self) -> None:
+    def test_default_true_graduated(self) -> None:
+        # Slice 146: graduated default-TRUE (DW transport self-healing on by default).
         os.environ.pop("JARVIS_DW_DYNAMIC_RECOVERY_ENABLED", None)
-        self.assertFalse(dw_dynamic_recovery_enabled())
+        self.assertTrue(dw_dynamic_recovery_enabled())
 
     def test_enabled_truthy(self) -> None:
         for v in ("1", "true", "yes", "on"):

--- a/tests/governance/test_fallback_skip_gate.py
+++ b/tests/governance/test_fallback_skip_gate.py
@@ -26,9 +26,11 @@ from backend.core.ouroboros.governance.candidate_generator import (
 
 
 class TestFallbackSkipGateMaster(unittest.TestCase):
-    def test_default_false(self) -> None:
+    def test_default_true_graduated(self) -> None:
+        # Slice 146: graduated default-TRUE — when the Claude lane breaker is OPEN,
+        # IMMEDIATE ops skip the depleted fallback and reroute to funded DW (live-proven).
         os.environ.pop("JARVIS_FALLBACK_SKIP_GATE_ENABLED", None)
-        self.assertFalse(fallback_skip_gate_enabled())
+        self.assertTrue(fallback_skip_gate_enabled())
 
     def test_enabled_truthy(self) -> None:
         for v in ("1", "true", "yes", "on"):


### PR DESCRIPTION
The live Docker soak proved the Slice-127 economic machinery end-to-end: economically-dead Claude → recoverable `TERMINAL_QUOTA` (not sticky brick) → per-lane quarantine → IMMEDIATE reroute to funded **DW primary**. Answers *'can DW be the sovereign primary?'* — **yes**. Graduating the four failure-path-only masters to default-TRUE so DW-sovereign is the baseline:

- `JARVIS_ECONOMIC_RECLASSIFY_ENABLED`
- `JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED`
- `JARVIS_DW_DYNAMIC_RECOVERY_ENABLED`
- `JARVIS_FALLBACK_SKIP_GATE_ENABLED`

All failure-path-only (can't raise happy-path spend); operator override (`=0`) verified. **46 tests green** (4 defaults flipped RED→GREEN). The semantic_index 8s block re-groups into Slice 148 with the posture GIL + Oracle (one async-hygiene unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make DW the default primary during economic failures to keep requests flowing when a Claude lane runs out of credits. Flip defaults to true for `JARVIS_ECONOMIC_RECLASSIFY_ENABLED`, `JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED`, `JARVIS_DW_DYNAMIC_RECOVERY_ENABLED`, and `JARVIS_FALLBACK_SKIP_GATE_ENABLED` so dead Claude lanes are quarantined and immediate ops reroute to funded DW; operators can still disable via env if needed.

<sup>Written for commit 8b4c91bb0b693f7e7afb21dd8c8562a30afcb096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

