### PR TITLE
feat(concurrency): CD-1 lag-aware stream timeout + CD-2 lag-triggered load-shed (gated)

### DIFF
--- a/backend/core/ouroboros/governance/control_plane_load_shed.py
+++ b/backend/core/ouroboros/governance/control_plane_load_shed.py
@@ -1,0 +1,61 @@
+"""Control-plane load-shed signal (CD-2). A process-level latch set while an LLM
+stream is active AND the event loop is critically lagged, so the SensorGovernor
+sheds low-priority background work to free the loop for stream consumption.
+Reuses control_plane_watchdog (lag) + SensorGovernor (brake) — no new governor.
+Gated by JARVIS_CONTROL_PLANE_LOAD_SHED_ENABLED (default OFF)."""
+from __future__ import annotations
+
+import os
+import threading
+
+_TRUE = {"1", "true", "yes", "on"}
+_lock = threading.Lock()
+_stream_active = 0          # reentrancy count (nested/concurrent streams)
+_shed_active = False
+
+
+def load_shed_enabled() -> bool:
+    return os.environ.get("JARVIS_CONTROL_PLANE_LOAD_SHED_ENABLED", "").strip().lower() in _TRUE
+
+
+def critical_lag_threshold_ms() -> float:
+    return float(os.environ.get("JARVIS_LOAD_SHED_LAG_THRESHOLD_MS", "150"))
+
+
+def stream_begin() -> None:
+    global _stream_active
+    with _lock:
+        _stream_active += 1
+
+
+def stream_end() -> None:
+    global _stream_active, _shed_active
+    with _lock:
+        _stream_active = max(0, _stream_active - 1)
+        if _stream_active == 0:
+            _shed_active = False   # restore when no stream is active
+
+
+def evaluate(recent_lag_ms: float) -> bool:
+    """Update + return the shed latch: shed iff enabled AND a stream is active AND
+    recent lag exceeds the critical threshold. Latches ON during the stream; clears
+    on stream_end. Returns current shed state."""
+    global _shed_active
+    if not load_shed_enabled():
+        return False
+    with _lock:
+        if _stream_active > 0 and float(recent_lag_ms) >= critical_lag_threshold_ms():
+            _shed_active = True
+        return _shed_active
+
+
+def is_shedding() -> bool:
+    with _lock:
+        return _shed_active and load_shed_enabled()
+
+
+def _reset_for_test() -> None:
+    global _stream_active, _shed_active
+    with _lock:
+        _stream_active = 0
+        _shed_active = False

--- a/backend/core/ouroboros/governance/control_plane_watchdog.py
+++ b/backend/core/ouroboros/governance/control_plane_watchdog.py
@@ -819,6 +819,31 @@ _default_watchdog: Optional[ControlPlaneWatchdog] = None
 _default_lock = threading.Lock()
 
 
+def recent_lag_ms(window_s: float = 10.0) -> float:
+    """Sum of observed event-loop lag (ms) over the recent window.
+
+    Used by the stream-rupture inter-chunk watchdog (CD-1) to credit
+    accumulated loop-lag back to the timeout budget so a starved loop
+    cannot false-rupture a healthy flowing stream.
+
+    The function windows ``LagRecord`` entries by ``ts_monotonic`` so
+    only lag observed within the last ``window_s`` seconds contributes.
+    Best-effort: returns 0.0 on any error so callers are never broken.
+    """
+    try:
+        recs = get_default_watchdog().recent_lag_records()
+        if not recs:
+            return 0.0
+        cutoff = time.monotonic() - window_s
+        total = 0.0
+        for r in recs:
+            if r.ts_monotonic >= cutoff:
+                total += float(r.lag_ms or 0.0)
+        return total
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
 def get_default_watchdog() -> ControlPlaneWatchdog:
     """Process-singleton accessor. NEVER raises."""
     global _default_watchdog
@@ -846,6 +871,8 @@ __all__ = [
     "watchdog_enabled",
     "get_default_watchdog",
     "reset_default_watchdog",
+    # CD-1 — lag-aware inter-chunk stream timeout
+    "recent_lag_ms",
     # Slice 12K — starvation attribution surface
     "StarvationSnapshot",
     "ThreadFrameSnapshot",

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -3247,6 +3247,19 @@ class DoublewordProvider:
                     _content_seen = False
                     _first_progress_at = 0.0
                     _cognitive_stall_s = _cognitive_stall_timeout_s()
+                    # CD-2 — mark this SSE stream active so the load-shed latch
+                    # can engage SensorGovernor emergency-brake when event-loop
+                    # lag is critical. Wrapped defensively: a missing module or
+                    # broken import NEVER interrupts streaming. stream_end() is
+                    # called after the loop regardless of exit path.
+                    _cd2_ls = None
+                    try:
+                        from backend.core.ouroboros.governance import (
+                            control_plane_load_shed as _cd2_ls,
+                        )
+                        _cd2_ls.stream_begin()
+                    except Exception:  # noqa: BLE001
+                        _cd2_ls = None
                     # Parse SSE stream with per-chunk timeout to detect stalled streams
                     while True:
                         try:
@@ -3546,6 +3559,15 @@ class DoublewordProvider:
                                         _activity_pulse(_stream_op_id)
                                     except Exception:  # noqa: BLE001
                                         pass
+                                    # CD-2 — evaluate lag every 8 chunks (same
+                                    # cadence as the heartbeat) and update the
+                                    # shed latch. Defensive: NEVER raises into
+                                    # the SSE loop.
+                                    try:
+                                        if _cd2_ls is not None:
+                                            _cd2_ls.evaluate(_recent_lag_ms())
+                                    except Exception:  # noqa: BLE001
+                                        pass
                                 # Phase 12.2 Slice C — record TTFT once
                                 # per request on first non-empty content
                                 # chunk. NEVER raises into the SSE loop:
@@ -3612,6 +3634,13 @@ class DoublewordProvider:
                                 output_tokens = _usage.get("completion_tokens", 0)
                         except json.JSONDecodeError:
                             continue
+                    # CD-2 — clear stream-active latch now that the SSE loop
+                    # has exited (normal completion, rupture, or stall).
+                    try:
+                        if _cd2_ls is not None:
+                            _cd2_ls.stream_end()
+                    except Exception:  # noqa: BLE001
+                        pass
             else:
                 # Non-streaming path
                 # Slice 31 — Aegis session bearer (closes v24

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -47,8 +47,12 @@ from backend.core.ouroboros.governance.stream_rupture import (
     CognitiveStallError,
     StreamRuptureError,
     cognitive_stall_timeout_s as _cognitive_stall_timeout_s,
+    lag_compensated_inter_chunk_timeout_s as _lag_compensated_inter_chunk_timeout_s,
     stream_inter_chunk_timeout_s as _stream_inter_chunk_timeout_s,
     stream_rupture_timeout_s as _stream_rupture_timeout_s,
+)
+from backend.core.ouroboros.governance.control_plane_watchdog import (
+    recent_lag_ms as _recent_lag_ms,
 )
 
 logger = logging.getLogger(__name__)
@@ -3219,7 +3223,13 @@ class DoublewordProvider:
                     # Phase 1 (TTFT): generous timeout for first token.
                     # Phase 2 (Inter-Chunk): tight timeout once streaming.
                     _rupture_ttft = _stream_rupture_timeout_s()
-                    _rupture_ic = _stream_inter_chunk_timeout_s()
+                    # CD-1 — lag-aware inter-chunk timeout: credit back
+                    # any accumulated event-loop lag so a starved loop
+                    # cannot false-rupture a flowing network stream.
+                    _rupture_ic = _lag_compensated_inter_chunk_timeout_s(
+                        base_s=_stream_inter_chunk_timeout_s(),
+                        lag_credit_s=_recent_lag_ms() / 1000.0,
+                    )
                     _chunk_phase_timeout = _rupture_ttft  # Phase 1
                     _sse_has_tokens = False
                     # Phase-Aware Heartbeat — pulse the harness

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -96,8 +96,12 @@ from backend.core.ouroboros.governance.op_context import (
 )
 from backend.core.ouroboros.governance.stream_rupture import (
     StreamRuptureError,
+    lag_compensated_inter_chunk_timeout_s as _lag_compensated_inter_chunk_timeout_s,
     stream_inter_chunk_timeout_s as _stream_inter_chunk_timeout_s,
     stream_rupture_timeout_s as _stream_rupture_timeout_s,
+)
+from backend.core.ouroboros.governance.control_plane_watchdog import (
+    recent_lag_ms as _recent_lag_ms,
 )
 
 try:
@@ -8055,7 +8059,13 @@ class ClaudeProvider:
             _rupture_ttft = _stream_rupture_timeout_s(
                 thinking_enabled=_thinking_active,
             )
-            _rupture_ic = _stream_inter_chunk_timeout_s()
+            # CD-1 — lag-aware inter-chunk timeout: credit back any
+            # accumulated event-loop lag so a starved loop cannot
+            # false-rupture a flowing Claude stream.
+            _rupture_ic = _lag_compensated_inter_chunk_timeout_s(
+                base_s=_stream_inter_chunk_timeout_s(),
+                lag_credit_s=_recent_lag_ms() / 1000.0,
+            )
             # Derive the truncated op_id for activity-pulse identity.
             _stream_op_id = str(
                 getattr(ctx.context, "op_id", "?")

--- a/backend/core/ouroboros/governance/sensor_governor.py
+++ b/backend/core/ouroboros/governance/sensor_governor.py
@@ -539,8 +539,24 @@ class SensorGovernor:
 
     def _emergency_brake_active(self) -> bool:
         """Reads the current signal bundle via the injected callable.
-        Returns True if cost_burn > threshold or postmortem_rate > threshold.
+        Returns True if cost_burn > threshold or postmortem_rate > threshold,
+        OR if the CD-2 control-plane load-shed latch is active (stream is
+        consuming the event loop under critical lag). CD-2 is gated by
+        JARVIS_CONTROL_PLANE_LOAD_SHED_ENABLED (default OFF) so this OR is
+        a no-op when the feature is disabled.
         Missing signals → False (brake disabled)."""
+        # CD-2 — load-shed latch: if a DW SSE stream is active AND event-loop
+        # lag exceeds JARVIS_LOAD_SHED_LAG_THRESHOLD_MS, shed low-priority
+        # background sensors to free the loop. Wrapped defensively so a
+        # missing/broken module never silences the existing brake logic.
+        try:
+            from backend.core.ouroboros.governance.control_plane_load_shed import (
+                is_shedding as _cd2_is_shedding,
+            )
+            if _cd2_is_shedding():
+                return True
+        except Exception:  # noqa: BLE001
+            pass
         try:
             bundle = self._signal_bundle_fn()
         except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/stream_rupture.py
+++ b/backend/core/ouroboros/governance/stream_rupture.py
@@ -23,6 +23,7 @@ provider imports permitted.
 from __future__ import annotations
 
 import os
+from typing import Optional
 
 
 # ---------------------------------------------------------------------------
@@ -303,3 +304,54 @@ class StreamBudgetTooShortError(RuntimeError):
             f"sem_wait={sem_wait_s:.1f}s:"
             f"route={route}"
         )
+
+
+# ---------------------------------------------------------------------------
+# CD-1 — Lag-aware inter-chunk timeout compensation
+# ---------------------------------------------------------------------------
+
+
+def stream_lag_compensation_enabled() -> bool:
+    """Master gate for CD-1 lag-credit compensation. Default OFF.
+
+    When OFF the ``lag_compensated_inter_chunk_timeout_s`` helper is
+    a transparent passthrough (returns ``base_s`` unchanged) so the
+    behaviour is byte-identical to the pre-CD-1 code path.
+    """
+    return os.environ.get(
+        "JARVIS_STREAM_LAG_COMPENSATION_ENABLED", ""
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _lag_credit_cap_s() -> float:
+    """Maximum seconds of lag that may be credited back (env-tunable).
+
+    Default 60s — chosen to be 2× the default inter-chunk timeout so
+    a single starved loop cycle never inflates the budget beyond 90s,
+    which remains well inside typical provider health thresholds.
+    """
+    return float(os.environ.get("JARVIS_STREAM_LAG_CREDIT_CAP_S", "60"))
+
+
+def lag_compensated_inter_chunk_timeout_s(
+    *,
+    base_s: float,
+    lag_credit_s: float,
+    max_credit_s: "Optional[float]" = None,
+) -> float:
+    """Inter-chunk timeout extended by credited loop-lag (capped).
+
+    When the event loop has been starved during the inter-chunk window
+    the delay is NOT real network silence — the provider was streaming
+    but the loop could not consume chunks in time. Crediting that lag
+    back widens the watchdog window by exactly the loop-busy time so
+    a flowing stream is never false-ruptured.
+
+    Returns ``base_s`` unchanged when lag-compensation is OFF or the
+    credit is zero/negative. Never raises.
+    """
+    if not stream_lag_compensation_enabled():
+        return float(base_s)
+    cap = max_credit_s if max_credit_s is not None else _lag_credit_cap_s()
+    credit = max(0.0, min(float(lag_credit_s), float(cap)))
+    return float(base_s) + credit

--- a/tests/governance/test_control_plane_load_shed.py
+++ b/tests/governance/test_control_plane_load_shed.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+
+def test_disabled_never_sheds(monkeypatch):
+    monkeypatch.delenv("JARVIS_CONTROL_PLANE_LOAD_SHED_ENABLED", raising=False)
+    import backend.core.ouroboros.governance.control_plane_load_shed as ls
+    ls._reset_for_test()
+    ls.stream_begin()
+    assert ls.evaluate(9999.0) is False
+    assert ls.is_shedding() is False
+    ls.stream_end()
+
+
+def test_sheds_on_high_lag_during_stream_restores_after(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONTROL_PLANE_LOAD_SHED_ENABLED", "true")
+    import backend.core.ouroboros.governance.control_plane_load_shed as ls
+    ls._reset_for_test()
+    # no stream -> no shed even on high lag
+    assert ls.evaluate(9999.0) is False
+    ls.stream_begin()
+    assert ls.evaluate(50.0) is False        # below threshold (150)
+    assert ls.evaluate(500.0) is True         # above threshold -> shed
+    assert ls.is_shedding() is True
+    ls.stream_end()                            # stream done -> restore
+    assert ls.is_shedding() is False
+
+
+def test_reentrant_streams(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONTROL_PLANE_LOAD_SHED_ENABLED", "true")
+    import backend.core.ouroboros.governance.control_plane_load_shed as ls
+    ls._reset_for_test()
+    ls.stream_begin(); ls.stream_begin()
+    assert ls.evaluate(500.0) is True
+    ls.stream_end()
+    assert ls.is_shedding() is True            # one stream still active
+    ls.stream_end()
+    assert ls.is_shedding() is False

--- a/tests/governance/test_stream_rupture.py
+++ b/tests/governance/test_stream_rupture.py
@@ -1,0 +1,117 @@
+"""Tests for CD-1 — lag-aware inter-chunk stream timeout.
+
+Covers:
+  * ``lag_compensated_inter_chunk_timeout_s`` helpers in stream_rupture.py
+  * ``recent_lag_ms`` fail-soft helper in control_plane_watchdog.py
+"""
+from __future__ import annotations
+
+
+def test_lag_compensation_off_returns_base(monkeypatch):
+    monkeypatch.delenv("JARVIS_STREAM_LAG_COMPENSATION_ENABLED", raising=False)
+    # Reload to pick up env change via the function (env is read at call time).
+    from backend.core.ouroboros.governance.stream_rupture import (
+        lag_compensated_inter_chunk_timeout_s,
+    )
+    assert lag_compensated_inter_chunk_timeout_s(base_s=30.0, lag_credit_s=25.0) == 30.0
+
+
+def test_lag_compensation_credits_lag_capped(monkeypatch):
+    monkeypatch.setenv("JARVIS_STREAM_LAG_COMPENSATION_ENABLED", "true")
+    from backend.core.ouroboros.governance.stream_rupture import (
+        lag_compensated_inter_chunk_timeout_s,
+    )
+    # Basic credit.
+    assert lag_compensated_inter_chunk_timeout_s(base_s=30.0, lag_credit_s=25.0) == 55.0
+    # Explicit cap honored.
+    assert (
+        lag_compensated_inter_chunk_timeout_s(
+            base_s=30.0, lag_credit_s=999.0, max_credit_s=60.0
+        )
+        == 90.0
+    )
+    # Negative credit ignored (clamped to 0).
+    assert lag_compensated_inter_chunk_timeout_s(base_s=30.0, lag_credit_s=-5.0) == 30.0
+
+
+def test_lag_compensation_env_variants(monkeypatch):
+    """Various truthy env values must enable compensation."""
+    from backend.core.ouroboros.governance.stream_rupture import (
+        stream_lag_compensation_enabled,
+    )
+    for val in ("1", "true", "yes", "on", "True", "YES"):
+        monkeypatch.setenv("JARVIS_STREAM_LAG_COMPENSATION_ENABLED", val)
+        assert stream_lag_compensation_enabled(), f"expected ON for {val!r}"
+    for val in ("0", "false", "no", "off", ""):
+        monkeypatch.setenv("JARVIS_STREAM_LAG_COMPENSATION_ENABLED", val)
+        assert not stream_lag_compensation_enabled(), f"expected OFF for {val!r}"
+
+
+def test_lag_compensation_zero_credit(monkeypatch):
+    """Zero lag credit returns base_s exactly."""
+    monkeypatch.setenv("JARVIS_STREAM_LAG_COMPENSATION_ENABLED", "true")
+    from backend.core.ouroboros.governance.stream_rupture import (
+        lag_compensated_inter_chunk_timeout_s,
+    )
+    assert lag_compensated_inter_chunk_timeout_s(base_s=30.0, lag_credit_s=0.0) == 30.0
+
+
+def test_recent_lag_ms_failsoft():
+    """recent_lag_ms must return a non-negative float and never raise."""
+    from backend.core.ouroboros.governance.control_plane_watchdog import recent_lag_ms
+    v = recent_lag_ms()
+    assert isinstance(v, float) and v >= 0.0
+
+
+def test_recent_lag_ms_no_records():
+    """When the ring is empty, recent_lag_ms returns 0.0."""
+    from backend.core.ouroboros.governance.control_plane_watchdog import (
+        ControlPlaneWatchdog,
+        recent_lag_ms,
+    )
+    import unittest.mock as mock
+    empty_watchdog = ControlPlaneWatchdog()
+    with mock.patch(
+        "backend.core.ouroboros.governance.control_plane_watchdog.get_default_watchdog",
+        return_value=empty_watchdog,
+    ):
+        assert recent_lag_ms() == 0.0
+
+
+def test_recent_lag_ms_windows_by_timestamp():
+    """Only LagRecords within the window contribute to the sum."""
+    import time
+    import unittest.mock as mock
+    from backend.core.ouroboros.governance.control_plane_watchdog import (
+        ControlPlaneWatchdog,
+        LagRecord,
+        recent_lag_ms,
+    )
+
+    now = time.monotonic()
+    old_record = LagRecord(
+        lag_ms=500.0,
+        requested_ms=100.0,
+        observed_ms=600.0,
+        ts_monotonic=now - 60.0,  # 60s old — outside default 10s window
+        thread_name="test",
+    )
+    recent_record = LagRecord(
+        lag_ms=200.0,
+        requested_ms=100.0,
+        observed_ms=300.0,
+        ts_monotonic=now - 2.0,  # 2s old — inside window
+        thread_name="test",
+    )
+
+    watchdog = ControlPlaneWatchdog()
+    watchdog._ring.append(old_record)
+    watchdog._ring.append(recent_record)
+
+    with mock.patch(
+        "backend.core.ouroboros.governance.control_plane_watchdog.get_default_watchdog",
+        return_value=watchdog,
+    ):
+        result = recent_lag_ms(window_s=10.0)
+    # Only the recent 200ms record should be counted.
+    assert result == 200.0, f"Expected 200.0, got {result}"


### PR DESCRIPTION
## Summary
Two gated, reuse-first control-plane hardening fixes that emerged from forensic diagnosis of a DW `StreamRuptureError` under event-loop starvation on the 16GB M1.

- **CD-1 — lag-aware inter-chunk timeout** (`stream_rupture.py` + `control_plane_watchdog.recent_lag_ms`): credits accumulated event-loop lag back to the inter-chunk stream-rupture budget, so a *starved loop* doesn't false-rupture a *flowing* DW/Claude stream. Wired into both the DW SSE reader and the Claude stream reader. Gated `JARVIS_STREAM_LAG_COMPENSATION_ENABLED` (default OFF → returns base timeout, byte-identical).
- **CD-2 — lag-triggered load-shed** (`control_plane_load_shed.py` → existing `SensorGovernor`): during an active GENERATE stream, critical loop-lag latches the **existing** `SensorGovernor` emergency brake to shed low-priority background sensors, restored on stream completion. Reuses the watchdog + SensorGovernor — **no new governor**. Gated `JARVIS_CONTROL_PLANE_LOAD_SHED_ENABLED` (default OFF).

## Honest scope note (from the validation soaks)
These target the **SSE streaming** path. The soak showed STANDARD-route DW ops use the **batch API** (a different timeout path) — so CD-1/CD-2 are correct + valuable for the SSE path but do **not** fix the batch-poll timeout (addressed separately by the batch-suspension controller). They also can't overcome fundamental 16GB-host starvation — that's a hardware verdict, not a code gap. Shipping them gated because they're correct and pay off on capable hardware / the SSE path.

## Reuse-first (audited)
- Reuses `control_plane_watchdog` (lag detection, `LagRecord.ts_monotonic` windowed) + `SensorGovernor` (emergency brake). No parallel governor, no new timing subsystem.

## Safety
- Both default OFF → byte-identical. All hooks fail-soft (best-effort try/except; never break streaming). 10 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lag-aware inter‑chunk timeouts to prevent false stream ruptures and a gated load‑shedding path that pauses background sensors when event‑loop lag spikes during streaming. Both features are off by default and reuse the existing watchdog and `SensorGovernor`.

- **New Features**
  - CD‑1: Lag‑aware inter‑chunk timeout for SSE streams (DW and Claude). Credits recent loop lag (`control_plane_watchdog.recent_lag_ms`) into the timeout via `lag_compensated_inter_chunk_timeout_s`, capped by `JARVIS_STREAM_LAG_CREDIT_CAP_S`. Gate: `JARVIS_STREAM_LAG_COMPENSATION_ENABLED`.
  - CD‑2: Lag‑triggered load‑shed during active GENERATE streams. Latches via `control_plane_load_shed` and engages the `SensorGovernor` emergency brake when lag ≥ `JARVIS_LOAD_SHED_LAG_THRESHOLD_MS` (default 150ms). Gate: `JARVIS_CONTROL_PLANE_LOAD_SHED_ENABLED`. Restores after stream end.
  - Scope: SSE streaming path only; batch API timeouts are unchanged.

- **Migration**
  - Defaults OFF → no behavior change.
  - To enable: set `JARVIS_STREAM_LAG_COMPENSATION_ENABLED=true` and/or `JARVIS_CONTROL_PLANE_LOAD_SHED_ENABLED=true` (optional: tune `JARVIS_LOAD_SHED_LAG_THRESHOLD_MS`, `JARVIS_STREAM_LAG_CREDIT_CAP_S`).
  - No API changes; all hooks are fail‑soft.

<sup>Written for commit ceef109f4d394687fa2899b7092cb23d3a42442f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

