### PR TITLE
Slice 241 T2: graduate the RT-vs-batch transport hedge to default-ON (dual-stream arbitrage)

### DIFF
--- a/backend/core/ouroboros/governance/dw_transport_hedge.py
+++ b/backend/core/ouroboros/governance/dw_transport_hedge.py
@@ -20,9 +20,18 @@ from typing import Any, Awaitable, Callable, Optional
 
 
 def transport_hedge_enabled() -> bool:
-    """Master for the proactive hedge. Default **FALSE** (§33.1 — new default-path behavior that
-    can double-spend; opt-in per deployment). NEVER raises."""
-    return os.environ.get("JARVIS_DW_TRANSPORT_HEDGE_ENABLED", "").strip().lower() in (
+    """Master for the proactive RT-vs-batch hedge.
+
+    Slice 241 T2 — GRADUATED to default **TRUE**: race the RT stream against the
+    stable batch path and take the first success, so a partial RT rupture is made
+    INVISIBLE (the batch arm wins, the op never sees the failure). This is the only
+    code lever for DW transport volatility (it cannot save a WHOLESALE DW outage
+    where both arms fail). The §33.1 double-spend concern is bounded: the loser is
+    cancelled aggressively on the first success, so steady-state cost ≈ RT (the
+    batch submit is cancelled before completion whenever RT wins). Kill switch:
+    ``JARVIS_DW_TRANSPORT_HEDGE_ENABLED=0`` (or false/no/off) reverts to the legacy
+    single-stream path. NEVER raises."""
+    return os.environ.get("JARVIS_DW_TRANSPORT_HEDGE_ENABLED", "true").strip().lower() in (
         "1", "true", "yes", "on",
     )
 

--- a/tests/governance/test_slice189_hedge_dispatch.py
+++ b/tests/governance/test_slice189_hedge_dispatch.py
@@ -87,9 +87,19 @@ class TestGenerateViaBatch(unittest.IsolatedAsyncioTestCase):
             await p._generate_via_batch(object(), None)
 
     def test_hedge_inactive_when_flag_off(self):
+        # Slice 241 T2 — the hedge is GRADUATED to default-ON, so verifying the
+        # flag-off path now requires explicitly setting the kill switch (=0)
+        # rather than relying on the default.
         import os
-        os.environ.pop("JARVIS_DW_TRANSPORT_HEDGE_ENABLED", None)
-        self.assertFalse(_MockProvider()._s189_transport_hedge_active())
+        _prev = os.environ.get("JARVIS_DW_TRANSPORT_HEDGE_ENABLED")
+        os.environ["JARVIS_DW_TRANSPORT_HEDGE_ENABLED"] = "0"
+        try:
+            self.assertFalse(_MockProvider()._s189_transport_hedge_active())
+        finally:
+            if _prev is None:
+                os.environ.pop("JARVIS_DW_TRANSPORT_HEDGE_ENABLED", None)
+            else:
+                os.environ["JARVIS_DW_TRANSPORT_HEDGE_ENABLED"] = _prev
 
 
 if __name__ == "__main__":

--- a/tests/governance/test_slice241_t2_hedge_graduation.py
+++ b/tests/governance/test_slice241_t2_hedge_graduation.py
@@ -1,0 +1,105 @@
+"""Slice 241 T2 — graduate the RT-vs-batch transport hedge to default-ON.
+
+The hedge (dw_transport_hedge.hedged_race) was BUILT + wired into the DW provider
+(_s189_transport_hedge_active → hedged_race) but gated default-OFF
+(JARVIS_DW_TRANSPORT_HEDGE_ENABLED, §33.1 "opt-in per deployment"). T2 graduates it:
+race the RT stream against the stable batch path, take the first success, cancel the
+loser; if RT ruptures mid-generation, the rupture is swallowed and the surviving
+batch payload is returned seamlessly — no live_transport exception escapes. This is
+the only remaining CODE lever for DW transport volatility (it can't help a wholesale
+DW outage where BOTH arms fail, but it makes a partial RT rupture invisible).
+
+These tests pin the graduated default + the rupture-pivot guarantee (your Phase 3:
+RT drops mid-stream → the completed batch payload is returned without a transport
+error). The deep race mechanics are already covered by slice188/189/190/194/227.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import dw_transport_hedge as h
+
+
+class TestHedgeGraduation:
+    def test_default_now_on(self, monkeypatch):
+        # T2 graduation: with no env override, the hedge is ACTIVE.
+        monkeypatch.delenv("JARVIS_DW_TRANSPORT_HEDGE_ENABLED", raising=False)
+        assert h.transport_hedge_enabled() is True
+
+    def test_kill_switch_reverts(self, monkeypatch):
+        # rollback contract: =0 reverts to the legacy single-stream path.
+        monkeypatch.setenv("JARVIS_DW_TRANSPORT_HEDGE_ENABLED", "0")
+        assert h.transport_hedge_enabled() is False
+
+
+class TestRupturePivot:
+    """Phase 3 — RT ruptures mid-generation → batch payload returned, no throw."""
+
+    async def test_rt_rupture_pivots_to_batch(self):
+        async def fast():  # RT drops "at the 50% byte mark"
+            await asyncio.sleep(0.001)
+            raise RuntimeError("live_transport: peer reset mid-stream (50%)")
+
+        async def stable():  # batch survives and completes
+            await asyncio.sleep(0.005)
+            return "batch_payload"
+
+        out = await h.hedged_race(fast, stable, is_rupture=lambda e: True)
+        assert out == "batch_payload"  # rupture swallowed, batch returned seamlessly
+
+    async def test_rt_success_cancels_batch_loser(self):
+        cancelled = {"batch": False}
+
+        async def fast():
+            return "rt_payload"
+
+        async def stable():
+            try:
+                await asyncio.sleep(10.0)
+            except asyncio.CancelledError:
+                cancelled["batch"] = True
+                raise
+            return "batch_payload"
+
+        out = await h.hedged_race(fast, stable)
+        assert out == "rt_payload"  # RT primacy on success
+        await asyncio.sleep(0.01)
+        assert cancelled["batch"] is True  # loser cancelled to preserve bandwidth
+
+    async def test_both_arms_fail_raises(self):
+        async def fast():
+            raise RuntimeError("rt down")
+
+        async def stable():
+            raise RuntimeError("batch down")
+
+        # wholesale DW outage: both arms rupture → the hedge cannot save it (honest
+        # limit — it surfaces the failure rather than hanging).
+        with pytest.raises(BaseException):
+            await h.hedged_race(fast, stable, is_rupture=lambda e: True)
+
+    async def test_rupture_pivot_emits_invisible_save_telemetry(self):
+        # on_outcome(winner, rupture_swallowed) must report that batch won AFTER an
+        # RT rupture — the "proactive capital-save made the rupture invisible" signal.
+        seen = {}
+
+        async def fast():
+            await asyncio.sleep(0.001)
+            raise RuntimeError("live_transport rupture")
+
+        async def stable():
+            await asyncio.sleep(0.005)
+            return "batch_payload"
+
+        def _outcome(winner, rupture_swallowed):
+            seen["winner"] = winner
+            seen["rupture_swallowed"] = rupture_swallowed
+
+        out = await h.hedged_race(
+            fast, stable, is_rupture=lambda e: True, on_outcome=_outcome,
+        )
+        assert out == "batch_payload"
+        assert seen["winner"] == "batch"
+        assert seen["rupture_swallowed"] is True


### PR DESCRIPTION
Activates the pre-built, pre-wired dual-stream hedge (`dw_transport_hedge.hedged_race`, wired at `_s189_transport_hedge_active`) by flipping `JARVIS_DW_TRANSPORT_HEDGE_ENABLED` default FALSE→TRUE.

- Races the RT stream against the stable batch path; first success wins, loser cancelled aggressively (no orphans).
- **RT primacy** (`prefer_fast`): a co-arriving batch result is held speculatively so the RT arm's Venom exploration clears the Iron Gate.
- **Rupture-pivot**: an RT rupture mid-generation is swallowed and the surviving **batch** payload returns seamlessly — no `live_transport` exception escapes, the DAG loop never drops.
- **Honest limit**: a *wholesale* DW outage (both arms fail) still surfaces — the hedge makes a *partial* RT rupture invisible, it can't conjure a result when DW is down.
- **Cost**: §33.1 double-spend is bounded — loser cancelled on first success → steady-state ≈ RT. Kill switch `=0` reverts.

TDD: graduation default + kill switch; rupture-pivot returns batch with no throw at the 50% drop; RT-win cancels batch; both-fail raises; invisible-save telemetry. 63 tests green (T2 + slice188/189/190/194/227); +0 regressions (updated slice189's flag-off test to set the kill switch explicitly).

The last code lever for DW transport volatility. Final assessment soak + flag-plant to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates the RT-vs-batch transport hedge to default ON, improving resilience to partial RT stream failures by racing RT against batch and taking the first success. Supports a kill switch to revert to the single-stream path.

- **New Features**
  - `JARVIS_DW_TRANSPORT_HEDGE_ENABLED` now defaults to `true`; `transport_hedge_enabled()` returns True by default.
  - Races RT vs batch; first success wins and the loser is cancelled (RT primacy on tie).
  - Rupture pivot: if RT drops mid-stream, the batch result is returned without raising; if both fail, the error surfaces.

- **Migration**
  - To keep the legacy behavior, set `JARVIS_DW_TRANSPORT_HEDGE_ENABLED=0` (or `false`/`no`/`off`).
  - Tests updated to pin the kill switch explicitly; added coverage for the default-ON and rupture-pivot paths.

<sup>Written for commit 199ee7322792e3ba5744e0d60615f03d4127a2f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

