### PR TITLE
Slice 155 - Oracle STDLIB in-memory semantic backend + chromadb option

### DIFF
--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -1352,6 +1352,22 @@ class OracleSemanticBackendStatus(str, enum.Enum):
 BackendStatus = OracleSemanticBackendStatus
 
 
+def _stdlib_backend_available() -> bool:
+    """Slice 155 — True if the STDLIB in-memory vector backend may take over when
+    chromadb is unavailable. Gated ``JARVIS_ORACLE_STDLIB_BACKEND_ENABLED``
+    (default TRUE — failure-path-only graceful degradation, can't affect the CHROMA
+    happy path; set =0 to force DEGRADED). Requires numpy (the cosine substrate).
+    NEVER raises."""
+    try:
+        if os.getenv("JARVIS_ORACLE_STDLIB_BACKEND_ENABLED", "true").strip().lower() \
+                not in ("1", "true", "yes", "on"):
+            return False
+        import importlib.util
+        return importlib.util.find_spec("numpy") is not None
+    except Exception:  # noqa: BLE001
+        return False
+
+
 class OracleSemanticIndex:
     """Manages ChromaDB embeddings for code symbols (functions, methods, classes).
 
@@ -1427,6 +1443,11 @@ class OracleSemanticIndex:
         # but not yet inside an event loop).
         self._init_lock: Optional[asyncio.Lock] = None
         self._init_attempted: bool = False
+        # Slice 155 — STDLIB in-memory vector backend (numpy cosine), used when
+        # chromadb is unavailable so semantic search still works (non-persistent)
+        # instead of DEGRADED-empty. id -> (embedding floats, metadata). NO chromadb
+        # import here (AST pin honored) — pure numpy.
+        self._stdlib_store: Dict[str, Tuple[List[float], Dict[str, Any]]] = {}
 
     # ---- Slice 10 status surface ----
 
@@ -1534,13 +1555,27 @@ class OracleSemanticIndex:
                     timeout_s,
                 )
             except Exception as exc:  # noqa: BLE001 — fault isolation
-                self._status = OracleSemanticBackendStatus.DEGRADED
-                logger.warning(
-                    "[OracleSemanticIndex] backend=degraded — init "
-                    "raised %s: %s; queries return empty; graph "
-                    "readiness is unaffected",
-                    type(exc).__name__, exc,
-                )
+                # Slice 155 — chromadb unavailable (e.g. ModuleNotFoundError in an
+                # Oracle-capable image without the vector store). Fall back to the
+                # STDLIB in-memory numpy backend so semantic search still WORKS
+                # (non-persistent) instead of DEGRADED-empty. Last resort = DEGRADED.
+                if _stdlib_backend_available():
+                    self._status = OracleSemanticBackendStatus.STDLIB
+                    self._available = True
+                    logger.warning(
+                        "[OracleSemanticIndex] backend=stdlib (in-memory numpy) — "
+                        "chromadb unavailable (%s: %s); semantic search works "
+                        "in-memory (non-persistent); graph readiness is unaffected",
+                        type(exc).__name__, exc,
+                    )
+                else:
+                    self._status = OracleSemanticBackendStatus.DEGRADED
+                    logger.warning(
+                        "[OracleSemanticIndex] backend=degraded — init "
+                        "raised %s: %s; queries return empty; graph "
+                        "readiness is unaffected",
+                        type(exc).__name__, exc,
+                    )
             self._init_attempted = True
             return self._status
 
@@ -1639,11 +1674,12 @@ class OracleSemanticIndex:
         Never raises.
         """
         await self._ensure_initialized()
-        if (
-            self._status != OracleSemanticBackendStatus.CHROMA
-            or self._collection is None
-            or self._embedder is None
-        ):
+        # Slice 155 — CHROMA (persistent) OR STDLIB (in-memory) both embed.
+        _chroma = self._status == OracleSemanticBackendStatus.CHROMA
+        _stdlib = self._status == OracleSemanticBackendStatus.STDLIB
+        if (not (_chroma or _stdlib)) or self._embedder is None:
+            return
+        if _chroma and self._collection is None:
             return
 
         try:
@@ -1672,11 +1708,16 @@ class OracleSemanticIndex:
                     for n in batch
                 ]
 
-                self._collection.upsert(
-                    ids=ids,
-                    embeddings=[e.tolist() for e in embeddings],
-                    metadatas=metadatas,
-                )
+                if _stdlib:
+                    for _eid, _emb, _meta in zip(ids, embeddings, metadatas):
+                        _vec = _emb.tolist() if hasattr(_emb, "tolist") else list(_emb)
+                        self._stdlib_store[_eid] = ([float(x) for x in _vec], _meta)
+                else:
+                    self._collection.upsert(
+                        ids=ids,
+                        embeddings=[e.tolist() for e in embeddings],
+                        metadatas=metadatas,
+                    )
 
             logger.debug("[OracleSemanticIndex] Embedded %d nodes", len(embeddable))
         except Exception as exc:
@@ -1697,11 +1738,12 @@ class OracleSemanticIndex:
         STDLIB) or on any error.
         """
         await self._ensure_initialized()
-        if (
-            self._status != OracleSemanticBackendStatus.CHROMA
-            or self._collection is None
-            or self._embedder is None
-        ):
+        # Slice 155 — CHROMA (persistent) OR STDLIB (in-memory) both search.
+        _chroma = self._status == OracleSemanticBackendStatus.CHROMA
+        _stdlib = self._status == OracleSemanticBackendStatus.STDLIB
+        if (not (_chroma or _stdlib)) or self._embedder is None:
+            return []
+        if _chroma and self._collection is None:
             return []
 
         try:
@@ -1713,6 +1755,9 @@ class OracleSemanticIndex:
                 # "not available" fast-path above instead of raising into
                 # the outer except (which would log a misleading WARNING).
                 return []
+
+            if _stdlib:
+                return self._semantic_search_stdlib(query_embedding, k)
 
             results = self._collection.query(
                 query_embeddings=[query_embedding.tolist()],
@@ -1737,6 +1782,28 @@ class OracleSemanticIndex:
 
         except Exception as exc:
             logger.warning("[OracleSemanticIndex] semantic_search failed: %s", exc)
+            return []
+
+    def _semantic_search_stdlib(
+        self, query_embedding: Any, k: int = 5,
+    ) -> List[Tuple[str, float]]:
+        """Slice 155 — in-memory cosine search over the STDLIB store (no chromadb).
+        Mirrors the CHROMA path's file-level dedup + top-k contract. NEVER raises."""
+        try:
+            import numpy as np
+            q = np.asarray(query_embedding, dtype="float32")
+            qn = float(np.linalg.norm(q)) or 1.0
+            best: Dict[str, float] = {}
+            for _id, (emb, meta) in self._stdlib_store.items():
+                v = np.asarray(emb, dtype="float32")
+                vn = float(np.linalg.norm(v)) or 1.0
+                sim = max(0.0, min(1.0, float(np.dot(q, v) / (qn * vn))))
+                file_key = f"{meta['repo']}:{meta['file_path']}"
+                if file_key not in best or sim > best[file_key]:
+                    best[file_key] = sim
+            return sorted(best.items(), key=lambda x: x[1], reverse=True)[:k]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[OracleSemanticIndex] stdlib search failed: %s", exc)
             return []
 
 

--- a/docker/requirements-soak-oracle.txt
+++ b/docker/requirements-soak-oracle.txt
@@ -18,3 +18,8 @@ tree_sitter
 
 # Event Spine (event-driven sensors instead of polling fallback)
 aiofiles
+
+# Oracle semantic vector store (Slice 155). arm64 wheels; the SOLE chromadb import
+# is oracle.py:_load_chromadb_sync (AST-pinned). When absent, the STDLIB in-memory
+# backend (Slice 155) takes over — chromadb is the canonical/persistent option.
+chromadb

--- a/tests/core/test_slice155_oracle_stdlib_backend.py
+++ b/tests/core/test_slice155_oracle_stdlib_backend.py
@@ -1,0 +1,104 @@
+"""Slice 155 — OracleSemanticIndex STDLIB in-memory backend (no chromadb).
+
+When chromadb is unavailable, the semantic index now falls back to an in-memory
+numpy cosine store (STDLIB) instead of DEGRADED-empty — so embed_nodes stores and
+semantic_search returns ranked results without the heavy chromadb/rust-GIL dep.
+Gated default-TRUE (failure-path-only). End-to-end with a fake embedder.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+
+import numpy as np
+
+from backend.core.ouroboros.oracle import (
+    OracleSemanticIndex,
+    OracleSemanticBackendStatus,
+    NodeID,
+    NodeData,
+    NodeType,
+    _stdlib_backend_available,
+)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class _FakeEmbedder:
+    """Keyword-anchored vectors so similarity is deterministic."""
+
+    def _v(self, text: str):
+        t = text.lower()
+        if "login" in t:
+            return np.array([1.0, 0.0, 0.0], dtype="float32")
+        if "parse" in t or "json" in t:
+            return np.array([0.0, 1.0, 0.0], dtype="float32")
+        return np.array([0.0, 0.0, 1.0], dtype="float32")
+
+    async def embed_batch(self, texts):
+        return [self._v(t) for t in texts]
+
+    async def embed(self, text):
+        return self._v(text)
+
+
+def _node(name, file_path):
+    return NodeData(
+        node_id=NodeID(repo="r", file_path=file_path, name=name,
+                       node_type=NodeType.FUNCTION),
+        signature=f"def {name}(): pass",
+    )
+
+
+class TestGate(unittest.TestCase):
+    def test_available_default_true_with_numpy(self):
+        os.environ.pop("JARVIS_ORACLE_STDLIB_BACKEND_ENABLED", None)
+        self.assertTrue(_stdlib_backend_available())
+
+    def test_disabled_via_env(self):
+        os.environ["JARVIS_ORACLE_STDLIB_BACKEND_ENABLED"] = "0"
+        try:
+            self.assertFalse(_stdlib_backend_available())
+        finally:
+            os.environ.pop("JARVIS_ORACLE_STDLIB_BACKEND_ENABLED", None)
+
+
+class TestStdlibBackend(unittest.TestCase):
+    def _index(self):
+        osi = OracleSemanticIndex()
+        osi._status = OracleSemanticBackendStatus.STDLIB
+        osi._embedder = _FakeEmbedder()
+        osi._init_attempted = True   # skip initialize_backend; keep STDLIB
+        osi._stdlib_store = {}
+        return osi
+
+    def test_embed_nodes_stores_in_memory(self):
+        osi = self._index()
+        _run(osi.embed_nodes([_node("login_user", "auth.py"),
+                              _node("parse_json", "util.py")]))
+        self.assertEqual(len(osi._stdlib_store), 2)
+
+    def test_semantic_search_ranks_by_cosine(self):
+        osi = self._index()
+        _run(osi.embed_nodes([_node("login_user", "auth.py"),
+                              _node("parse_json", "util.py")]))
+        results = _run(osi.semantic_search("user login flow", k=2))
+        self.assertTrue(results)
+        self.assertEqual(results[0][0], "r:auth.py")        # login ranks first
+        self.assertGreater(results[0][1], results[-1][1])   # ordered by similarity
+
+    def test_degraded_backend_still_returns_empty(self):
+        osi = OracleSemanticIndex()
+        osi._status = OracleSemanticBackendStatus.DEGRADED
+        osi._embedder = _FakeEmbedder()
+        osi._init_attempted = True
+        _run(osi.embed_nodes([_node("login_user", "auth.py")]))
+        self.assertEqual(len(osi._stdlib_store), 0)           # not stored
+        self.assertEqual(_run(osi.semantic_search("login")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
OracleSemanticIndex now works without chromadb. When chromadb is unavailable, init falls back to an **in-memory numpy cosine store (STDLIB)** instead of DEGRADED-empty, so embed_nodes stores + semantic_search ranks results — no heavy chromadb/rust-GIL dep. Gated JARVIS_ORACLE_STDLIB_BACKEND_ENABLED (default-TRUE, failure-path-only). chromadb added to docker/requirements-soak-oracle.txt for the canonical persistent backend. **Resolution ladder: CHROMA -> STDLIB -> DEGRADED**; CHROMA path byte-identical. Also gitignores __pycache__/ + *.pyc (root-caused: the autonomous AutoCommitter had swept 95 cache files into the prior commit). 5 tests (gate, in-memory store, cosine ranking, DEGRADED-empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-memory `numpy` cosine backend for OracleSemanticIndex so semantic search works when `chromadb` isn’t available. Chroma behavior is unchanged; fallback is gated by JARVIS_ORACLE_STDLIB_BACKEND_ENABLED and defaults on.

- New Features
  - Backend resolution: CHROMA → STDLIB (in-memory, non-persistent) → DEGRADED (empty).
  - Embedding and search work in STDLIB mode with cosine ranking and file-level dedup.
  - Gate via JARVIS_ORACLE_STDLIB_BACKEND_ENABLED=0 to force DEGRADED. Tests cover gating, in-memory store, ranking, and degraded path.

- Dependencies
  - Added `chromadb` to soak requirements as the canonical persistent backend.

<sup>Written for commit 9a2c267c54c59c9300c575ed3616db570cc053a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

