### PR TITLE
feat(fleet): Autonomic Repair Sentinel — idle DW O+V self-verification

### DIFF
--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -5078,6 +5078,42 @@ SEED_SPECS: list = [
         since="2026-06-19",
     ),
     FlagSpec(
+        name="JARVIS_FLEET_SENTINEL_ENABLED",
+        type=FlagType.BOOL, default=False,
+        description=(
+            "Master for the Autonomic Repair Sentinel: on idle cycles, run a "
+            "mutated slice of the O+V repair battery against the monitored DW "
+            "coder(s) and feed pass/fail into the FleetEvaluator EWMA so a "
+            "degrading model is auto-deprioritised before it fails a live op. "
+            "Default OFF (opt-in — spends real DW budget, cost-capped)."
+        ),
+        category=Category.ROUTING,
+        source_file="backend/core/ouroboros/governance/fleet_repair_sentinel.py",
+        example="true",
+        since="2026-06-20",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_SENTINEL_DEFECTS_PER_CYCLE",
+        type=FlagType.INT, default=3,
+        description=(
+            "Repair-battery defects probed per Sentinel idle cycle (bounds "
+            "cost; rotates across the battery + monitored models over cycles)."
+        ),
+        category=Category.CAPACITY,
+        source_file="backend/core/ouroboros/governance/fleet_repair_sentinel.py",
+        example="3",
+        since="2026-06-20",
+    ),
+    FlagSpec(
+        name="JARVIS_FLEET_SENTINEL_MAX_TOKENS",
+        type=FlagType.INT, default=1024,
+        description="Per-repair max_tokens cap for Sentinel generation probes.",
+        category=Category.CAPACITY,
+        source_file="backend/core/ouroboros/governance/fleet_repair_sentinel.py",
+        example="1024",
+        since="2026-06-20",
+    ),
+    FlagSpec(
         name="JARVIS_FLEET_GRAD_MIN_SAMPLES",
         type=FlagType.INT, default=5,
         description=(

--- a/backend/core/ouroboros/governance/fleet_evaluator.py
+++ b/backend/core/ouroboros/governance/fleet_evaluator.py
@@ -211,6 +211,28 @@ class FleetEvaluator:
         self.flag_persister = flag_persister or _default_flag_persister
         self._consecutive_wins = 0
         self._last_winner: Optional[str] = None
+        self._repair_sentinel: Any = None  # lazily built when sentinel enabled
+
+    # -- autonomic repair sentinel (idle self-verification) ----------------- #
+    async def _maybe_run_repair_sentinel(self, *, now: float) -> None:
+        """Run the Autonomic Repair Sentinel on this idle tick. Independent of
+        the calibration master (it self-gates on JARVIS_FLEET_SENTINEL_ENABLED +
+        idle + cost). Late-imported to avoid a circular dep. NEVER raises."""
+        try:
+            from backend.core.ouroboros.governance.fleet_repair_sentinel import (
+                RepairSentinel,
+                repair_sentinel_enabled,
+            )
+            if not repair_sentinel_enabled():
+                return
+            if self._repair_sentinel is None:
+                self._repair_sentinel = RepairSentinel(
+                    model_caller=self.model_caller, store=self.store,
+                    idle_check=self.idle_check, clock=self.clock,
+                )
+            await self._repair_sentinel.maybe_run_sentinel(now=now)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[FleetEvaluator] repair sentinel skipped: %s", exc)
 
     # -- single probe ------------------------------------------------------- #
     async def _probe_one(
@@ -301,6 +323,11 @@ class FleetEvaluator:
         """Idle-cycle entry. Short-circuits before any probe when the master
         switch is off or the system is not idle. Never raises."""
         try:
+            # Autonomic Repair Sentinel — runs FIRST + independent of the
+            # calibration master (self-gated on JARVIS_FLEET_SENTINEL_ENABLED +
+            # idle + cost), so DW O+V health self-verifies even when periodic
+            # model calibration is off.
+            await self._maybe_run_repair_sentinel(now=now)
             if not fleet_evaluator_enabled():
                 return
             if not self.idle_check():

--- a/backend/core/ouroboros/governance/fleet_repair_battery.py
+++ b/backend/core/ouroboros/governance/fleet_repair_battery.py
@@ -1,0 +1,151 @@
+"""Fleet repair battery — the canonical O+V repair-cycle defect set + runner.
+
+The single source of truth for the DW-driven repair battery: a set of diverse
+defects (each = buggy source + a test that catches it) and the pure
+GENERATE -> VALIDATE(ast) -> APPLY -> VERIFY(pytest) cycle that runs ONE defect
+through an injectable provider caller. `scripts/dw_ov_soak.py` and the
+RepairSentinel both import from here — no logic duplication.
+
+The caller matches FleetEvaluator's ``default_model_caller`` contract
+(``async (model_id, messages, *, max_tokens) -> ProbeResult``) so the live DW
+provider is shared, not re-implemented. NEVER executes model output during
+VALIDATE — only ``ast.parse`` (reuses fleet_quality_battery). The APPLY+VERIFY
+step DOES run the candidate under pytest in an isolated temp dir off the event
+loop (asyncio.to_thread) — that is the O+V VERIFY phase, by design.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Sequence, Tuple
+
+from backend.core.ouroboros.governance.fleet_quality_battery import (
+    extract_code_block,
+    is_ast_valid,
+)
+
+# DW coders proven valid in fleet calibration; tried in cascade order.
+DEFAULT_MODELS: Tuple[str, ...] = (
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "openai/gpt-oss-120b",
+    "deepseek-ai/DeepSeek-V4-Flash",
+)
+
+
+@dataclass(frozen=True)
+class Defect:
+    """One repair target: a buggy function + a test that catches the bug +
+    the function's name (so the mutator can rename it consistently)."""
+    name: str
+    fn_name: str
+    buggy_src: str
+    test_src: str
+
+
+@dataclass(frozen=True)
+class RepairResult:
+    applied: bool
+    model: str
+    completion_tokens: int
+    seconds: float
+    note: str
+
+
+# The canonical battery — 8 diverse defect classes (all proven repairable by DW
+# in the 16/16 soak). test_src imports the function from module ``m``.
+BATTERY: Tuple[Defect, ...] = (
+    Defect("arithmetic", "add_two",
+           "def add_two(a, b):\n    return a - b\n",
+           "from m import add_two\ndef test():\n    assert add_two(2,3)==5\n    assert add_two(-1,1)==0\n"),
+    Defect("comparison", "is_positive",
+           "def is_positive(n):\n    return n < 0\n",
+           "from m import is_positive\ndef test():\n    assert is_positive(5) is True\n    assert is_positive(-2) is False\n"),
+    Defect("off_by_one", "last_index",
+           "def last_index(xs):\n    return len(xs)\n",
+           "from m import last_index\ndef test():\n    assert last_index([1,2,3])==2\n    assert last_index(['a'])==0\n"),
+    Defect("wrong_op_max", "biggest",
+           "def biggest(xs):\n    return min(xs)\n",
+           "from m import biggest\ndef test():\n    assert biggest([3,7,1])==7\n"),
+    Defect("boolean_logic", "both_true",
+           "def both_true(a, b):\n    return a or b\n",
+           "from m import both_true\ndef test():\n    assert both_true(True, False) is False\n    assert both_true(True, True) is True\n"),
+    Defect("string_reverse", "reverse",
+           "def reverse(s):\n    return s\n",
+           "from m import reverse\ndef test():\n    assert reverse('abc')=='cba'\n"),
+    Defect("missing_return", "double",
+           "def double(x):\n    result = x * 2\n",
+           "from m import double\ndef test():\n    assert double(4)==8\n"),
+    Defect("edge_empty", "safe_div",
+           "def safe_div(a, b):\n    return a / b\n",
+           "from m import safe_div\ndef test():\n    assert safe_div(6,2)==3\n    assert safe_div(5,0)==0\n"),
+)
+
+_PROMPT_TMPL = (
+    "You are repairing a Python defect. The function below FAILS its unit test. "
+    "Fix the bug. Return the COMPLETE corrected function as ONLY a single python "
+    "code block — no prose.\n\n```python\n{src}```\n\nFailing test:\n```python\n{test}```"
+)
+
+
+def repair_prompt(buggy_src: str, test_src: str) -> str:
+    return _PROMPT_TMPL.format(src=buggy_src, test=test_src)
+
+
+def _run_pytest(code: str, test_src: str, timeout_s: float) -> bool:
+    """APPLY candidate to a temp module + VERIFY via pytest. Blocking — call via
+    asyncio.to_thread. Returns True iff the test passes. NEVER raises."""
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            with open(os.path.join(td, "m.py"), "w", encoding="utf-8") as fh:
+                fh.write(code + "\n")
+            with open(os.path.join(td, "test_m.py"), "w", encoding="utf-8") as fh:
+                fh.write(test_src)
+            r = subprocess.run(
+                [sys.executable, "-m", "pytest", "test_m.py", "-q"],
+                cwd=td, capture_output=True, text=True, timeout=timeout_s,
+            )
+            return r.returncode == 0
+    except Exception:  # noqa: BLE001 — verify failure is a fail, never a raise
+        return False
+
+
+async def repair_one(
+    caller: Callable[..., Awaitable[Any]],
+    defect: Defect,
+    *,
+    models: Sequence[str] = DEFAULT_MODELS,
+    max_tokens: int = 1024,
+    verify_timeout_s: float = 60.0,
+) -> RepairResult:
+    """Run ONE defect through the full O+V cycle via ``caller`` (FleetEvaluator
+    ProbeResult contract). Cascades through ``models``. NEVER raises."""
+    prompt = repair_prompt(defect.buggy_src, defect.test_src)
+    messages = [{"role": "user", "content": prompt}]
+    last_note = "no_models"
+    for model in models:
+        try:
+            pr = await caller(model, messages, max_tokens=max_tokens)
+        except Exception as exc:  # noqa: BLE001
+            last_note = f"generate_error:{str(exc)[:40]}"
+            continue
+        if not getattr(pr, "ok", False):
+            last_note = f"provider_not_ok:{getattr(pr, 'error', '')[:30]}"
+            continue
+        text = getattr(pr, "text", "") or ""
+        if not is_ast_valid(text):              # VALIDATE — ast.parse only
+            last_note = "ast_invalid"
+            continue
+        code = extract_code_block(text)
+        toks = int(getattr(pr, "completion_tokens", 0) or 0)
+        total_ms = float(getattr(pr, "total_ms", 0.0) or 0.0)
+        verified = await asyncio.to_thread(
+            _run_pytest, code, defect.test_src, verify_timeout_s,
+        )
+        if verified:                            # APPLY + VERIFY passed
+            return RepairResult(True, model, toks, total_ms / 1000.0, "state=applied")
+        last_note = "verify_failed"
+    return RepairResult(False, models[-1] if models else "?", 0, 0.0, last_note)

--- a/backend/core/ouroboros/governance/fleet_repair_mutator.py
+++ b/backend/core/ouroboros/governance/fleet_repair_mutator.py
@@ -1,0 +1,117 @@
+"""Fleet repair mutator — anti-overfit variant generation for the battery.
+
+Produces semantically-IDENTICAL variants of a battery defect by consistently
+renaming the function + its parameters + locals (and propagating the new
+function name into the test). Renaming cannot change behavior, so:
+
+  * the SAME bug is preserved (the test still catches it), and
+  * the correct fix is still verifiable by the (renamed) test.
+
+This defeats model memorization of the 8 fixed defects WITHOUT the unsound
+defect-synthesis-from-arbitrary-commits approach (you cannot auto-derive ground
+truth for arbitrary code). Pure + deterministic given a seed (stdlib only).
+
+The seed MAY be derived from recent-commit topology (see seed_from_text) so the
+variant identifiers drift as the repo evolves — honoring "test against the
+evolving shape of the repo" via the only sound mechanism: structural variation
+of verifiable cases.
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+from typing import Dict
+
+from backend.core.ouroboros.governance.fleet_repair_battery import Defect
+
+
+def seed_from_text(text: str) -> int:
+    """Deterministic non-negative seed from arbitrary text (e.g. concatenated
+    recent commit subjects). NEVER raises."""
+    try:
+        h = hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+        return int(h[:8], 16)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def _token(seed: int, salt: str) -> str:
+    """Short deterministic identifier-safe suffix token from (seed, salt)."""
+    h = hashlib.sha256(f"{seed}:{salt}".encode("utf-8")).hexdigest()
+    return "v" + h[:4]
+
+
+class _Renamer(ast.NodeTransformer):
+    def __init__(self, mapping: Dict[str, str]) -> None:
+        self._m = mapping
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
+        if node.name in self._m:
+            node.name = self._m[node.name]
+        self.generic_visit(node)
+        return node
+
+    def visit_AsyncFunctionDef(self, node: ast.AST) -> ast.AST:
+        return self.visit_FunctionDef(node)  # type: ignore[arg-type]
+
+    def visit_arg(self, node: ast.arg) -> ast.AST:
+        if node.arg in self._m:
+            node.arg = self._m[node.arg]
+        return node
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if node.id in self._m:
+            node.id = self._m[node.id]
+        return node
+
+
+def _collect_renamable(fn: ast.FunctionDef) -> Dict[str, str]:
+    """The function name is renamed by the caller (needed for the test too);
+    here we collect param + local-variable names to rename. NEVER raises."""
+    names = set()
+    for a in list(fn.args.args) + list(fn.args.posonlyargs) + list(fn.args.kwonlyargs):
+        names.add(a.arg)
+    for sub in ast.walk(fn):
+        if isinstance(sub, ast.Assign):
+            for t in sub.targets:
+                if isinstance(t, ast.Name):
+                    names.add(t.id)
+    return {n: "" for n in names}  # values filled by caller
+
+
+def mutate(defect: Defect, *, seed: int) -> Defect:
+    """Return a renamed, semantically-identical variant of *defect*.
+    Falls back to the original defect on any parse/unparse error (fail-soft)."""
+    try:
+        tree = ast.parse(defect.buggy_src)
+        fn = next(
+            (n for n in tree.body
+             if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))),
+            None,
+        )
+        if fn is None:
+            return defect
+        new_fn_name = f"{defect.fn_name}_{_token(seed, 'fn')}"
+        mapping: Dict[str, str] = {defect.fn_name: new_fn_name}
+        for local in _collect_renamable(fn):  # type: ignore[arg-type]
+            if local == defect.fn_name:
+                continue
+            mapping[local] = f"{local}_{_token(seed, local)}"
+        new_tree = _Renamer(mapping).visit(tree)
+        ast.fix_missing_locations(new_tree)
+        new_buggy = ast.unparse(new_tree)
+        # Propagate ONLY the function-name rename into the test (the test
+        # references the function by name via import + call; it does not see
+        # the function's internal params/locals). Whole-word replace.
+        new_test = re.sub(
+            rf"\b{re.escape(defect.fn_name)}\b", new_fn_name, defect.test_src,
+        )
+        return Defect(
+            name=f"{defect.name}:mut",
+            fn_name=new_fn_name,
+            buggy_src=new_buggy + "\n",
+            test_src=new_test,
+        )
+    except Exception:  # noqa: BLE001 — fail-soft to the canonical defect
+        return defect

--- a/backend/core/ouroboros/governance/fleet_repair_sentinel.py
+++ b/backend/core/ouroboros/governance/fleet_repair_sentinel.py
@@ -1,0 +1,165 @@
+"""Autonomic Repair Sentinel — background self-verification of DW O+V health.
+
+On idle cycles, runs a small (mutated, anti-overfit) slice of the repair battery
+against the monitored DW coder(s) and records each pass/fail into the EXISTING
+``FleetCalibrationStore`` (``record_probe(kind="code", code_pass=...)``). That
+feeds the SAME EWMA → ``fleet_rerank`` → ``graduation_ready`` machinery the
+FleetEvaluator already owns — so if DeepSeek-V4-Pro starts failing synthetic
+repairs in the background, its ``ast_pass_rate`` EWMA drops and it is
+auto-deprioritised in routing BEFORE it fails a live op. No new demotion logic:
+the sentinel is a new SIGNAL SOURCE into the existing calibration brain.
+
+Gated (``JARVIS_FLEET_SENTINEL_ENABLED`` default OFF — opt-in: it spends real DW
+budget), idle-gated, and cost-capped via the shared store spend ledger. NEVER
+raises into the caller. Reuses fleet_repair_battery (cycle) + fleet_repair_mutator
+(variants) + fleet_evaluator (cost knobs) — zero duplication.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Awaitable, Callable, Optional, Sequence
+
+from backend.core.ouroboros.governance.fleet_repair_battery import (
+    BATTERY,
+    DEFAULT_MODELS,
+    Defect,
+    repair_one,
+)
+from backend.core.ouroboros.governance.fleet_repair_mutator import mutate
+from backend.core.ouroboros.governance.fleet_calibration_store import (
+    FleetCalibrationStore,
+)
+from backend.core.ouroboros.governance.fleet_evaluator import (
+    _daily_usd_cap,
+    _estimate_probe_usd,
+)
+
+logger = logging.getLogger(__name__)
+_TRUE = {"1", "true", "yes", "on"}
+
+
+def repair_sentinel_enabled() -> bool:
+    return os.environ.get("JARVIS_FLEET_SENTINEL_ENABLED", "").strip().lower() in _TRUE
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(str(os.environ.get(name, "")).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _max_defects_per_cycle() -> int:
+    return _int_env("JARVIS_FLEET_SENTINEL_DEFECTS_PER_CYCLE", 3)
+
+
+def _probe_max_tokens() -> int:
+    return _int_env("JARVIS_FLEET_SENTINEL_MAX_TOKENS", 1024)
+
+
+class RepairSentinel:
+    """Idle-driven DW O+V self-verification. All collaborators injectable."""
+
+    def __init__(
+        self,
+        *,
+        model_caller: Callable[..., Awaitable[Any]],
+        store: Optional[FleetCalibrationStore] = None,
+        idle_check: Optional[Callable[[], bool]] = None,
+        clock: Optional[Callable[[], float]] = None,
+        monitored_models: Sequence[str] = DEFAULT_MODELS,
+        defects: Sequence[Defect] = BATTERY,
+        seed_source: Optional[Callable[[], int]] = None,
+        emit: Optional[Callable[..., None]] = None,
+    ) -> None:
+        self.model_caller = model_caller
+        self.store = store or FleetCalibrationStore()
+        self.idle_check = idle_check or (lambda: True)
+        self.clock = clock or time.time
+        self.monitored_models = tuple(monitored_models)
+        self.defects = tuple(defects)
+        # Default seed rotates with the clock so variants differ each cycle.
+        self.seed_source = seed_source or (lambda: int(self.clock()) & 0x7FFFFFFF)
+        self._emit_fn = emit
+        self._cursor = 0  # rotates which defects + model are probed each cycle
+
+    async def maybe_run_sentinel(self, *, now: float) -> int:
+        """Idle entry. Returns #defects probed this cycle (0 if skipped).
+        NEVER raises."""
+        try:
+            if not repair_sentinel_enabled():
+                return 0
+            if not self.idle_check():
+                return 0
+            cap = _daily_usd_cap()
+            if cap > 0.0 and self.store.spend_today(now) >= cap:
+                logger.info(
+                    "[RepairSentinel] daily cap reached ($%.4f>=$%.2f) — skip",
+                    self.store.spend_today(now), cap,
+                )
+                return 0
+            if not self.monitored_models or not self.defects:
+                return 0
+            # Rotate: one model + a window of defects per cycle (bounds cost).
+            model = self.monitored_models[self._cursor % len(self.monitored_models)]
+            n = max(1, _max_defects_per_cycle())
+            start = self._cursor % len(self.defects)
+            window = [self.defects[(start + i) % len(self.defects)] for i in range(min(n, len(self.defects)))]
+            self._cursor += 1
+            seed = int(self.seed_source())
+            probed = 0
+            for defect in window:
+                variant = mutate(defect, seed=seed)
+                res = await repair_one(
+                    self.model_caller, variant,
+                    models=(model,), max_tokens=_probe_max_tokens(),
+                )
+                tok_per_s = res.completion_tokens / max(res.seconds, 1e-3)
+                self.store.record_probe(
+                    model,
+                    kind="code",
+                    code_pass=res.applied,
+                    ttft_ms=res.seconds * 1000.0,
+                    tok_per_s=tok_per_s,
+                    now=now,
+                )
+                self.store.add_spend(
+                    _estimate_probe_usd(res.completion_tokens), now=now,
+                )
+                probed += 1
+                logger.info(
+                    "[RepairSentinel] model=%s defect=%s applied=%s %.1fs (%s)",
+                    model, variant.name, res.applied, res.seconds, res.note,
+                )
+                self._emit("fleet_calibrated", {
+                    "source": "repair_sentinel",
+                    "model_id": model,
+                    "defect": variant.name,
+                    "applied": res.applied,
+                    "seconds": round(res.seconds, 2),
+                })
+            try:
+                self.store.save()
+            except Exception:  # noqa: BLE001
+                pass
+            return probed
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[RepairSentinel] cycle skipped: %s", exc)
+            return 0
+
+    def _emit(self, event_type: str, payload: dict) -> None:
+        """Best-effort SSE (reuses fleet_calibrated event type). NEVER raises."""
+        try:
+            if self._emit_fn is not None:
+                self._emit_fn(event_type, payload)
+                return
+            from backend.core.ouroboros.governance.ide_observability_stream import (
+                get_default_broker,
+            )
+            broker = get_default_broker()
+            if broker is not None:
+                broker.publish(event_type, f"sentinel-{event_type}", payload)
+        except Exception:  # noqa: BLE001
+            pass

--- a/scripts/dw_ov_soak.py
+++ b/scripts/dw_ov_soak.py
@@ -1,128 +1,61 @@
-"""DW-primary O+V soak (2026-06-20).
+"""DW-primary O+V soak (2026-06-20) — thin CLI over the canonical battery.
 
-Soaks the DoubleWord-driven O+V repair cycle over a BATTERY of diverse real
-defects, multiple rounds, reporting per-op state=applied + aggregate success
-rate / latency / cost. Pure DW autarky (no Claude, no J-Prime). Runs on a 16GB
-M1 because it exercises only the core repair cycle (GENERATE -> VALIDATE/ast ->
-APPLY -> VERIFY/pytest), NOT the 6-layer sensor stack that starves the loop.
+Soaks the DoubleWord-driven O+V repair cycle over the SHARED defect battery,
+multiple rounds, reporting per-op state=applied + aggregate success rate /
+latency / cost. Pure DW autarky. Runs on a 16GB M1 (core repair cycle only, not
+the starving sensor stack).
+
+REUSES backend.core.ouroboros.governance.fleet_repair_battery (BATTERY +
+repair_one) and fleet_evaluator.default_model_caller — NO logic duplication
+(this is the SAME battery the Autonomic Repair Sentinel runs in the background).
 
 Run: DOUBLEWORD_API_KEY=... python3 scripts/dw_ov_soak.py [rounds]
 """
 from __future__ import annotations
 
-import ast
-import json
+import asyncio
 import os
-import re
-import subprocess
 import sys
-import tempfile
-import time
-import urllib.request
 
-KEY = os.environ.get("DOUBLEWORD_API_KEY", "")
-BASE = os.environ.get("DOUBLEWORD_BASE_URL", "https://api.doubleword.ai/v1").rstrip("/")
-MODELS = ["deepseek-ai/DeepSeek-V4-Pro", "openai/gpt-oss-120b", "deepseek-ai/DeepSeek-V4-Flash"]
-OUT_PER_MTOK = 1.10  # DeepSeek-V4 output tier, for a cost estimate
-
-# Each defect: (name, buggy_source, test_body). The test CATCHES the bug.
-DEFECTS = [
-    ("arithmetic", "def add_two(a, b):\n    return a - b\n",
-     "from m import add_two\ndef test():\n    assert add_two(2,3)==5\n    assert add_two(-1,1)==0\n"),
-    ("comparison", "def is_positive(n):\n    return n < 0\n",
-     "from m import is_positive\ndef test():\n    assert is_positive(5) is True\n    assert is_positive(-2) is False\n"),
-    ("off_by_one", "def last_index(xs):\n    return len(xs)\n",
-     "from m import last_index\ndef test():\n    assert last_index([1,2,3])==2\n    assert last_index(['a'])==0\n"),
-    ("wrong_op_max", "def biggest(xs):\n    return min(xs)\n",
-     "from m import biggest\ndef test():\n    assert biggest([3,7,1])==7\n"),
-    ("boolean_logic", "def both_true(a, b):\n    return a or b\n",
-     "from m import both_true\ndef test():\n    assert both_true(True, False) is False\n    assert both_true(True, True) is True\n"),
-    ("string_reverse", "def reverse(s):\n    return s\n",
-     "from m import reverse\ndef test():\n    assert reverse('abc')=='cba'\n"),
-    ("missing_return", "def double(x):\n    result = x * 2\n",
-     "from m import double\ndef test():\n    assert double(4)==8\n"),
-    ("edge_empty", "def safe_div(a, b):\n    return a / b\n",
-     "from m import safe_div\ndef test():\n    assert safe_div(6,2)==3\n    assert safe_div(5,0)==0\n"),
-]
-
-PROMPT_TMPL = (
-    "You are repairing a Python defect. The function below FAILS its unit test. "
-    "Fix the bug. Return the COMPLETE corrected function as ONLY a single python "
-    "code block — no prose.\n\n```python\n{src}```\n\nFailing test:\n```python\n{test}```"
+from backend.core.ouroboros.governance.fleet_repair_battery import (
+    BATTERY,
+    DEFAULT_MODELS,
+    repair_one,
 )
+from backend.core.ouroboros.governance.fleet_evaluator import default_model_caller
+
+OUT_PER_MTOK = 1.10  # DeepSeek-V4 output tier, cost estimate
 
 
-def dw_generate(model, prompt):
-    body = json.dumps({"model": model, "messages": [{"role": "user", "content": prompt}],
-                       "max_tokens": 1024, "temperature": 0.0}).encode()
-    req = urllib.request.Request(BASE + "/chat/completions", data=body,
-        headers={"Authorization": "Bearer " + KEY, "Content-Type": "application/json"})
-    t0 = time.monotonic()
-    with urllib.request.urlopen(req, timeout=90) as r:
-        d = json.load(r)
-    return (d["choices"][0]["message"].get("content") or "",
-            int(d.get("usage", {}).get("completion_tokens", 0) or 0), time.monotonic() - t0)
-
-
-def extract(text):
-    m = re.search(r"```(?:python)?\s*(.*?)```", text or "", re.S)
-    return (m.group(1) if m else (text or "")).strip()
-
-
-def repair_one(_name, src, test):
-    """Full O+V cycle for one defect. Returns (applied, model, toks, secs, note)."""
-    prompt = PROMPT_TMPL.format(src=src, test=test)
-    for model in MODELS:
-        try:
-            text, toks, dt = dw_generate(model, prompt)
-        except Exception as e:
-            return (False, model, 0, 0.0, f"generate_error:{str(e)[:40]}")
-        code = extract(text)
-        try:
-            ast.parse(code)               # VALIDATE
-        except Exception:
-            continue                      # ast-invalid -> next model
-        with tempfile.TemporaryDirectory() as td:  # APPLY + VERIFY
-            with open(os.path.join(td, "m.py"), "w") as fh:
-                fh.write(code + "\n")
-            with open(os.path.join(td, "test_m.py"), "w") as fh:
-                fh.write(test)
-            r = subprocess.run([sys.executable, "-m", "pytest", "test_m.py", "-q"],
-                               cwd=td, capture_output=True, text=True, timeout=60)
-        if r.returncode == 0:
-            return (True, model, toks, dt, "state=applied")
-        # verified-fail -> try next model (capability cascade)
-    return (False, MODELS[-1], 0, 0.0, "all_models_failed_verify")
-
-
-def main():
-    if not KEY:
+async def main() -> int:
+    if not os.environ.get("DOUBLEWORD_API_KEY", ""):
         print("ERROR: DOUBLEWORD_API_KEY not set"); return 2
     rounds = int(sys.argv[1]) if len(sys.argv) > 1 else 2
-    print(f"=== DW-primary O+V soak: {len(DEFECTS)} defects x {rounds} rounds "
+    print(f"=== DW-primary O+V soak: {len(BATTERY)} defects x {rounds} rounds "
           f"(pure DW autarky) ===\n")
-    applied = total = toks_sum = 0
+    applied = total = toks = 0
     lat = []
     for rnd in range(1, rounds + 1):
-        print(f"── round {rnd}/{rounds} ──")
-        for name, src, test in DEFECTS:
-            ok, model, toks, dt, note = repair_one(name, src, test)
-            total += 1; toks_sum += toks
-            if ok:
-                applied += 1; lat.append(dt)
-            mark = "✅" if ok else "❌"
-            print(f"  {mark} {name:16} {note:22} model={model.split('/')[-1]:22} "
-                  f"{dt:4.1f}s {toks:4}tok")
+        print(f"-- round {rnd}/{rounds} --")
+        for defect in BATTERY:
+            res = await repair_one(default_model_caller, defect, models=DEFAULT_MODELS)
+            total += 1; toks += res.completion_tokens
+            if res.applied:
+                applied += 1; lat.append(res.seconds)
+            mark = "OK " if res.applied else "XX "
+            print(f"  {mark} {defect.name:16} {res.note:22} "
+                  f"model={res.model.split('/')[-1]:22} {res.seconds:4.1f}s "
+                  f"{res.completion_tokens:4}tok")
         print()
     rate = 100.0 * applied / total if total else 0.0
     mean_lat = sum(lat) / len(lat) if lat else 0.0
-    print("═══════════════════════════════════════════════════════════")
+    print("=" * 59)
     print(f"  state=applied : {applied}/{total}  ({rate:.0f}%)")
     print(f"  mean latency  : {mean_lat:.1f}s (applied ops)")
-    print(f"  total tokens  : {toks_sum}  (~${toks_sum/1_000_000*OUT_PER_MTOK:.5f})")
-    print("═══════════════════════════════════════════════════════════")
+    print(f"  total tokens  : {toks}  (~${toks/1_000_000*OUT_PER_MTOK:.5f})")
+    print("=" * 59)
     return 0 if applied == total else 1
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(asyncio.run(main()))

--- a/tests/governance/test_fleet_repair_battery.py
+++ b/tests/governance/test_fleet_repair_battery.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance.fleet_repair_battery import (
+    BATTERY, repair_one,
+)
+from backend.core.ouroboros.governance.fleet_evaluator import ProbeResult
+
+
+def _defect(name):
+    return next(d for d in BATTERY if d.name == name)
+
+
+def _caller(text, ok=True, toks=50):
+    async def call(model, messages, *, max_tokens):
+        return ProbeResult(text=text, ttft_ms=100.0, total_ms=1000.0,
+                           completion_tokens=toks, ok=ok, error="")
+    return call
+
+
+@pytest.mark.asyncio
+async def test_correct_fix_reaches_state_applied():
+    good = "```python\ndef add_two(a, b):\n    return a + b\n```"
+    res = await repair_one(_caller(good), _defect("arithmetic"), models=("m",))
+    assert res.applied is True and res.note == "state=applied"
+
+
+@pytest.mark.asyncio
+async def test_wrong_fix_fails_verify():
+    bad = "```python\ndef add_two(a, b):\n    return a - b\n```"   # still buggy
+    res = await repair_one(_caller(bad), _defect("arithmetic"), models=("m",))
+    assert res.applied is False and res.note == "verify_failed"
+
+
+@pytest.mark.asyncio
+async def test_ast_invalid_is_rejected():
+    res = await repair_one(_caller("```python\ndef add_two(((\n```"),
+                           _defect("arithmetic"), models=("m",))
+    assert res.applied is False and res.note == "ast_invalid"
+
+
+@pytest.mark.asyncio
+async def test_provider_not_ok_cascades_then_fails():
+    res = await repair_one(_caller("", ok=False), _defect("arithmetic"), models=("m",))
+    assert res.applied is False and res.note.startswith("provider_not_ok")

--- a/tests/governance/test_fleet_repair_mutator.py
+++ b/tests/governance/test_fleet_repair_mutator.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import ast
+from backend.core.ouroboros.governance.fleet_repair_battery import BATTERY, Defect
+from backend.core.ouroboros.governance.fleet_repair_mutator import mutate, seed_from_text
+
+
+def _defect(name):
+    return next(d for d in BATTERY if d.name == name)
+
+
+def test_mutate_renames_fn_in_both_and_stays_ast_valid():
+    d = _defect("arithmetic")
+    m = mutate(d, seed=123)
+    assert m.fn_name != d.fn_name
+    assert m.fn_name in m.buggy_src and m.fn_name in m.test_src
+    ast.parse(m.buggy_src)              # variant still parses
+    ast.parse(m.test_src)
+
+
+def test_mutate_preserves_the_bug():
+    # arithmetic bug = subtraction; renaming must NOT fix it
+    m = mutate(_defect("arithmetic"), seed=7)
+    body = m.buggy_src.split("return")[1]
+    assert "-" in body and "+" not in body
+
+
+def test_mutate_deterministic_for_seed():
+    d = _defect("comparison")
+    assert mutate(d, seed=42).buggy_src == mutate(d, seed=42).buggy_src
+    assert mutate(d, seed=1).fn_name != mutate(d, seed=2).fn_name
+
+
+def test_mutate_renames_locals():
+    m = mutate(_defect("missing_return"), seed=9)   # has a local `result`
+    assert "result_" in m.buggy_src                 # local was renamed
+
+
+def test_seed_from_text_deterministic():
+    assert seed_from_text("abc") == seed_from_text("abc")
+    assert seed_from_text("abc") != seed_from_text("xyz")
+    assert seed_from_text("") >= 0
+
+
+def test_mutate_failsoft_on_garbage():
+    bad = Defect("bad", "f", "def (((", "x")
+    assert mutate(bad, seed=1) is bad   # unparseable -> original returned

--- a/tests/governance/test_fleet_repair_sentinel.py
+++ b/tests/governance/test_fleet_repair_sentinel.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+import re
+import pytest
+from backend.core.ouroboros.governance.fleet_repair_battery import BATTERY
+from backend.core.ouroboros.governance.fleet_evaluator import ProbeResult
+from backend.core.ouroboros.governance import fleet_calibration_store as s
+from backend.core.ouroboros.governance.fleet_repair_sentinel import RepairSentinel
+
+
+_ARITH = next(d for d in BATTERY if d.name == "arithmetic")
+
+
+def _first_block(prompt):
+    m = re.search(r"```python\s*(.*?)```", prompt, re.S)
+    return m.group(1) if m else ""
+
+
+def _smart_caller(fix=True):
+    """Prompt-aware fake: fixes the (possibly mutated/renamed) function it's
+    given, mirroring a real model. fix=False returns the buggy code unchanged."""
+    async def call(model, messages, *, max_tokens):
+        buggy = _first_block(messages[-1]["content"])
+        # operator fix, robust to the mutator's param renaming (a -> a_vXXXX)
+        out = buggy.replace(" - ", " + ", 1) if fix else buggy
+        return ProbeResult(text="```python\n" + out + "```", ttft_ms=100.0,
+                           total_ms=1000.0, completion_tokens=60, ok=True, error="")
+    return call
+
+
+def _store(tmp_path):
+    import os
+    os.environ["JARVIS_FLEET_CALIBRATION_PATH"] = str(tmp_path / "c.json")
+    return s.FleetCalibrationStore()
+
+
+@pytest.mark.asyncio
+async def test_disabled_is_noop(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_SENTINEL_ENABLED", "false")
+    calls = []
+    async def spy(m, msgs, *, max_tokens):
+        calls.append(m); return ProbeResult("", 0, 0, 0, False, "")
+    sen = RepairSentinel(model_caller=spy, store=_store(tmp_path),
+                         defects=(_ARITH,), monitored_models=("m",))
+    assert await sen.maybe_run_sentinel(now=1.0) == 0
+    assert calls == []          # gated off -> zero DW calls
+
+
+@pytest.mark.asyncio
+async def test_not_idle_is_noop(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_SENTINEL_DEFECTS_PER_CYCLE", "1")
+    sen = RepairSentinel(model_caller=_smart_caller(), store=_store(tmp_path),
+                         idle_check=lambda: False, defects=(_ARITH,),
+                         monitored_models=("m",))
+    assert await sen.maybe_run_sentinel(now=1.0) == 0
+
+
+@pytest.mark.asyncio
+async def test_passing_repair_records_code_pass_true(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FLEET_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_SENTINEL_DEFECTS_PER_CYCLE", "1")
+    st = _store(tmp_path)
+    sen = RepairSentinel(model_caller=_smart_caller(fix=True), store=st,
+                         idle_check=lambda: True, clock=lambda: 1.0,
+                         defects=(_ARITH,), monitored_models=("dw-pro",))
+    probed = await sen.maybe_run_sentinel(now=1.0)
+    assert probed == 1
+    sc = st.score("dw-pro")
+    assert sc is not None and sc.ast_pass_rate > 0.9    # healthy -> high EWMA
+
+
+@pytest.mark.asyncio
+async def test_failing_repair_records_demote_signal(monkeypatch, tmp_path):
+    """Auto-demote signal: a DW model that FAILS the synthetic repair drives its
+    ast_pass_rate EWMA down (feeds the existing rerank/graduation demotion)."""
+    monkeypatch.setenv("JARVIS_FLEET_SENTINEL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FLEET_SENTINEL_DEFECTS_PER_CYCLE", "1")
+    st = _store(tmp_path)
+    st.record_probe("dw-pro", kind="code", code_pass=True, ttft_ms=100, tok_per_s=50, now=1.0)
+    sen = RepairSentinel(model_caller=_smart_caller(fix=False), store=st,
+                         idle_check=lambda: True, clock=lambda: 2.0,
+                         defects=(_ARITH,), monitored_models=("dw-pro",))
+    await sen.maybe_run_sentinel(now=2.0)
+    sc = st.score("dw-pro")
+    assert sc.ast_pass_rate < 1.0      # degraded by the failed synthetic repair


### PR DESCRIPTION
## Autonomic Repair Sentinel — permanent DW O+V self-verification

Weaponizes the proven repair battery (16/16 soak) from a manual CLI into a **background heartbeat** that feeds the FleetEvaluator's existing EWMA → rerank → demotion brain. If DeepSeek-V4-Pro starts failing synthetic repairs on idle, its `ast_pass_rate` drops and it's **auto-deprioritised before it fails a live op**. Reuse-first, gated, cost-capped.

### Architecture (4 modules, no duplication)
- **`fleet_repair_battery.py`** — canonical defect battery + `repair_one` cycle (GENERATE→VALIDATE/ast→APPLY→VERIFY/pytest). `scripts/dw_ov_soak.py` now imports it (de-duped). Reuses `fleet_quality_battery` AST helpers + FleetEvaluator's `ProbeResult` caller.
- **`fleet_repair_mutator.py`** — pure AST mutator: renames fn/params/locals → semantically-identical, **verifiable** variants (defeats model overfitting on the fixed 8).
- **`fleet_repair_sentinel.py`** — async idle-driven sentinel; records pass/fail via `store.record_probe(kind="code")` → the **same** EWMA/rerank/`graduation_ready` demotion. **No new authority logic** — a new signal source into the existing brain. Gated `JARVIS_FLEET_SENTINEL_ENABLED` (default OFF, opt-in), idle-gated, shares the daily-USD cap.
- **`fleet_evaluator`** — `maybe_calibrate` runs the sentinel first (self-gated, independent of the calibration master; late-import breaks the circular dep).

### Honest design correction (param #3)
Generating **defects from arbitrary recent commits with auto-generated correctness tests is not soundly implementable** — you can't auto-derive ground truth for arbitrary code, so the sentinel couldn't verify its own pass/fail (garbage into the demotion math). The implemented anti-overfit mechanism is the sound one: **AST mutation of known-correct cases** (rename/restructure), where every variant stays verifiable by construction. The mutator seed *may* derive from commit text so variants drift with the repo — honoring "test against the evolving repo shape" via the only sound path.

### Live proof
```
sentinel mutated 3 defects -> DeepSeek-V4-Pro repaired all 3
recorded ast_pass_rate=1.00, 3 samples, valid_tok_per_s feeds EWMA
cost: $0.00004
```

### Tests
14 new (mutator 6, battery 4, sentinel 4) incl. the auto-demote signal (a failing synthetic repair drags `ast_pass_rate` down). Full fleet suite **35 green**.

## Test plan
- [x] `pytest tests/governance/test_fleet_repair_{mutator,battery,sentinel}.py` → 14 pass
- [x] Live sentinel against DW → records into EWMA, $0.00004
- [x] Full fleet suite 35 green
- [ ] Arm `JARVIS_FLEET_SENTINEL_ENABLED=true` on the Linux orchestrator for continuous background self-verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a background “Autonomic Repair Sentinel” that runs a small, mutated slice of the DW O+V repair battery on idle and feeds pass/fail into the existing EWMA → rerank pipeline to auto-deprioritize degrading models before live ops. Centralizes the repair battery, adds an AST-based mutator to avoid overfitting, and refactors the soak script to reuse shared logic.

- New Features
  - Background sentinel (`fleet_repair_sentinel.py`) runs on idle, records `kind="code"` pass/fail into the existing store, and respects the shared daily spend cap.
  - Integrated hook in `FleetEvaluator` runs the sentinel first on idle ticks; no new demotion logic, it reuses EWMA → rerank.
  - Canonical repair battery (`fleet_repair_battery.py`) with `repair_one` (GENERATE → VALIDATE/ast → APPLY → VERIFY/pytest), shared by the sentinel and CLI.
  - AST mutator (`fleet_repair_mutator.py`) renames function/params/locals to generate verifiable variants; seedable, deterministic, and prevents memorization.
  - New flags: `JARVIS_FLEET_SENTINEL_ENABLED` (default off), `JARVIS_FLEET_SENTINEL_DEFECTS_PER_CYCLE`, `JARVIS_FLEET_SENTINEL_MAX_TOKENS`.
  - `scripts/dw_ov_soak.py` now imports the battery and `default_model_caller` (no duplicated logic).

- Migration
  - Default is off. Set `JARVIS_FLEET_SENTINEL_ENABLED=true` to enable background self-verification.
  - Optional: tune `JARVIS_FLEET_SENTINEL_DEFECTS_PER_CYCLE` and `JARVIS_FLEET_SENTINEL_MAX_TOKENS` to bound cost.

<sup>Written for commit d20719ae7cf32fb33d1b210abe24f2ca4e8c7523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

