### PR TITLE
Slice 184 - the cold-start seal (fail-SAFE, not fail-RT)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3242,6 +3242,7 @@ class CandidateGenerator:
                 _dw_streaming_warm_degraded as _s182_warm,
                 _dw_rupture_risk_high as _s182_risk,
                 _dw_batch_lane_healthy as _s182_batch_ok,
+                _dw_in_cold_start as _s184_cold,
             )
             # Slice 183 — LIVE TELEMETRY PROBE. Capture the EXACT boolean state of every
             # sub-gate AND the final computed decision, UNCONDITIONALLY (before the if), so the
@@ -3251,11 +3252,14 @@ class CandidateGenerator:
             _g_batch = bool(_s182_batch_ok())
             _g_warm = bool(_s182_warm())
             _g_risk = bool(_s182_risk(""))
-            _s182_force_batch = _g_route_ok and _g_batch and (_g_warm or _g_risk)
+            # Slice 184 — cold-start is a degradation TRIGGER: at fresh boot the stream is
+            # unproven, so the sentinel commands batch (fail-safe) even when warm/risk are blind.
+            _g_cold = bool(_s184_cold())
+            _s182_force_batch = _g_route_ok and _g_batch and (_g_warm or _g_risk or _g_cold)
             logger.warning(
                 "[Slice183] dispatch-telemetry: op=%s route=%r route_ok=%s "
-                "batch_lane_healthy=%s warm_degraded=%s rupture_risk=%s → FORCE_BATCH=%s",
-                op_id_short, provider_route, _g_route_ok, _g_batch, _g_warm, _g_risk,
+                "batch_lane_healthy=%s warm_degraded=%s rupture_risk=%s cold_start=%s → FORCE_BATCH=%s",
+                op_id_short, provider_route, _g_route_ok, _g_batch, _g_warm, _g_risk, _g_cold,
                 _s182_force_batch,
             )
             if _s182_force_batch:

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -523,6 +523,41 @@ def reset_sentinel_force_batch(token) -> None:
         pass
 
 
+# Slice 184 — COLD-START SEAL. Process-scoped boot time (module-load ≈ process start).
+_PROCESS_START = time.monotonic()
+
+
+def dw_cold_start_enabled() -> bool:
+    """Slice 184 — master for the cold-start seal. Default **TRUE** (failure-path-only: only
+    forces batch during the boot window). NEVER raises."""
+    return os.environ.get("JARVIS_DW_COLDSTART_ENABLED", "true").strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
+def _dw_cold_start_window_s() -> float:
+    """Seconds after process start during which the stream is treated as UNPROVEN. NEVER raises."""
+    try:
+        raw = os.environ.get("JARVIS_DW_COLDSTART_WINDOW_S", "").strip()
+        v = float(raw) if raw else 90.0
+        return v if v > 0 else 90.0
+    except Exception:  # noqa: BLE001
+        return 90.0
+
+
+def _dw_in_cold_start() -> bool:
+    """Slice 184 — True for the first window after a FRESH process boot, when the warm-boot +
+    predictor are structurally BLIND (Slice 183: no durable degradation signal survives a
+    restart). DETERMINISTIC, not predictive — you KNOW you just booted with no signal, so fail
+    SAFE. NEVER raises."""
+    try:
+        if not dw_cold_start_enabled():
+            return False
+        return (time.monotonic() - _PROCESS_START) < _dw_cold_start_window_s()
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _slice36_should_force_batch(context: Any, *, model_id: str = "") -> bool:
     """Slice 36 — adaptive transport selector decision.
 
@@ -615,6 +650,19 @@ def _slice36_should_force_batch(context: Any, *, model_id: str = "") -> bool:
             logger.info(
                 "[Cortex] WARM-BOOT armor: persisted ledger shows DIRECT_STREAMING degraded "
                 "→ DW-batch from T=0 (model=%s; cold-start exhaustion eradicated)",
+                model_id or "?",
+            )
+            return True
+
+        # Slice 184 — COLD-START SEAL. The decisive fix: at fresh-process boot the warm-boot +
+        # predictor are structurally BLIND (Slice 183 telemetry: warm_degraded=False,
+        # rupture_risk=False — no durable degradation signal survives a restart). Rather than
+        # walk RT and rupture before the ledger learns, fail SAFE — force batch for the boot
+        # window so the FIRST ops can't rupture on an unproven stream. Batch-health-gated.
+        if _route_ok and _dw_in_cold_start() and _dw_batch_lane_healthy():
+            logger.info(
+                "[Cortex] COLD-START seal: fresh boot, stream UNPROVEN → DW-batch (fail-safe; "
+                "model=%s) until the ledger warms",
                 model_id or "?",
             )
             return True

--- a/tests/governance/conftest.py
+++ b/tests/governance/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest fixtures for governance tests."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_dw_cold_start(monkeypatch):
+    """Slice 184 — the cold-start seal forces DW-batch for the first ~90s of a FRESH process.
+    Every test process is freshly booted, so without this the seal would force batch in every
+    steady-state DW-routing test (and flip "healthy stream → RT" assertions). Neutralize by
+    default — push the process-start into the distant past so cold-start reads expired. Tests
+    that exercise the cold-start explicitly re-set `_PROCESS_START` to `time.monotonic()`."""
+    try:
+        from backend.core.ouroboros.governance import doubleword_provider as _dw
+        monkeypatch.setattr(_dw, "_PROCESS_START", time.monotonic() - 1_000_000.0, raising=False)
+    except Exception:  # noqa: BLE001 — never let the fixture break collection
+        pass

--- a/tests/governance/test_slice184_coldstart_seal.py
+++ b/tests/governance/test_slice184_coldstart_seal.py
@@ -1,0 +1,84 @@
+"""Slice 184 — the cold-start seal (fail-SAFE, not fail-RT).
+
+Slice 183 traced the bleed to its root: at fresh-process boot the warm-boot + predictor are
+BLIND (warm_degraded=False, rupture_risk=False) — no durable degradation signal survives the
+restart, so the first ops walk RT and rupture before the ledger learns. This seal is
+DETERMINISTIC, not predictive: for a bounded window after process start, force batch for
+standard/complex ops — the first ops can't rupture on an unproven stream. No ML needed; you
+KNOW you just booted and have no signal, so you fail SAFE (batch is stream-free + stable).
+"""
+from __future__ import annotations
+
+import time
+
+from backend.core.ouroboros.governance import doubleword_provider as DW
+
+
+class _Ctx:
+    def __init__(self, route="standard"):
+        self.provider_route = route
+
+
+def _blind_signals(monkeypatch):
+    # the EXACT Slice-183 telemetry state: every degradation signal is False/blind
+    monkeypatch.setattr(DW, "_dw_streaming_warm_degraded", lambda: False)
+    monkeypatch.setattr(DW, "_dw_rupture_risk_high", lambda *a, **k: False)
+    monkeypatch.setattr(DW, "_dw_batch_lane_healthy", lambda: True)
+    monkeypatch.setattr(DW, "_slice41_ledger_force_batch", lambda: False)
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)  # Claude "available"
+    monkeypatch.setattr(DW, "_claude_breaker_open", lambda *a, **k: False)
+
+
+def test_cold_start_forces_batch_despite_blind_signals(monkeypatch):
+    # THE fix: blind signals (warm=False, risk=False) BUT fresh process → force batch
+    _blind_signals(monkeypatch)
+    monkeypatch.setenv("JARVIS_DW_COLDSTART_WINDOW_S", "90")
+    monkeypatch.setattr(DW, "_PROCESS_START", time.monotonic())  # just booted
+    assert DW._slice36_should_force_batch(_Ctx("standard"), model_id="m") is True
+
+
+def test_cold_start_expires_then_normal_routing(monkeypatch):
+    # after the window, blind signals + Claude available → RT allowed again (fail-safe ends)
+    _blind_signals(monkeypatch)
+    monkeypatch.setenv("JARVIS_DW_COLDSTART_WINDOW_S", "90")
+    monkeypatch.setattr(DW, "_PROCESS_START", time.monotonic() - 1000.0)  # window long past
+    assert DW._slice36_should_force_batch(_Ctx("standard"), model_id="m") is False
+
+
+def test_cold_start_respects_batch_health(monkeypatch):
+    # never force into a broken batch lane even during cold-start
+    _blind_signals(monkeypatch)
+    monkeypatch.setattr(DW, "_dw_batch_lane_healthy", lambda: False)
+    monkeypatch.setenv("JARVIS_DW_COLDSTART_WINDOW_S", "90")
+    monkeypatch.setattr(DW, "_PROCESS_START", time.monotonic())
+    assert DW._slice36_should_force_batch(_Ctx("standard"), model_id="m") is False
+
+
+def test_cold_start_kill_switch(monkeypatch):
+    _blind_signals(monkeypatch)
+    monkeypatch.setenv("JARVIS_DW_COLDSTART_ENABLED", "0")
+    monkeypatch.setattr(DW, "_PROCESS_START", time.monotonic())
+    assert DW._slice36_should_force_batch(_Ctx("standard"), model_id="m") is False
+
+
+def test_in_cold_start_helper(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_COLDSTART_WINDOW_S", "90")
+    monkeypatch.delenv("JARVIS_DW_COLDSTART_ENABLED", raising=False)
+    monkeypatch.setattr(DW, "_PROCESS_START", time.monotonic())
+    assert DW._dw_in_cold_start() is True
+    monkeypatch.setattr(DW, "_PROCESS_START", time.monotonic() - 1000.0)
+    assert DW._dw_in_cold_start() is False
+
+
+def test_sentinel_enforcement_includes_cold_start(monkeypatch):
+    # the sentinel's Gap-1 enforcement condition must include cold-start as a trigger
+    import importlib.util
+    spec = importlib.util.find_spec("backend.core.ouroboros.governance.candidate_generator")
+    with open(spec.origin) as fh:
+        src = fh.read()
+    assert "_dw_in_cold_start" in src
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()


### PR DESCRIPTION
Closes the cold-start traced in Slice 183: at fresh boot the warm-boot/predictor are blind (no durable degradation signal survives restart), so the first ops rupture before the ledger learns. Deterministic seal (no ML): force DW-batch for the first ~90s of a fresh process (batch-health-gated), so the first ops CAN'T rupture on an unproven stream; the ledger warms from real traffic and the reactive/predictive/warm-boot layers take over. conftest neutralizes it for steady-state tests. 6 tests; 58 regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a cold-start seal that forces DW-batch for the first ~90s after a fresh process boot, so early requests can’t rupture on an unproven stream. Batch-health gated and integrated into the sentinel’s enforcement.

- **New Features**
  - `doubleword_provider`: added cold-start helpers (`_PROCESS_START`, `dw_cold_start_enabled`, `_dw_cold_start_window_s`, `_dw_in_cold_start`) and enforcement in `_slice36_should_force_batch`. Default window is 90s. Tunable via `JARVIS_DW_COLDSTART_ENABLED` and `JARVIS_DW_COLDSTART_WINDOW_S`.
  - `candidate_generator`: Gap-1 enforcement condition now includes `_dw_in_cold_start` as a trigger alongside warm/risk signals.
  - Tests: added Slice 184 coverage and a `tests/governance/conftest.py` fixture that neutralizes cold-start by default to keep steady-state routing tests stable.

<sup>Written for commit 690d73b15c9a3ace4bac94b654851bad73b94409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

