### PR TITLE
Slice 239: Adaptive Test-Sharding — decouple test-gen from the heavy primary patch (layer 9)

### DIFF
--- a/backend/core/ouroboros/governance/intake/intent_envelope.py
+++ b/backend/core/ouroboros/governance/intake/intent_envelope.py
@@ -81,6 +81,15 @@ _VALID_SOURCES = frozenset({
     # — drift between that constant and this frozenset is caught by an
     # AST pin in the B.2.1 spine.
     "swe_bench_pro",
+    # Added 2026-06-13 for Slice 239 (Adaptive Test-Sharding). The
+    # TestCoverageEnforcer decouples a heavy GOAL's "generate tests for N
+    # uncovered files" requirement into a SEPARATE background op instead of
+    # inlining it into the primary patch prompt (which blew the deadline —
+    # layer 9 of the s235 capstone arc). Honest-source token: decoupled
+    # test-coverage work MUST NOT masquerade as `test_failure` / `backlog`.
+    # Routes BACKGROUND via routing_override (low-cost; never burns Claude
+    # budget); the resulting op still flows the full Iron Gate pipeline.
+    "test_coverage",
 })
 _VALID_URGENCIES = frozenset({"critical", "high", "normal", "low"})
 

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -106,6 +106,7 @@ _PRIORITY_MAP_DEFERRED: frozenset = frozenset({
     "meta_dormancy_alarm",
     "performance_regression",
     "security_advisory",
+    "test_coverage",  # Slice 239 — decoupled background test-gen (deferred tier)
     "todo_scanner",
     "vision_sensor",
     "web_intelligence",

--- a/backend/core/ouroboros/governance/intelligence_hooks.py
+++ b/backend/core/ouroboros/governance/intelligence_hooks.py
@@ -18,6 +18,7 @@ Boundary Principle:
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from pathlib import Path
@@ -47,6 +48,145 @@ _REVIEW_ALWAYS_PATHS: Tuple[str, ...] = (
 
 
 # ---------------------------------------------------------------------------
+# Slice 239 — Adaptive Test-Sharding & Asynchronous Enforcement (layer 9).
+#
+# When a heavy multi-file GOAL has >2 uncovered files AND the remaining budget is
+# tight, injecting "also generate N test files" into the PRIMARY op's prompt
+# balloons it past its deadline. Instead, compile an ISOLATED test-coverage
+# payload and emit it as a SEPARATE background signal into the existing
+# UnifiedIntakeRouter WAL queue (reuse make_envelope + router.ingest + the
+# intake→op pipeline) so the primary patch graduates cleanly and a later
+# independent op fulfils coverage. Adaptive (route/budget/complexity-scaled, no
+# hardcoded cap), env-tunable, gated, fail-soft (no router → legacy inline inject).
+# ---------------------------------------------------------------------------
+
+# Route-scaled budget floor: decouple when remaining_s drops below the route's
+# floor. base × per-route fraction (tighter routes decouple earlier). The base is
+# env-tunable; the fractions mirror the route cost/deadline tiers (CLAUDE.md §5).
+_TEST_SHARD_ROUTE_FRACTIONS: Dict[str, float] = {
+    "immediate": 0.5,     # ~45s of the 90s base — very tight reflex window
+    "standard": 0.67,     # ~60s
+    "complex": 1.0,       # ~90s
+    "background": 1.33,   # ~120s
+    "speculative": 2.0,   # ~180s
+}
+
+
+def test_sharding_enabled() -> bool:
+    """Master switch for adaptive test-sharding (layer 9). Default TRUE — gated +
+    fail-soft (no router → legacy inline inject) + only fires when budget is tight
+    AND >2 files are uncovered, so light/ample ops are byte-identical. NEVER raises."""
+    raw = (os.environ.get("JARVIS_TEST_SHARDING_ENABLED", "true") or "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _test_shard_min_uncovered() -> int:
+    """Minimum uncovered-file count to warrant a SEPARATE test-coverage op (the
+    ">2 files" gate). Below this, inline injection is cheap enough. Default 3.
+    Env JARVIS_TEST_SHARD_MIN_UNCOVERED. Invalid/non-positive → default."""
+    raw = (os.environ.get("JARVIS_TEST_SHARD_MIN_UNCOVERED", "") or "").strip()
+    if not raw:
+        return 3
+    try:
+        v = int(raw)
+        return v if v > 0 else 3
+    except ValueError:
+        return 3
+
+
+def _test_shard_budget_base_s() -> float:
+    """Base budget floor (seconds) for the decouple decision, scaled per route.
+    Default 90. Env JARVIS_TEST_SHARD_BUDGET_BASE_S. Invalid/non-positive → default."""
+    raw = (os.environ.get("JARVIS_TEST_SHARD_BUDGET_BASE_S", "") or "").strip()
+    if not raw:
+        return 90.0
+    try:
+        v = float(raw)
+        return v if v > 0 else 90.0
+    except ValueError:
+        return 90.0
+
+
+def _test_shard_budget_floor_s(provider_route: str) -> float:
+    """The route-scaled remaining-budget floor below which test-gen is decoupled."""
+    frac = _TEST_SHARD_ROUTE_FRACTIONS.get(
+        (provider_route or "standard").strip().lower(), 0.67,
+    )
+    return _test_shard_budget_base_s() * frac
+
+
+def should_decouple_test_gen(
+    *, provider_route: str, remaining_s, uncovered_count: int,
+    target_file_count: int = 1, complexity: str = "", enabled: bool = True,
+) -> bool:
+    """Pure adaptive decision: emit a SEPARATE background test-coverage op instead
+    of inlining the test-gen instruction into the primary op? Decouple ONLY when
+    enabled AND there are >2 uncovered files AND the budget can't sustain the load
+    — the budget floor scales to the route, and heavy/multi-file ops decouple with
+    more headroom. Light / ample ops → False (legacy inline inject, byte-identical).
+    No env / IO reads of the breaker here — all inputs injected → deterministic +
+    unit-testable. Pure; NEVER raises → fail-soft to False (inline)."""
+    try:
+        if not enabled:
+            return False
+        if int(uncovered_count) < _test_shard_min_uncovered():
+            return False  # ≤2 uncovered → inline is cheap enough
+        rem = float(remaining_s)
+        floor = _test_shard_budget_floor_s(provider_route)
+        if rem < floor:
+            return True
+        # Heavy / multi-file ops decouple with 1.5× headroom — their per-round
+        # latency makes an inlined N-file test-gen especially deadline-risky.
+        heavy = (complexity or "").strip().lower() in ("heavy_code", "complex")
+        multifile = int(target_file_count) >= 5
+        if (heavy or multifile) and rem < floor * 1.5:
+            return True
+        return False
+    except Exception:  # noqa: BLE001 — fail-soft to inline
+        return False
+
+
+def build_test_coverage_envelope(
+    *, uncovered_files, parent_op_id: str, repo: str = "jarvis",
+    description: str = "",
+):
+    """Compile the ISOLATED, dedup-stable test-coverage payload as an
+    IntentEnvelope (source=test_coverage, urgency=low, routing_override=background)
+    via the existing ``make_envelope``. The dedup signature is the sorted
+    uncovered set, so the SAME requirement re-emitted across parent retries
+    collapses to one background op. NEVER raises here is NOT promised — the caller
+    wraps the emit fail-soft (a bad envelope must not break the primary op)."""
+    from backend.core.ouroboros.governance.intake.intent_envelope import (
+        make_envelope as _make_envelope,
+    )
+    files = tuple(sorted({str(f) for f in (uncovered_files or ()) if str(f).strip()}))
+    sig = "test_coverage:" + hashlib.sha256(
+        "|".join(files).encode("utf-8"),
+    ).hexdigest()[:16]
+    desc = description or (
+        f"Generate test coverage for {len(files)} uncovered file(s) decoupled from "
+        f"patch op {str(parent_op_id)[:16]}: "
+        f"{', '.join(files[:3])}{'…' if len(files) > 3 else ''}"
+    )
+    return _make_envelope(
+        source="test_coverage",
+        description=desc,
+        target_files=files,
+        repo=repo or "jarvis",
+        confidence=0.9,
+        urgency="low",
+        evidence={
+            "signature": sig,
+            "uncovered_files": list(files),
+            "parent_op_id": str(parent_op_id),
+            "enforcer_reason": "budget_constraint",
+        },
+        requires_human_ack=False,
+        routing_override="background",
+    )
+
+
+# ---------------------------------------------------------------------------
 # 1. Test Coverage Enforcer (Pre-GENERATE)
 # ---------------------------------------------------------------------------
 
@@ -62,6 +202,28 @@ class TestCoverageEnforcer:
     def __init__(self, project_root: Path) -> None:
         self._project_root = project_root
 
+    def detect_uncovered(self, target_files: Tuple[str, ...]) -> List[str]:
+        """Pure detection (Slice 239): the source-of-truth list of target files
+        that lack test coverage. Skips test files, non-Python files, and
+        ``__init__``/``conftest``. Both the legacy inline injection
+        (``check_and_inject``) and the decoupled sharding path read THIS, so the
+        "which files need tests" decision can never drift. NEVER raises → []."""
+        uncovered: List[str] = []
+        try:
+            for rel_path in target_files or ():
+                if "test_" in rel_path or rel_path.endswith("_test.py"):
+                    continue
+                if not rel_path.endswith(".py"):
+                    continue
+                basename = Path(rel_path).stem
+                if basename in ("__init__", "conftest"):
+                    continue
+                if not self._find_test_file(rel_path):
+                    uncovered.append(rel_path)
+        except Exception:  # noqa: BLE001 — detection must never break the pipeline
+            return []
+        return uncovered
+
     def check_and_inject(
         self,
         target_files: Tuple[str, ...],
@@ -73,23 +235,7 @@ class TestCoverageEnforcer:
         if any target files lack test coverage. Returns None if all files
         are covered or if target files are themselves tests.
         """
-        uncovered: List[str] = []
-
-        for rel_path in target_files:
-            # Skip test files and non-Python files
-            if "test_" in rel_path or rel_path.endswith("_test.py"):
-                continue
-            if not rel_path.endswith(".py"):
-                continue
-            # Skip __init__.py and config files
-            basename = Path(rel_path).stem
-            if basename in ("__init__", "conftest"):
-                continue
-
-            # Look for corresponding test files
-            test_exists = self._find_test_file(rel_path)
-            if not test_exists:
-                uncovered.append(rel_path)
+        uncovered = self.detect_uncovered(target_files)
 
         if not uncovered:
             return None

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -3970,28 +3970,81 @@ class GovernedOrchestrator:
                 logger.debug("[Orchestrator] Adaptive learning injection failed", exc_info=True)
 
             # ── P0: Test Coverage Enforcer (pre-GENERATE) ─────────────────────
-            # If target files lack test coverage, inject instruction into the
-            # generation context so the provider generates tests alongside code.
+            # Slice 239 (adaptive test-sharding, layer 9): when budget is tight
+            # and >2 target files are uncovered, DECOUPLE the "generate tests"
+            # requirement into a SEPARATE background intake op (reusing the
+            # UnifiedIntakeRouter WAL queue) so the PRIMARY patch graduates the
+            # Iron Gate cleanly instead of ballooning past its deadline. Otherwise
+            # inline-inject the instruction (legacy). Fail-soft throughout: no
+            # router / emit failure / ample budget → inline injection.
             try:
                 from backend.core.ouroboros.governance.intelligence_hooks import (
                     TestCoverageEnforcer,
+                    should_decouple_test_gen,
+                    build_test_coverage_envelope,
+                    test_sharding_enabled,
                 )
                 _coverage_enforcer = TestCoverageEnforcer(self._config.project_root)
-                _coverage_instruction = _coverage_enforcer.check_and_inject(
-                    ctx.target_files, ctx.description,
-                )
-                if _coverage_instruction:
-                    _existing_human = getattr(ctx, "human_instructions", "") or ""
-                    ctx = dataclasses.replace(
-                        ctx,
-                        human_instructions=_existing_human + _coverage_instruction,
-                        previous_hash=ctx.context_hash,
-                    )
-                    logger.info(
-                        "[Orchestrator] TestCoverageEnforcer: injected test generation "
-                        "instruction for %d uncovered files (op=%s)",
-                        _coverage_instruction.count("`"), ctx.op_id,
-                    )
+                _uncovered = _coverage_enforcer.detect_uncovered(ctx.target_files)
+                _decoupled = False
+                if _uncovered:
+                    _remaining_s = float("inf")
+                    try:
+                        _dl = getattr(ctx, "pipeline_deadline", None)
+                        if _dl is not None:
+                            _remaining_s = (
+                                _dl - datetime.now(tz=timezone.utc)
+                            ).total_seconds()
+                    except Exception:  # noqa: BLE001
+                        _remaining_s = float("inf")
+                    if test_sharding_enabled() and should_decouple_test_gen(
+                        provider_route=getattr(ctx, "provider_route", "") or "standard",
+                        remaining_s=_remaining_s,
+                        uncovered_count=len(_uncovered),
+                        target_file_count=len(ctx.target_files or ()),
+                        complexity=str(getattr(ctx, "task_complexity", "") or ""),
+                        enabled=True,
+                    ):
+                        _gls = getattr(self._stack, "governed_loop_service", None)
+                        _router = getattr(_gls, "_intake_router", None) if _gls else None
+                        if _router is not None:
+                            try:
+                                _env = build_test_coverage_envelope(
+                                    uncovered_files=_uncovered,
+                                    parent_op_id=getattr(ctx, "op_id", "") or "",
+                                    repo=getattr(ctx, "repo", "") or "jarvis",
+                                )
+                                _ing = await _router.ingest(_env)
+                                _decoupled = True
+                                logger.info(
+                                    "[Orchestrator] Slice239 test-sharding: DECOUPLED "
+                                    "test-gen for %d uncovered file(s) → intake (%s); "
+                                    "primary patch graduates clean (op=%s)",
+                                    len(_uncovered), _ing, ctx.op_id,
+                                )
+                            except Exception:  # noqa: BLE001 — never break the primary op
+                                logger.debug(
+                                    "[Orchestrator] Slice239 decouple emit failed — "
+                                    "falling back to inline inject", exc_info=True,
+                                )
+                                _decoupled = False
+                    if not _decoupled:
+                        # Legacy inline injection (ample budget / no router / emit failed).
+                        _coverage_instruction = _coverage_enforcer.check_and_inject(
+                            ctx.target_files, ctx.description,
+                        )
+                        if _coverage_instruction:
+                            _existing_human = getattr(ctx, "human_instructions", "") or ""
+                            ctx = dataclasses.replace(
+                                ctx,
+                                human_instructions=_existing_human + _coverage_instruction,
+                                previous_hash=ctx.context_hash,
+                            )
+                            logger.info(
+                                "[Orchestrator] TestCoverageEnforcer: injected test "
+                                "generation instruction for %d uncovered file(s) (op=%s)",
+                                len(_uncovered), ctx.op_id,
+                            )
             except ImportError:
                 pass
             except Exception:

--- a/tests/governance/test_slice239_enforcer_sharding.py
+++ b/tests/governance/test_slice239_enforcer_sharding.py
@@ -1,0 +1,219 @@
+"""Slice 239 — Adaptive Test-Sharding & Asynchronous Enforcement (layer 9).
+
+The s235→238 arc closed budget/severance/paths/convergence/output-format/model-
+routing/cascade. The remaining heavy-GOAL blocker: the TestCoverageEnforcer
+INJECTS "generate tests for N uncovered files" into the PRIMARY op's prompt, so a
+heavy multi-file GOAL balloons into a patch + N-file test-gen task under one
+deadline → exhaustion (the s237/238 soaks confirmed TestCoverageEnforcer amplifies
+the heavy GOAL).
+
+Fix (decouple, don't cap): when budget is tight and there are >2 uncovered files,
+the enforcer compiles an ISOLATED test-coverage payload and emits it as a SEPARATE
+signal into the EXISTING UnifiedIntakeRouter WAL queue (reusing make_envelope +
+router.ingest + the intake→op pipeline — no new sub-agent kernel) so the PRIMARY
+patch graduates the Iron Gate cleanly while a later independent background op
+fulfils coverage. Adaptive (scales to route / budget / complexity from existing
+signals — no hardcoded cap), gated, fail-soft (no router → legacy inline inject).
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance import intelligence_hooks as ih
+from backend.core.ouroboros.governance.intake.intent_envelope import (
+    make_envelope,
+    _VALID_SOURCES,
+)
+
+
+class TestDetectUncovered:
+    def _enforcer(self, tmp_path):
+        return ih.TestCoverageEnforcer(tmp_path)
+
+    def test_detects_uncovered_py_modules(self, tmp_path):
+        enf = self._enforcer(tmp_path)
+        out = enf.detect_uncovered(("backend/a.py", "backend/b.py"))
+        assert set(out) == {"backend/a.py", "backend/b.py"}
+
+    def test_skips_test_and_non_py_and_dunder(self, tmp_path):
+        enf = self._enforcer(tmp_path)
+        out = enf.detect_uncovered((
+            "tests/test_a.py", "backend/b_test.py", "README.md",
+            "backend/__init__.py", "conftest.py", "backend/real.py",
+        ))
+        assert out == ["backend/real.py"]
+
+    def test_covered_file_excluded(self, tmp_path):
+        # a module WITH a test file present is not "uncovered"
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "test_covered.py").write_text("def test_x(): pass\n")
+        enf = self._enforcer(tmp_path)
+        out = enf.detect_uncovered(("backend/covered.py",))
+        assert out == []
+
+    def test_check_and_inject_still_works(self, tmp_path):
+        # legacy injection path must still produce an instruction (uses detect_uncovered)
+        enf = self._enforcer(tmp_path)
+        instr = enf.check_and_inject(("backend/a.py", "backend/b.py"), "desc")
+        assert instr and "test coverage" in instr.lower()
+
+
+class TestShouldDecoupleTestGen:
+    """The adaptive decision — INVARIANT 1: tight budget + >2 uncovered → decouple."""
+
+    def test_invariant1_tight_budget_many_uncovered_decouples(self):
+        # the headline: standard route, tight budget, 3 (>2) uncovered → decouple
+        assert ih.should_decouple_test_gen(
+            provider_route="standard", remaining_s=20.0, uncovered_count=3,
+            target_file_count=3, complexity="heavy_code", enabled=True,
+        ) is True
+
+    def test_ample_budget_keeps_inline(self):
+        # plenty of time → inject inline (legacy), even with many uncovered
+        assert ih.should_decouple_test_gen(
+            provider_route="standard", remaining_s=600.0, uncovered_count=5,
+            target_file_count=5, complexity="standard", enabled=True,
+        ) is False
+
+    def test_two_or_fewer_uncovered_never_decouples(self):
+        # ">2 uncovered" gate — 2 is not enough to warrant a separate op
+        assert ih.should_decouple_test_gen(
+            provider_route="immediate", remaining_s=1.0, uncovered_count=2,
+            target_file_count=2, complexity="heavy_code", enabled=True,
+        ) is False
+
+    def test_heavy_complexity_moderate_budget_decouples(self):
+        assert ih.should_decouple_test_gen(
+            provider_route="complex", remaining_s=100.0, uncovered_count=4,
+            target_file_count=4, complexity="heavy_code", enabled=True,
+        ) is True
+
+    def test_disabled_never_decouples(self):
+        assert ih.should_decouple_test_gen(
+            provider_route="standard", remaining_s=1.0, uncovered_count=9,
+            target_file_count=9, complexity="complex", enabled=False,
+        ) is False
+
+    def test_adaptive_route_scaled_floor(self):
+        # immediate route has a tighter floor than complex — same remaining_s,
+        # immediate decouples while complex (more headroom) may not
+        imm = ih.should_decouple_test_gen(
+            provider_route="immediate", remaining_s=50.0, uncovered_count=3,
+            target_file_count=3, complexity="standard", enabled=True,
+        )
+        cplx = ih.should_decouple_test_gen(
+            provider_route="complex", remaining_s=300.0, uncovered_count=3,
+            target_file_count=3, complexity="standard", enabled=True,
+        )
+        assert imm is False  # 50s is above the immediate floor (~45s) and not heavy
+        assert cplx is False  # 300s ample for complex
+        # but a tight immediate budget decouples
+        assert ih.should_decouple_test_gen(
+            provider_route="immediate", remaining_s=30.0, uncovered_count=3,
+            target_file_count=3, complexity="standard", enabled=True,
+        ) is True
+
+    def test_min_uncovered_env_tunable(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TEST_SHARD_MIN_UNCOVERED", "5")
+        # now 3 uncovered is below the (raised) floor → no decouple
+        assert ih.should_decouple_test_gen(
+            provider_route="standard", remaining_s=10.0, uncovered_count=3,
+            target_file_count=3, complexity="heavy_code", enabled=True,
+        ) is False
+
+    def test_fail_soft_false_on_bad_input(self):
+        assert ih.should_decouple_test_gen(
+            provider_route="standard", remaining_s="bad", uncovered_count=3,
+            target_file_count=3, complexity="x", enabled=True,
+        ) is False
+
+
+class TestShardingFlag:
+    def test_default_enabled(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_TEST_SHARDING_ENABLED", raising=False)
+        assert ih.test_sharding_enabled() is True
+
+    def test_explicit_off(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TEST_SHARDING_ENABLED", "false")
+        assert ih.test_sharding_enabled() is False
+
+
+class TestBuildTestCoverageEnvelope:
+    """The isolated payload — reuses make_envelope; routes BACKGROUND; dedup-stable."""
+
+    def test_valid_background_envelope(self):
+        env = ih.build_test_coverage_envelope(
+            uncovered_files=["backend/a.py", "backend/b.py", "backend/c.py"],
+            parent_op_id="op-parent-123", repo="jarvis",
+        )
+        assert env.source == "test_coverage"
+        assert env.urgency == "low"
+        assert env.routing_override == "background"
+        assert set(env.target_files) == {"backend/a.py", "backend/b.py", "backend/c.py"}
+        assert env.requires_human_ack is False
+
+    def test_dedup_signature_deterministic(self):
+        # same uncovered set (order-independent) → same dedup_key (re-emit suppressed)
+        a = ih.build_test_coverage_envelope(
+            uncovered_files=["backend/a.py", "backend/b.py"],
+            parent_op_id="op-1", repo="jarvis",
+        )
+        b = ih.build_test_coverage_envelope(
+            uncovered_files=["backend/b.py", "backend/a.py"],
+            parent_op_id="op-2", repo="jarvis",
+        )
+        assert a.dedup_key == b.dedup_key
+
+    def test_different_files_different_dedup(self):
+        a = ih.build_test_coverage_envelope(
+            uncovered_files=["backend/a.py"], parent_op_id="op-1", repo="jarvis",
+        )
+        b = ih.build_test_coverage_envelope(
+            uncovered_files=["backend/z.py"], parent_op_id="op-1", repo="jarvis",
+        )
+        assert a.dedup_key != b.dedup_key
+
+    def test_evidence_records_parent_and_signature(self):
+        env = ih.build_test_coverage_envelope(
+            uncovered_files=["backend/a.py", "backend/b.py", "backend/c.py"],
+            parent_op_id="op-parent-xyz", repo="jarvis",
+        )
+        assert env.evidence.get("signature")
+        assert env.evidence.get("parent_op_id") == "op-parent-xyz"
+
+
+class TestSourceRegistration:
+    def test_test_coverage_is_a_valid_source(self):
+        assert "test_coverage" in _VALID_SOURCES
+        # constructing one must not raise the source-validation error
+        env = make_envelope(
+            source="test_coverage", description="d", target_files=("a.py",),
+            repo="jarvis", confidence=0.9, urgency="low",
+            evidence={"signature": "sig"}, requires_human_ack=False,
+        )
+        assert env.source == "test_coverage"
+
+    def test_test_coverage_has_priority_tier(self):
+        from backend.core.ouroboros.governance.intake import unified_intake_router as r
+        # must be in the deferred (background) tier OR the priority map — not unmapped
+        in_deferred = "test_coverage" in r._PRIORITY_MAP_DEFERRED
+        in_map = "test_coverage" in r._PRIORITY_MAP
+        assert in_deferred or in_map
+
+
+class TestOrchestratorWiring:
+    """Source pins: the seam decouples via the router when the decision fires, and
+    fail-softs to legacy inline injection otherwise / when no router is available."""
+
+    def test_seam_consults_decouple_decision_and_emits(self):
+        from backend.core.ouroboros.governance import orchestrator as o
+        src = inspect.getsource(o)
+        assert "should_decouple_test_gen(" in src, "seam must consult the adaptive decision"
+        assert "build_test_coverage_envelope(" in src, "seam must compile the isolated payload"
+        assert "ingest(" in src, "decoupled payload must be emitted to the intake router"
+
+    def test_seam_failsoft_keeps_legacy_inject(self):
+        # the legacy check_and_inject path must remain as the fail-soft fallback
+        from backend.core.ouroboros.governance import orchestrator as o
+        src = inspect.getsource(o)
+        assert "check_and_inject(" in src


### PR DESCRIPTION
The last heavy-GOAL blocker in the s235→238 capstone arc. The TestCoverageEnforcer INJECTED "generate tests for N uncovered files" into the PRIMARY op's prompt, ballooning a heavy multi-file GOAL into patch + N-file test-gen under one deadline → exhaustion.

## Fix — decouple, don't cap; reuse the existing intake pipeline (no new kernel)
When budget is tight AND there are >2 uncovered files, the enforcer compiles an **isolated** test-coverage payload and emits it as a **separate background signal** into the `UnifiedIntakeRouter` WAL queue, so the primary patch graduates the Iron Gate cleanly and a later independent op fulfils coverage.

- `intelligence_hooks.py`: `detect_uncovered()` (shared source-of-truth), `should_decouple_test_gen()` (pure adaptive decision — route-scaled budget floor × >2-uncovered gate × heavy/multi-file boosters; **no hardcoded cap**, env-tunable), `build_test_coverage_envelope()` (isolated payload via existing `make_envelope`; dedup-stable signature so re-emits across retries collapse to one op), `test_sharding_enabled()` (default-TRUE, gated).
- `intent_envelope.py`: `test_coverage` registered as an honest source. `unified_intake_router.py`: deferred (background) priority tier.
- `orchestrator.py` pre-GENERATE seam: decouple → `router.ingest()` when the decision fires and a router is reachable; **fail-soft to legacy inline injection** otherwise (no router / emit failure / ample budget). The decoupled op flows the **full Iron Gate** — no ungated path.

## Validation
22 TDD tests (incl. Invariant 1: tight budget + >2 uncovered → isolated payload, not appended to prompt). **+0 real regressions** — the cross-file batch failures are pre-existing flaky goal-inference/intake singleton pollution, proven by re-running the clean tree (changes stashed) where they also fail (11 failures). My tests pass in isolation and in-file.

Capstone soak (Phase 5) is the next deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples test generation from the primary patch by emitting a separate background `test_coverage` intake when budget is tight and more than two files are uncovered, so the main patch can finish on time. Adds an adaptive, fail-soft decision and registers the new intake source.

- **New Features**
  - Decouple path: build a `test_coverage` envelope and ingest it to the background tier of the `UnifiedIntakeRouter`; avoid inlining N-file test-gen into the primary prompt.
  - Adaptive decision: route-scaled budget floor + “>2 uncovered” gate, with heavy/multi-file boosters; env-tunable (`JARVIS_TEST_SHARDING_ENABLED`, `JARVIS_TEST_SHARD_MIN_UNCOVERED`, `JARVIS_TEST_SHARD_BUDGET_BASE_S`).
  - Shared detection via `detect_uncovered()` used by both decoupled and inline paths.
  - Envelope: source=`test_coverage`, low urgency, background routing, dedup by sorted uncovered set.
  - Orchestrator seam: emit when the decision fires and a router is available; otherwise fall back to legacy inline injection. Decoupled ops run the full gated pipeline.
  - Tests: 22 cases covering detection, decision invariants, envelope dedup, source/priority registration, and orchestrator wiring.

<sup>Written for commit 1209bd5e7b4674abdaa2b54122142286acc9e569. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

