### PR TITLE
feat(crucible): Sovereign Fleet-Wide Hibernation Matrix

### DIFF
--- a/backend/core/ouroboros/governance/fleet_exhaustion.py
+++ b/backend/core/ouroboros/governance/fleet_exhaustion.py
@@ -1,0 +1,168 @@
+"""Sovereign Fleet-Wide Hibernation Matrix (2026-06-20).
+
+Catastrophic-outage failsafe for the autonomic Crucible. If the topology sentinel
+(entitlement) + TtftObserver (latency) quarantine 100% of the diff-capable DW
+models for a route, generation has NOWHERE to go — every soak would burn the full
+wall-cap producing nothing while Spot credits drain. This module detects that
+**fleet-exhausted** state and drives a **DeepSleep**: the cadence idles for a
+mathematically-bounded backoff, then **flushes the ephemeral quarantine and
+re-probes** so a recovered DoubleWord API is re-discovered (a transient outage
+self-heals; a genuine entitlement block simply re-quarantines — bounded, no spin).
+
+Reuse-first: composes the EXISTING `provider_topology.dw_models_for_route`,
+`topology_sentinel` (get_state / reset_all_terminal_breakers), and
+`dw_ttft_observer` (is_cold_storage / clear). No new prober, no new state machine.
+
+## Authority posture (locked)
+  * **Read-mostly + fail-OPEN** — any error in detection returns "not exhausted"
+    (never falsely sleeps the engine). NEVER raises.
+  * **Env-tunable** — DeepSleep backoff + enable flag; no hardcoded constants in
+    the decision.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_FLEET_EXHAUSTION_FAILSAFE_ENABLED"
+_ENV_DEEPSLEEP_S = "JARVIS_FLEET_DEEPSLEEP_S"
+_DEFAULT_DEEPSLEEP_S = 2700.0  # 45 min — DW cold-start / outage recovery window
+
+
+def failsafe_enabled() -> bool:
+    """Master gate. Default TRUE — failure-path-only: only acts when 100% of the
+    fleet is quarantined, which is exactly when continuing is pure waste. =0
+    reverts to the legacy spin-until-budget behavior. NEVER raises."""
+    return (os.environ.get(_ENV_ENABLED, "true") or "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def deepsleep_seconds() -> float:
+    """Bounded DeepSleep backoff. Env-tunable; defensive default 45 min. Clamped
+    to [60s, 4h] so a typo can't idle forever or busy-spin. NEVER raises."""
+    raw = (os.environ.get(_ENV_DEEPSLEEP_S, "") or "").strip()
+    try:
+        v = float(raw) if raw else _DEFAULT_DEEPSLEEP_S
+    except (TypeError, ValueError):
+        v = _DEFAULT_DEEPSLEEP_S
+    return max(60.0, min(v, 4 * 3600.0))
+
+
+def _candidate_models(route: str) -> Tuple[str, ...]:
+    try:
+        from backend.core.ouroboros.governance.provider_topology import (
+            get_topology,
+        )
+        return tuple(get_topology().dw_models_for_route(route) or ())
+    except Exception:  # noqa: BLE001
+        return ()
+
+
+def _is_quarantined(model_id: str) -> bool:
+    """True iff the model is entitlement-banned (sentinel OPEN/TERMINAL_OPEN) OR
+    latency-banned (TtftObserver cold-storage). NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.topology_sentinel import (
+            get_default_sentinel,
+        )
+        state = get_default_sentinel().get_state(model_id)
+        if state in ("OPEN", "TERMINAL_OPEN"):
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from backend.core.ouroboros.governance.dw_discovery_runner import (
+            get_ttft_observer,
+        )
+        obs = get_ttft_observer()
+        if obs is not None and obs.is_cold_storage(model_id):
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    return False
+
+
+def fleet_exhausted(route: str = "standard") -> bool:
+    """True iff EVERY candidate DW model for ``route`` is quarantined (0 available
+    for generation). Fail-OPEN: an empty candidate list or any error → False (we
+    never sleep the engine on uncertainty). NEVER raises."""
+    if not failsafe_enabled():
+        return False
+    models = _candidate_models(route)
+    if not models:
+        # No candidate list resolved → cannot prove exhaustion; do not sleep.
+        return False
+    available = [m for m in models if not _is_quarantined(m)]
+    if available:
+        return False
+    logger.warning(
+        "[FleetExhaustion] ALL %d candidate models quarantined for route=%s "
+        "(entitlement/latency) — fleet exhausted, DeepSleep advised", len(models), route,
+    )
+    return True
+
+
+def flush_ephemeral_quarantine(route: str = "standard") -> int:
+    """Wake from DeepSleep: clear the ephemeral quarantine so the fleet re-probes
+    fresh. Resets sentinel TERMINAL_OPEN breakers + clears TtftObserver
+    cold-storage for the route's candidates. Returns the count cleared. A genuine
+    persistent block simply re-quarantines on the next probe (bounded). NEVER
+    raises."""
+    cleared = 0
+    try:
+        from backend.core.ouroboros.governance.topology_sentinel import (
+            get_default_sentinel,
+        )
+        cleared += int(get_default_sentinel().reset_all_terminal_breakers() or 0)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[FleetExhaustion] sentinel flush swallowed: %s", exc)
+    try:
+        from backend.core.ouroboros.governance.dw_discovery_runner import (
+            get_ttft_observer,
+        )
+        obs = get_ttft_observer()
+        if obs is not None:
+            for m in _candidate_models(route):
+                try:
+                    obs.clear(m)
+                    cleared += 1
+                except Exception:  # noqa: BLE001
+                    continue
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[FleetExhaustion] ttft flush swallowed: %s", exc)
+    logger.info("[FleetExhaustion] ephemeral quarantine flushed (%d entries)", cleared)
+    return cleared
+
+
+def _main() -> int:  # pragma: no cover — CLI for crucible_cadence.sh
+    """CLI: ``--check`` exits 0 iff fleet-exhausted (cadence then DeepSleeps);
+    ``--flush`` clears the quarantine on wake; ``--deepsleep-s`` prints the backoff."""
+    import sys
+    logging.basicConfig(level=logging.INFO)
+    args = set(sys.argv[1:])
+    route = os.environ.get("JARVIS_FLEET_EXHAUSTION_ROUTE", "standard")
+    if "--deepsleep-s" in args:
+        print(int(deepsleep_seconds()))
+        return 0
+    if "--flush" in args:
+        flush_ephemeral_quarantine(route)
+        return 0
+    if "--check" in args:
+        return 0 if fleet_exhausted(route) else 1
+    return 2
+
+
+__all__ = [
+    "failsafe_enabled",
+    "deepsleep_seconds",
+    "fleet_exhausted",
+    "flush_ephemeral_quarantine",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(_main())

--- a/scripts/crucible_cadence.sh
+++ b/scripts/crucible_cadence.sh
@@ -103,6 +103,18 @@ while true; do
     echo "[crucible] soak run returned non-zero (non-fatal)"
   _propose
   _sync_state
+  # Sovereign Fleet-Wide Hibernation Matrix: if 100% of diff-capable DW models
+  # are quarantined (entitlement TERMINAL_OPEN + latency cold-storage), generation
+  # has nowhere to go — DeepSleep instead of burning Spot credits spinning. On
+  # wake, flush the ephemeral quarantine + re-probe so a recovered DW is found.
+  if python3 -m backend.core.ouroboros.governance.fleet_exhaustion --check 2>/dev/null; then
+    DEEP=$(python3 -m backend.core.ouroboros.governance.fleet_exhaustion --deepsleep-s 2>/dev/null || echo 2700)
+    echo "🛌 [crucible] FLEET EXHAUSTED — DeepSleep ${DEEP}s (idling CPU; DW outage/total-quarantine)"
+    sleep "${DEEP}"
+    echo "⏰ [crucible] DeepSleep over — flushing quarantine + re-probing fleet"
+    python3 -m backend.core.ouroboros.governance.fleet_exhaustion --flush 2>&1 | sed 's/^/[fleet] /' || true
+    continue
+  fi
   echo "🧬 [crucible] iteration ${ITER} done — sleeping ${SLEEP_S}s"
   sleep "${SLEEP_S}"
 done

--- a/tests/governance/test_fleet_exhaustion.py
+++ b/tests/governance/test_fleet_exhaustion.py
@@ -1,0 +1,60 @@
+"""Sovereign Fleet-Wide Hibernation Matrix tests (2026-06-20)."""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance import fleet_exhaustion as FE
+
+
+def test_failsafe_default_on(monkeypatch):
+    monkeypatch.delenv("JARVIS_FLEET_EXHAUSTION_FAILSAFE_ENABLED", raising=False)
+    assert FE.failsafe_enabled() is True
+
+
+def test_failsafe_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_FLEET_EXHAUSTION_FAILSAFE_ENABLED", "0")
+    assert FE.failsafe_enabled() is False
+
+
+def test_deepsleep_default_and_clamp(monkeypatch):
+    monkeypatch.delenv("JARVIS_FLEET_DEEPSLEEP_S", raising=False)
+    assert FE.deepsleep_seconds() == 2700.0
+    monkeypatch.setenv("JARVIS_FLEET_DEEPSLEEP_S", "5")     # below floor
+    assert FE.deepsleep_seconds() == 60.0
+    monkeypatch.setenv("JARVIS_FLEET_DEEPSLEEP_S", "999999")  # above ceiling
+    assert FE.deepsleep_seconds() == 4 * 3600.0
+    monkeypatch.setenv("JARVIS_FLEET_DEEPSLEEP_S", "garbage")
+    assert FE.deepsleep_seconds() == 2700.0
+
+
+def test_disabled_never_reports_exhausted(monkeypatch):
+    monkeypatch.setenv("JARVIS_FLEET_EXHAUSTION_FAILSAFE_ENABLED", "0")
+    monkeypatch.setattr(FE, "_candidate_models", lambda r: ("m1", "m2"))
+    monkeypatch.setattr(FE, "_is_quarantined", lambda m: True)
+    assert FE.fleet_exhausted() is False
+
+
+def test_fail_open_on_empty_candidate_list(monkeypatch):
+    # No candidates resolved → cannot prove exhaustion → do NOT sleep.
+    monkeypatch.setenv("JARVIS_FLEET_EXHAUSTION_FAILSAFE_ENABLED", "true")
+    monkeypatch.setattr(FE, "_candidate_models", lambda r: ())
+    assert FE.fleet_exhausted() is False
+
+
+def test_exhausted_when_all_quarantined(monkeypatch):
+    monkeypatch.setenv("JARVIS_FLEET_EXHAUSTION_FAILSAFE_ENABLED", "true")
+    monkeypatch.setattr(FE, "_candidate_models", lambda r: ("m1", "m2", "m3"))
+    monkeypatch.setattr(FE, "_is_quarantined", lambda m: True)
+    assert FE.fleet_exhausted() is True
+
+
+def test_not_exhausted_when_one_available(monkeypatch):
+    monkeypatch.setenv("JARVIS_FLEET_EXHAUSTION_FAILSAFE_ENABLED", "true")
+    monkeypatch.setattr(FE, "_candidate_models", lambda r: ("m1", "m2", "m3"))
+    monkeypatch.setattr(FE, "_is_quarantined", lambda m: m != "m2")  # m2 available
+    assert FE.fleet_exhausted() is False
+
+
+def test_flush_never_raises(monkeypatch):
+    # Even with the substrates absent/raising, flush returns an int, never raises.
+    monkeypatch.setattr(FE, "_candidate_models", lambda r: ("m1",))
+    n = FE.flush_ephemeral_quarantine()
+    assert isinstance(n, int)


### PR DESCRIPTION
If 100% of diff-capable DW models are quarantined, the cadence DeepSleeps (env-tunable 45m, idles CPU) instead of burning Spot credits, then flushes the quarantine + re-probes on wake. Reuse-first; fail-open; 8 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fleet exhaustion failsafe that DeepSleeps the cadence when all diff-capable DW models are quarantined, then flushes quarantine and re-probes on wake. This avoids burning Spot credits during DW outages and self-heals when service recovers.

- **New Features**
  - `backend.core.ouroboros.governance.fleet_exhaustion`: detects when all route candidates are quarantined (entitlement or latency), exposes `--check`, `--flush`, `--deepsleep-s`, and uses a fail-open, never-raise posture.
  - Env-tunable DeepSleep with safe clamps (default 45m); reuses existing topology sentinel and TTFT observer.
  - `scripts/crucible_cadence.sh`: sleeps on exhaustion, then flushes and continues.
  - 8 tests covering defaults, clamping, fail-open, detection, and flush.

- **Migration**
  - Enabled by default; set `JARVIS_FLEET_EXHAUSTION_FAILSAFE_ENABLED=0` to disable.
  - Optional: tune backoff with `JARVIS_FLEET_DEEPSLEEP_S` (60s–4h) and route via `JARVIS_FLEET_EXHAUSTION_ROUTE`.

<sup>Written for commit ebb0ba7ea3142a5e8b36dd68b9fb4ee17ff17469. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

