### PR TITLE
Slice 166 - injection target fidelity (natural-risk validation)

### DIFF
--- a/backend/core/ouroboros/governance/event_channel.py
+++ b/backend/core/ouroboros/governance/event_channel.py
@@ -70,6 +70,29 @@ class ChannelEvent:
     signature_valid: bool = True
 
 
+def _generic_classification(payload, source, event_type):
+    """Slice 166 — classify a generic (non-github/ci) channel event, honoring an
+    explicit ``target_files`` + ``description`` from the payload (injection fidelity).
+
+    An injected op can thus declare its REAL target, so the organism's own
+    governance_boundary_gate evaluates the true file set — e.g. an op touching the
+    governance cage (backend/core/ouroboros/governance/) is elevated to
+    APPROVAL_REQUIRED BY NATURE. Falls back to the broad ``("backend/",)`` default and
+    a synthesized description when unspecified. Pure + fail-soft. Returns
+    ``(urgency, description, target_files, repo)``."""
+    targets = payload.get("target_files") if isinstance(payload, dict) else None
+    if isinstance(targets, (list, tuple)) and targets:
+        resolved = tuple(str(t) for t in targets if str(t).strip())
+    else:
+        resolved = ()
+    desc = ""
+    if isinstance(payload, dict):
+        desc = str(payload.get("description") or "")
+    if not desc:
+        desc = f"{source} event: {event_type}"
+    return ("normal", desc, resolved or ("backend/",), "jarvis")
+
+
 @dataclass
 class ChannelStats:
     """Cumulative channel statistics."""
@@ -1552,13 +1575,8 @@ class EventChannelServer:
                 "jarvis",
             )
 
-        # Generic fallback
-        return (
-            "normal",
-            f"{event.source} event: {event.event_type}",
-            ("backend/",),
-            "jarvis",
-        )
+        # Generic fallback — Slice 166: honor explicit payload target_files / description
+        return _generic_classification(event.payload, event.source, event.event_type)
 
     @staticmethod
     def _repo_from_github(full_name: str) -> str:

--- a/tests/governance/test_slice166_injection_target_fidelity.py
+++ b/tests/governance/test_slice166_injection_target_fidelity.py
@@ -1,0 +1,43 @@
+"""Slice 166 — injection target fidelity (enables natural-risk validation).
+
+The generic /webhook/generic ingress hardcoded target_files=("backend/",), so an
+injected op could not declare its REAL target. That blocked the natural-risk path: an
+op attempting to modify the governance cage (backend/core/ouroboros/governance/) must
+carry that target for the organism's own governance_boundary_gate to elevate it to
+APPROVAL_REQUIRED by nature. This honors an explicit target_files (and description)
+from the payload — composable injection fidelity, NOT a forced floor.
+"""
+from __future__ import annotations
+
+import unittest
+
+from backend.core.ouroboros.governance.event_channel import _generic_classification
+
+
+class TestGenericClassification(unittest.TestCase):
+    def test_honors_explicit_target_files(self):
+        urgency, desc, targets, repo = _generic_classification(
+            {"target_files": ["backend/core/ouroboros/governance/semantic_guardian.py"]},
+            "intrusion", "rewrite the guardian",
+        )
+        self.assertEqual(targets, ("backend/core/ouroboros/governance/semantic_guardian.py",))
+
+    def test_defaults_when_absent(self):
+        _, _, targets, _ = _generic_classification({}, "s", "t")
+        self.assertEqual(targets, ("backend/",))
+
+    def test_honors_explicit_description(self):
+        _, desc, _, _ = _generic_classification({"description": "custom intent"}, "s", "t")
+        self.assertEqual(desc, "custom intent")
+
+    def test_synthesizes_description_when_absent(self):
+        _, desc, _, _ = _generic_classification({}, "intrusion", "do X")
+        self.assertEqual(desc, "intrusion event: do X")
+
+    def test_ignores_garbage_target_files(self):
+        _, _, targets, _ = _generic_classification({"target_files": "not-a-list"}, "s", "t")
+        self.assertEqual(targets, ("backend/",))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The generic webhook hardcoded target_files=('backend/',), so an injected op couldn't declare its real target - blocking the natural-risk path (a cage-touching op must carry that target for governance_boundary_gate to elevate it by nature). `_generic_classification` now honors explicit payload target_files + description (composable fidelity, NOT a forced floor); defaults preserved. A cage-touching op trips BOUNDARY_CROSSED naturally → approval card; trivial ops still auto-apply. 5 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generic webhook events now honor explicit `target_files` and `description` (Slice 166), enabling natural-risk elevation when an injected op targets governance files. Defaults are preserved so trivial ops still auto-apply.

- **New Features**
  - Added `_generic_classification` to read payload `target_files` and `description`, with fallback to `("backend/",)` and a synthesized description.
  - Wired the new helper into the generic `_classify_event` path to let `governance_boundary_gate` evaluate real targets.
  - Ignores invalid `target_files` input safely.
  - Added 5 tests covering targets, defaults, and description behavior.

<sup>Written for commit 98691d4b462d1371265a0a8698d07aa472862cc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

