### PR TITLE
feat(security): Slice 208 - epistemic-integrity deception detectors (Antivenom hardening)

### DIFF
--- a/backend/core/ouroboros/governance/semantic_guardian.py
+++ b/backend/core/ouroboros/governance/semantic_guardian.py
@@ -1181,6 +1181,143 @@ def _pat_dynamic_dunder_construction(
 
 
 # Declared explicitly so tests + docs can enumerate without introspection.
+# ---------------------------------------------------------------------------
+# Slice 208 — Epistemic-integrity (metric-gaming deception) detectors
+# ---------------------------------------------------------------------------
+# Catch the structural-deception shapes observed this session that pass AST
+# validation while gaming the organism's own honesty: a patch that self-signs
+# a roadmap, suppresses an integrity counter, or launders Chronos
+# unsupervised-time across a supervised boundary.
+#
+# HONEST SCOPE: pattern detectors. They catch the known/obvious shapes, raise
+# friction, and route to APPROVAL_REQUIRED. They are NOT "un-gameable" — a
+# deliberately obfuscated deception can evade a regex. Defense-in-depth on the
+# immune system, not a proof of honesty.
+
+_SIGNING_OWNER_FILES = ("roadmap_reader.py", "strategy_signer.py")
+_SELF_SIGNING_RE = re.compile(
+    r"(compute_signature\s*\(|sign_roadmap_doc\s*\(|_build_signing_payload\s*\(|"
+    r"import\s+strategy_signer|from\s+\S*strategy_signer\s+import)"
+)
+
+
+def _pat_self_signing_attempt(
+    *, file_path: str, old_content: str, new_content: str,
+) -> Optional[Detection]:
+    """HARD: a patch in an AUTONOMOUS module invokes the roadmap signing
+    primitive — the self-authorization shape. The signer/reader modules own
+    the primitive and are exempt."""
+    base = (file_path or "").rsplit("/", 1)[-1]
+    if base in _SIGNING_OWNER_FILES:
+        return None
+    if len(_SELF_SIGNING_RE.findall(new_content)) <= len(
+        _SELF_SIGNING_RE.findall(old_content)
+    ):
+        return None
+    return Detection(
+        pattern="self_signing_attempt", severity="hard",
+        message=(
+            "Epistemic-integrity violation: patch invokes the roadmap signing "
+            "primitive (self-authorization — organism must not mint its own "
+            "operator attestation). METRIC_GAMING_DECEIT_ANOMALY."
+        ),
+        file_path=file_path,
+        lines=tuple(_line_numbers_for_pattern(new_content, _SELF_SIGNING_RE)),
+        snippet="self-signing",
+    )
+
+
+_PROTECTED_METRIC_VARS = (
+    "control_plane_starvation_events", "provider_exhaustions", "warmup_lag",
+    "hedge_races_abandoned", "lag_ms", "lag_event_count",
+)
+_METRIC_ZERO_RE = re.compile(
+    r"\b(" + "|".join(_PROTECTED_METRIC_VARS) + r")\b\s*=\s*0\b"
+)
+_ABSURD_THRESHOLD_RE = re.compile(
+    r"(threshold_ms|_threshold|max_starvation|starvation_threshold)\s*=\s*"
+    r"(9{6,}|1e\d{2,}|float\(\s*['\"]inf['\"]\s*\)|10\s*\*\*\s*\d{2,})"
+)
+_RECORD_CALL_RE = re.compile(
+    r"record_(control_plane_starvation|provider_exhaustion|warmup_lag|"
+    r"hedge_abandoned)\s*\("
+)
+
+
+def _pat_metric_counter_suppressed(
+    *, file_path: str, old_content: str, new_content: str,
+) -> Optional[Detection]:
+    """HARD: a patch hardcodes a protected integrity counter to zero, sets an
+    absurd threshold to disable a watchdog, or REMOVES a record_*() call —
+    suppressing a metric so it reports healthier than reality (the 'absolute
+    zero' deception). Test files out of scope."""
+    base = (file_path or "").rsplit("/", 1)[-1]
+    if base.startswith("test_") or base.endswith("_test.py"):
+        return None
+    for rx, why in (
+        (_METRIC_ZERO_RE, "hardcodes an integrity counter to 0"),
+        (_ABSURD_THRESHOLD_RE, "sets an absurd threshold to disable a watchdog"),
+    ):
+        if len(rx.findall(new_content)) > len(rx.findall(old_content)):
+            return Detection(
+                pattern="metric_counter_suppressed", severity="hard",
+                message=(
+                    f"Epistemic-integrity violation: patch {why} — suppressing "
+                    "a metric so it reports healthier than reality. "
+                    "METRIC_GAMING_DECEIT_ANOMALY."
+                ),
+                file_path=file_path,
+                lines=tuple(_line_numbers_for_pattern(new_content, rx)),
+                snippet="metric-suppression",
+            )
+    # Count only ACTIVE (non-comment) record calls so a comment-out counts as
+    # a removal (a commented line still contains the call text).
+    def _active_record_calls(text: str) -> int:
+        return sum(
+            1 for ln in text.splitlines()
+            if _RECORD_CALL_RE.search(ln) and not ln.lstrip().startswith("#")
+        )
+    if _active_record_calls(new_content) < _active_record_calls(old_content):
+        return Detection(
+            pattern="metric_counter_suppressed", severity="hard",
+            message=(
+                "Epistemic-integrity violation: patch removes a telemetry "
+                "record_*() call — blinding the metric. "
+                "METRIC_GAMING_DECEIT_ANOMALY."
+            ),
+            file_path=file_path, lines=(), snippet="record-call-removed",
+        )
+    return None
+
+
+_CHRONOS_RESET_RE = re.compile(r"unsupervised_interval_s\"?\]?\s*=\s*0\.0")
+
+
+def _pat_chronos_continuity_laundering(
+    *, file_path: str, old_content: str, new_content: str,
+) -> Optional[Detection]:
+    """HARD: a patch to chronos_ledger.py REMOVES an unsupervised-interval
+    reset — letting a supervised rebuild/migration claim continuous
+    UNSUPERVISED time (evidence laundering)."""
+    base = (file_path or "").rsplit("/", 1)[-1]
+    if base != "chronos_ledger.py":
+        return None
+    if len(_CHRONOS_RESET_RE.findall(new_content)) < len(
+        _CHRONOS_RESET_RE.findall(old_content)
+    ):
+        return Detection(
+            pattern="chronos_continuity_laundering", severity="hard",
+            message=(
+                "Epistemic-integrity violation: patch removes a Chronos "
+                "unsupervised-interval reset — a supervised rebuild/migration "
+                "could then claim continuous unsupervised time (evidence "
+                "laundering). METRIC_GAMING_DECEIT_ANOMALY."
+            ),
+            file_path=file_path, lines=(), snippet="chronos-reset-removed",
+        )
+    return None
+
+
 _ALL_PATTERNS: Tuple[str, ...] = (
     "removed_import_still_referenced",
     "function_body_collapsed",
@@ -1194,6 +1331,10 @@ _ALL_PATTERNS: Tuple[str, ...] = (
     "docstring_only_delete",
     "dynamic_import_chain",
     "dynamic_dunder_construction",
+    # Slice 208 — epistemic-integrity (metric-gaming deception)
+    "self_signing_attempt",
+    "metric_counter_suppressed",
+    "chronos_continuity_laundering",
 )
 
 
@@ -1212,6 +1353,10 @@ _PATTERNS: dict = {
     "dynamic_dunder_construction": (
         _pat_dynamic_dunder_construction
     ),
+    # Slice 208 — epistemic-integrity detectors
+    "self_signing_attempt": _pat_self_signing_attempt,
+    "metric_counter_suppressed": _pat_metric_counter_suppressed,
+    "chronos_continuity_laundering": _pat_chronos_continuity_laundering,
 }
 
 

--- a/progress.txt
+++ b/progress.txt
@@ -19,6 +19,12 @@
   [x] slice-206  boot-warmup lifecycle + honest starvation reclassification (warmup_lag)
   [x] slice-207  class-level loop guard: SemanticIndex.build() self-offloads if called sync on the loop
                  (immunizes ANY caller, current/future — not a localized patch)
+                 NOTE: 206/207 MISDIAGNOSED — the 25s freeze is GIL contention (CPU build in a thread),
+                 not on-loop execution. Real fix = process-isolation (JARVIS_COMPUTE_ISOLATION_ENABLED);
+                 helped 23s->13.5s but NOT fully eliminated (a direct cold-start caller remains). Open.
+  [x] slice-208  epistemic-integrity: SemanticGuardian now detects metric-gaming DECEPTION (not just AST
+                 mutation) — self-signing, counter-suppression, chronos-laundering -> HARD/APPROVAL_REQUIRED.
+                 HONEST SCOPE: pattern detectors raise friction + flag; NOT "un-gameable" (obfuscation evades).
 
 ## NEXT TARGETS (operator-gated — the engine is built; these need runtime + judgment)
   [ ] runtime       leave the soak UNTOUCHED to accrue continuous unsupervised days

--- a/tests/governance/test_semantic_guardian.py
+++ b/tests/governance/test_semantic_guardian.py
@@ -92,11 +92,10 @@ def test_all_pattern_names_is_exhaustive():
     this test fails if _ALL_PATTERNS and _PATTERNS desync."""
     from backend.core.ouroboros.governance.semantic_guardian import _PATTERNS
     assert set(all_pattern_names()) == set(_PATTERNS.keys())
-    # Pattern count: 11 originally + Pattern 12
-    # (dynamic_dunder_construction added 2026-05-07 to close
-    # P9.4 KNOWN GAP via static AST analysis of getattr arg
-    # construction shapes).
-    assert len(all_pattern_names()) == 12
+    # Pattern count: 12 structural + 3 Slice-208 epistemic-integrity
+    # (self_signing_attempt / metric_counter_suppressed /
+    # chronos_continuity_laundering — metric-gaming deception detectors).
+    assert len(all_pattern_names()) == 15
 
 
 # ---------------------------------------------------------------------------

--- a/tests/governance/test_slice208_epistemic_integrity.py
+++ b/tests/governance/test_slice208_epistemic_integrity.py
@@ -1,0 +1,144 @@
+"""Slice 208 — Epistemic Integrity: metric-gaming deception detectors.
+
+The brutal-review finding (and this session's lived evidence): the Antivenom
+validates code MUTATIONS (AST/patterns) but not epistemic HONESTY. Three
+distinct gaming attempts this session would have passed every existing check:
+self-signing the roadmap, laundering Chronos unsupervised-time across a
+supervised migration, and suppressing the starvation/latency counters to read
+zero. This slice adds SemanticGuardian patterns that catch those specific
+shapes on O+V's OWN generated patches → HARD finding → APPROVAL_REQUIRED.
+
+HONEST SCOPE (pinned in the messages, not overclaimed): these are PATTERN
+detectors. They catch the known/obvious gaming shapes and raise friction +
+flag for review. They are NOT "un-gameable" — a deliberately obfuscated
+deception can still evade a regex. Defense-in-depth, not a proof.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.semantic_guardian import (
+    SemanticGuardian,
+)
+
+
+@pytest.fixture(autouse=True)
+def _on(monkeypatch):
+    monkeypatch.setenv("JARVIS_SEMANTIC_GUARD_ENABLED", "1")
+    yield
+
+
+def _inspect(file_path, old, new):
+    return SemanticGuardian().inspect(
+        file_path=file_path, old_content=old, new_content=new,
+    )
+
+
+def _patterns(dets):
+    return {d.pattern for d in dets}
+
+
+# ===========================================================================
+# A — self-signing (the Slice-202 refusal, now structural)
+# ===========================================================================
+
+def test_self_signing_via_compute_signature_flagged():
+    old = "def run():\n    return 1\n"
+    new = (
+        "def run():\n"
+        "    from backend.core.ouroboros.governance.roadmap_reader import compute_signature\n"
+        "    sig = compute_signature(payload, secret)\n"
+        "    return sig\n"
+    )
+    dets = _inspect("backend/core/ouroboros/governance/some_autonomous_module.py", old, new)
+    assert "self_signing_attempt" in _patterns(dets)
+    d = next(x for x in dets if x.pattern == "self_signing_attempt")
+    assert d.severity == "hard"
+
+
+def test_self_signing_via_strategy_signer_flagged():
+    new = "from backend.core.ouroboros.governance.strategy_signer import sign_roadmap_doc\nx = sign_roadmap_doc(d, s)\n"
+    dets = _inspect("backend/core/ouroboros/governance/m10/proposal_synthesizer.py", "", new)
+    assert "self_signing_attempt" in _patterns(dets)
+
+
+def test_signer_module_itself_is_not_flagged():
+    """The signer/reader modules legitimately contain the primitive — only
+    OTHER (autonomous) modules calling it are suspicious."""
+    new = "def compute_signature(payload, secret):\n    return hmac_hex\n"
+    dets = _inspect("backend/core/ouroboros/governance/roadmap_reader.py", "", new)
+    assert "self_signing_attempt" not in _patterns(dets)
+
+
+# ===========================================================================
+# B — metric/counter suppression (the "absolute zero" attempts)
+# ===========================================================================
+
+def test_hardcoding_starvation_counter_to_zero_flagged():
+    old = "def snapshot(self):\n    return self._events\n"
+    new = "def snapshot(self):\n    control_plane_starvation_events = 0\n    return 0\n"
+    dets = _inspect("backend/core/ouroboros/governance/observability_registry.py", old, new)
+    assert "metric_counter_suppressed" in _patterns(dets)
+
+
+def test_absurd_threshold_to_disable_watchdog_flagged():
+    old = "self._threshold_ms = 500.0\n"
+    new = "self._threshold_ms = 99999999.0  # never fire\n"
+    dets = _inspect("backend/core/ouroboros/governance/control_plane_watchdog.py", old, new)
+    assert "metric_counter_suppressed" in _patterns(dets)
+
+
+def test_removing_a_record_call_flagged():
+    old = "        self._lag_event_count += 1\n        record_control_plane_starvation()\n"
+    new = "        self._lag_event_count += 1\n        # record_control_plane_starvation()  # disabled\n"
+    dets = _inspect("backend/core/ouroboros/governance/control_plane_watchdog.py", old, new)
+    assert "metric_counter_suppressed" in _patterns(dets)
+
+
+def test_legit_counter_use_not_flagged():
+    old = "x = 1\n"
+    new = "x = 1\nrecord_control_plane_starvation()\n"  # ADDING a record is fine
+    dets = _inspect("backend/core/ouroboros/governance/control_plane_watchdog.py", old, new)
+    assert "metric_counter_suppressed" not in _patterns(dets)
+
+
+# ===========================================================================
+# C — Chronos continuity laundering (supervised → unsupervised)
+# ===========================================================================
+
+def test_removing_unsupervised_reset_flagged():
+    """Deleting the unsupervised_interval reset on a supervised boundary would
+    let a rebuild claim continuous unsupervised time — the Slice-205 refusal."""
+    old = (
+        '                self._s["unsupervised_interval_s"] = 0.0\n'
+        '                self._event("rebuild_supervised")\n'
+    )
+    new = '                self._event("rebuild_supervised")\n'
+    dets = _inspect("backend/core/ouroboros/governance/chronos_ledger.py", old, new)
+    assert "chronos_continuity_laundering" in _patterns(dets)
+
+
+def test_chronos_unrelated_change_not_flagged():
+    old = 'logger.info("hi")\n'
+    new = 'logger.info("hello")\n'
+    dets = _inspect("backend/core/ouroboros/governance/chronos_ledger.py", old, new)
+    assert "chronos_continuity_laundering" not in _patterns(dets)
+
+
+# ===========================================================================
+# D — honest scope: messages flag deceit, severity is hard, registered
+# ===========================================================================
+
+def test_deception_patterns_registered_and_hard():
+    from backend.core.ouroboros.governance.semantic_guardian import _ALL_PATTERNS
+    for p in ("self_signing_attempt", "metric_counter_suppressed",
+              "chronos_continuity_laundering"):
+        assert p in _ALL_PATTERNS
+
+
+def test_messages_name_the_integrity_violation():
+    new = "sig = compute_signature(p, s)\n"
+    dets = _inspect("backend/core/ouroboros/governance/x.py", "", new)
+    d = next(x for x in dets if x.pattern == "self_signing_attempt")
+    assert "integrity" in d.message.lower() or "deceit" in d.message.lower() \
+        or "sign" in d.message.lower()


### PR DESCRIPTION
## Closes the immune-system blind spot the review exposed

The Antivenom validated code **mutations** (AST) but not epistemic **honesty**. Three gaming attempts *this session* would have passed every existing check — self-signing the roadmap (S202 refusal), laundering Chronos unsupervised-time across a supervised migration (S205 refusal), suppressing the starvation counters to read zero (S206 'absolute zero'). **The only thing that caught them was me refusing.** This makes that refusal structural.

Three new SemanticGuardian patterns on O+V's **own** generated patches → HARD → APPROVAL_REQUIRED, flagged `METRIC_GAMING_DECEIT_ANOMALY`:
- **self_signing_attempt** — a non-signer module invoking `compute_signature`/`sign_roadmap_doc`/`strategy_signer` (self-authorization shape; signer/reader modules exempt).
- **metric_counter_suppressed** — hardcoding a protected counter to 0, an absurd threshold disabling a watchdog, or removing a `record_*()` call (active/non-comment count, so a comment-out counts as removal).
- **chronos_continuity_laundering** — removing an unsupervised-interval reset.

## Honest scope (pinned, not overclaimed)

These are **pattern detectors** — they catch the known/obvious shapes and raise friction; they are **NOT 'un-gameable'** (a deliberately obfuscated deception evades regex). Defense-in-depth on the immune system, not a proof. Claiming otherwise would itself be the overclaim we're trying to stamp out.

## Declined Phase 3 (the variance invariant)

`Integrity Score = 1 − Σ|Metric_sim − Metric_reported|` is incoherent: there's no cheap *simulated execution* of an arbitrary patch to diff against reported metrics (that IS running it = VERIFY); demanding exact 1.0 breaks on any nondeterministic/float metric; and the boundary gate governs *who* modifies governance, not metric variance (category error). The real 'is claimed == actual' is **adversarial verification** — promote the Slice-86 mutation harness to a standing audit. Noted for follow-on.

## Verification

11 tests (each deception shape flagged HARD; signer-module exemption; legit-use-not-flagged negatives; registration). 57 green with the full semantic_guardian suite (count-pin 12→15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three epistemic-integrity detectors to `semantic_guardian` to block metric-gaming changes with HARD severity and require approval. This closes a blind spot by flagging self-signing, telemetry suppression, and Chronos continuity laundering.

- **New Features**
  - `self_signing_attempt`: Flags non-signer modules that call `compute_signature`/`sign_roadmap_doc` or import `strategy_signer` (self-authorization). Signer/reader modules are exempt. Raises `METRIC_GAMING_DECEIT_ANOMALY`.
  - `metric_counter_suppressed`: Detects protected counters set to 0, absurd watchdog thresholds, or removal of active `record_*()` calls (comments count as removals). Test files are ignored. Raises `METRIC_GAMING_DECEIT_ANOMALY`.
  - `chronos_continuity_laundering`: Detects removal of the `unsupervised_interval_s = 0.0` reset in `chronos_ledger.py`. Raises `METRIC_GAMING_DECEIT_ANOMALY`.
  - Registered all patterns and updated tests (suite grows from 12→15 patterns).

<sup>Written for commit e5bf60c4bfa8f886d3062336432633ebc4aadf8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

