### PR TITLE
feat(crucible): Native GCS Vault + GracefulTeardownMatrix (true preemption-immortality)

### DIFF
--- a/backend/core/ouroboros/governance/dw_discovery_runner.py
+++ b/backend/core/ouroboros/governance/dw_discovery_runner.py
@@ -745,6 +745,44 @@ def get_heavy_probe_budget() -> Optional[Any]:
     return _get_or_create_heavy_probe_budget()
 
 
+async def shutdown_background_loops(*, timeout_s: float = 5.0) -> int:
+    """GracefulTeardownMatrix (2026-06-20) — cancel the DW background loops at
+    shutdown so they don't leak ("Task was destroyed but it is pending!") and
+    hang the process on their pending awaits (aiohttp connector timeouts) for
+    minutes. Production-safe shutdown counterpart to ``reset_boot_state_for_tests``
+    (cancels ONLY the two tasks; does NOT drop ledgers/singletons). Awaits the
+    cancellations with a hard bound so a stuck task cannot wedge teardown.
+    Returns the number of tasks cancelled. NEVER raises."""
+    global _REFRESH_TASK, _HEAVY_PROBE_TASK
+    cancelled = []
+    try:
+        for _t in (_REFRESH_TASK, _HEAVY_PROBE_TASK):
+            if _t is not None and not _t.done():
+                _t.cancel()
+                cancelled.append(_t)
+        if cancelled:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*cancelled, return_exceptions=True),
+                    timeout=max(0.1, float(timeout_s)),
+                )
+            except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+                # A task refused to yield within the bound — it's cancelled and
+                # will be GC'd; teardown proceeds regardless (the watchdog/forced
+                # exit is the final backstop). Never block shutdown.
+                pass
+        _REFRESH_TASK = None
+        _HEAVY_PROBE_TASK = None
+        if cancelled:
+            logger.info(
+                "[DWDiscovery] shutdown_background_loops: cancelled %d loop(s)",
+                len(cancelled),
+            )
+    except Exception as exc:  # noqa: BLE001 — teardown must never raise
+        logger.debug("[DWDiscovery] shutdown_background_loops swallowed: %s", exc)
+    return len(cancelled)
+
+
 def reset_boot_state_for_tests() -> None:
     """Test hook — clears the boot flag, cancels any refresh task,
     drops the ledger singletons. Production code MUST NOT call this."""

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1961,6 +1961,27 @@ class GovernedLoopService:
 
         self._state = ServiceState.STOPPING
 
+        # GracefulTeardownMatrix (2026-06-20) — cancel the DW discovery/heavy-probe
+        # background loops FIRST. Left pending they leak ("Task was destroyed but
+        # it is pending!") and wedge teardown for minutes on their aiohttp
+        # connector-timeout awaits (the live-soak post-summary 5-min hang). Bounded
+        # + fail-soft; never blocks shutdown.
+        try:
+            from backend.core.ouroboros.governance.dw_discovery_runner import (
+                shutdown_background_loops as _dw_shutdown_loops,
+            )
+            await _dw_shutdown_loops(timeout_s=5.0)
+        except Exception:  # noqa: BLE001 — teardown must never raise
+            pass
+        # Close the DW provider's aiohttp session so its connector doesn't linger
+        # waiting on a TCP timeout during teardown (reuses force_session_reset).
+        try:
+            _dw_ref = getattr(self, "_doubleword_ref", None)
+            if _dw_ref is not None and hasattr(_dw_ref, "force_session_reset"):
+                await asyncio.wait_for(_dw_ref.force_session_reset(), timeout=5.0)
+        except Exception:  # noqa: BLE001
+            pass
+
         # Slice 101 — publish session_end onto the cognitive bus before the
         # drain so observational subscribers can react. Fire-and-forget,
         # NEVER raises, inert unless JARVIS_COGNITIVE_BUS_ENABLED.

--- a/backend/core/ouroboros/governance/state_persistence_daemon.py
+++ b/backend/core/ouroboros/governance/state_persistence_daemon.py
@@ -89,12 +89,12 @@ def build_backup_commands(backend: str, src: str, target: str) -> List[List[str]
     if b == "s3":
         return [["aws", "s3", "sync", src, target, "--delete"]]
     if b == "gcs":
-        # Sovereign Cognitive Crucible amnesia-proofing (2026-06-20): mirror the
-        # state dir to a GCS bucket so a preempted Spot node resumes its
-        # graduation ledger + soak history on restart. ``-m`` parallel, ``-r``
-        # recursive, ``-d`` prune remote deletions (mirror semantics, matching
-        # rsync/s3). The Spot VM's default compute SA authenticates via ADC.
-        return [["gsutil", "-m", "rsync", "-r", "-d", src.rstrip("/"), target]]
+        # Native Asynchronous GCS Vault (2026-06-20): the ``gcs`` backend is
+        # handled by the NATIVE google-cloud-storage SDK path (``_gcs_sync_native``
+        # in ``run_once``), NOT a ``gsutil`` subprocess — the lean soak container
+        # has no gcloud CLI, only the Python SDK + ADC from the instance metadata
+        # server. Returning [] here signals "no argv; the native path owns gcs."
+        return []
     if b == "git":
         # A self-contained git repo INSIDE src pushing to a private remote.
         msg = f"state-vault snapshot {int(time.time())}"
@@ -104,6 +104,100 @@ def build_backup_commands(backend: str, src: str, target: str) -> List[List[str]
             ["git", "-C", src, "push", target, "HEAD"],
         ]
     return []
+
+
+# ---------------------------------------------------------------------------
+# Native GCS Vault — google-cloud-storage SDK, ADC from the instance metadata
+# server, thread-offloaded so it never blocks the event loop. No gsutil / CLI.
+# ---------------------------------------------------------------------------
+
+
+def _parse_gs_uri(target: str) -> "Optional[tuple]":
+    """``gs://bucket/prefix`` → ``(bucket, prefix)``. None if not a gs URI."""
+    t = (target or "").strip()
+    if not t.startswith("gs://"):
+        return None
+    rest = t[len("gs://"):]
+    if not rest:
+        return None
+    parts = rest.split("/", 1)
+    bucket = parts[0].strip()
+    prefix = (parts[1].strip("/") if len(parts) > 1 else "")
+    if not bucket:
+        return None
+    return (bucket, prefix)
+
+
+def _gcs_push_blocking(src: str, target: str) -> bool:
+    """Upload every file under ``src`` to ``gs://bucket/prefix`` via the native
+    SDK (ADC auto-inherited from the GCE metadata server). Append-only ledger →
+    upload-only (no destructive remote prune). Blocking; call via to_thread.
+    NEVER raises — returns False on any failure."""
+    try:
+        parsed = _parse_gs_uri(target)
+        if parsed is None:
+            logger.warning("[StateVault] gcs target not a gs:// URI: %s", _redact(target))
+            return False
+        bucket_name, prefix = parsed
+        if not os.path.isdir(src):
+            logger.warning("[StateVault] gcs src dir missing: %s", src)
+            return False
+        from google.cloud import storage  # lazy — SDK optional at import time
+        client = storage.Client()
+        bucket = client.bucket(bucket_name)
+        n = 0
+        for root, _dirs, files in os.walk(src):
+            for fn in files:
+                local = os.path.join(root, fn)
+                rel = os.path.relpath(local, src)
+                blob_name = f"{prefix}/{rel}" if prefix else rel
+                bucket.blob(blob_name).upload_from_filename(local)
+                n += 1
+        logger.info("[StateVault] native GCS push: %d files %s → %s",
+                    n, src, _redact(target))
+        return True
+    except Exception as exc:  # noqa: BLE001 — vault must never crash the soak
+        logger.warning("[StateVault] native GCS push failed: %s", exc)
+        return False
+
+
+def _gcs_pull_blocking(target: str, dest: str) -> bool:
+    """Download ``gs://bucket/prefix`` into ``dest`` via the native SDK (ADC).
+    Used for preemption-resume on boot. Blocking; call via to_thread. NEVER
+    raises — returns False on any failure (treated as 'fresh node')."""
+    try:
+        parsed = _parse_gs_uri(target)
+        if parsed is None:
+            return False
+        bucket_name, prefix = parsed
+        from google.cloud import storage  # lazy
+        client = storage.Client()
+        n = 0
+        for blob in client.list_blobs(bucket_name, prefix=prefix or None):
+            rel = blob.name[len(prefix):].lstrip("/") if prefix else blob.name
+            if not rel:
+                continue
+            local = os.path.join(dest, rel)
+            os.makedirs(os.path.dirname(local) or ".", exist_ok=True)
+            blob.download_to_filename(local)
+            n += 1
+        logger.info("[StateVault] native GCS pull: %d files %s → %s",
+                    n, _redact(target), dest)
+        return n > 0
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[StateVault] native GCS pull failed (fresh node): %s", exc)
+        return False
+
+
+async def gcs_push(src: str, target: str) -> bool:
+    """Async native GCS push — offloads the blocking SDK to a worker thread so
+    the caller's event loop is never blocked. NEVER raises."""
+    return await asyncio.to_thread(_gcs_push_blocking, src, target)
+
+
+async def gcs_pull(target: str, dest: str) -> bool:
+    """Async native GCS pull (preemption-resume). NEVER raises."""
+    return await asyncio.to_thread(_gcs_pull_blocking, target, dest)
 
 
 async def _default_runner(cmd: List[str]) -> int:
@@ -130,6 +224,17 @@ async def run_once(*, runner: Optional[_Runner] = None) -> bool:
         return False
     try:
         backend, src, target = _backend(), _src(), _target()
+        # Native GCS path — no CLI subprocess (the lean container has the SDK,
+        # not gsutil). Authenticates via ADC from the instance metadata server.
+        if backend == "gcs":
+            if not src or not target:
+                logger.debug("[StateVault] gcs no-op (src/target unset)")
+                return False
+            ok = await gcs_push(src, target)
+            if ok:
+                logger.info("[StateVault] backed up %s → %s (gcs-native)",
+                            src, _redact(target))
+            return ok
         cmds = build_backup_commands(backend, src, target)
         if not cmds:
             logger.debug("[StateVault] no-op (backend=%s target set=%s)",
@@ -177,7 +282,32 @@ async def run_forever(
 
 
 def _main() -> None:  # pragma: no cover — process entrypoint
+    """CLI:
+      (no args)   → continuous backup daemon (run_forever)
+      --once      → a single push now (used by the Crucible cadence after each soak)
+      --restore   → a single native GCS pull into JARVIS_BACKUP_SRC (boot resume)
+    The --once / --restore one-shots are gate-INDEPENDENT (the cadence decides
+    when to call them) so a master-off daemon flag doesn't block an explicit sync.
+    """
+    import sys
     logging.basicConfig(level=logging.INFO)
+    args = set(sys.argv[1:])
+    target, src = _target(), _src()
+    if "--restore" in args:
+        if _backend() == "gcs" and target:
+            ok = asyncio.run(gcs_pull(target, src))
+            logger.info("[StateVault] restore %s → %s ok=%s",
+                        _redact(target), src, ok)
+        else:
+            logger.info("[StateVault] --restore no-op (backend!=gcs or no target)")
+        return
+    if "--once" in args:
+        if _backend() == "gcs" and target:
+            ok = asyncio.run(gcs_push(src, target))
+        else:
+            ok = asyncio.run(run_once())
+        logger.info("[StateVault] --once push ok=%s", ok)
+        return
     if not state_backup_enabled():
         logger.warning("[StateVault] JARVIS_STATE_BACKUP_ENABLED not set — exiting")
         return
@@ -192,6 +322,9 @@ __all__ = [
     "build_backup_commands",
     "run_once",
     "run_forever",
+    "gcs_push",
+    "gcs_pull",
+    "_parse_gs_uri",
 ]
 
 

--- a/deploy/gcp_ouroboros_startup.sh
+++ b/deploy/gcp_ouroboros_startup.sh
@@ -80,20 +80,11 @@ echo "[ignition] .env written (DW key len=${#DW_KEY}, pin=${PIN:-<default>}, gh_
 [ -z "$GH_TOK" ] && echo "[ignition] WARNING: no github-token secret / jarvis-gh-token metadata — graduation PRs cannot be pushed"
 mkdir -p "$APP_DIR/.jarvis"
 
-# ---- 3b. Amnesia-proofing: RESTORE .jarvis from GCS before boot ------------
-# A preempted Spot node restarts here (startup-script runs on every boot). Pull
-# the prior graduation ledger + soak history so the Crucible resumes its cadence
-# (e.g. interrupted at Soak 2 → continues at Soak 3) instead of starting over.
-# Fail-soft: an empty/absent bucket path is a no-op (fresh node).
-GCS_STATE="gs://jarvis-473803-deployments/crucible-state/.jarvis"
-if command -v gsutil >/dev/null 2>&1; then
-  echo "[ignition] restoring .jarvis from ${GCS_STATE} (resume) …"
-  gsutil -m rsync -r "$GCS_STATE" "$APP_DIR/.jarvis" 2>/dev/null \
-    && echo "[ignition] .jarvis restored from GCS" \
-    || echo "[ignition] no prior GCS state (fresh node) — starting clean"
-else
-  echo "[ignition] gsutil not present — skipping GCS restore"
-fi
+# ---- 3b. Amnesia-proofing: RESTORE handled NATIVELY inside the container ----
+# Preemption-resume (pulling the prior .jarvis ledger from GCS) is done by the
+# Crucible cadence entrypoint (crucible_cadence.sh) via the NATIVE
+# google-cloud-storage SDK (ADC from the metadata server) BEFORE its first soak —
+# not here with a host gsutil. Single native source of truth; no CLI reliance.
 
 # ---- 4. Boot the container --------------------------------------------------
 # `jarvis-crucible-mode=true` metadata arms the autonomic graduation cadence

--- a/docker/requirements-soak.txt
+++ b/docker/requirements-soak.txt
@@ -64,3 +64,4 @@ networkx>=3.0
 # (47-byte rc=1) → no FAILED line → no TestFailure signal → the calibration seed
 # op never flowed → no state=applied. Pure-python, light. (2026-06-20)
 pytest>=7.4
+google-cloud-storage>=2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -308,6 +308,7 @@ google-cloud-secret-manager>=2.20.0
 
 # GCP Compute Engine (for Spot VM auto-creation)
 google-cloud-compute>=1.40.0
+google-cloud-storage>=2.10.0
 
 # GCP Monitoring API (for real VM CPU metrics -- hypervisor-level, no agent needed)
 google-cloud-monitoring>=2.0.0

--- a/scripts/crucible_cadence.sh
+++ b/scripts/crucible_cadence.sh
@@ -49,14 +49,15 @@ if [[ -n "${GH_TOKEN:-}" ]]; then
 fi
 
 _sync_state() {
-  # After EVERY soak: mirror .jarvis → GCS (fail-soft; preemption-resume input).
-  # Direct gsutil (one-shot) — same argv the Evidence Vault's `gcs` backend
-  # builds (build_backup_commands), but inline so the loop never blocks on a
-  # long-lived daemon. The Vault daemon/systemd path remains for non-cadence use.
+  # After EVERY soak: push .jarvis → GCS via the NATIVE google-cloud-storage SDK
+  # (ADC from the instance metadata server) — NOT gsutil, which the lean soak
+  # container does not ship. Fail-soft; the push is the preemption-resume input.
   if [[ -n "${JARVIS_BACKUP_TARGET:-}" ]]; then
-    gsutil -m rsync -r -d /app/.jarvis "${JARVIS_BACKUP_TARGET}" 2>/dev/null \
-      && echo "[crucible] state synced → ${JARVIS_BACKUP_TARGET}" \
-      || echo "[crucible] state sync failed (non-fatal)"
+    if python3 -m backend.core.ouroboros.governance.state_persistence_daemon --once 2>&1 | sed 's/^/[vault] /'; then
+      echo "[crucible] state pushed → ${JARVIS_BACKUP_TARGET} (native SDK)"
+    else
+      echo "[crucible] state push failed (non-fatal)"
+    fi
   fi
 }
 
@@ -80,6 +81,15 @@ except Exception as exc:  # noqa: BLE001
     print("propose pass error (non-fatal): %s" % exc)
 PYEOF
 }
+
+# Preemption-RESUME: before the first soak, pull the prior .jarvis ledger from
+# GCS via the native SDK (a re-ignited node continues mid-cadence instead of
+# starting over). Fail-soft — a fresh node with no prior state is a clean start.
+if [[ -n "${JARVIS_BACKUP_TARGET:-}" ]]; then
+  echo "🧬 [crucible] native GCS restore (preemption-resume) from ${JARVIS_BACKUP_TARGET}…"
+  python3 -m backend.core.ouroboros.governance.state_persistence_daemon --restore 2>&1 | sed 's/^/[vault] /' || \
+    echo "[crucible] restore no-op (fresh node)"
+fi
 
 ITER=0
 while true; do

--- a/tests/architecture/test_slice138_state_persistence.py
+++ b/tests/architecture/test_slice138_state_persistence.py
@@ -42,19 +42,28 @@ class TestBuildCommand(unittest.TestCase):
         self.assertEqual(cmds[0][:3], ["aws", "s3", "sync"])
         self.assertIn("s3://my-vault/jarvis", cmds[0])
 
-    def test_gcs(self):
+    def test_gcs_is_native_no_argv(self):
+        # Native GCS Vault (2026-06-20): gcs is handled by the native SDK path,
+        # NOT a gsutil subprocess — build_backup_commands returns [] (no CLI).
         cmds = SP.build_backup_commands(
             "gcs", ".jarvis", "gs://jarvis-473803-deployments/crucible-state",
         )
-        self.assertEqual(len(cmds), 1)
-        self.assertEqual(cmds[0][:2], ["gsutil", "-m"])
-        self.assertIn("rsync", cmds[0])
-        self.assertIn("gs://jarvis-473803-deployments/crucible-state", cmds[0])
-        # mirror semantics: -d prunes remote deletions (matches rsync/s3 --delete)
-        self.assertIn("-d", cmds[0])
+        self.assertEqual(cmds, [])
 
-    def test_gcs_empty_target_noop(self):
-        self.assertEqual(SP.build_backup_commands("gcs", ".jarvis", ""), [])
+    def test_parse_gs_uri(self):
+        self.assertEqual(
+            SP._parse_gs_uri("gs://bucket/crucible-state/.jarvis"),
+            ("bucket", "crucible-state/.jarvis"),
+        )
+        self.assertEqual(SP._parse_gs_uri("gs://bucket"), ("bucket", ""))
+        self.assertEqual(SP._parse_gs_uri("gs://bucket/"), ("bucket", ""))
+        self.assertIsNone(SP._parse_gs_uri("s3://bucket/x"))
+        self.assertIsNone(SP._parse_gs_uri(""))
+        self.assertIsNone(SP._parse_gs_uri("gs://"))
+
+    def test_gcs_push_failsoft_bad_uri(self):
+        # Non-gs target → False, never raises (no SDK call attempted).
+        self.assertFalse(SP._gcs_push_blocking(".", "not-a-uri"))
 
     def test_git_is_three_step(self):
         cmds = SP.build_backup_commands("git", ".jarvis", "origin")

--- a/tests/governance/test_teardown_matrix.py
+++ b/tests/governance/test_teardown_matrix.py
@@ -1,0 +1,78 @@
+"""GracefulTeardownMatrix — DW background-loop cancellation at shutdown
+(post-summary 5-min hang fix, 2026-06-20)."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import dw_discovery_runner as DWR
+
+
+async def _never():
+    # A loop that would hang forever if not cancelled.
+    try:
+        await asyncio.sleep(3600)
+    except asyncio.CancelledError:
+        raise
+
+
+async def test_shutdown_cancels_pending_loops(monkeypatch):
+    t1 = asyncio.ensure_future(_never())
+    t2 = asyncio.ensure_future(_never())
+    monkeypatch.setattr(DWR, "_REFRESH_TASK", t1, raising=False)
+    monkeypatch.setattr(DWR, "_HEAVY_PROBE_TASK", t2, raising=False)
+    n = await DWR.shutdown_background_loops(timeout_s=2.0)
+    assert n == 2
+    assert t1.cancelled() and t2.cancelled()
+    # Module refs cleared so a second call is a clean no-op.
+    assert DWR._REFRESH_TASK is None
+    assert DWR._HEAVY_PROBE_TASK is None
+
+
+async def test_shutdown_noop_when_no_loops(monkeypatch):
+    monkeypatch.setattr(DWR, "_REFRESH_TASK", None, raising=False)
+    monkeypatch.setattr(DWR, "_HEAVY_PROBE_TASK", None, raising=False)
+    assert await DWR.shutdown_background_loops() == 0
+
+
+async def test_shutdown_skips_already_done(monkeypatch):
+    done = asyncio.ensure_future(asyncio.sleep(0))
+    await done
+    monkeypatch.setattr(DWR, "_REFRESH_TASK", done, raising=False)
+    monkeypatch.setattr(DWR, "_HEAVY_PROBE_TASK", None, raising=False)
+    assert await DWR.shutdown_background_loops() == 0
+
+
+async def test_shutdown_bounded_when_task_slow_to_cancel(monkeypatch):
+    # A task whose cancellation cleanup is SLOW must not wedge teardown past the
+    # bound — the function returns within ~timeout_s, not the cleanup duration.
+    # (Killable, so pytest's loop teardown doesn't hang.)
+    async def _slow_to_cancel():
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            await asyncio.sleep(1.5)  # slow cleanup, but eventually yields
+            raise
+    t = asyncio.ensure_future(_slow_to_cancel())
+    await asyncio.sleep(0)  # let it start
+    monkeypatch.setattr(DWR, "_REFRESH_TASK", t, raising=False)
+    monkeypatch.setattr(DWR, "_HEAVY_PROBE_TASK", None, raising=False)
+    import time
+    s = time.monotonic()
+    n = await asyncio.wait_for(
+        DWR.shutdown_background_loops(timeout_s=0.3), timeout=3.0,
+    )
+    elapsed = time.monotonic() - s
+    assert n == 1
+    assert elapsed < 1.2  # returned on the bound, NOT after the 1.5s cleanup
+
+
+async def test_never_raises_on_garbage(monkeypatch):
+    class _Bad:
+        def done(self):
+            raise RuntimeError("boom")
+    monkeypatch.setattr(DWR, "_REFRESH_TASK", _Bad(), raising=False)
+    monkeypatch.setattr(DWR, "_HEAVY_PROBE_TASK", None, raising=False)
+    # Swallows the error; returns a count (0 here) without raising.
+    assert await DWR.shutdown_background_loops() == 0


### PR DESCRIPTION
## Summary

Closes the two gaps that made the cadence *not* actually immortal and wasteful.

### 1. Native GCS Vault (no `gsutil`)
The prior amnesia-proofing called `gsutil` **inside the lean soak container** — which has no gcloud CLI → `state sync failed`, nothing persisted, every Spot preemption wiped the ledger. Now native:
- `state_persistence_daemon`: gcs backend uses the **`google-cloud-storage` SDK** with **ADC auto-inherited from the GCE metadata server**; `_gcs_push/_gcs_pull` offloaded via `asyncio.to_thread` (never blocks the loop); `--once`/`--restore` CLI.
- `crucible_cadence.sh`: native `--restore` (preemption-resume) before the first soak; native `--once` push after every soak.
- startup script: dropped the host `gsutil` restore (container owns it natively).
- `google-cloud-storage` added to requirements; compute SA granted `storage.objectAdmin` on the bucket.

### 2. GracefulTeardownMatrix (kill the ~5-min hang)
Root cause: the DW background loops (`dw_discovery_refresh_loop` / `dw_heavy_probe_loop`) leaked and wedged on aiohttp connector-timeout awaits after summary write.
- `dw_discovery_runner.shutdown_background_loops(timeout_s=5)`: cancels both loops with a **hard `asyncio.wait_for` bound** (a stuck task can't wedge teardown); never raises.
- `GLS.stop()` calls it **first** + closes the DW aiohttp session (`force_session_reset`, wait_for-bounded) before the drain — eliminating the hang at its source.

Reuse-first; no in-container CLI, no image bloat. 14 vault + 5 teardown tests green; teardown also validated directly.

## Test Plan
- [x] 14 native-vault tests (parse, fail-soft, gcs-native-no-argv)
- [x] 5 teardown tests (cancels loops, no-op, bounded under slow-cancel) + direct validation
- [ ] Live: re-ignite → native GCS push/pull works in-container; soak exits promptly (no 5-min hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native GCS state vault using `google-cloud-storage` and fixes teardown hangs by cancelling DW background loops. The cadence now resumes after preemption and exits promptly without the 5‑minute delay.

- **New Features**
  - Native GCS vault (no `gsutil`): `state_persistence_daemon` uses `google-cloud-storage` (ADC), with async `gcs_push`/`gcs_pull` and `--once`/`--restore` CLI.
  - Cadence integration: `crucible_cadence.sh` runs `--restore` before the first soak and `--once` after each soak; startup script drops host-side restore; `build_backup_commands('gcs')` returns [].
  - Dependencies: add `google-cloud-storage` to `requirements.txt` and `docker/requirements-soak.txt`.

- **Bug Fixes**
  - Graceful teardown: new `shutdown_background_loops(timeout_s=5)` cancels DW discovery/heavy-probe loops with a hard bound; `GLS.stop()` calls it first and closes the DW aiohttp session.
  - Tests: add native vault parsing/fail-soft tests and teardown matrix tests (cancelation, no-op, bounded under slow-cancel).

<sup>Written for commit 1986ebfbc5e9347841bc413d00d9bbf5d89f79e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

