### PR TITLE
Slice 250.2b Phase 3: BiometricExecutionMatrix + Zero-Trust OOM Circuit Breaker

### DIFF
--- a/tests/ml/biometric_execution_matrix.py
+++ b/tests/ml/biometric_execution_matrix.py
@@ -1,0 +1,426 @@
+"""BiometricExecutionMatrix & Zero-Trust OOM Circuit Breaker (Slice 250.2b
+Phase 3 — "The ECAPA Execution Matrix").
+
+A SYNCHRONOUS, fail-secure speaker-authentication front-end for the ECAPA
+embedder. Its single load-bearing guarantee:
+
+    Under ANY failure — circuit open, unified-memory / Metal OOM, or a generic
+    extractor error — the verdict is REJECTED (locked). The matrix NEVER returns
+    ACCEPTED on an error path.
+
+Why a circuit breaker, and why fail-secure
+------------------------------------------
+On Apple-Silicon unified memory, an ECAPA forward pass can raise ``MemoryError``
+under RAM pressure. A naive auth front-end might (a) treat an exception as
+"inconclusive" and fall through to ACCEPT, or (b) keep hammering the OOMing
+extractor. Both are unacceptable for a biometric gate. So:
+
+  * OOM (and designated RAM-pressure errors) → record a breaker failure and
+    return the secure-lock verdict SYNCHRONOUSLY. Telemetry (RESOURCE_PRESSURE
+    event + Slice-254 diagnostic swarm dispatch) fires FIRE-AND-FORGET so it can
+    never delay or alter the verdict.
+  * Sustained OOMs trip the breaker; while open, ``authenticate`` short-circuits
+    to ``circuit_open_locked`` WITHOUT ever invoking the embedder — protecting
+    the pipeline from a thundering OOM herd.
+
+Structural injection (NO backend imports — split-brain-guard safe)
+------------------------------------------------------------------
+Everything the kernel provides is consumed by SHAPE, never by import:
+
+  * ``CircuitBreakerLike`` (Protocol) — structurally aligned to the supervisor's
+    ``AdvancedCircuitBreaker``. Production injects the real one; this module
+    ships a standalone ``LocalOOMCircuitBreaker`` default so the matrix works
+    without the kernel.
+  * ``Embedder = Callable[[np.ndarray], np.ndarray]`` — the ECAPA extractor. In
+    production pass ``ecapa_facade.extract_embedding`` (a thin sync adapter over
+    the async facade) or any callable; in tests pass a deterministic stand-in or
+    a failing one. ``try_default_ecapa_embedder`` LAZILY probes the facade and
+    returns ``None`` if unavailable (no module-scope import).
+  * ``EventSink = Callable[[str, dict], None]`` — structurally the
+    ``SupervisorEventBus`` emit ``(event_type, payload)``. Production wraps
+    ``get_event_bus().emit(...)``.
+  * ``SwarmTrigger = Callable[[dict], Any]`` — structurally the Slice-254
+    ``DiagnosticSubAgent`` swarm dispatch.
+
+Pure numpy. No torch, no scipy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Optional, Protocol, runtime_checkable
+
+import numpy as np
+
+# --------------------------------------------------------------------------- #
+# Injection contracts (duck-typed — never imported from the kernel)
+# --------------------------------------------------------------------------- #
+Embedder = Callable[[np.ndarray], np.ndarray]
+EventSink = Callable[[str, dict], Any]
+SwarmTrigger = Callable[[dict], Any]
+
+
+@runtime_checkable
+class CircuitBreakerLike(Protocol):
+    """Structural alignment with the supervisor's ``AdvancedCircuitBreaker``.
+
+    Only these three methods are consumed. ``@runtime_checkable`` so either a
+    duck-typed fake or the real breaker satisfies ``isinstance``.
+    """
+
+    def can_execute(self) -> bool:
+        ...
+
+    def record_success(self) -> None:
+        ...
+
+    def record_failure(self, error: Optional[BaseException] = None) -> None:
+        ...
+
+
+# Error classes treated as RAM-pressure (fire RESOURCE_PRESSURE telemetry).
+# Tuple so production can extend via the env knob below without code change here.
+_RAM_PRESSURE_ERRORS: tuple[type[BaseException], ...] = (MemoryError,)
+
+
+# --------------------------------------------------------------------------- #
+# Standalone default breaker (importable, kernel-free)
+# --------------------------------------------------------------------------- #
+class LocalOOMCircuitBreaker:
+    """Minimal failure-threshold + reset-timeout breaker.
+
+    Structurally a ``CircuitBreakerLike``. Trips OPEN after ``failure_threshold``
+    consecutive failures; after ``reset_timeout_s`` elapses it goes HALF-OPEN
+    (``can_execute`` returns True again to permit one trial). A success resets
+    the failure count to zero. Env-tunable defaults so production can inject the
+    real ``AdvancedCircuitBreaker`` or rely on this without code edits.
+    """
+
+    def __init__(
+        self,
+        *,
+        failure_threshold: Optional[int] = None,
+        reset_timeout_s: Optional[float] = None,
+    ) -> None:
+        self.failure_threshold = int(
+            failure_threshold
+            if failure_threshold is not None
+            else os.environ.get("JARVIS_ECAPA_BREAKER_FAILURE_THRESHOLD", 5)
+        )
+        self.reset_timeout_s = float(
+            reset_timeout_s
+            if reset_timeout_s is not None
+            else os.environ.get("JARVIS_ECAPA_BREAKER_RESET_TIMEOUT_S", 30.0)
+        )
+        self._failures = 0
+        self._opened_at: Optional[float] = None
+        self._lock = threading.Lock()
+
+    def can_execute(self) -> bool:
+        with self._lock:
+            if self._opened_at is None:
+                return True
+            # Open: allow a half-open trial once the reset window has elapsed.
+            if (time.monotonic() - self._opened_at) >= self.reset_timeout_s:
+                return True
+            return False
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._failures = 0
+            self._opened_at = None
+
+    def record_failure(self, error: Optional[BaseException] = None) -> None:
+        with self._lock:
+            self._failures += 1
+            if self._failures >= self.failure_threshold:
+                self._opened_at = time.monotonic()
+
+
+# --------------------------------------------------------------------------- #
+# Lazy ECAPA probe — NO module-scope import of the facade.
+# --------------------------------------------------------------------------- #
+def try_default_ecapa_embedder() -> Optional[Embedder]:
+    """Lazily probe ``backend.core.ecapa_facade.extract_embedding``.
+
+    Returns a single-arg ``Embedder`` if the facade is importable and callable,
+    else ``None`` (sandbox / no torch / no model). Imported INSIDE the function
+    so this module never imports the kernel at module scope.
+    """
+    try:
+        from backend.core import ecapa_facade  # type: ignore
+    except Exception:
+        return None
+    extractor = getattr(ecapa_facade, "extract_embedding", None)
+    if not callable(extractor):
+        return None
+
+    def _embed(x: np.ndarray) -> np.ndarray:
+        return np.asarray(extractor(x), dtype=np.float64)
+
+    return _embed
+
+
+# --------------------------------------------------------------------------- #
+# Verdict + result
+# --------------------------------------------------------------------------- #
+class Verdict(str, Enum):
+    ACCEPTED = "verdict_accepted"
+    REJECTED = "verdict_rejected"
+
+
+@dataclass(frozen=True)
+class AuthResult:
+    verdict: Verdict
+    score: float
+    reason: str
+
+
+def _cosine_similarity(u: np.ndarray, v: np.ndarray) -> float:
+    """L2-cosine similarity; 0.0 for a zero vector (no NaN)."""
+    u = np.asarray(u, dtype=np.float64).reshape(-1)
+    v = np.asarray(v, dtype=np.float64).reshape(-1)
+    nu = float(np.linalg.norm(u))
+    nv = float(np.linalg.norm(v))
+    if nu == 0.0 or nv == 0.0:
+        return 0.0
+    return float(np.dot(u, v) / (nu * nv))
+
+
+# --------------------------------------------------------------------------- #
+# The matrix
+# --------------------------------------------------------------------------- #
+class BiometricExecutionMatrix:
+    """Synchronous, fail-secure ECAPA speaker-authentication front-end."""
+
+    def __init__(
+        self,
+        *,
+        embedder: Embedder,
+        baseline_embedding: np.ndarray,
+        accept_threshold: float,
+        breaker: Optional[CircuitBreakerLike] = None,
+        event_sink: Optional[EventSink] = None,
+        swarm_trigger: Optional[SwarmTrigger] = None,
+    ) -> None:
+        self._embedder = embedder
+        self._baseline = np.asarray(baseline_embedding, dtype=np.float64).reshape(-1)
+        self._accept_threshold = float(accept_threshold)
+        self.breaker: CircuitBreakerLike = (
+            breaker if breaker is not None else LocalOOMCircuitBreaker()
+        )
+        self._event_sink = event_sink
+        self._swarm_trigger = swarm_trigger
+        # Strong refs to fire-and-forget telemetry tasks so they are not GC'd
+        # mid-flight (asyncio holds only weak refs to bare tasks).
+        self._pending_tasks: set[asyncio.Task] = set()
+
+    # ------------------------------------------------------------------ #
+    # The headline: synchronous, fail-secure authentication.
+    # ------------------------------------------------------------------ #
+    def authenticate(self, uniform_tensor: np.ndarray) -> AuthResult:
+        # 1. Breaker open -> stay locked. Embedder is NEVER called.
+        if not self.breaker.can_execute():
+            return AuthResult(Verdict.REJECTED, 0.0, "circuit_open_locked")
+
+        # 2. Try the extractor.
+        try:
+            emb = self._embedder(uniform_tensor)
+            self.breaker.record_success()
+            score = _cosine_similarity(emb, self._baseline)
+            verdict = (
+                Verdict.ACCEPTED
+                if score >= self._accept_threshold
+                else Verdict.REJECTED
+            )
+            return AuthResult(verdict, score, "evaluated")
+
+        # 3. RAM-pressure failure -> FAIL SECURE + async telemetry, sync return.
+        except _RAM_PRESSURE_ERRORS as err:
+            self.breaker.record_failure(err)
+            # Fire telemetry/swarm fire-and-forget BEFORE returning, but it must
+            # never block or alter the secure-lock verdict below.
+            self._emit_pressure_async(
+                {
+                    "component": "ecapa",
+                    "error_class": type(err).__name__,
+                    "error_message": str(err),
+                    "rss_hint": self._rss_hint(),
+                    "verdict": Verdict.REJECTED.value,
+                    "reason": "oom_fail_secure",
+                }
+            )
+            return AuthResult(Verdict.REJECTED, 0.0, "oom_fail_secure")
+
+        # 4. Any other error -> also fail secure (no telemetry — not RAM class).
+        except Exception as err:  # noqa: BLE001 — fail-secure is the contract.
+            try:
+                self.breaker.record_failure(err)
+            except Exception:
+                pass
+            return AuthResult(Verdict.REJECTED, 0.0, "error_fail_secure")
+
+    # ------------------------------------------------------------------ #
+    # Fire-and-forget telemetry — NEVER blocks, NEVER raises, NEVER delays.
+    # ------------------------------------------------------------------ #
+    def _emit_pressure_async(self, payload: dict) -> None:
+        """Dispatch RESOURCE_PRESSURE telemetry + swarm trigger out-of-band.
+
+        Guarantees:
+          * Returns immediately (does not await the sinks).
+          * Any failure is swallowed (telemetry never affects the verdict).
+          * If a running loop exists, schedules a task (strong-ref'd, no-GC).
+          * If no running loop, fires best-effort on a daemon thread.
+        """
+        try:
+            if self._event_sink is None and self._swarm_trigger is None:
+                return
+
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+
+            if loop is not None:
+                task = loop.create_task(self._dispatch_async(payload))
+                self._pending_tasks.add(task)
+                task.add_done_callback(self._pending_tasks.discard)
+            else:
+                thread = threading.Thread(
+                    target=self._dispatch_sync,
+                    args=(payload,),
+                    name="ecapa-resource-pressure",
+                    daemon=True,
+                )
+                thread.start()
+        except Exception:
+            # Telemetry dispatch must never propagate.
+            pass
+
+    async def _dispatch_async(self, payload: dict) -> None:
+        """Fire both sinks CONCURRENTLY; each guarded independently so a slow or
+        failing event sink can never stall (or starve) the swarm dispatch."""
+        await asyncio.gather(
+            self._call_sink_maybe_async(
+                self._event_sink, "resource_pressure", payload
+            ),
+            self._call_trigger_maybe_async(self._swarm_trigger, payload),
+        )
+
+    def _dispatch_sync(self, payload: dict) -> None:
+        """Best-effort synchronous dispatch on a daemon thread (no loop)."""
+        if self._event_sink is not None:
+            try:
+                res = self._event_sink("resource_pressure", payload)
+                self._drain_if_coro(res)
+            except Exception:
+                pass
+        if self._swarm_trigger is not None:
+            try:
+                res = self._swarm_trigger(payload)
+                self._drain_if_coro(res)
+            except Exception:
+                pass
+
+    @staticmethod
+    def _drain_if_coro(res: Any) -> None:
+        """If a sink returned a coroutine in a sync context, run it to completion
+        on a throwaway loop so it doesn't leak — best-effort, errors swallowed."""
+        if asyncio.iscoroutine(res):
+            try:
+                asyncio.run(res)
+            except Exception:
+                pass
+
+    @staticmethod
+    async def _call_sink_maybe_async(
+        sink: Optional[EventSink], event_type: str, payload: dict
+    ) -> None:
+        if sink is None:
+            return
+        try:
+            res = sink(event_type, payload)
+            if asyncio.iscoroutine(res):
+                await res
+        except Exception:
+            pass
+
+    @staticmethod
+    async def _call_trigger_maybe_async(
+        trigger: Optional[SwarmTrigger], payload: dict
+    ) -> None:
+        if trigger is None:
+            return
+        try:
+            res = trigger(payload)
+            if asyncio.iscoroutine(res):
+                await res
+        except Exception:
+            pass
+
+    @staticmethod
+    def _rss_hint() -> Optional[float]:
+        """Best-effort resident-set-size hint (MiB). None if unavailable.
+
+        stdlib-only probe (``resource``); never raises. Documents the pressure
+        snapshot at the moment of the OOM for the diagnostic swarm.
+        """
+        try:
+            import resource  # POSIX-only; lazy + guarded.
+
+            ru = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            # Linux reports KiB, macOS reports bytes; normalize roughly to MiB.
+            import sys
+
+            divisor = 1024.0 * 1024.0 if sys.platform == "darwin" else 1024.0
+            return float(ru) / divisor
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------ #
+    # Optional async surface (awaits a coroutine embedder if provided).
+    # ------------------------------------------------------------------ #
+    async def authenticate_async(self, uniform_tensor: np.ndarray) -> AuthResult:
+        """Async variant: awaits the embedder if it is a coroutine function.
+
+        Same fail-secure contract as the sync path. The headline remains the
+        synchronous ``authenticate``; this is a convenience for an async ECAPA
+        facade.
+        """
+        if not self.breaker.can_execute():
+            return AuthResult(Verdict.REJECTED, 0.0, "circuit_open_locked")
+        try:
+            res = self._embedder(uniform_tensor)
+            emb = await res if asyncio.iscoroutine(res) else res
+            self.breaker.record_success()
+            score = _cosine_similarity(emb, self._baseline)
+            verdict = (
+                Verdict.ACCEPTED
+                if score >= self._accept_threshold
+                else Verdict.REJECTED
+            )
+            return AuthResult(verdict, score, "evaluated")
+        except _RAM_PRESSURE_ERRORS as err:
+            self.breaker.record_failure(err)
+            self._emit_pressure_async(
+                {
+                    "component": "ecapa",
+                    "error_class": type(err).__name__,
+                    "error_message": str(err),
+                    "rss_hint": self._rss_hint(),
+                    "verdict": Verdict.REJECTED.value,
+                    "reason": "oom_fail_secure",
+                }
+            )
+            return AuthResult(Verdict.REJECTED, 0.0, "oom_fail_secure")
+        except Exception as err:  # noqa: BLE001
+            try:
+                self.breaker.record_failure(err)
+            except Exception:
+                pass
+            return AuthResult(Verdict.REJECTED, 0.0, "error_fail_secure")

--- a/tests/ml/test_biometric_execution_matrix.py
+++ b/tests/ml/test_biometric_execution_matrix.py
@@ -1,0 +1,184 @@
+"""BiometricExecutionMatrix — happy-path + fail-secure unit tests.
+
+Slice 250.2b Phase 3. Proves the synchronous, fail-secure authentication
+verdict path: real-fixture ACCEPT/REJECT discrimination (reusing Phase 1/2),
+breaker-open short-circuit (embedder never called), and generic-error
+fail-secure (REJECTED + record_failure).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+import pytest
+
+from tests.ml.adaptive_audio_preprocessor import (
+    AdaptiveAudioPreprocessor,
+    PreprocessConfig,
+)
+from tests.ml.biometric_execution_matrix import (
+    AuthResult,
+    BiometricExecutionMatrix,
+    LocalOOMCircuitBreaker,
+    Verdict,
+)
+from tests.ml.synthetic_audio_matrix import SAMPLE_RATE, build_abc_matrix
+from tests.ml.test_speaker_parity_harness import (
+    _accept_threshold,
+    _spectral_embedding,
+    cosine_similarity,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers — adapt the (waveform, sample_rate) spectral fn into the single-arg
+# Embedder contract Callable[[np.ndarray], np.ndarray].
+# --------------------------------------------------------------------------- #
+def _single_arg_spectral() -> Callable[[np.ndarray], np.ndarray]:
+    return lambda wav: _spectral_embedding(wav, SAMPLE_RATE)
+
+
+def _real_pipeline() -> tuple[
+    Callable[[np.ndarray], np.ndarray], np.ndarray, np.ndarray, np.ndarray, float
+]:
+    """Build the embedder, baseline (A), B-probe, C-probe, and threshold using
+    the Phase 1 fixtures + Phase 2 preprocessor + Phase 1 spectral embedder."""
+    m = build_abc_matrix()
+    pre = AdaptiveAudioPreprocessor(
+        PreprocessConfig.for_duration(3.0, sample_rate=SAMPLE_RATE)
+    )
+    a = pre.preprocess(m.a)
+    b = pre.preprocess(m.b)
+    c = pre.preprocess(m.c)
+    embed = _single_arg_spectral()
+    baseline = embed(a)
+    # Threshold derived exactly as the parity harness does, on the same
+    # preprocessed clips (midpoint between same-voice and diff-voice sims).
+    sim_ab = cosine_similarity(baseline, embed(b))
+    sim_ac = cosine_similarity(baseline, embed(c))
+    threshold = _accept_threshold(sim_ab, sim_ac)
+    return embed, baseline, b, c, threshold
+
+
+# --------------------------------------------------------------------------- #
+# Happy path — real fixtures
+# --------------------------------------------------------------------------- #
+def test_happy_path_b_accepts_c_rejects() -> None:
+    embed, baseline, b, c, threshold = _real_pipeline()
+    matrix = BiometricExecutionMatrix(
+        embedder=embed,
+        baseline_embedding=baseline,
+        accept_threshold=threshold,
+    )
+
+    res_b = matrix.authenticate(b)
+    assert isinstance(res_b, AuthResult)
+    assert res_b.verdict is Verdict.ACCEPTED
+    assert res_b.score >= threshold
+    assert res_b.reason == "evaluated"
+
+    res_c = matrix.authenticate(c)
+    assert res_c.verdict is Verdict.REJECTED
+    assert res_c.score < threshold
+    assert res_c.reason == "evaluated"
+
+
+# --------------------------------------------------------------------------- #
+# Breaker-open fail-secure: embedder is NEVER called.
+# --------------------------------------------------------------------------- #
+class _OpenBreaker:
+    """can_execute() always False — the circuit is open/locked."""
+
+    def __init__(self) -> None:
+        self.failures = 0
+        self.successes = 0
+
+    def can_execute(self) -> bool:
+        return False
+
+    def record_success(self) -> None:
+        self.successes += 1
+
+    def record_failure(self, error=None) -> None:
+        self.failures += 1
+
+
+class _SpyEmbedder:
+    def __init__(self, ret: np.ndarray | None = None) -> None:
+        self.calls = 0
+        self._ret = ret if ret is not None else np.ones(4, dtype=np.float64)
+
+    def __call__(self, x: np.ndarray) -> np.ndarray:
+        self.calls += 1
+        return self._ret
+
+
+def test_breaker_open_fails_secure_without_calling_embedder() -> None:
+    spy = _SpyEmbedder()
+    matrix = BiometricExecutionMatrix(
+        embedder=spy,
+        baseline_embedding=np.ones(4, dtype=np.float64),
+        accept_threshold=0.5,
+        breaker=_OpenBreaker(),
+    )
+
+    res = matrix.authenticate(np.zeros(16, dtype=np.float64))
+
+    assert res.verdict is Verdict.REJECTED
+    assert res.reason == "circuit_open_locked"
+    assert res.score == 0.0
+    assert spy.calls == 0, "embedder MUST NOT be called when the breaker is open"
+
+
+# --------------------------------------------------------------------------- #
+# Non-OOM (generic) error fail-secure: REJECTED + record_failure.
+# --------------------------------------------------------------------------- #
+class _CountingBreaker:
+    def __init__(self) -> None:
+        self.failures: list = []
+        self.successes = 0
+        self._open = False
+
+    def can_execute(self) -> bool:
+        return not self._open
+
+    def record_success(self) -> None:
+        self.successes += 1
+
+    def record_failure(self, error=None) -> None:
+        self.failures.append(error)
+
+
+def test_generic_error_fails_secure() -> None:
+    def _boom(_x: np.ndarray) -> np.ndarray:
+        raise ValueError("bad input")
+
+    breaker = _CountingBreaker()
+    matrix = BiometricExecutionMatrix(
+        embedder=_boom,
+        baseline_embedding=np.ones(4, dtype=np.float64),
+        accept_threshold=0.5,
+        breaker=breaker,
+    )
+
+    res = matrix.authenticate(np.zeros(16, dtype=np.float64))
+
+    assert res.verdict is Verdict.REJECTED
+    assert res.reason == "error_fail_secure"
+    assert res.score == 0.0
+    assert len(breaker.failures) == 1
+    assert isinstance(breaker.failures[0], ValueError)
+
+
+# --------------------------------------------------------------------------- #
+# Default breaker is a standalone LocalOOMCircuitBreaker
+# --------------------------------------------------------------------------- #
+def test_default_breaker_is_local_oom_breaker() -> None:
+    matrix = BiometricExecutionMatrix(
+        embedder=_single_arg_spectral(),
+        baseline_embedding=np.ones(4, dtype=np.float64),
+        accept_threshold=0.5,
+    )
+    assert isinstance(matrix.breaker, LocalOOMCircuitBreaker)
+    assert matrix.breaker.can_execute() is True

--- a/tests/ml/test_oom_circuit_breaker.py
+++ b/tests/ml/test_oom_circuit_breaker.py
@@ -1,0 +1,279 @@
+"""Zero-Trust OOM Circuit Breaker — the headline integration proof.
+
+Slice 250.2b Phase 3. Proves that under unified-memory / Metal OOM during
+ECAPA extraction, the BiometricExecutionMatrix:
+
+  1. SYNCHRONOUSLY returns the secure-lock verdict (REJECTED, oom_fail_secure)
+     — never delayed by telemetry, never ACCEPTED.
+  2. Records the failure on the injected breaker.
+  3. Fires async RESOURCE_PRESSURE telemetry to the event sink AND dispatches
+     the Slice-254 diagnostic swarm — non-blocking.
+  4. Trips the breaker after N sustained OOMs, after which authenticate
+     short-circuits to circuit_open_locked WITHOUT invoking the embedder.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from tests.ml.biometric_execution_matrix import (
+    BiometricExecutionMatrix,
+    LocalOOMCircuitBreaker,
+    Verdict,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Spies
+# --------------------------------------------------------------------------- #
+class _SpyBreaker:
+    def __init__(self) -> None:
+        self.failures: list = []
+        self.successes = 0
+
+    def can_execute(self) -> bool:
+        return True
+
+    def record_success(self) -> None:
+        self.successes += 1
+
+    def record_failure(self, error=None) -> None:
+        self.failures.append(error)
+
+
+class _EventSpy:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+        self.lock = threading.Lock()
+
+    def __call__(self, event_type: str, payload: dict) -> None:
+        with self.lock:
+            self.events.append((event_type, payload))
+
+
+class _SwarmSpy:
+    def __init__(self) -> None:
+        self.payloads: list[dict] = []
+        self.lock = threading.Lock()
+
+    def __call__(self, payload: dict):
+        with self.lock:
+            self.payloads.append(payload)
+
+
+def _oom_embedder(_x: np.ndarray) -> np.ndarray:
+    raise MemoryError("Metal/unified-memory OOM")
+
+
+# --------------------------------------------------------------------------- #
+# OOM during extraction — sync REJECT + record_failure + async telemetry
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_oom_sync_reject_and_async_telemetry() -> None:
+    breaker = _SpyBreaker()
+    sink = _EventSpy()
+    swarm = _SwarmSpy()
+    matrix = BiometricExecutionMatrix(
+        embedder=_oom_embedder,
+        baseline_embedding=np.ones(4, dtype=np.float64),
+        accept_threshold=0.5,
+        breaker=breaker,
+        event_sink=sink,
+        swarm_trigger=swarm,
+    )
+
+    res = matrix.authenticate(np.zeros(16, dtype=np.float64))
+
+    # 1. Secure-lock verdict, synchronously.
+    assert res.verdict is Verdict.REJECTED
+    assert res.reason == "oom_fail_secure"
+    assert res.score == 0.0
+
+    # 2. Failure recorded on the breaker.
+    assert len(breaker.failures) == 1
+    assert isinstance(breaker.failures[0], MemoryError)
+
+    # 3. Let the async telemetry tasks run.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    assert len(sink.events) == 1
+    event_type, payload = sink.events[0]
+    assert event_type == "resource_pressure"
+    assert payload["component"] == "ecapa"
+    assert "MemoryError" in payload["error_class"]
+    assert "rss_hint" in payload
+
+    assert len(swarm.payloads) == 1
+    assert swarm.payloads[0]["component"] == "ecapa"
+    assert "MemoryError" in swarm.payloads[0]["error_class"]
+
+
+# --------------------------------------------------------------------------- #
+# Non-blocking proof: a SLOW sink must NOT delay the secure-lock verdict.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_verdict_not_blocked_by_slow_telemetry() -> None:
+    sink_completed_at: list[float] = []
+    slow_delay = 0.30
+
+    async def _slow_sink(event_type: str, payload: dict) -> None:
+        await asyncio.sleep(slow_delay)
+        sink_completed_at.append(time.monotonic())
+
+    swarm_completed_at: list[float] = []
+
+    async def _slow_swarm(payload: dict) -> None:
+        await asyncio.sleep(slow_delay)
+        swarm_completed_at.append(time.monotonic())
+
+    matrix = BiometricExecutionMatrix(
+        embedder=_oom_embedder,
+        baseline_embedding=np.ones(4, dtype=np.float64),
+        accept_threshold=0.5,
+        breaker=_SpyBreaker(),
+        event_sink=_slow_sink,
+        swarm_trigger=_slow_swarm,
+    )
+
+    t0 = time.monotonic()
+    res = matrix.authenticate(np.zeros(16, dtype=np.float64))
+    verdict_at = time.monotonic()
+
+    # The verdict returns essentially immediately — well before the slow sink.
+    assert res.verdict is Verdict.REJECTED
+    assert res.reason == "oom_fail_secure"
+    verdict_latency = verdict_at - t0
+    assert verdict_latency < slow_delay, (
+        f"verdict took {verdict_latency:.4f}s — should be << slow sink {slow_delay}s"
+    )
+
+    # Now drain the loop so the slow telemetry actually completes.
+    await asyncio.sleep(slow_delay + 0.1)
+    assert sink_completed_at, "slow sink should eventually complete"
+    assert swarm_completed_at, "slow swarm should eventually complete"
+
+    # Ordering: verdict returned strictly before the slow sink completed.
+    assert verdict_at < sink_completed_at[0]
+    assert verdict_at < swarm_completed_at[0]
+
+
+# --------------------------------------------------------------------------- #
+# No running loop: telemetry still fires best-effort on a daemon thread.
+# --------------------------------------------------------------------------- #
+def test_oom_telemetry_fires_without_running_loop() -> None:
+    breaker = _SpyBreaker()
+    sink = _EventSpy()
+    swarm = _SwarmSpy()
+    matrix = BiometricExecutionMatrix(
+        embedder=_oom_embedder,
+        baseline_embedding=np.ones(4, dtype=np.float64),
+        accept_threshold=0.5,
+        breaker=breaker,
+        event_sink=sink,
+        swarm_trigger=swarm,
+    )
+
+    # Called from a plain sync context (no running event loop).
+    res = matrix.authenticate(np.zeros(16, dtype=np.float64))
+    assert res.verdict is Verdict.REJECTED
+    assert res.reason == "oom_fail_secure"
+
+    # Give the daemon thread a brief moment to fire best-effort.
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and not sink.events:
+        time.sleep(0.01)
+
+    assert len(sink.events) == 1
+    assert sink.events[0][0] == "resource_pressure"
+    assert len(swarm.payloads) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Telemetry failure NEVER changes/delays the verdict.
+# --------------------------------------------------------------------------- #
+def test_telemetry_failure_does_not_affect_verdict() -> None:
+    def _explode_sink(event_type: str, payload: dict) -> None:
+        raise RuntimeError("telemetry backend down")
+
+    def _explode_swarm(payload: dict):
+        raise RuntimeError("swarm dispatch down")
+
+    matrix = BiometricExecutionMatrix(
+        embedder=_oom_embedder,
+        baseline_embedding=np.ones(4, dtype=np.float64),
+        accept_threshold=0.5,
+        breaker=_SpyBreaker(),
+        event_sink=_explode_sink,
+        swarm_trigger=_explode_swarm,
+    )
+
+    res = matrix.authenticate(np.zeros(16, dtype=np.float64))
+    assert res.verdict is Verdict.REJECTED
+    assert res.reason == "oom_fail_secure"
+    # Let any best-effort thread run; it must swallow the telemetry error.
+    time.sleep(0.1)
+
+
+# --------------------------------------------------------------------------- #
+# Breaker trips after N sustained OOMs -> subsequent calls short-circuit.
+# --------------------------------------------------------------------------- #
+def test_breaker_trips_after_n_ooms() -> None:
+    threshold = 3
+    breaker = LocalOOMCircuitBreaker(failure_threshold=threshold, reset_timeout_s=60.0)
+
+    calls = {"n": 0}
+
+    def _counting_oom(_x: np.ndarray) -> np.ndarray:
+        calls["n"] += 1
+        raise MemoryError("OOM")
+
+    matrix = BiometricExecutionMatrix(
+        embedder=_counting_oom,
+        baseline_embedding=np.ones(4, dtype=np.float64),
+        accept_threshold=0.5,
+        breaker=breaker,
+    )
+
+    # First `threshold` calls hit the embedder and OOM.
+    for i in range(threshold):
+        res = matrix.authenticate(np.zeros(16, dtype=np.float64))
+        assert res.verdict is Verdict.REJECTED
+        assert res.reason == "oom_fail_secure"
+
+    assert calls["n"] == threshold
+    assert breaker.can_execute() is False, "breaker should be open after N OOMs"
+
+    # Subsequent calls short-circuit: embedder NOT invoked, circuit_open_locked.
+    res = matrix.authenticate(np.zeros(16, dtype=np.float64))
+    assert res.verdict is Verdict.REJECTED
+    assert res.reason == "circuit_open_locked"
+    assert calls["n"] == threshold, "embedder MUST NOT be called once breaker open"
+
+
+# --------------------------------------------------------------------------- #
+# LocalOOMCircuitBreaker standalone unit behavior
+# --------------------------------------------------------------------------- #
+def test_local_breaker_resets_after_timeout() -> None:
+    breaker = LocalOOMCircuitBreaker(failure_threshold=2, reset_timeout_s=0.05)
+    assert breaker.can_execute() is True
+    breaker.record_failure()
+    breaker.record_failure()
+    assert breaker.can_execute() is False
+    time.sleep(0.07)
+    # After reset timeout, half-open: can_execute allows a trial again.
+    assert breaker.can_execute() is True
+
+
+def test_local_breaker_success_resets_failures() -> None:
+    breaker = LocalOOMCircuitBreaker(failure_threshold=2, reset_timeout_s=60.0)
+    breaker.record_failure()
+    breaker.record_success()
+    breaker.record_failure()
+    # One failure pre-reset + one post-reset = still under threshold of 2.
+    assert breaker.can_execute() is True


### PR DESCRIPTION
## Summary
Phase 3 (stacked on #69510). The ECAPA execution matrix + a fail-secure OOM circuit breaker for unified-memory volatility. `tests/ml/` only; fully decoupled by structural injection (no `unified_supervisor`/`backend` imports).

- **BiometricExecutionMatrix**: consumes uniform tensors (Phase 2) → embedder (ecapa_facade via lazy structural injection / stand-in) → cosine eval vs stored baseline voiceprint.
- **Zero-Trust OOM breaker** (`LocalOOMCircuitBreaker`, structurally `AdvancedCircuitBreaker`-shaped + injectable): **fail-secure** — breaker-open / `MemoryError` / generic error always return `VERDICT_REJECTED` (never ACCEPTED on error).
- **Async RESOURCE_PRESSURE swarm telemetry**: on OOM, fire-and-forget `("resource_pressure", {...})` to injected `EventSink` + `SwarmTrigger` (loop-task or daemon-thread fallback) — **never blocks the secure-lock verdict**.

## Test Plan
- [x] 57 passed, 3 skipped (real-ECAPA seam)
- [x] Happy path B-accept / C-reject on preprocessed fixtures
- [x] Fail-secure: breaker-open (embedder not called) / OOM / generic error → REJECTED
- [x] OOM proof: sync REJECT + record_failure + resource_pressure event fired + swarm triggered
- [x] Non-blocking: verdict ~1.7ms vs slow sink completing ~302ms later (ordering asserted)
- [x] Breaker trips after N=3 OOMs → 4th short-circuits without invoking the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail-secure ECAPA biometric execution matrix with a zero-trust OOM circuit breaker and non-blocking telemetry, implemented in `tests/ml/` via structural injection. Prevents ACCEPT on errors and shields the pipeline from unified-memory OOM storms.

- New Features
  - BiometricExecutionMatrix: embeds a uniform tensor, compares cosine similarity to a baseline, and applies an accept threshold; returns REJECTED on any error.
  - Zero-trust OOM breaker: `LocalOOMCircuitBreaker` (shape-compatible with `AdvancedCircuitBreaker`) trips after N OOMs; while open, short-circuits to REJECT without calling the embedder.
  - Async telemetry: on OOM, fire-and-forget `resource_pressure` events to injected `EventSink` and `SwarmTrigger`; never blocks the verdict and works without a running loop (daemon thread fallback).
  - Structural injection: no `backend` or supervisor imports; optional lazy probe of `ecapa_facade`; pure NumPy implementation with focused unit tests covering accept/reject paths, breaker-open short-circuiting, OOM handling, and telemetry behavior.

<sup>Written for commit 3d50f424fa174025c762c5de43c30e71d378de71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

