### PR TITLE
Slice 259: Adaptive Model Tiering Engine — EmbeddingService tiers instead of failing under memory pressure

### DIFF
--- a/backend/core/embedding_service.py
+++ b/backend/core/embedding_service.py
@@ -54,11 +54,36 @@ import threading
 import time
 from contextlib import suppress
 from dataclasses import dataclass
+from enum import IntEnum
 from typing import Any, Dict, Optional, Sequence, Union
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Adaptive Model Tiering — the Sovereign Adaptive Memory Matrix (Slice 259)
+# =============================================================================
+class EmbeddingTier(IntEnum):
+    """Fidelity-ordered embedding tiers (higher value = higher fidelity).
+
+    The service runs on exactly one tier at a time and adapts to host memory:
+
+      * ``HIGH``  — the ~800MB PyTorch SentenceTransformer (best quality).
+      * ``LITE``  — the ~200MB fastembed (ONNX/CoreML, ARM64-optimized) model,
+                    embedding-dimension-compatible (384-dim bge-small ≈
+                    all-MiniLM-L6-v2). The tier the service *demotes* to when
+                    the HIGH allocation is denied under memory pressure.
+      * ``NONE``  — no model loaded yet (or fully degraded).
+
+    Ordering matters: ``maybe_promote_tier`` only ever moves *up* (LITE→HIGH),
+    and the watchdog never demotes a working HIGH tier.
+    """
+
+    NONE = 0
+    LITE = 1
+    HIGH = 2
 
 # =============================================================================
 # CONFIGURATION
@@ -97,9 +122,35 @@ class EmbeddingServiceConfig:
     encode_timeout: float = 30.0
     shutdown_timeout: float = 10.0
 
+    # ── Adaptive Model Tiering (Slice 259) ──────────────────────────────
+    # Master switch for the demote-on-pressure / promote-on-headroom engine.
+    adaptive_tiering_enabled: bool = True
+    # Memory the two tiers are expected to cost (MB). Drives the budget gate +
+    # the promotion-headroom check. Env-tunable — no hardcoded thresholds in
+    # the logic.
+    pytorch_estimate_mb: int = 800
+    fastembed_estimate_mb: int = 200
+    # Background promotion poller (LITE→HIGH).
+    promotion_enabled: bool = True
+    promotion_poll_s: float = 60.0
+    # Hysteresis: require this many *consecutive* headroom observations before
+    # committing to an 800MB promotion (stops flapping when memory hovers near
+    # the line).
+    promotion_stable_checks: int = 2
+    # Extra free GB (beyond the model estimate) required before promoting —
+    # the floor the host must keep after the HIGH model loads.
+    promotion_headroom_gb: float = 2.0
+    # Free GB (beyond the LITE estimate) required to even attempt the LITE
+    # tier; below this the service degrades to no embeddings.
+    lite_floor_gb: float = 0.5
+
     @classmethod
     def from_env(cls) -> "EmbeddingServiceConfig":
         """Create config from environment variables."""
+        def _flag(name: str, default: bool) -> bool:
+            return os.getenv(name, str(default)).strip().lower() in (
+                "1", "true", "yes", "on",
+            )
         return cls(
             model_name=os.getenv("EMBEDDING_MODEL", "all-MiniLM-L6-v2"),
             device=os.getenv("EMBEDDING_DEVICE", "cpu"),
@@ -112,6 +163,16 @@ class EmbeddingServiceConfig:
             fastembed_model_name=os.getenv(
                 "EMBEDDING_FASTEMBED_MODEL", "BAAI/bge-small-en-v1.5",
             ),
+            adaptive_tiering_enabled=_flag("JARVIS_EMBEDDING_ADAPTIVE_TIERING", True),
+            pytorch_estimate_mb=int(os.getenv("EMBEDDING_PYTORCH_ESTIMATE_MB", "800")),
+            fastembed_estimate_mb=int(os.getenv("EMBEDDING_FASTEMBED_ESTIMATE_MB", "200")),
+            promotion_enabled=_flag("JARVIS_EMBEDDING_ADAPTIVE_PROMOTION", True),
+            promotion_poll_s=float(os.getenv("EMBEDDING_PROMOTION_POLL_S", "60")),
+            promotion_stable_checks=max(
+                1, int(os.getenv("EMBEDDING_PROMOTION_STABLE_CHECKS", "2"))
+            ),
+            promotion_headroom_gb=float(os.getenv("EMBEDDING_PROMOTION_HEADROOM_GB", "2.0")),
+            lite_floor_gb=float(os.getenv("EMBEDDING_LITE_FLOOR_GB", "0.5")),
         )
 
 
@@ -200,6 +261,12 @@ class EmbeddingService:
 
         self._active_grant = None  # Memory Control Plane grant, if loaded via broker
 
+        # ── Adaptive Model Tiering state (Slice 259) ────────────────────
+        self._active_tier: EmbeddingTier = EmbeddingTier.NONE
+        self._promotion_task: Optional[asyncio.Task] = None
+        self._promotion_stable_count: int = 0
+        self._tier_transitions: int = 0  # observability: total demote/promote events
+
         # Register cleanup
         atexit.register(self._sync_cleanup)
         self._register_with_shutdown_manager()
@@ -245,33 +312,49 @@ class EmbeddingService:
         except Exception as e:
             logger.debug(f"[EmbeddingService] Could not register with cross-repo cleanup: {e}")
 
-    async def _check_memory_budget(self) -> bool:
-        """Check if we have enough memory to load the model."""
+    async def _check_memory_budget(
+        self,
+        *,
+        component: str = "sentence_transformer",
+        estimated_mb: Optional[int] = None,
+        timeout: Optional[float] = None,
+    ) -> bool:
+        """Gate a tier load through the ProactiveResourceGuard.
+
+        Slice 259 — parameterised so each tier asks for its own footprint
+        (HIGH ~800MB / LITE ~200MB) and so the background promotion poller can
+        pass a short ``timeout`` (no 30s boot-style wait off the hot path).
+        Returns True (proceed) if the guard is unavailable — the guard is an
+        optimisation, not a hard dependency.
+        """
         try:
             from backend.core.proactive_resource_guard import (
                 get_proactive_resource_guard,
                 COMPONENT_MEMORY_ESTIMATES,
             )
-            
+
             guard = get_proactive_resource_guard()
-            estimated_mb = COMPONENT_MEMORY_ESTIMATES.get("sentence_transformer", 800)
-            
-            # Request memory budget with callback for emergency unload
-            granted = await guard.request_memory_budget(
-                component="sentence_transformer",
-                estimated_mb=estimated_mb,
-                priority=60,  # Medium-high priority (embeddings are important)
+            mb = estimated_mb if estimated_mb is not None else \
+                COMPONENT_MEMORY_ESTIMATES.get(component, 800)
+
+            kwargs: Dict[str, Any] = dict(
+                component=component,
+                estimated_mb=mb,
+                priority=60,  # Medium-high (embeddings matter)
                 can_unload=True,
                 unload_callback=self._sync_cleanup,
             )
-            
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            granted = await guard.request_memory_budget(**kwargs)
+
             if not granted:
                 logger.warning(
-                    f"[EmbeddingService] Memory budget denied for SentenceTransformer "
-                    f"(need ~{estimated_mb}MB)"
+                    "[EmbeddingService] Memory budget denied for %s (need ~%dMB)",
+                    component, mb,
                 )
             return granted
-            
+
         except ImportError:
             logger.debug("[EmbeddingService] ProactiveResourceGuard not available, skipping memory check")
             return True  # Proceed without guard
@@ -284,106 +367,294 @@ class EmbeddingService:
         adapter (config-sourced model name). ``factory`` injectable for tests."""
         return _FastembedSTAdapter(self._config.fastembed_model_name, factory=factory)
 
-    async def _load_model(self) -> bool:
-        """
-        Lazy load the SentenceTransformer model.
+    # ── Tier observability ──────────────────────────────────────────────
+    @property
+    def active_tier(self) -> EmbeddingTier:
+        """The embedding tier currently serving encode() (NONE if unloaded)."""
+        return self._active_tier
 
-        CRITICAL: This is the ONLY place SentenceTransformer should be instantiated.
-        
-        v2.0: Now checks memory budget via ProactiveResourceGuard before loading.
+    @property
+    def tier_name(self) -> str:
+        return self._active_tier.name
+
+    def tier_status(self) -> Dict[str, Any]:
+        """Snapshot for /observability — adaptive tiering state."""
+        return {
+            "active_tier": self._active_tier.name,
+            "model_loaded": self._model is not None,
+            "adaptive_tiering_enabled": self._config.adaptive_tiering_enabled,
+            "promotion_enabled": self._config.promotion_enabled,
+            "promotion_loop_running": (
+                self._promotion_task is not None and not self._promotion_task.done()
+            ),
+            "promotion_stable_count": self._promotion_stable_count,
+            "tier_transitions": self._tier_transitions,
+        }
+
+    # ── Model-construction seams (overridable for tests) ────────────────
+    def _load_sentence_transformer(self) -> Any:
+        """Construct the HIGH-tier PyTorch model. Isolated so tests can patch
+        it without a torch install. Raises ImportError if torch is absent."""
+        from sentence_transformers import SentenceTransformer  # deferred
+        return SentenceTransformer(self._config.model_name, device=self._config.device)
+
+    # ── Memory headroom probes (psutil via the guard, with fallback) ────
+    def _available_gb(self) -> Optional[float]:
+        """Best-effort system available memory in GB. Reuses the guard's
+        accounting (same psutil source) so the tiering and the guard never
+        disagree; falls back to psutil, then None (unknown)."""
+        try:
+            from backend.core.proactive_resource_guard import (
+                get_proactive_resource_guard,
+            )
+            _, available_gb, _ = get_proactive_resource_guard().get_memory_info()
+            return float(available_gb)
+        except Exception:
+            try:
+                import psutil
+                return psutil.virtual_memory().available / (1024 ** 3)
+            except Exception:
+                return None
+
+    def _pytorch_headroom_available(self) -> bool:
+        """True iff the host can hold the HIGH model AND keep the promotion
+        floor afterwards. Conservative: unknown memory → not enough."""
+        avail = self._available_gb()
+        if avail is None:
+            return False
+        need = (self._config.pytorch_estimate_mb / 1024.0) + self._config.promotion_headroom_gb
+        return avail >= need
+
+    def _lite_headroom_available(self) -> bool:
+        """True iff there's room for the LITE model + a small floor. Lenient:
+        unknown memory → allow (LITE is the whole point of degrading)."""
+        avail = self._available_gb()
+        if avail is None:
+            return True
+        need = (self._config.fastembed_estimate_mb / 1024.0) + self._config.lite_floor_gb
+        return avail >= need
+
+    async def _load_model(self) -> bool:
+        """Lazy-load an embedding tier, adapting to host memory.
+
+        Order: HIGH (PyTorch ~800MB) → on denial/absence, demote to LITE
+        (fastembed ~200MB, ONNX/CoreML) rather than running without embeddings.
+        Once on LITE, a background poller tries to climb back to HIGH when the
+        host recovers headroom. Returns True if any tier is serving.
         """
         if self._model is not None:
             return True
-
         if self._shutdown_requested:
             logger.warning("[EmbeddingService] Cannot load model during shutdown")
             return False
 
-        # Memory Control Plane: Try broker-mediated loading
+        # Tier 0 (HIGH): PyTorch SentenceTransformer.
+        if await self._try_load_pytorch_tier():
+            return True
+
+        # Adaptive demotion — pivot to the lighter ONNX/CoreML tier instead of
+        # degrading to no embeddings.
+        if self._config.adaptive_tiering_enabled:
+            if await self._try_load_fastembed_tier(reason="high_tier_unavailable"):
+                self._ensure_promotion_loop()
+                return True
+
+        logger.warning(
+            "[EmbeddingService] No embedding tier could load — long-term memory "
+            "runs without semantic embeddings until memory pressure eases."
+        )
+        return False
+
+    async def _try_load_pytorch_tier(self) -> bool:
+        """Load the HIGH (PyTorch) tier. Returns False (without erroring) when
+        the budget is denied or torch is absent, so the caller can demote."""
+        # Memory Control Plane: prefer the broker when present.
         try:
             from backend.core.memory_budget_broker import get_memory_budget_broker
-            from backend.core.budgeted_loaders import EmbeddingBudgetedLoader
-
             _broker = get_memory_budget_broker()
             if _broker is not None:
-                return await self._load_model_via_broker(_broker)
+                ok = await self._load_model_via_broker(_broker)
+                if ok:
+                    self._active_tier = EmbeddingTier.HIGH
+                return ok  # broker denial → False → caller demotes
         except ImportError:
             pass
         except Exception as e:
             logger.debug(f"[EmbeddingService] Broker unavailable, using legacy path: {e}")
 
-        # v2.0: Check memory budget BEFORE loading. A denial here is a
-        # *graceful degradation*, not a crash — the organism keeps running with
-        # long-term-memory embeddings disabled until memory frees up and a
-        # later load attempt succeeds. Logged at WARNING (not ERROR) so it
-        # reads as "operating in reduced mode under memory pressure" rather
-        # than a fault the operator must triage.
-        if not await self._check_memory_budget():
+        # Legacy guard gate.
+        if not await self._check_memory_budget(
+            component="sentence_transformer",
+            estimated_mb=self._config.pytorch_estimate_mb,
+        ):
             logger.warning(
-                "[EmbeddingService] Embedding model load deferred — insufficient "
-                "free memory for the ~800MB SentenceTransformer. Long-term "
-                "memory runs without semantic embeddings until pressure eases."
+                "[EmbeddingService] HIGH tier (PyTorch ~%dMB) denied under memory "
+                "pressure — attempting LITE tier.",
+                self._config.pytorch_estimate_mb,
             )
             return False
 
         async with self._model_lock:
-            # Double-check after acquiring lock
             if self._model is not None:
                 return True
-
             try:
-                logger.info(f"[EmbeddingService] Loading model: {self._config.model_name}")
+                logger.info(f"[EmbeddingService] Loading HIGH tier: {self._config.model_name}")
                 start = time.time()
-
-                # Import in function to defer loading
-                from sentence_transformers import SentenceTransformer
-
-                # Create model with explicit settings to avoid internal pool creation
-                self._model = SentenceTransformer(
-                    self._config.model_name,
-                    device=self._config.device,
-                )
-
-                # Explicitly disable internal multiprocessing pools
-                # SentenceTransformer can start pools for encode_multi_process()
-                # We never use that method, but ensure pools aren't started
-                if hasattr(self._model, '_target_device'):
-                    # Model loaded successfully
-                    pass
-
-                elapsed = time.time() - start
+                self._model = self._load_sentence_transformer()
+                self._active_tier = EmbeddingTier.HIGH
                 logger.info(
-                    f"[EmbeddingService] ✅ Model loaded in {elapsed:.2f}s "
-                    f"(device: {self._config.device})"
+                    "[EmbeddingService] ✅ HIGH tier loaded in %.2fs (device: %s)",
+                    time.time() - start, self._config.device,
                 )
                 return True
-
             except ImportError as e:
-                # Slice 153 — sentence-transformers absent (e.g. the Oracle-capable
-                # soak image: fastembed, not torch). Fall back to fastembed via a
-                # SentenceTransformer.encode-compatible adapter so encode() works
-                # unchanged — instead of returning None (which left the Oracle's
-                # embed_nodes producing no embeddings).
+                # torch absent — release the reservation we took and demote.
                 logger.warning(
                     "[EmbeddingService] sentence-transformers unavailable (%s) — "
-                    "falling back to fastembed (model=%s)",
-                    e, self._config.fastembed_model_name,
+                    "demoting to fastembed LITE tier.", e,
                 )
-                try:
-                    self._model = self._make_fastembed_model()
-                    logger.info(
-                        "[EmbeddingService] ✅ fastembed fallback loaded: model=%s",
-                        self._config.fastembed_model_name,
-                    )
-                    return True
-                except Exception as fe:  # noqa: BLE001
-                    logger.error(
-                        "[EmbeddingService] ❌ fastembed fallback failed: %s", fe,
-                    )
-                    return False
-            except Exception as e:
-                logger.error(f"[EmbeddingService] ❌ Failed to load model: {e}")
+                self._release_component("sentence_transformer")
                 return False
+            except Exception as e:
+                logger.error(f"[EmbeddingService] ❌ HIGH tier load failed: {e}")
+                self._release_component("sentence_transformer")
+                return False
+
+    async def _try_load_fastembed_tier(self, *, reason: str) -> bool:
+        """Load the LITE (fastembed / ONNX-CoreML) tier. Returns False only if
+        memory is too tight even for ~200MB or fastembed is unavailable."""
+        if not self._lite_headroom_available():
+            logger.warning(
+                "[EmbeddingService] Even the LITE tier (~%dMB) exceeds free "
+                "memory — running without embeddings.",
+                self._config.fastembed_estimate_mb,
+            )
+            return False
+        async with self._model_lock:
+            if self._model is not None:
+                return True
+            try:
+                start = time.time()
+                self._model = self._make_fastembed_model()
+                prev = self._active_tier
+                self._active_tier = EmbeddingTier.LITE
+                if prev != EmbeddingTier.LITE:
+                    self._tier_transitions += 1
+                logger.warning(
+                    "[EmbeddingService] ⬇️ Serving on LITE tier (fastembed=%s, "
+                    "~%dMB ONNX/CoreML) reason=%s — loaded in %.2fs. Will promote "
+                    "back to HIGH when headroom returns.",
+                    self._config.fastembed_model_name,
+                    self._config.fastembed_estimate_mb, reason, time.time() - start,
+                )
+                return True
+            except Exception as fe:  # noqa: BLE001 — fastembed missing / model fetch failed
+                logger.warning(
+                    "[EmbeddingService] LITE tier (fastembed) unavailable: %s", fe,
+                )
+                return False
+
+    def _release_component(self, component: str) -> None:
+        """Best-effort release of a guard budget reservation. NEVER raises."""
+        try:
+            from backend.core.proactive_resource_guard import (
+                get_proactive_resource_guard,
+            )
+            get_proactive_resource_guard().release_budget(component)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # ── Heuristic Promotion Protocol (LITE → HIGH) ──────────────────────
+    async def maybe_promote_tier(self) -> bool:
+        """Attempt a single LITE→HIGH promotion. Returns True if promoted.
+
+        Guards: only from LITE, only when enabled, only after
+        ``promotion_stable_checks`` consecutive headroom observations
+        (hysteresis), and the HIGH load is gated again at commit time. Atomic:
+        the model handle is swapped under the lock so in-flight encode() never
+        sees a half-loaded model. NEVER raises.
+        """
+        if self._shutdown_requested:
+            return False
+        if self._active_tier != EmbeddingTier.LITE:
+            return False
+        if not (self._config.adaptive_tiering_enabled and self._config.promotion_enabled):
+            return False
+
+        if not self._pytorch_headroom_available():
+            self._promotion_stable_count = 0
+            return False
+        self._promotion_stable_count += 1
+        if self._promotion_stable_count < self._config.promotion_stable_checks:
+            return False
+
+        # Gate the actual reservation (short timeout — we already saw headroom).
+        if not await self._check_memory_budget(
+            component="sentence_transformer",
+            estimated_mb=self._config.pytorch_estimate_mb,
+            timeout=2.0,
+        ):
+            self._promotion_stable_count = 0
+            return False
+
+        async with self._model_lock:
+            if self._active_tier != EmbeddingTier.LITE:  # raced
+                self._release_component("sentence_transformer")
+                return False
+            old_model = self._model
+            try:
+                start = time.time()
+                new_model = self._load_sentence_transformer()
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "[EmbeddingService] Promotion HIGH load failed (%s) — staying on LITE.", e,
+                )
+                self._release_component("sentence_transformer")
+                self._promotion_stable_count = 0
+                return False
+            self._model = new_model
+            self._active_tier = EmbeddingTier.HIGH
+            self._promotion_stable_count = 0
+            self._tier_transitions += 1
+            logger.info(
+                "[EmbeddingService] ⬆️ Promoted LITE→HIGH (fastembed→PyTorch) in "
+                "%.2fs — memory headroom recovered.", time.time() - start,
+            )
+        # Free the LITE model outside the lock.
+        with suppress(Exception):
+            del old_model
+            gc.collect()
+        return True
+
+    def _ensure_promotion_loop(self) -> None:
+        """Start the background LITE→HIGH poller once, if enabled and a loop
+        is running. Best-effort — promotion is opportunistic, never required."""
+        if not (self._config.adaptive_tiering_enabled and self._config.promotion_enabled):
+            return
+        if self._promotion_task is not None and not self._promotion_task.done():
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no running loop — caller can retry on next load
+        self._promotion_task = loop.create_task(self._promotion_loop())
+
+    async def _promotion_loop(self) -> None:
+        """Poll for headroom while degraded; exit once promoted or on shutdown."""
+        try:
+            while not self._shutdown_requested and self._active_tier == EmbeddingTier.LITE:
+                await asyncio.sleep(self._config.promotion_poll_s)
+                if self._shutdown_requested:
+                    break
+                try:
+                    if await self.maybe_promote_tier():
+                        break
+                except Exception as e:  # noqa: BLE001
+                    logger.debug("[EmbeddingService] promotion attempt error (ignored): %s", e)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._promotion_task = None
 
     async def _load_model_via_broker(self, broker) -> bool:
         """Load embedding model via Memory Control Plane broker."""
@@ -595,6 +866,15 @@ class EmbeddingService:
         self._shutdown_requested = True
         logger.info("[EmbeddingService] Starting cleanup...")
 
+        # Slice 259 — stop the background tier-promotion poller first.
+        _ptask = self._promotion_task
+        if _ptask is not None and not _ptask.done():
+            _ptask.cancel()
+            with suppress(Exception):
+                await _ptask
+        self._promotion_task = None
+        self._active_tier = EmbeddingTier.NONE
+
         try:
             # Stop any multiprocess pools that may have been started
             if self._model is not None:
@@ -632,6 +912,13 @@ class EmbeddingService:
         """
         self._shutdown_requested = True
 
+        # Slice 259 — signal the promotion poller to exit (it checks
+        # _shutdown_requested each tick); can't await from a sync context.
+        with suppress(Exception):
+            if self._promotion_task is not None and not self._promotion_task.done():
+                self._promotion_task.cancel()
+        self._active_tier = EmbeddingTier.NONE
+
         try:
             if self._model is not None:
                 if hasattr(self._model, 'stop_multi_process_pool'):
@@ -652,6 +939,8 @@ class EmbeddingService:
             "model_loaded": self._model is not None,
             "model_name": self._config.model_name,
             "device": self._config.device,
+            "active_tier": self._active_tier.name,
+            "tier_transitions": self._tier_transitions,
             "encode_count": self._encode_count,
             "cache_enabled": self._config.enable_cache,
             "cache_size": len(self._cache),

--- a/docs/architecture/OUROBOROS_VENOM_PRD.md
+++ b/docs/architecture/OUROBOROS_VENOM_PRD.md
@@ -1,6 +1,8 @@
 # Ouroboros + Venom (O+V) — Product Requirements Document & Roadmap
 
-**Version**: 3.28 (2026-06-15 — **§3.8 added — Slice 257 Battle-Test Loop-Starvation Hardening** (first clean `session_outcome=complete` after a wave of `heartbeat_stale` SIGKILLs: four event-loop / shutdown / telemetry wedges fixed — Oracle over-indexing `.claude/worktrees` (29.5k duplicate `.py`), posture `commit_ratios` forking git ON the loop thread (108s block), Oracle shutdown cache-write wedge, harvester false-positive OOM; 41 regression tests green; merged to main). — see §3.7 below)
+**Version**: 3.29 (2026-06-16 — **§3.9 added — Slice 259 Adaptive Model Tiering Engine (Sovereign Adaptive Memory Matrix)** (EmbeddingService tiers instead of failing under memory pressure: HIGH PyTorch ~800MB ⇄ LITE fastembed/ONNX-CoreML ~200MB; denial-triggered demotion + headroom-triggered promotion with hysteresis + atomic model swap; fastembed added to primary requirements.txt; 11 engine tests; live-validated on M1. ARM64 asm = compute not memory; Rust int8 quant deferred). — see §3.9 below)
+>
+> 3.28 (2026-06-15 — **§3.8 added — Slice 257 Battle-Test Loop-Starvation Hardening** (first clean `session_outcome=complete` after a wave of `heartbeat_stale` SIGKILLs: four event-loop / shutdown / telemetry wedges fixed — Oracle over-indexing `.claude/worktrees` (29.5k duplicate `.py`), posture `commit_ratios` forking git ON the loop thread (108s block), Oracle shutdown cache-write wedge, harvester false-positive OOM; 41 regression tests green; merged to main). — see §3.7 below)
 >
 > 3.27 (2026-06-12 — **§51.11.34 added — Soak Reliability + Token-Economic Arc (Slices 217-224)** (five-layer onion: funding->sleep->Aegis-token-1h-expiry->stale-ledger-hostage->sensor-self-DDoS; audited soak spend ~$1.90 not $26; P2a cache + /spend + $2/h rail COMPLETE; BLUNT: cost solved, file-00 still won't dispatch -> autonomy blocker is non-economic; roadmap A1 trace-dispatch > A2 QoS > B1 Claude-Batch > B2 compression > B3 UCCI-calibration > C1 /session/refresh > C2 non-sleeping-host). — full version history in OUROBOROS_VENOM_PRD_HISTORY.md)
 
@@ -908,6 +910,20 @@ See §9 Phase 10 for the full slice-by-slice plan.
 - The autonomous organism resets the shared checkout to `origin/main` mid-run — **commit fixes to a branch (or isolate in a worktree) before running the battle test**; running *from* the fix branch keeps it active (the harness branches `ouroboros/battle-test/<ts>` from current HEAD).
 - The battle test needs unsandboxed socket bind (Aegis IPC daemon) + provider network.
 - Claude (Tier-1 fallback) being out of credit is the 3-tier failback case; leave it **enabled** — `JARVIS_PROVIDER_CLAUDE_DISABLED=true` removes the fallback DW model-dispatch needs (`sentinel_dispatch_no_fallback` churn). DW (Tier-0 primary) carries the load; the Claude economic breaker trips fast and demotes IMMEDIATE→STANDARD→DW.
+
+---
+
+### 3.9 Slice 259 — Adaptive Model Tiering Engine (Sovereign Adaptive Memory Matrix) *(NEW 2026-06-16)*
+
+**The EmbeddingService no longer fails under memory pressure — it tiers.** A soak on the M1 host showed `[EmbeddingService] ❌ Insufficient memory to load model` when the `ProactiveResourceGuard` denied the ~800MB PyTorch SentenceTransformer (host at 77% used / ~4GB free). The physics: the memory lever is the **model's footprint** (quantization / a leaner runtime), not the memory *monitor* and not ARM64 assembly (assembly is a *compute* lever — NEON `arm64_dot_product`/`l2_norm`/`matvec` speed up vector math but don't shrink RAM; the Rust `RustMemoryMonitor` only measures and isn't even built). The right lever already lives in the repo: **fastembed** (ONNX Runtime + CoreML/ARM64, `BAAI/bge-small-en-v1.5`, ~200MB, 384-dim — dimension-compatible with `all-MiniLM-L6-v2`), exposed via the Slice 153 `_FastembedSTAdapter`. ONNX Runtime ships optimized ARM64/CoreML kernels, so the LITE tier gets assembly-grade speed for free.
+
+Rather than a brittle static fallback, the service runs a two-tier adaptive FSM (`backend/core/embedding_service.py`):
+
+- **Phase 1 — parity.** `fastembed>=0.3.0` added to the primary `requirements.txt` (it was only in `requirements-semantic.txt`) and installed on the M1 — the `ModuleNotFoundError` blocker is closed.
+- **Phase 2 — adaptive demotion.** `EmbeddingTier` (`HIGH`=PyTorch / `LITE`=fastembed / `NONE`). `_load_model` tries the HIGH tier (broker- or guard-gated at `pytorch_estimate_mb`); on **denial or torch-absence** it pivots to `_try_load_fastembed_tier` (gated at `fastembed_estimate_mb` + `lite_floor_gb`) instead of degrading to no embeddings. Validated live: HIGH-denied → real fastembed LITE loaded in ~1.2s → working 384-dim encodes.
+- **Phase 3 — heuristic promotion (blindspot armor).** A background poller (`_promotion_loop`, `promotion_poll_s`, default 60s) calls `maybe_promote_tier()` while on LITE: when `_pytorch_headroom_available()` holds for `promotion_stable_checks` consecutive observations (hysteresis, default 2) **and** the gate re-grants at commit time, it loads PyTorch and **atomically swaps the model under the lock** (in-flight `encode()` never sees a half-loaded model), then frees the LITE handle. The system *climbs back* to full fidelity when the host recovers — it never degrades permanently.
+
+All thresholds are env-tunable (`JARVIS_EMBEDDING_ADAPTIVE_TIERING` / `_ADAPTIVE_PROMOTION`, `EMBEDDING_{PYTORCH,FASTEMBED}_ESTIMATE_MB`, `EMBEDDING_PROMOTION_{POLL_S,STABLE_CHECKS,HEADROOM_GB}`, `EMBEDDING_LITE_FLOOR_GB`) — no hardcoded numbers in the logic. Observability via `active_tier` / `tier_status()` / `get_stats()["active_tier"]`. 11 engine tests + 14 existing embedding/broker/fallback tests green. *(Footnote: the Rust int8 quantization path — `quantized_inference.rs`'s own "4× memory reduction" — is the bigger torch-free native route, deferred: it needs the crate built + a full transformer runtime, where fastembed/ONNX already delivers the win.)*
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -209,6 +209,13 @@ numpy>=1.26.4,<2.5
 oauthlib==3.3.1
 opencv-python==4.10.0.84
 onnxruntime==1.19.2
+# fastembed — the LITE embedding tier of the Adaptive Model Tiering Engine
+# (EmbeddingService). ONNX/CoreML-backed bge-small (~200MB) the service pivots
+# to when the ~800MB PyTorch SentenceTransformer is denied under memory
+# pressure, and promotes back from once headroom returns. Rides the pinned
+# onnxruntime==1.19.2 above (fastembed needs onnxruntime>=1.17). Mirrors the
+# pin already in requirements-semantic.txt so the primary env has parity.
+fastembed>=0.3.0
 faster-whisper==1.2.1
 openai-whisper==20250625
 opentelemetry-api==1.39.0

--- a/tests/core/test_slice259_adaptive_embedding_tiering.py
+++ b/tests/core/test_slice259_adaptive_embedding_tiering.py
@@ -1,0 +1,186 @@
+"""Slice 259 — Adaptive Model Tiering Engine (Sovereign Adaptive Memory Matrix).
+
+The EmbeddingService runs on one of two tiers and adapts to host memory:
+  * HIGH  — PyTorch SentenceTransformer (~800MB)
+  * LITE  — fastembed / ONNX-CoreML (~200MB), dimension-compatible
+
+Pins:
+  §1  HIGH loads when the memory budget is granted
+  §2  HIGH denial → graceful DEMOTION to the LITE tier (not "no embeddings")
+  §3  torch absent → DEMOTION to LITE
+  §4  both tiers unaffordable → full degradation (no model), tier stays NONE
+  §5  PROMOTION LITE→HIGH once headroom returns, with hysteresis
+  §6  no promotion without headroom / from HIGH / when disabled
+  §7  observability surfaces the active tier
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import backend.core.embedding_service as es
+from backend.core.embedding_service import EmbeddingServiceConfig, EmbeddingTier
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+class _FakeModel:
+    def __init__(self, tag: str):
+        self.tag = tag
+
+
+async def _granted(*_a, **_k):
+    return True
+
+
+async def _denied(*_a, **_k):
+    return False
+
+
+def _fresh(monkeypatch, **cfg_overrides):
+    """A clean, singleton-reset EmbeddingService with the broker forced off
+    (so the deterministic legacy budget gate runs) and promotion off by
+    default (tests that exercise promotion re-enable it)."""
+    import backend.core.memory_budget_broker as mbb
+    monkeypatch.setattr(mbb, "get_memory_budget_broker", lambda: None, raising=False)
+    cfg = EmbeddingServiceConfig.from_env()
+    cfg.promotion_enabled = cfg_overrides.pop("promotion_enabled", False)
+    for k, v in cfg_overrides.items():
+        setattr(cfg, k, v)
+    es.EmbeddingService._instance = None
+    return es.EmbeddingService(config=cfg)
+
+
+# ── §1 HIGH loads when granted ──────────────────────────────────────────
+def test_high_tier_loads_when_budget_granted(monkeypatch):
+    svc = _fresh(monkeypatch)
+    monkeypatch.setattr(svc, "_check_memory_budget", _granted)
+    monkeypatch.setattr(svc, "_load_sentence_transformer", lambda: _FakeModel("high"))
+    assert asyncio.run(svc._load_model()) is True
+    assert svc.active_tier == EmbeddingTier.HIGH
+    assert svc._model.tag == "high"
+
+
+# ── §2 demotion on budget denial ────────────────────────────────────────
+def test_demotes_to_lite_on_budget_denial(monkeypatch):
+    svc = _fresh(monkeypatch)
+    monkeypatch.setattr(svc, "_check_memory_budget", _denied)            # deny HIGH
+    monkeypatch.setattr(svc, "_lite_headroom_available", lambda: True)
+    monkeypatch.setattr(svc, "_make_fastembed_model", lambda factory=None: _FakeModel("lite"))
+    assert asyncio.run(svc._load_model()) is True
+    assert svc.active_tier == EmbeddingTier.LITE
+    assert svc._model.tag == "lite"
+    assert svc._tier_transitions == 1
+
+
+# ── §3 torch absent → demote ────────────────────────────────────────────
+def test_demotes_when_torch_absent(monkeypatch):
+    svc = _fresh(monkeypatch)
+    monkeypatch.setattr(svc, "_check_memory_budget", _granted)           # budget OK
+    def _no_torch():
+        raise ImportError("No module named 'sentence_transformers'")
+    monkeypatch.setattr(svc, "_load_sentence_transformer", _no_torch)
+    monkeypatch.setattr(svc, "_lite_headroom_available", lambda: True)
+    monkeypatch.setattr(svc, "_make_fastembed_model", lambda factory=None: _FakeModel("lite"))
+    assert asyncio.run(svc._load_model()) is True
+    assert svc.active_tier == EmbeddingTier.LITE
+
+
+# ── §4 full degradation ─────────────────────────────────────────────────
+def test_full_degradation_when_no_tier_affordable(monkeypatch):
+    svc = _fresh(monkeypatch)
+    monkeypatch.setattr(svc, "_check_memory_budget", _denied)            # deny HIGH
+    monkeypatch.setattr(svc, "_lite_headroom_available", lambda: False)  # deny LITE
+    assert asyncio.run(svc._load_model()) is False
+    assert svc.active_tier == EmbeddingTier.NONE
+    assert svc._model is None
+
+
+# ── §5 promotion with hysteresis ────────────────────────────────────────
+def test_promotes_lite_to_high_after_stable_headroom(monkeypatch):
+    svc = _fresh(monkeypatch, promotion_enabled=True, promotion_stable_checks=2)
+    svc._model = _FakeModel("lite")
+    svc._active_tier = EmbeddingTier.LITE
+    monkeypatch.setattr(svc, "_pytorch_headroom_available", lambda: True)
+    monkeypatch.setattr(svc, "_check_memory_budget", _granted)
+    monkeypatch.setattr(svc, "_load_sentence_transformer", lambda: _FakeModel("high"))
+
+    # 1st observation: hysteresis not satisfied yet.
+    assert asyncio.run(svc.maybe_promote_tier()) is False
+    assert svc.active_tier == EmbeddingTier.LITE
+    assert svc._promotion_stable_count == 1
+    # 2nd observation: promote.
+    assert asyncio.run(svc.maybe_promote_tier()) is True
+    assert svc.active_tier == EmbeddingTier.HIGH
+    assert svc._model.tag == "high"
+
+
+def test_headroom_flap_resets_hysteresis(monkeypatch):
+    svc = _fresh(monkeypatch, promotion_enabled=True, promotion_stable_checks=2)
+    svc._model = _FakeModel("lite")
+    svc._active_tier = EmbeddingTier.LITE
+    monkeypatch.setattr(svc, "_check_memory_budget", _granted)
+    monkeypatch.setattr(svc, "_load_sentence_transformer", lambda: _FakeModel("high"))
+
+    headroom = {"v": True}
+    monkeypatch.setattr(svc, "_pytorch_headroom_available", lambda: headroom["v"])
+    assert asyncio.run(svc.maybe_promote_tier()) is False  # count 1
+    headroom["v"] = False
+    assert asyncio.run(svc.maybe_promote_tier()) is False  # resets to 0
+    assert svc._promotion_stable_count == 0
+    assert svc.active_tier == EmbeddingTier.LITE
+
+
+# ── §6 promotion guards ─────────────────────────────────────────────────
+def test_no_promotion_without_headroom(monkeypatch):
+    svc = _fresh(monkeypatch, promotion_enabled=True)
+    svc._model = _FakeModel("lite")
+    svc._active_tier = EmbeddingTier.LITE
+    monkeypatch.setattr(svc, "_pytorch_headroom_available", lambda: False)
+    assert asyncio.run(svc.maybe_promote_tier()) is False
+    assert svc.active_tier == EmbeddingTier.LITE
+
+
+def test_no_promotion_when_already_high(monkeypatch):
+    svc = _fresh(monkeypatch, promotion_enabled=True)
+    svc._model = _FakeModel("high")
+    svc._active_tier = EmbeddingTier.HIGH
+    assert asyncio.run(svc.maybe_promote_tier()) is False
+    assert svc.active_tier == EmbeddingTier.HIGH
+
+
+def test_promotion_respects_disable_flag(monkeypatch):
+    svc = _fresh(monkeypatch, promotion_enabled=False)
+    svc._model = _FakeModel("lite")
+    svc._active_tier = EmbeddingTier.LITE
+    monkeypatch.setattr(svc, "_pytorch_headroom_available", lambda: True)
+    assert asyncio.run(svc.maybe_promote_tier()) is False
+    assert svc.active_tier == EmbeddingTier.LITE
+
+
+def test_promotion_high_load_failure_stays_on_lite(monkeypatch):
+    svc = _fresh(monkeypatch, promotion_enabled=True, promotion_stable_checks=1)
+    svc._model = _FakeModel("lite")
+    svc._active_tier = EmbeddingTier.LITE
+    monkeypatch.setattr(svc, "_pytorch_headroom_available", lambda: True)
+    monkeypatch.setattr(svc, "_check_memory_budget", _granted)
+    def _boom():
+        raise RuntimeError("OOM during load")
+    monkeypatch.setattr(svc, "_load_sentence_transformer", _boom)
+    assert asyncio.run(svc.maybe_promote_tier()) is False
+    assert svc.active_tier == EmbeddingTier.LITE  # never lost the working LITE model
+    assert svc._model.tag == "lite"
+
+
+# ── §7 observability ────────────────────────────────────────────────────
+def test_tier_status_and_stats_reflect_tier(monkeypatch):
+    svc = _fresh(monkeypatch)
+    svc._active_tier = EmbeddingTier.LITE
+    status = svc.tier_status()
+    assert status["active_tier"] == "LITE"
+    assert "promotion_loop_running" in status
+    assert svc.get_stats()["active_tier"] == "LITE"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## The Sovereign Adaptive Memory Matrix

A soak surfaced `[EmbeddingService] ❌ Insufficient memory to load model` — the `ProactiveResourceGuard` denied the ~800MB PyTorch SentenceTransformer on the M1 (host 77% used) and long-term memory died. The lever for *memory* is the model's **footprint**, not the memory *monitor* and not ARM64 assembly (asm = compute: NEON `arm64_dot_product`/`matvec` speed up math but don't shrink RAM; the Rust `RustMemoryMonitor` only measures and isn't built). The right lever already lives in the repo: **fastembed** (ONNX/CoreML `bge-small`, ~200MB, 384-dim — dimension-compatible), via the Slice 153 `_FastembedSTAdapter`. ONNX RT ships ARM64/CoreML kernels, so LITE gets assembly-grade speed for free.

### Phase 1 — Dependency parity
`fastembed>=0.3.0` added to the primary `requirements.txt` (was only in `requirements-semantic.txt`). Installed + validated on the M1 (rides the pinned `onnxruntime==1.19.2`; native `arm64` `py-rust-stemmers`).

### Phase 2 — Adaptive demotion
`EmbeddingTier` (HIGH / LITE / NONE). `_load_model` tries HIGH (broker- or guard-gated at `pytorch_estimate_mb`); on **denial OR torch-absence** it pivots to `_try_load_fastembed_tier` (gated at `fastembed_estimate_mb` + `lite_floor_gb`) — not "no embeddings". **Live-validated:** HIGH-denied → real fastembed LITE loaded in ~1.2s → working 384-dim encodes (cosine 0.53 on related text).

### Phase 3 — Heuristic promotion (blindspot armor)
Background poller (`_promotion_loop`, default 60s) runs while on LITE; when `_pytorch_headroom_available()` holds for `promotion_stable_checks` consecutive observations (hysteresis, default 2) **and** the gate re-grants at commit, it loads PyTorch and **atomically swaps the model under the lock** (in-flight `encode()` never sees a half-loaded model), then frees LITE. The system **climbs back** to full fidelity — never permanently degraded.

All thresholds env-tunable — no hardcoded numbers. Observability via `active_tier` / `tier_status()` / `get_stats()`.

**Tests:** 11 new engine tests (demotion / torch-absence / full-degradation / promotion-with-hysteresis / flap-resets / guards / load-failure-stays-LITE / observability) + 14 existing embedding/broker/fallback tests green.

Docs: PRD §3.9 (version 3.28 → 3.29).

*Footnote:* the Rust int8 quantization path (`quantized_inference.rs`'s own "4× memory reduction") is the bigger torch-free native route — deferred: it needs the crate built + a full transformer runtime, where fastembed/ONNX already delivers the win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds adaptive model tiering to `EmbeddingService` so it demotes to a lighter ONNX/CoreML model under memory pressure and promotes back to the PyTorch model when headroom returns. Prevents embeddings from failing on constrained hosts.

- **New Features**
  - `EmbeddingTier` with HIGH → LITE → NONE.
  - Demotes to LITE when the memory budget is denied or PyTorch is unavailable.
  - Background promotion from LITE to HIGH with hysteresis and atomic model swap.
  - Env flags for thresholds and polling (e.g., `JARVIS_EMBEDDING_ADAPTIVE_TIERING`, `EMBEDDING_PROMOTION_*`).
  - Observability via `active_tier`, `tier_status()`, and `get_stats()`.
  - 11 new tests covering demotion, promotion, guards, and observability.

- **Dependencies**
  - Added `fastembed>=0.3.0` to `requirements.txt` (runs with pinned `onnxruntime==1.19.2`).

<sup>Written for commit d5eb8c1bf42f98ee3a611c65ef6ef06efce05986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

