### PR TITLE
Slice 257: Battle-Test Loop-Starvation Hardening — first clean session_outcome=complete

### DIFF
--- a/backend/core/ouroboros/governance/graduation/telemetry_parse.py
+++ b/backend/core/ouroboros/governance/graduation/telemetry_parse.py
@@ -41,8 +41,16 @@ _RE_RETRY = re.compile(r"GENERATE_RETRY|VALIDATE_RETRY")
 _RE_RECOVERED = re.compile(r"state=applied|state=complete|phase=COMPLETE")
 _RE_GATE_INERT = re.compile(r"GATE INERT")
 _RE_TIMEOUT = re.compile(r"LiveFireTimeout|live-fire exceeded")
+# Genuine memory-cap FIRE only. Slice 257 — the previous pattern matched bare
+# ``process_memory_cap`` / ``OOM``, which also matched the ProcessMemoryWatchdog
+# *arming* line ("armed: warn=…MB cap=…MB — graceful stop_reason=
+# process_memory_cap before OS OOM-kill"). That line merely DESCRIBES the cap;
+# arming is not firing. bt-2026-06-16-063106 completed cleanly at rss=555MB
+# (cap 12288MB) via wall_clock_cap yet was mis-verdicted ANOMALY/OOM. The
+# watchdog logs "Session X stopping: process_memory_cap" only when it actually
+# trips, and stamps summary.stop_reason=process_memory_cap — both authoritative.
 _RE_OOM = re.compile(
-    r"process_memory_cap|MemoryError|\bOOM\b|emergency_brake|"
+    r"stopping: process_memory_cap|MemoryError|emergency_brake|"
     r"memory_pressure_changed.*(critical|emergency)",
 )
 
@@ -108,6 +116,10 @@ def parse_metrics(
         m.stop_reason = str(summary.get("stop_reason", ""))
         m.cost_total = summary.get("cost_total")
         m.duration_s = summary.get("duration_s")
+    # Authoritative memory-cap signal: when the ProcessMemoryWatchdog actually
+    # fires it produces a graceful summary with stop_reason=process_memory_cap.
+    # (The log-regex above catches the same fire + MemoryError / pressure.)
+    m.oom = m.oom or m.stop_reason == "process_memory_cap"
     return m
 
 

--- a/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
@@ -267,6 +267,11 @@ def _todo_fixme_count(source: str) -> int:
 # classification): this set is about NEVER TRAVERSING heavy/non-source trees.
 _WALK_PRUNE_SEGMENTS: frozenset = frozenset({
     ".jarvis", ".worktrees", ".ouroboros",
+    # Slice 257 — Claude Code agent worktrees (``.claude/worktrees/<name>``)
+    # are full duplicate checkouts; pruning ``.claude`` stops the miner walk
+    # from descending into them (the Oracle leak that SIGKILLed
+    # bt-2026-06-16-042304 — same root cause, sibling scanner).
+    ".claude",
     ".git", "node_modules", "__pycache__",
     ".venv", "venv", ".mypy_cache", ".pytest_cache",
     "build", "dist", ".eggs",

--- a/backend/core/ouroboros/governance/posture_observer.py
+++ b/backend/core/ouroboros/governance/posture_observer.py
@@ -262,6 +262,27 @@ class SignalCollector:
             return []
         return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
 
+    def _git_head(self) -> str:
+        """Sync ``git rev-parse HEAD`` — the cheap cache anchor.
+
+        Slice 257 — paired with :meth:`_git_subjects` for the off-loop
+        ``commit_ratios_async`` path. Runs in the dedicated
+        ``fs_signal_executor`` thread, so even a slow fork (large
+        multi-threaded process) blocks a worker, never the event loop.
+        Returns "" on any failure so a stale value can't pin the cache.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=str(self._root), capture_output=True, text=True,
+                timeout=2.0, check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return ""
+        if result.returncode != 0:
+            return ""
+        return result.stdout.strip()
+
     async def _git_subjects_async(self, n: int) -> List[str]:
         """Slice 33 Arc 2 Phase 1 — async git subprocess.
 
@@ -372,25 +393,34 @@ class SignalCollector:
         }
 
     async def commit_ratios_async(self) -> Dict[str, float]:
-        """Slice 33 Arc 2 Phase 1 — async-native commit ratios.
+        """Async commit ratios — git work offloaded to a worker thread.
 
-        Same semantics as sync :meth:`commit_ratios`, but the git log
-        runs via ``create_subprocess_exec`` — no thread-pool slot
-        consumed even during cold-cache 18 s scans.
+        Slice 257 (bt-2026-06-16-052242, 108.9s loop wedge → near-fatal
+        heartbeat-stale SIGKILL): the previous implementation resolved HEAD
+        and the 100-commit ``git log`` via ``asyncio.create_subprocess_exec``,
+        which forks/execs the child **on the event-loop thread**. From the
+        large, multi-threaded organism process — concurrent with the Oracle
+        process pool forking 16 cold-index workers — that fork blocked the
+        loop synchronously for 33–108s (the ``git log`` query itself is
+        0.14s; the cost is the fork, not the work). Because the block is
+        synchronous and yield-less, the 30s collector ``wait_for`` could not
+        cancel it and ``ControlPlaneStarvation`` stayed silent — the heartbeat
+        froze and the 120s external watchdog SIGKILLed the session.
 
-        Slice 52 Phase 2 — reactive cache: a cheap ``git rev-parse HEAD``
-        gate short-circuits the 100-commit ``git log`` whenever HEAD has
-        not advanced since the last computation (the common case at the
-        300s cadence — this is what was costing up to 9.8s/cycle in v46).
-        Recomputes when HEAD moves; never caches when HEAD is unresolvable
-        so a stale value can't pin the posture.
+        The fix runs the git calls in the dedicated ``fs_signal_executor``
+        (the pool the other fs-backed signals already use). A slow fork now
+        blocks a worker thread, never the loop, so the heartbeat keeps
+        beating. ``subprocess.run`` timeouts (2s HEAD / 5s log) still bound
+        the work; the Slice 52 HEAD-cache short-circuit is preserved.
         """
+        loop = asyncio.get_running_loop()
+        executor = _get_fs_signal_executor()
         window = commit_window()
-        head = await self._git_head_async()
+        head = await loop.run_in_executor(executor, self._git_head)
         cache = self._commit_ratios_cache
         if head and cache is not None and cache[0] == head and cache[1] == window:
             return dict(cache[2])
-        subjects = await self._git_subjects_async(window)
+        subjects = await loop.run_in_executor(executor, self._git_subjects, window)
         ratios = self._compute_commit_ratios(subjects)
         if head:
             self._commit_ratios_cache = (head, window, dict(ratios))

--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -188,6 +188,15 @@ class OracleConfig:
         # dir (swe_bench checkouts, session telemetry, locks) — never source
         # to index. Substring ``.jarvis`` covers the entire subtree.
         ".jarvis",
+        # Slice 257 — Claude Code's agent worktrees live under
+        # ``.claude/worktrees/<name>`` (each a full 29k-file checkout). The
+        # ``.worktrees`` pattern above does NOT match ``.claude/worktrees``
+        # (slash, not dot), so the Oracle recursed into all of them and
+        # ast-parsed 6× the tree → process-pool saturation → loop
+        # starvation → stale heartbeat → ExternalWatchdog SIGKILL
+        # (bt-2026-06-16-042304, exit 137). ``.claude`` is tooling state,
+        # never source to index — substring covers the whole subtree.
+        ".claude",
     ]
 
     # File types to index
@@ -218,6 +227,41 @@ def _is_oracle_legacy_thread_mode() -> bool:
     / unset / unrecognized → False (new path active)."""
     raw = os.environ.get(_ORACLE_LEGACY_THREAD_MODE_ENV, "").strip().lower()
     return raw in ("1", "true", "yes", "on")
+
+
+def _is_linked_git_worktree(path: Path) -> bool:
+    """Return True iff ``path`` is the root of a *linked* git worktree.
+
+    Slice 257 — the static EXCLUDE_PATTERNS substring list can only catch
+    worktrees whose parent directory we already know to name (``.worktrees``,
+    ``.claude``, ``.jarvis/.../worktrees``). This is the general guard for any
+    future ``git worktree add`` location, with no hardcoded names.
+
+    The discriminator is exact, not heuristic: ``git worktree add`` creates a
+    ``.git`` **file** holding ``gitdir: <path>`` — never a directory. So:
+
+      * linked worktree  → ``<dir>/.git`` is a FILE   → skip (duplicate
+        checkout, 0 files tracked by the main repo)
+      * embedded clone /
+        first-class source → ``<dir>/.git`` is a DIR  → DO NOT skip
+        (e.g. ``backend/vision`` is a stray nested repo but its 229 ``.py``
+        files are tracked source the organism reasons about)
+      * the main repo root → ``.git`` is a DIR        → never skipped
+
+    Indexing 6× duplicate worktree checkouts is what saturated the process
+    pool, starved the asyncio loop, and tripped the ExternalWatchdog SIGKILL
+    in bt-2026-06-16-042304. Targeting *only* the file-``.git`` case removes
+    that load without dropping any real source from the index.
+
+    Fail-soft by construction: any OSError (permission, race, odd path) is
+    swallowed and treated as "not a worktree", so the guard can only ever
+    *add* exclusions for true linked worktrees — never crash the walk or skip
+    legitimate source.
+    """
+    try:
+        return (path / ".git").is_file()
+    except OSError:
+        return False
 
 
 # Slice 33 Arc 2 Phase 3 — async graph-write queue master switch.
@@ -2309,6 +2353,15 @@ class TheOracle:
                     if should_exclude(item):
                         continue
                     if item.is_dir():
+                        # Slice 257 — never descend into a linked git worktree
+                        # (a duplicate checkout whose files are not tracked
+                        # source). General, no-hardcoding guard that catches
+                        # any future `git worktree add` location the static
+                        # EXCLUDE_PATTERNS list does not yet name, while
+                        # preserving embedded clones that ARE real source
+                        # (e.g. backend/vision).
+                        if _is_linked_git_worktree(item):
+                            continue
                         scan_dir(item)
                     elif item.suffix in OracleConfig.SUPPORTED_EXTENSIONS:
                         python_files.append(item)

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -1,6 +1,8 @@
 # Ouroboros + Venom (O+V) — Product Requirements Document & Roadmap
 
-**Version**: 3.27 (2026-06-12 — **§51.11.34 added — Soak Reliability + Token-Economic Arc (Slices 217-224)** (five-layer onion: funding->sleep->Aegis-token-1h-expiry->stale-ledger-hostage->sensor-self-DDoS; audited soak spend ~$1.90 not $26; P2a cache + /spend + $2/h rail COMPLETE; BLUNT: cost solved, file-00 still won't dispatch -> autonomy blocker is non-economic; roadmap A1 trace-dispatch > A2 QoS > B1 Claude-Batch > B2 compression > B3 UCCI-calibration > C1 /session/refresh > C2 non-sleeping-host). — full version history in OUROBOROS_VENOM_PRD_HISTORY.md)
+**Version**: 3.28 (2026-06-15 — **§3.8 added — Slice 257 Battle-Test Loop-Starvation Hardening** (first clean `session_outcome=complete` after a wave of `heartbeat_stale` SIGKILLs: four event-loop / shutdown / telemetry wedges fixed — Oracle over-indexing `.claude/worktrees` (29.5k duplicate `.py`), posture `commit_ratios` forking git ON the loop thread (108s block), Oracle shutdown cache-write wedge, harvester false-positive OOM; 41 regression tests green; merged to main). — see §3.7 below)
+>
+> 3.27 (2026-06-12 — **§51.11.34 added — Soak Reliability + Token-Economic Arc (Slices 217-224)** (five-layer onion: funding->sleep->Aegis-token-1h-expiry->stale-ledger-hostage->sensor-self-DDoS; audited soak spend ~$1.90 not $26; P2a cache + /spend + $2/h rail COMPLETE; BLUNT: cost solved, file-00 still won't dispatch -> autonomy blocker is non-economic; roadmap A1 trace-dispatch > A2 QoS > B1 Claude-Batch > B2 compression > B3 UCCI-calibration > C1 /session/refresh > C2 non-sleeping-host). — full version history in OUROBOROS_VENOM_PRD_HISTORY.md)
 
 > **📑 This PRD is split across four files (the single doc grew past GitHub's render limit).**
 > - **`OUROBOROS_VENOM_PRD.md`** (this file) — the core spec: §1–§23 + Table of Contents.
@@ -886,6 +888,26 @@ These five are in addition to the four primary picks (Kimi-K2.6, GLM-5.1, Qwen3.
 - **Slice 6**: 24h soak validation + flag-default flip + lock in cost-per-op trending downward.
 
 See §9 Phase 10 for the full slice-by-slice plan.
+
+---
+
+### 3.8 Slice 257 — Battle-Test Loop-Starvation Hardening *(NEW 2026-06-15)*
+
+**The first clean `session_outcome=complete` after a wave of `heartbeat_stale` SIGKILLs.** Battle-test sessions kept finalizing as `in_flight` instead of `complete` because the out-of-process `ExternalWatchdog` SIGKILLed the process (`exit 137`, `reason=heartbeat_stale`) whenever the main asyncio loop starved long enough (≥120s, `JARVIS_EXTERNAL_WATCHDOG_STALE_S`) to freeze the on-loop heartbeat tick — so `_generate_report` (the only path that stamps `session_outcome=complete`) never ran. Forensic root-cause work across `bt-2026-06-16-042304 / 050048 / 052242 / 060619` isolated **four distinct wedges**, each unmasking the next. The deterministic fixes (no brute-force, no retries):
+
+1. **Oracle over-indexed `.claude/worktrees`.** `oracle.py::_find_python_files.should_exclude()` substring-matches `OracleConfig.EXCLUDE_PATTERNS`; the existing `.worktrees` entry never matched `.claude/worktrees` (slash, not dot), so the Oracle recursed into all of Claude Code's agent worktrees — **29,558 duplicate `.py` (~6× the 6,051-file real tree)** — and ast-parsed them every cycle, saturating the process pool and blocking the loop ~73s.
+   - **Fix:** add `.claude` to `EXCLUDE_PATTERNS` *and* the miner's `_WALK_PRUNE_SEGMENTS`; plus a general, no-hardcoding guard `_is_linked_git_worktree(path)` — the walk skips any directory whose `.git` is a **file** (`git worktree add` creates a `gitdir:` pointer file), catching every future worktree location while preserving embedded clones whose `.git` is a **directory** and whose files are real tracked source (e.g. `backend/vision`'s 229 `.py`).
+2. **Posture `commit_ratios` forked git ON the event-loop thread.** `posture_observer.py::commit_ratios_async` resolved HEAD + the 100-commit `git log` via `asyncio.create_subprocess_exec`, which forks/execs the child on the loop thread. From the large multi-threaded organism process — concurrent with the Oracle cold-index forking 16 workers — that fork blocked the loop **33–108s** (`git log` itself is 0.14s; the cost is the *fork*, not the query). The block is synchronous and yield-less, so the 30s collector `wait_for` could not cancel it and `ControlPlaneStarvation` stayed silent; 108.9s came within ~11s of the SIGKILL.
+   - **Fix:** run the git calls in the dedicated `fs_signal_executor` (the pool the other fs-backed posture signals already use) so a slow fork blocks a worker thread, never the loop. The Slice 52 HEAD-cache short-circuit and `subprocess.run` timeouts are preserved. After: `ControlPlaneStarvation 0`, heartbeat fresh, no SIGKILL.
+3. **Shutdown wedged on the Oracle cache write.** `_shutdown_components` → Oracle `_write_cache_blocking` (`cache_path.write_bytes` of the graph cache) cannot be interrupted by its 5s deadline (blocking C-level write), exceeding the 30s `BoundedShutdownWatchdog` → `os._exit(75)` before `_generate_report`. Mitigated operationally for soaks via the **existing designed flag** `JARVIS_ORACLE_SHUTDOWN_DEADLINE_S=0` (skips the shutdown cache save; rebuilds next boot). *Follow-up: make the cache write bounded/interruptible.*
+4. **Harvester false-positive OOM.** `graduation/telemetry_parse.py::_RE_OOM` matched bare `process_memory_cap`/`OOM`, which also matched the `ProcessMemoryWatchdog` *arming* line ("armed: … stop_reason=process_memory_cap before OS OOM-kill") — so a clean `wall_clock_cap` stop at `rss=555MB` (cap 12288MB) was mis-verdicted ANOMALY/OOM. **Fix:** match the genuine *fire* (`stopping: process_memory_cap`) + `MemoryError`/`emergency_brake`/critical-pressure, plus OR the authoritative `summary.stop_reason == "process_memory_cap"`.
+
+**Evidence:** `bt-2026-06-16-063106` → `session_outcome=complete`, `stop_reason=wall_clock_cap`, `dur=759s`, **0 new infra-noise classes** (only `cancelled_shutdown`, a baseline class). `telemetry_harvester.py` report — Metric A `booted=True`; Metric B all-false (self-heal UNEXERCISED — no kernel-touching candidate reached the default-off live-fire gate); Metric C all-false (`gate_inert=False / livefire_timeout=False / oom=False`); verdict OPERATIONAL_UNEXERCISED. **41 regression tests green** (`test_slice257_claude_worktree_exclusion`, `test_slice257_posture_git_offloop`, `test_telemetry_harvester`, `test_slice49_scanner_exclusions`, `test_slice44_worktree_reaper`).
+
+**Operational notes (load-bearing for future soaks):**
+- The autonomous organism resets the shared checkout to `origin/main` mid-run — **commit fixes to a branch (or isolate in a worktree) before running the battle test**; running *from* the fix branch keeps it active (the harness branches `ouroboros/battle-test/<ts>` from current HEAD).
+- The battle test needs unsandboxed socket bind (Aegis IPC daemon) + provider network.
+- Claude (Tier-1 fallback) being out of credit is the 3-tier failback case; leave it **enabled** — `JARVIS_PROVIDER_CLAUDE_DISABLED=true` removes the fallback DW model-dispatch needs (`sentinel_dispatch_no_fallback` churn). DW (Tier-0 primary) carries the load; the Claude economic breaker trips fast and demotes IMMEDIATE→STANDARD→DW.
 
 ---
 

--- a/tests/governance/test_slice257_claude_worktree_exclusion.py
+++ b/tests/governance/test_slice257_claude_worktree_exclusion.py
@@ -1,0 +1,100 @@
+"""Slice 257 — exclude ``.claude/worktrees`` + any nested git boundary.
+
+Root cause (bt-2026-06-16-042304, exit 137 ``ExternalWatchdog`` SIGKILL):
+the Oracle's ``should_exclude`` does a *substring* match against
+``EXCLUDE_PATTERNS``. Slice 44 added ``.worktrees`` but the path
+``/repo/.claude/worktrees/<wt>/...`` contains ``/worktrees`` (slash), not
+``.worktrees`` (dot), so the pattern never matched. Result: the Oracle
+recursed into all 6 agent worktrees under ``.claude/worktrees`` — each a
+full 29k-file checkout — and ast-parsed 6× the tree. The process pool
+saturated, the main asyncio loop starved (LoopSink:
+``posture_observer.run_one_cycle blocked_ms=73191``), the heartbeat went
+stale, and the out-of-process ``ExternalWatchdog`` SIGKILLed the session
+before it could reach ``_generate_report`` → summary frozen at ``in_flight``.
+
+Two layers of fix, both pinned here:
+  §1  STATIC — ``.claude`` joins the Oracle EXCLUDE_PATTERNS + the miner
+      ``_WALK_PRUNE_SEGMENTS`` (cheap fast-path, mirrors ``.jarvis``).
+  §2  DYNAMIC — the Oracle never recurses into a directory that is itself a
+      *linked* git worktree (``<dir>/.git`` is a FILE). This is the general,
+      no-hardcoding guard: any future ``git worktree add`` location is
+      auto-excluded, while embedded clones that ARE real source
+      (``backend/vision`` — ``.git`` is a DIR) are preserved.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.oracle import (
+    OracleConfig,
+    _is_linked_git_worktree,
+)
+from backend.core.ouroboros.governance.intake.sensors.opportunity_miner_sensor import (
+    _WALK_PRUNE_SEGMENTS,
+    _iter_python_files_pruned,
+)
+
+
+# ── §1 static pattern coverage ──────────────────────────────────────────
+def test_oracle_excludes_dot_claude() -> None:
+    assert ".claude" in set(OracleConfig.EXCLUDE_PATTERNS)
+
+
+def test_oracle_substring_excludes_claude_worktrees() -> None:
+    path = "/repo/.claude/worktrees/deploy256/backend/core/trinity_monitoring.py"
+    assert any(p in path for p in OracleConfig.EXCLUDE_PATTERNS)
+
+
+def test_miner_prune_segments_include_dot_claude() -> None:
+    assert ".claude" in _WALK_PRUNE_SEGMENTS
+
+
+def test_miner_walk_prunes_claude_worktrees(tmp_path: Path) -> None:
+    (tmp_path / "backend").mkdir()
+    (tmp_path / "backend" / "real.py").write_text("x = 1\n")
+    wt = tmp_path / ".claude" / "worktrees" / "deploy256" / "backend"
+    wt.mkdir(parents=True)
+    (wt / "dup.py").write_text("y = 2\n")
+
+    found = _iter_python_files_pruned(tmp_path, _WALK_PRUNE_SEGMENTS)
+    names = {p.name for p in found}
+    assert "real.py" in names
+    assert "dup.py" not in names
+    assert all(".claude" not in p.parts for p in found)
+
+
+# ── §2 dynamic linked-worktree guard (file-.git only) ───────────────────
+def test_linked_worktree_detected_by_gitfile(tmp_path: Path) -> None:
+    # A linked worktree (``git worktree add``) has a ``.git`` *file*.
+    wt = tmp_path / "some-worktree"
+    wt.mkdir()
+    (wt / ".git").write_text("gitdir: /repo/.git/worktrees/some-worktree\n")
+    assert _is_linked_git_worktree(wt) is True
+
+
+def test_embedded_clone_with_gitdir_is_NOT_skipped(tmp_path: Path) -> None:
+    # A nested clone (``.git`` is a DIRECTORY) may hold first-class tracked
+    # source (e.g. backend/vision: 229 real .py). It must NOT be skipped —
+    # only file-.git linked worktrees are duplicate checkouts.
+    sub = tmp_path / "vendored"
+    (sub / ".git").mkdir(parents=True)
+    assert _is_linked_git_worktree(sub) is False
+
+
+def test_linked_worktree_false_for_plain_source_dir(tmp_path: Path) -> None:
+    pkg = tmp_path / "backend" / "core"
+    pkg.mkdir(parents=True)
+    (pkg / "real.py").write_text("x = 1\n")
+    assert _is_linked_git_worktree(pkg) is False
+
+
+def test_linked_worktree_fail_soft_on_bad_path() -> None:
+    # Never raises — a non-existent / odd path resolves to "not a worktree"
+    # so the guard can only ever *add* exclusions, never crash the walk.
+    assert _is_linked_git_worktree(Path("/nonexistent/zzz/qqq")) is False
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/governance/test_slice257_posture_git_offloop.py
+++ b/tests/governance/test_slice257_posture_git_offloop.py
@@ -1,0 +1,109 @@
+"""Slice 257 — posture ``commit_ratios`` git must run OFF the event loop.
+
+Root cause (bt-2026-06-16-052242, near-fatal 108.9s loop wedge):
+``SignalCollector.commit_ratios_async`` resolved HEAD + the 100-commit
+``git log`` via ``asyncio.create_subprocess_exec``. That helper performs the
+fork/exec of the child **on the event-loop thread**. From the large,
+multi-threaded organism process — especially concurrent with the Oracle
+process pool forking 16 workers during the cold index — that fork blocked the
+loop synchronously for 33–108s across three sessions (``git log`` itself is
+0.14s, so the wedge is the fork, not the query). Because the block is
+synchronous and yield-less, the 30s collector ``wait_for`` could not cancel it
+and ``ControlPlaneStarvation`` stayed silent; the heartbeat froze and the
+120s ``ExternalWatchdog`` SIGKILLed the session at ``in_flight``.
+
+Fix: run the git work in the dedicated ``fs_signal_executor`` thread (the same
+pool the other fs-backed signals already use). A slow fork then blocks a
+worker thread, never the loop — the loop keeps beating the heartbeat. Caching
++ ratio semantics are preserved.
+
+Pins:
+  §1  commit_ratios_async still returns correct Conventional-Commit ratios
+  §2  HEAD-cache short-circuit still skips the git-log when HEAD is unchanged
+  §3  the git work executes on a NON-event-loop thread (proves off-loop)
+  §4  commit_ratios_async no longer calls create_subprocess_exec on the loop
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import threading
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.posture_observer import SignalCollector
+
+
+def test_commit_ratios_async_returns_correct_ratios(monkeypatch) -> None:
+    sc = SignalCollector(Path("."))
+    monkeypatch.setattr(sc, "_git_head", lambda: "headsha1")
+    monkeypatch.setattr(
+        sc, "_git_subjects",
+        lambda n: ["feat: a", "fix: b", "refactor: c", "test: d", "docs: e", "chore: f"],
+    )
+    ratios = asyncio.run(sc.commit_ratios_async())
+    # 6 subjects: 1 feat, 1 fix, 1 refactor, (1 test + 1 docs)=2 test_docs
+    assert ratios["feat"] == pytest.approx(1 / 6)
+    assert ratios["fix"] == pytest.approx(1 / 6)
+    assert ratios["refactor"] == pytest.approx(1 / 6)
+    assert ratios["test_docs"] == pytest.approx(2 / 6)
+
+
+def test_commit_ratios_head_cache_short_circuits_gitlog(monkeypatch) -> None:
+    sc = SignalCollector(Path("."))
+    monkeypatch.setattr(sc, "_git_head", lambda: "stablehead")
+    calls = {"subjects": 0}
+
+    def _subjects(n):
+        calls["subjects"] += 1
+        return ["feat: x"]
+
+    monkeypatch.setattr(sc, "_git_subjects", _subjects)
+    first = asyncio.run(sc.commit_ratios_async())
+    second = asyncio.run(sc.commit_ratios_async())
+    assert first == second
+    # HEAD unchanged → the expensive git-log runs exactly once.
+    assert calls["subjects"] == 1
+
+
+def test_git_work_runs_off_the_event_loop(monkeypatch) -> None:
+    loop_thread_ident = {"v": None}
+    seen = {"head": None, "subjects": None}
+
+    def _head():
+        seen["head"] = threading.get_ident()
+        return "h"
+
+    def _subjects(n):
+        seen["subjects"] = threading.get_ident()
+        return ["feat: x"]
+
+    async def _run():
+        loop_thread_ident["v"] = threading.get_ident()
+        sc = SignalCollector(Path("."))
+        monkeypatch.setattr(sc, "_git_head", _head)
+        monkeypatch.setattr(sc, "_git_subjects", _subjects)
+        await sc.commit_ratios_async()
+
+    asyncio.run(_run())
+    # The git calls MUST have executed on a different (worker) thread, never
+    # the event-loop thread — that is what keeps a slow fork off the loop.
+    assert seen["head"] is not None and seen["head"] != loop_thread_ident["v"]
+    assert seen["subjects"] is not None and seen["subjects"] != loop_thread_ident["v"]
+
+
+def test_commit_ratios_async_does_not_fork_on_loop() -> None:
+    # Structural guard: the coroutine must not CALL create_subprocess_exec
+    # (the loop-thread fork that caused the wedge) nor the on-loop async git
+    # helpers; it must offload via an executor. The docstring may still
+    # reference the historical mechanism, so match the call forms only.
+    src = inspect.getsource(SignalCollector.commit_ratios_async)
+    assert "create_subprocess_exec(" not in src
+    assert "_git_head_async(" not in src
+    assert "_git_subjects_async(" not in src
+    assert "run_in_executor(" in src
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/governance/test_telemetry_harvester.py
+++ b/tests/governance/test_telemetry_harvester.py
@@ -67,8 +67,27 @@ def test_gate_inert_is_anomaly():
 
 
 def test_oom_is_anomaly():
-    cert = _c(_HEALED_LOG + "\nstop_reason=process_memory_cap")
-    assert cert.verdict == H.ANOMALY and "OOM" in cert.headline.upper() or "memory" in cert.headline.lower()
+    # Real ProcessMemoryWatchdog FIRE log line ("Session X stopping: ...").
+    cert = _c(_HEALED_LOG + "\nSession bt-x stopping: process_memory_cap — RSS exceeded")
+    assert cert.verdict == H.ANOMALY and ("OOM" in cert.headline.upper() or "memory" in cert.headline.lower())
+
+
+def test_oom_via_summary_stop_reason_is_anomaly():
+    # Authoritative path: the watchdog stamps summary.stop_reason on a graceful stop.
+    summary = {**_COMPLETE, "stop_reason": "process_memory_cap"}
+    cert = H.certify(H.parse_metrics(_HEALED_LOG, summary, ""))
+    assert cert.verdict == H.ANOMALY and "memory" in cert.headline.lower()
+
+
+def test_armed_watchdog_is_NOT_oom():
+    # Slice 257 regression: the ProcessMemoryWatchdog *arming* line merely
+    # describes the cap (it contains "process_memory_cap" and "OOM-kill") — it
+    # must NOT be read as an OOM event. A clean wall_clock_cap run that armed
+    # the watchdog but never tripped (rss far below cap) must stay non-anomalous.
+    arming = ("[ProcessMemoryWatchdog] armed: warn=10445MB cap=12288MB interval=15s "
+              "— graceful stop_reason=process_memory_cap before OS OOM-kill.")
+    m = H.parse_metrics(_HEALED_LOG + "\n" + arming, _COMPLETE, "")
+    assert m.oom is False
 
 
 def test_boot_check_failed_is_anomaly():


### PR DESCRIPTION
## What & why

Battle-test sessions kept finalizing as `in_flight` instead of `complete`: the out-of-process `ExternalWatchdog` SIGKILLed the process (`exit 137`, `reason=heartbeat_stale`) whenever the main asyncio loop starved ≥120s and froze the on-loop heartbeat tick — so `_generate_report` (the only path that stamps `session_outcome=complete`) never ran. Forensics across `bt-2026-06-16-042304 / 050048 / 052242 / 060619` isolated **four distinct wedges**, each unmasking the next.

## Fixes (deterministic — no brute-force, no retries)

1. **Oracle over-indexed `.claude/worktrees`.** Substring exclude `.worktrees` never matched `.claude/worktrees` (slash≠dot) → Oracle ast-parsed **29,558 duplicate `.py`** (~6× the 6,051 real tree) every cycle → process-pool saturation → 73s loop block. Added `.claude` to `EXCLUDE_PATTERNS` + miner `_WALK_PRUNE_SEGMENTS`, plus a general `_is_linked_git_worktree()` guard (skip any dir whose `.git` is a *file* = `git worktree add`; embedded clones like `backend/vision` keep their dir-`.git` and stay indexed — 229 real `.py` preserved).
2. **Posture `commit_ratios` forked git ON the loop thread** (`asyncio.create_subprocess_exec`). From the large multi-threaded process, concurrent with the Oracle cold-index forking 16 workers, the fork blocked the loop **33–108s** (`git log` itself is 0.14s — the cost is the fork). Moved the git calls into the existing `fs_signal_executor` → fork blocks a worker thread, never the loop. Slice 52 HEAD-cache + `subprocess.run` timeouts preserved.
3. **Shutdown wedged on the Oracle cache write** (`_write_cache_blocking` blocking C-level `write_bytes` can't be interrupted by its 5s deadline) → `os._exit(75)` before `_generate_report`. Mitigated for soaks via the existing designed flag `JARVIS_ORACLE_SHUTDOWN_DEADLINE_S=0`. *(Follow-up: make the cache write bounded/interruptible.)*
4. **Harvester false-positive OOM.** `telemetry_parse._RE_OOM` matched the `ProcessMemoryWatchdog` *arming* line ("armed: … stop_reason=process_memory_cap before OS OOM-kill"); a clean `wall_clock_cap` stop at `rss=555MB` (cap 12288MB) was mis-verdicted ANOMALY/OOM. Now matches the genuine fire (`stopping: process_memory_cap`) + `MemoryError`/`emergency_brake`/critical-pressure, plus the authoritative `summary.stop_reason`.

## Evidence

`bt-2026-06-16-063106` → `session_outcome=complete`, `stop_reason=wall_clock_cap`, `dur=759s`, **0 new infra-noise classes** (only baseline `cancelled_shutdown`). Harvester: Metric A `booted=True`; B all-false (self-heal unexercised — no kernel-touching candidate hit the default-off live-fire gate); C all-false (`oom=False`); verdict OPERATIONAL_UNEXERCISED.

**41 regression tests green**: `test_slice257_claude_worktree_exclusion`, `test_slice257_posture_git_offloop`, `test_telemetry_harvester`, `test_slice49_scanner_exclusions`, `test_slice44_worktree_reaper`.

Docs: PRD §3.8 added (version 3.27 → 3.28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops event-loop starvation that caused `heartbeat_stale` SIGKILLs and left sessions stuck at `in_flight`. Sessions now finalize as `complete` by fixing Oracle over-indexing, moving git work off the loop, and correcting OOM detection.

- **Bug Fixes**
  - Oracle: exclude `.claude` in both Oracle and miner walks, and add `_is_linked_git_worktree()` to skip any dir with a file `.git` (linked worktrees) while keeping embedded clones; prevents massive duplicate indexing.
  - Posture: run `git rev-parse` and `git log` in the `fs_signal_executor` instead of the event loop; preserves HEAD cache and timeouts; avoids 30–100s loop blocks and stale heartbeats.
  - Telemetry: detect real OOMs only by matching `stopping: process_memory_cap` and by `summary.stop_reason`; stops false-positive OOMs on watchdog arming lines.
  - Shutdown: mitigate Oracle cache-write wedge for soaks via `JARVIS_ORACLE_SHUTDOWN_DEADLINE_S=0` so `_generate_report` can run.
  - Added targeted tests (`test_slice257_*`) and updated PRD §3.8.

<sup>Written for commit 82415aadc674c924e77e09d72547d9b0ad34adaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

