### PR TITLE
fix(docker): exclude untracked model/build bulk (~20GB) from soak context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -111,3 +111,32 @@ credentials/
 .ouroboros/**
 *.debug.log
 **/sessions/**
+
+# ── Untracked BULK that ballooned the build-context transfer to ~20GB when built
+# from a working checkout (the git-TRACKED source is only ~49MB). All of this is
+# gitignored data / build artifacts / model weights the soak image never needs —
+# we exclude the BULK while keeping the tracked .py source (vision/ has 119 tracked
+# source files the governance loop imports, buried in GB of artifacts). ──
+model_checkpoints/
+**/model_checkpoints/
+venv/
+**/venv/
+**/logs/
+**/target/                # rust/cargo build output (vision/jarvis-rust-core ≈ 4.3GB)
+**/.build/                # swift build output
+**/build/
+**/dist/
+**/.pytest_cache/
+**/.mypy_cache/
+# model weights / large binaries — never source
+*.pt
+*.pth
+*.onnx
+*.safetensors
+*.gguf
+*.rlib
+*.rmeta
+*.dylib
+*.a
+*.mlmodel
+*.mlmodelc


### PR DESCRIPTION
Excludes the gitignored bulk (vision rust/model artifacts, logs, venvs, checkpoints — ~20GB) from the build context while keeping the ~49MB tracked source. Soak buildable from any checkout. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrink Docker build context for soak builds by ignoring untracked bulk artifacts (models, logs, venvs, build outputs). Keeps only the tracked source.

- **Bug Fixes**
  - Added `.dockerignore` patterns for checkpoints, `venv`, logs, Rust/Swift build dirs (`target`, `.build`, `build`, `dist`), caches, and large model binaries (`*.pt`, `*.onnx`, `*.safetensors`, `*.gguf`, etc.).
  - Cuts build-context transfer from ~20GB to ~49MB and allows building from any working checkout.

<sup>Written for commit 3e00cfaece74b167e92920e246c2abfc8f6e7f60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

