### PR TITLE
Slice 149 P4 — Oracle dependency preflight (fail-fast; full-host canonical)

### DIFF
--- a/backend/core/ouroboros/oracle_ipc.py
+++ b/backend/core/ouroboros/oracle_ipc.py
@@ -108,6 +108,45 @@ class OracleCrash:
 
 
 # ===========================================================================
+# Slice 149 P4 — dependency preflight (fail-fast vs respawn storm)
+# ===========================================================================
+# Single source of the Oracle's HARD deps. Backed by the Oracle's own explicit
+# declaration: oracle.py:818 `raise ImportError("networkx is required for
+# Oracle")`. The lean soak image deliberately omits these (it runs the governance
+# loop context-free); a full host (requirements.txt) has them. Preflighting here
+# turns a permanent missing-dep ImportError into a SINGLE clean DEGRADE instead of
+# a 3x respawn storm with exponential backoff.
+_ORACLE_REQUIRED_DEPS: Tuple[str, ...] = ("networkx",)
+
+
+def oracle_dependencies_available(
+    checker: Optional[Callable[[str], bool]] = None,
+) -> Tuple[bool, list]:
+    """Return ``(all_present, missing_list)`` for the Oracle's hard deps.
+
+    ``checker(name) -> bool`` is injectable for deterministic tests; the default
+    uses ``importlib.util.find_spec``. NEVER raises — a probe error treats the dep
+    as PRESENT (fail-open toward spawning, so a buggy probe never disables the
+    Oracle on a host that actually has its deps)."""
+    def _present(name: str) -> bool:
+        try:
+            import importlib.util
+            return importlib.util.find_spec(name) is not None
+        except Exception:  # noqa: BLE001 — probe error → assume present (fail-open)
+            return True
+    probe = checker or _present
+    missing = []
+    for dep in _ORACLE_REQUIRED_DEPS:
+        try:
+            present = probe(dep)
+        except Exception:  # noqa: BLE001
+            present = True  # fail-open
+        if not present:
+            missing.append(dep)
+    return (not missing, missing)
+
+
+# ===========================================================================
 # Child worker — runs INSIDE the isolated process (own GIL)
 # ===========================================================================
 
@@ -237,14 +276,44 @@ class AsyncOracleProxy:
         self._started_at = 0.0
         self._respawns = 0
         self._closing = False
+        # Slice 149 P4 — set by the start() preflight when hard deps are absent
+        # (lean environment); a permanent DEGRADE, NOT a transient respawn.
+        self._missing_deps: list = []
 
     # -- lifecycle ----------------------------------------------------------
 
-    async def start(self) -> None:
+    async def start(
+        self,
+        *,
+        dep_check: Optional[Callable[[], Tuple[bool, list]]] = None,
+    ) -> None:
         """Spawn the Oracle process + begin reading. Returns immediately — the
         Oracle hydrates in the background; queries return OracleNotReady until
-        the worker signals ready."""
+        the worker signals ready.
+
+        Slice 149 P4 — DEPENDENCY PREFLIGHT first: if the Oracle's hard deps are
+        absent (lean environment), DEGRADE ONCE with a clear diagnostic and do NOT
+        spawn — turning a permanent missing-dep ImportError into a single clean
+        degrade instead of a 3x respawn storm. Full host (deps present) → normal
+        spawn; a later transient crash still uses the bounded respawn.
+        ``dep_check`` injectable for tests; a preflight error fails OPEN (spawns)."""
         self._closing = False
+        check = dep_check or oracle_dependencies_available
+        try:
+            ok, missing = check()
+        except Exception:  # noqa: BLE001 — never block the Oracle on a buggy preflight
+            ok, missing = True, []
+        if not ok:
+            self._missing_deps = list(missing)
+            self._started_at = time.time()
+            logger.warning(
+                "[OracleIPC] DEGRADED — missing hard dep(s): %s. Lean environment; "
+                "Oracle stays context-free (engine unaffected). NO respawn attempted "
+                "(permanent ImportError). Run on a full host (requirements.txt) for "
+                "the Oracle.", ", ".join(missing),
+            )
+            return
+        self._missing_deps = []
         await self._spawn()
 
     async def _spawn(self) -> None:
@@ -293,6 +362,8 @@ class AsyncOracleProxy:
         return self._ready
 
     def _not_ready(self, reason: Optional[str] = None) -> OracleNotReady:
+        if self._missing_deps and reason is None:
+            reason = "missing_deps"  # Slice 149 P4 — permanent, lean-environment degrade
         r = reason or ("init_failed" if self._init_failed else "hydrating")
         return OracleNotReady(reason=r, elapsed_s=time.time() - self._started_at, respawns=self._respawns)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,6 +4,22 @@ Reboot-surviving, self-backing-up deployment for the T5 unattended soak. One
 command arms the crypto gate and launches the organism as systemd services — and
 one command migrates the whole organism from your workstation to a cloud host.
 
+## Two environments (deliberate) — full host is canonical for the 12-month soak
+
+| Environment | Deps | Oracle | Use |
+|---|---|---|---|
+| **Full host** (`migrate_to_host.sh` → `provision_host.sh` installs `requirements.txt`) | complete graph (incl. `networkx`/`tree_sitter`/`scipy`/`sklearn`) | **runs** (codebase graph live) | **Canonical 12-month production soak** |
+| **Lean Docker** (`docker/requirements-soak.txt`) | minimal governance-loop set only | **DEGRADED by design** (context-free) | Cost/governance + Discord-observability soak; quick local runs |
+
+**Do not bloat `docker/requirements-soak.txt`** to make the lean image run the
+Oracle — that muddies the architecture. The lean image is *meant* to run
+context-free. **Slice 149-P4 guardrail:** `oracle_ipc` now **preflights its hard
+deps before spawning** (single source: `_ORACLE_REQUIRED_DEPS`, backed by
+`oracle.py`'s explicit `networkx is required` raise). In a lean environment the
+Oracle **DEGRADES once** with a clear diagnostic — no 3× respawn storm — and the
+engine continues context-free; a transient crash on a full host still uses the
+bounded respawn. The canonical 12-month soak runs on a **full host**.
+
 ## Autonomous cloud migration (Slice 139) — workstation → industrial host
 
 From the **main checkout** (where `.jarvis/` holds the real keys + signed roadmap):

--- a/tests/governance/test_slice149_oracle_preflight.py
+++ b/tests/governance/test_slice149_oracle_preflight.py
@@ -1,0 +1,110 @@
+"""Slice 149 P4 — Oracle dependency preflight + fail-fast.
+
+The lean soak image lacks the Oracle's hard deps (networkx, declared required at
+oracle.py:818). Today that causes a 3x respawn storm with exponential backoff
+before DEGRADED. This preflights the deps BEFORE spawning: missing → DEGRADE ONCE
+(reason=missing_deps), no respawn churn; present (full host) → normal spawn; a
+transient crash (deps present) still uses the bounded respawn. Single-source dep
+declaration; checker injectable → deterministic, no real imports.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import unittest
+
+from backend.core.ouroboros import oracle_ipc as OI
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class _FakeConn:
+    def __init__(self):
+        self._ev = threading.Event()
+        self._ready_sent = False
+
+    def recv(self):
+        if not self._ready_sent:
+            self._ready_sent = True
+            return {"control": "ready"}
+        self._ev.wait()      # block until close() (no spurious respawn)
+        raise EOFError
+
+    def send(self, msg):
+        pass
+
+    def close(self):
+        self._ev.set()
+
+
+class _FakeProc:
+    def is_alive(self):
+        return True
+
+    def terminate(self):
+        pass
+
+
+class TestDepDeclaration(unittest.TestCase):
+    def test_networkx_is_declared_required(self):
+        # Single source, backed by oracle.py:818 "networkx is required for Oracle".
+        self.assertIn("networkx", OI._ORACLE_REQUIRED_DEPS)
+
+    def test_dependencies_available_with_injected_checker(self):
+        ok, missing = OI.oracle_dependencies_available(checker=lambda d: d != "networkx")
+        self.assertFalse(ok)
+        self.assertIn("networkx", missing)
+        ok2, missing2 = OI.oracle_dependencies_available(checker=lambda d: True)
+        self.assertTrue(ok2)
+        self.assertEqual(missing2, [])
+
+
+class TestPreflightFailFast(unittest.TestCase):
+    def test_missing_deps_degrades_once_no_spawn_no_respawn(self):
+        spawned = []
+        proxy = OI.AsyncOracleProxy(spawn_fn=lambda: (spawned.append(1), (None, None))[1])
+        _run(proxy.start(dep_check=lambda: (False, ["networkx"])))
+        self.assertEqual(spawned, [])          # never spawned → no ImportError storm
+        self.assertEqual(proxy._respawns, 0)   # no respawn churn
+        self.assertFalse(proxy.is_ready)
+        self.assertEqual(proxy._not_ready().reason, "missing_deps")
+
+    def test_present_deps_spawn_normally(self):
+        spawned = []
+        def _spawn():
+            spawned.append(1)
+            return (_FakeConn(), _FakeProc())
+        proxy = OI.AsyncOracleProxy(spawn_fn=_spawn)
+        _run(proxy.start(dep_check=lambda: (True, [])))
+        self.assertEqual(spawned, [1])         # full host → normal spawn
+        _run(proxy.shutdown())
+
+    def test_preflight_exception_fails_open_to_spawn(self):
+        spawned = []
+        def _spawn():
+            spawned.append(1)
+            return (_FakeConn(), _FakeProc())
+        def _boom():
+            raise RuntimeError("checker broke")
+        proxy = OI.AsyncOracleProxy(spawn_fn=_spawn)
+        _run(proxy.start(dep_check=_boom))
+        self.assertEqual(spawned, [1])         # never block the Oracle on a buggy preflight
+        _run(proxy.shutdown())
+
+    def test_default_start_still_works(self):
+        # start() with no dep_check must still run (uses the real preflight).
+        spawned = []
+        def _spawn():
+            spawned.append(1)
+            return (_FakeConn(), _FakeProc())
+        proxy = OI.AsyncOracleProxy(spawn_fn=_spawn)
+        # Inject a checker that says present so we don't depend on the host's networkx.
+        _run(proxy.start(dep_check=lambda: (True, [])))
+        self.assertEqual(spawned, [1])
+        _run(proxy.shutdown())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The lean soak image omits the Oracle's hard deps (`networkx`, declared required at `oracle.py:818`) → worker ImportError-dies → 3 respawns w/ 2+4+6s backoff → DEGRADED (wasteful churn for a **permanent** failure). Now `oracle_ipc` **preflights its hard deps before spawning**:

- **`_ORACLE_REQUIRED_DEPS`** — single source, backed by the Oracle's own `networkx is required` raise (non-over-degrading)
- **`oracle_dependencies_available(checker=)`** — `find_spec` probe, injectable, never raises (fail-open)
- **`AsyncOracleProxy.start(dep_check=)`** — missing → **DEGRADE ONCE** (`reason=missing_deps`, clear diagnostic, **no spawn, no respawn**) → `call()` returns `OracleNotReady` → engine context-free; present → normal spawn; **transient crash still uses bounded respawn (unchanged)**

Wired automatically via `oracle_adapter.start() → proxy.start()`. `deploy/README` documents **full host = canonical 12-month soak** (full `requirements.txt` → Oracle runs); lean Docker is context-free by design — **don't bloat `requirements-soak.txt`**.

**6 preflight + 17 oracle regression green**; transient-crash respawn semantics unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a fail-fast dependency preflight for the Oracle to avoid respawn storms when hard deps like `networkx` are missing. Missing deps now cause a single, clear degrade (`reason=missing_deps`) with no spawn/respawn; normal spawn and bounded respawn for transient crashes are unchanged.

- **New Features**
  - `_ORACLE_REQUIRED_DEPS` defines hard deps (currently `networkx`) as a single source of truth.
  - `oracle_dependencies_available(checker=)` probes with `find_spec`; injectable; fail-open; never raises.
  - `AsyncOracleProxy.start(dep_check=)` runs the preflight. Missing deps → no spawn/respawn and `OracleNotReady(reason="missing_deps")`; deps present → normal spawn.
  - Auto-wired via `oracle_adapter.start()`. Added tests for preflight and spawn behavior. Updated `deploy/README.md` to clarify full host (full `requirements.txt`) vs lean Docker (`docker/requirements-soak.txt`) and that the lean image stays context-free.

<sup>Written for commit 1e3408240ee8bcac4b3161ac4e78abe4ba6a0f8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

