### PR TITLE
feat(jprime): truncation-retry → diff-shape (recover generative truncation, funded providers)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -1643,12 +1643,23 @@ class DoublewordProvider:
         # emits the native 2b.1-diff (bounded output → no 60K-blob JSONDecodeError);
         # everything else stays full_content. Fail-soft to full_content; the
         # orchestrator degrades a stale/failed diff back to full_content.
+        _schema_cap = resolve_diff_capability_for_model(_effective_model)
         _force_full = bool(getattr(ctx, "force_full_content_override", False)) or \
             resolve_force_full_content(
-                schema_capability=resolve_diff_capability_for_model(_effective_model),
+                schema_capability=_schema_cap,
                 target_files=getattr(ctx, "target_files", ()) or (),
                 repo_root=self._repo_root,
             )
+        # Truncation-retry (gated): honor force_diff_on_retry + retry_max_tokens_override
+        # on a stamped retry. No-op when the flags are unset (byte-identical).
+        try:
+            from backend.core.ouroboros.governance.truncation_retry import apply_retry_overrides
+            _force_full, _retry_max_tokens = apply_retry_overrides(
+                ctx=ctx, schema_capability=_schema_cap,
+                force_full=_force_full, max_tokens=self._max_tokens,
+            )
+        except Exception:
+            _retry_max_tokens = self._max_tokens
         if not _force_full:
             logger.info(
                 "[DoublewordProvider] Slice235 adaptive-diff: emitting 2b.1-diff "
@@ -1687,7 +1698,7 @@ class DoublewordProvider:
                     )},
                     {"role": "user", "content": prompt},
                 ],
-                "max_tokens": self._max_tokens,
+                "max_tokens": _retry_max_tokens,
                 "temperature": _DW_TEMPERATURE,
                 # Slice 54/55 — Qwen3.5 reasoning control. reasoning_effort
                 # (DW-honored; the old enable_thinking flag was ignored) is

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -1020,6 +1020,14 @@ class OperationContext:
     provider_route_reason: str = ""  # human-readable reason for telemetry
     prefer_local: bool = False    # Quota Shield: route this op to the local J-Prime tier
 
+    # ---- Truncation-retry shape flags (Task 2, feat/jprime-truncation-retry-diff-shape) ----
+    # Stamped by the orchestrator GENERATE_RETRY path when a truncation/elision
+    # failure is detected (JARVIS_TRUNCATION_RETRY_ENABLED=true). Consumed by
+    # the provider tier to change output shape on the next attempt instead of
+    # retrying with the same parameters.
+    force_diff_on_retry: bool = False        # Truncation-retry: force 2b.1-diff output on this retry
+    retry_max_tokens_override: int = 0        # Truncation-retry: >0 overrides provider max_tokens for this retry
+
     # ---- Slice 245 — hibernation resurrection flag ----
     # Set (via with_resurrection()) when an op that failed with provider
     # exhaustion during a dark window is re-ingested after the Grid Sentinel

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -6352,6 +6352,35 @@ class GovernedOrchestrator:
                             "- Ensure the JSON is valid (no trailing commas, no unquoted keys)\n"
                             "- full_content must be the entire file, not a summary or placeholder\n"
                         )
+                    # Truncation-retry (gated): output truncation/elision ->
+                    # retry with a changed output shape (diff) + token headroom
+                    # instead of re-yelling. Reuses build_truncation_retry_directive.
+                    try:
+                        from backend.core.ouroboros.governance.truncation_retry import (
+                            truncation_retry_enabled, is_truncation_failure,
+                            build_truncation_retry_directive, stamp_retry_directive,
+                        )
+                        if truncation_retry_enabled() and is_truncation_failure(_err_msg):
+                            _diff_capable = False
+                            _ri = getattr(getattr(ctx, "telemetry", None), "routing_intent", None)
+                            if _ri is not None:
+                                _diff_capable = getattr(_ri, "schema_capability", "") == "full_content_and_diff"
+                            _cur_max = int(getattr(ctx, "retry_max_tokens_override", 0) or 8192)
+                            _tr_directive = build_truncation_retry_directive(
+                                diff_capable=_diff_capable, current_max_tokens=_cur_max)
+                            ctx = stamp_retry_directive(ctx, _tr_directive)
+                            _error_feedback = (
+                                _error_feedback + "\n\n" + _tr_directive.feedback
+                                if _error_feedback else _tr_directive.feedback
+                            )
+                            logger.info(
+                                "[TruncationRetry] op=%s force_diff=%s max_tokens=%d -> GENERATE_RETRY",
+                                getattr(ctx, "op_id", "?"), _tr_directive.force_diff,
+                                _tr_directive.new_max_tokens,
+                            )
+                    except Exception:
+                        logger.debug("[TruncationRetry] skip", exc_info=True)
+
                     _retry_ctx_kwargs["strategic_memory_prompt"] = _error_feedback
 
                     # Record generation failure in episodic memory for downstream use

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -5174,6 +5174,17 @@ class PrimeProvider:
                 repo_root=repo_root,
             )
 
+        # Truncation-retry (gated): on a retry stamped force_diff_on_retry, allow the
+        # native 2b.1-diff path for diff-capable models, and honor retry_max_tokens_override.
+        try:
+            from backend.core.ouroboros.governance.truncation_retry import apply_retry_overrides
+            _force_full, _retry_max_tokens = apply_retry_overrides(
+                ctx=context, schema_capability=_schema_cap,
+                force_full=_force_full, max_tokens=self._max_tokens,
+            )
+        except Exception:
+            _retry_max_tokens = self._max_tokens
+
         # Gap #7: discover MCP tools for prompt injection
         _mcp_tools = None
         if self._mcp_client is not None and self._tools_enabled:
@@ -5240,7 +5251,7 @@ class PrimeProvider:
             resp = await self._client.generate(
                 prompt=p,
                 system_prompt=_CODEGEN_SYSTEM_PROMPT,
-                max_tokens=self._max_tokens,
+                max_tokens=_retry_max_tokens,
                 temperature=0.2,
                 model_name=_brain_model,
                 task_profile=_task_profile,
@@ -5422,7 +5433,7 @@ class PrimeProvider:
                 resp = await self._client.generate(
                     prompt=current_prompt,
                     system_prompt=_CODEGEN_SYSTEM_PROMPT,
-                    max_tokens=self._max_tokens,
+                    max_tokens=_retry_max_tokens,
                     temperature=0.2,
                     model_name=_brain_model,
                     task_profile=_task_profile,

--- a/backend/core/ouroboros/governance/truncation_retry.py
+++ b/backend/core/ouroboros/governance/truncation_retry.py
@@ -1,0 +1,77 @@
+"""Truncation-retry directive (pure) -- recover from generative output truncation
+by retrying with a CHANGED output shape instead of re-yelling at the model.
+
+When a provider elides/truncates its output (placeholder text -> the parser's
+`all_candidates_syntax_error`), a blind full-content retry tends to truncate
+again. Instead:
+  * diff-capable model -> retry as 2b.1-diff (a unified diff is tiny; it cannot
+    truncate a large file because the model never re-emits the whole file).
+  * full-content-only model -> bump max_tokens for headroom + feedback that
+    forbids elisions.
+This module is the PURE decision layer; the orchestrator/provider act on it.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+_TRUE = {"1", "true", "yes", "on"}
+
+# Failure-message markers that indicate generative truncation/elision.
+_TRUNCATION_MARKERS = ("all_candidates_syntax_error", "placeholder")
+
+
+def truncation_retry_enabled() -> bool:
+    return os.environ.get("JARVIS_TRUNCATION_RETRY_ENABLED", "").strip().lower() in _TRUE
+
+
+def is_truncation_failure(err_msg: Optional[str]) -> bool:
+    """True iff the failure message indicates output truncation/elision."""
+    if not err_msg:
+        return False
+    low = str(err_msg).lower()
+    return any(m in low for m in _TRUNCATION_MARKERS)
+
+
+@dataclass(frozen=True)
+class RetryDirective:
+    force_diff: bool
+    new_max_tokens: int
+    feedback: str
+
+
+def _token_ceiling() -> int:
+    try:
+        return int(os.environ.get("JARVIS_TRUNCATION_RETRY_TOKEN_CEILING", "16384"))
+    except Exception:
+        return 16384
+
+
+def build_truncation_retry_directive(*, diff_capable: bool, current_max_tokens: int) -> RetryDirective:
+    """Produce the retry directive for a truncation failure.
+
+    diff_capable -> force a 2b.1-diff retry (changes output shape; can't truncate).
+    otherwise    -> bump max_tokens (min(2x, ceiling)) + an explicit no-elision prompt.
+    """
+    ceiling = _token_ceiling()
+    if diff_capable:
+        return RetryDirective(
+            force_diff=True,
+            new_max_tokens=max(int(current_max_tokens), 0) or ceiling,
+            feedback=(
+                "Your previous output was truncated or contained placeholders. "
+                "Re-emit as a 2b.1-diff (unified diff) of ONLY the changed lines. "
+                "Do NOT re-emit the entire file."
+            ),
+        )
+    bumped = min(max(int(current_max_tokens), 1) * 2, ceiling)
+    return RetryDirective(
+        force_diff=False,
+        new_max_tokens=bumped,
+        feedback=(
+            "Your previous output was truncated or contained placeholders such as "
+            "'...' or '# rest of file unchanged'. Emit the COMPLETE file content with "
+            "NO elisions and NO placeholders."
+        ),
+    )

--- a/backend/core/ouroboros/governance/truncation_retry.py
+++ b/backend/core/ouroboros/governance/truncation_retry.py
@@ -65,6 +65,28 @@ def stamp_retry_directive(ctx: object, directive: RetryDirective) -> object:
         return ctx
 
 
+def apply_retry_overrides(*, ctx: object, schema_capability: str, force_full: bool, max_tokens: int):
+    """Apply truncation-retry context flags to a provider's (force_full, max_tokens).
+
+    Returns (force_full_out, max_tokens_out):
+      * force_diff_on_retry + diff-capable model -> force_full_out=False (allow 2b.1-diff).
+        (A full_content_only model cannot emit a diff, so force_full is left as-is.)
+      * retry_max_tokens_override > 0 -> max_tokens_out = the override.
+    Fail-soft: any error returns the inputs unchanged. No-op when flags unset.
+    """
+    try:
+        ff = bool(force_full)
+        mt = int(max_tokens)
+        if getattr(ctx, "force_diff_on_retry", False) and schema_capability == "full_content_and_diff":
+            ff = False
+        _ov = int(getattr(ctx, "retry_max_tokens_override", 0) or 0)
+        if _ov > 0:
+            mt = _ov
+        return ff, mt
+    except Exception:
+        return force_full, max_tokens
+
+
 def build_truncation_retry_directive(*, diff_capable: bool, current_max_tokens: int) -> RetryDirective:
     """Produce the retry directive for a truncation failure.
 

--- a/backend/core/ouroboros/governance/truncation_retry.py
+++ b/backend/core/ouroboros/governance/truncation_retry.py
@@ -48,6 +48,23 @@ def _token_ceiling() -> int:
         return 16384
 
 
+def stamp_retry_directive(ctx: object, directive: RetryDirective) -> object:
+    """Return a copy of *ctx* with the directive applied (frozen-dataclass safe).
+
+    force_diff -> ctx.force_diff_on_retry=True; always sets retry_max_tokens_override.
+    Fail-soft: if ctx is not a dataclass (or replace raises), returns ctx unchanged.
+    """
+    import dataclasses as _dc
+    try:
+        return _dc.replace(
+            ctx,  # type: ignore[arg-type]
+            force_diff_on_retry=bool(directive.force_diff),
+            retry_max_tokens_override=int(directive.new_max_tokens),
+        )
+    except Exception:
+        return ctx
+
+
 def build_truncation_retry_directive(*, diff_capable: bool, current_max_tokens: int) -> RetryDirective:
     """Produce the retry directive for a truncation failure.
 

--- a/tests/governance/test_truncation_retry.py
+++ b/tests/governance/test_truncation_retry.py
@@ -1,0 +1,45 @@
+# tests/governance/test_truncation_retry.py
+from __future__ import annotations
+
+
+def test_truncation_retry_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_TRUNCATION_RETRY_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.truncation_retry import truncation_retry_enabled
+    assert truncation_retry_enabled() is False
+    monkeypatch.setenv("JARVIS_TRUNCATION_RETRY_ENABLED", "true")
+    assert truncation_retry_enabled() is True
+
+
+def test_is_truncation_failure_matches_syntax_and_placeholder():
+    from backend.core.ouroboros.governance.truncation_retry import is_truncation_failure
+    assert is_truncation_failure("gcp-jprime_schema_invalid:all_candidates_syntax_error") is True
+    assert is_truncation_failure("doubleword-397b_schema_invalid:all_candidates_syntax_error") is True
+    assert is_truncation_failure("candidate contains placeholder text") is True
+    assert is_truncation_failure("all_providers_exhausted:terminal_quota") is False
+    assert is_truncation_failure("some_other_error") is False
+    assert is_truncation_failure("") is False
+    assert is_truncation_failure(None) is False  # robust to None
+
+
+def test_directive_diff_capable_forces_diff():
+    from backend.core.ouroboros.governance.truncation_retry import build_truncation_retry_directive
+    d = build_truncation_retry_directive(diff_capable=True, current_max_tokens=8192)
+    assert d.force_diff is True
+    assert "diff" in d.feedback.lower()
+    assert d.new_max_tokens >= 8192          # never lowers
+
+
+def test_directive_full_only_bumps_tokens_no_diff():
+    from backend.core.ouroboros.governance.truncation_retry import build_truncation_retry_directive
+    d = build_truncation_retry_directive(diff_capable=False, current_max_tokens=8192)
+    assert d.force_diff is False
+    assert d.new_max_tokens > 8192           # bumped to give headroom
+    # feedback must forbid elisions explicitly
+    assert "..." in d.feedback or "no elision" in d.feedback.lower() or "complete file" in d.feedback.lower()
+
+
+def test_directive_token_bump_respects_ceiling(monkeypatch):
+    from backend.core.ouroboros.governance.truncation_retry import build_truncation_retry_directive
+    monkeypatch.setenv("JARVIS_TRUNCATION_RETRY_TOKEN_CEILING", "16384")
+    d = build_truncation_retry_directive(diff_capable=False, current_max_tokens=12000)
+    assert d.new_max_tokens <= 16384         # min(2x, ceiling)

--- a/tests/governance/test_truncation_retry.py
+++ b/tests/governance/test_truncation_retry.py
@@ -73,3 +73,41 @@ def test_real_operation_context_has_truncation_fields():
     f = OperationContext.__dataclass_fields__
     assert "force_diff_on_retry" in f and f["force_diff_on_retry"].default is False
     assert "retry_max_tokens_override" in f and f["retry_max_tokens_override"].default == 0
+
+
+def _ctx(force_diff=False, override=0):
+    import dataclasses
+    @dataclasses.dataclass(frozen=True)
+    class _C:
+        force_diff_on_retry: bool = False
+        retry_max_tokens_override: int = 0
+    return _C(force_diff_on_retry=force_diff, retry_max_tokens_override=override)
+
+
+def test_apply_overrides_forces_diff_when_capable():
+    from backend.core.ouroboros.governance.truncation_retry import apply_retry_overrides
+    ff, mt = apply_retry_overrides(ctx=_ctx(force_diff=True), schema_capability="full_content_and_diff",
+                                   force_full=True, max_tokens=8192)
+    assert ff is False           # diff allowed
+    assert mt == 8192
+
+
+def test_apply_overrides_cannot_force_diff_on_full_only():
+    from backend.core.ouroboros.governance.truncation_retry import apply_retry_overrides
+    ff, mt = apply_retry_overrides(ctx=_ctx(force_diff=True), schema_capability="full_content_only",
+                                   force_full=True, max_tokens=8192)
+    assert ff is True            # full_content_only model can't emit a diff -> unchanged
+
+
+def test_apply_overrides_token_override():
+    from backend.core.ouroboros.governance.truncation_retry import apply_retry_overrides
+    ff, mt = apply_retry_overrides(ctx=_ctx(override=16384), schema_capability="full_content_only",
+                                   force_full=True, max_tokens=8192)
+    assert mt == 16384
+
+
+def test_apply_overrides_noop_when_unset():
+    from backend.core.ouroboros.governance.truncation_retry import apply_retry_overrides
+    ff, mt = apply_retry_overrides(ctx=_ctx(), schema_capability="full_content_and_diff",
+                                   force_full=True, max_tokens=8192)
+    assert ff is True and mt == 8192   # no flags -> unchanged

--- a/tests/governance/test_truncation_retry.py
+++ b/tests/governance/test_truncation_retry.py
@@ -43,3 +43,33 @@ def test_directive_token_bump_respects_ceiling(monkeypatch):
     monkeypatch.setenv("JARVIS_TRUNCATION_RETRY_TOKEN_CEILING", "16384")
     d = build_truncation_retry_directive(diff_capable=False, current_max_tokens=12000)
     assert d.new_max_tokens <= 16384         # min(2x, ceiling)
+
+
+def test_stamp_directive_sets_context_flags():
+    import dataclasses
+    from backend.core.ouroboros.governance.truncation_retry import (
+        stamp_retry_directive, RetryDirective)
+
+    @dataclasses.dataclass(frozen=True)
+    class _Ctx:
+        op_id: str = "o"
+        force_diff_on_retry: bool = False
+        retry_max_tokens_override: int = 0
+
+    out = stamp_retry_directive(_Ctx(), RetryDirective(force_diff=True, new_max_tokens=16384, feedback="x"))
+    assert out.force_diff_on_retry is True
+    assert out.retry_max_tokens_override == 16384
+
+
+def test_stamp_directive_failsoft_on_non_dataclass():
+    from backend.core.ouroboros.governance.truncation_retry import (
+        stamp_retry_directive, RetryDirective)
+    obj = object()
+    assert stamp_retry_directive(obj, RetryDirective(False, 1, "x")) is obj
+
+
+def test_real_operation_context_has_truncation_fields():
+    from backend.core.ouroboros.governance.op_context import OperationContext
+    f = OperationContext.__dataclass_fields__
+    assert "force_diff_on_retry" in f and f["force_diff_on_retry"].default is False
+    assert "retry_max_tokens_override" in f and f["retry_max_tokens_override"].default == 0

--- a/tests/governance/test_truncation_retry_integration.py
+++ b/tests/governance/test_truncation_retry_integration.py
@@ -48,3 +48,24 @@ def test_disabled_is_inert(monkeypatch):
     monkeypatch.setenv("JARVIS_TRUNCATION_RETRY_ENABLED", "false")
     from backend.core.ouroboros.governance.truncation_retry import truncation_retry_enabled
     assert truncation_retry_enabled() is False
+
+
+def test_real_operationcontext_advance_preserves_truncation_fields():
+    """Closes the recurring 'wiring verified only by inspection' gap: stamp the two
+    flags on a REAL OperationContext, advance to GENERATE_RETRY, and assert they
+    survive advance() (i.e. _retry_ctx_kwargs can't clobber them)."""
+    import dataclasses
+    from datetime import datetime, timezone
+    from backend.core.ouroboros.governance.op_context import (
+        OperationContext, OperationPhase)
+    now = datetime.now(timezone.utc)
+    ctx = OperationContext(
+        op_id="op-trunc-test", created_at=now, phase=OperationPhase.GENERATE,
+        phase_entered_at=now, context_hash="h0", previous_hash="",
+        target_files=("a.py",),
+    )
+    stamped = dataclasses.replace(
+        ctx, force_diff_on_retry=True, retry_max_tokens_override=16384)
+    advanced = stamped.advance(OperationPhase.GENERATE_RETRY)
+    assert advanced.force_diff_on_retry is True
+    assert advanced.retry_max_tokens_override == 16384

--- a/tests/governance/test_truncation_retry_integration.py
+++ b/tests/governance/test_truncation_retry_integration.py
@@ -1,0 +1,50 @@
+# tests/governance/test_truncation_retry_integration.py
+from __future__ import annotations
+import dataclasses
+
+
+def test_full_chain_diff_capable(monkeypatch):
+    """truncation failure -> directive(force_diff) -> stamp -> provider override allows diff."""
+    monkeypatch.setenv("JARVIS_TRUNCATION_RETRY_ENABLED", "true")
+    from backend.core.ouroboros.governance.truncation_retry import (
+        truncation_retry_enabled, is_truncation_failure,
+        build_truncation_retry_directive, stamp_retry_directive, apply_retry_overrides)
+
+    @dataclasses.dataclass(frozen=True)
+    class _Ctx:
+        op_id: str = "o"
+        force_diff_on_retry: bool = False
+        retry_max_tokens_override: int = 0
+
+    err = "doubleword-397b_schema_invalid:all_candidates_syntax_error"
+    assert truncation_retry_enabled() and is_truncation_failure(err)
+    d = build_truncation_retry_directive(diff_capable=True, current_max_tokens=8192)
+    ctx2 = stamp_retry_directive(_Ctx(), d)
+    assert ctx2.force_diff_on_retry is True
+    ff, mt = apply_retry_overrides(ctx=ctx2, schema_capability="full_content_and_diff",
+                                   force_full=True, max_tokens=8192)
+    assert ff is False                      # diff-capable retry -> diff allowed end to end
+
+
+def test_full_chain_full_only_bumps_tokens(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRUNCATION_RETRY_ENABLED", "true")
+    from backend.core.ouroboros.governance.truncation_retry import (
+        build_truncation_retry_directive, stamp_retry_directive, apply_retry_overrides)
+
+    @dataclasses.dataclass(frozen=True)
+    class _Ctx:
+        op_id: str = "o"
+        force_diff_on_retry: bool = False
+        retry_max_tokens_override: int = 0
+
+    d = build_truncation_retry_directive(diff_capable=False, current_max_tokens=8192)
+    ctx2 = stamp_retry_directive(_Ctx(), d)
+    ff, mt = apply_retry_overrides(ctx=ctx2, schema_capability="full_content_only",
+                                   force_full=True, max_tokens=8192)
+    assert ff is True and mt > 8192          # full-only -> can't diff, but more headroom
+
+
+def test_disabled_is_inert(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRUNCATION_RETRY_ENABLED", "false")
+    from backend.core.ouroboros.governance.truncation_retry import truncation_retry_enabled
+    assert truncation_retry_enabled() is False


### PR DESCRIPTION
## Summary
Recovers from **generative output truncation** (placeholder/elided content → `all_candidates_syntax_error`) by retrying with a **changed output shape**, not by re-prompting a token-exhausted model. For diff-capable models it forces **2b.1-diff** output (a diff is tiny → can't truncate a large file); for full-content-only models it bumps `max_tokens` + emits no-elision feedback. Gated `JARVIS_TRUNCATION_RETRY_ENABLED` (default OFF).

## Reuse-first (audited; rejected the over-engineered alternative)
The original ask was an "AST splicing engine" — **declined on feasibility** (AST can't parse the *broken* file; the dependency graph doesn't segment intra-file line ranges; re-weave is research-grade) and because it targets a failure DW rarely hits. This ships the **right-sized** fix instead, reusing:
- the existing **Iron Gate `GENERATE_RETRY`** machinery (detection → directive → retry)
- the existing **2b.1-diff path** (`resolve_force_full_content` / `should_force_full_content`) — the real systemic truncation-avoidance
- **no** new ComplexityAnalyzer, **no** FSM rewrite, **no** `context_compaction` mis-wire (its `dialogue_entries` shape doesn't fit `OperationContext` — caught for the 3rd time).

## Components
- `truncation_retry.py` (pure, tested): `is_truncation_failure`, `build_truncation_retry_directive` (diff for capable / token-bump for full-only), `stamp_retry_directive`, `apply_retry_overrides`.
- `op_context.py`: additive `force_diff_on_retry: bool=False`, `retry_max_tokens_override: int=0`.
- `orchestrator.py`: GENERATE_RETRY detection → stamp (survives `advance()`, execution-tested).
- `providers.py` (PrimeProvider) + `doubleword_provider.py` (**DW — the funded target**): honor the flags via `apply_retry_overrides`.

## Safety (final review: APPROVE, no BLOCKER/IMPORTANT)
- **Default-OFF byte-identical** at all 3 wiring sites; `_retry_max_tokens == self._max_tokens` when unset.
- **force_diff only for `full_content_and_diff` models** (a full-only model is never told to emit a diff it can't).
- **No infinite-retry** (rides the existing bounded GENERATE_RETRY loop).
- **Fail-soft** throughout (any error → unchanged ctx/inputs).
- All 3 wiring-site calls verified for correct (keyword-only) arg shapes.
- 16 tests green incl. a real-`OperationContext` `advance()`-preservation test (closes the inspection-only gap).

**Known follow-up:** DW SSE/dynamic-max-tokens path (`_compute_dynamic_max_tokens`) not wired for the token override (the batch path is); force_diff applies to both. Not a correctness hole (SSE behaves as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers from generative output truncation by retrying with a different output shape instead of re-prompting. Diff-capable models switch to 2b.1-diff; full-content-only models get a token bump and explicit no‑elision feedback; gated by `JARVIS_TRUNCATION_RETRY_ENABLED` (default off).

- **New Features**
  - Added pure `truncation_retry.py`: `truncation_retry_enabled`, `is_truncation_failure`, `build_truncation_retry_directive`, `stamp_retry_directive`, `apply_retry_overrides`.
  - Orchestrator `GENERATE_RETRY`: detects truncation, stamps `OperationContext` with `force_diff_on_retry` and `retry_max_tokens_override`, and appends user-facing feedback.
  - Providers (`providers.py` Prime, `doubleword_provider.py` Doubleword): honor overrides; allow native diff when schema is `full_content_and_diff`; pass `_retry_max_tokens` to generation calls.
  - Safe by default: feature off by default, bounded retries, fail-soft paths, and context flags preserved across `advance()`. Added unit and integration tests.

- **Migration**
  - Enable with `JARVIS_TRUNCATION_RETRY_ENABLED=true`.
  - Optional: set `JARVIS_TRUNCATION_RETRY_TOKEN_CEILING` to cap the token bump. No other changes required.

<sup>Written for commit af998e367db87773a131aa7398a123ced4787eb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

