### PR TITLE
feat(ops): Slice 209 - sovereign autonomy ignition (M10 on operator-signed GOAL-001)

### DIFF
--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -115,6 +115,22 @@ services:
       # offloaded build_async (non-blocking, eventually-consistent) instead of
       # freezing the loop for ~25s — immunizes ANY caller, current or future. ──
       JARVIS_LOOP_GUARD_ENABLED: "1"
+      # ── Slice 208-config: the 25s freeze is GIL contention (CPU build in a
+      # daemon thread), not on-loop execution — only PROCESS isolation frees
+      # the loop. Enables the dormant, tested Slice-150 subprocess build path
+      # (helped 23s->13.5s; residual cold-start caller is GOAL-001 below). ──
+      JARVIS_COMPUTE_ISOLATION_ENABLED: "1"
+      # ── Slice 209 — SOVEREIGN AUTONOMY IGNITION. Operator authored + signed
+      # GOAL-001 (eradicate cold-start GIL starvation) into .jarvis/roadmap.yaml
+      # (HMAC secret in .env, gitignored). Reader verifies it -> goal
+      # decomposition -> M10 ProposalSynthesizer -> the organism attempts its
+      # OWN #1 fix. Every patch still passes Iron Gate + SemanticGuardian (incl.
+      # Slice-208 deceit detectors) + boundary gate (governance edits ->
+      # APPROVAL_REQUIRED -> orange PR for human review, never auto-merge). ──
+      JARVIS_ROADMAP_READER_ENABLED: "1"
+      JARVIS_GOAL_DECOMPOSITION_ENABLED: "1"
+      JARVIS_M10_CADENCE_ENABLED: "1"
+      JARVIS_ORANGE_PR_ENABLED: "1"
       # ── Optional: live 🔮 forecast / 💸 sovereignty on the Discord spine ──
       # JARVIS_DISCORD_GATEWAY_ENABLED: "1"   # needs DISCORD_BOT_TOKEN in .env
       # JARVIS_DISCORD_GATES_CHANNEL_ID: "..."


### PR DESCRIPTION
Operator-chosen path: let the organism attempt its OWN #1 self-identified priority (PR #69445, cold-start GIL starvation) instead of a reactive Claude patch. Operator authored + signed GOAL-001 into `.jarvis/roadmap.yaml` (secret in `.env`, gitignored; reader verdict=valid, signature verified). Compose enables compute-isolation + RoadmapReader + goal decomposition + M10 cadence + orange PR. Safety unchanged: Iron Gate + SemanticGuardian (incl. Slice-208 deceit detectors) + boundary gate → APPROVAL_REQUIRED → orange PR for review, never auto-merge. Honest: tests whether the autonomy loop ENGAGES, not that O+V solves GIL contention. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Slice 209 in the soak compose so the system can tackle the operator‑signed GOAL‑001 (reduce cold‑start event‑loop starvation) with compute isolation and governed, human‑reviewed PRs. This turns on the reader → decomposition → M10 cadence path while keeping existing safety gates unchanged.

- **New Features**
  - Enable compute isolation for the build path; cold‑start improved from ~23s to ~13.5s.
  - Turn on signed roadmap reader, goal decomposition, M10 cadence, and approval‑required orange PRs in `docker-compose.dw-cortex-soak.yml`.

<sup>Written for commit 37a298bc16203728fdc92011986062a6b8c6c5fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

