### PR TITLE
fix(crucible): align park continuation timeout to batch budget

### DIFF
--- a/backend/core/ouroboros/governance/generate_park_wrapper.py
+++ b/backend/core/ouroboros/governance/generate_park_wrapper.py
@@ -476,6 +476,24 @@ async def _spawn_park_continuation(
         _continuation_timeout = max(_legacy_timeout, _thinking_cont_timeout)
     else:
         _continuation_timeout = _legacy_timeout
+    # Sovereign Transport Profiler Matrix (2026-06-20) — continuation/batch budget
+    # coherence. The reason this op was PARKED is that it is batch-bound; its inner
+    # provider call gets the batch budget (force_batch → _compute_primary_budget →
+    # JARVIS_DW_BATCH_TIMEOUT_S, default 300s). If the out-of-pool continuation's
+    # OUTER wait_for stays at the legacy ~185s gen wall, it SEVERS the batch before
+    # it completes — the live wedge: 7 batches completed at the DW level (one op at
+    # 257s) yet every op errored because the 185s continuation cancelled them first.
+    # Widen the continuation to the SAME batch floor (batch_cap + overhead, ~330s)
+    # the budget layer already granted — pure alignment, NOT a blind extension.
+    # max() only widens, never shrinks. Fail-soft → legacy on any error.
+    try:
+        if _resolve_async_batch_payload(ctx, _op_route):
+            from backend.core.ouroboros.governance.candidate_generator import (
+                force_batch_gen_timeout_floor_s as _batch_floor,
+            )
+            _continuation_timeout = max(_continuation_timeout, _batch_floor())
+    except Exception:  # noqa: BLE001 — never raise from the timeout calc
+        pass
 
     async def _continuation() -> None:
         store = get_default_store()


### PR DESCRIPTION
Parking fires + batches complete (7), but ops errored because the park continuation's outer timeout (~185s legacy) severed the 300s-budget batch — one batch completed at 257s but the op was already cancelled at 185s. Fix: widen the continuation timeout to the same batch floor (~330s) for batch-bound ops. Coherence alignment, not blind extension. 60 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align park continuation timeout with the batch budget so batch-bound ops are not cancelled at ~185s while their batch completes (up to ~330s). Uses the same batch predicate as the park gate and widens via max() with the batch timeout floor; falls back to legacy on error.

- **Bug Fixes**
  - For batch-bound ops, set continuation timeout to at least the batch floor (`force_batch_gen_timeout_floor_s` ≈ 330s).
  - Prevents cancelling batches that finish between 185–330s (e.g., 257s).
  - No change for non-batch ops; only widens, never shrinks.

<sup>Written for commit 9852bce49137776a2fe362924d74548592fd07c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

