### PR TITLE
feat(fleet): Sovereign Fleet Evaluator — quality-aware DW model routing (gated OFF)

### DIFF
--- a/.github/workflows/fleet_evaluator_soak.yml
+++ b/.github/workflows/fleet_evaluator_soak.yml
@@ -39,10 +39,22 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Fleet unit tests (offline)
+      - name: Install governance import-chain deps (lean, no ML bloat)
+        # Importing any backend.core.ouroboros.governance.* leaf runs the
+        # package __init__ aggregator, which hard-imports this set. Enumerated
+        # from the live import graph (not requirements-soak.txt, which omits
+        # aiofiles/aiosqlite/networkx/redis/opentelemetry/xxhash). All pure-
+        # python or manylinux wheels → fast, no compilation, no DW secret.
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio
+          pip install \
+            aiohttp aiofiles aiosqlite attrs cryptography networkx \
+            opentelemetry-api opentelemetry-sdk psutil redis uuid6 \
+            PyYAML xxhash \
+            pytest pytest-asyncio
+
+      - name: Fleet unit tests (offline, 35)
+        run: |
           python -m pytest -q \
             tests/governance/test_fleet_quality_battery.py \
             tests/governance/test_fleet_calibration_store.py \
@@ -51,6 +63,7 @@ jobs:
 
       - name: Multi-cycle EWMA-stability soak
         id: soak
+        if: always()   # headline deliverable — run even if a unit test regressed
         run: |
           python3 scripts/fleet_soak_multicycle.py "$RUNNER_TEMP/fleet_soak_report.md"
 

--- a/.github/workflows/fleet_evaluator_soak.yml
+++ b/.github/workflows/fleet_evaluator_soak.yml
@@ -1,0 +1,87 @@
+name: Fleet Evaluator — multi-cycle EWMA soak
+
+# Clean-room validation for the Sovereign Fleet Evaluator. Runs on a dedicated
+# ubuntu-latest runner (bare-metal event-loop fidelity, no macOS virtualization)
+# so the EWMA latency telemetry is uncorrupted. The soak is DETERMINISTIC (mocked
+# caller with injected latency spike + 502) — no DoubleWord secret, no cost, no
+# flake — it proves the EWMA absorbs transients without the routing rank flapping.
+
+on:
+  push:
+    branches: [fleet/sovereign-evaluator]
+    paths:
+      - "backend/core/ouroboros/governance/fleet_*.py"
+      - "scripts/fleet_soak_multicycle.py"
+      - ".github/workflows/fleet_evaluator_soak.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: fleet-soak-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  soak:
+    runs-on: ubuntu-latest
+    env:
+      JARVIS_FLEET_EVALUATOR_ENABLED: "true"
+      JARVIS_FLEET_EWMA_ALPHA: "0.4"
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Fleet unit tests (offline)
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-asyncio
+          python -m pytest -q \
+            tests/governance/test_fleet_quality_battery.py \
+            tests/governance/test_fleet_calibration_store.py \
+            tests/governance/test_fleet_evaluator.py \
+            tests/governance/test_fleet_topology_binding.py
+
+      - name: Multi-cycle EWMA-stability soak
+        id: soak
+        run: |
+          python3 scripts/fleet_soak_multicycle.py "$RUNNER_TEMP/fleet_soak_report.md"
+
+      - name: Publish soak report to job summary
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/fleet_soak_report.md" ]; then
+            cat "$RUNNER_TEMP/fleet_soak_report.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "soak produced no report (early failure)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Comment soak result on PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR=$(gh pr list --head "${GITHUB_REF_NAME}" --state open \
+                 --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -z "$PR" ]; then
+            echo "no open PR for ${GITHUB_REF_NAME}; skipping comment"
+            exit 0
+          fi
+          {
+            echo "<!-- fleet-soak -->"
+            if [ -f "$RUNNER_TEMP/fleet_soak_report.md" ]; then
+              cat "$RUNNER_TEMP/fleet_soak_report.md"
+            else
+              echo "## Fleet Evaluator soak: early failure (no report produced)"
+            fi
+            echo ""
+            echo "_Clean-room run [\`${GITHUB_RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) on \`ubuntu-latest\` — deterministic, no DW secret, no cost._"
+          } > "$RUNNER_TEMP/fleet_soak_comment.md"
+          gh pr comment "$PR" --body-file "$RUNNER_TEMP/fleet_soak_comment.md"

--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -4968,6 +4968,163 @@ SEED_SPECS: list = [
         since="Sovereign Fusion (resilience ignition, 2026-06-14)",
         posture_relevance=_HARDEN_CRITICAL,
     ),
+
+    # ====================================================================
+    # Sovereign Fleet Evaluator (Tasks 1-4, 2026-06-19) — 12 flags
+    # Measures DW model output quality, gated re-rank of live routing.
+    # ====================================================================
+    FlagSpec(
+        name="JARVIS_FLEET_EVALUATOR_ENABLED",
+        type=FlagType.BOOL, default=False,
+        description=(
+            "Master switch for the Sovereign Fleet Evaluator — when true, "
+            "idle-cycle quality calibration probes DW models and folds "
+            "results into the calibration store. Descriptive until "
+            "JARVIS_FLEET_EVALUATOR_AUTHORITATIVE flips."
+        ),
+        category=Category.ROUTING,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="false",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_EVALUATOR_AUTHORITATIVE",
+        type=FlagType.BOOL, default=False,
+        description=(
+            "When true, measured quality scores re-rank the live DW "
+            "model-selection path (provider_topology.dw_models_for_route). "
+            "Auto-flipped by the FleetEvaluator once a soak proves the "
+            "calibrated coder beats the static default. OFF is byte-"
+            "identical legacy routing."
+        ),
+        category=Category.ROUTING,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="false",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_EWMA_ALPHA",
+        type=FlagType.FLOAT, default=0.4,
+        description=(
+            "EWMA smoothing factor applied when folding a new probe "
+            "result into a model's running quality score. Higher = "
+            "faster adaptation, lower = more stable."
+        ),
+        category=Category.TUNING,
+        source_file="backend/core/ouroboros/governance/fleet_calibration_store.py",
+        example="0.4",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_PROBE_MAX_TOKENS",
+        type=FlagType.INT, default=512,
+        description=(
+            "Per-probe generation token cap. Bounds the cost and latency "
+            "of each calibration probe."
+        ),
+        category=Category.CAPACITY,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="512",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_PROBE_TIMEOUT_S",
+        type=FlagType.FLOAT, default=60.0,
+        description=(
+            "Per-probe HTTP timeout in seconds for a single calibration "
+            "probe request."
+        ),
+        category=Category.TIMING,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="60",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_MAX_MODELS_PER_CYCLE",
+        type=FlagType.INT, default=4,
+        description=(
+            "Maximum number of DW models calibrated per idle evaluation "
+            "cycle. Caps per-cycle probe fan-out."
+        ),
+        category=Category.CAPACITY,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="4",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_DAILY_USD_CAP",
+        type=FlagType.FLOAT, default=0.50,
+        description=(
+            "Daily probe spend ceiling in USD. Once exceeded, the "
+            "evaluator pauses further probes until the rolling window "
+            "resets."
+        ),
+        category=Category.CAPACITY,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="0.50",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_GRAD_MIN_SAMPLES",
+        type=FlagType.INT, default=5,
+        description=(
+            "Minimum number of probes a model must accumulate before it "
+            "is eligible to graduate into the authoritative re-rank."
+        ),
+        category=Category.TUNING,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="5",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_GRAD_MIN_AST",
+        type=FlagType.FLOAT, default=0.8,
+        description=(
+            "Minimum AST/code pass-rate (0.0-1.0) a model must hold "
+            "before it can graduate."
+        ),
+        category=Category.TUNING,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="0.8",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_GRAD_MARGIN",
+        type=FlagType.FLOAT, default=1.5,
+        description=(
+            "Multiplier on valid_tok_per_s the candidate winner must "
+            "beat the static default by before graduation. 1.5 = the "
+            "winner must be 50% faster-at-valid-output."
+        ),
+        category=Category.TUNING,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="1.5",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_GRAD_STABLE_CYCLES",
+        type=FlagType.INT, default=2,
+        description=(
+            "Consecutive winning evaluation cycles required before the "
+            "evaluator auto-flips JARVIS_FLEET_EVALUATOR_AUTHORITATIVE."
+        ),
+        category=Category.TUNING,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="2",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_CALIBRATION_PATH",
+        type=FlagType.STR, default=".jarvis/fleet_calibration.json",
+        description=(
+            "Filesystem path for the persistent fleet calibration store "
+            "(per-model EWMA quality scores)."
+        ),
+        category=Category.ROUTING,
+        source_file="backend/core/ouroboros/governance/fleet_calibration_store.py",
+        example=".jarvis/fleet_calibration.json",
+        since="2026-06-19",
+    ),
 ]
 
 

--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -5056,12 +5056,25 @@ SEED_SPECS: list = [
         type=FlagType.FLOAT, default=0.50,
         description=(
             "Daily probe spend ceiling in USD. Once exceeded, the "
-            "evaluator pauses further probes until the rolling window "
-            "resets."
+            "evaluator pauses further probes until the rolling UTC-day "
+            "window resets. <=0 disables the cap."
         ),
         category=Category.CAPACITY,
         source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
         example="0.50",
+        since="2026-06-19",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_PROBE_USD_PER_MTOK",
+        type=FlagType.FLOAT, default=0.40,
+        description=(
+            "Estimated USD per 1M completion tokens used to account probe "
+            "cost against JARVIS_FLEET_DAILY_USD_CAP (conservative DW "
+            "output-tier default; for the spend ledger, not billing)."
+        ),
+        category=Category.CAPACITY,
+        source_file="backend/core/ouroboros/governance/fleet_evaluator.py",
+        example="0.40",
         since="2026-06-19",
     ),
     FlagSpec(

--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -5017,7 +5017,7 @@ SEED_SPECS: list = [
     ),
     FlagSpec(
         name="JARVIS_FLEET_PROBE_MAX_TOKENS",
-        type=FlagType.INT, default=512,
+        type=FlagType.INT, default=2048,
         description=(
             "Per-probe generation token cap. Bounds the cost and latency "
             "of each calibration probe."

--- a/backend/core/ouroboros/governance/fleet_calibration_store.py
+++ b/backend/core/ouroboros/governance/fleet_calibration_store.py
@@ -219,7 +219,7 @@ class FleetCalibrationStore:
         scores_raw = payload.get("scores", {})
         if not isinstance(scores_raw, Mapping):
             return
-        for mid, raw in scores_raw.items():
+        for raw in scores_raw.values():
             if not isinstance(raw, Mapping):
                 continue
             sc = QualityScore.from_json_dict(raw)
@@ -338,13 +338,18 @@ class FleetCalibrationStore:
 
 
 def fleet_rerank(
-    route: str,
+    _route: str,
     ranked_models: Tuple[str, ...],
     scores: Mapping[str, QualityScore],
     *,
     route_kind: str,
 ) -> Tuple[str, ...]:
     """PURE quality-weighted re-rank. NEVER raises.
+
+    ``_route`` is accepted positionally for caller symmetry (the route
+    string callers already hold) but behavior is driven entirely by the
+    explicit keyword-only ``route_kind`` so the pure function stays
+    trivially testable; the raw route is intentionally unused here.
 
     Reorders ONLY the scored models among themselves (descending fitness,
     stable), keeping every UNSCORED model at its original index. Returns

--- a/backend/core/ouroboros/governance/fleet_calibration_store.py
+++ b/backend/core/ouroboros/governance/fleet_calibration_store.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import tempfile
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Tuple
@@ -194,6 +195,9 @@ class FleetCalibrationStore:
     def __init__(self, path: Optional[Path] = None) -> None:
         self._path = path  # resolved lazily so env can be patched
         self._scores: Dict[str, QualityScore] = {}
+        # Daily probe-spend ledger (UTC-day-bucketed). Auto-resets when the
+        # UTC date rolls over so the cap is a rolling daily ceiling.
+        self._spend: Dict[str, Any] = {"date": "", "usd": 0.0}
         self._loaded = False
 
     # ------------------------------------------------------------------
@@ -228,6 +232,15 @@ class FleetCalibrationStore:
             sc = QualityScore.from_json_dict(raw)
             if sc is not None:
                 self._scores[sc.model_id] = sc
+        spend_raw = payload.get("spend", {})
+        if isinstance(spend_raw, Mapping):
+            try:
+                self._spend = {
+                    "date": str(spend_raw.get("date", "")),
+                    "usd": float(spend_raw.get("usd", 0.0) or 0.0),
+                }
+            except (ValueError, TypeError):
+                self._spend = {"date": "", "usd": 0.0}
 
     def save(self) -> None:
         """Write current state to disk atomically. NEVER raises; logs."""
@@ -236,6 +249,7 @@ class FleetCalibrationStore:
                 mid: self._clamp_unseeded(sc).to_json_dict()
                 for mid, sc in self._scores.items()
             },
+            "spend": dict(self._spend),
         }
         try:
             _atomic_write(
@@ -327,6 +341,45 @@ class FleetCalibrationStore:
                 "[FleetCalibrationStore] record_probe failed for %s",
                 model_id, exc_info=True,
             )
+
+    # ------------------------------------------------------------------
+    # Daily probe-spend ledger (cost cap enforcement)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _utc_date(now: float) -> str:
+        """UTC calendar-day key (``YYYY-MM-DD``) for a unix timestamp."""
+        return datetime.fromtimestamp(float(now), tz=timezone.utc).strftime(
+            "%Y-%m-%d"
+        )
+
+    def spend_today(self, now: float) -> float:
+        """USD spent on probes in the current UTC day. NEVER raises.
+
+        Returns 0.0 when the stored ledger is from an earlier day (the cap
+        is a rolling daily ceiling — yesterday's spend does not count today).
+        """
+        try:
+            self._ensure_loaded()
+            if str(self._spend.get("date", "")) != self._utc_date(now):
+                return 0.0
+            return float(self._spend.get("usd", 0.0) or 0.0)
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+    def add_spend(self, usd: float, *, now: float) -> None:
+        """Add probe spend to today's ledger (resets on UTC date roll). NEVER raises."""
+        try:
+            self._ensure_loaded()
+            today = self._utc_date(now)
+            prior = (
+                float(self._spend.get("usd", 0.0) or 0.0)
+                if str(self._spend.get("date", "")) == today
+                else 0.0
+            )
+            self._spend = {"date": today, "usd": prior + max(0.0, float(usd))}
+        except Exception:  # noqa: BLE001
+            logger.debug("[FleetCalibrationStore] add_spend failed", exc_info=True)
 
     # ------------------------------------------------------------------
     # Queries (read-only)

--- a/backend/core/ouroboros/governance/fleet_calibration_store.py
+++ b/backend/core/ouroboros/governance/fleet_calibration_store.py
@@ -1,0 +1,448 @@
+"""Sovereign Fleet Evaluator — calibration persistence + pure math core.
+
+Task 2 of the FleetEvaluator subsystem (spec §4.2). Measures DoubleWord
+(DW) model OUTPUT QUALITY (AST-valid code rate, classification adherence)
+and exposes the PURE re-rank + graduation-decision functions that drive
+quality-weighted model routing.
+
+This is the persistence + math core only:
+
+  * ``QualityScore`` — frozen per-model quality snapshot (EWMA-smoothed)
+  * ``ewma_update`` — exponentially-weighted moving average primitive
+  * ``valid_tok_per_s`` / ``triage_fitness`` — composite fitness scalars
+  * ``FleetCalibrationStore`` — atomic-write JSON store of per-model scores
+  * ``fleet_rerank`` — PURE quality-weighted re-rank (preserves unscored slots)
+  * ``graduation_ready`` — PURE graduation-decision gate
+  * ``fleet_apply_rerank`` — fail-soft store-backed re-rank convenience
+
+Persistence mirrors ``dw_promotion_ledger.py`` style: atomic temp+rename,
+lazy load, never raises out of telemetry/query paths. Leaf module —
+stdlib only, no sibling/organism imports (split-brain guard).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Quality score record
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QualityScore:
+    """Frozen per-model quality snapshot (EWMA-smoothed fields).
+
+    Fields are persisted as a flat JSON object via ``to_json_dict`` /
+    ``from_json_dict``.
+    """
+
+    model_id: str
+    ast_pass_rate: float
+    label_adherence: float
+    ttft_ms: float
+    tok_per_s: float
+    sample_count: int
+    updated_at: float
+
+    def to_json_dict(self) -> Dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "ast_pass_rate": self.ast_pass_rate,
+            "label_adherence": self.label_adherence,
+            "ttft_ms": self.ttft_ms,
+            "tok_per_s": self.tok_per_s,
+            "sample_count": self.sample_count,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_json_dict(cls, raw: Mapping[str, Any]) -> Optional["QualityScore"]:
+        """Parse a persisted record. Returns None on malformed input."""
+        try:
+            mid = str(raw.get("model_id", "")).strip()
+            if not mid:
+                return None
+            return cls(
+                model_id=mid,
+                ast_pass_rate=float(raw.get("ast_pass_rate", 0.0) or 0.0),
+                label_adherence=float(raw.get("label_adherence", 0.0) or 0.0),
+                ttft_ms=float(raw.get("ttft_ms", 0.0) or 0.0),
+                tok_per_s=float(raw.get("tok_per_s", 0.0) or 0.0),
+                sample_count=max(0, int(raw.get("sample_count", 0) or 0)),
+                updated_at=float(raw.get("updated_at", 0.0) or 0.0),
+            )
+        except (ValueError, TypeError):
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Pure math primitives
+# ---------------------------------------------------------------------------
+
+
+def ewma_update(prev: Optional[float], new: float, alpha: float) -> float:
+    """Exponentially-weighted moving average.
+
+    First sample (``prev is None``) returns the new value directly so the
+    series starts unbiased. Otherwise ``alpha*new + (1-alpha)*prev``.
+    """
+    return float(new) if prev is None else alpha * new + (1.0 - alpha) * prev
+
+
+def valid_tok_per_s(sc: QualityScore) -> float:
+    """Throughput of VALID code: tokens/s weighted by AST-pass rate.
+
+    A blazing-fast model that emits unparseable code scores ~0 here.
+    """
+    return sc.tok_per_s * sc.ast_pass_rate
+
+
+def triage_fitness(sc: QualityScore) -> float:
+    """Triage fitness: classification adherence per millisecond of latency.
+
+    Rewards correct labels delivered fast. ttft clamped to >=1ms to avoid
+    division blowups.
+    """
+    return sc.label_adherence / max(sc.ttft_ms, 1.0) * 1000.0
+
+
+# ---------------------------------------------------------------------------
+# Env getters (read at call time so tests + operators can flip)
+# ---------------------------------------------------------------------------
+
+
+def _alpha() -> float:
+    """``JARVIS_FLEET_EWMA_ALPHA`` (default 0.4). Bad values -> 0.4."""
+    try:
+        return float(os.environ.get("JARVIS_FLEET_EWMA_ALPHA", "0.4").strip())
+    except (ValueError, TypeError):
+        return 0.4
+
+
+def _path() -> Path:
+    """``JARVIS_FLEET_CALIBRATION_PATH`` (default
+    ``.jarvis/fleet_calibration.json``)."""
+    raw = os.environ.get(
+        "JARVIS_FLEET_CALIBRATION_PATH",
+        ".jarvis/fleet_calibration.json",
+    ).strip()
+    return Path(raw)
+
+
+def _min_ast() -> float:
+    """``JARVIS_FLEET_GRAD_MIN_AST`` (default 0.8). Bad values -> 0.8."""
+    try:
+        return float(os.environ.get("JARVIS_FLEET_GRAD_MIN_AST", "0.8").strip())
+    except (ValueError, TypeError):
+        return 0.8
+
+
+def route_kind_for_route(route: str) -> str:
+    """Map a route string to a fitness kind: ``triage`` or ``code``."""
+    norm = (route or "").strip().lower()
+    if norm in {"triage", "semantic_triage", "classify"}:
+        return "triage"
+    return "code"
+
+
+# ---------------------------------------------------------------------------
+# Atomic disk I/O (mirrored from dw_promotion_ledger.py)
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=path.name + ".", suffix=".tmp", dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Calibration store
+# ---------------------------------------------------------------------------
+
+
+class FleetCalibrationStore:
+    """Per-model quality-score store with atomic JSON persistence.
+
+    Lazy load on first access; ``save()`` writes atomically. Telemetry +
+    query paths NEVER raise.
+    """
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._path = path  # resolved lazily so env can be patched
+        self._scores: Dict[str, QualityScore] = {}
+        self._loaded = False
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def _resolved_path(self) -> Path:
+        return self._path if self._path is not None else _path()
+
+    def load(self) -> None:
+        """Load from disk. Missing/corrupt -> empty store. NEVER raises."""
+        self._loaded = True
+        p = self._resolved_path()
+        if not p.exists():
+            return
+        try:
+            payload = json.loads(p.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning(
+                "[FleetCalibrationStore] corrupt or unreadable store at %s — "
+                "starting empty (%s)", p, exc,
+            )
+            return
+        if not isinstance(payload, Mapping):
+            return
+        scores_raw = payload.get("scores", {})
+        if not isinstance(scores_raw, Mapping):
+            return
+        for mid, raw in scores_raw.items():
+            if not isinstance(raw, Mapping):
+                continue
+            sc = QualityScore.from_json_dict(raw)
+            if sc is not None:
+                self._scores[sc.model_id] = sc
+
+    def save(self) -> None:
+        """Write current state to disk atomically. NEVER raises; logs."""
+        payload = {
+            "scores": {
+                mid: sc.to_json_dict() for mid, sc in self._scores.items()
+            },
+        }
+        try:
+            _atomic_write(
+                self._resolved_path(),
+                json.dumps(payload, sort_keys=True, indent=2),
+            )
+        except OSError as exc:
+            logger.warning(
+                "[FleetCalibrationStore] save failed: %s — "
+                "store remains in memory", exc,
+            )
+
+    def _ensure_loaded(self) -> None:
+        if not self._loaded:
+            self.load()
+
+    # ------------------------------------------------------------------
+    # Telemetry input
+    # ------------------------------------------------------------------
+
+    def record_probe(
+        self,
+        model_id: str,
+        *,
+        kind: str,
+        code_pass: Optional[bool] = None,
+        label_score: Optional[float] = None,
+        ttft_ms: float,
+        tok_per_s: float,
+        now: float,
+    ) -> None:
+        """Fold one probe result into the model's EWMA-smoothed score.
+
+        ``kind="code"`` updates ``ast_pass_rate`` from ``code_pass``;
+        ``kind="triage"`` updates ``label_adherence`` from ``label_score``.
+        ttft + tok_per_s always folded. NEVER raises.
+        """
+        try:
+            mid = str(model_id or "").strip()
+            if not mid:
+                return
+            self._ensure_loaded()
+            alpha = _alpha()
+            prev = self._scores.get(mid)
+
+            prev_ast = prev.ast_pass_rate if prev else 0.0
+            prev_label = prev.label_adherence if prev else 0.0
+            prev_ttft = prev.ttft_ms if prev else None
+            prev_tps = prev.tok_per_s if prev else None
+
+            if kind == "code":
+                new_ast = ewma_update(
+                    prev.ast_pass_rate if prev else None,
+                    1.0 if code_pass else 0.0,
+                    alpha,
+                )
+                new_label = prev_label
+            elif kind == "triage":
+                new_label = ewma_update(
+                    prev.label_adherence if prev else None,
+                    float(label_score or 0.0),
+                    alpha,
+                )
+                new_ast = prev_ast
+            else:
+                # Unknown kind — only fold latency/throughput.
+                new_ast = prev_ast
+                new_label = prev_label
+
+            new_ttft = ewma_update(prev_ttft, float(ttft_ms), alpha)
+            new_tps = ewma_update(prev_tps, float(tok_per_s), alpha)
+
+            self._scores[mid] = QualityScore(
+                model_id=mid,
+                ast_pass_rate=new_ast,
+                label_adherence=new_label,
+                ttft_ms=new_ttft,
+                tok_per_s=new_tps,
+                sample_count=(prev.sample_count if prev else 0) + 1,
+                updated_at=float(now),
+            )
+        except Exception:  # noqa: BLE001 — defensive: never take down caller
+            logger.debug(
+                "[FleetCalibrationStore] record_probe failed for %s",
+                model_id, exc_info=True,
+            )
+
+    # ------------------------------------------------------------------
+    # Queries (read-only)
+    # ------------------------------------------------------------------
+
+    def score(self, model_id: str) -> Optional[QualityScore]:
+        self._ensure_loaded()
+        return self._scores.get(model_id)
+
+    def all_scores(self) -> Dict[str, QualityScore]:
+        self._ensure_loaded()
+        return dict(self._scores)
+
+
+# ---------------------------------------------------------------------------
+# Pure re-rank + graduation decision
+# ---------------------------------------------------------------------------
+
+
+def fleet_rerank(
+    route: str,
+    ranked_models: Tuple[str, ...],
+    scores: Mapping[str, QualityScore],
+    *,
+    route_kind: str,
+) -> Tuple[str, ...]:
+    """PURE quality-weighted re-rank. NEVER raises.
+
+    Reorders ONLY the scored models among themselves (descending fitness,
+    stable), keeping every UNSCORED model at its original index. Returns
+    input unchanged when fewer than 2 scored models are present, or on
+    unknown ``route_kind``.
+    """
+    try:
+        if route_kind == "code":
+            key = valid_tok_per_s
+        elif route_kind == "triage":
+            key = triage_fitness
+        else:
+            return tuple(ranked_models)
+
+        ranked = tuple(ranked_models)
+        scored = [
+            m for m in ranked
+            if m in scores and scores[m].sample_count >= 1
+        ]
+        if len(scored) < 2:
+            return ranked
+
+        ranked_scored = sorted(
+            scored, key=lambda m: key(scores[m]), reverse=True,
+        )
+        scored_set = set(scored)
+        out = []
+        idx = 0
+        for m in ranked:
+            if m in scored_set:
+                out.append(ranked_scored[idx])
+                idx += 1
+            else:
+                out.append(m)
+        return tuple(out)
+    except Exception:  # noqa: BLE001 — pure + defensive
+        return tuple(ranked_models)
+
+
+def graduation_ready(
+    scores: Mapping[str, QualityScore],
+    *,
+    default_model: str,
+    min_samples: int,
+    min_margin: float,
+) -> Optional[str]:
+    """PURE graduation-decision gate. Returns the winning model or None.
+
+    A candidate qualifies when it is not the default, has enough samples,
+    and meets the AST-pass floor. Among qualifiers the best ``valid_tok_per_s``
+    wins, but only graduates if the default is broken (missing or
+    ast_pass_rate < 0.2) OR the winner beats the default by ``min_margin``×.
+    """
+    try:
+        candidates = [
+            m for m, sc in scores.items()
+            if m != default_model
+            and sc.sample_count >= min_samples
+            and sc.ast_pass_rate >= _min_ast()
+        ]
+        if not candidates:
+            return None
+        winner = max(candidates, key=lambda m: valid_tok_per_s(scores[m]))
+        d = scores.get(default_model)
+        if d is None or d.ast_pass_rate < 0.2:
+            return winner
+        if valid_tok_per_s(scores[winner]) >= min_margin * valid_tok_per_s(d):
+            return winner
+        return None
+    except Exception:  # noqa: BLE001 — pure + defensive
+        return None
+
+
+def fleet_apply_rerank(
+    route: str,
+    ranked_models: Tuple[str, ...],
+) -> Tuple[str, ...]:
+    """Fail-soft store-backed re-rank. Returns input unchanged on error."""
+    try:
+        st = FleetCalibrationStore()
+        return fleet_rerank(
+            route,
+            tuple(ranked_models),
+            st.all_scores(),
+            route_kind=route_kind_for_route(route),
+        )
+    except Exception:  # noqa: BLE001 — fail-soft
+        return tuple(ranked_models)
+
+
+__all__ = [
+    "QualityScore",
+    "ewma_update",
+    "valid_tok_per_s",
+    "triage_fitness",
+    "route_kind_for_route",
+    "FleetCalibrationStore",
+    "fleet_rerank",
+    "graduation_ready",
+    "fleet_apply_rerank",
+]

--- a/backend/core/ouroboros/governance/fleet_calibration_store.py
+++ b/backend/core/ouroboros/governance/fleet_calibration_store.py
@@ -92,10 +92,13 @@ class QualityScore:
 def ewma_update(prev: Optional[float], new: float, alpha: float) -> float:
     """Exponentially-weighted moving average.
 
-    First sample (``prev is None``) returns the new value directly so the
-    series starts unbiased. Otherwise ``alpha*new + (1-alpha)*prev``.
+    First sample (``prev is None`` or an unseeded ``NaN`` carry) returns the
+    new value directly so the series starts unbiased. Otherwise
+    ``alpha*new + (1-alpha)*prev``.
     """
-    return float(new) if prev is None else alpha * new + (1.0 - alpha) * prev
+    if prev is None or prev != prev:  # None or NaN -> seed directly
+        return float(new)
+    return alpha * new + (1.0 - alpha) * prev
 
 
 def valid_tok_per_s(sc: QualityScore) -> float:
@@ -230,7 +233,8 @@ class FleetCalibrationStore:
         """Write current state to disk atomically. NEVER raises; logs."""
         payload = {
             "scores": {
-                mid: sc.to_json_dict() for mid, sc in self._scores.items()
+                mid: self._clamp_unseeded(sc).to_json_dict()
+                for mid, sc in self._scores.items()
             },
         }
         try:
@@ -277,8 +281,13 @@ class FleetCalibrationStore:
             alpha = _alpha()
             prev = self._scores.get(mid)
 
-            prev_ast = prev.ast_pass_rate if prev else 0.0
-            prev_label = prev.label_adherence if prev else 0.0
+            # An untouched field on a brand-new model is left UNSEEDED (NaN)
+            # so the first probe of the *other* kind seeds it directly instead
+            # of EWMA-blending against a poisoning 0.0. NaN is clamped to 0.0
+            # on every read/persist surface, so it never escapes the store.
+            _unseeded = float("nan")
+            prev_ast = prev.ast_pass_rate if prev else _unseeded
+            prev_label = prev.label_adherence if prev else _unseeded
             prev_ttft = prev.ttft_ms if prev else None
             prev_tps = prev.tok_per_s if prev else None
 
@@ -323,13 +332,32 @@ class FleetCalibrationStore:
     # Queries (read-only)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _clamp_unseeded(sc: QualityScore) -> QualityScore:
+        """Replace any UNSEEDED (NaN) field with 0.0 so NaN never escapes the
+        store to consumers (graduation gate, re-rank, persistence)."""
+        ast = sc.ast_pass_rate
+        lab = sc.label_adherence
+        if ast == ast and lab == lab:  # both already real (no NaN)
+            return sc
+        return QualityScore(
+            model_id=sc.model_id,
+            ast_pass_rate=ast if ast == ast else 0.0,
+            label_adherence=lab if lab == lab else 0.0,
+            ttft_ms=sc.ttft_ms,
+            tok_per_s=sc.tok_per_s,
+            sample_count=sc.sample_count,
+            updated_at=sc.updated_at,
+        )
+
     def score(self, model_id: str) -> Optional[QualityScore]:
         self._ensure_loaded()
-        return self._scores.get(model_id)
+        sc = self._scores.get(model_id)
+        return self._clamp_unseeded(sc) if sc is not None else None
 
     def all_scores(self) -> Dict[str, QualityScore]:
         self._ensure_loaded()
-        return dict(self._scores)
+        return {mid: self._clamp_unseeded(sc) for mid, sc in self._scores.items()}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/fleet_evaluator.py
+++ b/backend/core/ouroboros/governance/fleet_evaluator.py
@@ -19,7 +19,6 @@ LATE-imported inside try/except so this module imports cleanly with no network o
 real-file side effects.
 """
 
-import asyncio  # noqa: F401  (used by the optional live caller path)
 import logging
 import os
 import time
@@ -36,6 +35,7 @@ from backend.core.ouroboros.governance.fleet_quality_battery import (
 from backend.core.ouroboros.governance.fleet_calibration_store import (
     FleetCalibrationStore,
     graduation_ready,
+    valid_tok_per_s,
 )
 
 logger = logging.getLogger(__name__)
@@ -241,7 +241,7 @@ class FleetEvaluator:
                         model_id,
                         sc.ast_pass_rate,
                         sc.label_adherence,
-                        tok_per_s,
+                        valid_tok_per_s(sc),
                         sc.sample_count,
                     )
             except Exception as exc:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/fleet_evaluator.py
+++ b/backend/core/ouroboros/governance/fleet_evaluator.py
@@ -110,6 +110,25 @@ def _default_model() -> str:
     return os.environ.get("DOUBLEWORD_MODEL", "Qwen/Qwen3.5-397B-A17B-FP8")
 
 
+def _daily_usd_cap() -> float:
+    """Daily probe-spend ceiling; <=0 disables the cap."""
+    return _float_env("JARVIS_FLEET_DAILY_USD_CAP", 0.50)
+
+
+def _probe_usd_per_mtok() -> float:
+    """Estimated USD per 1M completion tokens for cost accounting (conservative
+    DW output-tier default). Used only for the daily-cap ledger, not billing."""
+    return _float_env("JARVIS_FLEET_PROBE_USD_PER_MTOK", 0.40)
+
+
+def _estimate_probe_usd(completion_tokens: int) -> float:
+    """Best-effort probe cost from completion tokens. Never raises."""
+    try:
+        return (max(0, int(completion_tokens)) / 1_000_000.0) * _probe_usd_per_mtok()
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
 # --------------------------------------------------------------------------- #
 # Default collaborators (all LATE-imported, fail-soft)
 # --------------------------------------------------------------------------- #
@@ -233,6 +252,13 @@ class FleetEvaluator:
                     now=self.clock(),
                 )
 
+                # Daily-cap ledger: record best-effort probe spend (both probes).
+                self.store.add_spend(
+                    _estimate_probe_usd(r.completion_tokens)
+                    + _estimate_probe_usd(c.completion_tokens),
+                    now=self.clock(),
+                )
+
                 sc = self.store.score(model_id)
                 if sc is not None:
                     logger.info(
@@ -243,6 +269,16 @@ class FleetEvaluator:
                         sc.label_adherence,
                         valid_tok_per_s(sc),
                         sc.sample_count,
+                    )
+                    self._emit(
+                        "fleet_calibrated",
+                        {
+                            "model_id": model_id,
+                            "ast_pass_rate": round(sc.ast_pass_rate, 4),
+                            "label_adherence": round(sc.label_adherence, 4),
+                            "valid_tok_per_s": round(valid_tok_per_s(sc), 2),
+                            "sample_count": sc.sample_count,
+                        },
                     )
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
@@ -263,6 +299,15 @@ class FleetEvaluator:
             if not fleet_evaluator_enabled():
                 return
             if not self.idle_check():
+                return
+            # Daily probe-spend ceiling — over cap → no-op this cycle.
+            cap = _daily_usd_cap()
+            if cap > 0.0 and self.store.spend_today(now) >= cap:
+                logger.info(
+                    "[FleetEvaluator] daily probe-spend cap reached "
+                    "($%.4f >= $%.2f) — skipping calibration cycle",
+                    self.store.spend_today(now), cap,
+                )
                 return
             models = list(self.snapshot_loader() or [])
             if not models:

--- a/backend/core/ouroboros/governance/fleet_evaluator.py
+++ b/backend/core/ouroboros/governance/fleet_evaluator.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+"""Sovereign Fleet Evaluator — async idle-driven DW model calibration driver.
+
+Probes DoubleWord (DW) models on idle cycles, AST-validates their output IN
+MEMORY (never executes), scores quality via the sibling quality battery, records
+into the sibling calibration store, and auto-graduates a quality-aware routing
+flip once a winner is stable across consecutive cycles.
+
+Design ref: docs/superpowers/specs/2026-06-19-sovereign-fleet-evaluator-design.md §4.3
+
+Fail-soft everywhere. Master switch ``JARVIS_FLEET_EVALUATOR_ENABLED`` (default
+false). The routing flip is gated behind ``JARVIS_FLEET_EVALUATOR_AUTHORITATIVE``
+(default false), persisted via the bounded credential-safe .env writer.
+
+Sandbox-safe: imports only the two sibling fleet leaves + stdlib at module top.
+The optional live model caller, snapshot loader, .env writer and SSE broker are
+LATE-imported inside try/except so this module imports cleanly with no network or
+real-file side effects.
+"""
+
+import asyncio  # noqa: F401  (used by the optional live caller path)
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Sequence
+
+from backend.core.ouroboros.governance.fleet_quality_battery import (
+    CODEGEN_PROMPT,
+    CLASSIFY_PROMPT,
+    EXPECTED_LABEL,
+    code_quality_pass,
+    label_adherence,
+)
+from backend.core.ouroboros.governance.fleet_calibration_store import (
+    FleetCalibrationStore,
+    graduation_ready,
+)
+
+logger = logging.getLogger(__name__)
+
+_TRUE = {"1", "true", "yes", "on"}
+
+
+# --------------------------------------------------------------------------- #
+# Probe result
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ProbeResult:
+    """One model probe outcome. ``ok=False`` means transport/HTTP failure."""
+
+    text: str
+    ttft_ms: float
+    total_ms: float
+    completion_tokens: int
+    ok: bool
+    error: str
+
+
+# --------------------------------------------------------------------------- #
+# Env gates / knobs (re-read at call time so monkeypatch + hot-flip work)
+# --------------------------------------------------------------------------- #
+def fleet_evaluator_enabled() -> bool:
+    return os.environ.get("JARVIS_FLEET_EVALUATOR_ENABLED", "").strip().lower() in _TRUE
+
+
+def fleet_authoritative_enabled() -> bool:
+    return (
+        os.environ.get("JARVIS_FLEET_EVALUATOR_AUTHORITATIVE", "").strip().lower()
+        in _TRUE
+    )
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(str(os.environ.get(name, "")).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(str(os.environ.get(name, "")).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _max_models_per_cycle() -> int:
+    return _int_env("JARVIS_FLEET_MAX_MODELS_PER_CYCLE", 4)
+
+
+def _probe_max_tokens() -> int:
+    return _int_env("JARVIS_FLEET_PROBE_MAX_TOKENS", 512)
+
+
+def _stable_cycles() -> int:
+    return _int_env("JARVIS_FLEET_GRAD_STABLE_CYCLES", 2)
+
+
+def _grad_min_samples() -> int:
+    return _int_env("JARVIS_FLEET_GRAD_MIN_SAMPLES", 5)
+
+
+def _grad_margin() -> float:
+    return _float_env("JARVIS_FLEET_GRAD_MARGIN", 1.5)
+
+
+def _default_model() -> str:
+    return os.environ.get("DOUBLEWORD_MODEL", "Qwen/Qwen3.5-397B-A17B-FP8")
+
+
+# --------------------------------------------------------------------------- #
+# Default collaborators (all LATE-imported, fail-soft)
+# --------------------------------------------------------------------------- #
+def _default_snapshot_loader() -> List[str]:
+    """Load DW model ids from the cached catalog snapshot. Fail-soft → []."""
+    try:
+        from backend.core.ouroboros.governance.dw_catalog_client import (
+            load_cached_snapshot,
+        )
+
+        snap = load_cached_snapshot()
+        return list(snap.model_ids()) if snap else []
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[FleetEvaluator] snapshot load skipped: %s", exc)
+        return []
+
+
+def _default_flag_persister(name: str, value: str) -> None:
+    """Durably persist a flag via the bounded credential-safe .env writer the
+    graduation orchestrator owns. Fail-soft → process-local env on any error.
+    Never raises."""
+    try:
+        from backend.core.ouroboros.governance.graduation_orchestrator import (
+            persist_flag_to_env,
+        )
+
+        ok = persist_flag_to_env(name, value)
+        if not ok:
+            os.environ[name] = value
+            logger.warning(
+                "[FleetEvaluator] durable .env persist refused/failed for %s; "
+                "set process-local only",
+                name,
+            )
+    except Exception as exc:  # noqa: BLE001
+        try:
+            os.environ[name] = value
+        except Exception:  # noqa: BLE001
+            pass
+        logger.warning(
+            "[FleetEvaluator] durable .env persist unavailable (%s); "
+            "set process-local only for %s",
+            exc,
+            name,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Evaluator
+# --------------------------------------------------------------------------- #
+class FleetEvaluator:
+    """Async idle-driven calibration driver + auto-graduation.
+
+    All collaborators are injectable for testing; the live defaults are
+    late-bound and fail-soft so unit tests never touch network or real files.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_caller: Callable[..., Any],
+        store: Optional[FleetCalibrationStore] = None,
+        idle_check: Optional[Callable[[], bool]] = None,
+        clock: Optional[Callable[[], float]] = None,
+        snapshot_loader: Optional[Callable[[], Sequence[str]]] = None,
+        default_model: Optional[str] = None,
+        flag_persister: Optional[Callable[[str, str], None]] = None,
+    ) -> None:
+        self.model_caller = model_caller
+        self.store = store or FleetCalibrationStore()
+        self.idle_check = idle_check or (lambda: True)
+        self.clock = clock or time.time
+        self.snapshot_loader = snapshot_loader or _default_snapshot_loader
+        self.default_model = default_model or _default_model()
+        self.flag_persister = flag_persister or _default_flag_persister
+        self._consecutive_wins = 0
+        self._last_winner: Optional[str] = None
+
+    # -- single probe ------------------------------------------------------- #
+    async def _probe_one(
+        self, model_id: str, *, prompt: str, max_tokens: int
+    ) -> ProbeResult:
+        messages = [{"role": "user", "content": prompt}]
+        try:
+            return await self.model_caller(model_id, messages, max_tokens=max_tokens)
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult("", 0.0, 0.0, 0, False, repr(exc))
+
+    # -- calibrate a list --------------------------------------------------- #
+    async def calibrate_models(self, model_ids: Sequence[str]) -> None:
+        max_tokens = _probe_max_tokens()
+        for model_id in model_ids:
+            try:
+                # Codegen probe (AST-validated in memory, never executed).
+                r = await self._probe_one(
+                    model_id, prompt=CODEGEN_PROMPT, max_tokens=max_tokens
+                )
+                tok_per_s = r.completion_tokens / max(r.total_ms / 1000.0, 1e-3)
+                self.store.record_probe(
+                    model_id,
+                    kind="code",
+                    code_pass=(code_quality_pass(r.text) if r.ok else False),
+                    ttft_ms=r.ttft_ms,
+                    tok_per_s=tok_per_s,
+                    now=self.clock(),
+                )
+
+                # Classify (triage) probe.
+                c = await self._probe_one(
+                    model_id, prompt=CLASSIFY_PROMPT, max_tokens=max_tokens
+                )
+                tok_per_s_c = c.completion_tokens / max(c.total_ms / 1000.0, 1e-3)
+                self.store.record_probe(
+                    model_id,
+                    kind="triage",
+                    label_score=(
+                        label_adherence(c.text, EXPECTED_LABEL) if c.ok else 0.0
+                    ),
+                    ttft_ms=c.ttft_ms,
+                    tok_per_s=tok_per_s_c,
+                    now=self.clock(),
+                )
+
+                sc = self.store.score(model_id)
+                if sc is not None:
+                    logger.info(
+                        "[FleetEvaluator] model=%s ast=%.2f label=%.2f vtps=%.1f "
+                        "samples=%d",
+                        model_id,
+                        sc.ast_pass_rate,
+                        sc.label_adherence,
+                        tok_per_s,
+                        sc.sample_count,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[FleetEvaluator] calibrate skipped model=%s: %s", model_id, exc
+                )
+                continue
+
+        try:
+            self.store.save()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[FleetEvaluator] store save skipped: %s", exc)
+
+    # -- idle entry point --------------------------------------------------- #
+    async def maybe_calibrate(self, *, now: float) -> None:
+        """Idle-cycle entry. Short-circuits before any probe when the master
+        switch is off or the system is not idle. Never raises."""
+        try:
+            if not fleet_evaluator_enabled():
+                return
+            if not self.idle_check():
+                return
+            models = list(self.snapshot_loader() or [])
+            if not models:
+                return
+            # Prefer least-recently-benchmarked (unscored first).
+            def _key(m: str) -> float:
+                sc = self.store.score(m)
+                return sc.updated_at if sc is not None else -1.0
+
+            models.sort(key=_key)
+            picked = models[: _max_models_per_cycle()]
+            await self.calibrate_models(picked)
+            self._maybe_graduate(now=now)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[FleetEvaluator] maybe_calibrate skipped: %s", exc)
+
+    # -- graduation --------------------------------------------------------- #
+    def _maybe_graduate(self, *, now: float) -> None:
+        """Propose + (after stable cycles) flip the authoritative routing gate.
+        Never raises."""
+        try:
+            winner = graduation_ready(
+                self.store.all_scores(),
+                default_model=self.default_model,
+                min_samples=_grad_min_samples(),
+                min_margin=_grad_margin(),
+            )
+            if winner is None:
+                self._consecutive_wins = 0
+                self._last_winner = None
+                return
+
+            logger.info(
+                "[FleetEvaluator] proposed coder=%s (advisory)", winner
+            )
+
+            if winner == self._last_winner:
+                self._consecutive_wins += 1
+            else:
+                self._consecutive_wins = 1
+                self._last_winner = winner
+
+            if (
+                self._consecutive_wins >= _stable_cycles()
+                and not fleet_authoritative_enabled()
+            ):
+                self.flag_persister("JARVIS_FLEET_EVALUATOR_AUTHORITATIVE", "true")
+                logger.info(
+                    "[FleetEvaluator] GRADUATED authoritative coder=%s", winner
+                )
+                self._emit(
+                    "fleet_graduated",
+                    {"coder": winner, "default": self.default_model, "now": now},
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[FleetEvaluator] graduation skipped: %s", exc)
+
+    # -- best-effort SSE ---------------------------------------------------- #
+    def _emit(self, event_type: str, payload: Any) -> None:
+        """Best-effort SSE emission. Late-imports the broker; never raises."""
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (
+                get_default_broker,
+            )
+
+            broker = get_default_broker()
+            broker.publish(event_type, f"fleet-{event_type}", payload)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[FleetEvaluator] SSE emit skipped: %s", exc)
+
+
+# --------------------------------------------------------------------------- #
+# Optional live model caller (NOT exercised by unit tests — keep simple + guarded)
+# --------------------------------------------------------------------------- #
+async def default_model_caller(
+    model_id: str, messages: list, *, max_tokens: int
+) -> ProbeResult:
+    """Live DW probe via ``/v1/chat/completions``, mirroring dw_catalog_client's
+    HTTP idiom (base URL + Bearer auth + key env). Non-streaming: ttft_ms is
+    approximated by total_ms. Fail-soft → ProbeResult(ok=False) on any error.
+    aiohttp is late-imported inside the function so this module imports cleanly
+    in the sandbox."""
+    t0 = time.monotonic()
+    try:
+        import aiohttp  # late import — sandbox-safe
+
+        base_url = os.environ.get(
+            "DOUBLEWORD_BASE_URL", "https://api.doubleword.ai/v1"
+        ).rstrip("/")
+        api_key = os.environ.get("DOUBLEWORD_API_KEY", "")
+        timeout_s = _float_env("JARVIS_FLEET_PROBE_TIMEOUT_S", 60.0)
+        url = f"{base_url}/chat/completions"
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        body = {
+            "model": model_id,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "stream": False,
+        }
+        timeout = aiohttp.ClientTimeout(total=timeout_s)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(url, headers=headers, json=body) as resp:
+                if resp.status != 200:
+                    return ProbeResult("", 0.0, 0.0, 0, False, f"http_{resp.status}")
+                data = await resp.json()
+        total_ms = (time.monotonic() - t0) * 1000.0
+        try:
+            text = data["choices"][0]["message"]["content"] or ""
+        except (KeyError, IndexError, TypeError):
+            text = ""
+        completion_tokens = 0
+        try:
+            completion_tokens = int(
+                data.get("usage", {}).get("completion_tokens", 0) or 0
+            )
+        except (TypeError, ValueError, AttributeError):
+            completion_tokens = 0
+        return ProbeResult(
+            text=text,
+            ttft_ms=total_ms,
+            total_ms=total_ms,
+            completion_tokens=completion_tokens,
+            ok=True,
+            error="",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ProbeResult("", 0.0, 0.0, 0, False, repr(exc))

--- a/backend/core/ouroboros/governance/fleet_evaluator.py
+++ b/backend/core/ouroboros/governance/fleet_evaluator.py
@@ -91,7 +91,12 @@ def _max_models_per_cycle() -> int:
 
 
 def _probe_max_tokens() -> int:
-    return _int_env("JARVIS_FLEET_PROBE_MAX_TOKENS", 512)
+    # 2048, not 512: the codegen battery asks for a full two-function answer
+    # (~1400 completion tokens for a real coder). 512 truncates valid coders
+    # mid-function → unparseable → false ast=0. Confirmed on a live DW soak
+    # (DeepSeek-V4-Flash needs 1360 tok; at 512 it scored 0). The classify
+    # probe stops early so the larger cap doesn't inflate triage cost.
+    return _int_env("JARVIS_FLEET_PROBE_MAX_TOKENS", 2048)
 
 
 def _stable_cycles() -> int:

--- a/backend/core/ouroboros/governance/fleet_quality_battery.py
+++ b/backend/core/ouroboros/governance/fleet_quality_battery.py
@@ -86,7 +86,7 @@ def is_ast_valid(text: str) -> bool:
 # --- Semantic placeholder detection ------------------------------------------
 
 
-def _is_ellipsis_expr(node: ast.stmt) -> bool:
+def _is_ellipsis_expr(node: ast.AST) -> bool:
     """True if node is a bare ``...`` expression statement."""
     return (
         isinstance(node, ast.Expr)
@@ -95,7 +95,7 @@ def _is_ellipsis_expr(node: ast.stmt) -> bool:
     )
 
 
-def _is_notimplemented_raise(node: ast.stmt) -> bool:
+def _is_notimplemented_raise(node: ast.AST) -> bool:
     """True for ``raise NotImplementedError`` or ``raise NotImplementedError(...)``."""
     if not isinstance(node, ast.Raise) or node.exc is None:
         return False

--- a/backend/core/ouroboros/governance/fleet_quality_battery.py
+++ b/backend/core/ouroboros/governance/fleet_quality_battery.py
@@ -1,0 +1,171 @@
+"""In-memory AST validation armor for the FleetEvaluator subsystem.
+
+This is the security boundary of the FleetEvaluator: it validates model
+output by *parsing* it to an AST and inspecting the tree. It NEVER executes,
+exec()s, eval()s, compiles-and-runs, or otherwise interprets the text it
+validates. It performs NO I/O, NO network, NO file writes.
+
+This module is a deliberate leaf: it imports only ``ast`` and ``re`` so it can
+be loaded in sandboxes where the full organism cannot be imported. Every
+public function is pure and never raises on None/empty/garbage input.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+
+# --- Probe prompts -----------------------------------------------------------
+
+# Codegen probe: a concrete, verifiable task. The downstream caller detects the
+# codegen probe via the lowercased substring "code block"; the trailing "ONLY"
+# sentence forces a clean single-block response.
+CODEGEN_PROMPT: str = (
+    "Implement two Python functions with full docstrings:\n"
+    "  1. merge_intervals(intervals): given a list of [start, end] intervals, "
+    "return a new list with all overlapping intervals merged, sorted by start. "
+    "Handle the empty list (return []).\n"
+    "  2. interval_union(a, b): given two intervals a=[s, e] and b=[s, e], "
+    "return their union as a list of intervals (one if they overlap or touch, "
+    "two if disjoint).\n"
+    "Do not leave any function body as a placeholder. "
+    "Return ONLY a single python code block."
+)
+
+# Classification probe: a task that is unambiguously ENRICH (add detail to an
+# existing artifact, not a no-op, redirect, or net-new generation).
+CLASSIFY_PROMPT: str = (
+    "Classify the following development task as exactly one of: "
+    "NO_OP | REDIRECT | ENRICH | GENERATE.\n"
+    "Task: enrich the README with usage examples and a quickstart section "
+    "for the functions that already exist in the module.\n"
+    "Reply with ONLY the label."
+)
+
+EXPECTED_LABEL: str = "ENRICH"
+
+# --- Code-block extraction ---------------------------------------------------
+
+_CODE_BLOCK_RE = re.compile(r"```(?:python)?\s*\n?(.*?)```", re.DOTALL)
+_TODO_RE = re.compile(r"#\s*(TODO|implement|fill in|your code)", re.IGNORECASE)
+
+
+def extract_code_block(text: str) -> str:
+    """Return the contents of a fenced ```python ... ``` block, else the text.
+
+    Falls back to the stripped raw text when no fenced block is present.
+    Never raises; treats None as empty.
+    """
+    if not text:
+        return ""
+    match = _CODE_BLOCK_RE.search(text)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+# --- Syntactic validation (parse only — never execute) -----------------------
+
+
+def is_ast_valid(text: str) -> bool:
+    """True iff the extracted code block parses as valid Python.
+
+    Parses with ``ast.parse`` only. Never calls exec/eval/compile-and-run, so
+    even a syntactically valid malicious payload is inspected, not executed.
+    """
+    code = extract_code_block(text)
+    if not code:
+        return False
+    try:
+        ast.parse(code)
+        return True
+    except (SyntaxError, ValueError, RecursionError, TypeError):
+        return False
+
+
+# --- Semantic placeholder detection ------------------------------------------
+
+
+def _is_ellipsis_expr(node: ast.stmt) -> bool:
+    """True if node is a bare ``...`` expression statement."""
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and node.value.value is Ellipsis
+    )
+
+
+def _is_notimplemented_raise(node: ast.stmt) -> bool:
+    """True for ``raise NotImplementedError`` or ``raise NotImplementedError(...)``."""
+    if not isinstance(node, ast.Raise) or node.exc is None:
+        return False
+    exc = node.exc
+    # raise NotImplementedError(...)
+    if isinstance(exc, ast.Call):
+        exc = exc.func
+    # raise NotImplementedError
+    return isinstance(exc, ast.Name) and exc.id == "NotImplementedError"
+
+
+def _is_placeholder_body(body: list[ast.stmt]) -> bool:
+    """True if a function body is exactly one placeholder statement."""
+    if len(body) != 1:
+        return False
+    stmt = body[0]
+    return (
+        _is_ellipsis_expr(stmt)
+        or isinstance(stmt, ast.Pass)
+        or _is_notimplemented_raise(stmt)
+    )
+
+
+def has_semantic_placeholder(text: str) -> bool:
+    """True if the code contains a placeholder body, bare ellipsis, or TODO.
+
+    A docstring-only function body is NOT a placeholder. Never raises.
+    """
+    code = extract_code_block(text)
+    if not code:
+        return False
+    try:
+        tree = ast.parse(code)
+    except Exception:
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if _is_placeholder_body(node.body):
+                return True
+        elif _is_ellipsis_expr(node):
+            # Module-level (or any-level) bare ellipsis expression statement.
+            return True
+
+    if _TODO_RE.search(code):
+        return True
+
+    return False
+
+
+def code_quality_pass(text: str) -> bool:
+    """True iff the code parses AND has no semantic placeholder."""
+    return is_ast_valid(text) and not has_semantic_placeholder(text)
+
+
+# --- Classification label adherence ------------------------------------------
+
+
+def label_adherence(text: str, expected: str) -> float:
+    """Score how well a classification response adheres to the expected label.
+
+    1.0 for an exact (case/punctuation-insensitive) match, 0.5 for the label
+    appearing within prose, 0.0 otherwise (including empty input). Never raises.
+    """
+    t = (text or "").strip().upper().strip(".!:\"' ")
+    e = (expected or "").strip().upper()
+    if not t or not e:
+        return 0.0
+    if t == e:
+        return 1.0
+    if e in t.split() or e in t:
+        return 0.5
+    return 0.0

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -1258,6 +1258,12 @@ EVENT_TYPE_ADMISSION_DECISION_EMITTED = "admission_decision_emitted"
 # J-Prime local handoff activates (all_providers_exhausted intercepted,
 # payload pruned topologically, local tier absorbing the op).
 EVENT_TYPE_EXHAUSTION_HANDOFF_TRIGGERED = "exhaustion_handoff_triggered"
+# Sovereign Fleet Evaluator (2026-06-19) — the autonomous quality-calibration
+# loop's two visible decisions: a per-model calibration result and the
+# auto-graduation that flips quality-aware routing authoritative. Manifesto §7
+# (every autonomous decision is visible). Both fire best-effort + fail-soft.
+EVENT_TYPE_FLEET_CALIBRATED = "fleet_calibrated"
+EVENT_TYPE_FLEET_GRADUATED = "fleet_graduated"
 # CodebaseCharacterDigest Slice 3 — emitted when ProactiveExploration
 # Sensor surfaces an under-touched semantic cluster as an IntentEnvelope.
 # Lets IDE/observability consumers correlate the cluster-coverage bias
@@ -1544,6 +1550,10 @@ _VALID_EVENT_TYPES = frozenset({
                                                   # topological prune applied, J-Prime local
                                                   # tier absorbs the op; gated by
                                                   # JARVIS_JPRIME_LASTRESORT_ENABLED)
+    EVENT_TYPE_FLEET_CALIBRATED,                  # Sovereign Fleet Evaluator (2026-06-19 —
+                                                  # per-model quality calibration result)
+    EVENT_TYPE_FLEET_GRADUATED,                   # Sovereign Fleet Evaluator (2026-06-19 —
+                                                  # quality-aware routing flipped authoritative)
 })
 
 

--- a/backend/core/ouroboros/governance/provider_topology.py
+++ b/backend/core/ouroboros/governance/provider_topology.py
@@ -412,7 +412,7 @@ class ProviderTopology:
                 key = (route or "").strip().lower()
                 ranked = holder.assignments_by_route.get(key, ())
                 if ranked:
-                    return ranked
+                    return _fleet_guarded(route, ranked)
             # Fall through to YAML — cold-start, stale, route missing,
             # or route empty in catalog. YAML stays authoritative for
             # all four fallback conditions
@@ -422,7 +422,7 @@ class ProviderTopology:
             return ()
         effective = entry.effective_dw_models
         if effective:
-            return effective
+            return _fleet_guarded(route, effective)
         # ── Slice 10B-ii — trusted-seed runtime bypass ──
         # YAML + dynamic catalog both returned empty; consult
         # PromotionLedger for operator-attested trusted seeds that
@@ -430,7 +430,7 @@ class ProviderTopology:
         # :func:`_trusted_seed_dw_models_for_route` for the gate
         # composition (re-uses dw_catalog_classifier.gate_for_route
         # so the same param/price thresholds apply).
-        return _trusted_seed_dw_models_for_route(route)
+        return _fleet_guarded(route, _trusted_seed_dw_models_for_route(route))
 
     def fallback_tolerance_for_route(self, route: str) -> str:
         """Return the v2 ``fallback_tolerance`` for *route*.
@@ -654,6 +654,30 @@ def elevate_pool_for_exploration(
             return tuple(ranked_models or ())
         except Exception:  # noqa: BLE001
             return ()
+
+
+def _fleet_guarded(route: str, result: Tuple[str, ...]) -> Tuple[str, ...]:
+    """Gated quality-aware re-rank (Sovereign Fleet Evaluator, 2026-06-19).
+
+    OFF by default → returns ``result`` byte-identically. When
+    ``JARVIS_FLEET_EVALUATOR_AUTHORITATIVE`` is set (auto-flipped by the
+    FleetEvaluator once a soak proves the calibrated coder beats the
+    static default), the already-resolved ranked tuple is reordered by
+    measured ``valid_tok_per_s`` / ``triage_fitness``. Pure + fail-soft:
+    any error returns the input unchanged.
+    """
+    try:
+        from backend.core.ouroboros.governance.fleet_evaluator import (
+            fleet_authoritative_enabled,
+        )
+        if fleet_authoritative_enabled():
+            from backend.core.ouroboros.governance.fleet_calibration_store import (
+                fleet_apply_rerank,
+            )
+            return fleet_apply_rerank(route, result)
+    except Exception:
+        pass
+    return result
 
 
 def _locate_policy_yaml() -> Optional[Path]:

--- a/docs/superpowers/plans/2026-06-19-sovereign-fleet-evaluator.md
+++ b/docs/superpowers/plans/2026-06-19-sovereign-fleet-evaluator.md
@@ -1,0 +1,380 @@
+# Sovereign Fleet Evaluator — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add an active correctness/quality calibration axis to DW model selection — an idle-driven `FleetEvaluator` that AST-validates model output in-memory, EWMA-smooths a `valid_tok_per_s` composite, and re-ranks `dw_models_for_route()` advisory→auto-graduate, demoting the 397B default.
+
+**Architecture:** Four new modules under `backend/core/ouroboros/governance/` + one guarded call in `provider_topology.py`. Reuses `dw_catalog_client` (discovery), `dw_promotion_ledger`/`dw_ttft_observer` (latency), the bounded `.env` writer (graduation). No code execution (`ast.parse` only). All gated OFF by default → byte-identical legacy.
+
+**Tech Stack:** Python 3.9+, `from __future__ import annotations`, asyncio, stdlib `ast`/`json`, pytest (+ `pytest.mark.asyncio`). Full spec: `docs/superpowers/specs/2026-06-19-sovereign-fleet-evaluator-design.md`.
+
+**Sandbox note for implementers:** the full organism cannot be imported here (split-brain guard). Each new module must be a **leaf** importable in isolation (stdlib + sibling governance leaves only). Verify with `python3 -c "import ast; ast.parse(open('<file>').read())"` and run the new tests directly with `PYTHONPATH=. python3 -m pytest <testfile> -q`. Do NOT import `unified_supervisor`, `orchestrator`, or `governed_loop_service`.
+
+---
+
+## File Structure
+
+- Create `backend/core/ouroboros/governance/fleet_quality_battery.py` — pure prompts + in-memory validators (the AST armor).
+- Create `backend/core/ouroboros/governance/fleet_calibration_store.py` — `QualityScore` + EWMA + persistence + pure `fleet_rerank` + `graduation_ready` + `fleet_apply_rerank` adapter.
+- Create `backend/core/ouroboros/governance/fleet_evaluator.py` — async idle-driven driver, injectable caller, cost/idle gates, `_maybe_graduate`.
+- Modify `backend/core/ouroboros/governance/provider_topology.py` — one guarded `fleet_apply_rerank` call at end of `dw_models_for_route`.
+- Tests: `tests/governance/test_fleet_quality_battery.py`, `test_fleet_calibration_store.py`, `test_fleet_evaluator.py`, `test_fleet_topology_binding.py`.
+
+---
+
+### Task 1: `fleet_quality_battery.py` — in-memory AST validation armor
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/fleet_quality_battery.py`
+- Test: `tests/governance/test_fleet_quality_battery.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/governance/test_fleet_quality_battery.py
+from __future__ import annotations
+from backend.core.ouroboros.governance import fleet_quality_battery as b
+
+
+def test_prompts_exist_and_are_strings():
+    assert isinstance(b.CODEGEN_PROMPT, str) and "ONLY" in b.CODEGEN_PROMPT.upper()
+    assert isinstance(b.CLASSIFY_PROMPT, str)
+    assert b.EXPECTED_LABEL == "ENRICH"
+
+
+def test_extract_code_block_fenced_and_bare():
+    assert "def f" in b.extract_code_block("```python\ndef f():\n    return 1\n```")
+    assert "def g" in b.extract_code_block("def g():\n    return 2")
+
+
+def test_is_ast_valid_true_for_real_code():
+    assert b.is_ast_valid("```python\ndef merge(x):\n    return sorted(x)\n```") is True
+
+
+def test_is_ast_valid_false_for_syntax_error():
+    assert b.is_ast_valid("```python\ndef merge(x):\n    return sorted(\n```") is False
+
+
+def test_placeholder_ellipsis_body_detected():
+    assert b.has_semantic_placeholder("```python\ndef f():\n    ...\n```") is True
+
+
+def test_placeholder_notimplemented_detected():
+    assert b.has_semantic_placeholder(
+        "```python\ndef f():\n    raise NotImplementedError\n```") is True
+
+
+def test_real_code_has_no_placeholder():
+    assert b.has_semantic_placeholder(
+        "```python\ndef f(x):\n    '''doc'''\n    return x + 1\n```") is False
+
+
+def test_code_quality_pass_combines_both():
+    assert b.code_quality_pass("```python\ndef f(x):\n    return x*2\n```") is True
+    assert b.code_quality_pass("```python\ndef f():\n    ...\n```") is False
+    assert b.code_quality_pass("not code at all !!!(") is False
+
+
+def test_label_adherence_exact_prose_empty():
+    assert b.label_adherence("ENRICH", "ENRICH") == 1.0
+    assert b.label_adherence("  enrich \n", "ENRICH") == 1.0
+    assert 0.0 < b.label_adherence("The label is ENRICH because...", "ENRICH") < 1.0
+    assert b.label_adherence("", "ENRICH") == 0.0
+    assert b.label_adherence("NO_OP", "ENRICH") == 0.0
+
+
+def test_adversarial_string_is_parsed_not_executed(tmp_path):
+    # A malicious payload as a STRING parses to a tree but must never run.
+    canary = tmp_path / "canary.txt"
+    payload = f"```python\nimport os\nos.system('touch {canary}')\n```"
+    assert b.is_ast_valid(payload) is True       # syntactically valid
+    assert canary.exists() is False              # but NEVER executed
+```
+
+- [ ] **Step 2: Run tests, verify they fail** — `PYTHONPATH=. python3 -m pytest tests/governance/test_fleet_quality_battery.py -q` → ImportError.
+
+- [ ] **Step 3: Implement `fleet_quality_battery.py`**
+
+Requirements (no I/O, no network, no exec/eval/file-write):
+- `from __future__ import annotations`; `import ast`, `import re`.
+- `CODEGEN_PROMPT`: a concrete multi-function task ending "Return ONLY a python code block." Example body: implement `merge_intervals(intervals)` and `interval_union(a, b)` with docstrings, handle empty list.
+- `CLASSIFY_PROMPT`: classify task `'enrich the README with usage examples'` as exactly one of `NO_OP | REDIRECT | ENRICH | GENERATE`; "Reply with ONLY the label." `EXPECTED_LABEL = "ENRICH"`.
+- `extract_code_block(text)`: regex ```` ```(?:python)?\s*(.*?)``` ```` DOTALL; group(1) if matched else the whole stripped text. Never raises (None text → "").
+- `is_ast_valid(text)`: `try: ast.parse(extract_code_block(text)); return bool(stripped)` `except (SyntaxError, ValueError, RecursionError, TypeError): return False`.
+- `has_semantic_placeholder(text)`: parse; if parse fails return False (validity is is_ast_valid's job). Walk tree: return True if any `ast.FunctionDef`/`ast.AsyncFunctionDef` whose body is exactly one stmt that is `ast.Expr(ast.Constant(Ellipsis))`, `ast.Pass`, or `ast.Raise` of `NotImplementedError`; OR a module-level bare `...`; OR a regex `#\s*(TODO|implement|fill in|your code)` in the raw text.
+- `code_quality_pass(text)`: `is_ast_valid(text) and not has_semantic_placeholder(text)`.
+- `label_adherence(text, expected)`: `t = (text or "").strip().upper().strip(".!:\"' ")`; exact == → 1.0; `expected in t.split()` or `expected in t` (word-bounded) with extra tokens → 0.5; else 0.0.
+
+- [ ] **Step 4: Run tests, verify pass.**
+- [ ] **Step 5: Commit** — `feat(fleet): in-memory AST validation battery (no exec)`.
+
+---
+
+### Task 2: `fleet_calibration_store.py` — scores, EWMA, persistence, rerank, graduation math
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/fleet_calibration_store.py`
+- Test: `tests/governance/test_fleet_calibration_store.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/governance/test_fleet_calibration_store.py
+from __future__ import annotations
+from backend.core.ouroboros.governance import fleet_calibration_store as s
+
+
+def test_ewma_first_sample_and_update():
+    assert s.ewma_update(None, 1.0, 0.4) == 1.0
+    assert abs(s.ewma_update(0.0, 1.0, 0.5) - 0.5) < 1e-9
+
+
+def test_quality_score_composites():
+    sc = s.QualityScore(model_id="m", ast_pass_rate=0.5, label_adherence=1.0,
+                        ttft_ms=100.0, tok_per_s=80.0, sample_count=5, updated_at=1.0)
+    assert abs(s.valid_tok_per_s(sc) - 40.0) < 1e-9         # 80 * 0.5
+    assert s.triage_fitness(sc) > 0
+
+
+def test_store_record_and_persist_roundtrip(tmp_path, monkeypatch):
+    p = tmp_path / "fleet_calibration.json"
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(p))
+    st = s.FleetCalibrationStore()
+    st.record_probe("deepseek", kind="code", code_pass=True, ttft_ms=200, tok_per_s=90, now=1.0)
+    st.record_probe("deepseek", kind="triage", label_score=1.0, ttft_ms=200, tok_per_s=90, now=2.0)
+    st.save()
+    st2 = s.FleetCalibrationStore()
+    sc = st2.score("deepseek")
+    assert sc is not None and sc.sample_count == 2 and sc.ast_pass_rate > 0
+
+
+def test_rerank_orders_measured_good_above_bad():
+    scores = {
+        "qwen397": s.QualityScore("qwen397", 0.0, 0.0, 150, 120, 8, 1.0),   # fast, no valid code
+        "deepseek": s.QualityScore("deepseek", 1.0, 1.0, 200, 90, 8, 1.0),  # slower, valid
+    }
+    out = s.fleet_rerank("standard", ("qwen397", "deepseek"), scores, route_kind="code")
+    assert out[0] == "deepseek"      # valid_tok_per_s: deepseek 90 > qwen397 0
+
+
+def test_rerank_leaves_unbenchmarked_alone_and_noop_on_thin_data():
+    scores = {"deepseek": s.QualityScore("deepseek", 1.0, 1.0, 200, 90, 8, 1.0)}
+    # only 1 scored model -> input returned unchanged
+    assert s.fleet_rerank("standard", ("qwen397", "deepseek"), scores, route_kind="code") == ("qwen397", "deepseek")
+    assert s.fleet_rerank("standard", ("a", "b"), {}, route_kind="code") == ("a", "b")
+
+
+def test_graduation_ready_fires_on_measured_bad_default():
+    scores = {
+        "qwen397": s.QualityScore("qwen397", 0.05, 0.0, 150, 120, 8, 1.0),
+        "deepseek": s.QualityScore("deepseek", 0.95, 1.0, 200, 90, 8, 1.0),
+    }
+    winner = s.graduation_ready(scores, default_model="qwen397",
+                                min_samples=5, min_margin=1.5)
+    assert winner == "deepseek"
+
+
+def test_graduation_ready_none_below_thresholds():
+    scores = {"deepseek": s.QualityScore("deepseek", 0.95, 1.0, 200, 90, 2, 1.0)}  # too few samples
+    assert s.graduation_ready(scores, default_model="qwen397", min_samples=5, min_margin=1.5) is None
+
+
+def test_apply_rerank_failsoft_returns_input_on_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "none.json"))
+    # no store data -> input unchanged
+    assert s.fleet_apply_rerank("standard", ("a", "b")) == ("a", "b")
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement.** Mirror `dw_promotion_ledger` patterns (`_atomic_write`, lazy `_ensure_loaded`, env path getter, never raises).
+- `QualityScore` frozen dataclass with the 7 fields from the spec.
+- `ewma_update(prev, new, alpha)`: `new if prev is None else alpha*new + (1-alpha)*prev`.
+- `valid_tok_per_s(sc) = sc.tok_per_s * sc.ast_pass_rate`.
+- `triage_fitness(sc) = sc.label_adherence / max(sc.ttft_ms, 1.0) * 1000.0`.
+- env getters: `_alpha()` (`JARVIS_FLEET_EWMA_ALPHA`, 0.4), `_path()` (`JARVIS_FLEET_CALIBRATION_PATH`, `.jarvis/fleet_calibration.json`).
+- `FleetCalibrationStore`: `load/save/_ensure_loaded`; `record_probe(model_id, *, kind, code_pass=None, label_score=None, ttft_ms, tok_per_s, now)` — folds via EWMA (code_pass→ast_pass_rate as 1.0/0.0; label_score→label_adherence), always updates ttft/tok EWMA + `sample_count += 1` + `updated_at = now`; `score(model_id)`; `all_scores()`.
+- `route_kind_for_route(route) -> str`: `"triage"` if route lower in {`triage`,`semantic_triage`,`classify`} else `"code"`.
+- `fleet_rerank(route, ranked_models, scores, *, route_kind)`: key fn = `valid_tok_per_s` (code) or `triage_fitness` (triage); collect models in `ranked_models` that have a score with `sample_count>=1`; if `<2` such → return `tuple(ranked_models)` unchanged; else stable-sort the WHOLE input so scored models are ordered by key desc while preserving each unscored model's original index (only reorder scored entries among themselves, leave unscored in place). Never raises.
+- `graduation_ready(scores, *, default_model, min_samples, min_margin)`: among scored models (excluding default) with `sample_count>=min_samples` and `ast_pass_rate >= _min_ast()` (`JARVIS_FLEET_GRAD_MIN_AST`, 0.8), pick max `valid_tok_per_s`; let `d = scores.get(default_model)`; return the winner iff (`d is None or d.ast_pass_rate < 0.2`) **or** `winner.valid_tok_per_s >= min_margin * valid_tok_per_s(d)`; else None.
+- `fleet_apply_rerank(route, ranked_models)`: try: load store, `fleet_rerank(route, ranked_models, store.all_scores(), route_kind=route_kind_for_route(route))`; except: return `tuple(ranked_models)`.
+
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** — `feat(fleet): calibration store + EWMA + pure rerank/graduation math`.
+
+---
+
+### Task 3: `fleet_evaluator.py` — async idle-driven calibration driver
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/fleet_evaluator.py`
+- Test: `tests/governance/test_fleet_evaluator.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/governance/test_fleet_evaluator.py
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import fleet_evaluator as fe
+from backend.core.ouroboros.governance import fleet_calibration_store as s
+
+
+def _fake_caller(behavior):
+    async def call(model_id, messages, *, max_tokens):
+        is_code = "code block" in messages[-1]["content"].lower()
+        if behavior == "good":
+            text = "```python\ndef merge_intervals(x):\n    '''m'''\n    return sorted(x)\n```" if is_code else "ENRICH"
+            return fe.ProbeResult(text=text, ttft_ms=200, total_ms=1000, completion_tokens=80, ok=True, error="")
+        if behavior == "prose":  # the 397B failure mode
+            return fe.ProbeResult(text="Let me think about intervals..." , ttft_ms=150, total_ms=4000, completion_tokens=900, ok=True, error="")
+        return fe.ProbeResult(text="", ttft_ms=0, total_ms=0, completion_tokens=0, ok=False, error="HTTP 502")
+    return call
+
+
+def test_disabled_is_noop(monkeypatch):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "false")
+    assert fe.fleet_evaluator_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_good_model_scores_high(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    store = s.FleetCalibrationStore()
+    ev = fe.FleetEvaluator(model_caller=_fake_caller("good"), store=store,
+                           idle_check=lambda: True, clock=lambda: 1.0)
+    await ev.calibrate_models(["deepseek"])
+    sc = store.score("deepseek")
+    assert sc.ast_pass_rate > 0.9 and sc.label_adherence > 0.9
+
+
+@pytest.mark.asyncio
+async def test_prose_model_scores_zero_ast(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    store = s.FleetCalibrationStore()
+    ev = fe.FleetEvaluator(model_caller=_fake_caller("prose"), store=store,
+                           idle_check=lambda: True, clock=lambda: 1.0)
+    await ev.calibrate_models(["qwen397"])
+    assert store.score("qwen397").ast_pass_rate < 0.1   # the diagnosed bug, now measured
+
+
+@pytest.mark.asyncio
+async def test_502_is_failsoft(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    store = s.FleetCalibrationStore()
+    ev = fe.FleetEvaluator(model_caller=_fake_caller("502"), store=store,
+                           idle_check=lambda: True, clock=lambda: 1.0)
+    await ev.calibrate_models(["devstral"])     # must NOT raise
+    assert store.score("devstral").ast_pass_rate == 0.0
+
+
+@pytest.mark.asyncio
+async def test_maybe_calibrate_skips_when_not_idle(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    store = s.FleetCalibrationStore()
+    calls = []
+    async def spy(model_id, messages, *, max_tokens):
+        calls.append(model_id); return fe.ProbeResult("", 0, 0, 0, False, "")
+    ev = fe.FleetEvaluator(model_caller=spy, store=store, idle_check=lambda: False,
+                           clock=lambda: 1.0, snapshot_loader=lambda: ["m"])
+    await ev.maybe_calibrate(now=1.0)
+    assert calls == []     # not idle -> no probes
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement.**
+- `from __future__ import annotations`; asyncio; dataclasses; logging; os.
+- `ProbeResult` frozen dataclass: `text, ttft_ms, total_ms, completion_tokens, ok, error`.
+- Env gates: `fleet_evaluator_enabled()` (`JARVIS_FLEET_EVALUATOR_ENABLED`, false), `fleet_authoritative_enabled()` (`JARVIS_FLEET_EVALUATOR_AUTHORITATIVE`, false), `_max_models_per_cycle()` (4), `_probe_max_tokens()` (512), `_stable_cycles()` (2).
+- `FleetEvaluator.__init__(self, *, model_caller, store=None, idle_check=None, clock=None, snapshot_loader=None, default_model=None)`. Defaults: store=`FleetCalibrationStore()`, idle_check=`lambda: True`, clock=`time.time`, snapshot_loader → reads `dw_catalog_client.load_cached_snapshot().model_ids()` (guarded, returns [] on None), default_model → `os.environ.get("DOUBLEWORD_MODEL", "Qwen/Qwen3.5-397B-A17B-FP8")`.
+- `async calibrate_models(self, model_ids)`: for each model, run codegen probe (messages from `CODEGEN_PROMPT`) then classify probe (`CLASSIFY_PROMPT`), `max_tokens=_probe_max_tokens()`; compute `tok_per_s = completion_tokens / max(total_ms/1000, 1e-3)`; on `ok`: `store.record_probe(code/label...)`; on `not ok`: record a failed probe (code_pass=False / label_score=0.0). Wrap each model in try/except (fail-soft, log). `store.save()` at end.
+- `async maybe_calibrate(self, *, now)`: return if not enabled; return if not `idle_check()`; `models = snapshot_loader()`; pick ≤N least-recently-benchmarked (sort by store.score(m).updated_at, unscored first); `await calibrate_models(picked)`; `self._maybe_graduate(now=now)`.
+- `_maybe_graduate(self, *, now)`: `winner = graduation_ready(store.all_scores(), default_model=self.default_model, min_samples=_grad_min_samples(), min_margin=_grad_margin())`; track consecutive-win count in an instance counter; if winner stable ≥ `_stable_cycles()` and not already authoritative → `persist_authoritative_flag()` (reuse the bounded `.env` writer used by the graduation orchestrator — locate it; do NOT author a new writer) + log `[FleetEvaluator] graduated coder=<winner>`. Advisory log of the proposed flip every cycle.
+- Structured logs + best-effort SSE via event broker if available (positional `publish(event_type, op_id, payload)`); guard import, never raise.
+
+- [ ] **Step 4: Run, verify pass.**
+- [ ] **Step 5: Commit** — `feat(fleet): async idle-driven calibration driver + auto-graduation`.
+
+---
+
+### Task 4: Bind into `provider_topology` + register flags
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/provider_topology.py` (end of `dw_models_for_route`, ~line 433)
+- Test: `tests/governance/test_fleet_topology_binding.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_fleet_topology_binding.py
+from __future__ import annotations
+
+
+def test_dw_models_for_route_byte_identical_when_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_FLEET_EVALUATOR_AUTHORITATIVE", raising=False)
+    import backend.core.ouroboros.governance.provider_topology as pt
+    src = open(pt.__file__).read()
+    assert "fleet_authoritative_enabled" in src           # guarded call present
+    assert "fleet_apply_rerank" in src
+    # the guard must wrap the call (off -> never invoked)
+    assert "if fleet_authoritative_enabled():" in src
+
+
+def test_rerank_applied_when_authoritative(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_AUTHORITATIVE", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    from backend.core.ouroboros.governance import fleet_calibration_store as s
+    st = s.FleetCalibrationStore()
+    st.record_probe("good", kind="code", code_pass=True, ttft_ms=200, tok_per_s=90, now=1.0)
+    st.record_probe("good", kind="code", code_pass=True, ttft_ms=200, tok_per_s=90, now=2.0)
+    st.record_probe("bad", kind="code", code_pass=False, ttft_ms=100, tok_per_s=120, now=1.0)
+    st.record_probe("bad", kind="code", code_pass=False, ttft_ms=100, tok_per_s=120, now=2.0)
+    st.save()
+    out = s.fleet_apply_rerank("standard", ("bad", "good"))
+    assert out[0] == "good"
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement the guarded binding.** At the END of `dw_models_for_route`, immediately before each `return ranked`/`return effective`/`return _trusted_seed_dw_models_for_route(route)`, route the final tuple through a single guarded helper. Cleanest: capture the result in a local `result` and add ONE exit:
+```python
+        # ── Sovereign Fleet Evaluator (quality-aware re-rank, gated) ──
+        # OFF by default → byte-identical. Authoritative flip is set by
+        # FleetEvaluator auto-graduation once a soak proves the calibrated
+        # coder beats the 397B default. Pure, fail-soft (returns input on error).
+        try:
+            from backend.core.ouroboros.governance.fleet_evaluator import (
+                fleet_authoritative_enabled,
+            )
+            if fleet_authoritative_enabled():
+                from backend.core.ouroboros.governance.fleet_calibration_store import (
+                    fleet_apply_rerank,
+                )
+                result = fleet_apply_rerank(route, result)
+        except Exception:
+            pass
+        return result
+```
+Refactor the three return paths to assign `result = ...` then fall to the single guarded return (preserve exact current values for each branch). Keep `if not self.enabled: return ()` and the catalog/early-empty returns unchanged — only the final resolved-tuple returns funnel through the guard.
+
+- [ ] **Step 4: Run the binding test AND the existing topology tests** — `PYTHONPATH=. python3 -m pytest tests/governance/test_fleet_topology_binding.py tests/governance/ -k "topology" -q`. Expected: all pass (off-path byte-identical).
+
+- [ ] **Step 5: Register flags in FlagRegistry.** Add the 12 `JARVIS_FLEET_*` flags (Table §8 of the spec) to the curated seed in `flag_registry.py` (type, category=`provider`/`routing`, source_file, example, posture-relevance IGNORED). Mirror an existing seed entry's shape. Add a test asserting `JARVIS_FLEET_EVALUATOR_ENABLED` is registered.
+
+- [ ] **Step 6: Commit** — `feat(fleet): bind quality rerank into dw_models_for_route (gated) + register flags`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** discovery reuse (Task 3 snapshot_loader), AST armor (Task 1), EWMA+rerank+graduation math (Task 2), idle/cost driver + auto-graduate (Task 3), guarded binding + flags (Task 4) — all spec sections mapped.
+- **Type consistency:** `QualityScore`, `ProbeResult`, `fleet_rerank`, `fleet_apply_rerank`, `graduation_ready`, `record_probe` signatures identical across tasks.
+- **No placeholders:** every step has concrete code/commands.
+- **OFF byte-identical:** Task 4 guard + Tasks 1-3 default-false gates.
+- **No exec:** Task 1 validators are `ast.parse`-only; adversarial test asserts no side effect.
+```

--- a/docs/superpowers/specs/2026-06-19-sovereign-fleet-evaluator-design.md
+++ b/docs/superpowers/specs/2026-06-19-sovereign-fleet-evaluator-design.md
@@ -262,7 +262,7 @@ green; the live calibration soak runs on a real host.
 | `JARVIS_FLEET_EVALUATOR_ENABLED` | false | master: run calibration at all |
 | `JARVIS_FLEET_EVALUATOR_AUTHORITATIVE` | false | quality scores re-rank live routing (auto-flipped) |
 | `JARVIS_FLEET_EWMA_ALPHA` | 0.4 | EWMA smoothing factor |
-| `JARVIS_FLEET_PROBE_MAX_TOKENS` | 512 | per-probe token cap |
+| `JARVIS_FLEET_PROBE_MAX_TOKENS` | 2048 | per-probe token cap (codegen battery needs ~1400 to finish; 512 truncated valid coders to ast=0 on live soak) |
 | `JARVIS_FLEET_PROBE_TIMEOUT_S` | 60 | per-probe HTTP timeout |
 | `JARVIS_FLEET_MAX_MODELS_PER_CYCLE` | 4 | models calibrated per idle cycle |
 | `JARVIS_FLEET_DAILY_USD_CAP` | 0.50 | daily probe spend ceiling (UTC-day rolling; `<=0` disables); enforced in `maybe_calibrate` via the store spend-ledger |

--- a/docs/superpowers/specs/2026-06-19-sovereign-fleet-evaluator-design.md
+++ b/docs/superpowers/specs/2026-06-19-sovereign-fleet-evaluator-design.md
@@ -265,7 +265,8 @@ green; the live calibration soak runs on a real host.
 | `JARVIS_FLEET_PROBE_MAX_TOKENS` | 512 | per-probe token cap |
 | `JARVIS_FLEET_PROBE_TIMEOUT_S` | 60 | per-probe HTTP timeout |
 | `JARVIS_FLEET_MAX_MODELS_PER_CYCLE` | 4 | models calibrated per idle cycle |
-| `JARVIS_FLEET_DAILY_USD_CAP` | 0.50 | daily probe spend ceiling |
+| `JARVIS_FLEET_DAILY_USD_CAP` | 0.50 | daily probe spend ceiling (UTC-day rolling; `<=0` disables); enforced in `maybe_calibrate` via the store spend-ledger |
+| `JARVIS_FLEET_PROBE_USD_PER_MTOK` | 0.40 | USD/1M completion tokens for the spend ledger (accounting, not billing) |
 | `JARVIS_FLEET_GRAD_MIN_SAMPLES` | 5 | min probes before a model can graduate |
 | `JARVIS_FLEET_GRAD_MIN_AST` | 0.8 | min code pass-rate to graduate |
 | `JARVIS_FLEET_GRAD_MARGIN` | 1.5 | × valid_tok_per_s the winner must beat the default |

--- a/docs/superpowers/specs/2026-06-19-sovereign-fleet-evaluator-design.md
+++ b/docs/superpowers/specs/2026-06-19-sovereign-fleet-evaluator-design.md
@@ -1,0 +1,274 @@
+# Sovereign Fleet Evaluator — Design Spec (2026-06-19)
+
+**Author:** O+V (Claude Opus 4.8) under operator authorization (Derek J. Russell)
+**Status:** Approved design — Option 1 (Advisory → auto-graduate)
+**Branch:** `fleet/sovereign-evaluator`
+
+---
+
+## 1. Problem (the genuine gap)
+
+The DoubleWord (DW) fleet selection layer is **already dynamic**: `dw_catalog_client.py`
+discovers `/v1/models` every 30 min (403/502-safe), `dw_promotion_ledger.py` runs a
+promote→demote "elites" FSM, and `dw_ttft_observer.py` computes per-model latency stats
+with dynamic-N math gates. The static `dw_models:` YAML arrays were already purged
+(Slice E, 2026-04-27); the catalog owns model *facts*, YAML owns *policy* only.
+
+**Every existing telemetry axis is latency-only and passive.** The ledger promotes a
+model when it is *fast and does not error*. **Nothing measures whether the output is
+valid** — AST-parseable code, or a clean discrete classification label.
+
+This is the exact, measured failure mode: `Qwen/Qwen3.5-397B-A17B-FP8` (the line-67
+cold-start default in `doubleword_provider.py`) is fast, never errors, and emits **zero
+valid code** — it reasons in prose. Under the current math it would *never be demoted*.
+The same blind spot would crown `Qwen3-14B` (returns empty strings on triage) as the
+triage model.
+
+**The missing axis is correctness.** We add an active quality-calibration layer on top
+of the existing discovery + latency skeleton — we do **not** rebuild discovery, the
+ledger, or the observer, and we do **not** re-introduce static model names into YAML.
+
+## 2. Goal
+
+A `FleetEvaluator` subsystem that, on idle cycles, proactively probes each
+**accessible** discovered DW model with a tiny, cost-bounded, **in-memory-only**
+quality battery, fuses the resulting syntax/label pass-rate with existing latency into a
+`valid_tok_per_s` composite (EWMA-smoothed), and feeds that score into
+`provider_topology.dw_models_for_route()` as a guarded re-rank — **advisory first**,
+then **auto-graduating** to authoritative once a soak proves the calibrated picks beat
+the 397B default. Demote the 397B cold-start default to the calibrated top coder.
+
+## 3. Non-goals (explicit, to prevent scope creep & duplication)
+
+- **NOT** a new discovery path — reuse `dw_catalog_client.load_cached_snapshot()`.
+- **NOT** a new latency tracker — read `dw_ttft_observer` / `dw_promotion_ledger` stats.
+- **NOT** a YAML rewrite — `dw_allowed`, `block_mode`, `fallback_tolerance`, cost
+  contracts stay 100% YAML-authored. We only re-order the already-ranked `dw_models`
+  tuple a route returns.
+- **NOT** code execution. **No `exec()`, no `eval()`, no file writes** of generated
+  payloads. Validation is `ast.parse()` on an in-memory string + AST-node inspection.
+- **NOT** an always-on benchmark — idle-gated + cost-capped + master-OFF by default.
+
+## 4. Architecture & units
+
+Four new modules under `backend/core/ouroboros/governance/`, plus one guarded call site
+in `provider_topology.py`. Each unit has one responsibility and a clean interface.
+
+```
+fleet_quality_battery.py   (pure)   prompts + in-memory validators (the AST armor)
+fleet_calibration_store.py (pure-ish) QualityScore + persistence + EWMA + rerank + graduation math
+fleet_evaluator.py         (async)  idle-driven driver: discover→probe→score→persist→graduate
+provider_topology.py       (1 line) guarded fleet rerank of dw_models_for_route() result
+```
+
+### 4.1 `fleet_quality_battery.py` — the AST-validation armor (pure, no I/O, no network)
+
+The "Ephemeral In-Memory Validation" the operator mandated. Zero execution.
+
+**Prompts (module constants):**
+- `CODEGEN_PROMPT` — a concrete multi-function refactor task whose answer is a Python
+  code block. (e.g. "implement `merge_intervals` + `interval_union` with docstrings,
+  handle empty list; return ONLY a python code block.")
+- `CLASSIFY_PROMPT` — a discrete-label task: classify a dev task as exactly one of
+  `NO_OP | REDIRECT | ENRICH | GENERATE`, "reply with ONLY the label."
+- `EXPECTED_LABEL = "ENRICH"` (the correct answer for the classify prompt).
+
+**Pure validators (each takes a string, returns a bool/float, never raises):**
+- `extract_code_block(text) -> str` — pull the fenced ```python block (or whole text).
+- `is_ast_valid(text) -> bool` — `extract_code_block` → `ast.parse(...)` in a
+  `try/except (SyntaxError, ValueError, RecursionError)`. **No exec.**
+- `has_semantic_placeholder(text) -> bool` — walk the parsed AST; True if it contains a
+  bare `Ellipsis` (`...`) constant as a statement body, a function whose body is only
+  `pass`/`...`/`raise NotImplementedError`, or a `# TODO`/`# implement` marker. A model
+  that emits `def f(): ...` "passes" `ast.parse` but is not real code — this catches it.
+- `code_quality_pass(text) -> bool` — `is_ast_valid(text) and not has_semantic_placeholder(text)`.
+- `label_adherence(text, expected) -> float` — 1.0 if the stripped, upper-cased output
+  is exactly the expected label (allowing surrounding whitespace/punctuation strip);
+  0.5 if expected token appears but with extra prose; 0.0 otherwise / empty.
+
+**Why a separate pure module:** the validators are the security boundary (the operator's
+"armor") and the part most worth exhaustively unit-testing in isolation. They must hold
+even if a probed model returns adversarial/hallucinatory text — `ast.parse` only ever
+builds a tree, never runs it.
+
+### 4.2 `fleet_calibration_store.py` — scores, persistence, EWMA, rerank & graduation math
+
+**`QualityScore` (frozen dataclass):**
+```
+model_id: str
+ast_pass_rate: float          # EWMA of code_quality_pass over codegen probes [0,1]
+label_adherence: float        # EWMA of label_adherence over classify probes  [0,1]
+ttft_ms: float                # EWMA first-token latency
+tok_per_s: float              # EWMA raw generation velocity
+sample_count: int             # total probes folded in
+updated_at: float             # unix ts (passed in by caller; module never calls time itself in pure paths)
+```
+Derived (pure properties / functions):
+- `valid_tok_per_s(score) -> float` = `tok_per_s * ast_pass_rate` (codegen routes).
+- `triage_fitness(score) -> float` = `label_adherence / max(ttft_ms, 1) * 1000`
+  (classification — adherence per second; rewards Gemma-class fast+correct).
+
+**EWMA merge (pure):**
+`ewma_update(prev, new, alpha) -> float` = `alpha*new + (1-alpha)*prev` (alpha from
+`JARVIS_FLEET_EWMA_ALPHA`, default 0.4). First sample (prev is None) → `new`. A single
+transient 502 (treated as a failed probe → 0.0 contribution) cannot zero a strong model.
+
+**Store (`FleetCalibrationStore`):**
+- Persist `.jarvis/fleet_calibration.json` (env `JARVIS_FLEET_CALIBRATION_PATH`), atomic
+  write (mirror `dw_promotion_ledger._atomic_write`).
+- `load()` / `save()` / `_ensure_loaded()` (lazy, never raises).
+- `record_probe(model_id, *, kind, code_pass=None, label_score=None, ttft_ms, tok_per_s, now)`
+  → folds one probe result into that model's `QualityScore` via EWMA.
+- `score(model_id) -> Optional[QualityScore]`.
+- `all_scores() -> Dict[str, QualityScore]`.
+
+**Rerank (pure, the binding math):**
+`fleet_rerank(route, ranked_models, scores, *, route_kind) -> Tuple[str,...]`
+- `route_kind` ∈ {`code`, `triage`} derived from route (IMMEDIATE/STANDARD/COMPLEX/
+  BACKGROUND/SPECULATIVE → `code`; the SemanticTriage caller path → `triage`).
+- Stable-sort the *input* `ranked_models` by the relevant composite descending
+  (`valid_tok_per_s` for code, `triage_fitness` for triage). Models with no score (never
+  benchmarked) keep their original relative order and sort *after* scored models only if
+  they have ≥1 sample; **unbenchmarked models retain catalog rank** (never demote a model
+  we haven't measured below one we have, on zero evidence — only reorder among measured).
+- Returns the input tuple unchanged if scores is empty / route_kind unknown / fewer than
+  2 scored models. Pure, deterministic, never raises.
+
+**Graduation math (pure):**
+`graduation_ready(scores, *, default_model, min_samples, min_margin) -> Optional[str]`
+- Returns the model id that should *replace* `default_model` as the cold-start coder iff:
+  a measured model has `sample_count >= min_samples`
+  (`JARVIS_FLEET_GRAD_MIN_SAMPLES`, default 5) **and** `code_quality` pass-rate ≥
+  `JARVIS_FLEET_GRAD_MIN_AST` (default 0.8) **and** its `valid_tok_per_s` exceeds the
+  default model's by `min_margin` factor (`JARVIS_FLEET_GRAD_MARGIN`, default 1.5×) —
+  *or* the default model itself scored `ast_pass_rate < 0.2` (the 397B case: it's
+  measured-bad, so any valid coder wins). Else `None`.
+
+### 4.3 `fleet_evaluator.py` — the async idle-driven driver
+
+**Gates:**
+- `fleet_evaluator_enabled()` — `JARVIS_FLEET_EVALUATOR_ENABLED` (default **false**).
+- `fleet_authoritative_enabled()` — `JARVIS_FLEET_EVALUATOR_AUTHORITATIVE` (default
+  **false**; flipped by auto-graduation).
+
+**Injectable model caller (testability + reuse):**
+```
+async def model_caller(model_id, messages, *, max_tokens) -> ProbeResult
+```
+`ProbeResult{text, ttft_ms, total_ms, completion_tokens, ok, error}`. The default
+implementation reuses the same DW HTTP idiom as `dw_catalog_client` (aiohttp POST to
+`/v1/chat/completions`, `JARVIS_FLEET_PROBE_TIMEOUT_S` default 60, key from the same env
+the catalog client uses). A `403/502/timeout` → `ProbeResult(ok=False)` → folds as a
+0.0 quality contribution (the access wall self-skips, never crashes the loop). Tests
+inject a fake caller — **no live network in unit tests.**
+
+**Cost bounding (reuse, don't reinvent):**
+- `max_tokens` per probe is small (`JARVIS_FLEET_PROBE_MAX_TOKENS`, default 512).
+- Per-cycle model cap (`JARVIS_FLEET_MAX_MODELS_PER_CYCLE`, default 4) — round-robins
+  across discovered models so each gets calibrated over several cycles.
+- Daily probe-spend cap tracked in the store (`JARVIS_FLEET_DAILY_USD_CAP`, default
+  0.50); estimated via DW per-token pricing already in the catalog `ModelCard`. Over cap
+  → cycle no-ops.
+- Only runs when idle (hook below).
+
+**Idle hook (reuse DreamEngine / IdleDetector):**
+`maybe_calibrate(now)` is invoked from the existing idle/background path. It:
+1. returns immediately unless `fleet_evaluator_enabled()`,
+2. checks idle + daily cap,
+3. loads the catalog snapshot (`load_cached_snapshot()`); if None → no-op,
+4. picks the next ≤N models (round-robin, prefer never-/least-recently-benchmarked),
+5. for each: run codegen probe + classify probe via `model_caller`, validate in-memory
+   via `fleet_quality_battery`, `store.record_probe(...)`,
+6. log `[FleetEvaluator] model=X ast=.. label=.. vtps=.. samples=N`,
+7. call `_maybe_graduate()`.
+
+**Auto-graduation (`_maybe_graduate`):**
+- Compute `graduation_ready(store.all_scores(), default_model=<line-67 default>, ...)`.
+- If a winner is found **and** not already authoritative: log the proposed flip
+  (advisory), and if the winner has held across `JARVIS_FLEET_GRAD_STABLE_CYCLES`
+  (default 2) consecutive evaluations, persist `JARVIS_FLEET_EVALUATOR_AUTHORITATIVE=true`
+  via the existing bounded `.env` writer (the same credential-safe persist used by the
+  graduation orchestrator — **reuse, do not re-author**), and record the chosen coder.
+- **Advisory mode = compute + log only; routing unchanged.** Authoritative flips the
+  rerank live.
+
+**Observability (Manifesto §7):** structured log lines + best-effort SSE
+`fleet_calibrated` / `fleet_graduated` via the existing event broker (positional
+`publish(event_type, op_id, payload)` signature — the real one, learned the hard way).
+
+### 4.4 Binding in `provider_topology.dw_models_for_route()` (one guarded block)
+
+At the **end** of `dw_models_for_route`, before returning the resolved `ranked`/`effective`
+tuple, add a single guarded re-rank:
+```python
+if fleet_authoritative_enabled():
+    ranked = fleet_apply_rerank(route, ranked)   # thin adapter: load store + route_kind + fleet_rerank
+return ranked
+```
+`fleet_apply_rerank` lives in `fleet_calibration_store.py` (loads the store, derives
+route_kind, calls pure `fleet_rerank`, returns input unchanged on any error). When
+`JARVIS_FLEET_EVALUATOR_AUTHORITATIVE` is false (default) the call is never made →
+**byte-identical legacy behavior.** The 397B-default demotion is automatic: once
+authoritative, the calibrated top coder sorts above 397B in every code route, and the
+cold-start default lookup consults the store's graduated coder.
+
+## 5. Safety, fail-soft & invariants
+
+- **No execution of model output, ever** — `ast.parse` only. (Operator armor mandate.)
+- **OFF is byte-identical** — every new path is behind `JARVIS_FLEET_EVALUATOR_ENABLED`
+  (compute) and `JARVIS_FLEET_EVALUATOR_AUTHORITATIVE` (routing). Both default false.
+- **Fail-soft everywhere** — every public method swallows exceptions and returns a safe
+  default (unchanged ctx / empty / None). A broken probe never wedges the loop.
+- **No new discovery / ledger / observer** — reuse the graduated subsystems.
+- **YAML policy untouched** — only the ranked tuple order changes.
+- **Idle + cost capped** — cannot starve the host or burn quota; respects daily USD cap.
+- **EWMA decay** — transient API flakes can't permanently mis-rank a model.
+- **Unbenchmarked models keep catalog rank** — zero-evidence never demotes.
+
+## 6. Testing strategy (TDD, all offline)
+
+- `fleet_quality_battery`: AST-valid pass, syntax-fail reject, placeholder (`def f(): ...`)
+  reject, `raise NotImplementedError` reject, label exact-match / prose / empty.
+  Adversarial input (`os.system('rm -rf /')` as a *string*) → parses to a tree, is NOT
+  executed (assert no side effect), classified by validity only.
+- `fleet_calibration_store`: EWMA merge math, first-sample, persistence round-trip,
+  rerank reorders measured-good above measured-bad, leaves unbenchmarked alone, returns
+  input on <2 scored, graduation_ready fires on 397B-bad case + margin case + returns
+  None below thresholds.
+- `fleet_evaluator`: fake `model_caller` returning (valid coder / 397B-style prose /
+  502) → store reflects correct scores; daily-cap no-op; disabled → no probes; idle-gate;
+  `_maybe_graduate` flips only after stable cycles; SSE publish uses positional signature.
+- `provider_topology`: authoritative-off → `dw_models_for_route` byte-identical;
+  authoritative-on with a store → tuple reordered by quality; error in rerank → original
+  tuple returned.
+
+Verification in this sandbox is via `ast.parse` / grep / `pytest --collect-only`
+(the full organism cannot be imported here — split-brain guard). Live unit tests run
+green; the live calibration soak runs on a real host.
+
+## 7. Deployment / soak
+
+1. Land all units (gated OFF — byte-identical, safe to merge).
+2. Arm `JARVIS_FLEET_EVALUATOR_ENABLED=true` (advisory) on a real host soak.
+3. Watch logs: evaluator must (a) identify 397B `ast_pass_rate≈0` and (b) rank
+   DeepSeek-V4-Flash's `valid_tok_per_s` highest among coders.
+4. Once `graduation_ready` returns the Flash coder for ≥2 stable cycles, auto-graduation
+   persists `JARVIS_FLEET_EVALUATOR_AUTHORITATIVE=true` → routing live, 397B demoted.
+
+## 8. Flag summary (all `JARVIS_FLEET_*`, registered in FlagRegistry)
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `JARVIS_FLEET_EVALUATOR_ENABLED` | false | master: run calibration at all |
+| `JARVIS_FLEET_EVALUATOR_AUTHORITATIVE` | false | quality scores re-rank live routing (auto-flipped) |
+| `JARVIS_FLEET_EWMA_ALPHA` | 0.4 | EWMA smoothing factor |
+| `JARVIS_FLEET_PROBE_MAX_TOKENS` | 512 | per-probe token cap |
+| `JARVIS_FLEET_PROBE_TIMEOUT_S` | 60 | per-probe HTTP timeout |
+| `JARVIS_FLEET_MAX_MODELS_PER_CYCLE` | 4 | models calibrated per idle cycle |
+| `JARVIS_FLEET_DAILY_USD_CAP` | 0.50 | daily probe spend ceiling |
+| `JARVIS_FLEET_GRAD_MIN_SAMPLES` | 5 | min probes before a model can graduate |
+| `JARVIS_FLEET_GRAD_MIN_AST` | 0.8 | min code pass-rate to graduate |
+| `JARVIS_FLEET_GRAD_MARGIN` | 1.5 | × valid_tok_per_s the winner must beat the default |
+| `JARVIS_FLEET_GRAD_STABLE_CYCLES` | 2 | consecutive wins before auto-flip |
+| `JARVIS_FLEET_CALIBRATION_PATH` | `.jarvis/fleet_calibration.json` | store path |
+```

--- a/scripts/fleet_first_calibration.py
+++ b/scripts/fleet_first_calibration.py
@@ -1,0 +1,94 @@
+"""First live FleetEvaluator calibration loop (operator mandate #4).
+
+Runs the ACTUAL subsystem code (not a manual probe) against the live DW API in
+advisory mode over the accessible roster, then prints per-model QualityScores,
+the would-be re-rank for the STANDARD code route, and the graduation verdict.
+
+Run: DOUBLEWORD_API_KEY=... PYTHONPATH=. python3 scripts/fleet_first_calibration.py
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+from backend.core.ouroboros.governance.fleet_evaluator import (
+    FleetEvaluator,
+    default_model_caller,
+    _grad_margin,
+)
+from backend.core.ouroboros.governance import fleet_calibration_store as s
+
+ROSTER = [
+    "deepseek-ai/DeepSeek-V4-Flash",
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "openai/gpt-oss-120b",
+    "zai-org/GLM-5.2",
+    "google/gemma-4-31B-it",
+    "Qwen/Qwen3.5-397B-A17B-FP8",   # the incumbent default we want to demote
+]
+DEFAULT_MODEL = "Qwen/Qwen3.5-397B-A17B-FP8"
+
+
+async def main() -> None:
+    os.environ["JARVIS_FLEET_EVALUATOR_ENABLED"] = "true"
+    os.environ.setdefault("JARVIS_FLEET_CALIBRATION_PATH", "/tmp/fleet_first_calibration.json")
+    os.environ.setdefault("JARVIS_FLEET_PROBE_TIMEOUT_S", "90")
+    # Leave JARVIS_FLEET_PROBE_MAX_TOKENS unset so the subsystem default
+    # (2048) applies — 512 truncates the two-function codegen battery.
+
+    store = s.FleetCalibrationStore()
+    ev = FleetEvaluator(
+        model_caller=default_model_caller,
+        store=store,
+        idle_check=lambda: True,
+        default_model=DEFAULT_MODEL,
+    )
+    from backend.core.ouroboros.governance.fleet_evaluator import _probe_max_tokens
+    print(
+        f"probing {len(ROSTER)} models "
+        f"(codegen + classify each, max_tokens={_probe_max_tokens()})...\n"
+    )
+    await ev.calibrate_models(ROSTER)
+
+    scores = store.all_scores()
+    print(f"{'model':42} {'ast':>5} {'label':>6} {'tok/s':>7} {'vtps':>7} {'n':>2}")
+    print("-" * 76)
+    for m in ROSTER:
+        sc = scores.get(m)
+        if sc is None:
+            print(f"{m:42} {'--- no result (probe failed) ---':>30}")
+            continue
+        print(
+            f"{m:42} {sc.ast_pass_rate:5.2f} {sc.label_adherence:6.2f} "
+            f"{sc.tok_per_s:7.1f} {s.valid_tok_per_s(sc):7.1f} {sc.sample_count:2d}"
+        )
+
+    print("\n--- STANDARD (code) route re-rank by valid_tok_per_s ---")
+    reranked = s.fleet_rerank(
+        "standard", tuple(ROSTER), scores, route_kind="code"
+    )
+    for i, m in enumerate(reranked, 1):
+        print(f"  {i}. {m}")
+
+    print("\n--- triage route re-rank by triage_fitness ---")
+    reranked_t = s.fleet_rerank(
+        "semantic_triage", tuple(ROSTER), scores, route_kind="triage"
+    )
+    for i, m in enumerate(reranked_t, 1):
+        print(f"  {i}. {m}")
+
+    winner = s.graduation_ready(
+        scores,
+        default_model=DEFAULT_MODEL,
+        min_samples=1,             # one calibration cycle for this demo
+        min_margin=_grad_margin(),
+    )
+    print(
+        f"\ngraduation verdict (vs default {DEFAULT_MODEL}): "
+        f"{'GRADUATE -> ' + winner if winner else 'no graduation yet'}"
+    )
+    print(f"daily probe spend so far: ${store.spend_today(__import__('time').time()):.5f}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/fleet_soak_multicycle.py
+++ b/scripts/fleet_soak_multicycle.py
@@ -1,0 +1,226 @@
+"""Deterministic multi-cycle EWMA-stability soak for the FleetEvaluator.
+
+Runs the REAL FleetEvaluator + FleetCalibrationStore + fleet_rerank across N
+mock operational cycles. Only the model_caller is mocked — with a controlled
+schedule that injects a transient latency spike (one cycle) and a transient
+502 (one cycle) so we can *prove* the EWMA absorbs them without the routing
+rank flapping. No network, no secrets, no cost — reproducible in CI.
+
+Profiles (steady-state valid_tok_per_s = tok/s x ast_pass_rate):
+  fast-valid (gpt-oss-120b-like)  tps 120, valid code, clean label  -> vtps ~120
+  mid-valid  (deepseek-like)      tps  80, valid code, clean label  -> vtps  ~80
+  slow-valid (gemma-like)         tps  16, valid code, clean label  -> vtps  ~16
+  reasoner   (qwen-397b-like)     tps  66, NO code block, prose lbl -> vtps   ~0
+
+Injected perturbations:
+  cycle 6: fast-valid latency SPIKE -> raw tps 40 for that cycle only.
+           (Without EWMA: 40 < mid's 80 => rank flip. With EWMA(0.4): the
+            blended value stays above mid => NO flip. This is the proof.)
+  cycle 8: mid-valid transient 502 (probe ok=False) -> ast dips one cycle.
+
+Asserts, over the steady-state window (cycle >= WARMUP):
+  * the #1 code-route slot never flaps (always fast-valid),
+  * the last slot is always the reasoner,
+  * no top-slot flip on the spike/502 cycles.
+Exit 1 (CI red) on any flap. Writes a markdown report to argv[1] (or stdout).
+
+Run: PYTHONPATH=. python3 scripts/fleet_soak_multicycle.py [report.md]
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+
+# Force the master switch on for the soak (the evaluator gates probes on it).
+os.environ["JARVIS_FLEET_EVALUATOR_ENABLED"] = "true"
+os.environ.setdefault(
+    "JARVIS_FLEET_CALIBRATION_PATH",
+    os.path.join(tempfile.gettempdir(), "fleet_soak_store.json"),
+)
+os.environ.setdefault("JARVIS_FLEET_EWMA_ALPHA", "0.4")
+
+from backend.core.ouroboros.governance.fleet_evaluator import (  # noqa: E402
+    FleetEvaluator,
+    ProbeResult,
+)
+from backend.core.ouroboros.governance import fleet_calibration_store as s  # noqa: E402
+
+CYCLES = 12
+WARMUP = 4  # ranks asserted stable from this cycle onward
+SPIKE_CYCLE = 6
+FIVEOHTWO_CYCLE = 8
+
+VALID_CODE = (
+    "```python\n"
+    "def merge_intervals(intervals):\n"
+    "    '''Merge overlapping intervals.'''\n"
+    "    if not intervals:\n"
+    "        return []\n"
+    "    out = [intervals[0]]\n"
+    "    for a, b in intervals[1:]:\n"
+    "        if a <= out[-1][1]:\n"
+    "            out[-1][1] = max(out[-1][1], b)\n"
+    "        else:\n"
+    "            out.append([a, b])\n"
+    "    return out\n"
+    "```"
+)
+PROSE = "Let me reason about intervals. First, consider the sorting step..."
+
+# model_id -> (base_tps, emits_valid_code, clean_label)
+PROFILES = {
+    "gpt-oss-120b": (120.0, True, True),
+    "DeepSeek-V4-Flash": (80.0, True, True),
+    "gemma-4-31B": (16.0, True, True),
+    "Qwen3.5-397B": (66.0, False, False),
+}
+MODELS = list(PROFILES)
+_state = {"cycle": 0}
+
+
+def _make_caller():
+    async def caller(model_id, messages, *, max_tokens):
+        cycle = _state["cycle"]
+        base_tps, valid_code, clean_label = PROFILES[model_id]
+        is_code = "code block" in messages[-1]["content"].lower()
+
+        # Transient 502 on mid-valid (affects whichever probe lands this cycle).
+        if model_id == "DeepSeek-V4-Flash" and cycle == FIVEOHTWO_CYCLE:
+            return ProbeResult("", 0.0, 0.0, 0, False, "http_502")
+
+        tps = base_tps
+        # Latency spike on the fast coder's CODEGEN probe for one cycle: the
+        # raw value (40) is BELOW the mid coder's 80 — without smoothing this
+        # would flip the #1 rank. EWMA must absorb it (proves the property).
+        if model_id == "gpt-oss-120b" and cycle == SPIKE_CYCLE and is_code:
+            tps = 40.0
+
+        # Encode target tps as completion_tokens over a 1000ms window so the
+        # evaluator's tok_per_s = completion_tokens / (total_ms/1000) == tps.
+        completion_tokens = int(tps)
+        total_ms = 1000.0
+        if is_code:
+            text = VALID_CODE if valid_code else PROSE
+        else:
+            text = "ENRICH" if clean_label else PROSE
+        return ProbeResult(
+            text=text, ttft_ms=total_ms, total_ms=total_ms,
+            completion_tokens=completion_tokens, ok=True, error="",
+        )
+
+    return caller
+
+
+_SPARK = "▁▂▃▄▅▆▇█"
+
+
+def _sparkline(vals):
+    lo, hi = min(vals), max(vals)
+    if hi - lo < 1e-9:
+        return _SPARK[len(_SPARK) // 2] * len(vals)
+    out = []
+    for v in vals:
+        idx = int((v - lo) / (hi - lo) * (len(_SPARK) - 1))
+        out.append(_SPARK[idx])
+    return "".join(out)
+
+
+async def main() -> int:
+    # Fresh store each run (deterministic).
+    try:
+        os.unlink(os.environ["JARVIS_FLEET_CALIBRATION_PATH"])
+    except OSError:
+        pass
+    store = s.FleetCalibrationStore()
+    ev = FleetEvaluator(
+        model_caller=_make_caller(), store=store,
+        idle_check=lambda: True, clock=lambda: float(_state["cycle"]),
+        default_model="Qwen3.5-397B",
+    )
+
+    rank_history = []     # per-cycle code-route order
+    vtps_history = {m: [] for m in MODELS}
+    top_slot = []
+
+    for c in range(1, CYCLES + 1):
+        _state["cycle"] = c
+        await ev.calibrate_models(MODELS)
+        scores = store.all_scores()
+        order = list(s.fleet_rerank("standard", tuple(MODELS), scores, route_kind="code"))
+        rank_history.append((c, order))
+        top_slot.append(order[0])
+        for m in MODELS:
+            sc = scores.get(m)
+            vtps_history[m].append(s.valid_tok_per_s(sc) if sc else 0.0)
+
+    # ---- assertions (steady-state stability) ----
+    steady = [(c, o) for (c, o) in rank_history if c >= WARMUP]
+    flaps = []
+    expected_top = "gpt-oss-120b"
+    expected_last = "Qwen3.5-397B"
+    for c, o in steady:
+        if o[0] != expected_top:
+            flaps.append(f"cycle {c}: top slot was {o[0]} (expected {expected_top})")
+        if o[-1] != expected_last:
+            flaps.append(f"cycle {c}: last slot was {o[-1]} (expected {expected_last})")
+
+    # ---- report ----
+    lines = []
+    lines.append("## 🧬 Fleet Evaluator — multi-cycle EWMA-stability soak")
+    lines.append("")
+    lines.append(
+        f"Deterministic clean-room soak on `ubuntu-latest` — **{CYCLES} cycles**, "
+        f"EWMA α={s._alpha()}, real `FleetEvaluator`/store/`fleet_rerank`, mocked "
+        "caller with an injected codegen-probe latency **spike** (cycle "
+        f"{SPIKE_CYCLE}: fast coder raw throughput → 40, *below* the mid coder's "
+        f"80 — would flip the rank unsmoothed) and a transient **502** "
+        f"(cycle {FIVEOHTWO_CYCLE}, mid coder)."
+    )
+    lines.append("")
+    lines.append("### valid_tok_per_s convergence (EWMA-smoothed)")
+    lines.append("")
+    lines.append("| model | trace | final |")
+    lines.append("|---|---|---|")
+    for m in MODELS:
+        vh = vtps_history[m]
+        lines.append(f"| `{m}` | `{_sparkline(vh)}` | {vh[-1]:.1f} |")
+    lines.append("")
+    lines.append("### per-cycle code-route rank order")
+    lines.append("")
+    lines.append("| cycle | #1 | #2 | #3 | #4 | note |")
+    lines.append("|---|---|---|---|---|---|")
+    for c, o in rank_history:
+        note = ""
+        if c == SPIKE_CYCLE:
+            note = "⚡ fast-coder latency spike"
+        elif c == FIVEOHTWO_CYCLE:
+            note = "🔌 mid-coder 502"
+        lines.append(f"| {c} | {o[0]} | {o[1]} | {o[2]} | {o[3]} | {note} |")
+    lines.append("")
+    settled = rank_history[-1][1]
+    lines.append(f"**Settled routing array (code route):** `{settled}`")
+    lines.append("")
+    if flaps:
+        lines.append("### ❌ VERDICT: RANK FLAP DETECTED")
+        for f in flaps:
+            lines.append(f"- {f}")
+    else:
+        lines.append(
+            "### ✅ VERDICT: STABLE — no top/last-slot flap across the "
+            f"steady-state window (cycles {WARMUP}–{CYCLES}), including the "
+            "spike and 502 cycles. EWMA absorbed both transients; the routing "
+            "rank did not flap."
+        )
+
+    report = "\n".join(lines)
+    if len(sys.argv) > 1:
+        with open(sys.argv[1], "w", encoding="utf-8") as fh:
+            fh.write(report + "\n")
+    print(report)
+    return 1 if flaps else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/governance/test_fleet_calibration_store.py
+++ b/tests/governance/test_fleet_calibration_store.py
@@ -1,0 +1,84 @@
+# tests/governance/test_fleet_calibration_store.py
+from __future__ import annotations
+from backend.core.ouroboros.governance import fleet_calibration_store as s
+
+
+def test_ewma_first_sample_and_update():
+    assert s.ewma_update(None, 1.0, 0.4) == 1.0
+    assert abs(s.ewma_update(0.0, 1.0, 0.5) - 0.5) < 1e-9
+
+
+def test_quality_score_composites():
+    sc = s.QualityScore(model_id="m", ast_pass_rate=0.5, label_adherence=1.0,
+                        ttft_ms=100.0, tok_per_s=80.0, sample_count=5, updated_at=1.0)
+    assert abs(s.valid_tok_per_s(sc) - 40.0) < 1e-9         # 80 * 0.5
+    assert s.triage_fitness(sc) > 0
+
+
+def test_store_record_and_persist_roundtrip(tmp_path, monkeypatch):
+    p = tmp_path / "fleet_calibration.json"
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(p))
+    st = s.FleetCalibrationStore()
+    st.record_probe("deepseek", kind="code", code_pass=True, ttft_ms=200, tok_per_s=90, now=1.0)
+    st.record_probe("deepseek", kind="triage", label_score=1.0, ttft_ms=200, tok_per_s=90, now=2.0)
+    st.save()
+    st2 = s.FleetCalibrationStore()
+    sc = st2.score("deepseek")
+    assert sc is not None and sc.sample_count == 2 and sc.ast_pass_rate > 0
+
+
+def test_rerank_orders_measured_good_above_bad():
+    scores = {
+        "qwen397": s.QualityScore("qwen397", 0.0, 0.0, 150, 120, 8, 1.0),   # fast, no valid code
+        "deepseek": s.QualityScore("deepseek", 1.0, 1.0, 200, 90, 8, 1.0),  # slower, valid
+    }
+    out = s.fleet_rerank("standard", ("qwen397", "deepseek"), scores, route_kind="code")
+    assert out[0] == "deepseek"      # valid_tok_per_s: deepseek 90 > qwen397 0
+
+
+def test_rerank_leaves_unbenchmarked_alone_and_noop_on_thin_data():
+    scores = {"deepseek": s.QualityScore("deepseek", 1.0, 1.0, 200, 90, 8, 1.0)}
+    # only 1 scored model -> input returned unchanged
+    assert s.fleet_rerank("standard", ("qwen397", "deepseek"), scores, route_kind="code") == ("qwen397", "deepseek")
+    assert s.fleet_rerank("standard", ("a", "b"), {}, route_kind="code") == ("a", "b")
+
+
+def test_rerank_preserves_unscored_positions():
+    # good(scored) should rise above bad(scored), but unscored 'x' keeps its slot index.
+    scores = {
+        "bad": s.QualityScore("bad", 0.0, 0.0, 100, 120, 5, 1.0),
+        "good": s.QualityScore("good", 1.0, 1.0, 200, 90, 5, 1.0),
+    }
+    out = s.fleet_rerank("standard", ("bad", "x", "good"), scores, route_kind="code")
+    assert out[1] == "x"                      # unscored model holds its index
+    assert out.index("good") < out.index("bad")
+
+
+def test_graduation_ready_fires_on_measured_bad_default():
+    scores = {
+        "qwen397": s.QualityScore("qwen397", 0.05, 0.0, 150, 120, 8, 1.0),
+        "deepseek": s.QualityScore("deepseek", 0.95, 1.0, 200, 90, 8, 1.0),
+    }
+    winner = s.graduation_ready(scores, default_model="qwen397",
+                                min_samples=5, min_margin=1.5)
+    assert winner == "deepseek"
+
+
+def test_graduation_ready_none_below_thresholds():
+    scores = {"deepseek": s.QualityScore("deepseek", 0.95, 1.0, 200, 90, 2, 1.0)}  # too few samples
+    assert s.graduation_ready(scores, default_model="qwen397", min_samples=5, min_margin=1.5) is None
+
+
+def test_graduation_margin_gate_when_default_is_ok():
+    # default is decent (ast 0.6, vtps = 120*0.6 = 72); candidate vtps must beat 1.5x = 108.
+    scores = {
+        "okdefault": s.QualityScore("okdefault", 0.6, 0.0, 150, 120, 8, 1.0),  # vtps 72
+        "weakwin": s.QualityScore("weakwin", 0.85, 1.0, 200, 100, 8, 1.0),     # vtps 85 < 108 -> no
+    }
+    assert s.graduation_ready(scores, default_model="okdefault", min_samples=5, min_margin=1.5) is None
+
+
+def test_apply_rerank_failsoft_returns_input_on_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "none.json"))
+    # no store data -> input unchanged
+    assert s.fleet_apply_rerank("standard", ("a", "b")) == ("a", "b")

--- a/tests/governance/test_fleet_calibration_store.py
+++ b/tests/governance/test_fleet_calibration_store.py
@@ -82,3 +82,22 @@ def test_apply_rerank_failsoft_returns_input_on_error(tmp_path, monkeypatch):
     monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "none.json"))
     # no store data -> input unchanged
     assert s.fleet_apply_rerank("standard", ("a", "b")) == ("a", "b")
+
+
+def test_spend_ledger_roundtrip_and_daily_reset(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    st = s.FleetCalibrationStore()
+    day1 = 1_700_000_000.0          # some fixed unix ts
+    day2 = day1 + 86_400.0          # +1 UTC day
+    assert st.spend_today(day1) == 0.0
+    st.add_spend(0.01, now=day1)
+    st.add_spend(0.02, now=day1)
+    assert abs(st.spend_today(day1) - 0.03) < 1e-9
+    st.save()
+    # reload persists the ledger
+    st2 = s.FleetCalibrationStore()
+    assert abs(st2.spend_today(day1) - 0.03) < 1e-9
+    # next UTC day -> rolling reset
+    assert st2.spend_today(day2) == 0.0
+    st2.add_spend(0.005, now=day2)
+    assert abs(st2.spend_today(day2) - 0.005) < 1e-9

--- a/tests/governance/test_fleet_evaluator.py
+++ b/tests/governance/test_fleet_evaluator.py
@@ -107,3 +107,35 @@ async def test_graduation_flips_after_stable_cycles(monkeypatch, tmp_path):
     assert flips == []
     ev._maybe_graduate(now=2.0)   # cycle 2 -> stable -> flip
     assert flips and flips[-1][0] == "JARVIS_FLEET_EVALUATOR_AUTHORITATIVE" and flips[-1][1] == "true"
+
+
+@pytest.mark.asyncio
+async def test_daily_cap_skips_calibration(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    monkeypatch.setenv("JARVIS_FLEET_DAILY_USD_CAP", "0.01")
+    store = s.FleetCalibrationStore()
+    store.add_spend(0.02, now=1.0)        # already over the $0.01 cap today
+    calls = []
+    async def spy(model_id, messages, *, max_tokens):
+        calls.append(model_id)
+        return fe.ProbeResult("", 0, 0, 0, False, "")
+    ev = fe.FleetEvaluator(model_caller=spy, store=store, idle_check=lambda: True,
+                           clock=lambda: 1.0, snapshot_loader=lambda: ["m"])
+    await ev.maybe_calibrate(now=1.0)
+    assert calls == []                    # over cap -> zero probes
+
+
+@pytest.mark.asyncio
+async def test_spend_accumulates_after_calibrate(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    monkeypatch.setenv("JARVIS_FLEET_PROBE_USD_PER_MTOK", "1.0")
+    store = s.FleetCalibrationStore()
+    ev = fe.FleetEvaluator(model_caller=_fake_caller("good"), store=store,
+                           idle_check=lambda: True, clock=lambda: 1.0)
+    await ev.calibrate_models(["deepseek"])
+    # 'good' caller returns 80 completion tokens per probe x 2 probes = 160 tok
+    # at $1.0/Mtok => 160/1e6 = 0.00016 USD
+    assert store.spend_today(1.0) > 0.0
+    assert abs(store.spend_today(1.0) - 160 / 1_000_000.0) < 1e-9

--- a/tests/governance/test_fleet_evaluator.py
+++ b/tests/governance/test_fleet_evaluator.py
@@ -1,0 +1,109 @@
+# tests/governance/test_fleet_evaluator.py
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import fleet_evaluator as fe
+from backend.core.ouroboros.governance import fleet_calibration_store as s
+
+
+def _fake_caller(behavior):
+    async def call(model_id, messages, *, max_tokens):
+        is_code = "code block" in messages[-1]["content"].lower()
+        if behavior == "good":
+            text = "```python\ndef merge_intervals(x):\n    '''m'''\n    return sorted(x)\n```" if is_code else "ENRICH"
+            return fe.ProbeResult(text=text, ttft_ms=200, total_ms=1000, completion_tokens=80, ok=True, error="")
+        if behavior == "prose":  # the 397B failure mode
+            return fe.ProbeResult(text="Let me think about intervals...", ttft_ms=150, total_ms=4000, completion_tokens=900, ok=True, error="")
+        return fe.ProbeResult(text="", ttft_ms=0, total_ms=0, completion_tokens=0, ok=False, error="HTTP 502")
+    return call
+
+
+def test_disabled_is_noop(monkeypatch):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "false")
+    assert fe.fleet_evaluator_enabled() is False
+
+
+def test_authoritative_default_false(monkeypatch):
+    monkeypatch.delenv("JARVIS_FLEET_EVALUATOR_AUTHORITATIVE", raising=False)
+    assert fe.fleet_authoritative_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_good_model_scores_high(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    store = s.FleetCalibrationStore()
+    ev = fe.FleetEvaluator(model_caller=_fake_caller("good"), store=store,
+                           idle_check=lambda: True, clock=lambda: 1.0)
+    await ev.calibrate_models(["deepseek"])
+    sc = store.score("deepseek")
+    assert sc.ast_pass_rate > 0.9 and sc.label_adherence > 0.9
+
+
+@pytest.mark.asyncio
+async def test_prose_model_scores_zero_ast(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    store = s.FleetCalibrationStore()
+    ev = fe.FleetEvaluator(model_caller=_fake_caller("prose"), store=store,
+                           idle_check=lambda: True, clock=lambda: 1.0)
+    await ev.calibrate_models(["qwen397"])
+    assert store.score("qwen397").ast_pass_rate < 0.1   # the diagnosed bug, now measured
+
+
+@pytest.mark.asyncio
+async def test_502_is_failsoft(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    store = s.FleetCalibrationStore()
+    ev = fe.FleetEvaluator(model_caller=_fake_caller("502"), store=store,
+                           idle_check=lambda: True, clock=lambda: 1.0)
+    await ev.calibrate_models(["devstral"])     # must NOT raise
+    assert store.score("devstral").ast_pass_rate == 0.0
+
+
+@pytest.mark.asyncio
+async def test_maybe_calibrate_skips_when_not_idle(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    store = s.FleetCalibrationStore()
+    calls = []
+    async def spy(model_id, messages, *, max_tokens):
+        calls.append(model_id); return fe.ProbeResult("", 0, 0, 0, False, "")
+    ev = fe.FleetEvaluator(model_caller=spy, store=store, idle_check=lambda: False,
+                           clock=lambda: 1.0, snapshot_loader=lambda: ["m"])
+    await ev.maybe_calibrate(now=1.0)
+    assert calls == []     # not idle -> no probes
+
+
+@pytest.mark.asyncio
+async def test_maybe_calibrate_disabled_skips(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    calls = []
+    async def spy(model_id, messages, *, max_tokens):
+        calls.append(model_id); return fe.ProbeResult("", 0, 0, 0, False, "")
+    ev = fe.FleetEvaluator(model_caller=spy, idle_check=lambda: True,
+                           clock=lambda: 1.0, snapshot_loader=lambda: ["m"])
+    await ev.maybe_calibrate(now=1.0)
+    assert calls == []     # master OFF -> no probes
+
+
+@pytest.mark.asyncio
+async def test_graduation_flips_after_stable_cycles(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    monkeypatch.setenv("JARVIS_FLEET_GRAD_MIN_SAMPLES", "1")
+    monkeypatch.setenv("JARVIS_FLEET_GRAD_STABLE_CYCLES", "2")
+    store = s.FleetCalibrationStore()
+    # pre-seed: a measured-bad default + a measured-good coder
+    store.record_probe("qwen397", kind="code", code_pass=False, ttft_ms=150, tok_per_s=120, now=1.0)
+    store.record_probe("deepseek", kind="code", code_pass=True, ttft_ms=200, tok_per_s=90, now=1.0)
+    flips = []
+    ev = fe.FleetEvaluator(model_caller=_fake_caller("good"), store=store,
+                           idle_check=lambda: True, clock=lambda: 1.0,
+                           default_model="qwen397",
+                           flag_persister=lambda name, val: flips.append((name, val)))
+    ev._maybe_graduate(now=1.0)   # cycle 1 -> proposes, not yet stable
+    assert flips == []
+    ev._maybe_graduate(now=2.0)   # cycle 2 -> stable -> flip
+    assert flips and flips[-1][0] == "JARVIS_FLEET_EVALUATOR_AUTHORITATIVE" and flips[-1][1] == "true"

--- a/tests/governance/test_fleet_quality_battery.py
+++ b/tests/governance/test_fleet_quality_battery.py
@@ -1,0 +1,58 @@
+# tests/governance/test_fleet_quality_battery.py
+from __future__ import annotations
+from backend.core.ouroboros.governance import fleet_quality_battery as b
+
+
+def test_prompts_exist_and_are_strings():
+    assert isinstance(b.CODEGEN_PROMPT, str) and "ONLY" in b.CODEGEN_PROMPT.upper()
+    assert isinstance(b.CLASSIFY_PROMPT, str)
+    assert b.EXPECTED_LABEL == "ENRICH"
+
+
+def test_extract_code_block_fenced_and_bare():
+    assert "def f" in b.extract_code_block("```python\ndef f():\n    return 1\n```")
+    assert "def g" in b.extract_code_block("def g():\n    return 2")
+
+
+def test_is_ast_valid_true_for_real_code():
+    assert b.is_ast_valid("```python\ndef merge(x):\n    return sorted(x)\n```") is True
+
+
+def test_is_ast_valid_false_for_syntax_error():
+    assert b.is_ast_valid("```python\ndef merge(x):\n    return sorted(\n```") is False
+
+
+def test_placeholder_ellipsis_body_detected():
+    assert b.has_semantic_placeholder("```python\ndef f():\n    ...\n```") is True
+
+
+def test_placeholder_notimplemented_detected():
+    assert b.has_semantic_placeholder(
+        "```python\ndef f():\n    raise NotImplementedError\n```") is True
+
+
+def test_real_code_has_no_placeholder():
+    assert b.has_semantic_placeholder(
+        "```python\ndef f(x):\n    '''doc'''\n    return x + 1\n```") is False
+
+
+def test_code_quality_pass_combines_both():
+    assert b.code_quality_pass("```python\ndef f(x):\n    return x*2\n```") is True
+    assert b.code_quality_pass("```python\ndef f():\n    ...\n```") is False
+    assert b.code_quality_pass("not code at all !!!(") is False
+
+
+def test_label_adherence_exact_prose_empty():
+    assert b.label_adherence("ENRICH", "ENRICH") == 1.0
+    assert b.label_adherence("  enrich \n", "ENRICH") == 1.0
+    assert 0.0 < b.label_adherence("The label is ENRICH because...", "ENRICH") < 1.0
+    assert b.label_adherence("", "ENRICH") == 0.0
+    assert b.label_adherence("NO_OP", "ENRICH") == 0.0
+
+
+def test_adversarial_string_is_parsed_not_executed(tmp_path):
+    # A malicious payload as a STRING parses to a tree but must never run.
+    canary = tmp_path / "canary.txt"
+    payload = f"```python\nimport os\nos.system('touch {canary}')\n```"
+    assert b.is_ast_valid(payload) is True       # syntactically valid
+    assert canary.exists() is False              # but NEVER executed

--- a/tests/governance/test_fleet_topology_binding.py
+++ b/tests/governance/test_fleet_topology_binding.py
@@ -1,0 +1,58 @@
+# tests/governance/test_fleet_topology_binding.py
+from __future__ import annotations
+
+
+def test_dw_models_for_route_guard_present_and_gated():
+    import backend.core.ouroboros.governance.provider_topology as pt
+    src = open(pt.__file__).read()
+    assert "_fleet_guarded" in src
+    assert "fleet_authoritative_enabled" in src
+    assert "fleet_apply_rerank" in src
+    # all three model-returning paths funnel through the guard
+    assert src.count("_fleet_guarded(route,") >= 3
+
+
+def test_rerank_applied_when_authoritative(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_EVALUATOR_AUTHORITATIVE", "true")
+    monkeypatch.setenv("JARVIS_FLEET_CALIBRATION_PATH", str(tmp_path / "c.json"))
+    from backend.core.ouroboros.governance import fleet_calibration_store as s
+    st = s.FleetCalibrationStore()
+    st.record_probe("good", kind="code", code_pass=True, ttft_ms=200, tok_per_s=90, now=1.0)
+    st.record_probe("good", kind="code", code_pass=True, ttft_ms=200, tok_per_s=90, now=2.0)
+    st.record_probe("bad", kind="code", code_pass=False, ttft_ms=100, tok_per_s=120, now=1.0)
+    st.record_probe("bad", kind="code", code_pass=False, ttft_ms=100, tok_per_s=120, now=2.0)
+    st.save()
+    out = s.fleet_apply_rerank("standard", ("bad", "good"))
+    assert out[0] == "good"     # measured-valid coder rises above measured-invalid
+
+
+def test_guard_off_is_identity(monkeypatch, tmp_path):
+    monkeypatch.delenv("JARVIS_FLEET_EVALUATOR_AUTHORITATIVE", raising=False)
+    from backend.core.ouroboros.governance import provider_topology as pt
+    # _fleet_guarded must be a pass-through when the gate is off
+    assert pt._fleet_guarded("standard", ("a", "b", "c")) == ("a", "b", "c")
+
+
+def test_fleet_flags_registered():
+    from backend.core.ouroboros.governance import flag_registry as fr
+    from backend.core.ouroboros.governance import flag_registry_seed as seed
+
+    reg = fr.FlagRegistry()
+    seed.seed_default_registry(reg)
+
+    expected = {
+        "JARVIS_FLEET_EVALUATOR_ENABLED",
+        "JARVIS_FLEET_EVALUATOR_AUTHORITATIVE",
+        "JARVIS_FLEET_EWMA_ALPHA",
+        "JARVIS_FLEET_PROBE_MAX_TOKENS",
+        "JARVIS_FLEET_PROBE_TIMEOUT_S",
+        "JARVIS_FLEET_MAX_MODELS_PER_CYCLE",
+        "JARVIS_FLEET_DAILY_USD_CAP",
+        "JARVIS_FLEET_GRAD_MIN_SAMPLES",
+        "JARVIS_FLEET_GRAD_MIN_AST",
+        "JARVIS_FLEET_GRAD_MARGIN",
+        "JARVIS_FLEET_GRAD_STABLE_CYCLES",
+        "JARVIS_FLEET_CALIBRATION_PATH",
+    }
+    for name in expected:
+        assert reg.get_spec(name) is not None, f"{name} not registered"

--- a/tests/governance/test_fleet_topology_binding.py
+++ b/tests/governance/test_fleet_topology_binding.py
@@ -26,7 +26,7 @@ def test_rerank_applied_when_authoritative(monkeypatch, tmp_path):
     assert out[0] == "good"     # measured-valid coder rises above measured-invalid
 
 
-def test_guard_off_is_identity(monkeypatch, tmp_path):
+def test_guard_off_is_identity(monkeypatch):
     monkeypatch.delenv("JARVIS_FLEET_EVALUATOR_AUTHORITATIVE", raising=False)
     from backend.core.ouroboros.governance import provider_topology as pt
     # _fleet_guarded must be a pass-through when the gate is off


### PR DESCRIPTION
## Sovereign Fleet Evaluator — quality-calibration axis for DW model selection

Adds the **correctness axis** the DoubleWord (DW) selection layer was missing. Discovery (`dw_catalog_client`) + latency-promotion (`dw_promotion_ledger`/`dw_ttft_observer`) already ship and are graduated — but every existing axis is latency-only. **Nothing measured whether a model's output is valid code or a clean label**, so a fast-but-useless model is never demoted. This closes that gap by AST-validating model output *in memory* and re-ranking routing by a quality-weighted composite — **advisory first, auto-graduating** once a soak proves the calibrated picks beat the static default.

Reuse-first: ~70% of the original "fleet orchestrator" idea already existed; this is purely additive and reuses discovery, the `.env` graduation writer, and the SSE broker. No new discovery path, no YAML model hardcoding.

### Live calibration soak (the actual subsystem, live DW API)
`scripts/fleet_first_calibration.py` ran the real `FleetEvaluator` over the accessible roster. `valid_tok_per_s = tok/s × ast_pass_rate`:

| model | ast_pass | label | tok/s | **valid_tok/s** |
|---|---|---|---|---|
| **openai/gpt-oss-120b** | 1.00 | 1.00 | 117.8 | **117.8** |
| deepseek-ai/DeepSeek-V4-Flash | 1.00 | 1.00 | 69.1 | 69.1 |
| deepseek-ai/DeepSeek-V4-Pro | 1.00 | 1.00 | 61.2 | 61.2 |
| google/gemma-4-31B-it | 1.00 | 1.00 | 15.7 | 15.7 |
| zai-org/GLM-5.2 | 0.00 | 0.00 | 0 | 0.0 |
| **Qwen/Qwen3.5-397B-A17B-FP8** | **0.00** | 1.00 | 66.3 | **0.0** |

**AST pass/fail evidence — 397B vs gpt-oss-120b** (probe at max_tokens=2048):
- `gpt-oss-120b`: emits a complete fenced code block → `ast.parse` OK, no placeholder → **PASS**.
- `Qwen3.5-397B`: burns the full 2048-token budget reasoning in prose → **emits no code block at all** → `extract_code_block` len=0 → **FAIL (ast=0)**. This is the long-suspected failure mode, now *measured* by the subsystem.

- **STANDARD code route re-rank:** `gpt-oss-120b → DeepSeek-Flash → DeepSeek-Pro → gemma → GLM → 397B (last)`.
- **Graduation verdict:** `GRADUATE → openai/gpt-oss-120b` (397B's `ast=0 < 0.2` trips the broken-default bypass).
- **Token expenditure footprint:** **$0.00312** total for the full 6-model × 2-probe soak — far under the $0.50 daily cap.

### Degradation / demotion ledger (zero-regression proof)
- The `Qwen3.5-397B` cold-start constant at `doubleword_provider.py:67` is **left untouched on purpose** — editing it would reintroduce the exact static hardcode this PR eliminates. Instead the 397B is **dynamically demoted at runtime**: when authoritative, `_fleet_guarded` re-orders the resolved `dw_models_for_route()` tuple so the calibrated coder sorts above 397B in every code route, and the graduation gate flips the authoritative flag. The fallback architecture is unchanged when the flag is off.
- **`JARVIS_FLEET_EVALUATOR_ENABLED` and `JARVIS_FLEET_EVALUATOR_AUTHORITATIVE` both default OFF → byte-identical legacy behavior.** With both off the evaluator never probes and `_fleet_guarded` is a pure pass-through (`test_guard_off_is_identity`). Regression run vs `origin/main`: the binding **net-reduced** pre-existing topology failures (19→16, strict subset, zero new).

### Architecture (4 leaf modules + 1 guarded binding)
- `fleet_quality_battery.py` — **pure in-memory AST armor**. `ast.parse` only — **no `exec`/`eval`/file-write** of model output (adversarial `os.system`-string test asserts the canary file is never created). Detects `...`/`pass`/`raise NotImplementedError` bodies as placeholders.
- `fleet_calibration_store.py` — `QualityScore` + EWMA smoothing + atomic JSON persistence + daily-USD spend ledger + **pure** `fleet_rerank` / `graduation_ready`. NaN-unseeded cross-kind seeding fix (NaN never escapes to JSON — verified strict-valid).
- `fleet_evaluator.py` — async idle-driven driver + auto-graduation; reuses `dw_catalog_client.load_cached_snapshot` + `graduation_orchestrator.persist_flag_to_env`; daily cost-cap enforced.
- `provider_topology.py` — one guarded `_fleet_guarded` re-rank funnel in `dw_models_for_route` (YAML policy gates untouched).
- `flag_registry_seed.py` (+13 `JARVIS_FLEET_*` flags), `ide_observability_stream.py` (+`fleet_calibrated`/`fleet_graduated` SSE — Manifesto §7).

### Safety invariants (verified by final whole-subsystem review)
No code execution · OFF byte-identical · fail-soft everywhere · no infra duplication · NaN-contained · idle + daily-USD-capped · EWMA decay (transient 502 can't mis-rank).

### Tests
**35 green** — battery 10, store 11, evaluator 10, topology binding 4. All offline (injected fake caller); built via subagent-driven TDD with per-task spec + code-quality review and a final whole-subsystem review.

## Test plan
- [x] `pytest tests/governance/test_fleet_{quality_battery,calibration_store,evaluator,topology_binding}.py` → 35 passed
- [x] Live calibration soak against DW (gpt-oss-120b graduates, 397B demoted, $0.003)
- [x] OFF-path byte-identical (guard identity test + stash-compare regression)
- [ ] Multi-cycle advisory soak on a Linux host to let EWMA settle the #1 coder before flipping authoritative

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a quality-aware DW model router that AST-checks outputs and re-ranks models by a smoothed validity metric, gated OFF by default. Adds a deterministic CI soak to prove EWMA stability and post telemetry to the PR.

- New Features
  - In-memory AST quality battery: parses code blocks, flags placeholders; never executes code.
  - Calibration store: EWMA scores and a `valid_tok_per_s` composite; atomic JSON persistence and a daily spend ledger; pure rerank and graduation decisions.
  - Evaluator: async idle probes with enforced daily USD cap, and SSE events `fleet_calibrated` and `fleet_graduated`.
  - Topology binding: `_fleet_guarded` integrates store-backed rerank into `dw_models_for_route` when authorized; falls back to legacy order when gated off.
  - Tests and CI: 35 tests; soak scripts at `scripts/fleet_first_calibration.py` and `scripts/fleet_soak_multicycle.py`; `.github/workflows/fleet_evaluator_soak.yml` runs a deterministic multi-cycle EWMA soak (no secrets/cost), posts convergence telemetry, and installs governance import-chain deps (`aiohttp`, `aiofiles`, `aiosqlite`, `networkx`, `redis`, `opentelemetry`, `xxhash`, `attrs`) so it runs on a clean runner.

- Migration
  - Soak only: set `JARVIS_FLEET_EVALUATOR_ENABLED=true` and leave `JARVIS_FLEET_EVALUATOR_AUTHORITATIVE=false`.
  - Flip routing after stable wins: set `JARVIS_FLEET_EVALUATOR_AUTHORITATIVE=true`.
  - Control spend: tune `JARVIS_FLEET_DAILY_USD_CAP` and `JARVIS_FLEET_PROBE_USD_PER_MTOK`. Default probe `max_tokens=2048`.

<sup>Written for commit 88d6d79f437ac23050b10df8d80b8c9eb6d43aa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

