### PR TITLE
fix(crucible): raise wall-cap shutdown deadline so complete summary lands

### DIFF
--- a/docker-compose.crucible.yml
+++ b/docker-compose.crucible.yml
@@ -67,6 +67,14 @@ services:
       # at the 300s/330s legacy budget. Mirrors the poll horizon (DOUBLEWORD_MAX_WAIT_S).
       # Bounded by the session wall-clock cap (OUROBOROS_BATTLE_MAX_WALL_SECONDS).
       JARVIS_DW_BATCH_SLA_HORIZON_S: "3600"
+      # Wall-cap shutdown with parked batch continuations + DW background loops to
+      # drain takes longer than the 30s default — the wall_clock_cap graceful
+      # _generate_report (which stamps session_outcome=complete) was being cut by
+      # the BoundedShutdownWatchdog os._exit at 30s, leaving only a partial
+      # in_flight summary → graded infra despite state=applied. Give the drain a
+      # bounded-but-sufficient window (well under the 2700s live_fire_soak wait) so
+      # the COMPLETE summary lands and the wall-cap soak grades clean.
+      JARVIS_BATTLE_SHUTDOWN_DEADLINE_S: "180"
       # --- Cadence tuning ---
       JARVIS_CRUCIBLE_CADENCE_SLEEP_S: "30"
       OUROBOROS_BATTLE_COST_CAP: "1.00"


### PR DESCRIPTION
Liveness probe fixed idle-reap → soak runs to wall-cap, but graded infra: the wall-cap graceful shutdown (drain parked continuations + DW loops + _generate_report→complete) exceeded the 30s shutdown deadline → os._exit → partial in_flight summary → infra. The drain was progressing, just needed >30s. Raise JARVIS_BATTLE_SHUTDOWN_DEADLINE_S to 180s (under the 2700s subprocess wait) so the COMPLETE summary lands → clean grade. Env-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the Crucible wall-cap shutdown deadline from 30s to 180s so graceful shutdown can finish and write the COMPLETE summary. Prevents forced exit at 30s that left a partial in_flight summary and caused infra grading; env-only change in `docker-compose.crucible.yml`.

<sup>Written for commit 0a2632a34458065bd5c89634cbaf9f98e77dcc2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

