### PR TITLE
fix(telemetry): Slice 215b - derive Chronos image-id from the attestation stamp

### DIFF
--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -130,7 +130,14 @@ services:
       # Sleep-frozen wall-clock is excluded. JARVIS_SOAK_IMAGE_ID lets the
       # ledger tell rebuilds (supervised) from recoveries (unsupervised). ──
       JARVIS_CHRONOS_LEDGER_ENABLED: "1"
-      JARVIS_SOAK_IMAGE_ID: "slice-206-warmup"
+      # Slice 215b — image identity DERIVED from the attestation stamp commit
+      # (kernel exports GIT_COMMIT at launch). The hardcoded "slice-206-warmup"
+      # went stale across SEVEN deploys, so Chronos classified supervised
+      # rebuilds as recovery_unsupervised — silently OVERCOUNTING the §41.6
+      # unsupervised-interval evidence (the continuity-laundering class S208
+      # polices in code, arriving via stale config). Now every attested launch
+      # carries its commit as the image id: rebuild => supervised reset, honest.
+      JARVIS_SOAK_IMAGE_ID: ${GIT_COMMIT:-dev-unstamped}
       # ── Slice 206: Boot-Warmup Lifecycle. One-time heavy-init lag is recorded
       # as warmup_lag (visible, benign) instead of polluting steady-state
       # control_plane_starvation_events; the heavy builds are pre-warmed off-loop


### PR DESCRIPTION
Caught by the 215 launch verification: `last_event=recovery_unsupervised` on a **supervised** rebuild. `JARVIS_SOAK_IMAGE_ID` was hardcoded and went stale across seven deploys → Chronos classified supervised rebuilds as unsupervised recoveries, silently overcounting the §41.6 unsupervised evidence (the continuity-laundering class S208 polices in code, via stale config). Fix: derive the id from the attestation stamp the kernel already exports (`${GIT_COMMIT:-dev-unstamped}`) — rebuild ⇒ supervised reset, restart ⇒ honest continuity. Zero new code; marries S204+S212+S213. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the Chronos image ID from the attestation commit so supervised rebuilds are recorded as supervised, not unsupervised recoveries. Fixes the unsupervised-interval overcount observed in Slice 215 verification.

- **Bug Fixes**
  - Set JARVIS_SOAK_IMAGE_ID to ${GIT_COMMIT:-dev-unstamped} in docker-compose.dw-cortex-soak.yml.
  - Image identity now mirrors the attested commit: rebuilds change the ID; restarts keep it.
  - Corrects Chronos ledger classification caused by a stale hardcoded ID; no code changes.

<sup>Written for commit cc8a5b81bacfdafd45472cdf69a88e3b29d3cbb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

