### PR TITLE
Slice 161 - read-only non-flickering Claude-breaker predicate

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -273,16 +273,24 @@ def _force_batch_on_breaker_enabled() -> bool:
 
 
 def _claude_breaker_open(getter: Any = None) -> bool:
-    """Slice 159 — True iff the Claude circuit breaker is currently REJECTING requests
-    (economic credit-death OR transport). In that state Claude cannot catch a DW RT
-    failure, so STANDARD/COMPLEX ops must force the DW batch transport. ``getter`` is
-    injectable for tests. NEVER raises — fail-closed to False (legacy RT)."""
+    """Slice 161 — True iff the Claude breaker is NOT CLOSED (OPEN or HALF_OPEN), i.e.
+    Claude is unreliable as a fallback, so STANDARD/COMPLEX ops must force the DW batch
+    transport.
+
+    Reads the breaker STATE directly (read-only). It deliberately does NOT call
+    ``should_allow_request()``, which (Slice 159 bug) has a SIDE EFFECT — it transitions
+    OPEN->HALF_OPEN and consumes the single probe slot — AND returns True during the
+    probe window, flickering force-batch OFF exactly when DW must carry the op (the
+    complex-op live_transport rupture observed in the soak). HALF_OPEN still counts as
+    unreliable: a probe is in flight, Claude is not yet proven healthy. ``getter``
+    injectable. NEVER raises — fail-closed to False (legacy RT)."""
     try:
         if getter is None:
             from backend.core.ouroboros.governance.claude_circuit_breaker import (
                 get_claude_circuit_breaker as getter,  # type: ignore[assignment]
             )
-        return not getter().should_allow_request()
+        from backend.core.ouroboros.governance.claude_circuit_breaker import CircuitState
+        return getter().state in (CircuitState.OPEN, CircuitState.HALF_OPEN)
     except Exception:  # noqa: BLE001 — defensive; legacy RT on any failure
         return False
 

--- a/tests/governance/test_slice159_dw_transport_sovereignty.py
+++ b/tests/governance/test_slice159_dw_transport_sovereignty.py
@@ -26,18 +26,22 @@ class _Ctx:
 
 
 class _FakeBreaker:
-    def __init__(self, allow):
-        self._allow = allow
-    def should_allow_request(self):
-        return self._allow
+    # Slice 161 — predicate reads .state (read-only), not should_allow_request.
+    def __init__(self, state):
+        self._state = state
+    @property
+    def state(self):
+        return self._state
 
 
 class TestBreakerOpenPredicate(unittest.TestCase):
     def test_open_when_breaker_rejects(self):
-        self.assertTrue(DW._claude_breaker_open(getter=lambda: _FakeBreaker(allow=False)))
+        from backend.core.ouroboros.governance.claude_circuit_breaker import CircuitState
+        self.assertTrue(DW._claude_breaker_open(getter=lambda: _FakeBreaker(CircuitState.OPEN)))
 
     def test_closed_when_breaker_allows(self):
-        self.assertFalse(DW._claude_breaker_open(getter=lambda: _FakeBreaker(allow=True)))
+        from backend.core.ouroboros.governance.claude_circuit_breaker import CircuitState
+        self.assertFalse(DW._claude_breaker_open(getter=lambda: _FakeBreaker(CircuitState.CLOSED)))
 
     def test_fail_closed_on_error(self):
         def _boom():

--- a/tests/governance/test_slice161_breaker_predicate.py
+++ b/tests/governance/test_slice161_breaker_predicate.py
@@ -1,0 +1,61 @@
+"""Slice 161 — read-only, non-flickering Claude-breaker predicate (universal floor).
+
+Slice 159's force-batch used should_allow_request() to detect a dead Claude. But that
+method (a) has a SIDE EFFECT — it transitions OPEN->HALF_OPEN and consumes the single
+probe slot — and (b) returns True during the probe window. So in the live soak a
+complex op's force-batch DISENGAGED exactly when Claude was unreliable → DW SSE
+ruptured → the op died at generate and never reached the gate/approval floor.
+
+Fix: read the breaker STATE directly (read-only). Claude is unreliable-as-fallback
+whenever the breaker is NOT CLOSED (OPEN or HALF_OPEN) → force DW batch. No mutation,
+no flicker. This lets complex ops survive generate on DW and reach the governance floor.
+"""
+from __future__ import annotations
+
+import unittest
+
+from backend.core.ouroboros.governance import doubleword_provider as DW
+from backend.core.ouroboros.governance.claude_circuit_breaker import CircuitState
+
+
+class _StateBreaker:
+    """Read-only fake exposing .state; should_allow_request must NOT be called."""
+    def __init__(self, state):
+        self._state = state
+        self.allow_calls = 0
+
+    @property
+    def state(self):
+        return self._state
+
+    def should_allow_request(self):  # pragma: no cover — must not be used by the fix
+        self.allow_calls += 1
+        return self._state is CircuitState.CLOSED
+
+
+class TestBreakerPredicate(unittest.TestCase):
+    def test_open_is_unreliable_forces_batch(self):
+        self.assertTrue(DW._claude_breaker_open(getter=lambda: _StateBreaker(CircuitState.OPEN)))
+
+    def test_half_open_is_unreliable_forces_batch(self):
+        # The flicker fix: HALF_OPEN (probe in flight) must still force batch — Claude
+        # is NOT healthy yet, so DW must carry the op.
+        self.assertTrue(DW._claude_breaker_open(getter=lambda: _StateBreaker(CircuitState.HALF_OPEN)))
+
+    def test_closed_is_healthy_no_force(self):
+        self.assertFalse(DW._claude_breaker_open(getter=lambda: _StateBreaker(CircuitState.CLOSED)))
+
+    def test_predicate_has_no_side_effect(self):
+        # Must read .state, NOT call the state-mutating should_allow_request().
+        b = _StateBreaker(CircuitState.OPEN)
+        DW._claude_breaker_open(getter=lambda: b)
+        self.assertEqual(b.allow_calls, 0)
+
+    def test_fail_closed_on_error(self):
+        def _boom():
+            raise RuntimeError("no breaker")
+        self.assertFalse(DW._claude_breaker_open(getter=_boom))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Verify-first reframe:** the card never appeared NOT because of the floor (`recommended_floor()=approval_required` works), but because the COMPLEX livefire op died at GENERATE. Slice 159's `_claude_breaker_open` used `should_allow_request()` which **has a side effect** (transitions OPEN->HALF_OPEN, consumes the probe slot) and returns True during the probe window → force-batch disengaged → DW SSE ruptured → cascade to dead Claude → op died before the floor.

**Fix:** read `.state` directly — unreliable = NOT CLOSED (OPEN or HALF_OPEN) → force DW batch. No mutation, no flicker. Complex ops now survive generate on DW batch → reach the floor → APPROVAL_REQUIRED → card. 5 tests; 39 regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Claude breaker check to be read-only and non-flickering so complex ops force DW batch and reach the approval floor (Slice 161). Treats `OPEN` and `HALF_OPEN` as unreliable without consuming the probe slot.

- **Bug Fixes**
  - Updated `doubleword_provider._claude_breaker_open` to read `.state` and return True for `CircuitState.OPEN` or `CircuitState.HALF_OPEN`; no `should_allow_request()` calls.
  - Added tests for OPEN/HALF_OPEN/CLOSED, side-effect prevention, and fail-closed behavior; updated existing tests.

<sup>Written for commit 18408af10d25baf46ccdea3b52b959fd891fe828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

