### PR TITLE
fix(calibration): point TestWatcher at tests/seed so the seed op flows

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -64,3 +64,9 @@ services:
       # be exercised; all other ops keep the strict heuristic gates.
       JARVIS_CALIBRATION_MODE_ENABLED: "true"
       JARVIS_CALIBRATION_TARGET_PATH: "tests/seed/test_seed_defect.py"
+      # Point the TestWatcher at ONLY the calibration seed so it gets a clean
+      # 1-test failure (TestFailure signal → seed op) instead of drowning it in
+      # collection errors from running the whole deps-incomplete tests/ tree.
+      JARVIS_INTENT_TEST_DIR: "tests/seed"
+      JARVIS_INTENT_TEST_INTERVAL_S: "60"
+


### PR DESCRIPTION
Live trace showed `CALIBRATION_OVERRIDE` never fired — the TestWatcher runs `pytest tests/` (whole tree → collection-error chaos in the soak image, burying the seed). Point it at `tests/seed/` only (`JARVIS_INTENT_TEST_DIR`) → clean 1-test failure → TestFailure signal → seed op → `CALIBRATION_OVERRIDE` greenlight → RT generates the fix → APPLY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes calibration flow by running only the seed tests. Ensures a clean single test failure that triggers the seed op and `CALIBRATION_OVERRIDE`.

- **Bug Fixes**
  - Set `JARVIS_INTENT_TEST_DIR` to `tests/seed` to avoid collection errors from the full `tests/` tree.
  - Set `JARVIS_INTENT_TEST_INTERVAL_S` to `60` for prompt triggering.

<sup>Written for commit a1cf59503c037fac694c36427ccab443078b30f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

