### PR TITLE
Slice 240 Phase 2: dynamic cost-vs-bandwidth shard trigger (strip the hardcoded >2 gate)

### DIFF
--- a/backend/core/ouroboros/governance/intelligence_hooks.py
+++ b/backend/core/ouroboros/governance/intelligence_hooks.py
@@ -60,88 +60,124 @@ _REVIEW_ALWAYS_PATHS: Tuple[str, ...] = (
 # hardcoded cap), env-tunable, gated, fail-soft (no router → legacy inline inject).
 # ---------------------------------------------------------------------------
 
-# Route-scaled budget floor: decouple when remaining_s drops below the route's
-# floor. base × per-route fraction (tighter routes decouple earlier). The base is
-# env-tunable; the fractions mirror the route cost/deadline tiers (CLAUDE.md §5).
-_TEST_SHARD_ROUTE_FRACTIONS: Dict[str, float] = {
-    "immediate": 0.5,     # ~45s of the 90s base — very tight reflex window
-    "standard": 0.67,     # ~60s
-    "complex": 1.0,       # ~90s
-    "background": 1.33,   # ~120s
-    "speculative": 2.0,   # ~180s
-}
+# Slice 240 — the decouple decision is now a DYNAMIC COST-vs-BANDWIDTH inequality
+# (no hardcoded file-count gate). Shard the test-gen to a background op iff the
+# mathematical cost of generating the tests EXCEEDS the live bandwidth of the
+# primary task window:
+#
+#     (Files_uncovered × Est_Tokens_per_file)  >  (Velocity_live × Budget_Remaining)
+#
+# The LHS (est_test_tokens) is derived from each uncovered file's ACTUAL line count
+# — data-driven, never a magic integer. The conversion ratios + the live velocity
+# baseline are env-tunable (no hardcoded thresholds). Light ops whose tests fit the
+# window stay inline (byte-identical); only ops whose test load can't fit decouple.
 
 
 def test_sharding_enabled() -> bool:
     """Master switch for adaptive test-sharding (layer 9). Default TRUE — gated +
-    fail-soft (no router → legacy inline inject) + only fires when budget is tight
-    AND >2 files are uncovered, so light/ample ops are byte-identical. NEVER raises."""
+    fail-soft (no router → legacy inline inject); only fires when the cost model
+    says the test load can't fit the primary window, so light/ample ops are
+    byte-identical. NEVER raises."""
     raw = (os.environ.get("JARVIS_TEST_SHARDING_ENABLED", "true") or "").strip().lower()
     return raw in ("1", "true", "yes", "on")
 
 
-def _test_shard_min_uncovered() -> int:
-    """Minimum uncovered-file count to warrant a SEPARATE test-coverage op (the
-    ">2 files" gate). Below this, inline injection is cheap enough. Default 3.
-    Env JARVIS_TEST_SHARD_MIN_UNCOVERED. Invalid/non-positive → default."""
-    raw = (os.environ.get("JARVIS_TEST_SHARD_MIN_UNCOVERED", "") or "").strip()
+def _env_float(name: str, default: float) -> float:
+    """Positive-float env reader (no hardcoded literals at the call sites). Invalid
+    / non-positive → default. NEVER raises."""
+    raw = (os.environ.get(name, "") or "").strip()
     if not raw:
-        return 3
-    try:
-        v = int(raw)
-        return v if v > 0 else 3
-    except ValueError:
-        return 3
-
-
-def _test_shard_budget_base_s() -> float:
-    """Base budget floor (seconds) for the decouple decision, scaled per route.
-    Default 90. Env JARVIS_TEST_SHARD_BUDGET_BASE_S. Invalid/non-positive → default."""
-    raw = (os.environ.get("JARVIS_TEST_SHARD_BUDGET_BASE_S", "") or "").strip()
-    if not raw:
-        return 90.0
+        return default
     try:
         v = float(raw)
-        return v if v > 0 else 90.0
+        return v if v > 0 else default
     except ValueError:
-        return 90.0
+        return default
 
 
-def _test_shard_budget_floor_s(provider_route: str) -> float:
-    """The route-scaled remaining-budget floor below which test-gen is decoupled."""
-    frac = _TEST_SHARD_ROUTE_FRACTIONS.get(
-        (provider_route or "standard").strip().lower(), 0.67,
-    )
-    return _test_shard_budget_base_s() * frac
+def _shard_tokens_per_line() -> float:
+    """Est tokens per source line (the lines→tokens conversion for the cost model).
+    Env JARVIS_TEST_SHARD_TOKENS_PER_LINE. Default 12.0 (empirical Python avg)."""
+    return _env_float("JARVIS_TEST_SHARD_TOKENS_PER_LINE", 12.0)
+
+
+def _shard_test_multiplier() -> float:
+    """Ratio of generated-test size to source size (a test file ≈ its module).
+    Env JARVIS_TEST_SHARD_TEST_MULTIPLIER. Default 1.0."""
+    return _env_float("JARVIS_TEST_SHARD_TEST_MULTIPLIER", 1.0)
+
+
+def _shard_velocity_tok_s() -> float:
+    """Live generation bandwidth baseline (tokens/sec) — Velocity_live in the cost
+    model. No per-op live throughput signal exists in the provider yet, so this is
+    an env-tunable baseline (the DW elite-pool steady-state). Env
+    JARVIS_TEST_SHARD_VELOCITY_TOK_S. Default 40.0."""
+    return _env_float("JARVIS_TEST_SHARD_VELOCITY_TOK_S", 40.0)
+
+
+def _shard_default_file_lines() -> float:
+    """Conservative line-count for an uncovered file that can't be read (so an
+    unresolvable path still contributes a real cost, never 0). Env
+    JARVIS_TEST_SHARD_DEFAULT_FILE_LINES. Default 200."""
+    return _env_float("JARVIS_TEST_SHARD_DEFAULT_FILE_LINES", 200.0)
+
+
+def estimate_test_gen_tokens(
+    *, uncovered_files, repo_root, tokens_per_line=None, test_multiplier=None,
+) -> float:
+    """Cost side (LHS) of the shard-trigger inequality: estimated tokens to GENERATE
+    tests for *uncovered_files*, derived from each file's ACTUAL line count
+    (× tokens/line × test-multiplier) — data-driven, NOT a hardcoded per-file
+    constant. An unreadable path contributes a conservative default so it is never
+    free. Pure (only reads file sizes); NEVER raises → 0.0 on total failure."""
+    try:
+        tpl = float(tokens_per_line) if tokens_per_line is not None else _shard_tokens_per_line()
+        mult = float(test_multiplier) if test_multiplier is not None else _shard_test_multiplier()
+        root = Path(repo_root) if repo_root is not None else None
+        total = 0.0
+        for rel in (uncovered_files or ()):
+            lines = 0
+            try:
+                if root is not None:
+                    p = root / str(rel)
+                    if p.is_file():
+                        lines = len(p.read_text(encoding="utf-8", errors="replace").splitlines())
+            except Exception:  # noqa: BLE001 — unreadable file → conservative default
+                lines = 0
+            if lines <= 0:
+                lines = int(_shard_default_file_lines())
+            total += float(lines) * tpl * mult
+        return max(0.0, total)
+    except Exception:  # noqa: BLE001
+        return 0.0
 
 
 def should_decouple_test_gen(
-    *, provider_route: str, remaining_s, uncovered_count: int,
-    target_file_count: int = 1, complexity: str = "", enabled: bool = True,
+    *, est_test_tokens, velocity_tok_s, remaining_s, enabled: bool = True,
 ) -> bool:
-    """Pure adaptive decision: emit a SEPARATE background test-coverage op instead
-    of inlining the test-gen instruction into the primary op? Decouple ONLY when
-    enabled AND there are >2 uncovered files AND the budget can't sustain the load
-    — the budget floor scales to the route, and heavy/multi-file ops decouple with
-    more headroom. Light / ample ops → False (legacy inline inject, byte-identical).
-    No env / IO reads of the breaker here — all inputs injected → deterministic +
-    unit-testable. Pure; NEVER raises → fail-soft to False (inline)."""
+    """Dynamic shard-trigger (Slice 240) — NO hardcoded file-count gate. Decouple
+    test-gen to a background op iff the mathematical cost of generating the tests
+    exceeds the live bandwidth of the primary task window:
+
+        est_test_tokens  >  velocity_tok_s × remaining_s
+
+    i.e. ``(Files × Est_Tokens_per_file) > (Velocity_live × Budget_Remaining)``.
+    An unbounded budget (remaining_s == inf) never shards; a depleted budget
+    (remaining_s ≤ 0) with real cost always shards (it can't possibly fit inline).
+    All inputs injected → deterministic + unit-testable. Pure; fail-soft → False."""
     try:
         if not enabled:
             return False
-        if int(uncovered_count) < _test_shard_min_uncovered():
-            return False  # ≤2 uncovered → inline is cheap enough
+        cost = float(est_test_tokens)
+        if cost <= 0.0:
+            return False  # nothing to generate → inline (no-op)
         rem = float(remaining_s)
-        floor = _test_shard_budget_floor_s(provider_route)
-        if rem < floor:
-            return True
-        # Heavy / multi-file ops decouple with 1.5× headroom — their per-round
-        # latency makes an inlined N-file test-gen especially deadline-risky.
-        heavy = (complexity or "").strip().lower() in ("heavy_code", "complex")
-        multifile = int(target_file_count) >= 5
-        if (heavy or multifile) and rem < floor * 1.5:
-            return True
-        return False
+        if rem == float("inf"):
+            return False  # no deadline pressure → keep inline
+        if rem <= 0.0:
+            return True   # no budget left → cannot fit inline, decouple
+        vel = float(velocity_tok_s)
+        return cost > vel * rem
     except Exception:  # noqa: BLE001 — fail-soft to inline
         return False
 

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -3983,6 +3983,8 @@ class GovernedOrchestrator:
                     should_decouple_test_gen,
                     build_test_coverage_envelope,
                     test_sharding_enabled,
+                    estimate_test_gen_tokens,
+                    _shard_velocity_tok_s,
                 )
                 _coverage_enforcer = TestCoverageEnforcer(self._config.project_root)
                 _uncovered = _coverage_enforcer.detect_uncovered(ctx.target_files)
@@ -3997,12 +3999,17 @@ class GovernedOrchestrator:
                             ).total_seconds()
                     except Exception:  # noqa: BLE001
                         _remaining_s = float("inf")
+                    # Slice 240 — dynamic cost-vs-bandwidth shard trigger (no
+                    # hardcoded file-count gate): decouple iff the estimated tokens
+                    # to generate the tests exceed velocity × remaining budget.
+                    _est_test_tokens = estimate_test_gen_tokens(
+                        uncovered_files=_uncovered,
+                        repo_root=self._config.project_root,
+                    )
                     if test_sharding_enabled() and should_decouple_test_gen(
-                        provider_route=getattr(ctx, "provider_route", "") or "standard",
+                        est_test_tokens=_est_test_tokens,
+                        velocity_tok_s=_shard_velocity_tok_s(),
                         remaining_s=_remaining_s,
-                        uncovered_count=len(_uncovered),
-                        target_file_count=len(ctx.target_files or ()),
-                        complexity=str(getattr(ctx, "task_complexity", "") or ""),
                         enabled=True,
                     ):
                         _gls = getattr(self._stack, "governed_loop_service", None)

--- a/backend/core/ouroboros/governance/phase_runners/plan_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/plan_runner.py
@@ -764,6 +764,8 @@ class PLANRunner(PhaseRunner):
                 should_decouple_test_gen,
                 build_test_coverage_envelope,
                 test_sharding_enabled,
+                estimate_test_gen_tokens,
+                _shard_velocity_tok_s,
             )
             _coverage_enforcer = TestCoverageEnforcer(orch._config.project_root)
             _uncovered = _coverage_enforcer.detect_uncovered(ctx.target_files)
@@ -778,12 +780,17 @@ class PLANRunner(PhaseRunner):
                         ).total_seconds()
                 except Exception:  # noqa: BLE001
                     _remaining_s = float("inf")
+                # Slice 240 — dynamic cost-vs-bandwidth shard trigger (no hardcoded
+                # file-count gate): decouple iff estimated test-gen tokens exceed
+                # velocity × remaining budget.
+                _est_test_tokens = estimate_test_gen_tokens(
+                    uncovered_files=_uncovered,
+                    repo_root=orch._config.project_root,
+                )
                 if test_sharding_enabled() and should_decouple_test_gen(
-                    provider_route=getattr(ctx, "provider_route", "") or "standard",
+                    est_test_tokens=_est_test_tokens,
+                    velocity_tok_s=_shard_velocity_tok_s(),
                     remaining_s=_remaining_s,
-                    uncovered_count=len(_uncovered),
-                    target_file_count=len(ctx.target_files or ()),
-                    complexity=str(getattr(ctx, "task_complexity", "") or ""),
                     enabled=True,
                 ):
                     _gls = getattr(orch._stack, "governed_loop_service", None)

--- a/tests/governance/test_slice239_enforcer_sharding.py
+++ b/tests/governance/test_slice239_enforcer_sharding.py
@@ -58,74 +58,112 @@ class TestDetectUncovered:
         assert instr and "test coverage" in instr.lower()
 
 
+class TestEstimateTestGenTokens:
+    """Cost side (LHS) — derived from ACTUAL file sizes, not a hardcoded constant."""
+
+    def test_scales_with_file_size(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("JARVIS_TEST_SHARD_TOKENS_PER_LINE", raising=False)
+        monkeypatch.delenv("JARVIS_TEST_SHARD_TEST_MULTIPLIER", raising=False)
+        (tmp_path / "small.py").write_text("\n".join(str(i) for i in range(10)))
+        (tmp_path / "big.py").write_text("\n".join(str(i) for i in range(1000)))
+        small = ih.estimate_test_gen_tokens(uncovered_files=["small.py"], repo_root=tmp_path)
+        big = ih.estimate_test_gen_tokens(uncovered_files=["big.py"], repo_root=tmp_path)
+        assert big > small * 50  # ~100x the lines → ~100x the cost (data-driven)
+
+    def test_sums_across_files(self, tmp_path):
+        (tmp_path / "a.py").write_text("\n".join(str(i) for i in range(100)))
+        (tmp_path / "b.py").write_text("\n".join(str(i) for i in range(100)))
+        one = ih.estimate_test_gen_tokens(uncovered_files=["a.py"], repo_root=tmp_path)
+        two = ih.estimate_test_gen_tokens(uncovered_files=["a.py", "b.py"], repo_root=tmp_path)
+        assert abs(two - 2 * one) < 1.0
+
+    def test_unreadable_file_costs_conservative_default(self, tmp_path):
+        out = ih.estimate_test_gen_tokens(uncovered_files=["ghost.py"], repo_root=tmp_path)
+        assert out > 0.0  # never free
+
+    def test_env_tunable_conversion(self, tmp_path, monkeypatch):
+        (tmp_path / "f.py").write_text("\n".join(str(i) for i in range(100)))
+        monkeypatch.setenv("JARVIS_TEST_SHARD_TOKENS_PER_LINE", "20")
+        monkeypatch.setenv("JARVIS_TEST_SHARD_TEST_MULTIPLIER", "2")
+        out = ih.estimate_test_gen_tokens(uncovered_files=["f.py"], repo_root=tmp_path)
+        assert abs(out - 100 * 20 * 2) < 1.0  # 4000
+
+    def test_fail_soft_zero(self):
+        assert ih.estimate_test_gen_tokens(uncovered_files=None, repo_root=None) == 0.0
+
+
 class TestShouldDecoupleTestGen:
-    """The adaptive decision — INVARIANT 1: tight budget + >2 uncovered → decouple."""
+    """Slice 240 — the DYNAMIC cost-vs-bandwidth trigger (no hardcoded file gate):
+    decouple iff est_test_tokens > velocity_tok_s × remaining_s."""
 
-    def test_invariant1_tight_budget_many_uncovered_decouples(self):
-        # the headline: standard route, tight budget, 3 (>2) uncovered → decouple
+    def test_cost_exceeds_bandwidth_decouples(self):
+        # 10000 tokens of tests, 40 tok/s, 60s window → 2400 capacity < 10000 → shard
         assert ih.should_decouple_test_gen(
-            provider_route="standard", remaining_s=20.0, uncovered_count=3,
-            target_file_count=3, complexity="heavy_code", enabled=True,
+            est_test_tokens=10000.0, velocity_tok_s=40.0, remaining_s=60.0, enabled=True,
         ) is True
 
-    def test_ample_budget_keeps_inline(self):
-        # plenty of time → inject inline (legacy), even with many uncovered
+    def test_cost_fits_bandwidth_inlines(self):
+        # 1000 tokens, 40 tok/s, 60s → 2400 capacity > 1000 → fits inline
         assert ih.should_decouple_test_gen(
-            provider_route="standard", remaining_s=600.0, uncovered_count=5,
-            target_file_count=5, complexity="standard", enabled=True,
+            est_test_tokens=1000.0, velocity_tok_s=40.0, remaining_s=60.0, enabled=True,
         ) is False
 
-    def test_two_or_fewer_uncovered_never_decouples(self):
-        # ">2 uncovered" gate — 2 is not enough to warrant a separate op
+    def test_boundary_strictly_greater(self):
+        # exactly at capacity (2400 == 40×60) → NOT strictly greater → inline
         assert ih.should_decouple_test_gen(
-            provider_route="immediate", remaining_s=1.0, uncovered_count=2,
-            target_file_count=2, complexity="heavy_code", enabled=True,
+            est_test_tokens=2400.0, velocity_tok_s=40.0, remaining_s=60.0, enabled=True,
         ) is False
-
-    def test_heavy_complexity_moderate_budget_decouples(self):
         assert ih.should_decouple_test_gen(
-            provider_route="complex", remaining_s=100.0, uncovered_count=4,
-            target_file_count=4, complexity="heavy_code", enabled=True,
+            est_test_tokens=2400.1, velocity_tok_s=40.0, remaining_s=60.0, enabled=True,
         ) is True
+
+    def test_ample_budget_inlines_even_large_tests(self):
+        # huge window swamps the cost → inline
+        assert ih.should_decouple_test_gen(
+            est_test_tokens=50000.0, velocity_tok_s=40.0, remaining_s=3600.0, enabled=True,
+        ) is False
+
+    def test_unbounded_budget_never_shards(self):
+        assert ih.should_decouple_test_gen(
+            est_test_tokens=99999.0, velocity_tok_s=40.0, remaining_s=float("inf"), enabled=True,
+        ) is False
+
+    def test_depleted_budget_shards(self):
+        # no budget left + real cost → cannot fit inline → decouple
+        assert ih.should_decouple_test_gen(
+            est_test_tokens=500.0, velocity_tok_s=40.0, remaining_s=0.0, enabled=True,
+        ) is True
+
+    def test_zero_cost_inlines(self):
+        assert ih.should_decouple_test_gen(
+            est_test_tokens=0.0, velocity_tok_s=40.0, remaining_s=1.0, enabled=True,
+        ) is False
 
     def test_disabled_never_decouples(self):
         assert ih.should_decouple_test_gen(
-            provider_route="standard", remaining_s=1.0, uncovered_count=9,
-            target_file_count=9, complexity="complex", enabled=False,
+            est_test_tokens=99999.0, velocity_tok_s=1.0, remaining_s=1.0, enabled=False,
         ) is False
 
-    def test_adaptive_route_scaled_floor(self):
-        # immediate route has a tighter floor than complex — same remaining_s,
-        # immediate decouples while complex (more headroom) may not
-        imm = ih.should_decouple_test_gen(
-            provider_route="immediate", remaining_s=50.0, uncovered_count=3,
-            target_file_count=3, complexity="standard", enabled=True,
-        )
-        cplx = ih.should_decouple_test_gen(
-            provider_route="complex", remaining_s=300.0, uncovered_count=3,
-            target_file_count=3, complexity="standard", enabled=True,
-        )
-        assert imm is False  # 50s is above the immediate floor (~45s) and not heavy
-        assert cplx is False  # 300s ample for complex
-        # but a tight immediate budget decouples
-        assert ih.should_decouple_test_gen(
-            provider_route="immediate", remaining_s=30.0, uncovered_count=3,
-            target_file_count=3, complexity="standard", enabled=True,
-        ) is True
-
-    def test_min_uncovered_env_tunable(self, monkeypatch):
-        monkeypatch.setenv("JARVIS_TEST_SHARD_MIN_UNCOVERED", "5")
-        # now 3 uncovered is below the (raised) floor → no decouple
-        assert ih.should_decouple_test_gen(
-            provider_route="standard", remaining_s=10.0, uncovered_count=3,
-            target_file_count=3, complexity="heavy_code", enabled=True,
-        ) is False
+    def test_no_hardcoded_file_count_gate_in_source(self):
+        # the >2 integer gate must be gone — the decision is purely the inequality
+        src = inspect.getsource(ih.should_decouple_test_gen)
+        assert "uncovered_count" not in src
+        assert "_test_shard_min_uncovered" not in src
+        assert "velocity_tok_s" in src and "est_test_tokens" in src
 
     def test_fail_soft_false_on_bad_input(self):
         assert ih.should_decouple_test_gen(
-            provider_route="standard", remaining_s="bad", uncovered_count=3,
-            target_file_count=3, complexity="x", enabled=True,
+            est_test_tokens="bad", velocity_tok_s=40.0, remaining_s=10.0, enabled=True,
         ) is False
+
+
+class TestVelocityEnvKnob:
+    def test_velocity_default_and_env(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_TEST_SHARD_VELOCITY_TOK_S", raising=False)
+        d = ih._shard_velocity_tok_s()
+        assert isinstance(d, float) and d > 0
+        monkeypatch.setenv("JARVIS_TEST_SHARD_VELOCITY_TOK_S", "75")
+        assert ih._shard_velocity_tok_s() == 75.0
 
 
 class TestShardingFlag:


### PR DESCRIPTION
Replaces the Slice-239 hardcoded `>2 uncovered files` integer gate with the mathematical shard-trigger invariant:

```
(Files_uncovered × Est_Tokens_per_file) > (Velocity_live × Budget_Remaining)
```

Decouple test-gen to a background intake op iff the estimated cost of generating the tests exceeds the live bandwidth of the primary task window. `Est_Tokens` is derived from each uncovered file's **actual line count** (data-driven, not a magic integer); conversion ratios + the velocity baseline are env-tunable. The `>2` gate / min-uncovered / route-floor are gone (a source pin asserts it). 31 TDD tests, +0 regressions. Wired at both seams (orchestrator + the live plan_runner).

## Phase 1 — honest verify-first finding (not faked)
The planned "byte-offset socket resume / stream context healer" is **not buildable**: DW is a **stateless** OpenAI-compat `/v1/chat/completions` SSE endpoint — no session id, no resumable offset; a drop must re-request from scratch. And the soaks' `live_transport` failures are predominantly `RuntimeError('tool_loop_deadline_exceeded')` **misclassified** into the `LIVE_TRANSPORT` default bucket (`candidate_generator.py:3694`) — a budget exhaustion, not a socket drop.

The real transport-resiliency levers (scoped follow-up, deliberately not crammed in here): (1) fix that misclassification so a budget-timeout stops *falsely* degrading DW transport health + severing the lane; (2) graduate the **existing** RT-vs-batch hedge (`dw_transport_hedge.py`, default-OFF) — the genuine storm-proof structural mechanism, already built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hardcoded “>2 uncovered files” gate with a dynamic cost-vs-bandwidth trigger so we only shard test generation when it can’t fit the live window, keeping light tasks inline and heavy ones reliable. Satisfies Slice 240 by using a data-driven inequality instead of static thresholds.

- **New Features**
  - Added a cost model: estimate_test_gen_tokens() sums per-file cost from actual line counts × tokens/line × test-multiplier; unreadable files use a conservative default.
  - Rewrote should_decouple_test_gen() to use est_test_tokens > velocity_tok_s × remaining_s, with proper handling for infinite and zero budgets.
  - Integrated at both seams (orchestrator and plan_runner) to compute estimated tokens and apply an env-tunable velocity baseline; removed route-based floors and the file-count gate.
  - Introduced env knobs: JARVIS_TEST_SHARD_{TOKENS_PER_LINE,TEST_MULTIPLIER,VELOCITY_TOK_S,DEFAULT_FILE_LINES}; added focused tests for scaling, boundaries, env tuning, fail-soft behavior, and a source pin ensuring the “>2” gate is gone.

<sup>Written for commit 828e27925be72486ea85d23dd4b1588740eb01a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

