### PR TITLE
fix(crucible): park batch-only ops via direct profile check (frozen ctx)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -5469,10 +5469,13 @@ class CandidateGenerator:
                     )
                     if _get_tp().is_batch_only(model_id):
                         _force_batch = True
-                        try:
-                            context.async_batch_payload = True
-                        except Exception:  # noqa: BLE001 — frozen/legacy ctx
-                            pass
+                        # NB: OperationContext is FROZEN — we deliberately do NOT
+                        # stamp a ctx tag (it would raise FrozenInstanceError, and
+                        # consumers can't rely on it). Every consumer of "is this op
+                        # batch-bound?" checks the immortal profile directly with the
+                        # resolved model: the budget here (force_batch), the Zero-Shot
+                        # ban-immunity seam below (is_batch_only(_dp_model)), and the
+                        # park gate (generate_park_wrapper._resolve_async_batch_payload).
             except Exception:  # noqa: BLE001 — defensive, legacy budget
                 pass
             # Slice 225 Phase 2 — Sovereign DW Autarky. Read the Claude fallback
@@ -5636,14 +5639,20 @@ class CandidateGenerator:
                         from backend.core.ouroboros.governance.dw_fault_taxonomy import (  # noqa: E501
                             is_generation_timeout as _zs_is_timeout,
                         )
-                        # Ban-immunity (Transport Profiler Matrix): an
-                        # ASYNC_BATCH_PAYLOAD op times out only because the batch
-                        # poll is async-slow, NOT because the model is dead — banning
-                        # it would blacklist the fleet's best diff-capable models for
-                        # transport latency. Skip the quarantine for batch-bound ops.
-                        _zs_batch_immune = bool(
-                            getattr(context, "async_batch_payload", False)
-                        )
+                        # Ban-immunity (Transport Profiler Matrix): a batch-only
+                        # model times out only because the batch poll is async-slow,
+                        # NOT because the model is dead — banning it would blacklist
+                        # the fleet's best diff-capable models for transport latency.
+                        # Checked DIRECTLY against the immortal profile with the
+                        # resolved model (OperationContext is frozen — no ctx tag).
+                        _zs_batch_immune = False
+                        try:
+                            from backend.core.ouroboros.governance.dw_transport_profile import (  # noqa: E501
+                                get_transport_profile as _zs_get_tp,
+                            )
+                            _zs_batch_immune = _zs_get_tp().is_batch_only(_dp_model)
+                        except Exception:  # noqa: BLE001
+                            _zs_batch_immune = False
                         if (
                             not _zs_batch_immune
                             and (

--- a/backend/core/ouroboros/governance/generate_park_wrapper.py
+++ b/backend/core/ouroboros/governance/generate_park_wrapper.py
@@ -207,10 +207,16 @@ async def maybe_park_or_resume(
     # Path 2 — PARK-EMIT
     # ----------------------------------------------------------------
     queue_pressure = pool is not None and pool.queue_depth() > 0
-    # Sovereign Transport Profiler Matrix (2026-06-20): a known batch-only op is
-    # stamped ASYNC_BATCH_PAYLOAD before the budget layer; it MUST detach regardless
-    # of queue pressure (its provider call is a minutes-long async batch poll).
-    _async_batch = bool(getattr(ctx, "async_batch_payload", False))
+    # Sovereign Transport Profiler Matrix (2026-06-20): a known batch-only op MUST
+    # detach regardless of queue pressure (its provider call is a minutes-long async
+    # batch poll). OperationContext is FROZEN, so we cannot stamp a tag on it (the
+    # _resolve_effective_model docstring records the FrozenInstanceError that defeated
+    # the old setattr pattern) — and the budget-seam tag would be set INSIDE generate()
+    # anyway, AFTER this park decision. So resolve it HERE, directly from the immortal
+    # profile: if any ranked DW model for this route is batch-only, the op will dispatch
+    # via batch → detach. Over-parking is harmless (the continuation runs generate()
+    # out-of-pool either way); under-parking re-wedges the worker. Fail-soft.
+    _async_batch = _resolve_async_batch_payload(ctx, provider_route)
     if (
         master_on
         and pool is not None
@@ -285,6 +291,35 @@ async def maybe_park_or_resume(
 # ---------------------------------------------------------------------------
 # Internals — kept here so the seam logic is one file, easy to review
 # ---------------------------------------------------------------------------
+
+
+def _resolve_async_batch_payload(ctx: Any, provider_route: str) -> bool:
+    """True iff this op should be treated as an ASYNC_BATCH_PAYLOAD (detach the
+    worker for a long async batch poll).
+
+    Resolved directly from the immortal transport profile (NOT a ctx tag —
+    OperationContext is frozen, and the budget-seam tag is set inside generate(),
+    too late for this pre-dispatch decision). If ANY ranked DW model for this route
+    is known batch-only, the op may dispatch via batch → detach. NEVER raises —
+    on any failure returns False (legacy in-pool await; never wedges incorrectly,
+    just forgoes the optimization)."""
+    try:
+        from backend.core.ouroboros.governance.dw_transport_profile import (
+            get_transport_profile,
+        )
+        route = (provider_route or "").strip().lower()
+        if route not in ("standard", "complex", "background"):
+            return False
+        from backend.core.ouroboros.governance.provider_topology import (
+            get_topology,
+        )
+        models = get_topology().dw_models_for_route(route) or ()
+        if not models:
+            return False
+        profile = get_transport_profile()
+        return any(profile.is_batch_only(m) for m in models)
+    except Exception:  # noqa: BLE001 — never raise from the park gate
+        return False
 
 
 def _resolve_next_park_attempt(pool: Any, ctx_op_id: str) -> int:

--- a/tests/governance/test_transport_profiler_park_gate.py
+++ b/tests/governance/test_transport_profiler_park_gate.py
@@ -63,3 +63,50 @@ def test_resumed_never_reparks_even_async_batch():
         "standard", queue_pressure=False, is_resumed=True,
         async_batch_payload=True,
     ) is False
+
+
+def test_resolve_async_batch_payload_reads_profile_not_frozen_ctx(monkeypatch):
+    """OperationContext is frozen — the park gate must resolve batch-only directly
+    from the immortal profile + live topology, NOT a ctx tag."""
+    from backend.core.ouroboros.governance import generate_park_wrapper as GPW
+    from backend.core.ouroboros.governance import dw_transport_profile as TP
+
+    monkeypatch.setenv("JARVIS_DW_TRANSPORT_PROFILE_ENABLED", "true")
+    prof = TP.get_transport_profile()
+    prof.record_batch_only("Qwen/Qwen3.5-397B-A17B-FP8-dottxt")
+
+    class _Topo:
+        def dw_models_for_route(self, route):
+            return ("Qwen/Qwen3.5-397B-A17B-FP8-dottxt", "openai/gpt-oss-20b")
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.provider_topology.get_topology",
+        lambda: _Topo(),
+    )
+
+    class Ctx:
+        provider_route = "standard"
+
+    # standard route + a batch-only model in the ranked list → detach.
+    assert GPW._resolve_async_batch_payload(Ctx(), "standard") is True
+    # immediate route is never batch-capable → no detach.
+    assert GPW._resolve_async_batch_payload(Ctx(), "immediate") is False
+    prof.clear("Qwen/Qwen3.5-397B-A17B-FP8-dottxt")
+
+
+def test_resolve_async_batch_payload_false_when_no_batch_only(monkeypatch):
+    from backend.core.ouroboros.governance import generate_park_wrapper as GPW
+
+    class _Topo:
+        def dw_models_for_route(self, route):
+            return ("openai/gpt-oss-20b",)  # not batch-only
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.provider_topology.get_topology",
+        lambda: _Topo(),
+    )
+
+    class Ctx:
+        provider_route = "complex"
+
+    assert GPW._resolve_async_batch_payload(Ctx(), "complex") is False


### PR DESCRIPTION
Live-diagnosed: profile learned + budget exemption worked (300s, batches complete, outcome=ok) but PARK-EMIT=0 — workers wedged on 300s batch waits. OperationContext is frozen so the ctx tag never set, and it was set after the park decision anyway. Fix: resolve batch-bound directly from the immortal profile + topology at each consumer (park gate pre-dispatch, budget seam, ban seam). Frees the worker → out-of-pool continuation → resume → state=applied. +2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes worker wedging on batch-only models by resolving batch-bound status from the transport profile at the park gate (no frozen `OperationContext` tag). Workers now detach before long batch polls and resume correctly, restoring throughput.

- **Bug Fixes**
  - Park gate uses `_resolve_async_batch_payload(ctx, provider_route)` to check `dw_transport_profile` + `provider_topology` directly, not a ctx tag.
  - Budget layer keeps `is_batch_only(model_id)` to force batch; removes the frozen-ctx assignment.
  - Zero-shot ban-immunity reads `is_batch_only(_dp_model)` from the profile instead of a ctx flag.
  - Adds tests to verify profile-based resolution (true/false) behavior.

<sup>Written for commit 66b85edf98a8b09b28d1239253b9d51af08fb19e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

