### PR TITLE
feat(repair-bridge): Slice 3 — Sovereign Structural Validation Gate (the enforce / zero-regression shield)

### DIFF
--- a/backend/core/ouroboros/governance/repair_context_bridge.py
+++ b/backend/core/ouroboros/governance/repair_context_bridge.py
@@ -257,9 +257,13 @@ class RepairContextBridge:
         evidence_json: str = "",
         target_file: str = "",
         failing_tests: Tuple[str, ...] = (),
+        force: bool = False,
     ) -> Optional[RepairCone]:
-        """Build the cone off-loop (the lazy graph query API is synchronous). Fail-soft → None."""
-        if not bridge_enabled():
+        """Build the cone off-loop (the lazy graph query API is synchronous). Fail-soft → None.
+
+        ``force=True`` bypasses the steer-flag self-gate so the Slice 3 structural gate (which has its
+        own master flag) can obtain a cone even when the prompt-steer flag is off."""
+        if not force and not bridge_enabled():
             return None
         import asyncio
 

--- a/backend/core/ouroboros/governance/repair_engine.py
+++ b/backend/core/ouroboros/governance/repair_engine.py
@@ -670,6 +670,15 @@ class RepairEngine:
         # provider chain hard-stops only after N back-to-back timeouts
         # (default 2) instead of starving the whole timebox on iter 1.
         consecutive_provider_timeouts = 0
+        # Slice 3 — failing tests from the most recent classification, used as the
+        # structural gate's reachability roots. Empty on iter 1 (roots then derive
+        # from the cone's call-chain only — fewer false rejects, never more).
+        last_failing_tests: Tuple[str, ...] = ()
+        # Slice 3 — bound consecutive structural rejections so a model that cannot
+        # satisfy the gate can't monopolize the timebox; falls through to the sandbox
+        # after the cap (the gate is friction, not an absolute wall). Rides the
+        # overall max_iterations budget too (each reject consumes one iteration).
+        structural_reject_streak = 0
         t_start = time.monotonic()
         records: list = []
         model_id: str = getattr(ctx.generation, "model_id", "")
@@ -819,11 +828,86 @@ class RepairEngine:
             elif not _has_full_content:
                 return _stopped("candidate_unusable:no_diff_or_full_content")
 
+            file_path = current_candidate.get("file_path", "")
+
+            # ----------------------------------------------------------------
+            # Slice 3 — PRE-FLIGHT STRUCTURAL VALIDATION GATE (the enforce).
+            # Runs BEFORE the sandbox so a structural regression (new cycle /
+            # severed live reachability / broken interface contract) is caught and
+            # fed back as a targeted DivergenceSignature WITHOUT burning a test run.
+            # Gated (JARVIS_REPAIR_STRUCTURAL_GATE_ENABLED) + fail-soft → None = OFF.
+            # ----------------------------------------------------------------
+            _struct_verdict = await self._structural_validate(
+                ctx, file_path, full_content, diff, last_failing_tests,
+            )
+            if _struct_verdict is not None and not _struct_verdict.accepted:
+                structural_reject_streak += 1
+                _max_struct_rejects = int(
+                    os.environ.get("JARVIS_REPAIR_STRUCTURAL_MAX_REJECTS", "3")
+                )
+                _logger.info(
+                    "\U0001f6e1️ [L2 Repair] Iteration %d: structural gate REJECT "
+                    "(streak=%d/%d) — %s",
+                    iteration, structural_reject_streak, _max_struct_rejects,
+                    _struct_verdict.telemetry(),
+                )
+                if structural_reject_streak <= _max_struct_rejects:
+                    # Route the structured divergence feedback into the NEXT
+                    # generation as a mathematically targeted correction phase.
+                    from backend.core.ouroboros.governance.op_context import RepairContext
+                    _struct_feedback = _struct_verdict.feedback()
+                    _struct_sig = next(
+                        (d.signature_hash for d in _struct_verdict.blocking()), ""
+                    )
+                    repair_context = RepairContext(
+                        iteration=iteration,
+                        max_iterations=budget.max_iterations,
+                        failure_class="structural",
+                        failure_signature_hash=_struct_sig,
+                        failing_tests=last_failing_tests,
+                        failure_summary=_struct_feedback[:600],
+                        current_candidate_content=full_content,
+                        current_candidate_file_path=file_path,
+                        dependency_cone=_struct_feedback,
+                    )
+                    rec = RepairIterationRecord(
+                        op_id=ctx.op_id,
+                        iteration=iteration,
+                        repair_state=L2State.L2_BUILD_REPAIR_PROMPT.value,
+                        failure_class="structural",
+                        failure_signature_hash=_struct_sig,
+                        patch_signature_hash=_patch_sig(diff or full_content),
+                        diff_lines=0,
+                        files_changed=1,
+                        validation_duration_s=0.0,
+                        outcome="structural_reject",
+                        model_id=model_id,
+                        provider_name=provider_name,
+                    )
+                    self._emit_record(ctx.op_id, rec)
+                    records.append(rec)
+                    continue  # regenerate with targeted structural feedback
+                # Cap reached: stop blocking, fall through to the sandbox (friction,
+                # not an absolute wall) so a genuine fix still gets a behavioral run.
+                _logger.info(
+                    "[L2 Repair] structural reject cap reached (%d) — proceeding to sandbox",
+                    _max_struct_rejects,
+                )
+            elif _struct_verdict is not None and _struct_verdict.prunes:
+                # Authorized dead-only severance — non-blocking cleanup telemetry (§3.1).
+                _logger.info(
+                    "\U0001f9f9 [L2 Repair] structural prune authorized: %d dead-only edge(s)",
+                    len(_struct_verdict.prunes),
+                )
+
+            # Proceeding to the sandbox → reset the consecutive-structural-reject
+            # streak (it tracks back-to-back gate blocks, not lifetime rejects).
+            structural_reject_streak = 0
+
             # ----------------------------------------------------------------
             # RUN in sandbox
             # ----------------------------------------------------------------
             total_validation_runs += 1
-            file_path = current_candidate.get("file_path", "")
             sandbox_content = ""
             _patch_failed = False
             try:
@@ -945,6 +1029,9 @@ class RepairEngine:
             # CLASSIFY FAILURE
             # ----------------------------------------------------------------
             classification = self._classifier.classify(svr)
+            # Slice 3 — refresh the structural gate's reachability roots from the
+            # latest failing tests (used on the NEXT iteration's pre-flight check).
+            last_failing_tests = tuple(classification.failing_test_ids or ())
             # ── Slice 4A — L2-local hard-stop subtype narrowing ──
             # Closes the bt-2026-05-25-091657 L2-after-1-iter trap:
             # the failure_classifier flags ``missing_dependency`` and
@@ -1065,37 +1152,104 @@ class RepairEngine:
             self._emit_record(ctx.op_id, rec)
             records.append(rec)
 
+    def _ensure_context_bridge(self) -> Any:
+        """Lazily instantiate the shared RepairContextBridge (Slices 2+3 reuse one instance)."""
+        if self._context_bridge is None:
+            from backend.core.ouroboros.governance.repair_context_bridge import (
+                RepairContextBridge,
+            )
+            self._context_bridge = RepairContextBridge()
+        return self._context_bridge
+
+    async def _build_cone_object(
+        self,
+        ctx: Any,
+        file_path: str,
+        failing_tests: Tuple[str, ...],
+        *,
+        force: bool = False,
+    ) -> Any:
+        """Build the dependency-cone OBJECT (shared by Slice 2 render + Slice 3 gate). ``force``
+        bypasses the steer-flag self-gate so the structural gate gets a cone under its own flag.
+        Fail-soft → ``None``."""
+        try:
+            bridge = self._ensure_context_bridge()
+            evidence_json = getattr(ctx, "intake_evidence_json", "") or ""
+            return await bridge.build(
+                evidence_json=evidence_json,
+                target_file=file_path,
+                failing_tests=tuple(failing_tests or ()),
+                force=force,
+            )
+        except Exception as exc:  # noqa: BLE001 — cone is advisory; never break L2
+            _logger.debug("[RepairBridge] cone object unavailable (non-fatal): %s", exc)
+            return None
+
     async def _build_dependency_cone(
         self,
         ctx: Any,
         file_path: str,
         failing_tests: Tuple[str, ...],
     ) -> Optional[str]:
-        """Repair Context Bridge (Slice 2) — build + render the graph dependency cone.
+        """Repair Context Bridge (Slice 2) — build + render the graph dependency-cone clause.
 
-        Gated by ``JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED`` (the bridge's ``build`` self-gates and
-        returns ``None`` when off). Lazily instantiates the bridge, sources the fault coordinates
-        adaptively (Slice 1 ``fault_node_keys`` from ``ctx.intake_evidence_json`` → file → tests),
-        and offloads the lazy-graph cone build to a worker thread. Fail-soft: any error → ``None``,
-        leaving the repair prompt byte-identical to pre-bridge behavior."""
+        Gated by ``JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED`` (the bridge self-gates → ``None`` when off).
+        Fail-soft: any error → ``None``, leaving the repair prompt byte-identical to pre-bridge."""
         try:
-            if self._context_bridge is None:
-                from backend.core.ouroboros.governance.repair_context_bridge import (
-                    RepairContextBridge,
-                )
-                self._context_bridge = RepairContextBridge()
-            evidence_json = getattr(ctx, "intake_evidence_json", "") or ""
-            cone = await self._context_bridge.build(
-                evidence_json=evidence_json,
-                target_file=file_path,
-                failing_tests=tuple(failing_tests or ()),
-            )
+            cone = await self._build_cone_object(ctx, file_path, failing_tests)
             if cone is None:
                 return None
-            clause = self._context_bridge.render_clause(cone)
+            clause = self._ensure_context_bridge().render_clause(cone)
             return clause or None
         except Exception as exc:  # noqa: BLE001 — cone is advisory; never break L2
             _logger.debug("[RepairBridge] dependency cone unavailable (non-fatal): %s", exc)
+            return None
+
+    async def _structural_validate(
+        self,
+        ctx: Any,
+        file_path: str,
+        full_content: str,
+        diff: str,
+        failing_tests: Tuple[str, ...],
+    ) -> Any:
+        """Repair Context Bridge (Slice 3) — pre-flight structural validation gate.
+
+        Returns a ``StructuralVerdict`` (``None`` when the gate is off / unavailable). Builds the
+        isolated cone-scoped what-if delta and runs the three structural proofs. Fail-soft: any error
+        → ``None`` (caller proceeds as today). The candidate is parsed off-process (Blindspot Armor);
+        the live ``SqliteLazyGraphBackend`` is only ever read, never written."""
+        try:
+            from backend.core.ouroboros.governance.structural_validation_gate import (
+                StructuralValidationGate,
+                OracleConeReader,
+                gate_enabled,
+            )
+            if not gate_enabled():
+                return None
+            if not full_content or not file_path:
+                return None  # diff-only / no full source → cannot simulate (fail-soft ACCEPT)
+            cone = await self._build_cone_object(ctx, file_path, failing_tests, force=True)
+            if cone is None:
+                return None
+            from backend.core.ouroboros.oracle import get_oracle
+
+            graph = getattr(get_oracle(), "_graph", None)
+            if graph is None:
+                return None
+            reader = OracleConeReader(graph, cone, tuple(failing_tests or ()))
+            repo_name = getattr(ctx, "primary_repo", "") or ""
+            gate = StructuralValidationGate()
+            verdict = await gate.validate(
+                candidate_source=full_content,
+                candidate_diff=diff,
+                file_path=file_path,
+                repo_name=repo_name,
+                reader=reader,
+            )
+            return verdict
+        except Exception as exc:  # noqa: BLE001 — gate must never break L2
+            _logger.debug("[StructuralGate] validate unavailable (non-fatal, ACCEPT): %s", exc)
             return None
 
     async def _generate_repair_candidate(

--- a/backend/core/ouroboros/governance/structural_validation_gate.py
+++ b/backend/core/ouroboros/governance/structural_validation_gate.py
@@ -1,0 +1,489 @@
+"""Repair Context Bridge — Slice 3: the Sovereign Structural Validation Gate (the enforce).
+
+The zero-regression shield. Slice 2 *steers* the model into the dependency cone; this gate *enforces*
+that a candidate patch does not introduce a structural regression the failing test won't catch — a new
+import/call cycle, a severed live execution path, or a broken intra-file interface contract — **before**
+the candidate is flushed to the sandbox or signed by AutoCommitter.
+
+Three deterministic, zero-LLM proofs run on an **isolated transactional delta** of the candidate:
+
+1. **Acyclicity Guard** (hard) — a dependency cycle present in the post-delta cone but absent pre-delta.
+2. **Path Reachability Matrix** (§3.1) — a modification that flips a downstream component from
+   reachable-from-a-live-root (active test / entry script) to unreachable. Dead-only severance is
+   authorized as valid structural pruning (ACCEPT + non-blocking telemetry), never a false reject.
+3. **Boundary Invariant Verification** (soft) — a changed intra-file symbol signature whose un-modified
+   in-cone callers would no longer type/arity-match.
+
+**Blindspot Armor (isolation + thread-safety):** the candidate is parsed off-process via
+``analyze_python_source_for_oracle`` (its own interpreter — never touches the live backend). The
+what-if graph is a *local* ``_DeltaGraph`` built per-invocation from a read-only cone snapshot; it is
+never written back to the ``SqliteLazyGraphBackend``. Concurrent repair iterations therefore cannot
+pollute each other's simulation or contend on a shared mutable graph.
+
+**Feedback (Phase 3):** a violation does not throw — it compiles a structured ``DivergenceSignature``
+with the exact AST coordinates (the closed loop / the severed edge path / the symbol + old→new
+signature), hashed via ``failure_classifier.patch_signature_hash``, and routes it back into the L2
+iterate-feedback loop so the next generation is a mathematically targeted correction.
+
+Gated ``JARVIS_REPAIR_STRUCTURAL_GATE_ENABLED`` (default OFF → L2 byte-identical). Fail-soft: any
+error → ACCEPT (the immune system is never *weakened* by the thing meant to strengthen it).
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DivergenceSignature",
+    "StructuralPrune",
+    "StructuralVerdict",
+    "ConeReader",
+    "StructuralValidationGate",
+    "gate_enabled",
+]
+
+_HARD = "hard"
+_SOFT = "soft"
+
+
+# --------------------------------------------------------------------------- flags
+def gate_enabled() -> bool:
+    """``JARVIS_REPAIR_STRUCTURAL_GATE_ENABLED`` (default OFF) — master for the structural gate."""
+    return os.environ.get("JARVIS_REPAIR_STRUCTURAL_GATE_ENABLED", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _severity(env_name: str, default: str) -> str:
+    """Per-check severity knob (soft→hard graduation discipline). ``hard`` blocks + feeds back;
+    ``soft`` records + feeds back as advisory but does not block on its own."""
+    val = os.environ.get(env_name, "").strip().lower()
+    return val if val in (_HARD, _SOFT) else default
+
+
+def _soft_blocks() -> bool:
+    """``JARVIS_REPAIR_STRUCTURAL_SOFT_BLOCKS`` — when on, soft divergences also block (post-soak)."""
+    return os.environ.get("JARVIS_REPAIR_STRUCTURAL_SOFT_BLOCKS", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+# --------------------------------------------------------------------------- payloads
+@dataclass
+class DivergenceSignature:
+    """Structured, AST-coordinate-precise description of a structural violation (Phase 3)."""
+
+    kind: str                                  # new_cycle | severed_reachability | boundary_signature_mismatch
+    severity: str                              # hard | soft
+    detail: str
+    coordinates: Dict[str, Any] = field(default_factory=dict)
+    signature_hash: str = ""
+
+    def to_feedback(self) -> str:
+        """Render targeted correction guidance for the next L2 generation step."""
+        head = f"[STRUCTURAL VIOLATION: {self.kind} ({self.severity})] {self.detail}"
+        coord = self.coordinates or {}
+        if self.kind == "new_cycle":
+            loop = " → ".join(coord.get("cycle", []))
+            return (
+                f"{head}\nYour patch closes a dependency cycle: {loop}.\n"
+                "Break this loop — remove or invert one edge in the cycle so the graph stays acyclic."
+            )
+        if self.kind == "severed_reachability":
+            path = " → ".join(coord.get("broken_path", []))
+            lost = ", ".join(coord.get("unreachable", []))
+            return (
+                f"{head}\nYour patch severs the only live execution path to: {lost}.\n"
+                f"Broken route (was reachable from {coord.get('root', 'a live root')}): {path}.\n"
+                "Preserve a call/import edge that keeps these components reachable, or move their "
+                "logic so the active test path still reaches them."
+            )
+        if self.kind == "boundary_signature_mismatch":
+            return (
+                f"{head}\nSymbol `{coord.get('symbol', '?')}` changed signature "
+                f"`{coord.get('old_signature', '?')}` → `{coord.get('new_signature', '?')}`, "
+                f"but in-cone callers still use the old contract: "
+                f"{', '.join(coord.get('callers', []))}.\n"
+                "Either keep the signature backward-compatible or update every caller in the same patch."
+            )
+        return head
+
+
+@dataclass
+class StructuralPrune:
+    """An authorized severance of dead/orphaned-only structure (telemetry, never blocks). §3.1."""
+
+    severed_edge: Tuple[str, str]
+    reason: str = "dead_only_subgraph"
+
+
+@dataclass
+class StructuralVerdict:
+    accepted: bool
+    divergences: Tuple[DivergenceSignature, ...] = ()
+    prunes: Tuple[StructuralPrune, ...] = ()
+    analyzed: bool = True                       # False → could not simulate (fail-soft ACCEPT)
+    note: str = ""
+
+    def blocking(self) -> Tuple[DivergenceSignature, ...]:
+        soft_blocks = _soft_blocks()
+        return tuple(d for d in self.divergences if d.severity == _HARD or soft_blocks)
+
+    def feedback(self) -> str:
+        """Concatenated targeted feedback for every divergence (Phase 3 routing payload)."""
+        return "\n\n".join(d.to_feedback() for d in self.divergences)
+
+    def telemetry(self) -> str:
+        kinds = ",".join(sorted({d.kind for d in self.divergences})) or "none"
+        return (
+            f"[StructuralGate] accepted={self.accepted} analyzed={self.analyzed} "
+            f"divergences={len(self.divergences)} kinds={kinds} prunes={len(self.prunes)}"
+        )
+
+
+# --------------------------------------------------------------------------- cone reader
+class ConeReader(Protocol):
+    """Read-only snapshot of the pre-fix cone structure. Production impl wraps the Oracle backend;
+    tests inject a fake. NEVER mutates the backend."""
+
+    def cone_edges(self) -> List[Tuple[str, str, str]]: ...   # (src_key, dst_key, edge_type)
+    def node_signature(self, key: str) -> Optional[str]: ...
+    def roots(self) -> List[str]: ...                          # entry-point reachability roots
+
+
+# --------------------------------------------------------------------------- isolated delta graph
+class _DeltaGraph:
+    """An isolated, in-memory directed graph for what-if simulation. Local to a single gate call —
+    no shared state, thread-safe by construction (the Blindspot Armor)."""
+
+    def __init__(self) -> None:
+        self._adj: Dict[str, Set[str]] = {}
+        self._nodes: Set[str] = set()
+
+    def add_edge(self, src: str, dst: str) -> None:
+        self._nodes.add(src)
+        self._nodes.add(dst)
+        self._adj.setdefault(src, set()).add(dst)
+
+    def successors(self, key: str) -> Set[str]:
+        return self._adj.get(key, set())
+
+    def reachable(self, roots: List[str]) -> Set[str]:
+        """BFS reachability closure from the root set."""
+        seen: Set[str] = set()
+        frontier = [r for r in roots if r in self._nodes]
+        while frontier:
+            n = frontier.pop()
+            if n in seen:
+                continue
+            seen.add(n)
+            frontier.extend(self._adj.get(n, set()) - seen)
+        return seen
+
+    def cycles(self) -> List[List[str]]:
+        """Return non-trivial cycles (DFS-based; the cone is small). Each cycle is a node list."""
+        WHITE, GREY, BLACK = 0, 1, 2
+        color: Dict[str, int] = {n: WHITE for n in self._nodes}
+        stack: List[str] = []
+        found: List[List[str]] = []
+        seen_keys: Set[frozenset] = set()
+
+        def _dfs(u: str) -> None:
+            color[u] = GREY
+            stack.append(u)
+            for v in self._adj.get(u, set()):
+                if color.get(v, WHITE) == GREY and v in stack:        # back-edge → cycle
+                    cyc = stack[stack.index(v):]
+                    key = frozenset(cyc)
+                    if len(cyc) > 1 and key not in seen_keys:
+                        seen_keys.add(key)
+                        found.append(list(cyc))
+                elif color.get(v, WHITE) == WHITE:
+                    _dfs(v)
+            stack.pop()
+            color[u] = BLACK
+
+        for node in list(self._nodes):
+            if color.get(node, WHITE) == WHITE:
+                _dfs(node)
+        return found
+
+
+# --------------------------------------------------------------------------- gate
+class StructuralValidationGate:
+    """Deterministic pre-flight structural delta validator. Composes the existing Oracle parser +
+    graph primitives; the only new logic is the isolated delta + the three proofs + the structured
+    feedback compiler.
+
+    Parameters
+    ----------
+    analyzer:
+        Async ``analyze_python_source_for_oracle``-shaped callable (injectable for tests). Default
+        resolves the real off-process analyzer.
+    """
+
+    def __init__(self, analyzer: Optional[Any] = None) -> None:
+        self._analyzer = analyzer
+
+    # ------------------------------------------------------------------ analyze
+    async def _analyze_candidate(
+        self, candidate_source: str, file_path: str, repo_name: str,
+    ) -> Optional[Tuple[List[Tuple[str, str, str]], Dict[str, Optional[str]]]]:
+        """Off-process parse of the candidate → ``(edge list, {node_key: signature})``. None on any
+        non-OK outcome (fail-soft → caller ACCEPTs). Never touches the live backend (its own
+        interpreter via the process pool — the Blindspot Armor)."""
+        analyzer = self._analyzer
+        if analyzer is None:
+            from backend.core.ouroboros.governance.ast_compile_helper import (
+                analyze_python_source_for_oracle,
+            )
+            analyzer = analyze_python_source_for_oracle
+        try:
+            result = await analyzer(
+                "structural_validation_gate.validate",
+                candidate_source,
+                filename=file_path or "<candidate>",
+                repo_name=repo_name,
+                relative_path=file_path,
+            )
+        except Exception as exc:  # noqa: BLE001 — analysis is best-effort
+            logger.debug("[StructuralGate] candidate analyze failed: %s", exc)
+            return None
+        if getattr(result, "outcome", None) is None or str(getattr(result.outcome, "value", result.outcome)) != "ok":
+            return None
+        edges: List[Tuple[str, str, str]] = []
+        for e in getattr(result, "edges", ()) or ():
+            try:
+                src, dst, data = e
+                etype = getattr(getattr(data, "edge_type", None), "value", "") or ""
+                edges.append((str(src), str(dst), str(etype)))
+            except Exception:  # noqa: BLE001 — skip malformed edge tuples
+                continue
+        sigs: Dict[str, Optional[str]] = {}
+        for nd in getattr(result, "nodes", ()) or ():
+            try:
+                nid = getattr(nd, "node_id", None)
+                if nid is not None:
+                    sigs[str(nid)] = getattr(nd, "signature", None)
+            except Exception:  # noqa: BLE001
+                continue
+        return edges, sigs
+
+    # ------------------------------------------------------------------ delta build
+    @staticmethod
+    def _build_delta(
+        pre_edges: List[Tuple[str, str, str]],
+        new_file_edges: List[Tuple[str, str, str]],
+        file_path: str,
+    ) -> Tuple["_DeltaGraph", "_DeltaGraph", List[Tuple[str, str]]]:
+        """Construct the isolated pre-delta and post-delta graphs + the list of edges the patch
+        removes. The patch replaces *all* edges originating in the changed file."""
+        def _file_of(key: str) -> str:
+            parts = key.split(":")
+            return parts[1] if len(parts) >= 3 else key
+
+        pre = _DeltaGraph()
+        post = _DeltaGraph()
+        removed: List[Tuple[str, str]] = []
+        for src, dst, _t in pre_edges:
+            pre.add_edge(src, dst)
+            if _file_of(src) == file_path:        # edge owned by the changed file → dropped by patch
+                removed.append((src, dst))
+            else:
+                post.add_edge(src, dst)
+        for src, dst, _t in new_file_edges:       # candidate's replacement edges for the file
+            post.add_edge(src, dst)
+        return pre, post, removed
+
+    # ------------------------------------------------------------------ proofs
+    @staticmethod
+    def _check_acyclicity(
+        pre: "_DeltaGraph", post: "_DeltaGraph",
+    ) -> List[DivergenceSignature]:
+        pre_cycles = {frozenset(c) for c in pre.cycles()}
+        out: List[DivergenceSignature] = []
+        for cyc in post.cycles():
+            if frozenset(cyc) not in pre_cycles:        # cycle absent pre-fix → introduced
+                out.append(DivergenceSignature(
+                    kind="new_cycle",
+                    severity=_severity("JARVIS_REPAIR_STRUCT_CYCLE_SEVERITY", _HARD),
+                    detail="patch introduces a dependency cycle absent before the fix",
+                    coordinates={"cycle": list(cyc)},
+                ))
+        return out
+
+    @staticmethod
+    def _check_reachability(
+        pre: "_DeltaGraph", post: "_DeltaGraph", roots: List[str],
+        removed: List[Tuple[str, str]],
+    ) -> Tuple[List[DivergenceSignature], List[StructuralPrune]]:
+        """§3.1 Dynamic Reachability Matrix: REJECT iff a node flips reachable-from-root → unreachable.
+        Severance of already-dead structure → authorized prune (telemetry, non-blocking)."""
+        if not roots:
+            return [], []
+        reach_pre = pre.reachable(roots)
+        reach_post = post.reachable(roots)
+        severed = reach_pre - reach_post              # lost live reachability — the regression set
+        divergences: List[DivergenceSignature] = []
+        prunes: List[StructuralPrune] = []
+        if severed:
+            divergences.append(DivergenceSignature(
+                kind="severed_reachability",
+                severity=_severity("JARVIS_REPAIR_STRUCT_REACH_SEVERITY", _HARD),
+                detail=f"patch makes {len(severed)} live component(s) unreachable from a system root",
+                coordinates={
+                    "root": next((r for r in roots if r in reach_pre), roots[0]),
+                    "unreachable": sorted(severed),
+                    "broken_path": [e for pair in removed for e in pair if e in severed][:6],
+                },
+            ))
+        # Pruning telemetry: removed edges whose endpoint was already dead pre-fix.
+        for src, dst in removed:
+            if dst not in reach_pre and dst not in reach_post:
+                prunes.append(StructuralPrune(severed_edge=(src, dst)))
+        return divergences, prunes
+
+    @staticmethod
+    def _check_boundary(
+        candidate_signatures: Dict[str, Optional[str]],
+        reader: ConeReader,
+        pre_edges: List[Tuple[str, str, str]],
+    ) -> List[DivergenceSignature]:
+        """Intra-file interface contract: a changed symbol signature whose in-cone callers
+        (incoming CALLS edges) still rely on the old contract."""
+        out: List[DivergenceSignature] = []
+        for sym_key, new_sig in candidate_signatures.items():
+            old_sig = reader.node_signature(sym_key)
+            if old_sig is None or new_sig is None or old_sig == new_sig:
+                continue
+            callers = sorted({
+                src for src, dst, etype in pre_edges
+                if dst == sym_key and etype in ("calls", "imports", "imports_from")
+            })
+            if callers:
+                out.append(DivergenceSignature(
+                    kind="boundary_signature_mismatch",
+                    severity=_severity("JARVIS_REPAIR_STRUCT_BOUNDARY_SEVERITY", _SOFT),
+                    detail="changed symbol signature with un-updated in-cone callers",
+                    coordinates={
+                        "symbol": sym_key,
+                        "old_signature": old_sig,
+                        "new_signature": new_sig,
+                        "callers": callers[:10],
+                    },
+                ))
+        return out
+
+    # ------------------------------------------------------------------ public
+    async def validate(
+        self,
+        *,
+        candidate_source: str,
+        candidate_diff: str = "",
+        file_path: str,
+        repo_name: str,
+        reader: ConeReader,
+        candidate_signatures: Optional[Dict[str, Optional[str]]] = None,
+    ) -> StructuralVerdict:
+        """Run the isolated delta simulation + three proofs. ACCEPT/REJECT verdict + structured
+        feedback. Self-gates on ``gate_enabled()``; fail-soft → ACCEPT on any inability to simulate."""
+        if not gate_enabled():
+            return StructuralVerdict(accepted=True, analyzed=False, note="gate_disabled")
+        if not candidate_source or not file_path:
+            return StructuralVerdict(accepted=True, analyzed=False, note="no_full_source")
+        try:
+            analyzed = await self._analyze_candidate(candidate_source, file_path, repo_name)
+            if analyzed is None:
+                return StructuralVerdict(accepted=True, analyzed=False, note="analyze_unavailable")
+            new_file_edges, analyzed_sigs = analyzed
+            sigs = candidate_signatures if candidate_signatures is not None else analyzed_sigs
+            pre_edges = list(reader.cone_edges() or [])
+            pre, post, removed = self._build_delta(pre_edges, new_file_edges, file_path)
+
+            divergences: List[DivergenceSignature] = []
+            prunes: List[StructuralPrune] = []
+            divergences += self._check_acyclicity(pre, post)
+            reach_div, reach_prunes = self._check_reachability(pre, post, reader.roots(), removed)
+            divergences += reach_div
+            prunes += reach_prunes
+            if sigs:
+                divergences += self._check_boundary(sigs, reader, pre_edges)
+
+            # Hash each divergence by the candidate diff + its kind/coords for a stable signature.
+            from backend.core.ouroboros.governance.failure_classifier import patch_signature_hash
+            for d in divergences:
+                d.signature_hash = patch_signature_hash(
+                    f"{candidate_diff or candidate_source}\n{d.kind}\n{sorted(d.coordinates.items()) if d.coordinates else ''}"
+                )
+
+            verdict = StructuralVerdict(
+                accepted=True, divergences=tuple(divergences), prunes=tuple(prunes), analyzed=True,
+            )
+            verdict.accepted = not verdict.blocking()
+            return verdict
+        except Exception as exc:  # noqa: BLE001 — gate must never break L2
+            logger.debug("[StructuralGate] validate failed (non-fatal, ACCEPT): %s", exc)
+            return StructuralVerdict(accepted=True, analyzed=False, note=f"error:{type(exc).__name__}")
+
+
+# --------------------------------------------------------------------------- production cone reader
+class OracleConeReader:
+    """Read-only cone snapshot backed by the Oracle CKG. Reads cone-scoped edges + signatures +
+    derives reachability roots from the graph (active tests / call-chain sources) — never mutates."""
+
+    def __init__(self, graph: Any, cone: Any, failing_tests: Tuple[str, ...] = ()) -> None:
+        self._g = graph
+        self._cone = cone
+        self._failing_tests = failing_tests
+
+    def _cone_keys(self) -> List[str]:
+        c = self._cone
+        keys: List[str] = []
+        for attr in ("fault_keys", "dependents", "dependencies"):
+            keys.extend(getattr(c, attr, []) or [])
+        return list(dict.fromkeys(keys))
+
+    def cone_edges(self) -> List[Tuple[str, str, str]]:
+        edges: List[Tuple[str, str, str]] = []
+        seen: Set[Tuple[str, str, str]] = set()
+        for key in self._cone_keys():
+            try:
+                for tgt, data in (self._g.get_edges_from(key) or []):
+                    t = (str(key), str(tgt), str(data.get("edge_type", "")))
+                    if t not in seen:
+                        seen.add(t); edges.append(t)
+                for src, data in (self._g.get_edges_to(key) or []):
+                    t = (str(src), str(key), str(data.get("edge_type", "")))
+                    if t not in seen:
+                        seen.add(t); edges.append(t)
+            except Exception:  # noqa: BLE001 — read-only best-effort
+                continue
+        return edges
+
+    def node_signature(self, key: str) -> Optional[str]:
+        try:
+            node = self._g.get_node(key)
+            return (node or {}).get("signature")
+        except Exception:  # noqa: BLE001
+            return None
+
+    def roots(self) -> List[str]:
+        """Reachability roots derived from the graph (no hardcoding): failing-test nodes + the
+        sources of the cone's causal call-chains."""
+        roots: List[str] = []
+        for tid in self._failing_tests:
+            name = tid.split("::")[-1].split("[")[0]
+            try:
+                for n in (self._g.find_nodes_by_name(name) or [])[:1]:
+                    roots.append(str(n))
+            except Exception:  # noqa: BLE001
+                continue
+        for chain in getattr(self._cone, "call_chain", []) or []:
+            head = chain.split(" → ")[0].strip()
+            if head:
+                roots.append(head)
+        return list(dict.fromkeys(roots))

--- a/docs/architecture/REPAIR_CONTEXT_BRIDGE_ADD.md
+++ b/docs/architecture/REPAIR_CONTEXT_BRIDGE_ADD.md
@@ -156,6 +156,38 @@ feedback loop, and the failure-classifier — net new code is the simulator + th
 - It validates **structure**, not behavior — VERIFY (the scoped test run) remains the behavioral
   authority. This gate is friction *before* the test run, catching structural breaks tests miss.
 
+**Implemented (Slice 3):** `governance/structural_validation_gate.py` — `StructuralValidationGate`
+runs at the post-GENERATE / pre-sandbox seam in `repair_engine._run_inner` (before the test run, so a
+structural regression is fed back without burning a validation run). Three deterministic, zero-LLM
+proofs over an **isolated** what-if delta:
+- **Acyclicity Guard** (hard) — a cycle in the post-delta cone absent pre-delta (DFS back-edge);
+  coordinates carry the closed loop.
+- **Path Reachability Matrix** (§3.1) — a node that flips reachable-from-a-live-root → unreachable
+  (BFS over pre/post delta); dead-only severance → `StructuralPrune` (ACCEPT + non-blocking
+  telemetry), never a false reject.
+- **Boundary Invariant Verification** (soft) — a changed intra-file symbol signature whose un-modified
+  in-cone callers (incoming CALLS/IMPORTS edges) still rely on the old contract. (This is the
+  as-built third proof; standalone dead-code detection is subsumed by the reachability matrix's prune
+  path — a node orphaned by the fix is exactly a reachability flip.)
+
+**Blindspot Armor (isolation + thread-safety):** the candidate is parsed off-process via
+`analyze_python_source_for_oracle` (its own interpreter — never touches the live backend); the what-if
+graph is a per-invocation local `_DeltaGraph` built from a **read-only** cone snapshot
+(`OracleConeReader`), never written back to the `SqliteLazyGraphBackend`. Concurrent repair iterations
+cannot pollute each other's simulation or contend on shared mutable graph state.
+
+**Feedback (Phase 3):** a violation compiles a structured `DivergenceSignature` (kind + severity +
+exact AST coordinates: the closed loop / the severed edge path / the symbol + old→new signature),
+hashed via `failure_classifier.patch_signature_hash`, rendered to targeted correction guidance, and
+routed into the L2 loop as a `failure_class="structural"` `RepairContext` → the existing
+iterate-with-feedback loop self-corrects. Bounded: `JARVIS_REPAIR_STRUCTURAL_MAX_REJECTS` (default 3)
+consecutive structural rejections fall through to the sandbox (friction, not an absolute wall); each
+reject also consumes one `max_iterations` slot. Per-check severity env-tunable
+(`JARVIS_REPAIR_STRUCT_{CYCLE,REACH,BOUNDARY}_SEVERITY`; cycle/reach `hard`, boundary `soft`);
+`JARVIS_REPAIR_STRUCTURAL_SOFT_BLOCKS` graduates soft → blocking post-soak. Gated
+`JARVIS_REPAIR_STRUCTURAL_GATE_ENABLED` (default OFF → L2 byte-identical); fail-soft → ACCEPT on any
+inability to simulate. 20 gate tests + 132 repair-engine regression green.
+
 ---
 
 ## 3.1 The Dynamic Graph Reachability Matrix (severed-chain adjudication)

--- a/tests/governance/test_structural_validation_gate.py
+++ b/tests/governance/test_structural_validation_gate.py
@@ -1,0 +1,317 @@
+"""Tests for the Sovereign Structural Validation Gate — Slice 3 (the enforce).
+
+Covers `structural_validation_gate.py`:
+1. Isolated delta build + the three structural proofs.
+2. Acyclicity Guard — a new cycle is a HARD reject with the closed loop in coordinates.
+3. Path Reachability Matrix (§3.1) — live-reachability sever → reject; dead-only sever → prune.
+4. Boundary Invariant Verification — changed signature with un-updated callers → soft divergence.
+5. Structured DivergenceSignature feedback + stable signature hashes (Phase 3).
+6. Gating + fail-soft (disabled → accept; analyze unavailable → accept; never raises).
+7. _DeltaGraph + OracleConeReader units.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance.structural_validation_gate import (
+    DivergenceSignature,
+    OracleConeReader,
+    StructuralValidationGate,
+    StructuralVerdict,
+    _DeltaGraph,
+)
+
+
+# --------------------------------------------------------------------------- analyzer fakes
+class _OutOK:
+    value = "ok"
+
+
+class _ET:
+    def __init__(self, v: str) -> None:
+        self.value = v
+
+
+class _ED:
+    def __init__(self, v: str) -> None:
+        self.edge_type = _ET(v)
+
+
+class _ND:
+    def __init__(self, key: str, sig: Optional[str] = None) -> None:
+        self.node_id = key
+        self.signature = sig
+
+
+class _Result:
+    def __init__(self, edges: List[Tuple[str, str, Any]], nodes: Tuple[Any, ...] = ()) -> None:
+        self.outcome = _OutOK()
+        self.edges = edges
+        self.nodes = nodes
+
+
+def _analyzer(edges: List[Tuple[str, str, str]], nodes: Tuple[Any, ...] = ()):
+    _e = [(s, d, _ED(t)) for s, d, t in edges]
+
+    async def _a(caller, source, *, filename="", repo_name="", relative_path=""):  # noqa: ANN001
+        return _Result(_e, nodes)
+
+    return _a
+
+
+def _analyzer_fail():
+    async def _a(caller, source, *, filename="", repo_name="", relative_path=""):  # noqa: ANN001
+        class _Bad:
+            outcome = _ET("syntax_error")
+            edges: Tuple = ()
+            nodes: Tuple = ()
+        return _Bad()
+
+    return _a
+
+
+class _Reader:
+    def __init__(self, edges: List[Tuple[str, str, str]],
+                 sigs: Optional[Dict[str, Optional[str]]] = None,
+                 roots: Optional[List[str]] = None) -> None:
+        self._edges = edges
+        self._sigs = sigs or {}
+        self._roots = roots or []
+
+    def cone_edges(self) -> List[Tuple[str, str, str]]:
+        return list(self._edges)
+
+    def node_signature(self, key: str) -> Optional[str]:
+        return self._sigs.get(key)
+
+    def roots(self) -> List[str]:
+        return list(self._roots)
+
+
+@pytest.fixture(autouse=True)
+def _enable_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_REPAIR_STRUCTURAL_GATE_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_REPAIR_STRUCTURAL_SOFT_BLOCKS", raising=False)
+
+
+# --------------------------------------------------------------------------- _DeltaGraph
+class TestDeltaGraph:
+    def test_cycle_detection(self) -> None:
+        g = _DeltaGraph()
+        g.add_edge("a", "b"); g.add_edge("b", "c"); g.add_edge("c", "a")
+        cyc = g.cycles()
+        assert len(cyc) == 1 and set(cyc[0]) == {"a", "b", "c"}
+
+    def test_no_cycle(self) -> None:
+        g = _DeltaGraph()
+        g.add_edge("a", "b"); g.add_edge("b", "c")
+        assert g.cycles() == []
+
+    def test_reachability(self) -> None:
+        g = _DeltaGraph()
+        g.add_edge("root", "a"); g.add_edge("a", "b"); g.add_edge("x", "y")
+        assert g.reachable(["root"]) == {"root", "a", "b"}
+
+
+# --------------------------------------------------------------------------- acyclicity
+class TestAcyclicity:
+    @pytest.mark.asyncio
+    async def test_new_cycle_hard_reject(self) -> None:
+        pre = [("r:f.py:a", "r:g.py:b", "calls")]
+        new = [("r:f.py:a", "r:f.py:c", "calls"), ("r:f.py:c", "r:f.py:a", "calls")]
+        gate = StructuralValidationGate(analyzer=_analyzer(new))
+        v = await gate.validate(candidate_source="x", file_path="f.py",
+                                repo_name="r", reader=_Reader(pre))
+        assert v.accepted is False
+        kinds = [d.kind for d in v.divergences]
+        assert "new_cycle" in kinds
+        cyc = next(d for d in v.divergences if d.kind == "new_cycle")
+        assert set(cyc.coordinates["cycle"]) == {"r:f.py:a", "r:f.py:c"}
+        assert cyc.severity == "hard"
+        assert cyc.signature_hash  # Phase 3 stable hash populated
+
+    @pytest.mark.asyncio
+    async def test_clean_candidate_accepted(self) -> None:
+        pre = [("r:f.py:a", "r:g.py:b", "calls")]
+        new = [("r:f.py:a", "r:g.py:b", "calls")]  # same shape, no cycle
+        gate = StructuralValidationGate(analyzer=_analyzer(new))
+        v = await gate.validate(candidate_source="x", file_path="f.py",
+                                repo_name="r", reader=_Reader(pre))
+        assert v.accepted is True
+        assert v.divergences == ()
+
+
+# --------------------------------------------------------------------------- reachability matrix
+class TestReachabilityMatrix:
+    @pytest.mark.asyncio
+    async def test_live_sever_rejected(self) -> None:
+        # root → a (f.py) → b ; patch drops a→b → b becomes unreachable
+        pre = [("r:t.py:test", "r:f.py:a", "calls"), ("r:f.py:a", "r:g.py:b", "calls")]
+        new: List[Tuple[str, str, str]] = []  # candidate removed the a→b call
+        gate = StructuralValidationGate(analyzer=_analyzer(new))
+        v = await gate.validate(candidate_source="x", file_path="f.py", repo_name="r",
+                                reader=_Reader(pre, roots=["r:t.py:test"]))
+        assert v.accepted is False
+        sev = next(d for d in v.divergences if d.kind == "severed_reachability")
+        assert "r:g.py:b" in sev.coordinates["unreachable"]
+
+    @pytest.mark.asyncio
+    async def test_dead_only_sever_is_pruned_not_rejected(self) -> None:
+        # root → a (g.py, kept) reachable; f.py holds dead→orphan (never reachable)
+        pre = [("r:t.py:test", "r:g.py:a", "calls"),
+               ("r:f.py:dead", "r:f.py:orphan", "calls")]
+        new: List[Tuple[str, str, str]] = []  # patch removed the dead code
+        gate = StructuralValidationGate(analyzer=_analyzer(new))
+        v = await gate.validate(candidate_source="x", file_path="f.py", repo_name="r",
+                                reader=_Reader(pre, roots=["r:t.py:test"]))
+        assert v.accepted is True            # authorized pruning, not a regression
+        assert not any(d.kind == "severed_reachability" for d in v.divergences)
+        assert len(v.prunes) == 1
+        assert v.prunes[0].severed_edge == ("r:f.py:dead", "r:f.py:orphan")
+
+    @pytest.mark.asyncio
+    async def test_no_roots_skips_reachability(self) -> None:
+        pre = [("r:f.py:a", "r:g.py:b", "calls")]
+        gate = StructuralValidationGate(analyzer=_analyzer([]))
+        v = await gate.validate(candidate_source="x", file_path="f.py", repo_name="r",
+                                reader=_Reader(pre, roots=[]))
+        assert v.accepted is True
+        assert not any(d.kind == "severed_reachability" for d in v.divergences)
+
+
+# --------------------------------------------------------------------------- boundary invariant
+class TestBoundaryInvariant:
+    @pytest.mark.asyncio
+    async def test_signature_change_with_callers_soft(self) -> None:
+        nodes = (_ND("r:f.py:func", sig="func(a, b)"),)
+        pre = [("r:f.py:caller", "r:f.py:func", "calls")]
+        reader = _Reader(pre, sigs={"r:f.py:func": "func(a)"})
+        gate = StructuralValidationGate(analyzer=_analyzer([], nodes=nodes))
+        v = await gate.validate(candidate_source="x", file_path="f.py",
+                                repo_name="r", reader=reader)
+        bd = next(d for d in v.divergences if d.kind == "boundary_signature_mismatch")
+        assert bd.coordinates["symbol"] == "r:f.py:func"
+        assert bd.coordinates["callers"] == ["r:f.py:caller"]
+        assert bd.severity == "soft"
+        assert v.accepted is True  # soft does not block by default
+
+    @pytest.mark.asyncio
+    async def test_soft_blocks_env_makes_boundary_block(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("JARVIS_REPAIR_STRUCTURAL_SOFT_BLOCKS", "true")
+        nodes = (_ND("r:f.py:func", sig="func(a, b)"),)
+        pre = [("r:f.py:caller", "r:f.py:func", "calls")]
+        reader = _Reader(pre, sigs={"r:f.py:func": "func(a)"})
+        gate = StructuralValidationGate(analyzer=_analyzer([], nodes=nodes))
+        v = await gate.validate(candidate_source="x", file_path="f.py",
+                                repo_name="r", reader=reader)
+        assert v.accepted is False
+
+    @pytest.mark.asyncio
+    async def test_unchanged_signature_no_divergence(self) -> None:
+        nodes = (_ND("r:f.py:func", sig="func(a)"),)
+        pre = [("r:f.py:caller", "r:f.py:func", "calls")]
+        reader = _Reader(pre, sigs={"r:f.py:func": "func(a)"})
+        gate = StructuralValidationGate(analyzer=_analyzer([], nodes=nodes))
+        v = await gate.validate(candidate_source="x", file_path="f.py",
+                                repo_name="r", reader=reader)
+        assert v.divergences == ()
+
+
+# --------------------------------------------------------------------------- gating + fail-soft
+class TestGatingAndFailSoft:
+    @pytest.mark.asyncio
+    async def test_disabled_accepts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("JARVIS_REPAIR_STRUCTURAL_GATE_ENABLED", raising=False)
+        gate = StructuralValidationGate(analyzer=_analyzer([]))
+        v = await gate.validate(candidate_source="x", file_path="f.py",
+                                repo_name="r", reader=_Reader([]))
+        assert v.accepted is True and v.analyzed is False
+
+    @pytest.mark.asyncio
+    async def test_no_source_accepts(self) -> None:
+        gate = StructuralValidationGate(analyzer=_analyzer([]))
+        v = await gate.validate(candidate_source="", file_path="f.py",
+                                repo_name="r", reader=_Reader([]))
+        assert v.accepted is True and v.analyzed is False
+
+    @pytest.mark.asyncio
+    async def test_analyze_failure_accepts(self) -> None:
+        gate = StructuralValidationGate(analyzer=_analyzer_fail())
+        v = await gate.validate(candidate_source="x", file_path="f.py",
+                                repo_name="r", reader=_Reader([]))
+        assert v.accepted is True and v.analyzed is False
+
+
+# --------------------------------------------------------------------------- feedback (Phase 3)
+class TestDivergenceFeedback:
+    def test_cycle_feedback(self) -> None:
+        d = DivergenceSignature(kind="new_cycle", severity="hard", detail="d",
+                                coordinates={"cycle": ["a", "b"]})
+        fb = d.to_feedback()
+        assert "dependency cycle" in fb and "a → b" in fb
+
+    def test_reachability_feedback(self) -> None:
+        d = DivergenceSignature(kind="severed_reachability", severity="hard", detail="d",
+                                coordinates={"unreachable": ["x"], "broken_path": ["a", "x"],
+                                             "root": "t"})
+        fb = d.to_feedback()
+        assert "severs" in fb.lower() and "x" in fb
+
+    def test_verdict_feedback_concats(self) -> None:
+        v = StructuralVerdict(accepted=False, divergences=(
+            DivergenceSignature(kind="new_cycle", severity="hard", detail="d",
+                                coordinates={"cycle": ["a", "b"]}),
+        ))
+        assert "STRUCTURAL VIOLATION" in v.feedback()
+        assert "accepted=False" in v.telemetry()
+
+
+# --------------------------------------------------------------------------- OracleConeReader
+class _FakeCKG:
+    def __init__(self) -> None:
+        self._from = {"r:f.py:a": [("r:g.py:b", {"edge_type": "calls"})]}
+        self._to = {"r:f.py:a": [("r:t.py:test", {"edge_type": "calls"})]}
+        self._sig = {"r:f.py:a": "a(self)"}
+        self._names = {"test_x": ["r:t.py:test_x"]}
+
+    def get_edges_from(self, k: str):
+        return self._from.get(k, [])
+
+    def get_edges_to(self, k: str):
+        return self._to.get(k, [])
+
+    def get_node(self, k: str):
+        return {"signature": self._sig.get(k)}
+
+    def find_nodes_by_name(self, name: str):
+        return self._names.get(name, [])
+
+
+class _FakeCone:
+    fault_keys = ["r:f.py:a"]
+    dependents = []
+    dependencies = []
+    call_chain = ["r:t.py:test → r:f.py:a"]
+
+
+class TestOracleConeReader:
+    def test_cone_edges_union(self) -> None:
+        r = OracleConeReader(_FakeCKG(), _FakeCone(), failing_tests=())
+        edges = r.cone_edges()
+        assert ("r:f.py:a", "r:g.py:b", "calls") in edges
+        assert ("r:t.py:test", "r:f.py:a", "calls") in edges
+
+    def test_node_signature(self) -> None:
+        r = OracleConeReader(_FakeCKG(), _FakeCone(), failing_tests=())
+        assert r.node_signature("r:f.py:a") == "a(self)"
+
+    def test_roots_from_tests_and_chain(self) -> None:
+        r = OracleConeReader(_FakeCKG(), _FakeCone(),
+                             failing_tests=("tests/test_x.py::test_x",))
+        roots = r.roots()
+        assert "r:t.py:test_x" in roots          # from failing test name
+        assert "r:t.py:test" in roots            # from call-chain head


### PR DESCRIPTION
## Summary

**Repair Context Bridge — Slice 3: the enforce.** Slice 2 *steers* the model into the dependency cone; this gate *enforces* it. A deterministic, zero-LLM pre-flight shield that catches a structural regression the failing test won't — a new dependency cycle, a severed live execution path, or a broken intra-file interface contract — **before** the candidate reaches the sandbox or AutoCommitter, and routes a mathematically precise correction back into the L2 loop. This locks the immune system into ironclad local permanence.

## Phase 1 — Isolated Transactional Delta Simulation

- Candidate parsed via the existing `analyze_python_source_for_oracle` → a virtual graph delta.
- **Blindspot Armor (isolation + thread-safety):** the parse runs **off-process** (its own interpreter — never touches the live backend). The what-if graph is a **per-invocation local `_DeltaGraph`** built from a **read-only** cone snapshot (`OracleConeReader`), never written back to the `SqliteLazyGraphBackend`. Concurrent repair iterations cannot pollute each other's simulation or contend on shared mutable graph state — operating safely within the proven sub-10 MB lazy footprint.

## Phase 2 — Structural Invariant Proofs & Dynamic Reachability

Three deterministic algorithms over the virtual delta:
- **Acyclicity Guard** (hard) — a cycle in the post-delta cone absent pre-delta (DFS back-edge); coordinates carry the closed loop.
- **Path Reachability Matrix** (§3.1) — a node that flips **reachable-from-a-live-root** (active test / entry script) → unreachable (BFS pre/post). Dead-only severance → authorized `StructuralPrune` (ACCEPT + non-blocking cleanup telemetry), **never a false reject**.
- **Boundary Invariant Verification** (soft) — a changed intra-file symbol signature whose un-modified in-cone callers still rely on the old contract.

## Phase 3 — Structured AST-Relational Diff Feedback Loops

- No flat exception/string. A violation compiles a structured **`DivergenceSignature`** with the **exact AST coordinates** (the closed loop / the severed edge path / the symbol + old→new signature), hashed via `failure_classifier.patch_signature_hash`.
- Routed into the L2 loop as a `failure_class="structural"` `RepairContext` → the **existing iterate-with-feedback loop** self-corrects, transforming the next generation into a targeted correction phase.
- **Bounded:** `JARVIS_REPAIR_STRUCTURAL_MAX_REJECTS` (default 3) consecutive rejections fall through to the sandbox (friction, not an absolute wall); each reject also consumes one `max_iterations` slot — no new unbounded loop.

## Design discipline

- **No duplication** — composes the shipped Oracle parser + GraphBackend + lazy backend + L2 feedback loop + failure-classifier. Net-new = the isolated delta + the three proofs + the feedback compiler.
- **No hardcoding** — per-check severity env-tunable (`JARVIS_REPAIR_STRUCT_{CYCLE,REACH,BOUNDARY}_SEVERITY`); reachability roots **derived from the graph** (failing tests + call-chain heads), not a static list.
- **Soft→hard graduation** — cycle/reach `hard`, boundary `soft`; `JARVIS_REPAIR_STRUCTURAL_SOFT_BLOCKS` graduates soft → blocking after the soak (same earn-trust pattern as SemanticGuardian).
- **Fail-soft** — gated `JARVIS_REPAIR_STRUCTURAL_GATE_ENABLED` (default OFF → L2 byte-identical); any inability to simulate → ACCEPT. The immune system is never *weakened* by the thing meant to strengthen it.

## Test Plan

- [x] 20 new gate tests — `_DeltaGraph` cycle/reachability units; acyclicity hard-reject + clean-accept; reachability live-sever reject + dead-only prune + no-roots skip; boundary soft + soft-blocks env + unchanged-signature; gating + fail-soft (disabled / no-source / analyze-failure); structured feedback + hash; `OracleConeReader` edges/signature/roots.
- [x] **132 repair-engine** regression tests green (`_run_inner` gate insertion + new loop vars safe).
- [x] **209 bridge/intent** tests green; OFF path byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pre-flight structural validation gate to catch new dependency cycles, severed live reachability, and interface signature mismatches before sandbox tests. This cuts wasted runs and returns targeted structural feedback to the repair loop with a bounded reject cap.

- **New Features**
  - Introduces `StructuralValidationGate` with three deterministic checks over an isolated `_DeltaGraph`: acyclicity (hard), reachability from live roots (hard), and boundary signature changes (soft).
  - Runs post-generate and pre-sandbox in `repair_engine`; rejects feed `failure_class="structural"` feedback; dead-only severances emit non-blocking `StructuralPrune` telemetry.
  - Parses candidates off-process via `analyze_python_source_for_oracle` and reads a read-only cone via `OracleConeReader` (no writes to the live graph).
  - Caps consecutive rejects with `JARVIS_REPAIR_STRUCTURAL_MAX_REJECTS`; per-check severity tuned by `JARVIS_REPAIR_STRUCT_{CYCLE,REACH,BOUNDARY}_SEVERITY`; optional soft-blocks via `JARVIS_REPAIR_STRUCTURAL_SOFT_BLOCKS`.
  - Master flag `JARVIS_REPAIR_STRUCTURAL_GATE_ENABLED` (default off); fail-soft accepts if analysis or cone build is unavailable.
  - `RepairContextBridge.build(force=True)` lets the gate build its cone independent of the steer flag; shared cone builder added to `repair_engine`. New tests and docs included.

- **Migration**
  - Enable with `JARVIS_REPAIR_STRUCTURAL_GATE_ENABLED=true`.
  - Optionally tune `JARVIS_REPAIR_STRUCT_{CYCLE,REACH,BOUNDARY}_SEVERITY`, `JARVIS_REPAIR_STRUCTURAL_SOFT_BLOCKS`, and `JARVIS_REPAIR_STRUCTURAL_MAX_REJECTS`.
  - No code changes required; the gate force-builds its cone even if the steer flag is off.

<sup>Written for commit 0ec6cb2c85e5c330b52a1d68ebfac3c5dfeb2000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

