### PR TITLE
feat(routing): Slice 223 - headless-soak sensor demotion (10A pattern) + token protection

### DIFF
--- a/backend/core/ouroboros/governance/urgency_router.py
+++ b/backend/core/ouroboros/governance/urgency_router.py
@@ -500,6 +500,40 @@ class UrgencyRouter:
             # NEVER let envelope inspection break the route — fall through.
             pass
 
+        # ── Priority 0.75: headless-soak sensor demotion (Slice 223) ──
+        # The Slice-10A pattern, generalized. §5 urgency routing was designed
+        # for the HUMAN-REFLEX case; in a headless soak NO HUMAN IS WAITING on
+        # a sensor alarm. Live evidence (2026-06-12): the TestFailure sensor's
+        # storm over 3 known pre-existing failures routed IMMEDIATE ->
+        # Claude-direct, saturating the worker pool + burning premium tokens
+        # on unfixable noise while the operator-signed GOAL-001 starved 40min
+        # in queue. Demote test_failure-source ops to STANDARD (DW primary,
+        # Claude per-round rescue preserved — the 10A choice) when BOTH:
+        #   * JARVIS_SOAK_SENSOR_DEMOTION_ENABLED (gate, default FALSE)
+        #   * OUROBOROS_BATTLE_HEADLESS truthy (no human present)
+        # Source-discriminated (signal_source, stamped by the sensor), NOT a
+        # priority label a generated patch could self-elevate (S208 concern).
+        # Interactive sessions byte-identical: a human watching a test fail
+        # mid-typing keeps the reflex lane.
+        try:
+            _demote_on = os.environ.get(
+                "JARVIS_SOAK_SENSOR_DEMOTION_ENABLED", "",
+            ).strip().lower() in ("1", "true", "yes", "on")
+            _headless = os.environ.get(
+                "OUROBOROS_BATTLE_HEADLESS", "",
+            ).strip().lower() in ("1", "true", "yes", "on")
+            if (
+                _demote_on and _headless
+                and (getattr(ctx, "signal_source", "") or "") == "test_failure"
+            ):
+                return (
+                    ProviderRoute.STANDARD,
+                    "headless_soak_sensor_demotion:test_failure:"
+                    "no_human_waiting:dw_primary",
+                )
+        except Exception:  # noqa: BLE001 — defensive
+            pass
+
         urgency = getattr(ctx, "signal_urgency", "") or "normal"
         source = getattr(ctx, "signal_source", "") or ""
         complexity = getattr(ctx, "task_complexity", "") or "moderate"

--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -144,6 +144,12 @@ services:
       # the durable fix if starvation persists with the noise quieted. ──
       JARVIS_TEST_FAILURE_FALLBACK_INTERVAL_S: "86400"
       JARVIS_TEST_FAILURE_FS_EVENTS_ENABLED: "0"
+      # ── Slice 223 — headless sensor demotion (the durable layer under 222's
+      # timer). Even if ANY sensor storms again, test_failure-source ops in a
+      # headless soak route STANDARD (DW primary), never IMMEDIATE/Claude-
+      # direct — premium tokens reserved for human-reflex + strategic work.
+      # Source-discriminated; interactive sessions byte-identical. ──
+      JARVIS_SOAK_SENSOR_DEMOTION_ENABLED: "1"
       GCM_INTERACTIVE: "never"
       JARVIS_GIT_ORIGIN_SLUG: "drussell23/JARVIS"
       JARVIS_GIT_AUTHOR_NAME: "Ouroboros+Venom"

--- a/progress.txt
+++ b/progress.txt
@@ -99,3 +99,9 @@
                  (priority 4) starved 40min in queue. Soak config: poll 1/day + fs-events off.
                  NOT gaming (failures documented pre-existing; changes WHEN we look). QoS build
                  remains the durable fix if starvation persists.
+  [x] slice-223  headless sensor demotion (10A pattern generalized; verify-first DESCOPED the
+                 plan's two-lane pool + 'cryptographic firewall'): BG/SPEC already barred from Claude
+                 (topology skip_and_queue); the leak was test_failure->IMMEDIATE->Claude-direct. New
+                 Priority 0.75: headless + test_failure -> STANDARD (DW primary, rescue preserved).
+                 Source-discriminated (S208-safe: not a self-elevatable label). Two-lane QoS pool
+                 build stays gated on the b5nai4cms watch verdict (starvation with noise quieted?).

--- a/tests/governance/test_slice223_headless_sensor_demotion.py
+++ b/tests/governance/test_slice223_headless_sensor_demotion.py
@@ -1,0 +1,80 @@
+"""Slice 223 — headless-soak sensor demotion (the 10A pattern, generalized).
+
+Slice 10A precedent: SWE-Bench fixtures masquerading as test_failure routed
+IMMEDIATE -> Claude-direct and burned 99.83% of soak spend on Claude. Same
+disease in the unattended soak: the TestFailure sensor's storm (3 known
+pre-existing failures it can never fix) routed IMMEDIATE, saturating workers
++ burning Claude rescue tokens on noise. §5's reasoning applies verbatim:
+urgency routing was designed for the HUMAN-REFLEX case — in a headless soak,
+NO HUMAN IS WAITING on a sensor alarm.
+
+Priority 0.75: when JARVIS_SOAK_SENSOR_DEMOTION_ENABLED + the soak is headless
+(OUROBOROS_BATTLE_HEADLESS truthy), test_failure-source ops downgrade
+IMMEDIATE -> STANDARD (DW primary, Claude per-round rescue preserved — the 10A
+choice: capability kept, cost restored). Gated default-FALSE; interactive
+(non-headless) behavior byte-identical. Source-discriminated (signal_source),
+not priority-label-based — a generated patch can't elevate itself past it by
+relabeling priority (the S208 concern).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance.urgency_router import (
+    ProviderRoute, UrgencyRouter,
+)
+
+
+def _ctx(source="test_failure", urgency="critical"):
+    return SimpleNamespace(
+        signal_source=source, signal_urgency=urgency,
+        task_complexity="moderate", target_files=["a.py"], cross_repo=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    for k in ("JARVIS_SOAK_SENSOR_DEMOTION_ENABLED", "OUROBOROS_BATTLE_HEADLESS"):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def test_default_off_is_byte_identical(monkeypatch):
+    """Gate off -> test_failure + critical still routes IMMEDIATE (legacy)."""
+    route, _ = UrgencyRouter().classify(_ctx())
+    assert route is ProviderRoute.IMMEDIATE
+
+
+def test_headless_soak_demotes_test_failure(monkeypatch):
+    monkeypatch.setenv("JARVIS_SOAK_SENSOR_DEMOTION_ENABLED", "1")
+    monkeypatch.setenv("OUROBOROS_BATTLE_HEADLESS", "1")
+    route, reason = UrgencyRouter().classify(_ctx())
+    assert route is ProviderRoute.STANDARD
+    assert "headless" in reason and "test_failure" in reason
+
+
+def test_interactive_session_unaffected(monkeypatch):
+    """Gate ON but NOT headless -> human may be waiting -> IMMEDIATE stays."""
+    monkeypatch.setenv("JARVIS_SOAK_SENSOR_DEMOTION_ENABLED", "1")
+    route, _ = UrgencyRouter().classify(_ctx())
+    assert route is ProviderRoute.IMMEDIATE
+
+
+def test_non_sensor_sources_unaffected(monkeypatch):
+    """Voice/human-critical signals keep the reflex lane even in headless."""
+    monkeypatch.setenv("JARVIS_SOAK_SENSOR_DEMOTION_ENABLED", "1")
+    monkeypatch.setenv("OUROBOROS_BATTLE_HEADLESS", "1")
+    route, _ = UrgencyRouter().classify(_ctx(source="voice_human"))
+    assert route is ProviderRoute.IMMEDIATE
+
+
+def test_discriminator_is_source_not_priority_label(monkeypatch):
+    """S208 concern: the gate keys on signal_source (stamped by the sensor),
+    not any priority label a patch could self-elevate."""
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[2] / "backend" / "core"
+           / "ouroboros" / "governance" / "urgency_router.py").read_text(encoding="utf-8")
+    assert "JARVIS_SOAK_SENSOR_DEMOTION_ENABLED" in src
+    assert "OUROBOROS_BATTLE_HEADLESS" in src


### PR DESCRIPTION
**Verify-first descoped the plan**: BG/SPEC are already structurally barred from Claude (topology `skip_and_queue`); the real leak was `test_failure`→IMMEDIATE→Claude-direct (the §5 human-reflex lane, with no human present). The two-lane pool build stays gated on the S221 blueprint trigger.

**The 10A precedent, generalized**: identical disease fixed once for SWE-Bench fixtures (99.83% of spend on Claude). New Priority 0.75: headless + `test_failure` source → STANDARD (DW primary, rescue preserved). Interactive sessions byte-identical. S208-safe: keyed on sensor-stamped `signal_source`, not a self-elevatable priority label. 5 tests; 11 green w/ 10A suite. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demotes headless soak test-failure sensor traffic from IMMEDIATE (Claude-direct) to STANDARD to stop token burn and worker saturation. Interactive sessions are unchanged; Claude rescue per-round remains available.

- **New Features**
  - Adds a source-based rule in `urgency_router.classify`: when `JARVIS_SOAK_SENSOR_DEMOTION_ENABLED` and `OUROBOROS_BATTLE_HEADLESS` are true and `signal_source` is `test_failure`, route STANDARD.
  - Enables the gate in `docker-compose.dw-cortex-soak.yml` by setting `JARVIS_SOAK_SENSOR_DEMOTION_ENABLED=1`.
  - Adds tests covering default-off behavior, headless demotion, interactive unaffected, and source-based discrimination.

<sup>Written for commit 6e932c0ad8aed29649423226b052746943507ae1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

