### PR TITLE
Slice 160 - environment-aware, fail-soft InfraApplicator

### DIFF
--- a/backend/core/ouroboros/governance/infrastructure_applicator.py
+++ b/backend/core/ouroboros/governance/infrastructure_applicator.py
@@ -79,12 +79,75 @@ class InfraResult:
     file_trigger: str
 
 
+# Slice 160 — environment-aware manifest resolution. The agentic layer may write a
+# generic "requirements.txt", but the live environment's ACTIVE manifest can differ
+# (the soak container ships requirements-soak*.txt, not requirements.txt). Resolve the
+# manifest actually present in the repo root by priority instead of hardcoding one.
+_DEFAULT_MANIFEST_PRIORITY: Tuple[str, ...] = (
+    "requirements-soak-oracle.txt",  # Oracle-capable soak (most specific)
+    "requirements-soak.txt",          # lean soak
+    "requirements.txt",               # full host / standard
+)
+
+
+def _manifest_priority() -> Tuple[str, ...]:
+    """Manifest resolution priority (env-tunable, no hardcode in logic). Highest
+    priority first. Invalid/empty env → the default order. NEVER raises."""
+    raw = (os.environ.get("JARVIS_INFRA_MANIFEST_PRIORITY", "") or "").strip()
+    if raw:
+        parts = tuple(p.strip() for p in raw.split(",") if p.strip())
+        if parts:
+            return parts
+    return _DEFAULT_MANIFEST_PRIORITY
+
+
+def _resolve_pip_manifest(project_root: Path, requested_file: str) -> Optional[str]:
+    """Slice 160 — resolve the active pip manifest. The exact requested file wins if it
+    is actually present; otherwise the highest-priority manifest present in the repo
+    root; otherwise None (nothing to install → caller skips, never a hard fail).
+    Environment-aware, no hardcoded single-file assumption. NEVER raises."""
+    try:
+        if requested_file and (project_root / requested_file).is_file():
+            return requested_file
+        for cand in _manifest_priority():
+            if (project_root / cand).is_file():
+                return cand
+    except Exception:  # noqa: BLE001 — defensive
+        pass
+    return None
+
+
 def _build_pip_argv(project_root: Path, file_path: str) -> List[str]:
-    """Build pip install argv using the project's venv Python."""
+    """Build pip install argv using the project's venv Python, targeting the
+    dynamically-resolved active manifest (Slice 160). Falls back to the requested
+    file when nothing resolvable is present (the fail-soft layer then catches it)."""
+    target = _resolve_pip_manifest(project_root, file_path) or file_path
     venv_pip = project_root / "venv" / "bin" / "pip"
     if venv_pip.exists():
-        return [str(venv_pip), "install", "-r", file_path]
-    return [sys.executable, "-m", "pip", "install", "-r", file_path]
+        return [str(venv_pip), "install", "-r", target]
+    return [sys.executable, "-m", "pip", "install", "-r", target]
+
+
+def infra_fail_soft_enabled() -> bool:
+    """Slice 160 — master for fail-soft infra. Default **TRUE** (failure-path-only: an
+    infra hook failure flags INFRA_WARNING and the op continues to the governance floor
+    instead of terminally dying; =0 reverts to legacy terminal-FAILED). NEVER raises."""
+    return os.environ.get("JARVIS_INFRA_FAIL_SOFT_ENABLED", "true").strip().lower() \
+        not in ("0", "false", "no", "off")
+
+
+def summarize_infra_failures(results: List["InfraResult"]) -> str:
+    """Compact INFRA_WARNING text from failed infra results — surfaced in the op
+    context + the Discord #governance-gates embed so the operator can decide."""
+    parts = []
+    for r in results:
+        if not getattr(r, "success", True):
+            tail = (getattr(r, "stderr_tail", "") or "").strip().replace("\n", " ")
+            parts.append(
+                f"{getattr(r, 'file_trigger', '?')} (exit={getattr(r, 'exit_code', -1)}): "
+                f"{tail[:200]}"
+            )
+    return " | ".join(parts) if parts else ""
 
 
 def _build_npm_argv(project_root: Path, file_path: str) -> List[str]:

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -961,6 +961,10 @@ class OperationContext:
     strategic_memory_prompt: str = ""
     strategic_memory_digest: str = ""
     terminal_reason_code: str = ""
+    # Slice 160 — non-fatal infrastructure-hook warning (e.g. pip install failed under
+    # fail-soft). Carried forward so the op reaches the governance floor / COMPLETE and
+    # the operator sees it (Discord embed / telemetry) rather than the op dying.
+    infra_warning: str = ""
     rollback_occurred: bool = False
     # P2-6: Runbook-grade observability — cross-operation correlation identifier.
     # For single-repo ops: defaults to op_id (self-referential).
@@ -1359,6 +1363,20 @@ class OperationContext:
             expanded_context_files=files,
             previous_hash=self.context_hash,
             context_hash="",  # placeholder — recomputed below
+        )
+        fields_for_hash = _context_to_hash_dict(intermediate)
+        new_hash = _compute_hash(fields_for_hash)
+        return dataclasses.replace(intermediate, context_hash=new_hash)
+
+    def with_infra_warning(self, warning: str) -> "OperationContext":
+        """Slice 160 — return a new context carrying a non-fatal infra-hook warning
+        (no phase change). Set on fail-soft so the op continues to the governance
+        floor / COMPLETE and the operator sees it instead of the op dying."""
+        intermediate = dataclasses.replace(
+            self,
+            infra_warning=str(warning or "")[:2000],
+            previous_hash=self.context_hash,
+            context_hash="",
         )
         fields_for_hash = _context_to_hash_dict(intermediate)
         new_hash = _compute_hash(fields_for_hash)

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -8499,38 +8499,54 @@ class GovernedOrchestrator:
                     op_id=ctx.op_id,
                 )
                 if infra_results and not self._infra_applicator.all_succeeded(infra_results):
-                    # Infrastructure operation failed — the file change is correct
-                    # but the environment didn't accept it. Roll back the file change
-                    # and mark FAILED so Ouroboros can retry with corrected deps.
                     _failed = [r for r in infra_results if not r.success]
-                    logger.error(
-                        "[Orchestrator] Infrastructure hook failed for %s: %s",
-                        ctx.op_id,
-                        "; ".join(f"{r.file_trigger}: exit={r.exit_code}" for r in _failed),
+                    from backend.core.ouroboros.governance.infrastructure_applicator import (
+                        infra_fail_soft_enabled,
+                        summarize_infra_failures,
                     )
-                    ctx = ctx.advance(
-                        OperationPhase.POSTMORTEM,
-                        terminal_reason_code="infrastructure_failed",
+                    if not infra_fail_soft_enabled():
+                        # Legacy terminal FAILED (operator opt-out via fail-soft=0): the
+                        # file change is correct but the environment didn't accept it.
+                        logger.error(
+                            "[Orchestrator] Infrastructure hook failed for %s: %s",
+                            ctx.op_id,
+                            "; ".join(f"{r.file_trigger}: exit={r.exit_code}" for r in _failed),
+                        )
+                        ctx = ctx.advance(
+                            OperationPhase.POSTMORTEM,
+                            terminal_reason_code="infrastructure_failed",
+                        )
+                        await self._record_ledger(
+                            ctx,
+                            OperationState.FAILED,
+                            {
+                                "reason": "infrastructure_failed",
+                                "infra_results": [
+                                    {
+                                        "file": r.file_trigger,
+                                        "command": r.command,
+                                        "exit_code": r.exit_code,
+                                        "stderr": r.stderr_tail[:500],
+                                    }
+                                    for r in _failed
+                                ],
+                            },
+                        )
+                        self._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply)
+                        await self._publish_outcome(ctx, OperationState.FAILED, "infrastructure_failed")
+                        return ctx
+                    # Slice 160 fail-soft: infra failure is NOT fatal — flag
+                    # INFRA_WARNING + continue to VERIFY/COMPLETE (op survives; the
+                    # operator sees the warning via telemetry / Discord).
+                    _warn = summarize_infra_failures(_failed)
+                    logger.warning(
+                        "[Orchestrator] INFRA_WARNING (fail-soft) op=%s — continuing: %s",
+                        ctx.op_id, _warn,
                     )
-                    await self._record_ledger(
-                        ctx,
-                        OperationState.FAILED,
-                        {
-                            "reason": "infrastructure_failed",
-                            "infra_results": [
-                                {
-                                    "file": r.file_trigger,
-                                    "command": r.command,
-                                    "exit_code": r.exit_code,
-                                    "stderr": r.stderr_tail[:500],
-                                }
-                                for r in _failed
-                            ],
-                        },
-                    )
-                    self._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply)
-                    await self._publish_outcome(ctx, OperationState.FAILED, "infrastructure_failed")
-                    return ctx
+                    try:
+                        ctx = ctx.with_infra_warning(_warn)
+                    except Exception:  # noqa: BLE001
+                        pass
 
                 # Log successful infra operations for observability
                 for r in infra_results:

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -677,38 +677,58 @@ class Slice4bRunner(PhaseRunner):
             )
             if infra_results and not orch._infra_applicator.all_succeeded(infra_results):
                 _failed = [r for r in infra_results if not r.success]
-                logger.error(
-                    "[Orchestrator] Infrastructure hook failed for %s: %s",
-                    ctx.op_id,
-                    "; ".join(f"{r.file_trigger}: exit={r.exit_code}" for r in _failed),
+                from backend.core.ouroboros.governance.infrastructure_applicator import (
+                    infra_fail_soft_enabled,
+                    summarize_infra_failures,
                 )
-                ctx = ctx.advance(
-                    OperationPhase.POSTMORTEM,
-                    terminal_reason_code="infrastructure_failed",
+                if not infra_fail_soft_enabled():
+                    # Legacy: terminal FAILED (operator opt-out via fail-soft=0).
+                    logger.error(
+                        "[Orchestrator] Infrastructure hook failed for %s: %s",
+                        ctx.op_id,
+                        "; ".join(f"{r.file_trigger}: exit={r.exit_code}" for r in _failed),
+                    )
+                    ctx = ctx.advance(
+                        OperationPhase.POSTMORTEM,
+                        terminal_reason_code="infrastructure_failed",
+                    )
+                    await orch._record_ledger(
+                        ctx,
+                        OperationState.FAILED,
+                        {
+                            "reason": "infrastructure_failed",
+                            "infra_results": [
+                                {
+                                    "file": r.file_trigger,
+                                    "command": r.command,
+                                    "exit_code": r.exit_code,
+                                    "stderr": r.stderr_tail[:500],
+                                }
+                                for r in _failed
+                            ],
+                        },
+                    )
+                    orch._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply)
+                    await orch._publish_outcome(ctx, OperationState.FAILED, "infrastructure_failed")
+                    return PhaseResult(
+                        next_ctx=ctx, next_phase=None, status="fail",
+                        reason="infrastructure_failed",
+                        artifacts={"t_apply": _t_apply},
+                    )
+                # Slice 160 fail-soft: an infra-hook failure is NOT fatal. Flag
+                # INFRA_WARNING onto the context (surfaced to the operator via
+                # telemetry / Discord) and CONTINUE forward — the file change applied,
+                # only the deterministic consequence (pip/npm) didn't. The op proceeds
+                # to VERIFY/COMPLETE instead of dying before the governance floor.
+                _warn = summarize_infra_failures(_failed)
+                logger.warning(
+                    "[Orchestrator] INFRA_WARNING (fail-soft) op=%s — continuing: %s",
+                    ctx.op_id, _warn,
                 )
-                await orch._record_ledger(
-                    ctx,
-                    OperationState.FAILED,
-                    {
-                        "reason": "infrastructure_failed",
-                        "infra_results": [
-                            {
-                                "file": r.file_trigger,
-                                "command": r.command,
-                                "exit_code": r.exit_code,
-                                "stderr": r.stderr_tail[:500],
-                            }
-                            for r in _failed
-                        ],
-                    },
-                )
-                orch._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply)
-                await orch._publish_outcome(ctx, OperationState.FAILED, "infrastructure_failed")
-                return PhaseResult(
-                    next_ctx=ctx, next_phase=None, status="fail",
-                    reason="infrastructure_failed",
-                    artifacts={"t_apply": _t_apply},
-                )
+                try:
+                    ctx = ctx.with_infra_warning(_warn)
+                except Exception:  # noqa: BLE001 — never let warning-stamping break the op
+                    pass
 
             for r in infra_results:
                 logger.info(

--- a/tests/governance/test_slice160_infra_resilience.py
+++ b/tests/governance/test_slice160_infra_resilience.py
@@ -1,0 +1,93 @@
+"""Slice 160 — The Environment-Aware Applicator.
+
+The InfraApplicator hardcoded a single 'requirements.txt' assumption and a missing/
+failed pip install was a TERMINAL FAILED that killed the op before the governance
+floor. This makes it (a) environment-aware — dynamically resolve the active manifest
+present in the repo root, and (b) fail-soft — an infra failure flags INFRA_WARNING and
+the op continues to the approval floor for the operator to decide.
+
+Phase-2/fail-soft helpers are pure logic → unit-tested here; the orchestrator/runner
+wiring is verified live.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import tempfile
+import unittest
+
+from backend.core.ouroboros.governance import infrastructure_applicator as IA
+
+
+def _root_with(*files: str) -> pathlib.Path:
+    d = pathlib.Path(tempfile.mkdtemp())
+    for f in files:
+        (d / f).write_text("# manifest\n")
+    return d
+
+
+class TestManifestResolution(unittest.TestCase):
+    def test_requested_present_wins(self):
+        root = _root_with("requirements.txt", "requirements-soak.txt")
+        self.assertEqual(IA._resolve_pip_manifest(root, "requirements.txt"), "requirements.txt")
+
+    def test_falls_back_to_present_manifest_when_requested_absent(self):
+        root = _root_with("requirements-soak-oracle.txt")  # requirements.txt ABSENT
+        self.assertEqual(
+            IA._resolve_pip_manifest(root, "requirements.txt"),
+            "requirements-soak-oracle.txt",
+        )
+
+    def test_highest_priority_present_wins(self):
+        root = _root_with("requirements-soak.txt", "requirements-soak-oracle.txt")
+        self.assertEqual(
+            IA._resolve_pip_manifest(root, "nonexistent.txt"),
+            "requirements-soak-oracle.txt",  # oracle outranks soak
+        )
+
+    def test_none_when_nothing_present(self):
+        root = _root_with()
+        self.assertIsNone(IA._resolve_pip_manifest(root, "requirements.txt"))
+
+    def test_priority_is_env_tunable(self):
+        os.environ["JARVIS_INFRA_MANIFEST_PRIORITY"] = "requirements-soak.txt,requirements.txt"
+        try:
+            root = _root_with("requirements-soak.txt", "requirements-soak-oracle.txt")
+            self.assertEqual(IA._resolve_pip_manifest(root, "x.txt"), "requirements-soak.txt")
+        finally:
+            os.environ.pop("JARVIS_INFRA_MANIFEST_PRIORITY", None)
+
+
+class TestBuildPipArgvUsesResolved(unittest.TestCase):
+    def test_argv_targets_resolved_manifest(self):
+        root = _root_with("requirements-soak-oracle.txt")  # requested absent
+        argv = IA._build_pip_argv(root, "requirements.txt")
+        self.assertIn("requirements-soak-oracle.txt", argv)
+        self.assertNotIn("requirements.txt", [a for a in argv if a == "requirements.txt"])
+
+
+class TestFailSoft(unittest.TestCase):
+    def tearDown(self):
+        os.environ.pop("JARVIS_INFRA_FAIL_SOFT_ENABLED", None)
+
+    def test_fail_soft_default_true(self):
+        os.environ.pop("JARVIS_INFRA_FAIL_SOFT_ENABLED", None)
+        self.assertTrue(IA.infra_fail_soft_enabled())
+
+    def test_fail_soft_off(self):
+        os.environ["JARVIS_INFRA_FAIL_SOFT_ENABLED"] = "0"
+        self.assertFalse(IA.infra_fail_soft_enabled())
+
+    def test_summarize_failures(self):
+        r = IA.InfraResult(
+            success=False, command="pip install -r requirements.txt", exit_code=1,
+            duration_s=0.2, stdout_tail="", stderr_tail="No such file: requirements.txt",
+            file_trigger="requirements.txt",
+        )
+        text = IA.summarize_infra_failures([r])
+        self.assertIn("requirements.txt", text)
+        self.assertIn("No such file", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An autonomous organism must not crash because it hardcoded requirements.txt. **Phase 2 (dynamic manifest):** `_resolve_pip_manifest` resolves the active manifest present in the repo root (requested-first, then priority oracle>soak>standard, env-tunable) so the lean container resolves correctly. **Phase 3 (fail-soft):** infra-hook failure no longer goes terminal FAILED/POSTMORTEM — it flags `INFRA_WARNING` on the ctx (new `OperationContext.infra_warning`) and continues to VERIFY/COMPLETE for the operator to decide. Master `JARVIS_INFRA_FAIL_SOFT_ENABLED` default-TRUE (=0 reverts). Both the live slice4b_runner path + the orchestrator inline path covered. 9 new tests; 143 regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the InfraApplicator environment-aware and fail-soft. It resolves the correct pip manifest for the running environment and treats infra hook failures as warnings so ops can still reach VERIFY/COMPLETE.

- **New Features**
  - Dynamic pip manifest resolution: prefers the requested file if present, else `requirements-soak-oracle.txt` > `requirements-soak.txt` > `requirements.txt`; tunable via `JARVIS_INFRA_MANIFEST_PRIORITY`. `_build_pip_argv` now targets the resolved manifest.
  - Fail-soft infra path (default on): infra hook failures set `infra_warning` on `OperationContext` and continue; opt out with `JARVIS_INFRA_FAIL_SOFT_ENABLED=0`. Includes helpers `infra_fail_soft_enabled` and `summarize_infra_failures`.
  - Applied in both the orchestrator and `slice4b_runner`. Added unit tests for manifest resolution and fail-soft behavior.

<sup>Written for commit 5467dff8b07e9916f46c1b5a2d09f81739406133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

