### PR TITLE
docs(readme): By the Numbers — verified scale metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **An autonomous, solo-built systems-engineering framework — ~4.29M tracked lines and 8,300+ solo-authored commits.**
+
 # JARVIS -- Just A Rather Very Intelligent System
 
 **The Body of the Trinity AGI OS**
@@ -5,6 +7,24 @@
 **Author:** [Derek J. Russell](https://github.com/drussell23) -- RSI/AGI Researcher & Trinity Architect
 
 JARVIS is the control plane and execution layer of a three-repository AGI ecosystem. It owns macOS integration, screen vision, voice biometric authentication, focus-preserving UI automation, and the 102K-line unified supervisor that boots and coordinates the entire stack with a single command. All model references are resolved at runtime from a shared YAML policy -- zero hardcoded model names remain anywhere in the interactive or governance pipelines.
+
+---
+
+## 📊 By the Numbers
+
+A solo-built system. Every figure is `git`-tracked and reproducible (`git ls-files -z | xargs -0 wc -l`):
+
+| Metric | Value |
+|---|---|
+| **Total lines (tracked)** | **~4.29M** (3.19M Python) |
+| **Ouroboros + Venom (O+V)** — autonomous self-development engine | **~1.45M lines** |
+| &nbsp;&nbsp;↳ O+V breakdown | 734K engine · 646K test spine · 64K scripts & docs |
+| Python files | 5,961 |
+| Languages | Python · Swift · TypeScript · Rust · Shell |
+| Commits | **8,352 — ~99.8% solo-authored** |
+| Cadence | ~27 commits/day, Aug 2025 → present (~10 months) |
+
+> O+V is roughly **half engine, half proof** — the 646K-line test spine exists to keep a self-modifying system honest.
 
 ---
 


### PR DESCRIPTION
Adds a top-of-README banner + a **By the Numbers** section with verified, reproducible figures.

All figures from `git ls-files -z | xargs -0 wc -l` on this repo:
- **~4.29M** tracked lines (3.19M Python, 5,961 files)
- **~1.45M** O+V — 734K engine / 646K test spine / 64K scripts+docs
- **8,352 commits, ~99.8% solo-authored** (two git identities reconciled)
- ~27 commits/day, Aug 2025 → present

No code changes — README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a top-of-README banner and a By the Numbers table with verified, reproducible repo metrics. Improves credibility and gives a quick scale snapshot; docs-only change.

- **New Features**
  - Banner at the top of README with a concise scale tagline.
  - By the Numbers table based on reproducible git counts (`git ls-files -z | xargs -0 wc -l`).
  - Key figures: ~4.29M lines (3.19M Python); O+V ~1.45M (734K engine / 646K tests / 64K scripts+docs); 8,352 commits (~99.8% solo).

<sup>Written for commit 9f2edce9843fa1b66c0a4678b72cb27c3fde99f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

