### PR TITLE
feat(routing): Slice 194 - race-triage + cross-model rotation matrix (dual-arm failure recovery)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3328,6 +3328,28 @@ class CandidateGenerator:
                 # the tracker module is missing / unimportable / raises,
                 # fall through to normal attempt (legacy behavior).
                 pass
+            # Slice 194 — race-triage rotation. If BOTH hedge arms died on
+            # this model earlier in this same op (confirmed hard blockage),
+            # skip the corpse — the next iteration IS the next-highest-ranked
+            # catalog candidate. OWN master (JARVIS_RACE_TRIAGE_ENABLED,
+            # default TRUE, failure-path-only) — deliberately independent of
+            # the default-FALSE drift-rotation master above.
+            try:
+                from backend.core.ouroboros.governance.race_triage import (
+                    is_blacklisted_for_op as _s194_is_blacklisted,
+                )
+                _s194_op_id = getattr(context, "op_id", "") or ""
+                if _s194_is_blacklisted(_s194_op_id, model_id):
+                    logger.warning(
+                        "[RaceTriage] Sentinel dispatch: route=%s model=%s "
+                        "dual-arm-blacklisted on op — rotating to next ranked "
+                        "candidate (op=%s)",
+                        provider_route, model_id, op_id_short,
+                    )
+                    attempts.append(f"{model_id}:skipped_dual_arm")
+                    continue
+            except Exception:  # noqa: BLE001 — rotation is enhancement, not gate
+                pass
             attempts.append(f"{model_id}:attempted")
             # Stamp the per-attempt override via ContextVar (async-safe
             # per asyncio task, survives the frozen OperationContext

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -2281,6 +2281,49 @@ class DoublewordProvider:
                     except Exception:  # noqa: BLE001
                         pass
 
+                def _s194_on_abandoned(
+                    fast_exc: Optional[BaseException],
+                    stable_exc: Optional[BaseException],
+                ) -> None:
+                    # Slice 194 — the race died with NO winner. Count it
+                    # (explicit, no more derived-gap arithmetic), then triage:
+                    # a confirmed hard blockage blacklists THIS model for THIS
+                    # op so the sentinel walker rotates to the next ranked
+                    # candidate instead of re-walking the corpse every retry.
+                    try:
+                        from backend.core.ouroboros.governance.observability_registry import (
+                            record_hedge_abandoned as _s194_record_abandoned,
+                        )
+                        _s194_record_abandoned()
+                    except Exception:  # noqa: BLE001
+                        pass
+                    try:
+                        from backend.core.ouroboros.governance.race_triage import (
+                            race_triage_enabled as _s194_enabled,
+                            record_dual_arm_blacklist as _s194_blacklist,
+                            triage_dual_failure,
+                        )
+                        if not _s194_enabled():
+                            return
+                        verdict = triage_dual_failure(fast_exc, stable_exc)
+                        _s194_op = getattr(context, "op_id", "") or ""
+                        _s194_model = ""
+                        try:
+                            _s194_model = self._resolve_effective_model(context) or ""
+                        except Exception:  # noqa: BLE001
+                            pass
+                        logger.warning(
+                            "[RaceTriage] hedge race ABANDONED op=%s model=%s "
+                            "fast=%s stable=%s hard_blockage=%s — %s",
+                            _s194_op[:16], _s194_model,
+                            verdict.fast_class.value, verdict.stable_class.value,
+                            verdict.hard_blockage, verdict.reason,
+                        )
+                        if verdict.hard_blockage:
+                            _s194_blacklist(_s194_op, _s194_model, verdict)
+                    except Exception:  # noqa: BLE001
+                        pass
+
                 return await hedged_race(
                     lambda: self._generate_realtime(
                         context, deadline, prompt_override=prompt_override,
@@ -2292,6 +2335,7 @@ class DoublewordProvider:
                     fast_label="rt",
                     stable_label="batch",
                     on_outcome=_s190_hedge_outcome,
+                    on_abandoned=_s194_on_abandoned,
                 )
             try:
                 # Slice 9.1 — thread repair_context for L2 single-shot

--- a/backend/core/ouroboros/governance/dw_transport_hedge.py
+++ b/backend/core/ouroboros/governance/dw_transport_hedge.py
@@ -54,6 +54,9 @@ async def hedged_race(
     fast_label: str = "rt",
     stable_label: str = "batch",
     on_outcome: Optional[Callable[[str, bool], None]] = None,
+    on_abandoned: Optional[
+        Callable[[Optional[BaseException], Optional[BaseException]], None]
+    ] = None,
 ) -> Any:
     """Race ``fast`` (RT) against ``stable`` (batch). Return the FIRST successful result; cancel
     the loser aggressively. A ``fast`` failure that ``is_rupture`` returns True for is swallowed so
@@ -63,12 +66,20 @@ async def hedged_race(
     ``on_outcome(winner_label, rupture_swallowed)`` is invoked on the winning result so the caller
     can record telemetry — which transport won, and whether an RT rupture was made INVISIBLE by
     the stable path winning (a proactive capital-save). Best-effort: a sink error never breaks the
-    race."""
+    race.
+
+    ``on_abandoned(fast_exc, stable_exc)`` (Slice 194) fires when the race dies with NO winner —
+    both arms resolved, neither succeeded — passing each arm's captured exception (None for an
+    arm that was cancelled / never errored). The caller's triage engine classifies the pair to
+    confirm a hard model/endpoint blockage and rotate candidates. Best-effort: a sink error never
+    changes the raise behavior; the abandoned race still raises its last exception."""
     loop = asyncio.get_event_loop()
     t_fast = loop.create_task(fast())
     t_stable = loop.create_task(stable())
     pending = {t_fast, t_stable}
     last_exc: Optional[BaseException] = None
+    fast_exc: Optional[BaseException] = None
+    stable_exc: Optional[BaseException] = None
     fast_ruptured = False
 
     def _report(winner_label: str) -> None:
@@ -88,6 +99,11 @@ async def hedged_race(
                     continue
                 except BaseException as exc:  # noqa: BLE001
                     last_exc = exc
+                    # Slice 194 — capture per-arm so a dual failure can be triaged.
+                    if t is t_fast:
+                        fast_exc = exc
+                    else:
+                        stable_exc = exc
                     # a fast-path rupture is non-fatal — let the stable path keep racing
                     if t is t_fast and is_rupture(exc):
                         fast_ruptured = True
@@ -105,6 +121,15 @@ async def hedged_race(
                     return result
         # both finished without a success
         if last_exc is not None:
+            # Slice 194 — the race was ABANDONED (no winner). Hand both arms'
+            # exceptions to the caller's triage engine before raising. Only
+            # fires when at least one arm actually errored — a pure-cancellation
+            # unwind (outer shutdown) is not an abandoned race.
+            if on_abandoned is not None:
+                try:
+                    on_abandoned(fast_exc, stable_exc)
+                except Exception:  # noqa: BLE001 — triage never changes the raise
+                    pass
             raise last_exc
         raise RuntimeError("hedged_race: both transports resolved without a result")
     finally:

--- a/backend/core/ouroboros/governance/observability_registry.py
+++ b/backend/core/ouroboros/governance/observability_registry.py
@@ -63,17 +63,21 @@ _SLOT_SIZE = _NAME_SIZE + 8
 _MAX_SLOTS = 256
 _FILE_SIZE = _HEADER_SIZE + _MAX_SLOTS * _SLOT_SIZE
 
-# The four long-window hedge metrics (Slice 193 charter).
+# The long-window hedge metrics (Slice 193 charter + Slice 194 abandoned races).
 HEDGE_CONCURRENCY_DISPATCHES = "hedge_concurrency_dispatches"
 HEDGE_RT_VICTORIES = "hedge_rt_victories"
 HEDGE_BATCH_VICTORIES = "hedge_batch_victories"
 HEDGE_RUPTURES_SWALLOWED = "hedge_ruptures_swallowed"
+# Slice 194 — a race where BOTH arms failed (no winner). Previously only
+# derivable as dispatches − victories; now explicit and self-describing.
+HEDGE_RACES_ABANDONED = "hedge_races_abandoned"
 
 _PREREGISTERED = (
     HEDGE_CONCURRENCY_DISPATCHES,
     HEDGE_RT_VICTORIES,
     HEDGE_BATCH_VICTORIES,
     HEDGE_RUPTURES_SWALLOWED,
+    HEDGE_RACES_ABANDONED,
 )
 
 
@@ -316,6 +320,14 @@ def record_hedge_dispatch() -> None:
     """One proactive hedge race launched (RT + batch in flight concurrently)."""
     try:
         get_observability_registry().incr(HEDGE_CONCURRENCY_DISPATCHES)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def record_hedge_abandoned() -> None:
+    """Slice 194 — one hedge race died with NO winner (both arms failed)."""
+    try:
+        get_observability_registry().incr(HEDGE_RACES_ABANDONED)
     except Exception:  # noqa: BLE001
         pass
 

--- a/backend/core/ouroboros/governance/race_triage.py
+++ b/backend/core/ouroboros/governance/race_triage.py
@@ -1,0 +1,187 @@
+"""Slice 194 — Race-Triage & Cross-Model Rotation Matrix.
+
+The Slice 193 registry made abandoned hedge races VISIBLE (dispatches −
+victories); this module makes them ACTIONABLE. When BOTH arms of a proactive
+hedge die (e.g. an RT ``RuntimeError`` + a structural batch rejection — the
+live op-019eae7b shape), the organism must not blindly re-walk the same dead
+model every retry round. The triage engine:
+
+  1. Classifies each arm's exception signature (:func:`classify_arm`) and
+     confirms a HARD model/endpoint blockage (:func:`triage_dual_failure`).
+     Carve-outs per Slice 185 doctrine: an INTERNAL fault (NameError /
+     TypeError / … — OUR bug) never blames the model, and a cancelled or
+     absent arm is shutdown noise, not blockage evidence.
+  2. Blacklists the model FOR THE SCOPE OF THE CURRENT OPERATION
+     (:func:`record_dual_arm_blacklist`), riding the schema_drift_tracker's
+     bounded per-op storage (``DriftType.DUAL_ARM_FAILURE``) so dual-arm
+     events share the /drift audit surface for free.
+  3. Exposes its OWN dispatch skip predicate (:func:`is_blacklisted_for_op`)
+     gated by ``JARVIS_RACE_TRIAGE_ENABLED`` (default TRUE — failure-path-
+     only, Slice 170 precedent: it engages only after a race ALREADY died,
+     so it can only improve the retry). Deliberately INDEPENDENT of the
+     drift-rotation master (``JARVIS_SCHEMA_DRIFT_ROTATION_ENABLED``,
+     default FALSE) so the soak rotates without extra env flips.
+
+Cross-model rotation is structural, not duplicated: the sentinel walker in
+``candidate_generator`` iterates ``ranked_models`` (the brain_selection_policy
+/ dw_catalog ranking) — skipping a blacklisted model means the next loop
+iteration IS the next-highest-ranked candidate (Qwen → Nemotron → DeepSeek),
+within the same execution cycle. No new catalog query, no blind retry.
+
+Authority invariants: counts and skips ONE doomed candidate per op — never
+gates an operation, never imports the orchestrator/gate family. NEVER raises
+into the dispatch throat.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_RACE_TRIAGE_ENABLED"
+
+
+def race_triage_enabled() -> bool:
+    """Master gate (default TRUE — failure-path-only: engages only after a
+    hedge race has already died with no winner). NEVER raises."""
+    return os.environ.get(_ENV_ENABLED, "true").strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
+class ArmFailureClass(str, Enum):
+    """How one arm of an abandoned race died."""
+
+    VENDOR = "vendor"
+    """A vendor-lane failure (transport rupture, 429/5xx, structural/parse
+    rejection) — evidence against THIS model/endpoint."""
+
+    INTERNAL_FAULT = "internal_fault"
+    """A Python logic error — OUR bug (Slice 185 taxonomy). Never blames
+    the model; the strict-type segregation upstream crashes it loudly."""
+
+    CANCELLED = "cancelled"
+    """The arm was cancelled (race unwind / outer shutdown) — no evidence."""
+
+    ABSENT = "absent"
+    """No exception captured for this arm — no evidence."""
+
+
+@dataclass(frozen=True)
+class RaceTriageVerdict:
+    """The triage engine's ruling on one abandoned race."""
+
+    hard_blockage: bool
+    reason: str
+    fast_class: ArmFailureClass
+    stable_class: ArmFailureClass
+
+
+def classify_arm(exc: Optional[BaseException]) -> ArmFailureClass:
+    """Classify one arm's exception signature. NEVER raises."""
+    try:
+        if exc is None:
+            return ArmFailureClass.ABSENT
+        if isinstance(exc, asyncio.CancelledError):
+            return ArmFailureClass.CANCELLED
+        try:
+            from backend.core.ouroboros.governance.dw_fault_taxonomy import (
+                is_internal_fault,
+            )
+            if is_internal_fault(exc):
+                return ArmFailureClass.INTERNAL_FAULT
+        except Exception:  # noqa: BLE001 — taxonomy unavailable → vendor lane
+            pass
+        return ArmFailureClass.VENDOR
+    except Exception:  # noqa: BLE001
+        return ArmFailureClass.ABSENT
+
+
+def triage_dual_failure(
+    fast_exc: Optional[BaseException],
+    stable_exc: Optional[BaseException],
+) -> RaceTriageVerdict:
+    """Analyze both arms' exception signatures. A HARD blockage requires BOTH
+    arms to have failed in the vendor lane — two independent transports dying
+    on the same model is the signature of a dead model/endpoint, not a blip.
+    NEVER raises."""
+    fast_class = classify_arm(fast_exc)
+    stable_class = classify_arm(stable_exc)
+    if ArmFailureClass.INTERNAL_FAULT in (fast_class, stable_class):
+        return RaceTriageVerdict(
+            hard_blockage=False,
+            reason="internal fault present — our bug, never blame the model",
+            fast_class=fast_class, stable_class=stable_class,
+        )
+    if fast_class is not ArmFailureClass.VENDOR or (
+        stable_class is not ArmFailureClass.VENDOR
+    ):
+        return RaceTriageVerdict(
+            hard_blockage=False,
+            reason="single-arm evidence only (other arm cancelled/absent)",
+            fast_class=fast_class, stable_class=stable_class,
+        )
+    return RaceTriageVerdict(
+        hard_blockage=True,
+        reason=(
+            f"both transports failed independently "
+            f"(fast={type(fast_exc).__name__}, stable={type(stable_exc).__name__})"
+        ),
+        fast_class=fast_class, stable_class=stable_class,
+    )
+
+
+def record_dual_arm_blacklist(
+    op_id: str, model_id: str, verdict: RaceTriageVerdict,
+) -> bool:
+    """Blacklist ``model_id`` for the scope of ``op_id`` (hard verdicts only).
+    Returns True iff recorded. NEVER raises."""
+    try:
+        if not race_triage_enabled() or not verdict.hard_blockage:
+            return False
+        if not op_id or not model_id:
+            return False
+        from backend.core.ouroboros.governance.schema_drift_tracker import (
+            DriftType,
+            get_default_tracker,
+        )
+        get_default_tracker().record(
+            op_id=op_id,
+            model_id=model_id,
+            drift_type=DriftType.DUAL_ARM_FAILURE,
+            raw_excerpt=verdict.reason,
+        )
+        logger.warning(
+            "[RaceTriage] dual-arm failure CONFIRMED: model=%s blacklisted for "
+            "op=%s (%s) — next dispatch rotates to the next ranked candidate",
+            model_id, op_id[:16], verdict.reason,
+        )
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def is_blacklisted_for_op(op_id: str, model_id: str) -> bool:
+    """Dispatch skip predicate — has ``model_id`` suffered a confirmed
+    dual-arm failure on ``op_id``? Independent of the drift-rotation master
+    (this kind's rotation is owned by JARVIS_RACE_TRIAGE_ENABLED). O(events
+    for the op), bounded by the tracker's per-op ring. NEVER raises."""
+    try:
+        if not race_triage_enabled() or not op_id or not model_id:
+            return False
+        from backend.core.ouroboros.governance.schema_drift_tracker import (
+            DriftType,
+            get_default_tracker,
+        )
+        return any(
+            ev.model_id == model_id
+            and ev.drift_type is DriftType.DUAL_ARM_FAILURE
+            for ev in get_default_tracker().events_for(op_id)
+        )
+    except Exception:  # noqa: BLE001
+        return False

--- a/backend/core/ouroboros/governance/schema_drift_tracker.py
+++ b/backend/core/ouroboros/governance/schema_drift_tracker.py
@@ -136,6 +136,19 @@ class DriftType(str, Enum):
     A sibling model may be less prone to this judgment.
     """
 
+    DUAL_ARM_FAILURE = "dual_arm_failure"
+    """Slice 194 — a proactive hedge race where BOTH transport arms failed
+    on this model (e.g. an RT RuntimeError + a structural batch rejection).
+
+    Sourced from ``race_triage.record_dual_arm_blacklist`` after the
+    triage engine confirms a hard model/endpoint blockage (internal
+    faults and cancelled arms are carved out — Slice 185 doctrine).
+    Stored here so dual-arm events share the bounded per-op storage and
+    the /drift audit surface; the dispatch skip predicate for THIS kind
+    is ``race_triage.is_blacklisted_for_op`` (own master, default TRUE),
+    NOT ``has_drifted`` (whose rotation master defaults FALSE).
+    """
+
 
 @dataclass(frozen=True)
 class DriftEvent:

--- a/tests/governance/test_slice194_race_triage.py
+++ b/tests/governance/test_slice194_race_triage.py
@@ -1,0 +1,336 @@
+"""Slice 194 — Race-Triage & Cross-Model Rotation Matrix.
+
+The Slice 193 registry exposed a live gap: ``dispatches − victories = 2``
+races died with NO winner (op-019eae7b: RT RuntimeError + structural parser
+rejection) and the op kept re-walking the same dead model every ~2 minutes.
+A Sovereign Organism does not watch its races die — it triages and rotates.
+
+Pins:
+  * ``hedge_races_abandoned`` — explicit charter counter in the mmap registry
+    (no more derived-gap arithmetic).
+  * ``hedged_race(on_abandoned=...)`` — fires EXACTLY when both arms fail,
+    with per-arm exceptions; never fires on a win; a sink error never
+    changes the race's raise behavior.
+  * ``race_triage.triage_dual_failure`` — exception-signature analysis:
+    dual vendor failures → hard model/endpoint blockage; an INTERNAL fault
+    (our bug, Slice 185 taxonomy) or a cancelled arm NEVER blames the model.
+  * Per-op blacklist rides the schema_drift_tracker's bounded storage
+    (DriftType.DUAL_ARM_FAILURE) but is gated by JARVIS_RACE_TRIAGE_ENABLED
+    (default TRUE, failure-path-only) — INDEPENDENT of the default-FALSE
+    drift-rotation master, so the soak rotates without extra env flips.
+  * Sentinel walker skips blacklisted models → the next iteration IS the
+    next-highest-ranked catalog candidate (no blind retry, no 2-min stall).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_transport_hedge import hedged_race
+from backend.core.ouroboros.governance.observability_registry import (
+    HEDGE_RACES_ABANDONED,
+    _reset_singleton_for_tests,
+    get_observability_registry,
+    record_hedge_abandoned,
+)
+from backend.core.ouroboros.governance.race_triage import (
+    ArmFailureClass,
+    classify_arm,
+    is_blacklisted_for_op,
+    race_triage_enabled,
+    record_dual_arm_blacklist,
+    triage_dual_failure,
+)
+from backend.core.ouroboros.governance.schema_drift_tracker import (
+    DriftType,
+    get_default_tracker,
+    reset_default_tracker,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GOV = _REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+
+
+def _vendor_rejection(msg: str, status_code: int = 422) -> ValueError:
+    """A provider-layer structural rejection: per the Slice 185 taxonomy a
+    ValueError is ambiguous-internal UNLESS it carries a vendor status_code
+    (i.e. it came structured from the provider layer)."""
+    exc = ValueError(msg)
+    exc.status_code = status_code
+    return exc
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "JARVIS_OBSERVABILITY_REGISTRY_PATH", str(tmp_path / "reg.bin"),
+    )
+    monkeypatch.delenv("JARVIS_OBSERVABILITY_REGISTRY_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_RACE_TRIAGE_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_SCHEMA_DRIFT_ROTATION_ENABLED", raising=False)
+    _reset_singleton_for_tests()
+    reset_default_tracker()
+    yield
+    _reset_singleton_for_tests()
+    reset_default_tracker()
+
+
+# ===========================================================================
+# A — the explicit abandoned counter (Phase 1)
+# ===========================================================================
+
+def test_abandoned_counter_preregistered_at_zero():
+    assert get_observability_registry().snapshot()[HEDGE_RACES_ABANDONED] == 0
+
+
+def test_record_hedge_abandoned_increments():
+    record_hedge_abandoned()
+    record_hedge_abandoned()
+    assert get_observability_registry().get(HEDGE_RACES_ABANDONED) == 2
+
+
+# ===========================================================================
+# B — hedged_race on_abandoned hook (Phase 2)
+# ===========================================================================
+
+def test_dual_arm_failure_fires_on_abandoned_and_still_raises():
+    seen = {}
+
+    async def _fast():
+        raise RuntimeError("rt stream severed")
+
+    async def _stable():
+        await asyncio.sleep(0.01)
+        raise _vendor_rejection("batch candidate rejected: full_content too short")
+
+    def _abandoned(fast_exc, stable_exc):
+        seen["fast"] = fast_exc
+        seen["stable"] = stable_exc
+
+    async def _run():
+        with pytest.raises(ValueError):
+            await hedged_race(
+                _fast, _stable,
+                is_rupture=lambda e: isinstance(e, RuntimeError),
+                on_abandoned=_abandoned,
+            )
+    asyncio.run(_run())
+    assert isinstance(seen["fast"], RuntimeError)
+    assert isinstance(seen["stable"], ValueError)
+
+
+def test_winner_never_fires_on_abandoned():
+    called = []
+
+    async def _fast():
+        return "rt-result"
+
+    async def _stable():
+        await asyncio.sleep(5)
+        return "batch-result"
+
+    async def _run():
+        return await hedged_race(
+            _fast, _stable, on_abandoned=lambda f, s: called.append(1),
+        )
+    assert asyncio.run(_run()) == "rt-result"
+    assert called == []
+
+
+def test_swallowed_rupture_with_stable_win_never_fires_on_abandoned():
+    called = []
+
+    async def _fast():
+        raise RuntimeError("rupture")
+
+    async def _stable():
+        await asyncio.sleep(0.01)
+        return "batch-result"
+
+    async def _run():
+        return await hedged_race(
+            _fast, _stable,
+            is_rupture=lambda e: True,
+            on_abandoned=lambda f, s: called.append(1),
+        )
+    assert asyncio.run(_run()) == "batch-result"
+    assert called == []
+
+
+def test_on_abandoned_sink_error_never_changes_the_raise():
+    async def _fast():
+        raise RuntimeError("rt dead")
+
+    async def _stable():
+        raise _vendor_rejection("batch dead")
+
+    def _bad_sink(f, s):
+        raise OSError("sink exploded")
+
+    async def _run():
+        with pytest.raises((RuntimeError, ValueError)):
+            await hedged_race(_fast, _stable, on_abandoned=_bad_sink)
+    asyncio.run(_run())
+
+
+# ===========================================================================
+# C — the triage classifier (Phase 2)
+# ===========================================================================
+
+def test_classify_vendor_and_internal_arms():
+    assert classify_arm(RuntimeError("severed")) is ArmFailureClass.VENDOR
+    assert classify_arm(NameError("x undefined")) is ArmFailureClass.INTERNAL_FAULT
+    assert classify_arm(asyncio.CancelledError()) is ArmFailureClass.CANCELLED
+    assert classify_arm(None) is ArmFailureClass.ABSENT
+
+
+def test_dual_vendor_failure_is_hard_blockage():
+    """The live op-019eae7b shape: RT RuntimeError + structural rejection
+    (provider-shaped, carries the vendor status_code)."""
+    v = triage_dual_failure(
+        RuntimeError("rt stream severed"),
+        _vendor_rejection("full_content too short (1906 bytes vs original 4096)"),
+    )
+    assert v.hard_blockage is True
+    assert v.fast_class is ArmFailureClass.VENDOR
+    assert v.stable_class is ArmFailureClass.VENDOR
+
+
+def test_bare_valueerror_is_ambiguous_internal_no_blame():
+    """Slice 185 doctrine: a ValueError WITHOUT a vendor status_code is
+    ambiguous (parse vs logic) → treated internal → never blacklists."""
+    v = triage_dual_failure(RuntimeError("severed"), ValueError("bare"))
+    assert v.hard_blockage is False
+
+
+def test_internal_fault_never_blames_the_model():
+    """Slice 185 doctrine: a NameError is OUR bug — never blacklist the model."""
+    v = triage_dual_failure(NameError("_x undefined"), RuntimeError("severed"))
+    assert v.hard_blockage is False
+    assert "internal" in v.reason.lower()
+
+
+def test_cancelled_or_absent_arm_is_not_a_blockage():
+    v = triage_dual_failure(RuntimeError("severed"), None)
+    assert v.hard_blockage is False
+    v2 = triage_dual_failure(asyncio.CancelledError(), RuntimeError("severed"))
+    assert v2.hard_blockage is False
+
+
+# ===========================================================================
+# D — the per-op blacklist (Phase 3)
+# ===========================================================================
+
+def test_blacklist_records_and_is_scoped_to_the_op():
+    v = triage_dual_failure(RuntimeError("a"), _vendor_rejection("b"))
+    assert record_dual_arm_blacklist("op-123", "qwen/qwen3.5-35b", v) is True
+    assert is_blacklisted_for_op("op-123", "qwen/qwen3.5-35b") is True
+    assert is_blacklisted_for_op("op-123", "deepseek-ai/deepseek-v4") is False
+    assert is_blacklisted_for_op("op-OTHER", "qwen/qwen3.5-35b") is False
+
+
+def test_blacklist_independent_of_drift_rotation_master(monkeypatch):
+    """The drift-rotation master defaults FALSE — Slice 194's predicate must
+    rotate anyway (its own master, failure-path-only default TRUE)."""
+    monkeypatch.setenv("JARVIS_SCHEMA_DRIFT_ROTATION_ENABLED", "false")
+    v = triage_dual_failure(RuntimeError("a"), _vendor_rejection("b"))
+    record_dual_arm_blacklist("op-9", "m-1", v)
+    assert is_blacklisted_for_op("op-9", "m-1") is True
+
+
+def test_blacklist_event_lands_in_drift_audit_ledger():
+    v = triage_dual_failure(RuntimeError("a"), _vendor_rejection("b"))
+    record_dual_arm_blacklist("op-7", "m-7", v)
+    events = get_default_tracker().events_for("op-7")
+    assert any(e.drift_type is DriftType.DUAL_ARM_FAILURE for e in events)
+
+
+def test_master_off_disables_blacklist(monkeypatch):
+    monkeypatch.setenv("JARVIS_RACE_TRIAGE_ENABLED", "false")
+    assert race_triage_enabled() is False
+    v = triage_dual_failure(RuntimeError("a"), _vendor_rejection("b"))
+    assert record_dual_arm_blacklist("op-5", "m-5", v) is False
+    assert is_blacklisted_for_op("op-5", "m-5") is False
+
+
+def test_soft_verdict_is_never_recorded():
+    v = triage_dual_failure(NameError("our bug"), RuntimeError("x"))
+    assert record_dual_arm_blacklist("op-6", "m-6", v) is False
+    assert is_blacklisted_for_op("op-6", "m-6") is False
+
+
+def test_predicate_default_enabled():
+    assert race_triage_enabled() is True
+
+
+# ===========================================================================
+# E — end-to-end hot-swap simulation (Phase 4 acceptance)
+# ===========================================================================
+
+def test_synthetic_dual_arm_failure_counts_blacklists_and_rotates():
+    """The user-pinned Slice 194 acceptance: a synthetic dual-arm failure on a
+    target model → registry increments flawlessly, the model is blacklisted
+    for the op, and a ranked walk hot-swaps to the next candidate."""
+    op_id = "op-sim-194"
+    failing_model = "qwen/qwen3.5-35b-a3b-fp8"
+    ranked = [failing_model, "nvidia/nemotron-3", "deepseek-ai/deepseek-v4-pro"]
+
+    async def _fast():
+        raise RuntimeError("rt stream severed mid-generation")
+
+    async def _stable():
+        await asyncio.sleep(0.01)
+        raise _vendor_rejection("batch candidate structurally rejected")
+
+    def _abandoned(fast_exc, stable_exc):
+        record_hedge_abandoned()
+        verdict = triage_dual_failure(fast_exc, stable_exc)
+        if verdict.hard_blockage:
+            record_dual_arm_blacklist(op_id, failing_model, verdict)
+
+    async def _run():
+        with pytest.raises((RuntimeError, ValueError)):
+            await hedged_race(
+                _fast, _stable,
+                is_rupture=lambda e: isinstance(e, RuntimeError),
+                on_abandoned=_abandoned,
+            )
+    asyncio.run(_run())
+
+    # 1 — the registry counted the abandoned race
+    assert get_observability_registry().get(HEDGE_RACES_ABANDONED) == 1
+    # 2 — the model is blacklisted for THIS op only
+    assert is_blacklisted_for_op(op_id, failing_model) is True
+    # 3 — a ranked walk rotates past the corpse to the next candidate
+    survivors = [m for m in ranked if not is_blacklisted_for_op(op_id, m)]
+    assert survivors[0] == "nvidia/nemotron-3"
+
+
+# ===========================================================================
+# F — wiring pins (source-pinned, repo precedent)
+# ===========================================================================
+
+def test_provider_hedge_block_wires_on_abandoned():
+    src = (_GOV / "doubleword_provider.py").read_text(encoding="utf-8")
+    assert "on_abandoned" in src
+    assert "record_hedge_abandoned" in src
+    assert "triage_dual_failure" in src
+
+
+def test_sentinel_walker_skips_dual_arm_blacklisted_models():
+    src = (_GOV / "candidate_generator.py").read_text(encoding="utf-8")
+    assert "is_blacklisted_for_op" in src
+    assert "skipped_dual_arm" in src
+
+
+def test_authority_invariant_no_wide_imports():
+    src = (_GOV / "race_triage.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "from backend.core.ouroboros.governance.orchestrator",
+        "iron_gate", "change_engine",
+        "from backend.core.ouroboros.governance.candidate_generator",
+        "semantic_guardian", "risk_tier",
+    ):
+        assert forbidden not in src, f"authority leak: {forbidden}"


### PR DESCRIPTION
## Why

Slice 193's registry exposed the gap live in the soak: `dispatches − victories = 2` — two hedge races died with NO winner (op-019eae7b: RT `RuntimeError` + structural batch rejection) while the op blindly re-walked the same dead model every ~2 minutes. Visibility without recovery is not sovereignty.

## What

**Phase 1 — explicit counter.** `hedge_races_abandoned` joins the mmap registry charter (pre-registered at 0); `record_hedge_abandoned()` helper.

**Phase 2 — dual-arm triage.** `hedged_race(on_abandoned=)` captures per-arm exceptions and fires EXACTLY when both arms fail (never on a win; sink errors never change the raise). `race_triage.py` classifies each arm (`VENDOR` / `INTERNAL_FAULT` / `CANCELLED` / `ABSENT`): a hard blockage requires BOTH arms vendor-lane — Slice 185 doctrine carve-outs mean an internal fault (our bug) or a cancelled arm never blames the model.

**Phase 3 — cross-model rotation.** A confirmed hard blockage blacklists the model **for the scope of the current op**, riding the schema_drift_tracker's bounded per-op storage (new `DriftType.DUAL_ARM_FAILURE` — /drift audit for free) with its OWN skip predicate `is_blacklisted_for_op`, gated by `JARVIS_RACE_TRIAGE_ENABLED` (default TRUE — failure-path-only, Slice 170 precedent) and deliberately **independent of the default-FALSE drift-rotation master**. The sentinel walker skips the corpse, so the next loop iteration IS the next-highest-ranked brain_selection_policy/dw_catalog candidate (Qwen → Nemotron → DeepSeek) — same execution cycle, no 2-minute stall, no new catalog query.

## Verification (TDD, RED→GREEN)

- 21 new tests incl. the pinned acceptance: synthetic dual-arm failure → registry increments flawlessly, model blacklisted for that op only, ranked walk hot-swaps to the next candidate. Plus: on_abandoned firing semantics (3 negative cases), Slice-185 doctrine pins (bare ValueError = ambiguous-internal → no blame), master independence, /drift ledger landing, wiring + authority grep-pins.
- 428 regression green (registry/hedge 188-192/170/drift/taxonomy). 1 failure in `test_slice12af_universal_route_taxonomy` is pre-existing on clean main 9eff300d0f (generate_runner source pin, untouched files) — verified before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds race triage and per-op cross-model rotation for hedge races: when both RT and batch fail, we count the abandoned race, classify the failures, and temporarily blacklist the model for that op so the next ranked model is tried immediately. This prevents re-walking a dead model and removes the 2‑minute stall.

- **New Features**
  - `hedged_race` gains `on_abandoned(fast_exc, stable_exc)` to fire only when both arms fail; sink errors don’t change raise behavior.
  - New `race_triage` module: `ArmFailureClass`, `triage_dual_failure`, `record_dual_arm_blacklist`, `is_blacklisted_for_op`. Hard blockage requires both arms vendor-lane; internal faults or cancelled/absent arms never blame the model. Blacklist is per-op via `schema_drift_tracker` with `DriftType.DUAL_ARM_FAILURE`, gated by `JARVIS_RACE_TRIAGE_ENABLED` (default `true`), independent of `JARVIS_SCHEMA_DRIFT_ROTATION_ENABLED`.
  - Sentinel walker in `candidate_generator` skips dual‑arm‑blacklisted models and immediately tries the next ranked candidate in the same loop.
  - New `observability_registry` metric `hedge_races_abandoned` with `record_hedge_abandoned()` for explicit tracking.
  - Provider wiring in `doubleword_provider` to record abandoned races, triage outcomes, and blacklist on confirmed hard blockages.
  - 21 new tests, including an end‑to‑end rotation simulation.

<sup>Written for commit 846df90b2a2577b3390ffdc8833abbc8c2513310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

