### PR TITLE
Sovereign Execution Boundary (Stage A): OCA Iron Gate + execution_context

### DIFF
--- a/backend/core/ouroboros/governance/execution_context.py
+++ b/backend/core/ouroboros/governance/execution_context.py
@@ -1,0 +1,102 @@
+"""Sovereign Execution Boundary — canonical execution-context detection.
+
+The boundary that keeps the autonomous Ouroboros loop out of the operator's
+PRIMARY working tree needs two deterministic, spoof-resistant predicates.
+This module is the single canonical home for both (Stage A); the OCA Iron
+Gate and (later) the boot-time worktree router compose them — no duplication.
+
+  * :func:`is_primary_checkout` — git ``--git-dir`` vs ``--git-common-dir``.
+    A linked worktree's git-dir lives under ``<common>/worktrees/<name>`` so
+    it differs from the common dir; the primary checkout's git-dir *equals*
+    the common dir. Returns ``True`` ONLY on an affirmative match — any git
+    error / ambiguity → ``False`` (we never block a commit on an unprovable
+    "this is primary" claim).
+
+  * :func:`is_autonomous` — CRYPTOGRAPHIC, not a fragile env boolean. The
+    loop is autonomous iff there is NO valid HMAC-signed operator-presence
+    marker for ``(repo_root, branch)``. Reuses
+    :func:`operator_commit_authority.valid_operator_presence` — the exact
+    primitive OCA's channel resolver uses — so an autonomous agent cannot
+    forge operator status (the per-machine HMAC secret lives outside the
+    repo). Lazy import avoids an import cycle (OCA imports this module for
+    the gate).
+
+Authority posture: pure detection, stdlib-only at module top, NEVER raises.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+
+def _run_git(args: List[str], cwd: Path) -> Optional[str]:
+    """Run ``git <args>`` in ``cwd``; return stripped stdout or None on
+    any failure. NEVER raises."""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001 — git absent / cwd gone / timeout
+        return None
+    if proc.returncode != 0:
+        return None
+    out = (proc.stdout or "").strip()
+    return out or None
+
+
+def is_primary_checkout(repo_root: Optional[Path] = None) -> bool:
+    """Return ``True`` iff ``repo_root`` is affirmatively the PRIMARY git
+    checkout (``git-dir == git-common-dir``), ``False`` for a linked
+    worktree OR on any git error / non-git dir.
+
+    Deny-on-proof, never-on-doubt: the boundary that consumes this only
+    blocks an autonomous commit when we are SURE it targets the primary
+    tree, so a transient git hiccup can never wedge a legitimate worktree
+    commit. NEVER raises."""
+    cwd = Path(repo_root) if repo_root is not None else Path.cwd()
+    git_dir = _run_git(["rev-parse", "--git-dir"], cwd)
+    common_dir = _run_git(["rev-parse", "--git-common-dir"], cwd)
+    if not git_dir or not common_dir:
+        return False
+    try:
+        gd = Path(git_dir)
+        cd = Path(common_dir)
+        gd = (gd if gd.is_absolute() else cwd / gd).resolve()
+        cd = (cd if cd.is_absolute() else cwd / cd).resolve()
+        return gd == cd
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def is_autonomous(
+    repo_root: Optional[Path] = None,
+    branch: str = "",
+) -> bool:
+    """Return ``True`` iff running AUTONOMOUSLY — i.e. there is NO valid
+    HMAC-signed operator-presence marker for ``(repo_root, branch)``.
+
+    Reuses :func:`operator_commit_authority.valid_operator_presence` (the
+    same cryptographic primitive OCA's channel resolver trusts) rather
+    than any environment boolean an autonomous agent could set. Fail-safe:
+    if the OCA substrate is unavailable we cannot PROVE operator presence,
+    so we conservatively treat the session as autonomous. NEVER raises."""
+    root = Path(repo_root) if repo_root is not None else Path.cwd()
+    try:
+        from backend.core.ouroboros.governance import (
+            operator_commit_authority as _oca,
+        )
+    except Exception:  # noqa: BLE001 — substrate unavailable
+        return True
+    try:
+        return not bool(_oca.valid_operator_presence(root, branch))
+    except Exception:  # noqa: BLE001
+        return True
+
+
+__all__ = ["is_autonomous", "is_primary_checkout"]

--- a/backend/core/ouroboros/governance/operator_commit_authority.py
+++ b/backend/core/ouroboros/governance/operator_commit_authority.py
@@ -114,6 +114,13 @@ _ENV_SECRET_PATH = "JARVIS_COMMIT_AUTHORITY_SECRET_PATH"
 _ENV_ENABLE_FILE = "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE"
 _ENV_PRESENCE_FILE = "JARVIS_COMMIT_AUTHORITY_PRESENCE_FILE"
 _ENV_PRESENCE_TTL_S = "JARVIS_COMMIT_PRESENCE_TTL_S"
+# Sovereign Execution Boundary (Stage A) — dedicated default-OFF sub-flag.
+# Composes WITH the OCA master (the boundary only operates inside the OCA
+# pre-commit path), but is its own switch so enabling OCA is byte-identical
+# until the operator opts into the stricter "autonomous never commits in the
+# primary tree / on main" rule. Off → the autonomous channel keeps its
+# documented legacy contract unchanged.
+_ENV_EXECUTION_BOUNDARY = "JARVIS_EXECUTION_BOUNDARY_ENABLED"
 
 _DEFAULT_GRANTS_RELATIVE = ".jarvis/commit_authority/grants.jsonl"
 _DEFAULT_SECRET_RELATIVE = ("commit_authority", "secret")  # under ~/.jarvis
@@ -1295,6 +1302,57 @@ def _autonomous_verdict(
     )
 
 
+def _execution_boundary_verdict(
+    ctx: CommitAuthorityContext,
+    repo_root: Path,
+) -> Optional[CommitAuthorityVerdictResult]:
+    """Sovereign Execution Boundary (Stage A) — refuse an AUTONOMOUS commit
+    that targets the operator's PRIMARY checkout or the main/master branch.
+
+    Reached ONLY from the autonomous branch of :func:`verify_pre_commit`,
+    so autonomy is already cryptographically established (no valid operator
+    presence). This adds the *location* constraint that the bare sovereignty
+    marker does not: the loop must commit from an isolated worktree on a
+    feature branch, never the operator's primary tree — closing the
+    branch/file-mutation revert vector.
+
+    Deny-on-proof, never-on-doubt: composes
+    :func:`execution_context.is_primary_checkout` (which returns True only on
+    affirmative detection) so a transient git fault can never wedge a
+    legitimate worktree commit. Returns a DENY verdict or ``None`` (pass).
+    Reuses :attr:`CommitAuthorityVerdict.DENIED_SOVEREIGNTY` (the verdict
+    taxonomy is closed/pinned at 8). NEVER raises."""
+    # Dedicated default-OFF sub-flag — composes with the OCA master so
+    # enabling OCA alone stays byte-identical to the legacy autonomous
+    # contract. Off → the boundary is inert.
+    if not _flag(_ENV_EXECUTION_BOUNDARY, default=False):
+        return None
+    try:
+        from backend.core.ouroboros.governance import (
+            execution_context as _ec,
+        )
+        primary = bool(_ec.is_primary_checkout(repo_root))
+    except Exception:  # noqa: BLE001 — substrate unavailable → don't block
+        primary = False
+    norm_branch = str(getattr(ctx, "branch", "") or "").strip().lower()
+    on_protected = norm_branch in ("main", "master")
+    if not (primary or on_protected):
+        return None
+    where = (
+        "the operator PRIMARY checkout"
+        if primary
+        else f"protected branch '{norm_branch}'"
+    )
+    return _verdict(
+        CommitAuthorityVerdict.DENIED_SOVEREIGNTY,
+        ctx.channel,
+        "Sovereign Execution Boundary: autonomous commit into "
+        f"{where} refused — the loop must commit from an isolated "
+        "worktree on a feature branch, not the operator's primary "
+        f"tree. repo_root={repo_root}",
+    )
+
+
 def _governance_gate(
     ctx: CommitAuthorityContext,
     grant: Optional[CommitGrant],
@@ -1369,6 +1427,12 @@ def verify_pre_commit(
     # governance hash-cap still applies (autonomous ops touching
     # governance/ must match the signed manifest).
     if channel is CommitChannel.AUTONOMOUS:
+        # Sovereign Execution Boundary (Stage A): an autonomous commit must
+        # never land in the operator's primary checkout or on main/master —
+        # the loop commits from an isolated worktree on a feature branch.
+        boundary = _execution_boundary_verdict(ctx, repo_root)
+        if boundary is not None:
+            return boundary
         sov = _autonomous_verdict(ctx, repo_root)
         if not sov.authorized():
             return sov

--- a/tests/governance/test_execution_context.py
+++ b/tests/governance/test_execution_context.py
@@ -1,0 +1,112 @@
+"""Sovereign Execution Boundary (Stage A) — canonical execution context.
+
+`execution_context` provides the deterministic primitives the boundary
+relies on:
+  * is_primary_checkout(repo_root) — git --git-dir vs --git-common-dir;
+    True ONLY when affirmatively the primary checkout (not a linked
+    worktree). Fail-safe → False on any git error.
+  * is_autonomous(repo_root, branch) — cryptographic: autonomous iff NO
+    valid HMAC-signed operator-presence marker (reuses OCA's
+    valid_operator_presence, NOT a fragile env bool).
+
+TDD red: written before the module exists.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _git(args, cwd):
+    subprocess.run(
+        ["git", *args], cwd=str(cwd), check=True,
+        capture_output=True, text=True,
+    )
+
+
+def _make_primary(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-q"], path)
+    _git(["config", "user.email", "t@t"], path)
+    _git(["config", "user.name", "t"], path)
+    (path / "f.txt").write_text("x")
+    _git(["add", "."], path)
+    _git(["commit", "-qm", "init"], path)
+    return path
+
+
+def _add_worktree(primary: Path, wt_path: Path, branch="feat") -> Path:
+    _git(["worktree", "add", "-b", branch, str(wt_path)], primary)
+    return wt_path
+
+
+# --- is_primary_checkout ---------------------------------------------------
+def test_is_primary_checkout_true_in_primary(tmp_path):
+    from backend.core.ouroboros.governance import execution_context as ec
+    primary = _make_primary(tmp_path / "primary")
+    assert ec.is_primary_checkout(primary) is True
+
+
+def test_is_primary_checkout_false_in_linked_worktree(tmp_path):
+    from backend.core.ouroboros.governance import execution_context as ec
+    primary = _make_primary(tmp_path / "primary")
+    wt = _add_worktree(primary, tmp_path / "wt")
+    assert ec.is_primary_checkout(wt) is False
+
+
+def test_is_primary_checkout_false_on_non_git_dir(tmp_path):
+    from backend.core.ouroboros.governance import execution_context as ec
+    # Fail-safe: a non-git dir cannot be CONFIRMED primary → False
+    # (never block a commit on an unprovable claim).
+    assert ec.is_primary_checkout(tmp_path / "not_git") is False
+
+
+# --- is_autonomous (cryptographic, reuses OCA presence) --------------------
+def test_is_autonomous_true_when_no_operator_presence(tmp_path, monkeypatch):
+    from backend.core.ouroboros.governance import execution_context as ec
+    from backend.core.ouroboros.governance import (
+        operator_commit_authority as oca,
+    )
+    monkeypatch.setattr(
+        oca, "valid_operator_presence", lambda *a, **k: False,
+    )
+    assert ec.is_autonomous(tmp_path, "") is True
+
+
+def test_is_autonomous_false_when_operator_presence_valid(
+    tmp_path, monkeypatch,
+):
+    from backend.core.ouroboros.governance import execution_context as ec
+    from backend.core.ouroboros.governance import (
+        operator_commit_authority as oca,
+    )
+    monkeypatch.setattr(
+        oca, "valid_operator_presence", lambda *a, **k: True,
+    )
+    assert ec.is_autonomous(tmp_path, "") is False
+
+
+def test_is_autonomous_reuses_oca_primitive_not_env_bool(
+    tmp_path, monkeypatch,
+):
+    # Setting a fragile env bool must NOT flip autonomy — only the
+    # crypto presence primitive decides.
+    from backend.core.ouroboros.governance import execution_context as ec
+    from backend.core.ouroboros.governance import (
+        operator_commit_authority as oca,
+    )
+    monkeypatch.setenv("JARVIS_AUTO", "0")
+    monkeypatch.setenv("JARVIS_AUTONOMOUS_EXECUTION", "0")
+    monkeypatch.setattr(
+        oca, "valid_operator_presence", lambda *a, **k: False,
+    )
+    assert ec.is_autonomous(tmp_path, "") is True
+
+
+def test_functions_never_raise(tmp_path):
+    from backend.core.ouroboros.governance import execution_context as ec
+    # Garbage inputs must not raise.
+    assert ec.is_primary_checkout(Path("/nonexistent/xyz")) is False
+    assert isinstance(ec.is_autonomous(Path("/nonexistent/xyz"), ""), bool)

--- a/tests/governance/test_quarantine_reap_pin.py
+++ b/tests/governance/test_quarantine_reap_pin.py
@@ -1,0 +1,49 @@
+"""Sovereign Execution Boundary (Stage A) — Phase 3 reaping pin.
+
+The autonomous loop's quarantine worktrees (``ouroboros/auto/bt-*``) must be
+flushed on boot so orphaned zones from a crashed/killed prior session can't
+accumulate. The boot path (``governed_loop_service`` → ``reap_orphans()``)
+already resolves a MULTI-PREFIX reap set via ``_resolve_reap_prefixes``.
+
+This pin LOCKS that guarantee against future drift (no new code — the wiring
+exists; this guards it). If a refactor drops the autonomous prefix from the
+reap set, this fails loudly.
+"""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance import worktree_manager as wm
+
+
+def test_default_reap_set_includes_autonomous_quarantine_prefix(monkeypatch):
+    monkeypatch.delenv("JARVIS_WORKTREE_REAP_PREFIXES", raising=False)
+    prefixes = wm._resolve_reap_prefixes("unit-")
+    # The boot reaper's primary prefix plus the autonomous quarantine zones.
+    assert "unit-" in prefixes
+    assert "ouroboros/auto/bt-" in prefixes  # branch-form quarantine zone
+    assert "ouroboros__auto__bt-" in prefixes  # on-disk dir form
+
+
+def test_reap_prefixes_env_override_respected(monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_WORKTREE_REAP_PREFIXES", "unit-, auto-loop-",
+    )
+    prefixes = wm._resolve_reap_prefixes("unit-")
+    assert prefixes[0] == "unit-"
+    assert "auto-loop-" in prefixes
+
+
+def test_reap_prefixes_dedupes_and_preserves_order(monkeypatch):
+    monkeypatch.setenv("JARVIS_WORKTREE_REAP_PREFIXES", "unit-,unit-,x-")
+    prefixes = wm._resolve_reap_prefixes("unit-")
+    assert prefixes == ("unit-", "x-")
+
+
+def test_boot_path_calls_reap_orphans():
+    # Characterization pin: the GovernedLoopService boot path invokes the
+    # reaper (gated by JARVIS_WORKTREE_REAP_ORPHANS, default true). Guards
+    # against a refactor silently removing the boot-time flush.
+    import inspect
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+    src = inspect.getsource(gls)
+    assert "reap_orphans(" in src
+    assert "JARVIS_WORKTREE_REAP_ORPHANS" in src

--- a/tests/governance/test_sovereign_execution_boundary.py
+++ b/tests/governance/test_sovereign_execution_boundary.py
@@ -1,0 +1,155 @@
+"""Sovereign Execution Boundary (Stage A) — OCA Iron Gate.
+
+The missing rule injected into ``operator_commit_authority.verify_pre_commit``:
+an AUTONOMOUS commit that targets the PRIMARY checkout (or the main/master
+branch) is DENIED — the loop must commit from an isolated worktree on a
+feature branch. This closes the actual revert vector (the loop's branch/file
+mutations in the operator's primary tree).
+
+Gated by the existing OCA master flag (``JARVIS_OPERATOR_COMMIT_AUTHORITY_
+ENABLED``); master-off is byte-identical (DISABLED). Reuses the existing
+``DENIED_SOVEREIGNTY`` verdict (the enum is pinned to exactly 8 members).
+Operator channels are unaffected — the rule lives inside the autonomous
+branch only.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import (
+    operator_commit_authority as oca,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    for env in (
+        "JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED",
+        "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH",
+        "JARVIS_COMMIT_AUTHORITY_SECRET_PATH",
+        "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE",
+        "JARVIS_LEDGER_SOVEREIGNTY_ENABLED",
+        "JARVIS_GOVERNANCE_MANIFEST_ENABLED",
+        "JARVIS_EXECUTION_BOUNDARY_ENABLED",
+    ):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_GRANTS_PATH", str(tmp_path / "grants.jsonl"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_SECRET_PATH", str(tmp_path / "secret"),
+    )
+    monkeypatch.setenv(
+        "JARVIS_COMMIT_AUTHORITY_ENABLE_FILE", str(tmp_path / "enabled"),
+    )
+    yield
+
+
+def _on(monkeypatch):
+    """Enable OCA master AND the dedicated execution-boundary sub-flag."""
+    monkeypatch.setenv("JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_EXECUTION_BOUNDARY_ENABLED", "true")
+
+
+def _git(args, cwd):
+    subprocess.run(
+        ["git", *args], cwd=str(cwd), check=True,
+        capture_output=True, text=True,
+    )
+
+
+def _make_primary(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-q"], path)
+    _git(["config", "user.email", "t@t"], path)
+    _git(["config", "user.name", "t"], path)
+    (path / "f.txt").write_text("x")
+    _git(["add", "."], path)
+    _git(["commit", "-qm", "init"], path)
+    return path
+
+
+def _add_worktree(primary: Path, wt: Path, branch="feat") -> Path:
+    _git(["worktree", "add", "-b", branch, str(wt)], primary)
+    return wt
+
+
+def _ctx(repo_root, *, channel="autonomous", branch="", staged=()):
+    return oca.CommitAuthorityContext(
+        channel=channel, repo_root=str(repo_root),
+        branch=branch, staged_files=tuple(staged),
+    )
+
+
+# --- the core boundary -----------------------------------------------------
+def test_autonomous_commit_in_primary_checkout_denied(tmp_path, monkeypatch):
+    _on(monkeypatch)
+    primary = _make_primary(tmp_path / "primary")
+    v = oca.verify_pre_commit(_ctx(primary))
+    assert v.verdict is oca.CommitAuthorityVerdict.DENIED_SOVEREIGNTY
+    assert v.authorized() is False
+
+
+def test_autonomous_commit_in_worktree_authorized(tmp_path, monkeypatch):
+    _on(monkeypatch)
+    primary = _make_primary(tmp_path / "primary")
+    wt = _add_worktree(primary, tmp_path / "wt", branch="feat")
+    v = oca.verify_pre_commit(_ctx(wt, branch="feat"))
+    # Boundary passes (worktree); ledger_sovereignty master off → the
+    # autonomous channel authorizes.
+    assert v.verdict is oca.CommitAuthorityVerdict.AUTHORIZED
+    assert v.authorized() is True
+
+
+def test_autonomous_commit_to_main_branch_denied(tmp_path, monkeypatch):
+    _on(monkeypatch)
+    primary = _make_primary(tmp_path / "primary")
+    wt = _add_worktree(primary, tmp_path / "wt", branch="feat")
+    # Even in a worktree, targeting main/master is refused (defense in
+    # depth — mirrors pre-push protection).
+    v = oca.verify_pre_commit(_ctx(wt, branch="main"))
+    assert v.verdict is oca.CommitAuthorityVerdict.DENIED_SOVEREIGNTY
+    assert v.authorized() is False
+
+
+# --- gating (byte-identical when master off) -------------------------------
+def test_master_off_is_disabled_even_in_primary(tmp_path, monkeypatch):
+    primary = _make_primary(tmp_path / "primary")
+    v = oca.verify_pre_commit(_ctx(primary))
+    assert v.verdict is oca.CommitAuthorityVerdict.DISABLED
+    assert v.authorized() is True
+
+
+# --- operator channels are unaffected by the boundary ----------------------
+def test_operator_channel_in_primary_not_boundary_denied(
+    tmp_path, monkeypatch,
+):
+    _on(monkeypatch)
+    primary = _make_primary(tmp_path / "primary")
+    # An operator (ide) commit in the primary checkout is legitimate; the
+    # boundary must NOT fire. It fails for the ORDINARY reason (no grant),
+    # proving the boundary is autonomous-only.
+    v = oca.verify_pre_commit(_ctx(primary, channel="ide"))
+    assert v.verdict is oca.CommitAuthorityVerdict.DENIED_NO_GRANT
+
+
+def test_oca_on_boundary_off_is_byte_identical_legacy(tmp_path, monkeypatch):
+    # OCA master ON but the boundary sub-flag OFF → the autonomous channel
+    # keeps its documented legacy contract (authorized when sovereignty
+    # off), proving the boundary is a pure additive opt-in.
+    monkeypatch.setenv("JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_EXECUTION_BOUNDARY_ENABLED", raising=False)
+    primary = _make_primary(tmp_path / "primary")
+    v = oca.verify_pre_commit(_ctx(primary))
+    assert v.verdict is oca.CommitAuthorityVerdict.AUTHORIZED
+
+
+def test_boundary_never_raises_on_garbage_repo_root(tmp_path, monkeypatch):
+    _on(monkeypatch)
+    # Non-git repo_root → is_primary_checkout False → boundary passes,
+    # autonomous authorizes (no wedge on detection failure).
+    v = oca.verify_pre_commit(_ctx(tmp_path / "not_git"))
+    assert v.verdict is oca.CommitAuthorityVerdict.AUTHORIZED


### PR DESCRIPTION
## Sovereign Execution Boundary — Stage A

Closes the actual vector behind the loop reverting the operator's working tree: **the autonomous loop committing/mutating the primary checkout**. Stage A establishes the hard structural boundary; Stage B (routing the loop's GENERATE/VALIDATE/branch-ops into a worktree) is a separately-soaked follow-up.

### What landed
- **`execution_context.py`** (new canonical module — both maps flagged it was missing):
  - `is_primary_checkout()` — `git --git-dir` vs `--git-common-dir`; True only on affirmative match (deny-on-proof, never blocks a worktree commit on a transient git fault).
  - `is_autonomous()` — **cryptographic**: reuses OCA's HMAC-signed `valid_operator_presence` (an autonomous agent can't forge operator status), not a fragile env bool.
- **OCA Iron Gate** (`operator_commit_authority.verify_pre_commit`): `_execution_boundary_verdict` inside the AUTONOMOUS branch — an autonomous commit into the **primary checkout** or **main/master** is DENIED (reuses `DENIED_SOVEREIGNTY`; the verdict enum stays pinned at 8). Operator channels are untouched.
- **Dedicated default-off flag** `JARVIS_EXECUTION_BOUNDARY_ENABLED`, composing with the OCA master. Enabling OCA alone stays **byte-identical** to the documented legacy autonomous contract until the operator opts in.
- **Phase 3 hygiene**: deleted the stale untracked `worktree_manager 2.py`; pinned the existing boot-time multi-prefix quarantine reaping (`ouroboros/auto/bt-*`) against drift.

### Verification
- 18 new Stage A tests + 22 worktree/sovereignty regression tests green.
- OCA suite **identical** before/after (`2 failed, 15 passed` on clean main and this branch — the 2 are pre-existing sandbox `~/.jarvis` blocks, unrelated).

### Note
Pre-push protection (already present) blocks direct main pushes; this is a feature-branch PR. Builds on the worktree-isolation lesson — authored entirely in an isolated worktree so the live loop couldn't revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Sovereign Execution Boundary (Stage A) that blocks autonomous loop commits into the operator’s primary checkout and protected branches, using OCA’s Iron Gate. Introduces `execution_context` for deterministic, spoof‑resistant context checks; boundary is opt‑in via `JARVIS_EXECUTION_BOUNDARY_ENABLED`.

- **New Features**
  - New `execution_context.py`
    - `is_primary_checkout()` uses `git --git-dir` vs `--git-common-dir`; only true on an affirmative match.
    - `is_autonomous()` defers to OCA’s HMAC-signed `valid_operator_presence`; not env-based.
  - OCA Iron Gate: `_execution_boundary_verdict` in `verify_pre_commit`
    - Denies AUTONOMOUS commits in the primary checkout or on `main`/`master` (reuses `DENIED_SOVEREIGNTY`).
    - Operator channels are unaffected.
  - New flag `JARVIS_EXECUTION_BOUNDARY_ENABLED` (default off); composes with `JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED`.
  - Boot-time quarantine reaping prefixes are pinned to include `ouroboros/auto/bt-*`.

- **Migration**
  - To enable: set `JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED=true` and `JARVIS_EXECUTION_BOUNDARY_ENABLED=true`.
  - With the boundary on, autonomous commits must run from an isolated worktree on a feature branch.

<sup>Written for commit 1f6bc6f136e587ad5d243a16cc28a8731e7a59ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

