### PR TITLE
fix(dispatch): force RT not BATCH for cloud soak (batch never completes in budget)

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -34,6 +34,15 @@ services:
       JARVIS_DW_SURFACE_HEALTH_ENABLED: "false"
       # first proof isolates the loop from the AegisForward DW-streaming path
       JARVIS_AEGIS_ENABLED: "false"
+      # THE KILLING BLOW (2026-06-20 trace): Slice 36/41 forced the BATCH path for
+      # STANDARD + Claude-disabled (stale "RT TTFT 66s" evidence) — but the DW batch
+      # job submits (~600ms) and then NEVER completes within the 180s budget →
+      # STAGE_PROVIDER_GENERATE TimeoutError → fsm_exhausted on every model. RT
+      # streaming is PROVEN fast in-container (curl gpt-oss-120b = 0.78s). Force RT,
+      # not batch: disable both force-batch escape hatches so the loop uses the fast,
+      # working real-time chat/completions path.
+      JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX: "0"
+      JARVIS_DW_FORCE_BATCH_ON_CLAUDE_BREAKER: "0"
       # real cores → give DW generation full runway (no 90s reflex-cap timeouts)
       OUROBOROS_TIER0_MAX_WAIT_S: "600"
       JARVIS_GENERATION_TIMEOUT_S: "900"


### PR DESCRIPTION
Root cause of the cloud `state=applied` failure, found via the `dispatch_profiler` trace (silent_boot routes INFO to debug.log, not stdout): **Slice 36/41 force the DW BATCH path** for STANDARD + Claude-disabled; the batch submits (~600ms) but **never completes within the 180s budget → `STAGE_PROVIDER_GENERATE` TimeoutError → fsm_exhausted** on all 16 models. RT streaming is proven fast in-container (curl gpt-oss-120b = 0.78s) and was being skipped. Fix: disable both force-batch escape hatches in the GCP overlay so the loop uses the fast RT path. The batch-retrieve-hang is a separate DW issue tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force real-time streaming instead of batch in the GCP overlay to stop generation timeouts during cloud soak. This routes STANDARD/COMPLEX traffic through the fast RT path and unblocks state transitions.

- **Bug Fixes**
  - Disabled batch escape hatches in `docker-compose.gcp.yml` by setting `JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX=0` and `JARVIS_DW_FORCE_BATCH_ON_CLAUDE_BREAKER=0`.
  - Avoids the DW batch path where jobs submit but don’t complete within the 180s budget.
  - Keeps generation on the proven-fast RT streaming path.

<sup>Written for commit 4e04974715fd00782c6a5d384783f3e4dbc0d681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

