### PR TITLE
feat(crucible): autonomous fleet health quarantine + Aegis session-lifecycle fix

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -109,6 +109,17 @@ def cascade_breaker_consult_enabled() -> bool:
     return raw in ("1", "true", "yes", "on")
 
 
+def _latency_quarantine_enabled() -> bool:
+    """Master for the cold-storage latency quarantine at the DW selector seam.
+    Default TRUE — failure-path-only: it only skips a model the TtftObserver has
+    flagged as COLD_STORAGE (a real TTFT spike) AND only when another candidate
+    remains. When the observer is absent/disabled it short-circuits, so this is a
+    free no-op unless there's positive latency evidence. =0 reverts to the legacy
+    (entitlement-breaker-only) selection. NEVER raises."""
+    raw = (os.environ.get("JARVIS_DW_LATENCY_QUARANTINE_ENABLED", "true") or "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
 def autarky_backoff_wait_enabled() -> bool:
     """Master switch for the Sovereign Autarky Backoff-Wait (2026-06-20).
 
@@ -3653,6 +3664,30 @@ class CandidateGenerator:
                 )
                 attempts.append(f"{model_id}:skipped_{state.lower()}")
                 continue
+            # Latency quarantine (2026-06-20): the entitlement breaker (above)
+            # bans 403'd models; this bans models the TtftObserver has flagged as
+            # COLD STORAGE (latest TTFT > mean + Nσ — weights evicted from VRAM →
+            # the 180s-timeout black hole). Reuses the existing observer; only
+            # skips when there's at least one OTHER candidate left to try (never
+            # quarantines the sole remaining model into a no-op). Gated on the
+            # observer's own master flag; fail-open (never blocks dispatch).
+            if _latency_quarantine_enabled() and model_id != ranked_models[-1]:
+                try:
+                    from backend.core.ouroboros.governance.dw_ttft_observer import (
+                        get_ttft_observer as _get_ttft_obs,
+                    )
+                    _obs = _get_ttft_obs()
+                    if _obs is not None and _obs.is_cold_storage(model_id):
+                        logger.info(
+                            "[CandidateGenerator] Latency quarantine: route=%s "
+                            "model=%s COLD_STORAGE (TTFT spike) — skipping to a "
+                            "warmer candidate (op=%s)",
+                            provider_route, model_id, op_id_short,
+                        )
+                        attempts.append(f"{model_id}:skipped_cold_storage")
+                        continue
+                except Exception:  # noqa: BLE001 — observer must never block dispatch
+                    pass
             # Slice 20C — schema drift rotation. If this model has
             # produced a structurally-bad output earlier in this same
             # op (json_parse_error_after_heal / schema_id_hallucination

--- a/backend/core/ouroboros/governance/graduation/live_fire_soak.py
+++ b/backend/core/ouroboros/governance/graduation/live_fire_soak.py
@@ -1166,6 +1166,16 @@ class LiveFireSoakHarness:
         subprocess but the dispatcher never entered its branch).
         """
         env = dict(os.environ)
+        # Aegis Session Lifecycle fix (2026-06-20): each forked battle-test runs
+        # its OWN aegis_preflight, which spawns a FRESH daemon + mints a FRESH
+        # SINGLE-USE bootstrap PSK + a fresh ephemeral daemon URL. Inheriting the
+        # PARENT's (already-consumed) JARVIS_AEGIS_BOOTSTRAP_PSK / stale
+        # JARVIS_AEGIS_URL makes the fork's session/establish hit a consumed PSK
+        # (403 psk_already_consumed) or talk to a dead daemon URL → pre-forward
+        # lease 403 → generation never reaches DW. Strip them so every fork
+        # bootstraps aegis CLEANLY; the fork's own preflight repopulates both.
+        for _stale in ("JARVIS_AEGIS_BOOTSTRAP_PSK", "JARVIS_AEGIS_URL"):
+            env.pop(_stale, None)
         env[flag_name] = "true"
         for dep in get_dependencies(flag_name):
             env[dep] = "true"

--- a/docker-compose.crucible.yml
+++ b/docker-compose.crucible.yml
@@ -43,6 +43,15 @@ services:
       # --- TTFT/AST veto thresholds (env-tunable; defaults explicit) ---
       JARVIS_CRUCIBLE_TTFT_CEILING_MS: "30000"
       JARVIS_CRUCIBLE_TTFT_DEGRADE_RATIO: "1.5"
+      # --- Autonomous Fleet Latency & Entitlement Discovery (Layer 2) ---
+      # Arm the topology sentinel so entitlement_blocked (403) models flip to
+      # TERMINAL_OPEN and the selector EXCLUDES them; arm the heavy probe so it
+      # autonomously discovers entitlement/latency health BEFORE generation
+      # dispatches to a dead/slow model. Latency quarantine (cold-storage skip)
+      # is default-on in code. No hardcoded model whitelist — the fleet adapts.
+      JARVIS_TOPOLOGY_SENTINEL_ENABLED: "true"
+      JARVIS_TOPOLOGY_HEAVY_PROBE_ENABLED: "true"
+      JARVIS_DW_LATENCY_QUARANTINE_ENABLED: "true"
       # --- Cadence tuning ---
       JARVIS_CRUCIBLE_CADENCE_SLEEP_S: "30"
       OUROBOROS_BATTLE_COST_CAP: "1.00"

--- a/tests/governance/test_fleet_health_and_aegis_lifecycle.py
+++ b/tests/governance/test_fleet_health_and_aegis_lifecycle.py
@@ -1,0 +1,56 @@
+"""Autonomous Fleet Latency/Entitlement Discovery + Aegis session-lifecycle fixes
+(2026-06-20). Layer 1: forked soaks must not inherit a consumed aegis PSK. Layer 2:
+the DW selector must skip cold-storage (latency) models, not just entitlement-banned.
+"""
+from __future__ import annotations
+
+import os
+
+from backend.core.ouroboros.governance.candidate_generator import (
+    _latency_quarantine_enabled,
+)
+from backend.core.ouroboros.governance.graduation.live_fire_soak import (
+    get_default_harness,
+)
+
+
+# ── Layer 1: aegis env-strip per fork ───────────────────────────────────────
+
+def test_forked_env_strips_stale_aegis_psk_and_url(monkeypatch):
+    monkeypatch.setenv("JARVIS_AEGIS_BOOTSTRAP_PSK", "STALE_CONSUMED")
+    monkeypatch.setenv("JARVIS_AEGIS_URL", "http://dead-daemon:9999")
+    env = get_default_harness()._build_env_for_flag("JARVIS_CURIOSITY_ENGINE_ENABLED")
+    # Each fork bootstraps aegis cleanly via its own preflight.
+    assert "JARVIS_AEGIS_BOOTSTRAP_PSK" not in env
+    assert "JARVIS_AEGIS_URL" not in env
+    # ...but the target flag + harness masters are still set.
+    assert env["JARVIS_CURIOSITY_ENGINE_ENABLED"] == "true"
+    assert env["JARVIS_LIVE_FIRE_GRADUATION_SOAK_ENABLED"] == "true"
+
+
+def test_forked_env_clean_when_no_stale_aegis(monkeypatch):
+    monkeypatch.delenv("JARVIS_AEGIS_BOOTSTRAP_PSK", raising=False)
+    monkeypatch.delenv("JARVIS_AEGIS_URL", raising=False)
+    env = get_default_harness()._build_env_for_flag("JARVIS_CURIOSITY_ENGINE_ENABLED")
+    assert "JARVIS_AEGIS_BOOTSTRAP_PSK" not in env
+    assert env["JARVIS_CURIOSITY_ENGINE_ENABLED"] == "true"
+
+
+# ── Layer 2: latency-quarantine gate ────────────────────────────────────────
+
+def test_latency_quarantine_default_on(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_LATENCY_QUARANTINE_ENABLED", raising=False)
+    assert _latency_quarantine_enabled() is True
+
+
+def test_latency_quarantine_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_LATENCY_QUARANTINE_ENABLED", "0")
+    assert _latency_quarantine_enabled() is False
+    monkeypatch.setenv("JARVIS_DW_LATENCY_QUARANTINE_ENABLED", "false")
+    assert _latency_quarantine_enabled() is False
+
+
+def test_latency_quarantine_truthy_variants(monkeypatch):
+    for v in ("1", "true", "yes", "on", "TRUE"):
+        monkeypatch.setenv("JARVIS_DW_LATENCY_QUARANTINE_ENABLED", v)
+        assert _latency_quarantine_enabled() is True


### PR DESCRIPTION
## Summary

Closes Layers 1 & 2 of the convergence diagnosis — **reuse-first** (composes existing HeavyProbe / topology_sentinel / TtftObserver / aegis_preflight; **no new prober, no hardcoded model whitelist**).

### Layer 1 — Aegis session lifecycle vs the forking cadence
Each forked battle-test runs its own `aegis_preflight` (fresh daemon + fresh single-use PSK), but `_build_env_for_flag`'s `dict(os.environ)` inherited the parent's **already-consumed** `JARVIS_AEGIS_BOOTSTRAP_PSK` / stale `JARVIS_AEGIS_URL` → fork's `/session/establish` hits `psk_already_consumed` (403) → pre-forward lease 403 → generation never reaches DW. **Fix:** strip both per fork so every soak bootstraps aegis cleanly.

### Layer 2 — autonomous entitlement + latency quarantine (no hardcoding)
The infra existed but was inert/incomplete:
- `JARVIS_TOPOLOGY_SENTINEL_ENABLED` defaulted **false** → `entitlement_blocked` (403) models were never quarantined → selector kept dispatching to dead models. **Armed** in the crucible overlay (+ heavy probe for autonomous discovery).
- The selector skipped `TERMINAL_OPEN` (entitlement) but **never consulted the TtftObserver for latency** → the 180s-timeout cold-storage models kept being picked. **Added a cold-storage quarantine seam** (skip a model the observer flags COLD_STORAGE when another candidate remains; never strands the sole model). Gated `JARVIS_DW_LATENCY_QUARANTINE_ENABLED` (default true, fail-open).

The fleet now adapts: 403'd → `TERMINAL_OPEN`, slow → cold-storage-skip → generation routes only to fast, entitled models. **No static whitelist.**

## Test Plan
- [x] 5 fleet/aegis tests + 17 salvage/autarky + 90 dispatch/soak green
- [x] 2 pre-existing `pre_admission_shed` failures confirmed unrelated
- [ ] Re-ignite shields-up + validate aegis lease handshake + fast-model routing → state=applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Aegis session lifecycle for forked soaks and adds autonomous fleet health quarantine to route away from unauthorized or cold-storage models. This reduces 403 handshakes and avoids slow-model black holes without static whitelists.

- **Bug Fixes**
  - Strip `JARVIS_AEGIS_BOOTSTRAP_PSK` and `JARVIS_AEGIS_URL` from forked envs so each soak runs its own `aegis_preflight` and establishes a clean session.

- **New Features**
  - Enable topology sentinel and heavy probe in `docker-compose.crucible.yml` for autonomous entitlement discovery.
  - Add TTFT-based latency quarantine in the selector via `TtftObserver`: skip models flagged cold storage when another candidate exists. Controlled by `JARVIS_DW_LATENCY_QUARANTINE_ENABLED` (default true, fail-open).

<sup>Written for commit 45c3380b52f82542d9dedfd626f9c31e1cbb90f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

