### PR TITLE
fix(taxonomy): FSM-exhaustion not live_transport + un-swallow exception (Exception Taxonomy Matrix)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3787,6 +3787,7 @@ class CandidateGenerator:
                 from backend.core.ouroboros.governance.dw_fault_taxonomy import (
                     is_internal_fault as _s185_internal,
                     is_generation_timeout as _s241_gen_timeout,
+                    is_fsm_exhaustion as _fsm_exhausted,
                 )
                 if _s185_internal(exc):
                     logger.error(
@@ -3825,6 +3826,18 @@ class CandidateGenerator:
                     # topology breaker (weight 0.0) never trips on OUR budget.
                     # Stops blaming DoubleWord's network for our generation budget.
                     failure_source = FailureSource.GENERATION_TIMEOUT
+                elif _fsm_exhausted(exc):
+                    # Sovereign Exception Taxonomy (2026-06-20) — OUR-side FSM
+                    # dispatch exhaustion (DW produced no candidate AND no Claude
+                    # fallback configured under pure-DW autarky). NOT a vendor
+                    # rupture: no socket failed, the vendor rejected nothing. The
+                    # cloud soak proved a single
+                    # ``all_providers_exhausted:fallback_skipped:no_fallback_configured``
+                    # was mislabeled LIVE_TRANSPORT on all 16 models, severing the
+                    # whole DW lane + corrupting surface-health. Classify
+                    # FSM_EXHAUSTED (weight 0.0) so it fails ONLY this op without
+                    # severing the lane or touching the vendor ledger.
+                    failure_source = FailureSource.FSM_EXHAUSTED
                 elif _is_modality or _is_auth_terminal:
                     # Slice H — terminal failure class. Even though we
                     # report it as LIVE_HTTP_5XX semantics here for
@@ -3921,7 +3934,13 @@ class CandidateGenerator:
                         "[CandidateGenerator] Sentinel dispatch: model=%s "
                         "FAILED (source=%s, exc=%s) — trying next (op=%s)",
                         model_id, failure_source.value,
-                        type(exc).__name__, op_id_short,
+                        # Observability (2026-06-20): un-swallow the message. The
+                        # prior log emitted only ``type(exc).__name__`` — which hid
+                        # that a "live_transport RuntimeError" was actually an
+                        # internal ``...:no_fallback_configured`` FSM exhaustion,
+                        # costing two long blind diagnosis passes. Include the
+                        # (bounded) message so the real cause is visible at WARNING.
+                        f"{type(exc).__name__}: {err_str[:300]!r}", op_id_short,
                     )
                 attempts[-1] = f"{model_id}:failed:{failure_source.value}"
                 try:

--- a/backend/core/ouroboros/governance/dw_fault_taxonomy.py
+++ b/backend/core/ouroboros/governance/dw_fault_taxonomy.py
@@ -77,3 +77,36 @@ def is_generation_timeout(exc: BaseException) -> bool:
         return any(m in msg for m in _GENERATION_TIMEOUT_MARKERS)
     except Exception:  # noqa: BLE001 — the taxonomy must never itself throw
         return False
+
+
+# Sovereign Exception Taxonomy (2026-06-20) — FSM-EXHAUSTION segregation. When the
+# DW primary yields no candidate AND the Claude fallback is not configured (pure-DW
+# autarky), the per-model sentinel dispatch wraps it as a RuntimeError whose message
+# is one of these OUR-side FSM-control markers. These are NOT vendor transport
+# ruptures — no socket failed, the vendor never even rejected anything. Cloud soak
+# 2026-06-20 proved every one of the 16 models got mislabeled ``LIVE_TRANSPORT`` from
+# a single ``all_providers_exhausted:fallback_skipped:no_fallback_configured``,
+# which then SEVERED the whole DW lane (Slice 73/83 fast-cascade) and corrupted the
+# surface-health ledger — turning one op's no-candidate into a lane-wide outage.
+_FSM_EXHAUSTION_MARKERS = (
+    "no_fallback_configured",
+    "all_providers_exhausted",
+    "fallback_skipped",
+    "sentinel_dispatch_no_fallback",
+    "background_dw_blocked_by_topology",
+    "speculative_deferred",
+)
+
+
+def is_fsm_exhaustion(exc: BaseException) -> bool:
+    """True iff ``exc`` is an OUR-side FSM dispatch exhaustion (DW produced no
+    candidate AND no fallback is configured), NOT a vendor transport rupture. Must
+    be classified ``FSM_EXHAUSTED`` — never ``LIVE_TRANSPORT`` — so it fails only
+    the specific op WITHOUT severing the DW lane or corrupting the vendor
+    surface-health ledger (the 2026-06-20 cloud-soak lane-wide-outage root cause).
+    Message-matched; a genuine transport error never matches. NEVER raises → False."""
+    try:
+        msg = str(exc).lower()
+        return any(m in msg for m in _FSM_EXHAUSTION_MARKERS)
+    except Exception:  # noqa: BLE001 — the taxonomy must never itself throw
+        return False

--- a/backend/core/ouroboros/governance/topology_sentinel.py
+++ b/backend/core/ouroboros/governance/topology_sentinel.py
@@ -443,6 +443,12 @@ class FailureSource(str, enum.Enum):
     # to the weighted-streak that trips the DW model/topology breaker, and (being
     # != LIVE_TRANSPORT) the degrade/sever consumers ignore it automatically.
     GENERATION_TIMEOUT = "generation_timeout"      # 0.0
+    # Sovereign Exception Taxonomy (2026-06-20) — OUR-side FSM dispatch exhaustion
+    # (DW yielded no candidate AND no fallback configured under pure-DW autarky).
+    # NOT a vendor rupture. Weight 0.0: like GENERATION_TIMEOUT it is telemetry-only
+    # and (being != LIVE_TRANSPORT) the degrade/sever consumers ignore it — so one
+    # op's no-candidate can NEVER sever the DW lane or corrupt vendor surface-health.
+    FSM_EXHAUSTED = "fsm_exhausted"                # 0.0
 
 
 _DEFAULT_FAILURE_WEIGHTS: Dict[FailureSource, float] = {
@@ -455,6 +461,7 @@ _DEFAULT_FAILURE_WEIGHTS: Dict[FailureSource, float] = {
     FailureSource.LIGHT_PROBE_FAIL: 1.0,
     FailureSource.LIGHT_PROBE_TIMEOUT: 1.0,
     FailureSource.GENERATION_TIMEOUT: 0.0,
+    FailureSource.FSM_EXHAUSTED: 0.0,
 }
 
 

--- a/tests/governance/test_fsm_exception_taxonomy.py
+++ b/tests/governance/test_fsm_exception_taxonomy.py
@@ -1,0 +1,68 @@
+"""Sovereign Exception Taxonomy — FSM-exhaustion must not be mislabeled transport.
+
+Cloud soak 2026-06-20: a single
+``all_providers_exhausted:fallback_skipped:no_fallback_configured`` RuntimeError was
+classified ``LIVE_TRANSPORT`` on all 16 DW models, severing the whole lane +
+corrupting surface-health. These tests pin the carve-out: such an OUR-side FSM
+exhaustion is ``FSM_EXHAUSTED`` (weight 0.0, sever-immune), never a vendor rupture.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_fault_taxonomy import (
+    is_fsm_exhaustion,
+    is_generation_timeout,
+    is_internal_fault,
+)
+from backend.core.ouroboros.governance.topology_sentinel import (
+    FailureSource,
+    failure_weight,
+)
+
+
+@pytest.mark.parametrize("msg", [
+    "all_providers_exhausted:fallback_skipped:no_fallback_configured",
+    "sentinel_dispatch_no_fallback:nvidia/NVIDIA-Nemotron:live_transport",
+    "fallback_skipped:no_fallback_configured",
+    "background_dw_blocked_by_topology:dw_severed_queued:all_models_open",
+    "speculative_deferred:dw_severed_queued:x",
+])
+def test_fsm_exhaustion_markers_match(msg):
+    assert is_fsm_exhaustion(RuntimeError(msg)) is True
+
+
+@pytest.mark.parametrize("msg", [
+    "Connection reset by peer",
+    "Server disconnected",
+    "TimeoutError",
+    "stream stalled mid-response",
+])
+def test_genuine_transport_errors_do_not_match(msg):
+    assert is_fsm_exhaustion(RuntimeError(msg)) is False
+
+
+def test_fsm_exhaustion_is_segregated_from_other_taxonomies():
+    e = RuntimeError("all_providers_exhausted:fallback_skipped:no_fallback_configured")
+    assert is_fsm_exhaustion(e) is True
+    assert is_internal_fault(e) is False      # not a python logic bug
+    assert is_generation_timeout(e) is False  # not a tool-loop budget timeout
+
+
+def test_fsm_exhaustion_never_raises():
+    class _Bad(Exception):
+        def __str__(self):
+            raise ValueError("boom")
+    assert is_fsm_exhaustion(_Bad()) is False
+
+
+def test_fsm_exhausted_enum_exists_and_is_sever_immune():
+    assert FailureSource.FSM_EXHAUSTED.value == "fsm_exhausted"
+    # weight 0.0 → never contributes to the weighted-streak that severs the lane
+    assert failure_weight(FailureSource.FSM_EXHAUSTED) == 0.0
+    # and it is NOT the transport source the degrade/sever consumers act on
+    assert FailureSource.FSM_EXHAUSTED is not FailureSource.LIVE_TRANSPORT
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary
The **Sovereign Exception Taxonomy Matrix** — closes the misclassification + exception-swallowing root cause found on the 2026-06-20 GCP cloud soak.

**What happened:** a single OUR-side FSM dispatch exhaustion — DW produced no candidate AND no Claude fallback is configured (pure-DW autarky) — surfaced as `RuntimeError("all_providers_exhausted:fallback_skipped:no_fallback_configured")` and was classified **`LIVE_TRANSPORT` on all 16 DW models**. That severed the entire DW lane (Slice 73/83 fast-cascade) and corrupted the vendor surface-health ledger — turning one op's no-candidate into a lane-wide outage. The real message was also **swallowed** (only `type(exc).__name__` logged), which cost two long blind diagnosis passes.

## Fixes
- **`is_fsm_exhaustion()`** (`dw_fault_taxonomy.py`) — message-matched predicate for the OUR-side FSM-control markers (`no_fallback_configured`, `all_providers_exhausted`, `fallback_skipped`, `sentinel_dispatch_no_fallback`, `background_dw_blocked_by_topology`, `speculative_deferred`). Mirrors the existing Slice-185 internal-fault and Slice-241 generation-timeout carve-outs. Never raises.
- **`FailureSource.FSM_EXHAUSTED`** (weight 0.0) — a distinct, **sever-immune** classification (like `GENERATION_TIMEOUT`): telemetry-only, `!= LIVE_TRANSPORT`, so degrade/sever consumers ignore it. One op's no-candidate can no longer sever the lane or touch the vendor ledger.
- **Classifier** routes `is_fsm_exhaustion(exc) → FSM_EXHAUSTED` *before* the catch-all `LIVE_TRANSPORT` default.
- **Observability:** the per-model dispatch-`FAILED` WARNING now includes the (bounded) exception **message**, not just its type — un-swallowing the root cause at WARNING level.

## Scope (honest)
This stops the **misclassification + lane-severing + surface-health corruption** (the lane-wide-outage amplifier). The **deeper bug** — *why DW yields no candidate before the HTTP call (TTFT=0)* — is a separate short-circuit in `_dispatch_internal`'s RT path, tracked for the audit pass (now far easier with the un-swallowed message + non-severing classification).

## Test Plan
- [x] `tests/governance/test_fsm_exception_taxonomy.py` — 12 passed (markers match; genuine transport errors don't; segregation from internal/timeout; never-raises; enum sever-immune weight 0.0)
- [x] `test_slice185_telemetry_purification` + `test_slice241_*` — 115 passed (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents FSM dispatch exhaustion from being labeled `LIVE_TRANSPORT`, avoiding lane severing and vendor ledger noise. Adds a `FSM_EXHAUSTED` classification and surfaces the exception message for faster diagnosis.

- **Bug Fixes**
  - Added `is_fsm_exhaustion()` to detect OUR-side FSM no-candidate cases (`no_fallback_configured`, `all_providers_exhausted`, etc.).
  - Introduced `FailureSource.FSM_EXHAUSTED` with weight 0.0 (telemetry-only; not transport).
  - Routed `is_fsm_exhaustion()` before the `LIVE_TRANSPORT` default in `candidate_generator`.
  - Logs now include the bounded exception message in dispatch warnings (not just the type).
  - Added tests validating marker matching, non-matching for real transport errors, segregation from other taxonomies, and 0.0 weight.

<sup>Written for commit 69023f8f280fc44590f6b9069c7c3ab38818cdab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

