### PR TITLE
Slice 151 — instant [boot] telemetry (boot-sequencer rejected by verify-first)

### DIFF
--- a/backend/core/ouroboros/governance/discord_observability_bridge.py
+++ b/backend/core/ouroboros/governance/discord_observability_bridge.py
@@ -191,6 +191,25 @@ class DiscordBridge:
                 self._last_post[ch] = now
         return posted
 
+    async def post_boot(self, detail: str = "organism igniting",
+                        *, poster: Optional[_Poster] = None) -> bool:
+        """Slice 151 — instant [boot] telemetry: post a single ping to #heartbeat
+        the moment the bridge arms, so the organism is observable within seconds of
+        startup regardless of background warm-up. Bypasses batching/throttling (one
+        message). Fail-soft: no heartbeat webhook or a dead poster → False, never
+        raises (a boot ping must never block startup)."""
+        try:
+            url = webhook_url_for("heartbeat")
+            if not url:
+                return False
+            content = f"{_EMOJI.get('heartbeat', '💓')} **[boot]** {detail}"
+            send = poster or _default_poster
+            rc = await send(url, content)
+            return 200 <= int(rc) < 300
+        except Exception as exc:  # noqa: BLE001 — a boot ping never blocks startup
+            logger.debug("[DiscordBridge] boot ping swallowed: %s", exc)
+            return False
+
     async def run(self, *, source: Any, poster: Optional[_Poster] = None,
                   stop: Any = None) -> None:
         """Drain ``source`` (an asyncio.Queue of BridgeEvent/StreamEvent) into
@@ -267,6 +286,9 @@ async def run_bridge_against_broker(*, stop: Any = None) -> None:
             logger.warning("[DiscordBridge] broker subscriber cap reached — not bridging")
             return
         bridge = DiscordBridge()
+        # Slice 151 — fire instant [boot] telemetry the moment we arm, so the
+        # organism is observable within seconds of startup (before any warm-up).
+        await bridge.post_boot()
         try:
             await bridge.run(source=sub.queue, stop=stop)
         finally:

--- a/tests/architecture/test_slice151_boot_telemetry.py
+++ b/tests/architecture/test_slice151_boot_telemetry.py
@@ -1,0 +1,58 @@
+"""Slice 151 — instant [boot] telemetry.
+
+Verify-first killed the "boot sequencer" (the cold-boot 27s is a wall-clock artifact
+during a busy-but-non-blocking boot; the real contributor is the Oracle worker dying
+on missing lean-image deps — async churn, not a loop block). But the operator's
+underlying Stage-1 goal is real: the Discord bridge should post a visible [boot]
+ping the instant it arms, so the organism is observable within seconds of startup
+regardless of background warm-up. This is that — small, safe, fail-soft.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+
+from backend.core.ouroboros.governance import discord_observability_bridge as DB
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestBootPing(unittest.TestCase):
+    def setUp(self):
+        os.environ["JARVIS_DISCORD_WEBHOOK_HEARTBEAT"] = "https://hook/heartbeat"
+
+    def tearDown(self):
+        os.environ.pop("JARVIS_DISCORD_WEBHOOK_HEARTBEAT", None)
+
+    def test_post_boot_posts_to_heartbeat_immediately(self):
+        posts = []
+        async def _poster(url, content):
+            posts.append((url, content))
+            return 204
+        b = DB.DiscordBridge(min_post_interval_s=0)
+        ok = _run(b.post_boot("organism igniting", poster=_poster))
+        self.assertTrue(ok)
+        self.assertEqual(posts[0][0], "https://hook/heartbeat")
+        self.assertIn("boot", posts[0][1].lower())
+        self.assertIn("organism igniting", posts[0][1])
+
+    def test_post_boot_failsoft_when_no_heartbeat_webhook(self):
+        os.environ.pop("JARVIS_DISCORD_WEBHOOK_HEARTBEAT", None)
+        async def _poster(url, content):
+            return 204
+        b = DB.DiscordBridge(min_post_interval_s=0)
+        self.assertFalse(_run(b.post_boot("x", poster=_poster)))  # no webhook → no-op, no raise
+
+    def test_post_boot_failsoft_on_poster_error(self):
+        async def _boom(url, content):
+            raise RuntimeError("discord down")
+        b = DB.DiscordBridge(min_post_interval_s=0)
+        # must not raise (a dead webhook never blocks boot)
+        self.assertFalse(_run(b.post_boot("x", poster=_boom)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Verify-first verdict: the boot-sequencer is a phantom.** The cold-boot 27s is a **wall-clock** artifact (`_ls_sink_async` = monotonic delta) during a **busy-but-non-blocking** boot. Root contributor: the Oracle worker **dies on missing lean-image deps** (`networkx`/`tree_sitter`/`scipy`/`sklearn`) → fully-async respawn churn, not a loop block. A boot-sequencer would add startup-ordering risk to 'fix' a measurement artifact (same trap as the rejected P3). The loop is structurally healthy.

**But the real Stage-1 goal is delivered:** `DiscordBridge.post_boot()` posts a visible `[boot]` ping to #heartbeat the instant the bridge arms (bypasses batching, fail-soft — never blocks startup), wired into `run_bridge_against_broker`. **Live-proven: real ping posted (ok=True).** 3 tests + 10 bridge regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds instant boot telemetry: `DiscordBridge.post_boot()` sends a one-off [boot] ping to #heartbeat as soon as the bridge arms, bypassing batching and never blocking startup. Wired into `run_bridge_against_broker`; delivers Slice 151’s goal without adding a boot sequencer.

- **New Features**
  - Added `DiscordBridge.post_boot(detail)` that posts directly to the heartbeat webhook, bypasses batching/throttling, returns a bool, and swallows errors (fail-soft).
  - Invoked right after subscribe in `run_bridge_against_broker` so the service is visible within seconds of startup.
  - Added tests for success, missing webhook, and poster error.

<sup>Written for commit a428ca5fbc2aa8e6fe3beb148d5fa3b47ffde0e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

