### PR TITLE
Slice 256 — Sovereign Transition Injector (reversible LiveKernelValidator FSM wiring)

### DIFF
--- a/backend/core/ouroboros/governance/episodic_core.py
+++ b/backend/core/ouroboros/governance/episodic_core.py
@@ -32,7 +32,7 @@ import os
 import threading
 import time
 from collections import deque
-from typing import Any, Deque, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Deque, List, Optional, Sequence, Tuple
 
 _ENV_MASTER = "JARVIS_EPISODIC_CORE_ENABLED"
 _ENV_WINDOW = "JARVIS_EPISODIC_WINDOW"
@@ -207,6 +207,50 @@ class EpisodicLedger:
         with self._lock:
             self._longterm.append((vec, ep))
 
+    def prune(self, match: Callable[["Episode"], bool], *, tombstone_label: str = "") -> int:
+        """Integrity-preserving retirement of superseded episodes.
+
+        Evicts episodes for which ``match(ep)`` is True from the in-RAM long-term recall
+        cache AND the short-term window — freeing RAM immediately and stopping a
+        consolidated failure pattern from resurfacing in ``recall``. It then APPENDS a
+        tombstone receipt to the tamper-evident ledger recording the supersession.
+
+        It NEVER deletes from the append-only durable ledger: erasing a hash-chained
+        receipt would break tamper-evidence (Manifesto §8 audit-immutability + the
+        dissertation-evidence purity this module guarantees). The audit-correct way to
+        retire a record is to append a supersession marker, not erase the original.
+
+        Returns the number of in-memory episodes evicted. Fail-soft → 0. A predicate that
+        raises is treated as "no match" (keep) so a bad matcher can never nuke the cache.
+        """
+        def _hit(ep: "Episode") -> bool:
+            try:
+                return bool(match(ep))
+            except Exception:  # noqa: BLE001
+                return False
+        try:
+            with self._lock:
+                kept_lt = [(v, ep) for (v, ep) in self._longterm if not _hit(ep)]
+                kept_w = [ep for ep in self._window if not _hit(ep)]
+                removed = (len(self._longterm) - len(kept_lt)) + (len(self._window) - len(kept_w))
+                if removed:
+                    self._longterm = deque(kept_lt, maxlen=self._longterm.maxlen)
+                    self._window = deque(kept_w, maxlen=self._window.maxlen)
+            if removed:
+                try:
+                    bl = self._blue_ledger()
+                    if bl is not None:
+                        bl.record(
+                            attack_class="episodic_superseded",
+                            payload=f"superseded {removed} episodes: {tombstone_label}"[:300],
+                            verdict="superseded", blocked=False,
+                        )
+                except Exception:  # noqa: BLE001
+                    pass
+            return removed
+        except Exception:  # noqa: BLE001
+            return 0
+
     def recent(self, n: int) -> List[Episode]:
         """The immediate short-term window (most recent last). NEVER raises."""
         try:
@@ -263,6 +307,14 @@ def reset_episodic_ledger() -> None:
     global _singleton
     with _singleton_lock:
         _singleton = None
+
+
+def prune_episodes(match: Callable[["Episode"], bool], *, tombstone_label: str = "") -> int:
+    """Module helper: retire superseded episodes on the default ledger (integrity-preserving;
+    see :meth:`EpisodicLedger.prune`). No-op (0) when episodic core is disabled."""
+    if not episodic_core_enabled():
+        return 0
+    return get_episodic_ledger().prune(match, tombstone_label=tombstone_label)
 
 
 async def record_transition(

--- a/backend/core/ouroboros/governance/semantic_consolidation.py
+++ b/backend/core/ouroboros/governance/semantic_consolidation.py
@@ -1,0 +1,282 @@
+"""Tier 2 — Semantic Consolidation Matrix: the neuroplasticity loop's compressor.
+
+The learning half of the Anticipatory Edge-Case Armor. Live-fire failures and Guardian
+hard-findings stream in as :class:`Lesson`s. When N *structurally similar* lessons
+accumulate, the matrix distills them into a single high-weight CORE_DIRECTIVE persisted to
+the UserPreferenceStore (as a STYLE memory — injected into every generation) and purges the
+now-redundant episodic records. This keeps episodic memory from bloating the 16 GB
+unified-memory footprint / LLM context while *promoting* the lesson from transient to durable.
+
+Manifesto §6 (neuroplasticity): the organism learns its own blindspots from runtime failure
+instead of us hard-coding every rule. The LiveKernelValidator is the teacher; this is how the
+student writes the lesson down once and forgets the noise.
+
+Design discipline (matches the rest of the engine):
+  * Decoupled + duck-typed: ``store`` needs only ``.add(memory_type, name, description, ...)``;
+    ``purge`` is any ``Callable[[List[str]], None]``. No hard import of the heavy store, so it
+    is unit-testable with fakes and OFF-inert.
+  * Default OFF (``JARVIS_SEMANTIC_CONSOLIDATION_ENABLED``). Fail-soft — ``record`` never
+    raises into its caller.
+  * Bounded memory: at most ``max_clusters`` fingerprints, each holding at most ``threshold``
+    lessons → O(max_clusters × threshold) retained, never unbounded.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Optional, Sequence
+
+logger = logging.getLogger("ouroboros.semantic_consolidation")
+
+_ENV_ENABLED = "JARVIS_SEMANTIC_CONSOLIDATION_ENABLED"
+_ENV_THRESHOLD = "JARVIS_CONSOLIDATION_THRESHOLD"
+_ENV_MAX_CLUSTERS = "JARVIS_CONSOLIDATION_MAX_CLUSTERS"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Normalization patterns — strip the parts that vary between two instances of the SAME
+# structural failure so their fingerprints collide.
+_RE_HEXADDR = re.compile(r"0x[0-9a-fA-F]+")
+_RE_QUOTED = re.compile(r"""(['"]).*?\1""")
+_RE_PATH = re.compile(r"(/[\w.\-]+)+|[A-Za-z]:\\[\\\w.\-]+")
+_RE_NUM = re.compile(r"\b\d+\b")
+_RE_WS = re.compile(r"\s+")
+_RE_LINENO = re.compile(r"line\s+\d+", re.IGNORECASE)
+
+
+def consolidation_enabled() -> bool:
+    return os.environ.get(_ENV_ENABLED, "0").strip().lower() in _TRUTHY
+
+
+@dataclass(frozen=True)
+class Lesson:
+    """One recurring-failure signal fed to the matrix.
+
+    kind:        coarse family, e.g. "live_fire" / "guardian".
+    signature:   the raw failure text (exception line, message). Fingerprinted internally.
+    file_path:   optional file the failure relates to (used for directive path-scoping).
+    episode_id:  optional id of the backing episodic record (purged on consolidation).
+    """
+
+    signature: str
+    kind: str = "live_fire"
+    file_path: str = ""
+    episode_id: str = ""
+
+
+def fingerprint(signature: str) -> str:
+    """Structural key: lower-cased text with quoted strings, paths, hex addrs, line refs and
+    bare numbers elided, so two instances of the same failure shape collapse to one key."""
+    s = (signature or "").strip()
+    s = _RE_QUOTED.sub("'_'", s)
+    s = _RE_LINENO.sub("line _", s)
+    s = _RE_HEXADDR.sub("_", s)
+    s = _RE_PATH.sub("_", s)
+    s = _RE_NUM.sub("_", s)
+    s = _RE_WS.sub(" ", s).strip().lower()
+    return s
+
+
+# Principle extraction — recognise known exception families to write a useful directive.
+_PRINCIPLES: Sequence = (
+    ("frozeninstanceerror",
+     "Frozen/immutable instances cannot be mutated. Produce a NEW value with "
+     "dataclasses.replace(obj, field=...) (or NamedTuple._replace / pydantic model_copy) "
+     "and rebind — never `obj.field = ...`."),
+    ("nonetype",
+     "Guard Optional values before use: check `if x is not None:` (or narrow with an early "
+     "return) before any attribute access, subscript, or coercion."),
+    ("modulenotfounderror",
+     "Verify the import path and that the symbol exists before referencing it; a patch must "
+     "import cleanly under the real interpreter, not just parse."),
+    ("importerror",
+     "Verify the import path and that the symbol exists before referencing it; a patch must "
+     "import cleanly under the real interpreter, not just parse."),
+    ("attributeerror",
+     "Confirm attribute/method names against the actual class definition before access. Dict "
+     "candidates use [] / .get(); only objects use attribute access."),
+    ("keyerror",
+     "Access dict keys defensively with .get(key, default) unless the key is guaranteed; "
+     "validate the shape before indexing."),
+    ("typeerror",
+     "Check argument counts/types against the real signature before calling; functions that "
+     "need arguments must not be invoked argument-free."),
+)
+
+
+_NONE_PRINCIPLE = (
+    "Guard Optional values before use: check `if x is not None:` (or narrow with an early "
+    "return) before any attribute access, subscript, or coercion."
+)
+
+
+def _principle_for(fp: str, raw: str = "") -> str:
+    # None-deref is the most specific runtime hint, but tracebacks QUOTE 'NoneType' so it is
+    # normalized out of the fingerprint — detect it from the raw signature, prioritized.
+    if "nonetype" in (raw or "").lower() or "nonetype" in fp:
+        return _NONE_PRINCIPLE
+    for needle, text in _PRINCIPLES:
+        if needle in fp:
+            return text
+    return (f"Recurring failure pattern detected — review and eliminate the shared root "
+            f"cause: \"{fp[:160]}\".")
+
+
+@dataclass
+class _Cluster:
+    fingerprint: str
+    lessons: List[Lesson] = field(default_factory=list)
+    consolidated: bool = False
+
+
+@dataclass(frozen=True)
+class ConsolidationResult:
+    """What the matrix did when a cluster reached threshold."""
+
+    directive_name: str
+    principle: str
+    fingerprint: str
+    episodes_purged: int
+    occurrences: int
+
+
+class SemanticConsolidationMatrix:
+    """Clusters recurring lessons by structural fingerprint and, at threshold, distills a
+    single durable CORE_DIRECTIVE while purging the redundant episodes."""
+
+    def __init__(
+        self,
+        *,
+        store: Optional[Any] = None,
+        purge: Optional[Callable[[List[str]], None]] = None,
+        threshold: Optional[int] = None,
+        max_clusters: Optional[int] = None,
+        enabled: Optional[bool] = None,
+    ) -> None:
+        self._store = store
+        self._purge = purge
+        self._threshold = self._resolve_int(threshold, _ENV_THRESHOLD, 5, lo=2)
+        self._max_clusters = self._resolve_int(max_clusters, _ENV_MAX_CLUSTERS, 64, lo=1)
+        self._enabled_override = enabled
+        self._clusters: "OrderedDict[str, _Cluster]" = OrderedDict()
+        # resolve the STYLE memory type lazily so this module imports standalone
+        self._style_type = self._resolve_style_type()
+
+    # ---- helpers ----------------------------------------------------------
+    @staticmethod
+    def _resolve_int(explicit: Optional[int], env: str, default: int, *, lo: int) -> int:
+        if explicit is not None:
+            return max(lo, int(explicit))
+        raw = os.environ.get(env, "")
+        try:
+            return max(lo, int(raw)) if raw.strip() else default
+        except ValueError:
+            return default
+
+    @staticmethod
+    def _resolve_style_type():
+        try:
+            from backend.core.ouroboros.governance.user_preference_memory import MemoryType
+            return MemoryType.STYLE
+        except Exception:  # noqa: BLE001
+            return "style"
+
+    def _is_enabled(self) -> bool:
+        if self._enabled_override is not None:
+            return self._enabled_override
+        return consolidation_enabled()
+
+    # ---- public API -------------------------------------------------------
+    def record(self, lesson: Lesson) -> Optional[ConsolidationResult]:
+        """Ingest a lesson. Returns a ConsolidationResult if this call crossed the threshold
+        and produced a directive, else None. Never raises."""
+        try:
+            if not self._is_enabled():
+                return None
+            if not lesson or not (lesson.signature or "").strip():
+                return None
+            fp = fingerprint(lesson.signature)
+            if not fp:
+                return None
+
+            cluster = self._clusters.get(fp)
+            if cluster is None:
+                cluster = _Cluster(fingerprint=fp)
+                self._clusters[fp] = cluster
+                self._evict_if_needed()
+            self._clusters.move_to_end(fp)  # LRU freshness
+
+            if cluster.consolidated:
+                return None  # already distilled — don't re-fire or re-grow
+            if len(cluster.lessons) < self._threshold:
+                cluster.lessons.append(lesson)
+            if len(cluster.lessons) < self._threshold:
+                return None
+            return self._consolidate(cluster)
+        except Exception:  # noqa: BLE001
+            logger.debug("[Consolidation] record failed (fail-soft)", exc_info=True)
+            return None
+
+    def cluster_size(self, signature: str) -> int:
+        c = self._clusters.get(fingerprint(signature))
+        return len(c.lessons) if c else 0
+
+    # ---- internals --------------------------------------------------------
+    def _evict_if_needed(self) -> None:
+        while len(self._clusters) > self._max_clusters:
+            old_fp, _ = self._clusters.popitem(last=False)  # drop least-recently-used
+            logger.debug("[Consolidation] evicted cluster %s (cap %d)", old_fp[:40], self._max_clusters)
+
+    def _consolidate(self, cluster: _Cluster) -> Optional[ConsolidationResult]:
+        raw_sample = cluster.lessons[0].signature if cluster.lessons else ""
+        principle = _principle_for(cluster.fingerprint, raw_sample)
+        occurrences = len(cluster.lessons)
+        files = tuple(sorted({l.file_path for l in cluster.lessons if l.file_path}))
+        episode_ids = [l.episode_id for l in cluster.lessons if l.episode_id]
+        short = cluster.fingerprint[:60].strip() or "recurring-failure"
+        name = f"core-directive: {short}"
+        description = f"Distilled from {occurrences} similar failures — {principle[:120]}"
+        content = (
+            f"## CORE DIRECTIVE (auto-consolidated)\n\n{principle}\n\n"
+            f"Observed {occurrences}× as: `{cluster.fingerprint[:200]}`"
+        )
+
+        persisted = False
+        if self._store is not None:
+            try:
+                self._store.add(
+                    memory_type=self._style_type,
+                    name=name,
+                    description=description,
+                    content=content,
+                    why=f"Recurred {occurrences} times before consolidation.",
+                    how_to_apply="Apply whenever generating code in the affected area.",
+                    source=f"consolidation:{cluster.fingerprint[:16]}",
+                    tags=("core_directive", "consolidated", "live_fire", "edge_case_armor"),
+                    paths=files,
+                )
+                persisted = True
+            except Exception:  # noqa: BLE001
+                logger.debug("[Consolidation] store.add failed (fail-soft)", exc_info=True)
+
+        purged = 0
+        if persisted and self._purge is not None and episode_ids:
+            try:
+                self._purge(episode_ids)
+                purged = len(episode_ids)
+            except Exception:  # noqa: BLE001
+                logger.debug("[Consolidation] purge failed (fail-soft)", exc_info=True)
+
+        if persisted:
+            cluster.consolidated = True
+            cluster.lessons.clear()  # free the redundant in-memory copies
+            logger.info("[Consolidation] distilled %d×%s → CORE_DIRECTIVE (purged %d episodes)",
+                        occurrences, cluster.fingerprint[:40], purged)
+            return ConsolidationResult(
+                directive_name=name, principle=principle,
+                fingerprint=cluster.fingerprint, episodes_purged=purged,
+                occurrences=occurrences,
+            )
+        return None

--- a/backend/core/ouroboros/governance/semantic_consolidation.py
+++ b/backend/core/ouroboros/governance/semantic_consolidation.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import threading
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any, Callable, List, Optional, Sequence
@@ -280,3 +281,42 @@ class SemanticConsolidationMatrix:
                 occurrences=occurrences,
             )
         return None
+
+
+# ---------------------------------------------------------------------------
+# Process-wide lazy singleton (the call site the Tier-2 deployer injects)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_MATRIX: Optional["SemanticConsolidationMatrix"] = None
+_DEFAULT_MATRIX_LOCK = threading.Lock()
+
+
+def get_default_matrix(project_root: Optional[Any] = None) -> "SemanticConsolidationMatrix":
+    """Return a process-wide :class:`SemanticConsolidationMatrix` wired to the default
+    UserPreferenceStore. Lets orchestrator hooks reach the matrix without threading it
+    through every constructor (mirrors ``get_default_store``). Fail-soft: if the store can't
+    be built, the matrix runs store-less (clusters in memory, persists nothing) — never
+    raising into the hot lesson path. Gating is still per-call via the env master switch."""
+    global _DEFAULT_MATRIX
+    with _DEFAULT_MATRIX_LOCK:
+        if _DEFAULT_MATRIX is None:
+            store = None
+            try:
+                from backend.core.ouroboros.governance.user_preference_memory import (
+                    get_default_store,
+                )
+                store = get_default_store(project_root)
+            except Exception:  # noqa: BLE001
+                logger.debug("[Consolidation] default store unavailable — store-less matrix",
+                             exc_info=True)
+            # purge intentionally None: episodic-purge wiring is a separate, explicit
+            # follow-up — the directive still persists; we just don't auto-evict episodes yet.
+            _DEFAULT_MATRIX = SemanticConsolidationMatrix(store=store, purge=None)
+        return _DEFAULT_MATRIX
+
+
+def reset_default_matrix() -> None:
+    """Clear the process-wide singleton. Primarily for tests."""
+    global _DEFAULT_MATRIX
+    with _DEFAULT_MATRIX_LOCK:
+        _DEFAULT_MATRIX = None

--- a/backend/core/ouroboros/governance/semantic_consolidation.py
+++ b/backend/core/ouroboros/governance/semantic_consolidation.py
@@ -13,7 +13,8 @@ student writes the lesson down once and forgets the noise.
 
 Design discipline (matches the rest of the engine):
   * Decoupled + duck-typed: ``store`` needs only ``.add(memory_type, name, description, ...)``;
-    ``purge`` is any ``Callable[[List[str]], None]``. No hard import of the heavy store, so it
+    ``purge`` is any ``Callable[[str], int]`` taking the consolidated cluster fingerprint and
+    returning how many backing episodes it retired. No hard import of the heavy store, so it
     is unit-testable with fakes and OFF-inert.
   * Default OFF (``JARVIS_SEMANTIC_CONSOLIDATION_ENABLED``). Fail-soft — ``record`` never
     raises into its caller.
@@ -151,7 +152,7 @@ class SemanticConsolidationMatrix:
         self,
         *,
         store: Optional[Any] = None,
-        purge: Optional[Callable[[List[str]], None]] = None,
+        purge: Optional[Callable[[str], int]] = None,
         threshold: Optional[int] = None,
         max_clusters: Optional[int] = None,
         enabled: Optional[bool] = None,
@@ -235,7 +236,6 @@ class SemanticConsolidationMatrix:
         principle = _principle_for(cluster.fingerprint, raw_sample)
         occurrences = len(cluster.lessons)
         files = tuple(sorted({l.file_path for l in cluster.lessons if l.file_path}))
-        episode_ids = [l.episode_id for l in cluster.lessons if l.episode_id]
         short = cluster.fingerprint[:60].strip() or "recurring-failure"
         name = f"core-directive: {short}"
         description = f"Distilled from {occurrences} similar failures — {principle[:120]}"
@@ -263,10 +263,9 @@ class SemanticConsolidationMatrix:
                 logger.debug("[Consolidation] store.add failed (fail-soft)", exc_info=True)
 
         purged = 0
-        if persisted and self._purge is not None and episode_ids:
+        if persisted and self._purge is not None:
             try:
-                self._purge(episode_ids)
-                purged = len(episode_ids)
+                purged = int(self._purge(cluster.fingerprint) or 0)
             except Exception:  # noqa: BLE001
                 logger.debug("[Consolidation] purge failed (fail-soft)", exc_info=True)
 
@@ -309,10 +308,23 @@ def get_default_matrix(project_root: Optional[Any] = None) -> "SemanticConsolida
             except Exception:  # noqa: BLE001
                 logger.debug("[Consolidation] default store unavailable — store-less matrix",
                              exc_info=True)
-            # purge intentionally None: episodic-purge wiring is a separate, explicit
-            # follow-up — the directive still persists; we just don't auto-evict episodes yet.
-            _DEFAULT_MATRIX = SemanticConsolidationMatrix(store=store, purge=None)
+            _DEFAULT_MATRIX = SemanticConsolidationMatrix(store=store, purge=_default_purge)
         return _DEFAULT_MATRIX
+
+
+def _default_purge(fp: str) -> int:
+    """Integrity-preserving purge: retire episodic recall entries whose summary shares the
+    consolidated cluster's fingerprint (RAM cache eviction + append-only supersession
+    tombstone — NEVER deletes the tamper-evident chain). Fail-soft → 0."""
+    try:
+        from backend.core.ouroboros.governance.episodic_core import prune_episodes
+        return prune_episodes(
+            lambda ep: fingerprint(getattr(ep, "summary", "")) == fp,
+            tombstone_label=fp[:60],
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[Consolidation] episodic prune unavailable", exc_info=True)
+        return 0
 
 
 def reset_default_matrix() -> None:

--- a/backend/core/ouroboros/governance/semantic_guardian.py
+++ b/backend/core/ouroboros/governance/semantic_guardian.py
@@ -1361,6 +1361,28 @@ _PATTERNS: dict = {
 
 
 # ---------------------------------------------------------------------------
+# Tier 0 — Anticipatory Edge-Case Armor (blindspot detectors)
+# ---------------------------------------------------------------------------
+#
+# Static detectors for the bug classes that survive ast.parse and bite at runtime
+# (frozen-instance mutation, unguarded Optional deref, no-op loop rebinds) — the gap the
+# LiveKernelValidator catches dynamically. Additive + per-pattern kill switches
+# (JARVIS_SEMGUARD_<NAME>_ENABLED), identical inspect()/Detection contract. Living in a
+# separate module keeps the CFG/immutability analysis isolated; import is fail-soft so a
+# load error can never disable the existing guardian.
+try:  # pragma: no cover - import guard
+    from backend.core.ouroboros.governance.semantic_guardian_blindspots import (
+        BLINDSPOT_PATTERNS as _BLINDSPOT_PATTERNS,
+    )
+    for _bs_name, _bs_detector in _BLINDSPOT_PATTERNS.items():
+        if _bs_name not in _PATTERNS:                     # never shadow a hand-written pattern
+            _PATTERNS[_bs_name] = _bs_detector
+            _ALL_PATTERNS = tuple(_ALL_PATTERNS) + (_bs_name,)
+except Exception:  # noqa: BLE001
+    logger.debug("[SemanticGuard] blindspot detectors unavailable — skipping", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
 # Phase 7.1 — adapted-pattern boot-time merge
 # ---------------------------------------------------------------------------
 #

--- a/backend/core/ouroboros/governance/semantic_guardian_blindspots.py
+++ b/backend/core/ouroboros/governance/semantic_guardian_blindspots.py
@@ -1,0 +1,573 @@
+"""Tier 0 — Anticipatory Edge-Case Armor: blindspot detectors for SemanticGuardian.
+
+These are the static half of the "Founding-Engineer prescience" upgrade: deterministic,
+AST-based, zero-LLM detectors that flag the bug classes that bite at runtime AFTER
+`ast.parse` is happy — the exact gap the LiveKernelValidator exists to catch. They are
+registered into :mod:`semantic_guardian` and obey its contract + kill switches.
+
+Five detectors:
+  * ``frozen_dataclass_mutation``  (hard) — attribute set on a ``@dataclass(frozen=True)``
+  * ``namedtuple_attr_assignment`` (hard) — attribute set on a ``typing.NamedTuple``
+  * ``pydantic_immutable_set``     (hard) — attribute set on a frozen pydantic model
+  * ``type_coercion_blindspot``    (soft) — deref/coerce an ``Optional[...]`` without a guard
+  * ``loop_var_rebind_lost``       (soft) — rebind a loop var whose new value is never read
+
+HONEST SCOPE (the candor that keeps this real):
+  * Immutability detection is exact for classes defined IN the candidate file, and
+    best-effort across files via a *verified* + env-extensible known-frozen-types registry
+    (``JARVIS_SEMGUARD_KNOWN_FROZEN_TYPES``). Type-of-name inference is intra-procedural and
+    conservative (arg/AnnAssign annotations, direct constructor calls, ``dataclasses.replace``
+    propagation). It does not do whole-program type resolution — it favors low false positives.
+  * ``type_coercion_blindspot`` is flow-sensitive but RUDIMENTARY: it tracks None-narrowing
+    through ``if x is not None:`` / ``if x:`` blocks, early-exit ``if x is None: return/raise``
+    guards, ``assert x is not None``, and ``x is not None and <use>`` short-circuits. It is not
+    a type checker (no narrowing via helpers, walrus, complex boolean trees) — on any doubt it
+    stays silent rather than cry wolf at the Iron Gate.
+
+Each public detector matches the SemanticGuardian detector contract:
+    detector(*, file_path, old_content, new_content) -> Optional[Detection]
+and returns at most one Detection (aggregating line numbers), or ``None``.
+"""
+from __future__ import annotations
+
+import ast
+import os
+from typing import Dict, List, Optional, Set, Tuple
+
+# Detection is imported lazily (inside _make) to avoid a circular import with
+# semantic_guardian, which imports these detectors at the bottom of its module.
+
+# Verified-frozen project types (confirmed @dataclass(frozen=True) at read time). The
+# orchestrator mutates op_context.ValidationResult cross-file — the canonical case this
+# armor exists to catch — so it MUST be seeded here, not discovered in-file.
+_SEEDED_KNOWN_FROZEN: Tuple[str, ...] = (
+    "ValidationResult",
+    "OperationContext",
+    "ApprovalDecision",
+    "GenerationResult",
+    "UserMemory",
+    "Detection",
+)
+
+_COERCERS: frozenset = frozenset(
+    {"int", "float", "len", "str", "bool", "list", "dict", "set", "tuple", "sorted", "sum"}
+)
+_TERMINALS = (ast.Return, ast.Raise, ast.Continue, ast.Break)
+
+
+# ---------------------------------------------------------------------------
+# Result + parse + Detection adapter
+# ---------------------------------------------------------------------------
+
+
+class _Hit:
+    """Internal pre-Detection result (severity/message/lines/snippet)."""
+
+    __slots__ = ("severity", "message", "lines", "snippet")
+
+    def __init__(self, severity: str, message: str, lines: Tuple[int, ...], snippet: str = ""):
+        self.severity = severity
+        self.message = message
+        self.lines = lines
+        self.snippet = snippet
+
+
+def _make(pattern: str, file_path: str, hit: Optional[_Hit]):
+    """Adapt an internal _Hit to a semantic_guardian.Detection (lazy import)."""
+    if hit is None:
+        return None
+    from backend.core.ouroboros.governance.semantic_guardian import Detection
+
+    return Detection(
+        pattern=pattern,
+        severity=hit.severity,
+        message=hit.message,
+        file_path=file_path,
+        lines=hit.lines,
+        snippet=hit.snippet,
+    )
+
+
+def _parse(src: str) -> Optional[ast.Module]:
+    try:
+        return ast.parse(src or "")
+    except (SyntaxError, ValueError):
+        return None
+
+
+def _known_frozen_types() -> Set[str]:
+    extra = os.environ.get("JARVIS_SEMGUARD_KNOWN_FROZEN_TYPES", "")
+    names = set(_SEEDED_KNOWN_FROZEN)
+    for tok in extra.replace(",", " ").split():
+        tok = tok.strip()
+        if tok:
+            names.add(tok)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Immutability classification
+# ---------------------------------------------------------------------------
+
+
+def _decorator_is_frozen_dataclass(dec: ast.expr) -> bool:
+    """True for @dataclass(frozen=True) (with or without other args)."""
+    if not isinstance(dec, ast.Call):
+        return False
+    fn = dec.func
+    name = fn.id if isinstance(fn, ast.Name) else (fn.attr if isinstance(fn, ast.Attribute) else "")
+    if name != "dataclass":
+        return False
+    for kw in dec.keywords:
+        if kw.arg == "frozen" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+            return True
+    return False
+
+
+def _base_names(cls: ast.ClassDef) -> Set[str]:
+    out: Set[str] = set()
+    for b in cls.bases:
+        if isinstance(b, ast.Name):
+            out.add(b.id)
+        elif isinstance(b, ast.Attribute):
+            out.add(b.attr)
+    return out
+
+
+def _pydantic_is_frozen(cls: ast.ClassDef) -> bool:
+    """Detect a frozen pydantic model: model_config=ConfigDict(frozen=True) (v2) or a
+    nested ``class Config`` with frozen=True / allow_mutation=False (v1)."""
+    for node in cls.body:
+        # v2: model_config = ConfigDict(frozen=True) / model_config = {"frozen": True}
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == "model_config":
+                    v = node.value
+                    if isinstance(v, ast.Call):
+                        for kw in v.keywords:
+                            if kw.arg == "frozen" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                                return True
+                    if isinstance(v, ast.Dict):
+                        for k, val in zip(v.keys, v.values):
+                            if (isinstance(k, ast.Constant) and k.value == "frozen"
+                                    and isinstance(val, ast.Constant) and val.value is True):
+                                return True
+        # v1: class Config: frozen = True  /  allow_mutation = False
+        if isinstance(node, ast.ClassDef) and node.name == "Config":
+            for sub in node.body:
+                if isinstance(sub, ast.Assign):
+                    for tgt in sub.targets:
+                        if not isinstance(tgt, ast.Name):
+                            continue
+                        if (tgt.id == "frozen" and isinstance(sub.value, ast.Constant)
+                                and sub.value.value is True):
+                            return True
+                        if (tgt.id == "allow_mutation" and isinstance(sub.value, ast.Constant)
+                                and sub.value.value is False):
+                            return True
+    return False
+
+
+def _classify_module_classes(module: ast.Module) -> Dict[str, str]:
+    """Map class-name -> immutability kind for classes defined in this module.
+    kind ∈ {"frozen_dataclass", "namedtuple", "pydantic_frozen"}."""
+    kinds: Dict[str, str] = {}
+    for node in ast.walk(module):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if any(_decorator_is_frozen_dataclass(d) for d in node.decorator_list):
+            kinds[node.name] = "frozen_dataclass"
+            continue
+        bases = _base_names(node)
+        if "NamedTuple" in bases:
+            kinds[node.name] = "namedtuple"
+            continue
+        if "BaseModel" in bases and _pydantic_is_frozen(node):
+            kinds[node.name] = "pydantic_frozen"
+    return kinds
+
+
+def _annotation_type_name(ann: Optional[ast.expr]) -> Optional[str]:
+    if isinstance(ann, ast.Name):
+        return ann.id
+    if isinstance(ann, ast.Attribute):
+        return ann.attr
+    if isinstance(ann, ast.Constant) and isinstance(ann.value, str):
+        return ann.value  # string forward-ref
+    return None
+
+
+def _infer_name_types(func: ast.AST) -> Dict[str, str]:
+    """Intra-procedural name -> class-name inference. Conservative: arg annotations,
+    AnnAssign annotations, direct constructor calls, and dataclasses.replace propagation.
+    Last write wins; a rebind to an unknown shape clears the name."""
+    types: Dict[str, str] = {}
+
+    if isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        a = func.args
+        for arg in list(a.posonlyargs) + list(a.args) + list(a.kwonlyargs):
+            t = _annotation_type_name(arg.annotation)
+            if t:
+                types[arg.arg] = t
+
+    for node in ast.walk(func):
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            t = _annotation_type_name(node.annotation)
+            if t:
+                types[node.target.id] = t
+        elif isinstance(node, ast.Assign):
+            tnames = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if not tnames:
+                continue
+            inferred = _infer_value_type(node.value, types)
+            for nm in tnames:
+                if inferred:
+                    types[nm] = inferred
+                else:
+                    types.pop(nm, None)  # rebind to unknown shape — stop tracking
+    return types
+
+
+def _infer_value_type(value: ast.expr, known: Dict[str, str]) -> Optional[str]:
+    """ClassName(...) -> ClassName; dataclasses.replace(x, ...) -> type-of-x."""
+    if isinstance(value, ast.Call):
+        fn = value.func
+        if isinstance(fn, ast.Name):
+            if fn.id == "replace" and value.args:
+                first = value.args[0]
+                return known.get(first.id) if isinstance(first, ast.Name) else None
+            if fn.id and fn.id[:1].isupper():
+                return fn.id
+        elif isinstance(fn, ast.Attribute):
+            if fn.attr == "replace" and value.args:  # dataclasses.replace(x, ...)
+                first = value.args[0]
+                return known.get(first.id) if isinstance(first, ast.Name) else None
+            if fn.attr and fn.attr[:1].isupper():
+                return fn.attr
+    return None
+
+
+def _immutable_attr_violations(module: ast.Module, want_kind: str) -> List[int]:
+    """Line numbers of `x.attr = ...` / `x.attr op= ...` where x's inferred type is an
+    immutable class of ``want_kind`` (in-file class OR known-frozen registry → frozen_dataclass)."""
+    local_kinds = _classify_module_classes(module)
+    known_frozen = _known_frozen_types()
+    lines: List[int] = []
+
+    # module-level code + every function/method scope (each has its own name types)
+    scopes: List[ast.AST] = [module]
+    scopes += [n for n in ast.walk(module) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+
+    seen: Set[int] = set()
+    for scope in scopes:
+        types = _infer_name_types(scope)
+        for node in ast.walk(scope):
+            if isinstance(node, (ast.Assign,)):
+                tgts = node.targets
+            elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+                tgts = [node.target]
+            else:
+                continue
+            for tgt in tgts:
+                if not (isinstance(tgt, ast.Attribute) and isinstance(tgt.value, ast.Name)):
+                    continue
+                tname = types.get(tgt.value.id)
+                if not tname:
+                    continue
+                kind = local_kinds.get(tname)
+                if kind is None and tname in known_frozen:
+                    kind = "frozen_dataclass"
+                if kind == want_kind and node.lineno not in seen:
+                    seen.add(node.lineno)
+                    lines.append(node.lineno)
+    return sorted(lines)
+
+
+def _immutable_detector(want_kind: str, label: str, new_content: str) -> Optional[_Hit]:
+    module = _parse(new_content)
+    if module is None:
+        return None
+    lines = _immutable_attr_violations(module, want_kind)
+    if not lines:
+        return None
+    return _Hit(
+        severity="hard",
+        message=(f"attribute assignment to a {label} instance — this raises at runtime "
+                 f"(use dataclasses.replace / _replace / model_copy to produce a new value)"),
+        lines=tuple(lines),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Optional-guard flow analysis (type_coercion_blindspot)
+# ---------------------------------------------------------------------------
+
+
+def _is_optional_annotation(ann: Optional[ast.expr]) -> bool:
+    """True for Optional[...] or X | None (or None | X)."""
+    if ann is None:
+        return False
+    if isinstance(ann, ast.Subscript):
+        base = ann.value
+        nm = base.id if isinstance(base, ast.Name) else (base.attr if isinstance(base, ast.Attribute) else "")
+        return nm == "Optional"
+    if isinstance(ann, ast.BinOp) and isinstance(ann.op, ast.BitOr):
+        for side in (ann.left, ann.right):
+            if isinstance(side, ast.Constant) and side.value is None:
+                return True
+    if isinstance(ann, ast.Constant) and isinstance(ann.value, str):
+        s = ann.value.replace(" ", "")
+        return s.startswith("Optional[") or s.endswith("|None") or s.startswith("None|")
+    return False
+
+
+def _narrowed_name(test: ast.expr) -> Optional[Tuple[str, bool]]:
+    """Return (name, narrows_true) where narrows_true means the THEN branch makes name
+    non-None. `x is not None` / `x` -> (x, True); `x is None` -> (x, False)."""
+    if isinstance(test, ast.Compare) and len(test.ops) == 1 and isinstance(test.left, ast.Name):
+        op = test.ops[0]
+        comp = test.comparators[0]
+        if isinstance(comp, ast.Constant) and comp.value is None:
+            if isinstance(op, ast.IsNot):
+                return (test.left.id, True)
+            if isinstance(op, ast.Is):
+                return (test.left.id, False)
+    if isinstance(test, ast.Name):
+        return (test.id, True)  # `if x:` narrows x truthy in the body
+    return None
+
+
+def _block_terminates(stmts: List[ast.stmt]) -> bool:
+    return bool(stmts) and isinstance(stmts[-1], _TERMINALS)
+
+
+class _CoercionScan:
+    """Collects unguarded deref/coercion lines. Recurses through expressions honoring
+    `and` short-circuit narrowing (in `x is not None and x.f`, x is safe for the right
+    operand) and consults the CURRENT tracked set (so a reassigned name stops tracking)."""
+
+    def __init__(self) -> None:
+        self.lines: Set[int] = set()
+
+    def check_expr(self, node: Optional[ast.expr], tracked: Set[str], guarded: Set[str]) -> None:
+        if node is None:
+            return
+        self._visit(node, tracked, set(guarded))
+
+    def _visit(self, node: ast.AST, tracked: Set[str], guarded: Set[str]) -> None:
+        if isinstance(node, ast.BoolOp):
+            if isinstance(node.op, ast.And):
+                g = set(guarded)
+                for v in node.values:
+                    self._visit(v, tracked, g)
+                    nn = _narrowed_name(v)
+                    if nn and nn[1]:
+                        g.add(nn[0])          # left operand narrows the rest of the `and`
+            else:                              # Or: no fact carries between operands
+                for v in node.values:
+                    self._visit(v, tracked, guarded)
+            return
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            self._flag(node.value.id, node.lineno, tracked, guarded)
+        elif isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+            self._flag(node.value.id, node.lineno, tracked, guarded)
+        elif (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+              and node.func.id in _COERCERS):
+            for a in node.args:
+                if isinstance(a, ast.Name):
+                    self._flag(a.id, node.lineno, tracked, guarded)
+        for child in ast.iter_child_nodes(node):
+            self._visit(child, tracked, guarded)
+
+    def _flag(self, name: str, lineno: int, tracked: Set[str], guarded: Set[str]) -> None:
+        if name in tracked and name not in guarded:
+            self.lines.add(lineno)
+
+
+def _process_block(stmts: List[ast.stmt], tracked: Set[str], guarded: Set[str],
+                   scan: _CoercionScan) -> None:
+    """Walk a statement list sequentially, threading None-narrowing facts forward."""
+    guarded = set(guarded)
+    tracked = set(tracked)
+    for stmt in stmts:
+        if isinstance(stmt, ast.If):
+            scan.check_expr(stmt.test, tracked, guarded)
+            nn = _narrowed_name(stmt.test)
+            then_guard, else_guard = set(guarded), set(guarded)
+            if nn:
+                name, narrows_true = nn
+                (then_guard if narrows_true else else_guard).add(name)
+            _process_block(stmt.body, tracked, then_guard, scan)
+            _process_block(stmt.orelse, tracked, else_guard, scan)
+            # early-exit narrowing: rest of THIS block learns the surviving fact
+            if nn:
+                name, narrows_true = nn
+                if not narrows_true and _block_terminates(stmt.body):
+                    guarded.add(name)          # `if x is None: return` -> x safe after
+                elif narrows_true and _block_terminates(stmt.orelse):
+                    guarded.add(name)          # `if x is not None: ... else: return`
+        elif isinstance(stmt, ast.Assert):
+            scan.check_expr(stmt.test, tracked, guarded)
+            nn = _narrowed_name(stmt.test)
+            if nn and nn[1]:
+                guarded.add(nn[0])
+        elif isinstance(stmt, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            # check the RHS / value first under current facts
+            val = getattr(stmt, "value", None)
+            scan.check_expr(val, tracked, guarded)
+            # a rebind of a tracked name clears its tracking + guard for the rest
+            targets = stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
+            for t in targets:
+                if isinstance(t, ast.Name):
+                    tracked.discard(t.id)
+                    guarded.discard(t.id)
+                else:
+                    scan.check_expr(t, tracked, guarded)  # x.attr / x[i] target is itself a deref
+        elif isinstance(stmt, (ast.For, ast.AsyncFor)):
+            scan.check_expr(stmt.iter, tracked, guarded)
+            _process_block(stmt.body, tracked, guarded, scan)
+            _process_block(stmt.orelse, tracked, guarded, scan)
+        elif isinstance(stmt, ast.While):
+            scan.check_expr(stmt.test, tracked, guarded)
+            nn = _narrowed_name(stmt.test)
+            body_guard = set(guarded)
+            if nn and nn[1]:
+                body_guard.add(nn[0])
+            _process_block(stmt.body, tracked, body_guard, scan)
+            _process_block(stmt.orelse, tracked, guarded, scan)
+        elif isinstance(stmt, (ast.With, ast.AsyncWith)):
+            for item in stmt.items:
+                scan.check_expr(item.context_expr, tracked, guarded)
+            _process_block(stmt.body, tracked, guarded, scan)
+        elif isinstance(stmt, ast.Try):
+            _process_block(stmt.body, tracked, guarded, scan)
+            for h in stmt.handlers:
+                _process_block(h.body, tracked, guarded, scan)
+            _process_block(stmt.orelse, tracked, guarded, scan)
+            _process_block(stmt.finalbody, tracked, guarded, scan)
+        elif isinstance(stmt, (ast.Return, ast.Expr, ast.Raise)):
+            scan.check_expr(getattr(stmt, "value", None) or getattr(stmt, "exc", None), tracked, guarded)
+        # nested function/class defs: handled separately as their own scopes
+
+
+def _optional_names_for(func: ast.AST) -> Set[str]:
+    names: Set[str] = set()
+    if isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        a = func.args
+        for arg in list(a.posonlyargs) + list(a.args) + list(a.kwonlyargs):
+            if _is_optional_annotation(arg.annotation):
+                names.add(arg.arg)
+    for node in ast.walk(func):
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if _is_optional_annotation(node.annotation):
+                names.add(node.target.id)
+    return names
+
+
+def _coercion_blindspot(new_content: str) -> Optional[_Hit]:
+    module = _parse(new_content)
+    if module is None:
+        return None
+    all_lines: Set[int] = set()
+    for func in ast.walk(module):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        tracked = _optional_names_for(func)
+        if not tracked:
+            continue
+        scan = _CoercionScan()
+        _process_block(func.body, tracked, set(), scan)
+        all_lines |= scan.lines
+    if not all_lines:
+        return None
+    return _Hit(
+        severity="soft",
+        message=("Optional-typed value dereferenced/coerced without a None-guard — "
+                 "guard with `if x is not None:` (or narrow before use) to avoid a "
+                 "runtime AttributeError/TypeError"),
+        lines=tuple(sorted(all_lines)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# loop_var_rebind_lost
+# ---------------------------------------------------------------------------
+
+
+def _loop_var_rebind_lost(new_content: str) -> Optional[_Hit]:
+    """Flag `for v in ...: ... v = <expr>` where v is reassigned but the new value is never
+    read afterward in the loop body — a classic no-op 'fix' (the rebind is discarded next
+    iteration). Conservative: only the simple single-target case, value-not-read-after."""
+    module = _parse(new_content)
+    if module is None:
+        return None
+    lines: List[int] = []
+    for loop in ast.walk(module):
+        if not isinstance(loop, (ast.For, ast.AsyncFor)) or not isinstance(loop.target, ast.Name):
+            continue
+        var = loop.target.id
+        body = loop.body
+        for idx, stmt in enumerate(body):
+            if not isinstance(stmt, ast.Assign):
+                continue
+            if not (len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name)
+                    and stmt.targets[0].id == var):
+                continue
+            # is `var` read anywhere AFTER this statement in the remaining body?
+            read_after = False
+            for later in body[idx + 1:]:
+                for n in ast.walk(later):
+                    if isinstance(n, ast.Name) and n.id == var and isinstance(n.ctx, ast.Load):
+                        read_after = True
+                        break
+                if read_after:
+                    break
+            if not read_after:
+                lines.append(stmt.lineno)
+    if not lines:
+        return None
+    return _Hit(
+        severity="soft",
+        message=("loop variable reassigned but the new value is never read before the next "
+                 "iteration — the rebind is discarded (likely a no-op fix; mutate a "
+                 "collection or accumulate instead)"),
+        lines=tuple(sorted(set(lines))),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public detectors (SemanticGuardian contract)
+# ---------------------------------------------------------------------------
+
+
+def pat_frozen_dataclass_mutation(*, file_path: str, old_content: str, new_content: str):
+    return _make("frozen_dataclass_mutation", file_path,
+                 _immutable_detector("frozen_dataclass", "frozen dataclass", new_content))
+
+
+def pat_namedtuple_attr_assignment(*, file_path: str, old_content: str, new_content: str):
+    return _make("namedtuple_attr_assignment", file_path,
+                 _immutable_detector("namedtuple", "NamedTuple", new_content))
+
+
+def pat_pydantic_immutable_set(*, file_path: str, old_content: str, new_content: str):
+    return _make("pydantic_immutable_set", file_path,
+                 _immutable_detector("pydantic_frozen", "frozen pydantic model", new_content))
+
+
+def pat_type_coercion_blindspot(*, file_path: str, old_content: str, new_content: str):
+    return _make("type_coercion_blindspot", file_path, _coercion_blindspot(new_content))
+
+
+def pat_loop_var_rebind_lost(*, file_path: str, old_content: str, new_content: str):
+    return _make("loop_var_rebind_lost", file_path, _loop_var_rebind_lost(new_content))
+
+
+# Registry export consumed by semantic_guardian (name -> detector).
+BLINDSPOT_PATTERNS: Dict[str, object] = {
+    "frozen_dataclass_mutation": pat_frozen_dataclass_mutation,
+    "namedtuple_attr_assignment": pat_namedtuple_attr_assignment,
+    "pydantic_immutable_set": pat_pydantic_immutable_set,
+    "type_coercion_blindspot": pat_type_coercion_blindspot,
+    "loop_var_rebind_lost": pat_loop_var_rebind_lost,
+}

--- a/scripts/deploy_live_validator_fsm.py
+++ b/scripts/deploy_live_validator_fsm.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Slice 256 — Sovereign Transition Injector: wire the LiveKernelValidator into the
+orchestrator VALIDATE phase, SAFELY + reversibly.
+
+Design honesty (the same discipline the validator enforces):
+  * The injection is EXACT-CONTEXT (a unique anchor string found exactly once), NOT
+    fuzzy AST surgery — it refuses rather than guess if the anchor drifted.
+  * The rollback gate is a REAL subprocess import of the modified orchestrator
+    (reality), NOT ast.parse (syntax). ast.parse would pass a hook that references a
+    nonexistent attr — the exact AttributeError class this engine hunts. If the live
+    import fails, we auto-revert from the .bak.
+  * The injected hook is FLAG-GATED (JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED, default OFF)
+    and FAIL-SOFT (wrapped in try/except) so a subtly-wrong hook cannot crash VALIDATE
+    — worst case it logs and no-ops. It reuses the EXISTING retry machinery by flipping
+    validation.passed→False (and logs LOUDLY "gate INERT" if validation is frozen — the
+    one detail only the dogfood boot can confirm).
+
+Run sandbox-off on a main+.env checkout:  python3 scripts/deploy_live_validator_fsm.py
+Idempotent: refuses if the marker is already present.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ORCH = Path("backend/core/ouroboros/governance/orchestrator.py")
+BAK = ORCH.with_suffix(".py.slice256.bak")
+MARKER = "Slice 256: live-fire VALIDATE gate"
+ANCHOR = "                    candidate, validation, _validate_duration_s = _vr\n"
+
+WIRING = (
+    "                    # --- Slice 256: live-fire VALIDATE gate (flag-gated, fail-soft) ---\n"
+    "                    try:\n"
+    "                        import os as _lf_os\n"
+    "                        if (_lf_os.getenv('JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED', 'false')\n"
+    "                                .strip().lower() in ('1', 'true', 'yes', 'on')) and getattr(validation, 'passed', False):\n"
+    "                            import ast as _lf_ast\n"
+    "                            from backend.core.ouroboros.governance.live_kernel_validator import (\n"
+    "                                LiveKernelValidator as _LFV,\n"
+    "                            )\n"
+    "                            _lf_files = candidate.get('files') or [{\n"
+    "                                'file_path': candidate.get('file_path', ''),\n"
+    "                                'full_content': candidate.get('full_content', ''),\n"
+    "                            }]\n"
+    "                            _lf_changed = [f.get('file_path', '') for f in _lf_files if f.get('file_path')]\n"
+    "                            if _LFV.affects_kernel(_lf_changed):\n"
+    "                                _lf_syms = []\n"
+    "                                for _lf_f in _lf_files:\n"
+    "                                    try:\n"
+    "                                        for _lf_n in _lf_ast.parse(_lf_f.get('full_content', '')).body:\n"
+    "                                            if isinstance(_lf_n, (_lf_ast.FunctionDef, _lf_ast.AsyncFunctionDef, _lf_ast.ClassDef)):\n"
+    "                                                _lf_syms.append(_lf_n.name)\n"
+    "                                    except Exception:\n"
+    "                                        pass\n"
+    "                                _lf_res = await _LFV().validate_patch(changed_files=_lf_changed, affected_symbols=_lf_syms)\n"
+    "                                if not _lf_res.ok:\n"
+    "                                    logger.warning('[LiveFire] candidate FAILED live-fire boot: %s: %s',\n"
+    "                                                   _lf_res.exception_type, (_lf_res.traceback or '')[-500:])\n"
+    "                                    try:\n"
+    "                                        validation.passed = False\n"
+    "                                        validation.failure_class = 'live_fire_boot_failure'\n"
+    "                                    except Exception:\n"
+    "                                        logger.error('[LiveFire] could not mark validation failed (frozen?) — GATE INERT; '\n"
+    "                                                     'wire a mutable validation signal here.')\n"
+    "                    except Exception as _lf_err:\n"
+    "                        logger.warning('[LiveFire] gate error (fail-soft, skipped): %r', _lf_err)\n"
+    "                    # --- end Slice 256 ---\n"
+)
+
+
+def _default_boot_check() -> tuple[bool, str]:
+    """REAL validation: import the modified orchestrator in a subprocess. Catches
+    syntax + import-time breakage the injection might introduce (ast.parse would not)."""
+    proc = subprocess.run(
+        [sys.executable, "-c",
+         "import backend.core.ouroboros.governance.orchestrator; print('IMPORT_OK')"],
+        capture_output=True, text=True, timeout=180,
+    )
+    ok = proc.returncode == 0 and "IMPORT_OK" in proc.stdout
+    return ok, (proc.stderr or proc.stdout)[-3000:]
+
+
+def deploy(*, orch: Path = ORCH, boot_check=_default_boot_check) -> int:
+    if not orch.is_file():
+        print(f"ERROR: {orch} not found (run from repo root)", file=sys.stderr)
+        return 2
+    src = orch.read_text(encoding="utf-8")
+    if MARKER in src:
+        print("Already deployed (marker present) — no-op.")
+        return 0
+    n = src.count(ANCHOR)
+    if n != 1:
+        print(f"ERROR: anchor found {n} times (expected 1) — orchestrator drifted; "
+              f"refusing fuzzy injection. Re-derive the anchor.", file=sys.stderr)
+        return 3
+
+    shutil.copy2(orch, BAK)                      # .bak armor
+    patched = src.replace(ANCHOR, ANCHOR + WIRING, 1)
+    orch.write_text(patched, encoding="utf-8")
+    print(f"Injected wiring after anchor; backup at {BAK}")
+
+    try:
+        ok, detail = boot_check()
+    except Exception as err:  # noqa: BLE001
+        ok, detail = False, f"boot check raised: {err!r}"
+
+    if not ok:
+        shutil.copy2(BAK, orch)                  # AUTO-REVERT
+        print(f"BOOT CHECK FAILED → auto-reverted from {BAK}.\n--- detail ---\n{detail}",
+              file=sys.stderr)
+        return 4
+
+    print("BOOT CHECK PASSED (orchestrator imports clean). Wiring deployed.\n"
+          "NOTE: functional proof = the dogfood boot. If logs show "
+          "'[LiveFire] ... GATE INERT', `validation` is frozen — that's the one detail "
+          "the boot surfaces; fix with a mutable validation signal at the anchor.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(deploy())

--- a/scripts/deploy_live_validator_fsm.py
+++ b/scripts/deploy_live_validator_fsm.py
@@ -11,9 +11,10 @@ Design honesty (the same discipline the validator enforces):
     import fails, we auto-revert from the .bak.
   * The injected hook is FLAG-GATED (JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED, default OFF)
     and FAIL-SOFT (wrapped in try/except) so a subtly-wrong hook cannot crash VALIDATE
-    — worst case it logs and no-ops. It reuses the EXISTING retry machinery by flipping
-    validation.passed→False (and logs LOUDLY "gate INERT" if validation is frozen — the
-    one detail only the dogfood boot can confirm).
+    — worst case it logs and no-ops. It reuses the EXISTING retry machinery by REBINDING
+    validation via dataclasses.replace(passed=False) — VERIFIED-correct because
+    op_context.ValidationResult is @dataclass(frozen=True), so a plain attribute set would
+    raise FrozenInstanceError.
 
 Run sandbox-off on a main+.env checkout:  python3 scripts/deploy_live_validator_fsm.py
 Idempotent: refuses if the marker is already present.
@@ -58,12 +59,22 @@ WIRING = (
     "                                if not _lf_res.ok:\n"
     "                                    logger.warning('[LiveFire] candidate FAILED live-fire boot: %s: %s',\n"
     "                                                   _lf_res.exception_type, (_lf_res.traceback or '')[-500:])\n"
-    "                                    try:\n"
-    "                                        validation.passed = False\n"
-    "                                        validation.failure_class = 'live_fire_boot_failure'\n"
-    "                                    except Exception:\n"
-    "                                        logger.error('[LiveFire] could not mark validation failed (frozen?) — GATE INERT; '\n"
-    "                                                     'wire a mutable validation signal here.')\n"
+    "                                    # VERIFIED: op_context.ValidationResult is @dataclass(frozen=True) —\n"
+    "                                    # a plain `validation.passed = False` raises FrozenInstanceError. We\n"
+    "                                    # REBIND the loop var via dataclasses.replace so downstream\n"
+    "                                    # (`best_validation = validation`, the `if validation.passed` branch,\n"
+    "                                    # ledger) sees the failed result and the EXISTING retry/escalation\n"
+    "                                    # machinery handles route-back. failure_class='build' (the patch does\n"
+    "                                    # not even import) routes it like a build break; tune if desired.\n"
+    "                                    import dataclasses as _lf_dc\n"
+    "                                    validation = _lf_dc.replace(\n"
+    "                                        validation,\n"
+    "                                        passed=False,\n"
+    "                                        failure_class='build',\n"
+    "                                        error='live-fire boot failure: ' + str(_lf_res.exception_type),\n"
+    "                                        short_summary=('live-fire boot failure: ' + str(_lf_res.exception_type)\n"
+    "                                                       + ': ' + (_lf_res.traceback or ''))[:300],\n"
+    "                                    )\n"
     "                    except Exception as _lf_err:\n"
     "                        logger.warning('[LiveFire] gate error (fail-soft, skipped): %r', _lf_err)\n"
     "                    # --- end Slice 256 ---\n"
@@ -113,9 +124,11 @@ def deploy(*, orch: Path = ORCH, boot_check=_default_boot_check) -> int:
         return 4
 
     print("BOOT CHECK PASSED (orchestrator imports clean). Wiring deployed.\n"
-          "NOTE: functional proof = the dogfood boot. If logs show "
-          "'[LiveFire] ... GATE INERT', `validation` is frozen — that's the one detail "
-          "the boot surfaces; fix with a mutable validation signal at the anchor.")
+          "NOTE: functional proof = the dogfood boot. The wiring is frozen-dataclass-safe "
+          "(rebinds via dataclasses.replace). With JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED=true, "
+          "a kernel-touching candidate that fails its live-fire import will log "
+          "'[LiveFire] candidate FAILED live-fire boot' and route back through the existing "
+          "retry machinery (failure_class=build).")
     return 0
 
 

--- a/scripts/deploy_tier2_consolidation.py
+++ b/scripts/deploy_tier2_consolidation.py
@@ -91,10 +91,10 @@ def deploy(*, orch: Path = ORCH, boot_check=_default_boot_check) -> int:
         return 4
 
     print("BOOT CHECK PASSED (orchestrator imports clean). Tier-2 wiring deployed.\n"
-          "With JARVIS_SEMANTIC_CONSOLIDATION_ENABLED=true, recurring failure lessons now "
-          "cluster and distill into CORE_DIRECTIVE STYLE memories. NOTE: episodic-purge is a "
-          "separate follow-up (matrix runs purge=None for now — directives persist, episodes "
-          "are not auto-evicted yet).")
+          "With JARVIS_SEMANTIC_CONSOLIDATION_ENABLED=true, recurring failure lessons cluster "
+          "and distill into CORE_DIRECTIVE STYLE memories; on commit, the matrix retires the "
+          "superseded episodes via the integrity-preserving episodic prune (RAM eviction + "
+          "append-only supersession tombstone — the durable hash chain is never erased).")
     return 0
 
 

--- a/scripts/deploy_tier2_consolidation.py
+++ b/scripts/deploy_tier2_consolidation.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tier 2 deployer — wire the SemanticConsolidationMatrix into the orchestrator's lesson
+choke point, SAFELY + reversibly. Same armor + discipline as deploy_live_validator_fsm.py.
+
+Integration point (VERIFIED): every session lesson flows through ONE central append —
+`self._session_lessons.append((lesson_type, lesson_text))` (unique anchor). We inject a
+flag-gated, fail-soft `get_default_matrix(...).record(Lesson(...))` right after it, so the
+matrix sees ALL failure lessons (incl. live-fire build failures) with a single edit and no
+new method. The matrix is a process-wide lazy singleton (get_default_matrix), so no
+instance plumbing is injected.
+
+Armor (identical guarantees to the validator deployer):
+  * EXACT-CONTEXT injection (anchor count must == 1) — refuses on drift.
+  * Rollback gate = REAL subprocess import of the modified orchestrator (NOT ast.parse) —
+    auto-revert from .bak on any boot failure OR exception (fail-closed).
+  * Injected hook is FLAG-GATED (JARVIS_SEMANTIC_CONSOLIDATION_ENABLED, default OFF) +
+    FAIL-SOFT — cannot perturb the lesson hot path (worst case: no-op).
+  * Idempotent (marker check → no-op).
+
+Run sandbox-off on a main+.env checkout:  python3 scripts/deploy_tier2_consolidation.py
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ORCH = Path("backend/core/ouroboros/governance/orchestrator.py")
+BAK = ORCH.with_suffix(".py.tier2.bak")
+MARKER = "Tier 2: semantic consolidation"
+ANCHOR = "        self._session_lessons.append((lesson_type, lesson_text))\n"
+
+WIRING = (
+    "        # --- Tier 2: semantic consolidation (flag-gated, fail-soft) ---\n"
+    "        try:\n"
+    "            import os as _sc_os\n"
+    "            if _sc_os.getenv('JARVIS_SEMANTIC_CONSOLIDATION_ENABLED', 'false').strip().lower() \\\n"
+    "                    in ('1', 'true', 'yes', 'on'):\n"
+    "                from backend.core.ouroboros.governance.semantic_consolidation import (\n"
+    "                    get_default_matrix as _sc_matrix, Lesson as _sc_Lesson,\n"
+    "                )\n"
+    "                _sc_root = getattr(getattr(self, '_config', None), 'project_root', None)\n"
+    "                _sc_matrix(_sc_root).record(\n"
+    "                    _sc_Lesson(signature=str(lesson_text), kind=str(lesson_type))\n"
+    "                )\n"
+    "        except Exception:\n"
+    "            pass\n"
+    "        # --- end Tier 2 ---\n"
+)
+
+
+def _default_boot_check():
+    proc = subprocess.run(
+        [sys.executable, "-c",
+         "import backend.core.ouroboros.governance.orchestrator; print('IMPORT_OK')"],
+        capture_output=True, text=True, timeout=180,
+    )
+    ok = proc.returncode == 0 and "IMPORT_OK" in proc.stdout
+    return ok, (proc.stderr or proc.stdout)[-3000:]
+
+
+def deploy(*, orch: Path = ORCH, boot_check=_default_boot_check) -> int:
+    if not orch.is_file():
+        print(f"ERROR: {orch} not found (run from repo root)", file=sys.stderr)
+        return 2
+    src = orch.read_text(encoding="utf-8")
+    if MARKER in src:
+        print("Already deployed (marker present) — no-op.")
+        return 0
+    n = src.count(ANCHOR)
+    if n != 1:
+        print(f"ERROR: anchor found {n} times (expected 1) — orchestrator drifted; "
+              f"refusing fuzzy injection.", file=sys.stderr)
+        return 3
+
+    shutil.copy2(orch, BAK)
+    patched = src.replace(ANCHOR, ANCHOR + WIRING, 1)
+    orch.write_text(patched, encoding="utf-8")
+    print(f"Injected Tier-2 wiring after anchor; backup at {BAK}")
+
+    try:
+        ok, detail = boot_check()
+    except Exception as err:  # noqa: BLE001
+        ok, detail = False, f"boot check raised: {err!r}"
+
+    if not ok:
+        shutil.copy2(BAK, orch)
+        print(f"BOOT CHECK FAILED → auto-reverted from {BAK}.\n--- detail ---\n{detail}",
+              file=sys.stderr)
+        return 4
+
+    print("BOOT CHECK PASSED (orchestrator imports clean). Tier-2 wiring deployed.\n"
+          "With JARVIS_SEMANTIC_CONSOLIDATION_ENABLED=true, recurring failure lessons now "
+          "cluster and distill into CORE_DIRECTIVE STYLE memories. NOTE: episodic-purge is a "
+          "separate follow-up (matrix runs purge=None for now — directives persist, episodes "
+          "are not auto-evicted yet).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(deploy())

--- a/tests/governance/test_semantic_consolidation.py
+++ b/tests/governance/test_semantic_consolidation.py
@@ -88,15 +88,20 @@ def test_consolidates_once_then_quiet():
     assert len(store.added) == 1
 
 
-def test_purge_called_with_episode_ids():
+def test_purge_called_with_fingerprint():
     store = _FakeStore()
-    purged = []
-    m = SemanticConsolidationMatrix(store=store, purge=lambda ids: purged.extend(ids),
-                                    threshold=3, enabled=True)
-    for i in range(3):
-        m.record(_lf("ImportError: cannot import name x", ep=f"ep-{i}"))
-    assert sorted(purged) == ["ep-0", "ep-1", "ep-2"]
-    res = m.record  # noqa: just ensure no crash on extra
+    seen = {}
+
+    def _purge(fp):
+        seen["fp"] = fp
+        return 3                      # pretend 3 episodes retired
+
+    m = SemanticConsolidationMatrix(store=store, purge=_purge, threshold=3, enabled=True)
+    res = None
+    for _ in range(3):
+        res = m.record(_lf("ImportError: cannot import name 'x'"))
+    assert seen.get("fp") == fingerprint("ImportError: cannot import name 'x'")
+    assert res is not None and res.episodes_purged == 3
     assert len(store.added) == 1
 
 
@@ -104,13 +109,14 @@ def test_purge_skipped_if_store_fails():
     class _BadStore:
         def add(self, **kw):
             raise RuntimeError("disk full")
-    purged = []
-    m = SemanticConsolidationMatrix(store=_BadStore(), purge=lambda ids: purged.extend(ids),
+    calls = []
+    m = SemanticConsolidationMatrix(store=_BadStore(),
+                                    purge=lambda fp: calls.append(fp) or 0,
                                     threshold=2, enabled=True)
-    # store.add fails → not persisted → purge must NOT run (don't lose episodes on failure)
-    assert m.record(_lf("TypeError", ep="a")) is None
-    assert m.record(_lf("TypeError", ep="b")) is None
-    assert purged == []
+    # store.add fails → not persisted → purge must NOT run (don't retire episodes on failure)
+    assert m.record(_lf("TypeError")) is None
+    assert m.record(_lf("TypeError")) is None
+    assert calls == []
 
 
 def test_principle_selection_by_family():
@@ -194,6 +200,71 @@ def test_get_default_matrix_storeless_safe(monkeypatch):
     assert m is not None
     assert m.record(Lesson(signature="boom")) is None  # store-less + off → safe no-op
     sc.reset_default_matrix()
+
+
+# --------------------------------------------------------------------------- episodic prune
+class _FakeBlue:
+    def __init__(self):
+        self.records = []
+
+    def record(self, **kw):
+        self.records.append(kw)
+
+
+def _seed(led, summary, kind="error", op="op"):
+    from backend.core.ouroboros.governance.episodic_core import Episode
+    led._window.append(Episode(len(led._window), 0.0, kind, op, summary))
+
+
+def test_episodic_prune_evicts_matching_and_appends_tombstone():
+    from backend.core.ouroboros.governance.episodic_core import EpisodicLedger
+    blue = _FakeBlue()
+    led = EpisodicLedger(window=8, longterm_max=10, blue_ledger=blue, embedder=None)
+    _seed(led, "FrozenInstanceError: cannot assign to field 'passed'")
+    _seed(led, "all good — complete", kind="complete")
+    removed = led.prune(lambda ep: "frozeninstanceerror" in ep.summary.lower(),
+                        tombstone_label="fp")
+    assert removed == 1
+    assert all("frozeninstanceerror" not in ep.summary.lower() for ep in led._window)
+    # append-only supersession tombstone written; original receipts NOT deleted
+    assert any(r.get("verdict") == "superseded" for r in blue.records)
+
+
+def test_episodic_prune_bad_predicate_keeps_all():
+    from backend.core.ouroboros.governance.episodic_core import EpisodicLedger
+    led = EpisodicLedger(window=4, blue_ledger=_FakeBlue(), embedder=None)
+    _seed(led, "keep me")
+    removed = led.prune(lambda ep: (_ for _ in ()).throw(ValueError("boom")))
+    assert removed == 0 and len(led._window) == 1   # a throwing matcher never nukes the cache
+
+
+def test_episodic_prune_no_match_no_tombstone():
+    from backend.core.ouroboros.governance.episodic_core import EpisodicLedger
+    blue = _FakeBlue()
+    led = EpisodicLedger(window=4, blue_ledger=blue, embedder=None)
+    _seed(led, "unrelated")
+    assert led.prune(lambda ep: False) == 0
+    assert blue.records == []   # nothing removed → no tombstone churn
+
+
+def test_default_purge_wires_to_episodic(monkeypatch):
+    monkeypatch.setenv("JARVIS_EPISODIC_CORE_ENABLED", "1")
+    from backend.core.ouroboros.governance import episodic_core as ec
+    from backend.core.ouroboros.governance import semantic_consolidation as sc
+    ec.reset_episodic_ledger()
+    led = ec.get_episodic_ledger()
+    led._blue = _FakeBlue()          # avoid touching the real .jarvis ledger
+    led._blue_resolved = True
+    _seed(led, "FrozenInstanceError: cannot assign to field 'x'")
+    fp = sc.fingerprint("FrozenInstanceError: cannot assign to field 'x'")
+    assert sc._default_purge(fp) == 1
+    ec.reset_episodic_ledger()
+
+
+def test_prune_episodes_helper_off_when_disabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_EPISODIC_CORE_ENABLED", "0")
+    from backend.core.ouroboros.governance import episodic_core as ec
+    assert ec.prune_episodes(lambda ep: True) == 0   # disabled → no-op
 
 
 if __name__ == "__main__":

--- a/tests/governance/test_semantic_consolidation.py
+++ b/tests/governance/test_semantic_consolidation.py
@@ -172,5 +172,29 @@ def test_style_memory_type_used():
     assert getattr(mt, "value", mt) == "style"
 
 
+def test_get_default_matrix_singleton():
+    from backend.core.ouroboros.governance import semantic_consolidation as sc
+    sc.reset_default_matrix()
+    a = sc.get_default_matrix("/tmp/x")
+    b = sc.get_default_matrix()
+    assert a is b
+    sc.reset_default_matrix()
+    c = sc.get_default_matrix()
+    assert c is not a
+
+
+def test_get_default_matrix_storeless_safe(monkeypatch):
+    # if the store factory blows up, the matrix must still build (store-less) and record safely
+    from backend.core.ouroboros.governance import semantic_consolidation as sc
+    import backend.core.ouroboros.governance.user_preference_memory as upm
+    sc.reset_default_matrix()
+    monkeypatch.setattr(upm, "get_default_store",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no disk")))
+    m = sc.get_default_matrix()        # must not raise
+    assert m is not None
+    assert m.record(Lesson(signature="boom")) is None  # store-less + off → safe no-op
+    sc.reset_default_matrix()
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/governance/test_semantic_consolidation.py
+++ b/tests/governance/test_semantic_consolidation.py
@@ -1,0 +1,176 @@
+"""Tier 2 — Semantic Consolidation Matrix regression suite."""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.semantic_consolidation import (
+    Lesson,
+    SemanticConsolidationMatrix,
+    ConsolidationResult,
+    fingerprint,
+)
+
+
+class _FakeStore:
+    """Duck-typed UserPreferenceStore: records add() calls."""
+
+    def __init__(self):
+        self.added = []
+
+    def add(self, *, memory_type, name, description, content="", why="",
+            how_to_apply="", source="user", tags=(), paths=(), apps=()):
+        if not name.strip() or not description.strip():
+            raise ValueError("empty name/description")  # mirror real store contract
+        rec = dict(memory_type=memory_type, name=name, description=description,
+                   content=content, tags=tuple(tags), paths=tuple(paths), source=source)
+        self.added.append(rec)
+        return rec
+
+
+def _lf(msg, fp="kernel.py", ep=""):
+    return Lesson(signature=msg, kind="live_fire", file_path=fp, episode_id=ep)
+
+
+# --------------------------------------------------------------------------- fingerprint
+def test_fingerprint_collapses_variants():
+    a = fingerprint("live-fire boot failure: FrozenInstanceError: cannot assign to field 'passed'")
+    b = fingerprint("live-fire boot failure: FrozenInstanceError: cannot assign to field 'status'")
+    assert a == b  # different field name → same structural fingerprint
+
+
+def test_fingerprint_distinguishes_classes():
+    a = fingerprint("FrozenInstanceError: cannot assign")
+    b = fingerprint("AttributeError: no attribute foo")
+    assert a != b
+
+
+# --------------------------------------------------------------------------- gating
+def test_off_by_default_no_consolidation():
+    store = _FakeStore()
+    m = SemanticConsolidationMatrix(store=store)  # enabled resolves from env (default off)
+    for _ in range(10):
+        assert m.record(_lf("FrozenInstanceError: cannot assign to field 'x'")) is None
+    assert store.added == []
+
+
+def test_below_threshold_no_fire():
+    store = _FakeStore()
+    m = SemanticConsolidationMatrix(store=store, threshold=5, enabled=True)
+    for i in range(4):
+        assert m.record(_lf("FrozenInstanceError: cannot assign")) is None
+    assert store.added == []
+
+
+def test_threshold_fires_core_directive():
+    store = _FakeStore()
+    m = SemanticConsolidationMatrix(store=store, threshold=5, enabled=True)
+    results = [m.record(_lf("FrozenInstanceError: cannot assign to field 'f%d'" % i)) for i in range(5)]
+    assert results[:4] == [None, None, None, None]
+    res = results[4]
+    assert isinstance(res, ConsolidationResult)
+    assert res.occurrences == 5
+    assert "dataclasses.replace" in res.principle
+    assert len(store.added) == 1
+    mem = store.added[0]
+    assert "core_directive" in mem["tags"] and "consolidated" in mem["tags"]
+    assert mem["name"].startswith("core-directive:")
+
+
+def test_consolidates_once_then_quiet():
+    store = _FakeStore()
+    m = SemanticConsolidationMatrix(store=store, threshold=3, enabled=True)
+    for _ in range(3):
+        m.record(_lf("AttributeError: 'dict' object has no attribute 'passed'"))
+    assert len(store.added) == 1
+    # further identical failures do NOT re-fire (already distilled)
+    for _ in range(5):
+        assert m.record(_lf("AttributeError: 'dict' object has no attribute 'status'")) is None
+    assert len(store.added) == 1
+
+
+def test_purge_called_with_episode_ids():
+    store = _FakeStore()
+    purged = []
+    m = SemanticConsolidationMatrix(store=store, purge=lambda ids: purged.extend(ids),
+                                    threshold=3, enabled=True)
+    for i in range(3):
+        m.record(_lf("ImportError: cannot import name x", ep=f"ep-{i}"))
+    assert sorted(purged) == ["ep-0", "ep-1", "ep-2"]
+    res = m.record  # noqa: just ensure no crash on extra
+    assert len(store.added) == 1
+
+
+def test_purge_skipped_if_store_fails():
+    class _BadStore:
+        def add(self, **kw):
+            raise RuntimeError("disk full")
+    purged = []
+    m = SemanticConsolidationMatrix(store=_BadStore(), purge=lambda ids: purged.extend(ids),
+                                    threshold=2, enabled=True)
+    # store.add fails → not persisted → purge must NOT run (don't lose episodes on failure)
+    assert m.record(_lf("TypeError", ep="a")) is None
+    assert m.record(_lf("TypeError", ep="b")) is None
+    assert purged == []
+
+
+def test_principle_selection_by_family():
+    store = _FakeStore()
+    m = SemanticConsolidationMatrix(store=store, threshold=2, enabled=True)
+    m.record(_lf("TypeError: 'NoneType' object has no attribute 'a'"))
+    res = m.record(_lf("TypeError: 'NoneType' object has no attribute 'b'"))
+    assert "Optional" in res.principle or "None" in res.principle
+
+
+def test_distinct_failures_cluster_independently():
+    store = _FakeStore()
+    m = SemanticConsolidationMatrix(store=store, threshold=3, enabled=True)
+    # two different fingerprints — neither alone reaches threshold interleaved
+    seq = ["FrozenInstanceError: a", "AttributeError: b"] * 2
+    for s in seq:
+        assert m.record(_lf(s)) is None
+    assert store.added == []  # each cluster only at 2 < 3
+
+
+def test_bounded_clusters_evicts_lru():
+    store = _FakeStore()
+    m = SemanticConsolidationMatrix(store=store, threshold=5, max_clusters=2, enabled=True)
+    for i in range(10):
+        m.record(_lf("UniqueError%d: boom" % i))   # 10 distinct fingerprints
+    # never more than max_clusters retained
+    assert len(m._clusters) <= 2
+
+
+def test_record_never_raises_on_garbage():
+    m = SemanticConsolidationMatrix(store=_FakeStore(), threshold=2, enabled=True)
+    assert m.record(Lesson(signature="")) is None
+    assert m.record(Lesson(signature="   ")) is None
+
+
+def test_no_store_still_safe():
+    m = SemanticConsolidationMatrix(threshold=2, enabled=True)  # no store
+    for _ in range(3):
+        assert m.record(_lf("KeyError: missing")) is None  # nothing persisted, no crash
+
+
+def test_env_threshold_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONSOLIDATION_THRESHOLD", "2")
+    monkeypatch.setenv("JARVIS_SEMANTIC_CONSOLIDATION_ENABLED", "1")
+    store = _FakeStore()
+    m = SemanticConsolidationMatrix(store=store)
+    m.record(_lf("ValueError: invalid literal '1'"))
+    assert m.record(_lf("ValueError: invalid literal '2'")) is not None
+    assert len(store.added) == 1
+
+
+def test_style_memory_type_used():
+    store = _FakeStore()
+    m = SemanticConsolidationMatrix(store=store, threshold=2, enabled=True)
+    m.record(_lf("FrozenInstanceError: cannot assign to field 'x'"))
+    m.record(_lf("FrozenInstanceError: cannot assign to field 'y'"))
+    mt = store.added[0]["memory_type"]
+    # resolves to MemoryType.STYLE when importable, else the "style" fallback
+    assert getattr(mt, "value", mt) == "style"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/governance/test_semantic_guardian.py
+++ b/tests/governance/test_semantic_guardian.py
@@ -94,8 +94,10 @@ def test_all_pattern_names_is_exhaustive():
     assert set(all_pattern_names()) == set(_PATTERNS.keys())
     # Pattern count: 12 structural + 3 Slice-208 epistemic-integrity
     # (self_signing_attempt / metric_counter_suppressed /
-    # chronos_continuity_laundering — metric-gaming deception detectors).
-    assert len(all_pattern_names()) == 15
+    # chronos_continuity_laundering) + 5 Tier-0 Anticipatory Edge-Case Armor
+    # blindspot detectors (frozen_dataclass_mutation / namedtuple_attr_assignment /
+    # pydantic_immutable_set / type_coercion_blindspot / loop_var_rebind_lost).
+    assert len(all_pattern_names()) == 20
 
 
 # ---------------------------------------------------------------------------

--- a/tests/governance/test_semantic_guardian_blindspots.py
+++ b/tests/governance/test_semantic_guardian_blindspots.py
@@ -1,0 +1,309 @@
+"""Tier 0 — Anticipatory Edge-Case Armor regression suite."""
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from backend.core.ouroboros.governance.semantic_guardian_blindspots import (
+    pat_frozen_dataclass_mutation as frozen,
+    pat_namedtuple_attr_assignment as ntuple,
+    pat_pydantic_immutable_set as pyd,
+    pat_type_coercion_blindspot as coerce,
+    pat_loop_var_rebind_lost as loopreb,
+)
+from backend.core.ouroboros.governance.semantic_guardian import SemanticGuardian
+
+
+def _run(detector, src: str):
+    return detector(file_path="x.py", old_content="", new_content=textwrap.dedent(src))
+
+
+# --------------------------------------------------------------------------- frozen
+def test_frozen_infile_mutation_fires():
+    hit = _run(frozen, """
+        from dataclasses import dataclass
+        @dataclass(frozen=True)
+        class P:
+            x: int
+        def f():
+            p = P(1)
+            p.x = 2
+    """)
+    assert hit is not None and hit.severity == "hard" and hit.lines
+
+
+def test_frozen_replace_is_clean():
+    hit = _run(frozen, """
+        import dataclasses
+        from dataclasses import dataclass
+        @dataclass(frozen=True)
+        class P:
+            x: int
+        def f():
+            p = P(1)
+            p = dataclasses.replace(p, x=2)
+    """)
+    assert hit is None
+
+
+def test_frozen_cross_file_validationresult_via_registry():
+    # The canonical case: ValidationResult defined elsewhere, mutated here.
+    hit = _run(frozen, """
+        def f(validation):
+            validation = ValidationResult(passed=True)
+            validation.passed = False
+    """)
+    assert hit is not None and hit.severity == "hard"
+
+
+def test_frozen_replace_propagates_type():
+    hit = _run(frozen, """
+        import dataclasses
+        def f(validation):
+            validation = ValidationResult(passed=True)
+            v2 = dataclasses.replace(validation, passed=False)
+            v2.passed = True
+    """)
+    # v2 inherits ValidationResult type via replace propagation -> mutation flagged
+    assert hit is not None
+
+
+def test_non_frozen_dataclass_clean():
+    hit = _run(frozen, """
+        from dataclasses import dataclass
+        @dataclass
+        class P:
+            x: int
+        def f():
+            p = P(1)
+            p.x = 2
+    """)
+    assert hit is None
+
+
+def test_env_extensible_registry(monkeypatch):
+    monkeypatch.setenv("JARVIS_SEMGUARD_KNOWN_FROZEN_TYPES", "MyFrozenThing, Other")
+    hit = _run(frozen, """
+        def f():
+            t = MyFrozenThing()
+            t.value = 1
+    """)
+    assert hit is not None
+
+
+# --------------------------------------------------------------------------- namedtuple
+def test_namedtuple_mutation_fires():
+    hit = _run(ntuple, """
+        from typing import NamedTuple
+        class Point(NamedTuple):
+            x: int
+            y: int
+        def f():
+            p = Point(1, 2)
+            p.x = 9
+    """)
+    assert hit is not None and hit.severity == "hard"
+
+
+def test_namedtuple_not_flagged_by_frozen_detector():
+    # kind isolation: a NamedTuple is not a frozen dataclass
+    assert _run(frozen, """
+        from typing import NamedTuple
+        class Point(NamedTuple):
+            x: int
+        def f():
+            p = Point(1)
+            p.x = 9
+    """) is None
+
+
+# --------------------------------------------------------------------------- pydantic
+def test_pydantic_v2_frozen_fires():
+    hit = _run(pyd, """
+        from pydantic import BaseModel, ConfigDict
+        class M(BaseModel):
+            model_config = ConfigDict(frozen=True)
+            x: int
+        def f():
+            m = M(x=1)
+            m.x = 2
+    """)
+    assert hit is not None and hit.severity == "hard"
+
+
+def test_pydantic_v1_config_fires():
+    hit = _run(pyd, """
+        from pydantic import BaseModel
+        class M(BaseModel):
+            x: int
+            class Config:
+                allow_mutation = False
+        def f():
+            m = M(x=1)
+            m.x = 2
+    """)
+    assert hit is not None
+
+
+def test_pydantic_mutable_clean():
+    assert _run(pyd, """
+        from pydantic import BaseModel
+        class M(BaseModel):
+            x: int
+        def f():
+            m = M(x=1)
+            m.x = 2
+    """) is None
+
+
+# --------------------------------------------------------------------------- coercion (CFG)
+def test_coercion_unguarded_attr_fires():
+    hit = _run(coerce, """
+        from typing import Optional
+        def f(x: Optional[str]):
+            return x.upper()
+    """)
+    assert hit is not None and hit.severity == "soft"
+
+
+def test_coercion_if_not_none_guard_clean():
+    assert _run(coerce, """
+        from typing import Optional
+        def f(x: Optional[str]):
+            if x is not None:
+                return x.upper()
+            return ""
+    """) is None
+
+
+def test_coercion_early_return_guard_clean():
+    assert _run(coerce, """
+        from typing import Optional
+        def f(x: Optional[str]):
+            if x is None:
+                return ""
+            return x.upper()
+    """) is None
+
+
+def test_coercion_assert_guard_clean():
+    assert _run(coerce, """
+        from typing import Optional
+        def f(x: Optional[str]):
+            assert x is not None
+            return x.upper()
+    """) is None
+
+
+def test_coercion_and_shortcircuit_clean():
+    assert _run(coerce, """
+        from typing import Optional
+        def f(x: Optional[str]):
+            return x is not None and x.upper() or ""
+    """) is None
+
+
+def test_coercion_truthy_guard_clean():
+    assert _run(coerce, """
+        from typing import Optional
+        def f(x: Optional[str]):
+            if x:
+                return x.upper()
+            return ""
+    """) is None
+
+
+def test_coercion_pipe_none_annotation_fires():
+    hit = _run(coerce, """
+        def f(x: "str | None"):
+            return len(x)
+    """)
+    assert hit is not None
+
+
+def test_coercion_subscript_unguarded_fires():
+    hit = _run(coerce, """
+        from typing import Optional, List
+        def f(x: Optional[list]):
+            return x[0]
+    """)
+    assert hit is not None
+
+
+def test_coercion_int_call_unguarded_fires():
+    hit = _run(coerce, """
+        from typing import Optional
+        def f(x: Optional[str]):
+            return int(x)
+    """)
+    assert hit is not None
+
+
+def test_coercion_non_optional_clean():
+    assert _run(coerce, """
+        def f(x: str):
+            return x.upper()
+    """) is None
+
+
+def test_coercion_reassign_drops_tracking():
+    # x reassigned to a definitely-present value -> not flagged afterward
+    assert _run(coerce, """
+        from typing import Optional
+        def f(x: Optional[str]):
+            x = "default"
+            return x.upper()
+    """) is None
+
+
+# --------------------------------------------------------------------------- loop rebind
+def test_loop_rebind_lost_fires():
+    hit = _run(loopreb, """
+        def f(items):
+            for v in items:
+                v = v.strip()
+    """)
+    assert hit is not None and hit.severity == "soft"
+
+
+def test_loop_rebind_used_after_clean():
+    assert _run(loopreb, """
+        def f(items, out):
+            for v in items:
+                v = v.strip()
+                out.append(v)
+    """) is None
+
+
+# --------------------------------------------------------------------------- integration
+def test_registered_in_guardian():
+    g = SemanticGuardian()
+    assert "frozen_dataclass_mutation" in g.patterns
+    assert "type_coercion_blindspot" in g.patterns
+    dets = g.inspect(file_path="x.py", old_content="", new_content=textwrap.dedent("""
+        def f(validation):
+            validation = ValidationResult(passed=True)
+            validation.passed = False
+    """))
+    assert any(d.pattern == "frozen_dataclass_mutation" for d in dets)
+
+
+def test_per_pattern_kill_switch(monkeypatch):
+    monkeypatch.setenv("JARVIS_SEMGUARD_FROZEN_DATACLASS_MUTATION_ENABLED", "0")
+    g = SemanticGuardian()
+    dets = g.inspect(file_path="x.py", old_content="", new_content=textwrap.dedent("""
+        def f(validation):
+            validation = ValidationResult(passed=True)
+            validation.passed = False
+    """))
+    assert not any(d.pattern == "frozen_dataclass_mutation" for d in dets)
+
+
+def test_never_raises_on_garbage():
+    for d in (frozen, ntuple, pyd, coerce, loopreb):
+        assert d(file_path="x.py", old_content="", new_content="def (((") is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary
Engineers `scripts/deploy_live_validator_fsm.py` — a strictly-typed, **reversible** deployer that wires the (already-merged, #69515) `LiveKernelValidator` into the orchestrator VALIDATE phase. This is the FSM-wiring step Slice 256 deliberately left to an operator sandbox-off run.

## Why a deployer (not a blind paste)
A blind paste of a generic snippet would `AttributeError` at runtime — candidates are **dicts** (`file_path`/`full_content`), and `ast.parse` would *not* catch it. The deployer wires it **accurately + reversibly**:

- **Single, correct integration point:** the `candidate, validation, _validate_duration_s = _vr` loop — a *unique* anchor (found exactly once). A live-fire failure flips `validation.passed → False`, **reusing the existing retry/ledger/escalation machinery** instead of fragile surgery before the two `GATE`-advance seams.
- **EXACT-CONTEXT injection** (string anchor, count must == 1) — refuses on drift, never fuzzy-guesses.
- **Rollback gate = a REAL subprocess import** of the modified orchestrator, **not `ast.parse`** (syntax ≠ proof — the engine's own thesis). Auto-reverts from `.bak` on any boot failure *or* exception (fail-closed).
- **Injected hook is flag-gated** (`JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED`, default OFF) **+ fail-soft** — a subtly-wrong hook cannot crash VALIDATE (worst case: logs + no-ops). Logs LOUDLY `GATE INERT` if `validation` is frozen — the one detail only the dogfood boot confirms.
- **Idempotent** (marker check → no-op on re-run).

## Test Plan
Armor proven in-sandbox (injectable `boot_check`):
- [x] Injection yields **valid Python in the real orchestrator's context** (full-file `ast.parse`)
- [x] Passing gate → injects + marks
- [x] Failing gate **and** raising gate → both auto-revert (fail-closed)
- [x] Idempotent re-run → no-op
- [x] Anchor drift → refuses (rc=3)
- [ ] **Operator, sandbox-off:** `python3 scripts/deploy_live_validator_fsm.py` → expect `BOOT CHECK PASSED`; then `JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED=true` boot + the `KernelMemoryRingBuffer` dogfood. Watch for `[LiveFire] ... GATE INERT` (→ `validation` frozen, 1-line fix at the anchor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a safe, reversible injector that wires `LiveKernelValidator` into VALIDATE, plus Tier‑2 consolidation that promotes recurring failures to durable directives and prunes episodic memory without breaking audit history. Also adds Tier‑0 blindspot detectors to catch common runtime bugs before they ship.

- **New Features**
  - Injector: exact‑context wiring at the VALIDATE loop; real import boot‑check with auto‑revert; gated by `JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED`; `dataclasses.replace` for frozen‑dataclass safety; idempotent.
  - Tier‑0 Blindspots: 5 AST detectors (frozen‑dataclass mutation, `NamedTuple` attr set, frozen Pydantic set, Optional deref/coercion, loop‑var rebind); registered into `semantic_guardian`; per‑pattern kill switches; fail‑soft import; env‑extendable known‑frozen types.
  - Tier‑2 Consolidation: clusters failures by fingerprint into CORE_DIRECTIVE STYLE memories; `get_default_matrix()` singleton (store‑less safe); on commit, retires episodes via `EpisodicLedger.prune()`/`prune_episodes` (RAM eviction + supersession tombstone; no durable deletion); reversible deployer injects after the session lesson append; default off.

- **Migration**
  - Run: `python3 scripts/deploy_live_validator_fsm.py` and `python3 scripts/deploy_tier2_consolidation.py` (both auto‑revert on boot failure).
  - Enable as needed: `JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED=1`, `JARVIS_SEMANTIC_CONSOLIDATION_ENABLED=1`; guardian master `JARVIS_SEMANTIC_GUARD_ENABLED`; pattern toggles `JARVIS_SEMGUARD_<NAME>_ENABLED`; extend frozen‑type registry via `JARVIS_SEMGUARD_KNOWN_FROZEN_TYPES`.

<sup>Written for commit aec8bd4a89407953471a368e8528fb2996e134b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

