### PR TITLE
fix(soak): aegis OFF — re-arm soak proved it regresses generation

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -32,11 +32,13 @@ services:
       JARVIS_SEMANTIC_INFERENCE_ENABLED: "false"
       # don't let the heavy 550B boot probe false-degrade the DW stream lane
       JARVIS_DW_SURFACE_HEALTH_ENABLED: "false"
-      # SHIELDS UP (item 1): aegis re-armed to validate PR #69590 (the AegisForward
-      # upstream-response-release fix) holds the DW SSE stream under live load. The
-      # batch retrieve-hang (#69599) + dynamic router below make this safe to test —
-      # if aegis ruptures RT, the loop now routes/recovers cleanly instead of wedging.
-      JARVIS_AEGIS_ENABLED: "true"
+      # AEGIS VALIDATION RESULT (2026-06-20 soak): re-arming aegis REGRESSED the loop
+      # — every op fsm_exhausted, zero state=applied. PR #69590 fixed the upstream-
+      # response LEAK ("Unclosed connection") but the aegis DW-streaming path still
+      # breaks generation under live load (the rupture, not just the leak). Aegis
+      # stays OFF for the working cloud config; the deeper AegisForward DW-SSE rupture
+      # is a tracked follow-up (dedicated fix + its own validation soak required).
+      JARVIS_AEGIS_ENABLED: "false"
       # DYNAMIC TRANSPORT ROUTER (item 3): replaces the force-RT hardcode. A per-op
       # payload heuristic streams localized fixes (RT, fast) and batches large/
       # multi-file refactors (DW batch, now that the webhook-vs-poll retrieve-hang


### PR DESCRIPTION
Aegis re-arm soak: `JARVIS_AEGIS_ENABLED=true` → every op `fsm_exhausted`, zero `state=applied`. #69590 fixed the leak; the aegis DW-SSE **rupture persists under live load**. Revert to the proven config (aegis OFF + dynamic router #69600 + batch race #69599); aegis = tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Aegis in `docker-compose.gcp.yml` after the re-arm soak showed it breaks generation under live load (ops exhausted, no state applied). Keeps the stable setup with the dynamic transport router and batch race recovery enabled.

<sup>Written for commit cc7cf60ecfdf8ac48370050b161b2216c9119902. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

