### PR TITLE
fix(gitignore): compiled-artifact invariant — root fix for 433 untracked .pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -387,3 +387,23 @@ terraform/terraform.tfvars
 .jarvis/vision_frames/
 .jarvis/vision_cost_ledger.json
 .jarvis/vision_sensor_fp_ledger.json
+
+# ─────────────────────────────────────────────────────────────────────────────
+# COMPILED-ARTIFACT INVARIANT — must remain the LAST word in this file.
+# ─────────────────────────────────────────────────────────────────────────────
+# gitignore is last-match-wins. The broad source re-includes above
+# (`!tests/core/**/*`, `!tests/unit/core/**/*`, `!docs/core/**/*`,
+# `!backend/context_intelligence/core/**/*`, `!backend/voice_unlock/core/**/*`)
+# exist to TRACK the .py source under those dirs-named-`core` (which the line-204
+# core-dump rule would otherwise exclude). But `**/*` also re-includes compiled
+# bytecode + caches under them — that is exactly how 355 .pyc files became
+# tracked (untracked in #69490). `backend/core` was hand-patched against this
+# (lines ~236-242); the test/doc trees were not. Rather than patch each tree,
+# re-assert the artifact excludes ONCE here, after every negation, so NO
+# re-include — present or future — can ever pull a build artifact back into
+# tracking. A directory exclude (`**/__pycache__/`) also blocks `**/*` re-entry
+# because git never descends into an excluded directory.
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/.pytest_cache/


### PR DESCRIPTION
## Root fix for the 433-file worktree churn

After #69490 untracked the 355 *committed* `.pyc`, **433 freshly-generated `.pyc` still surfaced as untracked** (the IDE's "434 files"). My earlier "verified robust" claim was wrong — I grepped for a filename while `git status --short` *collapses* untracked dirs, so I missed them.

**True root cause** (`git check-ignore -v`): the broad source re-includes `!tests/core/**/*` (line 223) and `!tests/unit/core/**/*` (line 227) — which exist to **track the `.py` source** the line-204 core-dump rule would otherwise exclude — also re-include `__pycache__/*.pyc` under those trees. Being *later* than the global `*.pyc` (line 5), they win (gitignore is **last-match-wins**). `backend/core` was hand-patched against this (lines ~236–242); the test/doc trees never were.

**Fix:** one **COMPILED-ARTIFACT INVARIANT** appended as the *last word* of `.gitignore`:
```
**/__pycache__/
**/*.pyc
**/*.pyo
**/.pytest_cache/
```
Last-match-wins makes it beat **every** negation — present and future — and the `**/__pycache__/` *directory* exclude blocks `**/*` re-entry because git never descends into an excluded dir. No per-tree hardcoding: one durable invariant covers all negated `core` trees (`tests/core`, `tests/unit/core`, `docs/core`, `backend/context_intelligence/core`, `backend/voice_unlock/core`).

**Verified empirically (counting individual files, not collapsed dirs):**
- `check-ignore -v` now reports `**/__pycache__/` wins (not the `!` negation).
- **433 → 0** untracked `.pyc`; 0 untracked `__pycache__`/`.pytest_cache` dirs.
- The legit `.py` source under `tests/unit/core` remains **tracked** (only artifacts re-excluded) — the negations still do their real job.

Together with #69490 (untrack + `forbid-pyc` pre-commit guard), the index is now clean *and* self-defending: artifacts can't re-enter via stale tracking, accidental `git add`, `git add -f`, or any future `core/**` re-include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a compiled-artifact invariant at the end of `.gitignore` to stop re-including `.pyc` and cache dirs under `core/**` trees. This removes 433 untracked `.pyc` and prevents future churn.

- **Bug Fixes**
  - Appended final rules: `**/__pycache__/`, `**/*.pyc`, `**/*.pyo`, `**/.pytest_cache/`.
  - Fixes last-match-wins issue causing negated `core/**` paths to re-include artifacts.
  - Directory exclude blocks `**/*` descent, preventing re-entry without per-tree patches.
  - Verified: 0 untracked artifacts; `.py` sources in tests/docs remain tracked.

<sup>Written for commit 5b75edec4ff7dd0f01520ca9b5449bad99f4a140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

