### PR TITLE
feat(crucible): Immortal Cadence — JIT GH auth + GCS preemption-resume + cadence overlay

### DIFF
--- a/backend/core/ouroboros/governance/state_persistence_daemon.py
+++ b/backend/core/ouroboros/governance/state_persistence_daemon.py
@@ -88,6 +88,13 @@ def build_backup_commands(backend: str, src: str, target: str) -> List[List[str]
         return [["rsync", "-az", "--delete", f"{src.rstrip('/')}/", target]]
     if b == "s3":
         return [["aws", "s3", "sync", src, target, "--delete"]]
+    if b == "gcs":
+        # Sovereign Cognitive Crucible amnesia-proofing (2026-06-20): mirror the
+        # state dir to a GCS bucket so a preempted Spot node resumes its
+        # graduation ledger + soak history on restart. ``-m`` parallel, ``-r``
+        # recursive, ``-d`` prune remote deletions (mirror semantics, matching
+        # rsync/s3). The Spot VM's default compute SA authenticates via ADC.
+        return [["gsutil", "-m", "rsync", "-r", "-d", src.rstrip("/"), target]]
     if b == "git":
         # A self-contained git repo INSIDE src pushing to a private remote.
         msg = f"state-vault snapshot {int(time.time())}"

--- a/deploy/gcp_ouroboros_startup.sh
+++ b/deploy/gcp_ouroboros_startup.sh
@@ -57,25 +57,57 @@ else
 fi
 cd "$APP_DIR" || { echo "[ignition] FATAL: cannot cd $APP_DIR"; exit 1; }
 
-# ---- 3. Funded creds + pin from instance metadata → .env -------------------
+# ---- 3. Funded creds + pin + JIT GitHub token → .env -----------------------
 # Secrets travel as instance metadata (project-scoped, never in git/the image).
+# The GitHub token is the JIT Auth Vault: preferred source is Secret Manager
+# (gcloud secrets), falling back to instance metadata `jarvis-gh-token`. It lets
+# the Crucible push branches + open [SOVEREIGN GRADUATION] PRs with no human SSH.
 DW_KEY="$(meta jarvis-dw-api-key)"
 PIN="$(meta jarvis-dw-primary-override)"
+GH_TOK="$(gcloud secrets versions access latest --secret=github-token \
+  --project="${GCP_PROJECT:-jarvis-473803}" 2>/dev/null || true)"
+[ -z "$GH_TOK" ] && GH_TOK="$(meta jarvis-gh-token)"
 {
   [ -n "$DW_KEY" ] && echo "DOUBLEWORD_API_KEY=$DW_KEY"
-  # Pin override (optional): falls back to deploy/ouroboros_linux_prod.env default.
   [ -n "$PIN" ] && echo "JARVIS_DW_PRIMARY_OVERRIDE=$PIN"
+  # JIT GitHub auth — gh CLI + git both read GH_TOKEN; never logged (len only).
+  [ -n "$GH_TOK" ] && echo "GH_TOKEN=$GH_TOK"
+  [ -n "$GH_TOK" ] && echo "GITHUB_TOKEN=$GH_TOK"
 } > "$APP_DIR/.env"
 chmod 600 "$APP_DIR/.env"
-if [ -n "$DW_KEY" ]; then
-  echo "[ignition] .env written (DW key len=${#DW_KEY}, pin=${PIN:-<prod-env-default>})"
-else
-  echo "[ignition] WARNING: no jarvis-dw-api-key metadata — DW calls will 401"
-fi
+echo "[ignition] .env written (DW key len=${#DW_KEY}, pin=${PIN:-<default>}, gh_token len=${#GH_TOK})"
+[ -z "$DW_KEY" ] && echo "[ignition] WARNING: no jarvis-dw-api-key metadata — DW calls will 401"
+[ -z "$GH_TOK" ] && echo "[ignition] WARNING: no github-token secret / jarvis-gh-token metadata — graduation PRs cannot be pushed"
 mkdir -p "$APP_DIR/.jarvis"
 
-# ---- 4. Boot the Ouroboros soak container ----------------------------------
-echo "[ignition] docker compose up (prod + gcp overlay, --build)…"
-docker compose -f docker-compose.prod.yml -f docker-compose.gcp.yml up -d --build
-echo "🐍 [SovereignIgnition] $(date -u +%FT%TZ) container up — soak running."
+# ---- 3b. Amnesia-proofing: RESTORE .jarvis from GCS before boot ------------
+# A preempted Spot node restarts here (startup-script runs on every boot). Pull
+# the prior graduation ledger + soak history so the Crucible resumes its cadence
+# (e.g. interrupted at Soak 2 → continues at Soak 3) instead of starting over.
+# Fail-soft: an empty/absent bucket path is a no-op (fresh node).
+GCS_STATE="gs://jarvis-473803-deployments/crucible-state/.jarvis"
+if command -v gsutil >/dev/null 2>&1; then
+  echo "[ignition] restoring .jarvis from ${GCS_STATE} (resume) …"
+  gsutil -m rsync -r "$GCS_STATE" "$APP_DIR/.jarvis" 2>/dev/null \
+    && echo "[ignition] .jarvis restored from GCS" \
+    || echo "[ignition] no prior GCS state (fresh node) — starting clean"
+else
+  echo "[ignition] gsutil not present — skipping GCS restore"
+fi
+
+# ---- 4. Boot the container --------------------------------------------------
+# `jarvis-crucible-mode=true` metadata arms the autonomic graduation cadence
+# (crucible overlay: one soak at a time → propose PR → GCS sync). Absent/false
+# → the legacy perpetual-battle-test soak node (unchanged).
+CRUCIBLE="$(meta jarvis-crucible-mode)"
+if [ "$CRUCIBLE" = "true" ]; then
+  echo "[ignition] 🧬 CRUCIBLE MODE — arming the immortal graduation cadence…"
+  docker compose -f docker-compose.prod.yml -f docker-compose.gcp.yml \
+    -f docker-compose.crucible.yml up -d --build
+  echo "🧬 [SovereignIgnition] $(date -u +%FT%TZ) Crucible cadence armed."
+else
+  echo "[ignition] docker compose up (prod + gcp overlay, --build)…"
+  docker compose -f docker-compose.prod.yml -f docker-compose.gcp.yml up -d --build
+  echo "🐍 [SovereignIgnition] $(date -u +%FT%TZ) container up — soak running."
+fi
 echo "[ignition] monitor:  docker logs -f jarvis-sovereign-prod   (on the VM)"

--- a/docker-compose.crucible.yml
+++ b/docker-compose.crucible.yml
@@ -1,0 +1,52 @@
+# =============================================================================
+# Sovereign Cognitive Crucible overlay — the Immortal Graduation Cadence.
+#
+# Layered ON TOP of docker-compose.prod.yml + docker-compose.gcp.yml to convert
+# a node from "perpetual battle-test" into a "graduation cadence" node:
+#
+#   docker compose -f docker-compose.prod.yml \
+#                  -f docker-compose.gcp.yml \
+#                  -f docker-compose.crucible.yml up -d --build
+#
+# What it changes vs the GCP soak node:
+#   - entrypoint → scripts/crucible_cadence.sh (one soak at a time → propose PR
+#     → GCS sync → sleep), instead of a single perpetual battle-test.
+#   - turns ON the 7 graduation master flags (Crucible armed).
+#   - keeps SHADOW MODE ON (PR-proposes; no autonomous .env auto-flip — the
+#     Order-2 cage's human/OCA merge gate is preserved).
+#   - wires GCS amnesia-proofing (Evidence Vault gcs backend target) + the JIT
+#     GH token passthrough (read from .env, written by the startup script from
+#     instance metadata / Secret Manager — never in git, never in the image).
+# =============================================================================
+services:
+  jarvis-prod:
+    entrypoint: ["bash", "scripts/crucible_cadence.sh"]
+    command: []
+    environment:
+      # --- The 7 Crucible master flags (ARM the autonomic graduation loop) ---
+      JARVIS_GRADUATION_LEDGER_ENABLED: "true"
+      JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED: "true"
+      JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED: "true"
+      JARVIS_LIVE_FIRE_USE_GRADUATION_CONTRACT: "true"
+      JARVIS_LIVE_FIRE_TELEMETRY_ARBITER_ENABLED: "true"
+      JARVIS_PHASE9_ORCHESTRATOR_ENABLED: "true"
+      JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED: "true"
+      # Cage preserved: shadow mode ON → the override ledger never flips a flag
+      # in .env autonomously. The ONLY autonomous write surface is the
+      # source-of-truth [SOVEREIGN GRADUATION] PR (human/OCA merges it).
+      JARVIS_GRADUATION_SHADOW_MODE: "true"
+      # --- Amnesia-proofing: Evidence Vault → GCS (preemption resume) ---
+      JARVIS_STATE_BACKUP_ENABLED: "true"
+      JARVIS_BACKUP_BACKEND: "gcs"
+      JARVIS_BACKUP_TARGET: "gs://jarvis-473803-deployments/crucible-state/.jarvis"
+      JARVIS_BACKUP_SRC: "/app/.jarvis"
+      # --- TTFT/AST veto thresholds (env-tunable; defaults explicit) ---
+      JARVIS_CRUCIBLE_TTFT_CEILING_MS: "30000"
+      JARVIS_CRUCIBLE_TTFT_DEGRADE_RATIO: "1.5"
+      # --- Cadence tuning ---
+      JARVIS_CRUCIBLE_CADENCE_SLEEP_S: "30"
+      OUROBOROS_BATTLE_COST_CAP: "1.00"
+      OUROBOROS_BATTLE_MAX_WALL_SECONDS: "2400"
+      # GH_TOKEN flows in via env_file: .env (startup script writes it from
+      # instance metadata `jarvis-gh-token`). Declared here for visibility;
+      # the real value never lives in this file.

--- a/scripts/crucible_cadence.sh
+++ b/scripts/crucible_cadence.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# =============================================================================
+# Sovereign Cognitive Crucible — the Immortal Cadence loop (2026-06-20).
+#
+# Container entrypoint for a GRADUATION node (selected via docker-compose.
+# crucible.yml). Distinct from the perpetual-battle-test entrypoint: this runs
+# ONE live-fire graduation soak at a time so only a single battle-test ever
+# competes for budget/CPU (no contention), records its TTFT/AST evidence to the
+# bind-mounted .jarvis ledger, asks the autonomous graduation engine to propose
+# a [SOVEREIGN GRADUATION] PR for any flag whose 3 clean soaks cleared the math
+# veto, then aggressively syncs .jarvis to GCS so a Spot preemption resumes
+# exactly where it left off (amnesia-proofing).
+#
+# Loop per iteration:
+#   1. live_fire_graduation_soak.py run   → next pickable flag, ONE soak
+#   2. evaluate_graduations + execute_graduations → propose PR if eligible
+#   3. state-vault sync .jarvis → GCS (after EVERY soak, per spec)
+#   4. sleep JARVIS_CRUCIBLE_CADENCE_SLEEP_S (default 30s)
+#
+# Idempotent + fail-soft: any step's failure is logged and the loop continues.
+# The soak harness/engine are gated by the master flags set in the overlay.
+# =============================================================================
+set -uo pipefail
+cd /app || { echo "[crucible] FATAL: /app missing"; exit 1; }
+
+# Source .env (DW key, GH token, GCS target) — never echoed.
+if [[ -f /app/.env ]]; then set -a; source /app/.env; set +a; fi
+
+SLEEP_S="${JARVIS_CRUCIBLE_CADENCE_SLEEP_S:-30}"
+COST_CAP="${OUROBOROS_BATTLE_COST_CAP:-1.00}"
+WALL_CAP="${OUROBOROS_BATTLE_MAX_WALL_SECONDS:-2400}"
+TIMEOUT="${JARVIS_CRUCIBLE_SOAK_TIMEOUT_S:-2700}"
+
+echo "── 🧬 Sovereign Crucible Cadence ──────────────────────────────"
+echo "  cost_cap=\$${COST_CAP}  wall_cap=${WALL_CAP}s  sleep=${SLEEP_S}s"
+echo "  graduation_engine=${JARVIS_AUTONOMOUS_GRADUATION_ENGINE_ENABLED:-unset}"
+echo "  soak_harness=${JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED:-unset}"
+echo "  pr_gate=${JARVIS_CRUCIBLE_GRADUATION_PR_ENABLED:-unset}"
+echo "  gh_token=${GH_TOKEN:+present (masked)}"
+echo "  gcs_backup=${JARVIS_BACKUP_TARGET:-<none>} (backend=${JARVIS_BACKUP_BACKEND:-unset})"
+echo "───────────────────────────────────────────────────────────────"
+
+# git uses the JIT token for branch push (orange_pr_reviewer + gh CLI read GH_TOKEN).
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  git config --global credential.helper store 2>/dev/null || true
+  printf 'https://x-access-token:%s@github.com\n' "$GH_TOKEN" > ~/.git-credentials 2>/dev/null || true
+  chmod 600 ~/.git-credentials 2>/dev/null || true
+  git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/" 2>/dev/null || true
+fi
+
+_sync_state() {
+  # After EVERY soak: mirror .jarvis → GCS (fail-soft; preemption-resume input).
+  # Direct gsutil (one-shot) — same argv the Evidence Vault's `gcs` backend
+  # builds (build_backup_commands), but inline so the loop never blocks on a
+  # long-lived daemon. The Vault daemon/systemd path remains for non-cadence use.
+  if [[ -n "${JARVIS_BACKUP_TARGET:-}" ]]; then
+    gsutil -m rsync -r -d /app/.jarvis "${JARVIS_BACKUP_TARGET}" 2>/dev/null \
+      && echo "[crucible] state synced → ${JARVIS_BACKUP_TARGET}" \
+      || echo "[crucible] state sync failed (non-fatal)"
+  fi
+}
+
+_propose() {
+  # Ask the engine to evaluate eligible flags + propose source-of-truth PRs.
+  python3 - <<'PYEOF' 2>&1 | sed 's/^/[crucible] /' || true
+try:
+    from backend.core.ouroboros.governance.autonomous_graduation_engine import (
+        autonomous_graduation_engine_enabled, evaluate_graduations,
+        execute_graduations,
+    )
+    if autonomous_graduation_engine_enabled():
+        rep = evaluate_graduations()
+        res = execute_graduations(rep)
+        print("graduation pass: recorded=%s advised=%s"
+              % (getattr(res, "recorded_overrides", ()),
+                 getattr(res, "advisories_emitted", ())))
+    else:
+        print("graduation engine disabled — skipping propose")
+except Exception as exc:  # noqa: BLE001
+    print("propose pass error (non-fatal): %s" % exc)
+PYEOF
+}
+
+ITER=0
+while true; do
+  ITER=$((ITER + 1))
+  echo "🧬 [crucible] iteration ${ITER} $(date -u +%FT%TZ) — running one soak…"
+  python3 scripts/live_fire_graduation_soak.py run \
+    --cost-cap "${COST_CAP}" \
+    --max-wall-seconds "${WALL_CAP}" \
+    --timeout "${TIMEOUT}" \
+    --recorded-by crucible_cadence 2>&1 | sed 's/^/[soak] /' || \
+    echo "[crucible] soak run returned non-zero (non-fatal)"
+  _propose
+  _sync_state
+  echo "🧬 [crucible] iteration ${ITER} done — sleeping ${SLEEP_S}s"
+  sleep "${SLEEP_S}"
+done

--- a/scripts/ignite_sovereign_cloud_node.py
+++ b/scripts/ignite_sovereign_cloud_node.py
@@ -87,13 +87,29 @@ async def _ignite(args: argparse.Namespace) -> int:
         print("   --dry-run: config validated, NOT creating the VM.")
         return 0
 
+    md = {
+        "jarvis-dw-api-key": dw_key,
+        "jarvis-dw-primary-override": args.pin,
+    }
+    if args.crucible:
+        # Arm the autonomic graduation cadence (crucible overlay on the node).
+        md["jarvis-crucible-mode"] = "true"
+        print("   🧬 CRUCIBLE MODE — autonomic graduation cadence armed on boot")
+    # JIT GitHub auth: prefer Secret Manager `github-token` (the startup script
+    # reads it natively). Optionally pass a token through here as metadata
+    # fallback — NEVER printed, only length. A token is REQUIRED for the node to
+    # push [SOVEREIGN GRADUATION] PRs; without one the cadence soaks but cannot
+    # open PRs (it logs a clear warning).
+    gh_tok = os.environ.get("GH_TOKEN", "").strip()
+    if gh_tok:
+        md["jarvis-gh-token"] = gh_tok
+        print(f"   gh_token via metadata: {_mask(gh_tok)}")
+    else:
+        print("   gh_token: relying on Secret Manager `github-token` "
+              "(set GH_TOKEN env to pass via metadata instead)")
+
     mgr = GCPVMManager(cfg)
-    ok, result = await mgr.start_soak_vm(
-        extra_metadata={
-            "jarvis-dw-api-key": dw_key,
-            "jarvis-dw-primary-override": args.pin,
-        },
-    )
+    ok, result = await mgr.start_soak_vm(extra_metadata=md)
     if not ok:
         print(f"❌ ignition failed: {result}")
         return 1
@@ -115,6 +131,8 @@ def main() -> int:
     p.add_argument("--disk-gb", type=int, default=int(os.environ.get("GCP_BOOT_DISK_GB", "50")))
     p.add_argument("--max-hours", type=float, default=float(os.environ.get("GCP_MAX_VM_HOURS", "6")))
     p.add_argument("--dry-run", action="store_true", help="validate config, do not create the VM")
+    p.add_argument("--crucible", action="store_true",
+                   help="arm the autonomic Sovereign Cognitive Graduation Crucible cadence")
     args = p.parse_args()
     if str(_REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(_REPO_ROOT))

--- a/tests/architecture/test_slice138_state_persistence.py
+++ b/tests/architecture/test_slice138_state_persistence.py
@@ -42,6 +42,20 @@ class TestBuildCommand(unittest.TestCase):
         self.assertEqual(cmds[0][:3], ["aws", "s3", "sync"])
         self.assertIn("s3://my-vault/jarvis", cmds[0])
 
+    def test_gcs(self):
+        cmds = SP.build_backup_commands(
+            "gcs", ".jarvis", "gs://jarvis-473803-deployments/crucible-state",
+        )
+        self.assertEqual(len(cmds), 1)
+        self.assertEqual(cmds[0][:2], ["gsutil", "-m"])
+        self.assertIn("rsync", cmds[0])
+        self.assertIn("gs://jarvis-473803-deployments/crucible-state", cmds[0])
+        # mirror semantics: -d prunes remote deletions (matches rsync/s3 --delete)
+        self.assertIn("-d", cmds[0])
+
+    def test_gcs_empty_target_noop(self):
+        self.assertEqual(SP.build_backup_commands("gcs", ".jarvis", ""), [])
+
     def test_git_is_three_step(self):
         cmds = SP.build_backup_commands("git", ".jarvis", "origin")
         self.assertEqual(len(cmds), 3)            # add → commit → push


### PR DESCRIPTION
## Summary

Arms the Sovereign Cognitive Crucible for **unattended cloud ignition** with Spot-preemption resilience and zero human GitHub login. Builds on the merged Crucible (#69606/#69608).

1. **JIT GitHub Auth Vault** — `gcp_ouroboros_startup.sh` reads a GH token from Secret Manager `github-token` (preferred) → metadata `jarvis-gh-token` (fallback) → `.env` (chmod 600, length-only log). `env_file` passes it to the container; `gh` + `git` push branches + open `[SOVEREIGN GRADUATION]` PRs unattended.
2. **Spot-Preemption Resumption Matrix** — `state_persistence_daemon` gains a `gcs` backend (reuses the pluggable Evidence Vault); the startup script **restores `.jarvis` from GCS on every boot** before container-up (preempted at Soak 2 → resumes at Soak 3); `crucible_cadence.sh` syncs `.jarvis → GCS after every soak`.
3. **Cadence overlay** — `docker-compose.crucible.yml` + `crucible_cadence.sh`: one soak at a time (no battle-test contention) → propose PR → GCS sync → sleep. Sets the 7 master flags; **keeps shadow mode ON** (PR-proposes; Order-2 human/OCA merge gate preserved). `--crucible` ignite flag + `jarvis-crucible-mode` metadata.

## Safety / reuse
Cadence node is opt-in via metadata (legacy soak node unchanged). gcs backend reuses `build_backup_commands`. Shadow mode keeps the cage intact (no autonomous `.env` flip; the only autonomous write is the PR). All compose/bash validated; 13 state-persistence tests green.

## Test Plan
- [x] gcs backend + 13 state-persistence unit tests green
- [x] bash -n + docker compose config validate (3-file overlay)
- [x] ignite --crucible --dry-run validates
- [ ] Live: provision `--crucible` node → cadence soaks → GCS sync → first PR (needs `github-token` secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables unattended graduation cadence on GCP with JIT GitHub auth and spot-preemption resume via GCS. Adds a cadence overlay to run one soak at a time, propose PRs, and persist state safely.

- **New Features**
  - JIT GitHub auth: reads `github-token` from Secret Manager, then metadata `jarvis-gh-token`; writes `GH_TOKEN`/`GITHUB_TOKEN` to `.env` (600); configures `git` for unattended PRs.
  - GCS persistence: new `gcs` backend (`gsutil -m rsync -r -d`) and boot-time restore of `.jarvis`; cadence syncs to GCS after every soak.
  - Cadence overlay: `docker-compose.crucible.yml` + `scripts/crucible_cadence.sh` run one soak → evaluate/execute → propose `[SOVEREIGN GRADUATION]` PR → sync → sleep; keeps shadow mode on.
  - Ignite support: `--crucible` sets `jarvis-crucible-mode` metadata; optional `GH_TOKEN` passthrough.
  - Tests: adds GCS backup command tests; compose/bash validated.

- **Migration**
  - Store a repo-scoped token in Secret Manager as `github-token` (or pass `GH_TOKEN` to `ignite`; metadata fallback `jarvis-gh-token`).
  - Ensure a GCS bucket exists and the VM’s SA can `storage.objects.*`; default target is `gs://jarvis-473803-deployments/crucible-state/.jarvis` (override with `JARVIS_BACKUP_TARGET`).
  - Use `ignite ... --crucible` to arm the cadence; without it, legacy soak mode remains unchanged.

<sup>Written for commit c022bbb2e36df5f4ae9391e745f30b5d78b3ce48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

