### PR TITLE
feat(self-evolve): RepairTrajectoryEmitter + Pre-Flight Critic — DW-stability self-correction loop

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -10558,9 +10558,10 @@ class GovernedOrchestrator:
             # (JARVIS_REPAIR_TRAJECTORY_EMIT_ENABLED, default OFF), fail-soft — never affects APPLY.
             try:
                 from backend.core.ouroboros.governance.repair_trajectory_emitter import (
-                    RepairTrajectoryEmitter, emitter_enabled,
+                    RepairTrajectoryEmitter, emitter_enabled, critic_learn_enabled,
                 )
-                if emitter_enabled():
+                if emitter_enabled() or critic_learn_enabled():
+                    # emit() routes: feed the local M1 online critic (learn) and/or stream to Reactor.
                     RepairTrajectoryEmitter().emit(ctx, l2_result)
             except Exception:  # noqa: BLE001 — emission must never break the pipeline
                 logger.debug("[Orchestrator] repair-trajectory emit skipped", exc_info=True)

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -10552,6 +10552,19 @@ class GovernedOrchestrator:
             return ("fatal", ctx)
 
         if l2_result.terminal == "L2_CONVERGED" and l2_result.candidate is not None:
+            # Self-Correction & DPO Alignment Engine (Phase 1): emit the converged repair as a
+            # provider-labeled DPO trajectory (rejected=failing candidate, chosen=converged fix) to
+            # Reactor-Core for DW-stability training. Fire-and-forget, gated
+            # (JARVIS_REPAIR_TRAJECTORY_EMIT_ENABLED, default OFF), fail-soft — never affects APPLY.
+            try:
+                from backend.core.ouroboros.governance.repair_trajectory_emitter import (
+                    RepairTrajectoryEmitter, emitter_enabled,
+                )
+                if emitter_enabled():
+                    RepairTrajectoryEmitter().emit(ctx, l2_result)
+            except Exception:  # noqa: BLE001 — emission must never break the pipeline
+                logger.debug("[Orchestrator] repair-trajectory emit skipped", exc_info=True)
+
             # Post-L2 canonical validation is architecturally broken for
             # Python candidates: test_runner.PythonAdapter.run hard-codes
             # sandbox_dir=None (see its docstring at run() line 228-237) so

--- a/backend/core/ouroboros/governance/preflight_critic.py
+++ b/backend/core/ouroboros/governance/preflight_critic.py
@@ -1,0 +1,151 @@
+"""Pre-Flight Critic — Phases 2-3 of the Self-Correction & DPO Alignment Engine.
+
+A cheap local quality gate on a generated patch candidate BEFORE the expensive paths run — the heavy
+sandbox test suite AND (critically) the frontier-model cascade. Targets the DoubleWord stability
+problem directly: DW is the cheap primary provider but produces structurally-unreliable output
+(malformed JSON, non-diff, schema drift); a local critic that predicts "this DW candidate will fail"
+lets O+V catch it early and regenerate, instead of cascading to Claude (which costs money — and just
+hit a zero-credit wall in the live soak).
+
+Phase 2 — Predictive Failure Probability: ``predict_failure(candidate, context)`` calls the
+fine-tuned local model served by Reactor-Core (Llama-3.2-3B) → a 0-1 failure probability.
+
+Phase 3 — Stochastic gating + policy feedback: if the failure probability crosses the threshold,
+``evaluate()`` short-circuits — bypass the sandbox, convert the critic's inference into a prompt
+constraint clause, and signal "route back to generation" for an instant targeted correction.
+
+**Model-collapse / confirmation-bias armor:** the critic is ADVISORY pressure, not ground truth. A
+sampling floor (``JARVIS_PREFLIGHT_CRITIC_SAMPLE_RATE``) always lets some candidates through to the
+real sandbox regardless of the critic's verdict, so the empirical test signal keeps flowing and the
+loop can never collapse into trusting the critic blindly.
+
+**Honest status:** this is the CONSUMER of the training loop. It is **inert until a critic model is
+actually trained (by the RepairTrajectoryEmitter → Reactor pipeline) and served** — with no model,
+``predict_failure`` returns ``None`` and ``evaluate`` never short-circuits (the system behaves exactly
+as today). Gated ``JARVIS_PREFLIGHT_CRITIC_ENABLED`` (default OFF). Fail-soft throughout.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["PreflightCritic", "CriticVerdict", "critic_enabled"]
+
+
+def critic_enabled() -> bool:
+    """``JARVIS_PREFLIGHT_CRITIC_ENABLED`` (default OFF) — master for the local pre-flight critic."""
+    return os.environ.get("JARVIS_PREFLIGHT_CRITIC_ENABLED", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _fail_threshold() -> float:
+    """``JARVIS_PREFLIGHT_CRITIC_FAIL_THRESHOLD`` (default 0.85) — predicted-failure prob above which
+    the candidate is short-circuited back to generation."""
+    try:
+        return min(1.0, max(0.0, float(os.environ.get("JARVIS_PREFLIGHT_CRITIC_FAIL_THRESHOLD", "0.85"))))
+    except ValueError:
+        return 0.85
+
+
+def _sample_rate() -> float:
+    """``JARVIS_PREFLIGHT_CRITIC_SAMPLE_RATE`` (default 0.1) — fraction of candidates that ALWAYS go to
+    the real sandbox regardless of the critic, keeping the empirical signal alive (anti-collapse)."""
+    try:
+        return min(1.0, max(0.0, float(os.environ.get("JARVIS_PREFLIGHT_CRITIC_SAMPLE_RATE", "0.1"))))
+    except ValueError:
+        return 0.1
+
+
+@dataclass
+class CriticVerdict:
+    """The critic's pre-flight judgment on a candidate."""
+    failure_probability: Optional[float]   # None → critic unavailable / inert
+    short_circuit: bool                    # True → skip sandbox, route back to generation
+    constraint_clause: str = ""            # prompt constraint injected on short-circuit
+    reason: str = ""
+
+
+class PreflightCritic:
+    """Local pre-flight critic gate. Injectable inference fn (production = Reactor model_server)."""
+
+    def __init__(self, infer: Any = None, *, sampler: Any = None) -> None:
+        # infer: async callable(candidate_source, context) -> Optional[float] (failure prob)
+        self._infer = infer
+        # sampler: callable() -> float in [0,1) for the anti-collapse always-sandbox draw
+        self._sampler = sampler
+
+    async def predict_failure(self, candidate_source: str, context: str = "") -> Optional[float]:
+        """Phase 2: predicted failure probability for *candidate_source*. None when no critic model is
+        available (inert). Fail-soft."""
+        if not candidate_source:
+            return None
+        infer = self._infer
+        if infer is None:
+            infer = await self._resolve_reactor_infer()
+        if infer is None:
+            return None  # no served critic model yet → inert
+        try:
+            import asyncio
+            res = infer(candidate_source, context)
+            prob = await res if asyncio.iscoroutine(res) else res
+            if prob is None:
+                return None
+            return min(1.0, max(0.0, float(prob)))
+        except Exception as exc:  # noqa: BLE001 — critic is advisory; never break the loop
+            logger.debug("[PreflightCritic] inference failed (non-fatal): %s", exc)
+            return None
+
+    async def _resolve_reactor_infer(self) -> Any:
+        """Resolve the Reactor-served critic inference callable. Returns None when unavailable —
+        which is the expected state until a critic model has been trained + served (honest inert)."""
+        try:
+            from backend.clients.reactor_core_client import ReactorCoreClient, ReactorCoreConfig
+            client = ReactorCoreClient(ReactorCoreConfig())
+            critic_infer = getattr(client, "critic_infer", None)  # not present until model is served
+            if critic_infer is None:
+                return None
+            self._infer = critic_infer
+            return critic_infer
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def evaluate(self, candidate_source: str, context: str = "") -> CriticVerdict:
+        """Phase 3: predict + gate. Short-circuits (skip sandbox → regenerate) only when the critic is
+        confident the candidate will fail AND this candidate wasn't drawn into the anti-collapse
+        always-sandbox sample. Inert (never short-circuits) when disabled / no model."""
+        if not critic_enabled():
+            return CriticVerdict(failure_probability=None, short_circuit=False, reason="disabled")
+        prob = await self.predict_failure(candidate_source, context)
+        if prob is None:
+            return CriticVerdict(failure_probability=None, short_circuit=False, reason="no_critic_model")
+        if prob < _fail_threshold():
+            return CriticVerdict(failure_probability=prob, short_circuit=False,
+                                 reason=f"below_threshold({prob:.2f})")
+        # Anti-collapse: always let a sampled fraction reach the real sandbox even if the critic
+        # predicts failure — preserves the empirical signal that would retrain/calibrate the critic.
+        draw = self._sampler() if self._sampler is not None else _deterministic_draw(candidate_source)
+        if draw < _sample_rate():
+            return CriticVerdict(failure_probability=prob, short_circuit=False,
+                                 reason=f"anti_collapse_sampled({prob:.2f})")
+        clause = (
+            "## PRE-FLIGHT CRITIC CONSTRAINT\n"
+            f"A local critic predicts this candidate is very likely to FAIL validation "
+            f"(p_fail={prob:.0%}). Do NOT resubmit it as-is. Reconsider the approach — common "
+            "structural failure modes to avoid: malformed/incomplete output, wrong response schema "
+            "(emit a valid 2b.1-diff), and breaking the failing test's contract. Produce a "
+            "materially different candidate."
+        )
+        return CriticVerdict(failure_probability=prob, short_circuit=True, constraint_clause=clause,
+                             reason=f"short_circuit(p_fail={prob:.2f})")
+
+
+def _deterministic_draw(s: str) -> float:
+    """Deterministic [0,1) draw from the candidate text (no RNG — auditable, reproducible)."""
+    import hashlib
+    h = hashlib.sha256(s.encode("utf-8", errors="replace")).hexdigest()
+    return (int(h[:8], 16) % 10000) / 10000.0

--- a/backend/core/ouroboros/governance/preflight_critic.py
+++ b/backend/core/ouroboros/governance/preflight_critic.py
@@ -101,16 +101,17 @@ class PreflightCritic:
             return None
 
     async def _resolve_reactor_infer(self) -> Any:
-        """Resolve the Reactor-served critic inference callable. Returns None when unavailable —
-        which is the expected state until a critic model has been trained + served (honest inert)."""
+        """Resolve the inference callable. Default = the M1-native OnlineTopologicalCritic (on-device,
+        no CUDA/cloud). It is meaningful only once it has learned from real trajectories; an untrained
+        critic returns ``None`` (inert) so the gate never acts on noise. Fail-soft."""
         try:
-            from backend.clients.reactor_core_client import ReactorCoreClient, ReactorCoreConfig
-            client = ReactorCoreClient(ReactorCoreConfig())
-            critic_infer = getattr(client, "critic_infer", None)  # not present until model is served
-            if critic_infer is None:
-                return None
-            self._infer = critic_infer
-            return critic_infer
+            critic = get_default_critic()
+            if not critic.is_warm():
+                return None  # not enough learned signal yet → inert (never gate on a cold model)
+            def _infer(src: str, ctx: str = "") -> Optional[float]:
+                return critic.predict_failure(src, file_path="", graph=None)
+            self._infer = _infer
+            return _infer
         except Exception:  # noqa: BLE001
             return None
 
@@ -149,3 +150,218 @@ def _deterministic_draw(s: str) -> float:
     import hashlib
     h = hashlib.sha256(s.encode("utf-8", errors="replace")).hexdigest()
     return (int(h[:8], 16) % 10000) / 10000.0
+
+
+# ===========================================================================
+# M1-Native Online Topological Critic (on-device, ONNX/Metal + numpy SGD)
+# ===========================================================================
+# Replaces the CUDA 3B-LoRA dependency with a lightweight, hardware-native engine that trains AND
+# infers on the M1 in milliseconds: a multi-modal Structural-Semantic Risk Tensor (local fastembed
+# code vector ⊕ graph-topology metrics) fed to an online logistic head updated per trajectory via
+# prequential (test-then-train) SGD. No heavy daemons, no unified-memory blowup.
+
+_HASH_DIM = 256  # zero-dependency hashing featurizer width (used when fastembed is unavailable)
+
+
+def _hashing_features(text: str, dim: int = _HASH_DIM) -> "Any":
+    """Deterministic hashing-trick token vector — instant, zero-dep, always-works M1 baseline."""
+    import numpy as np
+    import re
+    vec = np.zeros(dim, dtype=np.float32)
+    for tok in re.findall(r"[A-Za-z_][A-Za-z0-9_]*|[^\sA-Za-z0-9]", text)[:4000]:
+        vec[hash(tok) % dim] += 1.0
+    n = float(np.linalg.norm(vec))
+    return vec / n if n > 0 else vec
+
+
+def _semantic_features(text: str) -> "Any":
+    """Local fastembed (ONNX-CoreML bge-small) code vector; None if unavailable (→ hashing fallback)."""
+    try:
+        from backend.core.ouroboros.governance.semantic_index import _embedder_factory  # type: ignore
+        emb = _embedder_factory()
+        vecs = emb.embed([text[:8000]]) if emb is not None else None
+        if vecs:
+            import numpy as np
+            return np.asarray(vecs[0], dtype=np.float32)
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def _topology_features(file_path: str, graph: Any) -> "Any":
+    """Structural graph-topology metrics for the target file: local degree (in/out — a cheap, honest
+    proxy for centrality; full betweenness over ~29k nodes per-op is impractical) + blast-radius depth.
+    log-scaled; zeros when unavailable. Fail-soft."""
+    import numpy as np
+    feats = np.zeros(4, dtype=np.float32)
+    if graph is None or not file_path:
+        return feats
+    try:
+        nodes = graph.find_nodes_in_file(file_path) or []
+        in_deg = out_deg = blast = 0
+        for n in nodes[:8]:
+            try:
+                out_deg += len(graph.get_dependencies(n) or [])
+                in_deg += len(graph.get_dependents(n) or [])
+                b = graph.compute_blast_radius(n)
+                blast += len(getattr(b, "transitively_affected", set()) or set())
+            except Exception:  # noqa: BLE001
+                continue
+        feats[0] = np.log1p(in_deg)
+        feats[1] = np.log1p(out_deg)
+        feats[2] = np.log1p(blast)
+        feats[3] = np.log1p(len(nodes))
+    except Exception:  # noqa: BLE001
+        pass
+    return feats
+
+
+def featurize(candidate_source: str, file_path: str = "", graph: Any = None) -> "Any":
+    """Compile the multi-modal Structural-Semantic Risk Tensor: code vector ⊕ topology metrics ⊕ bias."""
+    import numpy as np
+    sem = _semantic_features(candidate_source)
+    code_vec = sem if sem is not None else _hashing_features(candidate_source)
+    topo = _topology_features(file_path, graph)
+    return np.concatenate([code_vec, topo, np.ones(1, dtype=np.float32)])
+
+
+class OnlineTopologicalCritic:
+    """Online logistic critic (numpy SGD) over the Structural-Semantic Risk Tensor. Prequential
+    test-then-train: each sample is first PREDICTED (for an honest running accuracy) then learned —
+    in milliseconds, on the M1, no offline daemon. Persists weights to ``.jarvis/preflight_critic.npz``."""
+
+    def __init__(self, *, lr: float = 0.05, l2: float = 1e-4, path: Optional[str] = None) -> None:
+        self._lr = lr
+        self._l2 = l2
+        self._w = None            # lazily sized to the feature dim on first sample
+        self._n = 0               # real samples learned
+        self._correct = 0         # prequential correct predictions
+        self._recent: list = []   # rolling window of recent correctness (for windowed accuracy)
+        self._path = path or os.path.join(
+            os.environ.get("JARVIS_HOME", os.path.join(os.path.expanduser("~"), ".jarvis")),
+            "preflight_critic.npz",
+        )
+        self._load()
+
+    # ---- model ----
+    @staticmethod
+    def _sigmoid(z: float) -> float:
+        import math
+        if z < -60:
+            return 0.0
+        if z > 60:
+            return 1.0
+        return 1.0 / (1.0 + math.exp(-z))
+
+    def _ensure(self, dim: int) -> None:
+        import numpy as np
+        if self._w is None:
+            self._w = np.zeros(dim, dtype=np.float32)
+
+    def predict_failure(self, candidate_source: str, file_path: str = "", graph: Any = None) -> Optional[float]:
+        """p(fail) for a candidate. None if the model is cold (no learned signal)."""
+        if self._w is None or self._n == 0:
+            return None
+        import numpy as np
+        x = featurize(candidate_source, file_path, graph)
+        if x.shape[0] != self._w.shape[0]:
+            return None  # feature dim changed (embedder swapped) → treat as cold
+        return float(self._sigmoid(float(np.dot(self._w, x))))
+
+    def _update(self, x: "Any", y: int) -> None:
+        import numpy as np
+        self._ensure(x.shape[0])
+        w = self._w
+        if w is None or x.shape[0] != w.shape[0]:
+            return
+        p = self._sigmoid(float(np.dot(w, x)))
+        # prequential: score BEFORE the update
+        pred = 1 if p >= 0.5 else 0
+        ok = int(pred == y)
+        self._correct += ok
+        self._recent.append(ok)
+        if len(self._recent) > 200:
+            self._recent.pop(0)
+        self._n += 1
+        self._w = w - self._lr * ((p - y) * x + self._l2 * w)
+
+    def learn_pair(self, rejected_source: str, chosen_source: str,
+                   file_path: str = "", graph: Any = None) -> None:
+        """Learn one DPO pair: rejected → fail(1), chosen → pass(0). The core online step."""
+        if rejected_source:
+            self._update(featurize(rejected_source, file_path, graph), 1)
+        if chosen_source:
+            self._update(featurize(chosen_source, file_path, graph), 0)
+        self._save()
+
+    # ---- status / graduation ----
+    def samples(self) -> int:
+        return self._n
+
+    def windowed_accuracy(self) -> float:
+        return (sum(self._recent) / len(self._recent)) if self._recent else 0.0
+
+    def is_warm(self) -> bool:
+        """Enough learned signal to be worth consulting at all (not graduation — just non-cold)."""
+        try:
+            floor = int(os.environ.get("JARVIS_PREFLIGHT_CRITIC_WARM_SAMPLES", "40"))
+        except ValueError:
+            floor = 40
+        return self._n >= floor
+
+    def is_graduation_ready(self) -> bool:
+        """Honest auto-graduation bar: enough REAL samples AND a prequential accuracy above threshold.
+        A synthetic suite can prove the MECHANISM, but gating production requires real accumulated
+        accuracy — so a cold/undertrained critic never auto-enables."""
+        try:
+            min_n = int(os.environ.get("JARVIS_PREFLIGHT_CRITIC_GRAD_SAMPLES", "200"))
+            min_acc = float(os.environ.get("JARVIS_PREFLIGHT_CRITIC_GRAD_ACCURACY", "0.8"))
+        except ValueError:
+            min_n, min_acc = 200, 0.8
+        return self._n >= min_n and self.windowed_accuracy() >= min_acc
+
+    # ---- persistence ----
+    def _save(self) -> None:
+        try:
+            import numpy as np
+            if self._w is None:
+                return
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
+            np.savez(self._path, w=self._w, n=np.array([self._n]),
+                     correct=np.array([self._correct]), recent=np.array(self._recent, dtype=np.int8))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[OnlineCritic] save failed (non-fatal): %s", exc)
+
+    def _load(self) -> None:
+        try:
+            import numpy as np
+            if not os.path.isfile(self._path):
+                return
+            d = np.load(self._path, allow_pickle=False)
+            self._w = d["w"].astype(np.float32)
+            self._n = int(d["n"][0])
+            self._correct = int(d["correct"][0])
+            self._recent = list(int(x) for x in d.get("recent", np.array([], dtype=np.int8)))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[OnlineCritic] load failed (non-fatal): %s", exc)
+
+    # ---- async offload (Metal/CPU executor ring — zero latency on the control bus) ----
+    async def alearn_pair(self, rejected_source: str, chosen_source: str,
+                          file_path: str = "", graph: Any = None) -> None:
+        import asyncio
+        await asyncio.to_thread(self.learn_pair, rejected_source, chosen_source, file_path, graph)
+
+    async def apredict_failure(self, candidate_source: str, file_path: str = "", graph: Any = None):
+        import asyncio
+        return await asyncio.to_thread(self.predict_failure, candidate_source, file_path, graph)
+
+
+_DEFAULT_CRITIC: Optional[OnlineTopologicalCritic] = None
+
+
+def get_default_critic() -> OnlineTopologicalCritic:
+    """Process-wide singleton (shared by the gate + the trajectory emitter; persistent on disk)."""
+    global _DEFAULT_CRITIC
+    if _DEFAULT_CRITIC is None:
+        _DEFAULT_CRITIC = OnlineTopologicalCritic()
+    return _DEFAULT_CRITIC

--- a/backend/core/ouroboros/governance/repair_trajectory_emitter.py
+++ b/backend/core/ouroboros/governance/repair_trajectory_emitter.py
@@ -29,8 +29,17 @@ __all__ = ["RepairTrajectoryEmitter", "emitter_enabled", "build_dpo_trajectory"]
 
 def emitter_enabled() -> bool:
     """``JARVIS_REPAIR_TRAJECTORY_EMIT_ENABLED`` (default OFF) — opt-in; streams trajectory data to
-    Reactor-Core. OFF → no-op (the repair loop is byte-identical)."""
+    Reactor-Core. OFF → no remote stream (the repair loop is byte-identical)."""
     return os.environ.get("JARVIS_REPAIR_TRAJECTORY_EMIT_ENABLED", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def critic_learn_enabled() -> bool:
+    """``JARVIS_PREFLIGHT_CRITIC_LEARN_ENABLED`` (default OFF) — feed converged trajectories to the
+    M1-native online critic so it ACCUMULATES on-device (decoupled from gating: learn first, then the
+    critic auto-graduates to gating once warm + accurate). Cheap + fail-soft."""
+    return os.environ.get("JARVIS_PREFLIGHT_CRITIC_LEARN_ENABLED", "false").strip().lower() in (
         "1", "true", "yes", "on",
     )
 
@@ -161,28 +170,62 @@ class RepairTrajectoryEmitter:
                         pass
                     break
 
-    def emit(self, ctx: Any, result: Any) -> bool:
-        """Build + fire-and-forget the trajectory. Returns True if a task was scheduled (not that it
-        succeeded). Gated + fail-soft; safe to call from the repair loop's terminal path."""
-        if not emitter_enabled():
-            return False
+    def _learn_local(self, event: Dict[str, Any]) -> None:
+        """Feed the converged trajectory to the M1-native online critic (on-device, milliseconds).
+        Offloaded to a thread (Metal/CPU executor ring) so the control bus sees zero latency."""
         try:
-            event = build_dpo_trajectory(ctx, result)
-            if event is None:
-                return False
+            from backend.core.ouroboros.governance.preflight_critic import get_default_critic
+            critic = get_default_critic()
+            rejected = event.get("original_response", "") or ""
+            chosen = event.get("corrected_response", "") or ""
+            file_path = (event.get("metadata", {}) or {}).get("file_path", "") or ""
+            graph = None
+            try:
+                from backend.core.ouroboros.oracle import get_oracle
+                graph = getattr(get_oracle(), "_graph", None)
+            except Exception:  # noqa: BLE001
+                graph = None
             import asyncio
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:
                 loop = None
             if loop is not None:
-                task = loop.create_task(self._send(event))
-                # strong ref so the fire-and-forget task isn't GC'd mid-flight
-                _PENDING.add(task)
-                task.add_done_callback(_PENDING.discard)
+                t = loop.create_task(critic.alearn_pair(rejected, chosen, file_path, graph))
+                _PENDING.add(t); t.add_done_callback(_PENDING.discard)
             else:
-                asyncio.run(self._send(event))
-            return True
+                critic.learn_pair(rejected, chosen, file_path, graph)
+        except Exception as exc:  # noqa: BLE001 — learning is best-effort
+            logger.debug("[TrajectoryEmitter] local critic learn skipped: %s", exc)
+
+    def emit(self, ctx: Any, result: Any) -> bool:
+        """Build the trajectory once, then route it: (a) feed the local M1 online critic if learning is
+        on, (b) fire-and-forget stream to Reactor-Core if remote emit is on. Gated + fail-soft; safe
+        from the repair loop's terminal path. Returns True if either path ran."""
+        if not (emitter_enabled() or critic_learn_enabled()):
+            return False
+        try:
+            event = build_dpo_trajectory(ctx, result)
+            if event is None:
+                return False
+            did = False
+            if critic_learn_enabled():
+                self._learn_local(event)
+                did = True
+            if emitter_enabled():
+                import asyncio
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    loop = None
+                if loop is not None:
+                    task = loop.create_task(self._send(event))
+                    _PENDING.add(task)
+                    task.add_done_callback(_PENDING.discard)
+                else:
+                    asyncio.run(self._send(event))
+                did = True
+            return did
         except Exception as exc:  # noqa: BLE001 — emission must never break L2
             logger.debug("[TrajectoryEmitter] emit skipped (non-fatal): %s", exc)
             return False

--- a/backend/core/ouroboros/governance/repair_trajectory_emitter.py
+++ b/backend/core/ouroboros/governance/repair_trajectory_emitter.py
@@ -1,0 +1,192 @@
+"""RepairTrajectoryEmitter — Phase 1 of the Self-Correction & DPO Alignment Engine.
+
+O+V's L2 self-repair loop produces the single richest training signal a coding agent can: a
+**preference pair** — the candidate that FAILED validation (rejected) and the converged, test-passing
+candidate that fixed it (chosen). This module serializes those trajectories and streams them to
+Reactor-Core's experience pipeline, where the DPO pair generator + LoRA trainer consume them.
+
+**Scoped to the DoubleWord stability goal:** each trajectory is labeled with its `provider` (the
+generator that produced the rejected candidate). DW is the cheap primary provider but less stable than
+Claude — DW-labeled `(failed → fixed)` pairs are exactly the data needed to train a local critic /
+stabilizer for DW's specific structural failure modes (malformed JSON, non-diff output, schema drift),
+so O+V can keep DW primary and avoid the expensive Claude fallback.
+
+Honest scope: this emits the *data*; Reactor-Core does the training; the critic (preflight_critic.py)
+is the consumer. Network I/O is fire-and-forget on a background task — never blocks the repair loop —
+and fail-soft (any error is swallowed). Gated ``JARVIS_REPAIR_TRAJECTORY_EMIT_ENABLED`` (default OFF —
+opt-in, since it ships data to an external service).
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["RepairTrajectoryEmitter", "emitter_enabled", "build_dpo_trajectory"]
+
+
+def emitter_enabled() -> bool:
+    """``JARVIS_REPAIR_TRAJECTORY_EMIT_ENABLED`` (default OFF) — opt-in; streams trajectory data to
+    Reactor-Core. OFF → no-op (the repair loop is byte-identical)."""
+    return os.environ.get("JARVIS_REPAIR_TRAJECTORY_EMIT_ENABLED", "false").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _content(candidate: Any) -> str:
+    """Best-effort full source of a candidate dict (full_content, else first multi-file entry)."""
+    if not isinstance(candidate, dict):
+        return ""
+    fc = candidate.get("full_content")
+    if isinstance(fc, str) and fc:
+        return fc
+    files = candidate.get("files")
+    if isinstance(files, list) and files and isinstance(files[0], dict):
+        return str(files[0].get("full_content", "") or "")
+    return ""
+
+
+def _provider_of(result: Any) -> str:
+    """Provider attribution for the trajectory — the generator behind the chosen fix. Prefers the
+    converged iteration's provider_name, falls back to the summary. '' if unknown."""
+    try:
+        iters = getattr(result, "iterations", ()) or ()
+        for rec in reversed(iters):
+            p = getattr(rec, "provider_name", "") or ""
+            if p:
+                return p
+        summary = getattr(result, "summary", {}) or {}
+        return str(summary.get("provider_name", "") or "")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def build_dpo_trajectory(ctx: Any, result: Any) -> Optional[Dict[str, Any]]:
+    """Pure: compile a converged L2 repair into a provider-labeled DPO/correction ExperienceEvent.
+
+    rejected = the candidate that failed validation and triggered L2 (``ctx.generation.candidates[0]``);
+    chosen = the converged, test-passing candidate (``result.candidate``). Returns ``None`` unless this
+    is a genuine converged pair with both code states present (no hollow/empty trajectories)."""
+    if getattr(result, "terminal", "") != "L2_CONVERGED":
+        return None
+    chosen = _content(getattr(result, "candidate", None))
+    rejected = ""
+    try:
+        gen = getattr(ctx, "generation", None)
+        cands = getattr(gen, "candidates", None) if gen is not None else None
+        if cands:
+            rejected = _content(cands[0])
+    except Exception:  # noqa: BLE001
+        rejected = ""
+    if not chosen or not rejected or chosen == rejected:
+        return None
+
+    provider = _provider_of(result)
+    iters = getattr(result, "iterations", ()) or ()
+    # DivergenceSignature metrics from the validation gates (structural failure fingerprints).
+    divergence_kinds: List[str] = []
+    for rec in iters:
+        fc = getattr(rec, "failure_class", "") or ""
+        if fc:
+            divergence_kinds.append(fc)
+
+    file_path = ""
+    cand = getattr(result, "candidate", None)
+    if isinstance(cand, dict):
+        file_path = str(cand.get("file_path", "") or "")
+
+    # Canonical ExperienceEvent (correction shape) — original/corrected map to DPO rejected/chosen.
+    return {
+        "event_type": "correction",
+        "source": "jarvis_body",
+        "task_type": "l2_repair",
+        "outcome": "success",
+        "model_id": provider or "unknown",
+        "provider": provider,                       # DW-stability labeling
+        "user_input": f"Repair the failing candidate for {file_path or 'the target'}.",
+        "assistant_output": chosen,
+        "original_response": rejected,              # DPO rejected
+        "corrected_response": chosen,               # DPO chosen
+        "metadata": {
+            "op_id": getattr(ctx, "op_id", ""),
+            "file_path": file_path,
+            "iterations": len(iters),
+            "divergence_kinds": divergence_kinds,
+            "stop_reason": getattr(result, "stop_reason", None),
+        },
+    }
+
+
+class RepairTrajectoryEmitter:
+    """Fire-and-forget emitter of converged L2 repair trajectories to Reactor-Core. Never blocks the
+    repair loop; fail-soft. Injectable client for tests."""
+
+    def __init__(self, client: Any = None) -> None:
+        self._client = client
+
+    def _get_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            from backend.clients.reactor_core_client import ReactorCoreClient, ReactorCoreConfig
+            self._client = ReactorCoreClient(ReactorCoreConfig())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[TrajectoryEmitter] reactor client unavailable: %s", exc)
+        return self._client
+
+    async def _send(self, event: Dict[str, Any]) -> bool:
+        client = self._get_client()
+        if client is None:
+            return False
+        try:
+            init = getattr(client, "initialize", None)
+            if init is not None:
+                await init()
+            ok = await client.stream_experience(event)
+            logger.info("[TrajectoryEmitter] streamed l2_repair DPO pair provider=%s ok=%s",
+                        event.get("provider", "?"), ok)
+            return bool(ok)
+        except Exception as exc:  # noqa: BLE001 — emission is best-effort
+            logger.debug("[TrajectoryEmitter] stream failed (non-fatal): %s", exc)
+            return False
+        finally:
+            for m in ("close", "disconnect"):
+                fn = getattr(client, m, None)
+                if fn is not None:
+                    try:
+                        await fn()
+                    except Exception:  # noqa: BLE001
+                        pass
+                    break
+
+    def emit(self, ctx: Any, result: Any) -> bool:
+        """Build + fire-and-forget the trajectory. Returns True if a task was scheduled (not that it
+        succeeded). Gated + fail-soft; safe to call from the repair loop's terminal path."""
+        if not emitter_enabled():
+            return False
+        try:
+            event = build_dpo_trajectory(ctx, result)
+            if event is None:
+                return False
+            import asyncio
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+            if loop is not None:
+                task = loop.create_task(self._send(event))
+                # strong ref so the fire-and-forget task isn't GC'd mid-flight
+                _PENDING.add(task)
+                task.add_done_callback(_PENDING.discard)
+            else:
+                asyncio.run(self._send(event))
+            return True
+        except Exception as exc:  # noqa: BLE001 — emission must never break L2
+            logger.debug("[TrajectoryEmitter] emit skipped (non-fatal): %s", exc)
+            return False
+
+
+# Strong refs for in-flight fire-and-forget tasks (no-GC).
+_PENDING: "set" = set()

--- a/tests/governance/test_self_correction_engine.py
+++ b/tests/governance/test_self_correction_engine.py
@@ -148,3 +148,68 @@ class TestPreflightCritic:
         c = PreflightCritic(infer=_boom)
         v = await c.evaluate("x")
         assert v.failure_probability is None and v.short_circuit is False
+
+
+# --------------------------------------------------------------------------- M1-native online critic
+def _critic(tmp_path):
+    from backend.core.ouroboros.governance.preflight_critic import OnlineTopologicalCritic
+    return OnlineTopologicalCritic(path=str(tmp_path / "critic.npz"))
+
+
+class TestOnlineTopologicalCritic:
+    def test_featurize_produces_vector(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_SEMANTIC_EMBEDDER", "stdlib")
+        from backend.core.ouroboros.governance.preflight_critic import featurize
+        v = featurize("def f(): return 1", file_path="m.py", graph=None)
+        assert v.shape[0] > 4  # code vector ⊕ 4 topology ⊕ bias
+
+    def test_cold_predict_is_none(self, tmp_path) -> None:
+        c = _critic(tmp_path)
+        assert c.predict_failure("def f(): pass") is None  # no learned signal
+
+    def test_online_learning_separates(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_SEMANTIC_EMBEDDER", "stdlib")
+        c = _critic(tmp_path)
+        for i in range(120):
+            c.learn_pair(f"def b{i}(:\n SYNTAX_ERROR_TOKEN\n", f"def g{i}():\n return {i}\n",
+                         file_path="m.py", graph=None)
+        assert c.samples() == 240 and c.is_warm() is True
+        assert c.windowed_accuracy() >= 0.8
+        pf = c.predict_failure("def x(:\n SYNTAX_ERROR_TOKEN\n")
+        pp = c.predict_failure("def y():\n return 1\n")
+        assert pf is not None and pp is not None and pf > pp  # broken scored riskier than clean
+
+    def test_graduation_gate_requires_samples(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_SEMANTIC_EMBEDDER", "stdlib")
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_GRAD_SAMPLES", "50")
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_GRAD_ACCURACY", "0.7")
+        c = _critic(tmp_path)
+        assert c.is_graduation_ready() is False  # cold
+        for i in range(40):
+            c.learn_pair(f"def b{i}(:\n ERR\n", f"def g{i}():\n return {i}\n")
+        assert c.is_graduation_ready() is True   # 80 samples ≥ 50, acc high
+
+    def test_persistence_round_trip(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_SEMANTIC_EMBEDDER", "stdlib")
+        path = str(tmp_path / "p.npz")
+        from backend.core.ouroboros.governance.preflight_critic import OnlineTopologicalCritic
+        c1 = OnlineTopologicalCritic(path=path)
+        for i in range(20):
+            c1.learn_pair(f"def b{i}(:\n ERR\n", f"def g{i}():\n return {i}\n")
+        n = c1.samples()
+        c2 = OnlineTopologicalCritic(path=path)  # reload from disk
+        assert c2.samples() == n and c2.predict_failure("def z(): return 1") is not None
+
+    def test_topology_failsoft_no_graph(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_SEMANTIC_EMBEDDER", "stdlib")
+        from backend.core.ouroboros.governance.preflight_critic import _topology_features
+        feats = _topology_features("m.py", None)
+        assert feats.shape[0] == 4 and float(feats.sum()) == 0.0
+
+    @pytest.mark.asyncio
+    async def test_async_learn_and_predict(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_SEMANTIC_EMBEDDER", "stdlib")
+        c = _critic(tmp_path)
+        for i in range(30):
+            await c.alearn_pair(f"def b{i}(:\n ERR\n", f"def g{i}():\n return {i}\n")
+        assert await c.apredict_failure("def y(): return 1") is not None

--- a/tests/governance/test_self_correction_engine.py
+++ b/tests/governance/test_self_correction_engine.py
@@ -1,0 +1,150 @@
+"""Tests for the Self-Correction & DPO Alignment Engine.
+
+Covers:
+- repair_trajectory_emitter: DPO-pair extraction from converged L2 repairs (provider-labeled),
+  gating, fire-and-forget streaming.
+- preflight_critic: predicted-failure probability, threshold short-circuit, anti-collapse sampling,
+  inert-when-no-model, gating.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, List, Optional
+
+import pytest
+
+from backend.core.ouroboros.governance.repair_trajectory_emitter import (
+    RepairTrajectoryEmitter,
+    build_dpo_trajectory,
+    emitter_enabled,
+)
+from backend.core.ouroboros.governance.preflight_critic import (
+    PreflightCritic,
+    critic_enabled,
+)
+
+
+# --------------------------------------------------------------------------- fixtures
+def _ctx(rejected: str = "def f():\n    return 0\n"):
+    gen = SimpleNamespace(candidates=[{"file_path": "m.py", "full_content": rejected}],
+                          model_id="doubleword-397b", provider_name="doubleword")
+    return SimpleNamespace(op_id="op1", generation=gen)
+
+
+def _result(terminal="L2_CONVERGED", chosen="def f():\n    return 1\n", provider="doubleword"):
+    rec = SimpleNamespace(provider_name=provider, failure_class="test")
+    return SimpleNamespace(
+        terminal=terminal,
+        candidate={"file_path": "m.py", "full_content": chosen} if chosen else None,
+        stop_reason=None, summary={"provider_name": provider}, iterations=(rec,),
+    )
+
+
+# --------------------------------------------------------------------------- emitter: build
+class TestBuildTrajectory:
+    def test_converged_pair(self) -> None:
+        ev = build_dpo_trajectory(_ctx(), _result())
+        assert ev is not None
+        assert ev["event_type"] == "correction" and ev["task_type"] == "l2_repair"
+        assert ev["provider"] == "doubleword"               # DW-stability labeling
+        assert ev["original_response"].endswith("return 0\n")  # rejected
+        assert ev["corrected_response"].endswith("return 1\n")  # chosen
+        assert "test" in ev["metadata"]["divergence_kinds"]
+
+    def test_not_converged_returns_none(self) -> None:
+        assert build_dpo_trajectory(_ctx(), _result(terminal="L2_STOPPED")) is None
+
+    def test_identical_states_returns_none(self) -> None:
+        same = "def f():\n    return 0\n"
+        assert build_dpo_trajectory(_ctx(rejected=same), _result(chosen=same)) is None
+
+    def test_missing_chosen_returns_none(self) -> None:
+        assert build_dpo_trajectory(_ctx(), _result(chosen="")) is None
+
+
+# --------------------------------------------------------------------------- emitter: gate + send
+class TestEmitter:
+    def test_default_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("JARVIS_REPAIR_TRAJECTORY_EMIT_ENABLED", raising=False)
+        assert emitter_enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_send_uses_client(self) -> None:
+        sent: List[Any] = []
+
+        class _Client:
+            async def initialize(self): return True
+            async def stream_experience(self, ev): sent.append(ev); return True
+            async def close(self): return None
+
+        em = RepairTrajectoryEmitter(client=_Client())
+        ev = build_dpo_trajectory(_ctx(), _result())
+        ok = await em._send(ev)
+        assert ok is True and len(sent) == 1 and sent[0]["provider"] == "doubleword"
+
+    @pytest.mark.asyncio
+    async def test_send_failsoft(self) -> None:
+        class _Boom:
+            async def initialize(self): return True
+            async def stream_experience(self, ev): raise RuntimeError("reactor down")
+            async def close(self): return None
+        em = RepairTrajectoryEmitter(client=_Boom())
+        assert await em._send({"x": 1}) is False  # no raise
+
+    @pytest.mark.asyncio
+    async def test_emit_disabled_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("JARVIS_REPAIR_TRAJECTORY_EMIT_ENABLED", raising=False)
+        em = RepairTrajectoryEmitter(client=object())
+        assert em.emit(_ctx(), _result()) is False
+
+
+# --------------------------------------------------------------------------- critic
+class TestPreflightCritic:
+    def test_default_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("JARVIS_PREFLIGHT_CRITIC_ENABLED", raising=False)
+        assert critic_enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_no_model_is_inert(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_ENABLED", "true")
+        c = PreflightCritic(infer=None)  # no served critic model
+        # _resolve_reactor_infer → None (no critic_infer attr) → inert
+        v = await c.evaluate("def f(): pass")
+        assert v.failure_probability is None and v.short_circuit is False
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_no_shortcircuit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_FAIL_THRESHOLD", "0.85")
+        c = PreflightCritic(infer=lambda src, ctx="": 0.2)
+        v = await c.evaluate("x")
+        assert v.short_circuit is False and v.failure_probability == 0.2
+
+    @pytest.mark.asyncio
+    async def test_above_threshold_shortcircuits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_FAIL_THRESHOLD", "0.85")
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_SAMPLE_RATE", "0.0")  # never sample → always gate
+        c = PreflightCritic(infer=lambda src, ctx="": 0.95)
+        v = await c.evaluate("x")
+        assert v.short_circuit is True
+        assert "PRE-FLIGHT CRITIC CONSTRAINT" in v.constraint_clause
+        assert "2b.1-diff" in v.constraint_clause  # DW structural-failure guidance
+
+    @pytest.mark.asyncio
+    async def test_anti_collapse_sampling_lets_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_FAIL_THRESHOLD", "0.5")
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_SAMPLE_RATE", "1.0")  # always sample → never gate
+        c = PreflightCritic(infer=lambda src, ctx="": 0.99, sampler=lambda: 0.0)
+        v = await c.evaluate("x")
+        assert v.short_circuit is False and "anti_collapse" in v.reason
+
+    @pytest.mark.asyncio
+    async def test_inference_failsoft(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("JARVIS_PREFLIGHT_CRITIC_ENABLED", "true")
+        def _boom(src, ctx=""):
+            raise RuntimeError("model error")
+        c = PreflightCritic(infer=_boom)
+        v = await c.evaluate("x")
+        assert v.failure_probability is None and v.short_circuit is False


### PR DESCRIPTION
## Summary

Scoped to the real goal you named: **make DoubleWord (the cheap PRIMARY provider) more reliable.** We can't retrain DW's hosted 397B — but DW's instability is **structural** (malformed JSON, non-diff output, schema drift), and that's exactly what a cheap local model + critic can *learn from* and *gate on*. So Reactor-Core's role isn't "make DW smarter," it's: learn DW's failure patterns + pre-screen DW's output before O+V wastes a cycle or cascades to Claude (which costs $ and just hit a zero-credit wall).

## Phase 1 — RepairTrajectoryEmitter (`repair_trajectory_emitter.py`)
O+V's L2 repair loop produces the richest training signal a coding agent can: a **preference pair** — the candidate that FAILED validation (rejected) and the converged, test-passing fix (chosen). `build_dpo_trajectory()` compiles each converged repair into a **provider-labeled** `ExperienceEvent` (correction shape: `original_response`=rejected, `corrected_response`=chosen, `provider`=DW/claude/…, + `DivergenceSignature` metrics) and streams it to Reactor-Core via the existing `reactor_core_client.stream_experience` primitive (**no duplication**). **Fire-and-forget** on a background task (strong-ref no-GC) — never blocks the loop; fail-soft. Hooked at the orchestrator `L2_CONVERGED` seam. DW-labeled `(failed → fixed)` pairs are precisely the training data for a DW-specific stabilizer.

## Phases 2–3 — Pre-Flight Critic (`preflight_critic.py`)
A cheap local quality gate on a candidate **before** the heavy sandbox **and** the expensive Claude cascade. `predict_failure()` calls the Reactor-served local model → failure probability; `evaluate()` short-circuits (skip sandbox → inject a prompt constraint clause → regenerate) when `p_fail` crosses `JARVIS_PREFLIGHT_CRITIC_FAIL_THRESHOLD`.

**Model-collapse / confirmation-bias armor:** `JARVIS_PREFLIGHT_CRITIC_SAMPLE_RATE` always lets a fraction of candidates reach the *real* sandbox regardless of the critic, so the empirical signal never dies and the loop can't collapse into trusting the critic blindly. Deterministic sampling (no RNG).

## Honest status (load-bearing)
The critic is the **consumer** of the training loop — **inert until a critic model is actually trained** (by the emitter → Reactor pipeline) and served. With no model, `predict_failure` → `None` → `evaluate` never short-circuits → the system behaves exactly as today. This PR **wires the consumer**; the model is *earned* by running the loop (emit data → train → serve). Both gated default-OFF; fail-soft throughout.

## Test Plan
- [x] 14 tests — DPO-pair extraction (converged/not-converged/identical/missing), emitter gate + send + fail-soft + disabled-noop; critic predict/threshold/short-circuit (+ DW 2b.1-diff guidance)/anti-collapse-sampling/inert-no-model/fail-soft/gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DW-stability self-correction loop: `RepairTrajectoryEmitter` streams converged L2 `(rejected → chosen)` pairs, and an on‑device pre‑flight critic pre‑screens likely‑failing patches before sandbox/cascade. The critic learns online from these trajectories, is gated, fail‑soft, and stays inert until warmed by real samples.

- **New Features**
  - `RepairTrajectoryEmitter`: builds provider‑labeled DPO pairs with divergence metrics; streams via `reactor_core_client.stream_experience`; also feeds the on‑device critic when learning is enabled; fire‑and‑forget; hooked at `L2_CONVERGED`.
  - Pre‑flight critic: M1‑native Online Topological Critic (fastembed/hashing + topology) with online logistic head; predicts failure and short‑circuits above threshold; deterministic anti‑collapse sampling; consults only when warm; persists to `.jarvis/preflight_critic.npz`.

- **Migration**
  - Opt‑in envs: `JARVIS_REPAIR_TRAJECTORY_EMIT_ENABLED`, `JARVIS_PREFLIGHT_CRITIC_LEARN_ENABLED`, `JARVIS_PREFLIGHT_CRITIC_ENABLED`. Optional: `JARVIS_PREFLIGHT_CRITIC_FAIL_THRESHOLD` (0.85), `JARVIS_PREFLIGHT_CRITIC_SAMPLE_RATE` (0.1).
  - Reactor‑Core must accept `stream_experience`; with gates off or a cold critic, behavior is unchanged.

<sup>Written for commit df6b33e66151c1cdcb56bc720034fceec3bd991a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

