### PR TITLE
fix(security): Slice 212c - launcher set-e trap aborted the build on clean trees

### DIFF
--- a/scripts/launch_dw_cortex_soak.sh
+++ b/scripts/launch_dw_cortex_soak.sh
@@ -38,7 +38,12 @@ GIT_DIRTY="$([ -n "$(git status --porcelain -- ':\!.jarvis' ':\!**/__pycache__' 
 export GIT_COMMIT GIT_DIRTY
 export JARVIS_ATTESTATION_EXPECTED_COMMIT="$GIT_COMMIT"
 log "Attestation: stamping ${GIT_COMMIT:0:12} (dirty=$GIT_DIRTY) + pinning as boot expectation."
-[ "$GIT_DIRTY" = "true" ] && log "WARNING: dirty tree — strict attestation will REFUSE this image at boot. Commit or stash first."
+# NB: '|| true' is load-bearing — under set -e, a false [ test ] in a bare
+# 'a && b' statement kills the whole script (this exact line aborted the
+# 2026-06-10 relaunch BEFORE the build, leaving the old dirty image running).
+if [ "$GIT_DIRTY" = "true" ]; then
+  log "WARNING: dirty tree — strict attestation will REFUSE this image at boot. Commit or stash first."
+fi
 
 if [ "${1:-}" = "--monitor" ]; then
   exec "$REPO_ROOT/scripts/dw_cortex_monitor.sh"


### PR DESCRIPTION
The 212b relaunch stamped `dirty=false` then silently died before `docker compose build`: under `set -euo pipefail`, the bare `[ test ] && log` statement returns 1 when the test is false → script killed. The old dirty image kept running — and the attestation gate correctly kept refusing it, which is exactly how the failure surfaced. Converted to an if-block; both branches proven to survive under `set -e`. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a `set -e` crash in the launcher that aborted clean-tree builds before `docker compose build`. Replaces the short-circuit warning with an `if` so builds proceed and attestation pinning stays intact.

- **Bug Fixes**
  - In `scripts/launch_dw_cortex_soak.sh`, replaced `[ "$GIT_DIRTY" = "true" ] && log ...` with an `if` block to avoid exiting when `GIT_DIRTY=false` under `set -euo pipefail`.
  - Added a note explaining the load-bearing behavior to prevent regressions.

<sup>Written for commit 2372ce0c6b768aaceaf0923e93789323897277f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

