### PR TITLE
Slice 191 - sovereign migration (lean payload + --cortex hedge launch)

### DIFF
--- a/scripts/migrate_to_host.sh
+++ b/scripts/migrate_to_host.sh
@@ -25,7 +25,7 @@ log() { printf '\033[36m[migrate]\033[0m %s\n' "$*"; }
 die() { printf '\033[31m[migrate] FATAL:\033[0m %s\n' "$*" >&2; exit 1; }
 
 HOST="${1:-}"; REMOTE_DIR="${2:-}"; LAUNCH="${3:-}"
-[ -n "$HOST" ] && [ -n "$REMOTE_DIR" ] || die "usage: $0 <user@host> <remote_dir> [--launch]"
+[ -n "$HOST" ] && [ -n "$REMOTE_DIR" ] || die "usage: $0 <user@host> <remote_dir> [--launch|--cortex]"
 command -v ssh >/dev/null 2>&1 && command -v scp >/dev/null 2>&1 || die "ssh + scp required."
 
 # ── 1. Package ───────────────────────────────────────────────────────────────
@@ -61,8 +61,20 @@ if [ "$LAUNCH" = "--launch" ]; then
   log "ssh: igniting arm_and_launch.sh on $HOST (signed roadmap travels in the artifact → non-interactive)"
   ssh "$HOST" "cd '$REMOTE_DIR/jarvis-sovereign'; bash scripts/arm_and_launch.sh"
   log "═══════════════════════════════════════════════════════════════"
-  log "MIGRATION COMPLETE — organism igniting on $HOST."
+  log "MIGRATION COMPLETE — organism igniting on $HOST (Layer-4 systemd shadow-soak)."
   log "  Watch: ssh $HOST 'tail -f $REMOTE_DIR/jarvis-sovereign/.jarvis/t5_soak.out'"
+  log "═══════════════════════════════════════════════════════════════"
+elif [ "$LAUNCH" = "--cortex" ]; then
+  # Slice 191 — the PROACTIVE HEDGE soak via docker compose on the host's UNCONTENDED buildkit
+  # (the macOS daemon is retired). Reuses the existing launch_dw_cortex_soak.sh (the only
+  # launcher bound to docker-compose.dw-cortex-soak.yml with JARVIS_DW_TRANSPORT_HEDGE_ENABLED)
+  # — no duplication. --no-logs builds + up -d detached, then returns.
+  log "ssh: building + igniting the DW-cortex HEDGE soak on $HOST (docker compose, detached)…"
+  ssh "$HOST" "cd '$REMOTE_DIR/jarvis-sovereign'; chmod +x scripts/*.sh; SOAK_REQUIREMENTS=requirements-soak-oracle.txt ./scripts/launch_dw_cortex_soak.sh --no-logs"
+  log "═══════════════════════════════════════════════════════════════"
+  log "MIGRATION COMPLETE — PROACTIVE HEDGE soak building+running on $HOST."
+  log "  Hedge wins:  ssh $HOST \"docker logs jarvis-dw-cortex-soak 2>&1 | grep -E 'hedge WON|RT rupture SWALLOWED'\""
+  log "  Watch cortex: ssh $HOST 'docker logs -f jarvis-dw-cortex-soak'"
   log "═══════════════════════════════════════════════════════════════"
 else
   log "═══════════════════════════════════════════════════════════════"

--- a/scripts/pack_sovereign_release.sh
+++ b/scripts/pack_sovereign_release.sh
@@ -61,6 +61,30 @@ rsync -a \
   --exclude='.claude/worktrees' \
   --exclude='dist' \
   --exclude='.jarvis' \
+  `# Slice 191 — mirror the .dockerignore bulk excludes so the payload is LEAN. These are` \
+  `# build artifacts + model weights + logs (NOT source); the remote host rebuilds deps and` \
+  `# compiled extensions for its OWN arch via docker compose build, so Mac arm64 binaries` \
+  `# must not travel anyway. Without these the rsync drags ~20GB of untracked bulk.` \
+  --exclude='.ouroboros' \
+  --exclude='.cache' \
+  --exclude='model_checkpoints' \
+  --exclude='logs' \
+  --exclude='venv' \
+  --exclude='target' \
+  --exclude='.build' \
+  --exclude='*.so' \
+  --exclude='*.dylib' \
+  --exclude='*.a' \
+  --exclude='*.rlib' \
+  --exclude='*.rmeta' \
+  --exclude='*.pt' \
+  --exclude='*.pth' \
+  --exclude='*.onnx' \
+  --exclude='*.safetensors' \
+  --exclude='*.gguf' \
+  --exclude='*.mlmodel' \
+  --exclude='*.mlmodelc' \
+  --exclude='*.log' \
   ./ "$STAGE/"
 
 log "Preserving load-bearing .jarvis crypto + signatures + evidence (allowlist)…"


### PR DESCRIPTION
Retires the crashed local macOS daemon; migrates to an uncontended host. (1) pack_sovereign_release.sh now mirrors the .dockerignore bulk excludes (~20GB → lean; source .py preserved). (2) migrate_to_host.sh --cortex runs the existing launch_dw_cortex_soak.sh (hedge compose) on the host — pristine docker compose build + up -d detached, no duplication. Env hardened (hedge/calibration/janitor pinned). Secrets out-of-band. Ready for host credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slice 191: Migrate sovereign soak from the unstable macOS Docker daemon to an uncontended host, with a leaner release payload and a new `--cortex` launch path for the hedge-compose soak. This cuts transfer size by ~20GB and builds/runs the DW cortex soak remotely in detached mode.

- **New Features**
  - `scripts/migrate_to_host.sh` adds `--cortex` to build and start the DW-cortex hedge soak on the host via `launch_dw_cortex_soak.sh` (docker compose, detached).

- **Refactors**
  - `scripts/pack_sovereign_release.sh` mirrors `.dockerignore` bulk excludes to keep the payload lean (models, caches, logs, build artifacts), preserving source; host rebuilds deps during compose build.

<sup>Written for commit 5f1f59b5259cad9ff04de0d0b08aec0d16a981ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

