### PR TITLE
feat(autarky): Sovereign Autarky Backoff-Wait — wait out transient sole-provider backoff vs fail on absent fallback

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -109,6 +109,75 @@ def cascade_breaker_consult_enabled() -> bool:
     return raw in ("1", "true", "yes", "on")
 
 
+def autarky_backoff_wait_enabled() -> bool:
+    """Master switch for the Sovereign Autarky Backoff-Wait (2026-06-20).
+
+    Default TRUE — failure-path-only + autarky-only: it ONLY changes behavior
+    when (a) the sole-provider primary is in transient backoff AND (b) there is
+    NO fallback configured (DW-only mode). In every other state (fallback
+    present, primary healthy) it is byte-identical. Without it, a transient DW
+    TIMEOUT routes a STANDARD op to the absent Claude fallback and fails it with
+    ``fallback_skipped`` despite ample remaining budget to wait out the short
+    backoff and re-attempt the sole provider. Kill switch = pure rollback to the
+    legacy degrade-immediately path. NEVER raises."""
+    raw = (os.environ.get("JARVIS_AUTARKY_BACKOFF_WAIT_ENABLED", "true") or "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _autarky_backoff_max_wait_s() -> float:
+    """Hard cap on a SINGLE autarky backoff-wait (don't sleep absurdly long even
+    if budget allows). Env-tunable; defensive default 90s. NEVER raises."""
+    raw = (os.environ.get("JARVIS_AUTARKY_BACKOFF_MAX_WAIT_S", "") or "").strip()
+    try:
+        v = float(raw) if raw else 90.0
+        return v if v > 0 else 90.0
+    except (TypeError, ValueError):
+        return 90.0
+
+
+def _autarky_retry_margin_s() -> float:
+    """Budget that MUST remain AFTER the wait to attempt the primary call — so we
+    never burn the whole budget sleeping and then have nothing left to generate.
+    Env-tunable; defensive default 30s. NEVER raises."""
+    raw = (os.environ.get("JARVIS_AUTARKY_RETRY_MARGIN_S", "") or "").strip()
+    try:
+        v = float(raw) if raw else 30.0
+        return v if v > 0 else 30.0
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def autarky_should_wait_and_retry(
+    *,
+    has_fallback: bool,
+    enabled: bool,
+    eta_s: float,
+    remaining_s: float,
+    max_wait_s: float,
+    margin_s: float,
+) -> "Optional[float]":
+    """Pure decision: in DW-only autarky, should we WAIT out the sole provider's
+    transient backoff and re-attempt the primary (instead of routing to an absent
+    fallback)? Returns the bounded wait in seconds when yes, else ``None``.
+
+    Yes IFF: enabled AND no fallback AND a real positive backoff exists AND the
+    bounded wait + the post-wait call margin fit inside the remaining budget.
+    Pure + total — NEVER raises; trivially unit-testable."""
+    if not enabled or has_fallback:
+        return None
+    try:
+        if eta_s <= 0 or remaining_s <= 0:
+            return None
+        wait = min(float(eta_s), float(max_wait_s))
+        if wait <= 0:
+            return None
+        if wait + float(margin_s) < float(remaining_s):
+            return wait
+        return None
+    except (TypeError, ValueError):
+        return None
+
+
 def should_cascade_to_claude(
     *, has_fallback: bool, claude_breaker_open: bool, enabled: bool,
 ) -> bool:
@@ -5097,18 +5166,57 @@ class CandidateGenerator:
         # Dynamic fallback: skip a primary in active backoff.
         if not self.fsm.should_attempt_primary():
             _eta_s = max(0.0, self.fsm.recovery_eta() - time.monotonic())
-            logger.warning(
-                "[CandidateGenerator] Dynamic fallback engaged — primary "
-                "in %s backoff (consecutive_failures=%d, "
-                "recovery_eta=+%.0fs) — routing %s op to fallback "
-                "without re-attempting primary",
+            _mode_name = (
                 self.fsm._failure_mode.name
-                if self.fsm._failure_mode is not None else "UNKNOWN",
-                self.fsm._consecutive_failures,
-                _eta_s,
-                getattr(context, "provider_route", "?"),
+                if self.fsm._failure_mode is not None else "UNKNOWN"
             )
-            return await self._call_fallback(context, deadline)
+            # Sovereign Autarky Backoff-Wait (2026-06-20): in DW-only mode there
+            # is no fallback — routing to it is a guaranteed fallback_skipped
+            # failure. If the sole provider's transient backoff clears within our
+            # remaining budget, WAIT it out and re-attempt the primary instead of
+            # failing the op. Bounded to ONE wait-and-retry per dispatch: if the
+            # re-attempt also fails, control falls to the existing degrade path
+            # (record_primary_failure → _call_fallback → clean fallback_skipped),
+            # so a genuinely-dead provider self-limits and never loops.
+            _autarky_wait = autarky_should_wait_and_retry(
+                has_fallback=self._fallback is not None,
+                enabled=autarky_backoff_wait_enabled(),
+                eta_s=_eta_s,
+                remaining_s=self._remaining_seconds(deadline),
+                max_wait_s=_autarky_backoff_max_wait_s(),
+                margin_s=_autarky_retry_margin_s(),
+            )
+            if _autarky_wait is not None:
+                logger.info(
+                    "[CandidateGenerator] Sovereign autarky backoff-wait — sole "
+                    "provider %s in %s backoff (consecutive_failures=%d, "
+                    "eta=+%.0fs); waiting %.0fs then RE-ATTEMPTING primary "
+                    "(remaining_s=%.0f, route=%s) — no absent-fallback failure",
+                    self.fsm.primary_name if hasattr(self.fsm, "primary_name")
+                    else "primary",
+                    _mode_name, self.fsm._consecutive_failures, _eta_s,
+                    _autarky_wait, self._remaining_seconds(deadline),
+                    getattr(context, "provider_route", "?"),
+                )
+                try:
+                    await asyncio.sleep(_autarky_wait)
+                except asyncio.CancelledError:
+                    raise
+                # Fall through to the primary attempt below (do NOT route to the
+                # absent fallback). The backoff window has now elapsed, so
+                # should_attempt_primary() is True on the next FSM read.
+            else:
+                logger.warning(
+                    "[CandidateGenerator] Dynamic fallback engaged — primary "
+                    "in %s backoff (consecutive_failures=%d, "
+                    "recovery_eta=+%.0fs) — routing %s op to fallback "
+                    "without re-attempting primary",
+                    _mode_name,
+                    self.fsm._consecutive_failures,
+                    _eta_s,
+                    getattr(context, "provider_route", "?"),
+                )
+                return await self._call_fallback(context, deadline)
 
         try:
             # Slice 30 — explicit model_id propagation (no ContextVar magic)

--- a/tests/governance/test_autarky_backoff_wait.py
+++ b/tests/governance/test_autarky_backoff_wait.py
@@ -1,0 +1,89 @@
+"""Sovereign Autarky Backoff-Wait — pure decision tests (2026-06-20).
+
+Live bug: in DW-only autarky, a transient DW TIMEOUT (recovery_eta=+39s) routed a
+STANDARD op to the absent Claude fallback → fallback_skipped:no_fallback_configured
+EXHAUSTION, despite remaining_s=410 (ample budget to wait 39s + re-attempt DW).
+"""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.candidate_generator import (
+    autarky_backoff_wait_enabled,
+    autarky_should_wait_and_retry as W,
+    _autarky_backoff_max_wait_s,
+    _autarky_retry_margin_s,
+)
+
+
+def test_live_case_waits_out_transient_backoff():
+    # eta 39s, remaining 410s, no fallback, margin 30 → wait 39s + re-attempt.
+    assert W(has_fallback=False, enabled=True, eta_s=39, remaining_s=410,
+             max_wait_s=90, margin_s=30) == 39.0
+
+
+def test_fallback_present_never_waits():
+    # A real fallback exists → legacy route-to-fallback (None = don't wait).
+    assert W(has_fallback=True, enabled=True, eta_s=39, remaining_s=410,
+             max_wait_s=90, margin_s=30) is None
+
+
+def test_disabled_never_waits():
+    assert W(has_fallback=False, enabled=False, eta_s=39, remaining_s=410,
+             max_wait_s=90, margin_s=30) is None
+
+
+def test_eta_plus_margin_exceeds_budget_degrades():
+    # Not enough budget to wait AND still have margin to call → degrade (None).
+    assert W(has_fallback=False, enabled=True, eta_s=400, remaining_s=410,
+             max_wait_s=500, margin_s=30) is None
+
+
+def test_wait_capped_by_max_wait():
+    # eta 120 capped to 90; 90+30 < 410 → wait the cap.
+    assert W(has_fallback=False, enabled=True, eta_s=120, remaining_s=410,
+             max_wait_s=90, margin_s=30) == 90.0
+
+
+def test_capped_wait_still_budget_checked():
+    # eta 120 → cap 90, but 90+30 = 120 not < 110 → degrade.
+    assert W(has_fallback=False, enabled=True, eta_s=120, remaining_s=110,
+             max_wait_s=90, margin_s=30) is None
+
+
+def test_zero_or_negative_inputs_safe():
+    assert W(has_fallback=False, enabled=True, eta_s=0, remaining_s=410,
+             max_wait_s=90, margin_s=30) is None
+    assert W(has_fallback=False, enabled=True, eta_s=39, remaining_s=0,
+             max_wait_s=90, margin_s=30) is None
+
+
+def test_exact_boundary_is_strict_less_than():
+    # wait+margin must be STRICTLY less than remaining (reserve real call time).
+    # eta 40, margin 30 → 70; remaining exactly 70 → NOT < 70 → None.
+    assert W(has_fallback=False, enabled=True, eta_s=40, remaining_s=70,
+             max_wait_s=90, margin_s=30) is None
+    # remaining 70.1 → 70 < 70.1 → wait.
+    assert W(has_fallback=False, enabled=True, eta_s=40, remaining_s=70.1,
+             max_wait_s=90, margin_s=30) == 40.0
+
+
+def test_never_raises_on_garbage():
+    assert W(has_fallback=False, enabled=True, eta_s="x", remaining_s=410,  # type: ignore
+             max_wait_s=90, margin_s=30) is None
+
+
+def test_defaults():
+    assert autarky_backoff_wait_enabled() is True   # failure-path-only default-on
+    assert _autarky_backoff_max_wait_s() == 90.0
+    assert _autarky_retry_margin_s() == 30.0
+
+
+def test_env_overrides(monkeypatch):
+    monkeypatch.setenv("JARVIS_AUTARKY_BACKOFF_WAIT_ENABLED", "false")
+    assert autarky_backoff_wait_enabled() is False
+    monkeypatch.setenv("JARVIS_AUTARKY_BACKOFF_MAX_WAIT_S", "120")
+    assert _autarky_backoff_max_wait_s() == 120.0
+    monkeypatch.setenv("JARVIS_AUTARKY_RETRY_MARGIN_S", "15")
+    assert _autarky_retry_margin_s() == 15.0
+    # garbage → defensive default
+    monkeypatch.setenv("JARVIS_AUTARKY_BACKOFF_MAX_WAIT_S", "nonsense")
+    assert _autarky_backoff_max_wait_s() == 90.0


### PR DESCRIPTION
## Summary

Live-soak issue (pure-DW autarky): a transient DW TIMEOUT → 39s backoff → the FSM routed the STANDARD op to the **disabled** Claude fallback and failed it:
```
EXHAUSTION cause=fallback_skipped:no_fallback_configured fsm_failure_mode=TIMEOUT
primary=doubleword-397b fallback=none route=standard remaining_s=410
```
...despite **410s of budget** to wait the 39s backoff and re-attempt DW. Routing to an absent fallback is a guaranteed failure — and it poisons graduation evidence (turns a recoverable op into an exhaustion).

**Root fix** at the dispatch site: when the primary is in backoff **and** there's no fallback (autarky) **and** the backoff clears within remaining budget (with a post-wait call margin), **wait then re-attempt the primary** instead of routing to the absent fallback. **Bounded to one wait-and-retry** — if the re-attempt fails, the existing degrade path runs (so a genuinely-dead provider self-limits, never loops).

- pure `autarky_should_wait_and_retry(...)` (total, never-raises, unit-tested)
- env knobs (no hardcoding): `JARVIS_AUTARKY_BACKOFF_WAIT_ENABLED` (default true; failure-path + autarky-only → **byte-identical** when a fallback exists or primary healthy), `..._MAX_WAIT_S` (90s cap), `..._RETRY_MARGIN_S` (30s)
- reuses existing FSM (`should_attempt_primary`/`recovery_eta`) + `_remaining_seconds`; no new state machine

## Test Plan
- [x] 11 decision tests + 47 existing fallback tests green
- [x] 3 pre-existing admission-shed failures confirmed unrelated (fail on unmodified tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits out transient backoff for a sole provider in autarky and retries the primary when budget allows, instead of routing to a non-existent fallback and failing. This prevents false EXHAUSTIONs on short backoffs.

- **Bug Fixes**
  - Autarky backoff-wait: if the primary is in backoff, no fallback exists, and wait + margin fits in the remaining budget, wait up to a cap and retry once; otherwise follow the existing degrade path.
  - Controlled by env flags with safe defaults: JARVIS_AUTARKY_BACKOFF_WAIT_ENABLED (true), JARVIS_AUTARKY_BACKOFF_MAX_WAIT_S (90s), JARVIS_AUTARKY_RETRY_MARGIN_S (30s).
  - Reuses the existing FSM; legacy behavior is unchanged when a fallback exists or the primary is healthy. Added pure decision tests; existing fallback tests remain green.

<sup>Written for commit c97d1d3bb942fa70c45f8478a937a4dbd1186d5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

