### PR TITLE
feat(oracle): Phase 1 — Adaptive Backpressure for the cold index (cures ControlPlaneStarvation)

### DIFF
--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -1894,6 +1894,66 @@ _ORACLE_POOL_TEARDOWN_DEADLINE_ENV = "JARVIS_ORACLE_POOL_TEARDOWN_DEADLINE_S"
 _ORACLE_POOL_TEARDOWN_DEADLINE_DEFAULT_S = 5.0
 
 
+def _oracle_backpressure_enabled() -> bool:
+    """``JARVIS_ORACLE_BACKPRESSURE_ENABLED`` (default true) — AIMD throttle on the
+    index batch loop so cold indexing yields to the FSM control plane instead of
+    starving it (the ControlPlaneStarvation cold-boot wedge). Kill switch ``=0``
+    restores the fixed-batch firehose."""
+    raw = os.environ.get("JARVIS_ORACLE_BACKPRESSURE_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _oracle_backpressure_lag_ms() -> float:
+    """``JARVIS_ORACLE_BACKPRESSURE_LAG_MS`` — event-loop lag (ms) above which the
+    index throttles its concurrency. Default 50ms (control-plane comfort band)."""
+    try:
+        return max(1.0, float(os.environ.get("JARVIS_ORACLE_BACKPRESSURE_LAG_MS", "50")))
+    except (TypeError, ValueError):
+        return 50.0
+
+
+def _oracle_backpressure_min_batch() -> int:
+    """``JARVIS_ORACLE_BACKPRESSURE_MIN_BATCH`` — floor for the throttled batch so
+    progress never fully stalls. Default 4."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_ORACLE_BACKPRESSURE_MIN_BATCH", "4")))
+    except (TypeError, ValueError):
+        return 4
+
+
+class _AdaptiveIndexThrottle:
+    """AIMD backpressure for the Oracle index batch loop.
+
+    Multiplicative-DECREASE the batch size (= per-cycle ProcessPool concurrency) when
+    measured event-loop lag exceeds the threshold; additive-INCREASE back toward the
+    ceiling when the loop is responsive. The classic congestion-control shape:
+    background indexing gracefully yields cores to the primary FSM, then reclaims them
+    once the control plane has breathing room. Pure decision logic — no I/O, testable.
+    """
+
+    def __init__(self, *, max_batch: int, min_batch: int = 4, lag_threshold_ms: float = 50.0):
+        self.max_batch = max(1, int(max_batch))
+        self.min_batch = max(1, min(int(min_batch), self.max_batch))
+        self.lag_threshold_ms = max(1.0, float(lag_threshold_ms))
+        self.batch = self.max_batch
+        self._increment = max(1, self.max_batch // 8)
+
+    def update(self, lag_ms: float) -> int:
+        """Fold one lag observation into the batch size; return the new size."""
+        if lag_ms > self.lag_threshold_ms:
+            self.batch = max(self.min_batch, self.batch // 2)               # MD
+        else:
+            self.batch = min(self.max_batch, self.batch + self._increment)  # AI
+        return self.batch
+
+    def backoff_s(self, lag_ms: float) -> float:
+        """Seconds to yield the loop when lagging — proportional to the overshoot,
+        capped so one bad reading can't park indexing for long."""
+        if lag_ms <= self.lag_threshold_ms:
+            return 0.0
+        return min(0.5, (lag_ms - self.lag_threshold_ms) / 1000.0)
+
+
 def _oracle_pool_teardown_deadline_s() -> float:
     """``JARVIS_ORACLE_POOL_TEARDOWN_DEADLINE_S`` — bound on the AST process-pool
     teardown at shutdown. Default 5s: workers get this long to finish in-flight
@@ -2294,6 +2354,16 @@ class TheOracle:
         elapsed = time.time() - start_time
         logger.info(f"Incremental update complete in {elapsed:.2f}s")
 
+    async def _measure_loop_lag_ms(self, probe_s: float = 0.02) -> float:
+        """Cheap event-loop lag probe: how far a short ``asyncio.sleep`` overshoots
+        is how backed-up the loop is right now. Pure timing; never raises."""
+        try:
+            t0 = time.monotonic()
+            await asyncio.sleep(probe_s)
+            return max(0.0, (time.monotonic() - t0 - probe_s) * 1000.0)
+        except Exception:  # noqa: BLE001
+            return 0.0
+
     async def _index_repository(self, repo_name: str, repo_path: Path) -> None:
         """Index all Python files in a repository."""
         logger.info(f"Indexing repository: {repo_name} at {repo_path}")
@@ -2342,7 +2412,22 @@ class TheOracle:
             )
         except Exception:  # noqa: BLE001
             _await_quiescence = None  # type: ignore[assignment]
-        for i in range(0, total_files, batch_size):
+        # Adaptive backpressure (Phase 1): AIMD throttle so cold indexing yields to the
+        # FSM control plane instead of starving it (ControlPlaneStarvation cold-boot
+        # wedge). When disabled, ``effective`` stays pinned at the full batch_size — the
+        # legacy fixed-batch firehose, behaviorally unchanged.
+        _throttle = (
+            _AdaptiveIndexThrottle(
+                max_batch=batch_size,
+                min_batch=_oracle_backpressure_min_batch(),
+                lag_threshold_ms=_oracle_backpressure_lag_ms(),
+            )
+            if _oracle_backpressure_enabled()
+            else None
+        )
+        i = 0
+        _batch_no = 0
+        while i < total_files:
             # Cancellation token: abort the build if shutdown was requested, so the
             # AST pool can drain + teardown instead of being abandoned mid-index
             # (the bt-2026-06-16 "Shutting down The Oracle..." wedge).
@@ -2359,20 +2444,20 @@ class TheOracle:
                     await _await_quiescence(label="oracle_index_repository")
                 except Exception:  # noqa: BLE001 — never break the index
                     pass
-            batch = python_files[i:i + batch_size]
+            effective = _throttle.batch if _throttle is not None else batch_size
+            batch = python_files[i:i + effective]
             tasks = [
                 self._index_file(repo_name, repo_path, file_path)
                 for file_path in batch
             ]
             await asyncio.gather(*tasks, return_exceptions=True)
+            i += len(batch)
+            _batch_no += 1
+            _is_last_batch = i >= total_files
             # Durable partial checkpoint (see cadence note above).  Never
             # let a checkpoint failure break the index — durability is a
             # best-effort enhancement, not a correctness dependency.
-            _batch_idx = i // batch_size
-            _is_last_batch = (i + batch_size) >= total_files
-            if _ck_every_n > 0 and (
-                _is_last_batch or (_batch_idx > 0 and _batch_idx % _ck_every_n == 0)
-            ):
+            if _ck_every_n > 0 and (_is_last_batch or _batch_no % _ck_every_n == 0):
                 try:
                     await self._save_cache()
                 except Exception:  # noqa: BLE001 — never break the index
@@ -2380,18 +2465,26 @@ class TheOracle:
             # Emit progress at most every 5s OR on the last batch — bounds
             # log volume on fast SSDs while still surfacing forward motion.
             _now = time.monotonic()
-            files_done = min(i + batch_size, total_files)
-            is_last = files_done >= total_files
-            if is_last or (_now - _last_progress_log) >= 5.0:
+            files_done = min(i, total_files)
+            if _is_last_batch or (_now - _last_progress_log) >= 5.0:
                 rate = files_done / max(_now - _t_batch_start, 0.001)
                 pct = 100.0 * files_done / max(total_files, 1)
+                _bp_note = f" batch={effective}" if _throttle is not None else ""
                 logger.info(
                     "[Oracle.index] %s: %d/%d files (%.1f%%) "
-                    "rate=%.0f files/s elapsed=%.1fs",
+                    "rate=%.0f files/s elapsed=%.1fs%s",
                     repo_name, files_done, total_files, pct,
-                    rate, _now - _t_batch_start,
+                    rate, _now - _t_batch_start, _bp_note,
                 )
                 _last_progress_log = _now
+            # Adaptive backpressure: measure loop lag, throttle next-batch concurrency,
+            # and yield the loop proportional to the overshoot so the FSM can breathe.
+            if _throttle is not None and not _is_last_batch:
+                lag_ms = await self._measure_loop_lag_ms()
+                _throttle.update(lag_ms)
+                _backoff = _throttle.backoff_s(lag_ms)
+                if _backoff > 0.0:
+                    await asyncio.sleep(_backoff)
 
         self._graph._metrics["files_indexed"] = total_files
 

--- a/tests/governance/test_oracle_backpressure.py
+++ b/tests/governance/test_oracle_backpressure.py
@@ -1,0 +1,89 @@
+"""Phase 1 — Adaptive Backpressure for the Oracle cold index.
+
+Cures the ControlPlaneStarvation cold-boot wedge: AIMD throttle on the index batch
+loop so background indexing yields cores to the FSM control plane.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import backend.core.ouroboros.oracle as O
+
+
+def _throttle(max_batch=50, min_batch=4, lag=50.0):
+    return O._AdaptiveIndexThrottle(max_batch=max_batch, min_batch=min_batch, lag_threshold_ms=lag)
+
+
+# --------------------------------------------------------------------------- AIMD
+def test_decreases_multiplicatively_on_lag():
+    t = _throttle(max_batch=50)
+    assert t.batch == 50
+    assert t.update(200.0) == 25     # > threshold → halve
+    assert t.update(200.0) == 12
+    assert t.update(200.0) == 6
+
+
+def test_increases_additively_when_responsive():
+    t = _throttle(max_batch=64)
+    t.update(500.0)  # drop to 32
+    b1 = t.batch
+    nb = t.update(5.0)               # below threshold → +max//8 (=8)
+    assert nb == b1 + 8
+
+
+def test_floor_never_below_min():
+    t = _throttle(max_batch=50, min_batch=4)
+    for _ in range(20):
+        t.update(999.0)
+    assert t.batch == 4              # clamped at the floor
+
+
+def test_ceiling_never_above_max():
+    t = _throttle(max_batch=50)
+    for _ in range(50):
+        t.update(0.0)
+    assert t.batch == 50            # clamped at the ceiling
+
+
+def test_backoff_proportional_and_capped():
+    t = _throttle(lag=50.0)
+    assert t.backoff_s(40.0) == 0.0                 # below threshold → no backoff
+    assert t.backoff_s(150.0) == pytest.approx(0.1)  # (150-50)/1000
+    assert t.backoff_s(10_000.0) == 0.5             # capped
+
+
+def test_aimd_recovery_cycle():
+    t = _throttle(max_batch=64, min_batch=4)
+    t.update(300.0); t.update(300.0)               # decrease under load
+    low = t.batch
+    for _ in range(20):
+        t.update(1.0)                               # sustained calm → recover to max
+    assert t.batch == 64 and low < 64
+
+
+# --------------------------------------------------------------------------- probe + flag
+def test_lag_probe_nonnegative():
+    # the probe is pure timing — doesn't touch self; call it unbound with self=None
+    lag = asyncio.run(O.TheOracle._measure_loop_lag_ms(None, probe_s=0.01))
+    assert isinstance(lag, float) and lag >= 0.0
+
+
+def test_backpressure_enabled_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_ORACLE_BACKPRESSURE_ENABLED", raising=False)
+    assert O._oracle_backpressure_enabled() is True
+
+
+def test_backpressure_kill_switch(monkeypatch):
+    monkeypatch.setenv("JARVIS_ORACLE_BACKPRESSURE_ENABLED", "0")
+    assert O._oracle_backpressure_enabled() is False
+
+
+def test_lag_threshold_env_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_ORACLE_BACKPRESSURE_LAG_MS", "120")
+    assert O._oracle_backpressure_lag_ms() == 120.0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Root cause
The cold-boot wedge wasn't the Oracle teardown (that's fixed in #69538) — it was **upstream**: the index batch loop dispatched a **fixed 50-file ProcessPool firehose** per cycle, hoarding cores and **starving the FSM control plane** (`ControlPlaneStarvation lag_ms=3209`). The loop never went idle → never reached the (now-fixed) shutdown → every soak ended `in_flight_shutdown_wal`. And because the cold index never *finished*, it never saved the cache → next boot cold again (chicken-and-egg).

## Fix — AIMD Adaptive Backpressure (no light-index workaround)
- **`_AdaptiveIndexThrottle`** — multiplicative-decrease the batch size (per-cycle concurrency) when measured loop lag exceeds the threshold; additive-increase back toward the ceiling when responsive. Classic congestion control; pure, tested decision logic.
- **`_measure_loop_lag_ms`** — cheap sleep-overshoot probe at each batch boundary (no parallel monitor; dependency-free).
- **Index loop** restructured `for`→`while` with a dynamic `effective` batch + proportional, capped backoff yield. Background indexing **gracefully yields cores to primary FSM ops**, then reclaims them once the control plane has room.

## Why this also conquers the cold boot
With the index no longer starving the loop, it can actually **complete** → the **existing** periodic checkpoint finally lands → warm boot thereafter. (This is why I rejected Option B's light-index bypass — backpressure fixes the real concurrency defect *and* unblocks caching, instead of skipping the work.)

## Gating
`JARVIS_ORACLE_BACKPRESSURE_ENABLED` (default **true**; kill switch restores the fixed firehose, behaviorally unchanged). Tunable: `_LAG_MS` (50ms), `_MIN_BATCH` (4).

## Test Plan
- [x] **10 new tests** — AIMD decrease/increase/floor/ceiling, proportional+capped backoff, recovery cycle, lag probe, flags.
- [x] **50 existing oracle/pool tests green**; the 1 failing `cache-atomic` AST-pin is **pre-existing on `origin/main`** (verified by stash — diff never touches `_save_cache`).

## Scope note (Phases 2 & 3)
- **Phase 3 (workspace reclaim)** — done operationally this session (rogue loop killed, main reclaimed).
- **Phase 2 (incremental streaming cache / SQLite)** — deferred to its own dedicated slice: it's a major persistence-layer refactor, and **Phase 1 already lets the existing periodic checkpoint function**, so the cold-boot blocker is addressed without rushing a risky pickle→SQLite migration onto this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AIMD backpressure to the Oracle cold index to stop starving the FSM control plane and fix the cold-boot wedge. Indexing now adapts concurrency and briefly yields under load so checkpoints complete and warm boots stick.

- **New Features**
  - `_AdaptiveIndexThrottle`: halves batch on lag, adds toward max when healthy; proportional, capped sleep between batches.
  - `_measure_loop_lag_ms`: lightweight sleep-overshoot probe to detect event-loop lag.
  - Dynamic batch loop replaces the fixed 50-file firehose; preserves quiescence and periodic checkpoints.
  - Env toggles: `JARVIS_ORACLE_BACKPRESSURE_ENABLED` (default true), `JARVIS_ORACLE_BACKPRESSURE_LAG_MS` (default 50), `JARVIS_ORACLE_BACKPRESSURE_MIN_BATCH` (default 4).
  - New tests cover AIMD behavior, backoff, probe, and flags.

<sup>Written for commit 1f6a44e7038f46aee616927eced8d06727450f86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

