### PR TITLE
feat(observability): Slice 252 — Shadow-Telemetry (pipe shadow_guard traps into the live StreamEventBroker)

### DIFF
--- a/backend/core/cybernetic_reanimation.py
+++ b/backend/core/cybernetic_reanimation.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import os
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
@@ -33,6 +34,15 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 logger = logging.getLogger("jarvis.cybernetic_reanimation")
 
 _ENV_SHADOW = "JARVIS_RESILIENCE_SHADOW_MODE"
+
+# Slice 252 — the pressure signal currently being dispatched to an organ. The
+# dispatcher sets it before invoking a handler so shadow_guard (called deep
+# inside the organ, with no signal in scope) can attribute a trap to its
+# triggering signal WITHOUT threading the signal through every kernel method.
+# Async-safe (ContextVar is per-task).
+_current_signal_var: "ContextVar[Optional[Any]]" = ContextVar(
+    "jarvis_reanimation_current_signal", default=None,
+)
 
 
 class PressureSignalType(str, Enum):
@@ -82,19 +92,53 @@ def resilience_shadow_mode_enabled() -> bool:
         return True  # fail SAFE — default to shadow on error
 
 
+def emit_shadow_trap(
+    organ_name: str,
+    intended_action: str,
+    triggering_signal: Any = None,
+) -> None:
+    """Slice 252 — publish a SHADOW_ACTION_TRAPPED telemetry event to the
+    StreamEventBroker when a dangerous action is trapped, giving the Sovereign
+    Host real-time structured audit (organ + action + signal) instead of a text
+    log. ``triggering_signal`` defaults to the dispatcher-set ContextVar so the
+    deep guard call-site needs no signal in scope. Out-of-band + fail-soft + lazy
+    import (keeps this module decoupled from the broker). NEVER raises."""
+    try:
+        sig = triggering_signal if triggering_signal is not None else _current_signal_var.get()
+        sig_repr = ""
+        if sig is not None:
+            try:
+                sig_repr = f"{sig.type.value}:{sig.source}:{sig.edge.value}"
+            except Exception:  # noqa: BLE001
+                sig_repr = str(sig)[:128]
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_shadow_action_trapped as _publish,
+        )
+        _publish(
+            organ_name=str(organ_name),
+            intended_action=str(intended_action),
+            triggering_signal=sig_repr,
+        )
+    except Exception:  # noqa: BLE001 — telemetry is best-effort, never the gate
+        logger.debug("[Reanimation] shadow-trap telemetry emit skipped", exc_info=True)
+
+
 def shadow_guard(
     action_desc: str,
     execute: Callable[[], Any],
     *,
+    organ: str = "",
     log: Optional[logging.Logger] = None,
 ) -> Any:
     """Gate a DANGEROUS action behind shadow mode. In shadow mode: log
-    ``[SHADOW MODE] Would have <action_desc>`` and return ``SHADOW_TRAPPED``
-    WITHOUT calling ``execute``. Otherwise: return ``execute()``. The single
-    chokepoint every reanimated organ routes its kill/shed/restart through."""
+    ``[SHADOW MODE] Would have <action_desc>``, publish a SHADOW_ACTION_TRAPPED
+    telemetry event, and return ``SHADOW_TRAPPED`` WITHOUT calling ``execute``.
+    Otherwise: return ``execute()``. The single chokepoint every reanimated organ
+    routes its kill/shed/restart through."""
     _log = log or logger
     if resilience_shadow_mode_enabled():
         _log.warning("[SHADOW MODE] Would have %s", action_desc)
+        emit_shadow_trap(organ, action_desc)
         return SHADOW_TRAPPED
     return execute()
 
@@ -103,12 +147,14 @@ async def shadow_guard_async(
     action_desc: str,
     execute: Callable[[], Awaitable[Any]],
     *,
+    organ: str = "",
     log: Optional[logging.Logger] = None,
 ) -> Any:
     """Async variant of :func:`shadow_guard` for coroutine actions."""
     _log = log or logger
     if resilience_shadow_mode_enabled():
         _log.warning("[SHADOW MODE] Would have %s", action_desc)
+        emit_shadow_trap(organ, action_desc)
         return SHADOW_TRAPPED
     return await execute()
 
@@ -201,11 +247,17 @@ class EventActivationDispatcher:
         handlers = list(self._organs.get(signal.type, ()))
         delivered = 0
         for name, handler in handlers:
+            # Slice 252 — expose the triggering signal to shadow_guard (deep in
+            # the organ) via the ContextVar, so a trapped action is attributed to
+            # the signal that woke it. Reset after each handler (per-organ scope).
+            _token = _current_signal_var.set(signal)
             try:
                 await handler(signal)
                 delivered += 1
             except Exception:  # noqa: BLE001 — one organ never breaks the bus
                 logger.exception("[Reanimation] organ %s raised on %s", name, signal.type)
+            finally:
+                _current_signal_var.reset(_token)
         return delivered
 
     def attach_to_bus(self, bus: Any, *, extract: Callable[[Any], Optional[PressureSignal]]) -> None:

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -168,6 +168,12 @@ EVENT_TYPE_DRIFT_DETECTED = "drift_detected"
 EVENT_TYPE_TOOL_EXPLORATION_START = "tool_exploration_start"
 EVENT_TYPE_GUIDANCE_ABSORBED = "guidance_absorbed"
 
+# Slice 252 (Shadow-Telemetry) — fires when the Cybernetic Reanimation Shadow
+# Mode chokepoint (shadow_guard) traps a dangerous resilience action (kill / shed
+# / restart). Real-time, structured audit of the reanimated muscle's INTENT (no
+# log-grepping). Payload: organ_name + intended_action + triggering_signal.
+EVENT_TYPE_SHADOW_ACTION_TRAPPED = "shadow_action_trapped"
+
 # Slice 12D (Graceful Shutdown on Global Breaker Trip) — single
 # event type covering the global-session structural-refusal
 # transition CLOSED → OPEN_TERMINAL. Carries trip_count + window_s
@@ -1512,6 +1518,8 @@ _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_TOOL_EXPLORATION_START,            # Slice 249 (tool-round boundary — live progress)
     EVENT_TYPE_GUIDANCE_ABSORBED,                 # Slice 249 (running op folded live human steering
                                                   # into its prompt without suspending the lane)
+    EVENT_TYPE_SHADOW_ACTION_TRAPPED,             # Slice 252 (Shadow Mode trapped a dangerous
+                                                  # resilience action — kill/shed/restart)
     EVENT_TYPE_SESSION_EXHAUSTED,                 # Slice 12D (global breaker session-wide trip
                                                   # — fires once at CLOSED → OPEN_TERMINAL with
                                                   # trip_count + window_s + threshold; the
@@ -3078,6 +3086,38 @@ def publish_guidance_absorbed(
         )
     except Exception:  # noqa: BLE001
         logger.debug("[Stream] publish_guidance_absorbed exception", exc_info=True)
+        return None
+
+
+def publish_shadow_action_trapped(
+    *,
+    organ_name: str = "",
+    intended_action: str = "",
+    triggering_signal: str = "",
+    op_id: str = "",
+) -> Optional[str]:
+    """Slice 252 — publish a ``shadow_action_trapped`` event when the Cybernetic
+    Reanimation Shadow Mode chokepoint traps a dangerous resilience action. The
+    structured payload (organ_name + intended_action + triggering_signal) gives
+    the Sovereign Host real-time audit of the reanimated muscle's intent.
+    Non-blocking, NEVER raises (returns None when the stream is disabled)."""
+    if not stream_enabled():
+        return None
+    try:
+        return get_default_broker().publish(
+            EVENT_TYPE_SHADOW_ACTION_TRAPPED,
+            op_id or organ_name or "shadow_action_trapped",
+            {
+                "organ_name": str(organ_name)[:128],
+                "intended_action": str(intended_action)[:512],
+                "triggering_signal": str(triggering_signal)[:128],
+                "op_id": str(op_id)[:64],
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "[Stream] publish_shadow_action_trapped exception", exc_info=True,
+        )
         return None
 
 

--- a/tests/governance/test_reanimation_kernel_wiring.py
+++ b/tests/governance/test_reanimation_kernel_wiring.py
@@ -98,3 +98,31 @@ class TestAllSevenOrgansRegister:
         from unified_supervisor import build_resilience_dispatcher
         d = build_resilience_dispatcher({"SelfHealingOrchestrator": object()})
         assert d.organ_count() == 1
+
+
+class TestSlice252ShadowTelemetryKernel:
+    async def test_anomaly_trap_publishes_to_stream_broker(self, monkeypatch):
+        """Phase 3 (Slice 252): a synthesized ANOMALY_DETECTED wakes the real
+        SelfHealingOrchestrator via build_resilience_dispatcher, the shadow_guard
+        traps the kill, AND the StreamEventBroker registers a structured
+        SHADOW_ACTION_TRAPPED event — non-blocking, no log-grep needed."""
+        monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
+        from backend.core.ouroboros.governance import ide_observability_stream as ios
+        ios.reset_default_broker()
+        from unified_supervisor import build_resilience_dispatcher
+        sho, killed = _sho_with_fake_kill()
+        d = build_resilience_dispatcher({"SelfHealingOrchestrator": sho})
+
+        n = await d.dispatch(
+            PressureSignal(PT.ANOMALY_DETECTED, "proc-victim", SignalEdge.RISING)
+        )
+        assert n == 1
+        assert killed == [], "Shadow Mode must trap the kill"
+
+        evs = [e for e in ios.get_default_broker().recent_history(limit=100)
+               if e.event_type == ios.EVENT_TYPE_SHADOW_ACTION_TRAPPED]
+        assert len(evs) >= 1, "broker must register the SHADOW_ACTION_TRAPPED event"
+        p = evs[0].payload
+        assert p["organ_name"] == "SelfHealingOrchestrator"
+        assert "anomaly_detected:proc-victim" in p["triggering_signal"]
+        assert "execute remediation" in p["intended_action"]

--- a/tests/governance/test_slice252_shadow_telemetry.py
+++ b/tests/governance/test_slice252_shadow_telemetry.py
@@ -1,0 +1,135 @@
+"""Slice 252 — Shadow-Telemetry: pipe shadow_guard traps into the StreamEventBroker.
+
+Decoupled (no kernel import) so it runs in-sandbox. Proves: the
+SHADOW_ACTION_TRAPPED event type is registered; emit_shadow_trap +
+shadow_guard publish a structured event to the live broker non-blockingly; and
+the dispatcher's ContextVar attributes the trap to its triggering signal end to
+end (signal -> organ -> shadow_guard -> broker), without grepping text logs.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import ide_observability_stream as ios
+from backend.core import cybernetic_reanimation as cr
+from backend.core.cybernetic_reanimation import (
+    PressureSignal, PressureSignalType as PT, SignalEdge,
+    EventActivationDispatcher, shadow_guard, shadow_guard_async,
+    emit_shadow_trap, SHADOW_TRAPPED,
+)
+
+
+@pytest.fixture(autouse=True)
+def _stream_on(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_RESILIENCE_SHADOW_MODE", raising=False)  # default TRUE
+    ios.reset_default_broker()
+    yield
+    ios.reset_default_broker()
+
+
+def _trapped_events():
+    broker = ios.get_default_broker()
+    return [e for e in broker.recent_history(limit=100)
+            if e.event_type == ios.EVENT_TYPE_SHADOW_ACTION_TRAPPED]
+
+
+class TestEventTypeRegistered:
+    def test_shadow_action_trapped_is_valid_event(self):
+        assert ios.EVENT_TYPE_SHADOW_ACTION_TRAPPED == "shadow_action_trapped"
+        assert ios.EVENT_TYPE_SHADOW_ACTION_TRAPPED in ios._VALID_EVENT_TYPES
+
+
+class TestPublishWrapper:
+    def test_publish_registers_structured_payload(self):
+        eid = ios.publish_shadow_action_trapped(
+            organ_name="SelfHealingOrchestrator",
+            intended_action="kill pid 1234",
+            triggering_signal="anomaly_detected:proc:rising",
+        )
+        assert eid is not None
+        evs = _trapped_events()
+        assert len(evs) == 1
+        p = evs[0].payload
+        assert p["organ_name"] == "SelfHealingOrchestrator"
+        assert p["intended_action"] == "kill pid 1234"
+        assert p["triggering_signal"] == "anomaly_detected:proc:rising"
+
+    def test_disabled_stream_returns_none(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "0")
+        assert ios.publish_shadow_action_trapped(organ_name="x", intended_action="y") is None
+
+    def test_never_raises(self):
+        ios.publish_shadow_action_trapped()  # all defaults — must not raise
+
+
+class TestEmitShadowTrap:
+    def test_emit_publishes_to_broker(self):
+        emit_shadow_trap("LoadSheddingController", "shed (reject) request: reject:overload")
+        evs = _trapped_events()
+        assert len(evs) == 1
+        assert evs[0].payload["organ_name"] == "LoadSheddingController"
+
+    def test_emit_reads_signal_from_contextvar(self):
+        tok = cr._current_signal_var.set(
+            PressureSignal(PT.RESOURCE_PRESSURE, "cpu", SignalEdge.RISING)
+        )
+        try:
+            emit_shadow_trap("AutoScalingController", "scale down")
+        finally:
+            cr._current_signal_var.reset(tok)
+        assert _trapped_events()[0].payload["triggering_signal"] == "resource_pressure:cpu:rising"
+
+    def test_emit_never_raises_without_broker(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "0")
+        emit_shadow_trap("X", "y")  # no broker publish — must not raise
+
+
+class TestShadowGuardEmits:
+    def test_trap_publishes_telemetry_and_skips_execute(self):
+        ran = []
+        result = shadow_guard("terminate proc-9", lambda: ran.append("KILLED"),
+                              organ="SelfHealingOrchestrator")
+        assert result is SHADOW_TRAPPED and ran == []
+        evs = _trapped_events()
+        assert len(evs) == 1
+        assert evs[0].payload["organ_name"] == "SelfHealingOrchestrator"
+        assert evs[0].payload["intended_action"] == "terminate proc-9"
+
+    def test_shadow_off_does_not_emit_and_executes(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_RESILIENCE_SHADOW_MODE", "0")
+        ran = []
+        result = shadow_guard("terminate proc-9", lambda: ran.append("KILLED") or "done",
+                              organ="SelfHealingOrchestrator")
+        assert result == "done" and ran == ["KILLED"]
+        assert _trapped_events() == []
+
+    async def test_async_guard_emits(self):
+        async def act(): return "x"
+        await shadow_guard_async("restart svc", act, organ="GracefulDegradationManager")
+        assert _trapped_events()[0].payload["organ_name"] == "GracefulDegradationManager"
+
+
+class TestPhase3DispatchChain:
+    async def test_signal_to_organ_to_guard_to_broker_attributed(self):
+        """Synthesize a signal -> dispatcher sets the ContextVar -> organ wakes ->
+        its shadow_guard traps -> the broker registers a SHADOW_ACTION_TRAPPED
+        whose triggering_signal is attributed to the dispatched signal. No kernel,
+        non-blocking."""
+        d = EventActivationDispatcher()
+
+        async def reanimated_organ(sig):
+            # the organ reasons, then routes its kill through the guard
+            return shadow_guard("kill the leaking worker", lambda: ("EXECUTED",),
+                                organ="SelfHealingOrchestrator")
+
+        d.register_organ("SelfHealingOrchestrator", reanimated_organ, [PT.ANOMALY_DETECTED])
+        n = await d.dispatch(PressureSignal(PT.ANOMALY_DETECTED, "worker-7", SignalEdge.RISING))
+        assert n == 1
+        evs = _trapped_events()
+        assert len(evs) == 1
+        p = evs[0].payload
+        assert p["organ_name"] == "SelfHealingOrchestrator"
+        assert p["intended_action"] == "kill the leaking worker"
+        # the trap was attributed to the signal that woke the organ (ContextVar)
+        assert p["triggering_signal"] == "anomaly_detected:worker-7:rising"

--- a/unified_supervisor.py
+++ b/unified_supervisor.py
@@ -29433,6 +29433,7 @@ class SelfHealingOrchestrator:
             success = await _shadow_guard_async(
                 f"execute remediation '{strategy.value}' on component '{component}'",
                 lambda: handler(component),
+                organ="SelfHealingOrchestrator",
             )
             if success is _SHADOW_TRAPPED:
                 self._stats["remediations_failed"] += 1
@@ -40862,10 +40863,15 @@ class LoadSheddingController(SystemService):
             # the request through (run the normal handler) instead.
             from backend.core.cybernetic_reanimation import (
                 resilience_shadow_mode_enabled as _resilience_shadow_mode_enabled,
+                emit_shadow_trap as _emit_shadow_trap,
             )
             if _resilience_shadow_mode_enabled():
                 logging.getLogger("unified_supervisor.reanimation").warning(
                     "[SHADOW MODE] Would have shed (rejected) request: %s", action,
+                )
+                # Slice 252 — structured real-time audit of the trapped shed.
+                _emit_shadow_trap(
+                    "LoadSheddingController", f"shed (reject) request: {action}",
                 )
             else:
                 raise RuntimeError(f"Request rejected: {action}")


### PR DESCRIPTION
## Slice 252 — Shadow-Telemetry & Real-Time Auditing

Closes the Shadow Mode observability deficit: instead of only logging `[SHADOW MODE] Would have …` to text (a terminal blindspot), every trapped resilience action now emits a structured **`SHADOW_ACTION_TRAPPED`** event into the live Slice-249 `StreamEventBroker` — real-time audit of the reanimated muscle's intent, no log-grepping.

### `ide_observability_stream.py`
- `EVENT_TYPE_SHADOW_ACTION_TRAPPED` + `_VALID_EVENT_TYPES` entry.
- `publish_shadow_action_trapped(organ_name, intended_action, triggering_signal, op_id)` — non-blocking, never raises, returns `None` when the stream is disabled.

### `cybernetic_reanimation.py`
- `emit_shadow_trap(organ, action, signal=None)` — publishes the structured event (lazy broker import keeps the module decoupled/testable; fail-soft).
- `shadow_guard` / `shadow_guard_async` gain an `organ` kwarg and, on trap, **emit telemetry in addition to logging**.
- **`_current_signal_var` ContextVar**: `EventActivationDispatcher.dispatch` sets the triggering signal around each organ handler, so the *deep* guard call-site attributes a trap to its signal **without threading it through kernel methods** (async-safe, per-task).

### `unified_supervisor.py`
The two chokepoints now carry attribution — `SelfHealingOrchestrator._execute_remediation` passes `organ="SelfHealingOrchestrator"`; `LoadSheddingController.with_shedding` calls `emit_shadow_trap` on its trapped shed.

### Phase 3 proof
- **11 decoupled tests (in-sandbox):** event registered; `publish_*` + `emit_shadow_trap` register a structured payload in the broker; `shadow_guard` emits on trap (and not when shadow-off); the dispatch ContextVar attributes the trap end-to-end (signal → organ → guard → broker).
- **1 kernel-chain proof (sandbox-off):** a synthesized `ANOMALY_DETECTED` wakes the *real* `SelfHealingOrchestrator`, the kill is trapped, and the broker registers `SHADOW_ACTION_TRAPPED` with `organ_name="SelfHealingOrchestrator"`, `triggering_signal="anomaly_detected:proc-victim:rising"`, `intended_action` containing `execute remediation`. **Non-blocking** (sync broker publish, fail-soft).
- **37 green** incl. Slice 249 + reanimation foundation — zero regression (the stream edit is purely additive).

Built in an OCA-owned worktree off clean `origin/main`. Reuses the Slice-249 broker (no parallel telemetry path) per "leverage existing architecture."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real-time shadow telemetry for trapped resilience actions. When Shadow Mode blocks a kill/shed/restart, we emit a structured `shadow_action_trapped` event to the live StreamEventBroker for instant auditing (no log-grep).

- **New Features**
  - New event type `shadow_action_trapped` in `ide_observability_stream` and `publish_shadow_action_trapped(...)`. Non-blocking; returns `None` when the stream is disabled.
  - New `emit_shadow_trap(organ_name, intended_action, triggering_signal=None)` in `cybernetic_reanimation`. Lazy broker import; fail-soft; never raises.
  - `shadow_guard` and `shadow_guard_async` now accept `organ` and publish telemetry on trap alongside logging.
  - Added `_current_signal_var` ContextVar; `EventActivationDispatcher.dispatch` sets it so traps are attributed to the triggering signal (async-safe, no call-chain plumbing).
  - `unified_supervisor` wiring: `_execute_remediation` passes `organ="SelfHealingOrchestrator"`; `LoadSheddingController.with_shedding` calls `emit_shadow_trap` on trapped sheds.

<sup>Written for commit 763c7187baa9d0a2a180413f4eb9bf7a941b3f21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

