### PR TITLE
feat(repair-bridge): Slice 2 — Graph-Informed Cognitive Context (the steer)

### DIFF
--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -1799,6 +1799,12 @@ class RepairContext:
         last patch was applied. The model is asked to diff against this.
     current_candidate_file_path:
         Repo-relative path of the file being repaired.
+    dependency_cone:
+        Repair Context Bridge (Slice 2) — graph-derived dependency-cone boundary
+        clause (downstream dependents / upstream dependencies / causal call-chain
+        from the failing test) rendered for the REPAIR MODE prompt. ``None`` until
+        the bridge populates it (gated ``JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED``);
+        ``None`` leaves the repair prompt byte-identical to pre-bridge behavior.
     """
 
     iteration: int
@@ -1809,3 +1815,4 @@ class RepairContext:
     failure_summary: str
     current_candidate_content: str
     current_candidate_file_path: str
+    dependency_cone: Optional[str] = None

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -3482,6 +3482,12 @@ Rules:
             f"Fix ONLY the failing lines. Do not regenerate the whole file.\n"
             f"The diff must apply cleanly to the content shown above."
         )
+        # Repair Context Bridge (Slice 2) — additive graph-derived dependency-cone
+        # boundary clause. Present only when the bridge populated it (gated); when
+        # absent the repair block is byte-identical to pre-bridge behavior.
+        _cone = getattr(_rc, "dependency_cone", None)
+        if _cone:
+            _repair_block = f"{_repair_block}\n\n{_cone}"
         parts.append(_repair_block)
 
     parts.append(schema_instruction)

--- a/backend/core/ouroboros/governance/repair_context_bridge.py
+++ b/backend/core/ouroboros/governance/repair_context_bridge.py
@@ -1,0 +1,338 @@
+"""Repair Context Bridge — Slice 2: graph-informed cognitive context (the steer).
+
+L2's repair GENERATE has a ``repair_context`` slot but nothing populates it with graph topology, so
+the model fixes blind to what its patch could break. This bridge builds a **dependency cone** around
+the fault coordinates (downstream dependents, upstream dependencies, the causal call-chain from the
+failing test) using the shipped 16 GB-safe lazy GraphBackend, and renders it as an explicit boundary
+clause injected into ``RepairContext.dependency_cone``.
+
+Honest framing (ADD §2): a prompt clause **steers**, it does not enforce — the model *can* still
+wander outside the cone. This makes staying-in-cone the path of least resistance; the Slice 3
+structural gate is what actually enforces it.
+
+Design discipline:
+- **No duplication** — composes the Oracle's ``compute_blast_radius`` / ``get_dependencies`` /
+  ``find_call_chain`` primitives; the only new logic is cone assembly + rendering.
+- **Adaptive fault-key resolution** — prefers Slice 1's precise ``fault_node_keys`` (from the signal
+  evidence), then the file being repaired, then the failing tests. Works standalone *and* sharper
+  when Slice 1 is on. No hardcoded targets.
+- **Asynchronous** — the lazy graph query API is synchronous (load-bearing constraint), so the whole
+  cone build is offloaded via ``asyncio.to_thread`` — zero block on the L2 loop.
+- **Bounded** — caps are env-tunable (no hardcoding); memory rides the proven 7 MB lazy footprint.
+- **Fail-soft** — any error → ``None`` cone → L2 degrades to today's graph-blind repair.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
+
+from .intent.repair_traceback import bridge_enabled  # single master flag (no dup)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["RepairCone", "RepairContextBridge", "bridge_enabled"]
+
+
+def _cone_max_symbols() -> int:
+    """``JARVIS_REPAIR_CONE_MAX_SYMBOLS`` — top-K cap on dependents/dependencies/symbols by
+    proximity (token-budget discipline). Default 50 (ADD §8 Q1 starting guess)."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_REPAIR_CONE_MAX_SYMBOLS", "50")))
+    except ValueError:
+        return 50
+
+
+def _cone_blast_depth() -> int:
+    """``JARVIS_REPAIR_CONE_BLAST_DEPTH`` — blast-radius BFS depth for the cone. Default 2
+    (direct dependents + 1 hop), the ADD §8 Q1 lean."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_REPAIR_CONE_BLAST_DEPTH", "2")))
+    except ValueError:
+        return 2
+
+
+@dataclass
+class RepairCone:
+    """A structured, ordered node/edge set bounding a repair (NOT an embedding vector — see ADD §8
+    Q3). Ordered by proximity to the fault so truncation drops the least-relevant first."""
+
+    fault_keys: List[str] = field(default_factory=list)
+    files: List[str] = field(default_factory=list)
+    symbols: List[str] = field(default_factory=list)
+    call_chain: List[str] = field(default_factory=list)
+    dependents: List[str] = field(default_factory=list)     # downstream — what the fix could break
+    dependencies: List[str] = field(default_factory=list)   # upstream — what it relies on
+    risk_level: str = "unknown"
+    truncated: bool = False
+
+    def is_empty(self) -> bool:
+        return not (self.fault_keys or self.dependents or self.dependencies or self.call_chain)
+
+    def to_dict(self) -> dict:
+        return {
+            "fault_keys": list(self.fault_keys),
+            "files": list(self.files),
+            "symbols": list(self.symbols),
+            "call_chain": list(self.call_chain),
+            "dependents": list(self.dependents),
+            "dependencies": list(self.dependencies),
+            "risk_level": self.risk_level,
+            "truncated": self.truncated,
+        }
+
+
+class RepairContextBridge:
+    """Builds + renders the dependency cone for an L2 repair iteration.
+
+    Parameters
+    ----------
+    oracle_graph:
+        The Oracle's ``CodebaseKnowledgeGraph`` (exposes ``compute_blast_radius`` /
+        ``get_dependencies`` / ``find_call_chain`` / ``find_nodes_in_file`` / ``find_nodes_by_name``).
+        ``None`` → lazily fetched from the global Oracle (fail-soft). Tests inject a fake.
+    max_symbols / blast_depth:
+        Overrides for the env-tuned caps (tests pin them).
+    """
+
+    def __init__(
+        self,
+        oracle_graph: Optional[Any] = None,
+        max_symbols: Optional[int] = None,
+        blast_depth: Optional[int] = None,
+    ) -> None:
+        self._graph = oracle_graph
+        self._max_symbols = max_symbols
+        self._blast_depth = blast_depth
+
+    # ------------------------------------------------------------------ graph access
+    def _get_graph(self) -> Optional[Any]:
+        if self._graph is not None:
+            return self._graph
+        try:
+            from backend.core.ouroboros.oracle import get_oracle
+
+            g = getattr(get_oracle(), "_graph", None)
+            if g is not None and hasattr(g, "compute_blast_radius"):
+                self._graph = g
+                return g
+        except Exception as exc:  # noqa: BLE001 — graph is best-effort
+            logger.debug("[RepairBridge] oracle graph unavailable: %s", exc)
+        return None
+
+    # ------------------------------------------------------------------ fault keys
+    def resolve_fault_keys(
+        self,
+        evidence_json: str,
+        target_file: str,
+        failing_tests: Tuple[str, ...],
+        graph: Optional[Any] = None,
+    ) -> List[str]:
+        """Adaptive fault-key resolution (most-precise source wins, no hardcoding):
+        1. Slice 1's ``fault_node_keys`` from the signal evidence (function-level precision).
+        2. The file being repaired → its Oracle nodes (file-level — works without Slice 1).
+        3. The failing test functions → resolved by name (last-resort entry seed)."""
+        # 1) Slice 1 precise coordinates
+        keys = _parse_fault_keys(evidence_json)
+        if keys:
+            return keys
+        g = graph if graph is not None else self._get_graph()
+        if g is None:
+            return []
+        # 2) file-level nodes
+        if target_file:
+            try:
+                nodes = g.find_nodes_in_file(target_file)
+                if nodes:
+                    return [str(n) for n in nodes]
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[RepairBridge] find_nodes_in_file failed: %s", exc)
+        # 3) failing-test function names
+        out: List[str] = []
+        for tid in failing_tests:
+            name = tid.split("::")[-1].split("[")[0]
+            try:
+                for n in (g.find_nodes_by_name(name) or [])[:1]:
+                    out.append(str(n))
+            except Exception:  # noqa: BLE001
+                continue
+        return out
+
+    # ------------------------------------------------------------------ sync cone build
+    def _build_sync(
+        self,
+        evidence_json: str,
+        target_file: str,
+        failing_tests: Tuple[str, ...],
+    ) -> Optional[RepairCone]:
+        g = self._get_graph()
+        if g is None:
+            return None
+        fault_keys = self.resolve_fault_keys(evidence_json, target_file, failing_tests, graph=g)
+        if not fault_keys:
+            return None
+
+        cap = self._max_symbols if self._max_symbols is not None else _cone_max_symbols()
+        depth = self._blast_depth if self._blast_depth is not None else _cone_blast_depth()
+
+        files: List[str] = []
+        symbols: List[str] = []
+        dependents: List[str] = []
+        dependencies: List[str] = []
+        call_chain: List[str] = []
+        risk_rank = {"low": 1, "medium": 2, "high": 3, "critical": 4, "unknown": 0}
+        worst_risk = "unknown"
+        truncated = False
+
+        def _add(seq: List[str], val: str) -> None:
+            if val and val not in seq:
+                seq.append(val)
+
+        # Resolve failing-test entry nodes once (for call chains).
+        test_entries: List[str] = []
+        for tid in failing_tests[:5]:
+            name = tid.split("::")[-1].split("[")[0]
+            try:
+                for n in (g.find_nodes_by_name(name) or [])[:1]:
+                    _add(test_entries, str(n))
+            except Exception:  # noqa: BLE001
+                continue
+
+        for fkey in fault_keys[:3]:                       # bound the seed set
+            _add(symbols, _short_symbol(fkey))
+            _add(files, _file_of(fkey))
+            # downstream dependents (proximity-ordered: direct first) ────────
+            try:
+                blast = g.compute_blast_radius(fkey, max_depth=depth)
+                if risk_rank.get(getattr(blast, "risk_level", "unknown"), 0) > risk_rank.get(worst_risk, 0):
+                    worst_risk = getattr(blast, "risk_level", "unknown")
+                for n in sorted(getattr(blast, "directly_affected", set()) or set(), key=str):
+                    _add(dependents, str(n))
+                    _add(files, getattr(n, "file_path", "") or _file_of(str(n)))
+                for n in sorted(getattr(blast, "transitively_affected", set()) or set(), key=str):
+                    _add(dependents, str(n))
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[RepairBridge] blast_radius failed for %s: %s", fkey, exc)
+            # upstream dependencies ──────────────────────────────────────────
+            try:
+                for n in (g.get_dependencies(fkey) or []):
+                    _add(dependencies, str(n))
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[RepairBridge] get_dependencies failed for %s: %s", fkey, exc)
+            # causal call-chain test→fault ───────────────────────────────────
+            for entry in test_entries:
+                try:
+                    path = g.find_call_chain(entry, fkey)
+                    if path:
+                        _add(call_chain, " → ".join(str(p) for p in path))
+                except Exception:  # noqa: BLE001
+                    continue
+
+        # Top-K-by-proximity truncation (dependents are already proximity-ordered).
+        if len(dependents) > cap:
+            dependents, truncated = dependents[:cap], True
+        if len(dependencies) > cap:
+            dependencies, truncated = dependencies[:cap], True
+        if len(symbols) > cap:
+            symbols, truncated = symbols[:cap], True
+
+        cone = RepairCone(
+            fault_keys=fault_keys[:3],
+            files=files[:cap],
+            symbols=symbols,
+            call_chain=call_chain[:5],
+            dependents=dependents,
+            dependencies=dependencies,
+            risk_level=worst_risk,
+            truncated=truncated,
+        )
+        return None if cone.is_empty() else cone
+
+    # ------------------------------------------------------------------ async entry
+    async def build(
+        self,
+        *,
+        evidence_json: str = "",
+        target_file: str = "",
+        failing_tests: Tuple[str, ...] = (),
+    ) -> Optional[RepairCone]:
+        """Build the cone off-loop (the lazy graph query API is synchronous). Fail-soft → None."""
+        if not bridge_enabled():
+            return None
+        import asyncio
+
+        try:
+            return await asyncio.to_thread(
+                self._build_sync, evidence_json, target_file, tuple(failing_tests)
+            )
+        except Exception as exc:  # noqa: BLE001 — cone is advisory; never break L2
+            logger.debug("[RepairBridge] cone build failed (non-fatal): %s", exc)
+            return None
+
+    # ------------------------------------------------------------------ render
+    @staticmethod
+    def render_clause(cone: RepairCone) -> str:
+        """Render the cone as an explicit boundary clause for the repair prompt's REPAIR MODE.
+
+        Honest: this is a *boundary clause* (steer), not enforcement — Slice 3's structural gate is
+        what rejects out-of-cone structural damage."""
+        if cone is None or cone.is_empty():
+            return ""
+        lines: List[str] = [
+            "## DEPENDENCY CONE (graph-derived boundary — STAY INSIDE)",
+            f"Fault coordinates: {', '.join(cone.symbols[:8]) or '(file-level)'}",
+        ]
+        if cone.files:
+            lines.append(f"Files in scope (modify ONLY these): {', '.join(cone.files[:12])}")
+        if cone.dependents:
+            lines.append(
+                "Downstream dependents — these call/import the fault; your fix MUST NOT break "
+                f"their contract: {', '.join(cone.dependents[:20])}"
+            )
+        if cone.dependencies:
+            lines.append(
+                "Upstream dependencies the fix relies on (do not sever): "
+                f"{', '.join(cone.dependencies[:20])}"
+            )
+        if cone.call_chain:
+            lines.append("Causal path(s) from failing test → fault:")
+            lines.extend(f"  {c}" for c in cone.call_chain[:3])
+        suffix = " (cone truncated to top-K by proximity)" if cone.truncated else ""
+        lines.append(
+            f"Blast-radius risk={cone.risk_level}{suffix}. Keep the patch inside this cone; "
+            "changing structure outside it will be rejected by the structural gate."
+        )
+        return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- helpers
+def _parse_fault_keys(evidence_json: str) -> List[str]:
+    """Extract Slice 1's ``fault_node_keys`` from a serialized signal-evidence JSON. Fail-soft."""
+    if not evidence_json:
+        return []
+    try:
+        data = json.loads(evidence_json)
+    except Exception:  # noqa: BLE001
+        return []
+    if not isinstance(data, dict):
+        return []
+    keys = data.get("fault_node_keys")
+    if isinstance(keys, list):
+        return [str(k) for k in keys if k]
+    return []
+
+
+def _file_of(node_key: str) -> str:
+    """NodeID str is ``repo:file_path:name`` → the file_path segment (best-effort)."""
+    parts = node_key.split(":")
+    return parts[1] if len(parts) >= 3 else node_key
+
+
+def _short_symbol(node_key: str) -> str:
+    """NodeID str ``repo:file_path:name`` → ``file_path:name`` (drop the repo prefix for brevity)."""
+    parts = node_key.split(":")
+    if len(parts) >= 3:
+        return f"{parts[1]}:{parts[2]}"
+    return node_key

--- a/backend/core/ouroboros/governance/repair_engine.py
+++ b/backend/core/ouroboros/governance/repair_engine.py
@@ -363,11 +363,16 @@ class RepairEngine:
         repo_root: Any,
         sandbox_factory: Any = None,
         ledger: Any = None,
+        context_bridge: Any = None,
     ) -> None:
         self._budget = budget
         self._prime = prime_provider
         self._repo_root = repo_root
         self._ledger = ledger
+        # Repair Context Bridge (Slice 2): graph-derived dependency-cone steer.
+        # Injectable for tests; lazily built on first use otherwise. Only consulted
+        # when JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED is on (else inert / cone=None).
+        self._context_bridge = context_bridge
         if sandbox_factory is None:
             from backend.core.ouroboros.governance.repair_sandbox import RepairSandbox
             self._sandbox_factory = RepairSandbox
@@ -1024,6 +1029,12 @@ class RepairEngine:
             # BUILD REPAIR PROMPT (set repair_context for next iteration)
             # ----------------------------------------------------------------
             from backend.core.ouroboros.governance.op_context import RepairContext
+            # Repair Context Bridge (Slice 2): graph-derived dependency-cone steer
+            # for the NEXT iteration's GENERATE. Gated + fail-soft → None when off,
+            # leaving the repair prompt byte-identical to pre-bridge behavior.
+            _dependency_cone = await self._build_dependency_cone(
+                ctx, file_path, classification.failing_test_ids,
+            )
             repair_context = RepairContext(
                 iteration=iteration,
                 max_iterations=budget.max_iterations,
@@ -1033,6 +1044,7 @@ class RepairEngine:
                 failure_summary=(svr.stdout + svr.stderr)[:300],
                 current_candidate_content=sandbox_content,
                 current_candidate_file_path=file_path,
+                dependency_cone=_dependency_cone,
             )
 
             outcome = "progress" if is_progress else "no_progress"
@@ -1052,6 +1064,39 @@ class RepairEngine:
             )
             self._emit_record(ctx.op_id, rec)
             records.append(rec)
+
+    async def _build_dependency_cone(
+        self,
+        ctx: Any,
+        file_path: str,
+        failing_tests: Tuple[str, ...],
+    ) -> Optional[str]:
+        """Repair Context Bridge (Slice 2) — build + render the graph dependency cone.
+
+        Gated by ``JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED`` (the bridge's ``build`` self-gates and
+        returns ``None`` when off). Lazily instantiates the bridge, sources the fault coordinates
+        adaptively (Slice 1 ``fault_node_keys`` from ``ctx.intake_evidence_json`` → file → tests),
+        and offloads the lazy-graph cone build to a worker thread. Fail-soft: any error → ``None``,
+        leaving the repair prompt byte-identical to pre-bridge behavior."""
+        try:
+            if self._context_bridge is None:
+                from backend.core.ouroboros.governance.repair_context_bridge import (
+                    RepairContextBridge,
+                )
+                self._context_bridge = RepairContextBridge()
+            evidence_json = getattr(ctx, "intake_evidence_json", "") or ""
+            cone = await self._context_bridge.build(
+                evidence_json=evidence_json,
+                target_file=file_path,
+                failing_tests=tuple(failing_tests or ()),
+            )
+            if cone is None:
+                return None
+            clause = self._context_bridge.render_clause(cone)
+            return clause or None
+        except Exception as exc:  # noqa: BLE001 — cone is advisory; never break L2
+            _logger.debug("[RepairBridge] dependency cone unavailable (non-fatal): %s", exc)
+            return None
 
     async def _generate_repair_candidate(
         self,

--- a/docs/architecture/REPAIR_CONTEXT_BRIDGE_ADD.md
+++ b/docs/architecture/REPAIR_CONTEXT_BRIDGE_ADD.md
@@ -91,6 +91,22 @@ prompt is not immutable — only the gate is.
 already-proven 7 MB-vs-134 MB footprint) and reuses the `AdaptiveNodeCache` that contracts under
 `MemoryPressureGate` pressure.
 
+**Implemented (Slice 2):** `governance/repair_context_bridge.py` — `RepairCone` (structured,
+proximity-ordered node/edge set; *not* an embedding, per §8 Q3) + `RepairContextBridge`.
+**Adaptive fault-key resolution** (no hardcoding): Slice 1 `fault_node_keys` (from
+`ctx.intake_evidence_json`) → file being repaired (`find_nodes_in_file`) → failing-test functions
+(`find_nodes_by_name`) — sharper with Slice 1 on, still works standalone. Composes the shipped Oracle
+primitives `compute_blast_radius` (downstream dependents, proximity-ordered: direct then transitive),
+`get_dependencies` (upstream), `find_call_chain` (test→fault causal path) — **no new traversal**.
+`async build()` self-gates on the master flag and offloads the synchronous lazy-graph query path via
+`asyncio.to_thread` (zero block on the L2 loop). Caps env-tunable: `JARVIS_REPAIR_CONE_MAX_SYMBOLS`
+(default 50), `JARVIS_REPAIR_CONE_BLAST_DEPTH` (default 2); top-K-by-proximity truncation flagged in
+the clause. Injection: additive `RepairContext.dependency_cone` field (default `None` → prompt
+byte-identical); populated in `repair_engine._run_inner` via `_build_dependency_cone` (lazy
+bridge, fail-soft); rendered in `providers._build_codegen_prompt`'s REPAIR MODE block only when
+present. Gated `JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED` (shared master). 15 bridge tests + 112
+repair-engine regression green.
+
 ---
 
 ## 3. Phase 3 — Pre-Flight Structural Validation Gate (the Zero-Regression Shield)

--- a/tests/governance/test_repair_context_bridge.py
+++ b/tests/governance/test_repair_context_bridge.py
@@ -1,0 +1,218 @@
+"""Tests for the Repair Context Bridge — Slice 2 graph-informed cognitive context.
+
+Covers `repair_context_bridge.py`:
+1. Adaptive fault-key resolution (Slice-1 evidence > file > failing tests).
+2. Cone assembly composing blast-radius + dependencies + call-chain.
+3. Top-K-by-proximity truncation honors the env-tunable cap.
+4. render_clause emits the boundary clause with the right sections.
+5. Async build() self-gates on the master flag and offloads (to_thread).
+6. Fail-soft: a raising graph / no graph / no fault keys → None (never raises).
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from backend.core.ouroboros.governance.repair_context_bridge import (
+    RepairCone,
+    RepairContextBridge,
+    _file_of,
+    _parse_fault_keys,
+    _short_symbol,
+)
+
+
+# --------------------------------------------------------------------------- fakes
+class _Node:
+    def __init__(self, repo: str, file_path: str, name: str) -> None:
+        self.repo, self.file_path, self.name = repo, file_path, name
+
+    def __str__(self) -> str:
+        return f"{self.repo}:{self.file_path}:{self.name}"
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+    def __eq__(self, o: object) -> bool:
+        return str(self) == str(o)
+
+
+class _Blast:
+    def __init__(self, direct: List[_Node], trans: List[_Node], risk: str) -> None:
+        self.directly_affected = set(direct)
+        self.transitively_affected = set(trans)
+        self.risk_level = risk
+        self.broken_imports: List[Any] = []
+        self.broken_calls: List[Any] = []
+
+
+class _Graph:
+    """GraphBackend/CKG-shaped fake with the cone primitives."""
+
+    def __init__(
+        self,
+        blast: Optional[_Blast] = None,
+        deps: Optional[List[_Node]] = None,
+        chain: Optional[List[_Node]] = None,
+        file_nodes: Optional[Dict[str, List[_Node]]] = None,
+        name_nodes: Optional[Dict[str, List[_Node]]] = None,
+        raise_blast: bool = False,
+    ) -> None:
+        self._blast = blast
+        self._deps = deps or []
+        self._chain = chain
+        self._file_nodes = file_nodes or {}
+        self._name_nodes = name_nodes or {}
+        self._raise_blast = raise_blast
+
+    def compute_blast_radius(self, key: str, max_depth: int = 2) -> _Blast:
+        if self._raise_blast:
+            raise RuntimeError("graph down")
+        return self._blast or _Blast([], [], "low")
+
+    def get_dependencies(self, key: str) -> List[_Node]:
+        return list(self._deps)
+
+    def find_call_chain(self, src: str, tgt: str) -> Optional[List[_Node]]:
+        return self._chain
+
+    def find_nodes_in_file(self, path: str) -> List[_Node]:
+        return list(self._file_nodes.get(path, []))
+
+    def find_nodes_by_name(self, name: str) -> List[_Node]:
+        return list(self._name_nodes.get(name, []))
+
+
+_FAULT = "jarvis:src/calc.py:parse"
+_DEP_UP = _Node("jarvis", "src/util.py", "helper")
+_DEP_DOWN = _Node("jarvis", "src/app.py", "main")
+
+
+def _graph_full() -> _Graph:
+    return _Graph(
+        blast=_Blast(direct=[_DEP_DOWN], trans=[], risk="medium"),
+        deps=[_DEP_UP],
+        chain=[_Node("jarvis", "tests/test_calc.py", "test_parse"), _Node("jarvis", "src/calc.py", "parse")],
+        file_nodes={"src/calc.py": [_Node("jarvis", "src/calc.py", "parse")]},
+        name_nodes={"test_parse": [_Node("jarvis", "tests/test_calc.py", "test_parse")]},
+    )
+
+
+# --------------------------------------------------------------------------- helpers
+class TestHelpers:
+    def test_parse_fault_keys(self) -> None:
+        ev = '{"fault_node_keys": ["a:b:c", "d:e:f"], "x": 1}'
+        assert _parse_fault_keys(ev) == ["a:b:c", "d:e:f"]
+
+    def test_parse_fault_keys_empty(self) -> None:
+        assert _parse_fault_keys("") == []
+        assert _parse_fault_keys("not json") == []
+        assert _parse_fault_keys('{"other": 1}') == []
+
+    def test_file_and_symbol_extraction(self) -> None:
+        assert _file_of("jarvis:src/calc.py:parse") == "src/calc.py"
+        assert _short_symbol("jarvis:src/calc.py:parse") == "src/calc.py:parse"
+
+
+# --------------------------------------------------------------------------- resolution
+class TestFaultKeyResolution:
+    def test_evidence_wins(self) -> None:
+        b = RepairContextBridge(oracle_graph=_graph_full())
+        keys = b.resolve_fault_keys('{"fault_node_keys": ["x:y:z"]}', "src/calc.py", ())
+        assert keys == ["x:y:z"]
+
+    def test_falls_back_to_file(self) -> None:
+        b = RepairContextBridge(oracle_graph=_graph_full())
+        keys = b.resolve_fault_keys("", "src/calc.py", ())
+        assert keys == [_FAULT]
+
+    def test_falls_back_to_failing_tests(self) -> None:
+        b = RepairContextBridge(oracle_graph=_graph_full())
+        keys = b.resolve_fault_keys("", "", ("tests/test_calc.py::test_parse",))
+        assert keys == ["jarvis:tests/test_calc.py:test_parse"]
+
+
+# --------------------------------------------------------------------------- cone build
+class TestConeBuild:
+    def test_full_cone(self) -> None:
+        b = RepairContextBridge(oracle_graph=_graph_full())
+        cone = b._build_sync('{"fault_node_keys": ["%s"]}' % _FAULT, "src/calc.py",
+                             ("tests/test_calc.py::test_parse",))
+        assert cone is not None
+        assert _FAULT in cone.fault_keys
+        assert str(_DEP_DOWN) in cone.dependents
+        assert str(_DEP_UP) in cone.dependencies
+        assert cone.call_chain and "→" in cone.call_chain[0]
+        assert cone.risk_level == "medium"
+
+    def test_no_fault_keys_returns_none(self) -> None:
+        b = RepairContextBridge(oracle_graph=_Graph())  # empty graph, no file/name nodes
+        assert b._build_sync("", "", ()) is None
+
+    def test_truncation_respects_cap(self) -> None:
+        many = [_Node("jarvis", f"src/f{i}.py", f"sym{i}") for i in range(20)]
+        g = _Graph(blast=_Blast(direct=many, trans=[], risk="high"),
+                   file_nodes={"src/calc.py": [_Node("jarvis", "src/calc.py", "parse")]})
+        b = RepairContextBridge(oracle_graph=g, max_symbols=5)
+        cone = b._build_sync("", "src/calc.py", ())
+        assert cone is not None
+        assert len(cone.dependents) == 5
+        assert cone.truncated is True
+
+
+# --------------------------------------------------------------------------- render
+class TestRender:
+    def test_clause_sections(self) -> None:
+        b = RepairContextBridge(oracle_graph=_graph_full())
+        cone = b._build_sync('{"fault_node_keys": ["%s"]}' % _FAULT, "src/calc.py",
+                             ("tests/test_calc.py::test_parse",))
+        clause = RepairContextBridge.render_clause(cone)  # type: ignore[arg-type]
+        assert "DEPENDENCY CONE" in clause
+        assert "Downstream dependents" in clause
+        assert "Upstream dependencies" in clause
+        assert "structural gate" in clause  # honest steer-not-enforce note
+
+    def test_empty_cone_renders_empty(self) -> None:
+        assert RepairContextBridge.render_clause(RepairCone()) == ""
+
+
+# --------------------------------------------------------------------------- async gate
+class TestAsyncBuild:
+    @pytest.mark.asyncio
+    async def test_disabled_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", raising=False)
+        b = RepairContextBridge(oracle_graph=_graph_full())
+        cone = await b.build(evidence_json='{"fault_node_keys": ["%s"]}' % _FAULT,
+                             target_file="src/calc.py")
+        assert cone is None
+
+    @pytest.mark.asyncio
+    async def test_enabled_builds_cone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", "true")
+        b = RepairContextBridge(oracle_graph=_graph_full())
+        cone = await b.build(evidence_json='{"fault_node_keys": ["%s"]}' % _FAULT,
+                             target_file="src/calc.py",
+                             failing_tests=("tests/test_calc.py::test_parse",))
+        assert cone is not None
+        assert str(_DEP_DOWN) in cone.dependents
+
+    @pytest.mark.asyncio
+    async def test_failsoft_on_raising_graph(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", "true")
+        g = _Graph(raise_blast=True,
+                   file_nodes={"src/calc.py": [_Node("jarvis", "src/calc.py", "parse")]})
+        b = RepairContextBridge(oracle_graph=g)
+        # blast raises but is caught per-fault; deps/file still resolve → cone non-empty, no raise
+        cone = await b.build(evidence_json="", target_file="src/calc.py")
+        assert cone is not None
+        assert cone.dependents == []  # blast failed → no dependents, but fault_keys present
+
+    @pytest.mark.asyncio
+    async def test_no_graph_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED", "true")
+        b = RepairContextBridge(oracle_graph=None)
+        # _get_graph will try get_oracle(); in the test env that may succeed but have no nodes,
+        # or fail — either way must not raise and must return None when no fault keys resolve.
+        cone = await b.build(evidence_json="", target_file="does/not/exist.py")
+        assert cone is None


### PR DESCRIPTION
## Summary

**Repair Context Bridge — Slice 2.** L2's repair `GENERATE` has a `repair_context` slot but nothing populated it with graph topology — so the model fixed test failures **blind to what its patch could break**. This slice builds a **dependency cone** around the fault coordinates and injects it as an explicit boundary clause. This is the **steer** half of the bridge; Slice 3's structural gate is the **enforce** half (a prompt clause is advisory — stated plainly).

Builds directly on Slice 1: the precise `fault_node_keys` now flow `IntentSignal.evidence → ctx.intake_evidence_json →` the cone seed.

## What changed

- **`governance/repair_context_bridge.py`** (new): `RepairCone` (structured, proximity-ordered node/edge set — *not* an embedding, per ADD §8 Q3) + `RepairContextBridge`.
  - **Adaptive fault-key resolution** (no hardcoding): Slice 1 `fault_node_keys` → file being repaired (`find_nodes_in_file`) → failing-test functions (`find_nodes_by_name`). Sharper with Slice 1 on, **works standalone**.
  - **Composes shipped Oracle primitives** — `compute_blast_radius` (downstream dependents, direct-then-transitive), `get_dependencies` (upstream), `find_call_chain` (test→fault causal path). **No new traversal engine.**
  - **Asynchronous**: `async build()` self-gates on the master flag and offloads the synchronous lazy-graph query path via `asyncio.to_thread` — **zero block on the L2 loop**.
  - **Bounded**: caps env-tunable (`JARVIS_REPAIR_CONE_MAX_SYMBOLS`=50, `JARVIS_REPAIR_CONE_BLAST_DEPTH`=2); top-K-by-proximity truncation flagged in the clause. Rides the proven 7 MB lazy footprint.
  - **Fail-soft** throughout (any error → `None` cone → today's graph-blind repair).
- **`op_context.py`**: additive `RepairContext.dependency_cone` field (default `None` → prompt **byte-identical**).
- **`repair_engine.py`**: injectable `context_bridge`; `_build_dependency_cone` (lazy, fail-soft) populates the cone for the next iteration's `GENERATE`.
- **`providers.py`**: render the cone clause in the REPAIR MODE block **only when present**.

## Design discipline

- **No duplication** — reuses the Oracle GraphBackend + lazy backend; only new logic is cone assembly + rendering.
- **No hardcoding** — env-tunable caps; multi-source adaptive fault resolution; graph-derived, not table-driven.
- **Honest** — steer vs enforce stated in code + spec; structure not behavior (VERIFY stays authoritative).

## Test Plan

- [x] 15 new bridge tests — adaptive resolution priority, cone assembly (blast/deps/call-chain), cap-truncation, render-clause sections, async gate (off→None, on→cone), fail-soft (raising graph / no graph / no fault keys).
- [x] **112 repair-engine** regression tests green (init-signature + `_run_inner` wiring safe).
- [x] **200 intent + bridge** tests green; OFF path byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a graph‑informed Repair Context Bridge that builds a dependency cone around the fault to steer L2 fixes and reduce collateral breakage. The cone is injected into `RepairContext` and rendered in the REPAIR MODE prompt when enabled.

- **New Features**
  - New `governance/repair_context_bridge.py` with `RepairCone` and `RepairContextBridge`.
  - Builds the cone from the Oracle graph: `compute_blast_radius` (downstream), `get_dependencies` (upstream), `find_call_chain` (test→fault).
  - Adaptive seeds: Slice‑1 `fault_node_keys` → file nodes → failing test names.
  - Async and bounded: offloaded via `asyncio.to_thread`; caps `JARVIS_REPAIR_CONE_MAX_SYMBOLS` (default 50) and `JARVIS_REPAIR_CONE_BLAST_DEPTH` (default 2); fail‑soft.
  - Integrated wiring: `repair_engine` populates `RepairContext.dependency_cone`; `providers` appends the clause only when present; `RepairContext` gains the new field.

- **Migration**
  - Default OFF. Enable with `JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED=true`.
  - No prompt changes when OFF. Tune caps via `JARVIS_REPAIR_CONE_MAX_SYMBOLS` and `JARVIS_REPAIR_CONE_BLAST_DEPTH`.

<sup>Written for commit bf2b5ec11a78dfa4431733571978f0c0ae1f69a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

