### PR TITLE
Slice 162+163 - IMMEDIATE proactive-DW + fail-closed governance floor

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3703,16 +3703,22 @@ class CandidateGenerator:
             # grind an IMMEDIATE op against a depleted Claude lane (the live
             # soak: terminal_quota x N, no completion). When the Claude lane
             # breaker is OPEN (economic/transport), reroute to the funded DW
-            # primary instead. should_allow_request() returns True for a
-            # HALF_OPEN probe → we keep Claude-direct that one time so the lane
-            # self-heals. Gated default-FALSE → OFF is unchanged Claude-direct.
+            # primary instead. Slice 162 — read the breaker STATE (read-only) via the
+            # Slice 161 predicate, NOT should_allow_request(): the latter flickers True
+            # during a HALF_OPEN probe AND has a side effect (consumes the probe slot),
+            # so an IMMEDIATE op kept hammering a dead-but-probing Claude and exhausted
+            # before the gate. Now CLOSED → Claude-direct (self-heal); OPEN/HALF_OPEN →
+            # reroute to funded DW. Gated default-FALSE → OFF is unchanged Claude-direct.
             if fallback_skip_gate_enabled():
                 try:
                     from backend.core.ouroboros.governance.claude_circuit_breaker import (  # noqa: E501
                         get_claude_circuit_breaker as _p21_ccb,
                         is_enabled as _p21_ccb_enabled,
                     )
-                    _p21_allows = _p21_ccb().should_allow_request()
+                    from backend.core.ouroboros.governance.doubleword_provider import (
+                        _claude_breaker_open as _p21_breaker_open,
+                    )
+                    _p21_allows = not _p21_breaker_open(getter=_p21_ccb)
                     if immediate_reroute_to_dw(
                         dw_is_primary=True,
                         gate_enabled=True,

--- a/backend/core/ouroboros/governance/phase_runners/gate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/gate_runner.py
@@ -479,10 +479,26 @@ class GATERunner(PhaseRunner):
                     )
                     risk_tier = _tgt
         except Exception:
-            logger.debug(
-                "[Orchestrator] MIN_RISK_TIER floor skipped",
-                exc_info=True,
+            # Slice 163 — FAIL-CLOSED last resort. If the floor block itself errors
+            # (import / mapping / recommendation), the operator's configured
+            # MIN_RISK_TIER must STILL apply — a governance floor that a stray
+            # exception can silently bypass is not a floor.
+            logger.warning(
+                "[Orchestrator] MIN_RISK_TIER floor block errored — applying "
+                "fail-closed floor", exc_info=True,
             )
+            try:
+                _fc = (os.environ.get("JARVIS_MIN_RISK_TIER", "") or "").strip().lower()
+                _fc_tgt = {
+                    "safe_auto": RiskTier.SAFE_AUTO,
+                    "notify_apply": RiskTier.NOTIFY_APPLY,
+                    "approval_required": RiskTier.APPROVAL_REQUIRED,
+                    "blocked": RiskTier.BLOCKED,
+                }.get(_fc)
+                if _fc_tgt is not None and risk_tier.value < _fc_tgt.value:
+                    risk_tier = _fc_tgt
+            except Exception:  # noqa: BLE001
+                pass
 
         # ---- RR Pass B Slice 2b: ORDER_2_GOVERNANCE floor ----
         # Runs AFTER the MIN_RISK_TIER floor so paranoia/quiet-hours

--- a/backend/core/ouroboros/governance/risk_tier_floor.py
+++ b/backend/core/ouroboros/governance/risk_tier_floor.py
@@ -602,12 +602,19 @@ def apply_floor_to_name(
     _order = get_active_tier_order()
     if raw_in not in _order:
         return (tier_name, None)
-    floor = recommended_floor(
-        now,
-        signal_source=signal_source,
-        op_id=op_id,
-        target_files=target_files,
-    )
+    try:
+        floor = recommended_floor(
+            now,
+            signal_source=signal_source,
+            op_id=op_id,
+            target_files=target_files,
+        )
+    except Exception:  # noqa: BLE001
+        # Slice 163 — FAIL-CLOSED. A failure computing the recommendation must NOT
+        # silently bypass the operator's deliberate governance posture. Fall back to
+        # the explicit MIN_RISK_TIER floor so an erroring subsystem can never let an
+        # op auto-apply below the configured floor.
+        floor = _env_floor()
     if floor is None:
         return (tier_name, None)
     if _order[floor] <= _order[raw_in]:

--- a/tests/governance/test_slice162_163_route_floor.py
+++ b/tests/governance/test_slice162_163_route_floor.py
@@ -1,0 +1,99 @@
+"""Slice 162 + 163 — IMMEDIATE-route proactive-DW + fail-closed governance floor.
+
+162: the IMMEDIATE reroute (immediate_reroute_to_dw) fed claude_allows_request from
+should_allow_request(), which flickers True during a HALF_OPEN probe + has a side
+effect — so an IMMEDIATE op kept Claude-direct on a dead-but-probing Claude → exhausted
+before reaching the gate. Fix: feed it the read-only state-based predicate (reuse
+Slice 161's _claude_breaker_open) so HALF_OPEN reroutes to funded DW.
+
+163: the gate's MIN_RISK_TIER floor was wrapped in a try/except that silently swallowed
+to DEBUG — so an error in the floor computation silently BYPASSED the operator's
+governance floor (op auto-applied). Fix: apply_floor_to_name is fail-closed — if the
+recommendation errors, it still applies the configured MIN_RISK_TIER.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+
+from backend.core.ouroboros.governance.candidate_generator import immediate_reroute_to_dw
+from backend.core.ouroboros.governance.doubleword_provider import _claude_breaker_open
+from backend.core.ouroboros.governance import risk_tier_floor as RTF
+from backend.core.ouroboros.governance.claude_circuit_breaker import CircuitState
+
+
+class _StateBreaker:
+    def __init__(self, state):
+        self._state = state
+    @property
+    def state(self):
+        return self._state
+
+
+class TestImmediateProactiveDW(unittest.TestCase):
+    """162 — IMMEDIATE reroutes to DW whenever the breaker is non-CLOSED (incl. the
+    HALF_OPEN probe window), composing Slice 161's state-based predicate."""
+
+    def _allows(self, state):
+        # this is exactly what the patched call site computes
+        return not _claude_breaker_open(getter=lambda: _StateBreaker(state))
+
+    def test_half_open_reroutes_to_dw(self):
+        reroute = immediate_reroute_to_dw(
+            dw_is_primary=True, gate_enabled=True, claude_breaker_enabled=True,
+            claude_allows_request=self._allows(CircuitState.HALF_OPEN),
+        )
+        self.assertTrue(reroute)  # the flicker fix — was False before
+
+    def test_open_reroutes_to_dw(self):
+        self.assertTrue(immediate_reroute_to_dw(
+            dw_is_primary=True, gate_enabled=True, claude_breaker_enabled=True,
+            claude_allows_request=self._allows(CircuitState.OPEN)))
+
+    def test_closed_keeps_claude_direct(self):
+        self.assertFalse(immediate_reroute_to_dw(
+            dw_is_primary=True, gate_enabled=True, claude_breaker_enabled=True,
+            claude_allows_request=self._allows(CircuitState.CLOSED)))
+
+    def test_call_site_uses_state_predicate_not_should_allow(self):
+        # Lock the call-site fix: the IMMEDIATE reroute must feed the read-only
+        # state-based predicate, NOT the flickering/side-effecting should_allow_request.
+        import backend.core.ouroboros.governance.candidate_generator as CG
+        src = open(CG.__file__).read()
+        self.assertIn("_p21_allows = not _p21_breaker_open(getter=_p21_ccb)", src)
+        self.assertNotIn("_p21_allows = _p21_ccb().should_allow_request()", src)
+
+
+class TestFailClosedFloor(unittest.TestCase):
+    """163 — the governance floor is never silently bypassed by a computation error."""
+
+    def tearDown(self):
+        os.environ.pop("JARVIS_MIN_RISK_TIER", None)
+        # restore if monkeypatched
+        if hasattr(self, "_saved_rf"):
+            RTF.recommended_floor = self._saved_rf
+
+    def test_floor_applies_when_recommendation_errors(self):
+        os.environ["JARVIS_MIN_RISK_TIER"] = "approval_required"
+        self._saved_rf = RTF.recommended_floor
+        def _boom(*a, **k):
+            raise RuntimeError("recommendation backend down")
+        RTF.recommended_floor = _boom
+        effective, applied = RTF.apply_floor_to_name("safe_auto")
+        # fail-closed: still escalates to the configured MIN_RISK_TIER
+        self.assertEqual(effective, "approval_required")
+        self.assertEqual(applied, "approval_required")
+
+    def test_no_floor_configured_and_error_passes_through(self):
+        os.environ.pop("JARVIS_MIN_RISK_TIER", None)
+        self._saved_rf = RTF.recommended_floor
+        def _boom(*a, **k):
+            raise RuntimeError("down")
+        RTF.recommended_floor = _boom
+        effective, applied = RTF.apply_floor_to_name("safe_auto")
+        self.assertEqual(effective, "safe_auto")   # nothing configured → unchanged
+        self.assertIsNone(applied)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**162:** the IMMEDIATE reroute fed `immediate_reroute_to_dw` from `should_allow_request()` (flickers True during HALF_OPEN probe + side-effect) → IMMEDIATE ops hammered a dead-but-probing Claude → exhausted before the gate. Fix: use Slice 161's read-only state predicate (`_claude_breaker_open`) → OPEN/HALF_OPEN reroutes to funded DW. **163:** the gate floor's try/except silently swallowed errors to DEBUG → MIN_RISK_TIER silently bypassed. Fix: `apply_floor_to_name` fail-closed (recommendation error → `_env_floor()`); gate_runner except is a fail-closed last resort. 6 tests; 297 regression pass (2 unrelated pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proactively reroutes IMMEDIATE requests to the funded DW whenever the Claude circuit breaker isn’t CLOSED, and makes the governance risk floor fail-closed so errors can’t bypass MIN_RISK_TIER. Prevents probe-slot theft and silent floor skips.

- **Bug Fixes**
  - IMMEDIATE reroute: switched from `should_allow_request()` to the read-only `_claude_breaker_open` predicate in `candidate_generator` so OPEN/HALF_OPEN states reroute to DW; CLOSED stays Claude-direct, avoiding HALF_OPEN flicker and side effects.
  - Governance floor: `apply_floor_to_name` now falls back to the env MIN_RISK_TIER when recommendation lookup fails, and `gate_runner` enforces a fail-closed fallback with a warning instead of silently skipping the floor.

<sup>Written for commit 9e526a45594fd4b9e2b68590ce9ee7cb4413ec2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

