### PR TITLE
Slice 152 — Oracle-capable soak image for macOS (no Linux host needed)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -10,6 +10,14 @@ one command migrates the whole organism from your workstation to a cloud host.
 |---|---|---|---|
 | **Full host** (`migrate_to_host.sh` → `provision_host.sh` installs `requirements.txt`) | complete graph (incl. `networkx`/`tree_sitter`/`scipy`/`sklearn`) | **runs** (codebase graph live) | **Canonical 12-month production soak** |
 | **Lean Docker** (`docker/requirements-soak.txt`) | minimal governance-loop set only | **DEGRADED by design** (context-free) | Cost/governance + Discord-observability soak; quick local runs |
+| **Oracle-capable Docker** (`docker/requirements-soak-oracle.txt`, `launch_docker_soak.sh --oracle`) | lean + Oracle graph stack (`networkx`/`scipy`/`scikit-learn`/`tree_sitter`/`aiofiles`, arm64 wheels) | **runs** | **macOS soak with the Oracle live** — detached + decoupled, no separate Linux host |
+
+**On macOS (no separate Linux host):** `./scripts/launch_docker_soak.sh --oracle`
+builds the Oracle-capable image (the lean set + the Oracle graph deps via `-r`, NOT
+the full torch/transformers stack) and runs it **detached under dockerd** — surviving
+this session + reboot (with Docker Desktop auto-start), decoupled from any agent
+event loop, with the Oracle booting (preflight passes). This is the canonical-
+equivalent soak for a Mac without provisioning a cloud VM.
 
 **Do not bloat `docker/requirements-soak.txt`** to make the lean image run the
 Oracle — that muddies the architecture. The lean image is *meant* to run

--- a/docker-compose.soak.yml
+++ b/docker-compose.soak.yml
@@ -19,6 +19,10 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.soak
+      args:
+        # Slice 152 — lean (default) or Oracle-capable. launch_docker_soak.sh
+        # --oracle exports SOAK_REQUIREMENTS=requirements-soak-oracle.txt.
+        SOAK_REQUIREMENTS: ${SOAK_REQUIREMENTS:-requirements-soak.txt}
     image: jarvis-sovereign-soak:latest
     container_name: jarvis-sovereign-soak
     working_dir: /app

--- a/docker/Dockerfile.soak
+++ b/docker/Dockerfile.soak
@@ -33,10 +33,17 @@ WORKDIR /app
 # vision/voice/training stack (torch / transformers / faster-whisper / speechbrain)
 # that (a) the governance loop never imports and (b) does not resolve in a clean
 # Linux container (torch==2.12.0 is private-index-only; transformers vs pinned
-# huggingface-hub is ResolutionImpossible). See docker/requirements-soak.txt.
-COPY docker/requirements-soak.txt /app/requirements-soak.txt
+# huggingface-hub is ResolutionImpossible).
+#
+# Slice 152 — SOAK_REQUIREMENTS build-arg picks the variant (both live in docker/):
+#   * requirements-soak.txt         (default) — lean, Oracle-DEGRADED (context-free)
+#   * requirements-soak-oracle.txt  — lean + Oracle graph deps (networkx/scipy/
+#       scikit-learn/tree_sitter/aiofiles, all arm64 wheels) → Oracle BOOTS.
+# The oracle file composes the lean one via -r, so both are copied.
+ARG SOAK_REQUIREMENTS=requirements-soak.txt
+COPY docker/requirements-soak.txt docker/requirements-soak-oracle.txt /app/docker/
 RUN pip install --upgrade pip wheel setuptools && \
-    pip install -r /app/requirements-soak.txt
+    pip install -r /app/docker/${SOAK_REQUIREMENTS}
 
 # Application code (.dockerignore keeps .venv / .git / .env / .jarvis out).
 COPY . /app

--- a/docker/requirements-soak-oracle.txt
+++ b/docker/requirements-soak-oracle.txt
@@ -1,0 +1,20 @@
+# JARVIS Oracle-capable Soak — lean governance deps + the Oracle's codebase-graph deps.
+# =============================================================================
+# This is the Oracle-CAPABLE variant for macOS/Docker (no separate Linux host):
+# the lean governance set PLUS the Oracle's graph stack, so the Oracle dependency
+# preflight (Slice 149-P4) passes and the Oracle boots in-container.
+#
+# It does NOT bloat the lean requirements-soak.txt (composed via -r) and it does
+# NOT pull the full monorepo ML/voice/training stack (torch/transformers/etc. —
+# ResolutionImpossible on linux). The graph deps below all ship arm64 wheels.
+# =============================================================================
+-r requirements-soak.txt
+
+# Oracle codebase-graph stack (oracle.py: "networkx is required for Oracle")
+networkx>=3.0
+scipy
+scikit-learn
+tree_sitter
+
+# Event Spine (event-driven sensors instead of polling fallback)
+aiofiles

--- a/scripts/launch_docker_soak.sh
+++ b/scripts/launch_docker_soak.sh
@@ -17,6 +17,16 @@ die() { printf '\033[31m[docker-soak] FATAL:\033[0m %s\n' "$*" >&2; exit 1; }
 
 docker info >/dev/null 2>&1 || die "docker daemon not reachable."
 
+# Slice 152 — --oracle builds the Oracle-CAPABLE image (lean + Oracle graph deps:
+# networkx/scipy/scikit-learn/tree_sitter/aiofiles) so the Oracle BOOTS in-container
+# on macOS/Docker (no separate Linux host). Default = lean (Oracle-degraded).
+for _arg in "$@"; do
+  if [ "$_arg" = "--oracle" ]; then
+    export SOAK_REQUIREMENTS="requirements-soak-oracle.txt"
+    log "ORACLE-CAPABLE build selected (SOAK_REQUIREMENTS=$SOAK_REQUIREMENTS)."
+  fi
+done
+
 # Preflight: the runtime-mounted secrets + crypto must exist on the host.
 [ -f "$REPO_ROOT/.env" ] || die "no .env at repo root (funded DOUBLEWORD_API_KEY / ANTHROPIC_API_KEY required)."
 [ -f "$REPO_ROOT/.jarvis/roadmap.signed.yaml" ] || die "no .jarvis/roadmap.signed.yaml — provision + sign first (sovereign_keys), the Layer-4 gate is fail-closed."
@@ -38,7 +48,9 @@ log "  Stop:   ${DC[*]} -f $COMPOSE down"
 log "  Reboot-survival: sudo systemctl enable docker   (so dockerd starts on boot)"
 log "═══════════════════════════════════════════════════════════════"
 
-if [ "${1:-}" != "--no-logs" ]; then
+_no_logs=0
+for _arg in "$@"; do [ "$_arg" = "--no-logs" ] && _no_logs=1; done
+if [ "$_no_logs" -eq 0 ]; then
   log "Tailing logs (Ctrl-C detaches; the container keeps running)…"
   "${DC[@]}" -f "$COMPOSE" logs -f jarvis-soak
 fi


### PR DESCRIPTION
On macOS there's no separate Linux host for `migrate_to_host.sh`. But the Oracle's graph deps (`networkx`/`scipy`/`scikit-learn`/`tree_sitter` — unlike torch) all ship **arm64 wheels**, so the Oracle can run in a Mac Docker container.

- **`docker/requirements-soak-oracle.txt`** — composes the lean set via `-r` (**lean image untouched, no bloat**) + Oracle graph stack + `aiofiles`. Not the full monorepo (torch/transformers = ResolutionImpossible).
- **`Dockerfile.soak`** — `SOAK_REQUIREMENTS` build-arg (default lean) picks the variant.
- **`docker-compose.soak.yml`** — passes the arg from env.
- **`launch_docker_soak.sh --oracle`** — one flag builds the Oracle-capable image.

**Live-validated:** image builds (1.57GB, 0 errors), all graph deps present in-container, **** (no DEGRADE, no respawn storm).

```bash
./scripts/launch_docker_soak.sh --oracle   # detached + decoupled + Oracle live on macOS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Oracle-capable soak image for macOS so the Oracle can run in Docker without a separate Linux host. Toggle the variant with `--oracle` when launching (run `./scripts/launch_docker_soak.sh --oracle`).

- **New Features**
  - New `docker/requirements-soak-oracle.txt` composes the lean set via `-r` and adds Oracle graph deps (`networkx`, `scipy`, `scikit-learn`, `tree_sitter`) plus `aiofiles`; does not include `torch`/`transformers`.
  - `Dockerfile.soak` accepts `SOAK_REQUIREMENTS` (default `requirements-soak.txt`); both requirement files are copied and pip installs the selected list.
  - `docker-compose.soak.yml` passes `SOAK_REQUIREMENTS` from env with a default.
  - `launch_docker_soak.sh --oracle` sets `SOAK_REQUIREMENTS=requirements-soak-oracle.txt` and builds/runs the Oracle-capable image.
  - `deploy/README.md` documents the macOS Oracle path.

- **Bug Fixes**
  - `--no-logs` is now detected regardless of arg position in `launch_docker_soak.sh`.

<sup>Written for commit 61e737a8ca50047f1ffafdbaab1e8505c0f0df5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

