### PR TITLE
fix(crucible): learn batch-only at the batch-submit seam (all batch paths)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -1772,6 +1772,24 @@ class DoublewordProvider:
                 "[DoublewordProvider] Batch %s submitted async (model=%s, op=%s)",
                 batch_id, _effective_model, operation_id,
             )
+            # Sovereign Transport Profiler Matrix (2026-06-20) — LEARN step (broad).
+            # ANY model dispatched via the batch path is batch-bound: the system chose
+            # batch for it (force-batch cortex / hedge / sequential fallback), so its
+            # provider call is a minutes-long async batch poll that the RT/autarky
+            # budget (180s) strangles. Record it IMMORTALLY here — the single point
+            # common to ALL batch dispatches (the hedge-outcome seam only sees the
+            # ~1-in-16 ops that actually race; force-batch skips the hedge). The NEXT
+            # op for this model is tagged ASYNC_BATCH_PAYLOAD before the budget layer
+            # → batch budget + Zero-Shot immunity + park-detachment. Learn-then-detach:
+            # first contact may still time out once, then immortal. Gated + fail-soft.
+            try:
+                if _effective_model:
+                    from backend.core.ouroboros.governance.dw_transport_profile import (  # noqa: E501
+                        get_transport_profile as _tp_learn,
+                    )
+                    _tp_learn().record_batch_only(_effective_model)
+            except Exception:  # noqa: BLE001 — never raise from learn step
+                pass
             return PendingBatch(
                 op_id=operation_id,
                 batch_id=batch_id,


### PR DESCRIPTION
Live-diagnosed on node 203510: the matrix was inert — profile empty despite 16 batch submits because the learn hook only fired on the hedge path (1-in-16; force-batch skips the hedge) and required rupture_swallowed (False here). Moved the learn signal to submit_batch's 'Batch submitted async' point — common to ALL batch paths. _effective_model matches the budget-seam check (same ContextVar override). Learn-then-detach. Gated, fail-soft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the batch-only learn signal to the batch submit seam so it fires on all batch paths. Fixes missing transport profiles that left `ASYNC_BATCH_PAYLOAD` untagged and caused avoidable timeouts.

- **Bug Fixes**
  - Trigger learn at the submit point (“Batch submitted async”), common to force-batch, hedge, and sequential fallback.
  - Use `_effective_model` (same ContextVar override as the budget seam) for exact model ID matching; learn-then-detach; fail-soft with try/except.
  - Keep the hedge hook as an idempotent subset for defense-in-depth.

<sup>Written for commit 39ccafc52d99fac98265569cd4969f19d06bff51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

