### PR TITLE
fix(dw-batch): race webhook vs poll — kill the batch-retrieve hang (async recovery)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -4430,29 +4430,68 @@ class DoublewordProvider:
     async def _await_batch_result(
         self, batch_id: str, *, op_id: str = "dw-batch-await",
     ) -> Optional[str]:
-        """Wait for batch result via webhook future or adaptive poll fallback.
+        """Wait for batch result by RACING the webhook future against adaptive poll.
 
-        Tier 1: If a ``BatchFutureRegistry`` is wired and the batch has a
-        registered future, await it (zero polling — webhook resolves it).
+        Async Batch Recovery Matrix (2026-06-20). The prior design awaited the
+        webhook future FIRST and only polled on its exception — so when the
+        ``batch.completed`` webhook can't be delivered (e.g. a cloud node with no
+        public ingress for DW's callback), Tier 1 blocked the ENTIRE budget
+        (``_DW_MAX_WAIT_S``, cut off by the op's wall budget → 180s TimeoutError)
+        while the working poll path (Tier 2) was never reached. The live trace
+        proved DW completes a batch in ~11s, so polling would have caught it
+        trivially.
 
-        Tier 2: Adaptive exponential backoff polling with jitter.
+        Fix: run BOTH concurrently and take whichever resolves first —
+          * webhook (zero-poll, instant when ingress exists), AND
+          * adaptive exponential-backoff poll (always works; catches the ~11s
+            completion regardless of webhook reachability).
+        The loser is cancelled. A webhook that never arrives no longer starves
+        the op; a reachable webhook still wins instantly. NEVER blocks the loop
+        beyond the first resolver.
 
         Slice 2B-ii — ``op_id`` is forwarded to ``_adaptive_poll_batch``
         for per-call Aegis lease accounting.
         """
-        # Tier 1: webhook-driven (if registry wired)
+        # Always run the poll path — it is the reachability-independent ground truth.
+        poll_task = asyncio.ensure_future(
+            self._adaptive_poll_batch(batch_id, op_id=op_id)
+        )
         registry = getattr(self, "_batch_registry", None)
-        if registry is not None:
-            try:
-                return await registry.wait(batch_id, timeout=_DW_MAX_WAIT_S)
-            except asyncio.TimeoutError:
-                logger.warning("[DoublewordProvider] Webhook wait timed out for %s", batch_id)
-                return None
-            except Exception:
-                pass  # No future registered or rejected — fall through to Tier 2
+        if registry is None:
+            return await poll_task
 
-        # Tier 2: adaptive backoff poll
-        return await self._adaptive_poll_batch(batch_id, op_id=op_id)
+        # Race webhook (zero-poll) vs poll (always-works). First non-None wins.
+        webhook_task = asyncio.ensure_future(
+            registry.wait(batch_id, timeout=_DW_MAX_WAIT_S)
+        )
+        pending = {poll_task, webhook_task}
+        result: Optional[str] = None
+        try:
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED,
+                )
+                _winner_resolved = False
+                for t in done:
+                    try:
+                        r = t.result()
+                    except Exception:  # noqa: BLE001 — a failed arm yields to the other
+                        r = None
+                    if r is not None:
+                        result = r
+                        _winner_resolved = True
+                        break
+                if _winner_resolved:
+                    break
+            return result
+        finally:
+            for t in (poll_task, webhook_task):
+                if not t.done():
+                    t.cancel()
+                    try:
+                        await t
+                    except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                        pass
 
     @staticmethod
     def _next_poll_interval(attempt: int, *, network_error: bool = False) -> float:

--- a/tests/governance/test_batch_webhook_poll_race.py
+++ b/tests/governance/test_batch_webhook_poll_race.py
@@ -1,0 +1,81 @@
+"""Async Batch Recovery — _await_batch_result must race webhook vs poll.
+
+Pins the 2026-06-20 fix: a webhook that never arrives (cloud node, no ingress)
+must NOT starve the op — the always-works poll path wins. DW completes batches in
+~11s, so polling catches it; the prior await-webhook-first design hung the full
+budget → 180s TimeoutError.
+"""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from backend.core.ouroboros.governance.doubleword_provider import DoublewordProvider
+
+
+def _provider():
+    # construct minimally without network — only _await_batch_result is exercised
+    return DoublewordProvider.__new__(DoublewordProvider)
+
+
+class _Registry:
+    def __init__(self, *, hangs=False, result=None):
+        self._hangs = hangs
+        self._result = result
+    async def wait(self, batch_id, timeout=None):
+        if self._hangs:
+            await asyncio.sleep(3600)  # webhook never arrives
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_poll_wins_when_webhook_never_arrives(monkeypatch):
+    """The cloud-node case: webhook hangs forever, poll returns → poll wins fast."""
+    p = _provider()
+    p._batch_registry = _Registry(hangs=True)
+    async def _poll(batch_id, op_id="x"):
+        await asyncio.sleep(0.05)
+        return "out-file-from-poll"
+    monkeypatch.setattr(p, "_adaptive_poll_batch", _poll)
+    out = await asyncio.wait_for(p._await_batch_result("b1"), timeout=2.0)
+    assert out == "out-file-from-poll"
+
+
+@pytest.mark.asyncio
+async def test_webhook_wins_when_faster(monkeypatch):
+    p = _provider()
+    p._batch_registry = _Registry(hangs=False, result="out-file-from-webhook")
+    async def _poll(batch_id, op_id="x"):
+        await asyncio.sleep(5)  # slow poll
+        return "out-file-from-poll"
+    monkeypatch.setattr(p, "_adaptive_poll_batch", _poll)
+    out = await asyncio.wait_for(p._await_batch_result("b1"), timeout=2.0)
+    assert out == "out-file-from-webhook"
+
+
+@pytest.mark.asyncio
+async def test_no_registry_just_polls(monkeypatch):
+    p = _provider()
+    p._batch_registry = None
+    async def _poll(batch_id, op_id="x"):
+        return "out-file-from-poll"
+    monkeypatch.setattr(p, "_adaptive_poll_batch", _poll)
+    out = await p._await_batch_result("b1")
+    assert out == "out-file-from-poll"
+
+
+@pytest.mark.asyncio
+async def test_poll_wins_when_webhook_returns_none(monkeypatch):
+    """Webhook resolves None (rejected) → poll's real result is taken, not None."""
+    p = _provider()
+    p._batch_registry = _Registry(hangs=False, result=None)
+    async def _poll(batch_id, op_id="x"):
+        await asyncio.sleep(0.05)
+        return "out-file-from-poll"
+    monkeypatch.setattr(p, "_adaptive_poll_batch", _poll)
+    out = await asyncio.wait_for(p._await_batch_result("b1"), timeout=2.0)
+    assert out == "out-file-from-poll"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Live probe: DW completes a batch in ~11s, yet the loop hung the full op budget → 180s TimeoutError. Root cause in `_await_batch_result`: awaits the webhook future first (`registry.wait`, 3600s) and only polls on its exception — so when `batch.completed` can't reach the cloud node (no public ingress), Tier 1 blocks the whole budget while the working poll path (Tier 2) is never reached. Fix: **race webhook vs poll concurrently, take first non-None, cancel the loser**. Poll (reachability-independent) catches the 11s completion; webhook wins instantly when ingress exists. Removes the reason for the force-RT workaround and makes BATCH viable for large ops (prereq for the dynamic transport router). 4 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Race the batch webhook future against adaptive polling and return the first non-None result to prevent hangs when webhooks can’t reach the node. Restores fast completion (~11s) and avoids 180s timeouts.

- **Bug Fixes**
  - `_await_batch_result` now runs webhook wait and `_adaptive_poll_batch` concurrently and cancels the loser.
  - Poll always runs; if no registry is present, we poll only.
  - Added tests for webhook-faster, poll-wins-when-webhook-hangs, no-registry, and webhook-returns-None.

<sup>Written for commit 767cb48a47bded05ebf8bf865a58606521653751. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

