### PR TITLE
feat(crucible): Sovereign Telemetry Flush Failsafe (report-before-drain + watchdog pre-exit flush)

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -437,6 +437,12 @@ class BattleTestHarness:
             BoundedShutdownWatchdog as _BoundedShutdownWatchdog,
         )
         self._shutdown_watchdog = _BoundedShutdownWatchdog()
+        try:
+            self._shutdown_watchdog.register_pre_exit_flush(
+                self._watchdog_pre_exit_flush
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
         # TerminationHookRegistry Slice 3 — install per-process
         # active-harness singleton so termination hooks dispatched
@@ -687,6 +693,26 @@ class BattleTestHarness:
                 _sys.stderr.write(
                     f"[Harness] atexit fallback failed: {exc!r}\n"
                 )
+
+    def _watchdog_pre_exit_flush(self) -> None:
+        """Sync complete-summary writer the BoundedShutdownWatchdog calls right
+        before os._exit (which skips atexit). A watchdog fire during shutdown
+        means the session reached a terminal stop_reason and the DRAIN hung —
+        the work is done, so stamp complete. Idempotent (no-op if already
+        written). Sync, fail-soft, runs on the watchdog thread. NEVER raises."""
+        try:
+            if getattr(self, "_summary_written", False):
+                return
+            _clean = {
+                "wall_clock_cap", "idle_timeout", "budget_exhausted",
+                "cost_cap", "session_exhausted", "shutdown_signal",
+                "process_memory_cap",
+            }
+            _root = (self._stop_reason or "").split(":")[0].strip()
+            _outcome = "complete" if _root in _clean else "incomplete_kill"
+            self._atexit_fallback_write(session_outcome=_outcome)
+        except Exception:  # noqa: BLE001
+            pass
 
     # ------------------------------------------------------------------
     # Properties
@@ -1848,8 +1874,18 @@ class BattleTestHarness:
             logger.error("Session %s boot failed: %s", self._session_id, exc)
             self._stop_reason = f"boot_failure: {exc}"
         finally:
+            # Sovereign Telemetry Flush Failsafe (2026-06-21) — persist the
+            # COMPLETE summary BEFORE the (slow, possibly-hanging) component
+            # drain. _generate_report reads recorder/ledger/score-history (no
+            # dependency on drained components), so it is safe + fresher first.
+            try:
+                await self._generate_report()
+            except Exception as _rep_exc:  # noqa: BLE001
+                logger.error(
+                    "Session %s pre-drain report write failed: %s",
+                    self._session_id, _rep_exc, exc_info=True,
+                )
             await self._shutdown_components()
-            await self._generate_report()
             # Harness Epic Slice 1 — disarm the bounded-shutdown watchdog
             # since clean shutdown completed within deadline. Without
             # this disarm, a race between graceful shutdown completion

--- a/backend/core/ouroboros/battle_test/shutdown_watchdog.py
+++ b/backend/core/ouroboros/battle_test/shutdown_watchdog.py
@@ -124,6 +124,11 @@ class BoundedShutdownWatchdog:
     ) -> None:
         self._exit_fn = exit_fn
         self._sleep_fn = sleep_fn
+        # Sovereign Telemetry Flush Failsafe (2026-06-21) — synchronous
+        # best-effort callback invoked in the FINAL MILLISECOND before os._exit.
+        # os._exit() skips atexit, so a teardown overrunning the deadline would
+        # otherwise lose the summary. Idempotent + fail-soft + must not hang.
+        self._pre_exit_flush: Optional[Callable[[], None]] = None
         # The arm event signals "shutdown requested; deadline running".
         self._arm_event = threading.Event()
         # The disarm event lets disarm() interrupt a sleeping thread.
@@ -234,6 +239,11 @@ class BoundedShutdownWatchdog:
         # Wake the thread if it's blocked
         self._arm_event.set()
         self._disarm_event.set()
+
+    def register_pre_exit_flush(self, callback):
+        """Register the sync telemetry-flush callback invoked right before
+        os._exit (which skips atexit). Sync, idempotent, fail-soft. NEVER raises."""
+        self._pre_exit_flush = callback
 
     def _thread_loop(self) -> None:
         """Daemon thread body — wait, sleep deadline, fire os._exit."""
@@ -370,6 +380,25 @@ class BoundedShutdownWatchdog:
                         except Exception:  # noqa: BLE001
                             continue
             except Exception:  # noqa: BLE001
+                pass
+
+            # Sovereign Telemetry Flush Failsafe — the final millisecond.
+            # os._exit() skips atexit; this is the LAST chance to save the
+            # summary. Idempotent in the harness callback; fail-soft — the
+            # os._exit MUST still fire even if the flush raises/is absent.
+            try:
+                _flush = self._pre_exit_flush
+                if _flush is not None:
+                    _flush()
+                    try:
+                        sys.stderr.write(
+                            "[BoundedShutdownWatchdog] pre-exit telemetry "
+                            "flush invoked\n"
+                        )
+                        sys.stderr.flush()
+                    except Exception:
+                        pass
+            except Exception:
                 pass
 
             # GO

--- a/docker-compose.crucible.yml
+++ b/docker-compose.crucible.yml
@@ -67,6 +67,14 @@ services:
       # at the 300s/330s legacy budget. Mirrors the poll horizon (DOUBLEWORD_MAX_WAIT_S).
       # Bounded by the session wall-clock cap (OUROBOROS_BATTLE_MAX_WALL_SECONDS).
       JARVIS_DW_BATCH_SLA_HORIZON_S: "3600"
+      # Wall-cap shutdown with parked batch continuations + DW background loops to
+      # drain takes longer than the 30s default — the wall_clock_cap graceful
+      # _generate_report (which stamps session_outcome=complete) was being cut by
+      # the BoundedShutdownWatchdog os._exit at 30s, leaving only a partial
+      # in_flight summary → graded infra despite state=applied. Give the drain a
+      # bounded-but-sufficient window (well under the 2700s live_fire_soak wait) so
+      # the COMPLETE summary lands and the wall-cap soak grades clean.
+      JARVIS_BATTLE_SHUTDOWN_DEADLINE_S: "180"
       # --- Cadence tuning ---
       JARVIS_CRUCIBLE_CADENCE_SLEEP_S: "30"
       OUROBOROS_BATTLE_COST_CAP: "1.00"

--- a/tests/battle_test/test_bounded_shutdown_watchdog.py
+++ b/tests/battle_test/test_bounded_shutdown_watchdog.py
@@ -433,3 +433,59 @@ def test_harness_wires_watchdog_at_three_sites():
     assert "_wdg.disarm()" in src
     # Construction at __init__
     assert "BoundedShutdownWatchdog as _BoundedShutdownWatchdog" in src
+
+
+# ---- Sovereign Telemetry Flush Failsafe — pre-exit flush hook (2026-06-21) ----
+def test_pre_exit_flush_invoked_before_exit_on_deadline(monkeypatch):
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    order = []
+    wdg = BoundedShutdownWatchdog(
+        exit_fn=lambda code: order.append(("exit", code)),
+        sleep_fn=lambda s: None,
+    )
+    try:
+        wdg.register_pre_exit_flush(lambda: order.append(("flush", None)))
+        wdg.arm(reason="wall_clock_cap", deadline_s=0.0)
+        deadline = time.monotonic() + 2.0
+        while not wdg.fired and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert wdg.fired is True
+        assert ("flush", None) in order
+        assert ("exit", EXIT_CODE_HARNESS_WEDGED) in order
+        assert order.index(("flush", None)) < order.index(
+            ("exit", EXIT_CODE_HARNESS_WEDGED)
+        )
+    finally:
+        wdg.stop(); wdg._thread.join(timeout=1.0)
+
+
+def test_pre_exit_flush_raising_does_not_block_exit(monkeypatch):
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls = []
+    def _boom():
+        raise RuntimeError("flush exploded")
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append, sleep_fn=lambda s: None)
+    try:
+        wdg.register_pre_exit_flush(_boom)
+        wdg.arm(reason="wall_clock_cap", deadline_s=0.0)
+        deadline = time.monotonic() + 2.0
+        while not wdg.fired and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert wdg.fired is True
+        assert EXIT_CODE_HARNESS_WEDGED in exit_calls
+    finally:
+        wdg.stop(); wdg._thread.join(timeout=1.0)
+
+
+def test_no_pre_exit_flush_registered_still_exits(monkeypatch):
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append, sleep_fn=lambda s: None)
+    try:
+        wdg.arm(reason="wall_clock_cap", deadline_s=0.0)
+        deadline = time.monotonic() + 2.0
+        while not wdg.fired and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert EXIT_CODE_HARNESS_WEDGED in exit_calls
+    finally:
+        wdg.stop(); wdg._thread.join(timeout=1.0)


### PR DESCRIPTION
Decouples telemetry generation from resource teardown so a hung/overrunning drain can never cost the session summary — the failure that graded the convergence soak infra (wall-cap fired → drain overran the 30s deadline → os._exit left only a partial in_flight summary despite state=applied).

**1. Separation of Concerns** — `_generate_report()` now runs BEFORE `_shutdown_components()`, so the COMPLETE summary is persisted before the slow drain. Reads recorder/ledger/score-history (no dependency on drained components); guarded so a report failure never blocks the drain.

**2. Unkillable Watchdog Hook** — os._exit() skips atexit, so the BoundedShutdownWatchdog now invokes a registered sync pre-exit flush in the final millisecond before os._exit. The harness registers a sync, idempotent (no-op if already written), fail-soft complete-summary writer. Individually try-wrapped — os._exit ALWAYS fires.

Net: the summary lands whether the drain finishes in time (Change 1) OR the watchdog hard-kills (Change 2). +3 tests; 41 watchdog+partial-shutdown green.

NOT hot-deployed per operator directive — lands on main; the node pulls it on next boot if the 180s deadline param fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarantees the session summary is written even if shutdown drains hang or the watchdog kills the process. Generates the report before draining and adds a watchdog pre-exit flush; also raises the shutdown deadline to 180s to avoid premature kills.

- **New Features**
  - Generate the complete report before `_shutdown_components()` so telemetry is persisted first.
  - Add a watchdog pre-exit flush callback invoked just before `os._exit`; harness registers a sync, idempotent writer that never blocks exit.
  - Increase `JARVIS_BATTLE_SHUTDOWN_DEADLINE_S` to `180` in `docker-compose.crucible.yml`.
  - Add tests covering flush-before-exit ordering, error-tolerant flush, and no-op when not registered.

<sup>Written for commit 993cd5c8c947891279b2d2dfe89e04fd40c718ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

