### PR TITLE
feat(repair-bridge): Slice 1 — Deep Semantic Failure Ingestion + Dynamic Reachability Matrix spec

### DIFF
--- a/backend/core/ouroboros/governance/intent/repair_traceback.py
+++ b/backend/core/ouroboros/governance/intent/repair_traceback.py
@@ -1,0 +1,186 @@
+"""Repair Context Bridge — Slice 1: deep semantic failure ingestion.
+
+Parses pytest tracebacks frame-by-frame and AST-maps each frame to a canonical Oracle node key, so a
+test failure carries the *precise functional coordinates* of the fault (not just a one-line error).
+Those coordinates seed the blast-radius cone in Slice 2 and the structural gate in Slice 3.
+
+Pure + fail-soft + injectable: the line->node resolver is any object exposing the GraphBackend
+``nodes_in_file(rel) -> [keys]`` + ``get_node(key) -> attrs`` primitives (the Oracle's lazy backend
+in production, a fake in tests). Mapping never raises — any failure degrades to the unenriched signal,
+so the immune system is never weakened by the thing meant to strengthen it.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+# pytest --tb=short frame line: ``path/to/file.py:123: in func_name``
+_FRAME_RE = re.compile(r"^(?P<file>.+\.py):(?P<line>\d+): in (?P<func>\S+)\s*$")
+# a per-failure block header in the FAILURES section: ``____ test_foo ____`` / ``__ TestX.test_foo __``
+_BLOCK_RE = re.compile(r"^_{3,}\s+(?P<name>[^_].*?)\s+_{3,}\s*$")
+
+
+def bridge_enabled() -> bool:
+    """``JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED`` (default OFF) — master switch for traceback
+    enrichment + (Slice 2) blast-radius cone. OFF → signals are byte-identical to today."""
+    return os.environ.get("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+class NodeResolver(Protocol):
+    def nodes_in_file(self, file_path: str) -> List[str]: ...
+    def get_node(self, key: str) -> Optional[Dict[str, Any]]: ...
+
+
+@dataclass
+class Frame:
+    """One traceback frame, optionally AST-mapped to its Oracle node."""
+    file: str                       # path as printed by pytest
+    line: int
+    func: str
+    in_repo: bool = False           # resolvable under a known repo root
+    rel_path: Optional[str] = None  # path relative to the repo root (matches Oracle file_path)
+    node_key: Optional[str] = None  # canonical Oracle node key spanning this line, if any
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "file": self.file, "line": self.line, "func": self.func,
+            "in_repo": self.in_repo, "rel_path": self.rel_path, "node_key": self.node_key,
+        }
+
+
+@dataclass
+class TracebackMap:
+    frames: List[Frame] = field(default_factory=list)
+    # deepest-first repo-internal node keys — the prime fault coordinates for blast-radius
+    fault_node_keys: List[str] = field(default_factory=list)
+
+    def to_evidence(self) -> Dict[str, Any]:
+        return {
+            "traceback_frames": [f.to_dict() for f in self.frames],
+            "fault_node_keys": list(self.fault_node_keys),
+        }
+
+
+# --------------------------------------------------------------------------- parse
+def parse_pytest_tracebacks(stdout: str) -> Dict[str, List[Frame]]:
+    """Parse the FAILURES section into ``{block_name: [Frame, ...]}`` (in pytest print order, i.e.
+    outermost test frame first → deepest fault frame last). Best-effort; unparseable → {}."""
+    out: Dict[str, List[Frame]] = {}
+    current: Optional[str] = None
+    for raw in stdout.splitlines():
+        block = _BLOCK_RE.match(raw)
+        if block:
+            current = str(block.group("name")).strip()
+            out.setdefault(current, [])
+            continue
+        if current is None:
+            continue
+        m = _FRAME_RE.match(raw.strip())
+        if m:
+            out[current].append(Frame(file=m.group("file"), line=int(m.group("line")),
+                                      func=m.group("func")))
+    return {k: v for k, v in out.items() if v}
+
+
+def _frames_for_test(blocks: Dict[str, List[Frame]], test_id: str) -> List[Frame]:
+    """Correlate a ``file.py::Class::test_name`` id to its parsed block by the test function name."""
+    name = test_id.split("::")[-1].split("[")[0]      # strip params
+    # exact tail match first (handles ``TestX.test_name`` headers), then substring
+    for key, frames in blocks.items():
+        if key == name or key.endswith("." + name):
+            return frames
+    for key, frames in blocks.items():
+        if name in key:
+            return frames
+    return []
+
+
+# --------------------------------------------------------------------------- AST map
+def _to_rel(abs_or_rel: str, repo_roots: List[str]) -> Optional[str]:
+    """Path as printed by pytest → repo-relative (matches Oracle ``file_path``), or None if external
+    (stdlib / site-packages / outside every repo root).
+
+    pytest ``--tb=short`` runs with ``cwd=repo_path`` and prints **repo-relative** paths for in-repo
+    frames and **absolute** paths for out-of-repo frames (stdlib / site-packages). So a relative path
+    is already the Oracle ``file_path``; only absolute paths need root-relativization. This is robust
+    to the mapping process's own CWD differing from the repo root (it usually does)."""
+    p = abs_or_rel
+    if "site-packages" in p or "/lib/python" in p or "/dist-packages/" in p:
+        return None
+    if not os.path.isabs(p):
+        return os.path.normpath(p)            # already repo-relative (pytest cwd=repo)
+    for root in repo_roots:                    # absolute → relativize to a known root
+        try:
+            return str(Path(p).resolve().relative_to(Path(root).resolve()))
+        except ValueError:
+            continue
+    return None                                # absolute + outside every root → external
+
+
+def _node_for_line(rel_path: str, line: int, resolver: NodeResolver) -> Optional[str]:
+    """Innermost Oracle node whose span ``[line_number, line_number+line_count)`` contains *line*.
+    Innermost (smallest span) wins, so a function is preferred over the enclosing file/class node."""
+    best_key: Optional[str] = None
+    best_span = 1 << 62
+    for key in resolver.nodes_in_file(rel_path):
+        attrs = resolver.get_node(key)
+        if not attrs:
+            continue
+        nid = attrs.get("node_id") or {}
+        start = int(nid.get("line_number", 0) or 0)
+        span = int(attrs.get("line_count", 0) or 0)
+        if start <= 0 or span <= 0:
+            continue
+        if start <= line < start + span and span < best_span:
+            best_key, best_span = key, span
+    return best_key
+
+
+def map_frames_to_nodes(frames: List[Frame], repo_roots: List[str],
+                        resolver: Optional[NodeResolver]) -> List[Frame]:
+    """Fill ``in_repo``/``rel_path``/``node_key`` on each frame. Pure; never raises."""
+    for fr in frames:
+        rel = _to_rel(fr.file, repo_roots)
+        if rel is None:
+            continue
+        fr.in_repo = True
+        fr.rel_path = rel
+        if resolver is not None:
+            try:
+                fr.node_key = _node_for_line(rel, fr.line, resolver)
+            except Exception:  # noqa: BLE001 — mapping is best-effort
+                fr.node_key = None
+    return frames
+
+
+def build_traceback_map(stdout: str, test_id: str, repo_roots: List[str],
+                        resolver: Optional[NodeResolver]) -> TracebackMap:
+    """Top-level enrichment: parse → correlate to the test → AST-map → fault coordinates.
+
+    ``fault_node_keys`` are the repo-internal frames' nodes **deepest-first** (the innermost in-repo
+    frame = the prime fault suspect for blast-radius). De-duplicated, order-preserving. Fail-soft:
+    any error returns an empty map (caller keeps the unenriched signal)."""
+    try:
+        blocks = parse_pytest_tracebacks(stdout)
+        frames = _frames_for_test(blocks, test_id)
+        if not frames:
+            return TracebackMap()
+        map_frames_to_nodes(frames, repo_roots, resolver)
+        seen: set = set()
+        fault: List[str] = []
+        for fr in reversed(frames):                      # deepest-first
+            if fr.node_key and fr.node_key not in seen:
+                seen.add(fr.node_key)
+                fault.append(fr.node_key)
+        return TracebackMap(frames=frames, fault_node_keys=fault)
+    except Exception as exc:  # noqa: BLE001 — enrichment must never break the sensor
+        logger.debug("[RepairBridge] traceback enrichment failed (non-fatal): %s", exc)
+        return TracebackMap()

--- a/backend/core/ouroboros/governance/intent/test_watcher.py
+++ b/backend/core/ouroboros/governance/intent/test_watcher.py
@@ -27,8 +27,8 @@ import asyncio
 import logging
 import os
 import re
-from dataclasses import dataclass
-from typing import Dict, List, Optional, Set, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from .signals import IntentSignal
 
@@ -60,11 +60,18 @@ class TestFailure:
         The file portion of the test id, e.g. ``"tests/test_utils.py"``.
     error_text:
         The error summary text captured from the FAILED line.
+    traceback_evidence:
+        Repair Context Bridge (Slice 1) enrichment — additive evidence merged
+        into the emitted signal: ``{traceback_frames, fault_node_keys}`` mapping
+        the failing call stack to Oracle node keys. ``None`` until the bridge
+        enriches it (gated ``JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED``); ``None``
+        leaves the signal byte-identical to pre-bridge behavior.
     """
 
     test_id: str
     file_path: str
     error_text: str
+    traceback_evidence: Optional[Dict[str, Any]] = field(default=None)
 
 
 # ---------------------------------------------------------------------------
@@ -100,10 +107,15 @@ class TestWatcher:
         repo_path: Optional[str] = None,
         poll_interval_s: Optional[float] = None,
         pytest_timeout_s: float = 30.0,
+        node_resolver: Optional[Any] = None,
     ) -> None:
         self.repo = repo
         self.test_dir = os.environ.get("JARVIS_INTENT_TEST_DIR", test_dir)
         self.repo_path = repo_path or os.environ.get("JARVIS_REPO_PATH", ".")
+        # Repair Context Bridge (Slice 1): injectable Oracle line->node resolver.
+        # ``None`` → lazily resolved from the global Oracle backend at enrich time
+        # (fail-soft). Tests inject a fake. Only consulted when the bridge is on.
+        self._node_resolver = node_resolver
         self.poll_interval_s = (
             poll_interval_s
             if poll_interval_s is not None
@@ -242,6 +254,17 @@ class TestWatcher:
             # Stable = at least 2 consecutive failures
             if streak >= 2:
                 confidence = min(0.95, 0.7 + 0.1 * streak)
+                evidence: Dict[str, Any] = {
+                    "signature": f"{f.error_text}:{f.file_path}",
+                    "test_id": f.test_id,
+                    "streak": streak,
+                    "error_text": f.error_text,
+                }
+                # Repair Context Bridge (Slice 1): additive traceback enrichment.
+                # Only present when the bridge enriched this failure; merging
+                # ``None``/empty leaves the evidence byte-identical to before.
+                if f.traceback_evidence:
+                    evidence.update(f.traceback_evidence)
                 signal = IntentSignal(
                     source="intent:test_failure",
                     target_files=(f.file_path,),
@@ -250,12 +273,7 @@ class TestWatcher:
                         f"Stable test failure: {f.test_id} "
                         f"(streak={streak}): {f.error_text}"
                     ),
-                    evidence={
-                        "signature": f"{f.error_text}:{f.file_path}",
-                        "test_id": f.test_id,
-                        "streak": streak,
-                        "error_text": f.error_text,
-                    },
+                    evidence=evidence,
                     confidence=confidence,
                     stable=True,
                 )
@@ -284,6 +302,59 @@ class TestWatcher:
         return test_id.split("::")[0]
 
     # ------------------------------------------------------------------
+    # Repair Context Bridge (Slice 1) — deep semantic failure ingestion
+    # ------------------------------------------------------------------
+
+    def _get_node_resolver(self) -> Optional[Any]:
+        """Return the Oracle line->node resolver (``nodes_in_file`` + ``get_node``).
+
+        Uses the injected resolver if provided (tests); otherwise lazily reaches
+        the global Oracle's graph backend. Fail-soft: any error → ``None``, which
+        degrades enrichment to frame-only (no node mapping), never raising."""
+        if self._node_resolver is not None:
+            return self._node_resolver
+        try:
+            from backend.core.ouroboros.oracle import get_oracle
+
+            backend = getattr(get_oracle()._graph, "_backend", None)
+            if backend is not None and hasattr(backend, "nodes_in_file"):
+                self._node_resolver = backend
+                return backend
+        except Exception as exc:  # noqa: BLE001 — resolver is best-effort
+            logger.debug("[RepairBridge] node resolver unavailable: %s", exc)
+        return None
+
+    async def _enrich_failures(
+        self, failures: List[TestFailure], output: str
+    ) -> None:
+        """AST-map each failure's traceback to Oracle node keys (in place).
+
+        Gated by ``JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED`` (default OFF). The
+        parse + sqlite line->node mapping is offloaded to a worker thread
+        (``asyncio.to_thread``) so the sensor's primary poll loop never blocks on
+        graph I/O. Fail-soft: any error leaves ``traceback_evidence`` as ``None``
+        and the signal degrades to today's graph-blind behavior."""
+        try:
+            from .repair_traceback import bridge_enabled, build_traceback_map
+        except Exception:  # noqa: BLE001 — module import must never break the sensor
+            return
+        if not bridge_enabled() or not failures or not output:
+            return
+        resolver = self._get_node_resolver()
+        repo_roots = [str(self.repo_path)]
+
+        def _map_all() -> None:
+            for f in failures:
+                tb = build_traceback_map(output, f.test_id, repo_roots, resolver)
+                if tb.frames:
+                    f.traceback_evidence = tb.to_evidence()
+
+        try:
+            await asyncio.to_thread(_map_all)
+        except Exception as exc:  # noqa: BLE001 — enrichment is best-effort
+            logger.debug("[RepairBridge] failure enrichment failed: %s", exc)
+
+    # ------------------------------------------------------------------
     # Poll loop
     # ------------------------------------------------------------------
 
@@ -302,6 +373,9 @@ class TestWatcher:
         if exit_code == -1:
             return []  # timeout -- skip cycle, preserve streaks
         failures = self.parse_pytest_output(output, exit_code)
+        # Repair Context Bridge (Slice 1): non-blocking AST traceback enrichment
+        # (gated, fail-soft) — populates f.traceback_evidence before signal build.
+        await self._enrich_failures(failures, output)
         return self.process_failures(failures)
 
     async def start(self) -> None:

--- a/docs/architecture/REPAIR_CONTEXT_BRIDGE_ADD.md
+++ b/docs/architecture/REPAIR_CONTEXT_BRIDGE_ADD.md
@@ -54,6 +54,15 @@ overlaps resolve to the innermost span. Frames with no resolvable node (e.g. gen
 `node_key=None` and are skipped as targets. Fail-soft: if traceback parsing fails, the signal
 degrades to today's `error_text` (the loop still works, just graph-blind for that op).
 
+**Implemented (Slice 1):** pure mapper `governance/intent/repair_traceback.py`
+(`parse_pytest_tracebacks` → `_frames_for_test` correlation → `map_frames_to_nodes` innermost-span
+AST map → `build_traceback_map` deepest-first `fault_node_keys`); injectable `NodeResolver`
+(production = the Oracle's `_graph._backend`, lazily + fail-soft). Wired into
+`intent/test_watcher.py`: `TestFailure.traceback_evidence` (additive field) populated by the async
+`_enrich_failures` (mapping offloaded via `asyncio.to_thread` — zero block on the sensor poll loop),
+merged into `IntentSignal.evidence` in `process_failures`. Gated `JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED`
+(default OFF → signal evidence byte-identical to pre-bridge). 32 tests (mapper + watcher wiring).
+
 ---
 
 ## 2. Phase 2 — Graph-Informed Cognitive Context (the steer)
@@ -105,8 +114,14 @@ flushed to disk or signed by `AutoCommitter`:
      pre-fix cone → reject (introduced circular dependency).
    - **New dead code:** a node that had callers/importers pre-fix has *none* post-delta → reject
      (the fix orphaned a referenced symbol).
-   - **Severed call-chain:** a call-chain present pre-fix between two cone nodes no longer resolves
-     post-delta → reject (structural break elsewhere in the blast radius).
+   - **Severed call-chain (reachability-gated — see §3.1):** a call-chain present pre-fix between two
+     cone nodes no longer resolves post-delta. This is **not** a binary rejection: it is a structural
+     break *only if* severing it disrupts reachability from a **system entry point** (an active test
+     suite, a `__main__`/loop entry, or any live external caller) to a still-**active** downstream
+     component. If the only paths it severs lead to **dead/orphaned subgraphs**, the severance is
+     **authorized as valid structural pruning** (the fix legitimately removed reachable-only-from-dead
+     code) → ACCEPT + emit non-blocking cleanup telemetry. The Dynamic Reachability Matrix (§3.1)
+     decides which case applies.
 4. **Verdict:** ACCEPT → candidate proceeds to the existing VERIFY/SemanticGuardian/AutoCommit path
    unchanged. REJECT → emit a **structural-divergence signature** (kind + offending node/edge, hashed
    via `failure_classifier.patch_signature_hash`) and **append it to the L2 failure context**, so the
@@ -124,6 +139,57 @@ feedback loop, and the failure-classifier — net new code is the simulator + th
   regression *outside* the cone is out of scope (and would be unrelated to this fix by definition).
 - It validates **structure**, not behavior — VERIFY (the scoped test run) remains the behavioral
   authority. This gate is friction *before* the test run, catching structural breaks tests miss.
+
+---
+
+## 3.1 The Dynamic Graph Reachability Matrix (severed-chain adjudication)
+
+**The principle (operator-ratified behavioral rule):** *a severed call-chain is a structural
+regression only when it disrupts reachability from a live system entry point to a still-active
+downstream component. A chain severed only within a dead or orphaned subgraph is valid structural
+pruning, not a break.* This replaces naïve "any removed edge = reject" with intent-aware
+adjudication, and is the canonical answer to §8 Q2.
+
+**Entry points (the reachability roots) — derived, never hardcoded:**
+- **Active test suites** — the test nodes the Oracle already indexes (files under the configured test
+  dirs); for the repairing op specifically, the *failing test node* is always a root.
+- **Runtime entries** — `__main__` guards, registered loop/daemon entrypoints, and any node with a
+  live external in-edge the Oracle records (e.g. CLI/handler registration).
+- These are read from the graph, not a static list — new entrypoints become roots automatically (§5
+  intelligence-driven, no hardcoded routing).
+
+**The matrix (computed on the *post-delta* cone, deterministic, zero-LLM):**
+For each call-chain `C` that existed pre-fix but no longer resolves post-delta, classify its severed
+endpoint(s) by reachability from the entry-point root set `R` over the post-delta graph:
+
+| Downstream endpoint reachable from `R` post-delta? | Endpoint still has *other* live callers? | Verdict |
+|---|---|---|
+| **Yes** (a live root still reaches it another way) | — | **ACCEPT** — chain rerouted, not broken; reachability preserved |
+| **No** | **Yes** (reachable via a different live chain) | **ACCEPT** — local re-wiring; component still active |
+| **No** | **No**, but endpoint *was* reachable from `R` **pre-delta** | **REJECT** — *this fix* orphaned a live component → divergence signature → L2 feedback |
+| **No** | **No**, and endpoint was **already** dead pre-delta | **ACCEPT (prune)** — severing dead-only code; emit `structural_prune` cleanup telemetry (non-blocking) |
+
+The decisive comparison is **pre-delta vs post-delta reachability of the endpoint from `R`**: REJECT
+iff the fix transitions an endpoint from *reachable-from-a-live-root* to *unreachable*. Everything
+else (already-dead, rerouted, or still-reachable) is authorized.
+
+**Implementation (reuses shipped primitives, no new traversal engine):**
+- Reachability = the GraphBackend's existing `descendants(root)` / `find_call_chain` over the
+  cone-scoped *what-if* subgraph (§3 step 2) — run once for the root set pre-delta and once
+  post-delta; the endpoint's membership flip in `reachable(R)` is the whole decision. Streamed,
+  cone-bounded, ~10 ms, lazy-backend memory profile (the proven 7 MB path).
+- `structural_prune` events are fire-and-forget telemetry on the existing observability/SSE surface —
+  they record *what dead code the fix legitimately removed* (so cleanup is auditable per §7
+  observability), and **never block** the candidate.
+
+**Honest bound:** "dead" here means *graph-unreachable from the live root set* — a component reached
+only via reflection / dynamic dispatch / external RPC the Oracle can't see could be misclassified as
+dead. Mitigations: (a) the matrix only *prunes* (ACCEPT) on dead-only severance, so a
+misclassification is a missed-friction event, never a false REJECT that blocks a good fix; (b) VERIFY
+(the behavioral authority) still runs; (c) `structural_prune` telemetry makes every authorized
+pruning visible for human audit. Like the other two checks, severed-chain starts **soft** (logged +
+fed back, non-blocking) and graduates to hard-REJECT-on-live-orphan only after the soak shows a low
+false-positive rate.
 
 ---
 
@@ -176,8 +242,11 @@ TestFailure (pytest)
 ## 8. Open questions for the operator
 1. **Cone size cap** — top-K nodes/files injected into the prompt (token budget). Starting guess: the
    direct blast-radius + 1-hop dependencies, capped ~50 symbols; tune after the soak.
-2. **Severed-call-chain strictness** — should removing *any* pre-existing call-chain in the cone
-   reject, or only chains the failing test transitively exercised? (Lean: the latter — fewer false
-   positives.)
+2. **Severed-call-chain strictness** — **RESOLVED (see §3.1, operator-ratified).** Not binary: the
+   Dynamic Graph Reachability Matrix rejects *only* when a fix flips a downstream component from
+   reachable-from-a-live-entry-point to unreachable; a chain severed only within a dead/orphaned
+   subgraph is authorized as valid structural pruning (ACCEPT + non-blocking `structural_prune`
+   cleanup telemetry). Entry-point roots (active test suites incl. the failing test, `__main__`/loop
+   entries, live external callers) are derived from the graph, never hardcoded.
 3. **"Vectorized" cone** — confirm the structured node/edge-set interpretation (recommended) vs an
    actual embedding vector (out of scope; the semantic index already embeds separately).

--- a/tests/governance/intent/test_repair_traceback.py
+++ b/tests/governance/intent/test_repair_traceback.py
@@ -1,0 +1,171 @@
+"""Tests for the Repair Context Bridge — Slice 1 traceback->node mapper.
+
+Covers the pure mapper (`repair_traceback.py`):
+1. Parse `--tb=short` FAILURES into per-test frames (print order).
+2. Correlate a `file.py::Class::test` id to its block.
+3. AST-map line -> innermost Oracle node via stored line_number + line_count.
+4. fault_node_keys are deepest-first, de-duplicated, repo-internal only.
+5. External frames (site-packages / stdlib) are recorded but never mapped.
+6. Fail-soft: garbage input / no resolver degrade cleanly (never raise).
+"""
+from __future__ import annotations
+
+import textwrap
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from backend.core.ouroboros.governance.intent.repair_traceback import (
+    Frame,
+    bridge_enabled,
+    build_traceback_map,
+    map_frames_to_nodes,
+    parse_pytest_tracebacks,
+)
+
+
+# --------------------------------------------------------------------------- fixtures
+_TB_SHORT = textwrap.dedent("""\
+    =================================== FAILURES ===================================
+    _______________________________ test_parse ____________________________________
+    tests/test_core.py:12: in test_parse
+        assert parse("x") == 3
+    src/calc.py:42: in parse
+        return _inner(s)
+    src/calc.py:88: in _inner
+        raise ValueError("boom")
+    E   ValueError: boom
+    ________________________________ test_timeout __________________________________
+    tests/test_net.py:20: in test_timeout
+        connect()
+    /usr/lib/python3.11/socket.py:833: in connect
+        raise TimeoutError
+    E   TimeoutError: connection timed out
+    =========================== short test summary info ============================
+    FAILED tests/test_core.py::test_parse - ValueError: boom
+    FAILED tests/test_net.py::test_timeout - TimeoutError: connection timed out
+""")
+
+
+class _FakeResolver:
+    """Minimal GraphBackend-shaped resolver: file -> node keys, key -> attrs."""
+
+    def __init__(self, nodes: Dict[str, Dict[str, Any]]) -> None:
+        # nodes: key -> {"file": rel, "line_number": int, "line_count": int}
+        self._nodes = nodes
+        self._by_file: Dict[str, List[str]] = {}
+        for key, attrs in nodes.items():
+            self._by_file.setdefault(attrs["file"], []).append(key)
+
+    def nodes_in_file(self, file_path: str) -> List[str]:
+        return list(self._by_file.get(file_path, []))
+
+    def get_node(self, key: str) -> Optional[Dict[str, Any]]:
+        a = self._nodes.get(key)
+        if a is None:
+            return None
+        return {"node_id": {"line_number": a["line_number"]}, "line_count": a["line_count"]}
+
+
+def _resolver() -> _FakeResolver:
+    return _FakeResolver({
+        "src/calc.py::parse": {"file": "src/calc.py", "line_number": 40, "line_count": 10},
+        "src/calc.py::_inner": {"file": "src/calc.py", "line_number": 85, "line_count": 6},
+        "src/calc.py": {"file": "src/calc.py", "line_number": 1, "line_count": 300},
+        "tests/test_core.py::test_parse": {"file": "tests/test_core.py", "line_number": 10, "line_count": 5},
+    })
+
+
+# --------------------------------------------------------------------------- parse
+class TestParse:
+    def test_parses_two_blocks(self) -> None:
+        blocks = parse_pytest_tracebacks(_TB_SHORT)
+        assert set(blocks) == {"test_parse", "test_timeout"}
+
+    def test_frames_in_print_order(self) -> None:
+        blocks = parse_pytest_tracebacks(_TB_SHORT)
+        frames = blocks["test_parse"]
+        assert [(f.file, f.line, f.func) for f in frames] == [
+            ("tests/test_core.py", 12, "test_parse"),
+            ("src/calc.py", 42, "parse"),
+            ("src/calc.py", 88, "_inner"),
+        ]
+
+    def test_garbage_returns_empty(self) -> None:
+        assert parse_pytest_tracebacks("no failures here\njust noise") == {}
+
+
+# --------------------------------------------------------------------------- map
+class TestMap:
+    def test_innermost_span_wins(self) -> None:
+        # line 88 is inside both the file node (span 300) and _inner (span 6) -> _inner
+        frames = [Frame(file="src/calc.py", line=88, func="_inner")]
+        map_frames_to_nodes(frames, ["."], _resolver())
+        assert frames[0].node_key == "src/calc.py::_inner"
+        assert frames[0].in_repo is True
+        assert frames[0].rel_path == "src/calc.py"
+
+    def test_line_maps_to_enclosing_function(self) -> None:
+        frames = [Frame(file="src/calc.py", line=42, func="parse")]
+        map_frames_to_nodes(frames, ["."], _resolver())
+        assert frames[0].node_key == "src/calc.py::parse"
+
+    def test_external_frame_skipped(self) -> None:
+        frames = [Frame(file="/usr/lib/python3.11/socket.py", line=833, func="connect")]
+        map_frames_to_nodes(frames, ["."], _resolver())
+        assert frames[0].in_repo is False
+        assert frames[0].node_key is None
+
+    def test_no_resolver_records_frames_only(self) -> None:
+        frames = [Frame(file="src/calc.py", line=88, func="_inner")]
+        map_frames_to_nodes(frames, ["."], None)
+        assert frames[0].in_repo is True
+        assert frames[0].node_key is None
+
+
+# --------------------------------------------------------------------------- end-to-end
+class TestBuildTracebackMap:
+    def test_fault_keys_deepest_first_repo_internal(self) -> None:
+        tb = build_traceback_map(_TB_SHORT, "tests/test_core.py::test_parse", ["."], _resolver())
+        # deepest in-repo frame first; the test-file frame's node included; no None entries
+        assert tb.fault_node_keys[0] == "src/calc.py::_inner"
+        assert "src/calc.py::parse" in tb.fault_node_keys
+        assert all(k for k in tb.fault_node_keys)
+
+    def test_evidence_shape(self) -> None:
+        tb = build_traceback_map(_TB_SHORT, "tests/test_core.py::test_parse", ["."], _resolver())
+        ev = tb.to_evidence()
+        assert set(ev) == {"traceback_frames", "fault_node_keys"}
+        assert isinstance(ev["traceback_frames"], list)
+        assert ev["traceback_frames"][0]["func"] == "test_parse"
+
+    def test_external_only_block_has_no_fault_keys(self) -> None:
+        tb = build_traceback_map(_TB_SHORT, "tests/test_net.py::test_timeout", ["."], _resolver())
+        # test_timeout's only repo frame is the test file (unmapped here) + a stdlib frame
+        assert "src/calc.py::_inner" not in tb.fault_node_keys
+
+    def test_unknown_test_id_empty_map(self) -> None:
+        tb = build_traceback_map(_TB_SHORT, "tests/test_x.py::test_missing", ["."], _resolver())
+        assert tb.frames == []
+        assert tb.fault_node_keys == []
+
+    def test_failsoft_on_bad_input(self) -> None:
+        # None stdout would raise inside; build_traceback_map must swallow and return empty
+        tb = build_traceback_map(None, "x::y", ["."], _resolver())  # type: ignore[arg-type]
+        assert tb.frames == []
+
+
+# --------------------------------------------------------------------------- flag
+class TestFlag:
+    def test_default_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", raising=False)
+        assert bridge_enabled() is False
+
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+    def test_truthy(self, monkeypatch: pytest.MonkeyPatch, val: str) -> None:
+        monkeypatch.setenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", val)
+        assert bridge_enabled() is True
+
+    def test_falsey(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", "0")
+        assert bridge_enabled() is False

--- a/tests/governance/intent/test_test_watcher.py
+++ b/tests/governance/intent/test_test_watcher.py
@@ -173,3 +173,120 @@ class TestExtractsFilePathFromTestId:
             "tests/test_utils.py::TestClass::test_method"
         )
         assert result == "tests/test_utils.py"
+
+
+# ---------------------------------------------------------------------------
+# Repair Context Bridge (Slice 1) — traceback enrichment wiring
+# ---------------------------------------------------------------------------
+
+import textwrap as _textwrap  # noqa: E402
+
+_TB_OUTPUT = _textwrap.dedent("""\
+    =================================== FAILURES ===================================
+    _______________________________ test_parse ____________________________________
+    tests/test_core.py:12: in test_parse
+        assert parse("x") == 3
+    src/calc.py:42: in parse
+        raise ValueError("boom")
+    E   ValueError: boom
+    =========================== short test summary info ============================
+    FAILED tests/test_core.py::test_parse - ValueError: boom
+""")
+
+
+class _FakeResolver:
+    """GraphBackend-shaped fake: maps src/calc.py:42 -> a 'parse' node."""
+
+    def nodes_in_file(self, file_path):  # noqa: ANN001, ANN201
+        if file_path == "src/calc.py":
+            return ["src/calc.py::parse"]
+        return []
+
+    def get_node(self, key):  # noqa: ANN001, ANN201
+        if key == "src/calc.py::parse":
+            return {"node_id": {"line_number": 40}, "line_count": 10}
+        return None
+
+
+def _make_failure() -> TestFailure:
+    return TestFailure(
+        test_id="tests/test_core.py::test_parse",
+        file_path="tests/test_core.py",
+        error_text="ValueError: boom",
+    )
+
+
+class TestBridgeOffByteIdentical:
+    """With the bridge flag OFF, enrichment is a no-op and the signal evidence
+    is byte-identical to pre-bridge behavior (no traceback keys)."""
+
+    @pytest.mark.asyncio
+    async def test_off_leaves_evidence_unenriched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", raising=False)
+        watcher = TestWatcher(repo="jarvis", node_resolver=_FakeResolver())
+        f = _make_failure()
+        await watcher._enrich_failures([f], _TB_OUTPUT)
+        assert f.traceback_evidence is None  # untouched
+        # streak 2 → stable signal carries only the legacy evidence keys
+        watcher.process_failures([f])
+        signals = watcher.process_failures([_make_failure()])
+        ev = signals[0].evidence
+        assert set(ev) == {"signature", "test_id", "streak", "error_text"}
+
+
+class TestBridgeOnEnriches:
+    """With the bridge ON, the failure is enriched and the keys flow into the
+    emitted signal's evidence additively."""
+
+    @pytest.mark.asyncio
+    async def test_on_maps_traceback_to_node(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", "true")
+        watcher = TestWatcher(repo="jarvis", node_resolver=_FakeResolver())
+        f = _make_failure()
+        await watcher._enrich_failures([f], _TB_OUTPUT)
+        assert f.traceback_evidence is not None
+        assert "src/calc.py::parse" in f.traceback_evidence["fault_node_keys"]
+
+    @pytest.mark.asyncio
+    async def test_enriched_keys_merge_into_signal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", "true")
+        watcher = TestWatcher(repo="jarvis", node_resolver=_FakeResolver())
+        # streak 1 (not stable yet) — enrich the second-run failure
+        watcher.process_failures([_make_failure()])
+        f2 = _make_failure()
+        await watcher._enrich_failures([f2], _TB_OUTPUT)
+        signals = watcher.process_failures([f2])
+        assert len(signals) == 1
+        ev = signals[0].evidence
+        assert "fault_node_keys" in ev and "traceback_frames" in ev
+        assert ev["signature"] == "ValueError: boom:tests/test_core.py"  # legacy intact
+
+
+class TestBridgeFailSoft:
+    """Enrichment must never raise — a broken resolver degrades to None."""
+
+    @pytest.mark.asyncio
+    async def test_broken_resolver_degrades(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", "true")
+
+        class _Boom:
+            def nodes_in_file(self, file_path):  # noqa: ANN001, ANN201
+                raise RuntimeError("backend down")
+
+            def get_node(self, key):  # noqa: ANN001, ANN201
+                raise RuntimeError("backend down")
+
+        watcher = TestWatcher(repo="jarvis", node_resolver=_Boom())
+        f = _make_failure()
+        await watcher._enrich_failures([f], _TB_OUTPUT)  # must not raise
+        # frames still parse + record (in_repo) even though node mapping failed
+        assert f.traceback_evidence is not None
+        assert f.traceback_evidence["fault_node_keys"] == []


### PR DESCRIPTION
## Summary

**Repair Context Bridge — Slice 1** (the ADD's smallest, independently-shippable phase). Closes the structural blindspot's *input* gap: today a `TestFailure` carries a one-line `error_text` and no functional coordinates. This slice enriches the signal with the **failing call stack AST-mapped to Oracle node keys** — the prime fault coordinates that seed the Slice 2 blast-radius cone and the Slice 3 structural gate.

Also embeds the **operator-ratified behavioral rule** for the upcoming structural gate (resolves ADD §8 Q2).

## What changed

- **`governance/intent/repair_traceback.py`** (new, pure + fail-soft): parse pytest `--tb=short` FAILURES into per-test frames → correlate to the test id → innermost-span line→node AST map via an injectable `NodeResolver` (prod = the Oracle's `_graph._backend`, lazy + fail-soft) → deepest-first, de-duplicated `fault_node_keys`. Never raises; external (stdlib/site-packages) frames are recorded but never used as repair targets.
- **`governance/intent/test_watcher.py`**: additive `TestFailure.traceback_evidence`; async `_enrich_failures` offloads parse + sqlite mapping via `asyncio.to_thread` (**zero block on the sensor poll loop**); merged into `IntentSignal.evidence` in `process_failures`. Gated `JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED` (**default OFF → evidence byte-identical** to pre-bridge).
- **`docs/architecture/REPAIR_CONTEXT_BRIDGE_ADD.md`**: new **§3.1 Dynamic Graph Reachability Matrix** + §8 Q2 resolved + §1 implementation note. A severed call-chain is a structural regression **only when it flips a downstream component from reachable-from-a-live-entry-point to unreachable**; a chain severed only within a dead/orphaned subgraph is **authorized as valid structural pruning** (ACCEPT + non-blocking `structural_prune` telemetry). Entry-point roots (active test suites incl. the failing test, `__main__`/loop entries, live external callers) are **derived from the graph, never hardcoded** (§5). Reuses the shipped `descendants`/`find_call_chain` primitives over the cone-scoped what-if subgraph — no new traversal engine.

## Design discipline

- **Additive + fail-soft**: OFF is byte-identical; any enrichment error degrades to today's graph-blind signal.
- **Non-blocking**: graph I/O is offloaded off the sensor loop.
- **No duplication**: reuses the Oracle GraphBackend + lazy backend; mapper is the only new logic.
- **Leverages existing architecture**: enriches the existing signal schema, populates the existing L2 `repair_context` path (downstream slices).

## Test Plan

- [x] 32 new tests — mapper (parse order, innermost-span, external-frame skip, deepest-first fault keys, fail-soft on bad input/broken resolver, flag matrix) + watcher wiring (OFF byte-identical, ON enriches + merges, fail-soft).
- [x] `pytest tests/governance/intent/` → **174 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enriches test failure signals by parsing pytest tracebacks and mapping frames to Oracle node keys, so we emit precise fault coordinates for downstream repair. Also documents the Dynamic Reachability Matrix rule for severed chains.

- **New Features**
  - Added `governance/intent/repair_traceback.py`: parses `--tb=short` output, correlates to the failing test, and maps lines to nodes via an injectable `NodeResolver` (prod uses Oracle `_graph._backend`). Produces `traceback_frames` and deepest-first `fault_node_keys`; skips external frames; fail-soft.
  - Updated `governance/intent/test_watcher.py`: new `TestFailure.traceback_evidence`; async `_enrich_failures` via `asyncio.to_thread` (non-blocking) and merged into `IntentSignal.evidence`. Gated by `JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED` (default off, evidence remains byte-identical when off).
  - Spec update in `docs/architecture/REPAIR_CONTEXT_BRIDGE_ADD.md`: defines the Dynamic Reachability Matrix—reject only when a fix flips a component from reachable-from-live-entry to unreachable; dead-only severance is accepted with non-blocking `structural_prune` telemetry.
  - Tests: 32 new cases cover parsing, mapping, fail-soft behavior, and watcher wiring.

<sup>Written for commit b16deb03a1be8e57453a6db088b6772114edf99c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

