### PR TITLE
Slice 158 - robust channel dispatch (governance over fragile DMs)

### DIFF
--- a/backend/core/ouroboros/governance/discord_gateway.py
+++ b/backend/core/ouroboros/governance/discord_gateway.py
@@ -152,6 +152,33 @@ class GatewayCommandRouter:
             pass
 
 
+# Slice 158 — channel dispatch (DMs are a fragile governance surface; route approvals
+# to a shared #governance-gates text channel instead). The interaction.user.id guard
+# in the View callbacks stays intact, so only the operator's clicks are honored.
+def gates_channel_name() -> str:
+    """Target channel name for approval dispatch (env-tunable). Default
+    'governance-gates'. NEVER raises."""
+    return (os.getenv("JARVIS_DISCORD_GATES_CHANNEL", "") or "").strip() or "governance-gates"
+
+
+def gates_channel_id() -> str:
+    """Optional explicit channel-id override (numeric string), or '' to resolve by name."""
+    return (os.getenv("JARVIS_DISCORD_GATES_CHANNEL_ID", "") or "").strip()
+
+
+def pick_gates_channel(channels: Any, *, channel_id: str = "", channel_name: str = "governance-gates") -> Any:
+    """Resolve the gates channel from the bot's visible channels: explicit id wins;
+    a missing/unknown id falls back to name; returns None if neither matches."""
+    if channel_id:
+        for ch in channels:
+            if str(getattr(ch, "id", "")) == str(channel_id):
+                return ch
+    for ch in channels:
+        if getattr(ch, "name", None) == channel_name:
+            return ch
+    return None
+
+
 # Slice 157 — live-fire injection source tag (a genuine, non-github/ci channel source
 # → _classify_event's generic branch renders the op description from the event_type).
 LIVEFIRE_SOURCE = "livefire"
@@ -304,36 +331,50 @@ async def run_gateway_daemon(gls: Any, *, stop: Any = None) -> None:
 
     client._jarvis_make_view = _make_view  # type: ignore[attr-defined]
 
-    # ── Outbound dispatch: DM the operator a Rich embed + arbitration View for each
-    # NEW Orange APPROVAL_REQUIRED. Polls the EXISTING list_pending() — no hooking of
-    # provider internals (decoupled). Off the FSM loop (the bot's own event loop).
+    # ── Outbound dispatch (Slice 158): post a Rich embed + arbitration View for each
+    # NEW Orange APPROVAL_REQUIRED to the #governance-gates CHANNEL (not DMs — the
+    # account-limit proved DMs are fragile). Polls the EXISTING list_pending()
+    # (decoupled). Off the FSM loop. The interaction.user.id guard in the View stays
+    # intact, so only the operator's clicks in the shared channel are honored.
     import asyncio as _aio
     _interval = _env_float("JARVIS_DISCORD_GATEWAY_POLL_S", 3.0)
     _seen: set = set()
+    _warned_no_channel = {"v": False}
 
     async def _dispatch_pending() -> None:
         await client.wait_until_ready()
-        try:
-            operator = await client.fetch_user(int(authorized_operator_id()))
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("[DiscordGateway] cannot resolve operator DM (%s) — no dispatch", exc)
-            return
         provider = getattr(gls, "_approval_provider", None)
         while not (stop is not None and getattr(stop, "is_set", lambda: False)()):
             try:
-                pending = await provider.list_pending() if provider is not None else []
-                for req in pending or []:
-                    op_id = str(req.get("op_id") or req.get("request_id") or "")
-                    if not op_id or op_id in _seen:
-                        continue
-                    _seen.add(op_id)
-                    embed = discord.Embed(
-                        title="🚧 APPROVAL_REQUIRED — O+V awaiting arbitration",
-                        description=summarize_pending(req)[:4000],
-                        color=0xE67E22,
-                    )
-                    embed.add_field(name="op", value=op_id[:64], inline=False)
-                    await operator.send(embed=embed, view=_make_view(op_id))
+                channel = pick_gates_channel(
+                    list(client.get_all_channels()),
+                    channel_id=gates_channel_id(),
+                    channel_name=gates_channel_name(),
+                )
+                if channel is None:
+                    if not _warned_no_channel["v"]:
+                        logger.warning(
+                            "[DiscordGateway] gates channel #%s not found (create it + "
+                            "invite O+V, or set JARVIS_DISCORD_GATES_CHANNEL_ID) — "
+                            "approvals cannot be dispatched", gates_channel_name(),
+                        )
+                        _warned_no_channel["v"] = True
+                else:
+                    _warned_no_channel["v"] = False
+                    pending = await provider.list_pending() if provider is not None else []
+                    for req in pending or []:
+                        op_id = str(req.get("op_id") or req.get("request_id") or "")
+                        if not op_id or op_id in _seen:
+                            continue
+                        _seen.add(op_id)
+                        embed = discord.Embed(
+                            title="🚧 APPROVAL_REQUIRED — O+V awaiting arbitration",
+                            description=summarize_pending(req)[:4000],
+                            color=0xE67E22,
+                        )
+                        embed.add_field(name="op", value=op_id[:64], inline=False)
+                        embed.set_footer(text=f"only operator {authorized_operator_id()} may decide")
+                        await channel.send(embed=embed, view=_make_view(op_id))
             except Exception as exc:  # noqa: BLE001 — never crash the gateway
                 logger.debug("[DiscordGateway] dispatch poll error: %s", exc)
             await _aio.sleep(_interval)

--- a/tests/architecture/test_slice158_channel_dispatch.py
+++ b/tests/architecture/test_slice158_channel_dispatch.py
@@ -1,0 +1,73 @@
+"""Slice 158 — Robust Channel Dispatch.
+
+The Discord account-limit proved DMs are a fragile governance surface. This routes
+APPROVAL_REQUIRED embeds + [APPROVE]/[REJECT]/[STEER] to the #governance-gates text
+channel instead of operator DMs. The interaction.user.id authorization guard stays
+strictly intact so unauthorized clicks in the shared channel are dropped.
+
+Testable cores (the discord.py daemon is not unit-testable):
+  - gates_channel_name / gates_channel_id env resolution.
+  - pick_gates_channel: resolves the target channel by id (override) or by name,
+    from the bot's visible channels.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+from backend.core.ouroboros.governance import discord_gateway as DG
+
+
+class _FakeChannel:
+    def __init__(self, cid, name):
+        self.id = cid
+        self.name = name
+
+
+class TestGatesChannelEnv(unittest.TestCase):
+    def tearDown(self):
+        os.environ.pop("JARVIS_DISCORD_GATES_CHANNEL", None)
+        os.environ.pop("JARVIS_DISCORD_GATES_CHANNEL_ID", None)
+
+    def test_default_channel_name(self):
+        os.environ.pop("JARVIS_DISCORD_GATES_CHANNEL", None)
+        self.assertEqual(DG.gates_channel_name(), "governance-gates")
+
+    def test_channel_name_override(self):
+        os.environ["JARVIS_DISCORD_GATES_CHANNEL"] = "ops-approvals"
+        self.assertEqual(DG.gates_channel_name(), "ops-approvals")
+
+    def test_channel_id_optional(self):
+        os.environ.pop("JARVIS_DISCORD_GATES_CHANNEL_ID", None)
+        self.assertEqual(DG.gates_channel_id(), "")
+        os.environ["JARVIS_DISCORD_GATES_CHANNEL_ID"] = "12345"
+        self.assertEqual(DG.gates_channel_id(), "12345")
+
+
+class TestPickGatesChannel(unittest.TestCase):
+    def setUp(self):
+        self.channels = [
+            _FakeChannel(111, "general"),
+            _FakeChannel(222, "governance-gates"),
+            _FakeChannel(333, "cost-safety"),
+        ]
+
+    def test_pick_by_explicit_id(self):
+        ch = DG.pick_gates_channel(self.channels, channel_id="333", channel_name="governance-gates")
+        self.assertEqual(ch.id, 333)  # id override wins over name
+
+    def test_pick_by_name_when_no_id(self):
+        ch = DG.pick_gates_channel(self.channels, channel_id="", channel_name="governance-gates")
+        self.assertEqual(ch.id, 222)
+
+    def test_returns_none_when_absent(self):
+        ch = DG.pick_gates_channel(self.channels, channel_id="", channel_name="does-not-exist")
+        self.assertIsNone(ch)
+
+    def test_id_miss_falls_back_to_name(self):
+        ch = DG.pick_gates_channel(self.channels, channel_id="999", channel_name="governance-gates")
+        self.assertEqual(ch.id, 222)  # bad id → resolve by name instead of failing
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The Discord account-limit proved DMs are a fragile governance surface. Approval cards now route to the **#governance-gates channel** instead of operator DMs. `gates_channel_name`/`gates_channel_id`/`pick_gates_channel` (id override else by-name, bad-id falls back to name); daemon posts the embed + [APPROVE]/[REJECT]/[STEER] View to the channel. The `interaction.user.id` authorization guard is unchanged - in the shared channel only the operator's clicks are honored. 7 tests; 25 gateway total green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route approval requests to the `#governance-gates` channel instead of operator DMs to make governance more reliable. Operator-only authorization is unchanged; embeds include action buttons and a footer naming the authorized operator.

- New Features
  - Channel-based dispatch with env config: `JARVIS_DISCORD_GATES_CHANNEL` (default: governance-gates) and optional `JARVIS_DISCORD_GATES_CHANNEL_ID`.
  - `pick_gates_channel` resolves by id else name; bad id falls back to name; logs a warning once if the channel is missing.
  - Embed footer clarifies who can decide; existing click guard (interaction.user.id) remains intact.
  - Added tests for env resolution and channel selection. 

- Migration
  - Create `#governance-gates` and invite the bot, or set `JARVIS_DISCORD_GATES_CHANNEL_ID` to the target channel id.
  - No changes needed to operator permissions or existing approval workflows.

<sup>Written for commit cb487ea794ff6b256487b122d55c3b2e36804e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

