### PR TITLE
fix(crucible): wire Zero-Shot timeout quarantine at the _call_primary seam

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -5597,6 +5597,35 @@ class CandidateGenerator:
                 except Exception as _dp_exc:  # noqa: BLE001
                     _dp_provider_outcome = "error"
                     _dp_provider_err = type(_dp_exc).__name__
+                    # Zero-Shot timeout quarantine (Sovereign Zero-Shot & Decay
+                    # Matrix). This is the ONLY seam where the raw, unwrapped
+                    # provider exception is visible WITH the model_id in scope:
+                    # the sentinel-dispatch FSM downstream re-wraps a primary
+                    # TimeoutError into RuntimeError('all_providers_exhausted')
+                    # before it reaches the outer dispatch handler, so a hook
+                    # there never sees TimeoutError. A 180s provider timeout is
+                    # unambiguous → 1-strike cold-storage (bypass the n>=3 σ
+                    # window) so the model is skipped on the very next op rather
+                    # than tainting two more soaks. Fail-soft, gated, never
+                    # raises — must not perturb the cascade.
+                    try:
+                        from backend.core.ouroboros.governance.dw_fault_taxonomy import (  # noqa: E501
+                            is_generation_timeout as _zs_is_timeout,
+                        )
+                        if (
+                            isinstance(_dp_exc, asyncio.TimeoutError)
+                            or _zs_is_timeout(_dp_exc)
+                        ):
+                            from backend.core.ouroboros.governance.dw_discovery_runner import (  # noqa: E501
+                                get_ttft_observer as _zs_get_obs,
+                            )
+                            _zs_obs = _zs_get_obs()
+                            if _zs_obs is not None:
+                                _zs_obs.record_timeout(
+                                    _dp_model, op_id=str(_dp_op_id)[:24],
+                                )
+                    except Exception:  # noqa: BLE001 — never raise from quarantine
+                        pass
                     raise
                 finally:
                     # Slice 34 Phase 2 — record STAGE_PROVIDER_GENERATE

--- a/tests/governance/test_ttft_zeroshot_decay.py
+++ b/tests/governance/test_ttft_zeroshot_decay.py
@@ -98,3 +98,30 @@ def test_record_timeout_never_raises():
     o.record_timeout("")        # empty
     o.record_timeout(None)      # type: ignore
     assert o.is_cold_storage("") is False
+
+
+def test_quarantine_guard_predicate_matches_timeout_not_wrapped_runtimeerror():
+    """The candidate_generator seam fires record_timeout iff the RAW provider
+    exception is a TimeoutError. The sentinel-dispatch FSM re-wraps a primary
+    TimeoutError into RuntimeError('all_providers_exhausted:...') downstream, so
+    the OUTER handler never sees TimeoutError — which is exactly why the in-flight
+    quarantine hook must live at the _call_primary seam where the raw exception is
+    visible. This locks in that diagnosis: the guard must reject the wrapped error
+    and accept the raw timeout."""
+    import asyncio
+
+    from backend.core.ouroboros.governance.dw_fault_taxonomy import (
+        is_generation_timeout,
+    )
+
+    def _guard(exc: BaseException) -> bool:
+        return isinstance(exc, asyncio.TimeoutError) or is_generation_timeout(exc)
+
+    # Raw budget timeout from race_or_wait_for → quarantine fires.
+    assert _guard(asyncio.TimeoutError()) is True
+    # The downstream-wrapped exhaustion error → quarantine must NOT fire
+    # (proves the outer handler is the wrong seam; the _call_primary seam is right).
+    wrapped = RuntimeError(
+        "all_providers_exhausted:fallback_skipped:no_fallback_configured"
+    )
+    assert _guard(wrapped) is False


### PR DESCRIPTION
Live-diagnosed on the soak node: the Zero-Shot quarantine never fired because the original hook sat in the outer dispatch handler, but the sentinel-dispatch FSM re-wraps a primary TimeoutError into `RuntimeError('all_providers_exhausted')` before it gets there. Moved the `record_timeout` hook to the `_call_primary` STAGE_PROVIDER_GENERATE seam — the only point where the raw `asyncio.TimeoutError` is visible with the model_id in scope. Outer-handler hook kept for RT-direct/tool-loop-deadline paths. +1 regression test. 19 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Zero-Shot timeout quarantine not firing due to wrapped errors. Timeouts are now captured at the `_call_primary` seam where the raw `asyncio.TimeoutError` is visible, so offending models are quarantined immediately.

- **Bug Fixes**
  - Kept the outer handler hook for RT-direct and tool-loop deadline paths.
  - Guard triggers on raw `asyncio.TimeoutError` or `is_generation_timeout(exc)` and ignores wrapped `RuntimeError('all_providers_exhausted:...')`.
  - Added a regression test to lock the guard behavior.

<sup>Written for commit 2fe91dfa115aab47bc32838eee4d7b891e8c397a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

