### PR TITLE
fix(crucible): literal-site locator — graduate the real source-of-truth (not the declaration site)

### DIFF
--- a/backend/core/ouroboros/governance/autonomous_graduation_engine.py
+++ b/backend/core/ouroboros/governance/autonomous_graduation_engine.py
@@ -59,6 +59,7 @@ STANDARD→AUTO_FLIP, SAFETY→APPROVAL_ADVISORY. Master OFF → DISABLED.
 """
 from __future__ import annotations
 
+import asyncio
 import enum
 import hashlib
 import json
@@ -662,6 +663,78 @@ def _disabled_report(
 # ---------------------------------------------------------------------------
 
 
+def _maybe_propose_source_pr(decision: GraduationDecision) -> bool:
+    """Sovereign Cognitive Crucible source-of-truth graduation (2026-06-20).
+
+    When ``JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED`` is on, an AUTO_FLIP decision
+    ALSO fires the autonomous [SOVEREIGN GRADUATION] PR: it reads the flag's last
+    3 CLEAN soaks' crucible evidence and, IF they clear the TTFT/AST veto, opens
+    a cage-respecting PR that rewrites the source default literal (never merges).
+    The shadow-gated override-ledger receipt (the .env audit path) is unaffected.
+
+    Best-effort, fail-soft, gate-default-off. Returns True iff a PR proposal was
+    SCHEDULED. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.graduation.graduation_pr_proposer import (  # noqa: E501
+            graduation_pr_enabled,
+            propose_graduation_pr,
+        )
+        if not graduation_pr_enabled():
+            return False
+        from backend.core.ouroboros.governance.graduation.live_fire_soak import (
+            recent_clean_crucible_evidence,
+        )
+        from backend.core.ouroboros.governance.graduation.telemetry_manifest import (  # noqa: E501
+            manifest_recommends_merge,
+        )
+        from backend.core.ouroboros.governance.graduation import (
+            crucible_verdict as _cv,
+        )
+        flag = decision.flag_name
+        evidence = recent_clean_crucible_evidence(flag, limit=3)
+        required = 3
+        try:
+            from backend.core.ouroboros.governance.adaptation.graduation_ledger import (  # noqa: E501
+                CADENCE_POLICY,
+            )
+            for entry in CADENCE_POLICY:
+                if getattr(entry, "flag_name", None) == flag:
+                    required = int(getattr(entry, "required_clean_sessions", 3))
+                    break
+        except Exception:  # noqa: BLE001
+            pass
+        if not manifest_recommends_merge(evidence, required_clean=required):
+            return False
+        ceiling = _cv._env_float(
+            _cv._TTFT_CEILING_ENV, _cv._DEFAULT_TTFT_CEILING_MS,
+        )
+        session_ids = [str(e.get("session_id", "")) for e in evidence]
+        repo_root = os.environ.get("JARVIS_AUTO_COMMIT_WORKSPACE") or os.getcwd()
+
+        async def _go() -> None:
+            try:
+                await propose_graduation_pr(
+                    flag,
+                    soak_evidence=evidence,
+                    session_ids=session_ids,
+                    required_clean=required,
+                    ttft_ceiling_ms=ceiling,
+                    repo_root=repo_root,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[GraduationEngine] PR proposal failed: %s", exc)
+
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_go())
+        except RuntimeError:
+            asyncio.run(_go())
+        return True
+    except Exception as exc:  # noqa: BLE001 — fail-soft; never block graduation
+        logger.debug("[GraduationEngine] _maybe_propose_source_pr: %s", exc)
+        return False
+
+
 def execute_graduations(
     report: GraduationEngineReport,
     *,
@@ -693,6 +766,11 @@ def execute_graduations(
                     decision, now_unix=now_unix,
                 ):
                     recorded.append(decision.flag_name)
+                # Sovereign Cognitive Crucible: also fire the source-of-truth
+                # [SOVEREIGN GRADUATION] PR (gated, fail-soft, cage-respecting —
+                # proposes, never merges). Independent of the shadow-gated
+                # override receipt above.
+                _maybe_propose_source_pr(decision)
             elif (
                 decision.disposition
                 is GraduationDisposition.APPROVAL_ADVISORY

--- a/backend/core/ouroboros/governance/graduation/crucible_verdict.py
+++ b/backend/core/ouroboros/governance/graduation/crucible_verdict.py
@@ -1,0 +1,157 @@
+"""Sovereign Cognitive Crucible — the mathematical graduation veto (2026-06-20).
+
+Pure-evaluation helpers that turn a soak's parsed :class:`telemetry_parse.Metrics`
+into the two veto signals the autonomic crucible demands, on top of the existing
+``default_clean_predicate`` (which already catches FSM-exhaustion-class faults via
+the runner-bucket: ``phase_runner_error`` / ``candidate_validate_error`` /
+``fsm_state_corruption`` / …):
+
+  * **TTFT degradation** — did the cognitive feature under test slow first-token
+    latency past an absolute ceiling, or past ``ratio×`` an EWMA baseline?
+  * **AST corruption** — did it emit structurally-broken candidate code during
+    a soak (explicit validator/syntax markers beyond the runner-bucket)?
+
+If either fires across a flag's 3 soaks, the crucible MUST veto graduation.
+
+## Authority posture (locked)
+  * **Pure + stdlib-only** (``os`` for env knobs, ``statistics`` for the mean).
+    No I/O, no logger, no network. Mirrors ``telemetry_parse`` — this module
+    evaluates, it never observes state.
+  * **NEVER raises** — every helper returns a safe default on malformed input.
+  * **Fail-OPEN on absence** — if a soak emitted NO ttft samples we cannot
+    *prove* degradation, so we do not veto on missing instrumentation (same
+    graceful-degrade contract as the metrics-aware predicates). A veto fires
+    only on POSITIVE evidence of harm.
+  * **All thresholds env-tunable** — zero hardcoded magic in the decision.
+"""
+from __future__ import annotations
+
+import os
+import statistics
+from typing import Any, Dict, List, Optional, Tuple
+
+# Env knobs (defaults are conservative ceilings, not hardcoded decisions).
+_TTFT_CEILING_ENV = "JARVIS_CRUCIBLE_TTFT_CEILING_MS"
+_TTFT_RATIO_ENV = "JARVIS_CRUCIBLE_TTFT_DEGRADE_RATIO"
+_DEFAULT_TTFT_CEILING_MS = 30000.0   # absolute first-token ceiling
+_DEFAULT_TTFT_DEGRADE_RATIO = 1.5    # vs EWMA baseline when one is supplied
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        v = float(raw)
+        return v if v > 0 else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _nonzero_ttft(metrics: Any) -> List[int]:
+    """Non-zero ttft samples (0 = the failure/timeout sentinel — a *no-first-
+    token*, governed by the FSM/recovery gate, not the latency gate)."""
+    raw = getattr(metrics, "ttft_samples_ms", None)
+    if not isinstance(raw, (list, tuple)):
+        return []
+    out: List[int] = []
+    for v in raw:
+        try:
+            iv = int(v)
+        except (TypeError, ValueError):
+            continue
+        if iv > 0:
+            out.append(iv)
+    return out
+
+
+def ttft_stats(metrics: Any) -> Dict[str, float]:
+    """Summary stats over the non-zero ttft samples. NEVER raises."""
+    samples = _nonzero_ttft(metrics)
+    n = len(samples)
+    if n == 0:
+        return {"n": 0, "mean_ms": 0.0, "max_ms": 0.0}
+    return {
+        "n": float(n),
+        "mean_ms": float(statistics.fmean(samples)),
+        "max_ms": float(max(samples)),
+    }
+
+
+def ttft_degraded(
+    metrics: Any, *, baseline_ms: Optional[float] = None,
+) -> Tuple[bool, str]:
+    """True iff first-token latency degraded — past the absolute ceiling OR
+    (when a baseline EWMA is supplied) past ``ratio × baseline``.
+
+    Fail-OPEN: no samples → (False, "no_ttft_samples") (cannot prove harm).
+    NEVER raises."""
+    stats = ttft_stats(metrics)
+    if stats["n"] == 0:
+        return (False, "no_ttft_samples")
+    mean_ms = stats["mean_ms"]
+    ceiling = _env_float(_TTFT_CEILING_ENV, _DEFAULT_TTFT_CEILING_MS)
+    if mean_ms > ceiling:
+        return (True, f"mean_ttft {mean_ms:.0f}ms > ceiling {ceiling:.0f}ms")
+    if baseline_ms is not None and baseline_ms > 0:
+        ratio = _env_float(_TTFT_RATIO_ENV, _DEFAULT_TTFT_DEGRADE_RATIO)
+        if mean_ms > baseline_ms * ratio:
+            return (
+                True,
+                f"mean_ttft {mean_ms:.0f}ms > {ratio:g}x baseline "
+                f"{baseline_ms:.0f}ms",
+            )
+    return (False, f"mean_ttft {mean_ms:.0f}ms within bounds")
+
+
+def _ast_signal_count(metrics: Any) -> int:
+    """Guarded read of the AST-corruption signal count. NEVER raises."""
+    try:
+        return int(getattr(metrics, "ast_corruption_signals", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def ast_corrupted(metrics: Any) -> Tuple[bool, str]:
+    """True iff the soak surfaced explicit candidate AST/syntax corruption.
+    NEVER raises."""
+    n = _ast_signal_count(metrics)
+    if n > 0:
+        return (True, f"{n} AST/syntax corruption signal(s)")
+    return (False, "zero AST corruption")
+
+
+def crucible_evidence(
+    metrics: Any, *, baseline_ms: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Structured evidence bundle for the Sovereign Telemetry Manifest — the
+    empirical proof rendered into the [SOVEREIGN GRADUATION] PR body. Pure;
+    NEVER raises."""
+    stats = ttft_stats(metrics)
+    ttft_bad, ttft_detail = ttft_degraded(metrics, baseline_ms=baseline_ms)
+    ast_bad, ast_detail = ast_corrupted(metrics)
+    return {
+        "ttft_n": int(stats["n"]),
+        "ttft_mean_ms": round(stats["mean_ms"], 1),
+        "ttft_max_ms": round(stats["max_ms"], 1),
+        "ttft_ceiling_ms": _env_float(_TTFT_CEILING_ENV, _DEFAULT_TTFT_CEILING_MS),
+        "ttft_baseline_ms": baseline_ms,
+        "ttft_degraded": ttft_bad,
+        "ttft_detail": ttft_detail,
+        "ast_corruption_signals": _ast_signal_count(metrics),
+        "ast_corrupted": ast_bad,
+        "ast_detail": ast_detail,
+        "recovered": bool(getattr(metrics, "recovered", False)),
+        "oom": bool(getattr(metrics, "oom", False)),
+        "livefire_fired": list(getattr(metrics, "livefire_fired", []) or []),
+        "session_outcome": str(getattr(metrics, "session_outcome", "")),
+        "stop_reason": str(getattr(metrics, "stop_reason", "")),
+    }
+
+
+__all__ = [
+    "ttft_stats",
+    "ttft_degraded",
+    "ast_corrupted",
+    "crucible_evidence",
+]

--- a/backend/core/ouroboros/governance/graduation/graduation_contract.py
+++ b/backend/core/ouroboros/governance/graduation/graduation_contract.py
@@ -330,6 +330,49 @@ def predicate_requires_live_kernel_validation(
         return False
 
 
+def predicate_cognitive_graduation(
+    summary: Mapping[str, Any],
+    metrics: Any = None,
+) -> bool:
+    """Sovereign Cognitive Crucible universal veto (2026-06-20).
+
+    The default clean-predicate for any flag WITHOUT a more-specific built-in
+    contract. Composes the canonical :func:`default_clean_predicate` (which
+    already buckets FSM-exhaustion-class faults — ``phase_runner_error`` /
+    ``candidate_validate_error`` / ``fsm_state_corruption`` — as runner faults)
+    with the two latency/structural vetoes the autonomic crucible demands:
+
+      * TTFT degradation (``crucible_verdict.ttft_degraded``)
+      * AST corruption    (``crucible_verdict.ast_corrupted``)
+
+    Metrics-aware (2-arg), **VETO-ONLY** by construction: it returns ``False``
+    ONLY on positive evidence of TTFT/AST harm, and ``True`` otherwise. This is
+    deliberate — ``default_clean`` is already enforced upstream (the legacy
+    ``classify_outcome`` the arbiter composes), and the arbiter's metrics-
+    predicate step only ever *downgrades* a CLEAN outcome. A veto-only predicate
+    therefore adds the latency/structural gate WITHOUT undoing the arbiter's
+    recovery-override (P2): a session a legacy error + full self-heal promoted to
+    CLEAN stays CLEAN unless it ALSO degraded TTFT or corrupted AST.
+
+    **Fail-OPEN on absent telemetry** — ``metrics`` None (arbiter off / no
+    parse) → no objection (cannot prove harm). Pure; NEVER raises.
+
+    The ``crucible_verdict`` import is lazy to preserve this module's AST-pinned
+    stdlib-only top-level import posture (``crucible_verdict`` is itself pure +
+    stdlib-only, so there is no real coupling — only the pin to respect)."""
+    if metrics is None:
+        return True
+    try:
+        from backend.core.ouroboros.governance.graduation import (
+            crucible_verdict as _cv,
+        )
+        ttft_bad, _ = _cv.ttft_degraded(metrics)
+        ast_bad, _ = _cv.ast_corrupted(metrics)
+        return (not ttft_bad) and (not ast_bad)
+    except Exception:  # noqa: BLE001 — defensive; no objection on error
+        return True
+
+
 # ---------------------------------------------------------------------------
 # Contract dataclass
 # ---------------------------------------------------------------------------
@@ -572,7 +615,14 @@ def get_contract(flag_name: str) -> GraduationContract:
     builtin = _BUILT_IN_CONTRACTS.get(flag_name)
     if builtin is not None:
         return builtin
-    return GraduationContract(flag_name=flag_name)
+    # Sovereign Cognitive Crucible: flags without a specific built-in contract
+    # graduate under the universal TTFT/AST math-veto (composed on default-clean,
+    # fail-open on absent telemetry). No hardcoded per-flag list — every
+    # crucible-discovered candidate is auto-vetoed.
+    return GraduationContract(
+        flag_name=flag_name,
+        clean_predicate=predicate_cognitive_graduation,
+    )
 
 
 def has_custom_contract(flag_name: str) -> bool:

--- a/backend/core/ouroboros/governance/graduation/graduation_pr_proposer.py
+++ b/backend/core/ouroboros/governance/graduation/graduation_pr_proposer.py
@@ -1,0 +1,245 @@
+"""Sovereign GitOps Governance Matrix — source-of-truth graduation PR (2026-06-20).
+
+When the autonomic crucible greenlights a cognitive flag (3 clean soaks, zero
+TTFT/AST veto), it graduates by rewriting the DEFINITIVE source-of-truth — the
+``os.environ.get("<FLAG>", "<falsy>")`` default literal in the flag's consuming
+module — NOT by appending to a brittle ``.env``. The rewrite lands on a branch
+and is surfaced as a ``[SOVEREIGN GRADUATION]`` PR carrying the Telemetry
+Manifest; the merge to ``main`` stays the one human/OCA gate (the Order-2 cage's
+``amendment_requires_operator`` is locked-true — the organism PROPOSES, it does
+not self-merge).
+
+This module owns two layers:
+
+  * :func:`flip_default_to_true` — the PURE, bounded, AST-validated rewriter.
+    Conservative by construction: flips ONLY a single unambiguous falsy default
+    literal for the exact flag; refuses (changed=False) on zero matches, >1
+    match, an already-truthy default, or a result that fails ``ast.parse``.
+  * :func:`propose_graduation_pr` — the gated orchestration that composes the
+    rewriter + the Telemetry Manifest + the existing OrangePRReviewer git/gh
+    mechanics. Gated by ``JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED`` (default off).
+
+## Authority posture (locked)
+  * The rewriter is **pure + stdlib-only** (``ast`` + ``re``), NEVER raises,
+    and is the single tested decision point. The orchestration reuses the
+    audited OrangePRReviewer (branch + commit + ``gh pr create``) — no new
+    git/subprocess surface invented here.
+  * **Never self-merges** — opens a PR; the human/OCA merge gate is preserved.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence
+
+# Falsy default literals that mean "feature disabled by default".
+_FALSY_LITERALS = frozenset({"", "false", "0", "no", "off"})
+
+
+@dataclass(frozen=True)
+class RewriteResult:
+    changed: bool
+    new_text: str
+    matches: int
+    detail: str
+
+
+def _flag_default_pattern(flag: str) -> re.Pattern:
+    """Match ``os.environ.get("<FLAG>", "<literal>")`` capturing the quote +
+    inner default literal. Tolerates single/double quotes + inner whitespace."""
+    f = re.escape(flag)
+    # group 'q' = opening quote of the default literal; 'lit' = its contents.
+    return re.compile(
+        r"os\.environ\.get\(\s*[\"']" + f + r"[\"']\s*,\s*"
+        r"(?P<q>[\"'])(?P<lit>[^\"']*)(?P=q)\s*\)"
+    )
+
+
+def flip_default_to_true(source_text: str, flag: str) -> RewriteResult:
+    """Flip the flag's single falsy ``os.environ.get`` default literal to
+    ``"true"``. PURE; NEVER raises.
+
+    Refuses (changed=False) when:
+      * the flag's default pattern is not found (0 matches)
+      * more than one match exists (ambiguous — abstain rather than guess)
+      * the existing default literal is already truthy (already graduated)
+      * the rewritten module fails ``ast.parse`` (structural safety)
+    """
+    if not isinstance(source_text, str) or not isinstance(flag, str) or not flag:
+        return RewriteResult(False, source_text or "", 0, "bad_input")
+    pat = _flag_default_pattern(flag)
+    matches = list(pat.finditer(source_text))
+    n = len(matches)
+    if n == 0:
+        return RewriteResult(False, source_text, 0, "no_default_literal_found")
+    if n > 1:
+        return RewriteResult(
+            False, source_text, n, f"ambiguous_{n}_matches_abstained",
+        )
+    m = matches[0]
+    cur = m.group("lit").strip().lower()
+    if cur not in _FALSY_LITERALS:
+        return RewriteResult(
+            False, source_text, 1, f"already_truthy_default:{cur!r}",
+        )
+    q = m.group("q")
+    replacement = m.group(0).replace(
+        f"{q}{m.group('lit')}{q}", f'{q}true{q}', 1,
+    )
+    new_text = source_text[: m.start()] + replacement + source_text[m.end():]
+    # Structural safety: the rewrite MUST still parse.
+    try:
+        ast.parse(new_text)
+    except SyntaxError as exc:  # pragma: no cover - defensive
+        return RewriteResult(False, source_text, 1, f"ast_parse_failed:{exc}")
+    return RewriteResult(True, new_text, 1, "flipped_to_true")
+
+
+# ---------------------------------------------------------------------------
+# Gated orchestration (composes rewriter + manifest + OrangePRReviewer)
+# ---------------------------------------------------------------------------
+
+
+def graduation_pr_enabled() -> bool:
+    """Master gate for the autonomous source-of-truth graduation PR. Default
+    FALSE — the rewriter + manifest are always importable/testable; only the
+    live branch+PR action is gated."""
+    return os.environ.get(
+        "JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED", "false",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+@dataclass(frozen=True)
+class ProposalResult:
+    proposed: bool
+    flag: str
+    source_file: str
+    pr_url: Optional[str]
+    detail: str
+
+
+def _resolve_source_file(flag: str, registry: Any) -> Optional[str]:
+    """The FlagSpec.source_file is the declared home of the flag's default.
+    NEVER raises."""
+    try:
+        spec = registry.get_spec(flag)
+        sf = getattr(spec, "source_file", None) if spec else None
+        return str(sf) if sf else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def propose_graduation_pr(
+    flag: str,
+    *,
+    soak_evidence: Sequence[Dict[str, Any]],
+    session_ids: Sequence[str],
+    required_clean: int,
+    ttft_ceiling_ms: float,
+    repo_root: str,
+    registry: Any = None,
+    reviewer: Any = None,
+    generated_at: Optional[str] = None,
+) -> ProposalResult:
+    """Compose: verify merge-recommendation → locate source → flip default →
+    render manifest → open the [SOVEREIGN GRADUATION] PR via OrangePRReviewer.
+
+    Gated (graduation_pr_enabled). Returns a structured result; NEVER raises.
+    Does NOT merge — the human/OCA gate is preserved by construction."""
+    from backend.core.ouroboros.governance.graduation.telemetry_manifest import (
+        manifest_recommends_merge,
+        render_graduation_manifest,
+    )
+
+    if not graduation_pr_enabled():
+        return ProposalResult(False, flag, "", None, "gate_disabled")
+
+    # The crucible only PROPOSES when the evidence clears the math veto.
+    if not manifest_recommends_merge(soak_evidence, required_clean=required_clean):
+        return ProposalResult(False, flag, "", None, "evidence_did_not_clear_veto")
+
+    if registry is None:
+        try:
+            from backend.core.ouroboros.governance.flag_registry import (
+                ensure_seeded,
+            )
+            registry = ensure_seeded()
+        except Exception as exc:  # noqa: BLE001
+            return ProposalResult(False, flag, "", None, f"registry_unavailable:{exc}")
+
+    source_file = _resolve_source_file(flag, registry)
+    if not source_file:
+        return ProposalResult(False, flag, "", None, "source_file_unknown")
+
+    abs_path = os.path.join(repo_root, source_file)
+    try:
+        with open(abs_path, "r", encoding="utf-8") as fh:
+            original = fh.read()
+    except OSError as exc:
+        return ProposalResult(False, flag, source_file, None, f"read_failed:{exc}")
+
+    rw = flip_default_to_true(original, flag)
+    if not rw.changed:
+        return ProposalResult(
+            False, flag, source_file, None, f"rewrite_abstained:{rw.detail}",
+        )
+
+    body = render_graduation_manifest(
+        flag,
+        soak_evidence=soak_evidence,
+        session_ids=session_ids,
+        required_clean=required_clean,
+        source_file=source_file,
+        ttft_ceiling_ms=ttft_ceiling_ms,
+        generated_at=generated_at,
+    )
+
+    if reviewer is None:
+        try:
+            import pathlib
+            from backend.core.ouroboros.governance.orange_pr_reviewer import (
+                OrangePRReviewer,
+            )
+            reviewer = OrangePRReviewer(pathlib.Path(repo_root))
+        except Exception as exc:  # noqa: BLE001
+            return ProposalResult(False, flag, source_file, None, f"reviewer_unavailable:{exc}")
+
+    try:
+        pr = await reviewer.create_review_pr(
+            op_id=f"sovereign-graduation-{flag.lower()}",
+            description=f"[SOVEREIGN GRADUATION] Activated {flag}",
+            files=[(source_file, rw.new_text)],
+            evidence={"flag": flag, "soaks": list(session_ids)},
+            risk_tier_name="APPROVAL_REQUIRED",
+            body_override=body,
+            title_override=f"[SOVEREIGN GRADUATION] Activated {flag}",
+        )
+    except TypeError:
+        # OrangePRReviewer without body_override support — fall back to default
+        # body (the manifest is still in the evidence + commit).
+        pr = await reviewer.create_review_pr(
+            op_id=f"sovereign-graduation-{flag.lower()}",
+            description=f"[SOVEREIGN GRADUATION] Activated {flag}",
+            files=[(source_file, rw.new_text)],
+            evidence={"flag": flag, "manifest": body},
+            risk_tier_name="APPROVAL_REQUIRED",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ProposalResult(False, flag, source_file, None, f"pr_create_failed:{exc}")
+
+    url = getattr(pr, "url", None) if pr else None
+    return ProposalResult(
+        bool(pr), flag, source_file, url,
+        "pr_opened" if pr else "pr_create_returned_none",
+    )
+
+
+__all__ = [
+    "RewriteResult",
+    "flip_default_to_true",
+    "graduation_pr_enabled",
+    "ProposalResult",
+    "propose_graduation_pr",
+]

--- a/backend/core/ouroboros/governance/graduation/graduation_pr_proposer.py
+++ b/backend/core/ouroboros/governance/graduation/graduation_pr_proposer.py
@@ -46,6 +46,68 @@ class RewriteResult:
     detail: str
 
 
+# Bounded codebase search for the literal-site locator.
+_LOCATOR_ROOTS = ("backend", "scripts")
+_LOCATOR_MAX_FILE_BYTES = 2 * 1024 * 1024
+_LOCATOR_SKIP_DIRS = frozenset({
+    ".git", ".venv", "node_modules", "__pycache__", ".claude",
+    "tests", "test",
+})
+
+
+def locate_default_literal_file(
+    flag: str, repo_root: str, *, hint: Optional[str] = None,
+) -> Optional[str]:
+    """Find the single source file whose ``os.environ.get("<FLAG>", "<falsy>")``
+    default literal the crucible should flip.
+
+    ``FlagSpec.source_file`` points to the flag's DECLARATION/doc site, which is
+    frequently NOT where the default literal lives (audited: only ~6/96 align).
+    This locator searches the codebase for the actual literal site so the
+    crucible can graduate the real source-of-truth. Pure-ish (bounded file I/O),
+    fail-soft, NEVER raises.
+
+    Returns the repo-relative path IFF exactly one file contains exactly one
+    flippable falsy default for ``flag`` (the ``hint`` file is checked first and
+    wins if it qualifies). Returns ``None`` on zero or ambiguous (>1 file)
+    matches — abstain rather than guess."""
+    if not isinstance(flag, str) or not flag or not isinstance(repo_root, str):
+        return None
+    pat = _flag_default_pattern(flag)
+
+    def _qualifies(rel: str) -> bool:
+        try:
+            with open(os.path.join(repo_root, rel), "r", encoding="utf-8") as fh:
+                txt = fh.read(_LOCATOR_MAX_FILE_BYTES)
+        except OSError:
+            return False
+        ms = list(pat.finditer(txt))
+        if len(ms) != 1:
+            return False
+        return ms[0].group("lit").strip().lower() in _FALSY_LITERALS
+
+    # Hint (registry source_file) wins if it qualifies.
+    if hint and _qualifies(hint):
+        return hint
+
+    found: list = []
+    for root in _LOCATOR_ROOTS:
+        base = os.path.join(repo_root, root)
+        if not os.path.isdir(base):
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames if d not in _LOCATOR_SKIP_DIRS]
+            for fn in filenames:
+                if not fn.endswith(".py"):
+                    continue
+                rel = os.path.relpath(os.path.join(dirpath, fn), repo_root)
+                if _qualifies(rel):
+                    found.append(rel)
+                    if len(found) > 1:
+                        return None  # ambiguous across files — abstain
+    return found[0] if len(found) == 1 else None
+
+
 def _flag_default_pattern(flag: str) -> re.Pattern:
     """Match ``os.environ.get("<FLAG>", "<literal>")`` capturing the quote +
     inner default literal. Tolerates single/double quotes + inner whitespace."""
@@ -169,9 +231,15 @@ async def propose_graduation_pr(
         except Exception as exc:  # noqa: BLE001
             return ProposalResult(False, flag, "", None, f"registry_unavailable:{exc}")
 
-    source_file = _resolve_source_file(flag, registry)
+    # Resolve the literal SITE: the registry source_file is a hint (it points to
+    # the declaration, not always the default literal), so the locator searches
+    # the codebase and returns the real single literal-site (hint wins if valid).
+    hint = _resolve_source_file(flag, registry)
+    source_file = locate_default_literal_file(flag, repo_root, hint=hint)
     if not source_file:
-        return ProposalResult(False, flag, "", None, "source_file_unknown")
+        return ProposalResult(
+            False, flag, hint or "", None, "literal_site_unresolved",
+        )
 
     abs_path = os.path.join(repo_root, source_file)
     try:

--- a/backend/core/ouroboros/governance/graduation/live_fire_soak.py
+++ b/backend/core/ouroboros/governance/graduation/live_fire_soak.py
@@ -374,6 +374,45 @@ def history_path() -> Path:
     return Path(".jarvis") / "live_fire_graduation_history.jsonl"
 
 
+def recent_clean_crucible_evidence(
+    flag_name: str, *, limit: int = 3,
+) -> List[Dict[str, Any]]:
+    """Sovereign Cognitive Crucible (2026-06-20) — read the last ``limit`` CLEAN
+    soaks for ``flag_name`` and return their crucible evidence bundles (the
+    TTFT/AST proof folded into each EvidenceRow.telemetry["crucible"]). Used by
+    the autonomous graduation engine to build the [SOVEREIGN GRADUATION] PR
+    manifest. Best-effort; NEVER raises; returns [] when unavailable."""
+    out: List[Dict[str, Any]] = []
+    try:
+        p = history_path()
+        if not p.exists():
+            return out
+        text = p.read_text(encoding="utf-8")
+    except OSError:
+        return out
+    rows: List[Dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if obj.get("flag_name") != flag_name:
+            continue
+        if str(obj.get("outcome", "")).lower() != "clean":
+            continue
+        tel = obj.get("telemetry")
+        cruc = tel.get("crucible") if isinstance(tel, dict) else None
+        if isinstance(cruc, dict):
+            rows.append({**cruc, "session_id": obj.get("session_id", "")})
+    # Most-recent ``limit`` (history is append-only chronological).
+    return rows[-limit:] if limit and len(rows) > limit else rows
+
+
 # ---------------------------------------------------------------------------
 # Outcome classification helpers
 # ---------------------------------------------------------------------------
@@ -1312,6 +1351,16 @@ class LiveFireSoakHarness:
                 "arbiter_outcome": new_outcome,
                 "arbiter_changed_outcome": new_outcome != legacy_outcome,
             }
+            # Sovereign Cognitive Crucible (2026-06-20) — fold in the TTFT/AST
+            # evidence bundle so this soak's EvidenceRow carries the proof the
+            # graduation PR manifest renders. Best-effort; never blocks.
+            try:
+                from backend.core.ouroboros.governance.graduation import (
+                    crucible_verdict as _cv,
+                )
+                telemetry["crucible"] = _cv.crucible_evidence(metrics)
+            except Exception:  # noqa: BLE001
+                pass
         except Exception:  # noqa: BLE001
             telemetry = None
         return (new_outcome, new_ra, new_notes, telemetry)

--- a/backend/core/ouroboros/governance/graduation/telemetry_manifest.py
+++ b/backend/core/ouroboros/governance/graduation/telemetry_manifest.py
@@ -1,0 +1,248 @@
+"""Sovereign Telemetry Manifest — the empirical proof rendered into the
+[SOVEREIGN GRADUATION] PR body (2026-06-20).
+
+We reject silent upgrades and empty PRs. When the autonomic crucible proposes a
+cognitive graduation, the PR body MUST mathematically justify the flip: a
+per-soak evidence table (TTFT deltas, AST integrity, FSM/recovery), an aggregate
+verdict, the AI's argument for why the operator should click merge, and a
+**Rollback Strategy** payload (the exact one-command disable).
+
+## Authority posture (locked)
+  * **Pure + stdlib-only** (``hashlib`` for the evidence digest). No I/O, no
+    logger, no network. The renderer is consulted; it never observes state.
+  * **Deterministic** — same evidence in → byte-identical markdown out (no
+    wall-clock, no randomness; any timestamp is passed in by the caller).
+  * **NEVER raises** — malformed evidence degrades to a clearly-marked
+    "insufficient evidence" manifest rather than crashing the PR path.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, List, Optional, Sequence
+
+MANIFEST_SCHEMA_VERSION = "1.0"
+
+
+def _b(x: Any) -> bool:
+    return bool(x)
+
+
+def _f(x: Any, default: float = 0.0) -> float:
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return default
+
+
+def _i(x: Any, default: int = 0) -> int:
+    try:
+        return int(x)
+    except (TypeError, ValueError):
+        return default
+
+
+def evidence_digest(soak_evidence: Sequence[Dict[str, Any]]) -> str:
+    """Deterministic sha256[:16] over the soak evidence — the cryptographic
+    fingerprint stamped in the manifest so the proof is tamper-evident."""
+    try:
+        canon = json.dumps(
+            list(soak_evidence), sort_keys=True, separators=(",", ":"),
+            default=str,
+        )
+    except (TypeError, ValueError):
+        canon = repr(soak_evidence)
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()[:16]
+
+
+def _verdict_row(idx: int, ev: Dict[str, Any]) -> str:
+    n = _i(ev.get("ttft_n"))
+    mean_ms = _f(ev.get("ttft_mean_ms"))
+    max_ms = _f(ev.get("ttft_max_ms"))
+    ttft_bad = _b(ev.get("ttft_degraded"))
+    ast_sig = _i(ev.get("ast_corruption_signals"))
+    ast_bad = _b(ev.get("ast_corrupted"))
+    recovered = _b(ev.get("recovered"))
+    outcome = str(ev.get("session_outcome") or "?")
+    ttft_cell = (
+        f"{mean_ms:.0f}ms (max {max_ms:.0f}, n={n})" if n else "no samples"
+    )
+    ttft_pass = "❌ FAIL" if ttft_bad else "✅ PASS"
+    ast_pass = "❌ FAIL" if ast_bad else "✅ PASS"
+    rec_pass = "✅" if recovered else "⚠️"
+    return (
+        f"| Soak {idx} | {ttft_cell} | {ttft_pass} | {ast_sig} | {ast_pass} "
+        f"| {rec_pass} {outcome} |"
+    )
+
+
+def render_graduation_manifest(
+    flag_name: str,
+    *,
+    soak_evidence: Sequence[Dict[str, Any]],
+    session_ids: Sequence[str],
+    required_clean: int,
+    source_file: str,
+    ttft_ceiling_ms: float,
+    revert_sha: Optional[str] = None,
+    generated_at: Optional[str] = None,
+) -> str:
+    """Render the full [SOVEREIGN GRADUATION] PR body markdown. Deterministic;
+    NEVER raises.
+
+    ``revert_sha`` (if known) is woven into the Rollback Strategy as the exact
+    ``git revert`` target; the env hot-revert is always provided as the
+    instant, no-deploy fallback."""
+    evs = [e for e in soak_evidence if isinstance(e, dict)]
+    n_soaks = len(evs)
+    digest = evidence_digest(evs)
+
+    # Aggregate verdicts.
+    any_ttft_bad = any(_b(e.get("ttft_degraded")) for e in evs)
+    total_ast = sum(_i(e.get("ast_corruption_signals")) for e in evs)
+    any_ast_bad = any(_b(e.get("ast_corrupted")) for e in evs)
+    recovered_n = sum(1 for e in evs if _b(e.get("recovered")))
+    max_ttft = max((_f(e.get("ttft_max_ms")) for e in evs), default=0.0)
+    clean_enough = (
+        n_soaks >= required_clean
+        and not any_ttft_bad
+        and not any_ast_bad
+    )
+
+    lines: List[str] = []
+    lines.append(f"## 🧬 [SOVEREIGN GRADUATION] Activated `{flag_name}`")
+    lines.append("")
+    lines.append(
+        f"The autonomic Cognitive Crucible proposes graduating `{flag_name}` "
+        f"(default `False` → `True`) in `{source_file}`. This PR is "
+        f"machine-generated; the evidence below is the mathematical proof the "
+        f"feature survived **{n_soaks}** autonomous soak(s) "
+        f"(required: {required_clean}) without degrading TTFT or corrupting AST."
+    )
+    if generated_at:
+        lines.append("")
+        lines.append(f"*Generated: {generated_at} · evidence digest: `{digest}`*")
+    else:
+        lines.append("")
+        lines.append(f"*Evidence digest: `{digest}` (sha256[:16])*")
+
+    # Empirical proof table.
+    lines.append("")
+    lines.append("### Empirical proof (per soak)")
+    lines.append("")
+    lines.append(
+        "| Soak | TTFT (target < "
+        f"{ttft_ceiling_ms:.0f}ms) | TTFT verdict | AST signals | "
+        "AST verdict | Recovery |"
+    )
+    lines.append("|---|---|---|---|---|---|")
+    if evs:
+        for i, ev in enumerate(evs, start=1):
+            lines.append(_verdict_row(i, ev))
+    else:
+        lines.append("| — | insufficient evidence | ⚠️ | — | ⚠️ | — |")
+
+    # Aggregate.
+    lines.append("")
+    lines.append("### Aggregate verdict")
+    lines.append("")
+    lines.append(f"- **Clean soaks**: {n_soaks} / {required_clean} required")
+    lines.append(
+        f"- **TTFT integrity**: max {max_ttft:.0f}ms vs ceiling "
+        f"{ttft_ceiling_ms:.0f}ms → {'❌ DEGRADED' if any_ttft_bad else '✅ within bounds'}"
+    )
+    lines.append(
+        f"- **AST integrity**: {total_ast} corruption signal(s) → "
+        f"{'❌ CORRUPTED' if any_ast_bad else '✅ zero parse errors'}"
+    )
+    lines.append(
+        f"- **FSM exhaustion rate**: "
+        f"{'0%' if recovered_n == n_soaks and n_soaks else 'N/A'} "
+        f"({recovered_n}/{n_soaks} soaks reached terminal recovery)"
+    )
+
+    # Why merge.
+    lines.append("")
+    lines.append("### Why merge")
+    lines.append("")
+    if clean_enough:
+        lines.append(
+            f"All {required_clean} required soaks completed clean: zero TTFT "
+            f"degradation, zero AST corruption, full FSM recovery. The cognitive "
+            f"feature is empirically proven non-regressive. Merging flips the "
+            f"source-of-truth default so the capability is live by construction "
+            f"(not a brittle `.env` override). **Recommend merge.**"
+        )
+    else:
+        reasons = []
+        if n_soaks < required_clean:
+            reasons.append(f"only {n_soaks}/{required_clean} clean soaks")
+        if any_ttft_bad:
+            reasons.append("TTFT degraded")
+        if any_ast_bad:
+            reasons.append("AST corruption detected")
+        lines.append(
+            "⚠️ **Do NOT merge** — the crucible veto did not fully clear: "
+            + "; ".join(reasons)
+            + ". This manifest is published for audit; the flag stays `False`."
+        )
+
+    # Rollback strategy (always present — supreme safety).
+    lines.append("")
+    lines.append("### 🛟 Rollback Strategy")
+    lines.append("")
+    lines.append(
+        "If a downstream anomaly appears in production post-merge, disable the "
+        "flag **instantly** (no redeploy) via env hot-revert:"
+    )
+    lines.append("")
+    lines.append("```bash")
+    lines.append(f"export {flag_name}=false   # instant, process-restart applies")
+    lines.append("```")
+    lines.append("")
+    lines.append("Or revert the source-of-truth flip permanently:")
+    lines.append("")
+    lines.append("```bash")
+    if revert_sha:
+        lines.append(f"git revert {revert_sha}    # reverts the default-literal flip")
+    else:
+        lines.append(
+            f"git revert <merge-sha>   # reverts the {flag_name} default-literal flip"
+        )
+    lines.append("```")
+    lines.append("")
+    if session_ids:
+        lines.append(
+            "<sub>Soak sessions: "
+            + ", ".join(f"`{s}`" for s in session_ids if s)
+            + f" · manifest schema v{MANIFEST_SCHEMA_VERSION}</sub>"
+        )
+    lines.append("")
+    lines.append(
+        "🤖 Generated autonomously by the Sovereign Cognitive Crucible "
+        "(cage-respecting: PR-proposes, human merges)."
+    )
+    return "\n".join(lines)
+
+
+def manifest_recommends_merge(
+    soak_evidence: Sequence[Dict[str, Any]], *, required_clean: int,
+) -> bool:
+    """Pure predicate mirroring the manifest's merge recommendation — the
+    crucible MUST only open a PR when this is True. NEVER raises."""
+    evs = [e for e in soak_evidence if isinstance(e, dict)]
+    if len(evs) < required_clean:
+        return False
+    if any(_b(e.get("ttft_degraded")) for e in evs):
+        return False
+    if any(_b(e.get("ast_corrupted")) for e in evs):
+        return False
+    return True
+
+
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "evidence_digest",
+    "render_graduation_manifest",
+    "manifest_recommends_merge",
+]

--- a/backend/core/ouroboros/governance/graduation/telemetry_parse.py
+++ b/backend/core/ouroboros/governance/graduation/telemetry_parse.py
@@ -53,6 +53,24 @@ _RE_OOM = re.compile(
     r"stopping: process_memory_cap|MemoryError|emergency_brake|"
     r"memory_pressure_changed.*(critical|emergency)",
 )
+# Sovereign Cognitive Crucible (2026-06-20) — TTFT + AST veto signals.
+# TTFT samples: HeavyProbe + candidate_generator emit ``ttft_ms=<int>``.
+# 0 is the timeout/failure sentinel (dw_heavy_probe sets ttft_ms=0 on
+# failure) — kept in the raw list but the verdict math uses non-zero
+# samples only (a 0 means "no first token", handled by the FSM/recovery
+# signals, not the latency gate).
+_RE_TTFT = re.compile(r"ttft_ms=(\d+)")
+# Explicit candidate AST/syntax corruption — distinct from the failure_class
+# runner-bucket (already caught by default_clean via phase_runner_error /
+# candidate_validate_error). These markers prove the *cognitive feature under
+# test* emitted structurally-broken code during a soak.
+_RE_AST_CORRUPT = re.compile(
+    r"PhaseRunnerASTValidationError"
+    r"|failure_class[=:][\"']?(?:ast_\w+|syntax_\w+)"
+    r"|candidate[^\n]*invalid syntax"
+    r"|placeholder_detected"
+    r"|ast_validation_failed",
+)
 
 # Session outcomes the harness writes when the FSM finalized a summary.
 _TERMINAL_OUTCOMES = {"complete", "incomplete_kill"}
@@ -81,6 +99,9 @@ class Metrics:
     stop_reason: str = ""
     cost_total: Optional[float] = None
     duration_s: Optional[float] = None
+    # Sovereign Cognitive Crucible — latency + structural-integrity signals
+    ttft_samples_ms: List[int] = field(default_factory=list)  # all ttft_ms=N
+    ast_corruption_signals: int = 0   # explicit candidate AST/syntax breakage
 
 
 def parse_metrics(
@@ -110,6 +131,16 @@ def parse_metrics(
     m.gate_inert = bool(_RE_GATE_INERT.search(log_text))
     m.livefire_timeout = bool(_RE_TIMEOUT.search(log_text))
     m.oom = bool(_RE_OOM.search(log_text))
+
+    # Cognitive Crucible — TTFT samples + explicit AST-corruption count.
+    ttft_hits: List[int] = []
+    for raw in _RE_TTFT.findall(log_text):
+        try:
+            ttft_hits.append(int(raw))
+        except (TypeError, ValueError):
+            continue
+    m.ttft_samples_ms = ttft_hits
+    m.ast_corruption_signals = len(_RE_AST_CORRUPT.findall(log_text))
 
     if isinstance(summary, dict):
         m.session_outcome = str(summary.get("session_outcome", ""))

--- a/backend/core/ouroboros/governance/orange_pr_reviewer.py
+++ b/backend/core/ouroboros/governance/orange_pr_reviewer.py
@@ -226,6 +226,8 @@ class OrangePRReviewer:
         files: List[Tuple[str, str]],
         evidence: Optional[Dict[str, Any]] = None,
         risk_tier_name: str = "APPROVAL_REQUIRED",
+        body_override: Optional[str] = None,
+        title_override: Optional[str] = None,
     ) -> Optional[PRReviewResult]:
         """Open an async-review PR for the given candidate.
 
@@ -305,9 +307,19 @@ class OrangePRReviewer:
                 )
                 return None
 
-            pr_title = f"[Ouroboros Review] {description[:72].strip()}"
-            pr_body = build_pr_body(
-                op_id, description, files, evidence, risk_tier_name
+            # body_override / title_override let an autonomous caller (e.g. the
+            # Sovereign Cognitive Crucible) supply a self-authored PR body — the
+            # Telemetry Manifest — and an exact title. Falls back to the
+            # templated review body when not supplied (byte-identical legacy).
+            pr_title = (
+                title_override.strip() if title_override
+                else f"[Ouroboros Review] {description[:72].strip()}"
+            )
+            pr_body = (
+                body_override if body_override
+                else build_pr_body(
+                    op_id, description, files, evidence, risk_tier_name
+                )
             )
             rc, out, err = await self._run_gh(
                 "pr", "create",

--- a/tests/governance/test_crucible_verdict.py
+++ b/tests/governance/test_crucible_verdict.py
@@ -1,0 +1,129 @@
+"""Sovereign Cognitive Crucible — TTFT + AST math-veto tests (2026-06-20)."""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.graduation.telemetry_parse import (
+    parse_metrics,
+)
+from backend.core.ouroboros.governance.graduation.crucible_verdict import (
+    ast_corrupted,
+    crucible_evidence,
+    ttft_degraded,
+    ttft_stats,
+)
+
+
+# ── parse extensions ────────────────────────────────────────────────────────
+
+def test_parse_collects_ttft_samples():
+    log = "x ttft_ms=800 y\nz ttft_ms=1200 q\nttft_ms=0 fail\n"
+    m = parse_metrics(log, None)
+    assert m.ttft_samples_ms == [800, 1200, 0]
+
+
+def test_parse_counts_ast_corruption_signals():
+    log = (
+        "PhaseRunnerASTValidationError: bad\n"
+        "failure_class=ast_invalid here\n"
+        "candidate produced invalid syntax\n"
+        "placeholder_detected in patch\n"
+    )
+    m = parse_metrics(log, None)
+    assert m.ast_corruption_signals == 4
+
+
+def test_parse_no_signals_defaults_empty():
+    m = parse_metrics("phase=GENERATE state=applied", None)
+    assert m.ttft_samples_ms == []
+    assert m.ast_corruption_signals == 0
+
+
+# ── ttft stats / degradation ────────────────────────────────────────────────
+
+def test_ttft_stats_ignores_zero_sentinel():
+    m = parse_metrics("ttft_ms=1000 ttft_ms=3000 ttft_ms=0", None)
+    s = ttft_stats(m)
+    assert s["n"] == 2
+    assert s["mean_ms"] == 2000.0
+    assert s["max_ms"] == 3000.0
+
+
+def test_ttft_no_samples_fails_open():
+    m = parse_metrics("no latency here", None)
+    bad, detail = ttft_degraded(m)
+    assert bad is False
+    assert detail == "no_ttft_samples"
+
+
+def test_ttft_over_absolute_ceiling_vetoes(monkeypatch):
+    monkeypatch.setenv("JARVIS_CRUCIBLE_TTFT_CEILING_MS", "5000")
+    m = parse_metrics("ttft_ms=8000 ttft_ms=9000", None)
+    bad, detail = ttft_degraded(m)
+    assert bad is True
+    assert "ceiling" in detail
+
+
+def test_ttft_under_ceiling_passes(monkeypatch):
+    monkeypatch.setenv("JARVIS_CRUCIBLE_TTFT_CEILING_MS", "5000")
+    m = parse_metrics("ttft_ms=800 ttft_ms=1200", None)
+    bad, _ = ttft_degraded(m)
+    assert bad is False
+
+
+def test_ttft_baseline_ratio_vetoes(monkeypatch):
+    monkeypatch.setenv("JARVIS_CRUCIBLE_TTFT_CEILING_MS", "100000")
+    monkeypatch.setenv("JARVIS_CRUCIBLE_TTFT_DEGRADE_RATIO", "1.5")
+    m = parse_metrics("ttft_ms=2000 ttft_ms=2000", None)
+    # baseline 1000 → 1.5x = 1500; mean 2000 > 1500 → degraded
+    bad, detail = ttft_degraded(m, baseline_ms=1000.0)
+    assert bad is True
+    assert "baseline" in detail
+
+
+def test_ttft_baseline_within_ratio_passes(monkeypatch):
+    monkeypatch.setenv("JARVIS_CRUCIBLE_TTFT_CEILING_MS", "100000")
+    monkeypatch.setenv("JARVIS_CRUCIBLE_TTFT_DEGRADE_RATIO", "2.0")
+    m = parse_metrics("ttft_ms=1800", None)
+    bad, _ = ttft_degraded(m, baseline_ms=1000.0)  # 1800 < 2000
+    assert bad is False
+
+
+# ── ast corruption ──────────────────────────────────────────────────────────
+
+def test_ast_corrupted_when_signals_present():
+    m = parse_metrics("PhaseRunnerASTValidationError boom", None)
+    bad, detail = ast_corrupted(m)
+    assert bad is True
+    assert "corruption" in detail
+
+
+def test_ast_clean_when_no_signals():
+    m = parse_metrics("phase=COMPLETE state=applied", None)
+    bad, _ = ast_corrupted(m)
+    assert bad is False
+
+
+# ── evidence bundle (manifest input) ────────────────────────────────────────
+
+def test_crucible_evidence_shape(monkeypatch):
+    monkeypatch.setenv("JARVIS_CRUCIBLE_TTFT_CEILING_MS", "5000")
+    m = parse_metrics(
+        "ttft_ms=800 ttft_ms=1200 state=applied", None,
+    )
+    ev = crucible_evidence(m)
+    assert ev["ttft_n"] == 2
+    assert ev["ttft_mean_ms"] == 1000.0
+    assert ev["ttft_degraded"] is False
+    assert ev["ast_corrupted"] is False
+    assert ev["recovered"] is True
+    assert ev["ttft_ceiling_ms"] == 5000.0
+
+
+def test_crucible_evidence_never_raises_on_garbage():
+    class _Bad:
+        ttft_samples_ms = "not-a-list"
+        ast_corruption_signals = "nope"
+    ev = crucible_evidence(_Bad())
+    assert ev["ttft_n"] == 0
+    assert ev["ast_corruption_signals"] == 0

--- a/tests/governance/test_crucible_wiring.py
+++ b/tests/governance/test_crucible_wiring.py
@@ -1,0 +1,80 @@
+"""Sovereign Cognitive Crucible — soak-evidence → engine PR wiring (2026-06-20)."""
+from __future__ import annotations
+
+import json
+
+from backend.core.ouroboros.governance.graduation.live_fire_soak import (
+    recent_clean_crucible_evidence,
+)
+from backend.core.ouroboros.governance.autonomous_graduation_engine import (
+    GraduationDecision,
+    GraduationDisposition,
+    GraduationTier,
+    _maybe_propose_source_pr,
+)
+
+
+def _row(flag, sid, outcome="clean", with_cruc=True):
+    tel = {"recovered": True}
+    if with_cruc:
+        tel["crucible"] = {
+            "ttft_n": 3, "ttft_mean_ms": 800.0, "ttft_max_ms": 1000.0,
+            "ttft_degraded": False, "ast_corruption_signals": 0,
+            "ast_corrupted": False, "recovered": True,
+            "session_outcome": "complete",
+        }
+    return json.dumps({
+        "flag_name": flag, "session_id": sid, "outcome": outcome,
+        "telemetry": tel,
+    })
+
+
+def test_recent_clean_crucible_evidence_filters(tmp_path, monkeypatch):
+    hist = tmp_path / "hist.jsonl"
+    hist.write_text("\n".join([
+        _row("JARVIS_A", "s1"),
+        _row("JARVIS_B", "s2"),                       # other flag
+        _row("JARVIS_A", "s3", outcome="runner"),     # not clean
+        _row("JARVIS_A", "s4"),
+        _row("JARVIS_A", "s5", with_cruc=False),      # no crucible bundle
+        _row("JARVIS_A", "s6"),
+    ]) + "\n")
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_GRADUATION_HISTORY_PATH", str(hist))
+    ev = recent_clean_crucible_evidence("JARVIS_A", limit=3)
+    sids = [e["session_id"] for e in ev]
+    assert sids == ["s1", "s4", "s6"]  # clean + has-crucible, most-recent 3
+    assert all(e["ttft_degraded"] is False for e in ev)
+
+
+def test_recent_clean_evidence_missing_history_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_LIVE_FIRE_GRADUATION_HISTORY_PATH",
+        str(tmp_path / "nope.jsonl"),
+    )
+    assert recent_clean_crucible_evidence("JARVIS_A") == []
+
+
+def _decision(flag="JARVIS_A"):
+    return GraduationDecision(
+        flag_name=flag,
+        tier=GraduationTier.STANDARD,
+        disposition=GraduationDisposition.AUTO_FLIP,
+        evidence={},
+        delta="",
+        evidence_sha256="x",
+    )
+
+
+def test_pr_hook_gate_off_is_noop(monkeypatch):
+    monkeypatch.delenv("JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED", raising=False)
+    assert _maybe_propose_source_pr(_decision()) is False
+
+
+def test_pr_hook_gate_on_no_evidence_abstains(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_LIVE_FIRE_GRADUATION_HISTORY_PATH",
+        str(tmp_path / "empty.jsonl"),
+    )
+    # No clean evidence → manifest veto → no PR scheduled (safe; no empty PRs).
+    assert _maybe_propose_source_pr(_decision()) is False

--- a/tests/governance/test_graduation_pr_proposer.py
+++ b/tests/governance/test_graduation_pr_proposer.py
@@ -9,8 +9,48 @@ from backend.core.ouroboros.governance.graduation.graduation_pr_proposer import 
     ProposalResult,
     flip_default_to_true,
     graduation_pr_enabled,
+    locate_default_literal_file,
     propose_graduation_pr,
 )
+
+
+# ── literal-site locator (Slice 5.5) ────────────────────────────────────────
+
+def _mk(tmp_path, rel, text):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+def test_locator_finds_single_site(tmp_path):
+    _mk(tmp_path, "backend/m.py",
+        'x = os.environ.get("JARVIS_F", "false")\n')
+    assert locate_default_literal_file("JARVIS_F", str(tmp_path)) == "backend/m.py"
+
+
+def test_locator_abstains_on_multiple_files(tmp_path):
+    _mk(tmp_path, "backend/a.py", 'os.environ.get("JARVIS_F", "false")\n')
+    _mk(tmp_path, "backend/b.py", 'os.environ.get("JARVIS_F", "false")\n')
+    assert locate_default_literal_file("JARVIS_F", str(tmp_path)) is None
+
+
+def test_locator_hint_wins_when_valid(tmp_path):
+    _mk(tmp_path, "backend/decl.py", 'os.environ.get("JARVIS_F", "0")\n')
+    assert locate_default_literal_file(
+        "JARVIS_F", str(tmp_path), hint="backend/decl.py",
+    ) == "backend/decl.py"
+
+
+def test_locator_skips_tests_dir(tmp_path):
+    _mk(tmp_path, "backend/real.py", 'os.environ.get("JARVIS_F", "false")\n')
+    _mk(tmp_path, "backend/tests/t.py", 'os.environ.get("JARVIS_F", "false")\n')
+    # tests/ is pruned → only the real site counts (not ambiguous)
+    assert locate_default_literal_file("JARVIS_F", str(tmp_path)) == "backend/real.py"
+
+
+def test_locator_none_when_absent(tmp_path):
+    _mk(tmp_path, "backend/m.py", "x = 1\n")
+    assert locate_default_literal_file("JARVIS_MISSING", str(tmp_path)) is None
 
 
 # ── the pure rewriter (safety-critical) ─────────────────────────────────────

--- a/tests/governance/test_graduation_pr_proposer.py
+++ b/tests/governance/test_graduation_pr_proposer.py
@@ -1,0 +1,176 @@
+"""Sovereign GitOps graduation PR — source-of-truth rewriter tests (2026-06-20)."""
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from backend.core.ouroboros.governance.graduation.graduation_pr_proposer import (
+    ProposalResult,
+    flip_default_to_true,
+    graduation_pr_enabled,
+    propose_graduation_pr,
+)
+
+
+# ── the pure rewriter (safety-critical) ─────────────────────────────────────
+
+def test_flip_false_literal():
+    src = 'x = os.environ.get("JARVIS_CURIOSITY_ENGINE_ENABLED", "false")\n'
+    r = flip_default_to_true(src, "JARVIS_CURIOSITY_ENGINE_ENABLED")
+    assert r.changed is True
+    assert '"true"' in r.new_text
+    assert '"false"' not in r.new_text
+    ast.parse(r.new_text)  # still valid
+
+
+def test_flip_empty_default():
+    src = 'raw = os.environ.get("JARVIS_X", "").strip().lower()\n'
+    r = flip_default_to_true(src, "JARVIS_X")
+    assert r.changed is True
+    assert 'os.environ.get("JARVIS_X", "true")' in r.new_text
+
+
+def test_flip_single_quotes_and_zero():
+    src = "v = os.environ.get('JARVIS_Y', '0')\n"
+    r = flip_default_to_true(src, "JARVIS_Y")
+    assert r.changed is True
+    assert "os.environ.get('JARVIS_Y', 'true')" in r.new_text
+
+
+def test_no_match_abstains():
+    src = 'os.environ.get("JARVIS_OTHER", "false")\n'
+    r = flip_default_to_true(src, "JARVIS_MISSING")
+    assert r.changed is False
+    assert r.matches == 0
+    assert r.detail == "no_default_literal_found"
+
+
+def test_ambiguous_multiple_matches_abstains():
+    src = (
+        'a = os.environ.get("JARVIS_DUP", "false")\n'
+        'b = os.environ.get("JARVIS_DUP", "false")\n'
+    )
+    r = flip_default_to_true(src, "JARVIS_DUP")
+    assert r.changed is False
+    assert r.matches == 2
+    assert "ambiguous" in r.detail
+    assert r.new_text == src  # untouched
+
+
+def test_already_truthy_abstains():
+    src = 'os.environ.get("JARVIS_ON", "true")\n'
+    r = flip_default_to_true(src, "JARVIS_ON")
+    assert r.changed is False
+    assert "already_truthy" in r.detail
+
+
+def test_only_targets_the_named_flag():
+    src = (
+        'a = os.environ.get("JARVIS_A", "false")\n'
+        'b = os.environ.get("JARVIS_B", "false")\n'
+    )
+    r = flip_default_to_true(src, "JARVIS_A")
+    assert r.changed is True
+    assert 'os.environ.get("JARVIS_A", "true")' in r.new_text
+    assert 'os.environ.get("JARVIS_B", "false")' in r.new_text  # untouched
+
+
+def test_rewriter_never_raises_on_garbage():
+    assert flip_default_to_true(None, "JARVIS_X").changed is False  # type: ignore
+    assert flip_default_to_true("x=1", "").changed is False
+
+
+# ── gate + orchestration ────────────────────────────────────────────────────
+
+def test_gate_default_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED", raising=False)
+    assert graduation_pr_enabled() is False
+
+
+def test_gate_on(monkeypatch):
+    monkeypatch.setenv("JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED", "true")
+    assert graduation_pr_enabled() is True
+
+
+class _FakeSpec:
+    source_file = "pkg/mod.py"
+
+
+class _FakeRegistry:
+    def get_spec(self, flag):
+        return _FakeSpec()
+
+
+class _FakeReviewer:
+    def __init__(self):
+        self.calls = []
+
+    async def create_review_pr(self, **kwargs):
+        self.calls.append(kwargs)
+
+        class _PR:
+            url = "https://github.com/x/y/pull/42"
+        return _PR()
+
+
+def _clean_ev():
+    return {
+        "ttft_n": 3, "ttft_mean_ms": 800.0, "ttft_max_ms": 1000.0,
+        "ttft_degraded": False, "ast_corruption_signals": 0,
+        "ast_corrupted": False, "recovered": True,
+        "session_outcome": "complete",
+    }
+
+
+async def test_proposer_opens_pr_when_clean(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED", "true")
+    (tmp_path / "pkg").mkdir()
+    src = 'flag = os.environ.get("JARVIS_CURIOSITY_ENGINE_ENABLED", "false")\n'
+    (tmp_path / "pkg" / "mod.py").write_text(src)
+    reviewer = _FakeReviewer()
+    res = await propose_graduation_pr(
+        "JARVIS_CURIOSITY_ENGINE_ENABLED",
+        soak_evidence=[_clean_ev(), _clean_ev(), _clean_ev()],
+        session_ids=["bt-1", "bt-2", "bt-3"],
+        required_clean=3,
+        ttft_ceiling_ms=30000.0,
+        repo_root=str(tmp_path),
+        registry=_FakeRegistry(),
+        reviewer=reviewer,
+    )
+    assert res.proposed is True
+    assert res.pr_url == "https://github.com/x/y/pull/42"
+    assert len(reviewer.calls) == 1
+    call = reviewer.calls[0]
+    assert call["description"] == "[SOVEREIGN GRADUATION] Activated JARVIS_CURIOSITY_ENGINE_ENABLED"
+    # the rewritten file content carries the flip
+    assert any('"true"' in c for (_, c) in call["files"])
+
+
+async def test_proposer_gate_off_no_pr(monkeypatch, tmp_path):
+    monkeypatch.delenv("JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED", raising=False)
+    reviewer = _FakeReviewer()
+    res = await propose_graduation_pr(
+        "JARVIS_X", soak_evidence=[_clean_ev()] * 3, session_ids=["a"],
+        required_clean=3, ttft_ceiling_ms=30000.0, repo_root=str(tmp_path),
+        registry=_FakeRegistry(), reviewer=reviewer,
+    )
+    assert res.proposed is False
+    assert res.detail == "gate_disabled"
+    assert reviewer.calls == []
+
+
+async def test_proposer_vetoes_when_evidence_dirty(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED", "true")
+    reviewer = _FakeReviewer()
+    dirty = _clean_ev()
+    dirty["ttft_degraded"] = True
+    res = await propose_graduation_pr(
+        "JARVIS_X", soak_evidence=[_clean_ev(), _clean_ev(), dirty],
+        session_ids=["a"], required_clean=3, ttft_ceiling_ms=30000.0,
+        repo_root=str(tmp_path), registry=_FakeRegistry(), reviewer=reviewer,
+    )
+    assert res.proposed is False
+    assert res.detail == "evidence_did_not_clear_veto"
+    assert reviewer.calls == []

--- a/tests/governance/test_p9_2_p9_3_contract_repl.py
+++ b/tests/governance/test_p9_2_p9_3_contract_repl.py
@@ -284,10 +284,20 @@ def test_curiosity_predicate_falls_back_to_ops_when_field_absent():
 
 
 def test_get_contract_unknown_flag_returns_default():
+    # Sovereign Cognitive Crucible (2026-06-20): flags without a specific
+    # built-in now carry the universal TTFT/AST veto predicate
+    # (predicate_cognitive_graduation) instead of None. It is VETO-ONLY +
+    # fail-open: with no metrics it returns True (no objection), so the
+    # default behavior is byte-identical until positive TTFT/AST harm exists.
+    from backend.core.ouroboros.governance.graduation.graduation_contract import (
+        predicate_cognitive_graduation,
+    )
     c = get_contract("JARVIS_DOES_NOT_EXIST")
     assert c.flag_name == "JARVIS_DOES_NOT_EXIST"
-    assert c.clean_predicate is None
+    assert c.clean_predicate is predicate_cognitive_graduation
     assert c.failure_class_blocklist_overrides == frozenset()
+    # Fail-open contract: no metrics → no objection (default-clean preserved).
+    assert c.clean_predicate({"session_outcome": "complete"}, None) is True
 
 
 def test_get_contract_known_flag_returns_custom():

--- a/tests/governance/test_telemetry_manifest.py
+++ b/tests/governance/test_telemetry_manifest.py
@@ -1,0 +1,105 @@
+"""Sovereign Telemetry Manifest — PR-body proof renderer tests (2026-06-20)."""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.graduation.telemetry_manifest import (
+    evidence_digest,
+    manifest_recommends_merge,
+    render_graduation_manifest,
+)
+
+
+def _clean_ev(ttft_mean=800.0, ttft_max=1200.0):
+    return {
+        "ttft_n": 3, "ttft_mean_ms": ttft_mean, "ttft_max_ms": ttft_max,
+        "ttft_degraded": False, "ast_corruption_signals": 0,
+        "ast_corrupted": False, "recovered": True,
+        "session_outcome": "complete",
+    }
+
+
+def _render(evs, required=3):
+    return render_graduation_manifest(
+        "JARVIS_CURIOSITY_ENGINE_ENABLED",
+        soak_evidence=evs,
+        session_ids=["bt-1", "bt-2", "bt-3"],
+        required_clean=required,
+        source_file="backend/.../flag_registry_seed.py",
+        ttft_ceiling_ms=30000.0,
+        revert_sha="abc1234",
+    )
+
+
+def test_clean_three_soaks_recommends_merge():
+    evs = [_clean_ev(), _clean_ev(), _clean_ev()]
+    assert manifest_recommends_merge(evs, required_clean=3) is True
+    body = _render(evs)
+    assert "[SOVEREIGN GRADUATION] Activated `JARVIS_CURIOSITY_ENGINE_ENABLED`" in body
+    assert "Recommend merge." in body
+    assert "Empirical proof (per soak)" in body
+    assert "| Soak 1 |" in body and "| Soak 3 |" in body  # 3 evidence rows
+    assert "| Soak 4 |" not in body
+    assert "✅ zero parse errors" in body
+    assert "0%" in body  # FSM exhaustion rate
+
+
+def test_ttft_degraded_vetoes_merge():
+    bad = _clean_ev()
+    bad["ttft_degraded"] = True
+    evs = [_clean_ev(), _clean_ev(), bad]
+    assert manifest_recommends_merge(evs, required_clean=3) is False
+    body = _render(evs)
+    assert "Do NOT merge" in body
+    assert "TTFT degraded" in body
+    assert "❌ DEGRADED" in body
+
+
+def test_ast_corruption_vetoes_merge():
+    bad = _clean_ev()
+    bad["ast_corrupted"] = True
+    bad["ast_corruption_signals"] = 2
+    evs = [_clean_ev(), _clean_ev(), bad]
+    assert manifest_recommends_merge(evs, required_clean=3) is False
+    body = _render(evs)
+    assert "Do NOT merge" in body
+    assert "AST corruption detected" in body
+
+
+def test_insufficient_soaks_vetoes_merge():
+    evs = [_clean_ev(), _clean_ev()]  # only 2 of 3
+    assert manifest_recommends_merge(evs, required_clean=3) is False
+    body = _render(evs, required=3)
+    assert "Do NOT merge" in body
+    assert "2/3 clean soaks" in body
+
+
+def test_rollback_strategy_always_present():
+    body = _render([_clean_ev()] * 3)
+    assert "🛟 Rollback Strategy" in body
+    assert "export JARVIS_CURIOSITY_ENGINE_ENABLED=false" in body
+    assert "git revert abc1234" in body
+
+
+def test_manifest_is_deterministic():
+    evs = [_clean_ev(), _clean_ev(), _clean_ev()]
+    assert _render(evs) == _render(evs)  # no wall-clock / randomness
+
+
+def test_evidence_digest_stable_and_order_sensitive():
+    a = [_clean_ev(ttft_mean=800.0)]
+    b = [_clean_ev(ttft_mean=900.0)]
+    assert evidence_digest(a) == evidence_digest(a)
+    assert evidence_digest(a) != evidence_digest(b)
+    assert len(evidence_digest(a)) == 16
+
+
+def test_render_never_raises_on_garbage():
+    body = render_graduation_manifest(
+        "JARVIS_X",
+        soak_evidence=["not-a-dict", None, {"ttft_n": "bad"}],
+        session_ids=[],
+        required_clean=3,
+        source_file="x.py",
+        ttft_ceiling_ms=30000.0,
+    )
+    assert "[SOVEREIGN GRADUATION]" in body
+    assert "Rollback Strategy" in body


### PR DESCRIPTION
## Summary

Follow-up to #69606 (merged). The **First Cognitive Ignition** dry-run surfaced a real gap: `FlagSpec.source_file` points to a flag's declaration/doc site, **not** where the `os.environ.get("<FLAG>", "<falsy>")` default literal lives — only **6 of 96** default-false flags align. The naive proposer would abstain (`no_default_literal_found`) on ~94%.

**Fix:** `locate_default_literal_file(flag, repo_root, hint=source_file)` — bounded codebase search for the single file holding exactly one flippable falsy default (hint wins if valid; abstains on zero/ambiguous). Clean resolution **6 → 10**; the other 87 correctly abstain (indirect accessors / multi-site reads — conservative, no wrong rewrites).

**Proven end-to-end** against real `JARVIS_EXPLORATION_LEDGER_ENABLED`: located `exploration_engine.py`, flipped `"" → "true"` (AST-valid), rendered the full `[SOVEREIGN GRADUATION]` Telemetry Manifest (per-soak TTFT/AST table, sha256 digest, why-merge, 🛟 rollback).

## Test Plan
- [x] 5 locator tests + 18 proposer tests green
- [x] Live dry-run produced the real source diff + manifest for a real flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates flags by rewriting the real default-literal site (not the declaration) and opens a `[SOVEREIGN GRADUATION]` PR with a telemetry-backed manifest. Proposals are gated and only open when TTFT/AST checks pass.

- New Features
  - `graduation_pr_proposer`: `locate_default_literal_file` (bounded search) and `flip_default_to_true` (pure, AST-validated). `propose_graduation_pr` (gated by `JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED`) opens a PR with the Telemetry Manifest; never self-merges.
  - Telemetry: `telemetry_parse` now collects `ttft_ms` samples and AST corruption signals. `crucible_verdict` computes TTFT/AST veto and bundles evidence. `telemetry_manifest` renders the PR body and `manifest_recommends_merge`.
  - Governance wiring: engine schedules proposals on `AUTO_FLIP`; `live_fire_soak.recent_clean_crucible_evidence` supplies last clean soaks; `graduation_contract` adds a universal veto-only predicate (TTFT/AST) for flags without custom contracts.
  - `orange_pr_reviewer`: supports `body_override` and `title_override` so the Telemetry Manifest is the PR body.

- Bug Fixes
  - Correctly finds the literal site instead of relying on `FlagSpec.source_file`. Searches `backend/` and `scripts/`, skips tests/venv/git, enforces a single flippable falsy default, and abstains on zero/ambiguous matches. Improves clean resolution from 6 → 10 flags; verified on `JARVIS_EXPLORATION_LEDGER_ENABLED`.

<sup>Written for commit be020d89b3f7648fade87e0a6831917cd421366e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

