### PR TITLE
feat(crucible): Sovereign Infinite-Horizon Batch Matrix

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -974,6 +974,65 @@ def force_batch_gen_timeout_floor_s() -> float:
     return batch_cap + overhead
 
 
+# ---------------------------------------------------------------------------
+# Sovereign Infinite-Horizon Batch Matrix (2026-06-20)
+# ---------------------------------------------------------------------------
+# A PARKED ASYNC_BATCH_PAYLOAD op has had its worker slot freed — it costs ZERO
+# CPU while DoubleWord's batch queue churns. Severing it at the 300s/330s legacy
+# budget while DW is ACTIVELY processing the batch (validating / in_progress /
+# finalizing) is pure waste: the live wedge is mode=TIMEOUT "Batch retrieval
+# failed" (NOT a 403 — the retrieval HTTP path never returned >=300; the batch
+# simply hadn't finished). The poll layer (_adaptive_poll_batch) is ALREADY
+# lifecycle-aware — it returns ONLY on `completed` or terminal `failed/expired/
+# cancelled`, and otherwise keeps polling up to DOUBLEWORD_MAX_WAIT_S. The only
+# thing cutting it short is the OUTER budget. So: when (and ONLY when) the parked
+# out-of-pool continuation is running a batch-bound op, lift the force-batch cap
+# to the batch SLA horizon. Confined to the continuation via an async-task-local
+# ContextVar so an IN-pool dispatch can NEVER inherit the long budget and wedge a
+# live worker. Bounded by the session wall-clock cap in soaks.
+import contextvars as _ctxvars  # noqa: E402
+
+_PARKED_BATCH_HORIZON: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
+    "jarvis_parked_batch_horizon_active", default=False,
+)
+
+
+def batch_sla_horizon_s() -> float:
+    """The async-batch SLA horizon in seconds — how long a PARKED batch op may
+    wait for DW while the worker slot is free. Default mirrors the poll horizon
+    (``DOUBLEWORD_MAX_WAIT_S``, 3600s). Clamped [300s, 24h]. Env override:
+    ``JARVIS_DW_BATCH_SLA_HORIZON_S``. NEVER raises."""
+    default = _envf_or_default("DOUBLEWORD_MAX_WAIT_S", 3600.0)
+    raw = _envf_or_default("JARVIS_DW_BATCH_SLA_HORIZON_S", default)
+    return max(300.0, min(raw, 24 * 3600.0))
+
+
+def set_parked_batch_horizon(active: bool):
+    """Mark the current async task as a parked-batch continuation so
+    ``_compute_primary_budget`` lifts the force-batch cap to the SLA horizon.
+    Returns the ContextVar token; reset it in a finally. NEVER raises."""
+    try:
+        return _PARKED_BATCH_HORIZON.set(bool(active))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def reset_parked_batch_horizon(token) -> None:
+    """Reset the parked-batch-horizon ContextVar (paired with set_). NEVER raises."""
+    try:
+        if token is not None:
+            _PARKED_BATCH_HORIZON.reset(token)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _parked_batch_horizon_active() -> bool:
+    try:
+        return bool(_PARKED_BATCH_HORIZON.get())
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def apply_force_batch_deadline_floor(
     gen_timeout_s: float, *, force_batch: bool
 ) -> float:
@@ -7243,7 +7302,17 @@ class CandidateGenerator:
         # (Slice 36 precondition) → no fallback to reserve for, so the batch
         # gets the full remaining runway up to the batch cap.
         if force_batch:
-            batch_cap = _envf_or_default("JARVIS_DW_BATCH_TIMEOUT_S", 300.0)
+            # Sovereign Infinite-Horizon Batch Matrix: a PARKED batch continuation
+            # (worker freed, zero CPU) gets the full SLA horizon so an
+            # actively-processing DW batch is never severed mid-flight. The
+            # ContextVar is set ONLY by the out-of-pool park continuation, so an
+            # in-pool dispatch keeps the bounded 300s cap (never wedges a live
+            # worker). The poll itself is lifecycle-aware (gives up only on terminal
+            # status), so this just stops the OUTER budget from cutting it short.
+            if _parked_batch_horizon_active():
+                batch_cap = batch_sla_horizon_s()
+            else:
+                batch_cap = _envf_or_default("JARVIS_DW_BATCH_TIMEOUT_S", 300.0)
             return max(min(total_s, batch_cap), 0.0)
 
         # Slice 225 Phase 2 — Sovereign DW Autarky. When the Claude fallback

--- a/backend/core/ouroboros/governance/generate_park_wrapper.py
+++ b/backend/core/ouroboros/governance/generate_park_wrapper.py
@@ -476,33 +476,65 @@ async def _spawn_park_continuation(
         _continuation_timeout = max(_legacy_timeout, _thinking_cont_timeout)
     else:
         _continuation_timeout = _legacy_timeout
-    # Sovereign Transport Profiler Matrix (2026-06-20) — continuation/batch budget
-    # coherence. The reason this op was PARKED is that it is batch-bound; its inner
-    # provider call gets the batch budget (force_batch → _compute_primary_budget →
-    # JARVIS_DW_BATCH_TIMEOUT_S, default 300s). If the out-of-pool continuation's
-    # OUTER wait_for stays at the legacy ~185s gen wall, it SEVERS the batch before
-    # it completes — the live wedge: 7 batches completed at the DW level (one op at
-    # 257s) yet every op errored because the 185s continuation cancelled them first.
-    # Widen the continuation to the SAME batch floor (batch_cap + overhead, ~330s)
-    # the budget layer already granted — pure alignment, NOT a blind extension.
-    # max() only widens, never shrinks. Fail-soft → legacy on any error.
+    # Sovereign Infinite-Horizon Batch Matrix (2026-06-20). The op was PARKED
+    # because it is batch-bound — its worker slot is FREED, so it costs zero CPU
+    # while DoubleWord's batch queue churns. The poll layer is lifecycle-aware (it
+    # gives up ONLY on terminal failed/expired/cancelled, else polls on); the only
+    # thing severing an actively-processing batch is the OUTER budget. So decouple
+    # this continuation from the legacy ~185s/330s wall entirely: widen its outer
+    # wait_for to the batch SLA horizon AND hand generate() a FRESH deadline that
+    # far out, so the inner _compute_primary_budget (under the parked-horizon
+    # ContextVar set in _continuation) also gets the horizon. Confined to this
+    # out-of-pool task — an in-pool dispatch never inherits it. Bounded by the
+    # session wall-clock cap in soaks. Fail-soft → legacy budget on any error.
+    _is_batch_horizon_op = False
+    _gen_deadline = deadline
     try:
         if _resolve_async_batch_payload(ctx, _op_route):
             from backend.core.ouroboros.governance.candidate_generator import (
-                force_batch_gen_timeout_floor_s as _batch_floor,
+                batch_sla_horizon_s as _horizon_s,
             )
-            _continuation_timeout = max(_continuation_timeout, _batch_floor())
+            from datetime import timedelta as _td, timezone as _tz
+            _h = _horizon_s()
+            _continuation_timeout = max(_continuation_timeout, _h)
+            # Fresh, far-out deadline so the inner remaining-budget == horizon.
+            _gen_deadline = datetime.now(_tz.utc) + _td(seconds=_h)
+            _is_batch_horizon_op = True
     except Exception:  # noqa: BLE001 — never raise from the timeout calc
-        pass
+        _is_batch_horizon_op = False
+        _gen_deadline = deadline
 
     async def _continuation() -> None:
         store = get_default_store()
+        # Lift the inner force-batch cap to the SLA horizon for THIS task only.
+        _horizon_token = None
+        if _is_batch_horizon_op:
+            try:
+                from backend.core.ouroboros.governance.candidate_generator import (
+                    set_parked_batch_horizon as _set_horizon,
+                )
+                _horizon_token = _set_horizon(True)
+            except Exception:  # noqa: BLE001
+                _horizon_token = None
         try:
             # The actual provider call — out-of-pool, slot is free.
-            generation = await asyncio.wait_for(
-                orch._generator.generate(ctx, deadline),
-                timeout=_continuation_timeout,
-            )
+            try:
+                generation = await asyncio.wait_for(
+                    orch._generator.generate(ctx, _gen_deadline),
+                    timeout=_continuation_timeout,
+                )
+            finally:
+                # Reset the parked-batch-horizon ContextVar as soon as the
+                # provider call returns/raises (success, failure, or cancel) —
+                # the horizon is only meant to cover the generate() await.
+                if _horizon_token is not None:
+                    try:
+                        from backend.core.ouroboros.governance.candidate_generator import (  # noqa: E501
+                            reset_parked_batch_horizon as _reset_horizon,
+                        )
+                        _reset_horizon(_horizon_token)
+                    except Exception:  # noqa: BLE001
+                        pass
             await store.complete(
                 token, payload={"generation": generation},
             )

--- a/docker-compose.crucible.yml
+++ b/docker-compose.crucible.yml
@@ -62,6 +62,11 @@ services:
       # per §33.1; the rest default-on (failure-path-only, byte-identical when idle).
       JARVIS_DW_TRANSPORT_PROFILE_ENABLED: "true"
       JARVIS_BG_PARK_ENABLED: "true"
+      # Infinite-Horizon Batch Matrix: a PARKED batch op (worker freed, zero CPU)
+      # may wait the full async-batch SLA horizon for DW rather than being severed
+      # at the 300s/330s legacy budget. Mirrors the poll horizon (DOUBLEWORD_MAX_WAIT_S).
+      # Bounded by the session wall-clock cap (OUROBOROS_BATTLE_MAX_WALL_SECONDS).
+      JARVIS_DW_BATCH_SLA_HORIZON_S: "3600"
       # --- Cadence tuning ---
       JARVIS_CRUCIBLE_CADENCE_SLEEP_S: "30"
       OUROBOROS_BATTLE_COST_CAP: "1.00"

--- a/tests/governance/test_transport_profiler_park_gate.py
+++ b/tests/governance/test_transport_profiler_park_gate.py
@@ -94,6 +94,36 @@ def test_resolve_async_batch_payload_reads_profile_not_frozen_ctx(monkeypatch):
     prof.clear("Qwen/Qwen3.5-397B-A17B-FP8-dottxt")
 
 
+def test_batch_sla_horizon_default_override_clamp(monkeypatch):
+    from backend.core.ouroboros.governance.candidate_generator import (
+        batch_sla_horizon_s,
+    )
+    monkeypatch.delenv("JARVIS_DW_BATCH_SLA_HORIZON_S", raising=False)
+    monkeypatch.delenv("DOUBLEWORD_MAX_WAIT_S", raising=False)
+    assert batch_sla_horizon_s() == 3600.0          # mirrors poll horizon
+    monkeypatch.setenv("JARVIS_DW_BATCH_SLA_HORIZON_S", "1800")
+    assert batch_sla_horizon_s() == 1800.0
+    monkeypatch.setenv("JARVIS_DW_BATCH_SLA_HORIZON_S", "999999")
+    assert batch_sla_horizon_s() == 24 * 3600.0     # clamp 24h
+    monkeypatch.setenv("JARVIS_DW_BATCH_SLA_HORIZON_S", "10")
+    assert batch_sla_horizon_s() == 300.0           # floor
+
+
+def test_parked_batch_horizon_contextvar_isolated():
+    """The horizon ContextVar must default off and be task-local — an in-pool
+    dispatch must NEVER inherit the parked continuation's long budget."""
+    from backend.core.ouroboros.governance.candidate_generator import (
+        set_parked_batch_horizon,
+        reset_parked_batch_horizon,
+        _parked_batch_horizon_active,
+    )
+    assert _parked_batch_horizon_active() is False
+    tok = set_parked_batch_horizon(True)
+    assert _parked_batch_horizon_active() is True
+    reset_parked_batch_horizon(tok)
+    assert _parked_batch_horizon_active() is False
+
+
 def test_resolve_async_batch_payload_false_when_no_batch_only(monkeypatch):
     from backend.core.ouroboros.governance import generate_park_wrapper as GPW
 


### PR DESCRIPTION
Confirmed root cause: mode=TIMEOUT 'Batch retrieval failed' — the batch hadn't finished within 300s/330s (NOT a 403; zero retrieval-status>=300 lines). A parked batch op has a freed worker (zero CPU), so severing it while DW actively processes is waste. The poll is already lifecycle-aware (gives up only on terminal status). This lifts the outer budget to the batch SLA horizon (3600s, env JARVIS_DW_BATCH_SLA_HORIZON_S) ONLY for the parked out-of-pool continuation (task-local ContextVar → in-pool never inherits it). Bounded by the wall-clock cap. +2 tests, 72 regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let parked async batch ops wait up to the batch SLA horizon (default 3600s) instead of the legacy 300s/330s cap, preventing premature TIMEOUTs while the worker is freed. The longer budget applies only to the parked continuation; in-pool work stays on the normal cap.

- **New Features**
  - Added batch SLA horizon with `batch_sla_horizon_s()` (env `JARVIS_DW_BATCH_SLA_HORIZON_S`, default mirrors `DOUBLEWORD_MAX_WAIT_S` at 3600s; clamped to [300s, 24h]).
  - Introduced a task-local ContextVar to mark parked continuations; `_compute_primary_budget` lifts the force-batch cap to the horizon only when set.
  - In `generate_park_wrapper`, widened the parked continuation’s `wait_for` to the horizon and passed a fresh deadline (now + horizon); ContextVar is set/reset around `generate()`.
  - Default horizon enabled in `docker-compose.crucible.yml` via `JARVIS_DW_BATCH_SLA_HORIZON_S: "3600"`.
  - Tests cover horizon clamping and ContextVar isolation.

<sup>Written for commit b67e5adbf830c6f8bfd7a2269b1fb1dd0f8b4750. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

