### PR TITLE
Slice 177 - artifact janitor (autonomous workspace hygiene)

### DIFF
--- a/backend/core/ouroboros/governance/artifact_janitor.py
+++ b/backend/core/ouroboros/governance/artifact_janitor.py
@@ -1,0 +1,135 @@
+"""Slice 177 — autonomous workspace hygiene (the artifact janitor).
+
+The organism accumulates GBs of untracked bloat: `.ouroboros/` session logs, stray model
+checkpoints, vision caches. The Slice-176 `.dockerignore` stopped that polluting the build
+context, but that's a deployment band-aid — this is the root-cause cleanup: a janitor that
+COMPRESSES aging logs and PRUNES ancient artifacts on a strict age policy.
+
+Hard safety invariants:
+  * Operates ONLY within whitelisted artifact directories (never source, never the repo at
+    large). os.walk is rooted at each configured scan dir.
+  * Age-gated — a recent file (the active session's live debug.log) is never touched.
+  * Explicit ``protect_paths`` (e.g. the current session dir) are skipped even if ancient.
+  * Every operation is exception-isolated; sweep() NEVER raises (a janitor must not break
+    the loop it serves).
+
+Gated default-FALSE (§33.1 — it DELETES files; opt-in only). Run as a deferred once-per-boot
+maintenance task (or during deep idle), never a hot loop — no GIL contention.
+"""
+from __future__ import annotations
+
+import gzip
+import os
+import shutil
+import time
+from typing import Any, Dict, List, Optional
+
+_ENV_ENABLED = "JARVIS_ARTIFACT_JANITOR_ENABLED"
+_ENV_COMPRESS_DAYS = "JARVIS_ARTIFACT_COMPRESS_AGE_DAYS"
+_ENV_DELETE_DAYS = "JARVIS_ARTIFACT_DELETE_AGE_DAYS"
+_ENV_SCAN_DIRS = "JARVIS_ARTIFACT_SCAN_DIRS"
+
+_DAY = 86400.0
+_DEFAULT_COMPRESS_DAYS = 7.0
+_DEFAULT_DELETE_DAYS = 30.0
+_DEFAULT_SCAN_DIRS = ".ouroboros,model_checkpoints,backend/logs"
+_COMPRESSIBLE_SUFFIXES = (".log", ".jsonl", ".txt", ".out")
+_ALREADY_COMPRESSED = (".gz", ".tar.gz", ".zip", ".bz2", ".xz")
+
+
+def artifact_janitor_enabled() -> bool:
+    """Master gate — default **FALSE** (§33.1: deletes files). NEVER raises."""
+    return os.environ.get(_ENV_ENABLED, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _envf(name: str, default: float) -> float:
+    try:
+        raw = os.environ.get(name, "").strip()
+        v = float(raw) if raw else default
+        return v if v > 0 else default
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _default_scan_dirs() -> List[str]:
+    raw = os.environ.get(_ENV_SCAN_DIRS, "").strip() or _DEFAULT_SCAN_DIRS
+    base = os.environ.get("JARVIS_STATE_DIR", "").strip()
+    out: List[str] = []
+    for d in raw.split(","):
+        d = d.strip()
+        if not d:
+            continue
+        out.append(os.path.join(base, d) if base and not os.path.isabs(d) else d)
+    return out
+
+
+class ArtifactJanitor:
+    """Age-policy compressor/pruner over whitelisted artifact directories. NEVER raises."""
+
+    def __init__(
+        self, *,
+        scan_dirs: Optional[List[str]] = None,
+        compress_age_days: Optional[float] = None,
+        delete_age_days: Optional[float] = None,
+        protect_paths: Optional[List[str]] = None,
+    ) -> None:
+        self._scan_dirs = [str(d) for d in (scan_dirs if scan_dirs is not None else _default_scan_dirs())]
+        self._compress_age = (
+            compress_age_days if compress_age_days is not None else _envf(_ENV_COMPRESS_DAYS, _DEFAULT_COMPRESS_DAYS)
+        ) * _DAY
+        self._delete_age = (
+            delete_age_days if delete_age_days is not None else _envf(_ENV_DELETE_DAYS, _DEFAULT_DELETE_DAYS)
+        ) * _DAY
+        self._protect = [os.path.abspath(p) for p in (protect_paths or [])]
+
+    def _is_protected(self, path: str) -> bool:
+        ap = os.path.abspath(path)
+        return any(ap == p or ap.startswith(p + os.sep) for p in self._protect)
+
+    @staticmethod
+    def _is_compressible(fn: str) -> bool:
+        low = fn.lower()
+        return low.endswith(_COMPRESSIBLE_SUFFIXES) and not low.endswith(_ALREADY_COMPRESSED)
+
+    def _gzip_in_place(self, path: str, mtime: float) -> None:
+        gz = path + ".gz"
+        with open(path, "rb") as fi, gzip.open(gz, "wb") as fo:
+            shutil.copyfileobj(fi, fo)
+        os.utime(gz, (mtime, mtime))   # the archive ages from the original's date
+        os.remove(path)
+
+    def sweep(self, now: Optional[float] = None) -> Dict[str, Any]:
+        """Compress logs older than compress_age, hard-delete anything older than delete_age,
+        within the whitelisted scan dirs only. Returns a report. NEVER raises."""
+        now = time.time() if now is None else float(now)
+        report: Dict[str, Any] = {
+            "compressed": 0, "deleted": 0, "freed_bytes": 0, "scanned": 0, "errors": 0,
+        }
+        for d in self._scan_dirs:
+            try:
+                if not os.path.isdir(d):
+                    continue
+                for root, _dirs, files in os.walk(d):
+                    for fn in files:
+                        path = os.path.join(root, fn)
+                        try:
+                            if self._is_protected(path):
+                                continue
+                            st = os.stat(path)
+                            age = now - st.st_mtime
+                            report["scanned"] += 1
+                            if age > self._delete_age:
+                                size = st.st_size
+                                os.remove(path)
+                                report["deleted"] += 1
+                                report["freed_bytes"] += size
+                            elif age > self._compress_age and self._is_compressible(fn):
+                                size = st.st_size
+                                self._gzip_in_place(path, st.st_mtime)
+                                report["freed_bytes"] += max(0, size - os.path.getsize(path + ".gz"))
+                                report["compressed"] += 1
+                        except Exception:  # noqa: BLE001 — never let one file abort the sweep
+                            report["errors"] += 1
+            except Exception:  # noqa: BLE001 — never let one dir abort the sweep
+                report["errors"] += 1
+        return report

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1563,6 +1563,47 @@ class GovernedLoopService:
                     "swallowed: %r", _cr_exc,
                 )
 
+            # Slice 177 — autonomous workspace hygiene. Fire a DEFERRED, once-per-boot
+            # artifact sweep (compress aging logs, prune ancient artifacts) on a WORKER
+            # THREAD via asyncio.to_thread, so the blocking file I/O never touches the
+            # event loop or contends the GIL on the hot path. Gated default-FALSE
+            # (§33.1 — it deletes files); the active session dir is explicitly protected
+            # (and the age-gate already shields recent/live files). NEVER raises.
+            try:
+                from backend.core.ouroboros.governance.artifact_janitor import (  # noqa: E501
+                    artifact_janitor_enabled,
+                    ArtifactJanitor,
+                )
+                if artifact_janitor_enabled():
+                    import asyncio as _aio_jan
+                    _protect = []
+                    _sess = getattr(self, "_session_dir", None) \
+                        or os.environ.get("JARVIS_OUROBOROS_SESSION_DIR", "").strip()
+                    if _sess:
+                        _protect.append(str(_sess))
+
+                    async def _janitor_boot_sweep() -> None:
+                        try:
+                            _rep = await _aio_jan.to_thread(
+                                ArtifactJanitor(protect_paths=_protect).sweep
+                            )
+                            logger.info(
+                                "[GovernedLoop] artifact janitor: compressed=%s "
+                                "deleted=%s freed=%.1fMB errors=%s",
+                                _rep.get("compressed"), _rep.get("deleted"),
+                                _rep.get("freed_bytes", 0) / 1e6, _rep.get("errors"),
+                            )
+                        except Exception as _je:  # noqa: BLE001
+                            logger.debug("[GovernedLoop] janitor sweep swallowed: %r", _je)
+
+                    self._janitor_task = _aio_jan.create_task(_janitor_boot_sweep())
+                    logger.info(
+                        "[GovernedLoop] artifact janitor: deferred boot sweep scheduled "
+                        "(off-thread; active session protected)",
+                    )
+            except Exception as _jx:  # noqa: BLE001
+                logger.debug("[GovernedLoop] artifact janitor boot swallowed: %r", _jx)
+
         except Exception as exc:
             self._state = ServiceState.FAILED
             self._failure_reason = str(exc)

--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -61,10 +61,21 @@ services:
       - ./.jarvis:/app/.jarvis
     # The battle-test loop IS the supervisor (headless, no wall cap; restart:always
     # gives longevity). Cost cap is the only ceiling — DW is cheap, so $25 lasts.
-    command: >-
-      python3 scripts/ouroboros_battle_test.py
-      --production-soak --headless
-      --cost-cap 25 --idle-timeout 0 --max-wall-seconds 0
+    # entrypoint OVERRIDE: the image's default ENTRYPOINT is launch_shadow_soak.sh
+    # (which verifies Docker — wrong for an in-container cortex run); run the
+    # battle-test directly via python3, matching the working `--entrypoint python3`
+    # manual launches.
+    entrypoint: ["python3"]
+    command:
+      - scripts/ouroboros_battle_test.py
+      - --production-soak
+      - --headless
+      - --cost-cap
+      - "25"
+      - --idle-timeout
+      - "0"
+      - --max-wall-seconds
+      - "0"
     deploy:
       resources:
         limits:

--- a/tests/governance/test_slice177_artifact_janitor.py
+++ b/tests/governance/test_slice177_artifact_janitor.py
@@ -1,0 +1,122 @@
+"""Slice 177 — autonomous workspace hygiene (the artifact janitor).
+
+The organism accumulates ~20GB of untracked bloat (session logs, stray checkpoints,
+caches). The .dockerignore stopped it polluting the build context, but that's a deployment
+band-aid — this is the root-cause cleanup: a janitor that compresses aging logs and prunes
+ancient artifacts, on a strict age policy, WITHOUT ever touching an active FSM target or any
+file outside its whitelisted artifact directories.
+"""
+from __future__ import annotations
+
+import gzip
+import os
+import time
+import unittest
+import tempfile
+
+from backend.core.ouroboros.governance.artifact_janitor import ArtifactJanitor
+
+_DAY = 86400.0
+
+
+def _touch(path, *, age_days, content=b"x" * 1024):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as fh:
+        fh.write(content)
+    mt = time.time() - age_days * _DAY
+    os.utime(path, (mt, mt))
+    return path
+
+
+class TestRotationPolicy(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.logs = os.path.join(self.root, ".ouroboros")
+        self.now = time.time()
+
+    def _janitor(self, **kw):
+        return ArtifactJanitor(
+            scan_dirs=[self.logs], compress_age_days=7, delete_age_days=30, **kw
+        )
+
+    def test_old_log_compressed(self):
+        f = _touch(os.path.join(self.logs, "s1", "debug.log"), age_days=10)  # >7, <30
+        rep = self._janitor().sweep(now=self.now)
+        self.assertFalse(os.path.exists(f))                 # original gone
+        self.assertTrue(os.path.exists(f + ".gz"))          # compressed
+        self.assertGreaterEqual(rep["compressed"], 1)
+        with gzip.open(f + ".gz", "rb") as g:               # content preserved
+            self.assertEqual(g.read(), b"x" * 1024)
+
+    def test_ancient_file_deleted(self):
+        f = _touch(os.path.join(self.logs, "old", "debug.log"), age_days=45)  # >30
+        rep = self._janitor().sweep(now=self.now)
+        self.assertFalse(os.path.exists(f))
+        self.assertFalse(os.path.exists(f + ".gz"))         # deleted, not compressed
+        self.assertGreaterEqual(rep["deleted"], 1)
+
+    def test_recent_active_file_untouched(self):
+        f = _touch(os.path.join(self.logs, "live", "debug.log"), age_days=1)  # <7 → fresh
+        self._janitor().sweep(now=self.now)
+        self.assertTrue(os.path.exists(f))                  # the active session is SAFE
+        self.assertFalse(os.path.exists(f + ".gz"))
+
+    def test_protected_path_never_touched(self):
+        f = _touch(os.path.join(self.logs, "current", "debug.log"), age_days=99)  # ancient
+        # but it's the ACTIVE session → protected → must survive even though ancient
+        self._janitor(protect_paths=[os.path.join(self.logs, "current")]).sweep(now=self.now)
+        self.assertTrue(os.path.exists(f))
+
+    def test_already_compressed_not_recompressed(self):
+        f = _touch(os.path.join(self.logs, "s2", "old.log.gz"), age_days=10)
+        rep = self._janitor().sweep(now=self.now)
+        self.assertTrue(os.path.exists(f))                  # left alone (already .gz, <30d)
+        self.assertEqual(rep["compressed"], 0)
+
+    def test_never_scans_outside_whitelist(self):
+        # a file OUTSIDE the scan dirs (e.g. source) is never touched even if ancient
+        src = _touch(os.path.join(self.root, "backend", "core", "x.py"), age_days=99)
+        self._janitor().sweep(now=self.now)
+        self.assertTrue(os.path.exists(src))
+
+    def test_disabled_by_default(self):
+        import backend.core.ouroboros.governance.artifact_janitor as J
+        os.environ.pop("JARVIS_ARTIFACT_JANITOR_ENABLED", None)
+        self.assertFalse(J.artifact_janitor_enabled())
+
+    def test_report_totals(self):
+        _touch(os.path.join(self.logs, "a", "debug.log"), age_days=10)
+        _touch(os.path.join(self.logs, "b", "debug.log"), age_days=45)
+        rep = self._janitor().sweep(now=self.now)
+        self.assertEqual(rep["compressed"], 1)
+        self.assertEqual(rep["deleted"], 1)
+        self.assertGreater(rep["freed_bytes"], 0)
+
+    def test_never_raises_on_missing_dir(self):
+        j = ArtifactJanitor(scan_dirs=["/nonexistent/path/xyz"], compress_age_days=7, delete_age_days=30)
+        self.assertEqual(j.sweep(now=self.now)["compressed"], 0)  # no crash
+
+
+class TestGLSWiring(unittest.TestCase):
+    def _gls_src(self):
+        import importlib.util
+        spec = importlib.util.find_spec(
+            "backend.core.ouroboros.governance.governed_loop_service"
+        )
+        with open(spec.origin) as fh:
+            return fh.read()
+
+    def test_janitor_wired_deferred_offthread_gated(self):
+        src = self._gls_src()
+        self.assertIn("artifact_janitor_enabled", src)        # gated
+        self.assertIn("to_thread", src)                       # off the event loop (no GIL stall)
+        self.assertIn("create_task", src)                     # deferred, doesn't block boot
+        self.assertIn("protect_paths", src)                   # active session protected
+        # the sweep must be guarded by the master flag
+        i_gate = src.find("artifact_janitor_enabled()")
+        i_task = src.find("_janitor_boot_sweep")
+        self.assertTrue(0 < i_gate < i_task)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Root-cause fix for the ~20GB repo bloat. ArtifactJanitor compresses aging logs (>7d→.gz) + prunes ancient artifacts (>30d) within whitelisted dirs only, age-gated, active-session-protected, never-raises. Wired into GLS.start() as a deferred once-per-boot off-thread sweep (asyncio.to_thread — no GIL stall). Gated default-FALSE. Also fixes the compose entrypoint (dry-run showed launch_shadow_soak.sh wasn't overridden → added entrypoint: [python3]). Boot verdict: container RUNNING, cortex env active, no tracebacks. 10 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an autonomous artifact janitor to stop ~20GB workspace bloat by compressing aging logs and pruning stale artifacts. Runs once per boot off-thread, protected and gated off by default; also fixes the soak compose entrypoint. Implements Slice 177.

- New Features
  - `ArtifactJanitor` compresses logs older than 7d to `.gz` and deletes artifacts older than 30d within whitelisted dirs (`.ouroboros`, `model_checkpoints`, `backend/logs`); never touches source and never raises.
  - Integrated into `GovernedLoopService` as a deferred, once-per-boot sweep via `asyncio.to_thread`; active session is protected via `protect_paths`; gated by `JARVIS_ARTIFACT_JANITOR_ENABLED` (default false). Tests cover compress/prune/protection/whitelist and wiring.

- Bug Fixes
  - Override `docker-compose.dw-cortex-soak.yml` entrypoint to `["python3"]` so the battle test runs directly; the image’s default entrypoint wasn’t overridden by `command`.

<sup>Written for commit dccf8d51ec6056a4932f4511a5a696682b8a4491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

