### PR TITLE
feat(aegis): Sovereign Aegis Batch-Passthrough Matrix — stream massive uploads, re-arm dynamic router

### DIFF
--- a/backend/core/ouroboros/aegis/daemon.py
+++ b/backend/core/ouroboros/aegis/daemon.py
@@ -103,6 +103,27 @@ _K_UPSTREAM_MAP = "_upstream_map"
 # ---------------------------------------------------------------------------
 
 
+def _client_max_size() -> int:
+    """aiohttp server-level body ceiling for the Aegis app.
+
+    Sovereign Aegis Batch-Passthrough Matrix (2026-06-20). aiohttp's
+    ``web.Application`` defaults ``client_max_size`` to 1 MiB and enforces it in
+    the payload reader — so a MASSIVE batch JSONL upload was 413'd by aiohttp
+    itself BEFORE the passthrough handler (or its 64 MiB cap) ever ran. This is
+    the true outermost ceiling. Set it just ABOVE the passthrough body cap (cap
+    + 1 MiB headroom for the multipart envelope) so the passthrough's own clean
+    JSON 413 + telemetry remains authoritative for over-cap uploads, while
+    aiohttp's bare 413 only ever fires for pathological excess. Tracks the same
+    ``JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES`` env so the two never drift. NEVER raises.
+    """
+    raw = os.environ.get("JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES", "").strip()
+    try:
+        cap = max(1024, int(raw)) if raw else 64 * 1024 * 1024
+    except (TypeError, ValueError):
+        cap = 64 * 1024 * 1024
+    return cap + 1024 * 1024
+
+
 def build_app(
     *,
     budget: ImmutableBudgetStateMachine,
@@ -132,7 +153,7 @@ def build_app(
     surface. Default False preserves the Slice 1 dark-substrate
     posture for any caller that constructs the app directly.
     """
-    app = web.Application()
+    app = web.Application(client_max_size=_client_max_size())
 
     # K is generated INSIDE the factory, never returned, never logged.
     # AST pin confirms K is referenced only via app[_K_HMAC_KEY] in the

--- a/backend/core/ouroboros/aegis/passthrough.py
+++ b/backend/core/ouroboros/aegis/passthrough.py
@@ -47,7 +47,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from typing import Dict, Optional, Set, Tuple
+from typing import Any, Dict, Optional, Set, Tuple
 
 import aiohttp
 from aiohttp import web
@@ -58,7 +58,9 @@ from backend.core.ouroboros.aegis.lease import (
 )
 from backend.core.ouroboros.aegis.request_body import (
     BodyTooLarge,
+    content_length_hint,
     read_body_capped,
+    stream_body_capped,
 )
 from backend.core.ouroboros.aegis.upstream_registry import (
     AuthScheme,
@@ -134,14 +136,40 @@ def _bearer_session(request: web.Request) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 
+# Sovereign Aegis Batch-Passthrough Matrix (2026-06-20). Default raised from
+# 4 MiB → 64 MiB. The 4 MiB floor 413'd a MASSIVE multi-file architectural
+# refactor's batch JSONL (full file contents in the GENERATE prompt run to many
+# MiB) at the proxy boundary BEFORE it ever reached DW — the only real blocker
+# on routing huge ops through the batch lane. Safe to raise because the body is
+# now STREAMED (constant memory), so this cap bounds ACCEPTED bytes, not RAM.
+# INVARIANT: this MUST be >= the DW provider's upload preflight cap
+# (JARVIS_DW_UPLOAD_MAX_BYTES) so the provider's own guard rejects first with a
+# precise provider-side error rather than a bare aegis 413.
+_DEFAULT_MAX_REQUEST_BODY_BYTES = 64 * 1024 * 1024
+
+
 def _max_request_body_bytes() -> int:
     raw = os.environ.get("JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES", "").strip()
     if not raw:
-        return 4 * 1024 * 1024
+        return _DEFAULT_MAX_REQUEST_BODY_BYTES
     try:
         return max(1024, int(raw))
     except (TypeError, ValueError):
-        return 4 * 1024 * 1024
+        return _DEFAULT_MAX_REQUEST_BODY_BYTES
+
+
+def _stream_passthrough_enabled() -> bool:
+    """Master for the streaming (constant-memory) passthrough body forwarder.
+    Default **TRUE** — the batch lane must not buffer massive JSONL uploads
+    twice. =0/false reverts to the legacy buffered ``read_body_capped`` path
+    (byte-identical) for instant rollback. NEVER raises."""
+    return os.environ.get("JARVIS_AEGIS_STREAM_PASSTHROUGH", "true").strip().lower() \
+        not in ("0", "false", "no", "off")
+
+
+# Methods that carry a request body Aegis must forward. GET/DELETE polls and
+# content retrievals have no body → outbound data stays None (legacy shape).
+_BODY_METHODS: Tuple[str, ...] = ("POST", "PUT", "PATCH")
 
 
 def _strip_inbound_headers(request: web.Request) -> Dict[str, str]:
@@ -235,40 +263,64 @@ async def forward_passthrough(
         )
 
     # --- 3. Request body (FULL read, cap-enforced; passthrough never parses) -
-    # Slice 42 — read the ENTIRE body via read_body_capped (chunk-accumulation
-    # loop). The prior single ``request.content.read(cap)`` truncated bodies
-    # that arrived across multiple TCP segments (e.g. an 18 KB multipart batch
-    # upload), forwarding a broken multipart upstream → DW HTTP 400. The DoS
-    # cap is preserved: over-cap → HTTP 413, no unbounded buffering.
-    try:
-        body_bytes = await read_body_capped(request, _max_request_body_bytes())
-    except BodyTooLarge as exc:
+    # Slice 42 — read the ENTIRE body (never a single truncating read).
+    # Sovereign Aegis Batch-Passthrough Matrix — the body is resolved into an
+    # outbound ``data`` source that is EITHER a constant-memory streaming
+    # generator (default) OR the legacy buffered bytes (kill switch). Both
+    # enforce the cap; streaming additionally rejects an over-cap upload from
+    # its declared Content-Length BEFORE reading a byte (the common case, since
+    # aiohttp always sets Content-Length for a bytes/FormData body).
+    _cap = _max_request_body_bytes()
+    _has_body = request.method.upper() in _BODY_METHODS
+    outbound_data: Any = None
+
+    def _too_large(detail: str):
         return (
             web.json_response(
                 {"ok": False, "error": "request_body_too_large",
-                 "detail": str(exc)}, status=413,
+                 "detail": detail}, status=413,
             ),
             PassthroughResult(
                 outcome=PassthroughOutcome.REQUEST_TOO_LARGE,
                 upstream_status=None,
                 response_bytes=0,
-                detail=str(exc),
+                detail=detail,
             ),
         )
-    except (asyncio.CancelledError, aiohttp.ClientError):
-        raise
-    except Exception as exc:  # noqa: BLE001
-        return (
-            web.json_response(
-                {"ok": False, "error": "request_body_read_failed"}, status=400,
-            ),
-            PassthroughResult(
-                outcome=PassthroughOutcome.CLIENT_DISCONNECTED,
-                upstream_status=None,
-                response_bytes=0,
-                detail=str(exc),
-            ),
-        )
+
+    if _has_body:
+        # Clean early 413 from the declared size — no read, no upstream open.
+        declared = content_length_hint(request)
+        if declared is not None and declared > _cap:
+            return _too_large(
+                f"declared Content-Length {declared} exceeds cap {_cap}"
+            )
+        if _stream_passthrough_enabled():
+            # Constant-memory: yields chunks straight to the outbound request,
+            # raising BodyTooLarge mid-stream (caught at the forward site) for
+            # chunked / no-Content-Length clients the early check can't see.
+            outbound_data = stream_body_capped(request, _cap)
+        else:
+            try:
+                _buf = await read_body_capped(request, _cap)
+            except BodyTooLarge as exc:
+                return _too_large(str(exc))
+            except (asyncio.CancelledError, aiohttp.ClientError):
+                raise
+            except Exception as exc:  # noqa: BLE001
+                return (
+                    web.json_response(
+                        {"ok": False, "error": "request_body_read_failed"},
+                        status=400,
+                    ),
+                    PassthroughResult(
+                        outcome=PassthroughOutcome.CLIENT_DISCONNECTED,
+                        upstream_status=None,
+                        response_bytes=0,
+                        detail=str(exc),
+                    ),
+                )
+            outbound_data = _buf if _buf else None
 
     # --- 4. Credential injection (never logged) -----------------------------
     upstream_credential = os.environ.get(endpoint.credential_env_var, "").strip()
@@ -319,8 +371,13 @@ async def forward_passthrough(
             upstream_resp = await session.request(
                 method=request.method,
                 url=upstream_url,
-                data=body_bytes if body_bytes else None,
+                data=outbound_data,
             )
+        except BodyTooLarge as exc:
+            # Streaming path: a chunked / no-Content-Length client exceeded the
+            # cap mid-send (the early declared-size check couldn't see it). The
+            # upstream send is aborted by aiohttp; surface the clean 413.
+            return _too_large(str(exc))
         except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
             return (
                 web.json_response({

--- a/backend/core/ouroboros/aegis/request_body.py
+++ b/backend/core/ouroboros/aegis/request_body.py
@@ -17,8 +17,25 @@ masking the bug.
 preserves the DoS protection: if the accumulated length exceeds ``cap`` it
 raises :class:`BodyTooLarge` (caller → HTTP 413) WITHOUT buffering past the
 cap. It never silently truncates.
+
+Sovereign Aegis Batch-Passthrough Matrix (2026-06-20)
+-----------------------------------------------------
+``read_body_capped`` buffers the ENTIRE body in memory before forwarding —
+fine for the ~KB control-plane payloads, but for a MASSIVE multi-file
+architectural refactor the batch input JSONL (full file contents in the
+GENERATE prompt) can run to many megabytes, and buffering it twice (once
+here, once in the outbound aiohttp request) is exactly the blocking behaviour
+the batch lane must avoid. ``stream_body_capped`` is the constant-memory
+counterpart: an async generator that drains ``request.content`` chunk-by-chunk
+and YIELDS each chunk straight to the outbound request, holding at most one
+``_READ_CHUNK_BYTES`` window at a time while still enforcing ``cap`` mid-stream.
+``content_length_hint`` lets the caller reject an over-cap upload cleanly
+(HTTP 413) from the declared ``Content-Length`` BEFORE a single byte is read,
+when the client provides one (aiohttp always does for a bytes/FormData body).
 """
 from __future__ import annotations
+
+from typing import AsyncIterator, Optional
 
 # Per-iteration read unit. Large enough to drain quickly, bounded so a single
 # read() can't be coerced into an unbounded allocation. The cap is enforced
@@ -60,3 +77,46 @@ async def read_body_capped(request, cap: int) -> bytes:
             raise BodyTooLarge(cap)
         chunks.append(chunk)
     return b"".join(chunks)
+
+
+def content_length_hint(request) -> Optional[int]:
+    """Return the declared ``Content-Length`` as an int, or ``None``.
+
+    Used by the passthrough to reject an over-cap upload with a clean HTTP 413
+    BEFORE reading any body, when the client declares its size (aiohttp always
+    sets Content-Length for a ``bytes``/``FormData`` body). Returns ``None`` for
+    a missing or malformed header — callers MUST then fall back to the
+    mid-stream cap in :func:`stream_body_capped` (never trust the hint alone).
+    NEVER raises.
+    """
+    raw = request.headers.get("Content-Length")
+    if raw is None:
+        return None
+    try:
+        return int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+async def stream_body_capped(request, cap: int) -> AsyncIterator[bytes]:
+    """Stream the request body chunk-by-chunk, enforcing ``cap`` mid-stream.
+
+    Constant-memory counterpart to :func:`read_body_capped`: drains
+    ``request.content`` one ``_READ_CHUNK_BYTES`` window at a time and YIELDS
+    each chunk to the caller (which feeds it straight to the outbound request),
+    so the proxy never holds the whole body. Raises :class:`BodyTooLarge` the
+    moment the running total exceeds ``cap`` — bounding both buffered memory and
+    accepted bytes to ``cap + one chunk``. Never silently truncates.
+
+    Transport errors (``asyncio.CancelledError`` / ``aiohttp.ClientError``)
+    propagate to the caller's existing handler — not swallowed.
+    """
+    total = 0
+    while True:
+        chunk = await request.content.read(_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > cap:
+            raise BodyTooLarge(cap)
+        yield chunk

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -4210,7 +4210,16 @@ class DoublewordProvider:
         # Slice 37 Phase 1 — pre-flight size guard. DW's /v1/files
         # endpoint returns opaque HTTP 500 on oversized payloads;
         # fail-fast with named cause before the round-trip.
-        _max_upload_bytes = 5 * 1024 * 1024  # 5 MB default
+        #
+        # Sovereign Aegis Batch-Passthrough Matrix (2026-06-20). Default raised
+        # 5 MiB → 64 MiB so a MASSIVE multi-file architectural refactor's batch
+        # JSONL clears the provider preflight and reaches the (now streaming,
+        # 65 MiB-ceilinged) Aegis passthrough. INVARIANT: this preflight cap MUST
+        # stay <= the Aegis passthrough cap (JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES,
+        # default 64 MiB) so an over-cap upload is rejected HERE with a precise
+        # provider-side cause, never as a bare proxy 413 mid-flight. Both default
+        # to 64 MiB; if an operator raises one, raise the other to match.
+        _max_upload_bytes = 64 * 1024 * 1024  # 64 MiB default (aligned w/ Aegis)
         try:
             _env_max = os.environ.get("JARVIS_DW_UPLOAD_MAX_BYTES", "").strip()
             if _env_max:

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -32,18 +32,29 @@ services:
       JARVIS_SEMANTIC_INFERENCE_ENABLED: "false"
       # don't let the heavy 550B boot probe false-degrade the DW stream lane
       JARVIS_DW_SURFACE_HEALTH_ENABLED: "false"
-      # AEGIS VALIDATION RESULT (2026-06-20 soak): re-arming aegis REGRESSED the loop
-      # — every op fsm_exhausted, zero state=applied. PR #69590 fixed the upstream-
-      # response LEAK ("Unclosed connection") but the aegis DW-streaming path still
-      # breaks generation under live load (the rupture, not just the leak). Aegis
-      # stays OFF for the working cloud config; the deeper AegisForward DW-SSE rupture
-      # is a tracked follow-up (dedicated fix + its own validation soak required).
-      JARVIS_AEGIS_ENABLED: "false"
-      # DYNAMIC TRANSPORT ROUTER (item 3): replaces the force-RT hardcode. A per-op
-      # payload heuristic streams localized fixes (RT, fast) and batches large/
-      # multi-file refactors (DW batch, now that the webhook-vs-poll retrieve-hang
-      # is fixed in #69599). No all-or-nothing dichotomy.
+      # AEGIS SHIELDS UP + FULLY DYNAMIC (Sovereign Aegis Batch-Passthrough Matrix,
+      # 2026-06-20). Two isolation soaks proved BOTH proxied lanes healthy end to
+      # end with shields up:
+      #   - RT/SSE-through-aegis  → state=applied (op-019ee41b RT soak)
+      #   - BATCH-through-aegis   → files-upload + create + poll + content-retrieve
+      #     all upstream_status=200, zero 4xx/5xx, → state=applied (force-batch soak)
+      # The batch lane was never "ruptured"; its only real limit was payload SIZE:
+      # aiohttp's 1 MiB server default + the 4 MiB passthrough cap + the 5 MiB
+      # provider preflight all 413'd a MASSIVE multi-file refactor's batch JSONL.
+      # The Matrix fixes that structurally (streaming constant-memory passthrough +
+      # aligned 64 MiB caps + 65 MiB aiohttp ceiling) so the engine can route huge
+      # ops through batch under the proxy. No tourniquet: the dynamic router is
+      # ARMED and the force-batch pins are GONE — the engine evaluates each op's
+      # payload itself (RT for localized fixes, batch for large refactors).
+      JARVIS_AEGIS_ENABLED: "true"
       JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED: "true"
+      # Massive-payload ceilings (Matrix). Aegis passthrough cap MUST be >= the DW
+      # provider upload preflight (both 64 MiB) so the provider rejects first with a
+      # precise cause; aiohttp's server ceiling sits 1 MiB above so the proxy's clean
+      # JSON 413 stays authoritative. Streaming forwarder ON (constant memory).
+      JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES: "67108864"
+      JARVIS_DW_UPLOAD_MAX_BYTES: "67108864"
+      JARVIS_AEGIS_STREAM_PASSTHROUGH: "true"
       # real cores → give DW generation full runway (no 90s reflex-cap timeouts)
       OUROBOROS_TIER0_MAX_WAIT_S: "600"
       JARVIS_GENERATION_TIMEOUT_S: "900"

--- a/tests/aegis/test_passthrough.py
+++ b/tests/aegis/test_passthrough.py
@@ -60,8 +60,15 @@ class _Recorder:
 
 
 def _make_dw_passthrough_stub(recorder: _Recorder) -> web.Application:
-    """Stub upstream for the 5 allowlisted DW endpoints."""
-    app = web.Application()
+    """Stub upstream for the 5 allowlisted DW endpoints.
+
+    client_max_size raised to 128 MiB so the stub mirrors the REAL DW batch
+    API (which accepts large JSONL uploads). With aiohttp's 1 MiB default the
+    stub itself would 413 a massive upload, masking whether *Aegis* forwards
+    it — the Sovereign Aegis Batch-Passthrough Matrix tests must exercise the
+    proxy's own boundary, not the stub's.
+    """
+    app = web.Application(client_max_size=128 * 1024 * 1024)
 
     async def _record(request: web.Request) -> dict:
         # Read body raw (don't json-decode — multipart preservation test).
@@ -251,6 +258,83 @@ async def test_files_large_multipart_forwarded_byte_identical(stack, size):
     assert rec["body_len"] == len(body), (
         f"truncated forward: upstream saw {rec['body_len']} of {len(body)} bytes"
     )
+    assert rec["body_sha256"] == hashlib.sha256(body).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Sovereign Aegis Batch-Passthrough Matrix — massive payload streaming
+# ---------------------------------------------------------------------------
+
+
+async def test_files_massive_multipart_streamed_byte_identical(stack):
+    # A 2 MB upload — over the LEGACY 4 MB-ish band is not needed; this proves
+    # the streaming path forwards a multi-segment, multi-MB body byte-identical
+    # (constant memory). With JARVIS_AEGIS_STREAM_PASSTHROUGH default ON this
+    # exercises stream_body_capped end to end through the daemon.
+    client, recorder, _ = stack
+    session = await _session_token(client)
+    body = _large_multipart(2 * 1024 * 1024)
+    resp = await client.post(
+        "/v1/files",
+        headers={
+            "Authorization": f"Bearer {session}",
+            "Content-Type": "multipart/form-data; boundary=BOUNDARY",
+        },
+        data=body,
+    )
+    assert resp.status == 200
+    assert len(recorder.received) == 1
+    rec = recorder.received[0]
+    assert rec["body_len"] == len(body), (
+        f"truncated stream: upstream saw {rec['body_len']} of {len(body)} bytes"
+    )
+    assert rec["body_sha256"] == hashlib.sha256(body).hexdigest()
+    assert rec["auth_header"] == f"Bearer {_STUB_DW_KEY}"
+    assert "multipart/form-data" in rec["content_type"]
+
+
+async def test_files_over_cap_clean_413_before_upstream(stack, monkeypatch):
+    # An upload whose declared Content-Length exceeds the cap is rejected with a
+    # clean HTTP 413 BEFORE any body is read or the upstream is touched.
+    monkeypatch.setenv("JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES", str(1 * 1024 * 1024))
+    client, recorder, _ = stack
+    session = await _session_token(client)
+    body = _large_multipart(2 * 1024 * 1024)  # 2 MB > 1 MB cap
+    resp = await client.post(
+        "/v1/files",
+        headers={
+            "Authorization": f"Bearer {session}",
+            "Content-Type": "multipart/form-data; boundary=BOUNDARY",
+        },
+        data=body,
+    )
+    assert resp.status == 413
+    payload = await resp.json()
+    assert payload["error"] == "request_body_too_large"
+    # Upstream NEVER saw the request — rejected at the proxy boundary.
+    assert recorder.received == []
+
+
+async def test_files_streaming_disabled_buffered_fallback_byte_identical(
+    stack, monkeypatch,
+):
+    # Kill switch: JARVIS_AEGIS_STREAM_PASSTHROUGH=false reverts to the legacy
+    # buffered read_body_capped path — still byte-identical (instant rollback).
+    monkeypatch.setenv("JARVIS_AEGIS_STREAM_PASSTHROUGH", "false")
+    client, recorder, _ = stack
+    session = await _session_token(client)
+    body = _large_multipart(512 * 1024)
+    resp = await client.post(
+        "/v1/files",
+        headers={
+            "Authorization": f"Bearer {session}",
+            "Content-Type": "multipart/form-data; boundary=BOUNDARY",
+        },
+        data=body,
+    )
+    assert resp.status == 200
+    rec = recorder.received[0]
+    assert rec["body_len"] == len(body)
     assert rec["body_sha256"] == hashlib.sha256(body).hexdigest()
 
 

--- a/tests/aegis/test_request_body.py
+++ b/tests/aegis/test_request_body.py
@@ -1,11 +1,17 @@
-"""Slice 42 — Aegis full-body capped reader (multi-segment truncation fix)."""
+"""Slice 42 — Aegis full-body capped reader (multi-segment truncation fix).
+
+Sovereign Aegis Batch-Passthrough Matrix (2026-06-20) — adds the streaming,
+constant-memory body forwarder for massive batch JSONL uploads.
+"""
 from __future__ import annotations
 
 import pytest
 
 from backend.core.ouroboros.aegis.request_body import (
     BodyTooLarge,
+    content_length_hint,
     read_body_capped,
+    stream_body_capped,
 )
 
 
@@ -29,8 +35,9 @@ class _FragmentedContent:
 
 
 class _FakeReq:
-    def __init__(self, content):
+    def __init__(self, content, headers=None):
         self.content = content
+        self.headers = headers or {}
 
 
 async def test_reads_full_body_across_fragments():
@@ -83,3 +90,64 @@ async def test_exactly_at_cap_succeeds():
     req = _FakeReq(_FragmentedContent(body, fragment_size=4096))
     out = await read_body_capped(req, cap=cap)
     assert len(out) == cap
+
+
+# ---------------------------------------------------------------------------
+# Sovereign Aegis Batch-Passthrough Matrix — streaming, constant-memory body
+# ---------------------------------------------------------------------------
+
+
+async def _drain(agen) -> bytes:
+    out = bytearray()
+    async for chunk in agen:
+        out.extend(chunk)
+    return bytes(out)
+
+
+async def test_stream_yields_full_body_across_fragments():
+    # A 256 KB body delivered in 1500-byte segments — streamed, not buffered.
+    body = bytes((i % 256) for i in range(256 * 1024))
+    req = _FakeReq(_FragmentedContent(body, fragment_size=1500))
+    out = await _drain(stream_body_capped(req, cap=64 * 1024 * 1024))
+    assert out == body  # byte-identical full body via the streaming path
+
+
+async def test_stream_never_holds_more_than_one_chunk():
+    # The generator must yield as it reads — a body far larger than one chunk
+    # is delivered in many yields (proves constant-memory streaming, not buffer).
+    body = b"Z" * (300 * 1024)
+    req = _FakeReq(_FragmentedContent(body, fragment_size=64 * 1024))
+    chunks = []
+    async for chunk in stream_body_capped(req, cap=64 * 1024 * 1024):
+        chunks.append(len(chunk))
+    assert len(chunks) >= 4  # >=4 separate yields, not one giant buffer
+    assert sum(chunks) == len(body)
+
+
+async def test_stream_raises_too_large_over_cap_midstream():
+    cap = 8192
+    body = b"A" * (cap + 4096)
+    req = _FakeReq(_FragmentedContent(body, fragment_size=4096))
+    with pytest.raises(BodyTooLarge) as ei:
+        await _drain(stream_body_capped(req, cap=cap))
+    assert ei.value.cap == cap
+
+
+async def test_stream_empty_body():
+    req = _FakeReq(_FragmentedContent(b"", fragment_size=4096))
+    assert await _drain(stream_body_capped(req, cap=4096)) == b""
+
+
+def test_content_length_hint_present():
+    req = _FakeReq(None, headers={"Content-Length": "12345"})
+    assert content_length_hint(req) == 12345
+
+
+def test_content_length_hint_absent():
+    req = _FakeReq(None, headers={})
+    assert content_length_hint(req) is None
+
+
+def test_content_length_hint_malformed():
+    req = _FakeReq(None, headers={"Content-Length": "not-a-number"})
+    assert content_length_hint(req) is None

--- a/tests/governance/test_slice37_multipart_payload_alignment.py
+++ b/tests/governance/test_slice37_multipart_payload_alignment.py
@@ -94,12 +94,15 @@ def test_ast_pin_slice37_error_body_capture_widened() -> None:
 
 
 def test_spine_env_knob_overrides_default_max_bytes() -> None:
-    """``JARVIS_DW_UPLOAD_MAX_BYTES`` env overrides the 5 MB
-    default. Operators can tighten or loosen the guard."""
+    """``JARVIS_DW_UPLOAD_MAX_BYTES`` env overrides the default upload guard.
+    Operators can tighten or loosen it. Sovereign Aegis Batch-Passthrough
+    Matrix (2026-06-20) raised the default 5 MiB -> 64 MiB so massive
+    multi-file refactor JSONL clears the preflight, aligned with the Aegis
+    passthrough cap (JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES)."""
     src = DW_FILE.read_text()
     # The env knob name + default value documented
     assert "JARVIS_DW_UPLOAD_MAX_BYTES" in src
-    assert "5 * 1024 * 1024" in src  # 5 MB default
+    assert "64 * 1024 * 1024" in src  # 64 MiB default (aligned with Aegis cap)
 
 
 def test_spine_payload_size_logged_with_model_and_custom_id() -> None:


### PR DESCRIPTION
## Summary

**Supersedes #69603** (the force-RT tourniquet). The operator rejected hardcoding the dynamic router off; this is the real fix that lets the engine route **massive architectural refactors** through the batch lane *with shields up*.

### Live evidence overturned the premise

A forced-batch isolation soak (aegis ON) on GCP node `jarvis-ouroboros-soak-20260619-230622` proved the **full proxied batch lifecycle healthy**:

```
files_up=1  batch_create=1  batch_poll=10  file_content=1  →  state=applied
4xx=0  5xx=0  toolarge=0   THROUGHOUT
```

So batch-through-aegis was **never "ruptured."** Its only real limit was payload **SIZE** — three stacked ceilings 413'd a massive batch JSONL before it reached DW:

1. aiohttp `web.Application` default `client_max_size` = **1 MiB** (outermost; hit first, enforced by the server not our code)
2. Aegis passthrough body cap default = **4 MiB**
3. DW provider upload preflight default = **5 MiB**

### The Matrix (removes all three + makes the lane non-blocking)

- **`request_body.py`** — `stream_body_capped()`: constant-memory async generator, drains `request.content` → yields chunks straight to the outbound request, cap enforced mid-stream (no double-buffering of a multi-MiB JSONL). `content_length_hint()` for a clean early 413.
- **`passthrough.py`** — streaming forward path (default ON; `JARVIS_AEGIS_STREAM_PASSTHROUGH` kill switch → byte-identical buffered fallback). Early Content-Length 413 + mid-stream `BodyTooLarge` → clean JSON 413. Cap 4 MiB → **64 MiB**. GET poll/retrieve unchanged.
- **`daemon.py`** — `web.Application(client_max_size=cap + 1 MiB)` so aiohttp's server ceiling stops 413'ing massive uploads before the handler, and sits just above the body cap so the passthrough's clean 413 stays authoritative.
- **`doubleword_provider.py`** — upload preflight 5 MiB → **64 MiB**. INVARIANT: provider cap ≤ aegis cap (provider rejects first, precise cause).
- **`docker-compose.gcp.yml`** — `AEGIS_ENABLED=true` + `DYNAMIC_TRANSPORT=true` (**router ARMED, no force-batch tourniquet**) + explicit 64 MiB caps + streaming for auditability.

### Tests
+6 request_body (streaming / cap / content-length), +3 passthrough (massive-multipart streamed byte-identical, over-cap clean 413 pre-upstream, streaming-disabled buffered fallback). Stub upstream `client_max_size` raised to 128 MiB so tests exercise the *proxy* boundary, not the stub's default. **274 aegis + slice37 tests green.**

## Test Plan
- [x] 274 aegis + slice37 unit tests green
- [x] Forced-batch isolation soak: full batch-through-aegis lifecycle → state=applied, zero errors
- [ ] Heavy-duty soak: massive multi-file op → dynamic router → batch → 64 MiB streamed upload through aegis → poll → state=applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable constant‑memory streaming for Aegis passthrough to handle large batch uploads and re‑arm the dynamic router. Raises request body caps to 64 MiB with clean early 413s and adjusts the `aiohttp` server ceiling to avoid premature 413s.

- **New Features**
  - Streamed body forward path by default via `stream_body_capped()`; kill switch `JARVIS_AEGIS_STREAM_PASSTHROUGH=false` restores buffered path.
  - Early 413 from `Content-Length` via `content_length_hint()`; mid‑stream 413 on cap exceed.
  - Default passthrough cap → 64 MiB (`JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES`); DW upload preflight → 64 MiB (`JARVIS_DW_UPLOAD_MAX_BYTES`) with provider cap ≤ Aegis cap.
  - `aiohttp` `web.Application(client_max_size=cap + 1 MiB)` so the handler owns over‑cap errors.
  - `docker-compose.gcp.yml`: `JARVIS_AEGIS_ENABLED=true`, `JARVIS_DW_DYNAMIC_TRANSPORT_ENABLED=true`, 64 MiB caps, streaming enabled.
  - Tests cover streaming, early 413, and fallback; DW stub `client_max_size` set to 128 MiB.

- **Migration**
  - If you override caps, keep `JARVIS_DW_UPLOAD_MAX_BYTES` ≤ `JARVIS_AEGIS_MAX_REQUEST_BODY_BYTES` (defaults aligned at 64 MiB).
  - Streaming is ON by default; set `JARVIS_AEGIS_STREAM_PASSTHROUGH=false` to revert.

<sup>Written for commit 3e430e0e73aa79e44d452f46444d0a1744c34b13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

