### PR TITLE
fix(soak-image): add pytest so the TestWatcher can detect failing tests

### DIFF
--- a/docker/requirements-soak.txt
+++ b/docker/requirements-soak.txt
@@ -57,3 +57,10 @@ discord.py>=2.3
 # live Docker Desktop run; the rest of governance/__init__'s import graph is
 # already satisfied (verified by in-container import). Pure-python wheel, light.
 networkx>=3.0
+
+# pytest — REQUIRED for the TestWatcher (TestFailure sensor) to run/detect failing
+# tests and for the post-APPLY VERIFY scoped test run. Absent from the lean soak
+# image, the watcher's `python3 -m pytest` died with "No module named pytest"
+# (47-byte rc=1) → no FAILED line → no TestFailure signal → the calibration seed
+# op never flowed → no state=applied. Pure-python, light. (2026-06-20)
+pytest>=7.4


### PR DESCRIPTION
Live trace: TestWatcher's `python3 -m pytest tests/seed` → "No module named pytest" (pytest absent from lean soak image) → no FAILED line → no TestFailure signal → seed op never flows → no `CALIBRATION_OVERRIDE` → no state=applied. Add `pytest>=7.4`. Last identified gap in the seed→op→calibration→RT→apply chain after #69596 (force-RT) + #69597 (watcher→tests/seed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `pytest>=7.4` to the soak image so the TestWatcher can run `python3 -m pytest tests/seed` and detect failing tests. Fixes the "No module named pytest" error that blocked TestFailure signals and stalled the seed -> op -> calibration -> apply flow, and the post-APPLY verify run.

<sup>Written for commit 0a3790e71a998cf46a8cfadf949fb431c4205997. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

