### PR TITLE
Sovereign Telemetry Unification — graduation arbiter reuses the harvester (Phase 9 §P9.1)

### DIFF
--- a/backend/core/ouroboros/governance/adaptation/graduation_ledger.py
+++ b/backend/core/ouroboros/governance/adaptation/graduation_ledger.py
@@ -416,6 +416,24 @@ CADENCE_POLICY: Tuple[CadencePolicyEntry, ...] = (
             "delta emission"
         ),
     ),
+    # ----------------------------------------------------------------
+    # Capstone Dogfood — LiveKernelValidator (Sovereign Telemetry
+    # Unification, 2026-06-15). Kernel-touching: the validator reroutes
+    # live-fire-failing candidates back through GENERATE_RETRY as
+    # failure_class=build. Its per-flag GraduationContract demands
+    # harvester-proven self-heal evidence (fired + no-OOM + recovered),
+    # so it carries the stricter Pass C bar (5 clean sessions).
+    # ----------------------------------------------------------------
+    CadencePolicyEntry(
+        flag_name="JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED",
+        required_clean_sessions=5,
+        cadence_class=CadenceClass.PASS_C,
+        description=(
+            "LiveKernelValidator — live-fire boot validation reroutes "
+            "kernel-touching candidates to self-heal (mutation-adjacent "
+            "gate — Pass C bar; Metrics-aware capstone contract)"
+        ),
+    ),
 )
 
 

--- a/backend/core/ouroboros/governance/graduation/graduation_contract.py
+++ b/backend/core/ouroboros/governance/graduation/graduation_contract.py
@@ -51,9 +51,10 @@ opt in via ``JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true``.
 """
 from __future__ import annotations
 
+import inspect
 import os
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, FrozenSet, Mapping, Optional
+from typing import Any, Callable, Dict, FrozenSet, Mapping, Optional, Tuple
 
 
 _TRUTHY = ("1", "true", "yes", "on")
@@ -65,8 +66,12 @@ MIN_RE_ARM_SECONDS: int = 60
 MAX_RE_ARM_SECONDS: int = 24 * 3600  # 24h ceiling
 
 
-# Predicate signature: takes a summary dict, returns True iff CLEAN.
-CleanPredicate = Callable[[Mapping[str, Any]], bool]
+# Predicate signature: ``(summary) -> bool`` OR ``(summary, metrics) -> bool``.
+# Both arities are supported; :meth:`GraduationContract.is_clean` dispatches by
+# inspecting the callable's positional arity. ``metrics`` is duck-typed (the
+# telemetry_parse.Metrics object) so this module stays import-light + stdlib-
+# only (no telemetry_parse import, no cycle).
+CleanPredicate = Callable[..., bool]
 
 
 def is_contract_consultation_enabled() -> bool:
@@ -77,6 +82,86 @@ def is_contract_consultation_enabled() -> bool:
     return os.environ.get(
         "JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT", "",
     ).strip().lower() in _TRUTHY
+
+
+def is_telemetry_arbiter_enabled() -> bool:
+    """Master flag — ``JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED``
+    (default ``false``). Gates the Sovereign Arbiter Protocol: when on
+    (AND contract consultation is on AND harvester Metrics are available),
+    the substrate routes outcome classification through
+    :meth:`GraduationContract.arbitrate` instead of the summary-only
+    contract refinement. Off ⇒ byte-identical legacy behavior."""
+    return os.environ.get(
+        "JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED", "",
+    ).strip().lower() in _TRUTHY
+
+
+def _predicate_is_metrics_aware(predicate: CleanPredicate) -> bool:
+    """True iff ``predicate`` can accept a second positional ``metrics``
+    argument. Defensive: callables without an introspectable signature
+    (builtins, some C-level callables) fall back to legacy 1-arg.
+    NEVER raises."""
+    try:
+        sig = inspect.signature(predicate)
+    except (TypeError, ValueError):
+        return False
+    positional = 0
+    for p in sig.parameters.values():
+        if p.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional += 1
+        elif p.kind is inspect.Parameter.VAR_POSITIONAL:
+            return True  # *args swallows metrics
+    return positional >= 2
+
+
+def _metrics_shows_full_recovery(metrics: Any) -> bool:
+    """Deterministic 'the system autonomously caught + healed' signal.
+
+    Requires the COMPLETE self-heal trajectory: a live-fire failure
+    fired, was routed back as a build fault, the op retried, and a
+    subsequent recovery state was observed — AND no OOM anomaly. Pure;
+    duck-typed; NEVER raises."""
+    if metrics is None:
+        return False
+    try:
+        fired = bool(getattr(metrics, "livefire_fired", None))
+        return (
+            fired
+            and bool(getattr(metrics, "routed_build", False))
+            and bool(getattr(metrics, "retried", False))
+            and bool(getattr(metrics, "recovered", False))
+            and not bool(getattr(metrics, "oom", False))
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        return False
+
+
+def _is_positive_int_value(v: Any) -> bool:
+    """True iff ``v`` coerces to an int > 0. Pure; NEVER raises."""
+    try:
+        return int(v) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _metrics_anomaly(metrics: Any) -> Optional[str]:
+    """Return a structured anomaly tag iff a hard hardware/wiring
+    invariant was violated (``oom`` / ``gate_inert``), else None. These
+    DISQUALIFY a CLEAN classification (P1, highest priority). Pure;
+    NEVER raises."""
+    if metrics is None:
+        return None
+    try:
+        if bool(getattr(metrics, "oom", False)):
+            return "oom"
+        if bool(getattr(metrics, "gate_inert", False)):
+            return "gate_inert"
+    except Exception:  # noqa: BLE001
+        return None
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -206,6 +291,45 @@ def predicate_requires_curiosity_hypothesis(
     return _session_ops_count(summary) >= 1
 
 
+def predicate_requires_live_kernel_validation(
+    summary: Mapping[str, Any],
+    metrics: Any = None,
+) -> bool:
+    """Capstone Dogfood predicate for ``JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED``.
+
+    The LiveKernelValidator's OWN graduation demands the highest evidence
+    bar — proof from the harvester telemetry that the validator actually
+    exercised its self-heal path on this session, not merely that the
+    session completed. Metrics-aware (2-arg) signature.
+
+    CLEAN iff ALL hold:
+      * default clean (``session_outcome=='complete'``, no runner faults)
+      * ``metrics.livefire_fired``  — a live-fire test executed (≥1 catch)
+      * NOT ``metrics.oom``         — zero OOM anomalies (16GB invariant)
+      * ``metrics.recovered``       — the candidate was successfully
+        processed (state=applied/complete observed)
+
+    When metrics are unavailable (arbiter off / no telemetry), falls back
+    to the default predicate so the contract degrades gracefully rather
+    than blocking graduation on missing instrumentation. Pure; NEVER
+    raises."""
+    if not default_clean_predicate(summary):
+        return False
+    if metrics is None:
+        # No telemetry stream — cannot prove self-heal; defer to default
+        # (deployment proven). The arbiter only routes here when Metrics
+        # exist, so production graduation still demands the full bar.
+        return True
+    try:
+        return (
+            bool(getattr(metrics, "livefire_fired", None))
+            and not bool(getattr(metrics, "oom", False))
+            and bool(getattr(metrics, "recovered", False))
+        )
+    except Exception:  # noqa: BLE001 — defensive
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Contract dataclass
 # ---------------------------------------------------------------------------
@@ -237,15 +361,113 @@ class GraduationContract:
                 self, "re_arm_after_runner_seconds", clamped,
             )
 
-    def is_clean(self, summary: Mapping[str, Any]) -> bool:
+    def is_clean(
+        self,
+        summary: Mapping[str, Any],
+        metrics: Any = None,
+    ) -> bool:
         """Run the contract's clean predicate. Falls back to
-        ``default_clean_predicate`` when none registered. NEVER
+        ``default_clean_predicate`` when none registered.
+
+        Dual-signature dispatch: a ``(summary, metrics)`` predicate
+        receives the harvester Metrics; a legacy ``(summary)`` predicate
+        is called with summary only (metrics ignored safely). NEVER
         raises."""
         predicate = self.clean_predicate or default_clean_predicate
         try:
+            if _predicate_is_metrics_aware(predicate):
+                return bool(predicate(summary, metrics))
             return bool(predicate(summary))
         except Exception:  # noqa: BLE001 — defensive
             return False
+
+    def arbitrate(
+        self,
+        *,
+        legacy_outcome: str,
+        runner_attributed: bool,
+        class_notes: str,
+        summary: Mapping[str, Any],
+        metrics: Any,
+    ) -> Tuple[str, bool, str]:
+        """Sovereign Arbiter — resolve the legacy classify_outcome stream
+        against the harvester Metrics stream via a deterministic priority
+        matrix. Returns the synthesized ``(outcome, runner_attributed,
+        notes)``. Pure; NEVER raises into the caller.
+
+        Priority (a later rule can only TIGHTEN, never resurrect CLEAN
+        once an anomaly pulled it down):
+
+          P2 recovery override : legacy error + full self-heal -> CLEAN
+          P1 anomaly guard     : oom / gate_inert  -> CLEAN forbidden (INFRA)
+          P3 metrics predicate : CLEAN but contract predicate False -> RUNNER
+          P4 blocklist override: RUNNER -> INFRA waiver
+
+        ``metrics is None`` degrades gracefully to the legacy summary-only
+        contract refinement (recovery/anomaly steps skip)."""
+        outcome = str(legacy_outcome)
+        ra = bool(runner_attributed)
+        extra: list[str] = []
+        try:
+            # --- P2: autonomous-recovery override --------------------
+            # A legacy infra/runner verdict that the system PROVABLY
+            # caught + healed is actually a success. Recovery > static
+            # error.
+            if (
+                outcome in ("infra", "runner")
+                and _metrics_shows_full_recovery(metrics)
+            ):
+                outcome = "clean"
+                ra = False
+                extra.append("arbiter_recovery_override")
+
+            # --- P1: anomaly guard (dominates CLEAN) -----------------
+            # A hardware/wiring invariant violation can NEVER be CLEAN,
+            # even post-recovery-override. Downgrades to INFRA waiver
+            # (environmental fault, not feature fault).
+            if outcome == "clean":
+                anomaly = _metrics_anomaly(metrics)
+                if anomaly is not None:
+                    outcome = "infra"
+                    ra = False
+                    extra.append(f"arbiter_anomaly_{anomaly}")
+
+            # --- P3: metrics-aware predicate downgrade ---------------
+            # The contract gets the LAST word on whether a CLEAN session
+            # actually exercised the feature (now Metrics-aware).
+            if outcome == "clean" and self.clean_predicate is not None:
+                if not self.is_clean(summary, metrics):
+                    outcome = "runner"
+                    ra = True
+                    extra.append("contract_metrics_predicate_downgraded")
+
+            # --- P4: legacy blocklist override (RUNNER -> INFRA) ------
+            if outcome == "runner" and self.failure_class_blocklist_overrides:
+                failure_counts = {}
+                if isinstance(summary, Mapping):
+                    failure_counts = summary.get("failure_class_counts") or {}
+                if isinstance(failure_counts, dict):
+                    positive = {
+                        k for k, v in failure_counts.items()
+                        if _is_positive_int_value(v)
+                    }
+                    if positive and positive.issubset(
+                        self.failure_class_blocklist_overrides,
+                    ):
+                        outcome = "infra"
+                        ra = False
+                        extra.append(
+                            "contract_blocklist_upgraded_runner_to_infra",
+                        )
+        except Exception:  # noqa: BLE001 — arbiter NEVER raises
+            return (str(legacy_outcome), bool(runner_attributed), class_notes)
+
+        notes = class_notes
+        if extra:
+            notes = (notes + "|" + ",".join(extra)) if notes else "|".join(
+                extra,
+            )
+        return (outcome, ra, notes)
 
     def to_metadata_dict(self) -> Dict[str, Any]:
         """Serializable view (predicate not included — predicates
@@ -316,6 +538,23 @@ _BUILT_IN_CONTRACTS: Dict[str, GraduationContract] = {
             "as CLEAN — defends against engine-not-fired sessions."
         ),
     ),
+    # Capstone Dogfood Contract (Sovereign Telemetry Unification,
+    # 2026-06-15). The LiveKernelValidator is the live-fire boot check
+    # whose self-heal trajectory the telemetry harvester measures — so
+    # its graduation is gated on harvester-PROVEN evidence that it fired,
+    # did not OOM, and recovered. Metrics-aware predicate (2-arg). This
+    # closes the loop: the validator graduates only when the telemetry
+    # that watches it proves it works.
+    "JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED": GraduationContract(
+        flag_name="JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED",
+        clean_predicate=predicate_requires_live_kernel_validation,
+        description=(
+            "LiveKernelValidator may only graduate when harvester "
+            "telemetry proves a live-fire test executed, ZERO OOM "
+            "anomalies occurred, and the candidate was successfully "
+            "processed (self-heal recovered)."
+        ),
+    ),
 }
 
 
@@ -368,7 +607,9 @@ __all__ = [
     "get_contract",
     "has_custom_contract",
     "is_contract_consultation_enabled",
+    "is_telemetry_arbiter_enabled",
     "known_contract_flags",
     "predicate_requires_curiosity_hypothesis",
     "predicate_requires_decision_trace_rows",
+    "predicate_requires_live_kernel_validation",
 ]

--- a/backend/core/ouroboros/governance/graduation/live_fire_soak.py
+++ b/backend/core/ouroboros/governance/graduation/live_fire_soak.py
@@ -126,6 +126,52 @@ def is_paused() -> bool:
     ).strip().lower() in _TRUTHY
 
 
+# Debug-log capture bound (Sovereign Telemetry Unification, 2026-06-15).
+# The self-heal trajectory the Arbiter parses can span the whole log, so the
+# captured slice must be larger than the legacy 8KB tail — but still bounded
+# for memory safety. Env-tunable, NO hardcoded magic in the read path.
+_MIN_DEBUG_LOG_CAPTURE_BYTES: int = 8192            # legacy tail floor
+_DEFAULT_DEBUG_LOG_CAPTURE_BYTES: int = 1_048_576   # 1 MiB
+_MAX_DEBUG_LOG_CAPTURE_BYTES: int = 16 * 1_048_576  # 16 MiB ceiling
+
+
+def _debug_log_capture_bytes() -> int:
+    """Resolve the debug.log capture window from
+    ``JARVIS_LIVE_FIRE_DEBUG_LOG_CAPTURE_BYTES``, clamped to
+    ``[8192, 16 MiB]``. Invalid/absent → 1 MiB default. NEVER raises."""
+    raw = os.environ.get("JARVIS_LIVE_FIRE_DEBUG_LOG_CAPTURE_BYTES", "")
+    try:
+        val = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return _DEFAULT_DEBUG_LOG_CAPTURE_BYTES
+    return max(
+        _MIN_DEBUG_LOG_CAPTURE_BYTES,
+        min(val, _MAX_DEBUG_LOG_CAPTURE_BYTES),
+    )
+
+
+def _telemetry_arbiter_active() -> bool:
+    """True iff the Sovereign Arbiter should run: BOTH contract
+    consultation AND the telemetry-arbiter master flag are on. The
+    arbiter is a contract-layer refinement, so it requires contract
+    consultation to be enabled too. Defensive: import failure → False
+    (legacy path). NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.graduation.graduation_contract import (  # noqa: E501
+            is_contract_consultation_enabled,
+            is_telemetry_arbiter_enabled,
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    try:
+        return bool(
+            is_contract_consultation_enabled()
+            and is_telemetry_arbiter_enabled()
+        )
+    except Exception:  # noqa: BLE001
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Dependency ordering: substrate flags graduate BEFORE surface flags
 # ---------------------------------------------------------------------------
@@ -274,6 +320,11 @@ class EvidenceRow:
     notes: str
     # Slice 6 — Optional[str]; serialized only when present.
     runner_attributed_kind: Optional[str] = None
+    # Sovereign Telemetry Unification (2026-06-15) — Unified Evidence Row.
+    # The harvester self-heal trajectory wrapping the legacy classification.
+    # Optional[Dict]; serialized only when the Arbiter ran (present iff
+    # JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED was on for this soak).
+    telemetry: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {
@@ -297,6 +348,8 @@ class EvidenceRow:
         }
         if self.runner_attributed_kind is not None:
             out["runner_attributed_kind"] = self.runner_attributed_kind
+        if self.telemetry is not None:
+            out["telemetry"] = dict(self.telemetry)
         return out
 
 
@@ -900,20 +953,32 @@ class LiveFireSoakHarness:
         outcome_str, runner_attributed, class_notes = classify_outcome(
             summary, debug_log_tail=debug_tail or "",
         )
-        # Phase 9.2 — consult per-flag GraduationContract (opt-in via
-        # JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT). Contract can:
-        #   * Override clean predicate (e.g. require ≥1 hypothesis
-        #     for CuriosityEngine flag).
-        #   * Override failure-class blocklist (treat specific runner-
-        #     class failures as INFRA waivers for this flag).
-        # When master-off, contract consultation is a no-op — behavior
-        # is byte-identical to pre-9.2.
-        outcome_str, runner_attributed, class_notes = (
-            self._maybe_apply_contract(
-                chosen, summary,
+        # Sovereign Telemetry Unification (2026-06-15) — when the Arbiter
+        # is enabled (AND contract consultation is on), route the legacy
+        # classification + harvester Metrics through the GraduationContract
+        # Arbiter (recovery override / anomaly guard / Metrics-aware
+        # predicate / blocklist). Otherwise fall back to the Phase 9.2
+        # summary-only contract refinement — byte-identical legacy path.
+        telemetry_payload: Optional[Dict[str, Any]] = None
+        if _telemetry_arbiter_active():
+            (
+                outcome_str, runner_attributed, class_notes,
+                telemetry_payload,
+            ) = self._apply_telemetry_arbiter(
+                chosen, summary, debug_tail or "",
                 outcome_str, runner_attributed, class_notes,
             )
-        )
+        else:
+            # Phase 9.2 — consult per-flag GraduationContract (opt-in via
+            # JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT). When master-off,
+            # contract consultation is a no-op — behavior is byte-identical
+            # to pre-9.2.
+            outcome_str, runner_attributed, class_notes = (
+                self._maybe_apply_contract(
+                    chosen, summary,
+                    outcome_str, runner_attributed, class_notes,
+                )
+            )
         # Build evidence row.
         session_id = str(summary.get("session_id") or "unknown")
         cost_total = _safe_float(summary.get("cost_total"))
@@ -960,6 +1025,7 @@ class LiveFireSoakHarness:
             finished_at_epoch=finished_at_epoch,
             notes=class_notes[:MAX_NOTES_CHARS],
             runner_attributed_kind=runner_kind_value,
+            telemetry=telemetry_payload,
         )
         # Persist rich-evidence row.
         self._append_history_row(evidence)
@@ -1177,6 +1243,78 @@ class LiveFireSoakHarness:
                 class_notes + "|" + ",".join(notes_extra)
             )[:MAX_NOTES_CHARS]
         return (outcome_str, runner_attributed, class_notes)
+
+    def _apply_telemetry_arbiter(
+        self,
+        flag_name: str,
+        summary: Mapping[str, Any],
+        debug_text: str,
+        outcome_str: str,
+        runner_attributed: bool,
+        class_notes: str,
+    ) -> Tuple[str, bool, str, Optional[Dict[str, Any]]]:
+        """Sovereign Arbiter Protocol — fuse the legacy classify_outcome
+        stream with the harvester Metrics stream via the per-flag
+        GraduationContract, and synthesize the Unified Evidence Row
+        telemetry payload.
+
+        Composes the SHARED parse (``telemetry_parse.parse_metrics`` —
+        the exact parser the operator harvester uses, zero duplication)
+        and ``GraduationContract.arbitrate`` (recovery override / anomaly
+        guard / Metrics-aware predicate / blocklist). NEVER raises into
+        the run path — on any failure, returns the legacy tuple with a
+        ``None`` telemetry payload (degrades to pre-arbiter behavior)."""
+        try:
+            from backend.core.ouroboros.governance.graduation.telemetry_parse import (  # noqa: E501
+                parse_metrics,
+            )
+            from backend.core.ouroboros.governance.graduation.graduation_contract import (  # noqa: E501
+                get_contract,
+            )
+        except Exception:  # noqa: BLE001 — substrate unavailable
+            return (outcome_str, runner_attributed, class_notes, None)
+        try:
+            metrics = parse_metrics(
+                debug_text or "",
+                summary if isinstance(summary, dict) else None,
+            )
+        except Exception:  # noqa: BLE001
+            return (outcome_str, runner_attributed, class_notes, None)
+        legacy_outcome = outcome_str
+        try:
+            contract = get_contract(flag_name)
+            new_outcome, new_ra, new_notes = contract.arbitrate(
+                legacy_outcome=outcome_str,
+                runner_attributed=runner_attributed,
+                class_notes=class_notes,
+                summary=summary,
+                metrics=metrics,
+            )
+        except Exception:  # noqa: BLE001
+            new_outcome, new_ra, new_notes = (
+                outcome_str, runner_attributed, class_notes,
+            )
+        # Unified Evidence Row payload: legacy classification wrapped in
+        # the harvester trajectory context.
+        try:
+            fired = list(getattr(metrics, "livefire_fired", []) or [])[:16]
+            telemetry: Optional[Dict[str, Any]] = {
+                "livefire_fired": fired,
+                "routed_build": bool(getattr(metrics, "routed_build", False)),
+                "retried": bool(getattr(metrics, "retried", False)),
+                "recovered": bool(getattr(metrics, "recovered", False)),
+                "oom": bool(getattr(metrics, "oom", False)),
+                "gate_inert": bool(getattr(metrics, "gate_inert", False)),
+                "livefire_timeout": bool(
+                    getattr(metrics, "livefire_timeout", False),
+                ),
+                "legacy_outcome": legacy_outcome,
+                "arbiter_outcome": new_outcome,
+                "arbiter_changed_outcome": new_outcome != legacy_outcome,
+            }
+        except Exception:  # noqa: BLE001
+            telemetry = None
+        return (new_outcome, new_ra, new_notes, telemetry)
 
     def _truncate_failure_counts(
         self, raw: Mapping[str, Any],
@@ -1440,7 +1578,14 @@ def _read_most_recent_session(
                 text = debug_path.read_text(
                     encoding="utf-8", errors="replace",
                 )
-                debug_tail = text[-8192:]
+                # Sovereign Telemetry Unification (2026-06-15): the
+                # self-heal trajectory ([LiveFire] fail → failure_class
+                # =build → GENERATE_RETRY → state=applied) can span the
+                # whole log, so capture an env-tunable bounded slice
+                # rather than a hardcoded 8KB tail. The legacy
+                # classify_outcome only needs the tail; the Arbiter's
+                # parse_metrics needs the trajectory.
+                debug_tail = text[-_debug_log_capture_bytes():]
             except OSError:
                 debug_tail = ""
         if isinstance(summary, dict):

--- a/backend/core/ouroboros/governance/graduation/telemetry_parse.py
+++ b/backend/core/ouroboros/governance/graduation/telemetry_parse.py
@@ -1,0 +1,117 @@
+"""Sovereign Telemetry Parse — the pure, importable parse layer.
+
+Extracted verbatim from ``scripts/telemetry_harvester.py`` (Slice 256) so
+that BOTH the operator-facing harvester CLI *and* the Live-Fire Graduation
+Soak substrate share ONE parse — zero duplication, zero drift.
+
+This module owns only the **pure parse**:
+
+  * :class:`Metrics` — the Metric A/B/C signal extracted from a session's
+    ``debug.log`` + ``summary.json``.
+  * :func:`parse_metrics` — pure function, NEVER raises, no side effects.
+
+The harvester keeps its own concerns (``certify`` verdict, ``render_report``,
+the async session watcher, the CLI) and re-imports :class:`Metrics` +
+:func:`parse_metrics` from here.
+
+## Authority posture (locked)
+
+  * **Pure + stdlib-only** — ``re`` + ``dataclasses`` + ``typing`` at top
+    level. No logger, no I/O, no subprocess, no network. The soak substrate
+    *consults*; this module never observes state.
+  * **NEVER raises** — :func:`parse_metrics` returns a default
+    :class:`Metrics` on any malformed input.
+  * Grounded regexes — every pattern is matched against real emitted
+    ``debug.log`` strings (verified against the deployed LiveKernelValidator
+    wiring).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+# ── grounded log patterns (verified against real debug.log + deployed wiring)
+_RE_PHASE = re.compile(r"phase=[A-Z_]+")
+_RE_LIVEFIRE_FAIL = re.compile(
+    r"\[LiveFire\] candidate FAILED live-fire boot:\s*(\S+)",
+)
+_RE_FAILCLASS_BUILD = re.compile(r"failure_class[=:][\"']?build\b")
+_RE_RETRY = re.compile(r"GENERATE_RETRY|VALIDATE_RETRY")
+_RE_RECOVERED = re.compile(r"state=applied|state=complete|phase=COMPLETE")
+_RE_GATE_INERT = re.compile(r"GATE INERT")
+_RE_TIMEOUT = re.compile(r"LiveFireTimeout|live-fire exceeded")
+_RE_OOM = re.compile(
+    r"process_memory_cap|MemoryError|\bOOM\b|emergency_brake|"
+    r"memory_pressure_changed.*(critical|emergency)",
+)
+
+# Session outcomes the harness writes when the FSM finalized a summary.
+_TERMINAL_OUTCOMES = {"complete", "incomplete_kill"}
+
+
+@dataclass
+class Metrics:
+    """Parsed Metric A/B/C signal for one session. Duck-typed by the
+    Graduation Arbiter (it reads ``.recovered`` / ``.oom`` / etc.)."""
+
+    # A — deployment integrity
+    booted: bool = False
+    boot_check_passed: int = 0           # from optional deployer stdout
+    boot_check_failed: bool = False
+    # B — live-fire trajectory
+    livefire_fired: List[str] = field(default_factory=list)  # exc types caught
+    routed_build: bool = False
+    retried: bool = False
+    recovered: bool = False
+    # C — hardware/state
+    gate_inert: bool = False
+    livefire_timeout: bool = False
+    oom: bool = False
+    # termination
+    session_outcome: str = ""
+    stop_reason: str = ""
+    cost_total: Optional[float] = None
+    duration_s: Optional[float] = None
+
+
+def parse_metrics(
+    log_text: str,
+    summary: Optional[Dict],
+    deployer_stdout: str = "",
+) -> Metrics:
+    """Pure parse — grounded in real emitted strings. No side effects.
+
+    NEVER raises: malformed/absent inputs yield a default-valued
+    :class:`Metrics`."""
+    m = Metrics()
+    log_text = log_text if isinstance(log_text, str) else ""
+    deployer_stdout = (
+        deployer_stdout if isinstance(deployer_stdout, str) else ""
+    )
+
+    m.booted = bool(_RE_PHASE.search(log_text))
+    m.boot_check_passed = deployer_stdout.count("BOOT CHECK PASSED")
+    m.boot_check_failed = "BOOT CHECK FAILED" in deployer_stdout
+
+    m.livefire_fired = _RE_LIVEFIRE_FAIL.findall(log_text)
+    m.routed_build = bool(_RE_FAILCLASS_BUILD.search(log_text))
+    m.retried = bool(_RE_RETRY.search(log_text))
+    m.recovered = bool(_RE_RECOVERED.search(log_text))
+
+    m.gate_inert = bool(_RE_GATE_INERT.search(log_text))
+    m.livefire_timeout = bool(_RE_TIMEOUT.search(log_text))
+    m.oom = bool(_RE_OOM.search(log_text))
+
+    if isinstance(summary, dict):
+        m.session_outcome = str(summary.get("session_outcome", ""))
+        m.stop_reason = str(summary.get("stop_reason", ""))
+        m.cost_total = summary.get("cost_total")
+        m.duration_s = summary.get("duration_s")
+    return m
+
+
+__all__ = [
+    "Metrics",
+    "parse_metrics",
+]

--- a/docs/superpowers/specs/2026-06-15-sovereign-telemetry-unification-design.md
+++ b/docs/superpowers/specs/2026-06-15-sovereign-telemetry-unification-design.md
@@ -1,0 +1,82 @@
+# Sovereign Telemetry Unification — Live-Fire Graduation Matrix
+
+**Date**: 2026-06-15
+**Author**: Derek J. Russell (design dialogue + agent execution)
+**Status**: IMPLEMENTED 2026-06-15 (uncommitted on `main` working tree) — 27 new tests + 297 affected-suite tests green
+**Goal**: `scripts/live_fire_graduation_soak.py` per PRD §P9.1 — reuse `telemetry_harvester.py` for the parse, with a `GraduationContract` per flag. Solve the root problem (duplicated parse + trajectory-blind contracts); no workarounds, no hardcoding.
+
+---
+
+## 1. Problem statement
+
+The Live-Fire Graduation Soak system already exists and is mature:
+
+- `scripts/live_fire_graduation_soak.py` — thin CLI dispatcher (PRD §P9.1).
+- `backend/.../graduation/live_fire_soak.py` (1564 LOC) — the substrate harness: forks `ouroboros_battle_test.py`, parses `summary.json` + an **8KB tail** of `debug.log`, classifies the session via `classify_outcome` (clean/runner/infra/migration), refines via per-flag `GraduationContract`, persists an `EvidenceRow`.
+- `backend/.../graduation/graduation_contract.py` — P9.2 per-flag `GraduationContract` (summary-only clean predicates).
+
+Two root defects, both surfaced by the goal directive:
+
+1. **Duplicated parse.** The user's brand-new `scripts/telemetry_harvester.py` (Slice 256) extracts a far richer signal — the *self-heal trajectory* (`livefire_fired` → `routed_build` → `retried` → `recovered`), Metric A/B/C, and hardware anomalies (`oom`, `gate_inert`, `livefire_timeout`) — from the **full** `debug.log`. The soak substrate has its own thin `classify_outcome` parse and **never reuses the harvester**. Two parse paths = drift risk.
+2. **Trajectory-blind contracts.** `GraduationContract.clean_predicate` only ever receives `summary.json`. Per-flag contracts therefore *cannot* express criteria like "this flag is CLEAN only if the system autonomously recovered AND did not OOM" — exactly the dynamic/adaptive criteria the goal demands.
+
+## 2. Architecture — three units
+
+### Unit A — `telemetry_parse.py` (pure extraction, zero duplication)
+
+New module `backend/core/ouroboros/governance/graduation/telemetry_parse.py`. Stdlib-only, pure, never-raises. Houses the **pure parse** lifted verbatim from the harvester:
+
+- `Metrics` dataclass (Metric A/B/C fields).
+- `parse_metrics(log_text, summary, deployer_stdout="") -> Metrics`.
+- The grounded regexes (`_RE_LIVEFIRE_FAIL`, `_RE_FAILCLASS_BUILD`, `_RE_RETRY`, `_RE_RECOVERED`, `_RE_OOM`, …).
+
+`scripts/telemetry_harvester.py` is refactored to **import** `Metrics` + `parse_metrics` from this module and keep its own concerns (`certify`, `render_report`, async watcher, CLI) — **byte-identical CLI behavior**. The harvester remains "the user's file"; only the pure parse relocates to a properly importable backend home. The verdict layer (`certify`) stays in the script because graduation classification is a *different concern* from deployment self-heal certification.
+
+### Unit B — Arbiter + dual-signature predicates (`graduation_contract.py`)
+
+The `GraduationContract` becomes the **Sovereign Arbiter** over two independent assessment streams:
+
+- **Legacy stream**: `classify_outcome(summary, tail)` — authoritative for the base tree, migration heuristics, shutdown-noise handling (unchanged; no regression).
+- **Telemetry stream**: `parse_metrics(full_log, summary)` → `Metrics`.
+
+**Dual-signature predicate.** `clean_predicate` may be a legacy `(summary) -> bool` OR a new `(summary, metrics) -> bool`. Dispatch by `inspect.signature` positional-arity (≥2 positional params → metrics-aware), falling through safely. `metrics` is duck-typed (`Any`) inside `graduation_contract.py` to keep the module's stdlib-only/AST-pinned posture and avoid an import cycle. Old summary-only predicates keep working unchanged.
+
+**Arbiter priority matrix** (deterministic, pure function `arbitrate_outcome(...)`):
+
+| Priority | Rule | Effect |
+|----------|------|--------|
+| 1 (highest) | **Anomaly guard**: `metrics.oom` or `metrics.gate_inert` | force NOT-clean (clean→`infra` waiver) — hardware/wiring invariant violated |
+| 2 | **Autonomous-recovery override**: legacy ∈ {`infra`,`runner`} AND `livefire_fired` AND `routed_build` AND `retried` AND `recovered` AND NOT `oom` | override → `clean` (the system *caught + healed*; "Intelligent Autonomous Recovery > Legacy Static Errors") |
+| 3 | **Metrics-aware predicate downgrade**: outcome is `clean` AND contract predicate (summary, metrics) returns False | `clean` → `runner` |
+| 4 (lowest) | **Legacy blocklist override** (existing): RUNNER → INFRA waiver | unchanged |
+
+Each transition appends a structured note (`arbiter_anomaly_oom`, `arbiter_recovery_override`, `contract_metrics_predicate_downgraded`, …) for §7 absolute observability.
+
+### Unit C — substrate wiring + Unified Evidence Row (`live_fire_soak.py`)
+
+- **Full-log capture**: replace the hardcoded `text[-8192:]` with an env-tunable bounded read `JARVIS_LIVE_FIRE_DEBUG_LOG_CAPTURE_BYTES` (default generous, e.g. 1 MiB; bounded for memory safety, no hardcoding). Trajectory markers are sparse; this captures them without unbounded reads. The injectable-runner signature `(exit_code, summary, debug_text)` is **unchanged** — the third element is simply a larger bounded chunk.
+- **Gated telemetry ingestion**: new master flag `JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED` (default **false** → byte-identical rollback). When on, `run_soak` calls `parse_metrics(debug_text, summary)` and threads `Metrics` into `_maybe_apply_contract` → `arbitrate_outcome`.
+- **Unified Evidence Row**: add one additive optional field `telemetry: Optional[Dict]` on `EvidenceRow`, serialized only when present (mirrors the `runner_attributed_kind` pattern). It wraps the legacy classification inside the harvester trajectory context: `{livefire_fired, routed_build, retried, recovered, oom, gate_inert, arbiter_override, arbiter_reason}`.
+
+### Capstone Dogfood Contract
+
+A new built-in `GraduationContract` for **`JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED`** (a real flag — gates the `LiveKernelValidator` live-fire boot check). Predicate `predicate_requires_live_kernel_validation(summary, metrics)` demands a higher evidence bar: CLEAN per default **AND** `metrics.livefire_fired` (live-fire test executed) **AND NOT** `metrics.oom` (zero OOM) **AND** `metrics.recovered` (candidate successfully processed). This closes the loop: the validator's own graduation requires harvester-proven evidence that the validator fired and healed.
+
+## 3. Gating & rollback discipline
+
+- `JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED` (default false) — gates *all* new behavior in Unit C. Off ⇒ no `parse_metrics` call, no arbiter, no telemetry field ⇒ byte-identical to today.
+- `JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT` (existing, default false) — still gates contract consultation; arbiter only runs when *both* are on (arbiter is a contract-layer refinement).
+- New master flags registered in the FlagRegistry seed (no unregistered flags).
+
+## 4. Testing (TDD)
+
+- `tests/governance/test_telemetry_parse_extraction.py` — Unit A: extracted `parse_metrics` is behavior-identical to the harvester's original on fixture logs; harvester still imports + parses identically; round-trips the trajectory + anomaly fields.
+- `tests/governance/test_graduation_arbiter.py` — Unit B: each priority-matrix row (anomaly guard, recovery override, metrics-predicate downgrade, blocklist), dual-signature dispatch (1-arg vs 2-arg predicate), never-raises on malformed metrics, determinism.
+- `tests/governance/test_live_fire_telemetry_wiring.py` — Unit C: master-off byte-identical (no telemetry field, no parse call); master-on threads metrics → arbiter → EvidenceRow; full-log capture env knob bounds/defaults; capstone contract on `JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED`.
+- Existing `graduation_contract` + `live_fire_soak` suites stay green (master-off byte-identical guarantee).
+
+## 5. Non-goals (YAGNI)
+
+- No rewrite of `classify_outcome`'s base tree (augment, not replace).
+- No change to the CLI subcommand surface of `live_fire_graduation_soak.py` (the script already satisfies §P9.1; this work deepens the substrate it dispatches to).
+- No new producer wiring for Phase 8 ledgers (that's P9.5).

--- a/scripts/telemetry_harvester.py
+++ b/scripts/telemetry_harvester.py
@@ -23,25 +23,31 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import re
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 
-SESSIONS_DIR = Path(".ouroboros/sessions")
+# Sovereign Telemetry Unification (2026-06-15): the pure parse now lives in
+# an importable backend module so the Live-Fire Graduation Soak substrate can
+# reuse THE SAME parse — zero duplication, zero drift. This script keeps its
+# own concerns (certify verdict, render, async watcher, CLI) and re-imports
+# the pure parse. CLI behavior is byte-identical.
+#
+# Path bootstrap: cron/operator invokes this script directly, so ensure the
+# repo root is importable before the backend import.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-# ── grounded log patterns (verified against real debug.log + the deployed wiring) ────────
-_RE_PHASE = re.compile(r"phase=[A-Z_]+")
-_RE_LIVEFIRE_FAIL = re.compile(r"\[LiveFire\] candidate FAILED live-fire boot:\s*(\S+)")
-_RE_FAILCLASS_BUILD = re.compile(r"failure_class[=:][\"']?build\b")
-_RE_RETRY = re.compile(r"GENERATE_RETRY|VALIDATE_RETRY")
-_RE_RECOVERED = re.compile(r"state=applied|state=complete|phase=COMPLETE")
-_RE_GATE_INERT = re.compile(r"GATE INERT")
-_RE_TIMEOUT = re.compile(r"LiveFireTimeout|live-fire exceeded")
-_RE_OOM = re.compile(r"process_memory_cap|MemoryError|\bOOM\b|emergency_brake|memory_pressure_changed.*(critical|emergency)")
-_TERMINAL_OUTCOMES = {"complete", "incomplete_kill"}
+from backend.core.ouroboros.governance.graduation.telemetry_parse import (  # noqa: E402
+    Metrics,
+    _TERMINAL_OUTCOMES,
+    parse_metrics,
+)
+
+SESSIONS_DIR = Path(".ouroboros/sessions")
 
 # verdicts
 FIELD_CERTIFIED = "FIELD_CERTIFIED"
@@ -51,56 +57,10 @@ INCOMPLETE = "INCOMPLETE"
 
 
 @dataclass
-class Metrics:
-    # A — deployment integrity
-    booted: bool = False
-    boot_check_passed: int = 0           # from optional deployer stdout
-    boot_check_failed: bool = False
-    # B — live-fire trajectory
-    livefire_fired: List[str] = field(default_factory=list)   # exception types caught
-    routed_build: bool = False
-    retried: bool = False
-    recovered: bool = False
-    # C — hardware/state
-    gate_inert: bool = False
-    livefire_timeout: bool = False
-    oom: bool = False
-    # termination
-    session_outcome: str = ""
-    stop_reason: str = ""
-    cost_total: Optional[float] = None
-    duration_s: Optional[float] = None
-
-
-@dataclass
 class CertResult:
     verdict: str
     headline: str
     reasons: List[str]
-
-
-def parse_metrics(log_text: str, summary: Optional[Dict], deployer_stdout: str = "") -> Metrics:
-    """Pure parse — grounded in real emitted strings. No side effects."""
-    m = Metrics()
-    m.booted = bool(_RE_PHASE.search(log_text))
-    m.boot_check_passed = deployer_stdout.count("BOOT CHECK PASSED")
-    m.boot_check_failed = "BOOT CHECK FAILED" in deployer_stdout
-
-    m.livefire_fired = _RE_LIVEFIRE_FAIL.findall(log_text)
-    m.routed_build = bool(_RE_FAILCLASS_BUILD.search(log_text))
-    m.retried = bool(_RE_RETRY.search(log_text))
-    m.recovered = bool(_RE_RECOVERED.search(log_text))
-
-    m.gate_inert = bool(_RE_GATE_INERT.search(log_text))
-    m.livefire_timeout = bool(_RE_TIMEOUT.search(log_text))
-    m.oom = bool(_RE_OOM.search(log_text))
-
-    if summary:
-        m.session_outcome = str(summary.get("session_outcome", ""))
-        m.stop_reason = str(summary.get("stop_reason", ""))
-        m.cost_total = summary.get("cost_total")
-        m.duration_s = summary.get("duration_s")
-    return m
 
 
 def certify(m: Metrics) -> CertResult:

--- a/tests/governance/test_graduation_arbiter.py
+++ b/tests/governance/test_graduation_arbiter.py
@@ -1,0 +1,264 @@
+"""Unit B — Sovereign Arbiter Protocol + dual-signature predicates.
+
+The GraduationContract becomes the definitive Arbiter over two independent
+assessment streams (legacy classify_outcome + harvester Metrics), resolving
+conflicts with a deterministic priority matrix:
+
+  P1 (highest) anomaly guard      : oom / gate_inert  -> never CLEAN
+  P2           recovery override  : legacy error + full self-heal -> CLEAN
+  P3           metrics predicate  : CLEAN but contract says not really -> RUNNER
+  P4 (lowest)  blocklist override : RUNNER -> INFRA waiver
+
+Plus dual-signature clean_predicate dispatch: (summary) OR (summary, metrics).
+
+TDD red: these are written before arbitrate()/Metrics-aware is_clean() exist.
+"""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.graduation.graduation_contract import (
+    GraduationContract,
+)
+from backend.core.ouroboros.governance.graduation.telemetry_parse import (
+    Metrics,
+)
+
+_CLEAN_SUMMARY = {
+    "session_outcome": "complete",
+    "stop_reason": "wall_clock_cap",
+    "failure_class_counts": {},
+}
+
+
+def _full_recovery_metrics() -> Metrics:
+    return Metrics(
+        booted=True,
+        livefire_fired=["ImportError"],
+        routed_build=True,
+        retried=True,
+        recovered=True,
+        oom=False,
+        session_outcome="complete",
+    )
+
+
+# --- P2: autonomous recovery override --------------------------------------
+def test_recovery_override_promotes_legacy_infra_to_clean():
+    contract = GraduationContract(flag_name="X")
+    outcome, ra, notes = contract.arbitrate(
+        legacy_outcome="infra",
+        runner_attributed=False,
+        class_notes="api_timeout",
+        summary=_CLEAN_SUMMARY,
+        metrics=_full_recovery_metrics(),
+    )
+    assert outcome == "clean"
+    assert ra is False
+    assert "arbiter_recovery_override" in notes
+
+
+def test_recovery_override_requires_full_trajectory():
+    # Missing routed_build -> NOT a proven recovery -> legacy stands.
+    m = _full_recovery_metrics()
+    m.routed_build = False
+    contract = GraduationContract(flag_name="X")
+    outcome, ra, notes = contract.arbitrate(
+        legacy_outcome="runner",
+        runner_attributed=True,
+        class_notes="",
+        summary=_CLEAN_SUMMARY,
+        metrics=m,
+    )
+    assert outcome == "runner"
+    assert "arbiter_recovery_override" not in notes
+
+
+# --- P1: anomaly guard (dominates) -----------------------------------------
+def test_anomaly_guard_oom_blocks_clean():
+    m = Metrics(recovered=True, oom=True, session_outcome="complete")
+    contract = GraduationContract(flag_name="X")
+    outcome, ra, notes = contract.arbitrate(
+        legacy_outcome="clean",
+        runner_attributed=False,
+        class_notes="",
+        summary=_CLEAN_SUMMARY,
+        metrics=m,
+    )
+    assert outcome == "infra"  # waiver — hardware fault, not feature fault
+    assert ra is False
+    assert "arbiter_anomaly_oom" in notes
+
+
+def test_anomaly_guard_dominates_recovery_override():
+    # Full recovery trajectory BUT gate_inert (stale wiring) -> anomaly wins.
+    m = _full_recovery_metrics()
+    m.gate_inert = True
+    contract = GraduationContract(flag_name="X")
+    outcome, ra, notes = contract.arbitrate(
+        legacy_outcome="infra",
+        runner_attributed=False,
+        class_notes="",
+        summary=_CLEAN_SUMMARY,
+        metrics=m,
+    )
+    assert outcome == "infra"
+    assert "arbiter_anomaly_gate_inert" in notes
+
+
+# --- P3: metrics-aware predicate downgrade ---------------------------------
+def test_metrics_aware_predicate_downgrades_clean():
+    def needs_recovery(summary, metrics) -> bool:  # 2-arg predicate
+        return bool(getattr(metrics, "recovered", False))
+
+    contract = GraduationContract(
+        flag_name="X", clean_predicate=needs_recovery,
+    )
+    m = Metrics(recovered=False, session_outcome="complete")
+    outcome, ra, notes = contract.arbitrate(
+        legacy_outcome="clean",
+        runner_attributed=False,
+        class_notes="",
+        summary=_CLEAN_SUMMARY,
+        metrics=m,
+    )
+    assert outcome == "runner"
+    assert ra is True
+    assert "contract_metrics_predicate_downgraded" in notes
+
+
+# --- P4: legacy blocklist override preserved -------------------------------
+def test_legacy_blocklist_override_preserved():
+    contract = GraduationContract(
+        flag_name="X",
+        failure_class_blocklist_overrides=frozenset({"dw_provider_timeout"}),
+    )
+    summary = {
+        "session_outcome": "incomplete_kill",
+        "failure_class_counts": {"dw_provider_timeout": 2},
+    }
+    m = Metrics(session_outcome="incomplete_kill")
+    outcome, ra, notes = contract.arbitrate(
+        legacy_outcome="runner",
+        runner_attributed=True,
+        class_notes="",
+        summary=summary,
+        metrics=m,
+    )
+    assert outcome == "infra"
+    assert ra is False
+    assert "contract_blocklist_upgraded_runner_to_infra" in notes
+
+
+# --- dual-signature predicate dispatch -------------------------------------
+def test_is_clean_dispatches_one_arg_predicate():
+    seen = {}
+
+    def legacy_pred(summary) -> bool:  # 1-arg
+        seen["n"] = 1
+        return summary.get("session_outcome") == "complete"
+
+    contract = GraduationContract(flag_name="X", clean_predicate=legacy_pred)
+    assert contract.is_clean(_CLEAN_SUMMARY, _full_recovery_metrics()) is True
+    assert seen["n"] == 1  # called with one arg, metrics ignored safely
+
+
+def test_is_clean_dispatches_two_arg_predicate_with_metrics():
+    captured = {}
+
+    def metrics_pred(summary, metrics) -> bool:  # 2-arg
+        captured["metrics"] = metrics
+        return bool(getattr(metrics, "oom", False)) is False
+
+    contract = GraduationContract(flag_name="X", clean_predicate=metrics_pred)
+    m = _full_recovery_metrics()
+    assert contract.is_clean(_CLEAN_SUMMARY, m) is True
+    assert captured["metrics"] is m
+
+
+def test_is_clean_two_arg_predicate_with_no_metrics_passes_none():
+    def metrics_pred(summary, metrics) -> bool:
+        return metrics is None  # called without metrics -> None
+
+    contract = GraduationContract(flag_name="X", clean_predicate=metrics_pred)
+    assert contract.is_clean(_CLEAN_SUMMARY) is True
+
+
+# --- robustness ------------------------------------------------------------
+def test_arbitrate_never_raises_on_none_metrics():
+    contract = GraduationContract(flag_name="X")
+    outcome, ra, notes = contract.arbitrate(
+        legacy_outcome="clean",
+        runner_attributed=False,
+        class_notes="",
+        summary=_CLEAN_SUMMARY,
+        metrics=None,
+    )
+    assert outcome == "clean"  # no metrics -> legacy stands
+
+
+def test_arbitrate_clean_stays_clean_when_all_good():
+    contract = GraduationContract(flag_name="X")
+    outcome, ra, notes = contract.arbitrate(
+        legacy_outcome="clean",
+        runner_attributed=False,
+        class_notes="ok",
+        summary=_CLEAN_SUMMARY,
+        metrics=_full_recovery_metrics(),
+    )
+    assert outcome == "clean"
+    assert ra is False
+
+
+# --- Capstone Dogfood Contract: JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED --------
+def test_capstone_contract_registered_for_live_kernel_validator():
+    from backend.core.ouroboros.governance.graduation.graduation_contract import (  # noqa: E501
+        get_contract,
+        has_custom_contract,
+    )
+    flag = "JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED"
+    assert has_custom_contract(flag)
+    contract = get_contract(flag)
+    assert contract.flag_name == flag
+    assert contract.clean_predicate is not None
+
+
+def test_capstone_clean_requires_livefire_fired_no_oom_and_recovered():
+    from backend.core.ouroboros.governance.graduation.graduation_contract import (  # noqa: E501
+        get_contract,
+    )
+    contract = get_contract("JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED")
+
+    # Full evidence: validator fired, no OOM, candidate recovered -> CLEAN.
+    good = _full_recovery_metrics()
+    assert contract.is_clean(_CLEAN_SUMMARY, good) is True
+
+    # Validator never fired -> NOT clean (deployment proven, not self-heal).
+    never_fired = Metrics(recovered=True, session_outcome="complete")
+    assert contract.is_clean(_CLEAN_SUMMARY, never_fired) is False
+
+    # OOM anomaly -> NOT clean.
+    oomed = _full_recovery_metrics()
+    oomed.oom = True
+    assert contract.is_clean(_CLEAN_SUMMARY, oomed) is False
+
+    # Fired but never recovered -> NOT clean.
+    no_recover = _full_recovery_metrics()
+    no_recover.recovered = False
+    assert contract.is_clean(_CLEAN_SUMMARY, no_recover) is False
+
+
+def test_capstone_arbitrate_downgrades_clean_without_evidence():
+    from backend.core.ouroboros.governance.graduation.graduation_contract import (  # noqa: E501
+        get_contract,
+    )
+    contract = get_contract("JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED")
+    # Legacy said clean, but the validator never fired -> arbiter downgrades.
+    m = Metrics(recovered=True, session_outcome="complete")  # no livefire
+    outcome, ra, notes = contract.arbitrate(
+        legacy_outcome="clean",
+        runner_attributed=False,
+        class_notes="",
+        summary=_CLEAN_SUMMARY,
+        metrics=m,
+    )
+    assert outcome == "runner"
+    assert "contract_metrics_predicate_downgraded" in notes

--- a/tests/governance/test_live_fire_telemetry_wiring.py
+++ b/tests/governance/test_live_fire_telemetry_wiring.py
@@ -1,0 +1,246 @@
+"""Unit C — substrate wiring: Sovereign Arbiter + Unified Evidence Row.
+
+Proves the live_fire_soak substrate:
+  * captures a bounded-but-large debug.log slice (env-tunable, no hardcoded
+    8192) so the self-heal trajectory is parse-able;
+  * gates ALL new behavior behind JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED
+    (default off ⇒ byte-identical: no telemetry field, no parse call);
+  * when on, threads harvester Metrics through GraduationContract.arbitrate
+    and synthesizes a Unified Evidence Row (legacy classification wrapped in
+    harvester trajectory context).
+
+TDD red: written before the wiring + _debug_log_capture_bytes exist.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance.adaptation import (
+    graduation_ledger as _ledger_mod,
+)
+from backend.core.ouroboros.governance.graduation.live_fire_soak import (
+    HarnessStatus,
+    LiveFireSoakHarness,
+    get_default_harness,
+    reset_default_harness,
+)
+
+_FULL_RECOVERY_LOG = (
+    "phase=GENERATE op=1\n"
+    "[LiveFire] candidate FAILED live-fire boot: ImportError\n"
+    "routed back failure_class=build op=1\n"
+    "GENERATE_RETRY op=1\n"
+    "op=1 state=applied phase=COMPLETE\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    for k in list(os.environ.keys()):
+        if (
+            k.startswith("JARVIS_LIVE_FIRE_")
+            or k.startswith("JARVIS_GRADUATION_LEDGER_")
+        ):
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv(
+        "JARVIS_GRADUATION_LEDGER_PATH",
+        str(tmp_path / "ledger.jsonl"),
+    )
+    monkeypatch.setenv("JARVIS_GRADUATION_LEDGER_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_LIVE_FIRE_GRADUATION_HISTORY_PATH",
+        str(tmp_path / "history.jsonl"),
+    )
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED", "true")
+    _ledger_mod.reset_default_ledger()
+    reset_default_harness()
+    yield
+    _ledger_mod.reset_default_ledger()
+    reset_default_harness()
+
+
+def _runner(summary: Dict[str, Any], debug_text: str = ""):
+    def runner(
+        *, env, cost_cap_usd, max_wall_seconds, timeout_s, project_root,
+    ) -> Tuple[int, Dict[str, Any], str]:
+        return (0, summary, debug_text)
+    return runner
+
+
+def _harness() -> LiveFireSoakHarness:
+    return get_default_harness()
+
+
+# --- master-off byte-identical ---------------------------------------------
+def test_master_off_no_telemetry_field(monkeypatch):
+    # Arbiter flag unset (default off). Even with a recovery trajectory in
+    # the log, no telemetry is parsed/attached.
+    result = _harness().run_soak(
+        flag_name="JARVIS_HYPOTHESIS_PROBE_ENABLED",
+        subprocess_runner=_runner(
+            {
+                "session_id": "bt-off-1",
+                "session_outcome": "complete",
+                "stop_reason": "ok",
+                "failure_class_counts": {},
+            },
+            _FULL_RECOVERY_LOG,
+        ),
+    )
+    assert result.status == HarnessStatus.OK
+    assert result.evidence is not None
+    assert getattr(result.evidence, "telemetry", "MISSING") in (None, "MISSING")
+    assert "telemetry" not in result.evidence.to_dict()
+
+
+def test_contract_on_arbiter_off_is_legacy_path(monkeypatch):
+    # Contract consultation on, arbiter OFF -> legacy summary-only path,
+    # still no telemetry field.
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT", "true")
+    result = _harness().run_soak(
+        flag_name="JARVIS_HYPOTHESIS_PROBE_ENABLED",
+        subprocess_runner=_runner(
+            {
+                "session_id": "bt-off-2",
+                "session_outcome": "complete",
+                "stop_reason": "ok",
+                "failure_class_counts": {},
+            },
+            _FULL_RECOVERY_LOG,
+        ),
+    )
+    assert result.evidence is not None
+    assert "telemetry" not in result.evidence.to_dict()
+
+
+# --- master-on: arbiter recovery override ----------------------------------
+def _enable_arbiter(monkeypatch):
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT", "true")
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED", "true")
+
+
+def test_arbiter_recovery_override_promotes_infra_to_clean(monkeypatch):
+    _enable_arbiter(monkeypatch)
+    # Legacy classifies incomplete_kill as INFRA; metrics prove the system
+    # caught + healed -> arbiter overrides to CLEAN.
+    result = _harness().run_soak(
+        flag_name="JARVIS_HYPOTHESIS_PROBE_ENABLED",
+        subprocess_runner=_runner(
+            {
+                "session_id": "bt-heal-1",
+                "session_outcome": "incomplete_kill",
+                "stop_reason": "sigterm",
+                "failure_class_counts": {},
+            },
+            _FULL_RECOVERY_LOG,
+        ),
+    )
+    assert result.status == HarnessStatus.OK
+    assert result.evidence is not None
+    assert result.evidence.outcome == "clean"
+    tel = result.evidence.to_dict().get("telemetry")
+    assert tel is not None
+    assert tel["recovered"] is True
+    assert tel["livefire_fired"] == ["ImportError"]
+    assert tel["legacy_outcome"] == "infra"
+    assert tel["arbiter_changed_outcome"] is True
+    # Ledger recorded a clean session.
+    progress = _ledger_mod.get_default_ledger().progress(
+        "JARVIS_HYPOTHESIS_PROBE_ENABLED",
+    )
+    assert progress["clean"] == 1
+
+
+def test_arbiter_anomaly_oom_blocks_clean(monkeypatch):
+    _enable_arbiter(monkeypatch)
+    log = _FULL_RECOVERY_LOG + "process_memory_cap exceeded MemoryError\n"
+    result = _harness().run_soak(
+        flag_name="JARVIS_HYPOTHESIS_PROBE_ENABLED",
+        subprocess_runner=_runner(
+            {
+                "session_id": "bt-oom-1",
+                "session_outcome": "complete",
+                "stop_reason": "ok",
+                "failure_class_counts": {},
+            },
+            log,
+        ),
+    )
+    assert result.evidence is not None
+    assert result.evidence.outcome == "infra"  # OOM waiver, never clean
+    tel = result.evidence.to_dict().get("telemetry")
+    assert tel is not None and tel["oom"] is True
+
+
+def test_arbiter_clean_run_persists_full_trajectory(monkeypatch):
+    _enable_arbiter(monkeypatch)
+    result = _harness().run_soak(
+        flag_name="JARVIS_HYPOTHESIS_PROBE_ENABLED",
+        subprocess_runner=_runner(
+            {
+                "session_id": "bt-clean-tel",
+                "session_outcome": "complete",
+                "stop_reason": "ok",
+                "failure_class_counts": {},
+            },
+            _FULL_RECOVERY_LOG,
+        ),
+    )
+    assert result.evidence is not None
+    assert result.evidence.outcome == "clean"
+    tel = result.evidence.to_dict()["telemetry"]
+    assert tel["routed_build"] is True
+    assert tel["retried"] is True
+    assert tel["recovered"] is True
+    assert tel["oom"] is False
+
+
+# --- capstone wiring -------------------------------------------------------
+def test_capstone_downgrades_clean_without_livefire_evidence(monkeypatch):
+    _enable_arbiter(monkeypatch)
+    # Capstone flag, legacy clean, but NO live-fire in the log -> the
+    # Metrics-aware capstone predicate downgrades CLEAN -> RUNNER.
+    result = _harness().run_soak(
+        flag_name="JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED",
+        subprocess_runner=_runner(
+            {
+                "session_id": "bt-cap-1",
+                "session_outcome": "complete",
+                "stop_reason": "ok",
+                "failure_class_counts": {},
+                "strategic_drift": {"total_ops": 4},
+            },
+            "phase=GENERATE op=1\nop=1 state=applied\n",  # no [LiveFire]
+        ),
+    )
+    assert result.evidence is not None
+    assert result.evidence.outcome == "runner"
+    assert "contract_metrics_predicate_downgraded" in result.evidence.notes
+
+
+# --- env-tunable capture bytes ---------------------------------------------
+def test_debug_log_capture_bytes_default_and_override_and_bounds(monkeypatch):
+    from backend.core.ouroboros.governance.graduation.live_fire_soak import (
+        _debug_log_capture_bytes,
+    )
+    monkeypatch.delenv(
+        "JARVIS_LIVE_FIRE_DEBUG_LOG_CAPTURE_BYTES", raising=False,
+    )
+    default = _debug_log_capture_bytes()
+    assert default >= 8192  # at least the legacy tail
+    assert default >= 256 * 1024  # generous enough for the trajectory
+
+    monkeypatch.setenv(
+        "JARVIS_LIVE_FIRE_DEBUG_LOG_CAPTURE_BYTES", "500000",
+    )
+    assert _debug_log_capture_bytes() == 500000
+
+    # Garbage -> default; absurd low -> clamped to >= 8192.
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_DEBUG_LOG_CAPTURE_BYTES", "nope")
+    assert _debug_log_capture_bytes() == default
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_DEBUG_LOG_CAPTURE_BYTES", "10")
+    assert _debug_log_capture_bytes() >= 8192

--- a/tests/governance/test_telemetry_parse_extraction.py
+++ b/tests/governance/test_telemetry_parse_extraction.py
@@ -1,0 +1,121 @@
+"""Unit A — Sovereign Telemetry Unification: pure parse extraction.
+
+Proves the harvester's pure parse (``Metrics`` + ``parse_metrics``) was
+lifted verbatim into an importable backend module with ZERO duplication:
+
+  * ``backend.core.ouroboros.governance.graduation.telemetry_parse`` owns
+    the pure parse (stdlib-only, never-raises).
+  * ``scripts/telemetry_harvester.py`` re-imports from there → identity,
+    not a copy (no drift).
+
+These tests are written BEFORE the module exists (TDD red).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_harvester_module():
+    """Load scripts/telemetry_harvester.py as a proper sys.modules entry
+    (required so its dataclass forward-refs resolve)."""
+    path = _REPO_ROOT / "scripts" / "telemetry_harvester.py"
+    spec = importlib.util.spec_from_file_location(
+        "telemetry_harvester_under_test", path,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- full self-heal trajectory log fixture ---------------------------------
+_HEAL_LOG = """
+2026-06-15T00:00:01 phase=CLASSIFY op=1
+2026-06-15T00:00:02 phase=GENERATE op=1
+[LiveFire] candidate FAILED live-fire boot: ImportError
+2026-06-15T00:00:03 routed back failure_class=build op=1
+2026-06-15T00:00:04 GENERATE_RETRY op=1 attempt=2
+2026-06-15T00:00:09 op=1 state=applied phase=COMPLETE
+"""
+
+_CLEAN_SUMMARY = {
+    "session_outcome": "complete",
+    "stop_reason": "wall_clock_cap",
+    "cost_total": 0.1234,
+    "duration_s": 321.0,
+    "session_id": "bt-2026-06-15-000000",
+}
+
+
+def test_telemetry_parse_module_exists_and_exports():
+    from backend.core.ouroboros.governance.graduation import (
+        telemetry_parse,
+    )
+    assert hasattr(telemetry_parse, "Metrics")
+    assert hasattr(telemetry_parse, "parse_metrics")
+
+
+def test_parse_metrics_extracts_full_self_heal_trajectory():
+    from backend.core.ouroboros.governance.graduation.telemetry_parse import (
+        parse_metrics,
+    )
+    m = parse_metrics(_HEAL_LOG, _CLEAN_SUMMARY)
+    assert m.booted is True
+    assert m.livefire_fired == ["ImportError"]
+    assert m.routed_build is True
+    assert m.retried is True
+    assert m.recovered is True
+    assert m.oom is False
+    assert m.gate_inert is False
+    assert m.session_outcome == "complete"
+    assert m.cost_total == pytest.approx(0.1234)
+    assert m.duration_s == pytest.approx(321.0)
+
+
+def test_parse_metrics_detects_oom_anomaly():
+    from backend.core.ouroboros.governance.graduation.telemetry_parse import (
+        parse_metrics,
+    )
+    log = _HEAL_LOG + "\nprocess_memory_cap exceeded MemoryError\n"
+    m = parse_metrics(log, _CLEAN_SUMMARY)
+    assert m.oom is True
+
+
+def test_parse_metrics_never_raises_on_garbage():
+    from backend.core.ouroboros.governance.graduation.telemetry_parse import (
+        parse_metrics,
+    )
+    # Non-dict summary, empty log — must return a Metrics, not raise.
+    m = parse_metrics("", None)
+    assert m.livefire_fired == []
+    assert m.recovered is False
+    assert m.session_outcome == ""
+
+
+def test_harvester_reuses_extracted_parse_by_identity():
+    """The script must import the SAME objects, not copy them — proves
+    zero duplication / no drift."""
+    from backend.core.ouroboros.governance.graduation import (
+        telemetry_parse,
+    )
+    harvester = _load_harvester_module()
+    assert harvester.parse_metrics is telemetry_parse.parse_metrics
+    assert harvester.Metrics is telemetry_parse.Metrics
+
+
+def test_harvester_certify_still_present_after_extraction():
+    """certify/render_report stay in the script (graduation-classification
+    is a different concern than deployment self-heal certification)."""
+    harvester = _load_harvester_module()
+    assert hasattr(harvester, "certify")
+    assert hasattr(harvester, "render_report")
+    # And certify still operates on the extracted Metrics correctly.
+    m = harvester.parse_metrics(_HEAL_LOG, _CLEAN_SUMMARY)
+    cert = harvester.certify(m)
+    assert cert.verdict == harvester.FIELD_CERTIFIED


### PR DESCRIPTION
## Summary
Closes the PRD §P9.1 gap: the live-fire soak substrate duplicated a thin telemetry parse and never reused `telemetry_harvester.py`, so per-flag **graduation contracts were blind to the self-heal trajectory**. This unifies the parse at the root and adds a graduation arbiter that grants CLEAN only on proven recovery.

Authored autonomously by **O+V (a `/goal` run)**; isolated onto this branch by Claude — the concurrent autonomous-loop churn (`orchestrator.py`, `oracle.py`, `opportunity_miner_sensor.py`, `test_slice257_*`) and stale deploy `.bak` files were deliberately **excluded**.

## Units
- **A — `telemetry_parse.py`**: `Metrics` + `parse_metrics` lifted (stdlib-only, never-raises); `telemetry_harvester.py` re-imports them (identity, not a copy). Harvester CLI byte-identical.
- **B — `graduation_contract.py`**: `GraduationContract.arbitrate()` priority matrix — P1 anomaly guard (oom/gate_inert → never CLEAN) › P2 **self-heal recovery override** (legacy infra/runner + full live-fire trajectory → CLEAN) › P3 Metrics-aware predicate › P4 legacy blocklist. Dual-signature `is_clean(summary, metrics=None)` via arity dispatch. **Capstone Dogfood Contract** for `JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED` — CLEAN only if telemetry proves live-fire fired + zero OOM + recovered. *The validator graduates only when the harvester proves it healed.*
- **C — `live_fire_soak.py`**: env-tunable whole-trajectory debug-log capture; `Metrics` threaded into the arbiter; `EvidenceRow.telemetry` context. `graduation_ledger` CADENCE_POLICY gains the capstone flag (PASS_C / 5-clean, kernel-touching) to satisfy the contract⊆cadence invariant.

## Gating / safety
- Master `JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED` (default **false**) → off is byte-identical (no parse call, no telemetry field, legacy path untouched).

## Test Plan
- [x] **27 new tests** (6 extraction + 14 arbiter + 7 wiring) — re-verified green on this branch before commit.
- [x] Goal-run also reported 297 affected-suite tests green (p9_1/p9_2_p9_3/dogfood/autonomous-graduation/flag-registry/synthetic-workload/cron-installer).
- [x] All 9 files `ast.parse` + import clean; both CLIs run end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies telemetry parsing and adds a telemetry‑aware graduation arbiter so flags only graduate on proven self‑heal. Default off; legacy behavior is unchanged.

- **New Features**
  - Shared `backend/core/ouroboros/governance/graduation/telemetry_parse.py` with `Metrics` and `parse_metrics`; `scripts/telemetry_harvester.py` now imports it (CLI unchanged).
  - Telemetry arbiter: `GraduationContract.arbitrate()` merges legacy outcome with `Metrics` (anomaly guard → recovery override → metrics‑aware predicate → blocklist). `is_clean(summary, metrics=None)` supports 1‑arg or 2‑arg predicates.
  - Capstone contract: `JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED` is CLEAN only if live‑fire fired, no OOM, and recovered.
  - Soak wiring: `live_fire_soak.py` threads `Metrics`, captures a larger bounded log via `JARVIS_LIVE_FIRE_DEBUG_LOG_CAPTURE_BYTES`, and adds `telemetry` to `EvidenceRow`.
  - Gating: `JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED` (default false) controls the arbiter; cadence ledger adds `JARVIS_LIVE_KERNEL_VALIDATOR_ENABLED` (Pass C, 5 clean).
  - Tests: 27 new tests cover parse, arbiter, and wiring.

- **Migration**
  - No change by default. To adopt, enable `JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT=true` and `JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED=true`. Optionally tune `JARVIS_LIVE_FIRE_DEBUG_LOG_CAPTURE_BYTES`. Consumers should accept the new optional `telemetry` field on evidence rows.

<sup>Written for commit 3c30a8d6f762f199433fb031b006a6ca8c594bb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

