### PR TITLE
fix(telemetry): surface dispatch_profiler trace (JARVIS_LOG_LEVEL) + carry calibration seed into soak image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -58,6 +58,11 @@ test_*/
 *_test.py
 test_*.py
 pytest.ini
+# Calibration seed — a blast-radius-1 system-test target the soak image MUST carry
+# so the OperationAdvisor's CALIBRATION_OVERRIDE has a real on-disk target to greenlight.
+# Re-included after the broad tests/ + test_*.py excludes above (later rules win).
+!tests/seed/
+!tests/seed/test_seed_defect.py
 .pytest_cache/
 
 # Config files not needed in container

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -47,6 +47,9 @@ services:
       # timings per op. If STAGE_HTTP_DISPATCH never appears, the abort is pre-HTTP
       # (the short-circuit); if it does, the abort is in parse. Structured, not print().
       JARVIS_DISPATCH_PROFILER_ENABLED: "true"
+      # INFO so the profiler's op_summary / STAGE_ trace is actually emitted (the
+      # container root defaults to WARNING via a basicConfig no-op, which silences it).
+      JARVIS_LOG_LEVEL: "INFO"
       # Formal Calibration Bypass: the OperationAdvisor natively greenlights ONLY the
       # blast-radius-1 seed (tests/seed/test_seed_defect.py) so the dispatch path can
       # be exercised; all other ops keep the strict heuristic gates.

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -1397,6 +1397,25 @@ def main() -> None:
     ):
         logging.getLogger(_noisy).setLevel(logging.WARNING)
 
+    # Sovereign Telemetry (2026-06-20) — authoritative operator log-level override.
+    # ``logging.basicConfig`` above is a NO-OP when an imported module already
+    # installed a root handler (classic Python logging gotcha), so the root can end
+    # up at WARNING and silence the dispatch_profiler's INFO op_summary trace. When
+    # JARVIS_LOG_LEVEL is set we force it via explicit setLevel (which always wins),
+    # on the root AND the dispatch surfaces the telemetry mesh needs. Unset =
+    # legacy behavior (byte-identical).
+    _ov_level = os.environ.get("JARVIS_LOG_LEVEL", "").strip().upper()
+    if _ov_level:
+        _ov_resolved = getattr(logging, _ov_level, None)
+        if isinstance(_ov_resolved, int):
+            logging.getLogger().setLevel(_ov_resolved)
+            for _surface in (
+                "backend.core.ouroboros.governance.candidate_generator",
+                "backend.core.ouroboros.governance.doubleword_provider",
+                "backend.core.ouroboros.telemetry.dispatch_profiler",
+            ):
+                logging.getLogger(_surface).setLevel(_ov_resolved)
+
     # Gap #7 follow-up: O+V's own boot-accounting loggers (module
     # discovery, kernel init, graceful-shutdown, termination-hook
     # registration) emit DEBUG/INFO during early boot that's pure


### PR DESCRIPTION
Two config gates blocking the cloud calibration trace, now closed: (1) authoritative `JARVIS_LOG_LEVEL` override — the container root sits at WARNING via a `basicConfig` no-op, silencing the profiler's INFO `op_summary`/`STAGE_` trace; explicit `setLevel` forces it. (2) `.dockerignore` re-includes `tests/seed/test_seed_defect.py` (the broad `tests/`+`test_*.py` excludes dropped the calibration seed from the build context). (3) overlay sets `JARVIS_LOG_LEVEL=INFO`. Next deploy emits the per-op STAGE_ trace that pinpoints the pre-HTTP short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface the dispatch profiler’s INFO-level STAGE_ trace in cloud and include the calibration seed in the soak image. Restores telemetry for calibration and makes pre-HTTP vs parse aborts visible.

- **Bug Fixes**
  - Respect `JARVIS_LOG_LEVEL` by forcing `setLevel` on root and dispatch loggers in `scripts/ouroboros_battle_test.py` (unset keeps legacy behavior).
  - Set `JARVIS_LOG_LEVEL=INFO` in `docker-compose.gcp.yml` and re-include `tests/seed/test_seed_defect.py` in the build context so the soak image carries the calibration seed and the `dispatch_profiler` emits `STAGE_`/`op_summary`.

<sup>Written for commit 137693311bd9663d2facb507c173a7e3b7d47190. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

