### PR TITLE
Slice 170 - intra-DW transport failover (stop the Claude cost cascade)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -349,6 +349,21 @@ def _force_batch_on_breaker_enabled() -> bool:
         not in ("0", "false", "no", "off")
 
 
+_INTRA_DW_FAILOVER_ENV: str = "JARVIS_DW_INTRA_TRANSPORT_FAILOVER_ENABLED"
+
+
+def _slice170_intra_dw_failover_enabled() -> bool:
+    """Master for the Slice 170 intra-DW transport failover. Default **TRUE**
+    (failure-path-only: only fires when the surface-health ledger reports the DW
+    streaming wire degraded AND the batch lane healthy — it cannot affect the
+    stream-healthy happy path). When ON, a DW transport rupture fails over to DW-batch
+    instead of cascading to the expensive Claude fallback, keeping the FUNDED primary
+    primary. =0 reverts to the legacy cascade-to-Claude-when-available behaviour.
+    NEVER raises."""
+    return os.environ.get(_INTRA_DW_FAILOVER_ENV, "true").strip().lower() \
+        not in ("0", "false", "no", "off")
+
+
 def _claude_breaker_open(getter: Any = None) -> bool:
     """Slice 161 — True iff the Claude breaker is NOT CLOSED (OPEN or HALF_OPEN), i.e.
     Claude is unreliable as a fallback, so STANDARD/COMPLEX ops must force the DW batch
@@ -392,10 +407,30 @@ def _slice36_should_force_batch(context: Any) -> bool:
     failure (returns False = preserve legacy RT behavior).
     """
     try:
-        # Claude must be disabled — Slice 36 is the "pure-DW
-        # production" path optimization. With Claude available, RT
-        # failures cascade to Claude fallback and the empirical
-        # cost-benefit shifts.
+        # Route gate — only STANDARD + COMPLEX get the batch path (IMMEDIATE / BG /
+        # SPECULATIVE keep RT: small prompts + Venom value).
+        _route = (
+            getattr(context, "provider_route", "") or ""
+        ).strip().lower()
+        _route_ok = _route in ("standard", "complex")
+
+        # Slice 170 — intra-DW transport failover PRECEDES the cross-provider cascade.
+        # The economic leak: a DW streaming rupture (mislabeled live_transport) cascades
+        # to the expensive Claude fallback whenever Claude has credit — so DW, the FUNDED
+        # primary, only stays primary when Claude is broke. But a rupture is transport-
+        # specific: DW's batch lane serves the identical request stream-free. When the
+        # surface-health ledger shows the streaming wire degraded AND batch healthy (the
+        # Slice 41 signal), force DW-batch REGARDLESS of Claude availability — the rupture
+        # fails over WITHIN DW, not to Claude. Claude remains the fallback for genuine
+        # DW-WIDE outages (both surfaces degraded), not transport blips. Failure-path-only
+        # (fires solely on a degraded stream) → default-ON, §33.1.
+        if _route_ok and _slice170_intra_dw_failover_enabled() and _slice41_ledger_force_batch():
+            return True
+
+        # Legacy pure-DW batch optimization: requires Claude unavailable. With Claude
+        # available + a HEALTHY stream, RT failures cascade to Claude fallback and the
+        # empirical cost-benefit shifts (the Slice 170 block above is the exception — a
+        # DEGRADED stream fails over to DW-batch first).
         _claude_disabled = os.environ.get(
             "JARVIS_PROVIDER_CLAUDE_DISABLED", "",
         ).strip().lower() in ("1", "true", "yes", "on")
@@ -409,11 +444,7 @@ def _slice36_should_force_batch(context: Any) -> bool:
         )
         if not _claude_unavailable:
             return False
-        # Route gate — only STANDARD + COMPLEX get the batch path
-        _route = (
-            getattr(context, "provider_route", "") or ""
-        ).strip().lower()
-        if _route not in ("standard", "complex"):
+        if not _route_ok:
             return False
         # Slice 36 static opt-out (default ON per operator authorization).
         _raw = os.environ.get(_SLICE36_FORCE_BATCH_ENV, "1").strip().lower()

--- a/tests/governance/test_slice170_intra_dw_transport_failover.py
+++ b/tests/governance/test_slice170_intra_dw_transport_failover.py
@@ -1,0 +1,69 @@
+"""Slice 170 — intra-DW transport failover precedes the cross-provider cascade.
+
+The economic leak (operator, 2026-06-08): DW is the FUNDED primary, yet a DW streaming
+rupture (TransferEncodingError, mislabeled live_transport) cascades to the expensive
+Claude fallback and burns money — DW is only "primary" when Claude is broke. Root cause
+in _slice36_should_force_batch:
+
+    if not _claude_unavailable:
+        return False   # Claude available → RT failures cascade to Claude
+
+So DW only fails over to its OWN batch transport when Claude is dead. But a rupture is
+transport-specific: DW's batch lane serves the identical request stream-free.
+
+Fix: when the surface-health ledger shows the streaming wire degraded AND the batch lane
+healthy (the existing _slice41 signal), force DW-batch REGARDLESS of Claude availability
+— a transport rupture fails over WITHIN DW (the funded primary), not to Claude. Claude
+remains the fallback for genuine DW-WIDE outages (both surfaces degraded), not blips.
+"""
+from __future__ import annotations
+
+import backend.core.ouroboros.governance.doubleword_provider as DW
+
+
+class _Ctx:
+    def __init__(self, route):
+        self.provider_route = route
+
+
+def _claude_available(monkeypatch):
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)
+    monkeypatch.setattr(DW, "_claude_breaker_open", lambda *a, **k: False)
+
+
+def test_rupture_forces_dw_batch_even_when_claude_available(monkeypatch):
+    _claude_available(monkeypatch)
+    monkeypatch.delenv("JARVIS_DW_INTRA_TRANSPORT_FAILOVER_ENABLED", raising=False)
+    monkeypatch.setattr(DW, "_slice41_ledger_force_batch", lambda: True)  # stream degraded, batch healthy
+    # NEW: intra-DW failover keeps the op on DW instead of cascading to Claude
+    assert DW._slice36_should_force_batch(_Ctx("standard")) is True
+    assert DW._slice36_should_force_batch(_Ctx("complex")) is True
+
+
+def test_healthy_stream_with_claude_available_stays_rt(monkeypatch):
+    _claude_available(monkeypatch)
+    monkeypatch.setattr(DW, "_slice41_ledger_force_batch", lambda: False)  # stream healthy
+    # unchanged: no degradation → RT path (Claude is a fine safety net for a true outage)
+    assert DW._slice36_should_force_batch(_Ctx("standard")) is False
+
+
+def test_route_gate_still_applies_to_failover(monkeypatch):
+    _claude_available(monkeypatch)
+    monkeypatch.setattr(DW, "_slice41_ledger_force_batch", lambda: True)
+    # IMMEDIATE/BG/SPECULATIVE are not batch-routed even on degradation
+    assert DW._slice36_should_force_batch(_Ctx("immediate")) is False
+
+
+def test_failover_respects_kill_switch(monkeypatch):
+    _claude_available(monkeypatch)
+    monkeypatch.setenv("JARVIS_DW_INTRA_TRANSPORT_FAILOVER_ENABLED", "0")
+    monkeypatch.setattr(DW, "_slice41_ledger_force_batch", lambda: True)
+    # gated off → legacy behaviour (cascade to Claude)
+    assert DW._slice36_should_force_batch(_Ctx("standard")) is False
+
+
+def test_claude_dead_path_unchanged(monkeypatch):
+    # regression: the existing pure-DW path (Claude disabled) still forces batch
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    monkeypatch.setattr(DW, "_slice41_ledger_force_batch", lambda: False)
+    assert DW._slice36_should_force_batch(_Ctx("standard")) is True

--- a/tests/governance/test_slice41_batch_aware_fleet.py
+++ b/tests/governance/test_slice41_batch_aware_fleet.py
@@ -229,8 +229,21 @@ def test_force_batch_ledger_overrides_static_optout(monkeypatch, tmp_path):
     assert _slice36_should_force_batch(_Ctx("immediate")) is False
 
 
-def test_force_batch_requires_claude_disabled(monkeypatch, tmp_path):
+def test_degraded_stream_forces_batch_even_with_claude_available(monkeypatch, tmp_path):
+    # Slice 170 — intra-DW transport failover. A degraded streaming wire + healthy batch
+    # lane now forces DW-batch EVEN when Claude is available, so a transport rupture fails
+    # over within DW instead of cascading to the expensive Claude fallback. (Pre-170 this
+    # asserted False — "force_batch requires Claude disabled" — which was the cost leak.)
     monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "false")
     _seed_ledger(monkeypatch, tmp_path,
                  stream=SurfaceVerdict.UPSTREAM_DEGRADED, batch=SurfaceVerdict.HEALTHY)
+    assert _slice36_should_force_batch(_Ctx("standard")) is True
+
+
+def test_healthy_stream_still_requires_claude_disabled(monkeypatch, tmp_path):
+    # The legacy invariant still holds for a HEALTHY stream: with Claude available and no
+    # degradation, RT failures may cascade to Claude (Slice 170 fires only on a rupture).
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "false")
+    _seed_ledger(monkeypatch, tmp_path,
+                 stream=SurfaceVerdict.HEALTHY, batch=SurfaceVerdict.HEALTHY)
     assert _slice36_should_force_batch(_Ctx("standard")) is False


### PR DESCRIPTION
The economic leak: DW is the funded primary, but a DW streaming rupture (mislabeled live_transport) cascades to the expensive Claude fallback whenever Claude has credit - `if not _claude_unavailable: return False` means DW only fails over to its own batch transport when Claude is dead. A rupture is transport-specific (DW batch serves it stream-free). Fix: consult the existing _slice41 signal (stream degraded + batch healthy) BEFORE the Claude-availability gate, so a rupture fails over WITHIN DW even when Claude is available. Claude stays the fallback for genuine DW-wide outages. Default-ON, failure-path-only. 6 tests + updated the Slice 41 test that encoded the old leak; 49 regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the Claude cost cascade by failing over within DW when the streaming wire is degraded; DW now switches to DW-batch (not Claude) when batch is healthy. Default on; only affects failure paths.

- **Bug Fixes**
  - In `_slice36_should_force_batch`, consult `_slice41_ledger_force_batch` before the Claude gate; if stream is degraded and batch healthy, force DW-batch for `standard`/`complex` routes even when Claude is available.
  - Added `_slice170_intra_dw_failover_enabled` via `JARVIS_DW_INTRA_TRANSPORT_FAILOVER_ENABLED` (default `true`) as a kill switch; healthy-stream behavior unchanged and the route gate is preserved.
  - Tests: new `test_slice170_intra_dw_transport_failover.py`; updated `test_slice41_batch_aware_fleet.py` to reflect the new degraded-stream behavior.

<sup>Written for commit 6bfec42ebc55069547f08a9e34dfe3de9d046ff3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

