### PR TITLE
feat(jprime): Phase 3.1 — live adaptive memory governor (reuse-first, zero duplication)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1350,7 +1350,8 @@ def classify_local_failure(exc: BaseException) -> LocalFailureVerdict:
     op upstream (the FailbackStateMachine already passes context on cascade, so no
     L2 sandbox teardown). All other exceptions are ordinary provider failures.
     """
-    if getattr(exc, "failure_class", None) == "terminal_lag_lockup":
+    _LOCAL_DEGRADE_CLASSES = ("terminal_lag_lockup", "local_memory_critical")
+    if getattr(exc, "failure_class", None) in _LOCAL_DEGRADE_CLASSES:
         return LocalFailureVerdict(
             degrade=True, cascade_upstream=True, target_state="PRIMARY_DEGRADED"
         )

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4948,7 +4948,7 @@ class CandidateGenerator:
         except (Exception, asyncio.CancelledError) as exc:
             mode = FailbackStateMachine.classify_exception(exc)
             # Phase 3.1 observability: surface local-tier degradations (memory /
-            # latency) distinctly in operator logs. Pure telemetry — the FSM
+            # latency) distinctly in operator logs. Pure telemetry -- the FSM
             # transition above is authoritative; this never changes control flow.
             try:
                 _lv = classify_local_failure(exc)

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4947,6 +4947,19 @@ class CandidateGenerator:
             return result
         except (Exception, asyncio.CancelledError) as exc:
             mode = FailbackStateMachine.classify_exception(exc)
+            # Phase 3.1 observability: surface local-tier degradations (memory /
+            # latency) distinctly in operator logs. Pure telemetry — the FSM
+            # transition above is authoritative; this never changes control flow.
+            try:
+                _lv = classify_local_failure(exc)
+                if _lv.degrade:
+                    logger.info(
+                        "[LocalTier] degrade class=%s -> %s (cascading upstream)",
+                        getattr(exc, "failure_class", "unknown"),
+                        _lv.target_state,
+                    )
+            except Exception:
+                pass
             logger.warning(
                 "[CandidateGenerator] Primary failed (mode=%s, %s: %s), "
                 "falling back",

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -3929,11 +3929,16 @@ class GovernedLoopService:
                     self._prime_client = _local_prime
                     # Give the local tier a live home so shutdown releases its
                     # pooled aiohttp session (zero-FD teardown). The director also
-                    # hosts the CRITICAL memory-eviction valve for Phase 3.1 in-loop
-                    # wiring.
+                    # hosts the CRITICAL memory-eviction valve consulted on every
+                    # local generate.
                     self._local_inference_director = LocalInferenceDirector(
                         LocalConfig.from_env(), client=_local_prime
                     )
+                    # Phase 3.1: attach the director so every local generate()
+                    # consults memory_guard() (CRITICAL -> evict + refuse + cascade
+                    # upstream), protecting the host from OOM. Concurrency stays with
+                    # candidate_generator's existing _jprime_sem (no duplication).
+                    _local_prime.attach_governor(self._local_inference_director)
                     logger.info(
                         "[GovernedLoop] J-Prime local tier: LocalPrimeClient injected (Ollama)"
                     )

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -184,6 +184,13 @@ class LocalPrimeClient:
         self._cfg = cfg
         self._session = session
         self.profiler = LatencyProfiler(cfg)
+        self._governor: Any = None
+
+    def attach_governor(self, governor: Any) -> None:
+        """Attach a LocalInferenceDirector so generate() consults memory_guard()
+        before each local inference (host-OOM protection). When unattached,
+        behavior is byte-identical to the ungoverned path."""
+        self._governor = governor
 
     async def _ensure_session(self) -> Any:
         if self._session is None:
@@ -249,6 +256,8 @@ class LocalPrimeClient:
         context/task_profile are accepted for interface parity; the 3B path relies
         on the structured prompt + files already in `prompt` (documented v1 limit).
         """
+        if self._governor is not None:
+            await self._governor.memory_guard()
         import uuid
         from backend.core.prime_client import PrimeResponse
         sys_txt = system_prompt or ""

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -144,6 +144,16 @@ class LocalLatencyLockup(RuntimeError):
     failure_class = "terminal_lag_lockup"
 
 
+class LocalMemoryCritical(RuntimeError):
+    """Raised when host memory is CRITICAL at local-generate admission time.
+
+    The local tier evicts the model and refuses the op so the cascade routes
+    upstream to remote providers instead of OOM-ing the host. Consumed by
+    classify_local_failure -> PRIMARY_DEGRADED.
+    """
+    failure_class = "local_memory_critical"
+
+
 def render_structured_prompt(*, task: str, constraints: List[str], files: Dict[str, str]) -> str:
     """Structured-prompt discipline for the local 3B: rigid bounded tags, no loose NL."""
     parts = ["<task>", task, "</task>", "<constraints>"]

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -17,7 +17,7 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any, Deque, Dict, List, Optional
 
-from .memory_pressure_gate import PressureLevel
+from .memory_pressure_gate import PressureLevel, get_default_gate, is_enabled as memory_gate_enabled
 
 _TRUE = {"1", "true", "yes", "on"}
 
@@ -293,16 +293,10 @@ def build_local_prime_client() -> "Optional[LocalPrimeClient]":
 class LocalInferenceDirector:
     """Lifecycle + memory-aware governance for the local tier."""
 
-    def __init__(self, cfg: LocalConfig, client: Any) -> None:
+    def __init__(self, cfg: LocalConfig, client: Any, gate: Any = None) -> None:
         self._cfg = cfg
         self._client = client
-
-    def admit_concurrency(self, level: PressureLevel) -> int:
-        if level is PressureLevel.CRITICAL:
-            return 0
-        if level is PressureLevel.HIGH:
-            return 1
-        return self._cfg.max_concurrency
+        self._gate = gate if gate is not None else get_default_gate()
 
     async def _evict_model(self) -> None:
         """Force immediate unload from unified memory via keep_alive:0."""
@@ -322,6 +316,24 @@ class LocalInferenceDirector:
         gc.collect()                # 2) dual-stage GC sweep
         gc.collect()
         await asyncio.sleep(0)      # 3) yield to host OS for RAM reclaim
+
+    async def memory_guard(self) -> None:
+        """Reuse the shared MemoryPressureGate before local inference.
+
+        At CRITICAL host memory, evict the resident model and refuse the op by
+        raising LocalMemoryCritical so the cascade routes upstream to remote
+        providers instead of OOM-ing the host. Concurrency is NOT handled here
+        (candidate_generator's _jprime_sem already caps local inference at 1).
+        Pass-through when the gate master switch is OFF.
+        """
+        if not memory_gate_enabled():
+            return
+        level = self._gate.pressure()
+        if level is PressureLevel.CRITICAL:
+            await self.enforce_memory(level)  # evict + dual gc + yield (existing)
+            raise LocalMemoryCritical(
+                "host memory CRITICAL - local inference refused; cascading upstream"
+            )
 
     async def stop(self) -> None:
         """Clean teardown: release the pooled session (zero hanging FDs)."""

--- a/tests/governance/test_local_inference_director.py
+++ b/tests/governance/test_local_inference_director.py
@@ -310,3 +310,93 @@ async def test_memory_guard_passthrough_when_gate_disabled(monkeypatch):
 
     d = LocalInferenceDirector(LocalConfig.from_env(), client=object(), gate=_FakeGate())
     await d.memory_guard()  # no raise because the gate master switch is OFF
+
+
+@pytest.mark.asyncio
+async def test_generate_consults_governor_and_refuses_at_critical():
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalPrimeClient, LocalConfig, LocalMemoryCritical)
+
+    class _RecordSession:
+        closed = False
+        def __init__(self): self.posts = []
+        def post(self, url, **kw):
+            self.posts.append((url, kw))
+            class _R:
+                status = 200
+                async def __aenter__(self_): return self_
+                async def __aexit__(self_, *a): return False
+                async def json(self_): return {"choices": [{"message": {"content": "x"}}]}
+            return _R()
+        async def close(self): self.closed = True
+
+    class _CriticalGov:
+        async def memory_guard(self):
+            raise LocalMemoryCritical("host CRITICAL")
+
+    sess = _RecordSession()
+    client = LocalPrimeClient(LocalConfig.from_env(), session=sess)
+    client.attach_governor(_CriticalGov())
+    with pytest.raises(LocalMemoryCritical):
+        await client.generate(prompt="do x", system_prompt="s", max_tokens=64)
+    # refused BEFORE any inference call to Ollama
+    assert sess.posts == []
+
+
+@pytest.mark.asyncio
+async def test_generate_calls_guard_then_proceeds_when_ok():
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalPrimeClient, LocalConfig)
+    calls = {"guard": 0}
+
+    class _OkGov:
+        async def memory_guard(self):
+            calls["guard"] += 1  # OK -> returns without raising
+
+    fake_payload = {"choices": [{"message": {"content": "OK"}}], "usage": {"completion_tokens": 3}}
+
+    class _FakeSession:
+        closed = False
+        def __init__(self): self.posts = []
+        def post(self, url, **kw):
+            self.posts.append((url, kw))
+            class _R:
+                status = 200
+                async def __aenter__(self_): return self_
+                async def __aexit__(self_, *a): return False
+                async def json(self_): return fake_payload
+            return _R()
+        async def close(self): self.closed = True
+
+    sess = _FakeSession()
+    client = LocalPrimeClient(LocalConfig.from_env(), session=sess)
+    client.attach_governor(_OkGov())
+    resp = await client.generate(prompt="hi", system_prompt="s", max_tokens=16)
+    assert resp.content == "OK"
+    assert calls["guard"] == 1            # guard consulted
+    assert len(sess.posts) == 1           # inference proceeded after guard passed
+
+
+@pytest.mark.asyncio
+async def test_generate_no_governor_is_phase3_behavior():
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalPrimeClient, LocalConfig)
+    fake_payload = {"choices": [{"message": {"content": "Z"}}], "usage": {"completion_tokens": 2}}
+
+    class _FakeSession:
+        closed = False
+        def __init__(self): self.posts = []
+        def post(self, url, **kw):
+            self.posts.append((url, kw))
+            class _R:
+                status = 200
+                async def __aenter__(self_): return self_
+                async def __aexit__(self_, *a): return False
+                async def json(self_): return fake_payload
+            return _R()
+        async def close(self): self.closed = True
+
+    client = LocalPrimeClient(LocalConfig.from_env(), session=_FakeSession())
+    # no attach_governor -> governor is None -> unchanged Phase 3 behavior
+    resp = await client.generate(prompt="hi", system_prompt="s")
+    assert resp.content == "Z"

--- a/tests/governance/test_local_inference_director.py
+++ b/tests/governance/test_local_inference_director.py
@@ -167,15 +167,6 @@ async def test_breaker_trips_on_ceiling_breach(monkeypatch):
         await client.complete_guarded(system="<s/>", user="<u/>", prompt_tokens=10)
 
 
-@pytest.mark.asyncio
-async def test_high_pressure_clamps_concurrency_to_one():
-    from backend.core.ouroboros.governance.local_inference_director import LocalInferenceDirector, LocalConfig
-    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
-    d = LocalInferenceDirector(LocalConfig.from_env(), client=object())
-    assert d.admit_concurrency(PressureLevel.OK) == LocalConfig.from_env().max_concurrency
-    assert d.admit_concurrency(PressureLevel.HIGH) == 1
-    assert d.admit_concurrency(PressureLevel.CRITICAL) == 0
-
 
 @pytest.mark.asyncio
 async def test_critical_eviction_unloads_and_gc(monkeypatch):
@@ -261,3 +252,61 @@ def test_build_local_prime_client_on_returns_client(monkeypatch):
     from backend.core.ouroboros.governance.local_inference_director import (
         build_local_prime_client, LocalPrimeClient)
     assert isinstance(build_local_prime_client(), LocalPrimeClient)
+
+
+@pytest.mark.asyncio
+async def test_memory_guard_critical_evicts_and_raises(monkeypatch):
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalInferenceDirector, LocalConfig, LocalPrimeClient, LocalMemoryCritical)
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    monkeypatch.setenv("JARVIS_MEMORY_PRESSURE_GATE_ENABLED", "true")
+    evicted = {"calls": []}
+
+    class _EvictSession:
+        closed = False
+        def post(self, url, **kw):
+            evicted["calls"].append(kw.get("json", {}))
+            class _R:
+                status = 200
+                async def __aenter__(self_): return self_
+                async def __aexit__(self_, *a): return False
+                async def json(self_): return {"status": "ok"}
+            return _R()
+        async def close(self): self.closed = True
+
+    class _FakeGate:
+        def pressure(self): return PressureLevel.CRITICAL
+
+    client = LocalPrimeClient(LocalConfig.from_env(), session=_EvictSession())
+    d = LocalInferenceDirector(LocalConfig.from_env(), client=client, gate=_FakeGate())
+    with pytest.raises(LocalMemoryCritical):
+        await d.memory_guard()
+    assert any(c.get("keep_alive") == 0 for c in evicted["calls"])  # evicted before refusing
+
+
+@pytest.mark.asyncio
+async def test_memory_guard_ok_passes(monkeypatch):
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalInferenceDirector, LocalConfig)
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    monkeypatch.setenv("JARVIS_MEMORY_PRESSURE_GATE_ENABLED", "true")
+
+    class _FakeGate:
+        def pressure(self): return PressureLevel.OK
+
+    d = LocalInferenceDirector(LocalConfig.from_env(), client=object(), gate=_FakeGate())
+    await d.memory_guard()  # returns None, no raise
+
+
+@pytest.mark.asyncio
+async def test_memory_guard_passthrough_when_gate_disabled(monkeypatch):
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalInferenceDirector, LocalConfig)
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    monkeypatch.setenv("JARVIS_MEMORY_PRESSURE_GATE_ENABLED", "false")
+
+    class _FakeGate:  # even if it would say CRITICAL, disabled gate => pass-through
+        def pressure(self): return PressureLevel.CRITICAL
+
+    d = LocalInferenceDirector(LocalConfig.from_env(), client=object(), gate=_FakeGate())
+    await d.memory_guard()  # no raise because the gate master switch is OFF

--- a/tests/governance/test_local_prime_cascade_integration.py
+++ b/tests/governance/test_local_prime_cascade_integration.py
@@ -61,3 +61,41 @@ def test_memory_critical_failure_class_attr():
     from backend.core.ouroboros.governance.local_inference_director import LocalMemoryCritical
     assert LocalMemoryCritical("x").failure_class == "local_memory_critical"
     assert isinstance(LocalMemoryCritical("x"), RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_client_with_real_director_refuses_at_critical(monkeypatch):
+    """Full chain: attach real LocalInferenceDirector(gate=CRITICAL) -> client.generate
+    consults memory_guard -> evicts model + raises LocalMemoryCritical (no inference)."""
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalConfig, LocalPrimeClient, LocalInferenceDirector, LocalMemoryCritical)
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    monkeypatch.setenv("JARVIS_MEMORY_PRESSURE_GATE_ENABLED", "true")
+
+    class _Session:
+        closed = False
+        def __init__(self): self.posts = []
+        def post(self, url, **kw):
+            self.posts.append((url, kw))
+            class _R:
+                status = 200
+                async def __aenter__(self_): return self_
+                async def __aexit__(self_, *a): return False
+                async def json(self_): return {"choices": [{"message": {"content": "x"}}],
+                                               "status": "ok"}
+            return _R()
+        async def close(self): self.closed = True
+
+    class _CriticalGate:
+        def pressure(self): return PressureLevel.CRITICAL
+
+    sess = _Session()
+    client = LocalPrimeClient(LocalConfig.from_env(), session=sess)
+    director = LocalInferenceDirector(LocalConfig.from_env(), client=client, gate=_CriticalGate())
+    client.attach_governor(director)
+
+    with pytest.raises(LocalMemoryCritical):
+        await client.generate(prompt="do x", system_prompt="s", max_tokens=64)
+    # the ONLY post allowed is the eviction unload (keep_alive:0); NO chat/completions inference
+    assert all("/v1/chat/completions" not in url for url, _ in sess.posts)
+    assert any(kw.get("json", {}).get("keep_alive") == 0 for _, kw in sess.posts)

--- a/tests/governance/test_local_prime_cascade_integration.py
+++ b/tests/governance/test_local_prime_cascade_integration.py
@@ -99,3 +99,13 @@ async def test_end_to_end_client_with_real_director_refuses_at_critical(monkeypa
     # the ONLY post allowed is the eviction unload (keep_alive:0); NO chat/completions inference
     assert all("/v1/chat/completions" not in url for url, _ in sess.posts)
     assert any(kw.get("json", {}).get("keep_alive") == 0 for _, kw in sess.posts)
+
+
+@pytest.mark.asyncio
+async def test_killswitch_off_no_governor_no_guard(monkeypatch):
+    """With the local tier OFF, build_local_prime_client() is None, so nothing is
+    injected, no governor is attached, and memory_guard is never reachable --
+    byte-identical to pre-Phase-3.1 behavior."""
+    monkeypatch.setenv("JARVIS_LOCAL_PRIME_ENABLED", "false")
+    from backend.core.ouroboros.governance.local_inference_director import build_local_prime_client
+    assert build_local_prime_client() is None

--- a/tests/governance/test_local_prime_cascade_integration.py
+++ b/tests/governance/test_local_prime_cascade_integration.py
@@ -46,3 +46,18 @@ async def test_director_stop_closes_session_no_leak(monkeypatch):
     await d.stop()
     assert client._session is None   # released
     assert fake.closed is True       # zero hanging FDs
+
+
+def test_memory_critical_maps_to_primary_degraded():
+    from backend.core.ouroboros.governance.local_inference_director import LocalMemoryCritical
+    from backend.core.ouroboros.governance.candidate_generator import classify_local_failure
+    verdict = classify_local_failure(LocalMemoryCritical("host CRITICAL"))
+    assert verdict.degrade is True
+    assert verdict.target_state == "PRIMARY_DEGRADED"
+    assert verdict.cascade_upstream is True
+
+
+def test_memory_critical_failure_class_attr():
+    from backend.core.ouroboros.governance.local_inference_director import LocalMemoryCritical
+    assert LocalMemoryCritical("x").failure_class == "local_memory_critical"
+    assert isinstance(LocalMemoryCritical("x"), RuntimeError)


### PR DESCRIPTION
## Summary
Makes the J-Prime local tier's **memory-eviction valve LIVE** (Phase 3 built it but nothing called it). At the single local-inference chokepoint, if host memory is **CRITICAL** the resident Ollama model is evicted (`keep_alive:0`) and the op is **refused** (`LocalMemoryCritical`) so it cascades upstream — protecting the 16 GB M1 from OOM.

## Reuse-first (zero duplication — the explicit goal)
Final review confirmed all four reuse points:
- **Concurrency:** rides the **existing `_jprime_sem`** (Semaphore(1) + `.locked()`→DW fall-through) in `candidate_generator.py`. The redundant `admit_concurrency` helper from Phase 3 was **retired** (no callers).
- **Memory signal:** reuses the shared **`MemoryPressureGate`** via `get_default_gate()` + honors `is_enabled()`. No new gate/probe.
- **Cascade:** `LocalMemoryCritical` (RuntimeError) propagates into the **existing** cascade catch (`candidate_generator.py:~4947`). No parallel FSM.
- **Only new mechanism:** the Ollama eviction (`_evict_model`) — distinct from the gate's advisory `can_fanout` (which *allows* 1 at CRITICAL; local inference must *refuse*).

## What changed (surgical: ~20 lines of net logic)
- `LocalInferenceDirector.memory_guard()` — reuse shared gate; CRITICAL → `enforce_memory` (evict + dual `gc.collect()` + yield) **then** raise `LocalMemoryCritical`; pass-through when the gate switch is off.
- `LocalPrimeClient.attach_governor()` + `generate()` calls `await memory_guard()` as its first action (evict-before-any-inference).
- GLS attaches the director to the injected client (makes the guard live).
- `classify_local_failure` recognizes both `terminal_lag_lockup` + `local_memory_critical`; additive log-only telemetry at the cascade catch.

## Safety
- **OFF byte-identical:** flag OFF → no client → no governor → guard unreachable. Regression sweep: **no new failures** vs baseline (pre-existing 23/25 + 5 collection errors confirmed unrelated).
- 30 tests green (eviction-before-refuse ordering, OK pass-through, gate-disabled pass-through, generate-refuses-with-zero-Ollama-calls, kill-switch parity, end-to-end with a real director).

Master kill-switch: `JARVIS_LOCAL_PRIME_ENABLED` (default OFF). Follow-on to PR #69571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the J‑Prime local tier’s memory guard live. On CRITICAL host memory, it evicts the resident Ollama model and refuses local inference so requests cascade upstream, preventing OOM on 16‑GB hosts.

- **New Features**
  - Memory guard at the local-inference chokepoint: consults the shared gate; on CRITICAL, evicts (`keep_alive:0`), runs GC, yields, then raises LocalMemoryCritical; pass-through when disabled.
  - LocalPrimeClient can attach a governor; generate() calls the guard first. GovernedLoop wires the director to the client so every local generate is checked.
  - Local-tier degrade telemetry: classify_local_failure maps terminal_lag_lockup and local_memory_critical to PRIMARY_DEGRADED with clear logs.
  - Safety: behind `JARVIS_LOCAL_PRIME_ENABLED` (default OFF) and the gate’s enable switch; no behavior change when off.

- **Refactors**
  - Removed redundant concurrency helper; reuse candidate_generator’s existing single-flight `_jprime_sem`.
  - Reused the shared MemoryPressureGate via get_default_gate(); no new probe or gate.
  - No new FSM paths; LocalMemoryCritical propagates into the existing cascade handler.

<sup>Written for commit a3c3d6bfe257bd1b7d216760894a02f5ad3a507a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

