### PR TITLE
feat(c2): Sovereign C2 Telemetry Bridge — distributed observability

### DIFF
--- a/deploy/C2_TELEMETRY.md
+++ b/deploy/C2_TELEMETRY.md
@@ -1,0 +1,71 @@
+# Sovereign C2 Telemetry Bridge — distributed observability
+
+High-fidelity, real-time insight into the remote Linux engine from the M1 dev
+interface — **not** SSH log-tailing. The M1 subscribes to the engine's **native
+SSE event stream** (the same `StreamEventBroker` the IDE extensions consume) and
+renders FleetEvaluator EWMA, OperationAdvisor blocks, and `state=applied`
+victories live.
+
+## Why this design (reuse-first + secure)
+The engine already publishes everything over `GET /observability/stream` (a
+push-based async SSE broker, started by `GovernedLoopService` as the
+`EventChannelServer` on `127.0.0.1:8099`). A parallel Redis Pub/Sub would
+duplicate it. The stream is **loopback-only by a grep-pinned security
+invariant** — so the secure transport is an **SSH local-forward**, which keeps
+the stream loopback-only and adds zero internet-facing surface. SSH carries the
+encrypted bytes; the payload is the live native event stream.
+
+```
+ Linux engine (Publisher)                         M1 (Subscriber)
+ ┌───────────────────────────┐    SSH -L tunnel   ┌──────────────────────────┐
+ │ GLS → EventChannelServer  │  (encrypted)       │ jarvis_c2_subscriber.py  │
+ │ 127.0.0.1:8099            │◄───────────────────│ → live dashboard         │
+ │ /observability/stream     │                    │ (zero backend imports;   │
+ │ fleet_calibrated,         │                    │  cannot starve the loop) │
+ │ operation_terminal, …     │                    └──────────────────────────┘
+ └───────────────────────────┘
+```
+
+## Deploy the engine with the C2 overlay
+`network_mode: host` makes the container's loopback the host's loopback, so the
+loopback-only stream is reachable by an SSH forward to the host:
+
+```bash
+docker compose -f docker-compose.prod.yml -f docker-compose.c2.yml up -d --build
+```
+
+## Connect from the M1 (one command)
+```bash
+./scripts/jarvis_c2_connect.sh user@linux-host
+```
+This opens `ssh -N -L 8099:localhost:8099 user@linux-host` and launches the
+subscriber against `http://localhost:8099`. Live output:
+
+```
+[C2] connected — live engine telemetry:
+  14:03:11 📊 calib[repair_sentinel] DeepSeek-V4-Pro ast=1.0 vtps=18.7
+           └ applied=3 advisor_blocked=1 failed=0 grad=0 | EWMA[DeepSeek-V4-Pro=19]
+  14:03:48 ✅ state=applied op=op-019ee...
+           └ applied=4 advisor_blocked=1 failed=0 grad=0 | EWMA[DeepSeek-V4-Pro=19]
+  14:04:02 🛡  advisor BLOCKED op=op-019ef...
+```
+
+Manual variant (two terminals) if you prefer:
+```bash
+ssh -N -L 8099:localhost:8099 user@linux-host        # terminal 1
+python3 scripts/jarvis_c2_subscriber.py              # terminal 2 (M1)
+```
+
+## Security posture
+- Stream stays **loopback-only** on the engine (invariant untouched).
+- Transport is **SSH** (encrypted, key-auth) — no new listening port on the public interface.
+- Subscriber is **read-only + standalone** (imports only stdlib + aiohttp; no
+  orchestrator/policy modules) — it physically cannot mutate the engine or drag
+  it onto the Mac.
+
+## Validation status
+- ✅ Subscriber pure projection logic unit-tested (7 tests).
+- ✅ Reuses the existing SSE schema (`fleet_calibrated`, `operation_terminal`,
+  governor/breaker events) — all already published by the engine.
+- ⚠️ End-to-end tunnel + live render validated on the first Linux deploy (no
+  remote host available locally).

--- a/docker-compose.c2.yml
+++ b/docker-compose.c2.yml
@@ -1,0 +1,27 @@
+# JARVIS C2 Telemetry overlay (2026-06-20) — distributed observability.
+# =============================================================================
+# Compose OVERRIDE for the prod engine that makes its loopback-only SSE stream
+# (GET /observability/stream, started by GLS on 127.0.0.1:8099) reachable for a
+# secure SSH-forwarded C2 subscriber — WITHOUT weakening the engine's
+# loopback-only security invariant.
+#
+# network_mode: host → the container's loopback IS the host's loopback, so the
+# loopback-bound EventChannelServer listens on the HOST's 127.0.0.1:8099. An
+# SSH local-forward from the M1 (ssh -L 8099:localhost:8099 user@host) then
+# reaches it. No 0.0.0.0 bind, no auth bypass, no new internet-facing surface —
+# the stream stays loopback-only; SSH provides the encrypted transport.
+#
+#   docker compose -f docker-compose.prod.yml -f docker-compose.c2.yml up -d --build
+#
+# Then on the M1: see deploy/C2_TELEMETRY.md (one-line connect).
+# =============================================================================
+services:
+  jarvis-prod:
+    # Host networking: container loopback == host loopback. Port mappings are
+    # ignored under host mode (by design — the SSE stream stays on 127.0.0.1).
+    network_mode: host
+    environment:
+      # Ensure the observability HTTP listener + SSE stream are armed.
+      JARVIS_IDE_OBSERVABILITY_ENABLED: "true"
+      JARVIS_IDE_STREAM_ENABLED: "true"
+      JARVIS_CHANNEL_PORT: "8099"

--- a/scripts/jarvis_c2_connect.sh
+++ b/scripts/jarvis_c2_connect.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# ============================================================================
+# JARVIS C2 connect (2026-06-20) — one command: secure tunnel + live telemetry.
+# ============================================================================
+# Opens an SSH local-forward to the remote Linux engine's loopback SSE stream,
+# then launches the M1 subscriber against it. The stream stays loopback-only on
+# the engine; SSH is the encrypted transport (NOT log-tailing — this is the
+# real-time TrinityEventBus/SSE event stream).
+#
+#   ./scripts/jarvis_c2_connect.sh user@linux-host [remote_port] [local_port]
+#
+# Ctrl-C tears down both the subscriber and the tunnel.
+# ============================================================================
+set -euo pipefail
+
+HOSTSPEC="${1:?usage: jarvis_c2_connect.sh user@host [remote_port] [local_port]}"
+RPORT="${2:-8099}"
+LPORT="${3:-8099}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+echo "[C2] opening SSH forward localhost:${LPORT} -> ${HOSTSPEC}:127.0.0.1:${RPORT}"
+ssh -N -L "${LPORT}:localhost:${RPORT}" "${HOSTSPEC}" &
+SSH_PID=$!
+trap 'echo "[C2] tearing down tunnel"; kill "${SSH_PID}" 2>/dev/null || true' EXIT INT TERM
+
+# Give the tunnel a moment to establish.
+sleep 2
+echo "[C2] launching subscriber → http://localhost:${LPORT}"
+python3 "${REPO_ROOT}/scripts/jarvis_c2_subscriber.py" --url "http://localhost:${LPORT}"

--- a/scripts/jarvis_c2_subscriber.py
+++ b/scripts/jarvis_c2_subscriber.py
@@ -1,0 +1,174 @@
+"""JARVIS C2 Telemetry Subscriber — lightweight remote observability (2026-06-20).
+
+The DEV-side (M1) half of the bi-directional C2 bridge. Subscribes to the remote
+Linux engine's NATIVE SSE event stream (``GET /observability/stream`` — the same
+StreamEventBroker the IDE extensions consume) and renders a live local dashboard
+of the telemetry that matters: FleetEvaluator EWMA, OperationAdvisor blocks, and
+state=applied victories.
+
+This is NOT log-tailing — it's the real-time TrinityEventBus/SSE event stream,
+just consumed remotely. Deliberately a STANDALONE thin client: it imports ZERO
+backend/organism modules (only stdlib + aiohttp), so it cannot drag the heavy
+engine onto the Mac or starve its event loop. Bounded memory, exp-backoff
+reconnect, heartbeat-aware.
+
+Secure transport (respects the engine's loopback-only invariant — no new attack
+surface): SSH local-forward to the host's loopback stream, then point here at it:
+    ssh -N -L 8099:localhost:8099 user@linux-host        # in one terminal
+    python3 scripts/jarvis_c2_subscriber.py              # in another (M1)
+
+Run: python3 scripts/jarvis_c2_subscriber.py [--url http://localhost:8099] [--token T]
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import time
+from typing import Dict, List, Optional, Tuple
+
+# ---- pure event projection (unit-tested) ----------------------------------- #
+
+# The C2-relevant subset of the engine's ~60 SSE event types.
+_C2_EVENTS = {
+    "fleet_calibrated", "fleet_graduated", "operation_terminal",
+    "governor_throttle_applied", "governor_emergency_brake",
+    "memory_pressure_changed", "circuit_breaker_tripped",
+}
+
+
+def parse_sse_block(block: str) -> Tuple[Optional[str], Optional[dict]]:
+    """Parse one SSE record (``event:``/``data:`` lines) → (event_type, payload).
+    Returns (None, None) for heartbeats/comments/malformed. NEVER raises."""
+    event_type: Optional[str] = None
+    data_lines: List[str] = []
+    for line in block.splitlines():
+        if line.startswith(":"):           # SSE comment / heartbeat
+            continue
+        if line.startswith("event:"):
+            event_type = line[6:].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[5:].strip())
+    if not data_lines:
+        return event_type, None
+    try:
+        return event_type, json.loads("\n".join(data_lines))
+    except Exception:  # noqa: BLE001
+        return event_type, None
+
+
+class C2Dashboard:
+    """Bounded, pure telemetry aggregator. ingest() returns a one-line summary
+    (or None to suppress); render_status() gives the rolling headline."""
+
+    def __init__(self, recent_cap: int = 50) -> None:
+        self.applied = 0
+        self.blocked = 0
+        self.failed = 0
+        self.advisor_blocks = 0
+        self.graduations = 0
+        self.ewma: Dict[str, float] = {}      # model -> last valid_tok_per_s
+        self.ast_pass: Dict[str, float] = {}  # model -> last ast_pass_rate
+        self.recent: List[str] = []
+        self._cap = recent_cap
+
+    def ingest(self, event_type: Optional[str], data: Optional[dict]) -> Optional[str]:
+        if event_type not in _C2_EVENTS or not isinstance(data, dict):
+            return None
+        line: Optional[str] = None
+        if event_type == "fleet_calibrated":
+            m = str(data.get("model_id", "?")).split("/")[-1]
+            if "valid_tok_per_s" in data:
+                self.ewma[m] = float(data.get("valid_tok_per_s", 0.0) or 0.0)
+            if "ast_pass_rate" in data:
+                self.ast_pass[m] = float(data.get("ast_pass_rate", 0.0) or 0.0)
+            src = data.get("source", "calib")
+            applied = data.get("applied")
+            line = (f"📊 calib[{src}] {m} ast={self.ast_pass.get(m, '?')} "
+                    f"vtps={self.ewma.get(m, '?')}"
+                    + (f" applied={applied}" if applied is not None else ""))
+        elif event_type == "fleet_graduated":
+            self.graduations += 1
+            line = f"🎓 GRADUATED coder={data.get('winner', data.get('model_id', '?'))}"
+        elif event_type == "operation_terminal":
+            state = str(data.get("state", "")).lower()
+            reason = str(data.get("terminal_reason_code", data.get("reason", "")))
+            if state == "applied":
+                self.applied += 1
+                line = f"✅ state=applied op={str(data.get('op_id', '?'))[:18]}"
+            elif "advisor_blocked" in reason:
+                self.advisor_blocks += 1
+                line = f"🛡  advisor BLOCKED op={str(data.get('op_id', '?'))[:18]}"
+            elif state in ("blocked", "failed"):
+                self.failed += 1
+                line = f"❌ {state} op={str(data.get('op_id', '?'))[:18]} ({reason[:30]})"
+        elif event_type == "circuit_breaker_tripped":
+            line = f"⚡ breaker tripped: {data.get('terminal_reason_code', '?')}"
+        elif event_type.startswith("governor") or event_type == "memory_pressure_changed":
+            line = f"🔧 {event_type}: {json.dumps(data)[:60]}"
+        if line:
+            self.recent.append(line)
+            if len(self.recent) > self._cap:
+                self.recent.pop(0)
+        return line
+
+    def render_status(self) -> str:
+        ew = " ".join(f"{m}={v:.0f}" for m, v in sorted(self.ewma.items())) or "—"
+        return (f"applied={self.applied} advisor_blocked={self.advisor_blocks} "
+                f"failed={self.failed} grad={self.graduations} | EWMA[{ew}]")
+
+
+# ---- async network shell (thin; not unit-tested) --------------------------- #
+
+async def subscribe(url: str, token: Optional[str] = None) -> None:
+    import aiohttp  # late import — keeps the module importable for unit tests
+    dash = C2Dashboard()
+    headers = {"Accept": "text/event-stream"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    backoff = 1.0
+    stream_url = url.rstrip("/") + "/observability/stream"
+    print(f"[C2] subscribing → {stream_url}")
+    while True:
+        try:
+            timeout = aiohttp.ClientTimeout(total=None, sock_read=60)
+            async with aiohttp.ClientSession(timeout=timeout) as sess:
+                async with sess.get(stream_url, headers=headers) as resp:
+                    if resp.status != 200:
+                        print(f"[C2] stream HTTP {resp.status} — retrying");
+                        await asyncio.sleep(backoff); backoff = min(backoff * 2, 30); continue
+                    backoff = 1.0
+                    print("[C2] connected — live engine telemetry:")
+                    buf = ""
+                    async for chunk in resp.content.iter_any():
+                        buf += chunk.decode("utf-8", errors="ignore")
+                        while "\n\n" in buf:
+                            block, buf = buf.split("\n\n", 1)
+                            et, data = parse_sse_block(block)
+                            line = dash.ingest(et, data)
+                            if line:
+                                ts = time.strftime("%H:%M:%S")
+                                print(f"  {ts} {line}")
+                                print(f"         └ {dash.render_status()}")
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            print(f"[C2] disconnected ({type(exc).__name__}) — reconnecting in {backoff:.0f}s")
+            await asyncio.sleep(backoff); backoff = min(backoff * 2, 30)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="JARVIS C2 telemetry subscriber")
+    ap.add_argument("--url", default="http://localhost:8099",
+                    help="engine base URL (default loopback / SSH-forwarded)")
+    ap.add_argument("--token", default=None, help="bearer token (if engine C2 auth on)")
+    args = ap.parse_args()
+    try:
+        asyncio.run(subscribe(args.url, args.token))
+    except KeyboardInterrupt:
+        print("\n[C2] subscriber stopped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/governance/test_c2_subscriber.py
+++ b/tests/governance/test_c2_subscriber.py
@@ -1,0 +1,57 @@
+"""Tests for the C2 telemetry subscriber's pure projection logic (no network)."""
+from __future__ import annotations
+import importlib.util
+import os
+
+# Load the standalone script as a module (it lives in scripts/, not a package).
+_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "scripts",
+                     "jarvis_c2_subscriber.py")
+_spec = importlib.util.spec_from_file_location("jarvis_c2_subscriber", _PATH)
+c2 = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(c2)  # type: ignore[union-attr]
+
+
+def test_parse_sse_block_event_and_data():
+    et, data = c2.parse_sse_block('event: fleet_calibrated\ndata: {"model_id": "x", "ast_pass_rate": 1.0}')
+    assert et == "fleet_calibrated" and data["ast_pass_rate"] == 1.0
+
+
+def test_parse_sse_block_heartbeat_and_malformed():
+    assert c2.parse_sse_block(": heartbeat") == (None, None)
+    et, data = c2.parse_sse_block("event: x\ndata: {not json")
+    assert et == "x" and data is None
+
+
+def test_dashboard_counts_state_applied():
+    d = c2.C2Dashboard()
+    line = d.ingest("operation_terminal", {"state": "applied", "op_id": "op-1"})
+    assert "state=applied" in line and d.applied == 1
+
+
+def test_dashboard_counts_advisor_block():
+    d = c2.C2Dashboard()
+    line = d.ingest("operation_terminal",
+                    {"state": "blocked", "terminal_reason_code": "advisor_blocked", "op_id": "o"})
+    assert "advisor BLOCKED" in line and d.advisor_blocks == 1
+
+
+def test_dashboard_tracks_fleet_ewma():
+    d = c2.C2Dashboard()
+    d.ingest("fleet_calibrated",
+             {"model_id": "deepseek/DeepSeek-V4-Pro", "valid_tok_per_s": 90.0, "ast_pass_rate": 1.0})
+    assert d.ewma["DeepSeek-V4-Pro"] == 90.0
+    assert "applied=" in d.render_status() and "EWMA[" in d.render_status()
+
+
+def test_dashboard_ignores_irrelevant_events():
+    d = c2.C2Dashboard()
+    assert d.ingest("heartbeat", {"x": 1}) is None
+    assert d.ingest("task_updated", {"x": 1}) is None
+    assert d.ingest(None, None) is None
+
+
+def test_dashboard_recent_is_bounded():
+    d = c2.C2Dashboard(recent_cap=5)
+    for i in range(20):
+        d.ingest("operation_terminal", {"state": "applied", "op_id": f"o{i}"})
+    assert len(d.recent) == 5 and d.applied == 20


### PR DESCRIPTION
## Sovereign C2 Telemetry Bridge — remote insight into the Linux engine

Real-time, high-fidelity observability of the remote Linux engine from the M1 dev interface — **not** SSH log-tailing, the native real-time event stream, tunneled.

### Reuse-first reframe
The engine **already** has the network streaming layer: `GovernedLoopService` starts `EventChannelServer` on `127.0.0.1:8099` serving `GET /observability/stream` — a push-based async SSE broker with ~60 event types (incl. `fleet_calibrated`, `operation_terminal`, governor/breaker events), which the IDE extensions already consume. A parallel Redis Pub/Sub would duplicate it + add a heavy dep. So the bridge is the missing **subscriber + secure transport**, not a new bus.

### Components
- **`scripts/jarvis_c2_subscriber.py`** — standalone M1 SSE subscriber. Imports **zero backend modules** (only stdlib + aiohttp) → physically cannot drag the organism onto the Mac or starve its loop. Renders FleetEvaluator EWMA, OperationAdvisor blocks, `state=applied` victories live; bounded memory, exp-backoff reconnect, heartbeat-aware.
- **`scripts/jarvis_c2_connect.sh`** — one command: SSH local-forward + launch subscriber.
- **`docker-compose.c2.yml`** — overlay adding `network_mode: host` so the loopback-only stream is reachable by an SSH forward **without weakening the loopback-only security invariant** (no `0.0.0.0`, no auth bypass — SSH is the encrypted transport). Validated: `docker compose -f docker-compose.prod.yml -f docker-compose.c2.yml config` resolves.
- **`deploy/C2_TELEMETRY.md`** — rationale + one-line connect.

### Security posture
Stream stays **loopback-only** (invariant untouched); transport is **SSH** (encrypted, key-auth, no new public port); subscriber is **read-only + standalone**. Bypasses heavy CPU on the M1 by construction (thin client).

### Live render (illustrative)
```
14:03:11 📊 calib[repair_sentinel] DeepSeek-V4-Pro ast=1.0 vtps=18.7
         └ applied=3 advisor_blocked=1 failed=0 grad=0 | EWMA[DeepSeek-V4-Pro=19]
14:03:48 ✅ state=applied op=op-019ee...
14:04:02 🛡  advisor BLOCKED op=op-019ef...
```

## Test plan
- [x] `pytest tests/governance/test_c2_subscriber.py` → 7 pass (pure SSE-parse + dashboard projection)
- [x] `docker compose -f docker-compose.prod.yml -f docker-compose.c2.yml config` resolves
- [x] `bash -n` on connect.sh
- [ ] End-to-end tunnel + live render on the first Linux deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lightweight C2 Telemetry Bridge to stream real-time engine events from the remote Linux host to the M1 over SSH. Reuses the existing loopback SSE stream for secure, high-fidelity observability without opening new ports.

- **New Features**
  - `scripts/jarvis_c2_subscriber.py`: standalone SSE client using `aiohttp`; shows EWMA, advisor blocks, and applied ops; bounded memory with reconnects.
  - `scripts/jarvis_c2_connect.sh`: one command to open an SSH local-forward and launch the subscriber.
  - `docker-compose.c2.yml`: `network_mode: host` overlay enabling access to the loopback-only stream via SSH; sets stream env flags.
  - `deploy/C2_TELEMETRY.md`: rationale and one-line connect instructions.
  - `tests/governance/test_c2_subscriber.py`: unit tests for SSE parsing and dashboard projection.

- **Migration**
  - Deploy with: docker compose -f docker-compose.prod.yml -f docker-compose.c2.yml up -d --build
  - Connect from dev: ./scripts/jarvis_c2_connect.sh user@linux-host
  - Security: stream remains loopback-only; SSH provides encrypted transport; subscriber is read-only.

<sup>Written for commit 84288652f2c66377a052d7a0b8881e20640668a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

