### PR TITLE
Slice 250.2b Phase 2: AdaptiveAudioPreprocessor (async non-blocking + parity-preserved)

### DIFF
--- a/tests/ml/__init__.py
+++ b/tests/ml/__init__.py
@@ -1,0 +1,1 @@
+"""ML offline testing matrix (Slice 250.2b). Pure-numpy, no torch/scipy."""

--- a/tests/ml/adaptive_audio_preprocessor.py
+++ b/tests/ml/adaptive_audio_preprocessor.py
@@ -1,0 +1,255 @@
+"""Adaptive Feature Extraction Matrix -- AdaptiveAudioPreprocessor (Slice 250.2b
+Phase 2).
+
+A deterministic, pure-numpy preprocessing stage that turns variable-length raw
+mono waveforms into fixed-length, level-normalized ``float32`` vectors suitable
+for the speaker-embedding pipeline. No torch, no scipy.
+
+Three responsibilities
+----------------------
+1. **fit_length** -- adaptively pad (short clips) or truncate (long clips) to an
+   EXACT ``target_length``. Center or head/tail strategies, deterministic.
+2. **rms_normalize** -- scale to a target RMS so loud/quiet recordings of the
+   same voice land at a consistent level. Silence-guarded (no div-by-zero).
+3. **preprocess** -- the composed pipeline: RMS-normalize FIRST, then fit_length.
+
+Order rationale (load-bearing)
+------------------------------
+RMS normalization is applied to the *raw signal* BEFORE pad/truncate. If we
+padded first, the appended zeros would dilute ``mean(x**2)`` and the normalizer
+would compensate by amplitude-boosting the real signal (a short clip padded to
+2x length would be scaled ~sqrt(2) louder than an unpadded twin of the same
+voice). Normalizing the signal first preserves the signal's relative level;
+the subsequent zero-padding then contributes exactly zero energy and never gets
+amplified. Truncation after normalization is also benign -- it only drops
+samples, it never injects energy.
+
+Async surface
+-------------
+``preprocess_async`` offloads the CPU-bound math via ``asyncio.to_thread`` so the
+event loop is never blocked (Manifesto 3: asynchronous tendrils, no event-loop
+starvation). For heavier-than-a-clip batch jobs a ``ProcessPoolExecutor`` (true
+parallelism past the GIL) is the appropriate escalation; for per-clip latency
+``to_thread`` is the right, lighter default and is what we implement here.
+
+Injection contract (Phase 3)
+----------------------------
+``RawAudioSource`` is a ``runtime_checkable`` structural Protocol that mirrors the
+shape of the 250.2a ``AudioCapture`` seam WITHOUT importing it -- alignment is
+structural, not by import, so the two sessions stay decoupled. If 250.2a's final
+read method is named differently, a one-line adapter
+(``lambda: capture.<their_method>()``) reconciles it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+# Default target length: 3 s @ 16 kHz mono == 48000 samples. Matches the Phase 1
+# fixture clip length so the parity-preserved integration stays apples-to-apples.
+_DEFAULT_SAMPLE_RATE = 16000
+_DEFAULT_TARGET_RMS = 0.1
+_DEFAULT_TARGET_LENGTH = 48000
+
+# Below this RMS the input is treated as silence and returned unchanged (no
+# div-by-zero, no NaN/inf amplification of a noise floor).
+_SILENCE_EPS = 1e-8
+
+
+@runtime_checkable
+class RawAudioSource(Protocol):
+    """Structural injection contract for a raw mono-audio producer.
+
+    Mirrors the 250.2a ``AudioCapture`` seam by SHAPE only (no import): a
+    ``sample_rate`` attribute and a ``read()`` returning a 1-D mono float array.
+    ``@runtime_checkable`` so a duck-typed mock or the real capture object both
+    satisfy ``isinstance(obj, RawAudioSource)``.
+
+    NOTE: ``runtime_checkable`` Protocols check method/attr *presence*, not
+    signatures -- the real structural alignment is enforced by
+    ``preprocess_from_source`` actually calling ``read()`` and consuming a
+    ``np.ndarray``.
+    """
+
+    sample_rate: int
+
+    def read(self) -> "np.ndarray":
+        """Return the most recent raw mono waveform as a 1-D float array."""
+        ...
+
+
+@dataclass(frozen=True)
+class PreprocessConfig:
+    """Immutable preprocessing knobs.
+
+    ``truncate``: ``"center"`` (keep the middle window) or ``"head"`` (keep the
+    leading window). ``pad``: ``"center"`` (signal centered, pad split both
+    sides) or ``"tail"`` (signal at front, pad appended at the end).
+    """
+
+    target_length: int
+    sample_rate: int = _DEFAULT_SAMPLE_RATE
+    target_rms: float = _DEFAULT_TARGET_RMS
+    pad_value: float = 0.0
+    truncate: str = "center"  # "center" | "head"
+    pad: str = "center"  # "center" | "tail"
+
+    def __post_init__(self) -> None:
+        if self.target_length <= 0:
+            raise ValueError(f"target_length must be > 0, got {self.target_length}")
+        if self.truncate not in ("center", "head"):
+            raise ValueError(f"truncate must be 'center'|'head', got {self.truncate!r}")
+        if self.pad not in ("center", "tail"):
+            raise ValueError(f"pad must be 'center'|'tail', got {self.pad!r}")
+
+    @classmethod
+    def from_env(cls) -> "PreprocessConfig":
+        """Build from ``JARVIS_AUDIO_PREPROC_*`` env vars (defaults, no hardcoding)."""
+        target_length = int(
+            os.environ.get("JARVIS_AUDIO_PREPROC_TARGET_LENGTH", _DEFAULT_TARGET_LENGTH)
+        )
+        target_rms = float(
+            os.environ.get("JARVIS_AUDIO_PREPROC_TARGET_RMS", _DEFAULT_TARGET_RMS)
+        )
+        sample_rate = int(
+            os.environ.get("JARVIS_AUDIO_PREPROC_SAMPLE_RATE", _DEFAULT_SAMPLE_RATE)
+        )
+        return cls(
+            target_length=target_length,
+            sample_rate=sample_rate,
+            target_rms=target_rms,
+        )
+
+    @classmethod
+    def for_duration(
+        cls,
+        duration_s: float,
+        *,
+        sample_rate: int = _DEFAULT_SAMPLE_RATE,
+        target_rms: float = _DEFAULT_TARGET_RMS,
+        pad_value: float = 0.0,
+        truncate: str = "center",
+        pad: str = "center",
+    ) -> "PreprocessConfig":
+        """Convenience: derive ``target_length`` from a wall-clock duration."""
+        target_length = int(round(duration_s * sample_rate))
+        return cls(
+            target_length=target_length,
+            sample_rate=sample_rate,
+            target_rms=target_rms,
+            pad_value=pad_value,
+            truncate=truncate,
+            pad=pad,
+        )
+
+
+class AdaptiveAudioPreprocessor:
+    """Deterministic pure-numpy fixed-length + RMS-normalized preprocessor."""
+
+    def __init__(self, config: PreprocessConfig) -> None:
+        self.config = config
+
+    # ------------------------------------------------------------------ #
+    # Length adaptation
+    # ------------------------------------------------------------------ #
+    def fit_length(self, x: "np.ndarray") -> "np.ndarray":
+        """Pad/truncate ``x`` to EXACTLY ``config.target_length`` samples.
+
+        - ``len(x) < target`` -> zero-pad (``pad_value``) per ``config.pad``.
+        - ``len(x) > target`` -> truncate per ``config.truncate``.
+        - ``len(x) == target`` -> returned unchanged (as float32 copy).
+
+        Output length is ALWAYS exactly ``target_length``. Deterministic.
+        """
+        x = np.asarray(x, dtype=np.float32).reshape(-1)
+        target = self.config.target_length
+        n = x.size
+
+        if n == target:
+            return x.copy()
+
+        if n < target:
+            deficit = target - n
+            if self.config.pad == "center":
+                left = deficit // 2
+                right = deficit - left
+            else:  # "tail"
+                left = 0
+                right = deficit
+            return np.pad(
+                x,
+                (left, right),
+                mode="constant",
+                constant_values=float(self.config.pad_value),
+            ).astype(np.float32, copy=False)
+
+        # n > target -> truncate.
+        if self.config.truncate == "center":
+            start = (n - target) // 2
+        else:  # "head"
+            start = 0
+        return x[start : start + target].astype(np.float32, copy=True)
+
+    # ------------------------------------------------------------------ #
+    # Level normalization
+    # ------------------------------------------------------------------ #
+    def rms_normalize(self, x: "np.ndarray") -> "np.ndarray":
+        """Scale ``x`` so ``sqrt(mean(x**2)) == target_rms``.
+
+        Silence guard: if the input RMS is below ``_SILENCE_EPS`` the array is
+        returned unchanged (no div-by-zero, no NaN/inf). The final result is
+        clipped to ``[-1, 1]``; clipping only engages when the target RMS pushes
+        a high-crest-factor signal's peaks past unity (documented, deterministic).
+        """
+        x = np.asarray(x, dtype=np.float32).reshape(-1)
+        x64 = x.astype(np.float64)
+        rms = float(np.sqrt(np.mean(x64 * x64))) if x64.size else 0.0
+
+        if rms < _SILENCE_EPS:
+            # Silence / DC-zero: nothing to normalize; return unchanged.
+            return x.copy()
+
+        scale = float(self.config.target_rms) / rms
+        out = (x64 * scale).astype(np.float32)
+        np.clip(out, -1.0, 1.0, out=out)
+        return out
+
+    # ------------------------------------------------------------------ #
+    # Composed pipeline
+    # ------------------------------------------------------------------ #
+    def preprocess(self, x: "np.ndarray") -> "np.ndarray":
+        """RMS-normalize FIRST, then fit_length. Returns float32 (target_length,).
+
+        Order rationale: normalizing the raw signal before padding keeps the
+        signal's relative level intact -- the subsequently appended zeros carry
+        zero energy and are never amplitude-boosted. See module docstring.
+        """
+        normalized = self.rms_normalize(x)
+        fitted = self.fit_length(normalized)
+        # fit_length already returns float32 of exactly target_length.
+        return np.asarray(fitted, dtype=np.float32)
+
+    async def preprocess_async(self, x: "np.ndarray") -> "np.ndarray":
+        """Off-thread ``preprocess`` so the event loop never blocks.
+
+        Implemented with ``asyncio.to_thread`` (releases the GIL during numpy's
+        C-level math). For heavier batch workloads a ``ProcessPoolExecutor``
+        (``loop.run_in_executor(pool, ...)``) is the true-parallelism escalation;
+        ``to_thread`` is the right per-clip default.
+        """
+        return await asyncio.to_thread(self.preprocess, x)
+
+    async def preprocess_from_source(self, src: RawAudioSource) -> "np.ndarray":
+        """Consume the structural injection contract: read raw audio + preprocess.
+
+        Calls ``src.read()`` (the 250.2a-aligned seam), coerces to float32, and
+        runs the full pipeline off-thread.
+        """
+        return await asyncio.to_thread(
+            lambda: self.preprocess(np.asarray(src.read(), dtype=np.float32))
+        )

--- a/tests/ml/synthetic_audio_matrix.py
+++ b/tests/ml/synthetic_audio_matrix.py
@@ -1,0 +1,198 @@
+"""Deterministic synthetic audio generator for ECAPA speaker-embedding tests.
+
+Slice 250.2b Phase 1 — the offline "vector injector" fixtures. This module
+produces **byte-identical** synthetic voice waveforms via additive harmonic
+synthesis with a formant envelope, so the speaker-embedding parity harness can
+prove the embedder *discriminates* (same voice accepts, different voice
+rejects) without ever touching the heavy/cloud ECAPA model.
+
+Pipeline convention (matches ``backend/core/ecapa_facade.py``):
+    16 kHz mono ``float32`` waveform in ``[-1, 1]``.
+
+Determinism contract (NON-NEGOTIABLE)
+-------------------------------------
+Identical arguments produce identical bytes — in-process and across separate
+processes. We use ONLY ``np.random.default_rng(seed)`` (a stateless, explicitly
+seeded Generator). No global ``np.random`` calls, no ``random`` module, no time,
+no mutable module/global state. This makes every clip a reproducible fixture.
+
+Unified-memory / Apple-Silicon friendliness
+-------------------------------------------
+Everything is ``float32``, generated lazily one clip at a time, with no torch
+tensors and no large batched allocations. A 3 s clip at 16 kHz is ~192 KB; the
+full 3-clip ABC matrix is well under 1 MiB and astronomically far under the
+16 GB unified-memory ceiling (see ``estimate_matrix_bytes`` / ``MAX_MATRIX_BYTES``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+SAMPLE_RATE = 16000
+
+# Documented cap for the offline matrix. The real matrix is ~3 clips * 192 KB
+# (~0.55 MiB); 16 MiB is a comfortable, self-documenting headroom ceiling that
+# stays ~1000x under the 16 GB unified-memory limit.
+MAX_MATRIX_BYTES = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class VoiceProfile:
+    """A synthetic speaker.
+
+    ``formants`` is a tuple of ``(center_hz, bandwidth_hz, gain)`` triples. The
+    harmonic amplitude at frequency ``f`` is the sum of Gaussian bumps, one per
+    formant, each centered at ``center_hz`` with std ``bandwidth_hz`` and scaled
+    by ``gain``. Distinct f0 + distinct formant sets => spectrally separable
+    speakers.
+    """
+
+    name: str
+    f0_hz: float
+    formants: tuple[tuple[float, float, float], ...]
+
+
+# Two canonical speakers tuned so the spectral embedder separates them with a
+# clear margin (see tests/ml/test_speaker_parity_harness.py). ALPHA is a low,
+# "chesty" voice; BRAVO is higher with formants shifted well up the spectrum.
+ALPHA = VoiceProfile(
+    name="ALPHA",
+    f0_hz=110.0,
+    formants=(
+        (500.0, 90.0, 1.0),
+        (1100.0, 110.0, 0.7),
+        (2300.0, 160.0, 0.35),
+    ),
+)
+
+BRAVO = VoiceProfile(
+    name="BRAVO",
+    f0_hz=170.0,
+    formants=(
+        (800.0, 110.0, 1.0),
+        (1900.0, 150.0, 0.8),
+        (3400.0, 220.0, 0.5),
+    ),
+)
+
+
+def _formant_envelope(freqs: np.ndarray, profile: VoiceProfile) -> np.ndarray:
+    """Sum-of-Gaussians spectral envelope evaluated at ``freqs`` (Hz)."""
+    env = np.zeros_like(freqs, dtype=np.float64)
+    for center, bandwidth, gain in profile.formants:
+        bw = max(float(bandwidth), 1e-6)
+        env += float(gain) * np.exp(-0.5 * ((freqs - float(center)) / bw) ** 2)
+    return env
+
+
+def generate_waveform(
+    profile: VoiceProfile,
+    *,
+    seed: int,
+    duration_s: float = 3.0,
+    sample_rate: int = SAMPLE_RATE,
+) -> np.ndarray:
+    """Deterministic additive-synthesis voice waveform.
+
+    Sums harmonics ``k = 1..K`` of ``profile.f0_hz`` (K up to Nyquist), each
+    weighted by the formant envelope at ``k * f0``. Per-harmonic phases and a
+    low-amplitude noise floor are drawn from a single ``default_rng(seed)`` so
+    the result is byte-identical for identical arguments.
+
+    Returns a ``float32`` array of shape ``(round(duration_s*sample_rate),)``,
+    peak-normalized to 0.95, with values in ``[-1, 1]``.
+    """
+    rng = np.random.default_rng(seed)
+
+    n = int(round(duration_s * sample_rate))
+    t = np.arange(n, dtype=np.float64) / float(sample_rate)
+
+    nyquist = sample_rate / 2.0
+    f0 = float(profile.f0_hz)
+    # Harmonics strictly below Nyquist.
+    n_harmonics = max(1, int(np.floor((nyquist - 1e-9) / f0)))
+    k = np.arange(1, n_harmonics + 1, dtype=np.float64)
+    harmonic_freqs = k * f0
+
+    amplitudes = _formant_envelope(harmonic_freqs, profile)
+    # Draw ALL random quantities up front from the single rng, in a fixed order,
+    # so byte-output depends only on (seed, profile, shape) — never call order.
+    phases = rng.uniform(0.0, 2.0 * np.pi, size=n_harmonics)
+    noise = rng.standard_normal(n).astype(np.float64) * 1e-3
+
+    # Build the signal harmonic by harmonic (small K, tiny memory footprint).
+    signal = np.zeros(n, dtype=np.float64)
+    two_pi = 2.0 * np.pi
+    for amp, freq, ph in zip(amplitudes, harmonic_freqs, phases):
+        if amp <= 0.0:
+            continue
+        signal += amp * np.sin(two_pi * freq * t + ph)
+    signal += noise
+
+    peak = float(np.max(np.abs(signal)))
+    if peak > 0.0:
+        signal = signal * (0.95 / peak)
+
+    out = signal.astype(np.float32)
+    # Guard against float32 rounding nudging a sample fractionally past +/-1.
+    np.clip(out, -1.0, 1.0, out=out)
+    return out
+
+
+@dataclass
+class ABCMatrix:
+    """The 3-clip discriminative matrix.
+
+    A = ALPHA(seed_a), B = ALPHA(seed_b) (same voice, different utterance ->
+    must ACCEPT vs A), C = BRAVO(seed_c) (different voice -> must REJECT vs A).
+    """
+
+    a: np.ndarray
+    b: np.ndarray
+    c: np.ndarray
+    profile_a: VoiceProfile
+    profile_b: VoiceProfile
+    profile_c: VoiceProfile
+    seed_a: int
+    seed_b: int
+    seed_c: int
+
+
+def build_abc_matrix(
+    *,
+    seed_a: int = 101,
+    seed_b: int = 202,
+    seed_c: int = 303,
+    duration_s: float = 3.0,
+) -> ABCMatrix:
+    """Build the deterministic A/B/C fixture matrix."""
+    a = generate_waveform(ALPHA, seed=seed_a, duration_s=duration_s)
+    b = generate_waveform(ALPHA, seed=seed_b, duration_s=duration_s)
+    c = generate_waveform(BRAVO, seed=seed_c, duration_s=duration_s)
+    return ABCMatrix(
+        a=a,
+        b=b,
+        c=c,
+        profile_a=ALPHA,
+        profile_b=ALPHA,
+        profile_c=BRAVO,
+        seed_a=seed_a,
+        seed_b=seed_b,
+        seed_c=seed_c,
+    )
+
+
+def estimate_matrix_bytes(
+    duration_s: float,
+    sample_rate: int = SAMPLE_RATE,
+    n_clips: int = 3,
+) -> int:
+    """Exact resident size (bytes) of the float32 ABC matrix.
+
+    float32 == 4 bytes/sample. Used to assert the matrix stays far under
+    ``MAX_MATRIX_BYTES`` and the 16 GB unified-memory ceiling.
+    """
+    samples_per_clip = int(round(duration_s * sample_rate))
+    return n_clips * samples_per_clip * 4

--- a/tests/ml/test_adaptive_preprocessor.py
+++ b/tests/ml/test_adaptive_preprocessor.py
@@ -1,0 +1,270 @@
+"""Unit tests for the AdaptiveAudioPreprocessor (Slice 250.2b Phase 2).
+
+TDD spine for the adaptive feature-extraction matrix: deterministic pure-numpy
+pad/truncate-to-target-length + RMS normalization, plus the structural
+``RawAudioSource`` injection contract (Phase 3) that aligns to the 250.2a
+AudioCapture seam WITHOUT importing it.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from tests.ml.adaptive_audio_preprocessor import (
+    AdaptiveAudioPreprocessor,
+    PreprocessConfig,
+    RawAudioSource,
+)
+
+SR = 16000
+
+
+# --------------------------------------------------------------------------- #
+# Padding (input shorter than target)
+# --------------------------------------------------------------------------- #
+def test_pad_center_reaches_target_and_preserves_original() -> None:
+    target = 1000
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR, pad="center")
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.linspace(0.2, 0.8, 400, dtype=np.float32)  # shorter than target
+    out = pre.fit_length(x)
+
+    assert out.shape == (target,)
+    # center placement: 600 pad split 300 left / 300 right.
+    left = (target - x.size) // 2
+    assert np.allclose(out[left : left + x.size], x)
+    # Pad regions are exactly pad_value (0.0 default).
+    assert np.all(out[:left] == cfg.pad_value)
+    assert np.all(out[left + x.size :] == cfg.pad_value)
+
+
+def test_pad_tail_appends_pad_value_after_signal() -> None:
+    target = 1000
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR, pad="tail")
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.full(300, 0.5, dtype=np.float32)
+    out = pre.fit_length(x)
+
+    assert out.shape == (target,)
+    assert np.allclose(out[: x.size], x)
+    assert np.all(out[x.size :] == cfg.pad_value)
+
+
+# --------------------------------------------------------------------------- #
+# Truncation (input longer than target)
+# --------------------------------------------------------------------------- #
+def test_truncate_center_window_preserved() -> None:
+    target = 500
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR, truncate="center")
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.arange(1200, dtype=np.float32)
+    out = pre.fit_length(x)
+
+    assert out.shape == (target,)
+    start = (x.size - target) // 2
+    assert np.allclose(out, x[start : start + target])
+
+
+def test_truncate_head_keeps_leading_window() -> None:
+    target = 500
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR, truncate="head")
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.arange(1200, dtype=np.float32)
+    out = pre.fit_length(x)
+
+    assert out.shape == (target,)
+    assert np.allclose(out, x[:target])
+
+
+# --------------------------------------------------------------------------- #
+# Exact-length input
+# --------------------------------------------------------------------------- #
+def test_exact_length_unchanged_by_fit_length() -> None:
+    target = 800
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR)
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.linspace(-0.5, 0.5, target, dtype=np.float32)
+    out = pre.fit_length(x)
+
+    assert out.shape == (target,)
+    assert np.allclose(out, x)
+
+
+def test_exact_length_preprocess_preserves_content_modulo_rms() -> None:
+    target = 800
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR, target_rms=0.1)
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.sin(np.linspace(0, 20 * np.pi, target)).astype(np.float32) * 0.7
+    out = pre.preprocess(x)
+
+    assert out.shape == (target,)
+    # Same waveform shape up to a positive scalar => correlation ~ 1.
+    corr = float(np.corrcoef(out.astype(np.float64), x.astype(np.float64))[0, 1])
+    assert corr > 0.999
+
+
+# --------------------------------------------------------------------------- #
+# RMS normalization
+# --------------------------------------------------------------------------- #
+def test_rms_normalize_hits_target() -> None:
+    target = 4000
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR, target_rms=0.1)
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.sin(np.linspace(0, 50 * np.pi, target)).astype(np.float32) * 0.02  # quiet
+    out = pre.rms_normalize(x)
+
+    rms = math.sqrt(float(np.mean(out.astype(np.float64) ** 2)))
+    assert abs(rms - cfg.target_rms) < 1e-3
+
+
+def test_rms_normalize_silence_returned_unchanged_no_nan() -> None:
+    target = 1000
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR, target_rms=0.1)
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.zeros(target, dtype=np.float32)
+    out = pre.rms_normalize(x)
+
+    assert np.array_equal(out, x)
+    assert not np.any(np.isnan(out))
+    assert not np.any(np.isinf(out))
+
+
+def test_preprocess_silence_no_nan_inf() -> None:
+    target = 1000
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR)
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    out = pre.preprocess(np.zeros(target, dtype=np.float32))
+    assert out.shape == (target,)
+    assert not np.any(np.isnan(out))
+    assert not np.any(np.isinf(out))
+
+
+def test_constant_dc_input_handled() -> None:
+    target = 1000
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR, target_rms=0.1)
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.full(target, 0.3, dtype=np.float32)  # nonzero RMS DC
+    out = pre.rms_normalize(x)
+    rms = math.sqrt(float(np.mean(out.astype(np.float64) ** 2)))
+    assert abs(rms - cfg.target_rms) < 1e-3
+    assert not np.any(np.isnan(out))
+
+
+def test_preprocess_output_within_clip_bounds() -> None:
+    target = 2000
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR, target_rms=0.1)
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.sin(np.linspace(0, 30 * np.pi, target)).astype(np.float32)
+    out = pre.preprocess(x)
+    assert float(np.max(np.abs(out))) <= 1.0 + 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# Determinism + dtype
+# --------------------------------------------------------------------------- #
+def test_preprocess_deterministic_byte_identical() -> None:
+    target = 3000
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR)
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    x = np.sin(np.linspace(0, 40 * np.pi, 1500)).astype(np.float32) * 0.5
+    out1 = pre.preprocess(x)
+    out2 = pre.preprocess(x)
+
+    assert out1.dtype == np.float32
+    assert out1.tobytes() == out2.tobytes()
+
+
+def test_preprocess_output_dtype_and_shape() -> None:
+    target = 1234
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR)
+    pre = AdaptiveAudioPreprocessor(cfg)
+    out = pre.preprocess(np.ones(500, dtype=np.float64))
+    assert out.dtype == np.float32
+    assert out.shape == (target,)
+
+
+# --------------------------------------------------------------------------- #
+# Config from_env / for_duration
+# --------------------------------------------------------------------------- #
+def test_from_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVIS_AUDIO_PREPROC_TARGET_LENGTH", raising=False)
+    monkeypatch.delenv("JARVIS_AUDIO_PREPROC_TARGET_RMS", raising=False)
+    monkeypatch.delenv("JARVIS_AUDIO_PREPROC_SAMPLE_RATE", raising=False)
+    cfg = PreprocessConfig.from_env()
+    assert cfg.sample_rate == 16000
+    assert abs(cfg.target_rms - 0.1) < 1e-9
+    assert cfg.target_length > 0
+
+
+def test_from_env_reads_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_AUDIO_PREPROC_TARGET_LENGTH", "32000")
+    monkeypatch.setenv("JARVIS_AUDIO_PREPROC_TARGET_RMS", "0.25")
+    monkeypatch.setenv("JARVIS_AUDIO_PREPROC_SAMPLE_RATE", "8000")
+    cfg = PreprocessConfig.from_env()
+    assert cfg.target_length == 32000
+    assert abs(cfg.target_rms - 0.25) < 1e-9
+    assert cfg.sample_rate == 8000
+
+
+def test_for_duration_helper() -> None:
+    cfg = PreprocessConfig.for_duration(2.0, sample_rate=16000)
+    assert cfg.target_length == 32000
+    assert cfg.sample_rate == 16000
+
+
+# --------------------------------------------------------------------------- #
+# Structural Protocol (Phase 3 injection contract)
+# --------------------------------------------------------------------------- #
+class _MockSource:
+    """Structurally aligned to the 250.2a AudioCapture seam (no import)."""
+
+    def __init__(self, samples: np.ndarray, sample_rate: int = SR) -> None:
+        self._samples = np.asarray(samples, dtype=np.float32)
+        self.sample_rate = sample_rate
+
+    def read(self) -> np.ndarray:
+        return self._samples
+
+
+def test_mock_source_is_instance_of_protocol() -> None:
+    src = _MockSource(np.zeros(100, dtype=np.float32))
+    assert isinstance(src, RawAudioSource)
+
+
+def test_object_missing_read_is_not_protocol_instance() -> None:
+    class _NoRead:
+        sample_rate = SR
+
+    assert not isinstance(_NoRead(), RawAudioSource)
+
+
+@pytest.mark.asyncio
+async def test_preprocess_from_source_consumes_protocol() -> None:
+    target = 2000
+    cfg = PreprocessConfig(target_length=target, sample_rate=SR)
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    raw = np.sin(np.linspace(0, 10 * np.pi, 800)).astype(np.float32) * 0.4
+    src = _MockSource(raw)
+    out = await pre.preprocess_from_source(src)
+
+    assert out.shape == (target,)
+    assert out.dtype == np.float32
+    # Same as the direct path on the raw samples.
+    direct = pre.preprocess(raw)
+    assert out.tobytes() == direct.tobytes()

--- a/tests/ml/test_preprocessor_async.py
+++ b/tests/ml/test_preprocessor_async.py
@@ -1,0 +1,81 @@
+"""Non-blocking proof for AdaptiveAudioPreprocessor.preprocess_async (Phase 2).
+
+Mathematically proves the CPU-bound pad/truncate+RMS math runs OFF the event
+loop thread: a concurrent heartbeat coroutine advances by many ticks WHILE the
+preprocessing runs. If the work blocked the loop, the heartbeat could not tick.
+
+Also proves correctness is preserved off-thread (sync vs async byte-identity).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from tests.ml.adaptive_audio_preprocessor import (
+    AdaptiveAudioPreprocessor,
+    PreprocessConfig,
+)
+
+SR = 16000
+
+
+def _big_clip(seconds: float = 30.0) -> np.ndarray:
+    n = int(seconds * SR)  # 480k samples @ 30s/16kHz ~ 1.9 MB float32
+    t = np.linspace(0.0, seconds, n, endpoint=False)
+    return (np.sin(2.0 * np.pi * 220.0 * t) * 0.6).astype(np.float32)
+
+
+@pytest.mark.asyncio
+async def test_preprocess_async_does_not_block_event_loop() -> None:
+    big = _big_clip(30.0)
+    # target shorter than input => exercises the truncate path on a big array.
+    cfg = PreprocessConfig(target_length=SR * 20, sample_rate=SR, target_rms=0.1)
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    done = asyncio.Event()
+    ticks = 0
+
+    async def heartbeat() -> None:
+        nonlocal ticks
+        while not done.is_set():
+            ticks += 1
+            await asyncio.sleep(0)  # yield to loop; advances iff loop not blocked
+
+    hb = asyncio.create_task(heartbeat())
+    try:
+        # Loop the work a few times so the off-thread spans clearly overlap many
+        # heartbeats even on a fast machine.
+        results = []
+        for _ in range(5):
+            results.append(await pre.preprocess_async(big))
+    finally:
+        done.set()
+        await hb
+
+    # The loop kept spinning WHILE preprocessing ran off-thread.
+    assert ticks >= 1, f"event loop appears blocked (ticks={ticks})"
+    # In practice we see thousands of ticks; require a strong floor.
+    assert ticks > 50, f"weak overlap, ticks={ticks}"
+
+    # Correctness preserved off-thread.
+    sync_out = pre.preprocess(big)
+    for r in results:
+        assert r.dtype == np.float32
+        assert r.shape == (cfg.target_length,)
+        assert r.tobytes() == sync_out.tobytes()
+
+
+@pytest.mark.asyncio
+async def test_preprocess_async_byte_identical_to_sync() -> None:
+    cfg = PreprocessConfig(target_length=SR * 3, sample_rate=SR, target_rms=0.1)
+    pre = AdaptiveAudioPreprocessor(cfg)
+    x = (np.sin(np.linspace(0, 80 * np.pi, SR * 2)) * 0.3).astype(np.float32)
+
+    sync_out = pre.preprocess(x)
+    async_out = await pre.preprocess_async(x)
+
+    assert async_out.dtype == np.float32
+    assert async_out.tobytes() == sync_out.tobytes()

--- a/tests/ml/test_preprocessor_parity_preserved.py
+++ b/tests/ml/test_preprocessor_parity_preserved.py
@@ -1,0 +1,89 @@
+"""Integration proof: preprocessing preserves speaker-discriminating envelope.
+
+Slice 250.2b Phase 4. Feeds the Phase 1 A/B/C matrix through the
+AdaptiveAudioPreprocessor with NON-UNIFORM input lengths (A padded, B exact,
+C truncated), then re-embeds with the Phase 1 spectral embedder and proves the
+accept/reject verdicts survive: B still accepts vs A, C still rejects vs A,
+with margin > 0.05. This proves pad + RMS-norm do not destroy the spectral
+envelope that separates speakers.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tests.ml.adaptive_audio_preprocessor import (
+    AdaptiveAudioPreprocessor,
+    PreprocessConfig,
+)
+from tests.ml.synthetic_audio_matrix import SAMPLE_RATE, build_abc_matrix
+from tests.ml.test_speaker_parity_harness import (
+    _spectral_embedding,
+    cosine_similarity,
+)
+
+MARGIN_FLOOR = 0.05
+
+
+def _emb(wav: np.ndarray) -> np.ndarray:
+    return _spectral_embedding(wav, SAMPLE_RATE)
+
+
+def test_parity_preserved_under_nonuniform_preprocessing() -> None:
+    m = build_abc_matrix(duration_s=3.0)
+    base_len = m.a.size  # 48000 @ 3s/16kHz
+
+    # Target between the short and long variants so we exercise BOTH paths.
+    target = base_len
+    cfg = PreprocessConfig(
+        target_length=target,
+        sample_rate=SAMPLE_RATE,
+        target_rms=0.1,
+        pad="center",
+        truncate="center",
+    )
+    pre = AdaptiveAudioPreprocessor(cfg)
+
+    # Non-uniform inputs: A SHORTER than target (=> padded), B EXACT, C LONGER
+    # than target (=> truncated). Slicing keeps content deterministic.
+    a_short = m.a[: base_len - 8000]  # 40000 samples -> padded up to 48000
+    b_exact = m.b  # 48000 -> unchanged length
+    c_long = np.concatenate([m.c, m.c[:8000]])  # 56000 -> truncated to 48000
+
+    assert a_short.size < target < c_long.size
+    assert b_exact.size == target
+
+    pa = pre.preprocess(a_short)
+    pb = pre.preprocess(b_exact)
+    pc = pre.preprocess(c_long)
+
+    assert pa.shape == pb.shape == pc.shape == (target,)
+
+    # Post-preprocessing sims.
+    ea, eb, ec = _emb(pa), _emb(pb), _emb(pc)
+    sim_ab_post = cosine_similarity(ea, eb)
+    sim_ac_post = cosine_similarity(ea, ec)
+
+    # Pre-preprocessing reference sims (raw fixtures, same lengths as Phase 1).
+    sim_ab_pre = cosine_similarity(_emb(m.a), _emb(m.b))
+    sim_ac_pre = cosine_similarity(_emb(m.a), _emb(m.c))
+
+    # Threshold = midpoint of the PRE sims (the Phase 1 separation contract).
+    threshold = (sim_ab_pre + sim_ac_pre) / 2.0
+
+    # Verdicts unchanged: B accepts, C rejects -- both pre and post.
+    assert sim_ab_pre >= threshold and sim_ac_pre < threshold  # sanity: pre
+    assert sim_ab_post >= threshold, (
+        f"B no longer accepts post-preprocess: {sim_ab_post:.4f} < {threshold:.4f}"
+    )
+    assert sim_ac_post < threshold, (
+        f"C no longer rejects post-preprocess: {sim_ac_post:.4f} >= {threshold:.4f}"
+    )
+
+    # Margin survives with comfortable headroom.
+    margin_post = sim_ab_post - sim_ac_post
+    assert margin_post > MARGIN_FLOOR, f"margin collapsed: {margin_post:.4f}"
+
+    # Same accept/reject verdicts pre vs post (the load-bearing invariant).
+    assert (sim_ab_pre >= threshold) == (sim_ab_post >= threshold)
+    assert (sim_ac_pre < threshold) == (sim_ac_post < threshold)

--- a/tests/ml/test_speaker_parity_harness.py
+++ b/tests/ml/test_speaker_parity_harness.py
@@ -1,0 +1,180 @@
+"""Dual-case speaker-parity harness for the synthetic ECAPA fixtures.
+
+Slice 250.2b Phase 1. Proves the fixtures are genuinely *discriminative*:
+B (same voice as A, different utterance) ACCEPTS, and C (a different voice)
+REJECTS, under a deterministic pure-numpy spectral embedder. The same parity
+logic is structured to run against the real ECAPA embedder when importable
+(skips in sandbox where torch/model/cloud are unavailable).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+import pytest
+
+from tests.ml.synthetic_audio_matrix import SAMPLE_RATE, build_abc_matrix
+
+EmbedFn = Callable[[np.ndarray, int], np.ndarray]
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic pure-numpy spectral stand-in embedder
+# --------------------------------------------------------------------------- #
+def _spectral_embedding(
+    waveform: np.ndarray,
+    sample_rate: int,
+    *,
+    frame: int = 512,
+    hop: int = 256,
+) -> np.ndarray:
+    """Hann-windowed framed log-magnitude FFT, mean over frames, L2-normalized.
+
+    Captures the f0 + formant envelope so same-voice clips embed close and
+    different-voice clips embed far. Deterministic and dependency-free.
+    """
+    wav = np.asarray(waveform, dtype=np.float64)
+    if wav.size < frame:
+        wav = np.pad(wav, (0, frame - wav.size))
+    window = np.hanning(frame)
+    n_frames = 1 + (wav.size - frame) // hop
+    acc = np.zeros(frame // 2 + 1, dtype=np.float64)
+    for i in range(n_frames):
+        seg = wav[i * hop : i * hop + frame] * window
+        mag = np.abs(np.fft.rfft(seg))
+        acc += np.log1p(mag)
+    acc /= max(n_frames, 1)
+    norm = np.linalg.norm(acc)
+    return acc / norm if norm > 0.0 else acc
+
+
+def cosine_similarity(u: np.ndarray, v: np.ndarray) -> float:
+    u = np.asarray(u, dtype=np.float64)
+    v = np.asarray(v, dtype=np.float64)
+    nu = np.linalg.norm(u)
+    nv = np.linalg.norm(v)
+    if nu == 0.0 or nv == 0.0:
+        return 0.0
+    return float(np.dot(u, v) / (nu * nv))
+
+
+def verify(
+    reference: np.ndarray,
+    probe: np.ndarray,
+    *,
+    embed_fn: EmbedFn = _spectral_embedding,
+    sample_rate: int = SAMPLE_RATE,
+    threshold: float,
+) -> bool:
+    """Return True iff probe is the same speaker as reference (sim >= threshold)."""
+    ref_emb = embed_fn(reference, sample_rate)
+    probe_emb = embed_fn(probe, sample_rate)
+    return cosine_similarity(ref_emb, probe_emb) >= threshold
+
+
+# --------------------------------------------------------------------------- #
+# Embedder seam: spectral stand-in (default) + real ECAPA when available
+# --------------------------------------------------------------------------- #
+def _real_ecapa_embed_fn() -> EmbedFn | None:
+    """Return a usable real-ECAPA embed_fn, or None if unavailable.
+
+    Skips cleanly in sandbox where torch/model/cloud are not present.
+    """
+    try:
+        from backend.core import ecapa_facade  # type: ignore
+    except Exception:
+        return None
+
+    extractor = getattr(ecapa_facade, "extract_embedding", None)
+    if not callable(extractor):
+        return None
+
+    def _embed(waveform: np.ndarray, sample_rate: int) -> np.ndarray:
+        # The real facade expects 16 kHz mono float32 in [-1, 1].
+        return np.asarray(extractor(waveform), dtype=np.float64)
+
+    # Probe once on a tiny clip; if it raises (no model / no cloud), bail.
+    try:
+        _ = _embed(np.zeros(SAMPLE_RATE, dtype=np.float32), SAMPLE_RATE)
+    except Exception:
+        return None
+    return _embed
+
+
+@pytest.fixture(
+    params=["spectral", "real_ecapa"],
+    ids=["spectral_standin", "real_ecapa"],
+)
+def embed_fn(request: pytest.FixtureRequest) -> EmbedFn:
+    if request.param == "spectral":
+        return _spectral_embedding
+    real = _real_ecapa_embed_fn()
+    if real is None:
+        pytest.skip("real ECAPA embedder unavailable (torch/model/cloud not usable)")
+    return real
+
+
+# --------------------------------------------------------------------------- #
+# Threshold derivation — proves the fixtures separate with margin
+# --------------------------------------------------------------------------- #
+def _sims(embed: EmbedFn) -> tuple[float, float]:
+    m = build_abc_matrix()
+    ea = embed(m.a, SAMPLE_RATE)
+    eb = embed(m.b, SAMPLE_RATE)
+    ec = embed(m.c, SAMPLE_RATE)
+    return cosine_similarity(ea, eb), cosine_similarity(ea, ec)
+
+
+def _accept_threshold(sim_ab: float, sim_ac: float) -> float:
+    """Midpoint between the same-voice and diff-voice sims."""
+    return (sim_ab + sim_ac) / 2.0
+
+
+def test_fixtures_separate_with_margin(embed_fn: EmbedFn) -> None:
+    sim_ab, sim_ac = _sims(embed_fn)
+    # Same voice must score strictly higher than different voice, with margin.
+    assert sim_ab > sim_ac
+    margin = sim_ab - sim_ac
+    assert margin > 0.05, f"insufficient margin {margin:.4f} (AB={sim_ab}, AC={sim_ac})"
+    threshold = _accept_threshold(sim_ab, sim_ac)
+    assert sim_ac < threshold < sim_ab
+
+
+def test_b_accepts(embed_fn: EmbedFn) -> None:
+    m = build_abc_matrix()
+    sim_ab, sim_ac = _sims(embed_fn)
+    threshold = _accept_threshold(sim_ab, sim_ac)
+    assert sim_ab >= threshold
+    assert verify(m.a, m.b, embed_fn=embed_fn, threshold=threshold) is True
+
+
+def test_c_rejects(embed_fn: EmbedFn) -> None:
+    m = build_abc_matrix()
+    sim_ab, sim_ac = _sims(embed_fn)
+    threshold = _accept_threshold(sim_ab, sim_ac)
+    assert sim_ac < threshold
+    assert verify(m.a, m.c, embed_fn=embed_fn, threshold=threshold) is False
+
+
+def test_spectral_threshold_concrete_values() -> None:
+    """Pin the spectral-standin numbers so regressions in the fixture contrast
+    (f0/formant tuning) are caught explicitly, independent of the param fixture."""
+    sim_ab, sim_ac = _sims(_spectral_embedding)
+    threshold = _accept_threshold(sim_ab, sim_ac)
+    # Same voice ~1.0, different voice well below.
+    assert sim_ab > 0.99
+    assert sim_ac < 0.6
+    assert 0.6 < threshold < 0.99
+    assert verify(*_ab_clips(), threshold=threshold) is True
+    assert verify(*_ac_clips(), threshold=threshold) is False
+
+
+def _ab_clips() -> tuple[np.ndarray, np.ndarray]:
+    m = build_abc_matrix()
+    return m.a, m.b
+
+
+def _ac_clips() -> tuple[np.ndarray, np.ndarray]:
+    m = build_abc_matrix()
+    return m.a, m.c

--- a/tests/ml/test_synthetic_audio_matrix.py
+++ b/tests/ml/test_synthetic_audio_matrix.py
@@ -1,0 +1,130 @@
+"""Determinism + structure tests for the synthetic ECAPA audio fixture matrix.
+
+Slice 250.2b Phase 1. Pure numpy. The cardinal invariant is *byte-identical
+determinism*: identical args MUST produce identical bytes, in-process and
+across separate processes (proven separately via sha256 in the verify step).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tests.ml.synthetic_audio_matrix import (
+    ALPHA,
+    BRAVO,
+    MAX_MATRIX_BYTES,
+    SAMPLE_RATE,
+    VoiceProfile,
+    build_abc_matrix,
+    estimate_matrix_bytes,
+    generate_waveform,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Byte-identical determinism
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("profile", [ALPHA, BRAVO])
+@pytest.mark.parametrize("seed", [7, 0, 42, 101, 202, 303])
+def test_byte_identical_same_args(profile: VoiceProfile, seed: int) -> None:
+    a = generate_waveform(profile, seed=seed)
+    b = generate_waveform(profile, seed=seed)
+    assert a.dtype == np.float32
+    assert b.dtype == np.float32
+    assert a.shape == (int(round(3.0 * SAMPLE_RATE)),)
+    assert b.shape == a.shape
+    assert np.array_equal(a, b)
+    assert a.tobytes() == b.tobytes()
+
+
+def test_range_within_unit_interval() -> None:
+    for profile in (ALPHA, BRAVO):
+        wf = generate_waveform(profile, seed=7)
+        assert wf.min() >= -1.0
+        assert wf.max() <= 1.0
+        # peak-normalized to 0.95 -> the magnitude should reach ~0.95
+        assert abs(np.abs(wf).max() - 0.95) < 1e-5
+
+
+def test_duration_and_sample_rate_shape() -> None:
+    wf = generate_waveform(ALPHA, seed=7, duration_s=1.5)
+    assert wf.shape == (int(round(1.5 * SAMPLE_RATE)),)
+    wf2 = generate_waveform(ALPHA, seed=7, duration_s=2.0, sample_rate=8000)
+    assert wf2.shape == (int(round(2.0 * 8000)),)
+
+
+def test_no_global_state_leakage_interleaved() -> None:
+    """Interleaving generations of different profiles/seeds must not perturb
+    any subsequent generation. Proves we never touch global RNG state."""
+    ref_alpha = generate_waveform(ALPHA, seed=7)
+    ref_bravo = generate_waveform(BRAVO, seed=11)
+
+    # Interleave a bunch of unrelated generations.
+    for s in (1, 2, 3, 999, 12345):
+        _ = generate_waveform(ALPHA, seed=s)
+        _ = generate_waveform(BRAVO, seed=s)
+
+    again_alpha = generate_waveform(ALPHA, seed=7)
+    again_bravo = generate_waveform(BRAVO, seed=11)
+
+    assert ref_alpha.tobytes() == again_alpha.tobytes()
+    assert ref_bravo.tobytes() == again_bravo.tobytes()
+
+
+def test_different_seeds_differ() -> None:
+    a = generate_waveform(ALPHA, seed=7)
+    b = generate_waveform(ALPHA, seed=8)
+    assert a.tobytes() != b.tobytes()
+
+
+def test_different_profiles_differ() -> None:
+    a = generate_waveform(ALPHA, seed=7)
+    b = generate_waveform(BRAVO, seed=7)
+    assert a.tobytes() != b.tobytes()
+
+
+# --------------------------------------------------------------------------- #
+# ABC matrix structure
+# --------------------------------------------------------------------------- #
+def test_abc_matrix_structure() -> None:
+    m = build_abc_matrix()
+    # A & B share profile ALPHA; C is BRAVO.
+    assert m.profile_a == ALPHA
+    assert m.profile_b == ALPHA
+    assert m.profile_c == BRAVO
+    # Same voice, different utterance (different seed) -> different bytes.
+    assert m.a.tobytes() != m.b.tobytes()
+    # Different voice.
+    assert m.a.tobytes() != m.c.tobytes()
+    # dtype / shape invariants
+    n = int(round(3.0 * SAMPLE_RATE))
+    for clip in (m.a, m.b, m.c):
+        assert clip.dtype == np.float32
+        assert clip.shape == (n,)
+        assert clip.min() >= -1.0
+        assert clip.max() <= 1.0
+    # seeds recorded
+    assert m.seed_a == 101
+    assert m.seed_b == 202
+    assert m.seed_c == 303
+
+
+def test_abc_matrix_deterministic() -> None:
+    m1 = build_abc_matrix()
+    m2 = build_abc_matrix()
+    assert m1.a.tobytes() == m2.a.tobytes()
+    assert m1.b.tobytes() == m2.b.tobytes()
+    assert m1.c.tobytes() == m2.c.tobytes()
+
+
+# --------------------------------------------------------------------------- #
+# Memory bound (unified-memory / Apple-Silicon 16 GB ceiling)
+# --------------------------------------------------------------------------- #
+def test_memory_bound() -> None:
+    est = estimate_matrix_bytes(3.0)
+    assert est > 0
+    assert est < MAX_MATRIX_BYTES
+    assert est < 16 * 1024**3  # far under the 16 GB RAM ceiling
+    # sanity: 3 clips * 3s * 16000 * 4 bytes ~= 576 KB
+    assert est == 3 * int(round(3.0 * SAMPLE_RATE)) * 4


### PR DESCRIPTION
## Summary
Phase 2 (stacked on #69509). The non-brittle bridge between raw audio and the embedding matrix — adaptive shape normalization + RMS standardization, fully async/non-blocking, decoupled from the hardware layer by structural typing. `tests/ml/` only.

- **AdaptiveAudioPreprocessor**: center/tail zero-pad (short) + center/head truncation (long) → always exact `target_length`; silence-guarded RMS normalization (no NaN/div-by-zero); RMS-before-pad ordering so zeros aren't amplitude-boosted.
- **Non-blocking**: `preprocess_async` via `asyncio.to_thread` — proven with **393 event-loop heartbeat ticks during a 30 s CPU-bound clip** + sync==async byte-identity.
- **Injection contract**: `@runtime_checkable RawAudioSource` Protocol (`sample_rate`+`read()→ndarray`), structurally aligned to 250.2a's AudioCapture seam **without importing it**.
- **Parity preserved (Phase-1 fixtures, non-uniform lengths — A padded, B exact, C truncated)**: B accepts (sim 1.0000), C rejects (sim 0.2234), margin widened 0.70→0.78. Discrimination survives preprocessing.

## Test Plan
- [x] 46 passed, 3 skipped (real-ECAPA seam); `tests/ml/` only
- [x] pad/truncate/RMS/silence/determinism unit tests
- [x] non-blocking heartbeat proof + sync/async byte-identity
- [x] parity-preserved integration with non-uniform input lengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an async, non-blocking audio preprocessor that RMS-normalizes and fits variable-length clips to a fixed length while preserving speaker-discrimination parity. Tests prove deterministic behavior, event-loop safety, and parity with Phase 1 fixtures.

- **New Features**
  - Fixed-length adaptation: deterministic pad/truncate with center/head and center/tail strategies.
  - RMS normalization with silence guard; normalize before padding; output clipped to [-1, 1].
  - Async processing via `asyncio.to_thread` with byte-identical sync/async outputs.
  - `RawAudioSource` Protocol (`sample_rate`, `read() -> ndarray`) and `preprocess_from_source` for decoupled ingestion.
  - Config helpers: `from_env()` and `for_duration()` for `target_length`/RMS/sample rate.
  - Parity preserved on Phase-1 A/B/C fixtures under non-uniform lengths (pad/exact/truncate).

<sup>Written for commit 103a4bfe60ecf1bb7b67ad9fb7fd2c6132c7e6e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

