### PR TITLE
Slice 258: fix battle-test soak warnings at the root

### DIFF
--- a/backend/core/embedding_service.py
+++ b/backend/core/embedding_service.py
@@ -312,9 +312,18 @@ class EmbeddingService:
         except Exception as e:
             logger.debug(f"[EmbeddingService] Broker unavailable, using legacy path: {e}")
 
-        # v2.0: Check memory budget BEFORE loading
+        # v2.0: Check memory budget BEFORE loading. A denial here is a
+        # *graceful degradation*, not a crash — the organism keeps running with
+        # long-term-memory embeddings disabled until memory frees up and a
+        # later load attempt succeeds. Logged at WARNING (not ERROR) so it
+        # reads as "operating in reduced mode under memory pressure" rather
+        # than a fault the operator must triage.
         if not await self._check_memory_budget():
-            logger.error("[EmbeddingService] ❌ Insufficient memory to load model")
+            logger.warning(
+                "[EmbeddingService] Embedding model load deferred — insufficient "
+                "free memory for the ~800MB SentenceTransformer. Long-term "
+                "memory runs without semantic embeddings until pressure eases."
+            )
             return False
 
         async with self._model_lock:

--- a/backend/core/ouroboros/aegis/daemon.py
+++ b/backend/core/ouroboros/aegis/daemon.py
@@ -139,7 +139,12 @@ def build_app(
     # handlers below.
     app[_K_HMAC_KEY] = secrets.token_bytes(32)
     app[_K_BOOTSTRAP_PSK] = bootstrap_psk
-    app[_K_PSK_CONSUMED] = False
+    # Mutable runtime flag held in a one-element box, not a bare bool. aiohttp
+    # freezes the Application mapping on startup, so *reassigning* ``app[key]``
+    # at request time ("app[_K_PSK_CONSUMED] = True" mid-handler) raised
+    # ``DeprecationWarning: Changing state of started or joined application``.
+    # Mutating the box's *contents* leaves the (frozen) mapping untouched.
+    app[_K_PSK_CONSUMED] = {"v": False}
     active_sessions: Dict[str, SessionToken] = {}
     app[_K_ACTIVE_SESSIONS] = active_sessions
     app[_K_NONCE_LEDGER] = NonceLedger(capacity=nonce_ledger_capacity)
@@ -270,7 +275,7 @@ async def _handle_health(request: web.Request) -> web.Response:
         "schema_version": AEGIS_SCHEMA_VERSION,
         "bind_host": app[_K_BIND_HOST],
         "bind_port": app[_K_BIND_PORT],
-        "psk_consumed": app[_K_PSK_CONSUMED],
+        "psk_consumed": app[_K_PSK_CONSUMED]["v"],
         "active_session_count": len(app[_K_ACTIVE_SESSIONS]),
         "nonce_ledger_size": app[_K_NONCE_LEDGER].size(),
         "boot_ts": app[_K_BOOT_TS],
@@ -294,7 +299,7 @@ async def _handle_session_establish(request: web.Request) -> web.Response:
             {"ok": False, "error": "missing_bearer"}, status=401,
         )
 
-    if app[_K_PSK_CONSUMED]:
+    if app[_K_PSK_CONSUMED]["v"]:
         # Single-use: any subsequent attempt is rejected without
         # disclosing whether the PSK matched.
         return web.json_response(
@@ -316,8 +321,9 @@ async def _handle_session_establish(request: web.Request) -> web.Response:
         )
 
     # Mint the session token. Mark PSK consumed FIRST so a concurrent
-    # second request gets the consumed-path response.
-    app[_K_PSK_CONSUMED] = True
+    # second request gets the consumed-path response. Mutate the box's
+    # contents (not the frozen app mapping) — see _make_app.
+    app[_K_PSK_CONSUMED]["v"] = True
     now = time.time()
     K: bytes = app[_K_HMAC_KEY]
     wire, payload = mint_session_token(

--- a/backend/core/ouroboros/governance/git_momentum.py
+++ b/backend/core/ouroboros/governance/git_momentum.py
@@ -29,11 +29,54 @@ Authority invariants (PRD §12.2 / Manifesto §1 Boundary):
 """
 from __future__ import annotations
 
+import functools
 import re
 import subprocess
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+
+# ── Off-loop git-read executor (Slice 258) ──────────────────────────────────
+# git_momentum is the single hub for "read recent git log" across the
+# organism (StrategicDirection digest + DirectionInferrer arc context). The
+# async path MUST NOT spawn git via ``asyncio.create_subprocess_exec`` —
+# that helper forks/execs the child ON the event-loop thread, and from the
+# large multi-threaded organism process the fork alone blocks the loop for
+# tens of seconds (the Slice 257 ``commit_ratios`` finding; ``git log`` itself
+# is sub-second — the cost is the fork, not the query). Instead we run the
+# bounded sync ``compute_recent_momentum`` (subprocess.run) in this dedicated
+# 2-worker pool, so a slow fork blocks a worker thread, never the loop. A
+# private pool (not the default executor) isolates git-fork latency from every
+# other ``to_thread`` caller.
+_git_read_executor: Optional[ThreadPoolExecutor] = None
+_git_read_executor_lock = threading.Lock()
+
+
+def _get_git_read_executor() -> ThreadPoolExecutor:
+    global _git_read_executor
+    if _git_read_executor is not None:
+        return _git_read_executor
+    with _git_read_executor_lock:
+        if _git_read_executor is None:
+            _git_read_executor = ThreadPoolExecutor(
+                max_workers=2, thread_name_prefix="git-momentum-read",
+            )
+    return _git_read_executor
+
+
+def shutdown_git_read_executor() -> None:
+    """Best-effort clean shutdown of the git-read pool. NEVER raises."""
+    global _git_read_executor
+    with _git_read_executor_lock:
+        ex = _git_read_executor
+        _git_read_executor = None
+    if ex is not None:
+        try:
+            ex.shutdown(wait=False, cancel_futures=True)
+        except Exception:  # noqa: BLE001 — teardown must not raise
+            pass
 
 # Conventional Commits: ``type(scope)?: subject``. Scope is optional.
 # This regex is the single source of truth for both consumers
@@ -111,50 +154,32 @@ async def compute_recent_momentum_async(
     max_commits: int = _DEFAULT_MAX_COMMITS,
     timeout_s: float = _DEFAULT_TIMEOUT_S,
 ) -> Optional[MomentumSnapshot]:
-    """Slice 33 Arc 2 Phase 1 — async-native git momentum.
+    """Off-loop async git momentum.
 
-    Same return shape as :func:`compute_recent_momentum` but uses
-    ``asyncio.create_subprocess_exec`` so no thread-pool slot is
-    consumed during the git log scan. NEVER raises — every failure
-    path returns ``None``.
+    Same return shape as :func:`compute_recent_momentum`. Slice 258 replaces
+    the previous ``asyncio.create_subprocess_exec`` body — which forks the git
+    child ON the event-loop thread and blocked the loop tens of seconds from
+    the large organism process — with a thread-offloaded call to the bounded
+    sync path via the dedicated git-read pool. The fork now happens in a worker
+    thread; the loop stays free. ``timeout_s`` is enforced by the inner
+    ``subprocess.run``. NEVER raises — every failure path returns ``None``.
     """
     import asyncio as _asyncio_gm
-    n = max(1, int(max_commits))
+    loop = _asyncio_gm.get_running_loop()
     try:
-        proc = await _asyncio_gm.create_subprocess_exec(
-            "git", "log", f"-{n}", "--pretty=format:%H|%ct|%s",
-            cwd=str(project_root),
-            stdout=_asyncio_gm.subprocess.PIPE,
-            stderr=_asyncio_gm.subprocess.DEVNULL,
+        return await loop.run_in_executor(
+            _get_git_read_executor(),
+            functools.partial(
+                compute_recent_momentum,
+                project_root=project_root,
+                max_commits=max_commits,
+                timeout_s=timeout_s,
+            ),
         )
-    except (FileNotFoundError, OSError):
-        return None
-    try:
-        stdout_bytes, _ = await _asyncio_gm.wait_for(
-            proc.communicate(), timeout=float(timeout_s),
-        )
-    except _asyncio_gm.TimeoutError:
-        try:
-            proc.kill()
-            await proc.wait()
-        except Exception:  # noqa: BLE001
-            pass
-        return None
     except _asyncio_gm.CancelledError:
-        try:
-            proc.kill()
-        except Exception:  # noqa: BLE001
-            pass
         raise
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001 — async contract: never raise
         return None
-    if proc.returncode != 0:
-        return None
-    try:
-        text = stdout_bytes.decode("utf-8", errors="replace")
-    except Exception:  # noqa: BLE001
-        return None
-    return _parse_git_log_output(text)  # noqa: F821 — defined below
 
 
 def _parse_git_log_output(text: str) -> Optional[MomentumSnapshot]:

--- a/backend/core/ouroboros/governance/semantic_triage.py
+++ b/backend/core/ouroboros/governance/semantic_triage.py
@@ -55,6 +55,20 @@ _TRIAGE_MAX_FILE_CHARS = int(os.environ.get("OUROBOROS_TRIAGE_MAX_FILE_CHARS", "
 _TRIAGE_MAX_FILES = int(os.environ.get("OUROBOROS_TRIAGE_MAX_FILES", "3"))
 # Enable/disable triage (master switch)
 _TRIAGE_ENABLED = os.environ.get("OUROBOROS_TRIAGE_ENABLED", "true").lower() == "true"
+# verify_model() boot-race retry: the /v1/models probe can fire before the
+# Aegis credential proxy has injected the DW key, yielding a transient
+# 401/403. Retry a bounded number of times with short async backoff so the
+# triage model is genuinely verified once creds land — instead of logging a
+# spurious warning and proceeding unverified. Both knobs env-tunable.
+_TRIAGE_VERIFY_MAX_ATTEMPTS = max(
+    1, int(os.environ.get("OUROBOROS_TRIAGE_VERIFY_MAX_ATTEMPTS", "4"))
+)
+_TRIAGE_VERIFY_BACKOFF_S = max(
+    0.0, float(os.environ.get("OUROBOROS_TRIAGE_VERIFY_BACKOFF_S", "1.5"))
+)
+# HTTP statuses worth retrying — transient auth (proxy warming) + transient
+# upstream unavailability. A 404/400 is a real config error → no retry.
+_TRIAGE_VERIFY_RETRY_STATUSES = frozenset({401, 403, 429, 502, 503, 504})
 
 
 # ---------------------------------------------------------------------------
@@ -210,21 +224,48 @@ class SemanticTriageEngine:
                 self._model_verified = False
                 return False
 
-            async with session.get(
-                f"{base_url}/models",
-                timeout=self._dw._request_timeout(),
-            ) as resp:
-                if resp.status != 200:
+            # Bounded retry on transient auth / upstream blips — the probe can
+            # outrace the Aegis credential proxy at boot (401 before the key is
+            # injected, 200 moments later). Async backoff keeps the loop free.
+            body = None
+            for _attempt in range(1, _TRIAGE_VERIFY_MAX_ATTEMPTS + 1):
+                async with session.get(
+                    f"{base_url}/models",
+                    timeout=self._dw._request_timeout(),
+                ) as resp:
+                    if resp.status == 200:
+                        body = await resp.json()
+                        break
+                    if (
+                        resp.status in _TRIAGE_VERIFY_RETRY_STATUSES
+                        and _attempt < _TRIAGE_VERIFY_MAX_ATTEMPTS
+                    ):
+                        logger.debug(
+                            "[SemanticTriage] /v1/models returned %d "
+                            "(attempt %d/%d) — credential proxy likely still "
+                            "warming; retrying in %.1fs",
+                            resp.status, _attempt,
+                            _TRIAGE_VERIFY_MAX_ATTEMPTS, _TRIAGE_VERIFY_BACKOFF_S,
+                        )
+                        if _TRIAGE_VERIFY_BACKOFF_S > 0:
+                            await asyncio.sleep(_TRIAGE_VERIFY_BACKOFF_S)
+                        continue
+                    # Non-retryable status, or retries exhausted — the model
+                    # may still work, so proceed optimistically (unverified).
                     logger.warning(
-                        "[SemanticTriage] /v1/models returned %d — "
-                        "cannot verify triage model availability",
-                        resp.status,
+                        "[SemanticTriage] /v1/models returned %d after %d "
+                        "attempt(s) — cannot verify triage model availability",
+                        resp.status, _attempt,
                     )
-                    # Proceed anyway — model might still work
                     self._model_verified = True
                     return True
 
-                body = await resp.json()
+            # Defensive: the loop always sets ``body`` (200) or returns, but if
+            # a non-dict/None somehow slipped through, proceed optimistically
+            # rather than crash the boot-time verification.
+            if not isinstance(body, (list, dict)):
+                self._model_verified = True
+                return True
 
             # DW models endpoint returns {"data": [{"id": "model-name", ...}, ...]}
             # or a flat list — handle both

--- a/backend/core/ouroboros/governance/strategic_direction.py
+++ b/backend/core/ouroboros/governance/strategic_direction.py
@@ -130,7 +130,12 @@ class StrategicDirectionService:
         # — synthetic soul: the organism remembers what it has been working
         # on). Conventional-commit parsing, zero model inference.
         if _GIT_HISTORY_ENABLED:
-            self._git_themes = self._extract_git_themes(
+            # Slice 258 — await the off-loop async path. The sync
+            # ``_extract_git_themes`` ran ``git log`` (subprocess) on the
+            # asyncio thread (LoopSink: blocked_ms≈197); the async variant
+            # routes through ``git_momentum``'s thread-offloaded git-read pool
+            # so the git fork never blocks the loop.
+            self._git_themes = await self._extract_git_themes_async(
                 self._root, max_commits=_GIT_HISTORY_MAX_COMMITS,
             )
             momentum_section = self._format_git_themes(self._git_themes)
@@ -931,7 +936,9 @@ class StrategicDirectionService:
         )
         # Slice 33 Arc 0 — diagnostic only. Subprocess git log + parse
         # for 50 commits runs synchronously on the asyncio thread when
-        # this is called from any async caller.
+        # this is called from any async caller. Retained for back-compat
+        # (direct test callers); production ``load()`` uses the off-loop
+        # ``_extract_git_themes_async`` below (Slice 258).
         from backend.core.ouroboros.telemetry.loop_sink import (
             sink_sync as _ls_sink_sync,
         )
@@ -941,6 +948,31 @@ class StrategicDirectionService:
                 max_commits=int(max_commits),
             )
             return format_themes(snapshot)
+
+    @staticmethod
+    async def _extract_git_themes_async(
+        project_root: Path,
+        max_commits: int = 50,
+    ) -> List[str]:
+        """Off-loop twin of :meth:`_extract_git_themes` (Slice 258).
+
+        Delegates to ``git_momentum.compute_recent_momentum_async``, which runs
+        the bounded ``git log`` in the dedicated git-read thread pool — the git
+        fork happens on a worker thread, never the event loop. Byte-identical
+        ``List[str]`` output to the sync wrapper. NEVER raises.
+        """
+        from backend.core.ouroboros.governance.git_momentum import (
+            compute_recent_momentum_async,
+            format_themes,
+        )
+        try:
+            snapshot = await compute_recent_momentum_async(
+                project_root=project_root,
+                max_commits=int(max_commits),
+            )
+        except Exception:  # noqa: BLE001 — digest momentum is best-effort
+            return []
+        return format_themes(snapshot)
 
     @staticmethod
     def _format_git_themes(themes: List[str]) -> str:

--- a/backend/core/persistent_intelligence_manager.py
+++ b/backend/core/persistent_intelligence_manager.py
@@ -489,10 +489,22 @@ class PersistentIntelligenceManager:
         logger.debug("[PERSISTENT-INTELLIGENCE] Local database initialized")
 
     async def _init_cloud_adapter(self) -> None:
-        """Initialize cloud database adapter."""
+        """Initialize cloud database adapter.
+
+        Routes through the canonical ``get_database_adapter()`` factory rather
+        than the non-existent ``CloudDatabaseAdapter.create()`` (which raised
+        ``AttributeError: type object 'CloudDatabaseAdapter' has no attribute
+        'create'`` and aborted persistent-intelligence cloud init every boot).
+        The factory is the single source of truth: it returns the global
+        singleton, honours the Cloud SQL ReadinessGate (instant SQLite fallback
+        when the proxy is known-down), and wraps initialization in a timeout so
+        this call can never block the boot chain.
+        """
         try:
-            from backend.intelligence.cloud_database_adapter import CloudDatabaseAdapter
-            self._cloud_adapter = await CloudDatabaseAdapter.create()
+            from backend.intelligence.cloud_database_adapter import (
+                get_database_adapter,
+            )
+            self._cloud_adapter = await get_database_adapter()
             logger.info("[PERSISTENT-INTELLIGENCE] Cloud adapter initialized")
         except ImportError:
             logger.warning("[PERSISTENT-INTELLIGENCE] Cloud adapter not available")

--- a/tests/governance/test_slice258_soak_warnings.py
+++ b/tests/governance/test_slice258_soak_warnings.py
@@ -1,0 +1,149 @@
+"""Slice 258 — soak-warning fixes.
+
+Covers the behaviour changes that quiet a wave of battle-test warnings while
+fixing their root causes:
+
+  §1  SemanticTriageEngine.verify_model retries on transient 401/403 (the
+      /v1/models probe outracing the Aegis credential proxy at boot) and
+      genuinely verifies once creds land — instead of logging a spurious
+      warning and proceeding unverified.
+  §2  git_momentum.compute_recent_momentum_async runs the git subprocess on a
+      worker thread (the fork never blocks the event loop) — and
+      StrategicDirectionService._extract_git_themes_async does too.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.semantic_triage import SemanticTriageEngine
+import backend.core.ouroboros.governance.semantic_triage as st
+from backend.core.ouroboros.governance.git_momentum import (
+    compute_recent_momentum_async,
+)
+from backend.core.ouroboros.governance.strategic_direction import (
+    StrategicDirectionService,
+)
+
+
+# ── fakes for the DW provider + aiohttp session ─────────────────────────
+class _FakeResp:
+    def __init__(self, status: int, body=None):
+        self.status = status
+        self._body = body if body is not None else {"data": []}
+
+    async def json(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+class _FakeSession:
+    """Returns the i-th status from ``statuses`` on the i-th GET."""
+
+    def __init__(self, statuses):
+        self._statuses = list(statuses)
+        self.calls = 0
+
+    def get(self, url, timeout=None):
+        i = self.calls
+        self.calls += 1
+        status = self._statuses[min(i, len(self._statuses) - 1)]
+        body = {"data": [{"id": "triage-model"}]} if status == 200 else {}
+        return _FakeResp(status, body)
+
+
+class _FakeDW:
+    def __init__(self, session, model="dw-default"):
+        self._sess = session
+        self._base_url = "http://fake/v1"
+        self._model = model
+        self.is_available = True
+
+    async def _get_session(self):
+        return self._sess
+
+    def _request_timeout(self):
+        return 5.0
+
+
+def _engine(session) -> SemanticTriageEngine:
+    eng = SemanticTriageEngine(dw_provider=_FakeDW(session), project_root=Path("."))
+    eng._effective_model = "triage-model"
+    return eng
+
+
+# ── §1 verify_model retry ───────────────────────────────────────────────
+def test_verify_model_retries_then_succeeds(monkeypatch):
+    monkeypatch.setattr(st, "_TRIAGE_VERIFY_BACKOFF_S", 0.0)
+    monkeypatch.setattr(st, "_TRIAGE_VERIFY_MAX_ATTEMPTS", 4)
+    sess = _FakeSession([401, 401, 200])  # proxy warms up on the 3rd probe
+    eng = _engine(sess)
+    ok = asyncio.run(eng.verify_model())
+    assert ok is True
+    assert eng._model_verified is True
+    assert sess.calls == 3  # retried twice, verified on the third
+
+
+def test_verify_model_exhausts_then_proceeds_optimistically(monkeypatch):
+    monkeypatch.setattr(st, "_TRIAGE_VERIFY_BACKOFF_S", 0.0)
+    monkeypatch.setattr(st, "_TRIAGE_VERIFY_MAX_ATTEMPTS", 3)
+    sess = _FakeSession([401, 401, 401, 401])  # never recovers
+    eng = _engine(sess)
+    ok = asyncio.run(eng.verify_model())
+    assert ok is True  # non-fatal: proceed unverified
+    assert eng._model_verified is True
+    assert sess.calls == 3  # capped at max attempts, no infinite retry
+
+
+def test_verify_model_no_retry_on_real_config_error(monkeypatch):
+    monkeypatch.setattr(st, "_TRIAGE_VERIFY_BACKOFF_S", 0.0)
+    monkeypatch.setattr(st, "_TRIAGE_VERIFY_MAX_ATTEMPTS", 4)
+    sess = _FakeSession([404])  # 404 is not a transient — must not retry
+    eng = _engine(sess)
+    ok = asyncio.run(eng.verify_model())
+    assert ok is True
+    assert sess.calls == 1  # single attempt, no retry on non-transient status
+
+
+# ── §2 git reads run off the event loop ─────────────────────────────────
+def test_momentum_async_runs_off_event_loop():
+    loop_ident = {}
+    git_ident = {}
+
+    import backend.core.ouroboros.governance.git_momentum as gm
+    orig = gm.compute_recent_momentum
+
+    def _spy(*a, **k):
+        git_ident["t"] = threading.get_ident()
+        return orig(*a, **k)
+
+    async def _run():
+        loop_ident["t"] = threading.get_ident()
+        gm.compute_recent_momentum = _spy
+        try:
+            await compute_recent_momentum_async(project_root=Path("."), max_commits=10)
+        finally:
+            gm.compute_recent_momentum = orig
+
+    asyncio.run(_run())
+    assert git_ident.get("t") is not None
+    assert git_ident["t"] != loop_ident["t"]  # git ran on a worker thread
+
+
+def test_extract_git_themes_async_returns_list():
+    themes = asyncio.run(
+        StrategicDirectionService._extract_git_themes_async(Path("."), max_commits=20)
+    )
+    assert isinstance(themes, list)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Fixes six independent warnings from a battle-test soak log, each at its source (no log-muting).

| # | Warning | Root cause → fix |
|---|---------|------------------|
| 1 | `CloudDatabaseAdapter has no attribute 'create'` | `persistent_intelligence` called a non-existent factory → aborted cloud init every boot. Route through the canonical `get_database_adapter()` (singleton + Cloud-SQL ReadinessGate SQLite fallback + timeout). |
| 2 | `commit_ratios` / `_extract_git_themes` LoopSink blocks | `git_momentum.compute_recent_momentum_async` used `create_subprocess_exec`, forking git **on the event-loop thread** (tens of seconds from the large process — the Slice 257 finding). Now thread-offloads the bounded sync git read via a dedicated git-read pool; `_extract_git_themes` gains an off-loop async twin `load()` awaits. |
| 3 | aiohttp `Changing state of started application is deprecated` | aegis daemon reassigned the PSK-consumed flag on the frozen `Application` mapping at request time. Hold it in a one-element box; mutate the box, not the mapping. |
| 4 | `[SemanticTriage] /v1/models returned 401` | The probe outraced the Aegis credential proxy at boot. `verify_model()` now retries transient `401/403/5xx` with bounded async backoff (env-tunable) and genuinely verifies once creds land; `404` does not retry. |
| 5 | `EmbeddingService ❌ Insufficient memory` | Logged at ERROR for a by-design graceful degradation under **real** memory pressure (machine 77% used). Downgraded to an accurate WARNING. The denial itself is correct (it protects a memory floor); the organism continues without embeddings until pressure eases. |

`/v1/models 200` (AegisPassthrough) and `DiscordGateway armed` are healthy INFO lines, not faults.

**Note on the Rust memory components** (`RustMemoryMonitor` in `jarvis_rust_extensions`): well-designed (`is_memory_available`/`suggest_cleanup`/`update_ml_stats`) but **not currently built** (`ModuleNotFoundError`), so dormant — and it reads the same OS memory numbers psutil already reads, so it would not change this denial. Wiring it in (build + integrate into the guard for adaptive eviction) is a worthwhile separate enhancement, not a fix for this pressure event.

**82 regression tests green**: new `test_slice258_soak_warnings` + `test_git_momentum` + `test_slice33_arc0_loop_sink` + aegis `daemon`/`session_lifecycle`/`passthrough` + `test_slice257_posture_git_offloop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes six soak warnings by addressing their root causes and keeping the event loop responsive. Git reads now run off-loop, cloud DB init uses the canonical factory, triage model verification is resilient, and logging reflects real severity.

- **Bug Fixes**
  - Persistent intelligence: initialize cloud DB via `get_database_adapter()` (singleton, readiness gate + SQLite fallback, timeout) instead of the non-existent `CloudDatabaseAdapter.create()`.
  - Git momentum/strategic direction: move git reads to a dedicated thread pool (no `asyncio.create_subprocess_exec` on the loop); add `_extract_git_themes_async` and await it in `load()` to avoid loop stalls.
  - Aegis daemon: store the PSK-consumed flag in a one-element box and mutate it to avoid aiohttp’s “Changing state...” deprecation.
  - Semantic triage: `verify_model()` retries transient `401/403/429/5xx` with bounded async backoff (env-tunable), skips retry on `404`, and proceeds optimistically if retries exhaust.
  - Embedding service: downgrade “insufficient memory” to WARNING and clarify that model load is deferred until pressure eases.
  - Tests: add `test_slice258_soak_warnings` to cover triage retries and ensure git runs off the event loop.

<sup>Written for commit 756961ebc04c43d66b4367868497107564bfbc5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

