### PR TITLE
feat(resilience): Slice 253 — Active Shadow Endorsement & HITL Gateway (bidirectional return channel)

### DIFF
--- a/backend/core/cybernetic_reanimation.py
+++ b/backend/core/cybernetic_reanimation.py
@@ -24,8 +24,11 @@ Pure/async, env-driven, NEVER raises on the dispatch hot path.
 """
 from __future__ import annotations
 
+import inspect
 import logging
 import os
+import time
+from collections import OrderedDict
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import Enum
@@ -92,10 +95,226 @@ def resilience_shadow_mode_enabled() -> bool:
         return True  # fail SAFE — default to shadow on error
 
 
+# ---------------------------------------------------------------------------
+# Slice 253 — Active Shadow Endorsement & HITL Gateway (the return channel)
+#
+# Passive telemetry (Slice 252) tells the Host what the muscle WOULD have done.
+# This is the bidirectional half: when shadow_guard traps a dangerous action it
+# STASHES the original callable (a live in-process closure) keyed by a unique
+# action_id. The Host can later ENDORSE that one action_id — the closure is
+# re-hydrated and executed for a single run, bypassing the shadow block for THAT
+# action only, while the global JARVIS_RESILIENCE_SHADOW_MODE shield stays UP.
+#
+# Bounded + TTL'd: a pending action that is never endorsed expires (a stale kill
+# must NOT fire late) and the registry is capacity-capped (oldest evicted). The
+# stash is in-process only — closures are not serializable, so an un-endorsed
+# action does not survive a process restart (by design: a restart is a clean
+# slate, not a queue of pending world-mutations).
+# ---------------------------------------------------------------------------
+
+_ENV_PENDING_MAX = "JARVIS_SHADOW_PENDING_MAX"
+_ENV_PENDING_TTL_S = "JARVIS_SHADOW_PENDING_TTL_S"
+_DEFAULT_PENDING_MAX = 64
+_DEFAULT_PENDING_TTL_S = 300.0
+
+
+def _pending_max() -> int:
+    try:
+        return max(1, int(os.getenv(_ENV_PENDING_MAX, str(_DEFAULT_PENDING_MAX))))
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_PENDING_MAX
+
+
+def _pending_ttl_s() -> float:
+    try:
+        return max(0.0, float(os.getenv(_ENV_PENDING_TTL_S, str(_DEFAULT_PENDING_TTL_S))))
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_PENDING_TTL_S
+
+
+def _current_signal_repr() -> str:
+    """Compact repr of the dispatcher-set triggering signal (ContextVar), for
+    stashing alongside a pending action. NEVER raises."""
+    try:
+        sig = _current_signal_var.get()
+        if sig is None:
+            return ""
+        return f"{sig.type.value}:{sig.source}:{sig.edge.value}"
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+@dataclass
+class PendingShadowAction:
+    """A trapped dangerous action awaiting endorsement. Holds the live in-process
+    callable so it can be re-hydrated and executed for one run."""
+    action_id: str
+    organ: str
+    action_desc: str
+    execute: Callable[[], Any]
+    is_coro: bool
+    signal_repr: str
+    created_monotonic: float
+
+
+@dataclass(frozen=True)
+class EndorsementResult:
+    """Terminal outcome of an endorsement attempt. ``status`` is one of:
+    executed | declined | not_found | expired | error."""
+    status: str
+    action_id: str
+    organ: str = ""
+    intended_action: str = ""
+    result: Any = None
+    error: str = ""
+
+
+class PendingShadowActionRegistry:
+    """Bounded, TTL-aware store of trapped actions awaiting endorsement. Pure +
+    in-process; NEVER raises on the register/pop hot path."""
+
+    def __init__(self) -> None:
+        self.entries: "OrderedDict[str, PendingShadowAction]" = OrderedDict()
+        self._seq = 0
+
+    def register(
+        self,
+        *,
+        organ: str,
+        action_desc: str,
+        execute: Callable[[], Any],
+        is_coro: bool,
+        signal_repr: str = "",
+    ) -> str:
+        """Stash a trapped action; returns its unique action_id. Evicts the
+        oldest entry when the capacity cap is exceeded."""
+        self._seq += 1
+        action_id = f"shadow-{self._seq:06d}"
+        self.entries[action_id] = PendingShadowAction(
+            action_id=action_id,
+            organ=str(organ),
+            action_desc=str(action_desc),
+            execute=execute,
+            is_coro=bool(is_coro),
+            signal_repr=str(signal_repr),
+            created_monotonic=time.monotonic(),
+        )
+        # Bound the registry — drop oldest beyond the cap (FIFO).
+        cap = _pending_max()
+        while len(self.entries) > cap:
+            self.entries.popitem(last=False)
+        return action_id
+
+    def pop(self, action_id: str) -> Optional[PendingShadowAction]:
+        return self.entries.pop(action_id, None)
+
+    def reset(self) -> None:
+        self.entries.clear()
+        self._seq = 0
+
+
+_PENDING = PendingShadowActionRegistry()
+
+
+def reset_pending_shadow_actions() -> None:
+    """Clear all pending trapped actions (test seam + clean-slate on boot)."""
+    _PENDING.reset()
+
+
+def pending_shadow_action_count() -> int:
+    return len(_PENDING.entries)
+
+
+def pending_shadow_action_ids() -> List[str]:
+    """The action_ids currently awaiting endorsement (oldest first)."""
+    return list(_PENDING.entries.keys())
+
+
+async def endorse_shadow_action(action_id: str) -> EndorsementResult:
+    """Re-hydrate and execute ONE trapped action for the given ``action_id`` —
+    bypassing the shadow block for this single run WITHOUT touching the global
+    JARVIS_RESILIENCE_SHADOW_MODE shield. One-shot (the entry is popped, so it
+    cannot double-fire). Rejects unknown ids and expired (TTL'd) entries — a
+    stale kill must never fire late. Fail-soft: an exception in the underlying
+    action yields status="error", never propagates. Publishes an audit event."""
+    entry = _PENDING.pop(action_id)
+    if entry is None:
+        return EndorsementResult(status="not_found", action_id=action_id)
+
+    ttl = _pending_ttl_s()
+    if ttl > 0 and (time.monotonic() - entry.created_monotonic) > ttl:
+        _emit_endorsement(entry, "expired")
+        return EndorsementResult(
+            status="expired", action_id=action_id, organ=entry.organ,
+            intended_action=entry.action_desc,
+        )
+
+    try:
+        out = entry.execute()
+        if entry.is_coro or inspect.isawaitable(out):
+            out = await out
+        _emit_endorsement(entry, "executed")
+        return EndorsementResult(
+            status="executed", action_id=action_id, organ=entry.organ,
+            intended_action=entry.action_desc, result=out,
+        )
+    except Exception as exc:  # noqa: BLE001 — endorsement must never crash the Host
+        logger.exception(
+            "[Reanimation] endorsed action %s (%s) raised", action_id, entry.organ,
+        )
+        _emit_endorsement(entry, "error")
+        return EndorsementResult(
+            status="error", action_id=action_id, organ=entry.organ,
+            intended_action=entry.action_desc, error=str(exc)[:256],
+        )
+
+
+def _emit_endorsement(entry: PendingShadowAction, outcome: str) -> None:
+    """Publish the endorsement audit event. Fail-soft, lazy import, NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_endorse_shadow_action as _publish,
+        )
+        _publish(
+            action_id=entry.action_id,
+            organ_name=entry.organ,
+            intended_action=entry.action_desc,
+            outcome=outcome,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[Reanimation] endorsement telemetry emit skipped", exc_info=True)
+
+
+def endorsement_prompt_for(payload: Dict[str, Any]) -> str:
+    """Render the non-blocking HITL prompt the CLI/TUI shows the Host when a
+    SHADOW_ACTION_TRAPPED event arrives. Pure (TTY-free, testable)."""
+    organ = str(payload.get("organ_name", "") or "?")
+    action = str(payload.get("intended_action", "") or "?")
+    aid = str(payload.get("action_id", "") or "?")
+    return f"[SHADOW] {organ} would {action} (id={aid}). Endorse Execution? [Y/N]"
+
+
+async def handle_endorsement_choice(action_id: str, choice: str) -> EndorsementResult:
+    """Apply the Host's CLI/TUI decision. 'y'/'yes' endorses (re-hydrate+execute);
+    anything else declines (the action stays pending until its TTL lapses, so the
+    Host can still endorse it later). The IN-PROCESS dispatch target a REPL verb
+    or trusted command channel calls — deliberately NOT the read-only
+    /observability surface (executing a kill is an authority action)."""
+    if str(choice).strip().lower() in ("y", "yes"):
+        return await endorse_shadow_action(action_id)
+    entry = _PENDING.entries.get(action_id)
+    return EndorsementResult(
+        status="declined", action_id=action_id,
+        organ=entry.organ if entry else "",
+        intended_action=entry.action_desc if entry else "",
+    )
+
+
 def emit_shadow_trap(
     organ_name: str,
     intended_action: str,
     triggering_signal: Any = None,
+    action_id: str = "",
 ) -> None:
     """Slice 252 — publish a SHADOW_ACTION_TRAPPED telemetry event to the
     StreamEventBroker when a dangerous action is trapped, giving the Sovereign
@@ -118,6 +337,7 @@ def emit_shadow_trap(
             organ_name=str(organ_name),
             intended_action=str(intended_action),
             triggering_signal=sig_repr,
+            action_id=str(action_id),
         )
     except Exception:  # noqa: BLE001 — telemetry is best-effort, never the gate
         logger.debug("[Reanimation] shadow-trap telemetry emit skipped", exc_info=True)
@@ -138,7 +358,12 @@ def shadow_guard(
     _log = log or logger
     if resilience_shadow_mode_enabled():
         _log.warning("[SHADOW MODE] Would have %s", action_desc)
-        emit_shadow_trap(organ, action_desc)
+        # Slice 253 — stash the live callable so the Host can later endorse it.
+        action_id = _PENDING.register(
+            organ=organ, action_desc=action_desc, execute=execute, is_coro=False,
+            signal_repr=_current_signal_repr(),
+        )
+        emit_shadow_trap(organ, action_desc, action_id=action_id)
         return SHADOW_TRAPPED
     return execute()
 
@@ -154,7 +379,12 @@ async def shadow_guard_async(
     _log = log or logger
     if resilience_shadow_mode_enabled():
         _log.warning("[SHADOW MODE] Would have %s", action_desc)
-        emit_shadow_trap(organ, action_desc)
+        # Slice 253 — stash the live coroutine factory for endorsement.
+        action_id = _PENDING.register(
+            organ=organ, action_desc=action_desc, execute=execute, is_coro=True,
+            signal_repr=_current_signal_repr(),
+        )
+        emit_shadow_trap(organ, action_desc, action_id=action_id)
         return SHADOW_TRAPPED
     return await execute()
 

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -174,6 +174,13 @@ EVENT_TYPE_GUIDANCE_ABSORBED = "guidance_absorbed"
 # log-grepping). Payload: organ_name + intended_action + triggering_signal.
 EVENT_TYPE_SHADOW_ACTION_TRAPPED = "shadow_action_trapped"
 
+# Slice 253 (Active Shadow Endorsement & HITL Gateway) — the RETURN channel:
+# fires when the Sovereign Host endorses a previously-trapped shadow action,
+# re-hydrating + executing that ONE action_id (bypassing the shadow block for a
+# single run) WITHOUT dropping the global JARVIS_RESILIENCE_SHADOW_MODE shield.
+# Payload: action_id + organ_name + intended_action + outcome.
+EVENT_TYPE_ENDORSE_SHADOW_ACTION = "endorse_shadow_action"
+
 # Slice 12D (Graceful Shutdown on Global Breaker Trip) — single
 # event type covering the global-session structural-refusal
 # transition CLOSED → OPEN_TERMINAL. Carries trip_count + window_s
@@ -1520,6 +1527,8 @@ _VALID_EVENT_TYPES = frozenset({
                                                   # into its prompt without suspending the lane)
     EVENT_TYPE_SHADOW_ACTION_TRAPPED,             # Slice 252 (Shadow Mode trapped a dangerous
                                                   # resilience action — kill/shed/restart)
+    EVENT_TYPE_ENDORSE_SHADOW_ACTION,             # Slice 253 (Host endorsed a trapped action —
+                                                  # one-shot re-hydrate+execute, shield intact)
     EVENT_TYPE_SESSION_EXHAUSTED,                 # Slice 12D (global breaker session-wide trip
                                                   # — fires once at CLOSED → OPEN_TERMINAL with
                                                   # trip_count + window_s + threshold; the
@@ -3094,13 +3103,16 @@ def publish_shadow_action_trapped(
     organ_name: str = "",
     intended_action: str = "",
     triggering_signal: str = "",
+    action_id: str = "",
     op_id: str = "",
 ) -> Optional[str]:
     """Slice 252 — publish a ``shadow_action_trapped`` event when the Cybernetic
     Reanimation Shadow Mode chokepoint traps a dangerous resilience action. The
     structured payload (organ_name + intended_action + triggering_signal) gives
     the Sovereign Host real-time audit of the reanimated muscle's intent.
-    Non-blocking, NEVER raises (returns None when the stream is disabled)."""
+    ``action_id`` (Slice 253) lets the Host reference THIS specific trapped action
+    when endorsing it through the return channel. Non-blocking, NEVER raises
+    (returns None when the stream is disabled)."""
     if not stream_enabled():
         return None
     try:
@@ -3111,12 +3123,49 @@ def publish_shadow_action_trapped(
                 "organ_name": str(organ_name)[:128],
                 "intended_action": str(intended_action)[:512],
                 "triggering_signal": str(triggering_signal)[:128],
+                "action_id": str(action_id)[:64],
                 "op_id": str(op_id)[:64],
             },
         )
     except Exception:  # noqa: BLE001
         logger.debug(
             "[Stream] publish_shadow_action_trapped exception", exc_info=True,
+        )
+        return None
+
+
+def publish_endorse_shadow_action(
+    *,
+    action_id: str = "",
+    organ_name: str = "",
+    intended_action: str = "",
+    outcome: str = "",
+    op_id: str = "",
+) -> Optional[str]:
+    """Slice 253 — publish an ``endorse_shadow_action`` event when the Sovereign
+    Host endorses a previously-trapped action: it is re-hydrated and executed for
+    that ONE ``action_id`` (the shadow block bypassed for a single run) while the
+    global JARVIS_RESILIENCE_SHADOW_MODE shield stays UP. ``outcome`` is the
+    terminal status (executed / expired / not_found / error / declined). The audit
+    trail closes the bidirectional loop: trap -> endorse -> execute, all visible.
+    Non-blocking, NEVER raises (returns None when the stream is disabled)."""
+    if not stream_enabled():
+        return None
+    try:
+        return get_default_broker().publish(
+            EVENT_TYPE_ENDORSE_SHADOW_ACTION,
+            op_id or action_id or organ_name or "endorse_shadow_action",
+            {
+                "action_id": str(action_id)[:64],
+                "organ_name": str(organ_name)[:128],
+                "intended_action": str(intended_action)[:512],
+                "outcome": str(outcome)[:64],
+                "op_id": str(op_id)[:64],
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "[Stream] publish_endorse_shadow_action exception", exc_info=True,
         )
         return None
 

--- a/tests/governance/test_reanimation_kernel_wiring.py
+++ b/tests/governance/test_reanimation_kernel_wiring.py
@@ -126,3 +126,69 @@ class TestSlice252ShadowTelemetryKernel:
         assert p["organ_name"] == "SelfHealingOrchestrator"
         assert "anomaly_detected:proc-victim" in p["triggering_signal"]
         assert "execute remediation" in p["intended_action"]
+
+
+class TestSlice253ShadowEndorsementKernel:
+    async def test_trapped_anomaly_can_be_endorsed_without_dropping_shield(self, monkeypatch):
+        """Phase 4 (Slice 253): a synthesized ANOMALY_DETECTED wakes the REAL
+        SelfHealingOrchestrator; the shadow_guard traps the kill (killed == []).
+        The Host then ENDORSES that specific action_id (read off the trap
+        telemetry) — the original remediation closure is re-hydrated and EXECUTED
+        for that one run, WITHOUT dropping the global JARVIS_RESILIENCE_SHADOW_MODE
+        shield. Mathematical proof of the bidirectional HITL gateway."""
+        monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_RESILIENCE_SHADOW_MODE", "true")
+        from backend.core.ouroboros.governance import ide_observability_stream as ios
+        from backend.core import cybernetic_reanimation as cr
+        ios.reset_default_broker()
+        cr.reset_pending_shadow_actions()
+        from unified_supervisor import build_resilience_dispatcher
+        sho, killed = _sho_with_fake_kill()
+        d = build_resilience_dispatcher({"SelfHealingOrchestrator": sho})
+
+        # 1. Anomaly fires → real organ wakes → kill is TRAPPED (shield up).
+        await d.dispatch(
+            PressureSignal(PT.ANOMALY_DETECTED, "proc-victim", SignalEdge.RISING)
+        )
+        assert killed == [], "Shadow Mode must trap the kill on first dispatch"
+        assert cr.resilience_shadow_mode_enabled() is True
+
+        # 2. Host reads the action_id off the SHADOW_ACTION_TRAPPED telemetry.
+        trapped = [e for e in ios.get_default_broker().recent_history(limit=100)
+                   if e.event_type == ios.EVENT_TYPE_SHADOW_ACTION_TRAPPED]
+        action_id = trapped[-1].payload["action_id"]
+        assert action_id and action_id in cr.pending_shadow_action_ids()
+
+        # 3. Host ENDORSES that one action_id → remediation re-hydrated + executed.
+        res = await cr.endorse_shadow_action(action_id)
+        assert res.status == "executed"
+        assert killed == ["proc-victim"], "endorsed remediation MUST execute the real kill"
+
+        # 4. The global shield NEVER dropped, and the action is consumed (one-shot).
+        assert cr.resilience_shadow_mode_enabled() is True, "global Shadow Mode stays UP"
+        assert cr.pending_shadow_action_count() == 0
+
+        # 5. The endorsement is audited on the same telemetry mesh.
+        endorsed = [e for e in ios.get_default_broker().recent_history(limit=100)
+                    if e.event_type == ios.EVENT_TYPE_ENDORSE_SHADOW_ACTION]
+        assert endorsed and endorsed[-1].payload["action_id"] == action_id
+        assert endorsed[-1].payload["outcome"] == "executed"
+
+    async def test_a_fresh_anomaly_is_still_trapped_after_an_endorsement(self, monkeypatch):
+        """Endorsing one action does NOT open the floodgates: the next trapped
+        action is still gated by the global shield."""
+        monkeypatch.setenv("JARVIS_RESILIENCE_SHADOW_MODE", "true")
+        from backend.core import cybernetic_reanimation as cr
+        cr.reset_pending_shadow_actions()
+        from unified_supervisor import build_resilience_dispatcher
+        sho, killed = _sho_with_fake_kill()
+        d = build_resilience_dispatcher({"SelfHealingOrchestrator": sho})
+
+        await d.dispatch(PressureSignal(PT.ANOMALY_DETECTED, "victim-1", SignalEdge.RISING))
+        await cr.endorse_shadow_action(cr.pending_shadow_action_ids()[-1])
+        assert killed == ["victim-1"]
+
+        # second anomaly — trapped again (shield intact, no global bypass leaked)
+        await d.dispatch(PressureSignal(PT.ANOMALY_DETECTED, "victim-2", SignalEdge.RISING))
+        assert killed == ["victim-1"], "the new action must be trapped, not auto-executed"
+        assert cr.pending_shadow_action_count() == 1

--- a/tests/governance/test_slice253_shadow_endorsement.py
+++ b/tests/governance/test_slice253_shadow_endorsement.py
@@ -1,0 +1,228 @@
+"""Slice 253 — Active Shadow Endorsement & HITL Gateway (decoupled).
+
+Proves the bidirectional return channel: a trapped shadow action can be
+RE-HYDRATED and executed for one specific ``action_id`` — bypassing the shadow
+block for that single run — WITHOUT dropping the global
+``JARVIS_RESILIENCE_SHADOW_MODE`` shield. These tests are decoupled from the
+102K-line kernel (they exercise ``cybernetic_reanimation`` + the stream broker
+with fakes); the kernel-chain proof lives in
+``test_reanimation_kernel_wiring.py`` (sandbox-off).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+import backend.core.cybernetic_reanimation as cr
+from backend.core.ouroboros.governance import ide_observability_stream as ios
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    """Fresh broker + empty pending-action registry + shadow ON for every test."""
+    monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_RESILIENCE_SHADOW_MODE", "true")
+    monkeypatch.delenv("JARVIS_SHADOW_PENDING_MAX", raising=False)
+    monkeypatch.delenv("JARVIS_SHADOW_PENDING_TTL_S", raising=False)
+    ios.reset_default_broker()
+    cr.reset_pending_shadow_actions()
+    yield
+    cr.reset_pending_shadow_actions()
+    ios.reset_default_broker()
+
+
+def _events(event_type):
+    return [
+        e for e in ios.get_default_broker().recent_history(limit=100)
+        if e.event_type == event_type
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — the endorsement payload (event type + publish wrapper)
+# ---------------------------------------------------------------------------
+
+class TestEndorsementEventType:
+    def test_event_type_value(self):
+        assert ios.EVENT_TYPE_ENDORSE_SHADOW_ACTION == "endorse_shadow_action"
+
+    def test_event_type_registered(self):
+        assert ios.EVENT_TYPE_ENDORSE_SHADOW_ACTION in ios._VALID_EVENT_TYPES
+
+    def test_trapped_payload_carries_action_id(self):
+        # The trap telemetry must carry the action_id so the Host can reference
+        # the specific pending action when endorsing it.
+        ios.publish_shadow_action_trapped(
+            organ_name="SelfHealingOrchestrator",
+            intended_action="execute remediation",
+            action_id="shadow-000042",
+        )
+        evs = _events(ios.EVENT_TYPE_SHADOW_ACTION_TRAPPED)
+        assert evs and evs[-1].payload["action_id"] == "shadow-000042"
+
+
+class TestPublishEndorse:
+    def test_publishes_structured_audit(self):
+        eid = ios.publish_endorse_shadow_action(
+            action_id="shadow-000007", organ_name="LoadSheddingController",
+            outcome="executed",
+        )
+        assert eid is not None
+        evs = _events(ios.EVENT_TYPE_ENDORSE_SHADOW_ACTION)
+        assert len(evs) == 1
+        p = evs[-1].payload
+        assert p["action_id"] == "shadow-000007"
+        assert p["organ_name"] == "LoadSheddingController"
+        assert p["outcome"] == "executed"
+
+    def test_returns_none_when_stream_disabled(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "false")
+        assert ios.publish_endorse_shadow_action(action_id="x") is None
+
+    def test_never_raises(self):
+        # Garbage args must not raise (telemetry is best-effort).
+        ios.publish_endorse_shadow_action(action_id=None, organ_name=object())  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — execution re-hydration (the heart)
+# ---------------------------------------------------------------------------
+
+class TestRehydration:
+    def test_shadow_guard_stashes_pending_on_trap(self):
+        ran = []
+        rv = cr.shadow_guard("kill proc-9", lambda: ran.append("X"), organ="SHO")
+        assert rv is cr.SHADOW_TRAPPED
+        assert ran == []                                # NOT executed
+        assert cr.pending_shadow_action_count() == 1    # but stashed for endorsement
+        ids = cr.pending_shadow_action_ids()
+        assert len(ids) == 1 and ids[0].startswith("shadow-")
+
+    def test_trap_publishes_action_id_into_telemetry(self):
+        cr.shadow_guard("kill proc-9", lambda: None, organ="SHO")
+        aid = cr.pending_shadow_action_ids()[0]
+        evs = _events(ios.EVENT_TYPE_SHADOW_ACTION_TRAPPED)
+        assert evs and evs[-1].payload["action_id"] == aid
+
+    def test_endorse_executes_the_trapped_action(self):
+        ran = []
+        cr.shadow_guard("kill proc-9", lambda: ran.append("KILLED") or "done", organ="SHO")
+        aid = cr.pending_shadow_action_ids()[0]
+
+        res = asyncio.run(cr.endorse_shadow_action(aid))
+
+        assert res.status == "executed"
+        assert res.result == "done"
+        assert ran == ["KILLED"]                         # re-hydrated + executed
+        assert cr.pending_shadow_action_count() == 0     # one-shot — consumed
+
+    def test_endorse_does_not_drop_global_shadow_shield(self):
+        # The crux: a single action runs, but the global shield stays UP.
+        ran = []
+        cr.shadow_guard("kill proc-9", lambda: ran.append("X"), organ="SHO")
+        aid = cr.pending_shadow_action_ids()[0]
+        assert cr.resilience_shadow_mode_enabled() is True
+
+        asyncio.run(cr.endorse_shadow_action(aid))
+
+        assert ran == ["X"]                              # endorsed action ran
+        assert cr.resilience_shadow_mode_enabled() is True  # shield NEVER dropped
+        # A NEW action is still trapped (shadow still gating everything else).
+        ran2 = []
+        cr.shadow_guard("kill proc-2", lambda: ran2.append("Y"), organ="SHO")
+        assert ran2 == []
+
+    def test_endorse_publishes_audit_event(self):
+        cr.shadow_guard("kill proc-9", lambda: "ok", organ="SHO")
+        aid = cr.pending_shadow_action_ids()[0]
+        asyncio.run(cr.endorse_shadow_action(aid))
+        evs = _events(ios.EVENT_TYPE_ENDORSE_SHADOW_ACTION)
+        assert evs and evs[-1].payload["action_id"] == aid
+        assert evs[-1].payload["outcome"] == "executed"
+
+    def test_endorse_async_action(self):
+        ran = []
+
+        async def _kill():
+            ran.append("ASYNC-KILLED")
+            return "async-done"
+
+        asyncio.run(cr.shadow_guard_async("kill proc-9", _kill, organ="SHO"))
+        aid = cr.pending_shadow_action_ids()[0]
+
+        res = asyncio.run(cr.endorse_shadow_action(aid))
+        assert res.status == "executed"
+        assert res.result == "async-done"
+        assert ran == ["ASYNC-KILLED"]
+
+    def test_endorse_unknown_id_is_not_found(self):
+        res = asyncio.run(cr.endorse_shadow_action("shadow-999999"))
+        assert res.status == "not_found"
+
+    def test_endorse_is_one_shot(self):
+        cr.shadow_guard("kill proc-9", lambda: "ok", organ="SHO")
+        aid = cr.pending_shadow_action_ids()[0]
+        asyncio.run(cr.endorse_shadow_action(aid))
+        # second endorse of the same id cannot re-fire the action
+        res2 = asyncio.run(cr.endorse_shadow_action(aid))
+        assert res2.status == "not_found"
+
+    def test_endorse_expired_does_not_execute(self):
+        ran = []
+        cr.shadow_guard("kill proc-9", lambda: ran.append("X"), organ="SHO")
+        aid = cr.pending_shadow_action_ids()[0]
+        # age the entry past any TTL
+        cr._PENDING.entries[aid].created_monotonic = 0.0  # type: ignore[attr-defined]
+        res = asyncio.run(cr.endorse_shadow_action(aid))
+        assert res.status == "expired"
+        assert ran == []                                 # stale kill must NOT fire
+
+    def test_endorse_swallows_execute_error(self):
+        def _boom():
+            raise RuntimeError("kill failed")
+
+        cr.shadow_guard("kill proc-9", _boom, organ="SHO")
+        aid = cr.pending_shadow_action_ids()[0]
+        res = asyncio.run(cr.endorse_shadow_action(aid))   # must NOT raise
+        assert res.status == "error"
+
+    def test_registry_is_bounded(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_SHADOW_PENDING_MAX", "2")
+        for i in range(3):
+            cr.shadow_guard(f"kill proc-{i}", lambda: None, organ="SHO")
+        assert cr.pending_shadow_action_count() == 2     # oldest evicted, bounded
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — the CLI interceptor decision logic (transport-agnostic, TTY-free)
+# ---------------------------------------------------------------------------
+
+class TestCliInterceptorLogic:
+    def test_prompt_describes_the_trapped_action(self):
+        prompt = cr.endorsement_prompt_for({
+            "organ_name": "SelfHealingOrchestrator",
+            "intended_action": "execute remediation 'restart' on 'worker-7'",
+            "action_id": "shadow-000003",
+        })
+        assert "SelfHealingOrchestrator" in prompt
+        assert "execute remediation" in prompt
+        assert "Y/N" in prompt
+
+    def test_choice_yes_endorses_and_executes(self):
+        ran = []
+        cr.shadow_guard("kill proc-9", lambda: ran.append("X"), organ="SHO")
+        aid = cr.pending_shadow_action_ids()[0]
+        res = asyncio.run(cr.handle_endorsement_choice(aid, "y"))
+        assert res.status == "executed"
+        assert ran == ["X"]
+
+    def test_choice_no_declines_without_executing(self):
+        ran = []
+        cr.shadow_guard("kill proc-9", lambda: ran.append("X"), organ="SHO")
+        aid = cr.pending_shadow_action_ids()[0]
+        res = asyncio.run(cr.handle_endorsement_choice(aid, "n"))
+        assert res.status == "declined"
+        assert ran == []                                 # decline never executes
+        assert cr.pending_shadow_action_count() == 1     # left pending (until TTL)


### PR DESCRIPTION
## Slice 253 — Active Shadow Endorsement & HITL Gateway

Slice 252 made the shadow muscle **observable**. This makes it **commandable**: the Sovereign Host can **endorse one specific trapped action** so it executes a single time — bypassing the shadow block for that `action_id` only — **without dropping the global `JARVIS_RESILIENCE_SHADOW_MODE` shield**.

### The re-hydration is real (not fabricated)
When `shadow_guard` traps a dangerous action it **stashes the original in-process callable** (a live closure) keyed by a unique `action_id`. Endorsement awaits that closure. Honest bounds:
- **In-process** — closures aren't serializable, so un-endorsed actions don't survive a restart (by design: a restart is a clean slate, not a queue of pending world-mutations).
- **TTL'd** (`JARVIS_SHADOW_PENDING_TTL_S`, default 300s) — a stale kill must not fire late.
- **Capacity-capped** (`JARVIS_SHADOW_PENDING_MAX`, default 64) — oldest evicted (FIFO).
- **One-shot** — the entry is popped on endorse; it cannot double-fire.

### Phase 1 — endorsement payload (`ide_observability_stream.py`)
- `EVENT_TYPE_ENDORSE_SHADOW_ACTION` + `_VALID_EVENT_TYPES`.
- `publish_endorse_shadow_action(action_id, organ_name, intended_action, outcome)` — non-blocking, never raises.
- `publish_shadow_action_trapped` now carries `action_id` so the Host can reference the specific pending action.

### Phase 2 — execution re-hydration (`cybernetic_reanimation.py`)
- `PendingShadowActionRegistry` + `_PENDING`; `shadow_guard`/`shadow_guard_async` stash the callable on trap (`is_coro` flag) and thread `action_id` into the trap telemetry.
- `endorse_shadow_action(action_id)` — async, one-shot, TTL-checked, **fail-soft** (execute error → `status="error"`, never raises). Runs the raw callable **regardless of the shadow flag, which it never reads or mutates**. Returns `EndorsementResult(status ∈ executed|declined|not_found|expired|error)`. Publishes the audit event.

### Phase 3 — the CLI interceptor (TTY-free decision logic)
- `endorsement_prompt_for(payload)` renders `[SHADOW] … Endorse Execution? [Y/N]`; `handle_endorsement_choice(action_id, choice)` endorses on `y`, else declines (a decline leaves the action pending until TTL).
- **🔒 Security call-out:** an endorsement that *executes a kill* is an **authority action** — it must **not** ride the read-only / loopback / authority-free `/observability` surface (a grep-enforced invariant). The return channel is an **in-process trusted command path** (REPL verb / SerpentFlow), not an HTTP write on the observability mesh. The decision logic above is that path's dispatch target.

### Phase 4 — integration audit (sandbox-off, real kernel)
- A synthesized `ANOMALY_DETECTED` wakes the **real `SelfHealingOrchestrator`** → `shadow_guard` traps the kill (`killed == []`) → the Host reads the `action_id` off the trap telemetry → `endorse_shadow_action` → **the real remediation kill executes** (`killed == ["proc-victim"]`) → `resilience_shadow_mode_enabled()` is **still `True`** → action consumed → endorsement audited.
- A **fresh anomaly is still trapped afterwards** (no global bypass leaked).

**57 green** (20 decoupled in-sandbox + 2 kernel-chain sandbox-off + Slice 249/252/foundation regression) — zero regression (both module edits are additive).

Built in an OCA-owned worktree off the current `main` (which includes the autonomous loop's #69504 Sovereign Fusion). Reuses the Slice-249 broker — no parallel telemetry path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Active Shadow Endorsement so the Host can execute a single trapped action by `action_id` without lowering the global `JARVIS_RESILIENCE_SHADOW_MODE` shield. Completes the bidirectional HITL gateway with audit events and CLI decision hooks.

- **New Features**
  - Stashes trapped actions in a bounded, TTL’d in‑process registry; one‑shot rehydration on endorse (`JARVIS_SHADOW_PENDING_MAX`, `JARVIS_SHADOW_PENDING_TTL_S`).
  - `shadow_guard`/`shadow_guard_async` now stash the callable and publish `shadow_action_trapped` with `action_id`.
  - `endorse_shadow_action(action_id)` (async) rehydrates and runs the original callable; returns `EndorsementResult` (`executed|declined|not_found|expired|error`); fail‑soft and does not touch the shadow flag; audited via `publish_endorse_shadow_action`.
  - Observability stream adds `EVENT_TYPE_ENDORSE_SHADOW_ACTION`; `publish_shadow_action_trapped` now includes `action_id`.
  - CLI helpers: `endorsement_prompt_for` and `handle_endorsement_choice`; `'y'/'yes'` endorses, otherwise declines; return channel is in‑process only (authority action, not on `/observability`).
  - Tests cover sync/async execution, one‑shot semantics, TTL expiry, error handling, and kernel wiring; confirms shield stays enabled and new anomalies remain trapped.

<sup>Written for commit 6abae692833b14cb99481680fbc8cb5b7727525e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

