### PR TITLE
fix(aegis): release upstream response on every forward exit path

### DIFF
--- a/backend/core/ouroboros/aegis/forwarding.py
+++ b/backend/core/ouroboros/aegis/forwarding.py
@@ -738,6 +738,21 @@ async def forward_request(
             except (ConnectionResetError, aiohttp.ClientConnectionError):
                 client_disconnected = True
 
+            # Release the upstream response on EVERY exit path. Before this,
+            # only the guillotine branch released it; the normal-completion,
+            # client-disconnect, and upstream-read-failed paths left the upstream
+            # ClientResponse unreleased, so when ``async with session`` closed,
+            # aiohttp logged "Unclosed connection" and orphaned the upstream
+            # socket (observed every DW stream forward in the 2026-06-20 soak).
+            # release() is idempotent and safe after a full drain; on an early
+            # break it returns/closes the connection cleanly instead of leaking.
+            # Sync in aiohttp 3.x (not a coroutine — matches the guillotine
+            # branch's no-await call). Guarded so cleanup never fails loud.
+            try:
+                upstream_resp.release()
+            except Exception:  # noqa: BLE001 — cleanup must never fail-loud
+                pass
+
     actual_cost = usage.cost_usd(price)
 
     if guillotine_fired:

--- a/tests/aegis/test_slice78_aegis_realignment.py
+++ b/tests/aegis/test_slice78_aegis_realignment.py
@@ -65,3 +65,36 @@ def test_upstream_read_failure_maps_to_unreachable_outcome():
     assert src.index("upstream_read_failed = True") < src.rindex(
         "ForwardOutcome.UPSTREAM_UNREACHABLE"
     )
+
+
+# --- the upstream connection must be released on EVERY exit path -------------
+# Bug (2026-06-20 DW-stream soak): only the guillotine branch released the
+# upstream ClientResponse. The normal-completion, client-disconnect, and
+# upstream-read-failed paths left it unreleased, so when ``async with session``
+# closed, aiohttp logged "Unclosed connection" and orphaned the upstream socket.
+
+
+def test_upstream_response_released_in_finally_on_all_paths():
+    src = inspect.getsource(forwarding.forward_request)
+    # release must appear at least twice: the pre-existing guillotine branch
+    # AND the new all-paths release in the streaming finally.
+    assert src.count("upstream_resp.release()") >= 2, (
+        "upstream_resp must be released on every exit path, not just guillotine"
+    )
+    # the all-paths release must live inside the streaming finally (after the
+    # write_eof), so client-disconnect / upstream-read-failed breaks still hit it.
+    fin = src.index("finally:")
+    eof = src.index("write_eof", fin)
+    assert src.index("upstream_resp.release()", eof) > eof, (
+        "the all-paths release must be in the finally, after write_eof"
+    )
+
+
+def test_release_is_guarded_so_cleanup_never_fails_loud():
+    src = inspect.getsource(forwarding.forward_request)
+    rel = src.index("upstream_resp.release()", src.index("write_eof"))
+    # the all-paths release is wrapped so a cleanup error can't break the return
+    window = src[rel - 60:rel + 120]
+    assert "try:" in window and "except Exception" in window, (
+        "the all-paths release must be guarded (cleanup must never fail loud)"
+    )


### PR DESCRIPTION
## Summary
Fixes the `aegis-daemon ERROR Unclosed connection` seen on every DW `/v1/chat/completions` stream forward during the 2026-06-20 containerized soak.

**Root cause:** `forward_request` obtains the upstream `ClientResponse` via `session.post()` *without* `async with`, so it must be released explicitly — but only the **guillotine** branch did. The normal-completion, client-disconnect, and upstream-read-failed paths left it unreleased, so when `async with aiohttp.ClientSession` closed, aiohttp logged `Unclosed connection` and orphaned the upstream socket. The aegis graduation soaks (2026-05-25) only exercised Claude `/v1/messages`, never DW OpenAI-compat streaming, so this leak went unseen.

**Fix:** release `upstream_resp` in the streaming `finally` (after `write_eof`) on **all** paths. `release()` is idempotent and safe after a full drain; on an early break it returns/closes the connection cleanly. Sync in aiohttp 3.x (matches the guillotine branch's no-`await` call); guarded so cleanup never fails loud.

## Scope (honest boundary)
This fixes the **connection leak / `Unclosed connection`**. Whether it *fully* resolves the loop-side DW-streaming rupture (the DW provider classifying a gracefully-truncated stream as `live_transport`) must still be characterized by a **DW-streaming graduation soak on a capable (non-2-CPU) host** — that validation can't be run on the constrained M1 Docker Desktop where this was found, and is tracked as follow-up.

## Test Plan
- [x] `tests/aegis/test_slice78_aegis_realignment.py` — 8 passed (2 new: release-in-finally-on-all-paths, release-is-guarded)
- [x] `tests/aegis/test_forwarding.py` + `test_forwarding_nonstreaming_reconcile.py` — 18 passed (byte-identity + happy path unchanged)
- [ ] DW-streaming graduation soak on a capable host (validate the loop-side rupture is gone with aegis ON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes connection leaks in Aegis streaming forwards by releasing the upstream `aiohttp.ClientResponse` on every exit path. Stops `Unclosed connection` errors and orphaned sockets seen during DW `/v1/chat/completions` streams.

- **Bug Fixes**
  - Added `upstream_resp.release()` in the streaming `finally` after `write_eof` so normal completion, client disconnect, and upstream-read-failed paths clean up (not just the guillotine path).
  - Wrapped the release in a try/except; `aiohttp` 3.x `release()` is sync and idempotent, so this is safe on all paths.
  - Added tests to assert the release happens in `finally` and is guarded; existing forwarding tests continue to pass.

<sup>Written for commit cb64482be0f4f00f57700206b53098605781698e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

