### PR TITLE
Slice 159 - DW transport sovereignty (force batch when Claude breaker open)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -254,6 +254,38 @@ _DW_REQUEST_TIMEOUT_S = float(os.environ.get("DOUBLEWORD_REQUEST_TIMEOUT_S", "12
 
 _SLICE36_FORCE_BATCH_ENV: str = "JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX"
 
+# Slice 159 — DW transport sovereignty. Slice 36 force-batch originally engaged ONLY
+# when Claude was explicitly DISABLED. But a *configured* yet *credit-dead* Claude
+# leaves _claude_disabled=False → RT streaming → DW SSE rupture (live_transport) →
+# cascade to a dead Claude → terminal_quota. The premise "Claude catches RT failures"
+# is false whenever Claude's circuit breaker is OPEN. Composes the Slice 146 breaker.
+_FORCE_BATCH_ON_BREAKER_ENV: str = "JARVIS_DW_FORCE_BATCH_ON_CLAUDE_BREAKER"
+
+
+def _force_batch_on_breaker_enabled() -> bool:
+    """Master for the Slice 159 breaker-aware force-batch trigger. Default **TRUE**
+    (failure-path-only: only fires while the Claude breaker is OPEN, so it can't
+    affect the Claude-healthy happy path; =0 reverts to legacy disabled-only). The
+    economic breaker (JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED) still governs whether
+    the breaker opens at all. NEVER raises."""
+    return os.environ.get(_FORCE_BATCH_ON_BREAKER_ENV, "true").strip().lower() \
+        not in ("0", "false", "no", "off")
+
+
+def _claude_breaker_open(getter: Any = None) -> bool:
+    """Slice 159 — True iff the Claude circuit breaker is currently REJECTING requests
+    (economic credit-death OR transport). In that state Claude cannot catch a DW RT
+    failure, so STANDARD/COMPLEX ops must force the DW batch transport. ``getter`` is
+    injectable for tests. NEVER raises — fail-closed to False (legacy RT)."""
+    try:
+        if getter is None:
+            from backend.core.ouroboros.governance.claude_circuit_breaker import (
+                get_claude_circuit_breaker as getter,  # type: ignore[assignment]
+            )
+        return not getter().should_allow_request()
+    except Exception:  # noqa: BLE001 — defensive; legacy RT on any failure
+        return False
+
 
 def _slice36_should_force_batch(context: Any) -> bool:
     """Slice 36 — adaptive transport selector decision.
@@ -282,7 +314,15 @@ def _slice36_should_force_batch(context: Any) -> bool:
         _claude_disabled = os.environ.get(
             "JARVIS_PROVIDER_CLAUDE_DISABLED", "",
         ).strip().lower() in ("1", "true", "yes", "on")
-        if not _claude_disabled:
+        # Slice 159 — Claude is ALSO unavailable-as-fallback when its circuit breaker
+        # is OPEN (economic credit-death / transport). Then an RT failure cascades to a
+        # blocked Claude → terminal_quota exhaustion, so DW must carry via batch. This
+        # is what makes the organism sovereign on DW when Claude is credit-dead (not
+        # merely when explicitly disabled). Gated (default ON, failure-path-only).
+        _claude_unavailable = _claude_disabled or (
+            _force_batch_on_breaker_enabled() and _claude_breaker_open()
+        )
+        if not _claude_unavailable:
             return False
         # Route gate — only STANDARD + COMPLEX get the batch path
         _route = (

--- a/tests/governance/test_slice159_dw_transport_sovereignty.py
+++ b/tests/governance/test_slice159_dw_transport_sovereignty.py
@@ -1,0 +1,80 @@
+"""Slice 159 — DW transport sovereignty (force batch when Claude is economically dead).
+
+Root cause (verified live): Slice 36 force-batch only engaged when Claude was
+explicitly DISABLED (JARVIS_PROVIDER_CLAUDE_DISABLED). But when Claude is *configured*
+yet *credit-dead*, _claude_disabled=False → RT streaming → DW SSE ruptures
+(live_transport) → cascades to a dead Claude → terminal_quota exhaustion → the op
+dies before GATE. The premise "Claude catches any RT failure" is false when Claude's
+circuit breaker is OPEN.
+
+Fix: Claude is "unavailable as fallback" = disabled OR economic/transport breaker OPEN.
+In that state STANDARD/COMPLEX ops force the DW batch transport → the organism stays
+sovereign on DoubleWord. Composes the existing Slice 146 economic breaker; no hardcode.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+from backend.core.ouroboros.governance import doubleword_provider as DW
+
+
+class _Ctx:
+    def __init__(self, route="complex", op_id="op-1"):
+        self.provider_route = route
+        self.op_id = op_id
+
+
+class _FakeBreaker:
+    def __init__(self, allow):
+        self._allow = allow
+    def should_allow_request(self):
+        return self._allow
+
+
+class TestBreakerOpenPredicate(unittest.TestCase):
+    def test_open_when_breaker_rejects(self):
+        self.assertTrue(DW._claude_breaker_open(getter=lambda: _FakeBreaker(allow=False)))
+
+    def test_closed_when_breaker_allows(self):
+        self.assertFalse(DW._claude_breaker_open(getter=lambda: _FakeBreaker(allow=True)))
+
+    def test_fail_closed_on_error(self):
+        def _boom():
+            raise RuntimeError("no breaker")
+        self.assertFalse(DW._claude_breaker_open(getter=_boom))  # fail → legacy RT
+
+
+class TestForceBatchWhenClaudeDead(unittest.TestCase):
+    def setUp(self):
+        self._saved = DW._claude_breaker_open
+        os.environ["JARVIS_PROVIDER_CLAUDE_DISABLED"] = "false"   # Claude NOT disabled
+        os.environ["JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX"] = "1"
+        os.environ.pop("JARVIS_DW_FORCE_BATCH_ON_CLAUDE_BREAKER", None)
+
+    def tearDown(self):
+        DW._claude_breaker_open = self._saved
+        for k in ("JARVIS_PROVIDER_CLAUDE_DISABLED", "JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX",
+                  "JARVIS_DW_FORCE_BATCH_ON_CLAUDE_BREAKER"):
+            os.environ.pop(k, None)
+
+    def test_forces_batch_when_breaker_open_even_though_claude_configured(self):
+        DW._claude_breaker_open = lambda getter=None: True   # Claude credit-dead
+        self.assertTrue(DW._slice36_should_force_batch(_Ctx(route="complex")))
+
+    def test_legacy_rt_when_breaker_closed_and_claude_available(self):
+        DW._claude_breaker_open = lambda getter=None: False   # Claude healthy
+        self.assertFalse(DW._slice36_should_force_batch(_Ctx(route="complex")))
+
+    def test_gate_off_preserves_legacy_rt_even_if_breaker_open(self):
+        os.environ["JARVIS_DW_FORCE_BATCH_ON_CLAUDE_BREAKER"] = "0"
+        DW._claude_breaker_open = lambda getter=None: True
+        self.assertFalse(DW._slice36_should_force_batch(_Ctx(route="complex")))
+
+    def test_route_gate_still_respected(self):
+        DW._claude_breaker_open = lambda getter=None: True
+        self.assertFalse(DW._slice36_should_force_batch(_Ctx(route="immediate")))  # not std/complex
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Root cause (traced live):** the live-fire op died before GATE because DW's RT/SSE generation ruptured (`live_transport`) and cascaded to a **credit-dead** Claude → `terminal_quota` exhaustion. The existing Slice 36 force-batch only engaged when Claude was explicitly **disabled** — but a *configured yet credit-dead* Claude leaves `_claude_disabled=False`, so 'Claude catches RT failures' is false.

**Fix:** Claude is unavailable-as-fallback = disabled **OR circuit-breaker OPEN**, composing the Slice 146 economic breaker (`should_allow_request()`). `_force_batch_on_breaker_enabled()` master default-TRUE (failure-path-only; breaker-closed = byte-identical). When Claude is credit-dead, STANDARD/COMPLEX ops force DW's batch transport → survive generation → reach GATE → APPROVAL_REQUIRED. **Total vendor-agnostic sovereignty.**

7 new tests; Slice 36/41/50 regression green (42 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force DoubleWord to use batch transport when Claude’s circuit breaker is open, preventing RT/SSE cascades to a credit-dead Claude. STANDARD/COMPLEX ops now survive to GATE; healthy path remains unchanged.

- **Bug Fixes**
  - Treat Claude as unavailable if `get_claude_circuit_breaker().should_allow_request()` rejects; implemented via `_claude_breaker_open()` (fails closed to legacy RT).
  - Gate with `JARVIS_DW_FORCE_BATCH_ON_CLAUDE_BREAKER` (default true); still honors `JARVIS_PROVIDER_CLAUDE_DISABLED`.
  - Apply only to STANDARD/COMPLEX routes; `immediate` unchanged.
  - Added 7 tests for breaker predicate, gating, and route behavior.

<sup>Written for commit 0be247c14c23004a0a02d2c7c2d967750baa1de9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

