### PR TITLE
feat(deploy): M1 Docker Desktop overlay — adaptive constrained-host run

### DIFF
--- a/docker-compose.desktop.yml
+++ b/docker-compose.desktop.yml
@@ -1,0 +1,55 @@
+# JARVIS Desktop (M1 / Docker Desktop) overlay — adaptive constrained-host run.
+# =============================================================================
+# Runs the REAL engine on a 16GB-class Mac via Docker Desktop. The container VM
+# is decoupled from the dev/agent process (the contention that starved the
+# nested host runs) but gets only a SUBSET of the Mac's RAM — so survival here
+# depends on the engine SELF-THROTTLING under pressure, not on raw headroom.
+#
+# Root-cause approach (reuse-first, adaptive, no hardcoding): arm the EXISTING
+# MemoryPressureGate + SensorGovernor aggressively so the 16-sensor swarm reads
+# real memory % and dynamically sheds op-emission + L3 fanout as the VM fills —
+# the same graduated subsystems, tuned tight for a constrained host. No sensor
+# is hardcoded off; the swarm scales itself to whatever RAM Docker Desktop gives.
+#
+# Overlay on prod (reuses Dockerfile.soak + entrypoint + secret/persistence):
+#   open -a Docker                                   # launch Docker Desktop, wait for it
+#   # then in Settings → Resources, give it as much RAM as you can spare (>=12GB)
+#   docker compose -f docker-compose.prod.yml -f docker-compose.desktop.yml up -d --build
+#   docker compose -f docker-compose.prod.yml -f docker-compose.desktop.yml logs -f jarvis-prod
+# =============================================================================
+services:
+  jarvis-prod:
+    # Hard memory ceiling so the container can't drag the Mac under; tune to your
+    # Docker Desktop allocation (leave the host ~4GB). The engine self-throttles
+    # well before this via the pressure gate below.
+    mem_limit: 11g
+    deploy:
+      resources:
+        limits:
+          memory: 11g
+    environment:
+      # --- adaptive pressure response (reused graduated subsystems, tight) ---
+      JARVIS_MEMORY_PRESSURE_GATE_ENABLED: "true"
+      JARVIS_MEMORY_PRESSURE_PROCESS_DIM_ENABLED: "true"
+      JARVIS_MEMORY_PRESSURE_WARN_PCT: "0.55"     # trip earlier than default
+      JARVIS_MEMORY_PRESSURE_HIGH_PCT: "0.70"
+      JARVIS_MEMORY_PRESSURE_CRITICAL_PCT: "0.82"
+      JARVIS_MEMORY_PRESSURE_WARN_FANOUT_CAP: "2"
+      JARVIS_MEMORY_PRESSURE_HIGH_FANOUT_CAP: "1"
+      JARVIS_MEMORY_PRESSURE_CRITICAL_FANOUT_CAP: "1"
+      JARVIS_SENSOR_GOVERNOR_ENABLED: "true"
+      JARVIS_SENSOR_GOVERNOR_GLOBAL_CAP_PER_HOUR: "40"   # vs 200 default — fewer on-loop intakes
+      JARVIS_SENSOR_GOVERNOR_EMERGENCY_COST_THRESHOLD: "0.7"
+      JARVIS_SENSOR_GOVERNOR_EMERGENCY_REDUCTION_PCT: "0.85"
+      # --- constrained pools (don't oversubscribe the small VM) ---
+      JARVIS_AST_HELPER_POOL_MAX_WORKERS: "2"
+      JARVIS_BG_POOL_SIZE: "2"
+      # --- pure DW autarky on the M1 (Claude credits out; J-Prime can't hold) ---
+      JARVIS_PROVIDER_CLAUDE_DISABLED: "true"
+      JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED: "true"
+      JARVIS_FLEET_EVALUATOR_ENABLED: "true"
+      JARVIS_FLEET_SENTINEL_ENABLED: "true"
+      # --- modest leashes for a desktop run ---
+      OUROBOROS_BATTLE_COST_CAP: "3.00"
+      OUROBOROS_BATTLE_MAX_WALL_SECONDS: "1800"
+      JARVIS_INTENT_PYTEST_TIMEOUT_S: "180"


### PR DESCRIPTION
## M1 Docker Desktop overlay — run the real engine on a constrained Mac

Answers "can we start it on local Docker Desktop?" — yes, via an adaptive overlay that gives the **real engine** its best shot on a 16GB Mac.

### The honest physics
- **Decoupled VM helps:** Docker Desktop runs the container in its own VM, free of the dev/agent-process contention that caused the nested host runs to starve.
- **Less RAM hurts:** Docker Desktop gets a *subset* of the 16GB (default ~8GB). So it's a coin-flip for the *full* sensor loop — survival depends on **self-throttling**, not headroom.

### Root-cause, reuse-first adaptive response
Arms the **existing** `MemoryPressureGate` + `SensorGovernor` (graduated, default-on) aggressively: earlier WARN/HIGH/CRITICAL trip points, tight L3 fanout caps, 40/hr global op cap (vs 200). The 16-sensor swarm reads **real memory %** and dynamically sheds load as the VM fills — **no sensor hardcoded off**, the swarm scales itself to whatever RAM it's given. Plus an 11g hard ceiling, constrained pools, pure DW autarky.

### Launch
```bash
open -a Docker            # launch Docker Desktop; bump Settings → Resources → Memory to >=12GB
docker compose -f docker-compose.prod.yml -f docker-compose.desktop.yml up -d --build
docker compose -f docker-compose.prod.yml -f docker-compose.desktop.yml logs -f jarvis-prod
```

### Honest expectation
The proven DW-primary O+V repair core works on this hardware regardless (16/16 soak). This overlay gives the *full autonomous loop* its best adaptive shot in a Docker Desktop VM; if memory still bites, the governors shed load rather than starve, and the Linux orchestrator (PR #69581) remains the unconstrained home.

## Test plan
- [x] `docker compose -f docker-compose.prod.yml -f docker-compose.desktop.yml config` resolves
- [ ] Live `up` on Docker Desktop (requires the daemon running; observe self-throttle vs starve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Docker Desktop overlay to run the real engine on 16GB-class Macs by self-throttling under tight memory. It tightens memory gates/governor and caps the container at 11g so the swarm scales to the VM’s RAM instead of starving.

- **New Features**
  - Adds docker-compose.desktop.yml overlay for Apple Silicon Docker Desktop.
  - Caps container memory at 11g via mem_limit and deploy.limits.memory.
  - Aggressive MemoryPressureGate and SensorGovernor tuning (lower thresholds, fanout caps, 40/hr global cap).
  - Smaller worker pools (AST 2, BG 2), modest cost/time limits, `Claude` provider disabled; fleet evaluator/sentinel enabled.

- **Migration**
  - In Docker Desktop, set Resources → Memory to ≥12 GB.
  - Start: docker compose -f docker-compose.prod.yml -f docker-compose.desktop.yml up -d --build
  - Logs: docker compose -f docker-compose.prod.yml -f docker-compose.desktop.yml logs -f jarvis-prod

<sup>Written for commit 721bc2e45d86e0b43d20e131bf657ed1ecfeb6e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

