### PR TITLE
Sovereign Execution Boundary (Stage B): autonomous file isolation

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -2231,8 +2231,23 @@ class BattleTestHarness:
                 GovernedLoopService,
             )
 
+            # Sovereign Execution Boundary Stage B — dynamic project_root
+            # injection. When JARVIS_FILE_ISOLATION_ENABLED is on AND the
+            # session is autonomous, the loop's project_root resolves to an
+            # isolated worktree; every mutation delegate (ChangeEngine /
+            # BranchManager / TestRunner / ToolExecutor) inherits project_root,
+            # so this single redirect quarantines all file/git/test mutation
+            # out of the operator's primary checkout. No os.chdir, no global
+            # cwd state. Off (default) → repo_path → byte-identical boot.
+            from backend.core.ouroboros.governance.autonomous_workspace import (
+                resolve_loop_project_root,
+            )
+            _loop_root = await resolve_loop_project_root(
+                self._config.repo_path,
+                session_id=str(self._session_id),
+            )
             gls_config = GovernedLoopConfig.from_env(
-                project_root=self._config.repo_path,
+                project_root=_loop_root,
             )
             # Widen canary slices for battle test — allow all files.
             # Production default is ("tests/", "docs/") which blocks
@@ -2787,6 +2802,18 @@ class BattleTestHarness:
 
         if not master_enabled():
             return  # §33.1 master-FALSE byte-identical path
+
+        # Stage B unification: if file-isolation already created + exported
+        # the unified worktree earlier (at GLS-config construction, before
+        # this phase), reuse it instead of double-creating a second worktree.
+        _existing_ws = os.environ.get("JARVIS_AUTO_COMMIT_WORKSPACE", "")
+        if _existing_ws and Path(_existing_ws).is_dir():
+            self._auto_commit_workspace = Path(_existing_ws)
+            logger.info(
+                "[ledger_sovereignty] reusing file-isolation worktree "
+                "%s (Stage B already created it)", _existing_ws,
+            )
+            return
 
         # Session id MUST be exported BEFORE WorktreeManager.create
         # so the marker payload carries the correct value.

--- a/backend/core/ouroboros/governance/autonomous_workspace.py
+++ b/backend/core/ouroboros/governance/autonomous_workspace.py
@@ -1,0 +1,103 @@
+"""Sovereign Execution Boundary (Stage B) — autonomous file isolation.
+
+Stage A (the OCA Iron Gate) blocks the autonomous loop from *committing* in
+the operator's primary checkout. Stage B closes the remaining *file-mutation*
+vector: it routes the loop's GENERATE/VALIDATE/APPLY/branch-ops into an
+isolated worktree so the loop never touches the operator's working tree at all.
+
+## How (zero global cwd state, no os.chdir)
+
+The orchestrator and all four mutation delegates — ChangeEngine (file writes),
+BranchManager (`git checkout -b`), TestRunner (pytest subprocess), ToolExecutor
+(Venom bash) — derive their working dir from a `project_root` passed in at
+construction. So a SINGLE dynamic redirect of the orchestrator's `project_root`
+(at config-construction time in the harness boot) carries to every mutation.
+This module computes that root.
+
+:func:`resolve_loop_project_root` returns:
+  * ``repo_root`` unchanged when file isolation is off (default) OR the session
+    is not autonomous → byte-identical boot, human sessions use the primary
+    checkout.
+  * an isolated worktree path when file isolation is on AND the session is
+    autonomous. The worktree uses the SAME ``ouroboros/auto/<session>`` naming
+    as the Ledger-Sovereignty commit-workspace phase, so the two converge on
+    ONE worktree and the existing ``WorktreeManager.reap_orphans`` (which
+    already sweeps ``ouroboros/auto/*``) flushes orphaned quarantine zones on
+    the next boot.
+
+Authority posture: gated by ``JARVIS_FILE_ISOLATION_ENABLED`` (default off),
+composes with the Stage A boundary, NEVER raises (falls back to ``repo_root``
+— and the Stage A commit-gate still blocks any autonomous commit there, so a
+fallback can't silently corrupt the operator's tree).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+_TRUTHY = ("1", "true", "yes", "on")
+_ENV_FILE_ISOLATION = "JARVIS_FILE_ISOLATION_ENABLED"
+_ENV_COMMIT_WORKSPACE = "JARVIS_AUTO_COMMIT_WORKSPACE"
+_ENV_SESSION_ID = "JARVIS_OUROBOROS_SESSION_ID"
+
+
+def file_isolation_enabled() -> bool:
+    """Master flag — ``JARVIS_FILE_ISOLATION_ENABLED`` (default false).
+    Off → :func:`resolve_loop_project_root` is a pure pass-through (the
+    boot is byte-identical)."""
+    return os.environ.get(_ENV_FILE_ISOLATION, "").strip().lower() in _TRUTHY
+
+
+def workspace_branch(session_id: str) -> str:
+    """Quarantine branch name. Intentionally identical to the
+    Ledger-Sovereignty commit-workspace branch so file + commit isolation
+    converge on ONE worktree, swept by the existing ``ouroboros/auto/*``
+    reaper."""
+    return f"ouroboros/auto/{session_id}"
+
+
+async def resolve_loop_project_root(
+    repo_root: Any,
+    *,
+    session_id: str,
+    worktree_manager: Optional[Any] = None,
+) -> Path:
+    """Resolve the orchestrator's effective ``project_root`` for this
+    session (see module docstring). NEVER raises — any failure falls back
+    to ``repo_root``."""
+    root = Path(repo_root)
+    if not file_isolation_enabled():
+        return root
+    # Cryptographic autonomy check (Stage A primitive) — human sessions
+    # keep the primary checkout.
+    try:
+        from backend.core.ouroboros.governance import execution_context as ec
+        if not ec.is_autonomous(root):
+            return root
+    except Exception:  # noqa: BLE001 — can't prove human → be conservative
+        pass
+    try:
+        mgr = worktree_manager
+        if mgr is None:
+            from backend.core.ouroboros.governance.worktree_manager import (
+                WorktreeManager,
+            )
+            mgr = WorktreeManager(repo_root=root)
+        wt_path = Path(await mgr.create(workspace_branch(session_id)))
+    except Exception:  # noqa: BLE001 — fail-safe: stay in primary
+        return root
+    # Unify with the EXISTING commit-workspace handoff idiom (the same env
+    # the Ledger-Sovereignty phase sets) so AutoCommitter + ChangeEngine +
+    # the orchestrator all converge on this one worktree. This is the
+    # established workspace-handoff env, NOT process-cwd mutation.
+    os.environ[_ENV_COMMIT_WORKSPACE] = str(wt_path)
+    os.environ.setdefault(_ENV_SESSION_ID, str(session_id))
+    return wt_path
+
+
+__all__ = [
+    "file_isolation_enabled",
+    "resolve_loop_project_root",
+    "workspace_branch",
+]

--- a/backend/core/ouroboros/governance/autonomous_workspace.py
+++ b/backend/core/ouroboros/governance/autonomous_workspace.py
@@ -32,9 +32,12 @@ fallback can't silently corrupt the operator's tree).
 """
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
 
 _TRUTHY = ("1", "true", "yes", "on")
 _ENV_FILE_ISOLATION = "JARVIS_FILE_ISOLATION_ENABLED"
@@ -93,6 +96,13 @@ async def resolve_loop_project_root(
     # established workspace-handoff env, NOT process-cwd mutation.
     os.environ[_ENV_COMMIT_WORKSPACE] = str(wt_path)
     os.environ.setdefault(_ENV_SESSION_ID, str(session_id))
+    # §7 absolute observability — emit a grep-stable marker so a soak can
+    # verify the redirect fired and identify the quarantine zone.
+    logger.info(
+        "[FileIsolation] routed project_root -> %s "
+        "(session=%s branch=%s)",
+        wt_path, session_id, workspace_branch(session_id),
+    )
     return wt_path
 
 

--- a/scripts/verify_file_isolation.py
+++ b/scripts/verify_file_isolation.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Sovereign Quarantine Validation — Stage B file-isolation soak verifier.
+
+Watches ``.ouroboros/sessions/`` for the soak session, and on FSM termination
+verifies the four absolute invariants of the Sovereign File Isolation boundary:
+
+  I1  WORKTREE INITIALIZED   — the loop routed project_root into an isolated
+                               ``ouroboros/auto/bt-*`` worktree.
+  I2  MUTATIONS QUARANTINED  — file/git mutations landed in that worktree, not
+                               the operator's primary tree.
+  I3  PRIMARY PRISTINE       — the primary working tree is 100% clean of
+                               loop-authored source changes.
+  I4  WORKTREE REAPED        — the quarantine zone was reaped (or is registered
+                               for the boot-time reaper), not leaked.
+
+Composes the shared ``telemetry_parse`` (the SAME parser the harvester uses) for
+session health, then layers the isolation-specific checks. Stdlib only.
+
+Run (after the soak, or armed before it):
+    python3 scripts/verify_file_isolation.py \
+        --sessions-dir .ouroboros/sessions --primary-root <repo_root>
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# REUSE the extracted shared parse (Sovereign Telemetry Unification).
+from backend.core.ouroboros.governance.graduation.telemetry_parse import (  # noqa: E402,E501
+    _TERMINAL_OUTCOMES,
+    parse_metrics,
+)
+
+# Grep-stable marker emitted by autonomous_workspace.resolve_loop_project_root.
+_RE_ROUTED = re.compile(
+    r"\[FileIsolation\] routed project_root -> (\S+) "
+    r"\(session=(\S+) branch=(\S+)\)"
+)
+_RE_AUTO_WT = re.compile(r"ouroboros[/_]+auto[/_]+(?:bt-)?\S+")
+
+PASS = "PASS"
+FAIL = "FAIL"
+WARN = "WARN"
+INCOMPLETE = "INCOMPLETE"
+
+
+@dataclass
+class Invariant:
+    key: str
+    status: str
+    detail: str
+
+
+@dataclass
+class IsolationVerdict:
+    overall: str
+    invariants: List[Invariant] = field(default_factory=list)
+    quarantine_path: str = ""
+    session_outcome: str = ""
+
+
+def assess_isolation(
+    *,
+    debug_log: str,
+    primary_status_porcelain: str,
+    worktree_list_porcelain: str,
+    summary: Optional[Dict],
+    reap_log: str = "",
+) -> IsolationVerdict:
+    """Pure assessment of the four invariants. NEVER raises.
+
+    ``primary_status_porcelain`` — ``git -C <primary> status --porcelain``.
+    ``worktree_list_porcelain``  — ``git worktree list --porcelain`` AFTER the
+                                   session (to check reaping).
+    ``reap_log`` — optional next-boot debug.log tail proving reap_orphans ran.
+    """
+    debug_log = debug_log if isinstance(debug_log, str) else ""
+    invariants: List[Invariant] = []
+
+    # Session must have actually terminated.
+    outcome = ""
+    if isinstance(summary, dict):
+        outcome = str(summary.get("session_outcome", ""))
+    if outcome not in _TERMINAL_OUTCOMES or not outcome:
+        return IsolationVerdict(
+            overall=INCOMPLETE,
+            invariants=[Invariant(
+                "session", INCOMPLETE,
+                f"session_outcome={outcome or 'n/a'} — re-harvest after "
+                "the FSM finalizes summary.json",
+            )],
+            session_outcome=outcome,
+        )
+
+    # I1 — worktree initialized (the routing marker fired).
+    m = _RE_ROUTED.search(debug_log)
+    quarantine_path = m.group(1) if m else ""
+    if m:
+        invariants.append(Invariant(
+            "I1_worktree_initialized", PASS,
+            f"routed project_root -> {quarantine_path} "
+            f"(branch={m.group(3)})",
+        ))
+    else:
+        invariants.append(Invariant(
+            "I1_worktree_initialized", FAIL,
+            "no '[FileIsolation] routed project_root' marker in debug.log "
+            "— isolation did not activate (autonomous? flag set?)",
+        ))
+
+    # I2 — mutations quarantined: the quarantine path is referenced as the
+    # working root beyond the single routing line (delegates inherit it).
+    if quarantine_path:
+        refs = debug_log.count(quarantine_path)
+        if refs >= 2:
+            invariants.append(Invariant(
+                "I2_mutations_quarantined", PASS,
+                f"quarantine path referenced {refs}x (delegates inherited "
+                "project_root → mutations routed into the zone)",
+            ))
+        else:
+            invariants.append(Invariant(
+                "I2_mutations_quarantined", WARN,
+                f"quarantine path referenced only {refs}x — loop may not "
+                "have produced a file mutation this session (no APPLY)",
+            ))
+    else:
+        invariants.append(Invariant(
+            "I2_mutations_quarantined", FAIL,
+            "no quarantine path (I1 failed) → cannot confirm routing",
+        ))
+
+    # I3 — primary tree pristine: no loop-authored source changes. Ignore
+    # untracked soak artifacts (.ouroboros/.worktrees/.jarvis) + the verifier
+    # itself; flag any tracked source modification.
+    dirty = _loop_authored_dirty_lines(primary_status_porcelain)
+    if not dirty:
+        invariants.append(Invariant(
+            "I3_primary_pristine", PASS,
+            "primary working tree has no loop-authored source changes",
+        ))
+    else:
+        invariants.append(Invariant(
+            "I3_primary_pristine", FAIL,
+            "primary tree MUTATED by the loop: "
+            + "; ".join(dirty[:8]),
+        ))
+
+    # I4 — worktree reaped (or pending reap). Present in `worktree list` =
+    # not yet reaped this lifecycle (boot reaper will sweep it); absent OR a
+    # reap log line = reaped.
+    still_listed = bool(quarantine_path) and quarantine_path in (
+        worktree_list_porcelain or ""
+    )
+    reaped_logged = bool(
+        _RE_AUTO_WT.search(reap_log or "")
+    ) or "reap" in (reap_log or "").lower()
+    if not still_listed or reaped_logged:
+        invariants.append(Invariant(
+            "I4_worktree_reaped", PASS,
+            "quarantine worktree reaped (or absent from worktree list)",
+        ))
+    else:
+        invariants.append(Invariant(
+            "I4_worktree_reaped", WARN,
+            "quarantine worktree still registered — will be swept by the "
+            "boot reaper on next O+V init (reap_orphans covers "
+            "ouroboros/auto/*). Re-check after a reboot for PASS.",
+        ))
+
+    statuses = {i.status for i in invariants}
+    if FAIL in statuses:
+        overall = FAIL
+    elif WARN in statuses:
+        overall = WARN
+    else:
+        overall = PASS
+    return IsolationVerdict(
+        overall=overall,
+        invariants=invariants,
+        quarantine_path=quarantine_path,
+        session_outcome=outcome,
+    )
+
+
+def _loop_authored_dirty_lines(porcelain: str) -> List[str]:
+    """Return git-status-porcelain lines that represent loop-authored
+    source mutations to the PRIMARY tree. Ignores soak/runtime artifacts."""
+    if not isinstance(porcelain, str) or not porcelain.strip():
+        return []
+    ignore_prefixes = (
+        ".ouroboros/", ".worktrees/", ".jarvis/", ".claude/",
+        "scripts/verify_file_isolation.py",
+    )
+    out: List[str] = []
+    for line in porcelain.splitlines():
+        line = line.rstrip()
+        if not line or len(line) < 4:
+            continue
+        path = line[3:].strip().strip('"')
+        # Untracked dirs/files from the soak are noise; tracked source
+        # modifications (' M ', 'A ', 'D ') to backend/tests are the signal.
+        if any(path.startswith(p) for p in ignore_prefixes):
+            continue
+        out.append(line)
+    return out
+
+
+def render(verdict: IsolationVerdict) -> str:
+    bar = "=" * 74
+    sym = {PASS: "✓", FAIL: "✗", WARN: "!", INCOMPLETE: "…"}
+    lines = [
+        bar,
+        "  Sovereign Quarantine Validation — File Isolation Invariant Matrix",
+        bar,
+        f"  session_outcome : {verdict.session_outcome or 'n/a'}",
+        f"  quarantine zone : {verdict.quarantine_path or 'n/a'}",
+        "-" * 74,
+    ]
+    for inv in verdict.invariants:
+        lines.append(f"  [{sym.get(inv.status, '?')}] {inv.key:26s} {inv.status}")
+        lines.append(f"      {inv.detail}")
+    lines.append("-" * 74)
+    lines.append(f"  VERDICT: {verdict.overall}")
+    lines.append(bar)
+    return "\n".join(lines)
+
+
+# ── live I/O shell ─────────────────────────────────────────────────────────
+def _git(args: List[str], cwd: Path) -> str:
+    try:
+        r = subprocess.run(
+            ["git", *args], cwd=str(cwd), capture_output=True,
+            text=True, timeout=20, check=False,
+        )
+        return r.stdout if r.returncode == 0 else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _find_latest_session(sessions_dir: Path, since_ts: float) -> Optional[Path]:
+    if not sessions_dir.is_dir():
+        return None
+    cands = [
+        d for d in sessions_dir.iterdir()
+        if d.is_dir() and d.name.startswith("bt-")
+        and d.stat().st_mtime >= since_ts - 1
+    ]
+    return max(cands, key=lambda d: d.stat().st_mtime, default=None)
+
+
+def _read_summary(session: Path) -> Optional[Dict]:
+    p = session / "summary.json"
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def watch_and_verify(
+    *, sessions_dir: Path, primary_root: Path, since_ts: float,
+    timeout_s: float, poll_s: float,
+) -> int:
+    deadline = time.monotonic() + timeout_s
+    print(f"[verifier] watching {sessions_dir}/ for a soak session …",
+          flush=True)
+    session: Optional[Path] = None
+    while session is None:
+        session = _find_latest_session(sessions_dir, since_ts)
+        if session is None:
+            if time.monotonic() > deadline:
+                print("[verifier] TIMEOUT — no session appeared.",
+                      file=sys.stderr)
+                return 3
+            await asyncio.sleep(poll_s)
+    print(f"[verifier] bound to {session.name}; awaiting FSM termination …",
+          flush=True)
+    while True:
+        summary = _read_summary(session)
+        if summary and str(summary.get("session_outcome", "")) in _TERMINAL_OUTCOMES:
+            break
+        if time.monotonic() > deadline:
+            print("[verifier] TIMEOUT — FSM did not finalize; assessing "
+                  "partial state.", file=sys.stderr)
+            break
+        await asyncio.sleep(poll_s)
+
+    log_path = session / "debug.log"
+    debug_log = log_path.read_text(errors="replace") if log_path.is_file() else ""
+    summary = _read_summary(session)
+    # Health context via the SHARED harvester parse.
+    metrics = parse_metrics(debug_log, summary)
+    verdict = assess_isolation(
+        debug_log=debug_log,
+        primary_status_porcelain=_git(["status", "--porcelain"], primary_root),
+        worktree_list_porcelain=_git(["worktree", "list", "--porcelain"],
+                                     primary_root),
+        summary=summary,
+        reap_log="",
+    )
+    print(render(verdict))
+    print(f"  [context] booted={metrics.booted} oom={metrics.oom} "
+          f"cost=${metrics.cost_total or 0:.4f} dur={metrics.duration_s or 0:.0f}s")
+    return 0 if verdict.overall == PASS else (1 if verdict.overall == FAIL else 2)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Sovereign Quarantine Validation")
+    ap.add_argument("--sessions-dir", default=".ouroboros/sessions")
+    ap.add_argument("--primary-root", default=str(_PROJECT_ROOT))
+    ap.add_argument("--timeout", type=float, default=3600.0)
+    ap.add_argument("--poll", type=float, default=3.0)
+    args = ap.parse_args(argv)
+    return asyncio.run(watch_and_verify(
+        sessions_dir=Path(args.sessions_dir),
+        primary_root=Path(args.primary_root),
+        since_ts=time.time(),
+        timeout_s=args.timeout, poll_s=args.poll,
+    ))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_file_isolation.py
+++ b/scripts/verify_file_isolation.py
@@ -273,12 +273,19 @@ def _read_summary(session: Path) -> Optional[Dict]:
 
 async def watch_and_verify(
     *, sessions_dir: Path, primary_root: Path, since_ts: float,
-    timeout_s: float, poll_s: float,
+    timeout_s: float, poll_s: float, pin_session: str = "",
 ) -> int:
     deadline = time.monotonic() + timeout_s
-    print(f"[verifier] watching {sessions_dir}/ for a soak session …",
-          flush=True)
     session: Optional[Path] = None
+    if pin_session:
+        # Deterministic bind to a known session dir — immune to the
+        # autonomous loop spawning a newer bt-* mid-soak.
+        session = sessions_dir / pin_session
+        print(f"[verifier] pinned to {session} — awaiting termination …",
+              flush=True)
+    else:
+        print(f"[verifier] watching {sessions_dir}/ for a soak session …",
+              flush=True)
     while session is None:
         session = _find_latest_session(sessions_dir, since_ts)
         if session is None:
@@ -324,12 +331,15 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--primary-root", default=str(_PROJECT_ROOT))
     ap.add_argument("--timeout", type=float, default=3600.0)
     ap.add_argument("--poll", type=float, default=3.0)
+    ap.add_argument("--session", default="",
+                    help="Pin to a specific session dir name (e.g. bt-…).")
     args = ap.parse_args(argv)
     return asyncio.run(watch_and_verify(
         sessions_dir=Path(args.sessions_dir),
         primary_root=Path(args.primary_root),
         since_ts=time.time(),
         timeout_s=args.timeout, poll_s=args.poll,
+        pin_session=args.session,
     ))
 
 

--- a/scripts/verify_file_isolation.py
+++ b/scripts/verify_file_isolation.py
@@ -271,6 +271,45 @@ def _read_summary(session: Path) -> Optional[Dict]:
         return None
 
 
+def _session_candidate_dirs(session: Path, primary_root: Path) -> List[Path]:
+    """All dirs that may hold THIS session's artifacts. The harness splits
+    debug.log (repo_path-anchored → main) and summary.json (cwd-relative →
+    worktree) when the soak runs from a linked worktree, so search the bound
+    dir AND any worktree sibling session dir of the same name."""
+    cands = [session]
+    try:
+        cands.extend(sorted(primary_root.glob(
+            f".claude/worktrees/*/.ouroboros/sessions/{session.name}")))
+    except Exception:  # noqa: BLE001
+        pass
+    seen, out = set(), []
+    for c in cands:
+        if str(c) not in seen:
+            seen.add(str(c))
+            out.append(c)
+    return out
+
+
+def _read_summary_any(session: Path, primary_root: Path) -> Optional[Dict]:
+    for c in _session_candidate_dirs(session, primary_root):
+        s = _read_summary(c)
+        if s is not None:
+            return s
+    return None
+
+
+def _read_debug_any(session: Path, primary_root: Path) -> str:
+    best = ""
+    for c in _session_candidate_dirs(session, primary_root):
+        lp = c / "debug.log"
+        try:
+            if lp.is_file() and lp.stat().st_size > len(best):
+                best = lp.read_text(errors="replace")
+        except Exception:  # noqa: BLE001
+            continue
+    return best
+
+
 async def watch_and_verify(
     *, sessions_dir: Path, primary_root: Path, since_ts: float,
     timeout_s: float, poll_s: float, pin_session: str = "",
@@ -297,7 +336,7 @@ async def watch_and_verify(
     print(f"[verifier] bound to {session.name}; awaiting FSM termination …",
           flush=True)
     while True:
-        summary = _read_summary(session)
+        summary = _read_summary_any(session, primary_root)
         if summary and str(summary.get("session_outcome", "")) in _TERMINAL_OUTCOMES:
             break
         if time.monotonic() > deadline:
@@ -306,9 +345,8 @@ async def watch_and_verify(
             break
         await asyncio.sleep(poll_s)
 
-    log_path = session / "debug.log"
-    debug_log = log_path.read_text(errors="replace") if log_path.is_file() else ""
-    summary = _read_summary(session)
+    debug_log = _read_debug_any(session, primary_root)
+    summary = _read_summary_any(session, primary_root)
     # Health context via the SHARED harvester parse.
     metrics = parse_metrics(debug_log, summary)
     verdict = assess_isolation(

--- a/tests/governance/test_autonomous_workspace.py
+++ b/tests/governance/test_autonomous_workspace.py
@@ -1,0 +1,126 @@
+"""Sovereign Execution Boundary (Stage B) — autonomous file isolation.
+
+`autonomous_workspace.resolve_loop_project_root` is the single dynamic
+project_root injection (no os.chdir, no global cwd mutation): when file
+isolation is enabled AND the session is autonomous, the loop's project_root
+resolves to an isolated worktree (same `ouroboros/auto/<session>` naming the
+Ledger-Sovereignty phase uses, so the two converge on ONE worktree and the
+existing reaper sweeps it). All 4 delegates (ChangeEngine/BranchManager/
+TestRunner/ToolExecutor) inherit project_root, so this one redirect routes
+every mutation into the quarantine zone.
+
+Gated by JARVIS_FILE_ISOLATION_ENABLED (default off → returns repo_root,
+byte-identical boot). NEVER raises → repo_root fallback.
+
+TDD red: written before the module exists.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import execution_context as ec
+
+
+class _FakeMgr:
+    """Stand-in WorktreeManager: records create() calls, returns a real dir."""
+
+    def __init__(self, base: Path):
+        self._base = base
+        self.created: list[str] = []
+
+    async def create(self, branch: str) -> Path:
+        self.created.append(branch)
+        p = self._base / ("wt_" + branch.replace("/", "__"))
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+
+class _BoomMgr:
+    async def create(self, branch: str) -> Path:
+        raise RuntimeError("disk full")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for k in (
+        "JARVIS_FILE_ISOLATION_ENABLED",
+        "JARVIS_AUTO_COMMIT_WORKSPACE",
+        "JARVIS_OUROBOROS_SESSION_ID",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+async def test_off_returns_repo_root_no_create(tmp_path, monkeypatch):
+    from backend.core.ouroboros.governance import autonomous_workspace as aw
+    mgr = _FakeMgr(tmp_path)
+    out = await aw.resolve_loop_project_root(
+        tmp_path, session_id="bt-1", worktree_manager=mgr,
+    )
+    assert out == tmp_path
+    assert mgr.created == []  # inert when flag off — byte-identical boot
+
+
+async def test_on_but_not_autonomous_returns_repo_root(tmp_path, monkeypatch):
+    from backend.core.ouroboros.governance import autonomous_workspace as aw
+    monkeypatch.setenv("JARVIS_FILE_ISOLATION_ENABLED", "true")
+    monkeypatch.setattr(ec, "is_autonomous", lambda *a, **k: False)
+    mgr = _FakeMgr(tmp_path)
+    out = await aw.resolve_loop_project_root(
+        tmp_path, session_id="bt-1", worktree_manager=mgr,
+    )
+    assert out == tmp_path  # human session → primary checkout
+    assert mgr.created == []
+
+
+async def test_on_and_autonomous_routes_to_worktree(tmp_path, monkeypatch):
+    from backend.core.ouroboros.governance import autonomous_workspace as aw
+    monkeypatch.setenv("JARVIS_FILE_ISOLATION_ENABLED", "true")
+    monkeypatch.setattr(ec, "is_autonomous", lambda *a, **k: True)
+    mgr = _FakeMgr(tmp_path)
+    out = await aw.resolve_loop_project_root(
+        tmp_path, session_id="bt-xyz", worktree_manager=mgr,
+    )
+    assert out != tmp_path
+    assert out.is_dir()
+    # Same naming as the Ledger Sovereignty phase → one unified worktree,
+    # swept by the existing ouroboros/auto/* reaper.
+    assert mgr.created == ["ouroboros/auto/bt-xyz"]
+
+
+async def test_autonomous_route_unifies_commit_workspace_env(
+    tmp_path, monkeypatch,
+):
+    import os
+    from backend.core.ouroboros.governance import autonomous_workspace as aw
+    monkeypatch.setenv("JARVIS_FILE_ISOLATION_ENABLED", "true")
+    monkeypatch.setattr(ec, "is_autonomous", lambda *a, **k: True)
+    mgr = _FakeMgr(tmp_path)
+    out = await aw.resolve_loop_project_root(
+        tmp_path, session_id="bt-1", worktree_manager=mgr,
+    )
+    # Reuses the existing commit-workspace handoff env so AutoCommitter +
+    # ChangeEngine converge on the SAME worktree (not new global cwd state).
+    assert os.environ["JARVIS_AUTO_COMMIT_WORKSPACE"] == str(out)
+
+
+async def test_create_failure_falls_back_to_repo_root(tmp_path, monkeypatch):
+    from backend.core.ouroboros.governance import autonomous_workspace as aw
+    monkeypatch.setenv("JARVIS_FILE_ISOLATION_ENABLED", "true")
+    monkeypatch.setattr(ec, "is_autonomous", lambda *a, **k: True)
+    out = await aw.resolve_loop_project_root(
+        tmp_path, session_id="bt-1", worktree_manager=_BoomMgr(),
+    )
+    # Fail-safe: stay in primary (the Stage A commit-gate still blocks any
+    # autonomous commit there, so no silent harm).
+    assert out == tmp_path
+
+
+def test_file_isolation_flag_default_off(monkeypatch):
+    from backend.core.ouroboros.governance import autonomous_workspace as aw
+    monkeypatch.delenv("JARVIS_FILE_ISOLATION_ENABLED", raising=False)
+    assert aw.file_isolation_enabled() is False
+    monkeypatch.setenv("JARVIS_FILE_ISOLATION_ENABLED", "true")
+    assert aw.file_isolation_enabled() is True

--- a/tests/governance/test_file_isolation_pins.py
+++ b/tests/governance/test_file_isolation_pins.py
@@ -1,0 +1,61 @@
+"""Sovereign Execution Boundary (Stage B) — inheritance + wiring pins.
+
+Stage B's single-redirect design (route the orchestrator's project_root into
+an isolated worktree) only quarantines mutations IF every delegate derives its
+working dir from the injected root. These pins LOCK that property: if a future
+refactor makes a delegate use os.getcwd()/an independent `git rev-parse`
+instead of its passed root, the isolation silently breaks — and these fail.
+
+Source-inspection pins (the established AST/source-pin idiom): cheap, robust,
+no heavy object construction.
+"""
+from __future__ import annotations
+
+import inspect
+
+
+def _src(modpath: str) -> str:
+    import importlib
+    return inspect.getsource(importlib.import_module(modpath))
+
+
+def test_branch_manager_git_runs_in_injected_repo_path():
+    src = _src("backend.core.ouroboros.battle_test.branch_manager")
+    # git checkout -b runs against the injected repo_path, not ambient cwd.
+    assert 'self._repo_path = Path(repo_path)' in src
+    assert '"-C", str(self._repo_path)' in src
+
+
+def test_test_runner_pytest_cwd_falls_back_to_injected_repo_root():
+    src = _src("backend.core.ouroboros.governance.test_runner")
+    assert "self._repo_root" in src
+    assert "else str(self._repo_root)" in src  # pytest effective_cwd
+
+
+def test_change_engine_writes_under_injected_project_root():
+    src = _src("backend.core.ouroboros.governance.change_engine")
+    assert "self._project_root = Path(project_root)" in src
+    # _effective_write_root falls back to project_root.
+    assert "self._project_root" in src
+
+
+def test_tool_executor_bash_cwd_is_injected_repo_root():
+    src = _src("backend.core.ouroboros.governance.tool_executor")
+    assert "self._repo_root = repo_root" in src
+    assert "cwd=self._repo_root" in src or "cwd=str(self._repo_root)" in src
+
+
+def test_harness_redirects_project_root_via_resolver():
+    src = _src("backend.core.ouroboros.battle_test.harness")
+    # The single dynamic injection point feeds GLS config from the resolver.
+    assert "resolve_loop_project_root(" in src
+    assert "project_root=_loop_root" in src
+    # And the Ledger phase yields to a Stage-B-created worktree (no dup).
+    assert "reusing file-isolation worktree" in src
+
+
+def test_resolver_uses_same_branch_naming_as_ledger_sovereignty():
+    # File + commit isolation MUST converge on one worktree (swept by the
+    # existing ouroboros/auto/* reaper).
+    from backend.core.ouroboros.governance import autonomous_workspace as aw
+    assert aw.workspace_branch("bt-1") == "ouroboros/auto/bt-1"

--- a/tests/governance/test_verify_file_isolation.py
+++ b/tests/governance/test_verify_file_isolation.py
@@ -1,0 +1,122 @@
+"""Tests for the Stage B file-isolation soak verifier's pure assessment."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load():
+    path = _ROOT / "scripts" / "verify_file_isolation.py"
+    spec = importlib.util.spec_from_file_location("vfi_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+vfi = _load()
+
+_ROUTED = (
+    "[FileIsolation] routed project_root -> "
+    "/repo/.worktrees/ouroboros__auto__bt-2026-06-16-x "
+    "(session=bt-2026-06-16-x branch=ouroboros/auto/bt-2026-06-16-x)"
+)
+_QPATH = "/repo/.worktrees/ouroboros__auto__bt-2026-06-16-x"
+_COMPLETE = {"session_outcome": "complete"}
+
+
+def test_all_invariants_pass():
+    log = (
+        "phase=GENERATE\n" + _ROUTED + "\n"
+        f"APPLY wrote {_QPATH}/backend/x.py\n"
+        f"VALIDATE cwd={_QPATH}\n"
+    )
+    v = vfi.assess_isolation(
+        debug_log=log,
+        primary_status_porcelain="",          # primary clean
+        worktree_list_porcelain="",            # not listed → reaped
+        summary=_COMPLETE,
+    )
+    assert v.overall == vfi.PASS
+    assert v.quarantine_path == _QPATH
+    keys = {i.key: i.status for i in v.invariants}
+    assert keys["I1_worktree_initialized"] == vfi.PASS
+    assert keys["I2_mutations_quarantined"] == vfi.PASS
+    assert keys["I3_primary_pristine"] == vfi.PASS
+    assert keys["I4_worktree_reaped"] == vfi.PASS
+
+
+def test_primary_dirty_fails_i3():
+    log = "phase=GENERATE\n" + _ROUTED + "\n" + _QPATH + " again\n"
+    v = vfi.assess_isolation(
+        debug_log=log,
+        primary_status_porcelain=" M backend/core/ouroboros/x.py\n",
+        worktree_list_porcelain="",
+        summary=_COMPLETE,
+    )
+    assert v.overall == vfi.FAIL
+    keys = {i.key: i.status for i in v.invariants}
+    assert keys["I3_primary_pristine"] == vfi.FAIL
+
+
+def test_primary_soak_artifacts_ignored():
+    # .ouroboros/.worktrees/.jarvis untracked noise must NOT fail I3.
+    porcelain = (
+        "?? .ouroboros/sessions/bt-x/\n"
+        "?? .worktrees/ouroboros__auto__bt-x/\n"
+        "?? .jarvis/episodic_memory.jsonl\n"
+    )
+    log = "phase=GENERATE\n" + _ROUTED + "\n" + _QPATH + " ref\n"
+    v = vfi.assess_isolation(
+        debug_log=log, primary_status_porcelain=porcelain,
+        worktree_list_porcelain="", summary=_COMPLETE,
+    )
+    keys = {i.key: i.status for i in v.invariants}
+    assert keys["I3_primary_pristine"] == vfi.PASS
+
+
+def test_no_routing_marker_fails_i1():
+    v = vfi.assess_isolation(
+        debug_log="phase=GENERATE\nno isolation here\n",
+        primary_status_porcelain="", worktree_list_porcelain="",
+        summary=_COMPLETE,
+    )
+    keys = {i.key: i.status for i in v.invariants}
+    assert keys["I1_worktree_initialized"] == vfi.FAIL
+    assert v.overall == vfi.FAIL
+
+
+def test_incomplete_session_is_incomplete():
+    v = vfi.assess_isolation(
+        debug_log=_ROUTED, primary_status_porcelain="",
+        worktree_list_porcelain="",
+        summary={"session_outcome": ""},
+    )
+    assert v.overall == vfi.INCOMPLETE
+
+
+def test_worktree_still_listed_warns_i4():
+    log = "phase=GENERATE\n" + _ROUTED + "\n" + _QPATH + " ref\n"
+    v = vfi.assess_isolation(
+        debug_log=log, primary_status_porcelain="",
+        worktree_list_porcelain=f"worktree {_QPATH}\nHEAD abc\n",
+        summary=_COMPLETE,
+    )
+    keys = {i.key: i.status for i in v.invariants}
+    assert keys["I4_worktree_reaped"] == vfi.WARN
+    assert v.overall == vfi.WARN
+
+
+def test_reaped_via_log_passes_i4_even_if_listed():
+    log = "phase=GENERATE\n" + _ROUTED + "\n" + _QPATH + " ref\n"
+    v = vfi.assess_isolation(
+        debug_log=log, primary_status_porcelain="",
+        worktree_list_porcelain=f"worktree {_QPATH}\n",
+        summary=_COMPLETE,
+        reap_log="[WorktreeManager] reaped ouroboros/auto/bt-2026-06-16-x",
+    )
+    keys = {i.key: i.status for i in v.invariants}
+    assert keys["I4_worktree_reaped"] == vfi.PASS


### PR DESCRIPTION
## Sovereign Execution Boundary — Stage B (file isolation)

Stage A blocked the autonomous loop from **committing** in the operator's primary checkout. Stage B closes the remaining **file-mutation** vector — the `git checkout -b` / GENERATE writes / VALIDATE subprocesses that ran in the primary tree (the actual cause of the working-tree reverts) — by routing the loop's `project_root` into an isolated worktree.

### The key insight
The orchestrator has 84 `project_root` refs but **zero direct `subprocess.run`** — it delegates to ChangeEngine, BranchManager, TestRunner, ToolExecutor, and **all four already derive their cwd/write-root from the injected `project_root`**. So isolation needs **one constructor-time redirect**, not a cwd-threading sweep across the codebase. No `os.chdir`, no global cwd state (exactly as mandated).

### What landed
- **`autonomous_workspace.resolve_loop_project_root`** — dynamic `project_root` resolution. When `JARVIS_FILE_ISOLATION_ENABLED` is on AND the session is autonomous (Stage A's cryptographic `is_autonomous`), resolves to an isolated worktree using the **same `ouroboros/auto/<session>` naming** as the Ledger-Sovereignty commit phase → file + commit isolation **converge on one worktree**, swept by the existing reaper. NEVER raises → `repo_root` fallback (and the Stage A commit-gate still blocks commits there, so a fallback can't silently corrupt the tree).
- **Single redirect** at `harness.py` `boot_governed_loop_service` (before the orchestrator config is frozen). Off (default) → `repo_path` → **byte-identical boot**.
- **Ledger-Sovereignty phase yields** to the Stage-B worktree (no double-create).
- **Inheritance pins** lock the property the whole design rests on — if any delegate ever switches to `os.getcwd()`/independent `git rev-parse`, isolation breaks and the pin fails.

### Phase 3 "seamless handoff" — satisfied by reuse
`git worktree add` copies main state into the quarantine zone; all mutations happen there; the existing AutoCommitter (commits in the worktree) + auto-loop branch → PR flow surfaces the PR on graduation.

### Verification
12 Stage B tests + 29 harness/sovereignty/reap regression tests green.

### Graduation note
Ships **dark** (default-off). The boot path can't be exercised by unit tests, so graduation is a **live headless soak** with `JARVIS_FILE_ISOLATION_ENABLED=true` (verify the loop's worktree gets created, mutations land there, the primary tree stays clean, the worktree is reaped next boot). Authored in an isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the autonomous loop’s file writes and git ops into an isolated worktree so the primary checkout stays untouched. Adds an observability marker and a soak verifier to prove isolation end-to-end; ships dark by default.

- **New Features**
  - Added `autonomous_workspace.resolve_loop_project_root`: when `JARVIS_FILE_ISOLATION_ENABLED` is on and the session is autonomous, route to `ouroboros/auto/<session>` and export `JARVIS_AUTO_COMMIT_WORKSPACE`; otherwise return `repo_root`.
  - Redirected `project_root` in `boot_governed_loop_service` to the resolver output; Ledger phase reuses the same worktree; no `os.chdir` or global cwd state.
  - Emitted a grep-stable `[FileIsolation] routed project_root -> <wt> (session=.. branch=..)` marker for soak validation.
  - Added `scripts/verify_file_isolation.py` to check I1–I4 (worktree initialized, mutations quarantined, primary pristine, worktree reaped) using shared telemetry parsing; now handles harness path-split by searching both repo-anchored and worktree-bound session dirs for `debug.log` and `summary.json`; added tests and pins to ensure delegates derive cwd/write roots from the injected `project_root`.
  - Verifier supports `--session <bt-…>` to pin a specific soak session and avoid binding to concurrent runs.

- **Migration**
  - Default off. To soak: set `JARVIS_FILE_ISOLATION_ENABLED=true`, run the loop, then run `python3 scripts/verify_file_isolation.py --sessions-dir .ouroboros/sessions --primary-root <repo_root> [--session <bt-…>]` to confirm isolation and reaping.

<sup>Written for commit 4bf24729ce4160671eb490644966c6c585125cc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

