### PR TITLE
fix(soak): Slice 222 - quiet the TestFailure self-DDoS starving GOAL-001

### DIFF
--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -131,6 +131,19 @@ services:
       # re-mints anyway. DECLINED the plan's session-factory/pool-reconnect: it
       # would fix a non-existent socket bug while the 403 kept failing. ──
       JARVIS_AEGIS_SESSION_TOKEN_TTL_S: "7776000"
+      # ── Slice 222 — QUIET THE SELF-DDOS. The TestFailure sensor fires every
+      # ~30s on the SAME 3 known pre-existing failing tests (bg_readonly_cascade
+      # — verified identical on clean main days ago), spawning IMMEDIATE ops
+      # that all exhaust on DW timeouts and saturate the 3-worker pool —
+      # starving GOAL-001::file-00 (priority 4) which sat ENQUEUED for 40 min
+      # untouched. The organism was DDoSing itself with unfixable noise.
+      # Quiet the sensor in THIS soak (re-enable after the strategic run):
+      # poll once/day instead of constantly, fs-event triggers off. NOT metric
+      # gaming: the failures are documented pre-existing; this changes WHEN we
+      # look, not what exists. QoS reserved-slot build (blueprint, S221) stays
+      # the durable fix if starvation persists with the noise quieted. ──
+      JARVIS_TEST_FAILURE_FALLBACK_INTERVAL_S: "86400"
+      JARVIS_TEST_FAILURE_FS_EVENTS_ENABLED: "0"
       GCM_INTERACTIVE: "never"
       JARVIS_GIT_ORIGIN_SLUG: "drussell23/JARVIS"
       JARVIS_GIT_AUTHOR_NAME: "Ouroboros+Venom"

--- a/progress.txt
+++ b/progress.txt
@@ -94,3 +94,8 @@
                  — intake_priority_queue already has priority buckets; the gap is per-CLASS worker
                  reservation so an IMMEDIATE timeout storm can't consume all execution slots. Build
                  trigger: IF post-cleanup file-00 dispatches but starves behind sensor ops.
+  [x] slice-222  quiet the self-DDoS: TestFailure sensor thrashing on 3 KNOWN pre-existing
+                 failing tests -> constant IMMEDIATE ops -> all 3 workers saturated -> GOAL-001
+                 (priority 4) starved 40min in queue. Soak config: poll 1/day + fs-events off.
+                 NOT gaming (failures documented pre-existing; changes WHEN we look). QoS build
+                 remains the durable fix if starvation persists.


### PR DESCRIPTION
file-00 sat enqueued 40 min with zero dispatches while the TestFailure sensor (firing ~30s on the same 3 known pre-existing failures it can never fix) saturated all 3 workers with exhausting IMMEDIATE ops. Soak config: poll 1/day + fs-events off (re-enable post-run). Not gaming — the failures are documented pre-existing; changes when we look, not what exists. S221 QoS blueprint stays the durable fix if starvation persists. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quiets the TestFailure sensor in soak to stop a self-DDoS that blocked GOAL-001 (file-00) from dispatching. This reduces IMMEDIATE noise from known pre-existing failures.

- **Bug Fixes**
  - Set `JARVIS_TEST_FAILURE_FALLBACK_INTERVAL_S=86400` (poll once/day).
  - Set `JARVIS_TEST_FAILURE_FS_EVENTS_ENABLED=0` (disable fs-event triggers).

<sup>Written for commit b495d4189294f3c635e242b2b10fa1ba1d1107fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

