### PR TITLE
feat(routing): Slice 218 - arm the existing multi-model verification matrix (no duplicate circuit)

### DIFF
--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -97,6 +97,17 @@ services:
       # first fetch repopulates with the live catalog. ──
       JARVIS_DW_CATALOG_DISCOVERY_ENABLED: "1"
       JARVIS_DW_CATALOG_AUTHORITATIVE: "1"
+      # ── Slice 218 — arm the EXISTING multi-model runtime verification matrix
+      # (verify-first: NOT a new circuit — race_triage + schema_drift_tracker +
+      # PromotionLedger + cortex + bandit already implement it). The ONE missing
+      # flag: schema-drift rotation. With it on, a model that emits a
+      # schema_invalid payload (e.g. tool_call_without_tool_loop) is demoted +
+      # the op rotates to the next ranked candidate — zero loop disruption.
+      # JARVIS_RACE_TRIAGE_ENABLED (dual-arm rotation) + the Zero-Trust
+      # PromotionLedger (new models quarantined to SPECULATIVE until they prove
+      # 10 clean ops) are already default-ON — so an un-vetted model like
+      # Nemotron EARNS its way up; it does NOT jump into the COMPLEX main track. ──
+      JARVIS_SCHEMA_DRIFT_ROTATION_ENABLED: "1"
       # ── Organism baseline ──
       JARVIS_EPISODIC_CORE_ENABLED: "1"
       JARVIS_CAI_ROUTER_ENABLED: "1"

--- a/progress.txt
+++ b/progress.txt
@@ -65,3 +65,11 @@
                  singleton (incoherent cross-process; over-engineering for a missing assignment) +
                  sleep-sync queue-bypass (Chronos sleep-detect already honest; real fix = non-sleeping
                  host, not code). HOST NOTE: Mac slept overnight (chronos_sleep_event) -> laptop != soak host.
+  [x] slice-218  arm the EXISTING multi-model verification matrix (verify-first: NOT a new
+                 circuit). One missing flag: JARVIS_SCHEMA_DRIFT_ROTATION_ENABLED -> schema_invalid
+                 (tool_call_without_tool_loop) demotes the model + rotates to next ranked. Declined
+                 the duplicate schema-guard/demotion-circuit build (race_triage + schema_drift_tracker
+                 + PromotionLedger Zero-Trust quarantine + cortex timeout + bandit ALREADY do it).
+                 PREMISE CORRECTED: Nemotron does NOT jump into COMPLEX — the prove-it PromotionLedger
+                 quarantines new models to SPECULATIVE until 10 clean ops; DeepSeek-V4-Pro/Qwen-397B
+                 (proven, ranked) carry COMPLEX while Nemotron earns trust.


### PR DESCRIPTION
**Verify-first overturned the plan**: the schema-mirroring + demotion circuit is already built (race_triage + schema_drift_tracker + PromotionLedger + cortex + bandit). Building a new one = duplication. **The one missing flag: `JARVIS_SCHEMA_DRIFT_ROTATION_ENABLED`** — armed here; RACE_TRIAGE + PromotionLedger already default-on.

**Premise corrected**: Nemotron does NOT jump into the COMPLEX main track. The classifier ranks by a scored function (DeepSeek-V4-Pro currently tops COMPLEX, not Nemotron), and the Zero-Trust PromotionLedger quarantines new models to SPECULATIVE until ~10 clean ops promote them. So Nemotron earns its way up while proven models carry COMPLEX — exactly the un-vetted-model safety requested, already enforced. Pure-config; declined the duplicate build. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables schema-drift rotation in the soak stack to use the existing verify-first demotion/rotation path. Turns on `JARVIS_SCHEMA_DRIFT_ROTATION_ENABLED` so `schema_invalid` responses demote the model and rotate to the next ranked candidate; new models stay in SPECULATIVE until PromotionLedger promotion.

<sup>Written for commit 0115456f367a9c81daa5d157e32d2752c5fc94a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

