### PR TITLE
fix(observability): BudgetSynth severity — autarky=DEBUG, breaker degradation=WARNING

### DIFF
--- a/backend/core/ouroboros/governance/provider_availability.py
+++ b/backend/core/ouroboros/governance/provider_availability.py
@@ -75,6 +75,29 @@ class ProviderAvailabilitySnapshot:
     dw_latency_p95_s: Optional[float] = None
 
 
+# Claude-lane unavailability reasons that are EXPECTED steady states — an
+# operator-attested configuration, not a degradation. Co-located with the reason
+# taxonomy (_resolve_claude) so the two never drift. Used by observability
+# consumers to pick the log SEVERITY: an expected state is forensic (DEBUG), an
+# abnormal one (breaker_open_*, half_open_probing) is actionable (WARNING).
+_EXPECTED_CLAUDE_UNAVAILABLE_REASONS: frozenset = frozenset({
+    "structurally_disabled",  # JARVIS_PROVIDER_CLAUDE_DISABLED — pure-DW autarky
+    "breaker_disabled",       # breaker not authoritative → lane assumed usable
+})
+
+
+def is_expected_unavailability(claude_reason: Optional[str]) -> bool:
+    """True iff a Claude-lane ``claude_reason`` denotes an EXPECTED, operator-
+    intended unavailability (e.g. structurally disabled in autarky) rather than
+    an ABNORMAL degradation (economic/transport breaker open, half-open probing).
+
+    Lets observability emit the budget-synthesis adaptation at the SEVERITY that
+    matches reality — steady-state autarky is not a warning. Pure; NEVER raises."""
+    if not claude_reason:
+        return False
+    return str(claude_reason).strip().lower() in _EXPECTED_CLAUDE_UNAVAILABLE_REASONS
+
+
 def _env_true(var: str) -> bool:
     return os.environ.get(var, "").strip().lower() in _TRUE_TOKENS
 

--- a/backend/core/ouroboros/governance/urgency_router.py
+++ b/backend/core/ouroboros/governance/urgency_router.py
@@ -764,17 +764,35 @@ class UrgencyRouter:
             route, snapshot, legacy, tool_loop_demanded=tool_loop_demanded,
         )
         if synthesized != legacy:
-            # §7 observability — make the dynamic allocation visible without grep.
-            logger.warning(
+            # §7 observability — make the dynamic allocation visible without grep,
+            # at the SEVERITY that matches reality. An EXPECTED unavailability
+            # (operator-attested autarky: claude structurally_disabled) is the
+            # intended steady state — forensic DEBUG, not a per-op WARNING that
+            # breeds alarm fatigue / inflates warning-count telemetry. An ABNORMAL
+            # unavailability (economic/transport breaker open, half-open probing)
+            # is a genuine fallback-lane degradation the operator should see →
+            # WARNING. Classification lives with the reason taxonomy (single
+            # source of truth, no drift).
+            _claude_reason = getattr(snapshot, "claude_reason", "?")
+            try:
+                from backend.core.ouroboros.governance.provider_availability import (
+                    is_expected_unavailability as _is_expected,
+                )
+                _expected = _is_expected(_claude_reason)
+            except Exception:  # noqa: BLE001 — never block routing on a log gate
+                _expected = False
+            _log = logger.debug if _expected else logger.warning
+            _log(
                 "[BudgetSynth] route=%s claude=unavailable:%s dw=%s tool_loop=%s "
-                "→ dw_wait=%.1fs tier0=%.2f reserve=%.1f",
+                "→ dw_wait=%.1fs tier0=%.2f reserve=%.1f%s",
                 getattr(route, "value", route),
-                getattr(snapshot, "claude_reason", "?"),
+                _claude_reason,
                 getattr(snapshot, "dw_reason", "?"),
                 tool_loop_demanded,
                 synthesized.get("max_dw_wait_s", 0.0),
                 synthesized.get("tier0_fraction", 0.0),
                 synthesized.get("tier1_reserve_s", 0.0),
+                " (expected/autarky)" if _expected else "",
             )
         return synthesized
 

--- a/tests/governance/test_expected_unavailability.py
+++ b/tests/governance/test_expected_unavailability.py
@@ -1,0 +1,48 @@
+"""BudgetSynth log-severity classification: expected (autarky) vs abnormal
+(breaker degradation). Live noise fix 2026-06-20 — claude=structurally_disabled
+was logged WARNING-per-op despite being the operator-intended steady state."""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.provider_availability import (
+    is_expected_unavailability,
+)
+
+
+def test_structurally_disabled_is_expected():
+    # Operator autarky (JARVIS_PROVIDER_CLAUDE_DISABLED) → not a warning.
+    assert is_expected_unavailability("structurally_disabled") is True
+
+
+def test_breaker_disabled_is_expected():
+    assert is_expected_unavailability("breaker_disabled") is True
+
+
+def test_economic_breaker_is_abnormal():
+    assert is_expected_unavailability("breaker_open_economic") is False
+    assert is_expected_unavailability("breaker_open_economic_persisted") is False
+
+
+def test_transport_breaker_is_abnormal():
+    assert is_expected_unavailability("breaker_open_transport") is False
+
+
+def test_generic_breaker_open_is_abnormal():
+    assert is_expected_unavailability("breaker_open") is False
+
+
+def test_half_open_probing_is_abnormal():
+    assert is_expected_unavailability("half_open_probing") is False
+
+
+def test_case_insensitive_and_whitespace():
+    assert is_expected_unavailability("  STRUCTURALLY_DISABLED  ") is True
+
+
+def test_empty_and_none_are_not_expected():
+    assert is_expected_unavailability("") is False
+    assert is_expected_unavailability(None) is False
+
+
+def test_unknown_reason_defaults_abnormal():
+    # An unrecognized reason errs toward WARNING (surface the unknown).
+    assert is_expected_unavailability("some_new_reason") is False


### PR DESCRIPTION
## Summary

Live soak logged at **WARNING on every standard op**:
```
[BudgetSynth] route=standard claude=unavailable:structurally_disabled dw=unknown → dw_wait=115.0s tier0=1.00 reserve=0.0
```
But `structurally_disabled` is the operator's **intended** pure-DW autarky — a healthy steady state, not a degradation. A WARNING-per-op for that breeds alarm fatigue and inflates warning-count telemetry (which the graduation harvester reads).

**Root fix — match severity to reality, don't suppress observability:**
- `provider_availability.is_expected_unavailability(reason)` — pure classifier co-located with the reason taxonomy (single source of truth). Expected: `structurally_disabled`/`breaker_disabled`. Abnormal: `breaker_open_*`, `half_open_probing` (real fallback-lane degradation; unknown reasons err abnormal).
- BudgetSynth log → **DEBUG when expected** (still in debug.log for forensics), **WARNING when abnormal** (operator must see a genuine degradation). Fail-soft import.

**Explicitly NOT silenced:** the rest of the dump (`AstCompileHelper outcome=ok`, `SemanticIndex disabled`, `GoalTracker`, `CommProtocol INTENT`) is healthy DEBUG/INFO observability — left intact per Manifesto §7.

No hardcoding; reuses existing taxonomy. 9 classifier + 72 budget/router tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes noisy BudgetSynth warnings by logging expected Claude autarky as DEBUG and reserving WARNING for real breaker degradations. This reduces alert fatigue and keeps warning telemetry accurate.

- Bug Fixes
  - Added `provider_availability.is_expected_unavailability()` to classify reasons: expected (`structurally_disabled`, `breaker_disabled`) vs abnormal (`breaker_open_*`, `half_open_probing`, unknown).
  - Updated `urgency_router` to choose log severity via the classifier and append "(expected/autarky)" when applicable; import is fail-soft to never block routing.
  - Added tests for classification, including unknown reasons and case/whitespace handling.

<sup>Written for commit 06353e9df16195715cb487b368dba3fba9da7251. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

