### PR TITLE
feat(jprime): Phase 3.2 — TieredPrimeClient (GCP heavy + local light), wired not activated

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -3914,38 +3914,54 @@ class GovernedLoopService:
 
         # Build PrimeProvider if PrimeClient available
         _primary_probe_ok = False  # track for FSM sync after generator build
-        # J-Prime local activation (Phase 3): when no GCP PrimeClient is configured
-        # and the local tier is enabled, inject the local Ollama-backed client so
-        # PrimeProvider has a real backend. OFF or GCP-present -> no-op (legacy).
-        if self._prime_client is None:
-            try:
-                from backend.core.ouroboros.governance.local_inference_director import (
-                    build_local_prime_client,
-                    LocalConfig,
-                    LocalInferenceDirector,
+        # J-Prime tier wiring.
+        # Phase 3.2 (tiered, default OFF -> heavy GCP wired but NOT activated):
+        #   compose heavy (existing GCP prime_client) + light (governed local Ollama)
+        #   into a TieredPrimeClient. Phase 3.1 (default path): local-only injection
+        #   when no heavy client is configured. OFF for both -> byte-identical legacy.
+        try:
+            from backend.core.ouroboros.governance.local_inference_director import (
+                build_local_prime_client,
+                LocalConfig,
+                LocalInferenceDirector,
+            )
+            from backend.core.ouroboros.governance.tiered_prime_client import (
+                tiered_enabled,
+                build_tiered_prime_client,
+            )
+
+            def _build_governed_local():
+                _lp = build_local_prime_client()
+                if _lp is not None:
+                    _dir = LocalInferenceDirector(LocalConfig.from_env(), client=_lp)
+                    _lp.attach_governor(_dir)
+                    self._local_inference_director = _dir
+                return _lp
+
+            if tiered_enabled():
+                _light = _build_governed_local()
+                _composite = build_tiered_prime_client(
+                    heavy=self._prime_client, light=_light
                 )
-                _local_prime = build_local_prime_client()
+                if _composite is not None and _composite is not self._prime_client:
+                    self._prime_client = _composite
+                    logger.info(
+                        "[GovernedLoop] J-Prime tiered composite active "
+                        "(heavy=%s, light=%s)",
+                        self._prime_client is not None,
+                        _light is not None,
+                    )
+            elif self._prime_client is None:
+                _local_prime = _build_governed_local()
                 if _local_prime is not None:
                     self._prime_client = _local_prime
-                    # Give the local tier a live home so shutdown releases its
-                    # pooled aiohttp session (zero-FD teardown). The director also
-                    # hosts the CRITICAL memory-eviction valve consulted on every
-                    # local generate.
-                    self._local_inference_director = LocalInferenceDirector(
-                        LocalConfig.from_env(), client=_local_prime
-                    )
-                    # Phase 3.1: attach the director so every local generate()
-                    # consults memory_guard() (CRITICAL -> evict + refuse + cascade
-                    # upstream), protecting the host from OOM. Concurrency stays with
-                    # candidate_generator's existing _jprime_sem (no duplication).
-                    _local_prime.attach_governor(self._local_inference_director)
                     logger.info(
                         "[GovernedLoop] J-Prime local tier: LocalPrimeClient injected (Ollama)"
                     )
-            except Exception:
-                logger.debug(
-                    "[GovernedLoop] local prime injection skipped", exc_info=True
-                )
+        except Exception:
+            logger.debug(
+                "[GovernedLoop] J-Prime tier wiring skipped", exc_info=True
+            )
         if self._prime_client is not None:
             try:
                 from backend.core.ouroboros.governance.providers import (

--- a/backend/core/ouroboros/governance/tiered_prime_client.py
+++ b/backend/core/ouroboros/governance/tiered_prime_client.py
@@ -259,10 +259,17 @@ class TieredPrimeClient:
             await self._cancel_and_drain(heavy_task)
             self._record_heavy_failure()  # heavy too slow / failed -> soft failure
             return light_task.result()
-        # neither produced a clean success: drain both, then surface via fresh light
+        # neither produced a clean success: drain both (no-op on already-done tasks).
         await self._cancel_and_drain(light_task)
         await self._cancel_and_drain(heavy_task)
-        # final attempt on light (fresh) so the caller still gets a result if possible
+        # If the light hedge already finished with an exception (e.g. a deliberate
+        # LocalMemoryCritical valve refusal), surface it directly rather than firing
+        # a redundant third light call (which would duplicate the evict/refuse at
+        # CRITICAL memory). Only fall back to a fresh light attempt when the light
+        # hedge never produced a result (was still pending and got cancelled).
+        if (light_task.done() and not light_task.cancelled()
+                and light_task.exception() is not None):
+            raise light_task.exception()  # type: ignore[misc]
         return await self._light.generate(prompt, **kw)
 
     # ------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/tiered_prime_client.py
+++ b/backend/core/ouroboros/governance/tiered_prime_client.py
@@ -30,6 +30,12 @@ def _hedge_window_default_s() -> float:
     return float(os.environ.get("JARVIS_TIERED_HEDGE_WINDOW_MS", "800")) / 1000.0
 
 
+def tiered_enabled() -> bool:
+    """Master switch for composing the GCP-heavy + local-light tiered client.
+    Default OFF -> the heavy tier is wired but NOT activated."""
+    return os.environ.get("JARVIS_JPRIME_TIERED_ENABLED", "").strip().lower() in _TRUE
+
+
 class HeavyState(str, enum.Enum):
     HEALTHY = "HEALTHY"
     DEGRADED = "DEGRADED"

--- a/backend/core/ouroboros/governance/tiered_prime_client.py
+++ b/backend/core/ouroboros/governance/tiered_prime_client.py
@@ -13,10 +13,21 @@ from __future__ import annotations
 import asyncio
 import enum
 import logging
+import os
 import time
 from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
+
+_TRUE = {"1", "true", "yes", "on"}
+
+
+def _hedge_enabled_default() -> bool:
+    return os.environ.get("JARVIS_TIERED_HEDGE_ENABLED", "").strip().lower() in _TRUE
+
+
+def _hedge_window_default_s() -> float:
+    return float(os.environ.get("JARVIS_TIERED_HEDGE_WINDOW_MS", "800")) / 1000.0
 
 
 class HeavyState(str, enum.Enum):
@@ -61,6 +72,8 @@ class TieredPrimeClient:
         now_fn: Optional[Callable[[], float]] = None,
         failure_threshold: Optional[int] = None,
         cooldown_s: Optional[float] = None,
+        hedge_enabled: Optional[bool] = None,
+        hedge_window_s: Optional[float] = None,
     ) -> None:
         self._heavy = heavy
         self._light = light
@@ -75,6 +88,10 @@ class TieredPrimeClient:
         self._consecutive_failures: int = 0
         self._degraded_at: float = 0.0
         self._pending_recovery_probe: Optional[asyncio.Task] = None  # strong ref
+
+        # Hedging (Task 3)
+        self._hedge_enabled: bool = hedge_enabled if hedge_enabled is not None else _hedge_enabled_default()
+        self._hedge_window_s: float = hedge_window_s if hedge_window_s is not None else _hedge_window_default_s()
 
     @staticmethod
     def _resolve_recovery_params() -> tuple[int, float]:
@@ -171,6 +188,8 @@ class TieredPrimeClient:
         # Heavy tier only when HEALTHY. When DEGRADED, skip heavy entirely and,
         # once the cooldown has elapsed, schedule a non-blocking recovery probe.
         if self._heavy is not None and self._heavy_state is HeavyState.HEALTHY:
+            if self._hedge_enabled and self._light is not None:
+                return await self._generate_hedged(prompt, kw)
             try:
                 result = await self._heavy.generate(prompt, **kw)
                 self._record_heavy_success()
@@ -191,6 +210,54 @@ class TieredPrimeClient:
         if self._light is not None:
             return await self._light.generate(prompt, **kw)
         raise RuntimeError("tiered_prime_client: no tier available")
+
+    # ------------------------------------------------------------------
+    # Hedging helpers (Task 3)
+    # ------------------------------------------------------------------
+
+    async def _cancel_and_drain(self, task: "Optional[asyncio.Task]") -> None:
+        """Cancel a laggard task and await it so no task/FD/socket leaks."""
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    async def _generate_hedged(self, prompt: str, kw: dict) -> Any:
+        """Start heavy; if it doesn't finish within the hedge window, race a local
+        hedge. Accept first success; cancel the laggard cleanly. Heavy too-slow or
+        failed -> record_heavy_failure (FSM signal); heavy win -> record_success."""
+        heavy_task: asyncio.Task = asyncio.ensure_future(self._heavy.generate(prompt, **kw))
+        done, _pending = await asyncio.wait({heavy_task}, timeout=self._hedge_window_s)
+        if heavy_task in done:
+            try:
+                result = heavy_task.result()
+                self._record_heavy_success()
+                return result
+            except Exception as exc:
+                self._record_heavy_failure()
+                logger.info("[Tiered] heavy failed within window (%s) -> light", exc)
+                return await self._light.generate(prompt, **kw)
+        # window elapsed: race a local hedge
+        light_task: asyncio.Task = asyncio.ensure_future(self._light.generate(prompt, **kw))
+        done, pending = await asyncio.wait(
+            {heavy_task, light_task}, return_when=asyncio.FIRST_COMPLETED)
+        # Prefer a heavy success; else take a light success.
+        if heavy_task in done and not heavy_task.cancelled() and heavy_task.exception() is None:
+            await self._cancel_and_drain(light_task)
+            self._record_heavy_success()
+            return heavy_task.result()
+        if light_task in done and not light_task.cancelled() and light_task.exception() is None:
+            await self._cancel_and_drain(heavy_task)
+            self._record_heavy_failure()  # heavy too slow / failed -> soft failure
+            return light_task.result()
+        # neither produced a clean success: drain both, then surface via fresh light
+        await self._cancel_and_drain(light_task)
+        await self._cancel_and_drain(heavy_task)
+        # final attempt on light (fresh) so the caller still gets a result if possible
+        return await self._light.generate(prompt, **kw)
 
     # ------------------------------------------------------------------
     # Health + lifecycle

--- a/backend/core/ouroboros/governance/tiered_prime_client.py
+++ b/backend/core/ouroboros/governance/tiered_prime_client.py
@@ -10,10 +10,18 @@ Task 1 = basic routing. Health hysteresis FSM (Task 2) and speculative hedging
 """
 from __future__ import annotations
 
+import asyncio
+import enum
 import logging
-from typing import Any, Optional
+import time
+from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
+
+
+class HeavyState(str, enum.Enum):
+    HEALTHY = "HEALTHY"
+    DEGRADED = "DEGRADED"
 
 
 def _is_available(status: Any) -> bool:
@@ -35,33 +43,158 @@ async def _close_any(client: Any) -> None:
 
 
 class TieredPrimeClient:
-    """Composite of heavy + light PrimeClient-compatible tiers."""
+    """Composite of heavy + light PrimeClient-compatible tiers.
 
-    def __init__(self, *, heavy: Any, light: Any) -> None:
+    Task 2 adds a health hysteresis FSM for the heavy tier:
+    - Consecutive failures >= failure_threshold -> DEGRADED (route to light).
+    - While DEGRADED within the cooldown window, heavy is completely bypassed.
+    - Once the cooldown elapses, a NON-BLOCKING background recovery probe is
+      scheduled (strong ref, cleared in finally). A clean probe re-promotes to
+      HEALTHY; a failing probe keeps the state DEGRADED.
+    """
+
+    def __init__(
+        self,
+        *,
+        heavy: Any,
+        light: Any,
+        now_fn: Optional[Callable[[], float]] = None,
+        failure_threshold: Optional[int] = None,
+        cooldown_s: Optional[float] = None,
+    ) -> None:
         self._heavy = heavy
         self._light = light
+        self._now = now_fn or time.monotonic
+
+        thr, cool = self._resolve_recovery_params()
+        self._failure_threshold: int = failure_threshold if failure_threshold is not None else thr
+        self._cooldown_s: float = cooldown_s if cooldown_s is not None else cool
+
+        # FSM state (Task 2)
+        self._heavy_state: HeavyState = HeavyState.HEALTHY
+        self._consecutive_failures: int = 0
+        self._degraded_at: float = 0.0
+        self._pending_recovery_probe: Optional[asyncio.Task] = None  # strong ref
+
+    @staticmethod
+    def _resolve_recovery_params() -> tuple[int, float]:
+        """Pull circuit-breaker params from recovery_policy; fall back to 3/30.0."""
+        try:
+            from backend.core.recovery_policy import get_recovery_params
+            rp = get_recovery_params("prime_router")
+            if rp is not None:
+                return int(rp.circuit_failure_threshold), float(rp.circuit_recovery_seconds)
+        except Exception:
+            pass
+        return 3, 30.0
 
     @property
     def provider_name(self) -> str:
         return "tiered-jprime"
 
-    async def generate(self, prompt: str, system_prompt: Optional[str] = None,
-                       context: Optional[Any] = None, max_tokens: int = 4096,
-                       temperature: float = 0.7, model_name: Optional[str] = None,
-                       task_profile: Optional[Any] = None, **kwargs: Any) -> Any:
-        kw = dict(system_prompt=system_prompt, context=context, max_tokens=max_tokens,
-                  temperature=temperature, model_name=model_name,
-                  task_profile=task_profile, **kwargs)
-        if self._heavy is not None:
+    # ------------------------------------------------------------------
+    # FSM helpers
+    # ------------------------------------------------------------------
+
+    def heavy_state(self) -> str:
+        return self._heavy_state.value
+
+    def _record_heavy_success(self) -> None:
+        self._consecutive_failures = 0
+        self._heavy_state = HeavyState.HEALTHY
+
+    def _record_heavy_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= self._failure_threshold:
+            if self._heavy_state is not HeavyState.DEGRADED:
+                self._heavy_state = HeavyState.DEGRADED
+                self._degraded_at = self._now()
+                logger.info(
+                    "[Tiered] heavy DEGRADED after %d consecutive failures (cooldown=%.1fs)",
+                    self._consecutive_failures,
+                    self._cooldown_s,
+                )
+
+    def _cooldown_elapsed(self) -> bool:
+        return (self._now() - self._degraded_at) >= self._cooldown_s
+
+    async def _recovery_probe(self) -> None:
+        """Non-blocking background probe: re-promote heavy only on a clean health check."""
+        try:
+            status = await self._heavy._check_health()
+            if _is_available(status):
+                self._record_heavy_success()
+                logger.info("[Tiered] heavy recovery probe OK -> re-promoted HEALTHY")
+            else:
+                logger.debug("[Tiered] heavy recovery probe returned UNAVAILABLE -> stays DEGRADED")
+        except Exception:
+            logger.debug("[Tiered] heavy recovery probe raised", exc_info=True)
+        finally:
+            self._pending_recovery_probe = None
+
+    def _maybe_schedule_recovery_probe(self) -> None:
+        """Schedule a background recovery probe if cooldown has elapsed and none is running."""
+        if (
+            self._heavy_state is HeavyState.DEGRADED
+            and self._cooldown_elapsed()
+            and self._pending_recovery_probe is None
+            and self._heavy is not None
+        ):
+            # ensure_future keeps a strong ref via self._pending_recovery_probe;
+            # the finally block in _recovery_probe clears it when done.
+            self._pending_recovery_probe = asyncio.ensure_future(self._recovery_probe())
+
+    # ------------------------------------------------------------------
+    # Core generate (Task 1 routing extended by Task 2 FSM)
+    # ------------------------------------------------------------------
+
+    async def generate(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        context: Optional[Any] = None,
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        model_name: Optional[str] = None,
+        task_profile: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> Any:
+        kw = dict(
+            system_prompt=system_prompt,
+            context=context,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            model_name=model_name,
+            task_profile=task_profile,
+            **kwargs,
+        )
+        # Heavy tier only when HEALTHY. When DEGRADED, skip heavy entirely and,
+        # once the cooldown has elapsed, schedule a non-blocking recovery probe.
+        if self._heavy is not None and self._heavy_state is HeavyState.HEALTHY:
             try:
-                return await self._heavy.generate(prompt, **kw)
+                result = await self._heavy.generate(prompt, **kw)
+                self._record_heavy_success()
+                return result
             except Exception as exc:
-                logger.info("[Tiered] heavy generate failed (%s) -> light", exc)
+                self._record_heavy_failure()
+                logger.info(
+                    "[Tiered] heavy generate failed (%s) state=%s -> light",
+                    exc,
+                    self._heavy_state.value,
+                )
                 if self._light is None:
                     raise
+        else:
+            # DEGRADED path: maybe kick off a background probe
+            self._maybe_schedule_recovery_probe()
+
         if self._light is not None:
             return await self._light.generate(prompt, **kw)
         raise RuntimeError("tiered_prime_client: no tier available")
+
+    # ------------------------------------------------------------------
+    # Health + lifecycle
+    # ------------------------------------------------------------------
 
     async def _check_health(self) -> Any:
         from backend.core.prime_client import PrimeStatus

--- a/backend/core/ouroboros/governance/tiered_prime_client.py
+++ b/backend/core/ouroboros/governance/tiered_prime_client.py
@@ -1,0 +1,92 @@
+"""TieredPrimeClient -- composite J-Prime tier (Phase 3.2).
+
+Drop-in PrimeClient placing a HEAVY tier (GCP jarvis-prime via get_prime_client)
+ALONGSIDE a LIGHT tier (LocalPrimeClient / Ollama). Prefers heavy; falls to light
+on heavy failure/unavailability. Presents the same generate/_check_health/aclose
+contract PrimeProvider already consumes (no changes to PrimeProvider).
+
+Task 1 = basic routing. Health hysteresis FSM (Task 2) and speculative hedging
+(Task 3) layer on top without changing this contract.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _is_available(status: Any) -> bool:
+    return getattr(status, "name", "") == "AVAILABLE"
+
+
+async def _close_any(client: Any) -> None:
+    """Close a tier via aclose() or close(), best-effort (zero hanging FDs)."""
+    if client is None:
+        return
+    for meth in ("aclose", "close"):
+        fn = getattr(client, meth, None)
+        if fn is not None:
+            try:
+                await fn()
+            except Exception:
+                logger.debug("[Tiered] close via %s failed", meth, exc_info=True)
+            return
+
+
+class TieredPrimeClient:
+    """Composite of heavy + light PrimeClient-compatible tiers."""
+
+    def __init__(self, *, heavy: Any, light: Any) -> None:
+        self._heavy = heavy
+        self._light = light
+
+    @property
+    def provider_name(self) -> str:
+        return "tiered-jprime"
+
+    async def generate(self, prompt: str, system_prompt: Optional[str] = None,
+                       context: Optional[Any] = None, max_tokens: int = 4096,
+                       temperature: float = 0.7, model_name: Optional[str] = None,
+                       task_profile: Optional[Any] = None, **kwargs: Any) -> Any:
+        kw = dict(system_prompt=system_prompt, context=context, max_tokens=max_tokens,
+                  temperature=temperature, model_name=model_name,
+                  task_profile=task_profile, **kwargs)
+        if self._heavy is not None:
+            try:
+                return await self._heavy.generate(prompt, **kw)
+            except Exception as exc:
+                logger.info("[Tiered] heavy generate failed (%s) -> light", exc)
+                if self._light is None:
+                    raise
+        if self._light is not None:
+            return await self._light.generate(prompt, **kw)
+        raise RuntimeError("tiered_prime_client: no tier available")
+
+    async def _check_health(self) -> Any:
+        from backend.core.prime_client import PrimeStatus
+        for tier in (self._heavy, self._light):
+            if tier is None:
+                continue
+            try:
+                if _is_available(await tier._check_health()):
+                    return PrimeStatus.AVAILABLE
+            except Exception:
+                logger.debug("[Tiered] health probe failed", exc_info=True)
+        return PrimeStatus.UNAVAILABLE
+
+    async def aclose(self) -> None:
+        await _close_any(self._heavy)
+        await _close_any(self._light)
+
+
+def build_tiered_prime_client(*, heavy: Any, light: Any) -> Any:
+    """Factory. Both -> TieredPrimeClient; exactly one -> that one (passthrough);
+    neither -> None (byte-identical legacy)."""
+    if heavy is not None and light is not None:
+        return TieredPrimeClient(heavy=heavy, light=light)
+    if heavy is not None:
+        return heavy
+    if light is not None:
+        return light
+    return None

--- a/scripts/smoke_jprime_local.py
+++ b/scripts/smoke_jprime_local.py
@@ -1,0 +1,91 @@
+"""Live smoke test for the J-Prime local tier (Phase 3 + 3.1) against real Ollama.
+
+Run: JARVIS_LOCAL_PRIME_ENABLED=true python3 scripts/smoke_jprime_local.py
+Requires: native Ollama on :11434 with qwen2.5-coder:3b pulled.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+
+async def main() -> int:
+    os.environ.setdefault("JARVIS_LOCAL_PRIME_ENABLED", "true")
+    os.environ.setdefault("JARVIS_MEMORY_PRESSURE_GATE_ENABLED", "true")
+
+    from backend.core.ouroboros.governance.local_inference_director import (
+        build_local_prime_client,
+        LocalConfig,
+        LocalInferenceDirector,
+        LocalMemoryCritical,
+    )
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+
+    client = build_local_prime_client()
+    assert client is not None, "kill-switch should be ON for the smoke test"
+    print(f"[1] build_local_prime_client -> {type(client).__name__}  model={LocalConfig.from_env().model_name}")
+
+    # Health probe (drop-in PrimeClient._check_health)
+    status = await client._check_health()
+    print(f"[2] _check_health -> {status.name}")
+
+    # Cold generate (drop-in PrimeClient.generate -> PrimeResponse)
+    t0 = time.monotonic()
+    resp = await client.generate(
+        prompt="Write a Python function fib(n) returning the nth Fibonacci number. Code only.",
+        system_prompt="You are a terse code generator. Output only Python code, no prose.",
+        max_tokens=200,
+        temperature=0.0,
+    )
+    cold_ms = (time.monotonic() - t0) * 1000.0
+    print(f"[3] generate (cold) -> source={resp.source} tokens={resp.tokens_used} "
+          f"wall={cold_ms:.0f}ms latency_ms={resp.latency_ms:.0f}")
+    print("    --- content (first 240 chars) ---")
+    print("    " + resp.content[:240].replace("\n", "\n    "))
+
+    # Warm generate (weights resident -> should be faster TTFT)
+    t0 = time.monotonic()
+    resp2 = await client.generate(
+        prompt="Write a one-line Python lambda that squares its argument. Code only.",
+        system_prompt="Output only code.",
+        max_tokens=64,
+        temperature=0.0,
+    )
+    warm_ms = (time.monotonic() - t0) * 1000.0
+    print(f"[4] generate (warm) -> wall={warm_ms:.0f}ms tokens={resp2.tokens_used} "
+          f"content={resp2.content[:80]!r}")
+
+    # Profiler warmed?
+    print(f"[5] profiler.is_warm()={client.profiler.is_warm()} "
+          f"adaptive_timeout_ms(prompt_tokens=500)={client.profiler.adaptive_timeout_ms(prompt_tokens=500):.0f}")
+
+    # Live memory guard: a CRITICAL gate must evict + refuse (cascade upstream),
+    # proving the Phase 3.1 valve fires against the real engine.
+    class _CriticalGate:
+        def pressure(self):
+            return PressureLevel.CRITICAL
+
+    director = LocalInferenceDirector(LocalConfig.from_env(), client=client, gate=_CriticalGate())
+    client.attach_governor(director)
+    refused = False
+    try:
+        await client.generate(prompt="this must be refused", system_prompt="x", max_tokens=16)
+    except LocalMemoryCritical as e:
+        refused = True
+        print(f"[6] memory_guard CRITICAL -> evicted + refused (LocalMemoryCritical): {e}")
+    assert refused, "memory guard must refuse at CRITICAL"
+
+    # Detach + confirm normal generation resumes (model reloads on demand)
+    client.attach_governor(None)
+    resp3 = await client.generate(prompt="print('hi')? Output only code.", system_prompt="x", max_tokens=32)
+    print(f"[7] post-evict generate -> content={resp3.content[:60]!r} (model reloaded on demand)")
+
+    await client.aclose()
+    print("[8] aclose -> session released (zero hanging FDs)")
+    print("\nSMOKE: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/governance/test_tiered_health_fsm.py
+++ b/tests/governance/test_tiered_health_fsm.py
@@ -1,0 +1,98 @@
+# tests/governance/test_tiered_health_fsm.py
+from __future__ import annotations
+import pytest
+
+
+class _Resp:
+    def __init__(self, c): self.content = c
+
+
+class _Heavy:
+    def __init__(self, *, fail=False, healthy=True):
+        self.fail = fail; self.healthy = healthy
+        self.gen_calls = 0; self.health_calls = 0
+    async def generate(self, prompt, **kw):
+        self.gen_calls += 1
+        if self.fail: raise RuntimeError("heavy down")
+        return _Resp(f"HEAVY:{prompt}")
+    async def _check_health(self):
+        self.health_calls += 1
+        class _S: pass
+        s = _S(); s.name = "AVAILABLE" if self.healthy else "UNAVAILABLE"
+        return s
+    async def aclose(self): pass
+
+
+class _Light:
+    def __init__(self): self.gen_calls = 0
+    async def generate(self, prompt, **kw):
+        self.gen_calls += 1
+        return _Resp(f"LIGHT:{prompt}")
+    async def _check_health(self):
+        class _S: pass
+        s = _S(); s.name = "AVAILABLE"; return s
+    async def aclose(self): pass
+
+
+def _mk(heavy, light, t):
+    from backend.core.ouroboros.governance.tiered_prime_client import TieredPrimeClient
+    # injectable clock + tiny cooldown via explicit params
+    return TieredPrimeClient(heavy=heavy, light=light, now_fn=t,
+                             failure_threshold=2, cooldown_s=100.0)
+
+
+@pytest.mark.asyncio
+async def test_single_failure_does_not_degrade():
+    clock = {"t": 0.0}
+    heavy = _Heavy(fail=True); light = _Light()
+    t = _mk(heavy, light, lambda: clock["t"])
+    r = await t.generate(prompt="a")          # heavy fails once -> light, but still HEALTHY
+    assert r.content == "LIGHT:a"
+    assert t.heavy_state() == "HEALTHY"        # below threshold (2)
+
+
+@pytest.mark.asyncio
+async def test_threshold_failures_degrade_and_skip_heavy():
+    clock = {"t": 0.0}
+    heavy = _Heavy(fail=True); light = _Light()
+    t = _mk(heavy, light, lambda: clock["t"])
+    await t.generate(prompt="a")               # fail 1
+    await t.generate(prompt="b")               # fail 2 -> DEGRADED
+    assert t.heavy_state() == "DEGRADED"
+    heavy.gen_calls = 0
+    r = await t.generate(prompt="c")           # DEGRADED + within cooldown -> skip heavy entirely
+    assert r.content == "LIGHT:c"
+    assert heavy.gen_calls == 0                 # heavy NOT called while degraded in cooldown
+
+
+@pytest.mark.asyncio
+async def test_recovery_probe_repromotes_after_cooldown():
+    clock = {"t": 0.0}
+    heavy = _Heavy(fail=True); light = _Light()
+    t = _mk(heavy, light, lambda: clock["t"])
+    await t.generate(prompt="a"); await t.generate(prompt="b")   # -> DEGRADED at t=0
+    assert t.heavy_state() == "DEGRADED"
+    # advance past cooldown; heavy is now actually healthy again
+    clock["t"] = 200.0
+    heavy.fail = False; heavy.healthy = True
+    await t.generate(prompt="c")               # degraded+cooldown elapsed -> schedules bg recovery probe, routes light
+    probe = t._pending_recovery_probe          # background task handle (strong ref)
+    assert probe is not None
+    await probe                                  # await the non-blocking probe deterministically
+    assert t.heavy_state() == "HEALTHY"          # clean probe re-promoted
+    r = await t.generate(prompt="d")             # now heavy used again
+    assert r.content == "HEAVY:d"
+
+
+@pytest.mark.asyncio
+async def test_recovery_probe_failure_keeps_degraded():
+    clock = {"t": 0.0}
+    heavy = _Heavy(fail=True); light = _Light()
+    t = _mk(heavy, light, lambda: clock["t"])
+    await t.generate(prompt="a"); await t.generate(prompt="b")   # DEGRADED
+    clock["t"] = 200.0
+    heavy.healthy = False                        # remote still unhealthy
+    await t.generate(prompt="c")                 # schedules probe
+    if t._pending_recovery_probe is not None:
+        await t._pending_recovery_probe
+    assert t.heavy_state() == "DEGRADED"         # probe failed -> stays degraded

--- a/tests/governance/test_tiered_hedging.py
+++ b/tests/governance/test_tiered_hedging.py
@@ -1,0 +1,78 @@
+# tests/governance/test_tiered_hedging.py
+from __future__ import annotations
+import asyncio
+import pytest
+
+
+class _Resp:
+    def __init__(self, c): self.content = c
+
+
+class _DelayedClient:
+    """Generates after `delay` seconds; tracks cancellation cleanliness."""
+    def __init__(self, tag, delay):
+        self.tag = tag; self.delay = delay
+        self.started = 0; self.completed = 0; self.cancelled = 0
+    async def generate(self, prompt, **kw):
+        self.started += 1
+        try:
+            await asyncio.sleep(self.delay)
+        except asyncio.CancelledError:
+            self.cancelled += 1
+            raise
+        self.completed += 1
+        return _Resp(f"{self.tag}:{prompt}")
+    async def _check_health(self):
+        class _S: pass
+        s = _S(); s.name = "AVAILABLE"; return s
+    async def aclose(self): pass
+
+
+def _mk(heavy, light, *, hedge_window_s):
+    from backend.core.ouroboros.governance.tiered_prime_client import TieredPrimeClient
+    return TieredPrimeClient(heavy=heavy, light=light, hedge_enabled=True,
+                             hedge_window_s=hedge_window_s)
+
+
+@pytest.mark.asyncio
+async def test_hedge_disabled_by_default_uses_heavy_only(monkeypatch):
+    monkeypatch.delenv("JARVIS_TIERED_HEDGE_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.tiered_prime_client import TieredPrimeClient
+    heavy = _DelayedClient("HEAVY", 0.0); light = _DelayedClient("LIGHT", 0.0)
+    t = TieredPrimeClient(heavy=heavy, light=light)   # hedge defaults OFF
+    r = await t.generate(prompt="x")
+    assert r.content == "HEAVY:x"
+    assert light.started == 0
+
+
+@pytest.mark.asyncio
+async def test_hedge_heavy_fast_wins_no_light():
+    heavy = _DelayedClient("HEAVY", 0.0); light = _DelayedClient("LIGHT", 5.0)
+    t = _mk(heavy, light, hedge_window_s=0.5)
+    r = await t.generate(prompt="x")
+    assert r.content == "HEAVY:x"
+    assert light.started == 0           # heavy finished within window -> no hedge spawned
+
+
+@pytest.mark.asyncio
+async def test_hedge_heavy_slow_light_wins_and_heavy_cancelled_cleanly():
+    heavy = _DelayedClient("HEAVY", 5.0); light = _DelayedClient("LIGHT", 0.05)
+    t = _mk(heavy, light, hedge_window_s=0.1)
+    r = await t.generate(prompt="x")
+    assert r.content == "LIGHT:x"        # light won
+    assert light.completed == 1
+    assert heavy.cancelled == 1          # laggard heavy cancelled CLEANLY (CancelledError observed)
+    assert heavy.completed == 0
+    # heavy slow -> recorded as a soft failure for the FSM
+    assert t._consecutive_failures >= 1
+
+
+@pytest.mark.asyncio
+async def test_hedge_no_leaked_tasks_after_completion():
+    heavy = _DelayedClient("HEAVY", 5.0); light = _DelayedClient("LIGHT", 0.05)
+    t = _mk(heavy, light, hedge_window_s=0.1)
+    before = len(asyncio.all_tasks())
+    await t.generate(prompt="x")
+    await asyncio.sleep(0.05)            # let any teardown settle
+    after = len(asyncio.all_tasks())
+    assert after <= before              # no dangling hedge/laggard tasks leaked

--- a/tests/governance/test_tiered_memory_and_leaks.py
+++ b/tests/governance/test_tiered_memory_and_leaks.py
@@ -1,0 +1,118 @@
+# tests/governance/test_tiered_memory_and_leaks.py
+from __future__ import annotations
+import asyncio
+import pytest
+
+
+def _local_with_critical_governor(monkeypatch):
+    """Build a REAL LocalPrimeClient (light tier) with a CRITICAL-gate governor."""
+    monkeypatch.setenv("JARVIS_MEMORY_PRESSURE_GATE_ENABLED", "true")
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalConfig, LocalPrimeClient, LocalInferenceDirector)
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+
+    class _EvictSession:
+        closed = False
+        def __init__(self): self.posts = []
+        def post(self, url, **kw):
+            self.posts.append((url, kw))
+            class _R:
+                status = 200
+                async def __aenter__(self_): return self_
+                async def __aexit__(self_, *a): return False
+                async def json(self_): return {"choices": [{"message": {"content": "x"}}], "status": "ok"}
+            return _R()
+        async def close(self): self.closed = True
+
+    class _CriticalGate:
+        def pressure(self): return PressureLevel.CRITICAL
+
+    sess = _EvictSession()
+    light = LocalPrimeClient(LocalConfig.from_env(), session=sess)
+    director = LocalInferenceDirector(LocalConfig.from_env(), client=light, gate=_CriticalGate())
+    light.attach_governor(director)
+    return light, sess
+
+
+class _FailingHeavy:
+    def __init__(self, *, exc=None): self._exc = exc or RuntimeError("heavy quota exhausted")
+    async def generate(self, prompt, **kw): raise self._exc
+    async def _check_health(self):
+        class _S: pass
+        s = _S(); s.name = "UNAVAILABLE"; return s
+    async def aclose(self): pass
+
+
+@pytest.mark.asyncio
+async def test_memory_valve_overrides_when_composite_routes_to_light(monkeypatch):
+    """heavy fails -> composite routes to light -> light's memory_guard fires at CRITICAL."""
+    from backend.core.ouroboros.governance.tiered_prime_client import TieredPrimeClient
+    from backend.core.ouroboros.governance.local_inference_director import LocalMemoryCritical
+    light, sess = _local_with_critical_governor(monkeypatch)
+    t = TieredPrimeClient(heavy=_FailingHeavy(), light=light)  # hedge off
+    with pytest.raises(LocalMemoryCritical):
+        await t.generate(prompt="x", system_prompt="s", max_tokens=32)
+    # the valve evicted + refused before any chat/completions inference on the light tier
+    assert all("/v1/chat/completions" not in url for url, _ in sess.posts)
+    assert any(kw.get("json", {}).get("keep_alive") == 0 for _, kw in sess.posts)
+
+
+@pytest.mark.asyncio
+async def test_heavy_quota_exhaustion_cascades_to_light_cleanly(monkeypatch):
+    """With memory OK, heavy quota-exhaustion cascades to a working local light tier."""
+    monkeypatch.setenv("JARVIS_MEMORY_PRESSURE_GATE_ENABLED", "false")  # valve pass-through
+    from backend.core.ouroboros.governance.tiered_prime_client import TieredPrimeClient
+    from backend.core.ouroboros.governance.local_inference_director import (
+        LocalConfig, LocalPrimeClient)
+
+    class _OkSession:
+        closed = False
+        def __init__(self): self.posts = []
+        def post(self, url, **kw):
+            self.posts.append((url, kw))
+            class _R:
+                status = 200
+                async def __aenter__(self_): return self_
+                async def __aexit__(self_, *a): return False
+                async def json(self_): return {"choices": [{"message": {"content": "LOCAL_OK"}}],
+                                               "usage": {"completion_tokens": 3}}
+            return _R()
+        async def close(self): self.closed = True
+
+    light = LocalPrimeClient(LocalConfig.from_env(), session=_OkSession())
+    t = TieredPrimeClient(heavy=_FailingHeavy(exc=RuntimeError("terminal_quota")), light=light)
+    resp = await t.generate(prompt="x", system_prompt="s", max_tokens=16)
+    assert resp.content == "LOCAL_OK"
+    assert t.heavy_state() in ("HEALTHY", "DEGRADED")  # FSM recorded the failure
+
+
+@pytest.mark.asyncio
+async def test_hedge_cancellation_leaves_no_dangling_tasks():
+    """Hedge path cancels the laggard with no leaked tasks (reinforces Task 3)."""
+    from backend.core.ouroboros.governance.tiered_prime_client import TieredPrimeClient
+
+    class _Resp:
+        def __init__(self, c): self.content = c
+
+    class _Delayed:
+        def __init__(self, tag, delay): self.tag = tag; self.delay = delay; self.cancelled = 0
+        async def generate(self, prompt, **kw):
+            try:
+                await asyncio.sleep(self.delay)
+            except asyncio.CancelledError:
+                self.cancelled += 1; raise
+            return _Resp(f"{self.tag}")
+        async def _check_health(self):
+            class _S: pass
+            s = _S(); s.name = "AVAILABLE"; return s
+        async def aclose(self): pass
+
+    heavy = _Delayed("HEAVY", 5.0); light = _Delayed("LIGHT", 0.02)
+    t = TieredPrimeClient(heavy=heavy, light=light, hedge_enabled=True, hedge_window_s=0.05)
+    before = len(asyncio.all_tasks())
+    r = await t.generate(prompt="x")
+    await asyncio.sleep(0.05)
+    after = len(asyncio.all_tasks())
+    assert r.content == "LIGHT"
+    assert heavy.cancelled == 1
+    assert after <= before

--- a/tests/governance/test_tiered_prime_client.py
+++ b/tests/governance/test_tiered_prime_client.py
@@ -75,3 +75,11 @@ def test_factory_both_returns_tiered_only_one_returns_that_one():
     assert build_tiered_prime_client(heavy=None, light=light) is light   # only light -> passthrough
     assert build_tiered_prime_client(heavy=heavy, light=None) is heavy   # only heavy -> passthrough
     assert build_tiered_prime_client(heavy=None, light=None) is None     # neither -> None (legacy)
+
+
+def test_tiered_enabled_default_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_JPRIME_TIERED_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.tiered_prime_client import tiered_enabled
+    assert tiered_enabled() is False
+    monkeypatch.setenv("JARVIS_JPRIME_TIERED_ENABLED", "true")
+    assert tiered_enabled() is True

--- a/tests/governance/test_tiered_prime_client.py
+++ b/tests/governance/test_tiered_prime_client.py
@@ -1,0 +1,77 @@
+# tests/governance/test_tiered_prime_client.py
+from __future__ import annotations
+import pytest
+
+
+class _FakeResp:
+    def __init__(self, content): self.content = content; self.name = "AVAILABLE"
+
+
+class _FakeClient:
+    """Duck-typed PrimeClient: configurable generate result / health / failure."""
+    def __init__(self, tag, *, healthy=True, fail=False):
+        self.tag = tag; self._healthy = healthy; self._fail = fail
+        self.gen_calls = 0; self.closed = False
+
+    async def generate(self, prompt, **kw):
+        self.gen_calls += 1
+        if self._fail:
+            raise RuntimeError(f"{self.tag} boom")
+        return _FakeResp(f"{self.tag}:{prompt}")
+
+    async def _check_health(self):
+        class _S:  # mimic PrimeStatus member
+            pass
+        s = _S()
+        s.name = "AVAILABLE" if self._healthy else "UNAVAILABLE"
+        return s
+
+    async def aclose(self): self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_tiered_prefers_heavy_when_healthy():
+    from backend.core.ouroboros.governance.tiered_prime_client import TieredPrimeClient
+    heavy = _FakeClient("HEAVY"); light = _FakeClient("LIGHT")
+    t = TieredPrimeClient(heavy=heavy, light=light)
+    r = await t.generate(prompt="x")
+    assert r.content == "HEAVY:x"
+    assert heavy.gen_calls == 1 and light.gen_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_tiered_falls_to_light_on_heavy_failure():
+    from backend.core.ouroboros.governance.tiered_prime_client import TieredPrimeClient
+    heavy = _FakeClient("HEAVY", fail=True); light = _FakeClient("LIGHT")
+    t = TieredPrimeClient(heavy=heavy, light=light)
+    r = await t.generate(prompt="x")
+    assert r.content == "LIGHT:x"
+    assert heavy.gen_calls == 1 and light.gen_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_tiered_health_available_if_either_available():
+    from backend.core.ouroboros.governance.tiered_prime_client import TieredPrimeClient
+    heavy = _FakeClient("HEAVY", healthy=False); light = _FakeClient("LIGHT", healthy=True)
+    t = TieredPrimeClient(heavy=heavy, light=light)
+    s = await t._check_health()
+    assert s.name == "AVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_tiered_aclose_closes_both():
+    from backend.core.ouroboros.governance.tiered_prime_client import TieredPrimeClient
+    heavy = _FakeClient("HEAVY"); light = _FakeClient("LIGHT")
+    t = TieredPrimeClient(heavy=heavy, light=light)
+    await t.aclose()
+    assert heavy.closed and light.closed
+
+
+def test_factory_both_returns_tiered_only_one_returns_that_one():
+    from backend.core.ouroboros.governance.tiered_prime_client import (
+        build_tiered_prime_client, TieredPrimeClient)
+    heavy = _FakeClient("HEAVY"); light = _FakeClient("LIGHT")
+    assert isinstance(build_tiered_prime_client(heavy=heavy, light=light), TieredPrimeClient)
+    assert build_tiered_prime_client(heavy=None, light=light) is light   # only light -> passthrough
+    assert build_tiered_prime_client(heavy=heavy, light=None) is heavy   # only heavy -> passthrough
+    assert build_tiered_prime_client(heavy=None, light=None) is None     # neither -> None (legacy)


### PR DESCRIPTION
## Summary
Places the real GCP `jarvis-prime` Mind as the **HEAVY tier alongside** the local Ollama **LIGHT tier**, behind the existing `PrimeProvider` seat, via a new `TieredPrimeClient` composite. **Wired but not activated** — master switch `JARVIS_JPRIME_TIERED_ENABLED` defaults **OFF** (Phase 3.1 behavior byte-identical until you opt in + point `JARVIS_PRIME_URL` at a node).

## Reuse-first (zero duplication)
Final review confirmed: reuses `get_prime_client` (heavy), the governed `LocalPrimeClient` + `memory_guard` (light), and `recovery_policy.get_recovery_params` for breaker thresholds (no hardcoding). Re-implements **none** of `_jprime_sem`, `can_fanout`, or `_EndpointAwareCircuitBreaker`.

## What it does (flag ON)
- **Drop-in composite:** same `generate()/_check_health()/aclose()` contract PrimeProvider consumes; `_close_any` handles GCP `close()` + local `aclose()`.
- **Health hysteresis FSM:** HEALTHY→DEGRADED needs N *consecutive* heavy failures; DEGRADED→HEALTHY only via a clean **non-blocking background recovery probe** (60 s cooldown, one probe/window, strong-ref task) — no flapping.
- **Speculative hedging** (`JARVIS_TIERED_HEDGE_ENABLED`, default OFF): if heavy yields nothing within `JARVIS_TIERED_HEDGE_WINDOW_MS`, race a local hedge; accept-first; **cancel + drain the laggard** (zero leaked tasks/FDs). Heavy-too-slow = soft FSM failure; heavy-win = success.
- **Memory-valve override:** local paths (fallback + hedge) still honor `memory_guard` — `LocalMemoryCritical` propagates upstream, never swallowed.

## Safety
- **Default OFF byte-identical:** `tiered_enabled()` false → the GLS `elif self._prime_client is None` Phase 3.1 path runs unchanged (same governor attach, no double-injection); whole block exception-guarded.
- 17 composite tests + 30 local-tier tests green; regression sweep: **no new failures** vs baseline (pre-existing 25 + 5 collection errors unrelated).
- Live `scripts/smoke_jprime_local.py` harness included (validated end-to-end against real Ollama earlier).

Follow-on to PR #69572. To activate later: `JARVIS_JPRIME_TIERED_ENABLED=true` + `JARVIS_LOCAL_PRIME_ENABLED=true` + `JARVIS_PRIME_URL=<gcp-node>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `TieredPrimeClient` that composes the GCP heavy tier with the local Ollama light tier behind `PrimeProvider`. It is wired into the governed loop but stays disabled by default, so current behavior is unchanged.

- **New Features**
  - Drop-in composite with the same `generate`/`_check_health`/`aclose` contract.
  - Heavy-tier health FSM with failure threshold and cooldown; recovery via a non-blocking background health probe.
  - Optional speculative hedging (`JARVIS_TIERED_HEDGE_ENABLED` + `JARVIS_TIERED_HEDGE_WINDOW_MS`): race light after a window and cancel the laggard; heavy-too-slow counts as a soft failure.
  - Light-tier memory guard remains in force on fallback/hedge paths and propagates `LocalMemoryCritical`.
  - `build_tiered_prime_client` factory and `tiered_enabled` helper added; comprehensive unit tests and a `scripts/smoke_jprime_local.py` harness included.

- **Migration**
  - Default is OFF and byte-identical to Phase 3.1.
  - To enable the tiered composite later: set `JARVIS_JPRIME_TIERED_ENABLED=true`, `JARVIS_LOCAL_PRIME_ENABLED=true`, and `JARVIS_PRIME_URL=<gcp-node>`. Optional: `JARVIS_TIERED_HEDGE_ENABLED=true` (tune `JARVIS_TIERED_HEDGE_WINDOW_MS`).
  - Rollback is just unsetting these env vars.

<sup>Written for commit c6cf37ce67914f3f936860c2d933882870481dd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

