### PR TITLE
Cybernetic Reanimation (Phase C): event-driven resilience matrix

### DIFF
--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -45,7 +45,114 @@ _HARDEN_AND_CONSOLIDATE = {
 }
 
 
+_REANIMATION_SRC = (
+    "backend/core/ouroboros/governance/resilience_reanimation.py"
+)
+
+
+def _reanimate_organ_spec(organ_key: str, organ_label: str) -> "FlagSpec":
+    """One per-organ kill switch ``JARVIS_REANIMATE_<ORGAN>_ENABLED`` (default
+    true; gated under the master). Kept DRY across the 7 resilience organs."""
+    return FlagSpec(
+        name=f"JARVIS_REANIMATE_{organ_key.upper()}_ENABLED",
+        type=FlagType.BOOL, default=True,
+        description=(
+            f"Per-organ sub-gate for the {organ_label} adapter in the "
+            "Cybernetic Reanimation matrix. Default true, but only takes "
+            "effect when the master JARVIS_RESILIENCE_REANIMATION_ENABLED "
+            "is on. When false the organ is neither registered nor wired."
+        ),
+        category=Category.SAFETY,
+        source_file=_REANIMATION_SRC,
+        example="true",
+        since="v1.0",
+    )
+
+
+# The 7 reanimated resilience organs (adapter key -> human label).
+_REANIMATION_ORGANS = [
+    ("graceful_degradation", "GracefulDegradationManager"),
+    ("load_shedding", "LoadSheddingController"),
+    ("auto_scaling", "AutoScalingController"),
+    ("anomaly_detector", "AnomalyDetector"),
+    ("health_predictor", "ProcessHealthPredictor"),
+    ("self_healing", "SelfHealingOrchestrator"),
+    ("circuit_breaker", "AdvancedCircuitBreaker"),
+]
+
+
 SEED_SPECS: list = [
+    # ====================================================================
+    # Cybernetic Reanimation (Phase C) — event-driven resilience matrix
+    #   master + 7 per-organ gates + sampler interval + 3 thresholds
+    # ====================================================================
+    FlagSpec(
+        name="JARVIS_RESILIENCE_REANIMATION_ENABLED",
+        type=FlagType.BOOL, default=False,
+        description=(
+            "Master kill switch for the Cybernetic Reanimation matrix — the "
+            "bus->activation dispatcher, the edge-triggered PressureSignalEmitter, "
+            "and the 7 resilience-organ adapters. Default OFF: when false the "
+            "kernel constructs nothing and the boot path is byte-identical."
+        ),
+        category=Category.SAFETY,
+        source_file=_REANIMATION_SRC,
+        example="false",
+        since="v1.0",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
+    # Per-organ gates (pattern: JARVIS_REANIMATE_<ORGAN>_ENABLED, default true)
+    *[_reanimate_organ_spec(k, label) for k, label in _REANIMATION_ORGANS],
+    FlagSpec(
+        name="JARVIS_PRESSURE_SAMPLE_INTERVAL_S",
+        type=FlagType.FLOAT, default=5.0,
+        description=(
+            "Seconds between PressureSignalEmitter sampling ticks (the "
+            "background task that probes memory/CPU pressure and fires "
+            "edge-triggered resource_pressure events)."
+        ),
+        category=Category.TIMING,
+        source_file=_REANIMATION_SRC,
+        example="5.0",
+        since="v1.0",
+    ),
+    FlagSpec(
+        name="JARVIS_PRESSURE_MEM_THRESHOLD",
+        type=FlagType.FLOAT, default=0.9,
+        description=(
+            "Memory-pressure fraction (0..1) above which the "
+            "PressureSignalEmitter edge-fires a resource_pressure event."
+        ),
+        category=Category.TUNING,
+        source_file=_REANIMATION_SRC,
+        example="0.9",
+        since="v1.0",
+    ),
+    FlagSpec(
+        name="JARVIS_PRESSURE_CPU_THRESHOLD",
+        type=FlagType.FLOAT, default=0.9,
+        description=(
+            "CPU-pressure fraction (0..1) above which the "
+            "PressureSignalEmitter edge-fires a resource_pressure event."
+        ),
+        category=Category.TUNING,
+        source_file=_REANIMATION_SRC,
+        example="0.9",
+        since="v1.0",
+    ),
+    FlagSpec(
+        name="JARVIS_PRESSURE_DEGRADED_THRESHOLD",
+        type=FlagType.FLOAT, default=0.5,
+        description=(
+            "Component health-score fraction (0..1) at or below which a "
+            "component is treated as degraded, edge-firing a "
+            "component_degraded event into the reanimation matrix."
+        ),
+        category=Category.TUNING,
+        source_file=_REANIMATION_SRC,
+        example="0.5",
+        since="v1.0",
+    ),
     # ====================================================================
     # DirectionInferrer / StrategicPosture (Wave 1 #1) — 9 flags
     # ====================================================================

--- a/backend/core/ouroboros/governance/resilience_reanimation.py
+++ b/backend/core/ouroboros/governance/resilience_reanimation.py
@@ -1,0 +1,65 @@
+"""Cybernetic Reanimation (Phase C) — bus→activation bridge + pressure emitters.
+
+Standalone + injectable: never imports unified_supervisor at module scope, so it
+is unit-testable in environments where the kernel import is blocked. The kernel
+constructs the layer behind the JARVIS_RESILIENCE_REANIMATION_ENABLED flag and
+passes its live SupervisorEventBus + SystemServiceRegistry.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Iterable
+
+logger = logging.getLogger("resilience_reanimation")
+
+
+class EventActivationDispatcher:
+    """Subscribes to the supervisor event bus and activates registry services
+    whose ActivationContract.trigger_events match the emitted event type.
+
+    Adds NO new policy — the registry's gates (dependency/budget/backoff/rate)
+    remain authoritative. This is the missing wire, nothing more.
+    """
+
+    def __init__(self, event_bus: Any, service_registry: Any) -> None:
+        self._bus = event_bus
+        self._registry = service_registry
+        self._started = False
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._bus.subscribe(self._on_event)
+        self._started = True
+        logger.info("[Reanimation] dispatcher subscribed to event bus")
+
+    async def _on_event(self, event: Any) -> None:
+        try:
+            etype = event.event_type.value
+        except Exception:  # noqa: BLE001 — malformed event, ignore
+            return
+        try:
+            descriptors = list(self._registry.iter_event_driven())
+        except Exception as err:  # noqa: BLE001 — fail-soft
+            logger.warning("[Reanimation] registry iteration failed: %r", err)
+            return
+        activated = []
+        for desc in descriptors:
+            contract = getattr(desc, "activation_contract", None)
+            triggers = getattr(contract, "trigger_events", None) or []
+            if etype not in triggers:
+                continue
+            name = getattr(desc, "name", "")
+            try:
+                ok = await self._registry.activate_service(name)
+                if ok:
+                    activated.append(name)
+            except Exception as err:  # noqa: BLE001 — isolate per service
+                logger.warning(
+                    "[Reanimation] activate_service(%s) failed: %r", name, err
+                )
+        if activated:
+            logger.info(
+                "[Reanimation] event=%s activated=%s", etype, activated
+            )

--- a/backend/core/ouroboros/governance/resilience_reanimation.py
+++ b/backend/core/ouroboros/governance/resilience_reanimation.py
@@ -22,6 +22,21 @@ def _env_flag(name: str, default: bool = True) -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
+def _coerce_score(score: Any) -> Any:
+    """Best-effort numeric extraction from an AnomalyScore-like value.
+
+    The real organ returns an ``AnomalyScore`` dataclass with a ``.score``
+    attribute; tests pass a dict. Fail-soft — return None if neither shape
+    matches so the feedback payload stays well-formed.
+    """
+    val = getattr(score, "score", None)
+    if val is not None:
+        return val
+    if isinstance(score, dict):
+        return score.get("score")
+    return None
+
+
 class EventActivationDispatcher:
     """Subscribes to the supervisor event bus and activates registry services
     whose ActivationContract.trigger_events match the emitted event type.
@@ -126,14 +141,35 @@ class PressureSignalEmitter:
 
 
 class _OrganAdapter:
-    """Common fail-soft scaffold for organ adapters."""
+    """Common fail-soft scaffold for organ adapters.
+
+    ``emit`` is an OPTIONAL feedback callback ``emit(event_type_value, payload)``
+    that closes the reactive loop — an adapter that observes a meaningful organ
+    outcome (anomaly detected, breaker opened) re-broadcasts a typed event so
+    the rest of the matrix can react. Absent the callback an adapter behaves
+    exactly as before (backward-compatible). Emit failures are fail-soft.
+    """
 
     name: str = "organ"
     #: event_type.value strings this adapter reacts to.
     trigger_events: tuple = ()
 
-    def __init__(self, organ: Any) -> None:
+    def __init__(
+        self, organ: Any, *, emit: Optional[Callable[[str, dict], None]] = None
+    ) -> None:
         self._organ = organ
+        self._emit = emit
+
+    def _feedback(self, event_type_value: str, payload: dict) -> None:
+        """Fire the optional feedback emit, fail-soft. No-op without a callback."""
+        if self._emit is None:
+            return
+        try:
+            self._emit(event_type_value, payload)
+        except Exception as err:  # noqa: BLE001 — feedback must never wedge
+            logger.warning(
+                "[Reanimation] %s feedback emit failed: %r", self.name, err
+            )
 
     async def _safe(self, coro_or_value: Any) -> Any:
         """Await a value if it is awaitable; swallow + log on failure."""
@@ -224,7 +260,20 @@ class AnomalyDetectorAdapter(_OrganAdapter):
         try:
             category = payload.get("category", "unknown")
             features = payload.get("features") or {}
-            await self._safe(self._organ.record_observation(category, features))
+            score = await self._safe(
+                self._organ.record_observation(category, features)
+            )
+            # Closed loop: a truthy AnomalyScore means an anomaly was detected →
+            # re-broadcast so the matrix (e.g. self-healing) can react.
+            if score:
+                self._feedback(
+                    "anomaly_detected",
+                    {
+                        "category": category,
+                        "score": _coerce_score(score),
+                        "features": features,
+                    },
+                )
         except asyncio.CancelledError:
             raise
         except Exception as err:  # noqa: BLE001
@@ -282,6 +331,19 @@ class CircuitBreakerAdapter(_OrganAdapter):
         try:
             if payload.get("degraded", True):
                 await self._safe(self._organ.record_failure())
+                # Closed loop: a degraded component is an OPEN/degraded signal →
+                # re-broadcast component_degraded for the heal-tier organs.
+                self._feedback(
+                    "component_degraded",
+                    {
+                        "component": payload.get("component", "unknown"),
+                        "health_score": payload.get("health_score", 0.0),
+                        "failure_probability": payload.get(
+                            "failure_probability", 1.0
+                        ),
+                        "degraded": True,
+                    },
+                )
             else:
                 await self._safe(self._organ.record_success())
         except asyncio.CancelledError:
@@ -345,6 +407,13 @@ class ReanimationLayer:
     ``descriptor_factory`` / ``contract_factory`` are optional injection seams
     so the kernel can pass the real ``ServiceDescriptor`` / ``ActivationContract``
     constructors; absent them the layer uses duck-typed stand-ins (sandbox-safe).
+
+    ``emit`` is the OPTIONAL closed-loop feedback callback
+    ``emit(event_type_value, payload)``. When provided it is handed to the
+    feedback-capable adapters (AnomalyDetector, CircuitBreaker) so a detected
+    anomaly / opened breaker re-broadcasts a typed event onto the bus. The
+    kernel supplies an ``emit`` that constructs + publishes a SupervisorEvent;
+    absent it the loop is open (legacy behaviour).
     """
 
     def __init__(
@@ -356,6 +425,7 @@ class ReanimationLayer:
         enabled_flags: Optional[Dict[str, bool]] = None,
         descriptor_factory: Optional[Callable[..., Any]] = None,
         contract_factory: Optional[Callable[..., Any]] = None,
+        emit: Optional[Callable[[str, dict], None]] = None,
     ) -> None:
         self._bus = event_bus
         self._registry = service_registry
@@ -363,6 +433,7 @@ class ReanimationLayer:
         self._enabled_flags = dict(enabled_flags or {})
         self._descriptor_factory = descriptor_factory
         self._contract_factory = contract_factory
+        self._emit = emit
         self._adapters: Dict[str, _OrganAdapter] = {}
         self._wired = False
 
@@ -383,7 +454,7 @@ class ReanimationLayer:
             if not self._organ_enabled(key):
                 logger.info("[Reanimation] organ %s disabled by flag", key)
                 continue
-            adapter = factory(organ)
+            adapter = factory(organ, emit=self._emit)
             self._adapters[key] = adapter
             self._register_contract(key, list(adapter.trigger_events))
         if self._adapters:
@@ -413,6 +484,12 @@ class ReanimationLayer:
 
     @staticmethod
     def _extract_payload(event: Any) -> dict:
+        # Real SupervisorEvent stores metadata as a tuple of (k, v) pairs and
+        # exposes a ``metadata_dict`` accessor; tests pass a plain dict. Prefer
+        # the dict accessor, then a dict metadata/payload, else empty.
+        md = getattr(event, "metadata_dict", None)
+        if isinstance(md, dict) and md:
+            return md
         meta = getattr(event, "metadata", None)
         if isinstance(meta, dict):
             return meta
@@ -439,3 +516,55 @@ class ReanimationLayer:
                     "[Reanimation] adapter %s dispatch failed: %r",
                     adapter.name, err,
                 )
+
+
+# ===========================================================================
+# C.4 — master-flag-guarded factory (OFF no-op proof)
+# ===========================================================================
+
+
+def reanimation_enabled() -> bool:
+    """Master kill switch — ``JARVIS_RESILIENCE_REANIMATION_ENABLED``.
+
+    Default OFF: absent / falsy → the layer is never wired. Mirrors the
+    kernel's ``_reanimation_enabled()`` so the standalone factory and the
+    kernel hook agree on the gate.
+    """
+    return _env_flag("JARVIS_RESILIENCE_REANIMATION_ENABLED", False)
+
+
+def build_reanimation_layer(
+    event_bus: Any,
+    service_registry: Any,
+    organs: Dict[str, Any],
+    *,
+    enabled_flags: Optional[Dict[str, bool]] = None,
+    descriptor_factory: Optional[Callable[..., Any]] = None,
+    contract_factory: Optional[Callable[..., Any]] = None,
+    emit: Optional[Callable[[str, dict], None]] = None,
+) -> Optional["ReanimationLayer"]:
+    """Construct + ``wire()`` a ``ReanimationLayer`` IFF the master flag is on.
+
+    When ``JARVIS_RESILIENCE_REANIMATION_ENABLED`` is false (the default) this
+    is a strict no-op: it returns ``None`` and touches neither the bus
+    (no subscribe) nor the registry (no register) — proving the OFF path is
+    byte-identical. Fail-soft: if construction/wiring raises, it logs and
+    returns ``None`` (reanimation must never break boot).
+    """
+    if not reanimation_enabled():
+        return None
+    try:
+        layer = ReanimationLayer(
+            event_bus,
+            service_registry,
+            organs,
+            enabled_flags=enabled_flags,
+            descriptor_factory=descriptor_factory,
+            contract_factory=contract_factory,
+            emit=emit,
+        )
+        layer.wire()
+        return layer
+    except Exception as err:  # noqa: BLE001 — never break boot
+        logger.warning("[Reanimation] build_reanimation_layer failed: %r", err)
+        return None

--- a/backend/core/ouroboros/governance/resilience_reanimation.py
+++ b/backend/core/ouroboros/governance/resilience_reanimation.py
@@ -63,3 +63,37 @@ class EventActivationDispatcher:
             logger.info(
                 "[Reanimation] event=%s activated=%s", etype, activated
             )
+
+
+class PressureSignalEmitter:
+    """Edge-triggered pressure sampler. Emits a typed event only when a signal
+    transitions from below to above its threshold (never every tick). Fail-soft.
+    """
+
+    def __init__(self, sampler, emit, thresholds, signal_event):
+        self._sampler = sampler          # () -> {signal: level}
+        self._emit = emit                # (event_type_value, payload) -> None
+        self._thresholds = dict(thresholds)
+        self._signal_event = dict(signal_event)
+        self._above = {}                 # signal -> bool (last state)
+
+    async def tick(self) -> None:
+        try:
+            sample = self._sampler() or {}
+        except Exception as err:  # noqa: BLE001 — fail-soft
+            logger.warning("[Reanimation] pressure sample failed: %r", err)
+            return
+        for signal, level in sample.items():
+            thr = self._thresholds.get(signal)
+            if thr is None:
+                continue
+            now_above = level >= thr
+            was_above = self._above.get(signal, False)
+            if now_above and not was_above:
+                etype = self._signal_event.get(signal)
+                if etype:
+                    try:
+                        self._emit(etype, {"signal": signal, "level": level})
+                    except Exception as err:  # noqa: BLE001
+                        logger.warning("[Reanimation] emit failed: %r", err)
+            self._above[signal] = now_above

--- a/backend/core/ouroboros/governance/resilience_reanimation.py
+++ b/backend/core/ouroboros/governance/resilience_reanimation.py
@@ -9,9 +9,17 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Callable, Iterable
+import os
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 logger = logging.getLogger("resilience_reanimation")
+
+
+def _env_flag(name: str, default: bool = True) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
 class EventActivationDispatcher:
@@ -97,3 +105,337 @@ class PressureSignalEmitter:
                     except Exception as err:  # noqa: BLE001
                         logger.warning("[Reanimation] emit failed: %r", err)
             self._above[signal] = now_above
+
+
+# ===========================================================================
+# C.3 — Organ adapters: thin, fail-soft bus→organ-method bridges
+# ===========================================================================
+#
+# Each adapter wraps ONE real resilience organ and exposes a single
+# ``async on_event(payload: dict)`` coroutine that maps the event payload to
+# the organ's real reaction method. Adapters add NO policy and own NO state —
+# they are the missing wire between an emitted event and a dormant organ's
+# real action method. Every organ call is wrapped: on error we log + continue
+# (a dead organ must never wedge the bus fan-out).
+#
+# Payload contract (produced by PressureSignalEmitter / feedback emitters):
+#   resource_pressure  -> {"signal","level"[, "memory"]}
+#   anomaly_detected   -> {"category","features"[, "metadata"]}
+#   component_degraded -> {"component","health_score","failure_probability",
+#                          "degraded"[, "metrics"]}
+
+
+class _OrganAdapter:
+    """Common fail-soft scaffold for organ adapters."""
+
+    name: str = "organ"
+    #: event_type.value strings this adapter reacts to.
+    trigger_events: tuple = ()
+
+    def __init__(self, organ: Any) -> None:
+        self._organ = organ
+
+    async def _safe(self, coro_or_value: Any) -> Any:
+        """Await a value if it is awaitable; swallow + log on failure."""
+        try:
+            if asyncio.iscoroutine(coro_or_value):
+                return await coro_or_value
+            return coro_or_value
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001 — adapters are fail-soft
+            logger.warning(
+                "[Reanimation] %s organ call failed: %r", self.name, err
+            )
+            return None
+
+    async def on_event(self, payload: dict) -> None:  # pragma: no cover - base
+        raise NotImplementedError
+
+
+class GracefulDegradationAdapter(_OrganAdapter):
+    """resource_pressure -> GracefulDegradationManager._check_resources().
+
+    The manager samples real resource pressure itself and adjusts its
+    degradation level; the event is the *trigger* to re-evaluate now rather
+    than wait for the next poll interval.
+    """
+
+    name = "graceful_degradation"
+    trigger_events = ("resource_pressure",)
+
+    async def on_event(self, payload: dict) -> None:
+        try:
+            await self._safe(self._organ._check_resources())
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            logger.warning("[Reanimation] %s on_event failed: %r", self.name, err)
+
+
+class LoadSheddingAdapter(_OrganAdapter):
+    """resource_pressure -> LoadSheddingController.record_load(level)."""
+
+    name = "load_shedding"
+    trigger_events = ("resource_pressure",)
+
+    async def on_event(self, payload: dict) -> None:
+        try:
+            level = float(payload.get("level", 0.0) or 0.0)
+            await self._safe(self._organ.record_load(level))
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            logger.warning("[Reanimation] %s on_event failed: %r", self.name, err)
+
+
+class AutoScalingAdapter(_OrganAdapter):
+    """resource_pressure -> AutoScalingController.record_metrics(); evaluate().
+
+    ``level`` is the primary pressure signal (cpu); ``memory`` (optional, a
+    0..1 fraction) maps to memory_percent. Fractions are scaled to percent
+    because the organ expects percentages.
+    """
+
+    name = "auto_scaling"
+    trigger_events = ("resource_pressure",)
+
+    async def on_event(self, payload: dict) -> None:
+        try:
+            cpu = float(payload.get("level", 0.0) or 0.0) * 100.0
+            mem = float(payload.get("memory", 0.0) or 0.0) * 100.0
+            await self._safe(
+                self._organ.record_metrics(cpu_percent=cpu, memory_percent=mem)
+            )
+            await self._safe(self._organ.evaluate())
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            logger.warning("[Reanimation] %s on_event failed: %r", self.name, err)
+
+
+class AnomalyDetectorAdapter(_OrganAdapter):
+    """anomaly_detected -> AnomalyDetector.record_observation(category, features)."""
+
+    name = "anomaly_detector"
+    trigger_events = ("anomaly_detected",)
+
+    async def on_event(self, payload: dict) -> None:
+        try:
+            category = payload.get("category", "unknown")
+            features = payload.get("features") or {}
+            await self._safe(self._organ.record_observation(category, features))
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            logger.warning("[Reanimation] %s on_event failed: %r", self.name, err)
+
+
+class ProcessHealthPredictorAdapter(_OrganAdapter):
+    """component_degraded -> ProcessHealthPredictor.record_metrics(component, metrics)."""
+
+    name = "health_predictor"
+    trigger_events = ("component_degraded",)
+
+    async def on_event(self, payload: dict) -> None:
+        try:
+            component = payload.get("component", "unknown")
+            metrics = payload.get("metrics") or {}
+            await self._safe(self._organ.record_metrics(component, metrics))
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            logger.warning("[Reanimation] %s on_event failed: %r", self.name, err)
+
+
+class SelfHealingAdapter(_OrganAdapter):
+    """component_degraded -> SelfHealingOrchestrator.check_and_remediate(...)."""
+
+    name = "self_healing"
+    trigger_events = ("component_degraded",)
+
+    async def on_event(self, payload: dict) -> None:
+        try:
+            component = payload.get("component", "unknown")
+            health = float(payload.get("health_score", 1.0) or 0.0)
+            fail_prob = float(payload.get("failure_probability", 0.0) or 0.0)
+            await self._safe(
+                self._organ.check_and_remediate(component, health, fail_prob)
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            logger.warning("[Reanimation] %s on_event failed: %r", self.name, err)
+
+
+class CircuitBreakerAdapter(_OrganAdapter):
+    """component_degraded -> AdvancedCircuitBreaker.record_failure()/record_success().
+
+    A degraded component is a failure signal for the breaker; a healthy
+    component_degraded=False event records a success (recovery hint).
+    """
+
+    name = "circuit_breaker"
+    trigger_events = ("component_degraded",)
+
+    async def on_event(self, payload: dict) -> None:
+        try:
+            if payload.get("degraded", True):
+                await self._safe(self._organ.record_failure())
+            else:
+                await self._safe(self._organ.record_success())
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            logger.warning("[Reanimation] %s on_event failed: %r", self.name, err)
+
+
+# Default contract trigger mapping per organ key. Mirrors each adapter's
+# ``trigger_events``; used both for adapter fan-out and for the Activation
+# contracts registered on the service registry.
+_ADAPTER_FACTORIES: Dict[str, Any] = {
+    "graceful_degradation": GracefulDegradationAdapter,
+    "load_shedding": LoadSheddingAdapter,
+    "auto_scaling": AutoScalingAdapter,
+    "anomaly_detector": AnomalyDetectorAdapter,
+    "health_predictor": ProcessHealthPredictorAdapter,
+    "self_healing": SelfHealingAdapter,
+    "circuit_breaker": CircuitBreakerAdapter,
+}
+
+
+class _MiniContract:
+    """Duck-typed ActivationContract for the standalone (no-kernel) path.
+
+    When the real ``ActivationContract`` dataclass is injectable (kernel path)
+    the layer prefers it; in unit tests / sandbox we attach this minimal
+    stand-in carrying just ``trigger_events`` so ``iter_event_driven()`` and
+    the EventActivationDispatcher can still match it.
+    """
+
+    def __init__(self, trigger_events: List[str]) -> None:
+        self.trigger_events = list(trigger_events)
+        self.dependency_gate: List[str] = []
+
+
+class _MiniDescriptor:
+    """Duck-typed ServiceDescriptor stand-in for the standalone path."""
+
+    def __init__(self, name: str, contract: Any) -> None:
+        self.name = name
+        self.activation_contract = contract
+        self.activation_mode = "event_driven"
+
+
+class ReanimationLayer:
+    """Wires the 7 resilience organs into the event bus + service registry.
+
+    On ``wire()`` it:
+      1. Builds one adapter per enabled organ.
+      2. Subscribes a single fan-out handler to the bus that, per event,
+         dispatches to every adapter whose ``trigger_events`` contains the
+         event type, passing the payload extracted from event metadata.
+      3. Registers one descriptor per enabled organ carrying an
+         ActivationContract(trigger_events=...) so the C.1
+         EventActivationDispatcher can lazy-activate dormant organs.
+
+    Per-organ gating: ``JARVIS_REANIMATE_<ORGAN>_ENABLED`` (default true).
+    The ``enabled_flags`` constructor arg overrides env (test seam).
+
+    ``descriptor_factory`` / ``contract_factory`` are optional injection seams
+    so the kernel can pass the real ``ServiceDescriptor`` / ``ActivationContract``
+    constructors; absent them the layer uses duck-typed stand-ins (sandbox-safe).
+    """
+
+    def __init__(
+        self,
+        event_bus: Any,
+        service_registry: Any,
+        organs: Dict[str, Any],
+        *,
+        enabled_flags: Optional[Dict[str, bool]] = None,
+        descriptor_factory: Optional[Callable[..., Any]] = None,
+        contract_factory: Optional[Callable[..., Any]] = None,
+    ) -> None:
+        self._bus = event_bus
+        self._registry = service_registry
+        self._organs = dict(organs)
+        self._enabled_flags = dict(enabled_flags or {})
+        self._descriptor_factory = descriptor_factory
+        self._contract_factory = contract_factory
+        self._adapters: Dict[str, _OrganAdapter] = {}
+        self._wired = False
+
+    # -- gating ------------------------------------------------------------
+    def _organ_enabled(self, key: str) -> bool:
+        if key in self._enabled_flags:
+            return bool(self._enabled_flags[key])
+        return _env_flag(f"JARVIS_REANIMATE_{key.upper()}_ENABLED", True)
+
+    # -- wiring ------------------------------------------------------------
+    def wire(self) -> None:
+        if self._wired:
+            return
+        for key, factory in _ADAPTER_FACTORIES.items():
+            organ = self._organs.get(key)
+            if organ is None:
+                continue
+            if not self._organ_enabled(key):
+                logger.info("[Reanimation] organ %s disabled by flag", key)
+                continue
+            adapter = factory(organ)
+            self._adapters[key] = adapter
+            self._register_contract(key, list(adapter.trigger_events))
+        if self._adapters:
+            self._bus.subscribe(self._on_event)
+        self._wired = True
+        logger.info(
+            "[Reanimation] layer wired: organs=%s", sorted(self._adapters)
+        )
+
+    def _register_contract(self, key: str, triggers: List[str]) -> None:
+        try:
+            if self._contract_factory is not None:
+                contract = self._contract_factory(
+                    trigger_events=triggers, dependency_gate=[]
+                )
+            else:
+                contract = _MiniContract(triggers)
+            if self._descriptor_factory is not None:
+                desc = self._descriptor_factory(key, contract)
+            else:
+                desc = _MiniDescriptor(key, contract)
+            self._registry.register(desc)
+        except Exception as err:  # noqa: BLE001 — registration must never wedge boot
+            logger.warning(
+                "[Reanimation] register contract for %s failed: %r", key, err
+            )
+
+    @staticmethod
+    def _extract_payload(event: Any) -> dict:
+        meta = getattr(event, "metadata", None)
+        if isinstance(meta, dict):
+            return meta
+        payload = getattr(event, "payload", None)
+        if isinstance(payload, dict):
+            return payload
+        return {}
+
+    async def _on_event(self, event: Any) -> None:
+        try:
+            etype = event.event_type.value
+        except Exception:  # noqa: BLE001 — malformed event
+            return
+        payload = self._extract_payload(event)
+        for adapter in self._adapters.values():
+            if etype not in adapter.trigger_events:
+                continue
+            try:
+                await adapter.on_event(payload)
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:  # noqa: BLE001 — isolate per adapter
+                logger.warning(
+                    "[Reanimation] adapter %s dispatch failed: %r",
+                    adapter.name, err,
+                )

--- a/docs/superpowers/plans/2026-06-14-cybernetic-reanimation-phase-c.md
+++ b/docs/superpowers/plans/2026-06-14-cybernetic-reanimation-phase-c.md
@@ -1,0 +1,396 @@
+# Cybernetic Reanimation (Phase C) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Turn the dead event-driven resilience infrastructure in `unified_supervisor.py` into a live, edge-triggered async reactive nervous system: a bus→activation dispatcher, typed pressure emitters, and 7 resilience organs registered to fire on events — all in a focused, unit-testable module, default-OFF.
+
+**Architecture:** New module `backend/core/ouroboros/governance/resilience_reanimation.py` holds all reactive logic (importable + testable in isolation with mock bus/registry — `import unified_supervisor` is sandbox-blocked by split-brain-guard). The kernel gains one master-flag-guarded hook. Reuses `SupervisorEventBus`, `SystemServiceRegistry`, `ActivationContract` as-is.
+
+**Tech Stack:** Python 3.11, asyncio, `ast`/`tokenize`, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-cybernetic-reanimation-design.md`
+
+**Environment:** Work in worktree `/Users/djrussell23/Documents/repos/JARVIS-AI-Agent/.claude/worktrees/reanimation` (branch `feature/cybernetic-reanimation`, OCA-owned → commits authorized). `import unified_supervisor` FAILS in sandbox (split-brain-guard) — the new module must NOT import `unified_supervisor` at module top level; it takes the bus/registry as injected constructor args (duck-typed), so its tests never import the kernel.
+
+---
+
+## File Structure
+
+| File | Responsibility | Lifecycle |
+|---|---|---|
+| `backend/core/ouroboros/governance/resilience_reanimation.py` | Dispatcher + emitter + organ adapters + `ReanimationLayer` façade. No top-level `unified_supervisor` import. | Created C.1, extended C.2-C.4 |
+| `tests/governance/test_resilience_reanimation.py` | Unit + integration tests (mock/fake bus & registry) | Created C.1, extended |
+| `unified_supervisor.py` | `SupervisorEventType` += 3 values (C.2); kernel hook (C.1) | Modified |
+| `docs/superpowers/specs/2026-06-14-cybernetic-reanimation-design.md` | Spec (committed with impl in final PR) | Present |
+
+**Key design rule:** the module is provider-agnostic. The dispatcher accepts any object exposing `subscribe(handler)` (bus) and `activate_service(name)`/an event-driven-descriptor iterator (registry). This keeps it unit-testable with fakes.
+
+---
+
+## Task C.1: EventActivationDispatcher + module skeleton + kernel hook
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/resilience_reanimation.py`
+- Create: `tests/governance/test_resilience_reanimation.py`
+- Modify: `unified_supervisor.py` (guarded kernel hook + `iter_event_driven()` accessor on `SystemServiceRegistry`)
+
+- [ ] **Step 1: Write failing tests for the dispatcher**
+
+Create `tests/governance/test_resilience_reanimation.py`:
+
+```python
+"""Unit tests for the Cybernetic Reanimation layer (Phase C).
+
+These import ONLY the standalone module — never unified_supervisor (which is
+sandbox-blocked by split_brain_guard). Bus + registry are fakes.
+"""
+import asyncio
+import pytest
+
+from backend.core.ouroboros.governance.resilience_reanimation import (
+    EventActivationDispatcher,
+)
+
+
+class FakeBus:
+    def __init__(self):
+        self.handlers = []
+    def subscribe(self, handler):
+        self.handlers.append(handler)
+    async def fire(self, event):
+        for h in self.handlers:
+            r = h(event)
+            if asyncio.iscoroutine(r):
+                await r
+
+
+class FakeEvent:
+    def __init__(self, type_value):
+        self.event_type = type(self).Type(type_value)
+    class Type:
+        def __init__(self, value): self.value = value
+
+
+class FakeDescriptor:
+    def __init__(self, name, trigger_events):
+        self.name = name
+        self.activation_contract = type("C", (), {"trigger_events": trigger_events})()
+
+
+class FakeRegistry:
+    def __init__(self, descriptors):
+        self._descs = descriptors
+        self.activated = []
+        self.fail_on = set()
+    def iter_event_driven(self):
+        return list(self._descs)
+    async def activate_service(self, name):
+        if name in self.fail_on:
+            raise RuntimeError(f"boom:{name}")
+        self.activated.append(name)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_activates_matching_service():
+    bus = FakeBus()
+    reg = FakeRegistry([FakeDescriptor("grace", ["resource_pressure"])])
+    d = EventActivationDispatcher(bus, reg)
+    d.start()
+    await bus.fire(FakeEvent("resource_pressure"))
+    assert reg.activated == ["grace"]
+
+
+@pytest.mark.asyncio
+async def test_non_matching_event_does_not_activate():
+    bus = FakeBus()
+    reg = FakeRegistry([FakeDescriptor("grace", ["resource_pressure"])])
+    EventActivationDispatcher(bus, reg).start()
+    await bus.fire(FakeEvent("phase_start"))
+    assert reg.activated == []
+
+
+@pytest.mark.asyncio
+async def test_one_failing_activation_does_not_block_others():
+    bus = FakeBus()
+    reg = FakeRegistry([
+        FakeDescriptor("bad", ["resource_pressure"]),
+        FakeDescriptor("good", ["resource_pressure"]),
+    ])
+    reg.fail_on = {"bad"}
+    EventActivationDispatcher(bus, reg).start()
+    await bus.fire(FakeEvent("resource_pressure"))
+    assert reg.activated == ["good"]  # bad failed, good still ran
+```
+
+- [ ] **Step 2: Run tests — verify they FAIL (module missing)**
+
+Run: `cd <worktree> && python3 -m pytest tests/governance/test_resilience_reanimation.py -q`
+Expected: collection/import error — module `resilience_reanimation` does not exist yet.
+
+- [ ] **Step 3: Implement the module + dispatcher (minimal)**
+
+Create `backend/core/ouroboros/governance/resilience_reanimation.py`:
+
+```python
+"""Cybernetic Reanimation (Phase C) — bus→activation bridge + pressure emitters.
+
+Standalone + injectable: never imports unified_supervisor at module scope, so it
+is unit-testable in environments where the kernel import is blocked. The kernel
+constructs the layer behind the JARVIS_RESILIENCE_REANIMATION_ENABLED flag and
+passes its live SupervisorEventBus + SystemServiceRegistry.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Iterable
+
+logger = logging.getLogger("resilience_reanimation")
+
+
+class EventActivationDispatcher:
+    """Subscribes to the supervisor event bus and activates registry services
+    whose ActivationContract.trigger_events match the emitted event type.
+
+    Adds NO new policy — the registry's gates (dependency/budget/backoff/rate)
+    remain authoritative. This is the missing wire, nothing more.
+    """
+
+    def __init__(self, event_bus: Any, service_registry: Any) -> None:
+        self._bus = event_bus
+        self._registry = service_registry
+        self._started = False
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._bus.subscribe(self._on_event)
+        self._started = True
+        logger.info("[Reanimation] dispatcher subscribed to event bus")
+
+    async def _on_event(self, event: Any) -> None:
+        try:
+            etype = event.event_type.value
+        except Exception:  # noqa: BLE001 — malformed event, ignore
+            return
+        try:
+            descriptors = list(self._registry.iter_event_driven())
+        except Exception as err:  # noqa: BLE001 — fail-soft
+            logger.warning("[Reanimation] registry iteration failed: %r", err)
+            return
+        activated = []
+        for desc in descriptors:
+            contract = getattr(desc, "activation_contract", None)
+            triggers = getattr(contract, "trigger_events", None) or []
+            if etype not in triggers:
+                continue
+            name = getattr(desc, "name", "")
+            try:
+                ok = await self._registry.activate_service(name)
+                if ok:
+                    activated.append(name)
+            except Exception as err:  # noqa: BLE001 — isolate per service
+                logger.warning(
+                    "[Reanimation] activate_service(%s) failed: %r", name, err
+                )
+        if activated:
+            logger.info(
+                "[Reanimation] event=%s activated=%s", etype, activated
+            )
+```
+
+- [ ] **Step 4: Run tests — verify PASS**
+
+Run: `python3 -m pytest tests/governance/test_resilience_reanimation.py -q`
+Expected: 3 passed.
+
+- [ ] **Step 5: Add `iter_event_driven()` accessor to `SystemServiceRegistry`**
+
+Read `unified_supervisor.py` around `class SystemServiceRegistry` (~line 13809) and its `register`/descriptor storage. Add a minimal **read-only** method that yields registered `ServiceDescriptor`s whose `activation_mode == "event_driven"` (or that carry an `activation_contract`). Pure-add; no behavior change to existing methods. Confirm `ServiceDescriptor` exposes `.name` and `.activation_contract` (read the dataclass; if the field is named differently, match it and update the test's `FakeDescriptor` to the real attribute name).
+
+- [ ] **Step 6: Add the guarded kernel hook**
+
+Read the `JarvisSystemKernel` boot sequence where `self._service_registry` is created and the event bus is available. Add, behind a flag helper:
+
+```python
+# near other env-flag helpers
+def _reanimation_enabled() -> bool:
+    import os
+    return os.getenv("JARVIS_RESILIENCE_REANIMATION_ENABLED", "false").strip().lower() in ("1", "true", "yes", "on")
+```
+and in boot (after registry + bus exist):
+```python
+if _reanimation_enabled():
+    try:
+        from backend.core.ouroboros.governance.resilience_reanimation import EventActivationDispatcher
+        self._reanimation_dispatcher = EventActivationDispatcher(get_event_bus(), self._service_registry)
+        self._reanimation_dispatcher.start()
+    except Exception as _e:  # fail-soft — reanimation must never break boot
+        self._logger.warning(f"[Reanimation] disabled (init failed): {_e!r}")
+```
+OFF path: the `if` is false → nothing constructed → byte-identical.
+
+- [ ] **Step 7: Verify supervisor still parses + guard/governance still green**
+
+Run:
+```bash
+python3 -c "import ast; ast.parse(open('unified_supervisor.py').read()); print('PARSE OK')"
+python3 -m pytest tests/unit/core/test_no_shadowed_definitions.py -q
+python3 -m pytest tests/governance/test_resilience_reanimation.py -q
+```
+Expected: PARSE OK; shadow guard 2 passed; reanimation tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/resilience_reanimation.py tests/governance/test_resilience_reanimation.py unified_supervisor.py
+git commit -m "feat(reanimation): C.1 — EventActivationDispatcher bridge + guarded kernel hook (default-off)"
+```
+
+---
+
+## Task C.2: SupervisorEventType extension + PressureSignalEmitter
+
+**Files:**
+- Modify: `unified_supervisor.py` (`SupervisorEventType` += 3 values)
+- Modify: `backend/core/ouroboros/governance/resilience_reanimation.py` (+ `PressureSignalEmitter`)
+- Modify: `tests/governance/test_resilience_reanimation.py` (+ emitter tests)
+
+- [ ] **Step 1: Add 3 enum values** to `SupervisorEventType` (additive):
+```python
+    RESOURCE_PRESSURE = "resource_pressure"
+    ANOMALY_DETECTED = "anomaly_detected"
+    COMPONENT_DEGRADED = "component_degraded"
+```
+Verify `ast.parse` OK.
+
+- [ ] **Step 2: Write failing emitter tests** (in the test file). The emitter is injectable: it takes a `sampler` callable returning a dict `{signal: level}` and an `emit(event_type_value, payload)` callable, plus a thresholds dict. Edge-trigger semantics:
+
+```python
+from backend.core.ouroboros.governance.resilience_reanimation import PressureSignalEmitter
+
+@pytest.mark.asyncio
+async def test_emitter_edge_triggers_once_on_crossing():
+    emitted = []
+    levels = {"mem": [0.5, 0.95, 0.96, 0.4]}   # below, cross, stay, drop
+    seq = iter(levels["mem"])
+    def sampler(): return {"mem": next(seq)}
+    em = PressureSignalEmitter(
+        sampler=sampler,
+        emit=lambda etype, payload: emitted.append((etype, payload)),
+        thresholds={"mem": 0.9},
+        signal_event={"mem": "resource_pressure"},
+    )
+    for _ in range(4):
+        await em.tick()
+    # crossing 0.5->0.95 emits once; 0.95->0.96 (stay above) no emit; drop resets
+    assert [e[0] for e in emitted] == ["resource_pressure"]
+
+@pytest.mark.asyncio
+async def test_emitter_reemits_after_drop_then_recross():
+    emitted = []
+    seq = iter([0.95, 0.4, 0.95])
+    em = PressureSignalEmitter(
+        sampler=lambda: {"mem": next(seq)},
+        emit=lambda etype, payload: emitted.append(etype),
+        thresholds={"mem": 0.9},
+        signal_event={"mem": "resource_pressure"},
+    )
+    for _ in range(3):
+        await em.tick()
+    assert emitted == ["resource_pressure", "resource_pressure"]
+
+@pytest.mark.asyncio
+async def test_emitter_failsoft_on_sampler_error():
+    def sampler(): raise RuntimeError("probe down")
+    em = PressureSignalEmitter(sampler=sampler, emit=lambda *a: None,
+                               thresholds={"mem": 0.9}, signal_event={"mem": "resource_pressure"})
+    await em.tick()  # must not raise
+```
+
+- [ ] **Step 3: Run — verify FAIL** (PressureSignalEmitter missing).
+
+- [ ] **Step 4: Implement `PressureSignalEmitter`** in the module:
+
+```python
+class PressureSignalEmitter:
+    """Edge-triggered pressure sampler. Emits a typed event only when a signal
+    transitions from below to above its threshold (never every tick). Fail-soft.
+    """
+
+    def __init__(self, sampler, emit, thresholds, signal_event):
+        self._sampler = sampler          # () -> {signal: level}
+        self._emit = emit                # (event_type_value, payload) -> None
+        self._thresholds = dict(thresholds)
+        self._signal_event = dict(signal_event)
+        self._above = {}                 # signal -> bool (last state)
+
+    async def tick(self) -> None:
+        try:
+            sample = self._sampler() or {}
+        except Exception as err:  # noqa: BLE001 — fail-soft
+            logger.warning("[Reanimation] pressure sample failed: %r", err)
+            return
+        for signal, level in sample.items():
+            thr = self._thresholds.get(signal)
+            if thr is None:
+                continue
+            now_above = level >= thr
+            was_above = self._above.get(signal, False)
+            if now_above and not was_above:
+                etype = self._signal_event.get(signal)
+                if etype:
+                    try:
+                        self._emit(etype, {"signal": signal, "level": level})
+                    except Exception as err:  # noqa: BLE001
+                        logger.warning("[Reanimation] emit failed: %r", err)
+            self._above[signal] = now_above
+```
+
+- [ ] **Step 5: Run — verify PASS** (all reanimation tests). **Step 6: Commit** `feat(reanimation): C.2 — typed pressure events + edge-triggered PressureSignalEmitter`.
+
+---
+
+## Task C.3: Register the 7 organs with ActivationContracts
+
+**Files:** Modify `resilience_reanimation.py` (organ adapters + `ReanimationLayer` registration helper), `unified_supervisor.py` (wire emitter sampler to real `DynamicRAMMonitor`/`psutil` + register organs via registry), tests.
+
+- [ ] **Step 1:** Read each organ's real API in `unified_supervisor.py`: `GracefulDegradationManager`, `LoadSheddingController` (`record_load`/`should_accept`), `AutoScalingController` (`record_metrics`/`evaluate`/`add_scale_callback`), `AnomalyDetector` (`record_observation`/`register_handler`), `ProcessHealthPredictor` (`record_metrics`), `SelfHealingOrchestrator` (`check_and_remediate`/`register_handler`), `AdvancedCircuitBreaker`. Note exact signatures.
+- [ ] **Step 2:** Write adapter unit tests (mock organ objects; assert the adapter maps an event payload → the correct organ method call). One test per organ.
+- [ ] **Step 3:** Implement adapters in the module (each adapter wraps an organ + exposes an `async on_event(payload)` calling the organ's API). Build a `ReanimationLayer` that registers each organ as a `ServiceDescriptor` with an `ActivationContract(trigger_events=[...])` via the injected registry, gated by `JARVIS_REANIMATE_<ORGAN>_ENABLED`.
+- [ ] **Step 4:** Wire the real sampler in the kernel hook: sampler reads `DynamicRAMMonitor`/`psutil`; thresholds from `JARVIS_PRESSURE_*` env. Register the emitter as a `KernelBackgroundTaskRegistry` task (interval `JARVIS_PRESSURE_SAMPLE_INTERVAL_S`).
+- [ ] **Step 5:** Verify (`ast.parse`, shadow guard, all reanimation tests). **Step 6: Commit** `feat(reanimation): C.3 — register 7 resilience organs with event-driven ActivationContracts`.
+
+---
+
+## Task C.4: Feedback emitters + integration proof + flags + finalize
+
+**Files:** Modify module (feedback wiring), `unified_supervisor.py` (AnomalyDetector→`anomaly_detected`, breaker→`component_degraded`; FlagRegistry seeds), tests.
+
+- [ ] **Step 1: Write the headline integration test** (module-level, real `SupervisorEventBus` if importable standalone — else a faithful FakeBus that delivers async): construct `ReanimationLayer` with a fake registry holding the 7 contracts; emit a synthetic `RESOURCE_PRESSURE`; assert `GracefulDegradationManager`/`LoadSheddingController`/`AutoScalingController` activate. Add an OFF test: layer factory with master flag false returns a no-op (no subscription, no registration).
+- [ ] **Step 2:** Implement feedback: `AnomalyDetector` adapter, on anomaly, calls `emit("anomaly_detected", ...)`; `AdvancedCircuitBreaker` `on_state_change(OPEN)` calls `emit("component_degraded", ...)`. Wire `ProcessHealthPredictor`→`SelfHealingOrchestrator` from the existing `_health_monitor_loop` (reuse; pass health score; on low score emit `component_degraded`).
+- [ ] **Step 3:** Register all flags in `FlagRegistry`: master + per-organ + thresholds + interval.
+- [ ] **Step 4: Full verification:**
+```bash
+python3 -c "import ast; ast.parse(open('unified_supervisor.py').read()); print('PARSE OK')"
+python3 -m pytest tests/unit/core/test_no_shadowed_definitions.py tests/governance/test_resilience_reanimation.py -q
+python3 -m pytest tests/unit/backend/test_enterprise_organ_governance.py tests/unit/supervisor/test_higher_functions_protocol.py --collect-only -q
+```
+Expected: PARSE OK; reanimation + shadow-guard green; governance collection 0 errors.
+- [ ] **Step 5: Commit spec + impl together** then push + PR:
+```bash
+git add -A
+git commit -m "feat(reanimation): C.4 — closed-loop feedback + integration proof + flags; Phase C complete"
+git push -u origin feature/cybernetic-reanimation
+gh pr create --title "Cybernetic Reanimation (Phase C): event-driven resilience matrix" --body "<spec summary + test plan>"
+```
+
+---
+
+## Self-Review
+- **Spec coverage:** bridge → C.1; pressure emitters → C.2; muscle registration → C.3; feedback + integration proof + flags → C.4. All §4 components mapped.
+- **Testability:** module never imports `unified_supervisor` at top level → all tests run in sandbox.
+- **OFF byte-identical:** kernel hook flag-guarded; verified by inspection + OFF test.
+- **No placeholders in C.1/C.2** (complete code). C.3/C.4 require reading real organ APIs first (instructed) — adapters are thin, signatures resolved at implementation.
+- **No hardcoding:** all intervals/thresholds/flags via env + FlagRegistry.

--- a/docs/superpowers/specs/2026-06-14-cybernetic-reanimation-design.md
+++ b/docs/superpowers/specs/2026-06-14-cybernetic-reanimation-design.md
@@ -1,0 +1,104 @@
+# Spec 2 — Cybernetic Reanimation (Phase C)
+
+**Date:** 2026-06-14
+**Author:** Derek J. Russell (O+V architect) / Claude
+**Target:** `unified_supervisor.py` @ `origin/main` (post-Distillation, 98,877 lines) + a new focused module.
+**Depends on:** Spec 1 (Sovereign Distillation, merged via #69497 / #69498).
+**Execution:** Manual, on an isolated OCA-owned worktree. Spec is committed together with the implementation in the final PR (NOT committed early — the autonomous loop ingests committed specs).
+
+---
+
+## 1. Problem Statement
+
+The event-driven resilience infrastructure already exists in `unified_supervisor.py` but is **dead config**:
+- `SystemServiceRegistry` supports `ActivationContract.trigger_events` + an `event_driven` activation mode, **but nothing dispatches `SupervisorEventBus` events to `activate_service()`** — so contracts never fire.
+- Seven resilience organs survive (each defined once on `origin/main`): `SelfHealingOrchestrator`, `ProcessHealthPredictor`, `AutoScalingController`, `AnomalyDetector`, `GracefulDegradationManager`, `LoadSheddingController`, `AdvancedCircuitBreaker` — none are wired to fire on system pressure.
+- There are no typed "pressure" signals on the bus to drive them.
+
+Phase C builds the missing bridge + the signals + the registration, turning the dead infrastructure into a live, **edge-triggered, asynchronous reactive nervous system** — no hardcoded polling loops, all cadences/thresholds env-tunable, fail-soft, default-OFF until soak-validated.
+
+## 2. Architecture Refinement (vs. the inline design)
+
+The reactive logic is implemented in a **new focused module** `backend/core/ouroboros/governance/resilience_reanimation.py`, NOT inline in `unified_supervisor.py`. Rationale:
+- **Testability:** `import unified_supervisor` raises `RuntimeError: split-brain-guard` in sandbox/CI-without-lockdirs. A standalone module is importable and unit-testable with a mock bus/registry — which is the only way to satisfy this spec's headline integration proof in the available environment.
+- **Modularity:** the kernel file is already 99K lines; new subsystems belong in focused modules (matches the `governance/` layout).
+- The kernel's only change is a **minimal master-flag-guarded hook** that constructs and starts the reanimation layer, passing it the kernel's existing `SupervisorEventBus` + `SystemServiceRegistry`. When the master flag is OFF the hook is not constructed → kernel behavior is **byte-identical**.
+
+## 3. Guiding Constraints
+
+- **Root-cause, no shortcuts.** Build the genuinely missing dispatcher; reuse `ActivationContract`/`SystemServiceRegistry`/`SupervisorEventBus` as-is — do not invent a parallel mechanism.
+- **No hardcoding.** Every interval/threshold/cap reads from a `JARVIS_*` env var with a sensible default, registered in `FlagRegistry`.
+- **Edge-triggered.** Emitters publish only on threshold *transitions*, never every tick — prevents event storms.
+- **Fail-soft.** Every handler/sample is wrapped; a failure logs + continues, never crashes the kernel.
+- **Default-OFF + graduation.** Master `JARVIS_RESILIENCE_REANIMATION_ENABLED` defaults `false`; OFF path byte-identical; graduate after soak.
+- **Absolute observability.** Dispatcher + emitter emit structured telemetry (`[Reanimation] ...`).
+
+## 4. Components
+
+### 4.1 `EventActivationDispatcher` (the bridge — root fix)
+- Constructed with `(event_bus, service_registry)`. On `start()`, calls `event_bus.subscribe(self._on_event)`.
+- `async _on_event(event: SupervisorEvent)`: looks up registry service descriptors whose `ActivationContract.trigger_events` contains `event.event_type.value`; for each match, `await service_registry.activate_service(name)`. The registry already enforces `dependency_gate` / `budget_gate` / `backoff_gate` / `max_activations_per_hour` / `deactivate_after_idle_s` — the dispatcher adds **no** new policy, it only connects.
+- Fault-isolated per match (one failing activation never blocks others); structured telemetry per dispatch.
+- Requires a registry accessor for "descriptors with contracts" — if `SystemServiceRegistry` lacks a public iterator, add a minimal read-only `iter_event_driven()` accessor (pure-add, no behavior change).
+
+### 4.2 `SupervisorEventType` extension + `PressureSignalEmitter`
+- Add three additive enum values: `RESOURCE_PRESSURE = "resource_pressure"`, `ANOMALY_DETECTED = "anomaly_detected"`, `COMPONENT_DEGRADED = "component_degraded"`.
+- `PressureSignalEmitter` runs as a kernel background task (registered via `KernelBackgroundTaskRegistry`, reusing the async spine — no bespoke loop). Each tick (interval `JARVIS_PRESSURE_SAMPLE_INTERVAL_S`, default 15) it samples:
+  - memory pressure via existing `DynamicRAMMonitor`,
+  - CPU/load via `IntelligentResourceOrchestrator`/`psutil`,
+  - component health via the existing `_health_monitor_loop` state.
+- **Edge-triggered:** keeps the last emitted level per signal; emits a typed `SupervisorEvent` only when a level *transition* crosses an env threshold (`JARVIS_PRESSURE_MEM_THRESHOLD`, `JARVIS_PRESSURE_CPU_THRESHOLD`, …). Payload carries level/metric/component in `metadata`.
+- Fail-soft sampling (a probe error logs + skips that signal for the tick).
+
+### 4.3 Muscle Registration (7 organs, event-driven contracts)
+Register each surviving organ as a `ServiceDescriptor` with an `ActivationContract` (mode `event_driven` unless noted). Reuse each organ's existing API:
+
+| Organ | `trigger_events` | Action |
+|---|---|---|
+| `GracefulDegradationManager` | `resource_pressure` | disable low-priority features for the level (event-driven, replacing its internal 10s poll) |
+| `LoadSheddingController` | `resource_pressure` | `record_load()` from payload; shed by priority |
+| `AutoScalingController` | `resource_pressure` | `evaluate()` → scale callbacks |
+| `AnomalyDetector` | `component_degraded`, `metric` | `record_observation()`; on anomaly → **emit `anomaly_detected`** |
+| `ProcessHealthPredictor` + `SelfHealingOrchestrator` | fed by existing `_health_monitor_loop` + `component_degraded` | predictor scores health → `SelfHealingOrchestrator.check_and_remediate()` |
+| `AdvancedCircuitBreaker` | wrapped on Trinity/provider calls | on OPEN → **emit `component_degraded`** |
+
+**Feedback loops:** `AnomalyDetector` emits `anomaly_detected` and breakers emit `component_degraded` — the dispatcher re-dispatches these, closing the reactive matrix through the one bus.
+
+### 4.4 Kernel hook (minimal, guarded)
+In `JarvisSystemKernel` boot, behind `if reanimation_enabled():` construct `ReanimationLayer(event_bus, service_registry, kernel_signals)` and register its emitter task + dispatcher start. OFF → not constructed → byte-identical.
+
+## 5. Flags (no hardcoding; all in `FlagRegistry`)
+- Master: `JARVIS_RESILIENCE_REANIMATION_ENABLED` (default `false`).
+- Per-organ: `JARVIS_REANIMATE_<ORGAN>_ENABLED` (default `true` when master on).
+- `JARVIS_PRESSURE_SAMPLE_INTERVAL_S` (15), `JARVIS_PRESSURE_MEM_THRESHOLD`, `JARVIS_PRESSURE_CPU_THRESHOLD`, `JARVIS_PRESSURE_DEGRADED_THRESHOLD` — sensible defaults, env-overridable.
+
+## 6. Testing & Verification (the proof, runnable in-sandbox via the extracted module)
+- **Unit (module imported in isolation, mock bus/registry):**
+  - Dispatcher: emit event whose type ∈ a service's `trigger_events` → that service's `activate_service` awaited; non-matching event → not activated; one failing activation doesn't block others.
+  - Emitter: rising metric across threshold → exactly one typed event; staying above → no repeat (edge-trigger); dropping below then rising → new event; probe exception → fail-soft skip.
+  - Each organ adapter: event payload → correct organ method called.
+- **Integration (module-level, the headline proof):** construct `ReanimationLayer` with a real `SupervisorEventBus` + a fake registry holding the 7 contracts; emit a synthetic `RESOURCE_PRESSURE` → assert `GracefulDegradationManager`/`LoadSheddingController`/`AutoScalingController` activate.
+- **OFF byte-identical:** master OFF → `ReanimationLayer` not constructed; prove the kernel hook is the only change and it's flag-guarded (code inspection + a test that the layer factory returns a no-op sentinel when disabled).
+- **No-regression:** `unified_supervisor.py` still `ast.parse`s; shadow-guard test green; governance tests still collect.
+
+## 7. Slice Plan (each independently green)
+- **C.1** New module skeleton + `EventActivationDispatcher` + registry `iter_event_driven()` accessor + unit tests (mock bus/registry). Kernel hook (guarded, default-off).
+- **C.2** `SupervisorEventType` += 3 values + `PressureSignalEmitter` (edge-triggered, fail-soft) + unit tests.
+- **C.3** Register the 7 organs with `ActivationContract`s + per-organ adapter unit tests.
+- **C.4** Feedback emitters (`AnomalyDetector`, `AdvancedCircuitBreaker`) + the synthetic `RESOURCE_PRESSURE` integration proof + flag registration + final verification.
+
+## 8. Risks & Mitigations
+| Risk | Mitigation |
+|---|---|
+| Event storms | edge-triggered emit + bus's bounded queue/drop-oldest |
+| Activation thrash | existing `max_activations_per_hour` / `backoff_gate` / `deactivate_after_idle_s` |
+| Kernel import unrunnable in sandbox | logic in standalone importable module; unit/integration tests there |
+| Behavior change | master default-OFF; OFF byte-identical; soak before graduation |
+| Double-driving (organ's own loop + events) | `GracefulDegradationManager` switched to event-driven; its internal poll disabled under reanimation |
+
+## 9. Definition of Done
+- New module with dispatcher + emitter + organ adapters; all unit + integration tests green (runnable in sandbox).
+- `SupervisorEventType` has the 3 new values; kernel hook guarded by master flag; OFF byte-identical.
+- 7 organs registered with contracts; synthetic `RESOURCE_PRESSURE` activates the pressure-tier organs in test.
+- All flags in `FlagRegistry`; `ast.parse` + shadow-guard + governance collection still green.
+- Spec + implementation committed together in one PR (master default-OFF).

--- a/tests/governance/test_resilience_reanimation.py
+++ b/tests/governance/test_resilience_reanimation.py
@@ -127,3 +127,265 @@ async def test_emitter_failsoft_on_sampler_error():
     em = PressureSignalEmitter(sampler=sampler, emit=lambda *a: None,
                                thresholds={"mem": 0.9}, signal_event={"mem": "resource_pressure"})
     await em.tick()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# C.3 — organ adapters + ReanimationLayer tests
+# ---------------------------------------------------------------------------
+from backend.core.ouroboros.governance.resilience_reanimation import (
+    GracefulDegradationAdapter,
+    LoadSheddingAdapter,
+    AutoScalingAdapter,
+    AnomalyDetectorAdapter,
+    ProcessHealthPredictorAdapter,
+    SelfHealingAdapter,
+    CircuitBreakerAdapter,
+    ReanimationLayer,
+)
+
+
+class MockOrgan:
+    """Records every method call as (name, args, kwargs)."""
+
+    def __init__(self, **returns):
+        self.calls = []
+        self._returns = returns
+
+    def _rec(self, name, *a, **k):
+        self.calls.append((name, a, k))
+        return self._returns.get(name)
+
+    # sync surfaces
+    def record_load(self, load):
+        return self._rec("record_load", load)
+
+    def record_metrics(self, *a, **k):
+        return self._rec("record_metrics", *a, **k)
+
+    # async surfaces — return whatever was configured
+    async def _check_resources(self):
+        return self._rec("_check_resources")
+
+    async def evaluate(self):
+        return self._rec("evaluate")
+
+    async def record_observation(self, *a, **k):
+        return self._rec("record_observation", *a, **k)
+
+    async def check_and_remediate(self, *a, **k):
+        return self._rec("check_and_remediate", *a, **k)
+
+    def record_failure(self, *a, **k):
+        return self._rec("record_failure", *a, **k)
+
+    def record_success(self, *a, **k):
+        return self._rec("record_success", *a, **k)
+
+    def names(self):
+        return [c[0] for c in self.calls]
+
+
+@pytest.mark.asyncio
+async def test_graceful_degradation_adapter_calls_check_resources():
+    organ = MockOrgan()
+    ad = GracefulDegradationAdapter(organ)
+    await ad.on_event({"signal": "mem", "level": 0.95})
+    assert organ.names() == ["_check_resources"]
+
+
+@pytest.mark.asyncio
+async def test_load_shedding_adapter_records_load_from_payload():
+    organ = MockOrgan()
+    ad = LoadSheddingAdapter(organ)
+    await ad.on_event({"signal": "cpu", "level": 0.92})
+    assert organ.calls == [("record_load", (0.92,), {})]
+
+
+@pytest.mark.asyncio
+async def test_autoscaling_adapter_records_then_evaluates():
+    organ = MockOrgan(evaluate="decision")
+    ad = AutoScalingAdapter(organ)
+    await ad.on_event({"signal": "cpu", "level": 0.88, "memory": 0.7})
+    names = organ.names()
+    assert names == ["record_metrics", "evaluate"]
+    # record_metrics gets cpu+mem fractions scaled to percent
+    rec = organ.calls[0]
+    assert rec[2].get("cpu_percent") == pytest.approx(88.0)
+    assert rec[2].get("memory_percent") == pytest.approx(70.0)
+
+
+@pytest.mark.asyncio
+async def test_anomaly_adapter_records_observation():
+    organ = MockOrgan()
+    ad = AnomalyDetectorAdapter(organ)
+    await ad.on_event({"category": "latency", "features": {"p99": 1200.0}})
+    assert organ.calls == [
+        ("record_observation", ("latency", {"p99": 1200.0}), {})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_health_predictor_adapter_records_metrics():
+    organ = MockOrgan(record_metrics={"health_score": 0.4, "failure_probability": 0.6})
+    ad = ProcessHealthPredictorAdapter(organ)
+    await ad.on_event({"component": "worker-1", "metrics": {"cpu": 95.0}})
+    assert organ.calls[0] == ("record_metrics", ("worker-1", {"cpu": 95.0}), {})
+
+
+@pytest.mark.asyncio
+async def test_self_healing_adapter_remediates_from_payload():
+    organ = MockOrgan()
+    ad = SelfHealingAdapter(organ)
+    await ad.on_event({
+        "component": "worker-1",
+        "health_score": 0.2,
+        "failure_probability": 0.8,
+    })
+    assert organ.calls == [
+        ("check_and_remediate", ("worker-1", 0.2, 0.8), {})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_adapter_records_failure_on_degraded():
+    organ = MockOrgan()
+    ad = CircuitBreakerAdapter(organ)
+    await ad.on_event({"component": "worker-1", "degraded": True})
+    assert organ.names() == ["record_failure"]
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_adapter_records_success_when_not_degraded():
+    organ = MockOrgan()
+    ad = CircuitBreakerAdapter(organ)
+    await ad.on_event({"component": "worker-1", "degraded": False})
+    assert organ.names() == ["record_success"]
+
+
+@pytest.mark.asyncio
+async def test_adapter_failsoft_swallows_organ_error():
+    class Boom:
+        def record_load(self, load):
+            raise RuntimeError("organ down")
+    ad = LoadSheddingAdapter(Boom())
+    # must not raise
+    await ad.on_event({"signal": "cpu", "level": 0.99})
+
+
+# ---- ReanimationLayer ------------------------------------------------------
+
+
+class _Meta:
+    def __init__(self, metadata):
+        self.metadata = metadata
+
+
+class FakeEventWithMeta:
+    def __init__(self, type_value, metadata=None):
+        self.event_type = type("T", (), {"value": type_value})()
+        self.metadata = metadata or {}
+
+
+class RecordingRegistry:
+    def __init__(self):
+        self.registered = []   # ServiceDescriptor-like
+
+    def register(self, desc):
+        self.registered.append(desc)
+
+    def iter_event_driven(self):
+        return list(self.registered)
+
+    async def activate_service(self, name):
+        return True
+
+
+def _seven_mock_organs():
+    return {
+        "graceful_degradation": MockOrgan(),
+        "load_shedding": MockOrgan(),
+        "auto_scaling": MockOrgan(evaluate="d"),
+        "anomaly_detector": MockOrgan(),
+        "health_predictor": MockOrgan(record_metrics={"health_score": 0.5}),
+        "self_healing": MockOrgan(),
+        "circuit_breaker": MockOrgan(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_layer_wire_subscribes_and_registers_seven_contracts():
+    bus = FakeBus()
+    reg = RecordingRegistry()
+    organs = _seven_mock_organs()
+    layer = ReanimationLayer(bus, reg, organs)
+    layer.wire()
+    # 7 descriptors registered, each carrying an activation_contract w/ triggers
+    assert len(reg.registered) == 7
+    for d in reg.registered:
+        assert getattr(d, "activation_contract", None) is not None
+        assert getattr(d.activation_contract, "trigger_events", None)
+    # bus has at least one subscriber (the adapter fan-out handler)
+    assert bus.handlers
+
+
+@pytest.mark.asyncio
+async def test_layer_resource_pressure_drives_pressure_tier_adapters():
+    bus = FakeBus()
+    reg = RecordingRegistry()
+    organs = _seven_mock_organs()
+    layer = ReanimationLayer(bus, reg, organs)
+    layer.wire()
+    await bus.fire(FakeEventWithMeta("resource_pressure",
+                                     {"signal": "cpu", "level": 0.9, "memory": 0.8}))
+    assert "_check_resources" in organs["graceful_degradation"].names()
+    assert "record_load" in organs["load_shedding"].names()
+    assert "evaluate" in organs["auto_scaling"].names()
+    # anomaly organ should NOT fire on a pressure event
+    assert organs["anomaly_detector"].names() == []
+
+
+@pytest.mark.asyncio
+async def test_layer_per_organ_flag_off_skips_that_organ():
+    bus = FakeBus()
+    reg = RecordingRegistry()
+    organs = _seven_mock_organs()
+    layer = ReanimationLayer(
+        bus, reg, organs,
+        enabled_flags={"load_shedding": False},
+    )
+    layer.wire()
+    # disabled organ not registered
+    names = [d.name for d in reg.registered]
+    assert "load_shedding" not in names
+    assert len(reg.registered) == 6
+    # and it never fires
+    await bus.fire(FakeEventWithMeta("resource_pressure",
+                                     {"signal": "cpu", "level": 0.9}))
+    assert organs["load_shedding"].names() == []
+    assert "_check_resources" in organs["graceful_degradation"].names()
+
+
+@pytest.mark.asyncio
+async def test_layer_anomaly_event_drives_anomaly_adapter():
+    bus = FakeBus()
+    reg = RecordingRegistry()
+    organs = _seven_mock_organs()
+    ReanimationLayer(bus, reg, organs).wire()
+    await bus.fire(FakeEventWithMeta(
+        "anomaly_detected", {"category": "latency", "features": {"p99": 999.0}}))
+    assert "record_observation" in organs["anomaly_detector"].names()
+
+
+@pytest.mark.asyncio
+async def test_layer_component_degraded_drives_heal_tier():
+    bus = FakeBus()
+    reg = RecordingRegistry()
+    organs = _seven_mock_organs()
+    ReanimationLayer(bus, reg, organs).wire()
+    await bus.fire(FakeEventWithMeta(
+        "component_degraded",
+        {"component": "w1", "health_score": 0.2, "failure_probability": 0.8,
+         "degraded": True}))
+    assert "record_metrics" in organs["health_predictor"].names()
+    assert "check_and_remediate" in organs["self_healing"].names()
+    assert "record_failure" in organs["circuit_breaker"].names()

--- a/tests/governance/test_resilience_reanimation.py
+++ b/tests/governance/test_resilience_reanimation.py
@@ -1,0 +1,82 @@
+"""Unit tests for the Cybernetic Reanimation layer (Phase C).
+
+These import ONLY the standalone module — never unified_supervisor (which is
+sandbox-blocked by split_brain_guard). Bus + registry are fakes.
+"""
+import asyncio
+import pytest
+
+from backend.core.ouroboros.governance.resilience_reanimation import (
+    EventActivationDispatcher,
+)
+
+
+class FakeBus:
+    def __init__(self):
+        self.handlers = []
+    def subscribe(self, handler):
+        self.handlers.append(handler)
+    async def fire(self, event):
+        for h in self.handlers:
+            r = h(event)
+            if asyncio.iscoroutine(r):
+                await r
+
+
+class FakeEvent:
+    def __init__(self, type_value):
+        self.event_type = type(self).Type(type_value)
+    class Type:
+        def __init__(self, value): self.value = value
+
+
+class FakeDescriptor:
+    def __init__(self, name, trigger_events):
+        self.name = name
+        self.activation_contract = type("C", (), {"trigger_events": trigger_events})()
+
+
+class FakeRegistry:
+    def __init__(self, descriptors):
+        self._descs = descriptors
+        self.activated = []
+        self.fail_on = set()
+    def iter_event_driven(self):
+        return list(self._descs)
+    async def activate_service(self, name):
+        if name in self.fail_on:
+            raise RuntimeError(f"boom:{name}")
+        self.activated.append(name)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_activates_matching_service():
+    bus = FakeBus()
+    reg = FakeRegistry([FakeDescriptor("grace", ["resource_pressure"])])
+    d = EventActivationDispatcher(bus, reg)
+    d.start()
+    await bus.fire(FakeEvent("resource_pressure"))
+    assert reg.activated == ["grace"]
+
+
+@pytest.mark.asyncio
+async def test_non_matching_event_does_not_activate():
+    bus = FakeBus()
+    reg = FakeRegistry([FakeDescriptor("grace", ["resource_pressure"])])
+    EventActivationDispatcher(bus, reg).start()
+    await bus.fire(FakeEvent("phase_start"))
+    assert reg.activated == []
+
+
+@pytest.mark.asyncio
+async def test_one_failing_activation_does_not_block_others():
+    bus = FakeBus()
+    reg = FakeRegistry([
+        FakeDescriptor("bad", ["resource_pressure"]),
+        FakeDescriptor("good", ["resource_pressure"]),
+    ])
+    reg.fail_on = {"bad"}
+    EventActivationDispatcher(bus, reg).start()
+    await bus.fire(FakeEvent("resource_pressure"))
+    assert reg.activated == ["good"]  # bad failed, good still ran

--- a/tests/governance/test_resilience_reanimation.py
+++ b/tests/governance/test_resilience_reanimation.py
@@ -80,3 +80,50 @@ async def test_one_failing_activation_does_not_block_others():
     EventActivationDispatcher(bus, reg).start()
     await bus.fire(FakeEvent("resource_pressure"))
     assert reg.activated == ["good"]  # bad failed, good still ran
+
+
+# ---------------------------------------------------------------------------
+# C.2 — PressureSignalEmitter tests
+# ---------------------------------------------------------------------------
+from backend.core.ouroboros.governance.resilience_reanimation import PressureSignalEmitter
+
+
+@pytest.mark.asyncio
+async def test_emitter_edge_triggers_once_on_crossing():
+    emitted = []
+    levels = {"mem": [0.5, 0.95, 0.96, 0.4]}   # below, cross, stay, drop
+    seq = iter(levels["mem"])
+    def sampler(): return {"mem": next(seq)}
+    em = PressureSignalEmitter(
+        sampler=sampler,
+        emit=lambda etype, payload: emitted.append((etype, payload)),
+        thresholds={"mem": 0.9},
+        signal_event={"mem": "resource_pressure"},
+    )
+    for _ in range(4):
+        await em.tick()
+    # crossing 0.5->0.95 emits once; 0.95->0.96 (stay above) no emit; drop resets
+    assert [e[0] for e in emitted] == ["resource_pressure"]
+
+
+@pytest.mark.asyncio
+async def test_emitter_reemits_after_drop_then_recross():
+    emitted = []
+    seq = iter([0.95, 0.4, 0.95])
+    em = PressureSignalEmitter(
+        sampler=lambda: {"mem": next(seq)},
+        emit=lambda etype, payload: emitted.append(etype),
+        thresholds={"mem": 0.9},
+        signal_event={"mem": "resource_pressure"},
+    )
+    for _ in range(3):
+        await em.tick()
+    assert emitted == ["resource_pressure", "resource_pressure"]
+
+
+@pytest.mark.asyncio
+async def test_emitter_failsoft_on_sampler_error():
+    def sampler(): raise RuntimeError("probe down")
+    em = PressureSignalEmitter(sampler=sampler, emit=lambda *a: None,
+                               thresholds={"mem": 0.9}, signal_event={"mem": "resource_pressure"})
+    await em.tick()  # must not raise

--- a/tests/governance/test_resilience_reanimation.py
+++ b/tests/governance/test_resilience_reanimation.py
@@ -389,3 +389,188 @@ async def test_layer_component_degraded_drives_heal_tier():
     assert "record_metrics" in organs["health_predictor"].names()
     assert "check_and_remediate" in organs["self_healing"].names()
     assert "record_failure" in organs["circuit_breaker"].names()
+
+
+# ---------------------------------------------------------------------------
+# C.4 — feedback emitters (closed loop)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anomaly_adapter_emits_anomaly_detected_on_detection():
+    """When the organ's record_observation returns a truthy AnomalyScore, the
+    adapter re-broadcasts an anomaly_detected event via the injected emit."""
+    emitted = []
+    # MockOrgan returns a truthy 'score' for record_observation → anomaly seen
+    organ = MockOrgan(record_observation={"is_anomaly": True, "score": 9.9})
+    ad = AnomalyDetectorAdapter(
+        organ, emit=lambda etype, payload: emitted.append((etype, payload))
+    )
+    await ad.on_event({"category": "latency", "features": {"p99": 9999.0}})
+    assert organ.names() == ["record_observation"]
+    assert len(emitted) == 1
+    etype, payload = emitted[0]
+    assert etype == "anomaly_detected"
+    assert payload.get("category") == "latency"
+    assert payload.get("score") == 9.9
+
+
+@pytest.mark.asyncio
+async def test_anomaly_adapter_no_emit_when_not_anomalous():
+    """record_observation returns None (no anomaly) → no feedback emit."""
+    emitted = []
+    organ = MockOrgan()  # record_observation returns None
+    ad = AnomalyDetectorAdapter(
+        organ, emit=lambda etype, payload: emitted.append(etype)
+    )
+    await ad.on_event({"category": "latency", "features": {"p99": 1.0}})
+    assert emitted == []
+
+
+@pytest.mark.asyncio
+async def test_anomaly_adapter_backward_compat_without_emit():
+    """Adapter with no emit callback behaves exactly as before (no error)."""
+    organ = MockOrgan(record_observation={"is_anomaly": True})
+    ad = AnomalyDetectorAdapter(organ)  # no emit
+    await ad.on_event({"category": "latency", "features": {"p99": 9.0}})
+    assert organ.names() == ["record_observation"]
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_adapter_emits_component_degraded_on_open():
+    """On a degraded component the breaker records a failure AND re-broadcasts
+    component_degraded so the heal-tier organs can react."""
+    emitted = []
+    organ = MockOrgan()
+    ad = CircuitBreakerAdapter(
+        organ, emit=lambda etype, payload: emitted.append((etype, payload))
+    )
+    await ad.on_event({"component": "w1", "degraded": True})
+    assert organ.names() == ["record_failure"]
+    assert len(emitted) == 1
+    etype, payload = emitted[0]
+    assert etype == "component_degraded"
+    assert payload.get("component") == "w1"
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_adapter_no_emit_when_not_degraded():
+    """A recovery (degraded=False) records success and does NOT emit a
+    degraded feedback event."""
+    emitted = []
+    organ = MockOrgan()
+    ad = CircuitBreakerAdapter(
+        organ, emit=lambda etype, payload: emitted.append(etype)
+    )
+    await ad.on_event({"component": "w1", "degraded": False})
+    assert organ.names() == ["record_success"]
+    assert emitted == []
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_adapter_backward_compat_without_emit():
+    organ = MockOrgan()
+    ad = CircuitBreakerAdapter(organ)  # no emit
+    await ad.on_event({"component": "w1", "degraded": True})
+    assert organ.names() == ["record_failure"]
+
+
+@pytest.mark.asyncio
+async def test_feedback_emit_failure_is_failsoft():
+    """If the injected emit callback raises, the adapter logs + continues — the
+    organ call still happened and no exception propagates."""
+    organ = MockOrgan(record_observation={"is_anomaly": True})
+
+    def boom_emit(etype, payload):
+        raise RuntimeError("bus down")
+
+    ad = AnomalyDetectorAdapter(organ, emit=boom_emit)
+    await ad.on_event({"category": "x", "features": {}})  # must not raise
+    assert organ.names() == ["record_observation"]
+
+
+# ---------------------------------------------------------------------------
+# C.4 — integration proof: async-delivering bus + ON/OFF factory gate
+# ---------------------------------------------------------------------------
+from backend.core.ouroboros.governance.resilience_reanimation import (
+    build_reanimation_layer,
+)
+
+
+class AsyncDeliveringBus:
+    """A FakeBus that schedules subscriber delivery on the event loop so the
+    integration test exercises the real async fan-out path (not inline)."""
+
+    def __init__(self):
+        self.handlers = []
+
+    def subscribe(self, handler):
+        self.handlers.append(handler)
+
+    async def fire(self, event):
+        # Deliver via the loop (await each handler) — faithful async path.
+        for h in self.handlers:
+            await asyncio.sleep(0)  # yield to the loop first
+            r = h(event)
+            if asyncio.iscoroutine(r):
+                await r
+
+
+@pytest.mark.asyncio
+async def test_integration_resource_pressure_activates_three_pressure_organs():
+    bus = AsyncDeliveringBus()
+    reg = RecordingRegistry()
+    organs = _seven_mock_organs()
+    layer = ReanimationLayer(bus, reg, organs)
+    layer.wire()
+    assert len(reg.registered) == 7  # all 7 contracts registered
+
+    await bus.fire(FakeEventWithMeta(
+        "resource_pressure",
+        {"signal": "cpu", "level": 0.92, "memory": 0.81}))
+
+    # The 3 pressure-tier organs all reacted to the single synthetic event.
+    assert "_check_resources" in organs["graceful_degradation"].names()
+    assert "record_load" in organs["load_shedding"].names()
+    assert "evaluate" in organs["auto_scaling"].names()
+    # Non-pressure organs stayed dormant.
+    assert organs["anomaly_detector"].names() == []
+    assert organs["self_healing"].names() == []
+
+
+@pytest.mark.asyncio
+async def test_build_reanimation_layer_on_wires(monkeypatch):
+    monkeypatch.setenv("JARVIS_RESILIENCE_REANIMATION_ENABLED", "true")
+    bus = FakeBus()
+    reg = RecordingRegistry()
+    organs = _seven_mock_organs()
+    layer = build_reanimation_layer(bus, reg, organs)
+    assert layer is not None
+    # ON → wired: bus subscribed + contracts registered.
+    assert bus.handlers
+    assert len(reg.registered) == 7
+
+
+@pytest.mark.asyncio
+async def test_build_reanimation_layer_off_is_noop(monkeypatch):
+    monkeypatch.setenv("JARVIS_RESILIENCE_REANIMATION_ENABLED", "false")
+    bus = FakeBus()
+    reg = RecordingRegistry()
+    organs = _seven_mock_organs()
+    layer = build_reanimation_layer(bus, reg, organs)
+    # OFF → no-op: no layer, no subscription, no registration.
+    assert layer is None
+    assert bus.handlers == []
+    assert reg.registered == []
+
+
+@pytest.mark.asyncio
+async def test_build_reanimation_layer_off_default_is_noop(monkeypatch):
+    """Master flag unset → default OFF → no-op (byte-identical boot)."""
+    monkeypatch.delenv("JARVIS_RESILIENCE_REANIMATION_ENABLED", raising=False)
+    bus = FakeBus()
+    reg = RecordingRegistry()
+    layer = build_reanimation_layer(bus, reg, _seven_mock_organs())
+    assert layer is None
+    assert bus.handlers == []
+    assert reg.registered == []

--- a/unified_supervisor.py
+++ b/unified_supervisor.py
@@ -13764,6 +13764,13 @@ class ServiceDescriptor:
     activation_count: int = 0
     last_health_check: float = 0.0
 
+    # --- Cybernetic Reanimation (Phase C) ---
+    # Optional event-driven activation contract. Default None → byte-identical
+    # for every existing descriptor. When present (set by the ReanimationLayer),
+    # iter_event_driven()/EventActivationDispatcher use trigger_events to lazy-
+    # activate this dormant organ on a matching SupervisorEventType.
+    activation_contract: Optional["ActivationContract"] = None
+
 
 # =========================================================================
 # GOVERNANCE DATACLASSES (Enterprise Organ Activation Program v1.0)

--- a/unified_supervisor.py
+++ b/unified_supervisor.py
@@ -8787,6 +8787,9 @@ class SupervisorEventType(Enum):
     SHUTDOWN_START = "shutdown_start"
     SHUTDOWN_END = "shutdown_end"
     LOG = "log"
+    RESOURCE_PRESSURE = "resource_pressure"
+    ANOMALY_DETECTED = "anomaly_detected"
+    COMPONENT_DEGRADED = "component_degraded"
 
 
 # =========================================================================

--- a/unified_supervisor.py
+++ b/unified_supervisor.py
@@ -64500,6 +64500,181 @@ class JarvisSystemKernel:
                 self.logger.warning(
                     f"[Reanimation] disabled (init failed): {_e!r}"
                 )
+            # ── C.4: live ReanimationLayer + PressureSignalEmitter ─────────
+            # Best-effort: construct only the organs that build cleanly, wire
+            # the layer (subscribe + register contracts — no event loop needed),
+            # and launch the edge-triggered pressure sampler as a kernel
+            # background task. Entirely inside the master `if` + a dedicated
+            # try/except → OFF path is byte-identical and any failure here only
+            # warns (reanimation must NEVER break boot).
+            try:
+                self._wire_reanimation_layer()
+            except Exception as _e:  # noqa: BLE001 — fail-soft; never break boot
+                self.logger.warning(
+                    f"[Reanimation] layer wiring skipped (init failed): {_e!r}"
+                )
+
+    def _wire_reanimation_layer(self) -> None:
+        """C.4 kernel wiring — construct the live resilience-organ matrix.
+
+        Conservative + fail-soft by construction:
+          * Each organ is constructed in its own try/except; an organ that
+            cannot be built cleanly is simply skipped (the layer tolerates a
+            partial organ dict). No fragile organ is force-instantiated.
+          * ``ReanimationLayer.wire()`` only subscribes to the bus and
+            registers ActivationContracts — no running loop required, so this
+            is safe to call from the synchronous ``__init__`` boot path.
+          * The PressureSignalEmitter is launched as a background task ONLY if
+            an event loop is already running; otherwise it is stashed on
+            ``self._reanimation_emitter`` for a later async boot stage to start
+            (never blocks / crashes boot).
+        Gated entirely by the master flag (caller checks ``_reanimation_enabled``).
+        """
+        from backend.core.ouroboros.governance.resilience_reanimation import (
+            ReanimationLayer,
+            PressureSignalEmitter,
+        )
+
+        # 1. Best-effort organ construction — skip any that don't build cleanly.
+        organs: Dict[str, Any] = {}
+
+        def _try(key: str, ctor: Callable[[], Any]) -> None:
+            try:
+                organs[key] = ctor()
+            except Exception as _e:  # noqa: BLE001 — skip fragile organ
+                self.logger.warning(
+                    f"[Reanimation] organ {key} skipped (construct failed): {_e!r}"
+                )
+
+        _try("graceful_degradation", lambda: GracefulDegradationManager())
+        _try("load_shedding", lambda: LoadSheddingController())
+        _try("auto_scaling", lambda: AutoScalingController())
+        _try(
+            "anomaly_detector",
+            lambda: AnomalyDetector(SystemKernelConfig.from_environment()),
+        )
+        _try("health_predictor", lambda: ProcessHealthPredictor())
+        _try("self_healing", lambda: SelfHealingOrchestrator())
+        _try(
+            "circuit_breaker",
+            lambda: AdvancedCircuitBreaker(name="reanimation"),
+        )
+
+        if not organs:
+            self.logger.warning(
+                "[Reanimation] no organs constructed cleanly; layer not wired"
+            )
+            return
+
+        bus = get_event_bus()
+
+        # 2. Closed-loop feedback emit — publish a typed SupervisorEvent.
+        def _emit(event_type_value: str, payload: dict) -> None:
+            try:
+                etype = SupervisorEventType(event_type_value)
+            except Exception:  # noqa: BLE001 — unknown type, drop
+                return
+            try:
+                bus.emit(SupervisorEvent(
+                    event_type=etype,
+                    timestamp=time.time(),
+                    message=f"[Reanimation] {event_type_value}",
+                    metadata=tuple(payload.items()),
+                ))
+            except Exception as _e:  # noqa: BLE001 — fail-soft
+                self.logger.warning(f"[Reanimation] feedback emit failed: {_e!r}")
+
+        # 3. Wire the layer with the REAL ServiceDescriptor / ActivationContract.
+        def _desc_factory(name: str, contract: Any) -> ServiceDescriptor:
+            return ServiceDescriptor(
+                name=f"reanimate_{name}",
+                service=organs[name],
+                phase=8, tier="optional",
+                activation_mode="event_driven",
+                criticality="optional",
+                boot_policy="non_blocking",
+                activation_contract=contract,
+            )
+
+        def _contract_factory(*, trigger_events, dependency_gate):
+            return ActivationContract(
+                trigger_events=list(trigger_events),
+                dependency_gate=list(dependency_gate),
+            )
+
+        self._reanimation_layer = ReanimationLayer(
+            bus, self._service_registry, organs,
+            descriptor_factory=_desc_factory,
+            contract_factory=_contract_factory,
+            emit=_emit,
+        )
+        self._reanimation_layer.wire()
+
+        # 4. Edge-triggered pressure sampler → resource_pressure events.
+        def _sampler() -> Dict[str, float]:
+            try:
+                import psutil
+                mem = float(psutil.virtual_memory().percent) / 100.0
+                cpu = float(psutil.cpu_percent(interval=None)) / 100.0
+                return {"mem": mem, "cpu": cpu}
+            except Exception:  # noqa: BLE001 — probe down → no sample
+                return {}
+
+        mem_thr = float(os.getenv("JARVIS_PRESSURE_MEM_THRESHOLD", "0.9"))
+        cpu_thr = float(os.getenv("JARVIS_PRESSURE_CPU_THRESHOLD", "0.9"))
+        emitter = PressureSignalEmitter(
+            sampler=_sampler,
+            emit=_emit,
+            thresholds={"mem": mem_thr, "cpu": cpu_thr},
+            signal_event={
+                "mem": SupervisorEventType.RESOURCE_PRESSURE.value,
+                "cpu": SupervisorEventType.RESOURCE_PRESSURE.value,
+            },
+        )
+        self._reanimation_emitter = emitter
+        self._reanimation_emitter_started = False
+
+        # Launch the sampler ONLY when a loop is already running. In the
+        # synchronous boot path no loop exists yet → stash for deferred start
+        # by ``_start_reanimation_emitter`` from the async event-infra stage.
+        try:
+            asyncio.get_running_loop()
+            self._start_reanimation_emitter()
+            self.logger.info(
+                "[Reanimation] layer wired; pressure emitter launched "
+                f"(organs={sorted(organs)})"
+            )
+        except RuntimeError:
+            self.logger.info(
+                "[Reanimation] layer wired; pressure emitter deferred "
+                f"(no running loop; organs={sorted(organs)})"
+            )
+
+    def _start_reanimation_emitter(self) -> None:
+        """Launch the stashed PressureSignalEmitter as a kernel background task.
+
+        Idempotent + fail-soft. Called from ``_wire_reanimation_layer`` when a
+        loop is already running, else from the async ``_initialize_event_
+        infrastructure`` stage (deferred start). No-op if the emitter was never
+        constructed (master flag off / no organs) or is already running.
+        """
+        emitter = getattr(self, "_reanimation_emitter", None)
+        if emitter is None or getattr(self, "_reanimation_emitter_started", False):
+            return
+        interval_s = float(
+            os.getenv("JARVIS_PRESSURE_SAMPLE_INTERVAL_S", "5.0")
+        )
+
+        async def _pressure_loop() -> None:
+            while True:
+                await emitter.tick()
+                await asyncio.sleep(interval_s)
+
+        task = create_safe_task(
+            _pressure_loop(), name="reanimation-pressure-emitter"
+        )
+        self._background_tasks.append(task)
+        self._reanimation_emitter_started = True
 
     async def _on_supervisor_rollback_outcome(self, outcome: Dict[str, Any]) -> None:
         """Bridge supervisor/manual rollback outcomes into the governed event stream."""
@@ -75679,6 +75854,18 @@ class JarvisSystemKernel:
                 self.logger.debug("[Kernel] v243.1: Event bus health checks registered")
         except Exception as e:
             self.logger.debug(f"[Kernel] v243.1: Health registration error: {e}")
+
+        # Cybernetic Reanimation (Phase C, C.4): deferred pressure-emitter start.
+        # The layer + emitter were wired synchronously in __init__ (no loop yet),
+        # so launch the sampler now that a running loop exists. Master-flag-gated
+        # (emitter is None when off) + fail-soft → never breaks event-infra boot.
+        if _reanimation_enabled():
+            try:
+                self._start_reanimation_emitter()
+            except Exception as _re:  # noqa: BLE001 — fail-soft
+                self.logger.warning(
+                    f"[Reanimation] deferred emitter start failed: {_re!r}"
+                )
 
     async def _check_event_bus_health(self) -> Tuple[bool, str, Dict[str, Any]]:
         """Health check for TrinityEventBus.

--- a/unified_supervisor.py
+++ b/unified_supervisor.py
@@ -1876,6 +1876,17 @@ def _use_modular_crash_recovery() -> bool:
         return False
     return not _get_env_bool("JARVIS_FORCE_INLINE_CRASH_RECOVERY", False)
 
+def _reanimation_enabled() -> bool:
+    """Cybernetic Reanimation (Phase C) master flag — default OFF.
+
+    When false, the bus→activation dispatcher is never constructed and the
+    boot path is byte-identical to legacy behaviour.
+    """
+    import os
+    return os.getenv(
+        "JARVIS_RESILIENCE_REANIMATION_ENABLED", "false",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
 # Log modular integration status at startup
 _integration_logger = logging.getLogger("unified_supervisor.integration")
 _integration_status = []
@@ -14114,6 +14125,23 @@ class SystemServiceRegistry:
             desc.healthy = False
             logger.warning("[SSR] On-demand start failed for %s: %s", name, e)
             return False
+
+    def iter_event_driven(self) -> List["ServiceDescriptor"]:
+        """Read-only: yield registered descriptors that are event-driven.
+
+        Returns the descriptors whose ``activation_mode == "event_driven"`` or
+        that carry an ``activation_contract`` (the Cybernetic Reanimation
+        ActivationContract attached in a later phase). Pure projection — no
+        state mutation, no activation. The EventActivationDispatcher consumes
+        this to bridge bus events to ``activate_service`` calls; the registry's
+        gates remain authoritative.
+        """
+        out: List["ServiceDescriptor"] = []
+        for desc in self._services.values():
+            if getattr(desc, "activation_mode", None) == "event_driven" or \
+                    getattr(desc, "activation_contract", None) is not None:
+                out.append(desc)
+        return out
 
     # ── health ──────────────────────────────────────────────────────────
 
@@ -64442,6 +64470,26 @@ class JarvisSystemKernel:
         ))
 
         logger.info("[Kernel] Service registry: 76 services registered across phases 1-8")
+
+        # ── Cybernetic Reanimation (Phase C) ─ bus→activation bridge ──────
+        # Default OFF. When enabled, wires the SupervisorEventBus to the
+        # registry's event-driven services so they activate on emitted
+        # pressure/health events. The registry's gates remain authoritative.
+        # Fail-soft: reanimation must never break boot. OFF path is the `if`
+        # simply not taken → byte-identical legacy behaviour.
+        if _reanimation_enabled():
+            try:
+                from backend.core.ouroboros.governance.resilience_reanimation import (
+                    EventActivationDispatcher,
+                )
+                self._reanimation_dispatcher = EventActivationDispatcher(
+                    get_event_bus(), self._service_registry,
+                )
+                self._reanimation_dispatcher.start()
+            except Exception as _e:  # noqa: BLE001 — fail-soft; never break boot
+                self.logger.warning(
+                    f"[Reanimation] disabled (init failed): {_e!r}"
+                )
 
     async def _on_supervisor_rollback_outcome(self, outcome: Dict[str, Any]) -> None:
         """Bridge supervisor/manual rollback outcomes into the governed event stream."""


### PR DESCRIPTION
## Summary
Reanimates the dormant event-driven resilience infrastructure in unified_supervisor.py as a live, edge-triggered async reactive nervous system. Default-OFF (JARVIS_RESILIENCE_REANIMATION_ENABLED).

- **EventActivationDispatcher** — the missing bridge: subscribes the SystemServiceRegistry to the SupervisorEventBus so ActivationContract.trigger_events finally fire activate_service() (root fix; adds no policy).
- **PressureSignalEmitter** — edge-triggered, fail-soft typed signals: RESOURCE_PRESSURE / ANOMALY_DETECTED / COMPONENT_DEGRADED (new SupervisorEventType values).
- **7 resilience organ adapters** (GracefulDegradationManager, LoadSheddingController, AutoScalingController, AnomalyDetector, ProcessHealthPredictor, SelfHealingOrchestrator, AdvancedCircuitBreaker) registered with event-driven ActivationContracts + bus-subscriber adapters; AnomalyDetector + CircuitBreaker emit feedback events (closed loop).
- New focused module backend/core/ouroboros/governance/resilience_reanimation.py (standalone, unit-testable — kernel import is split-brain-guarded). Kernel changes: ServiceDescriptor.activation_contract field (pure-add) + one flag-guarded fail-soft hook + deferred pressure-emitter start. OFF path byte-identical (187 insertions / 0 deletions in unified_supervisor.py).

## Test Plan
- [x] Module unit + integration tests green — 31 passed (dispatcher, emitter edge-trigger/fail-soft, 7 adapters, ReanimationLayer wire ON / no-op OFF, feedback emitters incl. backward-compat without emit)
- [x] Synthetic RESOURCE_PRESSURE activates the 3 pressure-tier organs in test (async-delivering FakeBus)
- [x] build_reanimation_layer ON wires / OFF (and default-unset) is a strict no-op (no subscribe, no register)
- [x] ast.parse(unified_supervisor.py) OK; shadow-guard 2 passed; governance tests collect (194, 0 errors)
- [x] 12 FlagRegistry seeds registered (master + 7 per-organ + sample interval + 3 thresholds); flag_registry suite 102 passed
- [ ] Soak-validate live kernel wiring before graduating the master flag (default-off ships safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the dormant event-driven resilience into a live, edge-triggered system by bridging the event bus to activation contracts and wiring seven resilience organs via a new `ReanimationLayer`. Default OFF behind `JARVIS_RESILIENCE_REANIMATION_ENABLED`, with fail-soft, guarded kernel wiring.

- **New Features**
  - `EventActivationDispatcher`: subscribes the supervisor event bus and calls `activate_service()` for services whose `activation_contract.trigger_events` match.
  - `PressureSignalEmitter`: edge-triggered sampler that emits `resource_pressure` events; runs as a background task with `JARVIS_PRESSURE_SAMPLE_INTERVAL_S`, `JARVIS_PRESSURE_MEM_THRESHOLD`, `JARVIS_PRESSURE_CPU_THRESHOLD`.
  - `ReanimationLayer`: builds adapters for 7 organs (Graceful Degradation, Load Shedding, Auto Scaling, Anomaly Detector, Health Predictor, Self-Healing, Circuit Breaker), subscribes once, and registers `ActivationContract`s; feedback emits `anomaly_detected` and `component_degraded`.
  - `SupervisorEventType` gains `resource_pressure`, `anomaly_detected`, `component_degraded`.
  - Kernel updates: guarded wiring in `unified_supervisor.py`, deferred emitter start; `ServiceDescriptor.activation_contract` (pure-add) and `SystemServiceRegistry.iter_event_driven()` for dispatch; new module `backend/core/ouroboros/governance/resilience_reanimation.py`; 12 flag seeds added; tests and docs included.

- **Migration**
  - No action needed (default OFF; boot is byte-identical).
  - To enable: set `JARVIS_RESILIENCE_REANIMATION_ENABLED=true`. Optionally tune `JARVIS_REANIMATE_<ORGAN>_ENABLED`, `JARVIS_PRESSURE_SAMPLE_INTERVAL_S`, `JARVIS_PRESSURE_MEM_THRESHOLD`, `JARVIS_PRESSURE_CPU_THRESHOLD`, `JARVIS_PRESSURE_DEGRADED_THRESHOLD`.

<sup>Written for commit 97887fdf7b70974ecf09a3670856947ee6ed498e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

