### PR TITLE
fix(crucible): salvage completed soaks discarded as infra on post-summary cleanup hang

### DIFF
--- a/backend/core/ouroboros/governance/graduation/live_fire_soak.py
+++ b/backend/core/ouroboros/governance/graduation/live_fire_soak.py
@@ -126,6 +126,20 @@ def is_paused() -> bool:
     ).strip().lower() in _TRUTHY
 
 
+def _timeout_salvage_enabled() -> bool:
+    """Master for COMPLETED-WORK SALVAGE on subprocess timeout. Default TRUE —
+    failure-path-only: it ONLY engages when the subprocess exceeded its hard kill
+    cap AND a ``session_outcome=='complete'`` summary is already on disk (the
+    battle-test finished its work, then hung in cleanup). Without it, a soak that
+    completed cleanly but overran its post-summary cleanup window is discarded as
+    ``infra`` and never counts toward graduation — the live-soak blocker
+    (2026-06-20). Kill switch = pure rollback to the legacy discard. NEVER
+    raises."""
+    return os.environ.get(
+        "JARVIS_LIVE_FIRE_TIMEOUT_SALVAGE_ENABLED", "true",
+    ).strip().lower() in _TRUTHY
+
+
 # Debug-log capture bound (Sovereign Telemetry Unification, 2026-06-15).
 # The self-heal trajectory the Arbiter parses can span the whole log, so the
 # captured slice must be larger than the legacy 8KB tail — but still bounded
@@ -1553,16 +1567,52 @@ def _run_battle_test_subprocess(
     # Forward NTP skew during subprocess cannot move this; backward
     # skew is absorbed by _SESSION_DETECTION_GRACE_S below.
     start_wall_anchor = time.time()
-    proc = subprocess.run(
-        cmd,
-        cwd=str(project_root),
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=timeout_s,
-        check=False,
-    )
     sessions_root = project_root / ".ouroboros" / "sessions"
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(project_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        # COMPLETED-WORK SALVAGE (2026-06-20). The subprocess exceeded the hard
+        # kill cap — but the battle-test may have already FINISHED its work and
+        # written a terminal summary.json (stop_reason=wall_clock_cap), then hung
+        # in post-summary cleanup (e.g. leaked asyncio shutdown tasks —
+        # dw_discovery_refresh_loop / dw_heavy_probe_loop). A soak that finished
+        # its work must be GRADED ON ITS SUMMARY, not discarded as infra: the
+        # overrun was cleanup, not lost work. Read the session written during
+        # this run; if it carries session_outcome=='complete' (proof
+        # _generate_report ran fully), return it for normal grading. Only when no
+        # COMPLETE summary exists do we propagate the timeout (a genuine hang
+        # with no result). Gated; default-ON (failure-path-only). NEVER masks a
+        # real hang — requires a complete summary on disk.
+        if _timeout_salvage_enabled():
+            _salv_summary, _salv_tail = _read_most_recent_session(
+                sessions_root,
+                after_epoch=start_wall_anchor - _SESSION_DETECTION_GRACE_S,
+            )
+            if (
+                isinstance(_salv_summary, dict)
+                and str(_salv_summary.get("session_outcome", "")) == "complete"
+            ):
+                logger.warning(
+                    "[LiveFireSoak] subprocess exceeded %ss BUT a COMPLETE "
+                    "summary was written (stop_reason=%s, dur=%.0fs) — grading "
+                    "on the finished soak; the overrun was post-summary cleanup "
+                    "(leaked shutdown tasks), not lost work.",
+                    timeout_s, _salv_summary.get("stop_reason", "?"),
+                    float(_salv_summary.get("duration_s", 0.0) or 0.0),
+                )
+                # Synthetic exit 0 — the battle-test's own clean exit code had it
+                # not hung; downstream grades on the summary, not the code.
+                return (0, _salv_summary, _salv_tail)
+        # No complete summary → genuine hang; let the caller record the timeout.
+        raise
     summary, debug_tail = _read_most_recent_session(
         sessions_root,
         after_epoch=start_wall_anchor - _SESSION_DETECTION_GRACE_S,

--- a/tests/governance/test_timeout_salvage.py
+++ b/tests/governance/test_timeout_salvage.py
@@ -1,0 +1,131 @@
+"""Completed-work salvage on subprocess timeout (live-soak blocker, 2026-06-20).
+
+A graduation soak finished its work and wrote session_outcome=complete, then hung
+in post-summary cleanup (leaked asyncio shutdown tasks) until the hard subprocess
+kill cap → TimeoutExpired. Pre-fix, the harness discarded the COMPLETE summary
+and recorded outcome=infra → no soak ever counted clean. The salvage grades the
+finished soak on its real summary; a genuine hang (no complete summary) still
+propagates the timeout.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.graduation import live_fire_soak as LFS
+
+
+def _make_script(root: Path) -> None:
+    # _run_battle_test_subprocess early-returns -1 if the script is absent.
+    s = root / "scripts" / "ouroboros_battle_test.py"
+    s.parent.mkdir(parents=True, exist_ok=True)
+    s.write_text("# stub\n")
+
+
+def _write_session(root: Path, sid: str, outcome: str, stop_reason: str) -> None:
+    d = root / ".ouroboros" / "sessions" / sid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "summary.json").write_text(json.dumps({
+        "session_id": sid,
+        "session_outcome": outcome,
+        "stop_reason": stop_reason,
+        "duration_s": 2445.0,
+        "cost_total": 0.003,
+    }))
+    (d / "debug.log").write_text("phase=COMPLETE state=applied\n")
+
+
+def test_salvage_grades_complete_summary_on_timeout(tmp_path, monkeypatch):
+    _make_script(tmp_path)
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_TIMEOUT_SALVAGE_ENABLED", "true")
+    _write_session(tmp_path, "bt-complete", "complete", "wall_clock_cap")
+    # subprocess.run raises TimeoutExpired (process hung in cleanup after summary).
+    monkeypatch.setattr(
+        LFS.subprocess, "run",
+        lambda *a, **k: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(cmd="x", timeout=2700)
+        ),
+    )
+    # ensure the session mtime is >= the run anchor
+    exit_code, summary, _tail = LFS._run_battle_test_subprocess(
+        env={}, cost_cap_usd=1.0, max_wall_seconds=2400,
+        timeout_s=2700, project_root=tmp_path,
+    )
+    assert exit_code == 0
+    assert summary.get("session_outcome") == "complete"
+    assert summary.get("stop_reason") == "wall_clock_cap"
+
+
+def test_genuine_hang_no_complete_summary_propagates(tmp_path, monkeypatch):
+    _make_script(tmp_path)
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_TIMEOUT_SALVAGE_ENABLED", "true")
+    # An incomplete_kill summary is NOT salvageable (work didn't finish).
+    _write_session(tmp_path, "bt-killed", "incomplete_kill", "sigterm")
+    monkeypatch.setattr(
+        LFS.subprocess, "run",
+        lambda *a, **k: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(cmd="x", timeout=2700)
+        ),
+    )
+    with pytest.raises(subprocess.TimeoutExpired):
+        LFS._run_battle_test_subprocess(
+            env={}, cost_cap_usd=1.0, max_wall_seconds=2400,
+            timeout_s=2700, project_root=tmp_path,
+        )
+
+
+def test_no_summary_at_all_propagates(tmp_path, monkeypatch):
+    _make_script(tmp_path)
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_TIMEOUT_SALVAGE_ENABLED", "true")
+    monkeypatch.setattr(
+        LFS.subprocess, "run",
+        lambda *a, **k: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(cmd="x", timeout=2700)
+        ),
+    )
+    with pytest.raises(subprocess.TimeoutExpired):
+        LFS._run_battle_test_subprocess(
+            env={}, cost_cap_usd=1.0, max_wall_seconds=2400,
+            timeout_s=2700, project_root=tmp_path,
+        )
+
+
+def test_salvage_disabled_propagates_even_with_complete(tmp_path, monkeypatch):
+    _make_script(tmp_path)
+    monkeypatch.setenv("JARVIS_LIVE_FIRE_TIMEOUT_SALVAGE_ENABLED", "false")
+    _write_session(tmp_path, "bt-complete", "complete", "wall_clock_cap")
+    monkeypatch.setattr(
+        LFS.subprocess, "run",
+        lambda *a, **k: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(cmd="x", timeout=2700)
+        ),
+    )
+    with pytest.raises(subprocess.TimeoutExpired):
+        LFS._run_battle_test_subprocess(
+            env={}, cost_cap_usd=1.0, max_wall_seconds=2400,
+            timeout_s=2700, project_root=tmp_path,
+        )
+
+
+def test_salvage_default_enabled(monkeypatch):
+    monkeypatch.delenv("JARVIS_LIVE_FIRE_TIMEOUT_SALVAGE_ENABLED", raising=False)
+    assert LFS._timeout_salvage_enabled() is True
+
+
+def test_normal_exit_unaffected(tmp_path, monkeypatch):
+    # No timeout → legacy path: returns the real exit code + parsed summary.
+    _make_script(tmp_path)
+    _write_session(tmp_path, "bt-ok", "complete", "idle_timeout")
+
+    class _Proc:
+        returncode = 0
+    monkeypatch.setattr(LFS.subprocess, "run", lambda *a, **k: _Proc())
+    exit_code, summary, _ = LFS._run_battle_test_subprocess(
+        env={}, cost_cap_usd=1.0, max_wall_seconds=2400,
+        timeout_s=2700, project_root=tmp_path,
+    )
+    assert exit_code == 0
+    assert summary.get("session_outcome") == "complete"


### PR DESCRIPTION
## Summary

**The graduation blocker, found live.** A soak finished its work and wrote a clean `summary.json` (`session_outcome=complete`, `stop_reason=wall_clock_cap`, dur=2445s) — then **hung in post-summary cleanup** (leaked asyncio shutdown tasks `dw_discovery_refresh_loop` / `dw_heavy_probe_loop`) until the 2700s hard subprocess kill cap. `subprocess.run` raised `TimeoutExpired` **before** the harness read the on-disk summary → it recorded `session=unknown/infra` and **discarded the completed soak**.

Result: *every* soak grades `infra`, the clean count never climbs, the Crucible can never graduate. (Observed: `bt-2026-06-20-110623` — complete summary on disk, reported infra.)

**Root fix** (`_run_battle_test_subprocess`): on `TimeoutExpired`, still read the session written during the run; if `session_outcome=='complete'` (proof `_generate_report` ran fully), **grade on it** (synthetic exit 0) instead of discarding — the work finished, the overrun was cleanup. A genuine hang (no complete summary / `incomplete_kill`) still propagates the timeout. Gated `JARVIS_LIVE_FIRE_TIMEOUT_SALVAGE_ENABLED` (default true, failure-path-only).

No hardcoding; reuses `_read_most_recent_session`. 6 salvage + 109 live-fire-soak tests green.

Follow-up (non-blocking): the post-summary asyncio-leak cleanup hang itself (battle-test shutdown hygiene) wastes ~255s/soak.

## Test Plan
- [x] 6 salvage tests (complete→graded, incomplete_kill→propagate, no-summary→propagate, disabled→propagate, normal-exit unaffected)
- [x] 109 live-fire-soak tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Salvages completed live-fire soaks that hang during post-summary cleanup so they’re graded instead of discarded as infra. Unblocks graduation when cleanup overruns the subprocess timeout.

- **Bug Fixes**
  - On `TimeoutExpired`, read the most recent session and, if `session_outcome == "complete"`, return a synthetic exit 0 and grade on that summary.
  - Genuine hangs (no complete summary or `incomplete_kill`) still propagate the timeout.
  - Feature is gated by `JARVIS_LIVE_FIRE_TIMEOUT_SALVAGE_ENABLED` (default true); normal exits are unchanged.
  - Added targeted tests to cover complete-summary salvage, genuine hangs, disabled gate, default-on behavior, and normal exits.

<sup>Written for commit 81bff870b5fc41fd699bcec513498c98b8c91618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

