### PR TITLE
Cybernetic Reanimation: ignite the resilience matrix (live pressure producer + dispatcher wiring)

### DIFF
--- a/backend/core/cybernetic_reanimation.py
+++ b/backend/core/cybernetic_reanimation.py
@@ -114,6 +114,27 @@ async def shadow_guard_async(
 
 
 # ---------------------------------------------------------------------------
+# Pure sampler predicate — extracted for unit testing the producer's logic
+# ---------------------------------------------------------------------------
+
+def _pressure_active(
+    mem: float,
+    cpu: float,
+    mem_thr: float,
+    cpu_thr: float,
+) -> bool:
+    """Return True when EITHER normalized resource (0.0-1.0) is at-or-above its
+    threshold. The pure predicate the live pressure sampler feeds into
+    :meth:`PressureSignalEmitter.observe` — extracted so the producer's
+    threshold/edge logic is unit-testable without the 102K-line kernel. NEVER
+    raises (non-numeric inputs coerce to the safe ``False`` floor)."""
+    try:
+        return (float(mem) >= float(mem_thr)) or (float(cpu) >= float(cpu_thr))
+    except Exception:  # noqa: BLE001 — sampler must never throw into the loop
+        return False
+
+
+# ---------------------------------------------------------------------------
 # PressureSignalEmitter — level observations -> edge-triggered signals
 # ---------------------------------------------------------------------------
 

--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -4889,6 +4889,85 @@ SEED_SPECS: list = [
         since="Slice 46 (monotonic heartbeat alignment, 2026-05-29)",
         posture_relevance=_HARDEN_CRITICAL,
     ),
+    # ====================================================================
+    # Sovereign Fusion — Cybernetic Reanimation ignition (Spec 2) — 5 flags
+    # ====================================================================
+    FlagSpec(
+        name="JARVIS_RESILIENCE_REANIMATION_ENABLED",
+        type=FlagType.BOOL, default=False,
+        description=(
+            "Master gate for the Cybernetic Reanimation ignition. When "
+            "true, the kernel instantiates the 7 resilience organs, wires "
+            "build_resilience_dispatcher, and starts the live pressure "
+            "sampler (PRODUCER) that drives them via edge-triggered "
+            "signals. Default false → ignition early-returns (boot is "
+            "byte-identical). Dangerous organ actions stay Shadow-guarded."
+        ),
+        category=Category.SAFETY,
+        source_file="unified_supervisor.py",
+        example="false",
+        since="Sovereign Fusion (resilience ignition, 2026-06-14)",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
+    FlagSpec(
+        name="JARVIS_RESILIENCE_SHADOW_MODE",
+        type=FlagType.BOOL, default=True,
+        description=(
+            "Fail-safe for reanimated resilience organs (default TRUE). "
+            "While on, every DANGEROUS action (process kill, load shed, "
+            "remediation) is trapped at its source by shadow_guard — the "
+            "organ logs '[SHADOW MODE] Would have ...' and yields the "
+            "trapped sentinel instead of executing. Clear it only when the "
+            "matrix has earned trust to act on the world."
+        ),
+        category=Category.SAFETY,
+        source_file="backend/core/cybernetic_reanimation.py",
+        example="true",
+        since="Spec 2 (Cybernetic Reanimation foundation)",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
+    FlagSpec(
+        name="JARVIS_PRESSURE_SAMPLE_INTERVAL_S",
+        type=FlagType.FLOAT, default=15.0,
+        description=(
+            "Cadence (seconds) of the resilience pressure sampler loop — "
+            "how often memory% and cpu% are read and fed to the edge-"
+            "triggered PressureSignalEmitter. Only active when reanimation "
+            "is ignited."
+        ),
+        category=Category.TIMING,
+        source_file="unified_supervisor.py",
+        example="15.0",
+        since="Sovereign Fusion (resilience ignition, 2026-06-14)",
+    ),
+    FlagSpec(
+        name="JARVIS_PRESSURE_MEM_THRESHOLD",
+        type=FlagType.FLOAT, default=0.9,
+        description=(
+            "Normalized memory-usage threshold (0.0-1.0) at/above which the "
+            "pressure sampler treats RESOURCE_PRESSURE as active, raising a "
+            "rising-edge signal to the resilience organs."
+        ),
+        category=Category.TUNING,
+        source_file="unified_supervisor.py",
+        example="0.9",
+        since="Sovereign Fusion (resilience ignition, 2026-06-14)",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
+    FlagSpec(
+        name="JARVIS_PRESSURE_CPU_THRESHOLD",
+        type=FlagType.FLOAT, default=0.9,
+        description=(
+            "Normalized cpu-utilization threshold (0.0-1.0) at/above which "
+            "the pressure sampler treats RESOURCE_PRESSURE as active, "
+            "raising a rising-edge signal to the resilience organs."
+        ),
+        category=Category.TUNING,
+        source_file="unified_supervisor.py",
+        example="0.9",
+        since="Sovereign Fusion (resilience ignition, 2026-06-14)",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
 ]
 
 

--- a/tests/governance/test_reanimation_ignition.py
+++ b/tests/governance/test_reanimation_ignition.py
@@ -1,0 +1,195 @@
+"""Sovereign Fusion — regression spine for igniting the resilience matrix.
+
+These tests deliberately DO NOT import ``unified_supervisor`` (its import is
+sandbox-blocked by the split-brain guard). They exercise the REAL
+``backend.core.cybernetic_reanimation`` primitives + the extracted pure
+producer predicate, with fakes standing in for the 7 reanimated organs.
+
+Two concerns under test:
+  1. The PRODUCER logic — ``_pressure_active`` threshold predicate fed through
+     ``PressureSignalEmitter.observe`` proves edge-triggering: a single RISING
+     edge while pressure is sustained, then exactly one FALLING edge on clear.
+  2. The WIRING — a synthetic ``RESOURCE_PRESSURE`` rising edge dispatched
+     through a real ``EventActivationDispatcher`` reaches a registered mock
+     organ handler. Shadow-safety is inherited from source-level
+     ``shadow_guard`` chokepoints (referenced, not re-tested here).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.cybernetic_reanimation import (
+    EventActivationDispatcher,
+    PressureSignal,
+    PressureSignalEmitter,
+    PressureSignalType,
+    SignalEdge,
+    _pressure_active,
+    resilience_shadow_mode_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Producer predicate — pure threshold logic
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "mem,cpu,mem_thr,cpu_thr,expected",
+    [
+        (0.5, 0.5, 0.9, 0.9, False),   # both below
+        (0.95, 0.5, 0.9, 0.9, True),   # mem over
+        (0.5, 0.95, 0.9, 0.9, True),   # cpu over
+        (0.9, 0.0, 0.9, 0.9, True),    # at-threshold mem (>=)
+        (0.0, 0.9, 0.9, 0.9, True),    # at-threshold cpu (>=)
+        (0.89, 0.89, 0.9, 0.9, False), # just below both
+    ],
+)
+def test_pressure_active_predicate(mem, cpu, mem_thr, cpu_thr, expected):
+    assert _pressure_active(mem, cpu, mem_thr, cpu_thr) is expected
+
+
+def test_pressure_active_never_raises_on_bad_input():
+    # sampler must survive a degenerate probe reading
+    assert _pressure_active(None, "x", 0.9, 0.9) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 2. Edge-triggering through the real emitter (the producer's signal shaping)
+# ---------------------------------------------------------------------------
+
+def _make_emitter():
+    emitted = []
+    em = PressureSignalEmitter(emit_fn=emitted.append)
+    return em, emitted
+
+
+def test_sampler_rising_once_then_silent_while_sustained():
+    em, emitted = _make_emitter()
+    MEM_THR = CPU_THR = 0.9
+
+    def sample(mem, cpu):
+        return em.observe(
+            PressureSignalType.RESOURCE_PRESSURE,
+            "system",
+            active=_pressure_active(mem, cpu, MEM_THR, CPU_THR),
+            detail={"mem": mem, "cpu": cpu},
+        )
+
+    # below threshold — no edge
+    assert sample(0.5, 0.5) is None
+    # crosses up — exactly one RISING edge
+    sig = sample(0.95, 0.5)
+    assert sig is not None and sig.edge is SignalEdge.RISING
+    assert sig.type is PressureSignalType.RESOURCE_PRESSURE
+    # still over — sustained, NO re-emit (the anti-spam invariant)
+    assert sample(0.96, 0.6) is None
+    assert sample(0.99, 0.2) is None
+    # only one signal so far
+    assert len(emitted) == 1
+    assert emitted[0].edge is SignalEdge.RISING
+
+
+def test_sampler_falling_edge_on_clear():
+    em, emitted = _make_emitter()
+    MEM_THR = CPU_THR = 0.9
+
+    def sample(mem, cpu):
+        return em.observe(
+            PressureSignalType.RESOURCE_PRESSURE,
+            "system",
+            active=_pressure_active(mem, cpu, MEM_THR, CPU_THR),
+        )
+
+    sample(0.95, 0.5)            # rising
+    falling = sample(0.1, 0.1)   # clear -> falling
+    assert falling is not None and falling.edge is SignalEdge.FALLING
+    # back below stays silent
+    assert sample(0.2, 0.2) is None
+    assert [s.edge for s in emitted] == [SignalEdge.RISING, SignalEdge.FALLING]
+
+
+# ---------------------------------------------------------------------------
+# 3. Ignition wiring — emitter -> dispatcher -> mock organ handler
+# ---------------------------------------------------------------------------
+
+def test_rising_edge_reaches_registered_organ():
+    """Prove the full producer->dispatcher->organ synapse: a RESOURCE_PRESSURE
+    rising edge produced by the emitter is delivered to a registered mock organ.
+
+    This mirrors what ``_ignite_resilience_reanimation`` wires in the kernel
+    (build_resilience_dispatcher + PressureSignalEmitter(emit_fn=schedule)),
+    but stays on the importable primitives since unified_supervisor cannot be
+    imported under the split-brain guard.
+    """
+    received = []
+
+    async def organ_handler(sig: PressureSignal):
+        received.append(sig)
+
+    dispatcher = EventActivationDispatcher()
+    dispatcher.register_organ(
+        "FakeLoadShedder",
+        organ_handler,
+        [PressureSignalType.RESOURCE_PRESSURE],
+    )
+
+    # the kernel's _schedule_dispatch does loop.create_task(dispatcher.dispatch)
+    scheduled = []
+
+    def schedule(sig):
+        scheduled.append(sig)
+
+    emitter = PressureSignalEmitter(emit_fn=schedule)
+
+    # produce a rising edge
+    emitter.observe(PressureSignalType.RESOURCE_PRESSURE, "system", active=True)
+    assert len(scheduled) == 1
+
+    # now actually run dispatch (what create_task would do on the loop)
+    delivered = asyncio.run(dispatcher.dispatch(scheduled[0]))
+    assert delivered == 1
+    assert len(received) == 1
+    assert received[0].type is PressureSignalType.RESOURCE_PRESSURE
+    assert received[0].edge is SignalEdge.RISING
+
+
+def test_dispatch_is_fail_soft_across_organs():
+    """One broken organ never starves the others (the bus invariant the
+    ignition relies on)."""
+    good = []
+
+    async def broken(sig):
+        raise RuntimeError("organ exploded")
+
+    async def healthy(sig):
+        good.append(sig)
+
+    d = EventActivationDispatcher()
+    d.register_organ("Broken", broken, [PressureSignalType.RESOURCE_PRESSURE])
+    d.register_organ("Healthy", healthy, [PressureSignalType.RESOURCE_PRESSURE])
+
+    sig = PressureSignal(
+        type=PressureSignalType.RESOURCE_PRESSURE,
+        source="system",
+        edge=SignalEdge.RISING,
+    )
+    delivered = asyncio.run(d.dispatch(sig))
+    # the healthy organ still received the signal; broken one swallowed
+    assert delivered == 1
+    assert len(good) == 1
+
+
+def test_shadow_mode_default_on_is_inherited():
+    """Shadow-safety is inherited at the SOURCE chokepoints (shadow_guard wraps
+    every dangerous action). Reanimation only wakes the organs; it does not
+    bypass that guard. Default posture is shadow-ON (fail-safe)."""
+    import os
+
+    prev = os.environ.pop("JARVIS_RESILIENCE_SHADOW_MODE", None)
+    try:
+        assert resilience_shadow_mode_enabled() is True
+    finally:
+        if prev is not None:
+            os.environ["JARVIS_RESILIENCE_SHADOW_MODE"] = prev

--- a/unified_supervisor.py
+++ b/unified_supervisor.py
@@ -29528,6 +29528,201 @@ def build_resilience_dispatcher(organs: "Dict[str, Any]") -> "Any":
     return d
 
 
+# ---------------------------------------------------------------------------
+# Sovereign Fusion — IGNITE the resilience matrix (Spec 2 completion)
+#
+# ``build_resilience_dispatcher`` (above) wires the 7 organs to typed pressure
+# signals but was never CALLED, no organs were ever instantiated, and nothing
+# produced pressure signals. The three helpers below close that loop:
+#   * ``_instantiate_resilience_organs`` — best-effort construct each organ.
+#   * ``_ignite_resilience_reanimation`` — flag-guarded ignition: build the
+#     dispatcher, wire a ``PressureSignalEmitter``, and start the live PRODUCER
+#     (a background sampler that turns psutil resource readings into edge-
+#     triggered signals). Dangerous organ actions remain trapped at their
+#     SOURCE chokepoints by ``shadow_guard`` (default shadow-ON), so igniting
+#     the matrix wakes the organs to reason but cannot act on the world.
+#
+# Default OFF (``JARVIS_RESILIENCE_REANIMATION_ENABLED``) → early return →
+# byte-identical to the un-ignited kernel. ALL boot calls are fail-soft.
+# ---------------------------------------------------------------------------
+
+def _instantiate_resilience_organs() -> "Dict[str, Any]":
+    """Best-effort construct each of the 7 resilience organs. Each construction
+    is isolated in its own try/except — a single organ that needs an
+    unavailable arg is SKIPPED, never aborting the others. Returns a
+    ``{ClassName: instance}`` dict for the organs that built cleanly. NEVER
+    raises."""
+    organs: "Dict[str, Any]" = {}
+
+    # Organs with all-defaulted constructors.
+    for _name, _ctor in (
+        ("GracefulDegradationManager", lambda: GracefulDegradationManager()),
+        ("LoadSheddingController", lambda: LoadSheddingController()),
+        ("AutoScalingController", lambda: AutoScalingController()),
+        ("ProcessHealthPredictor", lambda: ProcessHealthPredictor()),
+        ("SelfHealingOrchestrator", lambda: SelfHealingOrchestrator()),
+        # AdvancedCircuitBreaker requires a name.
+        ("AdvancedCircuitBreaker", lambda: AdvancedCircuitBreaker(name="reanimation")),
+    ):
+        try:
+            organs[_name] = _ctor()
+        except Exception as _e:  # noqa: BLE001
+            logger.debug("[Reanimation] skip organ %s: %s", _name, _e)
+
+    # AnomalyDetector needs a SystemKernelConfig — derive from environment.
+    try:
+        _cfg = SystemKernelConfig.from_environment()
+        organs["AnomalyDetector"] = AnomalyDetector(_cfg)
+    except Exception as _e:  # noqa: BLE001
+        logger.debug("[Reanimation] skip organ AnomalyDetector: %s", _e)
+
+    logger.info(
+        "[Reanimation] instantiated %d/7 resilience organs: %s",
+        len(organs), sorted(organs),
+    )
+    return organs
+
+
+def _resilience_reanimation_enabled() -> bool:
+    """Master gate for the Sovereign Fusion ignition (default FALSE → OFF path
+    is byte-identical). NEVER raises."""
+    try:
+        return os.getenv(
+            "JARVIS_RESILIENCE_REANIMATION_ENABLED", "false"
+        ).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001
+        return False
+
+
+async def _resilience_pressure_sampler(
+    emitter: "Any",
+    *,
+    interval_s: float,
+    mem_thr: float,
+    cpu_thr: float,
+) -> None:
+    """The live PRODUCER. Loops forever (until cancelled) sampling memory% and
+    cpu% and feeding the edge-triggered :class:`PressureSignalEmitter`. Prefers
+    ``psutil``; falls back to a ``DynamicRAMMonitor`` reading for memory if
+    psutil is unavailable. Fail-soft per tick — a bad probe skips one cycle, it
+    never breaks the loop. Returns only on cancellation."""
+    from backend.core.cybernetic_reanimation import (
+        PressureSignalType as _PT, _pressure_active,
+    )
+
+    _ram_monitor = None  # lazy fallback for memory only
+
+    while True:
+        try:
+            mem = 0.0
+            cpu = 0.0
+            try:
+                mem = float(psutil.virtual_memory().percent) / 100.0
+            except Exception:  # noqa: BLE001 — fall back to DynamicRAMMonitor
+                try:
+                    if _ram_monitor is None:
+                        _ram_monitor = DynamicRAMMonitor()
+                    mem = float(getattr(_ram_monitor, "current_usage", 0.0) or 0.0)
+                except Exception:  # noqa: BLE001
+                    mem = 0.0
+            try:
+                cpu = float(psutil.cpu_percent(interval=None)) / 100.0
+            except Exception:  # noqa: BLE001
+                cpu = 0.0
+
+            emitter.observe(
+                _PT.RESOURCE_PRESSURE,
+                "system",
+                active=_pressure_active(mem, cpu, mem_thr, cpu_thr),
+                detail={"mem": mem, "cpu": cpu},
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — one bad tick never breaks the loop
+            logger.debug("[Reanimation] pressure sampler tick failed", exc_info=True)
+
+        try:
+            await asyncio.sleep(interval_s)
+        except asyncio.CancelledError:
+            raise
+
+
+def _ignite_resilience_reanimation(kernel: "Any") -> bool:
+    """Ignite the Cybernetic Reanimation matrix on the live kernel. ONLY active
+    when ``JARVIS_RESILIENCE_REANIMATION_ENABLED`` is true (default FALSE →
+    early return, byte-identical OFF path). Fully fail-soft — NEVER breaks boot.
+
+    Wiring: instantiate organs → ``build_resilience_dispatcher`` → a
+    ``PressureSignalEmitter`` whose ``emit_fn`` schedules ``dispatcher.dispatch``
+    on the running loop → a background sampler task (the PRODUCER) registered in
+    the kernel's background-task registry. Returns True if ignition started.
+
+    Must be called from an async boot stage where the event loop is running and
+    the service registry exists. Dangerous organ actions stay Shadow-guarded at
+    their source."""
+    if not _resilience_reanimation_enabled():
+        return False
+    try:
+        organs = _instantiate_resilience_organs()
+        dispatcher = build_resilience_dispatcher(organs)
+
+        from backend.core.cybernetic_reanimation import (
+            PressureSignalEmitter, resilience_shadow_mode_enabled,
+        )
+
+        def _schedule_dispatch(sig: "Any") -> None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                return  # no loop — nothing to schedule onto
+            loop.create_task(dispatcher.dispatch(sig))
+
+        emitter = PressureSignalEmitter(emit_fn=_schedule_dispatch)
+
+        def _env_float(name: str, default: float) -> float:
+            try:
+                return float(os.getenv(name, str(default)))
+            except Exception:  # noqa: BLE001
+                return default
+
+        interval_s = _env_float("JARVIS_PRESSURE_SAMPLE_INTERVAL_S", 15.0)
+        mem_thr = _env_float("JARVIS_PRESSURE_MEM_THRESHOLD", 0.9)
+        cpu_thr = _env_float("JARVIS_PRESSURE_CPU_THRESHOLD", 0.9)
+
+        task = create_safe_task(
+            _resilience_pressure_sampler(
+                emitter,
+                interval_s=interval_s,
+                mem_thr=mem_thr,
+                cpu_thr=cpu_thr,
+            ),
+            name="resilience-pressure-sampler",
+        )
+        try:
+            kernel._background_tasks.append(task)
+        except Exception:  # noqa: BLE001 — registry is best-effort; task already live
+            logger.debug("[Reanimation] could not register sampler task", exc_info=True)
+
+        # Stash references on the kernel so they outlive this frame (no GC).
+        try:
+            kernel._resilience_dispatcher = dispatcher
+            kernel._resilience_emitter = emitter
+            kernel._resilience_sampler_task = task
+        except Exception:  # noqa: BLE001
+            pass
+
+        logger.info(
+            "[Reanimation] IGNITED — %d organs, sampler interval=%.1fs "
+            "mem_thr=%.2f cpu_thr=%.2f (shadow_mode=%s)",
+            dispatcher.organ_count(), interval_s, mem_thr, cpu_thr,
+            resilience_shadow_mode_enabled(),
+        )
+        return True
+    except Exception as _e:  # noqa: BLE001 — ignition NEVER breaks boot
+        logger.warning("[Reanimation] ignition failed (non-fatal): %s", _e)
+        return False
+
+
 class DistributedStateCoordinator:
     """
     Cross-repo state synchronization using file-based coordination.
@@ -72796,6 +72991,19 @@ class JarvisSystemKernel:
                         "[Startup] trace hook: %s: %s",
                         type(_exc).__name__, _exc,
                     )
+
+            # Sovereign Fusion — ignite the Cybernetic Reanimation matrix.
+            # Flag-guarded (JARVIS_RESILIENCE_REANIMATION_ENABLED, default OFF →
+            # early return → byte-identical) + fully fail-soft. The loop is
+            # running and the service registry + bus are up at this point, so
+            # this is the correct async stage for the live pressure producer.
+            try:
+                _ignite_resilience_reanimation(self)
+            except Exception as _reanim_err:  # noqa: BLE001 — never break boot
+                self.logger.debug(
+                    "[Startup] resilience reanimation ignition skipped: %s",
+                    _reanim_err,
+                )
 
             return 0
 


### PR DESCRIPTION
Completes Spec 2 on top of #69500/#69502: instantiates the 7 organs, calls build_resilience_dispatcher, and adds the missing PRODUCER — a flag-guarded, fail-soft, edge-triggered PressureSignalEmitter sampler (psutil/DynamicRAMMonitor) that drives the organs through the existing shadow_guard. Default-OFF (JARVIS_RESILIENCE_REANIMATION_ENABLED); OFF byte-identical (unified_supervisor.py additive, 0 deletions). Adds FlagRegistry seeds. Tests green; ast.parse clean; shadow-guard test green.

🤖 Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignites the resilience matrix by instantiating the seven organs, wiring the dispatcher, and starting a flag-guarded live pressure producer that emits edge-triggered signals. Default OFF; runtime is unchanged when disabled and dangerous actions remain shadow-guarded.

- **New Features**
  - Instantiates 7 resilience organs and builds `build_resilience_dispatcher` during startup when enabled.
  - Adds a live pressure sampler that emits edge-triggered `RESOURCE_PRESSURE` signals (uses `psutil`, falls back to `DynamicRAMMonitor`); fail-soft each tick.
  - Extracts `_pressure_active` predicate for unit testing; adds tests for edge behavior, dispatcher delivery, and shadow-mode default.
  - Seeds 5 flags: `JARVIS_RESILIENCE_REANIMATION_ENABLED`, `JARVIS_RESILIENCE_SHADOW_MODE`, `JARVIS_PRESSURE_SAMPLE_INTERVAL_S`, `JARVIS_PRESSURE_MEM_THRESHOLD`, `JARVIS_PRESSURE_CPU_THRESHOLD`.

- **Migration**
  - No change by default. To enable, set `JARVIS_RESILIENCE_REANIMATION_ENABLED=true`.
  - Keep `JARVIS_RESILIENCE_SHADOW_MODE=true` initially for safe rollout.
  - Optional tuning: `JARVIS_PRESSURE_SAMPLE_INTERVAL_S` (seconds), `JARVIS_PRESSURE_MEM_THRESHOLD`, `JARVIS_PRESSURE_CPU_THRESHOLD` (0.0–1.0).

<sup>Written for commit cfbbf23bad4d44bc6ead0f5e2d50fb1dcdda483d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

