### PR TITLE
feat(recovery): Slice 242 — adaptive statistical recovery-duration prior for hibernation probing

### DIFF
--- a/backend/core/ouroboros/governance/dw_transport_recovery.py
+++ b/backend/core/ouroboros/governance/dw_transport_recovery.py
@@ -168,6 +168,184 @@ def reset_dw_transport_recovery() -> None:
     get_dw_transport_recovery().reset()
 
 
+# ---------------------------------------------------------------------------
+# Slice 242 — adaptive statistical recovery-duration prior.
+#
+# The hibernation_prober already probes a dark DW grid on exponential backoff
+# and auto-wakes on recovery, but its FIRST probe interval was a STATIC default
+# (5s) — wasteful when outages historically last minutes (you ping a dark grid
+# for nothing, and DW won't return any sooner). This is an online, training-free
+# estimator (NOT an ML predictor — DW's recovery is an exogenous vendor event
+# with no observable features): record observed outage durations
+# (enter_hibernation → wake) into a bounded ring, then set the first re-probe
+# near a low quantile (p25) of history so we don't ping before the grid
+# plausibly recovers. It times WHEN to start probing — it never claims to know
+# WHEN DW returns. Falls back to the static default below ``min_samples``.
+# Pure, env-driven, thread-safe, NEVER raises (sits on the recovery path).
+# ---------------------------------------------------------------------------
+
+_ENV_PRIOR_WINDOW = "JARVIS_RECOVERY_PRIOR_WINDOW"
+_ENV_PRIOR_QUANTILE = "JARVIS_RECOVERY_PRIOR_QUANTILE"
+_ENV_PRIOR_MIN_SAMPLES = "JARVIS_RECOVERY_PRIOR_MIN_SAMPLES"
+_ENV_PRIOR_FLOOR_S = "JARVIS_RECOVERY_PRIOR_FLOOR_S"
+
+_DEFAULT_PRIOR_WINDOW = 20
+_DEFAULT_PRIOR_QUANTILE = 0.25
+_DEFAULT_PRIOR_MIN_SAMPLES = 3
+_DEFAULT_PRIOR_FLOOR_S = 1.0
+
+
+def _recovery_prior_window() -> int:
+    try:
+        v = int(float(os.getenv(_ENV_PRIOR_WINDOW, "").strip() or _DEFAULT_PRIOR_WINDOW))
+        return v if v > 0 else _DEFAULT_PRIOR_WINDOW
+    except (TypeError, ValueError):
+        return _DEFAULT_PRIOR_WINDOW
+
+
+def _recovery_prior_quantile() -> float:
+    try:
+        v = float(os.getenv(_ENV_PRIOR_QUANTILE, "").strip() or _DEFAULT_PRIOR_QUANTILE)
+        return v if 0.0 < v < 1.0 else _DEFAULT_PRIOR_QUANTILE
+    except (TypeError, ValueError):
+        return _DEFAULT_PRIOR_QUANTILE
+
+
+def _recovery_prior_min_samples() -> int:
+    try:
+        v = int(float(os.getenv(_ENV_PRIOR_MIN_SAMPLES, "").strip() or _DEFAULT_PRIOR_MIN_SAMPLES))
+        return v if v > 0 else _DEFAULT_PRIOR_MIN_SAMPLES
+    except (TypeError, ValueError):
+        return _DEFAULT_PRIOR_MIN_SAMPLES
+
+
+def _recovery_prior_floor_s() -> float:
+    try:
+        v = float(os.getenv(_ENV_PRIOR_FLOOR_S, "").strip() or _DEFAULT_PRIOR_FLOOR_S)
+        return v if v > 0 else _DEFAULT_PRIOR_FLOOR_S
+    except (TypeError, ValueError):
+        return _DEFAULT_PRIOR_FLOOR_S
+
+
+class RecoveryDurationPrior:
+    """Bounded ring of observed grid-outage durations → quantile-derived first
+    probe interval. Online, training-free, thread-safe, NEVER raises."""
+
+    def __init__(self) -> None:
+        from collections import deque
+
+        self._lock = threading.Lock()
+        self._samples: "deque[float]" = deque(maxlen=_recovery_prior_window())
+
+    def record(self, duration_s: Any) -> None:
+        """Append an observed outage duration (seconds). Non-numeric or
+        non-positive values are ignored. NEVER raises."""
+        try:
+            d = float(duration_s)
+        except (TypeError, ValueError):
+            return
+        if not (d > 0.0) or d != d:  # reject <=0 and NaN
+            return
+        try:
+            with self._lock:
+                # honour a live env change to the window size
+                want = _recovery_prior_window()
+                if self._samples.maxlen != want:
+                    from collections import deque
+
+                    self._samples = deque(self._samples, maxlen=want)
+                self._samples.append(d)
+        except Exception:  # noqa: BLE001 — recovery path, never raise
+            pass
+
+    def sample_count(self) -> int:
+        with self._lock:
+            return len(self._samples)
+
+    def quantile(self, q: float) -> float:
+        """Linear-interpolated quantile of the retained durations. 0.0 if empty.
+        NEVER raises."""
+        try:
+            with self._lock:
+                data = sorted(self._samples)
+            if not data:
+                return 0.0
+            if len(data) == 1:
+                return data[0]
+            qq = min(1.0, max(0.0, float(q)))
+            pos = qq * (len(data) - 1)
+            lo = int(pos)
+            frac = pos - lo
+            if lo + 1 >= len(data):
+                return data[-1]
+            return data[lo] + (data[lo + 1] - data[lo]) * frac
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+    def first_probe_interval(
+        self,
+        *,
+        default_s: float,
+        max_s: float,
+        min_samples: Optional[int] = None,
+        quantile: Optional[float] = None,
+        floor_s: Optional[float] = None,
+    ) -> float:
+        """The interval before the FIRST health probe of a dark grid.
+
+        Below ``min_samples`` of history → fall back to the STATIC ``default_s``
+        (no trust yet). With enough history → the chosen low ``quantile`` (p25)
+        of observed durations, clamped to ``[floor_s, max_s]``. NEVER raises —
+        degrades to ``default_s`` on any error."""
+        try:
+            need = _recovery_prior_min_samples() if min_samples is None else int(min_samples)
+            if self.sample_count() < need:
+                return float(default_s)
+            q = _recovery_prior_quantile() if quantile is None else float(quantile)
+            floor = _recovery_prior_floor_s() if floor_s is None else float(floor_s)
+            est = self.quantile(q)
+            return min(float(max_s), max(float(floor), est))
+        except Exception:  # noqa: BLE001
+            return float(default_s)
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            data = list(self._samples)
+        return {
+            "sample_count": len(data),
+            "window": _recovery_prior_window(),
+            "quantile": _recovery_prior_quantile(),
+            "min_samples": _recovery_prior_min_samples(),
+            "floor_s": _recovery_prior_floor_s(),
+        }
+
+    def reset(self) -> None:
+        from collections import deque
+
+        with self._lock:
+            self._samples = deque(maxlen=_recovery_prior_window())
+
+
+_PRIOR_SINGLETON: "RecoveryDurationPrior | None" = None
+_PRIOR_SINGLETON_LOCK = threading.Lock()
+
+
+def get_recovery_prior() -> RecoveryDurationPrior:
+    """Process-wide singleton — outage history accumulates across hibernation
+    cycles within a session (and across the prober's restarts)."""
+    global _PRIOR_SINGLETON
+    if _PRIOR_SINGLETON is None:
+        with _PRIOR_SINGLETON_LOCK:
+            if _PRIOR_SINGLETON is None:
+                _PRIOR_SINGLETON = RecoveryDurationPrior()
+    return _PRIOR_SINGLETON
+
+
+def reset_recovery_prior() -> None:
+    """Test isolation — clear the accumulated outage history."""
+    get_recovery_prior().reset()
+
+
 __all__ = [
     "DWTransportRecovery",
     "dw_dynamic_recovery_enabled",

--- a/backend/core/ouroboros/governance/hibernation_prober.py
+++ b/backend/core/ouroboros/governance/hibernation_prober.py
@@ -66,10 +66,23 @@ logger = logging.getLogger("Ouroboros.HibernationProber")
 _ENV_INITIAL_S = "JARVIS_HIBERNATION_PROBE_INITIAL_S"
 _ENV_MAX_S = "JARVIS_HIBERNATION_PROBE_MAX_S"
 _ENV_DURATION_S = "JARVIS_HIBERNATION_MAX_DURATION_S"
+# Slice 242 — adaptive statistical recovery-duration prior gate (graduated-on,
+# mirrors JARVIS_DW_DYNAMIC_RECOVERY_ENABLED). =0 → byte-identical static-5s path.
+_ENV_PRIOR_ENABLED = "JARVIS_RECOVERY_PRIOR_ENABLED"
 
 _DEFAULT_INITIAL_S = 5.0
 _DEFAULT_MAX_S = 300.0
 _DEFAULT_DURATION_S = 3600.0
+
+
+def _recovery_prior_enabled() -> bool:
+    """Master gate for the adaptive first-probe interval. NEVER raises."""
+    try:
+        return os.getenv(_ENV_PRIOR_ENABLED, "true").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _resolve_float(env: str, default: float, explicit: Optional[float]) -> float:
@@ -256,9 +269,52 @@ class HibernationProber:
     # Internal
     # ------------------------------------------------------------------
 
+    def _first_probe_delay(self) -> float:
+        """The interval before the FIRST probe of a dark grid.
+
+        Slice 242: when the recovery-prior is enabled and has enough outage
+        history, derive it from a low quantile (p25) of past dark-window
+        durations — don't ping before the grid plausibly recovers. Below
+        ``min_samples`` (or gate off) → the static ``initial_delay_s``. Fully
+        fail-soft: any error falls back to the static default."""
+        if not _recovery_prior_enabled():
+            return self._initial_delay_s
+        try:
+            from backend.core.ouroboros.governance.dw_transport_recovery import (
+                get_recovery_prior,
+            )
+
+            derived = get_recovery_prior().first_probe_interval(
+                default_s=self._initial_delay_s,
+                max_s=self._max_delay_s,
+            )
+            if derived != self._initial_delay_s:
+                logger.info(
+                    "[HibernationProber] adaptive first-probe delay=%.1fs "
+                    "(static default=%.1fs) — derived from outage history",
+                    derived, self._initial_delay_s,
+                )
+            return derived
+        except Exception:  # noqa: BLE001 — never starve probing on a prior error
+            return self._initial_delay_s
+
+    def _record_outage_duration(self, elapsed_s: float) -> None:
+        """Record the just-ended dark-window duration so the NEXT outage's
+        first probe is timed from history. NEVER raises."""
+        if not _recovery_prior_enabled():
+            return
+        try:
+            from backend.core.ouroboros.governance.dw_transport_recovery import (
+                get_recovery_prior,
+            )
+
+            get_recovery_prior().record(elapsed_s)
+        except Exception:  # noqa: BLE001
+            pass
+
     async def _probe_loop(self) -> None:
         """Exponential-backoff probe loop running in its own Task."""
-        delay = self._initial_delay_s
+        delay = self._first_probe_delay()
         try:
             while True:
                 await asyncio.sleep(delay)
@@ -278,6 +334,10 @@ class HibernationProber:
                 if healthy_name is not None:
                     self._last_result = f"woken_by:{healthy_name}"
                     self._wake_count += 1
+                    # Slice 242: the dark window just ended — feed its observed
+                    # duration into the prior so the NEXT outage's first probe
+                    # is timed from history, not a static guess.
+                    self._record_outage_duration(elapsed)
                     logger.info(
                         "[HibernationProber] %s healthy after %d probes "
                         "in %.1fs — waking controller",

--- a/tests/governance/test_slice242_recovery_prior.py
+++ b/tests/governance/test_slice242_recovery_prior.py
@@ -1,0 +1,109 @@
+"""Slice 242 — adaptive statistical recovery-duration prior for hibernation probing.
+
+The hibernation_prober (the "Grid Sentinel") already probes a dark DW grid on
+exponential backoff and auto-wakes on recovery. T2's gap: the FIRST probe interval
+was a STATIC default (5s) — wasteful when outages historically last minutes (you
+ping a dark grid for nothing). This adds an online, training-free estimator
+(no NN — exogenous vendor outage, no predictive features): record observed outage
+durations (enter_hibernation → wake), and set the first re-probe near a low
+quantile (p25) of history so we don't ping before the grid plausibly recovers.
+Optimizes resurrection latency vs probe cost; ~$0 while dark. Falls back to the
+static default below min-samples. NOT a recovery predictor — it times WHEN to start
+probing, never claims to know when DW returns.
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance import dw_transport_recovery as rec
+
+
+class TestRecoveryDurationPrior:
+    def _fresh(self):
+        p = rec.RecoveryDurationPrior()
+        p.reset()
+        return p
+
+    def test_insufficient_history_returns_default(self):
+        p = self._fresh()
+        # below min_samples → fall back to the static default (no trust yet)
+        assert p.first_probe_interval(default_s=5.0, max_s=300.0, min_samples=3) == 5.0
+        p.record(120.0)
+        p.record(140.0)
+        assert p.first_probe_interval(default_s=5.0, max_s=300.0, min_samples=3) == 5.0
+
+    def test_with_history_uses_p25_quantile(self):
+        p = self._fresh()
+        # durations: p25 of [60,120,180,240,300] ≈ 120
+        for d in (60.0, 120.0, 180.0, 240.0, 300.0):
+            p.record(d)
+        out = p.first_probe_interval(default_s=5.0, max_s=600.0, min_samples=3, quantile=0.25)
+        assert 100.0 <= out <= 140.0  # near p25 — don't probe before then
+
+    def test_clamped_to_max(self):
+        p = self._fresh()
+        for d in (1000.0, 1200.0, 1400.0):
+            p.record(d)
+        out = p.first_probe_interval(default_s=5.0, max_s=300.0, min_samples=3)
+        assert out == 300.0  # never exceed the cap
+
+    def test_clamped_to_floor(self):
+        p = self._fresh()
+        for d in (0.1, 0.2, 0.3):
+            p.record(d)
+        out = p.first_probe_interval(default_s=5.0, max_s=300.0, min_samples=3, floor_s=1.0)
+        assert out == 1.0  # never below the floor
+
+    def test_ring_is_bounded(self):
+        p = self._fresh()
+        for d in range(1000):
+            p.record(float(d))
+        # bounded window — only the most recent N durations are retained
+        assert p.sample_count() <= rec._recovery_prior_window()
+
+    def test_fail_soft_on_bad_input(self):
+        p = self._fresh()
+        p.record("oops")  # non-numeric — swallowed
+        p.record(-5.0)    # negative — ignored
+        assert p.sample_count() == 0
+        # bad args → default, never raise
+        assert p.first_probe_interval(default_s=5.0, max_s=300.0) == 5.0
+
+    def test_quantile_correctness(self):
+        p = self._fresh()
+        for d in (10.0, 20.0, 30.0, 40.0):
+            p.record(d)
+        # p50 of [10,20,30,40] is ~25 (linear interp) — sanity on the quantile math
+        q = p.quantile(0.5)
+        assert 20.0 <= q <= 30.0
+
+
+class TestRecoveryPriorEnvKnobs:
+    def test_window_and_quantile_and_minsamples_env(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_RECOVERY_PRIOR_WINDOW", raising=False)
+        assert isinstance(rec._recovery_prior_window(), int) and rec._recovery_prior_window() > 0
+        monkeypatch.setenv("JARVIS_RECOVERY_PRIOR_WINDOW", "8")
+        assert rec._recovery_prior_window() == 8
+        monkeypatch.delenv("JARVIS_RECOVERY_PRIOR_QUANTILE", raising=False)
+        d = rec._recovery_prior_quantile()
+        assert 0.0 < d < 1.0
+        monkeypatch.setenv("JARVIS_RECOVERY_PRIOR_QUANTILE", "0.4")
+        assert rec._recovery_prior_quantile() == 0.4
+
+    def test_singleton_accessor(self):
+        a = rec.get_recovery_prior()
+        b = rec.get_recovery_prior()
+        assert a is b  # process-wide accumulation of outage history
+
+
+class TestProberWiring:
+    """The prober records the outage duration on wake and consults the prior for
+    the first probe interval (source pins — the deep async loop is covered by the
+    injection integration test below + the existing prober suite)."""
+
+    def test_prober_records_duration_and_consults_prior(self):
+        from backend.core.ouroboros.governance import hibernation_prober as hp
+        src = inspect.getsource(hp)
+        assert "recovery_prior" in src or "RecoveryDurationPrior" in src or "get_recovery_prior" in src
+        assert "first_probe_interval" in src, "prober must derive the first interval from the prior"
+        assert ".record(" in src, "prober must record the outage duration on wake"

--- a/tests/governance/test_slice242_resurrection_soak.py
+++ b/tests/governance/test_slice242_resurrection_soak.py
@@ -1,0 +1,160 @@
+"""Slice 242 Phase 3 — end-to-end resurrection injection soak.
+
+We do not assume the hibernation persistence loop works — we prove it against a
+controllable, injected outage→recovery cycle (a live container soak cannot force
+a deterministic DW outage; this mock harness can). The flow proven here mirrors
+the production HIBERNATION_MODE step 6:
+
+  1. Inject a catastrophic grid outage  → every provider health_probe DOWN.
+  2. The Grid Sentinel (HibernationProber) backs off and keeps probing at ~$0.
+  3. Inject grid recovery               → a provider reports UP.
+  4. The prober autonomously fires controller.wake_from_hibernation AND records
+     the observed dark-window duration into the statistical prior.
+  5. On the NEXT outage, the prior (now holding history) times the first probe
+     from the recorded durations instead of the static default.
+
+Uses tiny real delays (no monkeypatched clock) so the asyncio backoff path is
+exercised exactly as in production, just compressed.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import dw_transport_recovery as rec
+from backend.core.ouroboros.governance.hibernation_prober import HibernationProber
+
+
+class _FakeController:
+    """Structurally-typed wake target — records the autonomous resurrection."""
+
+    def __init__(self) -> None:
+        self.woken = False
+        self.wake_reason = None
+        self.wake_calls = 0
+
+    async def wake_from_hibernation(self, reason: str) -> None:
+        self.woken = True
+        self.wake_reason = reason
+        self.wake_calls += 1
+
+
+class _GridProvider:
+    """Simulated DW endpoint. ``up_after`` probes return DOWN, then UP — i.e. the
+    dark window lasts ``up_after`` probe cycles before the grid recovers."""
+
+    provider_name = "doubleword-397b"
+
+    def __init__(self, up_after: int) -> None:
+        self._up_after = up_after
+        self.probe_count = 0
+
+    async def health_probe(self) -> bool:
+        self.probe_count += 1
+        return self.probe_count > self._up_after
+
+
+@pytest.fixture(autouse=True)
+def _isolate_prior():
+    rec.reset_recovery_prior()
+    yield
+    rec.reset_recovery_prior()
+
+
+class TestResurrectionSoak:
+    async def test_outage_then_autonomous_wake_records_duration(self):
+        """Inject a 2-cycle dark window → prober probes, recovers, wakes the
+        controller, and banks the outage duration into the prior."""
+        controller = _FakeController()
+        provider = _GridProvider(up_after=2)  # DOWN, DOWN, UP
+        prober = HibernationProber(
+            controller=controller,
+            providers=[provider],
+            initial_delay_s=0.02,
+            max_delay_s=0.05,
+            max_duration_s=10.0,
+        )
+
+        assert await prober.start() is True
+        # wait for the loop to probe through the dark window and wake
+        for _ in range(200):
+            if controller.woken:
+                break
+            await asyncio.sleep(0.02)
+        await prober.stop()
+
+        assert controller.woken is True, "grid recovered but controller was never woken"
+        assert controller.wake_calls == 1
+        assert provider.probe_count >= 3, "should have probed through the dark window"
+        assert prober.wake_count == 1
+        # the dark-window duration is now banked for next time
+        assert rec.get_recovery_prior().sample_count() == 1
+
+    async def test_prior_times_next_outage_from_history(self):
+        """After enough recorded outages, the NEXT first-probe interval is
+        derived from the dark-window history — not the static default."""
+        prior = rec.get_recovery_prior()
+        # bank a history of ~120s outages (min_samples default = 3)
+        for _ in range(5):
+            prior.record(120.0)
+
+        controller = _FakeController()
+        provider = _GridProvider(up_after=0)  # already UP
+        prober = HibernationProber(
+            controller=controller,
+            providers=[provider],
+            initial_delay_s=5.0,   # static default would wait 5s
+            max_delay_s=300.0,
+            max_duration_s=10.0,
+        )
+        # the adaptive first-probe delay is sourced from the prior (p25 ≈ 120s),
+        # proving we no longer blindly use the static 5s
+        derived = prober._first_probe_delay()
+        assert derived != 5.0, "prior should override the static default"
+        assert 100.0 <= derived <= 140.0, f"expected ~p25 of history, got {derived}"
+
+    async def test_gate_off_is_byte_identical_static(self, monkeypatch):
+        """Kill switch (=0) → the prober ignores the prior and uses the static
+        default, even with a rich outage history present."""
+        monkeypatch.setenv("JARVIS_RECOVERY_PRIOR_ENABLED", "0")
+        prior = rec.get_recovery_prior()
+        for _ in range(5):
+            prior.record(120.0)
+
+        prober = HibernationProber(
+            controller=_FakeController(),
+            providers=[_GridProvider(up_after=0)],
+            initial_delay_s=5.0,
+            max_delay_s=300.0,
+            max_duration_s=10.0,
+        )
+        assert prober._first_probe_delay() == 5.0  # static, prior ignored
+        # and the duration is NOT recorded when gated off
+        prior.reset()
+        prober._record_outage_duration(99.0)
+        assert prior.sample_count() == 0
+
+    async def test_full_two_outage_cycle_history_accumulates(self):
+        """Two successive inject→recover cycles each bank a duration — the prior
+        accumulates across hibernation cycles within the process."""
+        rec.reset_recovery_prior()
+        for cycle in range(2):
+            controller = _FakeController()
+            provider = _GridProvider(up_after=1)
+            prober = HibernationProber(
+                controller=controller,
+                providers=[provider],
+                initial_delay_s=0.02,
+                max_delay_s=0.05,
+                max_duration_s=10.0,
+            )
+            await prober.start()
+            for _ in range(200):
+                if controller.woken:
+                    break
+                await asyncio.sleep(0.02)
+            await prober.stop()
+            assert controller.woken is True
+
+        assert rec.get_recovery_prior().sample_count() == 2


### PR DESCRIPTION
## Slice 242 — The Adaptive Statistical Recovery Matrix & Resurrection Soak

Eradicates the static 5s first-probe interval in the hibernation Grid Sentinel. The `HibernationProber` already probes a dark DW grid on exponential backoff and auto-wakes on recovery — but its **first** probe was a hardcoded default. That's wasteful when outages historically last minutes: you ping a dark grid for nothing, and DW won't return any sooner.

This is an **online, training-free** estimator — explicitly **not** an ML/NN predictor. DW's recovery is an exogenous vendor event with no observable features; you can't forecast it, and a wrong guess strictly costs you. So we don't predict *when DW returns* — we optimize *when to start probing*.

### What it does
- Record observed dark-window durations (`enter_hibernation → wake`) into a bounded ring.
- Time the first re-probe near a low quantile (**p25**) of that history — don't ping before the grid plausibly recovers; ~$0 while dark; near-optimal resurrection latency.
- Below `min_samples` (default 3) → fall back to the static default (no trust yet).

### Changes
- **`dw_transport_recovery.py`** — `RecoveryDurationPrior`: `collections.deque` ring + linear-interpolation quantile + `first_probe_interval`. Pure, env-driven, thread-safe, NEVER raises (sits on the recovery path). Process-wide singleton accumulates across hibernation cycles. Knobs: `JARVIS_RECOVERY_PRIOR_{WINDOW,QUANTILE,MIN_SAMPLES,FLOOR_S}`.
- **`hibernation_prober.py`** — `_first_probe_delay()` derives the first interval from the prior; `_record_outage_duration()` banks the dark-window length on wake. Master `JARVIS_RECOVERY_PRIOR_ENABLED` default-TRUE (`=0` → byte-identical static-5s path).
- **Phase 3 resurrection injection soak** — deterministic `inject-outage → backoff → recover → autonomous wake → record → adaptive-next-probe` proof. A live container soak cannot force a deterministic DW outage; this mock harness can.

### Discipline
- **No duplication**: reuses the existing `dw_transport_recovery` module + the prober's existing backoff/wake loop. No parallel "Grid Sentinel."
- **No fiction**: does **not** attempt mid-stream LLM state serialization or "zero-lost-compute mid-DAG resume" (architecturally impossible against a stateless endpoint). The WAL's `_replay_wal` "no op left behind" remains the correct, untouched persistence granularity.
- **Zero regression**: `_replay_wal` untouched; existing prober + recovery + WAL suites green. **75 tests total, 14 new.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the fixed 5s first-probe delay with an adaptive, quantile-based delay learned from recent outage durations. This cuts wasted pings during long outages while keeping wake-ups fast.

- **New Features**
  - `RecoveryDurationPrior`: bounded ring of outage durations with linear-interpolated quantiles, clamped by floor/max; process-wide singleton. Env knobs: `JARVIS_RECOVERY_PRIOR_{WINDOW,QUANTILE,MIN_SAMPLES,FLOOR_S}`.
  - `HibernationProber` now derives `_first_probe_delay()` from the prior and records dark-window duration on wake; gate via `JARVIS_RECOVERY_PRIOR_ENABLED` (default on). Fully fail-soft to the static path on errors or insufficient history.
  - Added unit tests for the prior and an end-to-end resurrection soak covering inject→backoff→recover→record→adaptive-next-probe.

- **Migration**
  - No action required. To keep the previous behavior, set `JARVIS_RECOVERY_PRIOR_ENABLED=0`. Optional tuning via `JARVIS_RECOVERY_PRIOR_{WINDOW,QUANTILE,MIN_SAMPLES,FLOOR_S}`.

<sup>Written for commit 1bb1b3cc48a589e3b78b8f1b30f0cb8fe8f20c24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

