### PR TITLE
feat(observability): Slice 193 - sovereign telemetry registry (durable structured hedge metrics)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -2245,6 +2245,16 @@ class DoublewordProvider:
                     "it, rupture can't be on the critical path (op=%s)",
                     getattr(context, "op_id", "?")[:16],
                 )
+                try:
+                    # Slice 193 — durable structured counter; the INFO line above
+                    # is invisible at the soak's WARNING threshold, the registry
+                    # is not (Manifesto §7).
+                    from backend.core.ouroboros.governance.observability_registry import (
+                        record_hedge_dispatch as _s193_record_hedge_dispatch,
+                    )
+                    _s193_record_hedge_dispatch()
+                except Exception:  # noqa: BLE001
+                    pass
                 def _s190_hedge_outcome(winner: str, rupture_swallowed: bool) -> None:
                     # Slice 190 — record the proactive win into the EXISTING economic ledger
                     # (171): which transport won + whether an RT rupture was made INVISIBLE.
@@ -2259,6 +2269,15 @@ class DoublewordProvider:
                             get_economic_telemetry,
                         )
                         get_economic_telemetry().record_hedge_outcome(winner, rupture_swallowed)
+                    except Exception:  # noqa: BLE001
+                        pass
+                    try:
+                        # Slice 193 — the same outcome lands in the durable registry
+                        # so the long soak can audit victories across restarts.
+                        from backend.core.ouroboros.governance.observability_registry import (
+                            record_hedge_outcome as _s193_record_hedge_outcome,
+                        )
+                        _s193_record_hedge_outcome(winner, rupture_swallowed)
                     except Exception:  # noqa: BLE001
                         pass
 

--- a/backend/core/ouroboros/governance/event_channel.py
+++ b/backend/core/ouroboros/governance/event_channel.py
@@ -304,6 +304,46 @@ class EventChannelServer:
                     metrics_exc,
                 )
 
+            # Slice 193 — sovereign telemetry registry surface.
+            # Mounts /observability/registry (durable mmap-backed hedge
+            # counters: dispatches / rt victories / batch victories /
+            # ruptures swallowed). Loopback + CORS invariants mirror the
+            # existing IDE router; authority invariant is grep-pinned in
+            # tests/governance/test_observability_registry.py.
+            registry_router_mounted = False
+            try:
+                from backend.core.ouroboros.governance.ide_observability import (
+                    IDEObservabilityRouter as _IDEObsRouterReg,
+                    assert_loopback_only as _assert_loopback_registry,
+                )
+                from backend.core.ouroboros.governance.observability_registry import (
+                    observability_registry_enabled as _registry_enabled,
+                    register_registry_routes,
+                )
+                if _registry_enabled():
+                    _assert_loopback_registry(self._host)
+                    _registry_helper = _IDEObsRouterReg()
+                    register_registry_routes(
+                        app,
+                        rate_limit_check=lambda req: (
+                            _registry_helper._check_rate_limit(
+                                _registry_helper._client_key(req),
+                            )
+                        ),
+                        cors_headers=_registry_helper._cors_headers,
+                    )
+                    registry_router_mounted = True
+            except ValueError as registry_loopback_exc:
+                logger.warning(
+                    "[EventChannel] registry observability refused: %s",
+                    registry_loopback_exc,
+                )
+            except Exception as registry_exc:
+                logger.warning(
+                    "[EventChannel] registry observability wiring failed: %s",
+                    registry_exc,
+                )
+
             # P5 Slice 5 — adversarial reviewer observability surface.
             # Mounts /observability/adversarial{,/history,/stats,
             # /{op_id}}. Loopback + CORS invariants mirror the

--- a/backend/core/ouroboros/governance/observability_registry.py
+++ b/backend/core/ouroboros/governance/observability_registry.py
@@ -1,0 +1,390 @@
+"""Slice 193 — Sovereign Telemetry Registry: structured, durable, unsuppressed
+counters for the proactive transport-hedge (Manifesto §7).
+
+The Slice 192 live verdict exposed a structural gap: the hedge's win/loss/
+swallow telemetry is logger.info — invisible at the soak's WARNING console
+threshold — and the Slice 190 economic counters are in-memory only, lost on
+every restart. Promoting victory logs to WARNING would dilute the warning
+channel; the correct answer is metrics, not noisier text.
+
+This module is that answer:
+
+  * :class:`ObservabilityRegistry` — thread-safe atomic counters backed by a
+    fixed-slot memory-mapped file (``.jarvis/observability_registry.bin``).
+    An increment is one lock-guarded ``struct.pack_into`` against the mmap —
+    a page-cache write, no syscall I/O, no fsync — so the dispatch throat
+    pays microseconds. Durability comes from the OS page cache plus a
+    background daemon flusher thread (msync off the hot path, zero GIL
+    contention during generation).
+  * Fail-soft everywhere: a corrupt, missing-dir, or unwritable backing file
+    degrades to an in-memory dict — counting still works, NOTHING raises
+    into the dispatch throat. The corrupt file is left in place (evidence,
+    not destruction).
+  * :func:`record_hedge_dispatch` / :func:`record_hedge_outcome` — the two
+    fire-and-forget helpers the doubleword_provider hedge block calls.
+  * :func:`register_registry_routes` — GET ``/observability/registry``
+    mounted on the EventChannelServer app, mirroring the metrics_observability
+    pattern (403 master-off, 429 rate-limited, no-store, loopback-only via
+    the caller's helpers).
+
+Authority invariants: counts, never gates. No orchestrator / policy /
+gate-family imports. The only I/O is the registry's own backing file.
+"""
+from __future__ import annotations
+
+import logging
+import mmap
+import os
+import struct
+import threading
+import time
+from pathlib import Path
+from typing import Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_OBSERVABILITY_REGISTRY_ENABLED"
+_ENV_PATH = "JARVIS_OBSERVABILITY_REGISTRY_PATH"
+_ENV_FLUSH_S = "JARVIS_OBSERVABILITY_REGISTRY_FLUSH_S"
+
+_DEFAULT_PATH = ".jarvis/observability_registry.bin"
+_DEFAULT_FLUSH_S = 5.0
+
+REGISTRY_SCHEMA_VERSION = "1.0"
+
+# Backing-file format (little-endian):
+#   header  : magic b"JOR1" (4) + u32 version (4) + u32 used_slots (4) + pad (4)
+#   slot[i] : name utf-8 NUL-padded (64) + u64 value (8)
+_MAGIC = b"JOR1"
+_FORMAT_VERSION = 1
+_HEADER_SIZE = 16
+_NAME_SIZE = 64
+_SLOT_SIZE = _NAME_SIZE + 8
+_MAX_SLOTS = 256
+_FILE_SIZE = _HEADER_SIZE + _MAX_SLOTS * _SLOT_SIZE
+
+# The four long-window hedge metrics (Slice 193 charter).
+HEDGE_CONCURRENCY_DISPATCHES = "hedge_concurrency_dispatches"
+HEDGE_RT_VICTORIES = "hedge_rt_victories"
+HEDGE_BATCH_VICTORIES = "hedge_batch_victories"
+HEDGE_RUPTURES_SWALLOWED = "hedge_ruptures_swallowed"
+
+_PREREGISTERED = (
+    HEDGE_CONCURRENCY_DISPATCHES,
+    HEDGE_RT_VICTORIES,
+    HEDGE_BATCH_VICTORIES,
+    HEDGE_RUPTURES_SWALLOWED,
+)
+
+
+def observability_registry_enabled() -> bool:
+    """Master gate (default TRUE — authority-free observability, economic
+    telemetry precedent). NEVER raises."""
+    return os.environ.get(_ENV_ENABLED, "true").strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
+def _registry_path() -> Path:
+    raw = os.environ.get(_ENV_PATH, "").strip()
+    return Path(raw) if raw else Path(_DEFAULT_PATH)
+
+
+def _flush_interval_s() -> float:
+    try:
+        raw = os.environ.get(_ENV_FLUSH_S, "").strip()
+        v = float(raw) if raw else _DEFAULT_FLUSH_S
+        return v if v > 0 else _DEFAULT_FLUSH_S
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_FLUSH_S
+
+
+class ObservabilityRegistry:
+    """Thread-safe atomic counter registry, mmap-backed with in-memory
+    fail-soft fallback. All public methods NEVER raise."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._lock = threading.Lock()
+        self._path = path if path is not None else _registry_path()
+        self._mm: Optional[mmap.mmap] = None
+        self._file = None
+        self._slots: Dict[str, int] = {}  # name -> slot index (mmap mode)
+        self._memory: Dict[str, int] = {}  # fallback / disabled mode
+        self.backend_kind = "memory"
+        self._flusher_stop = threading.Event()
+        self._flusher: Optional[threading.Thread] = None
+        if observability_registry_enabled():
+            self._open_backend()
+            for name in _PREREGISTERED:
+                self._ensure_counter(name)
+            if self._mm is not None:
+                self._start_flusher()
+
+    # -- backend -----------------------------------------------------------
+
+    def _open_backend(self) -> None:
+        """Open or create the mmap backing file; degrade to memory on ANY
+        failure (corrupt file is left in place as evidence)."""
+        try:
+            existing = self._path.exists()
+            if existing:
+                if self._path.stat().st_size != _FILE_SIZE:
+                    raise ValueError("backing file size mismatch")
+            else:
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+                with open(self._path, "wb") as fh:
+                    fh.write(_MAGIC)
+                    fh.write(struct.pack("<II", _FORMAT_VERSION, 0))
+                    fh.write(b"\x00" * (_FILE_SIZE - 12))
+            self._file = open(self._path, "r+b")
+            self._mm = mmap.mmap(self._file.fileno(), _FILE_SIZE)
+            if self._mm[:4] != _MAGIC:
+                raise ValueError("bad magic")
+            version, used = struct.unpack_from("<II", self._mm, 4)
+            if version != _FORMAT_VERSION or used > _MAX_SLOTS:
+                raise ValueError(f"unsupported header version={version} used={used}")
+            for i in range(used):
+                off = _HEADER_SIZE + i * _SLOT_SIZE
+                name = self._mm[off:off + _NAME_SIZE].rstrip(b"\x00").decode(
+                    "utf-8", errors="replace",
+                )
+                if name:
+                    self._slots[name] = i
+            self.backend_kind = "mmap"
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[ObservabilityRegistry] mmap backend unavailable (%s) — "
+                "fail-soft to in-memory counters: %s",
+                self._path, exc,
+            )
+            self._teardown_mmap()
+            self.backend_kind = "memory"
+
+    def _teardown_mmap(self) -> None:
+        try:
+            if self._mm is not None:
+                self._mm.close()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            if self._file is not None:
+                self._file.close()
+        except Exception:  # noqa: BLE001
+            pass
+        self._mm = None
+        self._file = None
+        self._slots = {}
+
+    def _ensure_counter(self, name: str) -> None:
+        """Allocate a slot for *name* if absent. Caller need not hold the
+        lock (construction) — incr() re-enters under the lock."""
+        if self._mm is None:
+            self._memory.setdefault(name, 0)
+            return
+        if name in self._slots:
+            return
+        used = len(self._slots)
+        if used >= _MAX_SLOTS:
+            # Registry full — overflow counters live in memory (still counted,
+            # still in snapshot, just not crash-durable).
+            self._memory.setdefault(name, 0)
+            return
+        off = _HEADER_SIZE + used * _SLOT_SIZE
+        encoded = name.encode("utf-8")[:_NAME_SIZE]
+        self._mm[off:off + _NAME_SIZE] = encoded.ljust(_NAME_SIZE, b"\x00")
+        struct.pack_into("<Q", self._mm, off + _NAME_SIZE, 0)
+        self._slots[name] = used
+        struct.pack_into("<I", self._mm, 8, used + 1)
+
+    # -- background flusher (durability off the hot path) -------------------
+
+    def _start_flusher(self) -> None:
+        interval = _flush_interval_s()
+
+        def _run() -> None:
+            while not self._flusher_stop.wait(interval):
+                self.flush()
+
+        self._flusher = threading.Thread(
+            target=_run, name="observability-registry-flusher", daemon=True,
+        )
+        self._flusher.start()
+
+    def flush(self) -> None:
+        """msync the mmap (durability point). Off the hot path. NEVER raises."""
+        try:
+            with self._lock:
+                if self._mm is not None:
+                    self._mm.flush()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- public API ----------------------------------------------------------
+
+    def incr(self, name: str, n: int = 1) -> None:
+        """Atomically increment counter *name* by *n*. Microsecond lock +
+        page-cache write — no I/O syscalls. NEVER raises."""
+        if not observability_registry_enabled():
+            return
+        try:
+            with self._lock:
+                self._ensure_counter(name)
+                idx = self._slots.get(name)
+                if self._mm is not None and idx is not None:
+                    off = _HEADER_SIZE + idx * _SLOT_SIZE + _NAME_SIZE
+                    (current,) = struct.unpack_from("<Q", self._mm, off)
+                    struct.pack_into("<Q", self._mm, off, current + n)
+                else:
+                    self._memory[name] = self._memory.get(name, 0) + n
+        except Exception:  # noqa: BLE001
+            pass
+
+    def get(self, name: str) -> int:
+        """Current value of *name* (0 if unknown or disabled). NEVER raises."""
+        if not observability_registry_enabled():
+            return 0
+        try:
+            with self._lock:
+                idx = self._slots.get(name)
+                if self._mm is not None and idx is not None:
+                    off = _HEADER_SIZE + idx * _SLOT_SIZE + _NAME_SIZE
+                    (value,) = struct.unpack_from("<Q", self._mm, off)
+                    return int(value)
+                return int(self._memory.get(name, 0))
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def snapshot(self) -> Dict[str, int]:
+        """All counters as a plain dict ({} when disabled). NEVER raises."""
+        if not observability_registry_enabled():
+            return {}
+        try:
+            with self._lock:
+                out: Dict[str, int] = {}
+                if self._mm is not None:
+                    for name, idx in self._slots.items():
+                        off = _HEADER_SIZE + idx * _SLOT_SIZE + _NAME_SIZE
+                        (value,) = struct.unpack_from("<Q", self._mm, off)
+                        out[name] = int(value)
+                for name, value in self._memory.items():
+                    out.setdefault(name, int(value))
+                return out
+        except Exception:  # noqa: BLE001
+            return {}
+
+    def close(self) -> None:
+        """Stop the flusher, msync, release the mmap. NEVER raises."""
+        try:
+            self._flusher_stop.set()
+            if self._flusher is not None:
+                self._flusher.join(timeout=2.0)
+        except Exception:  # noqa: BLE001
+            pass
+        self.flush()
+        with self._lock:
+            self._teardown_mmap()
+
+
+# -- process-wide singleton ---------------------------------------------------
+
+_singleton: Optional[ObservabilityRegistry] = None
+_singleton_lock = threading.Lock()
+
+
+def get_observability_registry() -> ObservabilityRegistry:
+    """Process-wide singleton (double-checked lock). NEVER raises."""
+    global _singleton
+    if _singleton is None:
+        with _singleton_lock:
+            if _singleton is None:
+                _singleton = ObservabilityRegistry()
+    return _singleton
+
+
+def _reset_singleton_for_tests() -> None:
+    """Test seam — close and discard the singleton."""
+    global _singleton
+    with _singleton_lock:
+        if _singleton is not None:
+            _singleton.close()
+        _singleton = None
+
+
+# -- dispatch-throat helpers (fire-and-forget, NEVER raise) -------------------
+
+def record_hedge_dispatch() -> None:
+    """One proactive hedge race launched (RT + batch in flight concurrently)."""
+    try:
+        get_observability_registry().incr(HEDGE_CONCURRENCY_DISPATCHES)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def record_hedge_outcome(winner: str, rupture_swallowed: bool) -> None:
+    """One hedge race settled: which transport won, and whether an RT rupture
+    was made invisible by batch winning."""
+    try:
+        reg = get_observability_registry()
+        if str(winner).strip().lower() == "rt":
+            reg.incr(HEDGE_RT_VICTORIES)
+        else:
+            reg.incr(HEDGE_BATCH_VICTORIES)
+        if rupture_swallowed:
+            reg.incr(HEDGE_RUPTURES_SWALLOWED)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# -- GET /observability/registry ----------------------------------------------
+
+def register_registry_routes(
+    app,
+    rate_limit_check: Optional[Callable] = None,
+    cors_headers: Optional[Callable] = None,
+) -> None:
+    """Mount GET /observability/registry on a caller-supplied aiohttp app.
+
+    Mirrors the metrics_observability pattern: the caller (EventChannelServer)
+    supplies the rate-limit + CORS helpers from a dedicated
+    IDEObservabilityRouter instance so the operator-visible surface stays
+    uniform; loopback enforcement happens at the caller before mounting.
+    """
+    from aiohttp import web  # lazy — module import stays aiohttp-free
+
+    def _headers(request) -> Dict[str, str]:
+        out = {"Cache-Control": "no-store"}
+        if cors_headers is not None:
+            try:
+                out.update(cors_headers(request) or {})
+            except Exception:  # noqa: BLE001
+                pass
+        return out
+
+    async def _handle_registry(request):
+        if not observability_registry_enabled():
+            return web.json_response(
+                {"error": True, "reason_code": "ide_observability.disabled"},
+                status=403, headers=_headers(request),
+            )
+        if rate_limit_check is not None:
+            try:
+                allowed = rate_limit_check(request)
+            except Exception:  # noqa: BLE001
+                allowed = True
+            if not allowed:
+                return web.json_response(
+                    {"error": True, "reason_code": "ide_observability.rate_limited"},
+                    status=429, headers=_headers(request),
+                )
+        reg = get_observability_registry()
+        return web.json_response(
+            {
+                "schema_version": REGISTRY_SCHEMA_VERSION,
+                "backend": reg.backend_kind,
+                "counters": reg.snapshot(),
+                "generated_at_unix": time.time(),
+            },
+            status=200, headers=_headers(request),
+        )
+
+    app.router.add_get("/observability/registry", _handle_registry)

--- a/tests/governance/test_observability_registry.py
+++ b/tests/governance/test_observability_registry.py
@@ -1,0 +1,329 @@
+"""Slice 193 — Sovereign Telemetry Registry (structured hedge observability).
+
+The Slice 192 verdict was readable only by cross-referencing the aegis proxy's
+HTTP log: the hedge's win/loss/swallow telemetry is logger.info (invisible at
+the soak's WARNING threshold) and the Slice 190 counters are in-memory only.
+This slice gives the organism a structured, durable, unsuppressed metrics
+surface — counters, not log lines (Manifesto §7).
+
+Pins:
+  * ObservabilityRegistry — thread-safe, mmap-backed atomic counters that
+    survive process restart (.jarvis/observability_registry.bin).
+  * 10 concurrent hedge victories update the registry EXACTLY (no lost incr).
+  * Corrupt/unwritable backing file → fail-soft in-memory fallback, NEVER
+    raises into the dispatch throat.
+  * record_hedge_dispatch / record_hedge_outcome module helpers are wired
+    into the doubleword_provider hedge block (source-pinned).
+  * GET /observability/registry — 403 master-off, structured payload
+    master-on, Cache-Control: no-store. Mounted in EventChannelServer
+    (source-pinned).
+  * Authority invariant: the module never imports orchestrator / policy /
+    iron_gate / change_engine / candidate_generator (grep-pinned).
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.observability_registry import (
+    HEDGE_BATCH_VICTORIES,
+    HEDGE_CONCURRENCY_DISPATCHES,
+    HEDGE_RT_VICTORIES,
+    HEDGE_RUPTURES_SWALLOWED,
+    REGISTRY_SCHEMA_VERSION,
+    ObservabilityRegistry,
+    _reset_singleton_for_tests,
+    get_observability_registry,
+    observability_registry_enabled,
+    record_hedge_dispatch,
+    record_hedge_outcome,
+    register_registry_routes,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GOV = _REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch, tmp_path):
+    """Every test gets an isolated backing file + a fresh singleton."""
+    monkeypatch.setenv(
+        "JARVIS_OBSERVABILITY_REGISTRY_PATH", str(tmp_path / "reg.bin"),
+    )
+    monkeypatch.delenv("JARVIS_OBSERVABILITY_REGISTRY_ENABLED", raising=False)
+    _reset_singleton_for_tests()
+    yield
+    _reset_singleton_for_tests()
+
+
+# ===========================================================================
+# A — master gate
+# ===========================================================================
+
+def test_enabled_default_true():
+    """Authority-free observability defaults ON (economic_telemetry
+    precedent, Slice 171)."""
+    assert observability_registry_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "FALSE"])
+def test_enabled_falsy_values_disable(monkeypatch, val):
+    monkeypatch.setenv("JARVIS_OBSERVABILITY_REGISTRY_ENABLED", val)
+    assert observability_registry_enabled() is False
+
+
+# ===========================================================================
+# B — counter core
+# ===========================================================================
+
+def test_hedge_counters_preregistered_at_zero():
+    """The four hedge counters exist from birth so the soak payload always
+    shows them — a 0 is a verdict, a missing key is a question."""
+    snap = get_observability_registry().snapshot()
+    for name in (
+        HEDGE_CONCURRENCY_DISPATCHES,
+        HEDGE_RT_VICTORIES,
+        HEDGE_BATCH_VICTORIES,
+        HEDGE_RUPTURES_SWALLOWED,
+    ):
+        assert snap[name] == 0
+
+
+def test_incr_and_get():
+    reg = get_observability_registry()
+    reg.incr(HEDGE_RT_VICTORIES)
+    reg.incr(HEDGE_RT_VICTORIES, 4)
+    assert reg.get(HEDGE_RT_VICTORIES) == 5
+
+
+def test_incr_auto_registers_new_counter():
+    reg = get_observability_registry()
+    reg.incr("custom_sensor_emissions", 7)
+    assert reg.snapshot()["custom_sensor_emissions"] == 7
+
+
+def test_disabled_incr_is_noop(monkeypatch):
+    monkeypatch.setenv("JARVIS_OBSERVABILITY_REGISTRY_ENABLED", "false")
+    _reset_singleton_for_tests()
+    reg = get_observability_registry()
+    reg.incr(HEDGE_RT_VICTORIES)
+    assert reg.snapshot() == {}
+
+
+# ===========================================================================
+# C — atomicity under concurrency (Phase 4 acceptance criterion)
+# ===========================================================================
+
+def test_ten_concurrent_hedge_victories_exact():
+    """10 threads each record one hedge victory concurrently → registry
+    state is EXACTLY 10. The user-pinned Slice 193 acceptance test."""
+    barrier = threading.Barrier(10)
+
+    def _win(i):
+        barrier.wait()
+        record_hedge_outcome("rt" if i % 2 == 0 else "batch",
+                             rupture_swallowed=(i % 3 == 0))
+
+    threads = [threading.Thread(target=_win, args=(i,)) for i in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    snap = get_observability_registry().snapshot()
+    assert snap[HEDGE_RT_VICTORIES] == 5
+    assert snap[HEDGE_BATCH_VICTORIES] == 5
+    assert snap[HEDGE_RT_VICTORIES] + snap[HEDGE_BATCH_VICTORIES] == 10
+    assert snap[HEDGE_RUPTURES_SWALLOWED] == 4  # i in {0, 3, 6, 9}
+
+
+def test_hammer_no_lost_increments():
+    """8 threads × 1000 increments → exactly 8000 (no torn mmap writes)."""
+    reg = get_observability_registry()
+
+    def _hammer():
+        for _ in range(1000):
+            reg.incr(HEDGE_CONCURRENCY_DISPATCHES)
+
+    threads = [threading.Thread(target=_hammer) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert reg.get(HEDGE_CONCURRENCY_DISPATCHES) == 8000
+
+
+# ===========================================================================
+# D — mmap durability + fail-soft
+# ===========================================================================
+
+def test_counters_survive_reopen(tmp_path):
+    path = tmp_path / "durable.bin"
+    reg = ObservabilityRegistry(path=path)
+    reg.incr(HEDGE_BATCH_VICTORIES, 42)
+    reg.incr("custom_counter", 3)
+    reg.close()
+
+    reborn = ObservabilityRegistry(path=path)
+    assert reborn.get(HEDGE_BATCH_VICTORIES) == 42
+    assert reborn.get("custom_counter") == 3
+    assert reborn.backend_kind == "mmap"
+    reborn.close()
+
+
+def test_corrupt_backing_file_fails_soft(tmp_path):
+    """Garbage backing file → in-memory fallback; counting still works and
+    nothing raises into the dispatch throat."""
+    path = tmp_path / "corrupt.bin"
+    path.write_bytes(b"\x00garbage" * 7)
+    reg = ObservabilityRegistry(path=path)
+    reg.incr(HEDGE_RT_VICTORIES)
+    assert reg.get(HEDGE_RT_VICTORIES) == 1
+    assert reg.backend_kind == "memory"
+    reg.close()
+
+
+def test_unwritable_path_fails_soft():
+    reg = ObservabilityRegistry(path=Path("/nonexistent-dir-x9/reg.bin"))
+    reg.incr(HEDGE_RT_VICTORIES, 2)
+    assert reg.get(HEDGE_RT_VICTORIES) == 2
+    assert reg.backend_kind == "memory"
+    reg.close()
+
+
+def test_singleton_uses_env_path(tmp_path, monkeypatch):
+    p = tmp_path / "envpath.bin"
+    monkeypatch.setenv("JARVIS_OBSERVABILITY_REGISTRY_PATH", str(p))
+    _reset_singleton_for_tests()
+    get_observability_registry().incr(HEDGE_RT_VICTORIES)
+    assert p.exists()
+
+
+# ===========================================================================
+# E — hedge recording helpers (the dispatch-throat API)
+# ===========================================================================
+
+def test_record_hedge_dispatch_increments():
+    record_hedge_dispatch()
+    record_hedge_dispatch()
+    assert get_observability_registry().get(HEDGE_CONCURRENCY_DISPATCHES) == 2
+
+
+def test_record_hedge_outcome_rt_no_rupture():
+    record_hedge_outcome("rt", rupture_swallowed=False)
+    snap = get_observability_registry().snapshot()
+    assert snap[HEDGE_RT_VICTORIES] == 1
+    assert snap[HEDGE_BATCH_VICTORIES] == 0
+    assert snap[HEDGE_RUPTURES_SWALLOWED] == 0
+
+
+def test_record_hedge_outcome_batch_with_swallow():
+    record_hedge_outcome("batch", rupture_swallowed=True)
+    snap = get_observability_registry().snapshot()
+    assert snap[HEDGE_BATCH_VICTORIES] == 1
+    assert snap[HEDGE_RUPTURES_SWALLOWED] == 1
+
+
+def test_helpers_never_raise_when_disabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_OBSERVABILITY_REGISTRY_ENABLED", "0")
+    _reset_singleton_for_tests()
+    record_hedge_dispatch()
+    record_hedge_outcome("rt", rupture_swallowed=True)
+
+
+# ===========================================================================
+# F — dispatch-throat wiring (source-pinned, repo precedent)
+# ===========================================================================
+
+def test_provider_hedge_block_wired_to_registry():
+    src = (_GOV / "doubleword_provider.py").read_text(encoding="utf-8")
+    assert "record_hedge_dispatch" in src, (
+        "the hedge race site must count hedge_concurrency_dispatches"
+    )
+    assert src.count("record_hedge_outcome") >= 2, (
+        "the win lambda must feed BOTH the economic ledger (190) and the "
+        "registry (193)"
+    )
+
+
+def test_event_channel_mounts_registry_routes():
+    src = (_GOV / "event_channel.py").read_text(encoding="utf-8")
+    assert "register_registry_routes" in src
+
+
+def test_authority_invariant_no_wide_imports():
+    src = (_GOV / "observability_registry.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "import orchestrator", "from backend.core.ouroboros.governance.orchestrator",
+        "iron_gate", "change_engine", "candidate_generator",
+        "semantic_guardian", "risk_tier",
+    ):
+        assert forbidden not in src, f"authority leak: {forbidden}"
+
+
+# ===========================================================================
+# G — GET /observability/registry
+# ===========================================================================
+
+async def _get(app, path):
+    aiohttp_test = pytest.importorskip("aiohttp.test_utils")
+    async with aiohttp_test.TestServer(app) as server:
+        async with aiohttp_test.TestClient(server) as client:
+            resp = await client.get(path)
+            return resp.status, await resp.json(), dict(resp.headers)
+
+
+def _make_app():
+    web = pytest.importorskip("aiohttp.web")
+    app = web.Application()
+    register_registry_routes(
+        app,
+        rate_limit_check=lambda req: True,
+        cors_headers=lambda req: {"Access-Control-Allow-Origin": "x"},
+    )
+    return app
+
+
+def test_endpoint_disabled_returns_403(monkeypatch):
+    monkeypatch.setenv("JARVIS_OBSERVABILITY_REGISTRY_ENABLED", "false")
+    _reset_singleton_for_tests()
+    app = _make_app()
+
+    async def _run():
+        status, body, _ = await _get(app, "/observability/registry")
+        assert status == 403
+        assert body["error"] is True
+        assert body["reason_code"] == "ide_observability.disabled"
+    asyncio.run(_run())
+
+
+def test_endpoint_returns_structured_counters():
+    record_hedge_dispatch()
+    record_hedge_outcome("rt", rupture_swallowed=False)
+    app = _make_app()
+
+    async def _run():
+        status, body, headers = await _get(app, "/observability/registry")
+        assert status == 200
+        assert body["schema_version"] == REGISTRY_SCHEMA_VERSION
+        assert body["backend"] in ("mmap", "memory")
+        c = body["counters"]
+        assert c[HEDGE_CONCURRENCY_DISPATCHES] == 1
+        assert c[HEDGE_RT_VICTORIES] == 1
+        assert c[HEDGE_BATCH_VICTORIES] == 0
+        assert c[HEDGE_RUPTURES_SWALLOWED] == 0
+        assert headers.get("Cache-Control") == "no-store"
+    asyncio.run(_run())
+
+
+def test_endpoint_rate_limited_returns_429():
+    app = pytest.importorskip("aiohttp.web").Application()
+    register_registry_routes(app, rate_limit_check=lambda req: False)
+
+    async def _run():
+        status, body, _ = await _get(app, "/observability/registry")
+        assert status == 429
+    asyncio.run(_run())


### PR DESCRIPTION
## Why

The Slice 192 live verdict (hedge raced at T=0, op-019eae3a) was readable only by cross-referencing the aegis proxy HTTP log: the hedge's `racing`/`WON by`/`SWALLOWED` telemetry is `logger.info` — invisible at the soak's WARNING console threshold — and the Slice 190 economic counters are in-memory only, lost on every restart. Promoting victory logs to WARNING would dilute the warning channel. The structural answer is metrics, not noisier text (Manifesto §7).

## What

- **`observability_registry.py`** — thread-safe atomic counter registry backed by a fixed-slot mmap file (`.jarvis/observability_registry.bin`, magic `JOR1`, 256 × name/u64 slots). An increment is one microsecond lock + page-cache write (no syscall I/O on the dispatch throat); durability via a background daemon flusher (msync off the hot path, zero GIL contention during generation). Corrupt / unwritable backing file → fail-soft in-memory counting; the public API NEVER raises.
- **Four charter counters**: `hedge_concurrency_dispatches`, `hedge_rt_victories`, `hedge_batch_victories`, `hedge_ruptures_swallowed` — pre-registered at 0 so a zero is a verdict, not a question.
- **Dispatch-throat wiring** (`doubleword_provider.py`): the race site counts dispatches; the `_s190_hedge_outcome` callback feeds BOTH the existing economic ledger (171) and the durable registry.
- **`GET /observability/registry`** mounted on `EventChannelServer` — 403 master-off, 429 rate-limited, `Cache-Control: no-store`, loopback-only; mirrors the `metrics_observability` mount pattern exactly.
- **Masters**: `JARVIS_OBSERVABILITY_REGISTRY_ENABLED` (default true), `JARVIS_OBSERVABILITY_REGISTRY_PATH`, `JARVIS_OBSERVABILITY_REGISTRY_FLUSH_S`.

## Verification (TDD, RED→GREEN)

- 26 new tests: 10-concurrent-victory exactness (user-pinned acceptance), 8×1000 hammer (no torn writes), close/reopen durability, corruption + unwritable-path fail-soft, helper no-op when disabled, dispatch-throat + event-channel source pins, authority grep-pin, endpoint 403/429/200 payload.
- 245 regression green: hedge family (188/189/190/192 + 170 + metrics_observability) 84, event_channel + IDE observability 161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a durable, mmap-backed telemetry registry for hedge metrics and a new `/observability/registry` endpoint. Hedge dispatches and outcomes are now counted across restarts without extra log noise or risk of raising in hot paths.

- **New Features**
  - Thread-safe counter registry backed by mmap with in-memory fail-soft, background flusher, and a no-raise API.
  - Pre-registered counters: hedge_concurrency_dispatches, hedge_rt_victories, hedge_batch_victories, hedge_ruptures_swallowed.
  - Dispatch wiring: counts each hedge launch; outcome records RT vs Batch wins and whether a rupture was swallowed.
  - Event channel: GET `/observability/registry` (403 when disabled, 429 when rate-limited, `Cache-Control: no-store`, loopback-only) mirroring the existing metrics mount.
  - Tests cover concurrency accuracy, durability across restarts, corrupt/unwritable fallback, and endpoint behavior.

- **Migration**
  - No action required; enabled by default. Optional envs: `JARVIS_OBSERVABILITY_REGISTRY_ENABLED`, `JARVIS_OBSERVABILITY_REGISTRY_PATH`, `JARVIS_OBSERVABILITY_REGISTRY_FLUSH_S`.

<sup>Written for commit a28b00f0ade243a0873dc7356b7781e87b084ff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

