### PR TITLE
feat(oracle): Lazy Traversal Slice 1 — GraphBackend seam + live differential parity harness

### DIFF
--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -879,6 +879,17 @@ class CodebaseKnowledgeGraph:
             "last_incremental_update": 0.0,
         }
 
+        # Traversal seam (Slice 1) — all graph QUERIES route through this backend instead of hitting
+        # NetworkX directly, so the read layer is decoupled from the storage format. Default is the
+        # in-memory backend (byte-identical to the pre-seam path); Slice 2 swaps in a parity-checked
+        # SQLite lazy backend. Reads ``self`` dynamically, so wholesale ``_graph`` replacement on
+        # cache load is transparent. Never raises (fail-soft to direct nx if the seam can't build).
+        try:
+            from backend.core.ouroboros.oracle_graph_backend import build_graph_backend
+            self._backend = build_graph_backend(self)
+        except Exception:  # noqa: BLE001
+            self._backend = None  # type: ignore[assignment]
+
     def add_node(self, node_data: NodeData) -> None:
         """Add a node to the graph."""
         node_id = node_data.node_id
@@ -985,29 +996,33 @@ class CodebaseKnowledgeGraph:
             self._metrics["total_edges"] += 1
 
     def get_node(self, node_id: Union[NodeID, str]) -> Optional[Dict[str, Any]]:
-        """Get node data by ID."""
+        """Get node data by ID. Routes through the traversal seam (Slice 1)."""
         node_key = str(node_id)
+        if self._backend is not None:
+            return self._backend.get_node(node_key)
         if node_key in self._graph:
             return dict(self._graph.nodes[node_key])
         return None
 
     def get_edges_from(self, node_id: Union[NodeID, str]) -> List[Tuple[str, Dict[str, Any]]]:
-        """Get all outgoing edges from a node."""
+        """Get all outgoing edges from a node. Routes through the traversal seam (Slice 1)."""
         node_key = str(node_id)
+        if self._backend is not None:
+            return self._backend.successors(node_key)
         if node_key not in self._graph:
             return []
-
         return [
             (target, dict(self._graph.edges[node_key, target]))
             for target in self._graph.successors(node_key)
         ]
 
     def get_edges_to(self, node_id: Union[NodeID, str]) -> List[Tuple[str, Dict[str, Any]]]:
-        """Get all incoming edges to a node."""
+        """Get all incoming edges to a node. Routes through the traversal seam (Slice 1)."""
         node_key = str(node_id)
+        if self._backend is not None:
+            return self._backend.predecessors(node_key)
         if node_key not in self._graph:
             return []
-
         return [
             (source, dict(self._graph.edges[source, node_key]))
             for source in self._graph.predecessors(node_key)
@@ -1238,23 +1253,26 @@ class CodebaseKnowledgeGraph:
         if source_key not in self._graph or target_key not in self._graph:
             return None
 
+        # Route through the traversal seam (Slice 1) — InMemory overrides with nx.shortest_path;
+        # the SQLite backend (Slice 2) uses the primitive-based BFS. Identical results either way.
+        if self._backend is not None:
+            path = self._backend.shortest_path(source_key, target_key)
+            if path is None:
+                return None
+            return [self._node_index[key] for key in path if key in self._node_index]
         try:
-            # Use networkx shortest path
-            path = nx.shortest_path(
-                self._graph,
-                source_key,
-                target_key,
-            )
+            path = nx.shortest_path(self._graph, source_key, target_key)
             return [self._node_index[key] for key in path if key in self._node_index]
         except nx.NetworkXNoPath:
             return None
 
     def find_circular_dependencies(self) -> List[List[NodeID]]:
-        """Find all circular dependencies in the graph."""
+        """Find all circular dependencies in the graph (declared in-scope per §10 — routes through
+        the seam so it never falls into the partial-graph trap under the Scoper)."""
         cycles = []
-
         try:
-            for cycle in nx.simple_cycles(self._graph):
+            source = self._backend.simple_cycles() if self._backend is not None else nx.simple_cycles(self._graph)
+            for cycle in source:
                 if len(cycle) > 1:  # Ignore self-loops
                     cycle_nodes = [
                         self._node_index[key]
@@ -1310,10 +1328,19 @@ class CodebaseKnowledgeGraph:
             next_level: Set[str] = set()
 
             for node_key in current_level:
-                if direction in ("out", "both"):
-                    next_level.update(self._graph.successors(node_key))
-                if direction in ("in", "both"):
-                    next_level.update(self._graph.predecessors(node_key))
+                # Neighbor collection routes through the seam (Slice 1). The subgraph
+                # materialization below stays nx for the in-memory backend; the SQLite backend
+                # (Slice 2) builds the sub-graph from rows.
+                if self._backend is not None:
+                    if direction in ("out", "both"):
+                        next_level.update(self._backend.successor_keys(node_key))
+                    if direction in ("in", "both"):
+                        next_level.update(self._backend.predecessor_keys(node_key))
+                else:
+                    if direction in ("out", "both"):
+                        next_level.update(self._graph.successors(node_key))
+                    if direction in ("in", "both"):
+                        next_level.update(self._graph.predecessors(node_key))
 
             nodes_to_include.update(next_level)
             current_level = next_level

--- a/backend/core/ouroboros/oracle_graph_backend.py
+++ b/backend/core/ouroboros/oracle_graph_backend.py
@@ -1,0 +1,430 @@
+"""Oracle graph traversal seam — interface-segregated backends for graph queries.
+
+Slice 1 of the SQLite-Backed Lazy Traversal arc (`docs/architecture/ORACLE_LAZY_TRAVERSAL_ADD.md`).
+
+Today every blast-radius / call-chain / dependency query runs over the whole in-memory NetworkX
+``DiGraph`` (~5 GB for the 29k-file brain). This module introduces the seam that will let those
+traversals read SQLite on demand instead — so the full graph becomes *queryable* on a constrained
+host without being *resident*. Slice 1 ships the seam + the canonical in-memory backend + the live
+differential parity harness; Slice 2 plugs a ``SqliteLazyGraphBackend`` into the harness's shadow
+slot.
+
+Design (mirrors ``PersistenceProvider``):
+  - ``GraphBackend``           — ABC exposing the ~7 traversal primitives + default algorithms
+    (``shortest_path`` / ``simple_cycles`` / ``descendants``) built ON those primitives, so any
+    backend works without bespoke algorithm code.
+  - ``InMemoryGraphBackend``   — canonical baseline over the live ``CodebaseKnowledgeGraph`` (the
+    DEFAULT; byte-identical to the pre-seam path). Overrides the algorithms with NetworkX for speed.
+  - ``DualBackendParityHarness`` — a backend façade wrapping a trusted ``primary`` + a candidate
+    ``shadow``. Every lookup runs on both; on ANY divergence/shadow-error it captures a rich
+    telemetry payload and **autonomously falls back to the primary result** — never crashes the
+    control plane. This is how the SQLite backend earns trust in production before it's trusted alone.
+  - ``AdaptiveNodeCache``      — bounded LRU (baseline 5,000 nodes) whose ``maxsize`` contracts under
+    ``MemoryPressureGate`` pressure. Wired into the SQLite backend in Slice 3; defined+tested here.
+
+The query API is synchronous (see ADD §2), so this whole layer is sync.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from abc import ABC, abstractmethod
+from collections import OrderedDict, deque
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+EdgeRow = Tuple[str, Dict[str, Any]]  # (neighbor_key, edge_attrs)
+
+
+# ---------------------------------------------------------------------------- config (§10)
+def lazy_traversal_enabled() -> bool:
+    """``JARVIS_ORACLE_LAZY_TRAVERSAL_ENABLED`` (default false) — route graph queries through the
+    SQLite-backed lazy backend instead of the resident in-memory DiGraph. OFF → InMemory (today)."""
+    return os.environ.get("JARVIS_ORACLE_LAZY_TRAVERSAL_ENABLED", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def parity_harness_enabled() -> bool:
+    """``JARVIS_ORACLE_PARITY_HARNESS_ENABLED`` (default false) — run the candidate backend in the
+    shadow slot of the DualBackendParityHarness, differentially verified against the trusted primary
+    with autonomous fallback. The safe way to graduate the lazy backend in production."""
+    return os.environ.get("JARVIS_ORACLE_PARITY_HARNESS_ENABLED", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def traversal_cache_max() -> int:
+    """``JARVIS_ORACLE_TRAVERSAL_CACHE_MAX`` — baseline working-set node-cache size (§10 resolution:
+    5,000 nodes). The adaptive contraction loop shrinks below this under host memory pressure."""
+    try:
+        return max(0, int(os.environ.get("JARVIS_ORACLE_TRAVERSAL_CACHE_MAX", "5000")))
+    except (TypeError, ValueError):
+        return 5000
+
+
+# ---------------------------------------------------------------------------- the seam
+class GraphBackend(ABC):
+    """The traversal seam. Concrete backends implement the primitives; the algorithms below are
+    built purely on those primitives so they work over any backend (in-memory, SQLite, future)."""
+
+    # --- primitives (every backend MUST implement) ---
+    @abstractmethod
+    def contains(self, key: str) -> bool: ...
+
+    @abstractmethod
+    def get_node(self, key: str) -> Optional[Dict[str, Any]]:
+        """Node attribute dict (the exact shape ``NodeData.to_dict()`` produces), or None."""
+
+    @abstractmethod
+    def successors(self, key: str) -> List[EdgeRow]:
+        """Outgoing edges: ``[(dst_key, edge_attrs), ...]``."""
+
+    @abstractmethod
+    def predecessors(self, key: str) -> List[EdgeRow]:
+        """Incoming edges: ``[(src_key, edge_attrs), ...]``."""
+
+    @abstractmethod
+    def node_count(self) -> int: ...
+
+    @abstractmethod
+    def edge_count(self) -> int: ...
+
+    # --- algorithms over the primitives (overridable for native speed) ---
+    def successor_keys(self, key: str) -> List[str]:
+        return [dst for dst, _ in self.successors(key)]
+
+    def predecessor_keys(self, key: str) -> List[str]:
+        return [src for src, _ in self.predecessors(key)]
+
+    def shortest_path(self, source: str, target: str) -> Optional[List[str]]:
+        """Unweighted shortest path via BFS over ``successors`` (matches ``nx.shortest_path`` for an
+        unweighted DiGraph). Returns the node-key path inclusive of endpoints, or None."""
+        if source == target:
+            return [source] if self.contains(source) else None
+        if not self.contains(source) or not self.contains(target):
+            return None
+        prev: Dict[str, Optional[str]] = {source: None}
+        q: deque = deque([source])
+        while q:
+            cur = q.popleft()
+            for nxt in self.successor_keys(cur):
+                if nxt in prev:
+                    continue
+                prev[nxt] = cur
+                if nxt == target:
+                    path = [nxt]
+                    while prev[path[-1]] is not None:
+                        path.append(prev[path[-1]])  # type: ignore[arg-type]
+                    path.reverse()
+                    return path
+                q.append(nxt)
+        return None
+
+    def descendants(self, key: str, max_depth: Optional[int] = None) -> Set[str]:
+        """All nodes reachable from ``key`` (exclusive of ``key``), optional depth bound."""
+        seen: Set[str] = set()
+        frontier: List[str] = [key]
+        depth = 0
+        while frontier and (max_depth is None or depth < max_depth):
+            nxt: List[str] = []
+            for n in frontier:
+                for s in self.successor_keys(n):
+                    if s not in seen and s != key:
+                        seen.add(s)
+                        nxt.append(s)
+            frontier = nxt
+            depth += 1
+        return seen
+
+    def simple_cycles(self, max_cycles: Optional[int] = None) -> List[List[str]]:
+        """Enumerate elementary cycles via primitive-only DFS (Johnson-style backtracking). A global
+        analysis — heavier than local traversals (ADD §6). Bounded by ``max_cycles`` when set."""
+        cycles: List[List[str]] = []
+        keys = list(self.all_keys())
+        index = {k: i for i, k in enumerate(keys)}
+
+        def dfs(start: str, node: str, stack: List[str], on_stack: Set[str]) -> None:
+            if max_cycles is not None and len(cycles) >= max_cycles:
+                return
+            stack.append(node)
+            on_stack.add(node)
+            for nbr in self.successor_keys(node):
+                if index.get(nbr, -1) < index.get(start, 1 << 62):
+                    continue  # only consider nodes >= start (avoid duplicate rotations)
+                if nbr == start:
+                    cycles.append(list(stack))
+                    if max_cycles is not None and len(cycles) >= max_cycles:
+                        break
+                elif nbr not in on_stack:
+                    dfs(start, nbr, stack, on_stack)
+            stack.pop()
+            on_stack.discard(node)
+
+        for k in keys:
+            if max_cycles is not None and len(cycles) >= max_cycles:
+                break
+            dfs(k, k, [], set())
+        return cycles
+
+    def all_keys(self) -> List[str]:
+        """All node keys. Default raises — backends that support global scans override it."""
+        raise NotImplementedError("backend does not support full key enumeration")
+
+
+# ---------------------------------------------------------------------------- in-memory baseline
+class InMemoryGraphBackend(GraphBackend):
+    """Canonical backend over a live ``CodebaseKnowledgeGraph`` (read dynamically, so wholesale
+    ``_graph`` replacement on cache load is transparent). Overrides the algorithms with NetworkX."""
+
+    def __init__(self, ckg: Any):
+        self._ckg = ckg
+
+    @property
+    def _g(self):
+        return self._ckg._graph
+
+    def contains(self, key: str) -> bool:
+        return key in self._g
+
+    def get_node(self, key: str) -> Optional[Dict[str, Any]]:
+        g = self._g
+        return dict(g.nodes[key]) if key in g else None
+
+    def successors(self, key: str) -> List[EdgeRow]:
+        g = self._g
+        if key not in g:
+            return []
+        return [(dst, dict(g.edges[key, dst])) for dst in g.successors(key)]
+
+    def predecessors(self, key: str) -> List[EdgeRow]:
+        g = self._g
+        if key not in g:
+            return []
+        return [(src, dict(g.edges[src, key])) for src in g.predecessors(key)]
+
+    def node_count(self) -> int:
+        return self._g.number_of_nodes()
+
+    def edge_count(self) -> int:
+        return self._g.number_of_edges()
+
+    def all_keys(self) -> List[str]:
+        return list(self._g.nodes)
+
+    # native NetworkX overrides (exact + fast)
+    def shortest_path(self, source: str, target: str) -> Optional[List[str]]:
+        import networkx as nx
+        g = self._g
+        if source not in g or target not in g:
+            return None
+        try:
+            return nx.shortest_path(g, source, target)
+        except nx.NetworkXNoPath:
+            return None
+
+    def simple_cycles(self, max_cycles: Optional[int] = None) -> List[List[str]]:
+        import networkx as nx
+        out: List[List[str]] = []
+        for cyc in nx.simple_cycles(self._g):
+            out.append(cyc)
+            if max_cycles is not None and len(out) >= max_cycles:
+                break
+        return out
+
+
+# ---------------------------------------------------------------------------- live differential harness
+class DualBackendParityHarness(GraphBackend):
+    """Weaponized live differential guard. Wraps a trusted ``primary`` + candidate ``shadow``; runs
+    every read on both, and on ANY divergence or shadow error captures a telemetry payload and
+    returns the PRIMARY result — never crashing the control plane. The primary's result is always
+    authoritative, so the shadow can be wrong/absent without any availability impact."""
+
+    def __init__(
+        self,
+        primary: GraphBackend,
+        shadow: Optional[GraphBackend] = None,
+        *,
+        on_divergence: Optional[Callable[[Dict[str, Any]], None]] = None,
+        max_records: int = 100,
+    ):
+        self.primary = primary
+        self.shadow = shadow
+        self._on_divergence = on_divergence
+        self.comparisons = 0
+        self.divergences = 0
+        self.shadow_errors = 0
+        self.records: deque = deque(maxlen=max(1, max_records))
+
+    # -- the differential wrapper --
+    def _diff(self, method: str, args: tuple, primary_val: Any) -> Any:
+        """Run the shadow, compare to ``primary_val``, record + fall back on any mismatch/error.
+        Always returns ``primary_val`` (the trusted path)."""
+        if self.shadow is None:
+            return primary_val
+        self.comparisons += 1
+        try:
+            shadow_val = getattr(self.shadow, method)(*args)
+        except Exception as exc:  # noqa: BLE001 — shadow must never break the query
+            self.shadow_errors += 1
+            self._record(method, args, primary_val, f"<shadow raised: {exc!r}>", kind="shadow_error")
+            return primary_val
+        if not _results_equal(primary_val, shadow_val):
+            self.divergences += 1
+            self._record(method, args, primary_val, shadow_val, kind="divergence")
+        return primary_val
+
+    def _record(self, method: str, args: tuple, primary_val: Any, shadow_val: Any, *, kind: str) -> None:
+        payload = {
+            "kind": kind,
+            "method": method,
+            "args": [str(a) for a in args],
+            "primary": _summarize(primary_val),
+            "shadow": _summarize(shadow_val),
+        }
+        self.records.append(payload)
+        logger.warning(
+            "[OracleParity] %s on %s%s — primary=%s shadow=%s (autonomous fallback to primary)",
+            kind, method, payload["args"], payload["primary"], payload["shadow"],
+        )
+        if self._on_divergence is not None:
+            try:
+                self._on_divergence(payload)
+            except Exception:  # noqa: BLE001 — telemetry sink must never break the query
+                logger.debug("[OracleParity] on_divergence sink failed", exc_info=True)
+
+    # -- primitives (primary authoritative, shadow differentially checked) --
+    def contains(self, key: str) -> bool:
+        return self._diff("contains", (key,), self.primary.contains(key))
+
+    def get_node(self, key: str) -> Optional[Dict[str, Any]]:
+        return self._diff("get_node", (key,), self.primary.get_node(key))
+
+    def successors(self, key: str) -> List[EdgeRow]:
+        return self._diff("successors", (key,), self.primary.successors(key))
+
+    def predecessors(self, key: str) -> List[EdgeRow]:
+        return self._diff("predecessors", (key,), self.primary.predecessors(key))
+
+    def node_count(self) -> int:
+        return self._diff("node_count", (), self.primary.node_count())
+
+    def edge_count(self) -> int:
+        return self._diff("edge_count", (), self.primary.edge_count())
+
+    def all_keys(self) -> List[str]:
+        return self.primary.all_keys()
+
+    # algorithms: trust the primary's (overridden) impl, differentially check the shadow's
+    def shortest_path(self, source: str, target: str) -> Optional[List[str]]:
+        return self._diff("shortest_path", (source, target), self.primary.shortest_path(source, target))
+
+    def simple_cycles(self, max_cycles: Optional[int] = None) -> List[List[str]]:
+        return self._diff("simple_cycles", (max_cycles,), self.primary.simple_cycles(max_cycles))
+
+    def stats(self) -> Dict[str, int]:
+        return {
+            "comparisons": self.comparisons,
+            "divergences": self.divergences,
+            "shadow_errors": self.shadow_errors,
+            "records": len(self.records),
+        }
+
+
+def _results_equal(a: Any, b: Any) -> bool:
+    """Order-insensitive structural equality for primitive results (edge lists are sets of
+    (neighbor, sorted-attr-items); node dicts compared directly)."""
+    if isinstance(a, list) and isinstance(b, list):
+        try:
+            return _norm_edges(a) == _norm_edges(b)
+        except (TypeError, ValueError):
+            return a == b
+    return a == b
+
+
+def _norm_edges(rows: list):
+    norm = set()
+    for r in rows:
+        if isinstance(r, tuple) and len(r) == 2 and isinstance(r[1], dict):
+            norm.add((r[0], tuple(sorted((k, _h(v)) for k, v in r[1].items()))))
+        else:
+            norm.add(_h(r))
+    return norm
+
+
+def _h(v: Any):
+    return tuple(sorted(v.items())) if isinstance(v, dict) else (tuple(v) if isinstance(v, list) else v)
+
+
+def _summarize(v: Any) -> str:
+    if isinstance(v, list):
+        return f"list[{len(v)}]"
+    if isinstance(v, dict):
+        return f"dict{{{','.join(sorted(v)[:4])}}}"
+    s = repr(v)
+    return s if len(s) <= 80 else s[:77] + "..."
+
+
+# ---------------------------------------------------------------------------- adaptive working-set cache
+class AdaptiveNodeCache:
+    """Bounded LRU for traversal working-set nodes (baseline 5,000). ``maxsize`` contracts under
+    host memory pressure — the query-side mirror of the index-side Memory Armor. Sync hot path;
+    contraction is driven by :meth:`apply_pressure` (a pressure-level string). Wired into the SQLite
+    backend in Slice 3; standalone + tested here."""
+
+    _PRESSURE_FRAC = {"ok": 1.0, "warn": 1.0, "high": 0.5, "critical": 0.1}
+
+    def __init__(self, baseline: Optional[int] = None):
+        self._baseline = traversal_cache_max() if baseline is None else max(0, baseline)
+        self._maxsize = self._baseline
+        self._d: "OrderedDict[str, Any]" = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+        self.evictions = 0
+
+    @property
+    def maxsize(self) -> int:
+        return self._maxsize
+
+    def get(self, key: str) -> Any:
+        if key in self._d:
+            self._d.move_to_end(key)
+            self.hits += 1
+            return self._d[key]
+        self.misses += 1
+        return None
+
+    def put(self, key: str, value: Any) -> None:
+        if self._maxsize <= 0:
+            return
+        self._d[key] = value
+        self._d.move_to_end(key)
+        self._trim()
+
+    def apply_pressure(self, level: str) -> int:
+        """Recompute ``maxsize`` from the pressure level and evict down to it. Returns evicted count.
+        CRITICAL also signals the caller to GC (handled by the caller, which holds gc)."""
+        frac = self._PRESSURE_FRAC.get(level, 1.0)
+        self._maxsize = int(self._baseline * frac)
+        return self._trim()
+
+    def _trim(self) -> int:
+        n = 0
+        while len(self._d) > self._maxsize:
+            self._d.popitem(last=False)  # evict LRU
+            self.evictions += 1
+            n += 1
+        return n
+
+    def __len__(self) -> int:
+        return len(self._d)
+
+
+# ---------------------------------------------------------------------------- factory
+def build_graph_backend(ckg: Any) -> GraphBackend:
+    """Single decision point for the traversal backend. Slice 1: always returns
+    ``InMemoryGraphBackend`` (byte-identical to the pre-seam path). Slice 2 will return a
+    ``DualBackendParityHarness(primary=InMemory, shadow=SqliteLazy)`` when the lazy + parity flags
+    are on — so the Oracle's query layer never needs to change again."""
+    return InMemoryGraphBackend(ckg)

--- a/tests/governance/test_oracle_graph_backend.py
+++ b/tests/governance/test_oracle_graph_backend.py
@@ -1,0 +1,203 @@
+"""Slice 1 — the GraphBackend traversal seam + live differential parity harness.
+
+Validates the seam against the production CodebaseKnowledgeGraph (no mocks): the in-memory backend's
+primitives + algorithms, the DualBackendParityHarness's autonomous-fallback-on-divergence behavior,
+and the adaptive working-set cache.
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.oracle_graph_backend as GB
+from backend.core.ouroboros.oracle import (
+    CodebaseKnowledgeGraph,
+    EdgeData,
+    EdgeType,
+    NodeData,
+    NodeID,
+    NodeType,
+)
+
+
+def _g(n=4):
+    """Linear call chain sym0 -> sym1 -> sym2 -> ... across files."""
+    g = CodebaseKnowledgeGraph()
+    ids = []
+    for i in range(n):
+        nid = NodeID(repo="jarvis", file_path=f"pkg/m{i}.py", name=f"sym{i}",
+                     node_type=NodeType.FUNCTION, line_number=1)
+        g.add_node(NodeData(node_id=nid, docstring=f"d{i}"))
+        ids.append(nid)
+    for i in range(n - 1):
+        g.add_edge(ids[i], ids[i + 1], EdgeData(EdgeType.CALLS, line_number=i))
+    return g, ids
+
+
+# --------------------------------------------------------------------------- in-memory primitives
+def test_inmemory_primitives_match_graph():
+    g, ids = _g(4)
+    b = g._backend
+    k0, k1 = str(ids[0]), str(ids[1])
+    assert b.contains(k0) and not b.contains("nope")
+    assert b.get_node(k0)["node_id"]["name"] == "sym0"
+    assert b.get_node("nope") is None
+    succ = b.successors(k0)
+    assert succ == [(k1, {"edge_type": "calls", "line_number": 0, "context": ""})]
+    assert b.predecessors(k1) == [(k0, {"edge_type": "calls", "line_number": 0, "context": ""})]
+    assert b.node_count() == 4 and b.edge_count() == 3
+    assert set(b.all_keys()) == {str(i) for i in ids}
+
+
+def test_inmemory_shortest_path_and_cycles():
+    g, ids = _g(4)
+    b = g._backend
+    path = b.shortest_path(str(ids[0]), str(ids[3]))
+    assert path == [str(i) for i in ids]            # full chain
+    assert b.shortest_path(str(ids[3]), str(ids[0])) is None  # no reverse edge
+    assert b.simple_cycles() == []                  # acyclic
+    # add a back-edge → one cycle
+    g.add_edge(ids[3], ids[0], EdgeData(EdgeType.CALLS))
+    cycles = g._backend.simple_cycles()
+    assert len(cycles) == 1 and set(cycles[0]) == {str(i) for i in ids}
+
+
+def test_default_algorithms_match_nx_overrides():
+    """The ABC's primitive-only shortest_path/simple_cycles (used by the future SQLite backend) must
+    agree with the in-memory nx overrides."""
+    g, ids = _g(5)
+    g.add_edge(ids[4], ids[1], EdgeData(EdgeType.CALLS))  # cycle 1..4
+
+    native = g._backend  # InMemory (nx overrides)
+
+    class _PurePrimitiveView(GB.GraphBackend):
+        """Wraps the in-memory primitives but uses the ABC's DEFAULT algorithms (no nx)."""
+        def __init__(self, base): self._b = base
+        def contains(self, k): return self._b.contains(k)
+        def get_node(self, k): return self._b.get_node(k)
+        def successors(self, k): return self._b.successors(k)
+        def predecessors(self, k): return self._b.predecessors(k)
+        def node_count(self): return self._b.node_count()
+        def edge_count(self): return self._b.edge_count()
+        def all_keys(self): return self._b.all_keys()
+
+    pure = _PurePrimitiveView(native)
+    # shortest path identical
+    assert pure.shortest_path(str(ids[0]), str(ids[4])) == native.shortest_path(str(ids[0]), str(ids[4]))
+    # cycle sets identical (order-insensitive)
+    nset = {frozenset(c) for c in native.simple_cycles()}
+    pset = {frozenset(c) for c in pure.simple_cycles()}
+    assert nset == pset and len(nset) == 1
+
+
+# --------------------------------------------------------------------------- parity harness
+def test_parity_no_shadow_passthrough():
+    g, ids = _g(3)
+    h = GB.DualBackendParityHarness(primary=g._backend, shadow=None)
+    assert h.successors(str(ids[0])) == g._backend.successors(str(ids[0]))
+    assert h.comparisons == 0 and h.divergences == 0
+
+
+def test_parity_equal_shadow_zero_divergence():
+    g, ids = _g(4)
+    # shadow is a SECOND in-memory backend over the same graph → must always agree
+    h = GB.DualBackendParityHarness(primary=g._backend, shadow=GB.InMemoryGraphBackend(g))
+    for nid in ids:
+        h.get_node(str(nid)); h.successors(str(nid)); h.predecessors(str(nid))
+    h.node_count(); h.edge_count(); h.shortest_path(str(ids[0]), str(ids[3]))
+    assert h.divergences == 0 and h.shadow_errors == 0
+    assert h.comparisons > 0
+
+
+def test_parity_divergence_captures_telemetry_and_falls_back():
+    """A wrong shadow must NOT corrupt results: harness returns the PRIMARY value, records rich
+    telemetry, and never raises."""
+    g, ids = _g(3)
+    captured = []
+
+    class _WrongShadow(GB.InMemoryGraphBackend):
+        def successors(self, key):
+            return [("BOGUS:node:x", {"edge_type": "calls", "line_number": 99, "context": "wrong"})]
+        def get_node(self, key):
+            return {"node_id": {"name": "WRONG"}}
+
+    h = GB.DualBackendParityHarness(
+        primary=g._backend, shadow=_WrongShadow(g), on_divergence=captured.append,
+    )
+    # result is the TRUSTED primary's, despite the lying shadow
+    assert h.successors(str(ids[0])) == g._backend.successors(str(ids[0]))
+    assert h.get_node(str(ids[0]))["node_id"]["name"] == "sym0"
+    assert h.divergences >= 2
+    assert captured and captured[0]["kind"] == "divergence"
+    assert "method" in captured[0] and "primary" in captured[0] and "shadow" in captured[0]
+    assert len(h.records) >= 2
+
+
+def test_parity_shadow_exception_falls_back_no_crash():
+    g, ids = _g(3)
+
+    class _ExplodingShadow(GB.InMemoryGraphBackend):
+        def successors(self, key):
+            raise RuntimeError("shadow backend on fire")
+
+    h = GB.DualBackendParityHarness(primary=g._backend, shadow=_ExplodingShadow(g))
+    # must still return the primary's correct result, counting a shadow_error
+    assert h.successors(str(ids[0])) == g._backend.successors(str(ids[0]))
+    assert h.shadow_errors == 1 and h.divergences == 0
+    assert h.records[-1]["kind"] == "shadow_error"
+
+
+# --------------------------------------------------------------------------- adaptive cache
+def test_adaptive_cache_lru_eviction():
+    c = GB.AdaptiveNodeCache(baseline=3)
+    for i in range(3):
+        c.put(f"k{i}", i)
+    assert len(c) == 3
+    c.get("k0")            # touch k0 → most-recent
+    c.put("k3", 3)         # overflow → evict LRU (k1)
+    assert c.get("k1") is None and c.get("k0") == 0 and c.get("k3") == 3
+    assert c.evictions == 1
+
+
+def test_adaptive_cache_contracts_under_pressure():
+    c = GB.AdaptiveNodeCache(baseline=100)
+    for i in range(100):
+        c.put(f"k{i}", i)
+    assert len(c) == 100
+    evicted = c.apply_pressure("high")     # ×0.5
+    assert c.maxsize == 50 and len(c) == 50 and evicted == 50
+    evicted2 = c.apply_pressure("critical")  # ×0.1
+    assert c.maxsize == 10 and len(c) == 10 and evicted2 == 40
+    c.apply_pressure("ok")                  # restore baseline
+    assert c.maxsize == 100
+
+
+def test_cache_default_baseline_is_5000(monkeypatch):
+    monkeypatch.delenv("JARVIS_ORACLE_TRAVERSAL_CACHE_MAX", raising=False)
+    assert GB.traversal_cache_max() == 5000               # §10 resolution
+    assert GB.AdaptiveNodeCache().maxsize == 5000
+
+
+def test_flags_default_off(monkeypatch):
+    for f in ("JARVIS_ORACLE_LAZY_TRAVERSAL_ENABLED", "JARVIS_ORACLE_PARITY_HARNESS_ENABLED"):
+        monkeypatch.delenv(f, raising=False)
+    assert GB.lazy_traversal_enabled() is False
+    assert GB.parity_harness_enabled() is False
+
+
+# --------------------------------------------------------------------------- seam preserves Oracle behavior
+def test_oracle_query_methods_still_work_through_seam():
+    """The refactored CodebaseKnowledgeGraph query methods (now routing through the seam) return the
+    same results — the regression net for the in-place refactor."""
+    g, ids = _g(4)
+    assert g.get_node(str(ids[0]))["node_id"]["name"] == "sym0"
+    assert [k for k, _ in g.get_edges_from(str(ids[0]))] == [str(ids[1])]
+    assert [k for k, _ in g.get_edges_to(str(ids[1]))] == [str(ids[0])]
+    chain = g.find_call_chain(ids[0], ids[3])
+    assert chain is not None and [n.name for n in chain] == ["sym0", "sym1", "sym2", "sym3"]
+    assert g.find_circular_dependencies() == []
+    g.add_edge(ids[3], ids[0], EdgeData(EdgeType.CALLS))
+    assert len(g.find_circular_dependencies()) == 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

First slice of the SQLite-Backed Lazy Traversal arc (ADD #69549). Abstracts all graph **query**
access behind a `GraphBackend` seam so traversals become storage-agnostic — with the canonical
in-memory backend as the byte-identical default and a weaponized live-differential harness ready for
the SQLite shadow (Slice 2). Pure refactor + safety net; **no behavior change** (the seam is the
de-risking foundation for everything after).

### 1. `GraphBackend` seam (`oracle_graph_backend.py`)
ABC with ~7 primitives (`contains`/`get_node`/`successors`/`predecessors`/`node_count`/`edge_count`/
`all_keys`) + **default algorithms built purely on them** (`shortest_path` BFS, `simple_cycles` DFS,
`descendants`), so any backend works without bespoke algorithm code. `InMemoryGraphBackend` is the
baseline (overrides `shortest_path`/`simple_cycles` with NetworkX). `CodebaseKnowledgeGraph` routes
`get_node`/`get_edges_from`/`get_edges_to`/`find_call_chain`/`find_circular_dependencies`/
`get_subgraph` through `self._backend` (fail-soft to direct nx); blast-radius, dependencies,
callers/callees, dead-code ride the same primitives for free.

### 2. `DualBackendParityHarness` — the weaponized live differential guard
Wraps a trusted **primary** + candidate **shadow**; every read runs on both, and on **any** divergence
or shadow-error it captures a rich telemetry payload and **autonomously returns the primary result —
never crashing the control plane.** The primary is always authoritative, so the shadow can be wrong or
absent with zero availability impact. This is how the SQLite backend earns trust in production before
it's trusted alone.

### 3. §10 resolutions, in code
- `AdaptiveNodeCache` **baseline 5,000 nodes** with sync adaptive contraction (`high ×0.5`,
  `critical ×0.1`, LRU eviction) — wired into the SQLite backend in Slice 3.
- `circular_dependencies` + `dead_code` **declared in-scope**: both route through the seam, so they
  never fall into the partial-graph trap under the Scoper.

Gated `JARVIS_ORACLE_LAZY_TRAVERSAL_ENABLED` + `JARVIS_ORACLE_PARITY_HARNESS_ENABLED` (default OFF →
InMemory, byte-identical). Sequencing per ADD §0: Scoper default-ON stays the **final** slice.

## Tests
- **12 new seam tests**: primitives, nx-vs-default-algorithm parity, harness equal-shadow → zero
  divergence, **divergence → telemetry + fallback**, **shadow-exception → fallback, no crash**,
  adaptive-cache LRU + pressure contraction + 5000 baseline.
- **Refactor proven byte-identical** by existing regression suites: graph-counter (7) + graph-hygiene
  (5) + persistence (41) + blast-radius/verification (80) — all green.

## Next (Slice 2)
`SqliteLazyGraphBackend` (sync read-only `sqlite3` conn over the existing `idx_edges_src/dst`
indexes) plugged into the harness's shadow slot, differentially verified against in-memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a storage-agnostic traversal seam with `GraphBackend` and a live differential `DualBackendParityHarness` to prepare for a SQLite lazy backend, with no behavior changes. All graph reads now route through the backend; default remains the in-memory path.

- **New Features**
  - `GraphBackend` ABC with primitives and default algorithms; `InMemoryGraphBackend` overrides use NetworkX.
  - `DualBackendParityHarness` runs primary+shadow, records divergences or shadow errors, and always returns the primary result.
  - `AdaptiveNodeCache` (baseline 5,000) with LRU and pressure-based contraction.
  - Flags: `JARVIS_ORACLE_LAZY_TRAVERSAL_ENABLED`, `JARVIS_ORACLE_PARITY_HARNESS_ENABLED` (both off by default).

- **Refactors**
  - `get_node`, `get_edges_from`, `get_edges_to`, `find_call_chain`, `find_circular_dependencies`, and `get_subgraph` now use the backend, fail-soft to NetworkX if needed.
  - New tests cover primitives, algorithm parity, harness behavior (divergence and exceptions), and cache contraction/eviction.
  - No behavior change; results remain byte-identical.

<sup>Written for commit fbf5e75127d7619814e608aaaa577c37a8d79c27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

