### PR TITLE
Slice 164 - durable Claude-breaker state (kills the cold-start)

### DIFF
--- a/backend/core/ouroboros/governance/claude_circuit_breaker.py
+++ b/backend/core/ouroboros/governance/claude_circuit_breaker.py
@@ -45,6 +45,7 @@ consult via ``get_claude_circuit_breaker()``. No reverse dependency.
 from __future__ import annotations
 
 import enum
+import json
 import logging
 import os
 import threading
@@ -150,6 +151,88 @@ def _economic_threshold() -> int:
 
 
 # ---------------------------------------------------------------------------
+# Slice 164 — durable economic-trip state (kills the cold-start at boot)
+# ---------------------------------------------------------------------------
+# The breaker is an in-memory singleton; it resets to CLOSED every process boot,
+# so a credit-dead Claude is re-learned from scratch each relaunch and the first
+# ops exhaust before the Slice 161/162 DW-sovereignty protections engage. Persist
+# the economic-OPEN state (host-local .jarvis, gitignored) and restore it at boot
+# when RECENT (within a TTL) so protections are warm from op #1. The recovery
+# window restarts from boot, so a since-funded Claude still self-heals via the
+# normal HALF_OPEN probe — no permanent lock-out, no hardcoding.
+
+def _breaker_persist_enabled() -> bool:
+    """Master gate, default-FALSE per §33.1. NEVER raises."""
+    return os.environ.get("JARVIS_CLAUDE_BREAKER_PERSIST_ENABLED", "false") \
+        .strip().lower() in ("1", "true", "yes", "on")
+
+
+def _breaker_persist_path() -> str:
+    """Host-local state file (env-tunable; default .jarvis/). NEVER raises."""
+    explicit = (os.environ.get("JARVIS_CLAUDE_BREAKER_PERSIST_PATH", "") or "").strip()
+    if explicit:
+        return explicit
+    base = (os.environ.get("JARVIS_STATE_DIR", "") or "").strip() or ".jarvis"
+    return os.path.join(base, "claude_breaker_state.json")
+
+
+def _breaker_persist_ttl_s() -> float:
+    """How long a persisted economic trip is honored before re-probing Claude.
+    Default 24h (a funded lane is re-checked daily). Floored at 0. NEVER raises."""
+    try:
+        return max(0.0, float(os.environ.get("JARVIS_CLAUDE_BREAKER_PERSIST_TTL_S", "86400")))
+    except (TypeError, ValueError):
+        return 86400.0
+
+
+def _write_breaker_state(
+    state_name: str, economic_failures: int, *,
+    reason: str = "economic", path: Optional[str] = None, now_wall: Optional[float] = None,
+) -> None:
+    """Atomically persist the breaker state with a WALL-CLOCK timestamp (monotonic
+    doesn't survive a restart). NEVER raises — persistence is best-effort."""
+    try:
+        p = path or _breaker_persist_path()
+        d = os.path.dirname(p)
+        if d:
+            os.makedirs(d, exist_ok=True)
+        payload = {
+            "state": str(state_name),
+            "economic_failures": int(economic_failures),
+            "tripped_at_wall": float(now_wall if now_wall is not None else time.time()),
+            "reason": str(reason),
+            "schema": 1,
+        }
+        tmp = p + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+        os.replace(tmp, p)  # atomic
+    except Exception:  # noqa: BLE001 — best-effort
+        pass
+
+
+def _read_breaker_state(
+    *, path: Optional[str] = None, now_wall: Optional[float] = None, ttl_s: Optional[float] = None,
+) -> Optional[int]:
+    """Read the persisted state. Returns the economic-failure count to restore IFF the
+    record is an OPEN economic trip within the TTL; otherwise None (no restore →
+    legacy cold start / re-probe). NEVER raises — fail-soft to None."""
+    try:
+        p = path or _breaker_persist_path()
+        with open(p, "r", encoding="utf-8") as fh:
+            d = json.load(fh)
+        if str(d.get("state", "")).lower() != "open":
+            return None
+        _ttl = ttl_s if ttl_s is not None else _breaker_persist_ttl_s()
+        _now = now_wall if now_wall is not None else time.time()
+        if (_now - float(d.get("tripped_at_wall", 0.0))) > _ttl:
+            return None  # stale → re-probe Claude (it may have been funded)
+        return max(1, int(d.get("economic_failures", 1)))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Transport-class detection — string-based to avoid hard httpx dependency
 # ---------------------------------------------------------------------------
 
@@ -224,7 +307,9 @@ class ClaudeCircuitBreaker:
         self,
         failure_threshold: Optional[int] = None,
         recovery_window_s: Optional[float] = None,
+        persist_path: Optional[str] = None,
     ) -> None:
+        self._persist_path: Optional[str] = persist_path
         self._state: CircuitState = CircuitState.CLOSED
         self._consecutive_transport_failures: int = 0
         # Slice 127 — economic-exhaustion counter, kept DISTINCT from the
@@ -249,6 +334,35 @@ class ClaudeCircuitBreaker:
         self._total_trips: int = 0
         self._total_successes: int = 0
         self._lock = threading.RLock()
+        # Slice 164 — durable economic-trip restore. If a RECENT economic OPEN was
+        # persisted (within TTL), boot OPEN so the Slice 161/162 DW-sovereignty
+        # protections are warm from op #1 instead of paying the cold-start. The
+        # recovery window restarts from boot, so a since-funded lane self-heals.
+        if _breaker_persist_enabled():
+            _restored = _read_breaker_state(path=self._persist_path)
+            if _restored is not None:
+                self._state = CircuitState.OPEN
+                self._consecutive_economic_failures = _restored
+                self._tripped_at_monotonic = time.monotonic()
+                self._total_trips += 1
+                logger.warning(
+                    "[ClaudeCircuitBreaker] restored OPEN from persisted economic "
+                    "trip (failures=%d) — DW-sovereignty warm from boot (Slice 164)",
+                    _restored,
+                )
+
+    def _maybe_persist_open(self) -> None:
+        """Slice 164 — persist the economic-OPEN state (best-effort, caller holds lock)."""
+        if _breaker_persist_enabled():
+            _write_breaker_state(
+                "open", self._consecutive_economic_failures,
+                reason="economic", path=self._persist_path,
+            )
+
+    def _maybe_clear_persisted(self) -> None:
+        """Slice 164 — mark the lane recovered so the next boot starts CLOSED."""
+        if _breaker_persist_enabled():
+            _write_breaker_state("closed", 0, reason="recovered", path=self._persist_path)
 
     # -- Properties --------------------------------------------------------
 
@@ -354,6 +468,7 @@ class ClaudeCircuitBreaker:
                     "(%s) — re-tripping to OPEN (re-probe window now %.0fs)",
                     detail, self._effective_recovery_window_s(),
                 )
+                self._maybe_persist_open()  # Slice 164
                 return
             self._consecutive_economic_failures += 1
             if (
@@ -371,6 +486,7 @@ class ClaudeCircuitBreaker:
                     self._consecutive_economic_failures, detail,
                     self._recovery_window_s,
                 )
+                self._maybe_persist_open()  # Slice 164 — warm next boot
 
     def record_success(self) -> None:
         """Record a successful Claude call. Resets consecutive-failure
@@ -393,6 +509,7 @@ class ClaudeCircuitBreaker:
                 )
                 self._state = CircuitState.CLOSED
                 self._tripped_at_monotonic = None
+                self._maybe_clear_persisted()  # Slice 164 — recovered → cold-start next boot
 
     def record_non_transport_failure(self) -> None:
         """Record a non-transport failure (content failure, validation,

--- a/tests/governance/test_slice164_breaker_persistence.py
+++ b/tests/governance/test_slice164_breaker_persistence.py
@@ -1,0 +1,96 @@
+"""Slice 164 — durable Claude-breaker state (kill the cold-start, no funding).
+
+The breaker is an in-memory singleton: it resets to CLOSED on every process boot. So
+when Claude is credit-dead, the first ops each relaunch hammer Claude-direct and
+exhaust BEFORE the breaker re-learns it's dead and the Slice 161/162 protections engage.
+
+Fix: persist the economic-trip state to disk (.jarvis, host-local). On boot, if a
+RECENT economic death is recorded (within a TTL), the breaker restores OPEN so the
+DW-sovereignty protections are warm from op #1 — no cold-start, no funding. The
+recovery window restarts from boot, so a since-funded Claude still self-heals via the
+normal HALF_OPEN probe. Gated default-FALSE.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+import unittest
+
+from backend.core.ouroboros.governance import claude_circuit_breaker as CB
+from backend.core.ouroboros.governance.claude_circuit_breaker import (
+    ClaudeCircuitBreaker,
+    CircuitState,
+)
+
+
+def _tmp():
+    return os.path.join(tempfile.mkdtemp(), "claude_breaker_state.json")
+
+
+class TestPersistHelpers(unittest.TestCase):
+    def test_write_read_roundtrip(self):
+        p = _tmp()
+        CB._write_breaker_state("open", 2, reason="economic", path=p, now_wall=1000.0)
+        self.assertEqual(CB._read_breaker_state(path=p, now_wall=1100.0, ttl_s=86400), 2)
+
+    def test_ttl_expiry_returns_none(self):
+        p = _tmp()
+        CB._write_breaker_state("open", 2, reason="economic", path=p, now_wall=1000.0)
+        self.assertIsNone(CB._read_breaker_state(path=p, now_wall=1000.0 + 90000, ttl_s=86400))
+
+    def test_non_open_state_returns_none(self):
+        p = _tmp()
+        CB._write_breaker_state("closed", 0, reason="recovered", path=p, now_wall=1000.0)
+        self.assertIsNone(CB._read_breaker_state(path=p, now_wall=1000.0, ttl_s=86400))
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(CB._read_breaker_state(path="/no/such/file.json", now_wall=1.0, ttl_s=1))
+
+
+class TestBreakerRestore(unittest.TestCase):
+    def tearDown(self):
+        for k in ("JARVIS_CLAUDE_BREAKER_PERSIST_ENABLED", "JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED"):
+            os.environ.pop(k, None)
+
+    def test_default_persist_disabled(self):
+        os.environ.pop("JARVIS_CLAUDE_BREAKER_PERSIST_ENABLED", None)
+        self.assertFalse(CB._breaker_persist_enabled())
+
+    def test_restores_open_from_recent_economic_death(self):
+        os.environ["JARVIS_CLAUDE_BREAKER_PERSIST_ENABLED"] = "1"
+        p = _tmp()
+        CB._write_breaker_state("open", 3, reason="economic", path=p, now_wall=time.time())
+        b = ClaudeCircuitBreaker(persist_path=p)
+        self.assertIs(b.state, CircuitState.OPEN)  # warm from boot — no cold-start
+
+    def test_no_restore_when_disabled(self):
+        os.environ.pop("JARVIS_CLAUDE_BREAKER_PERSIST_ENABLED", None)
+        p = _tmp()
+        CB._write_breaker_state("open", 3, reason="economic", path=p, now_wall=time.time())
+        b = ClaudeCircuitBreaker(persist_path=p)
+        self.assertIs(b.state, CircuitState.CLOSED)  # gated off → legacy cold start
+
+    def test_no_restore_when_stale(self):
+        os.environ["JARVIS_CLAUDE_BREAKER_PERSIST_ENABLED"] = "1"
+        os.environ["JARVIS_CLAUDE_BREAKER_PERSIST_TTL_S"] = "60"
+        try:
+            p = _tmp()
+            CB._write_breaker_state("open", 3, reason="economic", path=p, now_wall=time.time() - 3600)
+            b = ClaudeCircuitBreaker(persist_path=p)
+            self.assertIs(b.state, CircuitState.CLOSED)  # stale → re-probe Claude
+        finally:
+            os.environ.pop("JARVIS_CLAUDE_BREAKER_PERSIST_TTL_S", None)
+
+    def test_economic_trip_persists_state(self):
+        os.environ["JARVIS_CLAUDE_BREAKER_PERSIST_ENABLED"] = "1"
+        os.environ["JARVIS_CLAUDE_ECONOMIC_BREAKER_ENABLED"] = "1"
+        p = _tmp()
+        b = ClaudeCircuitBreaker(persist_path=p)
+        b.record_economic_exhaustion("test")  # threshold default 1 → trips OPEN
+        self.assertIs(b.state, CircuitState.OPEN)
+        self.assertEqual(CB._read_breaker_state(path=p, now_wall=time.time(), ttl_s=86400), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The breaker resets CLOSED every boot, so a credit-dead Claude is re-learned from scratch each relaunch and the first ops exhaust before the Slice 161/162 protections engage - the residual cold-start. Fix: persist the economic-OPEN state to host-local .jarvis with a wall-clock timestamp; restore OPEN at boot when recent (within JARVIS_CLAUDE_BREAKER_PERSIST_TTL_S, default 24h). Recovery window restarts from boot so a since-funded lane self-heals. Gated JARVIS_CLAUDE_BREAKER_PERSIST_ENABLED default-FALSE. Protections warm from op #1 - no funding, no workaround. 9 tests; clean in isolation (combined pollution pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the Claude circuit breaker’s economic OPEN state to disk and restore it on boot to remove the cold-start. Protections are active from the first request and lanes still self-heal after funding.

- **New Features**
  - Persist economic OPEN to `.jarvis/claude_breaker_state.json` (atomic JSON with wall-clock timestamp).
  - Restore OPEN at boot when recent within `JARVIS_CLAUDE_BREAKER_PERSIST_TTL_S` (default 24h).
  - Gate via `JARVIS_CLAUDE_BREAKER_PERSIST_ENABLED` (default false); path via `JARVIS_CLAUDE_BREAKER_PERSIST_PATH` or `JARVIS_STATE_DIR`.
  - Persist on trip and clear on recovery; recovery window restarts from boot.
  - Added tests for read/write, TTL, gating, restore, and persistence.

- **Migration**
  - To enable, set `JARVIS_CLAUDE_BREAKER_PERSIST_ENABLED=1`.
  - Optionally set `JARVIS_CLAUDE_BREAKER_PERSIST_TTL_S` and `JARVIS_CLAUDE_BREAKER_PERSIST_PATH` (or `JARVIS_STATE_DIR`).

<sup>Written for commit 319171a77552284ed57f37c00fcb1ec735ac9385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

