### PR TITLE
fix(autarky): config-disabled Claude engages DW full-runway grant

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -777,6 +777,27 @@ _CLAUDE_DISABLED_ENV = "JARVIS_PROVIDER_CLAUDE_DISABLED"
 _SLICE23_MIN_PROMOTED_FOR_AUTO = 2
 
 
+def _claude_config_disabled() -> bool:
+    """True when the Claude fallback tier is STRUCTURALLY disabled via
+    ``JARVIS_PROVIDER_CLAUDE_DISABLED`` — the deadest possible fallback (the
+    provider is never even constructed), distinct from a tripped circuit breaker.
+
+    DW-autarky's full-runway grant (Slice 225) keys off ``_claude_breaker_open``,
+    which reads only the breaker STATE — and a config-disabled Claude never trips
+    the breaker, so it stays CLOSED and autarky NEVER engaged under
+    ``JARVIS_PROVIDER_CLAUDE_DISABLED=true``. The sole-lane DW was then held to
+    the 90s reflex cap and TIMED OUT on slow hosts (live container soak,
+    2026-06-20). A config-disabled Claude is *more* dead than a breaker-open one;
+    this predicate lets the autarky path treat it as such. Reuses the existing
+    ``_CLAUDE_DISABLED_ENV`` constant (no new flag). NEVER raises."""
+    try:
+        return os.environ.get(_CLAUDE_DISABLED_ENV, "").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+    except Exception:  # noqa: BLE001 — fail-closed to legacy cascade
+        return False
+
+
 def _slice23_should_activate_sentinel(provider_route: str) -> Tuple[bool, str]:
     """Slice 23 — autonomous registry-driven sentinel activation.
 
@@ -5242,13 +5263,20 @@ class CandidateGenerator:
             # OFF (or breaker CLOSED) is the byte-identical legacy cascade.
             _fallback_dead = False
             if _dw_autarky_enabled():
-                try:
-                    from backend.core.ouroboros.governance.doubleword_provider import (
-                        _claude_breaker_open as _autarky_breaker_open,
-                    )
-                    _fallback_dead = _autarky_breaker_open()
-                except Exception:  # noqa: BLE001 — fail-closed to legacy cascade
-                    _fallback_dead = False
+                # A CONFIG-disabled Claude (JARVIS_PROVIDER_CLAUDE_DISABLED) is the
+                # deadest fallback of all — never constructed — yet it leaves the
+                # circuit breaker CLOSED, so the breaker-state check below misses it.
+                # Check it first so the sole-lane DW gets the full runway instead of
+                # the reflex cap (the live-soak TIMEOUT root, 2026-06-20).
+                _fallback_dead = _claude_config_disabled()
+                if not _fallback_dead:
+                    try:
+                        from backend.core.ouroboros.governance.doubleword_provider import (
+                            _claude_breaker_open as _autarky_breaker_open,
+                        )
+                        _fallback_dead = _autarky_breaker_open()
+                    except Exception:  # noqa: BLE001 — fail-closed to legacy cascade
+                        _fallback_dead = False
             primary_budget = self._compute_primary_budget(
                 remaining, model_id=model_id, force_batch=_force_batch,
                 fallback_dead=_fallback_dead,

--- a/tests/governance/test_slice225_dw_autarky.py
+++ b/tests/governance/test_slice225_dw_autarky.py
@@ -71,5 +71,37 @@ def test_fallback_dead_zero_remaining_is_zero():
     assert CandidateGenerator._compute_primary_budget(0.0, fallback_dead=True) == 0.0
 
 
+# ── config-disabled Claude is a DEAD fallback → autarky must engage ─────────
+# Gap: ``_claude_breaker_open()`` reads only the breaker STATE, so a
+# CONFIG-disabled Claude (``JARVIS_PROVIDER_CLAUDE_DISABLED=true``) — which is
+# never even constructed, the deadest possible fallback — leaves the breaker
+# CLOSED and the autarky full-runway grant never engaged, holding the sole-lane
+# DW to the reflex cap until it TIMED OUT. ``_claude_config_disabled()`` closes it.
+
+def test_claude_config_disabled_true_when_env_on(monkeypatch):
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _claude_config_disabled,
+    )
+    for val in ("1", "true", "TRUE", "yes", "on"):
+        monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", val)
+        assert _claude_config_disabled() is True, f"{val!r} should disable Claude"
+
+
+def test_claude_config_disabled_false_when_unset(monkeypatch):
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _claude_config_disabled,
+    )
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)
+    assert _claude_config_disabled() is False
+
+
+def test_claude_config_disabled_false_when_explicit_false(monkeypatch):
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _claude_config_disabled,
+    )
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "false")
+    assert _claude_config_disabled() is False
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary
Closes a DW-autarky gap found during the live containerized DW-primary soak (2026-06-20): under `JARVIS_PROVIDER_CLAUDE_DISABLED=true`, the autarky full-runway grant **never engaged**, so the sole-lane DW was held to the 90s reflex cap and **timed out** (`fsm_failure_mode=TIMEOUT`) → exhaust → cooldown → repeat, never producing a patch.

**Root cause:** DW autarky (Slice 225) lifts the 90s `_PRIMARY_MAX_TIMEOUT_S` cap when the Claude fallback is dead — but its trigger `_claude_breaker_open()` reads only the **circuit-breaker state**. A *config-disabled* Claude is never constructed and never trips the breaker, so it stays `CLOSED`. The deadest possible fallback was invisible to the very check meant to detect a dead fallback.

**Fix:** add `_claude_config_disabled()` (reuses the existing `_CLAUDE_DISABLED_ENV` constant — no new flag) and OR it into the `_fallback_dead` computation in `_call_primary`, checked before the breaker-state probe. Still gated by `_dw_autarky_enabled()` (default-TRUE); autarky-off or Claude-enabled is byte-identical legacy.

## Test Plan
- [x] `tests/governance/test_slice225_dw_autarky.py` — 9 passed (3 new: env-on/unset/explicit-false)
- [x] `tests/governance/test_provider_quota_isolation.py` — 4 passed (regression)
- [x] `python3 -c "import ast; ast.parse(...)"` — clean
- [ ] Validate on a real Linux host where DW generation has CPU to converge within the now-granted full runway

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DW autarky not engaging when the Claude fallback is disabled by config. With `JARVIS_PROVIDER_CLAUDE_DISABLED=true`, DW now gets the full runway instead of the 90s cap, preventing timeouts on slow hosts.

- **Bug Fixes**
  - Added `_claude_config_disabled()` to detect a config-disabled Claude via `JARVIS_PROVIDER_CLAUDE_DISABLED` (reuses `_CLAUDE_DISABLED_ENV`; no new flag).
  - In `_call_primary`, treat a config-disabled Claude as a dead fallback before the breaker check so autarky engages; unchanged when autarky is off or Claude is enabled.
  - Tests: added 3 env-handling tests; existing governance tests pass.

<sup>Written for commit 16384bc528917f88633e1b272869f7ab2c7f982e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

