### PR TITLE
fix(crucible): WAL checkpoint must not clobber the complete summary (last graduation blocker)

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -7190,7 +7190,10 @@ class BattleTestHarness:
                 # checkpoint with reason=shutdown_cancel before
                 # returning so the in-flight state is captured.
                 try:
-                    if self._session_wal is not None:
+                    if self._session_wal is not None and not self._summary_written:
+                        # Skip the shutdown_cancel checkpoint once the final
+                        # complete summary is on disk — otherwise cancelling the
+                        # WAL during the drain re-clobbers it with in_flight.
                         state = self._slice12g3_build_checkpoint_state(
                             reason="shutdown_cancel",
                         )
@@ -7201,8 +7204,13 @@ class BattleTestHarness:
                     pass
                 raise
             try:
-                if self._session_wal is None:
-                    return  # WAL gone — exit gracefully
+                if self._session_wal is None or self._summary_written:
+                    # WAL gone, OR the final complete summary has been written
+                    # (Telemetry Flush Failsafe) — the periodic checkpoint must
+                    # NEVER overwrite session_outcome=complete with an in_flight
+                    # tick during a hanging drain (the bt-084639 clobber: mtime
+                    # 09:30:01 rewrote the 09:27:10 complete summary → infra).
+                    return
                 state = self._slice12g3_build_checkpoint_state(
                     reason="periodic",
                 )

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -437,6 +437,12 @@ class BattleTestHarness:
             BoundedShutdownWatchdog as _BoundedShutdownWatchdog,
         )
         self._shutdown_watchdog = _BoundedShutdownWatchdog()
+        try:
+            self._shutdown_watchdog.register_pre_exit_flush(
+                self._watchdog_pre_exit_flush
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
         # TerminationHookRegistry Slice 3 — install per-process
         # active-harness singleton so termination hooks dispatched
@@ -687,6 +693,26 @@ class BattleTestHarness:
                 _sys.stderr.write(
                     f"[Harness] atexit fallback failed: {exc!r}\n"
                 )
+
+    def _watchdog_pre_exit_flush(self) -> None:
+        """Sync complete-summary writer the BoundedShutdownWatchdog calls right
+        before os._exit (which skips atexit). A watchdog fire during shutdown
+        means the session reached a terminal stop_reason and the DRAIN hung —
+        the work is done, so stamp complete. Idempotent (no-op if already
+        written). Sync, fail-soft, runs on the watchdog thread. NEVER raises."""
+        try:
+            if getattr(self, "_summary_written", False):
+                return
+            _clean = {
+                "wall_clock_cap", "idle_timeout", "budget_exhausted",
+                "cost_cap", "session_exhausted", "shutdown_signal",
+                "process_memory_cap",
+            }
+            _root = (self._stop_reason or "").split(":")[0].strip()
+            _outcome = "complete" if _root in _clean else "incomplete_kill"
+            self._atexit_fallback_write(session_outcome=_outcome)
+        except Exception:  # noqa: BLE001
+            pass
 
     # ------------------------------------------------------------------
     # Properties
@@ -1848,8 +1874,18 @@ class BattleTestHarness:
             logger.error("Session %s boot failed: %s", self._session_id, exc)
             self._stop_reason = f"boot_failure: {exc}"
         finally:
+            # Sovereign Telemetry Flush Failsafe (2026-06-21) — persist the
+            # COMPLETE summary BEFORE the (slow, possibly-hanging) component
+            # drain. _generate_report reads recorder/ledger/score-history (no
+            # dependency on drained components), so it is safe + fresher first.
+            try:
+                await self._generate_report()
+            except Exception as _rep_exc:  # noqa: BLE001
+                logger.error(
+                    "Session %s pre-drain report write failed: %s",
+                    self._session_id, _rep_exc, exc_info=True,
+                )
             await self._shutdown_components()
-            await self._generate_report()
             # Harness Epic Slice 1 — disarm the bounded-shutdown watchdog
             # since clean shutdown completed within deadline. Without
             # this disarm, a race between graceful shutdown completion

--- a/backend/core/ouroboros/battle_test/shutdown_watchdog.py
+++ b/backend/core/ouroboros/battle_test/shutdown_watchdog.py
@@ -124,6 +124,11 @@ class BoundedShutdownWatchdog:
     ) -> None:
         self._exit_fn = exit_fn
         self._sleep_fn = sleep_fn
+        # Sovereign Telemetry Flush Failsafe (2026-06-21) — synchronous
+        # best-effort callback invoked in the FINAL MILLISECOND before os._exit.
+        # os._exit() skips atexit, so a teardown overrunning the deadline would
+        # otherwise lose the summary. Idempotent + fail-soft + must not hang.
+        self._pre_exit_flush: Optional[Callable[[], None]] = None
         # The arm event signals "shutdown requested; deadline running".
         self._arm_event = threading.Event()
         # The disarm event lets disarm() interrupt a sleeping thread.
@@ -234,6 +239,11 @@ class BoundedShutdownWatchdog:
         # Wake the thread if it's blocked
         self._arm_event.set()
         self._disarm_event.set()
+
+    def register_pre_exit_flush(self, callback):
+        """Register the sync telemetry-flush callback invoked right before
+        os._exit (which skips atexit). Sync, idempotent, fail-soft. NEVER raises."""
+        self._pre_exit_flush = callback
 
     def _thread_loop(self) -> None:
         """Daemon thread body — wait, sleep deadline, fire os._exit."""
@@ -370,6 +380,25 @@ class BoundedShutdownWatchdog:
                         except Exception:  # noqa: BLE001
                             continue
             except Exception:  # noqa: BLE001
+                pass
+
+            # Sovereign Telemetry Flush Failsafe — the final millisecond.
+            # os._exit() skips atexit; this is the LAST chance to save the
+            # summary. Idempotent in the harness callback; fail-soft — the
+            # os._exit MUST still fire even if the flush raises/is absent.
+            try:
+                _flush = self._pre_exit_flush
+                if _flush is not None:
+                    _flush()
+                    try:
+                        sys.stderr.write(
+                            "[BoundedShutdownWatchdog] pre-exit telemetry "
+                            "flush invoked\n"
+                        )
+                        sys.stderr.flush()
+                    except Exception:
+                        pass
+            except Exception:
                 pass
 
             # GO

--- a/docker-compose.crucible.yml
+++ b/docker-compose.crucible.yml
@@ -67,6 +67,14 @@ services:
       # at the 300s/330s legacy budget. Mirrors the poll horizon (DOUBLEWORD_MAX_WAIT_S).
       # Bounded by the session wall-clock cap (OUROBOROS_BATTLE_MAX_WALL_SECONDS).
       JARVIS_DW_BATCH_SLA_HORIZON_S: "3600"
+      # Wall-cap shutdown with parked batch continuations + DW background loops to
+      # drain takes longer than the 30s default — the wall_clock_cap graceful
+      # _generate_report (which stamps session_outcome=complete) was being cut by
+      # the BoundedShutdownWatchdog os._exit at 30s, leaving only a partial
+      # in_flight summary → graded infra despite state=applied. Give the drain a
+      # bounded-but-sufficient window (well under the 2700s live_fire_soak wait) so
+      # the COMPLETE summary lands and the wall-cap soak grades clean.
+      JARVIS_BATTLE_SHUTDOWN_DEADLINE_S: "180"
       # --- Cadence tuning ---
       JARVIS_CRUCIBLE_CADENCE_SLEEP_S: "30"
       OUROBOROS_BATTLE_COST_CAP: "1.00"

--- a/tests/battle_test/test_bounded_shutdown_watchdog.py
+++ b/tests/battle_test/test_bounded_shutdown_watchdog.py
@@ -433,3 +433,59 @@ def test_harness_wires_watchdog_at_three_sites():
     assert "_wdg.disarm()" in src
     # Construction at __init__
     assert "BoundedShutdownWatchdog as _BoundedShutdownWatchdog" in src
+
+
+# ---- Sovereign Telemetry Flush Failsafe — pre-exit flush hook (2026-06-21) ----
+def test_pre_exit_flush_invoked_before_exit_on_deadline(monkeypatch):
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    order = []
+    wdg = BoundedShutdownWatchdog(
+        exit_fn=lambda code: order.append(("exit", code)),
+        sleep_fn=lambda s: None,
+    )
+    try:
+        wdg.register_pre_exit_flush(lambda: order.append(("flush", None)))
+        wdg.arm(reason="wall_clock_cap", deadline_s=0.0)
+        deadline = time.monotonic() + 2.0
+        while not wdg.fired and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert wdg.fired is True
+        assert ("flush", None) in order
+        assert ("exit", EXIT_CODE_HARNESS_WEDGED) in order
+        assert order.index(("flush", None)) < order.index(
+            ("exit", EXIT_CODE_HARNESS_WEDGED)
+        )
+    finally:
+        wdg.stop(); wdg._thread.join(timeout=1.0)
+
+
+def test_pre_exit_flush_raising_does_not_block_exit(monkeypatch):
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls = []
+    def _boom():
+        raise RuntimeError("flush exploded")
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append, sleep_fn=lambda s: None)
+    try:
+        wdg.register_pre_exit_flush(_boom)
+        wdg.arm(reason="wall_clock_cap", deadline_s=0.0)
+        deadline = time.monotonic() + 2.0
+        while not wdg.fired and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert wdg.fired is True
+        assert EXIT_CODE_HARNESS_WEDGED in exit_calls
+    finally:
+        wdg.stop(); wdg._thread.join(timeout=1.0)
+
+
+def test_no_pre_exit_flush_registered_still_exits(monkeypatch):
+    monkeypatch.setenv("JARVIS_BATTLE_BOUNDED_SHUTDOWN_ENABLED", "true")
+    exit_calls = []
+    wdg = BoundedShutdownWatchdog(exit_fn=exit_calls.append, sleep_fn=lambda s: None)
+    try:
+        wdg.arm(reason="wall_clock_cap", deadline_s=0.0)
+        deadline = time.monotonic() + 2.0
+        while not wdg.fired and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert EXIT_CODE_HARNESS_WEDGED in exit_calls
+    finally:
+        wdg.stop(); wdg._thread.join(timeout=1.0)


### PR DESCRIPTION
Live-confirmed on bt-084639 WITH the Telemetry Flush Failsafe deployed: report-before-drain worked (Summary written at 09:27:10 before drain, state=applied landed), but summary.json was rewritten at 09:30:01 (mtime proof) back to in_flight. Culprit: the SessionWAL periodic checkpoint (every 15s) + its shutdown_cancel force_checkpoint kept writing in_flight during the hanging drain, neither checking _summary_written. Fix: both WAL write paths skip once the final complete summary is written. Combined with report-before-drain + watchdog pre-exit flush, the complete summary survives the hanging drain → wall-cap soak grades clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents WAL checkpoints from overwriting the final complete session summary during shutdown. Also adds a pre-exit flush and extends the shutdown deadline so complete summaries survive slow or hanging drains.

- **Bug Fixes**
  - Skip WAL periodic and shutdown_cancel checkpoints once `_summary_written` is true to avoid clobbering a complete summary.
  - Write the report before draining components, and add a watchdog pre-exit flush that writes a final summary if needed (idempotent, fail-soft).
  - Raise `JARVIS_BATTLE_SHUTDOWN_DEADLINE_S` to 180s to give drains a bounded window.
  - Add tests covering flush-before-exit ordering, flush errors not blocking exit, and exit without a registered flush.

<sup>Written for commit 624d5533f725cb12277cdd8e2aefbb59d96cca34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

