### PR TITLE
feat(oracle): graduate SQLite to default-ON + eradicate the .pkl auto-migration trap

### DIFF
--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -3218,9 +3218,13 @@ class TheOracle:
         return self._persistence
 
     async def _load_cache_via_provider(self) -> bool:
-        """Provider-backed load. On a fresh DB with a legacy pickle present, performs the one-time
-        seamless migration (ingest → archive) first, then loads. Fail-soft → ``False`` triggers a
-        Phase-1-throttled cold index (never a wedge)."""
+        """Provider-backed load. DB present → load it. DB absent → return ``False`` so the FSM
+        cold-indexes FRESH (Phase-1-throttled + memory-armored), never a wedge.
+
+        The legacy ``.pkl`` auto-migration is DEPRECATED and gated behind an explicit opt-in
+        (``JARVIS_ORACLE_SQLITE_MIGRATE_PKL``, default off) — materializing a large accreted pickle
+        into a live DiGraph is the ~10GB memory monster this layer replaces and would OOM a
+        constrained host. Default-ON persistence cold-indexes fresh instead."""
         from backend.core.ouroboros import oracle_persistence as _op
 
         prov = self._persistence_provider()
@@ -3228,7 +3232,10 @@ class TheOracle:
             return False
         try:
             if not await prov.exists():
-                await _op.migrate_pickle_to_sqlite(self._resolved_graph_cache_path(), prov)
+                if _op.sqlite_migrate_pkl_enabled():
+                    await _op.migrate_pickle_to_sqlite(self._resolved_graph_cache_path(), prov)
+                else:
+                    return False  # no db + migration deprecated → cold index fresh
             state = await prov.load()
         except Exception as exc:  # noqa: BLE001 — load must never crash boot
             logger.warning("[Oracle] sqlite load failed (cold index will rebuild): %s", exc)

--- a/backend/core/ouroboros/oracle_persistence.py
+++ b/backend/core/ouroboros/oracle_persistence.py
@@ -61,8 +61,20 @@ def _env_truthy(name: str, default: bool = False) -> bool:
 
 
 def sqlite_persistence_enabled() -> bool:
-    """Master switch. Default OFF — flip to graduate after a real-graph soak (ADD §9 caveat)."""
-    return _env_truthy("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", False)
+    """Master switch. **Default ON** (graduated 2026-06-16): SQLite is the canonical Oracle memory
+    layer. The Sovereign Memory Armor (AIMD memory-pressure throttle + streaming warm-load) makes a
+    fresh cold index 16GB-safe by construction — it contracts and, at CRITICAL, suspends-durably
+    rather than OOM. Kill switch ``=0`` restores the legacy monolithic-pickle path."""
+    return _env_truthy("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", True)
+
+
+def sqlite_migrate_pkl_enabled() -> bool:
+    """**Default OFF** — the legacy ``.pkl`` → SQLite auto-migration is DEPRECATED. Materializing a
+    large accreted pickle into a live DiGraph is the ~10GB memory monster this whole layer replaces;
+    on a constrained host it OOMs. Default-ON persistence therefore cold-indexes FRESH, never auto-
+    loads the pickle. This opt-in is for a provisioned host with headroom that explicitly wants the
+    one-time ingest (``JARVIS_ORACLE_SQLITE_MIGRATE_PKL=1``)."""
+    return _env_truthy("JARVIS_ORACLE_SQLITE_MIGRATE_PKL", False)
 
 
 def sqlite_busy_timeout_ms() -> int:

--- a/docs/architecture/ORACLE_SQLITE_HOTPATH_SOAK.md
+++ b/docs/architecture/ORACLE_SQLITE_HOTPATH_SOAK.md
@@ -150,3 +150,35 @@ VERDICT: PASS
 
 The 16 GB-host boundary is actively defended on both the cold-index and warm-boot paths.
 
+## Capstone graduation crucible — default-ON, under REAL ambient pressure
+
+After flipping `JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED` to default-ON, the full `backend/` index
+was re-run with **no forcing** — the host was genuinely at HIGH pressure (~3 GB free), so the armor
+engaged on real signal:
+
+```
+PHASE A — cold index (default-ON, real ambient HIGH pressure)
+  files indexed (graph nodes)   :    214,854
+  edges                         :    402,321
+  cold index wall time          :      78.72 s   (vs 62 s unarmored — the armor slowed it to protect the host)
+  peak RSS after index          :        575 MB
+  max control-plane stall       :     831.2 ms
+  memory armor — contractions   :        621      <-- driven by REAL ambient pressure, not forced
+  memory armor — suspended?     :      False
+PHASE B — warm reboot (streaming load)
+  warm load nodes               :    214,854
+  warm load wall time           :       7.789 s   (10x faster than cold)
+  transient spike over steady   :      11.4 %     (streaming load; flattened vs a fetchall spike)
+VERDICT: PASS
+```
+
+621 natural contractions + clean completion + 10× warm boot, default-ON, no OOM, no kill switch.
+This is the canonical SQLite layer running on the constrained host under genuine memory pressure.
+
+### Honest boundary on the full 29k-file / Phase-9 graduation
+This crucible is `backend/` (214k nodes). A fresh full **3-repo** index (~29k files, ~2 M nodes,
+~4.8 GB steady) does not fit the host's current ~3 GB free — the armor would suspend-durably (it
+guarantees no-OOM, not infinite RAM), completing across resume passes or with more headroom.
+`session_outcome=complete` is produced by the **battle-test harness** (`ouroboros_battle_test.py`),
+not this index path — that Phase-9 graduation is a separate, heavier soak.
+

--- a/tests/governance/test_oracle_persistence.py
+++ b/tests/governance/test_oracle_persistence.py
@@ -270,24 +270,32 @@ def test_corrupt_db_is_quarantined_and_returns_none(tmp_path):
 
 # --------------------------------------------------------------------------- factory + flags
 def test_factory_off_returns_none(monkeypatch, tmp_path):
-    monkeypatch.delenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", "0")  # explicit kill switch
     assert P.build_provider(db_path=tmp_path / "o.db", pickle_path=tmp_path / "o.pkl") is None
 
 
-def test_factory_on_returns_sqlite(monkeypatch, tmp_path):
-    monkeypatch.setenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", "1")
+def test_factory_on_by_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", raising=False)  # graduated default-ON
     prov = P.build_provider(db_path=tmp_path / "o.db", pickle_path=tmp_path / "o.pkl")
     assert isinstance(prov, P.AioSqliteProvider)
 
 
-def test_flag_default_off(monkeypatch):
+def test_flag_default_on(monkeypatch):
     monkeypatch.delenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", raising=False)
-    assert P.sqlite_persistence_enabled() is False
+    assert P.sqlite_persistence_enabled() is True   # graduated 2026-06-16
 
 
 def test_flag_kill_switch(monkeypatch):
-    monkeypatch.setenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", "1")
-    assert P.sqlite_persistence_enabled() is True
+    monkeypatch.setenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", "0")
+    assert P.sqlite_persistence_enabled() is False
+
+
+def test_migrate_pkl_default_off(monkeypatch):
+    """The legacy .pkl auto-migration is DEPRECATED — default OFF (opt-in only)."""
+    monkeypatch.delenv("JARVIS_ORACLE_SQLITE_MIGRATE_PKL", raising=False)
+    assert P.sqlite_migrate_pkl_enabled() is False
+    monkeypatch.setenv("JARVIS_ORACLE_SQLITE_MIGRATE_PKL", "1")
+    assert P.sqlite_migrate_pkl_enabled() is True
 
 
 def test_busy_timeout_env_override(monkeypatch):
@@ -315,8 +323,8 @@ def _populate(oracle, n=3):
 
 
 def test_oracle_off_uses_legacy_pickle(monkeypatch, tmp_path):
-    """Master OFF → the .pkl is written, the provider is never even built (byte-identical path)."""
-    monkeypatch.delenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", raising=False)
+    """Kill switch =0 → the .pkl is written, the provider is never even built (legacy path)."""
+    monkeypatch.setenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", "0")
 
     async def run():
         o = _fresh_oracle(monkeypatch, tmp_path)
@@ -350,12 +358,12 @@ def test_oracle_on_roundtrips_through_sqlite(monkeypatch, tmp_path):
     asyncio.run(run())
 
 
-def test_oracle_on_migrates_legacy_pickle_on_first_load(monkeypatch, tmp_path):
-    """Master ON + a legacy .pkl present + no db → first load migrates (ingest + archive)."""
+def test_oracle_on_migrates_legacy_pickle_only_with_optin(monkeypatch, tmp_path):
+    """Master ON + legacy .pkl + no db + MIGRATE opt-in → first load migrates (ingest + archive)."""
     monkeypatch.setenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_ORACLE_SQLITE_MIGRATE_PKL", "1")  # explicit opt-in
 
     async def run():
-        # seed a legacy pickle via the legacy (OFF) save path
         seed = _fresh_oracle(monkeypatch, tmp_path)
         g = _populate(seed)
         nn = g._graph.number_of_nodes()
@@ -367,10 +375,32 @@ def test_oracle_on_migrates_legacy_pickle_on_first_load(monkeypatch, tmp_path):
         await o._persistence.close()
         assert ok is True
         assert o._graph._graph.number_of_nodes() == nn
-        # migrated: db created, pickle archived
         assert (tmp_path / "oracle.db").exists()
         assert not (tmp_path / "codebase_graph.pkl").exists()
         assert (tmp_path / "codebase_graph.pkl.migrated").exists()
+    asyncio.run(run())
+
+
+def test_oracle_default_on_does_NOT_auto_load_legacy_pickle(monkeypatch, tmp_path):
+    """THE TRAP ERADICATION: master ON (default) + a legacy .pkl present + no db + migration NOT
+    opted-in → the Oracle must NOT touch the pickle (no ~10GB load). _load_cache returns False so
+    the FSM cold-indexes fresh, and the .pkl is left untouched."""
+    monkeypatch.delenv("JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED", raising=False)  # default ON
+    monkeypatch.delenv("JARVIS_ORACLE_SQLITE_MIGRATE_PKL", raising=False)          # default OFF
+
+    async def run():
+        seed = _fresh_oracle(monkeypatch, tmp_path)
+        g = _populate(seed)
+        await P.PickleProvider(tmp_path / "codebase_graph.pkl").save(_state_from_graph(g))
+        assert (tmp_path / "codebase_graph.pkl").exists()
+
+        o = _fresh_oracle(monkeypatch, tmp_path)
+        ok = await o._load_cache()           # db absent + migration off → cold-index signal
+        if o._persistence is not None:
+            await o._persistence.close()
+        assert ok is False                                       # no load → fresh cold index
+        assert (tmp_path / "codebase_graph.pkl").exists()        # pickle untouched (NOT migrated)
+        assert not (tmp_path / "codebase_graph.pkl.migrated").exists()
     asyncio.run(run())
 
 


### PR DESCRIPTION
## Summary

**Phase 1 of the Sovereign Capstone Graduation.** SQLite becomes the canonical Oracle memory
layer (`JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED` default OFF → **ON**), earned by the Memory
Armor soak (313 contractions + graceful completion + −0.6% flattened warm-boot; 16 GB-safe by
construction). Kill switch `=0` restores the legacy monolithic-pickle path.

### Critical safety fix shipped *with* the flip
A naive default-ON would be catastrophic: the auto-migration path would load the real **2.67 GB**
`codebase_graph.pkl` into a live DiGraph (~10 GB+) on first boot → **guaranteed OOM** on a 16 GB
host. So this PR eradicates that trap:

- The `.pkl` → SQLite auto-migration is **deprecated** and gated behind a new explicit opt-in
  `JARVIS_ORACLE_SQLITE_MIGRATE_PKL` (default **OFF**).
- `_load_cache_via_provider`: db present → load; **db absent + migration off → return False so the
  FSM cold-indexes fresh** (memory-armored). The pickle is never touched on the default path.

### Test
- 33 tests green. New `test_oracle_default_on_does_NOT_auto_load_legacy_pickle` proves the trap is
  gone — default-ON + a legacy `.pkl` present + migration off leaves the pickle **untouched** and
  returns the cold-index signal. Plus `test_migrate_pkl_default_off`; prior default-OFF assertions
  inverted to default-ON + kill-switch.

### Operational notes
- The legacy 2.67 GB `codebase_graph.pkl` on this host was archived (reversible `mv` →
  `.deprecated-20260616`). 8.8 GB of stale `.tmp` failed-write garbage remains in
  `~/.jarvis/oracle/` — reclaimable, left for the operator.
- On-host crucible (full `backend/`, 214k nodes, default-ON, armor active) results appended to the
  PR after the run.

## Honest scope on the full 29k-file graduation
The host currently has **~3 GB free**; a fresh full 3-repo index needs ~4.8 GB steady. The armor
guarantees **no-OOM** (it contracts, then suspends-durably at CRITICAL), not infinite RAM — so the
full 29k index completes either with RAM headroom or across resume passes (`file_hashes` skip).
`session_outcome=complete` is the separate battle-test (Phase-9) harness, not this index path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates SQLite to the default-ON Oracle persistence and deprecates automatic `.pkl` migration to avoid OOM; the default path cold-indexes fresh unless migration is explicitly enabled. Adds crucible results to `docs/architecture/ORACLE_SQLITE_HOTPATH_SOAK.md` showing stable behavior under real pressure (621 contractions, 575MB peak RSS, 7.79s warm boot).

- **New Features**
  - SQLite persistence is now default ON via `JARVIS_ORACLE_SQLITE_PERSISTENCE_ENABLED` (set `=0` to restore legacy pickle).
  - New opt-in `JARVIS_ORACLE_SQLITE_MIGRATE_PKL` flag (default OFF) for one-time `.pkl` → SQLite migration on provisioned hosts.
  - `_load_cache_via_provider`: DB present → load; DB absent + migration off → return False so the FSM cold-indexes fresh.

- **Bug Fixes**
  - Removes the auto-migration trap that could load a multi-GB pickle and OOM; added `test_oracle_default_on_does_NOT_auto_load_legacy_pickle` and `test_migrate_pkl_default_off`, and updated tests for the new default and kill switch.

<sup>Written for commit 9c274691f3b217d1d8844cd0d6b0b210ba4e07b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

