### PR TITLE
feat(routing): Slice 215 - FrugalGPT per-round cascade (Claude re-enabled) + cost containment

### DIFF
--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -37,8 +37,32 @@ services:
       - path: .env          # funded DOUBLEWORD_API_KEY — runtime only, never imaged
         required: false
     environment:
-      # ── DW-ONLY: no Claude, no cross-provider cascade ──
-      JARVIS_PROVIDER_CLAUDE_DISABLED: "true"
+      # ── Slice 215 — THE FrugalGPT PER-ROUND CASCADE (DW-only era ENDS). ──
+      # The DW-cortex validation purpose of this soak is long served; the soak's
+      # purpose is now AUTONOMY. Claude re-enabled as the per-round rescue tier:
+      # each Venom round runs DW-primary -> Claude rescues THAT round on failure
+      # (per-round survival ~99.7% vs 0.7^n chain death), so chains survive
+      # without paying Claude for whole chains.
+      #   CHARTER (provider_topology defaults already encode it):
+      #   - IMMEDIATE/COMPLEX: dw_allowed=false -> cascade_to_claude (the spine)
+      #   - STANDARD: DW-primary, Claude per-round rescue
+      #   - BACKGROUND/SPECULATIVE: skip_and_queue — NEVER Claude (cost shield)
+      JARVIS_PROVIDER_CLAUDE_DISABLED: "false"
+      # Rescue budgets (blindspot #2): the 60-120s fallback caps were tuned to
+      # protect DW from Claude-starvation; as RESCUE they truncated healthy
+      # mid-stream generations. Raised for generation, modest for PLAN.
+      JARVIS_FALLBACK_MAX_TIMEOUT_S: "180"
+      OUROBOROS_PLAN_FALLBACK_MAX_TIMEOUT_S: "120"
+      # COST CONTAINMENT (operator's #1 concern — Claude spend velocity):
+      #   - session cost-cap lowered 25 -> 10 in the command below: bounds the
+      #     restart:always per-session-reset loophole to $10/session worst-case
+      #   - telemetry sentinel armed: COST_CAP_90 fires the Discord webhook
+      #     (webhook already in .env) BEFORE the cap, not after
+      #   - IMMEDIATE extended thinking stays OFF; BACKGROUND/SPECULATIVE stay
+      #     DW-only by topology; provider response cache (S131) default-ON
+      #     dedupes repeat Claude calls
+      JARVIS_TELEMETRY_SENTINEL_ENABLED: "1"
+      JARVIS_THINKING_BUDGET_IMMEDIATE: "0"
       # ── The predictive cortex — the subject of this soak (172/174 are default-OFF) ──
       JARVIS_DW_PREDICTIVE_ROUTING_ENABLED: "1"      # 172 — preemptive forecast routing
       JARVIS_DW_CALIBRATION_ENABLED: "1"             # 174 — self-tuning Brier threshold
@@ -171,7 +195,7 @@ services:
       - --production-soak
       - --headless
       - --cost-cap
-      - "25"
+      - "10"
       - --idle-timeout
       - "0"
       - --max-wall-seconds

--- a/progress.txt
+++ b/progress.txt
@@ -41,3 +41,13 @@
                  REFUSED: in-container self-cycling (docker-socket = host escape) + auto-reload
                  on self-verified patches (S208 = friction not proof; operator merge stays the
                  deploy boundary).
+  [x] slice-215  FrugalGPT per-round cascade: Claude RE-ENABLED as per-round rescue tier
+                 (DW-primary rounds, Claude rescues the failed round -> ~99.7% round survival vs
+                 0.7^n chain death). Topology defaults already encode the charter (IMMEDIATE/
+                 COMPLEX cascade_to_claude; BACKGROUND/SPECULATIVE skip_and_queue = never Claude).
+                 Rescue budgets 180s/120s. COST: session cap 25->10 (bounds restart-reset
+                 loophole), sentinel COST_CAP_90 Discord alert armed, thinking IMMEDIATE=0,
+                 response cache dedupes. Bandit state reset for the new Claude arm (cold-start).
+                 L2 PROBE PROVED: goal->reader(valid)->decomposition(valid, 2 sub-goals)->
+                 envelope INTO router. Remaining break: orchestration 'no_plan' = planning needs
+                 reliable LLM capacity = exactly what this slice supplies.


### PR DESCRIPTION
**The flip**: `JARVIS_PROVIDER_CLAUDE_DISABLED=false`. The L2 probe proved GOAL-001 flows reader→decomposition(valid, 2 sub-goals)→envelope into the router, then dies at orchestration `no_plan` — planning needs reliable LLM capacity, which DW-only can't provide (39 exhaustions/49 dispatches).

**Per-round cascade** (not Claude-primary chains): each Venom round runs DW-primary, Claude rescues the failed round → ~99.7% round survival, ~97% 10-round chains, DW still serves cheap rounds. Charter via topology *defaults*: IMMEDIATE/COMPLEX `cascade_to_claude`; BACKGROUND/SPECULATIVE `skip_and_queue` (never Claude — the cost shield).

**Rescue budgets**: fallback 120→180s, PLAN 60→120s (old caps truncated healthy mid-stream rescues).

**Cost containment (operator's #1 concern)**: session cap 25→$10 (bounds the restart-reset loophole), sentinel COST_CAP_90 Discord alert armed, thinking IMMEDIATE=0, BG/SPEC DW-only, S131 cache dedupes. Expected steady spend ~$1–2/day.

Pure-config slice — every knob was already env-driven. Bandit state reset host-side at relaunch (fresh priors for the Claude arm). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled Claude as a per-round rescue (DW stays primary) to improve chain reliability and reduce orchestration “no_plan” failures. Tightened budgets and caps to contain spend; changes are config-only in `docker-compose.dw-cortex-soak.yml`.

- **New Features**
  - Per-round cascade: DW-primary; failed rounds cascade to Claude. Defaults: IMMEDIATE/COMPLEX `cascade_to_claude`; BACKGROUND/SPECULATIVE `skip_and_queue` (DW-only).
  - Flip `JARVIS_PROVIDER_CLAUDE_DISABLED` to `"false"`.
  - Raised rescue timeouts: `JARVIS_FALLBACK_MAX_TIMEOUT_S=180`, `OUROBOROS_PLAN_FALLBACK_MAX_TIMEOUT_S=120`.

- **Cost Containment**
  - Lowered session cost cap to $10 (`--cost-cap "10"`); enabled sentinel alerts (`JARVIS_TELEMETRY_SENTINEL_ENABLED=1`) before hitting the cap.
  - Kept IMMEDIATE thinking off (`JARVIS_THINKING_BUDGET_IMMEDIATE=0`); BACKGROUND/SPECULATIVE remain DW-only; provider response cache dedupes calls.
  - Bandit state resets on relaunch for fresh priors on the Claude arm.

<sup>Written for commit 865b0fa4b782bf2c38f607c7d2322fe0671e4b6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

