### PR TITLE
bench(oracle): Quad-modal persistence benchmark → empirical verdict (proceed with aiosqlite)

### DIFF
--- a/docs/architecture/ORACLE_PERSISTENCE_BENCHMARK_RESULTS.md
+++ b/docs/architecture/ORACLE_PERSISTENCE_BENCHMARK_RESULTS.md
@@ -1,0 +1,131 @@
+# Oracle Persistence — Synthetic Quad-Modal Benchmark Results
+
+> **Gate:** `ORACLE_PERSISTENCE_ADD.md` §9 (Benchmark Gate). Phase-2 implementation is
+> blocked until empirical data picks the persistence backend. This document is that data.
+> **Harness:** `scripts/benchmarks/oracle_persistence_benchmark.py` (self-contained, repeatable).
+
+## TL;DR — the data validates SQLite, but *not* for the reason the ADD assumed
+
+The race was framed as tri-modal (monolithic pickle vs chunked pickle vs aiosqlite). During
+execution the per-file chunked mode exposed a filesystem-overhead problem on load, so I added a
+**fourth** mode — *coarse* chunking (shard by package, ~50 shards) — to test the obvious fix.
+
+That fourth mode is what makes the verdict trustworthy: **coarse chunking fixes the load
+regression but destroys the checkpoint advantage**, because a realistic scatter of edits touches
+nearly every coarse shard. SQLite is the *only* design that is good on both axes at once — its
+update granularity (row) is decoupled from its read granularity (bulk SELECT), so it sidesteps
+the chunk-size tension entirely.
+
+## Synthetic payload
+
+Exact production dataclasses (`NodeID`, `NodeData`, `EdgeData`, `NodeType`, `EdgeType` imported
+from `oracle.py` — no mocks):
+
+- **24,000 files × 4 entities = 120,000 nodes**, 512-byte docstrings each
+- **192,000 edges** (CALLS / IMPORTS / INHERITS mix)
+- Incremental-checkpoint probe: **500 new nodes** scattered across packages
+
+This is ~300 MB of live `DiGraph` in RAM — a faithful 1:N scale model of the real
+`codebase_graph.pkl` (the real graph is ~1.4 GB; load/checkpoint costs scale ~linearly, the
+*relative* ranking is what transfers).
+
+## Telemetry (two consecutive runs — ranking is stable; absolute ms vary with machine load)
+
+```
+MODE                         save_s  disk_MB   TTFR_s  loop_lag_ms  load_RAM_MB  ckpt500_ms
+-------------------------------------------------------------------------------------------- run 1
+A monolithic-pickle            0.64       29     5.74        361.2          345       476.8
+B chunked-pickle (per-file)    3.67       49     9.12        357.7          354        14.7
+D chunked-coarse (~50 shards)  0.80       30     6.02        298.3          300       712.8
+C aiosqlite-normalized         2.52      184     7.93        457.9          411        47.2
+-------------------------------------------------------------------------------------------- run 2
+A monolithic-pickle            0.73       29     5.61        314.3          345       482.9
+B chunked-pickle (per-file)    3.69       49     9.04        358.7          354        16.8
+D chunked-coarse (~50 shards)  0.78       30     5.98        293.0          300       648.5
+C aiosqlite-normalized         2.51      184     7.90        458.0          411        44.8
+```
+
+**Metric definitions:**
+- `TTFR_s` — time-to-first-ready: full deserialize **+** `DiGraph` reconstruction, run via
+  `asyncio.to_thread` for all modes (production loads off-loop). This is boot latency.
+- `loop_lag_ms` — peak event-loop stall during load, measured by a concurrent sleep-overshoot
+  heartbeat. **Fairness fix:** an earlier draft reconstructed mode C on-loop and A/B off-loop,
+  producing a bogus 12 s lag for C; all four now reconstruct in `to_thread`, so this column
+  isolates GIL contention only.
+- `ckpt500_ms` — cost to persist 500 new scattered nodes incrementally (the hot path during
+  live indexing — the workload that caused the cold-index `ControlPlaneStarvation` wedge).
+
+## Findings
+
+### 1. Load (TTFR) — the chunk-granularity tension
+`A (5.7s) < D (6.0s) < C (7.9s) < B (9.1s)`
+
+- Monolithic pickle is fastest — one `pickle.load`, no per-shard overhead.
+- **Per-file chunking (B) is +59% slower** — opening/reading 24,000 shard files dominates;
+  the format itself is fine, the *filesystem* is the tax.
+- **Coarse chunking (D) erases that tax** (+5% over monolithic) — confirming the FS-overhead
+  diagnosis. ~50 shards = ~50 opens.
+- SQLite (C) is +38% — one file, but row→object marshalling costs more than a flat unpickle.
+
+### 2. Incremental checkpoint — where chunking betrays itself
+`B (15ms) < C (46ms) ≪ A (480ms) < D (680ms)`
+
+- Monolithic (A) must rewrite the **entire** file on every checkpoint (480ms here; seconds at
+  1.4 GB). **This is the root cause of the cold-index starvation** — the index never got to
+  checkpoint cheaply, so write pressure competed with the FSM control plane.
+- Per-file chunking (B) wins (15ms) — but only because each shard is tiny.
+- **Coarse chunking (D) is the *worst* (680ms)** — the surprise. 500 scattered nodes touch
+  nearly all ~50 coarse shards, forcing a read-modify-write of almost the whole graph. Coarse
+  shards buy load speed by sacrificing the entire reason to chunk.
+- SQLite (C) stays cheap (46ms) under the same scatter — row-level `UPSERT` is indexed by key,
+  immune to the file-grouping scatter problem.
+
+### 3. Disk & RAM
+- Disk: `A (29MB) ≈ D (30MB) < B (49MB) < C (184MB, 6.3×)`. SQLite pays for indices + row
+  overhead. Acceptable on any modern disk; worth noting.
+- RAM: all ~300–411 MB; the live `DiGraph` dominates regardless of on-disk format.
+
+### 4. The decisive trade matrix
+
+| Mode | Load | Checkpoint | Disk | Fatal flaw |
+|------|------|-----------|------|------------|
+| A monolithic | **best** | terrible | best | full-rewrite checkpoint → the starvation we observed |
+| B chunk/file | worst | **best** | ok | 24k-file load tax |
+| D chunk/coarse | good | worst | best | scatter touches every shard → checkpoint collapses |
+| **C aiosqlite** | ok (+38%) | **near-best** | worst (6×) | none fatal |
+
+## Verdict — proceed with aiosqlite (ADD §9 satisfied, with a caveat)
+
+**SQLite is the only mode without a fatal axis.** Every chunking strategy faces an irreducible
+tension: shard size cheap to *load* (coarse) is expensive to *incrementally write* (scatter),
+and vice versa. SQLite dissolves the tension because read granularity (bulk SELECT) and write
+granularity (indexed row) are independent.
+
+The §9 gate asked for a candidate that **beats monolithic on checkpoint without regressing load.**
+Strictly, *no* mode is free — SQLite beats monolithic on checkpoint by **~10×** but regresses
+load by **~38%**. That trade is correct for this system because:
+
+1. The observed failure was **write-path starvation during indexing**, not load latency.
+   SQLite's 10× cheaper checkpoint targets the actual wound.
+2. Load happens **once per boot** and is already mitigated by Phase-1 Adaptive Backpressure;
+   checkpoint happens **continuously** as files change.
+3. The +38% (~2.2 s here; tens of seconds at 1.4 GB cold) is a bounded, one-time, warm-cacheable
+   cost — and the warm `.db` means cold loads become rare.
+
+**Caveat carried into Phase 2:** the +38% load and 6× disk are real. The implementation should
+(a) keep the warm-cache path dominant so cold loads are exceptional, and (b) re-run this harness
+against the *real* 1.4 GB graph before graduation to confirm the linear-scale assumption holds.
+
+Rejected, with data:
+- **Monolithic pickle** — its full-rewrite checkpoint is the documented cause of the cold-index
+  wedge. Phase-1 backpressure treats the symptom; it does not make a 480ms→multi-second
+  checkpoint cheap.
+- **Chunked pickle (any granularity)** — fine vs coarse is a lose-one-axis dial. No setting wins
+  both load and scatter-checkpoint, and the format offers no transactional integrity.
+
+## Reproduce
+
+```bash
+cd <repo-root>
+PYTHONPATH=$(pwd) python3 scripts/benchmarks/oracle_persistence_benchmark.py
+```

--- a/scripts/benchmarks/oracle_persistence_benchmark.py
+++ b/scripts/benchmarks/oracle_persistence_benchmark.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Oracle Persistence Tri-Modal Benchmark — the ADD §9 decision gate.
+
+Measures three persistence paradigms against a synthetic graph that mirrors the cold-index
+statistics (~24k file nodes + entity nodes + ~200k edges), using the REAL
+NodeID/NodeData/EdgeData dataclasses:
+
+  A) Monolithic pickle      — current state / baseline
+  B) Chunked pickle (shards)— per-file shards + manifest (incremental saves, mmap-ish load)
+  C) aiosqlite normalized   — the ADD's proposed relational design (WAL + NORMAL)
+
+Per mode it reports: cold save time + on-disk size, TTFR (full load → reconstructed
+networkx DiGraph), peak load RAM (tracemalloc), event-loop block (max heartbeat lag while
+the load runs ON the loop) + the to_thread/async-offloaded lag, and the incremental
+checkpoint cost (persist 500 new nodes + edges).
+
+Pure stdlib + aiosqlite + networkx. Writes only to a temp dir. Deterministic-ish (seeded
+content sizing; no Math.random reliance).
+"""
+from __future__ import annotations
+
+import asyncio
+import gc
+import json
+import os
+import pickle
+import shutil
+import sqlite3
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import networkx as nx
+
+from backend.core.ouroboros.oracle import (
+    EdgeData, EdgeType, NodeData, NodeID, NodeType,
+)
+
+# ── scale (representative-but-runnable; real graph ~1.4GB — see report extrapolation) ──
+N_FILES = int(os.getenv("BENCH_N_FILES", "24000"))
+ENTITIES_PER_FILE = int(os.getenv("BENCH_ENTITIES", "4"))      # → ~120k entity+file nodes
+DOCSTRING_LEN = int(os.getenv("BENCH_DOCLEN", "512"))           # bytes/node payload knob
+CHECKPOINT_NODES = 500
+_DOC = "x" * DOCSTRING_LEN
+_SIG = "(self, a: int, b: str = 'z') -> Optional[Dict[str, Any]]"
+
+
+# ── synthetic payload (real dataclasses) ─────────────────────────────────────────────────
+def build_payload() -> Tuple[List[NodeData], List[Tuple[str, str, EdgeData]], Dict[str, str]]:
+    nodes: List[NodeData] = []
+    edges: List[Tuple[str, str, EdgeData]] = []
+    file_hashes: Dict[str, str] = {}
+    ntypes = [NodeType.CLASS, NodeType.FUNCTION, NodeType.METHOD, NodeType.IMPORT]
+    etypes = [EdgeType.CONTAINS, EdgeType.CALLS, EdgeType.IMPORTS, EdgeType.INHERITS]
+    for f in range(N_FILES):
+        fp = f"backend/pkg{f % 50}/module_{f}.py"
+        file_hashes[fp] = f"hash{f:08d}"
+        file_id = NodeID(repo="jarvis", file_path=fp, name=f"module_{f}", node_type=NodeType.FILE)
+        fkey = str(file_id)
+        nodes.append(NodeData(node_id=file_id, docstring=_DOC, signature="", source_hash=file_hashes[fp]))
+        for e in range(ENTITIES_PER_FILE):
+            nt = ntypes[e % len(ntypes)]
+            nid = NodeID(repo="jarvis", file_path=fp, name=f"sym_{f}_{e}", node_type=nt, line_number=e * 7)
+            nkey = str(nid)
+            nodes.append(NodeData(
+                node_id=nid, docstring=_DOC, signature=_SIG,
+                decorators=["staticmethod"] if e % 3 else [],
+                base_classes=["Base"] if nt is NodeType.CLASS else [],
+                complexity=e, line_count=20 + e, source_hash=file_hashes[fp],
+            ))
+            edges.append((fkey, nkey, EdgeData(EdgeType.CONTAINS, e * 7, "")))
+            # a cross-entity call edge → ~2 edges/entity → ~200k total
+            tgt = f"jarvis:{fp}:sym_{f}_{(e + 1) % ENTITIES_PER_FILE}"
+            edges.append((nkey, tgt, EdgeData(etypes[e % len(etypes)], e * 7 + 3, "call")))
+    return nodes, edges, file_hashes
+
+
+def reconstruct(nodes_dicts: List[dict], edges_rows: List[tuple]) -> nx.DiGraph:
+    """Rebuild the in-memory DiGraph — the shared end-state all 3 modes must reach."""
+    g = nx.DiGraph()
+    for nd in nodes_dicts:
+        nid = NodeID.from_dict(nd["node_id"])
+        g.add_node(str(nid), data=NodeData(
+            node_id=nid, docstring=nd["docstring"], signature=nd["signature"],
+            decorators=nd["decorators"], base_classes=nd["base_classes"],
+            complexity=nd["complexity"], line_count=nd["line_count"],
+            last_modified=nd["last_modified"], source_hash=nd["source_hash"],
+        ))
+    for (src, dst, et, ln, ctx) in edges_rows:
+        g.add_edge(src, dst, data=EdgeData(EdgeType(et), ln, ctx))
+    return g
+
+
+# ── metric helpers ───────────────────────────────────────────────────────────────────────
+async def _loop_block_ms(load_coro_factory) -> Tuple[float, float]:
+    """Run a load while a 10ms heartbeat measures its own scheduling lag. Returns
+    (max_lag_ms, wall_ms). A sync load on the loop spikes the lag to ~wall; an offloaded
+    load keeps the lag near zero."""
+    stop = False
+    max_lag = 0.0
+
+    async def heartbeat():
+        nonlocal max_lag
+        while not stop:
+            t = time.monotonic()
+            await asyncio.sleep(0.01)
+            max_lag = max(max_lag, (time.monotonic() - t - 0.01) * 1000.0)
+
+    hb = asyncio.create_task(heartbeat())
+    await asyncio.sleep(0)
+    t0 = time.monotonic()
+    await load_coro_factory()
+    wall = (time.monotonic() - t0) * 1000.0
+    stop = True
+    await hb
+    return max_lag, wall
+
+
+def _dir_size_mb(p: Path) -> float:
+    if p.is_file():
+        return p.stat().st_size / 1e6
+    return sum(f.stat().st_size for f in p.rglob("*") if f.is_file()) / 1e6
+
+
+# ── Mode A: monolithic pickle ────────────────────────────────────────────────────────────
+def save_pickle(path: Path, nodes, edges, fh) -> float:
+    t0 = time.monotonic()
+    data = {
+        "nodes": [n.to_dict() for n in nodes],
+        "edges": [(s, d, e.to_dict()) for (s, d, e) in edges],
+        "file_hashes": fh,
+    }
+    with open(path, "wb") as fobj:
+        pickle.dump(data, fobj, protocol=pickle.HIGHEST_PROTOCOL)
+    return time.monotonic() - t0
+
+
+def load_pickle(path: Path) -> nx.DiGraph:
+    with open(path, "rb") as fobj:
+        data = pickle.load(fobj)
+    edges = [(s, d, e["edge_type"], e["line_number"], e["context"]) for (s, d, e) in data["edges"]]
+    return reconstruct(data["nodes"], edges)
+
+
+# ── Mode B: chunked pickle (per-file shards + manifest) ──────────────────────────────────
+def save_chunked(root: Path, nodes, edges, fh) -> float:
+    t0 = time.monotonic()
+    root.mkdir(parents=True, exist_ok=True)
+    by_file_nodes: Dict[str, list] = {}
+    by_file_edges: Dict[str, list] = {}
+    for n in nodes:
+        by_file_nodes.setdefault(n.node_id.file_path, []).append(n.to_dict())
+    for (s, d, e) in edges:
+        fp = s.split(":", 2)[1]
+        by_file_edges.setdefault(fp, []).append((s, d, e.to_dict()))
+    manifest = {}
+    for i, fp in enumerate(by_file_nodes):
+        shard = root / f"shard_{i}.pkl"
+        with open(shard, "wb") as fobj:
+            pickle.dump({"nodes": by_file_nodes[fp], "edges": by_file_edges.get(fp, [])},
+                        fobj, protocol=pickle.HIGHEST_PROTOCOL)
+        manifest[fp] = shard.name
+    (root / "manifest.json").write_text(json.dumps({"shards": manifest, "file_hashes": fh}))
+    return time.monotonic() - t0
+
+
+def load_chunked(root: Path) -> nx.DiGraph:
+    manifest = json.loads((root / "manifest.json").read_text())
+    all_nodes, all_edges = [], []
+    for shard_name in manifest["shards"].values():
+        with open(root / shard_name, "rb") as fobj:
+            sd = pickle.load(fobj)
+        all_nodes.extend(sd["nodes"])
+        all_edges.extend((s, d, e["edge_type"], e["line_number"], e["context"]) for (s, d, e) in sd["edges"])
+    return reconstruct(all_nodes, all_edges)
+
+
+# ── Mode D: chunked-COARSE (shard by package dir, ~50 shards) ────────────────────────────
+def _pkg_of(fp: str) -> str:
+    parts = fp.split("/")
+    return parts[1] if len(parts) > 1 else "root"
+
+
+def save_chunked_coarse(root: Path, nodes, edges, fh) -> float:
+    t0 = time.monotonic()
+    root.mkdir(parents=True, exist_ok=True)
+    by_pkg_n: Dict[str, list] = {}
+    by_pkg_e: Dict[str, list] = {}
+    for n in nodes:
+        by_pkg_n.setdefault(_pkg_of(n.node_id.file_path), []).append(n.to_dict())
+    for (s, d, e) in edges:
+        by_pkg_e.setdefault(_pkg_of(s.split(":", 2)[1]), []).append((s, d, e.to_dict()))
+    manifest = {}
+    for i, pkg in enumerate(by_pkg_n):
+        shard = root / f"pkg_{i}.pkl"
+        with open(shard, "wb") as fobj:
+            pickle.dump({"nodes": by_pkg_n[pkg], "edges": by_pkg_e.get(pkg, [])},
+                        fobj, protocol=pickle.HIGHEST_PROTOCOL)
+        manifest[pkg] = shard.name
+    (root / "manifest.json").write_text(json.dumps({"shards": manifest, "file_hashes": fh}))
+    return time.monotonic() - t0
+
+
+def load_chunked_coarse(root: Path) -> nx.DiGraph:
+    manifest = json.loads((root / "manifest.json").read_text())
+    all_nodes, all_edges = [], []
+    for shard_name in manifest["shards"].values():
+        with open(root / shard_name, "rb") as fobj:
+            sd = pickle.load(fobj)
+        all_nodes.extend(sd["nodes"])
+        all_edges.extend((s, d, e["edge_type"], e["line_number"], e["context"]) for (s, d, e) in sd["edges"])
+    return reconstruct(all_nodes, all_edges)
+
+
+# ── Mode C: aiosqlite normalized (WAL + NORMAL) ──────────────────────────────────────────
+_SCHEMA = """
+CREATE TABLE nodes(node_key TEXT PRIMARY KEY, repo TEXT, file_path TEXT, name TEXT,
+  node_type TEXT, line_number INT, docstring TEXT, signature TEXT, decorators TEXT,
+  base_classes TEXT, complexity INT, line_count INT, last_modified REAL, source_hash TEXT);
+CREATE INDEX idx_nodes_file ON nodes(file_path);
+CREATE TABLE edges(src_key TEXT, dst_key TEXT, edge_type TEXT, line_number INT, context TEXT,
+  PRIMARY KEY(src_key,dst_key,edge_type,line_number));
+CREATE INDEX idx_edges_src ON edges(src_key);
+CREATE INDEX idx_edges_dst ON edges(dst_key);
+CREATE TABLE file_hashes(file_path TEXT PRIMARY KEY, source_hash TEXT, indexed_at REAL);
+"""
+
+
+def save_sqlite(path: Path, nodes, edges, fh) -> float:
+    t0 = time.monotonic()
+    con = sqlite3.connect(path)
+    con.executescript("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;" + _SCHEMA)
+    con.executemany(
+        "INSERT INTO nodes VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        [(str(n.node_id), n.node_id.repo, n.node_id.file_path, n.node_id.name,
+          n.node_id.node_type.value, n.node_id.line_number, n.docstring, n.signature,
+          json.dumps(n.decorators), json.dumps(n.base_classes), n.complexity,
+          n.line_count, n.last_modified, n.source_hash) for n in nodes],
+    )
+    con.executemany("INSERT OR IGNORE INTO edges VALUES (?,?,?,?,?)",
+                    [(s, d, e.edge_type.value, e.line_number, e.context) for (s, d, e) in edges])
+    con.executemany("INSERT INTO file_hashes VALUES (?,?,?)",
+                    [(k, v, 0.0) for k, v in fh.items()])
+    con.commit()
+    con.close()
+    return time.monotonic() - t0
+
+
+def load_sqlite_sync(path: Path) -> nx.DiGraph:
+    """sqlite3 (sync) loader — for the FAIR loop-lag test, all 3 modes load via the same
+    asyncio.to_thread offload (production uses to_thread). The DiGraph reconstruction is
+    GIL-bound Python work regardless of format, so this isolates the format's deserialize
+    cost without the on-loop-vs-offloaded confound."""
+    con = sqlite3.connect(path)
+    node_rows = con.execute(
+        "SELECT node_key,repo,file_path,name,node_type,line_number,docstring,signature,"
+        "decorators,base_classes,complexity,line_count,last_modified,source_hash FROM nodes"
+    ).fetchall()
+    edge_rows = con.execute("SELECT src_key,dst_key,edge_type,line_number,context FROM edges").fetchall()
+    con.close()
+    g = nx.DiGraph()
+    for r in node_rows:
+        nid = NodeID(repo=r[1], file_path=r[2], name=r[3], node_type=NodeType(r[4]), line_number=r[5])
+        g.add_node(r[0], data=NodeData(
+            node_id=nid, docstring=r[6], signature=r[7], decorators=json.loads(r[8]),
+            base_classes=json.loads(r[9]), complexity=r[10], line_count=r[11],
+            last_modified=r[12], source_hash=r[13]))
+    for r in edge_rows:
+        g.add_edge(r[0], r[1], data=EdgeData(EdgeType(r[2]), r[3], r[4]))
+    return g
+
+
+async def load_sqlite_async(path: Path) -> nx.DiGraph:
+    import aiosqlite
+    async with aiosqlite.connect(path) as con:
+        cur = await con.execute("SELECT node_key,repo,file_path,name,node_type,line_number,"
+                                "docstring,signature,decorators,base_classes,complexity,"
+                                "line_count,last_modified,source_hash FROM nodes")
+        node_rows = await cur.fetchall()
+        cur = await con.execute("SELECT src_key,dst_key,edge_type,line_number,context FROM edges")
+        edge_rows = await cur.fetchall()
+    g = nx.DiGraph()
+    for r in node_rows:
+        nid = NodeID(repo=r[1], file_path=r[2], name=r[3], node_type=NodeType(r[4]), line_number=r[5])
+        g.add_node(r[0], data=NodeData(
+            node_id=nid, docstring=r[6], signature=r[7], decorators=json.loads(r[8]),
+            base_classes=json.loads(r[9]), complexity=r[10], line_count=r[11],
+            last_modified=r[12], source_hash=r[13]))
+    for r in edge_rows:
+        g.add_edge(r[0], r[1], data=EdgeData(EdgeType(r[2]), r[3], r[4]))
+    return g
+
+
+def checkpoint_sqlite(path: Path, new_nodes, new_edges) -> float:
+    t0 = time.monotonic()
+    con = sqlite3.connect(path)
+    con.execute("PRAGMA synchronous=NORMAL;")
+    con.executemany("INSERT OR REPLACE INTO nodes VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                    [(str(n.node_id), n.node_id.repo, n.node_id.file_path, n.node_id.name,
+                      n.node_id.node_type.value, n.node_id.line_number, n.docstring, n.signature,
+                      json.dumps(n.decorators), json.dumps(n.base_classes), n.complexity,
+                      n.line_count, n.last_modified, n.source_hash) for n in new_nodes])
+    con.executemany("INSERT OR IGNORE INTO edges VALUES (?,?,?,?,?)",
+                    [(s, d, e.edge_type.value, e.line_number, e.context) for (s, d, e) in new_edges])
+    con.commit()
+    con.close()
+    return time.monotonic() - t0
+
+
+# ── driver ───────────────────────────────────────────────────────────────────────────────
+async def run():
+    tmp = Path(tempfile.mkdtemp(prefix="oracle_bench_"))
+    print(f"# Oracle Persistence Tri-Modal Benchmark")
+    print(f"# scale: {N_FILES} files x {ENTITIES_PER_FILE} entities, doclen={DOCSTRING_LEN}B")
+    nodes, edges, fh = build_payload()
+    n_nodes, n_edges = len(nodes), len(edges)
+    print(f"# payload: {n_nodes} nodes, {n_edges} edges")
+    # 500 new nodes for the incremental-checkpoint test
+    new_nodes = nodes[:CHECKPOINT_NODES]
+    new_edges = edges[:CHECKPOINT_NODES]
+    results = {}
+
+    # A — monolithic pickle
+    pk = tmp / "graph.pkl"
+    a_save = save_pickle(pk, nodes, edges, fh)
+    gc.collect(); tracemalloc.start()
+    a_lag, a_wall = await _loop_block_ms(lambda: asyncio.to_thread(load_pickle, pk))
+    _, a_peak = tracemalloc.get_traced_memory(); tracemalloc.stop()
+    a_ckpt = save_pickle(pk, nodes, edges, fh)  # monolithic checkpoint = FULL rewrite
+    results["A monolithic-pickle"] = dict(save=a_save, size=_dir_size_mb(pk), ttfr=a_wall,
+                                          loop_lag=a_lag, ram=a_peak / 1e6, ckpt=a_ckpt)
+
+    # B — chunked pickle
+    ch = tmp / "chunks"
+    b_save = save_chunked(ch, nodes, edges, fh)
+    gc.collect(); tracemalloc.start()
+    b_lag, b_wall = await _loop_block_ms(lambda: asyncio.to_thread(load_chunked, ch))
+    _, b_peak = tracemalloc.get_traced_memory(); tracemalloc.stop()
+    # incremental checkpoint: rewrite only the shards touched by 500 new nodes' files
+    t0 = time.monotonic()
+    touched = {n.node_id.file_path for n in new_nodes}
+    bf_n = {fp: [n.to_dict() for n in new_nodes if n.node_id.file_path == fp] for fp in touched}
+    for i, fp in enumerate(touched):
+        with open(ch / f"_ck_{i}.pkl", "wb") as fobj:
+            pickle.dump({"nodes": bf_n[fp], "edges": []}, fobj, protocol=pickle.HIGHEST_PROTOCOL)
+    b_ckpt = time.monotonic() - t0
+    results["B chunked-pickle"] = dict(save=b_save, size=_dir_size_mb(ch), ttfr=b_wall,
+                                       loop_lag=b_lag, ram=b_peak / 1e6, ckpt=b_ckpt)
+
+    # D — chunked COARSE (shard by package dir, ~50 shards) — the hypothesis fix for B's load
+    chc = tmp / "chunks_coarse"
+    d_save = save_chunked_coarse(chc, nodes, edges, fh)
+    gc.collect(); tracemalloc.start()
+    d_lag, d_wall = await _loop_block_ms(lambda: asyncio.to_thread(load_chunked_coarse, chc))
+    _, d_peak = tracemalloc.get_traced_memory(); tracemalloc.stop()
+    # incremental checkpoint: rewrite only the package shards touched by 500 new nodes
+    t0 = time.monotonic()
+    touched_pkgs: Dict[str, list] = {}
+    for n in new_nodes:
+        touched_pkgs.setdefault(_pkg_of(n.node_id.file_path), []).append(n.to_dict())
+    manifest = json.loads((chc / "manifest.json").read_text())
+    for pkg, nlist in touched_pkgs.items():
+        shard_name = manifest["shards"].get(pkg)
+        if shard_name is None:
+            continue
+        with open(chc / shard_name, "rb") as fobj:
+            sd = pickle.load(fobj)
+        sd["nodes"].extend(nlist)  # read-modify-write the affected shard
+        with open(chc / shard_name, "wb") as fobj:
+            pickle.dump(sd, fobj, protocol=pickle.HIGHEST_PROTOCOL)
+    d_ckpt = time.monotonic() - t0
+    results["D chunked-coarse"] = dict(save=d_save, size=_dir_size_mb(chc), ttfr=d_wall,
+                                       loop_lag=d_lag, ram=d_peak / 1e6, ckpt=d_ckpt)
+
+    # C — aiosqlite normalized
+    db = tmp / "oracle.db"
+    c_save = save_sqlite(db, nodes, edges, fh)
+    gc.collect(); tracemalloc.start()
+    # FAIR loop-lag: load via to_thread like A/B (production uses to_thread).
+    c_lag, c_wall = await _loop_block_ms(lambda: asyncio.to_thread(load_sqlite_sync, db))
+    _, c_peak = tracemalloc.get_traced_memory(); tracemalloc.stop()
+    c_ckpt = checkpoint_sqlite(db, new_nodes, new_edges)
+    results["C aiosqlite-normalized"] = dict(save=c_save, size=_dir_size_mb(db), ttfr=c_wall,
+                                             loop_lag=c_lag, ram=c_peak / 1e6, ckpt=c_ckpt)
+
+    # ── report ──
+    print("\n" + "=" * 92)
+    print(f"{'MODE':<26}{'save_s':>9}{'disk_MB':>9}{'TTFR_s':>9}{'loop_lag_ms':>13}"
+          f"{'load_RAM_MB':>13}{'ckpt500_ms':>12}")
+    print("-" * 92)
+    for mode, r in results.items():
+        print(f"{mode:<26}{r['save']:>9.2f}{r['size']:>9.0f}{r['ttfr']/1000:>9.2f}"
+              f"{r['loop_lag']:>13.1f}{r['ram']:>13.0f}{r['ckpt']*1000:>12.1f}")
+    print("=" * 92)
+    shutil.rmtree(tmp, ignore_errors=True)
+    return results
+
+
+if __name__ == "__main__":
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

Closes the **ORACLE_PERSISTENCE_ADD §9 Benchmark Gate** with empirical data. Phase-2 persistence
implementation was gated on a head-to-head race; this is that race and its verdict.

`scripts/benchmarks/oracle_persistence_benchmark.py` is a self-contained harness that races **4**
persistence backends against a synthetic **120k-node / 192k-edge** `DiGraph` built from the exact
production dataclasses (`NodeID`/`NodeData`/`EdgeData` imported from `oracle.py` — no mocks). It
captures TTFR (boot latency), event-loop stall, peak RAM, disk footprint, and the incremental
500-node checkpoint cost.

## Telemetry (two stable runs)

```
MODE                         save_s  disk_MB   TTFR_s  loop_lag_ms  load_RAM_MB  ckpt500_ms
A monolithic-pickle            0.64       29     5.74        361          345       476.8
B chunked-pickle (per-file)    3.67       49     9.12        358          354        14.7
D chunked-coarse (~50 shards)  0.80       30     6.02        298          300       712.8
C aiosqlite-normalized         2.52      184     7.93        458          411        47.2
```

## Verdict: proceed with **aiosqlite**

SQLite is the **only mode without a fatal axis**. Chunking faces an irreducible tension I tested
directly by adding mode **D** mid-race:
- **Coarse shards** load fast (+5% vs monolithic) but a realistic edit-scatter touches nearly every
  shard, so the incremental checkpoint **collapses** (D is the worst at ~680ms).
- **Fine (per-file) shards** checkpoint cheap (15ms) but pay a **+59% load tax** from opening 24k files.

SQLite decouples read granularity (bulk SELECT) from write granularity (indexed row), giving a
**~10× cheaper checkpoint** than monolithic — the documented cause of the cold-index
`ControlPlaneStarvation` wedge — at a bounded **+38% load** and **6× disk** cost. The trade is correct
because the observed failure was write-path starvation during indexing (continuous), not load
latency (once-per-boot, warm-cacheable, already mitigated by Phase-1 backpressure).

Monolithic and chunked (both granularities) rejected **with data**. Full analysis:
`docs/architecture/ORACLE_PERSISTENCE_BENCHMARK_RESULTS.md`.

**Caveat carried into Phase 2:** re-run this harness against the real 1.4 GB graph before graduation
to confirm the linear-scale assumption.

## Methodology note

An early draft measured mode C's loop-lag on-loop while A/B were offloaded (a bogus 12s artifact).
All four modes now reconstruct via `asyncio.to_thread`, so the loop-lag column isolates GIL
contention fairly.

## Test Plan
- [x] Harness AST-validates and runs end-to-end (`PYTHONPATH=$(pwd) python3 scripts/benchmarks/oracle_persistence_benchmark.py`)
- [x] Ranking stable across repeated runs
- [x] Uses real production dataclasses, not mocks
- [ ] (Phase 2 follow-up) re-run against the real 1.4 GB graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a quad‑modal persistence benchmark for the Oracle graph and documents empirical results. The data selects `aiosqlite` for Phase‑2 persistence (ADD §9 gate satisfied).

- **New Features**
  - `scripts/benchmarks/oracle_persistence_benchmark.py`: races monolithic pickle, chunked per‑file, chunked coarse, and `aiosqlite` on a 120k‑node/192k‑edge synthetic graph using production dataclasses; reports TTFR, event‑loop stall, RAM, disk, and a 500‑node incremental checkpoint, with fair `asyncio.to_thread` loading.
  - `docs/architecture/ORACLE_PERSISTENCE_BENCHMARK_RESULTS.md`: verdict and rationale—chunking has an unfixable load vs checkpoint trade‑off; `aiosqlite` delivers ~10× cheaper checkpoints than monolithic with a bounded ~+38% load and ~6× disk. Follow‑up: rerun on the real 1.4 GB graph before graduation.

<sup>Written for commit dc9349bd9d8b50fccb993c0dda6206269e4b598c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

