### PR TITLE
feat(routing): Sovereign Context-Routing Override Matrix (model pin + soft-lock)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3726,6 +3726,15 @@ class CandidateGenerator:
                     _s201_bandit_ok().record_outcome(model_id, success=True)
                 except Exception:  # noqa: BLE001
                     pass
+                try:
+                    # Override Matrix — clear the model-pin soft-lock streak on a
+                    # real success (passive observed outcome; no active probe).
+                    from backend.core.ouroboros.governance.model_pinning_heuristic import (
+                        note_pin_outcome as _pin_ok,
+                    )
+                    _pin_ok(model_id, success=True)
+                except Exception:  # noqa: BLE001
+                    pass
                 # Slice 20C — zero-candidate drift detection. The
                 # parser succeeded (we're on the success branch) but
                 # may have returned an empty candidates tuple while
@@ -3922,6 +3931,16 @@ class CandidateGenerator:
                         get_bandit_router as _s201_bandit_fail,
                     )
                     _s201_bandit_fail().record_outcome(model_id, success=False)
+                except Exception:  # noqa: BLE001
+                    pass
+                try:
+                    # Override Matrix — feed the model-pin soft-lock a real
+                    # failure (429/500/live-transport). At threshold the pin
+                    # enters cooldown and routing yields to the EWMA ranking.
+                    from backend.core.ouroboros.governance.model_pinning_heuristic import (
+                        note_pin_outcome as _pin_fail,
+                    )
+                    _pin_fail(model_id, success=False)
                 except Exception:  # noqa: BLE001
                     pass
                 # Slice 77 — dynamic transport telemetry. The moment a LIVE

--- a/backend/core/ouroboros/governance/model_pinning_heuristic.py
+++ b/backend/core/ouroboros/governance/model_pinning_heuristic.py
@@ -1,0 +1,190 @@
+"""Sovereign Context-Routing Override Matrix — operator model pin with soft-lock.
+
+When ``JARVIS_DW_PRIMARY_OVERRIDE=<model_id>`` is declared, the named model is
+promoted to **Rank 1 across ALL routes** (IMMEDIATE / STANDARD / COMPLEX /
+BACKGROUND / SPECULATIVE) by intercepting the resolved DW model tuple in
+``provider_topology.dw_models_for_route``. The pin is composed *after*
+``_fleet_guarded`` (the Sovereign Fleet Evaluator EWMA re-rank), so a healthy
+pin overrides the EWMA ordering — and a *failing* pin yields straight back to it.
+
+WHY THIS IS A SOFT LOCK, NOT A HARDCODE
+---------------------------------------
+The operator declares intent ("route to gpt-oss-120b"); the matrix honors it
+only while the model is actually delivering. The pin is suspended automatically
+when the model misbehaves:
+
+  * **Driven by PASSIVELY OBSERVED runtime outcomes** — every real
+    sentinel-dispatch success/failure (429 / 500 / live-transport rupture) is
+    fed to :func:`note_pin_outcome` at the existing dispatch sites. There is NO
+    active synthetic probe: an active boot probe is exactly the heavy-probe
+    false-degrade pathology that wedged the 2026-06-20 container soak
+    (one slow 550B probe degraded the whole stream lane). Observed truth only.
+  * **Consecutive-failure trip:** once the pinned model logs
+    ``JARVIS_DW_PIN_FAIL_THRESHOLD`` (default 3) consecutive failures, the pin
+    enters a cooldown of ``JARVIS_DW_PIN_COOLDOWN_S`` (default 120s) during
+    which ``dw_models_for_route`` returns the standard FleetEvaluator EWMA
+    ranking unchanged. A single success clears the streak immediately.
+
+GATING & SAFETY
+---------------
+  * Unset / empty ``JARVIS_DW_PRIMARY_OVERRIDE`` → OFF, byte-identical legacy.
+  * Pure + fail-soft: any internal error returns the input ranking unchanged.
+  * The pin is prepended (deduped) even if the model is absent from the resolved
+    fleet — an explicit operator declaration is honored, and the soft-lock is
+    the armor: a non-existent/cold model fails fast and the cooldown demotes it.
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Dict, Tuple
+
+_MODEL_PIN_ENV = "JARVIS_DW_PRIMARY_OVERRIDE"
+_PIN_FAIL_THRESHOLD_ENV = "JARVIS_DW_PIN_FAIL_THRESHOLD"
+_PIN_COOLDOWN_ENV = "JARVIS_DW_PIN_COOLDOWN_S"
+
+_DEFAULT_FAIL_THRESHOLD = 3
+_DEFAULT_COOLDOWN_S = 120.0
+
+
+def model_pin_override() -> str:
+    """The operator-declared pinned model id, or ``""`` when unset/disabled.
+
+    Reads ``JARVIS_DW_PRIMARY_OVERRIDE`` per call (env-precedence; an operator
+    can flip the pin live). NEVER raises."""
+    try:
+        return os.environ.get(_MODEL_PIN_ENV, "").strip()
+    except Exception:  # noqa: BLE001 — defensive
+        return ""
+
+
+def _fail_threshold() -> int:
+    try:
+        v = int(os.environ.get(_PIN_FAIL_THRESHOLD_ENV, "").strip() or _DEFAULT_FAIL_THRESHOLD)
+        return v if v >= 1 else _DEFAULT_FAIL_THRESHOLD
+    except (ValueError, TypeError):
+        return _DEFAULT_FAIL_THRESHOLD
+
+
+def _cooldown_s() -> float:
+    try:
+        v = float(os.environ.get(_PIN_COOLDOWN_ENV, "").strip() or _DEFAULT_COOLDOWN_S)
+        return v if v > 0.0 else _DEFAULT_COOLDOWN_S
+    except (ValueError, TypeError):
+        return _DEFAULT_COOLDOWN_S
+
+
+class ModelPinLedger:
+    """Per-model consecutive-failure tracker driving the pin soft-lock.
+
+    Thread-safe (asyncio tasks + the AST/bg thread pools share it). All state
+    is in-memory and process-local — the pin is a live operator override, not
+    durable policy, so it MUST start clean every boot (a stale cooldown must
+    never silently suppress a fresh pin)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._consecutive_failures: Dict[str, int] = {}
+        self._locked_until: Dict[str, float] = {}
+
+    def note_outcome(self, model_id: str, *, success: bool) -> None:
+        """Feed one observed dispatch outcome for ``model_id``. A success clears
+        the streak + any cooldown; a failure increments and, at threshold, arms
+        the cooldown. NEVER raises."""
+        if not model_id:
+            return
+        try:
+            with self._lock:
+                if success:
+                    self._consecutive_failures.pop(model_id, None)
+                    self._locked_until.pop(model_id, None)
+                    return
+                n = self._consecutive_failures.get(model_id, 0) + 1
+                self._consecutive_failures[model_id] = n
+                if n >= _fail_threshold():
+                    self._locked_until[model_id] = time.monotonic() + _cooldown_s()
+        except Exception:  # noqa: BLE001 — telemetry must never break dispatch
+            pass
+
+    def is_soft_locked(self, model_id: str) -> bool:
+        """True while ``model_id`` is inside its failure cooldown. Expired
+        cooldowns self-heal (the entry is cleared on read). NEVER raises."""
+        if not model_id:
+            return False
+        try:
+            with self._lock:
+                until = self._locked_until.get(model_id)
+                if until is None:
+                    return False
+                if time.monotonic() >= until:
+                    # cooldown elapsed → give the pin another chance
+                    self._locked_until.pop(model_id, None)
+                    self._consecutive_failures.pop(model_id, None)
+                    return False
+                return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    def reset(self) -> None:
+        """Clear all state (test hook / live ``/posture``-style reset)."""
+        with self._lock:
+            self._consecutive_failures.clear()
+            self._locked_until.clear()
+
+
+_LEDGER = ModelPinLedger()
+
+
+def get_pin_ledger() -> ModelPinLedger:
+    """Process-wide singleton ledger."""
+    return _LEDGER
+
+
+def note_pin_outcome(model_id: str, *, success: bool) -> None:
+    """Convenience wired into the sentinel-dispatch success/failure sites.
+
+    No-op (cheap early return) unless a pin is active AND this is the pinned
+    model — the ledger only ever needs to track the pinned model. NEVER raises."""
+    try:
+        pin = model_pin_override()
+        if pin and model_id == pin:
+            _LEDGER.note_outcome(model_id, success=success)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def apply_model_pin(route: str, ranked: Tuple[str, ...]) -> Tuple[str, ...]:
+    """Promote the operator-pinned model to Rank 1 of ``ranked`` — the Override
+    Matrix interception. Composed AFTER ``_fleet_guarded`` in
+    ``dw_models_for_route``.
+
+    Returns ``ranked`` unchanged when: no pin declared, the pin is soft-locked
+    (cooldown active → defer to EWMA), or on any internal error. Otherwise
+    returns the pinned model first, followed by the rest of ``ranked`` with the
+    pin deduped. The pin is honored across every route because every route
+    resolves through this one choke point. NEVER raises."""
+    try:
+        pin = model_pin_override()
+        if not pin:
+            return ranked
+        if _LEDGER.is_soft_locked(pin):
+            # Soft lock engaged — yield to the FleetEvaluator EWMA ranking.
+            return ranked
+        rest = tuple(m for m in ranked if m != pin)
+        if len(rest) == len(ranked) and pin in ranked:
+            # (defensive) pin equals an entry but filter kept all — shouldn't
+            # happen; fall through to the prepend below which dedups anyway.
+            pass
+        return (pin,) + rest
+    except Exception:  # noqa: BLE001 — pin is best-effort; never break routing
+        return ranked
+
+
+__all__ = [
+    "model_pin_override",
+    "ModelPinLedger",
+    "get_pin_ledger",
+    "note_pin_outcome",
+    "apply_model_pin",
+]

--- a/backend/core/ouroboros/governance/provider_topology.py
+++ b/backend/core/ouroboros/governance/provider_topology.py
@@ -412,7 +412,7 @@ class ProviderTopology:
                 key = (route or "").strip().lower()
                 ranked = holder.assignments_by_route.get(key, ())
                 if ranked:
-                    return _fleet_guarded(route, ranked)
+                    return _pin_and_fleet_guarded(route, ranked)
             # Fall through to YAML — cold-start, stale, route missing,
             # or route empty in catalog. YAML stays authoritative for
             # all four fallback conditions
@@ -422,7 +422,7 @@ class ProviderTopology:
             return ()
         effective = entry.effective_dw_models
         if effective:
-            return _fleet_guarded(route, effective)
+            return _pin_and_fleet_guarded(route, effective)
         # ── Slice 10B-ii — trusted-seed runtime bypass ──
         # YAML + dynamic catalog both returned empty; consult
         # PromotionLedger for operator-attested trusted seeds that
@@ -430,7 +430,7 @@ class ProviderTopology:
         # :func:`_trusted_seed_dw_models_for_route` for the gate
         # composition (re-uses dw_catalog_classifier.gate_for_route
         # so the same param/price thresholds apply).
-        return _fleet_guarded(route, _trusted_seed_dw_models_for_route(route))
+        return _pin_and_fleet_guarded(route, _trusted_seed_dw_models_for_route(route))
 
     def fallback_tolerance_for_route(self, route: str) -> str:
         """Return the v2 ``fallback_tolerance`` for *route*.
@@ -678,6 +678,26 @@ def _fleet_guarded(route: str, result: Tuple[str, ...]) -> Tuple[str, ...]:
     except Exception:
         pass
     return result
+
+
+def _pin_and_fleet_guarded(route: str, result: Tuple[str, ...]) -> Tuple[str, ...]:
+    """Sovereign Context-Routing Override Matrix (2026-06-20) composed OVER the
+    FleetEvaluator re-rank.
+
+    Order is deliberate: ``_fleet_guarded`` first (measured EWMA quality
+    ordering), then the operator pin on top. A healthy pin
+    (``JARVIS_DW_PRIMARY_OVERRIDE``) is promoted to Rank 1; a soft-locked pin
+    (consecutive failures over threshold → cooldown) yields straight back to the
+    EWMA ordering. Pin unset → returns the fleet result byte-identically. Pure +
+    fail-soft: any error returns the fleet-guarded result unchanged."""
+    fleet_ranked = _fleet_guarded(route, result)
+    try:
+        from backend.core.ouroboros.governance.model_pinning_heuristic import (
+            apply_model_pin,
+        )
+        return apply_model_pin(route, fleet_ranked)
+    except Exception:
+        return fleet_ranked
 
 
 def _locate_policy_yaml() -> Optional[Path]:

--- a/deploy/ouroboros_linux_prod.env
+++ b/deploy/ouroboros_linux_prod.env
@@ -32,6 +32,19 @@ export OUROBOROS_BATTLE_COST_CAP=10.00       # realistic cap (NOT the $0.50 trap
 export OUROBOROS_BATTLE_MAX_WALL_SECONDS=3600 # 60 min soak window
 export OUROBOROS_BATTLE_HEADLESS=true        # daemon/CI: no interactive REPL
 
-# ---- Optional: explicit DW-autarky posture if Claude credits are exhausted.
-#      Leave UNSET to use Claude when funded; set =true to run pure DW. ----
-# export JARVIS_PROVIDER_CLAUDE_DISABLED=true
+# ---- DW-autarky posture (Claude credits exhausted → pure DW). ----
+#      SAFE as of the autarky-config-disable fix (#69589): config-disabled Claude
+#      now engages the full-runway grant, so the sole-lane DW is no longer held to
+#      the 90s reflex cap (the container-soak TIMEOUT root). Comment out if you
+#      refund Claude and want the §5 cascade back.
+export JARVIS_PROVIDER_CLAUDE_DISABLED=true
+
+# ---- Sovereign Context-Routing Override Matrix (#69591): pin the primary DW
+#      coder to Rank 1 across ALL routes. SOFT lock — if the pinned model logs
+#      JARVIS_DW_PIN_FAIL_THRESHOLD (default 3) consecutive 429/500/transport
+#      failures it enters a JARVIS_DW_PIN_COOLDOWN_S (default 120s) cooldown and
+#      routing yields to the FleetEvaluator EWMA ranking, then retries. Unset =
+#      OFF (legacy fleet ranking). Swap to deepseek/DeepSeek-V4-Pro as desired. ----
+export JARVIS_DW_PRIMARY_OVERRIDE=openai/gpt-oss-120b
+# export JARVIS_DW_PIN_FAIL_THRESHOLD=3
+# export JARVIS_DW_PIN_COOLDOWN_S=120

--- a/tests/governance/test_model_pinning_heuristic.py
+++ b/tests/governance/test_model_pinning_heuristic.py
@@ -1,0 +1,138 @@
+"""Sovereign Context-Routing Override Matrix — model-pin soft-lock tests.
+
+Covers: gated-off byte-identity, Rank-1 promotion (present + absent + dedup),
+the soft-lock trip/clear/cooldown-expiry cycle, the passive-outcome wiring
+(only the pinned model is tracked), env-tunable threshold/cooldown, and
+fail-soft posture.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import model_pinning_heuristic as mph
+
+
+@pytest.fixture(autouse=True)
+def _clean_ledger_and_env(monkeypatch):
+    """Each test starts with a clean ledger + no pin declared."""
+    monkeypatch.delenv("JARVIS_DW_PRIMARY_OVERRIDE", raising=False)
+    monkeypatch.delenv("JARVIS_DW_PIN_FAIL_THRESHOLD", raising=False)
+    monkeypatch.delenv("JARVIS_DW_PIN_COOLDOWN_S", raising=False)
+    mph.get_pin_ledger().reset()
+    yield
+    mph.get_pin_ledger().reset()
+
+
+_FLEET = ("Qwen/Qwen3.5-397B-A17B-FP8", "openai/gpt-oss-120b", "deepseek/V4")
+
+
+# ── gated OFF → byte-identical legacy ──────────────────────────────────────
+
+def test_no_pin_is_byte_identical():
+    assert mph.apply_model_pin("standard", _FLEET) == _FLEET
+
+
+def test_empty_pin_is_byte_identical(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "   ")
+    assert mph.apply_model_pin("standard", _FLEET) == _FLEET
+
+
+# ── pin promotes to Rank 1 across routes ───────────────────────────────────
+
+def test_pin_present_promoted_to_rank1(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "openai/gpt-oss-120b")
+    out = mph.apply_model_pin("standard", _FLEET)
+    assert out[0] == "openai/gpt-oss-120b"
+    # rest preserved in order, pin deduped (no duplicate)
+    assert out == ("openai/gpt-oss-120b", "Qwen/Qwen3.5-397B-A17B-FP8", "deepseek/V4")
+    assert out.count("openai/gpt-oss-120b") == 1
+
+
+def test_pin_absent_is_prepended(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "newco/fast-7b")
+    out = mph.apply_model_pin("complex", _FLEET)
+    assert out[0] == "newco/fast-7b"
+    assert out == ("newco/fast-7b",) + _FLEET
+
+
+def test_pin_applies_to_every_route(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "openai/gpt-oss-120b")
+    for route in ("immediate", "standard", "complex", "background", "speculative"):
+        assert mph.apply_model_pin(route, _FLEET)[0] == "openai/gpt-oss-120b", route
+
+
+def test_pin_on_empty_ranked(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "openai/gpt-oss-120b")
+    assert mph.apply_model_pin("standard", ()) == ("openai/gpt-oss-120b",)
+
+
+# ── soft lock: trip → defer to EWMA → recover ──────────────────────────────
+
+def test_soft_lock_trips_after_threshold_and_defers_to_ewma(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "openai/gpt-oss-120b")
+    monkeypatch.setenv("JARVIS_DW_PIN_FAIL_THRESHOLD", "3")
+    # below threshold → still pinned
+    for _ in range(2):
+        mph.note_pin_outcome("openai/gpt-oss-120b", success=False)
+    assert mph.apply_model_pin("standard", _FLEET)[0] == "openai/gpt-oss-120b"
+    # hit threshold → soft-locked → yields to the EWMA ranking unchanged
+    mph.note_pin_outcome("openai/gpt-oss-120b", success=False)
+    assert mph.apply_model_pin("standard", _FLEET) == _FLEET
+
+
+def test_single_success_clears_the_streak(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "openai/gpt-oss-120b")
+    monkeypatch.setenv("JARVIS_DW_PIN_FAIL_THRESHOLD", "3")
+    for _ in range(3):
+        mph.note_pin_outcome("openai/gpt-oss-120b", success=False)
+    assert mph.apply_model_pin("standard", _FLEET) == _FLEET  # locked
+    mph.note_pin_outcome("openai/gpt-oss-120b", success=True)  # clears
+    assert mph.apply_model_pin("standard", _FLEET)[0] == "openai/gpt-oss-120b"
+
+
+def test_cooldown_expiry_self_heals(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "openai/gpt-oss-120b")
+    monkeypatch.setenv("JARVIS_DW_PIN_FAIL_THRESHOLD", "1")
+    monkeypatch.setenv("JARVIS_DW_PIN_COOLDOWN_S", "0.05")
+    mph.note_pin_outcome("openai/gpt-oss-120b", success=False)  # trips at 1
+    assert mph.apply_model_pin("standard", _FLEET) == _FLEET    # locked
+    import time
+    time.sleep(0.07)
+    assert mph.apply_model_pin("standard", _FLEET)[0] == "openai/gpt-oss-120b"
+
+
+# ── the passive wiring tracks ONLY the pinned model ────────────────────────
+
+def test_note_outcome_ignores_non_pinned_models(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "openai/gpt-oss-120b")
+    monkeypatch.setenv("JARVIS_DW_PIN_FAIL_THRESHOLD", "1")
+    # failures for a DIFFERENT model must not soft-lock the pin
+    mph.note_pin_outcome("Qwen/Qwen3.5-397B-A17B-FP8", success=False)
+    mph.note_pin_outcome("deepseek/V4", success=False)
+    assert mph.apply_model_pin("standard", _FLEET)[0] == "openai/gpt-oss-120b"
+
+
+def test_threshold_and_cooldown_are_env_tunable(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "openai/gpt-oss-120b")
+    monkeypatch.setenv("JARVIS_DW_PIN_FAIL_THRESHOLD", "5")
+    for _ in range(4):
+        mph.note_pin_outcome("openai/gpt-oss-120b", success=False)
+    assert mph.apply_model_pin("standard", _FLEET)[0] == "openai/gpt-oss-120b"  # 4<5
+    mph.note_pin_outcome("openai/gpt-oss-120b", success=False)                  # 5
+    assert mph.apply_model_pin("standard", _FLEET) == _FLEET
+
+
+def test_invalid_threshold_falls_back_to_default(monkeypatch):
+    for bad in ("bad", "0", "-2", ""):
+        monkeypatch.setenv("JARVIS_DW_PIN_FAIL_THRESHOLD", bad)
+        assert mph._fail_threshold() == mph._DEFAULT_FAIL_THRESHOLD, bad
+
+
+def test_model_pin_override_reads_env(monkeypatch):
+    assert mph.model_pin_override() == ""
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "  openai/gpt-oss-120b  ")
+    assert mph.model_pin_override() == "openai/gpt-oss-120b"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary
A dynamic, non-blocking **model-pinning heuristic** that natively forces a DW model to Rank 1 across all routes — surviving the Slice-23 sentinel/topology ContextVar walker — with a **graceful soft-lock** instead of a brittle hardcode. Closes the routing limitation found during the 2026-06-20 containerized soak (couldn't force `gpt-oss-120b`/`DeepSeek-V4` without env hacks).

## How it works
- `JARVIS_DW_PRIMARY_OVERRIDE=<model_id>` → the model is promoted to **Rank 1 across IMMEDIATE / STANDARD / COMPLEX / BACKGROUND / SPECULATIVE**.
- Single choke point: `provider_topology.dw_models_for_route` composes `apply_model_pin(route, _fleet_guarded(route, ranked))` (new `_pin_and_fleet_guarded`) at all 3 return sites — the pin sits **over** the FleetEvaluator EWMA re-rank, so a healthy pin wins and a failing pin yields straight back to EWMA.

## The soft-lock (the "BEEF")
- **Passively observed outcomes, no active probe.** Every real sentinel-dispatch success/failure (429 / 500 / live-transport) feeds `note_pin_outcome` at the existing bandit-record sites. There is deliberately **no active synthetic probe** — that is exactly the heavy-probe false-degrade pathology that wedged the soak (one slow 550B boot probe degraded the whole stream lane).
- Consecutive failures ≥ `JARVIS_DW_PIN_FAIL_THRESHOLD` (default 3) → cooldown `JARVIS_DW_PIN_COOLDOWN_S` (default 120s) during which routing returns the EWMA ranking unchanged. One success clears it; cooldown self-heals on expiry.

## Safety
- Unset `JARVIS_DW_PRIMARY_OVERRIDE` → **OFF, byte-identical legacy**.
- Pure + fail-soft throughout; ledger is process-local (a live override starts clean each boot — no stale cooldown suppressing a fresh pin).

## Test Plan
- [x] `tests/governance/test_model_pinning_heuristic.py` — 13 passed (promotion, dedup, absent-prepend, all-routes, soft-lock trip/clear/cooldown-expiry, passive-wiring isolation, env-tunable, fail-soft)
- [x] `tests/governance/test_slice225_dw_autarky.py` — 9 passed (regression)
- [x] Integration smoke: pin promotes through the real `_pin_and_fleet_guarded` path
- [x] **0 regressions** — 683 topology/fleet governance tests pass identically with/without this change (16 pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a routing override to pin a specific model to rank 1 across all routes, with a soft-lock that yields back to EWMA after consecutive failures. Also enables the pin and DW-autarky in the Linux prod env for the launch profile.

- **New Features**
  - Soft-lock pinning across Immediate/Standard/Complex/Background/Speculative; during cooldown it defers to EWMA. Passive outcome tracking only; one success clears; threshold and cooldown are env-tunable.
  - Integrated at the routing choke point via `_pin_and_fleet_guarded` over `_fleet_guarded`; outcome hooks added in `candidate_generator._dispatch_via_sentinel`. Safe by default and fail-soft; pin can prepend even if absent; tests cover promotion and soft-lock.

- **Migration**
  - Enable with `JARVIS_DW_PRIMARY_OVERRIDE=<model_id>`; optional tuning via `JARVIS_DW_PIN_FAIL_THRESHOLD` (default 3) and `JARVIS_DW_PIN_COOLDOWN_S` (default 120s). If unset, behavior is unchanged.
  - Linux prod env now sets `JARVIS_DW_PRIMARY_OVERRIDE=openai/gpt-oss-120b` and `JARVIS_PROVIDER_CLAUDE_DISABLED=true` by default; both are operator-toggleable.

<sup>Written for commit 42c466ee0497c5dcf4eda80952605a0f2ab4712f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

