### PR TITLE
feat(governance): Slice 195 - adaptive horizon governor (dynamic background timeboxes)

### DIFF
--- a/backend/core/ouroboros/governance/adaptive_horizon.py
+++ b/backend/core/ouroboros/governance/adaptive_horizon.py
@@ -1,0 +1,140 @@
+"""Slice 195 — Adaptive Horizon Governor: the end of the 360s magic number.
+
+The background pool's per-op watchdog ceiling was a static, env-tunable table
+(base 360s; read_only / ≥4-file complex / swe_bench 900s) with a hard 4-file
+cliff. This module replaces the magic numbers with a derivation: the temporal
+runway is computed from the operation's actual shape —
+
+  * **input context size** — a longer description/prompt means more tokens in
+    flight at every phase (size factor, capped),
+  * **complexity vector** — continuous per-target-file scaling, eradicating
+    the ≥4-file cliff (2 files now earns more runway than 1),
+  * **the active model's catalog profile** — a heavy model (param count ≥
+    threshold, parsed by ``dw_catalog_client.parse_parameter_count`` — ZERO
+    hardcoded model names) earns the heavy factor, mirroring the Slice 28
+    heavy-TTFT doctrine.
+
+WATCHDOG DOCTRINE (Slice 47 — load-bearing, do not weaken):
+
+  The horizon is computed ONCE at worker pickup from STATIC envelope signals.
+  It is NOT an activity-gated mid-run extension — the rejected "adaptive
+  budget waiver" failure mode coupled the watchdog to the inner state-ledger
+  and deadlocked WITH the system it guarded. This governor reads no ledger,
+  no phase, no in-flight activity signal, and pulls in no async machinery; a
+  wedged op still dies at its precomputed ceiling. The governor can only RAISE above the legacy
+  max-aggregated floor and is hard-clamped by ``JARVIS_HORIZON_MAX_S``, so
+  the anti-hang purpose survives any input. OFF → byte-identical legacy.
+
+Env surface (all tunable, defaults conservative):
+  JARVIS_ADAPTIVE_HORIZON_ENABLED   master (default true — raise-only + clamped)
+  JARVIS_HORIZON_MAX_S              hard ceiling (default 1800)
+  JARVIS_HORIZON_SIZE_KNEE_CHARS    chars at which the size factor saturates'
+                                    growth midpoint (default 50000)
+  JARVIS_HORIZON_SIZE_FACTOR_MAX    size factor ceiling (default 2.0)
+  JARVIS_HORIZON_PER_FILE_FACTOR    additive factor per target file (default 0.15)
+  JARVIS_HORIZON_FILE_FACTOR_CAP    files counted at most (default 8)
+  JARVIS_HORIZON_HEAVY_PARAMS_B     heavy-model param threshold in B (default 100)
+  JARVIS_HORIZON_HEAVY_MODEL_FACTOR heavy-model multiplier (default 1.5)
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_ADAPTIVE_HORIZON_ENABLED"
+
+
+def _envf(name: str, default: float) -> float:
+    try:
+        raw = os.environ.get(name, "").strip()
+        v = float(raw) if raw else default
+        return v if v > 0 else default
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def adaptive_horizon_enabled() -> bool:
+    """Master gate (default TRUE — the governor is raise-only above the legacy
+    floor and hard-clamped, so it cannot weaken the watchdog). NEVER raises."""
+    return os.environ.get(_ENV_ENABLED, "true").strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
+def _size_factor(context_chars: int) -> float:
+    """1.0 + chars/knee, hard-capped at SIZE_FACTOR_MAX (linear, monotone,
+    bounded — reaches the cap exactly so the clamp is auditable)."""
+    knee = _envf("JARVIS_HORIZON_SIZE_KNEE_CHARS", 50_000.0)
+    cap = max(1.0, _envf("JARVIS_HORIZON_SIZE_FACTOR_MAX", 2.0))
+    chars = max(0.0, float(context_chars or 0))
+    return min(cap, 1.0 + chars / knee)
+
+
+def _file_factor(target_file_count: int) -> float:
+    """Continuous per-file scaling — no cliff. 1 file = 1+f, 2 files = 1+2f…
+    capped at FILE_FACTOR_CAP files."""
+    per_file = _envf("JARVIS_HORIZON_PER_FILE_FACTOR", 0.15)
+    file_cap = _envf("JARVIS_HORIZON_FILE_FACTOR_CAP", 8.0)
+    files = min(max(0.0, float(target_file_count or 0)), file_cap)
+    return 1.0 + per_file * files
+
+
+def _model_factor(model_id: Optional[str]) -> float:
+    """Catalog-profile factor: param count parsed by the EXISTING dw_catalog
+    heuristic (curated map + size-token regex — zero hardcoded names here).
+    Unknown / unparseable → 1.0 (conservative)."""
+    try:
+        if not model_id or not isinstance(model_id, str):
+            return 1.0
+        from backend.core.ouroboros.governance.dw_catalog_client import (
+            parse_parameter_count,
+        )
+        params_b = parse_parameter_count(model_id)
+        if params_b is None:
+            return 1.0
+        threshold = _envf("JARVIS_HORIZON_HEAVY_PARAMS_B", 100.0)
+        if params_b >= threshold:
+            return max(1.0, _envf("JARVIS_HORIZON_HEAVY_MODEL_FACTOR", 1.5))
+        return 1.0
+    except Exception:  # noqa: BLE001
+        return 1.0
+
+
+def compute_horizon(
+    *,
+    legacy_floor_s: float,
+    legacy_reason: str,
+    context_chars: int = 0,
+    target_file_count: int = 0,
+    model_id: Optional[str] = None,
+) -> Tuple[float, str]:
+    """Derive the per-op watchdog ceiling from the operation's static shape.
+
+    Returns ``(timeout_s, reason)``. Disabled → the legacy pair untouched.
+    Enabled → ``legacy_floor × size × files × model``, clamped to
+    ``[legacy_floor, JARVIS_HORIZON_MAX_S]``. Computed once at worker pickup;
+    NEVER raises (any internal failure → legacy pair)."""
+    try:
+        if not adaptive_horizon_enabled():
+            return float(legacy_floor_s), str(legacy_reason)
+        floor = max(0.0, float(legacy_floor_s))
+        sf = _size_factor(context_chars)
+        ff = _file_factor(target_file_count)
+        mf = _model_factor(model_id)
+        horizon = floor * sf * ff * mf
+        hard_max = _envf("JARVIS_HORIZON_MAX_S", 1800.0)
+        horizon = min(max(horizon, floor), max(hard_max, floor))
+        if horizon <= floor:
+            # All factors 1.0 — keep the legacy reason so logs stay familiar
+            # for unscaled ops.
+            return floor, str(legacy_reason)
+        reason = (
+            f"adaptive({legacy_reason};size={sf:.2f},files={ff:.2f},"
+            f"model={mf:.2f})"
+        )
+        return horizon, reason
+    except Exception:  # noqa: BLE001
+        return float(legacy_floor_s), str(legacy_reason)

--- a/backend/core/ouroboros/governance/background_agent_pool.py
+++ b/backend/core/ouroboros/governance/background_agent_pool.py
@@ -1040,6 +1040,45 @@ class BackgroundAgentPool:
                     _op_timeout_s, _ceiling_reason = max(
                         _candidates, key=lambda p: (p[0], p[1]),
                     )
+                    # Slice 195 — Adaptive Horizon Governor. Derive the ceiling
+                    # from the op's STATIC shape (context size, continuous
+                    # file-count vector, model catalog profile) instead of the
+                    # magic-number table. Raise-only above the legacy floor +
+                    # hard-clamped (JARVIS_HORIZON_MAX_S) — computed ONCE here
+                    # at pickup, never extended mid-run (Slice 47 watchdog
+                    # doctrine: no ledger/liveness coupling). OFF → the legacy
+                    # pair above passes through byte-identical.
+                    try:
+                        from backend.core.ouroboros.governance.adaptive_horizon import (
+                            compute_horizon as _s195_compute_horizon,
+                        )
+                        _s195_model_id = None
+                        try:
+                            from backend.core.ouroboros.governance.provider_topology import (
+                                get_topology as _s195_get_topology,
+                            )
+                            _s195_route = str(
+                                getattr(
+                                    getattr(op.context, "routing", None),
+                                    "provider_route", "",
+                                ) or "background"
+                            )
+                            _s195_model_id = _s195_get_topology().model_for_route(
+                                _s195_route,
+                            )
+                        except Exception:  # noqa: BLE001
+                            _s195_model_id = None
+                        _op_timeout_s, _ceiling_reason = _s195_compute_horizon(
+                            legacy_floor_s=_op_timeout_s,
+                            legacy_reason=_ceiling_reason,
+                            context_chars=len(
+                                getattr(op.context, "description", "") or ""
+                            ),
+                            target_file_count=_target_file_count,
+                            model_id=_s195_model_id,
+                        )
+                    except Exception:  # noqa: BLE001 — governor is enhancement,
+                        pass            # never blocks pickup; legacy pair stands
                     if _ceiling_reason != "base":
                         logger.info(
                             "Worker %d: %s ceiling=%.0fs reason=%s "

--- a/tests/governance/test_slice195_adaptive_horizon.py
+++ b/tests/governance/test_slice195_adaptive_horizon.py
@@ -1,0 +1,190 @@
+"""Slice 195 — Adaptive Horizon Governor (the end of the 360s magic number).
+
+The background pool's per-op watchdog ceiling was a static table (base 360s,
+read_only/complex/swe_bench 900s) with a 4-file cliff. A Sovereign Organism
+derives its temporal runway from the operation's actual shape: input context
+size, a continuous complexity vector, and the active model's catalog profile
+(a 120B+ heavy model gets a longer leash than an 8B).
+
+Watchdog doctrine pins (Slice 47 — load-bearing):
+  * The horizon is computed ONCE at worker pickup from STATIC envelope
+    signals. It is NOT an activity-gated mid-run extension (the rejected
+    "adaptive budget waiver" failure mode) — a wedged op still dies.
+  * The governor can only RAISE above the legacy max-aggregated floor, and
+    is hard-clamped by JARVIS_HORIZON_MAX_S — the anti-hang purpose survives.
+  * OFF (JARVIS_ADAPTIVE_HORIZON_ENABLED=false) → byte-identical legacy
+    (floor + reason pass through untouched).
+  * Zero hardcoded model names — the catalog factor keys off
+    dw_catalog_client.parse_parameter_count thresholds (env-tunable).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.adaptive_horizon import (
+    adaptive_horizon_enabled,
+    compute_horizon,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GOV = _REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in (
+        "JARVIS_ADAPTIVE_HORIZON_ENABLED",
+        "JARVIS_HORIZON_MAX_S",
+        "JARVIS_HORIZON_SIZE_KNEE_CHARS",
+        "JARVIS_HORIZON_SIZE_FACTOR_MAX",
+        "JARVIS_HORIZON_PER_FILE_FACTOR",
+        "JARVIS_HORIZON_FILE_FACTOR_CAP",
+        "JARVIS_HORIZON_HEAVY_PARAMS_B",
+        "JARVIS_HORIZON_HEAVY_MODEL_FACTOR",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ===========================================================================
+# A — master gate + legacy passthrough
+# ===========================================================================
+
+def test_enabled_default_true():
+    assert adaptive_horizon_enabled() is True
+
+
+def test_disabled_is_byte_identical_legacy(monkeypatch):
+    monkeypatch.setenv("JARVIS_ADAPTIVE_HORIZON_ENABLED", "false")
+    s, reason = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=500_000, target_file_count=12,
+        model_id="some/heavy-200B-model",
+    )
+    assert s == 360.0
+    assert reason == "base"
+
+
+def test_trivial_op_stays_at_the_legacy_floor():
+    """No signals → all factors 1.0 → exactly the legacy ceiling."""
+    s, reason = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=0, target_file_count=0, model_id=None,
+    )
+    assert s == 360.0
+
+
+# ===========================================================================
+# B — the three factors
+# ===========================================================================
+
+def test_context_size_raises_the_horizon():
+    small, _ = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=1_000, target_file_count=0, model_id=None,
+    )
+    big, reason = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=100_000, target_file_count=0, model_id=None,
+    )
+    assert big > small >= 360.0
+    assert "adaptive" in reason
+
+
+def test_size_factor_is_capped(monkeypatch):
+    monkeypatch.setenv("JARVIS_HORIZON_SIZE_FACTOR_MAX", "2.0")
+    capped, _ = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=10_000_000, target_file_count=0, model_id=None,
+    )
+    assert capped == pytest.approx(720.0)
+
+
+def test_file_count_scales_continuously_no_cliff():
+    """The legacy table had a >=4-file cliff; the governor scales per-file."""
+    two, _ = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=0, target_file_count=2, model_id=None,
+    )
+    three, _ = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=0, target_file_count=3, model_id=None,
+    )
+    assert 360.0 < two < three
+
+
+def test_heavy_model_catalog_profile_extends_runway():
+    """A 120B-class model id (param token parsed from the CATALOG heuristic —
+    no hardcoded names) earns the heavy-model factor."""
+    light, _ = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=0, target_file_count=0, model_id="acme/tiny-7B-fast",
+    )
+    heavy, _ = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=0, target_file_count=0,
+        model_id="nvidia/nemotron-3-super-120B",
+    )
+    assert light == 360.0
+    assert heavy == pytest.approx(360.0 * 1.5)
+
+
+def test_unknown_model_is_factor_one():
+    s, _ = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=0, target_file_count=0, model_id="mystery/no-size-token",
+    )
+    assert s == 360.0
+
+
+# ===========================================================================
+# C — watchdog doctrine: clamps
+# ===========================================================================
+
+def test_hard_max_clamp_survives_extreme_inputs(monkeypatch):
+    monkeypatch.setenv("JARVIS_HORIZON_MAX_S", "1800")
+    s, _ = compute_horizon(
+        legacy_floor_s=900.0, legacy_reason="complex",
+        context_chars=10_000_000, target_file_count=64,
+        model_id="acme/galaxy-400B",
+    )
+    assert s == 1800.0
+
+
+def test_never_below_the_legacy_floor():
+    s, _ = compute_horizon(
+        legacy_floor_s=900.0, legacy_reason="read_only",
+        context_chars=0, target_file_count=0, model_id=None,
+    )
+    assert s >= 900.0
+
+
+def test_never_raises_on_garbage():
+    s, reason = compute_horizon(
+        legacy_floor_s=360.0, legacy_reason="base",
+        context_chars=-5, target_file_count=-3, model_id=12345,  # type: ignore[arg-type]
+    )
+    assert s >= 360.0
+    assert isinstance(reason, str)
+
+
+# ===========================================================================
+# D — wiring + doctrine pins
+# ===========================================================================
+
+def test_pool_wires_the_governor():
+    src = (_GOV / "background_agent_pool.py").read_text(encoding="utf-8")
+    assert "compute_horizon" in src
+
+
+def test_governor_is_static_input_only_no_ledger_coupling():
+    """Slice 47 watchdog isolation: the governor must read STATIC envelope
+    inputs only — no orchestrator/op-ledger/liveness imports, no asyncio."""
+    src = (_GOV / "adaptive_horizon.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "import asyncio",
+        "from backend.core.ouroboros.governance.orchestrator",
+        "op_ledger", "liveness", "iron_gate", "change_engine",
+    ):
+        assert forbidden not in src, f"watchdog coupling: {forbidden}"


### PR DESCRIPTION
## Why

The background pool's per-op watchdog ceiling was a static table (base 360s; read_only / ≥4-file / swe_bench 900s) with a hard 4-file cliff — a magic-number temporal limit that strangles heavy multi-turn agent loops (Slice 195 Phase 2 charter).

## What

**`adaptive_horizon.py`** — `compute_horizon(legacy_floor_s, legacy_reason, context_chars, target_file_count, model_id)` derives the runway from the op's **static** shape:
- **size factor**: `1 + chars/knee`, hard-capped (`JARVIS_HORIZON_SIZE_KNEE_CHARS`=50k, `_SIZE_FACTOR_MAX`=2.0)
- **complexity vector**: continuous per-file scaling, no cliff (`_PER_FILE_FACTOR`=0.15 up to `_FILE_FACTOR_CAP`=8 files)
- **catalog profile**: `dw_catalog_client.parse_parameter_count` ≥ `JARVIS_HORIZON_HEAVY_PARAMS_B` (100B) → `_HEAVY_MODEL_FACTOR` (1.5×) — **zero hardcoded model names** (a Nemotron-3-Super-120B earns its runway from its parsed size, not its name)

**Watchdog doctrine (Slice 47) honored structurally:** computed ONCE at worker pickup from envelope signals; raise-only above the legacy max-aggregated floor; hard-clamped by `JARVIS_HORIZON_MAX_S` (1800s); no ledger/phase/activity coupling and no async machinery (grep-pinned). A wedged op still dies at its precomputed ceiling — this is input-shape derivation, NOT the rejected activity-gated waiver.

**Wiring:** `background_agent_pool.py` applies the governor after the legacy max-aggregation; model resolved best-effort via `provider_topology.model_for_route`; any governor failure → legacy pair stands. Master `JARVIS_ADAPTIVE_HORIZON_ENABLED` default TRUE; OFF → byte-identical legacy.

## Verification (TDD, RED→GREEN)

13 new tests: disabled passthrough, trivial-op floor identity, factor math + exact cap attainment, no-cliff continuity (2 < 3 files), catalog-profile factor (parsed 120B → 1.5×, unknown → 1.0), extreme-input hard clamp, never-below-floor, garbage-input safety, wiring + doctrine grep-pins. 103 regression green including the legacy `test_bg_pool_source_aware_timebox` suite with the governor default-ON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced static background watchdog limits with an adaptive horizon that scales by input size, file count, and model size. This removes the 4‑file cliff and gives heavy agents more runway while keeping the watchdog safe and clamped (Slice 195).

- **New Features**
  - Added `adaptive_horizon.compute_horizon(...)` to derive per-op ceilings from static signals: context chars (capped), continuous per-file scaling, and model parameter count via `dw_catalog_client.parse_parameter_count`.
  - Wired into `background_agent_pool` after legacy aggregation; model resolved best-effort via `provider_topology.model_for_route`. Fail-soft to legacy on any governor error.
  - Raise-only above legacy floor, hard-clamped by `JARVIS_HORIZON_MAX_S` (default 1800s). Computed once at pickup; no mid-run extensions; no ledger/activity coupling.
  - No hardcoded model names; heavy-model factor keyed off env threshold (default 100B). Continuous per-file factor replaces the ≥4-file cliff.
  - Default ON behind `JARVIS_ADAPTIVE_HORIZON_ENABLED`; OFF keeps byte-identical legacy behavior. New tests cover factors, caps, clamps, wiring, and doctrine pins.

- **Migration**
  - No action required. Defaults are conservative and backward-safe.
  - To disable: set `JARVIS_ADAPTIVE_HORIZON_ENABLED=false`.
  - Optional tuning: `JARVIS_HORIZON_MAX_S`, `JARVIS_HORIZON_SIZE_KNEE_CHARS`, `JARVIS_HORIZON_PER_FILE_FACTOR`, `JARVIS_HORIZON_FILE_FACTOR_CAP`, `JARVIS_HORIZON_HEAVY_PARAMS_B`, `JARVIS_HORIZON_HEAVY_MODEL_FACTOR`.

<sup>Written for commit 79a545ed03c7a44de6e5769d35375730448e908f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

