### PR TITLE
[Ouroboros Review] [Ouroboros Strategic Proposal] Project Horizon Upgrades

### DIFF
--- a/.jarvis/roadmap.draft.yaml
+++ b/.jarvis/roadmap.draft.yaml
@@ -1,0 +1,48 @@
+version: 1
+operator_id: ov-strategy-simulator
+source: strategy_simulation_telemetry_driven
+authority: draft
+signed: false
+note: DRAFT proposal synthesized by the strategy simulator from live registry telemetry.
+  NOT authoritative and NOT signed. Review the bundled PR; run strategy_signer to
+  elevate the goals you approve into the signed roadmap.yaml.
+goals:
+- id: sim-control_plane_starvation
+  title: Eliminate control-plane starvation (event-loop wedges)
+  description: 'Recurring ControlPlaneStarvation lag events — the main asyncio loop
+    is being starved by sync CPU work. Goal: move the blocking work off-thread / chunk
+    it so the loop ticks within threshold.'
+  priority: high
+  success_criteria: control_plane_starvation_events < 5 / 24h
+  depends_on: []
+  fitness: 3.5294
+  evidence:
+    counter: control_plane_starvation_events
+    count: 50.0
+    severity: 10.0
+- id: sim-provider_exhaustion
+  title: Harden provider resilience (eliminate all_providers_exhausted)
+  description: 'Telemetry shows ops fully exhausting every provider tier. Goal: drive
+    provider_exhaustions to 0 via deeper failover / backoff / additional fallback
+    capacity.'
+  priority: high
+  success_criteria: provider_exhaustions == 0 across a 24h window
+  depends_on: []
+  fitness: 2.402
+  evidence:
+    counter: provider_exhaustions
+    count: 15.0
+    severity: 10.0
+- id: sim-vendor_instability
+  title: Reduce abandoned hedge races (dual-arm vendor failures)
+  description: 'Races dying with no winner indicate dual-arm vendor failures. Goal:
+    lower the abandoned-race rate via earlier rotation / a third transport arm / better
+    model-health prediction.'
+  priority: medium
+  success_criteria: abandoned-race ratio < 5% of dispatches
+  depends_on: []
+  fitness: 0.5441
+  evidence:
+    counter: hedge_races_abandoned
+    count: 3.0
+    severity: 2.5


### PR DESCRIPTION
## Ouroboros Review Request

**Op ID:** `strategy-proposal`
**Risk tier:** `APPROVAL_REQUIRED` (Orange - human approval required)
**Description:** [Ouroboros Strategic Proposal] Project Horizon Upgrades

### Files changed

- `.jarvis/roadmap.draft.yaml`

### Risk evidence

```json
{
  "strategy_proposal": true,
  "body": "## [Ouroboros Strategic Proposal] Project Horizon Upgrades\n\nThe organism analyzed its own telemetry (observability registry) and proposes the following remediation goals, ranked by a **heuristic** fitness (severity \u00d7 frequency \u00f7 effort \u2014 a prioritization, not a predictive ROI). **DO-NOT-AUTO-MERGE** \u2014 this is a proposal for your review.\n\n| # | Goal | Priority | Fitness | Evidence |\n|---|------|----------|---------|----------|\n| 1 | Eliminate control-plane starvation (event-loop wedges) | high | 3.5294 | control_plane_starvation_events=50.0 |\n| 2 | Harden provider resilience (eliminate all_providers_exhausted) | high | 2.402 | provider_exhaustions=15.0 |\n| 3 | Reduce abandoned hedge races (dual-arm vendor failures) | medium | 0.5441 | hedge_races_abandoned=3.0 |\n\n### To accept\nReview the goals above. To elevate the ones you approve into the signed authoritative roadmap, run:\n```\npython3 -m backend.core.ouroboros.governance.strategy_signer .jarvis/roadmap.yaml\n```\n(after copying the goals you want from `.jarvis/roadmap.draft.yaml`)."
}
```

### Review checklist

- [ ] The diff does what the description claims
- [ ] Tests cover the new behavior (or are added in this PR)
- [ ] No new hardcoded model names, credentials, or URLs
- [ ] Nothing bypasses Manifesto §6 (Iron Gate) boundaries

---
*Filed automatically by the Ouroboros organism on behalf of an APPROVAL_REQUIRED change. The autonomous loop did NOT apply this change - it handed it off to you for review.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a telemetry-driven draft roadmap at `.jarvis/roadmap.draft.yaml` for Project Horizon. Proposes fixes for control‑plane starvation, provider exhaustion, and abandoned hedge races; human approval required before signing.

- **New Features**
  - Draft goals with priorities, evidence, and success criteria.
  - Targets: control‑plane starvation (<5/24h), provider exhaustions (0/24h), abandoned hedge races (<5% of dispatches).

- **Migration**
  - Review and copy approved goals into `.jarvis/roadmap.yaml`.
  - Sign the roadmap: `python3 -m backend.core.ouroboros.governance.strategy_signer .jarvis/roadmap.yaml`.

<sup>Written for commit 65d1ae43daafa075a33e62c84d7b121a1e4098bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

