### PR TITLE
feat(governance): Slice 197 - autonomous graduation contract + adaptive synthesis governor

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2144,6 +2144,15 @@ class CandidateGenerator:
         and the orchestrator ``_INFRA_PATTERNS`` set) keeps working.
         """
         self._counters.exhaustion_events += 1
+        try:
+            # Slice 197 — durable charter counter: the graduation contract
+            # reads provider exhaustions from the registry, not from logs.
+            from backend.core.ouroboros.governance.observability_registry import (
+                record_provider_exhaustion as _s197_record_exhaustion,
+            )
+            _s197_record_exhaustion()
+        except Exception:  # noqa: BLE001
+            pass
 
         fm = self.fsm._failure_mode
         report: Dict[str, Any] = {

--- a/backend/core/ouroboros/governance/control_plane_watchdog.py
+++ b/backend/core/ouroboros/governance/control_plane_watchdog.py
@@ -497,6 +497,15 @@ class ControlPlaneWatchdog:
                     pass
                 if lag_ms >= self._threshold_ms:
                     self._lag_event_count += 1
+                    try:
+                        # Slice 197 — durable charter counter for the M10
+                        # graduation contract's starvation criterion.
+                        from backend.core.ouroboros.governance.observability_registry import (  # noqa: E501
+                            record_control_plane_starvation as _s197_record_starvation,
+                        )
+                        _s197_record_starvation()
+                    except Exception:  # noqa: BLE001
+                        pass
                     logger.warning(
                         "[ControlPlaneStarvation] lag_ms=%.1f "
                         "(requested=%.1f observed=%.1f) "

--- a/backend/core/ouroboros/governance/m10/cadence_runner.py
+++ b/backend/core/ouroboros/governance/m10/cadence_runner.py
@@ -135,9 +135,14 @@ def _master_enabled() -> bool:
 
 
 def should_fire_at(op_count: object) -> bool:
-    """Pure: True iff cadence enabled AND
-    ``op_count % cadence_n_ops() == 0`` AND ``op_count >= 1``.
-    NEVER raises."""
+    """True iff cadence enabled AND ``op_count % effective-step == 0``
+    AND ``op_count >= 1``.
+
+    Slice 197 — the Adaptive Synthesis Governor modulates the step: the
+    base ``cadence_n_ops()`` is scaled by the recent hedge-dispatch delta
+    read from the durable registry (busy window → conserve capital, idle
+    window → compile aggressively). Fail-soft: governor unavailable →
+    legacy base step. NEVER raises."""
     if not cadence_enabled():
         return False
     try:
@@ -149,7 +154,43 @@ def should_fire_at(op_count: object) -> bool:
     step = cadence_n_ops()
     if step < 1:
         return False
+    try:
+        from backend.core.ouroboros.governance.m10_autonomous_graduation import (  # noqa: E501
+            effective_cadence_n,
+        )
+        step = effective_cadence_n(
+            base_n=step, dispatch_delta=_recent_dispatch_delta(),
+        )
+    except Exception:  # noqa: BLE001 — pacing is enhancement, not gate
+        pass
     return (n % step) == 0
+
+
+_last_dispatch_reading: int = -1
+
+
+def _recent_dispatch_delta() -> int:
+    """Hedge dispatches since the previous cadence check — the governor's
+    traffic signal, read from the durable registry. The first observation
+    reports moderate traffic (delta=1) so a fresh boot neither sprints nor
+    stalls. NEVER raises."""
+    global _last_dispatch_reading
+    try:
+        from backend.core.ouroboros.governance.observability_registry import (
+            HEDGE_CONCURRENCY_DISPATCHES,
+            get_observability_registry,
+        )
+        current = get_observability_registry().get(
+            HEDGE_CONCURRENCY_DISPATCHES,
+        )
+        if _last_dispatch_reading < 0:
+            _last_dispatch_reading = current
+            return 1
+        delta = max(0, current - _last_dispatch_reading)
+        _last_dispatch_reading = current
+        return delta
+    except Exception:  # noqa: BLE001
+        return 1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/m10/primitives.py
+++ b/backend/core/ouroboros/governance/m10/primitives.py
@@ -62,19 +62,33 @@ M10_PRIMITIVES_SCHEMA_VERSION: str = "m10_primitives.1"
 
 
 def m10_arch_proposer_enabled() -> bool:
-    """``JARVIS_M10_ARCH_PROPOSER_ENABLED`` (default ``false``
-    per §30.5.2 operator binding — STAYS default-false post-
-    Slice-5 graduation until 30+ proposal-acceptance audit).
+    """``JARVIS_M10_ARCH_PROPOSER_ENABLED`` — three-state resolution
+    (Slice 197 supersedes the static §30.5.2 binding via the
+    operator-delegated autonomous graduation contract):
 
-    Asymmetric env semantics — empty/whitespace = unset =
-    current default (false); explicit ``1``/``true``/``yes``/
-    ``on`` flips on. Re-read on every call so flips hot-revert
-    without restart."""
+      1. explicit ``1``/``true``/``yes``/``on`` → True (operator-on)
+      2. any other explicit value (incl. ``0``/``false``) → False —
+         the operator KILL SWITCH, supreme over any autonomous state
+         (Slice 136 precedent: operator =0 precedence honored)
+      3. unset/empty → consult the autonomous graduation contract
+         (``m10_autonomous_graduation.is_autonomously_unlocked`` —
+         criteria proven against the durable mmap registry; sticky
+         once persisted; fail-soft → False)
+
+    Re-read on every call so operator flips hot-revert without
+    restart."""
     raw = os.environ.get(
         "JARVIS_M10_ARCH_PROPOSER_ENABLED", "",
     ).strip().lower()
     if raw == "":
-        return False  # operator-pinned default per §30.5.2
+        # Slice 197 — operator-delegated autonomous graduation.
+        try:
+            from backend.core.ouroboros.governance.m10_autonomous_graduation import (  # noqa: E501
+                is_autonomously_unlocked,
+            )
+            return bool(is_autonomously_unlocked())
+        except Exception:  # noqa: BLE001 — contract unavailable → locked
+            return False
     return raw in ("1", "true", "yes", "on")
 
 

--- a/backend/core/ouroboros/governance/m10_autonomous_graduation.py
+++ b/backend/core/ouroboros/governance/m10_autonomous_graduation.py
@@ -1,0 +1,285 @@
+"""Slice 197 — Autonomous Graduation Contract + Adaptive Synthesis Governor.
+
+The M10 ArchitectureProposer sat frozen behind a static operator-set flag
+(§30.5.2: default-false until a proposal-acceptance audit). The deadlock: the
+audit needs proposals to audit, and the proposals need the flag. This module
+converts the static toggle into OPERATOR-DELEGATED CONDITIONAL AUTHORIZATION:
+
+  * The OPERATOR authorizes the unlock criteria ONCE — by reviewing and
+    merging this slice (the operator act that supersedes the §30.5.2 static
+    binding). The criteria live here, env-tunable, in the open.
+  * The ORGANISM proves the criteria against the durable mmap registry
+    (Slice 193 ``.bin`` — exhaustions, hedge stability, control-plane
+    starvation profile) and executes the unlock itself, persisting a stamped
+    audit artifact.
+  * The operator KILL SWITCH IS SUPREME: explicit
+    ``JARVIS_M10_ARCH_PROPOSER_ENABLED=0`` beats any autonomous state,
+    always (Slice 136 precedent: "Operator =0 precedence honored").
+    Revocation is one env var, not a code change.
+
+What this is NOT: self-authorization. The system cannot loosen its own
+criteria (they're code the operator reviewed), cannot override the kill
+switch, and the ``governance_boundary_gate`` recursion guard is untouched —
+proposals that would modify ``governance/`` (including THIS module) still
+route ``APPROVAL_REQUIRED``. Grep-pinned in the Slice 197 suite.
+
+Graduation criteria (all must hold, env-tunable):
+  * evidence floor — ``hedge_concurrency_dispatches >=
+    JARVIS_M10_GRAD_MIN_DISPATCHES`` (default 5): zero traffic proves
+    nothing.
+  * ``provider_exhaustions <= JARVIS_M10_GRAD_MAX_EXHAUSTIONS`` (default 0).
+  * ``hedge_races_abandoned / dispatches <=
+    JARVIS_M10_GRAD_MAX_ABANDONED_RATIO`` (default 0.25) — vendor
+    containment is holding.
+  * ``control_plane_starvation_events <=
+    JARVIS_M10_GRAD_MAX_STARVATION_EVENTS`` (default 50) — the loop ticks.
+
+Unlock semantics: STICKY. Once graduated + persisted
+(``.jarvis/m10_graduation_state.json``), later metric noise does not
+silently re-lock — graduation is a milestone, not an oscillator. Revocation
+belongs to the operator (=0).
+
+The Adaptive Synthesis Governor (:func:`effective_cadence_n`) paces proposal
+synthesis once unlocked: conserve computational capital when traffic or cost
+burn is high, compile aggressively when the organism is idle. Pure function
+of static inputs — no ledger coupling (Slice 47 doctrine).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_M10_AUTONOMOUS_GRADUATION_ENABLED"
+_ENV_STATE_PATH = "JARVIS_M10_GRADUATION_STATE_PATH"
+_DEFAULT_STATE_PATH = ".jarvis/m10_graduation_state.json"
+
+# Lazy-evaluation cache: m10_arch_proposer_enabled() is consulted on hot
+# paths (cadence checks), so an un-graduated organism re-evaluates at most
+# once per TTL instead of reading the registry on every call.
+_EVAL_TTL_S = 30.0
+_cache_lock = threading.Lock()
+_cached_unlocked: Optional[bool] = None
+_cached_at: float = 0.0
+
+
+def autonomous_graduation_enabled() -> bool:
+    """Master for the autonomous contract (default TRUE — the merged Slice
+    197 PR is the operator authorization; kill switch via this flag or the
+    supreme JARVIS_M10_ARCH_PROPOSER_ENABLED=0). NEVER raises."""
+    return os.environ.get(_ENV_ENABLED, "true").strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
+def _envf(name: str, default: float) -> float:
+    try:
+        raw = os.environ.get(name, "").strip()
+        v = float(raw) if raw else default
+        return v if v >= 0 else default
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _state_path() -> Path:
+    raw = os.environ.get(_ENV_STATE_PATH, "").strip()
+    return Path(raw) if raw else Path(_DEFAULT_STATE_PATH)
+
+
+@dataclass(frozen=True)
+class GraduationDecision:
+    """One evaluation of the graduation criteria against the registry."""
+
+    unlocked: bool
+    reason: str
+    metrics: Dict[str, int] = field(default_factory=dict)
+
+
+def evaluate_graduation() -> GraduationDecision:
+    """Evaluate the criteria against the live registry; persist the unlock
+    (with a stamped metrics snapshot) on pass. NEVER raises."""
+    try:
+        if not autonomous_graduation_enabled():
+            return GraduationDecision(False, "autonomous_graduation_disabled")
+        from backend.core.ouroboros.governance.observability_registry import (
+            CONTROL_PLANE_STARVATION_EVENTS,
+            HEDGE_CONCURRENCY_DISPATCHES,
+            HEDGE_RACES_ABANDONED,
+            PROVIDER_EXHAUSTIONS,
+            get_observability_registry,
+        )
+        snap = get_observability_registry().snapshot()
+        if not snap:
+            return GraduationDecision(False, "registry_unavailable")
+        dispatches = int(snap.get(HEDGE_CONCURRENCY_DISPATCHES, 0))
+        exhaustions = int(snap.get(PROVIDER_EXHAUSTIONS, 0))
+        abandoned = int(snap.get(HEDGE_RACES_ABANDONED, 0))
+        starvation = int(snap.get(CONTROL_PLANE_STARVATION_EVENTS, 0))
+
+        min_dispatches = int(_envf("JARVIS_M10_GRAD_MIN_DISPATCHES", 5))
+        max_exhaustions = int(_envf("JARVIS_M10_GRAD_MAX_EXHAUSTIONS", 0))
+        max_abandoned_ratio = _envf("JARVIS_M10_GRAD_MAX_ABANDONED_RATIO", 0.25)
+        max_starvation = int(
+            _envf("JARVIS_M10_GRAD_MAX_STARVATION_EVENTS", 50)
+        )
+
+        if dispatches < min_dispatches:
+            return GraduationDecision(
+                False,
+                f"evidence_floor: dispatches={dispatches} < {min_dispatches}",
+                dict(snap),
+            )
+        if exhaustions > max_exhaustions:
+            return GraduationDecision(
+                False,
+                f"provider_exhaustions={exhaustions} > {max_exhaustions}",
+                dict(snap),
+            )
+        ratio = abandoned / float(dispatches)
+        if ratio > max_abandoned_ratio:
+            return GraduationDecision(
+                False,
+                f"abandoned_ratio={ratio:.2f} > {max_abandoned_ratio}",
+                dict(snap),
+            )
+        if starvation > max_starvation:
+            return GraduationDecision(
+                False,
+                f"starvation_events={starvation} > {max_starvation}",
+                dict(snap),
+            )
+
+        decision = GraduationDecision(
+            True,
+            "all_criteria_met",
+            dict(snap),
+        )
+        _persist_unlock(decision, {
+            "min_dispatches": min_dispatches,
+            "max_exhaustions": max_exhaustions,
+            "max_abandoned_ratio": max_abandoned_ratio,
+            "max_starvation_events": max_starvation,
+        })
+        return decision
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[M10Graduation] evaluation failed soft: %s", exc)
+        return GraduationDecision(False, f"evaluation_error:{exc}")
+
+
+def _persist_unlock(decision: GraduationDecision, criteria: Dict) -> None:
+    """Durable audit artifact — the organism's signed-by-metrics unlock
+    record. Best-effort; failure to persist doesn't revoke the decision for
+    this process (the next process re-proves it)."""
+    try:
+        path = _state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "schema_version": "1.0",
+            "unlocked": True,
+            "reason": decision.reason,
+            "metrics": decision.metrics,
+            "criteria": criteria,
+            "unlocked_at_unix": time.time(),
+        }, indent=2), encoding="utf-8")
+        logger.warning(
+            "[M10Graduation] AUTONOMOUS GRADUATION: criteria met against the "
+            "registry — M10 ArchitectureProposer UNLOCKED (state=%s, "
+            "metrics=%s). Operator kill switch: "
+            "JARVIS_M10_ARCH_PROPOSER_ENABLED=0",
+            path, decision.metrics,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[M10Graduation] state persist failed soft: %s", exc)
+
+
+def _persisted_unlocked() -> bool:
+    try:
+        path = _state_path()
+        if not path.exists():
+            return False
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return bool(payload.get("unlocked"))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def is_autonomously_unlocked() -> bool:
+    """The predicate ``m10.primitives.m10_arch_proposer_enabled`` consults
+    when the operator env is UNSET. Sticky: a persisted unlock holds (later
+    metric noise doesn't re-lock; revocation = operator =0). Un-graduated →
+    lazily re-evaluates at most once per TTL. NEVER raises."""
+    global _cached_unlocked, _cached_at
+    try:
+        if not autonomous_graduation_enabled():
+            return False
+        if _persisted_unlocked():
+            return True
+        with _cache_lock:
+            now = time.monotonic()
+            if _cached_unlocked is not None and (now - _cached_at) < _EVAL_TTL_S:
+                return _cached_unlocked
+        decision = evaluate_graduation()
+        with _cache_lock:
+            _cached_unlocked = decision.unlocked
+            _cached_at = time.monotonic()
+        return decision.unlocked
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _reset_for_tests() -> None:
+    """Drop the lazy-evaluation cache so tests re-evaluate immediately."""
+    global _cached_unlocked, _cached_at
+    with _cache_lock:
+        _cached_unlocked = None
+        _cached_at = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Adaptive Synthesis Governor — pacing
+# ---------------------------------------------------------------------------
+
+def effective_cadence_n(
+    base_n: int,
+    dispatch_delta: int,
+    cost_burn_ratio: Optional[float] = None,
+) -> int:
+    """Adapt the M10 cadence (proposals fire every N ops) to the operating
+    window. Pure function of static inputs — no ledger coupling.
+
+      * busy (dispatch_delta >= BUSY_DISPATCH_DELTA, default 10) →
+        N × BUSY_FACTOR (default 2.0): conserve capital under load.
+      * idle (dispatch_delta == 0) → N × IDLE_FACTOR (default 0.5):
+        compile patterns aggressively while the organism is quiet.
+      * cost_burn_ratio >= COST_CONSERVE_RATIO (default 0.8) → conserve
+        regardless of traffic (the budget is the harder constraint).
+
+    Result floored at 1. NEVER raises."""
+    try:
+        n = max(1, int(base_n))
+        delta = max(0, int(dispatch_delta))
+        busy_at = _envf("JARVIS_M10_PACING_BUSY_DISPATCH_DELTA", 10.0)
+        busy_factor = _envf("JARVIS_M10_PACING_BUSY_FACTOR", 2.0)
+        idle_factor = _envf("JARVIS_M10_PACING_IDLE_FACTOR", 0.5)
+        conserve_at = _envf("JARVIS_M10_PACING_COST_CONSERVE_RATIO", 0.8)
+
+        factor = 1.0
+        if delta >= busy_at:
+            factor = max(factor, busy_factor)
+        elif delta == 0:
+            factor = idle_factor
+        if cost_burn_ratio is not None and float(cost_burn_ratio) >= conserve_at:
+            factor = max(factor, busy_factor)
+        return max(1, int(round(n * factor)))
+    except Exception:  # noqa: BLE001
+        try:
+            return max(1, int(base_n))
+        except Exception:  # noqa: BLE001
+            return 1

--- a/backend/core/ouroboros/governance/observability_registry.py
+++ b/backend/core/ouroboros/governance/observability_registry.py
@@ -71,6 +71,11 @@ HEDGE_RUPTURES_SWALLOWED = "hedge_ruptures_swallowed"
 # Slice 194 — a race where BOTH arms failed (no winner). Previously only
 # derivable as dispatches − victories; now explicit and self-describing.
 HEDGE_RACES_ABANDONED = "hedge_races_abandoned"
+# Slice 197 — organism-health criteria for the M10 autonomous graduation
+# contract. Previously log-line-only; charter counters make the graduation
+# evaluation a pure read of the .bin (no log parsing).
+PROVIDER_EXHAUSTIONS = "provider_exhaustions"
+CONTROL_PLANE_STARVATION_EVENTS = "control_plane_starvation_events"
 
 _PREREGISTERED = (
     HEDGE_CONCURRENCY_DISPATCHES,
@@ -78,6 +83,8 @@ _PREREGISTERED = (
     HEDGE_BATCH_VICTORIES,
     HEDGE_RUPTURES_SWALLOWED,
     HEDGE_RACES_ABANDONED,
+    PROVIDER_EXHAUSTIONS,
+    CONTROL_PLANE_STARVATION_EVENTS,
 )
 
 
@@ -320,6 +327,24 @@ def record_hedge_dispatch() -> None:
     """One proactive hedge race launched (RT + batch in flight concurrently)."""
     try:
         get_observability_registry().incr(HEDGE_CONCURRENCY_DISPATCHES)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def record_provider_exhaustion() -> None:
+    """Slice 197 — one op died with all_providers_exhausted (every provider
+    tier failed). The single strongest negative health signal."""
+    try:
+        get_observability_registry().incr(PROVIDER_EXHAUSTIONS)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def record_control_plane_starvation() -> None:
+    """Slice 197 — one ControlPlaneStarvation lag event (main asyncio loop
+    failed to tick within threshold)."""
+    try:
+        get_observability_registry().incr(CONTROL_PLANE_STARVATION_EVENTS)
     except Exception:  # noqa: BLE001
         pass
 

--- a/tests/governance/test_slice197_autonomous_graduation.py
+++ b/tests/governance/test_slice197_autonomous_graduation.py
@@ -1,0 +1,301 @@
+"""Slice 197 — Autonomous Graduation Contract + Adaptive Synthesis Governor.
+
+The M10 ArchitectureProposer was frozen behind a static operator-set env flag
+(§30.5.2). This slice converts that into OPERATOR-DELEGATED CONDITIONAL
+AUTHORIZATION: the operator authorizes the unlock criteria once (this merged
+PR is the operator act); the organism then proves the criteria against the
+durable mmap registry and executes the unlock itself — with two invariants
+that are NOT negotiable:
+
+  * **Kill switch supreme** — explicit JARVIS_M10_ARCH_PROPOSER_ENABLED=0
+    beats any autonomous unlock, always (Slice 136 precedent).
+  * **governance_boundary_gate untouched** — proposals modifying
+    governance/ still route APPROVAL_REQUIRED. The recursion guard does not
+    weaken in the same slice that unlocks the proposer (grep-pinned).
+
+Pins:
+  * Two new charter counters: provider_exhaustions +
+    control_plane_starvation_events (the graduation criteria become pure
+    reads of the .bin — no log parsing).
+  * evaluate_graduation: evidence floor (min dispatches) + exhaustions==0 +
+    abandoned-ratio + starvation-threshold; unlock persists durably with a
+    stamped metrics snapshot (audit artifact).
+  * Phase-4 acceptance: feeding stable metrics into the binary registry
+    flips m10_arch_proposer_enabled() True with NO env change.
+  * Adaptive Synthesis Governor: cadence scales with traffic + cost burn —
+    conserve when busy/expensive, compile aggressively when idle.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.m10.primitives import (
+    m10_arch_proposer_enabled,
+)
+from backend.core.ouroboros.governance.m10_autonomous_graduation import (
+    GraduationDecision,
+    _reset_for_tests,
+    autonomous_graduation_enabled,
+    effective_cadence_n,
+    evaluate_graduation,
+    is_autonomously_unlocked,
+)
+from backend.core.ouroboros.governance.observability_registry import (
+    CONTROL_PLANE_STARVATION_EVENTS,
+    HEDGE_CONCURRENCY_DISPATCHES,
+    HEDGE_RACES_ABANDONED,
+    PROVIDER_EXHAUSTIONS,
+    _reset_singleton_for_tests,
+    get_observability_registry,
+    record_control_plane_starvation,
+    record_provider_exhaustion,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GOV = _REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "JARVIS_OBSERVABILITY_REGISTRY_PATH", str(tmp_path / "reg.bin"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_M10_GRADUATION_STATE_PATH", str(tmp_path / "m10_state.json"),
+    )
+    for var in (
+        "JARVIS_OBSERVABILITY_REGISTRY_ENABLED",
+        "JARVIS_M10_ARCH_PROPOSER_ENABLED",
+        "JARVIS_M10_AUTONOMOUS_GRADUATION_ENABLED",
+        "JARVIS_M10_GRAD_MIN_DISPATCHES",
+        "JARVIS_M10_GRAD_MAX_EXHAUSTIONS",
+        "JARVIS_M10_GRAD_MAX_ABANDONED_RATIO",
+        "JARVIS_M10_GRAD_MAX_STARVATION_EVENTS",
+        "JARVIS_M10_PACING_BUSY_DISPATCH_DELTA",
+        "JARVIS_M10_PACING_BUSY_FACTOR",
+        "JARVIS_M10_PACING_IDLE_FACTOR",
+        "JARVIS_M10_PACING_COST_CONSERVE_RATIO",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    _reset_singleton_for_tests()
+    _reset_for_tests()
+    yield
+    _reset_singleton_for_tests()
+    _reset_for_tests()
+
+
+def _seed_healthy_registry(dispatches: int = 6, victories: int = 2) -> None:
+    reg = get_observability_registry()
+    reg.incr(HEDGE_CONCURRENCY_DISPATCHES, dispatches)
+    reg.incr("hedge_rt_victories", victories)
+
+
+# ===========================================================================
+# A — new charter counters (criteria become pure .bin reads)
+# ===========================================================================
+
+def test_new_counters_preregistered_at_zero():
+    snap = get_observability_registry().snapshot()
+    assert snap[PROVIDER_EXHAUSTIONS] == 0
+    assert snap[CONTROL_PLANE_STARVATION_EVENTS] == 0
+
+
+def test_record_helpers_increment():
+    record_provider_exhaustion()
+    record_control_plane_starvation()
+    record_control_plane_starvation()
+    reg = get_observability_registry()
+    assert reg.get(PROVIDER_EXHAUSTIONS) == 1
+    assert reg.get(CONTROL_PLANE_STARVATION_EVENTS) == 2
+
+
+# ===========================================================================
+# B — precedence: operator kill switch is SUPREME
+# ===========================================================================
+
+def test_explicit_zero_beats_autonomous_unlock(monkeypatch):
+    """Slice 136 precedent: operator =0 wins over ANY autonomous state."""
+    _seed_healthy_registry()
+    assert evaluate_graduation().unlocked is True  # state now persisted
+    monkeypatch.setenv("JARVIS_M10_ARCH_PROPOSER_ENABLED", "0")
+    assert m10_arch_proposer_enabled() is False
+
+
+def test_explicit_one_enables(monkeypatch):
+    monkeypatch.setenv("JARVIS_M10_ARCH_PROPOSER_ENABLED", "1")
+    assert m10_arch_proposer_enabled() is True
+
+
+def test_unset_with_no_graduation_state_stays_locked():
+    assert m10_arch_proposer_enabled() is False
+
+
+def test_unset_with_autonomous_master_off_stays_locked(monkeypatch):
+    _seed_healthy_registry()
+    evaluate_graduation()
+    monkeypatch.setenv("JARVIS_M10_AUTONOMOUS_GRADUATION_ENABLED", "false")
+    assert autonomous_graduation_enabled() is False
+    assert m10_arch_proposer_enabled() is False
+
+
+def test_garbage_env_value_is_safe_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_M10_ARCH_PROPOSER_ENABLED", "banana")
+    assert m10_arch_proposer_enabled() is False
+
+
+# ===========================================================================
+# C — the graduation evaluation
+# ===========================================================================
+
+def test_healthy_metrics_unlock():
+    _seed_healthy_registry(dispatches=6)
+    d = evaluate_graduation()
+    assert isinstance(d, GraduationDecision)
+    assert d.unlocked is True
+    assert d.metrics[HEDGE_CONCURRENCY_DISPATCHES] == 6
+
+
+def test_evidence_floor_blocks_empty_registry():
+    """Zero traffic is not evidence of health — it's evidence of nothing."""
+    d = evaluate_graduation()
+    assert d.unlocked is False
+    assert "evidence_floor" in d.reason
+
+
+def test_any_exhaustion_blocks():
+    _seed_healthy_registry()
+    record_provider_exhaustion()
+    d = evaluate_graduation()
+    assert d.unlocked is False
+    assert "exhaustion" in d.reason
+
+
+def test_abandoned_ratio_blocks():
+    _seed_healthy_registry(dispatches=6)
+    get_observability_registry().incr(HEDGE_RACES_ABANDONED, 3)  # 0.5 > 0.25
+    d = evaluate_graduation()
+    assert d.unlocked is False
+    assert "abandoned" in d.reason
+
+
+def test_starvation_threshold_blocks():
+    _seed_healthy_registry()
+    get_observability_registry().incr(CONTROL_PLANE_STARVATION_EVENTS, 51)
+    d = evaluate_graduation()
+    assert d.unlocked is False
+    assert "starvation" in d.reason
+
+
+def test_unlock_persists_audit_artifact(tmp_path, monkeypatch):
+    state = tmp_path / "audit_state.json"
+    monkeypatch.setenv("JARVIS_M10_GRADUATION_STATE_PATH", str(state))
+    _reset_for_tests()
+    _seed_healthy_registry()
+    d = evaluate_graduation()
+    assert d.unlocked is True
+    payload = json.loads(state.read_text())
+    assert payload["unlocked"] is True
+    assert payload["metrics"][HEDGE_CONCURRENCY_DISPATCHES] == 6
+    assert payload["criteria"]["min_dispatches"] == 5
+
+
+def test_unlock_is_sticky_across_evaluations():
+    """Graduation, not oscillation: once unlocked + persisted, a later noisy
+    window doesn't silently re-lock (revocation = the operator kill switch)."""
+    _seed_healthy_registry()
+    assert evaluate_graduation().unlocked is True
+    record_provider_exhaustion()  # health degrades AFTER graduation
+    assert is_autonomously_unlocked() is True
+
+
+def test_evaluation_never_raises_without_registry(monkeypatch):
+    monkeypatch.setenv("JARVIS_OBSERVABILITY_REGISTRY_ENABLED", "false")
+    _reset_singleton_for_tests()
+    d = evaluate_graduation()
+    assert d.unlocked is False
+
+
+# ===========================================================================
+# D — Phase-4 acceptance: metrics in the .bin flip the proposer, no env edit
+# ===========================================================================
+
+def test_stable_binary_metrics_activate_m10_without_env_change():
+    """The user-pinned Slice 197 acceptance: feed stable metrics into the
+    memory-mapped registry → M10 goes active. No environment files touched."""
+    assert m10_arch_proposer_enabled() is False  # locked at birth
+    _seed_healthy_registry(dispatches=7, victories=3)  # the live soak shape
+    _reset_for_tests()  # drop the lazy-eval TTL so the next check re-runs
+    assert m10_arch_proposer_enabled() is True
+
+
+# ===========================================================================
+# E — Adaptive Synthesis Governor (pacing)
+# ===========================================================================
+
+def test_idle_window_compiles_aggressively():
+    """Zero traffic since the last check → cadence shrinks (more proposals)."""
+    n = effective_cadence_n(base_n=8, dispatch_delta=0)
+    assert n < 8
+    assert n >= 1
+
+
+def test_busy_window_conserves_capital():
+    n = effective_cadence_n(base_n=8, dispatch_delta=20)
+    assert n > 8
+
+
+def test_high_cost_burn_conserves_even_when_idle():
+    n = effective_cadence_n(base_n=8, dispatch_delta=0, cost_burn_ratio=0.95)
+    assert n >= 8
+
+
+def test_moderate_traffic_keeps_base():
+    n = effective_cadence_n(base_n=8, dispatch_delta=3)
+    assert n == 8
+
+
+def test_pacing_never_raises_on_garbage():
+    n = effective_cadence_n(base_n=-1, dispatch_delta=-9, cost_burn_ratio=None)
+    assert n >= 1
+
+
+# ===========================================================================
+# F — wiring + doctrine pins
+# ===========================================================================
+
+def test_exhaustion_funnel_wired_to_registry():
+    src = (_GOV / "candidate_generator.py").read_text(encoding="utf-8")
+    assert "record_provider_exhaustion" in src
+
+
+def test_starvation_watchdog_wired_to_registry():
+    src = (_GOV / "control_plane_watchdog.py").read_text(encoding="utf-8")
+    assert "record_control_plane_starvation" in src
+
+
+def test_cadence_runner_consults_the_pacing_governor():
+    src = (_GOV / "m10" / "cadence_runner.py").read_text(encoding="utf-8")
+    assert "effective_cadence_n" in src
+
+
+def test_boundary_gate_not_weakened():
+    """The RRD §1 recursion guard survives this slice byte-for-byte in
+    spirit: governance-modifying proposals still APPROVAL_REQUIRED, and the
+    gate has NO coupling to the autonomous graduation module."""
+    src = (_GOV / "governance_boundary_gate.py").read_text(encoding="utf-8")
+    assert "APPROVAL_REQUIRED" in src
+    assert "m10_autonomous_graduation" not in src
+    assert "is_autonomously_unlocked" not in src
+
+
+def test_authority_invariant_no_wide_imports():
+    src = (_GOV / "m10_autonomous_graduation.py").read_text(encoding="utf-8")
+    for forbidden in (
+        "from backend.core.ouroboros.governance.orchestrator",
+        "iron_gate", "change_engine",
+        "semantic_guardian", "risk_tier",
+    ):
+        assert forbidden not in src, f"authority leak: {forbidden}"


### PR DESCRIPTION
## Why

M10 (ArchitectureProposer) was structurally deadlocked: §30.5.2 pins it default-false until a 30-proposal audit — but the audit needs proposals, and the proposals need the flag. Meanwhile the §41.6 evidence rows ("M10 proposals shipped") sat frozen at 0 while the soak accumulated uptime.

## What — operator-delegated conditional authorization (NOT self-authorization)

**The operator authorizes the criteria once — by reviewing and merging this PR.** The organism then proves the criteria against the durable mmap registry and executes the unlock itself. Two invariants are preserved structurally and grep-pinned:

- **Kill switch supreme** — explicit `JARVIS_M10_ARCH_PROPOSER_ENABLED=0` beats any autonomous state, always (Slice 136 precedent). Three-state resolution: explicit-on → on; explicit-off/garbage → off; unset → consult the contract.
- **`governance_boundary_gate` untouched** — proposals modifying `governance/` (including this module) still route APPROVAL_REQUIRED; the gate has zero coupling to the graduation contract. The proposer cannot loosen its own unlock criteria.

### Pieces
- **2 new charter counters** (the 193 pattern): `provider_exhaustions` (wired at the candidate_generator exhaustion funnel) + `control_plane_starvation_events` (wired at the watchdog lag site) — graduation evaluation is a pure read of the `.bin`, no log parsing.
- **`m10_autonomous_graduation.py`**: `evaluate_graduation()` — evidence floor (≥5 dispatches: zero traffic proves nothing), exhaustions ≤0, abandoned-ratio ≤0.25, starvation events ≤50 (all env-tunable). Unlock is **sticky** (graduation, not oscillation; revocation = the kill switch) and persists a stamped metrics snapshot to `.jarvis/m10_graduation_state.json` as the audit artifact, announced at WARNING.
- **Adaptive Synthesis Governor**: `effective_cadence_n` scales the M10 proposal cadence by the registry dispatch-delta — busy window → 2× conserve, idle → 0.5× compile aggressively, cost-burn ≥0.8 → conserve regardless. Wired fail-soft into `cadence_runner.should_fire_at`.

## Verification (TDD, RED→GREEN)

26 new tests including the pinned acceptance: **feeding stable metrics into the binary registry flips `m10_arch_proposer_enabled()` True with no environment change**; kill-switch supremacy over a persisted unlock; per-criterion lock matrix; sticky unlock; audit-artifact shape; boundary-gate-not-weakened pin; authority pins. 297 regression green (full `m10/` suite, graduation contract, boundary gate, registry lineage 193–195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the M10 ArchitectureProposer via an autonomous graduation contract that unlocks based on durable registry metrics, and adds an adaptive synthesis governor to pace proposal cadence. Operator kill switch and the `governance_boundary_gate` remain unchanged.

- **New Features**
  - Operator‑delegated unlock: `m10_autonomous_graduation` evaluates registry counters and persists a sticky audit artifact when criteria are met.
  - Three‑state env resolution: unset → consult contract; explicit on → enabled; explicit off (`JARVIS_M10_ARCH_PROPOSER_ENABLED=0`) → disabled (supreme).
  - New registry counters: `provider_exhaustions` and `control_plane_starvation_events`, wired into the generator and watchdog.
  - Adaptive Synthesis Governor: scales cadence by dispatch delta (busy conserve, idle accelerate; high cost burns conserve), integrated in `cadence_runner.should_fire_at`.

- **Migration**
  - No action required; the proposer stays locked until criteria pass.
  - Kill switch: set `JARVIS_M10_ARCH_PROPOSER_ENABLED=0` to force off at any time.
  - Optional tuning: thresholds via `JARVIS_M10_GRAD_*`, pacing via `JARVIS_M10_PACING_*`, audit state path via `JARVIS_M10_GRADUATION_STATE_PATH`.

<sup>Written for commit b527ea4a92dcf863f2cf8fc263809f32f69bd0db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

