### PR TITLE
Slice 149 Phase 1 — Discord bridge boot diagnostics (root cause: loop starvation)

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -737,21 +737,38 @@ class BattleTestHarness:
         # fail-soft. Placed here (not in the CommandCenter region, which the
         # production soak skips) so it ALWAYS arms when JARVIS_DISCORD_BRIDGE_ENABLED.
         # The broker is a lazy singleton; subscribing early just waits on its queue.
+        # Slice 149 Phase 1 — VISIBLE startup diagnostics. This block was silent
+        # in the soak (no armed/skip log) despite the flag being set; logging may
+        # not be fully configured this early in run(), so emit to stderr too
+        # (boot diagnostic, deterministic) and surface skips/errors at WARNING.
         try:
             from backend.core.ouroboros.governance.discord_observability_bridge import (
                 discord_bridge_enabled,
                 run_bridge_against_broker,
             )
-            if discord_bridge_enabled():
+            _bridge_on = discord_bridge_enabled()
+            print(
+                f"[DiscordBridge] boot: enabled={_bridge_on} "
+                f"(JARVIS_DISCORD_BRIDGE_ENABLED)",
+                file=sys.stderr, flush=True,
+            )
+            if _bridge_on:
                 self._discord_bridge_task = asyncio.create_task(
                     run_bridge_against_broker(stop=self._shutdown_event)
                 )
-                logger.info(
+                logger.warning(
                     "[DiscordBridge] live organism feed armed (Slice 142/143/145) — "
                     "streaming broker events to Discord"
                 )
+            else:
+                logger.warning(
+                    "[DiscordBridge] NOT armed — JARVIS_DISCORD_BRIDGE_ENABLED is off"
+                )
         except Exception as exc:  # noqa: BLE001 — never fatal to the soak
-            logger.debug("[DiscordBridge] bridge boot skipped: %s", exc)
+            print(f"[DiscordBridge] boot FAILED: {exc!r}", file=sys.stderr, flush=True)
+            logger.warning(
+                "[DiscordBridge] bridge boot FAILED: %r", exc, exc_info=True,
+            )
         # Ticket A Guard 2: wall-clock ceiling. Event fires when total session
         # wall time exceeds config.max_wall_seconds_s. Prevents provider retry
         # storms from hijacking both --idle-timeout (reset by retry activity)


### PR DESCRIPTION
Diagnostic-first per spec. The bridge block was silent in the soak despite the flag set. Made the boot path **visible** (stderr print + WARNING arm/skip/fail with exc_info).

**Finding:** the bridge *arms* fine (`enabled=True` → `live organism feed armed`) — the original log was `logger.info`, dropped this early in boot, so it only *looked* silent. But it never `started`/`subscriber_connected` because the **event loop is starved**: `posture.signal.commit_ratios` **27s**, `posture_observer.run_one_cycle` **27s**, `semantic_index.SemanticIndex.build` **8.8s**. The bridge coroutine is scheduled but never gets the loop. → Phase 1 (arm) + Phase 2 (semantic) + Phase 3 (posture GIL) are one disease; fixing the stalls unblocks both op-completion and the bridge feed.

Acceptance met: bridge now logs a clear armed state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Discord bridge boot path visible during soak by emitting early stderr diagnostics and WARNING logs for arm/skip/fail. This satisfies Slice 149 phase 1: confirms the bridge arms when `JARVIS_DISCORD_BRIDGE_ENABLED` is set and surfaces event loop starvation blocking subscriber start.

- **Bug Fixes**
  - Emit `[DiscordBridge] boot: enabled=…` to stderr before logging initializes.
  - Promote armed/skip/fail to WARNING; include `exc_info` and stderr print on failures.
  - Log explicit "NOT armed" when disabled; create the bridge task when enabled via `backend.core.ouroboros.governance.discord_observability_bridge`.

<sup>Written for commit 99aba987dd8191695af76d375696441c2c0ff63c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

