### PR TITLE
Slice 241 T1: classify GENERATION_TIMEOUT — stop blaming DW transport for our tool-loop budget

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3616,6 +3616,7 @@ class CandidateGenerator:
                 # again blame the vendor for its own internal codebase flaws.
                 from backend.core.ouroboros.governance.dw_fault_taxonomy import (
                     is_internal_fault as _s185_internal,
+                    is_generation_timeout as _s241_gen_timeout,
                 )
                 if _s185_internal(exc):
                     logger.error(
@@ -3646,7 +3647,15 @@ class CandidateGenerator:
                     getattr(exc, "is_terminal_auth_error", lambda: False)()
                 )
 
-                if _is_modality or _is_auth_terminal:
+                if _s241_gen_timeout(exc):
+                    # Slice 241 — OUR op-level tool-loop budget exhaustion
+                    # (tool_loop_deadline / max_rounds / starved), NOT a DW
+                    # transport rupture. Classify GENERATION_TIMEOUT so the
+                    # ==LIVE_TRANSPORT degrade/sever consumers ignore it and the
+                    # topology breaker (weight 0.0) never trips on OUR budget.
+                    # Stops blaming DoubleWord's network for our generation budget.
+                    failure_source = FailureSource.GENERATION_TIMEOUT
+                elif _is_modality or _is_auth_terminal:
                     # Slice H — terminal failure class. Even though we
                     # report it as LIVE_HTTP_5XX semantics here for
                     # back-compat, the breaker (Slice H wiring) will

--- a/backend/core/ouroboros/governance/dw_fault_taxonomy.py
+++ b/backend/core/ouroboros/governance/dw_fault_taxonomy.py
@@ -47,3 +47,33 @@ def is_internal_fault(exc: BaseException) -> bool:
         return False
     except Exception:  # noqa: BLE001 — the taxonomy must never itself throw
         return False
+
+
+# Slice 241 — OP-LEVEL generation/exploration budget exhaustion markers. These are
+# RuntimeErrors the Venom tool loop raises when OUR budget runs out (deadline /
+# max-rounds / round-starved / ttft-floor) — they bill $0, involve no socket, and
+# are NOT a DoubleWord transport rupture. Matched by message because they are
+# generic RuntimeErrors (deliberately outside _INTERNAL_FAULT_TYPES, which is for
+# Python logic bugs). All carry the unambiguous ``tool_loop_`` prefix.
+_GENERATION_TIMEOUT_MARKERS = (
+    "tool_loop_deadline",
+    "tool_loop_max_rounds",
+    "tool_loop_round_budget",
+    "tool_loop_starved",
+    "generation_timeout",
+)
+
+
+def is_generation_timeout(exc: BaseException) -> bool:
+    """True iff ``exc`` is an OP-LEVEL generation/tool-loop BUDGET exhaustion (our
+    budget ran out before a candidate was produced), NOT a vendor transport
+    rupture. Such failures must be classified ``GENERATION_TIMEOUT`` — never
+    ``LIVE_TRANSPORT`` — so they do NOT falsely degrade DoubleWord's surface
+    health, inflate the live_transport lane-sever counter, or feed the dead-Claude
+    cascade. Message-matched (markers all carry the ``tool_loop_`` prefix), so a
+    genuine transport error never matches. NEVER raises → False."""
+    try:
+        msg = str(exc).lower()
+        return any(m in msg for m in _GENERATION_TIMEOUT_MARKERS)
+    except Exception:  # noqa: BLE001 — the taxonomy must never itself throw
+        return False

--- a/backend/core/ouroboros/governance/topology_sentinel.py
+++ b/backend/core/ouroboros/governance/topology_sentinel.py
@@ -224,6 +224,7 @@ _SENTINEL_PROPAGATED_VARS: Tuple[str, ...] = (
     "JARVIS_TOPOLOGY_WEIGHT_HEAVY_PROBE_FAIL",
     "JARVIS_TOPOLOGY_WEIGHT_LIGHT_PROBE_FAIL",
     "JARVIS_TOPOLOGY_WEIGHT_LIGHT_PROBE_TIMEOUT",
+    "JARVIS_TOPOLOGY_WEIGHT_GENERATION_TIMEOUT",  # Slice 241
 )
 
 
@@ -437,6 +438,11 @@ class FailureSource(str, enum.Enum):
     HEAVY_PROBE_FAIL = "heavy_probe_fail"          # 1.5
     LIGHT_PROBE_FAIL = "light_probe_fail"          # 1.0
     LIGHT_PROBE_TIMEOUT = "light_probe_timeout"    # 1.0
+    # Slice 241 — OUR op-level generation/tool-loop budget exhaustion (NOT a DW
+    # transport rupture). Weight 0.0: recorded for telemetry but NEVER contributes
+    # to the weighted-streak that trips the DW model/topology breaker, and (being
+    # != LIVE_TRANSPORT) the degrade/sever consumers ignore it automatically.
+    GENERATION_TIMEOUT = "generation_timeout"      # 0.0
 
 
 _DEFAULT_FAILURE_WEIGHTS: Dict[FailureSource, float] = {
@@ -448,6 +454,7 @@ _DEFAULT_FAILURE_WEIGHTS: Dict[FailureSource, float] = {
     FailureSource.HEAVY_PROBE_FAIL: 1.5,
     FailureSource.LIGHT_PROBE_FAIL: 1.0,
     FailureSource.LIGHT_PROBE_TIMEOUT: 1.0,
+    FailureSource.GENERATION_TIMEOUT: 0.0,
 }
 
 

--- a/tests/governance/test_slice241_generation_timeout.py
+++ b/tests/governance/test_slice241_generation_timeout.py
@@ -1,0 +1,104 @@
+"""Slice 241 T1 — GENERATION_TIMEOUT classification (stop blaming DW for OUR budget).
+
+Root cause surfacing across the s235→240 arc: `RuntimeError('tool_loop_deadline_
+exceeded')` — the Venom tool-loop blowing its OP-LEVEL generation/exploration
+budget (bills $0, no socket involved) — falls through the sentinel classifier's
+regex to the catch-all `else → FailureSource.LIVE_TRANSPORT` (candidate_generator
+.py:3694). That FALSELY degrades DW's surface health, inflates the live_transport
+lane-sever counter, and feeds the cascade — i.e. we blame DoubleWord's *network*
+for OUR *budget*. (Same family as Slice 185, which already segregates internal
+Python faults via dw_fault_taxonomy.is_internal_fault, but RuntimeError is
+deliberately excluded there.)
+
+Fix (precise, reuse the existing ==LIVE_TRANSPORT keying): a distinct non-transport
+source GENERATION_TIMEOUT (weight 0.0 → never trips the DW topology breaker). The
+classifier labels tool-loop budget exhaustion as GENERATION_TIMEOUT FIRST; the
+existing degrade/sever consumers key on `is FailureSource.LIVE_TRANSPORT` and so
+automatically stop reacting to it. Genuine transport errors are untouched.
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance import dw_fault_taxonomy as tax
+from backend.core.ouroboros.governance.topology_sentinel import (
+    FailureSource,
+    failure_weight,
+)
+
+
+class TestIsGenerationTimeout:
+    def test_tool_loop_deadline_is_generation_timeout(self):
+        assert tax.is_generation_timeout(RuntimeError("tool_loop_deadline_exceeded")) is True
+
+    def test_tool_loop_other_budget_markers(self):
+        for msg in (
+            "tool_loop_max_rounds_exceeded",
+            "tool_loop_round_budget_starved",
+            "tool_loop_starved_below_min_ttft_floor",
+        ):
+            assert tax.is_generation_timeout(RuntimeError(msg)) is True, msg
+
+    def test_genuine_transport_errors_are_NOT_generation_timeout(self):
+        # the precision invariant: real transport must still flow to LIVE_TRANSPORT
+        for exc in (
+            ConnectionResetError("connection reset by peer"),
+            RuntimeError("RemoteProtocolError: peer closed connection"),
+            RuntimeError("stream stalled: no chunk in 30s"),
+            TimeoutError("read timeout"),
+        ):
+            assert tax.is_generation_timeout(exc) is False, repr(exc)
+
+    def test_unrelated_runtimeerror_not_generation_timeout(self):
+        assert tax.is_generation_timeout(RuntimeError("something else entirely")) is False
+
+    def test_fail_soft_false(self):
+        class _Bad:
+            def __str__(self):
+                raise ValueError("boom")
+        assert tax.is_generation_timeout(_Bad()) is False
+
+
+class TestFailureSourceEnum:
+    def test_generation_timeout_source_exists(self):
+        assert hasattr(FailureSource, "GENERATION_TIMEOUT")
+        assert FailureSource.GENERATION_TIMEOUT.value == "generation_timeout"
+
+    def test_generation_timeout_weight_is_zero(self):
+        # weight 0.0 → a budget timeout NEVER contributes to the weighted-streak
+        # that trips the DW model/topology breaker (it is not a DW health signal).
+        assert failure_weight(FailureSource.GENERATION_TIMEOUT) == 0.0
+
+    def test_live_transport_weight_unchanged(self):
+        # genuine transport still carries its real weight (regression guard)
+        assert failure_weight(FailureSource.LIVE_TRANSPORT) == 1.0
+
+
+class TestClassifierWiring:
+    """Source pins: the classifier labels GENERATION_TIMEOUT before the
+    LIVE_TRANSPORT fallback, and the degrade/sever consumers still key on
+    ==LIVE_TRANSPORT (so the new source auto-avoids them)."""
+
+    def test_classifier_checks_generation_timeout_first(self):
+        from backend.core.ouroboros.governance import candidate_generator as cg
+        src = inspect.getsource(cg)
+        assert "is_generation_timeout" in src, "classifier must consult is_generation_timeout"
+        assert "GENERATION_TIMEOUT" in src
+        # the check must precede the LIVE_TRANSPORT catch-all in the dispatch source
+        gt_idx = src.index("is_generation_timeout")
+        # there is at least one LIVE_TRANSPORT assignment after the GT check
+        assert "FailureSource.LIVE_TRANSPORT" in src[gt_idx:]
+
+    def test_degrade_and_sever_still_key_on_live_transport(self):
+        # the whole point: these consumers branch on ==LIVE_TRANSPORT, so a
+        # GENERATION_TIMEOUT (a different member) flows through them as a no-op.
+        from backend.core.ouroboros.governance import candidate_generator as cg
+        src = inspect.getsource(cg)
+        assert "is FailureSource.LIVE_TRANSPORT" in src
+
+    def test_generation_timeout_not_in_immortal_rupture_markers(self):
+        # the immortal-retry rupture markers must NOT include a generation-timeout
+        # marker (a budget timeout is not a vendor rupture to retry-around).
+        from backend.core.ouroboros.governance import dw_immortal as imm
+        src = inspect.getsource(imm)
+        assert "tool_loop_deadline" not in src


### PR DESCRIPTION
The root cause under several prior symptoms: `RuntimeError('tool_loop_deadline_exceeded')` — the Venom tool loop blowing its **op-level budget** (bills $0, no socket) — fell through the sentinel classifier to the catch-all `else → LIVE_TRANSPORT` (`candidate_generator.py:3694`), **falsely degrading DW's surface health, inflating the lane-sever counter, and feeding the dead-Claude cascade**. We blamed DoubleWord's network for *our* budget.

## Fix (reuse the existing `==LIVE_TRANSPORT` keying — a correct label fixes the machinery on its own)
- `dw_fault_taxonomy.is_generation_timeout()` — message-matched on the unambiguous `tool_loop_` markers; precise, so a genuine transport error never matches.
- `topology_sentinel`: new `FailureSource.GENERATION_TIMEOUT` (**weight 0.0** → never trips the DW breaker) + its propagated-var (the env-propagation contract caught the omission).
- classifier labels it **first** (after the Slice-185 internal-fault check). The degrade (`:3764`) + sever (`:3826`) consumers branch on `is FailureSource.LIVE_TRANSPORT`, so they now auto-ignore a budget timeout. **Genuine transport errors untouched.**

Audited all `LIVE_TRANSPORT` consumers (degrade/sever/predicate auto-skip; weight explicit 0.0; immortal markers exclude `tool_loop_*`; preflight/disambiguator separate path).

11 TDD tests (precision incl. genuine-transport-stays-out; enum/weight; classifier-first + consumer-keying pins). +0 new regressions (9 pre-existing dispatch/preflight failures proven via stash).

T2 (graduate the RT-vs-batch hedge) deferred — T1 soaked alone first to measure its true effect against the original objective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies tool-loop budget exhaustion as `GENERATION_TIMEOUT` (weight 0.0) instead of `LIVE_TRANSPORT` to stop false DW transport degradations and breaker trips. Precise detection via `dw_fault_taxonomy.is_generation_timeout`, applied before the fallback.

- **Bug Fixes**
  - Added `dw_fault_taxonomy.is_generation_timeout` that matches `tool_loop_*` markers and `generation_timeout`.
  - Introduced `FailureSource.GENERATION_TIMEOUT` with weight 0.0 and `JARVIS_TOPOLOGY_WEIGHT_GENERATION_TIMEOUT`.
  - Updated `candidate_generator` to label this first; `==LIVE_TRANSPORT`-keyed degrade/sever paths now ignore it.
  - Genuine transport errors remain unchanged; added targeted tests to pin behavior.

<sup>Written for commit 9a1e92e2afdf3f9079a559cdb60e4fe3a941ba86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

