### PR TITLE
Slice 237 + 237b: op-weight-scaled convergence (seventh-layer fix) — threshold + final-write reserve

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -3797,6 +3797,24 @@ class DoublewordProvider:
                 )
             except Exception:  # noqa: BLE001 — defensive
                 _eb_observer = None
+            # ── Slice 237 — op weight for convergence scaling ──
+            # The DW provider is the path heavy multi-file GOAL ops take when DW is
+            # sovereign (Claude breaker OPEN) — exactly where tool_loop_deadline_
+            # exceeded fired. Reuse the SAME op-weight signal the Slice-235 gate
+            # reads (resolve_force_full_content at :1647): providers._max_target_
+            # line_count over the SAME target_files + self._repo_root, so
+            # convergence scaling cannot drift from the gate. None on any miss →
+            # the tool loop's static threshold (byte-identical).
+            _op_weight_lines: Optional[int] = None
+            try:
+                from backend.core.ouroboros.governance.providers import (
+                    _max_target_line_count as _dw_max_lines,
+                )
+                _op_weight_lines = _dw_max_lines(
+                    getattr(context, "target_files", ()) or (), self._repo_root,
+                )
+            except Exception:  # noqa: BLE001 — never block the tool loop
+                _op_weight_lines = None
             try:
                 raw, tool_records_list = await self._tool_loop.run(
                     prompt=prompt,
@@ -3808,6 +3826,7 @@ class DoublewordProvider:
                     risk_tier=getattr(context, "risk_tier", None),
                     is_read_only=bool(getattr(context, "is_read_only", False)),
                     per_round_observer=_eb_observer,
+                    op_weight_lines=_op_weight_lines,
                 )
             finally:
                 try:

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -5346,6 +5346,20 @@ class PrimeProvider:
                 )
             except Exception:  # noqa: BLE001 — never block tool loop
                 _evidence_override = None
+            # ── Slice 237 — op weight for convergence scaling ──
+            # The largest target-file line count is the SAME op-weight signal the
+            # Slice-235 gate reads (resolve_force_full_content), computed via the
+            # SAME helper + the SAME repo_root — so the tool loop's "force
+            # convergence earlier on heavy ops" decision cannot drift from the
+            # gate's "this is a large-file op" decision. None on any miss → the
+            # tool loop falls back to its static threshold (byte-identical).
+            _op_weight_lines: Optional[int] = None
+            try:
+                _op_weight_lines = _max_target_line_count(
+                    getattr(context, "target_files", ()) or (), self._repo_root,
+                )
+            except Exception:  # noqa: BLE001 — never block the tool loop
+                _op_weight_lines = None
             try:
                 raw, tool_records_list = await self._tool_loop.run(
                     prompt=prompt,
@@ -5358,6 +5372,7 @@ class PrimeProvider:
                     is_read_only=_is_read_only,
                     per_round_observer=_eb_observer,
                     repo_root_override=_evidence_override,
+                    op_weight_lines=_op_weight_lines,
                 )
             finally:
                 # Idempotent close — no-op when master flag off.
@@ -9331,6 +9346,15 @@ class ClaudeProvider:
                 )
             except Exception:  # noqa: BLE001 — never block tool loop
                 _evidence_override = None
+            # ── Slice 237 — op weight for convergence scaling (see DW/Prime
+            # sites). Same op-weight signal the gate reads; None → byte-identical.
+            _op_weight_lines: Optional[int] = None
+            try:
+                _op_weight_lines = _max_target_line_count(
+                    getattr(context, "target_files", ()) or (), self._repo_root,
+                )
+            except Exception:  # noqa: BLE001 — never block the tool loop
+                _op_weight_lines = None
             raw, tool_records_list = await self._tool_loop.run(
                 prompt=prompt_text,
                 generate_fn=_generate_raw,
@@ -9341,6 +9365,7 @@ class ClaudeProvider:
                 risk_tier=getattr(context, "risk_tier", None),
                 is_read_only=bool(getattr(context, "is_read_only", False)),
                 repo_root_override=_evidence_override,
+                op_weight_lines=_op_weight_lines,
             )
             tool_records = tuple(tool_records_list)
             tool_rounds = len(tool_records_list)

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -4624,6 +4624,85 @@ def _should_force_convergence(
     return cumulative_explore_calls >= threshold
 
 
+# ---------------------------------------------------------------------------
+# Slice 237 — op-weight-scaled convergence (the "seventh layer" fix).
+#
+# The Slice-85 cumulative threshold above is STATIC. Heavy multi-file GOAL ops
+# burn 25-45s of the deadline per round (large context → high TTFT + generation
+# + tool-exec), so the loop completes only 1-3 rounds and the wall-clock deadline
+# fires before the static threshold accrues — the convergence trigger engages too
+# late and the op dies with tool_loop_deadline_exceeded. The fix REUSES the same
+# trigger: it scales the threshold DOWN in proportion to op weight (the largest
+# target file's line count — the SAME signal the Slice-235 gate reads), so the
+# existing _should_force_convergence fires EARLIER on heavy ops while light /
+# unknown ops keep the full budget (byte-identical). Not a deadline bump.
+# ---------------------------------------------------------------------------
+
+
+def _convergence_heavy_lines() -> int:
+    """Target-file line count above which an op is "heavy" and its cumulative
+    exploration budget is scaled DOWN toward earlier convergence. Default 800
+    (mirrors the diff-schema large-file boundary). Env
+    ``JARVIS_TOOL_LOOP_CONVERGENCE_HEAVY_LINES``. Invalid / non-positive →
+    default. NEVER raises."""
+    raw = os.environ.get("JARVIS_TOOL_LOOP_CONVERGENCE_HEAVY_LINES", "").strip()
+    if not raw:
+        return 800
+    try:
+        v = int(raw)
+        return v if v > 0 else 800
+    except ValueError:
+        return 800
+
+
+def _convergence_min_calls() -> int:
+    """Floor for the op-weight-scaled convergence threshold — even the heaviest
+    op gets at least this many read-only calls to localize before convergence is
+    forced. Default 4. Env ``JARVIS_TOOL_LOOP_CONVERGENCE_MIN_CALLS``. Invalid /
+    non-positive → default. NEVER raises."""
+    raw = os.environ.get("JARVIS_TOOL_LOOP_CONVERGENCE_MIN_CALLS", "").strip()
+    if not raw:
+        return 4
+    try:
+        v = int(raw)
+        return v if v > 0 else 4
+    except ValueError:
+        return 4
+
+
+def scale_convergence_threshold(
+    *, base_threshold, target_line_count, heavy_lines=None, min_calls=None,
+) -> int:
+    """Scale the cumulative-explore convergence ``base_threshold`` to op weight so
+    the EXISTING ``_should_force_convergence`` axis engages EARLIER on heavy
+    multi-file ops (whose high per-round latency would otherwise blow the deadline
+    before a static threshold is reached). Scales inversely to weight
+    (``target_line_count / heavy_lines``), floored at ``min_calls`` and capped at
+    ``base_threshold`` (scaling only ever REDUCES). Light / unknown ops (≤ the
+    heavy boundary or no line count) keep the full base threshold — byte-identical.
+    ``base_threshold <= 0`` (operator opted out of the axis) is respected verbatim.
+    Pure; NEVER raises → fail-soft to ``base_threshold``."""
+    try:
+        base = int(base_threshold)
+        if base <= 0:
+            return base  # axis disabled — respect the opt-out
+        hl = int(heavy_lines) if heavy_lines is not None else _convergence_heavy_lines()
+        mc = int(min_calls) if min_calls is not None else _convergence_min_calls()
+        if hl <= 0:
+            return base
+        if not isinstance(target_line_count, int) or target_line_count <= hl:
+            return base  # light / unknown → unchanged
+        ratio = target_line_count / float(hl)  # > 1 for a heavy op
+        scaled = int(base / ratio)
+        floor = mc if mc > 0 else 1
+        return max(floor, min(base, scaled))
+    except Exception:  # noqa: BLE001 — fail-soft
+        try:
+            return int(base_threshold)
+        except Exception:  # noqa: BLE001
+            return 0
+
+
 # ── Slice 233 — parse-gate enforcement of convergence ──
 # The Slice 3E nudge is ADVISORY: it tells the model "tool calls will be
 # IGNORED" but nothing stops it from emitting read-only navigation on the grace
@@ -5459,6 +5538,13 @@ class ToolLoopCoordinator:
         # fix composes the same path-validation contract the Advisor
         # already uses — no parallel resolver, no shared-state mutation.
         # Default ``None`` preserves byte-identical legacy behavior.
+        op_weight_lines: Optional[int] = None,
+        # Slice 237 — op weight (largest target-file line count, the SAME signal
+        # the Slice-235 gate reads). Scales the cumulative-convergence threshold
+        # DOWN for heavy multi-file ops so convergence engages before the per-round
+        # latency blows the deadline. ``None`` / light ops → byte-identical (the
+        # static Slice-85 threshold). The caller computes it via the existing
+        # ``providers._max_target_line_count``; no parallel weight calc here.
     ) -> Tuple[str, List[ToolExecutionRecord]]:
         """Multi-turn tool loop with parallel execution support.
 
@@ -5543,7 +5629,14 @@ class ToolLoopCoordinator:
         # Slice 85 Phase 3 — cumulative read-only-call counter (evasion-proof
         # convergence axis; mixed-tool wandering still accrues here).
         _cumulative_explore_calls = 0
-        _convergence_call_threshold = _convergence_explore_call_threshold()
+        # Slice 237 — scale the static Slice-85 threshold DOWN by op weight so a
+        # heavy multi-file op forces convergence EARLIER (before its per-round
+        # latency burns the deadline). op_weight_lines=None / light ops → the
+        # base threshold verbatim (byte-identical).
+        _convergence_call_threshold = scale_convergence_threshold(
+            base_threshold=_convergence_explore_call_threshold(),
+            target_line_count=op_weight_lines,
+        )
         _soft_overflow_warned = False
         # ── Slice 3E — convergence-force final-write nudge ──
         # ``_final_nudge_issued`` flips True when the final-write nudge

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -4703,6 +4703,60 @@ def scale_convergence_threshold(
             return 0
 
 
+def _final_write_reserve_max_fraction() -> float:
+    """Max fraction of the total tool-loop budget the op-weight-scaled final-write
+    reserve may claim. Heavy ops reserve MORE for the (large) forced write, but
+    never so much that exploration is starved entirely. Default 0.5. Env
+    ``JARVIS_TOOL_LOOP_FINAL_WRITE_RESERVE_MAX_FRACTION``. Out-of-range / invalid →
+    default. NEVER raises."""
+    raw = os.environ.get(
+        "JARVIS_TOOL_LOOP_FINAL_WRITE_RESERVE_MAX_FRACTION", "",
+    ).strip()
+    if not raw:
+        return 0.5
+    try:
+        v = float(raw)
+        return v if 0.0 < v <= 1.0 else 0.5
+    except ValueError:
+        return 0.5
+
+
+def scale_final_write_reserve(
+    *, base_reserve, total_budget_s, target_line_count,
+    heavy_lines=None, max_fraction=None,
+) -> float:
+    """Scale the final-write RESERVE UP for heavy ops so the forced final write
+    has budget to emit a large multi-file diff — the COMPLEMENT to
+    ``scale_convergence_threshold`` (firing convergence earlier is useless if only
+    ~10s is held back for the write). Scales with weight
+    (``target_line_count / heavy_lines``), never below ``base_reserve`` and capped
+    at ``max_fraction`` of ``total_budget_s`` (so exploration is never fully
+    starved). This is a REALLOCATION within the existing budget, NOT a deadline
+    bump. Light / unknown ops → ``base_reserve`` (byte-identical). Pure; NEVER
+    raises → fail-soft to ``base_reserve``."""
+    try:
+        base = float(base_reserve)
+        tot = float(total_budget_s)
+        if tot <= 0.0 or base < 0.0:
+            return base
+        hl = int(heavy_lines) if heavy_lines is not None else _convergence_heavy_lines()
+        mf = (
+            float(max_fraction) if max_fraction is not None
+            else _final_write_reserve_max_fraction()
+        )
+        if hl <= 0 or not isinstance(target_line_count, int) or target_line_count <= hl:
+            return base  # light / unknown → unchanged
+        ratio = target_line_count / float(hl)  # > 1 for a heavy op
+        scaled = base * ratio
+        cap = tot * mf
+        return max(base, min(scaled, cap))
+    except Exception:  # noqa: BLE001 — fail-soft
+        try:
+            return float(base_reserve)
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+
 # ── Slice 233 — parse-gate enforcement of convergence ──
 # The Slice 3E nudge is ADVISORY: it tells the model "tool calls will be
 # IGNORED" but nothing stops it from emitting read-only navigation on the grace
@@ -5405,20 +5459,37 @@ class ToolLoopCoordinator:
         """
         return list(self._last_edit_history)
 
-    def _build_budget_plan(self, deadline: float) -> BudgetPlan:
+    def _build_budget_plan(
+        self, deadline: float, op_weight_lines: Optional[int] = None,
+    ) -> BudgetPlan:
         """Construct a ``BudgetPlan`` for this ``run()`` invocation.
 
         Reads ``deadline - time.monotonic()`` at call time so the plan
         reflects the **actual** budget available when the tool loop starts
         (not when the coordinator was constructed).
+
+        Slice 237 — scales the final-write reserve UP by op weight so a heavy
+        multi-file op holds back enough budget to actually emit its (large)
+        forced final write. Reallocation within the budget, not a deadline bump;
+        ``op_weight_lines=None`` / light ops → byte-identical legacy reserve.
         """
         total_budget_s = max(0.0, deadline - time.monotonic())
+        # Mirror BudgetPlan.build's default so op-weight scaling has a base to
+        # grow from (build() would otherwise compute this internally).
+        _base_reserve = self._final_write_reserve_s
+        if _base_reserve is None:
+            _base_reserve = min(_DEFAULT_FINAL_WRITE_RESERVE_S, total_budget_s * 0.25)
+        _reserve = scale_final_write_reserve(
+            base_reserve=_base_reserve,
+            total_budget_s=total_budget_s,
+            target_line_count=op_weight_lines,
+        )
         return BudgetPlan.build(
             total_budget_s=total_budget_s,
             hard_max_rounds=self._max_rounds,
             max_per_round_s=self._tool_timeout_s,
             min_per_round_s=self._min_per_round_s,
-            final_write_reserve_s=self._final_write_reserve_s,
+            final_write_reserve_s=_reserve,
         )
 
     async def _maybe_inline_permission_check(
@@ -5582,7 +5653,7 @@ class ToolLoopCoordinator:
         # ── Structural budget plan ──
         # Built once per run() so all timing decisions are derived from
         # the same consistent snapshot of the deadline.
-        plan = self._build_budget_plan(deadline)
+        plan = self._build_budget_plan(deadline, op_weight_lines=op_weight_lines)
         self._last_budget_plan = plan
         effective_max_rounds = plan.effective_max_rounds
 

--- a/tests/governance/test_slice237_convergence_op_weight.py
+++ b/tests/governance/test_slice237_convergence_op_weight.py
@@ -1,0 +1,179 @@
+"""Slice 237 — op-weight-scaled convergence (the "seventh layer" fix).
+
+Layer-7 (surfaced by the Slice 235/236 soak): heavy multi-file GOAL ops blow the
+generation deadline with `tool_loop_deadline_exceeded` BEFORE emitting a patch.
+Root cause (investigated, not guessed): the Slice 85 cumulative-convergence axis
+(`_should_force_convergence`) uses a STATIC threshold (default 14 read-only
+calls). On heavy ops each round burns 25-45s of the deadline (large multi-file
+context → high TTFT + generation + tool-exec), so the loop completes only 1-3
+rounds and the wall-clock deadline fires before 14 explore calls accrue — the
+convergence trigger never reaches its threshold. This is the Slice 233 convergence
+problem at scale: the machinery is correct, it just engages too late on heavy ops.
+
+Fix (reuse, don't rebuild): scale the EXISTING cumulative threshold DOWN for heavy
+ops so `_should_force_convergence` engages EARLIER — using the op-weight signal the
+gate already computes (`_max_target_line_count`), floored so heavy ops still get
+enough localization. Light / unknown ops keep the full base threshold
+(byte-identical). NOT a deadline bump, NOT a parallel convergence system.
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance import tool_executor as te
+
+
+class TestScaleConvergenceThreshold:
+    def test_light_op_keeps_base_threshold(self):
+        # at or below the heavy boundary → exploration unaffected (byte-identical)
+        out = te.scale_convergence_threshold(
+            base_threshold=14, target_line_count=400, heavy_lines=800, min_calls=4,
+        )
+        assert out == 14
+
+    def test_at_boundary_keeps_base(self):
+        out = te.scale_convergence_threshold(
+            base_threshold=14, target_line_count=800, heavy_lines=800, min_calls=4,
+        )
+        assert out == 14
+
+    def test_unknown_line_count_keeps_base(self):
+        out = te.scale_convergence_threshold(
+            base_threshold=14, target_line_count=None, heavy_lines=800, min_calls=4,
+        )
+        assert out == 14
+
+    def test_heavy_op_scales_down(self):
+        # the 3246-line semantic_index.py case: ratio ~4 → ~3 → floored at 4
+        out = te.scale_convergence_threshold(
+            base_threshold=14, target_line_count=3246, heavy_lines=800, min_calls=4,
+        )
+        assert out == 4
+        assert out < 14  # convergence forced EARLIER than the static threshold
+
+    def test_moderate_op_scales_proportionally(self):
+        # 1600 lines = 2x boundary → base/2 = 7
+        out = te.scale_convergence_threshold(
+            base_threshold=14, target_line_count=1600, heavy_lines=800, min_calls=4,
+        )
+        assert out == 7
+
+    def test_very_heavy_floored_at_min_calls(self):
+        out = te.scale_convergence_threshold(
+            base_threshold=14, target_line_count=100000, heavy_lines=800, min_calls=4,
+        )
+        assert out == 4  # floored — even the heaviest op gets min localization
+
+    def test_never_exceeds_base(self):
+        # scaling only ever reduces; a heavy op can't get MORE budget than base
+        for n in (900, 1600, 3246, 50000):
+            out = te.scale_convergence_threshold(
+                base_threshold=14, target_line_count=n, heavy_lines=800, min_calls=4,
+            )
+            assert out <= 14
+
+    def test_disabled_axis_base_zero_respected(self):
+        # base 0 = operator opted out of the cumulative axis → stays 0 (never fires)
+        out = te.scale_convergence_threshold(
+            base_threshold=0, target_line_count=5000, heavy_lines=800, min_calls=4,
+        )
+        assert out == 0
+
+    def test_fail_soft_returns_base_on_bad_input(self):
+        out = te.scale_convergence_threshold(
+            base_threshold=14, target_line_count="oops", heavy_lines=800, min_calls=4,
+        )
+        assert out == 14
+
+    def test_defaults_pulled_from_env_when_omitted(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_TOOL_LOOP_CONVERGENCE_HEAVY_LINES", raising=False)
+        monkeypatch.delenv("JARVIS_TOOL_LOOP_CONVERGENCE_MIN_CALLS", raising=False)
+        # heavy op with defaults still scales below base
+        out = te.scale_convergence_threshold(base_threshold=14, target_line_count=4000)
+        assert isinstance(out, int) and 0 < out < 14
+
+
+class TestConvergenceWeightEnvKnobs:
+    def test_heavy_lines_default_and_env(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_TOOL_LOOP_CONVERGENCE_HEAVY_LINES", raising=False)
+        d = te._convergence_heavy_lines()
+        assert isinstance(d, int) and d > 0
+        monkeypatch.setenv("JARVIS_TOOL_LOOP_CONVERGENCE_HEAVY_LINES", "1200")
+        assert te._convergence_heavy_lines() == 1200
+        monkeypatch.setenv("JARVIS_TOOL_LOOP_CONVERGENCE_HEAVY_LINES", "-5")
+        assert te._convergence_heavy_lines() == d  # invalid → default
+
+    def test_min_calls_default_and_env(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_TOOL_LOOP_CONVERGENCE_MIN_CALLS", raising=False)
+        d = te._convergence_min_calls()
+        assert isinstance(d, int) and d > 0
+        monkeypatch.setenv("JARVIS_TOOL_LOOP_CONVERGENCE_MIN_CALLS", "6")
+        assert te._convergence_min_calls() == 6
+
+
+class TestComposedWithExistingTrigger:
+    """The scaled threshold makes the EXISTING _should_force_convergence engage
+    earlier on heavy ops — the whole point. Reuses the Slice 85 trigger verbatim."""
+
+    def test_heavy_op_converges_at_low_call_count(self):
+        thr = te.scale_convergence_threshold(
+            base_threshold=14, target_line_count=3246, heavy_lines=800, min_calls=4,
+        )
+        # a heavy op that has made 4 read-only calls now forces convergence,
+        # where the static threshold of 14 would have kept wandering
+        assert te._should_force_convergence(cumulative_explore_calls=4, threshold=thr) is True
+        assert te._should_force_convergence(cumulative_explore_calls=4, threshold=14) is False
+
+    def test_light_op_keeps_full_exploration(self):
+        thr = te.scale_convergence_threshold(
+            base_threshold=14, target_line_count=200, heavy_lines=800, min_calls=4,
+        )
+        # light op: 4 calls must NOT force convergence (full budget preserved)
+        assert te._should_force_convergence(cumulative_explore_calls=4, threshold=thr) is False
+
+
+class TestRunThreadsOpWeight:
+    """Wiring pins (mirrors test_slice85 style): the loop scales its threshold by
+    op weight, and the provider caller passes the existing op-weight signal."""
+
+    def test_run_accepts_op_weight_lines_param(self):
+        sig = inspect.signature(te.ToolLoopCoordinator.run)
+        assert "op_weight_lines" in sig.parameters
+
+    def test_run_loop_scales_threshold_by_op_weight(self):
+        src = inspect.getsource(te.ToolLoopCoordinator.run)
+        assert "scale_convergence_threshold(" in src, "loop must scale the threshold by op weight"
+        assert "op_weight_lines" in src
+        # still composes the existing cumulative trigger (not a replacement)
+        assert "_should_force_convergence(" in src
+
+    def test_provider_passes_op_weight_to_tool_loop(self):
+        from backend.core.ouroboros.governance import providers as pv
+        src = inspect.getsource(pv)
+        assert "op_weight_lines=" in src, "provider must thread op weight into the tool loop"
+        # reuses the EXISTING op-weight signal the gate computes (no parallel calc)
+        assert "_max_target_line_count(" in src
+
+    def test_doubleword_provider_passes_op_weight(self):
+        # The DW provider is THE path heavy GOAL ops take when DW is sovereign —
+        # it runs its own tool loop, so it must thread op weight too (the original
+        # providers-only pin missed this; the failing ops live here).
+        from backend.core.ouroboros.governance import doubleword_provider as dw
+        src = inspect.getsource(dw)
+        assert "op_weight_lines=" in src, "DW provider must thread op weight into its tool loop"
+        assert "_max_target_line_count" in src, "DW must reuse the gate's op-weight signal"
+
+    def test_all_tool_loop_run_sites_thread_op_weight(self):
+        # Every _tool_loop.run( call site must pass op_weight_lines — a site that
+        # forgets it silently reverts to the static threshold (the bug class that
+        # let the DW site slip the first pin).
+        from backend.core.ouroboros.governance import providers as pv
+        from backend.core.ouroboros.governance import doubleword_provider as dw
+        for mod in (pv, dw):
+            src = inspect.getsource(mod)
+            run_calls = src.count("_tool_loop.run(")
+            weight_args = src.count("op_weight_lines=")
+            assert weight_args >= run_calls, (
+                f"{mod.__name__}: {run_calls} _tool_loop.run( site(s) but only "
+                f"{weight_args} op_weight_lines= — a site is unwired"
+            )

--- a/tests/governance/test_slice237_convergence_op_weight.py
+++ b/tests/governance/test_slice237_convergence_op_weight.py
@@ -93,6 +93,75 @@ class TestScaleConvergenceThreshold:
         assert isinstance(out, int) and 0 < out < 14
 
 
+class TestScaleFinalWriteReserve:
+    """The complement to threshold scaling: scale the final-write RESERVE UP for
+    heavy ops so the forced final write has budget to emit a large multi-file diff
+    (firing convergence earlier is useless if only ~10s is held back for the
+    write). Reallocation WITHIN the budget — not a deadline bump."""
+
+    def test_light_op_keeps_base_reserve(self):
+        out = te.scale_final_write_reserve(
+            base_reserve=10.0, total_budget_s=600.0, target_line_count=300,
+            heavy_lines=800, max_fraction=0.5,
+        )
+        assert out == 10.0
+
+    def test_unknown_keeps_base_reserve(self):
+        out = te.scale_final_write_reserve(
+            base_reserve=10.0, total_budget_s=600.0, target_line_count=None,
+            heavy_lines=800, max_fraction=0.5,
+        )
+        assert out == 10.0
+
+    def test_heavy_op_scales_reserve_up(self):
+        # 3246 lines / 800 ≈ 4.06 → 10 * 4.06 ≈ 40.6 (well under the 300s cap)
+        out = te.scale_final_write_reserve(
+            base_reserve=10.0, total_budget_s=600.0, target_line_count=3246,
+            heavy_lines=800, max_fraction=0.5,
+        )
+        assert 40.0 <= out <= 41.5
+        assert out > 10.0  # heavy write gets MORE budget than the static 10s
+
+    def test_never_below_base(self):
+        out = te.scale_final_write_reserve(
+            base_reserve=10.0, total_budget_s=600.0, target_line_count=1000,
+            heavy_lines=800, max_fraction=0.5,
+        )
+        assert out >= 10.0
+
+    def test_capped_at_max_fraction_of_budget(self):
+        # an enormous op must not starve all exploration — reserve capped
+        out = te.scale_final_write_reserve(
+            base_reserve=10.0, total_budget_s=120.0, target_line_count=100000,
+            heavy_lines=800, max_fraction=0.5,
+        )
+        assert out == 60.0  # 0.5 * 120
+
+    def test_fail_soft_returns_base(self):
+        out = te.scale_final_write_reserve(
+            base_reserve=10.0, total_budget_s="bad", target_line_count=3246,
+            heavy_lines=800, max_fraction=0.5,
+        )
+        assert out == 10.0
+
+    def test_max_fraction_env_default_and_override(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_TOOL_LOOP_FINAL_WRITE_RESERVE_MAX_FRACTION", raising=False)
+        d = te._final_write_reserve_max_fraction()
+        assert isinstance(d, float) and 0.0 < d <= 1.0
+        monkeypatch.setenv("JARVIS_TOOL_LOOP_FINAL_WRITE_RESERVE_MAX_FRACTION", "0.4")
+        assert te._final_write_reserve_max_fraction() == 0.4
+
+
+class TestBudgetPlanScalesReserveByOpWeight:
+    def test_build_budget_plan_threads_and_scales_reserve(self):
+        src = inspect.getsource(te.ToolLoopCoordinator._build_budget_plan)
+        assert "scale_final_write_reserve(" in src, "budget plan must scale the reserve by op weight"
+        assert "op_weight_lines" in src
+        # and run() must pass op_weight_lines into _build_budget_plan
+        run_src = inspect.getsource(te.ToolLoopCoordinator.run)
+        assert "_build_budget_plan(" in run_src and "op_weight_lines" in run_src
+
+
 class TestConvergenceWeightEnvKnobs:
     def test_heavy_lines_default_and_env(self, monkeypatch):
         monkeypatch.delenv("JARVIS_TOOL_LOOP_CONVERGENCE_HEAVY_LINES", raising=False)


### PR DESCRIPTION
Lands the convergence-layer (seventh-layer) fix on its own merit: correct, tested, live-verified to engage. It is **necessary but not sufficient** for the full heavy-GOAL capstone (the residual is the sentinel-amplification + cascade layers, tracked separately) — but a validated improvement shouldn't sit unmerged waiting on layers beneath it.

## Problem
Heavy multi-file GOAL ops die with `tool_loop_deadline_exceeded` before emitting a patch. Root cause (investigated, not guessed): the Slice-85 `_should_force_convergence` cumulative threshold (14) is **static and op-weight-blind**, and the `final_write_reserve_s` (~10s) is too. Heavy ops burn 25-45s/round, complete only 1-3 rounds, and blow the wall-clock deadline before convergence trips — and even when it trips, ~10s isn't enough to emit a heavy diff.

## Fix (reuses existing machinery — no parallel system, no deadline bump)
- **237** — `scale_convergence_threshold`: scales the existing cumulative threshold **down** by op weight (`target_line_count / heavy_lines`, floored at `min_calls`) so convergence fires earlier on heavy ops.
- **237b** — `scale_final_write_reserve`: scales the existing `final_write_reserve_s` **up** by op weight (capped at 50% of budget) so the forced write has room — a reallocation *within* the budget.
- Both driven by the **same op-weight signal the Slice-235 gate reads** (`providers._max_target_line_count`, same `target_files` + `repo_root`) → no drift. Threaded via a new `op_weight_lines` param on `ToolLoopCoordinator.run`, wired at all 3 `_tool_loop.run(` sites (DoublewordProvider, PrimeProvider, ClaudeProvider).
- `op_weight_lines=None` / light ops / unknown line count → **byte-identical** legacy behavior. Env knobs: `JARVIS_TOOL_LOOP_CONVERGENCE_HEAVY_LINES` (800), `..._MIN_CALLS` (4), `..._FINAL_WRITE_RESERVE_MAX_FRACTION` (0.5).

For the 3246-line GOAL: threshold `14 → 4`, reserve `10s → ~41s`.

## Validation
27 TDD tests, **+0 regressions** (slice85/3e/233/3g/3d/scorer green). Live soak (bounded $5/40min/breaker-OPEN, 0 Claude calls): convergence verified engaging (op-weight `3246 → threshold 4`, nudge at `remaining=430s`); early `deadline_exhausted` **5** (was 31), `tool_loop_deadline_exceeded` **2** (was 6).

## Known follow-ups (separate slices, not in this PR)
- **(8) cascade-to-dead-Claude** (`terminal_quota`) — now the dominant residual; the sentinel re-walks every DW model re-running the doomed loop and STANDARD cascades to the credit-dead Claude. **Next.**
- (9) TestCoverageEnforcer scope amplification on heavy multi-file GOALs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scales the tool-loop convergence threshold down and the final-write reserve up based on op weight to stop heavy multi-file GOAL ops from timing out. No deadline increase; light or unknown ops keep legacy behavior.

- **Bug Fixes**
  - Added `scale_convergence_threshold` to reduce the cumulative explore-call threshold by largest target-file line count, floored at a min call count.
  - Added `scale_final_write_reserve` to grow the write reserve within the existing budget, capped by `JARVIS_TOOL_LOOP_FINAL_WRITE_RESERVE_MAX_FRACTION`.
  - Threaded `op_weight_lines` through `ToolLoopCoordinator.run` and all `_tool_loop.run(` call sites in providers and `doubleword_provider`, reusing `providers._max_target_line_count`; `None` preserves previous behavior.
  - Validation: 27 tests added. On a 3246-line GOAL, threshold `14 → 4` and reserve `~10s → ~41s`, with fewer early-deadline and deadline-exceeded errors. Env knobs: `JARVIS_TOOL_LOOP_CONVERGENCE_HEAVY_LINES`, `JARVIS_TOOL_LOOP_CONVERGENCE_MIN_CALLS`, `JARVIS_TOOL_LOOP_FINAL_WRITE_RESERVE_MAX_FRACTION`.

<sup>Written for commit bb6dfabc041ec4a4bf089cfd90c3475a1c1c2403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

