### PR TITLE
feat(cloud): Sovereign Cloud Ignition — Preemption Shield + soak-mode VM provisioner

### DIFF
--- a/backend/core/gcp_vm_manager.py
+++ b/backend/core/gcp_vm_manager.py
@@ -4639,7 +4639,89 @@ class GCPVMManager:
                 return running_vms[0]
             # No running VMs - return any VM
             return next(iter(self.managed_vms.values()), None)
-    
+
+    async def start_soak_vm(
+        self,
+        *,
+        vm_name: Optional[str] = None,
+        extra_metadata: Optional[Dict[str, str]] = None,
+    ) -> Tuple[bool, Optional[str]]:
+        """Provision a fire-and-forget Ouroboros **soak** Spot VM.
+
+        Sovereign Cloud Ignition (2026-06-20): a deliberate one-shot soak runner,
+        NOT a memory-offload server. It REUSES the full instance-build recipe
+        (``_build_instance_config`` → machine type from ``config.machine_type``
+        e.g. ``e2-custom-8-16384``, boot disk, network, Spot scheduling +
+        max_run_duration dead-man's-switch, the custom startup script from
+        ``config.startup_script_path``) but deliberately BYPASSES the
+        offload-only gating that ``start_spot_vm`` enforces:
+
+          * NO firewall health-check gate — a soak VM serves no traffic to the
+            Mac, so ``jarvis-allow-health-checks`` is irrelevant.
+          * NO active-VM reuse — each soak is a fresh node.
+          * NO component model — ``components=["ouroboros_soak"]`` is a label only.
+
+        ``extra_metadata`` is appended to the instance metadata AFTER the recipe
+        builds it (the recipe's ``metadata`` param is vestigial) — this is how the
+        DW API key + ``JARVIS_DW_PRIMARY_OVERRIDE`` pin reach the VM for the
+        startup script to consume. Returns ``(success, vm_name_or_error)``.
+
+        Requires: ``config.startup_script_path`` set + readable, GCP enabled,
+        project/zone valid. NEVER raises — all failures return ``(False, msg)``."""
+        if not self.config.enabled:
+            return False, "GCP_DISABLED: set GCP_ENABLED/GCP_VM_ENABLED=true"
+        is_valid, validation_error = self.config.is_valid_for_vm_operations()
+        if not is_valid:
+            return False, f"CONFIG_INVALID: {validation_error}"
+        if not (self.config.startup_script_path and os.path.exists(self.config.startup_script_path)):
+            return False, (
+                "SOAK_STARTUP_SCRIPT_MISSING: set config.startup_script_path to a "
+                f"readable file (got {self.config.startup_script_path!r})"
+            )
+        # Soak runs the script, never a golden image / container offload server.
+        self.config.use_golden_image = False
+        self.config.use_container = False
+        self.config.use_spot = True
+
+        name = vm_name or f"jarvis-ouroboros-soak-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        try:
+            if self.instances_client is None:
+                await self._initialize_gcp_clients()
+            client = self.instances_client
+            if client is None:
+                return False, "COMPUTE_CLIENT_UNAVAILABLE: compute_v1 not importable / no ADC"
+            # Reuse the proven instance-build recipe (machine type, disk, network,
+            # Spot scheduling, startup-script metadata).
+            instance = self._build_instance_config(
+                name, ["ouroboros_soak"], "ouroboros_soak", {},
+            )
+            # Append soak-specific metadata (DW key + pin) the recipe doesn't carry.
+            if extra_metadata:
+                if instance.metadata is None:
+                    instance.metadata = compute_v1.Metadata(items=[])
+                for k, v in extra_metadata.items():
+                    if k and v is not None:
+                        instance.metadata.items.append(
+                            compute_v1.Items(key=str(k), value=str(v))
+                        )
+            logger.info(
+                "[SoakVM] creating Spot soak node name=%s machine=%s zone=%s "
+                "startup_script=%s extra_meta_keys=%s",
+                name, self.config.machine_type, self.config.zone,
+                os.path.basename(self.config.startup_script_path),
+                sorted((extra_metadata or {}).keys()),
+            )
+            client.insert(
+                project=self.config.project_id,
+                zone=self.config.zone,
+                instance_resource=instance,
+            )
+            logger.info("[SoakVM] insert submitted for %s — VM booting", name)
+            return True, name
+        except Exception as exc:  # noqa: BLE001 — never raise into the launcher
+            logger.error("[SoakVM] create failed for %s: %s", name, exc, exc_info=True)
+            return False, f"SOAK_CREATE_FAILED:{type(exc).__name__}:{str(exc)[:160]}"
+
     async def start_spot_vm(self) -> Tuple[bool, Optional[str]]:
         """
         Start a Spot VM for immediate use.

--- a/backend/core/ouroboros/battle_test/graceful_preemption.py
+++ b/backend/core/ouroboros/battle_test/graceful_preemption.py
@@ -1,0 +1,217 @@
+"""Graceful Preemption Shield — Spot/SIGTERM anti-corruption matrix.
+
+GCP Spot instances get a **30-second** ``SIGTERM`` notice before forced
+termination. The battle-test harness already handles SIGTERM gracefully (sync
+partial-``summary.json`` write → shutdown event → async component shutdown), but
+that async path can exceed 30s and, more importantly, says nothing about the
+**working tree**: if the Ouroboros loop is mid-APPLY (``ChangeEngine`` writing a
+source file, or the ``AutoCommitter`` mid-commit) when the SIGKILL lands, the
+clone is left with a half-written file or a dangling ``.git/index.lock``.
+
+This module is the SYNCHRONOUS, bounded, corruption-critical front half of the
+shield, invoked at the very top of the harness signal handler (before the
+existing partial-summary write) so it always completes inside the 30s window:
+
+  1. **Detect** a genuine GCP preemption (metadata server) so the shutdown can be
+     tagged ``preempted`` vs. an operator interrupt — purely advisory.
+  2. **Halt** the child worker processes (the ``ProcessPoolExecutor`` AST/Oracle
+     pool) so no NEW file-touching work starts during teardown.
+  3. **Stash** any in-flight working-tree changes (``git stash -u``) so a partial
+     APPLY can't leave a corrupt tree — the work is fully recoverable from the
+     stash on the next boot, and a stray ``index.lock`` is cleared first.
+
+Everything is bounded (hard per-step deadlines), gated
+(``JARVIS_PREEMPTION_SHIELD_ENABLED``, default true), idempotent (runs once), and
+fail-soft (a cleanup step must NEVER raise into the signal path). It deliberately
+reuses ``psutil`` (already a harness dependency) and the stdlib ``git`` CLI; it
+does NOT reach into the orchestrator op-ledger (same isolation discipline as the
+wall-clock watchdog).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+import time
+import urllib.request
+from typing import Optional
+
+_SHIELD_ENV = "JARVIS_PREEMPTION_SHIELD_ENABLED"
+_GIT_STASH_ENV = "JARVIS_PREEMPTION_GIT_STASH_ENABLED"
+_METADATA_PREEMPTED_URL = (
+    "http://metadata.google.internal/computeMetadata/v1/instance/preempted"
+)
+
+# Hard per-step ceilings — the whole shield must fit well inside the 30s Spot
+# window with room left for the harness's own partial-summary write + the OS.
+_METADATA_TIMEOUT_S = 1.0
+_CHILD_TERM_GRACE_S = 3.0
+_GIT_STEP_TIMEOUT_S = 8.0
+
+_engaged_once = threading.Lock()
+_has_engaged = False
+
+
+def shield_enabled() -> bool:
+    """Master gate (default TRUE). NEVER raises."""
+    try:
+        return os.environ.get(_SHIELD_ENV, "true").strip().lower() not in (
+            "0", "false", "no", "off",
+        )
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def is_gcp_preemption() -> bool:
+    """True iff the GCP metadata server reports this instance is being preempted.
+
+    Probes ``/computeMetadata/v1/instance/preempted`` (returns ``TRUE`` only
+    during a Spot preemption). 1s timeout; any failure (not on GCP, no network,
+    DNS) → False. Advisory only — the shield runs regardless of the answer."""
+    try:
+        req = urllib.request.Request(
+            _METADATA_PREEMPTED_URL, headers={"Metadata-Flavor": "Google"},
+        )
+        with urllib.request.urlopen(req, timeout=_METADATA_TIMEOUT_S) as resp:
+            return resp.read().decode("utf-8", "replace").strip().upper() == "TRUE"
+    except Exception:  # noqa: BLE001 — not on GCP / no metadata / timeout
+        return False
+
+
+def halt_child_workers() -> int:
+    """Terminate this process's child workers (the ProcessPoolExecutor / Oracle
+    AST pool spawn) so no new file-touching compute starts during teardown.
+
+    SIGTERM → brief grace → SIGKILL stragglers. Returns the count signalled.
+    Best-effort + bounded; NEVER raises."""
+    try:
+        import psutil  # reused harness dependency
+    except Exception:  # noqa: BLE001
+        return 0
+    try:
+        me = psutil.Process()
+        kids = me.children(recursive=True)
+        for c in kids:
+            try:
+                c.terminate()
+            except Exception:  # noqa: BLE001
+                pass
+        _, alive = psutil.wait_procs(kids, timeout=_CHILD_TERM_GRACE_S)
+        for c in alive:
+            try:
+                c.kill()
+            except Exception:  # noqa: BLE001
+                pass
+        return len(kids)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def _run_git(repo_root: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", repo_root, *args],
+        capture_output=True, text=True, timeout=_GIT_STEP_TIMEOUT_S,
+    )
+
+
+def _detect_repo_root() -> Optional[str]:
+    try:
+        cp = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=_GIT_STEP_TIMEOUT_S,
+        )
+        root = cp.stdout.strip()
+        return root or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def git_safety_stash(repo_root: Optional[str] = None) -> str:
+    """Stash in-flight working-tree changes so a partial APPLY can't corrupt the
+    tree. Clears a stray ``.git/index.lock`` first (a crashed git op leaves one,
+    which would block the stash). Returns a short status string for telemetry.
+
+    ``git stash`` (not commit) is deliberate: it leaves a clean tree, pollutes no
+    history, and the in-flight work is fully recoverable via ``git stash list``
+    on the next boot. Bounded + fail-soft; NEVER raises."""
+    if os.environ.get(_GIT_STASH_ENV, "true").strip().lower() in ("0", "false", "no", "off"):
+        return "stash_disabled"
+    try:
+        root = repo_root or _detect_repo_root()
+        if not root:
+            return "no_repo"
+        # Clear a stale lock from a git op interrupted by an earlier signal.
+        lock = os.path.join(root, ".git", "index.lock")
+        try:
+            if os.path.isfile(lock):
+                os.remove(lock)
+        except Exception:  # noqa: BLE001
+            pass
+        status = _run_git(root, "status", "--porcelain")
+        if status.returncode != 0:
+            return f"status_failed:{(status.stderr or '').strip()[:60]}"
+        if not status.stdout.strip():
+            return "tree_clean"
+        ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        res = _run_git(root, "stash", "push", "-u", "-m", f"[preemption-shield] in-flight {ts}")
+        if res.returncode == 0:
+            return "stashed"
+        return f"stash_failed:{(res.stderr or '').strip()[:60]}"
+    except subprocess.TimeoutExpired:
+        return "git_timeout"
+    except Exception as exc:  # noqa: BLE001
+        return f"error:{type(exc).__name__}"
+
+
+def engage(signal_name: Optional[str] = None, repo_root: Optional[str] = None) -> dict:
+    """Run the full synchronous shield once. Idempotent (subsequent calls no-op
+    with ``{"skipped": "already_engaged"}``). Gated + fail-soft — returns a
+    telemetry dict and NEVER raises into the signal handler.
+
+    Order is corruption-first: git-safety BEFORE the (slower) child-halt, so the
+    tree is protected even if the halt eats into the budget."""
+    global _has_engaged
+    if not shield_enabled():
+        return {"skipped": "shield_disabled"}
+    with _engaged_once:
+        if _has_engaged:
+            return {"skipped": "already_engaged"}
+        _has_engaged = True
+    started = time.monotonic()
+    preempted = is_gcp_preemption()
+    stash = git_safety_stash(repo_root)
+    halted = halt_child_workers()
+    elapsed = time.monotonic() - started
+    result = {
+        "signal": signal_name or "?",
+        "gcp_preemption": preempted,
+        "git_safety": stash,
+        "children_halted": halted,
+        "elapsed_s": round(elapsed, 3),
+    }
+    try:
+        print(
+            f"[PreemptionShield] engaged signal={result['signal']} "
+            f"preempted={preempted} git_safety={stash} children_halted={halted} "
+            f"elapsed={result['elapsed_s']}s",
+            flush=True,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+    return result
+
+
+def _reset_for_tests() -> None:
+    """Test hook: clear the idempotency latch."""
+    global _has_engaged
+    with _engaged_once:
+        _has_engaged = False
+
+
+__all__ = [
+    "shield_enabled",
+    "is_gcp_preemption",
+    "halt_child_workers",
+    "git_safety_stash",
+    "engage",
+]

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -5232,6 +5232,20 @@ class BattleTestHarness:
         except Exception:  # noqa: BLE001 — never let watchdog arm crash signal handler
             pass
 
+        # Graceful Preemption Shield — SYNCHRONOUS, corruption-first. On a GCP
+        # Spot SIGTERM we have ~30s before SIGKILL; the existing async cleanup
+        # below can exceed that and says nothing about the working tree. Engage
+        # the shield FIRST (git-safety stash + child-worker halt) so a mid-APPLY
+        # file write / dangling index.lock can't leave a corrupt clone. Gated,
+        # idempotent, bounded, fail-soft — NEVER raises into the signal path.
+        try:
+            from backend.core.ouroboros.battle_test.graceful_preemption import (
+                engage as _preemption_shield_engage,
+            )
+            _preemption_shield_engage(signal_name=signal_name)
+        except Exception:  # noqa: BLE001 — shield must never break shutdown
+            pass
+
         # Stamp the signal-specific reason before the write runs so the
         # partial summary carries an actionable classifier instead of the
         # generic "shutdown_signal" catch-all. Keep the existing value if

--- a/deploy/gcp_ouroboros_startup.sh
+++ b/deploy/gcp_ouroboros_startup.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# =============================================================================
+# Sovereign Cloud Ignition — GCE metadata-startup-script for the Ouroboros soak.
+# Runs ONCE on first boot of the e2-custom-8-16384 Spot node provisioned by
+# scripts/ignite_sovereign_cloud_node.py (→ GCPVMManager.start_soak_vm).
+#
+# No human SSH: installs Docker, clones the PUBLIC repo @ main, pulls the funded
+# DW key + model pin from instance metadata, and boots the Ouroboros container
+# (docker-compose.prod.yml + docker-compose.gcp.yml). The container's entrypoint
+# (launch_linux_prod.sh) sources deploy/ouroboros_linux_prod.env which already
+# carries the pin + pure-DW autarky; the GCP overlay adds the constrained-loop
+# opt-outs (advisory subsystems off the event loop, surface-health probe off).
+#
+# Idempotent: re-running (e.g. after a Spot STOP→restart) detects an existing
+# clone + container and only re-ups. All output → /var/log/jarvis-soak.log AND
+# the serial console (readable via `gcloud compute instances get-serial-port-output`).
+# =============================================================================
+set -uo pipefail
+exec > >(tee -a /var/log/jarvis-soak.log | tee /dev/console) 2>&1
+echo "🐍 [SovereignIgnition] $(date -u +%FT%TZ) startup begins"
+
+REPO_URL="https://github.com/drussell23/JARVIS-AI-Agent.git"
+APP_DIR="/opt/jarvis/jarvis-ai-agent"
+META="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
+HDR="Metadata-Flavor: Google"
+
+meta() { curl -s -f -H "$HDR" "$META/$1" 2>/dev/null || echo ""; }
+
+# ---- 1. Docker + git (idempotent; skip if already present) ------------------
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[ignition] installing Docker + git…"
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -qq
+  apt-get install -y -qq git ca-certificates curl
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc 2>/dev/null \
+    || curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+  . /etc/os-release
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update -qq
+  apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-compose-plugin
+  systemctl enable --now docker
+else
+  echo "[ignition] Docker already present — skipping install"
+fi
+
+# ---- 2. Clone (or refresh) the public repo @ main --------------------------
+mkdir -p "$(dirname "$APP_DIR")"
+if [ -d "$APP_DIR/.git" ]; then
+  echo "[ignition] repo present — fetching latest main"
+  git -C "$APP_DIR" fetch --depth 1 origin main && git -C "$APP_DIR" reset --hard origin/main
+else
+  echo "[ignition] cloning $REPO_URL @ main"
+  git clone --depth 1 -b main "$REPO_URL" "$APP_DIR"
+fi
+cd "$APP_DIR" || { echo "[ignition] FATAL: cannot cd $APP_DIR"; exit 1; }
+
+# ---- 3. Funded creds + pin from instance metadata → .env -------------------
+# Secrets travel as instance metadata (project-scoped, never in git/the image).
+DW_KEY="$(meta jarvis-dw-api-key)"
+PIN="$(meta jarvis-dw-primary-override)"
+{
+  [ -n "$DW_KEY" ] && echo "DOUBLEWORD_API_KEY=$DW_KEY"
+  # Pin override (optional): falls back to deploy/ouroboros_linux_prod.env default.
+  [ -n "$PIN" ] && echo "JARVIS_DW_PRIMARY_OVERRIDE=$PIN"
+} > "$APP_DIR/.env"
+chmod 600 "$APP_DIR/.env"
+if [ -n "$DW_KEY" ]; then
+  echo "[ignition] .env written (DW key len=${#DW_KEY}, pin=${PIN:-<prod-env-default>})"
+else
+  echo "[ignition] WARNING: no jarvis-dw-api-key metadata — DW calls will 401"
+fi
+mkdir -p "$APP_DIR/.jarvis"
+
+# ---- 4. Boot the Ouroboros soak container ----------------------------------
+echo "[ignition] docker compose up (prod + gcp overlay, --build)…"
+docker compose -f docker-compose.prod.yml -f docker-compose.gcp.yml up -d --build
+echo "🐍 [SovereignIgnition] $(date -u +%FT%TZ) container up — soak running."
+echo "[ignition] monitor:  docker logs -f jarvis-sovereign-prod   (on the VM)"

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -1,0 +1,43 @@
+# GCP Sovereign Cloud overlay — 8 vCPU / 16GB e2-custom Spot node.
+# =============================================================================
+# Overlay on docker-compose.prod.yml for the cloud soak. The host now has REAL
+# cores (the 2-CPU Docker-Desktop floor is gone), so the memory-pressure /
+# sensor-governor throttling from the M1 desktop overlay is NOT needed and is
+# omitted — the swarm runs at full prod horizons.
+#
+# What IS retained from the desktop diagnosis (these are core-count-independent —
+# they each block the asyncio event loop or DW lane regardless of how many cores
+# the box has, so they stay off for the first clean state=applied proof):
+#   - posture collector + semantic-index build run synchronously on the loop and
+#     can stall it 14-45s → starve the in-flight DW SSE read. OFF.
+#   - the heavy surface-health boot probe (550B model) false-degrades the whole
+#     DIRECT_STREAMING lane on slow DW cold-starts. OFF.
+#   - Aegis OFF for the FIRST proof (isolate the loop from the AegisForward
+#     DW-streaming path; #69590 fixed the leak but the rupture validation is a
+#     separate aegis-ON soak). Turn back on once that soak is green.
+#
+# The pin (JARVIS_DW_PRIMARY_OVERRIDE=openai/gpt-oss-120b) + pure-DW autarky are
+# already supplied by deploy/ouroboros_linux_prod.env (sourced by the entrypoint)
+# and overridable via the .env the startup script writes from instance metadata.
+#
+#   docker compose -f docker-compose.prod.yml -f docker-compose.gcp.yml up -d --build
+# =============================================================================
+services:
+  jarvis-prod:
+    environment:
+      # pure DW autarky (Claude credits exhausted; safe via autarky fix #69589)
+      JARVIS_PROVIDER_CLAUDE_DISABLED: "true"
+      # advisory metacognition OFF the event loop (core-count-independent stalls)
+      JARVIS_DIRECTION_INFERRER_ENABLED: "false"
+      JARVIS_SEMANTIC_INFERENCE_ENABLED: "false"
+      # don't let the heavy 550B boot probe false-degrade the DW stream lane
+      JARVIS_DW_SURFACE_HEALTH_ENABLED: "false"
+      # first proof isolates the loop from the AegisForward DW-streaming path
+      JARVIS_AEGIS_ENABLED: "false"
+      # real cores → give DW generation full runway (no 90s reflex-cap timeouts)
+      OUROBOROS_TIER0_MAX_WAIT_S: "600"
+      JARVIS_GENERATION_TIMEOUT_S: "900"
+      OUROBOROS_BATTLE_MAX_WALL_SECONDS: "3600"
+      OUROBOROS_BATTLE_COST_CAP: "10.00"
+      # Preemption Shield armed (default-on; explicit for auditability)
+      JARVIS_PREEMPTION_SHIELD_ENABLED: "true"

--- a/scripts/ignite_sovereign_cloud_node.py
+++ b/scripts/ignite_sovereign_cloud_node.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Sovereign Cloud Ignition — provision the Ouroboros soak on a GCP Spot node.
+
+Thin launcher that REUSES the existing hybrid-cloud provisioner
+(``backend/core/gcp_vm_manager.py::GCPVMManager.start_soak_vm``) — it does NOT
+reimplement gcloud. It configures a ``VMManagerConfig`` for an
+``e2-custom-8-16384`` Spot instance, points it at the Ouroboros startup script
+(``deploy/gcp_ouroboros_startup.sh``), and passes the funded DW key + model pin
+as instance metadata for the startup script to consume.
+
+Usage (from the repo root, with ADC available — ``gcloud auth application-default
+login`` — and a funded ``DOUBLEWORD_API_KEY`` in ``.env``):
+
+    python3 scripts/ignite_sovereign_cloud_node.py \
+        --project jarvis-473803 --zone us-central1-a \
+        --machine e2-custom-8-16384 --pin openai/gpt-oss-120b
+
+The DW key is read from ``.env`` (never printed — only its sha256[:8] + length).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import os
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_STARTUP_SCRIPT = _REPO_ROOT / "deploy" / "gcp_ouroboros_startup.sh"
+
+
+def _read_dw_key() -> str:
+    """Read DOUBLEWORD_API_KEY from the process env or the repo ``.env``."""
+    k = os.environ.get("DOUBLEWORD_API_KEY", "").strip()
+    if k:
+        return k
+    env_path = _REPO_ROOT / ".env"
+    if env_path.is_file():
+        m = re.search(
+            r'^\s*(?:export\s+)?DOUBLEWORD_API_KEY\s*=\s*["\']?([^"\'\n]+)',
+            env_path.read_text(), re.M,
+        )
+        if m:
+            return m.group(1).strip()
+    return ""
+
+
+def _mask(key: str) -> str:
+    if not key:
+        return "<absent>"
+    return f"sha256:{hashlib.sha256(key.encode()).hexdigest()[:8]} len={len(key)}"
+
+
+async def _ignite(args: argparse.Namespace) -> int:
+    dw_key = _read_dw_key()
+    if not dw_key:
+        print("❌ DOUBLEWORD_API_KEY not found in env or .env — funded key required.")
+        return 2
+    if not _STARTUP_SCRIPT.is_file():
+        print(f"❌ startup script missing: {_STARTUP_SCRIPT}")
+        return 2
+
+    # Reuse the existing provisioner — configure, don't reimplement.
+    from backend.core.gcp_vm_manager import GCPVMManager, VMManagerConfig
+
+    cfg = VMManagerConfig()
+    cfg.enabled = True
+    cfg.project_id = args.project
+    cfg.zone = args.zone
+    cfg.region = args.zone.rsplit("-", 1)[0]
+    cfg.machine_type = args.machine
+    cfg.use_spot = True
+    cfg.use_golden_image = False
+    cfg.use_container = False
+    cfg.boot_disk_size_gb = args.disk_gb
+    cfg.max_vm_lifetime_hours = args.max_hours
+    cfg.startup_script_path = str(_STARTUP_SCRIPT)
+
+    print("🐍 Sovereign Cloud Ignition")
+    print(f"   project={cfg.project_id} zone={cfg.zone} machine={cfg.machine_type} (SPOT)")
+    print(f"   disk={cfg.boot_disk_size_gb}GB max_lifetime={cfg.max_vm_lifetime_hours}h")
+    print(f"   pin={args.pin}   DW key={_mask(dw_key)}")
+    print(f"   startup_script={_STARTUP_SCRIPT.name}")
+    if args.dry_run:
+        print("   --dry-run: config validated, NOT creating the VM.")
+        return 0
+
+    mgr = GCPVMManager(cfg)
+    ok, result = await mgr.start_soak_vm(
+        extra_metadata={
+            "jarvis-dw-api-key": dw_key,
+            "jarvis-dw-primary-override": args.pin,
+        },
+    )
+    if not ok:
+        print(f"❌ ignition failed: {result}")
+        return 1
+    print(f"✅ Spot soak node creating: {result}")
+    print("   monitor boot:   gcloud compute instances get-serial-port-output "
+          f"{result} --zone {cfg.zone} --project {cfg.project_id}")
+    print("   monitor loop:   gcloud compute ssh "
+          f"{result} --zone {cfg.zone} --project {cfg.project_id} "
+          "--command 'docker logs -f jarvis-sovereign-prod'")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Provision the Ouroboros soak on a GCP Spot node.")
+    p.add_argument("--project", default=os.environ.get("GCP_PROJECT_ID", "jarvis-473803"))
+    p.add_argument("--zone", default=os.environ.get("GCP_ZONE", "us-central1-a"))
+    p.add_argument("--machine", default=os.environ.get("GCP_VM_MACHINE_TYPE", "e2-custom-8-16384"))
+    p.add_argument("--pin", default=os.environ.get("JARVIS_DW_PRIMARY_OVERRIDE", "openai/gpt-oss-120b"))
+    p.add_argument("--disk-gb", type=int, default=int(os.environ.get("GCP_BOOT_DISK_GB", "50")))
+    p.add_argument("--max-hours", type=float, default=float(os.environ.get("GCP_MAX_VM_HOURS", "6")))
+    p.add_argument("--dry-run", action="store_true", help="validate config, do not create the VM")
+    args = p.parse_args()
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    return asyncio.run(_ignite(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/battle_test/test_graceful_preemption.py
+++ b/tests/battle_test/test_graceful_preemption.py
@@ -1,0 +1,120 @@
+"""Graceful Preemption Shield — anti-corruption matrix tests."""
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from backend.core.ouroboros.battle_test import graceful_preemption as gp
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.delenv("JARVIS_PREEMPTION_SHIELD_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_PREEMPTION_GIT_STASH_ENABLED", raising=False)
+    gp._reset_for_tests()
+    yield
+    gp._reset_for_tests()
+
+
+def test_shield_enabled_default_true():
+    assert gp.shield_enabled() is True
+
+
+def test_shield_disabled_skips(monkeypatch):
+    monkeypatch.setenv("JARVIS_PREEMPTION_SHIELD_ENABLED", "false")
+    assert gp.engage(signal_name="sigterm") == {"skipped": "shield_disabled"}
+
+
+def test_engage_is_idempotent(monkeypatch):
+    monkeypatch.setattr(gp, "is_gcp_preemption", lambda: False)
+    monkeypatch.setattr(gp, "git_safety_stash", lambda repo_root=None: "tree_clean")
+    monkeypatch.setattr(gp, "halt_child_workers", lambda: 0)
+    first = gp.engage(signal_name="sigterm")
+    second = gp.engage(signal_name="sigterm")
+    assert "skipped" not in first
+    assert second == {"skipped": "already_engaged"}
+
+
+def test_is_gcp_preemption_true(monkeypatch):
+    class _Resp:
+        def read(self): return b"TRUE"
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+    monkeypatch.setattr(gp.urllib.request, "urlopen", lambda *a, **k: _Resp())
+    assert gp.is_gcp_preemption() is True
+
+
+def test_is_gcp_preemption_false_off_gcp(monkeypatch):
+    def _boom(*a, **k):
+        raise OSError("no metadata server")
+    monkeypatch.setattr(gp.urllib.request, "urlopen", _boom)
+    assert gp.is_gcp_preemption() is False
+
+
+def _init_repo(path):
+    subprocess.run(["git", "init", "-q", path], check=True)
+    subprocess.run(["git", "-C", path, "config", "user.email", "t@t.t"], check=True)
+    subprocess.run(["git", "-C", path, "config", "user.name", "t"], check=True)
+    open(os.path.join(path, "seed.txt"), "w").write("seed\n")
+    subprocess.run(["git", "-C", path, "add", "-A"], check=True)
+    subprocess.run(["git", "-C", path, "commit", "-qm", "seed"], check=True)
+    return path
+
+
+def test_git_safety_stashes_in_flight_changes(tmp_path):
+    repo = _init_repo(str(tmp_path / "r"))
+    open(os.path.join(repo, "seed.txt"), "w").write("HALF-WRITTEN APPLY\n")
+    open(os.path.join(repo, "newfile.py"), "w").write("x = 1\n")
+    assert gp.git_safety_stash(repo) == "stashed"
+    porcelain = subprocess.run(
+        ["git", "-C", repo, "status", "--porcelain"], capture_output=True, text=True,
+    ).stdout.strip()
+    assert porcelain == ""
+    stashes = subprocess.run(
+        ["git", "-C", repo, "stash", "list"], capture_output=True, text=True,
+    ).stdout
+    assert "preemption-shield" in stashes
+
+
+def test_git_safety_clean_tree_is_noop(tmp_path):
+    repo = _init_repo(str(tmp_path / "r"))
+    assert gp.git_safety_stash(repo) == "tree_clean"
+
+
+def test_git_safety_clears_stale_index_lock(tmp_path):
+    repo = _init_repo(str(tmp_path / "r"))
+    open(os.path.join(repo, "seed.txt"), "w").write("dirty\n")
+    lock = os.path.join(repo, ".git", "index.lock")
+    open(lock, "w").write("")
+    assert gp.git_safety_stash(repo) == "stashed"
+    assert not os.path.isfile(lock)
+
+
+def test_git_safety_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_PREEMPTION_GIT_STASH_ENABLED", "false")
+    repo = _init_repo(str(tmp_path / "r"))
+    open(os.path.join(repo, "seed.txt"), "w").write("dirty\n")
+    assert gp.git_safety_stash(repo) == "stash_disabled"
+
+
+def test_git_safety_failsoft_on_non_repo(tmp_path):
+    out = gp.git_safety_stash(str(tmp_path))
+    assert isinstance(out, str) and out != "stashed"
+
+
+def test_engage_returns_telemetry(monkeypatch, tmp_path):
+    monkeypatch.setattr(gp, "is_gcp_preemption", lambda: True)
+    monkeypatch.setattr(gp, "halt_child_workers", lambda: 2)
+    monkeypatch.setattr(gp, "git_safety_stash", lambda repo_root=None: "tree_clean")
+    out = gp.engage(signal_name="sigterm")
+    assert out["gcp_preemption"] is True
+    assert out["children_halted"] == 2
+    assert out["git_safety"] == "tree_clean"
+    assert out["signal"] == "sigterm"
+    assert "elapsed_s" in out
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/governance/test_start_soak_vm.py
+++ b/tests/governance/test_start_soak_vm.py
@@ -1,0 +1,97 @@
+"""start_soak_vm — Sovereign Cloud soak-mode entry on GCPVMManager.
+
+Verifies it reuses the instance-build recipe, appends soak metadata (DW key +
+pin), and bypasses the offload gating — failing cleanly on bad config.
+"""
+from __future__ import annotations
+
+import pytest
+
+import google.cloud.compute_v1 as compute_v1
+from backend.core.gcp_vm_manager import GCPVMManager, VMManagerConfig
+
+
+def _mgr(tmp_path, *, enabled=True, script=True):
+    cfg = VMManagerConfig()
+    cfg.enabled = enabled
+    cfg.project_id = "jarvis-473803"
+    cfg.zone = "us-central1-a"
+    cfg.machine_type = "e2-custom-8-16384"
+    if script:
+        p = tmp_path / "startup.sh"
+        p.write_text("#!/bin/bash\necho soak\n")
+        cfg.startup_script_path = str(p)
+    else:
+        cfg.startup_script_path = None
+    return GCPVMManager(cfg)
+
+
+class _FakeClient:
+    def __init__(self):
+        self.inserts = []
+
+    def insert(self, *, project, zone, instance_resource):
+        self.inserts.append((project, zone, instance_resource))
+        return object()
+
+
+@pytest.mark.asyncio
+async def test_missing_startup_script_fails_clean(tmp_path):
+    m = _mgr(tmp_path, script=False)
+    ok, msg = await m.start_soak_vm()
+    assert ok is False and "SOAK_STARTUP_SCRIPT_MISSING" in msg
+
+
+@pytest.mark.asyncio
+async def test_gcp_disabled_fails_clean(tmp_path):
+    m = _mgr(tmp_path, enabled=False)
+    ok, msg = await m.start_soak_vm()
+    assert ok is False and "GCP_DISABLED" in msg
+
+
+@pytest.mark.asyncio
+async def test_success_inserts_and_reuses_recipe(tmp_path, monkeypatch):
+    m = _mgr(tmp_path)
+    fake = _FakeClient()
+    m.instances_client = fake  # _get_instances_client returns the cached client
+    built = {"called": None}
+
+    def _fake_build(vm_name, components, trigger, metadata):
+        built["called"] = (vm_name, tuple(components), trigger)
+        return compute_v1.Instance(
+            name=vm_name, metadata=compute_v1.Metadata(items=[]),
+        )
+    monkeypatch.setattr(m, "_build_instance_config", _fake_build)
+
+    ok, name = await m.start_soak_vm(
+        extra_metadata={
+            "jarvis-dw-api-key": "SECRET",
+            "jarvis-dw-primary-override": "openai/gpt-oss-120b",
+        },
+    )
+    assert ok is True
+    assert name.startswith("jarvis-ouroboros-soak-")
+    assert built["called"][1] == ("ouroboros_soak",)
+    assert built["called"][2] == "ouroboros_soak"
+    assert len(fake.inserts) == 1
+    proj, zone, inst = fake.inserts[0]
+    assert proj == "jarvis-473803" and zone == "us-central1-a"
+    keys = {it.key: it.value for it in inst.metadata.items}
+    assert keys["jarvis-dw-api-key"] == "SECRET"
+    assert keys["jarvis-dw-primary-override"] == "openai/gpt-oss-120b"
+
+
+@pytest.mark.asyncio
+async def test_create_failure_is_failsoft(tmp_path, monkeypatch):
+    m = _mgr(tmp_path)
+
+    def _boom(vm_name, components, trigger, metadata):
+        raise RuntimeError("compute exploded")
+    m.instances_client = _FakeClient()
+    monkeypatch.setattr(m, "_build_instance_config", _boom)
+    ok, msg = await m.start_soak_vm()
+    assert ok is False and "SOAK_CREATE_FAILED" in msg and "RuntimeError" in msg
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary
Reuses the existing hybrid-cloud architecture (`gcp_vm_manager.py`) to provision the Ouroboros soak on a GCP Spot node — **not** a fresh gcloud script — plus a Spot anti-corruption matrix. Answers "are we using the hybrid-cloud arch?": **yes**, via a clean soak-mode entry instead of bending the offload-server path.

## 1. Preemption Shield (`graceful_preemption.py` + harness wire)
GCP Spot sends SIGTERM with ~30s before SIGKILL. The harness already writes a partial summary on SIGTERM but said nothing about the **working tree** — a mid-APPLY `ChangeEngine` write / dangling `.git/index.lock` could leave a corrupt clone. The shield is the **synchronous, corruption-first** front half of the existing handler:
- detect GCP preemption (metadata server, advisory)
- **git-safety stash** in-flight changes (clears a stale `index.lock` first → clean, fully-recoverable tree)
- halt the ProcessPool child workers
Bounded per-step, gated (`JARVIS_PREEMPTION_SHIELD_ENABLED` default-on), idempotent, fail-soft — **never raises into the signal path**. Wired at the top of `_handle_shutdown_signal`.

## 2. Soak-mode provisioner (`GCPVMManager.start_soak_vm`)
Reuses the full `_build_instance_config` recipe (machine `e2-custom-8-16384`, boot disk, network, Spot + `max_run_duration` dead-man's-switch, custom `startup_script_path`) but **bypasses the offload-only gating** that `start_spot_vm` enforces (firewall health-check gate, active-VM reuse, component model — a soak serves no traffic to the Mac). Appends the DW key + model pin as instance metadata. Fail-soft.

## 3. Ignition artifacts
- `deploy/gcp_ouroboros_startup.sh` — metadata-startup-script (Docker + clone public repo @ main + `.env` from metadata + `compose up`), idempotent, serial-console logged.
- `docker-compose.gcp.yml` — 8-vCPU overlay: pure-DW autarky + the core-count-independent opt-outs (advisory subsystems off-loop, surface-health probe off, aegis off for the first proof) + full DW runway + shield armed.
- `scripts/ignite_sovereign_cloud_node.py` — thin launcher driving `start_soak_vm` (DW key from `.env`, masked in output; `--dry-run` supported).

## Test Plan
- [x] `tests/battle_test/test_graceful_preemption.py` — 11 passed (gating, idempotency, preemption detect, git-safety stash/lock-clear/clean-noop/disabled/non-repo, telemetry)
- [x] `tests/governance/test_start_soak_vm.py` — 4 passed (missing-script + disabled fail-clean, success reuses recipe + appends metadata, create fail-soft)
- [x] 37 harness signal-handler regressions (partial-shutdown + sighup + wall-clock) green — shield wire is safe
- [x] launcher `--dry-run` validates config; startup script `bash -n` clean
- [ ] Live ignition on GCP `jarvis-473803` (e2-custom-8-16384 Spot) — first 8-core state=applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a preemption shield for GCP Spot VMs and a soak‑mode VM provisioner that reuses our hybrid‑cloud manager to boot Ouroboros with a startup script. Safer shutdowns and a simple path to ignite an 8‑core soak in GCP.

- **New Features**
  - Preemption Shield (`graceful_preemption.py` + harness wire): detects GCP preemption, clears `.git/index.lock`, stashes in‑flight changes, and halts child workers; gated by `JARVIS_PREEMPTION_SHIELD_ENABLED` (default on), bounded and idempotent.
  - Soak‑mode provisioner (`GCPVMManager.start_soak_vm`): reuses `_build_instance_config`, bypasses offload gating, and appends DW key + model pin as instance metadata; returns `(success, name|error)`.
  - Ignition artifacts: `deploy/gcp_ouroboros_startup.sh` (Docker + clone + `.env` from metadata + compose up), `docker-compose.gcp.yml` (8‑vCPU overlay with DW‑only and shield enabled), `scripts/ignite_sovereign_cloud_node.py` (thin launcher with `--dry-run`).
  
- **Migration**
  - Put `DOUBLEWORD_API_KEY` in `.env` or env; optional `JARVIS_DW_PRIMARY_OVERRIDE` for the pin.
  - Run: `python3 scripts/ignite_sovereign_cloud_node.py --project <id> --zone <zone> --machine e2-custom-8-16384`.
  - Ensure `config.startup_script_path` points to `deploy/gcp_ouroboros_startup.sh`; ADC must be available.
  - To disable the shield: set `JARVIS_PREEMPTION_SHIELD_ENABLED=false`.

<sup>Written for commit 2cd02096008218f530707212ad054a5bfc900fe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

