### PR TITLE
feat(ops): Slice 211 - strategic ignition mesh (wire roadmap orchestrator into the live loop)

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1843,6 +1843,79 @@ class GovernedLoopService:
             except Exception as _ilx:  # noqa: BLE001
                 logger.debug("[GovernedLoop] warmup lifecycle swallowed: %r", _ilx)
 
+            # Slice 211 — STRATEGIC IGNITION MESH. The roadmap_orchestrator
+            # (reads the operator-signed roadmap, emits goal envelopes into
+            # intake) had ZERO callers in the live loop — the disconnected wire
+            # found in the GOAL-001 autonomy test. Plug it into GLS as a
+            # deferred daemon that drives execute_roadmap in single-poll bursts
+            # on an ADAPTIVE, stress-aware cadence (recovers to base when the
+            # vendor stabilizes — corrected from the cumulative formula that
+            # never recovers). Every emitted goal still flows through the full
+            # gated pipeline (Iron Gate + SemanticGuardian + boundary gate ->
+            # APPROVAL_REQUIRED -> orange PR). Gated, fail-soft, never blocks
+            # boot. Wired into GLS (the LIVE loop), NOT legacy engine.py.
+            try:
+                from backend.core.ouroboros.governance.roadmap_orchestrator import (  # noqa: E501
+                    master_enabled as _rmo_enabled,
+                    execute_roadmap as _rmo_execute,
+                )
+                from backend.core.ouroboros.governance.roadmap_cadence import (
+                    AdaptiveRoadmapCadence as _RmCadence,
+                )
+                if _rmo_enabled():
+                    import asyncio as _aio_rm
+
+                    async def _roadmap_ignition_daemon() -> None:
+                        cad = _RmCadence()
+                        # brief settle so intake/router are attached
+                        await _aio_rm.sleep(20)
+                        while True:
+                            try:
+                                _router = getattr(self, "_intake_router", None)
+                                _rep = await _rmo_execute(
+                                    router=_router,
+                                    max_iterations_override=1,
+                                )
+                                try:
+                                    from backend.core.ouroboros.governance.progress_ledger import (  # noqa: E501
+                                        ledger_enabled as _pl_on,
+                                        update_progress as _pl_update,
+                                    )
+                                    if _pl_on() and _rep is not None:
+                                        _pl_update(
+                                            completed=[],
+                                            next_targets=[(
+                                                "GOAL-001",
+                                                "roadmap orchestrator polling "
+                                                "(strategic ignition mesh live)",
+                                            )],
+                                        )
+                                except Exception:  # noqa: BLE001
+                                    pass
+                            except _aio_rm.CancelledError:
+                                break
+                            except Exception as _re:  # noqa: BLE001
+                                logger.debug(
+                                    "[GovernedLoop] roadmap poll swallowed: %r",
+                                    _re,
+                                )
+                            try:
+                                await _aio_rm.sleep(cad.next_interval_s())
+                            except _aio_rm.CancelledError:
+                                break
+
+                    self._roadmap_task = _aio_rm.create_task(
+                        _roadmap_ignition_daemon(),
+                    )
+                    logger.warning(
+                        "[GovernedLoop] STRATEGIC IGNITION MESH live — roadmap "
+                        "orchestrator wired into the control plane (adaptive "
+                        "stress-aware cadence); organism now feeds on "
+                        "operator-signed goals.",
+                    )
+            except Exception as _rmx:  # noqa: BLE001
+                logger.debug("[GovernedLoop] roadmap mesh wiring swallowed: %r", _rmx)
+
         except Exception as exc:
             self._state = ServiceState.FAILED
             self._failure_reason = str(exc)

--- a/backend/core/ouroboros/governance/roadmap_cadence.py
+++ b/backend/core/ouroboros/governance/roadmap_cadence.py
@@ -1,0 +1,112 @@
+"""Slice 211 — Adaptive stress-aware cadence for the roadmap orchestrator.
+
+The roadmap orchestrator (``roadmap_orchestrator.execute_roadmap``) is a
+complete, tested strategic driver that reads the operator-signed roadmap and
+emits goal envelopes into intake — but it had ZERO callers in the live loop
+(the disconnected wire found in the GOAL-001 autonomy test). This module is
+the adaptive cadence that the GLS daemon uses to drive it in single-poll
+bursts, so the strategic loop continuously feeds on operator goals while
+backing off its token footprint when the vendor environment is hostile.
+
+THE FORMULA CORRECTION (load-bearing). The proposed
+``Interval = base * (1 + provider_exhaustions)`` is broken: provider_exhaustions
+is a CUMULATIVE counter that only grows, so the interval would balloon to 51x,
+101x, ... and NEVER recover even after the vendor stabilizes. The coherent
+version backs off on the RECENT RATE — exhaustions since the last poll — so it
+returns to baseline the moment stress subsides:
+
+    Interval_next = min(base * (1 + recent_exhaustion_delta), max_interval)
+
+recent_exhaustion_delta = provider_exhaustions(now) - provider_exhaustions(last
+poll), floored at 0. delta == 0 (vendor stable) -> interval == base (recovered).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_ENV_BASE_S = "JARVIS_ROADMAP_CADENCE_BASE_S"
+_ENV_MAX_S = "JARVIS_ROADMAP_CADENCE_MAX_S"
+_DEFAULT_BASE_S = 120.0
+_DEFAULT_MAX_S = 1800.0
+
+
+def _envf(name: str, default: float) -> float:
+    try:
+        raw = os.environ.get(name, "").strip()
+        v = float(raw) if raw else default
+        return v if v > 0 else default
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def base_interval_s() -> float:
+    return _envf(_ENV_BASE_S, _DEFAULT_BASE_S)
+
+
+def max_interval_s() -> float:
+    return _envf(_ENV_MAX_S, _DEFAULT_MAX_S)
+
+
+def compute_adaptive_interval(
+    base_s: float,
+    exhaustion_delta: float,
+    max_s: float,
+) -> float:
+    """Recovering stress-aware backoff. delta is the RECENT exhaustion rate
+    (count since last poll), NOT the cumulative total — so the interval
+    returns to base when the vendor stabilizes. NEVER raises."""
+    try:
+        base = max(1.0, float(base_s))
+        cap = max(base, float(max_s))
+        delta = max(0.0, float(exhaustion_delta))
+        return min(base * (1.0 + delta), cap)
+    except Exception:  # noqa: BLE001
+        return max(1.0, float(base_s) if base_s else _DEFAULT_BASE_S)
+
+
+class AdaptiveRoadmapCadence:
+    """Tracks the cumulative provider_exhaustions reading between polls and
+    derives the recent-rate delta for the backoff. NEVER raises."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._last_exhaustions: Optional[int] = None
+
+    def _current_exhaustions(self) -> int:
+        try:
+            from backend.core.ouroboros.governance.observability_registry import (
+                PROVIDER_EXHAUSTIONS, get_observability_registry,
+            )
+            return int(get_observability_registry().get(PROVIDER_EXHAUSTIONS))
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def next_interval_s(self) -> float:
+        """Compute the next poll interval from the recent exhaustion rate.
+        First call anchors (delta 0 -> base). NEVER raises."""
+        try:
+            cur = self._current_exhaustions()
+            with self._lock:
+                if self._last_exhaustions is None:
+                    self._last_exhaustions = cur
+                    delta = 0.0
+                else:
+                    delta = max(0.0, float(cur - self._last_exhaustions))
+                    self._last_exhaustions = cur
+            interval = compute_adaptive_interval(
+                base_interval_s(), delta, max_interval_s(),
+            )
+            if delta > 0:
+                logger.info(
+                    "[RoadmapCadence] vendor stress (exhaustion_delta=%.0f) -> "
+                    "backoff poll interval %.0fs (base %.0fs)",
+                    delta, interval, base_interval_s(),
+                )
+            return interval
+        except Exception:  # noqa: BLE001
+            return base_interval_s()

--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -131,6 +131,14 @@ services:
       JARVIS_GOAL_DECOMPOSITION_ENABLED: "1"
       JARVIS_M10_CADENCE_ENABLED: "1"
       JARVIS_ORANGE_PR_ENABLED: "1"
+      # ── Slice 211 — STRATEGIC IGNITION MESH. The roadmap_orchestrator master
+      # (the driver that reads the signed roadmap + emits goals into intake) was
+      # the third cut wire — default-FALSE + zero callers. Enable it + the GLS
+      # daemon now drives it on an adaptive, stress-aware cadence (recovers to
+      # base when the vendor stabilizes). THIS is what makes GOAL-001 reach the
+      # organism's work queue. ──
+      JARVIS_ROADMAP_ORCHESTRATOR_ENABLED: "1"
+      JARVIS_PROGRESS_LEDGER_ENABLED: "1"
       # ── Optional: live 🔮 forecast / 💸 sovereignty on the Discord spine ──
       # JARVIS_DISCORD_GATEWAY_ENABLED: "1"   # needs DISCORD_BOT_TOKEN in .env
       # JARVIS_DISCORD_GATES_CHANNEL_ID: "..."

--- a/tests/governance/test_slice211_ignition_mesh.py
+++ b/tests/governance/test_slice211_ignition_mesh.py
@@ -1,0 +1,106 @@
+"""Slice 211 — Strategic Ignition Mesh: wire the roadmap orchestrator + the
+adaptive (recovering) stress-aware cadence.
+
+The GOAL-001 autonomy test found roadmap_orchestrator has ZERO callers in the
+live loop. This slice plugs it into the GLS boot as a deferred daemon driving
+single-poll bursts on an adaptive cadence. The cadence formula is CORRECTED
+from the proposed cumulative version (which never recovers) to a recent-rate
+backoff that returns to baseline when the vendor stabilizes.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.roadmap_cadence import (
+    AdaptiveRoadmapCadence,
+    compute_adaptive_interval,
+)
+
+_GOV = Path(__file__).resolve().parents[2] / "backend" / "core" \
+    / "ouroboros" / "governance"
+
+
+# ===========================================================================
+# A — the corrected (recovering) adaptive formula
+# ===========================================================================
+
+def test_no_stress_returns_base():
+    assert compute_adaptive_interval(120.0, exhaustion_delta=0, max_s=1800) == 120.0
+
+
+def test_stress_backs_off_on_RECENT_rate():
+    # delta of 5 exhaustions since last poll → 120 * (1+5) = 720s
+    assert compute_adaptive_interval(120.0, exhaustion_delta=5, max_s=1800) == 720.0
+
+
+def test_backoff_is_capped():
+    assert compute_adaptive_interval(120.0, exhaustion_delta=100, max_s=1800) == 1800.0
+
+
+def test_recovers_to_base_when_stress_subsides():
+    """The whole point vs the cumulative formula: once the recent delta drops
+    back to 0, the interval returns to base (a cumulative counter never would)."""
+    high = compute_adaptive_interval(120.0, exhaustion_delta=8, max_s=1800)
+    recovered = compute_adaptive_interval(120.0, exhaustion_delta=0, max_s=1800)
+    assert high > recovered == 120.0
+
+
+def test_never_raises_on_garbage():
+    assert compute_adaptive_interval(-1, exhaustion_delta=-9, max_s=0) >= 1.0
+
+
+# ===========================================================================
+# B — the cadence tracker derives DELTA, not cumulative
+# ===========================================================================
+
+def test_cadence_first_call_anchors_to_base(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_OBSERVABILITY_REGISTRY_PATH", str(tmp_path / "r.bin"))
+    monkeypatch.delenv("JARVIS_OBSERVABILITY_REGISTRY_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.observability_registry import (
+        _reset_singleton_for_tests,
+    )
+    _reset_singleton_for_tests()
+    cad = AdaptiveRoadmapCadence()
+    # first call: no prior reading → delta 0 → base
+    assert cad.next_interval_s() == 120.0
+    _reset_singleton_for_tests()
+
+
+def test_cadence_backs_off_on_new_exhaustions_then_recovers(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_OBSERVABILITY_REGISTRY_PATH", str(tmp_path / "r.bin"))
+    monkeypatch.delenv("JARVIS_OBSERVABILITY_REGISTRY_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.observability_registry import (
+        _reset_singleton_for_tests, get_observability_registry,
+        record_provider_exhaustion,
+    )
+    _reset_singleton_for_tests()
+    reg = get_observability_registry()
+    cad = AdaptiveRoadmapCadence()
+    cad.next_interval_s()                       # anchor at 0
+    for _ in range(3):
+        record_provider_exhaustion()            # +3 since last poll
+    backed_off = cad.next_interval_s()          # delta=3 → 120*4 = 480
+    assert backed_off == 480.0
+    recovered = cad.next_interval_s()           # delta=0 now → back to 120
+    assert recovered == 120.0
+    _reset_singleton_for_tests()
+
+
+# ===========================================================================
+# C — wiring pins
+# ===========================================================================
+
+def test_gls_wires_roadmap_orchestrator():
+    src = (_GOV / "governed_loop_service.py").read_text(encoding="utf-8")
+    assert "execute_roadmap" in src
+    assert "AdaptiveRoadmapCadence" in src or "next_interval_s" in src
+
+
+def test_gls_drives_single_poll_bursts_not_engine_py():
+    """Wire into the LIVE loop (GLS), and drive single-poll bursts so the
+    adaptive cadence (not the orchestrator's fixed internal timer) owns the
+    timing."""
+    src = (_GOV / "governed_loop_service.py").read_text(encoding="utf-8")
+    assert "max_iterations_override" in src


### PR DESCRIPTION
Plugs the disconnected wire the GOAL-001 test found: `roadmap_orchestrator` had **zero callers** in the live loop AND its master was default-FALSE.

- **roadmap_cadence.py**: adaptive stress-aware cadence. **Corrected** the proposed `base*(1+provider_exhaustions)` — that cumulative counter only grows, so the interval would balloon and *never recover*. The coherent version backs off on the **recent rate** (delta since last poll) and returns to base when the vendor stabilizes: `min(base*(1+recent_delta), max)`.
- **GLS daemon**: deferred, gated, fail-soft; drives `execute_roadmap` in single-poll bursts on the adaptive cadence; flushes progress.txt. Wired into **GLS (the live loop), not legacy engine.py**.
- compose: enable `JARVIS_ROADMAP_ORCHESTRATOR_ENABLED` + progress ledger.
- Safety unchanged: emitted goals flow the full gated pipeline → APPROVAL_REQUIRED → orange PR, never auto-merge.

9 tests (recovering formula + cap + recovery-to-base, delta-not-cumulative tracker, GLS wiring pins). 113 green with roadmap/GLS suites. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the roadmap orchestrator into the live loop and adds an adaptive, recovering cadence based on recent provider exhaustions. Goals from the signed roadmap now reach intake; safety and approval gates remain unchanged.

- **New Features**
  - GLS daemon runs `roadmap_orchestrator.execute_roadmap` in single-poll bursts using `AdaptiveRoadmapCadence`; deferred, gated, and fail-soft (wired into `governed_loop_service.py`, not `engine.py`).
  - Fixed the backoff formula: use recent exhaustion delta (not cumulative) so it recovers to base; capped and configurable via `JARVIS_ROADMAP_CADENCE_BASE_S` and `JARVIS_ROADMAP_CADENCE_MAX_S`.
  - Compose enables `JARVIS_ROADMAP_ORCHESTRATOR_ENABLED` and the progress ledger.
  - Tests cover the cadence math, recovery-to-base, delta tracking, and GLS wiring pins.

<sup>Written for commit 676cfb2688751501d3e26518d247f4acee8a7843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

