### PR TITLE
docs: Slice 221 - strategic target trace verdict + QoS isolation blueprint

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -81,3 +81,16 @@
                  DESIGNED knob (client.py:14-17): JARVIS_AEGIS_SESSION_TOKEN_TTL_S=7776000 (90d, covers
                  §41.6 evidence window). DURABLE follow-on = build the /session/refresh endpoint
                  (Slice-3 TODO) for truly-infinite uptime beyond any TTL.
+  [x] slice-221  STRATEGIC TARGET TRACE (verify-first KILLED two phantom slices first: the
+                 'topology bypass' didn't exist — immediate dw_allowed=False loads correctly; and the
+                 failing IMMEDIATE ops were TestFailure sensor noise, NOT GOAL-001 which routes
+                 COMPLEX/BACKGROUND). ROOT CAUSE FOUND: GOAL-001::file-00 held hostage by STALE
+                 goal_decomposition_ledger.jsonl (Jun-10 dry-run era, pre-S217) recording
+                 status=proposed/'emitted' for an emission that never ingested -> _mark_emitted_via_
+                 goal_decomposition sees already-emitted -> never re-emits -> emit_outcomes=[] forever.
+                 FIX: archive BOTH stale ledgers (multi_step + goal_decomposition) + clean-slate rebuild.
+                 QoS BLUEPRINT (designed, not built): partition intake into QoS-0 (sensor/health noise,
+                 throttleable) vs QoS-1 (operator-signed roadmap targets, dedicated un-starvable slots)
+                 — intake_priority_queue already has priority buckets; the gap is per-CLASS worker
+                 reservation so an IMMEDIATE timeout storm can't consume all execution slots. Build
+                 trigger: IF post-cleanup file-00 dispatches but starves behind sensor ops.


### PR DESCRIPTION
Trace verdict: GOAL-001::file-00 is held hostage by the stale `goal_decomposition_ledger.jsonl` (Jun-10 dry-run era, pre-S217) recording an emission that never ingested → orchestrator sees already-emitted → never re-emits. Two phantom slices killed by verify-first on the way (no topology bypass; IMMEDIATE failures are sensor noise, not GOAL-001). Fix = archive both stale ledgers + clean-slate rebuild; the fresh emit outcome decides suspect #2 (intake/router wire). QoS blueprint documented, build-gated on evidence. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the root cause blocking GOAL-001::file-00 and the cleanup plan, plus a QoS isolation blueprint to keep strategic targets from sensor‑noise storms. Stale ledgers (`.jarvis/goal_decomposition_ledger.jsonl` and multi_step) from the Jun‑10 dry run marked the emission as already sent, so it never re‑emitted—fix is to archive both and rebuild; verify‑first also ruled out a topology bypass and confirmed IMMEDIATE failures are unrelated noise.

<sup>Written for commit f710764771e6544400bdcfe1a1b468390dc93ed9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

