### PR TITLE
fix(battle_test): add FORBIDDEN_APP to MemoryType emoji/border renderer maps

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -98,6 +98,7 @@ def _memory_type_emoji(type_name: str) -> str:
         "reference": "🔗",
         "forbidden_path": "🚫",
         "style": "🎨",
+        "forbidden_app": "📵",
     }.get(type_name.lower(), "•")
 
 
@@ -109,6 +110,7 @@ def _memory_border_for_type(type_name: str) -> str:
         "reference": "magenta",
         "forbidden_path": "red",
         "style": "green",
+        "forbidden_app": "bright_red",
     }.get(type_name.lower(), "white")
 
 


### PR DESCRIPTION
## Cosmetic fix — `MemoryType.FORBIDDEN_APP` renderer coverage

`MemoryType.FORBIDDEN_APP` (the VisionSensor app-denylist kind) was added to the enum but never given emoji/border-color mappings in the battle_test REPL renderer (`harness.py`), so `_memory_type_emoji` / `_memory_border_for_type` fell through to the `•` / `white` defaults — failing the enum-coverage contract tests (`test_memory_type_emoji_covers_all_types`, `test_memory_border_for_type_covers_all_types`).

**Fix:** add `forbidden_app → 📵 / bright_red` (distinct from `forbidden_path`'s `red`) to both maps. Pure cosmetic; `tests/battle_test/test_plan_and_memory_cmds.py` now **26/26 green** (the 2 pre-existing failures resolved).

Built in an isolated git worktree under `.claude/worktrees/` with a sanctioned `ledger_sovereignty.mark_owned` lease (the same mechanism `WorktreeManager.create` uses for autonomous worktrees) — OCA gate honored, not bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing renderer mappings for `MemoryType.FORBIDDEN_APP` in `battle_test/harness.py`. Uses 📵 emoji and bright_red border so `_memory_type_emoji`/`_memory_border_for_type` no longer fall back to defaults and enum-coverage tests pass.

<sup>Written for commit eb4a27b0bc51d31861da164316f4b98ce11ddf43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

