### PR TITLE
feat(resilience): Slice 254 — Ephemeral Swarm Intelligence & Dynamic Diagnostic Delegation

### DIFF
--- a/backend/core/cybernetic_reanimation.py
+++ b/backend/core/cybernetic_reanimation.py
@@ -230,6 +230,47 @@ def pending_shadow_action_ids() -> List[str]:
     return list(_PENDING.entries.keys())
 
 
+# ---------------------------------------------------------------------------
+# Slice 254 — trap observers: the in-process subscription to SHADOW_ACTION_TRAPPED
+#
+# A consumer (e.g. the diagnostic swarm) registers a callback that fires — fully
+# fail-soft — every time shadow_guard traps an action, receiving the same payload
+# shape as the telemetry event. This is the decoupled, kernel-free equivalent of
+# subscribing to the event on the SupervisorEventBus: the trap chokepoint is the
+# single source of truth, so observers see exactly what the broker sees, in-proc.
+# Observers MUST be non-blocking (return immediately, schedule any real work).
+# ---------------------------------------------------------------------------
+
+_TRAP_OBSERVERS: "List[Callable[[Dict[str, Any]], Any]]" = []
+
+
+def register_trap_observer(callback: Callable[[Dict[str, Any]], Any]) -> None:
+    """Subscribe a callback to SHADOW_ACTION_TRAPPED. Idempotent per callable."""
+    if callback not in _TRAP_OBSERVERS:
+        _TRAP_OBSERVERS.append(callback)
+
+
+def unregister_trap_observer(callback: Callable[[Dict[str, Any]], Any]) -> None:
+    try:
+        _TRAP_OBSERVERS.remove(callback)
+    except ValueError:
+        pass
+
+
+def reset_trap_observers() -> None:
+    _TRAP_OBSERVERS.clear()
+
+
+def _notify_trap_observers(payload: Dict[str, Any]) -> None:
+    """Fan a trap out to every observer. NEVER raises; one bad observer never
+    blocks the trap path or the others."""
+    for cb in list(_TRAP_OBSERVERS):
+        try:
+            cb(payload)
+        except Exception:  # noqa: BLE001 — an observer must never break the trap
+            logger.debug("[Reanimation] trap observer raised", exc_info=True)
+
+
 async def endorse_shadow_action(action_id: str) -> EndorsementResult:
     """Re-hydrate and execute ONE trapped action for the given ``action_id`` —
     bypassing the shadow block for this single run WITHOUT touching the global
@@ -359,11 +400,16 @@ def shadow_guard(
     if resilience_shadow_mode_enabled():
         _log.warning("[SHADOW MODE] Would have %s", action_desc)
         # Slice 253 — stash the live callable so the Host can later endorse it.
+        sig_repr = _current_signal_repr()
         action_id = _PENDING.register(
             organ=organ, action_desc=action_desc, execute=execute, is_coro=False,
-            signal_repr=_current_signal_repr(),
+            signal_repr=sig_repr,
         )
         emit_shadow_trap(organ, action_desc, action_id=action_id)
+        _notify_trap_observers({
+            "organ_name": organ, "intended_action": action_desc,
+            "triggering_signal": sig_repr, "action_id": action_id, "op_id": "",
+        })
         return SHADOW_TRAPPED
     return execute()
 
@@ -380,11 +426,16 @@ async def shadow_guard_async(
     if resilience_shadow_mode_enabled():
         _log.warning("[SHADOW MODE] Would have %s", action_desc)
         # Slice 253 — stash the live coroutine factory for endorsement.
+        sig_repr = _current_signal_repr()
         action_id = _PENDING.register(
             organ=organ, action_desc=action_desc, execute=execute, is_coro=True,
-            signal_repr=_current_signal_repr(),
+            signal_repr=sig_repr,
         )
         emit_shadow_trap(organ, action_desc, action_id=action_id)
+        _notify_trap_observers({
+            "organ_name": organ, "intended_action": action_desc,
+            "triggering_signal": sig_repr, "action_id": action_id, "op_id": "",
+        })
         return SHADOW_TRAPPED
     return await execute()
 

--- a/backend/core/diagnostic_swarm.py
+++ b/backend/core/diagnostic_swarm.py
@@ -1,0 +1,333 @@
+"""Diagnostic Swarm — ephemeral, read-only intelligence for the endorsement
+gateway (Spec 2 / Slice 254).
+
+When the Cybernetic Reanimation shadow_guard traps a COMPLEX anomaly
+(RESOURCE_PRESSURE / ANOMALY_DETECTED), the kernel must not block to figure out
+*why*. Instead the ``SubAgentOrchestrator`` — subscribed to SHADOW_ACTION_TRAPPED
+— dynamically spawns an ephemeral, read-only ``DiagnosticSubAgent`` on a hard
+TTL. The agent investigates the live system state asynchronously and pipes a
+concise root-cause analysis back to the endorsement gateway, so the Host's
+``[Endorse Execution? Y/N]`` decision is intelligence-backed, not blind.
+
+Design invariants (kept deliberately strict):
+  * **Read-only.** A DiagnosticSubAgent observes; it has NO authority surface
+    (no execute / endorse / kill / shed). Diagnosis can never act on the world —
+    that authority stays with the Host (Slice 253) behind the shadow shield.
+  * **Non-blocking.** ``handle_trap`` schedules the investigation as a background
+    task and returns immediately. The trap chokepoint / kernel event loop is
+    never awaited on.
+  * **Bounded.** Every investigation is wrapped in a hard TTL (``asyncio.wait_for``,
+    default 60s) so a hung probe cannot leak; findings are kept in a capacity-
+    capped ring.
+  * **Fail-soft.** A probe that raises or times out yields a finding with the
+    failure status — it never propagates, never breaks the trap path.
+
+Decoupled + duck-typed (no kernel import): unit-testable with fake probes.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+import backend.core.cybernetic_reanimation as _cr
+
+logger = logging.getLogger("jarvis.diagnostic_swarm")
+
+_ENV_ENABLED = "JARVIS_DIAGNOSTIC_SWARM_ENABLED"
+_ENV_TTL_S = "JARVIS_DIAGNOSTIC_AGENT_TTL_S"
+_ENV_FINDINGS_MAX = "JARVIS_DIAGNOSTIC_FINDINGS_MAX"
+_DEFAULT_TTL_S = 60.0
+_DEFAULT_FINDINGS_MAX = 64
+
+# The signal types complex enough to warrant an ephemeral diagnostic (plan §2).
+_COMPLEX_SIGNAL_PREFIXES = ("anomaly_detected", "resource_pressure")
+
+
+def swarm_enabled() -> bool:
+    """Master switch (default-TRUE). NEVER raises."""
+    try:
+        return os.getenv(_ENV_ENABLED, "true").strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001
+        return False  # fail-safe OFF — the swarm is an enrichment, not a guarantee
+
+
+def agent_ttl_s() -> float:
+    try:
+        return max(0.5, float(os.getenv(_ENV_TTL_S, str(_DEFAULT_TTL_S))))
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_TTL_S
+
+
+def _findings_max() -> int:
+    try:
+        return max(1, int(os.getenv(_ENV_FINDINGS_MAX, str(_DEFAULT_FINDINGS_MAX))))
+    except Exception:  # noqa: BLE001
+        return _DEFAULT_FINDINGS_MAX
+
+
+def is_complex_trap(payload: Dict[str, Any]) -> bool:
+    """True iff the trapped signal is complex enough to delegate a diagnostic."""
+    try:
+        sig = str(payload.get("triggering_signal", "") or "")
+        return any(sig.startswith(p) for p in _COMPLEX_SIGNAL_PREFIXES)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+@dataclass(frozen=True)
+class DiagnosticFinding:
+    """An ephemeral agent's root-cause analysis of a trapped action."""
+    action_id: str
+    op_id: str
+    organ: str
+    summary: str               # concise, human-facing root-cause analysis
+    facts: Dict[str, Any]      # structured evidence (process tree / resource snapshot)
+    status: str                # ok | timeout | error
+    elapsed_s: float
+
+
+# ---------------------------------------------------------------------------
+# The read-only probe — injectable so tests use fakes and the hot path is safe.
+# ---------------------------------------------------------------------------
+
+class DefaultDiagnosticProbe:
+    """Read-only system-state probe. Best-effort psutil snapshot (top processes
+    by CPU + system memory). NEVER raises — returns whatever it could gather."""
+
+    async def investigate(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        facts: Dict[str, Any] = {}
+        try:
+            import psutil  # local import — optional dep, fail-soft
+            facts["cpu_pct"] = psutil.cpu_percent(interval=0.0)
+            vm = psutil.virtual_memory()
+            facts["mem_pct"] = getattr(vm, "percent", None)
+            procs = []
+            for p in psutil.process_iter(["pid", "name", "cpu_percent"]):
+                try:
+                    procs.append(p.info)
+                except Exception:  # noqa: BLE001
+                    continue
+            procs.sort(key=lambda d: (d.get("cpu_percent") or 0.0), reverse=True)
+            top = procs[:3]
+            facts["top_processes"] = top
+            if top:
+                t = top[0]
+                facts["top_process"] = f"{t.get('name')}(pid={t.get('pid')}) cpu={t.get('cpu_percent')}%"
+        except Exception:  # noqa: BLE001
+            logger.debug("[Swarm] default probe degraded", exc_info=True)
+            facts.setdefault("probe", "unavailable")
+        return facts
+
+
+class DiagnosticSubAgent:
+    """An ephemeral, READ-ONLY investigator. Spawned per trapped complex anomaly,
+    bounded by a hard TTL, discarded after it returns a single finding. It holds
+    no authority surface — it cannot execute, endorse, kill, or shed."""
+
+    def __init__(self, probe: Any = None, ttl_s: Optional[float] = None):
+        self._probe = probe if probe is not None else DefaultDiagnosticProbe()
+        self._ttl_s = ttl_s
+
+    async def investigate(
+        self,
+        *,
+        action_id: str,
+        op_id: str = "",
+        organ: str = "",
+        intended_action: str = "",
+        triggering_signal: str = "",
+    ) -> DiagnosticFinding:
+        ttl = self._ttl_s if self._ttl_s is not None else agent_ttl_s()
+        context = {
+            "action_id": action_id, "op_id": op_id, "organ": organ,
+            "intended_action": intended_action, "triggering_signal": triggering_signal,
+        }
+        start = time.monotonic()
+        try:
+            facts = await asyncio.wait_for(self._probe.investigate(context), timeout=ttl)
+            return DiagnosticFinding(
+                action_id=action_id, op_id=op_id, organ=organ,
+                summary=self._synthesize(context, facts), facts=dict(facts or {}),
+                status="ok", elapsed_s=round(time.monotonic() - start, 4),
+            )
+        except asyncio.TimeoutError:
+            return DiagnosticFinding(
+                action_id=action_id, op_id=op_id, organ=organ,
+                summary=f"diagnostic timed out after {ttl:.0f}s — investigate manually",
+                facts={}, status="timeout", elapsed_s=round(time.monotonic() - start, 4),
+            )
+        except Exception as exc:  # noqa: BLE001 — diagnosis is best-effort
+            logger.debug("[Swarm] sub-agent investigate failed", exc_info=True)
+            return DiagnosticFinding(
+                action_id=action_id, op_id=op_id, organ=organ,
+                summary=f"diagnostic error: {str(exc)[:160]}", facts={},
+                status="error", elapsed_s=round(time.monotonic() - start, 4),
+            )
+
+    @staticmethod
+    def _synthesize(context: Dict[str, Any], facts: Dict[str, Any]) -> str:
+        """Turn raw evidence into a concise, human-facing root-cause line."""
+        parts = []
+        top = facts.get("top_process")
+        if top:
+            parts.append(f"hottest: {top}")
+        if facts.get("cpu_pct") is not None:
+            parts.append(f"cpu={facts['cpu_pct']}%")
+        if facts.get("mem_pct") is not None:
+            parts.append(f"mem={facts['mem_pct']}%")
+        sig = context.get("triggering_signal") or "?"
+        if not parts:
+            return f"signal {sig}: no system evidence gathered"
+        return f"signal {sig}: " + ", ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Findings store — bounded + awaitable (the REPL can wait for a fresh diagnosis).
+# ---------------------------------------------------------------------------
+
+class DiagnosticFindingsStore:
+    """Capacity-capped store keyed by action_id, with a per-key asyncio.Event so a
+    consumer can await a finding that is still being computed."""
+
+    def __init__(self, max_size: Optional[int] = None):
+        self._max = max_size
+        self._findings: "OrderedDict[str, DiagnosticFinding]" = OrderedDict()
+        self._events: Dict[str, asyncio.Event] = {}
+
+    def _max_size(self) -> int:
+        return self._max if self._max is not None else _findings_max()
+
+    def _event_for(self, action_id: str) -> asyncio.Event:
+        ev = self._events.get(action_id)
+        if ev is None:
+            ev = asyncio.Event()
+            self._events[action_id] = ev
+        return ev
+
+    def put(self, finding: DiagnosticFinding) -> None:
+        self._findings[finding.action_id] = finding
+        self._findings.move_to_end(finding.action_id)
+        cap = self._max_size()
+        while len(self._findings) > cap:
+            old_id, _ = self._findings.popitem(last=False)
+            self._events.pop(old_id, None)
+        self._event_for(finding.action_id).set()
+
+    def get(self, action_id: str) -> Optional[DiagnosticFinding]:
+        return self._findings.get(action_id)
+
+    async def wait_for(self, action_id: str, timeout: float) -> Optional[DiagnosticFinding]:
+        existing = self._findings.get(action_id)
+        if existing is not None:
+            return existing
+        ev = self._event_for(action_id)
+        try:
+            await asyncio.wait_for(ev.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+        return self._findings.get(action_id)
+
+    def reset(self) -> None:
+        self._findings.clear()
+        self._events.clear()
+
+
+# ---------------------------------------------------------------------------
+# The orchestrator — subscribes to traps, spawns ephemeral agents non-blocking.
+# ---------------------------------------------------------------------------
+
+class SubAgentOrchestrator:
+    """Subscribes to SHADOW_ACTION_TRAPPED and, for each COMPLEX trapped anomaly,
+    spawns an ephemeral DiagnosticSubAgent as a background task (never blocking the
+    kernel). Stores each finding keyed by action_id for the endorsement gateway."""
+
+    def __init__(
+        self,
+        *,
+        store: Optional[DiagnosticFindingsStore] = None,
+        agent_factory: Optional[Callable[[], DiagnosticSubAgent]] = None,
+    ):
+        self.store = store if store is not None else DiagnosticFindingsStore()
+        self._agent_factory = agent_factory or (lambda: DiagnosticSubAgent())
+        self._tasks: "set[asyncio.Task]" = set()  # strong refs — no premature GC
+
+    def handle_trap(self, payload: Dict[str, Any]) -> Optional[asyncio.Task]:
+        """NON-BLOCKING. Schedule an ephemeral diagnostic for a complex trapped
+        action and return immediately. Returns the scheduled task (or None when
+        the swarm is disabled, the trap is not complex, or no loop is running)."""
+        if not swarm_enabled() or not is_complex_trap(payload):
+            return None
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug("[Swarm] no running loop — cannot spawn diagnostic")
+            return None
+        task = loop.create_task(self._investigate_and_store(dict(payload)))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    async def _investigate_and_store(self, payload: Dict[str, Any]) -> None:
+        try:
+            agent = self._agent_factory()
+            finding = await agent.investigate(
+                action_id=str(payload.get("action_id", "")),
+                op_id=str(payload.get("op_id", "")),
+                organ=str(payload.get("organ_name", "")),
+                intended_action=str(payload.get("intended_action", "")),
+                triggering_signal=str(payload.get("triggering_signal", "")),
+            )
+            self.store.put(finding)
+        except Exception:  # noqa: BLE001 — a swarm crash must never escape
+            logger.debug("[Swarm] investigate_and_store failed", exc_info=True)
+
+    def attach_to_trap_stream(self) -> None:
+        """Subscribe to SHADOW_ACTION_TRAPPED (in-process, the decoupled bus)."""
+        _cr.register_trap_observer(self.handle_trap)
+
+    def detach(self) -> None:
+        _cr.unregister_trap_observer(self.handle_trap)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — REPL enrichment: diagnosis FIRST, then the endorsement decision.
+# ---------------------------------------------------------------------------
+
+def enriched_endorsement_prompt(
+    payload: Dict[str, Any], finding: Optional[DiagnosticFinding],
+) -> str:
+    """Compose the intelligence-backed endorsement prompt: the ephemeral agent's
+    root-cause analysis renders ABOVE the base [Y/N] decision (Slice 253). When no
+    finding is available yet, a 'diagnosis pending' note keeps the Host informed
+    without blocking the decision."""
+    base = _cr.endorsement_prompt_for(payload)
+    if finding is None:
+        header = "🔬 Diagnosis pending — no analysis yet"
+    else:
+        header = f"🔬 Diagnosis ({finding.status}): {finding.summary}"
+    return f"{header}\n{base}"
+
+
+async def endorsement_prompt_with_diagnosis(
+    orchestrator: SubAgentOrchestrator,
+    payload: Dict[str, Any],
+    *,
+    wait_s: float = 2.0,
+) -> str:
+    """The endorsement gateway entry point: await the ephemeral agent's finding
+    (bounded by ``wait_s``, never the kernel loop), then render the enriched
+    prompt. If the diagnosis isn't ready in time, the Host still gets a prompt
+    (pending) — the decision is never gated on the swarm."""
+    finding: Optional[DiagnosticFinding] = None
+    try:
+        action_id = str(payload.get("action_id", "") or "")
+        if action_id:
+            finding = await orchestrator.store.wait_for(action_id, timeout=wait_s)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Swarm] enrichment wait failed", exc_info=True)
+    return enriched_endorsement_prompt(payload, finding)

--- a/tests/governance/test_reanimation_kernel_wiring.py
+++ b/tests/governance/test_reanimation_kernel_wiring.py
@@ -192,3 +192,53 @@ class TestSlice253ShadowEndorsementKernel:
         await d.dispatch(PressureSignal(PT.ANOMALY_DETECTED, "victim-2", SignalEdge.RISING))
         assert killed == ["victim-1"], "the new action must be trapped, not auto-executed"
         assert cr.pending_shadow_action_count() == 1
+
+
+class TestSlice254DiagnosticSwarmKernel:
+    async def test_trap_spawns_ephemeral_agent_and_enriches_prompt(self, monkeypatch):
+        """Phase 4 (Slice 254): a real ANOMALY_DETECTED wakes the real
+        SelfHealingOrchestrator; the shadow_guard traps the kill and the
+        SubAgentOrchestrator (subscribed to the trap) spawns an ephemeral
+        read-only DiagnosticSubAgent WITHOUT blocking the dispatch. The agent's
+        root-cause analysis is then piped back into the endorsement prompt — the
+        Host's [Y/N] is intelligence-backed, not blind."""
+        monkeypatch.setenv("JARVIS_RESILIENCE_SHADOW_MODE", "true")
+        monkeypatch.setenv("JARVIS_DIAGNOSTIC_SWARM_ENABLED", "true")
+        from backend.core import cybernetic_reanimation as cr
+        from backend.core import diagnostic_swarm as ds
+        cr.reset_pending_shadow_actions()
+        cr.reset_trap_observers()
+
+        # inject a deterministic read-only probe (no psutil dependence in CI)
+        class _Probe:
+            async def investigate(self, context):
+                return {"top_process": "python(pid=999) cpu=97%", "mem_pct": 91}
+
+        orch = ds.SubAgentOrchestrator(agent_factory=lambda: ds.DiagnosticSubAgent(probe=_Probe()))
+        orch.attach_to_trap_stream()
+        try:
+            from unified_supervisor import build_resilience_dispatcher
+            sho, killed = _sho_with_fake_kill()
+            d = build_resilience_dispatcher({"SelfHealingOrchestrator": sho})
+
+            # dispatch returns even though a diagnostic was spawned (non-blocking)
+            await d.dispatch(
+                PressureSignal(PT.ANOMALY_DETECTED, "proc-victim", SignalEdge.RISING)
+            )
+            assert killed == [], "kill trapped by shadow shield"
+            action_id = cr.pending_shadow_action_ids()[-1]
+
+            payload = {
+                "organ_name": "SelfHealingOrchestrator",
+                "intended_action": "execute remediation 'restart' on 'proc-victim'",
+                "triggering_signal": "anomaly_detected:proc-victim:rising",
+                "action_id": action_id,
+            }
+            prompt = await ds.endorsement_prompt_with_diagnosis(orch, payload, wait_s=3.0)
+
+            assert "python(pid=999)" in prompt, "ephemeral agent's root-cause surfaced"
+            assert action_id in prompt and "[Y/N]" in prompt, "contextualized endorsement"
+            # and the trapped action is still endorsable (Slice 253 intact)
+            assert action_id in cr.pending_shadow_action_ids()
+        finally:
+            orch.detach()

--- a/tests/governance/test_slice254_diagnostic_swarm.py
+++ b/tests/governance/test_slice254_diagnostic_swarm.py
@@ -1,0 +1,271 @@
+"""Slice 254 — Ephemeral Swarm Intelligence & Dynamic Diagnostic Delegation.
+
+Proves the diagnostic swarm: a trapped COMPLEX anomaly spawns an ephemeral,
+read-only DiagnosticSubAgent (bounded by a hard TTL) that investigates the system
+state asynchronously — NEVER blocking the kernel — and pipes a concise root-cause
+analysis back to the endorsement gateway, so the Host's [Y/N] decision is
+intelligence-backed instead of blind. Decoupled from the 102K kernel (fakes); the
+kernel-chain proof lives in test_reanimation_kernel_wiring.py (sandbox-off).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import backend.core.cybernetic_reanimation as cr
+import backend.core.diagnostic_swarm as ds
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.setenv("JARVIS_DIAGNOSTIC_SWARM_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_RESILIENCE_SHADOW_MODE", "true")
+    monkeypatch.delenv("JARVIS_DIAGNOSTIC_AGENT_TTL_S", raising=False)
+    cr.reset_trap_observers()
+    cr.reset_pending_shadow_actions()
+    yield
+    cr.reset_trap_observers()
+    cr.reset_pending_shadow_actions()
+
+
+class FakeProbe:
+    """Duck-typed read-only diagnostic probe for tests."""
+    def __init__(self, facts=None, delay=0.0, boom=False):
+        self.facts = facts or {"top_process": "python(pid=999) cpu=95%", "mem_pct": 92}
+        self.delay = delay
+        self.boom = boom
+        self.calls = 0
+
+    async def investigate(self, context):
+        self.calls += 1
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if self.boom:
+            raise RuntimeError("probe blew up")
+        return dict(self.facts)
+
+
+def _trap_payload(signal="anomaly_detected:worker-7:rising", aid="shadow-000001"):
+    return {
+        "organ_name": "SelfHealingOrchestrator",
+        "intended_action": "execute remediation 'restart' on 'worker-7'",
+        "triggering_signal": signal,
+        "action_id": aid,
+        "op_id": "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 1/2 — env flags + complexity filter
+# ---------------------------------------------------------------------------
+
+class TestEnvAndFilter:
+    def test_swarm_enabled_default_true(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_DIAGNOSTIC_SWARM_ENABLED", raising=False)
+        assert ds.swarm_enabled() is True
+
+    def test_swarm_can_be_disabled(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_DIAGNOSTIC_SWARM_ENABLED", "0")
+        assert ds.swarm_enabled() is False
+
+    def test_agent_ttl_defaults_to_60s(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_DIAGNOSTIC_AGENT_TTL_S", raising=False)
+        assert ds.agent_ttl_s() == 60.0
+
+    @pytest.mark.parametrize("sig,expected", [
+        ("anomaly_detected:worker-7:rising", True),
+        ("resource_pressure:cpu:rising", True),
+        ("component_degraded:db:rising", False),
+        ("", False),
+    ])
+    def test_complexity_filter(self, sig, expected):
+        assert ds.is_complex_trap(_trap_payload(signal=sig)) is expected
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — the ephemeral, read-only DiagnosticSubAgent
+# ---------------------------------------------------------------------------
+
+class TestDiagnosticSubAgent:
+    def test_investigate_returns_finding_with_facts(self):
+        agent = ds.DiagnosticSubAgent(probe=FakeProbe())
+        f = asyncio.run(agent.investigate(
+            action_id="shadow-000001", organ="SelfHealingOrchestrator",
+            intended_action="execute remediation", triggering_signal="anomaly_detected:w:rising",
+        ))
+        assert f.status == "ok"
+        assert f.action_id == "shadow-000001"
+        assert f.organ == "SelfHealingOrchestrator"
+        assert f.facts.get("mem_pct") == 92
+        assert f.summary                                  # concise root-cause text
+        assert "python(pid=999)" in f.summary or "python(pid=999)" in str(f.facts)
+
+    def test_ttl_timeout_yields_timeout_status_not_raise(self):
+        agent = ds.DiagnosticSubAgent(probe=FakeProbe(delay=0.5), ttl_s=0.01)
+        f = asyncio.run(agent.investigate(action_id="shadow-1"))
+        assert f.status == "timeout"                      # bounded — a hung probe cannot leak
+
+    def test_probe_error_is_swallowed(self):
+        agent = ds.DiagnosticSubAgent(probe=FakeProbe(boom=True))
+        f = asyncio.run(agent.investigate(action_id="shadow-1"))
+        assert f.status == "error"                        # fail-soft, never raises
+
+    def test_subagent_is_structurally_read_only(self):
+        agent = ds.DiagnosticSubAgent(probe=FakeProbe())
+        # No authority surface — a diagnostic agent can observe but never act.
+        for forbidden in ("execute", "endorse", "kill", "shed", "apply", "mutate"):
+            assert not hasattr(agent, forbidden)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — the findings store (bounded, awaitable)
+# ---------------------------------------------------------------------------
+
+class TestFindingsStore:
+    def _finding(self, aid):
+        return ds.DiagnosticFinding(
+            action_id=aid, op_id="", organ="SHO", summary="hot cpu", facts={}, status="ok", elapsed_s=0.01,
+        )
+
+    def test_put_then_get(self):
+        store = ds.DiagnosticFindingsStore()
+        store.put(self._finding("a1"))
+        assert store.get("a1").summary == "hot cpu"
+        assert store.get("missing") is None
+
+    def test_wait_for_present(self):
+        store = ds.DiagnosticFindingsStore()
+        store.put(self._finding("a1"))
+        got = asyncio.run(store.wait_for("a1", timeout=1.0))
+        assert got is not None and got.action_id == "a1"
+
+    def test_wait_for_arrives_concurrently(self):
+        store = ds.DiagnosticFindingsStore()
+
+        async def _go():
+            async def _late_put():
+                await asyncio.sleep(0.02)
+                store.put(self._finding("a1"))
+            asyncio.ensure_future(_late_put())
+            return await store.wait_for("a1", timeout=1.0)
+
+        got = asyncio.run(_go())
+        assert got is not None and got.action_id == "a1"
+
+    def test_wait_for_times_out_to_none(self):
+        store = ds.DiagnosticFindingsStore()
+        got = asyncio.run(store.wait_for("never", timeout=0.05))
+        assert got is None
+
+    def test_store_is_bounded(self):
+        store = ds.DiagnosticFindingsStore(max_size=2)
+        for i in range(3):
+            store.put(self._finding(f"a{i}"))
+        assert store.get("a0") is None                    # oldest evicted
+        assert store.get("a2") is not None
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — the orchestrator spawns NON-BLOCKING ephemeral agents
+# ---------------------------------------------------------------------------
+
+class TestOrchestratorSpawn:
+    def test_handle_trap_is_non_blocking(self):
+        async def _go():
+            orch = ds.SubAgentOrchestrator(agent_factory=lambda: ds.DiagnosticSubAgent(probe=FakeProbe(delay=0.05)))
+            payload = _trap_payload()
+            task = orch.handle_trap(payload)
+            # returns immediately with a scheduled task — finding NOT ready yet
+            assert task is not None
+            assert orch.store.get("shadow-000001") is None
+            await task                                     # let the ephemeral agent run
+            return orch.store.get("shadow-000001")
+
+        finding = asyncio.run(_go())
+        assert finding is not None and finding.status == "ok"
+
+    def test_handle_trap_skips_non_complex(self):
+        async def _go():
+            orch = ds.SubAgentOrchestrator(agent_factory=lambda: ds.DiagnosticSubAgent(probe=FakeProbe()))
+            return orch.handle_trap(_trap_payload(signal="component_degraded:db:rising"))
+        assert asyncio.run(_go()) is None
+
+    def test_handle_trap_skips_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_DIAGNOSTIC_SWARM_ENABLED", "0")
+        async def _go():
+            orch = ds.SubAgentOrchestrator(agent_factory=lambda: ds.DiagnosticSubAgent(probe=FakeProbe()))
+            return orch.handle_trap(_trap_payload())
+        assert asyncio.run(_go()) is None
+
+    def test_handle_trap_no_running_loop_is_fail_soft(self):
+        # Called from a sync context (no loop) — must not raise, returns None.
+        orch = ds.SubAgentOrchestrator(agent_factory=lambda: ds.DiagnosticSubAgent(probe=FakeProbe()))
+        assert orch.handle_trap(_trap_payload()) is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — REPL enrichment matrix
+# ---------------------------------------------------------------------------
+
+class TestEnrichment:
+    def test_enriched_prompt_includes_diagnosis(self):
+        finding = ds.DiagnosticFinding(
+            action_id="shadow-000001", op_id="", organ="SHO",
+            summary="root cause: runaway python(pid=999) at 95% cpu", facts={}, status="ok", elapsed_s=0.02,
+        )
+        out = ds.enriched_endorsement_prompt(_trap_payload(), finding)
+        assert "runaway python(pid=999)" in out           # diagnosis shown first
+        assert "[Y/N]" in out                             # then the decision
+        # diagnosis must precede the endorsement line
+        assert out.index("runaway") < out.index("[Y/N]")
+
+    def test_enriched_prompt_pending_when_no_finding(self):
+        out = ds.enriched_endorsement_prompt(_trap_payload(), None)
+        assert "pending" in out.lower()
+        assert "[Y/N]" in out
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — full chain: trap -> spawn -> investigate -> enriched prompt
+# ---------------------------------------------------------------------------
+
+class TestPhase4Chain:
+    def test_trap_spawns_agent_and_repl_renders_enriched_prompt(self):
+        async def _go():
+            probe = FakeProbe(facts={"top_process": "python(pid=999) cpu=95%", "mem_pct": 92})
+            orch = ds.SubAgentOrchestrator(agent_factory=lambda: ds.DiagnosticSubAgent(probe=probe))
+            orch.attach_to_trap_stream()                  # subscribe to SHADOW_ACTION_TRAPPED
+
+            # A real organ traps a dangerous action under a dispatched ANOMALY signal.
+            dispatcher = cr.EventActivationDispatcher()
+
+            async def _kill():
+                return "killed"
+
+            async def organ(signal):
+                await cr.shadow_guard_async(
+                    "execute remediation 'restart' on 'worker-7'",
+                    _kill, organ="SelfHealingOrchestrator",
+                )
+
+            dispatcher.register_organ("SelfHealingOrchestrator", organ, [cr.PressureSignalType.ANOMALY_DETECTED])
+            await dispatcher.dispatch(
+                cr.PressureSignal(cr.PressureSignalType.ANOMALY_DETECTED, "worker-7", cr.SignalEdge.RISING)
+            )
+
+            aid = cr.pending_shadow_action_ids()[-1]      # the trapped action awaiting endorsement
+            payload = {
+                "organ_name": "SelfHealingOrchestrator",
+                "intended_action": "execute remediation 'restart' on 'worker-7'",
+                "triggering_signal": "anomaly_detected:worker-7:rising",
+                "action_id": aid,
+            }
+            # the REPL gateway awaits the ephemeral agent's findings, then renders.
+            prompt = await ds.endorsement_prompt_with_diagnosis(orch, payload, wait_s=2.0)
+            return aid, prompt, probe.calls
+
+        aid, prompt, calls = asyncio.run(_go())
+        assert calls == 1, "exactly one ephemeral agent investigated the trap"
+        assert "python(pid=999)" in prompt, "root-cause analysis surfaced to the Host"
+        assert aid in prompt and "[Y/N]" in prompt, "the contextualized endorsement decision"


### PR DESCRIPTION
## Slice 254 — The Diagnostic Swarm

Gives the reanimated cybernetic muscle a **brain**. When `shadow_guard` traps a **complex** anomaly (`RESOURCE_PRESSURE` / `ANOMALY_DETECTED`), a `SubAgentOrchestrator` subscribed to `SHADOW_ACTION_TRAPPED` dynamically spawns an ephemeral, read-only `DiagnosticSubAgent` (hard TTL) that investigates the live system state asynchronously and pipes a concise root-cause analysis back to the endorsement gateway — so the Host's `[Endorse Execution? Y/N]` is **intelligence-backed, not blind**.

### Phase 1 — Sub-Agent Orchestrator (subscribes to the trap)
`cybernetic_reanimation.py` gains **trap observers** (`register_trap_observer` / `unregister` / `reset` + `_notify_trap_observers` fan-out, **never raises**) fired from `shadow_guard`/`shadow_guard_async` after stashing. This is the **in-process, kernel-free equivalent of subscribing to `SHADOW_ACTION_TRAPPED` on the SupervisorEventBus**: the trap chokepoint is the single source of truth, so observers see exactly what the broker sees. `SubAgentOrchestrator.attach_to_trap_stream()` registers itself.

### Phase 2 — Dynamic ephemeral instantiation (non-blocking, bounded, read-only)
- `SubAgentOrchestrator.handle_trap` — **NON-BLOCKING**: schedules the investigation as a background `create_task` (strong task-refs, no premature GC) and returns immediately. Skips non-complex traps, the disabled swarm, and the no-running-loop case (all fail-soft).
- `DiagnosticSubAgent` — ephemeral, **structurally read-only** (no `execute`/`endorse`/`kill`/`shed` surface — diagnosis observes, it can never act; authority stays with the Host behind the shield). `investigate()` wrapped in `asyncio.wait_for(ttl)` (default **60s**) so a hung probe can't leak; fail-soft (timeout/error → finding with that status, never raises). **Injectable probe** (`DefaultDiagnosticProbe` = best-effort psutil snapshot; tests use fakes).
- `DiagnosticFindingsStore` — capacity-capped ring keyed by `action_id` with a per-key `asyncio.Event` so the REPL can **await** a fresh diagnosis (bounded).

### Phase 3 — REPL enrichment matrix
`enriched_endorsement_prompt` / `endorsement_prompt_with_diagnosis` render the root-cause analysis **above** the Slice-253 `[Y/N]` line; a `diagnosis pending` note shows when it isn't ready — **the decision is never gated on the swarm**.

### Phase 4 — integration proof
- **23 decoupled tests (in-sandbox):** env flags + complexity filter; sub-agent finding / TTL-timeout / probe-error / read-only; store put-get-wait-bounded; non-blocking spawn (finding *not ready* until awaited) + skip-when-disabled/non-complex/no-loop; enrichment ordering (diagnosis precedes `[Y/N]`); full chain trap→spawn→investigate→enriched prompt.
- **1 kernel-chain proof (sandbox-off):** a real `ANOMALY_DETECTED` → real `SelfHealingOrchestrator` → trap → orchestrator spawns the ephemeral agent **without blocking dispatch** → the probe's root-cause is piped into the enriched prompt; the action stays endorsable (Slice 253 intact).
- **80 green** incl. 249/252/253/foundation — zero regression (both module changes are additive).

Knobs: `JARVIS_DIAGNOSTIC_SWARM_ENABLED` (default true), `JARVIS_DIAGNOSTIC_AGENT_TTL_S` (60), `JARVIS_DIAGNOSTIC_FINDINGS_MAX` (64). Built in an OCA-owned worktree off current `main` (`29904135`). Decoupled module — no 102K-kernel coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ephemeral diagnostic swarm that spawns read‑only sub‑agents for complex traps to surface root‑cause analysis in the endorsement prompt without blocking dispatch. Introduces in‑process trap observers and a non‑blocking, TTL‑bounded orchestrator with a small findings store.

- **New Features**
  - In‑process trap observers in `cybernetic_reanimation` (`register_trap_observer`, `unregister_trap_observer`, `reset_trap_observers`), fanned out from `shadow_guard`/`shadow_guard_async` (never raises).
  - New `diagnostic_swarm` module: `SubAgentOrchestrator` (non‑blocking spawn), `DiagnosticSubAgent` (read‑only, TTL via `asyncio.wait_for`, fail‑soft), and `DiagnosticFindingsStore` (bounded, awaitable).
  - Enriched endorsement prompt shows diagnosis above the `[Y/N]` line; shows “diagnosis pending” if not ready.
  - Config: `JARVIS_DIAGNOSTIC_SWARM_ENABLED` (default true), `JARVIS_DIAGNOSTIC_AGENT_TTL_S` (60s), `JARVIS_DIAGNOSTIC_FINDINGS_MAX` (64).

<sup>Written for commit 2e985ddddc43de5a97a494a8188e6386ebb3393e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

