### PR TITLE
feat(jprime): Phases 1+2 — Predictive Quota Shield (cognitive-load routing + JIT pre-warm)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2884,6 +2884,19 @@ class CandidateGenerator:
             )
             return await self._generate_immediate(context, deadline)
 
+        # Quota Shield: a shield-selected (prefer_local) op tries the zero-cost local
+        # tier first via the existing primacy path, regardless of urgency route. On
+        # local decline (sem saturation / timeout / error) it returns None and falls
+        # through to the normal route below -> graceful, no behavior change when unset.
+        if (
+            getattr(context, "prefer_local", False)
+            and self._jprime is not None
+            and _provider_route not in ("background", "speculative")
+        ):
+            _ql = await self._try_jprime_primacy(context, deadline, "quota_shield")
+            if _ql is not None:
+                return _ql
+
         if _provider_route == "immediate":
             return await self._generate_immediate(context, deadline)
         if _provider_route == "background":
@@ -4281,7 +4294,9 @@ class CandidateGenerator:
         # time keeps the hot-path branch cheap when the flag is off.
         from ._governance_state import jprime_primacy_enabled
 
-        if not jprime_primacy_enabled():
+        # Quota Shield: prefer_local ops use the same local-first primacy path even
+        # when jprime_primacy is otherwise off for this route.
+        if not (jprime_primacy_enabled() or getattr(context, "prefer_local", False)):
             return None
         if self._jprime is None or not getattr(
             self._jprime, "provider_name", ""

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2893,7 +2893,7 @@ class CandidateGenerator:
             and self._jprime is not None
             and _provider_route not in ("background", "speculative")
         ):
-            _ql = await self._try_jprime_primacy(context, deadline, "quota_shield")
+            _ql = await self._try_jprime_primacy(context, deadline, route_label="quota_shield")
             if _ql is not None:
                 return _ql
 

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -1018,6 +1018,7 @@ class OperationContext:
     # Determines which provider strategy CandidateGenerator uses.
     provider_route: str = ""   # "immediate" | "standard" | "complex" | "background" | "speculative"
     provider_route_reason: str = ""  # human-readable reason for telemetry
+    prefer_local: bool = False    # Quota Shield: route this op to the local J-Prime tier
 
     # ---- Slice 245 — hibernation resurrection flag ----
     # Set (via with_resurrection()) when an op that failed with provider

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -2395,6 +2395,15 @@ class GovernedOrchestrator:
             except Exception:
                 logger.debug("[Orchestrator] Advisor failed", exc_info=True)
 
+            # Quota Shield (Phases 1+2): proactively route trivial/localized ops
+            # to the zero-cost local tier (preserving DW quota), unless host memory
+            # is CRITICAL. Reuses the advisory just computed. Gated + fail-soft.
+            try:
+                from backend.core.ouroboros.governance.quota_shield import apply_quota_shield
+                ctx = await apply_quota_shield(ctx, advisory=_advisory)
+            except Exception:
+                logger.debug("[Orchestrator] quota shield skipped", exc_info=True)
+
             # ---- Phase 1: CLASSIFY ----
             profile = self._build_profile(ctx)
             classification = self._stack.risk_engine.classify(profile)

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -2395,15 +2395,6 @@ class GovernedOrchestrator:
             except Exception:
                 logger.debug("[Orchestrator] Advisor failed", exc_info=True)
 
-            # Quota Shield (Phases 1+2): proactively route trivial/localized ops
-            # to the zero-cost local tier (preserving DW quota), unless host memory
-            # is CRITICAL. Reuses the advisory just computed. Gated + fail-soft.
-            try:
-                from backend.core.ouroboros.governance.quota_shield import apply_quota_shield
-                ctx = await apply_quota_shield(ctx, advisory=_advisory)
-            except Exception:
-                logger.debug("[Orchestrator] quota shield skipped", exc_info=True)
-
             # ---- Phase 1: CLASSIFY ----
             profile = self._build_profile(ctx)
             classification = self._stack.risk_engine.classify(profile)
@@ -3140,6 +3131,17 @@ class GovernedOrchestrator:
                 )
 
         # Wave 2 (5) Slice 3 - ROUTE+CTX+PLAN PhaseRunner delegation gate.
+        # Quota Shield (Phases 1+2): proactively route trivial/localized ops to the
+        # zero-cost local tier (preserving DW quota), unless host memory is CRITICAL.
+        # Placed AFTER the CLASSIFY if/else so it runs on BOTH the extracted-runner
+        # (default/production) and legacy inline paths (both set _advisory + ctx here).
+        # Gated (default OFF) + fail-soft + advisory-None-guarded.
+        try:
+            from backend.core.ouroboros.governance.quota_shield import apply_quota_shield
+            ctx = await apply_quota_shield(ctx, advisory=_advisory)
+        except Exception:
+            logger.debug("[Orchestrator] quota shield skipped", exc_info=True)
+
         # All three flags (JARVIS_PHASE_RUNNER_{ROUTE,CONTEXT_EXPANSION,PLAN}_EXTRACTED)
         # must be set to engage the runner chain. This all-or-nothing
         # gate simplifies wiring while the three phases remain

--- a/backend/core/ouroboros/governance/quota_shield.py
+++ b/backend/core/ouroboros/governance/quota_shield.py
@@ -10,6 +10,9 @@ nothing itself.
 """
 from __future__ import annotations
 
+import asyncio
+import dataclasses
+import logging
 import os
 from dataclasses import dataclass
 from typing import Any
@@ -79,3 +82,93 @@ def decide(*, advisory: Any, pressure_level: Any, token_volume: int,
     if load < threshold:
         return ShieldDecision(True, False, load, f"low_cognitive_load:{load:.3f}<{threshold:.3f}")
     return ShieldDecision(False, False, load, f"high_cognitive_load:{load:.3f}>={threshold:.3f}")
+
+
+logger = logging.getLogger(__name__)
+
+# Strong refs so fire-and-forget pre-warm tasks are not GC'd mid-flight.
+_PREWARM_TASKS: set = set()
+
+
+def _default_token_estimator(ctx: Any) -> int:
+    """Best-effort token estimate from target file sizes (len//4). Never raises."""
+    import os as _os  # noqa: F401 — kept for clarity; _os not used but import validates
+    total = 0
+    for path in (getattr(ctx, "target_files", ()) or ()):
+        try:
+            with open(path, "r", errors="ignore") as fh:
+                total += len(fh.read()) // 4
+        except Exception:
+            continue
+    return total
+
+
+async def apply_quota_shield(
+    ctx: Any,
+    *,
+    advisory: Any,
+    gate: Any = None,
+    governor: Any = None,
+    local_enabled: Any = None,
+    token_estimator: Any = None,
+) -> Any:
+    """Orchestrator-side application of the quota shield.
+
+    Returns ctx unchanged when disabled; otherwise returns a (possibly
+    prefer_local-stamped) ctx and fires a non-blocking JIT pre-warm of the
+    local daemon when routing local. Fail-soft: any error returns the original
+    ctx untouched.
+    """
+    if not quota_shield_enabled():
+        return ctx
+    try:
+        if local_enabled is None:
+            from backend.core.ouroboros.governance.local_inference_director import (
+                local_prime_enabled as _lpe,
+            )
+            local_enabled = _lpe()
+        if gate is None:
+            from backend.core.ouroboros.governance.memory_pressure_gate import get_default_gate
+            gate = get_default_gate()
+        est = token_estimator or _default_token_estimator
+        token_volume = int(est(ctx))
+        level = gate.pressure()
+        decision = decide(
+            advisory=advisory,
+            pressure_level=level,
+            token_volume=token_volume,
+            local_enabled=bool(local_enabled),
+        )
+        logger.info(
+            "[QuotaShield] op=%s load=%.3f route_local=%s mem_override=%s reason=%s",
+            getattr(ctx, "op_id", "?"),
+            decision.cognitive_load,
+            decision.route_local,
+            decision.memory_override,
+            decision.reason,
+        )
+        if not decision.route_local:
+            return ctx
+        # JIT pre-warm: fire-and-forget so daemon boot latency is masked.
+        _gov = governor
+        try:
+            if _gov is None:
+                from backend.core.ouroboros.governance.local_daemon_governor import (
+                    daemon_governor_enabled,
+                    LocalDaemonGovernor,
+                )
+                if daemon_governor_enabled():
+                    _gov = LocalDaemonGovernor()
+            if _gov is not None:
+                _t = asyncio.ensure_future(_gov.start_if_enabled())
+                _PREWARM_TASKS.add(_t)
+                _t.add_done_callback(_PREWARM_TASKS.discard)
+        except Exception:
+            logger.debug("[QuotaShield] JIT pre-warm skipped", exc_info=True)
+        try:
+            return dataclasses.replace(ctx, prefer_local=True)
+        except Exception:
+            return ctx  # ctx not a dataclass / immutable replace failed -> leave as-is
+    except Exception:
+        logger.debug("[QuotaShield] apply skipped (fail-soft)", exc_info=True)
+        return ctx

--- a/backend/core/ouroboros/governance/quota_shield.py
+++ b/backend/core/ouroboros/governance/quota_shield.py
@@ -92,7 +92,6 @@ _PREWARM_TASKS: set = set()
 
 def _default_token_estimator(ctx: Any) -> int:
     """Best-effort token estimate from target file sizes (len//4). Never raises."""
-    import os as _os  # noqa: F401 — kept for clarity; _os not used but import validates
     total = 0
     for path in (getattr(ctx, "target_files", ()) or ()):
         try:
@@ -120,6 +119,10 @@ async def apply_quota_shield(
     ctx untouched.
     """
     if not quota_shield_enabled():
+        return ctx
+    # No advisory -> we cannot assess cognitive load. Do NOT hijack routing on a
+    # blind 0-load read (which would route everything local). Leave ctx untouched.
+    if advisory is None:
         return ctx
     try:
         if local_enabled is None:

--- a/backend/core/ouroboros/governance/quota_shield.py
+++ b/backend/core/ouroboros/governance/quota_shield.py
@@ -1,0 +1,81 @@
+"""Predictive Quota Shield (Phases 1+2) -- pure route-local-vs-remote decision.
+
+Fuses ALREADY-COMPUTED signals (OperationAdvisor risk_score + blast_radius, a
+precomputed token volume, and the live MemoryPressureGate level) into a single
+decision: route a trivial/localized op to the zero-cost local J-Prime tier
+(preserving remote DW quota), UNLESS host memory is CRITICAL (host stability wins
+-> hard upstream override). Pure + deterministic; the orchestrator supplies the
+signals and acts on the result. Reuses existing intelligence layers; computes
+nothing itself.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+_TRUE = {"1", "true", "yes", "on"}
+
+
+def quota_shield_enabled() -> bool:
+    return os.environ.get("JARVIS_QUOTA_SHIELD_ENABLED", "").strip().lower() in _TRUE
+
+
+def _f(name: str, d: float) -> float:
+    try:
+        return float(os.environ.get(name, str(d)))
+    except Exception:
+        return d
+
+
+def compute_cognitive_load(*, risk_score: float, blast_radius: int, token_volume: int) -> float:
+    """Fuse three normalized axes into a 0-1 cognitive-load score. Higher = heavier.
+
+    - risk_score: OperationAdvisor composite (already 0-1).
+    - blast_radius: downstream dependency count -> normalized by JARVIS_QUOTA_SHIELD_BLAST_NORM.
+    - token_volume: target payload size -> normalized by JARVIS_QUOTA_SHIELD_TOKEN_NORM.
+    Weights env-tunable; result clamped to [0,1].
+    """
+    blast_norm = max(1.0, _f("JARVIS_QUOTA_SHIELD_BLAST_NORM", 10.0))
+    token_norm = max(1.0, _f("JARVIS_QUOTA_SHIELD_TOKEN_NORM", 8000.0))
+    w_risk = _f("JARVIS_QUOTA_SHIELD_W_RISK", 0.5)
+    w_blast = _f("JARVIS_QUOTA_SHIELD_W_BLAST", 0.3)
+    w_tok = _f("JARVIS_QUOTA_SHIELD_W_TOKENS", 0.2)
+    r = min(1.0, max(0.0, float(risk_score)))
+    b = min(1.0, max(0.0, float(blast_radius) / blast_norm))
+    t = min(1.0, max(0.0, float(token_volume) / token_norm))
+    wsum = w_risk + w_blast + w_tok
+    if wsum <= 0:
+        return 0.0
+    return min(1.0, (w_risk * r + w_blast * b + w_tok * t) / wsum)
+
+
+@dataclass(frozen=True)
+class ShieldDecision:
+    route_local: bool
+    memory_override: bool
+    cognitive_load: float
+    reason: str
+
+
+def decide(*, advisory: Any, pressure_level: Any, token_volume: int,
+           local_enabled: bool) -> ShieldDecision:
+    """Decide whether to proactively route this op to the local tier.
+
+    Order: (1) local disabled -> never local. (2) CRITICAL memory -> hard upstream
+    override (host stability over quota savings). (3) low cognitive load -> local
+    (quota shield). (4) otherwise -> remote.
+    """
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    risk = float(getattr(advisory, "risk_score", 0.0) or 0.0)
+    blast = int(getattr(advisory, "blast_radius", 0) or 0)
+    load = compute_cognitive_load(risk_score=risk, blast_radius=blast, token_volume=token_volume)
+
+    if not local_enabled:
+        return ShieldDecision(False, False, load, "local_tier_disabled")
+    if pressure_level is PressureLevel.CRITICAL:
+        return ShieldDecision(False, True, load, "memory_critical_hard_override")
+    threshold = _f("JARVIS_QUOTA_SHIELD_THRESHOLD", 0.35)
+    if load < threshold:
+        return ShieldDecision(True, False, load, f"low_cognitive_load:{load:.3f}<{threshold:.3f}")
+    return ShieldDecision(False, False, load, f"high_cognitive_load:{load:.3f}>={threshold:.3f}")

--- a/tests/governance/test_quota_shield.py
+++ b/tests/governance/test_quota_shield.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+import dataclasses
+
+
+@dataclasses.dataclass
+class _Adv:
+    risk_score: float = 0.0
+    blast_radius: int = 0
+
+
+def test_quota_shield_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_QUOTA_SHIELD_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.quota_shield import quota_shield_enabled
+    assert quota_shield_enabled() is False
+    monkeypatch.setenv("JARVIS_QUOTA_SHIELD_ENABLED", "true")
+    assert quota_shield_enabled() is True
+
+
+def test_cognitive_load_monotonic():
+    from backend.core.ouroboros.governance.quota_shield import compute_cognitive_load
+    low = compute_cognitive_load(risk_score=0.0, blast_radius=0, token_volume=0)
+    hi_risk = compute_cognitive_load(risk_score=1.0, blast_radius=0, token_volume=0)
+    hi_blast = compute_cognitive_load(risk_score=0.0, blast_radius=100, token_volume=0)
+    hi_tok = compute_cognitive_load(risk_score=0.0, blast_radius=0, token_volume=100000)
+    assert 0.0 <= low <= hi_risk <= 1.0
+    assert low < hi_risk and low < hi_blast and low < hi_tok
+    assert compute_cognitive_load(risk_score=1.0, blast_radius=100, token_volume=100000) <= 1.0
+
+
+def test_decide_routes_local_on_low_load():
+    from backend.core.ouroboros.governance.quota_shield import decide
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    d = decide(advisory=_Adv(risk_score=0.05, blast_radius=1), pressure_level=PressureLevel.OK,
+               token_volume=200, local_enabled=True)
+    assert d.route_local is True
+    assert d.memory_override is False
+    assert d.cognitive_load < 0.5
+
+
+def test_decide_routes_remote_on_high_load():
+    from backend.core.ouroboros.governance.quota_shield import decide
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    d = decide(advisory=_Adv(risk_score=0.9, blast_radius=50), pressure_level=PressureLevel.OK,
+               token_volume=50000, local_enabled=True)
+    assert d.route_local is False
+    assert d.memory_override is False
+
+
+def test_critical_memory_hard_overrides_even_low_load():
+    from backend.core.ouroboros.governance.quota_shield import decide
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    d = decide(advisory=_Adv(risk_score=0.0, blast_radius=0), pressure_level=PressureLevel.CRITICAL,
+               token_volume=10, local_enabled=True)
+    assert d.route_local is False           # trivial, but host stability wins
+    assert d.memory_override is True
+    assert "memory" in d.reason.lower()
+
+
+def test_local_disabled_never_routes_local():
+    from backend.core.ouroboros.governance.quota_shield import decide
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+    d = decide(advisory=_Adv(risk_score=0.0, blast_radius=0), pressure_level=PressureLevel.OK,
+               token_volume=10, local_enabled=False)
+    assert d.route_local is False

--- a/tests/governance/test_quota_shield.py
+++ b/tests/governance/test_quota_shield.py
@@ -62,3 +62,85 @@ def test_local_disabled_never_routes_local():
     d = decide(advisory=_Adv(risk_score=0.0, blast_radius=0), pressure_level=PressureLevel.OK,
                token_volume=10, local_enabled=False)
     assert d.route_local is False
+
+
+import pytest
+
+
+class _Gov:
+    def __init__(self): self.started = 0
+    async def start_if_enabled(self): self.started += 1
+    def owns_daemon(self): return False
+
+
+@pytest.mark.asyncio
+async def test_apply_shield_disabled_returns_ctx_unchanged(monkeypatch):
+    monkeypatch.setenv("JARVIS_QUOTA_SHIELD_ENABLED", "false")
+    import dataclasses
+    from backend.core.ouroboros.governance.quota_shield import apply_quota_shield
+
+    @dataclasses.dataclass(frozen=True)
+    class _Ctx:
+        op_id: str = "o"
+        target_files: tuple = ("a.py",)
+        prefer_local: bool = False
+
+    ctx = _Ctx()
+    out = await apply_quota_shield(ctx, advisory=None)
+    assert out is ctx                      # untouched when disabled
+
+
+@pytest.mark.asyncio
+async def test_apply_shield_low_load_sets_prefer_local_and_prewarms(monkeypatch):
+    monkeypatch.setenv("JARVIS_QUOTA_SHIELD_ENABLED", "true")
+    import dataclasses
+    from backend.core.ouroboros.governance.quota_shield import apply_quota_shield
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+
+    @dataclasses.dataclass(frozen=True)
+    class _Ctx:
+        op_id: str = "o"
+        target_files: tuple = ("a.py",)
+        prefer_local: bool = False
+
+    @dataclasses.dataclass
+    class _Adv:
+        risk_score: float = 0.02
+        blast_radius: int = 1
+
+    gov = _Gov()
+    out = await apply_quota_shield(
+        _Ctx(), advisory=_Adv(),
+        gate=type("G", (), {"pressure": staticmethod(lambda: PressureLevel.OK)})(),
+        governor=gov, local_enabled=True, token_estimator=lambda ctx: 50)
+    assert out.prefer_local is True        # low load -> route local
+    await __import__("asyncio").sleep(0)   # let the fire-and-forget pre-warm schedule
+    assert gov.started == 1                # JIT pre-warm fired
+
+
+@pytest.mark.asyncio
+async def test_apply_shield_critical_memory_no_local_no_prewarm(monkeypatch):
+    monkeypatch.setenv("JARVIS_QUOTA_SHIELD_ENABLED", "true")
+    import dataclasses
+    from backend.core.ouroboros.governance.quota_shield import apply_quota_shield
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+
+    @dataclasses.dataclass(frozen=True)
+    class _Ctx:
+        op_id: str = "o"
+        target_files: tuple = ("a.py",)
+        prefer_local: bool = False
+
+    @dataclasses.dataclass
+    class _Adv:
+        risk_score: float = 0.0
+        blast_radius: int = 0
+
+    gov = _Gov()
+    out = await apply_quota_shield(
+        _Ctx(), advisory=_Adv(),
+        gate=type("G", (), {"pressure": staticmethod(lambda: PressureLevel.CRITICAL)})(),
+        governor=gov, local_enabled=True, token_estimator=lambda ctx: 10)
+    assert out.prefer_local is False       # CRITICAL -> host stability over quota
+    await __import__("asyncio").sleep(0)
+    assert gov.started == 0                # no pre-warm when not routing local

--- a/tests/governance/test_quota_shield_routing.py
+++ b/tests/governance/test_quota_shield_routing.py
@@ -1,0 +1,43 @@
+# tests/governance/test_quota_shield_routing.py
+from __future__ import annotations
+import dataclasses
+import pytest
+
+
+def test_prefer_local_field_defaults_false():
+    from backend.core.ouroboros.governance.op_context import OperationContext
+    assert "prefer_local" in OperationContext.__dataclass_fields__
+    assert OperationContext.__dataclass_fields__["prefer_local"].default is False
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_shield_decision_to_prefer_local(monkeypatch):
+    """Shield ON + low load + OK memory -> apply_quota_shield stamps prefer_local."""
+    monkeypatch.setenv("JARVIS_QUOTA_SHIELD_ENABLED", "true")
+    from backend.core.ouroboros.governance.quota_shield import apply_quota_shield
+    from backend.core.ouroboros.governance.memory_pressure_gate import PressureLevel
+
+    @dataclasses.dataclass(frozen=True)
+    class _Ctx:
+        op_id: str = "o"
+        target_files: tuple = ("x.py",)
+        prefer_local: bool = False
+
+    @dataclasses.dataclass
+    class _Adv:
+        risk_score: float = 0.01
+        blast_radius: int = 0
+
+    out = await apply_quota_shield(
+        _Ctx(), advisory=_Adv(),
+        gate=type("G", (), {"pressure": staticmethod(lambda: PressureLevel.OK)})(),
+        governor=None, local_enabled=True, token_estimator=lambda c: 20)
+    assert out.prefer_local is True
+
+
+def test_primacy_gate_honors_prefer_local_source():
+    """Static guard: the primacy gate fires on prefer_local OR jprime_primacy_enabled."""
+    import backend.core.ouroboros.governance.candidate_generator as cg
+    src = open(cg.__file__).read()
+    assert 'getattr(context, "prefer_local", False)' in src   # gate honors the flag
+    assert 'self._try_jprime_primacy(context, deadline, "quota_shield")' in src  # dispatch consult

--- a/tests/governance/test_quota_shield_routing.py
+++ b/tests/governance/test_quota_shield_routing.py
@@ -40,4 +40,5 @@ def test_primacy_gate_honors_prefer_local_source():
     import backend.core.ouroboros.governance.candidate_generator as cg
     src = open(cg.__file__).read()
     assert 'getattr(context, "prefer_local", False)' in src   # gate honors the flag
-    assert 'self._try_jprime_primacy(context, deadline, "quota_shield")' in src  # dispatch consult
+    # dispatch consult — route_label is keyword-only on _try_jprime_primacy
+    assert 'self._try_jprime_primacy(context, deadline, route_label="quota_shield")' in src

--- a/tests/governance/test_quota_shield_routing.py
+++ b/tests/governance/test_quota_shield_routing.py
@@ -35,6 +35,29 @@ async def test_end_to_end_shield_decision_to_prefer_local(monkeypatch):
     assert out.prefer_local is True
 
 
+import pytest as _pytest
+
+
+@_pytest.mark.asyncio
+async def test_apply_shield_none_advisory_is_noop(monkeypatch):
+    """Advisory None (e.g. extracted-classify path missing it) must NOT route local
+    on a blind 0-load read — the shield leaves ctx untouched."""
+    monkeypatch.setenv("JARVIS_QUOTA_SHIELD_ENABLED", "true")
+    import dataclasses
+    from backend.core.ouroboros.governance.quota_shield import apply_quota_shield
+
+    @dataclasses.dataclass(frozen=True)
+    class _Ctx:
+        op_id: str = "o"
+        target_files: tuple = ("x.py",)
+        prefer_local: bool = False
+
+    ctx = _Ctx()
+    out = await apply_quota_shield(ctx, advisory=None)
+    assert out is ctx                      # None advisory -> no hijack
+    assert out.prefer_local is False
+
+
 def test_primacy_gate_honors_prefer_local_source():
     """Static guard: the primacy gate fires on prefer_local OR jprime_primacy_enabled."""
     import backend.core.ouroboros.governance.candidate_generator as cg


### PR DESCRIPTION
## Summary
The proactive routing intelligence (original ADD Phases 1+2), composed from existing layers — **no new ComplexityAnalyzer, no FSM rewrite**. When enabled, trivial/localized ops are proactively routed to the **zero-cost local J-Prime tier** (preserving DW quota for heavy architectural work), unless host memory is CRITICAL (host stability wins → upstream). Plus speculative JIT daemon pre-warm.

## Reuse-first (the whole point — audited)
- **Cognitive load** reuses `OperationAdvisor` (`risk_score` + `blast_radius`, already computed per-op) + a token estimate + `MemoryPressureGate.pressure()` — **not** a new analyzer.
- **CRITICAL override** is `memory_guard` + one pressure check in `decide()` — **no FailbackStateMachine rewrite**.
- **Route-forcing** reuses the existing `_try_jprime_primacy` path (sem + fallthrough-to-DW) via an additive `prefer_local` flag — no new route enum.
- **JIT pre-warm** reuses `LocalDaemonGovernor.start_if_enabled()`.

## Components
- `quota_shield.py` — pure `compute_cognitive_load` + `decide()` (env-tuned weights/threshold) + `apply_quota_shield()` (orchestrator helper: reuse advisory, probe gate, stamp `prefer_local`, fire JIT pre-warm fire-and-forget). Master gate `JARVIS_QUOTA_SHIELD_ENABLED` (default OFF).
- `op_context.py` — additive `prefer_local: bool = False`.
- `orchestrator.py` — `apply_quota_shield` at the **shared post-CLASSIFY point** (runs on both the production CLASSIFYRunner path and legacy).
- `candidate_generator.py` — `_try_jprime_primacy` honors `prefer_local`; dispatch consults it local-first (falls through to DW on decline).

## Review caught two real bugs (both fixed)
1. **`route_label` keyword-only** — the dispatch consult passed it positionally → would `TypeError` at runtime (static-grep tests missed it; Pyright + review caught it). Fixed to `route_label="quota_shield"`.
2. **[BLOCKER] shield was dead in production** — initially wired into the legacy `else` CLASSIFY branch, but `_phase_runner_classify_extracted()` defaults TRUE → the production path skipped it (silent no-op). Moved to the shared post-CLASSIFY point so it runs on **both** paths. Also added a **None-advisory guard** (an absent advisory would otherwise read load=0 → route everything local).

## Safety
- Default OFF byte-identical (no op carries `prefer_local`; both new candidate_generator branches inert). Fail-soft (any error → original ctx). JIT pre-warm non-blocking (fire-and-forget, no-GC ref).
- 13 tests green; quota-shield suites pass; failures in the sweep are pre-existing (`test_provider_topology_v2` etc.) + the 5 known collection errors — unrelated.

Completes the J-Prime router intelligence arc (follow-on to the Phase 3.x infra + 3.3 exhaustion interceptor). Activate: `JARVIS_QUOTA_SHIELD_ENABLED=true` (+ `JARVIS_LOCAL_PRIME_ENABLED=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Predictive Quota Shield (Phases 1+2) to route low‑load ops to the zero‑cost local J‑Prime tier and JIT pre‑warm the daemon. Preserves DW quota and hard-overrides to remote when memory is critical; off by default.

- **New Features**
  - Computes a cognitive-load score from `OperationAdvisor` risk/blast, a token estimate, and `MemoryPressureGate`; routes local when below an env-tuned threshold.
  - Orchestrator applies `apply_quota_shield` after CLASSIFY on all paths; stamps `prefer_local` and fires JIT pre‑warm via `LocalDaemonGovernor` (non-blocking).
  - `candidate_generator` honors `prefer_local` via existing `_try_jprime_primacy`, with graceful fallback to normal routing.
  - Adds `prefer_local` to `OperationContext`. Master flag `JARVIS_QUOTA_SHIELD_ENABLED` (requires `JARVIS_LOCAL_PRIME_ENABLED`).

- **Bug Fixes**
  - Fixed `route_label` to be passed as a keyword to avoid a runtime TypeError.
  - Moved wiring to the shared post-CLASSIFY point so the shield runs on the production path; added a None-advisory guard to avoid routing everything local.

<sup>Written for commit 61cd2e6c8b9925bc765a6ca2ab39721f5f3f2518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

