### PR TITLE
Slice 253 frontend: SerpentREPL Shadow-Endorsement Interceptor (/endorse HITL)

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -28,6 +28,7 @@ symbiote must be entirely visible.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 import re
 import subprocess
@@ -396,6 +397,117 @@ def _headless_auto_approve_reason() -> Optional[str]:
         # as headless rather than letting the isatty() call raise.
         return "no-tty:stdin-invalid"
     return None
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Slice 253 — Shadow-Endorsement decision core (the "steering wheel")
+#
+# Pure + injectable so the /endorse decision logic is unit-testable WITHOUT
+# prompt_toolkit, a real TTY, or the 102K-line kernel. The REPL handler
+# (:meth:`SerpentREPL._handle_endorse`) wires the real backend callables +
+# prompt_toolkit prompt into these; the tests inject mocks.
+# ══════════════════════════════════════════════════════════════════════
+
+def classify_endorsement_choice(raw: Optional[str]) -> str:
+    """Normalize a raw human answer to the strict binary ``"y"`` / ``"n"``.
+
+    The endorsement gate is a STRICT binary ``[Endorse execution? y/N]`` — the
+    default (empty input, garbage, ``None``) is the SAFE ``"n"`` (decline). Only
+    an explicit ``y`` / ``yes`` (case-insensitive, whitespace-trimmed) endorses.
+    """
+    if raw is None:
+        return "n"
+    return "y" if str(raw).strip().lower() in ("y", "yes") else "n"
+
+
+async def resolve_endorsement(
+    action_id: str,
+    *,
+    choice: Optional[str] = None,
+    prompt_fn: "Callable[[Dict[str, Any]], Any]",
+    handle_choice: "Callable[[str, str], Any]",
+    payload: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """The injectable endorsement decision core.
+
+    Routes a single trapped-action endorsement decision through the backend:
+
+    * If ``choice`` is provided (``"y"``/``"n"`` or any string), it is used
+      directly — NO prompt is shown (the non-interactive ``/endorse <id> y|n``
+      scripting path + the headless path).
+    * If ``choice`` is ``None``, ``prompt_fn(payload)`` is awaited to obtain the
+      human's answer (the interactive ``[Endorse execution? y/N]`` prompt).
+    * The resolved answer is routed to ``handle_choice(action_id, answer)``
+      (the backend's ``handle_endorsement_choice``) which returns an
+      ``EndorsementResult``-shaped object (``.status`` / ``.action_id`` / etc.).
+
+    FAIL-SOFT by construction — a backend exception yields a synthetic
+    ``error`` result and an EOF/cancelled prompt is treated as a decline.
+    NEVER raises into the REPL loop. ``prompt_fn`` / ``handle_choice`` may be
+    sync or async (awaited iff awaitable).
+    """
+    answer: str
+    if choice is not None:
+        answer = str(choice)
+    else:
+        try:
+            out = prompt_fn(payload or {"action_id": action_id})
+            if inspect.isawaitable(out):
+                out = await out
+            answer = str(out)
+        except (EOFError, KeyboardInterrupt, asyncio.CancelledError):
+            answer = "n"  # cancelled prompt == decline (safe default)
+        except Exception:  # noqa: BLE001 — a broken prompt must never crash
+            answer = "n"
+
+    try:
+        res = handle_choice(action_id, answer)
+        if inspect.isawaitable(res):
+            res = await res
+        return res
+    except Exception as exc:  # noqa: BLE001 — endorsement must never crash Host
+        return _EndorsementErrorShim(action_id=action_id, error=str(exc)[:256])
+
+
+class _EndorsementErrorShim:
+    """Minimal ``EndorsementResult``-shaped fail-soft result for the case where
+    the backend call itself raised (so :func:`render_endorsement_outcome` and
+    the REPL renderer have a uniform ``.status`` surface)."""
+
+    __slots__ = ("status", "action_id", "organ", "intended_action", "error")
+
+    def __init__(self, *, action_id: str = "", error: str = "") -> None:
+        self.status = "error"
+        self.action_id = action_id
+        self.organ = ""
+        self.intended_action = ""
+        self.error = error
+
+
+def render_endorsement_outcome(result: Any) -> str:
+    """Map an ``EndorsementResult`` to a calm, restrained one-line display
+    string (plain text — the REPL handler wraps it in Rich color markup).
+
+    Green-for-outcomes aesthetic: only ``executed`` is a positive outcome; the
+    rest are muted/caution. Pure + total — unknown statuses degrade gracefully.
+    """
+    status = str(getattr(result, "status", "") or "?")
+    aid = str(getattr(result, "action_id", "") or "?")
+    organ = str(getattr(result, "organ", "") or "")
+    organ_tag = f" {organ}" if organ else ""
+    if status == "executed":
+        return f"✓ endorsed → executed{organ_tag} (id={aid})"
+    if status == "declined":
+        return f"✗ declined{organ_tag} (id={aid}) — still pending until TTL"
+    if status == "not_found":
+        return f"action not found (id={aid}) — already endorsed or evicted"
+    if status == "expired":
+        return f"expired (id={aid}) — a stale kill must not fire late"
+    if status == "error":
+        err = str(getattr(result, "error", "") or "").strip()
+        suffix = f": {err}" if err else ""
+        return f"endorsement error (id={aid}){suffix}"
+    return f"endorsement outcome={status} (id={aid})"
 
 
 def _prov(provider: str) -> str:
@@ -4334,6 +4446,8 @@ class SerpentREPL:
         self._running = False
         self._task: Optional[asyncio.Task[None]] = None
         self._gls = gls  # GovernedLoopService reference for /cancel
+        # Slice 253 — live shadow-trap breadcrumb listener task.
+        self._shadow_breadcrumb_task: Optional[asyncio.Task[None]] = None
 
     async def start(self) -> None:
         """Start the REPL loop as a background task."""
@@ -4341,10 +4455,81 @@ class SerpentREPL:
             return
         self._running = True
         self._task = asyncio.ensure_future(self._loop())
+        # Slice 253 — start the live shadow-trap breadcrumb listener
+        # (best-effort, in-process; never blocks REPL boot).
+        try:
+            self._shadow_breadcrumb_task = asyncio.ensure_future(
+                self._shadow_breadcrumb_listener()
+            )
+        except Exception:  # noqa: BLE001 — breadcrumb is best-effort
+            self._shadow_breadcrumb_task = None
+
+    async def _shadow_breadcrumb_listener(self) -> None:
+        """Slice 253 — surface a calm, non-blocking breadcrumb when a Shadow
+        Mode action is trapped, so the Host knows to run ``/endorse``.
+
+        Subscribes IN-PROCESS to the existing :class:`StreamEventBroker` (the
+        same broker the read-only ``/observability/stream`` SSE uses — which is
+        left fully intact) and prints a one-line breadcrumb on each
+        ``SHADOW_ACTION_TRAPPED`` event. Deliberately does NOT hijack the prompt
+        mid-input (auto-stealing the input line under prompt_toolkit is fragile);
+        a breadcrumb + the ``/endorse`` pull-verb is the robust, elegant UX.
+
+        Best-effort + fail-soft: any error (broker disabled, subscriber cap
+        reached, import failure) silently disables the breadcrumb — the
+        ``/endorse`` verb remains fully functional regardless."""
+        sub = None
+        broker = None
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (
+                EVENT_TYPE_SHADOW_ACTION_TRAPPED,
+                get_default_broker,
+            )
+
+            broker = get_default_broker()
+            sub = broker.subscribe()
+            if sub is None:
+                return  # subscriber cap reached — degrade silently
+            async for event in broker.stream_iter(sub, heartbeat_s=0):
+                if getattr(event, "event_type", "") != EVENT_TYPE_SHADOW_ACTION_TRAPPED:
+                    continue
+                try:
+                    payload = dict(getattr(event, "payload", {}) or {})
+                    organ = str(payload.get("organ_name", "") or "?")
+                    action = str(payload.get("intended_action", "") or "?")
+                    aid = str(payload.get("action_id", "") or "?")
+                    self._flow.console.print(
+                        f"  [{_C['heal']}]⚠ shadow action trapped[/{_C['heal']}]  "
+                        f"[{_C['neural']}]{organ}[/{_C['neural']}] wants to "
+                        f"[bold]{action}[/bold] "
+                        f"[{_C['dim']}](id={aid}) — /endorse to review[/{_C['dim']}]",
+                        highlight=False,
+                    )
+                except Exception:  # noqa: BLE001 — one bad event never kills the loop
+                    continue
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — breadcrumb is strictly best-effort
+            return
+        finally:
+            try:
+                if broker is not None and sub is not None:
+                    broker.unsubscribe(sub)
+            except Exception:  # noqa: BLE001
+                pass
 
     async def stop(self) -> None:
         """Gracefully shut down the REPL."""
         self._running = False
+        # Slice 253 — tear down the breadcrumb listener.
+        _bc = getattr(self, "_shadow_breadcrumb_task", None)
+        if _bc is not None:
+            _bc.cancel()
+            try:
+                await _bc
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._shadow_breadcrumb_task = None
         # Stop the spinner invalidator first so its task doesn't
         # outlive the REPL session.
         try:
@@ -5006,6 +5191,16 @@ class SerpentREPL:
                         or line.startswith("review ")
                     ):
                         self._handle_review(line)
+                        continue
+
+                    # Slice 253 — Shadow-Endorsement interceptor (HITL steering
+                    # wheel for trapped Cybernetic Reanimation actions).
+                    if (
+                        line in ("/endorse", "endorse")
+                        or line.startswith("/endorse ")
+                        or line.startswith("endorse ")
+                    ):
+                        await self._handle_endorse(line)
                         continue
 
                     # Gap #3 Slice 3 — unified /expand <ref> verb
@@ -6888,6 +7083,213 @@ class SerpentREPL:
             f"  [{_C['dim']}]/accept <op-id> · /reject <op-id>[/{_C['dim']}]",
             highlight=False,
         )
+
+    # ── Slice 253 — Shadow-Endorsement interceptor (HITL steering wheel) ──
+
+    def _shadow_payload_for(self, action_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch a trapped action's payload (organ_name / intended_action /
+        triggering_signal / action_id) by ``action_id`` for prompt rendering.
+
+        The backend exposes the pending store via its ``_PENDING`` registry's
+        ``entries`` OrderedDict (read-only here — we never pop; endorsement
+        pops one-shot through the backend API). Returns ``None`` when the id is
+        unknown. Fail-soft: any error yields ``None``."""
+        try:
+            from backend.core import cybernetic_reanimation as _cyber
+
+            entry = _cyber._PENDING.entries.get(action_id)
+            if entry is None:
+                return None
+            return {
+                "action_id": entry.action_id,
+                "organ_name": entry.organ,
+                "intended_action": entry.action_desc,
+                "triggering_signal": entry.signal_repr,
+            }
+        except Exception:  # noqa: BLE001 — read-side helper must never crash
+            return None
+
+    async def _endorse_prompt_fn(self, payload: Dict[str, Any]) -> str:
+        """The interactive ``[Endorse execution? y/N]`` prompt — reuses the EXACT
+        prompt_toolkit + ``patch_stdout`` mechanism the Plan Gate / review
+        approval prompt uses, with the same headless / no-TTY fallback.
+
+        Headless (no controlling TTY, or ``JARVIS_APPROVAL_AUTO_APPROVE``) is a
+        DECLINE here, NOT an auto-approve: endorsing a trapped kill is an
+        authority action — the safe default when no human is present is to leave
+        the global shadow shield UP. Returns the raw human answer string."""
+        c = self._flow.console
+        from backend.core.cybernetic_reanimation import endorsement_prompt_for
+
+        # Render the trapped action context (organ / action / signal).
+        try:
+            prompt_text = endorsement_prompt_for(payload)
+        except Exception:  # noqa: BLE001
+            prompt_text = f"[SHADOW] endorse {payload.get('action_id', '?')}?"
+        organ = str(payload.get("organ_name", "") or "?")
+        action = str(payload.get("intended_action", "") or "?")
+        signal = str(payload.get("triggering_signal", "") or "")
+        c.print()
+        c.print(
+            f"  [{_C['heal']}]⚠ shadow action trapped[/{_C['heal']}]  "
+            f"[{_C['dim']}]{prompt_text}[/{_C['dim']}]",
+            highlight=False,
+        )
+        c.print(
+            f"    organ: [{_C['neural']}]{organ}[/{_C['neural']}]  "
+            f"action: [bold]{action}[/bold]"
+            + (f"  signal: [{_C['dim']}]{signal}[/{_C['dim']}]" if signal else ""),
+            highlight=False,
+        )
+
+        # Headless / no-TTY → decline (do NOT execute a kill unattended).
+        if _headless_auto_approve_reason() is not None:
+            c.print(
+                f"  [{_C['dim']}](headless — declining endorsement; the global "
+                f"shadow shield stays up)[/{_C['dim']}]",
+                highlight=False,
+            )
+            return "n"
+
+        try:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.formatted_text import HTML
+            from prompt_toolkit.patch_stdout import patch_stdout
+
+            session = PromptSession()
+            with patch_stdout(raw=True):
+                answer = await session.prompt_async(
+                    HTML("<b>  Endorse execution? [y/N] </b>"),
+                )
+            return answer
+        except ImportError:
+            c.print(
+                f"  [{_C['dim']}](prompt_toolkit unavailable — declining)"
+                f"[/{_C['dim']}]",
+                highlight=False,
+            )
+            return "n"
+        except (EOFError, KeyboardInterrupt):
+            return "n"
+
+    async def _endorse_one(
+        self, action_id: str, choice: Optional[str] = None,
+    ) -> None:
+        """Resolve + render a single endorsement decision for ``action_id``.
+
+        Wires the real backend (``handle_endorsement_choice``) + the
+        prompt_toolkit prompt into the injectable :func:`resolve_endorsement`
+        core, then prints the outcome in the green-for-outcomes aesthetic.
+        Fail-soft throughout."""
+        c = self._flow.console
+        try:
+            from backend.core.cybernetic_reanimation import (
+                handle_endorsement_choice,
+            )
+        except Exception as exc:  # noqa: BLE001
+            c.print(
+                f"  [{_C['death']}]/endorse error: backend unavailable: "
+                f"{exc}[/{_C['death']}]",
+                highlight=False,
+            )
+            return
+
+        payload = self._shadow_payload_for(action_id) or {"action_id": action_id}
+        result = await resolve_endorsement(
+            action_id,
+            choice=choice,
+            prompt_fn=self._endorse_prompt_fn,
+            handle_choice=handle_endorsement_choice,
+            payload=payload,
+        )
+        line = render_endorsement_outcome(result)
+        status = str(getattr(result, "status", "") or "")
+        color = _C["life"] if status == "executed" else (
+            _C["death"] if status == "error" else _C["heal"]
+        )
+        c.print(f"  [{color}]{line}[/{color}]", highlight=False)
+
+    async def _handle_endorse(self, line: str) -> None:
+        """``/endorse`` — the human-in-the-loop "steering wheel" for trapped
+        Shadow Mode actions (Slice 253).
+
+        Forms::
+
+            /endorse                  — review the pending trapped action(s)
+                                        interactively ([y/N] per action)
+            /endorse <action_id>      — endorse/decline a specific id (prompts)
+            /endorse <action_id> y|n  — non-interactive (scripting / headless)
+
+        Endorsement re-hydrates + executes ONE trapped action in-process for a
+        single run (the global ``JARVIS_RESILIENCE_SHADOW_MODE`` shield stays
+        UP). Read-only SSE telemetry (``/observability/stream``) is unchanged.
+        ALL fail-soft — a backend error never crashes the REPL."""
+        c = self._flow.console
+        try:
+            from backend.core.cybernetic_reanimation import (
+                pending_shadow_action_count,
+                pending_shadow_action_ids,
+            )
+        except Exception as exc:  # noqa: BLE001
+            c.print(
+                f"  [{_C['death']}]/endorse error: backend unavailable: "
+                f"{exc}[/{_C['death']}]",
+                highlight=False,
+            )
+            return
+
+        # Parse args: optional <action_id> and optional trailing y|n.
+        parts = line.replace("/endorse", "endorse", 1).split()
+        args = parts[1:]  # drop the verb
+        explicit_choice: Optional[str] = None
+        target_id: Optional[str] = None
+        if args:
+            if args[-1].strip().lower() in ("y", "n", "yes", "no"):
+                explicit_choice = args[-1].strip().lower()
+                args = args[:-1]
+            if args:
+                target_id = args[0].strip()
+
+        # Specific action_id path.
+        if target_id is not None:
+            try:
+                await self._endorse_one(target_id, choice=explicit_choice)
+            except Exception as exc:  # noqa: BLE001
+                c.print(
+                    f"  [{_C['death']}]/endorse error: {exc}[/{_C['death']}]",
+                    highlight=False,
+                )
+            return
+
+        # No id given — operate on the pending queue.
+        try:
+            count = pending_shadow_action_count()
+        except Exception:  # noqa: BLE001
+            count = 0
+        if count == 0:
+            c.print(
+                f"  [{_C['dim']}]No trapped actions awaiting endorsement."
+                f"[/{_C['dim']}]",
+                highlight=False,
+            )
+            return
+
+        try:
+            ids = list(pending_shadow_action_ids())
+        except Exception:  # noqa: BLE001
+            ids = []
+        # Most-recent first (the registry is oldest-first) — the freshest trap
+        # is the one the Host most likely wants to act on.
+        for action_id in reversed(ids):
+            # An explicit trailing y|n applies to ALL in the batch (scripting).
+            try:
+                await self._endorse_one(action_id, choice=explicit_choice)
+            except Exception as exc:  # noqa: BLE001
+                c.print(
+                    f"  [{_C['death']}]/endorse {action_id} error: "
+                    f"{exc}[/{_C['death']}]",
+                    highlight=False,
+                )
 
     # ── Runtime configuration commands ──────────────────────────
 

--- a/tests/governance/test_slice253_endorse_integration.py
+++ b/tests/governance/test_slice253_endorse_integration.py
@@ -1,0 +1,82 @@
+"""Slice 253 — end-to-end endorsement integration proof.
+
+Drives the SerpentREPL injectable endorsement core (`resolve_endorsement`)
+against the REAL merged backend (`backend.core.cybernetic_reanimation`, which is
+standalone-importable — it never imports the split-brain-guarded
+`unified_supervisor`). Proves the CLI interceptor triggers the core's in-process
+re-hydration (closure execution) on endorse, and is inert on decline.
+"""
+import pytest
+
+import backend.core.cybernetic_reanimation as cr
+from backend.core.ouroboros.battle_test.serpent_flow import (
+    classify_endorsement_choice,
+    resolve_endorsement,
+)
+
+
+def _register(execute, *, organ="SelfHealingOrchestrator", action="restart jarvis-prime",
+              signal="component_degraded"):
+    return cr._PENDING.register(
+        organ=organ, action_desc=action, execute=execute, is_coro=False,
+        signal_repr=signal,
+    )
+
+
+@pytest.mark.asyncio
+async def test_endorse_executes_the_inprocess_closure():
+    cr.reset_pending_shadow_actions()
+    ran = {}
+    aid = _register(lambda: ran.setdefault("a", True))
+    payload = {"action_id": aid, "organ_name": "SelfHealingOrchestrator",
+               "intended_action": "restart jarvis-prime",
+               "triggering_signal": "component_degraded"}
+    result = await resolve_endorsement(
+        aid, prompt_fn=lambda _p: "y",
+        handle_choice=cr.handle_endorsement_choice, payload=payload,
+    )
+    assert result.status == "executed"
+    assert ran.get("a") is True                       # the closure actually ran
+    assert cr.pending_shadow_action_count() == 0       # one-shot: entry popped
+
+
+@pytest.mark.asyncio
+async def test_decline_leaves_the_closure_unrun():
+    cr.reset_pending_shadow_actions()
+    ran = {}
+    aid = _register(lambda: ran.setdefault("a", True), organ="LoadSheddingController",
+                    action="shed request", signal="resource_pressure")
+    payload = {"action_id": aid, "organ_name": "LoadSheddingController",
+               "intended_action": "shed request", "triggering_signal": "resource_pressure"}
+    result = await resolve_endorsement(
+        aid, prompt_fn=lambda _p: "n",
+        handle_choice=cr.handle_endorsement_choice, payload=payload,
+    )
+    assert result.status == "declined"
+    assert ran.get("a") is None                        # closure NOT executed
+
+
+@pytest.mark.asyncio
+async def test_headless_no_tty_defaults_to_decline():
+    """A no-TTY prompt that returns empty MUST decline — never auto-endorse a
+    trapped kill unattended (that would defeat the Shadow shield)."""
+    cr.reset_pending_shadow_actions()
+    ran = {}
+    aid = _register(lambda: ran.setdefault("a", True))
+    payload = {"action_id": aid, "organ_name": "SelfHealingOrchestrator",
+               "intended_action": "restart jarvis-prime",
+               "triggering_signal": "component_degraded"}
+    result = await resolve_endorsement(
+        aid, prompt_fn=lambda _p: "",   # headless / empty input
+        handle_choice=cr.handle_endorsement_choice, payload=payload,
+    )
+    assert result.status == "declined"
+    assert ran.get("a") is None
+
+
+def test_classify_choice_safe_default():
+    assert classify_endorsement_choice("y") == "y"
+    assert classify_endorsement_choice("Y") == "y"
+    assert classify_endorsement_choice("yes") == "y"
+    for raw in ("", "n", "no", "x", None):
+        assert classify_endorsement_choice(raw) == "n"

--- a/tests/governance/test_slice253_endorse_repl.py
+++ b/tests/governance/test_slice253_endorse_repl.py
@@ -1,0 +1,346 @@
+"""Slice 253 frontend — SerpentREPL Shadow-Endorsement interceptor.
+
+The CORE decision-logic tests here are *import-light* and *in-sandbox*: they
+exercise the injectable endorsement core
+(:func:`backend.core.ouroboros.battle_test.serpent_flow.resolve_endorsement`)
+WITHOUT prompt_toolkit, without a real TTY, and without the 102K-line kernel —
+backend callables + the prompt function are injected as plain (mock) callables.
+
+The REPL-method tests at the bottom DO import ``serpent_flow`` (which can pull
+in the kernel via the split-brain guard); they are marked + skip cleanly when
+that import is sandbox-blocked, so the core decision spine always runs green
+in-sandbox.
+
+Backend contract under test (``backend/core/cybernetic_reanimation.py``):
+
+* ``handle_endorsement_choice(action_id, choice) -> EndorsementResult`` —
+  'y'/'yes' endorses (re-hydrate + execute), anything else declines.
+* ``endorse_shadow_action(action_id) -> EndorsementResult`` — one-shot execute.
+* ``EndorsementResult.status`` ∈ executed | declined | not_found | expired | error.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Import the injectable endorsement core. It is deliberately import-light:
+# a pure async function with NO module-level prompt_toolkit / kernel imports.
+# ──────────────────────────────────────────────────────────────────────────
+from backend.core.ouroboros.battle_test.serpent_flow import (  # noqa: E402
+    resolve_endorsement,
+    classify_endorsement_choice,
+    render_endorsement_outcome,
+)
+
+
+# ── A tiny EndorsementResult stand-in (avoids importing the kernel) ────────
+class _FakeResult:
+    def __init__(
+        self,
+        status: str,
+        action_id: str = "",
+        organ: str = "",
+        intended_action: str = "",
+        error: str = "",
+    ) -> None:
+        self.status = status
+        self.action_id = action_id
+        self.organ = organ
+        self.intended_action = intended_action
+        self.error = error
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ════════════════════════════════════════════════════════════════════════
+# classify_endorsement_choice — the pure y/n normalizer
+# ════════════════════════════════════════════════════════════════════════
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("y", "y"), ("Y", "y"), ("yes", "y"), ("YES", "y"), (" yes ", "y"),
+        ("", "n"), ("n", "n"), ("N", "n"), ("no", "n"), ("garbage", "n"),
+        (None, "n"),
+    ],
+)
+def test_classify_endorsement_choice(raw, expected):
+    assert classify_endorsement_choice(raw) == expected
+
+
+# ════════════════════════════════════════════════════════════════════════
+# resolve_endorsement — the injectable async core (no TTY / no kernel)
+# ════════════════════════════════════════════════════════════════════════
+def test_explicit_yes_endorses_without_prompting():
+    calls: List[Tuple[str, str]] = []
+
+    async def fake_handle(action_id: str, choice: str) -> _FakeResult:
+        calls.append((action_id, choice))
+        return _FakeResult("executed", action_id=action_id, organ="janitor")
+
+    prompt_calls: List[str] = []
+
+    async def fake_prompt(_payload: Dict[str, Any]) -> str:
+        prompt_calls.append("called")
+        return "y"
+
+    result = _run(
+        resolve_endorsement(
+            "shadow-000001",
+            choice="y",
+            prompt_fn=fake_prompt,
+            handle_choice=fake_handle,
+        )
+    )
+    # explicit choice must NOT prompt
+    assert prompt_calls == []
+    assert calls == [("shadow-000001", "y")]
+    assert result.status == "executed"
+
+
+def test_explicit_no_declines_without_prompting():
+    async def fake_handle(action_id: str, choice: str) -> _FakeResult:
+        # decline path: handle_endorsement_choice returns declined for non-y
+        return _FakeResult("declined", action_id=action_id)
+
+    async def fake_prompt(_payload: Dict[str, Any]) -> str:
+        raise AssertionError("must not prompt when choice is explicit")
+
+    result = _run(
+        resolve_endorsement(
+            "shadow-000002",
+            choice="n",
+            prompt_fn=fake_prompt,
+            handle_choice=fake_handle,
+        )
+    )
+    assert result.status == "declined"
+
+
+def test_no_choice_prompts_then_endorses():
+    seen: List[Tuple[str, str]] = []
+
+    async def fake_handle(action_id: str, choice: str) -> _FakeResult:
+        seen.append((action_id, choice))
+        # backend normalizes internally — mirror that with the pure classifier.
+        return _FakeResult(
+            "executed" if classify_endorsement_choice(choice) == "y" else "declined",
+            action_id=action_id,
+        )
+
+    async def fake_prompt(payload: Dict[str, Any]) -> str:
+        # the prompt receives the trapped-action payload to render
+        assert payload.get("action_id") == "shadow-000003"
+        return "yes"
+
+    result = _run(
+        resolve_endorsement(
+            "shadow-000003",
+            choice=None,
+            prompt_fn=fake_prompt,
+            handle_choice=fake_handle,
+            payload={"action_id": "shadow-000003", "organ_name": "shedder"},
+        )
+    )
+    assert seen == [("shadow-000003", "yes")]
+    assert result.status == "executed"
+
+
+def test_no_choice_prompts_then_declines():
+    async def fake_handle(action_id: str, choice: str) -> _FakeResult:
+        return _FakeResult(
+            "executed" if classify_endorsement_choice(choice) == "y" else "declined",
+            action_id=action_id,
+        )
+
+    async def fake_prompt(_payload: Dict[str, Any]) -> str:
+        return ""  # empty == decline (binary [y/N])
+
+    result = _run(
+        resolve_endorsement(
+            "shadow-000004",
+            choice=None,
+            prompt_fn=fake_prompt,
+            handle_choice=fake_handle,
+        )
+    )
+    assert result.status == "declined"
+
+
+def test_unknown_action_id_surfaces_not_found():
+    async def fake_handle(action_id: str, choice: str) -> _FakeResult:
+        return _FakeResult("not_found", action_id=action_id)
+
+    async def fake_prompt(_payload: Dict[str, Any]) -> str:
+        return "y"
+
+    result = _run(
+        resolve_endorsement(
+            "shadow-bogus",
+            choice="y",
+            prompt_fn=fake_prompt,
+            handle_choice=fake_handle,
+        )
+    )
+    assert result.status == "not_found"
+
+
+def test_backend_exception_is_fail_soft():
+    async def fake_handle(action_id: str, choice: str) -> _FakeResult:
+        raise RuntimeError("backend exploded")
+
+    async def fake_prompt(_payload: Dict[str, Any]) -> str:
+        return "y"
+
+    # resolve_endorsement must NEVER propagate — returns an error result.
+    result = _run(
+        resolve_endorsement(
+            "shadow-000005",
+            choice="y",
+            prompt_fn=fake_prompt,
+            handle_choice=fake_handle,
+        )
+    )
+    assert result.status == "error"
+    assert "backend exploded" in (result.error or "")
+
+
+def test_prompt_eof_declines_fail_soft():
+    async def fake_handle(action_id: str, choice: str) -> _FakeResult:
+        return _FakeResult("declined", action_id=action_id)
+
+    async def fake_prompt(_payload: Dict[str, Any]) -> str:
+        raise EOFError
+
+    # An EOF / cancelled prompt must be treated as a decline, never a crash.
+    result = _run(
+        resolve_endorsement(
+            "shadow-000006",
+            choice=None,
+            prompt_fn=fake_prompt,
+            handle_choice=fake_handle,
+        )
+    )
+    assert result.status == "declined"
+
+
+# ════════════════════════════════════════════════════════════════════════
+# render_endorsement_outcome — pure outcome → display string mapping
+# ════════════════════════════════════════════════════════════════════════
+@pytest.mark.parametrize(
+    "status,needle",
+    [
+        ("executed", "endorsed"),
+        ("declined", "declined"),
+        ("not_found", "not found"),
+        ("expired", "expired"),
+        ("error", "error"),
+    ],
+)
+def test_render_endorsement_outcome(status, needle):
+    res = _FakeResult(status, action_id="shadow-000001", organ="janitor")
+    out = render_endorsement_outcome(res)
+    assert isinstance(out, str)
+    assert needle in out.lower()
+
+
+# ════════════════════════════════════════════════════════════════════════
+# REPL-method integration — imports serpent_flow + cybernetic_reanimation,
+# which import + construct cleanly in-sandbox (verified: serpent_flow does NOT
+# pull unified_supervisor at import time). They drive _handle_endorse
+# end-to-end against the real backend registry.
+# ════════════════════════════════════════════════════════════════════════
+def test_handle_endorse_empty_pending_is_calm_noop(monkeypatch):
+    import backend.core.cybernetic_reanimation as cyber
+
+    cyber.reset_pending_shadow_actions()
+    from backend.core.ouroboros.battle_test.serpent_flow import (
+        SerpentFlow,
+        SerpentREPL,
+    )
+
+    flow = SerpentFlow()
+    repl = SerpentREPL(flow)
+
+    printed: List[str] = []
+    monkeypatch.setattr(
+        flow.console, "print", lambda *a, **k: printed.append(" ".join(str(x) for x in a))
+    )
+
+    _run(repl._handle_endorse("/endorse"))
+    blob = "\n".join(printed).lower()
+    assert "no trapped" in blob or "no shadow" in blob or "awaiting" in blob
+
+
+def test_handle_endorse_specific_id_decline(monkeypatch):
+    import backend.core.cybernetic_reanimation as cyber
+
+    cyber.reset_pending_shadow_actions()
+
+    fired: Dict[str, bool] = {"executed": False}
+
+    def _execute() -> str:
+        fired["executed"] = True
+        return "killed"
+
+    # Register a trapped action directly via the backend registry.
+    action_id = cyber._PENDING.register(
+        organ="janitor",
+        action_desc="kill process 1234",
+        execute=_execute,
+        is_coro=False,
+        signal_repr="memory_pressure:psutil:rising",
+    )
+
+    from backend.core.ouroboros.battle_test.serpent_flow import (
+        SerpentFlow,
+        SerpentREPL,
+    )
+
+    flow = SerpentFlow()
+    repl = SerpentREPL(flow)
+    monkeypatch.setattr(flow.console, "print", lambda *a, **k: None)
+
+    # Non-interactive decline.
+    _run(repl._handle_endorse(f"/endorse {action_id} n"))
+    assert fired["executed"] is False
+    # declined leaves the action pending (still endorsable later).
+    assert action_id in cyber.pending_shadow_action_ids()
+
+
+def test_handle_endorse_specific_id_yes_executes(monkeypatch):
+    import backend.core.cybernetic_reanimation as cyber
+
+    cyber.reset_pending_shadow_actions()
+
+    fired: Dict[str, bool] = {"executed": False}
+
+    def _execute() -> str:
+        fired["executed"] = True
+        return "killed"
+
+    action_id = cyber._PENDING.register(
+        organ="janitor",
+        action_desc="kill process 1234",
+        execute=_execute,
+        is_coro=False,
+    )
+
+    from backend.core.ouroboros.battle_test.serpent_flow import (
+        SerpentFlow,
+        SerpentREPL,
+    )
+
+    flow = SerpentFlow()
+    repl = SerpentREPL(flow)
+    monkeypatch.setattr(flow.console, "print", lambda *a, **k: None)
+
+    _run(repl._handle_endorse(f"/endorse {action_id} y"))
+    assert fired["executed"] is True
+    # one-shot: the action is popped after execution.
+    assert action_id not in cyber.pending_shadow_action_ids()


### PR DESCRIPTION
## Summary
The human-in-the-loop **frontend** for Slice 253, completing the bidirectional shadow-endorsement loop on top of the merged backend (#69505). The autonomous backend built the gateway + decision helpers; this adds the live in-process steering wheel.

- **`/endorse` REPL verb** in `SerpentREPL` (extends the existing `/accept`·`/reject`·`/review` `ReviewCoordinator` HITL pattern): `/endorse` (interactive, iterates pending traps), `/endorse <action_id>` (prompt one), `/endorse <action_id> y|n` (non-interactive/scripting).
- **Interactive prompt** reuses the exact Plan-Gate `prompt_toolkit` `[y/N]` + `patch_stdout` mechanism. **Safety:** headless/no-TTY → **decline** (never auto-endorse a trapped kill unattended).
- **Live breadcrumb listener** subscribes to the existing `StreamEventBroker` (the same broker `/observability/stream` serves — left fully intact) and prints a calm `⚠ shadow action trapped … — /endorse to review` line on each `SHADOW_ACTION_TRAPPED`. Non-blocking; never hijacks the input line.
- **In-process by design:** endorsement executes the backend's non-serializable closures via `handle_endorsement_choice`/`endorse_shadow_action(action_id)` — a detached CLI cannot, so execution authority stays in REPL memory. The read-only SSE display remains for remote/IDE observability.
- Injectable core (`resolve_endorsement`, `classify_endorsement_choice`, `render_endorsement_outcome`) → unit-testable without a TTY or the (split-brain-guarded) kernel.

## Test Plan
- [x] 26 decision/UX unit tests (in-sandbox, injected prompt + backend)
- [x] 4 real-backend integration tests: endorse → closure **executes** + pending popped; decline / headless-empty → closure **not run**; safe-default classify
- [x] `serpent_flow.py` ast-parse clean; shadow-definitions guard green; `unified_supervisor.py` untouched
- [ ] Live interactive verification in a local TTY battle test (prompt rendering is TTY-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a human-in-the-loop `/endorse` command to `SerpentREPL` to review and execute trapped Shadow Mode actions in-process, completing Slice 253. Also surfaces a live breadcrumb when actions are trapped and uses a safe, binary `[y/N]` flow that declines by default in headless sessions.

- New Features
  - `/endorse` verbs: `/endorse`, `/endorse <action_id>`, `/endorse <action_id> y|n`.
  - Interactive prompt via `prompt_toolkit` with `[y/N]`; no TTY → decline.
  - In-process execution using backend handlers (`handle_endorsement_choice`), preserving closure authority in memory.
  - Breadcrumb listener subscribes to `StreamEventBroker` and prints a calm “shadow action trapped — /endorse to review” line; non-blocking and fail-soft.
  - Injectable core for testability: `resolve_endorsement`, `classify_endorsement_choice`, `render_endorsement_outcome`.
  - Read-only SSE via `/observability/stream` remains unchanged.

- Migration
  - Use `/endorse` in the REPL to review and decide pending traps; pass `y|n` for non-interactive scripts.
  - Endorsement must run inside the REPL process; remote SSE views are display-only.
  - Headless sessions always decline by default (no unattended endorsements).

<sup>Written for commit 5877c2bc95bde609611edf41d74f5671cb508c34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

