### PR TITLE
Slice 255: Reanimation live-fire fixes + Sovereign Remediation Matrix

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -5203,6 +5203,16 @@ class SerpentREPL:
                         await self._handle_endorse(line)
                         continue
 
+                    # Live-fire validation — flag-gated synthetic pressure injector
+                    # (debug tooling; inert unless JARVIS_REANIMATION_DEBUG_INJECT_ENABLED).
+                    if (
+                        line in ("/inject-pressure", "inject-pressure")
+                        or line.startswith("/inject-pressure ")
+                        or line.startswith("inject-pressure ")
+                    ):
+                        await self._handle_inject_pressure(line)
+                        continue
+
                     # Gap #3 Slice 3 — unified /expand <ref> verb
                     # dispatches by ref prefix:
                     #   t-N → tool result body (Gap #2 BoundedBodyStore)
@@ -7208,6 +7218,90 @@ class SerpentREPL:
             _C["death"] if status == "error" else _C["heal"]
         )
         c.print(f"  [{color}]{line}[/{color}]", highlight=False)
+
+    async def _handle_inject_pressure(self, line: str) -> None:
+        """``/inject-pressure [signal] [source]`` — DEBUG / live-fire validation.
+
+        Flag-gated (``JARVIS_REANIMATION_DEBUG_INJECT_ENABLED``, default off).
+        Synthesizes ONE precise pressure signal into the LIVE in-process
+        Cybernetic Reanimation dispatcher — **no host degradation** — to force
+        the full chain (dispatcher → organ → ``shadow_guard`` trap →
+        ``SHADOW_ACTION_TRAPPED`` telemetry → ``/endorse`` [y/N]) under
+        controlled input.
+
+        Forms::
+
+            /inject-pressure                    — component_degraded / jarvis-prime
+            /inject-pressure <signal>           — component_degraded | anomaly_detected
+                                                  | resource_pressure
+            /inject-pressure <signal> <source>  — e.g. component_degraded reactor-core
+
+        After a component_degraded/anomaly injection in shadow mode, run
+        ``/endorse`` to see the [y/N] prompt. ALL fail-soft."""
+        import os
+
+        c = self._flow.console
+        if os.getenv(
+            "JARVIS_REANIMATION_DEBUG_INJECT_ENABLED", "false"
+        ).strip().lower() not in ("1", "true", "yes", "on"):
+            c.print(
+                f"  [{_C['dim']}]/inject-pressure is disabled — boot with "
+                f"JARVIS_REANIMATION_DEBUG_INJECT_ENABLED=true to use it."
+                f"[/{_C['dim']}]",
+                highlight=False,
+            )
+            return
+
+        parts = line.replace("/inject-pressure", "inject-pressure", 1).split()
+        signal = parts[1] if len(parts) > 1 else "component_degraded"
+        source = parts[2] if len(parts) > 2 else "jarvis-prime"
+
+        try:
+            from backend.kernel import get_kernel_instance
+            from tests.battle_test.synthetic_pressure_injector import (
+                inject_pressure,
+            )
+        except Exception as exc:  # noqa: BLE001
+            c.print(
+                f"  [{_C['death']}]/inject-pressure: tooling unavailable: "
+                f"{exc}[/{_C['death']}]",
+                highlight=False,
+            )
+            return
+
+        try:
+            kernel = get_kernel_instance()
+            reached = await inject_pressure(
+                signal=signal, source=source, kernel=kernel
+            )
+        except Exception as exc:  # noqa: BLE001 — fail-soft, never crash the REPL
+            c.print(
+                f"  [{_C['death']}]/inject-pressure failed: {exc}[/{_C['death']}]",
+                highlight=False,
+            )
+            return
+
+        if reached is None:
+            c.print(
+                f"  [{_C['death']}]/inject-pressure: not injectable (see log — no "
+                f"live kernel, or reanimation not ignited via "
+                f"JARVIS_RESILIENCE_REANIMATION_ENABLED=true).[/{_C['death']}]",
+                highlight=False,
+            )
+            return
+
+        c.print(
+            f"  [{_C['life']}]⚡ injected synthetic {signal}[/{_C['life']}] "
+            f"[{_C['dim']}](source={source}) → {reached} organ(s) reached"
+            f"[/{_C['dim']}]",
+            highlight=False,
+        )
+        if signal in ("component_degraded", "anomaly_detected"):
+            c.print(
+                f"  [{_C['dim']}]if shadow mode is up, a trap is now pending — "
+                f"run /endorse to review the [y/N] prompt.[/{_C['dim']}]",
+                highlight=False,
+            )
 
     async def _handle_endorse(self, line: str) -> None:
         """``/endorse`` — the human-in-the-loop "steering wheel" for trapped

--- a/backend/core/remediation_arsenal.py
+++ b/backend/core/remediation_arsenal.py
@@ -1,0 +1,145 @@
+"""Sovereign Remediation Matrix (Slice 255) — genuine, kernel-bound self-healing actions.
+
+The Cybernetic Reanimation wiring instantiated ``SelfHealingOrchestrator`` with NO
+registered remediation handlers, so ``_execute_remediation`` always short-circuited
+("No handler registered") → the ``shadow_guard`` trap never fired → ``/endorse`` was
+dead in production (a wired-but-inert nervous system; live-fire finding, Slice 255).
+
+This module registers REAL remediations bound directly to the kernel's existing
+physical capabilities — NOT hollow mocks. Each handler is the genuine dangerous
+action; the existing ``SelfHealingOrchestrator._execute_remediation`` routes every
+call through ``shadow_guard`` first, so under ``JARVIS_RESILIENCE_SHADOW_MODE`` the
+action is TRAPPED (logged + stashed for ``/endorse``) and only executes for real
+once the Sovereign Host endorses it.
+
+Strategy → genuine capability:
+  RESTART / FAILOVER → ``kernel._trinity.restart_component(component)`` (real Trinity
+                       component process restart; failover = restart the failing one)
+  SCALE_DOWN         → ``GracefulDegradationManager._check_resources()`` organ
+                       (real: re-evaluates pressure + disables low-priority features)
+  ISOLATE            → ``AdvancedCircuitBreaker.record_failure()`` organ
+                       (real: trips the breaker → blocks the failing component)
+  ROLLBACK           → ``kernel._rollback_coordinator.rollback(component)`` if present
+  NOTIFY_ONLY        → benign notify (non-dangerous; logged)
+
+Decoupled by structural typing: takes the live ``self_healing`` organ + kernel +
+organs (duck-typed) — NEVER imports ``unified_supervisor``. All handlers are
+async ``(component: str) -> bool`` and fail-soft (a missing capability logs + returns
+False; it never raises into the orchestrator).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger("remediation_arsenal")
+
+
+def _resolve(obj: Optional[Any], *path: str) -> Optional[Callable[..., Any]]:
+    """Walk an attribute path (fail-soft) and return the final callable, else None."""
+    cur = obj
+    for name in path:
+        if cur is None:
+            return None
+        cur = getattr(cur, name, None)
+    return cur if callable(cur) else None
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+def build_remediation_handlers(
+    *, kernel: Optional[Any] = None, organs: Optional[Dict[str, Any]] = None
+) -> Dict[str, Callable[[str], Any]]:
+    """Return ``{strategy_value: async handler}`` bound to real kernel capabilities."""
+    organs = organs or {}
+    grace = organs.get("GracefulDegradationManager")
+    breaker = organs.get("AdvancedCircuitBreaker")
+
+    async def _restart(component: str) -> bool:
+        fn = _resolve(kernel, "_trinity", "restart_component")
+        if fn is None:
+            logger.warning("[Arsenal] RESTART: kernel._trinity.restart_component unavailable")
+            return False
+        return bool(await _maybe_await(fn(component)))
+
+    async def _failover(component: str) -> bool:
+        # Genuine failover = restart the failing Trinity component to recover it.
+        return await _restart(component)
+
+    async def _scale_down(component: str) -> bool:
+        fn = _resolve(grace, "_check_resources")
+        if fn is None:
+            logger.warning("[Arsenal] SCALE_DOWN: GracefulDegradationManager._check_resources unavailable")
+            return False
+        await _maybe_await(fn())
+        return True
+
+    async def _isolate(component: str) -> bool:
+        fn = _resolve(breaker, "record_failure")
+        if fn is None:
+            logger.warning("[Arsenal] ISOLATE: AdvancedCircuitBreaker.record_failure unavailable")
+            return False
+        # Trip the breaker for the failing component → isolates it from traffic.
+        await _maybe_await(fn(RuntimeError(f"isolate:{component}")))
+        return True
+
+    async def _rollback(component: str) -> bool:
+        fn = _resolve(kernel, "_rollback_coordinator", "rollback")
+        if fn is None:
+            logger.warning("[Arsenal] ROLLBACK: kernel._rollback_coordinator.rollback unavailable")
+            return False
+        return bool(await _maybe_await(fn(component)))
+
+    async def _notify_only(component: str) -> bool:
+        # Non-dangerous: just record the concern. Genuine (it really logs/notifies).
+        logger.info("[Arsenal] NOTIFY_ONLY: component=%s flagged (no mutating action)", component)
+        return True
+
+    return {
+        "restart": _restart,
+        "failover": _failover,
+        "scale_down": _scale_down,
+        "isolate": _isolate,
+        "rollback": _rollback,
+        "notify_only": _notify_only,
+    }
+
+
+def register_remediation_arsenal(
+    self_healing: Any,
+    *,
+    kernel: Optional[Any] = None,
+    organs: Optional[Dict[str, Any]] = None,
+) -> int:
+    """Register the genuine remediation arsenal onto a live ``SelfHealingOrchestrator``.
+
+    Returns the number of handlers registered. NEVER raises (fail-soft) — a wiring
+    failure must not break boot; it just leaves SelfHealing without that handler.
+    Idempotent-friendly: re-registering overwrites the same strategy keys.
+    """
+    if self_healing is None:
+        logger.warning("[Arsenal] no SelfHealingOrchestrator — nothing to arm")
+        return 0
+    register = getattr(self_healing, "register_handler", None)
+    strat_enum = getattr(type(self_healing), "RemediationStrategy", None)
+    if not callable(register) or strat_enum is None:
+        logger.warning("[Arsenal] SelfHealing has no register_handler/RemediationStrategy")
+        return 0
+
+    handlers = build_remediation_handlers(kernel=kernel, organs=organs)
+    count = 0
+    for strat in strat_enum:  # iterate the real enum so we only register valid strategies
+        handler = handlers.get(strat.value)
+        if handler is None:
+            continue
+        try:
+            register(strat, handler)
+            count += 1
+        except Exception as err:  # noqa: BLE001 — fail-soft per strategy
+            logger.warning("[Arsenal] register %s failed: %r", strat.value, err)
+    logger.info("[Arsenal] armed SelfHealingOrchestrator with %d genuine remediations", count)
+    return count

--- a/tests/battle_test/synthetic_pressure_injector.py
+++ b/tests/battle_test/synthetic_pressure_injector.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Synthetic pressure injector — live-fire validation of the Cybernetic Reanimation chain.
+
+SAFETY: this NEVER degrades the host. It does not spike real CPU/RAM; it dispatches a
+single, precise, synthetic ``PressureSignal`` straight into the LIVE in-process
+``EventActivationDispatcher`` (the reanimation muscle), so the chain fires under fully
+controlled input.
+
+IN-PROCESS ONLY (load-bearing constraint). The reanimation dispatcher and the
+``SupervisorEventBus`` are per-process singletons. This module resolves the *booted*
+kernel via ``backend.kernel.get_kernel_instance()`` and reaches
+``kernel._resilience_dispatcher`` — which only exists inside the running supervisor
+process. A standalone ``python synthetic_pressure_injector.py`` in a SEPARATE process
+finds no booted kernel and no-ops with a clear message — by design. It must be invoked
+in-process (e.g. from a flag-gated REPL debug verb or a harness post-boot hook).
+
+Signal → chain it exercises:
+  * ``component_degraded`` / ``anomaly_detected``
+        → SelfHealingOrchestrator.check_and_remediate → _execute_remediation
+        → shadow_guard_async TRAP (shadow mode) → PendingShadowAction stashed
+        → SHADOW_ACTION_TRAPPED telemetry on the StreamEventBroker
+        → ``/endorse`` [y/N] surfaces in the live REPL.   <-- the full HITL chain
+  * ``resource_pressure``
+        → LoadShedding / AutoScaling / GracefulDegradation react (recompute).
+        NOTE: a raw resource_pressure does NOT stash a /endorse-able trap — for that
+        leg, prefer the threshold-env path (set JARVIS_PRESSURE_CPU_THRESHOLD low) so
+        the REAL sampler fires it; this injector's value is the component_degraded leg.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger("synthetic_pressure_injector")
+
+# signal-name → PressureSignalType attribute name
+_SIGNAL_MAP = {
+    "resource_pressure": "RESOURCE_PRESSURE",
+    "component_degraded": "COMPONENT_DEGRADED",
+    "anomaly_detected": "ANOMALY_DETECTED",
+}
+
+
+def _resolve_kernel(kernel: Optional[Any]) -> Optional[Any]:
+    """Return the live booted kernel (passed in, or via the modular singleton)."""
+    if kernel is not None:
+        return kernel
+    try:
+        from backend.kernel import get_kernel_instance  # modular kernel package
+        return get_kernel_instance()
+    except Exception as err:  # noqa: BLE001 — diagnostic, never raise
+        logger.error("[INJECT] could not resolve live kernel singleton: %r", err)
+        return None
+
+
+async def inject_pressure(
+    signal: str = "component_degraded",
+    source: str = "jarvis-prime",
+    *,
+    kernel: Optional[Any] = None,
+    severity: str = "critical",
+) -> Optional[int]:
+    """Dispatch ONE synthetic, edge-triggered ``PressureSignal`` into the live
+    reanimation dispatcher. Returns the number of organs the signal reached, or
+    ``None`` if not injectable (no kernel / reanimation not ignited). NEVER raises.
+
+    Must be awaited IN-PROCESS inside the running supervisor.
+    """
+    sig_key = (signal or "").strip().lower()
+    if sig_key not in _SIGNAL_MAP:
+        logger.error("[INJECT] unknown signal %r (use one of %s)",
+                     signal, list(_SIGNAL_MAP))
+        return None
+
+    k = _resolve_kernel(kernel)
+    if k is None:
+        logger.error("[INJECT] no live kernel — run IN-PROCESS inside the booted "
+                     "supervisor (a standalone process has no kernel).")
+        return None
+
+    dispatcher = getattr(k, "_resilience_dispatcher", None)
+    if dispatcher is None:
+        logger.error("[INJECT] reanimation not ignited — boot with "
+                     "JARVIS_RESILIENCE_REANIMATION_ENABLED=true (kernel has no "
+                     "_resilience_dispatcher).")
+        return None
+
+    try:
+        from backend.core.cybernetic_reanimation import (
+            PressureSignal, PressureSignalType, SignalEdge,
+        )
+    except Exception as err:  # noqa: BLE001
+        logger.error("[INJECT] cybernetic_reanimation import failed: %r", err)
+        return None
+
+    sig = PressureSignal(
+        type=getattr(PressureSignalType, _SIGNAL_MAP[sig_key]),
+        source=source,
+        edge=SignalEdge.RISING,
+        severity=severity,
+        detail={
+            "synthetic": True,
+            "injector": "live-fire-validation",
+            "host_degraded": False,  # we never spike real hardware
+        },
+    )
+    try:
+        reached = await dispatcher.dispatch(sig)
+    except Exception as err:  # noqa: BLE001 — dispatcher is fail-soft; report and stop
+        logger.error("[INJECT] dispatch raised (unexpected — dispatcher is fail-soft): %r", err)
+        return None
+
+    logger.warning(
+        "[INJECT] dispatched synthetic %s (source=%s, severity=%s) -> %s organ(s) "
+        "reached. If shadow mode is ON and this was component_degraded/anomaly, a "
+        "PendingShadowAction is now awaiting /endorse.",
+        sig_key, source, severity, reached,
+    )
+    return reached
+
+
+if __name__ == "__main__":  # standalone guard — explains the in-process requirement
+    import sys
+    sys.stderr.write(
+        "synthetic_pressure_injector is IN-PROCESS tooling and cannot run standalone:\n"
+        "  the reanimation dispatcher is a per-process singleton inside the live\n"
+        "  supervisor. Invoke `await inject_pressure(...)` from inside the booted\n"
+        "  process (a flag-gated REPL debug verb or a harness post-boot hook), not\n"
+        "  as `python synthetic_pressure_injector.py`.\n"
+    )
+    raise SystemExit(2)

--- a/tests/governance/test_slice255_remediation_arsenal.py
+++ b/tests/governance/test_slice255_remediation_arsenal.py
@@ -1,0 +1,135 @@
+"""Slice 255 — Sovereign Remediation Matrix.
+
+Two layers:
+  * Sandbox-OK unit tests of `register_remediation_arsenal` / `build_remediation_handlers`
+    against a fake SelfHealing + fake kernel/organs (no `unified_supervisor` import).
+  * A sandbox-OFF integration test of the REAL chain (arm -> COMPONENT_DEGRADED -> FAILOVER
+    -> shadow_guard TRAP -> /endorse executes the real kernel action); skipped where the
+    kernel import is blocked (split-brain-guard).
+"""
+import asyncio
+import enum
+
+import pytest
+
+from backend.core.remediation_arsenal import (
+    build_remediation_handlers,
+    register_remediation_arsenal,
+)
+
+
+class _Strategy(enum.Enum):
+    RESTART = "restart"
+    SCALE_DOWN = "scale_down"
+    FAILOVER = "failover"
+    ISOLATE = "isolate"
+    ROLLBACK = "rollback"
+    NOTIFY_ONLY = "notify_only"
+
+
+class _FakeSelfHealing:
+    RemediationStrategy = _Strategy
+
+    def __init__(self):
+        self._handlers = {}
+
+    def register_handler(self, strategy, handler):
+        self._handlers[strategy.value] = handler
+
+
+class _Trinity:
+    def __init__(self):
+        self.calls = []
+
+    async def restart_component(self, name):
+        self.calls.append(name)
+        return True
+
+
+class _Kernel:
+    def __init__(self, trinity):
+        self._trinity = trinity
+
+
+def test_arms_all_six_strategies():
+    sho = _FakeSelfHealing()
+    n = register_remediation_arsenal(sho, kernel=_Kernel(_Trinity()), organs={})
+    assert n == 6
+    assert set(sho._handlers) == {s.value for s in _Strategy}
+
+
+def test_none_self_healing_is_failsoft():
+    assert register_remediation_arsenal(None, kernel=None, organs={}) == 0
+
+
+@pytest.mark.asyncio
+async def test_restart_and_failover_bind_to_real_trinity():
+    trin = _Trinity()
+    handlers = build_remediation_handlers(kernel=_Kernel(trin), organs={})
+    assert await handlers["restart"]("jarvis-prime") is True
+    assert await handlers["failover"]("reactor-core") is True
+    assert trin.calls == ["jarvis-prime", "reactor-core"]  # genuine capability invoked
+
+
+@pytest.mark.asyncio
+async def test_isolate_trips_the_breaker_organ():
+    tripped = []
+
+    class _Breaker:
+        def record_failure(self, err=None):
+            tripped.append(err)
+
+    handlers = build_remediation_handlers(
+        kernel=None, organs={"AdvancedCircuitBreaker": _Breaker()}
+    )
+    assert await handlers["isolate"]("vision") is True
+    assert len(tripped) == 1  # breaker actually tripped
+
+
+@pytest.mark.asyncio
+async def test_missing_capability_is_failsoft_not_crash():
+    # No kernel/_trinity → RESTART logs + returns False, never raises.
+    handlers = build_remediation_handlers(kernel=None, organs={})
+    assert await handlers["restart"]("x") is False
+    assert await handlers["notify_only"]("x") is True  # benign always-True
+
+
+# ── sandbox-OFF: the REAL end-to-end chain (skips where kernel import is blocked) ──
+
+def _real_supervisor_or_skip():
+    try:
+        import unified_supervisor as us  # noqa: F401
+        return us
+    except Exception as exc:  # noqa: BLE001 — split-brain-guard / heavy deps in sandbox
+        pytest.skip(f"unified_supervisor import unavailable (sandbox): {exc!r}")
+
+
+@pytest.mark.asyncio
+async def test_real_chain_traps_then_endorse_executes(monkeypatch):
+    monkeypatch.setenv("JARVIS_RESILIENCE_REANIMATION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_RESILIENCE_SHADOW_MODE", "true")
+    us = _real_supervisor_or_skip()
+    from backend.core.cybernetic_reanimation import (
+        PressureSignal, PressureSignalType, SignalEdge,
+        pending_shadow_action_ids, pending_shadow_action_count,
+        reset_pending_shadow_actions, handle_endorsement_choice,
+    )
+    trin = _Trinity()
+    organs = us._instantiate_resilience_organs()
+    dispatcher = us.build_resilience_dispatcher(organs)
+    armed = register_remediation_arsenal(
+        organs.get("SelfHealingOrchestrator"), kernel=_Kernel(trin), organs=organs
+    )
+    assert armed == 6
+    reset_pending_shadow_actions()
+
+    await dispatcher.dispatch(PressureSignal(
+        type=PressureSignalType.COMPONENT_DEGRADED, source="reactor-core",
+        edge=SignalEdge.RISING, severity="critical"))
+    ids = pending_shadow_action_ids()
+    assert pending_shadow_action_count() == 1          # shadow_guard trapped it
+    assert trin.calls == []                            # real action NOT executed in shadow
+
+    res = await handle_endorsement_choice(ids[0], "y")
+    assert getattr(res, "status", None) == "executed"
+    assert trin.calls == ["reactor-core"]              # genuine kernel action fired on endorse


### PR DESCRIPTION
## Summary
Live-fire validation of the merged Cybernetic Reanimation arc found it **structurally sound but operationally inert**, and fixed it. All changes verified by running the real chain in a live process (sandbox-off), not just sandbox mocks.

**Production bugfixes (these unblock reanimation regardless of the rest):**
- Ignition functions (`build_resilience_dispatcher`, `_instantiate_resilience_organs`, sampler, `_ignite_resilience_reanimation`) used a bare `logger` that is **not a module global** → `NameError` at boot → reanimation silently fail-soft-disabled in production. Fixed with a scoped `_reanim_log`.
- `build_resilience_dispatcher._wake` called `evaluate(sig)` on no-arg organ hooks (`AutoScalingController.evaluate()`) → `TypeError`, swallowed → organ inert. Now arg-tolerant.

**Slice 255 — Sovereign Remediation Matrix (`backend/core/remediation_arsenal.py`):**
SelfHealingOrchestrator was wired to receive signals but had **no remediation handlers** → `_execute_remediation` always returned "No handler registered" → `shadow_guard` never trapped → `/endorse` was dead. This registers GENUINE remediations bound to real kernel capabilities (no hollow mocks): RESTART/FAILOVER→`kernel._trinity.restart_component`, SCALE_DOWN→`GracefulDegradationManager._check_resources`, ISOLATE→`AdvancedCircuitBreaker.record_failure`, ROLLBACK→`_rollback_coordinator`, NOTIFY_ONLY→benign. Wired into `_ignite_resilience_reanimation` (fail-soft, default-OFF).

**Validation tooling:** in-process `synthetic_pressure_injector.py` + a flag-gated `/inject-pressure` REPL debug verb (`JARVIS_REANIMATION_DEBUG_INJECT_ENABLED`).

## Test Plan
- [x] 17 passed (Slice 255 arsenal incl. sandbox-off real-chain + reanimation kernel wiring + shadow-definition guard)
- [x] Live-proven sandbox-off: COMPONENT_DEGRADED → FAILOVER → shadow_guard TRAPS (real restart NOT executed; pending + SHADOW_ACTION_TRAPPED telemetry) → `/endorse y` → real `restart_component` fires
- [x] Default-OFF master + shadow shield up; OFF path byte-identical
- [ ] Operator TTY `/endorse` [Y/N] visual render (local interactive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes issues that left Cybernetic Reanimation inert in production and arms `SelfHealingOrchestrator` with real, kernel-bound remediations. Adds a safe, flag-gated in-process pressure injector to validate the full shadow-guarded `/endorse` flow.

- **Bug Fixes**
  - Replaced bare `logger` with scoped `_reanim_log` to stop boot `NameError` and allow ignition and sampler to run.
  - Made dispatcher wake logic arg-tolerant so no-arg hooks (e.g., `AutoScalingController.evaluate()`) don’t error and organs activate.

- **New Features**
  - Sovereign Remediation Matrix: registers genuine handlers on `SelfHealingOrchestrator` (RESTART/FAILOVER → `kernel._trinity.restart_component`, SCALE_DOWN → `GracefulDegradationManager._check_resources`, ISOLATE → `AdvancedCircuitBreaker.record_failure`, ROLLBACK → `_rollback_coordinator`, NOTIFY_ONLY → benign). Wired in `_ignite_resilience_reanimation`; fail-soft; shadow-guarded; default off.
  - In-process synthetic pressure injector and `/inject-pressure` REPL verb to send targeted signals without host impact; flag-gated and surfaces `/endorse` when shadow mode traps actions.

<sup>Written for commit 1f705d8b901aa5b4f0731c481ed4c77a21a0be7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

