### PR TITLE
feat(continuity): Slice 204 - chronos continuity matrix (non-volatile, honest uptime ledger)

### DIFF
--- a/backend/core/ouroboros/governance/chronos_ledger.py
+++ b/backend/core/ouroboros/governance/chronos_ledger.py
@@ -1,0 +1,296 @@
+"""Slice 204 — Chronos Continuity Matrix: a non-volatile, honest uptime ledger.
+
+Operational history bound to a single container's lifetime is a perverse
+incentive — it punishes you for ever rebuilding (i.e. improving) the system.
+This ledger decouples continuity from volatile container memory: a
+disk-backed, hash-chained record (``.jarvis/chronos_coherence.json``) that
+survives container recreation and RE-CHAINS on boot within a gap threshold.
+
+THE HONESTY GUARD (load-bearing). The ledger tracks TWO distinct totals so a
+rebuild can preserve history WITHOUT faking the strict "unsupervised" metric:
+
+  * ``total_operational_s``    — evolutionary history. Chains across ANY
+    restart within the gap threshold (crash, reboot, OR a supervised rebuild).
+  * ``unsupervised_interval_s`` — the strict §41.6 "continuous unsupervised
+    days" metric. Chains across an UNSUPERVISED recovery (same image — the
+    system recovered on its own), but RESETS on a SUPERVISED rebuild (the
+    image changed → the operator intervened) or an over-threshold gap. A
+    code rebuild must never let us claim continuous *unsupervised* time —
+    that would game the very metric §41 exists to earn honestly.
+
+SLEEP HANDLING. Each heartbeat compares wall-clock vs monotonic deltas. On a
+host freeze (macOS sleep advances wall-clock but pauses ``time.monotonic``),
+the discrepancy is detected, flagged ``CHRONOS_SLEEP_EVENT``, and only the
+TRUE running time (the monotonic delta) accrues — the frozen wall-clock hours
+are NOT counted as operational.
+
+Gated ``JARVIS_CHRONOS_LEDGER_ENABLED`` default-FALSE (writes to disk on a
+cadence). NEVER raises.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_CHRONOS_LEDGER_ENABLED"
+_DEFAULT_STATE_REL = ".jarvis/chronos_coherence.json"
+_DEFAULT_GAP_THRESHOLD_S = 1200.0   # 20 min — covers a rebuild / reboot
+_HEARTBEAT_INTERVAL_S = 60.0
+_SLEEP_DRIFT_S = 5.0                 # wall-vs-monotonic divergence → sleep
+_MAX_EVENTS = 200
+_SCHEMA = 1
+
+
+def chronos_enabled() -> bool:
+    """Gate, default FALSE. NEVER raises."""
+    return os.environ.get(_ENV_ENABLED, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def heartbeat_interval_s() -> float:
+    try:
+        raw = os.environ.get("JARVIS_CHRONOS_HEARTBEAT_S", "").strip()
+        v = float(raw) if raw else _HEARTBEAT_INTERVAL_S
+        return v if v > 0 else _HEARTBEAT_INTERVAL_S
+    except Exception:  # noqa: BLE001
+        return _HEARTBEAT_INTERVAL_S
+
+
+class ChronosLedger:
+    """Disk-backed, hash-chained operational continuity ledger. All public
+    methods NEVER raise."""
+
+    def __init__(self, state_path: Optional[Path] = None) -> None:
+        self._lock = threading.Lock()
+        self._path = Path(state_path) if state_path is not None \
+            else Path(_DEFAULT_STATE_REL)
+        self._s: Dict[str, Any] = self._fresh_state()
+        self._last_hb_unix: Optional[float] = None
+        self._last_hb_mono: Optional[float] = None
+
+    # -- state -------------------------------------------------------------
+
+    @staticmethod
+    def _fresh_state() -> Dict[str, Any]:
+        return {
+            "schema": _SCHEMA,
+            "boot_count": 0,
+            "total_operational_s": 0.0,
+            "unsupervised_interval_s": 0.0,
+            "sleep_events": 0,
+            "last_heartbeat_unix": 0.0,
+            "image_id": "",
+            "last_event": "none",
+            "last_hash": "",
+            "events": [],
+        }
+
+    def _load(self) -> Optional[Dict[str, Any]]:
+        try:
+            if not self._path.exists():
+                return None
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and "total_operational_s" in data:
+                return data
+            return None
+        except Exception:  # noqa: BLE001
+            return None  # corrupt → treated as fresh
+
+    def _persist(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            body = json.dumps(
+                {k: v for k, v in self._s.items() if k != "last_hash"},
+                sort_keys=True,
+            )
+            prior = str(self._s.get("last_hash", ""))
+            self._s["last_hash"] = hashlib.sha256(
+                (prior + body).encode("utf-8"),
+            ).hexdigest()
+            self._path.write_text(json.dumps(self._s), encoding="utf-8")
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _event(self, kind: str, **fields: Any) -> None:
+        try:
+            self._s["last_event"] = kind
+            evs: List[Dict[str, Any]] = self._s.setdefault("events", [])
+            evs.append({"kind": kind, **fields})
+            if len(evs) > _MAX_EVENTS:
+                del evs[: len(evs) - _MAX_EVENTS]
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- boot re-chain -----------------------------------------------------
+
+    def rechain_on_boot(
+        self,
+        now_unix: float,
+        image_id: str,
+        gap_threshold_s: float = _DEFAULT_GAP_THRESHOLD_S,
+    ) -> Dict[str, Any]:
+        """Read prior state and re-chain. Preserves total_operational_s as
+        evolutionary history; chains unsupervised_interval_s only across an
+        unsupervised recovery (same image, within gap). NEVER raises."""
+        try:
+            with self._lock:
+                prior = self._load()
+                if prior is None:
+                    self._s = self._fresh_state()
+                    self._s["boot_count"] = 1
+                    self._s["image_id"] = str(image_id)
+                    self._s["last_heartbeat_unix"] = float(now_unix)
+                    self._last_hb_unix = float(now_unix)
+                    self._last_hb_mono = None
+                    self._event("boot_fresh", at=float(now_unix))
+                    self._persist()
+                    return self._snapshot_nolock()
+
+                self._s = dict(prior)
+                self._s["boot_count"] = int(prior.get("boot_count", 0)) + 1
+                gap = float(now_unix) - float(prior.get("last_heartbeat_unix", 0))
+                prior_image = str(prior.get("image_id", ""))
+                # total_operational_s is preserved as-is (history chains; the
+                # gap itself is downtime and is never added to operational).
+                if gap < 0:
+                    # clock anomaly — break unsupervised continuity, keep history
+                    self._s["unsupervised_interval_s"] = 0.0
+                    self._event("clock_anomaly", gap=gap)
+                elif gap <= gap_threshold_s and str(image_id) == prior_image:
+                    # same image, small gap → unsupervised self-recovery: the
+                    # unsupervised interval continues uninterrupted.
+                    self._event("recovery_unsupervised", gap=gap)
+                elif gap <= gap_threshold_s and str(image_id) != prior_image:
+                    # SUPERVISED rebuild (image changed) → reset the strict
+                    # unsupervised metric; evolutionary history still chains.
+                    self._s["unsupervised_interval_s"] = 0.0
+                    self._event(
+                        "rebuild_supervised", gap=gap,
+                        from_image=prior_image[:16], to_image=str(image_id)[:16],
+                    )
+                else:
+                    # gap beyond threshold → genuine extended downtime
+                    self._s["unsupervised_interval_s"] = 0.0
+                    self._event("downtime_reset", gap=gap)
+
+                self._s["image_id"] = str(image_id)
+                self._s["last_heartbeat_unix"] = float(now_unix)
+                self._last_hb_unix = float(now_unix)
+                self._last_hb_mono = None
+                self._persist()
+                return self._snapshot_nolock()
+        except Exception:  # noqa: BLE001
+            return self.snapshot()
+
+    # -- heartbeat ---------------------------------------------------------
+
+    def heartbeat(self, now_unix: float, now_monotonic: float) -> None:
+        """Accrue operational time since the last tick (or the boot anchor).
+        Sleep-safe: when wall-clock and monotonic diverge (host freeze), count
+        only the TRUE running time (monotonic delta) and flag the event.
+        NEVER raises."""
+        try:
+            with self._lock:
+                # The wall anchor is set at rechain_on_boot (boot time); the
+                # monotonic anchor is process-local and set on the first tick.
+                if self._last_hb_unix is None:
+                    self._last_hb_unix = float(
+                        self._s.get("last_heartbeat_unix", now_unix),
+                    )
+                dw = float(now_unix) - self._last_hb_unix
+                first_tick = self._last_hb_mono is None
+                dm = dw if first_tick else (
+                    float(now_monotonic) - float(self._last_hb_mono or 0.0)
+                )
+                self._last_hb_unix = float(now_unix)
+                self._last_hb_mono = float(now_monotonic)
+
+                if dw < 0 or dm < 0:
+                    # clock anomaly — accrue nothing this tick
+                    self._event("clock_anomaly_tick", dw=round(dw, 1))
+                    self._persist()
+                    return
+
+                # First tick has no prior monotonic → can't detect sleep, so
+                # accrue the wall delta from the boot anchor (≈ one interval).
+                sleep_detected = (not first_tick) and abs(dw - dm) > _SLEEP_DRIFT_S
+                # true running time = monotonic delta (excludes frozen sleep)
+                accrue = dm if sleep_detected else dw
+                accrue = max(0.0, accrue)
+                self._s["total_operational_s"] = float(
+                    self._s.get("total_operational_s", 0.0),
+                ) + accrue
+                self._s["unsupervised_interval_s"] = float(
+                    self._s.get("unsupervised_interval_s", 0.0),
+                ) + accrue
+                self._s["last_heartbeat_unix"] = float(now_unix)
+                if sleep_detected:
+                    self._s["sleep_events"] = int(
+                        self._s.get("sleep_events", 0),
+                    ) + 1
+                    self._event(
+                        "chronos_sleep_event", frozen_s=round(dw - dm, 1),
+                    )
+                    logger.warning(
+                        "[Chronos] CHRONOS_SLEEP_EVENT — host freeze ~%.0fs "
+                        "(wall=%.0f mono=%.0f); frozen time NOT counted as "
+                        "operational", dw - dm, dw, dm,
+                    )
+                self._persist()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return self._snapshot_nolock()
+
+    def _snapshot_nolock(self) -> Dict[str, Any]:
+        try:
+            if True:
+                return {
+                    "schema": self._s.get("schema", _SCHEMA),
+                    "boot_count": int(self._s.get("boot_count", 0)),
+                    "total_operational_s": round(
+                        float(self._s.get("total_operational_s", 0.0)), 2),
+                    "unsupervised_interval_s": round(
+                        float(self._s.get("unsupervised_interval_s", 0.0)), 2),
+                    "total_operational_days": round(
+                        float(self._s.get("total_operational_s", 0.0)) / 86400.0, 3),
+                    "unsupervised_interval_days": round(
+                        float(self._s.get("unsupervised_interval_s", 0.0)) / 86400.0, 3),
+                    "sleep_events": int(self._s.get("sleep_events", 0)),
+                    "last_event": str(self._s.get("last_event", "none")),
+                    "image_id": str(self._s.get("image_id", ""))[:16],
+                    "last_hash": str(self._s.get("last_hash", ""))[:16],
+                }
+        except Exception:  # noqa: BLE001
+            return {"boot_count": 0, "total_operational_s": 0.0,
+                    "unsupervised_interval_s": 0.0}
+
+
+_singleton: Optional[ChronosLedger] = None
+_singleton_lock = threading.Lock()
+
+
+def get_chronos_ledger() -> ChronosLedger:
+    """Process-wide singleton. NEVER raises."""
+    global _singleton
+    if _singleton is None:
+        with _singleton_lock:
+            if _singleton is None:
+                _singleton = ChronosLedger()
+    return _singleton
+
+
+def _reset_singleton_for_tests() -> None:
+    global _singleton
+    with _singleton_lock:
+        _singleton = None

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1721,6 +1721,59 @@ class GovernedLoopService:
             except Exception as _sx:  # noqa: BLE001
                 logger.debug("[GovernedLoop] strategy sim wiring swallowed: %r", _sx)
 
+            # Slice 204 — Chronos Continuity Matrix. Decouples operational
+            # history from volatile container memory: re-chain the disk-backed
+            # ledger on boot (preserve evolutionary history; chain the strict
+            # unsupervised interval only across an UNSUPERVISED recovery — a
+            # supervised rebuild resets it), then a 60s heartbeat accrues true
+            # running time (sleep-frozen wall-clock excluded). Gated, fail-soft.
+            try:
+                from backend.core.ouroboros.governance.chronos_ledger import (
+                    chronos_enabled as _chronos_on,
+                    get_chronos_ledger as _chronos_get,
+                    heartbeat_interval_s as _chronos_hb_s,
+                )
+                if _chronos_on():
+                    import asyncio as _aio_chr
+                    import time as _t_chr
+                    _image = os.environ.get("JARVIS_SOAK_IMAGE_ID", "").strip() \
+                        or os.environ.get("HOSTNAME", "").strip() or "local"
+                    _chr_led = _chronos_get()
+                    _chr_snap = _chr_led.rechain_on_boot(
+                        now_unix=_t_chr.time(), image_id=_image,
+                    )
+                    logger.warning(
+                        "[GovernedLoop] Chronos re-chained: boot=%d event=%s "
+                        "total_days=%.3f unsupervised_days=%.3f",
+                        _chr_snap.get("boot_count"), _chr_snap.get("last_event"),
+                        _chr_snap.get("total_operational_days", 0.0),
+                        _chr_snap.get("unsupervised_interval_days", 0.0),
+                    )
+
+                    async def _chronos_heartbeat_loop() -> None:
+                        _iv = _chronos_hb_s()
+                        while True:
+                            try:
+                                await _aio_chr.sleep(_iv)
+                                _chr_led.heartbeat(
+                                    now_unix=_t_chr.time(),
+                                    now_monotonic=_t_chr.monotonic(),
+                                )
+                            except _aio_chr.CancelledError:
+                                break
+                            except Exception:  # noqa: BLE001
+                                pass
+
+                    self._chronos_task = _aio_chr.create_task(
+                        _chronos_heartbeat_loop(),
+                    )
+                    logger.info(
+                        "[GovernedLoop] Chronos heartbeat scheduled (%.0fs; "
+                        "non-volatile uptime ledger active)", _chronos_hb_s(),
+                    )
+            except Exception as _cx:  # noqa: BLE001
+                logger.debug("[GovernedLoop] chronos wiring swallowed: %r", _cx)
+
         except Exception as exc:
             self._state = ServiceState.FAILED
             self._failure_reason = str(exc)

--- a/backend/core/ouroboros/governance/observability_registry.py
+++ b/backend/core/ouroboros/governance/observability_registry.py
@@ -414,11 +414,24 @@ def register_registry_routes(
                     status=429, headers=_headers(request),
                 )
         reg = get_observability_registry()
+        # Slice 204 — surface the Chronos non-volatile uptime ledger alongside
+        # the counters so the operator can see operational continuity in one
+        # GET (best-effort; absent/disabled → omitted).
+        chronos = None
+        try:
+            from backend.core.ouroboros.governance.chronos_ledger import (
+                chronos_enabled as _chr_on, get_chronos_ledger as _chr_get,
+            )
+            if _chr_on():
+                chronos = _chr_get().snapshot()
+        except Exception:  # noqa: BLE001
+            chronos = None
         return web.json_response(
             {
                 "schema_version": REGISTRY_SCHEMA_VERSION,
                 "backend": reg.backend_kind,
                 "counters": reg.snapshot(),
+                "chronos": chronos,
                 "generated_at_unix": time.time(),
             },
             status=200, headers=_headers(request),

--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -95,6 +95,14 @@ services:
       # dispose: writes only roadmap.draft.yaml, never signs, never writes the
       # active roadmap — the operator elevates approved goals via strategy_signer. ──
       JARVIS_STRATEGY_SIMULATOR_ENABLED: "1"
+      # ── Slice 204: Chronos Continuity Matrix. Non-volatile, hash-chained
+      # uptime ledger (.jarvis/chronos_coherence.json) — re-chains on boot so a
+      # rebuild preserves evolutionary history (total_operational) while the
+      # strict unsupervised interval resets only on a SUPERVISED image change.
+      # Sleep-frozen wall-clock is excluded. JARVIS_SOAK_IMAGE_ID lets the
+      # ledger tell rebuilds (supervised) from recoveries (unsupervised). ──
+      JARVIS_CHRONOS_LEDGER_ENABLED: "1"
+      JARVIS_SOAK_IMAGE_ID: "slice-204-chronos"
       # ── Optional: live 🔮 forecast / 💸 sovereignty on the Discord spine ──
       # JARVIS_DISCORD_GATEWAY_ENABLED: "1"   # needs DISCORD_BOT_TOKEN in .env
       # JARVIS_DISCORD_GATES_CHANNEL_ID: "..."

--- a/tests/governance/test_slice204_chronos_ledger.py
+++ b/tests/governance/test_slice204_chronos_ledger.py
@@ -1,0 +1,191 @@
+"""Slice 204 — Chronos Continuity Matrix (non-volatile, honest uptime ledger).
+
+Decouples operational history from volatile container memory: a disk-backed,
+hash-chained ledger (.jarvis/chronos_coherence.json) that survives container
+recreation. On boot it RE-CHAINS within a gap threshold instead of resetting.
+
+The honesty guard (load-bearing): the ledger tracks TWO distinct totals —
+  * total_operational_s   — evolutionary history; chains across ANY restart
+    within the gap threshold (crash, reboot, OR supervised rebuild).
+  * unsupervised_interval_s — the strict §41.6 metric; chains across an
+    UNSUPERVISED recovery (same image), but RESETS on a SUPERVISED rebuild
+    (image changed = operator intervention). A rebuild must not let us claim
+    continuous *unsupervised* time — that would game the metric.
+
+Sleep handling: heartbeat ticks compare wall-clock vs monotonic deltas; a
+host freeze (macOS sleep advances wall but not monotonic) is detected,
+flagged CHRONOS_SLEEP_EVENT, and the FROZEN time is NOT counted as
+operational (only true running time accrues).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.chronos_ledger import (
+    ChronosLedger,
+    chronos_enabled,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    monkeypatch.delenv("JARVIS_CHRONOS_LEDGER_ENABLED", raising=False)
+    yield
+
+
+def _ledger(tmp_path):
+    return ChronosLedger(state_path=tmp_path / "chronos.json")
+
+
+# ===========================================================================
+# A — gate
+# ===========================================================================
+
+def test_disabled_by_default():
+    assert chronos_enabled() is False
+
+
+# ===========================================================================
+# B — fresh boot
+# ===========================================================================
+
+def test_fresh_boot_starts_at_zero(tmp_path):
+    led = _ledger(tmp_path)
+    snap = led.rechain_on_boot(now_unix=1000.0, image_id="img-A")
+    assert snap["boot_count"] == 1
+    assert snap["total_operational_s"] == 0.0
+    assert snap["unsupervised_interval_s"] == 0.0
+
+
+# ===========================================================================
+# C — heartbeat accrual
+# ===========================================================================
+
+def test_heartbeat_accrues_both_totals(tmp_path):
+    led = _ledger(tmp_path)
+    led.rechain_on_boot(now_unix=1000.0, image_id="A")
+    led.heartbeat(now_unix=1060.0, now_monotonic=60.0)
+    led.heartbeat(now_unix=1120.0, now_monotonic=120.0)
+    snap = led.snapshot()
+    assert snap["total_operational_s"] == pytest.approx(120.0)
+    assert snap["unsupervised_interval_s"] == pytest.approx(120.0)
+
+
+# ===========================================================================
+# D — re-chain across restart (the core)
+# ===========================================================================
+
+def test_rechain_same_image_within_gap_is_unsupervised_recovery(tmp_path):
+    p = tmp_path / "c.json"
+    led1 = ChronosLedger(state_path=p)
+    led1.rechain_on_boot(now_unix=1000.0, image_id="A")
+    led1.heartbeat(now_unix=1300.0, now_monotonic=300.0)  # +300s both
+    # restart: same image, 120s gap (crash/reboot recovery)
+    led2 = ChronosLedger(state_path=p)
+    snap = led2.rechain_on_boot(now_unix=1420.0, image_id="A", gap_threshold_s=1200)
+    assert snap["boot_count"] == 2
+    # history preserved AND unsupervised interval chained (same image)
+    assert snap["total_operational_s"] == pytest.approx(300.0)
+    assert snap["unsupervised_interval_s"] == pytest.approx(300.0)
+    assert snap["last_event"] in ("recovery_unsupervised", "RECOVERY_UNSUPERVISED")
+
+
+def test_rechain_changed_image_resets_unsupervised_but_keeps_history(tmp_path):
+    p = tmp_path / "c.json"
+    led1 = ChronosLedger(state_path=p)
+    led1.rechain_on_boot(now_unix=1000.0, image_id="A")
+    led1.heartbeat(now_unix=1300.0, now_monotonic=300.0)
+    # SUPERVISED rebuild: image changed
+    led2 = ChronosLedger(state_path=p)
+    snap = led2.rechain_on_boot(now_unix=1360.0, image_id="B", gap_threshold_s=1200)
+    # evolutionary history chains; unsupervised interval RESETS (honesty guard)
+    assert snap["total_operational_s"] == pytest.approx(300.0)
+    assert snap["unsupervised_interval_s"] == 0.0
+    assert snap["last_event"] in ("rebuild_supervised", "REBUILD_SUPERVISED")
+
+
+def test_rechain_large_gap_resets_unsupervised_keeps_history(tmp_path):
+    p = tmp_path / "c.json"
+    led1 = ChronosLedger(state_path=p)
+    led1.rechain_on_boot(now_unix=1000.0, image_id="A")
+    led1.heartbeat(now_unix=1300.0, now_monotonic=300.0)
+    # huge gap (extended downtime) — same image but beyond threshold
+    led2 = ChronosLedger(state_path=p)
+    snap = led2.rechain_on_boot(now_unix=99999.0, image_id="A", gap_threshold_s=1200)
+    assert snap["total_operational_s"] == pytest.approx(300.0)  # history kept
+    assert snap["unsupervised_interval_s"] == 0.0               # continuity broke
+    assert snap["last_event"] in ("downtime_reset", "DOWNTIME_RESET")
+
+
+# ===========================================================================
+# E — sleep / drift detection
+# ===========================================================================
+
+def test_sleep_freeze_does_not_count_frozen_time(tmp_path):
+    led = _ledger(tmp_path)
+    led.rechain_on_boot(now_unix=1000.0, image_id="A")
+    # normal tick
+    led.heartbeat(now_unix=1060.0, now_monotonic=60.0)
+    # macOS sleep: wall jumps 3600s but monotonic only advanced 60s
+    led.heartbeat(now_unix=4660.0, now_monotonic=120.0)
+    snap = led.snapshot()
+    # only the TRUE running time (monotonic) accrues, not the frozen hour
+    assert snap["total_operational_s"] == pytest.approx(120.0, abs=2.0)
+    assert snap["sleep_events"] >= 1
+
+
+def test_clock_going_backwards_is_safe(tmp_path):
+    led = _ledger(tmp_path)
+    led.rechain_on_boot(now_unix=1000.0, image_id="A")
+    led.heartbeat(now_unix=900.0, now_monotonic=30.0)  # wall went backwards
+    snap = led.snapshot()
+    assert snap["total_operational_s"] >= 0.0  # never negative
+
+
+# ===========================================================================
+# F — hash chain + durability + fail-soft
+# ===========================================================================
+
+def test_state_persists_and_hash_chains(tmp_path):
+    p = tmp_path / "c.json"
+    led = ChronosLedger(state_path=p)
+    led.rechain_on_boot(now_unix=1000.0, image_id="A")
+    led.heartbeat(now_unix=1060.0, now_monotonic=60.0)
+    import json
+    data = json.loads(p.read_text())
+    assert data.get("last_hash")  # hash-chained, tamper-evident
+    assert data["total_operational_s"] == pytest.approx(60.0)
+
+
+def test_corrupt_state_fails_soft_to_fresh(tmp_path):
+    p = tmp_path / "c.json"
+    p.write_text("{garbage not json")
+    led = ChronosLedger(state_path=p)
+    snap = led.rechain_on_boot(now_unix=1000.0, image_id="A")
+    assert snap["boot_count"] == 1  # treated as fresh, no raise
+
+
+def test_heartbeat_never_raises_on_bad_path():
+    led = ChronosLedger(state_path=Path("/nonexistent-x9/c.json"))
+    led.rechain_on_boot(now_unix=1.0, image_id="A")
+    led.heartbeat(now_unix=61.0, now_monotonic=60.0)  # must not raise
+
+
+# ===========================================================================
+# G — wiring pins
+# ===========================================================================
+
+def test_gls_wires_chronos_heartbeat():
+    gov = Path(__file__).resolve().parents[2] / "backend" / "core" \
+        / "ouroboros" / "governance"
+    src = (gov / "governed_loop_service.py").read_text(encoding="utf-8")
+    assert "chronos_ledger" in src or "rechain_on_boot" in src
+
+
+def test_registry_endpoint_surfaces_chronos():
+    gov = Path(__file__).resolve().parents[2] / "backend" / "core" \
+        / "ouroboros" / "governance"
+    src = (gov / "observability_registry.py").read_text(encoding="utf-8")
+    assert "chronos" in src


### PR DESCRIPTION
## Why

Uptime bound to a single container's lifetime is a perverse incentive — it punishes you for ever rebuilding (improving) the system. This decouples operational history from volatile container memory: a disk-backed, hash-chained ledger (`.jarvis/chronos_coherence.json`) that **re-chains on boot** instead of resetting.

## The honesty guard (load-bearing)

The ledger tracks **two distinct totals** so a rebuild preserves history *without* faking the strict unsupervised metric:

- **`total_operational_s`** — evolutionary history; chains across ANY restart within the gap threshold (crash / reboot / supervised rebuild). This is the continuity you wanted.
- **`unsupervised_interval_s`** — the strict §41.6 "continuous unsupervised days" metric; chains across an **unsupervised recovery** (same `image_id` — the system recovered on its own), but **resets on a supervised rebuild** (image changed = operator intervention) or an over-threshold gap.

A code rebuild is a supervised act — letting it claim continuous *unsupervised* time would game the very metric §41 exists to earn honestly. Both numbers are real; they measure different things.

## What

- **`chronos_ledger.py`**: `rechain_on_boot` (classifies recovery vs supervised-rebuild vs downtime by `image_id` + gap), `heartbeat` (**sleep-safe**: macOS freeze advances wall-clock but pauses `monotonic` → only true running time accrues; frozen hours flagged `CHRONOS_SLEEP_EVENT`, not counted), sha256 **hash-chained** persist (tamper-evident). Gated `JARVIS_CHRONOS_LEDGER_ENABLED` default-FALSE.
- **GLS.start**: boot re-chain + 60s heartbeat task (gated, fail-soft).
- **`/observability/registry`**: surfaces the chronos snapshot alongside counters — one GET shows operational continuity.
- **compose**: enabled + `JARVIS_SOAK_IMAGE_ID` (lets the ledger tell a supervised rebuild from an unsupervised recovery).

## Verification

13 tests: fresh boot, heartbeat accrual, the three re-chain classifications (recovery / supervised-rebuild / downtime), sleep-freeze excludes frozen time, clock-backwards safe, hash-chain durable, corrupt-state fails-soft, GLS + registry wiring pins. 39 green with the registry suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a disk-backed, hash-chained “Chronos” uptime ledger that survives restarts and keeps honest unsupervised time. Integrates a sleep-safe heartbeat and exposes a snapshot in the observability registry.

- **New Features**
  - New ledger at `.jarvis/chronos_coherence.json` with sha256 chaining.
  - Tracks `total_operational_s` (history) and `unsupervised_interval_s` (resets on supervised rebuild or long gaps).
  - Sleep-safe heartbeat accrues real run time via `time.monotonic`; scheduled every 60s in GLS when enabled.
  - `/observability/registry` now includes a `chronos` snapshot (best-effort).
  - Compose enables the ledger for soak; uses `JARVIS_SOAK_IMAGE_ID` to tell rebuilds from recoveries.

- **Migration**
  - Off by default. Set `JARVIS_CHRONOS_LEDGER_ENABLED=1` to enable.
  - Set `JARVIS_SOAK_IMAGE_ID` (or rely on `HOSTNAME`) to identify the image for continuity rules.
  - No breaking changes; safe to roll out incrementally.

<sup>Written for commit 384354b146ff527bf762a97f3b745be986eae4e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

