### PR TITLE
Slice 156 - Sovereign Bidirectional Gateway (interactive Discord control)

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -909,6 +909,29 @@ class BattleTestHarness:
                 await self.boot_governance_stack()
             with _BootPhase("boot_governed_loop_service"):
                 await self.boot_governed_loop_service()
+
+            # ── Slice 156 — interactive Discord control gateway ──
+            # GLS (+ its _approval_provider) is up → start the bidirectional bot as a
+            # decoupled background task: it DMs the operator [APPROVE]/[REJECT]/[STEER]
+            # for each Orange APPROVAL_REQUIRED and resolves it remotely. Gated
+            # default-FALSE + fail-soft (no token / no operator id → no-op); off the
+            # FSM loop. Authorization is enforced in the gateway (DISCORD_OPERATOR_ID).
+            try:
+                from backend.core.ouroboros.governance.discord_gateway import (
+                    discord_gateway_enabled,
+                    run_gateway_daemon,
+                )
+                if discord_gateway_enabled():
+                    self._discord_gateway_task = asyncio.create_task(
+                        run_gateway_daemon(
+                            self._governed_loop_service, stop=self._shutdown_event,
+                        )
+                    )
+                    logger.warning(
+                        "[DiscordGateway] interactive control gateway armed (Slice 156)"
+                    )
+            except Exception as exc:  # noqa: BLE001 — never fatal to the soak
+                logger.debug("[DiscordGateway] gateway boot skipped: %s", exc)
             # Provider-readiness gate (§33.1, default-FALSE). Fail-fast
             # *before* any op-emitting subsystem boots when Claude/DW
             # are unhealthy — closes the v18 27-min thrash failure mode

--- a/backend/core/ouroboros/governance/discord_gateway.py
+++ b/backend/core/ouroboros/governance/discord_gateway.py
@@ -1,0 +1,286 @@
+"""Slice 156 — The Sovereign Bidirectional Gateway (interactive Discord control).
+
+The webhook bridge (Slices 142-145) streams O+V's activity OUT (read-only). This
+closes the loop with remote ARBITRATION: [APPROVE] / [REJECT] / [STEER] buttons in
+Discord that resolve the SAME approval rendezvous the local TUI does — so an Orange
+APPROVAL_REQUIRED block can be cleared from your phone, exactly as if typed locally.
+
+Composition (no new control plane, no duplication):
+  * [APPROVE]/[REJECT] → the existing ``CLIApprovalProvider`` (per-op asyncio.Event;
+    ``approve``/``reject`` set it → the proactive loop resumes).
+  * [STEER] → the existing ``ConversationBridge`` (TUI→FSM input spine): the captured
+    text enters the next cycle as a prompt constraint; the current op is unblocked.
+
+Security: every interaction is authorized against ``DISCORD_OPERATOR_ID`` (from .env,
+never hardcoded). An unauthorized click is DROPPED, logged ``REFUSED_SAFETY``, and
+ignored — fail-closed when the operator id is unconfigured (deny all).
+
+Architecture: the COMMAND ROUTER is pure logic (no discord.py) → fully unit-tested.
+The discord.py gateway daemon is a thin, lazy-imported, fail-soft adapter around it
+(needs a live ``DISCORD_BOT_TOKEN``). Gated ``JARVIS_DISCORD_GATEWAY_ENABLED``
+default-FALSE; runs decoupled as a background task so it never blocks the FSM loop.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV_MASTER = "JARVIS_DISCORD_GATEWAY_ENABLED"
+_ENV_OPERATOR_ID = "DISCORD_OPERATOR_ID"
+_ENV_BOT_TOKEN = "DISCORD_BOT_TOKEN"
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return max(0.5, float(os.getenv(name, default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def discord_gateway_enabled() -> bool:
+    """Master gate, default-FALSE per §33.1. NEVER raises."""
+    return os.getenv(_ENV_MASTER, "false").strip().lower() in ("1", "true", "yes", "on")
+
+
+def authorized_operator_id() -> Optional[str]:
+    """The sole authorized Discord operator id (from .env), or None if unconfigured."""
+    v = (os.getenv(_ENV_OPERATOR_ID, "") or "").strip()
+    return v or None
+
+
+def is_authorized_operator(user_id: Any) -> bool:
+    """True iff ``user_id`` matches ``DISCORD_OPERATOR_ID``. FAIL-CLOSED: if the id
+    is unconfigured, deny EVERYONE (no implicit-trust). NEVER raises."""
+    try:
+        configured = authorized_operator_id()
+        if not configured:
+            return False
+        return str(user_id).strip() == configured
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# on_refused(user_id=..., action=..., op_id=...) — REFUSED_SAFETY sink (injectable)
+_RefusedHook = Callable[..., None]
+
+
+class GatewayCommandRouter:
+    """Pure-logic command router — the security + FSM-resolution core of the bot.
+
+    Composes the existing approval provider + conversation bridge; no discord.py.
+    Every command is authorized first (fail-closed). NEVER raises out of ``handle``."""
+
+    def __init__(
+        self,
+        *,
+        approval_provider: Any,
+        conversation_bridge: Any = None,
+        on_refused: Optional[_RefusedHook] = None,
+    ) -> None:
+        self._provider = approval_provider
+        self._bridge = conversation_bridge
+        self._on_refused = on_refused
+
+    async def handle(
+        self, action: str, op_id: str, user_id: Any, text: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Authorize + dispatch a button/modal action. Returns a result dict.
+        Unauthorized → dropped + REFUSED_SAFETY (no side effect)."""
+        # ── Biometric authorization guard (fail-closed) ──
+        if not is_authorized_operator(user_id):
+            logger.warning(
+                "[DiscordGateway] REFUSED_SAFETY — unauthorized interaction "
+                "user_id=%r action=%r op_id=%r (not DISCORD_OPERATOR_ID); dropped",
+                user_id, action, op_id,
+            )
+            self._fire_refused(user_id=str(user_id), action=action, op_id=op_id)
+            return {"ok": False, "refused": True, "reason": "unauthorized"}
+
+        approver = f"discord:{user_id}"
+        act = (action or "").strip().lower()
+        try:
+            if act == "approve":
+                res = await self._provider.approve(op_id, approver)
+                logger.info("[DiscordGateway] APPROVE op=%s by=%s", op_id, approver)
+                return {"ok": True, "action": "approve", "result": res}
+            if act == "reject":
+                res = await self._provider.reject(op_id, approver, text or "rejected via Discord")
+                logger.info("[DiscordGateway] REJECT op=%s by=%s", op_id, approver)
+                return {"ok": True, "action": "reject", "result": res}
+            if act == "steer":
+                # Feed the steer text into the FSM input spine (next-cycle constraint),
+                # then unblock the current op (reject) so the loop redirects.
+                constraint = (text or "").strip()
+                if constraint and self._bridge is not None:
+                    try:
+                        self._bridge.note_tui_user(f"[steer] {constraint}")
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("[DiscordGateway] steer bridge note failed: %s", exc)
+                await self._provider.reject(op_id, approver, f"steered via Discord: {constraint}")
+                logger.info("[DiscordGateway] STEER op=%s by=%s", op_id, approver)
+                return {"ok": True, "action": "steer", "constraint": constraint}
+            logger.warning("[DiscordGateway] unknown action=%r op=%s — ignored", action, op_id)
+            return {"ok": False, "reason": f"unknown action: {action}"}
+        except Exception as exc:  # noqa: BLE001 — a control click never crashes the loop
+            logger.warning("[DiscordGateway] handle(%s) failed: %s", act, exc)
+            return {"ok": False, "reason": repr(exc)}
+
+    def _fire_refused(self, **kw: Any) -> None:
+        if self._on_refused is None:
+            return
+        try:
+            self._on_refused(**kw)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def build_router_from_gls(gls: Any, *, on_refused: Optional[_RefusedHook] = None) -> "GatewayCommandRouter":
+    """Compose a router from a live GovernedLoopService (its _approval_provider +
+    the ConversationBridge TUI sink). Best-effort — missing pieces degrade gracefully."""
+    provider = getattr(gls, "_approval_provider", None)
+    bridge = None
+    try:
+        from backend.core.ouroboros.governance import conversation_bridge as _cb
+        # adapter exposing note_tui_user(text) over whatever the bridge offers
+        class _BridgeAdapter:
+            def note_tui_user(self, text: str) -> None:
+                fn = getattr(_cb, "note_tui_user", None) or getattr(_cb, "note", None)
+                if fn is not None:
+                    fn(text)
+        bridge = _BridgeAdapter()
+    except Exception:  # noqa: BLE001
+        bridge = None
+    return GatewayCommandRouter(
+        approval_provider=provider, conversation_bridge=bridge, on_refused=on_refused,
+    )
+
+
+async def run_gateway_daemon(gls: Any, *, stop: Any = None) -> None:
+    """Thin discord.py adapter: connect the bot, and on each Orange APPROVAL_REQUIRED
+    dispatch a Rich embed + a View with [APPROVE]/[REJECT]/[STEER] whose callbacks
+    route through :class:`GatewayCommandRouter`. Gated + fail-soft + lazy-imported.
+
+    Requires ``DISCORD_BOT_TOKEN`` (a Discord *bot* app token — distinct from the
+    channel webhooks). NEVER raises into the caller. This adapter is intentionally
+    thin: all security + FSM-resolution lives in the unit-tested router above."""
+    if not discord_gateway_enabled():
+        return
+    token = (os.getenv(_ENV_BOT_TOKEN, "") or "").strip()
+    if not token:
+        logger.warning("[DiscordGateway] enabled but DISCORD_BOT_TOKEN unset — not starting")
+        return
+    if not authorized_operator_id():
+        logger.warning("[DiscordGateway] enabled but DISCORD_OPERATOR_ID unset — fail-closed, not starting")
+        return
+    try:
+        import discord  # type: ignore[import-not-found]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[DiscordGateway] discord.py unavailable (%s) — gateway disabled", exc)
+        return
+
+    router = build_router_from_gls(gls)
+
+    intents = discord.Intents.default()
+    client = discord.Client(intents=intents)
+
+    def _make_view(op_id: str) -> Any:
+        class _ArbitrationView(discord.ui.View):
+            def __init__(self) -> None:
+                super().__init__(timeout=None)
+
+            @discord.ui.button(label="APPROVE", style=discord.ButtonStyle.success)
+            async def _approve(self, interaction: Any, _button: Any) -> None:
+                r = await router.handle("approve", op_id, interaction.user.id)
+                await interaction.response.send_message(
+                    "✅ approved" if r.get("ok") else "⛔ refused", ephemeral=True)
+
+            @discord.ui.button(label="REJECT", style=discord.ButtonStyle.danger)
+            async def _reject(self, interaction: Any, _button: Any) -> None:
+                r = await router.handle("reject", op_id, interaction.user.id)
+                await interaction.response.send_message(
+                    "🛑 rejected" if r.get("ok") else "⛔ refused", ephemeral=True)
+
+            @discord.ui.button(label="STEER", style=discord.ButtonStyle.primary)
+            async def _steer(self, interaction: Any, _button: Any) -> None:
+                # Authorize BEFORE showing the modal so intruders can't even type.
+                if not is_authorized_operator(interaction.user.id):
+                    await interaction.response.send_message("⛔ refused", ephemeral=True)
+                    router._fire_refused(user_id=str(interaction.user.id), action="steer", op_id=op_id)
+                    return
+
+                class _SteerModal(discord.ui.Modal, title="Steer O+V"):
+                    constraint = discord.ui.TextInput(label="Updated constraint / target vector")
+
+                    async def on_submit(self, modal_interaction: Any) -> None:
+                        await router.handle("steer", op_id, modal_interaction.user.id,
+                                            text=str(self.constraint))
+                        await modal_interaction.response.send_message("🧭 steered", ephemeral=True)
+
+                await interaction.response.send_modal(_SteerModal())
+
+        return _ArbitrationView()
+
+    client._jarvis_make_view = _make_view  # type: ignore[attr-defined]
+
+    # ── Outbound dispatch: DM the operator a Rich embed + arbitration View for each
+    # NEW Orange APPROVAL_REQUIRED. Polls the EXISTING list_pending() — no hooking of
+    # provider internals (decoupled). Off the FSM loop (the bot's own event loop).
+    import asyncio as _aio
+    _interval = _env_float("JARVIS_DISCORD_GATEWAY_POLL_S", 3.0)
+    _seen: set = set()
+
+    async def _dispatch_pending() -> None:
+        await client.wait_until_ready()
+        try:
+            operator = await client.fetch_user(int(authorized_operator_id()))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[DiscordGateway] cannot resolve operator DM (%s) — no dispatch", exc)
+            return
+        provider = getattr(gls, "_approval_provider", None)
+        while not (stop is not None and getattr(stop, "is_set", lambda: False)()):
+            try:
+                pending = await provider.list_pending() if provider is not None else []
+                for req in pending or []:
+                    op_id = str(req.get("op_id") or req.get("request_id") or "")
+                    if not op_id or op_id in _seen:
+                        continue
+                    _seen.add(op_id)
+                    embed = discord.Embed(
+                        title="🚧 APPROVAL_REQUIRED — O+V awaiting arbitration",
+                        description=str(req.get("summary") or req.get("reason") or op_id)[:4000],
+                        color=0xE67E22,
+                    )
+                    embed.add_field(name="op", value=op_id[:64], inline=False)
+                    await operator.send(embed=embed, view=_make_view(op_id))
+            except Exception as exc:  # noqa: BLE001 — never crash the gateway
+                logger.debug("[DiscordGateway] dispatch poll error: %s", exc)
+            await _aio.sleep(_interval)
+
+    @client.event
+    async def on_ready() -> None:  # noqa: ANN001
+        logger.warning("[DiscordGateway] connected as %s — arbitration live", client.user)
+        client.loop.create_task(_dispatch_pending())
+
+    logger.warning("[DiscordGateway] interactive control gateway connecting (Slice 156)…")
+    try:
+        await client.start(token)
+    except Exception as exc:  # noqa: BLE001 — a gateway failure never crashes the soak
+        logger.warning("[DiscordGateway] gateway stopped: %s", exc)
+    finally:
+        try:
+            await client.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+__all__ = [
+    "discord_gateway_enabled",
+    "authorized_operator_id",
+    "is_authorized_operator",
+    "GatewayCommandRouter",
+    "build_router_from_gls",
+    "run_gateway_daemon",
+]

--- a/docker/requirements-soak.txt
+++ b/docker/requirements-soak.txt
@@ -46,3 +46,7 @@ fastembed
 # the SMT prover (smt_invariant_prover) is import-guarded + fail-closed +
 # default-FALSE, so its absence is a clean no-op for the soak. To run formal
 # proofs on an x86_64 host (where a manylinux wheel exists), add:  z3-solver>=4.16.0
+
+# Slice 156 — interactive Discord control gateway (bot). Light (pure-python + aiohttp
+# already present). Gated JARVIS_DISCORD_GATEWAY_ENABLED default-FALSE.
+discord.py>=2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -308,3 +308,5 @@ google-cloud-monitoring>=2.0.0
 # Python 3.9.x is EOL (2025-10). Python 3.11.x is EOL (2026-10). Minimum supported version is now 3.12.
 # Upgrade your interpreter to Python 3.12 or 3.13 before installing.
 # Requires-Python: >=3.12
+
+discord.py>=2.3  # Slice 156 — interactive Discord control gateway (bot)

--- a/tests/architecture/test_slice156_discord_gateway.py
+++ b/tests/architecture/test_slice156_discord_gateway.py
@@ -1,0 +1,115 @@
+"""Slice 156 — The Sovereign Bidirectional Gateway (interactive Discord control).
+
+The webhook bridge (142-145) is a read-only megaphone. This adds remote ARBITRATION:
+[APPROVE]/[REJECT]/[STEER] buttons that resolve the SAME approval rendezvous the
+local TUI does — composing the existing CLIApprovalProvider (per-op asyncio.Event)
+and ConversationBridge (TUI→FSM input spine). Every interaction is authorized
+against DISCORD_OPERATOR_ID; an unauthorized click is dropped + logged REFUSED_SAFETY.
+
+The command router is pure logic (no discord.py) → fully unit-tested here; the
+discord.py gateway daemon is a thin adapter around it (needs a live bot token).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+
+from backend.core.ouroboros.governance import discord_gateway as DG
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class _FakeApprovalProvider:
+    def __init__(self):
+        self.approved = []
+        self.rejected = []
+    async def approve(self, request_id, approver):
+        self.approved.append((request_id, approver)); return {"ok": True}
+    async def reject(self, request_id, approver, reason=""):
+        self.rejected.append((request_id, approver, reason)); return {"ok": True}
+
+
+class _FakeBridge:
+    def __init__(self):
+        self.notes = []
+    def note_tui_user(self, text):
+        self.notes.append(text)
+
+
+class TestGate(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("JARVIS_DISCORD_GATEWAY_ENABLED", None)
+
+    def test_default_false(self):
+        self.assertFalse(DG.discord_gateway_enabled())
+
+
+class TestAuthorization(unittest.TestCase):
+    def tearDown(self):
+        os.environ.pop("DISCORD_OPERATOR_ID", None)
+
+    def test_authorized_matches_env(self):
+        os.environ["DISCORD_OPERATOR_ID"] = "12345"
+        self.assertTrue(DG.is_authorized_operator("12345"))
+        self.assertTrue(DG.is_authorized_operator(12345))  # int coerced
+
+    def test_unauthorized_mismatch(self):
+        os.environ["DISCORD_OPERATOR_ID"] = "12345"
+        self.assertFalse(DG.is_authorized_operator("99999"))
+
+    def test_fail_closed_when_unset(self):
+        os.environ.pop("DISCORD_OPERATOR_ID", None)
+        self.assertFalse(DG.is_authorized_operator("12345"))  # no config → deny ALL
+
+
+class TestCommandRouter(unittest.TestCase):
+    def setUp(self):
+        os.environ["DISCORD_OPERATOR_ID"] = "op-1"
+        self.provider = _FakeApprovalProvider()
+        self.bridge = _FakeBridge()
+        self.refusals = []
+        self.router = DG.GatewayCommandRouter(
+            approval_provider=self.provider,
+            conversation_bridge=self.bridge,
+            on_refused=lambda **k: self.refusals.append(k),
+        )
+
+    def tearDown(self):
+        os.environ.pop("DISCORD_OPERATOR_ID", None)
+
+    def test_approve_resolves_via_provider(self):
+        res = _run(self.router.handle("approve", "op-42", "op-1"))
+        self.assertTrue(res["ok"])
+        self.assertEqual(self.provider.approved[0][0], "op-42")
+        self.assertIn("discord", self.provider.approved[0][1])
+
+    def test_reject_resolves_via_provider(self):
+        _run(self.router.handle("reject", "op-42", "op-1", text="bad diff"))
+        self.assertEqual(self.provider.rejected[0][0], "op-42")
+        self.assertIn("bad diff", self.provider.rejected[0][2])
+
+    def test_steer_feeds_bridge_and_unblocks(self):
+        _run(self.router.handle("steer", "op-42", "op-1", text="prefer async"))
+        self.assertIn("prefer async", self.bridge.notes[0])     # constraint → FSM input spine
+        self.assertTrue(self.provider.rejected)                  # current op unblocked
+
+    def test_unauthorized_click_dropped_and_refused(self):
+        res = _run(self.router.handle("approve", "op-42", "intruder"))
+        self.assertFalse(res["ok"])
+        self.assertTrue(res.get("refused"))
+        self.assertEqual(self.provider.approved, [])             # NO action taken
+        self.assertTrue(self.refusals)                           # REFUSED_SAFETY logged
+        self.assertEqual(self.refusals[0]["user_id"], "intruder")
+
+    def test_unknown_action_noop(self):
+        res = _run(self.router.handle("nuke", "op-42", "op-1"))
+        self.assertFalse(res["ok"])
+        self.assertEqual(self.provider.approved, [])
+        self.assertEqual(self.provider.rejected, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the UI/UX loop: remote arbitration of Orange APPROVAL_REQUIRED from Discord, composing the **existing** control plane (no new control plane).

- **GatewayCommandRouter** (pure logic, no discord.py - fully unit-tested): authorize -> dispatch. **APPROVE/REJECT** -> existing CLIApprovalProvider (set the per-op asyncio.Event -> proactive loop resumes as a local TUI decision). **STEER** -> existing ConversationBridge (TUI->FSM input spine) + unblock.
- **Biometric guard**: DISCORD_OPERATOR_ID (.env, no hardcode); unauthorized click DROPPED + REFUSED_SAFETY; **fail-closed** when unset (deny all).
- **run_gateway_daemon**: thin lazy-imported fail-soft discord.py adapter - Rich embed + View([APPROVE]/[REJECT]/[STEER]) + Modal; on_ready poller DMs the operator each new pending approval (polls list_pending, decoupled). Needs a live DISCORD_BOT_TOKEN.

Gated JARVIS_DISCORD_GATEWAY_ENABLED **default-FALSE**; harness starts it as a decoupled background task after GLS boot, off the FSM loop. **9 tests**; core imports without discord.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a bidirectional Discord gateway to approve, reject, or steer Orange APPROVAL_REQUIRED ops from DMs, using the existing control plane. Secure by `DISCORD_OPERATOR_ID`, off by default, and runs as a background task.

- New Features
  - `GatewayCommandRouter`: pure logic; routes APPROVE/REJECT to the existing CLIApprovalProvider and STEER into the ConversationBridge (then unblocks the current op).
  - Discord adapter (`run_gateway_daemon`): DMs the operator each new pending approval with buttons and a STEER modal; lazy-imported and fail-soft.
  - Strict auth: checks `DISCORD_OPERATOR_ID`; unauthorized clicks are dropped and logged; fail-closed when unset.
  - Harness: starts the gateway as a decoupled task after GLS boot when enabled; does not block the FSM loop. Includes tests. Requires `discord.py>=2.3`.

- Migration
  - Disabled by default. To enable: set `JARVIS_DISCORD_GATEWAY_ENABLED=true`.
  - Configure `DISCORD_OPERATOR_ID` and `DISCORD_BOT_TOKEN` (bot token).
  - Optional: tune `JARVIS_DISCORD_GATEWAY_POLL_S` (seconds).

<sup>Written for commit c686b15c3a8b33d36a7330ab8eda890c008b99ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

