### PR TITLE
fix(ops): Slice 213b - dirty-filter in Python, not git pathspec

### DIFF
--- a/backend/core/ouroboros/governance/lifecycle_kernel.py
+++ b/backend/core/ouroboros/governance/lifecycle_kernel.py
@@ -43,9 +43,6 @@ from typing import Awaitable, Callable, Dict, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-# dirt that can never enter the image (mirrors .dockerignore — .jarvis is
-# runtime state mutated through the bind-mount; __pycache__ is build noise)
-_DIRT_EXCLUDES = (":!.jarvis", ":!**/__pycache__")
 _DEFAULT_MARKER = "STRATEGIC IGNITION MESH"
 _DEFAULT_COMPOSE = "docker-compose.dw-cortex-soak.yml"
 
@@ -82,18 +79,39 @@ def _default_sync_run(args: list) -> Tuple[int, str]:
         return 127, ""
 
 
+def _is_image_relevant(porcelain_line: str) -> bool:
+    """True if this porcelain status line names dirt that can enter the image.
+    .jarvis/* (runtime state mutated through the bind-mount), __pycache__ and
+    .pytest_cache are all dockerignored — they can never ship."""
+    path = porcelain_line[3:].strip().strip('"')
+    if " -> " in path:  # renames: check the destination
+        path = path.split(" -> ", 1)[1].strip().strip('"')
+    if path.startswith(".jarvis/") or path == ".jarvis":
+        return False
+    parts = path.rstrip("/").split("/")
+    if "__pycache__" in parts or ".pytest_cache" in parts:
+        return False
+    return True
+
+
 def compute_dirty(*, run: Optional[_SyncRun] = None) -> str:
-    """'true'/'false'/'unknown' — dirt scoped to what actually ships
-    (excludes .jarvis runtime state + __pycache__, both dockerignored).
-    NEVER raises."""
+    """'true'/'false'/'unknown' — dirt scoped to what actually ships.
+
+    Filtering happens IN PYTHON over the plain porcelain output, NOT via git
+    exclude pathspecs: the 213b bug was the same ':!**/__pycache__' pathspec
+    string excluding correctly in a shell but NOT via subprocess (git pathspec
+    magic is environment-sensitive). Deterministic line filtering removes the
+    whole quirk class. NEVER raises."""
     run = run or _default_sync_run
     try:
-        rc, out = run(
-            ["git", "status", "--porcelain", "--", *_DIRT_EXCLUDES],
-        )
+        rc, out = run(["git", "status", "--porcelain"])
         if rc != 0:
             return "unknown"
-        return "true" if out.strip() else "false"
+        relevant = [
+            ln for ln in out.splitlines()
+            if ln.strip() and _is_image_relevant(ln)
+        ]
+        return "true" if relevant else "false"
     except Exception:  # noqa: BLE001
         return "unknown"
 

--- a/tests/governance/test_slice213_lifecycle_kernel.py
+++ b/tests/governance/test_slice213_lifecycle_kernel.py
@@ -36,7 +36,7 @@ from backend.core.ouroboros.governance.lifecycle_kernel import (
 
 def test_dirty_false_on_clean_tree():
     def run(args):
-        assert ":!.jarvis" in args and ":!**/__pycache__" in args
+        assert args[:3] == ["git", "status", "--porcelain"]
         return 0, ""
     assert compute_dirty(run=run) == "false"
 
@@ -44,6 +44,28 @@ def test_dirty_false_on_clean_tree():
 def test_dirty_true_on_real_code_dirt():
     def run(args):
         return 0, " M backend/core/ouroboros/governance/orchestrator.py\n"
+    assert compute_dirty(run=run) == "true"
+
+
+def test_dirty_false_on_dockerignored_noise_only():
+    """The 213b lived bug: pycache/.jarvis noise must be filtered IN PYTHON
+    (the git exclude pathspec excluded in a shell but NOT via subprocess —
+    pathspec magic is environment-sensitive)."""
+    def run(args):
+        return 0, (
+            "?? tests/unit/backend/core/__pycache__/\n"
+            " M .jarvis/roadmap.draft.yaml\n"
+            "?? .pytest_cache/\n"
+        )
+    assert compute_dirty(run=run) == "false"
+
+
+def test_dirty_true_when_real_dirt_mixed_with_noise():
+    def run(args):
+        return 0, (
+            "?? tests/unit/core/__pycache__/\n"
+            " M scripts/launch_dw_cortex_soak.sh\n"
+        )
     assert compute_dirty(run=run) == "true"
 
 


### PR DESCRIPTION
Reproducible: the same `':!**/__pycache__'` exclude pathspec excluded in a shell but NOT via `subprocess.run` (git pathspec magic is environment-sensitive) → the kernel computed `dirty=true` on noise and correctly refused two launches. Fix: plain `git status --porcelain` + deterministic Python-side filtering (`.jarvis/*`, `__pycache__`, `.pytest_cache` — all dockerignored, can never ship). 14 tests incl. the lived noise-only/mixed cases. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slice 213b by filtering `git status --porcelain` output in Python instead of using git exclude pathspecs, so dockerignored noise no longer trips dirty detection. Prevents false dirty=true and spurious launch refusals.

- **Bug Fixes**
  - Replaced pathspec-based call with plain `git status --porcelain`; added `_is_image_relevant()` to drop `.jarvis/*`, `__pycache__`, and `.pytest_cache`, including renames and quoted paths.
  - Makes dirty checks deterministic across environments by removing pathspec/shell sensitivity.
  - Added tests for clean, noise-only, mixed dirt, and git failure; updated existing test to assert new args.

<sup>Written for commit 7d376f52d5cf36d02f8ec8d933df141165527946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

