### PR TITLE
Slice 239b: wire adaptive test-sharding into the LIVE plan_runner seam

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/plan_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/plan_runner.py
@@ -751,26 +751,80 @@ class PLANRunner(PhaseRunner):
             logger.debug("[Orchestrator] Adaptive learning injection failed", exc_info=True)
 
         # ── P0: Test Coverage Enforcer (pre-GENERATE) ──
+        # Slice 239 (adaptive test-sharding, layer 9): this is the LIVE seam (the
+        # phase-runner refactor moved the enforcer here from orchestrator._run_
+        # pipeline). When budget is tight and >2 target files are uncovered,
+        # DECOUPLE the "generate tests" requirement into a SEPARATE background
+        # intake op (UnifiedIntakeRouter WAL queue) so the PRIMARY patch graduates
+        # the Iron Gate cleanly; else inline-inject (legacy). Fail-soft: no router
+        # / emit failure / ample budget → inline injection.
         try:
             from backend.core.ouroboros.governance.intelligence_hooks import (
                 TestCoverageEnforcer,
+                should_decouple_test_gen,
+                build_test_coverage_envelope,
+                test_sharding_enabled,
             )
             _coverage_enforcer = TestCoverageEnforcer(orch._config.project_root)
-            _coverage_instruction = _coverage_enforcer.check_and_inject(
-                ctx.target_files, ctx.description,
-            )
-            if _coverage_instruction:
-                _existing_human = getattr(ctx, "human_instructions", "") or ""
-                ctx = dataclasses.replace(
-                    ctx,
-                    human_instructions=_existing_human + _coverage_instruction,
-                    previous_hash=ctx.context_hash,
-                )
-                logger.info(
-                    "[Orchestrator] TestCoverageEnforcer: injected test generation "
-                    "instruction for %d uncovered files (op=%s)",
-                    _coverage_instruction.count("`"), ctx.op_id,
-                )
+            _uncovered = _coverage_enforcer.detect_uncovered(ctx.target_files)
+            _decoupled = False
+            if _uncovered:
+                _remaining_s = float("inf")
+                try:
+                    _dl = getattr(ctx, "pipeline_deadline", None)
+                    if _dl is not None:
+                        _remaining_s = (
+                            _dl - datetime.now(tz=timezone.utc)
+                        ).total_seconds()
+                except Exception:  # noqa: BLE001
+                    _remaining_s = float("inf")
+                if test_sharding_enabled() and should_decouple_test_gen(
+                    provider_route=getattr(ctx, "provider_route", "") or "standard",
+                    remaining_s=_remaining_s,
+                    uncovered_count=len(_uncovered),
+                    target_file_count=len(ctx.target_files or ()),
+                    complexity=str(getattr(ctx, "task_complexity", "") or ""),
+                    enabled=True,
+                ):
+                    _gls = getattr(orch._stack, "governed_loop_service", None)
+                    _router = getattr(_gls, "_intake_router", None) if _gls else None
+                    if _router is not None:
+                        try:
+                            _env = build_test_coverage_envelope(
+                                uncovered_files=_uncovered,
+                                parent_op_id=getattr(ctx, "op_id", "") or "",
+                                repo=getattr(ctx, "repo", "") or "jarvis",
+                            )
+                            _ing = await _router.ingest(_env)
+                            _decoupled = True
+                            logger.info(
+                                "[Orchestrator] Slice239 test-sharding: DECOUPLED "
+                                "test-gen for %d uncovered file(s) → intake (%s); "
+                                "primary patch graduates clean (op=%s)",
+                                len(_uncovered), _ing, ctx.op_id,
+                            )
+                        except Exception:  # noqa: BLE001 — never break the primary op
+                            logger.debug(
+                                "[Orchestrator] Slice239 decouple emit failed — "
+                                "falling back to inline inject", exc_info=True,
+                            )
+                            _decoupled = False
+                if not _decoupled:
+                    _coverage_instruction = _coverage_enforcer.check_and_inject(
+                        ctx.target_files, ctx.description,
+                    )
+                    if _coverage_instruction:
+                        _existing_human = getattr(ctx, "human_instructions", "") or ""
+                        ctx = dataclasses.replace(
+                            ctx,
+                            human_instructions=_existing_human + _coverage_instruction,
+                            previous_hash=ctx.context_hash,
+                        )
+                        logger.info(
+                            "[Orchestrator] TestCoverageEnforcer: injected test "
+                            "generation instruction for %d uncovered file(s) (op=%s)",
+                            len(_uncovered), ctx.op_id,
+                        )
         except ImportError:
             pass
         except Exception:

--- a/tests/governance/test_slice239_enforcer_sharding.py
+++ b/tests/governance/test_slice239_enforcer_sharding.py
@@ -217,3 +217,16 @@ class TestOrchestratorWiring:
         from backend.core.ouroboros.governance import orchestrator as o
         src = inspect.getsource(o)
         assert "check_and_inject(" in src
+
+    def test_live_plan_runner_seam_is_wired(self):
+        # The phase-runner refactor moved the LIVE test-coverage enforcement into
+        # plan_runner.py — the capstone soak proved THIS is the executing seam (the
+        # orchestrator copy was dormant). It MUST carry the decouple wiring too, or
+        # sharding silently never fires. Regression pin against that exact drift.
+        from backend.core.ouroboros.governance.phase_runners import plan_runner as pr
+        src = inspect.getsource(pr)
+        assert "should_decouple_test_gen(" in src
+        assert "build_test_coverage_envelope(" in src
+        assert "ingest(" in src
+        # the old backtick-count log must be gone (proof the old path was replaced)
+        assert "uncovered files (op" not in src


### PR DESCRIPTION
Slice 239 wired the decouple into `orchestrator._run_pipeline`, but the capstone soak proved (verify-first) that seam is **dormant** — the phase-runner refactor moved the live test-coverage enforcement into `phase_runners/plan_runner.py`. Runtime evidence: plan_runner's OLD backtick-count log fired (×2), ZERO new-format logs, ZERO decouple decisions; L9 never executed despite correct/attested bytecode. Same "wired-the-wrong-seam" class as the s238 `_call_fallback` catch.

Fix: replicate the decouple wiring in `plan_runner.run()` (the executing seam) — `detect_uncovered → should_decouple_test_gen → build_test_coverage_envelope → router.ingest`, fail-soft to inline `check_and_inject`. Adds a regression pin (`test_live_plan_runner_seam_is_wired`) so this drift can't recur. 23 tests green.

Note: observing L9 fire in a soak still needs a GOAL with >2 uncovered files; the current roadmap's heavy GOAL has 2, so it inlines (correct per the `>2` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires adaptive test-sharding into the live `plan_runner.run()` seam, fixing the dormant wiring in `orchestrator._run_pipeline`. This enables decoupling test generation to intake when budget is tight and more than two files are uncovered, with a fail‑soft fallback to inline injection.

- **Bug Fixes**
  - Implemented the decouple flow in `plan_runner.run()`: `detect_uncovered` → `should_decouple_test_gen` → `build_test_coverage_envelope` → `router.ingest`; fallback to `check_and_inject`.
  - Replaced the old backtick-count log with clear logs for decoupled and inline paths.
  - Added `test_live_plan_runner_seam_is_wired` to pin the live seam wiring and prevent regressions.

<sup>Written for commit 54c1e4c17c3b8e2422986de154902ecc746efb36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

