### PR TITLE
feat(jprime): Phase 3.3 — runtime exhaustion interceptor (local last-resort + topological prune)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2407,6 +2407,40 @@ class CandidateGenerator:
                         "re-raising original exhaustion",
                         exc_info=True,
                     )
+                # Phase 3.3 Task 2 — J-Prime last-resort local handoff.
+                # When JARVIS_JPRIME_LASTRESORT_ENABLED is true, route the op
+                # to the local 3B tier with a topologically-pruned payload
+                # instead of crashing the loop. Gate default OFF -> re-raise
+                # (byte-identical legacy). Never masks the original error on
+                # local failure or unhealthy probe.
+                try:
+                    from backend.core.ouroboros.governance.exhaustion_interceptor import (
+                        should_intercept,
+                        execute_local_last_resort,
+                    )
+                    if should_intercept(exc, jprime=self._jprime):
+                        _ft = self._estimate_target_file_tokens(context)
+                        _broker = self._resolve_sse_broker()
+                        return await execute_local_last_resort(
+                            jprime=self._jprime,
+                            context=context,
+                            deadline=deadline,
+                            graph_backend=getattr(self, "_graph_backend", None),
+                            broker=_broker,
+                            file_tokens=_ft,
+                            original_exc=exc,
+                        )
+                except RuntimeError:
+                    # execute_local_last_resort re-raises original_exc on any
+                    # local failure — let it propagate cleanly.
+                    raise
+                except Exception:  # noqa: BLE001 — defensive
+                    logger.debug(
+                        "[CandidateGenerator] jprime lastresort "
+                        "intercept failed (non-fatal); "
+                        "re-raising original exhaustion",
+                        exc_info=True,
+                    )
             raise
         else:
             if self._exhaustion_watcher is not None:
@@ -2436,6 +2470,44 @@ class CandidateGenerator:
                     exc_info=True,
                 )
             return result
+
+    def _estimate_target_file_tokens(self, context: Any) -> Dict[str, int]:
+        """Best-effort per-file token estimate for the exhaustion interceptor.
+
+        Reads each file in ``context.target_files`` relative to the repo root
+        (``self._repo_root`` when set, else cwd) and estimates token count as
+        ``len(text) // 4``. Missing or unreadable files contribute 0. Never
+        raises -- any error is swallowed so the interceptor path stays safe.
+        """
+        result: Dict[str, int] = {}
+        try:
+            files = list(getattr(context, "target_files", ()) or ())
+            repo_root = getattr(self, "_repo_root", None)
+            for f in files:
+                try:
+                    import os as _os
+                    path = (
+                        _os.path.join(repo_root, f)
+                        if repo_root and not _os.path.isabs(f)
+                        else f
+                    )
+                    with open(path, encoding="utf-8", errors="replace") as fh:
+                        result[f] = len(fh.read()) // 4
+                except Exception:  # noqa: BLE001
+                    result[f] = 0
+        except Exception:  # noqa: BLE001
+            pass
+        return result
+
+    def _resolve_sse_broker(self) -> Any:
+        """Return the default SSE broker for beacon publishing, or None on failure."""
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (
+                get_default_broker,
+            )
+            return get_default_broker()
+        except Exception:  # noqa: BLE001
+            return None
 
     async def _apply_bg_spec_structural_filter(
         self,

--- a/backend/core/ouroboros/governance/exhaustion_interceptor.py
+++ b/backend/core/ouroboros/governance/exhaustion_interceptor.py
@@ -153,10 +153,13 @@ def _emit_handoff_beacon(
     if broker is None:
         return
     try:
+        # StreamEventBroker.publish(event_type, op_id, payload) — positional, as
+        # every real caller uses it. (The earlier data= kwarg silently TypeError'd
+        # into the best-effort guard, so the beacon never reached the broker.)
         broker.publish(
-            event_type="exhaustion_handoff_triggered",
-            op_id=str(getattr(context, "op_id", "") or "")[:48],
-            data={
+            "exhaustion_handoff_triggered",
+            str(getattr(context, "op_id", "") or "")[:48],
+            {
                 "cause": _exhaustion_cause(original_exc),
                 "tokens_before": prune.tokens_before,
                 "tokens_after": prune.tokens_after,

--- a/backend/core/ouroboros/governance/exhaustion_interceptor.py
+++ b/backend/core/ouroboros/governance/exhaustion_interceptor.py
@@ -1,0 +1,169 @@
+"""Exhaustion interceptor (Phase 3.3 Task 2) -- last-resort local handoff.
+
+When the provider cascade is about to raise ``all_providers_exhausted``, route
+the op to the local J-Prime tier with a topologically-pruned payload instead of
+crashing the loop. Gated by JARVIS_JPRIME_LASTRESORT_ENABLED (default OFF ->
+re-raise, byte-identical legacy). Remote restoration is handled by the EXISTING
+dw_transport_recovery + FailbackStateMachine -- no new probe loop here.
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+from backend.core.ouroboros.governance.topological_file_pruner import (
+    prune_files_by_centrality,
+    local_max_context_tokens,
+)
+
+logger = logging.getLogger(__name__)
+
+_TRUE = {"1", "true", "yes", "on"}
+
+
+def lastresort_enabled() -> bool:
+    """Return True iff JARVIS_JPRIME_LASTRESORT_ENABLED is set to a truthy value."""
+    return os.environ.get("JARVIS_JPRIME_LASTRESORT_ENABLED", "").strip().lower() in _TRUE
+
+
+def should_intercept(exc: BaseException, *, jprime: Any) -> bool:
+    """Return True iff the last-resort path should fire for this exception.
+
+    Conditions (all must hold):
+    - JARVIS_JPRIME_LASTRESORT_ENABLED is truthy
+    - jprime handle is not None
+    - exc message contains "all_providers_exhausted"
+    """
+    if not lastresort_enabled() or jprime is None:
+        return False
+    return "all_providers_exhausted" in str(exc)
+
+
+def _exhaustion_cause(exc: BaseException) -> str:
+    """Extract the cause suffix from the exhaustion error message (after ':')."""
+    msg = str(exc)
+    if ":" in msg:
+        return msg.split(":", 1)[1][:120]
+    return "unknown"
+
+
+async def execute_local_last_resort(
+    *,
+    jprime: Any,
+    context: Any,
+    deadline: Any,
+    graph_backend: Optional[Any] = None,
+    broker: Optional[Any] = None,
+    file_tokens: Optional[Dict[str, int]] = None,
+    ceiling_tokens: Optional[int] = None,
+    original_exc: BaseException,
+) -> Any:
+    """Health-gate the local tier, prune the payload by topological centrality,
+    generate locally, emit the handoff beacon, and return the result.
+
+    Any failure (unhealthy local OR local generate error) re-raises
+    ``original_exc`` so the caller's exhaustion contract is preserved (the
+    original all_providers_exhausted error is never masked into a different
+    error shape).
+
+    Parameters
+    ----------
+    jprime:
+        The local J-Prime provider handle. Must expose
+        ``async health_probe() -> bool`` and
+        ``async generate(context, deadline) -> obj with .content``.
+    context:
+        The operation context (dataclass with ``target_files`` and ``op_id``).
+    deadline:
+        Absolute deadline forwarded to jprime.generate unchanged.
+    graph_backend:
+        Optional graph backend for centrality scoring. Passed straight to
+        ``prune_files_by_centrality``; None => fall back to token-size ranking.
+    broker:
+        Optional SSE broker for the handoff beacon. None => beacon silently
+        suppressed (best-effort; never blocks the handoff).
+    file_tokens:
+        Per-file token estimates. None treated as empty dict (all files cost 0).
+    ceiling_tokens:
+        Token ceiling for the pruned payload. None => ``local_max_context_tokens()``.
+    original_exc:
+        The RuntimeError that triggered the interceptor. Re-raised on any
+        local failure so the caller always sees ``all_providers_exhausted``.
+    """
+    # 1) health gate — only hijack if the local engine is actually available
+    try:
+        healthy = await jprime.health_probe()
+    except Exception:  # noqa: BLE001
+        healthy = False
+    if not healthy:
+        logger.info("[ExhaustionInterceptor] local tier unhealthy -> re-raising exhaustion")
+        raise original_exc
+
+    # 2) topological prune of the target files for the local context ceiling
+    target_files: List[str] = list(getattr(context, "target_files", ()) or ())
+    toks: Dict[str, int] = file_tokens if file_tokens is not None else {}
+    prune = prune_files_by_centrality(
+        target_files,
+        file_tokens=toks,
+        graph_backend=graph_backend,
+        ceiling_tokens=ceiling_tokens if ceiling_tokens is not None else local_max_context_tokens(),
+    )
+    local_context = context
+    if prune.pruned:
+        try:
+            local_context = dataclasses.replace(context, target_files=tuple(prune.kept_files))
+        except Exception:  # noqa: BLE001 — context not a dataclass / immutable replace failed
+            local_context = context
+
+    # 3) telemetry beacon (best-effort, never blocks the handoff)
+    _emit_handoff_beacon(broker, context=context, original_exc=original_exc, prune=prune)
+
+    # 4) local generation; any failure re-raises the ORIGINAL exhaustion (not the local error)
+    try:
+        logger.info(
+            "[ExhaustionInterceptor] HANDOFF -> local tier (cause=%s, kept=%d/%d, "
+            "tokens %d->%d, discarded=%s)",
+            _exhaustion_cause(original_exc),
+            len(prune.kept_files),
+            len(target_files),
+            prune.tokens_before,
+            prune.tokens_after,
+            prune.discarded_files,
+        )
+        return await jprime.generate(local_context, deadline)
+    except Exception as local_exc:  # noqa: BLE001
+        logger.warning(
+            "[ExhaustionInterceptor] local handoff failed (%s) -> re-raising exhaustion",
+            local_exc,
+        )
+        raise original_exc
+
+
+def _emit_handoff_beacon(
+    broker: Optional[Any],
+    *,
+    context: Any,
+    original_exc: BaseException,
+    prune: Any,
+) -> None:
+    """Publish an exhaustion_handoff_triggered SSE event to the broker (best-effort)."""
+    if broker is None:
+        return
+    try:
+        broker.publish(
+            event_type="exhaustion_handoff_triggered",
+            op_id=str(getattr(context, "op_id", "") or "")[:48],
+            data={
+                "cause": _exhaustion_cause(original_exc),
+                "tokens_before": prune.tokens_before,
+                "tokens_after": prune.tokens_after,
+                "discarded_files": list(prune.discarded_files),
+                "kept_files": list(prune.kept_files),
+                "ts": time.time(),
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[ExhaustionInterceptor] beacon publish failed", exc_info=True)

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -4338,6 +4338,21 @@ class GovernedLoopService:
             )
             self._exhaustion_watcher = _exhaustion_watcher
 
+            # Phase 3.3: give the CandidateGenerator the Oracle graph backend so the
+            # exhaustion interceptor can prune by topological centrality. None-safe:
+            # the pruner falls back to size-ordering when no backend is available.
+            # Oracle stores its SqliteLazyGraphBackend at self._oracle._backend.
+            try:
+                _gb = None
+                _oracle = getattr(self, "_oracle", None)
+                if _oracle is not None:
+                    _gb = (getattr(_oracle, "_backend", None)
+                           or getattr(_oracle, "graph_backend", None)
+                           or getattr(_oracle, "graph", None))
+                setattr(self._generator, "_graph_backend", _gb)
+            except Exception:
+                logger.debug("[GovernedLoop] graph backend wiring skipped", exc_info=True)
+
             # HIBERNATION_MODE step 6: construct a HibernationProber over the
             # real provider handles and attach it to the watcher so that
             # entering HIBERNATION automatically arms a wake loop. Sequencing:

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -1254,6 +1254,10 @@ EVENT_TYPE_TERMINATION_HOOK_DISPATCHED = "termination_hook_dispatched"
 # "saturation event" notifications + correlate to the structural
 # `pre_admission_shed` exhaustion at the orchestrator level.
 EVENT_TYPE_ADMISSION_DECISION_EMITTED = "admission_decision_emitted"
+# Phase 3.3 Task 2 — Exhaustion Interceptor. Fired when the last-resort
+# J-Prime local handoff activates (all_providers_exhausted intercepted,
+# payload pruned topologically, local tier absorbing the op).
+EVENT_TYPE_EXHAUSTION_HANDOFF_TRIGGERED = "exhaustion_handoff_triggered"
 # CodebaseCharacterDigest Slice 3 — emitted when ProactiveExploration
 # Sensor surfaces an under-touched semantic cluster as an IntentEnvelope.
 # Lets IDE/observability consumers correlate the cluster-coverage bias
@@ -1535,6 +1539,11 @@ _VALID_EVENT_TYPES = frozenset({
                                                   # in-process on_trip callback drives harness
                                                   # graceful shutdown, this SSE is the IDE
                                                   # observability surface)
+    EVENT_TYPE_EXHAUSTION_HANDOFF_TRIGGERED,      # Phase 3.3 Task 2 (last-resort local handoff
+                                                  # — all_providers_exhausted intercepted,
+                                                  # topological prune applied, J-Prime local
+                                                  # tier absorbs the op; gated by
+                                                  # JARVIS_JPRIME_LASTRESORT_ENABLED)
 })
 
 

--- a/backend/core/ouroboros/governance/topological_file_pruner.py
+++ b/backend/core/ouroboros/governance/topological_file_pruner.py
@@ -1,0 +1,93 @@
+"""Topological file pruner (Phase 3.3) -- keep a local 3B payload under its
+context ceiling by discarding LOW-CENTRALITY files whole (never mid-string).
+
+Pure + deterministic: the caller supplies precomputed per-file token counts and
+(optionally) a graph backend. REUSES the existing SqliteLazyGraphBackend degree
+signals (nodes_in_file + successor/predecessor_keys); no new graph is built.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+def local_max_context_tokens() -> int:
+    return int(os.environ.get("JARVIS_LOCAL_MAX_CONTEXT_TOKENS", "8000"))
+
+
+@dataclass
+class PruneResult:
+    kept_files: List[str] = field(default_factory=list)
+    discarded_files: List[str] = field(default_factory=list)
+    tokens_before: int = 0
+    tokens_after: int = 0
+    pruned: bool = False
+
+
+def _file_centrality(graph_backend: Any, file_path: str) -> int:
+    """Aggregate degree-centrality of a file = sum of node in+out degrees.
+    Returns 0 when the backend is absent or the file has no graph nodes."""
+    if graph_backend is None:
+        return 0
+    try:
+        total = 0
+        for node in graph_backend.nodes_in_file(file_path):
+            total += len(graph_backend.successor_keys(node))
+            total += len(graph_backend.predecessor_keys(node))
+        return total
+    except Exception:
+        return 0
+
+
+def prune_files_by_centrality(
+    target_files: List[str],
+    *,
+    file_tokens: Dict[str, int],
+    graph_backend: Optional[Any] = None,
+    ceiling_tokens: Optional[int] = None,
+) -> PruneResult:
+    """Keep the most central files whose cumulative token cost fits under the
+    ceiling; discard the rest WHOLE. Always retains at least one file (the most
+    central) so the local engine still has something to work on.
+
+    Ranking key: (centrality DESC, token_cost ASC, declared-order ASC). With no
+    backend, centrality is 0 for all -> falls back to (smaller-first, then order)
+    which greedily keeps more files under the ceiling.
+    """
+    ceiling = ceiling_tokens if ceiling_tokens is not None else local_max_context_tokens()
+    files = list(target_files)
+    tokens_before = sum(int(file_tokens.get(f, 0)) for f in files)
+    if tokens_before <= ceiling or len(files) <= 1:
+        return PruneResult(kept_files=files, discarded_files=[],
+                           tokens_before=tokens_before, tokens_after=tokens_before,
+                           pruned=False)
+
+    ranked = sorted(
+        enumerate(files),
+        key=lambda iv: (
+            -_file_centrality(graph_backend, iv[1]),  # most central first
+            int(file_tokens.get(iv[1], 0)),           # then smaller first
+            iv[0],                                     # then declared order
+        ),
+    )
+    kept: List[str] = []
+    discarded: List[str] = []
+    running = 0
+    for _idx, f in ranked:
+        cost = int(file_tokens.get(f, 0))
+        if not kept:
+            # always keep the single most-critical file, even if it alone is over
+            kept.append(f)
+            running += cost
+            continue
+        if running + cost <= ceiling:
+            kept.append(f)
+            running += cost
+        else:
+            discarded.append(f)
+    # preserve declared order in the kept list for prompt stability
+    kept_in_order = [f for f in files if f in set(kept)]
+    return PruneResult(kept_files=kept_in_order, discarded_files=discarded,
+                       tokens_before=tokens_before, tokens_after=running,
+                       pruned=bool(discarded))

--- a/tests/governance/test_exhaustion_interceptor.py
+++ b/tests/governance/test_exhaustion_interceptor.py
@@ -27,8 +27,11 @@ class _Jprime:
 
 
 class _Broker:
+    # Mirrors the REAL StreamEventBroker.publish(event_type, op_id, payload=None)
+    # signature exactly, so a kwarg drift in the production call can't pass silently.
     def __init__(self): self.events = []
-    def publish(self, **kw): self.events.append(kw)
+    def publish(self, event_type, op_id, payload=None):
+        self.events.append({"event_type": event_type, "op_id": op_id, "data": payload})
 
 
 def test_lastresort_enabled_default_off(monkeypatch):

--- a/tests/governance/test_exhaustion_interceptor.py
+++ b/tests/governance/test_exhaustion_interceptor.py
@@ -1,0 +1,101 @@
+# tests/governance/test_exhaustion_interceptor.py
+from __future__ import annotations
+import dataclasses
+import pytest
+
+
+@dataclasses.dataclass
+class _Ctx:
+    op_id: str = "op1"
+    target_files: tuple = ("central.py", "mid.py", "orphan.py")
+
+
+class _Resp:
+    def __init__(self, c): self.content = c
+
+
+class _Jprime:
+    def __init__(self, *, healthy=True, fail=False):
+        self._healthy = healthy; self._fail = fail
+        self.gen_calls = 0; self.seen_target_files = None
+    async def health_probe(self): return self._healthy
+    async def generate(self, context, deadline):
+        self.gen_calls += 1
+        self.seen_target_files = tuple(getattr(context, "target_files", ()))
+        if self._fail: raise RuntimeError("local boom")
+        return _Resp("LOCAL_ABSORBED")
+
+
+class _Broker:
+    def __init__(self): self.events = []
+    def publish(self, **kw): self.events.append(kw)
+
+
+def test_lastresort_enabled_default_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_JPRIME_LASTRESORT_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.exhaustion_interceptor import lastresort_enabled
+    assert lastresort_enabled() is False
+    monkeypatch.setenv("JARVIS_JPRIME_LASTRESORT_ENABLED", "true")
+    assert lastresort_enabled() is True
+
+
+def test_should_intercept_only_on_exhaustion_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_JPRIME_LASTRESORT_ENABLED", "true")
+    from backend.core.ouroboros.governance.exhaustion_interceptor import should_intercept
+    assert should_intercept(RuntimeError("all_providers_exhausted:fallback_failed"), jprime=_Jprime()) is True
+    assert should_intercept(RuntimeError("something_else"), jprime=_Jprime()) is False
+    assert should_intercept(RuntimeError("all_providers_exhausted"), jprime=None) is False
+    monkeypatch.setenv("JARVIS_JPRIME_LASTRESORT_ENABLED", "false")
+    assert should_intercept(RuntimeError("all_providers_exhausted"), jprime=_Jprime()) is False
+
+
+@pytest.mark.asyncio
+async def test_local_last_resort_absorbs_and_prunes_and_beacons(monkeypatch):
+    monkeypatch.setenv("JARVIS_JPRIME_LASTRESORT_ENABLED", "true")
+    from backend.core.ouroboros.governance.exhaustion_interceptor import execute_local_last_resort
+    jp = _Jprime(); broker = _Broker()
+    ctx = _Ctx()
+    # huge per-file tokens force pruning under a tiny ceiling; central.py wins (highest degree)
+    file_tokens = {"central.py": 600, "mid.py": 600, "orphan.py": 600}
+
+    class _FakeBackend:
+        def nodes_in_file(self, f): return {"central.py": ["c"], "mid.py": ["m"], "orphan.py": ["o"]}.get(f, [])
+        def successor_keys(self, k): return {"c": ["x","y","z"], "m": ["x"], "o": []}.get(k, [])
+        def predecessor_keys(self, k): return {"c": ["a","b"], "m": [], "o": []}.get(k, [])
+
+    result = await execute_local_last_resort(
+        jprime=jp, context=ctx, deadline=None, graph_backend=_FakeBackend(),
+        broker=broker, file_tokens=file_tokens, ceiling_tokens=1000, original_exc=RuntimeError("all_providers_exhausted:fallback_failed"))
+    assert result.content == "LOCAL_ABSORBED"
+    assert jp.gen_calls == 1
+    # pruned: orphan.py (degree 0) discarded; central.py kept
+    assert "central.py" in jp.seen_target_files
+    assert "orphan.py" not in jp.seen_target_files
+    # beacon emitted with the right event type + discarded filenames + token differential
+    assert len(broker.events) == 1
+    ev = broker.events[0]
+    assert ev.get("event_type") == "exhaustion_handoff_triggered"
+    data = ev.get("data") or {}
+    assert "orphan.py" in (data.get("discarded_files") or [])
+    assert data.get("tokens_before", 0) >= data.get("tokens_after", 0)
+
+
+@pytest.mark.asyncio
+async def test_local_unhealthy_reraises_original(monkeypatch):
+    monkeypatch.setenv("JARVIS_JPRIME_LASTRESORT_ENABLED", "true")
+    from backend.core.ouroboros.governance.exhaustion_interceptor import execute_local_last_resort
+    jp = _Jprime(healthy=False); orig = RuntimeError("all_providers_exhausted:queue_only")
+    with pytest.raises(RuntimeError, match="all_providers_exhausted"):
+        await execute_local_last_resort(jprime=jp, context=_Ctx(), deadline=None,
+                                        graph_backend=None, broker=None, file_tokens={}, original_exc=orig)
+    assert jp.gen_calls == 0  # never generated when local is unhealthy
+
+
+@pytest.mark.asyncio
+async def test_local_generate_failure_reraises_original(monkeypatch):
+    monkeypatch.setenv("JARVIS_JPRIME_LASTRESORT_ENABLED", "true")
+    from backend.core.ouroboros.governance.exhaustion_interceptor import execute_local_last_resort
+    jp = _Jprime(fail=True); orig = RuntimeError("all_providers_exhausted:fallback_failed")
+    with pytest.raises(RuntimeError, match="all_providers_exhausted"):
+        await execute_local_last_resort(jprime=jp, context=_Ctx(), deadline=None,
+                                        graph_backend=None, broker=None, file_tokens={"central.py":1}, original_exc=orig)

--- a/tests/governance/test_exhaustion_interceptor_integration.py
+++ b/tests/governance/test_exhaustion_interceptor_integration.py
@@ -1,0 +1,122 @@
+"""Phase 3.3 Task 3 — integration matrix for exhaustion interceptor.
+
+Covers end-to-end interceptor behaviour: topology-aware pruning, flag gating,
+and zero-duplication guard (no new recovery loop). Stubs are used because
+constructing a full CandidateGenerator requires live provider credentials.
+"""
+from __future__ import annotations
+
+import dataclasses
+import pytest
+
+
+@dataclasses.dataclass
+class _Ctx:
+    op_id: str = "opX"
+    target_files: tuple = ("hub.py", "leaf1.py", "leaf2.py", "leaf3.py")
+
+
+class _Resp:
+    def __init__(self, c: str) -> None:
+        self.content = c
+
+
+class _Jprime:
+    def __init__(self) -> None:
+        self.seen: tuple = ()
+        self.calls: int = 0
+
+    async def health_probe(self) -> bool:
+        return True
+
+    async def generate(self, context: object, deadline: object) -> _Resp:
+        self.calls += 1
+        self.seen = tuple(getattr(context, "target_files", ()))
+        return _Resp("LOCAL")
+
+
+class _Backend:
+    """Minimal graph backend stub: hub.py has high degree, leaves peripheral."""
+
+    _map: dict = {
+        "hub.py": ["h"],
+        "leaf1.py": ["l1"],
+        "leaf2.py": ["l2"],
+        "leaf3.py": ["l3"],
+    }
+
+    def nodes_in_file(self, f: str) -> list:
+        return self._map.get(f, [])
+
+    def successor_keys(self, k: str) -> list:
+        return ["x"] * 9 if k == "h" else []
+
+    def predecessor_keys(self, k: str) -> list:
+        return ["y"] * 9 if k == "h" else []
+
+
+@pytest.mark.asyncio
+async def test_inflight_exhaustion_absorbed_with_topological_prune(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Induced all_providers_exhausted -> local absorbs; massive context pruned by
+    topology weight (hub kept, peripheral leaves discarded); loop not crashed."""
+    monkeypatch.setenv("JARVIS_JPRIME_LASTRESORT_ENABLED", "true")
+    from backend.core.ouroboros.governance.exhaustion_interceptor import (
+        should_intercept,
+        execute_local_last_resort,
+    )
+
+    jp = _Jprime()
+    exc = RuntimeError("all_providers_exhausted:fallback_failed")
+    assert should_intercept(exc, jprime=jp) is True
+
+    big_tokens = {
+        "hub.py": 700,
+        "leaf1.py": 700,
+        "leaf2.py": 700,
+        "leaf3.py": 700,
+    }
+    res = await execute_local_last_resort(
+        jprime=jp,
+        context=_Ctx(),
+        deadline=None,
+        graph_backend=_Backend(),
+        broker=None,
+        file_tokens=big_tokens,
+        ceiling_tokens=1000,
+        original_exc=exc,
+    )
+    assert res.content == "LOCAL"          # loop absorbed, not crashed
+    assert "hub.py" in jp.seen            # central node retained
+    assert len(jp.seen) < 4              # peripheral leaves pruned
+
+
+@pytest.mark.asyncio
+async def test_disabled_flag_does_not_intercept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the feature flag is off, should_intercept returns False."""
+    monkeypatch.setenv("JARVIS_JPRIME_LASTRESORT_ENABLED", "false")
+    from backend.core.ouroboros.governance.exhaustion_interceptor import should_intercept
+
+    assert should_intercept(RuntimeError("all_providers_exhausted"), jprime=_Jprime()) is False
+
+
+def test_no_new_recovery_loop_added() -> None:
+    """Recovery stays with the EXISTING dw_transport_recovery / FSM -- the interceptor
+    module must NOT spawn its own background probe loop (zero-duplication guard)."""
+    import backend.core.ouroboros.governance.exhaustion_interceptor as ei
+
+    src = open(ei.__file__).read()
+    # No asyncio task-spawning (would create a hidden probe loop)
+    assert "create_task" not in src
+    assert "ensure_future" not in src
+    # No infinite loop (would be a hidden polling loop)
+    assert "while True" not in src
+    # dw_transport_recovery may appear in the docstring as a reference to what we
+    # are NOT duplicating -- that is intentional and safe. What must NOT appear is
+    # an actual import or call to it. Guard: no 'import dw_transport_recovery' or
+    # 'dw_transport_recovery(' (functional invocation).
+    assert "import dw_transport_recovery" not in src
+    assert "dw_transport_recovery(" not in src

--- a/tests/governance/test_topological_file_pruner.py
+++ b/tests/governance/test_topological_file_pruner.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+
+class _FakeBackend:
+    """Duck-typed graph backend. degree map: file -> total degree."""
+    def __init__(self, file_degrees):
+        # file_degrees: {file_path: [(node, succ_count, pred_count), ...]}
+        self._fd = file_degrees
+    def nodes_in_file(self, file_path):
+        return [n for (n, _s, _p) in self._fd.get(file_path, [])]
+    def successor_keys(self, key):
+        for nodes in self._fd.values():
+            for (n, s, _p) in nodes:
+                if n == key:
+                    return [f"{key}_s{i}" for i in range(s)]
+        return []
+    def predecessor_keys(self, key):
+        for nodes in self._fd.values():
+            for (n, _s, p) in nodes:
+                if n == key:
+                    return [f"{key}_p{i}" for i in range(p)]
+        return []
+
+
+def test_no_pruning_when_under_ceiling():
+    from backend.core.ouroboros.governance.topological_file_pruner import prune_files_by_centrality
+    files = ["a.py", "b.py"]
+    toks = {"a.py": 100, "b.py": 100}
+    res = prune_files_by_centrality(files, file_tokens=toks, graph_backend=None, ceiling_tokens=1000)
+    assert res.kept_files == files
+    assert res.discarded_files == []
+    assert res.tokens_before == 200 and res.tokens_after == 200
+
+
+def test_prunes_lowest_centrality_first():
+    from backend.core.ouroboros.governance.topological_file_pruner import prune_files_by_centrality
+    # central.py is highly connected; orphan.py is peripheral (0 degree)
+    backend = _FakeBackend({
+        "central.py": [("central.fn", 5, 5)],   # degree 10
+        "mid.py": [("mid.fn", 1, 1)],           # degree 2
+        "orphan.py": [("orphan.fn", 0, 0)],     # degree 0
+    })
+    files = ["central.py", "mid.py", "orphan.py"]
+    toks = {"central.py": 600, "mid.py": 600, "orphan.py": 600}
+    res = prune_files_by_centrality(files, file_tokens=toks, graph_backend=backend, ceiling_tokens=1000)
+    # ceiling 1000: keep highest-centrality until over -> central.py(600) fits; +mid(1200>1000) stop
+    assert "central.py" in res.kept_files
+    assert "orphan.py" in res.discarded_files      # peripheral dropped first
+    assert res.tokens_after <= 1000
+    assert set(res.kept_files) | set(res.discarded_files) == set(files)
+
+
+def test_always_keeps_at_least_one_file_even_if_over_ceiling():
+    from backend.core.ouroboros.governance.topological_file_pruner import prune_files_by_centrality
+    backend = _FakeBackend({"big.py": [("big.fn", 9, 9)], "small.py": [("small.fn", 0, 0)]})
+    files = ["big.py", "small.py"]
+    toks = {"big.py": 5000, "small.py": 5000}    # each alone exceeds ceiling
+    res = prune_files_by_centrality(files, file_tokens=toks, graph_backend=backend, ceiling_tokens=1000)
+    assert len(res.kept_files) == 1               # never drop everything
+    assert res.kept_files == ["big.py"]            # the most central survives
+
+
+def test_fallback_size_order_when_no_backend():
+    from backend.core.ouroboros.governance.topological_file_pruner import prune_files_by_centrality
+    files = ["a.py", "b.py", "c.py"]
+    toks = {"a.py": 400, "b.py": 400, "c.py": 400}
+    res = prune_files_by_centrality(files, file_tokens=toks, graph_backend=None, ceiling_tokens=1000)
+    # no centrality signal -> keep smaller/earlier greedily under ceiling (2 fit: 800<=1000)
+    assert res.tokens_after <= 1000
+    assert len(res.kept_files) == 2 and len(res.discarded_files) == 1


### PR DESCRIPTION
## Summary
Closes the runtime `all_providers_exhausted` panic vector: when the cascade is about to raise it (DW quota gone **and** Claude exhausted, mid-run), a gated interceptor routes the op to the **local Ollama tier** with a **topologically-pruned payload** + a telemetry beacon — so the loop survives upstream outages on every route. Remote restoration stays with the **existing** `dw_transport_recovery` + FSM (no new probe loop).

## Reuse-first (zero duplication — verified by final review)
- Single interception at `candidate_generator.py::generate()`'s **existing** `all_providers_exhausted` catch (not 11 `_raise_exhausted` sites).
- Pruning reuses the existing `SqliteLazyGraphBackend` degree signals (`nodes_in_file`/`successor_keys`/`predecessor_keys`).
- Telemetry reuses the existing SSE `StreamEventBroker`.
- **No new recovery/probe loop** — restoration stays with `dw_transport_recovery`/FSM (source-guard test enforces it).

## What it does (flag ON)
- **`exhaustion_interceptor.py`** — `should_intercept` (gated `JARVIS_JPRIME_LASTRESORT_ENABLED`, default OFF) + `execute_local_last_resort`: health-gate local → prune → local generate → beacon. Any failure (unhealthy / local error) **re-raises the ORIGINAL exhaustion** (never masked, never silent success).
- **`topological_file_pruner.py`** — `prune_files_by_centrality`: keep highest degree-centrality files under `JARVIS_LOCAL_MAX_CONTEXT_TOKENS`, discard peripheral files **whole** (no mid-string), always keep ≥1. None-backend → deterministic size-order fallback.
- **Telemetry:** `EXHAUSTION_HANDOFF_TRIGGERED` SSE — cause, pre/post token differential, discarded filenames.
- **GLS** wires the Oracle `_backend` into the generator (None-safe → fallback).

## Safety
- **Default OFF byte-identical:** `should_intercept` false → existing `raise` fires unchanged; GLS wiring is pure additive None-safe `setattr`.
- **Final review `APPROVE_WITH_NITS`** — exhaustion contract airtight (no path swallows a real outage; non-exhaustion RuntimeErrors never rerouted). Caught + fixed one real defect: the beacon used `data=` vs the real `publish(payload=)` (telemetry was dead-on-arrival; mock now mirrors the real signature).
- 12 tests green; regression sweep: no new failures vs baseline.

Follow-on to PR #69573. Activate: `JARVIS_JPRIME_LASTRESORT_ENABLED=true` (+ `JARVIS_LOCAL_PRIME_ENABLED=true` + Ollama).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a gated exhaustion interceptor that reroutes `all_providers_exhausted` cases to the local J‑Prime tier with topological file pruning and an SSE beacon, so the governed loop keeps running during upstream outages. Default is OFF; behavior is unchanged when disabled.

- **New Features**
  - Interceptor in `candidate_generator.generate()` calls `exhaustion_interceptor.execute_local_last_resort` when `JARVIS_JPRIME_LASTRESORT_ENABLED` is true and `all_providers_exhausted` occurs.
  - Local handoff: health-probes `jprime`, prunes target files by centrality, then runs local generate; any local failure re-raises the original exhaustion error.
  - `topological_file_pruner.prune_files_by_centrality`: uses Oracle `SqliteLazyGraphBackend` degree signals; falls back to size; keeps ≥1 file; respects `JARVIS_LOCAL_MAX_CONTEXT_TOKENS`.
  - Wires Oracle graph backend into `CandidateGenerator` as `_graph_backend` in `governed_loop_service.py`.
  - Telemetry: publishes `exhaustion_handoff_triggered` via `StreamEventBroker` (cause, tokens before/after, kept/discarded). Uses the real `publish(event_type, op_id, payload)` signature.
  - Helpers: per-file token estimate and SSE broker resolver added to `candidate_generator.py`.
  - Tests: unit and integration cover gating, pruning, telemetry, and “no new recovery loop”.

- **Migration**
  - Off by default. To enable: set `JARVIS_JPRIME_LASTRESORT_ENABLED=true` and `JARVIS_LOCAL_PRIME_ENABLED=true`, and run a local Ollama J‑Prime model.
  - To observe handoffs, listen for `exhaustion_handoff_triggered` SSE events.

<sup>Written for commit c0eb2aa5b4d2de6be54d25683a51608ef6b93a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

