### PR TITLE
Slice 154 — lazy OracleSemanticIndex (embed_nodes NoneType fix)

### DIFF
--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -1973,7 +1973,7 @@ class TheOracle:
             # timeout without hanging the asyncio loop.
             if self._semantic_index is None:
                 with _OraclePhase("oracle_semantic_index_init"):
-                    self._semantic_index = OracleSemanticIndex()
+                    self._ensure_semantic_index()
 
             self._readiness.mark_semantic_ready()
             self._running = True
@@ -2044,6 +2044,18 @@ class TheOracle:
         self._running = False
         logger.info("The Oracle shutdown complete")
 
+    def _ensure_semantic_index(self) -> "OracleSemanticIndex":
+        """Slice 154 — lazily construct the OracleSemanticIndex if it isn't up yet.
+
+        ``initialize_backend`` pre-warms ``self._semantic_index``, but full_index /
+        incremental_update can run before that semantic phase — leaving it None and
+        crashing ``embed_nodes`` with 'NoneType has no attribute embed_nodes'. This
+        guarantees a non-None index at every embed call site (single construction
+        point; OracleSemanticIndex.__init__ is lazy + never raises). NEVER returns None."""
+        if self._semantic_index is None:
+            self._semantic_index = OracleSemanticIndex()
+        return self._semantic_index
+
     async def full_index(self) -> None:
         """Perform a full index of all repositories."""
         logger.info("Starting full codebase index...")
@@ -2072,7 +2084,7 @@ class TheOracle:
         # Embed all nodes into semantic index (fault-isolated)
         try:
             all_nodes = self._graph.get_all_nodes()
-            await self._semantic_index.embed_nodes(all_nodes)
+            await self._ensure_semantic_index().embed_nodes(all_nodes)
         except Exception as exc:
             logger.warning("[Oracle] Semantic embedding after full_index failed: %s", exc)
 
@@ -2114,7 +2126,7 @@ class TheOracle:
                 ]
             else:
                 changed_nodes = self._graph.get_all_nodes()
-            await self._semantic_index.embed_nodes(changed_nodes)
+            await self._ensure_semantic_index().embed_nodes(changed_nodes)
         except Exception as exc:
             logger.warning("[Oracle] Semantic embedding after incremental_update failed: %s", exc)
 

--- a/tests/core/test_slice154_oracle_semantic_lazy.py
+++ b/tests/core/test_slice154_oracle_semantic_lazy.py
@@ -1,0 +1,44 @@
+"""Slice 154 — lazy OracleSemanticIndex (embed_nodes no longer NoneType-crashes).
+
+Slice 153 fixed the embedder (fastembed fallback), but the live soak still showed
+`[Oracle] Semantic embedding after full_index failed: 'NoneType' object has no
+attribute embed_nodes` — because full_index/incremental_update call
+self._semantic_index.embed_nodes while _semantic_index is still None (it's
+constructed only in initialize_backend, which can run after full_index). A lazy
+getter ensures the index exists wherever embed_nodes is called.
+"""
+from __future__ import annotations
+
+import inspect
+import unittest
+
+from backend.core.ouroboros.oracle import TheOracle, OracleSemanticIndex
+
+
+class TestLazySemanticIndex(unittest.TestCase):
+    def test_ensure_constructs_when_none(self):
+        o = TheOracle()
+        o._semantic_index = None  # type: ignore[assignment]
+        idx = o._ensure_semantic_index()
+        self.assertIsNotNone(idx)
+        self.assertIsInstance(idx, OracleSemanticIndex)
+        self.assertIs(o._semantic_index, idx)
+
+    def test_ensure_idempotent(self):
+        o = TheOracle()
+        o._semantic_index = None  # type: ignore[assignment]
+        a = o._ensure_semantic_index()
+        b = o._ensure_semantic_index()
+        self.assertIs(a, b)
+
+    def test_call_sites_use_ensure_not_bare_index(self):
+        src = (
+            inspect.getsource(TheOracle.full_index)
+            + inspect.getsource(TheOracle.incremental_update)
+        )
+        self.assertNotIn("self._semantic_index.embed_nodes", src)
+        self.assertIn("_ensure_semantic_index()", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Slice 153 fixed the embedder; the live soak still showed `embed_nodes ... NoneType` because `full_index`/`incremental_update` call `self._semantic_index.embed_nodes` while `_semantic_index` is None (pre-warmed only in `initialize_backend`, which can run after full_index). Added `_ensure_semantic_index()` lazy getter (single construction point; `__init__` lazy + never raises); both embed call sites + the pre-warm route through it. 3 tests; 0 bare call sites. With Slice 153 → Oracle embeds via fastembed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 'NoneType' crashes during semantic embedding by lazily creating `OracleSemanticIndex` with `_ensure_semantic_index()`. Ensures `full_index` and `incremental_update` embed safely even if the index wasn't pre-warmed.

- **Bug Fixes**
  - Added `_ensure_semantic_index()` as the single construction point and routed `initialize`, `full_index`, and `incremental_update` through it.
  - Added tests for construct-when-none, idempotency, and to ensure no bare `self._semantic_index.embed_nodes` calls remain.

<sup>Written for commit d78932041df281cbb941f28d29f76bcef013ee50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

