### PR TITLE
refactor(supervisor): Slice 250 Phase B+C — The Purge (11 misfit organs/classes) + governance test pruning

### DIFF
--- a/tests/unit/backend/test_enterprise_organ_governance.py
+++ b/tests/unit/backend/test_enterprise_organ_governance.py
@@ -273,94 +273,6 @@ class TestStreamingAnalyticsEngineGovernance:
         assert healthy is False
 
 
-class TestConsentManagementSystemGovernance:
-    """ConsentManagementSystem must be a governed SystemService."""
-
-    def test_is_system_service(self):
-        from unified_supervisor import ConsentManagementSystem, SystemService
-        assert issubclass(ConsentManagementSystem, SystemService)
-
-    def test_constructor_purity(self):
-        from unified_supervisor import ConsentManagementSystem
-        cms = ConsentManagementSystem()
-        assert cms._initialized is False
-
-    def test_capability_contract(self):
-        from unified_supervisor import ConsentManagementSystem
-        cms = ConsentManagementSystem()
-        contract = cms.capability_contract()
-        assert contract.name == "ConsentManagementSystem"
-        assert "writes_consent_records" in contract.side_effects
-
-    def test_activation_triggers(self):
-        from unified_supervisor import ConsentManagementSystem
-        cms = ConsentManagementSystem()
-        triggers = cms.activation_triggers()
-        assert isinstance(triggers, list)
-
-    @pytest.mark.asyncio
-    async def test_health_check_before_init(self):
-        from unified_supervisor import ConsentManagementSystem
-        cms = ConsentManagementSystem()
-        healthy, msg = await cms.health_check()
-        assert healthy is False
-
-    @pytest.mark.asyncio
-    async def test_lifecycle(self):
-        from unified_supervisor import ConsentManagementSystem
-        cms = ConsentManagementSystem()
-        await cms.initialize()
-        assert cms._initialized is True
-        healthy, msg = await cms.health_check()
-        assert healthy is True
-        await cms.cleanup()
-        assert cms._initialized is False
-
-
-class TestDigitalSignatureServiceGovernance:
-    """DigitalSignatureService must be a governed SystemService."""
-
-    def test_is_system_service(self):
-        from unified_supervisor import DigitalSignatureService, SystemService
-        assert issubclass(DigitalSignatureService, SystemService)
-
-    def test_constructor_purity(self):
-        from unified_supervisor import DigitalSignatureService
-        dss = DigitalSignatureService()
-        assert dss._initialized is False
-
-    def test_capability_contract(self):
-        from unified_supervisor import DigitalSignatureService
-        dss = DigitalSignatureService()
-        contract = dss.capability_contract()
-        assert contract.name == "DigitalSignatureService"
-        assert "writes_signature_store" in contract.side_effects
-
-    def test_activation_triggers(self):
-        from unified_supervisor import DigitalSignatureService
-        dss = DigitalSignatureService()
-        triggers = dss.activation_triggers()
-        assert isinstance(triggers, list)
-
-    @pytest.mark.asyncio
-    async def test_health_check_before_init(self):
-        from unified_supervisor import DigitalSignatureService
-        dss = DigitalSignatureService()
-        healthy, msg = await dss.health_check()
-        assert healthy is False
-
-    @pytest.mark.asyncio
-    async def test_lifecycle(self):
-        from unified_supervisor import DigitalSignatureService
-        dss = DigitalSignatureService()
-        await dss.initialize()
-        assert dss._initialized is True
-        healthy, msg = await dss.health_check()
-        assert healthy is True
-        await dss.cleanup()
-        assert dss._initialized is False
-
-
 class TestLegacyDegradationManagerGovernance:
     """LegacyDegradationManager must be a governed SystemService."""
 
@@ -418,8 +330,6 @@ ORGAN_CLASSES = [
     "SessionManager",
     "DataLakeManager",
     "StreamingAnalyticsEngine",
-    "ConsentManagementSystem",
-    "DigitalSignatureService",
     "LegacyDegradationManager",
 ]
 
@@ -492,8 +402,6 @@ PERSISTENT_ORGANS = [
     "NotificationHub",
     "DataLakeManager",
     "StreamingAnalyticsEngine",
-    "ConsentManagementSystem",
-    "DigitalSignatureService",
     "LegacyDegradationManager",
 ]
 

--- a/tests/unit/supervisor/test_higher_functions_protocol.py
+++ b/tests/unit/supervisor/test_higher_functions_protocol.py
@@ -30,10 +30,8 @@ import pytest
 
 _USP_PATH = Path(__file__).resolve().parents[3] / "unified_supervisor.py"
 
-# The 32 higher functions classes
+# The 27 higher functions classes (5 enterprise organs purged in Slice 250 Phase B)
 _HIGHER_CLASSES = (
-    "BlueGreenDeployer",
-    "CanaryReleaseManager",
     "RollbackCoordinator",
     "DataPipelineManager",
     "InfrastructureProvisionerManager",
@@ -42,13 +40,10 @@ _HIGHER_CLASSES = (
     "GraphDatabaseManager",
     "SearchEngineManager",
     "IntegrationBusManager",
-    "TenantManager",
     "EncryptionServiceManager",
     "TemplateEngine",
     "ReportGenerator",
     "PluginManager",
-    "LocalizationManager",
-    "ABTestingFramework",
     "FeatureFlagManager",
     "ExternalServiceRegistry",
     "CalendarService",
@@ -139,13 +134,10 @@ _CONFIG_REQUIRED = frozenset({
     "GraphDatabaseManager",
     "SearchEngineManager",
     "IntegrationBusManager",
-    "TenantManager",
     "EncryptionServiceManager",
     "TemplateEngine",
     "ReportGenerator",
     "PluginManager",
-    "LocalizationManager",
-    "ABTestingFramework",
     "FeatureFlagManager",
     "ExternalServiceRegistry",
     "CalendarService",


### PR DESCRIPTION
## Slice 250 Phase B (The Purge) + C (Test Pruning)

Per `docs/superpowers/specs/2026-06-14-sovereign-distillation-design.md`. **Behavior-preserving at default config** (purged organs were `event_driven`/kill-switch-gated). **~3,300 lines removed** from `unified_supervisor.py`.

### B.1 — delete 3 dead `_Deprecated_*` classes (0 refs, verified)
`_Deprecated_IntelligentCacheManager`, `_Deprecated_SpotInstanceResilienceHandler`, `_Deprecated_EventSourcingManager`.

### B.2 — un-wire + delete 8 misfit enterprise organs
Per organ: registration → class → header-doc, with a **repo-wide grep across `backend/`, `extensions/`, `scripts/` run before each deletion** (the spec's #1 risk).
- **Zero external refs:** `TenantManager`, `LocalizationManager`, `BlueGreenDeployer`, `CanaryReleaseManager`, `ConsentManagementSystem`, `DigitalSignatureService` (`_organ_specs` tuples removed; `JARVIS_CONSENT_ENABLED`/`JARVIS_SIGNATURES_ENABLED` orphan flags scrubbed — not in FlagRegistry seed/.env.example).
- **Redundant supervisor copies** (live impls elsewhere, **untouched**): `ABTestingFramework` → `backend/core/model_management/unified_engine.py`; `ResourceQuotaManager` (multi-tenant) → `backend/core/system_primitives.py`. *(Spec said the AB impl was in `backend/vision/`; it's actually `model_management` — verified via grep.)*
- `OSResourceQuotaMonitor` (the Phase A rename of the OS-level monitor) is **retained**.

### C / B.3 — surgical governance test pruning
- `test_higher_functions_protocol.py`: removed the 5 purged organs from the `_HIGHER_CLASSES` + `_CONFIG_REQUIRED` parametrize lists → **109 passed**.
- `test_enterprise_organ_governance.py`: deleted the Consent + Signature test classes + coverage-list entries; **`MLOpsModelRegistry` + all surviving-organ tests retained** → **85 passed**.

### Verification
- `list-dupes` = 0; `test_no_shadowed_definitions` + `test_higher_functions_protocol` = **111 passed** (sandbox); `test_enterprise_organ_governance` = **85 passed** sandbox-off — which **imports `unified_supervisor` clean**, proving no dangling refs broke the kernel after the purge (the spec's import-sanity). `py_compile` clean.
- All structural edits via the AST-derived `_distillation_surgeon` (no hardcoded line numbers, drift-immune; registration removed before class so no dangling ref).

### Definition of Done (spec §8)
✅ 0 duplicate class names (Phase A); ✅ 8 organs + 3 deprecated removed, registrations + header docs scrubbed; ✅ governance tests green (purged removed, MLOps kept); ✅ kernel imports clean; ✅ no orphaned purged-organ flags; ✅ net reduction (~3,600 lines across A+B), zero behavior change at default config. Phase C (Cybernetic Reanimation) remains a separate future spec.

Built in an OCA-owned isolated worktree off clean `origin/main` (legacy `sovereign/distillation-*` branches abandoned per operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Purges 11 unused or redundant supervisor classes and prunes related governance tests, cutting ~3,300 lines from `unified_supervisor.py`. Behavior is unchanged at default config; imports and governance suites remain green.

- **Refactors**
  - Deleted 3 deprecated classes: `_Deprecated_IntelligentCacheManager`, `_Deprecated_SpotInstanceResilienceHandler`, `_Deprecated_EventSourcingManager`.
  - Removed 6 unused enterprise organs: TenantManager, LocalizationManager, BlueGreenDeployer, CanaryReleaseManager, ConsentManagementSystem, DigitalSignatureService.
  - Removed redundant supervisor copies of ABTestingFramework and ResourceQuotaManager; live implementations remain in `backend/core/model_management/unified_engine.py` and `backend/core/system_primitives.py`.
  - Scrubbed registrations, header docs, and orphan flags `JARVIS_CONSENT_ENABLED` and `JARVIS_SIGNATURES_ENABLED`. Retained `OSResourceQuotaMonitor`.
  - Pruned tests to drop purged classes in `tests/unit/supervisor/test_higher_functions_protocol.py` and `tests/unit/backend/test_enterprise_organ_governance.py`; all suites pass and `py_compile` is clean.

<sup>Written for commit ae8ec884951c3f54f074997858b3ad7fd3324110. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

