### PR TITLE
feat(jprime): Phase 3 — J-Prime local activation & cooperative cascade (Ollama tier)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1332,6 +1332,32 @@ def _fmt_val(value: Any) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Local-tier failure classifier (Phase 3 Task 7)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class LocalFailureVerdict:
+    degrade: bool
+    cascade_upstream: bool
+    target_state: Optional[str]
+
+
+def classify_local_failure(exc: BaseException) -> LocalFailureVerdict:
+    """Map a local-tier exception to an FSM transition verdict.
+
+    A terminal_lag_lockup degrades J-Prime to PRIMARY_DEGRADED and cascades the
+    op upstream (the FailbackStateMachine already passes context on cascade, so no
+    L2 sandbox teardown). All other exceptions are ordinary provider failures.
+    """
+    if getattr(exc, "failure_class", None) == "terminal_lag_lockup":
+        return LocalFailureVerdict(
+            degrade=True, cascade_upstream=True, target_state="PRIMARY_DEGRADED"
+        )
+    return LocalFailureVerdict(degrade=False, cascade_upstream=False, target_state=None)
+
+
+# ---------------------------------------------------------------------------
 # CandidateProvider Protocol
 # ---------------------------------------------------------------------------
 

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -2089,6 +2089,19 @@ class GovernedLoopService:
             except Exception:
                 pass
 
+        # J-Prime local tier (Phase 3) — release the injected LocalPrimeClient's
+        # pooled aiohttp session so shutdown leaves zero hanging FDs. Best-effort;
+        # inert unless a local client was injected (flag ON + no GCP client).
+        _lid = getattr(self, "_local_inference_director", None)
+        if _lid is not None:
+            try:
+                await _lid.stop()
+            except Exception:
+                logger.debug(
+                    "[GovernedLoop] local inference director stop failed",
+                    exc_info=True,
+                )
+
         # Detach from stack
         self._detach_from_stack()
         self._state = ServiceState.INACTIVE
@@ -3908,10 +3921,19 @@ class GovernedLoopService:
             try:
                 from backend.core.ouroboros.governance.local_inference_director import (
                     build_local_prime_client,
+                    LocalConfig,
+                    LocalInferenceDirector,
                 )
                 _local_prime = build_local_prime_client()
                 if _local_prime is not None:
                     self._prime_client = _local_prime
+                    # Give the local tier a live home so shutdown releases its
+                    # pooled aiohttp session (zero-FD teardown). The director also
+                    # hosts the CRITICAL memory-eviction valve for Phase 3.1 in-loop
+                    # wiring.
+                    self._local_inference_director = LocalInferenceDirector(
+                        LocalConfig.from_env(), client=_local_prime
+                    )
                     logger.info(
                         "[GovernedLoop] J-Prime local tier: LocalPrimeClient injected (Ollama)"
                     )

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -3901,6 +3901,24 @@ class GovernedLoopService:
 
         # Build PrimeProvider if PrimeClient available
         _primary_probe_ok = False  # track for FSM sync after generator build
+        # J-Prime local activation (Phase 3): when no GCP PrimeClient is configured
+        # and the local tier is enabled, inject the local Ollama-backed client so
+        # PrimeProvider has a real backend. OFF or GCP-present -> no-op (legacy).
+        if self._prime_client is None:
+            try:
+                from backend.core.ouroboros.governance.local_inference_director import (
+                    build_local_prime_client,
+                )
+                _local_prime = build_local_prime_client()
+                if _local_prime is not None:
+                    self._prime_client = _local_prime
+                    logger.info(
+                        "[GovernedLoop] J-Prime local tier: LocalPrimeClient injected (Ollama)"
+                    )
+            except Exception:
+                logger.debug(
+                    "[GovernedLoop] local prime injection skipped", exc_info=True
+                )
         if self._prime_client is not None:
             try:
                 from backend.core.ouroboros.governance.providers import (

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -162,7 +162,7 @@ class LocalPrimeClient:
         self._session = session
         self.profiler = LatencyProfiler(cfg)
 
-    async def _ensure_session(self) -> object:
+    async def _ensure_session(self) -> Any:
         if self._session is None:
             import aiohttp  # local import keeps module import cheap when OFF
             conn = aiohttp.TCPConnector(

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -312,3 +312,10 @@ class LocalInferenceDirector:
         gc.collect()                # 2) dual-stage GC sweep
         gc.collect()
         await asyncio.sleep(0)      # 3) yield to host OS for RAM reclaim
+
+    async def stop(self) -> None:
+        """Clean teardown: release the pooled session (zero hanging FDs)."""
+        try:
+            await self._client.aclose()
+        except Exception:
+            pass

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -40,8 +40,8 @@ class LocalConfig:
 
     @classmethod
     def from_env(cls) -> "LocalConfig":
-        def _i(n, d): return int(os.environ.get(n, d))
-        def _f(n, d): return float(os.environ.get(n, d))
+        def _i(n: str, d: int) -> int: return int(os.environ.get(n, str(d)))
+        def _f(n: str, d: float) -> float: return float(os.environ.get(n, str(d)))
         ceiling = _i("JARVIS_LOCAL_INFERENCE_TIMEOUT_MS", 120_000)
         return cls(
             base_url=os.environ.get("JARVIS_LOCAL_MODEL_BASE_URL", "http://127.0.0.1:11434"),

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -7,6 +7,7 @@ byte-identical legacy).
 """
 from __future__ import annotations
 
+import asyncio
 import math
 import os
 import threading
@@ -131,6 +132,15 @@ class LatencyProfiler:
         return elapsed_ms > (m + 3.0 * sd_eff)
 
 
+class LocalLatencyLockup(RuntimeError):
+    """Raised when local inference breaches the adaptive/ceiling timeout.
+
+    Consumed by candidate_generator's FailbackStateMachine to transition
+    J-Prime to PRIMARY_DEGRADED and cascade the op upstream.
+    """
+    failure_class = "terminal_lag_lockup"
+
+
 def render_structured_prompt(*, task: str, constraints: List[str], files: Dict[str, str]) -> str:
     """Structured-prompt discipline for the local 3B: rigid bounded tags, no loose NL."""
     parts = ["<task>", task, "</task>", "<constraints>"]
@@ -196,6 +206,19 @@ class LocalPrimeClient:
         ttft_ms = min(total_ms, 0.1 * total_ms)
         self.profiler.record(ttft_ms=ttft_ms, total_ms=total_ms, output_tokens=out_toks)
         return LocalCompletion(text=text, output_tokens=out_toks, ttft_ms=ttft_ms, total_ms=total_ms)
+
+    async def complete_guarded(self, *, system: str, user: str, prompt_tokens: int) -> LocalCompletion:
+        timeout_ms = self.profiler.adaptive_timeout_ms(prompt_tokens=prompt_tokens)
+        try:
+            return await asyncio.wait_for(
+                self.complete(system=system, user=user, prompt_tokens=prompt_tokens),
+                timeout=timeout_ms / 1000.0,
+            )
+        except asyncio.TimeoutError as e:
+            raise LocalLatencyLockup(
+                f"local_inference timeout: budget={timeout_ms:.0f}ms "
+                f"warm={self.profiler.is_warm()}"
+            ) from e
 
     async def aclose(self) -> None:
         if self._session is not None:

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -1,0 +1,59 @@
+# backend/core/ouroboros/governance/local_inference_director.py
+"""Local inference tier (J-Prime activation, Phase 3).
+
+Three units (added across Phase 3 tasks): LatencyProfiler, LocalPrimeClient,
+LocalInferenceDirector. Gated behind JARVIS_LOCAL_PRIME_ENABLED (default OFF ->
+byte-identical legacy).
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+_TRUE = {"1", "true", "yes", "on"}
+
+
+def _envb(name: str, default: bool = False) -> bool:
+    v = os.environ.get(name)
+    return default if v is None else v.strip().lower() in _TRUE
+
+
+def local_prime_enabled() -> bool:
+    """Master kill-switch. OFF means PrimeProvider gets no local client."""
+    return _envb("JARVIS_LOCAL_PRIME_ENABLED", False)
+
+
+@dataclass(frozen=True)
+class LocalConfig:
+    base_url: str
+    model_name: str
+    keep_alive_seconds: int
+    timeout_seed_ms: int       # cold-start seed
+    timeout_ceiling_ms: int    # absolute hard cap (adaptive never exceeds)
+    timeout_floor_ms: int
+    output_ratio: float        # est_output_tokens = prompt_tokens * ratio
+    margin_sigma: float
+    window_size: int
+    min_samples: int
+    max_concurrency: int
+    pool_limit: int
+
+    @classmethod
+    def from_env(cls) -> "LocalConfig":
+        def _i(n, d): return int(os.environ.get(n, d))
+        def _f(n, d): return float(os.environ.get(n, d))
+        ceiling = _i("JARVIS_LOCAL_INFERENCE_TIMEOUT_MS", 120_000)
+        return cls(
+            base_url=os.environ.get("JARVIS_LOCAL_MODEL_BASE_URL", "http://127.0.0.1:11434"),
+            model_name=os.environ.get("JARVIS_LOCAL_MODEL_NAME", "qwen2.5-coder:3b"),
+            keep_alive_seconds=_i("JARVIS_LOCAL_MODEL_KEEP_ALIVE_SECONDS", 300),
+            timeout_seed_ms=_i("JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS", 30_000),
+            timeout_ceiling_ms=ceiling,
+            timeout_floor_ms=_i("JARVIS_LOCAL_INFERENCE_TIMEOUT_FLOOR_MS", 4_000),
+            output_ratio=_f("JARVIS_LOCAL_OUTPUT_RATIO", 0.5),
+            margin_sigma=_f("JARVIS_LOCAL_MARGIN_SIGMA", 2.0),
+            window_size=_i("JARVIS_LOCAL_PROFILER_WINDOW", 20),
+            min_samples=_i("JARVIS_LOCAL_PROFILER_MIN_SAMPLES", 5),
+            max_concurrency=_i("JARVIS_LOCAL_MODEL_MAX_CONCURRENCY", 2),
+            pool_limit=_i("JARVIS_LOCAL_POOL_LIMIT", 8),
+        )

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -7,8 +7,12 @@ byte-identical legacy).
 """
 from __future__ import annotations
 
+import math
 import os
+import threading
+from collections import deque
 from dataclasses import dataclass
+from typing import Deque
 
 _TRUE = {"1", "true", "yes", "on"}
 
@@ -57,3 +61,70 @@ class LocalConfig:
             max_concurrency=_i("JARVIS_LOCAL_MODEL_MAX_CONCURRENCY", 2),
             pool_limit=_i("JARVIS_LOCAL_POOL_LIMIT", 8),
         )
+
+
+class LatencyProfiler:
+    """Thread-safe sliding window of (ttft_ms, per_token_ms) -> bounded adaptive timeout.
+
+    Cold start uses the seed; the adaptive value is always clamped to
+    [floor, ceiling]. The ceiling is the un-flexible hard cap that guarantees a
+    wedged model still trips the breaker (watchdog-isolation invariant).
+    """
+
+    def __init__(self, cfg: "LocalConfig") -> None:
+        self._cfg = cfg
+        self._lock = threading.Lock()
+        self._ttft: Deque[float] = deque(maxlen=cfg.window_size)
+        self._per_tok: Deque[float] = deque(maxlen=cfg.window_size)
+        self._total: Deque[float] = deque(maxlen=cfg.window_size)
+
+    def record(self, *, ttft_ms: float, total_ms: float, output_tokens: int) -> None:
+        per_tok = (total_ms - ttft_ms) / max(1, output_tokens)
+        with self._lock:
+            self._ttft.append(float(ttft_ms))
+            self._per_tok.append(max(0.0, per_tok))
+            self._total.append(float(total_ms))
+
+    def is_warm(self) -> bool:
+        with self._lock:
+            return len(self._total) >= self._cfg.min_samples
+
+    @staticmethod
+    def _mean(xs: Deque[float]) -> float:
+        return sum(xs) / len(xs) if xs else 0.0
+
+    @classmethod
+    def _stddev(cls, xs: Deque[float]) -> float:
+        if len(xs) < 2:
+            return 0.0
+        m = cls._mean(xs)
+        return math.sqrt(sum((x - m) ** 2 for x in xs) / (len(xs) - 1))
+
+    def adaptive_timeout_ms(self, *, prompt_tokens: int) -> float:
+        cfg = self._cfg
+        with self._lock:
+            warm = len(self._total) >= cfg.min_samples
+            ttft_m = self._mean(self._ttft)
+            tok_m = self._mean(self._per_tok)
+            tot_sd = self._stddev(self._total)
+        if not warm:
+            return float(min(cfg.timeout_seed_ms, cfg.timeout_ceiling_ms))
+        est_out = max(1.0, prompt_tokens * cfg.output_ratio)
+        expected = ttft_m + tok_m * est_out
+        flexed = expected + cfg.margin_sigma * tot_sd
+        return float(max(cfg.timeout_floor_ms, min(flexed, cfg.timeout_ceiling_ms)))
+
+    def is_terminal_lag(self, *, elapsed_ms: float) -> bool:
+        cfg = self._cfg
+        if elapsed_ms > cfg.timeout_ceiling_ms:
+            return True
+        with self._lock:
+            warm = len(self._total) >= cfg.min_samples
+            if not warm:
+                return False
+            m = self._mean(self._total)
+            sd = self._stddev(self._total)
+        # Use a minimum stddev floor of 10% of mean so that a perfectly uniform
+        # sample distribution still produces a meaningful 3-sigma band.
+        sd_eff = max(sd, m * 0.1)
+        return elapsed_ms > (m + 3.0 * sd_eff)

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -188,18 +188,22 @@ class LocalPrimeClient:
             )
         return self._session
 
-    async def complete(self, *, system: str, user: str, prompt_tokens: int) -> LocalCompletion:
+    async def complete(self, *, system: str, user: str, prompt_tokens: int,
+                       temperature: float = 0.2,
+                       max_tokens: "Optional[int]" = None) -> LocalCompletion:
         sess = await self._ensure_session()
         url = self._cfg.base_url.rstrip("/") + "/v1/chat/completions"
-        body = {
+        body: Dict[str, Any] = {
             "model": self._cfg.model_name,
             "keep_alive": self._cfg.keep_alive_seconds,
-            "temperature": 0.2,
+            "temperature": temperature,
             "messages": [
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ],
         }
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
         t0 = time.monotonic()
         async with sess.post(url, json=body) as resp:
             data = await resp.json()
@@ -210,11 +214,14 @@ class LocalPrimeClient:
         self.profiler.record(ttft_ms=ttft_ms, total_ms=total_ms, output_tokens=out_toks)
         return LocalCompletion(text=text, output_tokens=out_toks, ttft_ms=ttft_ms, total_ms=total_ms)
 
-    async def complete_guarded(self, *, system: str, user: str, prompt_tokens: int) -> LocalCompletion:
+    async def complete_guarded(self, *, system: str, user: str, prompt_tokens: int,
+                               temperature: float = 0.2,
+                               max_tokens: "Optional[int]" = None) -> LocalCompletion:
         timeout_ms = self.profiler.adaptive_timeout_ms(prompt_tokens=prompt_tokens)
         try:
             return await asyncio.wait_for(
-                self.complete(system=system, user=user, prompt_tokens=prompt_tokens),
+                self.complete(system=system, user=user, prompt_tokens=prompt_tokens,
+                              temperature=temperature, max_tokens=max_tokens),
                 timeout=timeout_ms / 1000.0,
             )
         except asyncio.TimeoutError as e:
@@ -223,10 +230,54 @@ class LocalPrimeClient:
                 f"warm={self.profiler.is_warm()}"
             ) from e
 
+    async def generate(self, prompt: str, system_prompt: "Optional[str]" = None,
+                       context: "Optional[Any]" = None, max_tokens: int = 4096,
+                       temperature: float = 0.7, model_name: "Optional[str]" = None,
+                       task_profile: "Optional[Any]" = None, **kwargs: Any) -> Any:
+        """Drop-in PrimeClient.generate adapter -> PrimeResponse (source=local_prime).
+
+        context/task_profile are accepted for interface parity; the 3B path relies
+        on the structured prompt + files already in `prompt` (documented v1 limit).
+        """
+        import uuid
+        from backend.core.prime_client import PrimeResponse
+        sys_txt = system_prompt or ""
+        est_tokens = max(1, (len(prompt) + len(sys_txt)) // 4)
+        lc = await self.complete_guarded(
+            system=sys_txt, user=prompt, prompt_tokens=est_tokens,
+            temperature=temperature, max_tokens=max_tokens,
+        )
+        return PrimeResponse(
+            content=lc.text,
+            request_id=uuid.uuid4().hex,
+            model=model_name or self._cfg.model_name,
+            source="local_prime",
+            latency_ms=lc.total_ms,
+            tokens_used=lc.output_tokens,
+        )
+
+    async def _check_health(self) -> Any:
+        """Drop-in PrimeClient._check_health -> PrimeStatus (AVAILABLE iff Ollama reachable)."""
+        from backend.core.prime_client import PrimeStatus
+        try:
+            sess = await self._ensure_session()
+            url = self._cfg.base_url.rstrip("/") + "/api/tags"
+            async with sess.get(url) as resp:
+                return PrimeStatus.AVAILABLE if resp.status == 200 else PrimeStatus.UNAVAILABLE
+        except Exception:
+            return PrimeStatus.UNAVAILABLE
+
     async def aclose(self) -> None:
         if self._session is not None:
             await self._session.close()
             self._session = None
+
+
+def build_local_prime_client() -> "Optional[LocalPrimeClient]":
+    """Factory honoring the master kill-switch. OFF -> None (legacy untouched)."""
+    if not local_prime_enabled():
+        return None
+    return LocalPrimeClient(LocalConfig.from_env())
 
 
 class LocalInferenceDirector:

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -8,6 +8,7 @@ byte-identical legacy).
 from __future__ import annotations
 
 import asyncio
+import gc
 import math
 import os
 import threading
@@ -15,6 +16,8 @@ import time
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Deque, Dict, List, Optional
+
+from .memory_pressure_gate import PressureLevel
 
 _TRUE = {"1", "true", "yes", "on"}
 
@@ -224,3 +227,37 @@ class LocalPrimeClient:
         if self._session is not None:
             await self._session.close()
             self._session = None
+
+
+class LocalInferenceDirector:
+    """Lifecycle + memory-aware governance for the local tier."""
+
+    def __init__(self, cfg: LocalConfig, client: Any) -> None:
+        self._cfg = cfg
+        self._client = client
+
+    def admit_concurrency(self, level: PressureLevel) -> int:
+        if level is PressureLevel.CRITICAL:
+            return 0
+        if level is PressureLevel.HIGH:
+            return 1
+        return self._cfg.max_concurrency
+
+    async def _evict_model(self) -> None:
+        """Force immediate unload from unified memory via keep_alive:0."""
+        try:
+            sess = await self._client._ensure_session()
+            url = self._cfg.base_url.rstrip("/") + "/api/generate"
+            async with sess.post(url, json={"model": self._cfg.model_name, "keep_alive": 0}):
+                pass
+        except Exception:
+            pass  # eviction is best-effort; never raise into the control path
+
+    async def enforce_memory(self, level: PressureLevel) -> None:
+        """At CRITICAL: un-bypassable atomic teardown."""
+        if level is not PressureLevel.CRITICAL:
+            return
+        await self._evict_model()   # 1) API unload
+        gc.collect()                # 2) dual-stage GC sweep
+        gc.collect()
+        await asyncio.sleep(0)      # 3) yield to host OS for RAM reclaim

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import math
 import os
 import threading
+import time
 from collections import deque
 from dataclasses import dataclass
-from typing import Deque
+from typing import Deque, Dict, List, Optional
 
 _TRUE = {"1", "true", "yes", "on"}
 
@@ -128,3 +129,75 @@ class LatencyProfiler:
         # sample distribution still produces a meaningful 3-sigma band.
         sd_eff = max(sd, m * 0.1)
         return elapsed_ms > (m + 3.0 * sd_eff)
+
+
+def render_structured_prompt(*, task: str, constraints: List[str], files: Dict[str, str]) -> str:
+    """Structured-prompt discipline for the local 3B: rigid bounded tags, no loose NL."""
+    parts = ["<task>", task, "</task>", "<constraints>"]
+    parts += [f"- {c}" for c in constraints]
+    parts += ["</constraints>", "<files>"]
+    for path, body in files.items():
+        parts += [f'<file path="{path}">', body, "</file>"]
+    parts += ["</files>", "<output_format>full_content</output_format>"]
+    return "\n".join(parts)
+
+
+@dataclass
+class LocalCompletion:
+    text: str
+    output_tokens: int
+    ttft_ms: float
+    total_ms: float
+
+
+class LocalPrimeClient:
+    """aiohttp connection-pooled client -> Ollama OpenAI-compat endpoint.
+
+    A persistent session (lazily built, or injected for tests) with a bounded
+    TCPConnector + keep-alive eliminates per-call socket setup across L2 passes.
+    """
+
+    def __init__(self, cfg: LocalConfig, session: Optional[object] = None) -> None:
+        self._cfg = cfg
+        self._session = session
+        self.profiler = LatencyProfiler(cfg)
+
+    async def _ensure_session(self) -> object:
+        if self._session is None:
+            import aiohttp  # local import keeps module import cheap when OFF
+            conn = aiohttp.TCPConnector(
+                limit=self._cfg.pool_limit,
+                limit_per_host=self._cfg.pool_limit,
+                keepalive_timeout=max(30, self._cfg.keep_alive_seconds),
+            )
+            self._session = aiohttp.ClientSession(
+                connector=conn, headers={"Connection": "keep-alive"},
+            )
+        return self._session
+
+    async def complete(self, *, system: str, user: str, prompt_tokens: int) -> LocalCompletion:
+        sess = await self._ensure_session()
+        url = self._cfg.base_url.rstrip("/") + "/v1/chat/completions"
+        body = {
+            "model": self._cfg.model_name,
+            "keep_alive": self._cfg.keep_alive_seconds,
+            "temperature": 0.2,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        }
+        t0 = time.monotonic()
+        async with sess.post(url, json=body) as resp:
+            data = await resp.json()
+        total_ms = (time.monotonic() - t0) * 1000.0
+        text = data["choices"][0]["message"]["content"]
+        out_toks = int(data.get("usage", {}).get("completion_tokens", 0)) or max(1, len(text) // 4)
+        ttft_ms = min(total_ms, 0.1 * total_ms)
+        self.profiler.record(ttft_ms=ttft_ms, total_ms=total_ms, output_tokens=out_toks)
+        return LocalCompletion(text=text, output_tokens=out_toks, ttft_ms=ttft_ms, total_ms=total_ms)
+
+    async def aclose(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -13,7 +13,7 @@ import threading
 import time
 from collections import deque
 from dataclasses import dataclass
-from typing import Deque, Dict, List, Optional
+from typing import Any, Deque, Dict, List, Optional
 
 _TRUE = {"1", "true", "yes", "on"}
 
@@ -157,7 +157,7 @@ class LocalPrimeClient:
     TCPConnector + keep-alive eliminates per-call socket setup across L2 passes.
     """
 
-    def __init__(self, cfg: LocalConfig, session: Optional[object] = None) -> None:
+    def __init__(self, cfg: LocalConfig, session: Optional[Any] = None) -> None:
         self._cfg = cfg
         self._session = session
         self.profiler = LatencyProfiler(cfg)

--- a/tests/governance/test_local_inference_director.py
+++ b/tests/governance/test_local_inference_director.py
@@ -1,6 +1,7 @@
 # tests/governance/test_local_inference_director.py
 from __future__ import annotations
 import importlib
+import pytest
 
 MOD = "backend.core.ouroboros.governance.local_inference_director"
 
@@ -70,3 +71,64 @@ def test_profiler_three_sigma_terminal_lag():
     assert p.is_terminal_lag(elapsed_ms=1100.0) is False
     assert p.is_terminal_lag(elapsed_ms=50_000.0) is True
     assert p.is_terminal_lag(elapsed_ms=cfg.timeout_ceiling_ms + 1) is True
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._p = payload
+        self.status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def json(self):
+        return self._p
+
+
+class _FakeSession:
+    def __init__(self, payload):
+        self._p = payload
+        self.closed = False
+        self.posts = []
+
+    def post(self, url, **kw):
+        self.posts.append((url, kw))
+        return _FakeResp(self._p)
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_client_generate_posts_to_openai_compat_with_keep_alive():
+    from backend.core.ouroboros.governance.local_inference_director import LocalPrimeClient, LocalConfig
+    payload = {"choices": [{"message": {"content": "patched code"}}],
+               "usage": {"completion_tokens": 12}}
+    fake = _FakeSession(payload)
+    cfg = LocalConfig.from_env()
+    client = LocalPrimeClient(cfg, session=fake)
+    out = await client.complete(system="<sys/>", user="<task/>", prompt_tokens=100)
+    assert out.text == "patched code"
+    url, kw = fake.posts[-1]
+    assert url.endswith("/v1/chat/completions")
+    assert kw["json"]["keep_alive"] == cfg.keep_alive_seconds
+    assert kw["json"]["model"] == cfg.model_name
+
+
+@pytest.mark.asyncio
+async def test_client_close_releases_session():
+    from backend.core.ouroboros.governance.local_inference_director import LocalPrimeClient, LocalConfig
+    fake = _FakeSession({"choices": [{"message": {"content": "x"}}]})
+    client = LocalPrimeClient(LocalConfig.from_env(), session=fake)
+    await client.aclose()
+    assert fake.closed is True
+
+
+def test_structured_prompt_uses_bounded_tags():
+    from backend.core.ouroboros.governance.local_inference_director import render_structured_prompt
+    s = render_structured_prompt(task="fix bug", constraints=["no new deps"], files={"a.py": "x=1"})
+    assert "<task>" in s and "</task>" in s
+    assert "<constraints>" in s and "<files>" in s

--- a/tests/governance/test_local_inference_director.py
+++ b/tests/governance/test_local_inference_director.py
@@ -1,7 +1,6 @@
 # tests/governance/test_local_inference_director.py
 from __future__ import annotations
 import importlib
-import pytest
 
 MOD = "backend.core.ouroboros.governance.local_inference_director"
 

--- a/tests/governance/test_local_inference_director.py
+++ b/tests/governance/test_local_inference_director.py
@@ -213,3 +213,51 @@ async def test_critical_eviction_unloads_and_gc(monkeypatch):
     await d.enforce_memory(PressureLevel.CRITICAL)
     assert any(c.get("keep_alive") == 0 for c in evicted["calls"])  # forced unload
     assert gc_calls["n"] >= 2  # dual-stage gc.collect()
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_primeresponse_with_content():
+    from backend.core.ouroboros.governance.local_inference_director import LocalPrimeClient, LocalConfig
+    fake = _FakeSession({"choices": [{"message": {"content": "GENERATED"}}],
+                         "usage": {"completion_tokens": 7}})
+    client = LocalPrimeClient(LocalConfig.from_env(), session=fake)
+    resp = await client.generate(prompt="do x", system_prompt="be terse", max_tokens=256, temperature=0.0)
+    assert resp.content == "GENERATED"
+    assert resp.source == "local_prime"
+    assert resp.request_id  # non-empty
+    # max_tokens forwarded to the Ollama body
+    _, kw = fake.posts[-1]
+    assert kw["json"].get("max_tokens") == 256
+
+
+@pytest.mark.asyncio
+async def test_check_health_available_on_200():
+    from backend.core.ouroboros.governance.local_inference_director import LocalPrimeClient, LocalConfig
+
+    class _HealthResp:
+        status = 200
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+
+    class _HealthSession:
+        closed = False
+        def get(self, url, **kw): return _HealthResp()
+        def post(self, url, **kw): raise AssertionError("health must use GET")
+        async def close(self): self.closed = True
+
+    client = LocalPrimeClient(LocalConfig.from_env(), session=_HealthSession())
+    status = await client._check_health()
+    assert status.name == "AVAILABLE"
+
+
+def test_build_local_prime_client_off_returns_none(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_PRIME_ENABLED", "false")
+    from backend.core.ouroboros.governance.local_inference_director import build_local_prime_client
+    assert build_local_prime_client() is None
+
+
+def test_build_local_prime_client_on_returns_client(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_PRIME_ENABLED", "true")
+    from backend.core.ouroboros.governance.local_inference_director import (
+        build_local_prime_client, LocalPrimeClient)
+    assert isinstance(build_local_prime_client(), LocalPrimeClient)

--- a/tests/governance/test_local_inference_director.py
+++ b/tests/governance/test_local_inference_director.py
@@ -132,3 +132,36 @@ def test_structured_prompt_uses_bounded_tags():
     s = render_structured_prompt(task="fix bug", constraints=["no new deps"], files={"a.py": "x=1"})
     assert "<task>" in s and "</task>" in s
     assert "<constraints>" in s and "<files>" in s
+
+
+@pytest.mark.asyncio
+async def test_breaker_trips_on_ceiling_breach(monkeypatch):
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalPrimeClient, LocalConfig, LocalLatencyLockup)
+    monkeypatch.setenv("JARVIS_LOCAL_INFERENCE_TIMEOUT_MS", "50")  # tiny ceiling
+
+    class _SlowSession:
+        closed = False
+
+        def post(self, url, **kw):
+            class _R:
+                status = 200
+
+                async def __aenter__(self_):
+                    import asyncio
+                    await asyncio.sleep(0.2)  # 200ms > 50ms ceiling
+                    return self_
+
+                async def __aexit__(self_, *a):
+                    return False
+
+                async def json(self_):
+                    return {"choices": [{"message": {"content": "x"}}]}
+            return _R()
+
+        async def close(self):
+            self.closed = True
+
+    client = LocalPrimeClient(LocalConfig.from_env(), session=_SlowSession())
+    with pytest.raises(LocalLatencyLockup):
+        await client.complete_guarded(system="<s/>", user="<u/>", prompt_tokens=10)

--- a/tests/governance/test_local_inference_director.py
+++ b/tests/governance/test_local_inference_director.py
@@ -165,3 +165,51 @@ async def test_breaker_trips_on_ceiling_breach(monkeypatch):
     client = LocalPrimeClient(LocalConfig.from_env(), session=_SlowSession())
     with pytest.raises(LocalLatencyLockup):
         await client.complete_guarded(system="<s/>", user="<u/>", prompt_tokens=10)
+
+
+@pytest.mark.asyncio
+async def test_high_pressure_clamps_concurrency_to_one():
+    from backend.core.ouroboros.governance.local_inference_director import LocalInferenceDirector, LocalConfig
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    d = LocalInferenceDirector(LocalConfig.from_env(), client=object())
+    assert d.admit_concurrency(PressureLevel.OK) == LocalConfig.from_env().max_concurrency
+    assert d.admit_concurrency(PressureLevel.HIGH) == 1
+    assert d.admit_concurrency(PressureLevel.CRITICAL) == 0
+
+
+@pytest.mark.asyncio
+async def test_critical_eviction_unloads_and_gc(monkeypatch):
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalInferenceDirector, LocalConfig, LocalPrimeClient)
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    evicted = {"calls": []}
+
+    class _EvictSession:
+        closed = False
+
+        def post(self, url, **kw):
+            evicted["calls"].append(kw.get("json", {}))
+
+            class _R:
+                status = 200
+
+                async def __aenter__(self_):
+                    return self_
+
+                async def __aexit__(self_, *a):
+                    return False
+
+                async def json(self_):
+                    return {"status": "ok"}
+            return _R()
+
+        async def close(self):
+            self.closed = True
+
+    client = LocalPrimeClient(LocalConfig.from_env(), session=_EvictSession())
+    d = LocalInferenceDirector(LocalConfig.from_env(), client=client)
+    gc_calls = {"n": 0}
+    monkeypatch.setattr("gc.collect", lambda *a, **k: gc_calls.__setitem__("n", gc_calls["n"] + 1) or 0)
+    await d.enforce_memory(PressureLevel.CRITICAL)
+    assert any(c.get("keep_alive") == 0 for c in evicted["calls"])  # forced unload
+    assert gc_calls["n"] >= 2  # dual-stage gc.collect()

--- a/tests/governance/test_local_inference_director.py
+++ b/tests/governance/test_local_inference_director.py
@@ -29,3 +29,44 @@ def test_config_defaults(monkeypatch):
     assert cfg.model_name == "qwen2.5-coder:3b"
     assert cfg.keep_alive_seconds == 300
     assert cfg.timeout_ceiling_ms == 120_000
+
+
+def test_profiler_cold_start_uses_seed():
+    from backend.core.ouroboros.governance.local_inference_director import LatencyProfiler, LocalConfig
+    cfg = LocalConfig.from_env()
+    p = LatencyProfiler(cfg)
+    assert p.adaptive_timeout_ms(prompt_tokens=1000) == min(cfg.timeout_seed_ms, cfg.timeout_ceiling_ms)
+    assert p.is_warm() is False
+
+
+def test_profiler_warms_and_scales_with_prompt_size():
+    from backend.core.ouroboros.governance.local_inference_director import LatencyProfiler, LocalConfig
+    cfg = LocalConfig.from_env()
+    p = LatencyProfiler(cfg)
+    for _ in range(6):
+        p.record(ttft_ms=200.0, total_ms=200.0 + 100 * 10.0, output_tokens=100)
+    assert p.is_warm() is True
+    t_big = p.adaptive_timeout_ms(prompt_tokens=2000)
+    t_small = p.adaptive_timeout_ms(prompt_tokens=200)
+    assert t_big > t_small
+    assert t_big <= cfg.timeout_ceiling_ms
+
+
+def test_profiler_never_exceeds_ceiling_even_with_huge_prompt():
+    from backend.core.ouroboros.governance.local_inference_director import LatencyProfiler, LocalConfig
+    cfg = LocalConfig.from_env()
+    p = LatencyProfiler(cfg)
+    for _ in range(6):
+        p.record(ttft_ms=500.0, total_ms=5000.0, output_tokens=100)
+    assert p.adaptive_timeout_ms(prompt_tokens=10_000_000) == cfg.timeout_ceiling_ms
+
+
+def test_profiler_three_sigma_terminal_lag():
+    from backend.core.ouroboros.governance.local_inference_director import LatencyProfiler, LocalConfig
+    cfg = LocalConfig.from_env()
+    p = LatencyProfiler(cfg)
+    for _ in range(6):
+        p.record(ttft_ms=200.0, total_ms=1000.0, output_tokens=100)
+    assert p.is_terminal_lag(elapsed_ms=1100.0) is False
+    assert p.is_terminal_lag(elapsed_ms=50_000.0) is True
+    assert p.is_terminal_lag(elapsed_ms=cfg.timeout_ceiling_ms + 1) is True

--- a/tests/governance/test_local_inference_director.py
+++ b/tests/governance/test_local_inference_director.py
@@ -1,0 +1,32 @@
+# tests/governance/test_local_inference_director.py
+from __future__ import annotations
+import importlib
+import pytest
+
+MOD = "backend.core.ouroboros.governance.local_inference_director"
+
+
+def test_local_prime_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_LOCAL_PRIME_ENABLED", raising=False)
+    lid = importlib.import_module(MOD)
+    assert lid.local_prime_enabled() is False
+
+
+def test_local_prime_enable_toggle(monkeypatch):
+    lid = importlib.import_module(MOD)
+    monkeypatch.setenv("JARVIS_LOCAL_PRIME_ENABLED", "true")
+    assert lid.local_prime_enabled() is True
+    monkeypatch.setenv("JARVIS_LOCAL_PRIME_ENABLED", "false")
+    assert lid.local_prime_enabled() is False
+
+
+def test_config_defaults(monkeypatch):
+    for k in ("JARVIS_LOCAL_MODEL_BASE_URL", "JARVIS_LOCAL_MODEL_NAME",
+              "JARVIS_LOCAL_MODEL_KEEP_ALIVE_SECONDS", "JARVIS_LOCAL_INFERENCE_TIMEOUT_MS"):
+        monkeypatch.delenv(k, raising=False)
+    lid = importlib.import_module(MOD)
+    cfg = lid.LocalConfig.from_env()
+    assert cfg.base_url == "http://127.0.0.1:11434"
+    assert cfg.model_name == "qwen2.5-coder:3b"
+    assert cfg.keep_alive_seconds == 300
+    assert cfg.timeout_ceiling_ms == 120_000

--- a/tests/governance/test_local_prime_cascade_integration.py
+++ b/tests/governance/test_local_prime_cascade_integration.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+def test_lockup_maps_to_primary_degraded():
+    from backend.core.ouroboros.governance.local_inference_director import LocalLatencyLockup
+    from backend.core.ouroboros.governance.candidate_generator import classify_local_failure
+    verdict = classify_local_failure(LocalLatencyLockup("timeout"))
+    assert verdict.degrade is True
+    assert verdict.target_state == "PRIMARY_DEGRADED"
+    assert verdict.cascade_upstream is True
+
+
+def test_normal_exception_does_not_degrade():
+    from backend.core.ouroboros.governance.candidate_generator import classify_local_failure
+    verdict = classify_local_failure(ValueError("schema"))
+    assert verdict.degrade is False
+    assert verdict.target_state is None
+    assert verdict.cascade_upstream is False

--- a/tests/governance/test_local_prime_cascade_integration.py
+++ b/tests/governance/test_local_prime_cascade_integration.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 
 def test_lockup_maps_to_primary_degraded():
     from backend.core.ouroboros.governance.local_inference_director import LocalLatencyLockup
@@ -16,3 +18,31 @@ def test_normal_exception_does_not_degrade():
     assert verdict.degrade is False
     assert verdict.target_state is None
     assert verdict.cascade_upstream is False
+
+
+@pytest.mark.asyncio
+async def test_killswitch_off_makes_no_ollama_call(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_PRIME_ENABLED", "false")
+    from backend.core.ouroboros.governance.local_inference_director import build_local_prime_client
+    # OFF -> no client is ever constructed, so no endpoint contact is possible.
+    assert build_local_prime_client() is None
+
+
+@pytest.mark.asyncio
+async def test_director_stop_closes_session_no_leak(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_PRIME_ENABLED", "true")
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalConfig, LocalPrimeClient, LocalInferenceDirector)
+
+    class _S:
+        closed = False
+
+        async def close(self):
+            self.closed = True
+
+    fake = _S()
+    client = LocalPrimeClient(LocalConfig.from_env(), session=fake)
+    d = LocalInferenceDirector(LocalConfig.from_env(), client=client)
+    await d.stop()
+    assert client._session is None   # released
+    assert fake.closed is True       # zero hanging FDs


### PR DESCRIPTION
## Summary
Activates the dormant Tier-2 **J-Prime** provider as a **native local inference tier** (Ollama + Qwen2.5-Coder-3B q4) on the M1 host — a free, no-quota fallback that closes the `all_providers_exhausted` wall. Implements the ADD (#69569) / plan (#69570) via 8 TDD increments + a final-review fix.

**Master kill-switch `JARVIS_LOCAL_PRIME_ENABLED` default-OFF → byte-identical legacy** (parity-proven: flag-OFF yields the same 23-fail/778-pass governance baseline as unset; the 23 failures + 5 collection errors are pre-existing on `main`).

## What's live (flag ON)
- **`LocalPrimeClient`** — aiohttp connection-pooled client to Ollama's OpenAI-compat endpoint (`:11434`), keep-alive warm-standby, structured-prompt discipline for the 3B. A **drop-in for `PrimeClient`**: implements `generate(...) -> PrimeResponse` and `_check_health() -> PrimeStatus` (reuses the real types), so the existing `PrimeProvider` consumes it unchanged.
- **Bounded adaptive latency timeout** — sliding-window TTFT/TGV profiler (`LatencyProfiler`) clamps every timeout to `[floor, ceiling]`; `JARVIS_LOCAL_INFERENCE_TIMEOUT_MS` is the **un-flexible ceiling** so a wedged 3B still trips (watchdog-isolation invariant). `complete_guarded` raises `LocalLatencyLockup`, which **cascades to fallback via the existing `candidate_generator.py:4921` machinery**.
- **Gated injection** into `GovernedLoopService` (additive; only when no GCP client + flag ON) + **zero-FD teardown** on `GLS.stop()`.

## Built + unit-tested, deliberately NOT yet wired in-loop (Phase 3.1 follow-up)
Honest scoping per the final review:
- **CRITICAL memory-eviction valve** (`LocalInferenceDirector.enforce_memory` / `admit_concurrency` / `_evict_model`) — built, tested, and the director is now instantiated at injection (so it has a live home + powers teardown), **but the per-op pre-generation eviction trigger is not yet wired into the generation loop.** A follow-up will hook it.
- **`classify_local_failure`** explicit mapping — tested; the lockup cascade is already handled by the existing FSM machinery, so this helper is supplementary until wired.

These are tracked, not forgotten — the memory valve is the safety feature for the 16GB M1 and warrants a deliberate hook, not a rushed hot-path edit.

## Tests
- 21 new tests green (`test_local_inference_director.py` 17 + `test_local_prime_cascade_integration.py` 4): config/kill-switch, bounded profiler + 3-sigma guard, pooled client + structured prompt, latency breaker, concurrency clamp + CRITICAL eviction, drop-in generate/health, factory gating, FSM classifier, kill-switch parity + zero-FD teardown.
- Kill-switch-OFF parity sweep: identical fail/pass to baseline.

## Operational setup (native, not Docker — Metal GPU access)
```
brew install ollama && brew services start ollama
ollama pull qwen2.5-coder:3b
export JARVIS_LOCAL_PRIME_ENABLED=true   # host-local .env, never committed
```

Reference: ADD `specs/2026-06-18-jprime-local-cascade-phase3-design.md`, plan `plans/2026-06-18-jprime-local-cascade-phase3.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates the J-Prime local inference tier using `Ollama` (Qwen2.5-Coder-3B) as a free fallback when no cloud `PrimeClient` is present, gated by `JARVIS_LOCAL_PRIME_ENABLED` (default OFF for byte-identical legacy behavior). Adds an adaptive timeout breaker and safe teardown to prevent lockups and FD leaks.

- **New Features**
  - Drop-in `LocalPrimeClient` (pooled `aiohttp`) targeting `Ollama`’s OpenAI-compatible API; implements `generate` and `_check_health`.
  - Adaptive latency profiler with a ceiling-bound timeout; on breach, raises `LocalLatencyLockup` to degrade to PRIMARY_DEGRADED and cascade upstream.
  - Conditional injection into `GovernedLoopService` only when no cloud `PrimeClient` and flag ON; shutdown closes the pooled session (zero FD leaks).
  - `LocalInferenceDirector` for memory safety: caps concurrency by pressure level and forcibly unloads the model at CRITICAL; per-op eviction wiring lands in Phase 3.1.
  - `classify_local_failure` maps lockups to PRIMARY_DEGRADED; 21 tests added; flag-OFF parity preserved.

- **Migration**
  - Install `ollama` and start it (e.g., brew services).
  - Pull `qwen2.5-coder:3b`.
  - Set `JARVIS_LOCAL_PRIME_ENABLED=true` (optional: tune `JARVIS_LOCAL_INFERENCE_TIMEOUT_MS`).

<sup>Written for commit 188e1071627e00a160a1f4d119a968d16a9b9ca9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

