### PR TITLE
feat(strategy): Slice 202 - strategic bootstrapper + operator-signer + progress ledger (honest variant)

### DIFF
--- a/backend/core/ouroboros/governance/progress_ledger.py
+++ b/backend/core/ouroboros/governance/progress_ledger.py
@@ -1,0 +1,80 @@
+"""Slice 202 — Git-tracked Progress Ledger (the Ralph legibility pattern).
+
+snarktank/ralph keeps a dead-simple, git-tracked, human-readable progress file
+so both the operator and the loop can see "what's done / what's next" at a
+glance. O+V's progress lives in ``.jarvis`` (gitignored, signed YAML, JSON
+summaries) — durable but not legible in the repo. This module adds a
+``progress.txt`` at the repo root: a plain, committable ledger the organism
+updates as roadmap sub-steps complete.
+
+Gated ``JARVIS_PROGRESS_LEDGER_ENABLED`` default-FALSE. Fail-soft — a write
+failure never blocks the loop. The file is plain text (git-diff-friendly);
+the AutoCommitter (or an operator) commits it like any other tracked file.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_PROGRESS_LEDGER_ENABLED"
+_DEFAULT_PATH = "progress.txt"
+
+
+def ledger_enabled() -> bool:
+    """Gate, default FALSE. NEVER raises."""
+    return os.environ.get(_ENV_ENABLED, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def render_progress(
+    completed: Sequence[Tuple[str, str]],
+    next_targets: Sequence[Tuple[str, str]],
+) -> str:
+    """Render a human-readable progress ledger. NEVER raises."""
+    try:
+        lines: List[str] = [
+            "# O+V Strategic Progress Ledger",
+            "# Auto-maintained by the organism (Slice 202). Git-tracked for",
+            "# operator legibility. Advisory — authority stays with the gates.",
+            "",
+            "## COMPLETED",
+        ]
+        if completed:
+            for gid, summary in completed:
+                lines.append(f"  [x] {gid}: {summary}")
+        else:
+            lines.append("  (none yet)")
+        lines += ["", "## NEXT TARGETS"]
+        if next_targets:
+            for gid, summary in next_targets:
+                lines.append(f"  [ ] {gid}: {summary}")
+        else:
+            lines.append("  (none queued)")
+        lines.append("")
+        return "\n".join(lines)
+    except Exception:  # noqa: BLE001
+        return "# O+V Strategic Progress Ledger\n(render error)\n"
+
+
+def update_progress(
+    completed: Sequence[Tuple[str, str]],
+    next_targets: Sequence[Tuple[str, str]],
+    path: Optional[Path] = None,
+) -> Optional[Path]:
+    """Write the ledger to ``path`` (repo-root ``progress.txt`` by default).
+    Returns the path on success, else None. NEVER raises."""
+    try:
+        target = Path(path) if path is not None else Path(_DEFAULT_PATH)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            render_progress(completed, next_targets), encoding="utf-8",
+        )
+        return target
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[ProgressLedger] update failed soft: %s", exc)
+        return None

--- a/backend/core/ouroboros/governance/strategy_bootstrapper.py
+++ b/backend/core/ouroboros/governance/strategy_bootstrapper.py
@@ -1,0 +1,163 @@
+"""Slice 202 — Autonomous Strategic Bootstrapper (honest, advisory).
+
+Seeds ``.jarvis/roadmap.yaml`` from the PRD §41.6 north-star objectives so the
+organism has a machine-readable statement of its own current goals — WITHOUT
+forging the operator's signature. The output is transparently
+``signed: false`` / ``authority: advisory``.
+
+Why advisory is honest AND safe: the RoadmapReader is intake-only — its goals
+become IntentEnvelopes that flow through the canonical pipeline (Iron Gate /
+SemanticGuardian / risk-tier-floor / human approval for anything beyond
+SAFE_AUTO). So advisory goals provide DIRECTION, never AUTHORITY. The
+signature only attests OPERATOR AUTHORSHIP; an unsigned roadmap makes no such
+claim (it is honestly labelled auto-seeded), and grants no auto-approval.
+
+To ELEVATE these goals to signed authenticity (operator authorship), the
+operator runs ``strategy_signer`` deliberately. This module never signs and
+never imports the signer — a bootstrapper that self-signs would be the
+self-authorization anti-pattern the cage forbids (operator = zero-order doll).
+
+Gated ``JARVIS_STRATEGY_BOOTSTRAP_ENABLED`` default-FALSE. NEVER overwrites an
+operator-authored ``roadmap.yaml``. Fail-soft.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_STRATEGY_BOOTSTRAP_ENABLED"
+_DEFAULT_ROADMAP_REL = ".jarvis/roadmap.yaml"
+
+# The PRD §41.6 Tier-A→B evidence thresholds, as honest north-star goals.
+# These are the organism's documented current objectives — grounded, not
+# invented. They carry no target_files (they are outcome objectives, not
+# file-tasks), so they bias intake DIRECTION without manufacturing fake ops.
+_NORTHSTAR_GOALS: List[Dict[str, Any]] = [
+    {
+        "id": "northstar-m10-proposals-shipped",
+        "title": "Ship 10 clean M10 architectural proposals",
+        "description": (
+            "PRD §41.6 Tier-A→B: accumulate 10 M10 ArchitectureProposer "
+            "proposals shipped with no regressions, each operator-reviewed."
+        ),
+        "priority": "high",
+        "success_criteria": "10 M10 proposals merged with zero regressions",
+        "depends_on": [],
+    },
+    {
+        "id": "northstar-unsupervised-soak-days",
+        "title": "Accumulate 7 continuous unsupervised soak days",
+        "description": (
+            "PRD §41.6 Tier-A→B: 7 days of continuous unsupervised operation "
+            "with the cage holding (no exhaustion storms, no boundary breach)."
+        ),
+        "priority": "high",
+        "success_criteria": "7 unbroken unsupervised days on a durable host",
+        "depends_on": [],
+    },
+    {
+        "id": "northstar-ov-signed-commits-audited",
+        "title": "30 O+V-signed commits adversarially audited clean",
+        "description": (
+            "PRD §41.6 Tier-A→B: 30 autonomous O+V-signed commits pass the "
+            "adversarial mutation audit with no findings."
+        ),
+        "priority": "medium",
+        "success_criteria": "30 OV-signed commits audited, zero findings",
+        "depends_on": [],
+    },
+    {
+        "id": "northstar-cadence-flags-graduated",
+        "title": "Graduate 5 cadence flags default-TRUE",
+        "description": (
+            "PRD §41.6 Tier-A→B: 5 cadence/autonomy flags graduated to "
+            "default-TRUE after evidence."
+        ),
+        "priority": "medium",
+        "success_criteria": "5 flags graduated default-TRUE with soak evidence",
+        "depends_on": [],
+    },
+]
+
+
+def bootstrap_enabled() -> bool:
+    """Gate, default FALSE (writes an advisory roadmap). NEVER raises."""
+    return os.environ.get(_ENV_ENABLED, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def extract_northstar_goals() -> List[Dict[str, Any]]:
+    """Return the PRD §41.6 Tier-A→B north-star goals. Grounded in the PRD;
+    the in-module constants ARE the documented thresholds (a parse of the
+    living PRD table would drift with edits — the constants are the stable,
+    auditable statement). NEVER raises."""
+    try:
+        return [dict(g) for g in _NORTHSTAR_GOALS]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def compile_roadmap(
+    goals: List[Dict[str, Any]],
+    operator_id: str = "ov-auto-seed",
+) -> Dict[str, Any]:
+    """Wrap goals in the roadmap.yaml schema, transparently UNSIGNED +
+    advisory. NEVER raises."""
+    try:
+        return {
+            "version": 1,
+            "operator_id": operator_id,
+            "source": "prd_section_41.6_auto_seeded",
+            "authority": "advisory",
+            "signed": False,
+            "note": (
+                "Auto-seeded advisory roadmap (NOT operator-signed). Goals "
+                "provide direction only; every emitted op is still fully "
+                "governed. Run strategy_signer to elevate to signed "
+                "authenticity, or replace this file with your own goals."
+            ),
+            "goals": list(goals),
+        }
+    except Exception:  # noqa: BLE001
+        return {"version": 1, "signed": False, "authority": "advisory",
+                "source": "prd_auto_seeded", "goals": []}
+
+
+def _serialize_roadmap(roadmap: Dict[str, Any]) -> str:
+    try:
+        import yaml  # type: ignore
+        return yaml.safe_dump(roadmap, sort_keys=False, allow_unicode=True)
+    except Exception:  # noqa: BLE001 — PyYAML optional; JSON is valid too
+        import json
+        return json.dumps(roadmap, indent=2)
+
+
+def write_roadmap_if_absent(path: Optional[Path] = None) -> Optional[Path]:
+    """Write the advisory roadmap iff the target does NOT already exist (an
+    operator-authored file is sacrosanct — never overwritten). Returns the
+    path on write, else None. NEVER raises."""
+    try:
+        target = Path(path) if path is not None else Path(_DEFAULT_ROADMAP_REL)
+        if target.exists():
+            logger.info(
+                "[StrategyBootstrap] roadmap already present at %s — not "
+                "overwriting (operator file is sacrosanct)", target,
+            )
+            return None
+        roadmap = compile_roadmap(extract_northstar_goals())
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(_serialize_roadmap(roadmap), encoding="utf-8")
+        logger.warning(
+            "[StrategyBootstrap] seeded ADVISORY roadmap at %s (signed=false; "
+            "direction only, fully governed). Operator: edit goals + run "
+            "strategy_signer to elevate to signed authenticity.", target,
+        )
+        return target
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[StrategyBootstrap] write failed soft: %s", exc)
+        return None

--- a/backend/core/ouroboros/governance/strategy_signer.py
+++ b/backend/core/ouroboros/governance/strategy_signer.py
@@ -1,0 +1,85 @@
+"""Slice 202 — Strategy Signer (OPERATOR utility, never autonomous).
+
+Elevates an advisory ``.jarvis/roadmap.yaml`` to SIGNED authenticity by
+computing the HMAC the RoadmapReader verifies. This exists so the OPERATOR can
+deliberately attest authorship of a set of goals — it is NOT, and must never
+be, wired into any boot path. A roadmap the organism signs over its own goals
+would be a false authenticity claim and the self-authorization anti-pattern
+the cage forbids (operator = zero-order doll, §41.2).
+
+Honest reuse: the signature primitive lives in ``roadmap_reader``
+(``compute_signature`` / ``_build_signing_payload``) — this module is a thin
+operator-facing wrapper + secret generator + CLI. The operator runs:
+
+    python3 -m backend.core.ouroboros.governance.strategy_signer .jarvis/roadmap.yaml
+
+which prints a freshly generated secret (to place in
+``JARVIS_ROADMAP_READER_HMAC_SECRET``) and writes the matching signature into
+the file. The secret is shown to the OPERATOR, never persisted autonomously.
+"""
+from __future__ import annotations
+
+import secrets
+from typing import Any, Dict, Mapping, Optional
+
+
+def generate_secret(nbytes: int = 32) -> str:
+    """A strong random HMAC secret for the OPERATOR to install in
+    ``JARVIS_ROADMAP_READER_HMAC_SECRET``. NEVER raises."""
+    try:
+        return secrets.token_hex(max(16, int(nbytes)))
+    except Exception:  # noqa: BLE001
+        return secrets.token_hex(32)
+
+
+def sign_roadmap_doc(doc: Mapping[str, Any], secret: str) -> Dict[str, Any]:
+    """Return a copy of ``doc`` with a ``signature`` field computed over the
+    reader's canonical signing payload. Marks ``signed: true``. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.roadmap_reader import (
+            _build_signing_payload, compute_signature,
+        )
+        out = dict(doc)
+        out.pop("signature", None)
+        payload = _build_signing_payload(out)
+        sig = compute_signature(payload, secret)
+        out["signature"] = sig
+        out["signed"] = bool(sig)
+        return out
+    except Exception:  # noqa: BLE001
+        return dict(doc)
+
+
+def _main(argv: Optional[list] = None) -> int:
+    import sys
+    import json
+    from pathlib import Path
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args:
+        print("usage: python3 -m ...strategy_signer <roadmap.yaml> [secret]")
+        return 2
+    path = Path(args[0])
+    secret = args[1] if len(args) > 1 else generate_secret()
+    try:
+        import yaml  # type: ignore
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    signed = sign_roadmap_doc(doc, secret)
+    try:
+        import yaml  # type: ignore
+        path.write_text(
+            yaml.safe_dump(signed, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+    except Exception:  # noqa: BLE001
+        path.write_text(json.dumps(signed, indent=2), encoding="utf-8")
+    print(f"signed {path}")
+    print("OPERATOR ACTION — set this in your environment / .env:")
+    print(f"  export JARVIS_ROADMAP_READER_HMAC_SECRET={secret}")
+    print("  export JARVIS_ROADMAP_READER_REQUIRE_SIGNATURE=true")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/governance/test_slice202_strategy_bootstrapper.py
+++ b/tests/governance/test_slice202_strategy_bootstrapper.py
@@ -1,0 +1,195 @@
+"""Slice 202 — Autonomous Strategic Bootstrapper (HONEST variant).
+
+The authorized plan asked the organism to mint its own HMAC secret and sign
+its own strategic roadmap headless. That is REFUSED by design: a signature
+the organism generates over its own goals is a FALSE authenticity claim — it
+defeats the only purpose of the signature (attesting OPERATOR authorship) and
+is the self-authorization anti-pattern the cage forbids (operator = zero-order
+doll, §41.2).
+
+What this slice delivers honestly instead:
+  * ``strategy_bootstrapper`` — seeds ``.jarvis/roadmap.yaml`` from the PRD
+    §41.6 north-star objectives, transparently ``signed: false`` /
+    ``authority: advisory``. Because the RoadmapReader is intake-only (goals
+    are DIRECTION; every emitted op still passes Iron Gate / SemanticGuardian
+    / risk-tier / human approval), advisory direction grants NO authority.
+    NEVER overwrites an operator-authored file.
+  * ``strategy_signer`` — an OPERATOR utility (CLI) to ELEVATE the advisory
+    roadmap to signed authenticity, reusing the reader's own
+    ``compute_signature``. There is NO boot wiring that auto-invokes it; the
+    operator runs it deliberately.
+  * ``progress_ledger`` — a git-tracked, human-readable progress.txt (the
+    Ralph legibility pattern).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.strategy_bootstrapper import (
+    bootstrap_enabled,
+    compile_roadmap,
+    extract_northstar_goals,
+    write_roadmap_if_absent,
+)
+from backend.core.ouroboros.governance.strategy_signer import (
+    generate_secret,
+    sign_roadmap_doc,
+)
+from backend.core.ouroboros.governance.progress_ledger import (
+    render_progress,
+    update_progress,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GOV = _REPO_ROOT / "backend" / "core" / "ouroboros" / "governance"
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    for v in (
+        "JARVIS_STRATEGY_BOOTSTRAP_ENABLED", "JARVIS_PROGRESS_LEDGER_ENABLED",
+    ):
+        monkeypatch.delenv(v, raising=False)
+    yield
+
+
+# ===========================================================================
+# A — bootstrapper: gate + honest advisory roadmap
+# ===========================================================================
+
+def test_bootstrap_disabled_by_default():
+    assert bootstrap_enabled() is False
+
+
+def test_extract_northstar_goals_are_grounded():
+    goals = extract_northstar_goals()
+    assert len(goals) >= 3
+    ids = {g["id"] for g in goals}
+    # the PRD §41.6 Tier-A→B objectives
+    assert any("m10" in i.lower() or "proposal" in i.lower() for i in ids)
+    assert any("unsupervised" in i.lower() or "soak" in i.lower() for i in ids)
+    for g in goals:
+        assert g["id"] and g["title"] and g["priority"] in (
+            "critical", "high", "medium", "low",
+        )
+
+
+def test_compiled_roadmap_is_transparently_unsigned():
+    roadmap = compile_roadmap(extract_northstar_goals())
+    assert roadmap["signed"] is False
+    assert roadmap["authority"] == "advisory"
+    assert "prd" in roadmap["source"].lower()
+    assert "signature" not in roadmap or not roadmap.get("signature")
+    assert isinstance(roadmap["goals"], list) and roadmap["goals"]
+
+
+def test_write_roadmap_creates_file_when_absent(tmp_path):
+    p = tmp_path / "roadmap.yaml"
+    out = write_roadmap_if_absent(p)
+    assert out == p and p.exists()
+    assert "goals" in p.read_text()
+
+
+def test_write_roadmap_NEVER_overwrites_operator_file(tmp_path):
+    p = tmp_path / "roadmap.yaml"
+    p.write_text("operator: hand-authored\ngoals: []\n")
+    out = write_roadmap_if_absent(p)
+    assert out is None  # refused — operator's file is sacrosanct
+    assert "hand-authored" in p.read_text()
+
+
+# ===========================================================================
+# B — signer is an OPERATOR tool, reuses the reader's own primitive
+# ===========================================================================
+
+def test_generate_secret_is_strong_and_unique():
+    s1, s2 = generate_secret(), generate_secret()
+    assert len(s1) >= 32 and s1 != s2
+
+
+def test_sign_roadmap_produces_reader_verifiable_signature():
+    from backend.core.ouroboros.governance.roadmap_reader import (
+        _build_signing_payload, verify_signature,
+    )
+    secret = generate_secret()
+    doc = {
+        "version": 1, "operator_id": "op@x", "signed_at": "2026-06-10",
+        "goals": [{"id": "g1", "title": "T", "priority": "high"}],
+    }
+    signed = sign_roadmap_doc(doc, secret)
+    assert signed["signature"]
+    # the reader's own verifier must accept it
+    assert verify_signature(
+        _build_signing_payload(signed), signed["signature"], secret,
+    ) is True
+
+
+def test_sign_with_wrong_secret_fails_verification():
+    from backend.core.ouroboros.governance.roadmap_reader import (
+        _build_signing_payload, verify_signature,
+    )
+    doc = {"version": 1, "goals": [{"id": "g", "title": "t", "priority": "low"}]}
+    signed = sign_roadmap_doc(doc, generate_secret())
+    assert verify_signature(
+        _build_signing_payload(signed), signed["signature"], "WRONG",
+    ) is False
+
+
+def test_signer_has_no_boot_autoinvocation():
+    """The signer must never be wired into a boot path — only operator-run."""
+    for fname in ("governed_loop_service.py", "harness.py"):
+        for d in (_GOV, _GOV.parent / "battle_test"):
+            f = d / fname
+            if f.exists():
+                assert "strategy_signer" not in f.read_text(encoding="utf-8")
+
+
+# ===========================================================================
+# C — progress ledger (Ralph legibility, git-tracked)
+# ===========================================================================
+
+def test_progress_render_is_human_readable():
+    text = render_progress(
+        completed=[("g1", "shipped registry")],
+        next_targets=[("g2", "activate roadmap")],
+    )
+    assert "g1" in text and "shipped registry" in text
+    assert "g2" in text and "activate roadmap" in text
+    assert "COMPLETED" in text.upper() and "NEXT" in text.upper()
+
+
+def test_update_progress_writes_file(tmp_path):
+    p = tmp_path / "progress.txt"
+    update_progress(
+        path=p, completed=[("g1", "done")], next_targets=[("g2", "todo")],
+    )
+    assert p.exists() and "g1" in p.read_text()
+
+
+def test_update_progress_never_raises_on_bad_path():
+    update_progress(
+        path=Path("/nonexistent-x9/progress.txt"),
+        completed=[], next_targets=[],
+    )
+
+
+# ===========================================================================
+# D — doctrine pins
+# ===========================================================================
+
+def test_bootstrapper_never_self_signs():
+    """The whole point: the bootstrapper produces an UNSIGNED roadmap. It must
+    not IMPORT or CALL the signer / signature primitive (no self-signature) —
+    a prose mention in the rationale is fine; an import is not."""
+    src = (_GOV / "strategy_bootstrapper.py").read_text(encoding="utf-8")
+    assert "import strategy_signer" not in src
+    assert "import compute_signature" not in src
+    assert "compute_signature(" not in src
+    assert "sign_roadmap_doc(" not in src
+
+
+def test_boundary_gate_not_weakened():
+    src = (_GOV / "governance_boundary_gate.py").read_text(encoding="utf-8")
+    assert "APPROVAL_REQUIRED" in src


### PR DESCRIPTION
## The line I drew, and why

The authorized plan asked the organism to **mint its own HMAC secret and sign its own strategic roadmap headless**. I refused that specific mechanism — and built the honest equivalent that achieves the real goal.

**Why refuse:** the RoadmapReader's HMAC signature exists for one purpose — to cryptographically attest that *the operator* authored the goals. If the organism generates the key and signs its own goals, the signature proves nothing; it's the cage forging the operator's signature on its own authorization. That's the self-authorization anti-pattern I refused in Slice 197 and that §41.2 forbids by treating the operator as the irreducible zero-order doll (the operator's *defined role* at Tier D is literally "roadmap signer"). Benign goals today don't fix the mechanism — the gate would no longer constrain anything.

**Why the honest version still delivers your goal:** the RoadmapReader is **intake-only** — its goals become IntentEnvelopes that flow through the full pipeline (Iron Gate / SemanticGuardian / risk-tier / human approval). So roadmap goals are **direction, never authority**, and the code explicitly supports a transparent unsigned advisory mode. The organism gets strategic direction with zero false authenticity claim.

## What shipped

- **`strategy_bootstrapper.py`**: seeds `.jarvis/roadmap.yaml` from the PRD §41.6 Tier-A→B north-star objectives (ship 10 M10 proposals, 7 unsupervised days, 30 audited commits, 5 graduated flags), transparently `signed: false` / `authority: advisory`. **Never overwrites an operator-authored file.** Gated default-FALSE. Does not import or call the signer (grep-pinned).
- **`strategy_signer.py`**: an **operator CLI** to *elevate* the advisory roadmap to signed authenticity — reuses the reader's own `compute_signature`/`_build_signing_payload` (verified: the reader's own verifier accepts the result). **No boot path auto-invokes it** (grep-pinned in GLS + harness).
- **`progress_ledger.py`**: git-tracked, human-readable `progress.txt` — the Ralph legibility pattern. Gated default-FALSE.
- **governance_boundary_gate** untouched.

## Verification

14 tests incl. the operator-signer round-tripping through the reader's verifier, wrong-secret-fails, the never-self-signs precise pin, and the no-boot-autoinvocation pin. 300 green across strategy + roadmap_reader + goal_decomposition + boundary.

## The honest bottom line

Auto-fabricating *good* strategic goals from prose is unreliable (the PRD §41.9 list is months old and mostly already built), and *what to build toward* is the judgment only you have. The advisory seed gives the organism transparent direction now; the real strategic vision — and its signature — stays yours by design. One command (`python3 -m ...strategy_signer .jarvis/roadmap.yaml`) elevates it whenever you author goals you want to sign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an advisory strategy bootstrapper that seeds `.jarvis/roadmap.yaml` without signing, an operator-only CLI to sign roadmaps, and a git-tracked `progress.txt` ledger. All features are gated off by default, fail-soft, and keep governance boundaries intact (no auto-signing or boot-time invocation).

- **New Features**
  - `strategy_bootstrapper.py`: Seeds `.jarvis/roadmap.yaml` from PRD §41.6 goals with `signed: false` and `authority: advisory`. Never overwrites an existing operator file. No signer imports. Gate: `JARVIS_STRATEGY_BOOTSTRAP_ENABLED`.
  - `strategy_signer.py`: Operator CLI that computes the RoadmapReader-compatible HMAC (`compute_signature` / `_build_signing_payload`). Not wired into any boot path.
  - `progress_ledger.py`: Writes human-readable `progress.txt` at repo root (git-tracked). Gate: `JARVIS_PROGRESS_LEDGER_ENABLED`.
  - Tests cover signer round-trip verification, wrong-secret failure, non-overwrite, non-self-sign, no boot auto-invoke, and ledger render/write.

- **Migration**
  - To seed advisory goals: set `JARVIS_STRATEGY_BOOTSTRAP_ENABLED=true` and run the loop; creates `.jarvis/roadmap.yaml` only if absent.
  - To sign as operator: `python3 -m backend.core.ouroboros.governance.strategy_signer .jarvis/roadmap.yaml`, then set:
    - `export JARVIS_ROADMAP_READER_HMAC_SECRET=<printed-secret>`
    - `export JARVIS_ROADMAP_READER_REQUIRE_SIGNATURE=true`
  - To enable the ledger: `export JARVIS_PROGRESS_LEDGER_ENABLED=true`.

<sup>Written for commit 9e602dd21fc2f9f04f6c36cd6646eab229848b2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

