### PR TITLE
feat(ops): Slice 213 - native orchestration kernel (attested launch contract)

### DIFF
--- a/backend/core/ouroboros/governance/lifecycle_kernel.py
+++ b/backend/core/ouroboros/governance/lifecycle_kernel.py
@@ -1,0 +1,273 @@
+"""Slice 213 — Native Orchestration Kernel (HOST-side Python launcher).
+
+Replaces the brittle bash launcher whose ``set -e`` trap silently aborted the
+2026-06-10 relaunch BEFORE the build — leaving a stale dirty image running,
+caught only because the Slice-212 attestation gate kept refusing it. The
+kernel is typed, tested, and async (``asyncio.create_subprocess_exec`` — no
+shell, no word-splitting, no ``set -e`` semantics), and it makes POST-LAUNCH
+ATTESTATION VERIFICATION part of the launch contract: a launch is not DONE
+until the running container's stamp MATCHes the pinned commit and the marker
+code is grep-confirmed present. The phantom-deploy class (stale image
+masquerading as a fresh deploy) can no longer return exit 0.
+
+SCOPE REFUSALS (load-bearing — these lines must not move):
+
+* **HOST-side only.** This module is the launcher's replacement and runs where
+  the launcher always ran: on the host. It does NOT enable in-container
+  self-cycling — that would require mounting the Docker control socket into an
+  autonomous LLM-agent container, which is root-equivalent host escape (the
+  same refusal class as the Slice-199 ``~/.ssh`` mount). The socket's literal
+  path deliberately appears NOWHERE in this file, and the regression suite
+  pins that absence.
+
+* **No auto-reload on self-verified patches** — refused. The Slice-208
+  deception detectors are friction, not proof; a kernel that hot-reloads the
+  organism with code "verified clean" by the organism's own filters would
+  collapse the operator boundary. The deploy boundary stays: O+V proposes →
+  orange PR → the OPERATOR merges → the kernel relaunches attested.
+
+Graceful shutdown: SIGINT/SIGTERM during a launch terminates the child
+``docker compose`` process group cleanly (no orphaned builds). In-container
+graceful shutdown is already owned by the harness signal handlers (Ticket B)
++ ``stop_grace_period`` — the kernel does not duplicate it.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import sys
+from typing import Awaitable, Callable, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# dirt that can never enter the image (mirrors .dockerignore — .jarvis is
+# runtime state mutated through the bind-mount; __pycache__ is build noise)
+_DIRT_EXCLUDES = (":!.jarvis", ":!**/__pycache__")
+_DEFAULT_MARKER = "STRATEGIC IGNITION MESH"
+_DEFAULT_COMPOSE = "docker-compose.dw-cortex-soak.yml"
+
+# sync runner: (args) -> (rc, stdout)
+_SyncRun = Callable[[list], Tuple[int, str]]
+# async runner: (args) -> awaitable (rc, stdout)
+_AsyncRun = Callable[[list], Awaitable[Tuple[int, str]]]
+
+
+class LaunchVerdict:
+    """Post-launch verification outcomes (the launch contract)."""
+
+    class _V:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def __repr__(self) -> str:  # pragma: no cover
+            return f"LaunchVerdict.{self.name}"
+
+    ATTESTED_MATCH = _V("ATTESTED_MATCH")
+    STAMP_MISMATCH = _V("STAMP_MISMATCH")
+    MARKER_MISSING = _V("MARKER_MISSING")
+    UNVERIFIED = _V("UNVERIFIED")
+
+
+def _default_sync_run(args: list) -> Tuple[int, str]:
+    import subprocess
+    try:
+        p = subprocess.run(
+            args, capture_output=True, text=True, timeout=60,
+        )
+        return p.returncode, p.stdout
+    except Exception:  # noqa: BLE001
+        return 127, ""
+
+
+def compute_dirty(*, run: Optional[_SyncRun] = None) -> str:
+    """'true'/'false'/'unknown' — dirt scoped to what actually ships
+    (excludes .jarvis runtime state + __pycache__, both dockerignored).
+    NEVER raises."""
+    run = run or _default_sync_run
+    try:
+        rc, out = run(
+            ["git", "status", "--porcelain", "--", *_DIRT_EXCLUDES],
+        )
+        if rc != 0:
+            return "unknown"
+        return "true" if out.strip() else "false"
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def resolve_commit(*, run: Optional[_SyncRun] = None) -> str:
+    """Full HEAD hash, or 'unstamped' on any failure. NEVER raises."""
+    run = run or _default_sync_run
+    try:
+        rc, out = run(["git", "rev-parse", "HEAD"])
+        commit = out.strip().lower()
+        if rc != 0 or not commit:
+            return "unstamped"
+        return commit
+    except Exception:  # noqa: BLE001
+        return "unstamped"
+
+
+def build_launch_env(
+    *, commit: str, dirty: str, base: Dict[str, str],
+) -> Dict[str, str]:
+    """Stamp + pin env for the compose build. REFUSES a dirty tree upfront —
+    the strict attestation gate would refuse the image at boot anyway, so
+    failing at launch time is the honest, earlier failure."""
+    if dirty == "true":
+        raise RuntimeError(
+            "refusing to launch from a DIRTY tree (image-relevant dirt "
+            "present): commit or stash first — the boot-time attestation "
+            "gate would fail-close this image anyway",
+        )
+    env = dict(base)
+    env["GIT_COMMIT"] = commit
+    env["GIT_DIRTY"] = dirty
+    env["JARVIS_ATTESTATION_EXPECTED_COMMIT"] = commit
+    env.setdefault("SOAK_REQUIREMENTS", "requirements-soak-oracle.txt")
+    return env
+
+
+async def _default_async_run(args: list) -> Tuple[int, str]:
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    out, _ = await proc.communicate()
+    return proc.returncode or 0, out.decode("utf-8", "replace")
+
+
+async def verify_postlaunch(
+    *,
+    container: str,
+    expected_commit: str,
+    run: Optional[_AsyncRun] = None,
+    marker: str = _DEFAULT_MARKER,
+):
+    """The launch contract: the running container must carry (1) a build
+    stamp whose commit prefix-matches the pin and (2) the marker code.
+    NEVER raises — returns a LaunchVerdict."""
+    run = run or _default_async_run
+    try:
+        rc, out = await run([
+            "docker", "exec", container,
+            "cat", "/app/.build_attestation.json",
+        ])
+        if rc != 0:
+            return LaunchVerdict.UNVERIFIED
+        stamp = str(json.loads(out).get("commit", "")).strip().lower()
+        pin = expected_commit.strip().lower()
+        if not (stamp.startswith(pin) or pin.startswith(stamp)):
+            logger.critical(
+                "[LifecycleKernel] STAMP_MISMATCH: container carries %s, "
+                "pinned %s — phantom deploy detected at launch time",
+                stamp[:12], pin[:12],
+            )
+            return LaunchVerdict.STAMP_MISMATCH
+        rc2, _ = await run([
+            "docker", "exec", container, "grep", "-c", marker,
+            "/app/backend/core/ouroboros/governance/governed_loop_service.py",
+        ])
+        if rc2 != 0:
+            return LaunchVerdict.MARKER_MISSING
+        return LaunchVerdict.ATTESTED_MATCH
+    except Exception:  # noqa: BLE001
+        return LaunchVerdict.UNVERIFIED
+
+
+async def launch(
+    *,
+    compose_file: str = _DEFAULT_COMPOSE,
+    container: str = "jarvis-dw-cortex-soak",
+    skip_build: bool = False,
+    settle_s: float = 25.0,
+) -> int:
+    """Full attested launch: stamp → pin → build → up → VERIFY. Returns a
+    process exit code (0 only on ATTESTED_MATCH)."""
+    commit = resolve_commit()
+    dirty = compute_dirty()
+    logger.info(
+        "[LifecycleKernel] stamping %s (dirty=%s) + pinning as boot expectation",
+        commit[:12], dirty,
+    )
+    try:
+        env = build_launch_env(commit=commit, dirty=dirty, base=dict(os.environ))
+    except RuntimeError as exc:
+        logger.critical("[LifecycleKernel] %s", exc)
+        return 3
+
+    async def _compose(*cargs: str) -> int:
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "compose", "-f", compose_file, *cargs, env=env,
+        )
+        # graceful SIGINT/SIGTERM: forward terminate to the child so a
+        # half-finished build is never orphaned
+        loop = asyncio.get_running_loop()
+
+        def _fwd() -> None:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                loop.add_signal_handler(sig, _fwd)
+            except (NotImplementedError, RuntimeError):
+                pass
+        try:
+            return await proc.wait()
+        finally:
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                try:
+                    loop.remove_signal_handler(sig)
+                except (NotImplementedError, RuntimeError, ValueError):
+                    pass
+
+    if not skip_build:
+        rc = await _compose("build")
+        if rc != 0:
+            logger.critical("[LifecycleKernel] build failed rc=%d", rc)
+            return rc
+    rc = await _compose("up", "-d", "--force-recreate")
+    if rc != 0:
+        logger.critical("[LifecycleKernel] up failed rc=%d", rc)
+        return rc
+    await asyncio.sleep(settle_s)
+    verdict = await verify_postlaunch(
+        container=container, expected_commit=commit,
+    )
+    if verdict is LaunchVerdict.ATTESTED_MATCH:
+        logger.info(
+            "[LifecycleKernel] LAUNCH ATTESTED: %s running, stamp==pin, "
+            "marker present", commit[:12],
+        )
+        return 0
+    logger.critical(
+        "[LifecycleKernel] LAUNCH NOT ATTESTED: %s — refusing to report "
+        "success on an unverified deploy", verdict,
+    )
+    return 4
+
+
+def main(argv: Optional[list] = None) -> int:  # pragma: no cover
+    import argparse
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    ap = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    ap.add_argument("--compose", default=_DEFAULT_COMPOSE)
+    ap.add_argument("--container", default="jarvis-dw-cortex-soak")
+    ap.add_argument("--skip-build", action="store_true")
+    args = ap.parse_args(argv)
+    return asyncio.run(launch(
+        compose_file=args.compose,
+        container=args.container,
+        skip_build=args.skip_build,
+    ))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/progress.txt
+++ b/progress.txt
@@ -35,3 +35,9 @@
                  operator pin -> DEPLOYMENT_INTEGRITY_MISMATCH fail-closed on drift (stale rebuild /
                  dirty tree / unstamped). Born from the LIVED 2026-06-10 failure: a dirty compose
                  blocked ff-merge and the "211 rebuild" silently ran 208 code. UNPINNED=warn-only.
+  [x] slice-213  native orchestration kernel: bash launcher -> typed/tested/async Python
+                 (lifecycle_kernel.py, HOST-side). Post-launch attestation verification IS the
+                 launch contract (exit 0 only on ATTESTED_MATCH — phantom deploys can't exit 0).
+                 REFUSED: in-container self-cycling (docker-socket = host escape) + auto-reload
+                 on self-verified patches (S208 = friction not proof; operator merge stays the
+                 deploy boundary).

--- a/scripts/launch_dw_cortex_soak.sh
+++ b/scripts/launch_dw_cortex_soak.sh
@@ -24,36 +24,16 @@ grep -q "DOUBLEWORD_API_KEY" "$REPO_ROOT/.env" || die ".env has no DOUBLEWORD_AP
 DC=(docker compose); docker compose version >/dev/null 2>&1 || DC=(docker-compose)
 export SOAK_REQUIREMENTS="requirements-soak-oracle.txt"
 
-# Slice 212 — runtime attestation. Stamp the image with the EXACT commit +
-# dirty flag of this build context, and pin the same commit as the boot-time
-# expectation. A stale rebuild (checkout behind what you merged) or a
-# dirty-tree build then FAILS CLOSED at boot with DEPLOYMENT_INTEGRITY_MISMATCH
-# instead of silently running old code (the 2026-06-10 drift class).
-GIT_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unstamped)"
-# Dirty = dirt that actually ENTERS the image. .jarvis (runtime state mutated
-# through the bind-mount, e.g. roadmap.draft.yaml) and __pycache__ are in
-# .dockerignore — they can never reach the image, so they must not dirty the
-# stamp (first live trip 2026-06-10 was exactly this false positive).
-GIT_DIRTY="$([ -n "$(git status --porcelain -- ':\!.jarvis' ':\!**/__pycache__' 2>/dev/null)" ] && echo true || echo false)"
-export GIT_COMMIT GIT_DIRTY
-export JARVIS_ATTESTATION_EXPECTED_COMMIT="$GIT_COMMIT"
-log "Attestation: stamping ${GIT_COMMIT:0:12} (dirty=$GIT_DIRTY) + pinning as boot expectation."
-# NB: '|| true' is load-bearing — under set -e, a false [ test ] in a bare
-# 'a && b' statement kills the whole script (this exact line aborted the
-# 2026-06-10 relaunch BEFORE the build, leaving the old dirty image running).
-if [ "$GIT_DIRTY" = "true" ]; then
-  log "WARNING: dirty tree — strict attestation will REFUSE this image at boot. Commit or stash first."
-fi
-
-if [ "${1:-}" = "--monitor" ]; then
-  exec "$REPO_ROOT/scripts/dw_cortex_monitor.sh"
-fi
-
-log "Building the cortex-soak image (oracle-capable)…"
-"${DC[@]}" -f "$COMPOSE" build
-log "Igniting DW-only cortex soak (Claude DISABLED; 172/174 ON; restart=always)…"
-"${DC[@]}" -f "$COMPOSE" up -d
-log "Live. The cortex learns from real DW failures (per-model rings, multi-signal, self-calibration)."
+# Slice 213 — the stamping/build/verify logic moved to the NATIVE PYTHON
+# lifecycle kernel (typed, tested, async; no set-e traps — the bash trap here
+# cost a deploy cycle on 2026-06-10). The kernel refuses dirty trees upfront,
+# stamps + pins the commit, builds, launches, and VERIFIES the running
+# container attests MATCH before reporting success (exit 0 only on
+# ATTESTED_MATCH — a phantom deploy can no longer exit 0).
+log "Handing off to the native lifecycle kernel (Slice 213)…"
+python3 -m backend.core.ouroboros.governance.lifecycle_kernel --compose "$COMPOSE" \
+  || die "lifecycle kernel refused or could not attest the launch (see log above)."
+log "Live + ATTESTED. The cortex learns from real DW failures."
 log "  Forecasts/calibration:  docker compose -f $COMPOSE logs -f | grep -E 'Cortex|reroute'"
 log "  Learned thresholds:     ./scripts/dw_cortex_monitor.sh"
 log "  Stop:                   docker compose -f $COMPOSE down"

--- a/tests/governance/test_slice213_lifecycle_kernel.py
+++ b/tests/governance/test_slice213_lifecycle_kernel.py
@@ -1,0 +1,151 @@
+"""Slice 213 — Native Orchestration Kernel (host-side Python launcher).
+
+Replaces the brittle bash launcher whose `set -e` trap silently aborted the
+2026-06-10 relaunch before the build (leaving a stale dirty image running —
+caught only because the 212 attestation gate kept refusing it). The kernel is
+typed, tested, async (asyncio.create_subprocess_exec), and makes POST-LAUNCH
+ATTESTATION VERIFICATION part of the launch contract: a launch is not DONE
+until the container's stamp MATCHes the pin and the marker code is present.
+
+SCOPE REFUSALS (load-bearing, mirrored in the module docstring):
+- HOST-side only. No in-container self-cycling: that requires the docker
+  socket inside an autonomous LLM-agent container = root-equivalent host
+  escape (same refusal class as the Slice-199 ~/.ssh mount).
+- No auto-reload on self-verified patches: S208 detectors are friction, not
+  proof. Deploy boundary stays operator merge -> kernel relaunch.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from backend.core.ouroboros.governance.lifecycle_kernel import (
+    LaunchVerdict,
+    build_launch_env,
+    compute_dirty,
+    resolve_commit,
+    verify_postlaunch,
+)
+
+
+# ===========================================================================
+# A — dirty computation (scoped to dirt that enters the image)
+# ===========================================================================
+
+def test_dirty_false_on_clean_tree():
+    def run(args):
+        assert ":!.jarvis" in args and ":!**/__pycache__" in args
+        return 0, ""
+    assert compute_dirty(run=run) == "false"
+
+
+def test_dirty_true_on_real_code_dirt():
+    def run(args):
+        return 0, " M backend/core/ouroboros/governance/orchestrator.py\n"
+    assert compute_dirty(run=run) == "true"
+
+
+def test_dirty_unknown_on_git_failure():
+    def run(args):
+        return 128, ""
+    assert compute_dirty(run=run) == "unknown"
+
+
+# ===========================================================================
+# B — commit resolution + env construction
+# ===========================================================================
+
+def test_resolve_commit():
+    def run(args):
+        return 0, "5873fbb1a0deadbeef00112233445566778899aa\n"
+    assert resolve_commit(run=run).startswith("5873fbb1a0")
+
+
+def test_resolve_commit_unstamped_on_failure():
+    def run(args):
+        return 1, ""
+    assert resolve_commit(run=run) == "unstamped"
+
+
+def test_build_launch_env_stamps_and_pins():
+    env = build_launch_env(commit="abc123", dirty="false", base={"PATH": "/x"})
+    assert env["GIT_COMMIT"] == "abc123"
+    assert env["GIT_DIRTY"] == "false"
+    assert env["JARVIS_ATTESTATION_EXPECTED_COMMIT"] == "abc123"
+    assert env["PATH"] == "/x"          # base preserved
+    assert "SOAK_REQUIREMENTS" in env   # oracle default
+
+
+def test_dirty_tree_refuses_pin():
+    """A dirty build must NOT be pinned-and-launched silently — the kernel
+    refuses upfront (strict gate would refuse it at boot anyway; failing at
+    launch time is the honest, earlier failure)."""
+    with pytest.raises(RuntimeError) as ei:
+        build_launch_env(commit="abc123", dirty="true", base={})
+    assert "dirty" in str(ei.value).lower()
+
+
+# ===========================================================================
+# C — post-launch verification IS the launch contract
+# ===========================================================================
+
+def _exec_runner(stamp_commit="abc123", mesh=True):
+    async def run(args):
+        joined = " ".join(args)
+        if ".build_attestation.json" in joined:
+            return 0, json.dumps({"commit": stamp_commit, "dirty": "false"})
+        if "STRATEGIC IGNITION MESH" in joined:
+            return (0, "2") if mesh else (1, "0")
+        return 0, ""
+    return run
+
+
+def test_verify_postlaunch_match():
+    v = asyncio.run(verify_postlaunch(
+        container="c", expected_commit="abc123",
+        run=_exec_runner(),
+    ))
+    assert v is LaunchVerdict.ATTESTED_MATCH
+
+
+def test_verify_postlaunch_detects_stale_container():
+    """THE phantom-deploy class: container stamp != pinned commit."""
+    v = asyncio.run(verify_postlaunch(
+        container="c", expected_commit="abc123",
+        run=_exec_runner(stamp_commit="bb0aab05ef"),
+    ))
+    assert v is LaunchVerdict.STAMP_MISMATCH
+
+
+def test_verify_postlaunch_detects_missing_marker():
+    v = asyncio.run(verify_postlaunch(
+        container="c", expected_commit="abc123",
+        run=_exec_runner(mesh=False), marker="STRATEGIC IGNITION MESH",
+    ))
+    assert v is LaunchVerdict.MARKER_MISSING
+
+
+def test_verify_postlaunch_unverified_on_exec_failure():
+    async def run(args):
+        return 125, ""  # container not up
+    v = asyncio.run(verify_postlaunch(
+        container="c", expected_commit="abc123", run=run,
+    ))
+    assert v is LaunchVerdict.UNVERIFIED
+
+
+# ===========================================================================
+# D — refusal pins (the lines that must not move)
+# ===========================================================================
+
+def test_kernel_never_touches_docker_socket():
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[2] / "backend" / "core"
+           / "ouroboros" / "governance" / "lifecycle_kernel.py").read_text(
+        encoding="utf-8")
+    assert "docker.sock" not in src
+    assert "auto-reload" not in src.lower() or "refus" in src.lower()
+    # host-side declaration present
+    assert "HOST-side" in src or "host-side" in src


### PR DESCRIPTION
Replaces the brittle bash stamping/build logic (whose `set -e` trap silently aborted the 2026-06-10 relaunch before the build) with `lifecycle_kernel.py` — typed, tested, async, HOST-side.

**The launch contract:** `launch()` = stamp → pin → build → up → **verify**; exit 0 ONLY when the running container's stamp matches the pin AND the marker code greps present. The phantom-deploy class can no longer exit 0. Dirty trees are refused upfront. Graceful SIGINT/SIGTERM forwards terminate to the child compose process. The bash launcher becomes a thin preflight wrapper that execs the kernel.

**Scope refusals (pinned by regression test):** no in-container self-cycling (Docker control socket inside an autonomous LLM-agent container = root-equivalent host escape — same class as the Slice-199 ~/.ssh refusal); no auto-reload on self-verified patches (S208 detectors are friction, not proof — the operator merge stays the deploy boundary).

12 tests incl. the lived stale-container class. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the bash launcher with a host-side Python orchestration kernel that stamps, pins, builds, launches, and verifies deployments. This makes attestation part of the launch contract, blocks phantom deploys, and refuses dirty trees upfront.

- **New Features**
  - Added `backend/core/ouroboros/governance/lifecycle_kernel.py` (typed, async) to handle stamp → pin → build → up → verify, with graceful SIGINT/SIGTERM forwarding.
  - Post-launch verification: ensures the running container’s stamp matches the pinned commit and the marker code is present; exit 0 only on an attested match.
  - Safety boundaries: host-side only (no `docker.sock`), no auto-reload on self-verified patches.
  - Added tests for dirt detection, commit resolution, env stamping/pinning, launch-verdicts (incl. stale-container), and refusal pins.

- **Refactors**
  - `scripts/launch_dw_cortex_soak.sh` is now a thin wrapper that delegates to `python3 -m backend.core.ouroboros.governance.lifecycle_kernel`, removing brittle `set -e` logic that previously masked failures.

<sup>Written for commit 5a7352c6c020e26047ad9faac5f43aa7648e5288. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

