### PR TITLE
fix(crucible): literal-site locator — graduate the real source-of-truth

### DIFF
--- a/backend/core/ouroboros/governance/graduation/graduation_pr_proposer.py
+++ b/backend/core/ouroboros/governance/graduation/graduation_pr_proposer.py
@@ -46,6 +46,68 @@ class RewriteResult:
     detail: str
 
 
+# Bounded codebase search for the literal-site locator.
+_LOCATOR_ROOTS = ("backend", "scripts")
+_LOCATOR_MAX_FILE_BYTES = 2 * 1024 * 1024
+_LOCATOR_SKIP_DIRS = frozenset({
+    ".git", ".venv", "node_modules", "__pycache__", ".claude",
+    "tests", "test",
+})
+
+
+def locate_default_literal_file(
+    flag: str, repo_root: str, *, hint: Optional[str] = None,
+) -> Optional[str]:
+    """Find the single source file whose ``os.environ.get("<FLAG>", "<falsy>")``
+    default literal the crucible should flip.
+
+    ``FlagSpec.source_file`` points to the flag's DECLARATION/doc site, which is
+    frequently NOT where the default literal lives (audited: only ~6/96 align).
+    This locator searches the codebase for the actual literal site so the
+    crucible can graduate the real source-of-truth. Pure-ish (bounded file I/O),
+    fail-soft, NEVER raises.
+
+    Returns the repo-relative path IFF exactly one file contains exactly one
+    flippable falsy default for ``flag`` (the ``hint`` file is checked first and
+    wins if it qualifies). Returns ``None`` on zero or ambiguous (>1 file)
+    matches — abstain rather than guess."""
+    if not isinstance(flag, str) or not flag or not isinstance(repo_root, str):
+        return None
+    pat = _flag_default_pattern(flag)
+
+    def _qualifies(rel: str) -> bool:
+        try:
+            with open(os.path.join(repo_root, rel), "r", encoding="utf-8") as fh:
+                txt = fh.read(_LOCATOR_MAX_FILE_BYTES)
+        except OSError:
+            return False
+        ms = list(pat.finditer(txt))
+        if len(ms) != 1:
+            return False
+        return ms[0].group("lit").strip().lower() in _FALSY_LITERALS
+
+    # Hint (registry source_file) wins if it qualifies.
+    if hint and _qualifies(hint):
+        return hint
+
+    found: list = []
+    for root in _LOCATOR_ROOTS:
+        base = os.path.join(repo_root, root)
+        if not os.path.isdir(base):
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames if d not in _LOCATOR_SKIP_DIRS]
+            for fn in filenames:
+                if not fn.endswith(".py"):
+                    continue
+                rel = os.path.relpath(os.path.join(dirpath, fn), repo_root)
+                if _qualifies(rel):
+                    found.append(rel)
+                    if len(found) > 1:
+                        return None  # ambiguous across files — abstain
+    return found[0] if len(found) == 1 else None
+
+
 def _flag_default_pattern(flag: str) -> re.Pattern:
     """Match ``os.environ.get("<FLAG>", "<literal>")`` capturing the quote +
     inner default literal. Tolerates single/double quotes + inner whitespace."""
@@ -169,9 +231,15 @@ async def propose_graduation_pr(
         except Exception as exc:  # noqa: BLE001
             return ProposalResult(False, flag, "", None, f"registry_unavailable:{exc}")
 
-    source_file = _resolve_source_file(flag, registry)
+    # Resolve the literal SITE: the registry source_file is a hint (it points to
+    # the declaration, not always the default literal), so the locator searches
+    # the codebase and returns the real single literal-site (hint wins if valid).
+    hint = _resolve_source_file(flag, registry)
+    source_file = locate_default_literal_file(flag, repo_root, hint=hint)
     if not source_file:
-        return ProposalResult(False, flag, "", None, "source_file_unknown")
+        return ProposalResult(
+            False, flag, hint or "", None, "literal_site_unresolved",
+        )
 
     abs_path = os.path.join(repo_root, source_file)
     try:

--- a/tests/governance/test_graduation_pr_proposer.py
+++ b/tests/governance/test_graduation_pr_proposer.py
@@ -9,8 +9,48 @@ from backend.core.ouroboros.governance.graduation.graduation_pr_proposer import 
     ProposalResult,
     flip_default_to_true,
     graduation_pr_enabled,
+    locate_default_literal_file,
     propose_graduation_pr,
 )
+
+
+# ── literal-site locator (Slice 5.5) ────────────────────────────────────────
+
+def _mk(tmp_path, rel, text):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+def test_locator_finds_single_site(tmp_path):
+    _mk(tmp_path, "backend/m.py",
+        'x = os.environ.get("JARVIS_F", "false")\n')
+    assert locate_default_literal_file("JARVIS_F", str(tmp_path)) == "backend/m.py"
+
+
+def test_locator_abstains_on_multiple_files(tmp_path):
+    _mk(tmp_path, "backend/a.py", 'os.environ.get("JARVIS_F", "false")\n')
+    _mk(tmp_path, "backend/b.py", 'os.environ.get("JARVIS_F", "false")\n')
+    assert locate_default_literal_file("JARVIS_F", str(tmp_path)) is None
+
+
+def test_locator_hint_wins_when_valid(tmp_path):
+    _mk(tmp_path, "backend/decl.py", 'os.environ.get("JARVIS_F", "0")\n')
+    assert locate_default_literal_file(
+        "JARVIS_F", str(tmp_path), hint="backend/decl.py",
+    ) == "backend/decl.py"
+
+
+def test_locator_skips_tests_dir(tmp_path):
+    _mk(tmp_path, "backend/real.py", 'os.environ.get("JARVIS_F", "false")\n')
+    _mk(tmp_path, "backend/tests/t.py", 'os.environ.get("JARVIS_F", "false")\n')
+    # tests/ is pruned → only the real site counts (not ambiguous)
+    assert locate_default_literal_file("JARVIS_F", str(tmp_path)) == "backend/real.py"
+
+
+def test_locator_none_when_absent(tmp_path):
+    _mk(tmp_path, "backend/m.py", "x = 1\n")
+    assert locate_default_literal_file("JARVIS_MISSING", str(tmp_path)) is None
 
 
 # ── the pure rewriter (safety-critical) ─────────────────────────────────────


### PR DESCRIPTION
Follow-up to #69606. FlagSpec.source_file points to the declaration site, not the os.environ.get default-literal site (only 6/96 align). locate_default_literal_file searches the codebase for the single flippable falsy default (hint wins; abstains on ambiguous). Clean resolution 6→10; the rest correctly abstain (conservative). Proven end-to-end on real JARVIS_EXPLORATION_LEDGER_ENABLED. 5 locator + 18 proposer tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crucible graduation by locating and rewriting the real default-literal site for env flags, not the registry declaration file. This reduces false abstentions and targets the actual source of truth.

- **Bug Fixes**
  - Implemented `locate_default_literal_file(...)` to find the single file with a flippable falsy `os.environ.get("<FLAG>", <literal>)` default; abstains on zero or multiple matches.
  - Bounded search: `backend/` and `scripts/`, skips `.git`, `.venv`, `node_modules`, `__pycache__`, `.claude`, `tests`, `test`; `.py` only; 2 MiB read cap; registry `source_file` is used as a hint and wins if valid.
  - Updated `propose_graduation_pr` to use the locator and return `literal_site_unresolved` (with the hint) when no unique literal site is found.
  - Added tests for single-site, ambiguity, hint precedence, test-dir pruning, and missing-flag cases.

<sup>Written for commit 5e02dc82a1a517d1d3426988b635d086621358aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

