### PR TITLE
Slice 150 Phase 1 — reusable subprocess-compute substrate (GIL decoupling)

### DIFF
--- a/backend/core/ouroboros/governance/subprocess_compute.py
+++ b/backend/core/ouroboros/governance/subprocess_compute.py
@@ -1,0 +1,139 @@
+"""Slice 150 — The Sovereign Decoupling Matrix: reusable subprocess-compute substrate.
+
+The event-loop starvation root cause (Slice 149) is GIL-bound CPU work — the
+SemanticIndex k-means build (~9.8s) and posture collectors (~32s) hold the GIL even
+when run via ``asyncio.to_thread``, because threads cannot escape the GIL. Processes
+can. This module COMPOSES the proven ``oracle_ipc`` parent machinery
+(``AsyncOracleProxy``: spawn → bounded respawn → async ``recv`` via executor →
+fail-closed ``OracleNotReady``) to run arbitrary CPU-bound work in a dedicated
+spawn-process, so the GovernedLoopService event loop NEVER stalls.
+
+It deliberately REUSES ``AsyncOracleProxy`` (the parent side is worker-agnostic:
+injectable ``spawn_fn`` + the generic ``{id, method, args}``→``{id, ok, result}``
+protocol) rather than reinventing the IPC wheel — only the worker entrypoint and a
+spawn helper are new. Workers built with :func:`run_worker_loop` speak the exact
+protocol ``AsyncOracleProxy`` expects.
+
+Gated ``JARVIS_COMPUTE_ISOLATION_ENABLED`` default-FALSE per §33.1. Fail-closed: a
+crashed/hung/not-yet-ready worker yields ``OracleNotReady`` from ``proxy.call`` —
+callers keep their existing in-process fallback (e.g. SemanticIndex.score against
+the current centroid), so an isolation failure NEVER takes down the loop.
+"""
+from __future__ import annotations
+
+import multiprocessing
+import os
+from typing import Any, Callable, Dict, Tuple
+
+# Reuse the proven parent IPC machinery — compose, don't reinvent.
+from backend.core.ouroboros.oracle_ipc import (
+    AsyncOracleProxy,
+    OracleNotReady,
+)
+
+_ENV_MASTER = "JARVIS_COMPUTE_ISOLATION_ENABLED"
+
+
+def compute_isolation_enabled() -> bool:
+    """Master gate, default-FALSE per §33.1. NEVER raises."""
+    return os.getenv(_ENV_MASTER, "false").strip().lower() in ("1", "true", "yes", "on")
+
+
+def spawn_worker(worker_main: Callable[[Any], None]) -> Tuple[Any, Any]:
+    """Spawn ``worker_main(child_conn)`` in a fresh spawn-process. Returns
+    ``(parent_conn, process)``. ``worker_main`` MUST be a top-level (spawn-picklable)
+    function. Mirrors ``oracle_ipc._default_spawn``: spawn context (clean GIL, safe
+    on macOS), duplex Pipe, daemon process, close the parent's child-end so an EOF
+    propagates when the child dies."""
+    ctx = multiprocessing.get_context("spawn")
+    parent_conn, child_conn = ctx.Pipe(duplex=True)
+    proc = ctx.Process(target=worker_main, args=(child_conn,), daemon=True)
+    proc.start()
+    try:
+        child_conn.close()
+    except Exception:  # noqa: BLE001
+        pass
+    return parent_conn, proc
+
+
+def run_worker_loop(
+    conn: Any,
+    handlers: Dict[str, Callable[..., Any]],
+    *,
+    signal_ready: bool = True,
+) -> None:
+    """Worker-side request loop — runs IN the child process. Implements the
+    ``oracle_ipc`` protocol so ``AsyncOracleProxy`` drives it unmodified:
+
+      1. send ``{"control": "ready"}`` (so the proxy flips ``is_ready``),
+      2. recv ``{"id", "method", "args", "kwargs"}``,
+      3. dispatch ``handlers[method](*args, **kwargs)``,
+      4. send ``{"id", "ok": True, "result": ...}`` or ``{"id", "ok": False, "error": ...}``.
+
+    Fail-closed PER CALL: a handler exception is reported, the loop survives.
+    ``{"control": "shutdown"}`` or a closed pipe (EOF/OSError) ends it cleanly.
+    NEVER raises out of the worker. Results must be picklable (Pipe transport)."""
+    if signal_ready:
+        try:
+            conn.send({"control": "ready"})
+        except Exception:  # noqa: BLE001 — pipe already gone
+            return
+    while True:
+        try:
+            msg = conn.recv()
+        except (EOFError, OSError):
+            break  # parent closed the pipe → exit
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("control") == "shutdown":
+            break
+        rid = msg.get("id")
+        method = str(msg.get("method", ""))
+        handler = handlers.get(method)
+        if handler is None:
+            try:
+                conn.send({"id": rid, "ok": False, "error": f"no handler: {method}"})
+            except Exception:  # noqa: BLE001
+                break
+            continue
+        try:
+            result = handler(*msg.get("args", []), **msg.get("kwargs", {}))
+            conn.send({"id": rid, "ok": True, "result": result})
+        except Exception as exc:  # noqa: BLE001 — per-call failure, never fatal
+            try:
+                conn.send({"id": rid, "ok": False, "error": repr(exc)})
+            except Exception:  # noqa: BLE001
+                break
+
+
+def make_compute_proxy(
+    worker_main: Callable[[Any], None],
+    **proxy_kwargs: Any,
+) -> AsyncOracleProxy:
+    """Build an ``AsyncOracleProxy`` (reused parent machinery) that spawns
+    ``worker_main``. Callers ``await proxy.start()`` then ``await proxy.call(method,
+    *args)``; an ``OracleNotReady`` return means the worker can't serve yet (hydrating
+    / crashed / respawn-exhausted) → use your in-process fallback (fail-closed).
+
+    Composition: only ``spawn_fn`` is overridden — the proxy's spawn/respawn/backoff/
+    async-recv/fail-closed logic is the same code that runs the Oracle in production."""
+    return AsyncOracleProxy(
+        spawn_fn=lambda: spawn_worker(worker_main),
+        **proxy_kwargs,
+    )
+
+
+def is_not_ready(result: Any) -> bool:
+    """True if a ``proxy.call`` result is the fail-closed not-ready sentinel —
+    the signal for a caller to fall back to its in-process path."""
+    return isinstance(result, OracleNotReady)
+
+
+__all__ = [
+    "compute_isolation_enabled",
+    "spawn_worker",
+    "run_worker_loop",
+    "make_compute_proxy",
+    "is_not_ready",
+    "OracleNotReady",
+]

--- a/tests/governance/test_slice150_subprocess_compute.py
+++ b/tests/governance/test_slice150_subprocess_compute.py
@@ -1,0 +1,105 @@
+"""Slice 150 Phase 1 — reusable subprocess-compute substrate.
+
+Composes the proven oracle_ipc parent machinery (AsyncOracleProxy: spawn → bounded
+respawn → async recv via executor → fail-closed) so GIL-bound CPU work (SemanticIndex
+k-means build, posture collectors) can run in a dedicated spawn-process. Threads
+can't escape the GIL; processes can. Gated default-FALSE; fail-closed.
+
+These tests are deterministic (fake Pipe / no real subprocess) — the real
+subprocess path is the SAME mechanism oracle_ipc already exercises in production.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+from backend.core.ouroboros.governance import subprocess_compute as SC
+
+
+class _FakeConn:
+    """Minimal duplex-Pipe stand-in for the worker side."""
+
+    def __init__(self, inbox):
+        self._inbox = list(inbox)
+        self.sent = []
+
+    def recv(self):
+        if not self._inbox:
+            raise EOFError
+        return self._inbox.pop(0)
+
+    def send(self, msg):
+        self.sent.append(msg)
+
+    def close(self):
+        pass
+
+
+class TestGate(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JARVIS_COMPUTE_ISOLATION_ENABLED", None)
+
+    def test_default_false(self):
+        self.assertFalse(SC.compute_isolation_enabled())
+
+
+class TestWorkerLoop(unittest.TestCase):
+    def test_signals_ready_then_dispatches(self):
+        conn = _FakeConn([
+            {"id": 1, "method": "double", "args": [5]},
+            {"control": "shutdown"},
+        ])
+        SC.run_worker_loop(conn, {"double": lambda x: x * 2})
+        self.assertEqual(conn.sent[0], {"control": "ready"})
+        self.assertEqual(conn.sent[1], {"id": 1, "ok": True, "result": 10})
+
+    def test_unknown_method_reported_not_fatal(self):
+        conn = _FakeConn([
+            {"id": 2, "method": "nope"},
+            {"id": 3, "method": "double", "args": [4]},
+            {"control": "shutdown"},
+        ])
+        SC.run_worker_loop(conn, {"double": lambda x: x * 2})
+        self.assertFalse(conn.sent[1]["ok"])
+        self.assertIn("no handler", conn.sent[1]["error"])
+        self.assertEqual(conn.sent[2], {"id": 3, "ok": True, "result": 8})  # loop survived
+
+    def test_handler_exception_is_fail_closed(self):
+        def _boom():
+            raise RuntimeError("kmeans exploded")
+        conn = _FakeConn([
+            {"id": 4, "method": "boom"},
+            {"id": 5, "method": "ok"},
+            {"control": "shutdown"},
+        ])
+        SC.run_worker_loop(conn, {"boom": _boom, "ok": lambda: "fine"})
+        self.assertFalse(conn.sent[1]["ok"])
+        self.assertIn("kmeans exploded", conn.sent[1]["error"])
+        self.assertEqual(conn.sent[2]["result"], "fine")  # survived the crash
+
+    def test_eof_breaks_cleanly(self):
+        conn = _FakeConn([])  # immediate EOF
+        SC.run_worker_loop(conn, {})
+        self.assertEqual(conn.sent, [{"control": "ready"}])  # ready then clean exit
+
+
+class TestProxyComposition(unittest.TestCase):
+    def test_make_compute_proxy_reuses_async_oracle_proxy(self):
+        from backend.core.ouroboros.oracle_ipc import AsyncOracleProxy
+
+        def _worker(conn):  # pragma: no cover - not run here
+            SC.run_worker_loop(conn, {})
+
+        proxy = SC.make_compute_proxy(_worker)
+        self.assertIsInstance(proxy, AsyncOracleProxy)
+        # the injected spawn_fn must be wired (callable) — composition, not reinvention
+        self.assertTrue(callable(proxy._spawn_fn))
+
+    def test_is_not_ready_sentinel(self):
+        from backend.core.ouroboros.oracle_ipc import OracleNotReady
+        self.assertTrue(SC.is_not_ready(OracleNotReady(reason="hydrating")))
+        self.assertFalse(SC.is_not_ready("a result"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Foundation for eradicating the GIL-bound event-loop starvation (Slice 149 root cause: SemanticIndex k-means ~9.8s + posture collectors ~32s stall the loop even via `to_thread` — threads can't escape the GIL).

**Composes `oracle_ipc` (no reinvention):** `AsyncOracleProxy`'s parent machinery is worker-agnostic (injectable `spawn_fn` + generic `{id,method,args}`→`{id,ok,result}` protocol). This adds only the worker-side helpers + a spawn helper:
- `compute_isolation_enabled()` — `JARVIS_COMPUTE_ISOLATION_ENABLED` default-FALSE
- `spawn_worker()` — spawn-context Pipe + daemon Process (mirrors `_default_spawn`)
- `run_worker_loop()` — worker request loop speaking the exact oracle_ipc protocol, fail-closed per call
- `make_compute_proxy()` — an `AsyncOracleProxy` with only `spawn_fn` overridden (reuses spawn/respawn/backoff/fail-closed)
- `is_not_ready()` — fail-closed sentinel for callers' in-process fallback

**Zero hot-path risk** (nothing imports it yet). 7 deterministic tests. Phases 2 (semantic build), 3 (posture collectors), 4 (soak validation) wire into this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a reusable subprocess-compute substrate that composes `oracle_ipc` to run CPU-heavy work in a separate process and prevent GIL-induced event-loop stalls. Gated by `JARVIS_COMPUTE_ISOLATION_ENABLED` and not wired into the hot path yet.

- **New Features**
  - `run_worker_loop(conn, handlers)` worker loop that speaks the `oracle_ipc` `{id,method,args}→{id,ok,result}` protocol and fails closed per call.
  - `spawn_worker(worker_main)` and `make_compute_proxy(worker_main, **kwargs)` to launch workers and reuse `AsyncOracleProxy` spawn/respawn/backoff logic.
  - `compute_isolation_enabled()` (via `JARVIS_COMPUTE_ISOLATION_ENABLED`, default false) and `is_not_ready(result)` for fallback checks; adds 7 deterministic tests.

<sup>Written for commit 5d802d074979eb822e02d64c4bd1d2c5d3bdb6f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

