### PR TITLE
Slice 238 + 238b: cascade consults economic breaker (layer 8 — stop poisoning ops via dead Claude)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -85,6 +85,46 @@ _TIER0_BUDGET_FRACTION = float(os.environ.get("OUROBOROS_TIER0_BUDGET_FRACTION",
 _TIER0_MAX_WAIT_S = float(os.environ.get("OUROBOROS_TIER0_MAX_WAIT_S", "90"))
 _TIER1_MIN_RESERVE_S = float(os.environ.get("OUROBOROS_TIER1_MIN_RESERVE_S", "25"))
 
+
+# ---------------------------------------------------------------------------
+# Slice 238 — cascade-to-dead-Claude guard (layer 8).
+#
+# The sentinel's ``fallback_tolerance=cascade_to_claude`` path invoked
+# ``_call_fallback`` (the Claude lane) with NO breaker consult — so a DW
+# transient hiccup poisoned the op via the credit-dead Claude lane
+# (terminal_quota). The PRIMARY Claude lane already gates on the economic
+# breaker; this makes the cascade read the SAME source-of-truth (the read-only
+# ``doubleword_provider._claude_breaker_open`` predicate, no probe side-effect)
+# so when Claude is economically/transport OPEN the cascade is suppressed and the
+# op routes to the existing immortal DW-retry / clean-degrade branch instead.
+# ---------------------------------------------------------------------------
+
+
+def cascade_breaker_consult_enabled() -> bool:
+    """Master switch for the Slice-238 cascade breaker consult. Default TRUE —
+    failure-path-only (only changes behavior when the Claude breaker is OPEN,
+    which is exactly when cascading to it is wrong); breaker-CLOSED is byte-
+    identical to the legacy cascade. Kill switch is pure rollback. NEVER raises."""
+    raw = (os.environ.get("JARVIS_CASCADE_BREAKER_CONSULT_ENABLED", "true") or "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def should_cascade_to_claude(
+    *, has_fallback: bool, claude_breaker_open: bool, enabled: bool,
+) -> bool:
+    """Pure decision: should the sentinel actually cascade to the Claude fallback
+    after DW exhaustion? Cascade ONLY when a fallback is configured AND it is not
+    suppressed by an OPEN economic breaker. When *enabled* and the breaker is OPEN
+    (Claude known-dead), suppress the cascade (→ caller routes to the immortal
+    DW-retry / degrade branch). When *enabled* is False (kill switch), legacy
+    behavior: cascade iff a fallback exists. No env / breaker reads here — the
+    caller injects both — so this stays deterministic + unit-testable. Pure."""
+    if not has_fallback:
+        return False
+    if enabled and claude_breaker_open:
+        return False  # Claude lane is dead — do not poison the op via it
+    return True
+
 # Complexity-aware multipliers applied on top of _TIER0_BUDGET_FRACTION.
 # Higher complexity => more time for DW 397B code generation.
 _TIER0_COMPLEXITY_MULTIPLIER: Dict[str, float] = {
@@ -3932,8 +3972,37 @@ class CandidateGenerator:
                 f"dw_severed_queued:"
                 f"{(last_failure or 'all_models_open')[:120]}"
             )
+        # cascade_to_claude — Claude is the explicit cost contract, BUT only when
+        # the Claude lane is actually alive. Slice 238: consult the SAME economic
+        # breaker the primary lane respects (read-only ``_claude_breaker_open`` —
+        # no probe side-effect) before cascading. When it is OPEN (Claude
+        # economically/transport dead) the cascade is suppressed and the op routes
+        # to the immortal DW-retry / clean-degrade branch below instead of
+        # poisoning the op via a known-dead lane (terminal_quota). Breaker CLOSED
+        # → byte-identical legacy cascade (a funded Claude is used normally).
+        _claude_lane_open = False
+        try:
+            from backend.core.ouroboros.governance.doubleword_provider import (
+                _claude_breaker_open as _cascade_breaker_open,
+            )
+            _claude_lane_open = _cascade_breaker_open()
+        except Exception:  # noqa: BLE001 — advisory; never block dispatch
+            _claude_lane_open = False
+        _do_cascade = should_cascade_to_claude(
+            has_fallback=self._fallback is not None,
+            claude_breaker_open=_claude_lane_open,
+            enabled=cascade_breaker_consult_enabled(),
+        )
+        if not _do_cascade and self._fallback is not None and _claude_lane_open:
+            logger.warning(
+                "[CandidateGenerator] Slice238 cascade-to-claude SUPPRESSED: "
+                "Claude breaker OPEN (economic/transport) — not poisoning op via "
+                "the known-dead lane (terminal_quota); routing to immortal "
+                "DW-retry/degrade (op=%s, last=%s)",
+                op_id_short, (last_failure or "?")[:60],
+            )
         # cascade_to_claude — Claude is the explicit cost contract.
-        if self._fallback is None:
+        if not _do_cascade:
             # Slice 180 — THE IMMORTAL EXECUTION LAYER. Raising here DELETES the op (the
             # soak's all_providers_exhausted bleed). With NO fallback configured, exhausting
             # is unacceptable. Instead → QUEUE_ONLY: exponential-backoff and RE-ATTEMPT the

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -5347,6 +5347,20 @@ class CandidateGenerator:
         os.environ.get("JARVIS_BG_READONLY_SYNTHESIS_RESERVE_S", "180.0")
     )
 
+    def _fallback_is_claude(self) -> bool:
+        """Slice 238 — True iff the configured fallback is the Claude lane (so the
+        Claude economic breaker is the right health signal to gate it). Reads the
+        fallback's ``provider_name`` (e.g. ``claude-api``); a non-Claude fallback
+        (e.g. Prime) returns False so the Claude breaker never suppresses it.
+        NEVER raises → fail-soft to False (legacy: don't suppress)."""
+        try:
+            if self._fallback is None:
+                return False
+            name = (getattr(self._fallback, "provider_name", "") or "").strip().lower()
+            return "claude" in name
+        except Exception:  # noqa: BLE001
+            return False
+
     async def _call_fallback(
         self,
         context: OperationContext,
@@ -5422,6 +5436,41 @@ class CandidateGenerator:
                 deadline=deadline,
                 disabled_routes=os.environ.get(_DISABLE_FALLBACK_ROUTES_ENV, ""),
             )
+
+        # Slice 238 — cascade breaker consult (CENTRAL seam). The s237 soak proved
+        # the cascade-to-dead-Claude poison (BadRequestError 400 → terminal_quota →
+        # cooldown cycle) reaches Claude from EVERY _call_fallback caller, not just
+        # the sentinel cascade_to_claude path. Guard it here, where all callers
+        # converge: when the fallback IS the Claude lane AND the economic breaker
+        # is OPEN (read-only _claude_breaker_open — same source-of-truth the
+        # primary lane respects, no probe side-effect), do NOT call the known-dead
+        # lane. Raise the EXISTING fallback_skipped sentinel (Slice 19b — NOT
+        # counted toward ExhaustionWatcher hibernation) so the op degrades cleanly
+        # instead of burning a 400 and poisoning the consecutive-failure counter.
+        # Breaker CLOSED → byte-identical (a funded Claude fallback is used).
+        if cascade_breaker_consult_enabled() and self._fallback_is_claude():
+            _claude_lane_open = False
+            try:
+                from backend.core.ouroboros.governance.doubleword_provider import (
+                    _claude_breaker_open as _cf_breaker_open,
+                )
+                _claude_lane_open = _cf_breaker_open()
+            except Exception:  # noqa: BLE001 — advisory; never block dispatch
+                _claude_lane_open = False
+            if _claude_lane_open:
+                logger.warning(
+                    "[CandidateGenerator] Slice238 fallback SUPPRESSED (central): "
+                    "Claude lane breaker OPEN (economic/transport) — skipping the "
+                    "known-dead Claude fallback (no terminal_quota poison); "
+                    "raising fallback_skipped so the op degrades cleanly "
+                    "(route=%s)", _op_route or "?",
+                )
+                self._raise_exhausted(
+                    "fallback_skipped:claude_breaker_open",
+                    context=context,
+                    deadline=deadline,
+                    fallback_state="economic_open",
+                )
 
         _pre_sem_remaining = self._remaining_seconds(deadline)
         _sem_t0 = time.monotonic()

--- a/tests/governance/test_slice238_cascade_breaker.py
+++ b/tests/governance/test_slice238_cascade_breaker.py
@@ -1,0 +1,94 @@
+"""Slice 238 — cascade-to-dead-Claude fix (layer 8).
+
+The s237 soak made this the dominant residual: on a STANDARD-route op, when DW
+models fail (transient transport hiccup), the sentinel applies
+``fallback_tolerance=cascade_to_claude`` and calls ``_call_fallback`` → the Claude
+lane → but Claude is economically dead (credit balance too low, HTTP 400) →
+``circuit_breaker_tripped:terminal_quota`` → ForegroundCooldown retry cycle.
+
+Investigated root cause (candidate_generator.py:3989): the cascade path reads NO
+breaker state — it blindly invokes the configured Claude fallback. The PRIMARY
+Claude lane gates on the economic breaker (``get_claude_circuit_breaker()`` /
+``_claude_breaker_open``); the cascade bypasses it entirely.
+
+Fix REUSES the same source-of-truth: consult the read-only ``_claude_breaker_open``
+predicate (no probe side-effect) before cascading. When the breaker is OPEN
+(Claude economically/transport dead), do NOT cascade into a known-dead lane —
+route to the EXISTING Slice-180 immortal DW-retry / clean-degrade path (the same
+branch the no-fallback case already uses). Breaker CLOSED → byte-identical legacy
+cascade (when Claude is funded, the cascade works normally). No hardcoded
+"never use Claude" — it reads the live breaker state.
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance import candidate_generator as cg
+
+
+class TestShouldCascadeToClaude:
+    def test_breaker_closed_with_fallback_cascades(self):
+        # Claude funded (breaker CLOSED) → cascade works normally (legacy)
+        assert cg.should_cascade_to_claude(
+            has_fallback=True, claude_breaker_open=False, enabled=True,
+        ) is True
+
+    def test_breaker_open_with_fallback_suppresses(self):
+        # Claude economically dead (breaker OPEN) → do NOT cascade to it
+        assert cg.should_cascade_to_claude(
+            has_fallback=True, claude_breaker_open=True, enabled=True,
+        ) is False
+
+    def test_breaker_open_but_disabled_is_legacy(self):
+        # kill switch off → legacy behavior (cascade regardless), for rollback
+        assert cg.should_cascade_to_claude(
+            has_fallback=True, claude_breaker_open=True, enabled=False,
+        ) is True
+
+    def test_no_fallback_never_cascades(self):
+        # no Claude fallback configured → never cascade (regardless of breaker)
+        assert cg.should_cascade_to_claude(
+            has_fallback=False, claude_breaker_open=False, enabled=True,
+        ) is False
+        assert cg.should_cascade_to_claude(
+            has_fallback=False, claude_breaker_open=True, enabled=True,
+        ) is False
+
+    def test_pure_no_env_reads_in_source(self):
+        # the decision is pure — env/breaker reads happen at the caller, injected
+        src = inspect.getsource(cg.should_cascade_to_claude)
+        assert "os.environ" not in src
+        assert "get_claude_circuit_breaker" not in src
+
+
+class TestCascadeBreakerConsultFlag:
+    def test_default_enabled(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_CASCADE_BREAKER_CONSULT_ENABLED", raising=False)
+        assert cg.cascade_breaker_consult_enabled() is True
+
+    def test_explicit_off(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CASCADE_BREAKER_CONSULT_ENABLED", "false")
+        assert cg.cascade_breaker_consult_enabled() is False
+
+
+class TestDispatchWiresBreakerConsult:
+    """Wiring pins (source-level, mirrors the slice-237 style): the sentinel
+    dispatch consults the breaker before the cascade, reusing the canonical
+    read-only predicate — and routes a suppressed cascade to the existing
+    immortal/degrade branch, not a new path."""
+
+    def test_dispatch_consults_breaker_before_cascade(self):
+        src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+        assert "should_cascade_to_claude(" in src, "dispatch must consult the cascade decision"
+        # reuses the canonical read-only economic-breaker predicate (no probe side-effect)
+        assert "_claude_breaker_open" in src
+        # the decision is consulted BEFORE the _call_fallback cascade
+        decide_idx = src.index("should_cascade_to_claude(")
+        fallback_idx = src.rindex("_call_fallback(")
+        assert decide_idx < fallback_idx
+
+    def test_suppressed_cascade_reuses_immortal_degrade_branch(self):
+        # a breaker-OPEN suppression must route to the EXISTING immortal DW-retry
+        # branch (Slice 180), not invent a new degrade path
+        src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
+        assert "immortal" in src.lower()

--- a/tests/governance/test_slice238_cascade_breaker.py
+++ b/tests/governance/test_slice238_cascade_breaker.py
@@ -92,3 +92,41 @@ class TestDispatchWiresBreakerConsult:
         # branch (Slice 180), not invent a new degrade path
         src = inspect.getsource(cg.CandidateGenerator._dispatch_via_sentinel)
         assert "immortal" in src.lower()
+
+
+class TestFallbackIsClaude:
+    """The Claude breaker only gates the Claude lane — a non-Claude fallback
+    (e.g. Prime) must never be suppressed by it."""
+
+    def _stub(self, provider_name):
+        from types import SimpleNamespace
+        stub = SimpleNamespace(_fallback=SimpleNamespace(provider_name=provider_name))
+        return cg.CandidateGenerator._fallback_is_claude(stub)
+
+    def test_claude_fallback_detected(self):
+        assert self._stub("claude-api") is True
+        assert self._stub("Claude") is True
+
+    def test_non_claude_fallback_not_detected(self):
+        assert self._stub("doubleword-397b") is False
+        assert self._stub("j-prime") is False
+
+    def test_none_fallback_not_claude(self):
+        from types import SimpleNamespace
+        assert cg.CandidateGenerator._fallback_is_claude(
+            SimpleNamespace(_fallback=None)
+        ) is False
+
+
+class TestCentralFallbackGuard:
+    """The CENTRAL seam: _call_fallback must suppress the dead Claude lane for
+    EVERY caller (not just the sentinel cascade — the s237 soak proved
+    BadRequestError 400 reached Claude from other _call_fallback callers too)."""
+
+    def test_call_fallback_consults_breaker_centrally(self):
+        src = inspect.getsource(cg.CandidateGenerator._call_fallback)
+        assert "_claude_breaker_open" in src, "central _call_fallback must consult the breaker"
+        assert "_fallback_is_claude" in src, "only suppress when the fallback IS Claude"
+        # reuses the existing non-hibernation fallback_skipped sentinel (Slice 19b)
+        assert "fallback_skipped:claude_breaker_open" in src
+        assert "cascade_breaker_consult_enabled" in src


### PR DESCRIPTION
Closes layer 8 — the dominant residual after the convergence fix (Slice 237). On a transient DW failure the sentinel/fallback path routed to the **credit-dead Claude lane**, producing `BadRequestError 400` → `circuit_breaker_tripped:terminal_quota` → cooldown-retry cycles.

## Root cause (investigated)
The cascade read **no breaker state** — it blindly invoked the configured Claude fallback. The PRIMARY Claude lane gates on the economic breaker (`get_claude_circuit_breaker` / `_claude_breaker_open`); the fallback path bypassed it. And the dead-Claude call reached Claude from **every** `_call_fallback` caller, not just the sentinel `cascade_to_claude` site.

## Fix (reuses the same source-of-truth; no second quota check)
- **238** — sentinel `cascade_to_claude`: consult the read-only `_claude_breaker_open` (no probe side-effect); when OPEN, suppress and route to the existing Slice-180 immortal DW-retry branch.
- **238b** — CENTRAL `_call_fallback` guard (where all callers converge): `_fallback_is_claude()` (via `provider_name`, so a non-Claude fallback like Prime is never suppressed) + breaker-OPEN → raise the EXISTING `fallback_skipped:claude_breaker_open` sentinel (Slice 19b — not counted toward hibernation) instead of calling the dead lane.
- Gated `JARVIS_CASCADE_BREAKER_CONSULT_ENABLED` (default TRUE; failure-path-only — breaker CLOSED is byte-identical; a funded Claude fallback is used normally). No hardcoded "never use Claude".

## Validation (bounded soak, breaker-OPEN, $5/40min)
Worst-case run (total DW transport outage + economically-dead Claude): **`terminal_quota: 0`** (was 60), **`BadRequestError: 0`** (was 23), **`deadline_exhausted: 0`**, 32 suppressions (28 central + 4 sentinel), 50 clean `fallback_skipped`, **$0.00 spend**, 0 Claude calls. The system degrades cleanly instead of cascading into the dead lane and burning credits. (No op applied that run because DW itself was down — environmental; a DW-healthy run applies as Slice-237b showed.)

13 TDD tests, +0 regressions (pre-existing dispatch/slice159 failures proven independent via stash).

## Known follow-up
Layer 9 (TestCoverageEnforcer scope-amplifying a heavy multi-file GOAL into an 8-file test-gen task under one deadline) — the next scoped slice, holds the full heavy-GOAL capstone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cascading to a credit-dead Claude by consulting the economic breaker before any Claude fallback call, and routes to the existing DW retry/degrade path instead. Guard is centralized and flaggable, so behavior is unchanged when the breaker is closed.

- **Bug Fixes**
  - Sentinel cascade now checks `doubleword_provider._claude_breaker_open` via `should_cascade_to_claude`; when open, it skips Claude and uses the existing “immortal” DW retry/degrade path.
  - Centralized guard in `_call_fallback`: if the fallback is Claude and the breaker is open, raise `fallback_skipped:claude_breaker_open` (no hibernation impact) instead of calling Claude.
  - Added `_fallback_is_claude` to avoid suppressing non-Claude fallbacks.
  - Feature flag `JARVIS_CASCADE_BREAKER_CONSULT_ENABLED` (default `true`); breaker closed → identical behavior to before.
  - New tests in `tests/governance/test_slice238_cascade_breaker.py` cover decision logic, flag defaults, and wiring pins.

<sup>Written for commit 1445898eb57d39991f13e1e5e425a98a1bbcff27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

