### PR TITLE
fix(observability): routine per-op adaptive decisions WARNING→INFO (autarky/hedge/capability)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -5408,6 +5408,7 @@ class CandidateGenerator:
             # runway instead of the 30s/75s reflex cap. Gated default-TRUE;
             # OFF (or breaker CLOSED) is the byte-identical legacy cascade.
             _fallback_dead = False
+            _autarky_reason = ""  # "structural" (expected) | "breaker_open" (abnormal)
             if _dw_autarky_enabled():
                 # A CONFIG-disabled Claude (JARVIS_PROVIDER_CLAUDE_DISABLED) is the
                 # deadest fallback of all — never constructed — yet it leaves the
@@ -5415,12 +5416,16 @@ class CandidateGenerator:
                 # Check it first so the sole-lane DW gets the full runway instead of
                 # the reflex cap (the live-soak TIMEOUT root, 2026-06-20).
                 _fallback_dead = _claude_config_disabled()
-                if not _fallback_dead:
+                if _fallback_dead:
+                    _autarky_reason = "structural"
+                else:
                     try:
                         from backend.core.ouroboros.governance.doubleword_provider import (
                             _claude_breaker_open as _autarky_breaker_open,
                         )
                         _fallback_dead = _autarky_breaker_open()
+                        if _fallback_dead:
+                            _autarky_reason = "breaker_open"
                     except Exception:  # noqa: BLE001 — fail-closed to legacy cascade
                         _fallback_dead = False
             primary_budget = self._compute_primary_budget(
@@ -5428,10 +5433,20 @@ class CandidateGenerator:
                 fallback_dead=_fallback_dead,
             )
             if _fallback_dead and primary_budget > _PRIMARY_MAX_TIMEOUT_S:
-                logger.warning(
+                # Severity matches reality: STRUCTURAL autarky (operator-attested
+                # JARVIS_PROVIDER_CLAUDE_DISABLED) is the intended steady state →
+                # INFO (observable, not alarming, no warning-count inflation). An
+                # actual breaker OPEN (economic/transport failures) is a real
+                # fallback-lane degradation → WARNING. The message now states the
+                # ACCURATE reason instead of always claiming "breaker OPEN".
+                _structural = _autarky_reason == "structural"
+                _emit = logger.info if _structural else logger.warning
+                _emit(
                     "[CandidateGenerator] ⚡ DW AUTARKY ENGAGED: Claude fallback "
-                    "breaker OPEN — granting DW the full %.1fs budget (vs %.1fs "
-                    "reflex cap), no dead-lane handoff. route=%s op=%s model=%s",
+                    "%s — granting DW the full %.1fs budget (vs %.1fs reflex cap), "
+                    "no dead-lane handoff. route=%s op=%s model=%s",
+                    "structurally disabled (autarky)" if _structural
+                    else "breaker OPEN (degraded)",
                     primary_budget, _PRIMARY_MAX_TIMEOUT_S,
                     getattr(context, "provider_route", "?"),
                     getattr(context, "op_id", "?")[:16],

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -2449,7 +2449,10 @@ class DoublewordProvider:
                     except Exception:  # noqa: BLE001 — fail-open to legacy race
                         _s227_prefer_fast = False
                 if _s227_prefer_fast:
-                    logger.warning(
+                    # INFO: a routine, by-design per-op routing decision (the hedge
+                    # governor preferring the RT/tool-loop arm for an Iron-Gate
+                    # exploration op). Observable, not actionable — not a WARNING.
+                    logger.info(
                         "[Cortex] ⚡ HEDGE GOVERNOR: op needs Iron-Gate "
                         "exploration — batch arm held speculative, RT arm (tool "
                         "loop) gets the slot unless it ruptures (op=%s)",
@@ -2919,7 +2922,10 @@ class DoublewordProvider:
             and str(_complexity).strip().lower() == "simple"
             and _s226_gate_demands(str(_complexity))
         ):
-            logger.warning(
+            # INFO: routine, by-design Iron-Gate enforcement (re-opening the Venom
+            # tool loop so a 'simple' op still meets the exploration floor).
+            # Observable adaptive behavior, not an actionable warning.
+            logger.info(
                 "[DoublewordProvider] ⚡ CAPABILITY ALIGNMENT: Iron Gate floor "
                 "demands exploration for a 'simple' op — re-opened the Venom "
                 "tool loop (read_file/search_code) the cost heuristic would "


### PR DESCRIPTION
Three ⚡ log sites WARNING-per-op for NORMAL by-design behavior (same class as #69613): DW AUTARKY ENGAGED (now INFO for structural autarky / WARNING for real breaker-open, + accurate message), HEDGE GOVERNOR → INFO, CAPABILITY ALIGNMENT → INFO. Cosmetic (log severity only). Healthy DEBUG/INFO telemetry left intact. Reuses existing reason signals; no hardcoding. 70 related tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce alert noise by downgrading three routine logs to INFO and making “DW AUTARKY ENGAGED” emit the correct severity and reason. No behavior change; telemetry stays the same.

- **Bug Fixes**
  - Candidate generator: “DW AUTARKY ENGAGED” is INFO when autarky is structural (config `JARVIS_PROVIDER_CLAUDE_DISABLED`), WARNING only when the breaker is open; message now states the right reason.
  - Doubleword provider: “HEDGE GOVERNOR” routing choice is now INFO.
  - Doubleword provider: “CAPABILITY ALIGNMENT” (Iron-Gate enforcement) is now INFO.

<sup>Written for commit 5b3519236aa8096665069aace3c2ec91b4311ec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

