### PR TITLE
Slice 188 - proactive supremacy engine

### DIFF
--- a/backend/core/ouroboros/governance/dw_latency_tracker.py
+++ b/backend/core/ouroboros/governance/dw_latency_tracker.py
@@ -74,6 +74,21 @@ class DwLatencyTracker:
         self._lock = threading.Lock()
         self._last_update_ns = 0
         self._total_samples = 0
+        # Slice 188 Phase 3 — O(1) streaming p95 (P² algorithm) available as an OPT-IN
+        # alternative to the per-query sorted(). DEFAULT-OFF (verify-first): benchmarking showed
+        # P² UNDER-estimates p95 on the tracker's small, BIMODAL latency distribution (fast ~5s
+        # vs ruptured ~66s) — which would make the governor under-route to batch. For a ~100-
+        # element window the exact sort is microseconds AND correct, so exactness wins. Enable
+        # only if the window grows large enough that the sort is a real bottleneck. NEVER blocks.
+        self._p2 = None
+        try:
+            if os.environ.get(
+                "JARVIS_DW_P2_QUANTILE_ENABLED", "false",
+            ).strip().lower() in ("1", "true", "yes", "on"):
+                from backend.core.ouroboros.governance.dw_streaming_stats import P2Quantile
+                self._p2 = P2Quantile(0.95)
+        except Exception:  # noqa: BLE001
+            self._p2 = None
 
     # ------------------------------------------------------------------
     # Recording
@@ -85,6 +100,8 @@ class DwLatencyTracker:
             return
         with self._lock:
             self._samples.append(float(elapsed_s))
+            if self._p2 is not None:
+                self._p2.update(float(elapsed_s))  # Slice 188: O(1) streaming p95
             self._consecutive_failures = 0
             self._last_update_ns = time.monotonic_ns()
             self._total_samples += 1
@@ -107,6 +124,11 @@ class DwLatencyTracker:
             return self._p95_locked()
 
     def _p95_locked(self) -> float:
+        # Slice 188 Phase 3 — O(1) P² estimate when warm; exact windowed sort as fallback.
+        if self._p2 is not None:
+            v = self._p2.value()
+            if v is not None:
+                return float(v)
         s = sorted(self._samples)
         idx = min(len(s) - 1, int(0.95 * len(s)))
         return s[idx]

--- a/backend/core/ouroboros/governance/dw_singleflight.py
+++ b/backend/core/ouroboros/governance/dw_singleflight.py
@@ -1,0 +1,63 @@
+"""Slice 188 Phase 4 — singleflight (zero redundant vendor calls).
+
+When multiple sub-agents concurrently request the SAME generation, they must all await ONE
+underlying network race, not fire N identical DW calls. Maps a cryptographic hash of the payload
+to an in-flight ``asyncio.Future``; the first caller does the work, the rest await its result.
+Inspired by Go's ``singleflight``. NEVER leaks a failed future (cleared in ``finally``).
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+
+def payload_key(*parts: Any) -> str:
+    """Deterministic content-address of a request payload (sha256 of the joined parts)."""
+    h = hashlib.sha256()
+    for p in parts:
+        h.update(repr(p).encode("utf-8", "replace"))
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+class Singleflight:
+    """Deduplicate concurrent identical async calls. ``do(key, factory)`` runs ``factory`` once per
+    in-flight key; concurrent callers with the same key await the same result. Off by default at
+    the call site — enable per integration. NEVER raises out of bookkeeping."""
+
+    def __init__(self) -> None:
+        self._inflight: Dict[str, "asyncio.Future[Any]"] = {}
+        self._lock = asyncio.Lock()
+
+    def inflight_count(self) -> int:
+        return len(self._inflight)
+
+    async def do(self, key: str, factory: Callable[[], Awaitable[Any]]) -> Any:
+        # fast path: an existing in-flight future for this key → await it (shared result)
+        async with self._lock:
+            fut: Optional["asyncio.Future[Any]"] = self._inflight.get(key)
+            is_leader = fut is None
+            if is_leader:
+                loop = asyncio.get_event_loop()
+                fut = loop.create_future()
+                self._inflight[key] = fut
+
+        if not is_leader:
+            # follower: await the leader's result WITHOUT cancelling it if I'm cancelled
+            return await asyncio.shield(fut)
+
+        # leader: do the work, publish the result, always clear the registry
+        try:
+            result = await factory()
+            if not fut.done():
+                fut.set_result(result)
+            return result
+        except BaseException as exc:  # noqa: BLE001 — propagate to followers then re-raise
+            if not fut.done():
+                fut.set_exception(exc)
+            raise
+        finally:
+            async with self._lock:
+                if self._inflight.get(key) is fut:
+                    del self._inflight[key]

--- a/backend/core/ouroboros/governance/dw_streaming_stats.py
+++ b/backend/core/ouroboros/governance/dw_streaming_stats.py
@@ -1,0 +1,197 @@
+"""Slice 188 Phase 3 — O(1) streaming statistics for the proactive engine.
+
+Eradicates the algorithmic bottlenecks identified in the Slice-188 research:
+  * ``P2Quantile`` — the P² algorithm: a streaming p95 in O(1) per update, constant space, NO
+    ``sorted()`` (the DwLatencyTracker hot-path cost).
+  * ``DecayingRate`` — an exponentially-decaying event rate (λ) updated incrementally in O(1)
+    instead of the predictor's O(n) ``Σ weight·decay`` ring loop. Also durable across restarts
+    (decay-forward from the persisted timestamp), which dissolves the cold-start blindness.
+  * ``HawkesIntensity`` — a self-exciting point-process intensity. Unlike Poisson (memoryless),
+    a rupture RAISES the near-term intensity, then decays — modelling DW's actual bursty,
+    correlated rupture STORMS so the cortex can preempt a storm as it begins, not after.
+
+Pure + deterministic + dependency-free (no numpy). NEVER raise out of the read methods.
+"""
+from __future__ import annotations
+
+import math
+from typing import List, Optional
+
+
+class P2Quantile:
+    """P² streaming quantile estimator (Jain & Chlamtac 1985). O(1) update, 5 markers, no sort."""
+
+    def __init__(self, p: float = 0.95) -> None:
+        self.p = min(0.999, max(0.001, float(p)))
+        self._init: List[float] = []
+        self._q: List[float] = []   # marker heights
+        self._n: List[float] = []   # marker positions
+        self._np: List[float] = []  # desired positions
+        self._dn: List[float] = []  # desired-position increments
+        self._count = 0
+
+    def update(self, x: float) -> None:
+        try:
+            x = float(x)
+        except Exception:  # noqa: BLE001
+            return
+        self._count += 1
+        if len(self._q) < 5:
+            self._init.append(x)
+            if len(self._init) == 5:
+                self._init.sort()
+                self._q = list(self._init)
+                self._n = [1.0, 2.0, 3.0, 4.0, 5.0]
+                p = self.p
+                self._np = [1.0, 1 + 2 * p, 1 + 4 * p, 3 + 2 * p, 5.0]
+                self._dn = [0.0, p / 2.0, p, (1 + p) / 2.0, 1.0]
+            return
+
+        # locate cell k
+        if x < self._q[0]:
+            self._q[0] = x
+            k = 0
+        elif x >= self._q[4]:
+            self._q[4] = x
+            k = 3
+        else:
+            k = 3
+            for i in range(4):
+                if self._q[i] <= x < self._q[i + 1]:
+                    k = i
+                    break
+
+        for i in range(k + 1, 5):
+            self._n[i] += 1
+        for i in range(5):
+            self._np[i] += self._dn[i]
+
+        for i in range(1, 4):
+            d = self._np[i] - self._n[i]
+            if (d >= 1 and (self._n[i + 1] - self._n[i]) > 1) or (
+                d <= -1 and (self._n[i - 1] - self._n[i]) < -1
+            ):
+                sd = 1.0 if d >= 0 else -1.0
+                qp = self._parabolic(i, sd)
+                if self._q[i - 1] < qp < self._q[i + 1]:
+                    self._q[i] = qp
+                else:
+                    self._q[i] = self._q[i] + sd * (
+                        self._q[int(i + sd)] - self._q[i]
+                    ) / (self._n[int(i + sd)] - self._n[i])
+                self._n[i] += sd
+
+    def _parabolic(self, i: int, d: float) -> float:
+        n = self._n
+        q = self._q
+        return q[i] + d / (n[i + 1] - n[i - 1]) * (
+            (n[i] - n[i - 1] + d) * (q[i + 1] - q[i]) / (n[i + 1] - n[i])
+            + (n[i + 1] - n[i] - d) * (q[i] - q[i - 1]) / (n[i] - n[i - 1])
+        )
+
+    def value(self) -> Optional[float]:
+        """Current p-quantile estimate. NEVER raises."""
+        try:
+            if len(self._q) == 5:
+                return self._q[2]
+            if not self._init:
+                return None
+            s = sorted(self._init)
+            return s[min(len(s) - 1, int(self.p * len(s)))]
+        except Exception:  # noqa: BLE001
+            return None
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+
+class DecayingRate:
+    """Exponentially-decaying event rate (λ), O(1) per event. λ decays with half-life ``halflife_s``
+    and is incremented by ``weight`` on each event. Durable: ``snapshot()``/``restore()`` carry the
+    rate + last-update time across restarts (decay-forward), dissolving cold-start blindness."""
+
+    def __init__(self, halflife_s: float = 300.0) -> None:
+        self._halflife = max(1e-3, float(halflife_s))
+        self._lambda = 0.0
+        self._last_t: Optional[float] = None
+
+    def _decay_to(self, now: float) -> None:
+        if self._last_t is None:
+            self._last_t = now
+            return
+        dt = now - self._last_t
+        if dt > 0:
+            self._lambda *= math.exp(-math.log(2.0) * dt / self._halflife)
+            self._last_t = now
+
+    def observe(self, now: float, weight: float = 1.0) -> None:
+        try:
+            self._decay_to(float(now))
+            self._lambda += float(weight)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def rate(self, now: float) -> float:
+        try:
+            self._decay_to(float(now))
+            return self._lambda
+        except Exception:  # noqa: BLE001
+            return self._lambda
+
+    def snapshot(self) -> dict:
+        return {"lambda": self._lambda, "last_t": self._last_t, "halflife_s": self._halflife}
+
+    def restore(self, snap: dict) -> None:
+        try:
+            self._lambda = float(snap.get("lambda", 0.0))
+            self._last_t = snap.get("last_t", None)
+            self._halflife = max(1e-3, float(snap.get("halflife_s", self._halflife)))
+        except Exception:  # noqa: BLE001
+            pass
+
+
+class HawkesIntensity:
+    """Self-exciting (Hawkes) intensity: λ(t) = μ + Σ α·exp(-β·(t−tᵢ)). A rupture RAISES the
+    near-term intensity (excitation ``alpha``) which decays at rate ``beta`` — modelling DW's
+    bursty, correlated STORMS (Poisson can't). O(1) incremental via a decaying excitation term."""
+
+    def __init__(self, mu: float = 0.0, alpha: float = 1.0, beta: float = 1.0 / 60.0) -> None:
+        self._mu = max(0.0, float(mu))
+        self._alpha = max(0.0, float(alpha))
+        self._beta = max(1e-6, float(beta))
+        self._excite = 0.0
+        self._last_t: Optional[float] = None
+
+    def _decay_to(self, now: float) -> None:
+        if self._last_t is None:
+            self._last_t = now
+            return
+        dt = now - self._last_t
+        if dt > 0:
+            self._excite *= math.exp(-self._beta * dt)
+            self._last_t = now
+
+    def observe(self, now: float, weight: float = 1.0) -> None:
+        try:
+            self._decay_to(float(now))
+            self._excite += self._alpha * float(weight)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def intensity(self, now: float) -> float:
+        """Current conditional intensity λ(t) — high right after a burst, decaying toward μ."""
+        try:
+            self._decay_to(float(now))
+            return self._mu + self._excite
+        except Exception:  # noqa: BLE001
+            return self._mu
+
+    def storm_probability(self, now: float, horizon_s: float) -> float:
+        """P(≥1 event in the next ``horizon_s``) from the current intensity (Poisson approx over
+        the short horizon where intensity is ~constant): 1 − exp(−λ·horizon). NEVER raises."""
+        try:
+            lam = self.intensity(now)
+            return 1.0 - math.exp(-max(0.0, lam) * max(0.0, float(horizon_s)))
+        except Exception:  # noqa: BLE001
+            return 0.0

--- a/backend/core/ouroboros/governance/dw_transport_hedge.py
+++ b/backend/core/ouroboros/governance/dw_transport_hedge.py
@@ -1,0 +1,95 @@
+"""Slice 188 Phase 1+2 — the proactive transport-hedge (concurrent supremacy).
+
+The paradigm flip: we do NOT react to or predict DW's RT ruptures — we STRUCTURALLY neutralize
+them by racing the fast path (RT stream) against the stable path (batch) concurrently and taking
+the winner. A rupture on the fast path simply means batch wins; the op NEVER sees the failure.
+
+Phase 1 — ``hedged_race``: fire both, ``asyncio.wait(FIRST_COMPLETED)``, take the first SUCCESS,
+aggressively ``cancel()`` the loser (no orphaned tasks / wasted credits). A fast-path rupture is
+swallowed so the stable path can still win.
+
+Phase 2 — ``should_skip_race_for_storm``: the cortex is demoted from safety-net to ECONOMIC
+governor. Before racing, consult the forecast; if a platform-wide STORM is imminent, racing the
+RT path is pure waste (it will rupture) — so bypass it and go batch-only, saving the credits.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Awaitable, Callable, Optional
+
+
+def transport_hedge_enabled() -> bool:
+    """Master for the proactive hedge. Default **FALSE** (§33.1 — new default-path behavior that
+    can double-spend; opt-in per deployment). NEVER raises."""
+    return os.environ.get("JARVIS_DW_TRANSPORT_HEDGE_ENABLED", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _storm_threshold() -> float:
+    try:
+        raw = os.environ.get("JARVIS_DW_STORM_SKIP_THRESHOLD", "").strip()
+        v = float(raw) if raw else 0.8
+        return min(1.0, max(0.0, v))
+    except Exception:  # noqa: BLE001
+        return 0.8
+
+
+def should_skip_race_for_storm(storm_probability: float) -> bool:
+    """Phase 2 — the cortex as cost-optimizer. If a platform-wide rupture STORM is forecast above
+    threshold, don't waste a hedge racing the RT path (it will rupture) — go batch-only. NEVER
+    raises."""
+    try:
+        return float(storm_probability) >= _storm_threshold()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+async def hedged_race(
+    fast: Callable[[], Awaitable[Any]],
+    stable: Callable[[], Awaitable[Any]],
+    *,
+    is_rupture: Callable[[BaseException], bool] = lambda e: True,
+) -> Any:
+    """Race ``fast`` (RT) against ``stable`` (batch). Return the FIRST successful result; cancel
+    the loser aggressively. A ``fast`` failure that ``is_rupture`` returns True for is swallowed so
+    ``stable`` can still win. If BOTH fail, the last exception is raised. Cancellation is awaited
+    so no orphaned tasks survive."""
+    loop = asyncio.get_event_loop()
+    t_fast = loop.create_task(fast())
+    t_stable = loop.create_task(stable())
+    pending = {t_fast, t_stable}
+    last_exc: Optional[BaseException] = None
+
+    try:
+        while pending:
+            done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+            for t in done:
+                try:
+                    result = t.result()
+                except asyncio.CancelledError:
+                    continue
+                except BaseException as exc:  # noqa: BLE001
+                    last_exc = exc
+                    # a fast-path rupture is non-fatal — let the stable path keep racing
+                    if t is t_fast and is_rupture(exc):
+                        continue
+                    # a non-rupture fast error or a stable error: if the other is still
+                    # pending, keep waiting; else propagate below
+                    continue
+                else:
+                    # FIRST SUCCESS — cancel the loser aggressively + await its unwind
+                    for other in pending:
+                        other.cancel()
+                    if pending:
+                        await asyncio.gather(*pending, return_exceptions=True)
+                    return result
+        # both finished without a success
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("hedged_race: both transports resolved without a result")
+    finally:
+        for t in (t_fast, t_stable):
+            if not t.done():
+                t.cancel()

--- a/tests/governance/test_slice188_proactive_supremacy.py
+++ b/tests/governance/test_slice188_proactive_supremacy.py
@@ -1,0 +1,172 @@
+"""Slice 188 — proactive supremacy: transport-hedge + cortex-as-cost-optimizer + O(1) DSA +
+singleflight."""
+from __future__ import annotations
+
+import asyncio
+import random
+import unittest
+
+from backend.core.ouroboros.governance.dw_streaming_stats import (
+    P2Quantile,
+    DecayingRate,
+    HawkesIntensity,
+)
+from backend.core.ouroboros.governance.dw_singleflight import Singleflight, payload_key
+from backend.core.ouroboros.governance.dw_transport_hedge import (
+    hedged_race,
+    should_skip_race_for_storm,
+)
+
+
+# ─────────────── Phase 3: DSA ───────────────
+class TestP2Quantile(unittest.TestCase):
+    def test_approximates_true_p95_no_sort(self):
+        random.seed(42)
+        data = [random.gauss(50, 10) for _ in range(2000)]
+        est = P2Quantile(0.95)
+        for x in data:
+            est.update(x)
+        true_p95 = sorted(data)[int(0.95 * len(data))]
+        # P2 is an approximation — within ~5% of the true percentile
+        self.assertLess(abs(est.value() - true_p95) / true_p95, 0.05)
+
+    def test_cold_returns_something_or_none(self):
+        est = P2Quantile(0.95)
+        self.assertIsNone(est.value())
+        est.update(1.0)
+        self.assertIsNotNone(est.value())
+
+
+class TestDecayingRate(unittest.TestCase):
+    def test_rate_rises_then_decays(self):
+        r = DecayingRate(halflife_s=10.0)
+        for t in range(5):
+            r.observe(float(t))
+        hot = r.rate(5.0)
+        self.assertGreater(hot, 0)
+        cold = r.rate(5.0 + 100.0)  # 10 half-lives later → ~0
+        self.assertLess(cold, hot * 0.01)
+
+    def test_snapshot_restore_decays_forward(self):
+        r = DecayingRate(halflife_s=10.0)
+        r.observe(0.0); r.observe(1.0)
+        snap = r.snapshot()
+        r2 = DecayingRate()
+        r2.restore(snap)
+        # decay-forward from the persisted state (dissolves cold-start blindness)
+        self.assertAlmostEqual(r2.rate(1.0), r.rate(1.0), places=6)
+
+
+class TestHawkesIntensity(unittest.TestCase):
+    def test_burst_spikes_intensity_then_decays(self):
+        h = HawkesIntensity(mu=0.001, alpha=1.0, beta=0.1)
+        base = h.intensity(0.0)
+        for t in range(6):  # a rupture storm
+            h.observe(float(t))
+        spiked = h.intensity(6.0)
+        self.assertGreater(spiked, base + 1.0)  # self-excited well above baseline
+        decayed = h.intensity(6.0 + 200.0)
+        self.assertLess(decayed, spiked * 0.05)
+
+    def test_storm_probability_high_after_burst(self):
+        h = HawkesIntensity(mu=0.0, alpha=1.0, beta=0.05)
+        for t in range(5):
+            h.observe(float(t))
+        self.assertGreater(h.storm_probability(5.0, horizon_s=30.0), 0.8)
+
+
+# ─────────────── Phase 2: cost-optimizer ───────────────
+class TestStormGate(unittest.TestCase):
+    def test_skip_race_when_storm_imminent(self):
+        self.assertTrue(should_skip_race_for_storm(0.95))   # storm → batch-only, save credits
+
+    def test_race_when_calm(self):
+        self.assertFalse(should_skip_race_for_storm(0.2))   # calm → race RT vs batch
+
+
+# ─────────────── Phase 1: transport-hedge ───────────────
+class TestHedgedRace(unittest.IsolatedAsyncioTestCase):
+    async def test_fast_path_wins_and_loser_cancelled(self):
+        stable_cancelled = {"v": False}
+
+        async def fast():
+            await asyncio.sleep(0.01)
+            return "RT"
+
+        async def stable():
+            try:
+                await asyncio.sleep(10.0)
+                return "BATCH"
+            except asyncio.CancelledError:
+                stable_cancelled["v"] = True
+                raise
+
+        result = await hedged_race(fast, stable)
+        self.assertEqual(result, "RT")
+        await asyncio.sleep(0)  # let cancellation propagate
+        self.assertTrue(stable_cancelled["v"])
+
+    async def test_rupture_swallowed_batch_wins(self):
+        async def fast():
+            await asyncio.sleep(0.01)
+            raise RuntimeError("live_transport:RuntimeError")  # RT ruptures
+
+        async def stable():
+            await asyncio.sleep(0.05)
+            return "BATCH"
+
+        result = await hedged_race(fast, stable, is_rupture=lambda e: "live_transport" in str(e))
+        self.assertEqual(result, "BATCH")  # the op NEVER saw the rupture
+
+    async def test_both_fail_raises(self):
+        async def fast():
+            raise RuntimeError("live_transport:x")
+
+        async def stable():
+            raise ValueError("batch broke too")
+
+        with self.assertRaises(BaseException):
+            await hedged_race(fast, stable, is_rupture=lambda e: "live_transport" in str(e))
+
+
+# ─────────────── Phase 4: singleflight ───────────────
+class TestSingleflight(unittest.IsolatedAsyncioTestCase):
+    async def test_concurrent_identical_calls_share_one_execution(self):
+        sf = Singleflight()
+        calls = {"n": 0}
+
+        async def factory():
+            calls["n"] += 1
+            await asyncio.sleep(0.02)
+            return "RESULT"
+
+        key = payload_key("same-prompt", "deepseek")
+        results = await asyncio.gather(*[sf.do(key, factory) for _ in range(5)])
+        self.assertEqual(results, ["RESULT"] * 5)
+        self.assertEqual(calls["n"], 1)          # ONE underlying DW call, not 5
+        self.assertEqual(sf.inflight_count(), 0)  # registry cleared
+
+    async def test_different_keys_run_independently(self):
+        sf = Singleflight()
+        calls = {"n": 0}
+
+        async def factory():
+            calls["n"] += 1
+            return calls["n"]
+
+        await asyncio.gather(sf.do("a", factory), sf.do("b", factory))
+        self.assertEqual(calls["n"], 2)
+
+    async def test_leader_failure_propagates_then_clears(self):
+        sf = Singleflight()
+
+        async def boom():
+            raise RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            await sf.do("k", boom)
+        self.assertEqual(sf.inflight_count(), 0)  # failed future cleared, not leaked
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The proactive-first paradigm flip, cores built + TDD-proven. P1 transport-hedge (race RT vs batch, take winner, cancel+swallow rupture). P2 cortex as cost-optimizer (skip race on storm forecast). P3 O(1) DSA: P²/DecayingRate/Hawkes (P² wired opt-in — verify-first showed it under-estimates on bimodal latency, exact sort kept default). P4 singleflight dedup. 14 Slice-188 tests; 43 regression green. Honest scope: cores proven + ready; deep provider-dispatch wiring is the next gated integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Slice-188: adds a proactive transport hedge that races RT vs batch and picks the first success, plus O(1) streaming stats and singleflight dedup to cut redundant calls. All new behavior is gated and off by default.

- **New Features**
  - Transport hedging in `dw_transport_hedge`: `hedged_race` races RT vs batch and cancels the loser; `should_skip_race_for_storm` lets the cortex skip the RT race when a storm is forecast.
  - Streaming stats in `dw_streaming_stats`: `P2Quantile` (streaming p95), `DecayingRate` (durable, O(1)), `HawkesIntensity` (burst-aware).
  - Latency tracker update in `dw_latency_tracker`: opt-in P² p95; exact windowed sort remains the default.
  - Singleflight in `dw_singleflight`: `Singleflight` + `payload_key` to deduplicate concurrent identical async calls.

- **Migration**
  - Enable the hedge with `JARVIS_DW_TRANSPORT_HEDGE_ENABLED=1`.
  - Tune storm skip with `JARVIS_DW_STORM_SKIP_THRESHOLD` (default 0.8).
  - Opt into P² with `JARVIS_DW_P2_QUANTILE_ENABLED=1`.
  - Adopt `Singleflight` at call sites and key requests with `payload_key(...)`.

<sup>Written for commit c49cf8efa19eea9bc66187174a53ec417b89dfea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

