### PR TITLE
fix(scripts): trigger_live_approval sys.path bootstrap for docker exec

### DIFF
--- a/scripts/trigger_live_approval.py
+++ b/scripts/trigger_live_approval.py
@@ -30,8 +30,12 @@ import os
 import sys
 import urllib.request
 
+# `docker exec python3 scripts/x.py` puts /app/scripts on sys.path, not /app — so the
+# `backend` package isn't importable. Bootstrap the repo root (parent of scripts/).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 # Reuse the canonical payload builder + source tag (single source of truth).
-from backend.core.ouroboros.governance.discord_gateway import (
+from backend.core.ouroboros.governance.discord_gateway import (  # noqa: E402
     build_livefire_payload,
     LIVEFIRE_SOURCE,
 )


### PR DESCRIPTION
docker exec puts /app/scripts on sys.path not /app, so 'import backend' failed. Bootstrap the repo root before the import so the Phase-4 live-fire exec command works.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ModuleNotFoundError when running `docker exec python3 scripts/trigger_live_approval.py` by prepending the repo root to `sys.path` so the `backend` package is importable. Restores the Phase-4 live-fire exec command.

<sup>Written for commit 45269468aebb87d9b116f78c739375f2f1d809f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

