### PR TITLE
feat(exec-engine): budget reconciliation + cross-provider state isolation + Linux exec bridge

### DIFF
--- a/backend/core/ouroboros/governance/background_agent_pool.py
+++ b/backend/core/ouroboros/governance/background_agent_pool.py
@@ -499,6 +499,22 @@ class BackgroundAgentPool:
                 op.completed_at = time.monotonic()
                 self._cancelled_count += 1
                 drained += 1
+                # Sovereign Exec Engine (2026-06-19) — release any budget
+                # reservation this queued op held. These ops never reach the
+                # orchestrator terminal release hook (they're cancelled here,
+                # not run()), so without this they LEAK their reservation and
+                # permanently shrink effective_remaining. The TTL sweep is the
+                # backstop; this is the precise, immediate release.
+                try:
+                    _ctx = getattr(op, "context", None)
+                    _oid = str(getattr(_ctx, "op_id", "") or "")
+                    if _oid:
+                        from backend.core.ouroboros.governance.session_budget_authority import (  # noqa: E501
+                            release_reservation as _sba_release,
+                        )
+                        _sba_release(_oid)
+                except Exception:  # noqa: BLE001 — release is best-effort
+                    pass
                 self._queue.task_done()
             except asyncio.QueueEmpty:
                 break

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1188,6 +1188,34 @@ def _dw_autarky_enabled() -> bool:
         return False
 
 
+def _provider_quota_isolation_enabled() -> bool:
+    """Sovereign State Isolation (2026-06-19) master. Default-TRUE — a
+    provider's economic/quota death (e.g. Claude 402 'credit balance too
+    low') is recorded on THAT provider's own lane breaker only, and is NOT
+    allowed to trip the provider-NEUTRAL per-op circuit breaker into
+    OPEN_TERMINAL. Without this, Claude's credit-death poisons the whole op
+    so DW autarky can never carry it — the empirically-confirmed
+    cross-provider contamination (terminal_quota 5->0 once isolated).
+    Operator force-off with =0 -> byte-identical legacy. NEVER raises."""
+    try:
+        return os.environ.get(
+            "JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED", "true",
+        ).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def quota_isolation_skips_op_breaker(
+    *, is_provider_economic_block: bool, isolation_enabled: bool,
+) -> bool:
+    """PURE predicate: should the per-op breaker trip be SKIPPED for this
+    failure? True iff the failure is a provider economic block AND
+    isolation is enabled — the provider's OWN lane breaker already owns the
+    death, so tripping the op-neutral breaker would cross-contaminate the op
+    for every other (still-viable) provider. NEVER raises."""
+    return bool(is_provider_economic_block) and bool(isolation_enabled)
+
+
 def immediate_reroute_to_dw(
     *,
     dw_is_primary: bool,
@@ -6454,6 +6482,7 @@ class CandidateGenerator:
                         # should_allow_request gate) and it recovers after the
                         # window — no sticky session brick. Gated + defensive;
                         # detail is the redacted economic code, never a secret.
+                        _claude_econ_block = False
                         try:
                             if _s127_econ_on:
                                 from backend.core.ouroboros.governance.economic_router import (  # noqa: E501
@@ -6461,6 +6490,7 @@ class CandidateGenerator:
                                 )
                                 _s127_block = _s127_is_econ(str(inner_exc))
                                 if _s127_block is not None:
+                                    _claude_econ_block = True
                                     from backend.core.ouroboros.governance.claude_circuit_breaker import (  # noqa: E501
                                         get_claude_circuit_breaker as _s127_get_ccb,
                                     )
@@ -6478,6 +6508,31 @@ class CandidateGenerator:
                             provider="claude",
                             op_id=_slice7e_op_id,
                         )
+                        # Sovereign State Isolation (2026-06-19): a confirmed
+                        # Claude economic death is OWNED by Claude's lane breaker
+                        # (recorded above). Do NOT let it trip the provider-
+                        # NEUTRAL per-op breaker into the sticky OPEN_TERMINAL —
+                        # that poisons the op for DW too (empirically-confirmed
+                        # cross-provider contamination: terminal_quota 5->0 once
+                        # isolated). Downgrade ONLY the decision the OP breaker
+                        # sees to RETRY_TRANSIENT (non-poisoning) so the op stays
+                        # viable for DW autarky; the Claude lane is already marked
+                        # dead by its global breaker + the Slice238 suppression.
+                        # Telemetry above already published the TRUE decision.
+                        if quota_isolation_skips_op_breaker(
+                            is_provider_economic_block=_claude_econ_block,
+                            isolation_enabled=_provider_quota_isolation_enabled(),
+                        ):
+                            logger.warning(
+                                "[CandidateGenerator] QUOTA ISOLATION: Claude "
+                                "economic death contained to Claude lane breaker; "
+                                "per-op breaker NOT terminal-tripped (op stays "
+                                "viable for DW autarky) op=%s",
+                                _slice7e_op_id,
+                            )
+                            _slice7e_decision = type(
+                                _slice7e_decision
+                            ).RETRY_TRANSIENT
                         _slice7e_prior_state = _slice7e_breaker.state.value
                         _slice7e_verdict = _slice7e_breaker.evaluate(
                             _slice7e_decision,

--- a/backend/core/ouroboros/governance/intent/test_watcher.py
+++ b/backend/core/ouroboros/governance/intent/test_watcher.py
@@ -121,7 +121,18 @@ class TestWatcher:
             if poll_interval_s is not None
             else float(os.environ.get("JARVIS_INTENT_TEST_INTERVAL_S", "300"))
         )
-        self.pytest_timeout_s = pytest_timeout_s
+        # Env-overridable (Sovereign Exec Engine, 2026-06-19): high-compute
+        # hosts raise this past the 30s default so a full-repo pytest sweep
+        # completes instead of being SIGKILLed mid-run (the local M1 foil that
+        # kept an isolated seed defect from ever being detected).
+        try:
+            self.pytest_timeout_s = float(
+                os.environ.get(
+                    "JARVIS_INTENT_PYTEST_TIMEOUT_S", str(pytest_timeout_s),
+                )
+            )
+        except (TypeError, ValueError):
+            self.pytest_timeout_s = pytest_timeout_s
 
         # Streak tracking: test_id -> consecutive failure count
         self._failure_streak: Dict[str, int] = {}

--- a/backend/core/ouroboros/governance/session_budget_authority.py
+++ b/backend/core/ouroboros/governance/session_budget_authority.py
@@ -227,6 +227,25 @@ def per_op_reservation_enabled() -> bool:
     return raw in {"1", "true", "yes", "on"}
 
 
+def _reservation_ttl_s() -> float:
+    """Max seconds a reservation may sit unspent before a lazy sweep
+    releases it (Sovereign Exec Engine, 2026-06-19). Default 600s.
+
+    Fixes the reservation LEAK: ops that are queued then drained at
+    background-pool shutdown (or otherwise never reach the orchestrator
+    terminal release hook) would otherwise hold their reservation
+    forever, permanently shrinking ``effective_remaining`` and starving
+    every subsequent preflight. The TTL is deliberately GENEROUS —
+    longer than any legitimate op wall-time (heavy tool-loops run
+    130s+) — so a live, still-generating op is never swept mid-flight
+    (which would let it spend past the cap). ``<=0`` disables the sweep.
+    NEVER raises."""
+    try:
+        return float(os.environ.get("JARVIS_SBA_RESERVATION_TTL_S", "600"))
+    except (TypeError, ValueError):
+        return 600.0
+
+
 @dataclass(frozen=True)
 class Reservation:
     """Slice 12AA per-op reservation entry. Immutable snapshot of
@@ -284,6 +303,10 @@ def acquire_reservation(
         return False
 
     with _reservations_lock:
+        # Lazy TTL sweep: reclaim leaked reservations before computing
+        # the contended pool, so a stalled/drained op can't permanently
+        # block a fresh acquire.
+        _sweep_stale_locked(time.monotonic(), _reservation_ttl_s())
         other_reserved = sum(
             r.reserved_usd
             for r in _reservations.values()
@@ -324,6 +347,48 @@ def get_reservations_snapshot() -> Tuple[Reservation, ...]:
             return tuple(_reservations.values())
     except Exception:  # noqa: BLE001
         return ()
+
+
+def _sweep_stale_locked(now: float, ttl_s: float) -> int:
+    """Release reservations older than ``ttl_s``. ASSUMES the caller
+    already holds ``_reservations_lock``. Returns count released.
+    NEVER raises. ``ttl_s <= 0`` is a no-op (sweep disabled)."""
+    if ttl_s <= 0.0:
+        return 0
+    stale = [
+        oid for oid, r in _reservations.items()
+        if (now - r.acquired_at_monotonic) > ttl_s
+    ]
+    for oid in stale:
+        r = _reservations.pop(oid, None)
+        if r is not None:
+            logger.info(
+                "[SBA] reservation TTL sweep: released op_id=%s "
+                "reserved=$%.4f age=%.1fs > ttl=%.1fs (leak reclaimed)",
+                oid, r.reserved_usd, now - r.acquired_at_monotonic, ttl_s,
+            )
+    return len(stale)
+
+
+def sweep_stale_reservations(now: Optional[float] = None) -> int:
+    """Public, lock-acquiring TTL sweep. Releases reservations whose
+    age exceeds ``JARVIS_SBA_RESERVATION_TTL_S``. Returns count
+    released. ``now`` is injectable for tests. NEVER raises.
+
+    Called lazily from :func:`acquire_reservation` and
+    :func:`check_preflight` so liquidity self-heals exactly when
+    budget is contended — no background task, so it adds ZERO
+    event-loop load (deliberate: a sweep coroutine would worsen the
+    on-loop starvation this engine exists to relieve)."""
+    try:
+        ttl = _reservation_ttl_s()
+        if ttl <= 0.0:
+            return 0
+        _now = float(now) if now is not None else time.monotonic()
+        with _reservations_lock:
+            return _sweep_stale_locked(_now, ttl)
+    except Exception:  # noqa: BLE001 — never break the budget path
+        return 0
 
 
 def _sum_other_reservations(op_id: Optional[str]) -> float:
@@ -567,6 +632,9 @@ def check_preflight(
     # owning op's OWN reservation is intentionally NOT subtracted
     # — the owning op spends FROM its reservation. When op_id is
     # None (legacy callers), other ops' reservations still apply.
+    # Sovereign Exec Engine — lazy TTL sweep first so leaked/stalled
+    # reservations don't perpetually refuse fresh preflights.
+    sweep_stale_reservations()
     other_reserved = _sum_other_reservations(op_id)
     effective_remaining = max(0.0, remaining - other_reserved)
 
@@ -646,6 +714,7 @@ __all__ = [
     "check_preflight",
     "get_background_spend_limit_pct",
     "get_reservations_snapshot",
+    "sweep_stale_reservations",
     "get_session_budget_provider",
     "get_session_remaining_usd",
     "get_session_total_cap_usd",

--- a/deploy/ouroboros_linux_prod.env
+++ b/deploy/ouroboros_linux_prod.env
@@ -1,0 +1,37 @@
+# ============================================================================
+# Sovereign Remote Execution Bridge — high-compute Linux production profile
+# (2026-06-19). Source this on a dedicated Linux host BEFORE launching the
+# Ouroboros battle test. Tunes away the three blockers the local 16GB M1
+# nested run empirically hit (host-bound, not code-bound):
+#   1. pytest sweeps SIGKILLed at 30s  -> seed/test-failure never detected
+#   2. AST ProcessPool pinned to 1 worker -> slow parse, on-loop stalls
+#   3. event-loop starvation from nested-on-Mac contention
+# Pair with scripts/launch_linux_prod.sh (computes $(nproc) for the pools).
+#
+# Secrets (DOUBLEWORD_API_KEY / ANTHROPIC_API_KEY) live in .env, NEVER here.
+# ============================================================================
+
+# ---- The features built this session (all default-on; explicit for clarity) ----
+export JARVIS_FLEET_EVALUATOR_ENABLED=true            # quality-calibration axis
+export JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED=true   # Claude-death can't poison DW
+export JARVIS_SBA_RESERVATION_TTL_S=600               # reservation-leak backstop
+
+# ---- Blocker #1: full-repo pytest sweep needs room (was SIGKILLed at 30s) ----
+export JARVIS_INTENT_PYTEST_TIMEOUT_S=180   # TestWatcher pytest cap (default 30)
+export JARVIS_TEST_TIMEOUT_S=180            # post-APPLY scoped test run (default 120)
+export JARVIS_TEST_PER_TEST_TIMEOUT_S=30    # per-test cap (default 10)
+
+# ---- Blocker #2: parallelism — scale to the host. launch_linux_prod.sh sets
+#      these to $(nproc)-derived values at runtime; the lines below are the
+#      conservative floor if you source this file standalone on a >=8-core box. ----
+export JARVIS_AST_HELPER_POOL_MAX_WORKERS=8  # AST parse pool (default 1!) -> nproc
+export JARVIS_BG_POOL_SIZE=6                 # background workers (default 3)
+
+# ---- Blocker #3: real soak leashes (a dedicated host can run long + spend) ----
+export OUROBOROS_BATTLE_COST_CAP=10.00       # realistic cap (NOT the $0.50 trap)
+export OUROBOROS_BATTLE_MAX_WALL_SECONDS=3600 # 60 min soak window
+export OUROBOROS_BATTLE_HEADLESS=true        # daemon/CI: no interactive REPL
+
+# ---- Optional: explicit DW-autarky posture if Claude credits are exhausted.
+#      Leave UNSET to use Claude when funded; set =true to run pure DW. ----
+# export JARVIS_PROVIDER_CLAUDE_DISABLED=true

--- a/scripts/launch_linux_prod.sh
+++ b/scripts/launch_linux_prod.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Sovereign Remote Execution Bridge — launch the Ouroboros battle test on a
+# dedicated high-compute Linux host (2026-06-19).
+#
+# Does what the local 16GB M1 could not: gives pytest room, scales the AST
+# ProcessPool + background pool to the host's core count, and runs a real
+# cost-capped soak so the loop can actually reach state=applied.
+#
+# Usage (from repo root on the Linux host, with .env present for secrets):
+#   ./scripts/launch_linux_prod.sh [extra battle-test args...]
+#
+# Secrets come from .env (DOUBLEWORD_API_KEY / ANTHROPIC_API_KEY) — this
+# script never embeds them. Non-Linux hosts are refused (the whole point).
+# ============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$REPO_ROOT"
+
+# --- Refuse non-Linux: this profile exists precisely to escape the Mac. ---
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "ERROR: launch_linux_prod.sh is for a dedicated Linux host." >&2
+  echo "       Detected $(uname -s). On macOS the nested event loop starves" >&2
+  echo "       (the empirically-proven wall). Use a Linux box / container." >&2
+  exit 2
+fi
+
+# --- Load the production env profile. ---
+PROFILE="${REPO_ROOT}/deploy/ouroboros_linux_prod.env"
+if [[ ! -f "$PROFILE" ]]; then
+  echo "ERROR: missing $PROFILE" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$PROFILE"
+
+# --- Dynamically scale the pools to the host's core count. ---
+CORES="$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+# AST parse pool: cores - 1 (leave one for the event loop), min 2.
+AST_WORKERS=$(( CORES > 2 ? CORES - 1 : 2 ))
+# Background worker pool: half the cores, min 3, cap 12.
+BG_WORKERS=$(( CORES / 2 )); (( BG_WORKERS < 3 )) && BG_WORKERS=3; (( BG_WORKERS > 12 )) && BG_WORKERS=12
+export JARVIS_AST_HELPER_POOL_MAX_WORKERS="$AST_WORKERS"
+export JARVIS_BG_POOL_SIZE="$BG_WORKERS"
+
+# --- Load secrets from .env (never logged). ---
+if [[ -f "${REPO_ROOT}/.env" ]]; then
+  set -a; # shellcheck disable=SC1091
+  source "${REPO_ROOT}/.env"; set +a
+fi
+
+echo "── Sovereign Linux Prod launch ────────────────────────────────"
+echo "  host cores       : ${CORES}"
+echo "  AST pool workers : ${JARVIS_AST_HELPER_POOL_MAX_WORKERS} (default was 1)"
+echo "  BG pool size     : ${JARVIS_BG_POOL_SIZE} (default was 3)"
+echo "  pytest timeout   : ${JARVIS_INTENT_PYTEST_TIMEOUT_S}s (default was 30)"
+echo "  cost cap         : \$${OUROBOROS_BATTLE_COST_CAP}"
+echo "  wall cap         : ${OUROBOROS_BATTLE_MAX_WALL_SECONDS}s"
+echo "  fleet evaluator  : ${JARVIS_FLEET_EVALUATOR_ENABLED}"
+echo "  quota isolation  : ${JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED}"
+echo "  DW key           : ${DOUBLEWORD_API_KEY:+present (masked)}"
+echo "───────────────────────────────────────────────────────────────"
+
+exec python3 scripts/ouroboros_battle_test.py \
+  --cost-cap "${OUROBOROS_BATTLE_COST_CAP}" \
+  --max-wall-seconds "${OUROBOROS_BATTLE_MAX_WALL_SECONDS}" \
+  --headless -v "$@"

--- a/tests/governance/test_provider_quota_isolation.py
+++ b/tests/governance/test_provider_quota_isolation.py
@@ -1,0 +1,44 @@
+"""Sovereign State Isolation (2026-06-19) — per-provider terminal_quota
+isolation. A provider's economic death (Claude 402) must be contained to
+that provider's lane breaker and must NOT trip the provider-neutral per-op
+breaker (which would poison the op for DW autarky)."""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.candidate_generator import (
+    quota_isolation_skips_op_breaker,
+    _provider_quota_isolation_enabled,
+)
+
+
+def test_isolation_default_on(monkeypatch):
+    monkeypatch.delenv("JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED", raising=False)
+    assert _provider_quota_isolation_enabled() is True
+
+
+def test_isolation_force_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED", "0")
+    assert _provider_quota_isolation_enabled() is False
+
+
+def test_predicate_truth_table():
+    # economic block + isolation on -> skip the op-breaker trip (contain it)
+    assert quota_isolation_skips_op_breaker(
+        is_provider_economic_block=True, isolation_enabled=True) is True
+    # economic block but isolation off -> legacy: op-breaker trips (no skip)
+    assert quota_isolation_skips_op_breaker(
+        is_provider_economic_block=True, isolation_enabled=False) is False
+    # NON-economic failure (e.g. real structural/timeout) -> never skip,
+    # the op-breaker must still trip on genuine op-fatal failures
+    assert quota_isolation_skips_op_breaker(
+        is_provider_economic_block=False, isolation_enabled=True) is False
+    assert quota_isolation_skips_op_breaker(
+        is_provider_economic_block=False, isolation_enabled=False) is False
+
+
+def test_real_failure_still_trips_op_breaker():
+    """The isolation must NOT mask genuine op-fatal failures: a structural/
+    config death (not an economic block) must still allow the op breaker to
+    trip, regardless of isolation flag."""
+    for iso in (True, False):
+        assert quota_isolation_skips_op_breaker(
+            is_provider_economic_block=False, isolation_enabled=iso) is False

--- a/tests/governance/test_session_budget_authority.py
+++ b/tests/governance/test_session_budget_authority.py
@@ -588,3 +588,69 @@ def test_dw_complete_sync_inherits_preflight_via_check_budget(tmp_path):
     assert session_calls == [], (
         "complete_sync must refuse via _check_budget BEFORE opening a session"
     )
+
+
+# ============================================================================
+# Sovereign Exec Engine (2026-06-19) — reservation TTL sweep (leak fix)
+# ============================================================================
+import time as _time
+from backend.core.ouroboros.governance import session_budget_authority as _sba
+from backend.core.ouroboros.governance.session_budget_authority import (
+    acquire_reservation,
+    get_reservations_snapshot,
+    sweep_stale_reservations,
+)
+
+
+def test_ttl_sweep_releases_stale_reservation(monkeypatch):
+    monkeypatch.setenv("JARVIS_SBA_RESERVATION_TTL_S", "600")
+    set_session_budget_provider(_FakeProvider(5.0))
+    assert acquire_reservation(op_id="op-a", signal_source="test_failure",
+                               estimated_total_usd=0.50) is True
+    assert len(get_reservations_snapshot()) == 1
+    # age the clock past the TTL -> swept
+    released = sweep_stale_reservations(now=_time.monotonic() + 700.0)
+    assert released == 1
+    assert get_reservations_snapshot() == ()
+
+
+def test_ttl_sweep_keeps_fresh_reservation(monkeypatch):
+    monkeypatch.setenv("JARVIS_SBA_RESERVATION_TTL_S", "600")
+    set_session_budget_provider(_FakeProvider(5.0))
+    acquire_reservation(op_id="op-b", signal_source="test_failure",
+                        estimated_total_usd=0.50)
+    released = sweep_stale_reservations(now=_time.monotonic() + 1.0)
+    assert released == 0
+    assert len(get_reservations_snapshot()) == 1
+
+
+def test_ttl_zero_disables_sweep(monkeypatch):
+    monkeypatch.setenv("JARVIS_SBA_RESERVATION_TTL_S", "0")
+    set_session_budget_provider(_FakeProvider(5.0))
+    acquire_reservation(op_id="op-c", signal_source="test_failure",
+                        estimated_total_usd=0.50)
+    assert sweep_stale_reservations(now=_time.monotonic() + 9999.0) == 0
+    assert len(get_reservations_snapshot()) == 1
+
+
+def test_lazy_sweep_in_acquire_reclaims_leaked_budget(monkeypatch):
+    """The bug: op-A reserves the whole cap, never releases (queued+drained);
+    op-B can never acquire. With the lazy TTL sweep, once A is stale, B's
+    acquire reclaims it and succeeds."""
+    monkeypatch.setenv("JARVIS_SBA_RESERVATION_TTL_S", "600")
+    set_session_budget_provider(_FakeProvider(0.50))   # tiny cap, like the soak
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(_sba.time, "monotonic", lambda: clock["t"])
+    # A reserves the ENTIRE $0.50 cap
+    assert acquire_reservation(op_id="op-A", signal_source="test_failure",
+                               estimated_total_usd=0.50) is True
+    # B cannot acquire — no liquidity (this is the live-soak lock)
+    assert acquire_reservation(op_id="op-B", signal_source="test_failure",
+                               estimated_total_usd=0.50) is False
+    # ...time passes; A is now a stale leak (queued+drained, never released)
+    clock["t"] = 1000.0 + 700.0
+    # B retries — the lazy sweep inside acquire reclaims A, so B succeeds
+    assert acquire_reservation(op_id="op-B", signal_source="test_failure",
+                               estimated_total_usd=0.50) is True
+    snap = {r.op_id for r in get_reservations_snapshot()}
+    assert snap == {"op-B"}      # A swept, B holds the reservation


### PR DESCRIPTION
## Sovereign Execution Engine — budget reconciliation + cross-provider state isolation + Linux exec bridge

Three fixes that fortify the active Ouroboros control plane, each diagnosed from live battle-test evidence (not speculation). Built TDD, gated, reversible.

### 1. Reservation TTL sweep + queue-drain release (`session_budget_authority`, `background_agent_pool`)
**Live symptom:** every provider preflight `REFUSED` with `other_reserved=$0.50 == whole cap`, `cost_total $0.00` — the loop could never spend.
**Root cause:** a foreground op reserves the full cap; queued ops cancelled at `background_agent_pool.stop()` never reach the orchestrator terminal release hook, so they **leak** their reservation forever, permanently shrinking `effective_remaining`.
**Fix:**
- **Lazy TTL sweep** inside `acquire_reservation` + `check_preflight` — releases reservations older than `JARVIS_SBA_RESERVATION_TTL_S` (default **600s**, generous so live 130s+ tool-loops are never swept mid-flight). **No background task** (deliberate: zero added event-loop load, since on-loop starvation is the very thing this engine relieves).
- **Precise drain-release** at the queue-cancel site — the exact leak source.
- **Live-validated:** re-run at $5 cap → `preflight REFUSED: 0` (was 14), an op reached real GENERATE for the first time.

### 2. Per-provider terminal_quota isolation (`candidate_generator`)
**Live symptom (Claude credits depleted):** `circuit_breaker_tripped:terminal_quota` → `all_providers_exhausted` even after `⚡ DW AUTARKY ENGAGED`.
**Root cause (confirmed by controlled experiment — `terminal_quota` went **5 → 0** when Claude was disabled):** Claude's economic death (402) records on Claude's *global* lane breaker **and** was tripping the provider-**neutral** per-op breaker into sticky `OPEN_TERMINAL` — poisoning the op for DW too.
**Fix:** a confirmed Claude economic block downgrades **only** the decision the *per-op* breaker sees (→ `RETRY_TRANSIENT`, non-poisoning). Telemetry still publishes the true classification; Claude's lane breaker still owns the death (future ops route around it). The op stays viable for DW autarky. **Genuine** structural/config/timeout failures are unaffected — they still trip the op breaker. Gated `JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED` (default true, `=0` → byte-identical legacy).

### 3. Sovereign Remote Execution Bridge (`deploy/ouroboros_linux_prod.env`, `scripts/launch_linux_prod.sh`, `test_watcher`)
**Why:** local validation **empirically proved the 16GB-M1 host — not the code — blocks `state=applied`**: nested event-loop starvation (35–48 on-loop blocks of 900ms+), pytest SIGKILLed at 30s (so isolated seed defects are never detected), AST ProcessPool pinned to 1 worker.
**Bridge:** a high-compute Linux profile (pytest 30→180s via the new `JARVIS_INTENT_PYTEST_TIMEOUT_S`, AST pool 1→`$(nproc)`, BG pool 3→cores/2, realistic $10 cap + 60min wall) + a Linux-only launcher that scales pools to the host and refuses macOS by design. Secrets stay in `.env`.

## Validation status (honest)
- ✅ Budget fix: **live-validated** — 0 preflight refusals at $5 cap, op reached GENERATE.
- ✅ Isolation mechanism: **empirically confirmed** (`terminal_quota` 5→0), unit-tested (pure predicate + genuine-failure-still-trips guard).
- ✅ Tests: SBA suite 39 passed (4 new TTL), isolation 4 passed. (Pre-existing `providers.py` AST-pin failure is unrelated — confirmed against pristine main.)
- ⚠️ **`state=applied` not achieved locally — and that's the point of Bridge #3.** With budget fixed *and* contamination bypassed, the nested M1 still can't reach a repair (host starvation + pytest-timeout + DW-generation-timeout). First blood requires the Linux host this PR provisions.

## Test plan
- [x] `pytest tests/governance/test_session_budget_authority.py tests/governance/test_provider_quota_isolation.py` → 39+4 pass
- [x] Budget fix live-validated ($5 re-run, 0 refusals, GENERATE reached)
- [x] Isolation mechanism confirmed (Claude-disabled experiment, terminal_quota 5→0)
- [ ] **Full `state=applied` run on a dedicated Linux host** via `scripts/launch_linux_prod.sh` (the bridge this PR ships)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes budget reservation leaks and cross-provider quota contamination, and adds a Linux execution bridge to unblock event-loop starvation. The loop can now spend, route around dead providers, and realistically reach state=applied.

- **Bug Fixes**
  - Budget leak: TTL sweep in `session_budget_authority` plus immediate release on queue drain in `background_agent_pool.stop()`. `JARVIS_SBA_RESERVATION_TTL_S` (default 600s); new `sweep_stale_reservations()`; tests added.
  - Provider isolation: contain provider economic blocks (e.g., Claude 402) to the provider breaker. Per-op breaker no longer terminal-trips when `JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED=true` (default). Adds `quota_isolation_skips_op_breaker`; tests added.

- **New Features**
  - Linux exec bridge: `deploy/ouroboros_linux_prod.env` and `scripts/launch_linux_prod.sh` (Linux-only). Scales `JARVIS_AST_HELPER_POOL_MAX_WORKERS` and `JARVIS_BG_POOL_SIZE` via `nproc`, sets realistic cost/wall caps, reads secrets from `.env`.
  - Test runtime tuning: `JARVIS_INTENT_PYTEST_TIMEOUT_S` in `test_watcher` (30s → configurable) so full pytest sweeps can finish.

<sup>Written for commit 4c271354391bb1cc9019e0cd94b09cd841da64f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

