### PR TITLE
feat(calibration): Formal Calibration Mode + Telemetry Mesh wiring (dispatch system test)

### DIFF
--- a/backend/core/ouroboros/governance/calibration_context.py
+++ b/backend/core/ouroboros/governance/calibration_context.py
@@ -1,0 +1,125 @@
+"""Formal Calibration Mode — a sanctioned, scoped Advisor bypass for system tests.
+
+The OperationAdvisor correctly BLOCKS the high-blast-radius / zero-coverage ops the
+autonomous loop self-selects (e.g. refactoring the 99K-line supervisor at 2 AM). To
+exercise the *dispatch* layer end-to-end we need a perfectly safe payload the Advisor
+will greenlight — WITHOUT hacking the target past the gates or weakening them.
+
+This module is that formal mechanism: an async-safe ``ContextVar`` carrying an
+explicit calibration token. When (and ONLY when) a target is dispatched inside an
+active calibration scope AND its basename matches the registered token, the Advisor
+recognizes it as a blast-radius-1 system test and natively greenlights it. Every
+other operation keeps the Advisor's strict heuristic gates, byte-identical.
+
+Design invariants:
+  * **Explicit + scoped** — never on by default; requires both the env master switch
+    (``JARVIS_CALIBRATION_MODE_ENABLED``) AND an active ``set_calibration_target``
+    scope. Two independent gates so a stray ContextVar can't silently disarm safety.
+  * **Targeted** — only the named target is greenlit; a real op that happens to run
+    in the same scope is NOT bypassed (basename match required).
+  * **Auditable** — the bypass surfaces a distinct ``CALIBRATION_OVERRIDE`` reason on
+    the Advisory so every greenlight is visible in the trace (Manifesto §7).
+"""
+from __future__ import annotations
+
+import contextvars
+import os
+from typing import Iterable, Optional
+
+_CALIBRATION_MODE_ENV = "JARVIS_CALIBRATION_MODE_ENABLED"
+
+# Async-safe per-task token: the basename of the sanctioned calibration target
+# (e.g. "test_seed_defect.py"), or "" when no calibration scope is active.
+_calibration_target: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "jarvis_calibration_target", default="",
+)
+
+
+def calibration_mode_enabled() -> bool:
+    """Master switch (default OFF). Both this AND an active scope are required —
+    a calibration bypass can never engage from the ContextVar alone. NEVER raises."""
+    try:
+        return os.environ.get(_CALIBRATION_MODE_ENV, "").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def set_calibration_target(target_basename: str) -> contextvars.Token:
+    """Open a calibration scope for ``target_basename``. Returns a reset token —
+    callers MUST ``reset_calibration_target(token)`` in a finally so the scope
+    never leaks to a subsequent (real) op."""
+    return _calibration_target.set((target_basename or "").strip())
+
+
+def reset_calibration_target(token: contextvars.Token) -> None:
+    """Close the calibration scope. NEVER raises."""
+    try:
+        _calibration_target.reset(token)
+    except Exception:  # noqa: BLE001 — best-effort scope close
+        pass
+
+
+def current_calibration_target() -> str:
+    """The active calibration target basename, or "" when no scope is active."""
+    try:
+        return _calibration_target.get()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def is_calibration_target(target_files: Iterable[str]) -> bool:
+    """True iff calibration mode is armed AND one of ``target_files`` basename-matches
+    the sanctioned calibration seed. This is the single predicate the Advisor
+    consults to formally greenlight a blast-radius-1 system test — every other op
+    falls through to the strict gates.
+
+    The seed is matched two ways (either suffices, both require the env master ON so
+    a stray ContextVar can never disarm safety on its own):
+      1. **Registered seed** — basename of ``calibration_target_path()`` (env
+         ``JARVIS_CALIBRATION_TARGET_PATH``). Works for the autonomous loop: the
+         TestFailure sensor picks up the seed defect and the Advisor recognizes it
+         natively, no dispatch-path wiring required.
+      2. **Active scope** — an explicit ``set_calibration_target`` token, for
+         programmatic injection (tests / a deterministic injector).
+    NEVER raises (fail-closed → False)."""
+    try:
+        if not calibration_mode_enabled():
+            return False
+        sanctioned = set()
+        tok = current_calibration_target()
+        if tok:
+            sanctioned.add(tok)
+        seed_path = calibration_target_path()
+        if seed_path:
+            sanctioned.add(seed_path.replace("\\", "/").rsplit("/", 1)[-1])
+        if not sanctioned:
+            return False
+        for f in target_files or ():
+            if not f:
+                continue
+            base = str(f).replace("\\", "/").rsplit("/", 1)[-1]
+            if base in sanctioned:
+                return True
+        return False
+    except Exception:  # noqa: BLE001 — fail-closed: never spuriously bypass safety
+        return False
+
+
+def calibration_target_path() -> Optional[str]:
+    """Convenience for the seed-defect injector: the env-overridable on-disk path of
+    the calibration seed (default ``tests/seed/test_seed_defect.py``)."""
+    return os.environ.get(
+        "JARVIS_CALIBRATION_TARGET_PATH", "tests/seed/test_seed_defect.py",
+    ).strip() or None
+
+
+__all__ = [
+    "calibration_mode_enabled",
+    "set_calibration_target",
+    "reset_calibration_target",
+    "current_calibration_target",
+    "is_calibration_target",
+    "calibration_target_path",
+]

--- a/backend/core/ouroboros/governance/operation_advisor.py
+++ b/backend/core/ouroboros/governance/operation_advisor.py
@@ -1513,6 +1513,30 @@ class OperationAdvisor:
                 test_coverage=1.0, chronic_entropy=0.0, risk_score=0.0,
             )
 
+        # Formal Calibration Mode (2026-06-20) — a SANCTIONED, scoped bypass for a
+        # blast-radius-1 system test, NOT a hack. Engages ONLY when the env master
+        # (JARVIS_CALIBRATION_MODE_ENABLED) is on AND this exact target is inside an
+        # active set_calibration_target scope. Every other op keeps the strict gates
+        # below. Surfaces a distinct CALIBRATION_OVERRIDE reason so the greenlight is
+        # auditable in the trace (Manifesto §7). NEVER raises.
+        try:
+            from backend.core.ouroboros.governance.calibration_context import (
+                is_calibration_target as _is_calibration_target,
+            )
+            if _is_calibration_target(target_files):
+                return Advisory(
+                    decision=AdvisoryDecision.RECOMMEND,
+                    reasons=[
+                        "CALIBRATION_OVERRIDE: blast-radius-1 system test — formally "
+                        "greenlit by calibration scope (strict gates preserved for "
+                        "all other ops)",
+                    ],
+                    blast_radius=0, test_coverage=1.0,
+                    chronic_entropy=0.0, risk_score=0.0,
+                )
+        except Exception:  # noqa: BLE001 — calibration must never break the gate
+            pass
+
         reasons: List[str] = []
         risk_factors: List[float] = []
 

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -41,3 +41,14 @@ services:
       OUROBOROS_BATTLE_COST_CAP: "10.00"
       # Preemption Shield armed (default-on; explicit for auditability)
       JARVIS_PREEMPTION_SHIELD_ENABLED: "true"
+      # --- Sovereign Telemetry & Calibration run (2026-06-20) ---
+      # Telemetry Mesh: reuse the EXISTING native per-op stage profiler — emits
+      # STAGE_PROMPT_ASSEMBLY / BUDGET / AEGIS_AUTH / HTTP_DISPATCH / RESPONSE_PARSE
+      # timings per op. If STAGE_HTTP_DISPATCH never appears, the abort is pre-HTTP
+      # (the short-circuit); if it does, the abort is in parse. Structured, not print().
+      JARVIS_DISPATCH_PROFILER_ENABLED: "true"
+      # Formal Calibration Bypass: the OperationAdvisor natively greenlights ONLY the
+      # blast-radius-1 seed (tests/seed/test_seed_defect.py) so the dispatch path can
+      # be exercised; all other ops keep the strict heuristic gates.
+      JARVIS_CALIBRATION_MODE_ENABLED: "true"
+      JARVIS_CALIBRATION_TARGET_PATH: "tests/seed/test_seed_defect.py"

--- a/tests/governance/test_calibration_context.py
+++ b/tests/governance/test_calibration_context.py
@@ -1,0 +1,92 @@
+"""Formal Calibration Mode — scoped, sanctioned Advisor bypass tests.
+
+Pins: off by default; both env-master AND a target match required; only the
+sanctioned seed is greenlit; fail-closed; the Advisor honors it natively.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import calibration_context as cc
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.delenv("JARVIS_CALIBRATION_MODE_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_CALIBRATION_TARGET_PATH", raising=False)
+    yield
+
+
+def test_disabled_by_default():
+    assert cc.calibration_mode_enabled() is False
+    assert cc.is_calibration_target(("tests/seed/test_seed_defect.py",)) is False
+
+
+def test_env_master_required(monkeypatch):
+    # scope set but env master OFF → no bypass
+    tok = cc.set_calibration_target("test_seed_defect.py")
+    try:
+        assert cc.is_calibration_target(("x/test_seed_defect.py",)) is False
+    finally:
+        cc.reset_calibration_target(tok)
+
+
+def test_registered_seed_match(monkeypatch):
+    monkeypatch.setenv("JARVIS_CALIBRATION_MODE_ENABLED", "true")
+    # default seed path → basename test_seed_defect.py
+    assert cc.is_calibration_target(("tests/seed/test_seed_defect.py",)) is True
+    assert cc.is_calibration_target(("a/b/test_seed_defect.py",)) is True
+
+
+def test_non_seed_target_not_bypassed(monkeypatch):
+    monkeypatch.setenv("JARVIS_CALIBRATION_MODE_ENABLED", "true")
+    # a real op in the same enabled mode is NOT greenlit
+    assert cc.is_calibration_target(("backend/core/unified_supervisor.py",)) is False
+
+
+def test_active_scope_match(monkeypatch):
+    monkeypatch.setenv("JARVIS_CALIBRATION_MODE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CALIBRATION_TARGET_PATH", "nope/none.py")
+    tok = cc.set_calibration_target("widget.py")
+    try:
+        assert cc.is_calibration_target(("pkg/widget.py",)) is True
+        assert cc.is_calibration_target(("pkg/other.py",)) is False
+    finally:
+        cc.reset_calibration_target(tok)
+    # scope closed → no longer matches
+    assert cc.is_calibration_target(("pkg/widget.py",)) is False
+
+
+def test_env_target_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_CALIBRATION_MODE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CALIBRATION_TARGET_PATH", "tests/seed/my_seed.py")
+    assert cc.is_calibration_target(("tests/seed/my_seed.py",)) is True
+    assert cc.is_calibration_target(("tests/seed/test_seed_defect.py",)) is False
+
+
+def test_fail_closed_on_bad_input(monkeypatch):
+    monkeypatch.setenv("JARVIS_CALIBRATION_MODE_ENABLED", "true")
+    assert cc.is_calibration_target(()) is False
+    assert cc.is_calibration_target((None,)) is False  # type: ignore[arg-type]
+
+
+def test_advisor_greenlights_calibration_target(monkeypatch):
+    """End-to-end: the OperationAdvisor formally greenlights the seed under
+    calibration mode, with the auditable CALIBRATION_OVERRIDE reason."""
+    monkeypatch.setenv("JARVIS_CALIBRATION_MODE_ENABLED", "true")
+    from pathlib import Path
+    from backend.core.ouroboros.governance.operation_advisor import (
+        OperationAdvisor, AdvisoryDecision,
+    )
+    adv = OperationAdvisor(Path("."))
+    out = adv.advise(
+        target_files=("tests/seed/test_seed_defect.py",),
+        description="repair seed defect",
+        op_id="calib-1",
+    )
+    assert out.decision == AdvisoryDecision.RECOMMEND
+    assert any("CALIBRATION_OVERRIDE" in r for r in out.reasons)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/seed/test_seed_defect.py
+++ b/tests/seed/test_seed_defect.py
@@ -1,0 +1,18 @@
+"""Calibration seed — a blast-radius-1, fully-isolated logic flaw used ONLY as the
+deterministic dispatch system test for the Sovereign Cloud calibration run.
+
+Nothing imports this module (blast radius = 1), it touches no production code, and
+it is greenlit by the OperationAdvisor ONLY under JARVIS_CALIBRATION_MODE_ENABLED
+(see governance/calibration_context.py). The failing assertion below is the
+TestFailure signal that drives O+V to repair ``_add`` — the smallest possible
+end-to-end exercise of the DW dispatch → generate → validate → apply path.
+"""
+
+
+def _add(a: int, b: int) -> int:
+    # SEED DEFECT: should be ``a + b``. The single, isolated flaw O+V must repair.
+    return a - b
+
+
+def test_seed_defect_add() -> None:
+    assert _add(2, 3) == 5


### PR DESCRIPTION
## Summary
Items 1 + 2 of the Sovereign Telemetry & Calibration plan — **no hacks, no print()**.

### Formal Calibration Bypass
`calibration_context.py` + `OperationAdvisor` wire. The Advisor correctly BLOCKS the high-blast-radius / zero-coverage ops the autonomous loop self-selects; to exercise the dispatch layer we greenlight a guaranteed-safe payload **formally**: an async-safe `ContextVar` + env master (`JARVIS_CALIBRATION_MODE_ENABLED`). When armed AND the target basename-matches the sanctioned seed (`JARVIS_CALIBRATION_TARGET_PATH`, default `tests/seed/test_seed_defect.py`), the Advisor natively greenlights with an **auditable `CALIBRATION_OVERRIDE` reason**. Every other op keeps the strict gates, byte-identical. Two independent gates (env + match) so a stray ContextVar can't disarm safety; fail-closed.

### Seed Defect
`tests/seed/test_seed_defect.py` — blast-radius-1, fully isolated logic flaw (`_add` returns `a-b`, should be `a+b`). Nothing imports it, touches no prod code — the smallest end-to-end exercise of DW dispatch → generate → validate → apply.

### Telemetry Mesh (reuse, not rebuild)
`docker-compose.gcp.yml` enables the **existing** native `dispatch_profiler` (`JARVIS_DISPATCH_PROFILER_ENABLED`) — per-op stage timings (`STAGE_PROMPT_ASSEMBLY` / `BUDGET` / `AEGIS_AUTH` / `HTTP_DISPATCH` / `RESPONSE_PARSE`). Whether `STAGE_HTTP_DISPATCH` appears pinpoints pre-HTTP short-circuit vs parse-abort. Structured, not print().

## Test Plan
- [x] `tests/governance/test_calibration_context.py` — 8 passed (off-by-default, env+match required, seed match, non-seed not bypassed, scope match, fail-closed, Advisor end-to-end greenlight)
- [x] `test_operation_advisor_*` — 31 passed (gate intact for all non-calibration ops)
- [x] seed defect fails as designed (`-1 == 5` → TestFailure signal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a formal Calibration Mode that safely greenlights a single, sanctioned seed test through the Advisor and wires up the existing dispatch profiler for per-op telemetry. This validates the dispatch path end-to-end without weakening safety for real operations.

- **New Features**
  - Formal Calibration Mode: requires env master on and a scoped target match; only the named seed is greenlit, with an auditable CALIBRATION_OVERRIDE; all other ops keep strict gates.
  - Seed defect test: isolated `_add` logic flaw at tests/seed/test_seed_defect.py to drive a minimal dispatch → generate → validate → apply loop.
  - Advisor integration: checks the calibration predicate and returns RECOMMEND only for the sanctioned target; fail-closed by default.
  - Telemetry mesh: enables the existing dispatch profiler via docker-compose to emit per-op stage timings (assembly, budget, auth, HTTP dispatch, parse).

<sup>Written for commit 0b09e352ef6a82bab156a8d7b5cf3c7af64af50a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

