### PR TITLE
feat(transport): Dynamic Transport Router (no force-RT hardcode) + re-arm Aegis

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -4430,29 +4430,68 @@ class DoublewordProvider:
     async def _await_batch_result(
         self, batch_id: str, *, op_id: str = "dw-batch-await",
     ) -> Optional[str]:
-        """Wait for batch result via webhook future or adaptive poll fallback.
+        """Wait for batch result by RACING the webhook future against adaptive poll.
 
-        Tier 1: If a ``BatchFutureRegistry`` is wired and the batch has a
-        registered future, await it (zero polling — webhook resolves it).
+        Async Batch Recovery Matrix (2026-06-20). The prior design awaited the
+        webhook future FIRST and only polled on its exception — so when the
+        ``batch.completed`` webhook can't be delivered (e.g. a cloud node with no
+        public ingress for DW's callback), Tier 1 blocked the ENTIRE budget
+        (``_DW_MAX_WAIT_S``, cut off by the op's wall budget → 180s TimeoutError)
+        while the working poll path (Tier 2) was never reached. The live trace
+        proved DW completes a batch in ~11s, so polling would have caught it
+        trivially.
 
-        Tier 2: Adaptive exponential backoff polling with jitter.
+        Fix: run BOTH concurrently and take whichever resolves first —
+          * webhook (zero-poll, instant when ingress exists), AND
+          * adaptive exponential-backoff poll (always works; catches the ~11s
+            completion regardless of webhook reachability).
+        The loser is cancelled. A webhook that never arrives no longer starves
+        the op; a reachable webhook still wins instantly. NEVER blocks the loop
+        beyond the first resolver.
 
         Slice 2B-ii — ``op_id`` is forwarded to ``_adaptive_poll_batch``
         for per-call Aegis lease accounting.
         """
-        # Tier 1: webhook-driven (if registry wired)
+        # Always run the poll path — it is the reachability-independent ground truth.
+        poll_task = asyncio.ensure_future(
+            self._adaptive_poll_batch(batch_id, op_id=op_id)
+        )
         registry = getattr(self, "_batch_registry", None)
-        if registry is not None:
-            try:
-                return await registry.wait(batch_id, timeout=_DW_MAX_WAIT_S)
-            except asyncio.TimeoutError:
-                logger.warning("[DoublewordProvider] Webhook wait timed out for %s", batch_id)
-                return None
-            except Exception:
-                pass  # No future registered or rejected — fall through to Tier 2
+        if registry is None:
+            return await poll_task
 
-        # Tier 2: adaptive backoff poll
-        return await self._adaptive_poll_batch(batch_id, op_id=op_id)
+        # Race webhook (zero-poll) vs poll (always-works). First non-None wins.
+        webhook_task = asyncio.ensure_future(
+            registry.wait(batch_id, timeout=_DW_MAX_WAIT_S)
+        )
+        pending = {poll_task, webhook_task}
+        result: Optional[str] = None
+        try:
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED,
+                )
+                _winner_resolved = False
+                for t in done:
+                    try:
+                        r = t.result()
+                    except Exception:  # noqa: BLE001 — a failed arm yields to the other
+                        r = None
+                    if r is not None:
+                        result = r
+                        _winner_resolved = True
+                        break
+                if _winner_resolved:
+                    break
+            return result
+        finally:
+            for t in (poll_task, webhook_task):
+                if not t.done():
+                    t.cancel()
+                    try:
+                        await t
+                    except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                        pass
 
     @staticmethod
     def _next_poll_interval(attempt: int, *, network_error: bool = False) -> float:

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -833,6 +833,22 @@ def _slice36_should_force_batch(context: Any, *, model_id: str = "") -> bool:
             return False
         if not _route_ok:
             return False
+        # Dynamic Transport Router (2026-06-20): when enabled, the all-or-nothing
+        # static blanket below is REPLACED by a per-op payload heuristic — a
+        # localized fix streams (RT, fast), a large/multi-file refactor batches
+        # (viable now the webhook-vs-poll retrieve-hang is fixed). The
+        # ledger-degraded-stream override (Slice 41) still forces batch regardless
+        # (a broken wire must batch at any size). Removes the force-RT/force-batch
+        # hardcode dichotomy. Gated; OFF → the legacy static decision below.
+        try:
+            from backend.core.ouroboros.governance.payload_transport_heuristic import (
+                dynamic_transport_enabled as _dyn_on,
+                should_batch_by_payload as _dyn_should_batch,
+            )
+            if _dyn_on():
+                return _dyn_should_batch(context, model_id) or _slice41_ledger_force_batch()
+        except Exception:  # noqa: BLE001 — fall through to the static decision
+            pass
         # Slice 36 static opt-out (default ON per operator authorization).
         _raw = os.environ.get(_SLICE36_FORCE_BATCH_ENV, "1").strip().lower()
         _static_on = _raw not in ("0", "false", "no", "off")

--- a/backend/core/ouroboros/governance/payload_transport_heuristic.py
+++ b/backend/core/ouroboros/governance/payload_transport_heuristic.py
@@ -1,0 +1,104 @@
+"""Dynamic Transport Router — per-op RT-vs-BATCH selection by payload size.
+
+Replaces the all-or-nothing transport dichotomy (blanket force-batch OR the
+force-RT workaround) with a heuristic: a localized fix streams (RT — fast TTFT,
+proven ~0.78s, low latency), a large/multi-file refactor batches (the DW batch
+API, viable now that the webhook-vs-poll retrieve-hang is fixed). The op's own
+shape decides — no hardcode.
+
+Consulted by ``doubleword_provider._slice36_should_force_batch`` ONLY for the
+"Claude-unavailable + healthy stream" case; the rupture-driven slices (170 ledger
+failover, 172 predictive, 179 warm-boot) still force batch on a DEGRADED stream
+regardless (a broken wire must batch no matter the size).
+
+Size signal (first available wins), reusing existing primitives — no new scan:
+  1. ``providers._max_target_line_count`` over the op's target files (the SAME
+     signal Slice-235 + the tool-loop op-weight read) when a repo root resolves.
+  2. target-file COUNT (multi-file ⇒ architectural ⇒ batch).
+  3. ``task_complexity`` tier (heavy/complex ⇒ batch).
+
+Gated by ``JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED`` (default OFF → legacy static
+decision, byte-identical). Pure + fail-soft: any error → False (prefer RT, the
+low-latency default). NEVER raises.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+_ENABLED_ENV = "JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED"
+_LINE_THRESHOLD_ENV = "JARVIS_DW_BATCH_PAYLOAD_LINE_THRESHOLD"
+_FILE_COUNT_THRESHOLD_ENV = "JARVIS_DW_BATCH_PAYLOAD_FILE_THRESHOLD"
+
+# A localized fix (version bump, one-liner, small function) is well under these.
+# A large/multi-file refactor exceeds them → batch.
+_DEFAULT_LINE_THRESHOLD = 400
+_DEFAULT_FILE_THRESHOLD = 3
+_HEAVY_COMPLEXITIES = frozenset({"heavy", "complex", "architectural", "heavy_code"})
+
+
+def dynamic_transport_enabled() -> bool:
+    """Master gate (default OFF → legacy static transport decision). NEVER raises."""
+    try:
+        return os.environ.get(_ENABLED_ENV, "").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        v = int(os.environ.get(name, "").strip() or default)
+        return v if v > 0 else default
+    except (ValueError, TypeError):
+        return default
+
+
+def should_batch_by_payload(context: Any, model_id: str = "") -> bool:
+    """True ⇒ route THIS op to BATCH (large/multi-file); False ⇒ RT stream
+    (localized). Size-aware, reachability-independent, fail-soft → False (RT).
+
+    Only meaningful when ``dynamic_transport_enabled()``; the caller checks that.
+    NEVER raises."""
+    try:
+        targets = tuple(getattr(context, "target_files", ()) or ())
+
+        # (2) multi-file ⇒ architectural ⇒ batch.
+        if len(targets) >= _int_env(_FILE_COUNT_THRESHOLD_ENV, _DEFAULT_FILE_THRESHOLD):
+            return True
+
+        # (1) largest target file's line count (reuses the Slice-235 size primitive).
+        line_threshold = _int_env(_LINE_THRESHOLD_ENV, _DEFAULT_LINE_THRESHOLD)
+        repo_root = (
+            getattr(context, "primary_repo_root", None)
+            or getattr(context, "repo_root", None)
+            or os.environ.get("JARVIS_PROJECT_ROOT")
+            or "."
+        )
+        try:
+            from backend.core.ouroboros.governance.providers import (
+                _max_target_line_count as _max_lines,
+            )
+            lines = _max_lines(targets, repo_root)
+            if isinstance(lines, int) and lines >= line_threshold:
+                return True
+        except Exception:  # noqa: BLE001 — size probe is best-effort
+            pass
+
+        # (3) complexity tier fallback (heavy/architectural ⇒ batch even if the
+        # line probe missed, e.g. new-file creation with no on-disk target yet).
+        complexity = str(getattr(context, "task_complexity", "") or "").strip().lower()
+        if complexity in _HEAVY_COMPLEXITIES:
+            return True
+
+        # Localized op → RT stream (the fast, low-latency default).
+        return False
+    except Exception:  # noqa: BLE001 — fail-soft to RT
+        return False
+
+
+__all__ = [
+    "dynamic_transport_enabled",
+    "should_batch_by_payload",
+]

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -32,17 +32,16 @@ services:
       JARVIS_SEMANTIC_INFERENCE_ENABLED: "false"
       # don't let the heavy 550B boot probe false-degrade the DW stream lane
       JARVIS_DW_SURFACE_HEALTH_ENABLED: "false"
-      # first proof isolates the loop from the AegisForward DW-streaming path
-      JARVIS_AEGIS_ENABLED: "false"
-      # THE KILLING BLOW (2026-06-20 trace): Slice 36/41 forced the BATCH path for
-      # STANDARD + Claude-disabled (stale "RT TTFT 66s" evidence) — but the DW batch
-      # job submits (~600ms) and then NEVER completes within the 180s budget →
-      # STAGE_PROVIDER_GENERATE TimeoutError → fsm_exhausted on every model. RT
-      # streaming is PROVEN fast in-container (curl gpt-oss-120b = 0.78s). Force RT,
-      # not batch: disable both force-batch escape hatches so the loop uses the fast,
-      # working real-time chat/completions path.
-      JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX: "0"
-      JARVIS_DW_FORCE_BATCH_ON_CLAUDE_BREAKER: "0"
+      # SHIELDS UP (item 1): aegis re-armed to validate PR #69590 (the AegisForward
+      # upstream-response-release fix) holds the DW SSE stream under live load. The
+      # batch retrieve-hang (#69599) + dynamic router below make this safe to test —
+      # if aegis ruptures RT, the loop now routes/recovers cleanly instead of wedging.
+      JARVIS_AEGIS_ENABLED: "true"
+      # DYNAMIC TRANSPORT ROUTER (item 3): replaces the force-RT hardcode. A per-op
+      # payload heuristic streams localized fixes (RT, fast) and batches large/
+      # multi-file refactors (DW batch, now that the webhook-vs-poll retrieve-hang
+      # is fixed in #69599). No all-or-nothing dichotomy.
+      JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED: "true"
       # real cores → give DW generation full runway (no 90s reflex-cap timeouts)
       OUROBOROS_TIER0_MAX_WAIT_S: "600"
       JARVIS_GENERATION_TIMEOUT_S: "900"

--- a/tests/governance/test_batch_webhook_poll_race.py
+++ b/tests/governance/test_batch_webhook_poll_race.py
@@ -1,0 +1,81 @@
+"""Async Batch Recovery — _await_batch_result must race webhook vs poll.
+
+Pins the 2026-06-20 fix: a webhook that never arrives (cloud node, no ingress)
+must NOT starve the op — the always-works poll path wins. DW completes batches in
+~11s, so polling catches it; the prior await-webhook-first design hung the full
+budget → 180s TimeoutError.
+"""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from backend.core.ouroboros.governance.doubleword_provider import DoublewordProvider
+
+
+def _provider():
+    # construct minimally without network — only _await_batch_result is exercised
+    return DoublewordProvider.__new__(DoublewordProvider)
+
+
+class _Registry:
+    def __init__(self, *, hangs=False, result=None):
+        self._hangs = hangs
+        self._result = result
+    async def wait(self, batch_id, timeout=None):
+        if self._hangs:
+            await asyncio.sleep(3600)  # webhook never arrives
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_poll_wins_when_webhook_never_arrives(monkeypatch):
+    """The cloud-node case: webhook hangs forever, poll returns → poll wins fast."""
+    p = _provider()
+    p._batch_registry = _Registry(hangs=True)
+    async def _poll(batch_id, op_id="x"):
+        await asyncio.sleep(0.05)
+        return "out-file-from-poll"
+    monkeypatch.setattr(p, "_adaptive_poll_batch", _poll)
+    out = await asyncio.wait_for(p._await_batch_result("b1"), timeout=2.0)
+    assert out == "out-file-from-poll"
+
+
+@pytest.mark.asyncio
+async def test_webhook_wins_when_faster(monkeypatch):
+    p = _provider()
+    p._batch_registry = _Registry(hangs=False, result="out-file-from-webhook")
+    async def _poll(batch_id, op_id="x"):
+        await asyncio.sleep(5)  # slow poll
+        return "out-file-from-poll"
+    monkeypatch.setattr(p, "_adaptive_poll_batch", _poll)
+    out = await asyncio.wait_for(p._await_batch_result("b1"), timeout=2.0)
+    assert out == "out-file-from-webhook"
+
+
+@pytest.mark.asyncio
+async def test_no_registry_just_polls(monkeypatch):
+    p = _provider()
+    p._batch_registry = None
+    async def _poll(batch_id, op_id="x"):
+        return "out-file-from-poll"
+    monkeypatch.setattr(p, "_adaptive_poll_batch", _poll)
+    out = await p._await_batch_result("b1")
+    assert out == "out-file-from-poll"
+
+
+@pytest.mark.asyncio
+async def test_poll_wins_when_webhook_returns_none(monkeypatch):
+    """Webhook resolves None (rejected) → poll's real result is taken, not None."""
+    p = _provider()
+    p._batch_registry = _Registry(hangs=False, result=None)
+    async def _poll(batch_id, op_id="x"):
+        await asyncio.sleep(0.05)
+        return "out-file-from-poll"
+    monkeypatch.setattr(p, "_adaptive_poll_batch", _poll)
+    out = await asyncio.wait_for(p._await_batch_result("b1"), timeout=2.0)
+    assert out == "out-file-from-poll"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/governance/test_payload_transport_heuristic.py
+++ b/tests/governance/test_payload_transport_heuristic.py
@@ -1,0 +1,68 @@
+"""Dynamic Transport Router — payload-size RT-vs-BATCH selection tests."""
+from __future__ import annotations
+
+import types
+import pytest
+
+from backend.core.ouroboros.governance import payload_transport_heuristic as h
+
+
+def _ctx(targets=(), complexity="trivial"):
+    return types.SimpleNamespace(target_files=tuple(targets), task_complexity=complexity)
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    for k in ("JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED", "JARVIS_DW_BATCH_PAYLOAD_LINE_THRESHOLD",
+              "JARVIS_DW_BATCH_PAYLOAD_FILE_THRESHOLD", "JARVIS_PROJECT_ROOT"):
+        monkeypatch.delenv(k, raising=False)
+    # neutralize the line-count probe unless a test sets it
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.providers._max_target_line_count",
+        lambda targets, root: 0, raising=False,
+    )
+    yield
+
+
+def test_disabled_by_default():
+    assert h.dynamic_transport_enabled() is False
+
+
+def test_localized_single_small_file_streams(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED", "true")
+    assert h.should_batch_by_payload(_ctx(("requirements.txt",), "trivial")) is False
+
+
+def test_multi_file_batches(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED", "true")
+    assert h.should_batch_by_payload(_ctx(("a.py", "b.py", "c.py"), "moderate")) is True
+
+
+def test_large_file_batches(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED", "true")
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.providers._max_target_line_count",
+        lambda targets, root: 1200, raising=False,
+    )
+    assert h.should_batch_by_payload(_ctx(("big.py",), "moderate")) is True
+
+
+def test_heavy_complexity_batches(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED", "true")
+    assert h.should_batch_by_payload(_ctx(("new_file.py",), "heavy")) is True
+
+
+def test_thresholds_env_tunable(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_BATCH_PAYLOAD_FILE_THRESHOLD", "2")
+    assert h.should_batch_by_payload(_ctx(("a.py", "b.py"), "moderate")) is True
+
+
+def test_fail_soft_to_rt_on_bad_context(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED", "true")
+    bad = types.SimpleNamespace()  # no target_files attr
+    assert h.should_batch_by_payload(bad) is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
**Item 3 (no hardcoding):** `payload_transport_heuristic.py` replaces the force-RT/force-batch dichotomy with a per-op size heuristic (localized→RT, large/multi-file→BATCH), consulted by `_slice36_should_force_batch` only for the Claude-unavailable+healthy-stream case; rupture-driven slices still batch a degraded stream. Reuses `_max_target_line_count`. Gated, fail-soft→RT. 7 tests.
**Item 1 (shields up):** overlay removes the force-RT hardcode and re-arms `JARVIS_AEGIS_ENABLED=true` to validate #69590 under live load (safe now the batch fix #69599 + router recover if RT ruptures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dynamic transport router that picks RT or BATCH per operation based on payload size, replacing the blanket force-RT/force-batch toggle. Also fixes batch completion hangs by racing webhook vs adaptive polling, and re‑enables Aegis for live validation.

- **New Features**
  - Per-op heuristic in `payload_transport_heuristic.py`: multi-file or large-linecount or heavy complexity ⇒ BATCH; otherwise RT. Gated by `JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED` (default off). Wired into `_slice36_should_force_batch`; degraded-stream slices still force BATCH.
  - Docker overlay enables the router and sets `JARVIS_AEGIS_ENABLED=true`.

- **Bug Fixes**
  - `_await_batch_result` now races the webhook future against adaptive polling and returns the first non-None result; cancels the loser. Prevents long hangs when webhooks are unreachable.
  - Tests added for the race behavior and the routing heuristic.

<sup>Written for commit a99ee1d60a1e3f00cf0fdeb156dca90f1c231579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

