### PR TITLE
fix(aegis): Slice 220 - set Aegis session-token TTL to cover the soak (the real AegisClientError root cause)

### DIFF
--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -119,6 +119,18 @@ services:
       # less). Non-interactive hardening: a missing/expired credential FAILS
       # CLOSED rather than hanging on a hidden CLI prompt.
       GIT_TERMINAL_PROMPT: "0"
+      # ── Slice 220 — THE AegisClientError ROOT CAUSE (verify-first; NOT a socket/
+      # pool bug). The Aegis session TOKEN expires after JARVIS_AEGIS_SESSION_
+      # TOKEN_TTL_S (default 3600=1h). The bootstrap PSK is single-use + there is
+      # no /session/refresh endpoint yet, so after 1h every Claude call fails
+      # "403 psk_already_consumed" -> fallback_failed -> EXHAUSTION (sleep- AND
+      # socket-independent; the HTTP session already self-heals via _ensure_http).
+      # client.py:14-17 prescribes the fix: "set JARVIS_AEGIS_SESSION_TOKEN_TTL_S
+      # to cover the whole intended session duration." 90 days covers the full
+      # §41.6 Tier-D unsupervised-evidence window in one continuous run; a restart
+      # re-mints anyway. DECLINED the plan's session-factory/pool-reconnect: it
+      # would fix a non-existent socket bug while the 403 kept failing. ──
+      JARVIS_AEGIS_SESSION_TOKEN_TTL_S: "7776000"
       GCM_INTERACTIVE: "never"
       JARVIS_GIT_ORIGIN_SLUG: "drussell23/JARVIS"
       JARVIS_GIT_AUTHOR_NAME: "Ouroboros+Venom"

--- a/progress.txt
+++ b/progress.txt
@@ -73,3 +73,11 @@
                  PREMISE CORRECTED: Nemotron does NOT jump into COMPLEX — the prove-it PromotionLedger
                  quarantines new models to SPECULATIVE until 10 clean ops; DeepSeek-V4-Pro/Qwen-397B
                  (proven, ranked) carry COMPLEX while Nemotron earns trust.
+  [x] slice-220  Aegis session-TOKEN-expiry root cause (verify-first; declined the plan's
+                 session-factory/pool-reconnect as fixing a non-existent socket bug). The real bug:
+                 session token TTL default 3600=1h + single-use PSK + no /session/refresh -> after 1h
+                 every Claude call = 403 psk_already_consumed -> fallback_failed -> EXHAUSTION (NOT
+                 sleep, NOT sockets; HTTP session already self-heals via _ensure_http). Fix = the
+                 DESIGNED knob (client.py:14-17): JARVIS_AEGIS_SESSION_TOKEN_TTL_S=7776000 (90d, covers
+                 §41.6 evidence window). DURABLE follow-on = build the /session/refresh endpoint
+                 (Slice-3 TODO) for truly-infinite uptime beyond any TTL.


### PR DESCRIPTION
**Verify-first overturned the plan.** The AegisClientError exhaustions aren't a socket/pool bug — the forward session is per-request, the client's HTTP session already self-heals, and AegisClientError is a client-side *misconfiguration* error.

**Real root cause (72× in logs):** the Aegis session *token* expires after `JARVIS_AEGIS_SESSION_TOKEN_TTL_S` (default 3600 = **1h**). The bootstrap PSK is single-use + there's no `/session/refresh` endpoint → after 1h every Claude call gets `403 psk_already_consumed` → fallback_failed → EXHAUSTION, until restart. The 10.5h container had been failing ~9.5h. **Sleep- and socket-independent** — exactly why the awake-host AFTER window still showed errors.

**The fix (prescribed verbatim in client.py:14-17):** set the TTL to cover the run. The soak never set it. Set to 7776000 (90 days) — covers the §41.6 evidence window. **Declined** the plan's session-factory/pool-reconnect (would fix a non-existent socket bug). Durable follow-on noted: build the `/session/refresh` endpoint. Pure-config. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Aegis session token TTL to 90 days in the soak environment to prevent 1-hour expiry from breaking long runs. This stops `403 psk_already_consumed` loops and eliminates `AegisClientError` exhaustion during soaks.

- **Bug Fixes**
  - Configure `JARVIS_AEGIS_SESSION_TOKEN_TTL_S=7776000` in `docker-compose.dw-cortex-soak.yml`.
  - Root cause: default 1h TTL + single-use PSK + no `/session/refresh`.
  - Impact: stable multi-hour soaks without socket/session code changes.

<sup>Written for commit 00d661f75bd393c8cc0e91f9b3bc8bca3b6dab70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

