### PR TITLE
fix(oracle): deterministic AST-pool teardown — closes the 'Shutting down The Oracle...' deadlock

### DIFF
--- a/backend/core/ouroboros/governance/ast_compile_helper.py
+++ b/backend/core/ouroboros/governance/ast_compile_helper.py
@@ -511,19 +511,81 @@ def _get_pool() -> ProcessPoolExecutor:
     return _pool
 
 
-def shutdown_pool() -> None:
-    """Shut down the process pool (for tests + clean exit).
-    NEVER raises."""
+def _proc_alive(p: Any) -> bool:
+    """is_alive() that never raises (a torn-down handle may throw)."""
+    try:
+        return bool(p.is_alive())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def shutdown_pool(*, deadline_s: float = 5.0) -> str:
+    """Deterministically tear down the AST process pool. NEVER raises.
+
+    Returns the teardown verdict: ``"idle"`` (no pool), ``"graceful"`` (workers
+    drained within ``deadline_s``), or ``"escalated"`` (workers force-terminated).
+
+    Three layers — because ``ProcessPoolExecutor.shutdown(cancel_futures=True)``
+    only drops QUEUED futures; it cannot interrupt a worker already running an AST
+    parse. That is the v25 / bt-2026-06-16 ``Shutting down The Oracle...`` wedge:
+    an in-flight index left running workers that no public API could stop, so the
+    process never exited cleanly (and ``session_outcome`` never reached ``complete``).
+
+      1. ``shutdown(wait=False, cancel_futures=True)`` — drop the queue, don't block.
+      2. bounded ``join(timeout)`` per worker — let in-flight parses finish gracefully.
+      3. escalation — ``terminate()`` (then ``kill()``) any worker still alive past
+         the deadline. The pool can't interrupt running workers; the OS can.
+    """
     global _pool
     with _pool_lock:
-        if _pool is None:
-            return
+        pool = _pool
+        _pool = None
+    if pool is None:
+        return "idle"
+    # Snapshot the worker handles FIRST — ProcessPoolExecutor.shutdown() nulls
+    # ``_processes``, so capturing after Layer 1 loses them.
+    procs = list((getattr(pool, "_processes", None) or {}).values())
+    # Layer 1 — drop queued futures, return immediately (no join-hang).
+    try:
+        pool.shutdown(wait=False, cancel_futures=True)
+    except TypeError:                       # cancel_futures is 3.9+; degrade safely
         try:
-            _pool.shutdown(wait=False, cancel_futures=True)
+            pool.shutdown(wait=False)
         except Exception:  # noqa: BLE001
             pass
-        finally:
-            _pool = None
+    except Exception:  # noqa: BLE001
+        pass
+    # Layer 2 — bounded graceful drain of running workers.
+    deadline = time.monotonic() + max(0.0, float(deadline_s))
+    for p in procs:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            p.join(timeout=remaining)
+        except Exception:  # noqa: BLE001
+            pass
+    # Layer 3 — escalate: force-terminate stragglers the pool can't interrupt.
+    stuck = [p for p in procs if _proc_alive(p)]
+    if not stuck:
+        return "graceful"
+    for p in stuck:
+        try:
+            p.terminate()
+        except Exception:  # noqa: BLE001
+            pass
+    time.sleep(0.2)
+    for p in stuck:
+        if _proc_alive(p):
+            try:
+                p.kill()
+            except Exception:  # noqa: BLE001
+                pass
+    logger.warning(
+        "[AstCompileHelper] ORACLE_TEARDOWN_ESCALATION: force-terminated %d stuck "
+        "worker(s) past %.1fs deadline", len(stuck), float(deadline_s),
+    )
+    return "escalated"
 
 
 # ============================================================================

--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -1890,6 +1890,26 @@ def _oracle_shutdown_deadline_s() -> float:
         return _ORACLE_SHUTDOWN_DEADLINE_DEFAULT_S
 
 
+_ORACLE_POOL_TEARDOWN_DEADLINE_ENV = "JARVIS_ORACLE_POOL_TEARDOWN_DEADLINE_S"
+_ORACLE_POOL_TEARDOWN_DEADLINE_DEFAULT_S = 5.0
+
+
+def _oracle_pool_teardown_deadline_s() -> float:
+    """``JARVIS_ORACLE_POOL_TEARDOWN_DEADLINE_S`` — bound on the AST process-pool
+    teardown at shutdown. Default 5s: workers get this long to finish in-flight
+    parses gracefully before they are force-terminated. Set ``0`` to skip the
+    graceful drain and force-terminate immediately. Keep under the
+    BoundedShutdownWatchdog 30s budget (shared with the cache-save deadline)."""
+    raw = os.environ.get(
+        _ORACLE_POOL_TEARDOWN_DEADLINE_ENV,
+        str(_ORACLE_POOL_TEARDOWN_DEADLINE_DEFAULT_S),
+    )
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        return _ORACLE_POOL_TEARDOWN_DEADLINE_DEFAULT_S
+
+
 # =============================================================================
 # THE ORACLE - MAIN INDEXER
 # =============================================================================
@@ -1907,6 +1927,7 @@ class TheOracle:
         self._file_hashes: Dict[str, str] = {}  # file_path -> content hash
         self._lock = asyncio.Lock()
         self._running = False
+        self._shutting_down = False  # cancellation token: stops the indexer mid-build on shutdown
         self._last_indexed_monotonic_ns: int = 0  # set after each full index build
 
         # Repository configurations
@@ -2132,6 +2153,9 @@ class TheOracle:
         Set to ``0`` to skip ``_save_cache`` entirely on shutdown.
         """
         logger.info("Shutting down The Oracle...")
+        # Cancellation token FIRST: stop the indexer from submitting new batches so
+        # the AST pool can drain instead of fighting fresh work during teardown.
+        self._shutting_down = True
         deadline_s = _oracle_shutdown_deadline_s()
         if deadline_s <= 0.0:
             logger.info(
@@ -2152,6 +2176,32 @@ class TheOracle:
                     "or =0 to skip saves on shutdown entirely.",
                     deadline_s,
                 )
+        # Tear down the AST-indexing ProcessPoolExecutor deterministically.
+        # Closes the bt-2026-06-16 "Shutting down The Oracle..." wedge: an in-flight
+        # index left pool workers running, which blocked clean exit so
+        # session_outcome never reached "complete". Bounded drain + force-terminate
+        # (see ast_compile_helper.shutdown_pool). Runs in a thread because the
+        # graceful join is blocking; the event loop keeps ticking. NEVER raises.
+        try:
+            from backend.core.ouroboros.governance.ast_compile_helper import (
+                shutdown_pool as _shutdown_ast_pool,
+            )
+            verdict = await asyncio.to_thread(
+                _shutdown_ast_pool,
+                deadline_s=_oracle_pool_teardown_deadline_s(),
+            )
+            if verdict == "escalated":
+                logger.warning(
+                    "[Oracle.shutdown] ORACLE_TEARDOWN_ESCALATION — AST pool "
+                    "force-terminated to guarantee bounded shutdown",
+                )
+            else:
+                logger.info("[Oracle.shutdown] AST pool teardown: %s", verdict)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[Oracle.shutdown] AST pool teardown best-effort failed",
+                exc_info=True,
+            )
         self._running = False
         logger.info("The Oracle shutdown complete")
 
@@ -2293,6 +2343,15 @@ class TheOracle:
         except Exception:  # noqa: BLE001
             _await_quiescence = None  # type: ignore[assignment]
         for i in range(0, total_files, batch_size):
+            # Cancellation token: abort the build if shutdown was requested, so the
+            # AST pool can drain + teardown instead of being abandoned mid-index
+            # (the bt-2026-06-16 "Shutting down The Oracle..." wedge).
+            if self._shutting_down:
+                logger.info(
+                    "[Oracle] index of %s cancelled — shutdown requested "
+                    "(%d/%d files submitted)", repo_name, i, total_files,
+                )
+                break
             # Park at 0% CPU here if a Claude SDK stream is in flight —
             # deterministic containment, not best-effort sleep(0).
             if _await_quiescence is not None:

--- a/tests/governance/test_oracle_teardown.py
+++ b/tests/governance/test_oracle_teardown.py
@@ -1,0 +1,135 @@
+"""Oracle teardown deadlock fix — bounded + escalating AST pool shutdown.
+
+Closes the bt-2026-06-16 "Shutting down The Oracle..." wedge: an in-flight index
+left ProcessPoolExecutor workers running, blocking clean exit so session_outcome
+never reached "complete".
+"""
+from __future__ import annotations
+
+import asyncio
+import multiprocessing as mp
+import time
+from concurrent.futures import ProcessPoolExecutor
+
+import pytest
+
+import backend.core.ouroboros.governance.ast_compile_helper as A
+
+
+# --------------------------------------------------------------------------- fakes
+class _FakeProc:
+    """A worker that stays alive through join() (simulates a stuck AST parse)."""
+
+    def __init__(self, drains: bool = False):
+        self._alive = True
+        self._drains = drains
+        self.terminated = False
+        self.killed = False
+
+    def is_alive(self):
+        return self._alive
+
+    def join(self, timeout=None):
+        if self._drains:
+            self._alive = False          # finishes in-flight within the deadline
+
+    def terminate(self):
+        self.terminated = True
+        self._alive = False
+
+    def kill(self):
+        self.killed = True
+        self._alive = False
+
+
+class _FakePool:
+    def __init__(self, procs):
+        self._processes = {i: p for i, p in enumerate(procs)}
+        self.shutdown_args = None
+
+    def shutdown(self, wait=True, cancel_futures=False):
+        self.shutdown_args = (wait, cancel_futures)
+
+
+# --------------------------------------------------------------------------- logic
+def test_shutdown_pool_idle(monkeypatch):
+    monkeypatch.setattr(A, "_pool", None)
+    assert A.shutdown_pool() == "idle"
+
+
+def test_shutdown_pool_graceful(monkeypatch):
+    procs = [_FakeProc(drains=True), _FakeProc(drains=True)]
+    fake = _FakePool(procs)
+    monkeypatch.setattr(A, "_pool", fake)
+    assert A.shutdown_pool(deadline_s=1.0) == "graceful"
+    assert fake.shutdown_args == (False, True)     # queue dropped, non-blocking
+    assert not any(p.terminated for p in procs)    # no force needed
+    assert A._pool is None                          # singleton cleared
+
+
+def test_shutdown_pool_escalates_on_stuck(monkeypatch):
+    procs = [_FakeProc(drains=False), _FakeProc(drains=False)]
+    fake = _FakePool(procs)
+    monkeypatch.setattr(A, "_pool", fake)
+    assert A.shutdown_pool(deadline_s=0.05) == "escalated"
+    assert all(p.terminated for p in procs)        # force-terminated the stragglers
+    assert A._pool is None
+
+
+def test_shutdown_pool_never_raises(monkeypatch):
+    class _BadPool:
+        _processes = {0: _FakeProc()}
+        def shutdown(self, **k):
+            raise RuntimeError("nope")
+    monkeypatch.setattr(A, "_pool", _BadPool())
+    # must not raise even when shutdown() throws; still escalates the stuck proc
+    assert A.shutdown_pool(deadline_s=0.05) == "escalated"
+
+
+# --------------------------------------------------------------------------- real pool
+def test_shutdown_pool_real_hung_workers_bounded(monkeypatch):
+    """The load-bearing proof: a REAL pool with genuinely-hung 30s workers is torn
+    down in well under 5s (escalated) — it does NOT block on the 30s sleeps."""
+    pool = ProcessPoolExecutor(max_workers=2, mp_context=mp.get_context("spawn"))
+    try:
+        pool.submit(time.sleep, 30)
+        pool.submit(time.sleep, 30)
+        time.sleep(1.2)                            # let workers actually start running
+        monkeypatch.setattr(A, "_pool", pool)
+        t0 = time.monotonic()
+        verdict = A.shutdown_pool(deadline_s=0.5)
+        elapsed = time.monotonic() - t0
+        assert verdict == "escalated"
+        assert elapsed < 5.0, f"teardown took {elapsed:.1f}s — did NOT bound the hang"
+        assert A._pool is None
+    finally:
+        try:
+            pool.shutdown(wait=False, cancel_futures=True)
+        except Exception:
+            pass
+
+
+# --------------------------------------------------------------------------- oracle wiring
+def test_oracle_shutdown_invokes_pool_teardown(monkeypatch):
+    import backend.core.ouroboros.oracle as O
+    oracle = O.TheOracle()
+
+    async def _noop_save():
+        return None
+
+    monkeypatch.setattr(oracle, "_save_cache", _noop_save)
+    called = {}
+
+    def _spy(*, deadline_s):
+        called["deadline"] = deadline_s
+        return "graceful"
+
+    monkeypatch.setattr(A, "shutdown_pool", _spy)
+    asyncio.run(oracle.shutdown())
+    assert oracle._shutting_down is True            # cancellation token set
+    assert "deadline" in called                     # pool teardown invoked
+    assert oracle._running is False                  # clean completion
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## The bug (root-caused from a live soak)
Every graduation soak this session ended `in_flight_shutdown_wal`, never `session_outcome=complete` — silently failing Phase 9. Root cause: when `Oracle.shutdown()` fires mid-index, the AST `ProcessPoolExecutor`'s **running** workers were never stopped. `shutdown()` bounded only the cache-save; it never tore down the pool. And `ProcessPoolExecutor.shutdown(cancel_futures=True)` only drops **queued** futures — it cannot interrupt a worker already running an AST parse — so the process hung at `Shutting down The Oracle...`, orphaned its workers, and fell through to the atexit WAL fallback (never the clean `_generate_report` that stamps `complete`).

## The fix — Sovereign Teardown Matrix (bounded + escalating, no brute force)
- **Cancellation token** — `Oracle._shutting_down`, set first in `shutdown()`; the `_index_repository` batch loop polls it and stops submitting new work so the pool can drain.
- **`shutdown_pool(deadline_s=5.0) -> "idle"|"graceful"|"escalated"`** (upgraded the *existing* function, backward-compatible):
  1. `shutdown(wait=False, cancel_futures=True)` — drop the queue, never block.
  2. bounded `join(timeout)` per worker — graceful drain of in-flight parses.
  3. **escalation** — `terminate()` then `kill()` any worker still alive past the deadline (the pool can't interrupt running workers; the OS can), logged `ORACLE_TEARDOWN_ESCALATION`.
  - Snapshots worker handles **before** Layer 1 (`shutdown()` nulls `_processes` — caught by the real-pool test). Never raises.
- `Oracle.shutdown()` invokes it via `asyncio.to_thread` (blocking joins off the loop), bounded by `JARVIS_ORACLE_POOL_TEARDOWN_DEADLINE_S` (default 5s).

## Why this unblocks Phase 9
With teardown bounded + guaranteed, clean shutdown completes → `_generate_report` stamps `session_outcome=complete`. That's the literal prerequisite the capstone soak couldn't meet.

## Test Plan
- [x] **6 new tests** — idle/graceful/escalated logic, never-raises, oracle wiring (token + teardown + clean completion).
- [x] **Load-bearing proof**: a real pool with two genuinely-hung `time.sleep(30)` workers is torn down in **<5s** (escalated), not 30s.
- [x] **34 existing tests green** (`test_slice32_oracle_process_pool`, `test_slice11_ast_compile_helper`) — `shutdown_pool()` no-arg callers unaffected.
- [ ] Operator: a follow-up headless soak should now reach `session_outcome=complete` (the capstone `/goal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the shutdown deadlock by adding a bounded, deterministic teardown for the AST process pool so clean shutdown completes and sessions reach "complete".

- **Bug Fixes**
  - Added a shutdown cancellation token to stop submitting new index batches mid-build.
  - Implemented `shutdown_pool(deadline_s)` with a 3-step strategy: drop queued futures, bounded `join()`, then `terminate()/kill()` if still running; returns "idle"/"graceful"/"escalated" and never raises.
  - `Oracle.shutdown()` runs pool teardown in a thread; deadline controlled by `JARVIS_ORACLE_POOL_TEARDOWN_DEADLINE_S` (default 5s). Logs escalation.
  - Added tests covering idle/graceful/escalated paths and a real pool with hung workers (<5s teardown). Existing callers of `shutdown_pool()` remain compatible.

<sup>Written for commit e4b4e7e796a41eb17d559affb8345cf3c074341e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

