### PR TITLE
Slice 250.2b Phase 1: Deterministic synthetic ECAPA audio fixture matrix

### DIFF
--- a/tests/ml/__init__.py
+++ b/tests/ml/__init__.py
@@ -1,0 +1,1 @@
+"""ML offline testing matrix (Slice 250.2b). Pure-numpy, no torch/scipy."""

--- a/tests/ml/synthetic_audio_matrix.py
+++ b/tests/ml/synthetic_audio_matrix.py
@@ -1,0 +1,198 @@
+"""Deterministic synthetic audio generator for ECAPA speaker-embedding tests.
+
+Slice 250.2b Phase 1 — the offline "vector injector" fixtures. This module
+produces **byte-identical** synthetic voice waveforms via additive harmonic
+synthesis with a formant envelope, so the speaker-embedding parity harness can
+prove the embedder *discriminates* (same voice accepts, different voice
+rejects) without ever touching the heavy/cloud ECAPA model.
+
+Pipeline convention (matches ``backend/core/ecapa_facade.py``):
+    16 kHz mono ``float32`` waveform in ``[-1, 1]``.
+
+Determinism contract (NON-NEGOTIABLE)
+-------------------------------------
+Identical arguments produce identical bytes — in-process and across separate
+processes. We use ONLY ``np.random.default_rng(seed)`` (a stateless, explicitly
+seeded Generator). No global ``np.random`` calls, no ``random`` module, no time,
+no mutable module/global state. This makes every clip a reproducible fixture.
+
+Unified-memory / Apple-Silicon friendliness
+-------------------------------------------
+Everything is ``float32``, generated lazily one clip at a time, with no torch
+tensors and no large batched allocations. A 3 s clip at 16 kHz is ~192 KB; the
+full 3-clip ABC matrix is well under 1 MiB and astronomically far under the
+16 GB unified-memory ceiling (see ``estimate_matrix_bytes`` / ``MAX_MATRIX_BYTES``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+SAMPLE_RATE = 16000
+
+# Documented cap for the offline matrix. The real matrix is ~3 clips * 192 KB
+# (~0.55 MiB); 16 MiB is a comfortable, self-documenting headroom ceiling that
+# stays ~1000x under the 16 GB unified-memory limit.
+MAX_MATRIX_BYTES = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class VoiceProfile:
+    """A synthetic speaker.
+
+    ``formants`` is a tuple of ``(center_hz, bandwidth_hz, gain)`` triples. The
+    harmonic amplitude at frequency ``f`` is the sum of Gaussian bumps, one per
+    formant, each centered at ``center_hz`` with std ``bandwidth_hz`` and scaled
+    by ``gain``. Distinct f0 + distinct formant sets => spectrally separable
+    speakers.
+    """
+
+    name: str
+    f0_hz: float
+    formants: tuple[tuple[float, float, float], ...]
+
+
+# Two canonical speakers tuned so the spectral embedder separates them with a
+# clear margin (see tests/ml/test_speaker_parity_harness.py). ALPHA is a low,
+# "chesty" voice; BRAVO is higher with formants shifted well up the spectrum.
+ALPHA = VoiceProfile(
+    name="ALPHA",
+    f0_hz=110.0,
+    formants=(
+        (500.0, 90.0, 1.0),
+        (1100.0, 110.0, 0.7),
+        (2300.0, 160.0, 0.35),
+    ),
+)
+
+BRAVO = VoiceProfile(
+    name="BRAVO",
+    f0_hz=170.0,
+    formants=(
+        (800.0, 110.0, 1.0),
+        (1900.0, 150.0, 0.8),
+        (3400.0, 220.0, 0.5),
+    ),
+)
+
+
+def _formant_envelope(freqs: np.ndarray, profile: VoiceProfile) -> np.ndarray:
+    """Sum-of-Gaussians spectral envelope evaluated at ``freqs`` (Hz)."""
+    env = np.zeros_like(freqs, dtype=np.float64)
+    for center, bandwidth, gain in profile.formants:
+        bw = max(float(bandwidth), 1e-6)
+        env += float(gain) * np.exp(-0.5 * ((freqs - float(center)) / bw) ** 2)
+    return env
+
+
+def generate_waveform(
+    profile: VoiceProfile,
+    *,
+    seed: int,
+    duration_s: float = 3.0,
+    sample_rate: int = SAMPLE_RATE,
+) -> np.ndarray:
+    """Deterministic additive-synthesis voice waveform.
+
+    Sums harmonics ``k = 1..K`` of ``profile.f0_hz`` (K up to Nyquist), each
+    weighted by the formant envelope at ``k * f0``. Per-harmonic phases and a
+    low-amplitude noise floor are drawn from a single ``default_rng(seed)`` so
+    the result is byte-identical for identical arguments.
+
+    Returns a ``float32`` array of shape ``(round(duration_s*sample_rate),)``,
+    peak-normalized to 0.95, with values in ``[-1, 1]``.
+    """
+    rng = np.random.default_rng(seed)
+
+    n = int(round(duration_s * sample_rate))
+    t = np.arange(n, dtype=np.float64) / float(sample_rate)
+
+    nyquist = sample_rate / 2.0
+    f0 = float(profile.f0_hz)
+    # Harmonics strictly below Nyquist.
+    n_harmonics = max(1, int(np.floor((nyquist - 1e-9) / f0)))
+    k = np.arange(1, n_harmonics + 1, dtype=np.float64)
+    harmonic_freqs = k * f0
+
+    amplitudes = _formant_envelope(harmonic_freqs, profile)
+    # Draw ALL random quantities up front from the single rng, in a fixed order,
+    # so byte-output depends only on (seed, profile, shape) — never call order.
+    phases = rng.uniform(0.0, 2.0 * np.pi, size=n_harmonics)
+    noise = rng.standard_normal(n).astype(np.float64) * 1e-3
+
+    # Build the signal harmonic by harmonic (small K, tiny memory footprint).
+    signal = np.zeros(n, dtype=np.float64)
+    two_pi = 2.0 * np.pi
+    for amp, freq, ph in zip(amplitudes, harmonic_freqs, phases):
+        if amp <= 0.0:
+            continue
+        signal += amp * np.sin(two_pi * freq * t + ph)
+    signal += noise
+
+    peak = float(np.max(np.abs(signal)))
+    if peak > 0.0:
+        signal = signal * (0.95 / peak)
+
+    out = signal.astype(np.float32)
+    # Guard against float32 rounding nudging a sample fractionally past +/-1.
+    np.clip(out, -1.0, 1.0, out=out)
+    return out
+
+
+@dataclass
+class ABCMatrix:
+    """The 3-clip discriminative matrix.
+
+    A = ALPHA(seed_a), B = ALPHA(seed_b) (same voice, different utterance ->
+    must ACCEPT vs A), C = BRAVO(seed_c) (different voice -> must REJECT vs A).
+    """
+
+    a: np.ndarray
+    b: np.ndarray
+    c: np.ndarray
+    profile_a: VoiceProfile
+    profile_b: VoiceProfile
+    profile_c: VoiceProfile
+    seed_a: int
+    seed_b: int
+    seed_c: int
+
+
+def build_abc_matrix(
+    *,
+    seed_a: int = 101,
+    seed_b: int = 202,
+    seed_c: int = 303,
+    duration_s: float = 3.0,
+) -> ABCMatrix:
+    """Build the deterministic A/B/C fixture matrix."""
+    a = generate_waveform(ALPHA, seed=seed_a, duration_s=duration_s)
+    b = generate_waveform(ALPHA, seed=seed_b, duration_s=duration_s)
+    c = generate_waveform(BRAVO, seed=seed_c, duration_s=duration_s)
+    return ABCMatrix(
+        a=a,
+        b=b,
+        c=c,
+        profile_a=ALPHA,
+        profile_b=ALPHA,
+        profile_c=BRAVO,
+        seed_a=seed_a,
+        seed_b=seed_b,
+        seed_c=seed_c,
+    )
+
+
+def estimate_matrix_bytes(
+    duration_s: float,
+    sample_rate: int = SAMPLE_RATE,
+    n_clips: int = 3,
+) -> int:
+    """Exact resident size (bytes) of the float32 ABC matrix.
+
+    float32 == 4 bytes/sample. Used to assert the matrix stays far under
+    ``MAX_MATRIX_BYTES`` and the 16 GB unified-memory ceiling.
+    """
+    samples_per_clip = int(round(duration_s * sample_rate))
+    return n_clips * samples_per_clip * 4

--- a/tests/ml/test_speaker_parity_harness.py
+++ b/tests/ml/test_speaker_parity_harness.py
@@ -1,0 +1,180 @@
+"""Dual-case speaker-parity harness for the synthetic ECAPA fixtures.
+
+Slice 250.2b Phase 1. Proves the fixtures are genuinely *discriminative*:
+B (same voice as A, different utterance) ACCEPTS, and C (a different voice)
+REJECTS, under a deterministic pure-numpy spectral embedder. The same parity
+logic is structured to run against the real ECAPA embedder when importable
+(skips in sandbox where torch/model/cloud are unavailable).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+import pytest
+
+from tests.ml.synthetic_audio_matrix import SAMPLE_RATE, build_abc_matrix
+
+EmbedFn = Callable[[np.ndarray, int], np.ndarray]
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic pure-numpy spectral stand-in embedder
+# --------------------------------------------------------------------------- #
+def _spectral_embedding(
+    waveform: np.ndarray,
+    sample_rate: int,
+    *,
+    frame: int = 512,
+    hop: int = 256,
+) -> np.ndarray:
+    """Hann-windowed framed log-magnitude FFT, mean over frames, L2-normalized.
+
+    Captures the f0 + formant envelope so same-voice clips embed close and
+    different-voice clips embed far. Deterministic and dependency-free.
+    """
+    wav = np.asarray(waveform, dtype=np.float64)
+    if wav.size < frame:
+        wav = np.pad(wav, (0, frame - wav.size))
+    window = np.hanning(frame)
+    n_frames = 1 + (wav.size - frame) // hop
+    acc = np.zeros(frame // 2 + 1, dtype=np.float64)
+    for i in range(n_frames):
+        seg = wav[i * hop : i * hop + frame] * window
+        mag = np.abs(np.fft.rfft(seg))
+        acc += np.log1p(mag)
+    acc /= max(n_frames, 1)
+    norm = np.linalg.norm(acc)
+    return acc / norm if norm > 0.0 else acc
+
+
+def cosine_similarity(u: np.ndarray, v: np.ndarray) -> float:
+    u = np.asarray(u, dtype=np.float64)
+    v = np.asarray(v, dtype=np.float64)
+    nu = np.linalg.norm(u)
+    nv = np.linalg.norm(v)
+    if nu == 0.0 or nv == 0.0:
+        return 0.0
+    return float(np.dot(u, v) / (nu * nv))
+
+
+def verify(
+    reference: np.ndarray,
+    probe: np.ndarray,
+    *,
+    embed_fn: EmbedFn = _spectral_embedding,
+    sample_rate: int = SAMPLE_RATE,
+    threshold: float,
+) -> bool:
+    """Return True iff probe is the same speaker as reference (sim >= threshold)."""
+    ref_emb = embed_fn(reference, sample_rate)
+    probe_emb = embed_fn(probe, sample_rate)
+    return cosine_similarity(ref_emb, probe_emb) >= threshold
+
+
+# --------------------------------------------------------------------------- #
+# Embedder seam: spectral stand-in (default) + real ECAPA when available
+# --------------------------------------------------------------------------- #
+def _real_ecapa_embed_fn() -> EmbedFn | None:
+    """Return a usable real-ECAPA embed_fn, or None if unavailable.
+
+    Skips cleanly in sandbox where torch/model/cloud are not present.
+    """
+    try:
+        from backend.core import ecapa_facade  # type: ignore
+    except Exception:
+        return None
+
+    extractor = getattr(ecapa_facade, "extract_embedding", None)
+    if not callable(extractor):
+        return None
+
+    def _embed(waveform: np.ndarray, sample_rate: int) -> np.ndarray:
+        # The real facade expects 16 kHz mono float32 in [-1, 1].
+        return np.asarray(extractor(waveform), dtype=np.float64)
+
+    # Probe once on a tiny clip; if it raises (no model / no cloud), bail.
+    try:
+        _ = _embed(np.zeros(SAMPLE_RATE, dtype=np.float32), SAMPLE_RATE)
+    except Exception:
+        return None
+    return _embed
+
+
+@pytest.fixture(
+    params=["spectral", "real_ecapa"],
+    ids=["spectral_standin", "real_ecapa"],
+)
+def embed_fn(request: pytest.FixtureRequest) -> EmbedFn:
+    if request.param == "spectral":
+        return _spectral_embedding
+    real = _real_ecapa_embed_fn()
+    if real is None:
+        pytest.skip("real ECAPA embedder unavailable (torch/model/cloud not usable)")
+    return real
+
+
+# --------------------------------------------------------------------------- #
+# Threshold derivation — proves the fixtures separate with margin
+# --------------------------------------------------------------------------- #
+def _sims(embed: EmbedFn) -> tuple[float, float]:
+    m = build_abc_matrix()
+    ea = embed(m.a, SAMPLE_RATE)
+    eb = embed(m.b, SAMPLE_RATE)
+    ec = embed(m.c, SAMPLE_RATE)
+    return cosine_similarity(ea, eb), cosine_similarity(ea, ec)
+
+
+def _accept_threshold(sim_ab: float, sim_ac: float) -> float:
+    """Midpoint between the same-voice and diff-voice sims."""
+    return (sim_ab + sim_ac) / 2.0
+
+
+def test_fixtures_separate_with_margin(embed_fn: EmbedFn) -> None:
+    sim_ab, sim_ac = _sims(embed_fn)
+    # Same voice must score strictly higher than different voice, with margin.
+    assert sim_ab > sim_ac
+    margin = sim_ab - sim_ac
+    assert margin > 0.05, f"insufficient margin {margin:.4f} (AB={sim_ab}, AC={sim_ac})"
+    threshold = _accept_threshold(sim_ab, sim_ac)
+    assert sim_ac < threshold < sim_ab
+
+
+def test_b_accepts(embed_fn: EmbedFn) -> None:
+    m = build_abc_matrix()
+    sim_ab, sim_ac = _sims(embed_fn)
+    threshold = _accept_threshold(sim_ab, sim_ac)
+    assert sim_ab >= threshold
+    assert verify(m.a, m.b, embed_fn=embed_fn, threshold=threshold) is True
+
+
+def test_c_rejects(embed_fn: EmbedFn) -> None:
+    m = build_abc_matrix()
+    sim_ab, sim_ac = _sims(embed_fn)
+    threshold = _accept_threshold(sim_ab, sim_ac)
+    assert sim_ac < threshold
+    assert verify(m.a, m.c, embed_fn=embed_fn, threshold=threshold) is False
+
+
+def test_spectral_threshold_concrete_values() -> None:
+    """Pin the spectral-standin numbers so regressions in the fixture contrast
+    (f0/formant tuning) are caught explicitly, independent of the param fixture."""
+    sim_ab, sim_ac = _sims(_spectral_embedding)
+    threshold = _accept_threshold(sim_ab, sim_ac)
+    # Same voice ~1.0, different voice well below.
+    assert sim_ab > 0.99
+    assert sim_ac < 0.6
+    assert 0.6 < threshold < 0.99
+    assert verify(*_ab_clips(), threshold=threshold) is True
+    assert verify(*_ac_clips(), threshold=threshold) is False
+
+
+def _ab_clips() -> tuple[np.ndarray, np.ndarray]:
+    m = build_abc_matrix()
+    return m.a, m.b
+
+
+def _ac_clips() -> tuple[np.ndarray, np.ndarray]:
+    m = build_abc_matrix()
+    return m.a, m.c

--- a/tests/ml/test_synthetic_audio_matrix.py
+++ b/tests/ml/test_synthetic_audio_matrix.py
@@ -1,0 +1,130 @@
+"""Determinism + structure tests for the synthetic ECAPA audio fixture matrix.
+
+Slice 250.2b Phase 1. Pure numpy. The cardinal invariant is *byte-identical
+determinism*: identical args MUST produce identical bytes, in-process and
+across separate processes (proven separately via sha256 in the verify step).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tests.ml.synthetic_audio_matrix import (
+    ALPHA,
+    BRAVO,
+    MAX_MATRIX_BYTES,
+    SAMPLE_RATE,
+    VoiceProfile,
+    build_abc_matrix,
+    estimate_matrix_bytes,
+    generate_waveform,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Byte-identical determinism
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("profile", [ALPHA, BRAVO])
+@pytest.mark.parametrize("seed", [7, 0, 42, 101, 202, 303])
+def test_byte_identical_same_args(profile: VoiceProfile, seed: int) -> None:
+    a = generate_waveform(profile, seed=seed)
+    b = generate_waveform(profile, seed=seed)
+    assert a.dtype == np.float32
+    assert b.dtype == np.float32
+    assert a.shape == (int(round(3.0 * SAMPLE_RATE)),)
+    assert b.shape == a.shape
+    assert np.array_equal(a, b)
+    assert a.tobytes() == b.tobytes()
+
+
+def test_range_within_unit_interval() -> None:
+    for profile in (ALPHA, BRAVO):
+        wf = generate_waveform(profile, seed=7)
+        assert wf.min() >= -1.0
+        assert wf.max() <= 1.0
+        # peak-normalized to 0.95 -> the magnitude should reach ~0.95
+        assert abs(np.abs(wf).max() - 0.95) < 1e-5
+
+
+def test_duration_and_sample_rate_shape() -> None:
+    wf = generate_waveform(ALPHA, seed=7, duration_s=1.5)
+    assert wf.shape == (int(round(1.5 * SAMPLE_RATE)),)
+    wf2 = generate_waveform(ALPHA, seed=7, duration_s=2.0, sample_rate=8000)
+    assert wf2.shape == (int(round(2.0 * 8000)),)
+
+
+def test_no_global_state_leakage_interleaved() -> None:
+    """Interleaving generations of different profiles/seeds must not perturb
+    any subsequent generation. Proves we never touch global RNG state."""
+    ref_alpha = generate_waveform(ALPHA, seed=7)
+    ref_bravo = generate_waveform(BRAVO, seed=11)
+
+    # Interleave a bunch of unrelated generations.
+    for s in (1, 2, 3, 999, 12345):
+        _ = generate_waveform(ALPHA, seed=s)
+        _ = generate_waveform(BRAVO, seed=s)
+
+    again_alpha = generate_waveform(ALPHA, seed=7)
+    again_bravo = generate_waveform(BRAVO, seed=11)
+
+    assert ref_alpha.tobytes() == again_alpha.tobytes()
+    assert ref_bravo.tobytes() == again_bravo.tobytes()
+
+
+def test_different_seeds_differ() -> None:
+    a = generate_waveform(ALPHA, seed=7)
+    b = generate_waveform(ALPHA, seed=8)
+    assert a.tobytes() != b.tobytes()
+
+
+def test_different_profiles_differ() -> None:
+    a = generate_waveform(ALPHA, seed=7)
+    b = generate_waveform(BRAVO, seed=7)
+    assert a.tobytes() != b.tobytes()
+
+
+# --------------------------------------------------------------------------- #
+# ABC matrix structure
+# --------------------------------------------------------------------------- #
+def test_abc_matrix_structure() -> None:
+    m = build_abc_matrix()
+    # A & B share profile ALPHA; C is BRAVO.
+    assert m.profile_a == ALPHA
+    assert m.profile_b == ALPHA
+    assert m.profile_c == BRAVO
+    # Same voice, different utterance (different seed) -> different bytes.
+    assert m.a.tobytes() != m.b.tobytes()
+    # Different voice.
+    assert m.a.tobytes() != m.c.tobytes()
+    # dtype / shape invariants
+    n = int(round(3.0 * SAMPLE_RATE))
+    for clip in (m.a, m.b, m.c):
+        assert clip.dtype == np.float32
+        assert clip.shape == (n,)
+        assert clip.min() >= -1.0
+        assert clip.max() <= 1.0
+    # seeds recorded
+    assert m.seed_a == 101
+    assert m.seed_b == 202
+    assert m.seed_c == 303
+
+
+def test_abc_matrix_deterministic() -> None:
+    m1 = build_abc_matrix()
+    m2 = build_abc_matrix()
+    assert m1.a.tobytes() == m2.a.tobytes()
+    assert m1.b.tobytes() == m2.b.tobytes()
+    assert m1.c.tobytes() == m2.c.tobytes()
+
+
+# --------------------------------------------------------------------------- #
+# Memory bound (unified-memory / Apple-Silicon 16 GB ceiling)
+# --------------------------------------------------------------------------- #
+def test_memory_bound() -> None:
+    est = estimate_matrix_bytes(3.0)
+    assert est > 0
+    assert est < MAX_MATRIX_BYTES
+    assert est < 16 * 1024**3  # far under the 16 GB RAM ceiling
+    # sanity: 3 clips * 3s * 16000 * 4 bytes ~= 576 KB
+    assert est == 3 * int(round(3.0 * SAMPLE_RATE)) * 4


### PR DESCRIPTION
## Summary
Phase 1 of the offline ML testing matrix for the ECAPA speaker-embedding pipeline — a reproducible, byte-identical synthetic A/B/C audio generator + a dual-case parity harness. **Strictly `tests/`-only** (no `unified_supervisor.py` / `backend/core/hardware` touched — built in parallel isolation alongside 250.2a).

- **Deterministic generator** (`tests/ml/synthetic_audio_matrix.py`): additive-synthesis voices `ALPHA`(f0 110 Hz) / `BRAVO`(f0 170 Hz), pure numpy, 16 kHz mono float32 ∈ [-1,1]. Seeded via `np.random.default_rng` only — **byte-identical across runs and processes** (sha256-verified).
- **A/B/C matrix**: A=ALPHA ref, B=ALPHA (same voice, different utterance → accept), C=BRAVO (different voice → reject).
- **Parity harness** (`tests/ml/test_speaker_parity_harness.py`): injectable `embed_fn`; deterministic spectral-envelope stand-in by default + a real-ECAPA seam that skips cleanly when torch/model/cloud is unavailable. sim(A,B)=0.99999 vs sim(A,C)=0.298 → **B accepts / C rejects** with margin 0.70.
- **Memory**: matrix ≈ 0.55 MiB (`MAX_MATRIX_BYTES`=16 MiB), far under the 16 GB unified-memory ceiling.

## Test Plan
- [x] 24 passed, 3 skipped (real-ECAPA seam skips in sandbox)
- [x] Byte-identity proven in-process (`np.array_equal`+`tobytes`) AND cross-process (matching sha256)
- [x] Discriminative margin asserted (`sim_ac < threshold < sim_ab`)
- [x] Memory bound asserted under 16 GB
- [x] `git status` confirms only `tests/ml/*` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic synthetic audio fixture matrix and a parity test harness for the ECAPA speaker-embedding pipeline to validate A/B accept and C reject entirely offline. Tests-only change for Slice 250.2b Phase 1; no runtime code touched.

- **New Features**
  - Deterministic generator (`tests/ml/synthetic_audio_matrix.py`): 16 kHz mono `float32` in [-1, 1], additive synthesis with `np.random.default_rng` seeding; byte-identical across runs; voices ALPHA (110 Hz) and BRAVO (170 Hz).
  - A/B/C matrix: A=ALPHA, B=ALPHA (different seed → accept), C=BRAVO (reject); size ~0.55 MiB with an asserted cap (`MAX_MATRIX_BYTES`=16 MiB).
  - Parity harness (`tests/ml/test_speaker_parity_harness.py`): deterministic spectral embedding stand-in plus a seam to real ECAPA via `backend.core.ecapa_facade` (skips if unavailable); asserts sim(A,B) > sim(A,C) with safe thresholding.
  - Determinism and structure tests (`tests/ml/test_synthetic_audio_matrix.py`): byte-identity, range, shape, seed behavior, and memory bounds.

<sup>Written for commit f7e666103639cf084a89e71e30cd6e4481bf3d03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

