### PR TITLE
fix(security): Slice 212b - scope attestation dirty-flag to dirt that enters the image

### DIFF
--- a/scripts/launch_dw_cortex_soak.sh
+++ b/scripts/launch_dw_cortex_soak.sh
@@ -30,7 +30,11 @@ export SOAK_REQUIREMENTS="requirements-soak-oracle.txt"
 # dirty-tree build then FAILS CLOSED at boot with DEPLOYMENT_INTEGRITY_MISMATCH
 # instead of silently running old code (the 2026-06-10 drift class).
 GIT_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unstamped)"
-GIT_DIRTY="$([ -n "$(git status --porcelain 2>/dev/null)" ] && echo true || echo false)"
+# Dirty = dirt that actually ENTERS the image. .jarvis (runtime state mutated
+# through the bind-mount, e.g. roadmap.draft.yaml) and __pycache__ are in
+# .dockerignore — they can never reach the image, so they must not dirty the
+# stamp (first live trip 2026-06-10 was exactly this false positive).
+GIT_DIRTY="$([ -n "$(git status --porcelain -- ':\!.jarvis' ':\!**/__pycache__' 2>/dev/null)" ] && echo true || echo false)"
 export GIT_COMMIT GIT_DIRTY
 export JARVIS_ATTESTATION_EXPECTED_COMMIT="$GIT_COMMIT"
 log "Attestation: stamping ${GIT_COMMIT:0:12} (dirty=$GIT_DIRTY) + pinning as boot expectation."


### PR DESCRIPTION
First live trip of the 212 gate was a spirit-level false positive: blunt `git status --porcelain` counted `.jarvis/roadmap.draft.yaml` (runtime state mutated through the bind-mount) + `__pycache__` — both in `.dockerignore`, so neither can reach the image the stamp attests. The gate fail-closed exactly as designed, for dirt that couldn't cause drift. Fix: scope the dirty computation with `':!.jarvis' ':!**/__pycache__'` pathspecs — dirty = only what ships. Verified live: the tripping dirt now reads false; real code dirt still trips. Gate strictness unchanged. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the attestation dirty check to only files that ship in the image, preventing false positives from bind-mounted `.jarvis` state and `__pycache__`. The gate stays strict and still fails closed on real code changes.

- Updated `scripts/launch_dw_cortex_soak.sh` to compute dirty via `git status --porcelain -- ':\!.jarvis' ':\!**/__pycache__'` so non-shipping files no longer mark the tree as dirty.

<sup>Written for commit 10d57c092e549ee1e3c076cc8b5e018120c3d470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

