### PR TITLE
Slice 153 — EmbeddingService fastembed fallback (Oracle embed_nodes via fastembed)

### DIFF
--- a/backend/core/embedding_service.py
+++ b/backend/core/embedding_service.py
@@ -71,6 +71,11 @@ class EmbeddingServiceConfig:
     # Model settings
     model_name: str = "all-MiniLM-L6-v2"
     device: str = "cpu"  # "cpu", "cuda", "mps"
+    # Slice 153 — fastembed fallback model (used when sentence-transformers is
+    # unavailable, e.g. the Oracle-capable soak image which ships fastembed not
+    # torch). 384-dim like all-MiniLM-L6-v2 → embedding-dim compatible. The model
+    # name is config-sourced (no hardcode in logic); matches semantic_index's default.
+    fastembed_model_name: str = "BAAI/bge-small-en-v1.5"
 
     # Performance settings
     batch_size: int = 32
@@ -104,7 +109,51 @@ class EmbeddingServiceConfig:
             pool_size=int(os.getenv("EMBEDDING_POOL_SIZE", "0")),
             enable_cache=os.getenv("EMBEDDING_CACHE", "true").lower() == "true",
             cache_maxsize=int(os.getenv("EMBEDDING_CACHE_SIZE", "10000")),
+            fastembed_model_name=os.getenv(
+                "EMBEDDING_FASTEMBED_MODEL", "BAAI/bge-small-en-v1.5",
+            ),
         )
+
+
+# =============================================================================
+# Slice 153 — fastembed fallback adapter (SentenceTransformer.encode-compatible)
+# =============================================================================
+
+class _FastembedSTAdapter:
+    """A ``SentenceTransformer.encode``-compatible adapter over fastembed's
+    ``TextEmbedding``. Slice 153 — lets ``EmbeddingService.encode()`` (and every
+    one of its 14+ consumers, incl. the Oracle's ``embed_nodes``) work UNCHANGED on
+    fastembed when sentence-transformers is unavailable (the Oracle-capable soak
+    image ships fastembed, not torch). Exposes only the ``encode(...)`` subset
+    EmbeddingService calls; returns a normalized float32 ``(n, dim)`` array."""
+
+    def __init__(self, model_name: str, *, factory: Any = None) -> None:
+        self.model_name = model_name
+        if factory is not None:
+            self._te = factory(model_name)          # injectable for tests
+        else:
+            from fastembed import TextEmbedding      # deferred: no import unless used
+            self._te = TextEmbedding(model_name=model_name)
+
+    def encode(
+        self,
+        sentences: Any,
+        batch_size: Any = None,
+        normalize_embeddings: bool = True,
+        show_progress_bar: bool = False,
+        convert_to_numpy: bool = True,
+        **_kw: Any,
+    ) -> np.ndarray:
+        items = [sentences] if isinstance(sentences, str) else list(sentences)
+        vecs = [np.asarray(v, dtype="float32") for v in self._te.embed(items)]
+        if not vecs:
+            return np.zeros((0, 0), dtype="float32")
+        arr = np.vstack(vecs).astype("float32")
+        if normalize_embeddings:
+            norms = np.linalg.norm(arr, axis=1, keepdims=True)
+            norms[norms == 0] = 1.0
+            arr = arr / norms
+        return arr
 
 
 # =============================================================================
@@ -230,6 +279,11 @@ class EmbeddingService:
             logger.warning(f"[EmbeddingService] Memory check failed: {e}, proceeding anyway")
             return True
 
+    def _make_fastembed_model(self, factory: Any = None) -> "_FastembedSTAdapter":
+        """Slice 153 — build the SentenceTransformer.encode-compatible fastembed
+        adapter (config-sourced model name). ``factory`` injectable for tests."""
+        return _FastembedSTAdapter(self._config.fastembed_model_name, factory=factory)
+
     async def _load_model(self) -> bool:
         """
         Lazy load the SentenceTransformer model.
@@ -296,8 +350,28 @@ class EmbeddingService:
                 return True
 
             except ImportError as e:
-                logger.error(f"[EmbeddingService] ❌ sentence-transformers not installed: {e}")
-                return False
+                # Slice 153 — sentence-transformers absent (e.g. the Oracle-capable
+                # soak image: fastembed, not torch). Fall back to fastembed via a
+                # SentenceTransformer.encode-compatible adapter so encode() works
+                # unchanged — instead of returning None (which left the Oracle's
+                # embed_nodes producing no embeddings).
+                logger.warning(
+                    "[EmbeddingService] sentence-transformers unavailable (%s) — "
+                    "falling back to fastembed (model=%s)",
+                    e, self._config.fastembed_model_name,
+                )
+                try:
+                    self._model = self._make_fastembed_model()
+                    logger.info(
+                        "[EmbeddingService] ✅ fastembed fallback loaded: model=%s",
+                        self._config.fastembed_model_name,
+                    )
+                    return True
+                except Exception as fe:  # noqa: BLE001
+                    logger.error(
+                        "[EmbeddingService] ❌ fastembed fallback failed: %s", fe,
+                    )
+                    return False
             except Exception as e:
                 logger.error(f"[EmbeddingService] ❌ Failed to load model: {e}")
                 return False

--- a/tests/core/test_slice153_embedding_fastembed_fallback.py
+++ b/tests/core/test_slice153_embedding_fastembed_fallback.py
@@ -1,0 +1,88 @@
+"""Slice 153 — EmbeddingService fastembed fallback (Oracle embed_nodes via fastembed).
+
+The Oracle-capable soak image ships fastembed, not sentence-transformers (which pulls
+torch). Today EmbeddingService._load_model ImportErrors on missing sentence-transformers
+→ encode() returns None → the Oracle's embed_nodes produces no embeddings. This wires
+a SentenceTransformer.encode-compatible fastembed adapter into that ImportError branch,
+so encode() (and all 14+ consumers) work UNCHANGED on fastembed. Config-sourced model
+name (no hardcode); fastembed import injectable → deterministic tests.
+"""
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from backend.core import embedding_service as ES
+
+
+class _FakeTextEmbedding:
+    """Stand-in for fastembed.TextEmbedding: .embed(list[str]) -> iterator of vectors."""
+
+    def __init__(self, model_name):
+        self.model_name = model_name
+
+    def embed(self, texts):
+        # deterministic 4-dim vectors (unnormalized) per text length
+        for t in texts:
+            n = float(len(t)) + 1.0
+            yield np.array([n, n * 2, n * 3, n * 4], dtype="float32")
+
+
+class TestConfig(unittest.TestCase):
+    def test_fastembed_model_name_default(self):
+        cfg = ES.EmbeddingServiceConfig()
+        self.assertTrue(getattr(cfg, "fastembed_model_name", None))
+
+    def test_fastembed_model_name_from_env(self):
+        import os
+        os.environ["EMBEDDING_FASTEMBED_MODEL"] = "BAAI/bge-small-en-v1.5"
+        try:
+            cfg = ES.EmbeddingServiceConfig.from_env()
+            self.assertEqual(cfg.fastembed_model_name, "BAAI/bge-small-en-v1.5")
+        finally:
+            os.environ.pop("EMBEDDING_FASTEMBED_MODEL", None)
+
+
+class TestAdapter(unittest.TestCase):
+    def _adapter(self):
+        return ES._FastembedSTAdapter("m", factory=lambda name: _FakeTextEmbedding(name))
+
+    def test_encode_returns_2d_float32_array(self):
+        a = self._adapter()
+        out = a.encode(["alpha", "beta"], convert_to_numpy=True)
+        self.assertEqual(out.shape, (2, 4))
+        self.assertEqual(out.dtype, np.float32)
+
+    def test_encode_normalizes_when_requested(self):
+        a = self._adapter()
+        out = a.encode(["alpha"], normalize_embeddings=True)
+        self.assertAlmostEqual(float(np.linalg.norm(out[0])), 1.0, places=5)
+
+    def test_encode_unnormalized_when_disabled(self):
+        a = self._adapter()
+        out = a.encode(["alpha"], normalize_embeddings=False)
+        self.assertGreater(float(np.linalg.norm(out[0])), 1.0)  # raw magnitude kept
+
+    def test_encode_accepts_sentencetransformer_kwargs(self):
+        # Must swallow the exact kwargs EmbeddingService.encode passes to model.encode.
+        a = self._adapter()
+        out = a.encode(
+            ["x"], batch_size=32, normalize_embeddings=True,
+            show_progress_bar=False, convert_to_numpy=True,
+        )
+        self.assertEqual(out.shape, (1, 4))
+
+
+class TestServiceFallback(unittest.TestCase):
+    def test_make_fastembed_model_uses_injected_factory(self):
+        svc = ES.EmbeddingService()  # singleton
+        model = svc._make_fastembed_model(factory=lambda name: _FakeTextEmbedding(name))
+        self.assertIsNotNone(model)
+        self.assertEqual(model.model_name, svc._config.fastembed_model_name)
+        out = model.encode(["hello"], normalize_embeddings=True)
+        self.assertEqual(out.shape, (1, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Oracle-capable soak image ships fastembed, not sentence-transformers (pulls torch). `EmbeddingService._load_model` ImportError'd → `encode()` returned None → the Oracle's `embed_nodes` produced no embeddings. Now it falls back to fastembed via a **SentenceTransformer.encode-compatible adapter** (`_FastembedSTAdapter`), so `encode()` + all 14+ consumers work **unchanged**. Config-sourced model (`EMBEDDING_FASTEMBED_MODEL`, default `BAAI/bge-small-en-v1.5` = 384-dim, ChromaDB-compatible; no hardcode). ST path byte-identical when present; cleanup hasattr-guarded.

**Live-proven in the Oracle image:** `encode -> shape=(1,384)` via fastembed; `OracleSemanticIndex` constructs without chromadb (no None-crash). 7 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fallback to `fastembed` in EmbeddingService when `sentence-transformers` isn’t installed via a `SentenceTransformer.encode`-compatible adapter. This fixes missing embeddings in the Oracle image and keeps all current `encode()` consumers working unchanged.

- **New Features**
  - `_FastembedSTAdapter` wraps `fastembed.TextEmbedding` and mirrors `.encode(...)` (returns normalized float32 arrays; deferred import).
  - Configurable fallback model via `EMBEDDING_FASTEMBED_MODEL` (default `BAAI/bge-small-en-v1.5`).

<sup>Written for commit 36cfb5e48c22374f6f78147edede3ff7febb897b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

