### PR TITLE
Slice 149 Phase 2 — offload CLASSIFY goal-inference build off the event loop

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -737,21 +737,38 @@ class BattleTestHarness:
         # fail-soft. Placed here (not in the CommandCenter region, which the
         # production soak skips) so it ALWAYS arms when JARVIS_DISCORD_BRIDGE_ENABLED.
         # The broker is a lazy singleton; subscribing early just waits on its queue.
+        # Slice 149 Phase 1 — VISIBLE startup diagnostics. This block was silent
+        # in the soak (no armed/skip log) despite the flag being set; logging may
+        # not be fully configured this early in run(), so emit to stderr too
+        # (boot diagnostic, deterministic) and surface skips/errors at WARNING.
         try:
             from backend.core.ouroboros.governance.discord_observability_bridge import (
                 discord_bridge_enabled,
                 run_bridge_against_broker,
             )
-            if discord_bridge_enabled():
+            _bridge_on = discord_bridge_enabled()
+            print(
+                f"[DiscordBridge] boot: enabled={_bridge_on} "
+                f"(JARVIS_DISCORD_BRIDGE_ENABLED)",
+                file=sys.stderr, flush=True,
+            )
+            if _bridge_on:
                 self._discord_bridge_task = asyncio.create_task(
                     run_bridge_against_broker(stop=self._shutdown_event)
                 )
-                logger.info(
+                logger.warning(
                     "[DiscordBridge] live organism feed armed (Slice 142/143/145) — "
                     "streaming broker events to Discord"
                 )
+            else:
+                logger.warning(
+                    "[DiscordBridge] NOT armed — JARVIS_DISCORD_BRIDGE_ENABLED is off"
+                )
         except Exception as exc:  # noqa: BLE001 — never fatal to the soak
-            logger.debug("[DiscordBridge] bridge boot skipped: %s", exc)
+            print(f"[DiscordBridge] boot FAILED: {exc!r}", file=sys.stderr, flush=True)
+            logger.warning(
+                "[DiscordBridge] bridge boot FAILED: %r", exc, exc_info=True,
+            )
         # Ticket A Guard 2: wall-clock ceiling. Event fires when total session
         # wall time exceeds config.max_wall_seconds_s. Prevents provider retry
         # storms from hijacking both --idle-timeout (reset by retry activity)

--- a/backend/core/ouroboros/governance/goal_inference.py
+++ b/backend/core/ouroboros/governance/goal_inference.py
@@ -613,6 +613,19 @@ class GoalInferenceEngine:
     # Public API
     # ------------------------------------------------------------------
 
+    async def build_offloaded(self, *, force: bool = False) -> InferenceResult:
+        """Slice 149 Phase 2 — async, off-loop build for boot/soak call sites.
+
+        The synchronous ``build()`` (→ ``SemanticIndex.build``, fastembed
+        inference + ``git log`` corpus assembly) can stall the event loop several
+        seconds (LoopSink caught ~8.8s). Running it via ``asyncio.to_thread``
+        keeps the governance loop responsive while other coroutines proceed. This
+        is the SINGLE off-loop entry point — orchestrator CONTEXT_EXPANSION and
+        the CLASSIFY phase runner both use it, so no caller scatters its own
+        ``to_thread`` wrapper. Returns the same ``InferenceResult`` as ``build``."""
+        import asyncio as _asyncio
+        return await _asyncio.to_thread(self.build, force=force)
+
     def build(self, *, force: bool = False) -> InferenceResult:
         if not inference_enabled():
             return InferenceResult(build_reason="disabled")

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -2644,11 +2644,11 @@ class GovernedOrchestrator:
                         _engine = GoalInferenceEngine(
                             repo_root=self._config.project_root,
                         )
-                    # Slice 148 — the heavy GoalInferenceEngine.build (→
+                    # Slice 148/149 — the heavy GoalInferenceEngine.build (→
                     # SemanticIndex.build, fastembed inference) is synchronous and
-                    # was caught stalling the event loop ~8s (LoopSink). Offload it
-                    # so other coroutines keep running while it builds.
-                    _inf_result = await asyncio.to_thread(_engine.build)
+                    # stalls the event loop ~8s (LoopSink). Use the single off-loop
+                    # entry point so both boot call sites share one pattern.
+                    _inf_result = await _engine.build_offloaded()
                     _inf_text = render_prompt_section(_inf_result)
                     if _inf_text:
                         _existing = getattr(

--- a/backend/core/ouroboros/governance/phase_runners/classify_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/classify_runner.py
@@ -930,7 +930,9 @@ class CLASSIFYRunner(PhaseRunner):
                     _engine = GoalInferenceEngine(
                         repo_root=orch._config.project_root,
                     )
-                _inf_result = _engine.build()
+                # Slice 149 Phase 2 — off-loop build (LoopSink caught the sync
+                # build stalling the loop ~8.8s in the CLASSIFY phase).
+                _inf_result = await _engine.build_offloaded()
                 _inf_text = render_prompt_section(_inf_result)
                 if _inf_text:
                     _existing = getattr(

--- a/tests/governance/test_slice148_loop_hardening.py
+++ b/tests/governance/test_slice148_loop_hardening.py
@@ -25,8 +25,13 @@ class TestGoalInferenceBuildOffloaded(unittest.TestCase):
         self.src = _ORCH.read_text(encoding="utf-8")
 
     def test_build_runs_off_loop_via_to_thread(self):
-        # The heavy build must be offloaded.
-        self.assertIn("asyncio.to_thread(_engine.build", self.src)
+        # The heavy build must be offloaded. Slice 149 Phase 2 converged the
+        # orchestrator + CLASSIFY call sites onto GoalInferenceEngine.build_offloaded()
+        # (which wraps asyncio.to_thread) — either form keeps it off the loop.
+        self.assertTrue(
+            "await _engine.build_offloaded()" in self.src
+            or "asyncio.to_thread(_engine.build" in self.src
+        )
 
     def test_no_bare_sync_build_on_loop(self):
         # The bare synchronous on-loop call must be gone.

--- a/tests/governance/test_slice149_phase2_goal_inference_offload.py
+++ b/tests/governance/test_slice149_phase2_goal_inference_offload.py
@@ -1,0 +1,76 @@
+"""Slice 149 Phase 2 — goal-inference build must never run on the event loop.
+
+The live soak's LoopSink caught a SECOND `semantic_index.SemanticIndex.build
+kind=sync blocked_ms~8800` after S148 fixed the orchestrator's CONTEXT_EXPANSION
+call — this one in `phase_runners/classify_runner.py` (CLASSIFY phase). Both call
+sites now go through a single async off-loop method, `GoalInferenceEngine.
+build_offloaded()`, so the heavy synchronous build (→ SemanticIndex.build, fastembed
+inference) can never stall the governance loop.
+
+Regression pin: no boot/soak phase path may call the bare synchronous
+`_engine.build()` on the loop — they must await `build_offloaded()`.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import pathlib
+import re
+import unittest
+
+_GOV = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "backend" / "core" / "ouroboros" / "governance"
+)
+_SCAN = [
+    _GOV / "orchestrator.py",
+    _GOV / "phase_runners" / "classify_runner.py",
+]
+
+
+class TestBuildOffloadedExists(unittest.TestCase):
+    def test_engine_has_async_build_offloaded(self):
+        from backend.core.ouroboros.governance.goal_inference import (
+            GoalInferenceEngine,
+        )
+        self.assertTrue(hasattr(GoalInferenceEngine, "build_offloaded"))
+        self.assertTrue(
+            inspect.iscoroutinefunction(GoalInferenceEngine.build_offloaded)
+        )
+
+
+class TestNoBareBuildOnLoop(unittest.TestCase):
+    def test_no_bare_engine_build_in_boot_paths(self):
+        # Any `_engine.build(` must be either `build_offloaded` or wrapped in
+        # to_thread — never a bare synchronous on-loop call.
+        offenders = []
+        for p in _SCAN:
+            src = p.read_text(encoding="utf-8")
+            for m in re.finditer(r"_engine\.build\((?!_offloaded)", src):
+                # allow the to_thread form: asyncio.to_thread(_engine.build
+                start = max(0, m.start() - 40)
+                ctx = src[start:m.start()]
+                if "to_thread(_engine.build" in src[start:m.end() + 5]:
+                    continue
+                # the bare-call form is `_engine.build(` not preceded by build_offloaded
+                offenders.append(f"{p.name}: ...{src[start:m.end()+5]!r}")
+        self.assertEqual(offenders, [], f"bare on-loop _engine.build found: {offenders}")
+
+
+class TestOffloadRunsOffLoop(unittest.TestCase):
+    def test_build_offloaded_delegates_to_thread(self):
+        # build_offloaded must return the same result as build, computed off-loop.
+        from backend.core.ouroboros.governance.goal_inference import (
+            GoalInferenceEngine,
+        )
+        eng = GoalInferenceEngine(repo_root=str(pathlib.Path.cwd()))
+        async def go():
+            # Should not raise; returns whatever build() returns (InferenceResult).
+            res = await eng.build_offloaded()
+            return res
+        # Just prove it runs as a coroutine off the loop without error.
+        asyncio.get_event_loop().run_until_complete(go())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
LoopSink caught a **second** `semantic_index.SemanticIndex.build kind=sync ~8.8s` after S148 — this one in `classify_runner.py:933` (CLASSIFY phase) ran `GoalInferenceEngine.build()` directly on the loop.

**Root fix, no duplication:** new single off-loop entry point `GoalInferenceEngine.build_offloaded()` (async; wraps `asyncio.to_thread(self.build)`; `build()` already swaps atomically under lock → thread-safe). **Converged both** boot call sites onto it — the CLASSIFY runner *and* S148's orchestrator site (which had its own scattered `to_thread`) — one canonical pattern.

**Regression pin** scans orchestrator + classify_runner and fails on any bare on-loop `_engine.build()`. 5 tests green. Live-verify (8.8s stall gone) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slice 149 Phase 2: Offloaded the heavy goal-inference build from the event loop via a new async `GoalInferenceEngine.build_offloaded()`, removing ~8.8s stalls seen in CLASSIFY and keeping the governance loop responsive. Also added regression tests and surfaced Discord bridge boot diagnostics.

- **Bug Fixes**
  - Added `GoalInferenceEngine.build_offloaded()` (async; wraps `asyncio.to_thread(self.build)`).
  - Switched orchestrator and CLASSIFY paths to `await _engine.build_offloaded()`.
  - Added tests to block any on-loop `_engine.build(` calls; updated existing pin to accept the new entry point.
  - Made Discord bridge boot state visible early (stderr + WARNING logs) for soak diagnostics.

<sup>Written for commit 52e238a0e9ed8bd67149e0a1200198b3f8500414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

