### PR TITLE
fix(aegis): raise shields — RT/SSE-through-aegis proven, state=applied with proxy defending

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -32,18 +32,29 @@ services:
       JARVIS_SEMANTIC_INFERENCE_ENABLED: "false"
       # don't let the heavy 550B boot probe false-degrade the DW stream lane
       JARVIS_DW_SURFACE_HEALTH_ENABLED: "false"
-      # AEGIS VALIDATION RESULT (2026-06-20 soak): re-arming aegis REGRESSED the loop
-      # — every op fsm_exhausted, zero state=applied. PR #69590 fixed the upstream-
-      # response LEAK ("Unclosed connection") but the aegis DW-streaming path still
-      # breaks generation under live load (the rupture, not just the leak). Aegis
-      # stays OFF for the working cloud config; the deeper AegisForward DW-SSE rupture
-      # is a tracked follow-up (dedicated fix + its own validation soak required).
-      JARVIS_AEGIS_ENABLED: "false"
-      # DYNAMIC TRANSPORT ROUTER (item 3): replaces the force-RT hardcode. A per-op
-      # payload heuristic streams localized fixes (RT, fast) and batches large/
-      # multi-file refactors (DW batch, now that the webhook-vs-poll retrieve-hang
-      # is fixed in #69599). No all-or-nothing dichotomy.
-      JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED: "true"
+      # AEGIS SHIELDS UP — CORRECTED DIAGNOSIS (2026-06-20 isolation soak).
+      # The earlier "aegis regressed" reading was MISATTRIBUTED to the SSE path. An
+      # isolated soak (aegis ON + RT transport, batch off) proves the RT/SSE-through-
+      # aegis path is HEALTHY end to end:
+      #   - [AegisForward] credential injection on /v1/chat/completions (key sha256:90f571d4)
+      #   - upstream_status=200 (zero 4xx / zero 5xx at the aegis→DW boundary)
+      #   - zero "Unclosed connection" (the #69590 leak fix holds)
+      #   - rupture_risk=False throughout — NO SSE rupture
+      #   - op-019ee41b-700c: GENERATE outcome=ok → LEDGER_TERMINAL state=applied
+      # i.e. state=applied WITH THE SECURITY PROXY ACTIVELY DEFENDING. The boot-time
+      # /v1/models 401s are transient "credential proxy warming" that self-heal to 200
+      # within ~3 min — fail-soft, not a generation failure.
+      # What actually regressed the prior DUAL soak was the BATCH-through-aegis-
+      # passthrough path (dynamic router sending heavy ops to DW /v1/batches), NOT the
+      # RT SSE path. So: shields ARMED, and transport PINNED TO RT until the
+      # batch-through-aegis-passthrough path gets its own dedicated fix + soak
+      # (tracked follow-up). No SSE rewrite needed — the stream pipeline works.
+      JARVIS_AEGIS_ENABLED: "true"
+      # RT transport pinned: the RT/SSE-through-aegis path is the proven shields-up
+      # lane (state=applied above). Dynamic routing stays OFF here only because its
+      # batch arm rides the unproven batch-through-aegis-passthrough path; re-enable
+      # once that path is validated under aegis.
+      JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED: "false"
       # real cores → give DW generation full runway (no 90s reflex-cap timeouts)
       OUROBOROS_TIER0_MAX_WAIT_S: "600"
       JARVIS_GENERATION_TIMEOUT_S: "900"

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -55,6 +55,14 @@ services:
       # batch arm rides the unproven batch-through-aegis-passthrough path; re-enable
       # once that path is validated under aegis.
       JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED: "false"
+      # PIN RT (load-bearing for shields-up): both force-batch triggers default ON
+      # (_SLICE36_FORCE_BATCH_ENV="1", breaker-aware="true"). With Claude DISABLED
+      # above, leaving them at default would force the STANDARD/COMPLEX *batch*-through-
+      # aegis-passthrough path — the unproven weak link that regressed the dual soak.
+      # =0 reverts to the legacy RT-only routing that proved state=applied with shields
+      # up. Remove these two once batch-through-aegis is validated under the proxy.
+      JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX: "0"
+      JARVIS_DW_FORCE_BATCH_ON_CLAUDE_BREAKER: "0"
       # real cores → give DW generation full runway (no 90s reflex-cap timeouts)
       OUROBOROS_TIER0_MAX_WAIT_S: "600"
       JARVIS_GENERATION_TIMEOUT_S: "900"


### PR DESCRIPTION
## Summary

Corrects a **misattributed diagnosis** and makes the proven shields-up config durable.

The prior cloud config (`docker-compose.gcp.yml`) kept `JARVIS_AEGIS_ENABLED=false` on the belief that re-arming aegis *ruptured* the DW SSE streaming path. An **isolated soak** (aegis ON + RT transport, batch off) on the GCP Spot node disproves that — the RT/SSE-through-aegis path is healthy end to end and achieves autonomous `state=applied` **with the security proxy actively defending**.

### Evidence (node `jarvis-ouroboros-soak-20260619-230622`)

| Signal | Result |
|---|---|
| `[AegisForward] credential injection: /v1/chat/completions key=sha256:90f571d4` | proxy injecting creds |
| `upstream_status` 200 / 4xx / 5xx | **200 / 0 / 0** — clean aegis to DW boundary |
| `Unclosed connection` (the #69590 leak) | **0** — leak fix holds |
| `rupture_risk` | **False throughout** — no SSE rupture |
| `Primary sem release op-019ee41b-700c outcome=ok` | GENERATE succeeded through aegis |
| `LEDGER_TERMINAL op-019ee41b-700c state=applied` | **state=applied, shields up** |
| boot `/v1/models 401` | transient "proxy warming" -> self-heals to 200 in ~3 min (fail-soft) |

Since `env_scrub` pops `DOUBLEWORD_API_KEY` from the loop env when aegis is on, op-019ee41b-700c *structurally could not* have reached DW except through the proxy.

### Root cause of the earlier "regression"

What broke the earlier **dual** soak was the **batch-through-aegis-passthrough** path (the dynamic transport router sending heavy ops to DW `/v1/batches`), **not** the RT SSE path.

### Change

- `JARVIS_AEGIS_ENABLED` -> **`true`** (shields up, durable in git)
- `JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED` -> **`false`** (RT is the proven shields-up lane; the batch arm rides the unproven batch-through-aegis path — deferred to its own fix + soak)

**No SSE pipeline rewrite.** The stream path works as-is; a zero-buffering rewrite would have fixed a non-problem. The batch-through-aegis path remains the tracked follow-up.

## Test Plan
- [x] Isolated aegis-ON + RT soak reached `state=applied` with AegisForward injecting creds + upstream 200 + zero ruptures/leaks
- [ ] Confirm on next clean deploy from main: shields up by default, seed op reaches `state=applied`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Aegis by default and lock transport to RT/SSE through the proxy; block the unproven batch-through-aegis route by disabling dynamic routing and force-batch triggers.

- **Bug Fixes**
  - Corrects the earlier regression: the broken path was batch `/v1/batches`, not RT SSE.
  - Sets `JARVIS_AEGIS_ENABLED="true"` and `JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED="false"` in `docker-compose.gcp.yml`.
  - Pins the RT lane by setting `JARVIS_DW_FORCE_BATCH_STANDARD_COMPLEX="0"` and `JARVIS_DW_FORCE_BATCH_ON_CLAUDE_BREAKER="0"` so standard/complex ops don’t fall to batch.
  - No SSE rewrite; soak reached `state=applied` with upstream 200 and no leaks/ruptures. Transient `/v1/models` 401 during proxy warm-up self-heals.

<sup>Written for commit 6e55476d5e8f868171822f4a17131f9db888ddec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

