### PR TITLE
feat(perf): Slice 224 - token-economic accounting fabric (P2a wire + /spend + burn rail)

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -4868,6 +4868,20 @@ class SerpentREPL:
                     if line in ("cost", "/cost"):
                         self._print_cost()
                         continue
+                    if line in ("spend", "/spend"):
+                        # Slice 224 — day x provider x route attribution over
+                        # the Aegis spend WAL (read-only; never raises).
+                        try:
+                            from backend.core.ouroboros.governance.accounting_ledger import (  # noqa: E501
+                                format_spend_report, rollup_spend,
+                            )
+                            self._console.print(
+                                format_spend_report(rollup_spend()),
+                                highlight=False,
+                            )
+                        except Exception as _se:  # noqa: BLE001
+                            self._console.print(f"  spend report error: {_se}")
+                        continue
                     if line in ("posture", "/posture"):
                         self._print_posture()
                         continue

--- a/backend/core/ouroboros/governance/accounting_ledger.py
+++ b/backend/core/ouroboros/governance/accounting_ledger.py
@@ -1,0 +1,152 @@
+"""Slice 224 — Token-Economic Accounting Fabric (read-only spend analytics).
+
+Answers the operator's question — "where is the money going?" — from the
+authoritative Aegis spend WAL (``.jarvis/aegis/spend.jsonl`` + its rotation
+backups). Only ``kind=reconcile`` records count (real, usage-reconciled
+``actual_cost_usd``); admits/reserves are accounting holds, not spend.
+
+PROVIDER ATTRIBUTION IS HONEST-HEURISTIC and labeled as such in every
+output: the spend WAL does not carry an explicit provider field, so we
+attribute ``dw-*`` op-ids to DoubleWord and the rest to Claude (the Aegis
+daemon's two upstreams), rendered as ``claude(inferred)`` /
+``doubleword(inferred)`` so a reader never mistakes the heuristic for
+ground truth. The Anthropic/DW consoles remain the authoritative external
+numbers — this fabric is for *attribution shape* (which day, which route,
+which provider, how many calls), which consoles can't see per-op.
+
+Read-only, stdlib-only, NEVER raises. Surfaces:
+  * ``rollup_spend()`` / ``format_spend_report()`` — library
+  * ``/spend`` REPL verb (serpent_flow) — live in-session
+  * ``python3 -m backend.core.ouroboros.governance.accounting_ledger`` —
+    host-side CLI over the bind-mounted ``.jarvis`` (works on a dead
+    container too).
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+__all__ = ["SpendRollup", "rollup_spend", "format_spend_report"]
+
+
+@dataclass
+class SpendRollup:
+    total_usd: float = 0.0
+    calls: int = 0
+    by_day: Dict[str, float] = field(default_factory=dict)
+    by_provider: Dict[str, float] = field(default_factory=dict)
+    by_route: Dict[str, float] = field(default_factory=dict)
+    by_day_provider: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    ledger_files: int = 0
+    skipped_lines: int = 0
+
+
+def _provider_of(op_id: str) -> str:
+    """Honest heuristic — labeled '(inferred)' everywhere it surfaces."""
+    if str(op_id).startswith("dw-"):
+        return "doubleword(inferred)"
+    return "claude(inferred)"
+
+
+def _day_of(ts: float) -> str:
+    try:
+        return time.strftime("%Y-%m-%d", time.gmtime(float(ts)))
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def rollup_spend(*, jarvis_dir: Optional[Path] = None) -> SpendRollup:
+    """Aggregate every reconcile record across the live spend WAL + all
+    rotation backups. NEVER raises — garbage lines are counted+skipped."""
+    r = SpendRollup()
+    try:
+        base = Path(jarvis_dir) if jarvis_dir else Path(
+            os.environ.get("JARVIS_DIR", ".jarvis"),
+        )
+        pattern = str(base / "aegis" / "spend.jsonl*")
+        for f in sorted(glob.glob(pattern)):
+            r.ledger_files += 1
+            try:
+                lines = Path(f).read_text(encoding="utf-8").splitlines()
+            except Exception:  # noqa: BLE001
+                continue
+            for line in lines:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    d = json.loads(line)
+                except Exception:  # noqa: BLE001
+                    r.skipped_lines += 1
+                    continue
+                if d.get("kind") != "reconcile":
+                    continue
+                cost = d.get("actual_cost_usd")
+                if not isinstance(cost, (int, float)) or cost <= 0:
+                    continue
+                cost = float(cost)
+                day = _day_of(d.get("ts", 0))
+                prov = _provider_of(d.get("op_id", ""))
+                route = str(d.get("route") or "unknown")
+                r.total_usd += cost
+                r.calls += 1
+                r.by_day[day] = r.by_day.get(day, 0.0) + cost
+                r.by_provider[prov] = r.by_provider.get(prov, 0.0) + cost
+                r.by_route[route] = r.by_route.get(route, 0.0) + cost
+                r.by_day_provider.setdefault(day, {})
+                r.by_day_provider[day][prov] = (
+                    r.by_day_provider[day].get(prov, 0.0) + cost
+                )
+    except Exception:  # noqa: BLE001
+        pass
+    return r
+
+
+def format_spend_report(r: SpendRollup) -> str:
+    """Scannable day x provider x route matrix. NEVER raises."""
+    try:
+        out = [
+            f"TOTAL reconciled spend: ${r.total_usd:.2f} across {r.calls} "
+            f"billable calls ({r.ledger_files} ledger file(s), "
+            f"{r.skipped_lines} garbage line(s) skipped)",
+            "",
+            "by provider (op-id heuristic — inferred, consoles are "
+            "authoritative):",
+        ]
+        for k, v in sorted(r.by_provider.items(), key=lambda x: -x[1]):
+            out.append(f"  {k:24} ${v:.2f}")
+        out.append("")
+        out.append("by route:")
+        for k, v in sorted(r.by_route.items(), key=lambda x: -x[1]):
+            out.append(f"  {k:24} ${v:.2f}")
+        out.append("")
+        out.append("by day x provider:")
+        for day in sorted(r.by_day_provider):
+            cell = "  ".join(
+                f"{p.split('(')[0]}=${v:.2f}"
+                for p, v in sorted(r.by_day_provider[day].items())
+            )
+            out.append(f"  {day}  {cell}  (day total ${r.by_day[day]:.2f})")
+        return "\n".join(out)
+    except Exception:  # noqa: BLE001
+        return f"TOTAL: ${r.total_usd:.2f} ({r.calls} calls)"
+
+
+def main() -> int:  # pragma: no cover — host-side CLI
+    import argparse
+    ap = argparse.ArgumentParser(
+        description="O+V spend attribution over the Aegis spend WAL",
+    )
+    ap.add_argument("--jarvis-dir", default=".jarvis")
+    args = ap.parse_args()
+    print(format_spend_report(rollup_spend(jarvis_dir=Path(args.jarvis_dir))))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -8144,11 +8144,19 @@ class ClaudeProvider:
 
         # Zero-Waste S1 (D2): MCP discovery + lean/full prompt build
         # extracted into _assemble_codegen_prompt (low-risk extract).
+        # Slice 224 — P2a call-site wire (closes the 'on_without_sink_falls_
+        # back' gap): collect the stable tool-catalog/schema blocks here and
+        # fold them into the CACHED system prefix below, so the biggest fixed
+        # prompt blocks ride Anthropic's ~90%-cheaper cache instead of being
+        # re-billed in the volatile user prompt every op. Local per-call list
+        # -> concurrency-safe. Empty unless JARVIS_PROMPT_PREFIX_CACHE_ENABLED.
+        _p2a_stable_prefix: List[str] = []
         prompt_text, _mcp_tools, _preloaded_files = (
             await self._assemble_codegen_prompt(
                 context=context,
                 repo_root=repo_root,
                 repair_context=repair_context,
+                stable_prefix_out=_p2a_stable_prefix,
             )
         )
         # Build messages array for multi-turn conversation
@@ -8316,8 +8324,14 @@ class ClaudeProvider:
             # Env-gated via JARVIS_CLAUDE_PROMPT_CACHE_ENABLED /
             # JARVIS_CLAUDE_PROMPT_CACHE_MIN_CHARS. On a cache hit, cached
             # input tokens cost $0.30/M instead of $3.00/M (90% savings).
-            _system_with_cache = self._build_cached_system_blocks(
+            _p2a_sys_base = (
                 _CODEGEN_SYSTEM_PROMPT
+                if not _p2a_stable_prefix
+                else _CODEGEN_SYSTEM_PROMPT + "\n\n"
+                + "\n\n".join(_p2a_stable_prefix)
+            )
+            _system_with_cache = self._build_cached_system_blocks(
+                _p2a_sys_base
             )
 
             # Streaming: use stream() for token-by-token output via TUI callback.
@@ -9191,6 +9205,7 @@ class ClaudeProvider:
         context: "OperationContext",
         repo_root: Optional[Path],
         repair_context: Optional[Any],
+        stable_prefix_out: Optional[List[str]] = None,
     ) -> Tuple[str, Any, List[str]]:
         """Zero-Waste S1 (D2) extract — MCP tools discovery + lean/
         full prompt build. Pulled out of :meth:`generate` so the
@@ -9223,6 +9238,7 @@ class ClaudeProvider:
                 force_full_content=True,
                 mcp_tools=_mcp_tools,
                 preloaded_out=_preloaded_files,
+                stable_prefix_out=stable_prefix_out,
             )
             logger.info(
                 "[ClaudeAPI] Using lean prompt "

--- a/docker-compose.dw-cortex-soak.yml
+++ b/docker-compose.dw-cortex-soak.yml
@@ -150,6 +150,16 @@ services:
       # direct — premium tokens reserved for human-reflex + strategic work.
       # Source-discriminated; interactive sessions byte-identical. ──
       JARVIS_SOAK_SENSOR_DEMOTION_ENABLED: "1"
+      # ── Slice 224 — Token-Economic Accounting Fabric. ──
+      # P2a prompt-prefix cache: the Venom tool catalog + output schema (the
+      # biggest FIXED blocks, previously re-billed in full every op) now ride
+      # the cached system prefix (~90% cheaper on hits). Builder logic was
+      # proven by 7 pre-existing tests; Slice 224 closed the missing call-site
+      # wire. Verify live via get_cache_stats hit-rate.
+      JARVIS_PROMPT_PREFIX_CACHE_ENABLED: "1"
+      # Hourly burn-rate cap (the '$26 can never vanish in a day' rail) —
+      # Aegis budget state machine denies premium dispatch past this rate.
+      JARVIS_AEGIS_HOURLY_BURN_CAP_USD: "2.00"
       GCM_INTERACTIVE: "never"
       JARVIS_GIT_ORIGIN_SLUG: "drussell23/JARVIS"
       JARVIS_GIT_AUTHOR_NAME: "Ouroboros+Venom"

--- a/progress.txt
+++ b/progress.txt
@@ -105,3 +105,11 @@
                  Priority 0.75: headless + test_failure -> STANDARD (DW primary, rescue preserved).
                  Source-discriminated (S208-safe: not a self-elevatable label). Two-lane QoS pool
                  build stays gated on the b5nai4cms watch verdict (starvation with noise quieted?).
+  [x] slice-224  token-economic accounting fabric: (1) P2a prompt-prefix cache COMPLETED —
+                 builder logic pre-existed (7 tests green) but NO call-site passed the sink
+                 ('on_without_sink_falls_back'); wired generate() -> _assemble_codegen_prompt ->
+                 fold into cached system blocks (concurrency-safe local). Tool catalog + schema
+                 now ~90% cheaper on cache hits. (2) accounting_ledger.py + /spend verb + CLI:
+                 day x provider(inferred) x route rollups over aegis spend WAL incl. backups.
+                 (3) JARVIS_AEGIS_HOURLY_BURN_CAP_USD=2.00 pinned (rate rail). Honest: provider
+                 attribution is op-id heuristic, LABELED inferred; consoles stay authoritative.

--- a/tests/governance/test_slice224_accounting_fabric.py
+++ b/tests/governance/test_slice224_accounting_fabric.py
@@ -1,0 +1,86 @@
+"""Slice 224 — Token-Economic Accounting Fabric.
+
+(1) accounting_ledger.py: read-only rollups over the Aegis spend WAL
+    (.jarvis/aegis/spend.jsonl*) answering 'where did the money go' by
+    day x provider x route. Provider attribution is HONEST-heuristic: the
+    spend WAL doesn't carry an explicit provider field, so we attribute by
+    op-id prefix (dw-* = doubleword) + route topology (immediate=claude-
+    direct), and label it 'inferred' in the output.
+(2) The P2a call-site wire: generate() now passes stable_prefix_out into
+    _assemble_codegen_prompt -> _build_lean_codegen_prompt, and folds the
+    returned stable blocks into the CACHED system prefix (the
+    'on_without_sink_falls_back' gap closed).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backend.core.ouroboros.governance.accounting_ledger import (
+    rollup_spend, format_spend_report,
+)
+
+_GOV = Path(__file__).resolve().parents[2] / "backend" / "core" \
+    / "ouroboros" / "governance"
+
+
+def _write_ledger(tmp_path, rows):
+    d = tmp_path / "aegis"; d.mkdir(parents=True, exist_ok=True)
+    p = d / "spend.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return tmp_path
+
+
+def _rec(op, route, cost, ts):
+    return {"kind": "reconcile", "op_id": op, "route": route,
+            "actual_cost_usd": cost, "ts": ts}
+
+
+def test_rollup_by_day_provider_route(tmp_path):
+    base = 1781290000  # 2026-06-12 UTC
+    root = _write_ledger(tmp_path, [
+        _rec("op-aaa", "immediate", 0.03, base),
+        _rec("op-bbb", "standard", 0.01, base),
+        _rec("dw-123", "standard", 0.0005, base),
+        _rec("op-ccc", "immediate", 0.02, base + 86400),  # next day
+        {"kind": "admit", "op_id": "op-zzz", "route": "standard",
+         "estimated_cost_usd": 0.05, "ts": base},  # admits NOT counted
+    ])
+    r = rollup_spend(jarvis_dir=root)
+    assert abs(r.total_usd - 0.0605) < 1e-9
+    assert r.by_provider["claude(inferred)"] > r.by_provider["doubleword(inferred)"]
+    assert r.by_route["immediate"] == 0.05
+    assert len(r.by_day) == 2
+    assert r.calls == 4
+
+
+def test_rollup_includes_backups_and_never_raises(tmp_path):
+    root = _write_ledger(tmp_path, [_rec("op-a", "standard", 0.01, 1781290000)])
+    bak = root / "aegis" / "spend.jsonl.bak-pre-bt-1"
+    bak.write_text(json.dumps(_rec("op-b", "standard", 0.02, 1781290000)) + "\n"
+                   + "NOT JSON\n")
+    r = rollup_spend(jarvis_dir=root)
+    assert abs(r.total_usd - 0.03) < 1e-9  # backups counted, garbage skipped
+
+
+def test_rollup_missing_dir_safe(tmp_path):
+    r = rollup_spend(jarvis_dir=tmp_path / "nope")
+    assert r.total_usd == 0.0 and r.calls == 0
+
+
+def test_report_renders_all_dimensions(tmp_path):
+    root = _write_ledger(tmp_path, [_rec("op-a", "immediate", 0.03, 1781290000)])
+    out = format_spend_report(rollup_spend(jarvis_dir=root))
+    assert "TOTAL" in out and "immediate" in out and "claude(inferred)" in out
+    assert "inferred" in out  # the honesty label
+
+
+def test_p2a_callsite_wired():
+    """The 'on_without_sink_falls_back' gap is closed: generate's assembly
+    passes a stable_prefix sink and folds it into the cached system base."""
+    src = (_GOV / "providers.py").read_text(encoding="utf-8")
+    assert "stable_prefix_out=_p2a_stable_prefix" in src
+    assert "_p2a_stable_prefix" in src.split("def _assemble_codegen_prompt")[0]
+    # fold into the CACHED system blocks (at the CALL-site, not the def)
+    call_idx = src.index("self._build_cached_system_blocks(")
+    assert "_p2a_sys_base" in src[call_idx - 600:call_idx + 200]


### PR DESCRIPTION
**P2a completed, not rebuilt**: builder logic pre-existed (7 green tests) but no call-site passed the sink — the suite's own `on_without_sink_falls_back` documented it. 3 edits wire generate() → assembly → fold into the cached system blocks: the tool catalog + schema (biggest fixed blocks, previously re-billed every op) now ride the ~90%-cheaper cache. Gated; OFF byte-identical.

**accounting_ledger.py + /spend verb + host CLI**: day × provider × route rollups over the Aegis spend WAL (+ backups, garbage-tolerant). Provider attribution is an op-id heuristic **labeled '(inferred)'** — consoles stay authoritative.

**Burn-RATE rail**: `JARVIS_AEGIS_HOURLY_BURN_CAP_USD=2.00` pinned. Declined wiring it to SensorGovernor (Aegis enforces it itself — duplication). 12 green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the P2a prompt‑prefix cache into the cached system prompt to cut input token spend on cache hits (~90%) with no behavior change when disabled. Added a read‑only spend ledger with a `/spend` report and host CLI, and set an hourly burn‑rate cap.

- **Performance**
  - Fold stable tool catalog + schema into cached system blocks in `generate()` via `_p2a_stable_prefix` and `stable_prefix_out`, gated by `JARVIS_PROMPT_PREFIX_CACHE_ENABLED`.
  - Byte‑identical when off; per‑call state is concurrency‑safe.

- **New Features**
  - New `accounting_ledger.py`: rollups by day × provider `(inferred)` × route from `.jarvis/aegis/spend.jsonl*` (includes backups, garbage‑tolerant); consoles remain authoritative for totals.
  - New `/spend` REPL verb and CLI: `python3 -m backend.core.ouroboros.governance.accounting_ledger --jarvis-dir .jarvis`.
  - Burn‑rate rail: `JARVIS_AEGIS_HOURLY_BURN_CAP_USD=2.00` enforced by Aegis.

<sup>Written for commit 796866681fa0458c632d5b2372b07a7cdb165822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

