### PR TITLE
feat(routing): Slice 219 - enable DW catalog-discovery so Nemotron-3-Ultra-550B auto-ranks

### DIFF
--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -89,6 +89,14 @@ services:
       #    a cost-optimizer that skips the race during a forecast storm. Outcomes recorded into
       #    the economic ledger (171): hedge_rt_wins / hedge_batch_wins / hedge_ruptures_swallowed. ──
       JARVIS_DW_TRANSPORT_HEDGE_ENABLED: "1"
+      # ── Slice 219 — make DW dynamic catalog-discovery EXPLICIT so the new
+      # funded key live-fetches DW's /v1/models and ranks per-route by params.
+      # This auto-discovers nvidia/NVIDIA-Nemotron-3-Ultra-550B (ranks #1 for
+      # COMPLEX at 550B > Qwen-397B) + Super-120B — NO hardcoded model id; the
+      # classifier owns ranking. The stale May-24 cache was archived so the
+      # first fetch repopulates with the live catalog. ──
+      JARVIS_DW_CATALOG_DISCOVERY_ENABLED: "1"
+      JARVIS_DW_CATALOG_AUTHORITATIVE: "1"
       # ── Organism baseline ──
       JARVIS_EPISODIC_CORE_ENABLED: "1"
       JARVIS_CAI_ROUTER_ENABLED: "1"


### PR DESCRIPTION
Operator: 'can we utilize DW's Nemotron 3 Ultra?' **Verify-first proved the architecture already does this** — the dynamic catalog-discovery pipeline fetches DW's /v1/models live and ranks per-route by params. No hardcoded model id.

**Confirmed live (new funded key)**: DW serves Ultra-550B + Super-120B; the parser handles 550B; Ultra ranks #1 for COMPLEX (550B > Qwen-397B).

**Why it wasn't already appearing**: discovery had failed over to a stale May-24 cache (old key was 402-ing → live fetches failed → served stale). Fix (config): archived the stale caches + pinned the discovery flags explicit-on.

**Honest caveat**: Ultra-550B is biggest → slowest → most timeout-prone on DW's unstable backend; the classifier ranks by raw params so COMPLEX routes to the slowest model, which *could* raise timeouts. Watch it; Super-120B may be the better workhorse. Not pre-judged — discovery ranks, we measure. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable DW dynamic catalog discovery in soak to live-fetch `/v1/models` and auto-rank by params, so `nvidia/NVIDIA-Nemotron-3-Ultra-550B` (and `Super-120B`) are selected without hardcoding. Addresses Slice 219 and avoids stale-cache fallback by making discovery authoritative.

<sup>Written for commit 4eb6ffce09e2269e3a5a51a1846b44e5e26b7dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

