### PR TITLE
Slice 148 — Offload goal-inference build off the event loop (8s stall)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1085,11 +1085,12 @@ def dw_transport_degraded_preflight() -> bool:
 
 
 def fallback_skip_gate_enabled() -> bool:
-    """Slice 127 P2.1 master. Default **FALSE** per §33.1 — when OFF, the
-    IMMEDIATE path stays byte-identical Claude-direct. NEVER raises."""
+    """Slice 127 P2.1 master. Slice 146: graduated default-TRUE — when the Claude
+    lane breaker is OPEN, IMMEDIATE ops skip the depleted fallback and reroute to
+    funded DW (live-proven). Operator can still force-off with =0. NEVER raises."""
     try:
         return os.environ.get(
-            "JARVIS_FALLBACK_SKIP_GATE_ENABLED", "false",
+            "JARVIS_FALLBACK_SKIP_GATE_ENABLED", "true",
         ).strip().lower() in ("1", "true", "yes", "on")
     except Exception:  # noqa: BLE001
         return False

--- a/backend/core/ouroboros/governance/claude_circuit_breaker.py
+++ b/backend/core/ouroboros/governance/claude_circuit_breaker.py
@@ -111,7 +111,7 @@ def claude_economic_breaker_enabled() -> bool:
     future ops route around it, and the existing recovery-window self-heals it.
     NEVER raises."""
     raw = os.environ.get(
-        "JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED", "",
+        "JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED", "true",  # Slice 146: graduated default-TRUE
     ).strip().lower()
     return raw in ("1", "true", "yes", "on")
 

--- a/backend/core/ouroboros/governance/claude_circuit_breaker.py
+++ b/backend/core/ouroboros/governance/claude_circuit_breaker.py
@@ -116,6 +116,26 @@ def claude_economic_breaker_enabled() -> bool:
     return raw in ("1", "true", "yes", "on")
 
 
+def adaptive_reprobe_enabled() -> bool:
+    """Slice 147 — master for ADAPTIVE exponential economic re-probe backoff.
+    Default FALSE per §33.1. When OFF, the economic breaker keeps the fixed
+    recovery window (byte-identical to Slice 127). NEVER raises."""
+    return os.environ.get(
+        "JARVIS_CLAUDE_ECONOMIC_ADAPTIVE_REPROBE_ENABLED", "false",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _max_reprobe_exponent() -> int:
+    """Cap on the economic re-probe exponent (window = base * 2**exp). Default 4
+    → max 16x the base window. Floored at 0. NEVER raises."""
+    try:
+        return max(0, int(
+            os.environ.get("JARVIS_CLAUDE_ECONOMIC_REPROBE_MAX_EXPONENT", "4")
+        ))
+    except (TypeError, ValueError):
+        return 4
+
+
 def _economic_threshold() -> int:
     """Consecutive economic exhaustions that trip the lane. Default 1 — an
     economic refusal ("credit balance too low" / 402) is a definitive,
@@ -210,6 +230,10 @@ class ClaudeCircuitBreaker:
         # Slice 127 — economic-exhaustion counter, kept DISTINCT from the
         # transport counter so the two health signals don't cross-contaminate.
         self._consecutive_economic_failures: int = 0
+        # Slice 147 — adaptive economic re-probe backoff. Grows by 1 on each
+        # failed economic HALF_OPEN probe (window = base * 2**exp), reset on
+        # success. Inert unless adaptive_reprobe_enabled().
+        self._economic_reprobe_exponent: int = 0
         self._tripped_at_monotonic: Optional[float] = None
         self._failure_threshold: int = (
             failure_threshold
@@ -316,13 +340,19 @@ class ClaudeCircuitBreaker:
         with self._lock:
             if self._state is CircuitState.HALF_OPEN:
                 # Probe hit the SAME economic wall — re-open, reset the clock.
+                # Slice 147: grow the adaptive re-probe exponent so a persistently
+                # broke lane is re-probed exponentially less often (DW runs clean).
                 self._state = CircuitState.OPEN
                 self._tripped_at_monotonic = time.monotonic()
                 self._total_trips += 1
+                if adaptive_reprobe_enabled():
+                    self._economic_reprobe_exponent = min(
+                        self._economic_reprobe_exponent + 1, _max_reprobe_exponent(),
+                    )
                 logger.warning(
                     "[ClaudeCircuitBreaker] HALF_OPEN economic probe failed "
-                    "(%s) — re-tripping to OPEN",
-                    detail,
+                    "(%s) — re-tripping to OPEN (re-probe window now %.0fs)",
+                    detail, self._effective_recovery_window_s(),
                 )
                 return
             self._consecutive_economic_failures += 1
@@ -352,6 +382,7 @@ class ClaudeCircuitBreaker:
             self._total_successes += 1
             self._consecutive_transport_failures = 0
             self._consecutive_economic_failures = 0
+            self._economic_reprobe_exponent = 0  # Slice 147: funding returned → reset backoff
             if self._state is not CircuitState.CLOSED:
                 logger.info(
                     "[ClaudeCircuitBreaker] %s -> CLOSED (probe "
@@ -372,6 +403,19 @@ class ClaudeCircuitBreaker:
         with self._lock:
             self._consecutive_transport_failures = 0
 
+    def _effective_recovery_window_s(self) -> float:
+        """Slice 147 — the recovery window in force. With adaptive re-probe ON,
+        an economically-quarantined lane backs off exponentially
+        (base * 2**exponent, exponent capped); OFF → the fixed base window
+        (byte-identical to Slice 127). NEVER raises."""
+        try:
+            if not adaptive_reprobe_enabled() or self._economic_reprobe_exponent <= 0:
+                return self._recovery_window_s
+            exp = min(self._economic_reprobe_exponent, _max_reprobe_exponent())
+            return self._recovery_window_s * float(2 ** exp)
+        except Exception:  # noqa: BLE001
+            return self._recovery_window_s
+
     def should_allow_request(self) -> bool:
         """Pre-call gate: True if a Claude request should be attempted.
 
@@ -389,13 +433,14 @@ class ClaudeCircuitBreaker:
                     self._state = CircuitState.HALF_OPEN
                     return True
                 elapsed = time.monotonic() - self._tripped_at_monotonic
-                if elapsed >= self._recovery_window_s:
+                _window = self._effective_recovery_window_s()
+                if elapsed >= _window:
                     self._state = CircuitState.HALF_OPEN
                     logger.info(
                         "[ClaudeCircuitBreaker] OPEN -> HALF_OPEN "
                         "(recovery window %.0fs elapsed) — allowing "
                         "one probe",
-                        self._recovery_window_s,
+                        _window,
                     )
                     return True
                 return False
@@ -410,6 +455,7 @@ class ClaudeCircuitBreaker:
             self._state = CircuitState.CLOSED
             self._consecutive_transport_failures = 0
             self._consecutive_economic_failures = 0
+            self._economic_reprobe_exponent = 0
             self._tripped_at_monotonic = None
 
     def snapshot(self) -> dict:
@@ -421,6 +467,9 @@ class ClaudeCircuitBreaker:
                     self._consecutive_transport_failures,
                 "consecutive_economic_failures":
                     self._consecutive_economic_failures,
+                "economic_reprobe_exponent": self._economic_reprobe_exponent,
+                "effective_recovery_window_s":
+                    self._effective_recovery_window_s(),
                 "tripped_at_monotonic": self._tripped_at_monotonic,
                 "failure_threshold": self._failure_threshold,
                 "recovery_window_s": self._recovery_window_s,

--- a/backend/core/ouroboros/governance/dw_transport_recovery.py
+++ b/backend/core/ouroboros/governance/dw_transport_recovery.py
@@ -47,9 +47,10 @@ _DEFAULT_CAP_S = 600.0
 
 
 def dw_dynamic_recovery_enabled() -> bool:
-    """Master gate. Default **FALSE** per §33.1. NEVER raises."""
+    """Master gate. Slice 146: graduated default-TRUE (DW transport self-healing
+    on by default — live-proven). NEVER raises."""
     try:
-        return os.getenv(_ENV_MASTER, "false").strip().lower() in (
+        return os.getenv(_ENV_MASTER, "true").strip().lower() in (
             "1", "true", "yes", "on",
         )
     except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/economic_router.py
+++ b/backend/core/ouroboros/governance/economic_router.py
@@ -79,7 +79,7 @@ def economic_reclassify_enabled() -> bool:
     the recoverable ``TERMINAL_QUOTA`` instead of the sticky ``TERMINAL_CONFIG``
     that would otherwise sticky-brick the op. Lives here (next to the canonical
     economic detector) so the PURE-DATA classifier stays env-free. NEVER raises."""
-    return os.getenv(_ENV_RECLASSIFY, "false").strip().lower() in ("1", "true", "yes", "on")
+    return os.getenv(_ENV_RECLASSIFY, "true").strip().lower() in ("1", "true", "yes", "on")
 
 
 def micro_op_token_limit() -> int:

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -2644,7 +2644,11 @@ class GovernedOrchestrator:
                         _engine = GoalInferenceEngine(
                             repo_root=self._config.project_root,
                         )
-                    _inf_result = _engine.build()
+                    # Slice 148 — the heavy GoalInferenceEngine.build (→
+                    # SemanticIndex.build, fastembed inference) is synchronous and
+                    # was caught stalling the event loop ~8s (LoopSink). Offload it
+                    # so other coroutines keep running while it builds.
+                    _inf_result = await asyncio.to_thread(_engine.build)
                     _inf_text = render_prompt_section(_inf_result)
                     if _inf_text:
                         _existing = getattr(

--- a/tests/architecture/test_slice124_economic_router.py
+++ b/tests/architecture/test_slice124_economic_router.py
@@ -50,9 +50,10 @@ class TestErrorClassification:
 
 
 class TestEconomicReclassifyMaster:
-    def test_default_false(self, monkeypatch):
+    def test_default_true_graduated(self, monkeypatch):
+        # Slice 146: graduated default-TRUE — DW-sovereign (live-proven).
         monkeypatch.delenv("JARVIS_ECONOMIC_RECLASSIFY_ENABLED", raising=False)
-        assert ER.economic_reclassify_enabled() is False
+        assert ER.economic_reclassify_enabled() is True
 
     def test_enabled_truthy(self, monkeypatch):
         for v in ("1", "true", "yes", "on", "TRUE"):

--- a/tests/governance/test_claude_circuit_breaker_economic.py
+++ b/tests/governance/test_claude_circuit_breaker_economic.py
@@ -86,9 +86,11 @@ class TestClaudeEconomicBreaker(unittest.TestCase):
         finally:
             os.environ.pop("JARVIS_CLAUDE_ECONOMIC_BREAKER_THRESHOLD", None)
 
-    def test_master_default_false(self) -> None:
+    def test_master_default_true_graduated(self) -> None:
+        # Slice 146: graduated default-TRUE — economic trips quarantine the Claude
+        # lane by default so future ops route to DW (live-proven).
         os.environ.pop("JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED", None)
-        self.assertFalse(claude_economic_breaker_enabled())
+        self.assertTrue(claude_economic_breaker_enabled())
 
 
 class TestEconomicBreakerWiringPin(unittest.TestCase):

--- a/tests/governance/test_dw_transport_recovery.py
+++ b/tests/governance/test_dw_transport_recovery.py
@@ -38,9 +38,10 @@ class _ZeroRng:
 
 
 class TestMaster(unittest.TestCase):
-    def test_default_false(self) -> None:
+    def test_default_true_graduated(self) -> None:
+        # Slice 146: graduated default-TRUE (DW transport self-healing on by default).
         os.environ.pop("JARVIS_DW_DYNAMIC_RECOVERY_ENABLED", None)
-        self.assertFalse(dw_dynamic_recovery_enabled())
+        self.assertTrue(dw_dynamic_recovery_enabled())
 
     def test_enabled_truthy(self) -> None:
         for v in ("1", "true", "yes", "on"):

--- a/tests/governance/test_fallback_skip_gate.py
+++ b/tests/governance/test_fallback_skip_gate.py
@@ -26,9 +26,11 @@ from backend.core.ouroboros.governance.candidate_generator import (
 
 
 class TestFallbackSkipGateMaster(unittest.TestCase):
-    def test_default_false(self) -> None:
+    def test_default_true_graduated(self) -> None:
+        # Slice 146: graduated default-TRUE — when the Claude lane breaker is OPEN,
+        # IMMEDIATE ops skip the depleted fallback and reroute to funded DW (live-proven).
         os.environ.pop("JARVIS_FALLBACK_SKIP_GATE_ENABLED", None)
-        self.assertFalse(fallback_skip_gate_enabled())
+        self.assertTrue(fallback_skip_gate_enabled())
 
     def test_enabled_truthy(self) -> None:
         for v in ("1", "true", "yes", "on"):

--- a/tests/governance/test_slice147_adaptive_economic_quarantine.py
+++ b/tests/governance/test_slice147_adaptive_economic_quarantine.py
@@ -1,0 +1,101 @@
+"""Slice 147 — Adaptive Economic Quarantine.
+
+A persistently economically-dead Claude lane (credit-too-low until the operator
+funds it — could be hours/days) shouldn't be re-probed every fixed recovery
+window, sacrificing one op each time. This adds an EXPONENTIAL re-probe backoff:
+each failed economic HALF_OPEN probe doubles the effective recovery window (capped);
+a successful probe (funding returned) resets it. Gated default-FALSE per §33.1 →
+OFF is byte-identical fixed-window behavior. Transport trips are unaffected.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+from backend.core.ouroboros.governance import claude_circuit_breaker as CB
+from backend.core.ouroboros.governance.claude_circuit_breaker import (
+    ClaudeCircuitBreaker,
+    CircuitState,
+)
+
+
+class TestAdaptiveGate(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JARVIS_CLAUDE_ECONOMIC_ADAPTIVE_REPROBE_ENABLED", None)
+
+    def test_adaptive_default_false(self):
+        self.assertFalse(CB.adaptive_reprobe_enabled())
+
+    def test_off_window_is_fixed_regardless_of_exponent(self):
+        b = ClaudeCircuitBreaker(recovery_window_s=900.0)
+        b._economic_reprobe_exponent = 3  # even if set, OFF must ignore it
+        self.assertEqual(b._effective_recovery_window_s(), 900.0)
+
+
+class TestAdaptiveBackoff(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_CLAUDE_ECONOMIC_ADAPTIVE_REPROBE_ENABLED"] = "1"
+        os.environ["JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED"] = "1"
+
+    def tearDown(self):
+        for k in ("JARVIS_CLAUDE_ECONOMIC_ADAPTIVE_REPROBE_ENABLED",
+                  "JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED",
+                  "JARVIS_CLAUDE_ECONOMIC_REPROBE_MAX_EXPONENT"):
+            os.environ.pop(k, None)
+
+    def test_window_doubles_per_failed_economic_probe(self):
+        b = ClaudeCircuitBreaker(recovery_window_s=900.0)
+        self.assertEqual(b._effective_recovery_window_s(), 900.0)   # exp 0
+        # Simulate a failed economic HALF_OPEN probe → exponent grows.
+        b._state = CircuitState.HALF_OPEN
+        b.record_economic_exhaustion("402")
+        self.assertEqual(b._economic_reprobe_exponent, 1)
+        self.assertEqual(b._effective_recovery_window_s(), 1800.0)  # 900*2^1
+        b._state = CircuitState.HALF_OPEN
+        b.record_economic_exhaustion("402")
+        self.assertEqual(b._effective_recovery_window_s(), 3600.0)  # 900*2^2
+
+    def test_exponent_capped(self):
+        os.environ["JARVIS_CLAUDE_ECONOMIC_REPROBE_MAX_EXPONENT"] = "2"
+        b = ClaudeCircuitBreaker(recovery_window_s=100.0)
+        for _ in range(6):
+            b._state = CircuitState.HALF_OPEN
+            b.record_economic_exhaustion("402")
+        self.assertLessEqual(b._economic_reprobe_exponent, 2)
+        self.assertEqual(b._effective_recovery_window_s(), 400.0)   # 100*2^2 (capped)
+
+    def test_success_resets_backoff(self):
+        b = ClaudeCircuitBreaker(recovery_window_s=900.0)
+        b._state = CircuitState.HALF_OPEN
+        b.record_economic_exhaustion("402")
+        b._state = CircuitState.HALF_OPEN
+        b.record_economic_exhaustion("402")
+        self.assertGreater(b._economic_reprobe_exponent, 0)
+        b.record_success()  # funding returned → probe succeeds
+        self.assertEqual(b._economic_reprobe_exponent, 0)
+        self.assertEqual(b._effective_recovery_window_s(), 900.0)
+
+    def test_transport_trip_unaffected_by_economic_exponent(self):
+        # A pure transport breaker (exponent 0) keeps the fixed window.
+        b = ClaudeCircuitBreaker(recovery_window_s=900.0)
+        b._state = CircuitState.HALF_OPEN
+        b.record_transport_exhaustion("ReadTimeout")
+        self.assertEqual(b._economic_reprobe_exponent, 0)
+        self.assertEqual(b._effective_recovery_window_s(), 900.0)
+
+    def test_reset_clears_exponent(self):
+        b = ClaudeCircuitBreaker(recovery_window_s=900.0)
+        b._state = CircuitState.HALF_OPEN
+        b.record_economic_exhaustion("402")
+        b.reset()
+        self.assertEqual(b._economic_reprobe_exponent, 0)
+
+    def test_snapshot_exposes_adaptive_fields(self):
+        b = ClaudeCircuitBreaker(recovery_window_s=900.0)
+        snap = b.snapshot()
+        self.assertIn("economic_reprobe_exponent", snap)
+        self.assertIn("effective_recovery_window_s", snap)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/governance/test_slice148_loop_hardening.py
+++ b/tests/governance/test_slice148_loop_hardening.py
@@ -1,0 +1,37 @@
+"""Slice 148 — Event-loop hardening (goal-inference build offload).
+
+The live soak's LoopSink caught `semantic_index.SemanticIndex.build kind=sync
+blocked_ms=8044` — the orchestrator's CONTEXT_EXPANSION called the synchronous
+`GoalInferenceEngine.build()` (→ SemanticIndex.build, fastembed inference) directly
+on the event loop, stalling the whole governance loop for 8s. The heavy build must
+run off-loop via asyncio.to_thread so other coroutines keep running.
+
+This is a call-site wiring pin (the orchestrator pipeline is too large to unit-test
+directly — same convention as the economic-breaker wiring pin).
+"""
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+_ORCH = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "backend" / "core" / "ouroboros" / "governance" / "orchestrator.py"
+)
+
+
+class TestGoalInferenceBuildOffloaded(unittest.TestCase):
+    def setUp(self):
+        self.src = _ORCH.read_text(encoding="utf-8")
+
+    def test_build_runs_off_loop_via_to_thread(self):
+        # The heavy build must be offloaded.
+        self.assertIn("asyncio.to_thread(_engine.build", self.src)
+
+    def test_no_bare_sync_build_on_loop(self):
+        # The bare synchronous on-loop call must be gone.
+        self.assertNotIn("_inf_result = _engine.build()", self.src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
LoopSink caught `semantic_index.SemanticIndex.build kind=sync blocked_ms=8044` — orchestrator CONTEXT_EXPANSION called synchronous `GoalInferenceEngine.build()` (→ `SemanticIndex.build`, fastembed) **directly on the async loop**, stalling the governance loop ~8s. Wrapped in `asyncio.to_thread` (build already does its atomic swap under `self._lock` → thread-safe). Behavior-preserving; call-site wiring pin. Surfaced by enabling the semantic/episodic features.

Deeper offenders (posture_observer 36s GIL block + Oracle DEGRADED) → Slice 149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Offloaded goal inference build to a background thread to remove an ~8s event-loop stall. Also added adaptive economic re-probe backoff and set DW-sovereignty feature flags to default TRUE.

- **New Features**
  - Adaptive exponential economic re-probe backoff in `ClaudeCircuitBreaker` (gate `JARVIS_CLAUDE_ECONOMIC_ADAPTIVE_REPROBE_ENABLED`, cap `JARVIS_CLAUDE_ECONOMIC_REPROBE_MAX_EXPONENT`); `snapshot()` now includes `economic_reprobe_exponent` and `effective_recovery_window_s`.
  - Graduated defaults to TRUE: `JARVIS_ECONOMIC_RECLASSIFY_ENABLED`, `JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED`, `JARVIS_DW_DYNAMIC_RECOVERY_ENABLED`, `JARVIS_FALLBACK_SKIP_GATE_ENABLED`.

- **Performance**
  - Wrapped `GoalInferenceEngine.build()` with `asyncio.to_thread` to keep the async loop responsive during semantic index/embedding.
  - Added tests for Slice 147 (adaptive quarantine) and Slice 148 (loop offload).

<sup>Written for commit 1bcb372ffcc7f16e1a7559a72dc4ddc1f5632531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

