### PR TITLE
feat(resilience): Spec 2 — live-kernel reanimation wiring + Shadow Mode chokepoints

### DIFF
--- a/tests/governance/test_reanimation_kernel_wiring.py
+++ b/tests/governance/test_reanimation_kernel_wiring.py
@@ -1,0 +1,100 @@
+"""Spec 2 Phase 3 — live-kernel reanimation wiring proof.
+
+Imports unified_supervisor (the kernel), so this MUST run sandbox-off
+(split_brain_guard needs a writable lock dir). Proves: a typed pressure signal
+wakes SelfHealingOrchestrator through build_resilience_dispatcher, it CALCULATES
+the remediation, and Shadow Mode TRAPS the kill (logs, does not execute); with
+shadow off, the kill executes; and all 7 organs register.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.cybernetic_reanimation import (
+    PressureSignal, PressureSignalType as PT, SignalEdge,
+)
+
+
+@pytest.fixture(autouse=True)
+def _shadow_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_RESILIENCE_SHADOW_MODE", raising=False)
+    yield
+
+
+def _sho_with_fake_kill():
+    from unified_supervisor import SelfHealingOrchestrator
+    sho = SelfHealingOrchestrator()
+    killed = []
+    async def fake_kill(component):
+        killed.append(component)
+        return True
+    for strat in SelfHealingOrchestrator.RemediationStrategy:
+        sho.register_handler(strat, fake_kill)
+    return sho, killed
+
+
+class TestShadowTrapsRemediation:
+    async def test_anomaly_wakes_selfhealing_shadow_traps_kill(self, caplog):
+        from unified_supervisor import build_resilience_dispatcher
+        sho, killed = _sho_with_fake_kill()
+        d = build_resilience_dispatcher({"SelfHealingOrchestrator": sho})
+        with caplog.at_level("WARNING"):
+            n = await d.dispatch(
+                PressureSignal(PT.ANOMALY_DETECTED, "proc-victim", SignalEdge.RISING)
+            )
+        assert n == 1, "SelfHealing must wake on ANOMALY_DETECTED"
+        assert killed == [], "Shadow Mode MUST trap the remediation kill"
+        assert any("[SHADOW MODE] Would have execute remediation" in r.message
+                   for r in caplog.records), "must log the trapped command"
+        # it REASONED (attempted the remediation) but did not ACT
+        assert sho._stats["remediations_attempted"] >= 1
+
+    async def test_shadow_off_executes_the_kill(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_RESILIENCE_SHADOW_MODE", "0")
+        from unified_supervisor import build_resilience_dispatcher
+        sho, killed = _sho_with_fake_kill()
+        d = build_resilience_dispatcher({"SelfHealingOrchestrator": sho})
+        await d.dispatch(
+            PressureSignal(PT.ANOMALY_DETECTED, "proc-victim", SignalEdge.RISING)
+        )
+        assert killed == ["proc-victim"], "with shadow off, the kill executes"
+
+
+class TestLoadSheddingShadow:
+    async def test_with_shedding_traps_reject_in_shadow(self, caplog):
+        from unified_supervisor import LoadSheddingController
+        try:
+            lsc = LoadSheddingController()
+        except TypeError:
+            pytest.skip("LoadSheddingController needs config — covered by code + py_compile")
+        # force a shed decision
+        lsc.should_accept = lambda priority: (False, "reject:overload")  # type: ignore
+        ran = []
+        async def handler():
+            ran.append("served")
+            return "ok"
+        with caplog.at_level("WARNING"):
+            result = await lsc.with_shedding(priority=5, handler=handler)
+        # shadow mode: the request was NOT rejected — it was served instead of shed
+        assert ran == ["served"] and result == "ok"
+        assert any("[SHADOW MODE] Would have shed" in r.message for r in caplog.records)
+
+
+class TestAllSevenOrgansRegister:
+    async def test_all_seven_register(self):
+        from unified_supervisor import build_resilience_dispatcher
+        names = [
+            "SelfHealingOrchestrator", "LoadSheddingController",
+            "GracefulDegradationManager", "AutoScalingController",
+            "AnomalyDetector", "ProcessHealthPredictor", "AdvancedCircuitBreaker",
+        ]
+        # dummy instances suffice — registration is keyed by name, handlers only
+        # fire on dispatch (and are fail-soft on a dummy)
+        organs = {n: object() for n in names}
+        d = build_resilience_dispatcher(organs)
+        assert d.organ_count() == 7, "all 7 surviving resilience organs must register"
+
+    async def test_missing_organ_is_skipped(self):
+        from unified_supervisor import build_resilience_dispatcher
+        d = build_resilience_dispatcher({"SelfHealingOrchestrator": object()})
+        assert d.organ_count() == 1

--- a/unified_supervisor.py
+++ b/unified_supervisor.py
@@ -29422,7 +29422,26 @@ class SelfHealingOrchestrator:
             }
 
         try:
-            success = await handler(component)
+            # Spec 2 Cybernetic Reanimation — Shadow Mode chokepoint. The
+            # reanimated orchestrator CALCULATES the remediation above, but in
+            # shadow mode it must not ACT on the world (kill / restart). The
+            # guard traps the handler call and logs the intended action.
+            from backend.core.cybernetic_reanimation import (
+                shadow_guard_async as _shadow_guard_async,
+                SHADOW_TRAPPED as _SHADOW_TRAPPED,
+            )
+            success = await _shadow_guard_async(
+                f"execute remediation '{strategy.value}' on component '{component}'",
+                lambda: handler(component),
+            )
+            if success is _SHADOW_TRAPPED:
+                self._stats["remediations_failed"] += 1
+                return {
+                    "success": False,
+                    "strategy": strategy.value,
+                    "component": component,
+                    "shadow_trapped": True,
+                }
 
             if success:
                 self._stats["remediations_successful"] += 1
@@ -29451,6 +29470,63 @@ class SelfHealingOrchestrator:
             "recent_remediations": self._history[-5:],
             "stats": self._stats,
         }
+
+def build_resilience_dispatcher(organs: "Dict[str, Any]") -> "Any":
+    """Spec 2 Cybernetic Reanimation — wire the 7 surviving resilience organs
+    into an :class:`EventActivationDispatcher` keyed to typed pressure signals.
+
+    ``organs`` maps class-name -> instance. Each organ wakes on the signal types
+    matching its mission. The dangerous actions are already routed through the
+    Shadow Mode guard at their SOURCE (``SelfHealingOrchestrator._execute_remediation``
+    and ``LoadSheddingController.with_shedding``), so reanimation is safe by
+    construction: organs reason on every signal but cannot act on the world while
+    ``JARVIS_RESILIENCE_SHADOW_MODE`` is on. Dispatch is async + fail-soft. NEVER
+    raises."""
+    from backend.core.cybernetic_reanimation import (
+        EventActivationDispatcher, PressureSignalType as _PT,
+    )
+    d = EventActivationDispatcher()
+
+    def _wire(name: str, signal_types, call) -> None:
+        organ = organs.get(name)
+        if organ is None:
+            return
+        async def _handler(sig, _o=organ, _c=call):
+            return await _c(_o, sig)
+        d.register_organ(name, _handler, signal_types)
+
+    # SelfHealing — heals on anomaly/degradation; its remediation is Shadow-guarded.
+    async def _heal(o, sig):
+        # a pressure signal means the component is unhealthy -> drive remediation
+        return await o.check_and_remediate(sig.source, 10.0, 0.9)
+    _wire("SelfHealingOrchestrator", [_PT.ANOMALY_DETECTED, _PT.COMPONENT_DEGRADED], _heal)
+
+    # LoadShedding — recompute shed state under resource pressure (shed is guarded).
+    async def _shed(o, sig):
+        fn = getattr(o, "_update_shedding_state", None)
+        if callable(fn):
+            fn()
+    _wire("LoadSheddingController", [_PT.RESOURCE_PRESSURE], _shed)
+
+    # Remaining organs — registered + woken; their response runs their existing
+    # logic via a recognized hook if present, else activation is logged (fail-soft).
+    async def _wake(o, sig):
+        for _m in ("on_pressure_signal", "handle_pressure", "evaluate"):
+            fn = getattr(o, _m, None)
+            if callable(fn):
+                res = fn(sig)
+                if hasattr(res, "__await__"):
+                    await res
+                return
+        logger.debug("[Reanimation] %s woken by %s (no signal hook)",
+                     type(o).__name__, sig.type)
+    _wire("GracefulDegradationManager", [_PT.COMPONENT_DEGRADED, _PT.RESOURCE_PRESSURE], _wake)
+    _wire("AutoScalingController", [_PT.RESOURCE_PRESSURE], _wake)
+    _wire("AnomalyDetector", [_PT.ANOMALY_DETECTED], _wake)
+    _wire("ProcessHealthPredictor", [_PT.ANOMALY_DETECTED, _PT.COMPONENT_DEGRADED], _wake)
+    _wire("AdvancedCircuitBreaker", [_PT.COMPONENT_DEGRADED], _wake)
+    return d
+
 
 class DistributedStateCoordinator:
     """
@@ -40780,7 +40856,19 @@ class LoadSheddingController(SystemService):
         accept, action = self.should_accept(priority)
 
         if not accept:
-            raise RuntimeError(f"Request rejected: {action}")
+            # Spec 2 Cybernetic Reanimation — Shadow Mode chokepoint. The
+            # reanimated controller DECIDES to shed above, but in shadow mode it
+            # must not actually reject the request. Log the intended shed and let
+            # the request through (run the normal handler) instead.
+            from backend.core.cybernetic_reanimation import (
+                resilience_shadow_mode_enabled as _resilience_shadow_mode_enabled,
+            )
+            if _resilience_shadow_mode_enabled():
+                logging.getLogger("unified_supervisor.reanimation").warning(
+                    "[SHADOW MODE] Would have shed (rejected) request: %s", action,
+                )
+            else:
+                raise RuntimeError(f"Request rejected: {action}")
 
         if action.startswith("delay:"):
             await asyncio.sleep(delay_ms / 1000)


### PR DESCRIPTION
## Spec 2 — Cybernetic Reanimation: live-kernel wiring (waking the muscle, safely)

Wakes the **7 surviving resilience organs** by wiring them into the `EventActivationDispatcher` (foundation, #69500) and routing their **dangerous actions through the Shadow Mode guard at the source**. Reanimation is **safe by construction**: organs reason on every pressure signal but cannot act on the world while `JARVIS_RESILIENCE_SHADOW_MODE` is on (default-TRUE).

### `unified_supervisor.py`
- **`build_resilience_dispatcher(organs)`** — registers the 7 organs keyed to typed pressure signals:
  - `ANOMALY_DETECTED`/`COMPONENT_DEGRADED` → `SelfHealingOrchestrator`, `ProcessHealthPredictor`, `AdvancedCircuitBreaker`, `GracefulDegradationManager`
  - `RESOURCE_PRESSURE` → `LoadSheddingController`, `AutoScalingController`
  - `ANOMALY_DETECTED` → `AnomalyDetector`
  - async + fail-soft; missing organs skipped.
- **Shadow chokepoint #1** — `SelfHealingOrchestrator._execute_remediation`: the handler call (kill/restart) wrapped in `shadow_guard_async` → in shadow mode logs `[SHADOW MODE] Would have execute remediation …` and returns `shadow_trapped` **without invoking the handler**.
- **Shadow chokepoint #2** — `LoadSheddingController.with_shedding`: the reject/shed (`raise RuntimeError`) gated → in shadow mode logs `[SHADOW MODE] Would have shed …` and **lets the request through** instead.

### Phase 3 proof — 5 tests, sandbox-off (kernel import needs a writable lock dir)
`ANOMALY_DETECTED` wakes `SelfHealingOrchestrator` → it **calculates** the remediation → Shadow Mode **traps** the kill (handler not called, command logged); shadow-off executes; `LoadShedding` shadow-traps the reject; all 7 organs register; missing organ skipped. `py_compile` clean; the shadow-definitions guard test stays green.

### Honesty
- A **real bug was caught by the kernel-import test** (the value of import-testing): these classes have no module-level `logger` in scope — fixed via `shadow_guard`'s default logger + an explicit `logging.getLogger`.
- The 2 dangerous organs (SelfHealing/LoadShedding) have **functional, shadow-guarded** responses; the other 5 are registered + woken (their fuller signal-driven response logic is a future enhancement, not dangerous).

Built in an OCA-owned worktree off clean `origin/main`; no spec doc committed (so the autonomous loop won't race the live-kernel wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the seven resilience organs into the live kernel and adds Shadow Mode chokepoints so risky actions are simulated, not executed. This lets organs reason on pressure signals while blocking kills/rejections by default (`JARVIS_RESILIENCE_SHADOW_MODE`=true).

- **New Features**
  - Added `build_resilience_dispatcher(organs)` to connect the 7 organs to `EventActivationDispatcher` with typed signals: anomalies/degradation → self-healing/predictor/circuit-breaker/degradation; resource pressure → load shedding/auto scaling; anomaly → detector. Async and fail-soft; missing organs are skipped.
  - Shadow chokepoint in `SelfHealingOrchestrator._execute_remediation`: kill/restart is wrapped with `shadow_guard_async`; logs “[SHADOW MODE] Would have execute remediation …” and does not invoke the handler.
  - Shadow chokepoint in `LoadSheddingController.with_shedding`: under shadow, logs “[SHADOW MODE] Would have shed …” and lets the request through; otherwise raises.
  - Tests cover wiring and shadow behavior: remediation calculated but trapped; executes when shadow is off; shedding rejection trapped; all seven register; missing organ skipped.

- **Bug Fixes**
  - Fixed missing logger usage in reanimation paths by using the guard’s default logger and `logging.getLogger`, preventing import-time/logging errors during guarded operations.

<sup>Written for commit 058f52f499cb6b31c2703941467752f8e2cfb3a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

