### PR TITLE
feat(security): Slice 212 - boot-time runtime attestation gate (fail-closed on deployment drift)

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1251,6 +1251,35 @@ class GovernedLoopService:
             )
 
         self._state = ServiceState.STARTING
+
+        # Slice 212 — RUNTIME ATTESTATION GATE. Deliberately OUTSIDE the
+        # fail-soft boot block below: a strict deployment-integrity mismatch
+        # (image stamped with a different commit than the operator pinned,
+        # dirty-tree build, or unstamped image) must HALT the boot — state →
+        # FAILED, DeploymentIntegrityMismatch propagates — never be
+        # logged-and-continued. Gated default-FALSE; UNPINNED is warn-only.
+        # Guards against the 2026-06-10 drift class: a stale rebuild running
+        # Slice-208 code while believed to be Slice-211.
+        try:
+            from backend.core.ouroboros.governance.runtime_attestation import (
+                DeploymentIntegrityMismatch,
+                enforce as _attest_enforce,
+            )
+        except Exception:  # noqa: BLE001
+            DeploymentIntegrityMismatch = None  # type: ignore[assignment]
+            _attest_enforce = None
+        if _attest_enforce is not None:
+            try:
+                _attest_enforce()
+            except DeploymentIntegrityMismatch:
+                self._state = ServiceState.FAILED
+                self._failure_reason = "deployment_integrity_mismatch"
+                raise
+            except Exception as _ax:  # noqa: BLE001
+                # Only the explicit mismatch halts; infrastructure errors in
+                # the attestation path itself must not brick a legacy boot.
+                logger.debug("[GovernedLoop] attestation infra swallowed: %r", _ax)
+
         try:
             # Slice 185 Phase 4 — purge DW learned-state corrupted by the NameError phantom
             # (surface-health + calibration learned from internal faults mislabeled as vendor

--- a/backend/core/ouroboros/governance/runtime_attestation.py
+++ b/backend/core/ouroboros/governance/runtime_attestation.py
@@ -1,0 +1,190 @@
+"""Slice 212 — Boot-Time Runtime Attestation & Integrity Gate.
+
+Hardens against the lived deployment-drift failure (2026-06-10): a dirty
+compose file silently blocked the ff-merge, the image was rebuilt from STALE
+Slice-208 sources while everyone believed it carried Slice-211, and a buggy
+monitor false-positived. Nothing in the runtime could attest which code it was
+actually running.
+
+DESIGN (corrected from the original plan):
+- The image ships no ``.git`` (excluded from the build context), and checking
+  live ``origin/main`` on every boot would FALSE-TRIP under ``restart:always``
+  after any later legitimate merge — the watchdog would brick a healthy soak.
+- Instead: the image is STAMPED at build time (Dockerfile build args →
+  ``/app/.build_attestation.json`` with ``{commit, dirty}``), and at boot the
+  stamp is compared against an OPERATOR-PINNED expected commit
+  (``JARVIS_ATTESTATION_EXPECTED_COMMIT``, set by the launch path at launch).
+  Container restarts keep the same pin → no false trips; a stale or
+  dirty-tree build trips the gate.
+
+Verdicts: DISABLED / MATCH / MISMATCH / DIRTY_BUILD / UNSTAMPED / UNPINNED.
+Strict mode (default ON when enabled): MISMATCH / DIRTY_BUILD / UNSTAMPED →
+``DeploymentIntegrityMismatch`` raised BEFORE the GLS fail-soft boot block
+(state → FAILED, the loop never runs). UNPINNED is always warn-only so a
+casual ``docker compose up`` without the launch wrapper degrades loudly, not
+fatally. A best-effort telemetry-sentinel webhook fires on any failure
+verdict. Master ``JARVIS_RUNTIME_ATTESTATION_ENABLED`` default-FALSE
+(OFF = byte-identical legacy boot).
+"""
+from __future__ import annotations
+
+import enum
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+_ENV_MASTER = "JARVIS_RUNTIME_ATTESTATION_ENABLED"
+_ENV_STRICT = "JARVIS_RUNTIME_ATTESTATION_STRICT"
+_ENV_EXPECTED = "JARVIS_ATTESTATION_EXPECTED_COMMIT"
+_ENV_STAMP_PATH = "JARVIS_BUILD_ATTESTATION_PATH"
+_DEFAULT_STAMP_PATH = "/app/.build_attestation.json"
+
+
+class AttestationVerdict(str, enum.Enum):
+    DISABLED = "disabled"
+    MATCH = "match"
+    MISMATCH = "mismatch"
+    DIRTY_BUILD = "dirty_build"
+    UNSTAMPED = "unstamped"
+    UNPINNED = "unpinned"
+
+
+class DeploymentIntegrityMismatch(RuntimeError):
+    """Strict attestation failure — the running image does not carry the code
+    the operator pinned. The loop must not run on unattested code."""
+
+
+def _truthy(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in ("1", "true", "yes", "on")
+
+
+def attestation_enabled() -> bool:
+    """Master gate, default-FALSE. NEVER raises."""
+    return _truthy(_ENV_MASTER, False)
+
+
+def strict_mode() -> bool:
+    """Fail-closed on failure verdicts (default TRUE when enabled)."""
+    return _truthy(_ENV_STRICT, True)
+
+
+def _stamp_path() -> Path:
+    return Path(os.environ.get(_ENV_STAMP_PATH, "").strip() or _DEFAULT_STAMP_PATH)
+
+
+def load_build_stamp() -> Tuple[str, str]:
+    """Return (commit, dirty) from the build stamp; ('', '') if unreadable.
+    NEVER raises."""
+    try:
+        doc = json.loads(_stamp_path().read_text(encoding="utf-8"))
+        return (
+            str(doc.get("commit", "") or "").strip().lower(),
+            str(doc.get("dirty", "") or "").strip().lower(),
+        )
+    except Exception:  # noqa: BLE001
+        return "", ""
+
+
+def expected_commit() -> str:
+    return os.environ.get(_ENV_EXPECTED, "").strip().lower()
+
+
+def verify() -> Tuple[AttestationVerdict, str]:
+    """Compare the image's build stamp against the operator pin. NEVER raises.
+
+    Prefix comparison (either direction) so a short pin matches a full stamped
+    hash. ``commit == 'unstamped'`` (the Dockerfile ARG default) counts as
+    UNSTAMPED, not a weird mismatch.
+    """
+    try:
+        if not attestation_enabled():
+            return AttestationVerdict.DISABLED, "attestation disabled"
+        commit, dirty = load_build_stamp()
+        if not commit or commit == "unstamped":
+            return (
+                AttestationVerdict.UNSTAMPED,
+                f"image carries no build stamp at {_stamp_path()} — built "
+                "outside the attested launch path",
+            )
+        if dirty in ("true", "1", "yes"):
+            return (
+                AttestationVerdict.DIRTY_BUILD,
+                f"image was built from a DIRTY tree at {commit[:12]} — "
+                "uncommitted changes were baked in (the exact drift class that "
+                "shipped stale Slice-208 code as 'Slice 211')",
+            )
+        pin = expected_commit()
+        if not pin:
+            return (
+                AttestationVerdict.UNPINNED,
+                f"image stamped {commit[:12]} but no operator pin set "
+                f"({_ENV_EXPECTED}) — drift check skipped",
+            )
+        if commit.startswith(pin) or pin.startswith(commit):
+            return AttestationVerdict.MATCH, f"image {commit[:12]} == pin {pin[:12]}"
+        return (
+            AttestationVerdict.MISMATCH,
+            f"image stamped {commit[:12]} but operator pinned {pin[:12]} — "
+            "the container is NOT running the code you think it is",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return AttestationVerdict.UNSTAMPED, f"attestation verify error: {exc!r}"
+
+
+def _alert_best_effort(detail: str) -> None:
+    """Fire the telemetry-sentinel webhook if configured. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.telemetry_sentinel import (
+            get_sentinel, telemetry_sentinel_enabled,
+        )
+        if not telemetry_sentinel_enabled():
+            return
+        sentinel = get_sentinel()
+        alert = sentinel.note_safety_refusal(
+            f"DEPLOYMENT_INTEGRITY_MISMATCH: {detail}",
+        )
+        if alert is not None:
+            import asyncio
+            try:
+                loop = asyncio.get_running_loop()
+                task = loop.create_task(sentinel.dispatch(alert))
+                _ = task  # strong ref held by loop until done
+            except RuntimeError:
+                asyncio.run(sentinel.dispatch(alert))
+    except Exception:  # noqa: BLE001
+        logger.debug("[Attestation] sentinel alert swallowed", exc_info=True)
+
+
+def enforce() -> AttestationVerdict:
+    """Boot-time gate. MATCH/DISABLED → silent pass. UNPINNED → warn.
+    Failure verdicts → CRITICAL log + best-effort sentinel alert, then
+    ``DeploymentIntegrityMismatch`` in strict mode (warn-only otherwise)."""
+    verdict, detail = verify()
+    if verdict in (AttestationVerdict.DISABLED, AttestationVerdict.MATCH):
+        if verdict is AttestationVerdict.MATCH:
+            logger.info("[Attestation] runtime attested: %s", detail)
+        return verdict
+    if verdict is AttestationVerdict.UNPINNED:
+        logger.warning("[Attestation] %s", detail)
+        return verdict
+    logger.critical(
+        "[Attestation] DEPLOYMENT_INTEGRITY_MISMATCH (%s): %s",
+        verdict.value, detail,
+    )
+    _alert_best_effort(detail)
+    if strict_mode():
+        raise DeploymentIntegrityMismatch(
+            f"DEPLOYMENT_INTEGRITY_MISMATCH ({verdict.value}): {detail}",
+        )
+    logger.warning(
+        "[Attestation] strict mode OFF — continuing on unattested code "
+        "(verdict=%s)", verdict.value,
+    )
+    return verdict

--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -24,6 +24,10 @@ services:
       dockerfile: docker/Dockerfile.soak
       args:
         SOAK_REQUIREMENTS: ${SOAK_REQUIREMENTS:-requirements-soak-oracle.txt}
+        # Slice 212 — attestation stamp (launcher exports these; bare builds
+        # produce an UNSTAMPED image that strict attestation refuses to boot).
+        GIT_COMMIT: ${GIT_COMMIT:-unstamped}
+        GIT_DIRTY: ${GIT_DIRTY:-unknown}
     image: jarvis-sovereign-soak:oracle
     container_name: jarvis-dw-cortex-soak
     working_dir: /app
@@ -139,6 +143,14 @@ services:
       # organism's work queue. ──
       JARVIS_ROADMAP_ORCHESTRATOR_ENABLED: "1"
       JARVIS_PROGRESS_LEDGER_ENABLED: "1"
+      # ── Slice 212 — RUNTIME ATTESTATION GATE. At boot, the image's build
+      # stamp (commit+dirty) is compared against the operator pin below; a
+      # stale rebuild / dirty-tree build / unstamped image FAILS CLOSED with
+      # DEPLOYMENT_INTEGRITY_MISMATCH (state=FAILED, loop never runs). The pin
+      # is set at launch by launch_dw_cortex_soak.sh; restarts keep it, so
+      # later merges to main can't false-trip a healthy soak. ──
+      JARVIS_RUNTIME_ATTESTATION_ENABLED: "1"
+      JARVIS_ATTESTATION_EXPECTED_COMMIT: ${JARVIS_ATTESTATION_EXPECTED_COMMIT:-}
       # ── Optional: live 🔮 forecast / 💸 sovereignty on the Discord spine ──
       # JARVIS_DISCORD_GATEWAY_ENABLED: "1"   # needs DISCORD_BOT_TOKEN in .env
       # JARVIS_DISCORD_GATES_CHANNEL_ID: "..."

--- a/docker/Dockerfile.soak
+++ b/docker/Dockerfile.soak
@@ -61,6 +61,18 @@ RUN pip install --upgrade pip wheel setuptools && \
 # Application code (.dockerignore keeps .venv / .git / .env / .jarvis out).
 COPY . /app
 
+# Slice 212 — build-time attestation stamp. The launch path passes the exact
+# commit + dirty-tree flag of the build context; at boot, runtime_attestation
+# compares this stamp against the operator-pinned expected commit and
+# fail-closes on drift (the stale-rebuild failure class of 2026-06-10).
+# Placed AFTER `COPY . /app` so the stamp can never survive a code change via
+# layer cache. Defaults mean an un-wrapped `docker build` yields an UNSTAMPED
+# image (strict mode refuses to boot it; the message says to use the launcher).
+ARG GIT_COMMIT=unstamped
+ARG GIT_DIRTY=unknown
+RUN printf '{"commit":"%s","dirty":"%s"}\n' "$GIT_COMMIT" "$GIT_DIRTY" \
+    > /app/.build_attestation.json
+
 # .env (funded creds) + .jarvis (crypto + signed roadmap + persistence) are
 # supplied at runtime by compose — not present in the image.
 ENTRYPOINT ["bash", "scripts/launch_shadow_soak.sh"]

--- a/progress.txt
+++ b/progress.txt
@@ -31,3 +31,7 @@
   [ ] host          keep Mac awake (caffeinate) + Docker autostart, OR migrate to GCP when billing on
   [ ] direction     author + sign real strategic goals (.jarvis/roadmap.yaml via strategy_signer)
   [ ] starvation    the organism's own #1 self-identified priority: eliminate control-plane starvation
+  [x] slice-212  runtime attestation: image stamped (commit+dirty) at build; boot compares vs
+                 operator pin -> DEPLOYMENT_INTEGRITY_MISMATCH fail-closed on drift (stale rebuild /
+                 dirty tree / unstamped). Born from the LIVED 2026-06-10 failure: a dirty compose
+                 blocked ff-merge and the "211 rebuild" silently ran 208 code. UNPINNED=warn-only.

--- a/scripts/launch_dw_cortex_soak.sh
+++ b/scripts/launch_dw_cortex_soak.sh
@@ -24,6 +24,18 @@ grep -q "DOUBLEWORD_API_KEY" "$REPO_ROOT/.env" || die ".env has no DOUBLEWORD_AP
 DC=(docker compose); docker compose version >/dev/null 2>&1 || DC=(docker-compose)
 export SOAK_REQUIREMENTS="requirements-soak-oracle.txt"
 
+# Slice 212 — runtime attestation. Stamp the image with the EXACT commit +
+# dirty flag of this build context, and pin the same commit as the boot-time
+# expectation. A stale rebuild (checkout behind what you merged) or a
+# dirty-tree build then FAILS CLOSED at boot with DEPLOYMENT_INTEGRITY_MISMATCH
+# instead of silently running old code (the 2026-06-10 drift class).
+GIT_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unstamped)"
+GIT_DIRTY="$([ -n "$(git status --porcelain 2>/dev/null)" ] && echo true || echo false)"
+export GIT_COMMIT GIT_DIRTY
+export JARVIS_ATTESTATION_EXPECTED_COMMIT="$GIT_COMMIT"
+log "Attestation: stamping ${GIT_COMMIT:0:12} (dirty=$GIT_DIRTY) + pinning as boot expectation."
+[ "$GIT_DIRTY" = "true" ] && log "WARNING: dirty tree — strict attestation will REFUSE this image at boot. Commit or stash first."
+
 if [ "${1:-}" = "--monitor" ]; then
   exec "$REPO_ROOT/scripts/dw_cortex_monitor.sh"
 fi

--- a/tests/governance/test_slice212_runtime_attestation.py
+++ b/tests/governance/test_slice212_runtime_attestation.py
@@ -1,0 +1,184 @@
+"""Slice 212 — Boot-Time Runtime Attestation & Integrity Gate.
+
+The lived failure this hardens against: the 211 rebuild silently used STALE
+code — a dirty compose file blocked the ff-merge, Docker rebuilt Slice-208
+sources, and a buggy monitor false-positived. Nothing in the runtime itself
+could tell us the image didn't contain the code we thought it did.
+
+DESIGN (corrected from the plan):
+- The image deliberately ships no .git, and checking live origin/main on every
+  boot would FALSE-TRIP under restart:always after any later legitimate merge.
+- So: the image is STAMPED at build time (build args -> .build_attestation.json
+  with {commit, dirty}), and at boot the stamp is compared against an
+  OPERATOR-PINNED expected commit (env, set by the launch path at launch time).
+  Restarts keep the same pin -> no false trips; a stale/dirty build trips it.
+- Strict mode (default ON when enabled) -> DeploymentIntegrityMismatch raised
+  BEFORE the GLS fail-soft boot block: state -> FAILED, loop never runs.
+- Gated JARVIS_RUNTIME_ATTESTATION_ENABLED default-FALSE (OFF = byte-identical).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.runtime_attestation import (
+    AttestationVerdict,
+    DeploymentIntegrityMismatch,
+    attestation_enabled,
+    enforce,
+    verify,
+)
+
+_GOV = Path(__file__).resolve().parents[2] / "backend" / "core" \
+    / "ouroboros" / "governance"
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    for k in (
+        "JARVIS_RUNTIME_ATTESTATION_ENABLED",
+        "JARVIS_RUNTIME_ATTESTATION_STRICT",
+        "JARVIS_ATTESTATION_EXPECTED_COMMIT",
+        "JARVIS_BUILD_ATTESTATION_PATH",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def _stamp(tmp_path, commit="a6e72d4aad" + "0" * 30, dirty="false"):
+    p = tmp_path / ".build_attestation.json"
+    p.write_text(json.dumps({"commit": commit, "dirty": dirty}), encoding="utf-8")
+    return p
+
+
+# ===========================================================================
+# A — gate + disabled behavior
+# ===========================================================================
+
+def test_disabled_by_default():
+    assert attestation_enabled() is False
+
+
+def test_disabled_verdict_short_circuits(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BUILD_ATTESTATION_PATH", str(_stamp(tmp_path)))
+    v, _ = verify()
+    assert v is AttestationVerdict.DISABLED
+
+
+# ===========================================================================
+# B — verdicts
+# ===========================================================================
+
+def test_match_on_pinned_prefix(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_RUNTIME_ATTESTATION_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_BUILD_ATTESTATION_PATH", str(_stamp(tmp_path)))
+    monkeypatch.setenv("JARVIS_ATTESTATION_EXPECTED_COMMIT", "a6e72d4aad")
+    v, _ = verify()
+    assert v is AttestationVerdict.MATCH
+
+
+def test_mismatch_on_stale_image(tmp_path, monkeypatch):
+    """THE failure we lived: image stamped with the stale commit while the
+    operator pinned the freshly-merged one."""
+    monkeypatch.setenv("JARVIS_RUNTIME_ATTESTATION_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_BUILD_ATTESTATION_PATH",
+        str(_stamp(tmp_path, commit="bb0aab05ef" + "0" * 30)),
+    )
+    monkeypatch.setenv("JARVIS_ATTESTATION_EXPECTED_COMMIT", "a6e72d4aad")
+    v, detail = verify()
+    assert v is AttestationVerdict.MISMATCH
+    assert "bb0aab05ef" in detail and "a6e72d4aad" in detail
+
+
+def test_dirty_build_is_flagged(tmp_path, monkeypatch):
+    """The OTHER half of the lived failure: building from a dirty tree."""
+    monkeypatch.setenv("JARVIS_RUNTIME_ATTESTATION_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_BUILD_ATTESTATION_PATH", str(_stamp(tmp_path, dirty="true")),
+    )
+    monkeypatch.setenv("JARVIS_ATTESTATION_EXPECTED_COMMIT", "a6e72d4aad")
+    v, _ = verify()
+    assert v is AttestationVerdict.DIRTY_BUILD
+
+
+def test_unstamped_image_detected(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_RUNTIME_ATTESTATION_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_BUILD_ATTESTATION_PATH", str(tmp_path / "missing.json"),
+    )
+    monkeypatch.setenv("JARVIS_ATTESTATION_EXPECTED_COMMIT", "a6e72d4aad")
+    v, _ = verify()
+    assert v is AttestationVerdict.UNSTAMPED
+
+
+def test_no_pin_is_unpinned_not_mismatch(tmp_path, monkeypatch):
+    """No expected commit set -> UNPINNED (warn), NOT a fail — otherwise every
+    casual `docker compose up` without the launch path would brick the soak."""
+    monkeypatch.setenv("JARVIS_RUNTIME_ATTESTATION_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_BUILD_ATTESTATION_PATH", str(_stamp(tmp_path)))
+    v, _ = verify()
+    assert v is AttestationVerdict.UNPINNED
+
+
+# ===========================================================================
+# C — enforce(): strict fail-closed vs warn
+# ===========================================================================
+
+def test_enforce_raises_on_mismatch_strict(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_RUNTIME_ATTESTATION_ENABLED", "1")
+    monkeypatch.setenv(
+        "JARVIS_BUILD_ATTESTATION_PATH",
+        str(_stamp(tmp_path, commit="bb0aab05ef" + "0" * 30)),
+    )
+    monkeypatch.setenv("JARVIS_ATTESTATION_EXPECTED_COMMIT", "a6e72d4aad")
+    with pytest.raises(DeploymentIntegrityMismatch) as ei:
+        enforce()
+    assert "DEPLOYMENT_INTEGRITY_MISMATCH" in str(ei.value)
+
+
+def test_enforce_warn_mode_does_not_raise(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_RUNTIME_ATTESTATION_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_RUNTIME_ATTESTATION_STRICT", "0")
+    monkeypatch.setenv(
+        "JARVIS_BUILD_ATTESTATION_PATH",
+        str(_stamp(tmp_path, commit="bb0aab05ef" + "0" * 30)),
+    )
+    monkeypatch.setenv("JARVIS_ATTESTATION_EXPECTED_COMMIT", "a6e72d4aad")
+    enforce()  # must not raise
+
+
+def test_enforce_match_passes(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_RUNTIME_ATTESTATION_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_BUILD_ATTESTATION_PATH", str(_stamp(tmp_path)))
+    monkeypatch.setenv("JARVIS_ATTESTATION_EXPECTED_COMMIT", "a6e72d4aad")
+    enforce()  # no raise
+
+
+def test_enforce_disabled_never_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_BUILD_ATTESTATION_PATH",
+        str(_stamp(tmp_path, commit="deadbeef" + "0" * 32)),
+    )
+    monkeypatch.setenv("JARVIS_ATTESTATION_EXPECTED_COMMIT", "a6e72d4aad")
+    enforce()  # disabled -> no raise
+
+
+# ===========================================================================
+# D — wiring pins
+# ===========================================================================
+
+def test_gls_enforces_before_failsoft_boot():
+    """The gate must sit OUTSIDE the swallow-all boot block — a strict
+    mismatch must set FAILED and halt, not be logged-and-continued."""
+    src = (_GOV / "governed_loop_service.py").read_text(encoding="utf-8")
+    assert "runtime_attestation" in src
+    assert "DeploymentIntegrityMismatch" in src
+
+
+def test_dockerfile_stamps_build():
+    root = _GOV.parents[3]
+    df = (root / "docker" / "Dockerfile.soak").read_text(encoding="utf-8")
+    assert "GIT_COMMIT" in df and ".build_attestation.json" in df


### PR DESCRIPTION
## Born from a lived failure, not a hypothetical

On 2026-06-10 a dirty compose file silently blocked `git merge --ff-only`, the '211 rebuild' rebuilt **stale Slice-208 sources**, a buggy monitor false-positived, and the autonomy retest ran against code that wasn't there. Nothing in the runtime could attest which code it was actually running. This slice makes the container self-attesting.

## Design (corrected from the plan)

- **Not** a live origin/main check at boot — the image ships no `.git`, and under `restart:always` any later legitimate merge would false-trip the gate and brick a healthy soak. Instead: **stamp at build, pin at launch.**
- `Dockerfile.soak`: `ARG GIT_COMMIT/GIT_DIRTY` → `/app/.build_attestation.json`, placed **after** `COPY . /app` so layer-cache can never preserve a stale stamp.
- `launch_dw_cortex_soak.sh`: stamps the exact build-context commit + dirty flag, pins the same commit as `JARVIS_ATTESTATION_EXPECTED_COMMIT` (restarts keep the pin → no false trips; relaunch re-pins).
- `runtime_attestation.py`: verdicts DISABLED/MATCH/MISMATCH/DIRTY_BUILD/UNSTAMPED/UNPINNED; `enforce()` → CRITICAL log + best-effort telemetry-sentinel webhook + `DeploymentIntegrityMismatch` in strict mode. UNPINNED is **warn-only** so a bare `docker compose up` degrades loudly, not fatally. Master default-FALSE.
- **GLS wiring sits OUTSIDE the fail-soft boot block** — a strict mismatch sets `state=FAILED` and propagates; the loop never runs on unattested code. Wired into GLS (the live loop), not legacy engine.py.

## Verification

13 tests — including the exact lived drift class (stale-image mismatch, dirty-tree build, unstamped image), unpinned-warn degradation, strict-vs-warn enforce, and the GLS/Dockerfile wiring pins. 22 green with ignition-mesh + GLS + sentinel suites. A live invalidation test (boot the real image with a wrong pin → refuse) follows post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a boot-time runtime attestation gate that stamps images at build and enforces a commit pin at launch. Prevents GLS from starting on deployment drift (stale or dirty builds).

- **New Features**
  - Build stamp: Dockerfile writes `/app/.build_attestation.json` with `{commit, dirty}` after `COPY` to avoid stale cache.
  - Launch pin: `scripts/launch_dw_cortex_soak.sh` sets `GIT_COMMIT`/`GIT_DIRTY` and pins `JARVIS_ATTESTATION_EXPECTED_COMMIT`; restarts keep the pin.
  - Boot gate: verdicts `DISABLED/MATCH/MISMATCH/DIRTY_BUILD/UNSTAMPED/UNPINNED`; strict mode raises `DeploymentIntegrityMismatch`; `UNPINNED` warns only; best-effort sentinel alert.
  - Wiring: enforced in GLS before the fail-soft block; mismatches set `state=FAILED`; attestation infra errors are swallowed.
  - Compose: master flag `JARVIS_RUNTIME_ATTESTATION_ENABLED` (default off) and `JARVIS_ATTESTATION_EXPECTED_COMMIT` added.

- **Migration**
  - Build and run via `scripts/launch_dw_cortex_soak.sh` to stamp and pin automatically.
  - To enable elsewhere, set `JARVIS_RUNTIME_ATTESTATION_ENABLED=1` and `JARVIS_ATTESTATION_EXPECTED_COMMIT` to the built commit.
  - Keep the working tree clean; dirty builds fail in strict mode.
  - Temporary bypass: set `JARVIS_RUNTIME_ATTESTATION_STRICT=0` or disable the master flag.

<sup>Written for commit 42f4212b5570a226c9003039bfd23167b8e9ec4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

