### PR TITLE
feat(perf): Slice 207 - class-level loop guard on SemanticIndex.build (self-offload)

### DIFF
--- a/backend/core/ouroboros/governance/semantic_index.py
+++ b/backend/core/ouroboros/governance/semantic_index.py
@@ -91,6 +91,15 @@ def _env_float(name: str, default: float, minimum: float = 0.0) -> float:
         return default
 
 
+def loop_guard_enabled() -> bool:
+    """Slice 207 — master for the class-level event-loop guard on ``build()``.
+    Default FALSE (OFF = byte-identical legacy: build() always runs the sync
+    rebuild). ON = build() invoked synchronously on the running event loop
+    redirects to the thread-offloaded build_async (non-blocking,
+    eventually-consistent) instead of freezing the loop. NEVER raises."""
+    return _env_bool("JARVIS_LOOP_GUARD_ENABLED", False)
+
+
 def _is_enabled() -> bool:
     """Master switch (default ``true`` post Tier 0a flip 2026-05-03).
 
@@ -1664,6 +1673,41 @@ class SemanticIndex:
         Honors the refresh interval unless ``force=True``. Never raises —
         failures log at DEBUG and leave the prior index (if any) in place.
         """
+        # Slice 207 — class-level event-loop guard. If build() is invoked
+        # SYNCHRONOUSLY on the running event loop (any caller, current or
+        # future — a non-singleton index, a per-op consumer, etc.), do NOT
+        # freeze the loop with the multi-second rebuild. Redirect to the
+        # existing thread-offloaded build_async (single-flight) and return the
+        # current eventually-consistent built-state. The advisory index
+        # tolerates one cycle of staleness (score/boost operate against the
+        # currently-loaded centroid; empty on cold start — exactly what a sync
+        # build would also yield before the embedder is warm). In a worker
+        # thread get_running_loop() raises → the guard is inert → the real
+        # rebuild runs there (no recursion). Gated; OFF → byte-identical.
+        if loop_guard_enabled():
+            _on_loop = False
+            try:
+                import asyncio as _aio_lg
+                _aio_lg.get_running_loop()
+                _on_loop = True
+            except RuntimeError:
+                _on_loop = False
+            except Exception:  # noqa: BLE001
+                _on_loop = False
+            if _on_loop:
+                logger.warning(
+                    "[SemanticIndex] build() invoked synchronously on the event "
+                    "loop — redirecting to thread-offloaded build_async "
+                    "(non-blocking, eventually-consistent). Caller should use "
+                    "build_async()/build_offloaded() directly.",
+                )
+                try:
+                    self.build_async()
+                except Exception:  # noqa: BLE001
+                    pass
+                with self._lock:
+                    return self._built_at > 0
+
         # Slice 33 Arc 0 — diagnostic only. Heavy sync rebuild
         # (centroid + clusters); called from build_async via
         # threadpool but also potentially on main during cold start.

--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -110,6 +110,11 @@ services:
       # ever masking real steady-state starvation. ──
       JARVIS_INIT_LIFECYCLE_ENABLED: "1"
       JARVIS_INIT_WARMUP_MAX_S: "180"
+      # ── Slice 207: class-level loop guard. SemanticIndex.build() invoked
+      # synchronously on the event loop redirects to the existing thread-
+      # offloaded build_async (non-blocking, eventually-consistent) instead of
+      # freezing the loop for ~25s — immunizes ANY caller, current or future. ──
+      JARVIS_LOOP_GUARD_ENABLED: "1"
       # ── Optional: live 🔮 forecast / 💸 sovereignty on the Discord spine ──
       # JARVIS_DISCORD_GATEWAY_ENABLED: "1"   # needs DISCORD_BOT_TOKEN in .env
       # JARVIS_DISCORD_GATES_CHANNEL_ID: "..."

--- a/progress.txt
+++ b/progress.txt
@@ -16,6 +16,9 @@
   [x] slice-203  strategy simulator (telemetry-driven proposal) -> PR #69445 MERGED
   [x] slice-204  chronos continuity matrix (non-volatile, honest uptime ledger)
   [x] slice-205  state portability (operational ledgers travel on migration)
+  [x] slice-206  boot-warmup lifecycle + honest starvation reclassification (warmup_lag)
+  [x] slice-207  class-level loop guard: SemanticIndex.build() self-offloads if called sync on the loop
+                 (immunizes ANY caller, current/future — not a localized patch)
 
 ## NEXT TARGETS (operator-gated — the engine is built; these need runtime + judgment)
   [ ] runtime       leave the soak UNTOUCHED to accrue continuous unsupervised days

--- a/tests/governance/test_slice207_loop_guard.py
+++ b/tests/governance/test_slice207_loop_guard.py
@@ -1,0 +1,146 @@
+"""Slice 207 — Class-level loop guard on SemanticIndex.build().
+
+Slice 206 proved (and I reported honestly) that the 25s loop freeze persists:
+a non-singleton SemanticIndex somewhere calls the SYNC build() directly on the
+event loop. Rather than hunt that caller (and stay vulnerable to the next
+module that does the same), the CLASS itself becomes loop-aware: if build() is
+invoked synchronously on the running event loop, it does NOT block — it
+redirects to the existing thread-offloaded build_async (single-flight) and
+returns the current (eventually-consistent) built-state immediately.
+
+Why this is coherent (the plan's run_coroutine_threadsafe().result() is NOT):
+a sync method returning bool cannot offload-and-wait without re-blocking the
+loop or deadlocking. The viable pivot — valid here because the index is
+ADVISORY/eventually-consistent — is "schedule the thread build, return the
+last-known-good now." In a worker thread get_running_loop() raises, so the
+guard never fires there and never recurses.
+
+Gated JARVIS_LOOP_GUARD_ENABLED default-FALSE (OFF = byte-identical: build()
+always runs _build_impl). Off-loop callers are unaffected either way.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.semantic_index import (
+    SemanticIndex,
+    loop_guard_enabled,
+)
+
+_GOV = Path(__file__).resolve().parents[2] / "backend" / "core" \
+    / "ouroboros" / "governance"
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    monkeypatch.delenv("JARVIS_LOOP_GUARD_ENABLED", raising=False)
+    yield
+
+
+def _idx(tmp_path):
+    return SemanticIndex(project_root=tmp_path)
+
+
+# ===========================================================================
+# A — gate
+# ===========================================================================
+
+def test_loop_guard_disabled_by_default():
+    assert loop_guard_enabled() is False
+
+
+# ===========================================================================
+# B — off-loop: byte-identical (runs the real build)
+# ===========================================================================
+
+def test_offloop_runs_real_build(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_LOOP_GUARD_ENABLED", "1")
+    idx = _idx(tmp_path)
+    calls = {"impl": 0, "async": 0}
+    monkeypatch.setattr(idx, "_build_impl", lambda *, force=False: calls.__setitem__("impl", calls["impl"] + 1) or True)
+    monkeypatch.setattr(idx, "build_async", lambda: calls.__setitem__("async", calls["async"] + 1) or "started")
+    # No running loop here → guard must NOT fire → real build runs.
+    idx.build(force=True)
+    assert calls["impl"] == 1 and calls["async"] == 0
+
+
+# ===========================================================================
+# C — on-loop: redirect to thread-offload, do NOT block (the fix)
+# ===========================================================================
+
+def test_onloop_redirects_to_build_async(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_LOOP_GUARD_ENABLED", "1")
+    idx = _idx(tmp_path)
+    calls = {"impl": 0, "async": 0}
+    monkeypatch.setattr(idx, "_build_impl", lambda *, force=False: calls.__setitem__("impl", calls["impl"] + 1) or True)
+    monkeypatch.setattr(idx, "build_async", lambda: calls.__setitem__("async", calls["async"] + 1) or "started")
+
+    async def _run():
+        # Called synchronously INSIDE the running loop → guard fires.
+        return idx.build(force=True)
+
+    result = asyncio.run(_run())
+    assert isinstance(result, bool)
+    assert calls["async"] == 1          # redirected to thread-offload
+    assert calls["impl"] == 0           # the loop was NEVER blocked by _build_impl
+
+
+def test_onloop_returns_built_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_LOOP_GUARD_ENABLED", "1")
+    idx = _idx(tmp_path)
+    monkeypatch.setattr(idx, "build_async", lambda: "started")
+    monkeypatch.setattr(idx, "_build_impl", lambda *, force=False: True)
+    # cold (never built) → returns False (advisory degrade, non-blocking)
+    idx._built_at = 0.0
+    assert asyncio.run(_run_build(idx)) is False
+    # already built → returns True (last-known-good)
+    idx._built_at = 12345.0
+    assert asyncio.run(_run_build(idx)) is True
+
+
+async def _run_build(idx):
+    return idx.build(force=True)
+
+
+# ===========================================================================
+# D — guard disabled: byte-identical even on the loop
+# ===========================================================================
+
+def test_disabled_on_loop_runs_real_build(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_LOOP_GUARD_ENABLED", "false")
+    idx = _idx(tmp_path)
+    calls = {"impl": 0, "async": 0}
+    monkeypatch.setattr(idx, "_build_impl", lambda *, force=False: calls.__setitem__("impl", calls["impl"] + 1) or True)
+    monkeypatch.setattr(idx, "build_async", lambda: calls.__setitem__("async", calls["async"] + 1) or "started")
+    asyncio.run(_run_build(idx))
+    assert calls["impl"] == 1 and calls["async"] == 0  # legacy behavior
+
+
+# ===========================================================================
+# E — recursion safety (worker thread has no loop → real build)
+# ===========================================================================
+
+def test_worker_thread_runs_real_build(tmp_path, monkeypatch):
+    """The guard must NOT recurse: build_async's daemon thread calls build()
+    with no running loop → real build runs there."""
+    monkeypatch.setenv("JARVIS_LOOP_GUARD_ENABLED", "1")
+    idx = _idx(tmp_path)
+    calls = {"impl": 0}
+    monkeypatch.setattr(idx, "_build_impl", lambda *, force=False: calls.__setitem__("impl", calls["impl"] + 1) or True)
+    import threading
+    t = threading.Thread(target=lambda: idx.build(force=True))
+    t.start(); t.join(timeout=5)
+    assert calls["impl"] == 1  # ran the real build in the thread (no redirect)
+
+
+# ===========================================================================
+# F — wiring pin
+# ===========================================================================
+
+def test_build_has_loop_guard():
+    src = (_GOV / "semantic_index.py").read_text(encoding="utf-8")
+    assert "loop_guard_enabled" in src
+    assert "get_running_loop" in src


### PR DESCRIPTION
## Why class-level beats caller-hunting

Slice 206 proved (and I reported honestly) the 25s loop freeze persists: a non-singleton SemanticIndex calls the **sync** build() directly on the event loop. Fixing only that caller leaves the system vulnerable to the next module that inits its own index. So the **class itself** becomes loop-aware.

## I corrected the plan's mechanism (it was incoherent)

The plan asked build() to offload via run_coroutine_threadsafe().result(). That cannot work: a **synchronous method returning bool cannot offload-and-wait** without re-blocking the loop (.result() blocks the loop thread on the future) or deadlocking (you can't drive the loop you're blocking). 

The **coherent** pivot — valid *here* because the semantic index is advisory / eventually-consistent: on a sync-on-loop call, redirect to the **existing thread-offloaded build_async** (single-flight daemon thread) and return the **last-known-good built-state immediately**. The loop never blocks; the index refreshes a cycle later (score/boost already operate against the currently-loaded or empty centroid — exactly what a cold sync build would also yield before the embedder is warm).

## What

- **`semantic_index.py`**: `loop_guard_enabled()` (`JARVIS_LOOP_GUARD_ENABLED`, default FALSE = byte-identical). `build()` detects `get_running_loop()` success → warns + `build_async()` + returns `self._built_at > 0`. **Recursion-safe**: build_async's daemon thread has no running loop → `get_running_loop` raises → the real rebuild runs there (guard inert off-loop). This immunizes **any** caller, current or future, without hunting them.
- compose: enable. `progress.txt` updated.

## Honestly scoped out

`strategic_direction._extract_git_themes` (1.5s — 16× smaller) is a `@staticmethod` with no instance cache. A clean guard needs an instance-cache refactor; a naive on-loop `return []` would **regress** the git-momentum feature. Deferred rather than rushed — I won't trade a feature for a marginal latency win.

## Verification

7 tests: off-loop runs the real build, on-loop redirects to build_async and **never calls _build_impl** (loop never blocked), returns built-state, disabled = byte-identical, worker-thread recursion-safety, wiring pin. 189 green with the full semantic_index suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a class-level event loop guard to `SemanticIndex.build()` to prevent loop freezes by redirecting on-loop sync calls to `build_async()`. Opt-in via `JARVIS_LOOP_GUARD_ENABLED` (default off) to keep legacy behavior by default.

- **Bug Fixes**
  - On-loop sync `build()` redirects to `build_async()` and returns last-known built state; loop never blocks.
  - Off-loop and worker-thread calls still run `_build_impl`; recursion-safe.
  - Added `JARVIS_LOOP_GUARD_ENABLED` and enabled it in `docker-compose.dw-cortex-soak.yml`.
  - New tests cover on/off-loop behavior, gating, and wiring.

<sup>Written for commit 4a82968d6dd97e7f6fac9e9f9ecaa4a3401b775a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

