### PR TITLE
Sovereign Terminal UI: Claude-Code-clean borderless render for O+V

### DIFF
--- a/backend/core/ouroboros/battle_test/presentation_restraint.py
+++ b/backend/core/ouroboros/battle_test/presentation_restraint.py
@@ -1066,6 +1066,27 @@ def spinner_name() -> str:
     return "dots" if _stdout_supports_utf8() else "line"
 
 
+def print_fit(console, markup: str) -> None:
+    """Print one op-block line, truncated to the live console width with an
+    ellipsis -- never wraps (so the glyph column never moves). Width is read
+    from the console per call (SIGWINCH-adaptive; Rich defaults to 80
+    off-terminal). Fail-soft: on any Rich error, falls back to a plain crop
+    print, and if that fails too, swallows the error rather than crash the
+    render path."""
+    try:
+        from rich.text import Text
+        console.print(
+            Text.from_markup(markup),
+            no_wrap=True, overflow="ellipsis", crop=True, soft_wrap=False,
+        )
+    except Exception:  # noqa: BLE001
+        try:
+            width = getattr(console, "width", 80) or 80
+            console.print(str(markup)[: max(8, int(width) - 1)], highlight=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+
 def format_idle_breadcrumb(
     *,
     branch: str = "",

--- a/backend/core/ouroboros/battle_test/presentation_restraint.py
+++ b/backend/core/ouroboros/battle_test/presentation_restraint.py
@@ -1087,6 +1087,44 @@ def print_fit(console, markup: str) -> None:
             pass
 
 
+from contextlib import asynccontextmanager  # noqa: E402
+
+
+@asynccontextmanager
+async def pulse(console, line: str, *, spinner: str = ""):
+    """Non-blocking spinner on the active action line during awaited work.
+
+    TTY-gated -- a no-op headless/CI/piped (no spinner art leaks into logs; the
+    awaited body still runs). Cursor armor: a try/finally GUARANTEES the cursor
+    is restored and the buffer flushed on ANY exception boundary (fatal LLM /
+    network error mid-spin must never leave the operator's terminal with a
+    hidden cursor). Leverages Rich ``console.status`` (background-thread spinner
+    + cursor management); raw ``\\033[?25h`` is only the last-resort fallback."""
+    if not real_stdout_isatty():
+        yield
+        return
+    spin = spinner or spinner_name()
+    status = None
+    try:
+        status = console.status(line, spinner=spin)
+        status.start()
+        yield
+    finally:
+        try:
+            if status is not None:
+                status.stop()          # clears spinner region, restores cursor
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            console.show_cursor(True)  # Rich-native cursor restore
+        except Exception:  # noqa: BLE001
+            try:
+                sys.stdout.write("\033[?25h")   # last-resort raw ANSI show-cursor
+                sys.stdout.flush()
+            except Exception:  # noqa: BLE001
+                pass
+
+
 def format_idle_breadcrumb(
     *,
     branch: str = "",

--- a/backend/core/ouroboros/battle_test/presentation_restraint.py
+++ b/backend/core/ouroboros/battle_test/presentation_restraint.py
@@ -727,6 +727,41 @@ def register_flags(registry) -> int:
             example="~/.jarvis/repl_history",
             since="Gap #7 Slice 5 (2026-05-04)",
         ),
+        # ── Sovereign Terminal UI: borderless render + pulse ──────
+        FlagSpec(
+            name="JARVIS_OPBLOCK_BORDERLESS_ENABLED",
+            type=FlagType.BOOL,
+            default=True,
+            description=(
+                "Borderless Claude-Code-clean op-block render: glyph "
+                "action/result hierarchy (no box-drawing borders), "
+                "grayscale chrome, vertical rhythm. Gated by the "
+                "presentation-restraint master; when that master is off "
+                "the legacy boxed renderer is byte-identical. Default TRUE."
+            ),
+            category=Category.SAFETY,
+            source_file=(
+                "backend/core/ouroboros/battle_test/presentation_restraint.py"
+            ),
+            example="true",
+            since="Sovereign Terminal UI (2026-06-15)",
+        ),
+        FlagSpec(
+            name="JARVIS_TUI_PULSE_ENABLED",
+            type=FlagType.BOOL,
+            default=True,
+            description=(
+                "Async pulse spinner on the active action line during "
+                "synthesizing/validating awaits. TTY-gated (no-op "
+                "headless/CI). Default TRUE under the restraint master."
+            ),
+            category=Category.TUNING,
+            source_file=(
+                "backend/core/ouroboros/battle_test/presentation_restraint.py"
+            ),
+            example="true",
+            since="Sovereign Terminal UI (2026-06-15)",
+        ),
         # ── Slice 4: input polish ─────────────────────────────────
         FlagSpec(
             name="JARVIS_REPL_INPUT_POLISH_ENABLED",
@@ -1059,6 +1094,23 @@ def _stdout_supports_utf8() -> bool:
 def glyphs() -> dict:
     """Glyph vocabulary, degraded to ASCII on non-UTF-8 stdout."""
     return dict(_GLYPHS_UTF8 if _stdout_supports_utf8() else _GLYPHS_ASCII)
+
+
+def borderless_enabled() -> bool:
+    """Borderless glyph op-block render. Default TRUE under the restraint master;
+    the master gates it so master-off is byte-identical legacy boxed rendering."""
+    if not is_restraint_enabled():
+        return False
+    raw = os.environ.get("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def pulse_enabled() -> bool:
+    """Async pulse spinner. Default TRUE under the restraint master."""
+    if not is_restraint_enabled():
+        return False
+    raw = os.environ.get("JARVIS_TUI_PULSE_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
 
 
 def spinner_name() -> str:

--- a/backend/core/ouroboros/battle_test/presentation_restraint.py
+++ b/backend/core/ouroboros/battle_test/presentation_restraint.py
@@ -80,6 +80,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import threading
 from dataclasses import dataclass
 from typing import Any, List, Mapping, Optional, Sequence, Tuple
@@ -1036,6 +1037,33 @@ def real_stdout_isatty() -> bool:
         return bool(sys.stdout.isatty())
     except Exception:  # noqa: BLE001
         return False
+
+
+# ---------------------------------------------------------------------------
+# Encoding-aware glyph vocabulary (ASCII fallback for non-UTF-8 terminals)
+# ---------------------------------------------------------------------------
+
+_GLYPHS_UTF8 = {"action": "\u23fa", "result": "\u23bf"}
+_GLYPHS_ASCII = {"action": "*", "result": ">"}
+
+
+def _stdout_supports_utf8() -> bool:
+    """True only when stdout can encode our glyphs. Fail-safe to False."""
+    try:
+        enc = (getattr(sys.stdout, "encoding", "") or "").lower()
+        return "utf" in enc
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def glyphs() -> dict:
+    """Glyph vocabulary, degraded to ASCII on non-UTF-8 stdout."""
+    return dict(_GLYPHS_UTF8 if _stdout_supports_utf8() else _GLYPHS_ASCII)
+
+
+def spinner_name() -> str:
+    """Rich spinner name: braille 'dots' on UTF-8, ASCII 'line' otherwise."""
+    return "dots" if _stdout_supports_utf8() else "line"
 
 
 def format_idle_breadcrumb(

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -1150,6 +1150,8 @@ class SerpentFlow:
                 out = out.replace("[/" + style + "]", "[/dim]")
             for emoji in SerpentFlow._PHASE_EMOJI:
                 out = out.replace(emoji + " ", "").replace(emoji, "")
+            for box in ("┌", "│", "└", "─"):       # stray box chars never belong borderless
+                out = out.replace(box, "")
             return out
         except Exception:  # noqa: BLE001
             return markup
@@ -1165,31 +1167,38 @@ class SerpentFlow:
             self.console.print(markup, highlight=False)
 
     def _synth_pulse(self, op_id: str, provider: str):
-        """Return an async context that pulses a spinner on the active
-        'synthesizing' line while an awaited generation/validation runs:
+        """Async context that masks an awaited generation with the EXISTING
+        execution spinner (``_start_status``/``_stop_status`` → ``_spinner_state``
+        → bottom-toolbar ouroboros glyph) — NOT a second ``console.status``
+        overlay (that would be a duplicate, competing spinner). Use as:
 
             async with self._synth_pulse(op_id, provider):
                 result = await provider.generate(...)
 
-        No-op (still runs the body) when pulse is disabled or headless. The
-        cursor-armor + TTY-gating live in presentation_restraint.pulse."""
-        try:
+        No-op (body still runs) when pulse is disabled. The ``try/finally``
+        guarantees the spinner state is cleared on ANY exception boundary."""
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _ctx():
             from backend.core.ouroboros.battle_test.presentation_restraint import (
-                pulse, pulse_enabled, glyphs,
+                pulse_enabled, glyphs,
             )
-            if not pulse_enabled():
-                raise RuntimeError("pulse disabled")  # fall through to no-op
-            prov = _PROV.get(provider, provider)
-            line = f"{glyphs()['action']} synthesizing [{_C['dim']}]{prov}[/{_C['dim']}]"
-            return pulse(self.console, line)
-        except Exception:  # noqa: BLE001
-            from contextlib import asynccontextmanager
-
-            @asynccontextmanager
-            async def _noop():
+            armed = False
+            try:
+                if pulse_enabled():
+                    prov = _PROV.get(provider, provider)
+                    self._start_status(
+                        f"{glyphs()['action']} synthesizing {prov}",
+                        spinner=_active_spinner_name(),
+                    )
+                    armed = True
                 yield
+            finally:
+                if armed:
+                    self._stop_status()
 
-            return _noop()
+        return _ctx()
 
     @staticmethod
     def _action_glyph() -> str:
@@ -1650,6 +1659,11 @@ class SerpentFlow:
         marker so operators still see the status was set (no
         animation possible without an active prompt session).
         """
+        # Borderless mode: clean the spinner message to the grayscale glyph
+        # vocabulary (drop box prefixes + per-phase emojis) so the EXISTING
+        # bottom-toolbar spinner matches the Claude-Code-clean op-block render.
+        if self._borderless():
+            message = self._clean_markup(message).strip()
         self._spinner_state.active = True
         self._spinner_state.message = message
         self._spinner_state.token_count = 0

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -1131,13 +1131,36 @@ class SerpentFlow:
         except Exception:  # noqa: BLE001
             return False
 
+    # Secondary Rich styles demoted to dim in borderless mode (color is
+    # reserved for outcomes — green/red are intentionally NOT listed here).
+    _SECONDARY_STYLES = ("cyan", "magenta", "yellow", "blue underline", "blue")
+    # Per-phase decoration emojis stripped in borderless mode (signature
+    # emojis live at boot only).
+    _PHASE_EMOJI = ("🔬", "🧬", "⚙️", "🛡️", "👤", "🔍", "🔭", "▸")
+
+    @staticmethod
+    def _clean_markup(markup: str) -> str:
+        """Grayscale + emoji normalization for borderless lines: demote secondary
+        color styles to dim, strip per-phase emojis. Preserves green/red so
+        outcome signals stay legible. Fail-soft (returns input on any error)."""
+        try:
+            out = str(markup)
+            for style in SerpentFlow._SECONDARY_STYLES:
+                out = out.replace("[" + style + "]", "[dim]")
+                out = out.replace("[/" + style + "]", "[/dim]")
+            for emoji in SerpentFlow._PHASE_EMOJI:
+                out = out.replace(emoji + " ", "").replace(emoji, "")
+            return out
+        except Exception:  # noqa: BLE001
+            return markup
+
     def _emit_fit(self, markup: str) -> None:
-        """Print one borderless line through overflow-safe print_fit."""
+        """Print one borderless line: grayscale-normalized + overflow-safe."""
         try:
             from backend.core.ouroboros.battle_test.presentation_restraint import (
                 print_fit,
             )
-            print_fit(self.console, markup)
+            print_fit(self.console, self._clean_markup(markup))
         except Exception:  # noqa: BLE001
             self.console.print(markup, highlight=False)
 

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -1164,6 +1164,33 @@ class SerpentFlow:
         except Exception:  # noqa: BLE001
             self.console.print(markup, highlight=False)
 
+    def _synth_pulse(self, op_id: str, provider: str):
+        """Return an async context that pulses a spinner on the active
+        'synthesizing' line while an awaited generation/validation runs:
+
+            async with self._synth_pulse(op_id, provider):
+                result = await provider.generate(...)
+
+        No-op (still runs the body) when pulse is disabled or headless. The
+        cursor-armor + TTY-gating live in presentation_restraint.pulse."""
+        try:
+            from backend.core.ouroboros.battle_test.presentation_restraint import (
+                pulse, pulse_enabled, glyphs,
+            )
+            if not pulse_enabled():
+                raise RuntimeError("pulse disabled")  # fall through to no-op
+            prov = _PROV.get(provider, provider)
+            line = f"{glyphs()['action']} synthesizing [{_C['dim']}]{prov}[/{_C['dim']}]"
+            return pulse(self.console, line)
+        except Exception:  # noqa: BLE001
+            from contextlib import asynccontextmanager
+
+            @asynccontextmanager
+            async def _noop():
+                yield
+
+            return _noop()
+
     @staticmethod
     def _action_glyph() -> str:
         from backend.core.ouroboros.battle_test.presentation_restraint import glyphs

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -1118,12 +1118,45 @@ class SerpentFlow:
             f"  {events}"
         )
 
-    def _open_op_block(self, op_id: str, sensor: str) -> None:
-        """Print the top border of an op block and register it as active.
+    # ── Sovereign Terminal UI: borderless render helpers ─────────
+    @staticmethod
+    def _borderless() -> bool:
+        """True when the Claude-Code-clean borderless render is active
+        (master-gated). Fail-soft to False → legacy boxed path."""
+        try:
+            from backend.core.ouroboros.battle_test.presentation_restraint import (
+                borderless_enabled,
+            )
+            return borderless_enabled()
+        except Exception:  # noqa: BLE001
+            return False
 
-        Refactored 2026-05-03: snapshot is recorded for the swarm
-        digest unconditionally; the visible header only prints when
-        the lens is focused on this op.
+    def _emit_fit(self, markup: str) -> None:
+        """Print one borderless line through overflow-safe print_fit."""
+        try:
+            from backend.core.ouroboros.battle_test.presentation_restraint import (
+                print_fit,
+            )
+            print_fit(self.console, markup)
+        except Exception:  # noqa: BLE001
+            self.console.print(markup, highlight=False)
+
+    @staticmethod
+    def _action_glyph() -> str:
+        from backend.core.ouroboros.battle_test.presentation_restraint import glyphs
+        return glyphs()["action"]
+
+    @staticmethod
+    def _result_glyph() -> str:
+        from backend.core.ouroboros.battle_test.presentation_restraint import glyphs
+        return glyphs()["result"]
+
+    def _open_op_block(self, op_id: str, sensor: str) -> None:
+        """Print the op-block header and register it as active.
+
+        Borderless mode: a single ``glyph sensor  short`` action line (no box).
+        Legacy mode: the top border. Snapshot is recorded for the swarm digest
+        unconditionally; the visible header only prints when the lens is focused.
         """
         self._active_ops.add(op_id)
         self._op_sensors[op_id] = sensor
@@ -1135,6 +1168,11 @@ class SerpentFlow:
         if not self._is_focused(op_id):
             return
         short = _short_id(op_id)
+        if self._borderless():
+            self._emit_fit(
+                f"{self._action_glyph()} {sensor}  [{_C['dim']}]{short}[/{_C['dim']}]"
+            )
+            return
         w = self._block_w()
         label = f" {short} ── {sensor} "
         pad = max(2, w - len(label) - 2)
@@ -1264,6 +1302,11 @@ class SerpentFlow:
         self._streaming_started_ops.discard(op_id)
         if not was_focused:
             return
+        if self._borderless():
+            # No footer border — the receipt line already carried the outcome;
+            # one blank line provides the vertical rhythm between op groups.
+            self.console.print()
+            return
         short = _short_id(op_id)
         w = self._block_w()
         stats = (
@@ -1303,10 +1346,15 @@ class SerpentFlow:
         if op_id and op_id in self._active_ops:
             if not self._is_focused(op_id):
                 return
-            self.console.print(
-                f"  [{_C['border']}]│[/{_C['border']}]  {text}",
-                highlight=False,
-            )
+            if self._borderless():
+                self._emit_fit(
+                    f"  [{_C['dim']}]{self._result_glyph()}[/{_C['dim']}] {text}"
+                )
+            else:
+                self.console.print(
+                    f"  [{_C['border']}]│[/{_C['border']}]  {text}",
+                    highlight=False,
+                )
         else:
             # Out-of-band lines (system messages, banners) — always render
             self.console.print(f"  {text}", highlight=False)
@@ -1477,8 +1525,9 @@ class SerpentFlow:
             pass  # no event loop / sync context — skip silently
 
     def _op_blank(self, op_id: str) -> None:
-        """Print a blank line with the op border (visual breathing room)."""
-        if op_id and op_id in self._active_ops:
+        """Print a blank line for visual breathing room (borderless: plain blank;
+        legacy: a bordered ``│`` spacer)."""
+        if op_id and op_id in self._active_ops and not self._borderless():
             self.console.print(
                 f"  [{_C['border']}]│[/{_C['border']}]",
                 highlight=False,
@@ -1490,6 +1539,10 @@ class SerpentFlow:
 
     def _open_nested(self, op_id: str, header: str) -> None:
         """Open a nested block within an op (tool call, diff, etc.)."""
+        if self._borderless():
+            # nested header as a dim result sub-line (no box frame)
+            self._op_line(op_id, f"[{_C['dim']}]{header}[/{_C['dim']}]")
+            return
         w = self._block_w() - 6  # indent for op border
         pad = max(2, w - _visible_len(header) - 4)
         border = f"[{_C['border']}]┌─ {header} {'─' * pad}[/{_C['border']}]"
@@ -1498,7 +1551,10 @@ class SerpentFlow:
     def _nested_line(self, op_id: str, text: str) -> None:
         """Print a line inside a nested block."""
         if op_id and op_id in self._active_ops:
-            if len(self._active_ops) > 1:
+            if self._borderless():
+                # deeper indent, no box rails
+                self._emit_fit(f"      {text}")
+            elif len(self._active_ops) > 1:
                 short = _short_id(op_id)
                 self.console.print(
                     f"  [{_C['border']}]│ {short} │[/{_C['border']}]  {text}",
@@ -1514,6 +1570,8 @@ class SerpentFlow:
 
     def _close_nested(self, op_id: str) -> None:
         """Close a nested block."""
+        if self._borderless():
+            return                      # no footer rail in borderless mode
         w = self._block_w() - 6
         border = f"[{_C['border']}]└{'─' * w}[/{_C['border']}]"
         self._op_line(op_id, border)

--- a/docs/superpowers/plans/2026-06-15-sovereign-terminal-ui.md
+++ b/docs/superpowers/plans/2026-06-15-sovereign-terminal-ui.md
@@ -1,0 +1,540 @@
+# Sovereign Terminal UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render O+V's live terminal output in a Claude-Code-clean borderless `⏺`/`⎿` grayscale style, hardened against terminal-width overflow, async dead-air, non-UTF-8 terminals, and cursor corruption.
+
+**Architecture:** Tune the existing render layer only. New pure/async helpers live in `presentation_restraint.py` (encoding-aware glyph vocabulary, `print_fit`, async `pulse`); the SerpentFlow box-drawing render methods are rewritten to consume them. Everything rides the existing `JARVIS_PRESENTATION_RESTRAINT_ENABLED` master plus two sub-flags for byte-identical OFF rollback. Leverage Rich (`Text` overflow, `console.status`, `console.width`) — do not hand-roll width math or signal handlers.
+
+**Tech Stack:** Python 3.11, Rich, pytest, asyncio.
+
+---
+
+## File Structure
+- `backend/core/ouroboros/battle_test/presentation_restraint.py` — add: glyph vocabulary (`glyphs()`, `spinner_name()`, `_stdout_supports_utf8()`), `print_fit()`, async `pulse()`, two sub-flags. One clear responsibility: presentation primitives.
+- `backend/core/ouroboros/battle_test/serpent_flow.py` — modify: grayscale `_C` palette accessors; rewrite `_op_line` + the `┌`/`└` header/footer emitters + `_op_blank` to borderless `⏺`/`⎿`; route op-block prints through `print_fit`; wrap synth/validate awaits in `pulse`.
+- `tests/battle_test/test_presentation_glyphs_fit_pulse.py` — new: unit tests for the three helpers.
+- `tests/battle_test/test_serpent_borderless_render.py` — new: render-snapshot + OFF-parity tests.
+
+---
+
+### Task 1: Encoding-aware glyph vocabulary (Unicode Degradation Armor)
+
+**Files:**
+- Modify: `backend/core/ouroboros/battle_test/presentation_restraint.py`
+- Test: `tests/battle_test/test_presentation_glyphs_fit_pulse.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+import importlib
+import backend.core.ouroboros.battle_test.presentation_restraint as PR
+
+def test_glyphs_utf8(monkeypatch):
+    monkeypatch.setattr("sys.stdout.encoding", "utf-8", raising=False)
+    g = PR.glyphs()
+    assert g["action"] == "⏺" and g["result"] == "⎿"
+    assert PR.spinner_name() == "dots"
+
+def test_glyphs_ascii_fallback(monkeypatch):
+    monkeypatch.setattr("sys.stdout.encoding", "ascii", raising=False)
+    g = PR.glyphs()
+    assert g["action"] == "*" and g["result"] == ">"
+    assert PR.spinner_name() == "line"
+
+def test_glyphs_none_encoding_is_safe(monkeypatch):
+    monkeypatch.setattr("sys.stdout.encoding", None, raising=False)
+    assert PR.glyphs()["action"] in ("*", "⏺")   # never raises
+```
+
+- [ ] **Step 2: Run to verify it fails**
+Run: `python3 -m pytest tests/battle_test/test_presentation_glyphs_fit_pulse.py -k glyphs -v`
+Expected: FAIL — `AttributeError: module has no attribute 'glyphs'`
+
+- [ ] **Step 3: Implement**
+Add to `presentation_restraint.py`:
+```python
+import sys
+
+_GLYPHS_UTF8 = {"action": "⏺", "result": "⎿"}
+_GLYPHS_ASCII = {"action": "*", "result": ">"}
+
+
+def _stdout_supports_utf8() -> bool:
+    """True only when stdout can encode our glyphs. Fail-safe to False."""
+    try:
+        enc = (getattr(sys.stdout, "encoding", "") or "").lower()
+        return "utf" in enc
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def glyphs() -> dict:
+    """Glyph vocabulary, degraded to ASCII on non-UTF-8 stdout."""
+    return dict(_GLYPHS_UTF8 if _stdout_supports_utf8() else _GLYPHS_ASCII)
+
+
+def spinner_name() -> str:
+    """Rich spinner name: braille 'dots' on UTF-8, ASCII 'line' otherwise."""
+    return "dots" if _stdout_supports_utf8() else "line"
+```
+
+- [ ] **Step 4: Run to verify it passes**
+Run: `python3 -m pytest tests/battle_test/test_presentation_glyphs_fit_pulse.py -k glyphs -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+```bash
+git add backend/core/ouroboros/battle_test/presentation_restraint.py tests/battle_test/test_presentation_glyphs_fit_pulse.py
+git commit -m "feat(tui): encoding-aware glyph vocabulary with ASCII fallback"
+```
+
+---
+
+### Task 2: `print_fit` overflow helper (Overflow + SIGWINCH Armor)
+
+**Files:**
+- Modify: `backend/core/ouroboros/battle_test/presentation_restraint.py`
+- Test: `tests/battle_test/test_presentation_glyphs_fit_pulse.py`
+
+Leverages Rich `Text(no_wrap, overflow="ellipsis")` + `Console.width` (re-measured per print → SIGWINCH-adaptive; defaults to 80 when not a terminal). No `os.get_terminal_size` math, no signal handler.
+
+- [ ] **Step 1: Write the failing test**
+```python
+from io import StringIO
+from rich.console import Console
+import backend.core.ouroboros.battle_test.presentation_restraint as PR
+
+def test_print_fit_truncates_to_width():
+    buf = StringIO()
+    con = Console(file=buf, width=40, force_terminal=False, color_system=None)
+    PR.print_fit(con, "  ⎿ " + ("x/" * 80))          # far wider than 40
+    out = buf.getvalue().rstrip("\n")
+    assert len(out) <= 40                              # never exceeds width
+    assert out.endswith("…") or out.endswith("...")    # ellipsis applied
+
+def test_print_fit_short_line_unchanged():
+    buf = StringIO()
+    con = Console(file=buf, width=80, force_terminal=False, color_system=None)
+    PR.print_fit(con, "⏺ applied")
+    assert "applied" in buf.getvalue() and "…" not in buf.getvalue()
+
+def test_print_fit_never_wraps_multiline():
+    buf = StringIO()
+    con = Console(file=buf, width=20, force_terminal=False, color_system=None)
+    PR.print_fit(con, "⏺ " + ("verylongtokenwithoutspaces" * 4))
+    assert buf.getvalue().count("\n") == 1            # exactly one line, no wrap
+```
+
+- [ ] **Step 2: Run to verify it fails**
+Run: `python3 -m pytest tests/battle_test/test_presentation_glyphs_fit_pulse.py -k print_fit -v`
+Expected: FAIL — `AttributeError: ... 'print_fit'`
+
+- [ ] **Step 3: Implement**
+```python
+def print_fit(console, markup: str) -> None:
+    """Print one op-block line, truncated to the live console width with an
+    ellipsis — never wraps (so the ⏺/⎿ column never moves). Width is read from
+    the console per call (SIGWINCH-adaptive); Rich defaults to 80 off-terminal.
+    Fail-soft: on any Rich error, falls back to a plain crop print."""
+    try:
+        from rich.text import Text
+        console.print(
+            Text.from_markup(markup),
+            no_wrap=True, overflow="ellipsis", crop=True, soft_wrap=False,
+        )
+    except Exception:  # noqa: BLE001
+        try:
+            width = getattr(console, "width", 80) or 80
+            plain = markup
+            console.print(plain[: max(8, width - 1)], highlight=False)
+        except Exception:  # noqa: BLE001
+            pass
+```
+
+- [ ] **Step 4: Run to verify it passes**
+Run: `python3 -m pytest tests/battle_test/test_presentation_glyphs_fit_pulse.py -k print_fit -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+```bash
+git add backend/core/ouroboros/battle_test/presentation_restraint.py tests/battle_test/test_presentation_glyphs_fit_pulse.py
+git commit -m "feat(tui): Rich-native print_fit overflow truncation (SIGWINCH-adaptive)"
+```
+
+---
+
+### Task 3: Async `pulse` spinner (Cursor Armor + TTY gating)
+
+**Files:**
+- Modify: `backend/core/ouroboros/battle_test/presentation_restraint.py`
+- Test: `tests/battle_test/test_presentation_glyphs_fit_pulse.py`
+
+Uses `Console.status()` (background-thread spinner, non-blocking) gated by `real_stdout_isatty()`. The `finally` guarantees cursor restoration on any exception boundary.
+
+- [ ] **Step 1: Write the failing test**
+```python
+import asyncio
+from unittest.mock import MagicMock
+import backend.core.ouroboros.battle_test.presentation_restraint as PR
+
+def test_pulse_noop_when_not_tty(monkeypatch):
+    monkeypatch.setattr(PR, "real_stdout_isatty", lambda: False)
+    con = MagicMock()
+    ran = {}
+    async def go():
+        async with PR.pulse(con, "⏺ synthesizing"):
+            ran["body"] = True
+    asyncio.run(go())
+    assert ran["body"] is True
+    con.status.assert_not_called()            # no spinner in headless
+
+def test_pulse_starts_stops_and_restores_cursor(monkeypatch):
+    monkeypatch.setattr(PR, "real_stdout_isatty", lambda: True)
+    con = MagicMock()
+    status = MagicMock(); con.status.return_value = status
+    async def go():
+        async with PR.pulse(con, "⏺ synthesizing"):
+            pass
+    asyncio.run(go())
+    status.start.assert_called_once()
+    status.stop.assert_called_once()
+    con.show_cursor.assert_called_with(True)   # cursor armor
+
+def test_pulse_restores_cursor_on_exception(monkeypatch):
+    monkeypatch.setattr(PR, "real_stdout_isatty", lambda: True)
+    con = MagicMock(); status = MagicMock(); con.status.return_value = status
+    async def go():
+        async with PR.pulse(con, "⏺ x"):
+            raise ValueError("boom")
+    try:
+        asyncio.run(go())
+    except ValueError:
+        pass
+    status.stop.assert_called_once()           # stopped despite exception
+    con.show_cursor.assert_called_with(True)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+Run: `python3 -m pytest tests/battle_test/test_presentation_glyphs_fit_pulse.py -k pulse -v`
+Expected: FAIL — `AttributeError: ... 'pulse'`
+
+- [ ] **Step 3: Implement**
+```python
+import sys
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def pulse(console, line: str, *, spinner: str = ""):
+    """Non-blocking spinner on the active action line during awaited work.
+    TTY-gated (no-op headless/CI). Cursor armor: guarantees the cursor is
+    restored and the buffer flushed on ANY exception boundary."""
+    if not real_stdout_isatty():
+        yield
+        return
+    spin = spinner or spinner_name()
+    status = None
+    try:
+        status = console.status(line, spinner=spin)
+        status.start()
+        yield
+    finally:
+        try:
+            if status is not None:
+                status.stop()                  # clears spinner, restores cursor
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            console.show_cursor(True)          # Rich-native cursor restore
+        except Exception:  # noqa: BLE001
+            try:
+                sys.stdout.write("\033[?25h")  # last-resort raw ANSI
+                sys.stdout.flush()
+            except Exception:  # noqa: BLE001
+                pass
+```
+
+- [ ] **Step 4: Run to verify it passes**
+Run: `python3 -m pytest tests/battle_test/test_presentation_glyphs_fit_pulse.py -k pulse -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+```bash
+git add backend/core/ouroboros/battle_test/presentation_restraint.py tests/battle_test/test_presentation_glyphs_fit_pulse.py
+git commit -m "feat(tui): async pulse spinner with cursor armor + TTY gating"
+```
+
+---
+
+### Task 4: Borderless sub-flags + grayscale palette accessor
+
+**Files:**
+- Modify: `backend/core/ouroboros/battle_test/presentation_restraint.py` (flags)
+- Modify: `backend/core/ouroboros/battle_test/serpent_flow.py` (palette accessor)
+- Test: `tests/battle_test/test_serpent_borderless_render.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+import backend.core.ouroboros.battle_test.presentation_restraint as PR
+
+def test_borderless_flag_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", raising=False)
+    assert PR.borderless_enabled() is True
+
+def test_borderless_flag_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "false")
+    assert PR.borderless_enabled() is False
+
+def test_pulse_flag_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_TUI_PULSE_ENABLED", raising=False)
+    assert PR.pulse_enabled() is True
+```
+
+- [ ] **Step 2: Run to verify it fails**
+Run: `python3 -m pytest tests/battle_test/test_serpent_borderless_render.py -k flag -v`
+Expected: FAIL — `AttributeError: ... 'borderless_enabled'`
+
+- [ ] **Step 3: Implement**
+Add to `presentation_restraint.py`:
+```python
+def borderless_enabled() -> bool:
+    """Borderless ⏺/⎿ op-block render. Default TRUE under the restraint master."""
+    if not is_restraint_enabled():
+        return False
+    raw = os.environ.get("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def pulse_enabled() -> bool:
+    """Async pulse spinner. Default TRUE under the restraint master."""
+    if not is_restraint_enabled():
+        return False
+    raw = os.environ.get("JARVIS_TUI_PULSE_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+```
+Register both in `register_flags(registry)` alongside the existing restraint flags (type=bool, category="presentation", default "true", example, posture=IGNORED).
+
+- [ ] **Step 4: Run to verify it passes**
+Run: `python3 -m pytest tests/battle_test/test_serpent_borderless_render.py -k flag -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+```bash
+git add backend/core/ouroboros/battle_test/presentation_restraint.py tests/battle_test/test_serpent_borderless_render.py
+git commit -m "feat(tui): borderless + pulse sub-flags (default-true under restraint master)"
+```
+
+---
+
+### Task 5: Rewrite op-block render to borderless `⏺`/`⎿`
+
+**Files:**
+- Modify: `backend/core/ouroboros/battle_test/serpent_flow.py` — `_op_line` (~1283), the `┌`/`└` header/footer emitters (~1142, ~1278, ~1495, ~1518), `_op_blank` (~1479)
+- Test: `tests/battle_test/test_serpent_borderless_render.py`
+
+Rule: when `borderless_enabled()`, result lines render as `    {result_glyph} {text}` (4-space indent), header/action lines as `{action_glyph} {text}`, **no `┌│└─`**, every line via `print_fit`, with one blank line between op groups. When off, the legacy boxed path runs unchanged.
+
+- [ ] **Step 1: Write the failing test**
+```python
+from io import StringIO
+from rich.console import Console
+# Construct a SerpentFlow with a captured console; drive one op lifecycle.
+# (Use the existing test harness/fixtures in tests/battle_test for SerpentFlow setup.)
+
+def test_borderless_has_no_box_chars(serpent_with_capture, monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    sf, buf = serpent_with_capture
+    op = "op-test-1"
+    sf._active_ops.add(op) if hasattr(sf, "_active_ops") else None
+    sf._op_line(op, "applied · doubleword · $0.004")
+    out = buf.getvalue()
+    assert "│" not in out and "┌" not in out and "└" not in out
+    assert "⎿" in out or ">" in out            # result glyph present
+
+def test_legacy_box_path_when_off(serpent_with_capture, monkeypatch):
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "false")
+    sf, buf = serpent_with_capture
+    op = "op-test-2"
+    if hasattr(sf, "_active_ops"):
+        sf._active_ops.add(op)
+    sf._op_line(op, "x")
+    assert "│" in buf.getvalue()                # legacy border retained
+```
+
+- [ ] **Step 2: Run to verify it fails**
+Run: `python3 -m pytest tests/battle_test/test_serpent_borderless_render.py -k borderless -v`
+Expected: FAIL — box chars still present (borderless branch not implemented)
+
+- [ ] **Step 3: Implement**
+In `_op_line`, replace the focused-print branch:
+```python
+        if op_id and op_id in self._active_ops:
+            if not self._is_focused(op_id):
+                return
+            from backend.core.ouroboros.battle_test.presentation_restraint import (
+                borderless_enabled, glyphs, print_fit,
+            )
+            if borderless_enabled():
+                rg = glyphs()["result"]
+                print_fit(self.console, f"    [{_C['dim']}]{rg}[/{_C['dim']}] {text}")
+            else:
+                self.console.print(
+                    f"  [{_C['border']}]│[/{_C['border']}]  {text}", highlight=False,
+                )
+```
+Apply the analogous pattern to the header/footer emitters: when `borderless_enabled()`, emit a single `⏺ {header}` action line (no `┌`, no trailing `└` footer; the blank line from `_op_blank` separates groups). Route each through `print_fit`. In `_op_blank`, when borderless, print exactly one blank line (skip the `│` spacer).
+
+- [ ] **Step 4: Run to verify it passes**
+Run: `python3 -m pytest tests/battle_test/test_serpent_borderless_render.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+git add backend/core/ouroboros/battle_test/serpent_flow.py tests/battle_test/test_serpent_borderless_render.py
+git commit -m "feat(tui): borderless ⏺/⎿ op-block render via glyphs + print_fit"
+```
+
+---
+
+### Task 6: Grayscale palette audit (color only on outcomes)
+
+**Files:**
+- Modify: `backend/core/ouroboros/battle_test/serpent_flow.py` — render call sites that wrap secondary tokens (provider/cost/timing/op-id/posture) in non-dim colors
+- Test: `tests/battle_test/test_serpent_borderless_render.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+def test_secondary_tokens_are_dim(serpent_with_capture, monkeypatch):
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    sf, buf = serpent_with_capture
+    # render a completion line carrying provider + cost
+    sf._render_commit_phase("op-c", provider="doubleword", cost_usd=0.004)
+    out = buf.getvalue()
+    # provider/cost must not carry the magenta provider color in borderless mode
+    assert "magenta" not in out  # color_system=None renders names; assert no provider hue token
+```
+(If the capture console uses `color_system=None`, assert via the markup-builder seam instead: extract the rendered markup string and assert provider/cost segments use `_C['dim']`, and that `_C['life']`/green appears only on the success line.)
+
+- [ ] **Step 2: Run to verify it fails**
+Run: `python3 -m pytest tests/battle_test/test_serpent_borderless_render.py -k dim -v`
+Expected: FAIL — provider/cost still colored
+
+- [ ] **Step 3: Implement**
+In the borderless branches, build secondary tokens with `_C['dim']` (not `_C['provider']`/`_C['neural']`/`_C['heal']`). Keep `_C['life']` (green) only on success/`✓`/applied lines and `_C['death']` (red) only on failure lines. Leave the legacy (non-borderless) path untouched.
+
+- [ ] **Step 4: Run to verify it passes**
+Run: `python3 -m pytest tests/battle_test/test_serpent_borderless_render.py -k dim -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+git add backend/core/ouroboros/battle_test/serpent_flow.py tests/battle_test/test_serpent_borderless_render.py
+git commit -m "feat(tui): grayscale chrome — color reserved for outcomes"
+```
+
+---
+
+### Task 7: Wire `pulse` into synth/validate awaits
+
+**Files:**
+- Modify: `backend/core/ouroboros/battle_test/serpent_flow.py` — `show_streaming_start` (~1571) / the generation+validation await path
+- Test: `tests/battle_test/test_serpent_borderless_render.py`
+
+- [ ] **Step 1: Write the failing test**
+```python
+import asyncio
+from unittest.mock import MagicMock, patch
+
+def test_pulse_used_around_synth(serpent_with_capture, monkeypatch):
+    monkeypatch.setenv("JARVIS_TUI_PULSE_ENABLED", "true")
+    sf, _ = serpent_with_capture
+    seen = {}
+    import backend.core.ouroboros.battle_test.presentation_restraint as PR
+    monkeypatch.setattr(PR, "real_stdout_isatty", lambda: True)
+    monkeypatch.setattr(sf.console, "status", lambda *a, **k: seen.setdefault("status", MagicMock(**{"start": MagicMock(), "stop": MagicMock()})) or seen["status"])
+    async def go():
+        async with sf._synth_pulse("op-p", "doubleword"):   # thin wrapper added in impl
+            pass
+    asyncio.run(go())
+    assert "status" in seen
+```
+
+- [ ] **Step 2: Run to verify it fails**
+Run: `python3 -m pytest tests/battle_test/test_serpent_borderless_render.py -k pulse_used -v`
+Expected: FAIL — `_synth_pulse` not defined
+
+- [ ] **Step 3: Implement**
+Add a thin wrapper that respects `pulse_enabled()` and delegates to `presentation_restraint.pulse`:
+```python
+    def _synth_pulse(self, op_id: str, provider: str):
+        from backend.core.ouroboros.battle_test.presentation_restraint import (
+            pulse, pulse_enabled, glyphs,
+        )
+        if not pulse_enabled():
+            from contextlib import asynccontextmanager
+            @asynccontextmanager
+            async def _noop():
+                yield
+            return _noop()
+        line = f"{glyphs()['action']} synthesizing · {_PROV.get(provider, provider)}"
+        return pulse(self.console, line)
+```
+Wrap the actual generation/validation await in the live loop with `async with self._synth_pulse(op_id, provider):` (and an analogous `validating` line for the LiveKernelValidator await).
+
+- [ ] **Step 4: Run to verify it passes**
+Run: `python3 -m pytest tests/battle_test/test_serpent_borderless_render.py -k pulse_used -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+git add backend/core/ouroboros/battle_test/serpent_flow.py tests/battle_test/test_serpent_borderless_render.py
+git commit -m "feat(tui): wire async pulse into synthesizing/validating awaits"
+```
+
+---
+
+### Task 8: Full-lifecycle render snapshot + OFF parity
+
+**Files:**
+- Test: `tests/battle_test/test_serpent_borderless_render.py`
+
+- [ ] **Step 1: Write the test**
+```python
+def test_full_lifecycle_clean(serpent_with_capture, monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    sf, buf = serpent_with_capture
+    # drive sensed → synthesizing → validating → applied via the public render methods
+    # (use the same calls the orchestrator emits; see existing presentation tests)
+    out = buf.getvalue()
+    assert not any(c in out for c in "┌│└")          # borderless
+    assert out.count("\n\n") >= 1                      # vertical rhythm between groups
+
+def test_off_parity_identical_to_legacy(serpent_with_capture, monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "false")
+    sf, buf = serpent_with_capture
+    sf._op_line("op-x", "y") if hasattr(sf, "_active_ops") else None
+    assert "│" in buf.getvalue() or buf.getvalue() == ""   # legacy path active
+```
+
+- [ ] **Step 2: Run to verify**
+Run: `python3 -m pytest tests/battle_test/test_serpent_borderless_render.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 3: Run the broader presentation suite for regressions**
+Run: `python3 -m pytest tests/battle_test/ -k "presentation or restraint or serpent or render" -q`
+Expected: PASS (no regressions in the existing 198 presentation tests)
+
+- [ ] **Step 4: Commit**
+```bash
+git add tests/battle_test/test_serpent_borderless_render.py
+git commit -m "test(tui): full-lifecycle borderless snapshot + OFF parity"
+```
+
+---
+
+## Self-Review
+- **Spec coverage:** Phase 1 (borderless/glyphs/grayscale/whitespace) → Tasks 5,6,8. Phase 2 (overflow, SIGWINCH) → Task 2. Phase 3 (pulse) → Tasks 3,7. Safety Matrix: cursor armor → Task 3; Unicode degradation → Task 1; SIGWINCH → Task 2 (per-render width). Flags/OFF-parity → Tasks 4,8. ✓ no gaps.
+- **Placeholder scan:** all steps carry real code/commands; the only soft reference is the `serpent_with_capture` fixture — the implementer must reuse the existing SerpentFlow test fixture in `tests/battle_test/` (noted explicitly in Task 5). No TBD/TODO.
+- **Type consistency:** helper names consistent across tasks — `glyphs()`, `spinner_name()`, `print_fit(console, markup)`, `pulse(console, line, *, spinner="")`, `borderless_enabled()`, `pulse_enabled()`, `_synth_pulse(op_id, provider)`. ✓

--- a/docs/superpowers/specs/2026-06-15-sovereign-terminal-ui-design.md
+++ b/docs/superpowers/specs/2026-06-15-sovereign-terminal-ui-design.md
@@ -1,0 +1,145 @@
+# Sovereign Terminal UI — Claude-Code-Clean Presentation for O+V
+
+**Date:** 2026-06-15
+**Status:** design (pending user review → writing-plans)
+
+## Goal
+Make O+V's live terminal presentation read as cleanly as Claude Code: a borderless
+`⏺`/`⎿` hierarchy in grayscale, with color reserved for outcomes — while staying robust
+against terminal-width overflow and async "dead air." This **tunes the existing
+presentation layer** (`presentation_restraint.py` + the SerpentFlow render methods); it
+deletes the box-drawing paths rather than adding a parallel renderer, and rides the existing
+master flags so OFF is byte-identical rollback.
+
+## Non-goals
+- No change to what information is shown (same phases, provider, cost, risk, diff) — only
+  *how* it's rendered.
+- No change to the TUI split/focus layout FSM, the diff preview, or the observability/SSE
+  surfaces.
+- No new dependency — Rich is already the rendering substrate.
+
+## Architecture
+The render layer is the only thing touched. Three composable units, each independently
+testable and OFF-inert:
+
+1. **Chrome vocabulary** (`presentation_restraint.py`): glyph constants (`GLYPH_ACTION="⏺"`,
+   `GLYPH_RESULT="⎿"`), a grayscale-first palette accessor, and pure formatting helpers.
+   No Rich import here beyond what already exists; returns plain strings / Rich markup.
+2. **Op-block renderer** (`serpent_flow.py`): the methods that currently draw
+   `┌ │ └ ─` frames + per-phase emojis + colored badges are rewritten to emit the flat
+   `⏺ action` / `  ⎿ result` form with 2-space indentation and one blank line between op
+   groups.
+3. **Fit + pulse** (`presentation_restraint.py` helpers, consumed by `serpent_flow.py`):
+   `_fit()` (overflow) and an async `pulse()` context (spinner), both TTY-aware.
+
+### Data flow
+Unchanged: orchestrator/intake emit the same phase events → SerpentFlow render methods →
+Rich `Console`. Only the render-method bodies change. Every event still maps 1:1 to a
+rendered line; we change the glyph/indent/color, not the event model.
+
+---
+
+## Phase 1 — Typographical Restraint
+**Changes (the 4 agreed):**
+1. **Kill the boxes.** Remove every `_C['border']` `┌ │ └ ─` emission in the op-block /
+   plan / generation render methods. Hierarchy is expressed as:
+   ```
+   ⏺ <action>  <primary target>            <dim right-meta>
+     ⎿ <result / sub-detail, dim>
+   ```
+   Action line at column 0 with `⏺`; result lines indented 2 spaces under it with `⎿`.
+2. **Glyph vocabulary.** One vocabulary everywhere: `⏺` for an action/phase-start, `⎿` for
+   its result/continuation. Per-phase emojis (`🔬 🧬 ⚙️ 🐍` on lines) are removed.
+3. **Grayscale chrome.** Action text = default/white; **all** secondary tokens (provider,
+   cost, timing, op-id, posture) = `dim`. Color is reserved: **green only** for
+   success/`✓`/applied, **red only** for failure. Risk tier shows as a dim word
+   (`notify_apply`) except `approval_required`/`blocked` which may use a single accent.
+4. **Vertical rhythm.** Exactly one blank line between distinct operation groups (not
+   between an action and its own `⎿` results).
+
+**Emoji decision (default, adjustable at review):** keep the operator's signature emojis in
+the **boot panel only**; remove all per-line phase emojis. (If the user prefers fully
+emoji-free, flip one constant.)
+
+**Reversibility:** gated by the existing `JARVIS_PRESENTATION_RESTRAINT_ENABLED` master (+ a
+sub-flag `JARVIS_OPBLOCK_BORDERLESS_ENABLED`, default TRUE under the master). When the
+master is off, the legacy boxed renderer path is retained byte-identically.
+
+---
+
+## Phase 2 — Overflow Integrity Protocol
+**Problem:** long file paths / tracebacks wrap, shattering the indentation hierarchy.
+
+**Approach (leverage Rich, do not hand-roll width math):**
+- A single helper `fit(text, *, indent, width=None) -> str` that renders through a Rich
+  `Text(text, no_wrap=True, overflow="ellipsis")` (or equivalent truncation) so wide chars,
+  emoji, and ANSI are width-counted correctly.
+- Width source precedence: explicit `width` arg → live `console.width` →
+  `os.get_terminal_size().columns` → `80` (headless/pipe fallback).
+- Effective budget = `width - indent`; the indent prefix is added back after truncation so
+  the `⏺`/`⎿` column never moves.
+- Applied uniformly: every rendered op-block line passes through `fit()`. Multi-line
+  payloads (tracebacks, diffs) keep their existing dedicated renderers (diff preview is
+  out of scope) but their *one-line summaries* in the op-block are `fit()`-bounded.
+
+**Why not raw `os.get_terminal_size()` per line:** it miscounts ANSI/wide chars and
+duplicates Rich's measurer. Rich is already the substrate; `get_terminal_size` is only the
+no-console fallback. (Matches the repo's "no duplication / leverage existing" mandate.)
+
+---
+
+## Phase 3 — Asynchronous Pulse
+**Problem:** during `synthesizing` (network I/O) and `validating` (LiveKernelValidator
+subprocess) the active line is frozen — no proof the FSM is alive.
+
+**Approach (leverage Rich spinner, TTY-gated):**
+- An async helper `pulse(console, action_line, *, frames="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", interval=0.1)`
+  used as an async context manager around the awaited work:
+  ```python
+  async with pulse(console, "⏺ synthesizing · doubleword"):
+      result = await provider.generate(...)
+  # on exit: spinner cleared, final ⏺ line rewritten in place
+  ```
+- Renders **only on the active action line**, in place (carriage-return / Rich `Live` or
+  `Status`), and clears cleanly on exit (success or exception) leaving the resolved line.
+- **TTY-gated** via `real_stdout_isatty()` (the load-bearing check — `sys.__stdout__`, works
+  under `patch_stdout(raw=True)`). Headless / sandbox / CI / piped → **no-op** (the awaited
+  work still runs; no spinner art leaks into logs). This mirrors the existing rule that the
+  stream renderer + diff preview require a real TTY.
+- Non-blocking: the spinner is a separate `asyncio` task that ticks while the real coroutine
+  is awaited; cancelled + joined on context exit. Never blocks the event loop.
+
+**Reversibility:** gated by `JARVIS_TUI_PULSE_ENABLED` (default TRUE under the restraint
+master). Off → static line (today's behavior).
+
+---
+
+## Components / files
+| File | Change |
+|---|---|
+| `battle_test/presentation_restraint.py` | add glyph constants, grayscale palette accessor, `fit()`, async `pulse()`; new sub-flags in `register_flags` |
+| `battle_test/serpent_flow.py` | rewrite op-block / plan / generation render methods to borderless `⏺`/`⎿`; route every line through `fit()`; wrap synth/validate awaits in `pulse()` |
+| `tests/battle_test/` | new render-snapshot + fit + pulse-gating tests (extend existing presentation tests) |
+
+`stream_renderer.py`, `status_line.py`, `diff_preview.py` are **not** rewritten, but the
+status-line/glyph palette is aligned to the grayscale rule for consistency (color audit
+only, no structural change).
+
+## Testing
+- **Render snapshots:** given a synthetic op lifecycle, assert the rendered text has no
+  `┌│└─`, uses `⏺`/`⎿`, indents results 2 spaces, and emits one blank line between groups.
+- **Grayscale:** assert secondary tokens carry `dim` and that green/red appear only on
+  success/failure lines (markup assertions).
+- **Overflow:** a path longer than `width` → output length ≤ width, ends with `…`, `⏺`
+  column unchanged; width fallback chain exercised (no console → get_terminal_size → 80).
+- **Pulse gating:** `real_stdout_isatty()` True → spinner task starts/stops + line cleared;
+  False (headless) → `pulse()` is a no-op, awaited work still completes, zero spinner output.
+- **OFF parity:** master flag off → byte-identical to the legacy boxed renderer.
+
+## Risks / invariants
+- **TTY detection is load-bearing** — use `real_stdout_isatty()` everywhere, never
+  `sys.stdout.isatty()` (fails under `patch_stdout(raw=True)`).
+- **Rich import stays in the view layer** — `fit()`/`pulse()` live with the other render
+  code; no Rich import leaks into governance/authority modules.
+- **No event-model change** — pure presentation; if a render path is missed, worst case is a
+  legacy-looking line, never a crash (every helper fail-soft → returns plain text).

--- a/tests/battle_test/test_presentation_glyphs_fit_pulse.py
+++ b/tests/battle_test/test_presentation_glyphs_fit_pulse.py
@@ -1,0 +1,20 @@
+import backend.core.ouroboros.battle_test.presentation_restraint as PR
+
+
+def test_glyphs_utf8(monkeypatch):
+    monkeypatch.setattr(PR, "_stdout_supports_utf8", lambda: True)
+    g = PR.glyphs()
+    assert g["action"] == "⏺" and g["result"] == "⎿"
+    assert PR.spinner_name() == "dots"
+
+
+def test_glyphs_ascii_fallback(monkeypatch):
+    monkeypatch.setattr(PR, "_stdout_supports_utf8", lambda: False)
+    g = PR.glyphs()
+    assert g["action"] == "*" and g["result"] == ">"
+    assert PR.spinner_name() == "line"
+
+
+def test_glyphs_none_encoding_is_safe(monkeypatch):
+    monkeypatch.setattr(PR, "_stdout_supports_utf8", lambda: False)
+    assert PR.glyphs()["action"] in ("*", "⏺")  # never raises

--- a/tests/battle_test/test_presentation_glyphs_fit_pulse.py
+++ b/tests/battle_test/test_presentation_glyphs_fit_pulse.py
@@ -43,3 +43,41 @@ def test_glyphs_none_encoding_is_safe(monkeypatch):
 def test_glyphs_missing_stdout_is_safe(monkeypatch):
     monkeypatch.setattr(sys, "stdout", object())  # no .encoding attr at all
     assert PR.glyphs()["action"] == "*"          # fail-safe to ASCII
+
+
+# --------------------------------------------------------------------------- print_fit
+from io import StringIO  # noqa: E402
+from rich.console import Console  # noqa: E402
+
+
+def _con(width):
+    return Console(file=StringIO(), width=width, force_terminal=False, color_system=None)
+
+
+def test_print_fit_truncates_to_width():
+    con = _con(40)
+    PR.print_fit(con, "  ⎿ " + ("x/" * 80))            # far wider than 40
+    out = con.file.getvalue().rstrip("\n")
+    assert len(out) <= 40                               # never exceeds width
+    assert out.endswith("…") or out.endswith("...")     # ellipsis applied
+
+
+def test_print_fit_short_line_unchanged():
+    con = _con(80)
+    PR.print_fit(con, "⏺ applied")
+    out = con.file.getvalue()
+    assert "applied" in out and "…" not in out
+
+
+def test_print_fit_never_wraps_multiline():
+    con = _con(20)
+    PR.print_fit(con, "⏺ " + ("verylongtokenwithoutspaces" * 4))
+    assert con.file.getvalue().count("\n") == 1        # exactly one line, no wrap
+
+
+def test_print_fit_failsoft_on_bad_console():
+    class _Boom:
+        width = 30
+        def print(self, *a, **k):
+            raise RuntimeError("nope")
+    PR.print_fit(_Boom(), "anything")                  # must not raise

--- a/tests/battle_test/test_presentation_glyphs_fit_pulse.py
+++ b/tests/battle_test/test_presentation_glyphs_fit_pulse.py
@@ -81,3 +81,61 @@ def test_print_fit_failsoft_on_bad_console():
         def print(self, *a, **k):
             raise RuntimeError("nope")
     PR.print_fit(_Boom(), "anything")                  # must not raise
+
+
+# --------------------------------------------------------------------------- pulse
+import asyncio  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+
+def test_pulse_noop_when_not_tty(monkeypatch):
+    monkeypatch.setattr(PR, "real_stdout_isatty", lambda: False)
+    con = MagicMock()
+    ran = {}
+
+    async def go():
+        async with PR.pulse(con, "⏺ synthesizing"):
+            ran["body"] = True
+
+    asyncio.run(go())
+    assert ran["body"] is True
+    con.status.assert_not_called()             # no spinner in headless
+
+
+def test_pulse_starts_stops_and_restores_cursor(monkeypatch):
+    monkeypatch.setattr(PR, "real_stdout_isatty", lambda: True)
+    con = MagicMock()
+    status = MagicMock()
+    con.status.return_value = status
+
+    async def go():
+        async with PR.pulse(con, "⏺ synthesizing"):
+            pass
+
+    asyncio.run(go())
+    status.start.assert_called_once()
+    status.stop.assert_called_once()
+    con.show_cursor.assert_called_with(True)   # cursor armor
+
+
+def test_pulse_restores_cursor_on_exception(monkeypatch):
+    monkeypatch.setattr(PR, "real_stdout_isatty", lambda: True)
+    con = MagicMock()
+    status = MagicMock()
+    con.status.return_value = status
+
+    async def go():
+        async with PR.pulse(con, "⏺ x"):
+            raise ValueError("boom")
+
+    with pytest_raises(ValueError):
+        asyncio.run(go())
+    status.stop.assert_called_once()           # stopped despite exception
+    con.show_cursor.assert_called_with(True)
+
+
+import pytest as _pytest  # noqa: E402
+
+
+def pytest_raises(exc):
+    return _pytest.raises(exc)

--- a/tests/battle_test/test_presentation_glyphs_fit_pulse.py
+++ b/tests/battle_test/test_presentation_glyphs_fit_pulse.py
@@ -1,20 +1,45 @@
+"""Sovereign Terminal UI — glyph vocabulary / print_fit / pulse unit tests."""
+import sys
+
 import backend.core.ouroboros.battle_test.presentation_restraint as PR
 
 
+class _FakeStdout:
+    """Minimal stdout stand-in carrying a settable ``encoding`` (the real
+    ``sys.stdout.encoding`` is a readonly C attribute, so we replace the whole
+    object to exercise the genuine encoding-detection path)."""
+
+    def __init__(self, encoding):
+        self.encoding = encoding
+
+    def write(self, *_a):
+        return 0
+
+    def flush(self):
+        pass
+
+
+# --------------------------------------------------------------------------- glyphs
 def test_glyphs_utf8(monkeypatch):
-    monkeypatch.setattr(PR, "_stdout_supports_utf8", lambda: True)
+    monkeypatch.setattr(sys, "stdout", _FakeStdout("utf-8"))
     g = PR.glyphs()
     assert g["action"] == "⏺" and g["result"] == "⎿"
     assert PR.spinner_name() == "dots"
 
 
 def test_glyphs_ascii_fallback(monkeypatch):
-    monkeypatch.setattr(PR, "_stdout_supports_utf8", lambda: False)
+    monkeypatch.setattr(sys, "stdout", _FakeStdout("ascii"))
     g = PR.glyphs()
     assert g["action"] == "*" and g["result"] == ">"
     assert PR.spinner_name() == "line"
 
 
 def test_glyphs_none_encoding_is_safe(monkeypatch):
-    monkeypatch.setattr(PR, "_stdout_supports_utf8", lambda: False)
-    assert PR.glyphs()["action"] in ("*", "⏺")  # never raises
+    monkeypatch.setattr(sys, "stdout", _FakeStdout(None))   # encoding can be None
+    assert PR.glyphs()["action"] == "*"          # degrades, never raises
+    assert PR.spinner_name() == "line"
+
+
+def test_glyphs_missing_stdout_is_safe(monkeypatch):
+    monkeypatch.setattr(sys, "stdout", object())  # no .encoding attr at all
+    assert PR.glyphs()["action"] == "*"          # fail-safe to ASCII

--- a/tests/battle_test/test_serpent_borderless_render.py
+++ b/tests/battle_test/test_serpent_borderless_render.py
@@ -171,3 +171,34 @@ def test_synth_pulse_noop_when_disabled(monkeypatch):
     asyncio.run(go())
     assert ran["body"] is True
     flow.console.status.assert_not_called()
+
+
+# --------------------------------------------------------------------------- lifecycle
+def test_full_lifecycle_borderless_clean(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    flow, buf = _flow()
+    op = "op-life"
+    flow._open_op_block(op, "TestFailure")
+    flow._op_line(op, "[cyan]🔬 sensed[/cyan]  fix the thing")
+    flow._op_line(op, "[magenta]synthesizing[/magenta]  doubleword")
+    flow._op_line(op, "[green]applied[/green]  $0.004")
+    flow._op_blank(op)
+    flow._close_op_block(op)
+    out = buf.getvalue()
+    assert not any(c in out for c in _BOX_CHARS)          # borderless throughout
+    assert ("⏺" in out) or ("*" in out)                   # action glyph
+    assert "fix the thing" in out and "TestFailure" in out
+    assert "🔬" not in out                                 # emoji demoted
+    assert "\n\n" in out                                   # vertical rhythm
+
+
+def test_off_parity_legacy_boxes_intact(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "false")
+    flow, buf = _flow()
+    op = "op-legacy"
+    flow._open_op_block(op, "TestFailure")
+    flow._op_line(op, "x")
+    flow._close_op_block(op)
+    out = buf.getvalue()
+    assert "┌" in out and "│" in out and "└" in out       # legacy boxed render intact

--- a/tests/battle_test/test_serpent_borderless_render.py
+++ b/tests/battle_test/test_serpent_borderless_render.py
@@ -131,3 +131,43 @@ def test_op_line_borderless_strips_emoji_and_color(monkeypatch):
     flow._op_line(op, "[cyan]🔬 sensed[/cyan]  mygoal")
     out = buf.getvalue()
     assert "🔬" not in out and "mygoal" in out
+
+
+# --------------------------------------------------------------------------- pulse wiring
+import asyncio  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+
+def test_synth_pulse_uses_status_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TUI_PULSE_ENABLED", "true")
+    monkeypatch.setattr(PR, "real_stdout_isatty", lambda: True)
+    flow, _ = _flow()
+    status = MagicMock()
+    flow.console = MagicMock()
+    flow.console.status.return_value = status
+
+    async def go():
+        async with flow._synth_pulse("op-p", "doubleword"):
+            pass
+
+    asyncio.run(go())
+    status.start.assert_called_once()
+    status.stop.assert_called_once()
+    flow.console.show_cursor.assert_called_with(True)
+
+
+def test_synth_pulse_noop_when_disabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TUI_PULSE_ENABLED", "false")
+    flow, _ = _flow()
+    flow.console = MagicMock()
+    ran = {}
+
+    async def go():
+        async with flow._synth_pulse("op-p", "doubleword"):
+            ran["body"] = True
+
+    asyncio.run(go())
+    assert ran["body"] is True
+    flow.console.status.assert_not_called()

--- a/tests/battle_test/test_serpent_borderless_render.py
+++ b/tests/battle_test/test_serpent_borderless_render.py
@@ -31,3 +31,72 @@ def test_pulse_off_when_master_off(monkeypatch):
     monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "false")
     monkeypatch.delenv("JARVIS_TUI_PULSE_ENABLED", raising=False)
     assert PR.pulse_enabled() is False
+
+
+# --------------------------------------------------------------------------- render
+import io  # noqa: E402
+
+_BOX_CHARS = "┌│└─"
+
+
+def _flow():
+    from rich.console import Console
+    from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+    flow = SerpentFlow(session_id="bt-tui-test", cost_cap_usd=2.5, idle_timeout_s=3600.0)
+    buf = io.StringIO()
+    flow.console = Console(file=buf, force_terminal=False, width=120, color_system=None)
+    flow._lens_mode = "all"                  # force every op to render to the viewport
+    flow._read_current_posture_token = lambda: "EXPLORE"
+    return flow, buf
+
+
+def test_op_line_borderless_no_box(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    flow, buf = _flow()
+    op = "op-test-aaaa"
+    flow._active_ops.add(op)
+    flow._op_line(op, "applied · doubleword · $0.004")
+    out = buf.getvalue()
+    assert not any(c in out for c in _BOX_CHARS)
+    assert ("⎿" in out) or (">" in out)       # result glyph (utf8 or ascii)
+
+
+def test_op_line_legacy_box_when_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "false")
+    flow, buf = _flow()
+    op = "op-test-bbbb"
+    flow._active_ops.add(op)
+    flow._op_line(op, "x")
+    assert "│" in buf.getvalue()                # legacy border retained
+
+
+def test_open_block_borderless_action_glyph(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    flow, buf = _flow()
+    flow._open_op_block("op-test-cccc", "VoiceCommand")
+    out = buf.getvalue()
+    assert "┌" not in out
+    assert ("⏺" in out) or ("*" in out)        # action glyph
+    assert "VoiceCommand" in out
+
+
+def test_op_blank_borderless_is_plain(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    flow, buf = _flow()
+    op = "op-test-dddd"
+    flow._active_ops.add(op)
+    flow._op_blank(op)
+    assert "│" not in buf.getvalue()
+
+
+def test_close_block_borderless_no_footer(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    flow, buf = _flow()
+    op = "op-test-eeee"
+    flow._active_ops.add(op)
+    flow._close_op_block(op)
+    assert not any(c in buf.getvalue() for c in _BOX_CHARS)

--- a/tests/battle_test/test_serpent_borderless_render.py
+++ b/tests/battle_test/test_serpent_borderless_render.py
@@ -138,39 +138,66 @@ import asyncio  # noqa: E402
 from unittest.mock import MagicMock  # noqa: E402
 
 
-def test_synth_pulse_uses_status_when_enabled(monkeypatch):
+def test_synth_pulse_drives_existing_spinner(monkeypatch):
+    # Leverages the EXISTING _spinner_state mechanism, not a console.status overlay.
     monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
     monkeypatch.setenv("JARVIS_TUI_PULSE_ENABLED", "true")
-    monkeypatch.setattr(PR, "real_stdout_isatty", lambda: True)
     flow, _ = _flow()
-    status = MagicMock()
-    flow.console = MagicMock()
-    flow.console.status.return_value = status
+    mid = {}
 
     async def go():
         async with flow._synth_pulse("op-p", "doubleword"):
-            pass
+            mid["active"] = flow._spinner_state.active
+            mid["msg"] = flow._spinner_state.message
 
     asyncio.run(go())
-    status.start.assert_called_once()
-    status.stop.assert_called_once()
-    flow.console.show_cursor.assert_called_with(True)
+    assert mid["active"] is True                         # spinner armed during await
+    assert "synthesizing" in mid["msg"]
+    assert flow._spinner_state.active is False           # cleared after
+
+
+def test_synth_pulse_clears_spinner_on_exception(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TUI_PULSE_ENABLED", "true")
+    flow, _ = _flow()
+
+    async def go():
+        async with flow._synth_pulse("op-p", "doubleword"):
+            raise ValueError("boom")
+
+    try:
+        asyncio.run(go())
+    except ValueError:
+        pass
+    assert flow._spinner_state.active is False           # cleared despite exception
 
 
 def test_synth_pulse_noop_when_disabled(monkeypatch):
     monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
     monkeypatch.setenv("JARVIS_TUI_PULSE_ENABLED", "false")
     flow, _ = _flow()
-    flow.console = MagicMock()
     ran = {}
 
     async def go():
         async with flow._synth_pulse("op-p", "doubleword"):
             ran["body"] = True
+            ran["active"] = flow._spinner_state.active
 
     asyncio.run(go())
     assert ran["body"] is True
-    flow.console.status.assert_not_called()
+    assert ran["active"] is False                        # never armed when disabled
+
+
+def test_start_status_borderless_cleans_message(monkeypatch):
+    # The EXISTING execution spinner (validate/verify/tool) shows grayscale-clean
+    # messages in borderless mode: no box prefix, no per-phase emoji.
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    flow, _ = _flow()
+    flow._start_status("  │  🛡️ immune check │ running tests…")
+    msg = flow._spinner_state.message
+    assert "│" not in msg and "🛡️" not in msg
+    assert "immune check" in msg and "running tests" in msg
 
 
 # --------------------------------------------------------------------------- lifecycle

--- a/tests/battle_test/test_serpent_borderless_render.py
+++ b/tests/battle_test/test_serpent_borderless_render.py
@@ -100,3 +100,34 @@ def test_close_block_borderless_no_footer(monkeypatch):
     flow._active_ops.add(op)
     flow._close_op_block(op)
     assert not any(c in buf.getvalue() for c in _BOX_CHARS)
+
+
+# --------------------------------------------------------------------------- grayscale
+def test_clean_markup_demotes_secondary_colors():
+    from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+    out = SerpentFlow._clean_markup("[cyan]synth[/cyan] [magenta]DW[/magenta] [yellow]m[/yellow]")
+    assert "cyan" not in out and "magenta" not in out and "yellow" not in out
+    assert "[dim]" in out
+
+
+def test_clean_markup_preserves_outcome_colors():
+    from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+    out = SerpentFlow._clean_markup("[green]ok[/green] [red]bad[/red]")
+    assert "[green]" in out and "[red]" in out
+
+
+def test_clean_markup_strips_phase_emoji():
+    from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+    out = SerpentFlow._clean_markup("🔬 sensed")
+    assert "🔬" not in out and "sensed" in out
+
+
+def test_op_line_borderless_strips_emoji_and_color(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "true")
+    flow, buf = _flow()
+    op = "op-emoji"
+    flow._active_ops.add(op)
+    flow._op_line(op, "[cyan]🔬 sensed[/cyan]  mygoal")
+    out = buf.getvalue()
+    assert "🔬" not in out and "mygoal" in out

--- a/tests/battle_test/test_serpent_borderless_render.py
+++ b/tests/battle_test/test_serpent_borderless_render.py
@@ -1,0 +1,33 @@
+"""Sovereign Terminal UI — borderless render + sub-flag regression suite."""
+import backend.core.ouroboros.battle_test.presentation_restraint as PR
+
+
+# --------------------------------------------------------------------------- flags
+def test_borderless_flag_default_true(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", raising=False)
+    assert PR.borderless_enabled() is True
+
+
+def test_borderless_flag_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", "false")
+    assert PR.borderless_enabled() is False
+
+
+def test_borderless_off_when_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_OPBLOCK_BORDERLESS_ENABLED", raising=False)
+    assert PR.borderless_enabled() is False     # master gates the sub-flag
+
+
+def test_pulse_flag_default_true(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_TUI_PULSE_ENABLED", raising=False)
+    assert PR.pulse_enabled() is True
+
+
+def test_pulse_off_when_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_RESTRAINT_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_TUI_PULSE_ENABLED", raising=False)
+    assert PR.pulse_enabled() is False


### PR DESCRIPTION
## Summary
Makes O+V's live terminal presentation read like Claude Code: a **borderless `⏺`/`⎿` grayscale** hierarchy, hardened against terminal overflow, async dead-air, non-UTF-8 terminals, and cursor corruption. Tunes the existing `presentation_restraint` + SerpentFlow render layer (deletes the box-drawing — *reduces* code, no parallel renderer). Spec + plan: `docs/superpowers/specs/2026-06-15-sovereign-terminal-ui-design.md`, `docs/superpowers/plans/2026-06-15-sovereign-terminal-ui.md`.

## What changed (8 TDD tasks, 29 tests)
- **Borderless render** — `_open_op_block`/`_op_line`/`_op_blank`/`_close_op_block` + nested blocks emit `⏺` action / indented `⎿` result, no `┌│└─`, one blank line between op groups.
- **Grayscale chrome** — single `_clean_markup` chokepoint demotes secondary styles (cyan/magenta/yellow/blue) → dim and strips per-phase emojis; **green/red preserved for outcomes**.
- **Encoding-aware glyphs** — degrade `⏺`/`⎿`/braille → `*`/`>`/`line` on non-UTF-8 stdout (no `UnicodeEncodeError`).
- **Overflow integrity** — `print_fit` truncates each line to live `console.width` via Rich `no_wrap+ellipsis` (SIGWINCH-adaptive); never wraps.
- **Async pulse** — `console.status` spinner on the active line, **TTY-gated**, `try/finally` **cursor armor** (`show_cursor`, raw `\033[?25h` fallback) on any exception.
- **Flags** — `JARVIS_OPBLOCK_BORDERLESS_ENABLED` + `JARVIS_TUI_PULSE_ENABLED`, default-true **under the restraint master**; master-off is byte-identical legacy boxed render. Registered in FlagRegistry for `/help`.

## Test Plan
- [x] 29 tests: glyph fallback, print_fit overflow/no-wrap/fail-soft, pulse start/stop/cursor-restore (incl. exception path), flag gating, borderless render, grayscale+emoji demotion, full-lifecycle snapshot, OFF parity.
- [x] **Zero regressions** — the 16 status_line/banner/streaming failures in the broad suite are **pre-existing on `origin/main`** (verified identical on a pristine worktree).
- [ ] Operator: visual confirmation on a real TTY boot (tests prove structure; eyes confirm feel).

## Honest scope note
`_synth_pulse` is built + tested but not yet wrapped around the live orchestrator generation await (SerpentFlow renders; the await is orchestrator-side) — a clean follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches O+V’s live terminal to a clean, borderless ⏺/⎿ layout with grayscale chrome, overflow-safe printing, UTF‑8 fallbacks, and a TTY‑gated async pulse that reuses the existing spinner. All changes are presentation-only; turning the master off preserves the legacy boxed renderer byte-for-byte.

- New Features
  - Borderless render: action ⏺ header and indented ⎿ result lines; no ┌│└─; one blank line between op groups; nested blocks render as dim sub-lines.
  - Grayscale cleanup: demotes cyan/magenta/yellow/blue to dim and strips phase emojis; keeps green/red for outcomes.
  - Robust output: encoding-aware glyphs and spinner name (`dots`/`line` on non‑UTF‑8), and `print_fit` uses `Rich` (no-wrap + ellipsis, SIGWINCH-adaptive) to prevent wrapping.
  - Flags and tests: `JARVIS_OPBLOCK_BORDERLESS_ENABLED` and `JARVIS_TUI_PULSE_ENABLED` (default true under the restraint master; listed in `/help`), with targeted tests for glyphs, fit, borderless render, and OFF parity.

- Refactors
  - Pulse now delegates to the existing `_start_status`/`_stop_status` spinner (no new `console.status` overlay in SerpentFlow), with cursor-restore guarantees and TTY gating; `_start_status` messages are grayscale-cleaned to match the borderless style. The generic `pulse()` helper remains available.

<sup>Written for commit 6708b1c0a47eccd7b4d7412c71871a314fba0e2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

