### PR TITLE
feat(advisor): Proactive Advisory Plane — git-volatility + memory axes + Phase-3 prerequisite safety plan

### DIFF
--- a/backend/core/ouroboros/governance/operation_advisor.py
+++ b/backend/core/ouroboros/governance/operation_advisor.py
@@ -972,6 +972,118 @@ class Advisory:
     chronic_entropy: float     # Domain failure rate from LearningConsolidator
     risk_score: float          # Composite 0.0–1.0
     voice_message: str = ""    # What JARVIS would say
+    # Proactive Advisory Plane extensions (2026-06-18):
+    git_volatility: float = 0.0          # 0.0–1.0 churn hotspot score of the targets
+    memory_pressure: str = "ok"          # host RAM headroom level at evaluation time
+    safety_plan: List[str] = field(default_factory=list)  # Phase 3 prerequisite de-risk steps
+
+    def render_safety_plan(self) -> str:
+        """Render the prerequisite safety plan as an advisory clause for the prompt context."""
+        if not self.safety_plan:
+            return ""
+        lines = [
+            f"## PREREQUISITE SAFETY PLAN ({self.decision.value.upper()} — de-risk before mutating)",
+            "The advisor flagged this operation as fragile. Complete these prerequisites FIRST:",
+        ]
+        lines.extend(f"  {i + 1}. {step}" for i, step in enumerate(self.safety_plan))
+        return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- Proactive axes
+def _advisor_git_volatility_enabled() -> bool:
+    """``JARVIS_ADVISOR_GIT_VOLATILITY_ENABLED`` (default ON) — git churn-hotspot risk axis."""
+    return os.environ.get("JARVIS_ADVISOR_GIT_VOLATILITY_ENABLED", "true").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _advisor_memory_axis_enabled() -> bool:
+    """``JARVIS_ADVISOR_MEMORY_AXIS_ENABLED`` (default ON) — host RAM-headroom risk axis."""
+    return os.environ.get("JARVIS_ADVISOR_MEMORY_AXIS_ENABLED", "true").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _advisor_safety_plan_enabled() -> bool:
+    """``JARVIS_ADVISOR_SAFETY_PLAN_ENABLED`` (default ON) — Phase 3 prerequisite-plan generation."""
+    return os.environ.get("JARVIS_ADVISOR_SAFETY_PLAN_ENABLED", "true").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def compute_git_volatility(target_files, repo_root, *, runner=None):  # noqa: ANN001
+    """Git Volatility Telemetry axis: commit churn of the targets over a window → (score 0-1, hotspots).
+
+    High churn = a frequently-changing hot-spot (risky to mutate); the score feeds the fragility
+    vector. Pure (injectable ``runner`` for tests); fail-soft → (0.0, []) on any git error."""
+    import subprocess
+    try:
+        window = int(os.environ.get("JARVIS_ADVISOR_CHURN_WINDOW_DAYS", "90"))
+    except ValueError:
+        window = 90
+    try:
+        hotspot = max(1, int(os.environ.get("JARVIS_ADVISOR_CHURN_HOTSPOT_COMMITS", "20")))
+    except ValueError:
+        hotspot = 20
+    root = str(repo_root) if repo_root else "."
+
+    def _default_runner(path: str) -> int:
+        out = subprocess.run(
+            ["git", "-C", root, "log", f"--since={window}.days.ago", "--oneline", "--", path],
+            capture_output=True, text=True, timeout=10,
+        )
+        return len([ln for ln in out.stdout.splitlines() if ln.strip()])
+
+    run = runner or _default_runner
+    max_churn = 0
+    hotspots: List[str] = []
+    for f in (target_files or ()):
+        try:
+            n = int(run(f))
+        except Exception:  # noqa: BLE001 — git is best-effort
+            continue
+        if n > max_churn:
+            max_churn = n
+        if n >= hotspot:
+            hotspots.append(f"{f}({n})")
+    score = min(1.0, max_churn / float(hotspot)) if max_churn else 0.0
+    return round(score, 3), hotspots
+
+
+def memory_headroom_factor(*, gate=None):  # noqa: ANN001
+    """System Resource Headroom axis: MemoryPressureGate level → (risk factor 0-1, level name).
+    Fail-soft → (0.0, "ok")."""
+    _MAP = {"ok": 0.0, "warn": 0.3, "high": 0.6, "critical": 0.9}
+    try:
+        if gate is None:
+            from backend.core.ouroboros.governance.memory_pressure_gate import get_default_gate
+            gate = get_default_gate()
+        level = getattr(gate.pressure(), "value", "ok")
+        return _MAP.get(str(level).lower(), 0.0), str(level).lower()
+    except Exception:  # noqa: BLE001
+        return 0.0, "ok"
+
+
+def build_safety_plan(decision, blast_radius, test_coverage, target_files, hotspots):  # noqa: ANN001
+    """Phase 3: autonomous prerequisite safety pipeline for a CAUTION/BLOCK operation — concrete
+    de-risking steps (characterization test, forensic branch) to run BEFORE the feature mutation."""
+    steps: List[str] = []
+    tgt = ", ".join(list(target_files or ())[:3]) or "the target(s)"
+    if test_coverage <= 0.0:
+        steps.append(f"Write a characterization test asserting the CURRENT behavior of {tgt}, "
+                     "and run it green — establishing a regression baseline before any mutation.")
+    elif test_coverage < 0.5:
+        steps.append(f"Extend coverage of {tgt} (currently {test_coverage:.0%}) with a targeted test "
+                     "for the surface you intend to change, run it green first.")
+    if blast_radius >= 10:
+        steps.append(f"Establish an isolated forensic branch for the mutation (blast radius "
+                     f"{blast_radius} files) so the change can be reviewed/reverted as a unit.")
+    if hotspots:
+        steps.append(f"These targets are churn hot-spots ({', '.join(hotspots[:3])}); run the existing "
+                     "suite for them BEFORE mutating to capture the current green state.")
+    if decision == AdvisoryDecision.BLOCK and not steps:
+        steps.append("Add minimal test coverage for the targets and re-run the advisor before proceeding.")
+    return steps
 
 
 class OperationAdvisor:
@@ -1459,6 +1571,25 @@ class OperationAdvisor:
             )
             risk_factors.append(0.2)
 
+        # Signal 7: Git volatility (churn hot-spot telemetry) — frequently-changing targets are
+        # riskier to mutate. Proactive Advisory Plane axis (2026-06-18). Fail-soft.
+        git_volatility = 0.0
+        hotspots: List[str] = []
+        if _advisor_git_volatility_enabled() and not is_read_only:
+            git_volatility, hotspots = compute_git_volatility(target_files, repo_root)
+            if git_volatility >= 0.5:
+                reasons.append(f"High git volatility (churn hot-spot): {', '.join(hotspots[:3])}")
+                risk_factors.append(round(git_volatility * 0.4, 3))
+
+        # Signal 8: System resource headroom (MemoryPressureGate) — mutating under host memory
+        # pressure compounds risk. Proactive Advisory Plane axis. Fail-soft.
+        mem_factor, mem_level = (0.0, "ok")
+        if _advisor_memory_axis_enabled():
+            mem_factor, mem_level = memory_headroom_factor()
+            if mem_factor > 0.0:
+                reasons.append(f"Host memory pressure: {mem_level}")
+                risk_factors.append(round(mem_factor * 0.5, 3))
+
         # Compute composite risk score
         risk_score = sum(risk_factors) / max(1, len(risk_factors)) if risk_factors else 0.0
         risk_score = min(1.0, risk_score)
@@ -1482,6 +1613,18 @@ class OperationAdvisor:
             decision = AdvisoryDecision.BLOCK
             reasons.append("BLOCKED: Zero test coverage + extreme blast radius")
 
+        # Adaptive Armor (Proactive Advisory Plane): a highly-connected node with low coverage,
+        # mutated under HIGH/CRITICAL host memory pressure, is the worst-case fragility compound —
+        # escalate to at least CAUTION (BLOCK when coverage is zero). Reversible via the axis flags.
+        if (not is_read_only and blast_radius >= 10 and test_coverage < 0.5
+                and mem_level in ("high", "critical")):
+            if test_coverage <= 0.0 and decision != AdvisoryDecision.BLOCK:
+                decision = AdvisoryDecision.BLOCK
+                reasons.append("BLOCKED (Adaptive Armor): high blast + zero coverage + memory pressure")
+            elif decision in (AdvisoryDecision.RECOMMEND,):
+                decision = AdvisoryDecision.CAUTION
+                reasons.append("CAUTION (Adaptive Armor): high blast + low coverage + memory pressure")
+
         # Observability: surface the bypass as a positive reason so the
         # log line and prompt-context both show WHY a high-blast op passed.
         if is_read_only:
@@ -1490,6 +1633,16 @@ class OperationAdvisor:
                 f"Read-only op: blast_radius={blast_radius}, "
                 f"coverage={test_coverage:.0%} bypassed (no-mutation contract)",
             )
+
+        # Phase 3: autonomous prerequisite safety plan — on CAUTION/ADVISE_AGAINST/BLOCK the advisor
+        # does not flat-exit; it generates concrete de-risk prerequisites (characterization test /
+        # forensic branch) to run BEFORE the feature mutation. Fail-soft + reversible.
+        safety_plan: List[str] = []
+        if (_advisor_safety_plan_enabled() and not is_read_only
+                and decision in (AdvisoryDecision.CAUTION, AdvisoryDecision.ADVISE_AGAINST,
+                                 AdvisoryDecision.BLOCK)):
+            safety_plan = build_safety_plan(decision, blast_radius, test_coverage,
+                                            target_files, hotspots)
 
         # Build voice message
         voice = self._build_voice_message(decision, reasons, target_files)
@@ -1502,6 +1655,9 @@ class OperationAdvisor:
             chronic_entropy=chronic_entropy,
             risk_score=round(risk_score, 3),
             voice_message=voice,
+            git_volatility=git_volatility,
+            memory_pressure=mem_level,
+            safety_plan=safety_plan,
         )
 
         logger.info(
@@ -1533,6 +1689,10 @@ class OperationAdvisor:
             lines.append(
                 "\nBe careful with these files. Check for side effects."
             )
+        # Phase 3: surface the prerequisite safety plan (de-risk steps) into the prompt context.
+        plan = advisory.render_safety_plan()
+        if plan:
+            lines.append("\n" + plan)
         return "\n".join(lines)
 
     # ------------------------------------------------------------------

--- a/tests/governance/test_operation_advisor_fragility.py
+++ b/tests/governance/test_operation_advisor_fragility.py
@@ -1,0 +1,114 @@
+"""Tests for the Proactive Advisory Plane extensions to OperationAdvisor.
+
+Covers the three additions (git-volatility axis, memory-headroom axis, Phase-3 safety plan):
+1. compute_git_volatility — churn hot-spot scoring + normalization + fail-soft.
+2. memory_headroom_factor — MemoryPressureGate level → risk factor + fail-soft.
+3. build_safety_plan — prerequisite de-risk steps for CAUTION/BLOCK.
+4. Advisory.render_safety_plan — prompt clause.
+5. axis flag gates (default-ON + kill-switch).
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.operation_advisor import (
+    Advisory,
+    AdvisoryDecision,
+    _advisor_git_volatility_enabled,
+    _advisor_memory_axis_enabled,
+    _advisor_safety_plan_enabled,
+    build_safety_plan,
+    compute_git_volatility,
+    memory_headroom_factor,
+)
+
+
+# --------------------------------------------------------------------------- git volatility
+class TestGitVolatility:
+    def test_hotspot_scores_high(self) -> None:
+        score, hot = compute_git_volatility(
+            ("a.py", "b.py"), ".", runner=lambda f: 40 if f == "a.py" else 1)
+        assert score == 1.0          # 40 commits >> hotspot threshold (20) → clamped 1.0
+        assert "a.py(40)" in hot
+
+    def test_low_churn_low_score(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_ADVISOR_CHURN_HOTSPOT_COMMITS", "20")
+        score, hot = compute_git_volatility(("a.py",), ".", runner=lambda f: 5)
+        assert 0.0 < score < 0.5 and hot == []
+
+    def test_no_churn_zero(self) -> None:
+        score, hot = compute_git_volatility(("a.py",), ".", runner=lambda f: 0)
+        assert score == 0.0 and hot == []
+
+    def test_runner_failure_failsoft(self) -> None:
+        def _boom(f):
+            raise RuntimeError("git missing")
+        score, hot = compute_git_volatility(("a.py",), ".", runner=_boom)
+        assert score == 0.0 and hot == []
+
+
+# --------------------------------------------------------------------------- memory axis
+class TestMemoryHeadroom:
+    @pytest.mark.parametrize("level,factor", [("ok", 0.0), ("warn", 0.3), ("high", 0.6), ("critical", 0.9)])
+    def test_levels(self, level: str, factor: float) -> None:
+        class _G:
+            def pressure(self):  # noqa: ANN201
+                return type("L", (), {"value": level})()
+        f, lv = memory_headroom_factor(gate=_G())
+        assert f == factor and lv == level
+
+    def test_failsoft(self) -> None:
+        class _Boom:
+            def pressure(self):  # noqa: ANN201
+                raise RuntimeError("no gate")
+        assert memory_headroom_factor(gate=_Boom()) == (0.0, "ok")
+
+
+# --------------------------------------------------------------------------- safety plan
+class TestSafetyPlan:
+    def test_zero_coverage_adds_characterization_test(self) -> None:
+        plan = build_safety_plan(AdvisoryDecision.CAUTION, 5, 0.0, ("x.py",), [])
+        assert any("characterization test" in s for s in plan)
+
+    def test_high_blast_adds_forensic_branch(self) -> None:
+        plan = build_safety_plan(AdvisoryDecision.CAUTION, 25, 0.8, ("x.py",), [])
+        assert any("forensic branch" in s for s in plan)
+
+    def test_hotspot_adds_suite_step(self) -> None:
+        plan = build_safety_plan(AdvisoryDecision.CAUTION, 3, 0.8, ("x.py",), ["x.py(40)"])
+        assert any("hot-spot" in s for s in plan)
+
+    def test_block_always_has_a_step(self) -> None:
+        plan = build_safety_plan(AdvisoryDecision.BLOCK, 1, 1.0, ("x.py",), [])
+        assert len(plan) >= 1
+
+    def test_render_clause(self) -> None:
+        adv = Advisory(decision=AdvisoryDecision.BLOCK, reasons=[], blast_radius=25,
+                       test_coverage=0.0, chronic_entropy=0.0, risk_score=0.9,
+                       safety_plan=["step one", "step two"])
+        out = adv.render_safety_plan()
+        assert "PREREQUISITE SAFETY PLAN" in out and "step one" in out and "step two" in out
+
+    def test_render_empty_when_no_plan(self) -> None:
+        adv = Advisory(decision=AdvisoryDecision.RECOMMEND, reasons=[], blast_radius=0,
+                       test_coverage=1.0, chronic_entropy=0.0, risk_score=0.0)
+        assert adv.render_safety_plan() == ""
+
+
+# --------------------------------------------------------------------------- flag gates
+class TestAxisFlags:
+    def test_defaults_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for v in ("JARVIS_ADVISOR_GIT_VOLATILITY_ENABLED", "JARVIS_ADVISOR_MEMORY_AXIS_ENABLED",
+                  "JARVIS_ADVISOR_SAFETY_PLAN_ENABLED"):
+            monkeypatch.delenv(v, raising=False)
+        assert _advisor_git_volatility_enabled() is True
+        assert _advisor_memory_axis_enabled() is True
+        assert _advisor_safety_plan_enabled() is True
+
+    def test_kill_switch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for v in ("JARVIS_ADVISOR_GIT_VOLATILITY_ENABLED", "JARVIS_ADVISOR_MEMORY_AXIS_ENABLED",
+                  "JARVIS_ADVISOR_SAFETY_PLAN_ENABLED"):
+            monkeypatch.setenv(v, "false")
+        assert _advisor_git_volatility_enabled() is False
+        assert _advisor_memory_axis_enabled() is False
+        assert _advisor_safety_plan_enabled() is False


### PR DESCRIPTION
## Summary

`OperationAdvisor` already exists and is wired pre-CLASSIFY (Oracle-graph blast radius, test coverage, chronic entropy, time/staleness/size signals → composite `risk_score` → RECOMMEND/CAUTION/ADVISE_AGAINST/BLOCK, dedicated executor, worktree-aware). This **extends** it (no duplication) with the three axes the proactive plane was missing.

## Phase 1 — Multi-axis fragility vectorization (new axes feed the existing composite score)
- **Git Volatility Telemetry** (`compute_git_volatility`): commit churn over a window → hot-spot score; frequently-changing targets are riskier to mutate. Injectable runner, fail-soft.
- **System Resource Headroom** (`memory_headroom_factor`): `MemoryPressureGate` level → risk factor `{ok:0, warn:.3, high:.6, critical:.9}`. Fail-soft.

Both join `blast_radius`/`coverage`/`entropy`/… as **Signals 7 & 8** in the existing composite `risk_score`.

## Phase 2 — Adaptive Armor
A highly-connected node (`blast≥10`) with low coverage (`<0.5`) **under HIGH/CRITICAL host memory pressure** escalates to **CAUTION** (and **BLOCK** when coverage is zero) — the worst-case fragility compound, exactly as specified.

## Phase 3 — Prerequisite Safety Plan (no flat exit)
On CAUTION/ADVISE_AGAINST/BLOCK the advisor **generates concrete de-risk prerequisites** (`build_safety_plan`): a characterization test for zero-coverage targets, an isolated forensic branch for high blast radius, run-suite-first for churn hot-spots. Surfaced into the generation prompt via the **existing** `format_for_prompt()` path (`Advisory.render_safety_plan()`).

## Design discipline
- **No duplication** — extends the shipped advisor + reuses `MemoryPressureGate` + the existing prompt-injection path; additive `Advisory` fields (defaults preserve all existing constructions).
- **Gated default-ON + kill-switches** — `JARVIS_ADVISOR_{GIT_VOLATILITY,MEMORY_AXIS,SAFETY_PLAN}_ENABLED`.
- **Fail-soft** everywhere (git/gate errors → neutral).

## Test Plan
- [x] 17 new tests — git-volatility (hotspot/low/zero/failsoft), memory axis (4 levels + failsoft), safety plan (characterization/forensic/hotspot/block/render/empty), flag gates (default-ON + kill-switch).
- [x] 129 advisor-suite tests green.
- [x] Note: 3 pre-existing `test_operation_advisor_worktree_aware` AST-pin failures are unrelated drift (origin/main uses `guard_envelope_repo_root`; the test pins the old `resolve_` name) — I only touched `operation_advisor.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends `OperationAdvisor` with a proactive plane: adds git volatility and memory headroom axes to the risk score, and generates a prerequisite safety plan for risky operations to reduce fragility.

- **New Features**
  - Git volatility telemetry: churn score for target files, flags hot-spots; feeds the composite risk score (fail-soft, injectable runner).
  - Memory headroom axis: `MemoryPressureGate` levels map to risk factors (`ok` 0.0, `warn` 0.3, `high` 0.6, `critical` 0.9); affects scoring (fail-soft).
  - Adaptive Armor: when blast radius ≥10 and coverage <0.5 under `high`/`critical` memory pressure, escalate to CAUTION (or BLOCK if coverage is 0).
  - Safety plan on CAUTION/ADVISE_AGAINST/BLOCK: concrete steps (e.g., characterization test, forensic branch, run suite for hot-spots); surfaced via `format_for_prompt()` using `Advisory.render_safety_plan()`.
  - `Advisory` adds `git_volatility`, `memory_pressure`, `safety_plan` (defaults preserve compatibility).

- **Migration**
  - Default-ON flags: `JARVIS_ADVISOR_GIT_VOLATILITY_ENABLED`, `JARVIS_ADVISOR_MEMORY_AXIS_ENABLED`, `JARVIS_ADVISOR_SAFETY_PLAN_ENABLED` (set to `false` to disable).
  - No caller changes required.

<sup>Written for commit 7755a422460560dc370ea7ccc873891b0b234af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

