### PR TITLE
fix(codegen): resolve repo_root ABSOLUTE — L2/batch relative_to crash on absolute target_files

### DIFF
--- a/backend/core/ouroboros/governance/multi_repo/registry.py
+++ b/backend/core/ouroboros/governance/multi_repo/registry.py
@@ -52,11 +52,19 @@ class RepoRegistry:
         """Build registry from environment variables."""
         configs: List[RepoConfig] = []
 
-        # Always include jarvis
-        jarvis_path = os.environ.get("JARVIS_REPO_PATH", ".")
+        # Always include jarvis. Normalize the env path to an ABSOLUTE, resolved
+        # root: a set-but-empty / whitespace var must NOT become ``Path("")``, and
+        # even ``.`` must be resolved — downstream codegen joins + relative_to over
+        # ABSOLUTE target_files require an absolute root (mirrors the strip+resolve
+        # pattern in session_archive / cursor_rule_guard). NEVER raises.
+        jarvis_path = (os.environ.get("JARVIS_REPO_PATH") or "").strip() or "."
+        try:
+            jarvis_local = Path(jarvis_path).resolve()
+        except Exception:  # noqa: BLE001
+            jarvis_local = Path.cwd().resolve()
         configs.append(RepoConfig(
             name="jarvis",
-            local_path=Path(jarvis_path),
+            local_path=jarvis_local,
             canary_slices=("tests/",),
         ))
 

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -1019,18 +1019,54 @@ def _serialize_attachments(
     return blocks
 
 
+def _abs_repo_root(candidate: "Optional[Path]") -> "Optional[Path]":
+    """Normalize a repo-root candidate to an ABSOLUTE, resolved path.
+
+    Returns ``None`` for an empty / whitespace / unusable candidate so the
+    caller can fall through to the next source. A relative candidate (``.``,
+    ``''``, ``foo``) is resolved against the CWD — this is the load-bearing
+    fix for the L2/batch codegen prompt: ``target_files`` arrive ABSOLUTE
+    (e.g. ``/app/tests/seed/test_seed_defect.py`` from pytest), so a relative
+    repo root makes ``Path.relative_to`` raise *"one path is relative and the
+    other is absolute"*. Resolving the root to an absolute path bridges that.
+    NEVER raises."""
+    if candidate is None:
+        return None
+    try:
+        s = str(candidate).strip()
+    except Exception:  # noqa: BLE001
+        return None
+    if not s:
+        return None
+    try:
+        return Path(s).resolve()
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _resolve_effective_repo_root(
     ctx: "OperationContext",
     repo_root: Optional[Path],
     repo_roots: Optional[Dict[str, Path]],
 ) -> Path:
-    """Resolve the filesystem root for the current operation context."""
-    base_root = repo_root or Path.cwd()
+    """Resolve the filesystem root for the current operation context.
+
+    INVARIANT: ALWAYS returns an ABSOLUTE, resolved path — never a relative or
+    empty one — so downstream ``relative_to`` / path-join over ABSOLUTE
+    ``target_files`` is well-defined. Resolution order (first usable wins):
+    per-op ``repo_roots[primary_repo]`` → passed ``repo_root`` → CWD. Each
+    candidate is normalized via :func:`_abs_repo_root`; an empty/relative
+    candidate is upgraded (resolved) rather than passed through. NEVER raises."""
     if repo_roots:
         primary_repo = getattr(ctx, "primary_repo", "")
         if primary_repo and primary_repo in repo_roots:
-            return Path(repo_roots[primary_repo])
-    return Path(base_root)
+            picked = _abs_repo_root(repo_roots[primary_repo])
+            if picked is not None:
+                return picked
+    picked = _abs_repo_root(repo_root)
+    if picked is not None:
+        return picked
+    return Path.cwd().resolve()
 
 # ── Tool-use interface ────────────────────────────────────────────────
 _TOOL_SCHEMA_VERSION = "2b.2-tool"

--- a/tests/governance/test_repo_root_resolution.py
+++ b/tests/governance/test_repo_root_resolution.py
@@ -1,0 +1,73 @@
+"""Regression: codegen repo-root resolution must be ABSOLUTE so relative_to over
+ABSOLUTE target_files never raises (L2/batch live bug, 2026-06-20).
+
+Trigger: repo_roots maps the primary repo to a RELATIVE path (Path('.') — the
+default when JARVIS_REPO_PATH is unset), while pytest emits ABSOLUTE failing-test
+paths (/app/tests/seed/test_seed_defect.py). _build_codegen_prompt did
+tfile.relative_to(repo_root) → ValueError "one path is relative and the other is
+absolute" → L2 repair quarantined the op as generate_error.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.core.ouroboros.governance.providers import (
+    _abs_repo_root,
+    _resolve_effective_repo_root,
+)
+
+
+class _Ctx:
+    primary_repo = "jarvis"
+
+
+def test_relative_repo_root_resolves_absolute():
+    # The exact live trigger: relative '.' root via repo_roots.
+    r = _resolve_effective_repo_root(_Ctx(), Path("."), {"jarvis": Path(".")})
+    assert r.is_absolute()
+    # And an absolute target file is now relativizable (the bug).
+    tfile = (Path.cwd() / "tests" / "seed" / "test_seed_defect.py")
+    assert tfile.relative_to(r) == Path("tests/seed/test_seed_defect.py")
+
+
+def test_empty_repo_root_falls_back_to_cwd():
+    r = _resolve_effective_repo_root(_Ctx(), Path(""), None)
+    assert r.is_absolute()
+    assert r == Path.cwd().resolve()
+
+
+def test_empty_path_in_repo_roots_resolves_to_cwd():
+    # pathlib normalizes Path("") -> Path(".") , so an empty/relative entry is a
+    # valid "use cwd" root (resolved absolute), NOT a fall-through. This is the
+    # exact live case (repo_roots[jarvis]=Path('.')) and it must yield cwd.
+    r = _resolve_effective_repo_root(_Ctx(), Path("/tmp"), {"jarvis": Path("")})
+    assert r.is_absolute()
+    assert r == Path.cwd().resolve()
+
+
+def test_valid_absolute_repo_roots_entry_wins():
+    r = _resolve_effective_repo_root(_Ctx(), Path("/other"), {"jarvis": Path("/repo")})
+    assert r == Path("/repo").resolve()
+
+
+def test_none_repo_root_no_map_is_cwd():
+    r = _resolve_effective_repo_root(_Ctx(), None, None)
+    assert r == Path.cwd().resolve()
+
+
+def test_abs_repo_root_helper():
+    # None falls through; a string-empty (defensive) falls through; a Path("")
+    # normalizes to "." → cwd (a valid relative root, resolved absolute).
+    assert _abs_repo_root(None) is None
+    assert _abs_repo_root("") is None            # type: ignore[arg-type]
+    assert _abs_repo_root("   ") is None         # type: ignore[arg-type]
+    assert _abs_repo_root(Path("")) == Path.cwd().resolve()
+    assert _abs_repo_root(Path(".")) == Path.cwd().resolve()
+    assert _abs_repo_root(Path("/x/y")) == Path("/x/y").resolve()
+
+
+def test_unknown_primary_repo_falls_through():
+    class C:
+        primary_repo = "not-in-map"
+    r = _resolve_effective_repo_root(C(), Path("/base"), {"jarvis": Path("/repo")})
+    assert r == Path("/base").resolve()


### PR DESCRIPTION
## Summary

Live-soak bug: L2 repair via the DW batch path quarantined ops as `generate_error`:
```
_build_codegen_prompt: tfile.relative_to(repo_root)
ValueError: '/app/tests/seed/test_seed_defect.py' is not in the subpath of '' OR one path is relative and the other is absolute.
```

**Root cause (confirmed on the live node):** `JARVIS_REPO_PATH` unset → `RepoRegistry` maps jarvis → `Path(".")` (relative), while pytest emits **absolute** failing-test paths. The codegen resolver passed the relative root straight through → `relative_to` over an absolute target raised → L2 generate_error → would **poison graduation evidence** (clean op → fault).

**Root fix (no call-site workaround):**
- `_resolve_effective_repo_root` + new `_abs_repo_root`: ALWAYS return an absolute, resolved root (repo_roots[primary] → repo_root → cwd; each normalized via strip + `resolve()`; relative/empty upgraded, never passed through). Single chokepoint → fixes the whole class.
- `RepoRegistry.from_env`: normalize `JARVIS_REPO_PATH` (strip+resolve) so the map holds absolute paths (defense-in-depth; mirrors session_archive/cursor_rule_guard).

No hardcoding, reuses the canonical resolver. 7 regression tests; pre-existing unrelated providers/codegen failures untouched.

## Test Plan
- [x] 7 new repo-root resolution tests green
- [x] live-trigger repro (relative '.' root + absolute target) now relativizes
- [x] pre-existing test failures confirmed unrelated (fail on unmodified tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in L2/batch codegen when `target_files` are absolute and the repo root is relative (unset `JARVIS_REPO_PATH`). Repo roots are now always resolved to absolute paths, preventing `relative_to` errors and avoid quarantining ops.

- **Bug Fixes**
  - `_resolve_effective_repo_root` now always returns an absolute, resolved path (`repo_roots[primary]` → `repo_root` → `cwd`).
  - Added `_abs_repo_root` to normalize candidates and never raise.
  - `RepoRegistry.from_env` strips and resolves `JARVIS_REPO_PATH` so the map holds absolute paths.
  - Added regression tests covering relative/empty roots and absolute targets.

<sup>Written for commit 84120ba4dc475aa5ea308ec0cf071545dcd37849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

