### PR TITLE
fix(soak-image): add networkx so Oracle boots at 100% in the container

### DIFF
--- a/docker/requirements-soak.txt
+++ b/docker/requirements-soak.txt
@@ -50,3 +50,10 @@ fastembed
 # Slice 156 — interactive Discord control gateway (bot). Light (pure-python + aiohttp
 # already present). Gated JARVIS_DISCORD_GATEWAY_ENABLED default-FALSE.
 discord.py>=2.3
+
+# 2026-06-20 — Oracle codebase-graph dependency. WITHOUT this the container boots
+# with "Oracle failed to boot: networkx is required" and runs with the codebase
+# graph unavailable (degraded exploration/context). Confirmed missing in the
+# live Docker Desktop run; the rest of governance/__init__'s import graph is
+# already satisfied (verified by in-container import). Pure-python wheel, light.
+networkx>=3.0


### PR DESCRIPTION
## Add `networkx` to the soak image (Oracle dependency)

The live Docker Desktop full-loop run booted with:
```
WARNING Oracle failed to boot: networkx is required for Oracle. Install with: pip install networkx
WARNING [GovernedLoop] Oracle initialization failed: ... codebase graph unavailable
```
`networkx` was missing from `docker/requirements-soak.txt`, so Oracle ran degraded (no codebase graph → weaker exploration/context). Added it (pure-python wheel, light). The rest of `governance/__init__`'s import graph is already satisfied — verified by a clean in-container `import` of the governance package, so this is the one precise gap.

## Honest scope note (the operator's Readiness Matrix)
- **Param #1 (dependency realignment): done** — this PR.
- **Param #2 (synthetic probe on `/v1/models` RBAC 401): NOT built — by design.** Diagnosis disproved the RBAC premise: the key returns **200 on `/v1/models` directly**, both on the host and *inside the container*. The 401 is purely the **Aegis credential proxy** failing to inject the key on the DW passthrough (a credential-injection gap `credential_env_loader.py` explicitly documents), not RBAC. A synthetic probe gated on "RBAC 401" would fire on the wrong condition. The real fix is in the Aegis daemon credential handoff — a separate, focused change.

## Test plan
- [x] `networkx` import confirmed missing in the running container
- [ ] Rebuild image + confirm `Oracle ... booted` (no networkx warning) on next container run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `networkx>=3.0` to `docker/requirements-soak.txt` so Oracle boots with the codebase graph enabled in the soak container. This fixes the degraded startup caused by the missing dependency.

<sup>Written for commit 851c74088cb89379cdef20fdd54925a028f824b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

