### PR TITLE
feat(repair-engine): L2 Completion — Coordinated Transactional & Stochastic Mutation Engine

### DIFF
--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -1816,3 +1816,7 @@ class RepairContext:
     current_candidate_content: str
     current_candidate_file_path: str
     dependency_cone: Optional[str] = None
+    # L2 completion (Phase 2): stochastic strategy-escalation directive injected when the repair loop
+    # diverges (local minimum). Switches the generation paradigm (localized patch → full-method /
+    # module-level rewrite). ``None`` outside a divergence → prompt byte-identical.
+    escalation_directive: Optional[str] = None

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -3482,6 +3482,11 @@ Rules:
             f"Fix ONLY the failing lines. Do not regenerate the whole file.\n"
             f"The diff must apply cleanly to the content shown above."
         )
+        # L2 completion (Phase 2) — stochastic strategy-escalation directive, injected
+        # FIRST (highest priority) when the loop diverged so the model switches paradigm.
+        _escalation = getattr(_rc, "escalation_directive", None)
+        if _escalation:
+            _repair_block = f"{_escalation}\n\n{_repair_block}"
         # Repair Context Bridge (Slice 2) — additive graph-derived dependency-cone
         # boundary clause. Present only when the bridge populated it (gated); when
         # absent the repair block is byte-identical to pre-bridge behavior.

--- a/backend/core/ouroboros/governance/repair_context_bridge.py
+++ b/backend/core/ouroboros/governance/repair_context_bridge.py
@@ -166,6 +166,7 @@ class RepairContextBridge:
         evidence_json: str,
         target_file: str,
         failing_tests: Tuple[str, ...],
+        depth_override: int = 0,
     ) -> Optional[RepairCone]:
         g = self._get_graph()
         if g is None:
@@ -175,7 +176,9 @@ class RepairContextBridge:
             return None
 
         cap = self._max_symbols if self._max_symbols is not None else _cone_max_symbols()
-        depth = self._blast_depth if self._blast_depth is not None else _cone_blast_depth()
+        base_depth = self._blast_depth if self._blast_depth is not None else _cone_blast_depth()
+        # Phase 2 (L2 divergence escape): widen the lookahead radius when escalating.
+        depth = base_depth + max(0, int(depth_override or 0))
 
         files: List[str] = []
         symbols: List[str] = []
@@ -258,18 +261,21 @@ class RepairContextBridge:
         target_file: str = "",
         failing_tests: Tuple[str, ...] = (),
         force: bool = False,
+        depth_override: int = 0,
     ) -> Optional[RepairCone]:
         """Build the cone off-loop (the lazy graph query API is synchronous). Fail-soft → None.
 
         ``force=True`` bypasses the steer-flag self-gate so the Slice 3 structural gate (which has its
-        own master flag) can obtain a cone even when the prompt-steer flag is off."""
+        own master flag) can obtain a cone even when the prompt-steer flag is off. ``depth_override``
+        widens the blast-radius lookahead (L2 divergence escalation, Phase 2)."""
         if not force and not bridge_enabled():
             return None
         import asyncio
 
         try:
             return await asyncio.to_thread(
-                self._build_sync, evidence_json, target_file, tuple(failing_tests)
+                self._build_sync, evidence_json, target_file, tuple(failing_tests),
+                depth_override,
             )
         except Exception as exc:  # noqa: BLE001 — cone is advisory; never break L2
             logger.debug("[RepairBridge] cone build failed (non-fatal): %s", exc)

--- a/backend/core/ouroboros/governance/repair_engine.py
+++ b/backend/core/ouroboros/governance/repair_engine.py
@@ -679,6 +679,13 @@ class RepairEngine:
         # after the cap (the gate is friction, not an absolute wall). Rides the
         # overall max_iterations budget too (each reject consumes one iteration).
         structural_reject_streak = 0
+        # L2 completion — Phase 2/3 state. progress_tracker drives granular-progress +
+        # velocity; escalation_count bounds the stochastic strategy-escalation budget;
+        # pending_escalation carries the active paradigm switch into the next GENERATE.
+        from backend.core.ouroboros.governance.repair_progress import RepairProgressTracker
+        progress_tracker = RepairProgressTracker()
+        escalation_count = 0
+        pending_escalation: Any = None
         t_start = time.monotonic()
         records: list = []
         model_id: str = getattr(ctx.generation, "model_id", "")
@@ -820,15 +827,32 @@ class RepairEngine:
             _has_real_diff = "@@" in diff and ("+" in diff or "-" in diff)
             _has_full_content = bool(full_content)
 
+            # L2 completion (Phase 1) — topologically-ordered multi-file coordinated repair.
+            # Extract + dependency-order the candidate's files (None when off / single-file).
+            # The throwaway sandbox is the atomic transaction boundary: any apply/test failure
+            # discards the whole batch, so cross-file mutations are all-or-nothing.
+            _multi_files = await self._resolve_multifile_batch(current_candidate)
+            _is_multi = _multi_files is not None and len(_multi_files) > 1
+
             if _has_real_diff:
                 if _count_diff_lines(diff) > budget.max_diff_lines:
                     return _stopped("diff_expansion_rejected")
                 if _count_diff_files(diff) > budget.max_files_changed:
                     return _stopped("diff_files_rejected")
+            elif _is_multi:
+                if len(_multi_files) > budget.max_files_changed:
+                    return _stopped("diff_files_rejected")
             elif not _has_full_content:
                 return _stopped("candidate_unusable:no_diff_or_full_content")
 
-            file_path = current_candidate.get("file_path", "")
+            # Primary file = first in dependency order (used for the structural gate, cone,
+            # RepairContext echo, and as a test target). For multi-file, full_content is the
+            # primary's content so the single-file gate/cone path still has a coherent source.
+            if _is_multi:
+                file_path = _multi_files[0][0]
+                full_content = _multi_files[0][1]
+            else:
+                file_path = current_candidate.get("file_path", "")
 
             # ----------------------------------------------------------------
             # Slice 3 — PRE-FLIGHT STRUCTURAL VALIDATION GATE (the enforce).
@@ -917,11 +941,14 @@ class RepairEngine:
                     try:
                         if _has_real_diff:
                             await sb.apply_patch(diff, file_path)
+                        elif _is_multi:
+                            # Phase 1 — apply every file in dependency order as one batch.
+                            # The sandbox is the atomic boundary: if any apply raises, the
+                            # whole sandbox is discarded (all-or-nothing transaction).
+                            for _mf_path, _mf_content in _multi_files:
+                                await sb.apply_full_content(_mf_content, _mf_path)
                         else:
                             # full_content path: write the candidate verbatim.
-                            # NOTE: L2 is single-file; ``files: [...]`` multi-
-                            # file candidates are not yet handled inside the
-                            # sandbox apply path.
                             await sb.apply_full_content(full_content, file_path)
                     except RuntimeError as apply_exc:
                         # Apply failure — the diff is malformed, doesn't match
@@ -959,7 +986,14 @@ class RepairEngine:
                     if _patch_failed:
                         svr = None
                     else:
-                        test_targets: Tuple[str, ...] = (file_path,) if file_path else ()
+                        # Multi-file: scope tests to ALL changed files so the batch is
+                        # validated coherently; single-file keeps the original scoping.
+                        if _is_multi:
+                            test_targets: Tuple[str, ...] = tuple(
+                                p for p, _ in _multi_files
+                            )
+                        else:
+                            test_targets = (file_path,) if file_path else ()
                         svr = await sb.run_tests(
                             test_targets, budget.per_iteration_test_timeout_s
                         )
@@ -1067,13 +1101,9 @@ class RepairEngine:
             patch_sig = _patch_sig(diff if _has_real_diff else full_content)
 
             # ----------------------------------------------------------------
-            # EVALUATE PROGRESS
+            # EVALUATE PROGRESS (Phase 3 — granular v1.1 when enabled)
             # ----------------------------------------------------------------
-            # Two of three progress conditions from the design doc are checked:
-            #   1. Fewer failing tests than previous iteration.
-            #   2. Failure severity improved (syntax/env → test).
-            # Condition 3 (sig-hash set narrowing + diff_lines decrease) is
-            # deferred to v1.1 per the implementation plan.
+            # Base conditions (always): fewer failing tests, or severity improved.
             current_failing_count = len(classification.failing_test_ids)
             is_progress = (
                 prev_failing_count is None
@@ -1084,26 +1114,72 @@ class RepairEngine:
                     and prev_failure_class in ("syntax", "env")
                 )
             )
+            from backend.core.ouroboros.governance.repair_progress import (
+                progress_v11_enabled, diverge_escape_enabled, next_escalation,
+            )
+            # Phase 3 — record telemetry; a strictly-narrowing failing-signature SET
+            # counts as progress even at constant count (condition 3), and a non-positive
+            # Operational Velocity Score under persistent errors throttles the graph cache
+            # before a token/memory blow-up. Gated + fail-soft.
+            _diff_lines_now = (
+                _count_diff_lines(diff) if _has_real_diff
+                else len(full_content.splitlines())
+            )
+            progress_tracker.record(
+                fail_sig=fail_sig, patch_sig=patch_sig,
+                failing_sigs=frozenset(classification.failing_test_ids or ()),
+                diff_lines=_diff_lines_now,
+            )
+            if progress_v11_enabled():
+                if progress_tracker.sig_set_narrowed():
+                    is_progress = True
+                if progress_tracker.should_throttle_memory():
+                    _logger.info(
+                        "\U0001f4c9 [L2 Repair] velocity=%.3f (thrashing) → throttling graph cache",
+                        progress_tracker.velocity_score(),
+                    )
+                    self._throttle_graph_cache()
             prev_failing_count = current_failing_count
             prev_failure_class = fail_class
 
             # ----------------------------------------------------------------
-            # OSCILLATION check
+            # DIVERGENCE → stochastic strategy escalation (Phase 2) or terminal stop
             # ----------------------------------------------------------------
+            # The two flat early-stops (oscillation = identical fail+patch pair;
+            # no-progress streak = identical failure over sequential iters) are local
+            # minima. When escape is enabled and the escalation budget remains, instead
+            # of stopping we MUTATE the strategy: switch the generation paradigm
+            # (localized patch → full-method/module rewrite) and widen the cone — then
+            # let the loop regenerate. Budget-bounded so termination is guaranteed.
             pair = (fail_sig, patch_sig)
+            _diverged_reason: Optional[str] = None
             if pair in seen_pairs:
-                return _stopped("oscillation_detected")
+                _diverged_reason = "oscillation_detected"
             seen_pairs.add(pair)
-
-            # ----------------------------------------------------------------
-            # NO-PROGRESS streak
-            # ----------------------------------------------------------------
             if is_progress:
                 no_progress_streak = 0
             else:
                 no_progress_streak += 1
                 if no_progress_streak >= budget.no_progress_streak_kill:
-                    return _stopped("no_progress_streak")
+                    _diverged_reason = _diverged_reason or "no_progress_streak"
+
+            pending_escalation = None
+            if _diverged_reason is not None:
+                _esc = (
+                    next_escalation(escalation_count + 1)
+                    if diverge_escape_enabled() else None
+                )
+                if _esc is None:
+                    # Escape disabled or budget exhausted → terminal stop (legacy behavior).
+                    return _stopped(_diverged_reason)
+                escalation_count += 1
+                pending_escalation = _esc
+                no_progress_streak = 0  # changed strategy — give the new paradigm room
+                _logger.info(
+                    "\U0001f300 [L2 Repair] DIVERGED (%s) → escalation L%d "
+                    "(paradigm switch + cone depth +%d)",
+                    _diverged_reason, _esc.level, _esc.cone_depth_bump,
+                )
 
             # ----------------------------------------------------------------
             # PER-CLASS retry cap
@@ -1119,8 +1195,14 @@ class RepairEngine:
             # Repair Context Bridge (Slice 2): graph-derived dependency-cone steer
             # for the NEXT iteration's GENERATE. Gated + fail-soft → None when off,
             # leaving the repair prompt byte-identical to pre-bridge behavior.
+            # Phase 2: on divergence, widen the cone lookahead so the escalated
+            # paradigm gets additional architectural telemetry.
+            _cone_depth_override = (
+                pending_escalation.cone_depth_bump if pending_escalation else 0
+            )
             _dependency_cone = await self._build_dependency_cone(
                 ctx, file_path, classification.failing_test_ids,
+                cone_depth_override=_cone_depth_override,
             )
             repair_context = RepairContext(
                 iteration=iteration,
@@ -1132,6 +1214,9 @@ class RepairEngine:
                 current_candidate_content=sandbox_content,
                 current_candidate_file_path=file_path,
                 dependency_cone=_dependency_cone,
+                escalation_directive=(
+                    pending_escalation.paradigm if pending_escalation else None
+                ),
             )
 
             outcome = "progress" if is_progress else "no_progress"
@@ -1168,10 +1253,11 @@ class RepairEngine:
         failing_tests: Tuple[str, ...],
         *,
         force: bool = False,
+        depth_override: int = 0,
     ) -> Any:
         """Build the dependency-cone OBJECT (shared by Slice 2 render + Slice 3 gate). ``force``
         bypasses the steer-flag self-gate so the structural gate gets a cone under its own flag.
-        Fail-soft → ``None``."""
+        ``depth_override`` widens the lookahead (L2 divergence escalation). Fail-soft → ``None``."""
         try:
             bridge = self._ensure_context_bridge()
             evidence_json = getattr(ctx, "intake_evidence_json", "") or ""
@@ -1180,6 +1266,7 @@ class RepairEngine:
                 target_file=file_path,
                 failing_tests=tuple(failing_tests or ()),
                 force=force,
+                depth_override=depth_override,
             )
         except Exception as exc:  # noqa: BLE001 — cone is advisory; never break L2
             _logger.debug("[RepairBridge] cone object unavailable (non-fatal): %s", exc)
@@ -1190,13 +1277,16 @@ class RepairEngine:
         ctx: Any,
         file_path: str,
         failing_tests: Tuple[str, ...],
+        cone_depth_override: int = 0,
     ) -> Optional[str]:
         """Repair Context Bridge (Slice 2) — build + render the graph dependency-cone clause.
 
         Gated by ``JARVIS_REPAIR_CONTEXT_BRIDGE_ENABLED`` (the bridge self-gates → ``None`` when off).
         Fail-soft: any error → ``None``, leaving the repair prompt byte-identical to pre-bridge."""
         try:
-            cone = await self._build_cone_object(ctx, file_path, failing_tests)
+            cone = await self._build_cone_object(
+                ctx, file_path, failing_tests, depth_override=cone_depth_override,
+            )
             if cone is None:
                 return None
             clause = self._ensure_context_bridge().render_clause(cone)
@@ -1204,6 +1294,62 @@ class RepairEngine:
         except Exception as exc:  # noqa: BLE001 — cone is advisory; never break L2
             _logger.debug("[RepairBridge] dependency cone unavailable (non-fatal): %s", exc)
             return None
+
+    async def _resolve_multifile_batch(self, candidate: Any) -> Optional[list]:
+        """L2 completion (Phase 1) — extract + topologically order a candidate's files.
+
+        Returns a dependency-ordered ``[(file_path, full_content), ...]`` when
+        ``JARVIS_L2_MULTIFILE_ENABLED`` is on AND the candidate carries >1 usable file; otherwise
+        ``None`` (L2 stays single-file, byte-identical). Topo order uses the Oracle graph so a file
+        others depend on is applied first. Fail-soft: any error → ``None``."""
+        try:
+            from backend.core.ouroboros.governance.repair_multifile import (
+                l2_multifile_enabled, extract_candidate_files, topo_sort_files,
+            )
+            if not l2_multifile_enabled():
+                return None
+            files = extract_candidate_files(candidate)
+            if len(files) <= 1:
+                return None
+
+            # depends_on(a, b): does file a import/call file b? (via the Oracle graph, read-only)
+            graph = None
+            try:
+                from backend.core.ouroboros.oracle import get_oracle
+                graph = getattr(get_oracle(), "_graph", None)
+            except Exception:  # noqa: BLE001
+                graph = None
+
+            def _depends_on(a_path: str, b_path: str) -> bool:
+                if graph is None:
+                    return False
+                try:
+                    for n in (graph.find_nodes_in_file(a_path) or []):
+                        for dep in (graph.get_dependencies(n) or []):
+                            # NodeID str is "repo:file:name" → file segment.
+                            parts = str(dep).split(":")
+                            if len(parts) >= 3 and parts[1] == b_path:
+                                return True
+                except Exception:  # noqa: BLE001
+                    return False
+                return False
+
+            return topo_sort_files(files, _depends_on)
+        except Exception as exc:  # noqa: BLE001 — multi-file is additive; never break L2
+            _logger.debug("[L2 Repair] multi-file resolve failed (non-fatal): %s", exc)
+            return None
+
+    def _throttle_graph_cache(self) -> None:
+        """L2 completion (Phase 3) — contract the Oracle's adaptive node cache when the repair loop
+        is thrashing (negative velocity under persistent errors), to head off a token/memory blow-up
+        before it happens. Fail-soft + best-effort."""
+        try:
+            from backend.core.ouroboros.oracle import get_oracle
+            backend = getattr(getattr(get_oracle(), "_graph", None), "_backend", None)
+            if backend is not None and hasattr(backend, "apply_pressure"):
+                backend.apply_pressure("high")
+        except Exception as exc:  # noqa: BLE001 — advisory throttle; never break L2
+            _logger.debug("[L2 Repair] graph cache throttle unavailable (non-fatal): %s", exc)
 
     async def _structural_validate(
         self,

--- a/backend/core/ouroboros/governance/repair_multifile.py
+++ b/backend/core/ouroboros/governance/repair_multifile.py
@@ -1,0 +1,108 @@
+"""L2 Repair Engine completion — Phase 1: topologically-ordered multi-file coordinated repair.
+
+The L2 self-repair loop was single-file: a candidate carrying ``files: [...]`` (the multi-file shape
+GENERATE/orchestrator already produce, with atomic batch-rollback via ``_apply_multi_file_candidate``)
+was silently dropped, so any fault needing coordinated cross-file changes was unfixable by L2. This
+module closes that asymmetry.
+
+Pure + testable: extract the candidate's files, then **topologically sort** them by dependency
+direction (a file others depend on is applied before its dependents) using the Oracle's lazy graph.
+The L2 sandbox is itself the atomic transaction boundary — if any file in the batch fails to apply or
+the tests fail, the throwaway sandbox is discarded, so the batch is all-or-nothing by construction.
+
+Gated ``JARVIS_L2_MULTIFILE_ENABLED`` (default OFF → L2 stays single-file, byte-identical).
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, List, Optional, Tuple
+
+__all__ = [
+    "l2_multifile_enabled",
+    "extract_candidate_files",
+    "topo_sort_files",
+]
+
+# A changed file: (file_path, full_content).
+CandidateFile = Tuple[str, str]
+
+
+def l2_multifile_enabled() -> bool:
+    """``JARVIS_L2_MULTIFILE_ENABLED`` (default OFF) — let L2 repair coordinated multi-file candidates."""
+    return os.environ.get("JARVIS_L2_MULTIFILE_ENABLED", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def extract_candidate_files(candidate: Any) -> List[CandidateFile]:
+    """Canonical extraction of the changed files from a candidate dict (mirrors the orchestrator's
+    ``files: [...]`` shape; falls back to the legacy single ``file_path``/``full_content`` pair).
+
+    Returns only entries with a non-empty path AND string content (a real, usable change)."""
+    if not isinstance(candidate, dict):
+        return []
+    files = candidate.get("files")
+    out: List[CandidateFile] = []
+    if isinstance(files, list) and files:
+        for entry in files:
+            if not isinstance(entry, dict):
+                continue
+            path = entry.get("file_path", "")
+            content = entry.get("full_content", "")
+            if path and isinstance(content, str) and content:
+                out.append((path, content))
+        return out
+    # legacy single-file shape
+    path = candidate.get("file_path", "")
+    content = candidate.get("full_content", "")
+    if path and isinstance(content, str) and content:
+        out.append((path, content))
+    return out
+
+
+def topo_sort_files(
+    files: List[CandidateFile],
+    depends_on: Optional[Callable[[str, str], bool]] = None,
+) -> List[CandidateFile]:
+    """Order the changed files so a file's **dependencies are applied before it** (dependency →
+    dependent). ``depends_on(a, b)`` returns True iff file *a* depends on file *b* (a imports/calls b).
+
+    Deterministic Kahn's algorithm with stable tie-break on the candidate's original order. A
+    dependency cycle among the changed files (or no ``depends_on`` provider) degrades gracefully to the
+    original order — never raises, never drops a file."""
+    paths = [p for p, _ in files]
+    by_path = dict(files)
+    if depends_on is None or len(files) <= 1:
+        return list(files)
+
+    order = {p: i for i, p in enumerate(paths)}
+    # edge b -> a means "b must come before a" (a depends on b).
+    deps: dict[str, set] = {p: set() for p in paths}   # p -> set of paths p depends on (within batch)
+    for a in paths:
+        for b in paths:
+            if a == b:
+                continue
+            try:
+                if depends_on(a, b):
+                    deps[a].add(b)
+            except Exception:  # noqa: BLE001 — graph lookups are best-effort
+                continue
+
+    resolved: List[str] = []
+    remaining = set(paths)
+    # Kahn: repeatedly emit nodes whose deps are all already resolved (stable by original order).
+    progress = True
+    while remaining and progress:
+        progress = False
+        ready = sorted(
+            (p for p in remaining if deps[p] <= set(resolved)),
+            key=lambda p: order[p],
+        )
+        for p in ready:
+            resolved.append(p)
+            remaining.discard(p)
+            progress = True
+    # Cycle remnant (or unresolved): append in original order — never drop.
+    if remaining:
+        resolved.extend(sorted(remaining, key=lambda p: order[p]))
+    return [(p, by_path[p]) for p in resolved]

--- a/backend/core/ouroboros/governance/repair_progress.py
+++ b/backend/core/ouroboros/governance/repair_progress.py
@@ -1,0 +1,161 @@
+"""L2 Repair Engine completion — Phase 2 (divergence escape) + Phase 3 (progress v1.1 / velocity).
+
+Pure, deterministic, testable helpers that upgrade the L2 self-repair loop from flat early-stops to a
+dynamic, path-aware execution fabric:
+
+- **Stochastic State-Mutation Escape (Phase 2):** when the loop stalls (identical failure signature or
+  identical patch over sequential iterations = a local minimum), instead of a flat `_stopped` the loop
+  mutates its own strategy — escalating the generation *paradigm* (localized patch → full-method
+  encapsulation rewrite → module-level redesign) and widening the dependency-cone lookahead so the
+  model gets more architectural telemetry. Bounded by an escalation budget so it always terminates.
+- **Granular Progress v1.1 (Phase 3):** progress is no longer just "fewer failing tests" — a shrinking
+  *set* of failing-test signatures (even at constant count) counts as progress, and an Operational
+  Velocity Score over the repair timeline detects thrashing (velocity ≤ 0 while errors persist) so the
+  loop can throttle graph-cache memory before a token-limit failure.
+
+All thresholds env-tunable (no hardcoding). All gated default-OFF (the loop is byte-identical when off).
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import FrozenSet, List, Optional, Tuple
+
+__all__ = [
+    "diverge_escape_enabled",
+    "progress_v11_enabled",
+    "EscalationDirective",
+    "next_escalation",
+    "RepairProgressTracker",
+]
+
+
+# --------------------------------------------------------------------------- flags
+def diverge_escape_enabled() -> bool:
+    """``JARVIS_L2_DIVERGE_ESCAPE_ENABLED`` (default OFF) — convert flat oscillation/no-progress
+    stops into bounded stochastic strategy escalations."""
+    return os.environ.get("JARVIS_L2_DIVERGE_ESCAPE_ENABLED", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def progress_v11_enabled() -> bool:
+    """``JARVIS_L2_PROGRESS_V11_ENABLED`` (default OFF) — sig-set-narrowing progress signal +
+    Operational Velocity Score + memory-throttle."""
+    return os.environ.get("JARVIS_L2_PROGRESS_V11_ENABLED", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _diverge_window() -> int:
+    try:
+        return max(2, int(os.environ.get("JARVIS_L2_DIVERGE_WINDOW", "2")))
+    except ValueError:
+        return 2
+
+
+def max_escalations() -> int:
+    """``JARVIS_L2_MAX_ESCALATIONS`` (default 2) — escalation budget before the loop falls back to a
+    terminal stop. Guarantees termination."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_L2_MAX_ESCALATIONS", "2")))
+    except ValueError:
+        return 2
+
+
+# --------------------------------------------------------------------------- escalation ladder
+@dataclass(frozen=True)
+class EscalationDirective:
+    """A strategy mutation injected into the next generation when the loop is diverged."""
+
+    level: int
+    paradigm: str          # prompt directive that switches the generation paradigm
+    cone_depth_bump: int   # widen the dependency-cone lookahead by this many graph levels
+
+
+# Deterministic escalation ladder (no RNG — Math.random is banned and determinism is auditable).
+# Each level abandons a finer-grained strategy that stalled for a coarser, more structural one.
+_LADDER: Tuple[str, ...] = (
+    "ESCALATION (loop diverged): localized line-level patching has stalled in a local minimum. "
+    "ABANDON the targeted diff. REWRITE the entire failing function/method from its signature + "
+    "docstring contract (full-method encapsulation) — reconsider the algorithm, not just the lines.",
+    "ESCALATION L2 (still diverged): the function-level rewrite also stalled. Step up to the "
+    "MODULE level — reconsider the class/module design and the contracts between the failing symbol "
+    "and the dependents shown in the (now-widened) dependency cone. A larger structural change is "
+    "authorized; preserve the public interface unless the cone shows it is the fault.",
+    "ESCALATION L3 (persistent divergence): treat this as a design defect, not a bug. Re-derive the "
+    "failing component from first principles against the cone's call-chain and dependents; you may "
+    "restructure internal helpers freely as long as the dependency cone's boundary contracts hold.",
+)
+
+
+def next_escalation(count: int) -> Optional[EscalationDirective]:
+    """Return the escalation for the *count*-th divergence (1-based), or ``None`` once the budget
+    (``max_escalations``) is spent → caller falls back to a terminal stop."""
+    if count < 1 or count > max_escalations():
+        return None
+    idx = min(count - 1, len(_LADDER) - 1)
+    return EscalationDirective(level=count, paradigm=_LADDER[idx], cone_depth_bump=count)
+
+
+# --------------------------------------------------------------------------- progress tracker
+@dataclass
+class _Sample:
+    fail_sig: str
+    patch_sig: str
+    failing_sigs: FrozenSet[str]
+    diff_lines: int
+
+
+@dataclass
+class RepairProgressTracker:
+    """Per-iteration repair telemetry → divergence + granular-progress + velocity signals."""
+
+    samples: List[_Sample] = field(default_factory=list)
+
+    def record(self, *, fail_sig: str, patch_sig: str,
+               failing_sigs: FrozenSet[str], diff_lines: int) -> None:
+        self.samples.append(_Sample(fail_sig, patch_sig, frozenset(failing_sigs), int(diff_lines)))
+
+    # ---- Phase 2: divergence ----
+    def is_diverged(self, window: Optional[int] = None) -> bool:
+        """True when the last *window* iterations share one identical failure signature OR one
+        identical patch signature — a local minimum the model can't escape with the same strategy."""
+        w = window if window is not None else _diverge_window()
+        if len(self.samples) < w:
+            return False
+        tail = self.samples[-w:]
+        same_fail = len({s.fail_sig for s in tail}) == 1
+        same_patch = len({s.patch_sig for s in tail}) == 1
+        return same_fail or same_patch
+
+    # ---- Phase 3: granular progress ----
+    def sig_set_narrowed(self) -> bool:
+        """True when the *set* of failing-test signatures strictly shrank vs the previous iteration
+        (progress even when the raw count is unchanged — a fix that resolved one and surfaced none)."""
+        if len(self.samples) < 2:
+            return False
+        prev, cur = self.samples[-2].failing_sigs, self.samples[-1].failing_sigs
+        return cur < prev  # proper subset → strictly narrowed
+
+    def velocity_score(self, window: int = 3) -> float:
+        """Operational Velocity Score over the recent timeline. Positive = converging (failures and/or
+        signature-set and/or churn shrinking); negative = thrashing. Normalized, deterministic."""
+        if len(self.samples) < 2:
+            return 0.0
+        tail = self.samples[-(window + 1):] if len(self.samples) > window else self.samples
+        deltas: List[float] = []
+        for a, b in zip(tail, tail[1:]):
+            d_count = len(a.failing_sigs) - len(b.failing_sigs)        # +ve = fewer failures
+            d_set = len(a.failing_sigs - b.failing_sigs)               # +ve = some resolved
+            d_diff = abs(a.diff_lines) - abs(b.diff_lines)             # +ve = less churn
+            base = max(1, len(a.failing_sigs))
+            deltas.append((2.0 * d_count + 1.0 * d_set + 0.25 * (d_diff / base)) / base)
+        return sum(deltas) / len(deltas) if deltas else 0.0
+
+    def should_throttle_memory(self, window: int = 3) -> bool:
+        """True when velocity is non-positive while failures persist — the loop is thrashing and may
+        be heading for a token/memory blow-up, so the graph cache should contract pre-emptively."""
+        if not self.samples or not self.samples[-1].failing_sigs:
+            return False
+        return self.velocity_score(window) <= 0.0

--- a/docs/architecture/REPAIR_CONTEXT_BRIDGE_ADD.md
+++ b/docs/architecture/REPAIR_CONTEXT_BRIDGE_ADD.md
@@ -298,3 +298,38 @@ TestFailure (pytest)
    entries, live external callers) are derived from the graph, never hardcoded.
 3. **"Vectorized" cone** — confirm the structured node/edge-set interpretation (recommended) vs an
    actual embedding vector (out of scope; the semantic index already embeds separately).
+
+---
+
+## 9. L2 Engine Completion — Coordinated Transactional & Stochastic Mutation Engine
+
+With the bridge (Slices 1-3) making L2 graph-aware, three remaining L2 limitations were closed so the
+self-healing loop is a dynamic, path-aware, resilient execution fabric (not flat early-stops).
+
+**Phase 1 — Topologically-ordered multi-file coordinated repair** (`repair_multifile.py`): L2 was
+single-file; multi-file `files: [...]` candidates (which GENERATE/orchestrator already emit with atomic
+batch-rollback) were silently dropped. Now `extract_candidate_files` + `topo_sort_files` (dependency →
+dependent, via the Oracle lazy graph; cycle-safe) order the batch, and `_run_inner` applies every file
+in the L2 sandbox — which is itself the atomic transaction boundary (any apply/test failure discards
+the throwaway sandbox → all-or-nothing). Tests scoped to all changed files. Gated
+`JARVIS_L2_MULTIFILE_ENABLED` (default OFF). *Honest bound:* the structural gate validates the primary
+(dependency-root) file; full multi-file delta simulation is a clean follow-up.
+
+**Phase 2 — Stochastic state-mutation escape gates** (`repair_progress.py`): the two flat early-stops
+(`oscillation_detected` = identical fail+patch pair; `no_progress_streak`) are local minima. When
+`JARVIS_L2_DIVERGE_ESCAPE_ENABLED` is on and the escalation budget (`JARVIS_L2_MAX_ESCALATIONS`,
+default 2) remains, instead of stopping the loop **mutates its own strategy**: a deterministic
+escalation ladder switches the generation paradigm (localized patch → full-method encapsulation rewrite
+→ module-level redesign, injected via `RepairContext.escalation_directive`) and widens the
+dependency-cone lookahead (`cone_depth_bump`) so the model gets more architectural telemetry. Budget-
+bounded → termination guaranteed; falls back to the legacy terminal stop when spent.
+
+**Phase 3 — Granular AST-relational progress tracking** (`repair_progress.py`): `RepairProgressTracker`
+adds the deferred condition 3 — a strictly-narrowing failing-signature **set** counts as progress even
+at constant count — plus an **Operational Velocity Score** over the repair timeline. When velocity is
+non-positive while failures persist (thrashing), the loop pre-emptively throttles the Oracle's
+`AdaptiveNodeCache` (`apply_pressure`) to head off a token/memory blow-up. Gated
+`JARVIS_L2_PROGRESS_V11_ENABLED` (default OFF).
+
+All three gated default-OFF → L2 byte-identical when off (147 repair-engine + 317 combined tests
+green). Graduation soak (with the bridge + gate flags) flips them on.

--- a/tests/governance/test_repair_l2_completion.py
+++ b/tests/governance/test_repair_l2_completion.py
@@ -1,0 +1,178 @@
+"""Tests for the L2 Repair Engine completion — multi-file (Phase 1) + divergence/progress (Phase 2/3).
+
+Covers `repair_multifile.py` + `repair_progress.py`:
+1. Multi-file extraction (files[] shape + legacy single fallback).
+2. Topological ordering by dependency direction (dependency before dependent; cycle-safe).
+3. Divergence detection (identical fail-sig OR identical patch-sig over window).
+4. Stochastic escalation ladder (paradigm switch + cone bump, budget-bounded).
+5. Granular progress v1.1 (sig-set narrowing) + Operational Velocity Score + memory-throttle signal.
+6. Flag gating (all default OFF).
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.repair_multifile import (
+    extract_candidate_files,
+    l2_multifile_enabled,
+    topo_sort_files,
+)
+from backend.core.ouroboros.governance.repair_progress import (
+    RepairProgressTracker,
+    diverge_escape_enabled,
+    max_escalations,
+    next_escalation,
+    progress_v11_enabled,
+)
+
+
+# --------------------------------------------------------------------------- multi-file extract
+class TestExtractCandidateFiles:
+    def test_files_shape(self) -> None:
+        cand = {"files": [
+            {"file_path": "a.py", "full_content": "x", "rationale": "r"},
+            {"file_path": "b.py", "full_content": "y"},
+        ]}
+        assert extract_candidate_files(cand) == [("a.py", "x"), ("b.py", "y")]
+
+    def test_legacy_single(self) -> None:
+        cand = {"file_path": "a.py", "full_content": "x"}
+        assert extract_candidate_files(cand) == [("a.py", "x")]
+
+    def test_skips_empty(self) -> None:
+        cand = {"files": [
+            {"file_path": "", "full_content": "x"},
+            {"file_path": "b.py", "full_content": ""},
+            {"file_path": "c.py", "full_content": "z"},
+        ]}
+        assert extract_candidate_files(cand) == [("c.py", "z")]
+
+    def test_non_dict(self) -> None:
+        assert extract_candidate_files(None) == []
+
+
+# --------------------------------------------------------------------------- topo sort
+class TestTopoSortFiles:
+    def test_dependency_before_dependent(self) -> None:
+        files = [("app.py", "1"), ("util.py", "2")]
+        # app depends on util → util must come first
+        def dep(a: str, b: str) -> bool:
+            return a == "app.py" and b == "util.py"
+        ordered = topo_sort_files(files, dep)
+        assert [p for p, _ in ordered] == ["util.py", "app.py"]
+
+    def test_no_provider_keeps_order(self) -> None:
+        files = [("a.py", "1"), ("b.py", "2")]
+        assert topo_sort_files(files, None) == files
+
+    def test_cycle_degrades_gracefully(self) -> None:
+        files = [("a.py", "1"), ("b.py", "2")]
+        # mutual dependency (cycle) → stable original order, no drop, no raise
+        def dep(a: str, b: str) -> bool:
+            return True
+        ordered = topo_sort_files(files, dep)
+        assert {p for p, _ in ordered} == {"a.py", "b.py"}
+        assert len(ordered) == 2
+
+    def test_provider_raise_is_safe(self) -> None:
+        files = [("a.py", "1"), ("b.py", "2")]
+        def dep(a: str, b: str) -> bool:
+            raise RuntimeError("graph down")
+        ordered = topo_sort_files(files, dep)
+        assert len(ordered) == 2  # no edges resolved → original order, no raise
+
+
+# --------------------------------------------------------------------------- divergence
+class TestDivergence:
+    def test_identical_fail_sig_diverges(self) -> None:
+        t = RepairProgressTracker()
+        for _ in range(2):
+            t.record(fail_sig="F", patch_sig="p%d" % _, failing_sigs=frozenset({"t1"}), diff_lines=5)
+        assert t.is_diverged(window=2) is True
+
+    def test_identical_patch_sig_diverges(self) -> None:
+        t = RepairProgressTracker()
+        t.record(fail_sig="F1", patch_sig="P", failing_sigs=frozenset({"t1"}), diff_lines=5)
+        t.record(fail_sig="F2", patch_sig="P", failing_sigs=frozenset({"t1"}), diff_lines=5)
+        assert t.is_diverged(window=2) is True
+
+    def test_distinct_no_diverge(self) -> None:
+        t = RepairProgressTracker()
+        t.record(fail_sig="F1", patch_sig="P1", failing_sigs=frozenset({"t1"}), diff_lines=5)
+        t.record(fail_sig="F2", patch_sig="P2", failing_sigs=frozenset(), diff_lines=2)
+        assert t.is_diverged(window=2) is False
+
+    def test_needs_full_window(self) -> None:
+        t = RepairProgressTracker()
+        t.record(fail_sig="F", patch_sig="P", failing_sigs=frozenset({"t1"}), diff_lines=5)
+        assert t.is_diverged(window=2) is False
+
+
+# --------------------------------------------------------------------------- escalation ladder
+class TestEscalation:
+    def test_levels_escalate(self) -> None:
+        e1 = next_escalation(1)
+        e2 = next_escalation(2)
+        assert e1 is not None and e2 is not None
+        assert e1.level == 1 and e2.level == 2
+        assert e2.cone_depth_bump > e1.cone_depth_bump
+        assert "ESCALATION" in e1.paradigm and e1.paradigm != e2.paradigm
+
+    def test_budget_exhaustion(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_L2_MAX_ESCALATIONS", "2")
+        assert next_escalation(1) is not None
+        assert next_escalation(2) is not None
+        assert next_escalation(3) is None  # budget spent → terminal stop
+
+    def test_invalid_count(self) -> None:
+        assert next_escalation(0) is None
+
+
+# --------------------------------------------------------------------------- progress v1.1
+class TestProgressV11:
+    def test_sig_set_narrowing(self) -> None:
+        t = RepairProgressTracker()
+        t.record(fail_sig="F1", patch_sig="P1", failing_sigs=frozenset({"t1", "t2"}), diff_lines=10)
+        t.record(fail_sig="F2", patch_sig="P2", failing_sigs=frozenset({"t1"}), diff_lines=8)
+        assert t.sig_set_narrowed() is True
+
+    def test_sig_set_not_narrowed_when_disjoint(self) -> None:
+        t = RepairProgressTracker()
+        t.record(fail_sig="F1", patch_sig="P1", failing_sigs=frozenset({"t1"}), diff_lines=10)
+        t.record(fail_sig="F2", patch_sig="P2", failing_sigs=frozenset({"t2"}), diff_lines=10)
+        assert t.sig_set_narrowed() is False  # different failure, not a subset
+
+    def test_velocity_positive_when_converging(self) -> None:
+        t = RepairProgressTracker()
+        t.record(fail_sig="F1", patch_sig="P1", failing_sigs=frozenset({"t1", "t2", "t3"}), diff_lines=30)
+        t.record(fail_sig="F2", patch_sig="P2", failing_sigs=frozenset({"t1", "t2"}), diff_lines=20)
+        t.record(fail_sig="F3", patch_sig="P3", failing_sigs=frozenset({"t1"}), diff_lines=10)
+        assert t.velocity_score() > 0
+        assert t.should_throttle_memory() is False
+
+    def test_velocity_nonpositive_when_thrashing(self) -> None:
+        t = RepairProgressTracker()
+        for i in range(3):
+            t.record(fail_sig="F", patch_sig="P%d" % i, failing_sigs=frozenset({"t1", "t2"}), diff_lines=20 + i * 5)
+        assert t.velocity_score() <= 0
+        assert t.should_throttle_memory() is True  # errors persist + no velocity
+
+    def test_no_throttle_when_no_failures(self) -> None:
+        t = RepairProgressTracker()
+        t.record(fail_sig="F", patch_sig="P", failing_sigs=frozenset(), diff_lines=0)
+        assert t.should_throttle_memory() is False
+
+
+# --------------------------------------------------------------------------- flags
+class TestFlags:
+    def test_defaults_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for v in ("JARVIS_L2_MULTIFILE_ENABLED", "JARVIS_L2_DIVERGE_ESCAPE_ENABLED",
+                  "JARVIS_L2_PROGRESS_V11_ENABLED"):
+            monkeypatch.delenv(v, raising=False)
+        assert l2_multifile_enabled() is False
+        assert diverge_escape_enabled() is False
+        assert progress_v11_enabled() is False
+
+    def test_max_escalations_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("JARVIS_L2_MAX_ESCALATIONS", raising=False)
+        assert max_escalations() == 2


### PR DESCRIPTION
## Summary

With the **Repair Context Bridge (Slices 1-3)** making L2 graph-aware, this completes the L2 self-repair engine itself — closing the multi-file blindspot and converting flat early-stops into a **dynamic, path-aware, resilient execution fabric**. All three phases gated default-OFF → L2 byte-identical when off.

## Phase 1 — Topologically-Ordered Multi-File Coordinated Repair (`repair_multifile.py`)

L2 was single-file: a candidate carrying `files: [...]` (the multi-file shape GENERATE/orchestrator already emit) was **silently dropped**, so any fault needing coordinated cross-file changes was unfixable. Now:
- `extract_candidate_files` + `topo_sort_files` order the batch by **dependency direction** (a file others depend on is applied first), via the Oracle lazy graph; **cycle-safe** (degrades to stable order, never drops a file).
- `_run_inner` applies every file in the L2 sandbox — **itself the atomic transaction boundary**: any apply/test failure discards the throwaway sandbox → all-or-nothing.
- Tests scoped to **all** changed files. Gated `JARVIS_L2_MULTIFILE_ENABLED`.
- *Honest bound:* the structural gate validates the primary (dependency-root) file; full multi-file delta sim is a clean follow-up.

## Phase 2 — Stochastic State-Mutation Escape Gates (`repair_progress.py`)

The two flat early-stops (`oscillation_detected` = identical fail+patch pair; `no_progress_streak`) are local minima. Instead of a flat stop, the loop **mutates its own strategy**:
- A deterministic **escalation ladder** switches the generation paradigm (localized patch → full-method encapsulation rewrite → module-level redesign), injected via the new additive `RepairContext.escalation_directive` (rendered FIRST in REPAIR MODE).
- The dependency-cone **lookahead widens** (`cone_depth_bump` threaded through `_build_dependency_cone` → `bridge.build`) so the model gets more architectural telemetry.
- **Budget-bounded** (`JARVIS_L2_MAX_ESCALATIONS`, default 2) → guaranteed termination; falls back to the legacy terminal stop when spent. Gated `JARVIS_L2_DIVERGE_ESCAPE_ENABLED`.

## Phase 3 — Granular AST-Relational Progress Tracking (`repair_progress.py`)

`RepairProgressTracker`:
- Adds the deferred **condition 3** — a strictly-narrowing failing-signature **set** counts as progress even at constant count.
- Computes an **Operational Velocity Score** over the repair timeline; when velocity is non-positive while failures persist (thrashing), pre-emptively **throttles the Oracle `AdaptiveNodeCache`** (`apply_pressure`) to head off a token/memory blow-up. Gated `JARVIS_L2_PROGRESS_V11_ENABLED`.

## Design discipline

- **No duplication** — composes the orchestrator's multi-file rollback semantics (sandbox-as-transaction), the Oracle lazy graph, and the existing L2 feedback loop. Net-new = two pure modules + thin wiring.
- **No hardcoding** — env-tunable budgets/windows; topo order + escalation derived from the graph and a deterministic ladder, not RNG (auditable).
- **Fail-soft everywhere** — `_resolve_multifile_batch` / `_throttle_graph_cache` / escalation all degrade to today's behavior on any error.

## Test Plan

- [x] 22 new unit tests (`test_repair_l2_completion.py`) — multi-file extract/topo (incl. cycle + raising-provider safety), divergence (fail-sig/patch-sig/window), escalation ladder + budget exhaustion, sig-set narrowing, velocity (converging vs thrashing) + throttle signal, flag gating.
- [x] **147 repair-engine** regression green — OFF byte-identical.
- [x] **317 combined** repair/bridge/gate/intent tests green.
- [x] Prompt-injection render verified (escalation leads, cone present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the L2 repair engine by adding coordinated multi-file repair and a bounded strategy‑escalation loop, turning flat early stops into a path‑aware, resilient flow. All changes are flag‑gated and default off; when off, behavior is byte‑identical.

- **New Features**
  - Multi-file repair: extract and topo‑order candidate files via the Oracle graph; apply in the sandbox as one atomic batch; run tests against all changed files.
  - Divergence escape: deterministic escalation ladder injected via `RepairContext.escalation_directive`; widens the dependency cone per level; bounded by `JARVIS_L2_MAX_ESCALATIONS`.
  - Progress v1.1: treats a shrinking failing‑test set as progress; computes a velocity score and throttles the Oracle cache when thrashing.
  - Bridge/prompt plumbing: cone `depth_override` threaded through the `repair_context_bridge`; providers prepend the escalation directive to the repair block.

- **Migration**
  - No action needed. To enable:
    - `JARVIS_L2_MULTIFILE_ENABLED=true` for multi-file batches.
    - `JARVIS_L2_DIVERGE_ESCAPE_ENABLED=true` (optionally tune `JARVIS_L2_MAX_ESCALATIONS`).
    - `JARVIS_L2_PROGRESS_V11_ENABLED=true` for progress v1.1 and cache throttling.

<sup>Written for commit 82d1fdc3466b3b07914016bd6f18528ec30b4fc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

