### PR TITLE
feat(deploy): Sovereign Cloud Orchestrator — IaC prod deployment matrix

### DIFF
--- a/deploy/DEPLOY_PROD.md
+++ b/deploy/DEPLOY_PROD.md
@@ -1,0 +1,57 @@
+# Sovereign Cloud Orchestrator — production deployment
+
+IaC path to the first real `state=applied` generation run on a high-compute
+Linux host. Removes the three empirically-proven local-M1 bottlenecks
+(nested event-loop starvation, pytest SIGKILL @30s, AST pool pinned to 1).
+
+## Components
+- **`docker-compose.prod.yml`** — reuses `docker/Dockerfile.soak` (deps + code),
+  `restart: always`, `.env` (runtime secrets) + `.jarvis/` bind-mount
+  (funded keys + evidence chain survive container death). Entrypoint is
+  `scripts/launch_linux_prod.sh` (computes `$(nproc)` inside the container →
+  AST pool = cores-1, BG pool = cores/2). **No CPU cap** — wants every core.
+- **`deploy/ouroboros_linux_prod.env`** — the tuned horizons (pytest 30→180s,
+  AST 1→nproc, $10 cap, 60-min wall, all session features on).
+- **`deploy/provision_docker_host.sh`** — idempotent Docker Engine + compose
+  install for a raw Ubuntu/RHEL host; enables dockerd on boot.
+
+## Prerequisite
+Place the funded `.env` (DOUBLEWORD_API_KEY / ANTHROPIC_API_KEY) in the repo
+root on the host — out-of-band (scp), **never committed**. DW is funded; if
+Claude credits are exhausted, set `JARVIS_PROVIDER_CLAUDE_DISABLED=true` in
+`.env` for pure DW autarky (now safe — the per-provider quota isolation fix
+keeps Claude's death from poisoning the DW lane).
+
+## The single-line bootstrap (raw Linux host → first generation run)
+From a host that already has `.env` staged in `/opt/jarvis/.env`:
+
+```bash
+sudo bash -c 'curl -fsSL https://raw.githubusercontent.com/drussell23/JARVIS/main/deploy/provision_docker_host.sh | bash && git clone https://github.com/drussell23/JARVIS.git /opt/jarvis && cp /opt/jarvis/.env.staged /opt/jarvis/.env 2>/dev/null; cd /opt/jarvis && docker compose -f docker-compose.prod.yml up -d --build && docker compose -f docker-compose.prod.yml logs -f jarvis-prod'
+```
+
+Or, broken into the three honest steps (recommended — easier to verify each):
+
+```bash
+# 1. provision docker on the raw host (idempotent)
+curl -fsSL https://raw.githubusercontent.com/drussell23/JARVIS/main/deploy/provision_docker_host.sh | sudo bash
+# 2. clone + stage funded secrets (scp your .env into the repo root first)
+git clone https://github.com/drussell23/JARVIS.git /opt/jarvis && cd /opt/jarvis && scp you@vault:/secure/.env .
+# 3. build + boot the engine + watch it hunt
+docker compose -f docker-compose.prod.yml up -d --build && docker compose -f docker-compose.prod.yml logs -f jarvis-prod
+```
+
+## What to watch for (the first `state=applied`)
+```bash
+docker compose -f docker-compose.prod.yml logs -f jarvis-prod \
+  | grep -E "QUOTA ISOLATION|AUTARKY|emitting 2b|state=applied|APPLY|on-loop"
+```
+Success markers: `preflight REFUSED: 0`, `emitting 2b.1-diff`, an op reaching
+`APPLY`, and `state=applied` — with **no** `on-loop call exceeded threshold`
+storms (the host now has the cores the M1 lacked).
+
+## Validation status (honest)
+- `docker compose -f docker-compose.prod.yml config` → **resolves clean** (validated locally).
+- Provisioner + compose are structurally sound + idempotent.
+- **Not yet run on a real Linux host** — that run IS the first `state=applied`
+  proving ground. The software (budget fix + quota isolation + fleet evaluator)
+  is validated; this bridge gives it the compute it needs.

--- a/deploy/provision_docker_host.sh
+++ b/deploy/provision_docker_host.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Sovereign Cloud Orchestrator — raw-Linux-host Docker provisioning (2026-06-19)
+# ============================================================================
+# Idempotent: installs Docker Engine + the compose plugin on a bare Ubuntu/
+# Debian (apt) or RHEL/Fedora (dnf) host and enables dockerd on boot (so the
+# `restart: always` prod container survives reboots). Safe to re-run.
+#
+#   curl -fsSL <raw>/deploy/provision_docker_host.sh | sudo bash
+# or, after clone:
+#   sudo bash deploy/provision_docker_host.sh
+#
+# Does NOT touch secrets, the repo, or the container — pure host prep.
+# ============================================================================
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "ERROR: this provisioner targets a Linux host (got $(uname -s))." >&2
+  exit 2
+fi
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+  echo "ERROR: run as root (sudo) — installs system packages + enables docker." >&2
+  exit 2
+fi
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  echo "✅ docker + compose plugin already present — nothing to do."
+  docker --version; docker compose version
+  systemctl enable --now docker 2>/dev/null || true
+  exit 0
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+  echo "── apt path (Debian/Ubuntu) ──"
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -y
+  apt-get install -y ca-certificates curl gnupg
+  install -m 0755 -d /etc/apt/keyrings
+  if [[ ! -f /etc/apt/keyrings/docker.gpg ]]; then
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+      | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    chmod a+r /etc/apt/keyrings/docker.gpg
+  fi
+  . /etc/os-release
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+https://download.docker.com/linux/ubuntu ${VERSION_CODENAME:-stable} stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update -y
+  apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+elif command -v dnf >/dev/null 2>&1; then
+  echo "── dnf path (RHEL/Fedora) ──"
+  dnf -y install dnf-plugins-core
+  dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo 2>/dev/null \
+    || dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+  dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+else
+  echo "ERROR: no apt-get or dnf — install Docker manually for this distro." >&2
+  exit 1
+fi
+
+systemctl enable --now docker
+echo "✅ provisioned:"; docker --version; docker compose version
+echo "   dockerd enabled on boot → restart:always container survives reboot."

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,77 @@
+# JARVIS Sovereign Cloud Orchestrator — production generative run (2026-06-19)
+# =============================================================================
+# Infrastructure-as-Code path to the FIRST real state=applied run on a
+# high-compute Linux host — the environment the local 16GB M1 could never be
+# (nested event-loop starvation + pytest SIGKILL@30s + AST pool pinned to 1).
+#
+# REUSES the existing soak image (docker/Dockerfile.soak — deps + full code) and
+# the .env/.jarvis secret+persistence pattern; the ONLY prod-specific changes
+# are (a) entrypoint -> scripts/launch_linux_prod.sh (computes $(nproc) inside
+# the container, sources deploy/ouroboros_linux_prod.env), and (b) NO cpu cap so
+# AST parsing scales to every host core.
+#
+#   docker compose -f docker-compose.prod.yml up -d --build
+#   docker compose -f docker-compose.prod.yml logs -f jarvis-prod
+#   docker compose -f docker-compose.prod.yml down
+#
+# Secrets: .env (DOUBLEWORD_API_KEY / ANTHROPIC_API_KEY) injected at runtime
+# only — NEVER baked into the image. .jarvis/ is bind-mounted so the funded
+# keys + episodic/evidence chain survive container death.
+# =============================================================================
+services:
+  jarvis-prod:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.soak
+      args:
+        # Oracle-capable parse pool wants the heavier reqs; launch with
+        # SOAK_REQUIREMENTS=requirements-soak-oracle.txt for full AST power.
+        SOAK_REQUIREMENTS: ${SOAK_REQUIREMENTS:-requirements-soak.txt}
+    image: jarvis-sovereign-prod:latest
+    container_name: jarvis-sovereign-prod
+    working_dir: /app
+    restart: always            # survives crash + host reboot (if dockerd enabled on boot)
+    stop_grace_period: 30s
+
+    # Funded provider creds — runtime only, never in the image.
+    env_file:
+      - path: .env
+        required: false
+
+    # Prod tunings that eliminate the M1 bottlenecks. launch_linux_prod.sh also
+    # sources deploy/ouroboros_linux_prod.env; these are pinned here so a bare
+    # `compose up` (without the launcher) still gets the right horizons, and so
+    # `compose config` documents the contract explicitly.
+    environment:
+      # the session's three fixes (all default-on; explicit for auditability)
+      JARVIS_FLEET_EVALUATOR_ENABLED: "true"
+      JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED: "true"
+      JARVIS_SBA_RESERVATION_TTL_S: "600"
+      # Blocker #1 — give the full-repo pytest sweep room (was SIGKILLed @30s)
+      JARVIS_INTENT_PYTEST_TIMEOUT_S: "180"
+      JARVIS_TEST_TIMEOUT_S: "180"
+      JARVIS_TEST_PER_TEST_TIMEOUT_S: "30"
+      # Blocker #2 — AST parse pool; launch_linux_prod.sh raises to nproc-1 at
+      # boot. This is the conservative floor if run without the launcher.
+      JARVIS_AST_HELPER_POOL_MAX_WORKERS: "8"
+      JARVIS_BG_POOL_SIZE: "6"
+      # Blocker #3 — real soak leashes (a dedicated host can run long + spend)
+      OUROBOROS_BATTLE_COST_CAP: "10.00"
+      OUROBOROS_BATTLE_MAX_WALL_SECONDS: "3600"
+      OUROBOROS_BATTLE_HEADLESS: "true"
+      # Set to "true" for pure DW autarky if Claude credits are exhausted.
+      # JARVIS_PROVIDER_CLAUDE_DISABLED: "true"
+
+    volumes:
+      # Funded keys + signed roadmap READ from host; evidence/episodic chain
+      # WRITTEN back → survive container death (the persistence vault).
+      - ./.jarvis:/app/.jarvis
+
+    # Entrypoint override: the nproc-scaling Linux launcher (refuses non-Linux;
+    # inside the container it IS Linux). Computes AST pool = cores-1, BG = cores/2.
+    entrypoint: ["bash", "scripts/launch_linux_prod.sh"]
+    command: []
+
+    # NO deploy.resources.limits.cpus — the prod run WANTS every host core for
+    # unthrottled AST parsing + a non-starved event loop (the opposite of the
+    # 4-core soak cap). Add a cpus limit back only on a shared/noisy host.


### PR DESCRIPTION
## Sovereign Cloud Orchestrator — IaC production deployment

Declarative Infrastructure-as-Code to take J.A.R.M.A.T.R.I.X. to the high-compute Linux host where it can actually reach `state=applied` — replacing the brittle bash-migrate path. Removes the three **empirically-proven** local-M1 bottlenecks (nested event-loop starvation, pytest SIGKILL@30s, AST ProcessPool pinned to 1 worker).

### Components
- **`docker-compose.prod.yml`** — **reuses** `docker/Dockerfile.soak` (deps + full code) and the `.env`/`.jarvis` secret+persistence pattern. Overrides entrypoint → `scripts/launch_linux_prod.sh` (computes `$(nproc)` **inside the container** → AST pool = cores-1, BG pool = cores/2). **No CPU cap** (the opposite of the 4-core soak limit — prod wants every core for unthrottled AST parsing + a non-starved loop). `restart: always` (survives crash + reboot). Bakes the bottleneck fixes: pytest 30→180s, AST 1→nproc, $10 cap, 60-min wall, all three session features on. **Validated:** `docker compose -f docker-compose.prod.yml config` resolves clean (run locally).
- **`deploy/provision_docker_host.sh`** — idempotent Docker Engine + compose-plugin install (apt/dnf), enables dockerd on boot. Raw host → ready.
- **`deploy/DEPLOY_PROD.md`** — the single-line bootstrap + what to grep for the first `state=applied`.

### The single-line bootstrap (raw Linux host → first generation run)
```bash
curl -fsSL https://raw.githubusercontent.com/drussell23/JARVIS/main/deploy/provision_docker_host.sh | sudo bash && git clone https://github.com/drussell23/JARVIS.git /opt/jarvis && cd /opt/jarvis && scp you@vault:/secure/.env . && docker compose -f docker-compose.prod.yml up -d --build && docker compose -f docker-compose.prod.yml logs -f jarvis-prod
```

### Security
Secrets (`DOUBLEWORD_API_KEY` / `ANTHROPIC_API_KEY`) live in `.env`, injected at runtime only — **never baked into the image**. `.jarvis/` bind-mount keeps funded keys + the episodic/evidence chain across container death.

### Honest validation status
- ✅ `docker compose config` resolves; provisioner + compose structurally sound + idempotent.
- ⚠️ **Not yet run on a real Linux host** — that run IS the first `state=applied` proving ground. The software (budget fix + quota isolation + fleet evaluator, all merged) is validated; this bridge gives it the compute it needs.

## Test plan
- [x] `docker compose -f docker-compose.prod.yml config` resolves clean
- [x] `bash -n` on provisioner + launcher
- [ ] First `state=applied` run on a dedicated Linux host via the bootstrap above

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up a production IaC path for the Sovereign Cloud Orchestrator using Docker Compose on a high‑compute Linux host, replacing the brittle bash path and unlocking full‑core AST parsing for reliable `state=applied` runs.

- **New Features**
  - Added `docker-compose.prod.yml` that reuses the soak image, reads `.env`, bind‑mounts `.jarvis/`, sets `restart: always`, removes CPU caps, and launches via `scripts/launch_linux_prod.sh` to scale pools from `nproc`. Includes longer test timeouts, budget/wall caps, and enables fleet evaluator and quota isolation.
  - Added `deploy/provision_docker_host.sh` (idempotent) to install Docker Engine + compose on Debian/Ubuntu and RHEL/Fedora, and enable `dockerd` on boot.
  - Added `deploy/DEPLOY_PROD.md` with a single‑line bootstrap and log markers to verify the first `state=applied`.

- **Migration**
  - Stage funded `.env` on the host, run `deploy/provision_docker_host.sh`, then `docker compose -f docker-compose.prod.yml up -d --build`; tail logs for `state=applied`.
  - Secrets stay in `.env` (runtime only). `.jarvis/` persists keys and evidence across restarts.
  - First real Linux‑host run is pending and will validate the path.

<sup>Written for commit 5fb8d1e139debd799406f803de71bd271eed8b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

